### PR TITLE
fix: address #7 #8 #10 #11 + drop misleading _int8 voice IDs

### DIFF
--- a/core-playback/src/main/kotlin/in/jphe/storyvox/playback/tts/EnginePlayer.kt
+++ b/core-playback/src/main/kotlin/in/jphe/storyvox/playback/tts/EnginePlayer.kt
@@ -330,27 +330,39 @@ class EnginePlayer @AssistedInject constructor(
         invalidateState()
 
         val loadResult: String = withContext(Dispatchers.IO) {
-            when (active.engineType) {
-                EngineType.Piper -> {
-                    val voiceDir = voiceManager.voiceDirFor(active.id)
-                    val onnx = File(voiceDir, "model.onnx").absolutePath
-                    val tokens = File(voiceDir, "tokens.txt").absolutePath
-                    VoiceEngine.getInstance().loadModel(context, onnx, tokens) ?: "Error: load returned null"
-                }
-                is EngineType.Kokoro -> {
-                    // All 53 Kokoro speakers share a single ~168MB multi-speaker
-                    // model. Switching speakers reuses the loaded engine; first
-                    // load takes 30+s as sherpa-onnx builds the onnxruntime
-                    // session and runs a warm-up generate.
-                    val sharedDir = voiceManager.kokoroSharedDir()
-                    val onnx = File(sharedDir, "model.onnx").absolutePath
-                    val tokens = File(sharedDir, "tokens.txt").absolutePath
-                    val voicesBin = File(sharedDir, "voices.bin").absolutePath
-                    KokoroEngine.getInstance().setActiveSpeakerId(
-                        (active.engineType as EngineType.Kokoro).speakerId,
-                    )
-                    KokoroEngine.getInstance().loadModel(context, onnx, tokens, voicesBin)
-                        ?: "Error: load returned null"
+            // Critical: serialize loadModel against in-flight generateAudioPCM
+            // by holding engineMutex (issue #11). Without it, a Piper-to-Piper
+            // swap can call loadModel().destroy() and free the native `tts`
+            // pointer while the prior generator's JNI generate(...) is still
+            // dereferencing it on another thread → SIGSEGV. The producer
+            // coroutine takes engineMutex around every generateAudioPCM, so
+            // withLock here waits for the in-flight call to finish before
+            // we tear the model down.
+            engineMutex.withLock {
+                when (active.engineType) {
+                    EngineType.Piper -> {
+                        val voiceDir = voiceManager.voiceDirFor(active.id)
+                        val onnx = File(voiceDir, "model.onnx").absolutePath
+                        val tokens = File(voiceDir, "tokens.txt").absolutePath
+                        VoiceEngine.getInstance().loadModel(context, onnx, tokens)
+                            ?: "Error: load returned null"
+                    }
+                    is EngineType.Kokoro -> {
+                        // All 53 Kokoro speakers share a single ~325MB fp32
+                        // multi-speaker model. Switching speakers reuses the
+                        // loaded engine; first load takes 30+s as sherpa-onnx
+                        // builds the onnxruntime session and runs a warm-up
+                        // generate.
+                        val sharedDir = voiceManager.kokoroSharedDir()
+                        val onnx = File(sharedDir, "model.onnx").absolutePath
+                        val tokens = File(sharedDir, "tokens.txt").absolutePath
+                        val voicesBin = File(sharedDir, "voices.bin").absolutePath
+                        KokoroEngine.getInstance().setActiveSpeakerId(
+                            (active.engineType as EngineType.Kokoro).speakerId,
+                        )
+                        KokoroEngine.getInstance().loadModel(context, onnx, tokens, voicesBin)
+                            ?: "Error: load returned null"
+                    }
                 }
             }
         }
@@ -659,7 +671,16 @@ class EnginePlayer @AssistedInject constructor(
         val target = sentences.indexOfLast { it.startChar <= clamped }
             .takeIf { it >= 0 } ?: 0
         currentSentenceIndex = target
-        _observableState.update { it.copy(charOffset = sentences[target].startChar) }
+        val s = sentences[target]
+        // Issue #7: also update currentSentenceRange so the brass underline
+        // and auto-scroll move to the tapped sentence — previously only
+        // charOffset moved, leaving the visual highlight stale.
+        _observableState.update {
+            it.copy(
+                charOffset = s.startChar,
+                currentSentenceRange = SentenceRange(s.index, s.startChar, s.endChar),
+            )
+        }
         if (_observableState.value.isPlaying) startPlaybackPipeline()
         invalidateState()
     }

--- a/core-playback/src/main/kotlin/in/jphe/storyvox/playback/voice/VoiceCatalog.kt
+++ b/core-playback/src/main/kotlin/in/jphe/storyvox/playback/voice/VoiceCatalog.kt
@@ -7,15 +7,19 @@ object VoiceCatalog {
     /** The three voices we hand-picked as the strongest starters. Surfaced
      *  on the first-launch picker AND highlighted in the Voice Library
      *  under a "Featured" section so newcomers don't have to scroll the
-     *  90-voice catalog hunting for the good ones. */
+     *  98-voice catalog hunting for the good ones.
+     *
+     *  Curated per JP's call (issue #10): Cori for en_GB Piper, Lessac
+     *  for en_US Piper, Aoede for the multi-speaker Kokoro path. Three
+     *  distinct engines and accents so first-time users hear the range. */
     val featuredIds: List<String> = listOf(
-        "piper_lessac_en_US_high_int8",
-        "piper_ryan_en_US_high_int8",
-        "piper_amy_en_US_medium_int8",
+        "piper_cori_en_GB_high",
+        "piper_lessac_en_US_high",
+        "kokoro_aoede_en_US_1",
     )
     private fun piperEntries(): List<CatalogEntry> = listOf(
         CatalogEntry(
-            id = "piper_lessac_en_US_high_int8",
+            id = "piper_lessac_en_US_high",
             displayName = "⭐ Lessac (High)",
             language = "en_US",
             sizeBytes = 113895332L,
@@ -27,7 +31,7 @@ object VoiceCatalog {
             ),
         ),
         CatalogEntry(
-            id = "piper_ryan_en_US_high_int8",
+            id = "piper_ryan_en_US_high",
             displayName = "⭐ Ryan (High)",
             language = "en_US",
             sizeBytes = 120786923L,
@@ -39,7 +43,7 @@ object VoiceCatalog {
             ),
         ),
         CatalogEntry(
-            id = "piper_amy_en_US_medium_int8",
+            id = "piper_amy_en_US_medium",
             displayName = "⭐ Amy (Medium)",
             language = "en_US",
             sizeBytes = 63201425L,
@@ -51,7 +55,7 @@ object VoiceCatalog {
             ),
         ),
         CatalogEntry(
-            id = "piper_alan_en_GB_low_int8",
+            id = "piper_alan_en_GB_low",
             displayName = "Alan (Low)",
             language = "en_GB",
             sizeBytes = 63104662L,
@@ -63,7 +67,7 @@ object VoiceCatalog {
             ),
         ),
         CatalogEntry(
-            id = "piper_alan_en_GB_medium_int8",
+            id = "piper_alan_en_GB_medium",
             displayName = "Alan (Medium)",
             language = "en_GB",
             sizeBytes = 63201430L,
@@ -75,7 +79,7 @@ object VoiceCatalog {
             ),
         ),
         CatalogEntry(
-            id = "piper_alba_en_GB_medium_int8",
+            id = "piper_alba_en_GB_medium",
             displayName = "Alba (Medium)",
             language = "en_GB",
             sizeBytes = 63201430L,
@@ -87,7 +91,7 @@ object VoiceCatalog {
             ),
         ),
         CatalogEntry(
-            id = "piper_aru_en_GB_medium_int8",
+            id = "piper_aru_en_GB_medium",
             displayName = "Aru (Medium)",
             language = "en_GB",
             sizeBytes = 76754234L,
@@ -99,7 +103,7 @@ object VoiceCatalog {
             ),
         ),
         CatalogEntry(
-            id = "piper_cori_en_GB_medium_int8",
+            id = "piper_cori_en_GB_medium",
             displayName = "Cori (Medium)",
             language = "en_GB",
             sizeBytes = 63531507L,
@@ -111,7 +115,7 @@ object VoiceCatalog {
             ),
         ),
         CatalogEntry(
-            id = "piper_cori_en_GB_high_int8",
+            id = "piper_cori_en_GB_high",
             displayName = "Cori (High)",
             language = "en_GB",
             sizeBytes = 114219480L,
@@ -123,7 +127,7 @@ object VoiceCatalog {
             ),
         ),
         CatalogEntry(
-            id = "piper_dii_en_GB_high_int8",
+            id = "piper_dii_en_GB_high",
             displayName = "Dii (High)",
             language = "en_GB",
             sizeBytes = 63511174L,
@@ -135,7 +139,7 @@ object VoiceCatalog {
             ),
         ),
         CatalogEntry(
-            id = "piper_jenny_dioco_en_GB_medium_int8",
+            id = "piper_jenny_dioco_en_GB_medium",
             displayName = "Jenny Dioco (Medium)",
             language = "en_GB",
             sizeBytes = 63201430L,
@@ -147,7 +151,7 @@ object VoiceCatalog {
             ),
         ),
         CatalogEntry(
-            id = "piper_miro_en_GB_high_int8",
+            id = "piper_miro_en_GB_high",
             displayName = "Miro (High)",
             language = "en_GB",
             sizeBytes = 63511174L,
@@ -159,7 +163,7 @@ object VoiceCatalog {
             ),
         ),
         CatalogEntry(
-            id = "piper_northern_english_male_en_GB_medium_int8",
+            id = "piper_northern_english_male_en_GB_medium",
             displayName = "Northern English Male (Medium)",
             language = "en_GB",
             sizeBytes = 63201430L,
@@ -171,7 +175,7 @@ object VoiceCatalog {
             ),
         ),
         CatalogEntry(
-            id = "piper_semaine_en_GB_medium_int8",
+            id = "piper_semaine_en_GB_medium",
             displayName = "Semaine (Medium)",
             language = "en_GB",
             sizeBytes = 76737847L,
@@ -183,7 +187,7 @@ object VoiceCatalog {
             ),
         ),
         CatalogEntry(
-            id = "piper_southern_english_female_en_GB_low_int8",
+            id = "piper_southern_english_female_en_GB_low",
             displayName = "Southern English Female (Low)",
             language = "en_GB",
             sizeBytes = 63104662L,
@@ -195,7 +199,7 @@ object VoiceCatalog {
             ),
         ),
         CatalogEntry(
-            id = "piper_southern_english_female_en_GB_medium_int8",
+            id = "piper_southern_english_female_en_GB_medium",
             displayName = "Southern English Female (Medium)",
             language = "en_GB",
             sizeBytes = 77059414L,
@@ -207,7 +211,7 @@ object VoiceCatalog {
             ),
         ),
         CatalogEntry(
-            id = "piper_southern_english_male_en_GB_medium_int8",
+            id = "piper_southern_english_male_en_GB_medium",
             displayName = "Southern English Male (Medium)",
             language = "en_GB",
             sizeBytes = 77063512L,
@@ -231,7 +235,7 @@ object VoiceCatalog {
             ),
         ),
         CatalogEntry(
-            id = "piper_vctk_en_GB_medium_int8",
+            id = "piper_vctk_en_GB_medium",
             displayName = "Vctk (Medium)",
             language = "en_GB",
             sizeBytes = 76952891L,
@@ -243,7 +247,7 @@ object VoiceCatalog {
             ),
         ),
         CatalogEntry(
-            id = "piper_amy_en_US_low_int8",
+            id = "piper_amy_en_US_low",
             displayName = "Amy (Low)",
             language = "en_US",
             sizeBytes = 63104657L,
@@ -255,7 +259,7 @@ object VoiceCatalog {
             ),
         ),
         CatalogEntry(
-            id = "piper_arctic_en_US_medium_int8",
+            id = "piper_arctic_en_US_medium",
             displayName = "Arctic (Medium)",
             language = "en_US",
             sizeBytes = 76715309L,
@@ -267,7 +271,7 @@ object VoiceCatalog {
             ),
         ),
         CatalogEntry(
-            id = "piper_bryce_en_US_medium_int8",
+            id = "piper_bryce_en_US_medium",
             displayName = "Bryce (Medium)",
             language = "en_US",
             sizeBytes = 63152970L,
@@ -279,7 +283,7 @@ object VoiceCatalog {
             ),
         ),
         CatalogEntry(
-            id = "piper_danny_en_US_low_int8",
+            id = "piper_danny_en_US_low",
             displayName = "Danny (Low)",
             language = "en_US",
             sizeBytes = 63052430L,
@@ -291,7 +295,7 @@ object VoiceCatalog {
             ),
         ),
         CatalogEntry(
-            id = "piper_glados_en_US_high_int8",
+            id = "piper_glados_en_US_high",
             displayName = "GLaDOS (High)",
             language = "en_US",
             sizeBytes = 113800584L,
@@ -315,7 +319,7 @@ object VoiceCatalog {
             ),
         ),
         CatalogEntry(
-            id = "piper_hfc_female_en_US_medium_int8",
+            id = "piper_hfc_female_en_US_medium",
             displayName = "Hfc Female (Medium)",
             language = "en_US",
             sizeBytes = 63149198L,
@@ -327,7 +331,7 @@ object VoiceCatalog {
             ),
         ),
         CatalogEntry(
-            id = "piper_hfc_male_en_US_medium_int8",
+            id = "piper_hfc_male_en_US_medium",
             displayName = "Hfc Male (Medium)",
             language = "en_US",
             sizeBytes = 63149198L,
@@ -339,7 +343,7 @@ object VoiceCatalog {
             ),
         ),
         CatalogEntry(
-            id = "piper_joe_en_US_medium_int8",
+            id = "piper_joe_en_US_medium",
             displayName = "Joe (Medium)",
             language = "en_US",
             sizeBytes = 63149198L,
@@ -351,7 +355,7 @@ object VoiceCatalog {
             ),
         ),
         CatalogEntry(
-            id = "piper_john_en_US_medium_int8",
+            id = "piper_john_en_US_medium",
             displayName = "John (Medium)",
             language = "en_US",
             sizeBytes = 63152970L,
@@ -363,7 +367,7 @@ object VoiceCatalog {
             ),
         ),
         CatalogEntry(
-            id = "piper_kathleen_en_US_low_int8",
+            id = "piper_kathleen_en_US_low",
             displayName = "Kathleen (Low)",
             language = "en_US",
             sizeBytes = 63052430L,
@@ -375,7 +379,7 @@ object VoiceCatalog {
             ),
         ),
         CatalogEntry(
-            id = "piper_kristin_en_US_medium_int8",
+            id = "piper_kristin_en_US_medium",
             displayName = "Kristin (Medium)",
             language = "en_US",
             sizeBytes = 63531507L,
@@ -387,7 +391,7 @@ object VoiceCatalog {
             ),
         ),
         CatalogEntry(
-            id = "piper_kusal_en_US_medium_int8",
+            id = "piper_kusal_en_US_medium",
             displayName = "Kusal (Medium)",
             language = "en_US",
             sizeBytes = 63201425L,
@@ -399,7 +403,7 @@ object VoiceCatalog {
             ),
         ),
         CatalogEntry(
-            id = "piper_l2arctic_en_US_medium_int8",
+            id = "piper_l2arctic_en_US_medium",
             displayName = "L2Arctic (Medium)",
             language = "en_US",
             sizeBytes = 76778805L,
@@ -411,7 +415,7 @@ object VoiceCatalog {
             ),
         ),
         CatalogEntry(
-            id = "piper_lessac_en_US_low_int8",
+            id = "piper_lessac_en_US_low",
             displayName = "Lessac (Low)",
             language = "en_US",
             sizeBytes = 63149198L,
@@ -423,7 +427,7 @@ object VoiceCatalog {
             ),
         ),
         CatalogEntry(
-            id = "piper_lessac_en_US_medium_int8",
+            id = "piper_lessac_en_US_medium",
             displayName = "Lessac (Medium)",
             language = "en_US",
             sizeBytes = 63149198L,
@@ -435,7 +439,7 @@ object VoiceCatalog {
             ),
         ),
         CatalogEntry(
-            id = "piper_libritts_en_US_high_int8",
+            id = "piper_libritts_en_US_high",
             displayName = "Libritts (High)",
             language = "en_US",
             sizeBytes = 129438513L,
@@ -447,7 +451,7 @@ object VoiceCatalog {
             ),
         ),
         CatalogEntry(
-            id = "piper_libritts_r_en_US_medium_int8",
+            id = "piper_libritts_r_en_US_medium",
             displayName = "Libritts R (Medium)",
             language = "en_US",
             sizeBytes = 78529840L,
@@ -459,7 +463,7 @@ object VoiceCatalog {
             ),
         ),
         CatalogEntry(
-            id = "piper_ljspeech_en_US_medium_int8",
+            id = "piper_ljspeech_en_US_medium",
             displayName = "Ljspeech (Medium)",
             language = "en_US",
             sizeBytes = 63531507L,
@@ -471,7 +475,7 @@ object VoiceCatalog {
             ),
         ),
         CatalogEntry(
-            id = "piper_ljspeech_en_US_high_int8",
+            id = "piper_ljspeech_en_US_high",
             displayName = "Ljspeech (High)",
             language = "en_US",
             sizeBytes = 114199139L,
@@ -483,7 +487,7 @@ object VoiceCatalog {
             ),
         ),
         CatalogEntry(
-            id = "piper_miro_en_US_high_int8",
+            id = "piper_miro_en_US_high",
             displayName = "Miro (High)",
             language = "en_US",
             sizeBytes = 63511169L,
@@ -495,7 +499,7 @@ object VoiceCatalog {
             ),
         ),
         CatalogEntry(
-            id = "piper_norman_en_US_medium_int8",
+            id = "piper_norman_en_US_medium",
             displayName = "Norman (Medium)",
             language = "en_US",
             sizeBytes = 63531507L,
@@ -507,7 +511,7 @@ object VoiceCatalog {
             ),
         ),
         CatalogEntry(
-            id = "piper_reza_ibrahim_en_US_medium_int8",
+            id = "piper_reza_ibrahim_en_US_medium",
             displayName = "Reza Ibrahim (Medium)",
             language = "en_US",
             sizeBytes = 63511169L,
@@ -519,7 +523,7 @@ object VoiceCatalog {
             ),
         ),
         CatalogEntry(
-            id = "piper_ryan_en_US_low_int8",
+            id = "piper_ryan_en_US_low",
             displayName = "Ryan (Low)",
             language = "en_US",
             sizeBytes = 63052430L,
@@ -531,7 +535,7 @@ object VoiceCatalog {
             ),
         ),
         CatalogEntry(
-            id = "piper_ryan_en_US_medium_int8",
+            id = "piper_ryan_en_US_medium",
             displayName = "Ryan (Medium)",
             language = "en_US",
             sizeBytes = 63149198L,
@@ -543,7 +547,7 @@ object VoiceCatalog {
             ),
         ),
         CatalogEntry(
-            id = "piper_sam_en_US_medium_int8",
+            id = "piper_sam_en_US_medium",
             displayName = "Sam (Medium)",
             language = "en_US",
             sizeBytes = 62946438L,

--- a/core-playback/src/main/kotlin/in/jphe/storyvox/playback/voice/VoiceManager.kt
+++ b/core-playback/src/main/kotlin/in/jphe/storyvox/playback/voice/VoiceManager.kt
@@ -75,26 +75,54 @@ class VoiceManager @Inject constructor(
     }
 
     private suspend fun migrateInt8VoiceIds() {
-        // 1. Filesystem: voices/{id}_int8/ → voices/{id}/
+        // 1. Filesystem: voices/{id}_int8/ → voices/{id}/. Track which IDs
+        //    we successfully migrated so we don't rewrite DataStore for an
+        //    ID whose directory we couldn't actually move (e.g. target
+        //    already exists from a previous interrupted migration, or
+        //    File.renameTo returns false on this filesystem). The
+        //    [normalizeId] reads tolerate either form, so a partial
+        //    migration is still functional — but we want DataStore to
+        //    eventually agree with the on-disk truth.
+        val migratedIds = mutableSetOf<String>()
         val voicesRoot = File(context.filesDir, "voices")
         if (voicesRoot.exists()) {
             voicesRoot.listFiles()?.forEach { dir ->
                 if (dir.isDirectory && dir.name.endsWith("_int8")) {
-                    val newDir = File(voicesRoot, dir.name.removeSuffix("_int8"))
-                    if (!newDir.exists()) dir.renameTo(newDir)
+                    val newName = dir.name.removeSuffix("_int8")
+                    val newDir = File(voicesRoot, newName)
+                    when {
+                        newDir.exists() -> {
+                            // New-form dir already there; treat the rename
+                            // as logically done. Any duplicate files on the
+                            // old path are dead weight but harmless.
+                            migratedIds += newName
+                        }
+                        dir.renameTo(newDir) -> migratedIds += newName
+                        // else: rename failed — leave both DataStore and
+                        // disk in legacy state. Reads still resolve.
+                    }
                 }
             }
         }
-        // 2. DataStore: rewrite ACTIVE_ID + INSTALLED_IDS to drop _int8
+        // 2. DataStore: only rewrite the legacy IDs whose directory we
+        //    actually moved (or that have no per-voice directory at all,
+        //    i.e. Kokoro entries). Anything else stays as `_int8` so
+        //    voiceDirFor(id) still resolves.
         store.edit { prefs ->
             prefs[VoiceKeys.ACTIVE_ID]?.let { active ->
-                if (active.endsWith("_int8")) {
-                    prefs[VoiceKeys.ACTIVE_ID] = active.removeSuffix("_int8")
+                val stripped = active.removeSuffix("_int8")
+                val isLegacy = active.endsWith("_int8")
+                val isKokoro = stripped.startsWith("kokoro_")
+                if (isLegacy && (isKokoro || stripped in migratedIds)) {
+                    prefs[VoiceKeys.ACTIVE_ID] = stripped
                 }
             }
             prefs[VoiceKeys.INSTALLED_IDS]?.let { ids ->
                 val rewritten = ids.map {
-                    if (it.endsWith("_int8")) it.removeSuffix("_int8") else it
+                    val stripped = it.removeSuffix("_int8")
+                    val isLegacy = it.endsWith("_int8")
+                    val isKokoro = stripped.startsWith("kokoro_")
+                    if (isLegacy && (isKokoro || stripped in migratedIds)) stripped else it
                 }.toSet()
                 if (rewritten != ids) prefs[VoiceKeys.INSTALLED_IDS] = rewritten
             }
@@ -108,24 +136,37 @@ class VoiceManager @Inject constructor(
     /** Hot Flow of installed voices, derived from the DataStore-backed installed-id set.
      *  All 53 Kokoro speakers report installed once the shared model has been
      *  downloaded — they all share one set of files, the speaker id is just
-     *  metadata baked into a generate() call. */
+     *  metadata baked into a generate() call.
+     *
+     *  Reads `_int8`-suffixed legacy IDs through [normalizeId] so users
+     *  upgrading from v0.4.5–v0.4.13 don't briefly see "no voices installed"
+     *  if the async [migrateInt8VoiceIds] hasn't completed by the time the
+     *  first collector observes this Flow. */
     val installedVoices: Flow<List<UiVoiceInfo>> = store.data.map { prefs ->
-        val installedIds = prefs[VoiceKeys.INSTALLED_IDS].orEmpty()
+        val installedIds = prefs[VoiceKeys.INSTALLED_IDS].orEmpty().map(::normalizeId).toSet()
         val kokoroReady = isKokoroSharedModelInstalled()
         VoiceCatalog.voices
             .filter { it.id in installedIds || (it.engineType is EngineType.Kokoro && kokoroReady) }
             .map { it.toUiVoiceInfo(installed = true) }
     }
 
-    /** Hot Flow of the active voice (or null if nothing chosen yet). */
+    /** Hot Flow of the active voice (or null if nothing chosen yet).
+     *  Same legacy-ID normalization as [installedVoices]. */
     val activeVoice: Flow<UiVoiceInfo?> = store.data.map { prefs ->
-        val activeId = prefs[VoiceKeys.ACTIVE_ID] ?: return@map null
-        val installed = prefs[VoiceKeys.INSTALLED_IDS].orEmpty()
+        val activeId = prefs[VoiceKeys.ACTIVE_ID]?.let(::normalizeId) ?: return@map null
+        val installed = prefs[VoiceKeys.INSTALLED_IDS].orEmpty().map(::normalizeId).toSet()
         val entry = VoiceCatalog.byId(activeId) ?: return@map null
         val isInstalled = activeId in installed ||
             (entry.engineType is EngineType.Kokoro && isKokoroSharedModelInstalled())
         entry.toUiVoiceInfo(installed = isInstalled)
     }
+
+    /** Strip the historical `_int8` suffix so legacy stored IDs resolve
+     *  against the current catalog. Used on every read; the async migration
+     *  rewrites the persisted store eventually but reads must succeed before
+     *  it lands. */
+    private fun normalizeId(id: String): String =
+        if (id.endsWith("_int8")) id.removeSuffix("_int8") else id
 
     private fun isKokoroSharedModelInstalled(): Boolean {
         val dir = kokoroSharedDir()

--- a/core-playback/src/main/kotlin/in/jphe/storyvox/playback/voice/VoiceManager.kt
+++ b/core-playback/src/main/kotlin/in/jphe/storyvox/playback/voice/VoiceManager.kt
@@ -12,11 +12,14 @@ import java.io.File
 import java.io.IOException
 import javax.inject.Inject
 import javax.inject.Singleton
+import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.flow.flowOn
 import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 import okhttp3.OkHttpClient
 import okhttp3.Request
@@ -60,6 +63,43 @@ class VoiceManager @Inject constructor(
 
     private val store: DataStore<Preferences> = context.voicesSettingsStore
     private val http: OkHttpClient = OkHttpClient.Builder().build()
+    private val migrationScope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
+
+    init {
+        // One-shot migration for users who installed v0.4.5–v0.4.13 with
+        // `piper_*_int8`-suffixed IDs. The suffix was kept across the
+        // INT8→fp32 catalog repoint to preserve persisted state, but it's
+        // misleading (the files have been fp32 since v0.4.12). Strip it
+        // from DataStore + rename matching voice directories.
+        migrationScope.launch { migrateInt8VoiceIds() }
+    }
+
+    private suspend fun migrateInt8VoiceIds() {
+        // 1. Filesystem: voices/{id}_int8/ → voices/{id}/
+        val voicesRoot = File(context.filesDir, "voices")
+        if (voicesRoot.exists()) {
+            voicesRoot.listFiles()?.forEach { dir ->
+                if (dir.isDirectory && dir.name.endsWith("_int8")) {
+                    val newDir = File(voicesRoot, dir.name.removeSuffix("_int8"))
+                    if (!newDir.exists()) dir.renameTo(newDir)
+                }
+            }
+        }
+        // 2. DataStore: rewrite ACTIVE_ID + INSTALLED_IDS to drop _int8
+        store.edit { prefs ->
+            prefs[VoiceKeys.ACTIVE_ID]?.let { active ->
+                if (active.endsWith("_int8")) {
+                    prefs[VoiceKeys.ACTIVE_ID] = active.removeSuffix("_int8")
+                }
+            }
+            prefs[VoiceKeys.INSTALLED_IDS]?.let { ids ->
+                val rewritten = ids.map {
+                    if (it.endsWith("_int8")) it.removeSuffix("_int8") else it
+                }.toSet()
+                if (rewritten != ids) prefs[VoiceKeys.INSTALLED_IDS] = rewritten
+            }
+        }
+    }
 
     /** Catalog projected as [UiVoiceInfo]. Static — never changes at runtime. */
     val availableVoices: List<UiVoiceInfo>

--- a/feature/src/main/kotlin/in/jphe/storyvox/feature/voicelibrary/VoiceLibraryScreen.kt
+++ b/feature/src/main/kotlin/in/jphe/storyvox/feature/voicelibrary/VoiceLibraryScreen.kt
@@ -184,7 +184,7 @@ private fun KokoroBundleNote() {
                 fontWeight = FontWeight.SemiBold,
             )
             Text(
-                "All 53 Kokoro speakers (English, Spanish, French, Hindi, Italian, Japanese, Portuguese, Chinese) live in one ~380 MB multi-speaker model. The first Kokoro voice you pick downloads it; every Kokoro voice after that activates instantly.",
+                "All 53 Kokoro speakers (English, Spanish, French, Hindi, Italian, Japanese, Portuguese, Chinese) share one ~380 MB bundle (model + speakers + tokens). The first Kokoro voice you pick downloads it; every Kokoro voice after that activates instantly.",
                 style = MaterialTheme.typography.bodySmall,
                 color = MaterialTheme.colorScheme.onSurfaceVariant,
             )

--- a/feature/src/main/kotlin/in/jphe/storyvox/feature/voicelibrary/VoiceLibraryScreen.kt
+++ b/feature/src/main/kotlin/in/jphe/storyvox/feature/voicelibrary/VoiceLibraryScreen.kt
@@ -39,6 +39,7 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import `in`.jphe.storyvox.playback.voice.EngineType
 import `in`.jphe.storyvox.playback.voice.UiVoiceInfo
 import `in`.jphe.storyvox.ui.component.BrassButton
 import `in`.jphe.storyvox.ui.component.BrassButtonVariant
@@ -129,6 +130,9 @@ fun VoiceLibraryScreen(
                     Spacer(modifier = Modifier.height(spacing.md))
                     SectionHeader("Available", count = available.size, dim = true)
                 }
+                if (available.any { it.engineType is EngineType.Kokoro }) {
+                    item { KokoroBundleNote() }
+                }
                 items(available, key = { "a-${it.id}" }) { voice ->
                     val downloading = state.currentDownload
                     val rowProgress = if (downloading?.voiceId == voice.id) downloading.progress ?: -1f else null
@@ -151,6 +155,45 @@ fun VoiceLibraryScreen(
             onConfirm = viewModel::confirmDelete,
             onDismiss = viewModel::cancelDelete,
         )
+    }
+}
+
+/** Explains the unusual storage model of Kokoro voices once, inline in
+ *  the Available list. The 53 Kokoro speakers all share one ~380 MB
+ *  bundled download — picking any of them downloads the model once,
+ *  and the remaining 52 then activate instantly. Inference is heavier
+ *  than Piper, so on modest hardware a small inter-sentence pause is
+ *  expected. Heading off both UX surprises upfront. */
+@Composable
+private fun KokoroBundleNote() {
+    val spacing = LocalSpacing.current
+    val outline = MaterialTheme.colorScheme.outlineVariant
+    Box(
+        modifier = Modifier
+            .fillMaxWidth()
+            .clip(RoundedCornerShape(8.dp))
+            .background(MaterialTheme.colorScheme.surfaceContainerLow)
+            .border(1.dp, outline.copy(alpha = 0.5f), RoundedCornerShape(8.dp))
+            .padding(spacing.sm),
+    ) {
+        Column(verticalArrangement = Arrangement.spacedBy(2.dp)) {
+            Text(
+                "🌐 Kokoro voices share one bundle",
+                style = MaterialTheme.typography.labelLarge,
+                color = MaterialTheme.colorScheme.primary,
+                fontWeight = FontWeight.SemiBold,
+            )
+            Text(
+                "All 53 Kokoro speakers (English, Spanish, French, Hindi, Italian, Japanese, Portuguese, Chinese) live in one ~380 MB multi-speaker model. The first Kokoro voice you pick downloads it; every Kokoro voice after that activates instantly.",
+                style = MaterialTheme.typography.bodySmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
+            Text(
+                "Kokoro inference is heavier than Piper — on modest hardware you may notice a small pause between sentences while the next chunk renders.",
+                style = MaterialTheme.typography.bodySmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
+        }
     }
 }
 


### PR DESCRIPTION
## Summary

Closes #7, #8, #10, #11. (Issue #12 — browse infinite scroll — deferred to a separate PR; it's a structural change to the browse paginator that deserves its own review.)

### #7 — tap-to-seek
`seekToCharOffset` was only updating `charOffset`, leaving `currentSentenceRange` stale, so the brass underline + auto-scroll never moved on tap. Now both update in the same `_observableState.update {…}`. Lookup math was already correct (no off-by-one).

### #8 / #11 — Piper voice swap crash + slow live swap
`loadAndPlay` was calling `VoiceEngine.loadModel(...)` from `Dispatchers.IO` **without** holding `engineMutex`. The mutex is taken by the producer around every JNI `generateAudioPCM`, but the load path bypassed it entirely. A Piper-to-Piper swap could call `loadModel` (which `destroy()`s + `release()`s the native `tts`) while the prior generator was still in-flight in JNI → SIGSEGV. Wrapping the load in `engineMutex.withLock {…}` blocks until the in-flight native call finishes before the model is torn down — fixes the crash and also eliminates the "voice didn't change right away" symptom for #8 (the new pipeline now starts cleanly with the new voice instead of racing the old one's residual queue).

### #10 — featured voices
```kotlin
val featuredIds = listOf(
    "piper_cori_en_GB_high",      // en_GB Piper
    "piper_lessac_en_US_high",    // en_US Piper
    "kokoro_aoede_en_US_1",       // Kokoro multi-speaker
)
```
Per JP's call. Three engines / accents so first-time users hear the range.

### Bonus — drop misleading `_int8` IDs

Voice IDs like `piper_lessac_en_US_high_int8` were inherited from voices-v1 (when the models actually were INT8-quantized) and kept across the v0.4.12 fp32 migration to preserve persisted state. The files have been fp32 for a release now — the suffix is just confusing. This PR renames every Piper ID to drop `_int8`, plus a one-shot migration in `VoiceManager.init`:
1. Renames `filesDir/voices/{id}_int8/` → `filesDir/voices/{id}/`
2. Rewrites DataStore `ACTIVE_ID` + `INSTALLED_IDS` to drop the suffix

Existing users keep their voice selection; the catalog now reads cleanly.

### Bonus — Kokoro UX note in voice library
Per JP's request. New `KokoroBundleNote` composable inserted above the Available section when any Kokoro voice is in it. Explains that all 53 Kokoro speakers share one ~380 MB bundled download (first pick downloads it, rest activate instantly) and that Kokoro inference is heavier than Piper so a small inter-sentence pause is expected on modest hardware.

## Test plan

- [ ] CI passes.
- [ ] On upgrade from v0.4.13: existing voice selection still active; `voices/{id}_int8/` dirs renamed to `voices/{id}/` (logcat or `adb shell run-as` to inspect).
- [ ] Tap any sentence in ebook mode while playing → highlight + audio jump there.
- [ ] Tap any sentence in ebook mode while paused → highlight moves, playback stays paused.
- [ ] Activate a Piper voice while another Piper voice is playing → no crash, audio swaps to the new voice within ~1 sentence.
- [ ] Activate a Kokoro speaker while a different Kokoro speaker is playing → no crash, swap is near-instant.
- [ ] Voice library: featured row shows Cori, Lessac, Aoede.
- [ ] Voice library: Available section, Kokoro note appears above the Kokoro voices.

🤖 Generated with [Claude Code](https://claude.com/claude-code)