### PR TITLE
feat(source-github): registry reader + browse stubs flipped to curated entries

### DIFF
--- a/source-github/src/main/kotlin/in/jphe/storyvox/source/github/GitHubSource.kt
+++ b/source-github/src/main/kotlin/in/jphe/storyvox/source/github/GitHubSource.kt
@@ -8,73 +8,131 @@ import `in`.jphe.storyvox.data.source.model.FictionSummary
 import `in`.jphe.storyvox.data.source.model.ListPage
 import `in`.jphe.storyvox.data.source.model.SearchQuery
 import `in`.jphe.storyvox.source.github.net.GitHubApi
+import `in`.jphe.storyvox.source.github.registry.Registry
+import `in`.jphe.storyvox.source.github.registry.RegistryEntry
+import `in`.jphe.storyvox.source.github.registry.toSummary
 import javax.inject.Inject
 import javax.inject.Singleton
 
 /**
- * Stub [FictionSource] for the GitHub source. The module is built and
- * test-covered in step-3a (this PR), but **not bound in Hilt yet** —
- * that wires up in step 3d when manifest parsing actually returns real
- * [FictionDetail] data. Today every call raises [NotImplementedError]
- * with a pointer to the implementing step in the spec, so any
- * accidental binding fails loudly during dev rather than silently
- * returning empty pages.
+ * GitHub [FictionSource]. Browse calls (popular/latestUpdates/byGenre/
+ * genres) are wired to the curated [Registry] as of step 3c. Detail
+ * and chapter still throw [NotImplementedError] — they land in step 3d
+ * when manifest parsing returns real [FictionDetail] data. Search
+ * lands in step 3-search (spec sequence step 8).
  *
- * The constructor accepts [GitHubApi] so the dependency graph is in
- * place — when the Hilt binding lands, no plumbing change here.
+ * **Still not Hilt-bound**: detail is the load-bearing call when the
+ * UrlRouter routes a paste through [`in`.jphe.storyvox.data.repository
+ * .FictionRepository.addByUrl], so binding the source before detail
+ * works would break that flow. Step 3d adds the @IntoMap binding
+ * once detail returns real data.
  */
 @Singleton
