### PR TITLE
docs(readme): refresh post-v0.4.x + clarify GPL license posture

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,8 +2,8 @@
 
 [![Build](https://github.com/jphein/storyvox/actions/workflows/android.yml/badge.svg)](https://github.com/jphein/storyvox/actions/workflows/android.yml)
 
-**A beautiful, neural-voice audiobook player for [Royal Road](https://royalroad.com).**
-Stream serial fiction read aloud by an offline neural TTS engine, with a hybrid reader/audiobook view that highlights the spoken sentence as you listen. Built for Android phones, tablets, and Wear OS.
+**A beautiful, neural-voice audiobook player for serial fiction.**
+Stream chapters from [Royal Road](https://royalroad.com) and [GitHub](https://github.com/) read aloud by an offline neural TTS engine, with a hybrid reader/audiobook view that highlights the spoken sentence as you listen. Built for Android phones, tablets, and Wear OS.
 
 <p align="center">
   <img src="docs/screenshots/03-reader.png" width="320" alt="storyvox reader playing The Archmage Coefficient" />
@@ -13,12 +13,14 @@ Stream serial fiction read aloud by an offline neural TTS engine, with a hybrid 
 
 ## What it does
 
-- **Browses Royal Road** with the full filter set: tags include/exclude, status, type, length, rating, content warnings, sort order.
-- **Plays chapters as audiobooks** through [VoxSherpa](https://github.com/CodeBySonu95/VoxSherpa-TTS) — a fully offline neural TTS engine that runs locally on your device. No cloud, no API keys, no per-character billing.
-- **Highlights the current sentence** in brass on the reader view as the TTS speaks. Swipe between audiobook view (cover + scrubber + transport) and reader view (chapter text).
-- **Auto-advances** between chapters. Eager-downloads ahead so the next chapter is ready when the current one ends.
-- **Sleep timer** with 15/30/45/60 minute presets and an "end of chapter" mode.
+- **Two fiction sources, side by side.** Browse [Royal Road](https://royalroad.com) with the full filter set (tags include/exclude, status, type, length, rating, content warnings, sort order) or browse fiction repositories on GitHub via the curated [storyvox-registry](https://github.com/jphein/storyvox-registry) plus live `/search/repositories` results.
+- **Plays chapters as audiobooks** through an in-process neural TTS engine. Two voice families ship: [Piper](https://github.com/rhasspy/piper) (compact, fast, ~14–30 MB per voice) and [Kokoro](https://github.com/hexgrad/kokoro) (multi-speaker, ~330 MB). Voice models download on demand from the project's `voices-v2` release; nothing is bundled in the APK. No cloud, no API keys, no per-character billing.
+- **Highlights the current sentence** in brass on the reader view as the TTS speaks. Swipe between audiobook view (cover + scrubber + transport) and reader view (chapter text). The highlight glides between sentences to match the read-aloud rhythm.
+- **Auto-advances** between chapters. Eager-downloads ahead so the next chapter is ready when the current one ends. PCM cache buffering keeps playback smooth even when synthesis temporarily falls behind — the player pauses, refills the buffer, and resumes without a glitch.
+- **Sleep timer** with 15/30/45/60 minute presets, an "end of chapter" mode, and a countdown pulse as time runs out.
 - **Library + Follows tabs** with sign-in via WebView (your Royal Road follow list syncs into the app).
+- **Infinite-scroll Browse** across every tab.
+- **Cheap polling for new chapters.** GitHub-sourced fictions watch the repo's HEAD commit SHA and only re-scan the manifest when something changes — so checking for updates is one HTTP request per fiction.
 - **MediaSession-aware** — lock screen art, transport from Bluetooth headsets, headphone media buttons, notification shade.
 - **Library Nocturne theme** — brass on warm dark, EB Garamond chapter body, Inter UI. Light mode is parchment cream.
 - **Adaptive layouts** — fills the screen on phones (2 columns), tablets (5 columns), foldables (more).
@@ -27,7 +29,7 @@ Stream serial fiction read aloud by an offline neural TTS engine, with a hybrid 
 
 <table>
 <tr>
-<td align="center"><b>Browse Royal Road</b><br/><img src="docs/screenshots/01-browse.png" width="220" /></td>
+<td align="center"><b>Browse</b><br/><img src="docs/screenshots/01-browse.png" width="220" /></td>
 <td align="center"><b>Fiction detail</b><br/><img src="docs/screenshots/02-detail.png" width="220" /></td>
 <td align="center"><b>Reader / audiobook</b><br/><img src="docs/screenshots/03-reader.png" width="220" /></td>
 </tr>
@@ -38,31 +40,26 @@ Stream serial fiction read aloud by an offline neural TTS engine, with a hybrid 
 </tr>
 </table>
 
-## Why VoxSherpa
+## TTS engine
 
-storyvox is a *consumer* of a system Text-to-Speech engine, not the engine itself. We picked [VoxSherpa](https://github.com/CodeBySonu95/VoxSherpa-TTS) (CodeBySonu95) because:
+storyvox links the TTS engine in-process via the [VoxSherpa-TTS](https://github.com/jphein/VoxSherpa-TTS) `:engine-lib` AAR (published to JitPack). That AAR re-projects [k2-fsa/sherpa-onnx](https://github.com/k2-fsa/sherpa-onnx) inference plus the Piper and Kokoro engine wrappers into a single dependency. We bypass Android's `TextToSpeech` framework entirely, manage our own `AudioTrack` with a fat buffer, and pipeline next-sentence generation against current playback. No second APK, no install gate, no engine-binding handshake — synthesis runs in storyvox's own process.
 
-- **It's offline** — neural inference runs on your phone, your reading habits never leave the device.
-- **It sounds good** — neural voices comparable to commercial cloud TTS.
-- **It's a system-wide engine** — registers with Android's `TextToSpeech` framework, so storyvox just calls `setEngineByPackageName("com.CodeBySonu.VoxSherpa")` and the OS handles the rest.
-
-VoxSherpa is GPL-3.0 and ships as a separate APK. **storyvox depends on having it installed** — first launch will surface a prompt to install if not present. You can fall back to your system default TTS engine, but the audio quality is noticeably lower.
+Voice model weights are downloaded on demand by `VoiceManager` from the `voices-v2` GitHub release; the in-app voice picker shows what's installed and what's available. See [`docs/VOICES.md`](docs/VOICES.md) for the catalog and refresh workflow.
 
 ## Install (sideload)
 
 storyvox is currently distributed by sideloading. The CI builds debug APKs on every `main` push; tagged releases (`v0.x.x`) attach a signed APK to the GitHub release.
 
-1. Download the latest `storyvox-debug.apk` from the [Releases page](https://github.com/jphein/storyvox/releases).
-2. Install [VoxSherpa-TTS](https://github.com/jphein/VoxSherpa-TTS/releases) (separate APK; this is JP's fork with a dry-run-detection fix on top of upstream).
-3. On your Android device, enable **Install unknown apps** for whatever browser/file manager you used.
-4. Open the APK to install.
-5. Launch storyvox. You'll be asked for notification permission (used for the lock-screen tile during playback).
+1. Download the latest `storyvox.apk` from the [Releases page](https://github.com/jphein/storyvox/releases).
+2. On your Android device, enable **Install unknown apps** for whatever browser/file manager you used.
+3. Open the APK to install.
+4. Launch storyvox. You'll be asked for notification permission (used for the lock-screen tile during playback). The voice picker appears on first launch — pick a Piper voice for a quick first chapter (~14–30 MB) or Kokoro for the multi-speaker model (~330 MB).
 
 System requirements:
 
 - Android 8.0 (API 26) or higher
-- ~50 MB free storage for storyvox; VoxSherpa adds ~500 MB for the bundled neural voice
-- An internet connection for browsing and chapter download (chapters are cached locally)
+- ~50 MB free storage for the APK; voice models add 14 MB to ~330 MB depending on which you install
+- An internet connection for browsing, chapter download, and the first-time voice download (chapters and voices are cached locally)
 
 ## Optional: sign in to Royal Road
 
@@ -112,24 +109,35 @@ The CI workflow (`.github/workflows/android.yml`) shows the canonical build step
        ▼              ▼     ▼
 ┌────────────┐  ┌─────────────────┐  ┌───────────────┐
 │ :core-data │  │ :core-playback  │  │  :core-ui     │
-│  Room +    │  │  MediaSession + │  │  Library      │
-│  repos +   │  │  TtsPlayer +    │  │  Nocturne     │
-│  Fiction   │  │  SentenceTracker│  │  theme +      │
-│  Source    │  │  + Wear bridge  │  │  components   │
-└─────┬──────┘  └─────────────────┘  └───────────────┘
-      │
-      ▼
-┌──────────────────────────┐
-│ :source-royalroad        │
-│  Cloudflare-aware fetch, │
-│  parsers, login WebView, │
-│  honeypot filter         │
-└──────────────────────────┘
+│  Room +    │  │  EnginePlayer + │  │  Library      │
+│  repos +   │  │  PcmSource +    │  │  Nocturne     │
+│  Fiction   │  │  VoiceManager + │  │  theme +      │
+│  Source    │  │  SentenceTracker│  │  components   │
+│  Map       │  │  (in-proc TTS)  │  │               │
+└─────┬──────┘  └────────┬────────┘  └───────────────┘
+      │                  │
+      ▼                  │ JitPack: VoxSherpa-TTS :engine-lib
+┌──────────────────────┐ │ (Piper + Kokoro + sherpa-onnx)
+│ :source-royalroad    │ │
+│  Cloudflare-aware    │ │
+│  fetch, parsers,     │ │
+│  login WebView,      │ │
+│  honeypot filter     │ │
+└──────────────────────┘ │
+┌──────────────────────┐ │
+│ :source-github       │ │
+│  GitHub API client,  │ │
+│  book.toml +         │ │
+│  storyvox.json,      │ │
+│  commonmark renderer │ │
+└──────────────────────┘ │
+                         ▼
+                   (audio out)
 ```
 
-Eight Gradle modules. The dependency arrows are deliberate — `:core-ui` is a leaf, sources implement an interface declared in `:core-data`, the playback layer is independent of UI.
+Eight Gradle modules. Sources implement an interface declared in `:core-data` and are bound into `Map<String, FictionSource>` via Hilt `@IntoMap @StringKey`. The playback layer is independent of UI; the engine library is a single transitive dep on `:core-playback`.
 
-For more depth see [`docs/superpowers/specs/2026-05-05-storyvox-design.md`](docs/superpowers/specs/2026-05-05-storyvox-design.md) and the per-dreamer detail specs in `scratch/dreamers/`.
+For more depth see [`docs/superpowers/specs/2026-05-05-storyvox-design.md`](docs/superpowers/specs/2026-05-05-storyvox-design.md), [`docs/superpowers/specs/2026-05-06-github-source-design.md`](docs/superpowers/specs/2026-05-06-github-source-design.md), and the per-dreamer detail specs in `scratch/dreamers/`.
 
 ## Stack
 
@@ -139,15 +147,16 @@ For more depth see [`docs/superpowers/specs/2026-05-05-storyvox-design.md`](docs
 | UI | Jetpack Compose, Material 3 |
 | DI | Hilt (KSP) |
 | Storage | Room, DataStore Preferences, EncryptedSharedPreferences |
-| Networking | OkHttp + Jsoup (RR is HTML, not JSON) |
-| Playback | Media3 SimpleBasePlayer + Android `TextToSpeech` |
+| Networking | OkHttp + Jsoup (RR is HTML, not JSON) + commonmark (GitHub markdown) |
+| Playback | Media3 SimpleBasePlayer + custom AudioTrack pipeline |
+| TTS | VoxSherpa-TTS engine-lib (Piper + Kokoro on sherpa-onnx) — in-process |
 | Async | Coroutines + Flow |
 | Wear OS | Compose for Wear, `play-services-wearable` |
 | CI | GitHub Actions |
 
 ## How it was built
 
-storyvox was built in a single day (May 5, 2026) by JP Hein orchestrating teams of dream-named [Claude Opus](https://www.anthropic.com/claude) agents working in parallel via [Claude Code](https://www.anthropic.com/claude-code). The five-act structure:
+storyvox was built starting May 5, 2026 by JP Hein orchestrating teams of dream-named [Claude Opus](https://www.anthropic.com/claude) agents working in parallel via [Claude Code](https://www.anthropic.com/claude-code). The original five-act structure shipped the v0.3 line:
 
 1. **storyvox-dreamers** — Morpheus, Selene, Oneiros, Hypnos, Aurora drafted the architecture, data layer, Royal Road integration, playback engine, and design system.
 2. **storyvox-tonight** — Phantasos, Morrigan, Caelus wired live audio playback, library round-trip, and loading skeletons.
@@ -155,8 +164,12 @@ storyvox was built in a single day (May 5, 2026) by JP Hein orchestrating teams 
 4. **storyvox-features-2** — Athena, Themis, Hestia shipped sign-in, full RR filters, and responsive grids.
 5. **Davis** orchestrated all four teams, integrated their work, verified on a Galaxy Tab A7 Lite, committed and pushed.
 
-Each commit message preserves who did what — `git log` reads as a team retro.
+Subsequent dreamer teams have shipped the in-process TTS engine, voice library, GitHub fiction source, infinite-scroll browse, motion polish, and PCM cache buffering. Each commit message preserves who did what — `git log` reads as a team retro.
 
 ## License
 
-storyvox is licensed under the [GNU General Public License v3.0](LICENSE) — same as VoxSherpa. You're free to use, modify, and redistribute under those terms.
+storyvox is licensed under the [GNU General Public License v3.0](LICENSE).
+
+We statically link [VoxSherpa-TTS](https://github.com/jphein/VoxSherpa-TTS) (GPL-3.0) into the APK as our TTS engine. The combined work is therefore GPL-3.0 — this license is not a posture choice, it's a downstream obligation. Relicensing more permissively would require replacing the engine, not just changing this file.
+
+You're free to use, modify, and redistribute under the terms of the GPL-3.0.


### PR DESCRIPTION
## Summary

- Rewrite README to reflect current state: v0.4.28, in-process TTS engine
  (Piper + Kokoro via VoxSherpa-TTS engine-lib AAR), Royal Road **and**
  GitHub fiction sources, infinite-scroll browse, PCM cache pause-buffer-
  resume, GitHub commit-SHA chapter polling. Previous README was frozen at
  v0.3.x and described the separate-APK install model that ended at v0.4.0.
- Update architecture diagram to include `:source-github` and the engine-lib
  link from `:core-playback`.
- Rewrite the License section to make the GPL-3.0 obligation explicit:
  storyvox statically links VoxSherpa-TTS (GPL-3.0) into the APK, so the
  combined work must be GPL-3.0. Relicensing permissively would require
  replacing the engine, not just changing this file.

## Note on the brief

Issue #82 was framed as "vox-sherpa has been removed → license review may free
us to relicense." The codebase reality is narrower: the **separate-APK install
model** ended at v0.4.0 (`1e67cdc`), but the **VoxSherpa-TTS library** is
still the TTS engine, pulled in-process via JitPack
(`core-playback/build.gradle.kts:64`,
`implementation("com.github.jphein:VoxSherpa-TTS:v2.7.3")`). The Piper and
Kokoro engines live inside that AAR. So:

- LICENSE stays GPL-3.0 (correct given in-process linking).
- README's "separate APK" framing was the actually-stale part — that's what
  this PR fixes.
- If at some point the engine is replaced with a permissively-licensed
  alternative, the relicense conversation becomes a real choice. Today it
  isn't.

## Test plan

- [ ] Visual: render README on GitHub, confirm tables and diagram render
- [ ] Verify no broken links (Royal Road, GitHub, VoxSherpa-TTS, sherpa-onnx,
      Piper, Kokoro, storyvox-registry, design specs in `docs/`)
- [ ] Spot-check screenshots still resolve

Issue: #82

🤖 Generated with [Claude Code](https://claude.com/claude-code)