### PR TITLE
refactor(voicelibrary): remove Featured section (#129)

### DIFF
--- a/feature/src/main/kotlin/in/jphe/storyvox/feature/voicelibrary/VoiceLibraryScreen.kt
+++ b/feature/src/main/kotlin/in/jphe/storyvox/feature/voicelibrary/VoiceLibraryScreen.kt
@@ -73,14 +73,13 @@ fun VoiceLibraryScreen(
         },
         snackbarHost = { SnackbarHost(snackbar) },
     ) { padding ->
-        val featured = state.featured
         val favorites = state.favorites
         val installedByEngine = state.installedByEngine
         val availableByEngine = state.availableByEngine
         val installedTotal = installedByEngine.values.sumOf { tiers -> tiers.values.sumOf { it.size } }
         val availableTotal = availableByEngine.values.sumOf { tiers -> tiers.values.sumOf { it.size } }
         val availableHasKokoro = availableByEngine.containsKey(VoiceEngine.Kokoro)
-        val isEmpty = featured.isEmpty() && favorites.isEmpty() &&
+        val isEmpty = favorites.isEmpty() &&
             installedTotal == 0 && availableTotal == 0
 
         if (isEmpty) {
@@ -115,27 +114,6 @@ fun VoiceLibraryScreen(
                         modifier = Modifier
                             .animateItem()
                             .cascadeReveal(index = index, key = "fav-${voice.id}"),
-                    )
-                }
-                item { Spacer(modifier = Modifier.height(spacing.md)) }
-            }
-
-            if (featured.isNotEmpty()) {
-                item { SectionHeader("⭐ Featured", count = featured.size) }
-                itemsIndexed(featured, key = { _, item -> "f-${item.id}" }) { index, voice ->
-                    val downloading = state.currentDownload
-                    val rowProgress = if (downloading?.voiceId == voice.id) downloading.progress ?: -1f else null
-                    VoiceRow(
-                        voice = voice,
-                        isActive = voice.id == state.activeVoiceId,
-                        isFavorite = voice.id in state.favoriteIds,
-                        downloadingProgress = rowProgress,
-                        onTap = { if (downloading == null || voice.isInstalled) viewModel.onRowTapped(voice) },
-                        onLongPress = if (voice.isInstalled) ({ viewModel.requestDelete(voice) }) else null,
-                        onToggleFavorite = { viewModel.toggleFavorite(voice.id) },
-                        modifier = Modifier
-                            .animateItem()
-                            .cascadeReveal(index = index, key = voice.id),
                     )
                 }
                 item { Spacer(modifier = Modifier.height(spacing.md)) }

--- a/feature/src/main/kotlin/in/jphe/storyvox/feature/voicelibrary/VoiceLibraryViewModel.kt
+++ b/feature/src/main/kotlin/in/jphe/storyvox/feature/voicelibrary/VoiceLibraryViewModel.kt
@@ -24,16 +24,17 @@ import kotlinx.coroutines.launch
 
 @Immutable
 data class VoiceLibraryUiState(
-    /** Hand-picked best-of-catalog voices, shown above all other sections.
-     *  Always 3 entries (sourced from [VoiceCatalog.featuredIds]); each
-     *  carries its own installed flag so the row reflects current state. */
-    val featured: List<UiVoiceInfo> = emptyList(),
-    /** User-starred voices, surfaced under their own header above
-     *  Featured. Empty when nothing pinned, in which case the whole
-     *  section is hidden by the screen. The internal name "favorites"
-     *  is preserved from #89 (so is the DataStore key
-     *  `voice_favorites_v1`) — only the user-facing label changed to
-     *  "Starred" in #106. */
+    /** User-starred voices, surfaced under their own header at the top.
+     *  Empty when nothing pinned, in which case the whole section is
+     *  hidden by the screen. The internal name "favorites" is preserved
+     *  from #89 (so is the DataStore key `voice_favorites_v1`) — only
+     *  the user-facing label changed to "Starred" in #106.
+     *
+     *  The legacy "Featured" header above this section was removed in
+     *  #129 — the curated [VoiceCatalog.featuredIds] still feeds the
+     *  first-launch [VoicePickerGate], but the Voice Library now lets
+     *  those voices appear in their natural Engine → Tier home alongside
+     *  every other voice rather than re-pinning them to a top section. */
     val favorites: List<UiVoiceInfo> = emptyList(),
     /** Installed voices grouped first by engine (Piper, then Kokoro)
      *  and then by tier within each engine. Within Piper the tier order
@@ -86,30 +87,22 @@ class VoiceLibraryViewModel @Inject constructor(
         ) { d, p, e -> Triple(d, p, e) },
     ) { installed, available, active, favIds, (downloading, pending, error) ->
         val installedIds = installed.mapTo(mutableSetOf()) { it.id }
-        // Featured voices use the live installed flag so the row's CTA
-        // ("Activate" vs "Download") matches reality. We pull the entry from
-        // the installed list when present, otherwise from the catalog.
-        val featured = VoiceCatalog.featuredIds.mapNotNull { id ->
-            installed.firstOrNull { it.id == id }
-                ?: available.firstOrNull { it.id == id }
-        }
-        val featuredIdSet = featured.mapTo(mutableSetOf()) { it.id }
         // Favourites pulls from installed first (preserving the
         // installed-flag) and falls back to the catalog for voices the
         // user pinned but hasn't downloaded yet. Listed favourites are
         // EXCLUDED from the per-tier sections below to avoid showing the
-        // same row twice — featured rows follow the same exclusion rule.
+        // same row twice. (#129 removed the parallel exclusion for the
+        // legacy Featured set — those voices now flow into their natural
+        // Engine → Tier section like any other catalog entry.)
         val favorites = favIds.mapNotNull { id ->
             installed.firstOrNull { it.id == id }
                 ?: available.firstOrNull { it.id == id }
         }
-        val excludedFromTiers = favIds + featuredIdSet
-        val installedFiltered = installed.filterNot { it.id in excludedFromTiers }
+        val installedFiltered = installed.filterNot { it.id in favIds }
         val availableFiltered = available.filterNot {
-            it.id in installedIds || it.id in excludedFromTiers
+            it.id in installedIds || it.id in favIds
         }
         VoiceLibraryUiState(
-            featured = featured,
             favorites = favorites,
             installedByEngine = installedFiltered.groupByEngineThenTier(),
             availableByEngine = availableFiltered.groupByEngineThenTier(),


### PR DESCRIPTION
## Summary
- Drop the curated Featured band from the Voice Library; voices that were in it now flow into their natural Engine → Tier section like any other catalog entry.

## Why
JP's #129 asks for the section gone. The Voice Library was rendering two top-of-list curated bands (Starred + Featured); after #89 the Starred section is the user-driven analogue, so the curator-driven Featured row had become a redundant pin above its own tier home. Removing it reads cleaner and stops the same voice rendering twice in a user's mental scroll.

`VoiceCatalog.featuredIds` is preserved — the first-launch `VoicePickerGate` still uses the curated trio as its starter recommendations.

## Test plan
- [x] :feature:assembleDebug green
- [x] :app:assembleDebug green
- [x] No new tests needed — VoiceGroupingTest doesn't reference the dropped UiState.featured field. Existing :feature:test suite is broken on main from #111 LLM-ctor fallout (unrelated to this PR; needs its own fix-tests sweep)
- [ ] Manual on-tablet (orchestrator)

Closes #129.