### PR TITLE
fix(reader): wire Open Settings nav + state-aware Recap subtitle (#152, #153)

### DIFF
--- a/app/src/main/kotlin/in/jphe/storyvox/navigation/StoryvoxNavHost.kt
+++ b/app/src/main/kotlin/in/jphe/storyvox/navigation/StoryvoxNavHost.kt
@@ -182,6 +182,7 @@ private fun StoryvoxNavHostContent(
             ) {
                 HybridReaderScreen(
                     onPickVoice = { navController.navigate(StoryvoxRoutes.VOICE_LIBRARY) },
+                    onOpenAiSettings = { navController.navigate(StoryvoxRoutes.SETTINGS) },
                 )
             }
             composable(
@@ -246,6 +247,7 @@ private fun StoryvoxNavHostContent(
             ) {
                 HybridReaderScreen(
                     onPickVoice = { navController.navigate(StoryvoxRoutes.VOICE_LIBRARY) },
+                    onOpenAiSettings = { navController.navigate(StoryvoxRoutes.SETTINGS) },
                 )
             }
 
@@ -262,6 +264,7 @@ private fun StoryvoxNavHostContent(
             ) {
                 HybridReaderScreen(
                     onPickVoice = { navController.navigate(StoryvoxRoutes.VOICE_LIBRARY) },
+                    onOpenAiSettings = { navController.navigate(StoryvoxRoutes.SETTINGS) },
                 )
             }
 

--- a/feature/src/main/kotlin/in/jphe/storyvox/feature/reader/HybridReaderScreen.kt
+++ b/feature/src/main/kotlin/in/jphe/storyvox/feature/reader/HybridReaderScreen.kt
@@ -16,7 +16,13 @@ import `in`.jphe.storyvox.ui.component.HybridReaderShell
 fun HybridReaderScreen(
     onPickVoice: () -> Unit,
     /** Open Settings → AI when the recap modal hits a NotConfigured /
-     *  AuthFailed state. AppNav wires this. Issue #81. */
+     *  AuthFailed state. **AppNav must wire this** — leaving the default
+     *  no-op causes the recap empty-state's "Open Settings" CTA to look
+     *  primary but be a dead button (issue #152, fixed in this PR by
+     *  wiring all three [HybridReaderScreen] composables in
+     *  `StoryvoxNavHost.kt`). The default stays for preview/test use,
+     *  but any new production callsite *must* pass a real navigation
+     *  callback or the unconfigured-AI user has no path forward. */
     onOpenAiSettings: () -> Unit = {},
     viewModel: ReaderViewModel = hiltViewModel(),
 ) {

--- a/feature/src/main/kotlin/in/jphe/storyvox/feature/reader/RecapModal.kt
+++ b/feature/src/main/kotlin/in/jphe/storyvox/feature/reader/RecapModal.kt
@@ -74,7 +74,13 @@ fun RecapModal(
                 .padding(spacing.md),
             verticalArrangement = Arrangement.spacedBy(spacing.md),
         ) {
-            // Header
+            // Header — subtitle copy switches with state so the
+            // empty/error case doesn't read as "we're working on it"
+            // when the body literally says "set up AI first" (#153).
+            // Loading + Streaming use the present-progressive in-flight
+            // copy; Done describes what's now on screen; Error /
+            // unconfigured falls back to a neutral descriptor of the
+            // feature itself.
             Column {
                 Text(
                     text = "Recap so far",
@@ -82,7 +88,7 @@ fun RecapModal(
                     color = MaterialTheme.colorScheme.primary,
                 )
                 Text(
-                    text = "Asking the librarian about the last few chapters.",
+                    text = subtitleFor(state),
                     style = MaterialTheme.typography.bodySmall,
                     color = MaterialTheme.colorScheme.onSurfaceVariant,
                 )
@@ -224,6 +230,30 @@ private fun StreamingBody(text: String) {
             modifier = Modifier.alpha(cursorAlpha),
         )
     }
+}
+
+/**
+ * Subtitle copy for the [RecapModal] header, picked by state. Issue #153 —
+ * the legacy hard-coded "Asking the librarian about the last few chapters."
+ * read as in-progress regardless of state, which clashed with the body's
+ * "Set up AI in Settings to use Recap." in the unconfigured/error case.
+ *
+ * - **Loading / Streaming** — present-progressive, matches the spinner /
+ *   blinking-cursor in-flight visual.
+ * - **Done** — past tense, matches the "this is the recap" body.
+ * - **Error** (NotConfigured / AuthFailed / Transport / ProviderError) —
+ *   neutral feature-descriptor, so the user reads the body's recovery copy
+ *   without a contradictory "we're already on it" subtitle.
+ *
+ * Internal so [`PunctuationPauseTickPlacementTest`-style] unit testing
+ * could cover the mapping if it grows beyond five branches.
+ */
+internal fun subtitleFor(state: RecapUiState): String = when (state) {
+    is RecapUiState.Loading,
+    is RecapUiState.Streaming -> "Asking the librarian about the last few chapters."
+    is RecapUiState.Done -> "Here's what happened in the last few chapters."
+    is RecapUiState.Error -> "Quick chapter summaries from your AI provider."
+    RecapUiState.Hidden -> ""  // unreachable — modal returns early when Hidden
 }
 
 @Composable


### PR DESCRIPTION
## Summary
- **#152**: Wire \`onOpenAiSettings\` at all three \`HybridReaderScreen\` call sites in \`StoryvoxNavHost.kt\`, so the recap modal's empty-state \"Open Settings\" CTA actually navigates instead of just dismissing.
- **#153**: Replace the hard-coded \"Asking the librarian…\" subtitle with a state-aware \`subtitleFor(state)\` helper so the unconfigured / error case doesn't read as in-progress when the body literally says \"set up AI first.\"

## Why
\`HybridReaderScreen\` exposes \`onOpenAiSettings: () -> Unit = {}\` with the comment \"AppNav wires this\" — but none of the three call sites (PLAYING / READER / AUDIOBOOK) actually passed a callback. The primary brown CTA in the empty-state modal was a dead button, and the *only* path the modal offered to fix the unconfigured AI was unreachable. Hazel reproduced twice on R83W80CAFZB. Bundled #153 because both touch the same modal in the same flow and ship together cleanly.

The kdoc on \`HybridReaderScreen.onOpenAiSettings\` is now a loud guard with a forward-thread documenting the trap, so a future composable call site can't repeat the dead-button mistake. Default stays \`{}\` for preview/test use.

## Test plan
- [x] \`:feature:assembleDebug\` green
- [x] \`:app:assembleDebug\` green
- [x] \`:feature:testDebugUnitTest\` green
- [x] \`:app:testDebugUnitTest\` green
- [ ] Manual on-tablet (orchestrator): unconfigured AI → Player Options → Recap so far → tap \"Open Settings\" → land on Settings tab. Configured-then-error path: same modal, subtitle reads \"Quick chapter summaries from your AI provider.\" not \"Asking the librarian…\"

Closes #152.
Closes #153.