### PR TITLE
feat(settings): Performance & buffering section + Mode A/B toggles (#98)

### DIFF
--- a/app/src/main/kotlin/in/jphe/storyvox/data/SettingsRepositoryUiImpl.kt
+++ b/app/src/main/kotlin/in/jphe/storyvox/data/SettingsRepositoryUiImpl.kt
@@ -13,6 +13,7 @@ import dagger.hilt.android.qualifiers.ApplicationContext
 import `in`.jphe.storyvox.data.auth.SessionHydrator
 import `in`.jphe.storyvox.data.repository.AuthRepository
 import `in`.jphe.storyvox.data.repository.playback.PlaybackBufferConfig
+import `in`.jphe.storyvox.data.repository.playback.PlaybackModeConfig
 import `in`.jphe.storyvox.feature.api.BUFFER_DEFAULT_CHUNKS
 import `in`.jphe.storyvox.feature.api.BUFFER_MAX_CHUNKS
 import `in`.jphe.storyvox.feature.api.BUFFER_MIN_CHUNKS
@@ -49,6 +50,15 @@ private object Keys {
      *  devices, so the persisted value is intentionally NOT clamped at a
      *  conservative ceiling; only the absolute mechanical bounds apply. */
     val PLAYBACK_BUFFER_CHUNKS = intPreferencesKey("pref_playback_buffer_chunks_v1")
+    /** Issue #98 — Mode A. Default true preserves the v0.4.30 spinner-on-warmup
+     *  behavior; OFF skips the warmup-wait UI and accepts silence at chapter
+     *  start. _v1 suffix matches PLAYBACK_BUFFER_CHUNKS' versioning so we can
+     *  rev defaults later without colliding with persisted v1 values. */
+    val WARMUP_WAIT = booleanPreferencesKey("pref_warmup_wait_v1")
+    /** Issue #98 — Mode B. Default true preserves PR #77's pause-buffer-resume
+     *  behavior on mid-stream underrun; OFF lets the consumer drain through
+     *  underruns without raising the "Buffering…" UI. */
+    val CATCHUP_PAUSE = booleanPreferencesKey("pref_catchup_pause_v1")
 }
 
 @Singleton
@@ -56,7 +66,7 @@ class SettingsRepositoryUiImpl(
     private val store: DataStore<Preferences>,
     private val auth: AuthRepository,
     private val hydrator: SessionHydrator,
-) : SettingsRepositoryUi, PlaybackBufferConfig {
+) : SettingsRepositoryUi, PlaybackBufferConfig, PlaybackModeConfig {
 
     /** Hilt entry point — pulls the production DataStore from the app context.
      *  The primary constructor takes the store directly so tests can swap in
@@ -84,6 +94,8 @@ class SettingsRepositoryUiImpl(
                 ?: PunctuationPause.Normal,
             playbackBufferChunks = (prefs[Keys.PLAYBACK_BUFFER_CHUNKS] ?: BUFFER_DEFAULT_CHUNKS)
                 .coerceIn(BUFFER_MIN_CHUNKS, BUFFER_MAX_CHUNKS),
+            warmupWait = prefs[Keys.WARMUP_WAIT] ?: true,
+            catchupPause = prefs[Keys.CATCHUP_PAUSE] ?: true,
             sigil = Sigil.current.let {
                 UiSigil(
                     name = it.name,
@@ -136,6 +148,14 @@ class SettingsRepositoryUiImpl(
         }
     }
 
+    override suspend fun setWarmupWait(enabled: Boolean) {
+        store.edit { it[Keys.WARMUP_WAIT] = enabled }
+    }
+
+    override suspend fun setCatchupPause(enabled: Boolean) {
+        store.edit { it[Keys.CATCHUP_PAUSE] = enabled }
+    }
+
     // --- PlaybackBufferConfig (consumed by core-playback's EnginePlayer) ---
 
     override val playbackBufferChunks: Flow<Int> = store.data.map { prefs ->
@@ -144,6 +164,13 @@ class SettingsRepositoryUiImpl(
     }
 
     override suspend fun currentBufferChunks(): Int = playbackBufferChunks.first()
+
+    // --- PlaybackModeConfig (issue #98) ---
+
+    override val warmupWait: Flow<Boolean> = store.data.map { it[Keys.WARMUP_WAIT] ?: true }
+    override val catchupPause: Flow<Boolean> = store.data.map { it[Keys.CATCHUP_PAUSE] ?: true }
+    override suspend fun currentWarmupWait(): Boolean = warmupWait.first()
+    override suspend fun currentCatchupPause(): Boolean = catchupPause.first()
 
     override suspend fun signIn() {
         // Just flips the persisted UI flag; the cookie capture is owned by

--- a/app/src/main/kotlin/in/jphe/storyvox/di/AppBindings.kt
+++ b/app/src/main/kotlin/in/jphe/storyvox/di/AppBindings.kt
@@ -14,6 +14,7 @@ import `in`.jphe.storyvox.data.VoiceProviderUiImpl
 import `in`.jphe.storyvox.data.repository.ChapterRepository
 import `in`.jphe.storyvox.data.repository.FictionRepository
 import `in`.jphe.storyvox.data.repository.playback.PlaybackBufferConfig
+import `in`.jphe.storyvox.data.repository.playback.PlaybackModeConfig
 import `in`.jphe.storyvox.data.source.WebViewFetcher
 import `in`.jphe.storyvox.data.source.model.ContentWarning
 import `in`.jphe.storyvox.data.source.model.FictionResult
@@ -112,6 +113,14 @@ object AppBindings {
      */
     @Provides @Singleton
     fun providePlaybackBufferConfig(impl: SettingsRepositoryUiImpl): PlaybackBufferConfig = impl
+
+    /**
+     * Issue #98 — Mode A / Mode B contract for `core-playback`'s EnginePlayer.
+     * Same singleton instance as [provideSettingsRepositoryUi]; one DataStore,
+     * three contracts.
+     */
+    @Provides @Singleton
+    fun providePlaybackModeConfig(impl: SettingsRepositoryUiImpl): PlaybackModeConfig = impl
 
     /**
      * Stub WebViewFetcher — Selene's `:core-data` declares the interface; the
@@ -367,6 +376,15 @@ private class RealPlaybackControllerUi(
 
     private val scope = CoroutineScope(SupervisorJob() + Dispatchers.Main.immediate)
 
+    /**
+     * Issue #98 — Mode A live cache. Read by [toUi] when computing
+     * `isWarmingUp` + the wall-time freeze gate. Volatile because writers
+     * are coroutine collectors and readers are state-flow combine emissions
+     * on potentially different threads.
+     */
+    @Volatile
+    private var cachedWarmupWait: Boolean = true
+
     init {
         // Issue #90: keep the live engine's punctuation-pause multiplier in
         // sync with the persisted user preference. We do the observation here
@@ -384,6 +402,15 @@ private class RealPlaybackControllerUi(
                 .map { it.punctuationPause.multiplier }
                 .distinctUntilChanged()
                 .collect { controller.setPunctuationPauseMultiplier(it) }
+        }
+        // Issue #98 Mode A — mirror warmupWait into the volatile cache so the
+        // synchronous toUi mapper can read it without suspending. Same shape
+        // as EnginePlayer's cachedBufferChunks.
+        scope.launch {
+            settings.settings
+                .map { it.warmupWait }
+                .distinctUntilChanged()
+                .collect { cachedWarmupWait = it }
         }
     }
 
@@ -552,7 +579,14 @@ private class RealPlaybackControllerUi(
         // user hit play but no sentence audio has started yet. Otherwise the
         // scrubber slides forward during a 5-15s engine load even though no
         // audio has actually played.
-        val warmingUp = isPlaying && sentence == null
+        //
+        // Issue #98 Mode A — when Warm-up Wait is OFF, treat the warmup
+        // window as if playback had already started: the scrubber ticks from
+        // t=0 even though no audio plays, and `isWarmingUp` reports false
+        // so the UI doesn't show the spinner. The user trades the spinner
+        // for visible "playing" feedback + silence.
+        val rawWarmingUp = isPlaying && sentence == null
+        val warmingUp = rawWarmingUp && cachedWarmupWait
         val elapsedMs = if (isPlaying && !warmingUp) (nowMs - anchorElapsedMs).coerceAtLeast(0L) else 0L
         val positionMs = (baseMs + elapsedMs).coerceAtMost(durationEstimateMs.coerceAtLeast(baseMs))
         return UiPlaybackState(
@@ -563,6 +597,7 @@ private class RealPlaybackControllerUi(
             coverUrl = coverUri,
             isPlaying = isPlaying,
             isBuffering = isBuffering,
+            isWarmingUp = warmingUp,
             positionMs = positionMs,
             durationMs = durationEstimateMs,
             sentenceStart = sentence?.startCharInChapter ?: 0,

--- a/app/src/test/kotlin/in/jphe/storyvox/data/SettingsRepositoryModesTest.kt
+++ b/app/src/test/kotlin/in/jphe/storyvox/data/SettingsRepositoryModesTest.kt
@@ -1,0 +1,160 @@
+package `in`.jphe.storyvox.data
+
+import androidx.datastore.core.DataStore
+import androidx.datastore.preferences.core.PreferenceDataStoreFactory
+import androidx.datastore.preferences.core.Preferences
+import `in`.jphe.storyvox.data.auth.SessionHydrator
+import `in`.jphe.storyvox.data.auth.SessionState
+import `in`.jphe.storyvox.data.repository.AuthRepository
+import java.io.File
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlinx.coroutines.test.runTest
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import org.junit.rules.TemporaryFolder
+
+/**
+ * Real-DataStore tests for the issue #98 Mode A / Mode B toggles.
+ *
+ * Same shape as [SettingsRepositoryBufferTest]: spins up a temp-file
+ * DataStore so persistence is identical to production. Verifies the
+ * defaults preserve v0.4.30 behavior (warmup wait + catch-up pause both
+ * on by default), and that both setters round-trip through the
+ * `UiSettings` flow + the `PlaybackModeConfig` snapshot/flow.
+ */
+@OptIn(ExperimentalCoroutinesApi::class)
+class SettingsRepositoryModesTest {
+
+    @get:Rule
+    val tempFolder = TemporaryFolder()
+
+    private lateinit var scope: CoroutineScope
+    private lateinit var store: DataStore<Preferences>
+    private lateinit var repo: SettingsRepositoryUiImpl
+
+    @Before
+    fun setUp() {
+        scope = CoroutineScope(SupervisorJob() + UnconfinedTestDispatcher())
+        val file = File(tempFolder.newFolder(), "storyvox_settings.preferences_pb")
+        store = PreferenceDataStoreFactory.create(
+            scope = scope,
+            produceFile = { file },
+        )
+        repo = SettingsRepositoryUiImpl(store, FakeAuth(), FakeHydrator())
+    }
+
+    @After
+    fun tearDown() {
+        scope.cancel()
+    }
+
+    // ---- Mode A — Warm-up Wait ----
+
+    @Test
+    fun `default warmup wait is on`() = runTest {
+        // The default-on bias preserves v0.4.30's "show spinner while
+        // engine warms up" behavior on first launch + on existing installs
+        // that have no value persisted.
+        assertEquals(true, repo.currentWarmupWait())
+        assertEquals(true, repo.settings.first().warmupWait)
+        assertEquals(true, repo.warmupWait.first())
+    }
+
+    @Test
+    fun `setWarmupWait persists and re-emits on settings flow`() = runTest {
+        repo.setWarmupWait(false)
+        assertEquals(false, repo.currentWarmupWait())
+        assertEquals(false, repo.settings.first().warmupWait)
+        assertEquals(false, repo.warmupWait.first())
+    }
+
+    @Test
+    fun `setWarmupWait round-trips both directions`() = runTest {
+        repo.setWarmupWait(false)
+        assertEquals(false, repo.currentWarmupWait())
+        repo.setWarmupWait(true)
+        assertEquals(true, repo.currentWarmupWait())
+    }
+
+    // ---- Mode B — Catch-up Pause ----
+
+    @Test
+    fun `default catchup pause is on`() = runTest {
+        // Default-on preserves PR #77's pause-buffer-resume contract.
+        assertEquals(true, repo.currentCatchupPause())
+        assertEquals(true, repo.settings.first().catchupPause)
+        assertEquals(true, repo.catchupPause.first())
+    }
+
+    @Test
+    fun `setCatchupPause persists and re-emits on settings flow`() = runTest {
+        repo.setCatchupPause(false)
+        assertEquals(false, repo.currentCatchupPause())
+        assertEquals(false, repo.settings.first().catchupPause)
+        assertEquals(false, repo.catchupPause.first())
+    }
+
+    @Test
+    fun `setCatchupPause round-trips both directions`() = runTest {
+        repo.setCatchupPause(false)
+        assertEquals(false, repo.currentCatchupPause())
+        repo.setCatchupPause(true)
+        assertEquals(true, repo.currentCatchupPause())
+    }
+
+    @Test
+    fun `Mode A and Mode B persist independently`() = runTest {
+        // Flipping Mode B must not affect Mode A and vice-versa. Catches
+        // a regression where both keys end up sharing a Preferences key
+        // (e.g. typo in Keys).
+        repo.setWarmupWait(false)
+        assertEquals(false, repo.currentWarmupWait())
+        assertEquals(true, repo.currentCatchupPause())
+
+        repo.setCatchupPause(false)
+        assertEquals(false, repo.currentWarmupWait())
+        assertEquals(false, repo.currentCatchupPause())
+
+        repo.setWarmupWait(true)
+        assertEquals(true, repo.currentWarmupWait())
+        assertEquals(false, repo.currentCatchupPause())
+
+        // Sanity: settings flow surfaces the same final state.
+        val finalSettings = repo.settings.first()
+        assertTrue(
+            "expected warmupWait=true catchupPause=false, got $finalSettings",
+            finalSettings.warmupWait && !finalSettings.catchupPause,
+        )
+    }
+
+    private class FakeAuth : AuthRepository {
+        private val state = MutableStateFlow<SessionState>(SessionState.Anonymous)
+        override val sessionState: StateFlow<SessionState> = state.asStateFlow()
+        override suspend fun captureSession(
+            cookieHeader: String,
+            userDisplayName: String?,
+            userId: String?,
+            expiresAt: Long?,
+        ) = Unit
+        override suspend fun clearSession() = Unit
+        override suspend fun cookieHeader(): String? = null
+        override suspend fun verifyOrExpire(): SessionState = SessionState.Anonymous
+    }
+
+    private class FakeHydrator : SessionHydrator {
+        override fun hydrate(cookies: Map<String, String>) = Unit
+        override fun clear() = Unit
+    }
+}

--- a/core-data/src/main/kotlin/in/jphe/storyvox/data/repository/playback/PlaybackModeConfig.kt
+++ b/core-data/src/main/kotlin/in/jphe/storyvox/data/repository/playback/PlaybackModeConfig.kt
@@ -1,0 +1,51 @@
+package `in`.jphe.storyvox.data.repository.playback
+
+import kotlinx.coroutines.flow.Flow
+
+/**
+ * Issue #98 — Performance & buffering mode toggles for the streaming pipeline.
+ *
+ * Sibling of [PlaybackBufferConfig]: surfaced as its own contract so
+ * `core-playback` can stay free of feature-layer types. The implementation
+ * lives in `:app`'s `SettingsRepositoryUiImpl`, which already implements
+ * [PlaybackBufferConfig]; one DataStore, three contracts.
+ *
+ * **Mode A — Warm-up Wait** ([warmupWait]). When true (default), UI shows a
+ * spinner + freezes scrubber while the voice engine loads + the first
+ * sentence is generated. When false, the UI behaves as if playback started
+ * immediately; listener accepts silence at chapter start in exchange for
+ * visible "playing" feedback. EnginePlayer doesn't behave differently for
+ * Mode A — it's a UI-side gate consumed at the `PlaybackState → UiPlaybackState`
+ * boundary.
+ *
+ * **Mode B — Catch-up Pause** ([catchupPause]). When true (default), the
+ * consumer thread pauses AudioTrack on mid-stream underrun (PR #77's
+ * pause-buffer-resume) and re-raises after the queue refills past the resume
+ * threshold. When false, the consumer drains through the underrun without
+ * pausing — listener may hear dead air mid-chapter but never sees the
+ * "Buffering…" spinner. EngineStreamingSource is untouched; only the two
+ * pause/resume branches in `EnginePlayer.startPlaybackPipeline()`'s consumer
+ * loop are gated.
+ *
+ * Both flows can re-emit at any time. For Mode A the value is read at UI
+ * binding time (every `toUi(nowMs)` mapping). For Mode B the value is read
+ * by the consumer thread on every iteration via a volatile mirror in
+ * EnginePlayer; flips take effect on the next consumer loop iteration with
+ * no pipeline rebuild.
+ */
+interface PlaybackModeConfig {
+
+    /** Live flow of Mode A — Warm-up Wait. Default true. */
+    val warmupWait: Flow<Boolean>
+
+    /** Live flow of Mode B — Catch-up Pause. Default true. */
+    val catchupPause: Flow<Boolean>
+
+    /**
+     * Snapshot reads for callers that need a single value without subscribing.
+     * Implementations should return the most recent value, falling back to the
+     * documented default (true / true) if the underlying store hasn't emitted yet.
+     */
+    suspend fun currentWarmupWait(): Boolean
+    suspend fun currentCatchupPause(): Boolean
+}

--- a/core-playback/src/main/kotlin/in/jphe/storyvox/playback/tts/EnginePlayer.kt
+++ b/core-playback/src/main/kotlin/in/jphe/storyvox/playback/tts/EnginePlayer.kt
@@ -26,6 +26,7 @@ import `in`.jphe.storyvox.data.repository.ChapterRepository
 import `in`.jphe.storyvox.data.repository.PlaybackPositionRepository
 import `in`.jphe.storyvox.data.repository.playback.PlaybackBufferConfig
 import `in`.jphe.storyvox.data.repository.playback.PlaybackChapter
+import `in`.jphe.storyvox.data.repository.playback.PlaybackModeConfig
 import `in`.jphe.storyvox.playback.PlaybackError
 import `in`.jphe.storyvox.playback.PlaybackState
 import `in`.jphe.storyvox.playback.PlaybackUiEvent
@@ -95,6 +96,7 @@ class EnginePlayer @AssistedInject constructor(
     private val voiceManager: VoiceManager,
     private val volumeRamp: TtsVolumeRamp,
     private val bufferConfig: PlaybackBufferConfig,
+    private val modeConfig: PlaybackModeConfig,
 ) : SimpleBasePlayer(Looper.getMainLooper()) {
 
     @AssistedFactory
@@ -146,15 +148,37 @@ class EnginePlayer @AssistedInject constructor(
     @Volatile
     private var cachedBufferChunks: Int = 8 // BUFFER_DEFAULT_CHUNKS — duplicated to avoid feature dep
 
+    /**
+     * Issue #98 — Mode B (Catch-up Pause) live cache. Gates the consumer
+     * thread's pause-buffer-resume branches in [startPlaybackPipeline].
+     * Volatile because the writer is the collector coroutine and the reader
+     * is the URGENT_AUDIO consumer thread; flips take effect on the next
+     * iteration of the consumer loop with no pipeline rebuild.
+     *
+     * Default true preserves PR #77's pause-buffer-resume contract; reading
+     * `true` until the first DataStore emission is the safe bias.
+     */
+    @Volatile
+    private var cachedCatchupPause: Boolean = true
+
     init {
         observeActiveVoice()
         observeBufferConfig()
+        observeModeConfig()
     }
 
     private fun observeBufferConfig() {
         scope.launch {
             bufferConfig.playbackBufferChunks.collect { v ->
                 cachedBufferChunks = v
+            }
+        }
+    }
+
+    private fun observeModeConfig() {
+        scope.launch {
+            modeConfig.catchupPause.collect { v ->
+                cachedCatchupPause = v
             }
         }
     }
@@ -503,7 +527,16 @@ class EnginePlayer @AssistedInject constructor(
                     // recovered above the resume threshold. If so, kick
                     // AudioTrack alive again so the next write lands in a
                     // playing track rather than a paused-then-played one.
-                    if (paused && source.bufferHeadroomMs.value >= BUFFER_RESUME_THRESHOLD_MS) {
+                    //
+                    // Issue #98 — Mode B gate. With Catch-up Pause off, this
+                    // branch never fires (paused is never true; see the
+                    // matching gate on the underrun pause branch below). The
+                    // `paused &&` short-circuit is the same fast-path either
+                    // way; the cached read is just for symmetry with the
+                    // pause branch.
+                    if (cachedCatchupPause &&
+                        paused &&
+                        source.bufferHeadroomMs.value >= BUFFER_RESUME_THRESHOLD_MS) {
                         runCatching { track.play() }
                         paused = false
                         scope.launch {
@@ -563,7 +596,14 @@ class EnginePlayer @AssistedInject constructor(
                     // write would land seconds before the listener hears
                     // silence, so the buffering UI needs to lead the audio
                     // by that margin.
-                    if (!paused && source.bufferHeadroomMs.value < BUFFER_UNDERRUN_THRESHOLD_MS) {
+                    //
+                    // Issue #98 — Mode B gate. With Catch-up Pause off, the
+                    // consumer drains through underruns without pausing:
+                    // listener may hear dead air, but never sees the
+                    // "Buffering…" UI. EngineStreamingSource is untouched.
+                    if (cachedCatchupPause &&
+                        !paused &&
+                        source.bufferHeadroomMs.value < BUFFER_UNDERRUN_THRESHOLD_MS) {
                         runCatching { track.pause() }
                         paused = true
                         scope.launch {

--- a/feature/src/main/kotlin/in/jphe/storyvox/feature/api/UiContracts.kt
+++ b/feature/src/main/kotlin/in/jphe/storyvox/feature/api/UiContracts.kt
@@ -208,8 +208,24 @@ data class UiPlaybackState(
     /** True when the streaming TTS pipeline has paused AudioTrack waiting
      *  for the producer to refill the queue past the underrun threshold.
      *  UI surfaces a "Buffering..." spinner; differs from `!isPlaying`
-     *  (user pause) and from initial voice warm-up (sentenceEnd == 0). */
+     *  (user pause) and from initial voice warm-up (see [isWarmingUp]).
+     *
+     *  Issue #98 — when the user disables Mode B (Catch-up Pause), the
+     *  EnginePlayer consumer thread no longer pauses on underrun, so this
+     *  flag stays false through underrun events and the consumer drains
+     *  through the silence instead. UI surfaces no buffering spinner in
+     *  that mode by construction. */
     val isBuffering: Boolean = false,
+    /** True when the user has hit play but the voice engine hasn't
+     *  produced the first sentence's audio yet. Distinct from
+     *  [isBuffering] (mid-stream underrun). UI surfaces the "warming up"
+     *  spinner + freezes wall-time scrubber interpolation.
+     *
+     *  Issue #98 — Mode A (Warm-up Wait) gates this. With Mode A on
+     *  (default), this is `isPlaying && sentenceEnd == 0`. With Mode A
+     *  off, this is always false: the UI behaves as if playback started
+     *  immediately and the listener accepts silence at chapter start. */
+    val isWarmingUp: Boolean = false,
     val positionMs: Long,
     val durationMs: Long,
     /** Char index into the chapter text where the current sentence begins. */
@@ -300,6 +316,25 @@ data class UiSettings(
      * as exploratory; we want telemetry from users running there.
      */
     val playbackBufferChunks: Int = BUFFER_DEFAULT_CHUNKS,
+    /**
+     * Issue #98 — Mode A. When true (default), the UI shows a "warming up"
+     * spinner + freezes wall-time scrubber interpolation while the voice
+     * engine is loading + producing the first sentence's audio. When false,
+     * the UI behaves as if playback started immediately; the listener hears
+     * silence until the engine catches up but the scrubber and play button
+     * look "playing" the whole time. Useful for users who'd rather see motion
+     * than a spinner on slower devices.
+     */
+    val warmupWait: Boolean = true,
+    /**
+     * Issue #98 — Mode B. When true (default), the streaming pipeline pauses
+     * AudioTrack on mid-stream underrun (PR #77's pause-buffer-resume) and
+     * surfaces a "Buffering..." spinner while the producer catches up. When
+     * false, the consumer thread drains through underruns; the listener
+     * hears moments of dead air instead of paused-then-resumed playback,
+     * but never sees the buffering spinner.
+     */
+    val catchupPause: Boolean = true,
 )
 
 /** Default queue depth — current hardcoded `EngineStreamingSource(queueCapacity = 8)`. */
@@ -402,6 +437,10 @@ interface SettingsRepositoryUi {
     suspend fun setPollIntervalHours(hours: Int)
     suspend fun setPunctuationPause(mode: PunctuationPause)
     suspend fun setPlaybackBufferChunks(chunks: Int)
+    /** Issue #98 — Mode A toggle. See [UiSettings.warmupWait]. */
+    suspend fun setWarmupWait(enabled: Boolean)
+    /** Issue #98 — Mode B toggle. See [UiSettings.catchupPause]. */
+    suspend fun setCatchupPause(enabled: Boolean)
     suspend fun signIn()
     suspend fun signOut()
 }

--- a/feature/src/main/kotlin/in/jphe/storyvox/feature/reader/AudiobookView.kt
+++ b/feature/src/main/kotlin/in/jphe/storyvox/feature/reader/AudiobookView.kt
@@ -125,12 +125,22 @@ fun AudiobookView(
             // engine hasn't produced the first sentence yet (no sentence
             // range emitted). Sherpa-onnx model load + first synth can take
             // 5-15s on modest hardware.
-            val warmingUp = state.isPlaying && state.sentenceEnd == 0
+            //
+            // Issue #98 Mode A — `isWarmingUp` is gated server-side: when
+            // the user has Warm-up Wait off, this is always false even
+            // during the genuine warmup window, so the UI doesn't show the
+            // spinner. The listener trades visible feedback for silence at
+            // chapter start.
+            val warmingUp = state.isWarmingUp
             // "Buffering" = streaming pipeline ran out of generated PCM
             // mid-chapter (producer can't keep up — e.g. Piper-high on
             // Tab A7 Lite). Same brass spinner so the visual stays
             // consistent; status label distinguishes the two states so
             // the user knows what's happening.
+            //
+            // Issue #98 Mode B — `isBuffering` stays false through underrun
+            // when Catch-up Pause is off, so the consumer drains through
+            // the silence without surfacing a spinner.
             val showSpinner = warmingUp || state.isBuffering
             if (coverLoading) {
                 MagicSkeletonTile(
@@ -206,7 +216,7 @@ fun AudiobookView(
                 // "Buffering" = mid-chapter underrun on slow voice + slow
                 // device; same spinner so the play button stays visually
                 // consistent.
-                val warmingUp = state.isPlaying && state.sentenceEnd == 0
+                val warmingUp = state.isWarmingUp
                 val showSpinner = warmingUp || state.isBuffering
                 Box(contentAlignment = Alignment.Center) {
                     androidx.compose.animation.AnimatedVisibility(

--- a/feature/src/main/kotlin/in/jphe/storyvox/feature/settings/SettingsScreen.kt
+++ b/feature/src/main/kotlin/in/jphe/storyvox/feature/settings/SettingsScreen.kt
@@ -21,6 +21,7 @@ import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.font.FontStyle
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import `in`.jphe.storyvox.feature.api.BUFFER_DANGER_MULTIPLIER
@@ -74,9 +75,74 @@ fun SettingsScreen(
         )
         Text("Pitch ${"%.2f".format(s.defaultPitch)}×", style = MaterialTheme.typography.bodySmall)
 
-        // Issue #90: three-stop selector for the inter-sentence silence
-        // splice. Same brass-button-row aesthetic as the Theme picker so
-        // it feels like a sibling control.
+        Divider()
+        // Issue #98 — "Performance & buffering" home for every setting that
+        // trades upfront wait + memory for smoother playback on slow devices.
+        // Order intentionally goes from the cheapest knobs (boolean modes) to
+        // the most exploratory (the buffer slider, which goes well past the
+        // recommended max for the LMK probe in #84). Punctuation cadence sits
+        // at the bottom because it's a cadence preference more than a perf
+        // trade-off, but it also lives in the perf trade space (Off skips
+        // synthesis time per sentence boundary).
+        SectionHeader("Performance & buffering")
+        Text(
+            "Settings that trade upfront wait + memory for smoother playback. Useful on slower devices.",
+            style = MaterialTheme.typography.bodySmall,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+            fontStyle = FontStyle.Italic,
+        )
+
+        // Mode A — Warm-up Wait. Toggle, default ON. When ON the UI shows a
+        // brass spinner + freezes the scrubber while the voice engine is
+        // loading + producing the first sentence. When OFF the UI behaves as
+        // if playback started immediately; listener accepts silence at chapter
+        // start. Wired through PlaybackModeConfig + AppBindings.toUi.
+        Row(verticalAlignment = Alignment.CenterVertically, modifier = Modifier.fillMaxWidth()) {
+            Column(modifier = Modifier.weight(1f)) {
+                Text("Warm-up Wait", style = MaterialTheme.typography.bodyMedium)
+                Text(
+                    if (s.warmupWait) {
+                        "Wait for the voice to warm up before playback starts."
+                    } else {
+                        "Start playback immediately; accept silence at chapter start."
+                    },
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                )
+            }
+            Switch(checked = s.warmupWait, onCheckedChange = viewModel::setWarmupWait)
+        }
+
+        // Mode B — Catch-up Pause. Toggle, default ON. When ON, mid-stream
+        // underrun pauses AudioTrack and surfaces "Buffering…" until the
+        // queue refills (PR #77's pause-buffer-resume). When OFF the consumer
+        // drains through the underrun: listener may hear dead air, but never
+        // sees the buffering spinner. EngineStreamingSource is untouched.
+        Row(verticalAlignment = Alignment.CenterVertically, modifier = Modifier.fillMaxWidth()) {
+            Column(modifier = Modifier.weight(1f)) {
+                Text("Catch-up Pause", style = MaterialTheme.typography.bodyMedium)
+                Text(
+                    if (s.catchupPause) {
+                        "Pause briefly when the voice falls behind, then resume cleanly."
+                    } else {
+                        "Drain through underruns; no buffering spinner."
+                    },
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                )
+            }
+            Switch(checked = s.catchupPause, onCheckedChange = viewModel::setCatchupPause)
+        }
+
+        // Buffer Headroom — migrated from the standalone "Audio buffer"
+        // section. Same control, same #84 LMK-probe semantics.
+        BufferSlider(
+            chunks = s.playbackBufferChunks,
+            onChunksChange = viewModel::setPlaybackBufferChunks,
+        )
+
+        // Punctuation Cadence — migrated from the Reading section. Same
+        // three-stop control + brass-button-row aesthetic from #93.
         Text("Pause after . , ? ! ; :", style = MaterialTheme.typography.bodyMedium)
         Text(
             "How long to pause between sentences. Off makes the reader sprint; Long gives narration room to breathe.",
@@ -89,13 +155,6 @@ fun SettingsScreen(
                 BrassButton(label = mode.name, onClick = { viewModel.setPunctuationPause(mode) }, variant = variant)
             }
         }
-
-        Divider()
-        SectionHeader("Audio buffer")
-        BufferSlider(
-            chunks = s.playbackBufferChunks,
-            onChunksChange = viewModel::setPlaybackBufferChunks,
-        )
 
         Divider()
         SectionHeader("Theme")

--- a/feature/src/main/kotlin/in/jphe/storyvox/feature/settings/SettingsViewModel.kt
+++ b/feature/src/main/kotlin/in/jphe/storyvox/feature/settings/SettingsViewModel.kt
@@ -46,6 +46,10 @@ class SettingsViewModel @Inject constructor(
     fun setPunctuationPause(mode: PunctuationPause) =
         viewModelScope.launch { repo.setPunctuationPause(mode) }
     fun setPlaybackBufferChunks(n: Int) = viewModelScope.launch { repo.setPlaybackBufferChunks(n) }
+    /** Issue #98 — Mode A toggle. */
+    fun setWarmupWait(enabled: Boolean) = viewModelScope.launch { repo.setWarmupWait(enabled) }
+    /** Issue #98 — Mode B toggle. */
+    fun setCatchupPause(enabled: Boolean) = viewModelScope.launch { repo.setCatchupPause(enabled) }
     fun signIn() = viewModelScope.launch { repo.signIn() }
     fun signOut() = viewModelScope.launch { repo.signOut() }
     fun previewVoice(voice: UiVoice) = voices.previewVoice(voice)

--- a/feature/src/test/kotlin/in/jphe/storyvox/feature/settings/SettingsViewModelModesTest.kt
+++ b/feature/src/test/kotlin/in/jphe/storyvox/feature/settings/SettingsViewModelModesTest.kt
@@ -1,7 +1,6 @@
 package `in`.jphe.storyvox.feature.settings
 
 import `in`.jphe.storyvox.feature.api.BUFFER_DEFAULT_CHUNKS
-import `in`.jphe.storyvox.feature.api.BUFFER_RECOMMENDED_MAX_CHUNKS
 import `in`.jphe.storyvox.feature.api.PunctuationPause
 import `in`.jphe.storyvox.feature.api.SettingsRepositoryUi
 import `in`.jphe.storyvox.feature.api.ThemeOverride
@@ -25,12 +24,15 @@ import org.junit.Before
 import org.junit.Test
 
 /**
- * Verifies that [SettingsViewModel.setPlaybackBufferChunks] forwards the
- * value to the repository contract and that the ViewModel's exposed
- * [SettingsUiState.settings] reflects what the repository emits.
+ * Verifies the issue #98 Mode A / Mode B launchers on
+ * [SettingsViewModel] forward the value to the repository contract and
+ * that [SettingsUiState.settings] surfaces the repository's emissions.
+ *
+ * Mirrors [SettingsViewModelBufferTest]'s shape so the pair stays
+ * easy to compare side-by-side.
  */
 @OptIn(ExperimentalCoroutinesApi::class)
-class SettingsViewModelBufferTest {
+class SettingsViewModelModesTest {
 
     @Before
     fun setUp() {
@@ -43,40 +45,49 @@ class SettingsViewModelBufferTest {
     }
 
     @Test
-    fun `setPlaybackBufferChunks forwards to the repository`() = runTest {
-        val repo = FakeSettingsRepo(initial = baseSettings(buffer = BUFFER_DEFAULT_CHUNKS))
+    fun `setWarmupWait forwards to the repository`() = runTest {
+        val repo = FakeSettingsRepo(initial = baseSettings(warmupWait = true, catchupPause = true))
         val vm = SettingsViewModel(repo, FakeVoiceProvider())
 
-        vm.setPlaybackBufferChunks(192)
+        vm.setWarmupWait(false)
 
-        assertEquals(listOf(192), repo.bufferWrites)
+        assertEquals(listOf(false), repo.warmupWaitWrites)
     }
 
     @Test
-    fun `viewmodel uiState surfaces repository's buffer value`() = runTest {
-        val repo = FakeSettingsRepo(initial = baseSettings(buffer = 256))
+    fun `setCatchupPause forwards to the repository`() = runTest {
+        val repo = FakeSettingsRepo(initial = baseSettings(warmupWait = true, catchupPause = true))
         val vm = SettingsViewModel(repo, FakeVoiceProvider())
 
-        // The shared flow's WhileSubscribed needs an active subscriber; first()
-        // covers that for the duration of the read.
+        vm.setCatchupPause(false)
+
+        assertEquals(listOf(false), repo.catchupPauseWrites)
+    }
+
+    @Test
+    fun `viewmodel uiState surfaces both mode values`() = runTest {
+        val repo = FakeSettingsRepo(initial = baseSettings(warmupWait = false, catchupPause = false))
+        val vm = SettingsViewModel(repo, FakeVoiceProvider())
+
         val emitted = vm.uiState.first { it.settings != null }
-        assertEquals(256, emitted.settings?.playbackBufferChunks)
+        assertEquals(false, emitted.settings?.warmupWait)
+        assertEquals(false, emitted.settings?.catchupPause)
     }
 
     @Test
-    fun `viewmodel allows past-the-tick values`() = runTest {
-        // Issue #84 — the ViewModel must not clamp at the recommended max;
-        // that's the whole point of the experimental probe. Repo is the only
-        // layer that applies the absolute mechanical bounds.
-        val repo = FakeSettingsRepo(initial = baseSettings(buffer = BUFFER_DEFAULT_CHUNKS))
+    fun `Mode A and Mode B writes are independent`() = runTest {
+        val repo = FakeSettingsRepo(initial = baseSettings(warmupWait = true, catchupPause = true))
         val vm = SettingsViewModel(repo, FakeVoiceProvider())
 
-        vm.setPlaybackBufferChunks(BUFFER_RECOMMENDED_MAX_CHUNKS * 8)
+        vm.setWarmupWait(false)
+        vm.setCatchupPause(false)
+        vm.setWarmupWait(true)
 
-        assertEquals(listOf(BUFFER_RECOMMENDED_MAX_CHUNKS * 8), repo.bufferWrites)
+        assertEquals(listOf(false, true), repo.warmupWaitWrites)
+        assertEquals(listOf(false), repo.catchupPauseWrites)
     }
 
-    private fun baseSettings(buffer: Int): UiSettings = UiSettings(
+    private fun baseSettings(warmupWait: Boolean, catchupPause: Boolean): UiSettings = UiSettings(
         ttsEngine = "VoxSherpa",
         defaultVoiceId = null,
         defaultSpeed = 1.0f,
@@ -86,13 +97,16 @@ class SettingsViewModelBufferTest {
         pollIntervalHours = 6,
         isSignedIn = false,
         sigil = UiSigil.UNKNOWN,
-        playbackBufferChunks = buffer,
+        playbackBufferChunks = BUFFER_DEFAULT_CHUNKS,
+        warmupWait = warmupWait,
+        catchupPause = catchupPause,
     )
 
     private class FakeSettingsRepo(initial: UiSettings) : SettingsRepositoryUi {
         private val state = MutableStateFlow(initial)
         override val settings: Flow<UiSettings> = state
-        val bufferWrites: MutableList<Int> = mutableListOf()
+        val warmupWaitWrites: MutableList<Boolean> = mutableListOf()
+        val catchupPauseWrites: MutableList<Boolean> = mutableListOf()
         override suspend fun setTheme(override: ThemeOverride) {
             state.value = state.value.copy(themeOverride = override)
         }
@@ -115,13 +129,14 @@ class SettingsViewModelBufferTest {
             state.value = state.value.copy(punctuationPause = mode)
         }
         override suspend fun setPlaybackBufferChunks(chunks: Int) {
-            bufferWrites += chunks
             state.value = state.value.copy(playbackBufferChunks = chunks)
         }
         override suspend fun setWarmupWait(enabled: Boolean) {
+            warmupWaitWrites += enabled
             state.value = state.value.copy(warmupWait = enabled)
         }
         override suspend fun setCatchupPause(enabled: Boolean) {
+            catchupPauseWrites += enabled
             state.value = state.value.copy(catchupPause = enabled)
         }
         override suspend fun signIn() = Unit


### PR DESCRIPTION
## Summary
- New "Performance & buffering" Settings section grouping the perf/buffering knobs.
- Mode A — Warm-up Wait (toggle, default ON). Gates the warming-up spinner + scrubber freeze. OFF accepts silence at chapter start.
- Mode B — Catch-up Pause (toggle, default ON). Gates PR #77's pause-buffer-resume on mid-stream underrun. OFF drains through underruns with no spinner.
- Migrates Buffer Headroom (#95) and Punctuation Cadence (#93) into the new section.
- Mode C (Full Pre-render) deferred — needs Aurora's PCM cache.

Closes #98.

## Wiring
- New `PlaybackModeConfig` contract in `core-data`, sibling of `PlaybackBufferConfig`. Bound to `SettingsRepositoryUiImpl` in `AppBindings` (one DataStore, three contracts).
- `EnginePlayer` injects `PlaybackModeConfig` and mirrors `catchupPause` into a volatile cache; the URGENT_AUDIO consumer reads it on every iteration to gate the two pause-buffer-resume branches. `EngineStreamingSource` untouched. PR #77's tuned thresholds preserved.
- `AppBindings.toUi` mirrors `warmupWait` into a volatile cache and emits `isWarmingUp` on `UiPlaybackState`. `AudiobookView` consumes that field instead of recomputing locally.
- DataStore keys versioned (`pref_warmup_wait_v1`, `pref_catchup_pause_v1`).

## Test plan
- [x] `./gradlew :app:assembleDebug`
- [x] `./gradlew :app:testDebugUnitTest :feature:testDebugUnitTest :core-playback:testDebugUnitTest`
- [x] `SettingsRepositoryModesTest` — defaults, round-trip, independence (real DataStore)
- [x] `SettingsViewModelModesTest` — launchers forward to repo, uiState surfaces values, independent writes
- [x] `SettingsViewModelBufferTest.FakeSettingsRepo` extended with new methods (Wren #96 lesson)
- [ ] Tablet smoke: toggle Mode A off → no spinner during model load on chapter open
- [ ] Tablet smoke: toggle Mode B off → no "Buffering…" UI on Piper-high underrun
- [ ] Tablet smoke: existing Buffer Headroom + Punctuation Cadence still work in their new home

## Test gaps (non-blocking)
- No `EnginePlayer` integration test (no scaffold exists). Mode B's gate is a small Boolean if-check against well-tested branches; toggle wiring is covered by repo + VM tests.
- No `AppBindings.toUi` test (also no scaffold).

🤖 Generated with [Claude Code](https://claude.com/claude-code)