### PR TITLE
perf(playback): stop ticking position interpolation when paused

### DIFF
--- a/app/src/main/kotlin/in/jphe/storyvox/di/AppBindings.kt
+++ b/app/src/main/kotlin/in/jphe/storyvox/di/AppBindings.kt
@@ -458,27 +458,38 @@ private class RealPlaybackControllerUi(
     private var anchorWallMs: Long = 0L
 
     /**
-     * Wall-clock ticker driving the position-interpolation between sentence
-     * boundaries. Gated by `isPlaying`: when paused the upstream state alone
-     * carries enough information for the UI to render a still scrubber, so
-     * we stop allocating UiPlaybackState 4×/sec for screens that are merely
-     * open and idle (e.g. user paused on the reader, walked away). Resuming
-     * playback emits an immediate tick so the slider snaps forward without
-     * waiting up to 250 ms for the first delay window.
+     * Wall-clock source driving position interpolation between sentence
+     * boundaries. Two regimes, gated by `isPlaying`:
+     *
+     *  - **Playing**: tick at 250 ms (the original cadence). Emits an
+     *    immediate tick on play-resume so the slider snaps forward without
+     *    waiting on the first delay window.
+     *  - **Paused**: tick is suppressed *but* every upstream state emission
+     *    re-emits a fresh `System.currentTimeMillis()`. Required because
+     *    `PlaybackState.toUi` re-anchors `anchorWallMs = nowMs` whenever the
+     *    engine reports a new `charOffset` (seek, chapter switch). If the
+     *    anchor were stuck at the pause-time tick, a seek-while-paused
+     *    followed by play would interpret all the paused wall-time as
+     *    elapsed playback time and lurch the scrubber forward (Copilot's
+     *    PR #21 review). Emitting on each upstream change keeps the
+     *    anchor's wall time fresh while still skipping the 4 Hz allocation
+     *    storm of an unconditional ticker.
+     *
+     * Net effect for an open-but-idle reader (paused, no seeks): one tick on
+     * the play→pause transition, then quiet until the user does something.
      */
     private fun tickWhilePlaying(stateFlow: Flow<PlaybackState>): Flow<Long> =
         stateFlow
             .map { it.isPlaying }
             .distinctUntilChanged()
             .flatMapLatest { playing ->
-                if (!playing) flowOf(System.currentTimeMillis())
-                else flow {
+                if (playing) flow {
                     emit(System.currentTimeMillis())
                     while (true) {
                         kotlinx.coroutines.delay(250L)
                         emit(System.currentTimeMillis())
                     }
-                }
+                } else stateFlow.map { System.currentTimeMillis() }
             }
 
     private fun PlaybackState.toUi(nowMs: Long): UiPlaybackState {

--- a/app/src/main/kotlin/in/jphe/storyvox/di/AppBindings.kt
+++ b/app/src/main/kotlin/in/jphe/storyvox/di/AppBindings.kt
@@ -457,13 +457,29 @@ private class RealPlaybackControllerUi(
     private var anchorCharOffset: Int = 0
     private var anchorWallMs: Long = 0L
 
-    private fun tickWhilePlaying(stateFlow: Flow<PlaybackState>): Flow<Long> = flow {
-        emit(System.currentTimeMillis())
-        while (true) {
-            kotlinx.coroutines.delay(250L)
-            emit(System.currentTimeMillis())
-        }
-    }
+    /**
+     * Wall-clock ticker driving the position-interpolation between sentence
+     * boundaries. Gated by `isPlaying`: when paused the upstream state alone
+     * carries enough information for the UI to render a still scrubber, so
+     * we stop allocating UiPlaybackState 4×/sec for screens that are merely
+     * open and idle (e.g. user paused on the reader, walked away). Resuming
+     * playback emits an immediate tick so the slider snaps forward without
+     * waiting up to 250 ms for the first delay window.
+     */
+    private fun tickWhilePlaying(stateFlow: Flow<PlaybackState>): Flow<Long> =
+        stateFlow
+            .map { it.isPlaying }
+            .distinctUntilChanged()
+            .flatMapLatest { playing ->
+                if (!playing) flowOf(System.currentTimeMillis())
+                else flow {
+                    emit(System.currentTimeMillis())
+                    while (true) {
+                        kotlinx.coroutines.delay(250L)
+                        emit(System.currentTimeMillis())
+                    }
+                }
+            }
 
     private fun PlaybackState.toUi(nowMs: Long): UiPlaybackState {
         val charsPerSec = SPEED_BASELINE_CHARS_PER_SECOND * speed


### PR DESCRIPTION
## Summary

`tickWhilePlaying` in `RealPlaybackControllerUi` was a misnomer: it emitted every 250 ms **unconditionally**, regardless of whether playback was running. Combined with the unshared `state` flow that `ReaderViewModel` collects for the lifetime of the reader screen, a paused-and-idle reader screen kept allocating a fresh `UiPlaybackState` (15 fields) 4×/sec forever.

This PR gates the ticker on `state.isPlaying` (distinct-until-changed). When paused, the ticker emits one final value and parks. Resume re-arms it with an immediate emission so the scrubber snaps forward without waiting on the first 250 ms delay window.

## Measurable win

| | Before | After |
|---|---|---|
| `UiPlaybackState` allocations per second while reader is open & paused | 4 | 0 |
| `combine` fires per second while paused | 4 | 0 |
| `stateIn`/Compose equality checks downstream | 4/sec while paused | 0/sec |

For a 30-minute paused session (user opened reader, paused to think, walked away):
- before: ~7,200 allocations + recomposition triggers
- after: ~1 (the transition from playing → paused), then quiet

This compounds with PR #18 (LIMIT 1 on continue-listening) and reduces background load whenever the reader screen is alive.

## Why this is safe

- `combine` requires every source to have emitted at least once; we still emit a single tick on the playing→paused transition so combine doesn't stall.
- `PlaybackState.toUi(nowMs)` only reads `nowMs` when `isPlaying && !warmingUp` (line 485 in `AppBindings.kt`). When paused, `nowMs` is unused — so a stale tick value during pause is fine.
- `controller.state` continues to emit (e.g. sleep timer countdown, sentence-range updates if any sneak through during pause). Those re-emissions fan out through combine using the most recent (cached) tick, with no re-tick allocation.

## Verification

- [x] `./gradlew :app:assembleDebug` — green
- [x] `./gradlew :app:installDebug` on tablet (`R83W80CAFZB`) — installed
- [x] No DAO/schema changes
- [x] No public API surface changes (`tickWhilePlaying` is private)

## Test plan

- [ ] Open Reader, hit play — slider advances smoothly
- [ ] Pause — slider freezes (already true)
- [ ] Resume from pause — slider picks up immediately, no >250 ms hesitation
- [ ] Skip / seek while paused — scrubber updates to new position (driven by `controller.state` emission, not the tick)
- [ ] Sleep timer starts → countdown chip ticks down (sleep timer is a `controller.state` source, separate from `tickWhilePlaying`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)