### PR TITLE
polish(errors): shared ErrorBlock + Browse/FictionDetail wiring

### DIFF
--- a/core-ui/src/main/kotlin/in/jphe/storyvox/ui/component/ErrorBlock.kt
+++ b/core-ui/src/main/kotlin/in/jphe/storyvox/ui/component/ErrorBlock.kt
@@ -1,0 +1,201 @@
+package `in`.jphe.storyvox.ui.component
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.material3.Card
+import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import `in`.jphe.storyvox.ui.theme.LibraryNocturneTheme
+import `in`.jphe.storyvox.ui.theme.LocalSpacing
+
+/** Where to render an [ErrorBlock]. */
+enum class ErrorPlacement {
+    /**
+     * Full-screen, centered. Use when the screen has no other content
+     * (first-load failure with no cached data).
+     */
+    FullScreen,
+
+    /**
+     * Compact card pinned at the top of a scrollable surface. Use when
+     * cached data is already on screen and the error is a tail/refresh
+     * blip — don't blank out what the user is reading.
+     */
+    Banner,
+}
+
+/**
+ * Brass-themed "the realm is unreachable" treatment for fetch / refresh
+ * failures. Mirrors the visual rhythm of [FollowsScreen.SignedOutEmpty]
+ * so the realm aesthetic stays coherent across negative paths.
+ *
+ * @param title short headline, e.g. "The realm is unreachable"
+ * @param message body copy explaining what happened in plain English
+ * @param onRetry primary action; pass null to omit the retry button
+ *   (e.g. when the only retry path is to leave and re-enter the screen)
+ * @param retryLabel button label, defaults to "Try again"
+ * @param placement [ErrorPlacement.FullScreen] or [ErrorPlacement.Banner]
+ */
+@Composable
+fun ErrorBlock(
+    title: String,
+    message: String,
+    onRetry: (() -> Unit)?,
+    modifier: Modifier = Modifier,
+    retryLabel: String = "Try again",
+    placement: ErrorPlacement = ErrorPlacement.FullScreen,
+) {
+    val spacing = LocalSpacing.current
+    when (placement) {
+        ErrorPlacement.FullScreen -> Column(
+            modifier = modifier.fillMaxSize().padding(spacing.lg),
+            horizontalAlignment = Alignment.CenterHorizontally,
+            verticalArrangement = Arrangement.Center,
+        ) {
+            MagicSkeletonTile(
+                modifier = Modifier.size(width = 160.dp, height = 220.dp),
+                shape = MaterialTheme.shapes.medium,
+                glyphSize = 80.dp,
+            )
+            Spacer(Modifier.height(spacing.lg))
+            Text(
+                title,
+                style = MaterialTheme.typography.titleMedium,
+                color = MaterialTheme.colorScheme.primary,
+                textAlign = TextAlign.Center,
+            )
+            Spacer(Modifier.height(spacing.xs))
+            Text(
+                message,
+                style = MaterialTheme.typography.bodyMedium,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                textAlign = TextAlign.Center,
+            )
+            if (onRetry != null) {
+                Spacer(Modifier.height(spacing.lg))
+                BrassButton(
+                    label = retryLabel,
+                    onClick = onRetry,
+                    variant = BrassButtonVariant.Primary,
+                )
+            }
+        }
+
+        ErrorPlacement.Banner -> Card(
+            modifier = modifier.fillMaxWidth().padding(horizontal = spacing.md, vertical = spacing.xs),
+            colors = CardDefaults.cardColors(
+                containerColor = MaterialTheme.colorScheme.errorContainer,
+                contentColor = MaterialTheme.colorScheme.onErrorContainer,
+            ),
+            shape = MaterialTheme.shapes.medium,
+        ) {
+            Row(
+                modifier = Modifier.fillMaxWidth().padding(horizontal = spacing.md, vertical = spacing.sm),
+                horizontalArrangement = Arrangement.spacedBy(spacing.sm),
+                verticalAlignment = Alignment.CenterVertically,
+            ) {
+                Column(modifier = Modifier.weight(1f)) {
+                    Text(title, style = MaterialTheme.typography.titleSmall)
+                    Text(
+                        message,
+                        style = MaterialTheme.typography.bodySmall,
+                        color = MaterialTheme.colorScheme.onErrorContainer.copy(alpha = 0.85f),
+                        maxLines = 2,
+                    )
+                }
+                if (onRetry != null) {
+                    BrassButton(
+                        label = retryLabel,
+                        onClick = onRetry,
+                        variant = BrassButtonVariant.Text,
+                    )
+                }
+            }
+        }
+    }
+}
+
+// region Previews
+
+@Preview(name = "FullScreen — RR offline (dark)", widthDp = 360, heightDp = 720)
+@Composable
+private fun PreviewErrorBlockFullScreenDark() = LibraryNocturneTheme(darkTheme = true) {
+    ErrorBlock(
+        title = "The realm is unreachable",
+        message = "We couldn't reach Royal Road. Check your connection and try again.",
+        onRetry = {},
+        placement = ErrorPlacement.FullScreen,
+    )
+}
+
+@Preview(name = "FullScreen — RR offline (light)", widthDp = 360, heightDp = 720)
+@Composable
+private fun PreviewErrorBlockFullScreenLight() = LibraryNocturneTheme(darkTheme = false) {
+    ErrorBlock(
+        title = "The realm is unreachable",
+        message = "We couldn't reach Royal Road. Check your connection and try again.",
+        onRetry = {},
+        placement = ErrorPlacement.FullScreen,
+    )
+}
+
+@Preview(name = "FullScreen — no retry button", widthDp = 360, heightDp = 720)
+@Composable
+private fun PreviewErrorBlockFullScreenNoRetry() = LibraryNocturneTheme(darkTheme = true) {
+    ErrorBlock(
+        title = "Couldn't load this fiction",
+        message = "We couldn't reach Royal Road. Go back and try again in a moment.",
+        onRetry = null,
+        placement = ErrorPlacement.FullScreen,
+    )
+}
+
+@Preview(name = "Banner — over Hero (dark)", widthDp = 360)
+@Composable
+private fun PreviewErrorBlockBannerDark() = LibraryNocturneTheme(darkTheme = true) {
+    ErrorBlock(
+        title = "Couldn't refresh",
+        message = "Showing cached data.",
+        onRetry = {},
+        placement = ErrorPlacement.Banner,
+    )
+}
+
+@Preview(name = "Banner — over Hero (light)", widthDp = 360)
+@Composable
+private fun PreviewErrorBlockBannerLight() = LibraryNocturneTheme(darkTheme = false) {
+    ErrorBlock(
+        title = "Couldn't refresh",
+        message = "Showing cached data.",
+        onRetry = {},
+        placement = ErrorPlacement.Banner,
+    )
+}
+
+@Preview(name = "Banner — long message", widthDp = 360)
+@Composable
+private fun PreviewErrorBlockBannerLong() = LibraryNocturneTheme(darkTheme = true) {
+    ErrorBlock(
+        title = "Couldn't refresh",
+        message = "Royal Road returned a Cloudflare challenge that we couldn't solve in the background — your cached chapters still play, but new chapters won't appear until next refresh.",
+        onRetry = {},
+        placement = ErrorPlacement.Banner,
+    )
+}
+
+// endregion
+

