### PR TITLE
fix(fiction-detail): surface refresh-failure as state.error

### DIFF
--- a/app/src/main/kotlin/in/jphe/storyvox/di/AppBindings.kt
+++ b/app/src/main/kotlin/in/jphe/storyvox/di/AppBindings.kt
@@ -134,11 +134,28 @@ private class RealFictionRepositoryUi(
             list.map { UiFollow(fiction = toUiFiction(it), unreadCount = 0) }
         }
 
+    /** Per-id error tracker shared between [fictionById] and
+     *  [fictionLoadError] so the same first-subscription refresh result
+     *  surfaces in both flows. Singleton-scoped (this adapter is
+     *  @Singleton via Hilt), so the map and its entries live for the app
+     *  lifetime — fine for the small number of fictions a user opens. */
+    private val loadErrors = java.util.concurrent.ConcurrentHashMap<String, MutableStateFlow<String?>>()
+
+    private fun errorState(id: String): MutableStateFlow<String?> =
+        loadErrors.getOrPut(id) { MutableStateFlow(null) }
+
     override fun fictionById(id: String): Flow<UiFiction?> = flow {
-        // Kick off a refresh on first subscription; ignore failure (cached row may exist).
-        repo.refreshDetail(id)
+        // Kick off a refresh on first subscription. Failures are silently
+        // tolerated for the value flow (the cached row may exist) but
+        // captured in [errorState] so [fictionLoadError] can surface them.
+        when (val result = repo.refreshDetail(id)) {
+            is FictionResult.Success -> errorState(id).value = null
+            is FictionResult.Failure -> errorState(id).value = result.message
+        }
         emitAll(repo.observeFiction(id).map { detail -> detail?.summary?.let(::toUiFiction) })
     }
+
+    override fun fictionLoadError(id: String): Flow<String?> = errorState(id).asStateFlow()
 
     override fun chaptersFor(fictionId: String): Flow<List<UiChapter>> =
         repo.observeFiction(fictionId).map { detail ->

--- a/feature/src/main/kotlin/in/jphe/storyvox/feature/api/UiContracts.kt
+++ b/feature/src/main/kotlin/in/jphe/storyvox/feature/api/UiContracts.kt
@@ -44,6 +44,15 @@ interface FictionRepositoryUi {
     val library: Flow<List<UiFiction>>
     val follows: Flow<List<UiFollow>>
     fun fictionById(id: String): Flow<UiFiction?>
+    /**
+     * Mirrors [fictionById]'s underlying first-subscription refresh — emits
+     * the error message of the most recent `refreshDetail(id)` attempt, or
+     * null on success / not-yet-attempted. Lets screens distinguish
+     * "still loading" (fiction == null, error == null) from "refresh failed
+     * and we have no cache" (fiction == null, error != null). Cleared on
+     * the next successful refresh.
+     */
+    fun fictionLoadError(id: String): Flow<String?>
     fun chaptersFor(fictionId: String): Flow<List<UiChapter>>
     suspend fun setDownloadMode(fictionId: String, mode: DownloadMode)
     suspend fun follow(fictionId: String, follow: Boolean)

--- a/feature/src/main/kotlin/in/jphe/storyvox/feature/fiction/FictionDetailViewModel.kt
+++ b/feature/src/main/kotlin/in/jphe/storyvox/feature/fiction/FictionDetailViewModel.kt
@@ -26,6 +26,12 @@ data class FictionDetailUiState(
     val isInLibrary: Boolean = false,
     val downloadMode: DownloadMode = DownloadMode.Lazy,
     val isLoading: Boolean = true,
+    /** Set when the first-subscription `refreshDetail` failed and we have
+     *  no cached row to show. Cleared on the next successful refresh.
+     *  When [fiction] is non-null this is a tail/refresh error — the
+     *  screen should keep showing the cached data and surface the error
+     *  as a snackbar / banner rather than blocking the page. */
+    val error: String? = null,
 )
 
 sealed interface FictionDetailUiEvent {
@@ -50,12 +56,17 @@ class FictionDetailViewModel @Inject constructor(
         repo.fictionById(fictionId),
         repo.chaptersFor(fictionId),
         repo.library,
-    ) { fiction, chapters, library ->
+        repo.fictionLoadError(fictionId),
+    ) { fiction, chapters, library, error ->
         FictionDetailUiState(
             fiction = fiction,
             chapters = chapters,
             isInLibrary = library.any { it.id == fictionId },
-            isLoading = fiction == null,
+            // Stop showing the spinner once we either have a cached row
+            // OR the refresh has failed — otherwise a Cloudflare/network
+            // error leaves the user on a permanent spinner with no signal.
+            isLoading = fiction == null && error == null,
+            error = error,
         )
     }.stateIn(viewModelScope, SharingStarted.WhileSubscribed(5_000), FictionDetailUiState())
 


### PR DESCRIPTION
## Summary

Sibling to PR #33 (Browse error surfacing). Same blank-grid-forever bug, different screen.

\`FictionDetailViewModel.uiState\` derives \`isLoading = fiction == null\`. \`repo.fictionById(id)\` does a one-shot \`refreshDetail(id)\` on first subscription and silently swallows the result (\`AppBindings.kt:138\`). If the fiction isn't in the local Room cache **and** the refresh fails (Cloudflare challenge, rate limit, network blip, parser error), \`fiction\` stays null forever — and so does \`isLoading\`. The user sees a permanent spinner with no signal.

## Plumbing

- \`FictionRepositoryUi\` gains \`fictionLoadError(id): Flow<String?>\` — a parallel error flow that mirrors \`fictionById\`'s underlying refresh result. Cleared on the next successful refresh.
- \`RealFictionRepositoryUi\` keeps a per-id \`MutableStateFlow<String?>\` in a \`ConcurrentHashMap\` so the same first-subscription refresh result populates both flows. Singleton-scoped via Hilt — fine for the small number of fictions a user opens, no eviction needed.
- \`FictionDetailUiState\` gains \`error: String?\`.
- \`FictionDetailViewModel\` adds the error flow to its \`combine\` and flips \`isLoading = fiction == null && error == null\` so the spinner exits when **either** condition resolves.

## Three meaningful states

| fiction | error | meaning | screen treatment (Vesper's call) |
|--------:|------:|---------|-----------------------------------|
| null    | null  | initial fetch in flight | spinner |
| null    | set   | first-load failed, no cache | full-screen error block |
| set     | set   | tail/refresh error, cache OK | snackbar/banner over cached data |

## Test plan

- [ ] Build: \`./gradlew :feature:compileDebugKotlin :app:compileDebugKotlin\` (verified locally — clean).
- [ ] Manual on tablet: tap a fiction with no local row, airplane-mode mid-fetch. Pre-fix: permanent spinner. Post-fix: \`state.error\` populates, \`isLoading\` flips false, screen will show error treatment in Vesper's follow-up.
- [ ] Cached-row path: open a fiction that's already in the library, network-blip a refresh. \`fiction\` stays populated, \`error\` carries the message, no spinner regression.
- [ ] Successful retry clears the error: re-network, navigate away and back, error flips to null.

## Related

- Sibling: PR #33 — same theme for Browse.
- Vesper's polish PR for the actual error UI is unblocked once both #33 and this land.