-@Suppress("unused", "UNUSED_PARAMETER") // intentional stub — see kdoc
 internal class GitHubSource @Inject constructor(
+    @Suppress("unused") // wired so the graph compiles when 3d adds detail
     private val api: GitHubApi,
+    private val registry: Registry,
 ) : FictionSource {
 
     override val id: String = "github"
     override val displayName: String = "GitHub"
 
     override suspend fun popular(page: Int): FictionResult<ListPage<FictionSummary>> =
-        throw NotImplementedError(STEP_3C_BROWSE)
+        registryPage(page) { entries ->
+            // Featured first, then the rest in registry order. Within each
+            // band we keep the curator's authored ordering rather than
+            // imposing a synthetic rank — curators sort hand-picks for a
+            // reason.
+            entries.sortedByDescending { it.featured }
+        }
 
     override suspend fun latestUpdates(page: Int): FictionResult<ListPage<FictionSummary>> =
-        throw NotImplementedError(STEP_3C_BROWSE)
+        registryPage(page) { entries ->
+            // `addedAt` is the only freshness signal we have pre-manifest.
+            // ISO-8601 yyyy-MM-dd string-sorts correctly; entries without
+            // an addedAt sort last (empty string < any date).
+            entries.sortedByDescending { it.addedAt.orEmpty() }
+        }
 
     override suspend fun byGenre(
         genre: String,
         page: Int,
     ): FictionResult<ListPage<FictionSummary>> =
-        throw NotImplementedError(STEP_3C_BROWSE)
+        registryPage(page) { entries ->
+            val needle = genre.trim().lowercase()
+            if (needle.isBlank()) entries
+            else entries.filter { it.tags.any { tag -> tag.equals(needle, ignoreCase = true) } }
+        }
+
+    override suspend fun genres(): FictionResult<List<String>> {
+        return when (val r = registry.entries()) {
+            is FictionResult.Success -> FictionResult.Success(
+                r.value.flatMap { it.tags }
+                    .map { it.lowercase() }
+                    .distinct()
+                    .sorted(),
+            )
+            is FictionResult.Failure -> r
+        }
+    }
 
     override suspend fun search(query: SearchQuery): FictionResult<ListPage<FictionSummary>> =
-        throw NotImplementedError(STEP_3C_BROWSE)
+        throw NotImplementedError(STEP_3_SEARCH)
 
     override suspend fun fictionDetail(fictionId: String): FictionResult<FictionDetail> =
         throw NotImplementedError(STEP_3D_DETAIL)
 
     override suspend fun chapter(
-        fictionId: String,
-        chapterId: String,
+        @Suppress("UNUSED_PARAMETER") fictionId: String,
+        @Suppress("UNUSED_PARAMETER") chapterId: String,
     ): FictionResult<ChapterContent> =
         throw NotImplementedError(STEP_3D_DETAIL)
 
-    override suspend fun followsList(page: Int): FictionResult<ListPage<FictionSummary>> =
+    override suspend fun followsList(
+        @Suppress("UNUSED_PARAMETER") page: Int,
+    ): FictionResult<ListPage<FictionSummary>> =
         throw NotImplementedError(STEP_3F_AUTH)
 
     override suspend fun setFollowed(
-        fictionId: String,
-        followed: Boolean,
+        @Suppress("UNUSED_PARAMETER") fictionId: String,
+        @Suppress("UNUSED_PARAMETER") followed: Boolean,
     ): FictionResult<Unit> =
         throw NotImplementedError(STEP_3F_AUTH)
 
-    override suspend fun genres(): FictionResult<List<String>> =
-        throw NotImplementedError(STEP_3C_BROWSE)
+    /**
+     * Registry-backed paging. Single page today (registry is small +
+     * hand-curated; pagination would be over-engineering until the
+     * curated set exceeds a screenful). [transform] runs over the raw
+     * [RegistryEntry] list — keeping `addedAt`/`featured` available
+     * for sort/filter before mapping to the cross-source
+     * [FictionSummary] shape.
+     */
+    private suspend fun registryPage(
+        page: Int,
+        transform: (List<RegistryEntry>) -> List<RegistryEntry>,
+    ): FictionResult<ListPage<FictionSummary>> {
+        // Page 2+ always empty — caller's pagination cursor short-
+        // circuits the next-page fetch via hasNext=false on page 1.
+        if (page > 1) {
+            return FictionResult.Success(
+                ListPage(items = emptyList(), page = page, hasNext = false),
+            )
+        }
+        return when (val r = registry.entries()) {
+            is FictionResult.Success -> FictionResult.Success(
+                ListPage(
+                    items = transform(r.value).map { it.toSummary() },
+                    page = 1,
+                    hasNext = false,
+                ),
+            )
+            is FictionResult.Failure -> r
+        }
+    }
 
     private companion object {
-        // References the build sequence in
-        // docs/superpowers/specs/2026-05-06-github-source-design.md
-        // (lines 256-262). Every NotImplementedError points at the
-        // step that fills it in.
-        const val STEP_3C_BROWSE = "GitHub source browse not implemented yet — lands in step 3c (registry-only Featured row + search)"
         const val STEP_3D_DETAIL = "GitHub source detail/chapter not implemented yet — lands in step 3d (manifest parsing + markdown rendering)"
         const val STEP_3F_AUTH = "GitHub source auth-gated calls not implemented yet — lands in step 3f (optional PAT support)"
+        const val STEP_3_SEARCH = "GitHub /search/repositories not implemented yet — lands in step 3-search (spec sequence step 8)"
     }
 }

