### PR TITLE
fix(tests): repair test compile breakage from #79 + #109 squash overlap

### DIFF
--- a/app/src/test/kotlin/in/jphe/storyvox/data/SettingsRepositoryBufferTest.kt
+++ b/app/src/test/kotlin/in/jphe/storyvox/data/SettingsRepositoryBufferTest.kt
@@ -3,19 +3,12 @@ package `in`.jphe.storyvox.data
 import androidx.datastore.core.DataStore
 import androidx.datastore.preferences.core.PreferenceDataStoreFactory
 import androidx.datastore.preferences.core.Preferences
-import `in`.jphe.storyvox.data.auth.SessionHydrator
-import `in`.jphe.storyvox.data.auth.SessionState
-import `in`.jphe.storyvox.data.repository.AuthRepository
-import kotlinx.coroutines.flow.MutableStateFlow
-import kotlinx.coroutines.flow.StateFlow
-import kotlinx.coroutines.flow.asStateFlow
 import `in`.jphe.storyvox.feature.api.BUFFER_DEFAULT_CHUNKS
 import `in`.jphe.storyvox.feature.api.BUFFER_MAX_CHUNKS
 import `in`.jphe.storyvox.feature.api.BUFFER_MIN_CHUNKS
 import `in`.jphe.storyvox.feature.api.BUFFER_RECOMMENDED_MAX_CHUNKS
 import java.io.File
 import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.cancel
@@ -121,100 +114,8 @@ class SettingsRepositoryBufferTest {
         assertEquals(BUFFER_MAX_CHUNKS, repo.currentBufferChunks())
     }
 
-    private class FakeAuth : AuthRepository {
-        private val state = MutableStateFlow<SessionState>(SessionState.Anonymous)
-        override val sessionState: StateFlow<SessionState> = state.asStateFlow()
-        override suspend fun captureSession(
-            cookieHeader: String,
-            userDisplayName: String?,
-            userId: String?,
-            expiresAt: Long?,
-        ) = Unit
-        override suspend fun clearSession() = Unit
-        override suspend fun cookieHeader(): String? = null
-        override suspend fun verifyOrExpire(): SessionState = SessionState.Anonymous
-    }
-
-    private class FakeHydrator : SessionHydrator {
-        override fun hydrate(cookies: Map<String, String>) = Unit
-        override fun clear() = Unit
-    }
-
-    /**
-     * Real [PalaceConfigImpl] backed by a temp DataStore + an in-memory
-     * SharedPreferences stub. The buffer-test fixture doesn't exercise
-     * the palace state, but the repo's settings flow joins on it via
-     * combine(), so we need a flow that emits at least once.
-     */
-    private fun makeFakePalaceConfig(
-        dir: File,
-        scope: CoroutineScope,
-    ): PalaceConfigImpl {
-        val palaceStore = PreferenceDataStoreFactory.create(
-            scope = scope,
-            produceFile = { File(dir, "storyvox_palace.preferences_pb") },
-        )
-        return PalaceConfigImpl(palaceStore, FakeSecrets())
-    }
-
-    /**
-     * Real [PalaceDaemonApi] over an OkHttpClient + the same fake config.
-     * No HTTP is exercised by the buffer tests; the dep is there because
-     * the repo signature requires it.
-     */
-    private fun makeFakePalaceApi(): `in`.jphe.storyvox.source.mempalace.net.PalaceDaemonApi =
-        `in`.jphe.storyvox.source.mempalace.net.PalaceDaemonApi(
-            httpClient = okhttp3.OkHttpClient(),
-            config = object : `in`.jphe.storyvox.source.mempalace.config.PalaceConfig {
-                override val state: kotlinx.coroutines.flow.Flow<
-                    `in`.jphe.storyvox.source.mempalace.config.PalaceConfigState
-                > = kotlinx.coroutines.flow.flowOf(
-                    `in`.jphe.storyvox.source.mempalace.config.PalaceConfigState("", ""),
-                )
-                override suspend fun current() =
-                    `in`.jphe.storyvox.source.mempalace.config.PalaceConfigState("", "")
-            },
-        )
-
-    /** Minimal SharedPreferences stub — only `getString` is reached by
-     *  the palace code paths the test fixture touches. */
-    private class FakeSecrets : android.content.SharedPreferences {
-        private val map = mutableMapOf<String, Any?>()
-        override fun getAll(): MutableMap<String, *> = map
-        override fun getString(key: String, defValue: String?): String? =
-            map[key] as? String ?: defValue
-        override fun getStringSet(
-            key: String,
-            defValues: MutableSet<String>?,
-        ): MutableSet<String>? = defValues
-        override fun getInt(key: String, defValue: Int): Int = (map[key] as? Int) ?: defValue
-        override fun getLong(key: String, defValue: Long): Long = (map[key] as? Long) ?: defValue
-        override fun getFloat(key: String, defValue: Float): Float =
-            (map[key] as? Float) ?: defValue
-        override fun getBoolean(key: String, defValue: Boolean): Boolean =
-            (map[key] as? Boolean) ?: defValue
-        override fun contains(key: String): Boolean = key in map
-        override fun edit(): android.content.SharedPreferences.Editor =
-            object : android.content.SharedPreferences.Editor {
-                override fun putString(key: String, value: String?) = apply { map[key] = value }
-                override fun putStringSet(
-                    key: String,
-                    values: MutableSet<String>?,
-                ) = apply { map[key] = values }
-                override fun putInt(key: String, value: Int) = apply { map[key] = value }
-                override fun putLong(key: String, value: Long) = apply { map[key] = value }
-                override fun putFloat(key: String, value: Float) = apply { map[key] = value }
-                override fun putBoolean(key: String, value: Boolean) = apply { map[key] = value }
-                override fun remove(key: String) = apply { map.remove(key) }
-                override fun clear() = apply { map.clear() }
-                override fun commit(): Boolean = true
-                override fun apply() = Unit
-            }
-        override fun registerOnSharedPreferenceChangeListener(
-            l: android.content.SharedPreferences.OnSharedPreferenceChangeListener?,
-        ) = Unit
-        override fun unregisterOnSharedPreferenceChangeListener(
-            l: android.content.SharedPreferences.OnSharedPreferenceChangeListener?,
-        ) = Unit
-    }
+    // FakeAuth / FakeHydrator / makeFakePalaceConfig / makeFakePalaceApi /
+    // FakeSecrets all live in [SettingsRepositoryTestSupport] so the three
+    // settings-repo tests share one source of truth as the repo's
+    // constructor surface evolves.
 }

