### PR TITLE
feat(source-github): /search/repositories integration + Search tab on GitHub

### DIFF
--- a/feature/src/main/kotlin/in/jphe/storyvox/feature/browse/BrowseScreen.kt
+++ b/feature/src/main/kotlin/in/jphe/storyvox/feature/browse/BrowseScreen.kt
@@ -107,11 +107,11 @@ fun BrowseScreen(
             }
         }
 
-        if (state.tab == BrowseTab.Search && state.sourceKey == BrowseSourceKey.RoyalRoad) {
+        if (state.tab == BrowseTab.Search) {
             OutlinedTextField(
                 value = state.query,
                 onValueChange = viewModel::setQuery,
-                label = { Text("Search Royal Road") },
+                label = { Text("Search ${state.sourceKey.displayName}") },
                 modifier = Modifier.fillMaxWidth().padding(spacing.md),
                 singleLine = true,
             )

--- a/feature/src/main/kotlin/in/jphe/storyvox/feature/browse/BrowseViewModel.kt
+++ b/feature/src/main/kotlin/in/jphe/storyvox/feature/browse/BrowseViewModel.kt
@@ -44,8 +44,11 @@ enum class BrowseSourceKey(val sourceId: String, val displayName: String) {
 }
 
 /** Tabs that are meaningful for [source]. GitHub registry doesn't
- *  yet support BestRated (no rating-ordered fetch) or Search (lands
- *  in step 8b), so those are hidden on GitHub. */
+ *  yet support BestRated (no rating-ordered fetch — registry stores
+ *  curator rating but doesn't yet sort by it), so it's hidden on
+ *  GitHub. Search is wired as of step 8b — flips
+ *  `GitHubSource.search()` to `/search/repositories?q=topic:fiction
+ *  +{userQuery}`. */
 fun BrowseSourceKey.supportedTabs(): List<BrowseTab> = when (this) {
     BrowseSourceKey.RoyalRoad -> listOf(
         BrowseTab.Popular,
@@ -56,6 +59,7 @@ fun BrowseSourceKey.supportedTabs(): List<BrowseTab> = when (this) {
     BrowseSourceKey.GitHub -> listOf(
         BrowseTab.Popular,
         BrowseTab.NewReleases,
+        BrowseTab.Search,
     )
 }
 

--- a/source-github/src/main/kotlin/in/jphe/storyvox/source/github/GitHubSource.kt
+++ b/source-github/src/main/kotlin/in/jphe/storyvox/source/github/GitHubSource.kt
@@ -90,8 +90,79 @@ internal class GitHubSource @Inject constructor(
         }
     }
 
-    override suspend fun search(query: SearchQuery): FictionResult<ListPage<FictionSummary>> =
-        throw NotImplementedError(STEP_3_SEARCH)
+    override suspend fun search(query: SearchQuery): FictionResult<ListPage<FictionSummary>> {
+        // Compose the GitHub search query: pin to fiction-shaped topics
+        // so we don't dredge generic repos, then append the user's
+        // search term verbatim. GitHub topic OR-syntax is `topic:a
+        // OR topic:b` — covers a few synonym tags at once. RR-shaped
+        // SearchQuery filter fields (genres, tags, statuses,
+        // requireWarnings, etc.) don't translate to GitHub today and
+        // are ignored; the GitHub-shaped filter sheet from step 8c
+        // will route through a different code path.
+        val term = query.term.trim()
+        val gh = buildString {
+            append("(topic:fiction OR topic:fanfiction OR topic:webnovel)")
+            if (term.isNotEmpty()) {
+                append(' ')
+                append(term)
+            }
+        }
+
+        return when (val r = api.searchRepositories(gh, page = query.page)) {
+            is GitHubApiResult.Success -> {
+                val items = r.value.items.map { it.toFictionSummary() }
+                FictionResult.Success(
+                    ListPage(
+                        items = items,
+                        page = query.page,
+                        // GitHub search caps at 1000 results across all
+                        // pages; signal end-of-list when items < per_page
+                        // OR we've reached the cap.
+                        hasNext = items.isNotEmpty() && items.size >= 20 && query.page < 50,
+                    ),
+                )
+            }
+            is GitHubApiResult.NotFound -> FictionResult.Success(
+                ListPage(items = emptyList(), page = query.page, hasNext = false),
+            )
+            is GitHubApiResult.RateLimited -> FictionResult.RateLimited(
+                retryAfter = r.retryAfterSeconds?.let { it.toDuration(DurationUnit.SECONDS) },
+            )
+            is GitHubApiResult.HttpError -> FictionResult.NetworkError(
+                message = "GitHub error ${r.code}: ${r.message}",
+            )
+            is GitHubApiResult.NetworkError -> FictionResult.NetworkError(
+                message = "Could not reach GitHub",
+                cause = r.cause,
+            )
+            is GitHubApiResult.ParseError -> FictionResult.NetworkError(
+                message = "Malformed search response",
+                cause = r.cause,
+            )
+        }
+    }
+
+    /**
+     * Map a GitHub repo into the cross-source [FictionSummary]. Cover
+     * URL is intentionally null — the manifest's storyvox.json.cover
+     * lives in the repo content, not the API response, so search
+     * results don't have it. The user opens the fiction → fictionDetail
+     * resolves the manifest → the detail card gets the cover. Tags
+     * fall back to GitHub topics; the manifest's storyvox.json.tags
+     * (if any) overrides that on the detail page.
+     */
+    private fun GhRepo.toFictionSummary(): FictionSummary = FictionSummary(
+        id = "${SourceIds.GITHUB}:${fullName.lowercase()}",
+        sourceId = SourceIds.GITHUB,
+        title = name,
+        author = owner.login,
+        coverUrl = null,
+        description = description,
+        tags = topics,
+        status = if (archived) FictionStatus.COMPLETED else FictionStatus.ONGOING,
+        chapterCount = null,
+        rating = null,
+    )
 
     override suspend fun fictionDetail(fictionId: String): FictionResult<FictionDetail> {
         val coords = parseFictionId(fictionId)
@@ -372,6 +443,5 @@ internal class GitHubSource @Inject constructor(
 
     private companion object {
         const val STEP_3F_AUTH = "GitHub source auth-gated calls not implemented yet — lands in step 3f (optional PAT support)"
-        const val STEP_3_SEARCH = "GitHub /search/repositories not implemented yet — lands in step 3-search (spec sequence step 8)"
     }
 }

--- a/source-github/src/main/kotlin/in/jphe/storyvox/source/github/model/GitHubModels.kt
+++ b/source-github/src/main/kotlin/in/jphe/storyvox/source/github/model/GitHubModels.kt
@@ -107,6 +107,24 @@ internal data class GhCommitAuthor(
     @SerialName("date") val date: String? = null,
 )
 
+/**
+ * `GET /search/repositories?q=...`. Search has its own rate limit
+ * (30 req/min unauthenticated) separate from the core API limit, so
+ * callers can typed-search safely with a 300 ms debounce.
+ *
+ * `incompleteResults` is GitHub's signal that the search timed out
+ * server-side and the items list is partial. Surfaced verbatim so
+ * the caller can choose to retry or accept the partial.
+ *
+ * https://docs.github.com/en/rest/search/search#search-repositories
+ */
+@Serializable
+internal data class GhSearchResponse(
+    @SerialName("total_count") val totalCount: Int,
+    @SerialName("incomplete_results") val incompleteResults: Boolean = false,
+    @SerialName("items") val items: List<GhRepo> = emptyList(),
+)
+
 @Serializable
 internal data class GhCommitFile(
     @SerialName("filename") val filename: String,

--- a/source-github/src/main/kotlin/in/jphe/storyvox/source/github/net/GitHubApi.kt
+++ b/source-github/src/main/kotlin/in/jphe/storyvox/source/github/net/GitHubApi.kt
@@ -2,6 +2,7 @@ package `in`.jphe.storyvox.source.github.net
 
 import `in`.jphe.storyvox.source.github.di.GitHubHttp
 import `in`.jphe.storyvox.source.github.model.GhCompareResponse
+import `in`.jphe.storyvox.source.github.model.GhSearchResponse
 import `in`.jphe.storyvox.source.github.model.GhContent
 import `in`.jphe.storyvox.source.github.model.GhRepo
 import kotlinx.coroutines.Dispatchers
@@ -97,6 +98,28 @@ internal open class GitHubApi @Inject constructor(
         head: String,
     ): GitHubApiResult<GhCompareResponse> =
         get("$BASE_URL/repos/${owner.lowercase()}/${repo.lowercase()}/compare/$base...$head")
+
+    /**
+     * `GET /search/repositories?q=...&page=...&per_page=...`. The
+     * search endpoint has its own 30 req/min unauthenticated rate
+     * limit (separate from the core 60/hr limit), so a 300 ms
+     * debounced typed-search UX fits well under the cap.
+     *
+     * [query] should already include any qualifier prefixes
+     * (`topic:fiction`, `language:en`, etc.) — this method just URL-
+     * encodes and forwards. Caller is responsible for composing the
+     * fiction-targeting topics into [query].
+     */
+    open suspend fun searchRepositories(
+        query: String,
+        page: Int = 1,
+        perPage: Int = 20,
+    ): GitHubApiResult<GhSearchResponse> {
+        val encoded = java.net.URLEncoder.encode(query, "UTF-8")
+        return get(
+            "$BASE_URL/search/repositories?q=$encoded&page=$page&per_page=$perPage",
+        )
+    }
 
     private suspend inline fun <reified T> get(url: String): GitHubApiResult<T> =
         withContext(Dispatchers.IO) {

--- a/source-github/src/test/kotlin/in/jphe/storyvox/source/github/GitHubSourceTest.kt
+++ b/source-github/src/test/kotlin/in/jphe/storyvox/source/github/GitHubSourceTest.kt
@@ -298,15 +298,155 @@ class GitHubSourceTest {
         assertTrue("got $r", r is FictionResult.NotFound)
     }
 
-    // ─── Still-stubbed surfaces ────────────────────────────────────────
+    // ─── search ────────────────────────────────────────────────────────
 
-    @Test fun `search still throws NotImplementedError`() {
-        assertThrows(NotImplementedError::class.java) {
-            runBlocking {
-                source().search(`in`.jphe.storyvox.data.source.model.SearchQuery(term = "anything"))
-            }
-        }
+    @Test fun `search composes topic-filtered query and maps results to FictionSummary`() {
+        val api = FakeGitHubApi(
+            searches = listOf(
+                "archmage" to GitHubApiResult.Success(
+                    `in`.jphe.storyvox.source.github.model.GhSearchResponse(
+                        totalCount = 2,
+                        items = listOf(
+                            ghRepo(owner = "onedayokay", name = "the-archmage", desc = "An overpowered archmage."),
+                            ghRepo(owner = "another", name = "archmage-tales", topics = listOf("fiction", "fantasy")),
+                        ),
+                    ),
+                    etag = null,
+                ),
+            ),
+        )
+        val src = source(api = api)
+
+        val r = runBlocking {
+            src.search(`in`.jphe.storyvox.data.source.model.SearchQuery(term = "archmage"))
+        } as FictionResult.Success
+
+        assertEquals(2, r.value.items.size)
+        val first = r.value.items[0]
+        assertEquals("github:onedayokay/the-archmage", first.id)
+        assertEquals(SourceIds.GITHUB, first.sourceId)
+        assertEquals("the-archmage", first.title)
+        assertEquals("onedayokay", first.author)
+        assertEquals("An overpowered archmage.", first.description)
+        assertEquals(listOf("fiction", "fantasy"), r.value.items[1].tags)
     }
+
+    @Test fun `search with empty term still goes through topic-filter and returns generic fictions`() {
+        val api = FakeGitHubApi(
+            // The composed query for term="" is "(topic:fiction OR
+            // topic:fanfiction OR topic:webnovel)" — match on "topic:".
+            searches = listOf(
+                "topic:" to GitHubApiResult.Success(
+                    `in`.jphe.storyvox.source.github.model.GhSearchResponse(
+                        totalCount = 1,
+                        items = listOf(ghRepo(owner = "o", name = "fiction-repo")),
+                    ),
+                    etag = null,
+                ),
+            ),
+        )
+        val src = source(api = api)
+
+        val r = runBlocking {
+            src.search(`in`.jphe.storyvox.data.source.model.SearchQuery(term = "  "))
+        } as FictionResult.Success
+
+        assertEquals(1, r.value.items.size)
+        assertEquals("github:o/fiction-repo", r.value.items.single().id)
+    }
+
+    @Test fun `search hasNext is false when results are below the per-page count`() {
+        val items = (1..5).map { ghRepo(owner = "o", name = "repo-$it") }
+        val api = FakeGitHubApi(
+            searches = listOf(
+                "x" to GitHubApiResult.Success(
+                    `in`.jphe.storyvox.source.github.model.GhSearchResponse(totalCount = 5, items = items),
+                    etag = null,
+                ),
+            ),
+        )
+        val src = source(api = api)
+        val r = runBlocking {
+            src.search(`in`.jphe.storyvox.data.source.model.SearchQuery(term = "x"))
+        } as FictionResult.Success
+        assertEquals(5, r.value.items.size)
+        assertEquals(false, r.value.hasNext)
+    }
+
+    @Test fun `search hasNext is true when a full page comes back below page-50 cap`() {
+        val items = (1..20).map { ghRepo(owner = "o", name = "repo-$it") }
+        val api = FakeGitHubApi(
+            searches = listOf(
+                "many" to GitHubApiResult.Success(
+                    `in`.jphe.storyvox.source.github.model.GhSearchResponse(totalCount = 1000, items = items),
+                    etag = null,
+                ),
+            ),
+        )
+        val src = source(api = api)
+        val r = runBlocking {
+            src.search(`in`.jphe.storyvox.data.source.model.SearchQuery(term = "many", page = 1))
+        } as FictionResult.Success
+        assertEquals(20, r.value.items.size)
+        assertEquals(true, r.value.hasNext)
+    }
+
+    @Test fun `search NotFound surfaces as empty page hasNext-false`() {
+        val api = FakeGitHubApi(
+            searches = listOf("zilch" to GitHubApiResult.NotFound("nada")),
+        )
+        val src = source(api = api)
+        val r = runBlocking {
+            src.search(`in`.jphe.storyvox.data.source.model.SearchQuery(term = "zilch"))
+        } as FictionResult.Success
+        assertTrue(r.value.items.isEmpty())
+        assertEquals(false, r.value.hasNext)
+    }
+
+    @Test fun `search RateLimited propagates with retry-after`() {
+        val api = FakeGitHubApi(
+            searches = listOf(
+                "throttled" to GitHubApiResult.RateLimited(retryAfterSeconds = 60),
+            ),
+        )
+        val src = source(api = api)
+        val r = runBlocking {
+            src.search(`in`.jphe.storyvox.data.source.model.SearchQuery(term = "throttled"))
+        }
+        assertTrue("got $r", r is FictionResult.RateLimited)
+    }
+
+    @Test fun `search NetworkError propagates`() {
+        val api = FakeGitHubApi(
+            searches = listOf("offline" to GitHubApiResult.NetworkError(java.io.IOException("offline"))),
+        )
+        val src = source(api = api)
+        val r = runBlocking {
+            src.search(`in`.jphe.storyvox.data.source.model.SearchQuery(term = "offline"))
+        }
+        assertTrue("got $r", r is FictionResult.NetworkError)
+    }
+
+    @Test fun `archived repos in search results map to COMPLETED status`() {
+        val api = FakeGitHubApi(
+            searches = listOf(
+                "archived" to GitHubApiResult.Success(
+                    `in`.jphe.storyvox.source.github.model.GhSearchResponse(
+                        totalCount = 1,
+                        items = listOf(ghRepo(owner = "o", name = "old", archived = true)),
+                    ),
+                    etag = null,
+                ),
+            ),
+        )
+        val src = source(api = api)
+        val r = runBlocking {
+            src.search(`in`.jphe.storyvox.data.source.model.SearchQuery(term = "archived"))
+        } as FictionResult.Success
+        assertEquals(FictionStatus.COMPLETED, r.value.items.single().status)
+    }
+
+    // ─── Still-stubbed surfaces ────────────────────────────────────────
 
     @Test fun `followsList and setFollowed still throw NotImplementedError`() {
         assertThrows(NotImplementedError::class.java) { runBlocking { source().followsList() } }
@@ -411,6 +551,10 @@ class GitHubSourceTest {
         private val files: Map<Triple<String, String, String>, GhContent> = emptyMap(),
         private val dirs: Map<Triple<String, String, String>, List<GhContent>> = emptyMap(),
         private val rateLimitedFiles: Set<Triple<String, String, String>> = emptySet(),
+        /** Search-result lookup keyed by a substring match on the
+         *  composed query. First key whose substring is contained in
+         *  the actual query wins. */
+        private val searches: List<Pair<String, GitHubApiResult<`in`.jphe.storyvox.source.github.model.GhSearchResponse>>> = emptyList(),
     ) : GitHubApi(httpClient = OkHttpClient()) {
 
         override suspend fun getRepo(owner: String, repo: String): GitHubApiResult<GhRepo> =
@@ -440,6 +584,21 @@ class GitHubSourceTest {
             return dirs[Triple(owner, repo, path)]
                 ?.let { GitHubApiResult.Success(it, etag = null) }
                 ?: GitHubApiResult.NotFound("dir not found")
+        }
+
+        override suspend fun searchRepositories(
+            query: String,
+            page: Int,
+            perPage: Int,
+        ): GitHubApiResult<`in`.jphe.storyvox.source.github.model.GhSearchResponse> {
+            val match = searches.firstOrNull { (key, _) -> key in query }
+            return match?.second ?: GitHubApiResult.Success(
+                `in`.jphe.storyvox.source.github.model.GhSearchResponse(
+                    totalCount = 0,
+                    items = emptyList(),
+                ),
+                etag = null,
+            )
         }
     }
 

--- a/source-github/src/test/kotlin/in/jphe/storyvox/source/github/model/GitHubModelsTest.kt
+++ b/source-github/src/test/kotlin/in/jphe/storyvox/source/github/model/GitHubModelsTest.kt
@@ -242,4 +242,60 @@ class GitHubModelsTest {
         assertTrue(cmp.commits.isEmpty())
         assertTrue(cmp.files.isEmpty())
     }
+
+    // ─── GhSearchResponse ──────────────────────────────────────────────
+
+    @Test fun `search response deserializes total + items`() {
+        val json = """
+            {
+              "total_count": 2,
+              "incomplete_results": false,
+              "items": [
+                {
+                  "id": 1, "name": "fiction-a", "full_name": "o/fiction-a",
+                  "default_branch": "main",
+                  "owner": { "login": "o" },
+                  "html_url": "https://github.com/o/fiction-a",
+                  "topics": ["fiction"]
+                },
+                {
+                  "id": 2, "name": "fiction-b", "full_name": "p/fiction-b",
+                  "default_branch": "main",
+                  "owner": { "login": "p" },
+                  "html_url": "https://github.com/p/fiction-b"
+                }
+              ]
+            }
+        """.trimIndent()
+
+        val r = GitHubJson.decodeFromString<GhSearchResponse>(json)
+        assertEquals(2, r.totalCount)
+        assertFalse(r.incompleteResults)
+        assertEquals(2, r.items.size)
+        assertEquals("o/fiction-a", r.items[0].fullName)
+        assertEquals(listOf("fiction"), r.items[0].topics)
+    }
+
+    @Test fun `search response with incomplete-results signals partial`() {
+        val r = GitHubJson.decodeFromString<GhSearchResponse>(
+            """{ "total_count": 0, "incomplete_results": true, "items": [] }""",
+        )
+        assertTrue(r.incompleteResults)
+        assertTrue(r.items.isEmpty())
+    }
+
+    @Test fun `search response with omitted incomplete_results defaults to false`() {
+        val r = GitHubJson.decodeFromString<GhSearchResponse>(
+            """{ "total_count": 0, "items": [] }""",
+        )
+        assertFalse(r.incompleteResults)
+    }
+
+    @Test fun `search response with empty items list deserializes`() {
+        val r = GitHubJson.decodeFromString<GhSearchResponse>(
+            """{ "total_count": 0, "incomplete_results": false, "items": [] }""",
+        )
+        assertEquals(0, r.totalCount)
+        assertTrue(r.items.isEmpty())
+    }
 }


### PR DESCRIPTION
## Summary

**Step 8b** — flips `GitHubSource.search()` from `NotImplementedError` to a real `GET /search/repositories?q=topic:fiction+{userQuery}` call. Adds the Search tab back to GitHub's `supportedTabs()` list so the BrowseScreen surfaces a search input on GitHub.

**Visible win**: typing "archmage" in Browse → GitHub → Search now hits GitHub's search API and renders matching topic-tagged repos as fiction cards. `addByUrl` + Browse Popular/NewReleases were the prior discovery surfaces; search rounds out the third.

## What lands

**Source-github**
- `GhSearchResponse` model — `total_count`, `incomplete_results`, `items: List<GhRepo>` reusing the existing repo model.
- `GitHubApi.searchRepositories(query, page, perPage)`. URL-encodes and forwards. `/search/*` has its own 30 req/min unauthenticated rate limit (separate from the 60/hr core limit), so a 300 ms debounced typed-search UX fits well under the cap. Caller composes the topic prefix.
- `GitHubSource.search` composes `(topic:fiction OR topic:fanfiction OR topic:webnovel) {userQuery}` to pin to fiction-shaped repos rather than dredging generic GitHub. Maps each `GhRepo` to `FictionSummary`: id=`github:owner/repo`, title=name, author=owner.login, description=repo.description, tags=topics, status=COMPLETED if archived else ONGOING, coverUrl=null (manifest cover is per-repo content not search metadata; resolved on detail open).
- `hasNext` heuristic: false when items < per_page or page >= 50 (GitHub search caps at 1000 results across all pages).
- RR-shaped `SearchQuery` filter fields are ignored — step 8c adds a GitHub-shaped filter sheet that routes through a different code path.

**Feature**
- `BrowseSourceKey.GitHub.supportedTabs()` re-includes `Search`.
- `BrowseScreen` Search OutlinedTextField parameterized — label derived from `state.sourceKey.displayName` ("Search GitHub" / "Search Royal Road") so future source additions don't churn the screen.

## Test plan

- [x] 7 new `GitHubSourceTest` cases: query composition + result mapping, empty-term still topic-filters, hasNext below/above per-page, NotFound surfaces empty page, RateLimited propagates with retry-after, NetworkError propagates, archived repos map to COMPLETED. The `search still throws NotImplementedError` test removed (invalidated by the new contract).
- [x] 4 new `GitHubModelsTest` cases for `GhSearchResponse`: total + items, incomplete-results signal, omitted-incomplete-results default, empty items list.
- [x] `FakeGitHubApi` test double gains a `searches` substring-keyed lookup; tests drive the search path with fixture responses without real HTTP.
- [x] Module total: **113 tests** (102 carried + 11 new). Pure-JVM, <1s.
- [x] `:app:assembleDebug` clean.
- [x] **Installed on R83W80CAFZB** (tablet lock claimed → install + boot test → released). versionName 0.4.26 confirmed, no logcat fatal/exception.
- [ ] **JP-side smoke test**: open Browse → tap GitHub → Search tab → type "fantasy" → verify topic-prefixed search results render. The `topic:fiction` GitHub topic is well-populated, so live results expected.

## What this unblocks

- **Step 8c**: GitHub-shaped filter sheet — different dimensions per spec lines 203-211 (tags, status, length, last updated, min stars, language, sort). When that lands, the FilterButton re-shows on GitHub and routes through GitHub-shaped query qualifiers (`stars:>10`, `language:en`, `pushed:>2026-01-01`).
- **Step 9** (orthogonal): commit-SHA polling for new chapters.

## Worktree + branch

- Worktree: `.claude/worktrees/selene-github-search`
- Branch: `dream/selene/github-search`