### PR TITLE
docs(pages): launch GitHub Pages for storyvox

### DIFF
--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -1,0 +1,45 @@
+title: storyvox
+description: A neural-voice audiobook player for serial fiction. Offline TTS, brass aesthetic, Royal Road and GitHub sources, no per-character billing.
+url: https://jphein.github.io
+baseurl: /storyvox
+
+# Use a minimal theme; we override most styling via _sass / assets/css.
+theme: minima
+minima:
+  skin: dark
+
+# Plugins available on GitHub Pages by default.
+plugins:
+  - jekyll-relative-links
+  - jekyll-seo-tag
+
+# Resolve relative .md links to .html so cross-page links keep working.
+relative_links:
+  enabled: true
+  collections: false
+
+# Don't surface specs / drafts as part of the public site.
+exclude:
+  - superpowers/
+  - ROADMAP.md
+  - compose-gotchas.md
+  - VOICES.md  # consolidated into voices.md, kept in repo for legacy links
+  - README.md
+  - Gemfile
+  - Gemfile.lock
+
+# Sensible defaults.
+markdown: kramdown
+kramdown:
+  syntax_highlighter: rouge
+  smart_quotes: ["apos", "apos", "quot", "quot"]
+
+# Author / SEO.
+author:
+  name: JP Hein
+  email: jp@jphein.com
+twitter:
+  card: summary_large_image
+
+# Pretty permalinks for the marketing pages.
+permalink: pretty