--- a/app/src/test/kotlin/in/jphe/storyvox/data/SettingsRepositoryModesTest.kt
+++ b/app/src/test/kotlin/in/jphe/storyvox/data/SettingsRepositoryModesTest.kt
@@ -3,17 +3,11 @@ package `in`.jphe.storyvox.data
 import androidx.datastore.core.DataStore
 import androidx.datastore.preferences.core.PreferenceDataStoreFactory
 import androidx.datastore.preferences.core.Preferences
-import `in`.jphe.storyvox.data.auth.SessionHydrator
-import `in`.jphe.storyvox.data.auth.SessionState
-import `in`.jphe.storyvox.data.repository.AuthRepository
 import java.io.File
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.cancel
-import kotlinx.coroutines.flow.MutableStateFlow
-import kotlinx.coroutines.flow.StateFlow
-import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.test.UnconfinedTestDispatcher
 import kotlinx.coroutines.test.runTest
@@ -52,7 +46,13 @@ class SettingsRepositoryModesTest {
             scope = scope,
             produceFile = { file },
         )
-        repo = SettingsRepositoryUiImpl(store, FakeAuth(), FakeHydrator())
+        repo = SettingsRepositoryUiImpl(
+            store = store,
+            auth = FakeAuth(),
+            hydrator = FakeHydrator(),
+            palaceConfig = makeFakePalaceConfig(tempFolder.newFolder("palace_ds"), scope),
+            palaceApi = makeFakePalaceApi(),
+        )
     }
 
     @After
@@ -139,22 +139,5 @@ class SettingsRepositoryModesTest {
         )
     }
 
