### PR TITLE
fix(playback): handle null PendingIntent on session activity build

### DIFF
--- a/core-playback/src/main/kotlin/in/jphe/storyvox/playback/StoryvoxPlaybackService.kt
+++ b/core-playback/src/main/kotlin/in/jphe/storyvox/playback/StoryvoxPlaybackService.kt
@@ -108,6 +108,12 @@ class StoryvoxPlaybackService : MediaSessionService() {
      * navigate straight to the reader for the playing chapter. With a null
      * fiction/chapter id (e.g. before playback starts) we still launch
      * MainActivity — the user lands on Library which is the right default.
+     *
+     * `TaskStackBuilder.getPendingIntent(...)` is documented as nullable on
+     * older platforms / under platform PendingIntent broker pressure. The
+     * previous `!!` would crash the foreground service on that path; we
+     * fall back to a flat `PendingIntent.getActivity` that exercises the
+     * simpler broker path before giving up.
      */
     private fun buildSessionActivity(fictionId: String?, chapterId: String?): PendingIntent {
         val launchIntent = Intent().apply {
@@ -121,12 +127,11 @@ class StoryvoxPlaybackService : MediaSessionService() {
         // FLAG_UPDATE_CURRENT so the new fictionId/chapterId actually overwrite
         // any previous intent extras (PendingIntent equality ignores extras by
         // default — without UPDATE_CURRENT we'd keep firing the original chapter).
+        val flags = PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_IMMUTABLE
         return TaskStackBuilder.create(this)
             .addNextIntent(launchIntent)
-            .getPendingIntent(
-                /* requestCode = */ 0,
-                PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_IMMUTABLE,
-            )!!
+            .getPendingIntent(/* requestCode = */ 0, flags)
+            ?: PendingIntent.getActivity(this, 0, launchIntent, flags)
     }
 
     /** Placeholder posted to satisfy Android's 5-sec foreground deadline.


### PR DESCRIPTION
## Summary

Found during a latent-bug sweep — no GitHub issue. \`TaskStackBuilder.getPendingIntent(...)\` is documented nullable and the previous \`!!\` would crash the foreground media service if the platform PendingIntent broker ever refused the request (resource pressure / older firmware quirks).

\`buildSessionActivity()\` is called from three hot paths in \`StoryvoxPlaybackService\`:

- \`MediaSession.Builder.setSessionActivity\` during \`onCreate\`.
- The chapter-change collector that refreshes the tap-target.
- The placeholder notification posted to satisfy Android's 5 s foreground deadline.

Any of those crashing tears down the playback service while music is playing.

## Fix

Fall back to a flat \`PendingIntent.getActivity\` (the simpler broker path) if \`TaskStackBuilder.getPendingIntent\` returns null. Same launch intent, same flags. The fallback loses the synthesized back-stack but keeps tap-to-MainActivity working — which is the only behavior the user actually sees from this PendingIntent.

## Test plan

- [ ] Build: \`./gradlew :core-playback:compileDebugKotlin\` (verified locally — clean).
- [ ] Manual on tablet: smoke-test playback notification taps still open the reader on the right chapter (happy path — fallback won't fire on a healthy device).
- [ ] No regression in lock-screen / Auto / Wear taps.

## Related

Sibling latent-bug findings tracked separately: PR #20 (cancel-aware downloads, awaiting Copilot fixup pass), PR #23 (auth cookie race, awaiting Copilot). Piper/Kokoro download cleanup-policy consistency still pending — will file as a separate PR or issue depending on team-lead's call.