### PR TITLE
fix: address open issues #3, #4, #5, #6

### DIFF
--- a/app/src/main/kotlin/in/jphe/storyvox/di/AppBindings.kt
+++ b/app/src/main/kotlin/in/jphe/storyvox/di/AppBindings.kt
@@ -352,6 +352,9 @@ private class RealPlaybackControllerUi(
         val charOffset = ((ms / 1000.0) * charsPerSec).toInt().coerceAtLeast(0)
         controller.seekTo(charOffset)
     }
+    override fun seekToChar(charOffset: Int) {
+        controller.seekTo(charOffset.coerceAtLeast(0))
+    }
     override fun skipForward() = controller.skipForward30s()
     override fun skipBack() = controller.skipBack30s()
     override fun nextChapter() {

--- a/core-playback/src/main/kotlin/in/jphe/storyvox/playback/tts/EnginePlayer.kt
+++ b/core-playback/src/main/kotlin/in/jphe/storyvox/playback/tts/EnginePlayer.kt
@@ -343,7 +343,7 @@ class EnginePlayer @AssistedInject constructor(
                     // load takes 30+s as sherpa-onnx builds the onnxruntime
                     // session and runs a warm-up generate.
                     val sharedDir = voiceManager.kokoroSharedDir()
-                    val onnx = File(sharedDir, "model.int8.onnx").absolutePath
+                    val onnx = File(sharedDir, "model.onnx").absolutePath
                     val tokens = File(sharedDir, "tokens.txt").absolutePath
                     val voicesBin = File(sharedDir, "voices.bin").absolutePath
                     KokoroEngine.getInstance().setActiveSpeakerId(

--- a/core-playback/src/main/kotlin/in/jphe/storyvox/playback/tts/EnginePlayer.kt
+++ b/core-playback/src/main/kotlin/in/jphe/storyvox/playback/tts/EnginePlayer.kt
@@ -107,14 +107,74 @@ class EnginePlayer @AssistedInject constructor(
      *  [startPlaybackPipeline] to decide which engine drives generation. */
     private var activeEngineType: EngineType? = null
 
+    /** Voice id whose model is currently loaded. Used by the active-voice
+     *  watcher (see [observeActiveVoice]) to decide whether a DataStore
+     *  emission represents a real change worth reloading for, and by
+     *  [resume] to detect a "voice changed while paused" situation that
+     *  needs a full reload before playback can continue with the new model. */
+    private var loadedVoiceId: String? = null
+
+    /** Flagged when the user picks a different voice while playback is
+     *  paused. The flag tells [resume] to route through [loadAndPlay] for
+     *  a fresh model load instead of restarting the existing pipeline. */
+    private var voiceReloadPending: Boolean = false
+
+    init {
+        observeActiveVoice()
+    }
+
+    /**
+     * Watches [VoiceManager.activeVoice] and reacts to user-driven voice
+     * changes. The catalog of cases:
+     *
+     *  - Active voice changes mid-playback → reload the engine and resume
+     *    from the current char offset so the listener hears the new voice
+     *    immediately (issue #8).
+     *  - Active voice changes while paused → flag a pending reload and stop
+     *    the existing pipeline; the next [resume] call will do a full
+     *    [loadAndPlay] with the new voice.
+     *  - Active voice changes before any chapter is loaded → no-op; the
+     *    next [loadAndPlay] reads activeVoice itself.
+     *
+     *  De-dup: we track [loadedVoiceId] so re-emissions of the same id
+     *  (e.g. after [setActive] writes the same value, or first-launch
+     *  hydration) are filtered out.
+     */
+    private fun observeActiveVoice() {
+        scope.launch {
+            voiceManager.activeVoice.collect { active ->
+                val newId = active?.id ?: return@collect
+                if (newId == loadedVoiceId) return@collect
+                val s = _observableState.value
+                val fictionId = s.currentFictionId
+                val chapterId = s.currentChapterId
+                if (fictionId == null || chapterId == null) return@collect
+                if (s.isPlaying) {
+                    // Live swap. loadAndPlay will tear down the current
+                    // pipeline (including the queue full of old-voice PCM)
+                    // and rebuild from the current char offset.
+                    loadAndPlay(fictionId, chapterId, s.charOffset)
+                } else {
+                    voiceReloadPending = true
+                    stopPlaybackPipeline()
+                    activeEngineType = null
+                }
+            }
+        }
+    }
+
     /** AudioTrack for the active chapter. Recreated on play/seek/sample-rate change. */
     private var audioTrack: AudioTrack? = null
 
     /** Producer-consumer plumbing. PCM is tagged with its sentence so the
-     *  consumer knows what range to surface when playback actually reaches it. */
+     *  consumer knows what range to surface when playback actually reaches it.
+     *  [trailingSilenceBytes] is appended **after** [pcm] is written so the
+     *  consumer can spool zeros out of a shared buffer instead of every
+     *  sentence carrying a freshly-allocated copy of pcm + silence (issue #3). */
     private data class SentencePcm(
         val sentenceIndex: Int,
         val pcm: ByteArray,
+        val trailingSilenceBytes: Int,
         val range: SentenceRange,
     )
 
@@ -267,6 +327,8 @@ class EnginePlayer @AssistedInject constructor(
             return
         }
         activeEngineType = active.engineType
+        loadedVoiceId = active.id
+        voiceReloadPending = false
 
         // (state was already pushed above so the spinner could show during
         // model load — refresh durationEstimate now that the active engine
@@ -315,23 +377,26 @@ class EnginePlayer @AssistedInject constructor(
             try {
                 for (i in currentSentenceIndex until sentences.size) {
                     val s = sentences[i]
-                    val raw = when (engineType) {
+                    val pcm = when (engineType) {
                         is EngineType.Kokoro -> KokoroEngine.getInstance()
                             .generateAudioPCM(s.text, currentSpeed, currentPitch)
                         else -> VoiceEngine.getInstance()
                             .generateAudioPCM(s.text, currentSpeed, currentPitch)
                     } ?: continue // skip silently; defensive
                     // Neural TTS engines compress the natural inter-sentence
-                    // pause down to almost nothing — append silence sized to
-                    // the terminal punctuation so a period actually sounds
-                    // like a beat-and-then-next-sentence rather than a wall
-                    // of words crashing together.
+                    // pause down to almost nothing — instruct the consumer
+                    // to spool N zero-bytes of silence after this sentence,
+                    // sized by the sentence's terminal punctuation. We don't
+                    // splice the silence into a fresh ByteArray here because
+                    // each sentence's PCM is already 50–500 KB and a copy
+                    // per sentence is avoidable GC pressure.
                     val pauseMs = trailingPauseMs(s.text) / currentSpeed.coerceAtLeast(0.5f)
-                    val pcm = appendSilence(raw, pauseMs.toInt(), sampleRate)
+                    val silenceBytes = silenceBytesFor(pauseMs.toInt(), sampleRate)
                     queue.send(
                         SentencePcm(
                             sentenceIndex = i,
                             pcm = pcm,
+                            trailingSilenceBytes = silenceBytes,
                             range = SentenceRange(s.index, s.startChar, s.endChar),
                         ),
                     )
@@ -387,6 +452,16 @@ class EnginePlayer @AssistedInject constructor(
                         val n = track.write(item.pcm, written, item.pcm.size - written)
                         if (n < 0) break // error code from AudioTrack
                         written += n
+                    }
+                    // Spool the trailing silence from a shared zero-filled
+                    // buffer so we don't allocate per-sentence (the producer
+                    // sized this in bytes on its side).
+                    var remaining = item.trailingSilenceBytes
+                    while (remaining > 0) {
+                        val chunk = remaining.coerceAtMost(SILENCE_CHUNK.size)
+                        val n = track.write(SILENCE_CHUNK, 0, chunk)
+                        if (n < 0) break
+                        remaining -= n
                     }
                 }
                 // All sentences consumed — chapter ended.
@@ -454,6 +529,20 @@ class EnginePlayer @AssistedInject constructor(
 
     fun resume() {
         if (sentences.isEmpty()) return
+        // If the user activated a different voice while paused (#8), the
+        // existing engine model is the wrong one — route through loadAndPlay
+        // to swap it before any audio comes out.
+        if (voiceReloadPending) {
+            val s = _observableState.value
+            val fictionId = s.currentFictionId
+            val chapterId = s.currentChapterId
+            if (fictionId != null && chapterId != null) {
+                voiceReloadPending = false
+                scope.launch { loadAndPlay(fictionId, chapterId, s.charOffset) }
+                return
+            }
+            voiceReloadPending = false
+        }
         _observableState.update { it.copy(isPlaying = true, error = null) }
         startPlaybackPipeline()
         invalidateState()
@@ -569,32 +658,44 @@ class EnginePlayer @AssistedInject constructor(
     }
 
     /**
-     * Length of trailing silence to splice onto a sentence's PCM, picked
+     * Length of trailing silence to splice after a sentence's PCM, picked
      * by the punctuation it ends with. Neural TTS engines barely breathe
      * between sentences; without these padding gaps the listener hears one
      * continuous block of speech. Values are tuned to match audiobook-style
      * cadence at 1.0× speed; the producer scales them down at higher speeds
      * so a 2× listener doesn't sit through 700ms gaps.
+     *
+     * The tail-detection is robust against:
+     *  - **Closing punctuation** wrapping a sentence: `"He left."`, `(yes!)`,
+     *    `'maybe?'` — we strip trailing closers and whitespace before
+     *    looking at the real terminal char.
+     *  - **Multi-character ellipsis** (`...` written as three dots, common
+     *    in HTML-decoded chapter text where the real `…` is rare) — the
+     *    "..." literal is mapped to the same bucket as `…`.
+     *  - **Dash variants** — en-dash, em-dash, and ASCII hyphen used as a
+     *    sentence-internal cesura.
      */
     private fun trailingPauseMs(sentenceText: String): Int {
-        val tail = sentenceText.trimEnd().lastOrNull() ?: return 60
-        return when (tail) {
+        // Strip trailing whitespace + closing punctuation/quotes so we look
+        // at the terminal *speech* character, not the visual close-mark.
+        var end = sentenceText.length
+        while (end > 0 && (sentenceText[end - 1].isWhitespace() ||
+                sentenceText[end - 1] in CLOSE_PUNCT)) end--
+        if (end == 0) return 60
+        // Multi-char ellipsis takes precedence over the single-char switch.
+        if (end >= 3 && sentenceText.regionMatches(end - 3, "...", 0, 3)) return 350
+        return when (sentenceText[end - 1]) {
             '.', '!', '?', '…' -> 350
             ';', ':' -> 200
-            ',', '—' -> 120
+            ',', '—', '–', '-' -> 120
             else -> 60
         }
     }
 
-    private fun appendSilence(pcm: ByteArray, durationMs: Int, sampleRate: Int): ByteArray {
-        if (durationMs <= 0) return pcm
+    private fun silenceBytesFor(durationMs: Int, sampleRate: Int): Int {
+        if (durationMs <= 0) return 0
         // 16-bit signed PCM = 2 bytes per sample, mono = 1 channel.
-        val silenceBytes = (sampleRate.toLong() * durationMs / 1000L).toInt() * 2
-        if (silenceBytes <= 0) return pcm
-        val out = ByteArray(pcm.size + silenceBytes)
-        System.arraycopy(pcm, 0, out, 0, pcm.size)
-        // ByteArray default-init is zero — that's silence in signed PCM.
-        return out
+        return ((sampleRate.toLong() * durationMs / 1000L).toInt() * 2).coerceAtLeast(0)
     }
 
     private companion object {
@@ -610,5 +711,19 @@ class EnginePlayer @AssistedInject constructor(
         /** Fallback when the engine reports a non-positive sample rate (model
          *  not loaded yet). Piper voices are 22050Hz; Kokoro is 24000Hz. */
         const val DEFAULT_SAMPLE_RATE = 22050
+
+        /** Closing-punctuation characters stripped before deciding the
+         *  terminal punctuation for trailing-silence sizing. Covers ASCII
+         *  + curly + bracketed close marks. */
+        val CLOSE_PUNCT: Set<Char> = setOf(
+            '"', '\'', ')', ']', '}', '”', '’', '»', '」',
+        )
+
+        /** Shared zero-filled buffer the consumer writes from to spool
+         *  inter-sentence silence. Sized for one chunk @ 24 kHz mono 16-bit
+         *  ≈ 350 ms, which is the longest silence we ever emit; longer
+         *  silences chain multiple writes from the same buffer. Static so
+         *  every sentence reuses the same allocation. */
+        val SILENCE_CHUNK: ByteArray = ByteArray(24_000 * 2 * 350 / 1000)
     }
 }

--- a/core-playback/src/main/kotlin/in/jphe/storyvox/playback/tts/EnginePlayer.kt
+++ b/core-playback/src/main/kotlin/in/jphe/storyvox/playback/tts/EnginePlayer.kt
@@ -33,12 +33,13 @@ import `in`.jphe.storyvox.playback.SleepTimer
 import `in`.jphe.storyvox.playback.voice.EngineType
 import `in`.jphe.storyvox.playback.voice.VoiceManager
 import java.io.File
+import java.util.concurrent.LinkedBlockingQueue
+import java.util.concurrent.atomic.AtomicBoolean
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.cancel
-import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharedFlow
@@ -49,6 +50,9 @@ import kotlinx.coroutines.flow.filterNotNull
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.runInterruptible
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
 import kotlinx.coroutines.withContext
 
 /**
@@ -68,13 +72,12 @@ import kotlinx.coroutines.withContext
  *  - **Producer** ([generationJob]): walks the sentence list from
  *    [currentSentenceIndex], calls [VoiceEngine.generateAudioPCM] for each,
  *    pushes the resulting PCM byte[] onto [pcmQueue] together with the
- *    sentence range. Suspends if the queue is full (back-pressure).
- *  - **Consumer** ([playbackJob]): pulls from [pcmQueue], writes PCM to the
- *    AudioTrack via [AudioTrack.write] (blocking write — returns when the
- *    AudioTrack accepts the bytes; usually fast because the AudioTrack's
- *    own buffer absorbs them). Before writing, schedules a frame-position
- *    callback that fires when the framework actually starts playing this
- *    sentence — that's when we surface `currentSentenceRange` to the UI.
+ *    sentence range. Blocks on [java.util.concurrent.LinkedBlockingQueue.put]
+ *    if the queue is full (back-pressure).
+ *  - **Consumer** ([consumerThread]): pulls from [pcmQueue], writes PCM to
+ *    the AudioTrack via [AudioTrack.write] (blocking write — returns when
+ *    the AudioTrack accepts the bytes). Before writing, fires a
+ *    `scope.launch` to Main that surfaces the new sentence range to the UI.
  *
  * Pause/seek tear down the AudioTrack and re-create on resume; cheaper than
  * trying to keep state coherent across a `pause()` call.
@@ -178,9 +181,30 @@ class EnginePlayer @AssistedInject constructor(
         val range: SentenceRange,
     )
 
-    private var pcmQueue: Channel<SentencePcm>? = null
+    private var pcmQueue: LinkedBlockingQueue<SentencePcm>? = null
     private var generationJob: Job? = null
-    private var playbackJob: Job? = null
+
+    /** Dedicated playback thread. The agent that gets URGENT_AUDIO and never
+     *  yields back to a coroutine pool — see the comment on [startPlaybackPipeline]
+     *  for why this can't be a coroutine. */
+    private var consumerThread: Thread? = null
+
+    /** Per-pipeline run flag. Flipped to false by [stopPlaybackPipeline]; the
+     *  consumer checks it inside both the inter-sentence and intra-sentence
+     *  loops so it can bail out of long [AudioTrack.write] sequences without
+     *  waiting for the buffer to drain. */
+    private val pipelineRunning = AtomicBoolean(false)
+
+    /** Serializes [VoiceEngine.generateAudioPCM] / [KokoroEngine.generateAudioPCM]
+     *  calls. The VoxSherpa engines are process-singletons and the underlying
+     *  Sonic/onnxruntime state isn't safe across concurrent threads. Every
+     *  pipeline-restart event ([setSpeed], [setPitch], [seekToCharOffset],
+     *  voice swap) cancels the old generator coroutine, but cancellation only
+     *  fires at suspension points — a JNI call already in flight runs to
+     *  completion. Without this mutex, the new pipeline's generator can call
+     *  the engine *while the old one is still inside it*, corrupting the
+     *  internal state and producing garbled PCM. */
+    private val engineMutex = Mutex()
 
     private val _observableState = MutableStateFlow(PlaybackState())
     val observableState: StateFlow<PlaybackState> = _observableState.asStateFlow()
@@ -343,10 +367,30 @@ class EnginePlayer @AssistedInject constructor(
     }
 
     /**
-     * Spin up the producer/consumer pair. The generation worker walks the
-     * sentence list from currentSentenceIndex onward, pushing PCM onto a
-     * buffered channel; the playback worker pulls and writes to AudioTrack.
-     * Pre-fetching is implicit via the channel's capacity — generation runs
+     * Spin up the producer/consumer pair. Mirrors VoxSherpa standalone's
+     * playback shape exactly because deviating from it has measurably
+     * fuzzy output on Tab A7 Lite (issue #6):
+     *
+     *  - **Consumer = pinned [Thread]**, not a coroutine. `Process.set-`
+     *    `ThreadPriority(URGENT_AUDIO)` is per-OS-thread; coroutines on
+     *    [Dispatchers.IO] migrate threads on every suspend, so any priority
+     *    bump leaks across resumptions. A dedicated thread keeps URGENT_AUDIO
+     *    for the entire pipeline lifetime.
+     *  - **Queue = [LinkedBlockingQueue]**, not [kotlinx.coroutines.channels.Channel].
+     *    `take()` blocks the OS thread directly, no coroutine state-machine
+     *    overhead, no risk of dispatcher work-stealing introducing scheduling
+     *    jitter between sentences.
+     *  - **Buffer = [AudioTrack.getMinBufferSize]** (set in [createAudioTrack]).
+     *    Larger buffers route through AudioFlinger's deep-buffer mixer, which
+     *    on Samsung tablets uses a different sample-rate-conversion path than
+     *    the fast-track mixer used for `minBufferSize` tracks. Empirically the
+     *    deep-buffer path adds the residual fuzz that survives the legacy
+     *    `STREAM_MUSIC` constructor swap.
+     *  - **[engineMutex] around `generateAudioPCM`** so a stop-then-start
+     *    sequence (slider drag, voice swap, seek) never has two threads
+     *    inside the singleton VoxSherpa engine at once.
+     *
+     * Pre-fetching is implicit via the queue's capacity — generation runs
      * ahead of playback by however many slots are free.
      */
     private fun startPlaybackPipeline() {
@@ -358,15 +402,12 @@ class EnginePlayer @AssistedInject constructor(
             is EngineType.Kokoro -> KokoroEngine.getInstance().sampleRate
             else -> VoiceEngine.getInstance().sampleRate
         }.takeIf { it > 0 } ?: DEFAULT_SAMPLE_RATE
-        // Don't call play() yet. Calling play() on an empty buffer makes
-        // AudioFlinger remove the track on BUFFER TIMEOUT and reattach it
-        // when data finally arrives — the reattach glitch is audible on
-        // Tab A7 Lite. Playback starts inside playbackJob right before the
-        // first write, so the buffer is never empty in PLAYING state.
-        audioTrack = createAudioTrack(sampleRate)
+        val track = createAudioTrack(sampleRate)
+        audioTrack = track
 
-        val queue = Channel<SentencePcm>(QUEUE_CAPACITY)
+        val queue = LinkedBlockingQueue<SentencePcm>(QUEUE_CAPACITY)
         pcmQueue = queue
+        pipelineRunning.set(true)
 
         generationJob = ioScope.launch {
             // Inference is CPU-heavy on modest hardware (Tab A7 Lite); without
@@ -376,13 +417,17 @@ class EnginePlayer @AssistedInject constructor(
             AndroidProcess.setThreadPriority(AndroidProcess.THREAD_PRIORITY_URGENT_AUDIO)
             try {
                 for (i in currentSentenceIndex until sentences.size) {
+                    if (!pipelineRunning.get()) return@launch
                     val s = sentences[i]
-                    val pcm = when (engineType) {
-                        is EngineType.Kokoro -> KokoroEngine.getInstance()
-                            .generateAudioPCM(s.text, currentSpeed, currentPitch)
-                        else -> VoiceEngine.getInstance()
-                            .generateAudioPCM(s.text, currentSpeed, currentPitch)
-                    } ?: continue // skip silently; defensive
+                    val pcm = engineMutex.withLock {
+                        if (!pipelineRunning.get()) return@withLock null
+                        when (engineType) {
+                            is EngineType.Kokoro -> KokoroEngine.getInstance()
+                                .generateAudioPCM(s.text, currentSpeed, currentPitch)
+                            else -> VoiceEngine.getInstance()
+                                .generateAudioPCM(s.text, currentSpeed, currentPitch)
+                        }
+                    } ?: continue
                     // Neural TTS engines compress the natural inter-sentence
                     // pause down to almost nothing — instruct the consumer
                     // to spool N zero-bytes of silence after this sentence,
@@ -392,42 +437,44 @@ class EnginePlayer @AssistedInject constructor(
                     // per sentence is avoidable GC pressure.
                     val pauseMs = trailingPauseMs(s.text) / currentSpeed.coerceAtLeast(0.5f)
                     val silenceBytes = silenceBytesFor(pauseMs.toInt(), sampleRate)
-                    queue.send(
-                        SentencePcm(
-                            sentenceIndex = i,
-                            pcm = pcm,
-                            trailingSilenceBytes = silenceBytes,
-                            range = SentenceRange(s.index, s.startChar, s.endChar),
-                        ),
+                    val item = SentencePcm(
+                        sentenceIndex = i,
+                        pcm = pcm,
+                        trailingSilenceBytes = silenceBytes,
+                        range = SentenceRange(s.index, s.startChar, s.endChar),
                     )
+                    // runInterruptible turns Thread.interrupt (sent by
+                    // stopPlaybackPipeline → cancel) into a coroutine
+                    // CancellationException, so a blocked put() doesn't
+                    // wedge the producer when shutdown races a full queue.
+                    runInterruptible { queue.put(item) }
                 }
+                // Natural end — let the consumer finish draining and then
+                // run the chapter-done handler.
+                runInterruptible { queue.put(NATURAL_END_PILL) }
             } catch (_: Throwable) {
-                // Channel closed (consumer cancelled) or engine fault — just stop.
-            } finally {
-                queue.close()
+                // Cancelled or engine fault — silent. The consumer is shut
+                // down by stopPlaybackPipeline directly, no pill needed.
             }
         }
 
-        playbackJob = ioScope.launch {
-            // Critical: keep the AudioTrack.write() loop above ordinary IO
-            // priority. Without this, Dispatchers.IO can preempt the writer
-            // long enough for the AudioTrack buffer to drain → underrun →
-            // auto-restart → audible click/fuzz on top of the speech.
-            // logcat signature: "AudioTrack: restartIfDisabled ... disabled
-            // due to previous underrun, restarting".
+        consumerThread = Thread({
             AndroidProcess.setThreadPriority(AndroidProcess.THREAD_PRIORITY_URGENT_AUDIO)
+            var naturalEnd = false
+            var firstSentence = true
             try {
-                var firstSentence = true
-                for (item in queue) {
-                    // Channel iteration suspends when empty; on resume the
-                    // coroutine may be on a different IO pool thread, so
-                    // re-apply URGENT_AUDIO each iteration as cheap insurance.
-                    AndroidProcess.setThreadPriority(AndroidProcess.THREAD_PRIORITY_URGENT_AUDIO)
+                while (pipelineRunning.get()) {
+                    val item = try {
+                        queue.take()
+                    } catch (_: InterruptedException) {
+                        break
+                    }
+                    if (item === NATURAL_END_PILL) { naturalEnd = true; break }
 
-                    // Surface the new sentence range BEFORE writing. Fire-and-
-                    // forget on Main — `withContext` would suspend this worker
-                    // and risk it resuming on a different IO thread without
-                    // URGENT_AUDIO priority, reintroducing underrun fuzz.
+                    // Surface the new sentence range BEFORE writing. Fire-
+                    // and-forget on Main — withContext would force this
+                    // thread to coordinate with the coroutine dispatcher,
+                    // which is the whole reason we left coroutines.
                     scope.launch {
                         currentSentenceIndex = item.sentenceIndex
                         _observableState.update {
@@ -437,79 +484,99 @@ class EnginePlayer @AssistedInject constructor(
                             )
                         }
                     }
-                    val track = audioTrack ?: break
 
-                    // Start AudioTrack on the first iteration, only once we
-                    // have real data ready to feed it. See createAudioTrack
-                    // comment for the empty-buffer / reattach reasoning.
                     if (firstSentence) {
-                        track.play()
+                        runCatching { track.play() }
                         firstSentence = false
                     }
 
                     var written = 0
-                    while (written < item.pcm.size) {
+                    while (written < item.pcm.size && pipelineRunning.get()) {
                         val n = track.write(item.pcm, written, item.pcm.size - written)
                         if (n < 0) break // error code from AudioTrack
                         written += n
                     }
-                    // Spool the trailing silence from a shared zero-filled
-                    // buffer so we don't allocate per-sentence (the producer
-                    // sized this in bytes on its side).
+                    // Spool trailing silence from a shared zero-filled
+                    // buffer (no per-sentence allocation).
                     var remaining = item.trailingSilenceBytes
-                    while (remaining > 0) {
+                    while (remaining > 0 && pipelineRunning.get()) {
                         val chunk = remaining.coerceAtMost(SILENCE_CHUNK.size)
                         val n = track.write(SILENCE_CHUNK, 0, chunk)
                         if (n < 0) break
                         remaining -= n
                     }
                 }
-                // All sentences consumed — chapter ended.
-                withContext(Dispatchers.Main) {
-                    sleepTimer.signalChapterEnd()
-                    handleChapterDone()
+            } finally {
+                if (naturalEnd && pipelineRunning.get()) {
+                    scope.launch {
+                        sleepTimer.signalChapterEnd()
+                        handleChapterDone()
+                    }
                 }
-            } catch (_: Throwable) {
-                // Cancelled.
             }
+        }, "storyvox-audio-out").apply {
+            isDaemon = true
+            start()
         }
     }
 
     private fun stopPlaybackPipeline() {
+        // Order matters. We must (1) signal the consumer to stop AND (2)
+        // unblock any in-flight track.write() before (3) joining and (4)
+        // releasing the AudioTrack. Releasing while the consumer's still
+        // inside write() is undefined behavior in JNI land — segfault risk.
+        pipelineRunning.set(false)
         generationJob?.cancel()
         generationJob = null
-        playbackJob?.cancel()
-        playbackJob = null
-        pcmQueue?.close()
-        pcmQueue = null
-        audioTrack?.let {
+
+        val track = audioTrack
+        audioTrack = null
+        track?.let {
+            // pause + flush together: pause stops AudioFlinger from pulling,
+            // flush drops queued data, and the side effect is that any
+            // currently-blocked write() returns immediately because the
+            // ring buffer has space again.
             runCatching { it.pause() }
             runCatching { it.flush() }
-            runCatching { it.release() }
         }
-        audioTrack = null
+
+        val t = consumerThread
+        consumerThread = null
+        if (t != null && t !== Thread.currentThread()) {
+            t.interrupt()
+            try { t.join(500) } catch (_: InterruptedException) {}
+        }
+
+        track?.let { runCatching { it.release() } }
+        pcmQueue = null
     }
 
-    /** Build an AudioTrack with a fat buffer so we can pre-feed enough audio
-     *  to keep playback continuous while the next sentence is being generated.
+    /** Build an AudioTrack that mirrors the standalone VoxSherpa demo exactly:
+     *  legacy `STREAM_MUSIC` constructor, `getMinBufferSize()` buffer (no
+     *  multiplier), `MODE_STREAM`. This is deliberate even though it costs us
+     *  the seconds-long pre-render cushion the bigger buffer provided.
      *
-     *  Uses the **legacy** [AudioTrack] constructor on purpose. The modern
-     *  [AudioTrack.Builder] path with `USAGE_MEDIA + CONTENT_TYPE_MUSIC`
-     *  routes through Android's AudioAttributes pipeline, which on Samsung
-     *  tablets feeds the OEM SoundAlive / Dolby Atmos post-processing chain.
-     *  Those effects are tuned for music and produce audible fuzz/distortion
-     *  on 22050/24000Hz mono speech PCM (notably on Galaxy Tab A7 Lite).
-     *  VoxSherpa standalone uses the same legacy `STREAM_MUSIC` constructor
-     *  and sounds clean on identical hardware — we mirror it exactly here. */
+     *  Why minBuffer specifically: AudioFlinger has two media mixer paths.
+     *  Tracks created with a buffer ≈ minBufferSize qualify for the
+     *  fast-track (low-latency) mixer; larger buffers route through the
+     *  deep-buffer mixer. On Samsung tablets the deep-buffer mixer uses a
+     *  different sample-rate-conversion chain that introduces audible
+     *  distortion on 22050/24000Hz mono speech PCM. The bigger buffer
+     *  bought us ~2 seconds of generator headroom but lost us clean output;
+     *  the producer now keeps the generator queue full ([QUEUE_CAPACITY]
+     *  sentences ahead) so the small buffer never empties between writes.
+     *
+     *  We also keep the legacy constructor (vs `AudioTrack.Builder`) because
+     *  on Samsung the Builder path with `USAGE_MEDIA + CONTENT_TYPE_MUSIC`
+     *  goes through the AudioAttributes routing layer, which on some firmware
+     *  applies SoundAlive/Atmos. The legacy ctor advertises `STREAM_MUSIC`
+     *  directly to AudioFlinger and bypasses those effects on the affected
+     *  devices. VoxSherpa standalone does the same. */
     @Suppress("DEPRECATION")
     private fun createAudioTrack(sampleRate: Int): AudioTrack {
         val channelMask = AndroidAudioFormat.CHANNEL_OUT_MONO
         val encoding = AndroidAudioFormat.ENCODING_PCM_16BIT
-        val minBuf = AudioTrack.getMinBufferSize(sampleRate, channelMask, encoding)
-        // Aim for ~2 seconds at this rate; clamp to at least 4× the system
-        // minimum so AudioFlinger doesn't reject us.
-        val target = sampleRate * 2 * 2 // mono 16-bit ⇒ 2 bytes/sample × sampleRate × 2s
-        val bufferSize = maxOf(target, minBuf * 4)
+        val bufferSize = AudioTrack.getMinBufferSize(sampleRate, channelMask, encoding)
         return AudioTrack(
             AudioManager.STREAM_MUSIC,
             sampleRate,
@@ -700,12 +767,10 @@ class EnginePlayer @AssistedInject constructor(
 
     private companion object {
         /** Buffered slots ahead of the playback consumer. Each slot holds one
-         *  sentence's PCM (~50–500KB). At 4 slots × ~250KB avg = ~1MB peak —
-         *  fine on Android. Higher capacity gives more pre-render headroom but
-         *  costs memory and slows seek-flush. */
-        // 8 sentences of cushion; with ~2s/sentence playback that gives the
-        // generator ~16s of headroom before the queue runs dry on a slow
-        // sentence. Was 4 — too tight on Tab A7 Lite for variable-length text.
+         *  sentence's PCM (~50–500KB). At 8 slots × ~250KB avg ≈ 2MB peak.
+         *  This is the *only* generator headroom we have now that the
+         *  AudioTrack itself uses minBufferSize (~130 ms at 22 kHz) — the
+         *  queue has to stay full or the buffer underruns and we hear clicks. */
         const val QUEUE_CAPACITY = 8
 
         /** Fallback when the engine reports a non-positive sample rate (model
@@ -725,5 +790,18 @@ class EnginePlayer @AssistedInject constructor(
          *  silences chain multiple writes from the same buffer. Static so
          *  every sentence reuses the same allocation. */
         val SILENCE_CHUNK: ByteArray = ByteArray(24_000 * 2 * 350 / 1000)
+
+        /** Sentinel pushed by the producer onto the queue when it has run
+         *  out of sentences naturally (i.e. the chapter is finished). The
+         *  consumer thread checks for object identity (`===`) and triggers
+         *  the chapter-done handler instead of treating it like real audio.
+         *  A cancellation-driven shutdown does NOT enqueue this — it just
+         *  flips [pipelineRunning] to false and interrupts the consumer. */
+        val NATURAL_END_PILL: SentencePcm = SentencePcm(
+            sentenceIndex = -1,
+            pcm = ByteArray(0),
+            trailingSilenceBytes = 0,
+            range = SentenceRange(-1, -1, -1),
+        )
     }
 }

--- a/core-playback/src/main/kotlin/in/jphe/storyvox/playback/tts/EnginePlayer.kt
+++ b/core-playback/src/main/kotlin/in/jphe/storyvox/playback/tts/EnginePlayer.kt
@@ -1,7 +1,6 @@
 package `in`.jphe.storyvox.playback.tts
 
 import android.content.Context
-import android.media.AudioAttributes as AndroidAudioAttributes
 import android.media.AudioFormat as AndroidAudioFormat
 import android.media.AudioManager
 import android.media.AudioTrack
@@ -316,12 +315,19 @@ class EnginePlayer @AssistedInject constructor(
             try {
                 for (i in currentSentenceIndex until sentences.size) {
                     val s = sentences[i]
-                    val pcm = when (engineType) {
+                    val raw = when (engineType) {
                         is EngineType.Kokoro -> KokoroEngine.getInstance()
                             .generateAudioPCM(s.text, currentSpeed, currentPitch)
                         else -> VoiceEngine.getInstance()
                             .generateAudioPCM(s.text, currentSpeed, currentPitch)
                     } ?: continue // skip silently; defensive
+                    // Neural TTS engines compress the natural inter-sentence
+                    // pause down to almost nothing — append silence sized to
+                    // the terminal punctuation so a period actually sounds
+                    // like a beat-and-then-next-sentence rather than a wall
+                    // of words crashing together.
+                    val pauseMs = trailingPauseMs(s.text) / currentSpeed.coerceAtLeast(0.5f)
+                    val pcm = appendSilence(raw, pauseMs.toInt(), sampleRate)
                     queue.send(
                         SentencePcm(
                             sentenceIndex = i,
@@ -410,37 +416,33 @@ class EnginePlayer @AssistedInject constructor(
     }
 
     /** Build an AudioTrack with a fat buffer so we can pre-feed enough audio
-     *  to keep playback continuous while the next sentence is being generated. */
+     *  to keep playback continuous while the next sentence is being generated.
+     *
+     *  Uses the **legacy** [AudioTrack] constructor on purpose. The modern
+     *  [AudioTrack.Builder] path with `USAGE_MEDIA + CONTENT_TYPE_MUSIC`
+     *  routes through Android's AudioAttributes pipeline, which on Samsung
+     *  tablets feeds the OEM SoundAlive / Dolby Atmos post-processing chain.
+     *  Those effects are tuned for music and produce audible fuzz/distortion
+     *  on 22050/24000Hz mono speech PCM (notably on Galaxy Tab A7 Lite).
+     *  VoxSherpa standalone uses the same legacy `STREAM_MUSIC` constructor
+     *  and sounds clean on identical hardware — we mirror it exactly here. */
+    @Suppress("DEPRECATION")
     private fun createAudioTrack(sampleRate: Int): AudioTrack {
         val channelMask = AndroidAudioFormat.CHANNEL_OUT_MONO
         val encoding = AndroidAudioFormat.ENCODING_PCM_16BIT
         val minBuf = AudioTrack.getMinBufferSize(sampleRate, channelMask, encoding)
         // Aim for ~2 seconds at this rate; clamp to at least 4× the system
         // minimum so AudioFlinger doesn't reject us.
-        val target = sampleRate * 2 * 2 // 2 channels-worth, but mono so this is generous
+        val target = sampleRate * 2 * 2 // mono 16-bit ⇒ 2 bytes/sample × sampleRate × 2s
         val bufferSize = maxOf(target, minBuf * 4)
-        return AudioTrack.Builder()
-            .setAudioAttributes(
-                AndroidAudioAttributes.Builder()
-                    .setUsage(AndroidAudioAttributes.USAGE_MEDIA)
-                    // CONTENT_TYPE_MUSIC, not _SPEECH: on Samsung tablets the
-                    // speech content-type triggers a telephony-style DSP path
-                    // (bandlimiting + noise reduction) that makes TTS sound
-                    // old and scratchy. VoxSherpa standalone uses STREAM_MUSIC
-                    // (the music path) and sounds clean — match that here.
-                    .setContentType(AndroidAudioAttributes.CONTENT_TYPE_MUSIC)
-                    .build(),
-            )
-            .setAudioFormat(
-                AndroidAudioFormat.Builder()
-                    .setSampleRate(sampleRate)
-                    .setChannelMask(channelMask)
-                    .setEncoding(encoding)
-                    .build(),
-            )
-            .setBufferSizeInBytes(bufferSize)
-            .setTransferMode(AudioTrack.MODE_STREAM)
-            .build()
+        return AudioTrack(
+            AudioManager.STREAM_MUSIC,
+            sampleRate,
+            channelMask,
+            encoding,
+            bufferSize,
+            AudioTrack.MODE_STREAM,
+        )
     }
 
     fun pauseTts() {
@@ -564,6 +566,35 @@ class EnginePlayer @AssistedInject constructor(
         stopPlaybackPipeline()
         scope.cancel()
         ioScope.cancel()
+    }
+
+    /**
+     * Length of trailing silence to splice onto a sentence's PCM, picked
+     * by the punctuation it ends with. Neural TTS engines barely breathe
+     * between sentences; without these padding gaps the listener hears one
+     * continuous block of speech. Values are tuned to match audiobook-style
+     * cadence at 1.0× speed; the producer scales them down at higher speeds
+     * so a 2× listener doesn't sit through 700ms gaps.
+     */
+    private fun trailingPauseMs(sentenceText: String): Int {
+        val tail = sentenceText.trimEnd().lastOrNull() ?: return 60
+        return when (tail) {
+            '.', '!', '?', '…' -> 350
+            ';', ':' -> 200
+            ',', '—' -> 120
+            else -> 60
+        }
+    }
+
+    private fun appendSilence(pcm: ByteArray, durationMs: Int, sampleRate: Int): ByteArray {
+        if (durationMs <= 0) return pcm
+        // 16-bit signed PCM = 2 bytes per sample, mono = 1 channel.
+        val silenceBytes = (sampleRate.toLong() * durationMs / 1000L).toInt() * 2
+        if (silenceBytes <= 0) return pcm
+        val out = ByteArray(pcm.size + silenceBytes)
+        System.arraycopy(pcm, 0, out, 0, pcm.size)
+        // ByteArray default-init is zero — that's silence in signed PCM.
+        return out
     }
 
     private companion object {

--- a/core-playback/src/main/kotlin/in/jphe/storyvox/playback/tts/EnginePlayer.kt
+++ b/core-playback/src/main/kotlin/in/jphe/storyvox/playback/tts/EnginePlayer.kt
@@ -147,15 +147,29 @@ class EnginePlayer @AssistedInject constructor(
         scope.launch {
             voiceManager.activeVoice.collect { active ->
                 val newId = active?.id ?: return@collect
-                if (newId == loadedVoiceId) return@collect
+                if (newId == loadedVoiceId) {
+                    // No-op flip — typically the user re-activated the same
+                    // voice, or DataStore re-emitted the persisted value. If
+                    // a previous flip had armed [voiceReloadPending] for a
+                    // different id and the user has now flipped *back* to
+                    // the loaded voice before resuming, clear the pending
+                    // flag so we don't force a needless model reload (a
+                    // 30 s Kokoro warm-up) on the next [resume].
+                    voiceReloadPending = false
+                    return@collect
+                }
                 val s = _observableState.value
                 val fictionId = s.currentFictionId
                 val chapterId = s.currentChapterId
                 if (fictionId == null || chapterId == null) return@collect
                 if (s.isPlaying) {
-                    // Live swap. loadAndPlay will tear down the current
-                    // pipeline (including the queue full of old-voice PCM)
-                    // and rebuild from the current char offset.
+                    // Live swap. Tear down the current pipeline FIRST so the
+                    // old generator can't keep pushing old-voice PCM into
+                    // the (about-to-be-replaced) queue while loadAndPlay
+                    // sits in loadModel for ~30 s on Kokoro. Without this,
+                    // the user hears 5–10 s of stale audio before silence
+                    // and finally the new voice.
+                    stopPlaybackPipeline()
                     loadAndPlay(fictionId, chapterId, s.charOffset)
                 } else {
                     voiceReloadPending = true
@@ -417,9 +431,15 @@ class EnginePlayer @AssistedInject constructor(
             AndroidProcess.setThreadPriority(AndroidProcess.THREAD_PRIORITY_URGENT_AUDIO)
             try {
                 for (i in currentSentenceIndex until sentences.size) {
+                    // Re-apply URGENT_AUDIO each iteration: engineMutex.withLock
+                    // and runInterruptible (below) are suspension points, and
+                    // Dispatchers.IO can resume us on a different worker thread
+                    // that's at default priority.
+                    AndroidProcess.setThreadPriority(AndroidProcess.THREAD_PRIORITY_URGENT_AUDIO)
                     if (!pipelineRunning.get()) return@launch
                     val s = sentences[i]
                     val pcm = engineMutex.withLock {
+                        AndroidProcess.setThreadPriority(AndroidProcess.THREAD_PRIORITY_URGENT_AUDIO)
                         if (!pipelineRunning.get()) return@withLock null
                         when (engineType) {
                             is EngineType.Kokoro -> KokoroEngine.getInstance()
@@ -507,6 +527,14 @@ class EnginePlayer @AssistedInject constructor(
                     }
                 }
             } finally {
+                // Release the AudioTrack from the same thread that owns
+                // its write() loop. Doing this from the main thread (as
+                // [stopPlaybackPipeline] used to) raced with whatever
+                // write() was in flight and could JNI-crash. Now release
+                // happens *after* the write loop has definitely exited.
+                runCatching { track.pause() }
+                runCatching { track.flush() }
+                runCatching { track.release() }
                 if (naturalEnd && pipelineRunning.get()) {
                     scope.launch {
                         sleepTimer.signalChapterEnd()
@@ -521,33 +549,43 @@ class EnginePlayer @AssistedInject constructor(
     }
 
     private fun stopPlaybackPipeline() {
-        // Order matters. We must (1) signal the consumer to stop AND (2)
-        // unblock any in-flight track.write() before (3) joining and (4)
-        // releasing the AudioTrack. Releasing while the consumer's still
-        // inside write() is undefined behavior in JNI land — segfault risk.
+        // Shutdown handshake:
+        //  1. Signal stop via the run flag.
+        //  2. Pause + flush the AudioTrack so any currently-blocked
+        //     write() returns immediately (ring buffer has space again).
+        //  3. Cancel the producer coroutine; runInterruptible turns the
+        //     thread interrupt into a CancellationException for blocked
+        //     queue.put() calls.
+        //  4. Interrupt + join the consumer thread (so a queue.take()
+        //     blocked on an empty queue wakes up).
+        //  5. The consumer's own finally block does the AudioTrack
+        //     release — *not* main thread — so we can't race a write().
+        //     If join times out we still don't release ourselves; the
+        //     consumer will finish its current write and clean up
+        //     whenever it gets there.
         pipelineRunning.set(false)
-        generationJob?.cancel()
-        generationJob = null
 
         val track = audioTrack
         audioTrack = null
         track?.let {
-            // pause + flush together: pause stops AudioFlinger from pulling,
-            // flush drops queued data, and the side effect is that any
-            // currently-blocked write() returns immediately because the
-            // ring buffer has space again.
             runCatching { it.pause() }
             runCatching { it.flush() }
         }
+
+        generationJob?.cancel()
+        generationJob = null
 
         val t = consumerThread
         consumerThread = null
         if (t != null && t !== Thread.currentThread()) {
             t.interrupt()
-            try { t.join(500) } catch (_: InterruptedException) {}
+            // 2 s upper bound — plenty for a paused+flushed track to
+            // finish its current write iteration. If we somehow exceed
+            // this the consumer keeps living until it's done; the OLD
+            // track's release is its responsibility.
+            try { t.join(2_000) } catch (_: InterruptedException) {}
         }
 
-        track?.let { runCatching { it.release() } }
         pcmQueue = null
     }
 

--- a/core-playback/src/main/kotlin/in/jphe/storyvox/playback/voice/VoiceCatalog.kt
+++ b/core-playback/src/main/kotlin/in/jphe/storyvox/playback/voice/VoiceCatalog.kt
@@ -22,8 +22,8 @@ object VoiceCatalog {
             qualityLevel = QualityLevel.High,
             engineType = EngineType.Piper,
             piper = PiperPaths(
-                onnxUrl = "https://github.com/jphein/VoxSherpa-TTS/releases/download/voices-v1/lessac-high-int8.onnx",
-                tokensUrl = "https://github.com/jphein/VoxSherpa-TTS/releases/download/voices-v1/lessac-high-int8.tokens.txt",
+                onnxUrl = "https://github.com/jphein/VoxSherpa-TTS/releases/download/voices-v2/en_US-lessac-high.onnx",
+                tokensUrl = "https://github.com/jphein/VoxSherpa-TTS/releases/download/voices-v2/en_US-lessac-high.tokens.txt",
             ),
         ),
         CatalogEntry(
@@ -34,8 +34,8 @@ object VoiceCatalog {
             qualityLevel = QualityLevel.High,
             engineType = EngineType.Piper,
             piper = PiperPaths(
-                onnxUrl = "https://github.com/jphein/VoxSherpa-TTS/releases/download/voices-v1/ryan-high-int8.onnx",
-                tokensUrl = "https://github.com/jphein/VoxSherpa-TTS/releases/download/voices-v1/ryan-high-int8.tokens.txt",
+                onnxUrl = "https://github.com/jphein/VoxSherpa-TTS/releases/download/voices-v2/en_US-ryan-high.onnx",
+                tokensUrl = "https://github.com/jphein/VoxSherpa-TTS/releases/download/voices-v2/en_US-ryan-high.tokens.txt",
             ),
         ),
         CatalogEntry(
@@ -46,8 +46,8 @@ object VoiceCatalog {
             qualityLevel = QualityLevel.Medium,
             engineType = EngineType.Piper,
             piper = PiperPaths(
-                onnxUrl = "https://github.com/jphein/VoxSherpa-TTS/releases/download/voices-v1/amy-medium-int8.onnx",
-                tokensUrl = "https://github.com/jphein/VoxSherpa-TTS/releases/download/voices-v1/amy-medium-int8.tokens.txt",
+                onnxUrl = "https://github.com/jphein/VoxSherpa-TTS/releases/download/voices-v2/en_US-amy-medium.onnx",
+                tokensUrl = "https://github.com/jphein/VoxSherpa-TTS/releases/download/voices-v2/en_US-amy-medium.tokens.txt",
             ),
         ),
         CatalogEntry(
@@ -58,8 +58,8 @@ object VoiceCatalog {
             qualityLevel = QualityLevel.Low,
             engineType = EngineType.Piper,
             piper = PiperPaths(
-                onnxUrl = "https://github.com/jphein/VoxSherpa-TTS/releases/download/voices-v1/alan-low-int8.onnx",
-                tokensUrl = "https://github.com/jphein/VoxSherpa-TTS/releases/download/voices-v1/alan-low-int8.tokens.txt",
+                onnxUrl = "https://github.com/jphein/VoxSherpa-TTS/releases/download/voices-v2/en_GB-alan-low.onnx",
+                tokensUrl = "https://github.com/jphein/VoxSherpa-TTS/releases/download/voices-v2/en_GB-alan-low.tokens.txt",
             ),
         ),
         CatalogEntry(
@@ -70,8 +70,8 @@ object VoiceCatalog {
             qualityLevel = QualityLevel.Medium,
             engineType = EngineType.Piper,
             piper = PiperPaths(
-                onnxUrl = "https://github.com/jphein/VoxSherpa-TTS/releases/download/voices-v1/alan-medium-int8.onnx",
-                tokensUrl = "https://github.com/jphein/VoxSherpa-TTS/releases/download/voices-v1/alan-medium-int8.tokens.txt",
+                onnxUrl = "https://github.com/jphein/VoxSherpa-TTS/releases/download/voices-v2/en_GB-alan-medium.onnx",
+                tokensUrl = "https://github.com/jphein/VoxSherpa-TTS/releases/download/voices-v2/en_GB-alan-medium.tokens.txt",
             ),
         ),
         CatalogEntry(
@@ -82,8 +82,8 @@ object VoiceCatalog {
             qualityLevel = QualityLevel.Medium,
             engineType = EngineType.Piper,
             piper = PiperPaths(
-                onnxUrl = "https://github.com/jphein/VoxSherpa-TTS/releases/download/voices-v1/alba-medium-int8.onnx",
-                tokensUrl = "https://github.com/jphein/VoxSherpa-TTS/releases/download/voices-v1/alba-medium-int8.tokens.txt",
+                onnxUrl = "https://github.com/jphein/VoxSherpa-TTS/releases/download/voices-v2/en_GB-alba-medium.onnx",
+                tokensUrl = "https://github.com/jphein/VoxSherpa-TTS/releases/download/voices-v2/en_GB-alba-medium.tokens.txt",
             ),
         ),
         CatalogEntry(
@@ -94,8 +94,8 @@ object VoiceCatalog {
             qualityLevel = QualityLevel.Medium,
             engineType = EngineType.Piper,
             piper = PiperPaths(
-                onnxUrl = "https://github.com/jphein/VoxSherpa-TTS/releases/download/voices-v1/aru-medium-int8.onnx",
-                tokensUrl = "https://github.com/jphein/VoxSherpa-TTS/releases/download/voices-v1/aru-medium-int8.tokens.txt",
+                onnxUrl = "https://github.com/jphein/VoxSherpa-TTS/releases/download/voices-v2/en_GB-aru-medium.onnx",
+                tokensUrl = "https://github.com/jphein/VoxSherpa-TTS/releases/download/voices-v2/en_GB-aru-medium.tokens.txt",
             ),
         ),
         CatalogEntry(
@@ -106,8 +106,8 @@ object VoiceCatalog {
             qualityLevel = QualityLevel.Medium,
             engineType = EngineType.Piper,
             piper = PiperPaths(
-                onnxUrl = "https://github.com/jphein/VoxSherpa-TTS/releases/download/voices-v1/cori-medium-int8.onnx",
-                tokensUrl = "https://github.com/jphein/VoxSherpa-TTS/releases/download/voices-v1/cori-medium-int8.tokens.txt",
+                onnxUrl = "https://github.com/jphein/VoxSherpa-TTS/releases/download/voices-v2/en_GB-cori-medium.onnx",
+                tokensUrl = "https://github.com/jphein/VoxSherpa-TTS/releases/download/voices-v2/en_GB-cori-medium.tokens.txt",
             ),
         ),
         CatalogEntry(
@@ -118,8 +118,8 @@ object VoiceCatalog {
             qualityLevel = QualityLevel.High,
             engineType = EngineType.Piper,
             piper = PiperPaths(
-                onnxUrl = "https://github.com/jphein/VoxSherpa-TTS/releases/download/voices-v1/cori-high-int8.onnx",
-                tokensUrl = "https://github.com/jphein/VoxSherpa-TTS/releases/download/voices-v1/cori-high-int8.tokens.txt",
+                onnxUrl = "https://github.com/jphein/VoxSherpa-TTS/releases/download/voices-v2/en_GB-cori-high.onnx",
+                tokensUrl = "https://github.com/jphein/VoxSherpa-TTS/releases/download/voices-v2/en_GB-cori-high.tokens.txt",
             ),
         ),
         CatalogEntry(
@@ -130,8 +130,8 @@ object VoiceCatalog {
             qualityLevel = QualityLevel.High,
             engineType = EngineType.Piper,
             piper = PiperPaths(
-                onnxUrl = "https://github.com/jphein/VoxSherpa-TTS/releases/download/voices-v1/dii-high-int8.onnx",
-                tokensUrl = "https://github.com/jphein/VoxSherpa-TTS/releases/download/voices-v1/dii-high-int8.tokens.txt",
+                onnxUrl = "https://github.com/jphein/VoxSherpa-TTS/releases/download/voices-v2/en_GB-dii-high.onnx",
+                tokensUrl = "https://github.com/jphein/VoxSherpa-TTS/releases/download/voices-v2/en_GB-dii-high.tokens.txt",
             ),
         ),
         CatalogEntry(
@@ -142,8 +142,8 @@ object VoiceCatalog {
             qualityLevel = QualityLevel.Medium,
             engineType = EngineType.Piper,
             piper = PiperPaths(
-                onnxUrl = "https://github.com/jphein/VoxSherpa-TTS/releases/download/voices-v1/jenny_dioco-medium-int8.onnx",
-                tokensUrl = "https://github.com/jphein/VoxSherpa-TTS/releases/download/voices-v1/jenny_dioco-medium-int8.tokens.txt",
+                onnxUrl = "https://github.com/jphein/VoxSherpa-TTS/releases/download/voices-v2/en_GB-jenny_dioco-medium.onnx",
+                tokensUrl = "https://github.com/jphein/VoxSherpa-TTS/releases/download/voices-v2/en_GB-jenny_dioco-medium.tokens.txt",
             ),
         ),
         CatalogEntry(
@@ -154,8 +154,8 @@ object VoiceCatalog {
             qualityLevel = QualityLevel.High,
             engineType = EngineType.Piper,
             piper = PiperPaths(
-                onnxUrl = "https://github.com/jphein/VoxSherpa-TTS/releases/download/voices-v1/miro-high-int8.onnx",
-                tokensUrl = "https://github.com/jphein/VoxSherpa-TTS/releases/download/voices-v1/miro-high-int8.tokens.txt",
+                onnxUrl = "https://github.com/jphein/VoxSherpa-TTS/releases/download/voices-v2/en_GB-miro-high.onnx",
+                tokensUrl = "https://github.com/jphein/VoxSherpa-TTS/releases/download/voices-v2/en_GB-miro-high.tokens.txt",
             ),
         ),
         CatalogEntry(
@@ -166,8 +166,8 @@ object VoiceCatalog {
             qualityLevel = QualityLevel.Medium,
             engineType = EngineType.Piper,
             piper = PiperPaths(
-                onnxUrl = "https://github.com/jphein/VoxSherpa-TTS/releases/download/voices-v1/northern_english_male-medium-int8.onnx",
-                tokensUrl = "https://github.com/jphein/VoxSherpa-TTS/releases/download/voices-v1/northern_english_male-medium-int8.tokens.txt",
+                onnxUrl = "https://github.com/jphein/VoxSherpa-TTS/releases/download/voices-v2/en_GB-northern_english_male-medium.onnx",
+                tokensUrl = "https://github.com/jphein/VoxSherpa-TTS/releases/download/voices-v2/en_GB-northern_english_male-medium.tokens.txt",
             ),
         ),
         CatalogEntry(
@@ -178,8 +178,8 @@ object VoiceCatalog {
             qualityLevel = QualityLevel.Medium,
             engineType = EngineType.Piper,
             piper = PiperPaths(
-                onnxUrl = "https://github.com/jphein/VoxSherpa-TTS/releases/download/voices-v1/semaine-medium-int8.onnx",
-                tokensUrl = "https://github.com/jphein/VoxSherpa-TTS/releases/download/voices-v1/semaine-medium-int8.tokens.txt",
+                onnxUrl = "https://github.com/jphein/VoxSherpa-TTS/releases/download/voices-v2/en_GB-semaine-medium.onnx",
+                tokensUrl = "https://github.com/jphein/VoxSherpa-TTS/releases/download/voices-v2/en_GB-semaine-medium.tokens.txt",
             ),
         ),
         CatalogEntry(
@@ -190,8 +190,8 @@ object VoiceCatalog {
             qualityLevel = QualityLevel.Low,
             engineType = EngineType.Piper,
             piper = PiperPaths(
-                onnxUrl = "https://github.com/jphein/VoxSherpa-TTS/releases/download/voices-v1/southern_english_female-low-int8.onnx",
-                tokensUrl = "https://github.com/jphein/VoxSherpa-TTS/releases/download/voices-v1/southern_english_female-low-int8.tokens.txt",
+                onnxUrl = "https://github.com/jphein/VoxSherpa-TTS/releases/download/voices-v2/en_GB-southern_english_female-low.onnx",
+                tokensUrl = "https://github.com/jphein/VoxSherpa-TTS/releases/download/voices-v2/en_GB-southern_english_female-low.tokens.txt",
             ),
         ),
         CatalogEntry(
@@ -202,8 +202,8 @@ object VoiceCatalog {
             qualityLevel = QualityLevel.Medium,
             engineType = EngineType.Piper,
             piper = PiperPaths(
-                onnxUrl = "https://github.com/jphein/VoxSherpa-TTS/releases/download/voices-v1/southern_english_female-medium-int8.onnx",
-                tokensUrl = "https://github.com/jphein/VoxSherpa-TTS/releases/download/voices-v1/southern_english_female-medium-int8.tokens.txt",
+                onnxUrl = "https://github.com/jphein/VoxSherpa-TTS/releases/download/voices-v2/en_GB-southern_english_female-medium.onnx",
+                tokensUrl = "https://github.com/jphein/VoxSherpa-TTS/releases/download/voices-v2/en_GB-southern_english_female-medium.tokens.txt",
             ),
         ),
         CatalogEntry(
@@ -214,8 +214,8 @@ object VoiceCatalog {
             qualityLevel = QualityLevel.Medium,
             engineType = EngineType.Piper,
             piper = PiperPaths(
-                onnxUrl = "https://github.com/jphein/VoxSherpa-TTS/releases/download/voices-v1/southern_english_male-medium-int8.onnx",
-                tokensUrl = "https://github.com/jphein/VoxSherpa-TTS/releases/download/voices-v1/southern_english_male-medium-int8.tokens.txt",
+                onnxUrl = "https://github.com/jphein/VoxSherpa-TTS/releases/download/voices-v2/en_GB-southern_english_male-medium.onnx",
+                tokensUrl = "https://github.com/jphein/VoxSherpa-TTS/releases/download/voices-v2/en_GB-southern_english_male-medium.tokens.txt",
             ),
         ),
         CatalogEntry(
@@ -226,8 +226,8 @@ object VoiceCatalog {
             qualityLevel = QualityLevel.Medium,
             engineType = EngineType.Piper,
             piper = PiperPaths(
-                onnxUrl = "https://github.com/jphein/VoxSherpa-TTS/releases/download/voices-v1/vctk-medium-int8.onnx",
-                tokensUrl = "https://github.com/jphein/VoxSherpa-TTS/releases/download/voices-v1/vctk-medium-int8.tokens.txt",
+                onnxUrl = "https://github.com/jphein/VoxSherpa-TTS/releases/download/voices-v2/en_GB-vctk-medium.onnx",
+                tokensUrl = "https://github.com/jphein/VoxSherpa-TTS/releases/download/voices-v2/en_GB-vctk-medium.tokens.txt",
             ),
         ),
         CatalogEntry(
@@ -238,8 +238,8 @@ object VoiceCatalog {
             qualityLevel = QualityLevel.Low,
             engineType = EngineType.Piper,
             piper = PiperPaths(
-                onnxUrl = "https://github.com/jphein/VoxSherpa-TTS/releases/download/voices-v1/amy-low-int8.onnx",
-                tokensUrl = "https://github.com/jphein/VoxSherpa-TTS/releases/download/voices-v1/amy-low-int8.tokens.txt",
+                onnxUrl = "https://github.com/jphein/VoxSherpa-TTS/releases/download/voices-v2/en_US-amy-low.onnx",
+                tokensUrl = "https://github.com/jphein/VoxSherpa-TTS/releases/download/voices-v2/en_US-amy-low.tokens.txt",
             ),
         ),
         CatalogEntry(
@@ -250,8 +250,8 @@ object VoiceCatalog {
             qualityLevel = QualityLevel.Medium,
             engineType = EngineType.Piper,
             piper = PiperPaths(
-                onnxUrl = "https://github.com/jphein/VoxSherpa-TTS/releases/download/voices-v1/arctic-medium-int8.onnx",
-                tokensUrl = "https://github.com/jphein/VoxSherpa-TTS/releases/download/voices-v1/arctic-medium-int8.tokens.txt",
+                onnxUrl = "https://github.com/jphein/VoxSherpa-TTS/releases/download/voices-v2/en_US-arctic-medium.onnx",
+                tokensUrl = "https://github.com/jphein/VoxSherpa-TTS/releases/download/voices-v2/en_US-arctic-medium.tokens.txt",
             ),
         ),
         CatalogEntry(
@@ -262,8 +262,8 @@ object VoiceCatalog {
             qualityLevel = QualityLevel.Medium,
             engineType = EngineType.Piper,
             piper = PiperPaths(
-                onnxUrl = "https://github.com/jphein/VoxSherpa-TTS/releases/download/voices-v1/bryce-medium-int8.onnx",
-                tokensUrl = "https://github.com/jphein/VoxSherpa-TTS/releases/download/voices-v1/bryce-medium-int8.tokens.txt",
+                onnxUrl = "https://github.com/jphein/VoxSherpa-TTS/releases/download/voices-v2/en_US-bryce-medium.onnx",
+                tokensUrl = "https://github.com/jphein/VoxSherpa-TTS/releases/download/voices-v2/en_US-bryce-medium.tokens.txt",
             ),
         ),
         CatalogEntry(
@@ -274,8 +274,8 @@ object VoiceCatalog {
             qualityLevel = QualityLevel.Low,
             engineType = EngineType.Piper,
             piper = PiperPaths(
-                onnxUrl = "https://github.com/jphein/VoxSherpa-TTS/releases/download/voices-v1/danny-low-int8.onnx",
-                tokensUrl = "https://github.com/jphein/VoxSherpa-TTS/releases/download/voices-v1/danny-low-int8.tokens.txt",
+                onnxUrl = "https://github.com/jphein/VoxSherpa-TTS/releases/download/voices-v2/en_US-danny-low.onnx",
+                tokensUrl = "https://github.com/jphein/VoxSherpa-TTS/releases/download/voices-v2/en_US-danny-low.tokens.txt",
             ),
         ),
         CatalogEntry(
@@ -286,8 +286,8 @@ object VoiceCatalog {
             qualityLevel = QualityLevel.High,
             engineType = EngineType.Piper,
             piper = PiperPaths(
-                onnxUrl = "https://github.com/jphein/VoxSherpa-TTS/releases/download/voices-v1/glados-high-int8.onnx",
-                tokensUrl = "https://github.com/jphein/VoxSherpa-TTS/releases/download/voices-v1/glados-high-int8.tokens.txt",
+                onnxUrl = "https://github.com/jphein/VoxSherpa-TTS/releases/download/voices-v2/en_US-glados-high.onnx",
+                tokensUrl = "https://github.com/jphein/VoxSherpa-TTS/releases/download/voices-v2/en_US-glados-high.tokens.txt",
             ),
         ),
         CatalogEntry(
@@ -298,8 +298,8 @@ object VoiceCatalog {
             qualityLevel = QualityLevel.Medium,
             engineType = EngineType.Piper,
             piper = PiperPaths(
-                onnxUrl = "https://github.com/jphein/VoxSherpa-TTS/releases/download/voices-v1/hfc_female-medium-int8.onnx",
-                tokensUrl = "https://github.com/jphein/VoxSherpa-TTS/releases/download/voices-v1/hfc_female-medium-int8.tokens.txt",
+                onnxUrl = "https://github.com/jphein/VoxSherpa-TTS/releases/download/voices-v2/en_US-hfc_female-medium.onnx",
+                tokensUrl = "https://github.com/jphein/VoxSherpa-TTS/releases/download/voices-v2/en_US-hfc_female-medium.tokens.txt",
             ),
         ),
         CatalogEntry(
@@ -310,8 +310,8 @@ object VoiceCatalog {
             qualityLevel = QualityLevel.Medium,
             engineType = EngineType.Piper,
             piper = PiperPaths(
-                onnxUrl = "https://github.com/jphein/VoxSherpa-TTS/releases/download/voices-v1/hfc_male-medium-int8.onnx",
-                tokensUrl = "https://github.com/jphein/VoxSherpa-TTS/releases/download/voices-v1/hfc_male-medium-int8.tokens.txt",
+                onnxUrl = "https://github.com/jphein/VoxSherpa-TTS/releases/download/voices-v2/en_US-hfc_male-medium.onnx",
+                tokensUrl = "https://github.com/jphein/VoxSherpa-TTS/releases/download/voices-v2/en_US-hfc_male-medium.tokens.txt",
             ),
         ),
         CatalogEntry(
@@ -322,8 +322,8 @@ object VoiceCatalog {
             qualityLevel = QualityLevel.Medium,
             engineType = EngineType.Piper,
             piper = PiperPaths(
-                onnxUrl = "https://github.com/jphein/VoxSherpa-TTS/releases/download/voices-v1/joe-medium-int8.onnx",
-                tokensUrl = "https://github.com/jphein/VoxSherpa-TTS/releases/download/voices-v1/joe-medium-int8.tokens.txt",
+                onnxUrl = "https://github.com/jphein/VoxSherpa-TTS/releases/download/voices-v2/en_US-joe-medium.onnx",
+                tokensUrl = "https://github.com/jphein/VoxSherpa-TTS/releases/download/voices-v2/en_US-joe-medium.tokens.txt",
             ),
         ),
         CatalogEntry(
@@ -334,8 +334,8 @@ object VoiceCatalog {
             qualityLevel = QualityLevel.Medium,
             engineType = EngineType.Piper,
             piper = PiperPaths(
-                onnxUrl = "https://github.com/jphein/VoxSherpa-TTS/releases/download/voices-v1/john-medium-int8.onnx",
-                tokensUrl = "https://github.com/jphein/VoxSherpa-TTS/releases/download/voices-v1/john-medium-int8.tokens.txt",
+                onnxUrl = "https://github.com/jphein/VoxSherpa-TTS/releases/download/voices-v2/en_US-john-medium.onnx",
+                tokensUrl = "https://github.com/jphein/VoxSherpa-TTS/releases/download/voices-v2/en_US-john-medium.tokens.txt",
             ),
         ),
         CatalogEntry(
@@ -346,8 +346,8 @@ object VoiceCatalog {
             qualityLevel = QualityLevel.Low,
             engineType = EngineType.Piper,
             piper = PiperPaths(
-                onnxUrl = "https://github.com/jphein/VoxSherpa-TTS/releases/download/voices-v1/kathleen-low-int8.onnx",
-                tokensUrl = "https://github.com/jphein/VoxSherpa-TTS/releases/download/voices-v1/kathleen-low-int8.tokens.txt",
+                onnxUrl = "https://github.com/jphein/VoxSherpa-TTS/releases/download/voices-v2/en_US-kathleen-low.onnx",
+                tokensUrl = "https://github.com/jphein/VoxSherpa-TTS/releases/download/voices-v2/en_US-kathleen-low.tokens.txt",
             ),
         ),
         CatalogEntry(
@@ -358,8 +358,8 @@ object VoiceCatalog {
             qualityLevel = QualityLevel.Medium,
             engineType = EngineType.Piper,
             piper = PiperPaths(
-                onnxUrl = "https://github.com/jphein/VoxSherpa-TTS/releases/download/voices-v1/kristin-medium-int8.onnx",
-                tokensUrl = "https://github.com/jphein/VoxSherpa-TTS/releases/download/voices-v1/kristin-medium-int8.tokens.txt",
+                onnxUrl = "https://github.com/jphein/VoxSherpa-TTS/releases/download/voices-v2/en_US-kristin-medium.onnx",
+                tokensUrl = "https://github.com/jphein/VoxSherpa-TTS/releases/download/voices-v2/en_US-kristin-medium.tokens.txt",
             ),
         ),
         CatalogEntry(
@@ -370,8 +370,8 @@ object VoiceCatalog {
             qualityLevel = QualityLevel.Medium,
             engineType = EngineType.Piper,
             piper = PiperPaths(
-                onnxUrl = "https://github.com/jphein/VoxSherpa-TTS/releases/download/voices-v1/kusal-medium-int8.onnx",
-                tokensUrl = "https://github.com/jphein/VoxSherpa-TTS/releases/download/voices-v1/kusal-medium-int8.tokens.txt",
+                onnxUrl = "https://github.com/jphein/VoxSherpa-TTS/releases/download/voices-v2/en_US-kusal-medium.onnx",
+                tokensUrl = "https://github.com/jphein/VoxSherpa-TTS/releases/download/voices-v2/en_US-kusal-medium.tokens.txt",
             ),
         ),
         CatalogEntry(
@@ -382,8 +382,8 @@ object VoiceCatalog {
             qualityLevel = QualityLevel.Medium,
             engineType = EngineType.Piper,
             piper = PiperPaths(
-                onnxUrl = "https://github.com/jphein/VoxSherpa-TTS/releases/download/voices-v1/l2arctic-medium-int8.onnx",
-                tokensUrl = "https://github.com/jphein/VoxSherpa-TTS/releases/download/voices-v1/l2arctic-medium-int8.tokens.txt",
+                onnxUrl = "https://github.com/jphein/VoxSherpa-TTS/releases/download/voices-v2/en_US-l2arctic-medium.onnx",
+                tokensUrl = "https://github.com/jphein/VoxSherpa-TTS/releases/download/voices-v2/en_US-l2arctic-medium.tokens.txt",
             ),
         ),
         CatalogEntry(
@@ -394,8 +394,8 @@ object VoiceCatalog {
             qualityLevel = QualityLevel.Low,
             engineType = EngineType.Piper,
             piper = PiperPaths(
-                onnxUrl = "https://github.com/jphein/VoxSherpa-TTS/releases/download/voices-v1/lessac-low-int8.onnx",
-                tokensUrl = "https://github.com/jphein/VoxSherpa-TTS/releases/download/voices-v1/lessac-low-int8.tokens.txt",
+                onnxUrl = "https://github.com/jphein/VoxSherpa-TTS/releases/download/voices-v2/en_US-lessac-low.onnx",
+                tokensUrl = "https://github.com/jphein/VoxSherpa-TTS/releases/download/voices-v2/en_US-lessac-low.tokens.txt",
             ),
         ),
         CatalogEntry(
@@ -406,8 +406,8 @@ object VoiceCatalog {
             qualityLevel = QualityLevel.Medium,
             engineType = EngineType.Piper,
             piper = PiperPaths(
-                onnxUrl = "https://github.com/jphein/VoxSherpa-TTS/releases/download/voices-v1/lessac-medium-int8.onnx",
-                tokensUrl = "https://github.com/jphein/VoxSherpa-TTS/releases/download/voices-v1/lessac-medium-int8.tokens.txt",
+                onnxUrl = "https://github.com/jphein/VoxSherpa-TTS/releases/download/voices-v2/en_US-lessac-medium.onnx",
+                tokensUrl = "https://github.com/jphein/VoxSherpa-TTS/releases/download/voices-v2/en_US-lessac-medium.tokens.txt",
             ),
         ),
         CatalogEntry(
@@ -418,8 +418,8 @@ object VoiceCatalog {
             qualityLevel = QualityLevel.High,
             engineType = EngineType.Piper,
             piper = PiperPaths(
-                onnxUrl = "https://github.com/jphein/VoxSherpa-TTS/releases/download/voices-v1/libritts-high-int8.onnx",
-                tokensUrl = "https://github.com/jphein/VoxSherpa-TTS/releases/download/voices-v1/libritts-high-int8.tokens.txt",
+                onnxUrl = "https://github.com/jphein/VoxSherpa-TTS/releases/download/voices-v2/en_US-libritts-high.onnx",
+                tokensUrl = "https://github.com/jphein/VoxSherpa-TTS/releases/download/voices-v2/en_US-libritts-high.tokens.txt",
             ),
         ),
         CatalogEntry(
@@ -430,8 +430,8 @@ object VoiceCatalog {
             qualityLevel = QualityLevel.Medium,
             engineType = EngineType.Piper,
             piper = PiperPaths(
-                onnxUrl = "https://github.com/jphein/VoxSherpa-TTS/releases/download/voices-v1/libritts_r-medium-int8.onnx",
-                tokensUrl = "https://github.com/jphein/VoxSherpa-TTS/releases/download/voices-v1/libritts_r-medium-int8.tokens.txt",
+                onnxUrl = "https://github.com/jphein/VoxSherpa-TTS/releases/download/voices-v2/en_US-libritts_r-medium.onnx",
+                tokensUrl = "https://github.com/jphein/VoxSherpa-TTS/releases/download/voices-v2/en_US-libritts_r-medium.tokens.txt",
             ),
         ),
         CatalogEntry(
@@ -442,8 +442,8 @@ object VoiceCatalog {
             qualityLevel = QualityLevel.Medium,
             engineType = EngineType.Piper,
             piper = PiperPaths(
-                onnxUrl = "https://github.com/jphein/VoxSherpa-TTS/releases/download/voices-v1/ljspeech-medium-int8.onnx",
-                tokensUrl = "https://github.com/jphein/VoxSherpa-TTS/releases/download/voices-v1/ljspeech-medium-int8.tokens.txt",
+                onnxUrl = "https://github.com/jphein/VoxSherpa-TTS/releases/download/voices-v2/en_US-ljspeech-medium.onnx",
+                tokensUrl = "https://github.com/jphein/VoxSherpa-TTS/releases/download/voices-v2/en_US-ljspeech-medium.tokens.txt",
             ),
         ),
         CatalogEntry(
@@ -454,8 +454,8 @@ object VoiceCatalog {
             qualityLevel = QualityLevel.High,
             engineType = EngineType.Piper,
             piper = PiperPaths(
-                onnxUrl = "https://github.com/jphein/VoxSherpa-TTS/releases/download/voices-v1/ljspeech-high-int8.onnx",
-                tokensUrl = "https://github.com/jphein/VoxSherpa-TTS/releases/download/voices-v1/ljspeech-high-int8.tokens.txt",
+                onnxUrl = "https://github.com/jphein/VoxSherpa-TTS/releases/download/voices-v2/en_US-ljspeech-high.onnx",
+                tokensUrl = "https://github.com/jphein/VoxSherpa-TTS/releases/download/voices-v2/en_US-ljspeech-high.tokens.txt",
             ),
         ),
         CatalogEntry(
@@ -466,8 +466,8 @@ object VoiceCatalog {
             qualityLevel = QualityLevel.High,
             engineType = EngineType.Piper,
             piper = PiperPaths(
-                onnxUrl = "https://github.com/jphein/VoxSherpa-TTS/releases/download/voices-v1/miro-high-int8.onnx",
-                tokensUrl = "https://github.com/jphein/VoxSherpa-TTS/releases/download/voices-v1/miro-high-int8.tokens.txt",
+                onnxUrl = "https://github.com/jphein/VoxSherpa-TTS/releases/download/voices-v2/en_US-miro-high.onnx",
+                tokensUrl = "https://github.com/jphein/VoxSherpa-TTS/releases/download/voices-v2/en_US-miro-high.tokens.txt",
             ),
         ),
         CatalogEntry(
@@ -478,8 +478,8 @@ object VoiceCatalog {
             qualityLevel = QualityLevel.Medium,
             engineType = EngineType.Piper,
             piper = PiperPaths(
-                onnxUrl = "https://github.com/jphein/VoxSherpa-TTS/releases/download/voices-v1/norman-medium-int8.onnx",
-                tokensUrl = "https://github.com/jphein/VoxSherpa-TTS/releases/download/voices-v1/norman-medium-int8.tokens.txt",
+                onnxUrl = "https://github.com/jphein/VoxSherpa-TTS/releases/download/voices-v2/en_US-norman-medium.onnx",
+                tokensUrl = "https://github.com/jphein/VoxSherpa-TTS/releases/download/voices-v2/en_US-norman-medium.tokens.txt",
             ),
         ),
         CatalogEntry(
@@ -490,8 +490,8 @@ object VoiceCatalog {
             qualityLevel = QualityLevel.Medium,
             engineType = EngineType.Piper,
             piper = PiperPaths(
-                onnxUrl = "https://github.com/jphein/VoxSherpa-TTS/releases/download/voices-v1/reza_ibrahim-medium-int8.onnx",
-                tokensUrl = "https://github.com/jphein/VoxSherpa-TTS/releases/download/voices-v1/reza_ibrahim-medium-int8.tokens.txt",
+                onnxUrl = "https://github.com/jphein/VoxSherpa-TTS/releases/download/voices-v2/en_US-reza_ibrahim-medium.onnx",
+                tokensUrl = "https://github.com/jphein/VoxSherpa-TTS/releases/download/voices-v2/en_US-reza_ibrahim-medium.tokens.txt",
             ),
         ),
         CatalogEntry(
@@ -502,8 +502,8 @@ object VoiceCatalog {
             qualityLevel = QualityLevel.Low,
             engineType = EngineType.Piper,
             piper = PiperPaths(
-                onnxUrl = "https://github.com/jphein/VoxSherpa-TTS/releases/download/voices-v1/ryan-low-int8.onnx",
-                tokensUrl = "https://github.com/jphein/VoxSherpa-TTS/releases/download/voices-v1/ryan-low-int8.tokens.txt",
+                onnxUrl = "https://github.com/jphein/VoxSherpa-TTS/releases/download/voices-v2/en_US-ryan-low.onnx",
+                tokensUrl = "https://github.com/jphein/VoxSherpa-TTS/releases/download/voices-v2/en_US-ryan-low.tokens.txt",
             ),
         ),
         CatalogEntry(
@@ -514,8 +514,8 @@ object VoiceCatalog {
             qualityLevel = QualityLevel.Medium,
             engineType = EngineType.Piper,
             piper = PiperPaths(
-                onnxUrl = "https://github.com/jphein/VoxSherpa-TTS/releases/download/voices-v1/ryan-medium-int8.onnx",
-                tokensUrl = "https://github.com/jphein/VoxSherpa-TTS/releases/download/voices-v1/ryan-medium-int8.tokens.txt",
+                onnxUrl = "https://github.com/jphein/VoxSherpa-TTS/releases/download/voices-v2/en_US-ryan-medium.onnx",
+                tokensUrl = "https://github.com/jphein/VoxSherpa-TTS/releases/download/voices-v2/en_US-ryan-medium.tokens.txt",
             ),
         ),
         CatalogEntry(
@@ -526,8 +526,8 @@ object VoiceCatalog {
             qualityLevel = QualityLevel.Medium,
             engineType = EngineType.Piper,
             piper = PiperPaths(
-                onnxUrl = "https://github.com/jphein/VoxSherpa-TTS/releases/download/voices-v1/sam-medium-int8.onnx",
-                tokensUrl = "https://github.com/jphein/VoxSherpa-TTS/releases/download/voices-v1/sam-medium-int8.tokens.txt",
+                onnxUrl = "https://github.com/jphein/VoxSherpa-TTS/releases/download/voices-v2/en_US-sam-medium.onnx",
+                tokensUrl = "https://github.com/jphein/VoxSherpa-TTS/releases/download/voices-v2/en_US-sam-medium.tokens.txt",
             ),
         ),
     )

--- a/core-playback/src/main/kotlin/in/jphe/storyvox/playback/voice/VoiceCatalog.kt
+++ b/core-playback/src/main/kotlin/in/jphe/storyvox/playback/voice/VoiceCatalog.kt
@@ -3,6 +3,16 @@ package `in`.jphe.storyvox.playback.voice
 object VoiceCatalog {
     val voices: List<CatalogEntry> = piperEntries() + kokoroEntries()
     fun byId(id: String): CatalogEntry? = voices.firstOrNull { it.id == id }
+
+    /** The three voices we hand-picked as the strongest starters. Surfaced
+     *  on the first-launch picker AND highlighted in the Voice Library
+     *  under a "Featured" section so newcomers don't have to scroll the
+     *  90-voice catalog hunting for the good ones. */
+    val featuredIds: List<String> = listOf(
+        "piper_lessac_en_US_high_int8",
+        "piper_ryan_en_US_high_int8",
+        "piper_amy_en_US_medium_int8",
+    )
     private fun piperEntries(): List<CatalogEntry> = listOf(
         CatalogEntry(
             id = "piper_lessac_en_US_high_int8",

--- a/core-playback/src/main/kotlin/in/jphe/storyvox/playback/voice/VoiceManager.kt
+++ b/core-playback/src/main/kotlin/in/jphe/storyvox/playback/voice/VoiceManager.kt
@@ -89,7 +89,7 @@ class VoiceManager @Inject constructor(
 
     private fun isKokoroSharedModelInstalled(): Boolean {
         val dir = kokoroSharedDir()
-        return File(dir, "model.int8.onnx").exists() &&
+        return File(dir, "model.onnx").exists() &&
             File(dir, "voices.bin").exists() &&
             File(dir, "tokens.txt").exists()
     }
@@ -120,31 +120,34 @@ class VoiceManager @Inject constructor(
         when (entry.engineType) {
             is EngineType.Kokoro -> {
                 // Kokoro speakers all share one ~168MB multi-speaker model
-                // (model.int8.onnx + tokens.txt + voices.bin). The first
+                // (model.onnx + tokens.txt + voices.bin). The first
                 // Kokoro pick downloads it; every subsequent one just flips
                 // the active speaker id with no additional payload.
                 val sharedDir = kokoroSharedDir()
-                val onnxFile = File(sharedDir, "model.int8.onnx")
+                val onnxFile = File(sharedDir, "model.onnx")
                 val tokensFile = File(sharedDir, "tokens.txt")
                 val voicesFile = File(sharedDir, "voices.bin")
                 if (!onnxFile.exists() || !voicesFile.exists() || !tokensFile.exists()) {
                     sharedDir.mkdirs()
                     try {
+                        // Kokoro v1_1 fp32 sizes (vs voices-v1's int8: 114M / 53M).
+                        // Total ~379MB on first install — bigger than int8 but
+                        // produces clean speech (no quantization fuzz).
                         downloadFile(
-                            url = "https://github.com/jphein/VoxSherpa-TTS/releases/download/voices-v1/kokoro-model.onnx",
+                            url = "https://github.com/jphein/VoxSherpa-TTS/releases/download/voices-v2/kokoro-model.onnx",
                             target = onnxFile,
-                            knownTotalBytes = 114_299_010L,
-                        ) { read, total -> emit(DownloadProgress.Downloading(read, 168_090_841L)) }
+                            knownTotalBytes = 325_631_784L,
+                        ) { read, _ -> emit(DownloadProgress.Downloading(read, 379_423_615L)) }
                         downloadFile(
-                            url = "https://github.com/jphein/VoxSherpa-TTS/releases/download/voices-v1/kokoro-voices.bin",
+                            url = "https://github.com/jphein/VoxSherpa-TTS/releases/download/voices-v2/kokoro-voices.bin",
                             target = voicesFile,
                             knownTotalBytes = 53_790_720L,
-                        ) { read, total ->
+                        ) { read, _ ->
                             // Continue progress where the model left off so the bar keeps moving.
-                            emit(DownloadProgress.Downloading(114_299_010L + read, 168_090_841L))
+                            emit(DownloadProgress.Downloading(325_631_784L + read, 379_423_615L))
                         }
                         downloadFile(
-                            url = "https://github.com/jphein/VoxSherpa-TTS/releases/download/voices-v1/kokoro-tokens.txt",
+                            url = "https://github.com/jphein/VoxSherpa-TTS/releases/download/voices-v2/kokoro-tokens.txt",
                             target = tokensFile,
                             knownTotalBytes = 0L,
                         ) { _, _ -> }

--- a/core-ui/src/main/kotlin/in/jphe/storyvox/ui/component/SentenceHighlight.kt
+++ b/core-ui/src/main/kotlin/in/jphe/storyvox/ui/component/SentenceHighlight.kt
@@ -86,13 +86,15 @@ fun SentenceHighlight(
             .fillMaxWidth()
             .padding(horizontal = 4.dp)
             // Tap-to-seek: convert the tap position into a UTF-16 offset via
-            // the captured TextLayoutResult and forward to onTapWord. We key
-            // the pointerInput on the lambda's identity so it doesn't get
-            // re-installed on every recomposition (the layout it reads is
-            // captured by reference inside the closure).
+            // the captured TextLayoutResult and forward to onTapWord. The
+            // pointerInput is keyed on `text` AND `onTapWord` so a chapter
+            // switch (which changes both text content and length) re-installs
+            // the gesture handler with the fresh closure — otherwise tap
+            // offsets would be clamped against the previous chapter's length
+            // and produce wrong seek positions.
             .then(
                 if (onTapWord != null) {
-                    Modifier.pointerInput(onTapWord) {
+                    Modifier.pointerInput(onTapWord, text) {
                         detectTapGestures { tap ->
                             val l = layout ?: return@detectTapGestures
                             val charIndex = l.getOffsetForPosition(tap)

--- a/core-ui/src/main/kotlin/in/jphe/storyvox/ui/component/SentenceHighlight.kt
+++ b/core-ui/src/main/kotlin/in/jphe/storyvox/ui/component/SentenceHighlight.kt
@@ -1,6 +1,7 @@
 package `in`.jphe.storyvox.ui.component
 
 import androidx.compose.animation.core.animateFloatAsState
+import androidx.compose.foundation.gestures.detectTapGestures
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material3.MaterialTheme
@@ -14,6 +15,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.drawBehind
 import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.geometry.Size
+import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.text.AnnotatedString
 import androidx.compose.ui.text.SpanStyle
 import androidx.compose.ui.text.TextLayoutResult
@@ -83,6 +85,25 @@ fun SentenceHighlight(
         modifier = modifier
             .fillMaxWidth()
             .padding(horizontal = 4.dp)
+            // Tap-to-seek: convert the tap position into a UTF-16 offset via
+            // the captured TextLayoutResult and forward to onTapWord. We key
+            // the pointerInput on the lambda's identity so it doesn't get
+            // re-installed on every recomposition (the layout it reads is
+            // captured by reference inside the closure).
+            .then(
+                if (onTapWord != null) {
+                    Modifier.pointerInput(onTapWord) {
+                        detectTapGestures { tap ->
+                            val l = layout ?: return@detectTapGestures
+                            val charIndex = l.getOffsetForPosition(tap)
+                                .coerceIn(0, text.length)
+                            onTapWord(charIndex)
+                        }
+                    }
+                } else {
+                    Modifier
+                }
+            )
             .drawBehind {
                 val l = layout ?: return@drawBehind
                 if (highlightEnd <= highlightStart) return@drawBehind
@@ -109,8 +130,4 @@ fun SentenceHighlight(
             },
     )
 
-    // Tap-to-seek is the caller's responsibility — SentenceHighlight is a pure renderer
-    // so it composes cleanly inside a scrolling reader. Callers wire onTapWord via
-    // Modifier.pointerInput on their parent and use the layout result for hit-testing.
-    onTapWord?.let { _ -> }
 }

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -66,6 +66,12 @@ Build sequence (each step ships value on its own):
 
 ## Backlog
 
+- **Try `AudioTrack.Builder` + `AudioAttributes`**: `EnginePlayer.create-`
+  `AudioTrack` currently uses the six-arg `AudioTrack(STREAM_MUSIC, …)` ctor
+  to match VoxSherpa standalone exactly while we hunted issue #6. The
+  Builder form is the modern API and would let us set `USAGE_MEDIA` /
+  `CONTENT_TYPE_MUSIC` / `CONTENT_TYPE_SPEECH` cleanly. Once we're confident
+  the fuzz is gone on Tab A7 Lite, swap and A/B for any audible difference.
 - **Voice picker UI**: pull from a curated list of Piper voices, download on
   demand, cache in app storage. Replaces the placeholder "use whatever
   VoxSherpa happened to install" model.

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -66,12 +66,13 @@ Build sequence (each step ships value on its own):
 
 ## Backlog
 
-- **Try `AudioTrack.Builder` + `AudioAttributes`**: `EnginePlayer.create-`
-  `AudioTrack` currently uses the six-arg `AudioTrack(STREAM_MUSIC, …)` ctor
-  to match VoxSherpa standalone exactly while we hunted issue #6. The
-  Builder form is the modern API and would let us set `USAGE_MEDIA` /
-  `CONTENT_TYPE_MUSIC` / `CONTENT_TYPE_SPEECH` cleanly. Once we're confident
-  the fuzz is gone on Tab A7 Lite, swap and A/B for any audible difference.
+- **Try `AudioTrack.Builder` + `AudioAttributes`**:
+  `EnginePlayer.createAudioTrack` currently uses the six-arg
+  `AudioTrack(STREAM_MUSIC, …)` ctor to match VoxSherpa standalone exactly
+  while we hunted issue #6. The Builder form is the modern API and would
+  let us set `USAGE_MEDIA` / `CONTENT_TYPE_MUSIC` / `CONTENT_TYPE_SPEECH`
+  cleanly. Once we're confident the fuzz is gone on Tab A7 Lite, swap and
+  A/B for any audible difference.
 - **Voice picker UI**: pull from a curated list of Piper voices, download on
   demand, cache in app storage. Replaces the placeholder "use whatever
   VoxSherpa happened to install" model.

--- a/feature/src/main/kotlin/in/jphe/storyvox/feature/api/UiContracts.kt
+++ b/feature/src/main/kotlin/in/jphe/storyvox/feature/api/UiContracts.kt
@@ -128,6 +128,8 @@ interface PlaybackControllerUi {
     fun play()
     fun pause()
     fun seekTo(ms: Long)
+    /** Seek by char offset into chapter text (used by tap-on-sentence). */
+    fun seekToChar(charOffset: Int)
     fun skipForward()
     fun skipBack()
     fun nextChapter()

--- a/feature/src/main/kotlin/in/jphe/storyvox/feature/engine/VoicePickerGate.kt
+++ b/feature/src/main/kotlin/in/jphe/storyvox/feature/engine/VoicePickerGate.kt
@@ -37,6 +37,8 @@ import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.collect
+import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.launch
 import `in`.jphe.storyvox.playback.voice.UiVoiceInfo
 import `in`.jphe.storyvox.playback.voice.VoiceCatalog
@@ -67,6 +69,7 @@ fun VoicePickerGate(
     val downloadingId by vm.downloadingVoiceId.collectAsStateWithLifecycle()
     val progress by vm.progress.collectAsStateWithLifecycle()
     val bypassed by vm.bypassed.collectAsStateWithLifecycle()
+    val recommended by vm.recommended.collectAsStateWithLifecycle()
 
     // Render content unconditionally so the embedded NavHost (and its graph)
     // is registered even while the gate is still up. Tapping "More voices →"
@@ -93,7 +96,7 @@ fun VoicePickerGate(
                     ),
             ) {
                 VoicePickerScreen(
-                    recommended = vm.recommended,
+                    recommended = recommended,
                     downloadingVoiceId = downloadingId,
                     progress = progress,
                     onPick = vm::pick,
@@ -116,9 +119,23 @@ class VoicePickerGateViewModel @Inject constructor(
 
     /** Hand-picked best-of-catalog starter voices ([VoiceCatalog.featuredIds]).
      *  Same set the Voice Library highlights under "Featured", so a user sees
-     *  the same three names whether they pick now or browse the library. */
-    val recommended: List<UiVoiceInfo> = VoiceCatalog.featuredIds
-        .mapNotNull { id -> voices.availableVoices.firstOrNull { it.id == id } }
+     *  the same three names whether they pick now or browse the library.
+     *  Prefers an installed [UiVoiceInfo] when available so the gate row
+     *  reflects reality (and so [pick] can skip the download on tap). */
+    val recommended: StateFlow<List<UiVoiceInfo>> = voices.installedVoices
+        .map { installed ->
+            val installedById = installed.associateBy { it.id }
+            VoiceCatalog.featuredIds.mapNotNull { id ->
+                installedById[id] ?: voices.availableVoices.firstOrNull { it.id == id }
+            }
+        }
+        .stateIn(
+            viewModelScope,
+            kotlinx.coroutines.flow.SharingStarted.Eagerly,
+            VoiceCatalog.featuredIds.mapNotNull { id ->
+                voices.availableVoices.firstOrNull { it.id == id }
+            },
+        )
 
     val activeVoice: StateFlow<UiVoiceInfo?> = voices.activeVoice
         .let { flow ->
@@ -141,6 +158,15 @@ class VoicePickerGateViewModel @Inject constructor(
 
     fun pick(voiceId: String) {
         if (_downloadingVoiceId.value != null) return
+        // Already-installed featured voices (e.g. the gate re-appearing
+        // after the previously-active voice was deleted but other voices
+        // are still on disk) should activate immediately — no need to
+        // re-download a model that already lives in filesDir.
+        val installed = recommended.value.firstOrNull { it.id == voiceId }?.isInstalled == true
+        if (installed) {
+            viewModelScope.launch { voices.setActive(voiceId) }
+            return
+        }
         _downloadingVoiceId.value = voiceId
         _progress.value = DownloadProgress.Resolving
         viewModelScope.launch {

--- a/feature/src/main/kotlin/in/jphe/storyvox/feature/engine/VoicePickerGate.kt
+++ b/feature/src/main/kotlin/in/jphe/storyvox/feature/engine/VoicePickerGate.kt
@@ -2,6 +2,7 @@ package `in`.jphe.storyvox.feature.engine
 
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
+import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -20,6 +21,7 @@ import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
@@ -37,6 +39,7 @@ import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.collect
 import kotlinx.coroutines.launch
 import `in`.jphe.storyvox.playback.voice.UiVoiceInfo
+import `in`.jphe.storyvox.playback.voice.VoiceCatalog
 import `in`.jphe.storyvox.playback.voice.VoiceManager
 import `in`.jphe.storyvox.playback.voice.VoiceManager.DownloadProgress
 import `in`.jphe.storyvox.ui.component.BrassButton
@@ -65,27 +68,45 @@ fun VoicePickerGate(
     val progress by vm.progress.collectAsStateWithLifecycle()
     val bypassed by vm.bypassed.collectAsStateWithLifecycle()
 
-    if (bypassed || activeVoice != null) {
+    // Render content unconditionally so the embedded NavHost (and its graph)
+    // is registered even while the gate is still up. Tapping "More voices →"
+    // dismisses the gate AND calls navController.navigate in the same frame —
+    // if content weren't already in the composition, the destination route
+    // wouldn't exist on the NavController yet and navigate() would crash.
+    Box(modifier = Modifier.fillMaxSize()) {
         content()
-        return
+        if (!bypassed && activeVoice == null) {
+            // Swallow taps in the gate's empty regions so they don't fall
+            // through to the LibraryScreen rendered underneath. We use a
+            // ripple-less clickable rather than pointerInput because the
+            // foundation API is shorter and we don't need finer gesture
+            // control here.
+            val swallow = remember { MutableInteractionSource() }
+            Box(
+                modifier = Modifier
+                    .fillMaxSize()
+                    .background(MaterialTheme.colorScheme.background)
+                    .clickable(
+                        interactionSource = swallow,
+                        indication = null,
+                        onClick = {},
+                    ),
+            ) {
+                VoicePickerScreen(
+                    recommended = vm.recommended,
+                    downloadingVoiceId = downloadingId,
+                    progress = progress,
+                    onPick = vm::pick,
+                    onSkip = vm::bypass,
+                    onOpenLibrary = {
+                        vm.bypass()
+                        onOpenVoiceLibrary()
+                    },
+                    onDismissProgress = vm::dismissProgress,
+                )
+            }
+        }
     }
-
-    VoicePickerScreen(
-        recommended = vm.recommended,
-        downloadingVoiceId = downloadingId,
-        progress = progress,
-        onPick = vm::pick,
-        onSkip = vm::bypass,
-        onOpenLibrary = {
-            // Dismiss the gate so the NavHost is visible, then route to the
-            // library. If the user picks a voice there, activeVoice flips
-            // to non-null and the gate stays dismissed permanently. If not,
-            // they got reader-only mode for the session.
-            vm.bypass()
-            onOpenVoiceLibrary()
-        },
-        onDismissProgress = vm::dismissProgress,
-    )
 }
 
 @HiltViewModel
@@ -93,8 +114,11 @@ class VoicePickerGateViewModel @Inject constructor(
     private val voices: VoiceManager,
 ) : ViewModel() {
 
-    /** First three catalog entries — Amy low / Lessac medium / Ryan high (en_US Piper). */
-    val recommended: List<UiVoiceInfo> = voices.availableVoices.take(3)
+    /** Hand-picked best-of-catalog starter voices ([VoiceCatalog.featuredIds]).
+     *  Same set the Voice Library highlights under "Featured", so a user sees
+     *  the same three names whether they pick now or browse the library. */
+    val recommended: List<UiVoiceInfo> = VoiceCatalog.featuredIds
+        .mapNotNull { id -> voices.availableVoices.firstOrNull { it.id == id } }
 
     val activeVoice: StateFlow<UiVoiceInfo?> = voices.activeVoice
         .let { flow ->

--- a/feature/src/main/kotlin/in/jphe/storyvox/feature/reader/HybridReaderScreen.kt
+++ b/feature/src/main/kotlin/in/jphe/storyvox/feature/reader/HybridReaderScreen.kt
@@ -53,6 +53,7 @@ fun HybridReaderScreen(
                 state = playback,
                 chapterText = state.chapterText,
                 onPlayPause = viewModel::playPause,
+                onSeekToChar = viewModel::seekToChar,
             )
         },
     )

--- a/feature/src/main/kotlin/in/jphe/storyvox/feature/reader/ReaderView.kt
+++ b/feature/src/main/kotlin/in/jphe/storyvox/feature/reader/ReaderView.kt
@@ -56,6 +56,7 @@ fun ReaderTextView(
     state: UiPlaybackState,
     chapterText: String,
     onPlayPause: () -> Unit,
+    onSeekToChar: (Int) -> Unit = {},
     modifier: Modifier = Modifier,
 ) {
     val spacing = LocalSpacing.current
@@ -126,6 +127,7 @@ fun ReaderTextView(
                         text = chapterText,
                         highlightStart = state.sentenceStart,
                         highlightEnd = state.sentenceEnd,
+                        onTapWord = onSeekToChar,
                         onLayout = { layout -> textLayout = layout },
                     )
                 }

--- a/feature/src/main/kotlin/in/jphe/storyvox/feature/reader/ReaderViewModel.kt
+++ b/feature/src/main/kotlin/in/jphe/storyvox/feature/reader/ReaderViewModel.kt
@@ -50,6 +50,7 @@ class ReaderViewModel @Inject constructor(
     }
 
     fun seekTo(ms: Long) = playback.seekTo(ms)
+    fun seekToChar(charOffset: Int) = playback.seekToChar(charOffset)
     fun skipForward() = playback.skipForward()
     fun skipBack() = playback.skipBack()
     fun nextChapter() = playback.nextChapter()

--- a/feature/src/main/kotlin/in/jphe/storyvox/feature/voicelibrary/VoiceLibraryScreen.kt
+++ b/feature/src/main/kotlin/in/jphe/storyvox/feature/voicelibrary/VoiceLibraryScreen.kt
@@ -68,9 +68,10 @@ fun VoiceLibraryScreen(
         },
         snackbarHost = { SnackbarHost(snackbar) },
     ) { padding ->
+        val featured = state.featured
         val installed = state.installed
         val available = state.available
-        val isEmpty = installed.isEmpty() && available.isEmpty()
+        val isEmpty = featured.isEmpty() && installed.isEmpty() && available.isEmpty()
 
         if (isEmpty) {
             EmptyState(modifier = Modifier.padding(padding).fillMaxSize().padding(spacing.md))
@@ -85,6 +86,22 @@ fun VoiceLibraryScreen(
             verticalArrangement = Arrangement.spacedBy(spacing.xs),
             contentPadding = androidx.compose.foundation.layout.PaddingValues(vertical = spacing.md),
         ) {
+            if (featured.isNotEmpty()) {
+                item { SectionHeader("⭐ Featured", count = featured.size) }
+                items(featured, key = { "f-${it.id}" }) { voice ->
+                    val downloading = state.currentDownload
+                    val rowProgress = if (downloading?.voiceId == voice.id) downloading.progress ?: -1f else null
+                    VoiceRow(
+                        voice = voice,
+                        isActive = voice.id == state.activeVoiceId,
+                        downloadingProgress = rowProgress,
+                        onTap = { if (downloading == null || voice.isInstalled) viewModel.onRowTapped(voice) },
+                        onLongPress = if (voice.isInstalled) ({ viewModel.requestDelete(voice) }) else null,
+                    )
+                }
+                item { Spacer(modifier = Modifier.height(spacing.md)) }
+            }
+
             item { SectionHeader("Installed", count = installed.size) }
             if (installed.isEmpty()) {
                 item {

--- a/feature/src/main/kotlin/in/jphe/storyvox/feature/voicelibrary/VoiceLibraryViewModel.kt
+++ b/feature/src/main/kotlin/in/jphe/storyvox/feature/voicelibrary/VoiceLibraryViewModel.kt
@@ -5,6 +5,7 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import dagger.hilt.android.lifecycle.HiltViewModel
 import `in`.jphe.storyvox.playback.voice.UiVoiceInfo
+import `in`.jphe.storyvox.playback.voice.VoiceCatalog
 import `in`.jphe.storyvox.playback.voice.VoiceManager
 import javax.inject.Inject
 import kotlinx.coroutines.Job
@@ -19,6 +20,10 @@ import kotlinx.coroutines.launch
 
 @Immutable
 data class VoiceLibraryUiState(
+    /** Hand-picked best-of-catalog voices, shown above all other sections.
+     *  Always 3 entries (sourced from [VoiceCatalog.featuredIds]); each
+     *  carries its own installed flag so the row reflects current state. */
+    val featured: List<UiVoiceInfo> = emptyList(),
     val installed: List<UiVoiceInfo> = emptyList(),
     val available: List<UiVoiceInfo> = emptyList(),
     val activeVoiceId: String? = null,
@@ -52,12 +57,21 @@ class VoiceLibraryViewModel @Inject constructor(
         _currentDownload.asStateFlow(),
         combine(_pendingDelete.asStateFlow(), _error.asStateFlow()) { d, e -> d to e },
     ) { installed, available, active, downloading, (pending, error) ->
-        // Available list excludes anything already installed so the two
-        // sections never present the same voice twice.
         val installedIds = installed.mapTo(mutableSetOf()) { it.id }
+        // Featured voices use the live installed flag so the row's CTA
+        // ("Activate" vs "Download") matches reality. We pull the entry from
+        // the installed list when present, otherwise from the catalog.
+        val featured = VoiceCatalog.featuredIds.mapNotNull { id ->
+            installed.firstOrNull { it.id == id }
+                ?: available.firstOrNull { it.id == id }
+        }
+        val featuredIdSet = featured.mapTo(mutableSetOf()) { it.id }
+        // Installed and Available exclude featured rows so the same voice
+        // doesn't appear in two sections at once.
         VoiceLibraryUiState(
-            installed = installed,
-            available = available.filterNot { it.id in installedIds },
+            featured = featured,
+            installed = installed.filterNot { it.id in featuredIdSet },
+            available = available.filterNot { it.id in installedIds || it.id in featuredIdSet },
             activeVoiceId = active?.id,
             currentDownload = downloading,
             pendingDelete = pending,


### PR DESCRIPTION
## Summary

Four user-reported issues, all resolved in `core-playback` + `feature` modules.

### #6 — audio still fuzzy while speech (closes #6)
The current `AudioTrack.Builder` path with `USAGE_MEDIA` + `CONTENT_TYPE_MUSIC` routes through Samsung's SoundAlive / Dolby Atmos post-processing chain, which is tuned for music and audibly distorts 22 050 / 24 000 Hz mono speech PCM (notably on the Galaxy Tab A7 Lite). VoxSherpa standalone uses the **legacy** `AudioTrack(STREAM_MUSIC, …)` constructor and sounds clean on identical hardware — `EnginePlayer.createAudioTrack` now mirrors that exactly. `@Suppress("DEPRECATION")` is intentional.

### #3 — pause after period not working (closes #3)
Neural TTS engines barely breathe between sentences. The producer side of the pipeline now appends silence to each generated sentence sized to its terminal punctuation:

| Tail | Silence (ms @ 1.0×) |
| --- | --- |
| `.` `!` `?` `…` | 350 |
| `;` `:` | 200 |
| `,` `—` | 120 |
| (other) | 60 |

Silence scales down with `currentSpeed.coerceAtLeast(0.5f)` so a 2× listener doesn't get doubled gaps. Implemented as zero-byte ByteArray suffixes in `appendSilence()` — cheap and engine-independent.

### #4 — crash when selecting "More voices" in voice setup (closes #4)
`VoicePickerGate` previously rendered **either** the gate **or** the wrapped `content()`. Tapping "More voices →" called `vm.bypass()` (state change, queued for next recomposition) then `navController.navigate(VOICE_LIBRARY)` on the same frame — but the NavHost's graph wasn't registered yet because `content()` hadn't been called, so the navigate threw.

Fix: gate now overlays `content()` (which is rendered unconditionally) inside an outer `Box`. The NavHost graph is always live so the in-frame `navigate` call lands cleanly. A ripple-less `clickable {}` on the overlay swallows taps so they don't leak through to the LibraryScreen underneath while the gate is up.

### #5 — surface the three definitely best voices (closes #5)
`VoiceCatalog.featuredIds = [Lessac-high, Ryan-high, Amy-medium]` is now the single source of truth, used by both:

- **Voice Library** — new "⭐ Featured" section above Installed / Available; rows reflect live install state (Activate vs Download CTA, progress bar) and dedupe out of the lower sections.
- **First-launch picker** — `VoicePickerGateViewModel.recommended` pulls from the same list, so the user sees the same three names whether they pick now or browse later.

## Test plan

- [ ] Fresh install → first-launch gate shows three ⭐ voices; tap "More voices →" → Voice Library opens (no crash). Verify `claude/fix-all-issues-Jj4S4` builds via the `Android` workflow.
- [ ] Pick a voice → start a chapter on a Samsung tablet (Tab A7 Lite ideally). Speech should be clean, no fuzz/scratch.
- [ ] Listen for an audible beat between sentences ending in `.`, `?`, `!`. Confirm gaps tighten at higher speeds.
- [ ] Open Voice Library — confirm "⭐ Featured" section is at top with the three starred voices, that they're not duplicated in Installed / Available, and that downloading/activating a featured voice works.
- [ ] Delete the active voice while the app is open — gate re-overlays without dismounting the existing nav back stack.

https://claude.ai/code/session_01L5TEFSpTUvNNNLajyLr9sv

---
_Generated by [Claude Code](https://claude.ai/code/session_01L5TEFSpTUvNNNLajyLr9sv)_