### PR TITLE
feat(playback): VoxSherpa P0 knobs — pitch widen + ellipsis pause

### DIFF
--- a/app/src/main/kotlin/in/jphe/storyvox/data/SettingsRepositoryUiImpl.kt
+++ b/app/src/main/kotlin/in/jphe/storyvox/data/SettingsRepositoryUiImpl.kt
@@ -215,7 +215,13 @@ class SettingsRepositoryUiImpl(
     }
 
     override suspend fun setDefaultPitch(pitch: Float) {
-        store.edit { it[Keys.DEFAULT_PITCH] = pitch.coerceIn(0.5f, 2.0f) }
+        // Persistence band matches the UI sliders (SettingsScreen +
+        // AudiobookView). Tightened from 0.5..2.0 → 0.6..1.4 in Thalia's
+        // VoxSherpa P0 #1 (2026-05-08): below ~0.7 Sonic introduces audible
+        // artifacts on Piper-medium voices, and above 1.4 the chipmunk
+        // territory is unlistenable. Stale prefs from before the widen
+        // (which covered 0.85..1.15) all sit comfortably inside the new band.
+        store.edit { it[Keys.DEFAULT_PITCH] = pitch.coerceIn(0.6f, 1.4f) }
     }
 
     override suspend fun setDefaultVoice(voiceId: String?) {

--- a/app/src/test/kotlin/in/jphe/storyvox/data/SettingsRepositoryPitchTest.kt
+++ b/app/src/test/kotlin/in/jphe/storyvox/data/SettingsRepositoryPitchTest.kt
@@ -1,0 +1,119 @@
+package `in`.jphe.storyvox.data
+
+import androidx.datastore.core.DataStore
+import androidx.datastore.preferences.core.PreferenceDataStoreFactory
+import androidx.datastore.preferences.core.Preferences
+import java.io.File
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlinx.coroutines.test.runTest
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import org.junit.rules.TemporaryFolder
+
+/**
+ * Persistence-layer tests for the [SettingsRepositoryUiImpl.setDefaultPitch]
+ * coercion band, tightened from `0.5..2.0` to `0.6..1.4` in Thalia's
+ * VoxSherpa P0 #1 (2026-05-08).
+ *
+ * Why a coercion change is worth a test:
+ *  - The UI sliders (`SettingsScreen` + `AudiobookView`) live in the
+ *    `feature` module and can drift independently of this clamp.
+ *  - A future code path (e.g. AI-suggested defaults, voice-import) might
+ *    bypass the slider and call [setDefaultPitch] directly. The clamp is
+ *    the last line of defense before the value reaches Sonic, and below
+ *    ~0.7 Sonic introduces audible artifacts on Piper-medium voices.
+ *  - The previous wider band (0.5..2.0) lived through the 0.85..1.15
+ *    UI era — anyone with a stale persisted pitch outside the new
+ *    0.6..1.4 will be re-coerced on next write, so this test also pins
+ *    the migration semantics.
+ */
+@OptIn(ExperimentalCoroutinesApi::class)
+class SettingsRepositoryPitchTest {
+
+    @get:Rule
+    val tempFolder = TemporaryFolder()
+
+    private lateinit var scope: CoroutineScope
+    private lateinit var store: DataStore<Preferences>
+    private lateinit var repo: SettingsRepositoryUiImpl
+
+    @Before
+    fun setUp() {
+        scope = CoroutineScope(SupervisorJob() + UnconfinedTestDispatcher())
+        val file = File(tempFolder.newFolder(), "storyvox_settings.preferences_pb")
+        store = PreferenceDataStoreFactory.create(
+            scope = scope,
+            produceFile = { file },
+        )
+        repo = SettingsRepositoryUiImpl(
+            store = store,
+            auth = FakeAuth(),
+            hydrator = FakeHydrator(),
+            palaceConfig = makeFakePalaceConfig(tempFolder.newFolder("palace_ds"), scope),
+            palaceApi = makeFakePalaceApi(),
+            llmCreds = `in`.jphe.storyvox.llm.LlmCredentialsStore.forTesting(),
+        )
+    }
+
+    @After
+    fun tearDown() {
+        scope.cancel()
+    }
+
+    @Test
+    fun `default pitch is 1_0 when nothing has been persisted`() = runTest {
+        assertEquals(1.0f, repo.settings.first().defaultPitch, 0.0001f)
+    }
+
+    @Test
+    fun `setDefaultPitch persists a value within the band`() = runTest {
+        repo.setDefaultPitch(0.85f)
+        assertEquals(0.85f, repo.settings.first().defaultPitch, 0.0001f)
+
+        repo.setDefaultPitch(1.25f)
+        assertEquals(1.25f, repo.settings.first().defaultPitch, 0.0001f)
+    }
+
+    @Test
+    fun `setDefaultPitch coerces below 0_6 up to the floor`() = runTest {
+        // Thalia's hard floor — below ~0.7 Sonic on Piper-medium starts
+        // introducing audible artifacts. 0.6 is the conservative limit.
+        repo.setDefaultPitch(0.5f)
+        assertEquals(0.6f, repo.settings.first().defaultPitch, 0.0001f)
+
+        repo.setDefaultPitch(0.0f)
+        assertEquals(0.6f, repo.settings.first().defaultPitch, 0.0001f)
+
+        repo.setDefaultPitch(-1.0f)
+        assertEquals(0.6f, repo.settings.first().defaultPitch, 0.0001f)
+    }
+
+    @Test
+    fun `setDefaultPitch coerces above 1_4 down to the ceiling`() = runTest {
+        repo.setDefaultPitch(1.5f)
+        assertEquals(1.4f, repo.settings.first().defaultPitch, 0.0001f)
+
+        repo.setDefaultPitch(2.0f)
+        assertEquals(1.4f, repo.settings.first().defaultPitch, 0.0001f)
+
+        repo.setDefaultPitch(99.0f)
+        assertEquals(1.4f, repo.settings.first().defaultPitch, 0.0001f)
+    }
+
+    @Test
+    fun `setDefaultPitch accepts the band edges exactly`() = runTest {
+        repo.setDefaultPitch(0.6f)
+        assertEquals(0.6f, repo.settings.first().defaultPitch, 0.0001f)
+
+        repo.setDefaultPitch(1.4f)
+        assertEquals(1.4f, repo.settings.first().defaultPitch, 0.0001f)
+    }
+}

--- a/core-playback/src/main/kotlin/in/jphe/storyvox/playback/tts/source/EngineStreamingSource.kt
+++ b/core-playback/src/main/kotlin/in/jphe/storyvox/playback/tts/source/EngineStreamingSource.kt
@@ -210,11 +210,22 @@ internal fun trailingPauseMs(sentenceText: String): Int {
     while (end > 0 && (sentenceText[end - 1].isWhitespace() ||
             sentenceText[end - 1] in closePunct)) end--
     if (end == 0) return 60
-    if (end >= 3 && sentenceText.regionMatches(end - 3, "...", 0, 3)) return 350
+    // Ellipsis (three-dot ASCII or Unicode U+2026) gets a longer pause than
+    // a plain '.' — narrators audibly trail off on "Wait..." vs "Wait."
+    // (Thalia's VoxSherpa P0 #3, 2026-05-08; matches AudioEmotionHelper's
+    // 380 ms ellipsis bucket.)
+    if (end >= 3 && sentenceText.regionMatches(end - 3, "...", 0, 3)) return 380
     return when (sentenceText[end - 1]) {
-        '.', '!', '?', '…' -> 350
+        '…' -> 380
+        '.', '!', '?' -> 350
         ';', ':' -> 200
         ',', '—', '–', '-' -> 120
+        // Sentences ending in a closer like ')' get the closer + whitespace
+        // stripped above, so a parenthetical like "(yes)" falls through to
+        // the inner content's terminal char ('s' here → 60ms fallback).
+        // Documented behavior; if narrators want a longer parenthetical
+        // pause, that's a separate enhancement (e.g. detect outermost
+        // closer before strip).
         else -> 60
     }
 }

--- a/core-playback/src/test/kotlin/in/jphe/storyvox/playback/tts/source/EngineStreamingSourceTest.kt
+++ b/core-playback/src/test/kotlin/in/jphe/storyvox/playback/tts/source/EngineStreamingSourceTest.kt
@@ -183,6 +183,71 @@ class EngineStreamingSourceTest {
         source.close()
     }
 
+    // ── trailingPauseMs cadence table ──────────────────────────────────
+    // Thalia's VoxSherpa P0 #3 (2026-05-08): bumped the ellipsis bucket
+    // (both ASCII `...` and Unicode `…`) from 350 to 380 ms — narrators
+    // audibly trail off on ellipsis vs a plain `.`. The other terminal
+    // punctuation values are unchanged.
+
+    @Test
+    fun `trailingPauseMs gives ASCII ellipsis a longer pause than period`() {
+        // Three-dot ASCII ellipsis (the shape that lands in HTML-decoded
+        // chapter text) should hit the new 380 ms bucket, not the 350 ms
+        // period bucket.
+        assertEquals(380, trailingPauseMs("Wait..."))
+        assertEquals(380, trailingPauseMs("She paused..."))
+        // With trailing whitespace + closer — the strip loop should still
+        // surface the ellipsis underneath.
+        assertEquals(380, trailingPauseMs("\"Wait...\" "))
+    }
+
+    @Test
+    fun `trailingPauseMs gives Unicode ellipsis the ellipsis pause`() {
+        assertEquals(380, trailingPauseMs("Wait…"))
+        assertEquals(380, trailingPauseMs("\"Wait…\""))
+    }
+
+    @Test
+    fun `trailingPauseMs preserves period question and bang at 350ms`() {
+        assertEquals(350, trailingPauseMs("Wait."))
+        assertEquals(350, trailingPauseMs("Really?"))
+        assertEquals(350, trailingPauseMs("Stop!"))
+    }
+
+    @Test
+    fun `trailingPauseMs preserves semicolon and colon at 200ms`() {
+        assertEquals(200, trailingPauseMs("First;"))
+        assertEquals(200, trailingPauseMs("Then:"))
+    }
+
+    @Test
+    fun `trailingPauseMs preserves comma and dashes at 120ms`() {
+        assertEquals(120, trailingPauseMs("Wait,"))
+        assertEquals(120, trailingPauseMs("Wait—"))
+        assertEquals(120, trailingPauseMs("Wait–"))
+        assertEquals(120, trailingPauseMs("Wait-"))
+    }
+
+    @Test
+    fun `trailingPauseMs falls through to 60ms for parentheticals`() {
+        // Documented behavior — the closer-stripping loop strips trailing
+        // ')' so `(parenthetical)` is evaluated against its inner content's
+        // terminal char. Here `l` falls through to the else branch.
+        // If narrators want a longer parenthetical pause, that's a separate
+        // enhancement (detect outermost closer before strip).
+        assertEquals(60, trailingPauseMs("(parenthetical)"))
+        assertEquals(60, trailingPauseMs("[bracketed]"))
+    }
+
+    @Test
+    fun `trailingPauseMs strips closers before classifying`() {
+        // Closers + whitespace are stripped before terminal-char lookup,
+        // so a quote-wrapped sentence still gets the period bucket.
+        assertEquals(350, trailingPauseMs("\"Wait.\""))
+        assertEquals(350, trailingPauseMs("'Wait.'"))
+        assertEquals(380, trailingPauseMs("\"Wait...\" "))
+    }
+
     @Test
     fun `bufferHeadroomMs reflects queued audio duration`() = runBlocking {
         val sentences = listOf(

--- a/feature/src/main/kotlin/in/jphe/storyvox/feature/reader/AudiobookView.kt
+++ b/feature/src/main/kotlin/in/jphe/storyvox/feature/reader/AudiobookView.kt
@@ -388,9 +388,12 @@ private fun PlayerOptionsSheet(
             value = state.pitch,
             onValueChange = onSetPitch,
             onValueChangeFinished = { onPersistPitch(state.pitch) },
-            // Narration-friendly band: anything beyond ±15% sounds robotic.
-            valueRange = 0.85f..1.15f,
-            steps = 29, // 0.01 per step
+            // Narration-friendly band — matches Settings → Reading. Widened
+            // from 0.85..1.15 (Thalia's VoxSherpa P0 #1, 2026-05-08) for
+            // narrator-baritone headroom. Hard floor at 0.6 — below ~0.7
+            // Sonic introduces audible artifacts on Piper-medium voices.
+            valueRange = 0.6f..1.4f,
+            steps = 79, // 0.01 per step
         )
 
         SheetHeader("Sleep timer", null)

--- a/feature/src/main/kotlin/in/jphe/storyvox/feature/settings/SettingsScreen.kt
+++ b/feature/src/main/kotlin/in/jphe/storyvox/feature/settings/SettingsScreen.kt
@@ -91,9 +91,12 @@ fun SettingsScreen(
             value = s.defaultPitch,
             onValueChange = viewModel::setPitch,
             // Narration-friendly band — matches the in-context pitch slider
-            // in AudiobookView. Beyond ±15% TTS sounds robotic.
-            valueRange = 0.85f..1.15f,
-            steps = 29, // 0.01 per step
+            // in AudiobookView. Widened from 0.85..1.15 (Thalia's VoxSherpa
+            // P0 #1, 2026-05-08) to give listeners headroom for narrator-
+            // baritone settings. Hard floor at 0.6 — below ~0.7 Sonic starts
+            // introducing audible artifacts on Piper-medium voices.
+            valueRange = 0.6f..1.4f,
+            steps = 79, // 0.01 per step
         )
         Text("Pitch ${"%.2f".format(s.defaultPitch)}×", style = MaterialTheme.typography.bodySmall)
 


### PR DESCRIPTION
## Summary

Implements 2 of Thalia's 3 path-(A) VoxSherpa P0 knobs from
[`docs/superpowers/specs/2026-05-08-voxsherpa-knobs-research.md`](docs/superpowers/specs/2026-05-08-voxsherpa-knobs-research.md):

- **P0 #1 — Pitch range widen.** UI sliders (Settings → Reading + Player Options sheet) widened from 0.85..1.15 to 0.6..1.4. Persistence-layer `coerceIn` tightened from 0.5..2.0 to 0.6..1.4 to match the UI band — below ~0.7 Sonic introduces audible interpolation artifacts on Piper-medium voices, so the floor caps there per Thalia's risk note.
- **P0 #3 — Ellipsis pause bucket.** `EngineStreamingSource.trailingPauseMs()` lifts ASCII `...` and Unicode `…` from the 350 ms period bucket to a dedicated 380 ms bucket — narrators audibly trail off on ellipsis vs a plain period. Matches VoxSherpa's `AudioEmotionHelper` table.

Two small commits, one per knob, no version bump (orchestrator owns next bundle).

## Deferred

- **P0 #2 — Sonic.setQuality(1).** Thalia's spec called this path-(A) "Low touch", but javap-inspection of `VoxSherpa-TTS-v2.7.3.aar` confirms `VoiceEngine.generateAudioPCM` and `KokoroEngine.generateAudioPCM` accept only `(text, speed, pitch)` — there's no Sonic injection point. Setting Sonic quality requires a public setter on the engines (or an overload accepting a Sonic instance), which is a VoxSherpa upstream PR. Deferring to the same fork queue as P0 #4.
- **P0 #4 — Voice-determinism toggle.** Already deferred per orchestrator brief (needs `VoiceEngine.setNoiseScale()` setter upstream).

Quinn's notes in `~/.claude/projects/-home-jp/scratch/loose-ends-round2-2026-05-08/quinn-p0/notes.md`.

## Test plan

- [x] `./gradlew :app:assembleDebug` — green
- [x] `./gradlew :core-playback:testDebugUnitTest` — `EngineStreamingSourceTest` 12/12 pass (5 pre-existing + 7 new ellipsis/cadence cases)
- [x] `./gradlew :app:testDebugUnitTest` — `SettingsRepositoryPitchTest` 5/5 pass; existing `SettingsRepositoryBufferTest`/`ModesTest`/`PunctuationPauseTest` regress-free
- [x] `./gradlew :feature:testDebugUnitTest` — green
- [ ] Tablet install + foreground cadence smoke (orchestrator queues per ship-iterate protocol)

🤖 Generated with [Claude Code](https://claude.com/claude-code)