--- a/docs/_layouts/default.html
+++ b/docs/_layouts/default.html
@@ -1,0 +1,43 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>{{ page.title | default: site.title }}</title>
+  <meta name="description" content="{{ page.description | default: site.description }}" />
+  {%- seo title=false -%}
+  <link rel="icon" href="{{ '/assets/favicon.svg' | relative_url }}" type="image/svg+xml" />
+  <link rel="preconnect" href="https://fonts.googleapis.com" />
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+  <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=EB+Garamond:ital,wght@0,400;0,500;0,600;1,400&family=Inter:wght@400;500;600;700&display=swap" />
+  <link rel="stylesheet" href="{{ '/assets/css/style.css' | relative_url }}" />
+</head>
+<body>
+  <header class="site-header">
+    <a class="brand" href="{{ '/' | relative_url }}">
+      <span class="brand-mark" aria-hidden="true">⌑</span>
+      <span class="brand-name">storyvox</span>
+    </a>
+    <nav class="site-nav" aria-label="Primary">
+      <a href="{{ '/install/' | relative_url }}">Install</a>
+      <a href="{{ '/voices/' | relative_url }}">Voices</a>
+      <a href="{{ '/architecture/' | relative_url }}">Architecture</a>
+      <a href="{{ '/screenshots/' | relative_url }}">Screenshots</a>
+      <a href="https://github.com/jphein/storyvox/wiki">Wiki</a>
+      <a href="https://github.com/jphein/storyvox" class="nav-cta">GitHub</a>
+    </nav>
+  </header>
+  <main class="site-main">
+    {{ content }}
+  </main>
+  <footer class="page-footer">
+    <p>
+      <a href="https://github.com/jphein/storyvox">GitHub</a> ·
+      <a href="https://github.com/jphein/storyvox/releases">Releases</a> ·
+      <a href="https://github.com/jphein/storyvox/wiki">Wiki</a> ·
+      <a href="https://github.com/jphein/storyvox/blob/main/LICENSE">GPL-3.0</a>
+    </p>
+    <p class="muted">© {{ 'now' | date: '%Y' }} JP Hein. Built with Claude Code.</p>
+  </footer>
+</body>
+</html>

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,0 +1,135 @@
+---
+layout: default
+title: Architecture
+description: storyvox's eight Gradle modules, fiction-source plug-in pattern, and in-process TTS engine.
+---
+
+# Architecture
+
+storyvox is **eight Gradle modules**. The split keeps fiction sources, playback, UI, and theming independently testable, and makes adding a new fiction source (or swapping the TTS engine) a localized change.
+
+```
+┌─────────────────────────────────────────────┐
+│  :app                                       │
+│  Hilt root · NavHost · Settings adapters    │
+└──────┬──────────────┬───────────────────────┘
+       │              │
+       │              ▼
+       │       ┌──────────────────────┐
+       │       │  :feature            │
+       │       │  Library / Follows / │
+       │       │  Browse / Reader /   │
+       │       │  Detail / Settings   │
+       │       └──────┬─────┬─────────┘
+       │              │     │
+       ▼              ▼     ▼
+┌────────────┐  ┌─────────────────┐  ┌───────────────┐
+│ :core-data │  │ :core-playback  │  │  :core-ui     │
+│  Room +    │  │  EnginePlayer + │  │  Library      │
+│  repos +   │  │  PcmSource +    │  │  Nocturne     │
+│  Fiction   │  │  VoiceManager + │  │  theme +      │
+│  Source    │  │  SentenceTracker│  │  components   │
+│  Map       │  │  (in-proc TTS)  │  │               │
+└─────┬──────┘  └────────┬────────┘  └───────────────┘
+      │                  │
+      ▼                  │ JitPack: VoxSherpa-TTS :engine-lib
+┌──────────────────────┐ │ (Piper + Kokoro + sherpa-onnx)
+│ :source-royalroad    │ │
+│  Cloudflare-aware    │ │
+│  fetch, parsers,     │ │
+│  login WebView,      │ │
+│  honeypot filter     │ │
+└──────────────────────┘ │
+┌──────────────────────┐ │
+│ :source-github       │ │
+│  GitHub API client,  │ │
+│  book.toml +         │ │
+│  storyvox.json,      │ │
+│  commonmark renderer │ │
+└──────────────────────┘ │
+                         ▼
+                   (audio out)
+```
+
+## Module map
+
+| Module | Role | Key types |
+|---|---|---|
+| `:app` | Hilt root, NavHost, top-level wiring. | `StoryvoxApp`, `MainActivity`, `AppBindings` |
+| `:feature` | Compose UI for every screen. | `LibraryScreen`, `BrowseScreen`, `ReaderScreen`, `SettingsScreen`, `VoiceLibraryScreen` |
+| `:core-data` | Room schema, repositories, fiction-source contract. | `FictionSource`, `ChapterRepository`, `FictionRepository`, `SettingsRepositoryUi` |
+| `:core-playback` | Audio engine, voice management, sentence tracking. | `EnginePlayer`, `EngineStreamingSource`, `PcmCache`, `VoiceManager`, `VoiceCatalog`, `SentenceTracker` |
+| `:core-ui` | Library Nocturne theme, shared components. | `LibraryNocturneTheme`, `BrassButton`, `BrassProgressTrack`, spacing/color tokens |
+| `:source-royalroad` | Royal Road implementation of `FictionSource`. | `RoyalRoadSource`, `RoyalRoadFetcher`, `RoyalRoadParsers`, `LoginWebView` |
+| `:source-github` | GitHub-repo implementation of `FictionSource`. | `GithubSource`, `GithubFetcher`, `BookTomlParser`, `CommonmarkRenderer` |
+| `:wear` | Wear OS companion (experimental). | `WearMainActivity`, `WearTransport` |
+
+## Fiction-source plug-in pattern
+
+Sources are bound into a `Map<String, FictionSource>` via Hilt `@IntoMap @StringKey`. Adding a new source is roughly:
+
+1. Implement `FictionSource` in a new `:source-foo` module — `browse()`, `detail(id)`, `chapter(id)`, `latestSha(id)` etc.
+2. Add a Hilt module that binds the implementation `@IntoMap @StringKey("foo")`.
+3. Register the source key in the Browse tab's source picker.
+
+`:core-data`'s `FictionSourceMap` injects the map and routes calls by the `sourceKey` stored on each fiction. UI never imports a source module directly.
+
+## Playback pipeline
+
+Playback is **independent of UI**. `EnginePlayer` is a Media3 `SimpleBasePlayer` subclass that exposes a standard player surface to MediaSession (lock-screen art, BT transport, headphone media buttons) while internally pipelining sentence synthesis against AudioTrack writes.
+
+```
+sentences ──► VoiceEngine (Piper or Kokoro inference)
+              │
+              ▼
+       ┌──────────────────┐
+       │  Producer        │  (tts.synthesize)
+       │  prefetch queue  │
+       │  8 PCM chunks    │
+       └────┬─────────────┘
+            │
+            ▼
+       ┌──────────────────┐
+       │  PcmCache        │  ← optional disk cache (PCM bytes + sentence index)
+       │  appender        │
+       └────┬─────────────┘
+            │
+            ▼
+       ┌──────────────────┐
+       │  URGENT_AUDIO    │  (consumer thread)
+       │  → AudioTrack    │
+       │  → SentenceTrack │
+       └──────────────────┘
+```
+
+The PCM cache (landed in v0.4.31) renders each chapter's audio to disk on first play, so replays are gapless on any device. See the [PCM cache design spec](https://github.com/jphein/storyvox/blob/main/docs/superpowers/specs/2026-05-07-pcm-cache-design.md) for the full pipeline diagram and cache-key rules.
+
+For tuning tradeoffs (warm-up wait, catch-up pause, buffer headroom, full pre-render, punctuation cadence), see the wiki's [Performance modes](https://github.com/jphein/storyvox/wiki/Performance-modes) page.
+
+## In-process TTS
+
+storyvox links the TTS engine **in-process** via the [VoxSherpa-TTS](https://github.com/jphein/VoxSherpa-TTS) `:engine-lib` AAR (published to JitPack). That AAR re-projects [k2-fsa/sherpa-onnx](https://github.com/k2-fsa/sherpa-onnx) inference plus the Piper and Kokoro engine wrappers into a single dependency.
+
+We bypass Android's `TextToSpeech` framework entirely, manage our own `AudioTrack` with a fat buffer, and pipeline next-sentence generation against current playback. **No second APK, no install gate, no engine-binding handshake** — synthesis runs in storyvox's own process.
+
+Voice model weights are downloaded on demand by `VoiceManager` from the `voices-v2` GitHub release. See [Voices](voices/) for catalog details.
+
+## Storage
+
+- **Room** — fictions, chapters, follows, library state, voice download status.
+- **DataStore Preferences** — settings (speed, pitch, theme, buffer headroom, mode toggles, etc.).
+- **EncryptedSharedPreferences** — Royal Road session cookies.
+- **Filesystem** — PCM cache files (`{cacheDir}/pcm/{chapterId}.{voiceId}.{speed}x.{pitch}.pcm`) plus sentence-index sidecars.
+- **OkHttp disk cache** — chapter HTML and image responses.
+
+## Specs and design docs
+
+The `docs/superpowers/specs/` directory in the repo holds the canonical design specs:
+
+- [`2026-05-05-storyvox-design.md`](https://github.com/jphein/storyvox/blob/main/docs/superpowers/specs/2026-05-05-storyvox-design.md) — original architecture
+- [`2026-05-06-github-source-design.md`](https://github.com/jphein/storyvox/blob/main/docs/superpowers/specs/2026-05-06-github-source-design.md) — GitHub fiction source
+- [`2026-05-07-pcm-cache-design.md`](https://github.com/jphein/storyvox/blob/main/docs/superpowers/specs/2026-05-07-pcm-cache-design.md) — chapter PCM cache
+- [`2026-05-08-azure-hd-voices-design.md`](https://github.com/jphein/storyvox/blob/main/docs/superpowers/specs/2026-05-08-azure-hd-voices-design.md) — Azure HD voices (future)
+- [`2026-05-08-github-oauth-design.md`](https://github.com/jphein/storyvox/blob/main/docs/superpowers/specs/2026-05-08-github-oauth-design.md) — GitHub OAuth (future)
+- [`2026-05-08-settings-redesign-design.md`](https://github.com/jphein/storyvox/blob/main/docs/superpowers/specs/2026-05-08-settings-redesign-design.md) — Settings UI redesign
+- [`2026-05-08-voxsherpa-knobs-research.md`](https://github.com/jphein/storyvox/blob/main/docs/superpowers/specs/2026-05-08-voxsherpa-knobs-research.md) — VoxSherpa knobs research

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -62,6 +62,7 @@ storyvox is **eight Gradle modules**. The split keeps fiction sources, playback,
 | `:core-ui` | Library Nocturne theme, shared components. | `LibraryNocturneTheme`, `BrassButton`, `BrassProgressTrack`, spacing/color tokens |
 | `:source-royalroad` | Royal Road implementation of `FictionSource`. | `RoyalRoadSource`, `RoyalRoadFetcher`, `RoyalRoadParsers`, `LoginWebView` |
 | `:source-github` | GitHub-repo implementation of `FictionSource`. | `GithubSource`, `GithubFetcher`, `BookTomlParser`, `CommonmarkRenderer` |
+| `:source-mempalace` | Read-only LAN-only [MemPalace](https://github.com/jphein/mempalace) source — wings as collections, rooms as fictions, drawers as chapters. | `MempalaceSource`, `MempalaceFetcher`, `PalaceDaemonClient` |
 | `:wear` | Wear OS companion (experimental). | `WearMainActivity`, `WearTransport` |
 
 ## Fiction-source plug-in pattern
@@ -133,3 +134,4 @@ The `docs/superpowers/specs/` directory in the repo holds the canonical design s
 - [`2026-05-08-github-oauth-design.md`](https://github.com/jphein/storyvox/blob/main/docs/superpowers/specs/2026-05-08-github-oauth-design.md) — GitHub OAuth (future)
 - [`2026-05-08-settings-redesign-design.md`](https://github.com/jphein/storyvox/blob/main/docs/superpowers/specs/2026-05-08-settings-redesign-design.md) — Settings UI redesign
 - [`2026-05-08-voxsherpa-knobs-research.md`](https://github.com/jphein/storyvox/blob/main/docs/superpowers/specs/2026-05-08-voxsherpa-knobs-research.md) — VoxSherpa knobs research
+- [`2026-05-08-mempalace-integration-design.md`](https://github.com/jphein/storyvox/blob/main/docs/superpowers/specs/2026-05-08-mempalace-integration-design.md) — MemPalace as fiction source

--- a/docs/assets/css/style.css
+++ b/docs/assets/css/style.css
@@ -1,0 +1,393 @@
+/* storyvox docs site — Library Nocturne aesthetic
+ * Brass on warm dark by default; parchment cream in light mode. */
+
+:root {
+  --brass-300: #e8c98f;
+  --brass-400: #d4a850;
+  --brass-500: #b8862a;
+  --brass-600: #8a5f17;
+  --warm-bg: #1a140d;
+  --warm-bg-elev: #221a11;
+  --warm-bg-card: #2a2015;
+  --warm-fg: #ece1d1;
+  --warm-fg-muted: #a89b85;
+  --warm-rule: #3a2c1a;
+  --plum: #6d3a4f;
+  --serif: "EB Garamond", "Iowan Old Style", Georgia, serif;
+  --sans: "Inter", -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  --max-w: 1080px;
+  --radius-lg: 14px;
+  --radius-md: 10px;
+}
+
+@media (prefers-color-scheme: light) {
+  :root {
+    --warm-bg: #f5ecd8;
+    --warm-bg-elev: #fff8e8;
+    --warm-bg-card: #fffaef;
+    --warm-fg: #2a2015;
+    --warm-fg-muted: #6d5d44;
+    --warm-rule: #d9c89e;
+    --brass-300: #8a5f17;
+    --brass-400: #6f4a10;
+    --brass-500: #b8862a;
+  }
+}
+
+* { box-sizing: border-box; }
+
+html { scroll-behavior: smooth; }
+
+body {
+  margin: 0;
+  font-family: var(--sans);
+  font-size: 16px;
+  line-height: 1.6;
+  color: var(--warm-fg);
+  background: var(--warm-bg);
+  -webkit-font-smoothing: antialiased;
+}
+
+a { color: var(--brass-300); text-decoration: none; }
+a:hover { color: var(--brass-400); text-decoration: underline; }
+@media (prefers-color-scheme: light) {
+  a { color: var(--brass-400); }
+  a:hover { color: var(--brass-500); }
+}
+
+code {
+  font-family: ui-monospace, "SF Mono", Menlo, Consolas, monospace;
+  font-size: 0.92em;
+  background: var(--warm-bg-elev);
+  padding: 0.12em 0.36em;
+  border-radius: 4px;
+}
+
+pre {
+  background: var(--warm-bg-elev);
+  border: 1px solid var(--warm-rule);
+  border-radius: var(--radius-md);
+  padding: 1em 1.2em;
+  overflow-x: auto;
+  font-size: 0.88em;
+  line-height: 1.5;
+}
+
+pre code { background: transparent; padding: 0; }
+
+table {
+  border-collapse: collapse;
+  width: 100%;
+  margin: 1.2em 0;
+  font-size: 0.95em;
+}
+
+th, td {
+  text-align: left;
+  padding: 0.55em 0.85em;
+  border-bottom: 1px solid var(--warm-rule);
+}
+
+th {
+  font-weight: 600;
+  color: var(--brass-300);
+  border-bottom-color: var(--brass-600);
+}
+
+img { max-width: 100%; height: auto; }
+
+blockquote {
+  border-left: 3px solid var(--brass-500);
+  margin: 1em 0;
+  padding: 0.4em 1em;
+  color: var(--warm-fg-muted);
+  background: var(--warm-bg-elev);
+}
+
+/* Header */
+.site-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 1.1em 1.4em;
+  border-bottom: 1px solid var(--warm-rule);
+  background: var(--warm-bg-elev);
+  position: sticky;
+  top: 0;
+  z-index: 10;
+  backdrop-filter: blur(8px);
+}
+
+.brand {
+  display: flex;
+  align-items: center;
+  gap: 0.55em;
+  font-family: var(--serif);
+  font-weight: 600;
+  font-size: 1.4em;
+  color: var(--brass-300);
+  text-decoration: none;
+}
+.brand:hover { text-decoration: none; color: var(--brass-400); }
+
+.brand-mark {
+  font-size: 1.2em;
+  color: var(--brass-400);
+  filter: drop-shadow(0 0 6px rgba(184, 134, 42, 0.35));
+}
+
+.brand-name { letter-spacing: 0.01em; }
+
+.site-nav {
+  display: flex;
+  gap: 1.4em;
+  align-items: center;
+  font-size: 0.95em;
+}
+
+.site-nav a {
+  color: var(--warm-fg);
+}
+
+.site-nav a:hover {
+  color: var(--brass-300);
+  text-decoration: none;
+}
+
+.site-nav .nav-cta {
+  border: 1px solid var(--brass-500);
+  padding: 0.35em 0.95em;
+  border-radius: var(--radius-md);
+  color: var(--brass-300);
+}
+
+.site-nav .nav-cta:hover {
+  background: var(--brass-500);
+  color: var(--warm-bg);
+}
+
+@media (max-width: 700px) {
+  .site-header { flex-direction: column; gap: 0.6em; padding: 0.9em 1em; }
+  .site-nav { flex-wrap: wrap; gap: 0.9em; justify-content: center; }
+}
+
+/* Main column */
+.site-main {
+  max-width: var(--max-w);
+  margin: 0 auto;
+  padding: 2.5em 1.5em 4em;
+}
+
+h1, h2, h3, h4 {
+  font-family: var(--serif);
+  font-weight: 600;
+  letter-spacing: 0.005em;
+  line-height: 1.2;
+  margin: 1.6em 0 0.6em;
+}
+
+h1 {
+  font-size: 2.6em;
+  margin-top: 0.2em;
+  color: var(--brass-300);
+}
+
+h2 {
+  font-size: 1.7em;
+  color: var(--brass-300);
+  border-bottom: 1px solid var(--warm-rule);
+  padding-bottom: 0.3em;
+}
+
+h3 {
+  font-size: 1.25em;
+  color: var(--warm-fg);
+}
+
+p { margin: 0.85em 0; }
+
+.muted { color: var(--warm-fg-muted); font-size: 0.95em; }
+
+/* Hero (index) */
+.hero {
+  display: grid;
+  grid-template-columns: 1.2fr 1fr;
+  gap: 2.5em;
+  align-items: center;
+  padding: 2em 0 2.5em;
+  border-bottom: 1px solid var(--warm-rule);
+  margin-bottom: 2em;
+}
+
+.hero h1 {
+  font-size: 3.1em;
+  margin: 0 0 0.15em;
+  color: var(--brass-300);
+}
+
+.hero .tagline {
+  font-family: var(--serif);
+  font-style: italic;
+  font-size: 1.25em;
+  color: var(--warm-fg);
+  margin: 0 0 1em;
+}
+
+.hero p { font-size: 1.05em; }
+
+.hero-art img {
+  max-width: 320px;
+  width: 100%;
+  border-radius: var(--radius-lg);
+  box-shadow: 0 18px 50px rgba(0,0,0,0.5), 0 0 0 1px var(--warm-rule);
+  display: block;
+  margin: 0 auto;
+}
+
+.cta-row { display: flex; gap: 0.9em; margin-top: 1.3em; flex-wrap: wrap; }
+
+.cta-primary, .cta-secondary {
+  display: inline-block;
+  padding: 0.65em 1.4em;
+  border-radius: var(--radius-md);
+  font-weight: 600;
+  text-decoration: none;
+  font-size: 1em;
+  transition: transform 0.05s ease, background 0.15s ease;
+}
+
+.cta-primary {
+  background: linear-gradient(180deg, var(--brass-400), var(--brass-500));
+  color: var(--warm-bg);
+  box-shadow: 0 2px 6px rgba(0,0,0,0.3), inset 0 1px 0 rgba(255,255,255,0.15);
+}
+.cta-primary:hover { color: var(--warm-bg); text-decoration: none; transform: translateY(-1px); }
+
+.cta-secondary {
+  border: 1px solid var(--brass-500);
+  color: var(--brass-300);
+  background: transparent;
+}
+.cta-secondary:hover { background: var(--warm-bg-card); color: var(--brass-300); text-decoration: none; }
+
+@media (max-width: 760px) {
+  .hero { grid-template-columns: 1fr; text-align: center; gap: 1.6em; }
+  .cta-row { justify-content: center; }
+  .hero h1 { font-size: 2.4em; }
+}
+
+/* Why grid */
+.why-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+  gap: 1.2em;
+  margin: 1.5em 0 2em;
+}
+
+.card {
+  background: var(--warm-bg-card);
+  border: 1px solid var(--warm-rule);
+  border-radius: var(--radius-lg);
+  padding: 1.3em 1.4em;
+  transition: border-color 0.15s ease;
+}
+.card:hover { border-color: var(--brass-600); }
+
+.card h3 {
+  margin-top: 0;
+  color: var(--brass-300);
+  font-size: 1.15em;
+}
+
+.card p { margin: 0.4em 0 0; font-size: 0.97em; line-height: 1.55; }
+
+/* Screens grid */
+.screens-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+  gap: 1em;
+  margin: 1.5em 0 2.5em;
+}
+
+.screens-grid figure {
+  margin: 0;
+  text-align: center;
+}
+
+.screens-grid img {
+  width: 100%;
+  border-radius: var(--radius-md);
+  box-shadow: 0 8px 24px rgba(0,0,0,0.4), 0 0 0 1px var(--warm-rule);
+}
+
+.screens-grid figcaption {
+  margin-top: 0.5em;
+  font-size: 0.9em;
+  color: var(--warm-fg-muted);
+}
+
+/* Recent block */
+.recent {
+  background: var(--warm-bg-elev);
+  border-left: 3px solid var(--brass-500);
+  padding: 1em 1.4em;
+  border-radius: 0 var(--radius-md) var(--radius-md) 0;
+  margin: 2em 0;
+}
+
+.recent h2 {
+  border-bottom: none;
+  padding-bottom: 0;
+  margin-top: 0;
+  font-size: 1.4em;
+}
+
+/* Page footer (in-page) */
+.site-footer {
+  border-top: 1px solid var(--warm-rule);
+  margin-top: 3em;
+  padding-top: 1.5em;
+  font-size: 0.95em;
+  color: var(--warm-fg-muted);
+}
+
+/* Site footer (below main) */
+.page-footer {
+  border-top: 1px solid var(--warm-rule);
+  text-align: center;
+  padding: 1.6em 1em 2em;
+  color: var(--warm-fg-muted);
+  font-size: 0.9em;
+  background: var(--warm-bg-elev);
+}
+
+.page-footer p { margin: 0.3em 0; }
+
+.page-footer a { color: var(--brass-300); }
+
+/* Reading-page polish: when a doc is text-heavy, give it more line-length comfort */
+.site-main figure { margin: 1.5em 0; }
+.site-main figure img {
+  border-radius: var(--radius-md);
+  box-shadow: 0 8px 24px rgba(0,0,0,0.4), 0 0 0 1px var(--warm-rule);
+}
+.site-main figure figcaption {
+  margin-top: 0.6em;
+  color: var(--warm-fg-muted);
+  font-size: 0.92em;
+  font-style: italic;
+}
+
+/* Inline lists tighten up a touch */
+ul, ol { padding-left: 1.4em; }
+li { margin: 0.25em 0; }
+
+/* Section spacing on the landing page */
+section { margin-bottom: 2.5em; }
+section:first-of-type { margin-top: 0; }
+
+/* Reduced motion */
+@media (prefers-reduced-motion: reduce) {
+  * { transition: none !important; animation: none !important; }
+  html { scroll-behavior: auto; }
+}

--- a/docs/assets/favicon.svg
+++ b/docs/assets/favicon.svg
@@ -1,0 +1,22 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" role="img" aria-label="storyvox">
+  <defs>
+    <linearGradient id="brass" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0" stop-color="#e8c98f"/>
+      <stop offset="0.55" stop-color="#d4a850"/>
+      <stop offset="1" stop-color="#8a5f17"/>
+    </linearGradient>
+    <radialGradient id="glow" cx="0.5" cy="0.5" r="0.65">
+      <stop offset="0" stop-color="#3a2c1a"/>
+      <stop offset="1" stop-color="#1a140d"/>
+    </radialGradient>
+  </defs>
+  <rect width="64" height="64" rx="12" fill="url(#glow)"/>
+  <!-- diamond / sigil mark -->
+  <path d="M32 10 L52 32 L32 54 L12 32 Z"
+        fill="none"
+        stroke="url(#brass)"
+        stroke-width="3"
+        stroke-linejoin="round"/>
+  <!-- inner sentence highlight bar -->
+  <rect x="22" y="29" width="20" height="6" rx="2" fill="url(#brass)" opacity="0.85"/>
+</svg>

--- a/docs/index.md
+++ b/docs/index.md
@@ -43,11 +43,12 @@ description: Offline neural TTS. Royal Road and GitHub fiction sources. Brass-on
       </p>
     </div>
     <div class="card">
-      <h3>Two fiction sources</h3>
+      <h3>Three fiction sources</h3>
       <p>
-        Browse Royal Road with the full filter set, or browse curated and discoverable GitHub
-        fiction repositories via <a href="https://github.com/jphein/storyvox-registry">storyvox-registry</a>
-        plus live <code>/search/repositories</code> results.
+        Browse Royal Road with the full filter set, browse curated and discoverable GitHub
+        fiction repositories via <a href="https://github.com/jphein/storyvox-registry">storyvox-registry</a>,
+        or read your <a href="https://github.com/jphein/mempalace">MemPalace</a> drawers as chapters
+        when on the home network.
       </p>
     </div>
     <div class="card">
@@ -101,10 +102,15 @@ description: Offline neural TTS. Royal Road and GitHub fiction sources. Brass-on
 <section class="recent">
   <h2>What just shipped</h2>
   <p>
-    <strong>v0.4.31</strong> — fixes infinite spin on track.pause() (regression from #77),
+    <strong>v0.4.31</strong> — fix(playback) infinite spin on track.pause() (regression from #77),
     PCM cache filesystem layer landed, Performance &amp; buffering Settings section with
     Mode A / Mode B toggles, voice library starring + Starred surface.
     <a href="https://github.com/jphein/storyvox/releases/tag/v0.4.31">Full release notes →</a>
+  </p>
+  <p>
+    <strong>Since v0.4.31:</strong> MemPalace as a read-only fiction source (#107),
+    speed/pitch flow-to-engine fix (#113), continuous Punctuation Cadence slider (#115),
+    polished README. Next release builds on these.
   </p>
   <p class="muted">
     See the <a href="https://github.com/jphein/storyvox/wiki">wiki</a> for per-feature documentation,

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,0 +1,122 @@
+---
+layout: default
+title: storyvox — neural-voice audiobook player for serial fiction
+description: Offline neural TTS. Royal Road and GitHub fiction sources. Brass-on-warm-dark Library Nocturne aesthetic. Free, GPL-3.0, no per-character billing.
+---
+
+<section class="hero">
+  <div class="hero-text">
+    <h1>storyvox</h1>
+    <p class="tagline">A neural-voice audiobook player for serial fiction.</p>
+    <p>
+      Stream chapters from <a href="https://royalroad.com">Royal Road</a> and
+      <a href="https://github.com/jphein/storyvox-registry">GitHub</a>, read aloud by an
+      <strong>offline neural TTS engine</strong>, with a hybrid reader/audiobook view that
+      highlights the spoken sentence as you listen.
+    </p>
+    <p class="cta-row">
+      <a class="cta-primary" href="install/">Install</a>
+      <a class="cta-secondary" href="https://github.com/jphein/storyvox">Source on GitHub</a>
+    </p>
+  </div>
+  <div class="hero-art">
+    <img src="screenshots/03-reader.png" alt="storyvox reader playing The Archmage Coefficient with the spoken sentence highlighted in brass." />
+  </div>
+</section>
+
+<section class="why">
+  <h2>Why storyvox</h2>
+  <div class="why-grid">
+    <div class="card">
+      <h3>Offline neural TTS</h3>
+      <p>
+        Two voice families ship — <a href="https://github.com/rhasspy/piper">Piper</a> (compact, ~14–30 MB)
+        and <a href="https://github.com/hexgrad/kokoro">Kokoro</a> (multi-speaker, ~330 MB).
+        Voices download once, then live on-device. No cloud, no API keys, no per-character billing.
+      </p>
+    </div>
+    <div class="card">
+      <h3>Brass on warm dark</h3>
+      <p>
+        Library Nocturne theme — brass accents, EB Garamond chapter body, Inter UI. Light mode is
+        parchment cream. Adaptive grid for phones (2 col), tablets (5 col), and foldables.
+      </p>
+    </div>
+    <div class="card">
+      <h3>Two fiction sources</h3>
+      <p>
+        Browse Royal Road with the full filter set, or browse curated and discoverable GitHub
+        fiction repositories via <a href="https://github.com/jphein/storyvox-registry">storyvox-registry</a>
+        plus live <code>/search/repositories</code> results.
+      </p>
+    </div>
+    <div class="card">
+      <h3>Reader view, in sync</h3>
+      <p>
+        Swipe between audiobook view (cover + scrubber + transport) and reader view (chapter text).
+        The current sentence glides along in brass, matching the read-aloud rhythm.
+      </p>
+    </div>
+    <div class="card">
+      <h3>Smooth on slow hardware</h3>
+      <p>
+        PCM cache buffering and optional render-ahead modes keep playback gapless even when
+        Piper-high struggles on a Helio P22T. Tuned on a Galaxy Tab A7 Lite.
+      </p>
+    </div>
+    <div class="card">
+      <h3>Free and open</h3>
+      <p>
+        GPL-3.0. Inheritable from the TTS engine, but also a posture: no telemetry, no analytics,
+        no upsell. Sideload the APK from <a href="https://github.com/jphein/storyvox/releases">Releases</a>
+        and you're done.
+      </p>
+    </div>
+  </div>
+</section>
+
+<section class="screens">
+  <h2>What it looks like</h2>
+  <p class="muted">Galaxy Tab A7 Lite, 800×1340 px. <a href="screenshots/">Full gallery →</a></p>
+  <div class="screens-grid">
+    <figure>
+      <img src="screenshots/01-browse.png" alt="Browse tab" />
+      <figcaption>Browse</figcaption>
+    </figure>
+    <figure>
+      <img src="screenshots/02-detail.png" alt="Fiction detail" />
+      <figcaption>Fiction detail</figcaption>
+    </figure>
+    <figure>
+      <img src="screenshots/04-library.png" alt="Library tab" />
+      <figcaption>Library</figcaption>
+    </figure>
+    <figure>
+      <img src="screenshots/05-settings.png" alt="Settings" />
+      <figcaption>Settings</figcaption>
+    </figure>
+  </div>
+</section>
+
+<section class="recent">
+  <h2>What just shipped</h2>
+  <p>
+    <strong>v0.4.31</strong> — fixes infinite spin on track.pause() (regression from #77),
+    PCM cache filesystem layer landed, Performance &amp; buffering Settings section with
+    Mode A / Mode B toggles, voice library starring + Starred surface.
+    <a href="https://github.com/jphein/storyvox/releases/tag/v0.4.31">Full release notes →</a>
+  </p>
+  <p class="muted">
+    See the <a href="https://github.com/jphein/storyvox/wiki">wiki</a> for per-feature documentation,
+    or <a href="architecture/">how the modules fit together</a>.
+  </p>
+</section>
+
+<footer class="site-footer">
+  <p>
+    storyvox is licensed under the
+    <a href="https://github.com/jphein/storyvox/blob/main/LICENSE">GNU General Public License v3.0</a>.
+    Built by <a href="https://github.com/jphein">JP Hein</a>
+    with teams of <a href="https://www.anthropic.com/claude-code">Claude Code</a> agents.
+  </p>
+</footer>

--- a/docs/install.md
+++ b/docs/install.md
@@ -1,0 +1,91 @@
+---
+layout: default
+title: Install storyvox
+description: Sideload storyvox on Android. System requirements, voice download sizes, and the optional Royal Road sign-in.
+---
+
+# Install
+
+storyvox is currently distributed by sideloading. CI builds debug APKs on every push to `main`; tagged releases (`v0.x.x`) attach a signed APK to the corresponding GitHub release.
+
+## Quick install
+
+1. Open the [Releases page](https://github.com/jphein/storyvox/releases) on your Android device.
+2. Download the latest `storyvox-vX.Y.Z.apk` from the assets.
+3. On the device, enable **Install unknown apps** for whichever browser or file manager you used.
+4. Open the APK to install.
+5. Launch storyvox. You'll be asked for **notification permission** (used for the lock-screen tile during playback).
+6. The voice picker appears on first launch — pick a Piper voice for a quick first chapter (~14–30 MB) or Kokoro if you want the multi-speaker model (~330 MB).
+
+That's it. There's no account requirement. Anonymous browsing works for all public Royal Road fictions and every GitHub-sourced fiction.
+
+## System requirements
+
+| Requirement | Minimum |
+|---|---|
+| Android version | 8.0 (API 26) |
+| Free storage (APK only) | ~50 MB |
+| Free storage (APK + one Piper voice) | ~70 MB |
+| Free storage (APK + Kokoro) | ~400 MB |
+| RAM | 2 GB+ recommended; tested on 3 GB Tab A7 Lite |
+| Network | Wi-Fi for first launch and voice download; chapters cache locally |
+
+The TTS engine runs in storyvox's own process via the
+[VoxSherpa-TTS](https://github.com/jphein/VoxSherpa-TTS) `:engine-lib` AAR, so there's no second
+APK to install and no engine-binding handshake. Voice models download on demand from the project's
+[`voices-v2`](https://github.com/jphein/VoxSherpa-TTS/releases/tag/voices-v2) GitHub release.
+Nothing is bundled in the APK.
+
+## Optional: sign in to Royal Road
+
+Anonymous browsing works for every public chapter. **Sign in** unlocks:
+
+- **Premium chapters** — Patreon-tier early access on supported fictions.
+- **Your Follows tab** — your bookmarked Royal Road fictions sync down into storyvox.
+
+storyvox uses an in-app WebView for the login flow. **Your password never touches our code; only the session cookies are captured, and they're stored encrypted on-device** via Android's `EncryptedSharedPreferences`.
+
+To sign in:
+
+1. Open the **Follows** tab.
+2. Tap **Sign in**.
+3. Complete the Royal Road login form in the WebView.
+4. Return to the app — your follow list will sync within a few seconds.
+
+To sign out: **Settings → Account → Sign out**.
+
+## Build from source
+
+Requires JDK 17, Android SDK 35, and a system Gradle ≥ 8.10 for the wrapper bootstrap.
+
+```sh
+git clone https://github.com/jphein/storyvox.git
+cd storyvox
+
+# One-time bootstrap
+gradle wrapper --gradle-version 8.10 --distribution-type bin
+echo "sdk.dir=$ANDROID_HOME" > local.properties
+
+# Build
+./gradlew :app:assembleDebug          # phone APK
+./gradlew :wear:assembleDebug         # wear APK
+./gradlew :app:installDebug           # install on connected device
+```
+
+The CI workflow `.github/workflows/android.yml` is the canonical build path.
+
+## What about Wear OS?
+
+There is a `:wear` module that builds an APK companion. Pairing-and-discovery via
+`play-services-wearable` works in principle, but it isn't yet a polished experience and isn't
+recommended for daily use. If you want to experiment, sideload the wear APK from the same release.
+
+## Update path
+
+storyvox doesn't auto-update. When a new release ships:
+
+1. Download the new APK from [Releases](https://github.com/jphein/storyvox/releases).
+2. Open it. Android will prompt to upgrade in place — your library, voices, and progress are preserved.
+
+The app's signing key is stable across releases starting with `v0.4.15`. Older debug-keystore
+builds may need a clean uninstall before upgrading.

--- a/docs/screenshots.md
+++ b/docs/screenshots.md
@@ -1,0 +1,63 @@
+---
+layout: default
+title: Screenshots
+description: Full screenshot gallery — Browse, Reader, Library, Settings, Filters, and Follows.
+---
+
+# Screenshots
+
+Captured on a Galaxy Tab A7 Lite (800×1340 px) running storyvox in the Library Nocturne dark theme.
+
+## Browse
+
+<figure>
+  <img src="screenshots/01-browse.png" alt="Browse tab — Royal Road and GitHub fiction sources side by side, infinite scroll grid." />
+  <figcaption>Browse — Royal Road infinite-scroll grid with cover art and pinned source picker.</figcaption>
+</figure>
+
+## Filters
+
+<figure>
+  <img src="screenshots/06-filter.png" alt="Filter sheet — tags include and exclude, status, type, length, rating, content warnings, sort order." />
+  <figcaption>The full Royal Road filter set — tags include / exclude, status, type, length, rating, content warnings, sort order.</figcaption>
+</figure>
+
+## Fiction detail
+
+<figure>
+  <img src="screenshots/02-detail.png" alt="Fiction detail — cover, synopsis, tags, chapter list with read state." />
+  <figcaption>Fiction detail — synopsis, tags, chapter list, follow / unfollow, jump to first unread.</figcaption>
+</figure>
+
+## Reader / audiobook view
+
+<figure>
+  <img src="screenshots/03-reader.png" alt="Reader playing The Archmage Coefficient with the spoken sentence highlighted in brass." />
+  <figcaption>Reader — the spoken sentence glides in brass as TTS plays. Swipe left for the audiobook view (cover, scrubber, transport controls).</figcaption>
+</figure>
+
+## Library
+
+<figure>
+  <img src="screenshots/04-library.png" alt="Library tab — currently-listening fictions with cover, progress, last-read sentence, resume button." />
+  <figcaption>Library — currently-listening fictions with cover, progress, last-read sentence, resume button.</figcaption>
+</figure>
+
+## Settings
+
+<figure>
+  <img src="screenshots/05-settings.png" alt="Settings — voice library, speed, pitch, punctuation cadence, audio buffer slider, theme override, Wi-Fi only, poll interval, account, version." />
+  <figcaption>Settings — voice picker, speed, pitch, punctuation cadence, buffer slider, theme override, Wi-Fi-only, poll interval, account, version. (Settings UI is being redesigned in <a href="https://github.com/jphein/storyvox/issues/104">#104</a> — these screenshots reflect v0.4.x layout.)</figcaption>
+</figure>
+
+## Follows
+
+<figure>
+  <img src="screenshots/07-follows-loading.png" alt="Follows tab loading — skeleton placeholders while Royal Road follow list syncs." />
+  <figcaption>Follows — sync in progress.</figcaption>
+</figure>
+
+<figure>
+  <img src="screenshots/07-follows-loaded.png" alt="Follows tab loaded — bookmarked Royal Road fictions in a grid." />
+  <figcaption>Follows — bookmarked fictions, grid view, signed in.</figcaption>
+</figure>

--- a/docs/voices.md
+++ b/docs/voices.md
@@ -1,0 +1,114 @@
+---
+layout: default
+title: Voice catalog
+description: Piper and Kokoro voices shipped via VoxSherpa-TTS. Sizes, quality tiers, refresh workflow, and why we don't quantize.
+---
+
+# Voice catalog
+
+storyvox ships **two voice families**:
+
+- **[Piper](https://github.com/rhasspy/piper)** — single-speaker, compact, fast. Each voice is ~14–30 MB. Best for first-time installs and for fast turnaround on slow hardware.
+- **[Kokoro](https://github.com/hexgrad/kokoro)** — multi-speaker, ~330 MB single download, ships dozens of voice profiles in one model. Higher quality, slower to synthesize.
+
+Both run **in-process** in storyvox via the [VoxSherpa-TTS](https://github.com/jphein/VoxSherpa-TTS) `:engine-lib` AAR, which wraps [k2-fsa/sherpa-onnx](https://github.com/k2-fsa/sherpa-onnx) for inference. No second APK, no system-TTS handoff, no per-character billing.
+
+## Quality tiers (Piper)
+
+Piper voices ship in three quality tiers from the upstream `vits-piper-*` models:
+
+| Tier | Approx. download | Synthesis speed | Notes |
+|------|------------------|-----------------|-------|
+| **low** | ~14 MB | Fastest | Best for very slow devices; some artifacting on long sentences. |
+| **medium** | ~22 MB | Mid | Default tier. Good balance. |
+| **high** | ~28 MB | Slowest | Most natural prosody; can run below realtime on Helio P22T-class chips (see [Performance modes](Performance-modes/) on the wiki). |
+
+Voice tiers are independent of speaker — pick the speaker first, then the tier you can afford.
+
+## Where voices live
+
+Model weights are **not bundled in the APK** (they'd add 1+ GB). They download on demand from the
+[`voices-v2`](https://github.com/jphein/VoxSherpa-TTS/releases/tag/voices-v2) GitHub release on
+`jphein/VoxSherpa-TTS`. Each Piper voice ships as `{lang}-{voice}-{quality}.onnx` plus a
+`.tokens.txt` sidecar. Kokoro ships as `kokoro-model.onnx` + `kokoro-voices.bin` + `kokoro-tokens.txt`.
+
+`voices-v2` is a re-hosting of the upstream k2-fsa tarballs as flat single-file downloads — extracting `.tar.bz2` archives on Tab A7 Lite-class hardware is slow enough to delay the first chapter for tens of seconds. Doing it once server-side moves that cost off the device.
+
+## Why fp32, not int8
+
+The previous `voices-v1` release used INT8-quantized models — ~3× smaller download, but a vocoder
+run through INT8 dynamic quantization adds audible noise to spectral coefficients. That's the
+"fuzz" symptom users heard on Samsung tablets in v0.4.x.
+
+`voices-v2` uses **fp32** weights — exactly what's inside the upstream
+`vits-piper-*.tar.bz2` and `kokoro-multi-lang-v1_1.tar.bz2` archives. Larger downloads, clean speech.
+
+The `_int8` suffix in some `VoiceCatalog.kt` voice IDs (e.g. `piper_lessac_en_US_high_int8`)
+is **historical** — kept stable so already-installed users don't have to re-pick a voice when they
+update. The on-disk files and URLs no longer involve quantization.
+
+## Picking a voice
+
+In the app: **Settings → Voice library**, or tap the voice name in **Settings → Voice & Playback** to jump there.
+
+The library groups voices by engine (Piper / Kokoro), language, and speaker. Each row shows:
+
+- **Star** — toggle to favorite a voice. Stars persist across reinstalls and sit at the top of the list.
+- **Status** — installed, downloading, available, or starred.
+- **Size** — disk footprint after install.
+- **Quality tier** — for Piper voices.
+
+The current selection is highlighted in brass. Tapping a voice that isn't installed kicks off the download with a progress bar and notification; the voice becomes selectable when it lands.
+
+### Disk hygiene
+
+- **Long-press a voice → Delete** to free disk. The currently-selected voice can't be deleted; switch first.
+- The starred surface in the library shows your favorite voices at the top regardless of install status. Use it as a shortlist when you reinstall.
+
+## Catalog refresh workflow (maintainers)
+
+```bash
+# Compare upstream to voices-v2 (no changes, no auth needed)
+./scripts/voices/refresh-voices-v2.sh --check-only
+
+# Pull new tarballs, extract, upload (needs gh CLI auth with write
+# access to jphein/VoxSherpa-TTS; uses ~5 GB temp space)
+./scripts/voices/refresh-voices-v2.sh
+```
+
+The script:
+
+1. Lists `tts-models` assets on `k2-fsa/sherpa-onnx` matching `vits-piper-(en_US|en_GB)-*.tar.bz2` (no `-int8`, no `-fp16` suffix) and `kokoro-multi-lang-v1_1.tar.bz2`.
+2. Diffs against assets currently on `voices-v2`.
+3. Downloads any missing tarballs (parallel x8).
+4. Extracts and flattens — drops `MODEL_CARD`, `espeak-ng-data/`, and various Kokoro lexicon/dict files (storyvox bundles its own espeak data).
+5. Uploads everything to `voices-v2` with `--clobber` so reruns are idempotent.
+
+When you add a new upstream voice, also add a `CatalogEntry` to
+`core-playback/src/main/kotlin/in/jphe/storyvox/playback/voice/VoiceCatalog.kt`. The script
+**does not** edit the catalog automatically — that part is a deliberate human review.
+
+## Automated drift detection
+
+`.github/workflows/voice-catalog-check.yml` runs on the 1st of every month (and on manual
+dispatch). It performs the same diff as `--check-only` and, if there's drift, files a GitHub
+issue listing new upstream voices. It does **not** auto-publish — refreshing `voices-v2` requires
+write access to `jphein/VoxSherpa-TTS`, which the default `GITHUB_TOKEN` doesn't have.
+
+## Why we don't auto-update the in-app catalog
+
+`VoiceCatalog.kt` is compiled into the APK. To pick up new voices the user has to install a new
+app version. That's intentional:
+
+- The catalog includes language tags, quality tier hints, and recommended voices that need human curation.
+- Adding voices is rare enough (months between k2-fsa releases) that a per-release cadence doesn't hurt.
+- A network-fetched dynamic catalog would add a runtime failure mode and an "is the index loading?" UX state. Not worth it for the cadence.
+
+If the cadence ever picks up, the plan is to switch to a JSON file in the same `voices-v2`
+release that the app fetches and caches; `VoiceCatalog.kt` becomes a fallback. That's a v1.x
+feature, not v0.4.x.
+
+## Coming soon
+
+- **Azure HD voices** ([#85](https://github.com/jphein/storyvox/issues/85)) — bring-your-own-key Azure Cognitive Services voices for users who want studio-grade narration. Optional, not required, never billed by storyvox. Design draft is in `docs/superpowers/specs/2026-05-08-azure-hd-voices-design.md`.
+- **VoxSherpa-TTS knob exposure** ([research draft](https://github.com/jphein/storyvox/blob/main/docs/superpowers/specs/2026-05-08-voxsherpa-knobs-research.md)) — loudness normalization, breath pause, pitch envelope as user-tunable settings.


### PR DESCRIPTION
## Summary
- Brass-themed marketing + docs site at https://jphein.github.io/storyvox/ via Jekyll on `main:/docs` (Pages already enabled via API).
- Five pages — landing (hero + why-cards + screenshots + recent), install, voices, architecture, screenshots gallery — plus custom layout, SVG favicon, brass-on-warm-dark CSS with `prefers-color-scheme` light variant.
- Reuses existing `docs/screenshots/` assets; no new screenshots fabricated, no roadmap features claimed as shipped.

## Aesthetic
- Library Nocturne palette: brass (`#e8c98f` / `#d4a850` / `#8a5f17`) on warm dark (`#1a140d`) by default, parchment cream in light mode.
- EB Garamond serif for headings + body emphasis, Inter sans for UI.
- Sticky brass header with diamond mark + nav (Install / Voices / Architecture / Screenshots / Wiki / GitHub).
- SVG favicon: brass diamond outline with a sentence-highlight bar inside — same idiom as the reader's brass underline.

## Site structure
```
docs/
├── _config.yml          # Jekyll config, minima dark, plugins, exclusions
├── _layouts/default.html # custom layout w/ brass header + footer
├── assets/
│   ├── css/style.css    # ~330 lines, brass palette + responsive grids
│   └── favicon.svg
├── index.md             # landing page
├── install.md
├── voices.md
├── architecture.md
└── screenshots.md
```

Existing `docs/VOICES.md`, `docs/ROADMAP.md`, `docs/compose-gotchas.md`, and `docs/superpowers/` are excluded from the Pages build via `_config.yml` (still in the repo as-is for direct GitHub viewing).

## Coordination
- **Briar** is on README polish concurrently; her README changes won't conflict with these `docs/*.md` additions. Briar can cross-link from README to the live Pages URL once this lands.
- **Saga** is on Settings UI redesign — no overlap.
- **Wiki** population is staged at `~/.claude/projects/-home-jp/scratch/loose-ends-round2-2026-05-08/cleo-gh-pages/wiki-staged/` (9 pages: Home, Browse, Reader, Voice-Library, Settings, Performance-modes, Sources, Troubleshooting, FAQ) and pushes via `push-wiki.sh` once JP creates the wiki's first page through the GitHub web UI (one-time bootstrap; GitHub doesn't allow `git push` to an empty wiki via API). Browser opened to https://github.com/jphein/storyvox/wiki/_new.

## Test plan
- [ ] After merge, GitHub Actions deploys Pages (legacy build, `main:/docs`); site live at https://jphein.github.io/storyvox/.
- [ ] Verify dark theme renders by default; light theme toggles via OS setting.
- [ ] Verify Install / Voices / Architecture / Screenshots links work end-to-end.
- [ ] Verify screenshots load (relative URLs resolve to `/storyvox/screenshots/0X-foo.png`).
- [ ] Verify nav cross-links to wiki and GitHub work.
- [ ] Cross-reference: README's `<img src="docs/screenshots/03-reader.png">` still renders on the GitHub repo home (Pages doesn't intercept that path).

## Iron rules followed
- No version bump.
- No tablet install.
- No new dependencies in app code (Pages uses GitHub-native Jekyll plugins only).
- Selective git add only.
- No fabricated screenshots; reused `docs/screenshots/01-07*.png`.
- No roadmap features claimed as shipped — Azure HD, Memory Palace, Mode C, GitHub OAuth, Settings redesign all called out as "Coming soon" / "future".

🤖 Generated with [Claude Code](https://claude.com/claude-code)