### PR TITLE
feat(browse): source picker UI for Royal Road | GitHub

### DIFF
--- a/app/src/main/kotlin/in/jphe/storyvox/di/AppBindings.kt
+++ b/app/src/main/kotlin/in/jphe/storyvox/di/AppBindings.kt
@@ -235,17 +235,18 @@ private fun relativeTime(epochMs: Long?): String {
 private class RealBrowseRepositoryUi(
     private val repo: FictionRepository,
 ) : BrowseRepositoryUi {
-    override fun paginator(source: BrowseSource): BrowsePaginator =
+    override fun paginator(source: BrowseSource, sourceId: String): BrowsePaginator =
         RealBrowsePaginator { page ->
             when (source) {
-                BrowseSource.Popular -> repo.browsePopular(page = page)
-                BrowseSource.NewReleases -> repo.browseLatest(page = page)
+                BrowseSource.Popular -> repo.browsePopular(page = page, sourceId = sourceId)
+                BrowseSource.NewReleases -> repo.browseLatest(page = page, sourceId = sourceId)
                 BrowseSource.BestRated -> repo.search(
                     SearchQuery(
                         orderBy = SearchOrder.RATING,
                         direction = SortDirection.DESC,
                         page = page,
                     ),
+                    sourceId = sourceId,
                 )
                 is BrowseSource.Search -> repo.search(
                     SearchQuery(
@@ -253,9 +254,11 @@ private class RealBrowseRepositoryUi(
                         orderBy = SearchOrder.RELEVANCE,
                         page = page,
                     ),
+                    sourceId = sourceId,
                 )
                 is BrowseSource.Filtered -> repo.search(
                     source.filter.toSearchQuery().copy(page = page),
+                    sourceId = sourceId,
                 )
             }
         }

--- a/feature/src/main/kotlin/in/jphe/storyvox/feature/api/UiContracts.kt
+++ b/feature/src/main/kotlin/in/jphe/storyvox/feature/api/UiContracts.kt
@@ -86,10 +86,20 @@ interface FictionRepositoryUi {
 }
 
 interface BrowseRepositoryUi {
-    /** Build a paginator for the given browse source. Callers consume
-     *  `items` / `isLoading` / `isAppending` / `hasMore` as Flows and call
-     *  `loadNext()` on initial composition + on near-end scroll. */
-    fun paginator(source: BrowseSource): BrowsePaginator
+    /**
+     * Build a paginator for the given browse [source] against the
+     * named [sourceId]. Callers consume `items` / `isLoading` /
+     * `isAppending` / `hasMore` as Flows and call `loadNext()` on
+     * initial composition + on near-end scroll.
+     *
+     * [sourceId] defaults to `royalroad` for backward compatibility
+     * with existing call sites; the BrowseScreen source-picker UI
+     * passes `github` when the user has chosen the GitHub tab.
+     */
+    fun paginator(
+        source: BrowseSource,
+        sourceId: String = `in`.jphe.storyvox.data.source.SourceIds.ROYAL_ROAD,
+    ): BrowsePaginator
 }
 
 /** What kind of listing the paginator should fetch. The repository

--- a/feature/src/main/kotlin/in/jphe/storyvox/feature/browse/BrowseScreen.kt
+++ b/feature/src/main/kotlin/in/jphe/storyvox/feature/browse/BrowseScreen.kt
@@ -28,7 +28,11 @@ import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.SecondaryTabRow
+import androidx.compose.material3.SegmentedButton
+import androidx.compose.material3.SegmentedButtonDefaults
+import androidx.compose.material3.SingleChoiceSegmentedButtonRow
 import androidx.compose.material3.Tab
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
@@ -66,15 +70,25 @@ fun BrowseScreen(
     var showFilterSheet by remember { mutableStateOf(false) }
 
     Column(modifier = Modifier.fillMaxSize().padding(top = spacing.md)) {
+        // Top-level source picker. Switches the multibinding lookup in
+        // FictionRepository between Royal Road and GitHub. Tabs and the
+        // filter sheet rebind to whatever the chosen source supports.
+        BrowseSourcePicker(
+            selected = state.sourceKey,
+            onSelect = viewModel::selectSource,
+            modifier = Modifier.fillMaxWidth().padding(horizontal = spacing.md),
+        )
+
+        val supportedTabs = remember(state.sourceKey) { state.sourceKey.supportedTabs() }
         Row(
             modifier = Modifier.fillMaxWidth(),
             verticalAlignment = Alignment.CenterVertically,
         ) {
             SecondaryTabRow(
-                selectedTabIndex = state.tab.ordinal,
+                selectedTabIndex = supportedTabs.indexOf(state.tab).coerceAtLeast(0),
                 modifier = Modifier.weight(1f),
             ) {
-                BrowseTab.entries.forEach { tab ->
+                supportedTabs.forEach { tab ->
                     Tab(
                         selected = tab == state.tab,
                         onClick = { viewModel.selectTab(tab) },
@@ -82,13 +96,18 @@ fun BrowseScreen(
                     )
                 }
             }
-            FilterButton(
-                activeCount = state.filter.activeCount(),
-                onClick = { showFilterSheet = true },
-            )
+            // Filter sheet is RR-shaped (its dimensions don't yet
+            // translate to GitHub registry entries) so hide on GitHub.
+            // Step 8b will introduce a GitHub-shaped filter sheet.
+            if (state.sourceKey == BrowseSourceKey.RoyalRoad) {
+                FilterButton(
+                    activeCount = state.filter.activeCount(),
+                    onClick = { showFilterSheet = true },
+                )
+            }
         }
 
-        if (state.tab == BrowseTab.Search) {
+        if (state.tab == BrowseTab.Search && state.sourceKey == BrowseSourceKey.RoyalRoad) {
             OutlinedTextField(
                 value = state.query,
                 onValueChange = viewModel::setQuery,
@@ -119,7 +138,7 @@ fun BrowseScreen(
                 // hands us a fresh items list anyway; we just nudge the
                 // viewport back to the start so the user doesn't land
                 // mid-scroll into a different listing.
-                LaunchedEffect(state.tab, state.query, state.filter) {
+                LaunchedEffect(state.sourceKey, state.tab, state.query, state.filter) {
                     if (gridState.firstVisibleItemIndex != 0) {
                         gridState.scrollToItem(0)
                     }
@@ -311,6 +330,41 @@ private val BrowseTab.label: String
         BrowseTab.BestRated -> "Best Rated"
         BrowseTab.Search -> "Search"
     }
+
+/**
+ * Two-segment source picker pinned above the tab row. Material 3
+ * `SingleChoiceSegmentedButtonRow` with brass-tinted selection so it
+ * reads as part of the realm aesthetic and not a generic Material
+ * widget. Adding a new source is one more `forEach` entry once
+ * `BrowseSourceKey` grows.
+ */
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+private fun BrowseSourcePicker(
+    selected: BrowseSourceKey,
+    onSelect: (BrowseSourceKey) -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    val keys = remember { BrowseSourceKey.entries }
+    SingleChoiceSegmentedButtonRow(modifier = modifier) {
+        keys.forEachIndexed { index, key ->
+            SegmentedButton(
+                selected = key == selected,
+                onClick = { onSelect(key) },
+                shape = SegmentedButtonDefaults.itemShape(
+                    index = index,
+                    count = keys.size,
+                ),
+                colors = SegmentedButtonDefaults.colors(
+                    activeContainerColor = MaterialTheme.colorScheme.primaryContainer,
+                    activeContentColor = MaterialTheme.colorScheme.onPrimaryContainer,
+                ),
+            ) {
+                Text(key.displayName, style = MaterialTheme.typography.labelLarge)
+            }
+        }
+    }
+}
 
 /** Number of independent filter knobs the user has actively set. */
 private fun BrowseFilter.activeCount(): Int {

--- a/feature/src/main/kotlin/in/jphe/storyvox/feature/browse/BrowseViewModel.kt
+++ b/feature/src/main/kotlin/in/jphe/storyvox/feature/browse/BrowseViewModel.kt
@@ -4,6 +4,7 @@ import androidx.compose.runtime.Immutable
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import dagger.hilt.android.lifecycle.HiltViewModel
+import `in`.jphe.storyvox.data.source.SourceIds
 import `in`.jphe.storyvox.feature.api.BrowseFilter
 import `in`.jphe.storyvox.feature.api.BrowsePaginator
 import `in`.jphe.storyvox.feature.api.BrowseRepositoryUi
@@ -30,8 +31,37 @@ import kotlinx.coroutines.launch
 
 enum class BrowseTab { Popular, NewReleases, BestRated, Search }
 
+/**
+ * Top-level source picker on the Browse screen. Chooses which
+ * `FictionSource` the tabs route to. Royal Road is the default; the
+ * GitHub option surfaces the curated registry from PR #58 via the
+ * existing Popular/NewReleases tabs (BestRated + Search are hidden
+ * on GitHub until step 8b adds /search/repositories integration).
+ */
+enum class BrowseSourceKey(val sourceId: String, val displayName: String) {
+    RoyalRoad(SourceIds.ROYAL_ROAD, "Royal Road"),
+    GitHub(SourceIds.GITHUB, "GitHub"),
+}
+
+/** Tabs that are meaningful for [source]. GitHub registry doesn't
+ *  yet support BestRated (no rating-ordered fetch) or Search (lands
+ *  in step 8b), so those are hidden on GitHub. */
+fun BrowseSourceKey.supportedTabs(): List<BrowseTab> = when (this) {
+    BrowseSourceKey.RoyalRoad -> listOf(
+        BrowseTab.Popular,
+        BrowseTab.NewReleases,
+        BrowseTab.BestRated,
+        BrowseTab.Search,
+    )
+    BrowseSourceKey.GitHub -> listOf(
+        BrowseTab.Popular,
+        BrowseTab.NewReleases,
+    )
+}
+
 @Immutable
 data class BrowseUiState(
+    val sourceKey: BrowseSourceKey = BrowseSourceKey.RoyalRoad,
     val tab: BrowseTab = BrowseTab.Popular,
     val query: String = "",
     val items: List<UiFiction> = emptyList(),
@@ -81,6 +111,7 @@ class BrowseViewModel @Inject constructor(
     private val repo: BrowseRepositoryUi,
 ) : ViewModel() {
 
+    private val _sourceKey = MutableStateFlow(BrowseSourceKey.RoyalRoad)
     private val _tab = MutableStateFlow(BrowseTab.Popular)
     private val _query = MutableStateFlow("")
     private val _filter = MutableStateFlow(BrowseFilter())
@@ -90,12 +121,15 @@ class BrowseViewModel @Inject constructor(
      *  has neither a query nor active filters (the empty search hint is
      *  shown instead). */
     private val paginator: StateFlow<BrowsePaginator?> = combine(
+        _sourceKey,
         _tab,
         _query.debounce(300),
         _filter,
-    ) { tab, q, filter -> resolveSource(tab, q, filter) }
+    ) { sourceKey, tab, q, filter ->
+        resolveSource(tab, q, filter)?.let { source -> source to sourceKey.sourceId }
+    }
         .distinctUntilChanged()
-        .map { source -> source?.let(repo::paginator) }
+        .map { pair -> pair?.let { (source, sourceId) -> repo.paginator(source, sourceId) } }
         .stateIn(viewModelScope, SharingStarted.WhileSubscribed(5_000), null)
 
     init {
@@ -113,8 +147,9 @@ class BrowseViewModel @Inject constructor(
         if (p == null) {
             // Empty-search/no-filter: surface a quiet idle state so the
             // screen renders SearchHint rather than the skeleton grid.
-            combine(_tab, _query, _filter) { tab, q, filter ->
+            combine(_sourceKey, _tab, _query, _filter) { sourceKey, tab, q, filter ->
                 BrowseUiState(
+                    sourceKey = sourceKey,
                     tab = tab,
                     query = q,
                     items = emptyList(),
@@ -129,8 +164,9 @@ class BrowseViewModel @Inject constructor(
         } else {
             // Two-step combine: first collapse the paginator's five
             // flows into a typed [PaginatorView], then merge with the
-            // tab/query/filter trio. Keeps each combine within the
-            // 5-arg comfort zone and avoids positional `vals[i]` casts.
+            // sourceKey/tab/query/filter quartet. Keeps each combine
+            // within the 5-arg comfort zone and avoids positional
+            // `vals[i]` casts.
             val paginatorView = combine(
                 p.items,
                 p.isLoading,
@@ -140,8 +176,10 @@ class BrowseViewModel @Inject constructor(
             ) { items, loading, appending, more, error ->
                 PaginatorView(items, loading, appending, more, error)
             }
-            combine(paginatorView, _tab, _query, _filter) { view, tab, q, filter ->
+            combine(paginatorView, _sourceKey, _tab, _query, _filter) {
+                view, sourceKey, tab, q, filter ->
                 BrowseUiState(
+                    sourceKey = sourceKey,
                     tab = tab,
                     query = q,
                     items = view.items,
@@ -155,6 +193,23 @@ class BrowseViewModel @Inject constructor(
             }
         }
     }.stateIn(viewModelScope, SharingStarted.WhileSubscribed(5_000), BrowseUiState())
+
+    fun selectSource(key: BrowseSourceKey) {
+        if (_sourceKey.value == key) return
+        _sourceKey.value = key
+        // If the previously-selected tab isn't supported on the new
+        // source (e.g. user was on BestRated/Search on RR and switches
+        // to GitHub), snap to Popular so the screen has something
+        // sensible to render. Filters are RR-shaped and don't apply
+        // to GitHub yet, so reset them too.
+        if (_tab.value !in key.supportedTabs()) {
+            _tab.value = BrowseTab.Popular
+        }
+        if (key == BrowseSourceKey.GitHub) {
+            _filter.value = BrowseFilter()
+            _query.value = ""
+        }
+    }
 
     fun selectTab(tab: BrowseTab) { _tab.value = tab }
     fun setQuery(q: String) { _query.value = q }


### PR DESCRIPTION
## Summary

**Step 8a-ii** — UI half of step 8. Adds a top-level segmented control above the Browse tab row that switches the multibinding lookup in `FictionRepository` between Royal Road and GitHub. Selecting GitHub surfaces the curated registry from #58 via the existing Popular/NewReleases tabs.

**Visible win**: GitHub source goes from "wired but invisible" to "discoverable via Browse." `addByUrl(github URL)` was the only entry point; now Browse is too.

## What lands

- **`BrowseSourceKey` enum + `supportedTabs()`** — Royal Road keeps all 4 tabs (Popular/NewReleases/BestRated/Search); GitHub has only Popular and NewReleases for now. BestRated requires a rating-ordered query (not in the registry shape today) and Search requires the GitHub `/search/repositories` integration which is step 8b. When the user toggles to GitHub while on an unsupported tab, snap to Popular.
- **`BrowseRepositoryUi.paginator`** gains a `sourceId` parameter (default `SourceIds.ROYAL_ROAD`). Existing callers compile unchanged. New `BrowseScreen` passes `state.sourceKey.sourceId` so the data layer routes via the multibinding map from #35.
- **`RealBrowseRepositoryUi`** threads `sourceId` to every `repo.browse...` call site. Repo's catalog methods accepted the parameter as of #71.
- **`BrowseViewModel`** gains `_sourceKey` MutableStateFlow joined into the combine tuple. Paginator key now `(sourceKey, tab, debouncedQuery, filter)` — switching source rebuilds the paginator just like switching tabs. `selectSource(key)` snaps tab to a supported one and resets RR-shaped filter/query when crossing to GitHub.
- **`BrowseScreen`** gains a `BrowseSourcePicker` composable (Material 3 `SingleChoiceSegmentedButtonRow` with brass-tinted selection so it reads as part of the realm aesthetic, not a generic Material widget). Pinned above the tab row. Tab row derives its list from `state.sourceKey.supportedTabs()` so unsupported tabs are hidden, not greyed. Filter button only shown on Royal Road (filter sheet is RR-shaped; GitHub-shaped filters land in 8b). Scroll-to-top `LaunchedEffect` dependency list grew `state.sourceKey`.

## Test plan

- [x] `:feature:compileDebugKotlin` clean.
- [x] `:app:assembleDebug` clean — Hilt graph unchanged (no new injections, just new arg threading).
- [x] `:core-data:testDebugUnitTest` + `:feature:testDebugUnitTest` — all green (no test changes needed; default `sourceId` keeps existing tests valid).
- [x] **Installed on R83W80CAFZB** — tablet lock claimed during install, released on completion. App boots cleanly with both sources Hilt-bound, no logcat fatal/exception. versionName 0.4.26 confirmed, lastUpdateTime fresh.
- [ ] **JP-side smoke test** (next install cycle): open Browse, tap GitHub segment, verify Popular tab attempts a registry fetch (will surface NetworkError until `jphein/storyvox-registry` repo exists with a populated `registry.json`; that's a JP-task hinted at in PR #70's body too).

## What this unblocks

- **Step 8b**: GitHub `/search/repositories` integration — flips `GitHubSource.search()` from `NotImplementedError` to a real query. When that lands, the Search tab becomes available on GitHub and the search OutlinedTextField re-shows.
- **Step 8c**: GitHub-shaped filter sheet — different dimensions per spec lines 203-211 (tags, status, length, last updated, min stars, language, sort). When that lands, the FilterButton re-shows on GitHub.
- **Step 9**: commit-SHA-based polling — orthogonal to Browse.

## Worktree + branch

- Worktree: `.claude/worktrees/selene-browse-source-picker`
- Branch: `dream/selene/browse-source-picker`