### PR TITLE
refactor(core-data): multi-source FictionSource via Hilt MapBinding

### DIFF
--- a/core-data/src/main/kotlin/in/jphe/storyvox/data/repository/AuthRepository.kt
+++ b/core-data/src/main/kotlin/in/jphe/storyvox/data/repository/AuthRepository.kt
@@ -53,12 +53,19 @@ interface AuthRepository {
 class AuthRepositoryImpl @Inject constructor(
     private val dao: AuthDao,
     private val prefs: SharedPreferences,
-    private val source: FictionSource,
+    private val sources: Map<String, @JvmSuppressWildcards FictionSource>,
 ) : AuthRepository {
 
     private val state = MutableStateFlow<SessionState>(SessionState.Anonymous)
     override val sessionState: StateFlow<SessionState> = state.asStateFlow()
 
+    // Auth is per-source. Today only one source binds a SessionHydrator
+    // (RoyalRoad), so we pin to the only bound FictionSource. When GitHub
+    // source lands with its own auth flow, this becomes a per-call lookup
+    // — the cookie store is already keyed `cookie:$sourceId` so the data
+    // layer doesn't need migration.
+    private val source: FictionSource = sources.values.singleOrNull()
+        ?: error("AuthRepository: expected exactly one FictionSource bound, got ${sources.keys}")
     private val sourceId: String get() = source.id
     private val cookieKey: String get() = "cookie:$sourceId"
 

--- a/core-data/src/main/kotlin/in/jphe/storyvox/data/repository/FictionRepository.kt
+++ b/core-data/src/main/kotlin/in/jphe/storyvox/data/repository/FictionRepository.kt
@@ -59,10 +59,25 @@ interface FictionRepository {
 
 @Singleton
 class FictionRepositoryImpl @Inject constructor(
-    private val source: FictionSource,
+    private val sources: Map<String, @JvmSuppressWildcards FictionSource>,
     private val fictionDao: FictionDao,
     private val chapterDao: ChapterDao,
 ) : FictionRepository {
+
+    /**
+     * Resolves a [FictionSource] by [sourceId]. When [sourceId] is null or
+     * not bound, falls back to the only source in the map — preserves
+     * single-source behaviour today and short-circuits the catalog calls
+     * (browse, search, genres) that don't yet have a per-source UX. Errors
+     * if multiple sources are bound and the key is missing/unknown — that's
+     * a programming bug we want to catch loudly when GitHub source lands.
+     */
+    private fun sourceFor(sourceId: String?): FictionSource =
+        sourceId?.let { sources[it] }
+            ?: sources.values.singleOrNull()
+            ?: error("No FictionSource for id=$sourceId; bound: ${sources.keys}")
+
+    private val source: FictionSource get() = sourceFor(null)
 
     override fun observeLibrary(): Flow<List<FictionSummary>> =
         fictionDao.observeLibrary().map { rows -> rows.map { it.toSummary() } }
@@ -101,7 +116,13 @@ class FictionRepositoryImpl @Inject constructor(
     override suspend fun genres(): FictionResult<List<String>> = source.genres()
 
     override suspend fun refreshDetail(id: String): FictionResult<Unit> = withContext(Dispatchers.IO) {
-        when (val result = source.fictionDetail(id)) {
+        // Look up the persisted row to route to the correct source. Falls
+        // back to the default source when the row is absent (first-add flow:
+        // addToLibrary → refreshDetail before the row exists). Future
+        // multi-source addByUrl pre-writes a stub row with sourceId so this
+        // path always finds it.
+        val src = sourceFor(fictionDao.get(id)?.sourceId)
+        when (val result = src.fictionDetail(id)) {
             is FictionResult.Success -> {
                 upsertDetail(result.value)
                 FictionResult.Success(Unit)
@@ -177,7 +198,8 @@ class FictionRepositoryImpl @Inject constructor(
 
     override suspend fun setFollowedRemote(id: String, followed: Boolean): FictionResult<Unit> =
         withContext(Dispatchers.IO) {
-            when (val r = source.setFollowed(id, followed)) {
+            val src = sourceFor(fictionDao.get(id)?.sourceId)
+            when (val r = src.setFollowed(id, followed)) {
                 is FictionResult.Success -> {
                     fictionDao.setFollowedRemote(id, followed)
                     FictionResult.Success(Unit)

--- a/core-data/src/main/kotlin/in/jphe/storyvox/data/work/ChapterDownloadWorker.kt
+++ b/core-data/src/main/kotlin/in/jphe/storyvox/data/work/ChapterDownloadWorker.kt
@@ -8,6 +8,7 @@ import androidx.work.WorkerParameters
 import dagger.assisted.Assisted
 import dagger.assisted.AssistedInject
 import `in`.jphe.storyvox.data.db.dao.ChapterDao
+import `in`.jphe.storyvox.data.db.dao.FictionDao
 import `in`.jphe.storyvox.data.db.entity.ChapterDownloadState
 import `in`.jphe.storyvox.data.repository.AuthRepository
 import `in`.jphe.storyvox.data.source.FictionSource
@@ -35,11 +36,17 @@ import java.security.MessageDigest
 class ChapterDownloadWorker @AssistedInject constructor(
     @Assisted appContext: Context,
     @Assisted params: WorkerParameters,
-    private val source: FictionSource,
+    private val sources: Map<String, @JvmSuppressWildcards FictionSource>,
     private val chapterDao: ChapterDao,
+    private val fictionDao: FictionDao,
     private val auth: AuthRepository,
     private val webView: WebViewFetcher? = null,
 ) : CoroutineWorker(appContext, params) {
+
+    private fun sourceFor(sourceId: String?): FictionSource =
+        sourceId?.let { sources[it] }
+            ?: sources.values.singleOrNull()
+            ?: error("No FictionSource for id=$sourceId; bound: ${sources.keys}")
 
     override suspend fun doWork(): Result {
         val fictionId = inputData.getString(KEY_FICTION_ID) ?: return Result.failure(
@@ -49,6 +56,7 @@ class ChapterDownloadWorker @AssistedInject constructor(
             Data.Builder().putString(KEY_RESULT, RESULT_BAD_INPUT).build(),
         )
         val now = System.currentTimeMillis()
+        val source = sourceFor(fictionDao.get(fictionId)?.sourceId)
 
         chapterDao.setDownloadState(chapterId, ChapterDownloadState.DOWNLOADING, now, null)
 

--- a/source-royalroad/src/main/kotlin/in/jphe/storyvox/source/royalroad/di/RoyalRoadModule.kt
+++ b/source-royalroad/src/main/kotlin/in/jphe/storyvox/source/royalroad/di/RoyalRoadModule.kt
@@ -12,6 +12,8 @@ import dagger.Module
 import dagger.Provides
 import dagger.hilt.InstallIn
 import dagger.hilt.components.SingletonComponent
+import dagger.multibindings.IntoMap
+import dagger.multibindings.StringKey
 import okhttp3.OkHttpClient
 import javax.inject.Qualifier
 import javax.inject.Singleton
@@ -50,6 +52,8 @@ internal abstract class RoyalRoadBindings {
 
     @Binds
     @Singleton
+    @IntoMap
+    @StringKey("royalroad")
     abstract fun bindFictionSource(impl: RoyalRoadSource): FictionSource
 
     @Binds


### PR DESCRIPTION
## Summary

Step 1 of the GitHub-source plan ([spec](docs/superpowers/specs/2026-05-06-github-source-design.md), lines 25-52, sequenced item 1 at line 254). **No user-visible change** — same code paths still call the same RoyalRoad source today; what's different is *how* the data layer resolves which source to call. This unblocks `:source-github` (step 3) without forcing it to land alongside data-layer churn.

## What changes

- `RoyalRoadModule` binding flips from a plain `@Binds FictionSource` to `@Binds @IntoMap @StringKey("royalroad")`, contributing into a `Map<String, FictionSource>` instead of being the lone bound `FictionSource`.
- `FictionRepositoryImpl`, `AuthRepositoryImpl`, and `ChapterDownloadWorker` inject `Map<String, @JvmSuppressWildcards FictionSource>` instead of a single `FictionSource`.
- A small `sourceFor(sourceId)` helper resolves a source by key, falling back to the only bound source when the key is null/unknown. Preserves single-source behaviour today and keeps catalog calls (browse, search, genres, refreshRemoteFollows) working without needing a per-source UX yet — that's a later step in the plan.
- Methods that already have a `fictionId` (`refreshDetail`, `setFollowedRemote`, `ChapterDownloadWorker.doWork`) look up the persisted Fiction row's `sourceId` and route through `sourceFor(sourceId)`. Falls back to the default when the row is absent (the first-add flow path: `addToLibrary` → `refreshDetail` runs before the row is written).
- `ChapterDownloadWorker` also gains a `FictionDao` injection for that lookup.
- `AuthRepository` pins to the single bound source on construction. Errors loudly if multiple sources are bound — auth is per-source and the multi-source auth UX is a separate, later piece. The cookie store is already keyed `cookie:\$sourceId`, so no migration needed.

## Why this is small + safe

- Net diff: 4 files, +46/-5. Zero functional change for users.
- `sourceId` is already on the Room `Fiction` entity (`Fiction.kt:23`) and `FictionSummary` (`FictionSummary.kt:11`), with an existing index on `(sourceId, lastUpdatedAt)`. Spec line 52 confirms this and the live code matches.
- The `sourceFor(null)` fallback to `sources.values.singleOrNull()` cleanly preserves single-source behaviour. When GitHub source actually binds, multi-source consumers without a `sourceId` will fail loudly via `error("No FictionSource for id=null; bound: …")` — exactly when we want to find them.
- Keeps `private val source: FictionSource get() = sourceFor(null)` as a transitional shim in `FictionRepositoryImpl` so the existing catalog call sites (six of them) didn't churn — they'll be revisited when step 7 adds the per-source Browse UX.

## Test plan

- [x] `:core-data:compileDebugKotlin` clean.
- [x] `:source-royalroad:compileDebugKotlin` clean.
- [x] `:app:assembleDebug` clean — Hilt aggregation (`hiltAggregateDepsDebug`, `hiltJavaCompileDebug`) verifies the multibinding map wires end-to-end.
- [x] `:core-playback:testDebugUnitTest` + `:core-data:testDebugUnitTest` pass.
- [x] Installed on R83W80CAFZB; app launches, no logcat errors.
- [ ] Smoke-test browse + open a fiction + start a chapter download in app (JP-task during next install cycle — verifies `sourceFor` row-lookup branches).