### PR TITLE
fix(playback): switch scrubber-clock anchor to SystemClock.elapsedRealtime

### DIFF
--- a/app/src/main/kotlin/in/jphe/storyvox/di/AppBindings.kt
+++ b/app/src/main/kotlin/in/jphe/storyvox/di/AppBindings.kt
@@ -2,6 +2,7 @@ package `in`.jphe.storyvox.di
 
 import android.content.Context
 import android.content.Intent
+import android.os.SystemClock
 import androidx.core.content.ContextCompat
 import dagger.Module
 import dagger.Provides
@@ -479,28 +480,40 @@ private class RealPlaybackControllerUi(
         }
     }
 
-    /** Anchor state for position interpolation between sentence-boundary updates. */
+    /**
+     * Anchor state for position interpolation between sentence-boundary
+     * updates. `anchorElapsedMs` is in the [SystemClock.elapsedRealtime]
+     * time base — see [tickWhilePlaying].
+     */
     private var anchorChapterId: String? = null
     private var anchorCharOffset: Int = 0
-    private var anchorWallMs: Long = 0L
+    private var anchorElapsedMs: Long = 0L
 
     /**
-     * Wall-clock source driving position interpolation between sentence
+     * Monotonic-clock source driving position interpolation between sentence
      * boundaries. Two regimes, gated by `isPlaying`:
      *
      *  - **Playing**: tick at 250 ms (the original cadence). Emits an
      *    immediate tick on play-resume so the slider snaps forward without
      *    waiting on the first delay window.
      *  - **Paused**: tick is suppressed *but* every upstream state emission
-     *    re-emits a fresh `System.currentTimeMillis()`. Required because
-     *    `PlaybackState.toUi` re-anchors `anchorWallMs = nowMs` whenever the
-     *    engine reports a new `charOffset` (seek, chapter switch). If the
-     *    anchor were stuck at the pause-time tick, a seek-while-paused
+     *    re-emits a fresh [SystemClock.elapsedRealtime]. Required because
+     *    `PlaybackState.toUi` re-anchors `anchorElapsedMs = nowMs` whenever
+     *    the engine reports a new `charOffset` (seek, chapter switch). If
+     *    the anchor were stuck at the pause-time tick, a seek-while-paused
      *    followed by play would interpret all the paused wall-time as
      *    elapsed playback time and lurch the scrubber forward (Copilot's
-     *    PR #21 review). Emitting on each upstream change keeps the
-     *    anchor's wall time fresh while still skipping the 4 Hz allocation
-     *    storm of an unconditional ticker.
+     *    PR #21 review). Emitting on each upstream change keeps the anchor
+     *    fresh while still skipping the 4 Hz allocation storm of an
+     *    unconditional ticker.
+     *
+     * Time base: [SystemClock.elapsedRealtime] is monotonic and counts
+     * milliseconds since boot, including deep sleep. Unlike
+     * [System.currentTimeMillis], it cannot jump backwards or forwards from
+     * NTP corrections / user time changes, so a corrected wall clock can
+     * never make the scrubber jitter, leap, or freeze. Both the tick source
+     * and [anchorElapsedMs] use this time base so the subtraction in
+     * [PlaybackState.toUi] stays consistent.
      *
      * Net effect for an open-but-idle reader (paused, no seeks): one tick on
      * the play→pause transition, then quiet until the user does something.
@@ -511,12 +524,12 @@ private class RealPlaybackControllerUi(
             .distinctUntilChanged()
             .flatMapLatest { playing ->
                 if (playing) flow {
-                    emit(System.currentTimeMillis())
+                    emit(SystemClock.elapsedRealtime())
                     while (true) {
                         kotlinx.coroutines.delay(250L)
-                        emit(System.currentTimeMillis())
+                        emit(SystemClock.elapsedRealtime())
                     }
-                } else stateFlow.map { System.currentTimeMillis() }
+                } else stateFlow.map { SystemClock.elapsedRealtime() }
             }
 
     private fun PlaybackState.toUi(nowMs: Long): UiPlaybackState {
@@ -527,7 +540,7 @@ private class RealPlaybackControllerUi(
         if (currentChapterId != anchorChapterId || charOffset != anchorCharOffset) {
             anchorChapterId = currentChapterId
             anchorCharOffset = charOffset
-            anchorWallMs = nowMs
+            anchorElapsedMs = nowMs
         }
         val baseMs = if (charsPerSec > 0f) ((charOffset / charsPerSec) * 1000f).toLong() else 0L
         val sentence = currentSentenceRange
@@ -536,7 +549,7 @@ private class RealPlaybackControllerUi(
         // scrubber slides forward during a 5-15s engine load even though no
         // audio has actually played.
         val warmingUp = isPlaying && sentence == null
-        val elapsedMs = if (isPlaying && !warmingUp) (nowMs - anchorWallMs).coerceAtLeast(0L) else 0L
+        val elapsedMs = if (isPlaying && !warmingUp) (nowMs - anchorElapsedMs).coerceAtLeast(0L) else 0L
         val positionMs = (baseMs + elapsedMs).coerceAtMost(durationEstimateMs.coerceAtLeast(baseMs))
         return UiPlaybackState(
             fictionId = currentFictionId,


### PR DESCRIPTION
## Summary

Closes the timing/clock cleanup raised by Copilot on PR #21 (non-monotonic-clock concern, parked at the time as an out-of-scope follow-up).

The position-interpolation tick source and the corresponding `anchorWallMs` variable in `PlaybackState.toUi` both used `System.currentTimeMillis()`. That clock is **wall-time**: it can jump backwards or forwards from NTP corrections, manual user time changes, or DST adjustments. When it does, the scrubber recomputes `elapsedMs = (now - anchor)` against an inconsistent time base and visually jitters, leaps, or freezes for a window — even though playback is producing audio steadily.

Migrate **both** call sites in lockstep — the tick source's three emissions inside `tickWhilePlaying` plus the `anchorWallMs` field — to `SystemClock.elapsedRealtime()`. That clock is monotonic, counts milliseconds since boot including deep sleep, and cannot be moved by anything outside the kernel. The subtraction in `toUi` now stays consistent across any wall-time correction.

Field renamed `anchorWallMs` → `anchorElapsedMs` so the time base is explicit at the declaration. The comment block on `tickWhilePlaying` is updated to call out the time base and why.

## Out of scope

The unrelated `relativeTime(epochMs)` helper at line 212 that formats "5m ago" / "2h ago" labels stays wall-clock-based (epoch comparison) — that one is intentionally wall-clock and works correctly with `System.currentTimeMillis()`.

## Verification

- [x] `./gradlew :app:assembleDebug` — green
- [x] `./gradlew :app:installDebug` on tablet (`R83W80CAFZB`) — installed (tablet lock claimed and released per protocol)
- [x] Single-file change in `app/.../di/AppBindings.kt`
- [x] No behavior change in the steady-playback case; difference shows up only under wall-clock movement (NTP correction during a long playback session, DST transition, manual time change)

## Test plan

- [ ] Steady playback for several minutes — scrubber advances smoothly, identical to current main
- [ ] Pause / resume / seek — scrubber re-anchors correctly (the anchor logic is unchanged, only the clock base is)
- [ ] Optional, hard-to-reproduce: trigger an NTP correction or manual time change during playback — pre-PR scrubber would lurch; post-PR it stays smooth

## Credits

Concern raised by `copilot-pull-request-reviewer` on PR #21 review (2026-05-07T18:14:28Z).

🤖 Generated with [Claude Code](https://claude.com/claude-code)