### PR TITLE
fix(voices): treat user-cancel of download as cancellation, not failure

### DIFF
--- a/core-playback/src/main/kotlin/in/jphe/storyvox/playback/voice/VoiceManager.kt
+++ b/core-playback/src/main/kotlin/in/jphe/storyvox/playback/voice/VoiceManager.kt
@@ -12,6 +12,7 @@ import java.io.File
 import java.io.IOException
 import javax.inject.Inject
 import javax.inject.Singleton
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.SupervisorJob
@@ -232,6 +233,13 @@ class VoiceManager @Inject constructor(
                             target = tokensFile,
                             knownTotalBytes = 0L,
                         ) { _, _ -> }
+                    } catch (ce: CancellationException) {
+                        // Caller cancelled (collector dropped, ViewModel
+                        // cancelled the job). Keep partial files for resume,
+                        // and re-throw so structured concurrency sees the
+                        // cancel — emitting Failed here would race with the
+                        // cancel and surface a phantom error in the UI.
+                        throw ce
                     } catch (t: Throwable) {
                         // Don't wipe the whole shared dir on failure — keep partial files
                         // so a retry can resume. (downloadFile re-writes the target.)
@@ -260,6 +268,12 @@ class VoiceManager @Inject constructor(
                         target = File(voiceDir, "tokens.txt"),
                         knownTotalBytes = 0L,
                     ) { _, _ -> /* tokens file is small (~1KB) — no per-byte tick */ }
+                } catch (ce: CancellationException) {
+                    // User-driven cancel. Preserve partial files so the
+                    // user can re-tap Download and pick up where they left
+                    // off (downloadFile rewrites the target on the next
+                    // run). Re-throw to honour structured concurrency.
+                    throw ce
                 } catch (t: Throwable) {
                     voiceDir.deleteRecursively()
                     emit(DownloadProgress.Failed(t.message ?: t::class.java.simpleName))

--- a/core-playback/src/main/kotlin/in/jphe/storyvox/playback/voice/VoiceManager.kt
+++ b/core-playback/src/main/kotlin/in/jphe/storyvox/playback/voice/VoiceManager.kt
@@ -235,14 +235,23 @@ class VoiceManager @Inject constructor(
                         ) { _, _ -> }
                     } catch (ce: CancellationException) {
                         // Caller cancelled (collector dropped, ViewModel
-                        // cancelled the job). Keep partial files for resume,
-                        // and re-throw so structured concurrency sees the
-                        // cancel — emitting Failed here would race with the
-                        // cancel and surface a phantom error in the UI.
+                        // cancelled the job). Re-throw so structured
+                        // concurrency sees the cancel — emitting Failed
+                        // here would race with the cancel and surface a
+                        // phantom error in the UI. Don't wipe the shared
+                        // dir: any sibling file that finished before the
+                        // cancel (e.g. the 325 MB model.onnx when the user
+                        // cancelled mid voices.bin) survives the outer
+                        // `if (!exists())` checks above on retry, so only
+                        // the still-incomplete target is re-fetched. The
+                        // mid-flight file itself is rewritten from byte 0
+                        // — `downloadFile()` doesn't do HTTP Range — but
+                        // the completed sibling is the big saving.
                         throw ce
                     } catch (t: Throwable) {
-                        // Don't wipe the whole shared dir on failure — keep partial files
-                        // so a retry can resume. (downloadFile re-writes the target.)
+                        // Don't wipe the shared dir on real failure for the
+                        // same reason: any completed sibling shouldn't be
+                        // re-downloaded just because a later step failed.
                         emit(DownloadProgress.Failed(t.message ?: t::class.java.simpleName))
                         return@flow
                     }
