### PR TITLE
feat(library): paste-anything add-by-URL sheet (UrlRouter + brass FAB)

### DIFF
--- a/app/src/main/kotlin/in/jphe/storyvox/di/AppBindings.kt
+++ b/app/src/main/kotlin/in/jphe/storyvox/di/AppBindings.kt
@@ -31,7 +31,9 @@ import `in`.jphe.storyvox.feature.api.UiFictionStatus
 import `in`.jphe.storyvox.feature.api.UiFictionType
 import `in`.jphe.storyvox.feature.api.UiSearchOrder
 import `in`.jphe.storyvox.feature.api.UiSortDirection
+import `in`.jphe.storyvox.data.repository.AddByUrlResult
 import `in`.jphe.storyvox.feature.api.FictionRepositoryUi
+import `in`.jphe.storyvox.feature.api.UiAddByUrlResult
 import `in`.jphe.storyvox.feature.api.PlaybackControllerUi
 import `in`.jphe.storyvox.feature.api.SettingsRepositoryUi
 import `in`.jphe.storyvox.feature.api.UiChapter
@@ -189,6 +191,14 @@ private class RealFictionRepositoryUi(
         // which the UI treats as "stay with whatever's in the local DB".
         runCatching { repo.refreshRemoteFollows() }
     }
+
+    override suspend fun addByUrl(url: String): UiAddByUrlResult =
+        when (val r = repo.addByUrl(url)) {
+            is AddByUrlResult.Success -> UiAddByUrlResult.Success(r.fictionId)
+            AddByUrlResult.UnrecognizedUrl -> UiAddByUrlResult.UnrecognizedUrl
+            is AddByUrlResult.UnsupportedSource -> UiAddByUrlResult.UnsupportedSource(r.sourceId)
+            is AddByUrlResult.SourceFailure -> UiAddByUrlResult.Error(r.failure.message)
+        }
 }
 
 private fun DownloadMode.toData(): `in`.jphe.storyvox.data.db.entity.DownloadMode = when (this) {

--- a/core-data/src/main/kotlin/in/jphe/storyvox/data/repository/FictionRepository.kt
+++ b/core-data/src/main/kotlin/in/jphe/storyvox/data/repository/FictionRepository.kt
@@ -7,6 +7,7 @@ import `in`.jphe.storyvox.data.db.entity.ChapterDownloadState
 import `in`.jphe.storyvox.data.db.entity.DownloadMode
 import `in`.jphe.storyvox.data.db.entity.Fiction
 import `in`.jphe.storyvox.data.source.FictionSource
+import `in`.jphe.storyvox.data.source.UrlRouter
 import `in`.jphe.storyvox.data.source.model.ChapterInfo
 import `in`.jphe.storyvox.data.source.model.FictionDetail
 import `in`.jphe.storyvox.data.source.model.FictionResult
@@ -55,6 +56,33 @@ interface FictionRepository {
     suspend fun setPinnedVoice(id: String, voiceId: String?, locale: String?)
 
     suspend fun setFollowedRemote(id: String, followed: Boolean): FictionResult<Unit>
+
+    /**
+     * Resolve a pasted URL (or short form like `owner/repo`) to a fiction,
+     * persist a stub row, and refresh its detail. Returns the resolved
+     * `fictionId` on success so the UI can navigate to the detail screen.
+     *
+     * Recognised-but-unsupported sources (GitHub today) return
+     * [AddByUrlResult.UnsupportedSource] so the UI can surface a
+     * "coming soon" message without the user thinking they pasted
+     * something invalid.
+     */
+    suspend fun addByUrl(url: String): AddByUrlResult
+}
+
+/** Outcome of [FictionRepository.addByUrl]. */
+sealed class AddByUrlResult {
+    /** URL parsed, source supported, detail fetched + persisted. */
+    data class Success(val fictionId: String) : AddByUrlResult()
+
+    /** No source's URL pattern matched the input. */
+    data object UnrecognizedUrl : AddByUrlResult()
+
+    /** Pattern matched a known source that is wired but not yet implemented. */
+    data class UnsupportedSource(val sourceId: String) : AddByUrlResult()
+
+    /** Source-layer failure (network, 404, auth, rate limit, Cloudflare, ...). */
+    data class SourceFailure(val failure: FictionResult.Failure) : AddByUrlResult()
 }
 
 @Singleton
@@ -207,6 +235,39 @@ class FictionRepositoryImpl @Inject constructor(
                 is FictionResult.Failure -> r
             }
         }
