### PR TITLE
fix(tests): repair test compile breakage from #111 LLM-ctor expansion

### DIFF
--- a/app/src/test/kotlin/in/jphe/storyvox/data/SettingsRepositoryModesTest.kt
+++ b/app/src/test/kotlin/in/jphe/storyvox/data/SettingsRepositoryModesTest.kt
@@ -52,6 +52,9 @@ class SettingsRepositoryModesTest {
             hydrator = FakeHydrator(),
             palaceConfig = makeFakePalaceConfig(tempFolder.newFolder("palace_ds"), scope),
             palaceApi = makeFakePalaceApi(),
+            // Test-only LlmCredentialsStore (#81) — bypasses encrypted prefs.
+            // Modes tests don't touch AI fields, so a no-op store is fine.
+            llmCreds = `in`.jphe.storyvox.llm.LlmCredentialsStore.forTesting(),
         )
     }
 

--- a/app/src/test/kotlin/in/jphe/storyvox/data/SettingsRepositoryPunctuationPauseTest.kt
+++ b/app/src/test/kotlin/in/jphe/storyvox/data/SettingsRepositoryPunctuationPauseTest.kt
@@ -64,6 +64,9 @@ class SettingsRepositoryPunctuationPauseTest {
             hydrator = FakeHydrator(),
             palaceConfig = makeFakePalaceConfig(tempFolder.newFolder("palace_ds"), scope),
             palaceApi = makeFakePalaceApi(),
+            // Test-only LlmCredentialsStore (#81) — bypasses encrypted prefs.
+            // Punctuation-pause tests don't touch AI fields, so a no-op store is fine.
+            llmCreds = `in`.jphe.storyvox.llm.LlmCredentialsStore.forTesting(),
         )
     }
 

--- a/app/src/test/kotlin/in/jphe/storyvox/di/RealPlaybackControllerUiTest.kt
+++ b/app/src/test/kotlin/in/jphe/storyvox/di/RealPlaybackControllerUiTest.kt
@@ -8,6 +8,7 @@ import `in`.jphe.storyvox.data.source.model.ChapterContent
 import `in`.jphe.storyvox.data.source.model.ChapterInfo
 import `in`.jphe.storyvox.feature.api.PUNCTUATION_PAUSE_DEFAULT_MULTIPLIER
 import `in`.jphe.storyvox.feature.api.SettingsRepositoryUi
+import `in`.jphe.storyvox.feature.api.UiLlmProvider
 import `in`.jphe.storyvox.feature.api.ThemeOverride
 import `in`.jphe.storyvox.feature.api.UiSettings
 import `in`.jphe.storyvox.playback.PlaybackController
@@ -225,6 +226,18 @@ class RealPlaybackControllerUiTest {
         override suspend fun testPalaceConnection():
             `in`.jphe.storyvox.feature.api.PalaceProbeResult =
             `in`.jphe.storyvox.feature.api.PalaceProbeResult.NotConfigured
+
+        // ── AI no-ops (#81) — playback-controller-test fixture doesn't exercise these. ──
+        override suspend fun setAiProvider(provider: UiLlmProvider?) = Unit
+        override suspend fun setClaudeApiKey(key: String?) = Unit
+        override suspend fun setClaudeModel(model: String) = Unit
+        override suspend fun setOpenAiApiKey(key: String?) = Unit
+        override suspend fun setOpenAiModel(model: String) = Unit
+        override suspend fun setOllamaBaseUrl(url: String) = Unit
+        override suspend fun setOllamaModel(model: String) = Unit
+        override suspend fun setSendChapterTextEnabled(enabled: Boolean) = Unit
+        override suspend fun acknowledgeAiPrivacy() = Unit
+        override suspend fun resetAiSettings() = Unit
     }
 
     /** Chapter repo never invoked by the speed/pitch path under test. */

