### PR TITLE
feat(playback): punctuation-pause toggle (#90)

### DIFF
--- a/app/src/main/kotlin/in/jphe/storyvox/data/SettingsRepositoryUiImpl.kt
+++ b/app/src/main/kotlin/in/jphe/storyvox/data/SettingsRepositoryUiImpl.kt
@@ -12,6 +12,7 @@ import androidx.datastore.preferences.preferencesDataStore
 import dagger.hilt.android.qualifiers.ApplicationContext
 import `in`.jphe.storyvox.data.auth.SessionHydrator
 import `in`.jphe.storyvox.data.repository.AuthRepository
+import `in`.jphe.storyvox.feature.api.PunctuationPause
 import `in`.jphe.storyvox.feature.api.SettingsRepositoryUi
 import `in`.jphe.storyvox.feature.api.ThemeOverride
 import `in`.jphe.storyvox.feature.api.UiSettings
@@ -32,6 +33,12 @@ private object Keys {
     val DOWNLOAD_WIFI_ONLY = booleanPreferencesKey("pref_download_wifi_only")
     val POLL_INTERVAL_HOURS = intPreferencesKey("pref_poll_interval_hours")
     val SIGNED_IN = booleanPreferencesKey("pref_signed_in")
+    /** Issue #90 — three-stop selector for inter-sentence silence. Stored
+     *  as the enum name (`OFF`/`NORMAL`/`LONG`) for forward-compat if we
+     *  add stops later (matches THEME_OVERRIDE encoding). Default = NORMAL
+     *  preserves pre-#90 audiobook cadence on first launch + on existing
+     *  installs that have no value persisted. */
+    val PUNCTUATION_PAUSE = stringPreferencesKey("pref_punctuation_pause")
 }
 
 @Singleton
@@ -54,6 +61,9 @@ class SettingsRepositoryUiImpl @Inject constructor(
             downloadOnWifiOnly = prefs[Keys.DOWNLOAD_WIFI_ONLY] ?: true,
             pollIntervalHours = prefs[Keys.POLL_INTERVAL_HOURS] ?: 6,
             isSignedIn = prefs[Keys.SIGNED_IN] ?: false,
+            punctuationPause = prefs[Keys.PUNCTUATION_PAUSE]
+                ?.let { runCatching { PunctuationPause.valueOf(it) }.getOrNull() }
+                ?: PunctuationPause.Normal,
             sigil = Sigil.current.let {
                 UiSigil(
                     name = it.name,
@@ -94,6 +104,10 @@ class SettingsRepositoryUiImpl @Inject constructor(
 
     override suspend fun setPollIntervalHours(hours: Int) {
         store.edit { it[Keys.POLL_INTERVAL_HOURS] = hours.coerceIn(1, 24) }
+    }
+
+    override suspend fun setPunctuationPause(mode: PunctuationPause) {
+        store.edit { it[Keys.PUNCTUATION_PAUSE] = mode.name }
     }
 
     override suspend fun signIn() {

--- a/app/src/main/kotlin/in/jphe/storyvox/di/AppBindings.kt
+++ b/app/src/main/kotlin/in/jphe/storyvox/di/AppBindings.kt
@@ -94,7 +94,8 @@ object AppBindings {
         @ApplicationContext context: Context,
         controller: PlaybackController,
         chapters: ChapterRepository,
-    ): PlaybackControllerUi = RealPlaybackControllerUi(context, controller, chapters)
+        settings: SettingsRepositoryUi,
+    ): PlaybackControllerUi = RealPlaybackControllerUi(context, controller, chapters, settings)
 
     @Provides @Singleton
     fun provideVoiceProviderUi(impl: VoiceProviderUiImpl): VoiceProviderUi = impl
@@ -351,9 +352,30 @@ private class RealPlaybackControllerUi(
     private val context: Context,
     private val controller: PlaybackController,
     private val chapters: ChapterRepository,
+    private val settings: SettingsRepositoryUi,
 ) : PlaybackControllerUi {
 
     private val scope = CoroutineScope(SupervisorJob() + Dispatchers.Main.immediate)
+
+    init {
+        // Issue #90: keep the live engine's punctuation-pause multiplier in
+        // sync with the persisted user preference. We do the observation here
+        // (rather than in core-playback's StoryvoxPlaybackService) because
+        // SettingsRepositoryUi lives in feature/api — adding it as a dep on
+        // core-playback would invert the layering. This adapter is the
+        // first place both modules already meet, so it's the right seam.
+        //
+        // Distinct on the multiplier value (not the enum) so a no-op enum
+        // re-emission from DataStore hydration doesn't trigger a needless
+        // pipeline rebuild via setPunctuationPauseMultiplier (which calls
+        // startPlaybackPipeline if currently playing).
+        scope.launch {
+            settings.settings
+                .map { it.punctuationPause.multiplier }
+                .distinctUntilChanged()
+                .collect { controller.setPunctuationPauseMultiplier(it) }
+        }
+    }
 
     /**
      * Position interpolation: the underlying [PlaybackState.charOffset] only
@@ -420,6 +442,8 @@ private class RealPlaybackControllerUi(
     override fun setSpeed(speed: Float) = controller.setSpeed(speed)
     override fun setPitch(pitch: Float) = controller.setPitch(pitch)
     override fun setVoice(voiceId: String) = controller.setVoice(voiceId)
+    override fun setPunctuationPauseMultiplier(multiplier: Float) =
+        controller.setPunctuationPauseMultiplier(multiplier)
 
     override fun startSleepTimer(mode: UiSleepTimerMode) {
         val internal = when (mode) {

--- a/core-playback/src/main/kotlin/in/jphe/storyvox/playback/PlaybackController.kt
+++ b/core-playback/src/main/kotlin/in/jphe/storyvox/playback/PlaybackController.kt
@@ -33,6 +33,8 @@ interface PlaybackController {
     fun setSpeed(speed: Float)
     fun setPitch(pitch: Float)
     fun setVoice(voiceId: String)
+    /** Issue #90 — see [in.jphe.storyvox.playback.tts.EnginePlayer.setPunctuationPauseMultiplier]. */
+    fun setPunctuationPauseMultiplier(multiplier: Float)
 
     fun startSleepTimer(mode: SleepTimerMode)
     fun cancelSleepTimer()
@@ -131,6 +133,10 @@ class DefaultPlaybackController @Inject constructor(
 
     override fun setVoice(voiceId: String) {
         player?.setVoice(voiceId)
+    }
+
+    override fun setPunctuationPauseMultiplier(multiplier: Float) {
+        player?.setPunctuationPauseMultiplier(multiplier)
     }
 
     override fun startSleepTimer(mode: SleepTimerMode) {

--- a/core-playback/src/main/kotlin/in/jphe/storyvox/playback/tts/EnginePlayer.kt
+++ b/core-playback/src/main/kotlin/in/jphe/storyvox/playback/tts/EnginePlayer.kt
@@ -107,6 +107,15 @@ class EnginePlayer @AssistedInject constructor(
     private var currentSpeed: Float = 1.0f
     private var currentPitch: Float = 1.0f
 
+    /** Issue #90 — multiplier on the inter-sentence silence the producer
+     *  splices after each sentence's PCM. 0f = no trailing silence at all,
+     *  1f = the audiobook-tuned default, >1f lengthens. Wired through to
+     *  [EngineStreamingSource] on every pipeline rebuild (same lifecycle
+     *  as [currentSpeed] and [currentPitch] — changing it via
+     *  [setPunctuationPauseMultiplier] rebuilds the pipeline if playing,
+     *  so the new value takes effect on the next sentence boundary). */
+    private var currentPunctuationPauseMultiplier: Float = 1f
+
     /** Engine type for the currently-loaded voice. Set in [loadAndPlay]
      *  after a successful model load; read by the producer in
      *  [startPlaybackPipeline] to decide which engine drives generation. */
@@ -436,6 +445,7 @@ class EnginePlayer @AssistedInject constructor(
             speed = currentSpeed,
             pitch = currentPitch,
             engineMutex = engineMutex,
+            punctuationPauseMultiplier = currentPunctuationPauseMultiplier,
         )
         pcmSource = source
         pipelineRunning.set(true)
@@ -883,6 +893,24 @@ class EnginePlayer @AssistedInject constructor(
     fun setPitch(pitch: Float) {
         currentPitch = pitch
         _observableState.update { it.copy(pitch = pitch) }
+        if (_observableState.value.isPlaying) startPlaybackPipeline()
+        invalidateState()
+    }
+
+    /**
+     * Issue #90 — set the inter-sentence silence multiplier. 0f disables
+     * the splice entirely; 1f restores the default. Coerced to [0, 4] to
+     * defend against bad callers (the UI hard-codes Off=0 / Normal=1 /
+     * Long=1.75 today, but a future slider could pass arbitrary values).
+     *
+     * Mirrors [setSpeed] / [setPitch]: stores the new value, then rebuilds
+     * the pipeline so the next sentence the producer generates picks up
+     * the new multiplier. The currently-playing sentence finishes with
+     * whatever silence it was queued with — we don't try to retro-edit
+     * audio already in the AudioTrack ring buffer.
+     */
+    fun setPunctuationPauseMultiplier(multiplier: Float) {
+        currentPunctuationPauseMultiplier = multiplier.coerceIn(0f, 4f)
         if (_observableState.value.isPlaying) startPlaybackPipeline()
         invalidateState()
     }

--- a/core-playback/src/main/kotlin/in/jphe/storyvox/playback/tts/source/EngineStreamingSource.kt
+++ b/core-playback/src/main/kotlin/in/jphe/storyvox/playback/tts/source/EngineStreamingSource.kt
@@ -41,6 +41,13 @@ import kotlinx.coroutines.sync.withLock
  *  AND scales the trailing-cadence pause down at faster speeds so a 2× listener
  *  doesn't sit through 700 ms gaps.
  * @param pitch pitch multiplier, fed to engine.
+ * @param punctuationPauseMultiplier scales the inter-sentence silence
+ *  spliced after each sentence's PCM (issue #90). 0f = no trailing silence
+ *  at all; 1f = the audiobook-tuned default in [trailingPauseMs]; >1f
+ *  lengthens proportionally. Applied AFTER the speed scaling so the
+ *  semantic is "pause length the user wants to hear" — at 2× playback
+ *  with multiplier=1f the listener still gets a sensible 175 ms gap, and
+ *  at multiplier=0f they get no gap regardless of speed.
  * @param queueCapacity bounded queue depth; producer back-pressures when full.
  *  Defaults to 8 to match the prior EnginePlayer constant.
  */
@@ -56,6 +63,7 @@ class EngineStreamingSource(
      *  loadModel().destroy() while the prior source's generator is still
      *  inside the JNI generate(...) call, corrupting native state. */
     private val engineMutex: Mutex,
+    private val punctuationPauseMultiplier: Float = 1f,
     private val queueCapacity: Int = 8,
 ) : PcmSource {
 
@@ -135,7 +143,18 @@ class EngineStreamingSource(
                     engine.generateAudioPCM(s.text, speed, pitch)
                 } ?: continue
                 if (!running.get()) return@launch
-                val pauseMs = trailingPauseMs(s.text) / speed.coerceAtLeast(0.5f)
+                // Issue #90: the user-facing punctuation-pause selector
+                // (Off/Normal/Long) lands here as a multiplier. 0× kills
+                // the silence entirely, 1× preserves the pre-#90 default,
+                // 1.75× ("Long") stretches it. Speed scaling still applies
+                // on top so a 2× listener doesn't sit through long gaps
+                // even on Long. coerceAtLeast(0f) defends against a
+                // negative slipping in from a bad caller — silenceBytesFor
+                // already coerces non-positive durations to 0 but we also
+                // want the toInt() floor to behave.
+                val mult = punctuationPauseMultiplier.coerceAtLeast(0f)
+                val pauseMs =
+                    (trailingPauseMs(s.text) * mult) / speed.coerceAtLeast(0.5f)
                 val silenceBytes = silenceBytesFor(pauseMs.toInt(), sampleRate)
                 val chunk = PcmChunk(
                     sentenceIndex = i,

--- a/core-playback/src/test/kotlin/in/jphe/storyvox/playback/tts/source/EngineStreamingSourceTest.kt
+++ b/core-playback/src/test/kotlin/in/jphe/storyvox/playback/tts/source/EngineStreamingSourceTest.kt
@@ -87,6 +87,61 @@ class EngineStreamingSourceTest {
     }
 
     @Test
+    fun `punctuationPauseMultiplier scales trailing silence`() = runBlocking {
+        // Issue #90 — verify the multiplier we plumb down from the
+        // Settings selector actually changes the silence slot in each
+        // PcmChunk. Two sentences ending in '.', so the base
+        // trailingPauseMs is 350 ms each; speed=1f so no speed-scaling
+        // contribution. We check three points:
+        //   - multiplier=0f → silenceBytes == 0  (Off)
+        //   - multiplier=1f → silenceBytes ≈ baseline (Normal — pre-#90)
+        //   - multiplier=2f → silenceBytes ≈ 2× baseline (Long-ish)
+        val sentences = listOf(
+            Sentence(0, 0, 10, "First."),
+            Sentence(1, 11, 20, "Second."),
+        )
+        val sampleRate = 22050
+        val pcm = ByteArray(100) // small, doesn't matter for silence assertion
+        val fakeEngine = FakeVoiceEngine(sampleRate) { pcm }
+
+        suspend fun firstChunkSilenceBytes(multiplier: Float): Int {
+            val src = EngineStreamingSource(
+                sentences = sentences,
+                startSentenceIndex = 0,
+                engine = fakeEngine,
+                speed = 1f,
+                pitch = 1f,
+                engineMutex = Mutex(),
+                punctuationPauseMultiplier = multiplier,
+            )
+            val chunk = src.nextChunk()
+            src.close()
+            return chunk?.trailingSilenceBytes ?: -1
+        }
+
+        val off = firstChunkSilenceBytes(0f)
+        val normal = firstChunkSilenceBytes(1f)
+        val long = firstChunkSilenceBytes(2f)
+
+        // Off: zero silence regardless of terminal punctuation.
+        assertEquals(0, off)
+
+        // Normal: matches the pre-#90 baseline of trailingPauseMs(".")=350ms
+        // → silenceBytesFor(350, 22050) = (22050 * 350 / 1000).toInt() * 2
+        // = 7717 * 2 = 15434.
+        assertEquals(15_434, normal)
+
+        // Long-ish (2×): roughly twice normal. Allow a ±2-byte tolerance
+        // for the int floor in silenceBytesFor (700 ms × 22050 / 1000 =
+        // 15435; × 2 = 30870 vs 2 × normal = 30868).
+        val expected = silenceBytesFor(700, sampleRate)
+        assertEquals(expected, long)
+        assert(long >= normal * 2 - 4 && long <= normal * 2 + 4) {
+            "Long ($long) should be ≈ 2× normal ($normal); diff = ${long - normal * 2}"
+        }
+    }
+
+    @Test
     fun `bufferHeadroomMs reflects queued audio duration`() = runBlocking {
         val sentences = listOf(
             Sentence(0, 0, 10, "One."),

--- a/feature/src/main/kotlin/in/jphe/storyvox/feature/api/UiContracts.kt
+++ b/feature/src/main/kotlin/in/jphe/storyvox/feature/api/UiContracts.kt
@@ -245,6 +245,14 @@ interface PlaybackControllerUi {
     fun setSpeed(speed: Float)
     fun setPitch(pitch: Float)
     fun setVoice(voiceId: String)
+    /**
+     * Scale the inter-sentence punctuation pause (issue #90). 0f disables
+     * trailing silence entirely; 1f is the audiobook-tuned default; >1f
+     * lengthens. Applied to the next sentence the producer generates —
+     * the live pipeline rebuilds so the change takes effect on the next
+     * sentence boundary, mirroring [setSpeed]/[setPitch].
+     */
+    fun setPunctuationPauseMultiplier(multiplier: Float)
     fun startListening(fictionId: String, chapterId: String, charOffset: Int = 0)
     fun startSleepTimer(mode: UiSleepTimerMode)
     fun cancelSleepTimer()
@@ -278,8 +286,39 @@ data class UiSettings(
     val downloadOnWifiOnly: Boolean,
     val pollIntervalHours: Int,
     val isSignedIn: Boolean,
+    val punctuationPause: PunctuationPause = PunctuationPause.Normal,
     val sigil: UiSigil = UiSigil.UNKNOWN,
 )
+
+/**
+ * Three-stop selector for the inter-sentence silence storyvox splices after
+ * each TTS sentence (issue #90). The base pause table lives in
+ * `EngineStreamingSource.trailingPauseMs(...)` — `.`/`?`/`!` get 350 ms,
+ * `;`/`:` get 200 ms, `,`/dashes get 120 ms, fallback 60 ms. This enum
+ * scales every output by [multiplier]:
+ *
+ *  - **Off** (0×) — no inter-sentence silence at all. Engine boundary +
+ *    AudioTrack scheduling latency are the only pause. Useful for fast
+ *    re-listens or low-latency reads.
+ *  - **Normal** (1×) — the audiobook-tuned default; what storyvox shipped
+ *    pre-#90.
+ *  - **Long** (1.75×) — slightly more dramatic cadence; useful for narration
+ *    where the listener wants more time between sentences.
+ *
+ * The 1.75× ceiling is conservative — anything beyond that started feeling
+ * unnatural in JP's audiobook-ear test at 1× speed. A larger ceiling can be
+ * justified later if the user feedback warrants it.
+ */
+enum class PunctuationPause {
+    Off, Normal, Long;
+
+    val multiplier: Float
+        get() = when (this) {
+            Off -> 0f
+            Normal -> 1f
+            Long -> 1.75f
+        }
+}
 
 /**
  * Realm-sigil version metadata captured at build time. Surfaced in the
@@ -323,6 +362,7 @@ interface SettingsRepositoryUi {
     suspend fun setDefaultVoice(voiceId: String?)
     suspend fun setDownloadOnWifiOnly(enabled: Boolean)
     suspend fun setPollIntervalHours(hours: Int)
+    suspend fun setPunctuationPause(mode: PunctuationPause)
     suspend fun signIn()
     suspend fun signOut()
 }

--- a/feature/src/main/kotlin/in/jphe/storyvox/feature/settings/SettingsScreen.kt
+++ b/feature/src/main/kotlin/in/jphe/storyvox/feature/settings/SettingsScreen.kt
@@ -21,6 +21,7 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import `in`.jphe.storyvox.feature.api.PunctuationPause
 import `in`.jphe.storyvox.feature.api.ThemeOverride
 import `in`.jphe.storyvox.ui.component.BrassButton
 import `in`.jphe.storyvox.ui.component.BrassButtonVariant
@@ -66,6 +67,22 @@ fun SettingsScreen(
             steps = 29, // 0.01 per step
         )
         Text("Pitch ${"%.2f".format(s.defaultPitch)}×", style = MaterialTheme.typography.bodySmall)
+
+        // Issue #90: three-stop selector for the inter-sentence silence
+        // splice. Same brass-button-row aesthetic as the Theme picker so
+        // it feels like a sibling control.
+        Text("Pause after . , ? ! ; :", style = MaterialTheme.typography.bodyMedium)
+        Text(
+            "How long to pause between sentences. Off makes the reader sprint; Long gives narration room to breathe.",
+            style = MaterialTheme.typography.bodySmall,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+        )
+        Row(verticalAlignment = Alignment.CenterVertically, horizontalArrangement = Arrangement.spacedBy(spacing.xs)) {
+            PunctuationPause.entries.forEach { mode ->
+                val variant = if (s.punctuationPause == mode) BrassButtonVariant.Primary else BrassButtonVariant.Secondary
+                BrassButton(label = mode.name, onClick = { viewModel.setPunctuationPause(mode) }, variant = variant)
+            }
+        }
 
         Divider()
         SectionHeader("Theme")

--- a/feature/src/main/kotlin/in/jphe/storyvox/feature/settings/SettingsViewModel.kt
+++ b/feature/src/main/kotlin/in/jphe/storyvox/feature/settings/SettingsViewModel.kt
@@ -4,6 +4,7 @@ import androidx.compose.runtime.Immutable
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import dagger.hilt.android.lifecycle.HiltViewModel
+import `in`.jphe.storyvox.feature.api.PunctuationPause
 import `in`.jphe.storyvox.feature.api.SettingsRepositoryUi
 import `in`.jphe.storyvox.feature.api.ThemeOverride
 import `in`.jphe.storyvox.feature.api.UiSettings
@@ -41,6 +42,9 @@ class SettingsViewModel @Inject constructor(
     fun setDefaultVoice(id: String?) = viewModelScope.launch { repo.setDefaultVoice(id) }
     fun setWifiOnly(enabled: Boolean) = viewModelScope.launch { repo.setDownloadOnWifiOnly(enabled) }
     fun setPollHours(h: Int) = viewModelScope.launch { repo.setPollIntervalHours(h) }
+    /** Issue #90 — three-stop punctuation-pause selector. */
+    fun setPunctuationPause(mode: PunctuationPause) =
+        viewModelScope.launch { repo.setPunctuationPause(mode) }
     fun signIn() = viewModelScope.launch { repo.signIn() }
     fun signOut() = viewModelScope.launch { repo.signOut() }
     fun previewVoice(voice: UiVoice) = voices.previewVoice(voice)


### PR DESCRIPTION
## Summary

Closes #90.

Expose the inter-sentence silence storyvox splices after each TTS sentence as a Settings selector. Three stops — Off / Normal / Long — multiplying the per-punctuation pause table in `EngineStreamingSource.trailingPauseMs` by `0×` / `1×` / `1.75×`. Default = Normal preserves today's audiobook cadence; existing installs see no change until they touch the toggle.

The pause is a storyvox-side splice (zero-PCM bytes appended to each sentence's PCM, written from a shared zero-fill buffer to AudioTrack); VoxSherpa-TTS itself doesn't expose a punctuation-pause knob, so the toggle is fully under our control.

## Plumbing

- `PunctuationPause` enum (Off/Normal/Long) added to `feature/api` with a `multiplier` accessor.
- Persisted in `storyvox_settings` DataStore as `pref_punctuation_pause` (string-encoded enum name; mirrors `pref_theme_override`).
- `EngineStreamingSource` gains a `punctuationPauseMultiplier` ctor param, applied on top of the existing speed-scale of `trailingPauseMs`.
- `EnginePlayer` carries the multiplier as mutable state and rebuilds the pipeline on change (mirrors `setSpeed`/`setPitch`).
- `PlaybackController` + `PlaybackControllerUi` gain `setPunctuationPauseMultiplier`; `AppBindings` observes `settings.flow` and pushes the multiplier into the controller on change.
- `SettingsScreen` renders a 3-button brass row matching the Theme picker, placed under the Pitch slider in the Reading section.

## Tests

`EngineStreamingSourceTest`:
- New: `punctuationPauseMultiplier scales trailing silence` — verifies `0f → silenceBytes=0`, `1f → pre-#90 baseline`, `2f → ~2× baseline`.
- Existing 3 tests still green.

`./gradlew :app:assembleDebug` and `./gradlew :core-playback:test :feature:test :app:test` both pass.

## Test plan

- [ ] Settings screen: tap Off / Normal / Long, kill app, relaunch — selection persists.
- [ ] Listen mid-chapter, change setting from Normal → Off — next sentence boundary plays with no pause.
- [ ] Listen mid-chapter, change setting from Normal → Long — next sentence boundary plays with longer pause.
- [ ] On Off, fast-forward / seek still works (trailing silence wasn't load-bearing for the seek path).
- [ ] Speed scaling still applies on top of multiplier — at 2× speed + Long, pause is ~half what it'd be at 1× + Long.

🤖 Generated with [Claude Code](https://claude.com/claude-code)