### PR TITLE
polish(fiction-detail): tighten Hero column rhythm and Synopsis breathing

### DIFF
--- a/feature/src/main/kotlin/in/jphe/storyvox/feature/fiction/FictionDetailScreen.kt
+++ b/feature/src/main/kotlin/in/jphe/storyvox/feature/fiction/FictionDetailScreen.kt
@@ -140,10 +140,13 @@ private fun Hero(fiction: UiFiction) {
             authorInitial = fiction.author.firstOrNull()?.uppercaseChar() ?: '?',
             modifier = Modifier.size(width = 120.dp, height = 180.dp),
         )
-        Column(modifier = Modifier.weight(1f)) {
+        Column(
+            modifier = Modifier.weight(1f),
+            verticalArrangement = Arrangement.spacedBy(spacing.xxs),
+        ) {
             Text(fiction.title, style = MaterialTheme.typography.headlineSmall, maxLines = 3)
             Text(fiction.author, style = MaterialTheme.typography.bodyMedium, color = MaterialTheme.colorScheme.onSurfaceVariant)
-            Spacer(Modifier.height(spacing.xs))
+            Spacer(Modifier.height(spacing.xxs))
             Row(verticalAlignment = Alignment.CenterVertically, horizontalArrangement = Arrangement.spacedBy(spacing.xxs)) {
                 Icon(Icons.Filled.Star, contentDescription = null, tint = MaterialTheme.colorScheme.primary, modifier = Modifier.size(16.dp))
                 Text("%.1f".format(fiction.rating), style = MaterialTheme.typography.labelMedium)
@@ -160,7 +163,10 @@ private fun Hero(fiction: UiFiction) {
 private fun Synopsis(text: String) {
     val spacing = LocalSpacing.current
     var expanded by remember { mutableStateOf(false) }
-    Column(modifier = Modifier.fillMaxWidth().padding(horizontal = spacing.md, vertical = spacing.xs)) {
+    Column(
+        modifier = Modifier.fillMaxWidth().padding(horizontal = spacing.md, vertical = spacing.sm),
+        verticalArrangement = Arrangement.spacedBy(spacing.xs),
+    ) {
         Text(
             text,
             style = MaterialTheme.typography.bodyMedium,


### PR DESCRIPTION
## Summary

Visual rhythm pass on `FictionDetailScreen` Hero + Synopsis. No token changes, no behavior changes — just enforces the `LocalSpacing` 4dp grid where the column had ad-hoc gaps.

**Hero column** previously had no `verticalArrangement` — title, author, and the rating/chapter/status meta row sat flush, with the meta row separated by a single `spacing.xs` Spacer. The hierarchy read as one undifferentiated text blob.

After:
- `Column(verticalArrangement = Arrangement.spacedBy(spacing.xxs))` between siblings (4dp).
- The separator Spacer drops from `xs` to `xxs`, so author → meta lands at exactly `xxs + xxs = xs` — one rhythm tier above title → author. Meta row gets visibly more breathing than the title/author pair.

**Synopsis** previously used `vertical = spacing.xs` (8dp) which mismatched Hero's surrounding `spacing.md`. The "Read more" `BrassButton(Text)` sat flush against the body paragraph.

After:
- Vertical padding raised to `spacing.sm` (12dp) to bridge Hero's md → Synopsis cadence smoothly.
- `Arrangement.spacedBy(spacing.xs)` between body text and the Read more button.

Verified against the same fiction (Sky Pride) on R83W80CAFZB. Compare:

| Before (`docs/screenshots/02-detail.png`) | After (this PR) |
|---|---|
| title flush against author flush against meta | clean rhythm: title → author (xxs) → meta (xs) |
| Read more button jammed against synopsis | Read more breathing on its own line |

## Test plan

- [x] `./gradlew :app:assembleDebug` — clean
- [x] Installed on R83W80CAFZB (Galaxy Tab A7 Lite, SM-T227U) and navigated to a fiction detail (Sky Pride)
- [x] Hero rhythm visually verified: title/author/meta now have measured cadence
- [x] Synopsis "Read more" no longer jammed against body
- [ ] Awaiting `copilot-pull-request-reviewer[bot]`

🤖 Generated with [Claude Code](https://claude.com/claude-code)