### PR TITLE
feat(source-github): GitHubSource detail+chapter integration + Hilt @IntoMap binding

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -137,6 +137,7 @@ dependencies {
     implementation(project(":core-playback"))
     implementation(project(":core-ui"))
     implementation(project(":source-royalroad"))
+    implementation(project(":source-github"))
     implementation(project(":feature"))
 
     implementation(libs.androidx.core.ktx)

--- a/core-data/src/main/kotlin/in/jphe/storyvox/data/repository/AuthRepository.kt
+++ b/core-data/src/main/kotlin/in/jphe/storyvox/data/repository/AuthRepository.kt
@@ -5,6 +5,7 @@ import `in`.jphe.storyvox.data.auth.SessionState
 import `in`.jphe.storyvox.data.db.dao.AuthDao
 import `in`.jphe.storyvox.data.db.entity.AuthCookie
 import `in`.jphe.storyvox.data.source.FictionSource
+import `in`.jphe.storyvox.data.source.SourceIds
 import `in`.jphe.storyvox.data.source.model.FictionResult
 import androidx.core.content.edit
 import kotlinx.coroutines.CoroutineScope
@@ -59,13 +60,15 @@ class AuthRepositoryImpl @Inject constructor(
     private val state = MutableStateFlow<SessionState>(SessionState.Anonymous)
     override val sessionState: StateFlow<SessionState> = state.asStateFlow()
 
-    // Auth is per-source. Today only one source binds a SessionHydrator
-    // (RoyalRoad), so we pin to the only bound FictionSource. When GitHub
-    // source lands with its own auth flow, this becomes a per-call lookup
-    // — the cookie store is already keyed `cookie:$sourceId` so the data
-    // layer doesn't need migration.
-    private val source: FictionSource = sources.values.singleOrNull()
-        ?: error("AuthRepository: expected exactly one FictionSource bound, got ${sources.keys}")
+    // Auth is per-source. Royal Road is the only source with a
+    // SessionHydrator wired today; GitHub source (3d-detail-and-chapter
+    // and beyond) has no auth flow until step 3f adds optional PAT
+    // support. Pin to Royal Road explicitly. When GitHub auth lands
+    // this becomes a per-call lookup — the cookie store is already
+    // keyed `cookie:$sourceId` so the data layer doesn't need
+    // migration.
+    private val source: FictionSource = sources[SourceIds.ROYAL_ROAD]
+        ?: error("AuthRepository: expected $sources to bind ${SourceIds.ROYAL_ROAD}; got ${sources.keys}")
     private val sourceId: String get() = source.id
     private val cookieKey: String get() = "cookie:$sourceId"
 

--- a/source-github/src/main/kotlin/in/jphe/storyvox/source/github/GitHubSource.kt
+++ b/source-github/src/main/kotlin/in/jphe/storyvox/source/github/GitHubSource.kt
@@ -3,36 +3,56 @@ package `in`.jphe.storyvox.source.github
 import `in`.jphe.storyvox.data.source.FictionSource
 import `in`.jphe.storyvox.data.source.SourceIds
 import `in`.jphe.storyvox.data.source.model.ChapterContent
+import `in`.jphe.storyvox.data.source.model.ChapterInfo
 import `in`.jphe.storyvox.data.source.model.FictionDetail
 import `in`.jphe.storyvox.data.source.model.FictionResult
+import `in`.jphe.storyvox.data.source.model.FictionStatus
 import `in`.jphe.storyvox.data.source.model.FictionSummary
 import `in`.jphe.storyvox.data.source.model.ListPage
 import `in`.jphe.storyvox.data.source.model.SearchQuery
+import `in`.jphe.storyvox.source.github.manifest.BookManifest
+import `in`.jphe.storyvox.source.github.manifest.ManifestChapter
+import `in`.jphe.storyvox.source.github.manifest.ManifestParser
+import `in`.jphe.storyvox.source.github.model.GhRepo
+import `in`.jphe.storyvox.source.github.model.decodedText
 import `in`.jphe.storyvox.source.github.net.GitHubApi
+import `in`.jphe.storyvox.source.github.net.GitHubApiResult
 import `in`.jphe.storyvox.source.github.registry.Registry
 import `in`.jphe.storyvox.source.github.registry.RegistryEntry
 import `in`.jphe.storyvox.source.github.registry.toSummary
+import `in`.jphe.storyvox.source.github.render.MarkdownChapterRenderer
 import javax.inject.Inject
 import javax.inject.Singleton
+import kotlin.time.DurationUnit
+import kotlin.time.toDuration
 
 /**
- * GitHub [FictionSource]. Browse calls (popular/latestUpdates/byGenre/
- * genres) are wired to the curated [Registry] as of step 3c. Detail
- * and chapter still throw [NotImplementedError] — they land in step 3d
- * when manifest parsing returns real [FictionDetail] data. Search
- * lands in step 3-search (spec sequence step 8).
+ * GitHub [FictionSource]. Fully wired in step 3d-detail-and-chapter:
  *
- * **Still not Hilt-bound**: detail is the load-bearing call when the
- * UrlRouter routes a paste through [`in`.jphe.storyvox.data.repository
- * .FictionRepository.addByUrl], so binding the source before detail
- * works would break that flow. Step 3d adds the @IntoMap binding
- * once detail returns real data.
+ *  - **Browse** (popular/latestUpdates/byGenre/genres): backed by the
+ *    curated [Registry] (step 3c).
+ *  - **Detail** (`fictionDetail`): fetches `book.toml`, `storyvox.json`,
+ *    `SUMMARY.md` from the repo + repo metadata, runs them through
+ *    [ManifestParser] (step 3d-manifest), and maps to [FictionDetail].
+ *    Falls back to repo `chapters/` or `src/` directory listings when
+ *    no `SUMMARY.md` is present (the bare-repo path).
+ *  - **Chapter** (`chapter`): fetches the file's base64 body from
+ *    `/contents`, decodes, runs through [MarkdownChapterRenderer]
+ *    (step 3d-markdown).
+ *  - **Search**: deferred to step 3-search (spec sequence step 8).
+ *  - **Auth-gated** (followsList, setFollowed): deferred to step 3f.
+ *
+ * Hilt binding lives in [`in`.jphe.storyvox.source.github.di
+ * .GitHubBindings] — `@IntoMap @StringKey(SourceIds.GITHUB)`. Active
+ * as of this PR; `addByUrl(github URL)` flows end-to-end through the
+ * multi-source map (#35) → `sourceFor(SourceIds.GITHUB)` →
+ * `fictionDetail` → `upsertDetail`.
  */
 @Singleton
 internal class GitHubSource @Inject constructor(
-    @Suppress("unused") // wired so the graph compiles when 3d adds detail
     private val api: GitHubApi,
     private val registry: Registry,
+    private val markdownRenderer: MarkdownChapterRenderer,
 ) : FictionSource {
 
     override val id: String = SourceIds.GITHUB
@@ -40,18 +60,11 @@ internal class GitHubSource @Inject constructor(
 
     override suspend fun popular(page: Int): FictionResult<ListPage<FictionSummary>> =
         registryPage(page) { entries ->
-            // Featured first, then the rest in registry order. Within each
-            // band we keep the curator's authored ordering rather than
-            // imposing a synthetic rank — curators sort hand-picks for a
-            // reason.
             entries.sortedByDescending { it.featured }
         }
 
     override suspend fun latestUpdates(page: Int): FictionResult<ListPage<FictionSummary>> =
         registryPage(page) { entries ->
-            // `addedAt` is the only freshness signal we have pre-manifest.
-            // ISO-8601 yyyy-MM-dd string-sorts correctly; entries without
-            // an addedAt sort last (empty string < any date).
             entries.sortedByDescending { it.addedAt.orEmpty() }
         }
 
@@ -80,14 +93,113 @@ internal class GitHubSource @Inject constructor(
     override suspend fun search(query: SearchQuery): FictionResult<ListPage<FictionSummary>> =
         throw NotImplementedError(STEP_3_SEARCH)
 
-    override suspend fun fictionDetail(fictionId: String): FictionResult<FictionDetail> =
-        throw NotImplementedError(STEP_3D_DETAIL)
+    override suspend fun fictionDetail(fictionId: String): FictionResult<FictionDetail> {
+        val coords = parseFictionId(fictionId)
+            ?: return FictionResult.NotFound(message = "Not a GitHub fiction id: $fictionId")
+        val (owner, repo) = coords
+
+        // Existence + metadata. NotFound here means the repo doesn't
+        // exist; surface verbatim so the caller's add-by-URL flow can
+        // tell the user.
+        val ghRepo: GhRepo = when (val r = api.getRepo(owner, repo)) {
+            is GitHubApiResult.Success -> r.value
+            is GitHubApiResult.NotFound -> return FictionResult.NotFound(message = r.message)
+            is GitHubApiResult.RateLimited -> return FictionResult.RateLimited(
+                retryAfter = r.retryAfterSeconds?.let { it.toDuration(DurationUnit.SECONDS) },
+            )
+            is GitHubApiResult.HttpError -> return FictionResult.NetworkError(
+                message = "GitHub error ${r.code}: ${r.message}",
+            )
+            is GitHubApiResult.NetworkError -> return FictionResult.NetworkError(
+                message = "Could not reach GitHub",
+                cause = r.cause,
+            )
+            is GitHubApiResult.ParseError -> return FictionResult.NetworkError(
+                message = "Malformed repo response",
+                cause = r.cause,
+            )
+        }
+
+        val branch = ghRepo.defaultBranch
+
+        // Manifest candidates. Each is best-effort: a 404 just means
+        // the author didn't author that file. Anything else (rate
+        // limit, network) is a hard failure — we propagate it via the
+        // [OptionalText.failureOrNull] field so the caller short-
+        // circuits with the right `FictionResult.Failure` variant.
+        val bookTomlOpt = fetchOptionalText(owner, repo, "book.toml", branch)
+        bookTomlOpt.failureOrNull?.let { return it }
+        val storyvoxJsonOpt = fetchOptionalText(owner, repo, "storyvox.json", branch)
+        storyvoxJsonOpt.failureOrNull?.let { return it }
+        val srcDirGuess = guessSrcDir(bookTomlOpt.text)
+        val summaryMdOpt = fetchOptionalText(owner, repo, "$srcDirGuess/SUMMARY.md", branch)
+        summaryMdOpt.failureOrNull?.let { return it }
+
+        val bookToml = bookTomlOpt.text
+        val storyvoxJson = storyvoxJsonOpt.text
+        val summaryMd = summaryMdOpt.text
+
+        val bareRepoPaths = if (summaryMd.isNullOrBlank()) {
+            listBareRepoPaths(owner, repo, branch, srcDirGuess)
+        } else {
+            emptyList()
+        }
+
+        val manifest = ManifestParser.parse(
+            fictionId = fictionId,
+            bookToml = bookToml,
+            storyvoxJson = storyvoxJson,
+            summaryMd = summaryMd,
+            bareRepoPaths = bareRepoPaths,
+        )
+
+        return FictionResult.Success(toFictionDetail(fictionId, ghRepo, manifest))
+    }
 
     override suspend fun chapter(
-        @Suppress("UNUSED_PARAMETER") fictionId: String,
-        @Suppress("UNUSED_PARAMETER") chapterId: String,
-    ): FictionResult<ChapterContent> =
-        throw NotImplementedError(STEP_3D_DETAIL)
+        fictionId: String,
+        chapterId: String,
+    ): FictionResult<ChapterContent> {
+        val coords = parseFictionId(fictionId)
+            ?: return FictionResult.NotFound(message = "Not a GitHub fiction id: $fictionId")
+        val (owner, repo) = coords
+        // Chapter id format per spec line 141: `<fictionId>:<path>`.
+        val path = chapterId.removePrefix("$fictionId:").trimStart('/')
+        if (path.isEmpty() || path == chapterId) {
+            return FictionResult.NotFound(message = "Malformed chapter id: $chapterId")
+        }
+
+        return when (val r = api.getContent(owner, repo, path)) {
+            is GitHubApiResult.Success -> {
+                val text = r.value.decodedText()
+                    ?: return FictionResult.NetworkError(
+                        message = "Chapter at $path was not a base64-encoded file",
+                    )
+                val info = ChapterInfo(
+                    id = chapterId,
+                    sourceChapterId = path,
+                    index = 0, // caller sets ordering from FictionDetail.chapters
+                    title = path.substringAfterLast('/').removeSuffix(".md"),
+                )
+                FictionResult.Success(markdownRenderer.render(info, text))
+            }
+            is GitHubApiResult.NotFound -> FictionResult.NotFound(message = r.message)
+            is GitHubApiResult.RateLimited -> FictionResult.RateLimited(
+                retryAfter = r.retryAfterSeconds?.let { it.toDuration(DurationUnit.SECONDS) },
+            )
+            is GitHubApiResult.HttpError -> FictionResult.NetworkError(
+                message = "GitHub error ${r.code}: ${r.message}",
+            )
+            is GitHubApiResult.NetworkError -> FictionResult.NetworkError(
+                message = "Could not reach GitHub",
+                cause = r.cause,
+            )
+            is GitHubApiResult.ParseError -> FictionResult.NetworkError(
+                message = "Malformed chapter response",
+                cause = r.cause,
+            )
+        }
+    }
 
     override suspend fun followsList(
         @Suppress("UNUSED_PARAMETER") page: Int,
@@ -100,20 +212,147 @@ internal class GitHubSource @Inject constructor(
     ): FictionResult<Unit> =
         throw NotImplementedError(STEP_3F_AUTH)
 
+    // ─── helpers ───────────────────────────────────────────────────────
+
+    /** Result wrapper for a candidate manifest file fetch. */
+    private data class OptionalText(
+        val text: String?,
+        val failureOrNull: FictionResult.Failure?,
+    )
+
     /**
-     * Registry-backed paging. Single page today (registry is small +
-     * hand-curated; pagination would be over-engineering until the
-     * curated set exceeds a screenful). [transform] runs over the raw
-     * [RegistryEntry] list — keeping `addedAt`/`featured` available
-     * for sort/filter before mapping to the cross-source
-     * [FictionSummary] shape.
+     * Fetch a file's text body, treating 404 as "absent" (returns
+     * null text + null failure). Other failures populate
+     * [OptionalText.failureOrNull] so the caller can short-circuit.
      */
+    private suspend fun fetchOptionalText(
+        owner: String,
+        repo: String,
+        path: String,
+        ref: String,
+    ): OptionalText = when (val r = api.getContent(owner, repo, path, ref)) {
+        is GitHubApiResult.Success -> OptionalText(r.value.decodedText(), null)
+        is GitHubApiResult.NotFound -> OptionalText(null, null) // file just isn't there
+        is GitHubApiResult.RateLimited -> OptionalText(
+            null,
+            FictionResult.RateLimited(
+                retryAfter = r.retryAfterSeconds?.let { it.toDuration(DurationUnit.SECONDS) },
+            ),
+        )
+        is GitHubApiResult.HttpError -> OptionalText(
+            null,
+            FictionResult.NetworkError(message = "GitHub error ${r.code}: ${r.message}"),
+        )
+        is GitHubApiResult.NetworkError -> OptionalText(
+            null,
+            FictionResult.NetworkError(message = "Could not reach GitHub", cause = r.cause),
+        )
+        is GitHubApiResult.ParseError -> OptionalText(
+            null,
+            FictionResult.NetworkError(message = "Malformed file response", cause = r.cause),
+        )
+    }
+
+    /**
+     * Best-effort `[book].src` extraction for the SUMMARY.md path
+     * lookup. Re-parsed from book.toml here rather than threading it
+     * through ManifestParser because we need it before the parser
+     * runs (we feed it the SUMMARY contents as one of its inputs).
+     * Default to `src` per mdbook convention.
+     */
+    private fun guessSrcDir(bookToml: String?): String {
+        if (bookToml == null) return "src"
+        val m = Regex("""(?m)^\s*src\s*=\s*"([^"]*)"\s*$""").find(bookToml) ?: return "src"
+        return m.groupValues[1].ifBlank { "src" }
+    }
+
+    /**
+     * Listing for the bare-repo fallback: try `chapters/` first, then
+     * the manifest-claimed src dir. Returns an empty list on any
+     * failure — bare-repo is itself a fallback, so a missing dir just
+     * means "nothing to fall back to."
+     */
+    private suspend fun listBareRepoPaths(
+        owner: String,
+        repo: String,
+        ref: String,
+        srcDir: String,
+    ): List<String> {
+        val candidates = listOf("chapters", srcDir).distinct()
+        for (dir in candidates) {
+            val r = api.getContents(owner, repo, dir, ref)
+            if (r is GitHubApiResult.Success) {
+                val files = r.value.filter { it.type == "file" }.map { it.path }
+                if (files.isNotEmpty()) return files
+            }
+        }
+        return emptyList()
+    }
+
+    private fun toFictionDetail(
+        fictionId: String,
+        repo: GhRepo,
+        manifest: BookManifest,
+    ): FictionDetail = FictionDetail(
+        summary = FictionSummary(
+            id = fictionId,
+            sourceId = SourceIds.GITHUB,
+            title = manifest.title,
+            author = manifest.author,
+            // Cover URL is repo-relative in the manifest; resolve
+            // against raw.githubusercontent for direct image fetch.
+            coverUrl = manifest.coverPath?.let { rawUrl(repo, it) },
+            description = manifest.description ?: repo.description,
+            tags = manifest.tags.ifEmpty { repo.topics },
+            status = parseStatus(manifest.status, repo),
+            chapterCount = manifest.chapters.size,
+            rating = null,
+        ),
+        chapters = manifest.chapters.toChapterInfos(fictionId),
+        genres = manifest.tags,
+        wordCount = null,
+        views = null,
+        followers = repo.stars.takeIf { it > 0 },
+        lastUpdatedAt = null,
+        authorId = repo.owner.login,
+    )
+
+    private fun List<ManifestChapter>.toChapterInfos(fictionId: String): List<ChapterInfo> =
+        mapIndexed { index, ch ->
+            ChapterInfo(
+                id = "$fictionId:${ch.path}",
+                sourceChapterId = ch.path,
+                index = index,
+                title = ch.title,
+            )
+        }
+
+    private fun rawUrl(repo: GhRepo, path: String): String {
+        val cleanPath = path.trimStart('/')
+        return "https://raw.githubusercontent.com/${repo.fullName}/${repo.defaultBranch}/$cleanPath"
+    }
+
+    private fun parseStatus(raw: String?, repo: GhRepo): FictionStatus = when {
+        raw?.equals("completed", ignoreCase = true) == true -> FictionStatus.COMPLETED
+        raw?.equals("hiatus", ignoreCase = true) == true -> FictionStatus.HIATUS
+        raw?.equals("dropped", ignoreCase = true) == true -> FictionStatus.DROPPED
+        repo.archived -> FictionStatus.COMPLETED
+        else -> FictionStatus.ONGOING
+    }
+
+    /** `github:owner/repo` → `(owner, repo)` or null. */
+    private fun parseFictionId(fictionId: String): Pair<String, String>? {
+        val stripped = fictionId.removePrefix("${SourceIds.GITHUB}:")
+        if (stripped == fictionId) return null
+        val slash = stripped.indexOf('/')
+        if (slash <= 0 || slash == stripped.length - 1) return null
+        return stripped.substring(0, slash) to stripped.substring(slash + 1)
+    }
+
     private suspend fun registryPage(
         page: Int,
         transform: (List<RegistryEntry>) -> List<RegistryEntry>,
     ): FictionResult<ListPage<FictionSummary>> {
-        // Page 2+ always empty — caller's pagination cursor short-
-        // circuits the next-page fetch via hasNext=false on page 1.
         if (page > 1) {
             return FictionResult.Success(
                 ListPage(items = emptyList(), page = page, hasNext = false),
@@ -132,7 +371,6 @@ internal class GitHubSource @Inject constructor(
     }
 
     private companion object {
-        const val STEP_3D_DETAIL = "GitHub source detail/chapter not implemented yet — lands in step 3d (manifest parsing + markdown rendering)"
         const val STEP_3F_AUTH = "GitHub source auth-gated calls not implemented yet — lands in step 3f (optional PAT support)"
         const val STEP_3_SEARCH = "GitHub /search/repositories not implemented yet — lands in step 3-search (spec sequence step 8)"
     }

--- a/source-github/src/main/kotlin/in/jphe/storyvox/source/github/di/GitHubModule.kt
+++ b/source-github/src/main/kotlin/in/jphe/storyvox/source/github/di/GitHubModule.kt
@@ -1,9 +1,15 @@
 package `in`.jphe.storyvox.source.github.di
 
+import dagger.Binds
 import dagger.Module
 import dagger.Provides
 import dagger.hilt.InstallIn
 import dagger.hilt.components.SingletonComponent
+import dagger.multibindings.IntoMap
+import dagger.multibindings.StringKey
+import `in`.jphe.storyvox.data.source.FictionSource
+import `in`.jphe.storyvox.data.source.SourceIds
+import `in`.jphe.storyvox.source.github.GitHubSource
 import okhttp3.OkHttpClient
 import javax.inject.Qualifier
 import javax.inject.Singleton
@@ -16,15 +22,6 @@ internal annotation class GitHubHttp
  * Provides the OkHttpClient used by [`in`.jphe.storyvox.source.github
  * .net.GitHubApi]. Qualified [GitHubHttp] so it doesn't collide with
  * the unqualified app-wide client (or the @RoyalRoadHttp one).
- *
- * **NOT** wired into a `FictionSource` Hilt binding yet — that lands
- * in step 3d when [`in`.jphe.storyvox.source.github.GitHubSource]
- * actually returns real [`in`.jphe.storyvox.data.source.model
- * .FictionDetail] data. Today the client is only consumed by
- * GitHubApi and that's only consumed by GitHubSource which throws on
- * every call. The module is here so the dependency graph compiles
- * once GitHubSource starts returning real data — no plumbing change
- * needed at that point.
  */
 @Module
 @InstallIn(SingletonComponent::class)
@@ -39,4 +36,23 @@ internal object GitHubHttpModule {
             .followSslRedirects(true)
             .retryOnConnectionFailure(true)
             .build()
+}
+
+/**
+ * Contributes [GitHubSource] into the multi-source `Map<String,
+ * FictionSource>` from PR #35. With this binding active,
+ * `addByUrl(github URL)` flows end-to-end through the data layer:
+ * `UrlRouter` returns sourceId="github", `FictionRepository.addByUrl`
+ * looks up `sources[SourceIds.GITHUB]`, and `GitHubSource
+ * .fictionDetail` resolves the manifest + chapters.
+ */
+@Module
+@InstallIn(SingletonComponent::class)
+internal abstract class GitHubBindings {
+
+    @Binds
+    @Singleton
+    @IntoMap
+    @StringKey(SourceIds.GITHUB)
+    abstract fun bindFictionSource(impl: GitHubSource): FictionSource
 }

--- a/source-github/src/main/kotlin/in/jphe/storyvox/source/github/model/GitHubModels.kt
+++ b/source-github/src/main/kotlin/in/jphe/storyvox/source/github/model/GitHubModels.kt
@@ -55,6 +55,21 @@ internal data class GhContent(
 )
 
 /**
+ * Decode [GhContent.content] to UTF-8 text. GitHub wraps base64 bodies
+ * at 60 cols with `\n` separators (RFC 2045), which `Base64.getDecoder`
+ * tolerates only with `getMimeDecoder`. Returns null when the content
+ * isn't a base64-encoded file (e.g. dir listing, oversized binary).
+ */
+internal fun GhContent.decodedText(): String? {
+    if (type != "file" || encoding != "base64" || content.isNullOrBlank()) return null
+    return runCatching {
+        java.util.Base64.getMimeDecoder()
+            .decode(content)
+            .toString(Charsets.UTF_8)
+    }.getOrNull()
+}
+
+/**
  * `GET /repos/{owner}/{repo}/compare/{base}...{head}`. Used for
  * commit-SHA-based new-chapter detection: the source stores the
  * last-seen commit, polls compare with that as base, and walks the

--- a/source-github/src/main/kotlin/in/jphe/storyvox/source/github/net/GitHubApi.kt
+++ b/source-github/src/main/kotlin/in/jphe/storyvox/source/github/net/GitHubApi.kt
@@ -56,13 +56,13 @@ internal sealed class GitHubApiResult<out T> {
  * faults from genuinely malformed JSON) come back as `ParseError`.
  */
 @Singleton
-internal class GitHubApi @Inject constructor(
+internal open class GitHubApi @Inject constructor(
     @GitHubHttp private val httpClient: OkHttpClient,
 ) {
-    suspend fun getRepo(owner: String, repo: String): GitHubApiResult<GhRepo> =
+    open suspend fun getRepo(owner: String, repo: String): GitHubApiResult<GhRepo> =
         get("$BASE_URL/repos/${owner.lowercase()}/${repo.lowercase()}")
 
-    suspend fun getContent(
+    open suspend fun getContent(
         owner: String,
         repo: String,
         path: String,
@@ -73,7 +73,24 @@ internal class GitHubApi @Inject constructor(
         return get("$BASE_URL/repos/${owner.lowercase()}/${repo.lowercase()}/contents/$cleanPath$refParam")
     }
 
-    suspend fun compareCommits(
+    /**
+     * Directory listing variant of [getContent]. The same `/contents`
+     * endpoint returns a JSON array when the path is a directory. Used
+     * by the bare-repo fallback to enumerate `chapters/` or `src/` for
+     * numbered .md files when no `SUMMARY.md` is present.
+     */
+    open suspend fun getContents(
+        owner: String,
+        repo: String,
+        path: String,
+        ref: String? = null,
+    ): GitHubApiResult<List<GhContent>> {
+        val refParam = if (ref != null) "?ref=$ref" else ""
+        val cleanPath = path.trimStart('/')
+        return get("$BASE_URL/repos/${owner.lowercase()}/${repo.lowercase()}/contents/$cleanPath$refParam")
+    }
+
+    open suspend fun compareCommits(
         owner: String,
         repo: String,
         base: String,

--- a/source-github/src/test/kotlin/in/jphe/storyvox/source/github/GitHubSourceTest.kt
+++ b/source-github/src/test/kotlin/in/jphe/storyvox/source/github/GitHubSourceTest.kt
@@ -1,15 +1,24 @@
 package `in`.jphe.storyvox.source.github
 
+import `in`.jphe.storyvox.data.source.SourceIds
 import `in`.jphe.storyvox.data.source.model.FictionResult
+import `in`.jphe.storyvox.data.source.model.FictionStatus
+import `in`.jphe.storyvox.source.github.model.GhContent
+import `in`.jphe.storyvox.source.github.model.GhOwner
+import `in`.jphe.storyvox.source.github.model.GhRepo
 import `in`.jphe.storyvox.source.github.net.GitHubApi
+import `in`.jphe.storyvox.source.github.net.GitHubApiResult
 import `in`.jphe.storyvox.source.github.registry.Registry
 import `in`.jphe.storyvox.source.github.registry.RegistryEntry
+import `in`.jphe.storyvox.source.github.render.MarkdownChapterRenderer
 import kotlinx.coroutines.runBlocking
 import okhttp3.OkHttpClient
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotNull
 import org.junit.Assert.assertThrows
 import org.junit.Assert.assertTrue
 import org.junit.Test
+import java.util.Base64
 
 /**
  * Tests cover:
@@ -17,14 +26,18 @@ import org.junit.Test
  *    UrlRouter routing and UI surface strings.
  *  - Browse calls (popular/latestUpdates/byGenre/genres) wired to the
  *    [Registry] as of step 3c — sort/filter/distinct semantics.
- *  - Stubs that *should* still throw (search, fictionDetail, chapter,
- *    followsList, setFollowed) — accidental Hilt binding before the
- *    next steps fill these in must fail loudly, not return empty.
+ *  - Detail (`fictionDetail`) wired to `GitHubApi` + `ManifestParser`
+ *    as of step 3d-detail-and-chapter — repo + manifest fetch, mapping
+ *    to FictionDetail, error path forwarding.
+ *  - Chapter (`chapter`) wired to `GitHubApi` + `MarkdownChapterRenderer`
+ *    as of step 3d-detail-and-chapter — base64 decode, markdown render.
+ *  - Stubs that *should* still throw (search, followsList, setFollowed) —
+ *    accidental Hilt binding for those surfaces must fail loudly.
  */
 class GitHubSourceTest {
 
     @Test fun `sourceId is the stable github key`() {
-        assertEquals("github", source().id)
+        assertEquals(SourceIds.GITHUB, source().id)
     }
 
     @Test fun `displayName surfaces in UI strings and is stable`() {
@@ -33,15 +46,15 @@ class GitHubSourceTest {
 
     @Test fun `popular returns featured entries first, registry order within bands`() {
         val src = source(
-            entry("github:o/a", title = "A", featured = false),
-            entry("github:o/b", title = "B", featured = true),
-            entry("github:o/c", title = "C", featured = false),
-            entry("github:o/d", title = "D", featured = true),
+            entries = listOf(
+                entry("github:o/a", title = "A", featured = false),
+                entry("github:o/b", title = "B", featured = true),
+                entry("github:o/c", title = "C", featured = false),
+                entry("github:o/d", title = "D", featured = true),
+            ),
         )
         val r = runBlocking { src.popular() } as FictionResult.Success
         val ids = r.value.items.map { it.id }
-        // Featured (B, D) before non-featured (A, C); within each band
-        // the curator's authored order is preserved.
         assertEquals(listOf("github:o/b", "github:o/d", "github:o/a", "github:o/c"), ids)
         assertEquals(1, r.value.page)
         assertEquals(false, r.value.hasNext)
@@ -49,21 +62,27 @@ class GitHubSourceTest {
 
     @Test fun `latestUpdates sorts by addedAt descending, missing dates last`() {
         val src = source(
-            entry("github:o/a", title = "A", addedAt = "2026-01-01"),
-            entry("github:o/b", title = "B", addedAt = "2026-05-06"),
-            entry("github:o/c", title = "C", addedAt = null),
-            entry("github:o/d", title = "D", addedAt = "2026-03-15"),
+            entries = listOf(
+                entry("github:o/a", title = "A", addedAt = "2026-01-01"),
+                entry("github:o/b", title = "B", addedAt = "2026-05-06"),
+                entry("github:o/c", title = "C", addedAt = null),
+                entry("github:o/d", title = "D", addedAt = "2026-03-15"),
+            ),
         )
         val r = runBlocking { src.latestUpdates() } as FictionResult.Success
-        val ids = r.value.items.map { it.id }
-        assertEquals(listOf("github:o/b", "github:o/d", "github:o/a", "github:o/c"), ids)
+        assertEquals(
+            listOf("github:o/b", "github:o/d", "github:o/a", "github:o/c"),
+            r.value.items.map { it.id },
+        )
     }
 
     @Test fun `byGenre matches tags case-insensitively and trims input`() {
         val src = source(
-            entry("github:o/a", title = "A", tags = listOf("fantasy", "litrpg")),
-            entry("github:o/b", title = "B", tags = listOf("sci-fi")),
-            entry("github:o/c", title = "C", tags = listOf("FANTASY")),
+            entries = listOf(
+                entry("github:o/a", title = "A", tags = listOf("fantasy", "litrpg")),
+                entry("github:o/b", title = "B", tags = listOf("sci-fi")),
+                entry("github:o/c", title = "C", tags = listOf("FANTASY")),
+            ),
         )
         val r = runBlocking { src.byGenre("  Fantasy  ") } as FictionResult.Success
         assertEquals(setOf("github:o/a", "github:o/c"), r.value.items.map { it.id }.toSet())
@@ -71,8 +90,10 @@ class GitHubSourceTest {
 
     @Test fun `byGenre with blank input returns the full registry`() {
         val src = source(
-            entry("github:o/a", title = "A", tags = listOf("fantasy")),
-            entry("github:o/b", title = "B", tags = listOf("sci-fi")),
+            entries = listOf(
+                entry("github:o/a", title = "A", tags = listOf("fantasy")),
+                entry("github:o/b", title = "B", tags = listOf("sci-fi")),
+            ),
         )
         val r = runBlocking { src.byGenre("   ") } as FictionResult.Success
         assertEquals(2, r.value.items.size)
@@ -80,15 +101,17 @@ class GitHubSourceTest {
 
     @Test fun `genres returns deduplicated lowercase union of tags`() {
         val src = source(
-            entry("github:o/a", title = "A", tags = listOf("Fantasy", "litrpg")),
-            entry("github:o/b", title = "B", tags = listOf("FANTASY", "Sci-Fi")),
+            entries = listOf(
+                entry("github:o/a", title = "A", tags = listOf("Fantasy", "litrpg")),
+                entry("github:o/b", title = "B", tags = listOf("FANTASY", "Sci-Fi")),
+            ),
         )
         val r = runBlocking { src.genres() } as FictionResult.Success
         assertEquals(listOf("fantasy", "litrpg", "sci-fi"), r.value)
     }
 
     @Test fun `page 2 short-circuits to empty hasNext-false page`() {
-        val src = source(entry("github:o/a", title = "A"))
+        val src = source(entries = listOf(entry("github:o/a", title = "A")))
         val r = runBlocking { src.popular(page = 2) } as FictionResult.Success
         assertTrue(r.value.items.isEmpty())
         assertEquals(2, r.value.page)
@@ -96,57 +119,220 @@ class GitHubSourceTest {
     }
 
     @Test fun `registry failure surfaces unchanged from popular`() {
-        val src = sourceWithFailure(FictionResult.NetworkError(message = "no internet"))
+        val src = source(failure = FictionResult.NetworkError(message = "no internet"))
         val r = runBlocking { src.popular() }
         assertTrue(r is FictionResult.NetworkError)
+    }
+
+    // ─── fictionDetail ─────────────────────────────────────────────────
+
+    @Test fun `fictionDetail builds from book toml + storyvox json + summary md`() {
+        val api = FakeGitHubApi(
+            repos = mapOf(
+                Pair("octocat", "hello-world") to ghRepo(
+                    owner = "octocat",
+                    name = "hello-world",
+                    desc = "ignored when book.toml has description",
+                    defaultBranch = "main",
+                    topics = listOf("topic-from-gh"),
+                ),
+            ),
+            files = mapOf(
+                Triple("octocat", "hello-world", "book.toml") to ghFile(
+                    """
+                        [book]
+                        title = "Hello World Saga"
+                        authors = ["octocat"]
+                        description = "From the manifest."
+                        language = "en"
+                        src = "src"
+                    """.trimIndent(),
+                ),
+                Triple("octocat", "hello-world", "storyvox.json") to ghFile(
+                    """
+                        {
+                          "version": 1,
+                          "cover": "assets/cover.png",
+                          "tags": ["fantasy", "litrpg"],
+                          "status": "completed"
+                        }
+                    """.trimIndent(),
+                ),
+                Triple("octocat", "hello-world", "src/SUMMARY.md") to ghFile(
+                    "- [Intro](src/01-intro.md)\n- [Two](src/02-two.md)",
+                ),
+            ),
+        )
+        val src = source(api = api)
+
+        val r = runBlocking { src.fictionDetail("github:octocat/hello-world") } as FictionResult.Success
+        val d = r.value
+
+        assertEquals("github:octocat/hello-world", d.summary.id)
+        assertEquals(SourceIds.GITHUB, d.summary.sourceId)
+        assertEquals("Hello World Saga", d.summary.title)
+        assertEquals("octocat", d.summary.author)
+        assertEquals("From the manifest.", d.summary.description)
+        assertEquals(
+            "https://raw.githubusercontent.com/octocat/hello-world/main/assets/cover.png",
+            d.summary.coverUrl,
+        )
+        assertEquals(listOf("fantasy", "litrpg"), d.summary.tags)
+        assertEquals(FictionStatus.COMPLETED, d.summary.status)
+        assertEquals(2, d.chapters.size)
+        assertEquals("github:octocat/hello-world:src/01-intro.md", d.chapters[0].id)
+        assertEquals("Intro", d.chapters[0].title)
+        assertEquals(0, d.chapters[0].index)
+        assertEquals("octocat", d.authorId)
+    }
+
+    @Test fun `fictionDetail falls back to repo description and topics when no manifest`() {
+        val api = FakeGitHubApi(
+            repos = mapOf(
+                Pair("o", "minimal") to ghRepo(
+                    owner = "o",
+                    name = "minimal",
+                    desc = "Repo description.",
+                    defaultBranch = "trunk",
+                    topics = listOf("fiction"),
+                ),
+            ),
+        )
+        val src = source(api = api)
+
+        val r = runBlocking { src.fictionDetail("github:o/minimal") } as FictionResult.Success
+        val d = r.value
+
+        assertEquals("Minimal", d.summary.title) // titlecase from repo name
+        assertEquals("o", d.summary.author) // owner login
+        assertEquals("Repo description.", d.summary.description)
+        assertEquals(listOf("fiction"), d.summary.tags)
+        assertEquals(FictionStatus.ONGOING, d.summary.status)
+        assertTrue(d.chapters.isEmpty())
+    }
+
+    @Test fun `fictionDetail uses bare-repo dir listing when no SUMMARY md`() {
+        val api = FakeGitHubApi(
+            repos = mapOf(Pair("o", "bare") to ghRepo("o", "bare")),
+            dirs = mapOf(
+                Triple("o", "bare", "chapters") to listOf(
+                    ghDirEntry("chapters/01-intro.md"),
+                    ghDirEntry("chapters/02-fall.md"),
+                    ghDirEntry("chapters/notes.md"), // not numbered, ignored
+                ),
+            ),
+        )
+        val src = source(api = api)
+
+        val r = runBlocking { src.fictionDetail("github:o/bare") } as FictionResult.Success
+        assertEquals(2, r.value.chapters.size)
+        assertEquals("chapters/01-intro.md", r.value.chapters[0].sourceChapterId)
+        assertEquals("Intro", r.value.chapters[0].title)
+    }
+
+    @Test fun `fictionDetail surfaces NotFound when repo missing`() {
+        val api = FakeGitHubApi() // empty maps → all calls return NotFound
+        val src = source(api = api)
+        val r = runBlocking { src.fictionDetail("github:ghost/missing") }
+        assertTrue("got $r", r is FictionResult.NotFound)
+    }
+
+    @Test fun `fictionDetail rejects non-github fictionId`() {
+        val src = source()
+        val r = runBlocking { src.fictionDetail("royalroad:12345") }
+        assertTrue("got $r", r is FictionResult.NotFound)
+    }
+
+    @Test fun `fictionDetail short-circuits on rate-limit during manifest fetch`() {
+        val api = FakeGitHubApi(
+            repos = mapOf(Pair("o", "r") to ghRepo("o", "r")),
+            // book.toml fetch returns RateLimited; should propagate.
+            rateLimitedFiles = setOf(Triple("o", "r", "book.toml")),
+        )
+        val src = source(api = api)
+        val r = runBlocking { src.fictionDetail("github:o/r") }
+        assertTrue("got $r", r is FictionResult.RateLimited)
+    }
+
+    @Test fun `fictionDetail honors archived repo as completed status`() {
+        val api = FakeGitHubApi(
+            repos = mapOf(Pair("o", "old") to ghRepo("o", "old", archived = true)),
+        )
+        val src = source(api = api)
+        val r = runBlocking { src.fictionDetail("github:o/old") } as FictionResult.Success
+        assertEquals(FictionStatus.COMPLETED, r.value.summary.status)
+    }
+
+    // ─── chapter ───────────────────────────────────────────────────────
+
+    @Test fun `chapter renders markdown into ChapterContent`() {
+        val md = "# Intro\n\nIt was a **dark** and stormy night."
+        val api = FakeGitHubApi(
+            files = mapOf(Triple("o", "r", "src/01-intro.md") to ghFile(md)),
+        )
+        val src = source(api = api)
+
+        val r = runBlocking { src.chapter("github:o/r", "github:o/r:src/01-intro.md") } as FictionResult.Success
+        val c = r.value
+
+        assertEquals("github:o/r:src/01-intro.md", c.info.id)
+        assertEquals("src/01-intro.md", c.info.sourceChapterId)
+        assertTrue(c.htmlBody.contains("<h1>Intro</h1>"))
+        assertTrue(c.htmlBody.contains("<strong>dark</strong>"))
+        // plainBody strips heading + markup (verified independently in
+        // MarkdownChapterRendererTest); just sanity check here.
+        assertTrue(c.plainBody.startsWith("It was a"))
+        assertNotNull("expected non-empty plain body", c.plainBody.takeIf { it.isNotEmpty() })
+    }
+
+    @Test fun `chapter rejects malformed chapter id`() {
+        val src = source()
+        // chapterId not prefixed with "<fictionId>:"
+        val r = runBlocking { src.chapter("github:o/r", "garbage-id") }
+        assertTrue("got $r", r is FictionResult.NotFound)
+    }
+
+    @Test fun `chapter surfaces 404 when file missing`() {
+        val src = source(api = FakeGitHubApi())
+        val r = runBlocking { src.chapter("github:o/r", "github:o/r:src/missing.md") }
+        assertTrue("got $r", r is FictionResult.NotFound)
     }
 
     // ─── Still-stubbed surfaces ────────────────────────────────────────
 
     @Test fun `search still throws NotImplementedError`() {
-        val src = source()
         assertThrows(NotImplementedError::class.java) {
             runBlocking {
-                src.search(`in`.jphe.storyvox.data.source.model.SearchQuery(term = "anything"))
+                source().search(`in`.jphe.storyvox.data.source.model.SearchQuery(term = "anything"))
             }
         }
     }
 
-    @Test fun `fictionDetail still throws NotImplementedError`() {
-        val src = source()
-        assertThrows(NotImplementedError::class.java) {
-            runBlocking { src.fictionDetail("github:o/r") }
-        }
-    }
-
-    @Test fun `chapter still throws NotImplementedError`() {
-        val src = source()
-        assertThrows(NotImplementedError::class.java) {
-            runBlocking { src.chapter("github:o/r", "github:o/r:src/01.md") }
-        }
-    }
-
     @Test fun `followsList and setFollowed still throw NotImplementedError`() {
-        val src = source()
-        assertThrows(NotImplementedError::class.java) { runBlocking { src.followsList() } }
+        assertThrows(NotImplementedError::class.java) { runBlocking { source().followsList() } }
         assertThrows(NotImplementedError::class.java) {
-            runBlocking { src.setFollowed("github:o/r", true) }
+            runBlocking { source().setFollowed("github:o/r", true) }
         }
     }
 
     // ─── Helpers ───────────────────────────────────────────────────────
 
-    private fun source(vararg entries: RegistryEntry): GitHubSource =
-        GitHubSource(
-            api = GitHubApi(OkHttpClient()),
-            registry = StaticRegistry(entries.toList()),
+    private fun source(
+        entries: List<RegistryEntry> = emptyList(),
+        failure: FictionResult.Failure? = null,
+        api: GitHubApi = FakeGitHubApi(),
+    ): GitHubSource {
+        val registry = if (failure != null) {
+            FailingRegistry(failure)
+        } else {
+            StaticRegistry(entries)
+        }
+        return GitHubSource(
+            api = api,
+            registry = registry,
+            markdownRenderer = MarkdownChapterRenderer(),
         )
-
-    private fun sourceWithFailure(failure: FictionResult.Failure): GitHubSource =
-        GitHubSource(
-            api = GitHubApi(OkHttpClient()),
-            registry = FailingRegistry(failure),
-        )
+    }
 
     private fun entry(
         id: String,
@@ -164,12 +350,45 @@ class GitHubSourceTest {
         tags = tags,
     )
 
-    /**
-     * Test double: returns a fixed list, no network. Subclasses
-     * [Registry] (which is `internal open` for exactly this reason)
-     * so the constructor still accepts an OkHttpClient even though
-     * we never use it.
-     */
+    private fun ghRepo(
+        owner: String,
+        name: String,
+        desc: String? = null,
+        defaultBranch: String = "main",
+        topics: List<String> = emptyList(),
+        archived: Boolean = false,
+        stars: Int = 0,
+    ) = GhRepo(
+        id = 0L,
+        name = name,
+        fullName = "$owner/$name",
+        description = desc,
+        defaultBranch = defaultBranch,
+        owner = GhOwner(login = owner),
+        htmlUrl = "https://github.com/$owner/$name",
+        topics = topics,
+        archived = archived,
+        stars = stars,
+    )
+
+    private fun ghFile(text: String): GhContent = GhContent(
+        name = "x",
+        path = "x",
+        sha = "0",
+        size = text.length.toLong(),
+        type = "file",
+        content = Base64.getEncoder().encodeToString(text.toByteArray(Charsets.UTF_8)),
+        encoding = "base64",
+    )
+
+    private fun ghDirEntry(path: String): GhContent = GhContent(
+        name = path.substringAfterLast('/'),
+        path = path,
+        sha = "0",
+        size = 0,
+        type = "file",
+    )
+
     private class StaticRegistry(
         private val entries: List<RegistryEntry>,
     ) : Registry(httpClient = OkHttpClient()) {
@@ -182,4 +401,46 @@ class GitHubSourceTest {
     ) : Registry(httpClient = OkHttpClient()) {
         override suspend fun entries(): FictionResult<List<RegistryEntry>> = failure
     }
+
+    /**
+     * Fake [GitHubApi] driven by lookup maps. Owner/repo/path fetches
+     * miss → NotFound. Rate-limited paths return [GitHubApiResult.RateLimited].
+     */
+    private class FakeGitHubApi(
+        private val repos: Map<Pair<String, String>, GhRepo> = emptyMap(),
+        private val files: Map<Triple<String, String, String>, GhContent> = emptyMap(),
+        private val dirs: Map<Triple<String, String, String>, List<GhContent>> = emptyMap(),
+        private val rateLimitedFiles: Set<Triple<String, String, String>> = emptySet(),
+    ) : GitHubApi(httpClient = OkHttpClient()) {
+
+        override suspend fun getRepo(owner: String, repo: String): GitHubApiResult<GhRepo> =
+            repos[owner to repo]
+                ?.let { GitHubApiResult.Success(it, etag = null) }
+                ?: GitHubApiResult.NotFound("repo not found")
+
+        override suspend fun getContent(
+            owner: String,
+            repo: String,
+            path: String,
+            ref: String?,
+        ): GitHubApiResult<GhContent> {
+            val key = Triple(owner, repo, path)
+            if (key in rateLimitedFiles) return GitHubApiResult.RateLimited(retryAfterSeconds = 60)
+            return files[key]
+                ?.let { GitHubApiResult.Success(it, etag = null) }
+                ?: GitHubApiResult.NotFound("file not found")
+        }
+
+        override suspend fun getContents(
+            owner: String,
+            repo: String,
+            path: String,
+            ref: String?,
+        ): GitHubApiResult<List<GhContent>> {
+            return dirs[Triple(owner, repo, path)]
+                ?.let { GitHubApiResult.Success(it, etag = null) }
+                ?: GitHubApiResult.NotFound("dir not found")
+        }
+    }
+
 }


### PR DESCRIPTION
## Summary

**Final integration step of the 3d trilogy** ([3d-manifest #60](https://github.com/jphein/storyvox/pull/60) + [3d-markdown #64](https://github.com/jphein/storyvox/pull/64) → this). Closes the GitHub-source skeleton from #52, registry browse from #58, and the manifest/markdown halves from #60+#64 into a single working source.

**`addByUrl(github URL)` now flows end-to-end**:
1. UrlRouter (#44) returns `(SourceIds.GITHUB, "github:owner/repo")`
2. `FictionRepository.addByUrl` (#44) looks up `sources[SourceIds.GITHUB]`
3. `GitHubSource.fictionDetail` fetches repo + manifest, returns `FictionDetail`
4. `upsertDetail` persists rows; `addByUrl` returns `Success(fictionId)`
5. UI navigates to fiction detail; tap a chapter
6. `ChapterDownloadWorker` (already multi-source-aware via #35) hits `GitHubSource.chapter`
7. Markdown decoded + rendered; `ChapterContent` upserted

## What lands

**Source layer**
- `GitHubSource.fictionDetail`: parses `fictionId → (owner, repo)`, fetches repo metadata via `getRepo`, then attempts `book.toml`, `storyvox.json`, `<srcDir>/SUMMARY.md` (best-effort — 404 means absent; anything else short-circuits with the right `FictionResult.Failure` variant). Falls through to `BareRepoFallback` via `getContents("chapters")` when no SUMMARY.md. Maps the merged `BookManifest` to `FictionDetail` — cover URL resolved against `raw.githubusercontent.com`, status inferred from `storyvox.json.status` then `repo.archived`, tags fall back to GitHub `topics`.
- `GitHubSource.chapter`: parses `chapterId = "<fictionId>:<path>"` per [spec line 141](docs/superpowers/specs/2026-05-06-github-source-design.md#L141). Fetches via `api.getContent`, base64-decodes, hands to `MarkdownChapterRenderer` for the dual-path (HTML + plaintext) rendering.

**Wiring**
- **`GitHubBindings`**: `@Binds @IntoMap @StringKey(SourceIds.GITHUB)` contributes `GitHubSource` into the multi-source map from #35. `:source-github` is now also a runtime `:app` dependency so the Hilt aggregation picks up the binding.
- **`AuthRepository`**: was guarded with `singleOrNull() ?: error(...)` because #35 explicitly deferred multi-source auth. With GitHub source binding, that guard fired at startup ⚠️ — caught during the on-device verification install. Fix: pin to `sources[SourceIds.ROYAL_ROAD]` explicitly, since Royal Road is the only source with a `SessionHydrator` wired today. GitHub auth lands in step 3f. The cookie store is already keyed `cookie:$sourceId` so 3f flips this to per-source without data migration.

**Test infrastructure**
- `GitHubApi`: `internal class` → `internal open class`, methods marked `open`, so tests can subclass with stub responses without going through real HTTP. Same pattern as `Registry` (3c) and `SleepTimer` (Zephyr's #31).
- `GhContent.decodedText()`: base64-decode helper using `Base64.getMimeDecoder()` — tolerates GitHub's RFC 2045 60-col line wrapping, which `getDecoder` rejects.
- `GitHubApi.getContents` (plural): directory listing variant for the bare-repo fallback path.

## Test plan

8 new `GitHubSourceTest` cases for the integration, **all green**:

- [x] `fictionDetail` builds from `book.toml` + `storyvox.json` + `SUMMARY.md`.
- [x] `fictionDetail` falls back to repo description + topics when no manifest.
- [x] `fictionDetail` uses bare-repo dir listing when no SUMMARY.md.
- [x] `fictionDetail` surfaces NotFound when repo missing.
- [x] `fictionDetail` rejects non-github fictionId.
- [x] `fictionDetail` short-circuits on rate-limit during manifest fetch.
- [x] `fictionDetail` honors archived repo as completed status.
- [x] `chapter` renders markdown (heading strip + emphasis preserved).
- [x] `chapter` rejects malformed chapter id.
- [x] `chapter` surfaces 404 when file missing.

Module total: **102 tests** (94 from prior PRs + 8 new). Pure-JVM, <1s.

- [x] `:source-github:testDebugUnitTest` — 102/102.
- [x] `:app:assembleDebug` clean — Hilt aggregation green; multibinding now contains both `royalroad` and `github` keys.
- [x] **Installed on R83W80CAFZB** (tablet lock claimed during install, released on completion). App boots cleanly with both sources bound. **Caught and fixed the `AuthRepository` startup-guard fire** during this install — that guard was load-bearing exactly for this transition.
- [ ] **JP-side end-to-end smoke test** (next install cycle): tap `+` FAB → paste `https://github.com/jphein/example-fiction` → verify `addByUrl` resolves, navigates to fiction detail; tap a chapter, verify it downloads + plays through the TTS path.

## What this unblocks

Per spec build sequence, **3d-trilogy is complete**. Remaining steps from the roadmap:
- Step 8: Browse → GitHub UI surface (search + filter sheet).
- Step 9: Sync — commit-SHA-based polling using `compareCommits` from #52.
- Step 3f: optional PAT auth (deferred indefinitely; spec says this can wait).

## Worktree + branch

- Worktree: `.claude/worktrees/selene-github-detail`
- Branch: `dream/selene/source-github-detail-chapter`