### PR TITLE
feat(motion): sleep timer countdown pulse + urgent hue shift

### DIFF
--- a/feature/src/main/kotlin/in/jphe/storyvox/feature/reader/AudiobookView.kt
+++ b/feature/src/main/kotlin/in/jphe/storyvox/feature/reader/AudiobookView.kt
@@ -2,6 +2,11 @@ package `in`.jphe.storyvox.feature.reader
 
 import androidx.compose.animation.EnterTransition
 import androidx.compose.animation.ExitTransition
+import androidx.compose.animation.animateColorAsState
+import androidx.compose.animation.core.RepeatMode
+import androidx.compose.animation.core.animateFloat
+import androidx.compose.animation.core.infiniteRepeatable
+import androidx.compose.animation.core.rememberInfiniteTransition
 import androidx.compose.animation.core.tween
 import androidx.compose.animation.fadeIn
 import androidx.compose.animation.fadeOut
@@ -49,6 +54,7 @@ import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.alpha
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.compositeOver
 import androidx.compose.ui.unit.dp
@@ -261,6 +267,44 @@ fun AudiobookView(
 private fun SleepTimerCountdownChip(remainingMs: Long, onCancel: () -> Unit) {
     val mins = (remainingMs / 60_000L).toInt()
     val secs = ((remainingMs % 60_000L) / 1000L).toInt()
+    val reducedMotion = LocalReducedMotion.current
+    val motion = LocalMotion.current
+
+    // Last 60s: gentle alpha breath. Last 15s: cross-fade container toward
+    // errorContainer hue to signal "almost out of time" without alarm-bell
+    // urgency. Reduced motion → static at full alpha + base color.
+    val isPulsing = !reducedMotion && remainingMs in 1..60_000
+    val isUrgent = remainingMs in 1..15_000
+
+    val pulseAlpha = if (isPulsing) {
+        val transition = rememberInfiniteTransition(label = "sleep-timer-breath")
+        transition.animateFloat(
+            initialValue = 1f,
+            targetValue = 0.55f,
+            animationSpec = infiniteRepeatable(
+                animation = tween(durationMillis = 1200, easing = motion.standardEasing),
+                repeatMode = RepeatMode.Reverse,
+            ),
+            label = "sleep-timer-alpha",
+        ).value
+    } else 1f
+
+    val baseContainer = MaterialTheme.colorScheme.primaryContainer
+    val urgentContainer = MaterialTheme.colorScheme.errorContainer
+    val baseLabel = MaterialTheme.colorScheme.onPrimaryContainer
+    val urgentLabel = MaterialTheme.colorScheme.onErrorContainer
+
+    val containerColor by animateColorAsState(
+        targetValue = if (isUrgent && !reducedMotion) urgentContainer else baseContainer,
+        animationSpec = tween(motion.standardDurationMs, easing = motion.standardEasing),
+        label = "sleep-timer-container",
+    )
+    val labelColor by animateColorAsState(
+        targetValue = if (isUrgent && !reducedMotion) urgentLabel else baseLabel,
+        animationSpec = tween(motion.standardDurationMs, easing = motion.standardEasing),
+        label = "sleep-timer-label",
+    )
+
     AssistChip(
         onClick = onCancel,
         label = {
@@ -269,10 +313,11 @@ private fun SleepTimerCountdownChip(remainingMs: Long, onCancel: () -> Unit) {
         leadingIcon = {
             Icon(Icons.Outlined.Bedtime, contentDescription = null)
         },
+        modifier = Modifier.alpha(pulseAlpha),
         colors = AssistChipDefaults.assistChipColors(
-            containerColor = MaterialTheme.colorScheme.primaryContainer,
-            labelColor = MaterialTheme.colorScheme.onPrimaryContainer,
-            leadingIconContentColor = MaterialTheme.colorScheme.onPrimaryContainer,
+            containerColor = containerColor,
+            labelColor = labelColor,
+            leadingIconContentColor = labelColor,
         ),
     )
 }


### PR DESCRIPTION
## Summary

The sleep timer chip currently counts down digits and that's it. This PR makes the chip *visibly settle* in the last minute — gentle breath-rate alpha pulse — and *softly warm* into the warning palette in the last 15 seconds. The motion does the talking before the digits do.

## The feel

- **Last 60s — alpha breath.** Chip fades 1.0 ↔ 0.55 over 1.2s, infinite reverse. Peripheral vision sees fading and reaches for the screen before consciously reading the number. Cadence is breath-rate (~25 cycles/min), not heartbeat — slow enough to feel intentional, not anxious.
- **Last 15s — urgent hue shift.** Container and label colors cross-fade from `primaryContainer`/`onPrimaryContainer` toward `errorContainer`/`onErrorContainer` over 280ms via `LocalMotion.standardEasing`. Soft hue slide, not alarm-bell red — staying inside Library Nocturne's vocabulary, just sliding toward the warning end of the palette.

The two motions overlap: the last 15 seconds you see *both* the breath and the warning hue, which is the strongest "almost done" signal the chip can carry without changing shape or position.

## Reduced motion

`LocalReducedMotion.current` short-circuits both. When on:
- `pulseAlpha` is held at 1f (no breath)
- Container + label colors stay at base (no warning shift)
- Chip behaves exactly as it did pre-PR: digits count down, nothing else moves.

Same contract as `cascadeReveal` (#25/#51 retrofit), `NavHost` transitions (#42), and spinner crossfade (#56) — three surfaces, three different APIs, one rule: reduce motion = absent motion.

## Token discipline

Reused from `LocalMotion`:
- `standardEasing` for the hue cross-fade
- `standardDurationMs` (280ms) for the hue cross-fade duration

Local-only constant:
- 1200ms breath cadence — single-use, not a vocabulary primitive, not promoted to a Motion token. If a future motion surface wants the same breath rhythm, that's the moment to extract `Motion.breathDurationMs` (and pre-coordinate with Vesper per the Motion.kt review process).

## Files

- `feature/.../reader/AudiobookView.kt` — single-file change. New imports for `animateColorAsState`, `animateFloat`, `infiniteRepeatable`, `rememberInfiniteTransition`, `RepeatMode`, `Modifier.alpha`. Body of `SleepTimerCountdownChip` rewritten to compute `pulseAlpha` and animated `containerColor` / `labelColor` based on `remainingMs` thresholds. Net: +48 / -3.

No surface other than the chip itself is touched — sleep timer logic, PlaybackViewModel, Selene's volume-fade work all untouched.

## Test plan

- [x] Build green: `:app:assembleDebug` against `dream/lumen/sleep-timer-pulse` off `2a1561e` (post-v0.4.21). Only pre-existing deprecation warnings.
- [x] APK installs cleanly on R83W80CAFZB. Crash-free launch, no FATAL in logcat.
- [x] Tablet lock claimed and released within the 2-min budget.
- [ ] **Live pulse + hue shift pending JP's first session with an active sleep timer.** Reaching the chip live requires fiction loaded + reader active + sleep timer started + 60s elapsed (or seek timer to <60s). Way over the 2-min lock budget, so I trust the structural correctness of the threshold logic (`remainingMs in 1..60_000` and `remainingMs in 1..15_000`) and the established token vocabulary. Worst-case failure is "didn't see the breath at the right time" which is parameter-tunable, not architectural.
- [ ] Reduced-motion path verified by code path: when `reducedMotion` is true, both `isPulsing` falls to `false` (alpha stays 1f) and the urgent flags pass `!reducedMotion` (color stays base). Test path is one toggle: Developer Options → Animator duration scale = Off, start a sleep timer, expect static chip throughout the countdown.

## Coordination

- **Vesper** flagged the `ColumnScope.AnimatedVisibility` overload-shadowing footgun for AudiobookView. Not relevant here — this PR uses `Modifier.alpha` + `animateColorAsState`, not `AnimatedVisibility`. No fully-qualify needed.
- No file overlap with anyone's open PRs. Vesper's #56 (spinner crossfade) already merged, Aurelia's perf lane closed, Selene is on `:source-github` step 3d-manifest (different module entirely).

🤖 Generated with [Claude Code](https://claude.com/claude-code)