-    private class FakeAuth : AuthRepository {
-        private val state = MutableStateFlow<SessionState>(SessionState.Anonymous)
-        override val sessionState: StateFlow<SessionState> = state.asStateFlow()
-        override suspend fun captureSession(
-            cookieHeader: String,
-            userDisplayName: String?,
-            userId: String?,
-            expiresAt: Long?,
-        ) = Unit
-        override suspend fun clearSession() = Unit
-        override suspend fun cookieHeader(): String? = null
-        override suspend fun verifyOrExpire(): SessionState = SessionState.Anonymous
-    }
-
-    private class FakeHydrator : SessionHydrator {
-        override fun hydrate(cookies: Map<String, String>) = Unit
-        override fun clear() = Unit
-    }
+    // FakeAuth / FakeHydrator / palace fakes live in [SettingsRepositoryTestSupport].
 }

--- a/app/src/test/kotlin/in/jphe/storyvox/data/SettingsRepositoryPunctuationPauseTest.kt
+++ b/app/src/test/kotlin/in/jphe/storyvox/data/SettingsRepositoryPunctuationPauseTest.kt
@@ -6,9 +6,6 @@ import androidx.datastore.preferences.core.Preferences
 import androidx.datastore.preferences.core.edit
 import androidx.datastore.preferences.core.floatPreferencesKey
 import androidx.datastore.preferences.core.stringPreferencesKey
-import `in`.jphe.storyvox.data.auth.SessionHydrator
-import `in`.jphe.storyvox.data.auth.SessionState
-import `in`.jphe.storyvox.data.repository.AuthRepository
 import `in`.jphe.storyvox.feature.api.PUNCTUATION_PAUSE_DEFAULT_MULTIPLIER
 import `in`.jphe.storyvox.feature.api.PUNCTUATION_PAUSE_LONG_MULTIPLIER
 import `in`.jphe.storyvox.feature.api.PUNCTUATION_PAUSE_MAX_MULTIPLIER
@@ -21,9 +18,6 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.cancel
-import kotlinx.coroutines.flow.MutableStateFlow
-import kotlinx.coroutines.flow.StateFlow
-import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.test.UnconfinedTestDispatcher
 import kotlinx.coroutines.test.runTest
@@ -64,7 +58,13 @@ class SettingsRepositoryPunctuationPauseTest {
             scope = scope,
             produceFile = { file },
         )
-        repo = SettingsRepositoryUiImpl(store, FakeAuth(), FakeHydrator())
+        repo = SettingsRepositoryUiImpl(
+            store = store,
+            auth = FakeAuth(),
+            hydrator = FakeHydrator(),
+            palaceConfig = makeFakePalaceConfig(tempFolder.newFolder("palace_ds"), scope),
+            palaceApi = makeFakePalaceApi(),
+        )
     }
 
     @After
@@ -210,22 +210,5 @@ class SettingsRepositoryPunctuationPauseTest {
         }
     }
 
-    private class FakeAuth : AuthRepository {
-        private val state = MutableStateFlow<SessionState>(SessionState.Anonymous)
-        override val sessionState: StateFlow<SessionState> = state.asStateFlow()
-        override suspend fun captureSession(
-            cookieHeader: String,
-            userDisplayName: String?,
-            userId: String?,
-            expiresAt: Long?,
-        ) = Unit
-        override suspend fun clearSession() = Unit
-        override suspend fun cookieHeader(): String? = null
-        override suspend fun verifyOrExpire(): SessionState = SessionState.Anonymous
-    }
-
-    private class FakeHydrator : SessionHydrator {
-        override fun hydrate(cookies: Map<String, String>) = Unit
-        override fun clear() = Unit
-    }
+    // FakeAuth / FakeHydrator / palace fakes live in [SettingsRepositoryTestSupport].
 }

