### PR TITLE
perf(core-data): slim chapter-info projection for FictionDetail/chapter list

### DIFF
--- a/core-data/src/main/kotlin/in/jphe/storyvox/data/db/dao/ChapterDao.kt
+++ b/core-data/src/main/kotlin/in/jphe/storyvox/data/db/dao/ChapterDao.kt
@@ -10,8 +10,28 @@ import kotlinx.coroutines.flow.Flow
 @Dao
 interface ChapterDao {
 
-    @Query("SELECT * FROM chapter WHERE fictionId = :fictionId ORDER BY `index` ASC")
-    fun observeByFiction(fictionId: String): Flow<List<Chapter>>
+    /**
+     * Slim chapter-info feed for FictionDetail and the public chapter list.
+     *
+     * Both consumers ([FictionRepositoryImpl.observeFiction] and
+     * [ChapterRepositoryImpl.observeChaptersFor]) immediately map the rows
+     * through [Chapter.toInfo], discarding the multi-MB `htmlBody` /
+     * `plainBody` blobs. By projecting only the `ChapterInfo` columns at
+     * the SQL level we avoid reading those text columns off disk on every
+     * emission. Each emission already fires whenever any single chapter
+     * row changes (downloadState flip during a queued download, body
+     * write on completion, userMarkedRead toggle) — for a fiction with
+     * 500+ chapters that's a lot of throwaway body bytes.
+     */
+    @Query(
+        """
+        SELECT id, sourceChapterId, `index`, title, publishedAt, wordCount
+          FROM chapter
+         WHERE fictionId = :fictionId
+         ORDER BY `index` ASC
+        """,
+    )
+    fun observeChapterInfosByFiction(fictionId: String): Flow<List<ChapterInfoRow>>
 
     @Query("SELECT * FROM chapter WHERE id = :id")
     fun observe(id: String): Flow<Chapter?>
@@ -159,6 +179,21 @@ interface ChapterDao {
 data class ChapterDownloadStateRow(
     val id: String,
     val downloadState: ChapterDownloadState,
+)
+
+/**
+ * Slim chapter-info row backing [ChapterDao.observeChapterInfosByFiction].
+ * Mirrors the [`in`.jphe.storyvox.data.source.model.ChapterInfo] field set
+ * directly so the repository mapper is a 1:1 copy and no body-text columns
+ * are ever read off disk for the FictionDetail / chapter-list feeds.
+ */
+data class ChapterInfoRow(
+    val id: String,
+    val sourceChapterId: String,
+    val index: Int,
+    val title: String,
+    val publishedAt: Long?,
+    val wordCount: Int?,
 )
 
 /** Joined chapter+fiction projection for the playback layer. */

--- a/core-data/src/main/kotlin/in/jphe/storyvox/data/repository/ChapterRepository.kt
+++ b/core-data/src/main/kotlin/in/jphe/storyvox/data/repository/ChapterRepository.kt
@@ -83,7 +83,7 @@ class ChapterRepositoryImpl @Inject constructor(
     private val workManager: WorkManager get() = WorkManager.getInstance(context)
 
     override fun observeChapters(fictionId: String): Flow<List<ChapterInfo>> =
-        dao.observeByFiction(fictionId).map { it.map(Chapter::toInfo) }
+        dao.observeChapterInfosByFiction(fictionId).map { rows -> rows.map(::toInfo) }
 
     override fun observeChapter(chapterId: String): Flow<ChapterContent?> =
         dao.observe(chapterId).map { row ->

--- a/core-data/src/main/kotlin/in/jphe/storyvox/data/repository/FictionRepository.kt
+++ b/core-data/src/main/kotlin/in/jphe/storyvox/data/repository/FictionRepository.kt
@@ -86,11 +86,11 @@ class FictionRepositoryImpl @Inject constructor(
         fictionDao.observeFollowsRemote().map { rows -> rows.map { it.toSummary() } }
 
     override fun observeFiction(id: String): Flow<FictionDetail?> =
-        fictionDao.observe(id).combine(chapterDao.observeByFiction(id)) { fiction, chapters ->
+        fictionDao.observe(id).combine(chapterDao.observeChapterInfosByFiction(id)) { fiction, chapters ->
             fiction?.let {
                 FictionDetail(
                     summary = it.toSummary(),
-                    chapters = chapters.map(Chapter::toInfo),
+                    chapters = chapters.map(::toInfo),
                     genres = it.genres,
                     wordCount = it.wordCount,
                     views = it.views,
@@ -315,4 +315,13 @@ internal fun Chapter.toInfo(): ChapterInfo = ChapterInfo(
     title = title,
     publishedAt = publishedAt,
     wordCount = wordCount,
+)
+
+internal fun toInfo(row: `in`.jphe.storyvox.data.db.dao.ChapterInfoRow): ChapterInfo = ChapterInfo(
+    id = row.id,
+    sourceChapterId = row.sourceChapterId,
+    index = row.index,
+    title = row.title,
+    publishedAt = row.publishedAt,
+    wordCount = row.wordCount,
 )


### PR DESCRIPTION
## Summary

Two consumers of the chapter-list flow were pulling `Flow<List<Chapter>>` rows that included the `htmlBody` and `plainBody` text columns, then immediately mapping through `Chapter.toInfo()` and discarding those blobs:

- `FictionRepository.observeFiction` — builds `FictionDetail.chapters` (table of contents)
- `ChapterRepository.observeChapters` — public `Flow<List<ChapterInfo>>`

Each emission fires whenever **any single chapter row changes**:

- download-state flip during a queued chapter download (one per chapter)
- `setBody` write on download completion (one heavy write per chapter)
- `setRead` toggle on user mark-as-read
- `trimDownloadedBodies` background sweep

For a fiction with 500+ chapters and an active eager-download in flight, the flow churns at every download tick, each emission carrying the entire fiction's chapter bodies (multi-MB total) only to throw the bodies away in the mapper.

## Fix

Replace `observeByFiction` with `observeChapterInfosByFiction` selecting **exactly the six `ChapterInfo` columns** (id, sourceChapterId, index, title, publishedAt, wordCount). Add a `ChapterInfoRow` POJO and a top-level `toInfo(ChapterInfoRow)` mapper so the repository projection is a 1:1 column copy. The original `observeByFiction` had no other callers; gone with it.

Same pattern landed in PR #18 for `observeContinueListening`'s `ContinueListeningRow`.

## Measurable win

Per chapter-row UPDATE during an active download (1× per chapter download tick, repeated for each of N queued chapters):

| | Before | After |
|---|---|---|
| Columns read off disk per chapter row | full `chapter` row including `htmlBody` + `plainBody` text blobs | 6 slim columns |
| Bytes per emission for a 500-chapter fiction with 200 downloaded | hundreds of MB (every downloaded body × 500 rows on every emission) | 500 × ~200 bytes ≈ 100 KB |

For an eager-download of 500 chapters, where each chapter completion fires one `setBody` UPDATE plus one `setDownloadState` UPDATE, this is the difference between re-emitting hundreds-of-MB worth of body bytes per tick and re-emitting ~100 KB of slim TOC rows.

## Verification

- [x] `./gradlew :app:assembleDebug` — green
- [x] `./gradlew :app:installDebug` on tablet (`R83W80CAFZB`) — installed
- [x] Verified generated `ChapterDao_Impl.java` SELECT list is exactly the six slim columns; no `htmlBody` / `plainBody` reads
- [x] Public surface (`ChapterInfo`, `FictionDetail.chapters`) unchanged
- [x] No DB migration needed (query change only)
- [x] Both call sites updated; original `observeByFiction` has no other consumers

## Test plan

- [ ] Open a fiction's detail screen — table of contents renders the same chapter list as before
- [ ] Start an eager download of a long fiction — chapter list refreshes in step with download progress, no UI regression
- [ ] Mark a chapter read → list refreshes, read state flips
- [ ] Verify reader / playback path is untouched (it goes through `dao.observe(chapterId)` and `dao.playbackChapter(id)`, both of which still pull full `Chapter` rows when actually needed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)