--- a/source-github/src/main/kotlin/in/jphe/storyvox/source/github/registry/Registry.kt
+++ b/source-github/src/main/kotlin/in/jphe/storyvox/source/github/registry/Registry.kt
@@ -1,0 +1,142 @@
+package `in`.jphe.storyvox.source.github.registry
+
+import `in`.jphe.storyvox.data.source.model.FictionResult
+import `in`.jphe.storyvox.source.github.di.GitHubHttp
+import `in`.jphe.storyvox.source.github.net.GitHubJson
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.suspendCancellableCoroutine
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
+import kotlinx.coroutines.withContext
+import kotlinx.serialization.ExperimentalSerializationApi
+import kotlinx.serialization.SerializationException
+import kotlinx.serialization.json.decodeFromStream
+import okhttp3.Call
+import okhttp3.Callback
+import okhttp3.OkHttpClient
+import okhttp3.Request
+import okhttp3.Response
+import java.io.IOException
+import javax.inject.Inject
+import javax.inject.Singleton
+import kotlin.coroutines.resume
+import kotlin.coroutines.resumeWithException
+
+/**
+ * Reads the curated `registry.json` from
+ * `raw.githubusercontent.com/jphein/storyvox-registry/main/registry.json`
+ * and caches it for the session.
+ *
+ * The registry is the source-of-truth for the **Featured** row at the
+ * top of Browse → GitHub. Entries carry their display fields directly
+ * (title, author, cover_url, description, tags) so the Featured row
+ * renders without N round-trips to `getRepo`. Manifest enrichment
+ * happens later — when the user opens an entry, step 3d reads
+ * `book.toml` / `storyvox.json` from the actual repo.
+ *
+ * Caching contract: first read fetches, subsequent reads return the
+ * cached value. Process death (or app re-launch) refetches. We don't
+ * persist to disk — registry size is small (≤ a few KB) and the data
+ * isn't load-bearing enough to need offline survival.
+ */
+@Singleton
+internal open class Registry @Inject constructor(
+    @GitHubHttp private val httpClient: OkHttpClient,
+) {
+    private val gate = Mutex()
+
+    @Volatile
+    private var cached: List<RegistryEntry>? = null
+
+    /**
+     * Returns the registry as a list of curator-authored entries.
+     * Result is computed once per session under [gate] so concurrent
+     * first callers don't N-fetch. Entries with non-`github:`
+     * prefixes are filtered out — the registry shape is sourceId-
+     * tagged, but only github entries are meaningful here.
+     *
+     * On network or parse failure, returns the matching
+     * [FictionResult.Failure] without poisoning the cache — a later
+     * call may succeed.
+     */
+    open suspend fun entries(): FictionResult<List<RegistryEntry>> {
+        cached?.let { return FictionResult.Success(it) }
+        return gate.withLock {
+            cached?.let { return@withLock FictionResult.Success(it) }
+            when (val r = fetch()) {
+                is FictionResult.Success -> {
+                    cached = r.value
+                    r
+                }
+                is FictionResult.Failure -> r
+            }
+        }
+    }
+
+    /** Forces the next [entries] call to refetch. Used by tests. */
+    internal fun invalidate() {
+        cached = null
+    }
+
+    @OptIn(ExperimentalSerializationApi::class)
+    private suspend fun fetch(): FictionResult<List<RegistryEntry>> = withContext(Dispatchers.IO) {
+        val req = Request.Builder()
+            .url(REGISTRY_URL)
+            .header("Accept", "application/json")
+            .header("User-Agent", USER_AGENT)
+            .build()
+        val response = try {
+            httpClient.newCall(req).await()
+        } catch (e: IOException) {
+            return@withContext FictionResult.NetworkError(
+                message = "Could not reach the GitHub registry",
+                cause = e,
+            )
+        }
+        response.use { r ->
+            if (!r.isSuccessful) {
+                return@withContext FictionResult.NetworkError(
+                    message = "Registry HTTP ${r.code}: ${r.message}",
+                )
+            }
+            val body = r.body ?: return@withContext FictionResult.NetworkError(
+                message = "Registry returned empty body",
+            )
+            val doc = try {
+                GitHubJson.decodeFromStream<RegistryDocument>(body.byteStream())
+            } catch (e: SerializationException) {
+                return@withContext FictionResult.NetworkError(
+                    message = "Registry JSON parse error",
+                    cause = e,
+                )
+            }
+            val filtered = doc.fictions.filter { it.id.startsWith("github:") }
+            FictionResult.Success(filtered)
+        }
+    }
+
+    companion object {
+        const val REGISTRY_URL: String =
+            "https://raw.githubusercontent.com/jphein/storyvox-registry/main/registry.json"
+        const val USER_AGENT: String =
+            "storyvox/0.4 (+https://github.com/jphein/storyvox)"
+    }
+}
+
+/** Suspending bridge over OkHttp's enqueue → callback API. Local copy
+ *  to keep the registry independent of [`in`.jphe.storyvox.source.github
+ *  .net.GitHubApi]'s internal helper; both wrap the same OkHttp idiom.
+ */
+private suspend fun Call.await(): Response = suspendCancellableCoroutine { cont ->
+    enqueue(object : Callback {
+        override fun onResponse(call: Call, response: Response) {
+            cont.resume(response)
+        }
+
+        override fun onFailure(call: Call, e: IOException) {
+            if (cont.isCancelled) return
+            cont.resumeWithException(e)
+        }
+    })
+    cont.invokeOnCancellation { runCatching { cancel() } }
+}

