### PR TITLE
feat(github-source): commit-SHA cheap-poll for new chapters (step 9)

### DIFF
--- a/core-data/schemas/in.jphe.storyvox.data.db.StoryvoxDatabase/2.json
+++ b/core-data/schemas/in.jphe.storyvox.data.db.StoryvoxDatabase/2.json
@@ -1,0 +1,524 @@
+{
+  "formatVersion": 1,
+  "database": {
+    "version": 2,
+    "identityHash": "820680acc737ffc5c56bb405592e30a2",
+    "entities": [
+      {
+        "tableName": "fiction",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `sourceId` TEXT NOT NULL, `title` TEXT NOT NULL, `author` TEXT NOT NULL, `authorId` TEXT, `coverUrl` TEXT, `description` TEXT, `genres` TEXT NOT NULL, `tags` TEXT NOT NULL, `status` TEXT NOT NULL, `chapterCount` INTEGER NOT NULL, `wordCount` INTEGER, `rating` REAL, `views` INTEGER, `followers` INTEGER, `lastUpdatedAt` INTEGER, `firstSeenAt` INTEGER NOT NULL, `metadataFetchedAt` INTEGER NOT NULL, `inLibrary` INTEGER NOT NULL, `addedToLibraryAt` INTEGER, `followedRemotely` INTEGER NOT NULL, `downloadMode` TEXT, `pinnedVoiceId` TEXT, `pinnedVoiceLocale` TEXT, `notesEverSeen` INTEGER NOT NULL, `lastSeenRevision` TEXT, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "sourceId",
+            "columnName": "sourceId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "title",
+            "columnName": "title",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "author",
+            "columnName": "author",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "authorId",
+            "columnName": "authorId",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "coverUrl",
+            "columnName": "coverUrl",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "description",
+            "columnName": "description",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "genres",
+            "columnName": "genres",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "tags",
+            "columnName": "tags",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "status",
+            "columnName": "status",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "chapterCount",
+            "columnName": "chapterCount",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "wordCount",
+            "columnName": "wordCount",
+            "affinity": "INTEGER",
+            "notNull": false
+          },
+          {
+            "fieldPath": "rating",
+            "columnName": "rating",
+            "affinity": "REAL",
+            "notNull": false
+          },
+          {
+            "fieldPath": "views",
+            "columnName": "views",
+            "affinity": "INTEGER",
+            "notNull": false
+          },
+          {
+            "fieldPath": "followers",
+            "columnName": "followers",
+            "affinity": "INTEGER",
+            "notNull": false
+          },
+          {
+            "fieldPath": "lastUpdatedAt",
+            "columnName": "lastUpdatedAt",
+            "affinity": "INTEGER",
+            "notNull": false
+          },
+          {
+            "fieldPath": "firstSeenAt",
+            "columnName": "firstSeenAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "metadataFetchedAt",
+            "columnName": "metadataFetchedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "inLibrary",
+            "columnName": "inLibrary",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "addedToLibraryAt",
+            "columnName": "addedToLibraryAt",
+            "affinity": "INTEGER",
+            "notNull": false
+          },
+          {
+            "fieldPath": "followedRemotely",
+            "columnName": "followedRemotely",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "downloadMode",
+            "columnName": "downloadMode",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "pinnedVoiceId",
+            "columnName": "pinnedVoiceId",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "pinnedVoiceLocale",
+            "columnName": "pinnedVoiceLocale",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "notesEverSeen",
+            "columnName": "notesEverSeen",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastSeenRevision",
+            "columnName": "lastSeenRevision",
+            "affinity": "TEXT",
+            "notNull": false
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_fiction_inLibrary",
+            "unique": false,
+            "columnNames": [
+              "inLibrary"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_fiction_inLibrary` ON `${TABLE_NAME}` (`inLibrary`)"
+          },
+          {
+            "name": "index_fiction_followedRemotely",
+            "unique": false,
+            "columnNames": [
+              "followedRemotely"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_fiction_followedRemotely` ON `${TABLE_NAME}` (`followedRemotely`)"
+          },
+          {
+            "name": "index_fiction_sourceId_lastUpdatedAt",
+            "unique": false,
+            "columnNames": [
+              "sourceId",
+              "lastUpdatedAt"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_fiction_sourceId_lastUpdatedAt` ON `${TABLE_NAME}` (`sourceId`, `lastUpdatedAt`)"
+          }
+        ],
+        "foreignKeys": []
+      },
+      {
+        "tableName": "chapter",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `fictionId` TEXT NOT NULL, `sourceChapterId` TEXT NOT NULL, `index` INTEGER NOT NULL, `title` TEXT NOT NULL, `publishedAt` INTEGER, `wordCount` INTEGER, `htmlBody` TEXT, `plainBody` TEXT, `bodyFetchedAt` INTEGER, `bodyChecksum` TEXT, `downloadState` TEXT NOT NULL, `lastDownloadAttemptAt` INTEGER, `lastDownloadError` TEXT, `notesAuthor` TEXT, `notesAuthorPosition` TEXT, `userMarkedRead` INTEGER NOT NULL, `firstReadAt` INTEGER, PRIMARY KEY(`id`), FOREIGN KEY(`fictionId`) REFERENCES `fiction`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "fictionId",
+            "columnName": "fictionId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "sourceChapterId",
+            "columnName": "sourceChapterId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "index",
+            "columnName": "index",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "title",
+            "columnName": "title",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "publishedAt",
+            "columnName": "publishedAt",
+            "affinity": "INTEGER",
+            "notNull": false
+          },
+          {
+            "fieldPath": "wordCount",
+            "columnName": "wordCount",
+            "affinity": "INTEGER",
+            "notNull": false
+          },
+          {
+            "fieldPath": "htmlBody",
+            "columnName": "htmlBody",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "plainBody",
+            "columnName": "plainBody",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "bodyFetchedAt",
+            "columnName": "bodyFetchedAt",
+            "affinity": "INTEGER",
+            "notNull": false
+          },
+          {
+            "fieldPath": "bodyChecksum",
+            "columnName": "bodyChecksum",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "downloadState",
+            "columnName": "downloadState",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastDownloadAttemptAt",
+            "columnName": "lastDownloadAttemptAt",
+            "affinity": "INTEGER",
+            "notNull": false
+          },
+          {
+            "fieldPath": "lastDownloadError",
+            "columnName": "lastDownloadError",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "notesAuthor",
+            "columnName": "notesAuthor",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "notesAuthorPosition",
+            "columnName": "notesAuthorPosition",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "userMarkedRead",
+            "columnName": "userMarkedRead",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "firstReadAt",
+            "columnName": "firstReadAt",
+            "affinity": "INTEGER",
+            "notNull": false
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_chapter_fictionId",
+            "unique": false,
+            "columnNames": [
+              "fictionId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_chapter_fictionId` ON `${TABLE_NAME}` (`fictionId`)"
+          },
+          {
+            "name": "index_chapter_fictionId_index",
+            "unique": true,
+            "columnNames": [
+              "fictionId",
+              "index"
+            ],
+            "orders": [],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_chapter_fictionId_index` ON `${TABLE_NAME}` (`fictionId`, `index`)"
+          },
+          {
+            "name": "index_chapter_downloadState",
+            "unique": false,
+            "columnNames": [
+              "downloadState"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_chapter_downloadState` ON `${TABLE_NAME}` (`downloadState`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "fiction",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "fictionId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "playback_position",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`fictionId` TEXT NOT NULL, `chapterId` TEXT NOT NULL, `charOffset` INTEGER NOT NULL, `paragraphIndex` INTEGER NOT NULL, `playbackSpeed` REAL NOT NULL, `durationEstimateMs` INTEGER NOT NULL, `updatedAt` INTEGER NOT NULL, PRIMARY KEY(`fictionId`), FOREIGN KEY(`fictionId`) REFERENCES `fiction`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE , FOREIGN KEY(`chapterId`) REFERENCES `chapter`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "fictionId",
+            "columnName": "fictionId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "chapterId",
+            "columnName": "chapterId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "charOffset",
+            "columnName": "charOffset",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "paragraphIndex",
+            "columnName": "paragraphIndex",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "playbackSpeed",
+            "columnName": "playbackSpeed",
+            "affinity": "REAL",
+            "notNull": true
+          },
+          {
+            "fieldPath": "durationEstimateMs",
+            "columnName": "durationEstimateMs",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "updatedAt",
+            "columnName": "updatedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "fictionId"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_playback_position_chapterId",
+            "unique": false,
+            "columnNames": [
+              "chapterId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_playback_position_chapterId` ON `${TABLE_NAME}` (`chapterId`)"
+          },
+          {
+            "name": "index_playback_position_updatedAt",
+            "unique": false,
+            "columnNames": [
+              "updatedAt"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_playback_position_updatedAt` ON `${TABLE_NAME}` (`updatedAt`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "fiction",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "fictionId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          },
+          {
+            "table": "chapter",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "chapterId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "auth_cookie",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`sourceId` TEXT NOT NULL, `userDisplayName` TEXT, `userId` TEXT, `capturedAt` INTEGER NOT NULL, `expiresAt` INTEGER, `lastVerifiedAt` INTEGER NOT NULL, PRIMARY KEY(`sourceId`))",
+        "fields": [
+          {
+            "fieldPath": "sourceId",
+            "columnName": "sourceId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "userDisplayName",
+            "columnName": "userDisplayName",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "userId",
+            "columnName": "userId",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "capturedAt",
+            "columnName": "capturedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "expiresAt",
+            "columnName": "expiresAt",
+            "affinity": "INTEGER",
+            "notNull": false
+          },
+          {
+            "fieldPath": "lastVerifiedAt",
+            "columnName": "lastVerifiedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "sourceId"
+          ]
+        },
+        "indices": [],
+        "foreignKeys": []
+      }
+    ],
+    "views": [],
+    "setupQueries": [
+      "CREATE TABLE IF NOT EXISTS room_master_table (id INTEGER PRIMARY KEY,identity_hash TEXT)",
+      "INSERT OR REPLACE INTO room_master_table (id,identity_hash) VALUES(42, '820680acc737ffc5c56bb405592e30a2')"
+    ]
+  }
+}

--- a/core-data/src/main/kotlin/in/jphe/storyvox/data/db/StoryvoxDatabase.kt
+++ b/core-data/src/main/kotlin/in/jphe/storyvox/data/db/StoryvoxDatabase.kt
@@ -20,7 +20,7 @@ import `in`.jphe.storyvox.data.db.entity.PlaybackPosition
         PlaybackPosition::class,
         AuthCookie::class,
     ],
-    version = 1,
+    version = 2,
     exportSchema = true,
 )
 @TypeConverters(Converters::class)

--- a/core-data/src/main/kotlin/in/jphe/storyvox/data/db/dao/FictionDao.kt
+++ b/core-data/src/main/kotlin/in/jphe/storyvox/data/db/dao/FictionDao.kt
@@ -70,6 +70,16 @@ interface FictionDao {
     @Query("UPDATE fiction SET metadataFetchedAt = :now WHERE id = :id")
     suspend fun touchMetadata(id: String, now: Long)
 
+    /**
+     * Source-side revision token captured the last time we successfully
+     * polled the fiction. See [Fiction.lastSeenRevision].
+     */
+    @Query("SELECT lastSeenRevision FROM fiction WHERE id = :id")
+    suspend fun getLastSeenRevision(id: String): String?
+
+    @Query("UPDATE fiction SET lastSeenRevision = :revision WHERE id = :id")
+    suspend fun setLastSeenRevision(id: String, revision: String?)
+
     @Transaction
     suspend fun upsertAllPreservingUserState(fictions: List<Fiction>) {
         // Listing pages don't know about library/follow state — preserve the
@@ -85,6 +95,10 @@ interface FictionDao {
                 pinnedVoiceLocale = existing.pinnedVoiceLocale,
                 notesEverSeen = existing.notesEverSeen,
                 firstSeenAt = existing.firstSeenAt,
+                // Listing pages don't carry revision tokens — only the
+                // poll worker writes this column. Preserve so a browse
+                // upsert doesn't reset the cheap-poll state.
+                lastSeenRevision = existing.lastSeenRevision,
             )
             upsert(merged)
         }

--- a/core-data/src/main/kotlin/in/jphe/storyvox/data/db/entity/Fiction.kt
+++ b/core-data/src/main/kotlin/in/jphe/storyvox/data/db/entity/Fiction.kt
@@ -44,6 +44,16 @@ data class Fiction(
     val pinnedVoiceId: String? = null,
     val pinnedVoiceLocale: String? = null,
     val notesEverSeen: Boolean = false,
+    /**
+     * Source-side revision token captured the last time we successfully
+     * polled this fiction. For GitHub it's the head commit SHA on the
+     * default branch; for sources that don't expose a cheap revision
+     * check it stays null. Used by `NewChapterPollWorker` to short-
+     * circuit the full detail fetch when nothing has changed upstream
+     * — see step 9 in
+     * `docs/superpowers/specs/2026-05-06-github-source-design.md`.
+     */
+    val lastSeenRevision: String? = null,
 )
 
 /** Per-book download policy override. Null = inherit global setting. */

--- a/core-data/src/main/kotlin/in/jphe/storyvox/data/db/migration/Migrations.kt
+++ b/core-data/src/main/kotlin/in/jphe/storyvox/data/db/migration/Migrations.kt
@@ -1,6 +1,7 @@
 package `in`.jphe.storyvox.data.db.migration
 
 import androidx.room.migration.Migration
+import androidx.sqlite.db.SupportSQLiteDatabase
 
 /**
  * v1 ships with no migrations. When the schema bumps, declare each step here
@@ -10,4 +11,17 @@ import androidx.room.migration.Migration
  * Schemas are exported to `core-data/schemas/` (see KSP `room.schemaLocation`)
  * so diffs land in PRs.
  */
-val ALL_MIGRATIONS: Array<Migration> = emptyArray()
+
+/**
+ * v2 — adds `fiction.lastSeenRevision` for the GitHub-source commit-SHA
+ * cheap-poll path (step 9 in the GitHub-source spec). Existing rows get
+ * NULL so the first poll after upgrade still hits the full detail fetch
+ * and persists a SHA, then subsequent polls take the short-circuit.
+ */
+val MIGRATION_1_2: Migration = object : Migration(1, 2) {
+    override fun migrate(db: SupportSQLiteDatabase) {
+        db.execSQL("ALTER TABLE fiction ADD COLUMN lastSeenRevision TEXT")
+    }
+}
+
+val ALL_MIGRATIONS: Array<Migration> = arrayOf(MIGRATION_1_2)

--- a/core-data/src/main/kotlin/in/jphe/storyvox/data/source/FictionSource.kt
+++ b/core-data/src/main/kotlin/in/jphe/storyvox/data/source/FictionSource.kt
@@ -75,6 +75,32 @@ interface FictionSource {
     /** All genres the source supports — for the genre picker UI. */
     suspend fun genres(): FictionResult<List<String>>
 
+    // ─── polling ──────────────────────────────────────────────────────────
+
+    /**
+     * Cheap revision check for cheap-poll: returns a token (e.g. a
+     * commit SHA, a feed-level ETag, a Last-Modified header) that the
+     * poll worker can compare against the previously-stored token to
+     * decide whether the upstream source has changed at all. If the
+     * tokens match, the worker skips the heavier `fictionDetail` fetch.
+     *
+     * Default implementation returns `Success(null)` — sources that
+     * don't have a cheap revision check (Royal Road today) opt out by
+     * not overriding, and the worker falls back to the full path.
+     *
+     * Returning a non-null token implicitly tells the worker "if you
+     * see this same token again, nothing has changed". Implementations
+     * MUST therefore mint a fresh token whenever any chapter-affecting
+     * content changes (typically: head commit on the default branch
+     * for Git-backed sources).
+     *
+     * Errors should come back as a [FictionResult] failure variant
+     * so the worker can choose to fall back to the full path; throwing
+     * is reserved for programmer errors.
+     */
+    suspend fun latestRevisionToken(fictionId: String): FictionResult<String?> =
+        FictionResult.Success(null)
+
     // ─── eventing ─────────────────────────────────────────────────────────
 
     /**

--- a/core-data/src/main/kotlin/in/jphe/storyvox/data/work/NewChapterPollWorker.kt
+++ b/core-data/src/main/kotlin/in/jphe/storyvox/data/work/NewChapterPollWorker.kt
@@ -1,6 +1,7 @@
 package `in`.jphe.storyvox.data.work
 
 import android.content.Context
+import android.util.Log
 import androidx.hilt.work.HiltWorker
 import androidx.work.CoroutineWorker
 import androidx.work.Data
@@ -13,6 +14,7 @@ import `in`.jphe.storyvox.data.db.entity.ChapterDownloadState
 import `in`.jphe.storyvox.data.db.entity.DownloadMode
 import `in`.jphe.storyvox.data.repository.ChapterRepository
 import `in`.jphe.storyvox.data.repository.FictionRepository
+import `in`.jphe.storyvox.data.source.FictionSource
 import `in`.jphe.storyvox.data.source.model.FictionResult
 import kotlinx.coroutines.flow.first
 
@@ -23,6 +25,12 @@ import kotlinx.coroutines.flow.first
  * fetches the detail page, diffs against cached chapters, inserts new rows
  * (state = NOT_DOWNLOADED), then auto-enqueues `ChapterDownloadWorker` for new
  * chapters when the fiction is in EAGER mode.
+ *
+ * Cheap-poll path: before the heavier `refreshDetail` call, ask the source
+ * for a revision token (e.g. head commit SHA on GitHub). When the source
+ * returns the same token we stored on the previous successful poll, skip
+ * the full fetch entirely. Sources without a cheap revision check return
+ * null (the default impl) and the worker falls back to the full path.
  *
  * Notification rendering (collapsible group, deep links) is the app module's
  * responsibility — this worker only sets the data and returns the count.
@@ -35,10 +43,12 @@ class NewChapterPollWorker @AssistedInject constructor(
     private val chapterDao: ChapterDao,
     private val fictionRepository: FictionRepository,
     private val chapterRepository: ChapterRepository,
+    private val sources: Map<String, @JvmSuppressWildcards FictionSource>,
 ) : CoroutineWorker(appContext, params) {
 
     override suspend fun doWork(): Result {
         var newChapters = 0
+        var skippedByRevisionCheck = 0
 
         // Pull a one-shot snapshot of the library — Room's Flow emits the
         // current set immediately on subscribe.
@@ -48,8 +58,47 @@ class NewChapterPollWorker @AssistedInject constructor(
             val mode = fiction.downloadMode ?: continue
             if (mode != DownloadMode.SUBSCRIBE && mode != DownloadMode.EAGER) continue
 
+            // Cheap-poll: ask the source for a revision token. If we have
+            // a stored token AND it matches, the upstream hasn't changed
+            // since last poll — skip the full detail fetch.
+            val source = sources[fiction.sourceId]
+            if (source != null && fiction.lastSeenRevision != null) {
+                val tokenResult = runCatching { source.latestRevisionToken(fiction.id) }
+                    .getOrElse { e ->
+                        Log.w(TAG, "latestRevisionToken threw for ${fiction.id}", e)
+                        null
+                    }
+                if (tokenResult is FictionResult.Success && tokenResult.value != null &&
+                    tokenResult.value == fiction.lastSeenRevision
+                ) {
+                    skippedByRevisionCheck++
+                    continue
+                }
+                // Otherwise fall through: token mismatch, source returned
+                // null (no cheap check available), or the call failed.
+                // The full refreshDetail path is the safe default.
+            }
+
             when (val result = fictionRepository.refreshDetail(fiction.id)) {
                 is FictionResult.Success -> {
+                    // After a successful refresh, persist whatever new
+                    // revision token the source has now. We re-ask
+                    // because `refreshDetail` doesn't return the token
+                    // through its Unit-shaped result; an extra call is
+                    // cheap (1-2 GitHub calls) and means subsequent
+                    // polls can short-circuit.
+                    if (source != null) {
+                        runCatching { source.latestRevisionToken(fiction.id) }
+                            .onSuccess { r ->
+                                if (r is FictionResult.Success && r.value != null) {
+                                    fictionDao.setLastSeenRevision(fiction.id, r.value)
+                                }
+                            }
+                            .onFailure { e ->
+                                Log.w(TAG, "latestRevisionToken (post-refresh) threw for ${fiction.id}", e)
+                            }
+                    }
+
                     val missing = chapterDao.missingForFiction(fiction.id)
                     if (missing.isEmpty()) continue
                     newChapters += missing.size
@@ -82,7 +131,10 @@ class NewChapterPollWorker @AssistedInject constructor(
         }
 
         return Result.success(
-            Data.Builder().putInt(KEY_NEW_CHAPTERS, newChapters).build(),
+            Data.Builder()
+                .putInt(KEY_NEW_CHAPTERS, newChapters)
+                .putInt(KEY_SKIPPED_BY_REVISION, skippedByRevisionCheck)
+                .build(),
         )
     }
 
@@ -90,5 +142,13 @@ class NewChapterPollWorker @AssistedInject constructor(
         const val TAG = "poll:new-chapters"
         const val UNIQUE_NAME = "poll:new-chapters"
         const val KEY_NEW_CHAPTERS = "newChapterCount"
+
+        /**
+         * Telemetry-friendly count of fictions whose poll was skipped
+         * because the source's revision token matched the stored one.
+         * Surfaced in the Result data so future observability can graph
+         * "% of polls that hit the cheap path".
+         */
+        const val KEY_SKIPPED_BY_REVISION = "skippedByRevision"
     }
 }

--- a/core-data/src/test/kotlin/in/jphe/storyvox/data/repository/FictionRepositoryImplTest.kt
+++ b/core-data/src/test/kotlin/in/jphe/storyvox/data/repository/FictionRepositoryImplTest.kt
@@ -160,6 +160,13 @@ class FictionRepositoryImplTest {
             rows[id] = r.copy(metadataFetchedAt = now)
         }
 
+        override suspend fun getLastSeenRevision(id: String): String? = rows[id]?.lastSeenRevision
+
+        override suspend fun setLastSeenRevision(id: String, revision: String?) {
+            val r = rows[id] ?: return
+            rows[id] = r.copy(lastSeenRevision = revision)
+        }
+
         override suspend fun upsertAllPreservingUserState(fictions: List<Fiction>) {
             callLog += "upsertAllPreservingUserState(${fictions.map { it.id }})"
             for (incoming in fictions) {
@@ -173,6 +180,7 @@ class FictionRepositoryImplTest {
                     pinnedVoiceLocale = existing.pinnedVoiceLocale,
                     notesEverSeen = existing.notesEverSeen,
                     firstSeenAt = existing.firstSeenAt,
+                    lastSeenRevision = existing.lastSeenRevision,
                 )
                 rows[merged.id] = merged
                 publish(merged.id)

--- a/source-github/src/main/kotlin/in/jphe/storyvox/source/github/GitHubSource.kt
+++ b/source-github/src/main/kotlin/in/jphe/storyvox/source/github/GitHubSource.kt
@@ -283,6 +283,72 @@ internal class GitHubSource @Inject constructor(
     ): FictionResult<Unit> =
         throw NotImplementedError(STEP_3F_AUTH)
 
+    /**
+     * Cheap-poll revision token: head commit SHA on the repo's default
+     * branch. The poll worker compares against the previously-stored
+     * token and skips the heavier `fictionDetail` round-trip when they
+     * match. Step 9 in the GitHub-source spec.
+     *
+     * Two API calls per check (`getRepo` for `default_branch` then
+     * `/commits?sha={branch}&per_page=1` for the head SHA), against a
+     * full `fictionDetail` of repo + book.toml + storyvox.json +
+     * SUMMARY.md (4-5 calls + parsing). Net win even if no skip-eligible
+     * fictions exist yet, because the parsing alone is the dominant
+     * cost.
+     *
+     * Failures (network, rate-limit, 404) come back as the equivalent
+     * `FictionResult.Failure` variants; the worker treats those as
+     * "fall back to the full path" rather than aborting the whole poll.
+     */
+    override suspend fun latestRevisionToken(fictionId: String): FictionResult<String?> {
+        val coords = parseFictionId(fictionId)
+            ?: return FictionResult.NotFound(message = "Not a GitHub fiction id: $fictionId")
+        val (owner, repo) = coords
+
+        val branch = when (val r = api.getRepo(owner, repo)) {
+            is GitHubApiResult.Success -> r.value.defaultBranch
+            is GitHubApiResult.NotFound -> return FictionResult.NotFound(message = r.message)
+            is GitHubApiResult.RateLimited -> return FictionResult.RateLimited(
+                retryAfter = r.retryAfterSeconds?.let { it.toDuration(DurationUnit.SECONDS) },
+            )
+            is GitHubApiResult.NetworkError -> return FictionResult.NetworkError(
+                message = "Could not reach GitHub",
+                cause = r.cause,
+            )
+            is GitHubApiResult.HttpError -> return FictionResult.NetworkError(
+                message = "GitHub error ${r.code}: ${r.message}",
+            )
+            is GitHubApiResult.ParseError -> return FictionResult.NetworkError(
+                message = "Malformed repo response",
+                cause = r.cause,
+            )
+        }
+
+        return when (val r = api.getHeadCommit(owner, repo, branch)) {
+            is GitHubApiResult.Success -> {
+                // Empty list means the branch has no commits yet — treat
+                // as "no revision known", caller falls back to the full
+                // path. A real repo always has at least one commit.
+                FictionResult.Success(r.value.firstOrNull()?.sha)
+            }
+            is GitHubApiResult.NotFound -> FictionResult.NotFound(message = r.message)
+            is GitHubApiResult.RateLimited -> FictionResult.RateLimited(
+                retryAfter = r.retryAfterSeconds?.let { it.toDuration(DurationUnit.SECONDS) },
+            )
+            is GitHubApiResult.NetworkError -> FictionResult.NetworkError(
+                message = "Could not reach GitHub",
+                cause = r.cause,
+            )
+            is GitHubApiResult.HttpError -> FictionResult.NetworkError(
+                message = "GitHub error ${r.code}: ${r.message}",
+            )
+            is GitHubApiResult.ParseError -> FictionResult.NetworkError(
+                message = "Malformed commits response",
+                cause = r.cause,
+            )
+        }
+    }
+
     // ─── helpers ───────────────────────────────────────────────────────
 
     /** Result wrapper for a candidate manifest file fetch. */

--- a/source-github/src/main/kotlin/in/jphe/storyvox/source/github/model/GitHubModels.kt
+++ b/source-github/src/main/kotlin/in/jphe/storyvox/source/github/model/GitHubModels.kt
@@ -77,6 +77,17 @@ internal fun GhContent.decodedText(): String? {
  *
  * https://docs.github.com/en/rest/commits/commits#compare-two-commits
  */
+/**
+ * `GET /repos/{owner}/{repo}/commits?sha={ref}&per_page=1` — returns
+ * the JSON array of commits; we only consume the first element to get
+ * the head SHA on a given branch. Cheap-poll path for step 9 in the
+ * GitHub-source spec.
+ */
+@Serializable
+internal data class GhCommitRef(
+    @SerialName("sha") val sha: String,
+)
+
 @Serializable
 internal data class GhCompareResponse(
     @SerialName("status") val status: String, // "identical" | "behind" | "ahead" | "diverged"

--- a/source-github/src/main/kotlin/in/jphe/storyvox/source/github/net/GitHubApi.kt
+++ b/source-github/src/main/kotlin/in/jphe/storyvox/source/github/net/GitHubApi.kt
@@ -1,6 +1,7 @@
 package `in`.jphe.storyvox.source.github.net
 
 import `in`.jphe.storyvox.source.github.di.GitHubHttp
+import `in`.jphe.storyvox.source.github.model.GhCommitRef
 import `in`.jphe.storyvox.source.github.model.GhCompareResponse
 import `in`.jphe.storyvox.source.github.model.GhSearchResponse
 import `in`.jphe.storyvox.source.github.model.GhContent
@@ -98,6 +99,24 @@ internal open class GitHubApi @Inject constructor(
         head: String,
     ): GitHubApiResult<GhCompareResponse> =
         get("$BASE_URL/repos/${owner.lowercase()}/${repo.lowercase()}/compare/$base...$head")
+
+    /**
+     * `GET /repos/{owner}/{repo}/commits?sha={ref}&per_page=1` — returns
+     * the head commit on [ref] (or the repo's default branch if [ref]
+     * is null). Used by `latestRevisionToken` in [GitHubSource] for the
+     * cheap-poll path: a 5-line JSON response (~1KB) the worker compares
+     * against the stored token.
+     */
+    open suspend fun getHeadCommit(
+        owner: String,
+        repo: String,
+        ref: String? = null,
+    ): GitHubApiResult<List<GhCommitRef>> {
+        val refParam = if (ref != null) "&sha=$ref" else ""
+        return get(
+            "$BASE_URL/repos/${owner.lowercase()}/${repo.lowercase()}/commits?per_page=1$refParam",
+        )
+    }
 
     /**
      * `GET /search/repositories?q=...&page=...&per_page=...`. The

--- a/source-github/src/test/kotlin/in/jphe/storyvox/source/github/GitHubSourceTest.kt
+++ b/source-github/src/test/kotlin/in/jphe/storyvox/source/github/GitHubSourceTest.kt
@@ -455,6 +455,55 @@ class GitHubSourceTest {
         }
     }
 
+    // ─── latestRevisionToken (step 9 cheap-poll) ───────────────────────
+
+    @Test fun `latestRevisionToken returns head SHA on default branch`() = runBlocking {
+        val api = FakeGitHubApi(
+            repos = mapOf(("o" to "r") to ghRepo("o", "r", defaultBranch = "trunk")),
+            headCommits = mapOf(
+                Triple("o", "r", "trunk") to "abc1234567890",
+            ),
+        )
+        val result = source(api = api).latestRevisionToken("github:o/r")
+        assertTrue(result is FictionResult.Success)
+        assertEquals("abc1234567890", (result as FictionResult.Success).value)
+    }
+
+    @Test fun `latestRevisionToken returns null when branch has no commits`() = runBlocking {
+        // Empty repo (just-created, no commits yet) — empty array from
+        // /commits per_page=1. The worker treats this as "no token, fall
+        // back to full path" rather than an error.
+        val api = FakeGitHubApi(
+            repos = mapOf(("o" to "r") to ghRepo("o", "r")),
+            headCommits = emptyMap(),
+        )
+        val result = source(api = api).latestRevisionToken("github:o/r")
+        assertTrue(result is FictionResult.Success)
+        assertEquals(null, (result as FictionResult.Success).value)
+    }
+
+    @Test fun `latestRevisionToken propagates NotFound when repo missing`() = runBlocking {
+        val result = source(api = FakeGitHubApi()).latestRevisionToken("github:o/r")
+        assertTrue("got $result", result is FictionResult.NotFound)
+    }
+
+    @Test fun `latestRevisionToken propagates RateLimited from getRepo`() = runBlocking {
+        // No repo lookup → first call (getRepo) returns NotFound, not
+        // RateLimited. Cover the head-commit rate-limit path: getRepo
+        // succeeds, /commits is rate-limited.
+        val api = FakeGitHubApi(
+            repos = mapOf(("o" to "r") to ghRepo("o", "r")),
+            rateLimitedHeadCommits = setOf("o" to "r"),
+        )
+        val result = source(api = api).latestRevisionToken("github:o/r")
+        assertTrue("got $result", result is FictionResult.RateLimited)
+    }
+
+    @Test fun `latestRevisionToken rejects non-github fictionId`() = runBlocking {
+        val result = source(api = FakeGitHubApi()).latestRevisionToken("royalroad:42")
+        assertTrue("got $result", result is FictionResult.NotFound)
+    }
+
     // ─── Helpers ───────────────────────────────────────────────────────
 
     private fun source(
@@ -551,6 +600,10 @@ class GitHubSourceTest {
         private val files: Map<Triple<String, String, String>, GhContent> = emptyMap(),
         private val dirs: Map<Triple<String, String, String>, List<GhContent>> = emptyMap(),
         private val rateLimitedFiles: Set<Triple<String, String, String>> = emptySet(),
+        /** Head SHA per (owner, repo, ref) — null `ref` falls back to
+         *  default-branch lookups via `(owner, repo, "")`. */
+        private val headCommits: Map<Triple<String, String, String>, String> = emptyMap(),
+        private val rateLimitedHeadCommits: Set<Pair<String, String>> = emptySet(),
         /** Search-result lookup keyed by a substring match on the
          *  composed query. First key whose substring is contained in
          *  the actual query wins. */
@@ -584,6 +637,22 @@ class GitHubSourceTest {
             return dirs[Triple(owner, repo, path)]
                 ?.let { GitHubApiResult.Success(it, etag = null) }
                 ?: GitHubApiResult.NotFound("dir not found")
+        }
+
+        override suspend fun getHeadCommit(
+            owner: String,
+            repo: String,
+            ref: String?,
+        ): GitHubApiResult<List<`in`.jphe.storyvox.source.github.model.GhCommitRef>> {
+            if (owner to repo in rateLimitedHeadCommits) {
+                return GitHubApiResult.RateLimited(retryAfterSeconds = 60)
+            }
+            val key = Triple(owner, repo, ref ?: "")
+            val sha = headCommits[key] ?: return GitHubApiResult.Success(emptyList(), etag = null)
+            return GitHubApiResult.Success(
+                listOf(`in`.jphe.storyvox.source.github.model.GhCommitRef(sha = sha)),
+                etag = null,
+            )
         }
 
         override suspend fun searchRepositories(


### PR DESCRIPTION
## Summary

Lands step 9 of the GitHub-source spec ([docs/superpowers/specs/2026-05-06-github-source-design.md](../blob/main/docs/superpowers/specs/2026-05-06-github-source-design.md), lines 232 + 262): commit-SHA-based cheap polling for new chapters. Closes the GitHub-source spec sequence (steps 1-9 now all landed).

Instead of refetching the full detail (repo + book.toml + storyvox.json + SUMMARY.md, ~4-5 GitHub calls + parsing) on every poll, the worker asks the source for a revision token first and skips the heavier path when nothing has changed upstream.

## Changes

- **`FictionSource.latestRevisionToken(fictionId)`** with default `Success(null)`. Sources that don't have a cheap revision check (Royal Road today) opt out by not overriding.
- **`GitHubSource`** implements it via `getRepo` (for default branch) + `/commits?sha={branch}&per_page=1` (head SHA). Two cheap calls vs the full detail's 4-5.
- **`Fiction.lastSeenRevision`** column + `MIGRATION_1_2`. Existing rows get NULL → first poll after upgrade still hits the full path and persists a SHA, then subsequent polls take the short-circuit.
- **`NewChapterPollWorker`** checks the token before `refreshDetail`. On match, skip; on success, re-ask and persist the new SHA. Failures fall back to the full path so a transient network blip doesn't starve subscribers.
- New worker output key `KEY_SKIPPED_BY_REVISION` for future observability ("% of polls hitting the cheap path").

## Test plan

- [x] 5 new `GitHubSourceTest` cases for the revision-token path: head SHA happy path, empty-repo `Success(null)`, NotFound for missing repo, RateLimited propagation, non-github fictionId rejection.
- [x] `:source-github:testDebugUnitTest` — 33 tests (was 28), all green.
- [x] `./gradlew test` — full repo unit suite passes.
- [x] `:app:assembleDebug` — clean.
- [x] Tablet smoke test on R83W80CAFZB:
  - v1→v2 migration runs cleanly on existing DB.
  - Library still loads with previous fictions intact (Sky Pride resume CTA still rendered).
  - No crashes in logcat.
- [x] Schema diff captured in `core-data/schemas/.../2.json` (Room auto-validates the migration's SQL against the exported v2 schema at compile time).

🤖 Generated with [Claude Code](https://claude.com/claude-code)