### PR TITLE
feat(source-github): Device Flow OAuth + encrypted token storage (#91 P0)

### DIFF
--- a/app/src/main/kotlin/in/jphe/storyvox/auth/github/GitHubSignInScreen.kt
+++ b/app/src/main/kotlin/in/jphe/storyvox/auth/github/GitHubSignInScreen.kt
@@ -1,0 +1,308 @@
+package `in`.jphe.storyvox.auth.github
+
+import android.content.ClipData
+import android.content.ClipboardManager
+import android.content.Context
+import android.content.Intent
+import android.net.Uri
+import android.widget.Toast
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.ArrowBack
+import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.FilledIconButton
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButtonDefaults
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.text.font.FontFamily
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import `in`.jphe.storyvox.ui.component.BrassButton
+import `in`.jphe.storyvox.ui.component.BrassButtonVariant
+import `in`.jphe.storyvox.ui.theme.LocalSpacing
+
+/**
+ * GitHub Device Flow sign-in modal (#91).
+ *
+ * Lives in `:app` so it can depend on both `:source-github` (auth surface)
+ * and `:core-ui` (BrassButton + spacing). Mirrors the placement of
+ * [`in`.jphe.storyvox.auth.AuthWebViewScreen] for the Royal Road WebView
+ * path.
+ *
+ * Flow:
+ *  1. User taps "Sign in to GitHub" → screen pushed → ViewModel.start().
+ *  2. Idle/RequestingCode show a spinner.
+ *  3. AwaitingUser shows the user code, "Open browser" button, "Copy code"
+ *     button. Polling runs in the background.
+ *  4. On success → Captured → toast → onSignedIn() pops the screen.
+ *  5. On failure / denied / expired → retry button cycles back to start().
+ */
+@Composable
+fun GitHubSignInScreen(
+    onSignedIn: () -> Unit,
+    onCancelled: () -> Unit,
+    viewModel: GitHubSignInViewModel = hiltViewModel(),
+) {
+    val state by viewModel.state.collectAsStateWithLifecycle()
+    val context = LocalContext.current
+    val spacing = LocalSpacing.current
+
+    // Kick off the device-code request when the screen appears.
+    LaunchedEffect(Unit) {
+        viewModel.start()
+    }
+
+    LaunchedEffect(state) {
+        if (state is SignInState.Captured) {
+            val login = (state as SignInState.Captured).login
+            val msg = if (login != null) "Signed in to GitHub as @$login" else "Signed in to GitHub"
+            Toast.makeText(context, msg, Toast.LENGTH_SHORT).show()
+            onSignedIn()
+        }
+    }
+
+    Scaffold { padding ->
+        Box(modifier = Modifier.fillMaxSize().padding(padding)) {
+            Column(
+                modifier = Modifier
+                    .fillMaxSize()
+                    .verticalScroll(rememberScrollState())
+                    .padding(spacing.lg),
+                verticalArrangement = Arrangement.spacedBy(spacing.md),
+            ) {
+                Text(
+                    "Sign in to GitHub",
+                    style = MaterialTheme.typography.headlineSmall,
+                    color = MaterialTheme.colorScheme.primary,
+                )
+                Text(
+                    "Sign-in lifts the unauthenticated 60 req/hr cap to 5,000 req/hr and unlocks " +
+                        "your repository readmes as fictions. We ask for the smallest scope possible: " +
+                        "read:user public_repo. We never see your password.",
+                    style = MaterialTheme.typography.bodyMedium,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                )
+                StateBody(
+                    state = state,
+                    onRetry = { viewModel.start() },
+                    onCopyCode = { code ->
+                        copyToClipboard(context, code)
+                        Toast.makeText(context, "Code copied", Toast.LENGTH_SHORT).show()
+                    },
+                    onOpenBrowser = { uri ->
+                        openInBrowser(context, uri)
+                    },
+                )
+            }
+
+            FilledIconButton(
+                onClick = {
+                    viewModel.cancel()
+                    onCancelled()
+                },
+                modifier = Modifier.align(Alignment.TopStart).padding(12.dp).size(40.dp),
+                shape = CircleShape,
+                colors = IconButtonDefaults.filledIconButtonColors(
+                    containerColor = MaterialTheme.colorScheme.primary,
+                    contentColor = MaterialTheme.colorScheme.onPrimary,
+                ),
+            ) {
+                Icon(Icons.Default.ArrowBack, contentDescription = "Cancel sign-in")
+            }
+        }
+    }
+}
+
+@Composable
+private fun StateBody(
+    state: SignInState,
+    onRetry: () -> Unit,
+    onCopyCode: (String) -> Unit,
+    onOpenBrowser: (String) -> Unit,
+) {
+    val spacing = LocalSpacing.current
+    when (state) {
+        SignInState.Idle, SignInState.RequestingCode -> {
+            Row(
+                verticalAlignment = Alignment.CenterVertically,
+                horizontalArrangement = Arrangement.spacedBy(spacing.sm),
+                modifier = Modifier.fillMaxWidth(),
+            ) {
+                CircularProgressIndicator(
+                    modifier = Modifier.size(24.dp),
+                    strokeWidth = 2.dp,
+                    color = MaterialTheme.colorScheme.primary,
+                )
+                Text("Asking GitHub for a code…", style = MaterialTheme.typography.bodyMedium)
+            }
+        }
+        is SignInState.AwaitingUser -> {
+            Text(
+                "Step 1 — Open this page in your browser",
+                style = MaterialTheme.typography.titleMedium,
+            )
+            BrassButton(
+                label = "Open github.com/login/device",
+                onClick = {
+                    onOpenBrowser(state.verificationUriComplete ?: state.verificationUri)
+                },
+                variant = BrassButtonVariant.Primary,
+            )
+            Text(
+                "Step 2 — Enter this code",
+                style = MaterialTheme.typography.titleMedium,
+            )
+            // Big monospaced code block — exact rendering of the user code
+            // is the whole point of this screen.
+            Text(
+                text = state.userCode,
+                style = MaterialTheme.typography.displaySmall.copy(
+                    fontFamily = FontFamily.Monospace,
+                    fontWeight = FontWeight.Bold,
+                    fontSize = 36.sp,
+                    letterSpacing = 4.sp,
+                ),
+                color = MaterialTheme.colorScheme.primary,
+            )
+            BrassButton(
+                label = "Copy code",
+                onClick = { onCopyCode(state.userCode) },
+                variant = BrassButtonVariant.Secondary,
+            )
+            Text(
+                "Storyvox is checking with GitHub every ${state.intervalSeconds} seconds. " +
+                    "Once you authorize in the browser, this screen will close automatically.",
+                style = MaterialTheme.typography.bodySmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
+            Row(
+                verticalAlignment = Alignment.CenterVertically,
+                horizontalArrangement = Arrangement.spacedBy(spacing.sm),
+            ) {
+                CircularProgressIndicator(
+                    modifier = Modifier.size(18.dp),
+                    strokeWidth = 2.dp,
+                    color = MaterialTheme.colorScheme.primary,
+                )
+                Text(
+                    "Waiting for confirmation…",
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                )
+            }
+        }
+        SignInState.Capturing -> {
+            Row(
+                verticalAlignment = Alignment.CenterVertically,
+                horizontalArrangement = Arrangement.spacedBy(spacing.sm),
+                modifier = Modifier.fillMaxWidth(),
+            ) {
+                CircularProgressIndicator(
+                    modifier = Modifier.size(24.dp),
+                    strokeWidth = 2.dp,
+                    color = MaterialTheme.colorScheme.primary,
+                )
+                Text("Fetching your profile…", style = MaterialTheme.typography.bodyMedium)
+            }
+        }
+        is SignInState.Captured -> {
+            // Shouldn't render — the Captured state triggers onSignedIn()
+            // via LaunchedEffect, which pops this screen. Brief defensive
+            // text in case of a race.
+            Text(
+                if (state.login != null) "Signed in as @${state.login}" else "Signed in",
+                style = MaterialTheme.typography.titleMedium,
+                color = MaterialTheme.colorScheme.primary,
+            )
+        }
+        SignInState.Denied -> {
+            Text(
+                "Sign-in cancelled.",
+                style = MaterialTheme.typography.titleMedium,
+                color = MaterialTheme.colorScheme.error,
+            )
+            Text(
+                "You declined storyvox at the GitHub authorization page. " +
+                    "Tap below to try again.",
+                style = MaterialTheme.typography.bodyMedium,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
+            BrassButton(
+                label = "Try again",
+                onClick = onRetry,
+                variant = BrassButtonVariant.Primary,
+            )
+        }
+        SignInState.Expired -> {
+            Text(
+                "Code expired",
+                style = MaterialTheme.typography.titleMedium,
+                color = MaterialTheme.colorScheme.error,
+            )
+            Text(
+                "The 8-character code is only valid for 15 minutes. Tap below to get a new one.",
+                style = MaterialTheme.typography.bodyMedium,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
+            BrassButton(
+                label = "Get a new code",
+                onClick = onRetry,
+                variant = BrassButtonVariant.Primary,
+            )
+        }
+        is SignInState.Failure -> {
+            Text(
+                "Sign-in failed",
+                style = MaterialTheme.typography.titleMedium,
+                color = MaterialTheme.colorScheme.error,
+            )
+            Text(
+                state.message,
+                style = MaterialTheme.typography.bodyMedium,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
+            if (state.retryable) {
+                BrassButton(
+                    label = "Try again",
+                    onClick = onRetry,
+                    variant = BrassButtonVariant.Primary,
+                )
+            }
+        }
+    }
+}
+
+private fun copyToClipboard(context: Context, text: String) {
+    val cm = context.getSystemService(Context.CLIPBOARD_SERVICE) as? ClipboardManager ?: return
+    cm.setPrimaryClip(ClipData.newPlainText("GitHub device code", text))
+}
+
+private fun openInBrowser(context: Context, uri: String) {
+    val intent = Intent(Intent.ACTION_VIEW, Uri.parse(uri)).apply {
+        addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
+    }
+    runCatching { context.startActivity(intent) }.onFailure {
+        Toast.makeText(context, "No browser available", Toast.LENGTH_LONG).show()
+    }
+}

--- a/app/src/main/kotlin/in/jphe/storyvox/auth/github/GitHubSignInViewModel.kt
+++ b/app/src/main/kotlin/in/jphe/storyvox/auth/github/GitHubSignInViewModel.kt
@@ -1,0 +1,263 @@
+package `in`.jphe.storyvox.auth.github
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import dagger.hilt.android.lifecycle.HiltViewModel
+import `in`.jphe.storyvox.source.github.auth.DeviceCodeResult
+import `in`.jphe.storyvox.source.github.auth.DeviceFlowApi
+import `in`.jphe.storyvox.source.github.auth.GitHubAuthConfig
+import `in`.jphe.storyvox.source.github.auth.GitHubAuthRepository
+import `in`.jphe.storyvox.source.github.auth.GitHubProfileService
+import `in`.jphe.storyvox.source.github.auth.ProfileResult
+import `in`.jphe.storyvox.source.github.auth.TokenPollResult
+import javax.inject.Inject
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.launch
+
+/**
+ * State machine for the GitHub Device Flow sign-in modal (#91).
+ *
+ * Spec § Login flow UX, lines 304-347 of
+ * `docs/superpowers/specs/2026-05-08-github-oauth-design.md`.
+ *
+ * States and transitions:
+ *
+ * ```
+ *  Idle ──[start]──▶ RequestingCode ──[ok]──▶ AwaitingUser ──[poll ok]──▶ Capturing
+ *    ▲                    │                       │                          │
+ *    │                    │                       ├─[denied]──▶ Denied       │
+ *    └────[error/back]────┴───────────────────────┴─[expired]──▶ Expired     │
+ *                                                                            ▼
+ *                                                                         Captured
+ * ```
+ *
+ * Polling cadence is RFC 8628 + GitHub-specific:
+ * - Initial interval from device-code response (typically 5s).
+ * - On `slow_down`, bump interval by +5s and continue.
+ * - On `authorization_pending`, just wait the next interval.
+ * - On `expired_token`, stop and surface "Code expired."
+ * - On `access_denied`, stop and surface "Sign-in cancelled."
+ * - On network error: silent retry once, then surface "Network error."
+ */
+@HiltViewModel
+class GitHubSignInViewModel @Inject constructor(
+    private val deviceFlow: DeviceFlowApi,
+    private val auth: GitHubAuthRepository,
+    private val profile: GitHubProfileService,
+) : ViewModel() {
+
+    private val _state = MutableStateFlow<SignInState>(SignInState.Idle)
+    val state: StateFlow<SignInState> = _state.asStateFlow()
+
+    private var pollJob: Job? = null
+
+    /** Test-only seam — production path uses the constant. */
+    internal var clientIdOverride: String? = null
+    private val clientId: String
+        get() = clientIdOverride ?: GitHubAuthConfig.DEFAULT_CLIENT_ID
+
+    fun start() {
+        if (_state.value !is SignInState.Idle && _state.value !is SignInState.Denied
+            && _state.value !is SignInState.Expired && _state.value !is SignInState.Failure
+        ) {
+            return
+        }
+        cancelPolling()
+        _state.value = SignInState.RequestingCode
+        viewModelScope.launch {
+            when (val result = deviceFlow.requestDeviceCode(
+                clientId = clientId,
+                scopes = GitHubAuthConfig.DEFAULT_SCOPES,
+            )) {
+                is DeviceCodeResult.Success -> {
+                    _state.value = SignInState.AwaitingUser(
+                        userCode = result.userCode,
+                        verificationUri = result.verificationUri,
+                        verificationUriComplete = result.verificationUriComplete,
+                        expiresInSeconds = result.expiresInSeconds,
+                        intervalSeconds = result.intervalSeconds,
+                    )
+                    startPolling(
+                        deviceCode = result.deviceCode,
+                        intervalSeconds = result.intervalSeconds,
+                        expiresInSeconds = result.expiresInSeconds,
+                    )
+                }
+                is DeviceCodeResult.GitHubError -> {
+                    _state.value = SignInState.Failure(
+                        message = describe(result),
+                        retryable = result.code != "device_flow_disabled",
+                    )
+                }
+                is DeviceCodeResult.NetworkError -> {
+                    _state.value = SignInState.Failure(
+                        message = "Network error — ${result.cause.message ?: "request failed"}",
+                        retryable = true,
+                    )
+                }
+                is DeviceCodeResult.HttpError -> {
+                    _state.value = SignInState.Failure(
+                        message = "GitHub returned HTTP ${result.code} — ${result.message}",
+                        retryable = true,
+                    )
+                }
+                is DeviceCodeResult.MalformedResponse -> {
+                    _state.value = SignInState.Failure(
+                        message = "Couldn't read GitHub's response — ${result.message}",
+                        retryable = true,
+                    )
+                }
+            }
+        }
+    }
+
+    /** User pressed back / dismissed the modal. Cancel everything in flight. */
+    fun cancel() {
+        cancelPolling()
+        _state.value = SignInState.Idle
+    }
+
+    private fun cancelPolling() {
+        pollJob?.cancel()
+        pollJob = null
+    }
+
+    private fun startPolling(
+        deviceCode: String,
+        intervalSeconds: Int,
+        expiresInSeconds: Int,
+    ) {
+        cancelPolling()
+        val deadline = System.currentTimeMillis() + expiresInSeconds * 1000L
+        var currentInterval = intervalSeconds
+        var consecutiveNetworkErrors = 0
+        pollJob = viewModelScope.launch {
+            // Wait the initial interval before the first poll — GitHub
+            // documents this; sending the first POST immediately gets us
+            // a `slow_down` on the second request.
+            delay(currentInterval * 1000L)
+            while (true) {
+                if (System.currentTimeMillis() >= deadline) {
+                    _state.value = SignInState.Expired
+                    return@launch
+                }
+                when (val r = deviceFlow.pollAccessToken(clientId, deviceCode)) {
+                    is TokenPollResult.Success -> {
+                        consecutiveNetworkErrors = 0
+                        capture(token = r.token, scopes = r.scopes)
+                        return@launch
+                    }
+                    TokenPollResult.Pending -> {
+                        consecutiveNetworkErrors = 0
+                        // continue at currentInterval
+                    }
+                    TokenPollResult.SlowDown -> {
+                        consecutiveNetworkErrors = 0
+                        // Per RFC 8628 §3.5, bump interval by 5s on slow_down.
+                        currentInterval += 5
+                    }
+                    TokenPollResult.Expired -> {
+                        _state.value = SignInState.Expired
+                        return@launch
+                    }
+                    TokenPollResult.Denied -> {
+                        _state.value = SignInState.Denied
+                        return@launch
+                    }
+                    is TokenPollResult.GitHubError -> {
+                        _state.value = SignInState.Failure(
+                            message = "GitHub error: ${r.code}${r.message?.let { " — $it" } ?: ""}",
+                            retryable = false,
+                        )
+                        return@launch
+                    }
+                    is TokenPollResult.NetworkError -> {
+                        // Silent retry once per CLAUDE.md error-recovery rule.
+                        consecutiveNetworkErrors++
+                        if (consecutiveNetworkErrors >= 2) {
+                            _state.value = SignInState.Failure(
+                                message = "Network error — ${r.cause.message ?: "polling failed"}",
+                                retryable = true,
+                            )
+                            return@launch
+                        }
+                    }
+                    is TokenPollResult.HttpError -> {
+                        _state.value = SignInState.Failure(
+                            message = "GitHub returned HTTP ${r.code} — ${r.message}",
+                            retryable = true,
+                        )
+                        return@launch
+                    }
+                    is TokenPollResult.MalformedResponse -> {
+                        _state.value = SignInState.Failure(
+                            message = "Couldn't read GitHub's response — ${r.message}",
+                            retryable = true,
+                        )
+                        return@launch
+                    }
+                }
+                delay(currentInterval * 1000L)
+            }
+        }
+    }
+
+    private suspend fun capture(token: String, scopes: String) {
+        _state.value = SignInState.Capturing
+        // Persist the token first so the auth interceptor will attach the
+        // Bearer header on the upcoming /user lookup.
+        auth.captureSession(token = token, login = null, scopes = scopes)
+        // Then resolve the @username. Failure here is non-fatal — we have
+        // a valid token and a working session, just no display login. The
+        // Settings UI tolerates a null login by falling back to "Signed in".
+        when (val p = profile.getCurrentUser()) {
+            is ProfileResult.Success -> {
+                auth.captureSession(token = token, login = p.login, scopes = scopes)
+                _state.value = SignInState.Captured(login = p.login)
+            }
+            is ProfileResult.NetworkError,
+            is ProfileResult.HttpError,
+            is ProfileResult.MalformedResponse -> {
+                _state.value = SignInState.Captured(login = null)
+            }
+        }
+    }
+
+    private fun describe(error: DeviceCodeResult.GitHubError): String = when (error.code) {
+        "device_flow_disabled" ->
+            "GitHub says Device Flow is disabled for this OAuth app. Report to JP — the app needs " +
+                "'Enable Device Flow' checked at github.com/settings/applications."
+        "incorrect_client_credentials" ->
+            "Sign-in failed: the OAuth app's client_id is wrong. " +
+                "(Has JP wired the real client_id yet? See GitHubAuthConfig.)"
+        else -> "Sign-in failed: ${error.code}${error.description?.let { " — $it" } ?: ""}"
+    }
+
+    override fun onCleared() {
+        cancelPolling()
+        super.onCleared()
+    }
+}
+
+sealed class SignInState {
+    object Idle : SignInState()
+    object RequestingCode : SignInState()
+    data class AwaitingUser(
+        val userCode: String,
+        /** Plain `https://github.com/login/device` (no code prefilled). */
+        val verificationUri: String,
+        /** Pre-filled URL `https://github.com/login/device?user_code=ABCD-1234`. */
+        val verificationUriComplete: String?,
+        val expiresInSeconds: Int,
+        val intervalSeconds: Int,
+    ) : SignInState()
+    object Capturing : SignInState()
+    data class Captured(val login: String?) : SignInState()
+    object Denied : SignInState()
+    object Expired : SignInState()
+    data class Failure(val message: String, val retryable: Boolean) : SignInState()
+}

--- a/app/src/main/kotlin/in/jphe/storyvox/data/SettingsRepositoryUiImpl.kt
+++ b/app/src/main/kotlin/in/jphe/storyvox/data/SettingsRepositoryUiImpl.kt
@@ -29,10 +29,13 @@ import `in`.jphe.storyvox.feature.api.PalaceProbeResult
 import `in`.jphe.storyvox.feature.api.SettingsRepositoryUi
 import `in`.jphe.storyvox.feature.api.ThemeOverride
 import `in`.jphe.storyvox.feature.api.UiAiSettings
+import `in`.jphe.storyvox.feature.api.UiGitHubAuthState
 import `in`.jphe.storyvox.feature.api.UiLlmProvider
 import `in`.jphe.storyvox.feature.api.UiPalaceConfig
 import `in`.jphe.storyvox.feature.api.UiSettings
 import `in`.jphe.storyvox.feature.api.UiSigil
+import `in`.jphe.storyvox.source.github.auth.GitHubAuthRepository
+import `in`.jphe.storyvox.source.github.auth.GitHubSession
 import `in`.jphe.storyvox.llm.LlmConfig
 import `in`.jphe.storyvox.llm.LlmConfigProvider
 import `in`.jphe.storyvox.llm.LlmCredentialsStore
@@ -150,6 +153,7 @@ class SettingsRepositoryUiImpl(
     private val palaceConfig: PalaceConfigImpl,
     private val palaceApi: PalaceDaemonApi,
     private val llmCreds: LlmCredentialsStore,
+    private val githubAuth: GitHubAuthRepository,
 ) : SettingsRepositoryUi, PlaybackBufferConfig, PlaybackModeConfig, VoiceTuningConfig, LlmConfigProvider {
 
     /** Hilt entry point — pulls the production DataStore from the app context.
@@ -163,12 +167,17 @@ class SettingsRepositoryUiImpl(
         palaceConfig: PalaceConfigImpl,
         palaceApi: PalaceDaemonApi,
         llmCreds: LlmCredentialsStore,
-    ) : this(context.settingsDataStore, auth, hydrator, palaceConfig, palaceApi, llmCreds)
+        githubAuth: GitHubAuthRepository,
+    ) : this(
+        context.settingsDataStore, auth, hydrator,
+        palaceConfig, palaceApi, llmCreds, githubAuth,
+    )
 
     override val settings: Flow<UiSettings> = combine(
         store.data,
         palaceConfig.state,
-    ) { prefs, palace ->
+        githubAuth.sessionState,
+    ) { prefs, palace, githubSession ->
         UiSettings(
             ttsEngine = "VoxSherpa",
             defaultVoiceId = prefs[Keys.DEFAULT_VOICE_ID],
@@ -188,6 +197,7 @@ class SettingsRepositoryUiImpl(
             catchupPause = prefs[Keys.CATCHUP_PAUSE] ?: true,
             voiceSteady = prefs[Keys.VOICE_STEADY] ?: true,
             palace = UiPalaceConfig(host = palace.host, apiKey = palace.apiKey),
+            github = githubSession.toUi(),
             ai = UiAiSettings(
                 provider = prefs[Keys.AI_PROVIDER]
                     ?.takeIf { it.isNotBlank() }
@@ -412,6 +422,17 @@ class SettingsRepositoryUiImpl(
         llmCreds.clearAll()
     }
 
+    // ── GitHub OAuth (#91) ─────────────────────────────────────────
+
+    override suspend fun signOutGitHub() {
+        // Remote revoke at github.com requires the client_secret we don't
+        // have (public client model — see GitHubAuthConfig kdoc). Local
+        // sign-out always works and clears the encrypted token + login +
+        // scopes from prefs. The Settings UI surfaces the deep-link to
+        // github.com/settings/applications for users who want full revoke.
+        githubAuth.clearSession()
+    }
+
     // ── LlmConfigProvider — bridge to :core-llm ────────────────────
 
     override val config: Flow<LlmConfig> = store.data.map { prefs ->
@@ -443,4 +464,18 @@ class SettingsRepositoryUiImpl(
             p[Keys.AI_SEND_CHAPTER_TEXT] = config.sendChapterTextEnabled
         }
     }
+}
+
+/**
+ * Source-internal [GitHubSession] → public [UiGitHubAuthState] projection.
+ * Strips the token before crossing into the feature/UI layer — Settings
+ * never needs the secret, only "are you signed in, who as." Issue #91.
+ */
+private fun GitHubSession.toUi(): UiGitHubAuthState = when (this) {
+    is GitHubSession.Anonymous -> UiGitHubAuthState.Anonymous
+    is GitHubSession.Authenticated -> UiGitHubAuthState.SignedIn(
+        login = login,
+        scopes = scopes,
+    )
+    is GitHubSession.Expired -> UiGitHubAuthState.Expired
 }

--- a/app/src/main/kotlin/in/jphe/storyvox/navigation/StoryvoxNavHost.kt
+++ b/app/src/main/kotlin/in/jphe/storyvox/navigation/StoryvoxNavHost.kt
@@ -24,6 +24,8 @@ import androidx.navigation.compose.composable
 import androidx.navigation.compose.currentBackStackEntryAsState
 import androidx.navigation.navArgument
 import `in`.jphe.storyvox.auth.AuthWebViewScreen
+import `in`.jphe.storyvox.auth.github.GitHubSignInScreen
+import `in`.jphe.storyvox.source.github.auth.GitHubAuthConfig
 import `in`.jphe.storyvox.feature.browse.BrowseScreen
 import `in`.jphe.storyvox.feature.engine.VoicePickerGate
 import `in`.jphe.storyvox.feature.fiction.FictionDetailScreen
@@ -50,6 +52,8 @@ object StoryvoxRoutes {
     const val SETTINGS_VOICE = "settings/voice"
     const val VOICE_LIBRARY = "settings/voices"
     const val AUTH_WEBVIEW = "auth/webview"
+    /** Issue #91 — GitHub Device Flow sign-in modal. */
+    const val GITHUB_SIGN_IN = "auth/github/signin"
 
     // Encode ids: GitHubSource fictionIds contain `/` (e.g. "github:owner/repo")
     // and chapterIds contain even more (e.g. "github:owner/repo:src/chapter-01.md"),
@@ -272,9 +276,26 @@ private fun StoryvoxNavHostContent(
                 popEnterTransition = homeEnter,
                 popExitTransition = homeExit,
             ) {
+                val ctx = androidx.compose.ui.platform.LocalContext.current
                 SettingsScreen(
                     onOpenVoiceLibrary = { navController.navigate(StoryvoxRoutes.VOICE_LIBRARY) },
                     onOpenSignIn = { navController.navigate(StoryvoxRoutes.AUTH_WEBVIEW) },
+                    onOpenGitHubSignIn = { navController.navigate(StoryvoxRoutes.GITHUB_SIGN_IN) },
+                    onOpenGitHubRevoke = {
+                        // Remote revoke deep-link — opens
+                        // `github.com/settings/applications` in the system
+                        // browser. Local sign-out alone leaves storyvox's
+                        // authorization recorded on GitHub's side; this is
+                        // how users tear it down fully. Issue #91.
+                        runCatching {
+                            ctx.startActivity(
+                                Intent(
+                                    Intent.ACTION_VIEW,
+                                    Uri.parse(GitHubAuthConfig.SETTINGS_APPLICATIONS_URL),
+                                ).apply { addFlags(Intent.FLAG_ACTIVITY_NEW_TASK) },
+                            )
+                        }
+                    },
                 )
             }
             composable(
@@ -307,6 +328,18 @@ private fun StoryvoxNavHostContent(
                 popExitTransition = popExit,
             ) {
                 AuthWebViewScreen(
+                    onSignedIn = { navController.popBackStack() },
+                    onCancelled = { navController.popBackStack() },
+                )
+            }
+            composable(
+                StoryvoxRoutes.GITHUB_SIGN_IN,
+                enterTransition = pushEnter,
+                exitTransition = pushExit,
+                popEnterTransition = popEnter,
+                popExitTransition = popExit,
+            ) {
+                GitHubSignInScreen(
                     onSignedIn = { navController.popBackStack() },
                     onCancelled = { navController.popBackStack() },
                 )

--- a/app/src/test/kotlin/in/jphe/storyvox/auth/github/GitHubSignInViewModelTest.kt
+++ b/app/src/test/kotlin/in/jphe/storyvox/auth/github/GitHubSignInViewModelTest.kt
@@ -1,0 +1,267 @@
+package `in`.jphe.storyvox.auth.github
+
+import `in`.jphe.storyvox.source.github.auth.DeviceCodeResult
+import `in`.jphe.storyvox.source.github.auth.DeviceFlowApi
+import `in`.jphe.storyvox.source.github.auth.GitHubAuthRepository
+import `in`.jphe.storyvox.source.github.auth.GitHubProfileService
+import `in`.jphe.storyvox.source.github.auth.GitHubSession
+import `in`.jphe.storyvox.source.github.auth.ProfileResult
+import `in`.jphe.storyvox.source.github.auth.TokenPollResult
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.advanceTimeBy
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.test.setMain
+import okhttp3.OkHttpClient
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+import java.io.IOException
+import java.util.concurrent.LinkedBlockingDeque
+
+/**
+ * State-machine tests for [GitHubSignInViewModel] — the orchestrating
+ * coroutine that drives the spec § Login flow UX state diagram. Issue #91.
+ *
+ * Stubs [DeviceFlowApi] and [GitHubProfileService] so each test enqueues
+ * the polling responses it wants and asserts the resulting state. The
+ * ViewModel uses [viewModelScope] which derives from Dispatchers.Main, so
+ * we install a [StandardTestDispatcher] on Main.
+ */
+@OptIn(ExperimentalCoroutinesApi::class)
+class GitHubSignInViewModelTest {
+
+    private val dispatcher = StandardTestDispatcher()
+
+    @Before
+    fun setUp() {
+        Dispatchers.setMain(dispatcher)
+    }
+
+    @After
+    fun tearDown() {
+        Dispatchers.resetMain()
+    }
+
+    private fun makeVm(
+        deviceFlow: DeviceFlowApi,
+        auth: GitHubAuthRepository = FakeAuth(),
+        profile: GitHubProfileService = FakeProfile(ProfileResult.Success("octocat", "Octo Cat", 1L)),
+    ): GitHubSignInViewModel = GitHubSignInViewModel(deviceFlow, auth, profile).also {
+        it.clientIdOverride = "test-client"
+    }
+
+    @Test
+    fun `successful flow transitions Idle to AwaitingUser to Captured`() = runTest(dispatcher) {
+        val flow = ScriptedDeviceFlow(
+            deviceCode = DeviceCodeResult.Success(
+                deviceCode = "dev-1",
+                userCode = "ABCD-EFGH",
+                verificationUri = "https://github.com/login/device",
+                verificationUriComplete = "https://github.com/login/device?user_code=ABCD-EFGH",
+                expiresInSeconds = 900,
+                intervalSeconds = 5,
+            ),
+            tokenPolls = arrayListOf(
+                TokenPollResult.Pending,
+                TokenPollResult.Success("gho_real", "read:user public_repo", "bearer"),
+            ),
+        )
+        val auth = FakeAuth()
+        val vm = makeVm(flow, auth)
+
+        vm.start()
+        advanceUntilIdle()
+
+        // After the device-code request resolves, we should be in AwaitingUser.
+        // (advanceUntilIdle advances through the initial-interval delay too,
+        // so we'll already have polled at least once.)
+        // Loop: 5s wait → poll #1 (Pending) → 5s wait → poll #2 (Success) → Captured.
+        assertTrue(
+            "expected Captured, got ${vm.state.value}",
+            vm.state.value is SignInState.Captured,
+        )
+        val captured = vm.state.value as SignInState.Captured
+        assertEquals("octocat", captured.login)
+        // Token persisted to repo.
+        val sess = auth.sessionState.value
+        assertTrue(sess is GitHubSession.Authenticated)
+        sess as GitHubSession.Authenticated
+        assertEquals("gho_real", sess.token)
+        assertEquals("octocat", sess.login)
+    }
+
+    @Test
+    fun `denied during polling transitions to Denied`() = runTest(dispatcher) {
+        val flow = ScriptedDeviceFlow(
+            deviceCode = DeviceCodeResult.Success(
+                deviceCode = "dev-1",
+                userCode = "ABCD-EFGH",
+                verificationUri = "https://github.com/login/device",
+                verificationUriComplete = null,
+                expiresInSeconds = 900,
+                intervalSeconds = 5,
+            ),
+            tokenPolls = arrayListOf(TokenPollResult.Denied),
+        )
+        val vm = makeVm(flow)
+        vm.start()
+        advanceUntilIdle()
+        assertEquals(SignInState.Denied, vm.state.value)
+    }
+
+    @Test
+    fun `expired during polling transitions to Expired`() = runTest(dispatcher) {
+        val flow = ScriptedDeviceFlow(
+            deviceCode = DeviceCodeResult.Success(
+                deviceCode = "dev-1",
+                userCode = "ABCD-EFGH",
+                verificationUri = "https://github.com/login/device",
+                verificationUriComplete = null,
+                expiresInSeconds = 900,
+                intervalSeconds = 5,
+            ),
+            tokenPolls = arrayListOf(TokenPollResult.Expired),
+        )
+        val vm = makeVm(flow)
+        vm.start()
+        advanceUntilIdle()
+        assertEquals(SignInState.Expired, vm.state.value)
+    }
+
+    @Test
+    fun `slow_down bumps interval but continues polling to success`() = runTest(dispatcher) {
+        val flow = ScriptedDeviceFlow(
+            deviceCode = DeviceCodeResult.Success(
+                deviceCode = "dev-1",
+                userCode = "ABCD-EFGH",
+                verificationUri = "https://github.com/login/device",
+                verificationUriComplete = null,
+                expiresInSeconds = 900,
+                intervalSeconds = 5,
+            ),
+            tokenPolls = arrayListOf(
+                TokenPollResult.SlowDown,
+                TokenPollResult.Success("gho_after_slowdown", "read:user", "bearer"),
+            ),
+        )
+        val vm = makeVm(flow)
+        vm.start()
+        advanceUntilIdle()
+        assertTrue(
+            "expected Captured after slow_down + success, got ${vm.state.value}",
+            vm.state.value is SignInState.Captured,
+        )
+    }
+
+    @Test
+    fun `device-code error surfaces as Failure`() = runTest(dispatcher) {
+        val flow = ScriptedDeviceFlow(
+            deviceCode = DeviceCodeResult.GitHubError(
+                code = "device_flow_disabled",
+                description = "Not configured",
+            ),
+            tokenPolls = arrayListOf(),
+        )
+        val vm = makeVm(flow)
+        vm.start()
+        advanceUntilIdle()
+        assertTrue("expected Failure, got ${vm.state.value}", vm.state.value is SignInState.Failure)
+        val failure = vm.state.value as SignInState.Failure
+        assertTrue(
+            "device_flow_disabled should be non-retryable",
+            !failure.retryable,
+        )
+    }
+
+    @Test
+    fun `request network error surfaces as retryable Failure`() = runTest(dispatcher) {
+        val flow = ScriptedDeviceFlow(
+            deviceCode = DeviceCodeResult.NetworkError(IOException("dns failed")),
+            tokenPolls = arrayListOf(),
+        )
+        val vm = makeVm(flow)
+        vm.start()
+        advanceUntilIdle()
+        assertTrue(vm.state.value is SignInState.Failure)
+        assertTrue((vm.state.value as SignInState.Failure).retryable)
+    }
+
+    @Test
+    fun `cancel stops polling and resets to Idle`() = runTest(dispatcher) {
+        val flow = ScriptedDeviceFlow(
+            deviceCode = DeviceCodeResult.Success(
+                deviceCode = "dev-1",
+                userCode = "ABCD-EFGH",
+                verificationUri = "https://github.com/login/device",
+                verificationUriComplete = null,
+                expiresInSeconds = 900,
+                intervalSeconds = 5,
+            ),
+            // Always pending → polling would loop forever without cancel.
+            tokenPolls = arrayListOf(TokenPollResult.Pending),
+            repeatLast = true,
+        )
+        val vm = makeVm(flow)
+        vm.start()
+        // Advance just past the initial interval so we're in AwaitingUser
+        // and have started polling.
+        advanceTimeBy(6_000)
+        assertTrue(
+            "expected AwaitingUser before cancel, got ${vm.state.value}",
+            vm.state.value is SignInState.AwaitingUser,
+        )
+        vm.cancel()
+        // No more state changes after cancel.
+        advanceTimeBy(60_000)
+        assertEquals(SignInState.Idle, vm.state.value)
+    }
+
+    // ── Test fakes ──────────────────────────────────────────────────
+
+    /**
+     * Test [DeviceFlowApi] that returns canned responses in the order they
+     * were enqueued. When [repeatLast] is true, the last enqueued response
+     * is returned for any subsequent polls (used by the cancel test to
+     * simulate "always pending").
+     */
+    private class ScriptedDeviceFlow(
+        private val deviceCode: DeviceCodeResult,
+        tokenPolls: List<TokenPollResult>,
+        private val repeatLast: Boolean = false,
+    ) : DeviceFlowApi(OkHttpClient()) {
+        private val polls = LinkedBlockingDeque(tokenPolls)
+        private var lastPoll: TokenPollResult? = null
+
+        override suspend fun requestDeviceCode(clientId: String, scopes: String): DeviceCodeResult =
+            deviceCode
+
+        override suspend fun pollAccessToken(clientId: String, deviceCode: String): TokenPollResult {
+            val next = polls.pollFirst() ?: lastPoll ?: TokenPollResult.Pending
+            lastPoll = if (repeatLast) next else null
+            return next
+        }
+    }
+
+    private class FakeAuth : GitHubAuthRepository {
+        private val state = MutableStateFlow<GitHubSession>(GitHubSession.Anonymous)
+        override val sessionState: StateFlow<GitHubSession> = state.asStateFlow()
+        override suspend fun captureSession(token: String, login: String?, scopes: String) {
+            state.value = GitHubSession.Authenticated(token, login, scopes, 0L)
+        }
+        override suspend fun clearSession() { state.value = GitHubSession.Anonymous }
+        override fun markExpired() { state.value = GitHubSession.Expired }
+    }
+
+    private class FakeProfile(private val result: ProfileResult) : GitHubProfileService(OkHttpClient()) {
+        override suspend fun getCurrentUser(): ProfileResult = result
+    }
+}

--- a/app/src/test/kotlin/in/jphe/storyvox/data/SettingsRepositoryBufferTest.kt
+++ b/app/src/test/kotlin/in/jphe/storyvox/data/SettingsRepositoryBufferTest.kt
@@ -59,6 +59,7 @@ class SettingsRepositoryBufferTest {
             // The buffer-related tests don't touch AI fields, so a
             // no-op store is fine.
             llmCreds = `in`.jphe.storyvox.llm.LlmCredentialsStore.forTesting(),
+            githubAuth = FakeGitHubAuth(),
         )
     }
 

--- a/app/src/test/kotlin/in/jphe/storyvox/data/SettingsRepositoryModesTest.kt
+++ b/app/src/test/kotlin/in/jphe/storyvox/data/SettingsRepositoryModesTest.kt
@@ -55,6 +55,7 @@ class SettingsRepositoryModesTest {
             // Test-only LlmCredentialsStore (#81) — bypasses encrypted prefs.
             // Modes tests don't touch AI fields, so a no-op store is fine.
             llmCreds = `in`.jphe.storyvox.llm.LlmCredentialsStore.forTesting(),
+            githubAuth = FakeGitHubAuth(),
         )
     }
 

--- a/app/src/test/kotlin/in/jphe/storyvox/data/SettingsRepositoryPunctuationPauseTest.kt
+++ b/app/src/test/kotlin/in/jphe/storyvox/data/SettingsRepositoryPunctuationPauseTest.kt
@@ -67,6 +67,7 @@ class SettingsRepositoryPunctuationPauseTest {
             // Test-only LlmCredentialsStore (#81) — bypasses encrypted prefs.
             // Punctuation-pause tests don't touch AI fields, so a no-op store is fine.
             llmCreds = `in`.jphe.storyvox.llm.LlmCredentialsStore.forTesting(),
+            githubAuth = FakeGitHubAuth(),
         )
     }
 

--- a/app/src/test/kotlin/in/jphe/storyvox/data/SettingsRepositoryTestSupport.kt
+++ b/app/src/test/kotlin/in/jphe/storyvox/data/SettingsRepositoryTestSupport.kt
@@ -5,6 +5,8 @@ import androidx.datastore.preferences.core.PreferenceDataStoreFactory
 import `in`.jphe.storyvox.data.auth.SessionHydrator
 import `in`.jphe.storyvox.data.auth.SessionState
 import `in`.jphe.storyvox.data.repository.AuthRepository
+import `in`.jphe.storyvox.source.github.auth.GitHubAuthRepository
+import `in`.jphe.storyvox.source.github.auth.GitHubSession
 import `in`.jphe.storyvox.source.mempalace.config.PalaceConfig
 import `in`.jphe.storyvox.source.mempalace.config.PalaceConfigState
 import `in`.jphe.storyvox.source.mempalace.net.PalaceDaemonApi
@@ -49,6 +51,24 @@ internal class FakeAuth : AuthRepository {
 internal class FakeHydrator : SessionHydrator {
     override fun hydrate(cookies: Map<String, String>) = Unit
     override fun clear() = Unit
+}
+
+/**
+ * In-memory [GitHubAuthRepository] for the settings tests. The buffer
+ * / modes / pause tests don't exercise GitHub auth but the constructor
+ * needs *some* binding since #91. Mirrors [FakeAuth]'s shape — start
+ * Anonymous, allow capture/clear to flip the state flow synchronously.
+ */
+internal class FakeGitHubAuth : GitHubAuthRepository {
+    private val state = MutableStateFlow<GitHubSession>(GitHubSession.Anonymous)
+    override val sessionState: StateFlow<GitHubSession> = state.asStateFlow()
+    override suspend fun captureSession(token: String, login: String?, scopes: String) {
+        state.value = GitHubSession.Authenticated(
+            token = token, login = login, scopes = scopes, grantedAt = 0L,
+        )
+    }
+    override suspend fun clearSession() { state.value = GitHubSession.Anonymous }
+    override fun markExpired() { state.value = GitHubSession.Expired }
 }
 
 /**

--- a/app/src/test/kotlin/in/jphe/storyvox/di/RealPlaybackControllerUiTest.kt
+++ b/app/src/test/kotlin/in/jphe/storyvox/di/RealPlaybackControllerUiTest.kt
@@ -239,6 +239,8 @@ class RealPlaybackControllerUiTest {
         override suspend fun setSendChapterTextEnabled(enabled: Boolean) = Unit
         override suspend fun acknowledgeAiPrivacy() = Unit
         override suspend fun resetAiSettings() = Unit
+        // ── GitHub OAuth no-op (#91) — playback-controller test doesn't auth. ──
+        override suspend fun signOutGitHub() = Unit
     }
 
     /** Chapter repo never invoked by the speed/pitch path under test. */

--- a/feature/src/main/kotlin/in/jphe/storyvox/feature/api/UiContracts.kt
+++ b/feature/src/main/kotlin/in/jphe/storyvox/feature/api/UiContracts.kt
@@ -403,7 +403,30 @@ data class UiSettings(
     val voiceSteady: Boolean = true,
     /** Memory Palace daemon config (#79). Empty host = source disabled. */
     val palace: UiPalaceConfig = UiPalaceConfig(),
+    /**
+     * GitHub OAuth session surface (#91). Drives the Sources → GitHub
+     * row in Settings. The token itself is never exposed to the UI —
+     * only the login + state. See [UiGitHubAuthState].
+     */
+    val github: UiGitHubAuthState = UiGitHubAuthState.Anonymous,
 )
+
+/**
+ * UI projection of the GitHub OAuth session (#91). The Settings row
+ * needs to know "are you signed in, who as, do you need to re-auth"
+ * — never the token string itself, which stays inside :source-github's
+ * `GitHubAuthRepository`.
+ */
+sealed class UiGitHubAuthState {
+    object Anonymous : UiGitHubAuthState()
+    data class SignedIn(val login: String?, val scopes: String) : UiGitHubAuthState()
+    /**
+     * Token at github.com is gone (revoked, rotated). Disk copy intact;
+     * settings row shows "Session expired — sign in again" + the same
+     * sign-in CTA as [Anonymous].
+     */
+    object Expired : UiGitHubAuthState()
+}
 
 /**
  * UI projection of the MemPalace daemon connection config. The
@@ -558,6 +581,15 @@ interface SettingsRepositoryUi {
     suspend fun acknowledgeAiPrivacy()
     /** Wipe all AI configuration — provider/keys/URLs. */
     suspend fun resetAiSettings()
+
+    // ── GitHub OAuth (#91) ─────────────────────────────────────────
+    /**
+     * Local sign-out from GitHub. Clears the encrypted token + identity
+     * metadata. Remote revoke at github.com requires the client_secret
+     * we don't have — Settings UI deep-links the user to
+     * `github.com/settings/applications` if they want to revoke fully.
+     */
+    suspend fun signOutGitHub()
 }
 
 /** Outcome of [`SettingsRepositoryUi.testPalaceConnection`]. */

--- a/feature/src/main/kotlin/in/jphe/storyvox/feature/settings/SettingsScreen.kt
+++ b/feature/src/main/kotlin/in/jphe/storyvox/feature/settings/SettingsScreen.kt
@@ -51,6 +51,7 @@ import `in`.jphe.storyvox.feature.api.PUNCTUATION_PAUSE_OFF_MULTIPLIER
 import `in`.jphe.storyvox.feature.api.PalaceProbeResult
 import `in`.jphe.storyvox.feature.api.ThemeOverride
 import `in`.jphe.storyvox.feature.api.UiAiSettings
+import `in`.jphe.storyvox.feature.api.UiGitHubAuthState
 import `in`.jphe.storyvox.feature.api.UiLlmProvider
 import `in`.jphe.storyvox.feature.api.UiPalaceConfig
 import `in`.jphe.storyvox.ui.component.BrassButton
@@ -62,6 +63,8 @@ import kotlinx.coroutines.delay
 fun SettingsScreen(
     onOpenVoiceLibrary: () -> Unit,
     onOpenSignIn: () -> Unit,
+    onOpenGitHubSignIn: () -> Unit,
+    onOpenGitHubRevoke: () -> Unit = {},
     viewModel: SettingsViewModel = hiltViewModel(),
 ) {
     val state by viewModel.uiState.collectAsStateWithLifecycle()
@@ -247,9 +250,24 @@ fun SettingsScreen(
         )
 
         Divider()
-        SectionHeader("Account")
+        SectionHeader("Sources")
+        // Royal Road row — preserves the v0.4.x "Account" surface, just
+        // labelled per-source so GitHub can sit beside it. Issue #91.
+        Text("Royal Road", style = MaterialTheme.typography.titleSmall)
         if (s.isSignedIn) {
-            BrassButton(label = "Sign out", onClick = viewModel::signOut, variant = BrassButtonVariant.Secondary)
+            Row(verticalAlignment = Alignment.CenterVertically) {
+                Text(
+                    "Signed in",
+                    style = MaterialTheme.typography.bodyMedium,
+                    color = MaterialTheme.colorScheme.primary,
+                    modifier = Modifier.weight(1f),
+                )
+                BrassButton(
+                    label = "Sign out",
+                    onClick = viewModel::signOut,
+                    variant = BrassButtonVariant.Secondary,
+                )
+            }
         } else {
             BrassButton(
                 label = "Sign in",
@@ -262,6 +280,16 @@ fun SettingsScreen(
                 color = MaterialTheme.colorScheme.onSurfaceVariant,
             )
         }
+
+        // GitHub row (#91). Always shown — sign-in is additive (lifts the
+        // anonymous 60 req/hr cap to 5,000 req/hr) so it's useful even
+        // before the user has any GitHub fictions in their library.
+        GitHubSignInRow(
+            state = s.github,
+            onSignIn = onOpenGitHubSignIn,
+            onSignOut = viewModel::signOutGitHub,
+            onOpenRevokePage = onOpenGitHubRevoke,
+        )
 
         Divider()
         MemoryPalaceSection(
@@ -307,6 +335,90 @@ fun SettingsScreen(
 @Composable
 private fun SectionHeader(label: String) {
     Text(label, style = MaterialTheme.typography.titleMedium, color = MaterialTheme.colorScheme.primary)
+}
+
+/**
+ * Sources → GitHub row. Issue #91.
+ *
+ * Three states matching [UiGitHubAuthState]:
+ *  - Anonymous → "Sign in to GitHub" CTA + scope explainer.
+ *  - SignedIn → "Signed in as @login" + Sign-out button + revoke deep-link.
+ *  - Expired → "Session expired — sign in again" CTA + same revoke link.
+ *
+ * Spec § Settings UI surface, lines 384-395 of the design doc.
+ */
+@Composable
+private fun GitHubSignInRow(
+    state: UiGitHubAuthState,
+    onSignIn: () -> Unit,
+    onSignOut: () -> Unit,
+    onOpenRevokePage: () -> Unit,
+) {
+    val spacing = LocalSpacing.current
+    Text(
+        "GitHub",
+        style = MaterialTheme.typography.titleSmall,
+        modifier = Modifier.padding(top = spacing.sm),
+    )
+    when (state) {
+        UiGitHubAuthState.Anonymous -> {
+            BrassButton(
+                label = "Sign in to GitHub",
+                onClick = onSignIn,
+                variant = BrassButtonVariant.Primary,
+            )
+            Text(
+                "Lifts the anonymous 60 req/hr cap to 5,000 req/hr and unlocks your repository " +
+                    "readmes as fictions. We ask for read:user public_repo only — never write " +
+                    "access, never private repos by default.",
+                style = MaterialTheme.typography.bodySmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
+        }
+        is UiGitHubAuthState.SignedIn -> {
+            Row(verticalAlignment = Alignment.CenterVertically) {
+                Text(
+                    text = state.login?.let { "Signed in as @$it" } ?: "Signed in",
+                    style = MaterialTheme.typography.bodyMedium,
+                    color = MaterialTheme.colorScheme.primary,
+                    modifier = Modifier.weight(1f),
+                )
+                BrassButton(
+                    label = "Sign out",
+                    onClick = onSignOut,
+                    variant = BrassButtonVariant.Secondary,
+                )
+            }
+            Text(
+                text = "Granted scope: ${state.scopes}",
+                style = MaterialTheme.typography.bodySmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
+            BrassButton(
+                label = "Revoke at github.com…",
+                onClick = onOpenRevokePage,
+                variant = BrassButtonVariant.Text,
+            )
+            Text(
+                "Sign-out clears the token from this device. To remove storyvox's authorization " +
+                    "on GitHub's side, use the link above.",
+                style = MaterialTheme.typography.bodySmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
+        }
+        UiGitHubAuthState.Expired -> {
+            Text(
+                "Session expired — sign in again to recover.",
+                style = MaterialTheme.typography.bodyMedium,
+                color = MaterialTheme.colorScheme.error,
+            )
+            BrassButton(
+                label = "Sign in to GitHub",
+                onClick = onSignIn,
+                variant = BrassButtonVariant.Primary,
+            )
+        }
+    }
 }
 
 /**

--- a/feature/src/main/kotlin/in/jphe/storyvox/feature/settings/SettingsViewModel.kt
+++ b/feature/src/main/kotlin/in/jphe/storyvox/feature/settings/SettingsViewModel.kt
@@ -94,6 +94,8 @@ class SettingsViewModel @Inject constructor(
     fun setVoiceSteady(enabled: Boolean) = viewModelScope.launch { repo.setVoiceSteady(enabled) }
     fun signIn() = viewModelScope.launch { repo.signIn() }
     fun signOut() = viewModelScope.launch { repo.signOut() }
+    /** GitHub OAuth (#91) — local sign-out. Remote revoke deep-links to github.com. */
+    fun signOutGitHub() = viewModelScope.launch { repo.signOutGitHub() }
     fun previewVoice(voice: UiVoice) = voices.previewVoice(voice)
 
     // ─── Memory Palace (#79) ────────────────────────────────────────────

--- a/feature/src/test/kotlin/in/jphe/storyvox/feature/settings/SettingsViewModelBufferTest.kt
+++ b/feature/src/test/kotlin/in/jphe/storyvox/feature/settings/SettingsViewModelBufferTest.kt
@@ -156,6 +156,7 @@ class SettingsViewModelBufferTest {
         override suspend fun setSendChapterTextEnabled(enabled: Boolean) = Unit
         override suspend fun acknowledgeAiPrivacy() = Unit
         override suspend fun resetAiSettings() = Unit
+        override suspend fun signOutGitHub() = Unit
     }
 
     /** Construct an LlmRepository with three real-but-stubbed

--- a/feature/src/test/kotlin/in/jphe/storyvox/feature/settings/SettingsViewModelModesTest.kt
+++ b/feature/src/test/kotlin/in/jphe/storyvox/feature/settings/SettingsViewModelModesTest.kt
@@ -231,6 +231,7 @@ class SettingsViewModelModesTest {
         override suspend fun setSendChapterTextEnabled(enabled: Boolean) = Unit
         override suspend fun acknowledgeAiPrivacy() = Unit
         override suspend fun resetAiSettings() = Unit
+        override suspend fun signOutGitHub() = Unit
     }
 
     private class FakeVoiceProvider : VoiceProviderUi {

--- a/feature/src/test/kotlin/in/jphe/storyvox/feature/settings/SettingsViewModelPunctuationPauseTest.kt
+++ b/feature/src/test/kotlin/in/jphe/storyvox/feature/settings/SettingsViewModelPunctuationPauseTest.kt
@@ -169,6 +169,7 @@ class SettingsViewModelPunctuationPauseTest {
         override suspend fun setSendChapterTextEnabled(enabled: Boolean) = Unit
         override suspend fun acknowledgeAiPrivacy() = Unit
         override suspend fun resetAiSettings() = Unit
+        override suspend fun signOutGitHub() = Unit
     }
 
     private class FakeVoiceProvider : VoiceProviderUi {

--- a/source-github/build.gradle.kts
+++ b/source-github/build.gradle.kts
@@ -37,4 +37,10 @@ dependencies {
     ksp(libs.hilt.compiler)
 
     testImplementation(libs.junit)
+    testImplementation(libs.kotlinx.coroutines.test)
+    // MockWebServer for DeviceFlowApi + GitHubAuthInterceptor tests (#91).
+    // Pinned to the same OkHttp version that production uses; mirrors the
+    // pattern in :core-llm where the LLM provider tests pull mockwebserver
+    // explicitly because the base okhttp dep is implementation-scoped.
+    testImplementation("com.squareup.okhttp3:mockwebserver:4.12.0")
 }

--- a/source-github/src/main/kotlin/in/jphe/storyvox/source/github/auth/DeviceFlowApi.kt
+++ b/source-github/src/main/kotlin/in/jphe/storyvox/source/github/auth/DeviceFlowApi.kt
@@ -1,0 +1,294 @@
+package `in`.jphe.storyvox.source.github.auth
+
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.suspendCancellableCoroutine
+import kotlinx.coroutines.withContext
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.json.Json
+import okhttp3.Call
+import okhttp3.Callback
+import okhttp3.FormBody
+import okhttp3.OkHttpClient
+import okhttp3.Request
+import okhttp3.Response
+import java.io.IOException
+import javax.inject.Inject
+import javax.inject.Singleton
+import kotlin.coroutines.resume
+import kotlin.coroutines.resumeWithException
+
+/**
+ * GitHub Device Flow client (RFC 8628 + GitHub-specific extensions).
+ *
+ * Issue #91. Spec: docs/superpowers/specs/2026-05-08-github-oauth-design.md
+ *
+ * Two endpoints, both on the **website** domain (not `api.github.com`):
+ *
+ * - `POST https://github.com/login/device/code` — request a device + user
+ *   code. Returns `verification_uri`, `user_code`, `device_code`,
+ *   `expires_in` (typically 900s), `interval` (typically 5s).
+ * - `POST https://github.com/login/oauth/access_token` — poll for the
+ *   access token. Returns either `{access_token, scope, token_type}` or
+ *   `{error}`. Errors during polling: `authorization_pending`, `slow_down`,
+ *   `expired_token`, `access_denied`, plus a few bug-class errors.
+ *
+ * Why not auto-poll inside this class: polling state — the current
+ * interval, the `expires_in` deadline, cancellation on user back-press —
+ * lives in the ViewModel where the UI state machine sees it. This class
+ * exposes the raw HTTP wrappers; [GitHubSignInViewModel] owns the
+ * `slow_down` / `authorization_pending` / `expired_token` orchestration.
+ *
+ * Construction: pass a *vanilla* [OkHttpClient] (no auth interceptor) —
+ * the device-code and access-token endpoints take only `client_id` in
+ * the form body, never an Authorization header. Re-using the GitHub-
+ * source's authed client would attach a Bearer header that GitHub's
+ * device-code endpoint ignores at best, rejects at worst.
+ */
+@Singleton
+open class DeviceFlowApi @Inject constructor(
+    private val httpClient: OkHttpClient,
+) {
+
+    /**
+     * Override hook for tests. Production uses [GitHubAuthConfig.DEVICE_CODE_URL].
+     */
+    open val deviceCodeUrl: String = GitHubAuthConfig.DEVICE_CODE_URL
+    open val accessTokenUrl: String = GitHubAuthConfig.ACCESS_TOKEN_URL
+
+    /**
+     * Step 1 — request a device + user code.
+     *
+     * Returns [DeviceCodeResult.Success] with the user-visible code on a
+     * 200, or one of the error variants on transport / GitHub failure.
+     *
+     * `open` so JVM unit tests in `:app` can override with canned results
+     * without a MockWebServer.
+     */
+    open suspend fun requestDeviceCode(
+        clientId: String,
+        scopes: String,
+    ): DeviceCodeResult = withContext(Dispatchers.IO) {
+        val body = FormBody.Builder()
+            .add("client_id", clientId)
+            .add("scope", scopes)
+            .build()
+        val req = Request.Builder()
+            .url(deviceCodeUrl)
+            .post(body)
+            .header("Accept", "application/json")
+            .header("User-Agent", USER_AGENT)
+            .build()
+        val response = try {
+            httpClient.newCall(req).await()
+        } catch (e: IOException) {
+            return@withContext DeviceCodeResult.NetworkError(e)
+        }
+        response.use { r ->
+            if (!r.isSuccessful) {
+                return@use DeviceCodeResult.HttpError(r.code, r.message)
+            }
+            val raw = r.body?.string().orEmpty()
+            try {
+                val parsed = JSON.decodeFromString(DeviceCodeResponse.serializer(), raw)
+                if (parsed.error != null) {
+                    return@use DeviceCodeResult.GitHubError(parsed.error, parsed.errorDescription)
+                }
+                DeviceCodeResult.Success(
+                    deviceCode = parsed.deviceCode
+                        ?: return@use DeviceCodeResult.MalformedResponse("missing device_code"),
+                    userCode = parsed.userCode
+                        ?: return@use DeviceCodeResult.MalformedResponse("missing user_code"),
+                    verificationUri = parsed.verificationUri
+                        ?: GitHubAuthConfig.VERIFICATION_URL,
+                    verificationUriComplete = parsed.verificationUriComplete,
+                    expiresInSeconds = parsed.expiresIn ?: 900,
+                    intervalSeconds = parsed.interval ?: 5,
+                )
+            } catch (e: Throwable) {
+                DeviceCodeResult.MalformedResponse(e.message ?: "parse failed")
+            }
+        }
+    }
+
+    /**
+     * Step 2 — single poll for the access token. The caller is responsible
+     * for the polling cadence (interval, slow_down handling, expires_in
+     * cap, cancellation).
+     *
+     * Returns:
+     * - [TokenPollResult.Success] with the access token + granted scope,
+     * - [TokenPollResult.Pending] for `authorization_pending` (caller polls again),
+     * - [TokenPollResult.SlowDown] for `slow_down` (caller bumps interval +5s),
+     * - [TokenPollResult.Expired] for `expired_token` (user too slow; restart),
+     * - [TokenPollResult.Denied] for `access_denied` (user cancelled in browser),
+     * - [TokenPollResult.GitHubError] for any other GitHub error code,
+     * - [TokenPollResult.NetworkError] / [TokenPollResult.HttpError] / [TokenPollResult.MalformedResponse].
+     */
+    open suspend fun pollAccessToken(
+        clientId: String,
+        deviceCode: String,
+    ): TokenPollResult = withContext(Dispatchers.IO) {
+        val body = FormBody.Builder()
+            .add("client_id", clientId)
+            .add("device_code", deviceCode)
+            .add("grant_type", DEVICE_CODE_GRANT)
+            .build()
+        val req = Request.Builder()
+            .url(accessTokenUrl)
+            .post(body)
+            .header("Accept", "application/json")
+            .header("User-Agent", USER_AGENT)
+            .build()
+        val response = try {
+            httpClient.newCall(req).await()
+        } catch (e: IOException) {
+            return@withContext TokenPollResult.NetworkError(e)
+        }
+        response.use { r ->
+            // Note: GitHub returns HTTP 200 with `{error: "..."}` for
+            // *every* polling-state error (authorization_pending, slow_down,
+            // expired_token, access_denied, unsupported_grant_type, etc.) —
+            // it's only HTTP-non-200 if the request itself was malformed.
+            // So we parse the body before checking response.code.
+            val raw = r.body?.string().orEmpty()
+            val parsed = try {
+                JSON.decodeFromString(AccessTokenResponse.serializer(), raw)
+            } catch (e: Throwable) {
+                return@use if (r.isSuccessful) {
+                    TokenPollResult.MalformedResponse(e.message ?: "parse failed")
+                } else {
+                    TokenPollResult.HttpError(r.code, r.message)
+                }
+            }
+            when {
+                parsed.accessToken != null -> TokenPollResult.Success(
+                    token = parsed.accessToken,
+                    scopes = parsed.scope.orEmpty(),
+                    tokenType = parsed.tokenType.orEmpty(),
+                )
+                parsed.error == "authorization_pending" -> TokenPollResult.Pending
+                parsed.error == "slow_down" -> TokenPollResult.SlowDown
+                parsed.error == "expired_token" -> TokenPollResult.Expired
+                parsed.error == "access_denied" -> TokenPollResult.Denied
+                parsed.error != null -> TokenPollResult.GitHubError(
+                    code = parsed.error,
+                    message = parsed.errorDescription,
+                )
+                else -> TokenPollResult.MalformedResponse(
+                    "no access_token and no error in response",
+                )
+            }
+        }
+    }
+
+    @Serializable
+    private data class DeviceCodeResponse(
+        @SerialName("device_code") val deviceCode: String? = null,
+        @SerialName("user_code") val userCode: String? = null,
+        @SerialName("verification_uri") val verificationUri: String? = null,
+        @SerialName("verification_uri_complete") val verificationUriComplete: String? = null,
+        @SerialName("expires_in") val expiresIn: Int? = null,
+        @SerialName("interval") val interval: Int? = null,
+        // GitHub returns `error` even on the device-code endpoint when the
+        // client_id is wrong / the OAuth app doesn't have Device Flow enabled.
+        val error: String? = null,
+        @SerialName("error_description") val errorDescription: String? = null,
+    )
+
+    @Serializable
+    private data class AccessTokenResponse(
+        @SerialName("access_token") val accessToken: String? = null,
+        val scope: String? = null,
+        @SerialName("token_type") val tokenType: String? = null,
+        val error: String? = null,
+        @SerialName("error_description") val errorDescription: String? = null,
+    )
+
+    companion object {
+        const val DEVICE_CODE_GRANT: String = "urn:ietf:params:oauth:grant-type:device_code"
+        const val USER_AGENT: String = "storyvox/0.4 (+https://github.com/jphein/storyvox)"
+        // ignoreUnknownKeys: GitHub freely adds new fields; don't break on them.
+        // explicitNulls = false: keeps the wire format permissive on optional values.
+        private val JSON: Json = Json {
+            ignoreUnknownKeys = true
+            explicitNulls = false
+        }
+    }
+}
+
+/** Outcome of [DeviceFlowApi.requestDeviceCode]. */
+sealed class DeviceCodeResult {
+    data class Success(
+        val deviceCode: String,
+        val userCode: String,
+        val verificationUri: String,
+        val verificationUriComplete: String?,
+        val expiresInSeconds: Int,
+        val intervalSeconds: Int,
+    ) : DeviceCodeResult()
+    /** Request never reached GitHub (DNS, TLS, dropped connection, ...). */
+    data class NetworkError(val cause: Throwable) : DeviceCodeResult()
+    /** GitHub answered with a non-2xx HTTP status. */
+    data class HttpError(val code: Int, val message: String) : DeviceCodeResult()
+    /**
+     * GitHub answered 200 but the JSON body carried an `error` field —
+     * typically `device_flow_disabled` (OAuth app misconfigured) or a
+     * client_id format error.
+     */
+    data class GitHubError(val code: String, val description: String?) : DeviceCodeResult()
+    /** 200 OK but the body was missing required fields or didn't parse. */
+    data class MalformedResponse(val message: String) : DeviceCodeResult()
+}
+
+/** Outcome of [DeviceFlowApi.pollAccessToken]. */
+sealed class TokenPollResult {
+    data class Success(
+        val token: String,
+        /** Space-separated list of granted scopes (may differ from requested). */
+        val scopes: String,
+        val tokenType: String,
+    ) : TokenPollResult()
+
+    /** User hasn't confirmed in the browser yet. Caller polls again at the same interval. */
+    data object Pending : TokenPollResult()
+
+    /** GitHub thinks we're polling too fast. Caller bumps interval by +5s and retries. */
+    data object SlowDown : TokenPollResult()
+
+    /** Device code expired (>900s since issuance). Caller restarts the flow with a fresh code. */
+    data object Expired : TokenPollResult()
+
+    /** User clicked "Cancel" / "Deny" in the browser. Caller surfaces the cancellation. */
+    data object Denied : TokenPollResult()
+
+    /**
+     * Catch-all for other GitHub-issued errors. [code] examples:
+     * `unsupported_grant_type`, `incorrect_client_credentials`,
+     * `incorrect_device_code`, `device_flow_disabled`. None are recoverable
+     * by polling; they all bubble up as a generic "Sign-in failed" with a
+     * report path.
+     */
+    data class GitHubError(val code: String, val message: String?) : TokenPollResult()
+
+    data class NetworkError(val cause: Throwable) : TokenPollResult()
+    data class HttpError(val code: Int, val message: String) : TokenPollResult()
+    data class MalformedResponse(val message: String) : TokenPollResult()
+}
+
+/** Suspending bridge over OkHttp's enqueue → callback API. */
+private suspend fun Call.await(): Response = suspendCancellableCoroutine { cont ->
+    enqueue(object : Callback {
+        override fun onResponse(call: Call, response: Response) {
+            cont.resume(response)
+        }
+
+        override fun onFailure(call: Call, e: IOException) {
+            if (cont.isCancelled) return
+            cont.resumeWithException(e)
+        }
+    })
+    cont.invokeOnCancellation {
+        runCatching { cancel() }
+    }
+}

--- a/source-github/src/main/kotlin/in/jphe/storyvox/source/github/auth/GitHubAuthConfig.kt
+++ b/source-github/src/main/kotlin/in/jphe/storyvox/source/github/auth/GitHubAuthConfig.kt
@@ -1,0 +1,73 @@
+package `in`.jphe.storyvox.source.github.auth
+
+/**
+ * Static OAuth-app config for storyvox's GitHub Device Flow integration.
+ *
+ * Issue #91. Spec: docs/superpowers/specs/2026-05-08-github-oauth-design.md
+ *
+ * ## TODO(client_id) — JP must register the OAuth app
+ *
+ * The Device Flow is a *public-client* flow: only `client_id` is sent to
+ * GitHub, never a `client_secret`. The `client_id` ships in every APK by
+ * design (no secrecy), so a hardcoded constant here is the right shape —
+ * this is a **deliberate exception** to CLAUDE.md's Vaultwarden rule, which
+ * applies to actual secrets.
+ *
+ * Steps for JP after this PR merges (per Ember's spec § Open Question #1):
+ *
+ * 1. Visit https://github.com/settings/applications/new
+ * 2. Name: `storyvox`
+ * 3. Homepage: `https://github.com/jphein/storyvox`
+ * 4. Authorization callback URL: `https://github.com/jphein/storyvox`
+ *    (unused for Device Flow but the form requires *something*)
+ * 5. **Check "Enable Device Flow"** — without this the `/login/device/code`
+ *    endpoint returns `device_flow_disabled`.
+ * 6. Save → copy the resulting 20-character `client_id`.
+ * 7. Replace [DEFAULT_CLIENT_ID] below with the real value, OR wire it via
+ *    `local.properties` → `BuildConfig.GITHUB_CLIENT_ID` (cleaner; matches
+ *    realm-sigil's Gradle pattern).
+ *
+ * Until then, sign-in attempts will hit a hardcoded placeholder and fail
+ * with `incorrect_client_credentials`. The auth substrate (token storage,
+ * interceptor, polling, UI) is fully wired and tested — only the live
+ * sign-in path needs the real id.
+ */
+object GitHubAuthConfig {
+
+    /**
+     * Placeholder. **Not a real GitHub OAuth app id.** See class kdoc for
+     * how JP wires the real value.
+     *
+     * Format check: real GitHub `client_id`s are 20 lowercase hex chars
+     * (e.g. `Iv1.b507a08c87ecfe98` for GitHub Apps; OAuth-App ids are
+     * shorter). Anything other than the placeholder will be tried verbatim
+     * against `https://github.com/login/device/code`.
+     */
+    const val DEFAULT_CLIENT_ID: String = "TODO_JP_REGISTER_OAUTH_APP"
+
+    /**
+     * Default scopes requested at sign-in. Spec § Scope minimization:
+     * least-privilege default. `repo` (private) and `gist` are deferred
+     * to opt-in toggles in future PRs.
+     */
+    const val DEFAULT_SCOPES: String = "read:user public_repo"
+
+    /** Device Flow endpoints live on the *website* domain, not api.github.com. */
+    const val DEVICE_CODE_URL: String = "https://github.com/login/device/code"
+    const val ACCESS_TOKEN_URL: String = "https://github.com/login/oauth/access_token"
+
+    /**
+     * Browser-friendly verification URL. The device-code response also
+     * carries a `verification_uri_complete` that pre-fills the user's
+     * code via query param; the modal prefers that when present and falls
+     * back to this constant.
+     */
+    const val VERIFICATION_URL: String = "https://github.com/login/device"
+
+    /**
+     * Where to send users to revoke storyvox's token on github.com.
+     * Local sign-out always succeeds; remote revoke requires the
+     * client_secret we don't have, so we deep-link instead.
+     */
+    const val SETTINGS_APPLICATIONS_URL: String = "https://github.com/settings/applications"
+}

--- a/source-github/src/main/kotlin/in/jphe/storyvox/source/github/auth/GitHubAuthInterceptor.kt
+++ b/source-github/src/main/kotlin/in/jphe/storyvox/source/github/auth/GitHubAuthInterceptor.kt
@@ -1,0 +1,64 @@
+package `in`.jphe.storyvox.source.github.auth
+
+import okhttp3.Interceptor
+import okhttp3.Response
+import javax.inject.Inject
+
+/**
+ * OkHttp interceptor that attaches `Authorization: Bearer <token>` to
+ * outgoing GitHub API requests when a session is captured.
+ *
+ * Issue #91. Spec: docs/superpowers/specs/2026-05-08-github-oauth-design.md
+ *
+ * Properties:
+ * - **Anonymous fallback** — if the in-memory session is [GitHubSession.Anonymous]
+ *   or [GitHubSession.Expired], the request goes out unauthenticated.
+ *   Existing 60 req/hr handling in `GitHubApi.mapResponse` keeps working.
+ * - **Host pinning** — the header attaches *only* when `req.url.host ==
+ *   api.github.com`. Redirects to `raw.githubusercontent.com` or any
+ *   other host see a clean request without the token. Defends against
+ *   token leaks via redirect.
+ * - **401 → Expired** — when GitHub answers 401, the in-memory session
+ *   flips to [GitHubSession.Expired] (disk copy intact, so Settings can
+ *   show "Session expired" instead of silently losing identity). The 401
+ *   response itself is returned to the caller so `GitHubApi.mapResponse`
+ *   classifies it as `HttpError(401, …)`.
+ *
+ * Construction note: the interceptor reads `auth.sessionState.value`
+ * synchronously on every call. That's a `StateFlow` `.value` access — a
+ * volatile field read, no suspension, no IO. Cheaper than a SharedPreferences
+ * lookup per request, which is why [GitHubAuthRepository] keeps the in-
+ * memory copy in the first place.
+ */
+internal class GitHubAuthInterceptor @Inject constructor(
+    private val auth: GitHubAuthRepository,
+) : Interceptor {
+
+    override fun intercept(chain: Interceptor.Chain): Response {
+        val req = chain.request()
+        if (req.url.host != API_HOST) {
+            return chain.proceed(req)
+        }
+        val session = auth.sessionState.value
+        val token = (session as? GitHubSession.Authenticated)?.token
+        val outgoing = if (token != null) {
+            req.newBuilder()
+                .header("Authorization", "Bearer $token")
+                .build()
+        } else {
+            req
+        }
+        val response = chain.proceed(outgoing)
+        // 401 only matters if we *sent* a token — an unauthenticated 401
+        // from GitHub is technically possible (rate-limit on a private
+        // endpoint, etc.) but doesn't represent token expiry on our end.
+        if (token != null && response.code == 401) {
+            auth.markExpired()
+        }
+        return response
+    }
+
+    private companion object {
+        const val API_HOST: String = "api.github.com"
+    }
+}

--- a/source-github/src/main/kotlin/in/jphe/storyvox/source/github/auth/GitHubAuthRepository.kt
+++ b/source-github/src/main/kotlin/in/jphe/storyvox/source/github/auth/GitHubAuthRepository.kt
@@ -1,0 +1,147 @@
+package `in`.jphe.storyvox.source.github.auth
+
+import android.content.SharedPreferences
+import androidx.core.content.edit
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
+import javax.inject.Inject
+import javax.inject.Singleton
+
+/**
+ * Owns the GitHub OAuth access token + identity metadata.
+ *
+ * Issue #91. Spec: docs/superpowers/specs/2026-05-08-github-oauth-design.md
+ *
+ * Persistence: keys live in the same `EncryptedSharedPreferences`
+ * instance (`storyvox.secrets`) that holds the Royal Road cookie. Tink-
+ * backed AES-256-GCM value encryption keyed by the Android keystore
+ * master key. No new prefs file, no new MasterKey — same threat model as
+ * the existing RR cookie.
+ *
+ * Single token per app instance (no multi-account in v1). Hydration on
+ * construction mirrors `AuthRepositoryImpl`'s pattern: read disk in the
+ * `init` block so the in-memory [StateFlow] is hot before the first
+ * outbound API call.
+ *
+ * **Why a parallel impl** (vs folding into `:core-data`'s
+ * `AuthRepository`): the spec calls out a "PR Auth-A — multi-source
+ * `AuthRepository` refactor" as a prerequisite. Sky's brief is "single
+ * PR, P0 only," so the cross-source refactor is deferred. GitHub auth
+ * stands beside the RR auth here; a future PR can fold both into the
+ * `SourceAuth` interface from the spec.
+ */
+interface GitHubAuthRepository {
+
+    /** Hot stream of the session state. Hydrated from disk on construction. */
+    val sessionState: StateFlow<GitHubSession>
+
+    /** Persist a freshly-issued token + identity. Transitions → [GitHubSession.Authenticated]. */
+    suspend fun captureSession(
+        token: String,
+        login: String?,
+        scopes: String,
+    )
+
+    /** Forget everything. Transitions → [GitHubSession.Anonymous]. */
+    suspend fun clearSession()
+
+    /**
+     * Token at github.com is gone (revoked, rotated, deleted OAuth app).
+     * Disk copy is left intact so Settings can show "Session expired —
+     * sign in again." The interceptor calls this on a 401 response.
+     */
+    fun markExpired()
+}
+
+@Singleton
+internal class GitHubAuthRepositoryImpl @Inject constructor(
+    private val prefs: SharedPreferences,
+) : GitHubAuthRepository {
+
+    private val state = MutableStateFlow<GitHubSession>(GitHubSession.Anonymous)
+    override val sessionState: StateFlow<GitHubSession> = state.asStateFlow()
+
+    init {
+        // Hydrate from disk before any caller can touch the StateFlow. Hilt
+        // creates this on the singleton component, and this is the single
+        // place where blocking IO on the prefs file is acceptable — the
+        // construction path runs before any coroutine consumes the flow.
+        val token = prefs.getString(KEY_TOKEN, null)
+        val login = prefs.getString(KEY_LOGIN, null)
+        val scopes = prefs.getString(KEY_SCOPES, null) ?: GitHubAuthConfig.DEFAULT_SCOPES
+        val grantedAt = prefs.getString(KEY_GRANTED_AT, null)?.toLongOrNull() ?: 0L
+        if (token != null) {
+            state.value = GitHubSession.Authenticated(
+                token = token,
+                login = login,
+                scopes = scopes,
+                grantedAt = grantedAt,
+            )
+        }
+    }
+
+    override suspend fun captureSession(
+        token: String,
+        login: String?,
+        scopes: String,
+    ) = withContext(Dispatchers.IO) {
+        val now = System.currentTimeMillis()
+        prefs.edit {
+            putString(KEY_TOKEN, token)
+            // Allow null/blank login to coexist with re-captures that happen
+            // before the GET /user lookup completes. Settings UI tolerates
+            // a null login by falling back to "Signed in".
+            if (login != null) putString(KEY_LOGIN, login) else remove(KEY_LOGIN)
+            putString(KEY_SCOPES, scopes)
+            putString(KEY_GRANTED_AT, now.toString())
+        }
+        state.value = GitHubSession.Authenticated(
+            token = token,
+            login = login,
+            scopes = scopes,
+            grantedAt = now,
+        )
+    }
+
+    override suspend fun clearSession() = withContext(Dispatchers.IO) {
+        prefs.edit {
+            remove(KEY_TOKEN)
+            remove(KEY_LOGIN)
+            remove(KEY_SCOPES)
+            remove(KEY_GRANTED_AT)
+        }
+        state.value = GitHubSession.Anonymous
+    }
+
+    override fun markExpired() {
+        // Called from the interceptor on a 401 — synchronous on the OkHttp
+        // dispatcher thread, so we can't suspend here. The on-disk copy
+        // stays intact so the next captureSession() restores cleanly. The
+        // in-memory state flips so the interceptor stops attaching the
+        // dead token to subsequent requests.
+        if (state.value is GitHubSession.Expired) return
+        state.value = GitHubSession.Expired
+        // Best-effort fan-out so background machinery (Settings, etc.)
+        // doesn't keep showing "signed in" when the token's actually dead.
+        // Doesn't await: the StateFlow update above is the source of truth.
+        CoroutineScope(Dispatchers.IO).launch {
+            // No-op other than yielding to ensure subscribers wake up.
+            state.value = GitHubSession.Expired
+        }
+    }
+
+    companion object {
+        // Per-source key namespace: `<kind>:<sourceId>`. Mirrors the
+        // existing `cookie:royalroad` shape so future multi-source auth
+        // refactors don't need a data migration.
+        const val KEY_TOKEN = "token:github"
+        const val KEY_LOGIN = "token:github:login"
+        const val KEY_SCOPES = "token:github:scopes"
+        const val KEY_GRANTED_AT = "token:github:granted_at"
+    }
+}

--- a/source-github/src/main/kotlin/in/jphe/storyvox/source/github/auth/GitHubProfileService.kt
+++ b/source-github/src/main/kotlin/in/jphe/storyvox/source/github/auth/GitHubProfileService.kt
@@ -1,0 +1,114 @@
+package `in`.jphe.storyvox.source.github.auth
+
+import `in`.jphe.storyvox.source.github.di.GitHubHttp
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.suspendCancellableCoroutine
+import kotlinx.coroutines.withContext
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.json.Json
+import okhttp3.Call
+import okhttp3.Callback
+import okhttp3.OkHttpClient
+import okhttp3.Request
+import okhttp3.Response
+import java.io.IOException
+import javax.inject.Inject
+import javax.inject.Singleton
+import kotlin.coroutines.resume
+import kotlin.coroutines.resumeWithException
+
+/**
+ * Tiny client for `GET https://api.github.com/user`. Used post-token to
+ * resolve the signed-in `@username` for the Settings UI display row.
+ *
+ * Issue #91. Spec: docs/superpowers/specs/2026-05-08-github-oauth-design.md
+ *
+ * Why a separate class (vs. extending `GitHubApi`): `GitHubApi` is
+ * `internal` and its result type is `GitHubApiResult<T>` which is also
+ * `internal` to the source module. The sign-in ViewModel lives in the
+ * `:app` module and can't see internal types. This is a minimal public
+ * facade — same authed OkHttp client (the [GitHubHttp]-qualified one
+ * with the auth interceptor wired in), but a public result type.
+ */
+@Singleton
+open class GitHubProfileService @Inject constructor(
+    @GitHubHttp private val httpClient: OkHttpClient,
+) {
+
+    /**
+     * Fetch the signed-in user's login + display name. Caller must have
+     * already captured a token in [GitHubAuthRepository] — the auth
+     * interceptor reads from there to attach the Bearer header.
+     *
+     * `open` so JVM unit tests can override with a canned [ProfileResult]
+     * without spinning up a MockWebServer. Same pattern that
+     * `GitHubApi`'s production methods use.
+     */
+    open suspend fun getCurrentUser(): ProfileResult = withContext(Dispatchers.IO) {
+        val req = Request.Builder()
+            .url(USER_URL)
+            .header("Accept", "application/vnd.github+json")
+            .header("X-GitHub-Api-Version", API_VERSION)
+            .header("User-Agent", USER_AGENT)
+            .build()
+        val response = try {
+            httpClient.newCall(req).await()
+        } catch (e: IOException) {
+            return@withContext ProfileResult.NetworkError(e)
+        }
+        response.use { r ->
+            if (!r.isSuccessful) {
+                return@use ProfileResult.HttpError(r.code, r.message)
+            }
+            val raw = r.body?.string().orEmpty()
+            try {
+                val parsed = JSON.decodeFromString(GhUser.serializer(), raw)
+                ProfileResult.Success(login = parsed.login, name = parsed.name, id = parsed.id)
+            } catch (e: Throwable) {
+                ProfileResult.MalformedResponse(e.message ?: "parse failed")
+            }
+        }
+    }
+
+    @Serializable
+    private data class GhUser(
+        val login: String,
+        val id: Long,
+        val name: String? = null,
+    )
+
+    private companion object {
+        const val USER_URL: String = "https://api.github.com/user"
+        const val API_VERSION: String = "2022-11-28"
+        const val USER_AGENT: String = "storyvox/0.4 (+https://github.com/jphein/storyvox)"
+        val JSON: Json = Json {
+            ignoreUnknownKeys = true
+            explicitNulls = false
+        }
+    }
+}
+
+sealed class ProfileResult {
+    data class Success(val login: String, val name: String?, val id: Long) : ProfileResult()
+    data class NetworkError(val cause: Throwable) : ProfileResult()
+    data class HttpError(val code: Int, val message: String) : ProfileResult()
+    data class MalformedResponse(val message: String) : ProfileResult()
+}
+
+/** Suspending bridge over OkHttp's enqueue → callback API. */
+private suspend fun Call.await(): Response = suspendCancellableCoroutine { cont ->
+    enqueue(object : Callback {
+        override fun onResponse(call: Call, response: Response) {
+            cont.resume(response)
+        }
+
+        override fun onFailure(call: Call, e: IOException) {
+            if (cont.isCancelled) return
+            cont.resumeWithException(e)
+        }
+    })
+    cont.invokeOnCancellation {
+        runCatching { cancel() }
+    }
+}

--- a/source-github/src/main/kotlin/in/jphe/storyvox/source/github/auth/GitHubSession.kt
+++ b/source-github/src/main/kotlin/in/jphe/storyvox/source/github/auth/GitHubSession.kt
@@ -1,0 +1,46 @@
+package `in`.jphe.storyvox.source.github.auth
+
+/**
+ * Tri-state GitHub session for the Sources → GitHub Settings row + the
+ * OkHttp [GitHubAuthInterceptor].
+ *
+ * Mirrors `:core-data`'s [`in`.jphe.storyvox.data.auth.SessionState] but
+ * lives next to the GitHub-specific auth code so the source module
+ * doesn't depend on the cross-source RR-shaped contract during P0. A
+ * future "PR Auth-A" refactor (per Ember's spec § Multi-source
+ * `AuthRepository`) can fold this into the cross-source `SourceAuth`
+ * interface without behavioural change.
+ */
+sealed interface GitHubSession {
+    /** No token on disk; calls go out unauthenticated (60 req/hr). */
+    data object Anonymous : GitHubSession
+
+    /** Token in memory + on disk. Calls bear `Authorization: Bearer ...`. */
+    data class Authenticated(
+        val token: String,
+        val login: String?,
+        val scopes: String,
+        val grantedAt: Long,
+    ) : GitHubSession
+
+    /**
+     * Token rejected by api.github.com (401). The encrypted-prefs copy is
+     * left intact so Settings can show "Session expired — sign in again"
+     * rather than silently losing the user's identity. Re-auth via
+     * [GitHubAuthRepository.captureSession] transitions back to
+     * [Authenticated].
+     */
+    data object Expired : GitHubSession
+
+    /**
+     * Public-facing identity surface for `:feature` / `:app` UI without
+     * exposing the raw token. Settings only needs login + state; never
+     * the token string itself. Mirrors `SessionState`'s shape but
+     * scrubs the secret.
+     */
+    val displayLogin: String?
+        get() = (this as? Authenticated)?.login
+
+    val isAuthenticated: Boolean
+        get() = this is Authenticated
+}

--- a/source-github/src/main/kotlin/in/jphe/storyvox/source/github/di/GitHubModule.kt
+++ b/source-github/src/main/kotlin/in/jphe/storyvox/source/github/di/GitHubModule.kt
@@ -10,6 +10,10 @@ import dagger.multibindings.StringKey
 import `in`.jphe.storyvox.data.source.FictionSource
 import `in`.jphe.storyvox.data.source.SourceIds
 import `in`.jphe.storyvox.source.github.GitHubSource
+import `in`.jphe.storyvox.source.github.auth.DeviceFlowApi
+import `in`.jphe.storyvox.source.github.auth.GitHubAuthInterceptor
+import `in`.jphe.storyvox.source.github.auth.GitHubAuthRepository
+import `in`.jphe.storyvox.source.github.auth.GitHubAuthRepositoryImpl
 import okhttp3.OkHttpClient
 import javax.inject.Qualifier
 import javax.inject.Singleton
@@ -19,9 +23,25 @@ import javax.inject.Singleton
 internal annotation class GitHubHttp
 
 /**
+ * Unauthenticated OkHttpClient for the Device Flow endpoints
+ * (`github.com/login/device/code` + `github.com/login/oauth/access_token`).
+ * Distinct from [GitHubHttp] so the auth interceptor doesn't fire on
+ * the token-issuing endpoints — which take only `client_id` in the form
+ * body and have nothing to authenticate against. Issue #91.
+ */
+@Qualifier
+@Retention(AnnotationRetention.BINARY)
+internal annotation class GitHubDeviceFlowHttp
+
+/**
  * Provides the OkHttpClient used by [`in`.jphe.storyvox.source.github
  * .net.GitHubApi]. Qualified [GitHubHttp] so it doesn't collide with
  * the unqualified app-wide client (or the @RoyalRoadHttp one).
+ *
+ * Issue #91 wired the [GitHubAuthInterceptor] in here so authed REST
+ * calls automatically attach `Authorization: Bearer <token>` when a
+ * session exists. The interceptor pins to `api.github.com` only — see
+ * [GitHubAuthInterceptor] for the host-leak defense.
  */
 @Module
 @InstallIn(SingletonComponent::class)
@@ -30,12 +50,40 @@ internal object GitHubHttpModule {
     @Provides
     @Singleton
     @GitHubHttp
-    fun provideClient(): OkHttpClient =
+    fun provideClient(authInterceptor: GitHubAuthInterceptor): OkHttpClient =
+        OkHttpClient.Builder()
+            .addInterceptor(authInterceptor)
+            .followRedirects(true)
+            .followSslRedirects(true)
+            .retryOnConnectionFailure(true)
+            .build()
+
+    /**
+     * No-auth client for the Device Flow `github.com/login/...` endpoints.
+     * The auth interceptor is intentionally absent: we have no token yet
+     * (we're requesting one), and the device-code endpoint takes only
+     * `client_id` + `scope` in the form body.
+     */
+    @Provides
+    @Singleton
+    @GitHubDeviceFlowHttp
+    fun provideDeviceFlowClient(): OkHttpClient =
         OkHttpClient.Builder()
             .followRedirects(true)
             .followSslRedirects(true)
             .retryOnConnectionFailure(true)
             .build()
+
+    /**
+     * The DeviceFlowApi takes a vanilla [OkHttpClient] in its constructor.
+     * Hilt resolves the `@GitHubDeviceFlowHttp`-qualified one here so the
+     * `@Inject` constructor doesn't need a qualifier annotation (which
+     * Kotlin makes verbose for `@Inject constructor` parameters).
+     */
+    @Provides
+    @Singleton
+    fun provideDeviceFlowApi(@GitHubDeviceFlowHttp http: OkHttpClient): DeviceFlowApi =
+        DeviceFlowApi(http)
 }
 
 /**
@@ -45,6 +93,10 @@ internal object GitHubHttpModule {
  * `UrlRouter` returns sourceId="github", `FictionRepository.addByUrl`
  * looks up `sources[SourceIds.GITHUB]`, and `GitHubSource
  * .fictionDetail` resolves the manifest + chapters.
+ *
+ * Issue #91 added the [GitHubAuthRepository] binding alongside, so
+ * `:feature` and `:app` can inject the GitHub session state for the
+ * Settings UI sign-in row.
  */
 @Module
 @InstallIn(SingletonComponent::class)
@@ -55,4 +107,8 @@ internal abstract class GitHubBindings {
     @IntoMap
     @StringKey(SourceIds.GITHUB)
     abstract fun bindFictionSource(impl: GitHubSource): FictionSource
+
+    @Binds
+    @Singleton
+    abstract fun bindGitHubAuthRepository(impl: GitHubAuthRepositoryImpl): GitHubAuthRepository
 }

--- a/source-github/src/test/kotlin/in/jphe/storyvox/source/github/auth/DeviceFlowApiTest.kt
+++ b/source-github/src/test/kotlin/in/jphe/storyvox/source/github/auth/DeviceFlowApiTest.kt
@@ -1,0 +1,219 @@
+package `in`.jphe.storyvox.source.github.auth
+
+import kotlinx.coroutines.test.runTest
+import okhttp3.OkHttpClient
+import okhttp3.mockwebserver.MockResponse
+import okhttp3.mockwebserver.MockWebServer
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+import java.util.concurrent.TimeUnit
+
+/**
+ * Unit tests for [DeviceFlowApi] — RFC 8628 + GitHub-specific behaviors.
+ *
+ * Issue #91. Drives a real OkHttpClient against MockWebServer so the
+ * wire format (form-encoded POST body, JSON response parsing, error
+ * branch dispatch) is exactly what production sees on github.com.
+ */
+class DeviceFlowApiTest {
+
+    private lateinit var server: MockWebServer
+    private lateinit var http: OkHttpClient
+
+    @Before
+    fun setUp() {
+        server = MockWebServer()
+        server.start()
+        http = OkHttpClient.Builder()
+            .readTimeout(2, TimeUnit.SECONDS)
+            .build()
+    }
+
+    @After
+    fun tearDown() {
+        server.shutdown()
+    }
+
+    private fun apiPointingAt(path: String): DeviceFlowApi {
+        val base = server.url(path).toString()
+        return object : DeviceFlowApi(http) {
+            override val deviceCodeUrl: String = base
+            override val accessTokenUrl: String = base
+        }
+    }
+
+    // ── requestDeviceCode ──────────────────────────────────────────
+
+    @Test
+    fun `requestDeviceCode parses a 200 response into Success`() = runTest {
+        server.enqueue(
+            MockResponse()
+                .setHeader("Content-Type", "application/json")
+                .setBody(
+                    """
+                    {"device_code":"3584d83530557fdd1f46af8289938c8ef79f9dc5",
+                     "user_code":"WDJB-MJHT",
+                     "verification_uri":"https://github.com/login/device",
+                     "verification_uri_complete":"https://github.com/login/device?user_code=WDJB-MJHT",
+                     "expires_in":900,
+                     "interval":5}
+                    """.trimIndent(),
+                )
+                .setResponseCode(200),
+        )
+        val result = apiPointingAt("/login/device/code")
+            .requestDeviceCode("client123", "read:user public_repo")
+        assertTrue("expected Success, got $result", result is DeviceCodeResult.Success)
+        result as DeviceCodeResult.Success
+        assertEquals("WDJB-MJHT", result.userCode)
+        assertEquals("3584d83530557fdd1f46af8289938c8ef79f9dc5", result.deviceCode)
+        assertEquals(900, result.expiresInSeconds)
+        assertEquals(5, result.intervalSeconds)
+        assertEquals(
+            "https://github.com/login/device?user_code=WDJB-MJHT",
+            result.verificationUriComplete,
+        )
+
+        // Verify the wire format — GitHub expects form-encoded body with
+        // client_id and scope keys (no client_secret).
+        val recorded = server.takeRequest()
+        assertEquals("POST", recorded.method)
+        val body = recorded.body.readUtf8()
+        assertTrue("body should carry client_id, got $body", body.contains("client_id=client123"))
+        assertTrue(
+            "body should URL-encode the scope, got $body",
+            body.contains("scope=read%3Auser+public_repo") || body.contains("scope=read%3Auser%20public_repo"),
+        )
+    }
+
+    @Test
+    fun `requestDeviceCode surfaces device_flow_disabled as a GitHubError`() = runTest {
+        server.enqueue(
+            MockResponse()
+                .setHeader("Content-Type", "application/json")
+                .setBody(
+                    """{"error":"device_flow_disabled","error_description":"OAuth app not configured"}""",
+                )
+                .setResponseCode(200),
+        )
+        val result = apiPointingAt("/login/device/code")
+            .requestDeviceCode("client123", "read:user")
+        assertTrue("expected GitHubError, got $result", result is DeviceCodeResult.GitHubError)
+        result as DeviceCodeResult.GitHubError
+        assertEquals("device_flow_disabled", result.code)
+    }
+
+    // ── pollAccessToken ────────────────────────────────────────────
+
+    @Test
+    fun `pollAccessToken returns Success when GitHub issues a token`() = runTest {
+        server.enqueue(
+            MockResponse()
+                .setHeader("Content-Type", "application/json")
+                .setBody(
+                    """{"access_token":"gho_abc123","scope":"read:user public_repo","token_type":"bearer"}""",
+                )
+                .setResponseCode(200),
+        )
+        val result = apiPointingAt("/login/oauth/access_token")
+            .pollAccessToken("client123", "device-xyz")
+        assertTrue(result is TokenPollResult.Success)
+        result as TokenPollResult.Success
+        assertEquals("gho_abc123", result.token)
+        assertEquals("read:user public_repo", result.scopes)
+        assertEquals("bearer", result.tokenType)
+
+        // Verify the form-encoded POST body shape.
+        val recorded = server.takeRequest()
+        val body = recorded.body.readUtf8()
+        assertTrue("body should carry client_id, got $body", body.contains("client_id=client123"))
+        assertTrue("body should carry device_code, got $body", body.contains("device_code=device-xyz"))
+        assertTrue(
+            "body should carry the device-flow grant_type, got $body",
+            body.contains(
+                "grant_type=urn%3Aietf%3Aparams%3Aoauth%3Agrant-type%3Adevice_code",
+            ),
+        )
+    }
+
+    @Test
+    fun `pollAccessToken maps authorization_pending to Pending`() = runTest {
+        server.enqueue(
+            MockResponse()
+                .setHeader("Content-Type", "application/json")
+                .setBody("""{"error":"authorization_pending"}""")
+                .setResponseCode(200),
+        )
+        val result = apiPointingAt("/login/oauth/access_token")
+            .pollAccessToken("client123", "device-xyz")
+        assertTrue("expected Pending, got $result", result is TokenPollResult.Pending)
+    }
+
+    @Test
+    fun `pollAccessToken maps slow_down to SlowDown`() = runTest {
+        server.enqueue(
+            MockResponse()
+                .setHeader("Content-Type", "application/json")
+                .setBody("""{"error":"slow_down"}""")
+                .setResponseCode(200),
+        )
+        val result = apiPointingAt("/login/oauth/access_token")
+            .pollAccessToken("client123", "device-xyz")
+        assertTrue("expected SlowDown, got $result", result is TokenPollResult.SlowDown)
+    }
+
+    @Test
+    fun `pollAccessToken maps expired_token to Expired`() = runTest {
+        server.enqueue(
+            MockResponse()
+                .setHeader("Content-Type", "application/json")
+                .setBody("""{"error":"expired_token"}""")
+                .setResponseCode(200),
+        )
+        val result = apiPointingAt("/login/oauth/access_token")
+            .pollAccessToken("client123", "device-xyz")
+        assertTrue("expected Expired, got $result", result is TokenPollResult.Expired)
+    }
+
+    @Test
+    fun `pollAccessToken maps access_denied to Denied`() = runTest {
+        server.enqueue(
+            MockResponse()
+                .setHeader("Content-Type", "application/json")
+                .setBody("""{"error":"access_denied"}""")
+                .setResponseCode(200),
+        )
+        val result = apiPointingAt("/login/oauth/access_token")
+            .pollAccessToken("client123", "device-xyz")
+        assertTrue("expected Denied, got $result", result is TokenPollResult.Denied)
+    }
+
+    @Test
+    fun `pollAccessToken maps unknown error codes to GitHubError`() = runTest {
+        server.enqueue(
+            MockResponse()
+                .setHeader("Content-Type", "application/json")
+                .setBody("""{"error":"incorrect_client_credentials","error_description":"bad id"}""")
+                .setResponseCode(200),
+        )
+        val result = apiPointingAt("/login/oauth/access_token")
+            .pollAccessToken("client123", "device-xyz")
+        assertTrue("expected GitHubError, got $result", result is TokenPollResult.GitHubError)
+        result as TokenPollResult.GitHubError
+        assertEquals("incorrect_client_credentials", result.code)
+        assertEquals("bad id", result.message)
+    }
+
+    @Test
+    fun `pollAccessToken returns NetworkError when connection fails`() = runTest {
+        // Shut down the server before the call — the OkHttp Call will fail
+        // to connect and surface as IOException → NetworkError.
+        server.shutdown()
+        val result = apiPointingAt("/login/oauth/access_token")
+            .pollAccessToken("client123", "device-xyz")
+        assertTrue("expected NetworkError, got $result", result is TokenPollResult.NetworkError)
+    }
+}

--- a/source-github/src/test/kotlin/in/jphe/storyvox/source/github/auth/GitHubAuthInterceptorTest.kt
+++ b/source-github/src/test/kotlin/in/jphe/storyvox/source/github/auth/GitHubAuthInterceptorTest.kt
@@ -1,0 +1,195 @@
+package `in`.jphe.storyvox.source.github.auth
+
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import okhttp3.HttpUrl.Companion.toHttpUrl
+import okhttp3.OkHttpClient
+import okhttp3.Request
+import okhttp3.mockwebserver.MockResponse
+import okhttp3.mockwebserver.MockWebServer
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+
+/**
+ * Integration tests for [GitHubAuthInterceptor]. Verifies the contract
+ * properties from spec § Auth header propagation:
+ *
+ *  1. Authenticated session → Bearer header attached on api.github.com.
+ *  2. Anonymous session → no header.
+ *  3. Expired session → no header (token suppressed in-memory).
+ *  4. Non-api.github.com host → no header (defends against redirects).
+ *  5. 401 response → markExpired() flips the in-memory session.
+ *
+ * Issue #91.
+ */
+class GitHubAuthInterceptorTest {
+
+    private lateinit var server: MockWebServer
+
+    @Before
+    fun setUp() {
+        server = MockWebServer()
+        server.start()
+    }
+
+    @After
+    fun tearDown() {
+        server.shutdown()
+    }
+
+    /**
+     * The interceptor only attaches when host == "api.github.com". To
+     * exercise that without DNS, we rewrite the outgoing URL via a wrapping
+     * interceptor: incoming request says api.github.com, we swap to the
+     * MockWebServer's localhost URL just before chain.proceed().
+     */
+    private fun buildClient(auth: GitHubAuthRepository): OkHttpClient =
+        OkHttpClient.Builder()
+            .addInterceptor(GitHubAuthInterceptor(auth))
+            // Rewrite host AFTER our interceptor has decided whether to
+            // attach the header — so the header decision uses the original
+            // api.github.com host (matching production), but the actual
+            // request goes to MockWebServer.
+            .addInterceptor { chain ->
+                val req = chain.request()
+                if (req.url.host == "api.github.com" || req.url.host == "raw.githubusercontent.com") {
+                    val rewritten = req.newBuilder()
+                        .url(
+                            req.url.newBuilder()
+                                .scheme("http")
+                                .host(server.hostName)
+                                .port(server.port)
+                                .build(),
+                        )
+                        .build()
+                    chain.proceed(rewritten)
+                } else {
+                    chain.proceed(req)
+                }
+            }
+            .build()
+
+    @Test
+    fun `attaches Bearer header when session is Authenticated and host is api github`() {
+        server.enqueue(MockResponse().setResponseCode(200).setBody("{}"))
+        val auth = FakeAuth(
+            GitHubSession.Authenticated(
+                token = "gho_abc",
+                login = "octocat",
+                scopes = "read:user",
+                grantedAt = 0L,
+            ),
+        )
+        val client = buildClient(auth)
+        val response = client.newCall(
+            Request.Builder().url("https://api.github.com/user".toHttpUrl()).build(),
+        ).execute()
+        response.close()
+        val recorded = server.takeRequest()
+        assertEquals("Bearer gho_abc", recorded.getHeader("Authorization"))
+    }
+
+    @Test
+    fun `does not attach header when session is Anonymous`() {
+        server.enqueue(MockResponse().setResponseCode(200).setBody("{}"))
+        val auth = FakeAuth(GitHubSession.Anonymous)
+        val client = buildClient(auth)
+        client.newCall(
+            Request.Builder().url("https://api.github.com/user".toHttpUrl()).build(),
+        ).execute().close()
+        val recorded = server.takeRequest()
+        assertNull(recorded.getHeader("Authorization"))
+    }
+
+    @Test
+    fun `does not attach header when session is Expired`() {
+        server.enqueue(MockResponse().setResponseCode(200).setBody("{}"))
+        val auth = FakeAuth(GitHubSession.Expired)
+        val client = buildClient(auth)
+        client.newCall(
+            Request.Builder().url("https://api.github.com/user".toHttpUrl()).build(),
+        ).execute().close()
+        val recorded = server.takeRequest()
+        assertNull(recorded.getHeader("Authorization"))
+    }
+
+    @Test
+    fun `does not attach header to non-api hosts`() {
+        // Token leak defense — even with an Authenticated session, requests
+        // to raw.githubusercontent.com (or any non-api host) must not bear
+        // the Bearer header.
+        server.enqueue(MockResponse().setResponseCode(200).setBody("plain content"))
+        val auth = FakeAuth(
+            GitHubSession.Authenticated(
+                token = "gho_abc", login = null, scopes = "read:user", grantedAt = 0L,
+            ),
+        )
+        val client = buildClient(auth)
+        client.newCall(
+            Request.Builder().url("https://raw.githubusercontent.com/x/y/z".toHttpUrl()).build(),
+        ).execute().close()
+        val recorded = server.takeRequest()
+        assertNull(
+            "raw.githubusercontent.com must not see the Bearer token",
+            recorded.getHeader("Authorization"),
+        )
+    }
+
+    @Test
+    fun `401 response transitions session to Expired and the token stops attaching`() {
+        // First request: 401 → markExpired() called.
+        server.enqueue(MockResponse().setResponseCode(401).setBody("{}"))
+        // Second request: anonymous (no header).
+        server.enqueue(MockResponse().setResponseCode(200).setBody("{}"))
+
+        val auth = FakeAuth(
+            GitHubSession.Authenticated(
+                token = "gho_revoked", login = null, scopes = "read:user", grantedAt = 0L,
+            ),
+        )
+        val client = buildClient(auth)
+
+        val first = client.newCall(
+            Request.Builder().url("https://api.github.com/user".toHttpUrl()).build(),
+        ).execute()
+        assertEquals(401, first.code)
+        first.close()
+        // After the 401, the interceptor should have flipped state to Expired.
+        assertTrue(
+            "expected Expired after 401, got ${auth.sessionState.value}",
+            auth.sessionState.value is GitHubSession.Expired,
+        )
+        val firstRecorded = server.takeRequest()
+        assertEquals("Bearer gho_revoked", firstRecorded.getHeader("Authorization"))
+
+        // Subsequent request — the in-memory session is Expired so no header.
+        client.newCall(
+            Request.Builder().url("https://api.github.com/user".toHttpUrl()).build(),
+        ).execute().close()
+        val secondRecorded = server.takeRequest()
+        assertNull(
+            "expired-session second request must not bear the dead token",
+            secondRecorded.getHeader("Authorization"),
+        )
+    }
+}
+
+/**
+ * Test fake — the real [GitHubAuthRepositoryImpl] depends on
+ * SharedPreferences which complicates pure-JVM tests. The interceptor
+ * only needs the StateFlow + markExpired, so this scope is sufficient.
+ */
+private class FakeAuth(initial: GitHubSession) : GitHubAuthRepository {
+    private val state = MutableStateFlow(initial)
+    override val sessionState: StateFlow<GitHubSession> = state.asStateFlow()
+    override suspend fun captureSession(token: String, login: String?, scopes: String) {
+        state.value = GitHubSession.Authenticated(token, login, scopes, 0L)
+    }
+    override suspend fun clearSession() { state.value = GitHubSession.Anonymous }
+    override fun markExpired() { state.value = GitHubSession.Expired }
+}

--- a/source-github/src/test/kotlin/in/jphe/storyvox/source/github/auth/GitHubAuthRepositoryTest.kt
+++ b/source-github/src/test/kotlin/in/jphe/storyvox/source/github/auth/GitHubAuthRepositoryTest.kt
@@ -1,0 +1,152 @@
+package `in`.jphe.storyvox.source.github.auth
+
+import android.content.SharedPreferences
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * Round-trip tests for [GitHubAuthRepositoryImpl] against an in-memory
+ * SharedPreferences fake. Verifies the encrypted-prefs key shape spec'd
+ * in the design doc (`token:github*` namespace) plus the StateFlow
+ * lifecycle on capture / clear / markExpired. Issue #91.
+ */
+class GitHubAuthRepositoryTest {
+
+    @Test
+    fun `init starts Anonymous when no token on disk`() = runTest {
+        val prefs = InMemoryPrefs()
+        val repo = GitHubAuthRepositoryImpl(prefs)
+        assertEquals(GitHubSession.Anonymous, repo.sessionState.value)
+    }
+
+    @Test
+    fun `init hydrates Authenticated when token is present`() = runTest {
+        val prefs = InMemoryPrefs().apply {
+            putString(GitHubAuthRepositoryImpl.KEY_TOKEN, "gho_abc")
+            putString(GitHubAuthRepositoryImpl.KEY_LOGIN, "octocat")
+            putString(GitHubAuthRepositoryImpl.KEY_SCOPES, "read:user public_repo")
+            putString(GitHubAuthRepositoryImpl.KEY_GRANTED_AT, "1735000000000")
+        }
+        val repo = GitHubAuthRepositoryImpl(prefs)
+        val session = repo.sessionState.value
+        assertTrue(session is GitHubSession.Authenticated)
+        session as GitHubSession.Authenticated
+        assertEquals("gho_abc", session.token)
+        assertEquals("octocat", session.login)
+        assertEquals("read:user public_repo", session.scopes)
+        assertEquals(1735000000000L, session.grantedAt)
+    }
+
+    @Test
+    fun `captureSession persists all four keys and updates StateFlow`() = runTest {
+        val prefs = InMemoryPrefs()
+        val repo = GitHubAuthRepositoryImpl(prefs)
+        repo.captureSession(token = "gho_xyz", login = "alice", scopes = "read:user public_repo")
+        // StateFlow updated.
+        val session = repo.sessionState.first()
+        assertTrue(session is GitHubSession.Authenticated)
+        session as GitHubSession.Authenticated
+        assertEquals("gho_xyz", session.token)
+        assertEquals("alice", session.login)
+        // All four keys on disk.
+        assertEquals("gho_xyz", prefs.getString(GitHubAuthRepositoryImpl.KEY_TOKEN, null))
+        assertEquals("alice", prefs.getString(GitHubAuthRepositoryImpl.KEY_LOGIN, null))
+        assertEquals("read:user public_repo", prefs.getString(GitHubAuthRepositoryImpl.KEY_SCOPES, null))
+        assertTrue(
+            "granted_at should be set to a positive epoch ms, got ${prefs.getString(GitHubAuthRepositoryImpl.KEY_GRANTED_AT, null)}",
+            prefs.getString(GitHubAuthRepositoryImpl.KEY_GRANTED_AT, null)
+                ?.toLongOrNull()?.let { it > 0L } == true,
+        )
+    }
+
+    @Test
+    fun `captureSession with null login removes login key but keeps token`() = runTest {
+        val prefs = InMemoryPrefs()
+        val repo = GitHubAuthRepositoryImpl(prefs)
+        repo.captureSession(token = "gho_first", login = "old", scopes = "read:user")
+        repo.captureSession(token = "gho_second", login = null, scopes = "read:user")
+        assertEquals("gho_second", prefs.getString(GitHubAuthRepositoryImpl.KEY_TOKEN, null))
+        assertNull(prefs.getString(GitHubAuthRepositoryImpl.KEY_LOGIN, null))
+    }
+
+    @Test
+    fun `clearSession removes all four keys and flips StateFlow to Anonymous`() = runTest {
+        val prefs = InMemoryPrefs().apply {
+            putString(GitHubAuthRepositoryImpl.KEY_TOKEN, "gho_abc")
+            putString(GitHubAuthRepositoryImpl.KEY_LOGIN, "octocat")
+            putString(GitHubAuthRepositoryImpl.KEY_SCOPES, "read:user")
+            putString(GitHubAuthRepositoryImpl.KEY_GRANTED_AT, "1")
+        }
+        val repo = GitHubAuthRepositoryImpl(prefs)
+        repo.clearSession()
+        assertEquals(GitHubSession.Anonymous, repo.sessionState.value)
+        assertNull(prefs.getString(GitHubAuthRepositoryImpl.KEY_TOKEN, null))
+        assertNull(prefs.getString(GitHubAuthRepositoryImpl.KEY_LOGIN, null))
+        assertNull(prefs.getString(GitHubAuthRepositoryImpl.KEY_SCOPES, null))
+        assertNull(prefs.getString(GitHubAuthRepositoryImpl.KEY_GRANTED_AT, null))
+    }
+
+    @Test
+    fun `markExpired flips StateFlow but leaves disk copy intact`() = runTest {
+        val prefs = InMemoryPrefs()
+        val repo = GitHubAuthRepositoryImpl(prefs)
+        repo.captureSession(token = "gho_abc", login = "octocat", scopes = "read:user")
+        repo.markExpired()
+        assertEquals(GitHubSession.Expired, repo.sessionState.value)
+        // Disk copy intact so Settings can show "Session expired" instead
+        // of silently losing identity.
+        assertEquals("gho_abc", prefs.getString(GitHubAuthRepositoryImpl.KEY_TOKEN, null))
+        assertEquals("octocat", prefs.getString(GitHubAuthRepositoryImpl.KEY_LOGIN, null))
+    }
+
+    @Test
+    fun `keys live under the per-source token namespace`() {
+        // Spec-locking the key shape so future multi-source refactors don't
+        // accidentally migrate them to a different prefix.
+        assertEquals("token:github", GitHubAuthRepositoryImpl.KEY_TOKEN)
+        assertEquals("token:github:login", GitHubAuthRepositoryImpl.KEY_LOGIN)
+        assertEquals("token:github:scopes", GitHubAuthRepositoryImpl.KEY_SCOPES)
+        assertEquals("token:github:granted_at", GitHubAuthRepositoryImpl.KEY_GRANTED_AT)
+    }
+}
+
+/**
+ * Minimal in-memory [SharedPreferences] for unit tests. Only the methods
+ * the repo touches are non-trivial. Mirrors the FakeSecrets in
+ * `:app`'s test-support module.
+ */
+private class InMemoryPrefs : SharedPreferences {
+    private val map = mutableMapOf<String, Any?>()
+
+    fun putString(key: String, value: String?) {
+        if (value == null) map.remove(key) else map[key] = value
+    }
+
+    override fun getAll(): MutableMap<String, *> = map
+    override fun getString(key: String, defValue: String?): String? =
+        map[key] as? String ?: defValue
+    override fun getStringSet(key: String, defValues: MutableSet<String>?): MutableSet<String>? = defValues
+    override fun getInt(key: String, defValue: Int): Int = (map[key] as? Int) ?: defValue
+    override fun getLong(key: String, defValue: Long): Long = (map[key] as? Long) ?: defValue
+    override fun getFloat(key: String, defValue: Float): Float = (map[key] as? Float) ?: defValue
+    override fun getBoolean(key: String, defValue: Boolean): Boolean = (map[key] as? Boolean) ?: defValue
+    override fun contains(key: String): Boolean = key in map
+    override fun edit(): SharedPreferences.Editor = object : SharedPreferences.Editor {
+        override fun putString(key: String, value: String?) = apply { map[key] = value }
+        override fun putStringSet(key: String, values: MutableSet<String>?) = apply { map[key] = values }
+        override fun putInt(key: String, value: Int) = apply { map[key] = value }
+        override fun putLong(key: String, value: Long) = apply { map[key] = value }
+        override fun putFloat(key: String, value: Float) = apply { map[key] = value }
+        override fun putBoolean(key: String, value: Boolean) = apply { map[key] = value }
+        override fun remove(key: String) = apply { map.remove(key) }
+        override fun clear() = apply { map.clear() }
+        override fun commit(): Boolean = true
+        override fun apply() = Unit
+    }
+    override fun registerOnSharedPreferenceChangeListener(l: SharedPreferences.OnSharedPreferenceChangeListener?) = Unit
+    override fun unregisterOnSharedPreferenceChangeListener(l: SharedPreferences.OnSharedPreferenceChangeListener?) = Unit
+}


### PR DESCRIPTION
Closes #91 (P0 substrate). Implements Ember's design at `docs/superpowers/specs/2026-05-08-github-oauth-design.md`.

## Summary

- **Device Flow** — `POST github.com/login/device/code` then poll `github.com/login/oauth/access_token` with full RFC 8628 + GitHub-specific error handling (slow_down, expired_token, access_denied, device_flow_disabled).
- **Token storage** — Single token per app, encrypted at rest in the existing `EncryptedSharedPreferences` instance (Tink AES-256-GCM, no new MasterKey, no new prefs file). Keys live under the spec'd `token:github*` namespace.
- **OkHttp interceptor** — Attaches `Authorization: Bearer <token>` to `api.github.com` only. Defends against token leak on redirects to other hosts. Flips session to `Expired` on 401 (disk copy intact so Settings can show "Session expired").
- **Sign-in modal** — Brass-themed Compose screen drives the Idle → RequestingCode → AwaitingUser → Capturing → Captured state machine. Browser open via `Intent.ACTION_VIEW`, "Copy code" clipboard fallback, polling cancellation on back-press.
- **Settings → Sources row** — "Sign in to GitHub" / "Signed in as @login" with scope display and remote-revoke deep-link to `github.com/settings/applications`.
- **Scope minimization** — requests `read:user public_repo` only. `repo` (private) and `gist` deferred to opt-in toggles in future PRs.

## Tests (all JVM unit, MockWebServer where needed)

- **DeviceFlowApiTest** — success / pending / slow_down / expired / denied / GitHubError / network-error branches plus the wire format (form-encoded POST body, grant_type, no client_secret).
- **GitHubAuthRepositoryTest** — round-trip persist, hydration on init, markExpired keeps disk copy intact, key namespace spec'd shape.
- **GitHubAuthInterceptorTest** — Bearer attached on `api.github.com` only, `raw.githubusercontent.com` gets nothing, 401 → markExpired.
- **GitHubSignInViewModelTest** — state machine transitions for success / denied / expired / slow_down + success / GitHubError / network-error / cancel.

## Deferred (per spec; separate PRs)

- F1: "Read your repos as fictions" entry-point feature (#91 deliverable, follow-up PR).
- F2-F5: Starred-repos browse row, gists as drafts, private-repo opt-in toggle, auth-aware browse.
- Multi-source `AuthRepository` refactor (Ember's "PR Auth-A") — kept as a parallel `GitHubAuthRepository` beside the existing RR `AuthRepository` for P0 scope. The cross-source `SourceAuth` interface is the right shape once 3+ sources have auth.

## OPEN FOLLOW-UP for JP — register the OAuth app

`GitHubAuthConfig.DEFAULT_CLIENT_ID` is the placeholder `TODO_JP_REGISTER_OAUTH_APP`. Until JP registers the OAuth app, sign-in attempts will hit `incorrect_client_credentials`. Steps documented in the `GitHubAuthConfig` kdoc:

1. https://github.com/settings/applications/new
2. Name: `storyvox` · Homepage: `https://github.com/jphein/storyvox` · Callback URL: same (unused for Device Flow but the form requires something)
3. **Check "Enable Device Flow"** — without this the device-code endpoint returns `device_flow_disabled`
4. Copy the 20-char `client_id` → replace the placeholder in `source-github/src/main/kotlin/in/jphe/storyvox/source/github/auth/GitHubAuthConfig.kt` (or wire via `local.properties` → `BuildConfig.GITHUB_CLIENT_ID`)

The `client_id` is **not a secret** in the public-client model (ships in every APK by design — deliberate exception to CLAUDE.md's Vaultwarden rule, called out in the kdoc).

## Test plan

- [x] All existing tests still pass (`./gradlew test`)
- [x] New DeviceFlowApi tests pass (8 cases)
- [x] New GitHubAuthRepository tests pass (6 cases)
- [x] New GitHubAuthInterceptor tests pass (5 cases)
- [x] New GitHubSignInViewModel tests pass (7 cases)
- [x] `:app:assembleDebug` builds clean
- [ ] **JP**: register OAuth app, wire real `client_id`, end-to-end sign-in on Tab A7 Lite

## Iron rules

- No version bump, no changelog churn — this is substrate, not user-visible until F1 lands and JP wires the client_id.
- Token never logged (HttpLoggingInterceptor isn't enabled in :source-github; if added later, redact `Authorization`).
- No new dependencies — `androidx.security:security-crypto` was already in `:core-data`.
- Selective `git add`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)