### PR TITLE
feat(browse): GitHub-shaped filter sheet (step 8c)

### DIFF
--- a/app/src/main/kotlin/in/jphe/storyvox/di/AppBindings.kt
+++ b/app/src/main/kotlin/in/jphe/storyvox/di/AppBindings.kt
@@ -260,6 +260,16 @@ private class RealBrowseRepositoryUi(
                     source.filter.toSearchQuery().copy(page = page),
                     sourceId = sourceId,
                 )
+                is BrowseSource.FilteredGitHub -> repo.search(
+                    SearchQuery(
+                        term = `in`.jphe.storyvox.feature.browse.composeGitHubQuery(
+                            term = source.query,
+                            filter = source.filter,
+                        ),
+                        page = page,
+                    ),
+                    sourceId = sourceId,
+                )
             }
         }
 }

--- a/feature/src/main/kotlin/in/jphe/storyvox/feature/api/UiContracts.kt
+++ b/feature/src/main/kotlin/in/jphe/storyvox/feature/api/UiContracts.kt
@@ -103,13 +103,24 @@ interface BrowseRepositoryUi {
 }
 
 /** What kind of listing the paginator should fetch. The repository
- *  adapter maps each variant onto a Royal Road call. */
+ *  adapter maps each variant onto a source call (Royal Road for the
+ *  legacy variants, GitHub for [FilteredGitHub]). */
 sealed interface BrowseSource {
     data object Popular : BrowseSource
     data object NewReleases : BrowseSource
     data object BestRated : BrowseSource
     data class Search(val query: String) : BrowseSource
     data class Filtered(val filter: BrowseFilter) : BrowseSource
+    /**
+     * GitHub-shaped filter routed through `/search/repositories`.
+     * `query` is the user's typed search term (may be blank); the
+     * filter contributes additional GitHub query qualifiers (stars,
+     * language, pushed-since, sort).
+     */
+    data class FilteredGitHub(
+        val query: String,
+        val filter: GitHubSearchFilter,
+    ) : BrowseSource
 }
 
 /** A page-by-page accumulating cursor over a remote fiction listing.
@@ -160,6 +171,32 @@ enum class UiFictionType { All, Original, FanFiction }
 enum class UiContentWarning { Profanity, SexualContent, GraphicViolence, SensitiveContent, AiAssisted, AiGenerated }
 enum class UiSearchOrder { Relevance, Popularity, Rating, LastUpdate, ReleaseDate, Followers, Length, Views, Title }
 enum class UiSortDirection { Asc, Desc }
+
+/**
+ * GitHub-shaped filter for Browse → GitHub. Different dimensions
+ * from [BrowseFilter] because GitHub's `/search/repositories`
+ * qualifiers don't translate to Royal Road's filter form. The
+ * full set per spec (tags, status, length, last-updated, min-stars,
+ * language, sort) is split: this PR (step 8c) lands minStars /
+ * language / pushedSince / sort. Tag-multi-select and status would
+ * be a follow-up if the curated registry grows enough that browsing
+ * stops being good enough.
+ */
+data class GitHubSearchFilter(
+    val minStars: Int? = null,
+    /** ISO 639-1 language code, e.g. `"en"`. Null = no language
+     *  qualifier (GitHub returns repos in any language). */
+    val language: String? = null,
+    val pushedSince: GitHubPushedSince = GitHubPushedSince.Any,
+    val sort: GitHubSort = GitHubSort.BestMatch,
+)
+
+/** GitHub `pushed:>YYYY-MM-DD` cutoffs. `Any` omits the qualifier. */
+enum class GitHubPushedSince { Any, Last7Days, Last30Days, Last90Days, LastYear }
+
+/** GitHub `sort=` axis. `BestMatch` is the API default and omits the
+ *  `sort=` parameter; the others map directly to GitHub's values. */
+enum class GitHubSort { BestMatch, Stars, Updated }
 
 data class UiPlaybackState(
     val fictionId: String?,

--- a/feature/src/main/kotlin/in/jphe/storyvox/feature/browse/BrowseScreen.kt
+++ b/feature/src/main/kotlin/in/jphe/storyvox/feature/browse/BrowseScreen.kt
@@ -96,15 +96,17 @@ fun BrowseScreen(
                     )
                 }
             }
