### PR TITLE
feat(playback): chunk-gap benchmark harness for TTS perf lane

### DIFF
--- a/core-playback/src/main/kotlin/in/jphe/storyvox/playback/tts/ChunkGapLogger.kt
+++ b/core-playback/src/main/kotlin/in/jphe/storyvox/playback/tts/ChunkGapLogger.kt
@@ -1,0 +1,130 @@
+package `in`.jphe.storyvox.playback.tts
+
+import android.content.Context
+import android.os.SystemClock
+import android.util.Log
+import java.io.File
+
+/**
+ * Inter-chunk gap instrumentation for the EnginePlayer consumer thread.
+ *
+ * Measures the dead time between the *last* AudioTrack.write of chunk N and
+ * the *first* AudioTrack.write of chunk N+1 — that is, the audible silence
+ * a listener experiences if the producer can't keep the queue full. On
+ * Tab A7 Lite with Piper-high or Kokoro voices, this gap is the bug
+ * Aurelia is hunting; this class is the measuring stick.
+ *
+ * # Why a marker file, not BuildConfig
+ * Storyvox ships a single AGP build type (see app/build.gradle.kts —
+ * "no separate release flavor being shipped"), so a `BuildConfig.DEBUG`
+ * gate would either always log or never log. The marker-file pattern
+ * (`/data/data/in.jphe.storyvox/files/chunk-gap-log`) mirrors the
+ * AudioTrack.Builder A/B toggle in EnginePlayer.createAudioTrack:
+ * `adb shell touch ...` to flip on, `adb shell rm ...` to flip off,
+ * effective on the next pipeline rebuild. No app restart required.
+ *
+ * # Why we don't measure "audio actually emitted from speaker"
+ * The truthful answer would require AAudio's underrun callback or a mic
+ * + acoustic analysis, both heavy. AudioTrack.write returns when the
+ * ring buffer has accepted the bytes, which on minBufferSize tracks
+ * (see EnginePlayer.createAudioTrack) is ~130 ms ahead of the speaker.
+ * That 130 ms latency is constant across chunks, so it cancels out of
+ * gap_ms = chunk_start_ms[N+1] - chunk_end_ms[N]. The gap we log is
+ * the gap the listener will hear, modulo a fixed offset.
+ *
+ * # API
+ * `start(voiceId, chunkIndex)` is called immediately before the inner
+ * write loop for a chunk; `end()` is called immediately after the
+ * trailing-silence spool finishes. The logger computes the gap from
+ * the previous chunk's `end()` to the current `start()` and emits it
+ * via `Log.i` with tag `ChunkGap`. Tag includes the active voice id
+ * so a single logcat session can be split-by-voice with `grep voice=`.
+ *
+ * Pipeline boundaries (a fresh `startPlaybackPipeline()` call after a
+ * pause, seek, voice swap, or the first chunk of a chapter) reset the
+ * "previous end" anchor to -1 so the first chunk of a pipeline run
+ * doesn't get a misleading multi-second "gap" attributed to user
+ * pause time.
+ *
+ * @param context used once at construction to check the marker file.
+ *  We re-check on every `start()` so a `touch` on the marker takes
+ *  effect on the next chunk without requiring a pipeline rebuild.
+ *  Marker check is a stat() call — cheap.
+ */
+class ChunkGapLogger(private val context: Context) {
+
+    private var prevChunkEndMs: Long = -1L
+    private var currentChunkStartMs: Long = -1L
+
+    /**
+     * Reset between pipeline lifetimes (start of a pause/resume, seek,
+     * voice swap, chapter advance). Without this, the gap between the
+     * last chunk before a pause and the first chunk after resume gets
+     * logged as the user's pause duration — useless noise.
+     */
+    fun resetForNewPipeline() {
+        prevChunkEndMs = -1L
+        currentChunkStartMs = -1L
+    }
+
+    /**
+     * Record the start-of-write timestamp for chunk [chunkIndex] played
+     * with [voiceId]. If the previous chunk's end timestamp is set,
+     * emits the gap in ms via Log.i. Returns immediately if the marker
+     * file is not present.
+     */
+    fun chunkStart(voiceId: String, chunkIndex: Int) {
+        if (!isEnabled()) return
+        currentChunkStartMs = SystemClock.elapsedRealtime()
+        val prev = prevChunkEndMs
+        if (prev > 0) {
+            val gap = currentChunkStartMs - prev
+            Log.i(
+                TAG,
+                "voice=$voiceId chunk=$chunkIndex gap_ms=$gap " +
+                    "prev_end_ms=$prev start_ms=$currentChunkStartMs",
+            )
+        } else {
+            Log.i(
+                TAG,
+                "voice=$voiceId chunk=$chunkIndex gap_ms=- " +
+                    "start_ms=$currentChunkStartMs (pipeline-start, no prev)",
+            )
+        }
+    }
+
+    /**
+     * Record the end-of-write timestamp for the chunk most recently
+     * passed to [chunkStart]. Stores it as the anchor for the next
+     * chunk's gap computation. Also logs the per-chunk wall-clock
+     * duration (start→end) so a reader can sanity-check that the
+     * AudioTrack write loop didn't itself stall.
+     */
+    fun chunkEnd(voiceId: String, chunkIndex: Int) {
+        if (!isEnabled()) return
+        val end = SystemClock.elapsedRealtime()
+        val start = currentChunkStartMs
+        prevChunkEndMs = end
+        if (start > 0) {
+            Log.i(
+                TAG,
+                "voice=$voiceId chunk=$chunkIndex write_duration_ms=${end - start} end_ms=$end",
+            )
+        }
+    }
+
+    private fun isEnabled(): Boolean = try {
+        File(context.filesDir, MARKER_FILE).exists()
+    } catch (_: Throwable) {
+        false
+    }
+
+    private companion object {
+        const val TAG = "ChunkGap"
+
+        /** Touch this file on-device to enable gap logging:
+         *  `adb shell touch /data/data/in.jphe.storyvox/files/chunk-gap-log`
+         *  Remove to disable; takes effect on the next chunk. */
+        const val MARKER_FILE = "chunk-gap-log"
+    }
+}

