### PR TITLE
feat(nav): add Playing tab as first item in bottom dock

### DIFF
--- a/app/src/main/kotlin/in/jphe/storyvox/navigation/StoryvoxNavHost.kt
+++ b/app/src/main/kotlin/in/jphe/storyvox/navigation/StoryvoxNavHost.kt
@@ -28,6 +28,7 @@ import `in`.jphe.storyvox.ui.component.BottomTabBar
 import `in`.jphe.storyvox.ui.component.HomeTab
 
 object StoryvoxRoutes {
+    const val PLAYING = "playing"
     const val LIBRARY = "library"
     const val FOLLOWS = "follows"
     const val BROWSE = "browse"
@@ -43,7 +44,7 @@ object StoryvoxRoutes {
     fun reader(fictionId: String, chapterId: String) = "reader/$fictionId/$chapterId"
     fun audiobook(fictionId: String, chapterId: String) = "audiobook/$fictionId/$chapterId"
 
-    private val HOME_ROUTES = setOf(LIBRARY, FOLLOWS, BROWSE, SETTINGS)
+    private val HOME_ROUTES = setOf(PLAYING, LIBRARY, FOLLOWS, BROWSE, SETTINGS)
     fun isHome(route: String?) = route in HOME_ROUTES
 }
 
@@ -74,6 +75,7 @@ private fun StoryvoxNavHostContent(
             if (showBottomBar) {
                 BottomTabBar(
                     selected = when (currentRoute) {
+                        StoryvoxRoutes.PLAYING -> HomeTab.Playing
                         StoryvoxRoutes.FOLLOWS -> HomeTab.Follows
                         StoryvoxRoutes.BROWSE -> HomeTab.Browse
                         StoryvoxRoutes.SETTINGS -> HomeTab.Settings
@@ -81,6 +83,7 @@ private fun StoryvoxNavHostContent(
                     },
                     onSelect = { tab ->
                         val target = when (tab) {
+                            HomeTab.Playing -> StoryvoxRoutes.PLAYING
                             HomeTab.Library -> StoryvoxRoutes.LIBRARY
                             HomeTab.Follows -> StoryvoxRoutes.FOLLOWS
                             HomeTab.Browse -> StoryvoxRoutes.BROWSE
@@ -103,6 +106,11 @@ private fun StoryvoxNavHostContent(
             startDestination = StoryvoxRoutes.LIBRARY,
             modifier = Modifier.padding(padding),
         ) {
+            composable(StoryvoxRoutes.PLAYING) {
+                HybridReaderScreen(
+                    onPickVoice = { navController.navigate(StoryvoxRoutes.VOICE_LIBRARY) },
+                )
+            }
             composable(StoryvoxRoutes.LIBRARY) {
                 LibraryScreen(
                     onOpenFiction = { id -> navController.navigate(StoryvoxRoutes.fictionDetail(id)) },

--- a/core-ui/src/main/kotlin/in/jphe/storyvox/ui/component/BottomTabBar.kt
+++ b/core-ui/src/main/kotlin/in/jphe/storyvox/ui/component/BottomTabBar.kt
@@ -4,10 +4,12 @@ import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.AutoStories
 import androidx.compose.material.icons.filled.Bookmarks
 import androidx.compose.material.icons.filled.Explore
+import androidx.compose.material.icons.filled.Headphones
 import androidx.compose.material.icons.filled.Settings
 import androidx.compose.material.icons.outlined.AutoStories
 import androidx.compose.material.icons.outlined.Bookmarks
 import androidx.compose.material.icons.outlined.Explore
+import androidx.compose.material.icons.outlined.Headphones
 import androidx.compose.material.icons.outlined.Settings
 import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
@@ -22,6 +24,7 @@ import androidx.compose.ui.graphics.vector.ImageVector
 
 @Immutable
 enum class HomeTab(val label: String, val filled: ImageVector, val outlined: ImageVector) {
+    Playing("Playing", Icons.Filled.Headphones, Icons.Outlined.Headphones),
     Library("Library", Icons.Filled.AutoStories, Icons.Outlined.AutoStories),
     Follows("Follows", Icons.Filled.Bookmarks, Icons.Outlined.Bookmarks),
     Browse("Browse", Icons.Filled.Explore, Icons.Outlined.Explore),


### PR DESCRIPTION
## Summary
- Adds a **Playing** home destination as the first icon in the bottom dock (uses `Icons.Filled.Headphones` / `Icons.Outlined.Headphones`).
- Wires it through `StoryvoxRoutes.PLAYING` and includes it in `HOME_ROUTES` so the dock stays visible.
- The new route hosts `HybridReaderScreen` directly. `ReaderViewModel` already observes the singleton `PlaybackController` state, so the screen renders whatever is currently playing without nav args — and falls back to the existing "No chapter loaded." empty state when nothing is queued.

## Test plan
- [ ] Launch app → Playing is the leftmost dock tab with a headphones icon.
- [ ] Tap Playing with nothing playing → empty state.
- [ ] Start playback from Library/Browse → switch tabs → tap Playing → audiobook view shows current chapter; transport works.

https://claude.ai/code/session_01M7D16LQT3TqsbW21wd6Lvs

---
_Generated by [Claude Code](https://claude.ai/code/session_01M7D16LQT3TqsbW21wd6Lvs)_