### PR TITLE
fix(settings): align punctuation cadence slider tick labels (#139)

### DIFF
--- a/feature/src/main/kotlin/in/jphe/storyvox/feature/settings/SettingsScreen.kt
+++ b/feature/src/main/kotlin/in/jphe/storyvox/feature/settings/SettingsScreen.kt
@@ -30,10 +30,12 @@ import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.layout.Layout
 import androidx.compose.ui.text.font.FontStyle
 import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.text.input.PasswordVisualTransformation
 import androidx.compose.ui.text.input.VisualTransformation
+import androidx.compose.ui.unit.Constraints
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
@@ -627,51 +629,107 @@ private fun PunctuationPauseSlider(
 /**
  * Anchored row of legacy-stop labels under [PunctuationPauseSlider]. Each
  * label sits at its true fractional position along the [0..4] range using
- * weight spacers, mirroring [TickMarker]'s technique. Labels include the
- * legacy stop names (Off / Normal / Long) so users coming from the 3-stop
- * selector can find their preferred cadence at a glance.
+ * a [Layout] composable, so the visual ▲ caret on each label aligns with
+ * the slider thumb position for that value. Labels include the legacy stop
+ * names (Off / Normal / Long) so users coming from the 3-stop selector
+ * can find their preferred cadence at a glance.
+ *
+ * Why not the [TickMarker] weight-spacer trick? With multiple labels in a
+ * single [Row], Compose's weight system divides only the *remaining* width
+ * after measuring unweighted children (the Texts themselves), so each label
+ * drifts right by the cumulative widths of preceding labels. With four
+ * labels the drift visibly mismatches the thumb position (issue #139).
+ *
+ * We also account for the M3 [Slider]'s internal track padding (half the
+ * thumb width = 10dp on each side), which the surrounding Column does not
+ * inherit. Fraction 0 in the parent layout maps to track-x = 0 + padding,
+ * not to the leftmost pixel of the parent.
  */
 @Composable
 private fun PunctuationPauseTickLabels() {
     val total = PUNCTUATION_PAUSE_MAX_MULTIPLIER - PUNCTUATION_PAUSE_MIN_MULTIPLIER
-    val offFrac = ((PUNCTUATION_PAUSE_OFF_MULTIPLIER - PUNCTUATION_PAUSE_MIN_MULTIPLIER) / total)
-        .coerceIn(0f, 1f)
-    val normalFrac = ((PUNCTUATION_PAUSE_NORMAL_MULTIPLIER - PUNCTUATION_PAUSE_MIN_MULTIPLIER) / total)
-        .coerceIn(0f, 1f)
-    val longFrac = ((PUNCTUATION_PAUSE_LONG_MULTIPLIER - PUNCTUATION_PAUSE_MIN_MULTIPLIER) / total)
-        .coerceIn(0f, 1f)
+    val ticks = listOf(
+        "▲ Off" to ((PUNCTUATION_PAUSE_OFF_MULTIPLIER - PUNCTUATION_PAUSE_MIN_MULTIPLIER) / total),
+        "▲ 1×" to ((PUNCTUATION_PAUSE_NORMAL_MULTIPLIER - PUNCTUATION_PAUSE_MIN_MULTIPLIER) / total),
+        "▲ Long" to ((PUNCTUATION_PAUSE_LONG_MULTIPLIER - PUNCTUATION_PAUSE_MIN_MULTIPLIER) / total),
+        "▲ 4×" to 1f,
+    )
 
-    // Distances between adjacent ticks along the row; the trailing slack
-    // after "Max" pads to the right edge of the parent.
-    val toNormal = (normalFrac - offFrac).coerceAtLeast(0.001f)
-    val toLong = (longFrac - normalFrac).coerceAtLeast(0.001f)
-    val toMax = (1f - longFrac).coerceAtLeast(0.001f)
+    // M3 Slider reserves half the thumb diameter as track padding on each
+    // side (default thumb is 20dp, so 10dp). Hardcoded here because
+    // SliderDefaults doesn't expose this constant publicly. If the thumb
+    // size ever changes, the labels will drift by ≤10dp — visible only on
+    // the extreme ends — so this stays a load-bearing constant.
+    val trackPaddingDp = SLIDER_TRACK_PADDING_DP
 
-    Row(modifier = Modifier.fillMaxWidth(), verticalAlignment = Alignment.CenterVertically) {
-        Text(
-            text = "▲ Off",
-            style = MaterialTheme.typography.labelSmall,
-            color = MaterialTheme.colorScheme.onSurfaceVariant,
-        )
-        Box(modifier = Modifier.weight(toNormal))
-        Text(
-            text = "▲ 1×",
-            style = MaterialTheme.typography.labelSmall,
-            color = MaterialTheme.colorScheme.onSurfaceVariant,
-        )
-        Box(modifier = Modifier.weight(toLong))
-        Text(
-            text = "▲ Long",
-            style = MaterialTheme.typography.labelSmall,
-            color = MaterialTheme.colorScheme.onSurfaceVariant,
-        )
-        Box(modifier = Modifier.weight(toMax))
-        Text(
-            text = "▲ 4×",
-            style = MaterialTheme.typography.labelSmall,
-            color = MaterialTheme.colorScheme.onSurfaceVariant,
-        )
+    Layout(
+        modifier = Modifier.fillMaxWidth(),
+        content = {
+            ticks.forEach { (label, _) ->
+                Text(
+                    text = label,
+                    style = MaterialTheme.typography.labelSmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                )
+            }
+        },
+    ) { measurables, constraints ->
+        val placeables = measurables.map { it.measure(Constraints()) }
+        val rowWidth = constraints.maxWidth
+        val height = placeables.maxOfOrNull { it.height } ?: 0
+        val trackPaddingPx = trackPaddingDp.dp.toPx().toInt()
+
+        layout(rowWidth, height) {
+            placeables.forEachIndexed { i, placeable ->
+                val frac = ticks[i].second
+                val x = computeTickLabelX(
+                    rowWidthPx = rowWidth,
+                    trackPaddingPx = trackPaddingPx,
+                    fraction = frac,
+                    labelWidthPx = placeable.width,
+                    isLast = i == ticks.lastIndex,
+                )
+                placeable.place(x, 0)
+            }
+        }
     }
+}
+
+/** Half the M3 default thumb diameter; track padding on each side. */
+private const val SLIDER_TRACK_PADDING_DP: Int = 10
+
+/**
+ * Pure placement math for [PunctuationPauseTickLabels], extracted for unit
+ * testing. Returns the integer x-offset (in pixels) at which a tick label
+ * should be placed inside the parent so its visual ▲ caret sits at the
+ * slider thumb position for the given [fraction].
+ *
+ * Anchoring rule:
+ *  - The leftmost label and all middle labels are **left-aligned** at
+ *    `trackPaddingPx + fraction × trackWidthPx`. This puts the leading ▲
+ *    character at the slider's thumb-x for that value.
+ *  - The rightmost label is **right-aligned** to the parent so its full
+ *    text stays on screen (the ▲ ends up slightly right of the thumb's
+ *    track-x by half-a-thumb, which is the correct visual since the
+ *    thumb itself extends right of trackEnd by half its width).
+ *
+ * All labels are clamped so they never overflow the parent on the right.
+ */
+internal fun computeTickLabelX(
+    rowWidthPx: Int,
+    trackPaddingPx: Int,
+    fraction: Float,
+    labelWidthPx: Int,
+    isLast: Boolean,
+): Int {
+    if (isLast) {
+        // Right-align: label's right edge at parent's right edge.
+        return (rowWidthPx - labelWidthPx).coerceAtLeast(0)
+    }
+    val trackWidthPx = (rowWidthPx - 2 * trackPaddingPx).coerceAtLeast(0)
+    val anchorX = trackPaddingPx + (fraction.coerceIn(0f, 1f) * trackWidthPx).toInt()
+    // Clamp so multi-character middle labels don't overflow the right edge.
+    return anchorX.coerceIn(0, (rowWidthPx - labelWidthPx).coerceAtLeast(0))
 }
 
 /**

--- a/feature/src/test/kotlin/in/jphe/storyvox/feature/settings/PunctuationPauseTickPlacementTest.kt
+++ b/feature/src/test/kotlin/in/jphe/storyvox/feature/settings/PunctuationPauseTickPlacementTest.kt
@@ -1,0 +1,150 @@
+package `in`.jphe.storyvox.feature.settings
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * Unit tests for [computeTickLabelX], the pure placement helper that powers
+ * `PunctuationPauseTickLabels`. Issue #139 — labels visibly drifted right
+ * because the previous `Row(weight)` layout treats label widths as a
+ * fixed-takeout from the row, leaving weights to divvy up only the
+ * *remaining* space. These tests guarantee the new placement math anchors
+ * each label to its true value-fraction along the slider track.
+ */
+class PunctuationPauseTickPlacementTest {
+
+    /**
+     * At fraction 0 (value = MIN_MULTIPLIER, "Off"), the label's left edge
+     * sits at trackPadding — the same x-pixel where the slider thumb sits
+     * when fully left.
+     */
+    @Test
+    fun `leftmost tick anchored at track padding, not parent left edge`() {
+        val x = computeTickLabelX(
+            rowWidthPx = 600,
+            trackPaddingPx = 10,
+            fraction = 0f,
+            labelWidthPx = 50,
+            isLast = false,
+        )
+        assertEquals(10, x)
+    }
+
+    /**
+     * Middle tick at fraction 0.25 (value = 1×) sits at 10 + 0.25 × 580 = 155.
+     * This is the fix for the symptom JP reported: previously "▲ 1×"
+     * appeared at slider position ~1.09× because cumulative label widths
+     * pushed it right of fraction 0.25.
+     */
+    @Test
+    fun `middle tick at value-fraction along the track, not the row`() {
+        val x = computeTickLabelX(
+            rowWidthPx = 600,
+            trackPaddingPx = 10,
+            fraction = 0.25f, // value = 1× in 0..4 range
+            labelWidthPx = 40,
+            isLast = false,
+        )
+        assertEquals(10 + (0.25f * 580f).toInt(), x) // 155
+    }
+
+    /**
+     * "Long" at value 1.75 in a 0..4 range: fraction 0.4375.
+     * Track-x = 10 + 0.4375 × 580 = 263.75 → 263 (Int).
+     * Hazel reported this label appearing at "1.92×" before the fix —
+     * (label drifted ~10% right, consistent with cumulative label width).
+     */
+    @Test
+    fun `long tick lands at fraction 0_4375 on a 600px parent`() {
+        val x = computeTickLabelX(
+            rowWidthPx = 600,
+            trackPaddingPx = 10,
+            fraction = 1.75f / 4f,
+            labelWidthPx = 60,
+            isLast = false,
+        )
+        // 10 + (0.4375 × 580).toInt() = 10 + 253 = 263
+        assertEquals(10 + (0.4375f * 580f).toInt(), x)
+    }
+
+    /**
+     * The rightmost tick is right-aligned so its text doesn't overflow
+     * the parent's right edge. The visual ▲ then sits slightly right of
+     * the track end, which matches the thumb's visual extent (the thumb
+     * is a circle that extends half its width past the track end).
+     */
+    @Test
+    fun `rightmost tick is right-aligned to parent edge`() {
+        val x = computeTickLabelX(
+            rowWidthPx = 600,
+            trackPaddingPx = 10,
+            fraction = 1f,
+            labelWidthPx = 50,
+            isLast = true,
+        )
+        assertEquals(550, x) // 600 - 50
+    }
+
+    /**
+     * Defensive: a wide middle label that would otherwise overflow the
+     * right edge gets clamped. Prevents text from being cut off if a
+     * future locale's "Long" translation is unusually wide.
+     */
+    @Test
+    fun `middle tick clamps when label would overflow the right edge`() {
+        val x = computeTickLabelX(
+            rowWidthPx = 200,
+            trackPaddingPx = 10,
+            fraction = 0.95f,
+            labelWidthPx = 80,
+            isLast = false,
+        )
+        // anchorX = 10 + (0.95 × 180).toInt() = 10 + 171 = 181
+        // clamp = (200 - 80) = 120
+        assertEquals(120, x)
+    }
+
+    /**
+     * Defensive: a fraction outside [0, 1] is clamped so the label stays
+     * within the parent. Should never happen given the [0..1] derivation
+     * upstream, but cheap to guarantee.
+     */
+    @Test
+    fun `fraction below zero clamps to track padding`() {
+        val x = computeTickLabelX(
+            rowWidthPx = 600,
+            trackPaddingPx = 10,
+            fraction = -0.5f,
+            labelWidthPx = 40,
+            isLast = false,
+        )
+        assertEquals(10, x)
+    }
+
+    /**
+     * Sanity check that the four real tick fractions (Off/1×/Long/4×) for
+     * the punctuation cadence slider produce monotonically increasing
+     * positions — i.e., labels don't visually re-order or overlap-collide
+     * on a typical tablet width.
+     */
+    @Test
+    fun `four real ticks monotonically increase across a 600px parent`() {
+        val labelWidth = 40
+        val xs = listOf(0f, 0.25f, 0.4375f, 1f).mapIndexed { i, frac ->
+            computeTickLabelX(
+                rowWidthPx = 600,
+                trackPaddingPx = 10,
+                fraction = frac,
+                labelWidthPx = labelWidth,
+                isLast = i == 3,
+            )
+        }
+        for (i in 1 until xs.size) {
+            assertTrue(
+                "x[$i]=${xs[i]} should be > x[${i - 1}]=${xs[i - 1]}",
+                xs[i] > xs[i - 1],
+            )
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- Fixes #139: Punctuation Cadence slider tick labels (`▲ Off` / `▲ 1×` / `▲ Long` / `▲ 4×`) drifted right of their true thumb positions on v0.4.32. Hazel measured "Off" at ~0.10× and "4×" at ~3.92× — labels and slider values were progressively de-synced.
- Root cause was twofold: (1) `Row` with weighted spacers only works as a tick anchor for a *single* label, because Compose measures unweighted Text children at intrinsic width first and only divvies up the **remaining** width proportional to weights — so each label drifted right by the cumulative widths of its predecessors; (2) the M3 `Slider` reserves ~10dp track padding on each side (half thumb-width) that the labelling Row didn't account for.
- Replaced the `Row(weight)` layout with a custom `Layout` composable that places each label at `trackPadding + fraction × trackWidth`. The rightmost label is right-aligned so it stays on-screen (matching the thumb's visual extent past trackEnd). Placement math extracted to a pure `computeTickLabelX` helper and unit-tested.

## Test plan
- [x] New `PunctuationPauseTickPlacementTest` — 7 cases: leftmost-at-trackPadding, middle-at-fraction (1× and Long), rightmost-right-aligned, overflow-clamping, negative-fraction-clamping, monotonic ordering across all four real ticks. All pass.
- [x] `:feature:testDebugUnitTest` — full module test suite green, no regressions.
- [ ] Visual verification on tablet (deferred per task scope — Reeve will pick up at merge).

## Notes
- One narrow assumption: `SLIDER_TRACK_PADDING_DP = 10`, hardcoded because Material3's `SliderDefaults` doesn't expose this constant publicly. If M3 ever changes the default thumb size, label drift would resurface up to ±10dp on the extreme ends only — no compounding error like the previous bug. A future PR could measure the slider's actual track via a `SubcomposeLayout` if M3 changes that geometry.
- Did **not** touch the Buffer Headroom slider (#138/#140) — that's design-deferred territory.

🤖 Generated with [Claude Code](https://claude.com/claude-code)