### PR TITLE
polish(brass-button): brass-tinted disabled colors

### DIFF
--- a/core-ui/src/main/kotlin/in/jphe/storyvox/ui/component/BrassButton.kt
+++ b/core-ui/src/main/kotlin/in/jphe/storyvox/ui/component/BrassButton.kt
@@ -26,14 +26,22 @@ fun BrassButton(
 ) {
     val padding = PaddingValues(horizontal = 24.dp, vertical = 12.dp)
     val sem = Modifier.semantics { role = Role.Button }
+    // Disabled colors stay in the brass family rather than falling through to
+    // M3's default `onSurface * 0.12 / 0.38`, which renders as cool grey and
+    // breaks the brass aesthetic during reachable disabled flows (e.g.,
+    // VoicePickerGate during voice download).
+    val brass = MaterialTheme.colorScheme.primary
+    val onBrass = MaterialTheme.colorScheme.onPrimary
     when (variant) {
         BrassButtonVariant.Primary -> Button(
             onClick = onClick,
             enabled = enabled,
             modifier = modifier.then(sem),
             colors = ButtonDefaults.buttonColors(
-                containerColor = MaterialTheme.colorScheme.primary,
-                contentColor = MaterialTheme.colorScheme.onPrimary,
+                containerColor = brass,
+                contentColor = onBrass,
+                disabledContainerColor = brass.copy(alpha = 0.12f),
+                disabledContentColor = onBrass.copy(alpha = 0.38f),
             ),
             shape = MaterialTheme.shapes.medium,
             contentPadding = padding,
@@ -44,7 +52,8 @@ fun BrassButton(
             enabled = enabled,
             modifier = modifier.then(sem),
             colors = ButtonDefaults.outlinedButtonColors(
-                contentColor = MaterialTheme.colorScheme.primary,
+                contentColor = brass,
+                disabledContentColor = brass.copy(alpha = 0.38f),
             ),
             shape = MaterialTheme.shapes.medium,
             contentPadding = padding,
@@ -55,7 +64,8 @@ fun BrassButton(
             enabled = enabled,
             modifier = modifier.then(sem),
             colors = ButtonDefaults.textButtonColors(
-                contentColor = MaterialTheme.colorScheme.primary,
+                contentColor = brass,
+                disabledContentColor = brass.copy(alpha = 0.38f),
             ),
             contentPadding = PaddingValues(horizontal = 12.dp, vertical = 8.dp),
         ) { Text(label, style = MaterialTheme.typography.labelLarge) }


### PR DESCRIPTION
## Summary

All three `BrassButton` variants (Primary, Secondary, Text) only set the enabled colors, so the disabled state fell through to M3 defaults (`onSurface * 0.12 / 0.38`) which renders as **cool grey**. In a brass-on-warm-dark theme that breaks the aesthetic at the moments the disabled state is actually reachable.

The reachable site that triggered this finding: `VoicePickerGate` during a voice download. The "More voices →" and "Continue without audio" Text-variant `BrassButton`s get `enabled = false` for the multi-second to multi-minute window while the model bundle downloads. Cool grey buttons in the middle of a brass gate read as a theme glitch.

## Fix

Pass explicit disabled colors using the same `primary` / `onPrimary` roles, faded by the M3-conventional alphas (0.38 for content, 0.12 for container). No public API change, no behavior change, no token edits.

```kotlin
disabledContainerColor = brass.copy(alpha = 0.12f),
disabledContentColor = onBrass.copy(alpha = 0.38f),
```

## Test plan

- [x] `./gradlew :app:assembleDebug` — clean
- [x] Installed on R83W80CAFZB
- [x] Triggered Aoede download (1 MB) on the voice picker gate to enter the disabled state
- [x] Confirmed brass continuity: "More voices →" and "Continue without audio" go from full-saturation brass (enabled) to faded brass (disabled, ~38% alpha) — same color family, dimmed
- [x] No regressions on enabled buttons (Library "In library" / "Listen", Settings primary buttons, etc.)
- [ ] Awaiting `copilot-pull-request-reviewer[bot]`

## Blast radius

`BrassButton` is foundational. The change is invisible at every call site that doesn't pass `enabled =` (i.e., everywhere except `VoicePickerGate`), and at sites that *do* set `enabled = false` it brings them into the brass family. Approved with team-lead before opening per the "ripples through every screen" rule for foundational components.

🤖 Generated with [Claude Code](https://claude.com/claude-code)