### PR TITLE
polish(library): brass-themed empty state matching SignedOutEmpty rhythm

### DIFF
--- a/feature/src/main/kotlin/in/jphe/storyvox/feature/library/LibraryScreen.kt
+++ b/feature/src/main/kotlin/in/jphe/storyvox/feature/library/LibraryScreen.kt
@@ -35,8 +35,11 @@ import `in`.jphe.storyvox.data.repository.ContinueListeningEntry
 import `in`.jphe.storyvox.ui.component.BrassButton
 import `in`.jphe.storyvox.ui.component.BrassButtonVariant
 import `in`.jphe.storyvox.ui.component.FictionCoverThumb
+import `in`.jphe.storyvox.ui.component.MagicSkeletonTile
 import `in`.jphe.storyvox.ui.component.cascadeReveal
 import `in`.jphe.storyvox.ui.theme.LocalSpacing
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.ui.text.style.TextAlign
 
 @Composable
 fun LibraryScreen(
@@ -188,25 +191,35 @@ private fun ResumeCard(entry: ContinueListeningEntry, onResume: () -> Unit) {
 @Composable
 private fun EmptyLibrary() {
     val spacing = LocalSpacing.current
-    Box(
+    // Same brass-realm rhythm as FollowsScreen.SignedOutEmpty and the
+    // ErrorBlock FullScreen treatment — sigil tile, titleMedium primary
+    // headline, bodyMedium body. No CTA: Browse is one tap away in the
+    // bottom nav and Add-by-URL is on the FAB above. Empty state's job
+    // is to acknowledge and invite, not duplicate navigation.
+    Column(
         modifier = Modifier.fillMaxSize().padding(spacing.lg),
-        contentAlignment = Alignment.Center,
+        horizontalAlignment = Alignment.CenterHorizontally,
+        verticalArrangement = Arrangement.Center,
     ) {
-        Column(
-            horizontalAlignment = Alignment.CenterHorizontally,
-            verticalArrangement = Arrangement.spacedBy(spacing.xs),
-        ) {
-            Text(
-                "Your library is empty",
-                style = MaterialTheme.typography.titleMedium,
-                color = MaterialTheme.colorScheme.onSurface,
-            )
-            Text(
-                "Open Browse to add fictions",
-                style = MaterialTheme.typography.bodyMedium,
-                color = MaterialTheme.colorScheme.onSurfaceVariant,
-            )
-        }
+        MagicSkeletonTile(
+            modifier = Modifier.size(width = 160.dp, height = 220.dp),
+            shape = MaterialTheme.shapes.medium,
+            glyphSize = 80.dp,
+        )
+        Spacer(Modifier.height(spacing.lg))
+        Text(
+            "Your library is empty",
+            style = MaterialTheme.typography.titleMedium,
+            color = MaterialTheme.colorScheme.primary,
+            textAlign = TextAlign.Center,
+        )
+        Spacer(Modifier.height(spacing.xs))
+        Text(
+            "Browse Royal Road or paste a fiction URL with the + button to start collecting.",
+            style = MaterialTheme.typography.bodyMedium,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+            textAlign = TextAlign.Center,
+        )
     }
 }
 


### PR DESCRIPTION
## Summary

`LibraryScreen.EmptyLibrary` was a centered Box with two plain Text composables — functional but visually minimalist against the brass-realm aesthetic established by `FollowsScreen.SignedOutEmpty` and the ErrorBlock FullScreen treatment shipped in #46.

Realigned to the same vocabulary:
- `MagicSkeletonTile` sigil (160×220, glyphSize 80)
- `titleMedium` primary brass headline
- `bodyMedium` onSurfaceVariant body copy

The realm aesthetic now carries through Library's negative path the same way it does Follows' signed-out path and Browse/FictionDetail's error path. Three negative-path screens, one shared visual vocabulary.

## Body copy update

The previous "Open Browse to add fictions" only mentioned one navigation path. Selene's #44 added an Add-by-URL FAB, so updated to mention both:

> "Browse Royal Road or paste a fiction URL with the + button to start collecting."

No CTA button — both Browse (bottom nav) and the FAB (Add-by-URL) are already one tap away. The empty state's job is to acknowledge and invite, not duplicate navigation.

## Test plan

- [x] `./gradlew :app:assembleDebug` — clean
- [x] Tablet lock claimed/released per protocol on R83W80CAFZB
- [x] `pm clear` to force fresh empty-library state, installed, "Continue without audio" → empty Library
- [x] Verified: brass sigil tile centered, "Your library is empty" headline in primary brass, body copy mentions both nav paths, `+` FAB visible bottom-right matching the body copy reference
- [ ] Awaiting `copilot-pull-request-reviewer[bot]`

🤖 Generated with [Claude Code](https://claude.com/claude-code)