### PR TITLE
release: v0.4.8 — Playing tab as first dock item

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -33,8 +33,8 @@ android {
         applicationId = "in.jphe.storyvox"
         minSdk = 26
         targetSdk = 35
-        versionCode = 19
-        versionName = "0.4.7"
+        versionCode = 20
+        versionName = "0.4.8"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
         vectorDrawables.useSupportLibrary = true


### PR DESCRIPTION
## Summary
- Bumps `versionCode` 19 → 20 and `versionName` 0.4.7 → 0.4.8.
- Only user-visible change since v0.4.7 is the new **Playing** tab on the bottom dock (#1).
- Pushing the `v0.4.8` tag after merge will trigger the `release` job in `.github/workflows/android.yml` to build the debug APK and attach it to a fresh GitHub release.

## Test plan
- [ ] CI debug build is green on this branch.
- [ ] After merge + tag push, GitHub release `v0.4.8` appears with `storyvox-v0.4.8-debug.apk` attached.
- [ ] Sideload APK → Playing tab is the leftmost dock icon and lands on the now-playing screen.

https://claude.ai/code/session_01M7D16LQT3TqsbW21wd6Lvs

---
_Generated by [Claude Code](https://claude.ai/code/session_01M7D16LQT3TqsbW21wd6Lvs)_