### PR TITLE
feat(source-github): book.toml + storyvox.json + SUMMARY.md parsers

### DIFF
--- a/source-github/src/main/kotlin/in/jphe/storyvox/source/github/manifest/BareRepoFallback.kt
+++ b/source-github/src/main/kotlin/in/jphe/storyvox/source/github/manifest/BareRepoFallback.kt
@@ -1,0 +1,66 @@
+package `in`.jphe.storyvox.source.github.manifest
+
+/**
+ * Last-resort chapter list when neither `book.toml` + `SUMMARY.md`
+ * nor an explicit author manifest is present. Picks markdown files
+ * from a `chapters/` or `src/` directory whose filename matches
+ * `^\d+[-_].*\.md$`, sorts by the leading number, and uses the
+ * filename stem as the chapter title.
+ *
+ * Example match table:
+ *
+ * | Path                      | Match | Index | Title-from-stem        |
+ * |---------------------------|-------|-------|-------------------------|
+ * | chapters/01-intro.md      | yes   | 1     | "intro"                 |
+ * | chapters/02_brass-gate.md | yes   | 2     | "brass gate"            |
+ * | chapters/foo.md           | no    | —     | —                       |
+ * | src/03-fall.md            | yes   | 3     | "fall"                  |
+ * | src/index.md              | no    | —     | —                       |
+ *
+ * Caller can supply a `headingResolver` that reads a file's
+ * `# Heading` first line to override the stem-derived title; this
+ * keeps the parser pure (no IO) while still allowing 3d-detail to
+ * call `getContent` per chapter for the prettier title.
+ */
+internal object BareRepoFallback {
+
+    private val NUMBERED_MD = Regex("""^(\d+)[-_](.+)\.md$""", RegexOption.IGNORE_CASE)
+
+    /**
+     * @param paths repo-relative file paths (from a directory tree
+     *   listing — typically `chapters/` or `src/`).
+     * @param headingResolver optional reader that returns the
+     *   `# Heading` text of a chapter file, or null if unavailable.
+     *   When null, falls back to the kebab-case-to-title-case stem.
+     */
+    fun chaptersFrom(
+        paths: List<String>,
+        headingResolver: ((path: String) -> String?)? = null,
+    ): List<ManifestChapter> {
+        return paths
+            .mapNotNull { path ->
+                val filename = path.substringAfterLast('/')
+                val m = NUMBERED_MD.matchEntire(filename) ?: return@mapNotNull null
+                val index = m.groupValues[1].toIntOrNull() ?: return@mapNotNull null
+                val stem = m.groupValues[2]
+                Triple(index, path, stem)
+            }
+            .sortedBy { it.first }
+            .map { (_, path, stem) ->
+                val resolved = headingResolver?.invoke(path)?.takeIf { it.isNotBlank() }
+                val title = resolved ?: stem.replace('-', ' ').replace('_', ' ').titleCase()
+                ManifestChapter(title = title, path = path)
+            }
+    }
+
+    /** Repo name → human title. `the-archmage-coefficient` → `The Archmage Coefficient`. */
+    fun titleFromRepoName(repo: String): String =
+        repo.replace('-', ' ').replace('_', ' ').titleCase()
+
+    private fun String.titleCase(): String =
+        split(' ')
+            .filter { it.isNotEmpty() }
+            .joinToString(" ") { word ->
+                word[0].uppercaseChar() + word.substring(1)
+            }
+}

--- a/source-github/src/main/kotlin/in/jphe/storyvox/source/github/manifest/BookManifest.kt
+++ b/source-github/src/main/kotlin/in/jphe/storyvox/source/github/manifest/BookManifest.kt
@@ -1,0 +1,42 @@
+package `in`.jphe.storyvox.source.github.manifest
+
+/**
+ * Merged result of book.toml + storyvox.json + (optional) bare-repo
+ * fallback. The single shape downstream consumers
+ * ([`in`.jphe.storyvox.source.github.GitHubSource.fictionDetail],
+ * arriving in step 3d-detail-and-chapter) read from.
+ *
+ * Field origins, in priority order:
+ *  - `title` ← `book.toml [book].title` → repo name (kebab-case → Title Case)
+ *  - `author` ← first of `book.toml [book].authors` → repo owner login
+ *  - `description` ← `book.toml [book].description` → null
+ *  - `coverPath` ← `storyvox.json.cover` → null
+ *  - `tags` ← `storyvox.json.tags` → empty
+ *  - `status` ← `storyvox.json.status` → null (caller decides default)
+ *  - `language` ← `book.toml [book].language` → null
+ *  - `srcDir` ← `book.toml [book].src` → "src"
+ *  - `chapters` ← parsed `SUMMARY.md` → bare-repo numbered-file fallback
+ *  - `narratorVoiceId` ← `storyvox.json.narrator_voice_id` → null
+ *  - `honeypotSelectors` ← `storyvox.json.honeypot_selectors` → empty
+ */
+internal data class BookManifest(
+    val title: String,
+    val author: String,
+    val description: String? = null,
+    val coverPath: String? = null,
+    val tags: List<String> = emptyList(),
+    /** Raw curator string ("ongoing"/"completed"/"hiatus"/"dropped"); caller maps. */
+    val status: String? = null,
+    val language: String? = null,
+    val srcDir: String = "src",
+    val chapters: List<ManifestChapter> = emptyList(),
+    val narratorVoiceId: String? = null,
+    val honeypotSelectors: List<String> = emptyList(),
+)
+
+/** A single chapter entry derived from SUMMARY.md or the bare-repo
+ *  fallback. `path` is repo-relative (no leading slash). */
+internal data class ManifestChapter(
+    val title: String,
+    val path: String,
+)