-            // Filter sheet is RR-shaped (its dimensions don't yet
-            // translate to GitHub registry entries) so hide on GitHub.
-            // Step 8b will introduce a GitHub-shaped filter sheet.
-            if (state.sourceKey == BrowseSourceKey.RoyalRoad) {
-                FilterButton(
-                    activeCount = state.filter.activeCount(),
-                    onClick = { showFilterSheet = true },
-                )
-            }
+            // Filter sheet is per-source: RR has its `/fictions/search`
+            // form, GitHub has the `/search/repositories` qualifier set.
+            // Both surface through the same FilterButton; the badge
+            // count and the sheet that opens both branch on sourceKey.
+            FilterButton(
+                activeCount = when (state.sourceKey) {
+                    BrowseSourceKey.RoyalRoad -> state.filter.activeCount()
+                    BrowseSourceKey.GitHub -> state.githubFilter.activeCount()
+                },
+                onClick = { showFilterSheet = true },
+            )
         }
 
         if (state.tab == BrowseTab.Search) {
@@ -243,18 +245,32 @@ fun BrowseScreen(
     }
 
     if (showFilterSheet) {
-        BrowseFilterSheet(
-            filter = state.filter,
-            onApply = { applied ->
-                viewModel.setFilter(applied)
-                showFilterSheet = false
-            },
-            onReset = {
-                viewModel.resetFilter()
-                showFilterSheet = false
-            },
-            onDismiss = { showFilterSheet = false },
-        )
+        when (state.sourceKey) {
+            BrowseSourceKey.RoyalRoad -> BrowseFilterSheet(
+                filter = state.filter,
+                onApply = { applied ->
+                    viewModel.setFilter(applied)
+                    showFilterSheet = false
+                },
+                onReset = {
+                    viewModel.resetFilter()
+                    showFilterSheet = false
+                },
+                onDismiss = { showFilterSheet = false },
+            )
+            BrowseSourceKey.GitHub -> GitHubFilterSheet(
+                filter = state.githubFilter,
+                onApply = { applied ->
+                    viewModel.setGitHubFilter(applied)
+                    showFilterSheet = false
+                },
+                onReset = {
+                    viewModel.resetGitHubFilter()
+                    showFilterSheet = false
+                },
+                onDismiss = { showFilterSheet = false },
+            )
+        }
     }
 }
 

--- a/feature/src/main/kotlin/in/jphe/storyvox/feature/browse/BrowseViewModel.kt
+++ b/feature/src/main/kotlin/in/jphe/storyvox/feature/browse/BrowseViewModel.kt
@@ -9,6 +9,7 @@ import `in`.jphe.storyvox.feature.api.BrowseFilter
 import `in`.jphe.storyvox.feature.api.BrowsePaginator
 import `in`.jphe.storyvox.feature.api.BrowseRepositoryUi
 import `in`.jphe.storyvox.feature.api.BrowseSource
+import `in`.jphe.storyvox.feature.api.GitHubSearchFilter
 import `in`.jphe.storyvox.feature.api.UiFiction
 import `in`.jphe.storyvox.feature.api.UiSearchOrder
 import `in`.jphe.storyvox.feature.api.UiSortDirection
