### PR TITLE
feat(motion): cascade reveal on Library + Browse grids

### DIFF
--- a/core-ui/src/main/kotlin/in/jphe/storyvox/ui/component/CascadeReveal.kt
+++ b/core-ui/src/main/kotlin/in/jphe/storyvox/ui/component/CascadeReveal.kt
@@ -1,0 +1,70 @@
+package `in`.jphe.storyvox.ui.component
+
+import androidx.compose.animation.core.Animatable
+import androidx.compose.animation.core.tween
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.composed
+import androidx.compose.ui.graphics.graphicsLayer
+import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.dp
+import `in`.jphe.storyvox.ui.theme.LocalMotion
+import kotlinx.coroutines.delay
+
+/**
+ * Library Nocturne cascade — fade + soft rise as items reveal.
+ *
+ * The animation runs once per `key`. Stagger by item index so a fresh grid
+ * pours in like candlelight catching pages, instead of all snapping at once.
+ *
+ * Pass [LocalMotion.current.standardDurationMs] (default 280ms) and the
+ * `standardEasing` curve from the theme — keep motion vocabulary consistent.
+ *
+ * @param index item index in the lazy list/grid; drives stagger timing
+ * @param key  identity for the entry animation; reset to re-play (e.g. on
+ *             search/filter change). Pass `Unit` to play once per composition
+ *             of this item.
+ * @param staggerMs delay between successive items, capped so off-screen items
+ *                  catch up quickly when scrolled into view
+ * @param riseFrom vertical offset items rise from
+ */
+fun Modifier.cascadeReveal(
+    index: Int,
+    key: Any = Unit,
+    staggerMs: Int = 28,
+    riseFrom: Dp = 10.dp,
+): Modifier = composed {
+    val motion = LocalMotion.current
+    val density = LocalDensity.current
+    val riseFromPx = with(density) { riseFrom.toPx() }
+
+    val alpha = remember(key) { Animatable(0f) }
+    val rise = remember(key) { Animatable(1f) }
+
+    // Modulo so paged-in items at index 32, 33, ... don't all wait the
+    // maximum delay; the cascade refreshes per visible page of ~12 items.
+    val cappedDelay = ((index.coerceAtLeast(0) % 12) * staggerMs).toLong()
+
+    LaunchedEffect(key) {
+        if (cappedDelay > 0) delay(cappedDelay)
+        alpha.animateTo(
+            targetValue = 1f,
+            animationSpec = tween(motion.standardDurationMs, easing = motion.standardEasing),
+        )
+    }
+    LaunchedEffect(key) {
+        if (cappedDelay > 0) delay(cappedDelay)
+        rise.animateTo(
+            targetValue = 0f,
+            animationSpec = tween(motion.standardDurationMs, easing = motion.standardEasing),
+        )
+    }
+
+    graphicsLayer {
+        this.alpha = alpha.value
+        this.translationY = rise.value * riseFromPx
+    }
+}

--- a/feature/src/main/kotlin/in/jphe/storyvox/feature/browse/BrowseScreen.kt
+++ b/feature/src/main/kotlin/in/jphe/storyvox/feature/browse/BrowseScreen.kt
@@ -15,6 +15,7 @@ import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.lazy.grid.GridCells
 import androidx.compose.foundation.lazy.grid.GridItemSpan
 import androidx.compose.foundation.lazy.grid.LazyVerticalGrid
+import androidx.compose.foundation.lazy.grid.itemsIndexed
 import androidx.compose.foundation.lazy.grid.items
 import androidx.compose.foundation.lazy.grid.rememberLazyGridState
 import androidx.compose.material.icons.Icons
@@ -48,6 +49,7 @@ import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import `in`.jphe.storyvox.feature.api.BrowseFilter
+import `in`.jphe.storyvox.ui.component.cascadeReveal
 import `in`.jphe.storyvox.ui.component.FictionCardSkeleton
 import `in`.jphe.storyvox.ui.component.FictionCoverThumb
 import `in`.jphe.storyvox.ui.theme.LocalSpacing
