### PR TITLE
test(nav): regression coverage for v0.4.25 nav-route encoding fix

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -117,6 +117,18 @@ android {
         getByName("main") {
             java.srcDirs("src/main/kotlin")
         }
+        getByName("test") {
+            java.srcDirs("src/test/kotlin")
+        }
+    }
+
+    testOptions {
+        unitTests {
+            // Robolectric needs Android resources visible to the test classpath
+            // so it can spin up a stub application context. Required for
+            // StoryvoxRoutesTest, which calls into android.net.Uri.
+            isIncludeAndroidResources = true
+        }
     }
 
     packaging {
@@ -171,6 +183,14 @@ dependencies {
     coreLibraryDesugaring(libs.android.desugar.jdk.libs)
 
     testImplementation(libs.junit)
+    // Robolectric supplies a real android.net.Uri implementation under JVM
+    // unit tests so StoryvoxRoutesTest can verify the v0.4.25 encoding fix
+    // (Uri.encode in the route-builder) — the framework stub jar throws
+    // "Method not mocked" on every Uri.* call and isReturnDefaultValues
+    // would just hand us null, which won't catch a regression. This is
+    // the only Robolectric-using test in the repo today; if more land
+    // they should reuse this dep, not add their own.
+    testImplementation(libs.robolectric)
     androidTestImplementation(libs.androidx.junit)
     androidTestImplementation(libs.androidx.espresso.core)
 }

--- a/app/src/test/kotlin/in/jphe/storyvox/navigation/StoryvoxRoutesTest.kt
+++ b/app/src/test/kotlin/in/jphe/storyvox/navigation/StoryvoxRoutesTest.kt
@@ -1,0 +1,98 @@
+package `in`.jphe.storyvox.navigation
+
+import android.app.Application
+import android.net.Uri
+import org.junit.Assert.assertEquals
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+
+/**
+ * Regression coverage for v0.4.25 (commit 5cfc3c5): GitHubSource fictionIds
+ * contain `/` (e.g. "github:jphein/example-fiction") and chapterIds contain
+ * even more (e.g. "github:jphein/example-fiction:src/chapter-01.md").
+ *
+ * StoryvoxNavHost declares `fiction/{fictionId}` as a single-segment route
+ * template — without per-segment encoding, the router can't bind the arg to
+ * a 3-segment path and crashes the whole nav graph on first GitHub fiction
+ * tap. The fix in StoryvoxNavHost.kt:54-60 wraps every id in `Uri.encode()`
+ * at the route-builder so the on-the-wire path always has the segment count
+ * the template expects.
+ *
+ * These tests pin that behaviour: each id-bearing route helper produces a
+ * path with the correct slash count, and round-tripping the encoded
+ * segments through `Uri.decode` returns the original id verbatim. If the
+ * encoding ever silently drops out (e.g. someone "simplifies" the helper
+ * to a string template), the next GitHub click crashes — these tests
+ * catch that before it ships.
+ *
+ * Robolectric runner: `Uri.encode` lives in android.jar and the framework
+ * stub throws "Method not mocked" under plain JUnit. Robolectric provides
+ * a real implementation backed by libcore. See app/build.gradle.kts for
+ * the (single-purpose) Robolectric dep.
+ */
+// `application = Application::class` skips the Hilt-injected StoryvoxApp,
+// which would otherwise pull in DataModule.provideEncryptedPrefs and
+// crash on `AndroidKeyStore not available` under Robolectric. The test
+// only needs `android.net.Uri`, not a real DI graph.
+@RunWith(RobolectricTestRunner::class)
+@Config(application = Application::class)
+class StoryvoxRoutesTest {
+
+    @Test
+    fun fictionDetail_githubId_producesTwoSegmentPath() {
+        val id = "github:jphein/example-fiction"
+        val route = StoryvoxRoutes.fictionDetail(id)
+        // Exactly one slash → 2 segments: "fiction" and the encoded id.
+        assertEquals(1, route.count { it == '/' })
+        val parts = route.split('/')
+        assertEquals(2, parts.size)
+        assertEquals("fiction", parts[0])
+        assertEquals(id, Uri.decode(parts[1]))
+    }
+
+    @Test
+    fun reader_githubIds_produceThreeSegmentPathAndRoundTrip() {
+        val fictionId = "github:jphein/example-fiction"
+        val chapterId = "github:jphein/example-fiction:src/chapter-01.md"
+        val route = StoryvoxRoutes.reader(fictionId, chapterId)
+        // Exactly two slashes → 3 segments: "reader", encoded fictionId,
+        // encoded chapterId. Without per-segment encoding the chapterId
+        // alone contributes 4 slashes and the route blows the template up.
+        assertEquals(2, route.count { it == '/' })
+        val parts = route.split('/')
+        assertEquals(3, parts.size)
+        assertEquals("reader", parts[0])
+        assertEquals(fictionId, Uri.decode(parts[1]))
+        assertEquals(chapterId, Uri.decode(parts[2]))
+    }
+
+    @Test
+    fun audiobook_githubIds_produceThreeSegmentPathAndRoundTrip() {
+        val fictionId = "github:jphein/example-fiction"
+        val chapterId = "github:jphein/example-fiction:src/chapter-01.md"
+        val route = StoryvoxRoutes.audiobook(fictionId, chapterId)
+        assertEquals(2, route.count { it == '/' })
+        val parts = route.split('/')
+        assertEquals(3, parts.size)
+        assertEquals("audiobook", parts[0])
+        assertEquals(fictionId, Uri.decode(parts[1]))
+        assertEquals(chapterId, Uri.decode(parts[2]))
+    }
+
+    @Test
+    fun fictionDetail_royalRoadId_roundTripsCleanly() {
+        // Sanity: the encoding helper must not corrupt the simple
+        // royalroad ids that worked pre-v0.4.25 — they have no `/` so
+        // `Uri.encode` is essentially a no-op for the path-significant
+        // characters, but `:` still gets percent-encoded to `%3A`.
+        val id = "royalroad:12345"
+        val route = StoryvoxRoutes.fictionDetail(id)
+        assertEquals(1, route.count { it == '/' })
+        val parts = route.split('/')
+        assertEquals(2, parts.size)
+        assertEquals("fiction", parts[0])
+        assertEquals(id, Uri.decode(parts[1]))
+    }
+}

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -57,6 +57,7 @@ play-services-wearable = "18.2.0"
 junit = "4.13.2"
 androidx-junit = "1.2.1"
 espresso = "3.6.1"
+robolectric = "4.14.1"
 
 # Desugaring
 desugar = "2.1.3"
@@ -141,6 +142,7 @@ android-desugar-jdk-libs = { module = "com.android.tools:desugar_jdk_libs", vers
 junit = { module = "junit:junit", version.ref = "junit" }
 androidx-junit = { module = "androidx.test.ext:junit", version.ref = "androidx-junit" }
 androidx-espresso-core = { module = "androidx.test.espresso:espresso-core", version.ref = "espresso" }
+robolectric = { module = "org.robolectric:robolectric", version.ref = "robolectric" }
 
 [plugins]
 android-application = { id = "com.android.application", version.ref = "agp" }


### PR DESCRIPTION
## Summary
Pin `StoryvoxRoutes.fictionDetail` / `reader` / `audiobook` against the v0.4.25 encoding regression (commit 5cfc3c5). GitHubSource fictionIds contain `/` characters; without per-segment `Uri.encode`, the single-segment route template `fiction/{fictionId}` can't bind a 3-segment path and the nav graph crashes on the first GitHub click.

The tests assert two invariants for each id-bearing route helper:
1. **Slash count** — `fictionDetail` produces 1 slash (2 segments), `reader` / `audiobook` produce 2 slashes (3 segments). If the encoding ever silently drops out, the count blows up.
2. **Round-trip** — `Uri.decode(parts[i])` recovers the original id verbatim, including `:` and `/` characters from `github:owner/repo:src/chapter-NN.md`.

A sanity test for `royalroad:12345` covers the pre-v0.4.25 id shape.

## Implementation notes
- **Robolectric 4.14.1** (4.13 errors `targetSdkVersion=35 > maxSdkVersion=34`). It supplies a real `android.net.Uri` implementation; `isReturnDefaultValues = true` would hand the test `null` and silently mask any regression.
- `@Config(application = Application::class)` skips the Hilt-injected `StoryvoxApp`, which would otherwise pull in `DataModule.provideEncryptedPrefs` and crash on `AndroidKeyStore not available` under JVM.
- This is the only Robolectric-using test in the repo today. The dep is added solely for `Uri.encode`; if more tests ever land that need a real Android API the comment in `app/build.gradle.kts` directs them to reuse this dep instead of forking.

## Test plan
- [x] `./gradlew :app:testDebugUnitTest --tests "in.jphe.storyvox.navigation.StoryvoxRoutesTest"` — BUILD SUCCESSFUL, 4 tests pass
- [x] Full app build (`./gradlew :app:assembleDebug`) succeeds with the new test source set + dep

🤖 Generated with [Claude Code](https://claude.com/claude-code)