--- a/app/src/test/kotlin/in/jphe/storyvox/data/SettingsRepositoryTestSupport.kt
+++ b/app/src/test/kotlin/in/jphe/storyvox/data/SettingsRepositoryTestSupport.kt
@@ -1,0 +1,127 @@
+package `in`.jphe.storyvox.data
+
+import android.content.SharedPreferences
+import androidx.datastore.preferences.core.PreferenceDataStoreFactory
+import `in`.jphe.storyvox.data.auth.SessionHydrator
+import `in`.jphe.storyvox.data.auth.SessionState
+import `in`.jphe.storyvox.data.repository.AuthRepository
+import `in`.jphe.storyvox.source.mempalace.config.PalaceConfig
+import `in`.jphe.storyvox.source.mempalace.config.PalaceConfigState
+import `in`.jphe.storyvox.source.mempalace.net.PalaceDaemonApi
+import java.io.File
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.flowOf
+import okhttp3.OkHttpClient
+
+/**
+ * Shared test fixtures for the three [SettingsRepositoryUiImpl] tests
+ * (Buffer, Modes, PunctuationPause). Each test spins up its own temp-file
+ * DataStore for the settings store; the palace surface is required by
+ * the constructor since #79 but isn't exercised by these tests, so we
+ * stub it with a real [PalaceConfigImpl] over a separate temp DataStore
+ * + an in-memory [SharedPreferences] stub, and wire a [PalaceDaemonApi]
+ * at a never-touched config flow.
+ *
+ * Extracting these here (instead of inlining identical helpers in three
+ * places) keeps the surface stable as the [SettingsRepositoryUi] interface
+ * grows — when a future contract member needs a new fake, one edit covers
+ * every test fixture. Mirrors the rationale behind `Hilt`-shared test
+ * doubles in this codebase.
+ */
+internal class FakeAuth : AuthRepository {
+    private val state = MutableStateFlow<SessionState>(SessionState.Anonymous)
+    override val sessionState: StateFlow<SessionState> = state.asStateFlow()
+    override suspend fun captureSession(
+        cookieHeader: String,
+        userDisplayName: String?,
+        userId: String?,
+        expiresAt: Long?,
+    ) = Unit
+    override suspend fun clearSession() = Unit
+    override suspend fun cookieHeader(): String? = null
+    override suspend fun verifyOrExpire(): SessionState = SessionState.Anonymous
+}
+
+internal class FakeHydrator : SessionHydrator {
+    override fun hydrate(cookies: Map<String, String>) = Unit
+    override fun clear() = Unit
+}
+
+/**
+ * Real [PalaceConfigImpl] backed by a temp DataStore + an in-memory
+ * SharedPreferences stub. The settings-tests don't exercise palace
+ * state, but the repo's `settings` flow joins on it via combine(), so
+ * we need a flow that emits at least once.
+ */
+internal fun makeFakePalaceConfig(
+    dir: File,
+    scope: CoroutineScope,
+): PalaceConfigImpl {
+    val palaceStore = PreferenceDataStoreFactory.create(
+        scope = scope,
+        produceFile = { File(dir, "storyvox_palace.preferences_pb") },
+    )
+    return PalaceConfigImpl(palaceStore, FakeSecrets())
+}
+
+/**
+ * Real [PalaceDaemonApi] over an OkHttpClient + a fake config that emits
+ * an empty [PalaceConfigState]. No HTTP is exercised by the settings
+ * tests; the dep is there because the repo signature requires it.
+ */
+internal fun makeFakePalaceApi(): PalaceDaemonApi =
+    PalaceDaemonApi(
+        httpClient = OkHttpClient(),
+        config = object : PalaceConfig {
+            override val state: Flow<PalaceConfigState> = flowOf(PalaceConfigState("", ""))
+            override suspend fun current() = PalaceConfigState("", "")
+        },
+    )
+
+/**
+ * Minimal SharedPreferences stub — only `getString` / `edit` are reached
+ * by the palace code paths the test fixtures touch.
+ */
+internal class FakeSecrets : SharedPreferences {
+    private val map = mutableMapOf<String, Any?>()
+    override fun getAll(): MutableMap<String, *> = map
+    override fun getString(key: String, defValue: String?): String? =
+        map[key] as? String ?: defValue
+    override fun getStringSet(
+        key: String,
+        defValues: MutableSet<String>?,
+    ): MutableSet<String>? = defValues
+    override fun getInt(key: String, defValue: Int): Int = (map[key] as? Int) ?: defValue
+    override fun getLong(key: String, defValue: Long): Long = (map[key] as? Long) ?: defValue
+    override fun getFloat(key: String, defValue: Float): Float =
+        (map[key] as? Float) ?: defValue
+    override fun getBoolean(key: String, defValue: Boolean): Boolean =
+        (map[key] as? Boolean) ?: defValue
+    override fun contains(key: String): Boolean = key in map
+    override fun edit(): SharedPreferences.Editor =
+        object : SharedPreferences.Editor {
+            override fun putString(key: String, value: String?) = apply { map[key] = value }
+            override fun putStringSet(
+                key: String,
+                values: MutableSet<String>?,
+            ) = apply { map[key] = values }
+            override fun putInt(key: String, value: Int) = apply { map[key] = value }
+            override fun putLong(key: String, value: Long) = apply { map[key] = value }
+            override fun putFloat(key: String, value: Float) = apply { map[key] = value }
+            override fun putBoolean(key: String, value: Boolean) = apply { map[key] = value }
+            override fun remove(key: String) = apply { map.remove(key) }
+            override fun clear() = apply { map.clear() }
+            override fun commit(): Boolean = true
+            override fun apply() = Unit
+        }
+    override fun registerOnSharedPreferenceChangeListener(
+        l: SharedPreferences.OnSharedPreferenceChangeListener?,
+    ) = Unit
+    override fun unregisterOnSharedPreferenceChangeListener(
+        l: SharedPreferences.OnSharedPreferenceChangeListener?,
+    ) = Unit
+}

