### PR TITLE
test(core-playback): add unit tests for chunker / volume ramp / scrubProgress

### DIFF
--- a/core-playback/src/test/kotlin/in/jphe/storyvox/playback/PlaybackStateTest.kt
+++ b/core-playback/src/test/kotlin/in/jphe/storyvox/playback/PlaybackStateTest.kt
@@ -1,0 +1,55 @@
+package `in`.jphe.storyvox.playback
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class PlaybackStateTest {
+
+    @Test fun `scrubProgress is zero when duration is zero`() {
+        assertEquals(0f, PlaybackState().scrubProgress(), 0f)
+    }
+
+    @Test fun `scrubProgress is zero when duration is negative`() {
+        val s = PlaybackState(durationEstimateMs = -100L, charOffset = 50)
+        assertEquals(0f, s.scrubProgress(), 0f)
+    }
+
+    @Test fun `scrubProgress is zero at start of chapter`() {
+        val s = PlaybackState(durationEstimateMs = 10_000L, charOffset = 0)
+        assertEquals(0f, s.scrubProgress(), 0f)
+    }
+
+    @Test fun `scrubProgress at half-way charOffset is roughly half`() {
+        // 1000ms at speed=1.0 => 1.0 * 12.5 chars/s = 12.5 chars total.
+        // (SPEED_BASELINE_WPM 150 * 5 / 60 = 12.5 chars/sec.)
+        val total = (1_000f / 1000f) * SPEED_BASELINE_CHARS_PER_SECOND * 1.0f
+        val s = PlaybackState(
+            durationEstimateMs = 1_000L,
+            charOffset = (total / 2f).toInt(),
+            speed = 1.0f,
+        )
+        assertEquals(0.5f, s.scrubProgress(), 0.05f)
+    }
+
+    @Test fun `scrubProgress is clamped to 1 when charOffset overshoots`() {
+        val s = PlaybackState(
+            durationEstimateMs = 1_000L,
+            charOffset = 10_000,
+            speed = 1.0f,
+        )
+        assertEquals(1f, s.scrubProgress(), 0f)
+    }
+
+    @Test fun `higher speed expands expected total chars and reduces progress`() {
+        val base = PlaybackState(durationEstimateMs = 10_000L, charOffset = 100, speed = 1.0f)
+        val fast = base.copy(speed = 2.0f)
+        // At 2x speed, the same charOffset over the same duration represents
+        // half as much progress (twice as much total content fits).
+        assertEquals(base.scrubProgress() / 2f, fast.scrubProgress(), 1e-4f)
+    }
+
+    @Test fun `speed baseline constants are stable contract`() {
+        assertEquals(150f, SPEED_BASELINE_WPM, 0f)
+        assertEquals(12.5f, SPEED_BASELINE_CHARS_PER_SECOND, 0f)
+    }
+}

--- a/core-playback/src/test/kotlin/in/jphe/storyvox/playback/TtsVolumeRampTest.kt
+++ b/core-playback/src/test/kotlin/in/jphe/storyvox/playback/TtsVolumeRampTest.kt
@@ -1,0 +1,45 @@
+package `in`.jphe.storyvox.playback
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class TtsVolumeRampTest {
+
+    @Test fun `default current is full volume`() {
+        assertEquals(1.0f, TtsVolumeRamp().current, 0f)
+    }
+
+    @Test fun `set within range updates current verbatim`() {
+        val ramp = TtsVolumeRamp()
+        ramp.set(0.5f)
+        assertEquals(0.5f, ramp.current, 0f)
+        ramp.set(0.0f)
+        assertEquals(0.0f, ramp.current, 0f)
+        ramp.set(1.0f)
+        assertEquals(1.0f, ramp.current, 0f)
+    }
+
+    @Test fun `negative input is clamped to zero`() {
+        val ramp = TtsVolumeRamp()
+        ramp.set(-0.5f)
+        assertEquals(0f, ramp.current, 0f)
+        ramp.set(-1000f)
+        assertEquals(0f, ramp.current, 0f)
+    }
+
+    @Test fun `above-one input is clamped to one`() {
+        val ramp = TtsVolumeRamp()
+        ramp.set(1.5f)
+        assertEquals(1f, ramp.current, 0f)
+        ramp.set(99f)
+        assertEquals(1f, ramp.current, 0f)
+    }
+
+    @Test fun `successive sets overwrite, last write wins`() {
+        val ramp = TtsVolumeRamp()
+        ramp.set(0.2f)
+        ramp.set(0.8f)
+        ramp.set(0.4f)
+        assertEquals(0.4f, ramp.current, 0f)
+    }
+}