--- a/source-github/src/main/kotlin/in/jphe/storyvox/source/github/registry/RegistryModels.kt
+++ b/source-github/src/main/kotlin/in/jphe/storyvox/source/github/registry/RegistryModels.kt
@@ -1,0 +1,73 @@
+package `in`.jphe.storyvox.source.github.registry
+
+import `in`.jphe.storyvox.data.source.model.FictionStatus
+import `in`.jphe.storyvox.data.source.model.FictionSummary
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+/**
+ * Top-level shape of `registry.json`, fetched from
+ * `raw.githubusercontent.com/jphein/storyvox-registry/main/registry.json`
+ * (path overrideable by [Registry] for tests).
+ *
+ * The registry is curated and hand-edited, so each entry carries the
+ * display fields directly. Filling them from `getRepo` would cost 60+
+ * API calls per session for no benefit — the curator already typed the
+ * title once when adding the entry, and storyvox's only job is to
+ * display it.
+ *
+ * Step-3c surfaces these as the Featured row at the top of Browse →
+ * GitHub. Step-3d will enrich with manifest data when the user opens
+ * a specific entry.
+ */
+@Serializable
+internal data class RegistryDocument(
+    @SerialName("version") val version: Int,
+    @SerialName("fictions") val fictions: List<RegistryEntry> = emptyList(),
+)
+
+@Serializable
+internal data class RegistryEntry(
+    /** Stable id, e.g. `github:jphein/example-fiction`. */
+    @SerialName("id") val id: String,
+    @SerialName("title") val title: String,
+    @SerialName("author") val author: String,
+    @SerialName("description") val description: String? = null,
+    @SerialName("cover_url") val coverUrl: String? = null,
+    @SerialName("tags") val tags: List<String> = emptyList(),
+    /** Pinned/featured at the top of the Featured row. */
+    @SerialName("featured") val featured: Boolean = false,
+    /** ISO-8601 date the curator added this row. Used for "recently added" sorting. */
+    @SerialName("added_at") val addedAt: String? = null,
+    /** Optional status hint; falls back to ONGOING. */
+    @SerialName("status") val status: String? = null,
+    /** Optional rating (0..5) the curator can assign for hand-picks. */
+    @SerialName("rating") val rating: Float? = null,
+    /** Optional chapter count snapshot at curation time. */
+    @SerialName("chapter_count") val chapterCount: Int? = null,
+)
+
+/**
+ * Map a registry entry to the cross-source [FictionSummary] used by
+ * the data layer. Status falls back to ONGOING when unparseable, since
+ * a curator's typo shouldn't crash the Featured row.
+ */
+internal fun RegistryEntry.toSummary(): FictionSummary = FictionSummary(
+    id = id,
+    sourceId = "github",
+    title = title,
+    author = author,
+    coverUrl = coverUrl,
+    description = description,
+    tags = tags,
+    status = parseStatus(status),
+    chapterCount = chapterCount,
+    rating = rating,
+)
+
+private fun parseStatus(raw: String?): FictionStatus = when (raw?.uppercase()) {
+    "COMPLETED" -> FictionStatus.COMPLETED
+    "HIATUS" -> FictionStatus.HIATUS
+    "DROPPED" -> FictionStatus.DROPPED
+    else -> FictionStatus.ONGOING
+}

--- a/source-github/src/test/kotlin/in/jphe/storyvox/source/github/GitHubSourceTest.kt
+++ b/source-github/src/test/kotlin/in/jphe/storyvox/source/github/GitHubSourceTest.kt
@@ -1,50 +1,185 @@
 package `in`.jphe.storyvox.source.github
 
+import `in`.jphe.storyvox.data.source.model.FictionResult
 import `in`.jphe.storyvox.source.github.net.GitHubApi
+import `in`.jphe.storyvox.source.github.registry.Registry
+import `in`.jphe.storyvox.source.github.registry.RegistryEntry
+import kotlinx.coroutines.runBlocking
 import okhttp3.OkHttpClient
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertThrows
+import org.junit.Assert.assertTrue
 import org.junit.Test
