### PR TITLE
fix(browse): surface paginator fetch errors in BrowseUiState

### DIFF
--- a/feature/src/main/kotlin/in/jphe/storyvox/feature/browse/BrowseViewModel.kt
+++ b/feature/src/main/kotlin/in/jphe/storyvox/feature/browse/BrowseViewModel.kt
@@ -41,11 +41,17 @@ data class BrowseUiState(
     val isAppending: Boolean = false,
     /** False once the upstream returned `hasNext = false`. */
     val hasMore: Boolean = true,
+    /** Last fetch error from the paginator, if any. Cleared on the next
+     *  successful page. The screen surfaces this as an error state when
+     *  [items] is empty (no prior data to fall back on) and as a snackbar
+     *  / footer hint when [items] is non-empty (a tail-page failed but
+     *  earlier pages are still useful). */
+    val error: String? = null,
     val filter: BrowseFilter = BrowseFilter(),
     val isFilterActive: Boolean = false,
 )
 
-/** Typed view of a paginator's four state flows. Lifted into its own
+/** Typed view of a paginator's five state flows. Lifted into its own
  *  type so the outer `combine` doesn't need positional `vals[i]` casts —
  *  Copilot called the indexing form fragile and was right. */
 private data class PaginatorView(
@@ -53,6 +59,7 @@ private data class PaginatorView(
     val isLoading: Boolean,
     val isAppending: Boolean,
     val hasMore: Boolean,
+    val error: String?,
 )
 
 /**
@@ -114,12 +121,13 @@ class BrowseViewModel @Inject constructor(
                     isLoading = false,
                     isAppending = false,
                     hasMore = false,
+                    error = null,
                     filter = filter,
                     isFilterActive = filter.isActive(),
                 )
             }
         } else {
-            // Two-step combine: first collapse the paginator's four
+            // Two-step combine: first collapse the paginator's five
             // flows into a typed [PaginatorView], then merge with the
             // tab/query/filter trio. Keeps each combine within the
             // 5-arg comfort zone and avoids positional `vals[i]` casts.
@@ -128,8 +136,9 @@ class BrowseViewModel @Inject constructor(
                 p.isLoading,
                 p.isAppending,
                 p.hasMore,
-            ) { items, loading, appending, more ->
-                PaginatorView(items, loading, appending, more)
+                p.error,
+            ) { items, loading, appending, more, error ->
+                PaginatorView(items, loading, appending, more, error)
             }
             combine(paginatorView, _tab, _query, _filter) { view, tab, q, filter ->
                 BrowseUiState(
@@ -139,6 +148,7 @@ class BrowseViewModel @Inject constructor(
                     isLoading = view.isLoading,
                     isAppending = view.isAppending,
                     hasMore = view.hasMore,
+                    error = view.error,
                     filter = filter,
                     isFilterActive = filter.isActive(),
                 )


### PR DESCRIPTION
## Summary

Found by Vesper while auditing #8 empty/error/loading states. \`BrowsePaginator\` exposes a fifth flow — \`error: Flow<String?>\` — that captures the most recent fetch failure (Cloudflare challenge, rate limit, network blip, parser error). \`BrowseViewModel\` was combining only the first four flows (items / isLoading / isAppending / hasMore), silently dropping the error.

## User-visible consequence

When the first page of a tab fails to fetch, the user sees a blank grid forever:
- \`isLoading\` flips false (paginator's mutex releases).
- \`items\` stays empty (no successful page to populate from).
- No error message anywhere.

The paginator was already logging the failure to logcat (\`AppBindings.kt:267\`), but nothing surfaced to the UI.

## Fix

- Add \`error: String?\` to \`BrowseUiState\` (new field).
- Extend the private \`PaginatorView\` data class with the error field.
- Pull \`p.error\` into the inner combine (still 5-arg, the largest stable overload).
- Mirror the \`error = null\` slot in the empty-search/no-filter branch so the type lines up.

## Hand-off

This unblocks Vesper's polish PR for the Browse error-state UI. Recommendation in the commit body: full-screen error block when \`items.isEmpty()\` (no prior data to fall back on), snackbar / footer hint when \`items.isNotEmpty()\` (a tail-page failed but earlier pages are still useful). Vesper will pick the exact treatment.

## Test plan

- [ ] Build: \`./gradlew :feature:compileDebugKotlin\` (verified locally — clean).
- [ ] Manual on tablet: airplane-mode the tablet, switch to Browse → Popular tab. Pre-fix: blank grid forever. Post-fix: \`state.error\` carries the failure message; the screen will get a treatment in Vesper's follow-up PR.
- [ ] Tail-page failure preserves prior pages: scroll deep, airplane-mode, near-end trigger fires, prior items remain visible while \`error\` populates.