--- a/core-playback/src/test/kotlin/in/jphe/storyvox/playback/tts/SentenceChunkerTest.kt
+++ b/core-playback/src/test/kotlin/in/jphe/storyvox/playback/tts/SentenceChunkerTest.kt
@@ -1,0 +1,118 @@
+package `in`.jphe.storyvox.playback.tts
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import java.util.Locale
+
+class SentenceChunkerTest {
+
+    private val chunker = SentenceChunker()
+    private val locale = Locale.US
+
+    @Test fun `empty text yields empty list`() {
+        assertEquals(emptyList<Sentence>(), chunker.chunk("", locale))
+    }
+
+    @Test fun `whitespace-only text yields empty list`() {
+        assertEquals(emptyList<Sentence>(), chunker.chunk("   \n\t  ", locale))
+    }
+
+    @Test fun `single sentence with no terminator is one chunk`() {
+        val out = chunker.chunk("Hello world", locale)
+        assertEquals(1, out.size)
+        assertEquals(0, out[0].index)
+        assertEquals("Hello world", out[0].text)
+        assertEquals(0, out[0].startChar)
+        assertEquals("Hello world".length, out[0].endChar)
+    }
+
+    @Test fun `three sentences split on terminators`() {
+        val text = "First. Second! Third?"
+        val out = chunker.chunk(text, locale)
+        assertEquals(3, out.size)
+        assertEquals(listOf("First.", "Second!", "Third?"), out.map { it.text })
+        assertEquals(listOf(0, 1, 2), out.map { it.index })
+    }
+
+    @Test fun `sentence indices are zero-based and contiguous`() {
+        val out = chunker.chunk("A. B. C. D. E.", locale)
+        assertEquals(5, out.size)
+        out.forEachIndexed { i, s -> assertEquals(i, s.index) }
+    }
+
+    @Test fun `endChar minus startChar equals trimmed text length`() {
+        val text = "First sentence.   Second sentence after extra spaces. "
+        val out = chunker.chunk(text, locale)
+        out.forEach { s ->
+            assertEquals(
+                "endChar-startChar must equal text length for $s",
+                s.text.length,
+                s.endChar - s.startChar,
+            )
+        }
+    }
+
+    @Test fun `startChar points at first non-whitespace of trimmed sentence`() {
+        val text = "First.   Second."
+        val out = chunker.chunk(text, locale)
+        assertEquals(2, out.size)
+        // "First." starts at offset 0, "Second." starts at offset 9 (after "First.   ")
+        assertEquals(0, out[0].startChar)
+        assertEquals(text.indexOf("Second."), out[1].startChar)
+    }
+
+    @Test fun `text slice at startChar matches sentence text`() {
+        val text = "Alpha is first. Bravo is second. Charlie is third."
+        val out = chunker.chunk(text, locale)
+        out.forEach { s ->
+            assertEquals(
+                "substring(${s.startChar}, ${s.endChar}) should equal sentence text",
+                s.text,
+                text.substring(s.startChar, s.endChar),
+            )
+        }
+    }
+
+    @Test fun `leading whitespace before first sentence is excluded`() {
+        val text = "    Hello there."
+        val out = chunker.chunk(text, locale)
+        assertEquals(1, out.size)
+        assertEquals("Hello there.", out[0].text)
+        assertEquals(text.indexOf("Hello"), out[0].startChar)
+    }
+
+    @Test fun `multiple consecutive whitespace runs do not produce empty sentences`() {
+        val text = "One.\n\n\n   Two.\t\t\tThree."
+        val out = chunker.chunk(text, locale)
+        assertEquals(3, out.size)
+        assertTrue(out.all { it.text.isNotEmpty() })
+    }
+
+    @Test fun `utteranceId encodes sentence and sub-index`() {
+        assertEquals("s0_p0", chunker.utteranceId(0))
+        assertEquals("s0_p0", chunker.utteranceId(0, 0))
+        assertEquals("s5_p2", chunker.utteranceId(5, 2))
+        assertEquals("s42_p7", chunker.utteranceId(42, 7))
+    }
+
+    @Test fun `parseSentenceIndex round-trips utteranceId`() {
+        listOf(0 to 0, 1 to 0, 5 to 2, 42 to 7, 999 to 0).forEach { (s, p) ->
+            val id = chunker.utteranceId(s, p)
+            assertEquals("round-trip on $id", s, chunker.parseSentenceIndex(id))
+        }
+    }
+
+    @Test fun `parseSentenceIndex returns null for malformed ids`() {
+        assertNull(chunker.parseSentenceIndex("garbage"))
+        assertNull(chunker.parseSentenceIndex("sX_p0"))
+        assertNull(chunker.parseSentenceIndex(""))
+    }
+
+    @Test fun `parseSentenceIndex handles missing sub-index suffix`() {
+        // No "_p" — substringBefore("_") returns the whole string after "s",
+        // which should still parse if numeric.
+        assertEquals(3, chunker.parseSentenceIndex("s3"))
+    }
+}


