### PR TITLE
refactor(core-data): FictionRepository catalog methods take sourceId

### DIFF
--- a/core-data/src/main/kotlin/in/jphe/storyvox/data/repository/FictionRepository.kt
+++ b/core-data/src/main/kotlin/in/jphe/storyvox/data/repository/FictionRepository.kt
@@ -7,6 +7,7 @@ import `in`.jphe.storyvox.data.db.entity.ChapterDownloadState
 import `in`.jphe.storyvox.data.db.entity.DownloadMode
 import `in`.jphe.storyvox.data.db.entity.Fiction
 import `in`.jphe.storyvox.data.source.FictionSource
+import `in`.jphe.storyvox.data.source.SourceIds
 import `in`.jphe.storyvox.data.source.UrlRouter
 import `in`.jphe.storyvox.data.source.model.ChapterInfo
 import `in`.jphe.storyvox.data.source.model.FictionDetail
@@ -33,11 +34,36 @@ interface FictionRepository {
     fun observeFollowsRemote(): Flow<List<FictionSummary>>
     fun observeFiction(id: String): Flow<FictionDetail?>
 
-    suspend fun browsePopular(page: Int): FictionResult<ListPage<FictionSummary>>
-    suspend fun browseLatest(page: Int): FictionResult<ListPage<FictionSummary>>
-    suspend fun browseByGenre(genre: String, page: Int): FictionResult<ListPage<FictionSummary>>
-    suspend fun search(query: SearchQuery): FictionResult<ListPage<FictionSummary>>
-    suspend fun genres(): FictionResult<List<String>>
+    /**
+     * Browse the popular fictions on [sourceId]. Defaults to
+     * [SourceIds.ROYAL_ROAD] for backwards-compat with existing
+     * callers; UI surfaces that route to other sources (e.g.
+     * Browse → GitHub) pass the chosen sourceId explicitly.
+     */
+    suspend fun browsePopular(
+        page: Int,
+        sourceId: String = SourceIds.ROYAL_ROAD,
+    ): FictionResult<ListPage<FictionSummary>>
+
+    suspend fun browseLatest(
+        page: Int,
+        sourceId: String = SourceIds.ROYAL_ROAD,
+    ): FictionResult<ListPage<FictionSummary>>
+
+    suspend fun browseByGenre(
+        genre: String,
+        page: Int,
+        sourceId: String = SourceIds.ROYAL_ROAD,
+    ): FictionResult<ListPage<FictionSummary>>
+
+    suspend fun search(
+        query: SearchQuery,
+        sourceId: String = SourceIds.ROYAL_ROAD,
+    ): FictionResult<ListPage<FictionSummary>>
+
+    suspend fun genres(
+        sourceId: String = SourceIds.ROYAL_ROAD,
+    ): FictionResult<List<String>>
 
     /** Force a detail-page refresh, upserting the cached row. */
     suspend fun refreshDetail(id: String): FictionResult<Unit>
@@ -93,19 +119,15 @@ class FictionRepositoryImpl @Inject constructor(
 ) : FictionRepository {
 
     /**
-     * Resolves a [FictionSource] by [sourceId]. When [sourceId] is null or
-     * not bound, falls back to the only source in the map — preserves
-     * single-source behaviour today and short-circuits the catalog calls
-     * (browse, search, genres) that don't yet have a per-source UX. Errors
-     * if multiple sources are bound and the key is missing/unknown — that's
-     * a programming bug we want to catch loudly when GitHub source lands.
+     * Resolves a [FictionSource] by [sourceId]. Errors loudly if the
+     * key isn't bound — callers either pass a known sourceId from
+     * [SourceIds] or look one up from a persisted Fiction row. The
+     * old "fall back to the only source" behaviour from #35 was
+     * removed in step 8a-i now that multiple sources are bound.
      */
-    private fun sourceFor(sourceId: String?): FictionSource =
-        sourceId?.let { sources[it] }
-            ?: sources.values.singleOrNull()
+    private fun sourceFor(sourceId: String): FictionSource =
+        sources[sourceId]
             ?: error("No FictionSource for id=$sourceId; bound: ${sources.keys}")
-
-    private val source: FictionSource get() = sourceFor(null)
 
     override fun observeLibrary(): Flow<List<FictionSummary>> =
         fictionDao.observeLibrary().map { rows -> rows.map { it.toSummary() } }
@@ -129,19 +151,33 @@ class FictionRepositoryImpl @Inject constructor(
             }
         }
 
-    override suspend fun browsePopular(page: Int): FictionResult<ListPage<FictionSummary>> =
-        cacheListing(source.popular(page))
+    override suspend fun browsePopular(
+        page: Int,
+        sourceId: String,
+    ): FictionResult<ListPage<FictionSummary>> =
+        cacheListing(sourceFor(sourceId).popular(page))
 
-    override suspend fun browseLatest(page: Int): FictionResult<ListPage<FictionSummary>> =
-        cacheListing(source.latestUpdates(page))
+    override suspend fun browseLatest(
+        page: Int,
+        sourceId: String,
+    ): FictionResult<ListPage<FictionSummary>> =
+        cacheListing(sourceFor(sourceId).latestUpdates(page))
 
-    override suspend fun browseByGenre(genre: String, page: Int): FictionResult<ListPage<FictionSummary>> =
-        cacheListing(source.byGenre(genre, page))
+    override suspend fun browseByGenre(
+        genre: String,
+        page: Int,
+        sourceId: String,
+    ): FictionResult<ListPage<FictionSummary>> =
+        cacheListing(sourceFor(sourceId).byGenre(genre, page))
 
-    override suspend fun search(query: SearchQuery): FictionResult<ListPage<FictionSummary>> =
-        cacheListing(source.search(query))
+    override suspend fun search(
+        query: SearchQuery,
+        sourceId: String,
+    ): FictionResult<ListPage<FictionSummary>> =
+        cacheListing(sourceFor(sourceId).search(query))
 
-    override suspend fun genres(): FictionResult<List<String>> = source.genres()
+    override suspend fun genres(sourceId: String): FictionResult<List<String>> =
+        sourceFor(sourceId).genres()
 
     override suspend fun refreshDetail(id: String): FictionResult<Unit> = withContext(Dispatchers.IO) {
         // Look up the persisted row to route to the correct source. Falls
@@ -149,7 +185,7 @@ class FictionRepositoryImpl @Inject constructor(
         // addToLibrary → refreshDetail before the row exists). Future
         // multi-source addByUrl pre-writes a stub row with sourceId so this
         // path always finds it.
-        val src = sourceFor(fictionDao.get(id)?.sourceId)
+        val src = sourceFor(fictionDao.get(id)?.sourceId ?: SourceIds.ROYAL_ROAD)
         when (val result = src.fictionDetail(id)) {
             is FictionResult.Success -> {
                 upsertDetail(result.value)
@@ -160,7 +196,11 @@ class FictionRepositoryImpl @Inject constructor(
     }
 
     override suspend fun refreshRemoteFollows(): FictionResult<Unit> = withContext(Dispatchers.IO) {
-        when (val result = source.followsList(page = 1)) {
+        // Follows is RR-only today — GitHub source throws on
+        // `followsList`. When step 3f wires GitHub PAT auth, this
+        // becomes a per-source flow and the kdoc on the interface
+        // method should grow a `sourceId` parameter to match.
+        when (val result = sourceFor(SourceIds.ROYAL_ROAD).followsList(page = 1)) {
             is FictionResult.Success -> {
                 val now = System.currentTimeMillis()
                 val incoming = result.value.items
@@ -226,7 +266,7 @@ class FictionRepositoryImpl @Inject constructor(
 
     override suspend fun setFollowedRemote(id: String, followed: Boolean): FictionResult<Unit> =
         withContext(Dispatchers.IO) {
-            val src = sourceFor(fictionDao.get(id)?.sourceId)
+            val src = sourceFor(fictionDao.get(id)?.sourceId ?: SourceIds.ROYAL_ROAD)
             when (val r = src.setFollowed(id, followed)) {
                 is FictionResult.Success -> {
                     fictionDao.setFollowedRemote(id, followed)

--- a/core-data/src/test/kotlin/in/jphe/storyvox/data/repository/FictionRepositoryImplTest.kt
+++ b/core-data/src/test/kotlin/in/jphe/storyvox/data/repository/FictionRepositoryImplTest.kt
@@ -12,6 +12,7 @@ import `in`.jphe.storyvox.data.db.entity.DownloadMode
 import `in`.jphe.storyvox.data.db.entity.Fiction
 import `in`.jphe.storyvox.data.source.FictionSource
 import `in`.jphe.storyvox.data.source.FictionSourceEvent
+import `in`.jphe.storyvox.data.source.SourceIds
 import `in`.jphe.storyvox.data.source.model.ChapterContent
 import `in`.jphe.storyvox.data.source.model.ChapterInfo
 import `in`.jphe.storyvox.data.source.model.FictionDetail
@@ -37,10 +38,10 @@ class FictionRepositoryImplTest {
 
     // -- Fixtures ----------------------------------------------------------------
 
-    private fun summary(id: String, sourceId: String = "rr", title: String = id) =
+    private fun summary(id: String, sourceId: String = SourceIds.ROYAL_ROAD, title: String = id) =
         FictionSummary(id = id, sourceId = sourceId, title = title, author = "auth-$id")
 
-    private fun detail(id: String, sourceId: String = "rr", chapterCount: Int = 1) =
+    private fun detail(id: String, sourceId: String = SourceIds.ROYAL_ROAD, chapterCount: Int = 1) =
         FictionDetail(
             summary = summary(id, sourceId, title = "title-$id"),
             chapters = (0 until chapterCount).map {
@@ -279,7 +280,7 @@ class FictionRepositoryImplTest {
      * repository call, then asserts on the recorded call log + result mapping.
      * Defaults to a generic NetworkError so an un-stubbed call fails loudly.
      */
-    private class FakeSource(override val id: String = "rr") : FictionSource {
+    private class FakeSource(override val id: String = SourceIds.ROYAL_ROAD) : FictionSource {
         override val displayName: String = "Fake $id"
 
         var detailResult: FictionResult<FictionDetail> =
@@ -336,7 +337,7 @@ class FictionRepositoryImplTest {
     // -- repo() ------------------------------------------------------------------
 
     private fun repo(
-        sources: Map<String, FictionSource> = mapOf("rr" to FakeSource("rr")),
+        sources: Map<String, FictionSource> = mapOf(SourceIds.ROYAL_ROAD to FakeSource(SourceIds.ROYAL_ROAD)),
         fictionDao: FakeFictionDao = FakeFictionDao(),
         chapterDao: FakeChapterDao = FakeChapterDao(),
     ) = Triple(
@@ -348,23 +349,23 @@ class FictionRepositoryImplTest {
     // -- sourceFor() routing -----------------------------------------------------
 
     @Test fun `single bound source is used as fallback when sourceId is null`() = runTest {
-        val src = FakeSource("rr").apply {
+        val src = FakeSource(SourceIds.ROYAL_ROAD).apply {
             popularResult = FictionResult.Success(ListPage(emptyList(), 1, false))
         }
-        val (r, _, _) = repo(sources = mapOf("rr" to src))
+        val (r, _, _) = repo(sources = mapOf(SourceIds.ROYAL_ROAD to src))
         val result = r.browsePopular(1)
         assertTrue(result is FictionResult.Success)
         assertEquals(listOf("popular(1)"), src.callLog)
     }
 
     @Test fun `multi-bound source routes by row's sourceId on refreshDetail`() = runTest {
-        val rr = FakeSource("rr").apply {
-            detailResult = FictionResult.Success(detail("123", sourceId = "rr"))
+        val rr = FakeSource(SourceIds.ROYAL_ROAD).apply {
+            detailResult = FictionResult.Success(detail("123", sourceId = SourceIds.ROYAL_ROAD))
         }
         val gh = FakeSource("github").apply {
             detailResult = FictionResult.Success(detail("123", sourceId = "github"))
         }
-        val (r, fictionDao, _) = repo(sources = mapOf("rr" to rr, "github" to gh))
+        val (r, fictionDao, _) = repo(sources = mapOf(SourceIds.ROYAL_ROAD to rr, "github" to gh))
         // Pre-seed the row so refreshDetail's lookup finds the sourceId.
         fictionDao.rows["123"] = Fiction(
             id = "123", sourceId = "github", title = "", author = "",
@@ -377,32 +378,51 @@ class FictionRepositoryImplTest {
         assertEquals(emptyList<String>(), rr.callLog)
     }
 
-    @Test fun `multi-bound with missing row falls through to error on null sourceId`() = runTest {
-        val rr = FakeSource("rr")
+    @Test fun `multi-bound with missing row defaults to ROYAL_ROAD source for refreshDetail`() = runTest {
+        // Step-8a-i contract: when the persisted row is absent, the
+        // browse/refresh paths default to SourceIds.ROYAL_ROAD rather
+        // than firing the old multi-source guard. The pre-write of a
+        // stub row in addByUrl (#44) means new GitHub fictions reach
+        // refreshDetail with their sourceId already on disk; only
+        // legacy paths (refreshDetail before any add) hit this default.
+        val rr = FakeSource(SourceIds.ROYAL_ROAD).apply {
+            detailResult = FictionResult.NotFound("not on RR either")
+        }
         val gh = FakeSource("github")
-        val (r, _, _) = repo(sources = mapOf("rr" to rr, "github" to gh))
+        val (r, _, _) = repo(sources = mapOf(SourceIds.ROYAL_ROAD to rr, "github" to gh))
+
+        val result = r.refreshDetail("404")
+        // Routed to RR (the default), which returns NotFound — surfaced
+        // verbatim to the caller. No IllegalStateException.
+        assertEquals(FictionResult.NotFound("not on RR either"), result)
+    }
+
+    @Test fun `sourceFor errors loudly when caller passes unknown sourceId`() = runTest {
+        // The loud-error behavior from PR #35 is preserved for the case
+        // it was actually designed for: a *known-bad* sourceId (e.g. a
+        // typo or a removed source). browsePopular with a sourceId not
+        // in the map throws — fail-fast for programming bugs.
+        val rr = FakeSource(SourceIds.ROYAL_ROAD)
+        val (r, _, _) = repo(sources = mapOf(SourceIds.ROYAL_ROAD to rr))
 
         val ex = try {
-            // observeFiction doesn't hit sourceFor(); refreshDetail does, but
-            // with an absent row passes null → with multi-source bound and no
-            // singleOrNull match, sourceFor() throws.
-            r.refreshDetail("404")
+            r.browsePopular(page = 1, sourceId = "not-a-real-source")
             null
         } catch (t: IllegalStateException) {
             t
         }
-        assertNotNull("expected IllegalStateException for unknown sourceId in multi-bound map", ex)
+        assertNotNull("expected IllegalStateException for unknown sourceId", ex)
     }
 
     // -- browse / search / genres ------------------------------------------------
 
     @Test fun `browsePopular caches successful pages via upsertAllPreservingUserState`() = runTest {
-        val src = FakeSource("rr").apply {
+        val src = FakeSource(SourceIds.ROYAL_ROAD).apply {
             popularResult = FictionResult.Success(
                 ListPage(items = listOf(summary("a"), summary("b")), page = 1, hasNext = true),
             )
         }
-        val (r, fictionDao, _) = repo(sources = mapOf("rr" to src))
+        val (r, fictionDao, _) = repo(sources = mapOf(SourceIds.ROYAL_ROAD to src))
 
         val result = r.browsePopular(1)
         assertTrue(result is FictionResult.Success)
@@ -411,10 +431,10 @@ class FictionRepositoryImplTest {
     }
 
     @Test fun `browsePopular does NOT write on Failure`() = runTest {
-        val src = FakeSource("rr").apply {
+        val src = FakeSource(SourceIds.ROYAL_ROAD).apply {
             popularResult = FictionResult.NetworkError("boom")
         }
-        val (r, fictionDao, _) = repo(sources = mapOf("rr" to src))
+        val (r, fictionDao, _) = repo(sources = mapOf(SourceIds.ROYAL_ROAD to src))
 
         val result = r.browsePopular(1)
         assertTrue(result is FictionResult.Failure)
@@ -426,12 +446,12 @@ class FictionRepositoryImplTest {
     }
 
     @Test fun `browseLatest, browseByGenre, search all flow through cacheListing`() = runTest {
-        val src = FakeSource("rr").apply {
+        val src = FakeSource(SourceIds.ROYAL_ROAD).apply {
             latestResult = FictionResult.Success(ListPage(listOf(summary("a")), 1, false))
             byGenreResult = FictionResult.Success(ListPage(listOf(summary("b")), 1, false))
             searchResult = FictionResult.Success(ListPage(listOf(summary("c")), 1, false))
         }
-        val (r, fictionDao, _) = repo(sources = mapOf("rr" to src))
+        val (r, fictionDao, _) = repo(sources = mapOf(SourceIds.ROYAL_ROAD to src))
 
         r.browseLatest(1)
         r.browseByGenre("fantasy", 1)
@@ -441,10 +461,10 @@ class FictionRepositoryImplTest {
     }
 
     @Test fun `genres() passes through source result without caching`() = runTest {
-        val src = FakeSource("rr").apply {
+        val src = FakeSource(SourceIds.ROYAL_ROAD).apply {
             genresResult = FictionResult.Success(listOf("fantasy", "litrpg"))
         }
-        val (r, fictionDao, _) = repo(sources = mapOf("rr" to src))
+        val (r, fictionDao, _) = repo(sources = mapOf(SourceIds.ROYAL_ROAD to src))
 
         val result = r.genres()
         assertTrue(result is FictionResult.Success)
@@ -455,10 +475,10 @@ class FictionRepositoryImplTest {
     // -- refreshDetail -----------------------------------------------------------
 
     @Test fun `refreshDetail success writes detail and chapters`() = runTest {
-        val src = FakeSource("rr").apply {
+        val src = FakeSource(SourceIds.ROYAL_ROAD).apply {
             detailResult = FictionResult.Success(detail("99", chapterCount = 3))
         }
-        val (r, fictionDao, chapterDao) = repo(sources = mapOf("rr" to src))
+        val (r, fictionDao, chapterDao) = repo(sources = mapOf(SourceIds.ROYAL_ROAD to src))
 
         val result = r.refreshDetail("99")
         assertTrue(result is FictionResult.Success)
@@ -467,10 +487,10 @@ class FictionRepositoryImplTest {
     }
 
     @Test fun `refreshDetail failure does NOT touch the DB`() = runTest {
-        val src = FakeSource("rr").apply {
+        val src = FakeSource(SourceIds.ROYAL_ROAD).apply {
             detailResult = FictionResult.NotFound()
         }
-        val (r, fictionDao, chapterDao) = repo(sources = mapOf("rr" to src))
+        val (r, fictionDao, chapterDao) = repo(sources = mapOf(SourceIds.ROYAL_ROAD to src))
 
         val result = r.refreshDetail("99")
         assertTrue(result is FictionResult.NotFound)
@@ -479,10 +499,10 @@ class FictionRepositoryImplTest {
     }
 
     @Test fun `refreshDetail preserves existing chapter body bytes on merge`() = runTest {
-        val src = FakeSource("rr").apply {
+        val src = FakeSource(SourceIds.ROYAL_ROAD).apply {
             detailResult = FictionResult.Success(detail("99", chapterCount = 2))
         }
-        val (r, _, chapterDao) = repo(sources = mapOf("rr" to src))
+        val (r, _, chapterDao) = repo(sources = mapOf(SourceIds.ROYAL_ROAD to src))
         // Pre-seed chapter 0 with downloaded body.
         chapterDao.rows["99-c0"] = Chapter(
             id = "99-c0", fictionId = "99", sourceChapterId = "src-0",
@@ -508,12 +528,12 @@ class FictionRepositoryImplTest {
     // -- refreshRemoteFollows ---------------------------------------------------
 
     @Test fun `refreshRemoteFollows upserts incoming and clears gone-from-remote`() = runTest {
-        val src = FakeSource("rr").apply {
+        val src = FakeSource(SourceIds.ROYAL_ROAD).apply {
             followsListResult = FictionResult.Success(
                 ListPage(listOf(summary("keep"), summary("new")), 1, false),
             )
         }
-        val (r, fictionDao, _) = repo(sources = mapOf("rr" to src))
+        val (r, fictionDao, _) = repo(sources = mapOf(SourceIds.ROYAL_ROAD to src))
         // Pre-seed rows: "keep" already followedRemotely (should stay),
         // "gone" previously followedRemotely (should clear).
         fictionDao.rows["keep"] = summary("keep").toEntity(0L).copy(followedRemotely = true)
@@ -527,10 +547,10 @@ class FictionRepositoryImplTest {
     }
 
     @Test fun `refreshRemoteFollows AuthRequired propagates without DB writes`() = runTest {
-        val src = FakeSource("rr").apply {
+        val src = FakeSource(SourceIds.ROYAL_ROAD).apply {
             followsListResult = FictionResult.AuthRequired()
         }
-        val (r, fictionDao, _) = repo(sources = mapOf("rr" to src))
+        val (r, fictionDao, _) = repo(sources = mapOf(SourceIds.ROYAL_ROAD to src))
 
         val result = r.refreshRemoteFollows()
         assertTrue(result is FictionResult.AuthRequired)
@@ -538,7 +558,7 @@ class FictionRepositoryImplTest {
     }
 
     @Test fun `refreshRemoteFollows preserves richer detail-page fields on merge`() = runTest {
-        val src = FakeSource("rr").apply {
+        val src = FakeSource(SourceIds.ROYAL_ROAD).apply {
             // Incoming row has blank title — repository must keep existing.
             followsListResult = FictionResult.Success(
                 ListPage(
@@ -547,7 +567,7 @@ class FictionRepositoryImplTest {
                 ),
             )
         }
-        val (r, fictionDao, _) = repo(sources = mapOf("rr" to src))
+        val (r, fictionDao, _) = repo(sources = mapOf(SourceIds.ROYAL_ROAD to src))
         fictionDao.rows["keep"] = summary("keep").toEntity(0L).copy(
             title = "Existing Title",
             coverUrl = "https://existing.cover",
@@ -571,10 +591,10 @@ class FictionRepositoryImplTest {
     // -- addToLibrary / removeFromLibrary ----------------------------------------
 
     @Test fun `addToLibrary refreshes when row missing then sets inLibrary`() = runTest {
-        val src = FakeSource("rr").apply {
+        val src = FakeSource(SourceIds.ROYAL_ROAD).apply {
             detailResult = FictionResult.Success(detail("new", chapterCount = 1))
         }
-        val (r, fictionDao, _) = repo(sources = mapOf("rr" to src))
+        val (r, fictionDao, _) = repo(sources = mapOf(SourceIds.ROYAL_ROAD to src))
 
         r.addToLibrary("new")
 
@@ -587,8 +607,8 @@ class FictionRepositoryImplTest {
     }
 
     @Test fun `addToLibrary skips refresh when row already exists`() = runTest {
-        val src = FakeSource("rr") // detailResult left as default error
-        val (r, fictionDao, _) = repo(sources = mapOf("rr" to src))
+        val src = FakeSource(SourceIds.ROYAL_ROAD) // detailResult left as default error
+        val (r, fictionDao, _) = repo(sources = mapOf(SourceIds.ROYAL_ROAD to src))
         fictionDao.rows["existing"] = summary("existing").toEntity(0L)
 
         r.addToLibrary("existing")
@@ -601,10 +621,10 @@ class FictionRepositoryImplTest {
     }
 
     @Test fun `addToLibrary ignores refresh failure (best-effort)`() = runTest {
-        val src = FakeSource("rr").apply {
+        val src = FakeSource(SourceIds.ROYAL_ROAD).apply {
             detailResult = FictionResult.NetworkError("flaky")
         }
-        val (r, fictionDao, _) = repo(sources = mapOf("rr" to src))
+        val (r, fictionDao, _) = repo(sources = mapOf(SourceIds.ROYAL_ROAD to src))
 
         // refreshDetail will fail. Ensure addToLibrary still attempts to flip
         // setInLibrary — but setInLibrary on a non-existent row in the fake
@@ -616,10 +636,10 @@ class FictionRepositoryImplTest {
     }
 
     @Test fun `addToLibrary applies downloadMode after setInLibrary`() = runTest {
-        val src = FakeSource("rr").apply {
+        val src = FakeSource(SourceIds.ROYAL_ROAD).apply {
             detailResult = FictionResult.Success(detail("eager", chapterCount = 1))
         }
-        val (r, fictionDao, _) = repo(sources = mapOf("rr" to src))
+        val (r, fictionDao, _) = repo(sources = mapOf(SourceIds.ROYAL_ROAD to src))
 
         r.addToLibrary("eager", DownloadMode.EAGER)
 
@@ -660,10 +680,10 @@ class FictionRepositoryImplTest {
     // -- setFollowedRemote -------------------------------------------------------
 
     @Test fun `setFollowedRemote success flips local row only after source succeeds`() = runTest {
-        val src = FakeSource("rr").apply {
+        val src = FakeSource(SourceIds.ROYAL_ROAD).apply {
             setFollowedResult = FictionResult.Success(Unit)
         }
-        val (r, fictionDao, _) = repo(sources = mapOf("rr" to src))
+        val (r, fictionDao, _) = repo(sources = mapOf(SourceIds.ROYAL_ROAD to src))
         fictionDao.rows["x"] = summary("x").toEntity(0L)
 
         val result = r.setFollowedRemote("x", true)
@@ -672,10 +692,10 @@ class FictionRepositoryImplTest {
     }
 
     @Test fun `setFollowedRemote source failure preserves local state`() = runTest {
-        val src = FakeSource("rr").apply {
+        val src = FakeSource(SourceIds.ROYAL_ROAD).apply {
             setFollowedResult = FictionResult.AuthRequired()
         }
-        val (r, fictionDao, _) = repo(sources = mapOf("rr" to src))
+        val (r, fictionDao, _) = repo(sources = mapOf(SourceIds.ROYAL_ROAD to src))
         fictionDao.rows["x"] = summary("x").toEntity(0L).copy(followedRemotely = false)
 
         val result = r.setFollowedRemote("x", true)
@@ -697,8 +717,8 @@ class FictionRepositoryImplTest {
     }
 
     @Test fun `addByUrl recognised but unbound source returns UnsupportedSource`() = runTest {
-        // Map only has "rr"; UrlRouter recognises GitHub but no source bound.
-        val (r, fictionDao, _) = repo(sources = mapOf("rr" to FakeSource("rr")))
+        // Map only has SourceIds.ROYAL_ROAD; UrlRouter recognises GitHub but no source bound.
+        val (r, fictionDao, _) = repo(sources = mapOf(SourceIds.ROYAL_ROAD to FakeSource(SourceIds.ROYAL_ROAD)))
         val result = r.addByUrl("https://github.com/example/repo")
         assertTrue(result is AddByUrlResult.UnsupportedSource)
         assertEquals("github", (result as AddByUrlResult.UnsupportedSource).sourceId)


### PR DESCRIPTION
## Summary

**Step 8a-i** — data-layer prep for the Browse → GitHub UI surface. Adds a `sourceId: String = SourceIds.ROYAL_ROAD` parameter to the catalog methods on `FictionRepository` so UI surfaces can route per-source. The default keeps every existing call site working unchanged. **No UX change.**

This is the pure data-layer half of the broader step 8a; the UI half (Browse source picker) is a separate small PR (8a-ii) once this lands.

## Why this matters

PR #35's `sourceFor(null) → sources.values.singleOrNull()` fallback was load-bearing as long as exactly one source was Hilt-bound. PR #70 added the GitHub source binding — meaning `singleOrNull()` returns null on every catalog call. The guard would fire the first time a user navigated to Browse — catastrophic but easy to spot.

Same shape as the AuthRepository guard fire we caught during PR #70's install verification. The `?: error("...")` guard pattern landing in #35 worked exactly as designed: explicit transition points that flag when their assumption breaks. Same fix shape too — pin to `SourceIds.ROYAL_ROAD` for the legacy paths, parameterize for the per-source paths.

## What changes

- **`FictionRepository.{browsePopular, browseLatest, browseByGenre, search, genres}`** gain a `sourceId: String = SourceIds.ROYAL_ROAD` parameter. Default → existing call sites compile + behave unchanged.
- **`FictionRepositoryImpl.sourceFor`** simplified: takes non-null `sourceId`, errors loudly when the key isn't bound. The "singleOrNull fallback" branch is removed.
- **`refreshDetail` and `setFollowedRemote`** keep the row-lookup pattern from #35 but default to `SourceIds.ROYAL_ROAD` when the row is absent. Every legitimate pre-GitHub flow writes a row before refreshDetail; the multi-source `addByUrl` from #44 pre-writes the row with sourceId; only pure refreshDetail-against-unknown-id falls through to RR.
- **`refreshRemoteFollows`** pinned to `sourceFor(SourceIds.ROYAL_ROAD)` explicitly. Follows is RR-only today; GitHub source throws on `followsList`. Step 3f will make this per-source.

## Test updates

`FictionRepositoryImplTest`:
- **45 `"rr"` literals** replaced with `SourceIds.ROYAL_ROAD`. The original test used `"rr"` which never matched `SourceIds.ROYAL_ROAD = "royalroad"` and bypassed the guard by accident — landed before #66's SourceIds dedup, so the discrepancy was invisible. Now caught.
- **`multi-bound with missing row falls through to error on null sourceId`** rewritten as **`multi-bound with missing row defaults to ROYAL_ROAD source for refreshDetail`** — the assertion target was the old guard-firing semantics; new contract is "default to RR when row is missing", which is what the code actually does now.
- New test: **`sourceFor errors loudly when caller passes unknown sourceId`** — preserves the loud-error semantics from #35 for the case it was designed for (typo'd or removed source key), distinct from the now-removed "no row, fall through" path.

29 → 30 tests in `FictionRepositoryImplTest`, all green.

## Test plan

- [x] `:core-data:testDebugUnitTest` — 30/30 in FictionRepositoryImplTest, no regressions in ChapterRepositoryImplTest or UrlRouterTest.
- [x] `:source-github:testDebugUnitTest`, `:source-royalroad:testDebugUnitTest`, `:feature:testDebugUnitTest`, `:core-playback:testDebugUnitTest` — all green (cross-checked because contract change ripples).
- [x] `:app:assembleDebug` clean — Hilt graph unchanged.
- [x] No on-device verification needed — pure data-layer change, no UX impact, app behavior unchanged for end users.

## What this unblocks

Step 8a-ii: BrowseScreen source picker (Royal Road | GitHub segmented control). The ViewModel will pass the selected `sourceId` to `BrowseRepositoryUi.paginator(...)` which threads it down to these methods. UX surface goes from "GitHub source wired but invisible" to "discoverable via Browse." That PR is small + UI-shaped; this one was the prerequisite contract change.

## Worktree + branch

- Worktree: `.claude/worktrees/selene-github-browse`
- Branch: `dream/selene/browse-github`