### PR TITLE
fix(voices): engine-grouped voice library (#94)

### DIFF
--- a/feature/src/main/kotlin/in/jphe/storyvox/feature/voicelibrary/VoiceLibraryScreen.kt
+++ b/feature/src/main/kotlin/in/jphe/storyvox/feature/voicelibrary/VoiceLibraryScreen.kt
@@ -42,7 +42,6 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
-import `in`.jphe.storyvox.playback.voice.EngineType
 import `in`.jphe.storyvox.playback.voice.QualityLevel
 import `in`.jphe.storyvox.playback.voice.UiVoiceInfo
 import `in`.jphe.storyvox.ui.component.BrassButton
@@ -76,10 +75,11 @@ fun VoiceLibraryScreen(
     ) { padding ->
         val featured = state.featured
         val favorites = state.favorites
-        val installedByTier = state.installedByTier
-        val availableByTier = state.availableByTier
-        val installedTotal = installedByTier.values.sumOf { it.size }
-        val availableTotal = availableByTier.values.sumOf { it.size }
+        val installedByEngine = state.installedByEngine
+        val availableByEngine = state.availableByEngine
+        val installedTotal = installedByEngine.values.sumOf { tiers -> tiers.values.sumOf { it.size } }
+        val availableTotal = availableByEngine.values.sumOf { tiers -> tiers.values.sumOf { it.size } }
+        val availableHasKokoro = availableByEngine.containsKey(VoiceEngine.Kokoro)
         val isEmpty = featured.isEmpty() && favorites.isEmpty() &&
             installedTotal == 0 && availableTotal == 0
 
@@ -157,23 +157,32 @@ fun VoiceLibraryScreen(
                     )
                 }
             } else {
-                installedByTier.forEach { (tier, voicesInTier) ->
-                    item(key = "i-tier-${tier.name}") {
-                        TierSubHeader(tier = tier, count = voicesInTier.size)
+                installedByEngine.forEach { (engine, tiers) ->
+                    val engineCount = tiers.values.sumOf { it.size }
+                    item(key = "i-engine-${engine.name}") {
+                        EngineSubHeader(engine = engine, count = engineCount)
                     }
-                    itemsIndexed(voicesInTier, key = { _, item -> "i-${item.id}" }) { index, voice ->
-                        VoiceRow(
-                            voice = voice,
-                            isActive = voice.id == state.activeVoiceId,
-                            isFavorite = voice.id in state.favoriteIds,
-                            downloadingProgress = null,
-                            onTap = { viewModel.onRowTapped(voice) },
-                            onLongPress = { viewModel.requestDelete(voice) },
-                            onToggleFavorite = { viewModel.toggleFavorite(voice.id) },
-                            modifier = Modifier
-                                .animateItem()
-                                .cascadeReveal(index = index, key = voice.id),
-                        )
+                    tiers.forEach { (tier, voicesInTier) ->
+                        item(key = "i-${engine.name}-tier-${tier.name}") {
+                            TierSubHeader(tier = tier, count = voicesInTier.size)
+                        }
+                        itemsIndexed(
+                            voicesInTier,
+                            key = { _, item -> "i-${item.id}" },
+                        ) { index, voice ->
+                            VoiceRow(
+                                voice = voice,
+                                isActive = voice.id == state.activeVoiceId,
+                                isFavorite = voice.id in state.favoriteIds,
+                                downloadingProgress = null,
+                                onTap = { viewModel.onRowTapped(voice) },
+                                onLongPress = { viewModel.requestDelete(voice) },
+                                onToggleFavorite = { viewModel.toggleFavorite(voice.id) },
+                                modifier = Modifier
+                                    .animateItem()
+                                    .cascadeReveal(index = index, key = voice.id),
+                            )
+                        }
                     }
                 }
             }
@@ -183,31 +192,37 @@ fun VoiceLibraryScreen(
                     Spacer(modifier = Modifier.height(spacing.md))
                     SectionHeader("Available", count = availableTotal, dim = true)
                 }
-                if (availableByTier.values.any { tier ->
-                        tier.any { it.engineType is EngineType.Kokoro }
-                    }
-                ) {
+                if (availableHasKokoro) {
                     item { KokoroBundleNote() }
                 }
-                availableByTier.forEach { (tier, voicesInTier) ->
-                    item(key = "a-tier-${tier.name}") {
-                        TierSubHeader(tier = tier, count = voicesInTier.size, dim = true)
+                availableByEngine.forEach { (engine, tiers) ->
+                    val engineCount = tiers.values.sumOf { it.size }
+                    item(key = "a-engine-${engine.name}") {
+                        EngineSubHeader(engine = engine, count = engineCount, dim = true)
                     }
-                    val downloading = state.currentDownload
-                    itemsIndexed(voicesInTier, key = { _, item -> "a-${item.id}" }) { index, voice ->
-                        val rowProgress = if (downloading?.voiceId == voice.id) downloading.progress ?: -1f else null
-                        VoiceRow(
-                            voice = voice,
-                            isActive = false,
-                            isFavorite = voice.id in state.favoriteIds,
-                            downloadingProgress = rowProgress,
-                            onTap = { if (downloading == null) viewModel.onRowTapped(voice) },
-                            onLongPress = null,
-                            onToggleFavorite = { viewModel.toggleFavorite(voice.id) },
-                            modifier = Modifier
-                                .animateItem()
-                                .cascadeReveal(index = index, key = voice.id),
-                        )
+                    tiers.forEach { (tier, voicesInTier) ->
+                        item(key = "a-${engine.name}-tier-${tier.name}") {
+                            TierSubHeader(tier = tier, count = voicesInTier.size, dim = true)
+                        }
+                        val downloading = state.currentDownload
+                        itemsIndexed(
+                            voicesInTier,
+                            key = { _, item -> "a-${item.id}" },
+                        ) { index, voice ->
+                            val rowProgress = if (downloading?.voiceId == voice.id) downloading.progress ?: -1f else null
+                            VoiceRow(
+                                voice = voice,
+                                isActive = false,
+                                isFavorite = voice.id in state.favoriteIds,
+                                downloadingProgress = rowProgress,
+                                onTap = { if (downloading == null) viewModel.onRowTapped(voice) },
+                                onLongPress = null,
+                                onToggleFavorite = { viewModel.toggleFavorite(voice.id) },
+                                modifier = Modifier
+                                    .animateItem()
+                                    .cascadeReveal(index = index, key = voice.id),
+                            )
+                        }
                     }
                 }
             }
@@ -281,10 +296,44 @@ private fun SectionHeader(label: String, count: Int, dim: Boolean = false) {
     }
 }
 
-/** Tier label + count rendered under a [SectionHeader] (Studio /
- *  High / Medium / Low). Visually quieter than the section header so the
- *  Installed/Available grouping is still the primary read; the tier
- *  label is a refinement, not a peer. */
+/** Engine label + count rendered under a [SectionHeader] (Piper /
+ *  Kokoro). Visually slightly louder than the per-tier sub-header
+ *  beneath it so the read order is Section → Engine → Tier → Row.
+ *  Empty engine groups never reach this composable — the ViewModel's
+ *  [groupByEngineThenTier] drops them. */
+@Composable
+private fun EngineSubHeader(engine: VoiceEngine, count: Int, dim: Boolean = false) {
+    val baseColor = if (dim) {
+        MaterialTheme.colorScheme.onSurfaceVariant
+    } else {
+        MaterialTheme.colorScheme.primary
+    }
+    val label = when (engine) {
+        VoiceEngine.Piper -> "Piper"
+        VoiceEngine.Kokoro -> "Kokoro"
+    }
+    Row(
+        verticalAlignment = Alignment.CenterVertically,
+        modifier = Modifier.padding(top = 6.dp, bottom = 2.dp),
+    ) {
+        Text(
+            label,
+            style = MaterialTheme.typography.labelLarge,
+            color = baseColor.copy(alpha = 0.95f),
+            fontWeight = FontWeight.SemiBold,
+        )
+        Text(
+            "  ·  $count",
+            style = MaterialTheme.typography.labelMedium,
+            color = baseColor.copy(alpha = 0.65f),
+        )
+    }
+}
+
+/** Tier label + count rendered under an [EngineSubHeader] (Studio /
+ *  High / Medium / Low). Visually quieter than the engine sub-header so
+ *  the Section → Engine grouping reads first; the tier label is a
+ *  refinement, not a peer. */
 @Composable
 private fun TierSubHeader(tier: QualityLevel, count: Int, dim: Boolean = false) {
     val baseColor = if (dim) {

--- a/feature/src/main/kotlin/in/jphe/storyvox/feature/voicelibrary/VoiceLibraryViewModel.kt
+++ b/feature/src/main/kotlin/in/jphe/storyvox/feature/voicelibrary/VoiceLibraryViewModel.kt
@@ -4,6 +4,7 @@ import androidx.compose.runtime.Immutable
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import dagger.hilt.android.lifecycle.HiltViewModel
+import `in`.jphe.storyvox.playback.voice.EngineType
 import `in`.jphe.storyvox.playback.voice.QualityLevel
 import `in`.jphe.storyvox.playback.voice.UiVoiceInfo
 import `in`.jphe.storyvox.playback.voice.VoiceCatalog
@@ -31,14 +32,19 @@ data class VoiceLibraryUiState(
      *  Featured. Empty when nothing pinned, in which case the whole
      *  section is hidden by the screen. */
     val favorites: List<UiVoiceInfo> = emptyList(),
-    /** Installed voices grouped by tier (Studio → High → Medium → Low),
-     *  preserving the catalog's original order within each tier. The map
-     *  is iteration-ordered so callers can render groups in priority
-     *  order without re-sorting. */
-    val installedByTier: Map<QualityLevel, List<UiVoiceInfo>> = emptyMap(),
-    /** Available (not-yet-downloaded) voices grouped by tier. Same
-     *  ordering contract as [installedByTier]. */
-    val availableByTier: Map<QualityLevel, List<UiVoiceInfo>> = emptyMap(),
+    /** Installed voices grouped first by engine (Piper, then Kokoro)
+     *  and then by tier within each engine. Within Piper the tier order
+     *  is **ascending** (Low → Medium → High) — the engine choice is the
+     *  coarse bucket and users typically want to scroll past lighter
+     *  Piper voices on the way to the heavier ones. Within Kokoro the
+     *  Studio tier leads (Kokoro-exclusive) followed by the rest. Both
+     *  the outer and inner maps are iteration-ordered so the screen can
+     *  render straight through. Empty engine and tier groups are
+     *  dropped. See [groupByEngineThenTier]. */
+    val installedByEngine: Map<VoiceEngine, Map<QualityLevel, List<UiVoiceInfo>>> = emptyMap(),
+    /** Available (not-yet-downloaded) voices grouped by engine then
+     *  tier. Same ordering contract as [installedByEngine]. */
+    val availableByEngine: Map<VoiceEngine, Map<QualityLevel, List<UiVoiceInfo>>> = emptyMap(),
     val favoriteIds: Set<String> = emptySet(),
     val activeVoiceId: String? = null,
     val currentDownload: DownloadingVoice? = null,
@@ -102,8 +108,8 @@ class VoiceLibraryViewModel @Inject constructor(
         VoiceLibraryUiState(
             featured = featured,
             favorites = favorites,
-            installedByTier = installedFiltered.groupByTierDescending(),
-            availableByTier = availableFiltered.groupByTierDescending(),
+            installedByEngine = installedFiltered.groupByEngineThenTier(),
+            availableByEngine = availableFiltered.groupByEngineThenTier(),
             favoriteIds = favIds,
             activeVoiceId = active?.id,
             currentDownload = downloading,
@@ -185,29 +191,76 @@ class VoiceLibraryViewModel @Inject constructor(
     }
 }
 
-/** Tier display order — best at the top of the picker. Studio is
- *  Kokoro-only today (no Piper voice resolves to it), but listing it
- *  here keeps the screen-render code engine-agnostic. Order matters:
- *  this is iteration order for the rendered LinkedHashMap. */
-private val TIER_DISPLAY_ORDER: List<QualityLevel> = listOf(
+/** Engine grouping discriminator used by the voice library UI. The
+ *  underlying [EngineType] is sealed and Kokoro carries a speakerId we
+ *  don't want to key on, so we collapse to a tag-only enum here. Order
+ *  matters: this is the outer iteration order in [groupByEngineThenTier]
+ *  — Piper section first, then Kokoro. */
+enum class VoiceEngine { Piper, Kokoro }
+
+private fun UiVoiceInfo.voiceEngine(): VoiceEngine = when (engineType) {
+    is EngineType.Piper -> VoiceEngine.Piper
+    is EngineType.Kokoro -> VoiceEngine.Kokoro
+}
+
+/** Tier order **within Piper** — ascending (Low → Medium → High). Piper
+ *  has no Studio voice today, but if one ever lands it falls below High
+ *  (the slot is left out of this list). The ascending sort matches JP's
+ *  ask in #94: Piper users tend to start light and scale up, so showing
+ *  "Low" first keeps the lighter-weight voices visible without scroll. */
+private val PIPER_TIER_ORDER: List<QualityLevel> = listOf(
+    QualityLevel.Low,
+    QualityLevel.Medium,
+    QualityLevel.High,
+)
+
+/** Tier order **within Kokoro** — Studio first (the curated peak,
+ *  Kokoro-exclusive), then High, then Medium/Low if upstream ever
+ *  introduces them. Kokoro voices all share one bundle so tier here is
+ *  about quality grade rather than model size; Studio leading is the
+ *  point of the section. */
+private val KOKORO_TIER_ORDER: List<QualityLevel> = listOf(
     QualityLevel.Studio,
     QualityLevel.High,
     QualityLevel.Medium,
     QualityLevel.Low,
 )
 
-/** Group a list of voices by [QualityLevel] keeping the rendered order
- *  Studio → High → Medium → Low. Empty tier buckets are dropped so the
- *  screen doesn't render hollow headers. Within a tier we preserve the
- *  source list's order — the catalog already curates a sensible default
- *  (featured/⭐ rows first, then alphabetical-ish), and re-sorting here
- *  would lose that. */
-internal fun List<UiVoiceInfo>.groupByTierDescending(): Map<QualityLevel, List<UiVoiceInfo>> {
+private fun tierOrderFor(engine: VoiceEngine): List<QualityLevel> = when (engine) {
+    VoiceEngine.Piper -> PIPER_TIER_ORDER
+    VoiceEngine.Kokoro -> KOKORO_TIER_ORDER
+}
+
+/** Engine display order — Piper section first, Kokoro second. Drives
+ *  outer iteration order of [groupByEngineThenTier]. */
+private val ENGINE_DISPLAY_ORDER: List<VoiceEngine> = listOf(
+    VoiceEngine.Piper,
+    VoiceEngine.Kokoro,
+)
+
+/** Group a list of voices first by [VoiceEngine] then by
+ *  [QualityLevel], producing iteration-ordered nested maps the screen
+ *  can render straight through. Outer order: Piper → Kokoro. Inner
+ *  order: Low→Medium→High for Piper, Studio→High→Medium→Low for
+ *  Kokoro (see [PIPER_TIER_ORDER] / [KOKORO_TIER_ORDER] for the why).
+ *
+ *  Empty engine buckets and empty tier buckets are dropped so the
+ *  screen doesn't render hollow headers — a user with only Piper
+ *  voices installed never sees a "Kokoro" sub-header, and vice versa.
+ *  Within a tier the source list's order is preserved (the catalog
+ *  curates a sensible default; re-sorting here would lose that). */
+internal fun List<UiVoiceInfo>.groupByEngineThenTier(): Map<VoiceEngine, Map<QualityLevel, List<UiVoiceInfo>>> {
     if (isEmpty()) return emptyMap()
-    val out = linkedMapOf<QualityLevel, List<UiVoiceInfo>>()
-    val byTier = groupBy { it.qualityLevel }
-    for (tier in TIER_DISPLAY_ORDER) {
-        byTier[tier]?.takeIf { it.isNotEmpty() }?.let { out[tier] = it }
+    val byEngine = groupBy { it.voiceEngine() }
+    val out = linkedMapOf<VoiceEngine, Map<QualityLevel, List<UiVoiceInfo>>>()
+    for (engine in ENGINE_DISPLAY_ORDER) {
+        val voicesInEngine = byEngine[engine]?.takeIf { it.isNotEmpty() } ?: continue
+        val byTier = voicesInEngine.groupBy { it.qualityLevel }
+        val tierMap = linkedMapOf<QualityLevel, List<UiVoiceInfo>>()
+        for (tier in tierOrderFor(engine)) {
+            byTier[tier]?.takeIf { it.isNotEmpty() }?.let { tierMap[tier] = it }
+        }
+        if (tierMap.isNotEmpty()) out[engine] = tierMap
     }
     return out
 }

--- a/feature/src/test/kotlin/in/jphe/storyvox/feature/settings/SettingsViewModelBufferTest.kt
+++ b/feature/src/test/kotlin/in/jphe/storyvox/feature/settings/SettingsViewModelBufferTest.kt
@@ -2,6 +2,7 @@ package `in`.jphe.storyvox.feature.settings
 
 import `in`.jphe.storyvox.feature.api.BUFFER_DEFAULT_CHUNKS
 import `in`.jphe.storyvox.feature.api.BUFFER_RECOMMENDED_MAX_CHUNKS
+import `in`.jphe.storyvox.feature.api.PunctuationPause
 import `in`.jphe.storyvox.feature.api.SettingsRepositoryUi
 import `in`.jphe.storyvox.feature.api.ThemeOverride
 import `in`.jphe.storyvox.feature.api.UiSettings
@@ -109,6 +110,9 @@ class SettingsViewModelBufferTest {
         }
         override suspend fun setPollIntervalHours(hours: Int) {
             state.value = state.value.copy(pollIntervalHours = hours)
+        }
+        override suspend fun setPunctuationPause(mode: PunctuationPause) {
+            state.value = state.value.copy(punctuationPause = mode)
         }
         override suspend fun setPlaybackBufferChunks(chunks: Int) {
             bufferWrites += chunks

--- a/feature/src/test/kotlin/in/jphe/storyvox/feature/voicelibrary/VoiceGroupingTest.kt
+++ b/feature/src/test/kotlin/in/jphe/storyvox/feature/voicelibrary/VoiceGroupingTest.kt
@@ -1,0 +1,186 @@
+package `in`.jphe.storyvox.feature.voicelibrary
+
+import `in`.jphe.storyvox.playback.voice.EngineType
+import `in`.jphe.storyvox.playback.voice.QualityLevel
+import `in`.jphe.storyvox.playback.voice.UiVoiceInfo
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * Unit tests for [groupByEngineThenTier]. The grouping helper is the
+ * load-bearing piece of issue #94 — it decides the read order of the
+ * voice library (engine first, then tier within each engine). Anything
+ * that breaks this ordering is user-visible, so the contract is pinned
+ * here in JVM-only tests that don't bring up the screen.
+ */
+class VoiceGroupingTest {
+
+    private fun piper(id: String, tier: QualityLevel) = UiVoiceInfo(
+        id = id,
+        displayName = id,
+        language = "en_US",
+        sizeBytes = 0L,
+        isInstalled = true,
+        qualityLevel = tier,
+        engineType = EngineType.Piper,
+    )
+
+    private fun kokoro(id: String, tier: QualityLevel, speakerId: Int = 0) = UiVoiceInfo(
+        id = id,
+        displayName = id,
+        language = "en_US",
+        sizeBytes = 0L,
+        isInstalled = true,
+        qualityLevel = tier,
+        engineType = EngineType.Kokoro(speakerId),
+    )
+
+    @Test
+    fun `empty input yields empty map`() {
+        assertTrue(emptyList<UiVoiceInfo>().groupByEngineThenTier().isEmpty())
+    }
+
+    @Test
+    fun `mixed input groups Piper first then Kokoro`() {
+        val grouped = listOf(
+            kokoro("k1", QualityLevel.High),
+            piper("p1", QualityLevel.Medium),
+        ).groupByEngineThenTier()
+
+        // Outer iteration order matters — Piper must be first regardless
+        // of input order so the screen renders Piper section first.
+        assertEquals(
+            listOf(VoiceEngine.Piper, VoiceEngine.Kokoro),
+            grouped.keys.toList(),
+        )
+    }
+
+    @Test
+    fun `Piper inner order is ascending Low Medium High`() {
+        val grouped = listOf(
+            piper("p-high", QualityLevel.High),
+            piper("p-low", QualityLevel.Low),
+            piper("p-med", QualityLevel.Medium),
+        ).groupByEngineThenTier()
+
+        val piperTiers = grouped[VoiceEngine.Piper]?.keys?.toList()
+        assertEquals(
+            listOf(QualityLevel.Low, QualityLevel.Medium, QualityLevel.High),
+            piperTiers,
+        )
+    }
+
+    @Test
+    fun `Kokoro inner order has Studio first then High`() {
+        val grouped = listOf(
+            kokoro("k-high", QualityLevel.High),
+            kokoro("k-studio", QualityLevel.Studio),
+        ).groupByEngineThenTier()
+
+        val kokoroTiers = grouped[VoiceEngine.Kokoro]?.keys?.toList()
+        assertEquals(
+            listOf(QualityLevel.Studio, QualityLevel.High),
+            kokoroTiers,
+        )
+    }
+
+    @Test
+    fun `Piper-only input has no Kokoro key`() {
+        val grouped = listOf(
+            piper("p1", QualityLevel.Low),
+            piper("p2", QualityLevel.Medium),
+        ).groupByEngineThenTier()
+
+        assertTrue(grouped.containsKey(VoiceEngine.Piper))
+        assertFalse(
+            "Kokoro key must not appear when no Kokoro voices in input",
+            grouped.containsKey(VoiceEngine.Kokoro),
+        )
+    }
+
+    @Test
+    fun `Kokoro-only input has no Piper key`() {
+        val grouped = listOf(
+            kokoro("k1", QualityLevel.Studio),
+            kokoro("k2", QualityLevel.High, speakerId = 1),
+        ).groupByEngineThenTier()
+
+        assertTrue(grouped.containsKey(VoiceEngine.Kokoro))
+        assertFalse(
+            "Piper key must not appear when no Piper voices in input",
+            grouped.containsKey(VoiceEngine.Piper),
+        )
+    }
+
+    @Test
+    fun `empty tier within an engine is omitted`() {
+        // Piper input that only has Medium voices — Low and High keys
+        // must not appear under Piper. Hollow tier headers in the UI are
+        // exactly what #94 is trying to avoid.
+        val grouped = listOf(
+            piper("p-med-1", QualityLevel.Medium),
+            piper("p-med-2", QualityLevel.Medium),
+        ).groupByEngineThenTier()
+
+        val piperTiers = grouped[VoiceEngine.Piper]?.keys ?: emptySet()
+        assertEquals(setOf(QualityLevel.Medium), piperTiers)
+    }
+
+    @Test
+    fun `source order preserved within a tier`() {
+        // The catalog curates the inside-tier order; re-sorting here
+        // would lose that. Verify input order is mirrored on output.
+        val a = piper("p-med-a", QualityLevel.Medium)
+        val b = piper("p-med-b", QualityLevel.Medium)
+        val c = piper("p-med-c", QualityLevel.Medium)
+        val grouped = listOf(c, a, b).groupByEngineThenTier()
+
+        assertEquals(
+            listOf(c, a, b),
+            grouped[VoiceEngine.Piper]?.get(QualityLevel.Medium),
+        )
+    }
+
+    @Test
+    fun `full mixed scenario lays out cleanly`() {
+        // Realistic shape: a few Piper voices across all three tiers,
+        // a Studio Kokoro and a non-Studio Kokoro. Walks the full
+        // contract end-to-end: outer order, inner orders, omission of
+        // empty tiers, source-order preservation.
+        val pLow = piper("p-low", QualityLevel.Low)
+        val pMed1 = piper("p-med-1", QualityLevel.Medium)
+        val pMed2 = piper("p-med-2", QualityLevel.Medium)
+        val pHigh = piper("p-high", QualityLevel.High)
+        val kStudio = kokoro("k-studio", QualityLevel.Studio)
+        val kHigh = kokoro("k-high", QualityLevel.High, speakerId = 1)
+
+        // Shuffle the input so we know the helper isn't relying on
+        // an already-sorted list.
+        val grouped = listOf(kHigh, pHigh, pMed1, kStudio, pLow, pMed2)
+            .groupByEngineThenTier()
+
+        assertEquals(
+            listOf(VoiceEngine.Piper, VoiceEngine.Kokoro),
+            grouped.keys.toList(),
+        )
+
+        val piper = grouped.getValue(VoiceEngine.Piper)
+        assertEquals(
+            listOf(QualityLevel.Low, QualityLevel.Medium, QualityLevel.High),
+            piper.keys.toList(),
+        )
+        assertEquals(listOf(pLow), piper[QualityLevel.Low])
+        assertEquals(listOf(pMed1, pMed2), piper[QualityLevel.Medium])
+        assertEquals(listOf(pHigh), piper[QualityLevel.High])
+
+        val kokoro = grouped.getValue(VoiceEngine.Kokoro)
+        assertEquals(
+            listOf(QualityLevel.Studio, QualityLevel.High),
+            kokoro.keys.toList(),
+        )
+        assertEquals(listOf(kStudio), kokoro[QualityLevel.Studio])
+        assertEquals(listOf(kHigh), kokoro[QualityLevel.High])
+    }
+}


### PR DESCRIPTION
## Summary
- Re-group voice library: Piper section (ascending: low→med→high) + Kokoro section (studio first)
- Replaces #89's tier-descending mixed-engine grouping per #94 feedback
- Drive-by: stub `setPunctuationPause` on `FakeSettingsRepo` to unblock `:feature:test` (landed broken in #95)

## Why
JP wants users to pick engine first, then quality — not the other way round.

## Test plan
- [x] New: `VoiceGroupingTest` — 8 cases covering outer order, per-engine inner order, empty-engine/tier omission, source-order preservation
- [x] `:feature:testDebugUnitTest` green
- [x] `:core-playback:testDebugUnitTest` green (existing `VoiceTierTest` unaffected)
- [x] `:app:assembleDebug` green
- [ ] Manual on-device verification (handled by orchestrator)
- [ ] Existing favorites + heart toggle behavior preserved (visual; orchestrator)

Closes #94.

🤖 Generated with [Claude Code](https://claude.com/claude-code)