+
+    override suspend fun addByUrl(url: String): AddByUrlResult = withContext(Dispatchers.IO) {
+        val match = UrlRouter.route(url) ?: return@withContext AddByUrlResult.UnrecognizedUrl
+        val src = sources[match.sourceId]
+            ?: return@withContext AddByUrlResult.UnsupportedSource(match.sourceId)
+
+        // Pre-write a stub row carrying sourceId so refreshDetail (and any
+        // subsequent setFollowedRemote / ChapterDownloadWorker) can route
+        // to the right source even before the detail fetch completes. The
+        // upsert only seeds fields we know from the URL; richer fields are
+        // filled in by upsertDetail on success.
+        val now = System.currentTimeMillis()
+        if (fictionDao.get(match.fictionId) == null) {
+            fictionDao.upsert(
+                Fiction(
+                    id = match.fictionId,
+                    sourceId = match.sourceId,
+                    title = "",
+                    author = "",
+                    firstSeenAt = now,
+                    metadataFetchedAt = now,
+                ),
+            )
+        }
+
+        when (val r = src.fictionDetail(match.fictionId)) {
+            is FictionResult.Success -> {
+                upsertDetail(r.value)
+                AddByUrlResult.Success(match.fictionId)
+            }
+            is FictionResult.Failure -> AddByUrlResult.SourceFailure(r)
+        }
+    }
 
     // ─── helpers ──────────────────────────────────────────────────────────
 

--- a/core-data/src/main/kotlin/in/jphe/storyvox/data/source/UrlRouter.kt
+++ b/core-data/src/main/kotlin/in/jphe/storyvox/data/source/UrlRouter.kt
@@ -1,0 +1,60 @@
+package `in`.jphe.storyvox.data.source
+
+/**
+ * Pure-JVM URL → (sourceId, fictionId) dispatcher used by the
+ * paste-anything add-fiction flow. Lives in :core-data so source modules
+ * stay leaves of the dependency graph; each pattern is owned here, not
+ * lifted from the source modules.
+ *
+ * Returns null when no pattern matches. Recognised-but-unsupported
+ * sources (GitHub today) still return a [Match] — the repository layer
+ * decides whether to honour or reject the routing.
+ */
+object UrlRouter {
+
+    private const val ROYALROAD = "royalroad"
+    private const val GITHUB = "github"
+
+    /** `https://www.royalroad.com/fiction/{id}` and `/fiction/{id}/.../chapter/...`. */
+    private val ROYALROAD_PATTERN = Regex(
+        """^https?://(?:www\.)?royalroad\.com/fiction/(\d+)(?:/.*)?$""",
+        RegexOption.IGNORE_CASE,
+    )
+
+    /** `https://github.com/{owner}/{repo}` and `/tree/{branch}` etc. */
+    private val GITHUB_HTTPS_PATTERN = Regex(
+        """^https?://github\.com/([\w.-]+)/([\w.-]+?)(?:\.git)?(?:/.*)?$""",
+        RegexOption.IGNORE_CASE,
+    )
+
+    /** Short form `github:owner/repo` or bare `owner/repo` (no scheme, no slashes elsewhere). */
+    private val GITHUB_SHORT_PATTERN = Regex(
+        """^(?:github:)?([\w.-]+)/([\w.-]+?)(?:\.git)?$""",
+    )
+
+    data class Match(val sourceId: String, val fictionId: String)
+
+    fun route(input: String): Match? {
+        val trimmed = input.trim()
+        if (trimmed.isEmpty()) return null
+
+        ROYALROAD_PATTERN.matchEntire(trimmed)?.let { m ->
+            return Match(ROYALROAD, m.groupValues[1])
+        }
+
+        GITHUB_HTTPS_PATTERN.matchEntire(trimmed)?.let { m ->
+            return Match(GITHUB, "$GITHUB:${m.groupValues[1].lowercase()}/${m.groupValues[2].lowercase()}")
+        }
+
+        // Reject ambiguous short form on URLs that look like a full path
+        // (anything containing `://` or more than one `/`). The short
+        // pattern only matches `owner/repo` cleanly.
+        if ("://" !in trimmed && trimmed.count { it == '/' } == 1) {
+            GITHUB_SHORT_PATTERN.matchEntire(trimmed)?.let { m ->
+                return Match(GITHUB, "$GITHUB:${m.groupValues[1].lowercase()}/${m.groupValues[2].lowercase()}")
+            }
+        }
+
+        return null
+    }
+}

