### PR TITLE
fix(sleep-timer): chapterEndSignal replay=1 with cache-clear hooks (#34)

### DIFF
--- a/core-playback/src/main/kotlin/in/jphe/storyvox/playback/SleepTimer.kt
+++ b/core-playback/src/main/kotlin/in/jphe/storyvox/playback/SleepTimer.kt
@@ -42,7 +42,20 @@ class SleepTimer @Inject constructor(
     private val _remainingMs = MutableStateFlow<Long?>(null)
     val remainingMs: StateFlow<Long?> = _remainingMs.asStateFlow()
 
-    private val chapterEndSignal = MutableSharedFlow<Unit>(extraBufferCapacity = 1)
+    /**
+     * Issue #34: chapter-end signal uses `replay = 1` so a
+     * [signalChapterEnd] fired in the millisecond before
+     * [start] subscribes is still observable. The previous
+     * `replay = 0, extraBufferCapacity = 1` shape silently dropped that
+     * race.
+     *
+     * The replay cache MUST be cleared in [cancel] and at the end of
+     * [fadeAndPause] so a stale signal from a previously-played chapter
+     * doesn't fire a freshly-armed EndOfChapter timer immediately. The
+     * cache is logically tied to the active timer's lifetime, not the
+     * SharedFlow's process lifetime.
+     */
+    private val chapterEndSignal = MutableSharedFlow<Unit>(replay = 1)
     val chapterEnd: SharedFlow<Unit> = chapterEndSignal.asSharedFlow()
 
     /** Called by [tts.SentenceTracker] when the last sentence of a chapter finishes. */
@@ -51,7 +64,16 @@ class SleepTimer @Inject constructor(
     }
 
     fun start(mode: SleepTimerMode) {
-        cancel()
+        // Tear down any prior job WITHOUT clearing the replay cache —
+        // a chapter-end signal that arrived in the millisecond before
+        // this start() call must survive into the new job's
+        // chapterEndSignal.first() collector. Cache-clearing is
+        // user-cancel-driven (see [cancel]) or fade-completion-driven
+        // (see [fadeAndPause]).
+        job?.cancel()
+        job = null
+        _remainingMs.value = null
+        volumeRamp.set(1.0f)
         job = scope.launch {
             when (mode) {
                 is SleepTimerMode.Duration -> runCountdown(mode.minutes * 60_000L)
@@ -84,6 +106,9 @@ class SleepTimer @Inject constructor(
         pauseAction.invoke()
         volumeRamp.set(1.0f)
         _remainingMs.value = null
+        // Drop the consumed signal so a future EndOfChapter timer
+        // doesn't see a stale value (issue #34).
+        chapterEndSignal.resetReplayCache()
     }
 
     fun cancel() {
@@ -91,6 +116,11 @@ class SleepTimer @Inject constructor(
         job = null
         _remainingMs.value = null
         volumeRamp.set(1.0f)
+        // Drop any cached chapter-end signal — the user explicitly
+        // dismissed the timer, so a stale signal from a chapter that
+        // ended while the timer was active should not arm the next
+        // timer (issue #34).
+        chapterEndSignal.resetReplayCache()
     }
 
     fun interface PauseAction {

--- a/core-playback/src/test/kotlin/in/jphe/storyvox/playback/SleepTimerTest.kt
+++ b/core-playback/src/test/kotlin/in/jphe/storyvox/playback/SleepTimerTest.kt
@@ -233,23 +233,80 @@ class SleepTimerTest {
         timer.cancel()
     }
 
-    @Test fun `signalChapterEnd before EndOfChapter start does not auto-trigger`() = runTest {
+    @Test fun `signalChapterEnd before EndOfChapter start IS captured and replayed`() = runTest {
+        // Issue #34: chapterEndSignal uses replay=1 so a signal fired in
+        // the millisecond before start(EndOfChapter) subscribes is still
+        // observable. Previously this test documented the dropped-signal
+        // behavior as a contract; the contract is now "captured and
+        // replayed" because the dropped-signal version produced
+        // unobservable bugs (timer never fires; user thinks the feature
+        // is broken).
         val ramp = RecordingVolumeRamp()
         val pause = CountingPauseAction()
         val timer = SleepTimer(ramp, pause, backgroundScope)
 
-        // Fire signal first; chapterEndSignal has extraBufferCapacity=1 but
-        // SharedFlow does NOT replay to new subscribers, so the subsequent
-        // start(EndOfChapter) should NOT see this emission.
         timer.signalChapterEnd()
         runCurrent()
 
         timer.start(SleepTimerMode.EndOfChapter)
         runCurrent()
+        // Cached signal is consumed immediately; let the fade-tail run.
+        advanceTimeBy(11_000L); runCurrent() // 10s fade tail + slack
+
+        assertEquals(1, pause.count)
+        timer.cancel()
+    }
+
+    @Test fun `cancel clears the chapter-end replay cache`() = runTest {
+        // Issue #34 corollary: a stale signal from chapter A must not
+        // arm a freshly-started EndOfChapter timer for chapter B. The
+        // cache is logically per-timer-lifetime, not per-process.
+        val ramp = RecordingVolumeRamp()
+        val pause = CountingPauseAction()
+        val timer = SleepTimer(ramp, pause, backgroundScope)
+
+        // Chapter A ends while no timer is active — signal cached.
+        timer.signalChapterEnd()
+        runCurrent()
+        // User briefly armed and cancelled an EndOfChapter timer.
+        timer.start(SleepTimerMode.EndOfChapter)
+        runCurrent()
+        timer.cancel()
+        runCurrent()
+        // The cancel above should clear the cache. So a fresh
+        // EndOfChapter timer must NOT consume the stale chapter A
+        // signal.
+        timer.start(SleepTimerMode.EndOfChapter)
+        runCurrent()
         advanceTimeBy(60_000L); runCurrent()
 
-        // Signal was lost — pauseAction must not have fired.
         assertEquals(0, pause.count)
+        timer.cancel()
+    }
+
+    @Test fun `fadeAndPause clears the chapter-end replay cache`() = runTest {
+        // Issue #34 corollary: after a successful EndOfChapter timer
+        // completes, the consumed signal must not auto-arm the NEXT
+        // EndOfChapter timer.
+        val ramp = RecordingVolumeRamp()
+        val pause = CountingPauseAction()
+        val timer = SleepTimer(ramp, pause, backgroundScope)
+
+        timer.start(SleepTimerMode.EndOfChapter)
+        runCurrent()
+        timer.signalChapterEnd()
+        runCurrent()
+        advanceTimeBy(11_000L); runCurrent() // 10s fade tail + slack
+        assertEquals(1, pause.count)
+
+        // Now arm a second EndOfChapter timer — the cache from the
+        // first one must be empty.
+        timer.start(SleepTimerMode.EndOfChapter)
+        runCurrent()
+        advanceTimeBy(60_000L); runCurrent()
+
+        // No new signal fired, so pause count stays at 1.
+        assertEquals(1, pause.count)
         timer.cancel()
     }
 }


### PR DESCRIPTION
## Summary

Closes #34. The `chapterEndSignal` SharedFlow had `replay = 0, extraBufferCapacity = 1`, which buffers between active subscribers but does NOT replay to a new subscriber. A `signalChapterEnd()` fired in the millisecond before `start(EndOfChapter)` subscribed was silently dropped — timer never fired, user assumed the feature was broken.

Fix: `replay = 1` so the signal is captured-and-replayed across the `start()` boundary. Two corollary changes keep the cache scoped to the active timer's lifetime:

- **[cancel] (user-cancel)** clears `resetReplayCache()`. Without this, a stale chapter-A signal could fire a freshly-armed chapter-B EndOfChapter timer.
- **[fadeAndPause] (timer fires)** clears `resetReplayCache()` after consumption. Without this, a second EndOfChapter timer started after the first completes would auto-fire on the cached signal.

## Why split the cancel path

The previous `start()` body called `cancel()` first to tear down a prior job. With cache-clearing in `cancel()`, that internal `start()`-driven cancel would wipe the very replay cache the new `start()` was trying to consume. Splitting `start()`'s internal "cancel any prior job" out of `cancel()` preserves both the race-fix and the user-cancel semantics.

## Test changes

| Test | Before | After |
|------|--------|-------|
| `signalChapterEnd before EndOfChapter start does not auto-trigger` | asserted dropped-signal contract | flipped to assert captured-and-replayed contract |
| **(NEW)** `cancel clears the chapter-end replay cache` | — | asserts user-cancel clears stale signal |
| **(NEW)** `fadeAndPause clears the chapter-end replay cache` | — | asserts post-fade cache clear so a second timer doesn't auto-fire |

## Test plan

- [x] `./gradlew :core-playback:testDebugUnitTest --tests '*SleepTimerTest*'` — all 13 green locally including the 3 changed/new cases.
- [ ] No manual install needed; pure state-machine fix with full test coverage.

## Related

Filed by Zephyr during the SleepTimer state-machine test pass (PR #31). Cache-clear hooks were not in #31's scope but emerged as a logical pair with the replay flip during this fix.