### PR TITLE
fix(tts): SentenceTracker only flips hasReceivedRange on parseable id (#43)

### DIFF
--- a/core-playback/src/main/kotlin/in/jphe/storyvox/playback/tts/SentenceTracker.kt
+++ b/core-playback/src/main/kotlin/in/jphe/storyvox/playback/tts/SentenceTracker.kt
@@ -55,8 +55,13 @@ class SentenceTracker(
     }
 
     override fun onRangeStart(utteranceId: String, start: Int, end: Int, frame: Int) {
-        hasReceivedRange = true
+        // Parse first; only flip the "engine supports per-word ranges" flag
+        // on a parseable id (issue #43). A malformed id means the engine
+        // gave us a callback we can't act on — treating it as "ranges
+        // supported" would mislead the fallback path into thinking the
+        // engine works when it might not.
         val idx = parseIndex(utteranceId) ?: return
+        hasReceivedRange = true
         val s = sentences.getOrNull(idx) ?: return
         onSentence(
             SentenceRange(

--- a/core-playback/src/test/kotlin/in/jphe/storyvox/playback/tts/SentenceTrackerTest.kt
+++ b/core-playback/src/test/kotlin/in/jphe/storyvox/playback/tts/SentenceTrackerTest.kt
@@ -93,19 +93,25 @@ class SentenceTrackerTest {
         assertEquals(SentenceRange(1, 14, 17), r.sentences[0])
     }
 
-    @Test fun `onRangeStart with malformed id is ignored but flips hasReceivedRange`() {
-        // The flag flip is unconditional in the current contract (ack of any
-        // onRangeStart call from the engine, not of a successful parse).
+    @Test fun `onRangeStart with malformed id is ignored AND does not flip hasReceivedRange`() {
+        // Issue #43: a parse failure means the engine sent us a callback we
+        // can't act on. The "engine supports per-word ranges" flag should
+        // NOT flip on garbage — treating it as supported misleads the
+        // whole-sentence fallback path into thinking the engine works.
         val r = Recorder()
         val tracker = r.newTracker(sample)
 
         tracker.onRangeStart("garbage", 0, 1, 0)
 
-        assertTrue(tracker.hasReceivedRange)
+        assertFalse(tracker.hasReceivedRange)
         assertEquals(0, r.sentences.size)
     }
 
-    @Test fun `onRangeStart with out-of-range index is ignored`() {
+    @Test fun `onRangeStart with out-of-range index flips hasReceivedRange but emits nothing`() {
+        // Distinct from the malformed case: parse succeeded (returns 99),
+        // we just have no sentence at that index (e.g. a stale callback
+        // after a seek). The engine demonstrably emits per-word ranges,
+        // so the flag flip is correct.
         val r = Recorder()
         val tracker = r.newTracker(sample)
 


### PR DESCRIPTION
## Summary

Closes #43. `SentenceTracker.onRangeStart` now parses the utterance id BEFORE flipping the `hasReceivedRange` flag. A garbage id no longer misleads the whole-sentence fallback path into believing the engine emits per-word ranges.

## Behavior change

| Input id | Before | After |
|----------|--------|-------|
| Parseable, in-range (`s1_p0`) | flag flips, range emitted | flag flips, range emitted (unchanged) |
| Parseable, out-of-range (`s99_p0`) | flag flips, no emit | flag flips, no emit (unchanged) |
| Malformed (`garbage`) | **flag flips**, no emit | **flag does NOT flip**, no emit |

Out-of-range still flips the flag because the engine demonstrably emitted a per-word range — we just don't have a sentence at that index (likely a stale callback after a chapter switch). That's a bookkeeping concern, not an "is the engine working" concern.

## Test plan

- [x] `./gradlew :core-playback:testDebugUnitTest --tests '*SentenceTrackerTest*'` — all green locally including the two updated cases (malformed id, out-of-range id).
- No manual install needed; pure unit-tested logic change.

## Related

Filed during the latent-bug sweep that produced PRs #20/#23/#26/#33/#36/#45 and issues #28/#30/#37/#43/#57. Surfaced concretely by Zephyr's SentenceTracker tests in #41 (the existing test was actively documenting the wrong contract — flipped here).
