### PR TITLE
fix(playback): catch ForegroundServiceStartNotAllowedException (#37)

### DIFF
--- a/core-playback/src/main/kotlin/in/jphe/storyvox/playback/StoryvoxPlaybackService.kt
+++ b/core-playback/src/main/kotlin/in/jphe/storyvox/playback/StoryvoxPlaybackService.kt
@@ -1,5 +1,6 @@
 package `in`.jphe.storyvox.playback
 
+import android.app.ForegroundServiceStartNotAllowedException
 import android.app.NotificationChannel
 import android.app.NotificationManager
 import android.app.PendingIntent
@@ -7,7 +8,9 @@ import android.content.ComponentName
 import android.content.Intent
 import android.content.pm.ServiceInfo
 import android.os.Build
+import android.util.Log
 import androidx.core.app.NotificationCompat
+import androidx.core.app.NotificationManagerCompat
 import androidx.core.app.TaskStackBuilder
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.flow.distinctUntilChanged
@@ -202,14 +205,39 @@ class StoryvoxPlaybackService : MediaSessionService() {
             .setOngoing(true)
             .setStyle(MediaStyleNotificationHelper.MediaStyle(session))
             .build()
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.UPSIDE_DOWN_CAKE) {
-            startForeground(
-                NOTIFICATION_ID,
-                notif,
-                ServiceInfo.FOREGROUND_SERVICE_TYPE_MEDIA_PLAYBACK,
-            )
-        } else {
-            startForeground(NOTIFICATION_ID, notif)
+        // Issue #37: on Android 12+ (API 31), startForeground can throw
+        // ForegroundServiceStartNotAllowedException when the OS denies
+        // the foreground promotion (battery-saver-killed media-button
+        // exemption, OEM customizations, long-paused-then-resume after
+        // FG attribution lapsed). The previous code crashed the service
+        // on that path. Catch it, log, post a regular (non-foreground)
+        // notification so the user has *some* signal, and stopSelf so
+        // the service doesn't linger waiting for a promotion that
+        // won't arrive.
+        try {
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.UPSIDE_DOWN_CAKE) {
+                startForeground(
+                    NOTIFICATION_ID,
+                    notif,
+                    ServiceInfo.FOREGROUND_SERVICE_TYPE_MEDIA_PLAYBACK,
+                )
+            } else {
+                startForeground(NOTIFICATION_ID, notif)
+            }
+        } catch (e: Exception) {
+            // Guard the catch with a runtime version check rather than a
+            // typed catch — ForegroundServiceStartNotAllowedException is
+            // API 31+, and a typed catch on pre-31 devices crashes the
+            // service at class-load time, not just when thrown.
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S &&
+                e is ForegroundServiceStartNotAllowedException
+            ) {
+                Log.w(TAG, "FG-start denied; posting regular notification + stopSelf", e)
+                runCatching { NotificationManagerCompat.from(this).notify(NOTIFICATION_ID, notif) }
+                stopSelf()
+            } else {
+                throw e
+            }
         }
     }
 
@@ -255,6 +283,7 @@ class StoryvoxPlaybackService : MediaSessionService() {
     }
 
     companion object {
+        private const val TAG = "StoryvoxPlaybackService"
         const val CHANNEL_PLAYBACK = "playback"
         const val NOTIFICATION_ID = 1042
         /** FQN of the launcher Activity. Hardcoded so :core-playback doesn't


### PR DESCRIPTION
## Summary

Closes #37. Wraps the two `startForeground()` calls in `StoryvoxPlaybackService.postPlaceholder()` with a guarded try/catch for `ForegroundServiceStartNotAllowedException` (API 31+). On denial — log, post a regular notification, `stopSelf()` so the service doesn't linger waiting for a promotion that won't arrive.

## Why the guarded catch instead of a typed catch

A typed `catch (e: ForegroundServiceStartNotAllowedException)` causes a class-not-found error at class-load time on pre-31 devices, even if the catch never fires. The runtime `Build.VERSION.SDK_INT >= Build.VERSION_CODES.S && e is ForegroundServiceStartNotAllowedException` check sidesteps that. Non-FG-start exceptions re-throw unchanged.

## Trigger paths

| Path | Risk |
|------|------|
| User taps Listen → in-app FG attribution | Safe (happy path) |
| Bluetooth / lock-screen media button | Documented OS exemption, but battery-saver / OEM quirks can deny |
| Transport button after long pause | OS may have suspended FG attribution → real risk |
| Wear bridge resume | Untested edge |

The catch is defensive belt-and-braces for the latter three, not a fix for an observed crash on R83W80CAFZB.

## Test plan

- [x] `./gradlew :core-playback:compileDebugKotlin` — clean (pre-existing SimpleBitmapLoader deprecation warnings unchanged).
- [ ] Manual on tablet: smoke-test a Listen tap + a Bluetooth play/pause to confirm the happy path is unaffected. Denial paths can't be reproduced reliably without OS-level interference; the catch is exercised when it fires.
- [ ] Pre-31 device path: the runtime version check ensures the typed comparison never executes; class-load remains clean.

## Related

Filed during the third-pass latent-bug sweep that also produced #28, #30, #43, #57.