--- a/feature/src/main/kotlin/in/jphe/storyvox/feature/browse/BrowseScreen.kt
+++ b/feature/src/main/kotlin/in/jphe/storyvox/feature/browse/BrowseScreen.kt
@@ -50,6 +50,8 @@ import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import `in`.jphe.storyvox.feature.api.BrowseFilter
 import `in`.jphe.storyvox.ui.component.cascadeReveal
+import `in`.jphe.storyvox.ui.component.ErrorBlock
+import `in`.jphe.storyvox.ui.component.ErrorPlacement
 import `in`.jphe.storyvox.ui.component.FictionCardSkeleton
 import `in`.jphe.storyvox.ui.component.FictionCoverThumb
 import `in`.jphe.storyvox.ui.theme.LocalSpacing
@@ -99,6 +101,15 @@ fun BrowseScreen(
         when {
             state.isLoading && state.items.isEmpty() -> SkeletonGrid()
             state.tab == BrowseTab.Search && state.query.isBlank() && !state.isFilterActive -> SearchHint()
+            // First-load failure with no cached items: full-screen error.
+            // Retry triggers viewModel.loadMore() which the paginator
+            // resolves to the same page that failed.
+            state.error != null && state.items.isEmpty() -> ErrorBlock(
+                title = "The realm is unreachable",
+                message = state.error ?: "We couldn't reach Royal Road. Check your connection and try again.",
+                onRetry = { viewModel.loadMore() },
+                placement = ErrorPlacement.FullScreen,
+            )
             else -> {
                 // Hoist the grid state so we can watch the last-visible
                 // index and trigger viewModel.loadMore() near the end.
@@ -152,6 +163,20 @@ fun BrowseScreen(
                     horizontalArrangement = Arrangement.spacedBy(spacing.sm),
                     verticalArrangement = Arrangement.spacedBy(spacing.md),
                 ) {
+                    // Tail/refresh error while we still have cached items —
+                    // surface as a banner so users keep seeing what they were
+                    // browsing. Retry path is the same loadMore() the
+                    // paginator already wires to scroll-near-end.
+                    if (state.error != null) {
+                        item(span = { GridItemSpan(maxLineSpan) }) {
+                            ErrorBlock(
+                                title = "Couldn't refresh",
+                                message = state.error ?: "We couldn't reach Royal Road.",
+                                onRetry = { viewModel.loadMore() },
+                                placement = ErrorPlacement.Banner,
+                            )
+                        }
+                    }
                     itemsIndexed(state.items, key = { _, item -> item.id }) { index, fiction ->
                         Column(
                             modifier = Modifier

--- a/feature/src/main/kotlin/in/jphe/storyvox/feature/fiction/FictionDetailScreen.kt
+++ b/feature/src/main/kotlin/in/jphe/storyvox/feature/fiction/FictionDetailScreen.kt
@@ -37,6 +37,8 @@ import `in`.jphe.storyvox.ui.component.BrassButton
 import `in`.jphe.storyvox.ui.component.BrassButtonVariant
 import `in`.jphe.storyvox.ui.component.ChapterCard
 import `in`.jphe.storyvox.ui.component.ChapterCardState
+import `in`.jphe.storyvox.ui.component.ErrorBlock
+import `in`.jphe.storyvox.ui.component.ErrorPlacement
 import `in`.jphe.storyvox.ui.component.FictionCoverThumb
 import `in`.jphe.storyvox.ui.component.FictionDetailSkeleton
 import `in`.jphe.storyvox.ui.layout.isAtLeastTablet
@@ -59,7 +61,18 @@ fun FictionDetailScreen(
 
     val fiction = state.fiction
     Box(modifier = Modifier.fillMaxSize()) {
-        if (fiction == null) {
+        if (fiction == null && state.error != null) {
+            // First-load failure with no cached fiction. No retry button —
+            // backing out and re-entering re-subscribes to fictionById,
+            // which triggers the underlying refreshDetail. Surfacing this
+            // path inside the error message keeps users from getting stuck.
+            ErrorBlock(
+                title = "Couldn't load this fiction",
+                message = state.error ?: "We couldn't reach Royal Road. Go back and try again in a moment.",
+                onRetry = null,
+                placement = ErrorPlacement.FullScreen,
+            )
+        } else if (fiction == null) {
             FictionDetailSkeleton(modifier = Modifier.fillMaxSize())
         } else if (twoColumn) {
             // Wide layout: cover + meta + synopsis on the left, scrollable chapter list
@@ -74,6 +87,14 @@ fun FictionDetailScreen(
                         .verticalScroll(rememberScrollState())
                         .padding(bottom = 96.dp),
                 ) {
+                    if (state.error != null) {
+                        ErrorBlock(
+                            title = "Couldn't refresh",
+                            message = state.error ?: "We couldn't reach Royal Road.",
+                            onRetry = null,
+                            placement = ErrorPlacement.Banner,
+                        )
+                    }
                     Hero(fiction)
                     Synopsis(fiction.synopsis)
                 }
@@ -104,6 +125,16 @@ fun FictionDetailScreen(
                 modifier = Modifier.fillMaxSize(),
                 contentPadding = PaddingValues(bottom = 96.dp),
             ) {
+                if (state.error != null) {
+                    item {
+                        ErrorBlock(
+                            title = "Couldn't refresh",
+                            message = state.error ?: "We couldn't reach Royal Road.",
+                            onRetry = null,
+                            placement = ErrorPlacement.Banner,
+                        )
+                    }
+                }
                 item { Hero(fiction) }
                 item { Synopsis(fiction.synopsis) }
                 items(state.chapters) { ch ->


### PR DESCRIPTION
## Summary

Calliope plumbed `state.error: String?` on `BrowseUiState` (#33) and `FictionDetailUiState` (#36) in v0.4.18. This wires them into the UI with a shared brass-themed treatment that mirrors `FollowsScreen.SignedOutEmpty` so the realm aesthetic stays coherent across negative paths.

## Adds

`core-ui/component/ErrorBlock.kt` — single composable with two placements:

| Placement | When to use | Visual |
|---|---|---|
| `FullScreen` | First-load failure with no cached data | MagicSkeletonTile + titleMedium primary headline + bodyMedium onSurfaceVariant message + optional Primary BrassButton (centered, fills screen) |
| `Banner` | Cached data is on screen, refresh failed | errorContainer Card with titleSmall + bodySmall + optional Text BrassButton (compact, suitable as scroll-list header item) |

`onRetry: (() -> Unit)?` — pass null to omit the button. Used on FictionDetail, where no retry method exists today; backing out and re-entering the screen re-subscribes to `fictionById`, which triggers the underlying refreshDetail.

6 `@Preview` composables cover FullScreen dark/light/no-retry and Banner dark/light/long-message. Reviewers and future readers see both placements rendered without needing to provoke a real network failure.

## Wiring

**BrowseScreen**:
- FullScreen when `state.error != null && items.isEmpty()`
- Banner as a grid header item when items are present
- Retry calls `viewModel.loadMore()` — the paginator retries the same page on the next near-end trigger anyway, so this is the canonical retry path

**FictionDetailScreen**:
- FullScreen with `onRetry = null` when fiction is null (first-load failure, no cached data)
- Banner over Hero in both single-column and tablet two-column layouts when fiction is non-null (refresh failed but cached data is showing — don't blank out what the user is reading)

Three-state breakdown matches Calliope's documented contract for FictionDetail.

## Test plan

- [x] `./gradlew :core-ui:compileDebugKotlin` — clean
- [x] `./gradlew :app:assembleDebug` — clean
- [x] Installed on R83W80CAFZB (with tablet lock claimed/released per protocol). Walked success path on Browse (light mode, fictions loaded with no banner — correct) and FictionDetail (Lost and Found, no banner — correct).
- [x] @Preview composables compile cleanly. Studio renders all 6 variants.
- [ ] **Honest gap**: provoking the error path itself on-device proved hard without breaking network in a way that also kept the paginator's `loadNext` from firing. The contract follows Calliope's documented `state.error` semantics exactly, the structure is symmetric across both screens, and the visual mirrors a widely-used existing composable (SignedOutEmpty), but I do not have a runtime pixel diff of the rendered ErrorBlock on a real network failure. The @Preview snapshots fill that gap as a static reference. JP can exercise it for real on his next RR Cloudflare blip with the previews as a known-good visual baseline.
- [ ] Awaiting `copilot-pull-request-reviewer[bot]`

🤖 Generated with [Claude Code](https://claude.com/claude-code)