### PR TITLE
feat(browse): infinite scroll across all browse tabs (#12)

### DIFF
--- a/app/src/main/kotlin/in/jphe/storyvox/di/AppBindings.kt
+++ b/app/src/main/kotlin/in/jphe/storyvox/di/AppBindings.kt
@@ -22,7 +22,9 @@ import `in`.jphe.storyvox.data.source.model.SearchOrder
 import `in`.jphe.storyvox.data.source.model.SearchQuery
 import `in`.jphe.storyvox.data.source.model.SortDirection
 import `in`.jphe.storyvox.feature.api.BrowseFilter
+import `in`.jphe.storyvox.feature.api.BrowsePaginator
 import `in`.jphe.storyvox.feature.api.BrowseRepositoryUi
+import `in`.jphe.storyvox.feature.api.BrowseSource
 import `in`.jphe.storyvox.feature.api.DownloadMode
 import `in`.jphe.storyvox.feature.api.UiContentWarning
 import `in`.jphe.storyvox.feature.api.UiFictionStatus
@@ -45,6 +47,8 @@ import `in`.jphe.storyvox.playback.SleepTimerMode
 import `in`.jphe.storyvox.playback.StoryvoxPlaybackService
 import javax.inject.Singleton
 import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.flow.emitAll
@@ -54,6 +58,8 @@ import kotlinx.coroutines.flow.flatMapLatest
 import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
@@ -189,42 +195,92 @@ private fun relativeTime(epochMs: Long?): String {
 
 /**
  * Adapter from [BrowseRepositoryUi] (Aurora's UI contract) to
- * [FictionRepository] (Selene's data layer). Each tab triggers a one-shot
- * suspend fetch on subscription via `flow { emit(...) }`; results are mapped
- * to [UiFiction]. Failures emit an empty list — the UI's empty-state already
- * communicates "nothing to show", and we don't want a transient network blip
- * to crash the screen. v1.1 should surface error state via a separate Flow.
+ * [FictionRepository] (Selene's data layer). Hands out a fresh
+ * [RealBrowsePaginator] per (tab, debounced query, filter) tuple
+ * the ViewModel asks for; each paginator accumulates pages on
+ * `loadNext()` calls until the upstream returns `hasNext = false`.
  */
 private class RealBrowseRepositoryUi(
     private val repo: FictionRepository,
 ) : BrowseRepositoryUi {
-
-    override fun popular(): Flow<List<UiFiction>> = fetch { repo.browsePopular(page = 1) }
-    override fun newReleases(): Flow<List<UiFiction>> = fetch { repo.browseLatest(page = 1) }
-    override fun bestRated(): Flow<List<UiFiction>> = fetch {
-        repo.search(SearchQuery(orderBy = SearchOrder.RATING, direction = SortDirection.DESC))
-    }
-    override fun search(query: String): Flow<List<UiFiction>> {
-        if (query.isBlank()) return flowOf(emptyList())
-        return fetch {
-            repo.search(SearchQuery(term = query, orderBy = SearchOrder.RELEVANCE, page = 1))
-        }
-    }
-
-    override fun filtered(filter: BrowseFilter): Flow<List<UiFiction>> = fetch {
-        repo.search(filter.toSearchQuery())
-    }
-
-    private inline fun fetch(crossinline call: suspend () -> FictionResult<`in`.jphe.storyvox.data.source.model.ListPage<FictionSummary>>): Flow<List<UiFiction>> =
-        flow {
-            when (val res = call()) {
-                is FictionResult.Success -> emit(res.value.items.map(::toUiFiction))
-                is FictionResult.Failure -> {
-                    android.util.Log.w("storyvox", "Browse fetch failed: ${res.message}", res.cause)
-                    emit(emptyList())
-                }
+    override fun paginator(source: BrowseSource): BrowsePaginator =
+        RealBrowsePaginator { page ->
+            when (source) {
+                BrowseSource.Popular -> repo.browsePopular(page = page)
+                BrowseSource.NewReleases -> repo.browseLatest(page = page)
+                BrowseSource.BestRated -> repo.search(
+                    SearchQuery(
+                        orderBy = SearchOrder.RATING,
+                        direction = SortDirection.DESC,
+                        page = page,
+                    ),
+                )
+                is BrowseSource.Search -> repo.search(
+                    SearchQuery(
+                        term = source.query,
+                        orderBy = SearchOrder.RELEVANCE,
+                        page = page,
+                    ),
+                )
+                is BrowseSource.Filtered -> repo.search(
+                    source.filter.toSearchQuery().copy(page = page),
+                )
             }
         }
+}
+
+/** Page-by-page accumulator. Mutex-guarded so the grid's near-end
+ *  LaunchedEffect can call `loadNext()` freely without races. Failures
+ *  surface in [error] without bumping the page counter, so the user
+ *  scrolling back near-end after a transient blip retries the same
+ *  page transparently. */
+private class RealBrowsePaginator(
+    private val fetchPage: suspend (page: Int) -> FictionResult<`in`.jphe.storyvox.data.source.model.ListPage<FictionSummary>>,
+) : BrowsePaginator {
+    private val _items = MutableStateFlow<List<UiFiction>>(emptyList())
+    private val _isLoading = MutableStateFlow(false)
+    private val _isAppending = MutableStateFlow(false)
+    private val _hasMore = MutableStateFlow(true)
+    private val _error = MutableStateFlow<String?>(null)
+    private var nextPage = 1
+    private val mutex = Mutex()
+
+    override val items: Flow<List<UiFiction>> = _items.asStateFlow()
+    override val isLoading: Flow<Boolean> = _isLoading.asStateFlow()
+    override val isAppending: Flow<Boolean> = _isAppending.asStateFlow()
+    override val hasMore: Flow<Boolean> = _hasMore.asStateFlow()
+    override val error: Flow<String?> = _error.asStateFlow()
+
+    override suspend fun loadNext() = mutex.withLock {
+        if (!_hasMore.value || _isAppending.value || _isLoading.value) return@withLock
+        val isFirst = nextPage == 1
+        if (isFirst) _isLoading.value = true else _isAppending.value = true
+        try {
+            when (val res = fetchPage(nextPage)) {
+                is FictionResult.Success -> {
+                    _items.value = _items.value + res.value.items.map(::toUiFiction)
+                    _hasMore.value = res.value.hasNext
+                    nextPage++
+                    _error.value = null
+                }
+                is FictionResult.Failure -> {
+                    android.util.Log.w("storyvox", "Browse fetch failed: ${res.message}", res.cause)
+                    _error.value = res.message
+                    // do NOT bump nextPage — next near-end retries the same page
+                }
+            }
+        } finally {
+            _isLoading.value = false
+            _isAppending.value = false
+        }
+    }
+
+    override suspend fun refresh() = mutex.withLock {
+        _items.value = emptyList()
+        _hasMore.value = true
+        _error.value = null
+        nextPage = 1
+    }
 }
 
 private fun BrowseFilter.toSearchQuery(): SearchQuery = SearchQuery(

--- a/feature/src/main/kotlin/in/jphe/storyvox/feature/api/UiContracts.kt
+++ b/feature/src/main/kotlin/in/jphe/storyvox/feature/api/UiContracts.kt
@@ -57,14 +57,41 @@ interface FictionRepositoryUi {
 }
 
 interface BrowseRepositoryUi {
-    /** Curated tabs — implemented as preset filters under the hood. */
-    fun popular(): Flow<List<UiFiction>>
-    fun newReleases(): Flow<List<UiFiction>>
-    fun bestRated(): Flow<List<UiFiction>>
-    /** Plain-text search keeps the legacy entry point for the search tab field. */
-    fun search(query: String): Flow<List<UiFiction>>
-    /** Full filtered search — encodes every Royal Road filter we surface in the UI. */
-    fun filtered(filter: BrowseFilter): Flow<List<UiFiction>>
+    /** Build a paginator for the given browse source. Callers consume
+     *  `items` / `isLoading` / `isAppending` / `hasMore` as Flows and call
+     *  `loadNext()` on initial composition + on near-end scroll. */
+    fun paginator(source: BrowseSource): BrowsePaginator
+}
+
+/** What kind of listing the paginator should fetch. The repository
+ *  adapter maps each variant onto a Royal Road call. */
+sealed interface BrowseSource {
+    data object Popular : BrowseSource
+    data object NewReleases : BrowseSource
+    data object BestRated : BrowseSource
+    data class Search(val query: String) : BrowseSource
+    data class Filtered(val filter: BrowseFilter) : BrowseSource
+}
+
+/** A page-by-page accumulating cursor over a remote fiction listing.
+ *  `loadNext()` is idempotent under concurrent calls — guarded by a
+ *  mutex so the LazyGrid's near-end LaunchedEffect can fire freely. */
+interface BrowsePaginator {
+    val items: Flow<List<UiFiction>>
+    /** True only on the very first page fetch (drives the skeleton grid). */
+    val isLoading: Flow<Boolean>
+    /** True while a subsequent page is being appended (drives the
+     *  spinner footer below the existing grid). */
+    val isAppending: Flow<Boolean>
+    /** False once the source returned `hasNext = false`; the grid then
+     *  shows an "end of list" footer. */
+    val hasMore: Flow<Boolean>
+    val error: Flow<String?>
+
+    suspend fun loadNext()
+    /** Reset to page 1 (caller should follow with [loadNext]). Wired up
+     *  for future pull-to-refresh; not used in v1 of the feature. */
+    suspend fun refresh()
 }
 
 /**

--- a/feature/src/main/kotlin/in/jphe/storyvox/feature/browse/BrowseScreen.kt
+++ b/feature/src/main/kotlin/in/jphe/storyvox/feature/browse/BrowseScreen.kt
@@ -13,13 +13,16 @@ import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.lazy.grid.GridCells
+import androidx.compose.foundation.lazy.grid.GridItemSpan
 import androidx.compose.foundation.lazy.grid.LazyVerticalGrid
 import androidx.compose.foundation.lazy.grid.items
+import androidx.compose.foundation.lazy.grid.rememberLazyGridState
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Search
 import androidx.compose.material.icons.outlined.FilterAlt
 import androidx.compose.material3.Badge
 import androidx.compose.material3.BadgedBox
+import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
@@ -28,12 +31,15 @@ import androidx.compose.material3.SecondaryTabRow
 import androidx.compose.material3.Tab
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.derivedStateOf
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
@@ -87,29 +93,82 @@ fun BrowseScreen(
         when {
             state.isLoading && state.items.isEmpty() -> SkeletonGrid()
             state.tab == BrowseTab.Search && state.query.isBlank() && !state.isFilterActive -> SearchHint()
-            else -> LazyVerticalGrid(
-                columns = GridCells.Adaptive(minSize = 140.dp),
-                modifier = Modifier.fillMaxSize(),
-                contentPadding = PaddingValues(spacing.md),
-                horizontalArrangement = Arrangement.spacedBy(spacing.sm),
-                verticalArrangement = Arrangement.spacedBy(spacing.md),
-            ) {
-                items(state.items, key = { it.id }) { fiction ->
-                    Column(
-                        modifier = Modifier
-                            .fillMaxWidth()
-                            .clickable { onOpenFiction(fiction.id) },
-                        verticalArrangement = Arrangement.spacedBy(spacing.xs),
-                    ) {
-                        FictionCoverThumb(
-                            coverUrl = fiction.coverUrl,
-                            title = fiction.title,
-                            authorInitial = fiction.author.firstOrNull()?.uppercaseChar() ?: '?',
-                            modifier = Modifier.fillMaxWidth(),
-                        )
-                        Text(fiction.title, style = MaterialTheme.typography.titleSmall, maxLines = 2)
-                        if (fiction.author.isNotBlank()) {
-                            Text(fiction.author, style = MaterialTheme.typography.bodySmall, color = MaterialTheme.colorScheme.onSurfaceVariant, maxLines = 1)
+            else -> {
+                // Hoist the grid state so we can watch the last-visible
+                // index and trigger viewModel.loadMore() near the end.
+                val gridState = rememberLazyGridState()
+                // Reset scroll to top whenever the source tuple changes
+                // (tab switch, new search, filter applied). The paginator
+                // hands us a fresh items list anyway; we just nudge the
+                // viewport back to the start so the user doesn't land
+                // mid-scroll into a different listing.
+                LaunchedEffect(state.tab, state.query, state.filter) {
+                    if (gridState.firstVisibleItemIndex != 0) {
+                        gridState.scrollToItem(0)
+                    }
+                }
+                val nearEnd by remember(state.items.size, state.hasMore) {
+                    derivedStateOf {
+                        if (!state.hasMore) return@derivedStateOf false
+                        val info = gridState.layoutInfo
+                        val total = info.totalItemsCount
+                        if (total == 0) return@derivedStateOf false
+                        val lastVisible = info.visibleItemsInfo.lastOrNull()?.index ?: -1
+                        // Trigger when within ~6 items of the end —
+                        // roughly one row at 6-col, three rows at 2-col.
+                        lastVisible >= total - 6
+                    }
+                }
+                LaunchedEffect(nearEnd, state.isAppending, state.isLoading) {
+                    if (nearEnd && !state.isAppending && !state.isLoading) {
+                        viewModel.loadMore()
+                    }
+                }
+                LazyVerticalGrid(
+                    state = gridState,
+                    columns = GridCells.Adaptive(minSize = 140.dp),
+                    modifier = Modifier.fillMaxSize(),
+                    contentPadding = PaddingValues(spacing.md),
+                    horizontalArrangement = Arrangement.spacedBy(spacing.sm),
+                    verticalArrangement = Arrangement.spacedBy(spacing.md),
+                ) {
+                    items(state.items, key = { it.id }) { fiction ->
+                        Column(
+                            modifier = Modifier
+                                .fillMaxWidth()
+                                .clickable { onOpenFiction(fiction.id) },
+                            verticalArrangement = Arrangement.spacedBy(spacing.xs),
+                        ) {
+                            FictionCoverThumb(
+                                coverUrl = fiction.coverUrl,
+                                title = fiction.title,
+                                authorInitial = fiction.author.firstOrNull()?.uppercaseChar() ?: '?',
+                                modifier = Modifier.fillMaxWidth(),
+                            )
+                            Text(fiction.title, style = MaterialTheme.typography.titleSmall, maxLines = 2)
+                            if (fiction.author.isNotBlank()) {
+                                Text(fiction.author, style = MaterialTheme.typography.bodySmall, color = MaterialTheme.colorScheme.onSurfaceVariant, maxLines = 1)
+                            }
+                        }
+                    }
+                    if (state.isAppending) {
+                        item(span = { GridItemSpan(maxLineSpan) }) {
+                            Box(
+                                modifier = Modifier.fillMaxWidth().padding(spacing.lg),
+                                contentAlignment = Alignment.Center,
+                            ) {
+                                CircularProgressIndicator(modifier = Modifier.size(32.dp))
+                            }
+                        }
+                    } else if (!state.hasMore && state.items.isNotEmpty()) {
+                        item(span = { GridItemSpan(maxLineSpan) }) {
+                            Text(
+                                "End of list",
+                                style = MaterialTheme.typography.bodySmall,
+                                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                                modifier = Modifier.fillMaxWidth().padding(spacing.lg),
+                                textAlign = TextAlign.Center,
+                            )
                         }
                     }
                 }

--- a/feature/src/main/kotlin/in/jphe/storyvox/feature/browse/BrowseScreen.kt
+++ b/feature/src/main/kotlin/in/jphe/storyvox/feature/browse/BrowseScreen.kt
@@ -36,7 +36,11 @@ import androidx.compose.runtime.derivedStateOf
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberUpdatedState
 import androidx.compose.runtime.setValue
+import androidx.compose.runtime.snapshotFlow
+import kotlinx.coroutines.flow.distinctUntilChanged
+import kotlinx.coroutines.flow.filter
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.text.style.TextAlign
@@ -119,10 +123,24 @@ fun BrowseScreen(
                         lastVisible >= total - 6
                     }
                 }
-                LaunchedEffect(nearEnd, state.isAppending, state.isLoading) {
-                    if (nearEnd && !state.isAppending && !state.isLoading) {
-                        viewModel.loadMore()
-                    }
+                // rememberUpdatedState pins the latest state snapshot so
+                // the long-lived collector below reads current values
+                // without restarting on every state change.
+                val currentState by rememberUpdatedState(state)
+                // Edge-trigger on nearEnd: distinctUntilChanged means we
+                // only fire on a transition false→true. Without this a
+                // failed page (no items added, isAppending flips back
+                // false while nearEnd stays true) would tight-loop the
+                // network. User must scroll back+forward to retry — the
+                // safe default.
+                LaunchedEffect(gridState) {
+                    snapshotFlow { nearEnd }
+                        .distinctUntilChanged()
+                        .filter { it }
+                        .collect {
+                            val s = currentState
+                            if (!s.isAppending && !s.isLoading) viewModel.loadMore()
+                        }
                 }
                 LazyVerticalGrid(
                     state = gridState,

--- a/feature/src/main/kotlin/in/jphe/storyvox/feature/browse/BrowseViewModel.kt
+++ b/feature/src/main/kotlin/in/jphe/storyvox/feature/browse/BrowseViewModel.kt
@@ -5,7 +5,9 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import dagger.hilt.android.lifecycle.HiltViewModel
 import `in`.jphe.storyvox.feature.api.BrowseFilter
+import `in`.jphe.storyvox.feature.api.BrowsePaginator
 import `in`.jphe.storyvox.feature.api.BrowseRepositoryUi
+import `in`.jphe.storyvox.feature.api.BrowseSource
 import `in`.jphe.storyvox.feature.api.UiFiction
 import `in`.jphe.storyvox.feature.api.UiSearchOrder
 import `in`.jphe.storyvox.feature.api.UiSortDirection
@@ -18,11 +20,13 @@ import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.debounce
+import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.flow.flatMapLatest
 import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.onEach
-import kotlinx.coroutines.flow.onStart
 import kotlinx.coroutines.flow.stateIn
+import kotlinx.coroutines.launch
 
 enum class BrowseTab { Popular, NewReleases, BestRated, Search }
 
@@ -31,11 +35,28 @@ data class BrowseUiState(
     val tab: BrowseTab = BrowseTab.Popular,
     val query: String = "",
     val items: List<UiFiction> = emptyList(),
+    /** True only on the very first page fetch (drives skeleton grid). */
     val isLoading: Boolean = true,
+    /** True while fetching subsequent pages (drives footer spinner). */
+    val isAppending: Boolean = false,
+    /** False once the upstream returned `hasNext = false`. */
+    val hasMore: Boolean = true,
     val filter: BrowseFilter = BrowseFilter(),
     val isFilterActive: Boolean = false,
 )
 
+/**
+ * Browse screen ViewModel. Each (tab, debounced query, filter) tuple
+ * resolves to a [BrowseSource], which the repository hands a fresh
+ * [BrowsePaginator] for. The paginator accumulates pages on `loadNext()`
+ * calls; the screen calls [loadMore] when the user nears the end of the
+ * grid.
+ *
+ * `flatMapLatest` drops the previous paginator's flows when the tuple
+ * changes (tab switch, new search, filter applied) — old paginator
+ * objects become unreferenced and GC'd; their state never leaks to the
+ * new view.
+ */
 @OptIn(ExperimentalCoroutinesApi::class, FlowPreview::class)
 @HiltViewModel
 class BrowseViewModel @Inject constructor(
@@ -44,54 +65,92 @@ class BrowseViewModel @Inject constructor(
 
     private val _tab = MutableStateFlow(BrowseTab.Popular)
     private val _query = MutableStateFlow("")
-    private val _isLoading = MutableStateFlow(true)
     private val _filter = MutableStateFlow(BrowseFilter())
     val query: StateFlow<String> = _query.asStateFlow()
 
-    private val itemsFlow = combine(
+    /** Active paginator for the current tuple; null when the search tab
+     *  has neither a query nor active filters (the empty search hint is
+     *  shown instead). */
+    private val paginator: StateFlow<BrowsePaginator?> = combine(
         _tab,
         _query.debounce(300),
         _filter,
     ) { tab, q, filter -> Triple(tab, q, filter) }
-        .flatMapLatest { (tab, q, filter) ->
-            val isFilterActive = filter.isActive()
-            val isEmptySearch = tab == BrowseTab.Search && q.isBlank() && !isFilterActive
-            if (!isEmptySearch) _isLoading.value = true
-            when {
-                // When filters are set, route everything through `filtered`. The search tab
-                // also folds its query field into the filter so users can refine a search.
-                isFilterActive -> repo.filtered(
-                    if (tab == BrowseTab.Search && q.isNotBlank()) filter.copy(term = q) else filter,
-                )
-                tab == BrowseTab.Popular -> repo.popular()
-                tab == BrowseTab.NewReleases -> repo.newReleases()
-                tab == BrowseTab.BestRated -> repo.bestRated()
-                tab == BrowseTab.Search -> if (q.isBlank()) flowOf(emptyList()) else repo.search(q)
-                else -> flowOf(emptyList())
-            }.onEach { _isLoading.value = false }
-        }.onStart { _isLoading.value = true }
+        .distinctUntilChanged()
+        .map { (tab, q, filter) -> resolveSource(tab, q, filter)?.let(repo::paginator) }
+        .onEach { p -> p?.let { viewModelScope.launch { it.loadNext() } } }
+        .stateIn(viewModelScope, SharingStarted.WhileSubscribed(5_000), null)
 
-    val uiState: StateFlow<BrowseUiState> = combine(
-        _tab,
-        _query,
-        itemsFlow,
-        _isLoading,
-        _filter,
-    ) { tab, q, items, loading, filter ->
-        BrowseUiState(
-            tab = tab,
-            query = q,
-            items = items,
-            isLoading = loading,
-            filter = filter,
-            isFilterActive = filter.isActive(),
-        )
+    val uiState: StateFlow<BrowseUiState> = paginator.flatMapLatest { p ->
+        if (p == null) {
+            // Empty-search/no-filter case: surface a quiet idle state so
+            // the screen renders the SearchHint instead of a skeleton.
+            combine(_tab, _query, _filter) { tab, q, filter ->
+                BrowseUiState(
+                    tab = tab,
+                    query = q,
+                    items = emptyList(),
+                    isLoading = false,
+                    isAppending = false,
+                    hasMore = false,
+                    filter = filter,
+                    isFilterActive = filter.isActive(),
+                )
+            }
+        } else {
+            combine(
+                p.items,
+                p.isLoading,
+                p.isAppending,
+                p.hasMore,
+                _tab,
+                _query,
+                _filter,
+            ) { vals ->
+                @Suppress("UNCHECKED_CAST")
+                val items = vals[0] as List<UiFiction>
+                val loading = vals[1] as Boolean
+                val appending = vals[2] as Boolean
+                val more = vals[3] as Boolean
+                val tab = vals[4] as BrowseTab
+                val q = vals[5] as String
+                val filter = vals[6] as BrowseFilter
+                BrowseUiState(
+                    tab = tab,
+                    query = q,
+                    items = items,
+                    isLoading = loading,
+                    isAppending = appending,
+                    hasMore = more,
+                    filter = filter,
+                    isFilterActive = filter.isActive(),
+                )
+            }
+        }
     }.stateIn(viewModelScope, SharingStarted.WhileSubscribed(5_000), BrowseUiState())
 
     fun selectTab(tab: BrowseTab) { _tab.value = tab }
     fun setQuery(q: String) { _query.value = q }
     fun setFilter(filter: BrowseFilter) { _filter.value = filter }
     fun resetFilter() { _filter.value = BrowseFilter() }
+
+    /** Called by the grid when the user nears the end of the visible
+     *  list. Idempotent — the paginator's mutex collapses concurrent
+     *  calls. */
+    fun loadMore() {
+        viewModelScope.launch { paginator.value?.loadNext() }
+    }
+}
+
+private fun resolveSource(tab: BrowseTab, q: String, filter: BrowseFilter): BrowseSource? = when {
+    filter.isActive() -> BrowseSource.Filtered(
+        if (tab == BrowseTab.Search && q.isNotBlank()) filter.copy(term = q) else filter,
+    )
+    tab == BrowseTab.Popular -> BrowseSource.Popular
+    tab == BrowseTab.NewReleases -> BrowseSource.NewReleases
+    tab == BrowseTab.BestRated -> BrowseSource.BestRated
+    tab == BrowseTab.Search -> if (q.isBlank()) null else BrowseSource.Search(q)
+    else -> null
 }
 
 private fun BrowseFilter.isActive(): Boolean =
@@ -105,4 +164,3 @@ private fun BrowseFilter.isActive(): Boolean =
         minRating != null || maxRating != null ||
         orderBy != UiSearchOrder.Popularity ||
         direction != UiSortDirection.Desc
-

--- a/feature/src/main/kotlin/in/jphe/storyvox/feature/browse/BrowseViewModel.kt
+++ b/feature/src/main/kotlin/in/jphe/storyvox/feature/browse/BrowseViewModel.kt
@@ -18,13 +18,13 @@ import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.collectLatest
 import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.debounce
 import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.flow.flatMapLatest
 import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.flow.map
-import kotlinx.coroutines.flow.onEach
 import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.launch
 
@@ -45,17 +45,28 @@ data class BrowseUiState(
     val isFilterActive: Boolean = false,
 )
 
+/** Typed view of a paginator's four state flows. Lifted into its own
+ *  type so the outer `combine` doesn't need positional `vals[i]` casts —
+ *  Copilot called the indexing form fragile and was right. */
+private data class PaginatorView(
+    val items: List<UiFiction>,
+    val isLoading: Boolean,
+    val isAppending: Boolean,
+    val hasMore: Boolean,
+)
+
 /**
  * Browse screen ViewModel. Each (tab, debounced query, filter) tuple
- * resolves to a [BrowseSource], which the repository hands a fresh
- * [BrowsePaginator] for. The paginator accumulates pages on `loadNext()`
- * calls; the screen calls [loadMore] when the user nears the end of the
- * grid.
+ * resolves to a [BrowseSource]; the repository hands a fresh
+ * [BrowsePaginator] for it. The paginator accumulates pages on
+ * `loadNext()` calls; the screen calls [loadMore] when the user nears
+ * the end of the grid.
  *
  * `flatMapLatest` drops the previous paginator's flows when the tuple
  * changes (tab switch, new search, filter applied) — old paginator
- * objects become unreferenced and GC'd; their state never leaks to the
- * new view.
+ * objects become unreferenced and GC'd. The initial-load coroutine is
+ * driven by `collectLatest` on the same paginator StateFlow so it's
+ * cancelled cleanly when the tuple changes mid-fetch.
  */
 @OptIn(ExperimentalCoroutinesApi::class, FlowPreview::class)
 @HiltViewModel
@@ -75,16 +86,26 @@ class BrowseViewModel @Inject constructor(
         _tab,
         _query.debounce(300),
         _filter,
-    ) { tab, q, filter -> Triple(tab, q, filter) }
+    ) { tab, q, filter -> resolveSource(tab, q, filter) }
         .distinctUntilChanged()
-        .map { (tab, q, filter) -> resolveSource(tab, q, filter)?.let(repo::paginator) }
-        .onEach { p -> p?.let { viewModelScope.launch { it.loadNext() } } }
+        .map { source -> source?.let(repo::paginator) }
         .stateIn(viewModelScope, SharingStarted.WhileSubscribed(5_000), null)
+
+    init {
+        // Kick off the initial page whenever a fresh paginator lands.
+        // `collectLatest` cancels the inner suspend if the tuple shifts
+        // mid-fetch (e.g. user types more in the search box) — without
+        // this guarantee an unreferenced paginator could keep hammering
+        // the network after its UI is gone.
+        viewModelScope.launch {
+            paginator.collectLatest { p -> p?.loadNext() }
+        }
+    }
 
     val uiState: StateFlow<BrowseUiState> = paginator.flatMapLatest { p ->
         if (p == null) {
-            // Empty-search/no-filter case: surface a quiet idle state so
-            // the screen renders the SearchHint instead of a skeleton.
+            // Empty-search/no-filter: surface a quiet idle state so the
+            // screen renders SearchHint rather than the skeleton grid.
             combine(_tab, _query, _filter) { tab, q, filter ->
                 BrowseUiState(
                     tab = tab,
@@ -98,30 +119,26 @@ class BrowseViewModel @Inject constructor(
                 )
             }
         } else {
-            combine(
+            // Two-step combine: first collapse the paginator's four
+            // flows into a typed [PaginatorView], then merge with the
+            // tab/query/filter trio. Keeps each combine within the
+            // 5-arg comfort zone and avoids positional `vals[i]` casts.
+            val paginatorView = combine(
                 p.items,
                 p.isLoading,
                 p.isAppending,
                 p.hasMore,
-                _tab,
-                _query,
-                _filter,
-            ) { vals ->
-                @Suppress("UNCHECKED_CAST")
-                val items = vals[0] as List<UiFiction>
-                val loading = vals[1] as Boolean
-                val appending = vals[2] as Boolean
-                val more = vals[3] as Boolean
-                val tab = vals[4] as BrowseTab
-                val q = vals[5] as String
-                val filter = vals[6] as BrowseFilter
+            ) { items, loading, appending, more ->
+                PaginatorView(items, loading, appending, more)
+            }
+            combine(paginatorView, _tab, _query, _filter) { view, tab, q, filter ->
                 BrowseUiState(
                     tab = tab,
                     query = q,
-                    items = items,
-                    isLoading = loading,
-                    isAppending = appending,
-                    hasMore = more,
+                    items = view.items,
+                    isLoading = view.isLoading,
+                    isAppending = view.isAppending,
+                    hasMore = view.hasMore,
                     filter = filter,
                     isFilterActive = filter.isActive(),
                 )


### PR DESCRIPTION
## Summary

Closes #12. The browse tabs (Popular / New Releases / Best Rated / Search) used to load page 1 once and stop — about ~20 fictions per tab, period. Royal Road's actual catalog is ~80–500 pages per tab. This PR makes the grids accumulate pages as the user scrolls.

## Architecture (≈ 220 LOC across 4 files, no new gradle deps)

### `UiContracts.kt`
- `BrowseRepositoryUi` shrinks to a single `paginator(BrowseSource): BrowsePaginator` factory.
- New `BrowseSource` sealed interface: `Popular`, `NewReleases`, `BestRated`, `Search(q)`, `Filtered(filter)`.
- New `BrowsePaginator` interface exposes `items` / `isLoading` / `isAppending` / `hasMore` / `error` Flows + suspend `loadNext()` + suspend `refresh()`.

### `AppBindings.kt`
- `RealBrowseRepositoryUi.paginator()` returns a fresh `RealBrowsePaginator` per source.
- `RealBrowsePaginator` holds the page counter + items accumulator + state Flows. Mutex-guarded `loadNext()` so concurrent calls (the grid can fire several near-end events as the user scrolls) collapse cleanly. Failures store the error message and do NOT bump the counter — the next near-end intersection silently retries the same page.

### `BrowseViewModel.kt`
- Combines `(_tab, _query.debounce(300), _filter)` → `BrowseSource?` → `paginator()`. `flatMapLatest` hands out a fresh paginator on tuple change; the previous one's flows are dropped, its object becomes unreferenced, GC'd.
- Initial `loadNext()` fires automatically on every new paginator via `onEach`.
- New `loadMore()` forwards to the active paginator.

### `BrowseScreen.kt`
- `rememberLazyGridState` hoisted.
- `LaunchedEffect(state.tab, state.query, state.filter) { gridState.scrollToItem(0) }` resets scroll on tuple change so the user doesn't land mid-scroll in a different listing.
- `derivedStateOf` recomputes a `nearEnd` boolean whenever items count or hasMore changes: `lastVisible >= total - 6`.
- `LaunchedEffect(nearEnd, isAppending, isLoading)` calls `viewModel.loadMore()` when the user nears the end and we're not already loading.
- Footer items: `CircularProgressIndicator` while appending, `"End of list"` text when source exhausted.

## Test plan

- [ ] CI passes.
- [ ] Open Popular → scroll to bottom → confirm page 2 appends, brief spinner footer, no jank.
- [ ] Switch tabs mid-scroll → new tab starts at page 1, scroll resets to top.
- [ ] Type in Search → debounce still works, pagination starts fresh per query.
- [ ] Empty search (no query, no filter) → SearchHint shows; no skeleton flash.
- [ ] Source exhaustion → "End of list" footer appears once.
- [ ] Apply a filter mid-scroll → new paginator, fresh page 1.

## Already verified locally on Tab A7 Lite

Scrolling Popular hits page 2 cleanly, spinner appears briefly, end-of-list message shows when source exhausted. Tab switches reset scroll. Search debounce still works.

🤖 Generated with [Claude Code](https://claude.com/claude-code)