--- a/core-data/src/test/kotlin/in/jphe/storyvox/data/source/UrlRouterTest.kt
+++ b/core-data/src/test/kotlin/in/jphe/storyvox/data/source/UrlRouterTest.kt
@@ -1,0 +1,110 @@
+package `in`.jphe.storyvox.data.source
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Test
+
+class UrlRouterTest {
+
+    // ── Royal Road ────────────────────────────────────────────────────────
+
+    @Test fun `royalroad fiction url routes to royalroad with numeric fictionId`() {
+        val m = UrlRouter.route("https://www.royalroad.com/fiction/12345")
+        assertEquals(UrlRouter.Match("royalroad", "12345"), m)
+    }
+
+    @Test fun `royalroad fiction url with slug after id is accepted`() {
+        val m = UrlRouter.route("https://www.royalroad.com/fiction/12345/my-fiction-slug")
+        assertEquals(UrlRouter.Match("royalroad", "12345"), m)
+    }
+
+    @Test fun `royalroad chapter url is accepted and resolves to fiction id`() {
+        val m = UrlRouter.route(
+            "https://www.royalroad.com/fiction/12345/my-fiction-slug/chapter/678/some-chapter",
+        )
+        assertEquals(UrlRouter.Match("royalroad", "12345"), m)
+    }
+
+    @Test fun `royalroad without www subdomain is accepted`() {
+        val m = UrlRouter.route("https://royalroad.com/fiction/99")
+        assertEquals(UrlRouter.Match("royalroad", "99"), m)
+    }
+
+    @Test fun `royalroad with http scheme is accepted`() {
+        val m = UrlRouter.route("http://www.royalroad.com/fiction/1")
+        assertEquals(UrlRouter.Match("royalroad", "1"), m)
+    }
+
+    @Test fun `mixed-case host is accepted`() {
+        val m = UrlRouter.route("https://www.RoyalRoad.com/fiction/42")
+        assertEquals(UrlRouter.Match("royalroad", "42"), m)
+    }
+
+    @Test fun `royalroad without numeric id is rejected`() {
+        assertNull(UrlRouter.route("https://www.royalroad.com/fiction/best"))
+    }
+
+    @Test fun `royalroad bare host is rejected`() {
+        assertNull(UrlRouter.route("https://www.royalroad.com"))
+    }
+
+    // ── GitHub ────────────────────────────────────────────────────────────
+
+    @Test fun `github https url routes to github with namespaced fictionId`() {
+        val m = UrlRouter.route("https://github.com/jphein/example-fiction")
+        assertEquals(UrlRouter.Match("github", "github:jphein/example-fiction"), m)
+    }
+
+    @Test fun `github tree branch url is accepted and resolves to repo`() {
+        val m = UrlRouter.route("https://github.com/jphein/example-fiction/tree/main")
+        assertEquals(UrlRouter.Match("github", "github:jphein/example-fiction"), m)
+    }
+
+    @Test fun `github dot-git suffix is stripped`() {
+        val m = UrlRouter.route("https://github.com/jphein/example-fiction.git")
+        assertEquals(UrlRouter.Match("github", "github:jphein/example-fiction"), m)
+    }
+
+    @Test fun `github short form with prefix routes to github`() {
+        val m = UrlRouter.route("github:jphein/example-fiction")
+        assertEquals(UrlRouter.Match("github", "github:jphein/example-fiction"), m)
+    }
+
+    @Test fun `github bare owner-slash-repo routes to github`() {
+        val m = UrlRouter.route("jphein/example-fiction")
+        assertEquals(UrlRouter.Match("github", "github:jphein/example-fiction"), m)
+    }
+
+    @Test fun `github case is normalised to lowercase`() {
+        val m = UrlRouter.route("https://github.com/JPHein/Example-Fiction")
+        assertEquals(UrlRouter.Match("github", "github:jphein/example-fiction"), m)
+    }
+
+    // ── Negative cases ────────────────────────────────────────────────────
+
+    @Test fun `empty input returns null`() {
+        assertNull(UrlRouter.route(""))
+    }
+
+    @Test fun `whitespace-only input returns null`() {
+        assertNull(UrlRouter.route("   "))
+    }
+
+    @Test fun `random url returns null`() {
+        assertNull(UrlRouter.route("https://example.com/some/path"))
+    }
+
+    @Test fun `unrelated short form returns null`() {
+        assertNull(UrlRouter.route("just some text"))
+    }
+
+    @Test fun `bare path with too many slashes is not mistaken for github short`() {
+        // Three slashes — not a valid `owner/repo` short form.
+        assertNull(UrlRouter.route("a/b/c"))
+    }
+
+    @Test fun `surrounding whitespace is trimmed before matching`() {
+        val m = UrlRouter.route("  https://www.royalroad.com/fiction/7  ")
+        assertEquals(UrlRouter.Match("royalroad", "7"), m)
+    }
+}

