### PR TITLE
polish(playback): crossfade magic spinner around warmup state transitions

### DIFF
--- a/feature/src/main/kotlin/in/jphe/storyvox/feature/reader/AudiobookView.kt
+++ b/feature/src/main/kotlin/in/jphe/storyvox/feature/reader/AudiobookView.kt
@@ -1,5 +1,10 @@
 package `in`.jphe.storyvox.feature.reader
 
+import androidx.compose.animation.EnterTransition
+import androidx.compose.animation.ExitTransition
+import androidx.compose.animation.core.tween
+import androidx.compose.animation.fadeIn
+import androidx.compose.animation.fadeOut
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -53,6 +58,8 @@ import `in`.jphe.storyvox.ui.component.BrassProgressTrack
 import `in`.jphe.storyvox.ui.component.FictionCoverThumb
 import `in`.jphe.storyvox.ui.component.MagicSkeletonTile
 import `in`.jphe.storyvox.ui.component.MagicSpinner
+import `in`.jphe.storyvox.ui.theme.LocalMotion
+import `in`.jphe.storyvox.ui.theme.LocalReducedMotion
 import `in`.jphe.storyvox.ui.theme.LocalSpacing
 import kotlinx.coroutines.launch
 
@@ -76,6 +83,17 @@ fun AudiobookView(
     modifier: Modifier = Modifier,
 ) {
     val spacing = LocalSpacing.current
+    val motion = LocalMotion.current
+    val reducedMotion = LocalReducedMotion.current
+    // Spinner enter/exit transitions for the warmup state. Honors
+    // LocalReducedMotion: when true, visibility flips instantly (reduce
+    // motion = absent motion, not shorter motion — same pattern as
+    // cascadeReveal). Token vocabulary stays consistent with the rest
+    // of Library Nocturne via standardDurationMs + standardEasing.
+    val spinnerEnter = if (reducedMotion) EnterTransition.None else
+        fadeIn(animationSpec = tween(motion.standardDurationMs, easing = motion.standardEasing))
+    val spinnerExit = if (reducedMotion) ExitTransition.None else
+        fadeOut(animationSpec = tween(motion.standardDurationMs, easing = motion.standardEasing))
     var showSheet by remember { mutableStateOf(false) }
 
     Box(modifier = modifier.fillMaxSize()) {
@@ -118,8 +136,14 @@ fun AudiobookView(
                     )
                     // Subtle brass sigil ring orbiting the cover while the
                     // engine is producing the first sentence's audio. Fades
-                    // out as soon as audio actually starts (sentenceEnd > 0).
-                    if (warmingUp) {
+                    // in/out around the warmup transition rather than
+                    // popping — visual swap to the playing state stays
+                    // continuous instead of abrupt.
+                    androidx.compose.animation.AnimatedVisibility(
+                        visible = warmingUp,
+                        enter = spinnerEnter,
+                        exit = spinnerExit,
+                    ) {
                         MagicSpinner(modifier = Modifier.size(width = 240.dp, height = 350.dp))
                     }
                 }
@@ -168,7 +192,11 @@ fun AudiobookView(
                 // indicator the play button looks dead during that gap.
                 val warmingUp = state.isPlaying && state.sentenceEnd == 0
                 Box(contentAlignment = Alignment.Center) {
-                    if (warmingUp) {
+                    androidx.compose.animation.AnimatedVisibility(
+                        visible = warmingUp,
+                        enter = spinnerEnter,
+                        exit = spinnerExit,
+                    ) {
                         MagicSpinner(modifier = Modifier.size(96.dp))
                     }
                     FilledIconButton(


### PR DESCRIPTION
## Summary

The brass-star spinner that orbits the cover during voice warmup currently **appears via instant pop and disappears via instant pop**, so when warmup finishes the visual swap to the playing state is abrupt. Commit `febcb6a` (scrubber freeze + thumb pulse) softened the scrubber's warmup signal but the spinner itself stayed snappy.

## What changed

Both spinner sites in `AudiobookView` now wrap their `if (warmingUp)` with `AnimatedVisibility(fadeIn/fadeOut)`:

| Site | Spinner | Where |
|---|---|---|
| Cover overlay (240×350) | Orbits the cover thumb during warmup | Top of the audiobook layout |
| Play-button overlay (96dp) | Halos the play button during warmup | Center of the transport row |

Both use the existing Library Nocturne motion vocabulary — `LocalMotion.standardDurationMs` (280ms) + `standardEasing`. Same curve as cascadeReveal (#25) and the NavHost cross-fade (#42), so the realm's motion vocabulary stays consistent across surfaces.

## Reduced motion

Honors `LocalReducedMotion` from PR #51: when true, spinner visibility flips instantly via `EnterTransition.None` / `ExitTransition.None`. Reduce motion = **absent** motion, not shorter motion — the same pattern Lumen applied in `cascadeReveal`.

## Implementation note

Used the fully-qualified `androidx.compose.animation.AnimatedVisibility(...)` because the enclosing `Box` inherits `ColumnScope` from the outer `Column`, and `ColumnScope.AnimatedVisibility` overload resolution shadows the unqualified call. Compiler error on the import-level `AnimatedVisibility` was `cannot be called in this context with an implicit receiver`; FQ name resolves to the top-level overload. Removed the now-unused import.

## Test plan

- [x] `./gradlew :app:assembleDebug` — clean
- [x] Tablet lock claim/release per protocol on R83W80CAFZB
- [x] Installed and launched
- [ ] **Honest disclosure**: full crossfade observation on-device requires triggering warmup with a downloaded voice + active fiction + the 5–15s warmup window. That exceeds the tablet lock's 2-min hold budget and a single screencap of the easing curve isn't a meaningful pixel diff anyway. The structural correctness rests on:
  1. Same `motion.standardDurationMs` + `standardEasing` token vocabulary as Lumen's #25/#42/#51 (all on-device verified)
  2. Same `LocalReducedMotion` branching as `cascadeReveal`
  3. `AnimatedVisibility` is the textbook replacement for an `if` boolean, no novel composition pattern introduced
- [ ] Awaiting `copilot-pull-request-reviewer[bot]`

🤖 Generated with [Claude Code](https://claude.com/claude-code)