### PR TITLE
feat(source-github): commonmark renderer for markdown → HTML + plaintext

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -33,6 +33,7 @@ media3 = "1.5.0"
 # Networking + parsing
 okhttp = "4.12.0"
 jsoup = "1.18.1"
+commonmark = "0.24.0"
 androidx-webkit = "1.12.1"
 
 # Concurrency
@@ -114,6 +115,7 @@ play-services-wearable = { module = "com.google.android.gms:play-services-wearab
 okhttp = { module = "com.squareup.okhttp3:okhttp", version.ref = "okhttp" }
 okhttp-logging = { module = "com.squareup.okhttp3:logging-interceptor", version.ref = "okhttp" }
 jsoup = { module = "org.jsoup:jsoup", version.ref = "jsoup" }
+commonmark = { module = "org.commonmark:commonmark", version.ref = "commonmark" }
 androidx-webkit = { module = "androidx.webkit:webkit", version.ref = "androidx-webkit" }
 
 # Coroutines

--- a/source-github/build.gradle.kts
+++ b/source-github/build.gradle.kts
@@ -31,6 +31,7 @@ dependencies {
     implementation(libs.kotlinx.serialization.json)
     implementation(libs.okhttp)
     implementation(libs.okhttp.logging)
+    implementation(libs.commonmark)
 
     implementation(libs.hilt.android)
     ksp(libs.hilt.compiler)

--- a/source-github/src/main/kotlin/in/jphe/storyvox/source/github/render/MarkdownChapterRenderer.kt
+++ b/source-github/src/main/kotlin/in/jphe/storyvox/source/github/render/MarkdownChapterRenderer.kt
@@ -1,0 +1,132 @@
+package `in`.jphe.storyvox.source.github.render
+
+import `in`.jphe.storyvox.data.source.model.ChapterContent
+import `in`.jphe.storyvox.data.source.model.ChapterInfo
+import org.commonmark.node.AbstractVisitor
+import org.commonmark.node.Image
+import org.commonmark.node.Link
+import org.commonmark.node.Node
+import org.commonmark.parser.Parser
+import org.commonmark.renderer.html.HtmlRenderer
+import org.commonmark.renderer.text.TextContentRenderer
+import javax.inject.Inject
+import javax.inject.Singleton
+
+/**
+ * Render a markdown chapter body into a [ChapterContent] (sanitized
+ * HTML for the reader view + plaintext for the TTS engine).
+ *
+ * Two passes over the same parsed AST:
+ *  1. [HtmlRenderer] → `htmlBody` for the reader.
+ *  2. [TextContentRenderer] → `plainBody` for sentence chunking +
+ *     audiobook playback. Default config is "compact" — paragraphs
+ *     join with newlines, list items get a leading dash, headings
+ *     and inline emphasis become bare text. Good enough for the
+ *     SentenceChunker downstream.
+ *
+ * The `# Heading` first-line of a chapter file is stripped from
+ * `plainBody` when present — `ManifestChapter.title` already carries
+ * it, and reading the title aloud in the audio is redundant. (The
+ * HTML view keeps the heading; that's a visual landmark for sighted
+ * readers.)
+ *
+ * Honeypot enforcement (per spec line 130) is **deliberately not
+ * applied here** — this is a pure markdown→content transform. The
+ * caller (step 3d-detail-and-chapter, when GitHubSource.chapter
+ * lights up) is the right layer to drop honeypot blocks before
+ * handing to the playback engine, since that layer also has access
+ * to the manifest's `honeypotSelectors` config.
+ */
+@Singleton
+internal class MarkdownChapterRenderer @Inject constructor() {
+
+    private val parser: Parser = Parser.builder().build()
+    private val htmlRenderer: HtmlRenderer = HtmlRenderer.builder()
+        .escapeHtml(true)
+        .softbreak("<br />\n")
+        .build()
+    private val textRenderer: TextContentRenderer = TextContentRenderer.builder().build()
+
+    /**
+     * @param info chapter metadata to attach to the rendered content.
+     * @param markdown raw chapter body. Empty or whitespace-only input
+     *   yields an empty-but-valid [ChapterContent] (the reader UI
+     *   handles the empty-body case).
+     */
+    fun render(info: ChapterInfo, markdown: String): ChapterContent {
+        val htmlAst: Node = parser.parse(markdown)
+        val html = htmlRenderer.render(htmlAst).trim()
+        // Re-parse for plaintext so the AST mutation below doesn't
+        // affect the HTML branch — Node visitors mutate the tree.
+        val plainAst: Node = parser.parse(markdown)
+        flattenLinksAndImages(plainAst)
+        val plain = textRenderer.render(plainAst).trim()
+        return ChapterContent(
+            info = info,
+            htmlBody = html,
+            plainBody = stripLeadingHeading(plain),
+        )
+    }
+
+    /**
+     * Replace [Link] nodes with their child text and drop [Image]
+     * nodes entirely from the AST. commonmark's TextContentRenderer
+     * defaults to emitting `"anchor" (url)` for links and
+     * `"alt" (src)` for images — fine for terminal logs, wrong for
+     * audiobook playback. This visitor strips the URL/src half.
+     *
+     * Images go entirely (alt text often duplicates surrounding
+     * prose); link anchor text stays since dropping it would orphan
+     * the surrounding sentence ("Visit for more info." reads worse
+     * than "Visit the docs for more info.").
+     */
+    private fun flattenLinksAndImages(root: Node) {
+        root.accept(object : AbstractVisitor() {
+            override fun visit(link: Link) {
+                // Inline anchor children before dropping the Link wrapper.
+                var child = link.firstChild
+                while (child != null) {
+                    val next = child.next
+                    link.insertBefore(child)
+                    child = next
+                }
+                link.unlink()
+            }
+
+            override fun visit(image: Image) {
+                // Drop entirely — alt text is for sighted-fallback,
+                // not for inserting into prose.
+                image.unlink()
+            }
+        })
+    }
+
+    /**
+     * Drop the first line if it's the chapter title repeated as a
+     * heading — `ManifestChapter.title` already carries it. Match is
+     * structural (the leading line is shorter than the body and ends
+     * cleanly) rather than string-equality against the title; the
+     * caller doesn't pass the title in, and false-positive trims on
+     * a body whose first line happens to be heading-shaped are
+     * acceptable for an audio renderer.
+     */
+    private fun stripLeadingHeading(plain: String): String {
+        if (plain.isEmpty()) return plain
+        val newline = plain.indexOf('\n')
+        if (newline < 0) return plain
+        val first = plain.substring(0, newline).trim()
+        val rest = plain.substring(newline + 1).trimStart()
+        // Only treat short, terminal-punctuation-free first lines as
+        // headings. A normal opening sentence like "It was a dark and
+        // stormy night." stays untouched because of the period.
+        val isHeadingShape = first.length <= 80 &&
+            first.isNotEmpty() &&
+            first.last() !in TERMINAL_PUNCT &&
+            rest.isNotEmpty()
+        return if (isHeadingShape) rest else plain
+    }
+
+    private companion object {
+        private val TERMINAL_PUNCT = setOf('.', '!', '?', '"', '”')
+    }
+}

--- a/source-github/src/test/kotlin/in/jphe/storyvox/source/github/render/MarkdownChapterRendererTest.kt
+++ b/source-github/src/test/kotlin/in/jphe/storyvox/source/github/render/MarkdownChapterRendererTest.kt
@@ -1,0 +1,172 @@
+package `in`.jphe.storyvox.source.github.render
+
+import `in`.jphe.storyvox.data.source.model.ChapterInfo
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class MarkdownChapterRendererTest {
+
+    private val renderer = MarkdownChapterRenderer()
+    private val info = ChapterInfo(
+        id = "github:o/r:src/01-intro.md",
+        sourceChapterId = "src/01-intro.md",
+        index = 0,
+        title = "Intro",
+    )
+
+    // ─── HTML rendering ────────────────────────────────────────────────
+
+    @Test fun `paragraphs render to p tags`() {
+        val out = renderer.render(info, "Hello world.\n\nA second paragraph.")
+        assertTrue(out.htmlBody.contains("<p>Hello world.</p>"))
+        assertTrue(out.htmlBody.contains("<p>A second paragraph.</p>"))
+    }
+
+    @Test fun `inline emphasis becomes em and strong tags`() {
+        val out = renderer.render(info, "This is *italic* and **bold**.")
+        assertTrue(out.htmlBody.contains("<em>italic</em>"))
+        assertTrue(out.htmlBody.contains("<strong>bold</strong>"))
+    }
+
+    @Test fun `headings render with appropriate level`() {
+        val out = renderer.render(info, "# H1\n## H2\n### H3\n\nbody")
+        assertTrue(out.htmlBody.contains("<h1>H1</h1>"))
+        assertTrue(out.htmlBody.contains("<h2>H2</h2>"))
+        assertTrue(out.htmlBody.contains("<h3>H3</h3>"))
+    }
+
+    @Test fun `unordered lists render as ul`() {
+        val out = renderer.render(info, "- one\n- two\n- three")
+        assertTrue(out.htmlBody.contains("<ul>"))
+        assertTrue(out.htmlBody.contains("<li>one</li>"))
+        assertTrue(out.htmlBody.contains("<li>three</li>"))
+    }
+
+    @Test fun `ordered lists render as ol`() {
+        val out = renderer.render(info, "1. first\n2. second")
+        assertTrue(out.htmlBody.contains("<ol>"))
+    }
+
+    @Test fun `links render with href`() {
+        val out = renderer.render(info, "Visit [the wiki](https://example.com/wiki).")
+        assertTrue(out.htmlBody.contains("""<a href="https://example.com/wiki">the wiki</a>"""))
+    }
+
+    @Test fun `block quotes render as blockquote`() {
+        val out = renderer.render(info, "> A quoted line.\n> Another.")
+        assertTrue(out.htmlBody.contains("<blockquote>"))
+    }
+
+    @Test fun `inline html in markdown is escaped not passed through`() {
+        // escapeHtml=true: a `<script>` tag in raw markdown body should
+        // be rendered as visible text, never executable. Hardening for
+        // untrusted author input.
+        val out = renderer.render(info, "Sneaky <script>alert(1)</script> attempt.")
+        assertFalse(out.htmlBody.contains("<script>"))
+        assertTrue(out.htmlBody.contains("&lt;script&gt;"))
+    }
+
+    @Test fun `softbreak becomes br tag`() {
+        // Markdown softbreaks (newline within a paragraph, not blank-
+        // line-separated) become <br/> so the reader respects line
+        // breaks the author intended.
+        val out = renderer.render(info, "Line one\nLine two")
+        assertTrue(out.htmlBody.contains("<br />"))
+    }
+
+    // ─── Plaintext extraction ──────────────────────────────────────────
+
+    @Test fun `plain body strips html markup`() {
+        val out = renderer.render(info, "**Bold** and *italic* together.")
+        assertEquals("Bold and italic together.", out.plainBody)
+    }
+
+    @Test fun `plain body separates paragraphs with newlines`() {
+        val out = renderer.render(info, "First.\n\nSecond.\n\nThird.")
+        // commonmark TextContentRenderer joins paragraphs with newlines —
+        // good enough boundary for SentenceChunker downstream.
+        assertTrue(out.plainBody.contains("First."))
+        assertTrue(out.plainBody.contains("Second."))
+        assertTrue(out.plainBody.contains("Third."))
+    }
+
+    @Test fun `plain body drops link URL keeping anchor text`() {
+        val out = renderer.render(info, "Check [the docs](https://example.com).")
+        assertTrue("plain body should keep anchor text", out.plainBody.contains("the docs"))
+        assertFalse("plain body should not read the URL aloud", out.plainBody.contains("example.com"))
+    }
+
+    @Test fun `plain body drops images entirely`() {
+        // Images don't translate to audio. commonmark's TextContentRenderer
+        // emits alt text for images by default — acceptable for accessibility,
+        // and the reader gets to skip what they can't see.
+        val out = renderer.render(info, "Before ![cover](cover.png) after.")
+        assertFalse(out.plainBody.contains("cover.png"))
+    }
+
+    // ─── Heading-stripping in plain body ───────────────────────────────
+
+    @Test fun `leading short heading line is stripped from plain body`() {
+        val md = "# Master Elric\n\nIt was a dark and stormy night."
+        val out = renderer.render(info, md)
+        // Heading shouldn't be read aloud — title already in ChapterInfo.
+        assertFalse(out.plainBody.startsWith("Master Elric"))
+        assertTrue(out.plainBody.startsWith("It was a dark"))
+        // HTML keeps the heading as a visual landmark.
+        assertTrue(out.htmlBody.contains("<h1>Master Elric</h1>"))
+    }
+
+    @Test fun `opening sentence with terminal punctuation is preserved`() {
+        // Body without a leading heading — first line ends with a period,
+        // so it's clearly prose, not a heading. Don't strip it.
+        val md = "It was a dark and stormy night.\n\nThunder rolled."
+        val out = renderer.render(info, md)
+        assertTrue(out.plainBody.startsWith("It was a dark"))
+    }
+
+    @Test fun `long first line is preserved as prose`() {
+        // Lines over 80 chars are too long to be a heading. Keep them.
+        val md = "${"x".repeat(100)}\n\nNext paragraph."
+        val out = renderer.render(info, md)
+        assertTrue(out.plainBody.startsWith("x".repeat(100)))
+    }
+
+    @Test fun `body with only a heading yields heading text in plain`() {
+        // Edge case: file is just `# Heading` with no body. Don't strip
+        // it — that would yield empty audio. Better to read the heading
+        // than nothing.
+        val out = renderer.render(info, "# The Brass Gate")
+        assertTrue(out.plainBody.contains("The Brass Gate"))
+    }
+
+    // ─── Edge cases ────────────────────────────────────────────────────
+
+    @Test fun `empty input yields empty html and plain bodies`() {
+        val out = renderer.render(info, "")
+        assertEquals("", out.htmlBody)
+        assertEquals("", out.plainBody)
+    }
+
+    @Test fun `whitespace-only input yields empty bodies after trim`() {
+        val out = renderer.render(info, "   \n\n   \n")
+        assertEquals("", out.htmlBody)
+        assertEquals("", out.plainBody)
+    }
+
+    @Test fun `chapter info round-trips unchanged through render`() {
+        val customInfo = info.copy(title = "Custom Title", index = 7, wordCount = 1234)
+        val out = renderer.render(customInfo, "Body.")
+        assertEquals(customInfo, out.info)
+    }
+
+    @Test fun `notes fields default to null`() {
+        val out = renderer.render(info, "Body.")
+        // Author notes are surfaced by sources that have them (Royal Road
+        // splits author-notes from chapter-body in HTML); GitHub markdown
+        // doesn't have a notes convention, so they're always null here.
+        assertEquals(null, out.notesAuthor)
+        assertEquals(null, out.notesAuthorPosition)
+    }
+}


### PR DESCRIPTION
## Summary

Step 3d-markdown of the GitHub-source plan ([spec](docs/superpowers/specs/2026-05-06-github-source-design.md)). Second of three split PRs for step 3d. **Pure markdown → ChapterContent transformation** — no GitHub integration, no Hilt binding. The `@IntoMap @StringKey("github")` binding lands in 3d-detail-and-chapter (third PR), which is the integration layer that consumes both 3d-manifest and this PR.

## What lands

- **`commonmark = 0.24.0`** added to the version catalog. Single new dep — commonmark-java is itself dep-free, no transitives of consequence.
- **`MarkdownChapterRenderer`** (`@Singleton @Inject`-eligible). Two passes over a parsed AST:
    1. `HtmlRenderer` (`escapeHtml=true`, softbreak=`<br/>`) → sanitized `htmlBody` for the reader view.
    2. `TextContentRenderer` after AST flattening of links and images → `plainBody` for the TTS engine.
- **AST flattening**: commonmark's `TextContentRenderer` defaults emit `"anchor" (url)` for links and `"alt" (src)` for images — fine for terminal logs, wrong for audiobook playback (the URL shouldn't be read aloud mid-sentence). The renderer walks the AST, replaces `Link` nodes with their child text (anchor-only) and drops `Image` nodes entirely. **HTML branch keeps both as-is** for the reader UI.
- **Leading-heading strip on plainBody**: when a chapter file's first line is a `# Heading`-shaped non-prose line, drop it from the audio path. `ManifestChapter.title` already carries it; reading it aloud is redundant. Heuristic is structural (≤80 chars, no terminal punctuation) so opening sentences like *"It was a dark and stormy night."* are preserved untouched. HTML keeps the heading as a visual landmark.

## Honeypot enforcement

**Deliberately not applied here** — this PR is a pure transform. The caller (step 3d-detail-and-chapter, when `GitHubSource.chapter` lights up) is the right layer to drop honeypot blocks before handing to the playback engine, since that layer also has access to the manifest's `honeypotSelectors` config from `storyvox.json`. Spec line 130.

## Test plan

21 new unit tests; **94 total** in the module (73 from 3a/3c/3d-manifest + 21 new). All green. Pure-JVM, runs in <1s.

- [x] **HTML rendering (9)**: paragraphs, em/strong, h1-h3, ul, ol, links with href, blockquotes, inline `<script>` escaped (XSS hardening), softbreaks → `<br/>`.
- [x] **Plaintext extraction (4)**: markup stripped, paragraph separation, link URL dropped + anchor text kept, image src + alt dropped.
- [x] **Heading-strip (4)**: leading short heading dropped, opening prose with terminal punctuation preserved, long first line preserved as prose, heading-only body keeps the heading text (better than empty audio).
- [x] **Edge cases (4)**: empty input, whitespace-only input, `ChapterInfo` round-trip, notes fields default null.
- [x] `:source-github:testDebugUnitTest` — 94/94 green.
- [x] `:app:assembleDebug` clean — Hilt graph unaffected since `GitHubSource.chapter` still throws `NotImplementedError`.

## What this unblocks

- **3d-detail-and-chapter (next, final in 3d split)**: `GitHubSource.fictionDetail` consumes `ManifestParser`; `GitHubSource.chapter` consumes `MarkdownChapterRenderer`. Adds the `@IntoMap @StringKey("github")` Hilt binding so `addByUrl(github URL)` works end-to-end. First on-device verification lands in that PR.

## Worktree + branch

- Worktree: `.claude/worktrees/selene-github-markdown`
- Branch: `dream/selene/source-github-markdown`