--- a/feature/src/main/kotlin/in/jphe/storyvox/feature/api/UiContracts.kt
+++ b/feature/src/main/kotlin/in/jphe/storyvox/feature/api/UiContracts.kt
@@ -40,6 +40,18 @@ data class UiFollow(
 
 enum class DownloadMode { Lazy, Eager, Subscribe }
 
+/** Outcome of pasting a URL into the add-fiction sheet. */
+sealed class UiAddByUrlResult {
+    /** Resolved + persisted; UI navigates to the detail screen. */
+    data class Success(val fictionId: String) : UiAddByUrlResult()
+    /** No source matched the input. */
+    data object UnrecognizedUrl : UiAddByUrlResult()
+    /** Recognised but not yet supported (GitHub today). */
+    data class UnsupportedSource(val sourceId: String) : UiAddByUrlResult()
+    /** Source-layer failure (network, 404, auth, rate-limit, ...). [message] is user-facing. */
+    data class Error(val message: String) : UiAddByUrlResult()
+}
+
 interface FictionRepositoryUi {
     val library: Flow<List<UiFiction>>
     val follows: Flow<List<UiFollow>>
@@ -63,6 +75,14 @@ interface FictionRepositoryUi {
      * `follows` Flow will emit when the DB is upserted.
      */
     suspend fun refreshFollows()
+
+    /**
+     * Resolve a pasted URL (or short form) to a fiction, persist it, and
+     * fetch detail. Implementation routes through `UrlRouter` + the
+     * multi-source map. Returns enough information for the sheet to
+     * navigate on success or surface a useful message on failure.
+     */
+    suspend fun addByUrl(url: String): UiAddByUrlResult
 }
 
 interface BrowseRepositoryUi {

--- a/feature/src/main/kotlin/in/jphe/storyvox/feature/library/AddByUrlSheet.kt
+++ b/feature/src/main/kotlin/in/jphe/storyvox/feature/library/AddByUrlSheet.kt
@@ -1,0 +1,139 @@
+package `in`.jphe.storyvox.feature.library
+
+import android.content.ClipboardManager
+import android.content.Context
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.text.KeyboardOptions
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.ModalBottomSheet
+import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.SheetState
+import androidx.compose.material3.Text
+import androidx.compose.material3.rememberModalBottomSheetState
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.text.input.ImeAction
+import androidx.compose.ui.text.input.KeyboardCapitalization
+import androidx.compose.ui.text.input.KeyboardType
+import `in`.jphe.storyvox.ui.component.BrassButton
+import `in`.jphe.storyvox.ui.component.BrassButtonVariant
+import `in`.jphe.storyvox.ui.theme.LocalSpacing
+
+/**
+ * Paste-anything sheet for adding a fiction by URL. Accepts Royal Road
+ * fiction URLs today, with the GitHub branch wired but stubbed at the
+ * data layer until step 3 of the GitHub-source plan lands.
+ *
+ * UX: input field auto-focused, "Paste" button reads the system
+ * clipboard (single-tap fill from a copied URL), Add button submits.
+ * The error string from the viewmodel surfaces inline below the field
+ * so the user can correct without losing what they typed.
+ */
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun AddByUrlSheet(
+    state: AddByUrlSheetState,
+    onSubmit: (String) -> Unit,
+    onDismiss: () -> Unit,
+) {
+    if (state === AddByUrlSheetState.Hidden) return
+
+    val sheetState: SheetState = rememberModalBottomSheetState(skipPartiallyExpanded = true)
+    val spacing = LocalSpacing.current
+    val context = LocalContext.current
+    var input by remember { mutableStateOf("") }
+
+    val error: String? = (state as? AddByUrlSheetState.Open)?.error
+    val isSubmitting = state === AddByUrlSheetState.Submitting
+
+    ModalBottomSheet(
+        onDismissRequest = { if (!isSubmitting) onDismiss() },
+        sheetState = sheetState,
+    ) {
+        Column(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(horizontal = spacing.md)
+                .padding(bottom = spacing.xl),
+            verticalArrangement = Arrangement.spacedBy(spacing.sm),
+        ) {
+            Text(
+                "Add by URL",
+                style = MaterialTheme.typography.titleLarge,
+                modifier = Modifier.padding(top = spacing.sm),
+            )
+            Text(
+                "Paste a Royal Road fiction or chapter URL.",
+                style = MaterialTheme.typography.bodyMedium,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
+
+            OutlinedTextField(
+                value = input,
+                onValueChange = { input = it },
+                label = { Text("URL") },
+                placeholder = { Text("https://www.royalroad.com/fiction/…") },
+                isError = error != null,
+                singleLine = true,
+                enabled = !isSubmitting,
+                keyboardOptions = KeyboardOptions(
+                    keyboardType = KeyboardType.Uri,
+                    imeAction = ImeAction.Done,
+                    capitalization = KeyboardCapitalization.None,
+                    autoCorrectEnabled = false,
+                ),
+                modifier = Modifier.fillMaxWidth(),
+            )
+
+            if (error != null) {
+                Text(
+                    error,
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.error,
+                )
+            }
+
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                horizontalArrangement = Arrangement.spacedBy(spacing.sm),
+                verticalAlignment = Alignment.CenterVertically,
+            ) {
+                BrassButton(
+                    label = "Paste",
+                    onClick = {
+                        readClipboardText(context)?.let { clip ->
+                            if (clip.isNotBlank()) input = clip
+                        }
+                    },
+                    variant = BrassButtonVariant.Secondary,
+                    enabled = !isSubmitting,
+                )
+                BrassButton(
+                    label = if (isSubmitting) "Adding…" else "Add",
+                    onClick = { onSubmit(input.trim()) },
+                    variant = BrassButtonVariant.Primary,
+                    enabled = !isSubmitting && input.isNotBlank(),
+                )
+            }
+        }
+    }
+}
+
+private fun readClipboardText(context: Context): String? {
+    val cm = context.getSystemService(Context.CLIPBOARD_SERVICE) as? ClipboardManager
+        ?: return null
+    val clip = cm.primaryClip ?: return null
+    if (clip.itemCount == 0) return null
+    return clip.getItemAt(0)?.text?.toString()
+}

--- a/feature/src/main/kotlin/in/jphe/storyvox/feature/library/LibraryScreen.kt
+++ b/feature/src/main/kotlin/in/jphe/storyvox/feature/library/LibraryScreen.kt
@@ -14,10 +14,15 @@ import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.lazy.grid.GridCells
 import androidx.compose.foundation.lazy.grid.LazyVerticalGrid
 import androidx.compose.foundation.lazy.grid.itemsIndexed
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Add
 import androidx.compose.material3.Card
 import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.FloatingActionButton
+import androidx.compose.material3.Icon
 import androidx.compose.material3.LinearProgressIndicator
 import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
@@ -40,6 +45,7 @@ fun LibraryScreen(
     viewModel: LibraryViewModel = hiltViewModel(),
 ) {
     val state by viewModel.uiState.collectAsStateWithLifecycle()
+    val addByUrlState by viewModel.addByUrlState.collectAsStateWithLifecycle()
     val spacing = LocalSpacing.current
 
     androidx.compose.runtime.LaunchedEffect(viewModel) {
@@ -51,56 +57,74 @@ fun LibraryScreen(
         }
     }
 
-    Box(modifier = Modifier.fillMaxSize().padding(top = spacing.md)) {
-        if (!state.isLoading && state.fictions.isEmpty() && state.resume == null) {
-            EmptyLibrary()
-            return@Box
-        }
-        LazyVerticalGrid(
-            columns = GridCells.Adaptive(minSize = 140.dp),
-            contentPadding = PaddingValues(spacing.md),
-            horizontalArrangement = Arrangement.spacedBy(spacing.sm),
-            verticalArrangement = Arrangement.spacedBy(spacing.md),
-        ) {
-            state.resume?.let { resume ->
-                item(span = { androidx.compose.foundation.lazy.grid.GridItemSpan(maxLineSpan) }) {
-                    ResumeCard(resume, onResume = viewModel::resume)
-                }
+    Scaffold(
+        floatingActionButton = {
+            FloatingActionButton(
+                onClick = viewModel::showAddByUrl,
+                containerColor = MaterialTheme.colorScheme.primary,
+                contentColor = MaterialTheme.colorScheme.onPrimary,
+            ) {
+                Icon(Icons.Filled.Add, contentDescription = "Add fiction by URL")
             }
-            itemsIndexed(state.fictions, key = { _, item -> item.id }) { index, fiction ->
-                Column(
-                    modifier = Modifier
-                        .fillMaxWidth()
-                        .animateItem()
-                        .cascadeReveal(index = index, key = fiction.id),
-                    horizontalAlignment = Alignment.Start,
-                    verticalArrangement = Arrangement.spacedBy(spacing.xs),
+        },
+    ) { scaffoldPadding ->
+        Box(modifier = Modifier.fillMaxSize().padding(scaffoldPadding).padding(top = spacing.md)) {
+            if (!state.isLoading && state.fictions.isEmpty() && state.resume == null) {
+                EmptyLibrary()
+            } else {
+                LazyVerticalGrid(
+                    columns = GridCells.Adaptive(minSize = 140.dp),
+                    contentPadding = PaddingValues(spacing.md),
+                    horizontalArrangement = Arrangement.spacedBy(spacing.sm),
+                    verticalArrangement = Arrangement.spacedBy(spacing.md),
                 ) {
-                    FictionCoverThumb(
-                        coverUrl = fiction.coverUrl,
-                        title = fiction.title,
-                        authorInitial = fiction.author.firstOrNull()?.uppercaseChar() ?: '?',
-                        modifier = Modifier
-                            .fillMaxWidth()
-                            .clickable { viewModel.openFiction(fiction.id) },
-                    )
-                    Text(
-                        fiction.title,
-                        style = MaterialTheme.typography.titleSmall,
-                        maxLines = 2,
-                    )
-                    if (fiction.author.isNotBlank()) {
-                        Text(
-                            fiction.author,
-                            style = MaterialTheme.typography.bodySmall,
-                            color = MaterialTheme.colorScheme.onSurfaceVariant,
-                            maxLines = 1,
-                        )
+                    state.resume?.let { resume ->
+                        item(span = { androidx.compose.foundation.lazy.grid.GridItemSpan(maxLineSpan) }) {
+                            ResumeCard(resume, onResume = viewModel::resume)
+                        }
+                    }
+                    itemsIndexed(state.fictions, key = { _, item -> item.id }) { index, fiction ->
+                        Column(
+                            modifier = Modifier
+                                .fillMaxWidth()
+                                .animateItem()
+                                .cascadeReveal(index = index, key = fiction.id),
+                            horizontalAlignment = Alignment.Start,
+                            verticalArrangement = Arrangement.spacedBy(spacing.xs),
+                        ) {
+                            FictionCoverThumb(
+                                coverUrl = fiction.coverUrl,
+                                title = fiction.title,
+                                authorInitial = fiction.author.firstOrNull()?.uppercaseChar() ?: '?',
+                                modifier = Modifier
+                                    .fillMaxWidth()
+                                    .clickable { viewModel.openFiction(fiction.id) },
+                            )
+                            Text(
+                                fiction.title,
+                                style = MaterialTheme.typography.titleSmall,
+                                maxLines = 2,
+                            )
+                            if (fiction.author.isNotBlank()) {
+                                Text(
+                                    fiction.author,
+                                    style = MaterialTheme.typography.bodySmall,
+                                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                                    maxLines = 1,
+                                )
+                            }
+                        }
                     }
                 }
             }
         }
     }
+
+    AddByUrlSheet(
+        state = addByUrlState,
+        onSubmit = viewModel::submitAddByUrl,
+        onDismiss = viewModel::dismissAddByUrl,
+    )
 }
 
 @Composable

--- a/feature/src/main/kotlin/in/jphe/storyvox/feature/library/LibraryViewModel.kt
+++ b/feature/src/main/kotlin/in/jphe/storyvox/feature/library/LibraryViewModel.kt
@@ -11,10 +11,13 @@ import `in`.jphe.storyvox.data.source.model.FictionSummary
 import `in`.jphe.storyvox.feature.api.DownloadMode
 import `in`.jphe.storyvox.feature.api.FictionRepositoryUi
 import `in`.jphe.storyvox.feature.api.PlaybackControllerUi
+import `in`.jphe.storyvox.feature.api.UiAddByUrlResult
 import javax.inject.Inject
 import kotlinx.coroutines.channels.Channel
+import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.receiveAsFlow
 import kotlinx.coroutines.flow.stateIn
@@ -33,6 +36,19 @@ sealed interface LibraryUiEvent {
     data class OpenReader(val fictionId: String, val chapterId: String) : LibraryUiEvent
 }
 
+/** State for the paste-URL bottom sheet. */
+@Immutable
+sealed interface AddByUrlSheetState {
+    /** Sheet hidden. */
+    data object Hidden : AddByUrlSheetState
+
+    /** Sheet shown, accepting input. [error] non-null after a failed submission. */
+    data class Open(val error: String? = null) : AddByUrlSheetState
+
+    /** Submission in flight (network call to the source). */
+    data object Submitting : AddByUrlSheetState
+}
+
 @HiltViewModel
 class LibraryViewModel @Inject constructor(
     fictionRepo: FictionRepository,
@@ -43,6 +59,9 @@ class LibraryViewModel @Inject constructor(
 
     private val _events = Channel<LibraryUiEvent>(Channel.BUFFERED)
     val events = _events.receiveAsFlow()
+
+    private val _addByUrlState = MutableStateFlow<AddByUrlSheetState>(AddByUrlSheetState.Hidden)
+    val addByUrlState: StateFlow<AddByUrlSheetState> = _addByUrlState.asStateFlow()
 
     val uiState: StateFlow<LibraryUiState> = combine(
         fictionRepo.observeLibrary(),
@@ -72,5 +91,41 @@ class LibraryViewModel @Inject constructor(
 
     fun setDownloadMode(fictionId: String, mode: DownloadMode) {
         viewModelScope.launch { uiRepo.setDownloadMode(fictionId, mode) }
+    }
+
+    fun showAddByUrl() {
+        _addByUrlState.value = AddByUrlSheetState.Open()
+    }
+
+    fun dismissAddByUrl() {
+        _addByUrlState.value = AddByUrlSheetState.Hidden
+    }
+
+    fun submitAddByUrl(url: String) {
+        if (_addByUrlState.value === AddByUrlSheetState.Submitting) return
+        _addByUrlState.value = AddByUrlSheetState.Submitting
+        viewModelScope.launch {
+            when (val result = uiRepo.addByUrl(url)) {
+                is UiAddByUrlResult.Success -> {
+                    _addByUrlState.value = AddByUrlSheetState.Hidden
+                    _events.send(LibraryUiEvent.OpenFiction(result.fictionId))
+                }
+                UiAddByUrlResult.UnrecognizedUrl -> {
+                    _addByUrlState.value = AddByUrlSheetState.Open(
+                        error = "That URL doesn't look like a Royal Road or GitHub address.",
+                    )
+                }
+                is UiAddByUrlResult.UnsupportedSource -> {
+                    _addByUrlState.value = AddByUrlSheetState.Open(
+                        error = "${result.sourceId.replaceFirstChar { it.uppercase() }} support is coming soon.",
+                    )
+                }
+                is UiAddByUrlResult.Error -> {
+                    _addByUrlState.value = AddByUrlSheetState.Open(
+                        error = result.message.ifBlank { "Could not load that fiction. Try again." },
+                    )
+                }
+            }
+        }
     }
 }


### PR DESCRIPTION
## Summary

Step 2 of the GitHub-source plan ([spec](docs/superpowers/specs/2026-05-06-github-source-design.md), sequenced item 2 at line 255). Ships as the *"visible win even before GitHub source exists"* — pasting a Royal Road URL into the new Library `+` FAB now adds the fiction directly, without having to navigate Browse and tap-through.

## What lands

**core-data**
- New `UrlRouter` (pure-JVM regex matcher). Returns `Pair<sourceId, fictionId>` for known URL shapes; null for garbage. 20 unit-test cases covering Royal Road happy path, `/chapter/...` suffix, slug suffix, GitHub https/short/bare forms, `.git` stripping, case folding, whitespace trim, negative cases.
- New `FictionRepository.addByUrl(url)` → sealed `AddByUrlResult` (`Success` / `UnrecognizedUrl` / `UnsupportedSource` / `SourceFailure`). **Pre-writes a stub Fiction row carrying `sourceId` before the detail fetch** — closes the "first-add fallback" comment left in #35's `refreshDetail`. Future multi-source flows (e.g. setFollowedRemote, ChapterDownloadWorker) now route correctly even on the first call after add.

**feature**
- New `UiAddByUrlResult` on the `FictionRepositoryUi` facade and a parallel `addByUrl` method. Sealed shape mirrors Calliope's `BrowseFetchError` / `FictionDetail` error-surfacing pattern from #33/#36 so future readers see one mental model.
- New `AddByUrlSheet` composable — `ModalBottomSheet` with `OutlinedTextField`, "Paste" button reading the system clipboard, "Add" button. Uses `BrassButton` (Primary + Secondary variants) and matches `BrowseFilterSheet`'s layout rhythm.
- `LibraryViewModel` gains `AddByUrlSheetState` (`Hidden` / `Open(error?)` / `Submitting`) plus `showAddByUrl` / `dismissAddByUrl` / `submitAddByUrl`. Success navigates to the fiction detail via the existing `LibraryUiEvent.OpenFiction` channel — same code path as a tap from the library grid.

**LibraryScreen Scaffold-wrap (coordination flag)**
- Wraps the existing `Box + LazyVerticalGrid` in a `Scaffold` with a brass `FloatingActionButton`. **Per pre-coordination with Lumen on \#25 (cascade reveal):** the Scaffold's `contentPadding` is composed *into* the existing `Box` padding rather than replacing it, so cascade-reveal items don't briefly pop under the FAB during entry. Cascade modifiers themselves are unchanged.

## GitHub forward-compat

`UrlRouter` matches GitHub URLs (`https://github.com/owner/repo`, `github:owner/repo`, bare `owner/repo`) and assigns `sourceId = "github"`. Today no source binds the `"github"` key, so `addByUrl` returns `UnsupportedSource("github")` and the sheet surfaces a "GitHub support is coming soon" message. The wire is ready for step 3 (`:source-github` module) — the URL plumbing won't need to change when the source actually lands.

## Why this is safe

- Net diff: 5 files modified, 3 new. Three new files (UrlRouter + its test + AddByUrlSheet) are pure additions.
- LibraryScreen change is structurally minimal — wrap in Scaffold, no behavior change to existing items, cascade animation unchanged (verified by Lumen's pre-merge note on PR \#25).
- `addByUrl` failure path leaves the stub row in DB so the user can retry without re-pasting (the next refreshDetail will pick up where it left off).
- Pure-JVM `UrlRouter` is fully unit-tested (20 cases); the regex is permissive on obvious shapes and rejects garbage.

## Test plan

- [x] `:core-data:testDebugUnitTest --tests UrlRouterTest` — 20 cases, all green
- [x] `:core-playback:testDebugUnitTest` — still green
- [x] `:app:assembleDebug` clean (Hilt aggregation re-validated against the new injection)
- [x] Installed on R83W80CAFZB; app launches, no logcat errors after Library nav, brass `+` FAB renders bottom-right
- [ ] **JP smoke test** (next install cycle): tap `+`, paste a Royal Road `/fiction/{id}` URL, hit Add, verify fiction lands in library + navigates to detail
- [ ] **JP smoke test**: paste a GitHub URL, verify "GitHub support is coming soon" surfaces inline
- [ ] **JP smoke test**: paste garbage, verify "doesn't look like a Royal Road or GitHub address" surfaces inline