--- a/feature/src/test/kotlin/in/jphe/storyvox/feature/settings/SettingsViewModelModesTest.kt
+++ b/feature/src/test/kotlin/in/jphe/storyvox/feature/settings/SettingsViewModelModesTest.kt
@@ -3,10 +3,16 @@ package `in`.jphe.storyvox.feature.settings
 import `in`.jphe.storyvox.feature.api.BUFFER_DEFAULT_CHUNKS
 import `in`.jphe.storyvox.feature.api.SettingsRepositoryUi
 import `in`.jphe.storyvox.feature.api.ThemeOverride
+import `in`.jphe.storyvox.feature.api.UiLlmProvider
 import `in`.jphe.storyvox.feature.api.UiSettings
 import `in`.jphe.storyvox.feature.api.UiSigil
 import `in`.jphe.storyvox.feature.api.UiVoice
 import `in`.jphe.storyvox.feature.api.VoiceProviderUi
+import `in`.jphe.storyvox.llm.LlmConfig
+import `in`.jphe.storyvox.llm.LlmRepository
+import `in`.jphe.storyvox.llm.provider.ClaudeApiProvider
+import `in`.jphe.storyvox.llm.provider.OllamaProvider
+import `in`.jphe.storyvox.llm.provider.OpenAiApiProvider
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.Flow
@@ -17,6 +23,8 @@ import kotlinx.coroutines.test.UnconfinedTestDispatcher
 import kotlinx.coroutines.test.resetMain
 import kotlinx.coroutines.test.runTest
 import kotlinx.coroutines.test.setMain
+import kotlinx.serialization.json.Json
+import okhttp3.OkHttpClient
 import org.junit.After
 import org.junit.Assert.assertEquals
 import org.junit.Before
