### PR TITLE
perf(playback): shareIn the UiPlaybackState + chapterText flows

### DIFF
--- a/app/src/main/kotlin/in/jphe/storyvox/di/AppBindings.kt
+++ b/app/src/main/kotlin/in/jphe/storyvox/di/AppBindings.kt
@@ -51,6 +51,7 @@ import `in`.jphe.storyvox.playback.StoryvoxPlaybackService
 import javax.inject.Singleton
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.distinctUntilChanged
@@ -61,6 +62,7 @@ import kotlinx.coroutines.flow.flatMapLatest
 import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.flow.shareIn
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
 import kotlinx.coroutines.CoroutineScope
@@ -408,23 +410,41 @@ private class RealPlaybackControllerUi(
      * advances on sentence boundaries (or per-word if VoxSherpa fires
      * `onRangeStart`). To keep the slider moving smoothly we anchor on each
      * `charOffset` change and interpolate forward at the current speed using
-     * wall-clock time, ticking every 250ms while playing. Pause freezes the
-     * displayed position; sentence boundaries snap it back to the engine's
-     * truth.
+     * the monotonic [SystemClock.elapsedRealtime] clock, ticking every 250ms
+     * while playing. Pause freezes the displayed position; sentence
+     * boundaries snap it back to the engine's truth.
+     *
+     * Shared across consumers so the `combine` + `toUi` allocation path runs
+     * once per emission regardless of subscriber count, and so a config
+     * change / screen recreation reattaches to the same upstream collector
+     * within the 5 s `WhileSubscribed` grace window instead of restarting
+     * the tick flow + re-running the anchor logic from scratch. `replay = 1`
+     * gives a new subscriber the most recent `UiPlaybackState` immediately —
+     * crucial for the reader UI, which would otherwise paint one frame of
+     * stale state during a recomposition before the first new emission.
      */
     override val state: Flow<UiPlaybackState> = combine(
         controller.state,
         tickWhilePlaying(controller.state),
     ) { s, nowMs ->
         s.toUi(nowMs)
-    }
+    }.shareIn(scope, SharingStarted.WhileSubscribed(5_000), replay = 1)
 
+    /**
+     * Chapter body stream. Shared so a screen recreation (config change,
+     * pane swap) doesn't restart the chapter-DB query — the upstream
+     * `observeChapter(id)` Room flow stays alive for the 5 s
+     * `WhileSubscribed` grace window. `replay = 1` lets the reader UI
+     * render the body immediately on resubscribe instead of flickering
+     * empty for the duration of one DB roundtrip.
+     */
     override val chapterText: Flow<String> = controller.state
         .map { it.currentChapterId }
         .distinctUntilChanged()
         .flatMapLatest { id ->
             if (id == null) flowOf("") else chapters.observeChapter(id).map { it?.plainBody.orEmpty() }
         }
+        .shareIn(scope, SharingStarted.WhileSubscribed(5_000), replay = 1)
 
     override fun play() = controller.resume()
     override fun pause() = controller.pause()


### PR DESCRIPTION
## Summary

`RealPlaybackControllerUi.state` and `chapterText` were cold flows. Each subscription re-ran the full upstream pipeline:

- **`state`**: `combine(controller.state, tickWhilePlaying(...)) { s, nowMs -> s.toUi(nowMs) }` — including the 4 Hz tick allocator while playing and the `toUi` re-anchor logic — once per subscriber.
- **`chapterText`**: `controller.state.map { currentChapterId }.distinctUntilChanged().flatMapLatest { chapters.observeChapter(id).map { plainBody.orEmpty() } }` — including a fresh Room flow subscription on every resubscribe.

Steady state today is a single consumer (`ReaderViewModel`), but cold flows pay the full pipeline cost on every subscribe. A config change, screen recreation, or the brief hand-off when `HybridReaderShell` pane-swaps between AudiobookView and ReaderView all trigger an unnecessary teardown + rebuild of the upstream collector.

## Fix

Wrap both flows in `shareIn(scope, SharingStarted.WhileSubscribed(5_000), replay = 1)`:

- **`WhileSubscribed(5_000)`** keeps the upstream alive for 5 s after the last subscriber leaves — survives config changes and pane-swaps without restarting the tick or the chapter-DB query.
- **`replay = 1`** lets a new subscriber render the most recent `UiPlaybackState` / `chapterText` immediately on resubscribe, avoiding a one-frame flicker of empty state during recomposition.

## Verification

- [x] `./gradlew :app:assembleDebug` — green
- [x] `./gradlew :app:installDebug` on tablet (`R83W80CAFZB`) — installed (tablet lock claimed and released per protocol)
- [x] Single-file change in `app/.../di/AppBindings.kt`
- [x] Public surface (`Flow<UiPlaybackState>`, `Flow<String>`) unchanged
- [x] Closes the playback hot-path audit (last concrete target on the perf-audit lane following PRs #18, #21, #32, #40, #47, #50)

## Test plan

- [ ] Open a chapter and start playback — scrubber + sentence highlight track normally
- [ ] Swap between AudiobookView ↔ ReaderView panes via `HybridReaderShell` — body stays rendered immediately on swap (no flicker through empty state)
- [ ] Rotate device (config change) — chapter body reappears immediately, scrubber resumes without restart
- [ ] Pause / resume / seek — behavior unchanged
- [ ] Background the app, return after >5 s — pipeline restarts cleanly via `WhileSubscribed(5_000)` timeout

🤖 Generated with [Claude Code](https://claude.com/claude-code)