--- a/app/src/test/kotlin/in/jphe/storyvox/di/RealPlaybackControllerUiTest.kt
+++ b/app/src/test/kotlin/in/jphe/storyvox/di/RealPlaybackControllerUiTest.kt
@@ -6,7 +6,7 @@ import `in`.jphe.storyvox.data.repository.ChapterRepository
 import `in`.jphe.storyvox.data.repository.playback.PlaybackChapter
 import `in`.jphe.storyvox.data.source.model.ChapterContent
 import `in`.jphe.storyvox.data.source.model.ChapterInfo
-import `in`.jphe.storyvox.feature.api.PunctuationPause
+import `in`.jphe.storyvox.feature.api.PUNCTUATION_PAUSE_DEFAULT_MULTIPLIER
 import `in`.jphe.storyvox.feature.api.SettingsRepositoryUi
 import `in`.jphe.storyvox.feature.api.ThemeOverride
 import `in`.jphe.storyvox.feature.api.UiSettings
@@ -149,7 +149,7 @@ class RealPlaybackControllerUiTest {
         downloadOnWifiOnly = false,
         pollIntervalHours = 6,
         isSignedIn = false,
-        punctuationPause = PunctuationPause.Normal,
+        punctuationPauseMultiplier = PUNCTUATION_PAUSE_DEFAULT_MULTIPLIER,
     )
 
     /**
@@ -210,12 +210,21 @@ class RealPlaybackControllerUiTest {
         override suspend fun setDefaultVoice(voiceId: String?) = Unit
         override suspend fun setDownloadOnWifiOnly(enabled: Boolean) = Unit
         override suspend fun setPollIntervalHours(hours: Int) = Unit
-        override suspend fun setPunctuationPause(mode: PunctuationPause) = Unit
+        override suspend fun setPunctuationPauseMultiplier(multiplier: Float) = Unit
         override suspend fun setPlaybackBufferChunks(chunks: Int) = Unit
         override suspend fun setWarmupWait(enabled: Boolean) = Unit
         override suspend fun setCatchupPause(enabled: Boolean) = Unit
         override suspend fun signIn() = Unit
         override suspend fun signOut() = Unit
+        // Memory Palace stubs (#79) — playback-controller-test fixture
+        // doesn't exercise the palace surface; keep them no-op + return
+        // NotConfigured.
+        override suspend fun setPalaceHost(host: String) = Unit
+        override suspend fun setPalaceApiKey(apiKey: String) = Unit
+        override suspend fun clearPalaceConfig() = Unit
+        override suspend fun testPalaceConnection():
+            `in`.jphe.storyvox.feature.api.PalaceProbeResult =
+            `in`.jphe.storyvox.feature.api.PalaceProbeResult.NotConfigured
     }
 
     /** Chapter repo never invoked by the speed/pitch path under test. */