@@ -150,10 +152,12 @@ fun BrowseScreen(
                     horizontalArrangement = Arrangement.spacedBy(spacing.sm),
                     verticalArrangement = Arrangement.spacedBy(spacing.md),
                 ) {
-                    items(state.items, key = { it.id }) { fiction ->
+                    itemsIndexed(state.items, key = { _, item -> item.id }) { index, fiction ->
                         Column(
                             modifier = Modifier
                                 .fillMaxWidth()
+                                .animateItem()
+                                .cascadeReveal(index = index, key = fiction.id)
                                 .clickable { onOpenFiction(fiction.id) },
                             verticalArrangement = Arrangement.spacedBy(spacing.xs),
                         ) {

--- a/feature/src/main/kotlin/in/jphe/storyvox/feature/library/LibraryScreen.kt
+++ b/feature/src/main/kotlin/in/jphe/storyvox/feature/library/LibraryScreen.kt
@@ -13,7 +13,7 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.lazy.grid.GridCells
 import androidx.compose.foundation.lazy.grid.LazyVerticalGrid
-import androidx.compose.foundation.lazy.grid.items
+import androidx.compose.foundation.lazy.grid.itemsIndexed
 import androidx.compose.material3.Card
 import androidx.compose.material3.CardDefaults
 import androidx.compose.material3.LinearProgressIndicator
@@ -30,6 +30,7 @@ import `in`.jphe.storyvox.data.repository.ContinueListeningEntry
 import `in`.jphe.storyvox.ui.component.BrassButton
 import `in`.jphe.storyvox.ui.component.BrassButtonVariant
 import `in`.jphe.storyvox.ui.component.FictionCoverThumb
+import `in`.jphe.storyvox.ui.component.cascadeReveal
 import `in`.jphe.storyvox.ui.theme.LocalSpacing
 
 @Composable
@@ -66,9 +67,12 @@ fun LibraryScreen(
                     ResumeCard(resume, onResume = viewModel::resume)
                 }
             }
-            items(state.fictions, key = { it.id }) { fiction ->
+            itemsIndexed(state.fictions, key = { _, item -> item.id }) { index, fiction ->
                 Column(
-                    modifier = Modifier.fillMaxWidth(),
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .animateItem()
+                        .cascadeReveal(index = index, key = fiction.id),
                     horizontalAlignment = Alignment.Start,
                     verticalArrangement = Arrangement.spacedBy(spacing.xs),
                 ) {


### PR DESCRIPTION
## Summary

First pass of the storyvox motion language. Today the lazy grids on **Library** and **Browse** snap items in like a Material Design demo — abrupt, indifferent. This PR makes them pour in like candlelight catching pages: each cover fades in from alpha 0→1 and rises ~10dp, staggered by index so the grid arrives in a soft cascade instead of all at once.

The same callsites also gain `Modifier.animateItem()` so subsequent reorders (sort changes, filter applies, follows updates) glide rather than jump.

## The feel

- **Curve:** `LocalMotion.standardEasing` — the existing 0.4 / 0 / 0.2 / 1 cubic. Calm, deliberate, not bouncy.
- **Duration:** `LocalMotion.standardDurationMs` (280ms). Short enough not to feel laggy; long enough to register as motion rather than a flicker.
- **Stagger:** ~28ms per item, modulo 12, so paged-in arrivals from infinite scroll restage cleanly inside ~308ms instead of every page-50 item waiting the maximum delay.
- **Rise:** 10dp upward translation. Small enough to feel like settling, not arriving from off-screen.

## Files

- `core-ui/.../component/CascadeReveal.kt` — new `Modifier.cascadeReveal(index, key)` extension. Uses `Animatable` + `graphicsLayer`, no allocations per frame, replays only when `key` changes (so a fresh sort/filter triggers a fresh cascade).
- `feature/.../library/LibraryScreen.kt` — switch `items` to `itemsIndexed`, apply `.animateItem().cascadeReveal(index, fiction.id)` to each grid cell.
- `feature/.../browse/BrowseScreen.kt` — same treatment for the populated branch of the browse grid (skeleton grid stays unanimated; it has its own shimmer).

## Constraints honored (per Lumen brief)

- One animation surface per PR — only library/browse list reveals here. NavHost transitions, PlaybackSheet polish, and the spinner work follow in their own PRs (#12, #13, #14 in our task list).
- Vocabulary stays inside the existing `Motion.kt` theme tokens — no ad-hoc 'tween(150, FastOutLinearIn)' anywhere.
- Reduced-motion: open follow-up. The first version of `cascadeReveal` does not yet branch on `LocalAccessibilityManager`. I'd rather plumb a `Motion.respectReducedMotion: Boolean` token and apply it consistently across all upcoming animation surfaces (NavHost, sheet, spinner) than spot-fix it here. Filing as task #6 for Vesper's a11y pass to coordinate.
- `@Preview` annotations untouched. None of the touched composables had previews.

## Test plan

- [x] Build green: `:app:assembleDebug` against rebased `origin/main` (346e64a).
- [x] Installs cleanly on R83W80CAFZB over previous version.
- [x] No runtime errors — empty library + empty browse render without crash, no FATAL in logcat.
- [ ] **Visual confirmation deferred.** Tablet was in airplane mode during my pass so I never saw a populated grid in motion. Library was empty, Browse showed empty Popular tab with no skeleton retry. The cascade is gated behind `state.fictions.isNotEmpty()` / `state.items.isNotEmpty()` so empty-state is unaffected (verified). Whoever next runs this with network up should see the candlelight cascade on first Browse populate; please flag if the timing feels wrong.
- [ ] Coordinate with Vesper (#5 spacing audit) — both touch `LibraryScreen.kt` and `BrowseScreen.kt` cosmetically. My diff is import-only + one `Column.modifier =` chain change; should rebase cleanly under either order.

🤖 Generated with [Claude Code](https://claude.com/claude-code)