### PR TITLE
refactor(core-data): extract SourceIds, dedup sourceId literals (#57)

### DIFF
--- a/core-data/src/main/kotlin/in/jphe/storyvox/data/source/SourceIds.kt
+++ b/core-data/src/main/kotlin/in/jphe/storyvox/data/source/SourceIds.kt
@@ -1,0 +1,20 @@
+package `in`.jphe.storyvox.data.source
+
+/**
+ * Canonical sourceId literals shared across the source modules, the
+ * UrlRouter, the Hilt MapBinding @StringKey annotations, and any other
+ * call site that needs to identify a source by its string key.
+ *
+ * Lives in :core-data so source modules and core consumers can both
+ * depend on it without breaking the leaf-source architecture (source
+ * modules don't depend on each other; they all depend on core-data).
+ *
+ * Adding a new source: add a new `const val` here, then use it at the
+ * source's `FictionSource.id`, the corresponding Hilt `@StringKey`,
+ * and any UrlRouter Match construction. Issue #57 tracks the
+ * deduplication; this file is the single source of truth.
+ */
+object SourceIds {
+    const val ROYAL_ROAD: String = "royalroad"
+    const val GITHUB: String = "github"
+}

--- a/core-data/src/main/kotlin/in/jphe/storyvox/data/source/UrlRouter.kt
+++ b/core-data/src/main/kotlin/in/jphe/storyvox/data/source/UrlRouter.kt
@@ -12,9 +12,6 @@ package `in`.jphe.storyvox.data.source
  */
 object UrlRouter {
 
-    private const val ROYALROAD = "royalroad"
-    private const val GITHUB = "github"
-
     /** `https://www.royalroad.com/fiction/{id}` and `/fiction/{id}/.../chapter/...`. */
     private val ROYALROAD_PATTERN = Regex(
         """^https?://(?:www\.)?royalroad\.com/fiction/(\d+)(?:/.*)?$""",
@@ -39,11 +36,11 @@ object UrlRouter {
         if (trimmed.isEmpty()) return null
 
         ROYALROAD_PATTERN.matchEntire(trimmed)?.let { m ->
-            return Match(ROYALROAD, m.groupValues[1])
+            return Match(SourceIds.ROYAL_ROAD, m.groupValues[1])
         }
 
         GITHUB_HTTPS_PATTERN.matchEntire(trimmed)?.let { m ->
-            return Match(GITHUB, "$GITHUB:${m.groupValues[1].lowercase()}/${m.groupValues[2].lowercase()}")
+            return Match(SourceIds.GITHUB, "${SourceIds.GITHUB}:${m.groupValues[1].lowercase()}/${m.groupValues[2].lowercase()}")
         }
 
         // Reject ambiguous short form on URLs that look like a full path
@@ -51,7 +48,7 @@ object UrlRouter {
         // pattern only matches `owner/repo` cleanly.
         if ("://" !in trimmed && trimmed.count { it == '/' } == 1) {
             GITHUB_SHORT_PATTERN.matchEntire(trimmed)?.let { m ->
-                return Match(GITHUB, "$GITHUB:${m.groupValues[1].lowercase()}/${m.groupValues[2].lowercase()}")
+                return Match(SourceIds.GITHUB, "${SourceIds.GITHUB}:${m.groupValues[1].lowercase()}/${m.groupValues[2].lowercase()}")
             }
         }
 

--- a/source-github/src/main/kotlin/in/jphe/storyvox/source/github/GitHubSource.kt
+++ b/source-github/src/main/kotlin/in/jphe/storyvox/source/github/GitHubSource.kt
@@ -1,6 +1,7 @@
 package `in`.jphe.storyvox.source.github
 
 import `in`.jphe.storyvox.data.source.FictionSource
+import `in`.jphe.storyvox.data.source.SourceIds
 import `in`.jphe.storyvox.data.source.model.ChapterContent
 import `in`.jphe.storyvox.data.source.model.FictionDetail
 import `in`.jphe.storyvox.data.source.model.FictionResult
@@ -34,7 +35,7 @@ internal class GitHubSource @Inject constructor(
     private val registry: Registry,
 ) : FictionSource {
 
-    override val id: String = "github"
+    override val id: String = SourceIds.GITHUB
     override val displayName: String = "GitHub"
 
     override suspend fun popular(page: Int): FictionResult<ListPage<FictionSummary>> =

--- a/source-github/src/main/kotlin/in/jphe/storyvox/source/github/registry/RegistryModels.kt
+++ b/source-github/src/main/kotlin/in/jphe/storyvox/source/github/registry/RegistryModels.kt
@@ -1,5 +1,6 @@
 package `in`.jphe.storyvox.source.github.registry
 
+import `in`.jphe.storyvox.data.source.SourceIds
 import `in`.jphe.storyvox.data.source.model.FictionStatus
 import `in`.jphe.storyvox.data.source.model.FictionSummary
 import kotlinx.serialization.SerialName
@@ -54,7 +55,7 @@ internal data class RegistryEntry(
  */
 internal fun RegistryEntry.toSummary(): FictionSummary = FictionSummary(
     id = id,
-    sourceId = "github",
+    sourceId = SourceIds.GITHUB,
     title = title,
     author = author,
     coverUrl = coverUrl,

--- a/source-royalroad/src/main/kotlin/in/jphe/storyvox/source/royalroad/RoyalRoadSource.kt
+++ b/source-royalroad/src/main/kotlin/in/jphe/storyvox/source/royalroad/RoyalRoadSource.kt
@@ -50,8 +50,8 @@ class RoyalRoadSource @Inject internal constructor(
     @Suppress("unused") private val cookieJar: RoyalRoadCookieJar,
 ) : FictionSource {
 
-    override val id: String = "royalroad"
-    override val displayName: String = "Royal Road"
+    override val id: String = RoyalRoadIds.SOURCE_ID
+    override val displayName: String = RoyalRoadIds.SOURCE_NAME
 
     override suspend fun popular(page: Int): FictionResult<ListPage<FictionSummary>> =
         fetchBrowsePage(browseUrl("/fictions/active-popular", page), page)

--- a/source-royalroad/src/main/kotlin/in/jphe/storyvox/source/royalroad/di/RoyalRoadModule.kt
+++ b/source-royalroad/src/main/kotlin/in/jphe/storyvox/source/royalroad/di/RoyalRoadModule.kt
@@ -2,6 +2,7 @@ package `in`.jphe.storyvox.source.royalroad.di
 
 import `in`.jphe.storyvox.data.auth.SessionHydrator
 import `in`.jphe.storyvox.data.source.FictionSource
+import `in`.jphe.storyvox.data.source.SourceIds
 import `in`.jphe.storyvox.source.royalroad.RoyalRoadSource
 import `in`.jphe.storyvox.source.royalroad.auth.RoyalRoadSessionHydrator
 import `in`.jphe.storyvox.source.royalroad.model.RoyalRoadIds
@@ -73,7 +74,7 @@ internal abstract class RoyalRoadBindings {
     @Binds
     @Singleton
     @IntoMap
-    @StringKey("royalroad")
+    @StringKey(SourceIds.ROYAL_ROAD)
     abstract fun bindFictionSource(impl: RoyalRoadSource): FictionSource
 
     @Binds

--- a/source-royalroad/src/main/kotlin/in/jphe/storyvox/source/royalroad/model/RoyalRoadIds.kt
+++ b/source-royalroad/src/main/kotlin/in/jphe/storyvox/source/royalroad/model/RoyalRoadIds.kt
@@ -1,7 +1,9 @@
 package `in`.jphe.storyvox.source.royalroad.model
 
+import `in`.jphe.storyvox.data.source.SourceIds
+
 internal object RoyalRoadIds {
-    const val SOURCE_ID = "royalroad"
+    const val SOURCE_ID: String = SourceIds.ROYAL_ROAD
     const val SOURCE_NAME = "Royal Road"
     const val BASE_URL = "https://www.royalroad.com"
     const val USER_AGENT =


### PR DESCRIPTION
## Summary

Closes #57. Adds `:core-data/.../source/SourceIds.kt` as the single source of truth for source-id string keys. Replaces the literal `"royalroad"` / `"github"` occurrences across:

- `UrlRouter` (regex match's `Match.sourceId`)
- `RoyalRoadSource.id` and `displayName`
- `RoyalRoadIds.SOURCE_ID` (now forwards via `const val = SourceIds.ROYAL_ROAD`)
- `RoyalRoadModule`'s `@StringKey` (Hilt MapBinding)
- `GitHubSource.id`
- `source-github/registry/RegistryModels.toSummary()` (the lone literal in the registry mapper)

## Why a forwarding alias for RoyalRoadIds.SOURCE_ID

3 internal callers in source-royalroad parsers reference `RoyalRoadIds.SOURCE_ID`. Rewiring each to `SourceIds.ROYAL_ROAD` would mean three import-line churn in files unrelated to the dedup goal. Forwarding via `const val SOURCE_ID: String = SourceIds.ROYAL_ROAD` keeps the literal in exactly one place AND keeps the existing internal call sites untouched. If `SourceIds` and `RoyalRoadIds` ever drift, the `const val` chain doesn't compile — that's the regression test.

## What I deliberately did NOT add

A separate `assertEquals(SourceIds.ROYAL_ROAD, RoyalRoadIds.SOURCE_ID)` runtime test. The `const val` chain is itself the compile-time agreement; a runtime assertion would be lower-fidelity than what the type system already enforces.

## Test plan

- [x] `./gradlew :core-data:compileDebugKotlin :source-royalroad:compileDebugKotlin :source-github:compileDebugKotlin` — all green locally.
- [ ] No behavior change. Pure refactor — every literal that was `"royalroad"` is still `"royalroad"`, just looked up via the const.

## Related

Issue #57 was filed via Zephyr's test work (the literals showed up as fragile string-comparison fixtures across multiple test files).