--- a/feature/src/test/kotlin/in/jphe/storyvox/feature/settings/SettingsViewModelModesTest.kt
+++ b/feature/src/test/kotlin/in/jphe/storyvox/feature/settings/SettingsViewModelModesTest.kt
@@ -140,6 +140,14 @@ class SettingsViewModelModesTest {
         }
         override suspend fun signIn() = Unit
         override suspend fun signOut() = Unit
+        // Memory Palace stubs (#79) — modes-test fixture doesn't exercise
+        // the palace surface; keep them no-op + return NotConfigured.
+        override suspend fun setPalaceHost(host: String) = Unit
+        override suspend fun setPalaceApiKey(apiKey: String) = Unit
+        override suspend fun clearPalaceConfig() = Unit
+        override suspend fun testPalaceConnection():
+            `in`.jphe.storyvox.feature.api.PalaceProbeResult =
+            `in`.jphe.storyvox.feature.api.PalaceProbeResult.NotConfigured
     }
 
     private class FakeVoiceProvider : VoiceProviderUi {

--- a/feature/src/test/kotlin/in/jphe/storyvox/feature/settings/SettingsViewModelPunctuationPauseTest.kt
+++ b/feature/src/test/kotlin/in/jphe/storyvox/feature/settings/SettingsViewModelPunctuationPauseTest.kt
@@ -138,6 +138,14 @@ class SettingsViewModelPunctuationPauseTest {
         }
         override suspend fun signIn() = Unit
         override suspend fun signOut() = Unit
+        // Memory Palace stubs (#79) — punctuation-pause-test fixture doesn't
+        // exercise the palace surface; keep them no-op + return NotConfigured.
+        override suspend fun setPalaceHost(host: String) = Unit
+        override suspend fun setPalaceApiKey(apiKey: String) = Unit
+        override suspend fun clearPalaceConfig() = Unit
+        override suspend fun testPalaceConnection():
+            `in`.jphe.storyvox.feature.api.PalaceProbeResult =
+            `in`.jphe.storyvox.feature.api.PalaceProbeResult.NotConfigured
     }
 
     private class FakeVoiceProvider : VoiceProviderUi {


### PR DESCRIPTION
## Summary
The squash-merges of #107 (mempalace, contract-widening) and #115 (punctuation slider, contract-renaming) each landed against pre-#79/pre-#109 main respectively. Neither carried forward fixes for test fixtures that touched the **other** surface, leaving main's test compile broken in two places:

- **5-arg constructor**: `SettingsRepositoryUiImpl` gained `palaceConfig` + `palaceApi` from #79. `SettingsRepositoryModesTest` still called the old 3-arg constructor; `SettingsRepositoryPunctuationPauseTest` (new in #109) did too. Only `SettingsRepositoryBufferTest` was updated.
- **Palace stub overrides**: `SettingsRepositoryUi` gained `setPalaceHost` / `setPalaceApiKey` / `clearPalaceConfig` / `testPalaceConnection`. The `FakeSettingsRepo` classes in `SettingsViewModelModesTest`, `SettingsViewModelPunctuationPauseTest`, and `RealPlaybackControllerUiTest` don't override them, so their test compile fails with "is not abstract".
- `RealPlaybackControllerUiTest` also still references the dropped `PunctuationPause` enum + `setPunctuationPause` method.

## Changes
- Extract `FakeAuth` / `FakeHydrator` / `makeFakePalaceConfig` / `makeFakePalaceApi` / `FakeSecrets` into a shared `SettingsRepositoryTestSupport.kt` so the three repo tests share one source of truth as the constructor surface evolves.
- Add palace-stub overrides + 5-arg ctor calls to all three repo tests + the two viewmodel tests + `RealPlaybackControllerUiTest`.
- Migrate `RealPlaybackControllerUiTest` off `PunctuationPause` onto `PUNCTUATION_PAUSE_DEFAULT_MULTIPLIER` + `setPunctuationPauseMultiplier`.

## Test plan
- [x] \`:feature:testDebugUnitTest :app:testDebugUnitTest :core-playback:testDebugUnitTest\` — all green locally
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)