### PR TITLE
perf(reader): build sentence-highlight without copying chapter body

### DIFF
--- a/core-ui/src/main/kotlin/in/jphe/storyvox/ui/component/SentenceHighlight.kt
+++ b/core-ui/src/main/kotlin/in/jphe/storyvox/ui/component/SentenceHighlight.kt
@@ -19,9 +19,7 @@ import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.text.AnnotatedString
 import androidx.compose.ui.text.SpanStyle
 import androidx.compose.ui.text.TextLayoutResult
-import androidx.compose.ui.text.buildAnnotatedString
 import androidx.compose.ui.text.font.FontWeight
-import androidx.compose.ui.text.withStyle
 import androidx.compose.ui.unit.dp
 import `in`.jphe.storyvox.ui.theme.LocalMotion
 
@@ -50,20 +48,35 @@ fun SentenceHighlight(
 
     var layout by remember { mutableStateOf<TextLayoutResult?>(null) }
 
-    val annotated: AnnotatedString = remember(text, highlightStart, highlightEnd, onSurface, brass) {
-        buildAnnotatedString {
-            if (highlightStart in 0..text.length && highlightEnd in highlightStart..text.length) {
-                if (highlightStart > 0) append(text.substring(0, highlightStart))
-                withStyle(
-                    SpanStyle(
-                        color = onSurface,
-                        fontWeight = FontWeight.Medium,
+    // Build the highlighted AnnotatedString without copying the chapter body.
+    // The previous shape was three `text.substring(...)` calls per sentence
+    // change (pre-highlight prefix, highlighted span, post-highlight tail) —
+    // that's two ~10-50KB allocations every ~3 s while playback runs, just
+    // to throw the substrings into a freshly built AnnotatedString.
+    //
+    // Instead, hold a single shared `AnnotatedString` over the full text
+    // (memoized by `text` alone — the chapter body changes only on chapter
+    // switch) and overlay the highlight span via the public AnnotatedString
+    // constructor's `spanStyles` list. That constructor takes the SpanStyle
+    // ranges by reference; no character copying happens on a sentence change.
+    val baseAnnotated: AnnotatedString = remember(text) { AnnotatedString(text) }
+    val annotated: AnnotatedString = remember(baseAnnotated, highlightStart, highlightEnd, onSurface) {
+        if (highlightEnd > highlightStart &&
+            highlightStart in 0..text.length &&
+            highlightEnd in highlightStart..text.length
+        ) {
+            AnnotatedString(
+                text = text,
+                spanStyles = listOf(
+                    AnnotatedString.Range(
+                        item = SpanStyle(color = onSurface, fontWeight = FontWeight.Medium),
+                        start = highlightStart,
+                        end = highlightEnd,
                     ),
-                ) { append(text.substring(highlightStart, highlightEnd)) }
-                if (highlightEnd < text.length) append(text.substring(highlightEnd))
-            } else {
-                append(text)
-            }
+                ),
+            )
+        } else {
+            baseAnnotated
         }
     }
 


### PR DESCRIPTION
## Summary

`SentenceHighlight` rebuilt its `AnnotatedString` on every sentence change by issuing **three `text.substring(...)` calls** (pre-highlight prefix, highlighted span, post-highlight tail) and feeding them into `buildAnnotatedString`'s append. For a typical chapter body of 10–50 KB at one sentence change every ~3 s during playback, this was ~10–50 KB of throwaway character copies *twice* (substring + builder append), repeated for the entire chapter playthrough.

This PR switches to:

- **One** `AnnotatedString(text)` over the full chapter body, memoized by `text` alone — built once per chapter switch and reused for every sentence advance.
- The highlighted variant uses the public `AnnotatedString(text, spanStyles)` constructor, which takes the `SpanStyle` ranges by reference. No character copying happens on a sentence change.

The render side (`drawBehind` underline animation) is untouched — the underline already drew from `TextLayoutResult` on the full text, and the font-weight bump for the active sentence flows through unchanged via the `SpanStyle` range.

## Measurable win

Per 10-minute chapter playthrough (~200 sentences), this collapses the per-sentence allocation profile:

| | Before | After |
|---|---|---|
| `text.substring(...)` calls per sentence change | 3 (each O(text length)) | 0 |
| `AnnotatedString` body-char copies per sentence change | 1 builder pass over the full text | 0 (`SpanStyle` range only) |
| Aggregate over a 200-sentence chapter | ~1200 multi-KB allocation events on the recomposition path | ~200 tiny `Range<SpanStyle>` allocations |

For a 50 KB chapter that's roughly ~30 MB of throwaway string allocations per chapter avoided, plus the GC pressure they generated during a hot UI path.

## Verification

- [x] `./gradlew :app:assembleDebug` — green
- [x] `./gradlew :app:installDebug` on tablet (`R83W80CAFZB`) — installed
- [x] No public API change (`SentenceHighlight` signature unchanged)
- [x] No theme/animation behavior change — `drawBehind` underline & `animateFloatAsState` are untouched
- [x] Coordinated with Lumen task #18 (sentence-highlight underline easing tune): they own animation params (`motion.sentenceDurationMs`, `motion.sentenceEasing`); this PR only touches the AnnotatedString construction. No file collision expected.

## Test plan

- [ ] Open a long chapter, hit play — current sentence is rendered with bold weight (the SpanStyle highlight)
- [ ] Sentence advance → highlight moves smoothly, underline animation still tweens
- [ ] Tap-to-seek still lands at the tapped word (`detectTapGestures` and the `getOffsetForPosition` path are unchanged)
- [ ] Chapter switch → new full-body `AnnotatedString` is rebuilt (memoized only by `text`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)