@@ -83,6 +84,12 @@ data class BrowseUiState(
     val error: String? = null,
     val filter: BrowseFilter = BrowseFilter(),
     val isFilterActive: Boolean = false,
+    /** GitHub-shaped filter — applied when sourceKey is GitHub. RR-source
+     *  filter ([filter]) and GitHub filter coexist in state so flipping
+     *  between sources doesn't lose either side's settings (subject to
+     *  the [BrowseViewModel.selectSource] reset policy). */
+    val githubFilter: GitHubSearchFilter = GitHubSearchFilter(),
+    val isGitHubFilterActive: Boolean = false,
 )
 
 /** Typed view of a paginator's five state flows. Lifted into its own
@@ -94,6 +101,18 @@ private data class PaginatorView(
     val isAppending: Boolean,
     val hasMore: Boolean,
     val error: String?,
+)
+
+/** Bundled view of the user-controllable knobs (source picker, tab,
+ *  query, RR filter, GitHub filter). Lifted into its own record so the
+ *  outer combines stay within the 5-arg `combine` overload as we add
+ *  filter shapes per source. */
+private data class ControlsView(
+    val sourceKey: BrowseSourceKey,
+    val tab: BrowseTab,
+    val query: String,
+    val filter: BrowseFilter,
+    val githubFilter: GitHubSearchFilter,
 )
 
 /**
@@ -119,6 +138,7 @@ class BrowseViewModel @Inject constructor(
     private val _tab = MutableStateFlow(BrowseTab.Popular)
     private val _query = MutableStateFlow("")
     private val _filter = MutableStateFlow(BrowseFilter())
+    private val _githubFilter = MutableStateFlow(GitHubSearchFilter())
     val query: StateFlow<String> = _query.asStateFlow()
 
     /** Active paginator for the current tuple; null when the search tab
@@ -129,8 +149,9 @@ class BrowseViewModel @Inject constructor(
         _tab,
         _query.debounce(300),
         _filter,
-    ) { sourceKey, tab, q, filter ->
-        resolveSource(tab, q, filter)?.let { source -> source to sourceKey.sourceId }
+        _githubFilter,
+    ) { sourceKey, tab, q, filter, ghFilter ->
+        resolveSource(sourceKey, tab, q, filter, ghFilter)?.let { source -> source to sourceKey.sourceId }
     }
         .distinctUntilChanged()
         .map { pair -> pair?.let { (source, sourceId) -> repo.paginator(source, sourceId) } }
@@ -147,30 +168,39 @@ class BrowseViewModel @Inject constructor(
         }
     }
 
+    /** All user-controlled knobs collapsed into one typed record so the
+     *  outer combines below stay within the 5-arg `combine` overload. */
+    private val controls: kotlinx.coroutines.flow.Flow<ControlsView> = combine(
+        _sourceKey, _tab, _query, _filter, _githubFilter,
+    ) { sourceKey, tab, q, filter, ghFilter ->
+        ControlsView(sourceKey, tab, q, filter, ghFilter)
+    }
+
     val uiState: StateFlow<BrowseUiState> = paginator.flatMapLatest { p ->
         if (p == null) {
             // Empty-search/no-filter: surface a quiet idle state so the
             // screen renders SearchHint rather than the skeleton grid.
-            combine(_sourceKey, _tab, _query, _filter) { sourceKey, tab, q, filter ->
+            controls.map { c ->
                 BrowseUiState(
-                    sourceKey = sourceKey,
-                    tab = tab,
-                    query = q,
+                    sourceKey = c.sourceKey,
+                    tab = c.tab,
+                    query = c.query,
                     items = emptyList(),
                     isLoading = false,
                     isAppending = false,
                     hasMore = false,
                     error = null,
-                    filter = filter,
-                    isFilterActive = filter.isActive(),
+                    filter = c.filter,
+                    isFilterActive = c.filter.isActive(),
+                    githubFilter = c.githubFilter,
+                    isGitHubFilterActive = c.githubFilter.isActive(),
                 )
             }
         } else {
             // Two-step combine: first collapse the paginator's five
             // flows into a typed [PaginatorView], then merge with the
-            // sourceKey/tab/query/filter quartet. Keeps each combine
-            // within the 5-arg comfort zone and avoids positional
-            // `vals[i]` casts.
+            // [ControlsView]. Keeps each combine within the 5-arg
+            // comfort zone and avoids positional `vals[i]` casts.
             val paginatorView = combine(
                 p.items,
                 p.isLoading,
@@ -180,19 +210,20 @@ class BrowseViewModel @Inject constructor(
             ) { items, loading, appending, more, error ->
                 PaginatorView(items, loading, appending, more, error)
             }
-            combine(paginatorView, _sourceKey, _tab, _query, _filter) {
-                view, sourceKey, tab, q, filter ->
+            combine(paginatorView, controls) { view, c ->
                 BrowseUiState(
-                    sourceKey = sourceKey,
-                    tab = tab,
-                    query = q,
+                    sourceKey = c.sourceKey,
+                    tab = c.tab,
+                    query = c.query,
                     items = view.items,
                     isLoading = view.isLoading,
                     isAppending = view.isAppending,
                     hasMore = view.hasMore,
                     error = view.error,
-                    filter = filter,
-                    isFilterActive = filter.isActive(),
+                    filter = c.filter,
+                    isFilterActive = c.filter.isActive(),
+                    githubFilter = c.githubFilter,
+                    isGitHubFilterActive = c.githubFilter.isActive(),
                 )
             }
         }
@@ -204,14 +235,19 @@ class BrowseViewModel @Inject constructor(
         // If the previously-selected tab isn't supported on the new
         // source (e.g. user was on BestRated/Search on RR and switches
         // to GitHub), snap to Popular so the screen has something
-        // sensible to render. Filters are RR-shaped and don't apply
-        // to GitHub yet, so reset them too.
+        // sensible to render.
         if (_tab.value !in key.supportedTabs()) {
             _tab.value = BrowseTab.Popular
         }
-        if (key == BrowseSourceKey.GitHub) {
-            _filter.value = BrowseFilter()
-            _query.value = ""
+        // Per-source filter shapes don't translate, so clear the
+        // *other* source's filter on switch. Symmetrical: leaving
+        // GitHub clears the GH filter; leaving RR clears the RR
+        // filter. Always clear the query so a half-typed term doesn't
+        // leak across sources.
+        _query.value = ""
+        when (key) {
+            BrowseSourceKey.RoyalRoad -> _githubFilter.value = GitHubSearchFilter()
+            BrowseSourceKey.GitHub -> _filter.value = BrowseFilter()
         }
     }
 
@@ -219,6 +255,8 @@ class BrowseViewModel @Inject constructor(
     fun setQuery(q: String) { _query.value = q }
     fun setFilter(filter: BrowseFilter) { _filter.value = filter }
     fun resetFilter() { _filter.value = BrowseFilter() }
+    fun setGitHubFilter(filter: GitHubSearchFilter) { _githubFilter.value = filter }
+    fun resetGitHubFilter() { _githubFilter.value = GitHubSearchFilter() }
 
     /** Called by the grid when the user nears the end of the visible
      *  list. Idempotent — the paginator's mutex collapses concurrent
@@ -228,15 +266,38 @@ class BrowseViewModel @Inject constructor(
     }
 }
 
-private fun resolveSource(tab: BrowseTab, q: String, filter: BrowseFilter): BrowseSource? = when {
-    filter.isActive() -> BrowseSource.Filtered(
-        if (tab == BrowseTab.Search && q.isNotBlank()) filter.copy(term = q) else filter,
-    )
-    tab == BrowseTab.Popular -> BrowseSource.Popular
-    tab == BrowseTab.NewReleases -> BrowseSource.NewReleases
-    tab == BrowseTab.BestRated -> BrowseSource.BestRated
-    tab == BrowseTab.Search -> if (q.isBlank()) null else BrowseSource.Search(q)
-    else -> null
+private fun resolveSource(
+    sourceKey: BrowseSourceKey,
+    tab: BrowseTab,
+    q: String,
+    filter: BrowseFilter,
+    githubFilter: GitHubSearchFilter,
+): BrowseSource? = when (sourceKey) {
+    // GitHub: filter takes priority over tab. When filter is active OR
+    // user is on Search with a typed query, route to FilteredGitHub so
+    // the qualifier-laden query lands. Otherwise the tab decides
+    // (Popular/NewReleases/Search). Search-with-blank-query stays null
+    // so the screen renders SearchHint.
+    BrowseSourceKey.GitHub -> when {
+        githubFilter.isActive() -> BrowseSource.FilteredGitHub(
+            query = if (tab == BrowseTab.Search) q else "",
+            filter = githubFilter,
+        )
+        tab == BrowseTab.Popular -> BrowseSource.Popular
+        tab == BrowseTab.NewReleases -> BrowseSource.NewReleases
+        tab == BrowseTab.Search -> if (q.isBlank()) null else BrowseSource.Search(q)
+        else -> null
+    }
+    BrowseSourceKey.RoyalRoad -> when {
+        filter.isActive() -> BrowseSource.Filtered(
+            if (tab == BrowseTab.Search && q.isNotBlank()) filter.copy(term = q) else filter,
+        )
+        tab == BrowseTab.Popular -> BrowseSource.Popular
+        tab == BrowseTab.NewReleases -> BrowseSource.NewReleases
+        tab == BrowseTab.BestRated -> BrowseSource.BestRated
+        tab == BrowseTab.Search -> if (q.isBlank()) null else BrowseSource.Search(q)
+        else -> null
+    }
 }
 
 private fun BrowseFilter.isActive(): Boolean =

--- a/feature/src/main/kotlin/in/jphe/storyvox/feature/browse/GitHubFilterQuery.kt
+++ b/feature/src/main/kotlin/in/jphe/storyvox/feature/browse/GitHubFilterQuery.kt
@@ -1,0 +1,93 @@
+package `in`.jphe.storyvox.feature.browse
+
+import `in`.jphe.storyvox.feature.api.GitHubPushedSince
+import `in`.jphe.storyvox.feature.api.GitHubSearchFilter
+import `in`.jphe.storyvox.feature.api.GitHubSort
+import java.time.LocalDate
+import java.time.format.DateTimeFormatter
+
+/**
+ * Compose a [GitHubSearchFilter] + free-text term into the qualifier-
+ * laden string GitHub's `/search/repositories?q=...` consumes.
+ *
+ * The `topic:fiction OR topic:fanfiction OR topic:webnovel` prefix
+ * that pins results to fiction-shaped repos is added by
+ * `GitHubSource.search()` lower in the stack — this function only
+ * produces the *user-controllable* part of the query (term + filter
+ * qualifiers). `GitHubSource.search()` skips its own topic prefix
+ * when this layer has already added one (see the `topic:` check
+ * there); we don't add a topic here unless the user asks for it.
+ *
+ * Spec lines 199-211. Today's lands: minStars, language, pushedSince,
+ * sort. Tag-multi-select and status are deferred to a follow-up; they
+ * map onto GitHub's `topic:` and `archived:` qualifiers when added.
+ *
+ * Format examples:
+ *  - empty filter, term="archmage" → `"archmage"`
+ *  - empty term, minStars=10, language="en" → `"stars:>=10 language:en"`
+ *  - term="dragon", pushedSince=Last30Days, sort=Stars (today=2026-05-08) →
+ *    `"dragon pushed:>=2026-04-08 sort:stars"`
+ */
+fun composeGitHubQuery(
+    term: String,
+    filter: GitHubSearchFilter,
+    today: LocalDate = LocalDate.now(),
+): String = buildString {
+    val cleanTerm = term.trim()
+    if (cleanTerm.isNotEmpty()) append(cleanTerm)
+
+    filter.minStars?.let { stars ->
+        if (stars > 0) {
+            if (isNotEmpty()) append(' ')
+            append("stars:>=").append(stars)
+        }
+    }
+
+    filter.language?.takeIf { it.isNotBlank() }?.let { lang ->
+        if (isNotEmpty()) append(' ')
+        append("language:").append(lang.lowercase())
+    }
+
+    filter.pushedSince.toCutoffDate(today)?.let { cutoff ->
+        if (isNotEmpty()) append(' ')
+        append("pushed:>=").append(ISO_DATE.format(cutoff))
+    }
+
+    filter.sort.toQualifier()?.let { sortQ ->
+        if (isNotEmpty()) append(' ')
+        append(sortQ)
+    }
+}
+
+/** True when [filter] has any non-default knob set. Drives the
+ *  filter-button badge on Browse → GitHub. */
+fun GitHubSearchFilter.isActive(): Boolean =
+    (minStars != null && minStars > 0) ||
+        !language.isNullOrBlank() ||
+        pushedSince != GitHubPushedSince.Any ||
+        sort != GitHubSort.BestMatch
+
+fun GitHubSearchFilter.activeCount(): Int {
+    var n = 0
+    if (minStars != null && minStars > 0) n++
+    if (!language.isNullOrBlank()) n++
+    if (pushedSince != GitHubPushedSince.Any) n++
+    if (sort != GitHubSort.BestMatch) n++
+    return n
+}
+
+private fun GitHubPushedSince.toCutoffDate(today: LocalDate): LocalDate? = when (this) {
+    GitHubPushedSince.Any -> null
+    GitHubPushedSince.Last7Days -> today.minusDays(7)
+    GitHubPushedSince.Last30Days -> today.minusDays(30)
+    GitHubPushedSince.Last90Days -> today.minusDays(90)
+    GitHubPushedSince.LastYear -> today.minusYears(1)
+}
+
+private fun GitHubSort.toQualifier(): String? = when (this) {
+    GitHubSort.BestMatch -> null // API default — no qualifier needed
+    GitHubSort.Stars -> "sort:stars"
+    GitHubSort.Updated -> "sort:updated"
+}
+
+private val ISO_DATE: DateTimeFormatter = DateTimeFormatter.ISO_LOCAL_DATE

--- a/feature/src/main/kotlin/in/jphe/storyvox/feature/browse/GitHubFilterSheet.kt
+++ b/feature/src/main/kotlin/in/jphe/storyvox/feature/browse/GitHubFilterSheet.kt
@@ -1,0 +1,237 @@
+package `in`.jphe.storyvox.feature.browse
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material3.Button
+import androidx.compose.material3.DropdownMenuItem
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.ExposedDropdownMenuBox
+import androidx.compose.material3.ExposedDropdownMenuDefaults
+import androidx.compose.material3.HorizontalDivider
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.MenuAnchorType
+import androidx.compose.material3.ModalBottomSheet
+import androidx.compose.material3.OutlinedButton
+import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.Slider
+import androidx.compose.material3.Text
+import androidx.compose.material3.rememberModalBottomSheetState
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import `in`.jphe.storyvox.feature.api.GitHubPushedSince
+import `in`.jphe.storyvox.feature.api.GitHubSearchFilter
+import `in`.jphe.storyvox.feature.api.GitHubSort
+import `in`.jphe.storyvox.ui.theme.LocalSpacing
+
+/**
+ * GitHub-shaped filter bottom sheet. Mirrors the qualifier set
+ * `GitHubFilterQuery.composeGitHubQuery` consumes: minStars, language,
+ * pushedSince, sort. Local state buffers the user's tweaks until they
+ * tap Apply so each chip toggle doesn't fire a `/search/repositories`
+ * call.
+ */
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun GitHubFilterSheet(
+    filter: GitHubSearchFilter,
+    onApply: (GitHubSearchFilter) -> Unit,
+    onReset: () -> Unit,
+    onDismiss: () -> Unit,
+) {
+    val sheetState = rememberModalBottomSheetState(skipPartiallyExpanded = true)
+    val spacing = LocalSpacing.current
+    var local by remember { mutableStateOf(filter) }
+
+    ModalBottomSheet(
+        onDismissRequest = onDismiss,
+        sheetState = sheetState,
+    ) {
+        Column(
+            modifier = Modifier
+                .fillMaxWidth()
+                .verticalScroll(rememberScrollState())
+                .padding(horizontal = spacing.md)
+                .padding(bottom = spacing.xl),
+            verticalArrangement = Arrangement.spacedBy(spacing.md),
+        ) {
+            Text(
+                "Filter GitHub",
+                style = MaterialTheme.typography.titleLarge,
+                modifier = Modifier.padding(top = spacing.sm),
+            )
+
+            // Minimum stars — slider 0..500. Discrete steps every 10.
+            // Above 500 is uncommon for fiction repos and would mask
+            // smaller-but-relevant repos. User who wants exact control
+            // can supply a precise GitHub URL via the add-by-URL sheet.
+            SectionLabel("Minimum stars: ${local.minStars ?: 0}")
+            Slider(
+                value = (local.minStars ?: 0).toFloat(),
+                onValueChange = { v ->
+                    val n = v.toInt()
+                    local = local.copy(minStars = n.takeIf { it > 0 })
+                },
+                valueRange = 0f..STARS_MAX,
+                steps = STARS_STEPS,
+            )
+
+            HorizontalDivider()
+
+            // Language — free-text ISO-639-1 (en, fr, ja, ...). GitHub
+            // accepts the human label too ("English") but the code is
+            // less ambiguous. Empty = no language qualifier.
+            SectionLabel("Language (ISO code, e.g. en, ja)")
+            OutlinedTextField(
+                value = local.language.orEmpty(),
+                onValueChange = { v ->
+                    local = local.copy(language = v.trim().takeIf { it.isNotEmpty() })
+                },
+                placeholder = { Text("e.g. en") },
+                singleLine = true,
+                modifier = Modifier.fillMaxWidth(),
+            )
+
+            HorizontalDivider()
+
+            SectionLabel("Last pushed")
+            PushedSinceDropdown(
+                value = local.pushedSince,
+                onChange = { local = local.copy(pushedSince = it) },
+            )
+
+            HorizontalDivider()
+
+            SectionLabel("Sort by")
+            SortDropdown(
+                value = local.sort,
+                onChange = { local = local.copy(sort = it) },
+            )
+
+            // Apply / Reset buttons
+            Row(
+                modifier = Modifier.fillMaxWidth().padding(top = spacing.md),
+                horizontalArrangement = Arrangement.spacedBy(spacing.sm),
+            ) {
+                OutlinedButton(
+                    onClick = onReset,
+                    modifier = Modifier.weight(1f),
+                ) { Text("Reset") }
+                Button(
+                    onClick = { onApply(local) },
+                    modifier = Modifier.weight(2f),
+                ) { Text("Apply") }
+            }
+        }
+    }
+}
+
+@Composable
+private fun SectionLabel(text: String) {
+    Text(
+        text,
+        style = MaterialTheme.typography.titleSmall,
+        color = MaterialTheme.colorScheme.onSurfaceVariant,
+    )
+}
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+private fun PushedSinceDropdown(
+    value: GitHubPushedSince,
+    onChange: (GitHubPushedSince) -> Unit,
+) {
+    var expanded by remember { mutableStateOf(false) }
+    ExposedDropdownMenuBox(
+        expanded = expanded,
+        onExpandedChange = { expanded = it },
+    ) {
+        OutlinedTextField(
+            value = value.label,
+            onValueChange = {},
+            readOnly = true,
+            trailingIcon = { ExposedDropdownMenuDefaults.TrailingIcon(expanded = expanded) },
+            modifier = Modifier
+                .menuAnchor(MenuAnchorType.PrimaryNotEditable)
+                .fillMaxWidth(),
+        )
+        ExposedDropdownMenu(
+            expanded = expanded,
+            onDismissRequest = { expanded = false },
+        ) {
+            GitHubPushedSince.entries.forEach { option ->
+                DropdownMenuItem(
+                    text = { Text(option.label) },
+                    onClick = {
+                        onChange(option)
+                        expanded = false
+                    },
+                )
+            }
+        }
+    }
+}
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+private fun SortDropdown(
+    value: GitHubSort,
+    onChange: (GitHubSort) -> Unit,
+) {
+    var expanded by remember { mutableStateOf(false) }
+    ExposedDropdownMenuBox(
+        expanded = expanded,
+        onExpandedChange = { expanded = it },
+    ) {
+        OutlinedTextField(
+            value = value.label,
+            onValueChange = {},
+            readOnly = true,
+            trailingIcon = { ExposedDropdownMenuDefaults.TrailingIcon(expanded = expanded) },
+            modifier = Modifier
+                .menuAnchor(MenuAnchorType.PrimaryNotEditable)
+                .fillMaxWidth(),
+        )
+        ExposedDropdownMenu(
+            expanded = expanded,
+            onDismissRequest = { expanded = false },
+        ) {
+            GitHubSort.entries.forEach { option ->
+                DropdownMenuItem(
+                    text = { Text(option.label) },
+                    onClick = {
+                        onChange(option)
+                        expanded = false
+                    },
+                )
+            }
+        }
+    }
+}
+
+private const val STARS_MAX = 500f
+private const val STARS_STEPS = 49 // every 10 stars in 0..500
+
+private val GitHubPushedSince.label: String
+    get() = when (this) {
+        GitHubPushedSince.Any -> "Any time"
+        GitHubPushedSince.Last7Days -> "Last 7 days"
+        GitHubPushedSince.Last30Days -> "Last 30 days"
+        GitHubPushedSince.Last90Days -> "Last 90 days"
+        GitHubPushedSince.LastYear -> "Last year"
+    }
+
+private val GitHubSort.label: String
+    get() = when (this) {
+        GitHubSort.BestMatch -> "Best match"
+        GitHubSort.Stars -> "Stars"
+        GitHubSort.Updated -> "Recently updated"
+    }

--- a/feature/src/test/kotlin/in/jphe/storyvox/feature/browse/GitHubFilterQueryTest.kt
+++ b/feature/src/test/kotlin/in/jphe/storyvox/feature/browse/GitHubFilterQueryTest.kt
@@ -1,0 +1,178 @@
+package `in`.jphe.storyvox.feature.browse
+
+import `in`.jphe.storyvox.feature.api.GitHubPushedSince
+import `in`.jphe.storyvox.feature.api.GitHubSearchFilter
+import `in`.jphe.storyvox.feature.api.GitHubSort
+import java.time.LocalDate
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class GitHubFilterQueryTest {
+
+    private val today = LocalDate.of(2026, 5, 8)
+    private val empty = GitHubSearchFilter()
+
+    // -- composeGitHubQuery ------------------------------------------------------
+
+    @Test fun `empty filter and blank term yields empty string`() {
+        assertEquals("", composeGitHubQuery("", empty, today))
+    }
+
+    @Test fun `term only is trimmed and returned verbatim`() {
+        assertEquals("archmage", composeGitHubQuery("  archmage  ", empty, today))
+    }
+
+    @Test fun `minStars zero is omitted`() {
+        assertEquals("", composeGitHubQuery("", empty.copy(minStars = 0), today))
+    }
+
+    @Test fun `minStars negative is omitted`() {
+        // Defensive — UI never sets a negative value but the helper
+        // shouldn't emit `stars:>=-5` if it ever does.
+        assertEquals("", composeGitHubQuery("", empty.copy(minStars = -5), today))
+    }
+
+    @Test fun `minStars positive emits qualifier`() {
+        assertEquals(
+            "stars:>=10",
+            composeGitHubQuery("", empty.copy(minStars = 10), today),
+        )
+    }
+
+    @Test fun `language is lowercased`() {
+        assertEquals(
+            "language:en",
+            composeGitHubQuery("", empty.copy(language = "EN"), today),
+        )
+    }
+
+    @Test fun `blank language is omitted`() {
+        assertEquals("", composeGitHubQuery("", empty.copy(language = "   "), today))
+    }
+
+    @Test fun `pushedSince Last30Days emits ISO cutoff date`() {
+        assertEquals(
+            "pushed:>=2026-04-08",
+            composeGitHubQuery("", empty.copy(pushedSince = GitHubPushedSince.Last30Days), today),
+        )
+    }
+
+    @Test fun `pushedSince Any omits qualifier`() {
+        assertEquals(
+            "",
+            composeGitHubQuery("", empty.copy(pushedSince = GitHubPushedSince.Any), today),
+        )
+    }
+
+    @Test fun `sort BestMatch omits qualifier`() {
+        assertEquals(
+            "",
+            composeGitHubQuery("", empty.copy(sort = GitHubSort.BestMatch), today),
+        )
+    }
+
+    @Test fun `sort Stars emits qualifier`() {
+        assertEquals(
+            "sort:stars",
+            composeGitHubQuery("", empty.copy(sort = GitHubSort.Stars), today),
+        )
+    }
+
+    @Test fun `sort Updated emits qualifier`() {
+        assertEquals(
+            "sort:updated",
+            composeGitHubQuery("", empty.copy(sort = GitHubSort.Updated), today),
+        )
+    }
+
+    @Test fun `combined term and all qualifiers space-separated in expected order`() {
+        val filter = GitHubSearchFilter(
+            minStars = 100,
+            language = "en",
+            pushedSince = GitHubPushedSince.Last90Days,
+            sort = GitHubSort.Stars,
+        )
+        assertEquals(
+            "dragon stars:>=100 language:en pushed:>=2026-02-07 sort:stars",
+            composeGitHubQuery("dragon", filter, today),
+        )
+    }
+
+    @Test fun `qualifiers are space-separated when term is blank`() {
+        val filter = GitHubSearchFilter(
+            minStars = 50,
+            sort = GitHubSort.Updated,
+        )
+        assertEquals(
+            "stars:>=50 sort:updated",
+            composeGitHubQuery("", filter, today),
+        )
+    }
+
+    @Test fun `Last7Days uses minus-7 cutoff`() {
+        assertEquals(
+            "pushed:>=2026-05-01",
+            composeGitHubQuery("", empty.copy(pushedSince = GitHubPushedSince.Last7Days), today),
+        )
+    }
+
+    @Test fun `LastYear uses minus-1-year cutoff`() {
+        assertEquals(
+            "pushed:>=2025-05-08",
+            composeGitHubQuery("", empty.copy(pushedSince = GitHubPushedSince.LastYear), today),
+        )
+    }
+
+    // -- isActive ----------------------------------------------------------------
+
+    @Test fun `default filter is not active`() {
+        assertFalse(empty.isActive())
+    }
+
+    @Test fun `minStars zero is not active`() {
+        assertFalse(empty.copy(minStars = 0).isActive())
+    }
+
+    @Test fun `minStars positive is active`() {
+        assertTrue(empty.copy(minStars = 1).isActive())
+    }
+
+    @Test fun `non-blank language is active`() {
+        assertTrue(empty.copy(language = "en").isActive())
+    }
+
+    @Test fun `blank language is not active`() {
+        assertFalse(empty.copy(language = "  ").isActive())
+    }
+
+    @Test fun `non-default pushedSince is active`() {
+        assertTrue(empty.copy(pushedSince = GitHubPushedSince.Last30Days).isActive())
+    }
+
+    @Test fun `non-default sort is active`() {
+        assertTrue(empty.copy(sort = GitHubSort.Stars).isActive())
+    }
+
+    // -- activeCount -------------------------------------------------------------
+
+    @Test fun `default activeCount is 0`() {
+        assertEquals(0, empty.activeCount())
+    }
+
+    @Test fun `each set knob increments activeCount by 1`() {
+        val filter = GitHubSearchFilter(
+            minStars = 5,
+            language = "en",
+            pushedSince = GitHubPushedSince.Last7Days,
+            sort = GitHubSort.Updated,
+        )
+        assertEquals(4, filter.activeCount())
+    }
+
+    @Test fun `partial filter counts only set knobs`() {
+        assertEquals(1, empty.copy(minStars = 5).activeCount())
+        assertEquals(2, empty.copy(minStars = 5, language = "en").activeCount())
+    }
+}

--- a/source-github/src/main/kotlin/in/jphe/storyvox/source/github/GitHubSource.kt
+++ b/source-github/src/main/kotlin/in/jphe/storyvox/source/github/GitHubSource.kt
@@ -97,15 +97,22 @@ internal class GitHubSource @Inject constructor(
         // OR topic:b` — covers a few synonym tags at once. RR-shaped
         // SearchQuery filter fields (genres, tags, statuses,
         // requireWarnings, etc.) don't translate to GitHub today and
-        // are ignored; the GitHub-shaped filter sheet from step 8c
-        // will route through a different code path.
+        // are ignored.
+        //
+        // The GitHub filter sheet (step 8c) composes its own
+        // qualifier-laden query (stars:, language:, pushed:, sort:,
+        // and possibly its own topic:) and stuffs it into
+        // SearchQuery.term. Skip our default topic prefix when the
+        // term already contains a `topic:` qualifier so we don't
+        // double-up — the filter layer is more authoritative when
+        // it's chosen to override.
         val term = query.term.trim()
         val gh = buildString {
-            append("(topic:fiction OR topic:fanfiction OR topic:webnovel)")
-            if (term.isNotEmpty()) {
-                append(' ')
-                append(term)
+            if (!term.contains("topic:", ignoreCase = true)) {
+                append("(topic:fiction OR topic:fanfiction OR topic:webnovel)")
+                if (term.isNotEmpty()) append(' ')
             }
+            if (term.isNotEmpty()) append(term)
         }
 
         return when (val r = api.searchRepositories(gh, page = query.page)) {


### PR DESCRIPTION
## Summary

Lands step 8c of the GitHub-source spec ([docs/superpowers/specs/2026-05-06-github-source-design.md](../blob/main/docs/superpowers/specs/2026-05-06-github-source-design.md), lines 199-211): a GitHub-shaped filter sheet that mirrors `/search/repositories` qualifiers and lets the user pin Browse → GitHub to filtered listings.

- New `GitHubSearchFilter` (minStars / language / pushedSince / sort) in `feature/api`, with `GitHubPushedSince` + `GitHubSort` enums.
- `composeGitHubQuery()` (pure JVM) builds the qualifier-laden `q=...` string. `GitHubSource.search()` detects when the caller already added a `topic:` qualifier and skips its own topic-prefix in that case so the filter takes authority.
- New `BrowseSource.FilteredGitHub` variant routed by `RealBrowseRepositoryUi` to the GitHub source.
- `BrowseViewModel` now carries both filter shapes (RR + GH). They coexist in state; switching source key clears the *other* shape so a half-set GH filter doesn't leak to RR (and vice versa).
- New `GitHubFilterSheet` composable (slider for minStars 0..500, ISO-code language field, "Last pushed" + "Sort by" dropdowns, Reset / Apply).
- `BrowseScreen` shows the FilterButton on both sources and branches the sheet open by sourceKey.

Tag-multi-select and status are still deferred (would map onto `topic:` and `archived:` qualifiers); per the spec, only landed if the curated registry stops being good enough — not yet.

## Test plan

- [x] `:feature:testDebugUnitTest` — 24 new tests for `composeGitHubQuery` + `isActive` + `activeCount`, all green; full feature unit test pass.
- [x] `./gradlew test` — full repo unit test suite passes.
- [x] `:app:assembleDebug` — clean.
- [x] Tablet smoke test on R83W80CAFZB:
  - Browse → GitHub → Filter icon visible.
  - Tap → "Filter GitHub" sheet opens with minStars slider, language ISO field, "Last pushed" + "Sort by" dropdowns.
  - Slide minStars to 130, choose Sort by Stars, tap Apply → badge `2` appears on filter icon.
  - Switch to Royal Road → no badge (RR filter empty), RR tabs (Best Rated visible).
  - Switch back to GitHub → no badge (GH filter cleared by source-flip).
  - No crashes in logcat.

🤖 Generated with [Claude Code](https://claude.com/claude-code)