### PR TITLE
feat(motion): glide sentence-highlight underline between sentences

### DIFF
--- a/core-ui/src/main/kotlin/in/jphe/storyvox/ui/component/SentenceHighlight.kt
+++ b/core-ui/src/main/kotlin/in/jphe/storyvox/ui/component/SentenceHighlight.kt
@@ -1,6 +1,7 @@
 package `in`.jphe.storyvox.ui.component
 
 import androidx.compose.animation.core.animateFloatAsState
+import androidx.compose.animation.core.animateIntAsState
 import androidx.compose.foundation.gestures.detectTapGestures
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
@@ -22,6 +23,7 @@ import androidx.compose.ui.text.TextLayoutResult
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import `in`.jphe.storyvox.ui.theme.LocalMotion
+import `in`.jphe.storyvox.ui.theme.LocalReducedMotion
 
 /**
  * Renders chapter text with a brass underline that animates over the currently-spoken sentence.
@@ -80,12 +82,44 @@ fun SentenceHighlight(
         }
     }
 
+    val reducedMotion = LocalReducedMotion.current
+
+    // The underline used to snap from one sentence's bounds to the next.
+    // Now we animate the bounds themselves: `animatedStart` and
+    // `animatedEnd` glide between consecutive sentence ranges over
+    // `sentenceDurationMs` (180ms via `sentenceEasing`). The drawBehind
+    // resolves these animated offsets to line positions, so within a line
+    // the underline literally slides its edges; crossing a line boundary
+    // reads as a continuous traversal of the offset space rather than a
+    // jump cut.
+    //
+    // Reduced motion: skip the int animations entirely, fall back to the
+    // raw values. Same contract as cascadeReveal / NavHost / spinner /
+    // sleep timer — absent motion, not shorter motion.
+    val animatedStart by animateIntAsState(
+        targetValue = highlightStart,
+        animationSpec = androidx.compose.animation.core.tween(motion.sentenceDurationMs, easing = motion.sentenceEasing),
+        label = "sentenceUnderlineStart",
+    )
+    val animatedEnd by animateIntAsState(
+        targetValue = highlightEnd,
+        animationSpec = androidx.compose.animation.core.tween(motion.sentenceDurationMs, easing = motion.sentenceEasing),
+        label = "sentenceUnderlineEnd",
+    )
+
+    // Fade the underline in on first appearance / out on disappearance.
+    // Held at 1f throughout sentence-to-sentence transitions because the
+    // underline is *moving*, not appearing — fading the brass would obscure
+    // the glide.
     val target = if (highlightEnd > highlightStart) 1f else 0f
     val animated by animateFloatAsState(
         targetValue = target,
         animationSpec = androidx.compose.animation.core.tween(motion.sentenceDurationMs, easing = motion.sentenceEasing),
         label = "sentenceUnderline",
     )
+
+    val drawStart = if (reducedMotion) highlightStart else animatedStart
+    val drawEnd = if (reducedMotion) highlightEnd else animatedEnd
 
     Text(
         text = annotated,
@@ -121,9 +155,9 @@ fun SentenceHighlight(
             )
             .drawBehind {
                 val l = layout ?: return@drawBehind
-                if (highlightEnd <= highlightStart) return@drawBehind
-                val safeStart = highlightStart.coerceIn(0, text.length)
-                val safeEnd = highlightEnd.coerceIn(safeStart, text.length)
+                if (drawEnd <= drawStart) return@drawBehind
+                val safeStart = drawStart.coerceIn(0, text.length)
+                val safeEnd = drawEnd.coerceIn(safeStart, text.length)
                 val firstLine = l.getLineForOffset(safeStart)
                 val lastLine = l.getLineForOffset(safeEnd.coerceAtLeast(safeStart + 1) - 1)
                 for (line in firstLine..lastLine) {


### PR DESCRIPTION
## Summary

Last item in the motion vocabulary queue. The brass sentence-highlight underline in the reader currently *instant-relocates* on each TTS sentence change — `highlightStart` and `highlightEnd` jump from one range to another, and the existing `animated` float (already at 1f whenever a sentence is highlighted) provides no traversal motion. The reader sees a snap.

This PR makes the underline **glide**.

## What changes

The bounds themselves are now animated. Two new `animateIntAsState` values, `animatedStart` and `animatedEnd`, track the target `highlightStart` / `highlightEnd` over the existing `sentenceDurationMs` (180ms with `sentenceEasing`). The `drawBehind` block resolves these animated offsets to line positions, so:

- **Within a line**: the underline literally slides its left and right edges from the previous sentence's bounds to the new sentence's bounds.
- **Across line boundaries**: the offset interpolates through positions that resolve to consecutive lines, so the underline reads as a continuous traversal of the offset space rather than a jump cut.

## Why 180ms is the right duration (and unchanged)

TTS at 1.0× speech rate runs roughly 3-5 seconds per sentence. The underline must finish moving well before the next sentence arrives — at 180ms it's done in ~6% of a sentence's duration, which is fast enough to feel responsive but slow enough to register as a slide rather than a flicker.

The existing `Motion.sentenceEasing` token already encodes this constraint in its docstring: *"must keep up with TTS rate."* Reusing the token instead of introducing a new one is exactly the discipline `LocalMotion` was designed for. Vesper's framing from earlier in the session: one motion vocabulary, not three coincidentally-similar ones.

## Reduced motion

Short-circuit to the raw `highlightStart` / `highlightEnd` values when `LocalReducedMotion.current` is true. Underline relocates instantly. Fifth surface in the codebase honoring the contract:

1. `cascadeReveal` modifier — no-op `Modifier` returned
2. `NavHost` transitions — null transition factories
3. Spinner crossfade (Vesper's #56) — `EnterTransition.None` / `ExitTransition.None`
4. Sleep timer pulse / hue (#59) — pulse alpha held at 1f, hue stays base
5. **This PR** — underline offsets pass through unanimated

Different APIs, same contract: reduce motion = absent motion, not shorter motion.

## Files

- `core-ui/.../component/SentenceHighlight.kt` — single-file change. Two new `animateIntAsState` calls, two new local vals (`drawStart` / `drawEnd`) gating on reduced motion, four-character body change in the `drawBehind` block (uses `drawStart` / `drawEnd` instead of `highlightStart` / `highlightEnd`). Net: +37 / -3.

The existing alpha animation (`val animated by animateFloatAsState(...)`) is preserved untouched — it still fades the brass on first appearance / disappearance. Held at 1f throughout sentence-to-sentence transitions because the underline is *moving*, not appearing — fading the brass during a glide would obscure it.

## Test plan

- [x] Build green: `:app:assembleDebug` against `dream/lumen/sentence-highlight-easing` off `78eabb8` (post-v0.4.22). Only pre-existing deprecation warnings.
- [x] APK installs cleanly on R83W80CAFZB. Crash-free launch, no FATAL in logcat.
- [x] Tablet lock claimed and released within budget (task #47).
- [ ] **Live underline glide pending JP's first session with active TTS playback.** Reaching the underline live requires fiction loaded + chapter open + TTS playing + sentence transitions, which is way deeper than the 2-min lock budget allows. The change is visually layered (animation runs only when `highlightStart` / `highlightEnd` change; static text rendering untouched), so empty-state and no-active-highlight paths are unaffected. Worst-case failure is "the glide feels too fast/slow" which is parameter-tunable on a follow-up commit.
- [ ] Reduced-motion path: verified by code path (`drawStart` / `drawEnd` short-circuit to raw values when `LocalReducedMotion.current` is true). Test path: enable Developer Options → Animator duration scale = Off, expect underline to instant-relocate.

## What this closes out

Ninth motion PR in the session. Motion vocabulary surfaces touched:

1. #25 — Library/Browse cascade reveal
2. #42 — NavHost screen transitions
3. #51 — PlaybackSheet candlelight + `LocalReducedMotion` token
4. #55 — Voice library row cascade
5. #56 — Magic spinner crossfade (Vesper)
6. #59 — Sleep timer pulse + urgent hue shift
7. **This PR** — Sentence-highlight underline glide

Plus #58 (Selene's source-github registry) and Aurelia's perf lane (#53) flowed in alongside. Storyvox's motion vocabulary went from zero to a coherent token-driven system in one session.

🤖 Generated with [Claude Code](https://claude.com/claude-code)