--- a/source-github/src/main/kotlin/in/jphe/storyvox/source/github/manifest/BookTomlParser.kt
+++ b/source-github/src/main/kotlin/in/jphe/storyvox/source/github/manifest/BookTomlParser.kt
@@ -1,0 +1,162 @@
+package `in`.jphe.storyvox.source.github.manifest
+
+/**
+ * Minimal TOML reader for the subset of `book.toml` (mdbook standard)
+ * storyvox actually consumes. NOT a general-purpose TOML parser —
+ * intentionally scoped to keep the source-github module dep-free.
+ *
+ * Recognised:
+ *  - Section headers: `[book]`, `[output.html]` (subsection ignored).
+ *  - Bare key = value pairs inside the active section.
+ *  - String values: `"…"` with `\"`, `\\`, `\n`, `\t` escapes.
+ *  - String arrays: `["a", "b", "c"]` — single-line only.
+ *  - Comments: `# …` to end of line (outside strings).
+ *  - Blank lines and whitespace are ignored.
+ *
+ * NOT recognised:
+ *  - Multi-line strings (`"""…"""`).
+ *  - Numbers, booleans, datetimes.
+ *  - Inline tables.
+ *  - Multi-line arrays.
+ *  - Dotted keys.
+ *
+ * Unparseable lines fall through silently — book.toml authors using
+ * mdbook features storyvox doesn't read shouldn't crash the import.
+ */
+internal data class BookToml(
+    val title: String? = null,
+    val authors: List<String> = emptyList(),
+    val description: String? = null,
+    val language: String? = null,
+    val src: String? = null,
+)
+
+internal object BookTomlParser {
+
+    fun parse(raw: String): BookToml {
+        var section: String? = null
+        var title: String? = null
+        var authors: List<String> = emptyList()
+        var description: String? = null
+        var language: String? = null
+        var src: String? = null
+
+        for (rawLine in raw.lineSequence()) {
+            val line = stripComment(rawLine).trim()
+            if (line.isEmpty()) continue
+
+            // Section header.
+            if (line.startsWith("[") && line.endsWith("]")) {
+                section = line.substring(1, line.length - 1).trim()
+                continue
+            }
+
+            // Only [book] keys interest us. Everything else (preprocessor,
+            // output.*) we tolerate but skip.
+            if (section != "book") continue
+
+            val eq = line.indexOf('=')
+            if (eq < 0) continue
+            val key = line.substring(0, eq).trim()
+            val rest = line.substring(eq + 1).trim()
+
+            when (key) {
+                "title" -> title = parseString(rest)
+                "authors" -> authors = parseStringArray(rest)
+                "description" -> description = parseString(rest)
+                "language" -> language = parseString(rest)
+                "src" -> src = parseString(rest)
+                // book.toml may have other keys (multilingual, etc.) — skip.
+            }
+        }
+
+        return BookToml(
+            title = title,
+            authors = authors,
+            description = description,
+            language = language,
+            src = src,
+        )
+    }
+
+    /**
+     * Strip a trailing `# comment` from [line] without breaking
+     * comment characters that appear inside quoted strings.
+     */
+    private fun stripComment(line: String): String {
+        var inString = false
+        var escaped = false
+        for (i in line.indices) {
+            val c = line[i]
+            if (escaped) {
+                escaped = false
+                continue
+            }
+            when (c) {
+                '\\' -> if (inString) escaped = true
+                '"' -> inString = !inString
+                '#' -> if (!inString) return line.substring(0, i)
+            }
+        }
+        return line
+    }
+
+    /** `"hello"` → `hello`. Returns null on unparseable input. */
+    private fun parseString(raw: String): String? {
+        val s = raw.trim()
+        if (s.length < 2 || !s.startsWith('"') || !s.endsWith('"')) return null
+        return decodeEscapes(s.substring(1, s.length - 1))
+    }
+
+    /** `["a", "b"]` → `["a", "b"]`. Single-line only. */
+    private fun parseStringArray(raw: String): List<String> {
+        val s = raw.trim()
+        if (!s.startsWith("[") || !s.endsWith("]")) return emptyList()
+        val inner = s.substring(1, s.length - 1).trim()
+        if (inner.isEmpty()) return emptyList()
+        // Split by commas that aren't inside quoted strings.
+        val parts = mutableListOf<String>()
+        val current = StringBuilder()
+        var inString = false
+        var escaped = false
+        for (c in inner) {
+            if (escaped) {
+                current.append(c); escaped = false; continue
+            }
+            when {
+                c == '\\' && inString -> { current.append(c); escaped = true }
+                c == '"' -> { current.append(c); inString = !inString }
+                c == ',' && !inString -> {
+                    parts += current.toString().trim()
+                    current.clear()
+                }
+                else -> current.append(c)
+            }
+        }
+        if (current.isNotEmpty()) parts += current.toString().trim()
+        return parts.mapNotNull { parseString(it) }
+    }
+
+    private fun decodeEscapes(s: String): String {
+        if ('\\' !in s) return s
+        val sb = StringBuilder(s.length)
+        var i = 0
+        while (i < s.length) {
+            val c = s[i]
+            if (c == '\\' && i + 1 < s.length) {
+                when (val next = s[i + 1]) {
+                    '"' -> sb.append('"')
+                    '\\' -> sb.append('\\')
+                    'n' -> sb.append('\n')
+                    't' -> sb.append('\t')
+                    'r' -> sb.append('\r')
+                    else -> { sb.append(c); sb.append(next) }
+                }
+                i += 2
+            } else {
+                sb.append(c); i++
+            }
+        }
+        return sb.toString()
+    }
+}

--- a/source-github/src/main/kotlin/in/jphe/storyvox/source/github/manifest/BookTomlParser.kt
+++ b/source-github/src/main/kotlin/in/jphe/storyvox/source/github/manifest/BookTomlParser.kt
@@ -13,15 +13,20 @@ package `in`.jphe.storyvox.source.github.manifest
  *  - Comments: `# …` to end of line (outside strings).
  *  - Blank lines and whitespace are ignored.
  *