### PR DESCRIPTION
## Summary

First test coverage for `core-playback`. Pure-Kotlin units only — no new test dependencies. JUnit 4 from the existing version catalog.

## What's covered

- **`SentenceChunker`** — 14 tests
  - empty / whitespace-only input
  - BreakIterator splitting on `.`, `!`, `?`
  - sentence index contiguity
  - `endChar - startChar == text.length` invariant
  - `text.substring(startChar, endChar) == sentence.text` invariant
  - leading-whitespace exclusion, run-of-whitespace handling
  - `utteranceId` / `parseSentenceIndex` round-trip and malformed-id null
- **`TtsVolumeRamp`** — 5 tests
  - default = 1.0f, in-range pass-through, clamp negative, clamp >1, last-write-wins
- **`PlaybackState.scrubProgress()`** — 7 tests
  - zero / negative duration, start, half-way, overshoot clamp, speed scaling, baseline constants

26 tests, 0 failures via `./gradlew :core-playback:test` (both `testDebugUnitTest` and `testReleaseUnitTest`).

## What's NOT covered (deferred)

- **`SleepTimer` state machine** — uses `delay()` for the countdown and 10s fade tail. Needs `kotlinx-coroutines-test` for virtual-time assertions; dep request is in flight with team-lead. Will land in a follow-up PR.
- **`SentenceTracker`** — coroutine + state-flow heavy; will pair with the SleepTimer PR once `kotlinx-coroutines-test` is in.
- **`EnginePlayer`** — touches AudioTrack and Looper; needs Robolectric (not adding that on a whim).
- **`VoiceManager`, `VoiceCatalog`** — network + DataStore I/O; separate PR with test fakes.

## Side finding (out of scope of this PR)

While writing the `TtsVolumeRamp` test I hit a latent bug: `set(Float.NaN)` propagates NaN to `current` (`Float.coerceIn(0f, 1f)` is a no-op on NaN). Today nothing reads `current`, but Selene is wiring it into `AudioTrack.setVolume(...)` in a parallel PR — so this will become a real "track silently mutes" bug shortly. Reported to team-lead; not patching it from a test PR.

## Test plan

- [x] `./gradlew :core-playback:test` — green, both variants
- [ ] Copilot review pass (will not merge before review completes)

🤖 Generated with [Claude Code](https://claude.com/claude-code)