### PR TITLE
fix(royalroad): tighten OkHttp timeouts to bound blank-cream stall

### DIFF
--- a/source-royalroad/src/main/kotlin/in/jphe/storyvox/source/royalroad/di/RoyalRoadModule.kt
+++ b/source-royalroad/src/main/kotlin/in/jphe/storyvox/source/royalroad/di/RoyalRoadModule.kt
@@ -15,6 +15,7 @@ import dagger.hilt.components.SingletonComponent
 import dagger.multibindings.IntoMap
 import dagger.multibindings.StringKey
 import okhttp3.OkHttpClient
+import java.util.concurrent.TimeUnit
 import javax.inject.Qualifier
 import javax.inject.Singleton
 
@@ -32,6 +33,25 @@ internal object RoyalRoadHttpModule {
             .cookieJar(jar)
             .followRedirects(true)
             .followSslRedirects(true)
+            // Tab A7 Lite is the constraint device. With no explicit
+            // timeouts OkHttp falls back to 10 s/10 s/10 s, and combined
+            // with retryOnConnectionFailure(true) below the worst-case
+            // stall on Wi-Fi-off / flaky-cellular reaches ~30 s — long
+            // enough that Browse / FictionDetail sit at "blank cream"
+            // before the upstream Failure surfaces and ErrorBlock
+            // renders. Snappier numbers cap the perceived latency:
+            //   connectTimeout:  TCP handshake (incl. TLS pre-negotiation
+            //                    on a flaky link).
+            //   readTimeout:     between socket reads while a response
+            //                    streams.
+            //   callTimeout:     hard cap on the whole call (DNS +
+            //                    connect + TLS + read + retries) — the
+            //                    safety net that bounds the worst case
+            //                    even when retryOnConnectionFailure
+            //                    elects to retry.
+            .connectTimeout(5, TimeUnit.SECONDS)
+            .readTimeout(10, TimeUnit.SECONDS)
+            .callTimeout(15, TimeUnit.SECONDS)
             .retryOnConnectionFailure(true)
             .addInterceptor { chain ->
                 val req = chain.request().newBuilder()


### PR DESCRIPTION
## Summary

The RoyalRoad OkHttp client builds with no explicit timeouts, so OkHttp's `10 s/10 s/10 s` defaults apply. Combined with `retryOnConnectionFailure(true)`, the worst-case stall on a flaky cellular link or Wi-Fi-off cold-start reaches **~30 s** before the upstream `Failure` surfaces and Calliope's `state.error` plumbing feeds Vesper's `ErrorBlock`. During that window Browse and FictionDetail render the `SkeletonGrid` (or, returning to a tab the user already visited, blank cream).

This PR adds explicit timeouts sized for the Tab A7 Lite constraint device:

| | Value | Purpose |
|---|---|---|
| `connectTimeout` | 5 s | TCP handshake incl. TLS pre-negotiation on a flaky link |
| `readTimeout` | 10 s | between socket reads while a response streams |
| `callTimeout` | 15 s | hard cap on the whole call (DNS + connect + TLS + read + retries) |

`callTimeout` is the safety net — it bounds the worst case even when `retryOnConnectionFailure` decides to retry. Keeping `retryOnConnectionFailure(true)` is correct: a single transient blip shouldn't surface as a user-visible error, and the retry still lives inside the 15 s `callTimeout` window.

## UX delta

`blank-cream-for-30 s` → `blank-cream-for-15 s-max` → `ErrorBlock` renders.

Calliope's `BrowseUiState.error` / `FictionDetailUiState.error` (PRs #33, #36) and Vesper's `ErrorBlock` (PR #46) are already on main; this fix lets them surface within bounded latency. The reader perceives "the app noticed" rather than "the app is broken."

## Verification

- [x] `./gradlew :app:assembleDebug` — green
- [x] `./gradlew :app:installDebug` on tablet (`R83W80CAFZB`) — installed (tablet lock claimed and released per protocol)
- [x] Single-file change in `source-royalroad/.../di/RoyalRoadModule.kt`
- [x] No public API change

## Test plan

- [ ] Browse with normal Wi-Fi — pages load as before, no perceived slowdown (5 s connect easily covers a healthy connection)
- [ ] Toggle Wi-Fi off, tap Browse — `ErrorBlock` renders within ~15 s instead of ~30 s
- [ ] Toggle airplane mode, open FictionDetail — `ErrorBlock` renders within ~15 s
- [ ] Restore connectivity, retry → succeeds (callTimeout doesn't break the retry path)

## Credits

Pre-flight diagnosis from **Vesper** (PR #46 verification surfaced the stall) and **Calliope** (network-layer triage of the OkHttp default + retry stacking).

🤖 Generated with [Claude Code](https://claude.com/claude-code)