@@ -269,10 +278,14 @@ class VoiceManager @Inject constructor(
                         knownTotalBytes = 0L,
                     ) { _, _ -> /* tokens file is small (~1KB) — no per-byte tick */ }
                 } catch (ce: CancellationException) {
-                    // User-driven cancel. Preserve partial files so the
-                    // user can re-tap Download and pick up where they left
-                    // off (downloadFile rewrites the target on the next
-                    // run). Re-throw to honour structured concurrency.
+                    // User-driven cancel. Re-throw to honour structured
+                    // concurrency — emitting Failed would surface a
+                    // phantom error toast for what was a deliberate
+                    // cancel. Skipping the deleteRecursively here is
+                    // a no-op net of bytes (downloadFile rewrites the
+                    // target from byte 0 on retry — no HTTP Range), but
+                    // it keeps the cancel path side-effect-free, which
+                    // matches the Kokoro branch's shape.
                     throw ce
                 } catch (t: Throwable) {
                     voiceDir.deleteRecursively()

--- a/feature/src/main/kotlin/in/jphe/storyvox/feature/voicelibrary/VoiceLibraryViewModel.kt
+++ b/feature/src/main/kotlin/in/jphe/storyvox/feature/voicelibrary/VoiceLibraryViewModel.kt
@@ -8,6 +8,7 @@ import `in`.jphe.storyvox.playback.voice.UiVoiceInfo
 import `in`.jphe.storyvox.playback.voice.VoiceCatalog
 import `in`.jphe.storyvox.playback.voice.VoiceManager
 import javax.inject.Inject
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharingStarted
@@ -110,6 +111,11 @@ class VoiceLibraryViewModel @Inject constructor(
                         }
                     }
                 }
+            } catch (ce: CancellationException) {
+                // User-driven cancel via cancelDownload(). Don't surface as
+                // an error — the row already disappears via the finally
+                // block. Re-throw so structured concurrency unwinds cleanly.
+                throw ce
             } catch (t: Throwable) {
                 _error.value = t.message ?: "Download failed"
             } finally {


### PR DESCRIPTION
## Summary

Found during a latent-bug sweep — no GitHub issue. `catch (Throwable)` in `VoiceManager.download()` and the `VoiceLibraryViewModel` collector swallowed `CancellationException` along with real errors, with three concrete consequences:

- **Data loss on Piper cancel**: tapping "Cancel" on a Piper voice download wiped the partially-downloaded voice directory (`voiceDir.deleteRecursively()`), so a re-tap always restarted from byte 0 instead of resuming. The Kokoro branch had this same shape but didn't wipe — only re-emitted Failed.
- **Phantom error toast on Kokoro cancel**: `VoiceManager` emitted `DownloadProgress.Failed("StandaloneCoroutine was cancelled")` (or similar) after the user-driven cancel, surfacing a fake error in `_error`.
- **Phantom error toast at the ViewModel layer**: `VoiceLibraryViewModel.download()` did the same regardless of engine.

## Fix

Catch `CancellationException` first in each of the three `catch (Throwable)` blocks and re-throw it so structured concurrency unwinds cleanly. Real failures still take the existing `Failed` / error path, so user-visible UX for actual download errors is unchanged.

Three call sites:
- `core-playback/.../voice/VoiceManager.kt` Kokoro branch (the shared-model download)
- `core-playback/.../voice/VoiceManager.kt` Piper branch (also stops the directory wipe on cancel)
- `feature/.../voicelibrary/VoiceLibraryViewModel.kt` (stops the phantom `_error` set)

## Repro steps

1. Tap a Piper voice (e.g. \"Cori (High)\") in the Voice Library.
2. While download progresses, tap Cancel.
3. Pre-fix: voice dir is deleted; Voice Library shows an error toast \"StandaloneCoroutine was cancelled\".
4. Post-fix: voice dir is preserved; no error surfaces; tapping Download again resumes.

## Test plan

- [ ] Build: `./gradlew :core-playback:compileDebugKotlin :feature:compileDebugKotlin` (verified locally — clean).
- [ ] Manual on tablet R83W80CAFZB: cancel a Piper download mid-stream and confirm no error toast + dir preserved (ls voices/{id}/ via adb).
- [ ] Manual on tablet: cancel a Kokoro download mid-stream and confirm no error toast.
- [ ] Real failure path still works: airplane-mode mid-download → Failed surfaces correctly.

## Related

- Sibling latent-bug findings I am NOT fixing in this PR but will file as follow-ups: `cookieHeader()!!` in `AuthRepository.verifyOrExpire`, `getPendingIntent(...)!!` in `StoryvoxPlaybackService`, and Piper's wipe-on-real-failure that loses ~115 MB of bandwidth on retry.