### PR TITLE
feat(motion): cascade reveal on voice library rows

### DIFF
--- a/feature/src/main/kotlin/in/jphe/storyvox/feature/voicelibrary/VoiceLibraryScreen.kt
+++ b/feature/src/main/kotlin/in/jphe/storyvox/feature/voicelibrary/VoiceLibraryScreen.kt
@@ -15,6 +15,7 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.lazy.itemsIndexed
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
@@ -44,6 +45,7 @@ import `in`.jphe.storyvox.playback.voice.UiVoiceInfo
 import `in`.jphe.storyvox.ui.component.BrassButton
 import `in`.jphe.storyvox.ui.component.BrassButtonVariant
 import `in`.jphe.storyvox.ui.component.MagicSkeletonTile
+import `in`.jphe.storyvox.ui.component.cascadeReveal
 import `in`.jphe.storyvox.ui.theme.LocalSpacing
 
 @Composable
@@ -89,7 +91,7 @@ fun VoiceLibraryScreen(
         ) {
             if (featured.isNotEmpty()) {
                 item { SectionHeader("⭐ Featured", count = featured.size) }
-                items(featured, key = { "f-${it.id}" }) { voice ->
+                itemsIndexed(featured, key = { _, item -> "f-${item.id}" }) { index, voice ->
                     val downloading = state.currentDownload
                     val rowProgress = if (downloading?.voiceId == voice.id) downloading.progress ?: -1f else null
                     VoiceRow(
@@ -98,6 +100,9 @@ fun VoiceLibraryScreen(
                         downloadingProgress = rowProgress,
                         onTap = { if (downloading == null || voice.isInstalled) viewModel.onRowTapped(voice) },
                         onLongPress = if (voice.isInstalled) ({ viewModel.requestDelete(voice) }) else null,
+                        modifier = Modifier
+                            .animateItem()
+                            .cascadeReveal(index = index, key = voice.id),
                     )
                 }
                 item { Spacer(modifier = Modifier.height(spacing.md)) }
@@ -114,13 +119,16 @@ fun VoiceLibraryScreen(
                     )
                 }
             } else {
-                items(installed, key = { "i-${it.id}" }) { voice ->
+                itemsIndexed(installed, key = { _, item -> "i-${item.id}" }) { index, voice ->
                     VoiceRow(
                         voice = voice,
                         isActive = voice.id == state.activeVoiceId,
                         downloadingProgress = null,
                         onTap = { viewModel.onRowTapped(voice) },
                         onLongPress = { viewModel.requestDelete(voice) },
+                        modifier = Modifier
+                            .animateItem()
+                            .cascadeReveal(index = index, key = voice.id),
                     )
                 }
             }
@@ -133,7 +141,7 @@ fun VoiceLibraryScreen(
                 if (available.any { it.engineType is EngineType.Kokoro }) {
                     item { KokoroBundleNote() }
                 }
-                items(available, key = { "a-${it.id}" }) { voice ->
+                itemsIndexed(available, key = { _, item -> "a-${item.id}" }) { index, voice ->
                     val downloading = state.currentDownload
                     val rowProgress = if (downloading?.voiceId == voice.id) downloading.progress ?: -1f else null
                     VoiceRow(
@@ -142,6 +150,9 @@ fun VoiceLibraryScreen(
                         downloadingProgress = rowProgress,
                         onTap = { if (downloading == null) viewModel.onRowTapped(voice) },
                         onLongPress = null,
+                        modifier = Modifier
+                            .animateItem()
+                            .cascadeReveal(index = index, key = voice.id),
                     )
                 }
             }
@@ -223,6 +234,7 @@ private fun VoiceRow(
     downloadingProgress: Float?,
     onTap: () -> Unit,
     onLongPress: (() -> Unit)?,
+    modifier: Modifier = Modifier,
 ) {
     val spacing = LocalSpacing.current
     val brass = MaterialTheme.colorScheme.primary
@@ -236,7 +248,7 @@ private fun VoiceRow(
     val isAvailable = !voice.isInstalled
 
     Box(
-        modifier = Modifier
+        modifier = modifier
             .fillMaxWidth()
             .clip(RoundedCornerShape(12.dp))
             .background(containerColor)


### PR DESCRIPTION
## Summary

Same `cascadeReveal` modifier from #25 / #42 / #51 lands on the **VoiceLibraryScreen**'s three section lists (Featured, Installed, Available). The voice picker was the last list surface in storyvox without entry motion. Now it pours in like candlelight catching pages instead of snapping.

`VoiceRow` gains a standard `modifier: Modifier = Modifier` parameter (Compose convention) prepended to its existing internal Modifier chain. Call sites pass `Modifier.animateItem().cascadeReveal(index, voice.id)` so reorders glide on download/install state changes and first compose staggers each row's reveal.

## Why per-section indices

Each section uses `itemsIndexed`, so stagger restarts at index 0 for each section — Available[0] doesn't have to wait through Featured.size + Installed.size before it animates. The existing modulo-12 in `cascadeReveal` already handles paginated catch-up if a section is long, so this is "use what the modifier already does correctly."

## Reduced motion

Inherited automatically from `LocalReducedMotion` provided in #51's `LibraryNocturneTheme`. When the user has "Remove animations" on, `cascadeReveal` short-circuits to a no-op modifier — voice library rows appear instantly. No additional plumbing needed in this PR.

## Files

- `feature/.../voicelibrary/VoiceLibraryScreen.kt` — single-file change. Three `items()` → `itemsIndexed()` swaps, `cascadeReveal` modifier on each `VoiceRow`, and a `modifier` parameter added to `VoiceRow` itself.

Net: +16 / -4.

## Test plan

- [x] Build green: `:app:assembleDebug` against `dream/lumen/voice-library-cascade` off `44ce13c`. Only pre-existing deprecation warnings.
- [x] APK installs cleanly on R83W80CAFZB over the latest main.
- [x] Crash-free launch — no FATAL in logcat.
- [x] Tablet lock claimed and released within the 2-min window (task #47).
- [ ] **Live cascade pending JP's first populated session.** The voice library is 2-3 taps deep (Settings → Voice library) and the device handoff to that screen during my install pass landed in a non-deterministic launcher state, so I didn't catch the cascade animating. Cascade is gated by section non-emptiness, the empty path returns early via `EmptyState`, so the worst-case failure mode is "rows reveal in a different order than expected" — purely visual. JP will see it on next install.
- [ ] Reduced-motion path inherited from #51's `LocalReducedMotion`; verified by code path (cascadeReveal short-circuits), not yet device-tested.

## Coordination

- **Vesper** is on #14 (magic spinner crossfade) which touches `MagicSpinner.kt` and `AudiobookView.kt`. No file overlap with this PR — different surface entirely.
- **Selene** is on `:source-github` step 3c (Featured row in source-github registry). Her work flows into BrowseScreen, not VoiceLibraryScreen. No conflict.

🤖 Generated with [Claude Code](https://claude.com/claude-code)