### PR TITLE
test(feature): RealBrowsePaginator move to :feature.browse + 15 tests

### DIFF
--- a/app/src/main/kotlin/in/jphe/storyvox/di/AppBindings.kt
+++ b/app/src/main/kotlin/in/jphe/storyvox/di/AppBindings.kt
@@ -43,6 +43,8 @@ import `in`.jphe.storyvox.feature.api.UiFollow
 import `in`.jphe.storyvox.feature.api.UiPlaybackState
 import `in`.jphe.storyvox.feature.api.UiSleepTimerMode
 import `in`.jphe.storyvox.feature.api.VoiceProviderUi
+import `in`.jphe.storyvox.feature.browse.RealBrowsePaginator
+import `in`.jphe.storyvox.feature.browse.toUiFiction
 import `in`.jphe.storyvox.playback.PlaybackController
 import `in`.jphe.storyvox.playback.PlaybackState
 import `in`.jphe.storyvox.playback.SPEED_BASELINE_CHARS_PER_SECOND
@@ -259,60 +261,6 @@ private class RealBrowseRepositoryUi(
         }
 }
 
-/** Page-by-page accumulator. Mutex-guarded so the grid's near-end
- *  LaunchedEffect can call `loadNext()` freely without races. Failures
- *  surface in [error] without bumping the page counter, so the user
- *  scrolling back near-end after a transient blip retries the same
- *  page transparently. */
-private class RealBrowsePaginator(
-    private val fetchPage: suspend (page: Int) -> FictionResult<`in`.jphe.storyvox.data.source.model.ListPage<FictionSummary>>,
-) : BrowsePaginator {
-    private val _items = MutableStateFlow<List<UiFiction>>(emptyList())
-    private val _isLoading = MutableStateFlow(false)
-    private val _isAppending = MutableStateFlow(false)
-    private val _hasMore = MutableStateFlow(true)
-    private val _error = MutableStateFlow<String?>(null)
-    private var nextPage = 1
-    private val mutex = Mutex()
-
-    override val items: Flow<List<UiFiction>> = _items.asStateFlow()
-    override val isLoading: Flow<Boolean> = _isLoading.asStateFlow()
-    override val isAppending: Flow<Boolean> = _isAppending.asStateFlow()
-    override val hasMore: Flow<Boolean> = _hasMore.asStateFlow()
-    override val error: Flow<String?> = _error.asStateFlow()
-
-    override suspend fun loadNext() = mutex.withLock {
-        if (!_hasMore.value || _isAppending.value || _isLoading.value) return@withLock
-        val isFirst = nextPage == 1
-        if (isFirst) _isLoading.value = true else _isAppending.value = true
-        try {
-            when (val res = fetchPage(nextPage)) {
-                is FictionResult.Success -> {
-                    _items.value = _items.value + res.value.items.map(::toUiFiction)
-                    _hasMore.value = res.value.hasNext
-                    nextPage++
-                    _error.value = null
-                }
-                is FictionResult.Failure -> {
-                    android.util.Log.w("storyvox", "Browse fetch failed: ${res.message}", res.cause)
-                    _error.value = res.message
-                    // do NOT bump nextPage — next near-end retries the same page
-                }
-            }
-        } finally {
-            _isLoading.value = false
-            _isAppending.value = false
-        }
-    }
-
-    override suspend fun refresh() = mutex.withLock {
-        _items.value = emptyList()
-        _hasMore.value = true
-        _error.value = null
-        nextPage = 1
-    }
-}
-
 private fun BrowseFilter.toSearchQuery(): SearchQuery = SearchQuery(
     term = term,
     tags = tagsInclude,
@@ -368,17 +316,6 @@ private fun UiSortDirection.toData(): SortDirection = when (this) {
     UiSortDirection.Asc -> SortDirection.ASC
     UiSortDirection.Desc -> SortDirection.DESC
 }
-
-private fun toUiFiction(s: FictionSummary): UiFiction = UiFiction(
-    id = s.id,
-    title = s.title,
-    author = s.author,
-    coverUrl = s.coverUrl,
-    rating = s.rating ?: 0f,
-    chapterCount = s.chapterCount ?: 0,
-    isOngoing = s.status == FictionStatus.ONGOING,
-    synopsis = s.description.orEmpty(),
-)
 
 /**
  * Adapter from [PlaybackControllerUi] (Aurora's UI contract) to

--- a/feature/build.gradle.kts
+++ b/feature/build.gradle.kts
@@ -39,9 +39,15 @@ android {
 
     testOptions {
         unitTests {
-            // Lets `android.util.Log.w(...)` calls in production code (e.g.
-            // RealBrowsePaginator's failure-path logging) return a default
-            // 0 instead of throwing the "not mocked" RuntimeException.
+            // JVM unit tests run against android.jar's stub classes, where
+            // every Android-framework method throws "Method ... not mocked"
+            // by default. RealBrowsePaginator's failure-path calls
+            // android.util.Log.w(...) — production-correct logging that
+            // would otherwise crash JVM tests. Returning defaults for
+            // unmocked Android methods is the standard AGP pattern (see
+            // "Unit testing your app" docs), not lazy mocking — adding
+            // Robolectric just to mock android.util.Log would be heavier
+            // than the surface here justifies.
             isReturnDefaultValues = true
         }
     }

--- a/feature/build.gradle.kts
+++ b/feature/build.gradle.kts
@@ -36,6 +36,15 @@ android {
             java.srcDirs("src/main/kotlin")
         }
     }
+
+    testOptions {
+        unitTests {
+            // Lets `android.util.Log.w(...)` calls in production code (e.g.
+            // RealBrowsePaginator's failure-path logging) return a default
+            // 0 instead of throwing the "not mocked" RuntimeException.
+            isReturnDefaultValues = true
+        }
+    }
 }
 
 dependencies {
@@ -60,4 +69,5 @@ dependencies {
     implementation(libs.coil.compose)
 
     testImplementation(libs.junit)
+    testImplementation(libs.kotlinx.coroutines.test)
 }

--- a/feature/src/main/kotlin/in/jphe/storyvox/feature/browse/RealBrowsePaginator.kt
+++ b/feature/src/main/kotlin/in/jphe/storyvox/feature/browse/RealBrowsePaginator.kt
@@ -1,0 +1,87 @@
+package `in`.jphe.storyvox.feature.browse
+
+import `in`.jphe.storyvox.data.source.model.FictionResult
+import `in`.jphe.storyvox.data.source.model.FictionStatus
+import `in`.jphe.storyvox.data.source.model.FictionSummary
+import `in`.jphe.storyvox.data.source.model.ListPage
+import `in`.jphe.storyvox.feature.api.BrowsePaginator
+import `in`.jphe.storyvox.feature.api.UiFiction
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
+
+/**
+ * Page-by-page accumulator. Mutex-guarded so the grid's near-end
+ * `LaunchedEffect` can call `loadNext()` freely without races. Failures
+ * surface in [error] without bumping the page counter, so the user
+ * scrolling back near-end after a transient blip retries the same page
+ * transparently.
+ *
+ * Pulled out of `:app/AppBindings.kt` (where it was an inline anonymous
+ * implementation held by a lambda factory) so its state machine is
+ * unit-testable from the JVM. Lives in `:feature` rather than `:core-data`
+ * because [BrowsePaginator]'s contract + [UiFiction] both live in
+ * `:feature.api`, and pulling the impl up to `:core-data` would invert
+ * the existing `:feature → :core-data` dependency direction.
+ */
+class RealBrowsePaginator(
+    private val fetchPage: suspend (page: Int) -> FictionResult<ListPage<FictionSummary>>,
+) : BrowsePaginator {
+    private val _items = MutableStateFlow<List<UiFiction>>(emptyList())
+    private val _isLoading = MutableStateFlow(false)
+    private val _isAppending = MutableStateFlow(false)
+    private val _hasMore = MutableStateFlow(true)
+    private val _error = MutableStateFlow<String?>(null)
+    private var nextPage = 1
+    private val mutex = Mutex()
+
+    override val items: Flow<List<UiFiction>> = _items.asStateFlow()
+    override val isLoading: Flow<Boolean> = _isLoading.asStateFlow()
+    override val isAppending: Flow<Boolean> = _isAppending.asStateFlow()
+    override val hasMore: Flow<Boolean> = _hasMore.asStateFlow()
+    override val error: Flow<String?> = _error.asStateFlow()
+
+    override suspend fun loadNext() = mutex.withLock {
+        if (!_hasMore.value || _isAppending.value || _isLoading.value) return@withLock
+        val isFirst = nextPage == 1
+        if (isFirst) _isLoading.value = true else _isAppending.value = true
+        try {
+            when (val res = fetchPage(nextPage)) {
+                is FictionResult.Success -> {
+                    _items.value = _items.value + res.value.items.map(::toUiFiction)
+                    _hasMore.value = res.value.hasNext
+                    nextPage++
+                    _error.value = null
+                }
+                is FictionResult.Failure -> {
+                    android.util.Log.w("storyvox", "Browse fetch failed: ${res.message}", res.cause)
+                    _error.value = res.message
+                    // do NOT bump nextPage — next near-end retries the same page
+                }
+            }
+        } finally {
+            _isLoading.value = false
+            _isAppending.value = false
+        }
+    }
+
+    override suspend fun refresh() = mutex.withLock {
+        _items.value = emptyList()
+        _hasMore.value = true
+        _error.value = null
+        nextPage = 1
+    }
+}
+
+fun toUiFiction(s: FictionSummary): UiFiction = UiFiction(
+    id = s.id,
+    title = s.title,
+    author = s.author,
+    coverUrl = s.coverUrl,
+    rating = s.rating ?: 0f,
+    chapterCount = s.chapterCount ?: 0,
+    isOngoing = s.status == FictionStatus.ONGOING,
+    synopsis = s.description.orEmpty(),
+)

--- a/feature/src/test/kotlin/in/jphe/storyvox/feature/browse/RealBrowsePaginatorTest.kt
+++ b/feature/src/test/kotlin/in/jphe/storyvox/feature/browse/RealBrowsePaginatorTest.kt
@@ -1,0 +1,349 @@
+package `in`.jphe.storyvox.feature.browse
+
+import `in`.jphe.storyvox.data.source.model.FictionResult
+import `in`.jphe.storyvox.data.source.model.FictionStatus
+import `in`.jphe.storyvox.data.source.model.FictionSummary
+import `in`.jphe.storyvox.data.source.model.ListPage
+import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.async
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.runCurrent
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertSame
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class RealBrowsePaginatorTest {
+
+    // -- Fixtures ----------------------------------------------------------------
+
+    private fun summary(id: String, title: String = id) = FictionSummary(
+        id = id, sourceId = "rr", title = title, author = "auth-$id",
+        status = FictionStatus.ONGOING,
+    )
+
+    private fun page(items: List<FictionSummary>, page: Int, hasNext: Boolean) =
+        FictionResult.Success(ListPage(items, page, hasNext))
+
+    /** Programmable fetch lambda. Each call returns the next stubbed result and
+     *  records the page argument it was called with. */
+    private class RecordingFetch {
+        private val results = ArrayDeque<FictionResult<ListPage<FictionSummary>>>()
+        val pageArgs = mutableListOf<Int>()
+        var callCount = 0
+            private set
+
+        fun queue(vararg responses: FictionResult<ListPage<FictionSummary>>) {
+            results.addAll(responses.toList())
+        }
+
+        operator fun invoke(): suspend (Int) -> FictionResult<ListPage<FictionSummary>> = { p ->
+            callCount++
+            pageArgs += p
+            results.removeFirstOrNull()
+                ?: error("RecordingFetch: no stubbed result for page=$p (call #$callCount)")
+        }
+    }
+
+    // -- happy path: items, paging, hasMore --------------------------------------
+
+    @Test fun `loadNext on empty paginator fetches page 1 and accumulates items`() = runTest {
+        val fetch = RecordingFetch().apply {
+            queue(page(listOf(summary("a"), summary("b")), page = 1, hasNext = true))
+        }
+        val p = RealBrowsePaginator(fetch())
+
+        assertEquals(emptyList<Any>(), p.items.first())
+        p.loadNext()
+
+        val items = p.items.first()
+        assertEquals(listOf("a", "b"), items.map { it.id })
+        assertEquals(listOf(1), fetch.pageArgs)
+        assertEquals(true, p.hasMore.first())
+    }
+
+    @Test fun `loadNext appends subsequent pages and bumps page counter`() = runTest {
+        val fetch = RecordingFetch().apply {
+            queue(
+                page(listOf(summary("a")), page = 1, hasNext = true),
+                page(listOf(summary("b"), summary("c")), page = 2, hasNext = true),
+                page(listOf(summary("d")), page = 3, hasNext = false),
+            )
+        }
+        val p = RealBrowsePaginator(fetch())
+
+        p.loadNext()
+        p.loadNext()
+        p.loadNext()
+
+        assertEquals(listOf("a", "b", "c", "d"), p.items.first().map { it.id })
+        assertEquals(listOf(1, 2, 3), fetch.pageArgs)
+        assertEquals(false, p.hasMore.first())
+    }
+
+    @Test fun `loadNext is a no-op once hasMore flips to false`() = runTest {
+        val fetch = RecordingFetch().apply {
+            queue(page(listOf(summary("a")), page = 1, hasNext = false))
+        }
+        val p = RealBrowsePaginator(fetch())
+
+        p.loadNext()
+        assertEquals(false, p.hasMore.first())
+
+        // Subsequent loadNext calls must not invoke fetch again.
+        p.loadNext()
+        p.loadNext()
+
+        assertEquals(1, fetch.callCount)
+    }
+
+    // -- isLoading vs isAppending ----------------------------------------------
+
+    @Test fun `first page sets isLoading, subsequent pages set isAppending`() = runTest {
+        // Use a CompletableDeferred to inspect intermediate state DURING fetch.
+        val gate = CompletableDeferred<FictionResult<ListPage<FictionSummary>>>()
+        val p = RealBrowsePaginator { gate.await() }
+
+        val job = launch { p.loadNext() }
+        runCurrent()
+        // First page in flight: isLoading=true, isAppending=false.
+        assertEquals(true, p.isLoading.first())
+        assertEquals(false, p.isAppending.first())
+
+        gate.complete(page(listOf(summary("a")), page = 1, hasNext = true))
+        job.join()
+        assertEquals(false, p.isLoading.first())
+        assertEquals(false, p.isAppending.first())
+
+        // Second page: a fresh gate so we can see in-flight state.
+        val gate2 = CompletableDeferred<FictionResult<ListPage<FictionSummary>>>()
+        val p2 = RealBrowsePaginator { p ->
+            if (p == 1) page(listOf(summary("a")), 1, true)
+            else gate2.await()
+        }
+        p2.loadNext() // page 1 returns synchronously
+        val job2 = launch { p2.loadNext() }
+        runCurrent()
+        assertEquals(false, p2.isLoading.first())
+        assertEquals(true, p2.isAppending.first())
+        gate2.complete(page(listOf(summary("b")), 2, false))
+        job2.join()
+        assertEquals(false, p2.isAppending.first())
+    }
+
+    // -- error path -------------------------------------------------------------
+
+    @Test fun `Failure surfaces error and does NOT bump page counter`() = runTest {
+        val fetch = RecordingFetch().apply {
+            queue(
+                FictionResult.NetworkError("boom"),
+                page(listOf(summary("a")), page = 1, hasNext = true),
+            )
+        }
+        val p = RealBrowsePaginator(fetch())
+
+        p.loadNext()
+        assertEquals("boom", p.error.first())
+        assertEquals(emptyList<Any>(), p.items.first())
+        assertEquals(true, p.hasMore.first()) // stays true — we never got a definitive answer
+
+        // Retry: same page number is requested.
+        p.loadNext()
+        assertEquals(listOf(1, 1), fetch.pageArgs)
+        assertEquals(listOf("a"), p.items.first().map { it.id })
+        assertNull(p.error.first())
+    }
+
+    @Test fun `subsequent Success after Failure clears the error message`() = runTest {
+        val fetch = RecordingFetch().apply {
+            queue(
+                FictionResult.RateLimited(retryAfter = null, message = "slow down"),
+                page(listOf(summary("a")), page = 1, hasNext = false),
+            )
+        }
+        val p = RealBrowsePaginator(fetch())
+
+        p.loadNext()
+        assertEquals("slow down", p.error.first())
+
+        p.loadNext()
+        assertNull(p.error.first())
+    }
+
+    @Test fun `loading flags are cleared in finally even on Failure`() = runTest {
+        val fetch = RecordingFetch().apply {
+            queue(FictionResult.NetworkError("boom"))
+        }
+        val p = RealBrowsePaginator(fetch())
+
+        p.loadNext()
+
+        assertEquals(false, p.isLoading.first())
+        assertEquals(false, p.isAppending.first())
+    }
+
+    // -- mutex / concurrent calls ----------------------------------------------
+
+    @Test fun `concurrent loadNext calls are serialized — only one fetch fires`() = runTest {
+        val gate = CompletableDeferred<FictionResult<ListPage<FictionSummary>>>()
+        var concurrentCalls = 0
+        var maxConcurrent = 0
+
+        val p = RealBrowsePaginator { _ ->
+            concurrentCalls++
+            maxConcurrent = maxOf(maxConcurrent, concurrentCalls)
+            try {
+                gate.await()
+            } finally {
+                concurrentCalls--
+            }
+        }
+
+        // Fire 5 concurrent loadNext calls; the mutex + the isLoading/isAppending
+        // guard should mean the first wins and the rest no-op out.
+        val jobs = List(5) { async { p.loadNext() } }
+        runCurrent()
+
+        gate.complete(page(listOf(summary("a")), 1, false))
+        jobs.forEach { it.await() }
+
+        assertEquals("only the first concurrent loadNext should fire fetch", 1, maxConcurrent)
+        assertEquals(listOf("a"), p.items.first().map { it.id })
+    }
+
+    // -- refresh ---------------------------------------------------------------
+
+    @Test fun `refresh clears items, error, and resets to page 1`() = runTest {
+        val fetch = RecordingFetch().apply {
+            queue(
+                page(listOf(summary("a"), summary("b")), 1, true),
+                page(listOf(summary("c")), 2, false),
+                page(listOf(summary("a2")), 1, true),
+            )
+        }
+        val p = RealBrowsePaginator(fetch())
+
+        p.loadNext()
+        p.loadNext()
+        assertEquals(3, p.items.first().size) // 2 from page 1 + 1 from page 2
+        assertEquals(false, p.hasMore.first())
+
+        p.refresh()
+        assertEquals(emptyList<Any>(), p.items.first())
+        assertEquals(true, p.hasMore.first())
+        assertNull(p.error.first())
+
+        p.loadNext()
+        // After refresh, fetch is called with page=1 again.
+        assertEquals(listOf(1, 2, 1), fetch.pageArgs)
+        assertEquals(listOf("a2"), p.items.first().map { it.id })
+    }
+
+    @Test fun `refresh after a Failure clears the error message`() = runTest {
+        val fetch = RecordingFetch().apply {
+            queue(FictionResult.NetworkError("flaky"))
+        }
+        val p = RealBrowsePaginator(fetch())
+
+        p.loadNext()
+        assertNotNull(p.error.first())
+
+        p.refresh()
+        assertNull(p.error.first())
+    }
+
+    // -- toUiFiction mapper ----------------------------------------------------
+
+    @Test fun `toUiFiction maps fields with sane defaults for nullable inputs`() {
+        val s = FictionSummary(
+            id = "id1", sourceId = "rr", title = "Title",
+            author = "Author",
+            coverUrl = null,
+            description = null,
+            tags = emptyList(),
+            status = FictionStatus.ONGOING,
+            chapterCount = null,
+            rating = null,
+        )
+        val ui = toUiFiction(s)
+        assertEquals("id1", ui.id)
+        assertEquals("Title", ui.title)
+        assertEquals("Author", ui.author)
+        assertNull(ui.coverUrl)
+        assertEquals(0f, ui.rating, 0f)
+        assertEquals(0, ui.chapterCount)
+        assertEquals(true, ui.isOngoing)
+        assertEquals("", ui.synopsis)
+    }
+
+    @Test fun `toUiFiction maps non-ONGOING status to isOngoing=false`() {
+        listOf(
+            FictionStatus.COMPLETED,
+            FictionStatus.HIATUS,
+            FictionStatus.STUB,
+            FictionStatus.DROPPED,
+        ).forEach { s ->
+            assertEquals(
+                "status=$s should map to isOngoing=false",
+                false,
+                toUiFiction(summary("x").copy(status = s)).isOngoing,
+            )
+        }
+    }
+
+    @Test fun `toUiFiction passes rating and chapterCount when present`() {
+        val s = summary("x").copy(rating = 4.7f, chapterCount = 42)
+        val ui = toUiFiction(s)
+        assertEquals(4.7f, ui.rating, 0f)
+        assertEquals(42, ui.chapterCount)
+    }
+
+    // -- Identity preservation through items map ------------------------------
+
+    @Test fun `loadNext preserves accumulated items across pages (no rewrites)`() = runTest {
+        val fetch = RecordingFetch().apply {
+            queue(
+                page(listOf(summary("a")), 1, true),
+                page(listOf(summary("b")), 2, false),
+            )
+        }
+        val p = RealBrowsePaginator(fetch())
+
+        p.loadNext()
+        val firstSnapshot = p.items.first()
+        p.loadNext()
+        val secondSnapshot = p.items.first()
+
+        // The first item should be the same instance after page 2 (no recreate).
+        assertSame(
+            "page-2 fetch must not rebuild page-1 items",
+            firstSnapshot[0],
+            secondSnapshot[0],
+        )
+        assertEquals("b", secondSnapshot[1].id)
+    }
+
+    // -- defensive: dispatcher handling ----------------------------------------
+
+    @Test fun `advanceUntilIdle drives the launched fetch to completion`() = runTest {
+        // Verifies that the paginator's withLock + suspend fetch interplay
+        // doesn't park the test scheduler indefinitely. Single-shot smoke
+        // test for the "background scope drives to completion under runTest"
+        // contract this whole suite relies on.
+        val fetch = RecordingFetch().apply {
+            queue(page(listOf(summary("a")), 1, false))
+        }
+        val p = RealBrowsePaginator(fetch())
+
+        val job = launch { p.loadNext() }
+        advanceUntilIdle()
+        assertTrue("launched loadNext must complete", job.isCompleted)
+    }
+}


### PR DESCRIPTION
## Summary

Trilogy capstone — completes JVM unit-test coverage of the three load-bearing data-layer state machines:
- `FictionRepositoryImpl` (PR #54, 29 tests)
- `ChapterRepositoryImpl` (PR #62, 22 tests)
- **`BrowsePaginator`** (this PR, 15 tests)

Same testability-driven-refactor pattern as #62 (which extracted `ChapterDownloadScheduler` from `ChapterRepositoryImpl`): pull a real abstraction out of an inline lambda factory, get unit-testability and a boundary win in one PR.

## Production move

- `RealBrowsePaginator` (and its `toUiFiction` mapper) extracted from the inline anonymous-class-in-a-lambda-factory body of `app/AppBindings.kt:RealBrowseRepositoryUi` into its own file at **`feature/browse/RealBrowsePaginator.kt`**.
- **Lives in `:feature` rather than `:core-data`** — `BrowsePaginator` interface + `UiFiction` both already live in `:feature.api`, and `:feature` already depends on `:core-data`. Putting the impl in `:core-data` would invert the dep direction. `:feature` is the natural home.
- `:app/AppBindings.kt` now imports `RealBrowsePaginator` and `toUiFiction` from `:feature.browse`. **Behavior unchanged** — the lambda factory in `RealBrowseRepositoryUi.paginator()` reads identically. `:app:assembleDebug` confirms post-move imports resolve.

## Test infra adds (all in `:feature`)

- `testImplementation(libs.kotlinx.coroutines.test)` — catalog entry already added in PR #31.
- `testOptions { unitTests.isReturnDefaultValues = true }` — so the production `android.util.Log.w(...)` failure-path log doesn't throw the "not mocked" RuntimeException at unit-test time. Standard Android pattern.

## What's covered (15 tests)

**Page accumulation**
- `loadNext` on empty paginator fetches page 1, accumulates items
- Subsequent `loadNext` appends pages and bumps page counter
- `loadNext` is a no-op once `hasMore` flips to false (verified via fetch call count)

**Loading-state distinction**
- First page sets `isLoading=true` (drives skeleton grid)
- Subsequent pages set `isAppending=true` (drives footer spinner)
- Both flags cleared in `finally` even on Failure

**Error-path correctness** — the headline coverage gain
- `Failure` surfaces error message **without bumping the page counter** — the next near-end retry hits the same page (the user-visible "transparent retry on transient blip" UX)
- Subsequent `Success` after `Failure` clears the error message
- `RateLimited` failure produces the source-provided message

**Mutex correctness**
- 5 concurrent `loadNext` calls — only one fetch fires (proves the mutex + isLoading/isAppending guards work together under real coroutine scheduling)

**`refresh`**
- Clears items, error, resets to page 1
- After `refresh`, next `loadNext` requests page=1 again
- `refresh` after `Failure` clears the error message

**`toUiFiction` mapper**
- Null-defaults: `rating=0f`, `chapterCount=0`, `synopsis=""`, `coverUrl=null`
- Non-`ONGOING` status maps to `isOngoing=false` (all four enum values)
- Passes `rating` + `chapterCount` when present

**Identity preservation**
- `loadNext` preserves accumulated items across pages — page-2 fetch must NOT rebuild page-1 items (catches a future regression where someone "simplifies" the accumulation to a `mapTo` over the full page list)

## Test plan

- [x] `./gradlew :feature:test` — green, both variants, 15 new tests
- [x] `./gradlew :app:assembleDebug` — Hilt graph + the moved `RealBrowsePaginator` import resolve correctly
- [x] `./gradlew test` — full module sweep clean (66 tests across `:core-playback`, `:core-data`, `:feature`)
- [ ] Copilot review

🤖 Generated with [Claude Code](https://claude.com/claude-code)