### PR TITLE
fix(playback): park consumer when paused, don't spin on track.write() (regression from #77)

### DIFF
--- a/core-playback/src/main/kotlin/in/jphe/storyvox/playback/tts/EnginePlayer.kt
+++ b/core-playback/src/main/kotlin/in/jphe/storyvox/playback/tts/EnginePlayer.kt
@@ -571,6 +571,38 @@ class EnginePlayer @AssistedInject constructor(
                         }
                     }
 
+                    // While paused, DO NOT write into the AudioTrack —
+                    // a paused MODE_STREAM track does not drain its ring
+                    // buffer, so AudioTrack.write() returns 0 once the
+                    // buffer is full and the inner write loop spins at
+                    // URGENT_AUDIO priority forever (regression introduced
+                    // in PR #77, only surfaces with sub-realtime voices
+                    // like Piper-high on slow CPUs where headroom drops
+                    // below the underrun threshold). Park the consumer on
+                    // the headroom flow until the producer queues enough
+                    // audio to cross the resume threshold, then resume
+                    // the track and proceed with the write.
+                    if (paused) {
+                        try {
+                            runBlocking {
+                                source.bufferHeadroomMs.first {
+                                    it >= BUFFER_RESUME_THRESHOLD_MS || !pipelineRunning.get()
+                                }
+                            }
+                        } catch (_: Throwable) {
+                            // Interrupted by stopPlaybackPipeline (interrupt +
+                            // close). The pipelineRunning check below will
+                            // skip the resume; the outer while will exit.
+                        }
+                        if (pipelineRunning.get()) {
+                            runCatching { track.play() }
+                            paused = false
+                            scope.launch {
+                                _observableState.update { it.copy(isBuffering = false) }
+                            }
+                        }
+                    }
+
                     // Stamp the start of the AudioTrack-write phase for this
                     // chunk. Combined with the chunkEnd() below, this lets
                     // the perf lane log gap_ms = startN - endNm1, which is


### PR DESCRIPTION
## Summary

- **Bug**: On Tab A7 Lite with Piper-high \`cori\` (0.285x realtime), chapter playback warms up, transitions to \"Buffering…\", and never plays any audio. v0.4.30 report from JP, but the bug has been latent since **v0.4.28** (PR #77).
- **Root cause**: PR #77 added \`track.pause()\` when the underrun threshold fires, but the inner write loop has only an \`if (n < 0)\` guard. \`AudioTrack.write()\` returns **0** (not negative) when MODE_STREAM track is paused and ring buffer is full. Inner write loop spins forever at \`THREAD_PRIORITY_URGENT_AUDIO\`; the resume check at the top of the outer loop is unreachable.
- **Fix**: When paused, park the consumer on \`bufferHeadroomMs.first { ... }\` until the producer queues enough audio to cross the resume threshold, then resume the track and proceed with the write. No more spinning, no more PCM written into a paused buffer.

## Live evidence (Tab A7 Lite, R83W80CAFZB, v0.4.30)

| metric | observed |
|---|---|
| \`storyvox-audio-\` thread state | **R< (running, high-prio)** |
| voluntary context switches over 4s | +1 |
| nonvoluntary preemptions over 4s | +27 |
| \`/proc/.../wchan\` | 0 (not in any kernel wait) |
| Cumulative utime | **7m07s** on a single thread |

A blocked-on-take or blocked-on-write thread would be \`S\`. \`R<\` + sustained utime at high priority = tight CPU loop. The only loop in the consumer that has no blocking primitive between iterations is the inner \`while (written < chunk.pcm.size)\` write loop when \`track.write()\` returns 0.

## Why v0.4.27 worked, v0.4.28+ deadlocks

v0.4.27 never paused the track during streaming. \`track.write()\` always blocked on buffer-full, the consumer drained the buffer (audio played), \`n > 0\` returned, loop progressed.

v0.4.28+ pauses the track when headroom < 2000ms. Paused tracks don't drain their ring buffer, so once the buffer fills (~130-200ms on minBufferSize), \`write()\` returns 0 and the inner loop spins.

## Why other voices don't trip the bug

Kokoro and Piper-medium produce audio faster than realtime. By the time the consumer takes a chunk, the producer has queued more, so headroom never drops below the underrun threshold. The pause path is never entered. Only sub-realtime voices (Piper-high on Helio P22T-class CPUs) trip it.

## Fix shape

```kotlin
if (paused) {
    try {
        runBlocking {
            source.bufferHeadroomMs.first {
                it >= BUFFER_RESUME_THRESHOLD_MS || !pipelineRunning.get()
            }
        }
    } catch (_: Throwable) { /* interrupted by stopPlaybackPipeline */ }
    if (pipelineRunning.get()) {
        runCatching { track.play() }
        paused = false
        scope.launch { _observableState.update { it.copy(isBuffering = false) } }
    }
}
```

Inserted between the underrun-pause check and the inner write loop. 32 lines including comments.

## Trade-off

With sub-realtime voices, the listener still waits for the producer to fill the queue (~14s on Piper-high per Aurelia's measurements). The structural fix is Aurora's PCM cache (#86). This PR is the band-aid that gets first-time playback working again until then.

## Test plan

- [x] \`:core-playback:testDebugUnitTest\` — green
- [x] \`:app:assembleDebug\` — green
- [ ] Tablet install + first-time-play of Sky Pride Ch.1 with Piper-high \`cori\`: confirm audio plays after the first ~14s buffering wait, and confirm consumer thread state transitions from \`R<\` to \`S\` while waiting (orchestrator-owned tablet step)
- [ ] Confirm Kokoro / Piper-medium still play smoothly (no pause path entered = no behavior change for these voices)

🤖 Generated with [Claude Code](https://claude.com/claude-code)