--- a/core-playback/src/main/kotlin/in/jphe/storyvox/playback/tts/EnginePlayer.kt
+++ b/core-playback/src/main/kotlin/in/jphe/storyvox/playback/tts/EnginePlayer.kt
@@ -201,6 +201,12 @@ class EnginePlayer @AssistedInject constructor(
     private var pcmQueue: LinkedBlockingQueue<SentencePcm>? = null
     private var generationJob: Job? = null
 
+    /** Inter-chunk gap measurement (Tab A7 Lite TTS perf lane). Off by
+     *  default — reads a marker file at every chunkStart so a developer
+     *  can `adb shell touch /data/data/in.jphe.storyvox/files/chunk-gap-log`
+     *  and start collecting numbers without a build flip. See [ChunkGapLogger]. */
+    private val chunkGapLogger = ChunkGapLogger(context)
+
     /** Dedicated playback thread. The agent that gets URGENT_AUDIO and never
      *  yields back to a coroutine pool — see the comment on [startPlaybackPipeline]
      *  for why this can't be a coroutine. */
@@ -437,6 +443,10 @@ class EnginePlayer @AssistedInject constructor(
         val queue = LinkedBlockingQueue<SentencePcm>(QUEUE_CAPACITY)
         pcmQueue = queue
         pipelineRunning.set(true)
+        // Clear the prev-chunk-end anchor so the first chunk of this
+        // pipeline lifetime doesn't get a "gap" attributed to user
+        // pause time, seek time, or model load time.
+        chunkGapLogger.resetForNewPipeline()
 
         generationJob = ioScope.launch {
             // Inference is CPU-heavy on modest hardware (Tab A7 Lite); without
@@ -533,6 +543,16 @@ class EnginePlayer @AssistedInject constructor(
                         firstSentence = false
                     }
 
+                    // Stamp the start of the AudioTrack-write phase for this
+                    // chunk. Combined with the chunkEnd() below, this lets
+                    // the perf lane log gap_ms = startN - endNm1, which is
+                    // the audible silence between adjacent chunks (modulo
+                    // the constant ~130 ms minBuffer latency, see
+                    // ChunkGapLogger doc). No-op unless the marker file is
+                    // present, so this is free in normal operation.
+                    val gapVoiceId = loadedVoiceId ?: "unknown"
+                    chunkGapLogger.chunkStart(gapVoiceId, item.sentenceIndex)
+
                     // Apply the SleepTimer fade-out ramp to the live track.
                     // Polled per write iteration; AudioTrack.setVolume is a
                     // cheap JNI call but the lastVol guard skips it entirely
@@ -562,6 +582,12 @@ class EnginePlayer @AssistedInject constructor(
                         if (n < 0) break
                         remaining -= n
                     }
+
+                    // End-of-chunk: AudioTrack has accepted every byte of
+                    // pcm + trailing silence. The next iteration's blocking
+                    // queue.take() is where a slow producer shows up as a
+                    // logged gap.
+                    chunkGapLogger.chunkEnd(gapVoiceId, item.sentenceIndex)
                 }
             } finally {
                 // Release the AudioTrack from the same thread that owns


### PR DESCRIPTION
## Summary
Provides Aurelia's TTS perf lane with a measuring stick: per-chunk timestamps logged from the EnginePlayer consumer thread so the inter-chunk gap (audible silence between sentences on Tab A7 Lite under heavy voices) becomes a hard millisecond number, not a feel.

Sister PR for the nav-route regression: #73 (Task A).

## Architecture
A small \`ChunkGapLogger\` collaborator on EnginePlayer instruments three points on the consumer thread:
- **\`resetForNewPipeline()\`** at \`startPlaybackPipeline\` — clears the prev-end anchor so user pause / seek / model-load durations don't pollute chunk-N→chunk-N+1 measurements.
- **\`chunkStart(voiceId, idx)\`** immediately before the per-chunk write loop — stamps \`SystemClock.elapsedRealtime()\` and emits \`gap_ms\` against the last \`chunkEnd\`.
- **\`chunkEnd(voiceId, idx)\`** after the trailing-silence spool — stores the anchor for the next gap computation.

## How to enable on Tab A7 Lite
Off by default — every call early-returns unless a marker file exists. Mirrors the existing AudioTrack.Builder A/B toggle pattern.

\`\`\`bash
adb shell touch /data/data/in.jphe.storyvox/files/chunk-gap-log
adb logcat -c && adb logcat ChunkGap:I '*:S'
\`\`\`

Each chunk produces two lines:
\`\`\`
ChunkGap: voice=af_heart_kokoro chunk=12 gap_ms=247 prev_end_ms=12345 start_ms=12592
ChunkGap: voice=af_heart_kokoro chunk=12 write_duration_ms=1830 end_ms=14422
\`\`\`

\`grep voice=\` splits per-engine for Aurelia's split-by-voice analysis.

## Why \`SystemClock.elapsedRealtime\`, not wall-clock
Monotonic, immune to NTP / wall-clock jumps, matches the scrubber clock fix (PR #50). The constant ~130 ms minBuffer latency is a fixed per-write offset; it cancels out of \`gap_ms = startN - endNm1\` across adjacent chunks.

## How Aurelia can use this branch
Branch \`dream/zephyr/chunk-gap-benchmark\` (HEAD 69d3da9). Two files touched:
- New: \`core-playback/src/main/kotlin/in/jphe/storyvox/playback/tts/ChunkGapLogger.kt\`
- Modified (3 hunks): \`core-playback/src/main/kotlin/in/jphe/storyvox/playback/tts/EnginePlayer.kt\`

Cherry-pick or rebase onto her branch — both should be clean since the EnginePlayer hunks are localized to the consumer thread's read-only path. If she's also editing the consumer loop, rebase will surface the conflict early.

## What this is NOT
Not a Macrobenchmark module. The 30-line debug-build hook gets the number we need. If the same number ever needs to land in CI, that's a follow-up.

## Test plan
- [x] \`./gradlew :core-playback:compileDebugKotlin :core-playback:testDebugUnitTest\` — BUILD SUCCESSFUL
- [x] \`./gradlew :app:assembleDebug\` — BUILD SUCCESSFUL (full app builds with the harness wired in)
- [ ] **Tablet validation** — needs task #47 (TABLET LOCK). Aurelia is hunting the same hardware, so coordinate via TaskUpdate. Once she has logcat samples she'll attach a representative slice here.

## Why no unit test for ChunkGapLogger
\`SystemClock.elapsedRealtime\` and \`Log.i\` are Android stubs; under \`isReturnDefaultValues = true\` (core-playback's existing pattern) they return 0 / no-op, which makes a JVM test of marker-gated state transitions low-value. On-device logcat is the real test. Adding Robolectric to core-playback for a single small class would be heavier than the surface justifies.

🤖 Generated with [Claude Code](https://claude.com/claude-code)