- * NOT recognised:
+ * **Unsupported by design** (not TODOs — these are intentionally out
+ * of scope; if you need them, swap to `org.tomlj:tomlj` or
+ * `com.akuleshov7:ktoml` rather than extending this parser):
  *  - Multi-line strings (`"""…"""`).
  *  - Numbers, booleans, datetimes.
- *  - Inline tables.
+ *  - Inline tables (`{ key = "value", … }`).
  *  - Multi-line arrays.
- *  - Dotted keys.
+ *  - Dotted keys (`a.b.c = "…"`).
  *
- * Unparseable lines fall through silently — book.toml authors using
- * mdbook features storyvox doesn't read shouldn't crash the import.
+ * The threat model assumes well-formed `book.toml` files written by
+ * mdbook for mdbook — adversarial input isn't on the surface, so
+ * graceful fallthrough on unparseable lines is preferred over
+ * library-style hard-fail. Authors using mdbook features storyvox
+ * doesn't read shouldn't crash the import.
  */
 internal data class BookToml(
     val title: String? = null,

--- a/source-github/src/main/kotlin/in/jphe/storyvox/source/github/manifest/ManifestParser.kt
+++ b/source-github/src/main/kotlin/in/jphe/storyvox/source/github/manifest/ManifestParser.kt
@@ -1,0 +1,77 @@
+package `in`.jphe.storyvox.source.github.manifest
+
+/**
+ * Top-level manifest assembler. Step 3d-detail-and-chapter will pass
+ * the raw bytes (or null when absent) for each candidate file plus
+ * the bare-repo file listing; this assembler merges them per the
+ * priority order documented on [BookManifest].
+ *
+ * Inputs are all optional — a bare repo with only numbered chapter
+ * files still yields a valid (if minimal) manifest. The fictionId
+ * (`github:owner/repo`) provides the fallback title and author.
+ */
+internal object ManifestParser {
+
+    /**
+     * @param fictionId stable id of the form `github:owner/repo`. Used to
+     *   derive fallback `title` (from repo) and `author` (from owner)
+     *   when manifests are absent.
+     * @param bookToml raw bytes of `book.toml` at repo root, or null.
+     * @param storyvoxJson raw bytes of `storyvox.json` at repo root, or null.
+     * @param summaryMd raw bytes of `SUMMARY.md` (under `book.toml`'s `src`
+     *   directory, default `src`), or null.
+     * @param bareRepoPaths repo-relative file paths considered for the bare-
+     *   repo fallback. Only consulted when [summaryMd] is null or yields
+     *   no chapters.
+     * @param headingResolver optional `# Heading` extractor — see
+     *   [BareRepoFallback.chaptersFrom].
+     */
+    fun parse(
+        fictionId: String,
+        bookToml: String? = null,
+        storyvoxJson: String? = null,
+        summaryMd: String? = null,
+        bareRepoPaths: List<String> = emptyList(),
+        headingResolver: ((path: String) -> String?)? = null,
+    ): BookManifest {
+        val (owner, repo) = splitFictionId(fictionId)
+        val toml = bookToml?.let { BookTomlParser.parse(it) } ?: BookToml()
+        val sv = storyvoxJson?.let { StoryvoxJsonParser.parse(it) }
+
+        val title = toml.title?.takeIf { it.isNotBlank() }
+            ?: BareRepoFallback.titleFromRepoName(repo)
+        val author = toml.authors.firstOrNull()?.takeIf { it.isNotBlank() } ?: owner
+        val srcDir = toml.src?.takeIf { it.isNotBlank() } ?: "src"
+
+        val summaryChapters = summaryMd?.let { SummaryMdParser.parse(it) }.orEmpty()
+        val chapters = if (summaryChapters.isNotEmpty()) {
+            summaryChapters
+        } else {
+            BareRepoFallback.chaptersFrom(bareRepoPaths, headingResolver)
+        }
+
+        return BookManifest(
+            title = title,
+            author = author,
+            description = toml.description,
+            coverPath = sv?.cover,
+            tags = sv?.tags.orEmpty(),
+            status = sv?.status,
+            language = toml.language,
+            srcDir = srcDir,
+            chapters = chapters,
+            narratorVoiceId = sv?.narratorVoiceId,
+            honeypotSelectors = sv?.honeypotSelectors.orEmpty(),
+        )
+    }
+
+    /** `github:owner/repo` → `(owner, repo)`. Falls back to `("unknown", id)`
+     *  if the id doesn't match the expected shape (defensive — caller is
+     *  expected to pass a valid id). */
+    private fun splitFictionId(id: String): Pair<String, String> {
+        val stripped = id.removePrefix("github:")
+        val slash = stripped.indexOf('/')
+        if (slash <= 0 || slash == stripped.length - 1) return "unknown" to stripped
+        return stripped.substring(0, slash) to stripped.substring(slash + 1)
+    }
+}

--- a/source-github/src/main/kotlin/in/jphe/storyvox/source/github/manifest/StoryvoxJson.kt
+++ b/source-github/src/main/kotlin/in/jphe/storyvox/source/github/manifest/StoryvoxJson.kt
@@ -1,0 +1,48 @@
+package `in`.jphe.storyvox.source.github.manifest
+
+import `in`.jphe.storyvox.source.github.net.GitHubJson
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.SerializationException
+
+/**
+ * Optional storyvox.json manifest at the repo root. Authored by the
+ * fiction author (the curator/registry doesn't see this) — extends
+ * mdbook's book.toml with metadata mdbook doesn't know about.
+ *
+ * Spec shape (docs/superpowers/specs/2026-05-06-github-source-design.md
+ * lines 99-114):
+ *
+ * ```json
+ * {
+ *   "version": 1,
+ *   "cover": "assets/cover.png",
+ *   "tags": ["fantasy", "litrpg"],
+ *   "status": "ongoing",
+ *   "narrator_voice_id": "en-US-Andrew:DragonHDLatestNeural",
+ *   "honeypot_selectors": []
+ * }
+ * ```
+ *
+ * Every field is optional; absence falls back to [BookManifest]
+ * defaults at merge time.
+ */
+@Serializable
+internal data class StoryvoxJson(
+    @SerialName("version") val version: Int = 1,
+    @SerialName("cover") val cover: String? = null,
+    @SerialName("tags") val tags: List<String> = emptyList(),
+    @SerialName("status") val status: String? = null,
+    @SerialName("narrator_voice_id") val narratorVoiceId: String? = null,
+    @SerialName("honeypot_selectors") val honeypotSelectors: List<String> = emptyList(),
+)
+
+internal object StoryvoxJsonParser {
+    /** Parses [raw] storyvox.json. Returns null on unparseable input —
+     *  caller falls back to defaults. */
+    fun parse(raw: String): StoryvoxJson? = try {
+        GitHubJson.decodeFromString(StoryvoxJson.serializer(), raw)
+    } catch (_: SerializationException) {
+        null
+    }
+}

--- a/source-github/src/main/kotlin/in/jphe/storyvox/source/github/manifest/SummaryMdParser.kt
+++ b/source-github/src/main/kotlin/in/jphe/storyvox/source/github/manifest/SummaryMdParser.kt
@@ -1,0 +1,36 @@
+package `in`.jphe.storyvox.source.github.manifest
+
+/**
+ * Parses mdbook's `SUMMARY.md` to extract the chapter list. The
+ * mdbook standard is:
+ *
+ * ```markdown
+ * # Summary
+ * - [Chapter Title](path/to/chapter.md)
+ * - [Another One](path/to/other.md)
+ * ```
+ *
+ * Indented entries denote subsections — we treat them as chapters
+ * for now; storyvox doesn't yet have a part/section UI.
+ *
+ * Lines that don't match the bullet-link pattern are skipped. The
+ * `# Summary` heading itself is ignored; same for any prefix
+ * paragraph headings the author may add.
+ */
+internal object SummaryMdParser {
+
+    private val LINK_PATTERN = Regex("""^\s*[-*]\s*\[(.+?)\]\(([^)]+)\)\s*$""")
+
+    fun parse(raw: String): List<ManifestChapter> {
+        val out = mutableListOf<ManifestChapter>()
+        for (line in raw.lineSequence()) {
+            val m = LINK_PATTERN.find(line) ?: continue
+            val title = m.groupValues[1].trim()
+            val path = m.groupValues[2].trim().trimStart('/')
+            if (title.isNotEmpty() && path.isNotEmpty()) {
+                out += ManifestChapter(title = title, path = path)
+            }
+        }
+        return out
+    }
+}

--- a/source-github/src/test/kotlin/in/jphe/storyvox/source/github/manifest/BareRepoFallbackTest.kt
+++ b/source-github/src/test/kotlin/in/jphe/storyvox/source/github/manifest/BareRepoFallbackTest.kt
@@ -1,0 +1,102 @@
+package `in`.jphe.storyvox.source.github.manifest
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class BareRepoFallbackTest {
+
+    @Test fun `numbered markdown files in chapters dir are picked up in order`() {
+        val chapters = BareRepoFallback.chaptersFrom(
+            listOf(
+                "chapters/01-intro.md",
+                "chapters/03-fall.md",
+                "chapters/02_brass-gate.md",
+                "README.md", // not numbered, ignored
+                "chapters/foo.md", // not numbered, ignored
+            ),
+        )
+
+        assertEquals(3, chapters.size)
+        assertEquals("chapters/01-intro.md", chapters[0].path)
+        assertEquals("chapters/02_brass-gate.md", chapters[1].path)
+        assertEquals("chapters/03-fall.md", chapters[2].path)
+    }
+
+    @Test fun `numbered files in src dir also match`() {
+        val chapters = BareRepoFallback.chaptersFrom(listOf("src/01-elric.md", "src/02-fall.md"))
+        assertEquals(2, chapters.size)
+    }
+
+    @Test fun `large numeric prefixes are sorted numerically not lexically`() {
+        // `9 < 10` numerically; lexical sort would put 10 first.
+        val chapters = BareRepoFallback.chaptersFrom(
+            listOf(
+                "chapters/10-late.md",
+                "chapters/02-early.md",
+                "chapters/9-mid.md",
+            ),
+        )
+        assertEquals(
+            listOf("chapters/02-early.md", "chapters/9-mid.md", "chapters/10-late.md"),
+            chapters.map { it.path },
+        )
+    }
+
+    @Test fun `stem becomes title-cased when no headingResolver`() {
+        val chapters = BareRepoFallback.chaptersFrom(
+            listOf("chapters/01-master-elric_and-the-orbs.md"),
+        )
+        // - and _ both become spaces; first char of each word capitalised.
+        assertEquals("Master Elric And The Orbs", chapters.single().title)
+    }
+
+    @Test fun `headingResolver overrides stem-derived title when it returns non-blank`() {
+        val chapters = BareRepoFallback.chaptersFrom(
+            paths = listOf("chapters/01-intro.md"),
+            headingResolver = { path ->
+                if (path == "chapters/01-intro.md") "An Awakening" else null
+            },
+        )
+        assertEquals("An Awakening", chapters.single().title)
+    }
+
+    @Test fun `headingResolver returning null falls back to stem title`() {
+        val chapters = BareRepoFallback.chaptersFrom(
+            paths = listOf("chapters/01-intro.md"),
+            headingResolver = { null },
+        )
+        assertEquals("Intro", chapters.single().title)
+    }
+
+    @Test fun `headingResolver returning blank falls back to stem title`() {
+        val chapters = BareRepoFallback.chaptersFrom(
+            paths = listOf("chapters/01-intro.md"),
+            headingResolver = { "   " },
+        )
+        assertEquals("Intro", chapters.single().title)
+    }
+
+    @Test fun `non-md numbered files are ignored`() {
+        val chapters = BareRepoFallback.chaptersFrom(
+            listOf("chapters/01-foo.txt", "chapters/02-bar.md"),
+        )
+        assertEquals(1, chapters.size)
+        assertEquals("chapters/02-bar.md", chapters.single().path)
+    }
+
+    @Test fun `empty input yields empty list`() {
+        assertTrue(BareRepoFallback.chaptersFrom(emptyList()).isEmpty())
+    }
+
+    @Test fun `repo name is title-cased`() {
+        assertEquals(
+            "The Archmage Coefficient",
+            BareRepoFallback.titleFromRepoName("the-archmage-coefficient"),
+        )
+        assertEquals(
+            "Underscored Name Works",
+            BareRepoFallback.titleFromRepoName("underscored_name_works"),
+        )
+    }
+}

--- a/source-github/src/test/kotlin/in/jphe/storyvox/source/github/manifest/BookTomlParserTest.kt
+++ b/source-github/src/test/kotlin/in/jphe/storyvox/source/github/manifest/BookTomlParserTest.kt
@@ -1,0 +1,145 @@
+package `in`.jphe.storyvox.source.github.manifest
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class BookTomlParserTest {
+
+    @Test fun `full book section parses every field`() {
+        val toml = BookTomlParser.parse(
+            """
+                [book]
+                title = "The Archmage Coefficient"
+                authors = ["onedayokay", "co-author"]
+                description = "An overpowered archmage relearns humility."
+                language = "en"
+                src = "src"
+            """.trimIndent(),
+        )
+
+        assertEquals("The Archmage Coefficient", toml.title)
+        assertEquals(listOf("onedayokay", "co-author"), toml.authors)
+        assertEquals("An overpowered archmage relearns humility.", toml.description)
+        assertEquals("en", toml.language)
+        assertEquals("src", toml.src)
+    }
+
+    @Test fun `keys outside the book section are ignored`() {
+        val toml = BookTomlParser.parse(
+            """
+                [book]
+                title = "T"
+
+                [output.html]
+                no-section-folding = true
+                additional-css = ["theme/my.css"]
+
+                [preprocessor.toc]
+                command = "mdbook-toc"
+            """.trimIndent(),
+        )
+
+        assertEquals("T", toml.title)
+        // Nothing leaks from output/preprocessor sections.
+        assertTrue(toml.authors.isEmpty())
+        assertNull(toml.description)
+    }
+
+    @Test fun `comments are stripped including inline comments after values`() {
+        val toml = BookTomlParser.parse(
+            """
+                # full-line comment
+                [book]
+                title = "T" # inline comment
+                # another full-line
+                language = "en"
+            """.trimIndent(),
+        )
+
+        assertEquals("T", toml.title)
+        assertEquals("en", toml.language)
+    }
+
+    @Test fun `comment characters inside string values are preserved`() {
+        val toml = BookTomlParser.parse("""[book]
+            |description = "Hash # in the description"
+        """.trimMargin())
+
+        assertEquals("Hash # in the description", toml.description)
+    }
+
+    @Test fun `escape sequences in strings decode`() {
+        val toml = BookTomlParser.parse(
+            """
+                [book]
+                title = "Q: \"Why?\""
+                description = "line1\nline2\twith tab"
+            """.trimIndent(),
+        )
+
+        assertEquals("Q: \"Why?\"", toml.title)
+        assertEquals("line1\nline2\twith tab", toml.description)
+    }
+
+    @Test fun `empty array yields empty authors`() {
+        val toml = BookTomlParser.parse("""[book]
+            |authors = []
+        """.trimMargin())
+
+        assertTrue(toml.authors.isEmpty())
+    }
+
+    @Test fun `single-author array works`() {
+        val toml = BookTomlParser.parse("""[book]
+            |authors = ["solo"]
+        """.trimMargin())
+
+        assertEquals(listOf("solo"), toml.authors)
+    }
+
+    @Test fun `unparseable values are silently dropped`() {
+        // Numbers, booleans, dotted keys — none of these are
+        // recognised, but the parser doesn't crash on them.
+        val toml = BookTomlParser.parse(
+            """
+                [book]
+                title = "OK"
+                future_field = 42
+                another = true
+                a.b.c = "dotted"
+                description = "Real value still parses"
+            """.trimIndent(),
+        )
+
+        assertEquals("OK", toml.title)
+        assertEquals("Real value still parses", toml.description)
+    }
+
+    @Test fun `missing book section yields all-null result`() {
+        val toml = BookTomlParser.parse(
+            """
+                [preprocessor.toc]
+                command = "mdbook-toc"
+            """.trimIndent(),
+        )
+
+        assertNull(toml.title)
+        assertNull(toml.description)
+        assertTrue(toml.authors.isEmpty())
+    }
+
+    @Test fun `empty input yields all-null result`() {
+        val toml = BookTomlParser.parse("")
+        assertNull(toml.title)
+        assertNull(toml.description)
+    }
+
+    @Test fun `whitespace tolerance around tokens`() {
+        val toml = BookTomlParser.parse(
+            "[book]\n   title    =    \"Spaced\"   \n",
+        )
+        assertEquals("Spaced", toml.title)
+    }
+}

--- a/source-github/src/test/kotlin/in/jphe/storyvox/source/github/manifest/ManifestParserTest.kt
+++ b/source-github/src/test/kotlin/in/jphe/storyvox/source/github/manifest/ManifestParserTest.kt
@@ -1,0 +1,185 @@
+package `in`.jphe.storyvox.source.github.manifest
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class ManifestParserTest {
+
+    @Test fun `full happy path uses book toml + storyvox json + summary md`() {
+        val manifest = ManifestParser.parse(
+            fictionId = "github:onedayokay/the-archmage-coefficient",
+            bookToml = """
+                [book]
+                title = "The Archmage Coefficient"
+                authors = ["onedayokay"]
+                description = "An overpowered archmage relearns humility."
+                language = "en"
+                src = "src"
+            """.trimIndent(),
+            storyvoxJson = """
+                {
+                  "version": 1,
+                  "cover": "assets/cover.png",
+                  "tags": ["fantasy", "litrpg"],
+                  "status": "ongoing",
+                  "narrator_voice_id": "en-US-Andrew:DragonHDLatestNeural"
+                }
+            """.trimIndent(),
+            summaryMd = """
+                # Summary
+
+                - [Master Elric](chapters/01-master-elric.md)
+                - [The Brass Gate](chapters/02-brass-gate.md)
+            """.trimIndent(),
+        )
+
+        assertEquals("The Archmage Coefficient", manifest.title)
+        assertEquals("onedayokay", manifest.author)
+        assertEquals("An overpowered archmage relearns humility.", manifest.description)
+        assertEquals("assets/cover.png", manifest.coverPath)
+        assertEquals(listOf("fantasy", "litrpg"), manifest.tags)
+        assertEquals("ongoing", manifest.status)
+        assertEquals("en", manifest.language)
+        assertEquals("src", manifest.srcDir)
+        assertEquals(2, manifest.chapters.size)
+        assertEquals("Master Elric", manifest.chapters[0].title)
+        assertEquals("en-US-Andrew:DragonHDLatestNeural", manifest.narratorVoiceId)
+    }
+
+    @Test fun `bare repo falls back to repo name + numbered files`() {
+        val manifest = ManifestParser.parse(
+            fictionId = "github:jphein/example-fiction",
+            bareRepoPaths = listOf(
+                "chapters/01-intro.md",
+                "chapters/02-the-gate.md",
+                "README.md",
+            ),
+        )
+
+        assertEquals("Example Fiction", manifest.title)
+        assertEquals("jphein", manifest.author)
+        assertEquals(2, manifest.chapters.size)
+        assertEquals("chapters/01-intro.md", manifest.chapters[0].path)
+        assertEquals("Intro", manifest.chapters[0].title)
+        assertNull(manifest.description)
+        assertNull(manifest.coverPath)
+        assertTrue(manifest.tags.isEmpty())
+        assertNull(manifest.status)
+    }
+
+    @Test fun `summary md takes precedence over bare-repo fallback`() {
+        val manifest = ManifestParser.parse(
+            fictionId = "github:o/r",
+            bookToml = """[book]
+                |title = "T"
+            """.trimMargin(),
+            summaryMd = "- [Custom](custom.md)",
+            bareRepoPaths = listOf("chapters/01-numbered.md"),
+        )
+
+        assertEquals(1, manifest.chapters.size)
+        assertEquals("custom.md", manifest.chapters.single().path)
+        assertEquals("Custom", manifest.chapters.single().title)
+    }
+
+    @Test fun `falls back to bare repo when summary md is empty`() {
+        // Author may have a SUMMARY.md that's just a heading with no
+        // chapter list (work-in-progress repo). Fall through to the
+        // numbered-file heuristic rather than yielding zero chapters
+        // when files are present.
+        val manifest = ManifestParser.parse(
+            fictionId = "github:o/r",
+            summaryMd = "# Summary\n",
+            bareRepoPaths = listOf("chapters/01-fall.md"),
+        )
+
+        assertEquals(1, manifest.chapters.size)
+        assertEquals("chapters/01-fall.md", manifest.chapters.single().path)
+    }
+
+    @Test fun `book toml without authors falls back to repo owner`() {
+        val manifest = ManifestParser.parse(
+            fictionId = "github:owner/repo",
+            bookToml = """[book]
+                |title = "Has Title"
+            """.trimMargin(),
+        )
+        assertEquals("Has Title", manifest.title)
+        assertEquals("owner", manifest.author)
+    }
+
+    @Test fun `blank book toml title falls back to repo name`() {
+        val manifest = ManifestParser.parse(
+            fictionId = "github:o/lovely-repo",
+            bookToml = """[book]
+                |title = ""
+            """.trimMargin(),
+        )
+        assertEquals("Lovely Repo", manifest.title)
+    }
+
+    @Test fun `storyvox json fields fill in mdbook gaps`() {
+        val manifest = ManifestParser.parse(
+            fictionId = "github:o/r",
+            bookToml = """[book]
+                |title = "T"
+            """.trimMargin(),
+            storyvoxJson = """
+                {
+                  "version": 1,
+                  "cover": "cover.png",
+                  "tags": ["sci-fi"],
+                  "status": "completed",
+                  "honeypot_selectors": [".secret"]
+                }
+            """.trimIndent(),
+        )
+
+        assertEquals("cover.png", manifest.coverPath)
+        assertEquals(listOf("sci-fi"), manifest.tags)
+        assertEquals("completed", manifest.status)
+        assertEquals(listOf(".secret"), manifest.honeypotSelectors)
+    }
+
+    @Test fun `unparseable manifests fall through gracefully`() {
+        val manifest = ManifestParser.parse(
+            fictionId = "github:o/r",
+            bookToml = "garbage\nno-section\n",
+            storyvoxJson = "{ not json",
+        )
+
+        // Nothing parsed; we still get a valid manifest with fallbacks.
+        assertEquals("R", manifest.title) // from repo name "r" → titlecase
+        assertEquals("o", manifest.author)
+        assertNull(manifest.description)
+        assertNull(manifest.coverPath)
+    }
+
+    @Test fun `malformed fictionId still yields something printable`() {
+        val manifest = ManifestParser.parse(fictionId = "not-a-github-id")
+        // unknown owner, raw id as repo
+        assertEquals("Not A Github Id", manifest.title)
+        assertEquals("unknown", manifest.author)
+    }
+
+    @Test fun `defaults match documented field origins`() {
+        val manifest = ManifestParser.parse(fictionId = "github:owner/repo-name")
+        assertEquals("Repo Name", manifest.title)
+        assertEquals("owner", manifest.author)
+        assertEquals("src", manifest.srcDir)
+        assertTrue(manifest.tags.isEmpty())
+        assertTrue(manifest.honeypotSelectors.isEmpty())
+        assertTrue(manifest.chapters.isEmpty())
+    }
+
+    @Test fun `headingResolver routes through to bare-repo path`() {
+        val manifest = ManifestParser.parse(
+            fictionId = "github:o/r",
+            bareRepoPaths = listOf("chapters/01-intro.md"),
+            headingResolver = { "An Awakening" },
+        )
+        assertEquals("An Awakening", manifest.chapters.single().title)
+    }
+}

--- a/source-github/src/test/kotlin/in/jphe/storyvox/source/github/manifest/StoryvoxJsonParserTest.kt
+++ b/source-github/src/test/kotlin/in/jphe/storyvox/source/github/manifest/StoryvoxJsonParserTest.kt
@@ -1,0 +1,69 @@
+package `in`.jphe.storyvox.source.github.manifest
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class StoryvoxJsonParserTest {
+
+    @Test fun `full document parses every field`() {
+        val sv = StoryvoxJsonParser.parse(
+            """
+                {
+                  "version": 1,
+                  "cover": "assets/cover.png",
+                  "tags": ["fantasy", "litrpg"],
+                  "status": "ongoing",
+                  "narrator_voice_id": "en-US-Andrew:DragonHDLatestNeural",
+                  "honeypot_selectors": [".audio-only", ".visual-only"]
+                }
+            """.trimIndent(),
+        )!!
+
+        assertEquals(1, sv.version)
+        assertEquals("assets/cover.png", sv.cover)
+        assertEquals(listOf("fantasy", "litrpg"), sv.tags)
+        assertEquals("ongoing", sv.status)
+        assertEquals("en-US-Andrew:DragonHDLatestNeural", sv.narratorVoiceId)
+        assertEquals(listOf(".audio-only", ".visual-only"), sv.honeypotSelectors)
+    }
+
+    @Test fun `minimal document with only version parses`() {
+        val sv = StoryvoxJsonParser.parse("""{ "version": 1 }""")!!
+        assertEquals(1, sv.version)
+        assertNull(sv.cover)
+        assertTrue(sv.tags.isEmpty())
+        assertNull(sv.status)
+        assertNull(sv.narratorVoiceId)
+        assertTrue(sv.honeypotSelectors.isEmpty())
+    }
+
+    @Test fun `unknown keys are tolerated for forward-compat`() {
+        val sv = StoryvoxJsonParser.parse(
+            """
+                {
+                  "version": 1,
+                  "future_extension": "shrug",
+                  "tags": ["fantasy"]
+                }
+            """.trimIndent(),
+        )
+        assertNotNull(sv)
+        assertEquals(listOf("fantasy"), sv!!.tags)
+    }
+
+    @Test fun `unparseable input returns null`() {
+        assertNull(StoryvoxJsonParser.parse("not json {"))
+        assertNull(StoryvoxJsonParser.parse("[1, 2, 3]"))
+    }
+
+    @Test fun `version defaults to 1 when omitted`() {
+        // Curators may forget to author the version field; we don't
+        // hard-fail on it.
+        val sv = StoryvoxJsonParser.parse("""{ "tags": [] }""")
+        assertNotNull(sv)
+        assertEquals(1, sv!!.version)
+    }
+}

--- a/source-github/src/test/kotlin/in/jphe/storyvox/source/github/manifest/SummaryMdParserTest.kt
+++ b/source-github/src/test/kotlin/in/jphe/storyvox/source/github/manifest/SummaryMdParserTest.kt
@@ -1,0 +1,98 @@
+package `in`.jphe.storyvox.source.github.manifest
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class SummaryMdParserTest {
+
+    @Test fun `standard mdbook summary parses chapter entries`() {
+        val chapters = SummaryMdParser.parse(
+            """
+                # Summary
+
+                - [Master Elric and the Spirit Orbs](chapters/01-master-elric.md)
+                - [The Brass Gate](chapters/02-brass-gate.md)
+                - [The Fall](chapters/03-the-fall.md)
+            """.trimIndent(),
+        )
+
+        assertEquals(3, chapters.size)
+        assertEquals("Master Elric and the Spirit Orbs", chapters[0].title)
+        assertEquals("chapters/01-master-elric.md", chapters[0].path)
+        assertEquals("The Brass Gate", chapters[1].title)
+        assertEquals("chapters/02-brass-gate.md", chapters[1].path)
+    }
+
+    @Test fun `asterisk bullets work the same as dashes`() {
+        val chapters = SummaryMdParser.parse(
+            """
+                * [One](a.md)
+                * [Two](b.md)
+            """.trimIndent(),
+        )
+        assertEquals(2, chapters.size)
+    }
+
+    @Test fun `indented entries are still parsed as chapters`() {
+        val chapters = SummaryMdParser.parse(
+            """
+                # Summary
+
+                - [Part 1](part1.md)
+                  - [Sub A](part1/a.md)
+                  - [Sub B](part1/b.md)
+                - [Part 2](part2.md)
+            """.trimIndent(),
+        )
+
+        assertEquals(4, chapters.size)
+        assertEquals("Sub A", chapters[1].title)
+        assertEquals("part1/a.md", chapters[1].path)
+    }
+
+    @Test fun `non-bullet lines including the heading are skipped`() {
+        val chapters = SummaryMdParser.parse(
+            """
+                # Summary
+
+                Some prose the author added.
+
+                ## Part 1
+
+                - [One](a.md)
+
+                ## Part 2
+
+                - [Two](b.md)
+            """.trimIndent(),
+        )
+
+        assertEquals(2, chapters.size)
+        assertEquals(listOf("a.md", "b.md"), chapters.map { it.path })
+    }
+
+    @Test fun `leading slash on the path is trimmed`() {
+        val chapters = SummaryMdParser.parse("- [T](/abs/path.md)")
+        assertEquals("abs/path.md", chapters.single().path)
+    }
+
+    @Test fun `empty title or path is rejected`() {
+        // We can't represent these as ManifestChapter — drop them
+        // rather than emitting a malformed row.
+        val chapters = SummaryMdParser.parse(
+            """
+                - [](a.md)
+                - [Title]()
+                - [OK](good.md)
+            """.trimIndent(),
+        )
+        assertEquals(1, chapters.size)
+        assertEquals("OK", chapters.single().title)
+    }
+
+    @Test fun `empty input yields empty list`() {
+        assertTrue(SummaryMdParser.parse("").isEmpty())
+        assertTrue(SummaryMdParser.parse("   \n   ").isEmpty())
+    }
+}


### PR DESCRIPTION
## Summary

Step 3d-manifest of the GitHub-source plan ([spec](docs/superpowers/specs/2026-05-06-github-source-design.md)). First of three split PRs (per team-lead's call to land manifest, markdown, and detail-and-chapter as three independent reviewable units). **Pure parsing — no `:source-github` integration yet.** Hilt `@IntoMap @StringKey("github")` binding stays deferred to the third PR (3d-detail-and-chapter).

## What lands

All `internal` to `:source-github` — surface is consumer-facing only when 3d-detail-and-chapter wires `fictionDetail` to it.

- **`BookManifest`** — merged result of book.toml + storyvox.json + bare-repo fallback. Field-origin priority documented on the kdoc. `ManifestChapter(title, path)` for chapter rows.
- **`BookTomlParser`** — minimal hand-rolled TOML reader for the subset of `book.toml`'s `[book]` section storyvox actually consumes (`title`, `authors`, `description`, `language`, `src`). Recognises section headers, `key = value` pairs with double-quoted strings, single-line string arrays, comments (incl. comment-char-in-string handling), basic escapes (`\"`, `\\`, `\n`, `\t`). **No general-purpose TOML** — explicitly scoped to keep the source-github module dep-free per CLAUDE.md "simplest approach first". Unparseable lines fall through silently.
- **`StoryvoxJsonParser`** — kotlinx.serialization `@Serializable` wrapper for the optional `storyvox.json` extension manifest (cover/tags/status/narrator_voice_id/honeypot_selectors). Returns null on unparseable input.
- **`SummaryMdParser`** — extracts `(title, path)` pairs from mdbook's `SUMMARY.md` bullet-link format. Both `-` and `*` bullets, indented entries treated as flat chapters (no part/section UI yet).
- **`BareRepoFallback`** — last-resort chapter list when neither manifest is present. Picks `chapters/` or `src/` files matching `^\d+[-_].*\.md$`, sorts **numerically** (so 9 < 10, not lexical), uses the kebab/snake stem title-cased as the chapter title with an optional `headingResolver` override for `# Heading` lines. Repo-name → title-case helper for the fiction title fallback.
- **`ManifestParser`** — top-level orchestrator. Takes raw bytes for each candidate (any null) plus the bare-repo file listing, returns a unified `BookManifest`. Field-origin priority order documented on `BookManifest`. Garbage manifests fall through to fallbacks rather than crashing the import.

## Why no new gradle dep

`book.toml`'s `[book]` section is small and well-shaped enough that a 162-line hand-rolled parser handles every field storyvox cares about, with explicit kdoc on what's *not* recognised. Adding `org.tomlj:tomlj` or `com.akuleshov7:ktoml` would import a general-purpose TOML reader plus its supply chain for ~200 lines of avoidable scope. Per CLAUDE.md "simplest approach first, no over-engineering". If we ever start consuming TOML elsewhere or `book.toml`'s schema we read grows materially, that's the time to swap in a real library.

## Test plan

44 new unit tests; **73 total** in the module (29 from 3a/3c + 44 new). All green. Pure-JVM, runs in <1s.

- [x] `BookTomlParserTest` (11): full happy path, `[output.*]` section ignored, comment stripping (full-line + inline + comment-char-inside-string), escape sequences, empty/single-author arrays, unparseable values silently dropped, missing/empty input, whitespace tolerance.
- [x] `StoryvoxJsonParserTest` (5): full document, minimal version-only, unknown keys tolerated, unparseable→null, version defaults to 1.
- [x] `SummaryMdParserTest` (7): standard mdbook format, asterisk bullets, indented entries, non-bullet lines skipped, leading-slash trim, empty title/path rejected, empty input.
- [x] `BareRepoFallbackTest` (10): order-by-numeric-prefix, src/ also matches, **9 < 10 numeric not lexical**, stem title-case, headingResolver override + null/blank fallback, non-md ignored, empty input, repo-name→title.
- [x] `ManifestParserTest` (11): full happy path, bare-repo fallback, SUMMARY.md > bare-repo precedence, empty SUMMARY falls through, missing-author falls back to owner, blank title falls back to repo, storyvox.json fills mdbook gaps, unparseable manifests fall through, malformed fictionId still printable, defaults match documented origins, headingResolver routes through.
- [x] `:source-github:testDebugUnitTest` — all green.
- [x] `:app:assembleDebug` clean — Hilt graph unaffected since `GitHubSource.fictionDetail` still throws.

## What this unblocks

- **3d-markdown (next)**: commonmark integration + ChapterContent rendering (markdown → HTML/plaintext). Fully isolated — different files, different concern. Reviewers can sign off on each PR independently.
- **3d-detail-and-chapter (third)**: `GitHubSource.fictionDetail` + `.chapter` implementations consuming both — plus the `@IntoMap @StringKey("github")` Hilt binding. End-to-end `addByUrl(github URL)` integration starts working only when all three are merged. No half-implementation can ship.

## Worktree + branch

- Worktree: `.claude/worktrees/selene-github-manifest`
- Branch: `dream/selene/source-github-manifest`