@@ -46,7 +54,7 @@ class SettingsViewModelModesTest {
     @Test
     fun `setWarmupWait forwards to the repository`() = runTest {
         val repo = FakeSettingsRepo(initial = baseSettings(warmupWait = true, catchupPause = true))
-        val vm = SettingsViewModel(repo, FakeVoiceProvider())
+        val vm = SettingsViewModel(repo, FakeVoiceProvider(), fakeLlm())
 
         vm.setWarmupWait(false)
 
@@ -56,7 +64,7 @@ class SettingsViewModelModesTest {
     @Test
     fun `setCatchupPause forwards to the repository`() = runTest {
         val repo = FakeSettingsRepo(initial = baseSettings(warmupWait = true, catchupPause = true))
-        val vm = SettingsViewModel(repo, FakeVoiceProvider())
+        val vm = SettingsViewModel(repo, FakeVoiceProvider(), fakeLlm())
 
         vm.setCatchupPause(false)
 
@@ -66,7 +74,7 @@ class SettingsViewModelModesTest {
     @Test
     fun `viewmodel uiState surfaces both mode values`() = runTest {
         val repo = FakeSettingsRepo(initial = baseSettings(warmupWait = false, catchupPause = false))
-        val vm = SettingsViewModel(repo, FakeVoiceProvider())
+        val vm = SettingsViewModel(repo, FakeVoiceProvider(), fakeLlm())
 
         val emitted = vm.uiState.first { it.settings != null }
         assertEquals(false, emitted.settings?.warmupWait)
@@ -76,7 +84,7 @@ class SettingsViewModelModesTest {
     @Test
     fun `Mode A and Mode B writes are independent`() = runTest {
         val repo = FakeSettingsRepo(initial = baseSettings(warmupWait = true, catchupPause = true))
-        val vm = SettingsViewModel(repo, FakeVoiceProvider())
+        val vm = SettingsViewModel(repo, FakeVoiceProvider(), fakeLlm())
 
         vm.setWarmupWait(false)
         vm.setCatchupPause(false)
@@ -148,6 +156,35 @@ class SettingsViewModelModesTest {
         override suspend fun testPalaceConnection():
             `in`.jphe.storyvox.feature.api.PalaceProbeResult =
             `in`.jphe.storyvox.feature.api.PalaceProbeResult.NotConfigured
+
+        // ── AI no-ops (#81) — modes-test fixture doesn't exercise these. ──
+        override suspend fun setAiProvider(provider: UiLlmProvider?) = Unit
+        override suspend fun setClaudeApiKey(key: String?) = Unit
+        override suspend fun setClaudeModel(model: String) = Unit
+        override suspend fun setOpenAiApiKey(key: String?) = Unit
+        override suspend fun setOpenAiModel(model: String) = Unit
+        override suspend fun setOllamaBaseUrl(url: String) = Unit
+        override suspend fun setOllamaModel(model: String) = Unit
+        override suspend fun setSendChapterTextEnabled(enabled: Boolean) = Unit
+        override suspend fun acknowledgeAiPrivacy() = Unit
+        override suspend fun resetAiSettings() = Unit
+    }
+
+    /** Construct an LlmRepository with three real-but-stubbed provider
+     *  instances. The modes tests don't call any LLM methods, so we just
+     *  need an LlmRepository that doesn't blow up at construction.
+     *  Mirrors [SettingsViewModelBufferTest.fakeLlm]. */
+    private fun fakeLlm(): LlmRepository {
+        val cfg = flowOf(LlmConfig())
+        val store = `in`.jphe.storyvox.llm.LlmCredentialsStore.forTesting()
+        val http = OkHttpClient()
+        val json = Json
+        return LlmRepository(
+            configFlow = cfg,
+            claude = ClaudeApiProvider(http, store, cfg, json),
+            openAi = OpenAiApiProvider(http, store, cfg, json),
+            ollama = OllamaProvider(http, cfg, json),
+        )
     }
 
     private class FakeVoiceProvider : VoiceProviderUi {

--- a/feature/src/test/kotlin/in/jphe/storyvox/feature/settings/SettingsViewModelPunctuationPauseTest.kt
+++ b/feature/src/test/kotlin/in/jphe/storyvox/feature/settings/SettingsViewModelPunctuationPauseTest.kt
@@ -5,10 +5,16 @@ import `in`.jphe.storyvox.feature.api.PUNCTUATION_PAUSE_DEFAULT_MULTIPLIER
 import `in`.jphe.storyvox.feature.api.PUNCTUATION_PAUSE_LONG_MULTIPLIER
 import `in`.jphe.storyvox.feature.api.SettingsRepositoryUi
 import `in`.jphe.storyvox.feature.api.ThemeOverride
+import `in`.jphe.storyvox.feature.api.UiLlmProvider
 import `in`.jphe.storyvox.feature.api.UiSettings
 import `in`.jphe.storyvox.feature.api.UiSigil
 import `in`.jphe.storyvox.feature.api.UiVoice
 import `in`.jphe.storyvox.feature.api.VoiceProviderUi
+import `in`.jphe.storyvox.llm.LlmConfig
+import `in`.jphe.storyvox.llm.LlmRepository
+import `in`.jphe.storyvox.llm.provider.ClaudeApiProvider
+import `in`.jphe.storyvox.llm.provider.OllamaProvider
+import `in`.jphe.storyvox.llm.provider.OpenAiApiProvider
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.Flow
@@ -19,6 +25,8 @@ import kotlinx.coroutines.test.UnconfinedTestDispatcher
 import kotlinx.coroutines.test.resetMain
 import kotlinx.coroutines.test.runTest
 import kotlinx.coroutines.test.setMain
+import kotlinx.serialization.json.Json
+import okhttp3.OkHttpClient
 import org.junit.After
 import org.junit.Assert.assertEquals
 import org.junit.Before
@@ -50,7 +58,7 @@ class SettingsViewModelPunctuationPauseTest {
         val repo = FakeSettingsRepo(
             initial = baseSettings(multiplier = PUNCTUATION_PAUSE_DEFAULT_MULTIPLIER),
         )
-        val vm = SettingsViewModel(repo, FakeVoiceProvider())
+        val vm = SettingsViewModel(repo, FakeVoiceProvider(), fakeLlm())
 
         vm.setPunctuationPauseMultiplier(2.5f)
 
@@ -62,7 +70,7 @@ class SettingsViewModelPunctuationPauseTest {
         val repo = FakeSettingsRepo(
             initial = baseSettings(multiplier = PUNCTUATION_PAUSE_LONG_MULTIPLIER),
         )
-        val vm = SettingsViewModel(repo, FakeVoiceProvider())
+        val vm = SettingsViewModel(repo, FakeVoiceProvider(), fakeLlm())
 
         val emitted = vm.uiState.first { it.settings != null }
         assertEquals(
@@ -80,7 +88,7 @@ class SettingsViewModelPunctuationPauseTest {
         val repo = FakeSettingsRepo(
             initial = baseSettings(multiplier = PUNCTUATION_PAUSE_DEFAULT_MULTIPLIER),
         )
-        val vm = SettingsViewModel(repo, FakeVoiceProvider())
+        val vm = SettingsViewModel(repo, FakeVoiceProvider(), fakeLlm())
 
         vm.setPunctuationPauseMultiplier(3.5f)
 
@@ -146,6 +154,35 @@ class SettingsViewModelPunctuationPauseTest {
         override suspend fun testPalaceConnection():
             `in`.jphe.storyvox.feature.api.PalaceProbeResult =
             `in`.jphe.storyvox.feature.api.PalaceProbeResult.NotConfigured
+
+        // ── AI no-ops (#81) — punctuation-pause-test fixture doesn't exercise these. ──
+        override suspend fun setAiProvider(provider: UiLlmProvider?) = Unit
+        override suspend fun setClaudeApiKey(key: String?) = Unit
+        override suspend fun setClaudeModel(model: String) = Unit
+        override suspend fun setOpenAiApiKey(key: String?) = Unit
+        override suspend fun setOpenAiModel(model: String) = Unit
+        override suspend fun setOllamaBaseUrl(url: String) = Unit
+        override suspend fun setOllamaModel(model: String) = Unit
+        override suspend fun setSendChapterTextEnabled(enabled: Boolean) = Unit
+        override suspend fun acknowledgeAiPrivacy() = Unit
+        override suspend fun resetAiSettings() = Unit
+    }
+
+    /** Construct an LlmRepository with three real-but-stubbed provider
+     *  instances. The punctuation-pause tests don't call any LLM methods,
+     *  so we just need an LlmRepository that doesn't blow up at
+     *  construction. Mirrors [SettingsViewModelBufferTest.fakeLlm]. */
+    private fun fakeLlm(): LlmRepository {
+        val cfg = flowOf(LlmConfig())
+        val store = `in`.jphe.storyvox.llm.LlmCredentialsStore.forTesting()
+        val http = OkHttpClient()
+        val json = Json
+        return LlmRepository(
+            configFlow = cfg,
+            claude = ClaudeApiProvider(http, store, cfg, json),
+            openAi = OpenAiApiProvider(http, store, cfg, json),
+            ollama = OllamaProvider(http, cfg, json),
+        )
     }
 
     private class FakeVoiceProvider : VoiceProviderUi {


### PR DESCRIPTION
## Summary
- Repair :feature: + :app: test compile breakage left behind when #111 (Cassia LLM) merged in parallel with #126 (Lark palace/punctuation fix).
- Five test fakes brought back into contract-shape with the post-#111 SettingsRepositoryUi + 6-arg SettingsRepositoryUiImpl + 3-arg SettingsViewModel.

## Why
#111 widened the AI surface — 11 new SettingsRepositoryUi methods, a new \`ai: UiAiSettings\` field, an \`llm: LlmRepository\` constructor param on SettingsViewModel, and a 6th \`llmCreds: LlmCredentialsStore\` on SettingsRepositoryUiImpl. PR #126 patched the parallel collision from #79/#107 and #115/#109 but didn't carry forward the AI-side fixes, leaving \`./gradlew :feature:testDebugUnitTest\` and \`./gradlew :app:testDebugUnitTest\` failing on \`origin/main\`.

This is exactly the pattern PR #126 established for FakeSettingsRepo: mechanical mirroring of the new contract surface as no-ops, plus a \`fakeLlm()\` helper cribbed from the already-fixed SettingsViewModelBufferTest. No production code touched.

## Test plan
- [x] :feature:testDebugUnitTest green
- [x] :app:testDebugUnitTest green
- [x] :core-playback:testDebugUnitTest green
- [x] :app:assembleDebug green