### PR TITLE
test(core-playback): SleepTimer state machine + add coroutines-test

### DIFF
--- a/core-playback/build.gradle.kts
+++ b/core-playback/build.gradle.kts
@@ -87,5 +87,6 @@ dependencies {
     debugImplementation(libs.androidx.compose.ui.tooling)
 
     testImplementation(libs.junit)
+    testImplementation(libs.kotlinx.coroutines.test)
     androidTestImplementation(libs.androidx.junit)
 }

--- a/core-playback/src/main/kotlin/in/jphe/storyvox/playback/SleepTimer.kt
+++ b/core-playback/src/main/kotlin/in/jphe/storyvox/playback/SleepTimer.kt
@@ -1,5 +1,6 @@
 package `in`.jphe.storyvox.playback
 
+import androidx.annotation.VisibleForTesting
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
@@ -26,8 +27,17 @@ class SleepTimer @Inject constructor(
     private val volumeRamp: VolumeRamp,
     private val pauseAction: PauseAction,
 ) {
-    private val scope = CoroutineScope(SupervisorJob() + Dispatchers.Default)
+    private var scope: CoroutineScope = CoroutineScope(SupervisorJob() + Dispatchers.Default)
     private var job: Job? = null
+
+    @VisibleForTesting
+    internal constructor(
+        volumeRamp: VolumeRamp,
+        pauseAction: PauseAction,
+        scope: CoroutineScope,
+    ) : this(volumeRamp, pauseAction) {
+        this.scope = scope
+    }
 
     private val _remainingMs = MutableStateFlow<Long?>(null)
     val remainingMs: StateFlow<Long?> = _remainingMs.asStateFlow()

--- a/core-playback/src/test/kotlin/in/jphe/storyvox/playback/SleepTimerTest.kt
+++ b/core-playback/src/test/kotlin/in/jphe/storyvox/playback/SleepTimerTest.kt
@@ -1,0 +1,255 @@
+package `in`.jphe.storyvox.playback
+
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.advanceTimeBy
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.runCurrent
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class SleepTimerTest {
+
+    private class RecordingVolumeRamp : VolumeRamp {
+        val writes = mutableListOf<Float>()
+        override fun set(v: Float) {
+            writes += v
+        }
+    }
+
+    private class CountingPauseAction : SleepTimer.PauseAction {
+        var count: Int = 0
+            private set
+        override fun invoke() {
+            count++
+        }
+    }
+
+    @Test fun `remainingMs starts as null`() = runTest {
+        val ramp = RecordingVolumeRamp()
+        val pause = CountingPauseAction()
+        val timer = SleepTimer(ramp, pause, backgroundScope)
+        assertNull(timer.remainingMs.value)
+    }
+
+    @Test fun `Duration countdown publishes remainingMs at TICK_MS cadence`() = runTest {
+        val ramp = RecordingVolumeRamp()
+        val pause = CountingPauseAction()
+        val timer = SleepTimer(ramp, pause, backgroundScope)
+
+        timer.start(SleepTimerMode.Duration(minutes = 1)) // 60_000 ms total
+        runCurrent()
+        // First tick written before the first delay returns.
+        assertEquals(60_000L, timer.remainingMs.value)
+
+        advanceTimeBy(1_000L); runCurrent()
+        assertEquals(59_000L, timer.remainingMs.value)
+
+        advanceTimeBy(1_000L); runCurrent()
+        assertEquals(58_000L, timer.remainingMs.value)
+
+        // Stop the job so the test exits cleanly without simulating the full
+        // 50-second fade tail.
+        timer.cancel()
+    }
+
+    @Test fun `Duration countdown ends with fadeAndPause invoking pauseAction once`() = runTest {
+        val ramp = RecordingVolumeRamp()
+        val pause = CountingPauseAction()
+        val timer = SleepTimer(ramp, pause, backgroundScope)
+
+        timer.start(SleepTimerMode.Duration(minutes = 1))
+        runCurrent()
+        advanceTimeBy(70_000L) // 60s countdown + 10s fade tail
+        runCurrent()
+
+        assertEquals(1, pause.count)
+        assertNull(timer.remainingMs.value)
+    }
+
+    @Test fun `EndOfChapter waits for signalChapterEnd before fading`() = runTest {
+        val ramp = RecordingVolumeRamp()
+        val pause = CountingPauseAction()
+        val timer = SleepTimer(ramp, pause, backgroundScope)
+
+        timer.start(SleepTimerMode.EndOfChapter)
+        // Let the launched job park inside chapterEndSignal.first().
+        runCurrent()
+        // No chapter end yet — pauseAction must not have fired and time must
+        // not be advancing remainingMs.
+        assertEquals(0, pause.count)
+        assertNull(timer.remainingMs.value)
+
+        // Advance fake time arbitrarily; without a chapter signal nothing
+        // should happen.
+        advanceTimeBy(60_000L); runCurrent()
+        assertEquals(0, pause.count)
+
+        // Now signal chapter end and let the fade run.
+        timer.signalChapterEnd()
+        runCurrent()
+        advanceTimeBy(11_000L) // 10s fade tail + slack
+        runCurrent()
+
+        assertEquals(1, pause.count)
+        assertNull(timer.remainingMs.value)
+    }
+
+    @Test fun `fade ramps from 1f down to 0f across 100 steps`() = runTest {
+        val ramp = RecordingVolumeRamp()
+        val pause = CountingPauseAction()
+        val timer = SleepTimer(ramp, pause, backgroundScope)
+
+        timer.start(SleepTimerMode.EndOfChapter)
+        runCurrent()
+        timer.signalChapterEnd()
+        runCurrent()
+        advanceTimeBy(11_000L)
+        runCurrent()
+
+        // Fade writes by step index 0..100: values 100/100, 99/100, ..., 0/100.
+        // Then a final reset to 1.0f. 102 writes for the fade itself.
+        // start() called cancel() first which writes 1.0f, so the recorded
+        // sequence is [1.0 (cancel), 1.0 (step 0), 0.99, ..., 0.0 (step 100), 1.0 (reset)].
+        // Total writes = 1 + 101 + 1 = 103.
+        assertEquals(103, ramp.writes.size)
+        assertEquals(1.0f, ramp.writes.first(), 1e-6f) // cancel-as-restart from start()
+        assertEquals(1.0f, ramp.writes[1], 1e-6f)      // fade step 0
+        assertEquals(0.0f, ramp.writes[101], 1e-6f)    // fade step 100
+        assertEquals(1.0f, ramp.writes.last(), 1e-6f)  // post-pause reset
+
+        // Strictly monotonic non-increasing during the fade body
+        // (indices 1..101 in the recorded sequence).
+        for (i in 2..101) {
+            assertTrue(
+                "fade write index $i must be <= ${i - 1}",
+                ramp.writes[i] <= ramp.writes[i - 1],
+            )
+        }
+    }
+
+    @Test fun `fade publishes remainingMs counting down to 0 across 10 seconds`() = runTest {
+        val ramp = RecordingVolumeRamp()
+        val pause = CountingPauseAction()
+        val timer = SleepTimer(ramp, pause, backgroundScope)
+
+        timer.start(SleepTimerMode.EndOfChapter)
+        runCurrent()
+        timer.signalChapterEnd()
+        runCurrent()
+        // After signal received, fade writes its first remaining value
+        // (100 steps * 100ms = 10_000ms).
+        assertEquals(10_000L, timer.remainingMs.value)
+
+        advanceTimeBy(5_000L); runCurrent()
+        // Halfway through fade: should be ~5000ms remaining.
+        val mid = timer.remainingMs.value
+        assertNotNull(mid)
+        assertTrue("expected ~5000ms at halfway, got $mid", mid!! in 4_000L..6_000L)
+
+        advanceTimeBy(6_000L); runCurrent()
+        assertNull(timer.remainingMs.value)
+        assertEquals(1, pause.count)
+    }
+
+    @Test fun `cancel before any tick clears remainingMs and resets volume`() = runTest {
+        val ramp = RecordingVolumeRamp()
+        val pause = CountingPauseAction()
+        val timer = SleepTimer(ramp, pause, backgroundScope)
+
+        timer.start(SleepTimerMode.Duration(minutes = 5))
+        runCurrent()
+        assertEquals(300_000L, timer.remainingMs.value)
+
+        timer.cancel()
+        runCurrent()
+
+        assertNull(timer.remainingMs.value)
+        assertEquals(0, pause.count)
+        // cancel always resets ramp to 1.0f as its last act.
+        assertEquals(1.0f, ramp.writes.last(), 1e-6f)
+    }
+
+    @Test fun `cancel mid-fade prevents pauseAction and resets state`() = runTest {
+        val ramp = RecordingVolumeRamp()
+        val pause = CountingPauseAction()
+        val timer = SleepTimer(ramp, pause, backgroundScope)
+
+        timer.start(SleepTimerMode.EndOfChapter)
+        runCurrent()
+        timer.signalChapterEnd()
+        runCurrent()
+        // Step into the fade — past the first few writes but before completion.
+        advanceTimeBy(500L); runCurrent()
+        assertTrue(ramp.writes.isNotEmpty())
+
+        timer.cancel()
+        advanceTimeBy(11_000L); runCurrent()
+
+        assertEquals("cancel mid-fade must not invoke pauseAction", 0, pause.count)
+        assertNull(timer.remainingMs.value)
+        assertEquals(1.0f, ramp.writes.last(), 1e-6f)
+    }
+
+    @Test fun `cancel is idempotent when no timer is running`() = runTest {
+        val ramp = RecordingVolumeRamp()
+        val pause = CountingPauseAction()
+        val timer = SleepTimer(ramp, pause, backgroundScope)
+
+        // Multiple cancels with no active job must not throw and must not
+        // bring pauseAction.count above zero.
+        timer.cancel()
+        timer.cancel()
+        timer.cancel()
+        runCurrent()
+
+        assertEquals(0, pause.count)
+        assertNull(timer.remainingMs.value)
+        // Each cancel writes 1.0f to the ramp; that's a known and intentional
+        // side effect of the production code.
+        assertTrue(ramp.writes.all { it == 1.0f })
+        assertEquals(3, ramp.writes.size)
+    }
+
+    @Test fun `start cancels a previously running timer`() = runTest {
+        val ramp = RecordingVolumeRamp()
+        val pause = CountingPauseAction()
+        val timer = SleepTimer(ramp, pause, backgroundScope)
+
+        timer.start(SleepTimerMode.Duration(minutes = 5))
+        runCurrent()
+        assertEquals(300_000L, timer.remainingMs.value)
+
+        // Restart with a shorter duration. Per `start()`'s contract the prior
+        // job is cancelled before the new one is launched.
+        timer.start(SleepTimerMode.Duration(minutes = 1))
+        runCurrent()
+        assertEquals(60_000L, timer.remainingMs.value)
+
+        timer.cancel()
+    }
+
+    @Test fun `signalChapterEnd before EndOfChapter start does not auto-trigger`() = runTest {
+        val ramp = RecordingVolumeRamp()
+        val pause = CountingPauseAction()
+        val timer = SleepTimer(ramp, pause, backgroundScope)
+
+        // Fire signal first; chapterEndSignal has extraBufferCapacity=1 but
+        // SharedFlow does NOT replay to new subscribers, so the subsequent
+        // start(EndOfChapter) should NOT see this emission.
+        timer.signalChapterEnd()
+        runCurrent()
+
+        timer.start(SleepTimerMode.EndOfChapter)
+        runCurrent()
+        advanceTimeBy(60_000L); runCurrent()
+
+        // Signal was lost — pauseAction must not have fired.
+        assertEquals(0, pause.count)
+        timer.cancel()
+    }
+}

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -120,6 +120,7 @@ androidx-webkit = { module = "androidx.webkit:webkit", version.ref = "androidx-w
 kotlinx-coroutines-core = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-core", version.ref = "coroutines" }
 kotlinx-coroutines-android = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-android", version.ref = "coroutines" }
 kotlinx-coroutines-play-services = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-play-services", version.ref = "coroutines" }
+kotlinx-coroutines-test = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-test", version.ref = "coroutines" }
 kotlinx-serialization-json = { module = "org.jetbrains.kotlinx:kotlinx-serialization-json", version.ref = "kotlinx-serialization" }
 
 # Coil


### PR DESCRIPTION
## Summary

Adds 11 unit tests covering `SleepTimer`'s full state machine, plus the `kotlinx-coroutines-test` dependency that makes them possible. Suite runs in **0.3s** under virtual time.

## What's covered

- `remainingMs` starts `null`
- **Duration mode** countdown publishes `remainingMs` at 1s tick cadence
- **Duration mode** ends via `fadeAndPause` and invokes `pauseAction` exactly once
- **EndOfChapter mode** parks at `chapterEndSignal.first()` and does not progress until `signalChapterEnd()` is called
- Fade ramps volume from `1f` → `0f` across 100 steps, then resets to `1f` post-pause
- Fade publishes `remainingMs` counting down from `10_000ms` to `0`
- `cancel` before any tick clears state and resets volume
- `cancel` mid-fade prevents `pauseAction` and resets state
- `cancel` is idempotent on a stopped timer
- `start` cancels a previously running timer
- `signalChapterEnd` *before* `start(EndOfChapter)` does NOT auto-trigger — documents that `MutableSharedFlow(replay=0)` does not replay buffered emissions to new subscribers

## Production change for testability

Adds a `@VisibleForTesting internal` secondary constructor on `SleepTimer` that accepts a `CoroutineScope`. The Hilt-driven `@Inject` primary constructor is unchanged. Behavior in production is identical — only the internal `scope` field changes from `val` to `var` so the secondary ctor can swap it. Approved by team-lead in advance.

```kotlin
@VisibleForTesting
internal constructor(
    volumeRamp: VolumeRamp,
    pauseAction: PauseAction,
    scope: CoroutineScope,
) : this(volumeRamp, pauseAction) {
    this.scope = scope
}
```

This is what unlocks `runTest { SleepTimer(ramp, pause, backgroundScope) }` and lets virtual time replace the 60s + 10s of real `delay()` calls.

## New dependency

- `org.jetbrains.kotlinx:kotlinx-coroutines-test` — `testImplementation` only, version-aligned with the existing `kotlinx-coroutines-core 1.9.0`. Approved by team-lead.

## Notes for reviewers

- The full suite (chunker + ramp + scrubProgress + sleep timer) is now **37 tests**, all passing under both `testDebugUnitTest` and `testReleaseUnitTest`.
- Tests use `runCurrent()` + `advanceTimeBy(N)` patterns rather than `advanceUntilIdle()`, after observing that `advanceUntilIdle()` did not consistently drive `backgroundScope` work to completion on this kotlinx-coroutines-test 1.9.0 build. Explicit time advancement is more deterministic and matches the production behavior we're testing.
- The test that asserts `signalChapterEnd` *before* `start` is lost intentionally documents an existing race window — if a chapter ends in the millisecond before the user picks "Sleep at end of chapter", the timer will arm and never fire. Out of scope for this PR; flagging for a separate issue if anyone wants to fix it.

## Test plan

- [x] `./gradlew :core-playback:test` — green, both variants, 37 tests
- [ ] Copilot review — will not merge before review completes

🤖 Generated with [Claude Code](https://claude.com/claude-code)