-import kotlinx.coroutines.runBlocking
 
 /**
- * Sanity tests for the stub [GitHubSource]. The stub is intentional —
- * the source's id/displayName are stable contract surface (the
- * UrlRouter routes to `sourceId="github"` and the Library sheet
- * surfaces `displayName` in its "coming soon" message), but every
- * suspend call should fail loudly so an accidental Hilt binding
- * surfaces during dev rather than silently returning empty pages.
- *
- * The stub never calls into [GitHubApi], so the constructor argument
- * here is a no-op: a default OkHttpClient that never issues a request.
+ * Tests cover:
+ *  - Stable contract surface (id, displayName) since both leak to
+ *    UrlRouter routing and UI surface strings.
+ *  - Browse calls (popular/latestUpdates/byGenre/genres) wired to the
+ *    [Registry] as of step 3c — sort/filter/distinct semantics.
+ *  - Stubs that *should* still throw (search, fictionDetail, chapter,
+ *    followsList, setFollowed) — accidental Hilt binding before the
+ *    next steps fill these in must fail loudly, not return empty.
  */
 class GitHubSourceTest {
 
-    private fun stub(): GitHubSource = GitHubSource(api = GitHubApi(OkHttpClient()))
-
     @Test fun `sourceId is the stable github key`() {
-        assertEquals("github", stub().id)
+        assertEquals("github", source().id)
     }
 
     @Test fun `displayName surfaces in UI strings and is stable`() {
-        assertEquals("GitHub", stub().displayName)
+        assertEquals("GitHub", source().displayName)
     }
 
-    @Test fun `every suspend method throws NotImplementedError`() {
-        val src = stub()
-        assertThrows(NotImplementedError::class.java) { runBlocking { src.popular() } }
-        assertThrows(NotImplementedError::class.java) { runBlocking { src.latestUpdates() } }
-        assertThrows(NotImplementedError::class.java) { runBlocking { src.byGenre("fantasy") } }
-        assertThrows(NotImplementedError::class.java) { runBlocking { src.genres() } }
+    @Test fun `popular returns featured entries first, registry order within bands`() {
+        val src = source(
+            entry("github:o/a", title = "A", featured = false),
+            entry("github:o/b", title = "B", featured = true),
+            entry("github:o/c", title = "C", featured = false),
+            entry("github:o/d", title = "D", featured = true),
+        )
+        val r = runBlocking { src.popular() } as FictionResult.Success
+        val ids = r.value.items.map { it.id }
+        // Featured (B, D) before non-featured (A, C); within each band
+        // the curator's authored order is preserved.
+        assertEquals(listOf("github:o/b", "github:o/d", "github:o/a", "github:o/c"), ids)
+        assertEquals(1, r.value.page)
+        assertEquals(false, r.value.hasNext)
+    }
+
+    @Test fun `latestUpdates sorts by addedAt descending, missing dates last`() {
+        val src = source(
+            entry("github:o/a", title = "A", addedAt = "2026-01-01"),
+            entry("github:o/b", title = "B", addedAt = "2026-05-06"),
+            entry("github:o/c", title = "C", addedAt = null),
+            entry("github:o/d", title = "D", addedAt = "2026-03-15"),
+        )
+        val r = runBlocking { src.latestUpdates() } as FictionResult.Success
+        val ids = r.value.items.map { it.id }
+        assertEquals(listOf("github:o/b", "github:o/d", "github:o/a", "github:o/c"), ids)
+    }
+
+    @Test fun `byGenre matches tags case-insensitively and trims input`() {
+        val src = source(
+            entry("github:o/a", title = "A", tags = listOf("fantasy", "litrpg")),
+            entry("github:o/b", title = "B", tags = listOf("sci-fi")),
+            entry("github:o/c", title = "C", tags = listOf("FANTASY")),
+        )
+        val r = runBlocking { src.byGenre("  Fantasy  ") } as FictionResult.Success
+        assertEquals(setOf("github:o/a", "github:o/c"), r.value.items.map { it.id }.toSet())
+    }
+
+    @Test fun `byGenre with blank input returns the full registry`() {
+        val src = source(
+            entry("github:o/a", title = "A", tags = listOf("fantasy")),
+            entry("github:o/b", title = "B", tags = listOf("sci-fi")),
+        )
+        val r = runBlocking { src.byGenre("   ") } as FictionResult.Success
+        assertEquals(2, r.value.items.size)
+    }
+
+    @Test fun `genres returns deduplicated lowercase union of tags`() {
+        val src = source(
+            entry("github:o/a", title = "A", tags = listOf("Fantasy", "litrpg")),
+            entry("github:o/b", title = "B", tags = listOf("FANTASY", "Sci-Fi")),
+        )
+        val r = runBlocking { src.genres() } as FictionResult.Success
+        assertEquals(listOf("fantasy", "litrpg", "sci-fi"), r.value)
+    }
+
+    @Test fun `page 2 short-circuits to empty hasNext-false page`() {
+        val src = source(entry("github:o/a", title = "A"))
+        val r = runBlocking { src.popular(page = 2) } as FictionResult.Success
+        assertTrue(r.value.items.isEmpty())
+        assertEquals(2, r.value.page)
+        assertEquals(false, r.value.hasNext)
+    }
+
+    @Test fun `registry failure surfaces unchanged from popular`() {
+        val src = sourceWithFailure(FictionResult.NetworkError(message = "no internet"))
+        val r = runBlocking { src.popular() }
+        assertTrue(r is FictionResult.NetworkError)
+    }
+
+    // ─── Still-stubbed surfaces ────────────────────────────────────────
+
+    @Test fun `search still throws NotImplementedError`() {
+        val src = source()
+        assertThrows(NotImplementedError::class.java) {
+            runBlocking {
+                src.search(`in`.jphe.storyvox.data.source.model.SearchQuery(term = "anything"))
+            }
+        }
+    }
+
+    @Test fun `fictionDetail still throws NotImplementedError`() {
+        val src = source()
         assertThrows(NotImplementedError::class.java) {
             runBlocking { src.fictionDetail("github:o/r") }
         }
+    }
+
+    @Test fun `chapter still throws NotImplementedError`() {
+        val src = source()
         assertThrows(NotImplementedError::class.java) {
             runBlocking { src.chapter("github:o/r", "github:o/r:src/01.md") }
         }
+    }
+
+    @Test fun `followsList and setFollowed still throw NotImplementedError`() {
+        val src = source()
         assertThrows(NotImplementedError::class.java) { runBlocking { src.followsList() } }
         assertThrows(NotImplementedError::class.java) {
             runBlocking { src.setFollowed("github:o/r", true) }
         }
+    }
+
+    // ─── Helpers ───────────────────────────────────────────────────────
+
+    private fun source(vararg entries: RegistryEntry): GitHubSource =
+        GitHubSource(
+            api = GitHubApi(OkHttpClient()),
+            registry = StaticRegistry(entries.toList()),
+        )
+
+    private fun sourceWithFailure(failure: FictionResult.Failure): GitHubSource =
+        GitHubSource(
+            api = GitHubApi(OkHttpClient()),
+            registry = FailingRegistry(failure),
+        )
+
+    private fun entry(
+        id: String,
+        title: String,
+        author: String = "an-author",
+        featured: Boolean = false,
+        addedAt: String? = null,
+        tags: List<String> = emptyList(),
+    ) = RegistryEntry(
+        id = id,
+        title = title,
+        author = author,
+        featured = featured,
+        addedAt = addedAt,
+        tags = tags,
+    )
+
+    /**
+     * Test double: returns a fixed list, no network. Subclasses
+     * [Registry] (which is `internal open` for exactly this reason)
+     * so the constructor still accepts an OkHttpClient even though
+     * we never use it.
+     */
+    private class StaticRegistry(
+        private val entries: List<RegistryEntry>,
+    ) : Registry(httpClient = OkHttpClient()) {
+        override suspend fun entries(): FictionResult<List<RegistryEntry>> =
+            FictionResult.Success(entries)
+    }
+
+    private class FailingRegistry(
+        private val failure: FictionResult.Failure,
+    ) : Registry(httpClient = OkHttpClient()) {
+        override suspend fun entries(): FictionResult<List<RegistryEntry>> = failure
     }
 }

--- a/source-github/src/test/kotlin/in/jphe/storyvox/source/github/registry/RegistryModelsTest.kt
+++ b/source-github/src/test/kotlin/in/jphe/storyvox/source/github/registry/RegistryModelsTest.kt
@@ -1,0 +1,162 @@
+package `in`.jphe.storyvox.source.github.registry
+
+import `in`.jphe.storyvox.data.source.model.FictionStatus
+import `in`.jphe.storyvox.source.github.net.GitHubJson
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class RegistryModelsTest {
+
+    @Test fun `full document deserializes`() {
+        val json = """
+            {
+              "version": 1,
+              "fictions": [
+                {
+                  "id": "github:jphein/example-fiction",
+                  "title": "Example Fiction",
+                  "author": "onedayokay",
+                  "description": "An overpowered archmage relearns humility.",
+                  "cover_url": "https://example.com/cover.png",
+                  "tags": ["fantasy", "litrpg"],
+                  "featured": true,
+                  "added_at": "2026-05-06",
+                  "status": "ONGOING",
+                  "rating": 4.5,
+                  "chapter_count": 42
+                }
+              ]
+            }
+        """.trimIndent()
+
+        val doc = GitHubJson.decodeFromString<RegistryDocument>(json)
+
+        assertEquals(1, doc.version)
+        assertEquals(1, doc.fictions.size)
+        val e = doc.fictions[0]
+        assertEquals("github:jphein/example-fiction", e.id)
+        assertEquals("Example Fiction", e.title)
+        assertEquals("onedayokay", e.author)
+        assertEquals(listOf("fantasy", "litrpg"), e.tags)
+        assertTrue(e.featured)
+        assertEquals("2026-05-06", e.addedAt)
+        assertEquals(4.5f, e.rating!!, 0.001f)
+        assertEquals(42, e.chapterCount)
+    }
+
+    @Test fun `minimal entry tolerates missing optional fields`() {
+        val json = """
+            {
+              "version": 1,
+              "fictions": [
+                { "id": "github:o/r", "title": "Minimal", "author": "o" }
+              ]
+            }
+        """.trimIndent()
+
+        val doc = GitHubJson.decodeFromString<RegistryDocument>(json)
+        val e = doc.fictions.single()
+
+        assertNull(e.description)
+        assertNull(e.coverUrl)
+        assertEquals(emptyList<String>(), e.tags)
+        assertFalse(e.featured)
+        assertNull(e.addedAt)
+        assertNull(e.status)
+        assertNull(e.rating)
+        assertNull(e.chapterCount)
+    }
+
+    @Test fun `empty fictions list deserializes cleanly`() {
+        val doc = GitHubJson.decodeFromString<RegistryDocument>(
+            """{ "version": 1, "fictions": [] }""",
+        )
+        assertTrue(doc.fictions.isEmpty())
+    }
+
+    @Test fun `omitted fictions key defaults to empty list`() {
+        // Curator might author a registry skeleton with just the version.
+        val doc = GitHubJson.decodeFromString<RegistryDocument>("""{ "version": 1 }""")
+        assertTrue(doc.fictions.isEmpty())
+    }
+
+    @Test fun `unknown keys at document or entry level are tolerated`() {
+        // Forward-compat: registry schema may grow.
+        val json = """
+            {
+              "version": 1,
+              "schema_url": "https://example.com/schema.json",
+              "fictions": [
+                {
+                  "id": "github:o/r", "title": "T", "author": "A",
+                  "future_field": "shrug"
+                }
+              ]
+            }
+        """.trimIndent()
+
+        val doc = GitHubJson.decodeFromString<RegistryDocument>(json)
+        assertEquals("T", doc.fictions.single().title)
+    }
+
+    // ─── Mapping ───────────────────────────────────────────────────────
+
+    @Test fun `entry to summary preserves required fields and assigns sourceId`() {
+        val entry = RegistryEntry(
+            id = "github:o/r",
+            title = "Title",
+            author = "Author",
+            description = "Desc",
+            coverUrl = "https://example.com/c.png",
+            tags = listOf("fantasy"),
+            featured = true,
+            addedAt = "2026-05-06",
+            status = "ONGOING",
+            rating = 4.0f,
+            chapterCount = 10,
+        )
+
+        val s = entry.toSummary()
+
+        assertEquals("github:o/r", s.id)
+        assertEquals("github", s.sourceId)
+        assertEquals("Title", s.title)
+        assertEquals("Author", s.author)
+        assertEquals("Desc", s.description)
+        assertEquals("https://example.com/c.png", s.coverUrl)
+        assertEquals(listOf("fantasy"), s.tags)
+        assertEquals(FictionStatus.ONGOING, s.status)
+        assertEquals(10, s.chapterCount)
+        assertEquals(4.0f, s.rating!!, 0.001f)
+    }
+
+    @Test fun `status maps the supported variants`() {
+        listOf(
+            "COMPLETED" to FictionStatus.COMPLETED,
+            "completed" to FictionStatus.COMPLETED,
+            "HIATUS" to FictionStatus.HIATUS,
+            "DROPPED" to FictionStatus.DROPPED,
+            "ONGOING" to FictionStatus.ONGOING,
+        ).forEach { (raw, expected) ->
+            val mapped = baseEntry().copy(status = raw).toSummary().status
+            assertEquals("status=$raw", expected, mapped)
+        }
+    }
+
+    @Test fun `unknown or null status falls back to ONGOING`() {
+        assertEquals(FictionStatus.ONGOING, baseEntry().copy(status = null).toSummary().status)
+        assertEquals(
+            FictionStatus.ONGOING,
+            baseEntry().copy(status = "WIBBLY").toSummary().status,
+        )
+    }
+
+    private fun baseEntry() = RegistryEntry(
+        id = "github:o/r",
+        title = "T",
+        author = "A",
+    )
+}


### PR DESCRIPTION
## Summary

Step 3c per the GitHub-source plan ([spec](docs/superpowers/specs/2026-05-06-github-source-design.md), sequence step 7 at line 260: registry-only Featured row). Wires the curated `jphein/storyvox-registry/registry.json` into `GitHubSource.popular` / `latestUpdates` / `byGenre` / `genres` so those calls return real `FictionSummary` rows when the source binds.

**Still not Hilt-bound** — that lands in step 3d when `fictionDetail` returns real data. `fictionDetail` is the load-bearing call for `addByUrl(github URL)`, so binding the source before detail works would break that flow. Today this PR adds plumbing + tests; nothing user-visible.

## What lands

**New `Registry` singleton** ([`Registry.kt`](source-github/src/main/kotlin/in/jphe/storyvox/source/github/registry/Registry.kt))
- `@GitHubHttp OkHttpClient`-injected. Fetches `registry.json` once per session under a mutex (concurrent first callers don't N-fetch).
- On failure, returns the matching `FictionResult.Failure` without poisoning the cache so a later call may succeed.
- `internal open` so the test double can subclass and override `entries()` without going through the network.

**`RegistryDocument` + `RegistryEntry`** `@Serializable` models ([`RegistryModels.kt`](source-github/src/main/kotlin/in/jphe/storyvox/source/github/registry/RegistryModels.kt))
- Curated entries carry display fields directly (`title`, `author`, `cover_url`, `description`, `tags`) — pre-empts N round-trips to `getRepo` when rendering the Featured row. The curator already typed the title once; storyvox's job is to display it.
- `addedAt` and `featured` are curator fields used for sort/filter *before* mapping to the cross-source `FictionSummary` shape.

**`GitHubSource` browse calls flipped**
- `popular` returns featured entries first, then non-featured. Registry order is preserved within each band — curators sort hand-picks for a reason.
- `latestUpdates` sorts by `addedAt` descending; ISO-8601 `yyyy-MM-dd` string-sorts correctly. Entries without an `addedAt` sort last.
- `byGenre` filters by tag, case-insensitive, blank input returns the full registry.
- `genres` returns the deduplicated lowercase union of tags.

**Still stubbed** (each throws `NotImplementedError` pointing at the spec step that fills it in)
- `search` — spec sequence step 8 (`/search/repositories`).
- `fictionDetail` / `chapter` — step 3d (manifest parsing + markdown rendering).
- `followsList` / `setFollowed` — step 3f (optional PAT auth).

## Test plan

29 unit tests, all green. Pure-JVM, runs in <1s.

- [x] **Existing 11** from step 3a still pass (GhRepo / GhContent / GhCompareResponse / GitHubSource id+displayName).
- [x] **8 new `RegistryModelsTest`**: full doc / minimal entry / empty fictions / omitted fictions key / unknown keys / entry→summary mapping / status variants / unknown-status fallback.
- [x] **10 new `GitHubSourceTest`**: popular sort, latest sort with missing-date handling, byGenre case-insensitive + trim, byGenre blank, genres dedup+lowercase+sort, page 2 short-circuit, registry failure surfaces unchanged, search/fictionDetail/chapter/follows still throw.
- [x] `:source-github:testDebugUnitTest` — 29/29 green.
- [x] `:app:assembleDebug` clean — Hilt graph unaffected since the source remains unbound.

## What this unblocks

Per spec build sequence:
- **3d (next)**: manifest parsing + markdown rendering. Flips `fictionDetail` and `chapter` to real impls; **adds the Hilt `@IntoMap @StringKey("github")` binding** so `addByUrl(github URL)` actually works end-to-end. Once 3d lands, browse calls in this PR start returning data the user can actually open.
- **3-search (later)**: `/search/repositories` flips the `search` stub.
- **3-sync (later)**: `compareCommits` from #52 drives chapter polling.

No new gradle deps, no install needed. Pure module-internal change.

## Worktree + branch

- Worktree: `.claude/worktrees/selene-github-registry`
- Branch: `dream/selene/source-github-registry`