### PR TITLE
feat(playback): PcmSource extraction + pause-buffer-resume on underrun

### DIFF
--- a/app/src/main/kotlin/in/jphe/storyvox/di/AppBindings.kt
+++ b/app/src/main/kotlin/in/jphe/storyvox/di/AppBindings.kt
@@ -528,6 +528,7 @@ private class RealPlaybackControllerUi(
             fictionTitle = bookTitle.orEmpty(),
             coverUrl = coverUri,
             isPlaying = isPlaying,
+            isBuffering = isBuffering,
             positionMs = positionMs,
             durationMs = durationEstimateMs,
             sentenceStart = sentence?.startCharInChapter ?: 0,

--- a/core-playback/src/main/kotlin/in/jphe/storyvox/playback/PlaybackState.kt
+++ b/core-playback/src/main/kotlin/in/jphe/storyvox/playback/PlaybackState.kt
@@ -9,6 +9,11 @@ data class PlaybackState(
     val charOffset: Int = 0,
     val durationEstimateMs: Long = 0L,
     val isPlaying: Boolean = false,
+    /** True when the AudioTrack is paused waiting for the producer to
+     *  refill the queue past the underrun threshold. UI surfaces a
+     *  "Buffering..." spinner; differs from `!isPlaying` (user pause)
+     *  and from `isPlaying && sentenceEnd == 0` (initial voice warm-up). */
+    val isBuffering: Boolean = false,
     val currentSentenceRange: SentenceRange? = null,
     val voiceId: String? = null,
     val speed: Float = 1.0f,

--- a/core-playback/src/main/kotlin/in/jphe/storyvox/playback/tts/EnginePlayer.kt
+++ b/core-playback/src/main/kotlin/in/jphe/storyvox/playback/tts/EnginePlayer.kt
@@ -32,14 +32,14 @@ import `in`.jphe.storyvox.playback.SPEED_BASELINE_CHARS_PER_SECOND
 import `in`.jphe.storyvox.playback.SentenceRange
 import `in`.jphe.storyvox.playback.SleepTimer
 import `in`.jphe.storyvox.playback.TtsVolumeRamp
+import `in`.jphe.storyvox.playback.tts.source.EngineStreamingSource
+import `in`.jphe.storyvox.playback.tts.source.PcmSource
 import `in`.jphe.storyvox.playback.voice.EngineType
 import `in`.jphe.storyvox.playback.voice.VoiceManager
 import java.io.File
-import java.util.concurrent.LinkedBlockingQueue
 import java.util.concurrent.atomic.AtomicBoolean
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.Job
 import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.cancel
 import kotlinx.coroutines.flow.MutableSharedFlow
@@ -52,7 +52,7 @@ import kotlinx.coroutines.flow.filterNotNull
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
-import kotlinx.coroutines.runInterruptible
+import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
 import kotlinx.coroutines.withContext
@@ -101,7 +101,6 @@ class EnginePlayer @AssistedInject constructor(
     }
 
     private val scope = CoroutineScope(SupervisorJob() + Dispatchers.Main)
-    private val ioScope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
 
     private var sentences: List<Sentence> = emptyList()
     private var currentSentenceIndex: Int = 0
@@ -186,20 +185,10 @@ class EnginePlayer @AssistedInject constructor(
     /** AudioTrack for the active chapter. Recreated on play/seek/sample-rate change. */
     private var audioTrack: AudioTrack? = null
 
-    /** Producer-consumer plumbing. PCM is tagged with its sentence so the
-     *  consumer knows what range to surface when playback actually reaches it.
-     *  [trailingSilenceBytes] is appended **after** [pcm] is written so the
-     *  consumer can spool zeros out of a shared buffer instead of every
-     *  sentence carrying a freshly-allocated copy of pcm + silence (issue #3). */
-    private data class SentencePcm(
-        val sentenceIndex: Int,
-        val pcm: ByteArray,
-        val trailingSilenceBytes: Int,
-        val range: SentenceRange,
-    )
-
-    private var pcmQueue: LinkedBlockingQueue<SentencePcm>? = null
-    private var generationJob: Job? = null
+    /** PCM source feeding the consumer thread. Currently always the streaming
+     *  engine impl; PR-E adds a CacheFileSource branch when a complete cache
+     *  file exists for `(chapterId, voiceId, speed, pitch, chunkerVersion)`. */
+    private var pcmSource: PcmSource? = null
 
     /** Inter-chunk gap measurement (Tab A7 Lite TTS perf lane). Off by
      *  default — reads a marker file at every chunkStart so a developer
@@ -440,68 +429,20 @@ class EnginePlayer @AssistedInject constructor(
         val track = createAudioTrack(sampleRate)
         audioTrack = track
 
-        val queue = LinkedBlockingQueue<SentencePcm>(QUEUE_CAPACITY)
-        pcmQueue = queue
+        val source = EngineStreamingSource(
+            sentences = sentences,
+            startSentenceIndex = currentSentenceIndex,
+            engine = activeVoiceEngineHandle(engineType),
+            speed = currentSpeed,
+            pitch = currentPitch,
+            engineMutex = engineMutex,
+        )
+        pcmSource = source
         pipelineRunning.set(true)
         // Clear the prev-chunk-end anchor so the first chunk of this
         // pipeline lifetime doesn't get a "gap" attributed to user
         // pause time, seek time, or model load time.
         chunkGapLogger.resetForNewPipeline()
-
-        generationJob = ioScope.launch {
-            // Inference is CPU-heavy on modest hardware (Tab A7 Lite); without
-            // an audio-priority bump the producer can lag the AudioTrack drain
-            // and we underrun. VoxSherpa standalone does the same on its
-            // generator thread.
-            AndroidProcess.setThreadPriority(AndroidProcess.THREAD_PRIORITY_URGENT_AUDIO)
-            try {
-                for (i in currentSentenceIndex until sentences.size) {
-                    // Re-apply URGENT_AUDIO each iteration: engineMutex.withLock
-                    // and runInterruptible (below) are suspension points, and
-                    // Dispatchers.IO can resume us on a different worker thread
-                    // that's at default priority.
-                    AndroidProcess.setThreadPriority(AndroidProcess.THREAD_PRIORITY_URGENT_AUDIO)
-                    if (!pipelineRunning.get()) return@launch
-                    val s = sentences[i]
-                    val pcm = engineMutex.withLock {
-                        AndroidProcess.setThreadPriority(AndroidProcess.THREAD_PRIORITY_URGENT_AUDIO)
-                        if (!pipelineRunning.get()) return@withLock null
-                        when (engineType) {
-                            is EngineType.Kokoro -> KokoroEngine.getInstance()
-                                .generateAudioPCM(s.text, currentSpeed, currentPitch)
-                            else -> VoiceEngine.getInstance()
-                                .generateAudioPCM(s.text, currentSpeed, currentPitch)
-                        }
-                    } ?: continue
-                    // Neural TTS engines compress the natural inter-sentence
-                    // pause down to almost nothing — instruct the consumer
-                    // to spool N zero-bytes of silence after this sentence,
-                    // sized by the sentence's terminal punctuation. We don't
-                    // splice the silence into a fresh ByteArray here because
-                    // each sentence's PCM is already 50–500 KB and a copy
-                    // per sentence is avoidable GC pressure.
-                    val pauseMs = trailingPauseMs(s.text) / currentSpeed.coerceAtLeast(0.5f)
-                    val silenceBytes = silenceBytesFor(pauseMs.toInt(), sampleRate)
-                    val item = SentencePcm(
-                        sentenceIndex = i,
-                        pcm = pcm,
-                        trailingSilenceBytes = silenceBytes,
-                        range = SentenceRange(s.index, s.startChar, s.endChar),
-                    )
-                    // runInterruptible turns Thread.interrupt (sent by
-                    // stopPlaybackPipeline → cancel) into a coroutine
-                    // CancellationException, so a blocked put() doesn't
-                    // wedge the producer when shutdown races a full queue.
-                    runInterruptible { queue.put(item) }
-                }
-                // Natural end — let the consumer finish draining and then
-                // run the chapter-done handler.
-                runInterruptible { queue.put(NATURAL_END_PILL) }
-            } catch (_: Throwable) {
-                // Cancelled or engine fault — silent. The consumer is shut
-                // down by stopPlaybackPipeline directly, no pill needed.
-            }
-        }
 
         consumerThread = Thread({
             AndroidProcess.setThreadPriority(AndroidProcess.THREAD_PRIORITY_URGENT_AUDIO)
@@ -514,23 +455,37 @@ class EnginePlayer @AssistedInject constructor(
             var lastVol = -1f
             try {
                 while (pipelineRunning.get()) {
-                    val item = try {
-                        queue.take()
-                    } catch (_: InterruptedException) {
+                    // runBlocking on the dedicated audio thread — same shape
+                    // as the prior runInterruptible bridge. The thread stays
+                    // pinned at URGENT_AUDIO; nextChunk's runInterruptible
+                    // dispatches the take() to Dispatchers.IO under the hood,
+                    // but because the consumer thread is the only thing
+                    // waiting for the result, runBlocking just parks it
+                    // exactly as queue.take() did pre-PR-A.
+                    val chunk = try {
+                        runBlocking { source.nextChunk() }
+                    } catch (_: Throwable) {
+                        null
+                    }
+                    if (chunk == null) {
+                        // null = source exhausted (chapter end) OR closed
+                        // by stopPlaybackPipeline. Distinguish by the run
+                        // flag: if we're still meant to be running, the
+                        // null is an honest end-of-chapter.
+                        naturalEnd = pipelineRunning.get()
                         break
                     }
-                    if (item === NATURAL_END_PILL) { naturalEnd = true; break }
 
                     // Surface the new sentence range BEFORE writing. Fire-
                     // and-forget on Main — withContext would force this
                     // thread to coordinate with the coroutine dispatcher,
                     // which is the whole reason we left coroutines.
                     scope.launch {
-                        currentSentenceIndex = item.sentenceIndex
+                        currentSentenceIndex = chunk.sentenceIndex
                         _observableState.update {
                             it.copy(
-                                currentSentenceRange = item.range,
-                                charOffset = item.range.startCharInChapter,
+                                currentSentenceRange = chunk.range,
+                                charOffset = chunk.range.startCharInChapter,
                             )
                         }
                     }
@@ -558,27 +513,27 @@ class EnginePlayer @AssistedInject constructor(
                     // cheap JNI call but the lastVol guard skips it entirely
                     // when the ramp is idle (steady state).
                     var written = 0
-                    while (written < item.pcm.size && pipelineRunning.get()) {
+                    while (written < chunk.pcm.size && pipelineRunning.get()) {
                         val v = volumeRamp.current
                         if (v != lastVol) {
                             runCatching { track.setVolume(v) }
                             lastVol = v
                         }
-                        val n = track.write(item.pcm, written, item.pcm.size - written)
+                        val n = track.write(chunk.pcm, written, chunk.pcm.size - written)
                         if (n < 0) break // error code from AudioTrack
                         written += n
                     }
                     // Spool trailing silence from a shared zero-filled
                     // buffer (no per-sentence allocation).
-                    var remaining = item.trailingSilenceBytes
+                    var remaining = chunk.trailingSilenceBytes
                     while (remaining > 0 && pipelineRunning.get()) {
                         val v = volumeRamp.current
                         if (v != lastVol) {
                             runCatching { track.setVolume(v) }
                             lastVol = v
                         }
-                        val chunk = remaining.coerceAtMost(SILENCE_CHUNK.size)
-                        val n = track.write(SILENCE_CHUNK, 0, chunk)
+                        val sz = remaining.coerceAtMost(SILENCE_CHUNK.size)
+                        val n = track.write(SILENCE_CHUNK, 0, sz)
                         if (n < 0) break
                         remaining -= n
                     }
@@ -611,16 +566,37 @@ class EnginePlayer @AssistedInject constructor(
         }
     }
 
+    /** Bridge to the singleton VoxSherpa engines via the [EngineStreamingSource]
+     *  SAM. Lives here (not in the source module) so EnginePlayer can switch
+     *  on the active engine type and EngineStreamingSource stays
+     *  test-friendly without depending on VoxSherpa AARs. */
+    private fun activeVoiceEngineHandle(engineType: EngineType?): EngineStreamingSource.VoiceEngineHandle =
+        object : EngineStreamingSource.VoiceEngineHandle {
+            override val sampleRate: Int = when (engineType) {
+                is EngineType.Kokoro -> KokoroEngine.getInstance().sampleRate
+                else -> VoiceEngine.getInstance().sampleRate
+            }.takeIf { it > 0 } ?: DEFAULT_SAMPLE_RATE
+
+            override fun generateAudioPCM(text: String, speed: Float, pitch: Float): ByteArray? {
+                AndroidProcess.setThreadPriority(AndroidProcess.THREAD_PRIORITY_URGENT_AUDIO)
+                return when (engineType) {
+                    is EngineType.Kokoro -> KokoroEngine.getInstance()
+                        .generateAudioPCM(text, speed, pitch)
+                    else -> VoiceEngine.getInstance()
+                        .generateAudioPCM(text, speed, pitch)
+                }
+            }
+        }
+
     private fun stopPlaybackPipeline() {
         // Shutdown handshake:
         //  1. Signal stop via the run flag.
         //  2. Pause + flush the AudioTrack so any currently-blocked
         //     write() returns immediately (ring buffer has space again).
-        //  3. Cancel the producer coroutine; runInterruptible turns the
-        //     thread interrupt into a CancellationException for blocked
-        //     queue.put() calls.
-        //  4. Interrupt + join the consumer thread (so a queue.take()
-        //     blocked on an empty queue wakes up).
+        //  3. Close the source (cancels its producer; offers the END
+        //     pill so the consumer's nextChunk returns null promptly).
+        //  4. Interrupt + join the consumer thread (so a runBlocking
+        //     parked inside nextChunk wakes up).
         //  5. The consumer's own finally block does the AudioTrack
         //     release — *not* main thread — so we can't race a write().
         //     If join times out we still don't release ourselves; the
@@ -635,8 +611,14 @@ class EnginePlayer @AssistedInject constructor(
             runCatching { it.flush() }
         }
 
-        generationJob?.cancel()
-        generationJob = null
+        val src = pcmSource
+        pcmSource = null
+        if (src != null) {
+            // close() is suspending but synchronous in body — runBlocking
+            // here is fine; we're on Main and the close path doesn't
+            // dispatch.
+            runBlocking { src.close() }
+        }
 
         val t = consumerThread
         consumerThread = null
@@ -648,8 +630,6 @@ class EnginePlayer @AssistedInject constructor(
             // track's release is its responsibility.
             try { t.join(2_000) } catch (_: InterruptedException) {}
         }
-
-        pcmQueue = null
     }
 
     /** Build an AudioTrack that mirrors the standalone VoxSherpa demo exactly:
@@ -907,68 +887,12 @@ class EnginePlayer @AssistedInject constructor(
         kotlinx.coroutines.runBlocking { persistPosition() }
         stopPlaybackPipeline()
         scope.cancel()
-        ioScope.cancel()
-    }
-
-    /**
-     * Length of trailing silence to splice after a sentence's PCM, picked
-     * by the punctuation it ends with. Neural TTS engines barely breathe
-     * between sentences; without these padding gaps the listener hears one
-     * continuous block of speech. Values are tuned to match audiobook-style
-     * cadence at 1.0× speed; the producer scales them down at higher speeds
-     * so a 2× listener doesn't sit through 700ms gaps.
-     *
-     * The tail-detection is robust against:
-     *  - **Closing punctuation** wrapping a sentence: `"He left."`, `(yes!)`,
-     *    `'maybe?'` — we strip trailing closers and whitespace before
-     *    looking at the real terminal char.
-     *  - **Multi-character ellipsis** (`...` written as three dots, common
-     *    in HTML-decoded chapter text where the real `…` is rare) — the
-     *    "..." literal is mapped to the same bucket as `…`.
-     *  - **Dash variants** — en-dash, em-dash, and ASCII hyphen used as a
-     *    sentence-internal cesura.
-     */
-    private fun trailingPauseMs(sentenceText: String): Int {
-        // Strip trailing whitespace + closing punctuation/quotes so we look
-        // at the terminal *speech* character, not the visual close-mark.
-        var end = sentenceText.length
-        while (end > 0 && (sentenceText[end - 1].isWhitespace() ||
-                sentenceText[end - 1] in CLOSE_PUNCT)) end--
-        if (end == 0) return 60
-        // Multi-char ellipsis takes precedence over the single-char switch.
-        if (end >= 3 && sentenceText.regionMatches(end - 3, "...", 0, 3)) return 350
-        return when (sentenceText[end - 1]) {
-            '.', '!', '?', '…' -> 350
-            ';', ':' -> 200
-            ',', '—', '–', '-' -> 120
-            else -> 60
-        }
-    }
-
-    private fun silenceBytesFor(durationMs: Int, sampleRate: Int): Int {
-        if (durationMs <= 0) return 0
-        // 16-bit signed PCM = 2 bytes per sample, mono = 1 channel.
-        return ((sampleRate.toLong() * durationMs / 1000L).toInt() * 2).coerceAtLeast(0)
     }
 
     private companion object {
-        /** Buffered slots ahead of the playback consumer. Each slot holds one
-         *  sentence's PCM (~50–500KB). At 8 slots × ~250KB avg ≈ 2MB peak.
-         *  This is the *only* generator headroom we have now that the
-         *  AudioTrack itself uses minBufferSize (~130 ms at 22 kHz) — the
-         *  queue has to stay full or the buffer underruns and we hear clicks. */
-        const val QUEUE_CAPACITY = 8
-
         /** Fallback when the engine reports a non-positive sample rate (model
          *  not loaded yet). Piper voices are 22050Hz; Kokoro is 24000Hz. */
         const val DEFAULT_SAMPLE_RATE = 22050
-
-        /** Closing-punctuation characters stripped before deciding the
-         *  terminal punctuation for trailing-silence sizing. Covers ASCII
-         *  + curly + bracketed close marks. */
-        val CLOSE_PUNCT: Set<Char> = setOf(
-            '"', '\'', ')', ']', '}', '”', '’', '»', '」',
-        )
 
         /** Shared zero-filled buffer the consumer writes from to spool
          *  inter-sentence silence. Sized for one chunk @ 24 kHz mono 16-bit
@@ -976,18 +900,5 @@ class EnginePlayer @AssistedInject constructor(
          *  silences chain multiple writes from the same buffer. Static so
          *  every sentence reuses the same allocation. */
         val SILENCE_CHUNK: ByteArray = ByteArray(24_000 * 2 * 350 / 1000)
-
-        /** Sentinel pushed by the producer onto the queue when it has run
-         *  out of sentences naturally (i.e. the chapter is finished). The
-         *  consumer thread checks for object identity (`===`) and triggers
-         *  the chapter-done handler instead of treating it like real audio.
-         *  A cancellation-driven shutdown does NOT enqueue this — it just
-         *  flips [pipelineRunning] to false and interrupts the consumer. */
-        val NATURAL_END_PILL: SentencePcm = SentencePcm(
-            sentenceIndex = -1,
-            pcm = ByteArray(0),
-            trailingSilenceBytes = 0,
-            range = SentenceRange(-1, -1, -1),
-        )
     }
 }

--- a/core-playback/src/main/kotlin/in/jphe/storyvox/playback/tts/EnginePlayer.kt
+++ b/core-playback/src/main/kotlin/in/jphe/storyvox/playback/tts/EnginePlayer.kt
@@ -448,6 +448,12 @@ class EnginePlayer @AssistedInject constructor(
             AndroidProcess.setThreadPriority(AndroidProcess.THREAD_PRIORITY_URGENT_AUDIO)
             var naturalEnd = false
             var firstSentence = true
+            // Track AudioTrack pause state so the buffer-low check below can
+            // toggle play/pause without thrashing JNI on every iteration.
+            // Consumer is the only thread that calls track.play / track.pause
+            // for streaming-source playback (user-initiated pauses go through
+            // stopPlaybackPipeline, which tears the track down).
+            var paused = false
             // Live track volume mirror. Scoped to the consumer thread (not
             // per-sentence) so the per-write change-detection skips the
             // setVolume JNI call when the ramp is idle, which is the steady
@@ -455,6 +461,18 @@ class EnginePlayer @AssistedInject constructor(
             var lastVol = -1f
             try {
                 while (pipelineRunning.get()) {
+                    // BEFORE pulling the next chunk, check whether buffer
+                    // recovered above the resume threshold. If so, kick
+                    // AudioTrack alive again so the next write lands in a
+                    // playing track rather than a paused-then-played one.
+                    if (paused && source.bufferHeadroomMs.value >= BUFFER_RESUME_THRESHOLD_MS) {
+                        runCatching { track.play() }
+                        paused = false
+                        scope.launch {
+                            _observableState.update { it.copy(isBuffering = false) }
+                        }
+                    }
+
                     // runBlocking on the dedicated audio thread — same shape
                     // as the prior runInterruptible bridge. The thread stays
                     // pinned at URGENT_AUDIO; nextChunk's runInterruptible
@@ -498,6 +516,23 @@ class EnginePlayer @AssistedInject constructor(
                         firstSentence = false
                     }
 
+                    // After the take, headroom dropped by this chunk's audio
+                    // duration. If we just crossed below the underrun
+                    // threshold AND we're not already paused, pause the
+                    // AudioTrack and surface the buffering UI BEFORE we
+                    // start writing — the OS hardware buffer is large
+                    // enough on this device (~2-3 s deep) that the next
+                    // write would land seconds before the listener hears
+                    // silence, so the buffering UI needs to lead the audio
+                    // by that margin.
+                    if (!paused && source.bufferHeadroomMs.value < BUFFER_UNDERRUN_THRESHOLD_MS) {
+                        runCatching { track.pause() }
+                        paused = true
+                        scope.launch {
+                            _observableState.update { it.copy(isBuffering = true) }
+                        }
+                    }
+
                     // Stamp the start of the AudioTrack-write phase for this
                     // chunk. Combined with the chunkEnd() below, this lets
                     // the perf lane log gap_ms = startN - endNm1, which is
@@ -506,7 +541,7 @@ class EnginePlayer @AssistedInject constructor(
                     // ChunkGapLogger doc). No-op unless the marker file is
                     // present, so this is free in normal operation.
                     val gapVoiceId = loadedVoiceId ?: "unknown"
-                    chunkGapLogger.chunkStart(gapVoiceId, item.sentenceIndex)
+                    chunkGapLogger.chunkStart(gapVoiceId, chunk.sentenceIndex)
 
                     // Apply the SleepTimer fade-out ramp to the live track.
                     // Polled per write iteration; AudioTrack.setVolume is a
@@ -542,7 +577,7 @@ class EnginePlayer @AssistedInject constructor(
                     // pcm + trailing silence. The next iteration's blocking
                     // queue.take() is where a slow producer shows up as a
                     // logged gap.
-                    chunkGapLogger.chunkEnd(gapVoiceId, item.sentenceIndex)
+                    chunkGapLogger.chunkEnd(gapVoiceId, chunk.sentenceIndex)
                 }
             } finally {
                 // Release the AudioTrack from the same thread that owns
@@ -553,6 +588,16 @@ class EnginePlayer @AssistedInject constructor(
                 runCatching { track.pause() }
                 runCatching { track.flush() }
                 runCatching { track.release() }
+                // Don't leave the UI stuck in "Buffering..." after we've
+                // shut down — pause/stop tears the pipeline down via
+                // stopPlaybackPipeline which sets isPlaying=false; we
+                // additionally clear isBuffering so a subsequent resume
+                // that builds a fresh pipeline starts from a clean slate.
+                if (paused) {
+                    scope.launch {
+                        _observableState.update { it.copy(isBuffering = false) }
+                    }
+                }
                 if (naturalEnd && pipelineRunning.get()) {
                     scope.launch {
                         sleepTimer.signalChapterEnd()
@@ -893,6 +938,18 @@ class EnginePlayer @AssistedInject constructor(
         /** Fallback when the engine reports a non-positive sample rate (model
          *  not loaded yet). Piper voices are 22050Hz; Kokoro is 24000Hz. */
         const val DEFAULT_SAMPLE_RATE = 22050
+
+        /** When buffered audio falls below this, pause AudioTrack and surface
+         *  a "Buffering..." UI state. Tab A7 Lite's hardware buffer is ~2-3s
+         *  deep; pausing at 2s gives the listener clear feedback before the
+         *  silence fully drains the buffer and they hear dead air. */
+        const val BUFFER_UNDERRUN_THRESHOLD_MS = 2_000L
+
+        /** Hysteresis. Don't resume until we have this much queued or we'll
+         *  thrash pause/play on every chunk transition. 4s ≈ 2 sentences of
+         *  Piper-high audio average; the consumer can drain that before the
+         *  producer puts the next one. */
+        const val BUFFER_RESUME_THRESHOLD_MS = 4_000L
 
         /** Shared zero-filled buffer the consumer writes from to spool
          *  inter-sentence silence. Sized for one chunk @ 24 kHz mono 16-bit

--- a/core-playback/src/main/kotlin/in/jphe/storyvox/playback/tts/source/EngineStreamingSource.kt
+++ b/core-playback/src/main/kotlin/in/jphe/storyvox/playback/tts/source/EngineStreamingSource.kt
@@ -1,0 +1,175 @@
+package `in`.jphe.storyvox.playback.tts.source
+
+import `in`.jphe.storyvox.playback.SentenceRange
+import `in`.jphe.storyvox.playback.tts.Sentence
+import java.util.concurrent.LinkedBlockingQueue
+import java.util.concurrent.atomic.AtomicBoolean
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.runInterruptible
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
+
+/**
+ * Drives VoxSherpa's [VoiceEngineHandle] on a worker coroutine, putting
+ * generated PCM into a bounded queue. The consumer (EnginePlayer's
+ * AudioTrack writer thread) pulls from [nextChunk]. Mirrors the producer
+ * half of `EnginePlayer.startPlaybackPipeline` pre-PR-A.
+ *
+ * Why a [LinkedBlockingQueue] not a coroutine [kotlinx.coroutines.channels.Channel]:
+ * the EnginePlayer consumer is a pinned OS thread at URGENT_AUDIO; pulling
+ * via Channel would force it through the coroutine dispatcher and lose
+ * the priority bump (URGENT_AUDIO is per-OS-thread, not per-coroutine).
+ * We bridge via [runInterruptible] so the producer can coexist with
+ * structured concurrency for shutdown.
+ *
+ * @param sentences full sentence list for the chapter; the producer
+ *  walks from [startSentenceIndex] to the end.
+ * @param startSentenceIndex first sentence to generate. Updated by [seekToCharOffset]
+ *  by cancelling the producer and restarting from the new index.
+ * @param engine the active VoxSherpa-style engine (Piper or Kokoro) wrapped
+ *  in a SAM so unit tests can fake it without pulling the AAR.
+ * @param speed playback speed; fed to [VoiceEngineHandle.generateAudioPCM]
+ *  AND scales the trailing-cadence pause down at faster speeds so a 2× listener
+ *  doesn't sit through 700 ms gaps.
+ * @param pitch pitch multiplier, fed to engine.
+ * @param queueCapacity bounded queue depth; producer back-pressures when full.
+ *  Defaults to 8 to match the prior EnginePlayer constant.
+ */
+class EngineStreamingSource(
+    private val sentences: List<Sentence>,
+    startSentenceIndex: Int,
+    private val engine: VoiceEngineHandle,
+    private val speed: Float,
+    private val pitch: Float,
+    private val queueCapacity: Int = 8,
+) : PcmSource {
+
+    /** SAM-style handle so tests can fake the engine without pulling the
+     *  VoxSherpa AAR onto the JVM unit-test classpath. EnginePlayer wraps
+     *  the singleton VoiceEngine / KokoroEngine in this. */
+    interface VoiceEngineHandle {
+        val sampleRate: Int
+        fun generateAudioPCM(text: String, speed: Float, pitch: Float): ByteArray?
+    }
+
+    override val sampleRate: Int = engine.sampleRate
+
+    private val scope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
+    private val running = AtomicBoolean(true)
+    private val queue = LinkedBlockingQueue<Item>(queueCapacity)
+
+    /** Serializes generateAudioPCM calls. The VoxSherpa engines are
+     *  process-singletons and their internal Sonic/onnxruntime state isn't
+     *  safe across concurrent threads. EnginePlayer's outer loadAndPlay
+     *  also takes this same shape (its own engineMutex); the source-level
+     *  mutex protects against a second source instance racing the first
+     *  during seek-while-busy. */
+    private val engineMutex = Mutex()
+
+    private var producerJob: Job = startProducer(startSentenceIndex)
+
+    override suspend fun nextChunk(): PcmChunk? = runInterruptible {
+        val item = queue.take()
+        if (item === END_PILL) null else item.chunk
+    }
+
+    override suspend fun seekToCharOffset(charOffset: Int) {
+        val target = sentences.indexOfLast { it.startChar <= charOffset }
+            .takeIf { it >= 0 } ?: 0
+        producerJob.cancel()
+        queue.clear()
+        producerJob = startProducer(target)
+    }
+
+    override suspend fun close() {
+        running.set(false)
+        producerJob.cancel()
+        queue.clear()
+        // Wake any consumer blocked in take() so nextChunk returns null.
+        queue.offer(END_PILL)
+        scope.cancel()
+    }
+
+    private fun startProducer(fromIndex: Int): Job = scope.launch {
+        try {
+            for (i in fromIndex until sentences.size) {
+                if (!running.get()) return@launch
+                val s = sentences[i]
+                val pcm = engineMutex.withLock {
+                    if (!running.get()) return@withLock null
+                    engine.generateAudioPCM(s.text, speed, pitch)
+                } ?: continue
+                if (!running.get()) return@launch
+                val pauseMs = trailingPauseMs(s.text) / speed.coerceAtLeast(0.5f)
+                val silenceBytes = silenceBytesFor(pauseMs.toInt(), sampleRate)
+                val chunk = PcmChunk(
+                    sentenceIndex = i,
+                    range = SentenceRange(s.index, s.startChar, s.endChar),
+                    pcm = pcm,
+                    trailingSilenceBytes = silenceBytes,
+                )
+                runInterruptible { queue.put(Item(chunk)) }
+            }
+            // Natural end-of-chapter: push the pill so the consumer's
+            // next nextChunk() returns null.
+            runInterruptible { queue.put(END_PILL) }
+        } catch (_: Throwable) {
+            // Cancelled (close, seek, voice swap) — silent. A subsequent
+            // nextChunk() either gets the pill from close() or the next
+            // chunk from a restarted producer (seek).
+        }
+    }
+
+    /** Wrapper so the END_PILL identity check via `===` is type-safe and
+     *  the data class equals isn't tempted to compare the empty pcm. */
+    private class Item(val chunk: PcmChunk)
+
+    private companion object {
+        val END_PILL = Item(PcmChunk(-1, SentenceRange(-1, -1, -1), ByteArray(0), 0))
+    }
+}
+
+/**
+ * Length of trailing silence to splice after a sentence's PCM, picked
+ * by terminal punctuation. Neural TTS engines barely breathe between
+ * sentences; without padding the listener hears one continuous block
+ * of speech. Tuned for audiobook-style cadence at 1.0× speed; the
+ * caller scales by 1/speed so a 2× listener doesn't sit through 700 ms
+ * gaps.
+ *
+ * Robust against:
+ *  - **Closing punctuation** wrapping a sentence (`"He left."`, `(yes!)`)
+ *    — strip trailing closers + whitespace before looking at terminal char.
+ *  - **Multi-character ellipsis** (`...` written as three dots, common in
+ *    HTML-decoded chapter text) — mapped to the single-`…` bucket.
+ *  - **Dash variants** — en-dash, em-dash, ASCII hyphen as cesura.
+ *
+ * Lifted verbatim from the pre-PR-A `EnginePlayer.trailingPauseMs`; this
+ * is a refactor commit, no logic changes.
+ */
+internal fun trailingPauseMs(sentenceText: String): Int {
+    val closePunct: Set<Char> = setOf('"', '\'', ')', ']', '}', '”', '’', '»', '」')
+    var end = sentenceText.length
+    while (end > 0 && (sentenceText[end - 1].isWhitespace() ||
+            sentenceText[end - 1] in closePunct)) end--
+    if (end == 0) return 60
+    if (end >= 3 && sentenceText.regionMatches(end - 3, "...", 0, 3)) return 350
+    return when (sentenceText[end - 1]) {
+        '.', '!', '?', '…' -> 350
+        ';', ':' -> 200
+        ',', '—', '–', '-' -> 120
+        else -> 60
+    }
+}
+
+/** Bytes of zero-PCM = `durationMs × sampleRate × 2` (16-bit mono).
+ *  Lifted from EnginePlayer.silenceBytesFor; refactor commit. */
+internal fun silenceBytesFor(durationMs: Int, sampleRate: Int): Int {
+    if (durationMs <= 0) return 0
+    return ((sampleRate.toLong() * durationMs / 1000L).toInt() * 2).coerceAtLeast(0)
+}

--- a/core-playback/src/main/kotlin/in/jphe/storyvox/playback/tts/source/EngineStreamingSource.kt
+++ b/core-playback/src/main/kotlin/in/jphe/storyvox/playback/tts/source/EngineStreamingSource.kt
@@ -9,6 +9,10 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.cancel
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.runInterruptible
 import kotlinx.coroutines.sync.Mutex
@@ -69,11 +73,39 @@ class EngineStreamingSource(
     private val running = AtomicBoolean(true)
     private val queue = LinkedBlockingQueue<Item>(queueCapacity)
 
+    private val _bufferHeadroomMs = MutableStateFlow(0L)
+
+    /**
+     * Total ms of audio currently buffered in the queue (sum of pcm
+     * playback duration + cadence-silence duration across queued chunks).
+     * Updated atomically on every producer put and consumer take.
+     *
+     * The EnginePlayer consumer pauses AudioTrack and surfaces a
+     * "Buffering..." UI state when this drops below an underrun threshold,
+     * resumes at a higher hysteresis threshold. Lets the listener
+     * experience the gap as a clean pause rather than dribbling silence
+     * out of an underrunning AudioTrack ring buffer.
+     */
+    val bufferHeadroomMs: StateFlow<Long> = _bufferHeadroomMs.asStateFlow()
+
+    /** ms of audio represented by [bytes] of PCM at this source's sample rate.
+     *  16-bit signed mono → 2 bytes per sample, 1 channel. */
+    private fun pcmDurationMs(bytes: Int): Long =
+        bytes.toLong() * 1000L / (sampleRate.toLong() * 2L)
+
     private var producerJob: Job = startProducer(startSentenceIndex)
 
     override suspend fun nextChunk(): PcmChunk? = runInterruptible {
         val item = queue.take()
-        if (item === END_PILL) null else item.chunk
+        if (item === END_PILL) return@runInterruptible null
+        val chunk = item.chunk
+        // Decrement headroom by everything this chunk represented in the
+        // queue: PCM duration + the trailing cadence silence (consumer is
+        // about to write both into AudioTrack).
+        val durMs = pcmDurationMs(chunk.pcm.size) +
+            pcmDurationMs(chunk.trailingSilenceBytes)
+        _bufferHeadroomMs.update { (it - durMs).coerceAtLeast(0L) }
+        chunk
     }
 
     override suspend fun seekToCharOffset(charOffset: Int) {
@@ -112,6 +144,9 @@ class EngineStreamingSource(
                     trailingSilenceBytes = silenceBytes,
                 )
                 runInterruptible { queue.put(Item(chunk)) }
+                _bufferHeadroomMs.update {
+                    it + pcmDurationMs(pcm.size) + pcmDurationMs(silenceBytes)
+                }
             }
             // Natural end-of-chapter: push the pill so the consumer's
             // next nextChunk() returns null.

--- a/core-playback/src/main/kotlin/in/jphe/storyvox/playback/tts/source/EngineStreamingSource.kt
+++ b/core-playback/src/main/kotlin/in/jphe/storyvox/playback/tts/source/EngineStreamingSource.kt
@@ -46,6 +46,12 @@ class EngineStreamingSource(
     private val engine: VoiceEngineHandle,
     private val speed: Float,
     private val pitch: Float,
+    /** Shared with EnginePlayer.loadAndPlay so loadModel() can wait for any
+     *  in-flight generateAudioPCM to finish before tearing the model down.
+     *  Without this shared mutex, a Piper-to-Piper voice swap can call
+     *  loadModel().destroy() while the prior source's generator is still
+     *  inside the JNI generate(...) call, corrupting native state. */
+    private val engineMutex: Mutex,
     private val queueCapacity: Int = 8,
 ) : PcmSource {
 
@@ -62,14 +68,6 @@ class EngineStreamingSource(
     private val scope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
     private val running = AtomicBoolean(true)
     private val queue = LinkedBlockingQueue<Item>(queueCapacity)
-
-    /** Serializes generateAudioPCM calls. The VoxSherpa engines are
-     *  process-singletons and their internal Sonic/onnxruntime state isn't
-     *  safe across concurrent threads. EnginePlayer's outer loadAndPlay
-     *  also takes this same shape (its own engineMutex); the source-level
-     *  mutex protects against a second source instance racing the first
-     *  during seek-while-busy. */
-    private val engineMutex = Mutex()
 
     private var producerJob: Job = startProducer(startSentenceIndex)
 

--- a/core-playback/src/main/kotlin/in/jphe/storyvox/playback/tts/source/PcmSource.kt
+++ b/core-playback/src/main/kotlin/in/jphe/storyvox/playback/tts/source/PcmSource.kt
@@ -1,0 +1,73 @@
+package `in`.jphe.storyvox.playback.tts.source
+
+import `in`.jphe.storyvox.playback.SentenceRange
+
+/**
+ * Source of PCM chunks for the EnginePlayer consumer to write to AudioTrack.
+ *
+ * Two impls (PR-A only ships [EngineStreamingSource]; `CacheFileSource`
+ * follows in PR-E):
+ *  - [EngineStreamingSource] runs the VoxSherpa engine on a worker
+ *    coroutine, putting generated PCM into a queue. [nextChunk] blocks
+ *    on `queue.take`. Subject to producer-can't-keep-up underrun on
+ *    slow voice + slow device combos (Piper-high on Tab A7 Lite).
+ *  - `CacheFileSource` (PR-E) mmap-reads a pre-rendered chapter PCM file.
+ *    Never blocks for long.
+ *
+ * The consumer treats both uniformly. When the source is exhausted
+ * (chapter end), [nextChunk] returns null.
+ */
+sealed interface PcmSource {
+
+    /** Sample rate of every chunk this source yields. Stable for the
+     *  source's lifetime; the consumer sizes its AudioTrack from this. */
+    val sampleRate: Int
+
+    /**
+     * Pull the next chunk. Suspends if the source has no chunk ready
+     * (streaming impl: producer hasn't generated the next sentence yet;
+     * cache impl: never blocks meaningfully). Returns null when the
+     * chapter is fully drained.
+     *
+     * Cancellation: if the calling coroutine is cancelled, blocked
+     * impls must throw [kotlinx.coroutines.CancellationException]
+     * promptly so the consumer can shut down. The streaming impl
+     * achieves this via [kotlinx.coroutines.runInterruptible] around
+     * the underlying `queue.take`.
+     */
+    suspend fun nextChunk(): PcmChunk?
+
+    /**
+     * Re-anchor the source to the sentence containing [charOffset].
+     * Streaming impl cancels the producer and restarts at the new
+     * sentence index. Cache impl seeks the underlying file via the
+     * sidecar index.
+     */
+    suspend fun seekToCharOffset(charOffset: Int)
+
+    /** Release any resources (cancel producer, close mmap, etc).
+     *  Wakes any consumer blocked in [nextChunk] so it can exit. */
+    suspend fun close()
+}
+
+/**
+ * One chunk of PCM tagged with its sentence range. The trailing
+ * silence is intentional cadence; the consumer spools this many bytes
+ * of zero-PCM after the audible PCM to give sentences breathing
+ * room. See `EngineStreamingSource.trailingPauseMs` for the
+ * punctuation-driven sizing.
+ */
+data class PcmChunk(
+    val sentenceIndex: Int,
+    val range: SentenceRange,
+    val pcm: ByteArray,
+    val trailingSilenceBytes: Int,
+) {
+    /** Equality is identity-based to keep equals cheap; the consumer
+     *  never compares chunks, and the default equals on a data class
+     *  with a ByteArray field is structurally wrong (compares array
+     *  references) AND an O(N) cliff if we ever fix it to compare
+     *  contents. Identity is correct and trivial. */
+    override fun equals(other: Any?): Boolean = this === other
+    override fun hashCode(): Int = sentenceIndex
+}

--- a/core-playback/src/test/kotlin/in/jphe/storyvox/playback/PlaybackStateTest.kt
+++ b/core-playback/src/test/kotlin/in/jphe/storyvox/playback/PlaybackStateTest.kt
@@ -52,4 +52,16 @@ class PlaybackStateTest {
         assertEquals(150f, SPEED_BASELINE_WPM, 0f)
         assertEquals(12.5f, SPEED_BASELINE_CHARS_PER_SECOND, 0f)
     }
+
+    @Test fun `isBuffering defaults false and serializes round-trip`() {
+        val s = PlaybackState(isBuffering = true, isPlaying = true, charOffset = 42)
+        val json = kotlinx.serialization.json.Json.encodeToString(PlaybackState.serializer(), s)
+        val round = kotlinx.serialization.json.Json.decodeFromString(PlaybackState.serializer(), json)
+        assertEquals(true, round.isBuffering)
+        assertEquals(true, round.isPlaying)
+        assertEquals(42, round.charOffset)
+
+        val default = PlaybackState()
+        assertEquals(false, default.isBuffering)
+    }
 }

--- a/core-playback/src/test/kotlin/in/jphe/storyvox/playback/tts/source/EngineStreamingSourceTest.kt
+++ b/core-playback/src/test/kotlin/in/jphe/storyvox/playback/tts/source/EngineStreamingSourceTest.kt
@@ -1,0 +1,93 @@
+package `in`.jphe.storyvox.playback.tts.source
+
+import `in`.jphe.storyvox.playback.tts.Sentence
+import kotlinx.coroutines.async
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Test
+
+class EngineStreamingSourceTest {
+
+    @Test
+    fun `nextChunk returns sentences in order then null at end`() = runBlocking {
+        val sentences = listOf(
+            Sentence(0, 0, 10, "One."),
+            Sentence(1, 11, 20, "Two."),
+            Sentence(2, 21, 30, "Three."),
+        )
+        val fakeEngine = FakeVoiceEngine(
+            sampleRate = 22050,
+            pcmFor = { text -> ByteArray(text.length * 2) { 0 } },
+        )
+        val source = EngineStreamingSource(
+            sentences = sentences,
+            startSentenceIndex = 0,
+            engine = fakeEngine,
+            speed = 1.0f,
+            pitch = 1.0f,
+        )
+
+        val c0 = source.nextChunk()
+        val c1 = source.nextChunk()
+        val c2 = source.nextChunk()
+        val end = source.nextChunk()
+
+        assertEquals(0, c0?.sentenceIndex)
+        assertEquals(1, c1?.sentenceIndex)
+        assertEquals(2, c2?.sentenceIndex)
+        assertNull(end)
+
+        source.close()
+    }
+
+    @Test
+    fun `close makes a subsequent nextChunk return null`() = runBlocking {
+        // Engine that releases generation only when the test signals; this
+        // guarantees the producer is parked while close() runs, no timing race.
+        val gate = java.util.concurrent.CountDownLatch(1)
+        val gatedEngine = object : EngineStreamingSource.VoiceEngineHandle {
+            override val sampleRate: Int = 22050
+            override fun generateAudioPCM(text: String, speed: Float, pitch: Float): ByteArray? {
+                // Wait until the test releases us. If close() came before
+                // the test releases, the next iteration's running.get()
+                // check + the runInterruptible queue.put will both
+                // short-circuit, so no chunk reaches the queue.
+                gate.await()
+                return ByteArray(100)
+            }
+        }
+        val sentences = listOf(Sentence(0, 0, 10, "One."))
+        val source = EngineStreamingSource(sentences, 0, gatedEngine, 1f, 1f)
+
+        // Producer is now parked at gate.await() inside engine.generateAudioPCM.
+        // Give Dispatchers.IO a moment to schedule it; not strictly required
+        // since close()'s contract holds even if the producer hasn't started
+        // yet, but easier to reason about.
+        delay(50)
+
+        source.close()
+
+        // Now release the producer. Its `running.get()` post-engine guard
+        // should fire, the runInterruptible put should observe cancellation,
+        // and no chunk reaches the queue. nextChunk should return null
+        // (END_PILL placed by close).
+        gate.countDown()
+
+        val started = System.currentTimeMillis()
+        val result = source.nextChunk()
+        val elapsed = System.currentTimeMillis() - started
+
+        assertNull(result)
+        assert(elapsed < 500) { "nextChunk after close took $elapsed ms" }
+    }
+}
+
+private class FakeVoiceEngine(
+    override val sampleRate: Int,
+    val pcmFor: (String) -> ByteArray,
+) : EngineStreamingSource.VoiceEngineHandle {
+    override fun generateAudioPCM(text: String, speed: Float, pitch: Float): ByteArray? = pcmFor(text)
+}

--- a/core-playback/src/test/kotlin/in/jphe/storyvox/playback/tts/source/EngineStreamingSourceTest.kt
+++ b/core-playback/src/test/kotlin/in/jphe/storyvox/playback/tts/source/EngineStreamingSourceTest.kt
@@ -4,6 +4,7 @@ import `in`.jphe.storyvox.playback.tts.Sentence
 import kotlinx.coroutines.async
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.test.runTest
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNull
@@ -28,6 +29,7 @@ class EngineStreamingSourceTest {
             engine = fakeEngine,
             speed = 1.0f,
             pitch = 1.0f,
+            engineMutex = Mutex(),
         )
 
         val c0 = source.nextChunk()
@@ -60,7 +62,7 @@ class EngineStreamingSourceTest {
             }
         }
         val sentences = listOf(Sentence(0, 0, 10, "One."))
-        val source = EngineStreamingSource(sentences, 0, gatedEngine, 1f, 1f)
+        val source = EngineStreamingSource(sentences, 0, gatedEngine, 1f, 1f, Mutex())
 
         // Producer is now parked at gate.await() inside engine.generateAudioPCM.
         // Give Dispatchers.IO a moment to schedule it; not strictly required

--- a/core-playback/src/test/kotlin/in/jphe/storyvox/playback/tts/source/EngineStreamingSourceTest.kt
+++ b/core-playback/src/test/kotlin/in/jphe/storyvox/playback/tts/source/EngineStreamingSourceTest.kt
@@ -85,6 +85,39 @@ class EngineStreamingSourceTest {
         assertNull(result)
         assert(elapsed < 500) { "nextChunk after close took $elapsed ms" }
     }
+
+    @Test
+    fun `bufferHeadroomMs reflects queued audio duration`() = runBlocking {
+        val sentences = listOf(
+            Sentence(0, 0, 10, "One."),
+            Sentence(1, 11, 20, "Two."),
+        )
+        // 22050 Hz × 2 bytes per sample = 44100 bytes per second of audio.
+        // 44100 bytes ⇒ 1000 ms.
+        val fakeEngine = FakeVoiceEngine(22050) { _ -> ByteArray(44100) }
+        val source = EngineStreamingSource(sentences, 0, fakeEngine, 1f, 1f, Mutex())
+
+        // Wait for producer to fill the queue with both sentences.
+        val deadline = System.currentTimeMillis() + 2_000
+        while (System.currentTimeMillis() < deadline &&
+               source.bufferHeadroomMs.value < 2_000) {
+            delay(10)
+        }
+        // 2 sentences × (1000 ms PCM + 350 ms cadence) = 2700 ms expected
+        // (cadence is 350 ms because "One." / "Two." end in '.').
+        val before = source.bufferHeadroomMs.value
+        assert(before >= 2_000) { "expected ≥ 2000 ms headroom, got $before" }
+
+        val first = source.nextChunk()
+        assertEquals(0, first?.sentenceIndex)
+        val after = source.bufferHeadroomMs.value
+        // Headroom should drop by ~1350 ms (1000 ms PCM + 350 ms cadence).
+        assert(after < before - 1_000) {
+            "expected headroom to drop by > 1000 ms after take; was $before → $after"
+        }
+
+        source.close()
+    }
 }
 
 private class FakeVoiceEngine(

--- a/docs/superpowers/plans/2026-05-07-pcm-cache-pr-a-and-b.md
+++ b/docs/superpowers/plans/2026-05-07-pcm-cache-pr-a-and-b.md
@@ -1,0 +1,1253 @@
+# PCM Cache PR A + PR B Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Ship the smallest immediate-relief change for the audible inter-chunk gap on Piper-high + Tab A7 Lite by (PR A) extracting a `PcmSource` interface from EnginePlayer's pipeline as a behavioral no-op, then (PR B) wiring a `pause-buffer-resume` mode that pauses AudioTrack with a UI "buffering" state instead of emitting silence on underrun.
+
+**Architecture:** PR A is pure refactor — pull the producer + queue + write-loop out of `EnginePlayer.startPlaybackPipeline` into a new `PcmSource` interface with one impl, `EngineStreamingSource`. EnginePlayer's consumer thread keeps owning the AudioTrack but pulls `PcmChunk`s from the source instead of from a `LinkedBlockingQueue<SentencePcm>` directly. PR B layers on a `bufferLowSignal: StateFlow<Boolean>` from the source; the consumer pauses `AudioTrack.play()` while the signal is true, sets `PlaybackState.isBuffering = true`, and resumes when head-room recovers. Cap the AudioTrack request size to a tight buffer so the signal actually fires (currently the OS hands us ~2-3s of buffer, masking underrun).
+
+**Tech stack:** Kotlin, AndroidX Media3 SimpleBasePlayer, kotlinx.coroutines, JUnit4, Mockito-like fakes (existing project pattern).
+
+**Spec:** `docs/superpowers/specs/2026-05-07-pcm-cache-design.md`
+
+**Out of scope (follow-up PRs C-H):** PcmCache filesystem layer, CacheFileSource, RenderScheduler/WorkManager job, Settings UI for quota, LRU eviction, per-chapter cache status icons. PR A + B alone do NOT eliminate the gap — they convert "silent underrun" into "explicit buffering UI". Eliminating the gap requires PR C-F (cache + render).
+
+---
+
+## File Structure
+
+### PR A — PcmSource extraction (behavioral no-op)
+
+**New files:**
+- `core-playback/src/main/kotlin/in/jphe/storyvox/playback/tts/source/PcmSource.kt` — sealed interface + `PcmChunk` data class
+- `core-playback/src/main/kotlin/in/jphe/storyvox/playback/tts/source/EngineStreamingSource.kt` — moves the producer coroutine + queue out of EnginePlayer
+
+**Modified files:**
+- `core-playback/src/main/kotlin/in/jphe/storyvox/playback/tts/EnginePlayer.kt` — `startPlaybackPipeline` shrinks: instantiates a source, runs a thinner consumer loop pulling `PcmChunk` from `source.nextChunk()` instead of `LinkedBlockingQueue<SentencePcm>.take()`.
+
+**New tests:**
+- `core-playback/src/test/kotlin/in/jphe/storyvox/playback/tts/source/EngineStreamingSourceTest.kt` — verifies `nextChunk()` semantics, cancellation, and that `close()` interrupts blocked producers.
+
+### PR B — pause-buffer-resume
+
+**New files:** none (build on PR A's source).
+
+**Modified files:**
+- `core-playback/src/main/kotlin/in/jphe/storyvox/playback/PlaybackState.kt` — add `isBuffering: Boolean = false` field.
+- `core-playback/src/main/kotlin/in/jphe/storyvox/playback/tts/source/EngineStreamingSource.kt` — expose `bufferHeadroomMs: StateFlow<Long>` computed from queue depth × avg chunk duration; expose `bufferLowSignal: StateFlow<Boolean>` derived from headroom < 2000.
+- `core-playback/src/main/kotlin/in/jphe/storyvox/playback/tts/EnginePlayer.kt` — consumer collects `bufferLowSignal`, calls `audioTrack.pause()` / `audioTrack.play()`, updates `PlaybackState.isBuffering`. AudioTrack rebuild forces tighter buffer so signal can fire (`AudioTrack.getMinBufferSize()` is what the existing code requests, but the OS may upgrade — cap at request × 1 explicitly via `setBufferSizeInBytes`).
+- `feature/src/main/kotlin/in/jphe/storyvox/feature/reader/AudiobookView.kt` — extend the existing brass-spinner `warmingUp` derived state to include `isBuffering`, so the same visual surfaces during mid-stream underrun.
+
+**New tests:**
+- `core-playback/src/test/kotlin/in/jphe/storyvox/playback/tts/source/EngineStreamingSourceBufferLowTest.kt` — verifies the signal flips appropriately.
+- `core-playback/src/test/kotlin/in/jphe/storyvox/playback/PlaybackStateTest.kt` — extend with `isBuffering` defaults and serialization round-trip.
+
+---
+
+## Conventions
+
+- All commits use conventional-commit style: `feat`, `fix`, `refactor`, `docs`, `test`. Branch is `dream/aurelia/tts-chunk-gap`.
+- Run from the worktree root: `/home/jp/Projects/storyvox-worktrees/aurelia-tts-chunk-gap`.
+- `./gradlew :core-playback:testDebugUnitTest` for fast local test iteration.
+- `./gradlew :app:assembleDebug` and install via `adb -s R83W80CAFZB install -r app/build/outputs/apk/debug/app-debug.apk` for tablet verification (claim TASK #47 first per CLAUDE.md).
+
+---
+
+## PR A: PcmSource extraction
+
+### Task A1: Create the `PcmSource` interface and `PcmChunk` data class
+
+**Files:**
+- Create: `core-playback/src/main/kotlin/in/jphe/storyvox/playback/tts/source/PcmSource.kt`
+
+- [ ] **Step 1: Create the file with the sealed interface + data class.**
+
+```kotlin
+package `in`.jphe.storyvox.playback.tts.source
+
+import `in`.jphe.storyvox.playback.SentenceRange
+
+/**
+ * Source of PCM chunks for the EnginePlayer consumer to write to AudioTrack.
+ *
+ * Two impls (PR-A only ships [EngineStreamingSource]; [CacheFileSource]
+ * follows in PR-E):
+ *  - [EngineStreamingSource] runs the VoxSherpa engine on a worker
+ *    coroutine, putting generated PCM into a queue. `nextChunk` blocks
+ *    on queue.take. Subject to producer-can't-keep-up underrun.
+ *  - `CacheFileSource` (PR-E) mmap-reads a pre-rendered chapter PCM file.
+ *    Never blocks for long.
+ *
+ * The consumer treats both uniformly. When the source is exhausted
+ * (chapter end), `nextChunk` returns null.
+ */
+sealed interface PcmSource {
+
+    val sampleRate: Int
+
+    /**
+     * Pull the next chunk. Suspends if the source has no chunk ready
+     * (streaming impl: producer hasn't generated the next sentence yet;
+     * cache impl: never blocks meaningfully). Returns null when the
+     * chapter is fully drained.
+     *
+     * Cancellation: if the calling coroutine is cancelled, blocked
+     * impls must throw [kotlinx.coroutines.CancellationException]
+     * promptly so the consumer can shut down. The streaming impl
+     * achieves this via [kotlinx.coroutines.runInterruptible].
+     */
+    suspend fun nextChunk(): PcmChunk?
+
+    /**
+     * Re-anchor the source to the sentence containing [charOffset].
+     * Streaming impl cancels the producer and restarts at the new
+     * sentence index. Cache impl seeks the underlying file via the
+     * sidecar index.
+     */
+    suspend fun seekToCharOffset(charOffset: Int)
+
+    /** Release any resources (cancel producer, close mmap, etc). */
+    suspend fun close()
+}
+
+/**
+ * One chunk of PCM tagged with its sentence range. The trailing
+ * silence is intentional cadence; the consumer spools this many ms
+ * of silence-PCM after the audible PCM to give sentences breathing
+ * room. See [`in`.jphe.storyvox.playback.tts.EnginePlayer.trailingPauseMs].
+ */
+data class PcmChunk(
+    val sentenceIndex: Int,
+    val range: SentenceRange,
+    val pcm: ByteArray,
+    val trailingSilenceBytes: Int,
+) {
+    /** Equality is identity-based on sentenceIndex + first PCM byte
+     *  to keep equals cheap; the consumer never compares chunks. */
+    override fun equals(other: Any?): Boolean = this === other
+    override fun hashCode(): Int = sentenceIndex
+}
+```
+
+- [ ] **Step 2: Verify compile.**
+
+Run: `./gradlew :core-playback:compileDebugKotlin`
+Expected: BUILD SUCCESSFUL.
+
+- [ ] **Step 3: Commit.**
+
+```bash
+git add core-playback/src/main/kotlin/in/jphe/storyvox/playback/tts/source/PcmSource.kt
+git commit -m "refactor(playback): introduce PcmSource interface + PcmChunk
+
+Pre-extraction step for the chapter-cache work. Defines a uniform
+contract the consumer can pull PCM from; PR-A's EngineStreamingSource
+implements the existing engine-driven pipeline against it, future
+PR-E adds CacheFileSource."
+```
+
+### Task A2: Move producer + queue into `EngineStreamingSource`, write the failing test
+
+**Files:**
+- Create: `core-playback/src/main/kotlin/in/jphe/storyvox/playback/tts/source/EngineStreamingSource.kt`
+- Create: `core-playback/src/test/kotlin/in/jphe/storyvox/playback/tts/source/EngineStreamingSourceTest.kt`
+
+The streaming source owns: the producer coroutine, the `LinkedBlockingQueue<PcmChunk>`, the `engineMutex`, the trailing-silence sizing logic moved out of EnginePlayer. EnginePlayer keeps the AudioTrack write loop, the `pipelineRunning` flag, and lifecycle.
+
+- [ ] **Step 1: Write the failing test for `nextChunk` happy path.**
+
+```kotlin
+package `in`.jphe.storyvox.playback.tts.source
+
+import `in`.jphe.storyvox.playback.SentenceRange
+import `in`.jphe.storyvox.playback.tts.Sentence
+import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNull
+import org.junit.Test
+
+class EngineStreamingSourceTest {
+
+    @Test
+    fun `nextChunk returns sentences in order then null at end`() = runTest {
+        val sentences = listOf(
+            Sentence(0, 0,  10, "One."),
+            Sentence(1, 11, 20, "Two."),
+            Sentence(2, 21, 30, "Three."),
+        )
+        val fakeEngine = FakeVoiceEngine(
+            sampleRate = 22050,
+            pcmFor = { text -> ByteArray(text.length * 2) { 0 } },
+        )
+        val source = EngineStreamingSource(
+            sentences = sentences,
+            startSentenceIndex = 0,
+            engine = fakeEngine,
+            speed = 1.0f,
+            pitch = 1.0f,
+        )
+
+        val c0 = source.nextChunk(); val c1 = source.nextChunk(); val c2 = source.nextChunk()
+        val end = source.nextChunk()
+
+        assertEquals(0, c0?.sentenceIndex)
+        assertEquals(1, c1?.sentenceIndex)
+        assertEquals(2, c2?.sentenceIndex)
+        assertNull(end)
+
+        source.close()
+    }
+}
+
+/** Test fake — returns deterministic PCM for any text. */
+private class FakeVoiceEngine(
+    override val sampleRate: Int,
+    val pcmFor: (String) -> ByteArray,
+) : EngineStreamingSource.VoiceEngineHandle {
+    override fun generateAudioPCM(text: String, speed: Float, pitch: Float): ByteArray? = pcmFor(text)
+}
+```
+
+- [ ] **Step 2: Run test, expect compilation failure.**
+
+Run: `./gradlew :core-playback:testDebugUnitTest --tests "*EngineStreamingSourceTest*"`
+Expected: FAIL — `EngineStreamingSource` not found.
+
+- [ ] **Step 3: Implement `EngineStreamingSource` (minimal).**
+
+```kotlin
+package `in`.jphe.storyvox.playback.tts.source
+
+import `in`.jphe.storyvox.playback.SentenceRange
+import `in`.jphe.storyvox.playback.tts.Sentence
+import java.util.concurrent.LinkedBlockingQueue
+import java.util.concurrent.atomic.AtomicBoolean
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.runInterruptible
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
+
+/**
+ * Drives VoxSherpa's [VoiceEngine]-style handle on a worker coroutine,
+ * putting generated PCM into a bounded queue. The consumer (EnginePlayer's
+ * AudioTrack writer thread) pulls from [nextChunk]. Mirrors the producer
+ * half of EnginePlayer.startPlaybackPipeline pre-PR-A.
+ *
+ * Why a [LinkedBlockingQueue] not a coroutine [Channel]: the
+ * EnginePlayer consumer is a pinned OS thread at URGENT_AUDIO; pulling
+ * via Channel would force it through the coroutine dispatcher and lose
+ * the priority. We bridge via runInterruptible so the producer can
+ * coexist with structured concurrency for shutdown.
+ */
+class EngineStreamingSource(
+    private val sentences: List<Sentence>,
+    startSentenceIndex: Int,
+    private val engine: VoiceEngineHandle,
+    private val speed: Float,
+    private val pitch: Float,
+    private val queueCapacity: Int = 8,
+) : PcmSource {
+
+    /** SAM-style handle so we can fake the engine in tests without
+     *  pulling VoxSherpa onto the unit-test classpath. */
+    interface VoiceEngineHandle {
+        val sampleRate: Int
+        fun generateAudioPCM(text: String, speed: Float, pitch: Float): ByteArray?
+    }
+
+    override val sampleRate: Int = engine.sampleRate
+
+    private val scope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
+    private val running = AtomicBoolean(true)
+    private val queue = LinkedBlockingQueue<Item>(queueCapacity)
+    private val engineMutex = Mutex()
+
+    @Volatile private var startIndex: Int = startSentenceIndex
+    private var producerJob: Job = startProducer(startSentenceIndex)
+
+    override suspend fun nextChunk(): PcmChunk? = runInterruptible {
+        val item = queue.take()
+        if (item === END_PILL) null else item.chunk
+    }
+
+    override suspend fun seekToCharOffset(charOffset: Int) {
+        // Find target sentence
+        val target = sentences.indexOfLast { it.startChar <= charOffset }
+            .takeIf { it >= 0 } ?: 0
+        producerJob.cancel()
+        // Drain queue so consumer doesn't pull stale chunks
+        queue.clear()
+        startIndex = target
+        producerJob = startProducer(target)
+    }
+
+    override suspend fun close() {
+        running.set(false)
+        producerJob.cancel()
+        queue.clear()
+        // Wake any consumer blocked in take()
+        queue.offer(END_PILL)
+        scope.cancel()
+    }
+
+    private fun startProducer(fromIndex: Int): Job = scope.launch {
+        try {
+            for (i in fromIndex until sentences.size) {
+                if (!running.get()) return@launch
+                val s = sentences[i]
+                val pcm = engineMutex.withLock {
+                    if (!running.get()) return@withLock null
+                    engine.generateAudioPCM(s.text, speed, pitch)
+                } ?: continue
+                val pauseMs = trailingPauseMs(s.text) / speed.coerceAtLeast(0.5f)
+                val silenceBytes = silenceBytesFor(pauseMs.toInt(), sampleRate)
+                val chunk = PcmChunk(
+                    sentenceIndex = i,
+                    range = SentenceRange(s.index, s.startChar, s.endChar),
+                    pcm = pcm,
+                    trailingSilenceBytes = silenceBytes,
+                )
+                runInterruptible { queue.put(Item(chunk)) }
+            }
+            runInterruptible { queue.put(END_PILL) }
+        } catch (_: Throwable) {
+            // Cancelled — silent
+        }
+    }
+
+    /** Wrapper so the END_PILL identity check is === safe. */
+    private class Item(val chunk: PcmChunk)
+
+    private companion object {
+        val END_PILL = Item(PcmChunk(-1, SentenceRange(-1, -1, -1), ByteArray(0), 0))
+    }
+}
+
+/** Length of trailing silence, by terminal punctuation. Moved verbatim
+ *  from EnginePlayer.trailingPauseMs (PR-A is a refactor; the logic
+ *  doesn't change). */
+internal fun trailingPauseMs(sentenceText: String): Int {
+    val closePunct: Set<Char> = setOf('"', '\'', ')', ']', '}', '”', '’', '»', '」')
+    var end = sentenceText.length
+    while (end > 0 && (sentenceText[end - 1].isWhitespace() ||
+            sentenceText[end - 1] in closePunct)) end--
+    if (end == 0) return 60
+    if (end >= 3 && sentenceText.regionMatches(end - 3, "...", 0, 3)) return 350
+    return when (sentenceText[end - 1]) {
+        '.', '!', '?', '…' -> 350
+        ';', ':' -> 200
+        ',', '—', '–', '-' -> 120
+        else -> 60
+    }
+}
+
+internal fun silenceBytesFor(durationMs: Int, sampleRate: Int): Int {
+    if (durationMs <= 0) return 0
+    return ((sampleRate.toLong() * durationMs / 1000L).toInt() * 2).coerceAtLeast(0)
+}
+```
+
+- [ ] **Step 4: Run test, expect pass.**
+
+Run: `./gradlew :core-playback:testDebugUnitTest --tests "*EngineStreamingSourceTest*"`
+Expected: PASS.
+
+- [ ] **Step 5: Commit.**
+
+```bash
+git add core-playback/src/main/kotlin/in/jphe/storyvox/playback/tts/source/EngineStreamingSource.kt \
+        core-playback/src/test/kotlin/in/jphe/storyvox/playback/tts/source/EngineStreamingSourceTest.kt
+git commit -m "refactor(playback): extract EngineStreamingSource from EnginePlayer
+
+Producer + queue + engineMutex move into a PcmSource impl. EnginePlayer
+will switch to consuming through this in the next commit; no behavior
+change yet because the producer logic is verbatim.
+
+Adds VoiceEngineHandle SAM so tests can fake the engine without pulling
+in the VoxSherpa AAR on the JVM unit-test path."
+```
+
+### Task A3: Add `nextChunk` cancellation test
+
+**Files:**
+- Modify: `core-playback/src/test/kotlin/in/jphe/storyvox/playback/tts/source/EngineStreamingSourceTest.kt`
+
+- [ ] **Step 1: Add test.**
+
+Append to the existing test class:
+
+```kotlin
+@Test
+fun `close interrupts a blocked nextChunk`() = runBlocking {
+    val sentences = listOf(Sentence(0, 0, 10, "One."))
+    // Engine that never returns — simulates synthesis taking forever.
+    val slowEngine = object : EngineStreamingSource.VoiceEngineHandle {
+        override val sampleRate: Int = 22050
+        override fun generateAudioPCM(text: String, speed: Float, pitch: Float): ByteArray? {
+            // Sleep so the producer can't outpace close()
+            Thread.sleep(2_000)
+            return ByteArray(100)
+        }
+    }
+    val source = EngineStreamingSource(sentences, 0, slowEngine, 1f, 1f)
+
+    // Pull on a coroutine; close() must unblock it within ~100ms
+    val pulled = kotlinx.coroutines.async {
+        source.nextChunk()
+    }
+    kotlinx.coroutines.delay(50)
+    source.close()
+    val started = System.currentTimeMillis()
+    val result = pulled.await()
+    val elapsed = System.currentTimeMillis() - started
+
+    // After close(), nextChunk should return null promptly (END_PILL),
+    // not wait for the slow engine.
+    assertNull(result)
+    assert(elapsed < 500) { "close() took $elapsed ms to unblock nextChunk" }
+}
+```
+
+- [ ] **Step 2: Run, expect pass (close() offers END_PILL).**
+
+Run: `./gradlew :core-playback:testDebugUnitTest --tests "*EngineStreamingSourceTest*"`
+Expected: PASS (both tests).
+
+- [ ] **Step 3: Commit.**
+
+```bash
+git add core-playback/src/test/kotlin/in/jphe/storyvox/playback/tts/source/EngineStreamingSourceTest.kt
+git commit -m "test(playback): close() unblocks nextChunk
+
+Regression guard for the runInterruptible bridge — without END_PILL,
+a blocked queue.take inside nextChunk would survive close() until
+the slow engine finally returned. Real-world: voice swap mid-chapter
+or seek during inference."
+```
+
+### Task A4: Switch EnginePlayer to consume from `PcmSource`
+
+**Files:**
+- Modify: `core-playback/src/main/kotlin/in/jphe/storyvox/playback/tts/EnginePlayer.kt`
+
+This is the load-bearing change. The consumer thread inside `startPlaybackPipeline` now pulls from `source.nextChunk()` (suspending) instead of `queue.take()` (blocking). To preserve URGENT_AUDIO priority on the consumer, we keep the consumer as a pinned `Thread`, and bridge to suspending via `kotlinx.coroutines.runBlocking { source.nextChunk() }`. The `runBlocking` on a dedicated audio thread is acceptable — it's the same shape as the existing `runInterruptible` bridge.
+
+- [ ] **Step 1: Replace producer fields + producer launch with source instance.**
+
+In `EnginePlayer.kt`, locate the `// Producer-consumer plumbing` block (roughly lines 187-215 in the original). Replace this region:
+
+```kotlin
+private var pcmQueue: LinkedBlockingQueue<SentencePcm>? = null
+private var generationJob: Job? = null
+```
+
+with:
+
+```kotlin
+private var streamingSource: PcmSource? = null
+```
+
+Delete the `SentencePcm` data class declaration at the top of the same block — it's now `PcmChunk` inside `PcmSource.kt`.
+
+- [ ] **Step 2: Replace `startPlaybackPipeline` body.**
+
+Find the existing function and replace its body with:
+
+```kotlin
+private fun startPlaybackPipeline() {
+    stopPlaybackPipeline()
+
+    val engineType = activeEngineType
+    val sampleRate = when (engineType) {
+        is EngineType.Kokoro -> KokoroEngine.getInstance().sampleRate
+        else -> VoiceEngine.getInstance().sampleRate
+    }.takeIf { it > 0 } ?: DEFAULT_SAMPLE_RATE
+    val track = createAudioTrack(sampleRate)
+    audioTrack = track
+
+    val source = EngineStreamingSource(
+        sentences = sentences,
+        startSentenceIndex = currentSentenceIndex,
+        engine = activeVoiceEngineHandle(engineType),
+        speed = currentSpeed,
+        pitch = currentPitch,
+    )
+    streamingSource = source
+    pipelineRunning.set(true)
+
+    consumerThread = Thread({
+        AndroidProcess.setThreadPriority(AndroidProcess.THREAD_PRIORITY_URGENT_AUDIO)
+        var firstChunk = true
+        var lastVol = -1f
+        var naturalEnd = false
+        try {
+            while (pipelineRunning.get()) {
+                val chunk = try {
+                    runBlocking { source.nextChunk() }
+                } catch (_: Throwable) { null }
+                    ?: run { naturalEnd = pipelineRunning.get(); break }
+
+                scope.launch {
+                    currentSentenceIndex = chunk.sentenceIndex
+                    _observableState.update {
+                        it.copy(
+                            currentSentenceRange = chunk.range,
+                            charOffset = chunk.range.startCharInChapter,
+                        )
+                    }
+                }
+
+                if (firstChunk) {
+                    val v = volumeRamp.current
+                    runCatching { track.setVolume(v) }
+                    lastVol = v
+                    runCatching { track.play() }
+                    firstChunk = false
+                }
+
+                writePcmRespectingVolume(track, chunk.pcm, lastVolHolder = ::lastVolGet, set = { lastVol = it })
+                writeSilenceRespectingVolume(track, chunk.trailingSilenceBytes, ::lastVolGet, set = { lastVol = it })
+            }
+        } finally {
+            runCatching { track.pause() }
+            runCatching { track.flush() }
+            runCatching { track.release() }
+            if (naturalEnd && pipelineRunning.get()) {
+                scope.launch {
+                    sleepTimer.signalChapterEnd()
+                    handleChapterDone()
+                }
+            }
+        }
+    }, "storyvox-audio-out").apply {
+        isDaemon = true
+        start()
+    }
+}
+
+/** Helper holders the inner thread closes over. They look ugly but
+ *  Kotlin doesn't let us mutate a captured local from inside another
+ *  function, and the alternative is duplicating two write loops. */
+private var consumerLastVol: Float = -1f
+private fun lastVolGet(): Float = consumerLastVol
+
+private fun writePcmRespectingVolume(
+    track: AudioTrack,
+    pcm: ByteArray,
+    lastVolHolder: () -> Float,
+    set: (Float) -> Unit,
+) {
+    var written = 0
+    while (written < pcm.size && pipelineRunning.get()) {
+        val v = volumeRamp.current
+        if (v != lastVolHolder()) {
+            runCatching { track.setVolume(v) }
+            set(v)
+            consumerLastVol = v
+        }
+        val n = track.write(pcm, written, pcm.size - written)
+        if (n < 0) break
+        written += n
+    }
+}
+
+private fun writeSilenceRespectingVolume(
+    track: AudioTrack,
+    bytes: Int,
+    lastVolHolder: () -> Float,
+    set: (Float) -> Unit,
+) {
+    var remaining = bytes
+    while (remaining > 0 && pipelineRunning.get()) {
+        val v = volumeRamp.current
+        if (v != lastVolHolder()) {
+            runCatching { track.setVolume(v) }
+            set(v)
+            consumerLastVol = v
+        }
+        val chunk = remaining.coerceAtMost(SILENCE_CHUNK.size)
+        val n = track.write(SILENCE_CHUNK, 0, chunk)
+        if (n < 0) break
+        remaining -= n
+    }
+}
+
+/** Bridge to the existing VoxSherpa singletons via the
+ *  EngineStreamingSource.VoiceEngineHandle SAM. */
+private fun activeVoiceEngineHandle(engineType: EngineType?): EngineStreamingSource.VoiceEngineHandle =
+    object : EngineStreamingSource.VoiceEngineHandle {
+        override val sampleRate: Int = when (engineType) {
+            is EngineType.Kokoro -> KokoroEngine.getInstance().sampleRate
+            else -> VoiceEngine.getInstance().sampleRate
+        }
+        override fun generateAudioPCM(text: String, speed: Float, pitch: Float): ByteArray? = when (engineType) {
+            is EngineType.Kokoro -> KokoroEngine.getInstance().generateAudioPCM(text, speed, pitch)
+            else -> VoiceEngine.getInstance().generateAudioPCM(text, speed, pitch)
+        }
+    }
+```
+
+- [ ] **Step 3: Replace `stopPlaybackPipeline` body to close the source.**
+
+```kotlin
+private fun stopPlaybackPipeline() {
+    pipelineRunning.set(false)
+
+    val track = audioTrack
+    audioTrack = null
+    track?.let {
+        runCatching { it.pause() }
+        runCatching { it.flush() }
+    }
+
+    val src = streamingSource
+    streamingSource = null
+    if (src != null) {
+        runBlocking { src.close() }
+    }
+
+    val t = consumerThread
+    consumerThread = null
+    if (t != null && t !== Thread.currentThread()) {
+        t.interrupt()
+        try { t.join(2_000) } catch (_: InterruptedException) {}
+    }
+}
+```
+
+- [ ] **Step 4: Delete now-unused `trailingPauseMs`, `silenceBytesFor`, `SentencePcm` from EnginePlayer (they live in source/EngineStreamingSource.kt now).**
+
+Search and remove from EnginePlayer.kt:
+- the entire `private fun trailingPauseMs(sentenceText: String): Int { ... }` block
+- the entire `private fun silenceBytesFor(durationMs: Int, sampleRate: Int): Int { ... }` block
+- the `private data class SentencePcm(...)` declaration
+- the `NATURAL_END_PILL` companion-object constant
+- the unused `LinkedBlockingQueue`, `engineMutex`, and `runInterruptible` imports if no longer referenced
+
+Keep `SILENCE_CHUNK` (still used by the consumer for silence spool).
+
+- [ ] **Step 5: Build full module.**
+
+Run: `./gradlew :core-playback:assembleDebug`
+Expected: BUILD SUCCESSFUL.
+
+- [ ] **Step 6: Run all core-playback tests.**
+
+Run: `./gradlew :core-playback:testDebugUnitTest`
+Expected: ALL PASS (existing tests + new EngineStreamingSourceTest).
+
+- [ ] **Step 7: Commit.**
+
+```bash
+git add core-playback/src/main/kotlin/in/jphe/storyvox/playback/tts/EnginePlayer.kt
+git commit -m "refactor(playback): EnginePlayer consumes via PcmSource
+
+Producer + engineMutex + queue moved into EngineStreamingSource. Consumer
+keeps URGENT_AUDIO pinned thread + AudioTrack ownership. Bridges to the
+suspending source via runBlocking on the audio thread (acceptable on a
+dedicated thread, same shape as the prior runInterruptible bridge).
+
+Behavioral no-op: same producer/consumer shape, same trailingPauseMs
+semantics, same engineMutex, same queue depth. Verifying via the existing
+test suite — runtime parity confirmed on Tab A7 Lite separately."
+```
+
+### Task A5: Tablet smoke-test PR A on R83W80CAFZB
+
+**Files:** none
+
+- [ ] **Step 1: Claim tablet lock.**
+
+Run: `gh task update 47 --owner aurelia` (or via TaskUpdate tool).
+Expected: lock owned.
+
+- [ ] **Step 2: Build + install.**
+
+```bash
+./gradlew :app:assembleDebug
+adb -s R83W80CAFZB install -r app/build/outputs/apk/debug/app-debug.apk
+```
+
+Expected: SUCCESS.
+
+- [ ] **Step 3: Foreground app, play Sky Pride Ch.1 for 60 s.**
+
+```bash
+adb -s R83W80CAFZB shell am start -n in.jphe.storyvox/.MainActivity
+```
+
+Manual: tap Library → Sky Pride → Chapter 1 → Play. Listen for 60 s.
+
+Expected: same behavior as before this PR — producing audio with audible inter-chunk gaps (the gaps DON'T go away; that's PR-C-F's job). No crashes. Sentence highlight glide still tracks. Pause + resume works. Seek works.
+
+- [ ] **Step 4: Release tablet lock.**
+
+Run: `TaskUpdate id=47 owner=""`.
+
+- [ ] **Step 5: Push branch.**
+
+```bash
+git push origin dream/aurelia/tts-chunk-gap
+```
+
+### Task A6: Open PR A
+
+**Files:** none
+
+- [ ] **Step 1: Open PR via gh.**
+
+```bash
+gh pr create --base main --head dream/aurelia/tts-chunk-gap \
+  --title "refactor(playback): extract PcmSource interface from EnginePlayer" \
+  --body "$(cat <<'EOF'
+## Summary
+
+Behavioral no-op refactor that introduces a `PcmSource` interface
+between EnginePlayer and the VoxSherpa engine. The producer +
+LinkedBlockingQueue + engineMutex move out of EnginePlayer into the
+new `EngineStreamingSource` impl. EnginePlayer's URGENT_AUDIO consumer
+thread now pulls from `source.nextChunk()` instead of `queue.take()`.
+
+Pure refactor — same producer/consumer shape, same trailingPauseMs
+semantics, same queue depth, same AudioTrack write loop. Pre-extraction
+step for the chapter-cache work spec'd in
+`docs/superpowers/specs/2026-05-07-pcm-cache-design.md`.
+
+## Why
+
+Measured baseline (separate run, captured 2026-05-07 23:22Z, see
+`scratch/aurelia-tts-chunk-gap/baseline.md`): Piper-high \"cori\" on
+R83W80CAFZB synthesizes audio at **0.285× realtime** — producer is
+3.5× slower than playback, median inter-chunk gap 8021 ms. The full
+fix requires moving synthesis off the playback hot path (PR-C-F);
+this PR is the no-op refactor that lets PR-E plug a CacheFileSource
+into the same consumer.
+
+## Test plan
+
+- [x] core-playback unit tests pass (`:core-playback:testDebugUnitTest`)
+- [x] new EngineStreamingSourceTest covers nextChunk happy path + close-while-blocked
+- [x] R83W80CAFZB smoke test: play Sky Pride Ch.1 for 60s — same behavior as pre-PR (audible gaps remain, that's expected; PR-C-F closes them)
+- [x] sentence highlight glide tracks normally
+- [x] pause/resume works
+- [x] seek works
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+EOF
+)"
+```
+
+- [ ] **Step 2: Wait for copilot-pull-request-reviewer[bot] review (per memory feedback_copilot_review_required.md).**
+
+Poll: `gh pr view <num> --json reviews`
+Address any feedback in additional commits.
+
+- [ ] **Step 3: After approval, squash-merge.**
+
+```bash
+gh pr merge <num> --squash --delete-branch=false
+```
+
+Keep the branch — PR-B builds on it.
+
+---
+
+## PR B: pause-buffer-resume
+
+### Task B1: Add `bufferHeadroomMs` to `EngineStreamingSource`
+
+**Files:**
+- Modify: `core-playback/src/main/kotlin/in/jphe/storyvox/playback/tts/source/EngineStreamingSource.kt`
+
+`headroomMs` = total ms of audio currently sitting in the queue (sum of `pcm.size / sampleRate / 2 * 1000` over queued chunks). Updated on every `put` (producer) and `take` (consumer). Backed by a `MutableStateFlow<Long>`.
+
+- [ ] **Step 1: Add the StateFlow + update logic.**
+
+Add to the `EngineStreamingSource` class:
+
+```kotlin
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+
+private val _bufferHeadroomMs = MutableStateFlow(0L)
+/** Sum of audio duration of every PCM chunk currently in the queue.
+ *  The consumer pauses AudioTrack when this drops below the underrun
+ *  threshold, surfacing a "buffering" UI state instead of silence. */
+val bufferHeadroomMs: StateFlow<Long> = _bufferHeadroomMs.asStateFlow()
+
+private fun pcmDurationMs(pcm: ByteArray): Long =
+    pcm.size.toLong() * 1000L / (sampleRate.toLong() * 2L)
+```
+
+Modify the producer to update on put, and `nextChunk` to update on take. After:
+
+```kotlin
+runInterruptible { queue.put(Item(chunk)) }
+_bufferHeadroomMs.update { it + pcmDurationMs(pcm) + pauseMs.toLong() }
+```
+
+(import `kotlinx.coroutines.flow.update`)
+
+And in `nextChunk`:
+
+```kotlin
+override suspend fun nextChunk(): PcmChunk? = runInterruptible {
+    val item = queue.take()
+    if (item === END_PILL) return@runInterruptible null
+    val chunk = item.chunk
+    val durMs = pcmDurationMs(chunk.pcm) +
+        chunk.trailingSilenceBytes.toLong() * 1000L / (sampleRate.toLong() * 2L)
+    _bufferHeadroomMs.update { (it - durMs).coerceAtLeast(0L) }
+    chunk
+}
+```
+
+- [ ] **Step 2: Verify compile.**
+
+Run: `./gradlew :core-playback:compileDebugKotlin`
+
+- [ ] **Step 3: Commit.**
+
+```bash
+git add core-playback/src/main/kotlin/in/jphe/storyvox/playback/tts/source/EngineStreamingSource.kt
+git commit -m "feat(playback): EngineStreamingSource exposes bufferHeadroomMs
+
+Sum of buffered audio duration across queued chunks, updated on every
+producer put and consumer take. Consumer will pause AudioTrack when
+this drops below the underrun threshold (next commit)."
+```
+
+### Task B2: Test bufferHeadroomMs accounting
+
+**Files:**
+- Modify: `core-playback/src/test/kotlin/in/jphe/storyvox/playback/tts/source/EngineStreamingSourceTest.kt`
+
+- [ ] **Step 1: Add test.**
+
+```kotlin
+@Test
+fun `bufferHeadroomMs reflects queued audio duration`() = runTest {
+    val sentences = listOf(
+        Sentence(0, 0, 10, "One."),
+        Sentence(1, 11, 20, "Two."),
+    )
+    // 22050 * 2 = 44100 bytes per second of audio.
+    // 44100 bytes = 1000 ms at 22050 Hz mono 16bit.
+    val fakeEngine = FakeVoiceEngine(22050) { _ -> ByteArray(44100) }
+    val source = EngineStreamingSource(sentences, 0, fakeEngine, 1f, 1f)
+
+    // Wait for producer to fill the queue. Poll because the producer
+    // runs on Dispatchers.IO; we don't want to flake on test scheduler.
+    val deadline = System.currentTimeMillis() + 2000
+    while (System.currentTimeMillis() < deadline &&
+           source.bufferHeadroomMs.value < 2000) {
+        kotlinx.coroutines.delay(10)
+    }
+    // 2 sentences × (1000ms PCM + 350ms cadence) = 2700ms expected
+    val before = source.bufferHeadroomMs.value
+    assert(before >= 2000) { "expected >=2000ms headroom, got $before" }
+
+    val first = source.nextChunk()
+    assertEquals(0, first?.sentenceIndex)
+    val after = source.bufferHeadroomMs.value
+    // Headroom should drop by ~1350ms (1000ms PCM + 350ms cadence)
+    assert(after < before - 1000) {
+        "expected headroom to drop by >1000ms after take, was $before -> $after"
+    }
+
+    source.close()
+}
+```
+
+- [ ] **Step 2: Run.**
+
+Run: `./gradlew :core-playback:testDebugUnitTest --tests "*EngineStreamingSourceTest*"`
+Expected: PASS.
+
+- [ ] **Step 3: Commit.**
+
+```bash
+git add core-playback/src/test/kotlin/in/jphe/storyvox/playback/tts/source/EngineStreamingSourceTest.kt
+git commit -m "test(playback): bufferHeadroomMs accounts produced + consumed audio"
+```
+
+### Task B3: Add `isBuffering` to `PlaybackState`
+
+**Files:**
+- Modify: `core-playback/src/main/kotlin/in/jphe/storyvox/playback/PlaybackState.kt`
+- Modify: `core-playback/src/test/kotlin/in/jphe/storyvox/playback/PlaybackStateTest.kt`
+
+- [ ] **Step 1: Add field.**
+
+In `PlaybackState`, add after `isPlaying`:
+
+```kotlin
+val isPlaying: Boolean = false,
+/** True when the AudioTrack is paused waiting for the producer to
+ *  refill the queue past the underrun threshold. UI surfaces a
+ *  "buffering" spinner; differs from `!isPlaying` (user pause) and
+ *  from `isPlaying && sentenceEnd == 0` (initial warm-up). */
+val isBuffering: Boolean = false,
+val currentSentenceRange: SentenceRange? = null,
+```
+
+- [ ] **Step 2: Add test.**
+
+In PlaybackStateTest.kt:
+
+```kotlin
+@Test
+fun `isBuffering defaults false and serializes`() {
+    val s = PlaybackState(isBuffering = true, isPlaying = true, charOffset = 42)
+    val json = kotlinx.serialization.json.Json.encodeToString(PlaybackState.serializer(), s)
+    val round = kotlinx.serialization.json.Json.decodeFromString(PlaybackState.serializer(), json)
+    assertEquals(true, round.isBuffering)
+    assertEquals(true, round.isPlaying)
+    assertEquals(42, round.charOffset)
+
+    val default = PlaybackState()
+    assertEquals(false, default.isBuffering)
+}
+```
+
+- [ ] **Step 3: Run all core-playback tests.**
+
+Run: `./gradlew :core-playback:testDebugUnitTest`
+Expected: ALL PASS.
+
+- [ ] **Step 4: Commit.**
+
+```bash
+git add core-playback/src/main/kotlin/in/jphe/storyvox/playback/PlaybackState.kt \
+        core-playback/src/test/kotlin/in/jphe/storyvox/playback/PlaybackStateTest.kt
+git commit -m "feat(playback): add PlaybackState.isBuffering"
+```
+
+### Task B4: Wire consumer to pause on low buffer
+
+**Files:**
+- Modify: `core-playback/src/main/kotlin/in/jphe/storyvox/playback/tts/EnginePlayer.kt`
+
+The consumer collects `bufferHeadroomMs` on its own thread (NOT the main scope, to keep the audio thread independent). When headroom drops below `BUFFER_UNDERRUN_THRESHOLD_MS = 2000`, call `audioTrack.pause()` and emit `isBuffering = true`. When headroom climbs back above `BUFFER_RESUME_THRESHOLD_MS = 4000` (hysteresis to prevent thrash), call `audioTrack.play()` and emit `isBuffering = false`.
+
+The simplest implementation: poll `bufferHeadroomMs.value` between each chunk write. (Don't need a coroutine collector — the consumer thread runs the write loop and can read the StateFlow value directly.)
+
+- [ ] **Step 1: Add buffer-state tracking to the consumer thread.**
+
+In `startPlaybackPipeline`, modify the consumer thread loop:
+
+```kotlin
+consumerThread = Thread({
+    AndroidProcess.setThreadPriority(AndroidProcess.THREAD_PRIORITY_URGENT_AUDIO)
+    var firstChunk = true
+    var naturalEnd = false
+    var paused = false   // tracks AudioTrack.pause() vs .play() state
+    try {
+        while (pipelineRunning.get()) {
+
+            // Check buffer headroom BEFORE pulling the next chunk.
+            // If we're paused and headroom is back over the resume
+            // threshold, kick AudioTrack alive again before nextChunk
+            // (which may block).
+            val headroom = source.bufferHeadroomMs.value
+            if (paused && headroom >= BUFFER_RESUME_THRESHOLD_MS) {
+                runCatching { track.play() }
+                paused = false
+                scope.launch {
+                    _observableState.update { it.copy(isBuffering = false) }
+                }
+            }
+
+            val chunk = try {
+                runBlocking { source.nextChunk() }
+            } catch (_: Throwable) { null }
+                ?: run { naturalEnd = pipelineRunning.get(); break }
+
+            scope.launch {
+                currentSentenceIndex = chunk.sentenceIndex
+                _observableState.update {
+                    it.copy(
+                        currentSentenceRange = chunk.range,
+                        charOffset = chunk.range.startCharInChapter,
+                    )
+                }
+            }
+
+            if (firstChunk) {
+                val v = volumeRamp.current
+                runCatching { track.setVolume(v) }
+                consumerLastVol = v
+                runCatching { track.play() }
+                firstChunk = false
+            }
+
+            // Re-check headroom after take (which decremented it).
+            // If we just dropped below the underrun threshold AND
+            // we're not already paused, pause the track and emit
+            // buffering state. This MUST happen BEFORE we begin
+            // writing this chunk's PCM, because the AudioTrack
+            // hardware buffer is large enough that the next write
+            // would land seconds before the listener hears silence.
+            val afterTakeHeadroom = source.bufferHeadroomMs.value
+            if (!paused && afterTakeHeadroom < BUFFER_UNDERRUN_THRESHOLD_MS) {
+                runCatching { track.pause() }
+                paused = true
+                scope.launch {
+                    _observableState.update { it.copy(isBuffering = true) }
+                }
+            }
+
+            writePcmRespectingVolume(track, chunk.pcm, ::lastVolGet) { consumerLastVol = it }
+            writeSilenceRespectingVolume(track, chunk.trailingSilenceBytes, ::lastVolGet) { consumerLastVol = it }
+        }
+    } finally {
+        runCatching { track.pause() }
+        runCatching { track.flush() }
+        runCatching { track.release() }
+        if (paused) {
+            // Make sure UI doesn't get stuck in buffering on shutdown
+            scope.launch {
+                _observableState.update { it.copy(isBuffering = false) }
+            }
+        }
+        if (naturalEnd && pipelineRunning.get()) {
+            scope.launch {
+                sleepTimer.signalChapterEnd()
+                handleChapterDone()
+            }
+        }
+    }
+}, "storyvox-audio-out").apply {
+    isDaemon = true
+    start()
+}
+```
+
+Add the threshold constants to the companion object:
+
+```kotlin
+/** When buffered audio falls below this, pause AudioTrack and surface
+ *  a "buffering" UI state. Tab A7 Lite's hardware buffer is ~2-3 s
+ *  deep; pausing at 2 s gives the listener clear feedback before the
+ *  silence fully drains the buffer. */
+const val BUFFER_UNDERRUN_THRESHOLD_MS = 2_000L
+
+/** Hysteresis. Don't resume until we have this much queued or we'll
+ *  thrash pause/play on every chunk transition. */
+const val BUFFER_RESUME_THRESHOLD_MS = 4_000L
+```
+
+- [ ] **Step 2: Build.**
+
+Run: `./gradlew :core-playback:assembleDebug`
+Expected: BUILD SUCCESSFUL.
+
+- [ ] **Step 3: Run tests.**
+
+Run: `./gradlew :core-playback:testDebugUnitTest`
+Expected: ALL PASS.
+
+- [ ] **Step 4: Commit.**
+
+```bash
+git add core-playback/src/main/kotlin/in/jphe/storyvox/playback/tts/EnginePlayer.kt
+git commit -m "feat(playback): pause-buffer-resume on streaming underrun
+
+When buffered audio drops below 2 s the consumer pauses AudioTrack and
+sets PlaybackState.isBuffering=true; resumes when buffered audio
+recovers above 4 s (hysteresis prevents pause/play thrash on every
+chunk). Listener hears a clean pause + resume instead of silence
+dribbling out of an underrunning AudioTrack ring buffer.
+
+Doesn't fix the underlying gap (PR-C-F do, by moving synthesis to
+disk). This makes the gap an honest UX event."
+```
+
+### Task B5: Surface `isBuffering` in the brass-spinner UI
+
+**Files:**
+- Modify: `feature/src/main/kotlin/in/jphe/storyvox/feature/reader/AudiobookView.kt`
+
+Search for the existing `warmingUp` derived state (~line 128 in HEAD~ snapshot) and extend it to OR-in `isBuffering`.
+
+- [ ] **Step 1: Read the file to locate the `warmingUp` definitions.**
+
+```bash
+grep -n "warmingUp" feature/src/main/kotlin/in/jphe/storyvox/feature/reader/AudiobookView.kt
+```
+
+Expected output: two lines, one near 128 and one near 199.
+
+- [ ] **Step 2: Replace each `warmingUp` definition.**
+
+Find:
+```kotlin
+val warmingUp = state.isPlaying && state.sentenceEnd == 0
+```
+
+Replace with:
+```kotlin
+val warmingUp = state.isPlaying && state.sentenceEnd == 0
+val showSpinner = warmingUp || state.isBuffering
+```
+
+Then change every reference to `warmingUp` in the spinner / loading-block code to `showSpinner`. Keep the "Voice waking up…" label gated on `warmingUp` only (not on `showSpinner`); add a "Buffering…" label for `state.isBuffering && !warmingUp` so the user sees a different word during mid-stream buffering vs initial warm-up.
+
+Pattern:
+
+```kotlin
+val statusLabel = when {
+    warmingUp -> "Voice waking up…"
+    state.isBuffering -> "Buffering…"
+    else -> /* existing else branch */
+}
+```
+
+(Reuse the existing `Text(...)` block; just swap the text expression.)
+
+- [ ] **Step 3: Read the modified file end-to-end to confirm no leftover `warmingUp` reference where `showSpinner` is wanted.**
+
+- [ ] **Step 4: Build.**
+
+Run: `./gradlew :feature:assembleDebug :app:assembleDebug`
+Expected: BUILD SUCCESSFUL.
+
+- [ ] **Step 5: Commit.**
+
+```bash
+git add feature/src/main/kotlin/in/jphe/storyvox/feature/reader/AudiobookView.kt
+git commit -m "feat(reader): brass spinner during mid-stream buffering
+
+The warming-up spinner now surfaces for both initial voice load and
+mid-stream buffering events. Status label distinguishes 'Voice waking up…'
+(initial) from 'Buffering…' (underrun)."
+```
+
+### Task B6: Tablet verification on R83W80CAFZB
+
+**Files:** none
+
+- [ ] **Step 1: Claim tablet lock #47.**
+
+- [ ] **Step 2: Build + install.**
+
+```bash
+./gradlew :app:assembleDebug
+adb -s R83W80CAFZB install -r app/build/outputs/apk/debug/app-debug.apk
+```
+
+- [ ] **Step 3: Foreground app + play Sky Pride Ch.1 for 90 s.**
+
+Watch for:
+1. **Pre-PR-B baseline** comparison: previously, after ~10 s of clean playback, listener heard silence-then-audio cycles repeatedly.
+2. **Post-PR-B expected**: after ~10 s of clean playback, AudioTrack pauses cleanly with brass spinner + "Buffering…" label, then resumes when 4 s of audio is queued. No silence-from-AudioTrack-underrun.
+
+- [ ] **Step 4: Capture a screenshot of the buffering state.**
+
+```bash
+adb -s R83W80CAFZB shell screencap -p /sdcard/buffering.png
+adb -s R83W80CAFZB pull /sdcard/buffering.png ~/.claude/projects/-home-jp/scratch/aurelia-tts-chunk-gap/buffering-state.png
+```
+
+- [ ] **Step 5: Release tablet lock #47.**
+
+- [ ] **Step 6: Push branch.**
+
+### Task B7: Open PR B
+
+**Files:** none
+
+- [ ] **Step 1: Open PR.**
+
+```bash
+gh pr create --base main --head dream/aurelia/tts-chunk-gap \
+  --title "feat(playback): pause-buffer-resume instead of silent underrun" \
+  --body "$(cat <<'EOF'
+## Summary
+
+When the streaming TTS pipeline underruns on slow voice + slow device
+combos (Piper-high on Tab A7 Lite has a 0.285× realtime synthesis rate;
+producer falls 715 ms/sec behind playback), the listener used to hear
+intermittent silence as the AudioTrack hardware buffer drained. Now,
+when buffered audio drops below 2 s, the consumer pauses AudioTrack
+and surfaces a 'Buffering…' UI state via the existing brass spinner;
+playback resumes when 4 s of audio is queued (hysteresis).
+
+This does NOT close the gap — synthesis is still 3.5× too slow for
+this combo, gaps still happen periodically. PR makes the gap an honest
+UX event instead of dead air. The structural fix (chapter PCM cache,
+playing from disk) is spec'd in
+docs/superpowers/specs/2026-05-07-pcm-cache-design.md and follows in
+PR-C-F.
+
+## Why
+
+JP measured baseline of 8 s median inter-chunk silence on Piper-high.
+Smallest immediate-relief change: convert the silence to a paused-with-
+spinner state so listeners know the device is working, not broken.
+
+## Test plan
+
+- [x] core-playback unit tests pass — bufferHeadroomMs accounting +
+      isBuffering serialization
+- [x] R83W80CAFZB: play Sky Pride Ch.1 for 90 s on Piper-high. Brass
+      spinner with 'Buffering…' label appears mid-chapter on underrun;
+      AudioTrack resumes cleanly when buffer recovers
+- [x] No regression in voice-warm-up spinner (initial 'Voice waking up…'
+      still shows pre-first-chunk)
+- [x] Pause/resume by user still works
+- [x] Sleep timer fade still works through buffering events
+- [x] No buffering label sticks after pause/stop
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+EOF
+)"
+```
+
+- [ ] **Step 2: Wait for copilot review (per memory feedback_copilot_review_required.md).**
+
+- [ ] **Step 3: After approval, ship via /ship patch (auto-bumps to v0.4.27, commits CHANGELOG, pushes tag, CI builds + uploads APK).**
+
+Memory note: ship pipeline auto-runs commit → push → tag → CI on JP's "ship it" or equivalent. Per memory `feedback_ship_dont_investigate.md`, JP wants the next tagged release as soon as the candidate is in the tree.
+
+```bash
+# After PR squash-merges:
+git checkout main && git pull
+/ship patch
+```
+
+The /ship skill handles version bump + CHANGELOG + tag + CI. CI builds the APK and the existing release-install workflow (per memory `feedback_install_test_each_iteration.md`) will pick it up.
+
+---
+
+## Self-review
+
+**Spec coverage check:**
+- ✓ PR A — PcmSource extraction → Tasks A1–A6
+- ✓ PR B — pause-buffer-resume + isBuffering → Tasks B1–B7
+- ✓ Out-of-scope PRs (C-H) called out in the goal block
+- ✓ All cited memories (`feedback_install_test_each_iteration.md`, `feedback_copilot_review_required.md`, `feedback_ship_dont_investigate.md`) are referenced where relevant
+- ✓ Tablet lock #47 protocol followed (claim → install → release) in Tasks A5 and B6
+- ✓ JP's success criterion ("high-quality voices smooth on slow devices") explicitly noted as NOT met by this PR — full spec's PR-C-F closes the gap
+
+**Placeholder scan:** None. Every Kotlin block is complete and compilable in context.
+
+**Type consistency:** `PcmSource.nextChunk()` signature is identical across A1, A2, A3, B1. `PcmChunk` fields (`sentenceIndex`, `range`, `pcm`, `trailingSilenceBytes`) are consistent. `EngineStreamingSource.VoiceEngineHandle` SAM contract identical in A2 and A4.
+
+**Outstanding:** the runBlocking-on-audio-thread pattern in Task A4 is a deliberate trade-off — the audio consumer thread is dedicated and pinned at URGENT_AUDIO, so blocking it doesn't starve any other work. Documented inline in the commit message. If a code reviewer flags it, the alternative is a bounded `Channel` and a coroutine-driven consumer, which loses the URGENT_AUDIO pinning that the original docstring (EnginePlayer line 397-411) calls out as load-bearing for clean output on Tab A7 Lite.
+
+---
+
+## Execution
+
+Plan complete and saved to `docs/superpowers/plans/2026-05-07-pcm-cache-pr-a-and-b.md`.
+
+In auto mode (per JP's instruction "do it all"), I'll proceed via **Inline Execution** using the executing-plans skill — batch-executing PR A end-to-end (A1-A6) with a checkpoint after `:core-playback:testDebugUnitTest` passes, then PR B (B1-B7) with a checkpoint after tablet verification. PR-open and CI ship are JP-visible boundaries; everything in between stays inside this session.

--- a/docs/superpowers/specs/2026-05-07-pcm-cache-design.md
+++ b/docs/superpowers/specs/2026-05-07-pcm-cache-design.md
@@ -1,0 +1,425 @@
+# Chapter PCM Cache — Design Spec
+
+**Author:** Aurelia (perf lane)
+**Date:** 2026-05-07
+**Status:** Draft, awaiting JP review
+**Branch:** `dream/aurelia/tts-chunk-gap`
+
+## Problem
+
+On Galaxy Tab A7 Lite (Helio P22T, 3 GB RAM) running Piper-high "cori",
+TTS synthesis runs at **0.285× realtime** — the producer falls behind
+playback by ~700 ms per second of audio, indefinitely. Measured baseline:
+
+| metric | value |
+|---|---|
+| chunks captured | 20 (Sky Pride Ch.1, sentences 8-28) |
+| audio synthesized | 45520 ms |
+| wall time spent generating | 159820 ms |
+| realtime factor | **0.285×** |
+| inter-chunk audible gap (median) | **8021 ms** |
+| inter-chunk audible gap (max) | **19601 ms** |
+
+The current streaming pipeline (producer/consumer with 8-slot prefetch
+queue, dedicated URGENT_AUDIO consumer thread, AudioTrack at minBufferSize)
+has a one-time grace at chapter start (queue + AudioTrack hardware buffer
+≈ 10-30 s of cushion), then steady-state underrun is unavoidable. No
+in-pipeline tuning closes the gap when synthesis < playback rate.
+
+JP's success criterion: **high-quality voices play smoothly on slow devices**.
+
+## Solution: render to disk, stream from disk
+
+Move synthesis off the playback hot path. Render each chapter's PCM to a
+cache file with a sentence-offset sidecar index. Playback streams from
+the cache file rather than from live engine output. When the cache exists
+and is complete, playback is gapless on any device because no inference
+runs in the playback thread.
+
+Streaming synthesis remains as fallback for first-ever chapter plays
+(cache miss); the streaming path adds a "buffering" UI state instead of
+emitting silence on underrun.
+
+## UX shape
+
+| user action | behavior |
+|---|---|
+| First-ever chapter play (no cache) | Streams via current pipeline, with **pause-buffer-resume** when head-room < 2 s. Cache renders in background as a side-effect of playback (each generated PCM byte appended to cache file). |
+| Replay of cached chapter | Instant. Plays from cache file, gapless. |
+| Adds fiction (FAB → URL paste, Library "+", browse → add) | Schedules render of chapters 1-3 in background. |
+| Finishes a chapter via natural-end | Schedules render of chapter N+2 (N+1 is usually already rendered or in flight). |
+| Voice swap mid-chapter | Cache is voice-keyed; current chapter's old-voice cache stays on disk (LRU-evictable). Re-render with new voice in background. Playback streams via fallback path until new cache catches up. |
+| Speed/pitch change | Same as voice swap — cache key includes speed and pitch quantized to 2 decimals. |
+| Seek backward into rendered region | Instant seek (file offset lookup via index). |
+| Seek forward past rendered watermark | Streaming fallback resumes from the seek target until cache catches up. |
+
+## Architecture
+
+```
+┌─────────────────────────────────────────────────────────────────┐
+│                        EnginePlayer                              │
+│  (existing SimpleBasePlayer surface, unchanged externally)       │
+│                                                                  │
+│  ┌──────────────────────────────────────────────────────────┐   │
+│  │ loadAndPlay(fictionId, chapterId, charOffset):           │   │
+│  │   key = PcmCacheKey(chapterId, voiceId, speed, pitch,    │   │
+│  │                     chunkerVersion)                       │   │
+│  │   if pcmCache.isComplete(key):                           │   │
+│  │     source = CacheFileSource(pcmCache.fileFor(key),      │   │
+│  │                              pcmCache.indexFor(key))     │   │
+│  │   else:                                                   │   │
+│  │     source = EngineStreamingSource(engine, sentences,    │   │
+│  │                                    pcmCache.appender(key))│   │
+│  │     scheduler.scheduleRender(key, fictionId, chapterId)  │   │
+│  │   pipeline = PlaybackPipeline(source, audioTrack,        │   │
+│  │                               sentenceTracker)            │   │
+│  └──────────────────────────────────────────────────────────┘   │
+└─────────────────────────────────────────────────────────────────┘
+
+         ▲                        ▲                       ▲
+         │                        │                       │
+   ┌─────┴────┐          ┌────────┴──────┐         ┌──────┴──────┐
+   │PcmSource │          │   PcmCache    │         │  Render-    │
+   │interface │          │ (LRU + quota) │         │ Scheduler   │
+   └──────────┘          └───────────────┘         └─────────────┘
+        ▲
+   ┌────┴──────────────────────────┐
+   │                                │
+┌──┴───────────────┐    ┌───────────┴──────────────────┐
+│ CacheFileSource  │    │   EngineStreamingSource      │
+│ (mmap PCM file,  │    │  (current producer/consumer  │
+│  read sequentially│   │   pipeline + cache appender   │
+│  from offset)    │    │   tee + buffer-low signal)   │
+└──────────────────┘    └──────────────────────────────┘
+```
+
+## Components
+
+### `PcmCacheKey`
+
+```kotlin
+data class PcmCacheKey(
+    val chapterId: String,
+    val voiceId: String,
+    val speedHundredths: Int,   // currentSpeed * 100, rounded
+    val pitchHundredths: Int,
+    val chunkerVersion: Int,    // bump in SentenceChunker if logic changes
+) {
+    fun fileBaseName(): String  // SHA-256 of toString()
+}
+```
+
+**Why all five fields:** the audio depends on every one. Same chapter at
+1.0× and 1.2× speed are different audio. Same voice with pitch shift = same.
+Chunker version invalidates if sentence boundaries change between releases
+(otherwise the sidecar index is wrong).
+
+### `PcmCache`
+
+Filesystem-backed cache with LRU eviction.
+
+```kotlin
+@Singleton
+class PcmCache @Inject constructor(
+    @ApplicationContext private val context: Context,
+    private val cacheConfig: PcmCacheConfig,
+) {
+    suspend fun isComplete(key: PcmCacheKey): Boolean
+    fun fileFor(key: PcmCacheKey): File          // PCM data
+    fun indexFor(key: PcmCacheKey): File         // sidecar JSON
+    fun appender(key: PcmCacheKey): PcmAppender  // streaming-fallback writer
+
+    suspend fun evictTo(quotaBytes: Long, pinnedKeys: Set<PcmCacheKey>)
+    suspend fun totalSizeBytes(): Long
+    suspend fun delete(key: PcmCacheKey)
+    suspend fun deleteAllForChapter(chapterId: String)  // chapter text changed
+}
+
+class PcmAppender(file: File, indexFile: File) {
+    fun appendSentence(sentence: Sentence, pcm: ByteArray)
+    fun finalize()  // writes the index file, marks cache complete
+    fun abandon()   // deletes partial files (e.g. on user-pause-during-stream)
+}
+```
+
+**Files on disk:**
+- `${cacheDir}/pcm-cache/<sha>.pcm` — raw 16-bit signed mono PCM at engine sample rate
+- `${cacheDir}/pcm-cache/<sha>.idx.json` — sentence offset index, written ONLY when render completes (presence = "cache is complete")
+- `${cacheDir}/pcm-cache/<sha>.meta.json` — voice id, sample rate, sentence count, total bytes, created timestamp; written at start of render so an in-progress render is identifiable
+
+Index format (sidecar JSON):
+```json
+{
+  "sample_rate": 22050,
+  "sentence_count": 87,
+  "total_bytes": 71098368,
+  "sentences": [
+    {"i": 0, "start": 0,   "end": 142, "byte_offset": 0,         "byte_len": 824032},
+    {"i": 1, "start": 142, "end": 287, "byte_offset": 824032,    "byte_len": 656128},
+    ...
+  ]
+}
+```
+
+`start`/`end` are character offsets into the chapter's plaintext (so
+`SentenceTracker` can keep working unchanged). `byte_offset`/`byte_len`
+locate the sentence's PCM in the .pcm file.
+
+**Quota:** default 2 GB user-configurable in Settings:
+- 500 MB (light)
+- 2 GB (default — ~30 chapters of Piper-high Sky Pride)
+- 5 GB
+- Unlimited
+
+LRU based on file mtime updated on every play (touch the .pcm file when
+opening). Pinned: currently-playing chapter + next chapter in sequence
+(if known). Eviction runs at scheduler enqueue time and after each render
+completes.
+
+### `PcmCacheConfig`
+
+DataStore-backed user preference, `quotaBytes`, default 2 GB. Read on
+demand from Settings, no DI cycles.
+
+### `PcmSource` (interface)
+
+```kotlin
+sealed interface PcmSource {
+    val sampleRate: Int
+    val sentenceCount: Int
+
+    /** Yields ranges of PCM with their sentence index. Suspending so
+     *  the streaming impl can block on engine generation. The cached
+     *  impl returns immediately from mmap. */
+    suspend fun nextChunk(consumed: Long): PcmChunk?
+    suspend fun seekToCharOffset(offset: Int): PcmChunk?
+    suspend fun close()
+}
+
+data class PcmChunk(
+    val sentenceIndex: Int,
+    val sentenceRange: SentenceRange,
+    val pcm: ByteBuffer,         // direct buffer, mmap'd or fresh
+    val trailingSilenceMs: Int,
+)
+```
+
+### `CacheFileSource`
+
+mmap's the .pcm file via `RandomAccessFile.channel.map(READ_ONLY, 0, len)`,
+reads sequentially with optional seek. Loads the index JSON once at construction.
+No engine calls — playback is purely I/O bound, which on internal flash is
+trivially fast (>100 MB/s sequential read).
+
+`trailingSilenceMs` is read from the index (computed by `trailingPauseMs()`
+at render time).
+
+### `EngineStreamingSource`
+
+The current producer/consumer pipeline, refactored to expose `nextChunk()`.
+Internally still has the IO-coroutine producer + LinkedBlockingQueue +
+URGENT_AUDIO consumer thread. **Tee writes** every generated PCM byte
+to a `PcmAppender` for the same key; if synthesis completes the chapter,
+the appender finalizes and the cache becomes available for replay.
+
+Adds a `bufferLowSignal: StateFlow<Boolean>` that flips true when the
+queue head-room (queued PCM duration) falls below 2 s. The `PlaybackPipeline`
+collects this and pauses `track.play()` while true, surfacing a "buffering"
+state in `PlaybackState`. When head-room recovers, resume.
+
+### `RenderScheduler`
+
+Wraps WorkManager. Single in-flight render at a time (engine is a singleton).
+
+```kotlin
+@Singleton
+class PcmRenderScheduler @Inject constructor(
+    @ApplicationContext private val context: Context,
+) {
+    fun scheduleRender(key: PcmCacheKey, fictionId: String, chapterId: String)
+    fun cancel(chapterId: String)
+}
+```
+
+Uses `OneTimeWorkRequest` with unique-name `pcm-render-<chapterId>`,
+ExistingWorkPolicy.KEEP. Constraints: `requiresBatteryNotLow=true`,
+`requiresStorageNotLow=true`. The worker:
+
+1. Re-reads the chapter text from `ChapterRepository`.
+2. Re-reads the active voice from `VoiceManager` (voice may have changed
+   between schedule and run — recompute the cache key).
+3. Acquires `engineMutex` (the existing one in EnginePlayer, hoisted to a
+   `@Singleton EngineMutex` provider).
+4. Runs the same generation loop as `EnginePlayer.startPlaybackPipeline()`'s
+   producer, but writes to a `PcmAppender` instead of a queue.
+5. On completion, finalizes the index and runs LRU eviction.
+6. On cancellation (chapter no longer wanted, or playback abandons cache),
+   `appender.abandon()` to remove partial files.
+
+**Trigger points:**
+
+- `EnginePlayer.loadAndPlay` on cache miss: do NOT schedule a separate worker — the streaming source's `PcmAppender` tee-write IS the render for the currently-playing chapter. The worker path is only used for chapters that are NOT currently being played.
+- `EnginePlayer.handleChapterDone`: schedule a worker render of N+2 (N+1 should already be cached, having been the target of the previous N's chapter-done trigger).
+- `FictionRepository.addToLibrary`: schedule worker renders of chapters 1-3.
+- `VoiceManager.setActive(newVoice)` while a chapter is loaded: the streaming source's appender abandons partial files for the old key (incomplete render). Schedule a worker render for the new (chapter, voice) key only if the chapter isn't currently re-loading via `loadAndPlay`.
+
+**Mutual-exclusion contract:** at most one process writes to a given cache key at a time — either the foreground streaming source's appender, OR the background `ChapterRenderJob`. The render scheduler checks for an existing complete or in-flight key before enqueueing; the streaming source's `loadAndPlay` cancels any matching in-flight worker before opening its own appender (using the unique work name).
+
+### `PlaybackPipeline`
+
+Renamed extraction of the consumer half of `EnginePlayer.startPlaybackPipeline`,
+now decoupled from the producer:
+
+```kotlin
+class PlaybackPipeline(
+    private val source: PcmSource,
+    private val audioTrack: AudioTrack,
+    private val sentenceTracker: SentenceTrackerSink,
+    private val volumeRamp: TtsVolumeRamp,
+    private val bufferLowSignal: StateFlow<Boolean>,  // from EngineStreamingSource only
+)
+```
+
+Loops on `source.nextChunk()`, writes to AudioTrack as today. When
+`bufferLowSignal` flips true, calls `audioTrack.pause()` + emits a
+`PlaybackState.buffering=true`. When the source has buffered at least
+4 s of audio again, calls `audioTrack.play()` + emits `buffering=false`.
+For `CacheFileSource` the signal is always false (no underrun possible).
+
+## Integration with existing features
+
+### SentenceTracker / sentence highlighting
+
+The sidecar index gives `(sentenceIndex, charOffset)` per sentence. The
+existing `SentenceTracker` consumes `SentenceRange` events; we still emit
+those when the consumer crosses a sentence boundary in the PCM stream.
+`PcmSource.nextChunk` returns a `PcmChunk` with `sentenceRange` —
+unchanged contract.
+
+### Sleep timer
+
+`TtsVolumeRamp` operates on `AudioTrack.setVolume`, source-agnostic. No change.
+`SleepTimer.signalChapterEnd` fires from `PlaybackPipeline` when source
+is exhausted. No change.
+
+### Voice swap mid-chapter
+
+`EnginePlayer.observeActiveVoice` already handles this. New behavior:
+old `PlaybackPipeline` is torn down; new `loadAndPlay(fictionId,
+chapterId, charOffset)` runs. New cache key = miss → `EngineStreamingSource`
+with appender for new voice. `RenderScheduler.scheduleRender` queues a
+background render of the same chapter+new-voice key.
+
+### Speed/pitch change
+
+Currently rebuilds the pipeline (`startPlaybackPipeline()`). Same
+behavior: cache key changes → likely miss → streaming fallback +
+schedule render. Old-speed cache stays on disk (LRU).
+
+### Seek
+
+`PcmSource.seekToCharOffset(offset)` returns a `PcmChunk` for the sentence
+containing that offset.
+
+- `CacheFileSource`: index lookup, `RandomAccessFile.seek(byteOffset)`.
+- `EngineStreamingSource`: cancels in-flight generation, restarts producer
+  from the new sentence index. The streaming appender's progress is
+  preserved if the seek lands within already-rendered region; otherwise
+  `appender.abandon()` and a fresh render scheduled.
+
+### MediaSession / Wear / Auto
+
+`EnginePlayer` keeps its `SimpleBasePlayer` API. `getState()` still maps
+internal state to `Player.State`. New `buffering` state maps to
+`Player.STATE_BUFFERING`. No change to media-route consumers.
+
+### Add-fiction flows / browse / library
+
+`FictionRepository.addToLibrary` (existing or new method) gains a
+"after add, schedule renders for chapters 1-3" hook. This is opt-in via
+a setting (default on for sequential listening). Cancelled if user removes
+fiction from library.
+
+## Storage policy
+
+- Default quota: **2 GB**. Configurable in Settings → Playback → "Audio cache size":
+  - 500 MB (light)
+  - 2 GB (default)
+  - 5 GB
+  - Unlimited
+- LRU eviction by file mtime (touched on every play of the cached chapter).
+- Pinned (never evicted): currently-playing chapter + next chapter in sequence.
+- Eviction runs:
+  - Before each render (must fit the new file in budget).
+  - After each render completes (top off LRU to budget).
+  - When user lowers the quota in Settings.
+- Disk-full fallback: if `requiresStorageNotLow` is violated mid-render,
+  WorkManager halts the worker; the appender's partial files stay on disk
+  for resume next time. (`ChapterRenderJob` uses `setForeground` for long
+  renders to avoid OS-doze interruption.)
+
+User-facing UI:
+
+- **Settings → Playback → Audio cache**:
+  - Currently used: `1.4 GB / 2 GB`
+  - Quota selector (radio buttons)
+  - "Clear cache" button (deletes all `.pcm` + `.idx.json` + `.meta.json`)
+
+## Migration / rollout
+
+- Zero DB migration. State is filesystem-only.
+- No behavior change on first install — cache populates as side-effect of streaming on first play. Streaming itself improves (pause-buffer-resume vs silence) immediately.
+- Feature flag: marker file `pcm-cache-enabled` in `filesDir`. Off by default until v0.5.0; on by default after. Reuses the existing marker-file pattern (AudioTrack.Builder, ChunkGapLogger).
+
+## Risks and open questions
+
+| risk | mitigation |
+|---|---|
+| **Storage runaway.** A 26-min Piper-high chapter is ~68 MB. A binger of long progression fantasy could hit 2 GB in a week. | LRU + quota with sensible default; user-visible Settings UI. |
+| **Render falls behind in WorkManager.** OS may pause/throttle background work; a chapter render at 0.285× rtf takes 90+ minutes wall — not run-once-and-done. | `setForeground` for the worker so it survives doze. Battery-not-low constraint avoids drain at low charge. Single-in-flight + retry on transient failure. |
+| **Engine singleton + WorkManager render = two threads in JNI.** EnginePlayer already serializes via `engineMutex`; promoting the mutex to a process-wide singleton (provided by Hilt) lets the worker share it. Race is the same shape as the existing voice-reload race. | Hoist `engineMutex` to `@Singleton` `EngineMutex` provider; both `EnginePlayer` and `ChapterRenderJob` use the same instance. |
+| **Cache key explosion with speed knob.** Users tweak speed often. Each speed creates a different cache file. | Speed quantization to 0.05× (5 hundredths) so 1.0× and 1.02× share a cache file. Hopefully users settle on 1.0/1.25/1.5/1.75/2.0×, all distinct keys but a small finite set. |
+| **First-play UX still bad on slow voice.** First chapter ever played still streams with buffering pauses while cache renders alongside. | Pre-render trigger on add-to-library (chapters 1-3 in background). For most users, "add fiction → walk away → come back" lands on a populated cache. |
+| **Sentence index drift.** If `SentenceChunker` boundaries change between app versions, the index is wrong. | `chunkerVersion: Int` constant in `SentenceChunker`, bumped when boundaries change; included in cache key so old caches invalidate. |
+| **Cache replay vs sentence-highlight motion glide (Lumen's PR #63).** The glide depends on real-time sentence transitions. Cache file streams audio fast — does the consumer pace via `track.write()` blocking, or freerun and out-pace UI? | Cache consumer paces via `track.write()` exactly like streaming consumer. AudioTrack hardware buffer (~2-3 s) regulates the rate. UI updates fire at sentence transitions, same code path. |
+
+## Out of scope
+
+- Re-encoding to compressed format (Ogg/Opus). Considered: would cut storage 10×, but adds decode CPU on playback (small but non-zero on the same slow devices we're trying to help) and risks reintroducing the Samsung speech-DSP fuzz path. Defer until storage proves to be a real-world problem.
+- Sharing cache across devices (cloud-sync of pre-rendered audio). Privacy and bandwidth nightmare.
+- Sharing cache across users (if multiple users use the app). Out of scope: app is single-user.
+- Per-fiction cache pin ("always keep this fiction cached"). Nice-to-have; defer.
+- Pre-render whole library at install. UX cost (bad first-run) outweighs benefit. The post-add 1-3 chapter pre-render covers the most common case.
+- Showing per-chapter cache status icons in the chapter list. Polish for v0.5.x; not required for this PR.
+
+## Implementation outline (for writing-plans skill follow-up)
+
+Suggested PR shape (not commitments, the implementation plan will refine):
+
+1. **PR A — `PcmSource` extraction.** Refactor `EnginePlayer.startPlaybackPipeline` to extract a `PcmSource` interface and the existing `EngineStreamingSource` impl. Behavioral no-op. Tests for `PcmSource` semantics. Lays groundwork.
+
+2. **PR B — `pause-buffer-resume`.** Add `bufferLowSignal` to `EngineStreamingSource`. Pipeline pauses `audioTrack.play()` instead of emitting silence on underrun. PlaybackState gains `buffering: Boolean`. UI gains "buffering…" state in PlaybackSheet (Lumen's lane). **This alone is shippable as v0.4.27 and improves the gap UX immediately**; subsequent PRs add the cache.
+
+3. **PR C — `PcmCache` + `PcmCacheKey` + filesystem layout.** Just the storage layer + tests. No integration yet.
+
+4. **PR D — `EngineStreamingSource` tee writer.** Streaming source writes generated PCM to `PcmAppender` as a side-effect; on natural-end finalizes. Cache populates organically from playback.
+
+5. **PR E — `CacheFileSource` + cache hit path.** `EnginePlayer.loadAndPlay` consults `PcmCache.isComplete`; mmap + play if hit. Sentence index drives sentence ranges.
+
+6. **PR F — `PcmRenderScheduler` + `ChapterRenderJob`.** Background WorkManager render. Wired to `loadAndPlay` cache miss + `handleChapterDone` (N+2) + `addToLibrary` (1-3).
+
+7. **PR G — Settings UI for quota + LRU eviction.** User-facing Settings entry, eviction runs at scheduler enqueue.
+
+8. **PR H — Polish.** Per-chapter cache status icon, "Clear cache" affordance.
+
+Total estimated work: 2-3 weeks of single-engineer time, but each PR is independently shippable and individually small. PR B alone can ship in this branch's lifetime to address JP's immediate complaint with a smaller win.
+
+## Definition of done
+
+- A chapter played to completion on Piper-high Tab A7 Lite leaves a complete `.pcm` + `.idx.json` cache.
+- Replaying that chapter from any starting offset is gapless (median inter-chunk gap ≤ 350 ms — i.e. at most the deliberate cadence).
+- First-ever play streams with `buffering` UI state when the queue runs dry, never silence.
+- `EnginePlayer` MediaSession surface unchanged (Wear / Auto / Bluetooth still see `Player.STATE_*` consistently).
+- Cache total size respects user quota; LRU evicts cleanly.
+- Voice swap, speed change, seek, and chapter advance all work and don't corrupt cache.
+- All existing core-playback tests still pass; new tests cover `PcmCache`, `PcmCacheKey` hashing, `CacheFileSource` seek, eviction.

--- a/feature/src/main/kotlin/in/jphe/storyvox/feature/api/UiContracts.kt
+++ b/feature/src/main/kotlin/in/jphe/storyvox/feature/api/UiContracts.kt
@@ -205,6 +205,11 @@ data class UiPlaybackState(
     val fictionTitle: String,
     val coverUrl: String?,
     val isPlaying: Boolean,
+    /** True when the streaming TTS pipeline has paused AudioTrack waiting
+     *  for the producer to refill the queue past the underrun threshold.
+     *  UI surfaces a "Buffering..." spinner; differs from `!isPlaying`
+     *  (user pause) and from initial voice warm-up (sentenceEnd == 0). */
+    val isBuffering: Boolean = false,
     val positionMs: Long,
     val durationMs: Long,
     /** Char index into the chapter text where the current sentence begins. */

--- a/feature/src/main/kotlin/in/jphe/storyvox/feature/reader/AudiobookView.kt
+++ b/feature/src/main/kotlin/in/jphe/storyvox/feature/reader/AudiobookView.kt
@@ -126,6 +126,12 @@ fun AudiobookView(
             // range emitted). Sherpa-onnx model load + first synth can take
             // 5-15s on modest hardware.
             val warmingUp = state.isPlaying && state.sentenceEnd == 0
+            // "Buffering" = streaming pipeline ran out of generated PCM
+            // mid-chapter (producer can't keep up — e.g. Piper-high on
+            // Tab A7 Lite). Same brass spinner so the visual stays
+            // consistent; status label distinguishes the two states so
+            // the user knows what's happening.
+            val showSpinner = warmingUp || state.isBuffering
             if (coverLoading) {
                 MagicSkeletonTile(
                     modifier = Modifier.size(width = 220.dp, height = 330.dp),
@@ -146,7 +152,7 @@ fun AudiobookView(
                     // popping — visual swap to the playing state stays
                     // continuous instead of abrupt.
                     androidx.compose.animation.AnimatedVisibility(
-                        visible = warmingUp,
+                        visible = showSpinner,
                         enter = spinnerEnter,
                         exit = spinnerExit,
                     ) {
@@ -163,10 +169,11 @@ fun AudiobookView(
                 when {
                     state.chapterTitle.isBlank() -> "Loading voice + chapter text"
                     warmingUp -> "Voice waking up…"
+                    state.isBuffering -> "Buffering…"
                     else -> state.chapterTitle
                 },
                 style = MaterialTheme.typography.bodyMedium,
-                color = if (warmingUp) MaterialTheme.colorScheme.primary else MaterialTheme.colorScheme.onSurfaceVariant,
+                color = if (showSpinner) MaterialTheme.colorScheme.primary else MaterialTheme.colorScheme.onSurfaceVariant,
             )
             Spacer(Modifier.height(spacing.xs))
             BrassProgressTrack(
@@ -174,7 +181,7 @@ fun AudiobookView(
                 durationMs = state.durationMs,
                 onSeekTo = onSeekTo,
                 modifier = Modifier.fillMaxWidth(),
-                loading = warmingUp,
+                loading = showSpinner,
             )
             if (state.sleepTimerRemainingMs != null) {
                 SleepTimerCountdownChip(remainingMs = state.sleepTimerRemainingMs, onCancel = onCancelSleepTimer)
@@ -196,10 +203,14 @@ fun AudiobookView(
                 // sentence range emitted). Sherpa-onnx model load + first
                 // synth can take 5-15s on modest hardware; without this
                 // indicator the play button looks dead during that gap.
+                // "Buffering" = mid-chapter underrun on slow voice + slow
+                // device; same spinner so the play button stays visually
+                // consistent.
                 val warmingUp = state.isPlaying && state.sentenceEnd == 0
+                val showSpinner = warmingUp || state.isBuffering
                 Box(contentAlignment = Alignment.Center) {
                     androidx.compose.animation.AnimatedVisibility(
-                        visible = warmingUp,
+                        visible = showSpinner,
                         enter = spinnerEnter,
                         exit = spinnerExit,
                     ) {


### PR DESCRIPTION
## Summary

Two changes stacked into one PR (the second builds on the first; reviewers can read them as separate commits):

### Part A — PcmSource extraction (behavioral no-op refactor)
- New `core-playback/.../tts/source/PcmSource.kt` — sealed interface + `PcmChunk` data class
- New `core-playback/.../tts/source/EngineStreamingSource.kt` — owns the producer coroutine, the LinkedBlockingQueue, the trailing-cadence punctuation table. SAM `VoiceEngineHandle` lets unit tests fake the engine without pulling the VoxSherpa AAR.
- `EnginePlayer.startPlaybackPipeline` shrinks 160→90 lines — consumer thread + AudioTrack write loop only. Producer logic gone.
- `engineMutex` hoisted to a constructor parameter on the source so `EnginePlayer.loadAndPlay`'s existing `engineMutex.withLock { loadModel }` still serializes against the source's `generateAudioPCM` calls (avoids the SIGSEGV path documented in #11).

### Part B — pause-buffer-resume on streaming underrun
- `EngineStreamingSource.bufferHeadroomMs: StateFlow<Long>` — sum of buffered audio duration across queued chunks
- EnginePlayer consumer pauses AudioTrack and emits `PlaybackState.isBuffering=true` when headroom drops below 2s; resumes at 4s (hysteresis)
- `UiPlaybackState.isBuffering` plumbed through to AudiobookView; brass spinner now surfaces for both initial voice load (`Voice waking up...`) and mid-stream buffering (`Buffering...`)
- Doesn't fix the gap (full fix is the chapter PCM cache, PRs C-H from the spec) — makes the gap an honest UX event so the listener knows the device is working, not broken

### Design + plan
- New `docs/superpowers/specs/2026-05-07-pcm-cache-design.md` — full chapter PCM cache design (PRs A-H)
- New `docs/superpowers/plans/2026-05-07-pcm-cache-pr-a-and-b.md` — implementation plan for this PR

## Why

Measured baseline (`scratch/aurelia-tts-chunk-gap/baseline.md`): Piper-high "cori" on R83W80CAFZB synthesizes audio at **0.285x realtime** — producer falls behind by ~715 ms per second of playback, indefinitely. Median inter-chunk audible gap 8021 ms, max 19601 ms. The full fix (PRs C-H) moves synthesis off the playback hot path; this PR is the immediate UX win shippable as v0.4.27.

## Test plan

- [x] `:core-playback:testDebugUnitTest` passes — existing tests + new `EngineStreamingSourceTest` (3 tests: nextChunk happy path, close-makes-nextChunk-return-null, bufferHeadroomMs accounting), plus extended `PlaybackStateTest` for `isBuffering` serialization round-trip
- [x] `:app:assembleDebug` clean
- [x] R83W80CAFZB v0.4.27 install: paste-by-URL → fiction-detail → Add to library → Listen all worked. PlaybackSheet showed "Voice waking up..." with brass spinner via the new `showSpinner = warmingUp || isBuffering` derived state
- [x] No regression in voice-warm-up spinner (initial 'Voice waking up...' still shows pre-first-chunk)
- [x] No crashes through the full add-fiction → listen flow
- [ ] Mid-stream buffering pulse capture deferred to organic playback — first-ever play takes 30+ seconds before underrun emerges. Logic verified by unit test; on-tablet visual capture is a polish follow-up

## Bumps

versionName 0.4.26 → 0.4.27, versionCode 38 → 39 (this PR is the v0.4.27 candidate per the plan).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
