### PR TITLE
polish(theme): fix light-mode scrim attenuation

### DIFF
--- a/core-ui/src/main/kotlin/in/jphe/storyvox/ui/theme/LibraryNocturneTheme.kt
+++ b/core-ui/src/main/kotlin/in/jphe/storyvox/ui/theme/LibraryNocturneTheme.kt
@@ -6,6 +6,7 @@ import androidx.compose.material3.darkColorScheme
 import androidx.compose.material3.lightColorScheme
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.ui.graphics.Color
 
 private val DarkColors = darkColorScheme(
     primary = BrassRamp.Brass500,
@@ -94,7 +95,10 @@ private val LightColors = lightColorScheme(
     errorContainer = StatusTokens.ErrorContainerLight,
     onErrorContainer = StatusTokens.OnErrorContainerLight,
 
-    scrim = SurfaceTokens.OnSurfaceDark,
+    // Scrim is the dim layer behind modals (ModalBottomSheet, dialogs).
+    // It needs to be DARK in light mode so the modal can attenuate the
+    // background; a near-cream value renders as "no perceptible dim".
+    scrim = Color.Black,
 )
 
 /**


### PR DESCRIPTION
## Summary

Light-mode `scrim` was set to `SurfaceTokens.OnSurfaceDark` (#E8DFD1) — the cream-on-dark foreground used by the dark scheme. The scrim is the dim layer M3 components draw behind modals (ModalBottomSheet, AlertDialog, etc.), so it must be a **dark** color to attenuate the background. A near-cream value over the cream paper-light surface yields no perceptible dim — modals appear to "float" with no visual hierarchy separating them from the page behind.

Fixed: light-mode scrim → `Color.Black` (M3 default). Dark-mode scrim is **left as-is** at `SurfaceTokens.SurfaceDark` since it works correctly and may be an intentional Library Nocturne tweak (faint near-black tint instead of pure black for the dim layer).

## Affected components

Existing modals that consume `MaterialTheme.colorScheme.scrim`:
- `VoiceLibraryScreen.DeleteConfirmDialog` (AlertDialog, triggered by long-pressing an installed voice)
- `BrowseFilterSheet` (ModalBottomSheet — uses `skipPartiallyExpanded = true`, so on tablets the sheet covers the viewport and the scrim region is mostly off-screen; on phones with half-expand it'd be visible)
- `AudiobookView.PlayerOptionsSheet` and sleep-timer dialog
- Any future modals automatically benefit

## Test plan

- [x] `./gradlew :app:assembleDebug` — clean
- [x] Installed on R83W80CAFZB. Walked Browse / voice library / voice picker in light mode — no regressions on non-modal surfaces.
- [ ] **Honest disclosure**: the currently-reachable modals on this device's tablet form-factor either fully cover the viewport (BrowseFilterSheet) or require provisioning state I didn't trigger (DeleteConfirmDialog needs a downloaded voice; PlayerOptionsSheet needs an active playback session). The fix is structurally correct against M3 spec — no near-cream value can dim a near-cream background — but I couldn't produce a clean before/after pixel diff for a half-expanded modal.
- [ ] Awaiting `copilot-pull-request-reviewer[bot]`

🤖 Generated with [Claude Code](https://claude.com/claude-code)