### PR TITLE
feat(playback): Voice Determinism toggle (Steady/Expressive) — VoxSherpa v2.7.4

### DIFF
--- a/app/src/main/kotlin/in/jphe/storyvox/data/SettingsRepositoryUiImpl.kt
+++ b/app/src/main/kotlin/in/jphe/storyvox/data/SettingsRepositoryUiImpl.kt
@@ -15,6 +15,7 @@ import `in`.jphe.storyvox.data.auth.SessionHydrator
 import `in`.jphe.storyvox.data.repository.AuthRepository
 import `in`.jphe.storyvox.data.repository.playback.PlaybackBufferConfig
 import `in`.jphe.storyvox.data.repository.playback.PlaybackModeConfig
+import `in`.jphe.storyvox.data.repository.playback.VoiceTuningConfig
 import `in`.jphe.storyvox.feature.api.BUFFER_DEFAULT_CHUNKS
 import `in`.jphe.storyvox.feature.api.BUFFER_MAX_CHUNKS
 import `in`.jphe.storyvox.feature.api.BUFFER_MIN_CHUNKS
@@ -120,6 +121,14 @@ private object Keys {
      *  behavior on mid-stream underrun; OFF lets the consumer drain through
      *  underruns without raising the "Buffering…" UI. */
     val CATCHUP_PAUSE = booleanPreferencesKey("pref_catchup_pause_v1")
+    /** Issue #85 — Voice-Determinism preset. Default true = Steady, which
+     *  preserves the pre-#85 calmed VITS defaults (0.35 / 0.667). false =
+     *  Expressive (sherpa-onnx upstream Piper defaults 0.667 / 0.8 — more
+     *  variable prosody but less reproducible). _v1 suffix matches the
+     *  versioning convention used by PLAYBACK_BUFFER_CHUNKS / WARMUP_WAIT
+     *  so we can rev defaults later without colliding with persisted v1
+     *  values. */
+    val VOICE_STEADY = booleanPreferencesKey("pref_voice_steady_v1")
 
     // ── AI / LLM (issue #81) ────────────────────────────────────────
     /** Active provider — stored as the [ProviderId] enum's name.
@@ -141,7 +150,7 @@ class SettingsRepositoryUiImpl(
     private val palaceConfig: PalaceConfigImpl,
     private val palaceApi: PalaceDaemonApi,
     private val llmCreds: LlmCredentialsStore,
-) : SettingsRepositoryUi, PlaybackBufferConfig, PlaybackModeConfig, LlmConfigProvider {
+) : SettingsRepositoryUi, PlaybackBufferConfig, PlaybackModeConfig, VoiceTuningConfig, LlmConfigProvider {
 
     /** Hilt entry point — pulls the production DataStore from the app context.
      *  The primary constructor takes the store directly so tests can swap in
@@ -177,6 +186,7 @@ class SettingsRepositoryUiImpl(
                 .coerceIn(BUFFER_MIN_CHUNKS, BUFFER_MAX_CHUNKS),
             warmupWait = prefs[Keys.WARMUP_WAIT] ?: true,
             catchupPause = prefs[Keys.CATCHUP_PAUSE] ?: true,
+            voiceSteady = prefs[Keys.VOICE_STEADY] ?: true,
             palace = UiPalaceConfig(host = palace.host, apiKey = palace.apiKey),
             ai = UiAiSettings(
                 provider = prefs[Keys.AI_PROVIDER]
@@ -260,6 +270,10 @@ class SettingsRepositoryUiImpl(
         store.edit { it[Keys.CATCHUP_PAUSE] = enabled }
     }
 
+    override suspend fun setVoiceSteady(enabled: Boolean) {
+        store.edit { it[Keys.VOICE_STEADY] = enabled }
+    }
+
     // --- PlaybackBufferConfig (consumed by core-playback's EnginePlayer) ---
 
     override val playbackBufferChunks: Flow<Int> = store.data.map { prefs ->
@@ -275,6 +289,11 @@ class SettingsRepositoryUiImpl(
     override val catchupPause: Flow<Boolean> = store.data.map { it[Keys.CATCHUP_PAUSE] ?: true }
     override suspend fun currentWarmupWait(): Boolean = warmupWait.first()
     override suspend fun currentCatchupPause(): Boolean = catchupPause.first()
+
+    // --- VoiceTuningConfig (issue #85, consumed by core-playback's EnginePlayer) ---
+
+    override val voiceSteady: Flow<Boolean> = store.data.map { it[Keys.VOICE_STEADY] ?: true }
+    override suspend fun currentVoiceSteady(): Boolean = voiceSteady.first()
 
     override suspend fun signIn() {
         // Just flips the persisted UI flag; the cookie capture is owned by

--- a/app/src/main/kotlin/in/jphe/storyvox/di/AppBindings.kt
+++ b/app/src/main/kotlin/in/jphe/storyvox/di/AppBindings.kt
@@ -17,6 +17,7 @@ import `in`.jphe.storyvox.data.repository.ChapterRepository
 import `in`.jphe.storyvox.data.repository.FictionRepository
 import `in`.jphe.storyvox.data.repository.playback.PlaybackBufferConfig
 import `in`.jphe.storyvox.data.repository.playback.PlaybackModeConfig
+import `in`.jphe.storyvox.data.repository.playback.VoiceTuningConfig
 import `in`.jphe.storyvox.data.source.WebViewFetcher
 import `in`.jphe.storyvox.data.source.model.ContentWarning
 import `in`.jphe.storyvox.data.source.model.FictionResult
@@ -133,6 +134,15 @@ object AppBindings {
      */
     @Provides @Singleton
     fun providePlaybackModeConfig(impl: SettingsRepositoryUiImpl): PlaybackModeConfig = impl
+
+    /**
+     * Issue #85 — Voice-Determinism preset for the VoxSherpa engine. Same
+     * singleton instance as [provideSettingsRepositoryUi]; consumed by
+     * `core-playback`'s EnginePlayer to dispatch
+     * `VoiceEngine.setNoiseScale[W]()` calls on flips.
+     */
+    @Provides @Singleton
+    fun provideVoiceTuningConfig(impl: SettingsRepositoryUiImpl): VoiceTuningConfig = impl
 
     /**
      * Same singleton instance as [provideSettingsRepositoryUi], exposed

--- a/app/src/test/kotlin/in/jphe/storyvox/data/SettingsRepositoryVoiceSteadyTest.kt
+++ b/app/src/test/kotlin/in/jphe/storyvox/data/SettingsRepositoryVoiceSteadyTest.kt
@@ -1,0 +1,120 @@
+package `in`.jphe.storyvox.data
+
+import androidx.datastore.core.DataStore
+import androidx.datastore.preferences.core.PreferenceDataStoreFactory
+import androidx.datastore.preferences.core.Preferences
+import java.io.File
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlinx.coroutines.test.runTest
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import org.junit.rules.TemporaryFolder
+
+/**
+ * Real-DataStore tests for the issue #85 Voice-Determinism (Steady /
+ * Expressive) preset persistence + flow surface.
+ *
+ * Same shape as [SettingsRepositoryModesTest]: spins up a temp-file
+ * DataStore so persistence is identical to production. Verifies the
+ * default preserves the calmed VITS shipping behavior (Steady = true on
+ * fresh install) and that the setter round-trips through the
+ * `UiSettings` flow + the [VoiceTuningConfig] snapshot/flow that
+ * core-playback's `EnginePlayer` collects from.
+ */
+@OptIn(ExperimentalCoroutinesApi::class)
+class SettingsRepositoryVoiceSteadyTest {
+
+    @get:Rule
+    val tempFolder = TemporaryFolder()
+
+    private lateinit var scope: CoroutineScope
+    private lateinit var store: DataStore<Preferences>
+    private lateinit var repo: SettingsRepositoryUiImpl
+
+    @Before
+    fun setUp() {
+        scope = CoroutineScope(SupervisorJob() + UnconfinedTestDispatcher())
+        val file = File(tempFolder.newFolder(), "storyvox_settings.preferences_pb")
+        store = PreferenceDataStoreFactory.create(
+            scope = scope,
+            produceFile = { file },
+        )
+        repo = SettingsRepositoryUiImpl(
+            store = store,
+            auth = FakeAuth(),
+            hydrator = FakeHydrator(),
+            palaceConfig = makeFakePalaceConfig(tempFolder.newFolder("palace_ds"), scope),
+            palaceApi = makeFakePalaceApi(),
+            // Test-only LlmCredentialsStore — voice-tuning tests don't touch
+            // AI fields; a no-op store is fine.
+            llmCreds = `in`.jphe.storyvox.llm.LlmCredentialsStore.forTesting(),
+        )
+    }
+
+    @After
+    fun tearDown() {
+        scope.cancel()
+    }
+
+    @Test
+    fun `default voice-steady is on (Steady)`() = runTest {
+        // The default-on bias preserves VoxSherpa's calmed VITS defaults
+        // (noise_scale 0.35 / 0.667). Listeners replaying chapters get
+        // identical-sounding takes.
+        assertEquals(true, repo.currentVoiceSteady())
+        assertEquals(true, repo.settings.first().voiceSteady)
+        assertEquals(true, repo.voiceSteady.first())
+    }
+
+    @Test
+    fun `setVoiceSteady false persists and re-emits on settings flow`() = runTest {
+        repo.setVoiceSteady(false)
+        assertEquals(false, repo.currentVoiceSteady())
+        assertEquals(false, repo.settings.first().voiceSteady)
+        assertEquals(false, repo.voiceSteady.first())
+    }
+
+    @Test
+    fun `setVoiceSteady round-trips both directions`() = runTest {
+        repo.setVoiceSteady(false)
+        assertEquals(false, repo.currentVoiceSteady())
+        repo.setVoiceSteady(true)
+        assertEquals(true, repo.currentVoiceSteady())
+    }
+
+    @Test
+    fun `voice-steady persists independently of warmup wait and catchup pause`() = runTest {
+        // Catches a regression where two booleans share a Preferences key
+        // (e.g. typo in Keys) — the three v1 booleans are all
+        // pref_*_v1 keys and a copy-paste mistake there would silently
+        // alias them.
+        repo.setWarmupWait(false)
+        repo.setCatchupPause(false)
+        repo.setVoiceSteady(false)
+
+        assertEquals(false, repo.currentWarmupWait())
+        assertEquals(false, repo.currentCatchupPause())
+        assertEquals(false, repo.currentVoiceSteady())
+
+        repo.setVoiceSteady(true)
+        assertEquals(false, repo.currentWarmupWait())
+        assertEquals(false, repo.currentCatchupPause())
+        assertEquals(true, repo.currentVoiceSteady())
+
+        // Sanity: the same triple surfaces on the joint settings flow.
+        val finalSettings = repo.settings.first()
+        assertEquals(false, finalSettings.warmupWait)
+        assertEquals(false, finalSettings.catchupPause)
+        assertEquals(true, finalSettings.voiceSteady)
+    }
+
+    // FakeAuth / FakeHydrator / palace fakes live in [SettingsRepositoryTestSupport].
+}

--- a/app/src/test/kotlin/in/jphe/storyvox/di/RealPlaybackControllerUiTest.kt
+++ b/app/src/test/kotlin/in/jphe/storyvox/di/RealPlaybackControllerUiTest.kt
@@ -215,6 +215,7 @@ class RealPlaybackControllerUiTest {
         override suspend fun setPlaybackBufferChunks(chunks: Int) = Unit
         override suspend fun setWarmupWait(enabled: Boolean) = Unit
         override suspend fun setCatchupPause(enabled: Boolean) = Unit
+        override suspend fun setVoiceSteady(enabled: Boolean) = Unit
         override suspend fun signIn() = Unit
         override suspend fun signOut() = Unit
         // Memory Palace stubs (#79) — playback-controller-test fixture

--- a/core-data/src/main/kotlin/in/jphe/storyvox/data/repository/playback/VoiceTuningConfig.kt
+++ b/core-data/src/main/kotlin/in/jphe/storyvox/data/repository/playback/VoiceTuningConfig.kt
@@ -1,0 +1,59 @@
+package `in`.jphe.storyvox.data.repository.playback
+
+import kotlinx.coroutines.flow.Flow
+
+/**
+ * Issue #85 — Voice-determinism preset for the VoxSherpa engine.
+ *
+ * Sibling of [PlaybackBufferConfig] / [PlaybackModeConfig]: surfaced as its
+ * own contract so `core-playback` (which owns the only consumer of the
+ * flow — the singleton VoxSherpa `VoiceEngine`) can stay free of
+ * feature-layer types. The implementation lives in `:app`'s
+ * `SettingsRepositoryUiImpl`, which already implements the other two
+ * playback configs; one DataStore, three contracts.
+ *
+ * **Steady (default, [voiceSteady] = true).** VoxSherpa's calmed VITS
+ * defaults — `noise_scale = 0.35`, `noise_scale_w = 0.667`. Identical text
+ * re-renders sound nearly identical between runs. Best for audiobook
+ * listeners replaying chapters.
+ *
+ * **Expressive ([voiceSteady] = false).** sherpa-onnx upstream's Piper
+ * defaults — `noise_scale = 0.667`, `noise_scale_w = 0.8`. Slightly more
+ * variable prosody, fuller delivery, take-to-take variation. Closer to
+ * vanilla Piper for users who find Steady's output too dry.
+ *
+ * The flow flips force a model reload on the active engine (~1-3s on
+ * Piper, ~30s on Kokoro — though Kokoro ignores noise_scale and the
+ * setter is a cheap no-op there). EnginePlayer subscribes and applies
+ * via `VoiceEngine.setNoiseScale*()`; the setter destroys + reconstructs
+ * `OfflineTts` only if the new value differs from the active config, so
+ * idempotent re-emits don't trigger spurious reloads.
+ */
+interface VoiceTuningConfig {
+
+    /** Live flow of the Voice-Determinism preset. Default `true` (Steady). */
+    val voiceSteady: Flow<Boolean>
+
+    /**
+     * Snapshot read for callers that need a single value without subscribing.
+     * Implementations should return the most recent value, falling back to
+     * the documented default (`true`) if the underlying store hasn't
+     * emitted yet.
+     */
+    suspend fun currentVoiceSteady(): Boolean
+}
+
+/**
+ * VoxSherpa's calmed VITS noise_scale (matches `VoiceEngine.DEFAULT_NOISE_SCALE`
+ * upstream). Used when [VoiceTuningConfig.voiceSteady] is `true`.
+ */
+const val NOISE_SCALE_STEADY: Float = 0.35f
+
+/** VoxSherpa's calmed VITS noise_scale_w. Used when Steady. */
+const val NOISE_SCALE_W_STEADY: Float = 0.667f
+
+/** sherpa-onnx upstream Piper default. Used when Expressive. */
+const val NOISE_SCALE_EXPRESSIVE: Float = 0.667f
+
+/** sherpa-onnx upstream Piper default. Used when Expressive. */
+const val NOISE_SCALE_W_EXPRESSIVE: Float = 0.8f

--- a/core-playback/build.gradle.kts
+++ b/core-playback/build.gradle.kts
@@ -71,7 +71,7 @@ dependencies {
     // single-module path `com.github.jphein:VoxSherpa-TTS:vX.Y.Z` (it
     // collapses multi-module configs to one root coordinate). The actual
     // AAR file at this URL is engine-lib's release artifact.
-    implementation("com.github.jphein:VoxSherpa-TTS:v2.7.3")
+    implementation("com.github.jphein:VoxSherpa-TTS:v2.7.4")
     implementation("com.github.k2-fsa:sherpa-onnx:1.12.26")
 
     // Media3 — session, player base classes

--- a/core-playback/src/main/kotlin/in/jphe/storyvox/playback/tts/EnginePlayer.kt
+++ b/core-playback/src/main/kotlin/in/jphe/storyvox/playback/tts/EnginePlayer.kt
@@ -24,9 +24,14 @@ import dagger.assisted.AssistedFactory
 import dagger.assisted.AssistedInject
 import `in`.jphe.storyvox.data.repository.ChapterRepository
 import `in`.jphe.storyvox.data.repository.PlaybackPositionRepository
+import `in`.jphe.storyvox.data.repository.playback.NOISE_SCALE_EXPRESSIVE
+import `in`.jphe.storyvox.data.repository.playback.NOISE_SCALE_STEADY
+import `in`.jphe.storyvox.data.repository.playback.NOISE_SCALE_W_EXPRESSIVE
+import `in`.jphe.storyvox.data.repository.playback.NOISE_SCALE_W_STEADY
 import `in`.jphe.storyvox.data.repository.playback.PlaybackBufferConfig
 import `in`.jphe.storyvox.data.repository.playback.PlaybackChapter
 import `in`.jphe.storyvox.data.repository.playback.PlaybackModeConfig
+import `in`.jphe.storyvox.data.repository.playback.VoiceTuningConfig
 import `in`.jphe.storyvox.playback.PlaybackError
 import `in`.jphe.storyvox.playback.PlaybackState
 import `in`.jphe.storyvox.playback.PlaybackUiEvent
@@ -97,6 +102,7 @@ class EnginePlayer @AssistedInject constructor(
     private val volumeRamp: TtsVolumeRamp,
     private val bufferConfig: PlaybackBufferConfig,
     private val modeConfig: PlaybackModeConfig,
+    private val voiceTuningConfig: VoiceTuningConfig,
 ) : SimpleBasePlayer(Looper.getMainLooper()) {
 
     @AssistedFactory
@@ -161,10 +167,28 @@ class EnginePlayer @AssistedInject constructor(
     @Volatile
     private var cachedCatchupPause: Boolean = true
 
+    /**
+     * Issue #85 — Voice-Determinism preset live cache. Mirrors the
+     * persisted DataStore Boolean (`true` = Steady, `false` = Expressive).
+     * Default `true` matches the persisted-default + the calmed VITS
+     * defaults VoxSherpa has shipped pre-#85, so a fresh install with no
+     * DataStore emission yet hits the same noise_scale values the engine
+     * defaults to (`VoiceEngine.DEFAULT_NOISE_SCALE` = 0.35).
+     *
+     * Applied to the live engine via [applyVoiceTuning] when the flow
+     * emits, NOT in the consumer/producer hot paths. Volatile because
+     * the writer is the collector coroutine on `scope` and the reader
+     * is [applyVoiceTuning] (also on `scope`); the cache is purely a
+     * "did this actually change?" gate so repeat emissions are cheap.
+     */
+    @Volatile
+    private var cachedVoiceSteady: Boolean = true
+
     init {
         observeActiveVoice()
         observeBufferConfig()
         observeModeConfig()
+        observeVoiceTuningConfig()
     }
 
     private fun observeBufferConfig() {
@@ -179,6 +203,70 @@ class EnginePlayer @AssistedInject constructor(
         scope.launch {
             modeConfig.catchupPause.collect { v ->
                 cachedCatchupPause = v
+            }
+        }
+    }
+
+    /**
+     * Issue #85 — Watches the persisted Voice-Determinism preset and
+     * applies it to the live VoxSherpa engine on every change.
+     *
+     * Each emission lands on the Main dispatcher (via `scope`'s default),
+     * but the actual setter call hops to [Dispatchers.IO] because
+     * `VoiceEngine.setNoiseScale*()` may destroy + reconstruct
+     * `OfflineTts` (a JNI sherpa-onnx call that takes ~1-3 s on Piper).
+     * We hold [engineMutex] during that work so it serializes against
+     * any in-flight `generateAudioPCM` in the producer — without it the
+     * producer's JNI generate could be running while we free `tts`,
+     * producing a SIGSEGV (the same hazard `loadModel` already handles
+     * by holding [engineMutex] in [loadAndPlay]).
+     *
+     * If no model is loaded yet, the setters still apply: VoxSherpa
+     * stores the values internally and applies them on the next
+     * `loadModel()`.
+     *
+     * Kokoro models ignore noise_scale (they're not VITS). The setters
+     * are no-ops on the Kokoro engine, but we still call them through
+     * `VoiceEngine` because `VoiceEngine` holds the cached config that
+     * applies to the next Piper voice the user picks.
+     */
+    private fun observeVoiceTuningConfig() {
+        scope.launch {
+            voiceTuningConfig.voiceSteady.collect { steady ->
+                if (cachedVoiceSteady == steady) return@collect
+                cachedVoiceSteady = steady
+                applyVoiceTuning(steady)
+            }
+        }
+    }
+
+    /**
+     * Hops to IO + holds [engineMutex] while pushing the (noise_scale,
+     * noise_scale_w) preset down to VoxSherpa's `VoiceEngine`. The setter
+     * itself decides whether a model reload is needed (no-op when the new
+     * value matches the active value, full destroy + reconstruct
+     * otherwise).
+     *
+     * The first emission on a fresh install carries the default `true`
+     * (Steady) which matches `VoiceEngine.DEFAULT_NOISE_SCALE` already —
+     * `cachedVoiceSteady` defaults to `true` and [observeVoiceTuningConfig]
+     * gates on inequality, so we never trigger a redundant first-pass
+     * reload.
+     */
+    private suspend fun applyVoiceTuning(steady: Boolean) {
+        val noiseScale = if (steady) NOISE_SCALE_STEADY else NOISE_SCALE_EXPRESSIVE
+        val noiseScaleW = if (steady) NOISE_SCALE_W_STEADY else NOISE_SCALE_W_EXPRESSIVE
+        withContext(Dispatchers.IO) {
+            engineMutex.withLock {
+                // VoiceEngine.setNoiseScale* are synchronized internally and
+                // each will reload the active model exactly once if the value
+                // changed. Calling both in sequence under engineMutex means
+                // worst-case we trigger two reloads — Piper goes 0.35→0.667
+                // then 0.667→0.8 — in practice still ≤6 s of warm-up. Could
+                // be batched into a single OfflineTts swap upstream later, but
+                // not worth the API surface in v1.
+                VoiceEngine.getInstance().setNoiseScale(noiseScale)
+                VoiceEngine.getInstance().setNoiseScaleW(noiseScaleW)
             }
         }
     }

--- a/feature/src/main/kotlin/in/jphe/storyvox/feature/api/UiContracts.kt
+++ b/feature/src/main/kotlin/in/jphe/storyvox/feature/api/UiContracts.kt
@@ -385,6 +385,22 @@ data class UiSettings(
      * but never sees the buffering spinner.
      */
     val catchupPause: Boolean = true,
+    /**
+     * Issue #85 — Voice-Determinism preset for the VoxSherpa engine. When
+     * true (default), the engine runs with VoxSherpa's calmed VITS defaults
+     * (`noise_scale = 0.35`, `noise_scale_w = 0.667`); identical text
+     * re-renders sound nearly identical, best for audiobook listeners
+     * replaying chapters. When false, the engine runs with sherpa-onnx
+     * upstream's Piper defaults (`0.667` / `0.8`); slightly more variable
+     * prosody and fuller delivery, closer to vanilla Piper.
+     *
+     * Toggling forces a model reload — ~1-3s on Piper, ~30s on Kokoro
+     * (though Kokoro ignores noise_scale and the setter is a cheap no-op
+     * there). The reload is handled in `EnginePlayer` via VoxSherpa's
+     * `VoiceEngine.setNoiseScale()` / `setNoiseScaleW()` setters
+     * (introduced in `VoxSherpa-TTS` v2.7.4).
+     */
+    val voiceSteady: Boolean = true,
     /** Memory Palace daemon config (#79). Empty host = source disabled. */
     val palace: UiPalaceConfig = UiPalaceConfig(),
 )
@@ -512,6 +528,8 @@ interface SettingsRepositoryUi {
     suspend fun setWarmupWait(enabled: Boolean)
     /** Issue #98 — Mode B toggle. See [UiSettings.catchupPause]. */
     suspend fun setCatchupPause(enabled: Boolean)
+    /** Issue #85 — Voice-Determinism preset. See [UiSettings.voiceSteady]. */
+    suspend fun setVoiceSteady(enabled: Boolean)
     suspend fun signIn()
     suspend fun signOut()
     /** Memory Palace daemon mutators (#79). */

--- a/feature/src/main/kotlin/in/jphe/storyvox/feature/settings/SettingsScreen.kt
+++ b/feature/src/main/kotlin/in/jphe/storyvox/feature/settings/SettingsScreen.kt
@@ -159,6 +159,33 @@ fun SettingsScreen(
             Switch(checked = s.catchupPause, onCheckedChange = viewModel::setCatchupPause)
         }
 
+        // Issue #85 — Voice Determinism preset. Toggle, default ON (Steady).
+        // ON  = VoxSherpa calmed VITS defaults (noise_scale 0.35 / 0.667).
+        //       Identical text re-renders sound nearly identical between runs;
+        //       best for audiobook listeners replaying chapters.
+        // OFF = sherpa-onnx upstream Piper defaults (0.667 / 0.8). Slightly
+        //       more variable prosody, fuller delivery, take-to-take variation.
+        // Flips force a model reload (~1-3s on Piper, ~30s on Kokoro). The
+        // reload is dispatched by EnginePlayer via VoxSherpa-TTS v2.7.4's
+        // VoiceEngine.setNoiseScale[W]() setters; the Settings UI itself
+        // doesn't need a spinner in v1 — the brief audible reload pause
+        // during playback is acceptable and a follow-up will polish UX.
+        Row(verticalAlignment = Alignment.CenterVertically, modifier = Modifier.fillMaxWidth()) {
+            Column(modifier = Modifier.weight(1f)) {
+                Text("Voice Determinism", style = MaterialTheme.typography.bodyMedium)
+                Text(
+                    if (s.voiceSteady) {
+                        "Steady — identical text plays the same each time."
+                    } else {
+                        "Expressive — slight variation, fuller prosody."
+                    },
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                )
+            }
+            Switch(checked = s.voiceSteady, onCheckedChange = viewModel::setVoiceSteady)
+        }
+
         // Buffer Headroom — migrated from the standalone "Audio buffer"
         // section. Same control, same #84 LMK-probe semantics.
         BufferSlider(

--- a/feature/src/main/kotlin/in/jphe/storyvox/feature/settings/SettingsViewModel.kt
+++ b/feature/src/main/kotlin/in/jphe/storyvox/feature/settings/SettingsViewModel.kt
@@ -90,6 +90,8 @@ class SettingsViewModel @Inject constructor(
     fun setWarmupWait(enabled: Boolean) = viewModelScope.launch { repo.setWarmupWait(enabled) }
     /** Issue #98 — Mode B toggle. */
     fun setCatchupPause(enabled: Boolean) = viewModelScope.launch { repo.setCatchupPause(enabled) }
+    /** Issue #85 — Voice-Determinism preset (Steady / Expressive). */
+    fun setVoiceSteady(enabled: Boolean) = viewModelScope.launch { repo.setVoiceSteady(enabled) }
     fun signIn() = viewModelScope.launch { repo.signIn() }
     fun signOut() = viewModelScope.launch { repo.signOut() }
     fun previewVoice(voice: UiVoice) = voices.previewVoice(voice)

--- a/feature/src/test/kotlin/in/jphe/storyvox/feature/settings/SettingsViewModelBufferTest.kt
+++ b/feature/src/test/kotlin/in/jphe/storyvox/feature/settings/SettingsViewModelBufferTest.kt
@@ -131,6 +131,9 @@ class SettingsViewModelBufferTest {
         override suspend fun setCatchupPause(enabled: Boolean) {
             state.value = state.value.copy(catchupPause = enabled)
         }
+        override suspend fun setVoiceSteady(enabled: Boolean) {
+            state.value = state.value.copy(voiceSteady = enabled)
+        }
         override suspend fun signIn() = Unit
         override suspend fun signOut() = Unit
         // Memory Palace stubs (#79) — buffer-test fixture doesn't exercise

--- a/feature/src/test/kotlin/in/jphe/storyvox/feature/settings/SettingsViewModelModesTest.kt
+++ b/feature/src/test/kotlin/in/jphe/storyvox/feature/settings/SettingsViewModelModesTest.kt
@@ -3,6 +3,7 @@ package `in`.jphe.storyvox.feature.settings
 import `in`.jphe.storyvox.feature.api.BUFFER_DEFAULT_CHUNKS
 import `in`.jphe.storyvox.feature.api.SettingsRepositoryUi
 import `in`.jphe.storyvox.feature.api.ThemeOverride
+import `in`.jphe.storyvox.feature.api.UiAiSettings
 import `in`.jphe.storyvox.feature.api.UiLlmProvider
 import `in`.jphe.storyvox.feature.api.UiSettings
 import `in`.jphe.storyvox.feature.api.UiSigil
@@ -31,11 +32,12 @@ import org.junit.Before
 import org.junit.Test
 
 /**
- * Verifies the issue #98 Mode A / Mode B launchers on
- * [SettingsViewModel] forward the value to the repository contract and
- * that [SettingsUiState.settings] surfaces the repository's emissions.
+ * Verifies the issue #98 Mode A / Mode B + issue #85 Voice-Determinism
+ * launchers on [SettingsViewModel] forward the value to the repository
+ * contract and that [SettingsUiState.settings] surfaces the repository's
+ * emissions.
  *
- * Mirrors [SettingsViewModelBufferTest]'s shape so the pair stays
+ * Mirrors [SettingsViewModelBufferTest]'s shape so the trio stays
  * easy to compare side-by-side.
  */
 @OptIn(ExperimentalCoroutinesApi::class)
@@ -94,7 +96,62 @@ class SettingsViewModelModesTest {
         assertEquals(listOf(false), repo.catchupPauseWrites)
     }
 
-    private fun baseSettings(warmupWait: Boolean, catchupPause: Boolean): UiSettings = UiSettings(
+    // ---- Issue #85 — Voice-Determinism preset ----
+
+    @Test
+    fun `setVoiceSteady true forwards to the repository`() = runTest {
+        val repo = FakeSettingsRepo(initial = baseSettings(voiceSteady = false))
+        val vm = SettingsViewModel(repo, FakeVoiceProvider(), fakeLlm())
+
+        vm.setVoiceSteady(true)
+
+        assertEquals(listOf(true), repo.voiceSteadyWrites)
+    }
+
+    @Test
+    fun `setVoiceSteady false forwards to the repository`() = runTest {
+        val repo = FakeSettingsRepo(initial = baseSettings(voiceSteady = true))
+        val vm = SettingsViewModel(repo, FakeVoiceProvider(), fakeLlm())
+
+        vm.setVoiceSteady(false)
+
+        assertEquals(listOf(false), repo.voiceSteadyWrites)
+    }
+
+    @Test
+    fun `viewmodel uiState surfaces voiceSteady value`() = runTest {
+        val repo = FakeSettingsRepo(initial = baseSettings(voiceSteady = false))
+        val vm = SettingsViewModel(repo, FakeVoiceProvider(), fakeLlm())
+
+        val emitted = vm.uiState.first { it.settings != null }
+        assertEquals(false, emitted.settings?.voiceSteady)
+    }
+
+    @Test
+    fun `voiceSteady and Mode toggles are independent`() = runTest {
+        // Catches a regression where copy(voiceSteady = ...) accidentally
+        // overlaps another field on UiSettings, or where the FakeSettingsRepo
+        // setters share a mutable list.
+        val repo = FakeSettingsRepo(initial = baseSettings(warmupWait = true, voiceSteady = true))
+        val vm = SettingsViewModel(repo, FakeVoiceProvider(), fakeLlm())
+
+        vm.setVoiceSteady(false)
+        vm.setWarmupWait(false)
+        vm.setVoiceSteady(true)
+
+        assertEquals(listOf(false, true), repo.voiceSteadyWrites)
+        assertEquals(listOf(false), repo.warmupWaitWrites)
+        // Final state surfaces both flips.
+        val final = vm.uiState.first { it.settings?.voiceSteady == true }.settings!!
+        assertEquals(true, final.voiceSteady)
+        assertEquals(false, final.warmupWait)
+    }
+
+    private fun baseSettings(
+        warmupWait: Boolean = true,
+        catchupPause: Boolean = true,
+        voiceSteady: Boolean = true,
+    ): UiSettings = UiSettings(
         ttsEngine = "VoxSherpa",
         defaultVoiceId = null,
         defaultSpeed = 1.0f,
@@ -107,6 +164,7 @@ class SettingsViewModelModesTest {
         playbackBufferChunks = BUFFER_DEFAULT_CHUNKS,
         warmupWait = warmupWait,
         catchupPause = catchupPause,
+        voiceSteady = voiceSteady,
     )
 
     private class FakeSettingsRepo(initial: UiSettings) : SettingsRepositoryUi {
@@ -114,6 +172,7 @@ class SettingsViewModelModesTest {
         override val settings: Flow<UiSettings> = state
         val warmupWaitWrites: MutableList<Boolean> = mutableListOf()
         val catchupPauseWrites: MutableList<Boolean> = mutableListOf()
+        val voiceSteadyWrites: MutableList<Boolean> = mutableListOf()
         override suspend fun setTheme(override: ThemeOverride) {
             state.value = state.value.copy(themeOverride = override)
         }
@@ -146,6 +205,10 @@ class SettingsViewModelModesTest {
             catchupPauseWrites += enabled
             state.value = state.value.copy(catchupPause = enabled)
         }
+        override suspend fun setVoiceSteady(enabled: Boolean) {
+            voiceSteadyWrites += enabled
+            state.value = state.value.copy(voiceSteady = enabled)
+        }
         override suspend fun signIn() = Unit
         override suspend fun signOut() = Unit
         // Memory Palace stubs (#79) — modes-test fixture doesn't exercise
@@ -170,10 +233,15 @@ class SettingsViewModelModesTest {
         override suspend fun resetAiSettings() = Unit
     }
 
-    /** Construct an LlmRepository with three real-but-stubbed provider
-     *  instances. The modes tests don't call any LLM methods, so we just
-     *  need an LlmRepository that doesn't blow up at construction.
-     *  Mirrors [SettingsViewModelBufferTest.fakeLlm]. */
+    private class FakeVoiceProvider : VoiceProviderUi {
+        override val installedVoices: Flow<List<UiVoice>> = flowOf(emptyList())
+        override fun previewVoice(voice: UiVoice) = Unit
+    }
+
+    /** Construct an LlmRepository with three real-but-stubbed
+     *  provider instances. The mode tests don't call any LLM
+     *  methods, so we just need an LlmRepository that doesn't blow
+     *  up at construction. Mirrors [SettingsViewModelBufferTest.fakeLlm]. */
     private fun fakeLlm(): LlmRepository {
         val cfg = flowOf(LlmConfig())
         val store = `in`.jphe.storyvox.llm.LlmCredentialsStore.forTesting()
@@ -185,10 +253,5 @@ class SettingsViewModelModesTest {
             openAi = OpenAiApiProvider(http, store, cfg, json),
             ollama = OllamaProvider(http, cfg, json),
         )
-    }
-
-    private class FakeVoiceProvider : VoiceProviderUi {
-        override val installedVoices: Flow<List<UiVoice>> = flowOf(emptyList())
-        override fun previewVoice(voice: UiVoice) = Unit
     }
 }

--- a/feature/src/test/kotlin/in/jphe/storyvox/feature/settings/SettingsViewModelPunctuationPauseTest.kt
+++ b/feature/src/test/kotlin/in/jphe/storyvox/feature/settings/SettingsViewModelPunctuationPauseTest.kt
@@ -144,6 +144,9 @@ class SettingsViewModelPunctuationPauseTest {
         override suspend fun setCatchupPause(enabled: Boolean) {
             state.value = state.value.copy(catchupPause = enabled)
         }
+        override suspend fun setVoiceSteady(enabled: Boolean) {
+            state.value = state.value.copy(voiceSteady = enabled)
+        }
         override suspend fun signIn() = Unit
         override suspend fun signOut() = Unit
         // Memory Palace stubs (#79) — punctuation-pause-test fixture doesn't
@@ -168,10 +171,15 @@ class SettingsViewModelPunctuationPauseTest {
         override suspend fun resetAiSettings() = Unit
     }
 
-    /** Construct an LlmRepository with three real-but-stubbed provider
-     *  instances. The punctuation-pause tests don't call any LLM methods,
-     *  so we just need an LlmRepository that doesn't blow up at
-     *  construction. Mirrors [SettingsViewModelBufferTest.fakeLlm]. */
+    private class FakeVoiceProvider : VoiceProviderUi {
+        override val installedVoices: Flow<List<UiVoice>> = flowOf(emptyList())
+        override fun previewVoice(voice: UiVoice) = Unit
+    }
+
+    /** Construct an LlmRepository with three real-but-stubbed
+     *  provider instances. The punctuation tests don't call any LLM
+     *  methods, so we just need an LlmRepository that doesn't blow up
+     *  at construction. Mirrors [SettingsViewModelBufferTest.fakeLlm]. */
     private fun fakeLlm(): LlmRepository {
         val cfg = flowOf(LlmConfig())
         val store = `in`.jphe.storyvox.llm.LlmCredentialsStore.forTesting()
@@ -183,10 +191,5 @@ class SettingsViewModelPunctuationPauseTest {
             openAi = OpenAiApiProvider(http, store, cfg, json),
             ollama = OllamaProvider(http, cfg, json),
         )
-    }
-
-    private class FakeVoiceProvider : VoiceProviderUi {
-        override val installedVoices: Flow<List<UiVoice>> = flowOf(emptyList())
-        override fun previewVoice(voice: UiVoice) = Unit
     }
 }


### PR DESCRIPTION
Closes #85.

## Summary

- Adds a Settings → Performance & buffering toggle that flips VoxSherpa's VITS sampling between **Steady** (default, calmed `noise_scale=0.35` / `noise_scale_w=0.667` — identical re-renders, best for replays) and **Expressive** (sherpa-onnx upstream `0.667` / `0.8` — fuller prosody, take-to-take variation).
- Bumps the JitPack `core-playback` dep `v2.7.3` → `v2.7.4`. The new tag adds `VoiceEngine.setNoiseScale()` / `setNoiseScaleW()` setters that destroy + reconstruct `OfflineTts` on change (~1-3 s reload on Piper; no-op on Kokoro since it's not VITS).
- New `VoiceTuningConfig` contract in `:core-data` mirrors `PlaybackBufferConfig` / `PlaybackModeConfig` — `:core-playback`'s `EnginePlayer` collects the flow and dispatches setter calls under `engineMutex` so they serialize against `generateAudioPCM` JNI calls.

## UX trade-off accepted in v1

A flip during playback triggers a brief audible reload (~1-3 s on Piper). The spec calls out an "Applying voice settings…" spinner as a follow-up; for v1 the brief pause is acceptable.

## Test plan

- [x] `:app:testDebugUnitTest` — DataStore round-trip + cross-key independence (`SettingsRepositoryVoiceSteadyTest`); pre-existing fixture repairs to Modes / PunctuationPause / RealPlaybackControllerUi tests.
- [x] `:feature:testDebugUnitTest` — ViewModel forwarding + uiState surface (`SettingsViewModelModesTest` extended).
- [x] `:core-data:testDebugUnitTest`, `:core-playback:testDebugUnitTest`, `:wear:compileDebugKotlin`, `:app:assembleDebug`.
- [ ] On-tablet: install on R83W80CAFZB, verify Steady/Expressive flip applies on next chapter; verify reload pause is audible-but-acceptable on Tab A7 Lite (Piper) vs Kokoro.

🤖 Generated with [Claude Code](https://claude.com/claude-code)