### PR TITLE
polish(voice-library): use titleMedium for voice row display name

### DIFF
--- a/feature/src/main/kotlin/in/jphe/storyvox/feature/voicelibrary/VoiceLibraryScreen.kt
+++ b/feature/src/main/kotlin/in/jphe/storyvox/feature/voicelibrary/VoiceLibraryScreen.kt
@@ -260,7 +260,7 @@ private fun VoiceRow(
                     Row(verticalAlignment = Alignment.CenterVertically) {
                         Text(
                             voice.displayName,
-                            style = MaterialTheme.typography.bodyLarge,
+                            style = MaterialTheme.typography.titleMedium,
                             color = if (isAvailable && downloadingProgress == null) {
                                 MaterialTheme.colorScheme.onSurfaceVariant
                             } else MaterialTheme.colorScheme.onSurface,


### PR DESCRIPTION
## Summary

`VoiceRow` was rendering the voice's `displayName` with `MaterialTheme.typography.bodyLarge`. In the LibraryNocturne typography, `bodyLarge` is the **chapter reader style** — 18sp EB Garamond, 28sp lh, 0.2 letter-spacing — explicitly tuned for long-form prose.

Using it as a list-row title mixed serif into UI chrome and oversized the label relative to the `bodySmall` metadata line below it (`en_GB · 114 MB · High`).

Switched to `titleMedium` (16sp Inter SemiBold, 24sp lh, 0.15 letter-spacing) — the correct Material3 scale role for a list-row title, same UI font family as the row's metadata so the row reads as a tight pair.

No behavior changes, no token edits, no other roles touched.

## Test plan

- [x] `./gradlew :app:assembleDebug` — clean
- [x] Installed on R83W80CAFZB and verified Voice Library renders correctly: voice display names now sit at appropriate weight against their bodySmall metadata
- [x] Verified `bodyLarge` is still used at `SentenceHighlight.kt:79` (the chapter reader, where it belongs) — only one stray usage existed
- [ ] Awaiting `copilot-pull-request-reviewer[bot]`

🤖 Generated with [Claude Code](https://claude.com/claude-code)