### PR TITLE
feat(voicelibrary): polish — collapsible sections + name normalization + drop In-use label (#127 #128 #130)

### DIFF
--- a/core-playback/src/main/kotlin/in/jphe/storyvox/playback/voice/UiVoiceInfo.kt
+++ b/core-playback/src/main/kotlin/in/jphe/storyvox/playback/voice/UiVoiceInfo.kt
@@ -12,6 +12,13 @@ package `in`.jphe.storyvox.playback.voice
  * [sizeBytes] is the on-disk install size (catalog estimate for Piper;
  * 0 for Kokoro since the speaker selection is just an integer index into
  * the shared Kokoro model — no per-speaker download).
+ *
+ * [displayName] is the **clean** voice name, e.g. "Lessac" or "Aoede" —
+ * no tier parentheticals, no flag prefix, no engine/quality clutter.
+ * See #128: the Voice Library composes the on-screen title as
+ * `<flag> <displayName>` and the subtitle as `<Engine> · <Tier> · <Gender>`,
+ * so this field stays render-agnostic. (Curated picks keep their ⭐
+ * marker prefixed inline — see [VoiceCatalog.featuredIds].)
  */
 data class UiVoiceInfo(
     val id: String,
@@ -21,7 +28,20 @@ data class UiVoiceInfo(
     val isInstalled: Boolean,
     val qualityLevel: QualityLevel,
     val engineType: EngineType,
+    val gender: VoiceGender = VoiceGender.Unknown,
 )
+
+/**
+ * Voice gender as surfaced in the Voice Library subtitle. Best-effort
+ * — Piper's upstream filenames don't always encode it (e.g. "lessac",
+ * "ryan", "amy" name speakers but only some carry an explicit gender
+ * marker like `*_male` / `*_female`). [Unknown] renders as an empty
+ * subtitle segment so the line collapses cleanly to `Engine · Tier`.
+ *
+ * Kokoro voices all carry an upstream gender grade — every Kokoro
+ * entry resolves to [Female] or [Male].
+ */
+enum class VoiceGender { Female, Male, Unknown }
 
 /**
  * Voice quality tiers shown in the picker. Order in this enum is

--- a/core-playback/src/main/kotlin/in/jphe/storyvox/playback/voice/VoiceCatalog.kt
+++ b/core-playback/src/main/kotlin/in/jphe/storyvox/playback/voice/VoiceCatalog.kt
@@ -5,9 +5,14 @@ object VoiceCatalog {
     fun byId(id: String): CatalogEntry? = voices.firstOrNull { it.id == id }
 
     /** The three voices we hand-picked as the strongest starters. Surfaced
-     *  on the first-launch picker AND highlighted in the Voice Library
-     *  under a "Featured" section so newcomers don't have to scroll the
-     *  98-voice catalog hunting for the good ones.
+     *  on the first-launch [VoicePickerGate] picker so newcomers don't
+     *  have to scroll the 98-voice catalog hunting for the good ones.
+     *
+     *  In the Voice Library these are marked with the inline ⭐ prefix
+     *  on their [CatalogEntry.displayName] (kept across #128's title
+     *  cleanup) — the dedicated "Featured" section was removed in #129
+     *  and these voices now appear in their natural Engine → Tier home
+     *  alongside every other entry, just visually marked.
      *
      *  Curated per JP's call (issue #10): Cori for en_GB Piper, Lessac
      *  for en_US Piper, Aoede for the multi-speaker Kokoro path. Three
@@ -20,7 +25,7 @@ object VoiceCatalog {
     private fun piperEntries(): List<CatalogEntry> = listOf(
         CatalogEntry(
             id = "piper_lessac_en_US_high",
-            displayName = "⭐ Lessac (High)",
+            displayName = "⭐ Lessac",
             language = "en_US",
             sizeBytes = 113895332L,
             qualityLevel = QualityLevel.High,
@@ -29,10 +34,11 @@ object VoiceCatalog {
                 onnxUrl = "https://github.com/jphein/VoxSherpa-TTS/releases/download/voices-v2/en_US-lessac-high.onnx",
                 tokensUrl = "https://github.com/jphein/VoxSherpa-TTS/releases/download/voices-v2/en_US-lessac-high.tokens.txt",
             ),
+            gender = VoiceGender.Female,
         ),
         CatalogEntry(
             id = "piper_ryan_en_US_high",
-            displayName = "⭐ Ryan (High)",
+            displayName = "⭐ Ryan",
             language = "en_US",
             sizeBytes = 120786923L,
             qualityLevel = QualityLevel.High,
@@ -41,10 +47,11 @@ object VoiceCatalog {
                 onnxUrl = "https://github.com/jphein/VoxSherpa-TTS/releases/download/voices-v2/en_US-ryan-high.onnx",
                 tokensUrl = "https://github.com/jphein/VoxSherpa-TTS/releases/download/voices-v2/en_US-ryan-high.tokens.txt",
             ),
+            gender = VoiceGender.Male,
         ),
         CatalogEntry(
             id = "piper_amy_en_US_medium",
-            displayName = "⭐ Amy (Medium)",
+            displayName = "⭐ Amy",
             language = "en_US",
             sizeBytes = 63201425L,
             qualityLevel = QualityLevel.Medium,
@@ -53,10 +60,11 @@ object VoiceCatalog {
                 onnxUrl = "https://github.com/jphein/VoxSherpa-TTS/releases/download/voices-v2/en_US-amy-medium.onnx",
                 tokensUrl = "https://github.com/jphein/VoxSherpa-TTS/releases/download/voices-v2/en_US-amy-medium.tokens.txt",
             ),
+            gender = VoiceGender.Female,
         ),
         CatalogEntry(
             id = "piper_alan_en_GB_low",
-            displayName = "Alan (Low)",
+            displayName = "Alan",
             language = "en_GB",
             sizeBytes = 63104662L,
             qualityLevel = QualityLevel.Low,
@@ -65,10 +73,11 @@ object VoiceCatalog {
                 onnxUrl = "https://github.com/jphein/VoxSherpa-TTS/releases/download/voices-v2/en_GB-alan-low.onnx",
                 tokensUrl = "https://github.com/jphein/VoxSherpa-TTS/releases/download/voices-v2/en_GB-alan-low.tokens.txt",
             ),
+            gender = VoiceGender.Male,
         ),
         CatalogEntry(
             id = "piper_alan_en_GB_medium",
-            displayName = "Alan (Medium)",
+            displayName = "Alan",
             language = "en_GB",
             sizeBytes = 63201430L,
             qualityLevel = QualityLevel.Medium,
@@ -77,10 +86,11 @@ object VoiceCatalog {
                 onnxUrl = "https://github.com/jphein/VoxSherpa-TTS/releases/download/voices-v2/en_GB-alan-medium.onnx",
                 tokensUrl = "https://github.com/jphein/VoxSherpa-TTS/releases/download/voices-v2/en_GB-alan-medium.tokens.txt",
             ),
+            gender = VoiceGender.Male,
         ),
         CatalogEntry(
             id = "piper_alba_en_GB_medium",
-            displayName = "Alba (Medium)",
+            displayName = "Alba",
             language = "en_GB",
             sizeBytes = 63201430L,
             qualityLevel = QualityLevel.Medium,
@@ -89,10 +99,11 @@ object VoiceCatalog {
                 onnxUrl = "https://github.com/jphein/VoxSherpa-TTS/releases/download/voices-v2/en_GB-alba-medium.onnx",
                 tokensUrl = "https://github.com/jphein/VoxSherpa-TTS/releases/download/voices-v2/en_GB-alba-medium.tokens.txt",
             ),
+            gender = VoiceGender.Female,
         ),
         CatalogEntry(
             id = "piper_aru_en_GB_medium",
-            displayName = "Aru (Medium)",
+            displayName = "Aru",
             language = "en_GB",
             sizeBytes = 76754234L,
             qualityLevel = QualityLevel.Medium,
@@ -101,10 +112,12 @@ object VoiceCatalog {
                 onnxUrl = "https://github.com/jphein/VoxSherpa-TTS/releases/download/voices-v2/en_GB-aru-medium.onnx",
                 tokensUrl = "https://github.com/jphein/VoxSherpa-TTS/releases/download/voices-v2/en_GB-aru-medium.tokens.txt",
             ),
+            // Aru is a multi-speaker dataset — leave gender Unknown so
+            // the subtitle collapses cleanly to "Piper · Medium".
         ),
         CatalogEntry(
             id = "piper_cori_en_GB_medium",
-            displayName = "Cori (Medium)",
+            displayName = "Cori",
             language = "en_GB",
             sizeBytes = 63531507L,
             qualityLevel = QualityLevel.Medium,
@@ -113,10 +126,11 @@ object VoiceCatalog {
                 onnxUrl = "https://github.com/jphein/VoxSherpa-TTS/releases/download/voices-v2/en_GB-cori-medium.onnx",
                 tokensUrl = "https://github.com/jphein/VoxSherpa-TTS/releases/download/voices-v2/en_GB-cori-medium.tokens.txt",
             ),
+            gender = VoiceGender.Female,
         ),
         CatalogEntry(
             id = "piper_cori_en_GB_high",
-            displayName = "Cori (High)",
+            displayName = "Cori",
             language = "en_GB",
             sizeBytes = 114219480L,
             qualityLevel = QualityLevel.High,
@@ -125,10 +139,11 @@ object VoiceCatalog {
                 onnxUrl = "https://github.com/jphein/VoxSherpa-TTS/releases/download/voices-v2/en_GB-cori-high.onnx",
                 tokensUrl = "https://github.com/jphein/VoxSherpa-TTS/releases/download/voices-v2/en_GB-cori-high.tokens.txt",
             ),
+            gender = VoiceGender.Female,
         ),
         CatalogEntry(
             id = "piper_dii_en_GB_high",
-            displayName = "Dii (High)",
+            displayName = "Dii",
             language = "en_GB",
             sizeBytes = 63511174L,
             qualityLevel = QualityLevel.High,
@@ -140,7 +155,7 @@ object VoiceCatalog {
         ),
         CatalogEntry(
             id = "piper_jenny_dioco_en_GB_medium",
-            displayName = "Jenny Dioco (Medium)",
+            displayName = "Jenny Dioco",
             language = "en_GB",
             sizeBytes = 63201430L,
             qualityLevel = QualityLevel.Medium,
@@ -149,10 +164,11 @@ object VoiceCatalog {
                 onnxUrl = "https://github.com/jphein/VoxSherpa-TTS/releases/download/voices-v2/en_GB-jenny_dioco-medium.onnx",
                 tokensUrl = "https://github.com/jphein/VoxSherpa-TTS/releases/download/voices-v2/en_GB-jenny_dioco-medium.tokens.txt",
             ),
+            gender = VoiceGender.Female,
         ),
         CatalogEntry(
             id = "piper_miro_en_GB_high",
-            displayName = "Miro (High)",
+            displayName = "Miro",
             language = "en_GB",
             sizeBytes = 63511174L,
             qualityLevel = QualityLevel.High,
@@ -161,10 +177,11 @@ object VoiceCatalog {
                 onnxUrl = "https://github.com/jphein/VoxSherpa-TTS/releases/download/voices-v2/en_GB-miro-high.onnx",
                 tokensUrl = "https://github.com/jphein/VoxSherpa-TTS/releases/download/voices-v2/en_GB-miro-high.tokens.txt",
             ),
+            gender = VoiceGender.Male,
         ),
         CatalogEntry(
             id = "piper_northern_english_male_en_GB_medium",
-            displayName = "Northern English Male (Medium)",
+            displayName = "Northern English",
             language = "en_GB",
             sizeBytes = 63201430L,
             qualityLevel = QualityLevel.Medium,
@@ -173,10 +190,13 @@ object VoiceCatalog {
                 onnxUrl = "https://github.com/jphein/VoxSherpa-TTS/releases/download/voices-v2/en_GB-northern_english_male-medium.onnx",
                 tokensUrl = "https://github.com/jphein/VoxSherpa-TTS/releases/download/voices-v2/en_GB-northern_english_male-medium.tokens.txt",
             ),
+            // Gender lived in the title before #128 ("Northern English Male");
+            // it now lives in the subtitle, so the title drops the suffix.
+            gender = VoiceGender.Male,
         ),
         CatalogEntry(
             id = "piper_semaine_en_GB_medium",
-            displayName = "Semaine (Medium)",
+            displayName = "Semaine",
             language = "en_GB",
             sizeBytes = 76737847L,
             qualityLevel = QualityLevel.Medium,
@@ -185,10 +205,11 @@ object VoiceCatalog {
                 onnxUrl = "https://github.com/jphein/VoxSherpa-TTS/releases/download/voices-v2/en_GB-semaine-medium.onnx",
                 tokensUrl = "https://github.com/jphein/VoxSherpa-TTS/releases/download/voices-v2/en_GB-semaine-medium.tokens.txt",
             ),
+            // Semaine is a multi-speaker corpus — leave gender Unknown.
         ),
         CatalogEntry(
             id = "piper_southern_english_female_en_GB_low",
-            displayName = "Southern English Female (Low)",
+            displayName = "Southern English",
             language = "en_GB",
             sizeBytes = 63104662L,
             qualityLevel = QualityLevel.Low,
@@ -197,10 +218,11 @@ object VoiceCatalog {
                 onnxUrl = "https://github.com/jphein/VoxSherpa-TTS/releases/download/voices-v2/en_GB-southern_english_female-low.onnx",
                 tokensUrl = "https://github.com/jphein/VoxSherpa-TTS/releases/download/voices-v2/en_GB-southern_english_female-low.tokens.txt",
             ),
+            gender = VoiceGender.Female,
         ),
         CatalogEntry(
             id = "piper_southern_english_female_en_GB_medium",
-            displayName = "Southern English Female (Medium)",
+            displayName = "Southern English",
             language = "en_GB",
             sizeBytes = 77059414L,
             qualityLevel = QualityLevel.Medium,
@@ -209,10 +231,11 @@ object VoiceCatalog {
                 onnxUrl = "https://github.com/jphein/VoxSherpa-TTS/releases/download/voices-v2/en_GB-southern_english_female-medium.onnx",
                 tokensUrl = "https://github.com/jphein/VoxSherpa-TTS/releases/download/voices-v2/en_GB-southern_english_female-medium.tokens.txt",
             ),
+            gender = VoiceGender.Female,
         ),
         CatalogEntry(
             id = "piper_southern_english_male_en_GB_medium",
-            displayName = "Southern English Male (Medium)",
+            displayName = "Southern English",
             language = "en_GB",
             sizeBytes = 77063512L,
             qualityLevel = QualityLevel.Medium,
@@ -221,10 +244,11 @@ object VoiceCatalog {
                 onnxUrl = "https://github.com/jphein/VoxSherpa-TTS/releases/download/voices-v2/en_GB-southern_english_male-medium.onnx",
                 tokensUrl = "https://github.com/jphein/VoxSherpa-TTS/releases/download/voices-v2/en_GB-southern_english_male-medium.tokens.txt",
             ),
+            gender = VoiceGender.Male,
         ),
         CatalogEntry(
             id = "piper_sweetbbak_amy_en_GB_high",
-            displayName = "Sweetbbak Amy (High)",
+            displayName = "Sweetbbak Amy",
             language = "en_GB",
             sizeBytes = 114199142L,
             qualityLevel = QualityLevel.High,
@@ -233,10 +257,11 @@ object VoiceCatalog {
                 onnxUrl = "https://github.com/jphein/VoxSherpa-TTS/releases/download/voices-v2/en_GB-sweetbbak-amy.onnx",
                 tokensUrl = "https://github.com/jphein/VoxSherpa-TTS/releases/download/voices-v2/en_GB-sweetbbak-amy.tokens.txt",
             ),
+            gender = VoiceGender.Female,
         ),
         CatalogEntry(
             id = "piper_vctk_en_GB_medium",
-            displayName = "Vctk (Medium)",
+            displayName = "VCTK",
             language = "en_GB",
             sizeBytes = 76952891L,
             qualityLevel = QualityLevel.Medium,
@@ -245,10 +270,11 @@ object VoiceCatalog {
                 onnxUrl = "https://github.com/jphein/VoxSherpa-TTS/releases/download/voices-v2/en_GB-vctk-medium.onnx",
                 tokensUrl = "https://github.com/jphein/VoxSherpa-TTS/releases/download/voices-v2/en_GB-vctk-medium.tokens.txt",
             ),
+            // VCTK is a multi-speaker corpus — leave gender Unknown.
         ),
         CatalogEntry(
             id = "piper_amy_en_US_low",
-            displayName = "Amy (Low)",
+            displayName = "Amy",
             language = "en_US",
             sizeBytes = 63104657L,
             qualityLevel = QualityLevel.Low,
@@ -257,10 +283,11 @@ object VoiceCatalog {
                 onnxUrl = "https://github.com/jphein/VoxSherpa-TTS/releases/download/voices-v2/en_US-amy-low.onnx",
                 tokensUrl = "https://github.com/jphein/VoxSherpa-TTS/releases/download/voices-v2/en_US-amy-low.tokens.txt",
             ),
+            gender = VoiceGender.Female,
         ),
         CatalogEntry(
             id = "piper_arctic_en_US_medium",
-            displayName = "Arctic (Medium)",
+            displayName = "Arctic",
             language = "en_US",
             sizeBytes = 76715309L,
             qualityLevel = QualityLevel.Medium,
@@ -269,10 +296,11 @@ object VoiceCatalog {
                 onnxUrl = "https://github.com/jphein/VoxSherpa-TTS/releases/download/voices-v2/en_US-arctic-medium.onnx",
                 tokensUrl = "https://github.com/jphein/VoxSherpa-TTS/releases/download/voices-v2/en_US-arctic-medium.tokens.txt",
             ),
+            // CMU Arctic is a multi-speaker corpus — gender Unknown.
         ),
         CatalogEntry(
             id = "piper_bryce_en_US_medium",
-            displayName = "Bryce (Medium)",
+            displayName = "Bryce",
             language = "en_US",
             sizeBytes = 63152970L,
             qualityLevel = QualityLevel.Medium,
@@ -281,10 +309,11 @@ object VoiceCatalog {
                 onnxUrl = "https://github.com/jphein/VoxSherpa-TTS/releases/download/voices-v2/en_US-bryce-medium.onnx",
                 tokensUrl = "https://github.com/jphein/VoxSherpa-TTS/releases/download/voices-v2/en_US-bryce-medium.tokens.txt",
             ),
+            gender = VoiceGender.Male,
         ),
         CatalogEntry(
             id = "piper_danny_en_US_low",
-            displayName = "Danny (Low)",
+            displayName = "Danny",
             language = "en_US",
             sizeBytes = 63052430L,
             qualityLevel = QualityLevel.Low,
@@ -293,10 +322,11 @@ object VoiceCatalog {
                 onnxUrl = "https://github.com/jphein/VoxSherpa-TTS/releases/download/voices-v2/en_US-danny-low.onnx",
                 tokensUrl = "https://github.com/jphein/VoxSherpa-TTS/releases/download/voices-v2/en_US-danny-low.tokens.txt",
             ),
+            gender = VoiceGender.Male,
         ),
         CatalogEntry(
             id = "piper_glados_en_US_high",
-            displayName = "GLaDOS (High)",
+            displayName = "GLaDOS",
             language = "en_US",
             sizeBytes = 113800584L,
             qualityLevel = QualityLevel.High,
@@ -305,10 +335,11 @@ object VoiceCatalog {
                 onnxUrl = "https://github.com/jphein/VoxSherpa-TTS/releases/download/voices-v2/en_US-glados-high.onnx",
                 tokensUrl = "https://github.com/jphein/VoxSherpa-TTS/releases/download/voices-v2/en_US-glados-high.tokens.txt",
             ),
+            gender = VoiceGender.Female,
         ),
         CatalogEntry(
             id = "piper_glados_en_US_medium",
-            displayName = "GLaDOS (Medium)",
+            displayName = "GLaDOS",
             language = "en_US",
             sizeBytes = 63511169L,
             qualityLevel = QualityLevel.Medium,
@@ -317,10 +348,11 @@ object VoiceCatalog {
                 onnxUrl = "https://github.com/jphein/VoxSherpa-TTS/releases/download/voices-v2/en_US-glados.onnx",
                 tokensUrl = "https://github.com/jphein/VoxSherpa-TTS/releases/download/voices-v2/en_US-glados.tokens.txt",
             ),
+            gender = VoiceGender.Female,
         ),
         CatalogEntry(
             id = "piper_hfc_female_en_US_medium",
-            displayName = "Hfc Female (Medium)",
+            displayName = "HFC",
             language = "en_US",
             sizeBytes = 63149198L,
             qualityLevel = QualityLevel.Medium,
@@ -329,10 +361,12 @@ object VoiceCatalog {
                 onnxUrl = "https://github.com/jphein/VoxSherpa-TTS/releases/download/voices-v2/en_US-hfc_female-medium.onnx",
                 tokensUrl = "https://github.com/jphein/VoxSherpa-TTS/releases/download/voices-v2/en_US-hfc_female-medium.tokens.txt",
             ),
+            // "Female" lived in the title before #128; now it lives only in the subtitle.
+            gender = VoiceGender.Female,
         ),
         CatalogEntry(
             id = "piper_hfc_male_en_US_medium",
-            displayName = "Hfc Male (Medium)",
+            displayName = "HFC",
             language = "en_US",
             sizeBytes = 63149198L,
             qualityLevel = QualityLevel.Medium,
@@ -341,10 +375,11 @@ object VoiceCatalog {
                 onnxUrl = "https://github.com/jphein/VoxSherpa-TTS/releases/download/voices-v2/en_US-hfc_male-medium.onnx",
                 tokensUrl = "https://github.com/jphein/VoxSherpa-TTS/releases/download/voices-v2/en_US-hfc_male-medium.tokens.txt",
             ),
+            gender = VoiceGender.Male,
         ),
         CatalogEntry(
             id = "piper_joe_en_US_medium",
-            displayName = "Joe (Medium)",
+            displayName = "Joe",
             language = "en_US",
             sizeBytes = 63149198L,
             qualityLevel = QualityLevel.Medium,
@@ -353,10 +388,11 @@ object VoiceCatalog {
                 onnxUrl = "https://github.com/jphein/VoxSherpa-TTS/releases/download/voices-v2/en_US-joe-medium.onnx",
                 tokensUrl = "https://github.com/jphein/VoxSherpa-TTS/releases/download/voices-v2/en_US-joe-medium.tokens.txt",
             ),
+            gender = VoiceGender.Male,
         ),
         CatalogEntry(
             id = "piper_john_en_US_medium",
-            displayName = "John (Medium)",
+            displayName = "John",
             language = "en_US",
             sizeBytes = 63152970L,
             qualityLevel = QualityLevel.Medium,
@@ -365,10 +401,11 @@ object VoiceCatalog {
                 onnxUrl = "https://github.com/jphein/VoxSherpa-TTS/releases/download/voices-v2/en_US-john-medium.onnx",
                 tokensUrl = "https://github.com/jphein/VoxSherpa-TTS/releases/download/voices-v2/en_US-john-medium.tokens.txt",
             ),
+            gender = VoiceGender.Male,
         ),
         CatalogEntry(
             id = "piper_kathleen_en_US_low",
-            displayName = "Kathleen (Low)",
+            displayName = "Kathleen",
             language = "en_US",
             sizeBytes = 63052430L,
             qualityLevel = QualityLevel.Low,
@@ -377,10 +414,11 @@ object VoiceCatalog {
                 onnxUrl = "https://github.com/jphein/VoxSherpa-TTS/releases/download/voices-v2/en_US-kathleen-low.onnx",
                 tokensUrl = "https://github.com/jphein/VoxSherpa-TTS/releases/download/voices-v2/en_US-kathleen-low.tokens.txt",
             ),
+            gender = VoiceGender.Female,
         ),
         CatalogEntry(
             id = "piper_kristin_en_US_medium",
-            displayName = "Kristin (Medium)",
+            displayName = "Kristin",
             language = "en_US",
             sizeBytes = 63531507L,
             qualityLevel = QualityLevel.Medium,
@@ -389,10 +427,11 @@ object VoiceCatalog {
                 onnxUrl = "https://github.com/jphein/VoxSherpa-TTS/releases/download/voices-v2/en_US-kristin-medium.onnx",
                 tokensUrl = "https://github.com/jphein/VoxSherpa-TTS/releases/download/voices-v2/en_US-kristin-medium.tokens.txt",
             ),
+            gender = VoiceGender.Female,
         ),
         CatalogEntry(
             id = "piper_kusal_en_US_medium",
-            displayName = "Kusal (Medium)",
+            displayName = "Kusal",
             language = "en_US",
             sizeBytes = 63201425L,
             qualityLevel = QualityLevel.Medium,
@@ -401,10 +440,11 @@ object VoiceCatalog {
                 onnxUrl = "https://github.com/jphein/VoxSherpa-TTS/releases/download/voices-v2/en_US-kusal-medium.onnx",
                 tokensUrl = "https://github.com/jphein/VoxSherpa-TTS/releases/download/voices-v2/en_US-kusal-medium.tokens.txt",
             ),
+            gender = VoiceGender.Male,
         ),
         CatalogEntry(
             id = "piper_l2arctic_en_US_medium",
-            displayName = "L2Arctic (Medium)",
+            displayName = "L2 Arctic",
             language = "en_US",
             sizeBytes = 76778805L,
             qualityLevel = QualityLevel.Medium,
@@ -413,10 +453,11 @@ object VoiceCatalog {
                 onnxUrl = "https://github.com/jphein/VoxSherpa-TTS/releases/download/voices-v2/en_US-l2arctic-medium.onnx",
                 tokensUrl = "https://github.com/jphein/VoxSherpa-TTS/releases/download/voices-v2/en_US-l2arctic-medium.tokens.txt",
             ),
+            // L2-Arctic is a multi-speaker non-native-English corpus — gender Unknown.
         ),
         CatalogEntry(
             id = "piper_lessac_en_US_low",
-            displayName = "Lessac (Low)",
+            displayName = "Lessac",
             language = "en_US",
             sizeBytes = 63149198L,
             qualityLevel = QualityLevel.Low,
@@ -425,10 +466,11 @@ object VoiceCatalog {
                 onnxUrl = "https://github.com/jphein/VoxSherpa-TTS/releases/download/voices-v2/en_US-lessac-low.onnx",
                 tokensUrl = "https://github.com/jphein/VoxSherpa-TTS/releases/download/voices-v2/en_US-lessac-low.tokens.txt",
             ),
+            gender = VoiceGender.Female,
         ),
         CatalogEntry(
             id = "piper_lessac_en_US_medium",
-            displayName = "Lessac (Medium)",
+            displayName = "Lessac",
             language = "en_US",
             sizeBytes = 63149198L,
             qualityLevel = QualityLevel.Medium,
@@ -437,10 +479,11 @@ object VoiceCatalog {
                 onnxUrl = "https://github.com/jphein/VoxSherpa-TTS/releases/download/voices-v2/en_US-lessac-medium.onnx",
                 tokensUrl = "https://github.com/jphein/VoxSherpa-TTS/releases/download/voices-v2/en_US-lessac-medium.tokens.txt",
             ),
+            gender = VoiceGender.Female,
         ),
         CatalogEntry(
             id = "piper_libritts_en_US_high",
-            displayName = "Libritts (High)",
+            displayName = "LibriTTS",
             language = "en_US",
             sizeBytes = 129438513L,
             qualityLevel = QualityLevel.High,
@@ -449,10 +492,11 @@ object VoiceCatalog {
                 onnxUrl = "https://github.com/jphein/VoxSherpa-TTS/releases/download/voices-v2/en_US-libritts-high.onnx",
                 tokensUrl = "https://github.com/jphein/VoxSherpa-TTS/releases/download/voices-v2/en_US-libritts-high.tokens.txt",
             ),
+            // LibriTTS is a multi-speaker corpus — gender Unknown.
         ),
         CatalogEntry(
             id = "piper_libritts_r_en_US_medium",
-            displayName = "Libritts R (Medium)",
+            displayName = "LibriTTS R",
             language = "en_US",
             sizeBytes = 78529840L,
             qualityLevel = QualityLevel.Medium,
@@ -461,10 +505,11 @@ object VoiceCatalog {
                 onnxUrl = "https://github.com/jphein/VoxSherpa-TTS/releases/download/voices-v2/en_US-libritts_r-medium.onnx",
                 tokensUrl = "https://github.com/jphein/VoxSherpa-TTS/releases/download/voices-v2/en_US-libritts_r-medium.tokens.txt",
             ),
+            // LibriTTS-R is a multi-speaker corpus — gender Unknown.
         ),
         CatalogEntry(
             id = "piper_ljspeech_en_US_medium",
-            displayName = "Ljspeech (Medium)",
+            displayName = "LJ Speech",
             language = "en_US",
             sizeBytes = 63531507L,
             qualityLevel = QualityLevel.Medium,
@@ -473,10 +518,11 @@ object VoiceCatalog {
                 onnxUrl = "https://github.com/jphein/VoxSherpa-TTS/releases/download/voices-v2/en_US-ljspeech-medium.onnx",
                 tokensUrl = "https://github.com/jphein/VoxSherpa-TTS/releases/download/voices-v2/en_US-ljspeech-medium.tokens.txt",
             ),
+            gender = VoiceGender.Female,
         ),
         CatalogEntry(
             id = "piper_ljspeech_en_US_high",
-            displayName = "Ljspeech (High)",
+            displayName = "LJ Speech",
             language = "en_US",
             sizeBytes = 114199139L,
             qualityLevel = QualityLevel.High,
@@ -485,10 +531,11 @@ object VoiceCatalog {
                 onnxUrl = "https://github.com/jphein/VoxSherpa-TTS/releases/download/voices-v2/en_US-ljspeech-high.onnx",
                 tokensUrl = "https://github.com/jphein/VoxSherpa-TTS/releases/download/voices-v2/en_US-ljspeech-high.tokens.txt",
             ),
+            gender = VoiceGender.Female,
         ),
         CatalogEntry(
             id = "piper_miro_en_US_high",
-            displayName = "Miro (High)",
+            displayName = "Miro",
             language = "en_US",
             sizeBytes = 63511169L,
             qualityLevel = QualityLevel.High,
@@ -497,10 +544,11 @@ object VoiceCatalog {
                 onnxUrl = "https://github.com/jphein/VoxSherpa-TTS/releases/download/voices-v2/en_US-miro-high.onnx",
                 tokensUrl = "https://github.com/jphein/VoxSherpa-TTS/releases/download/voices-v2/en_US-miro-high.tokens.txt",
             ),
+            gender = VoiceGender.Male,
         ),
         CatalogEntry(
             id = "piper_norman_en_US_medium",
-            displayName = "Norman (Medium)",
+            displayName = "Norman",
             language = "en_US",
             sizeBytes = 63531507L,
             qualityLevel = QualityLevel.Medium,
@@ -509,10 +557,11 @@ object VoiceCatalog {
                 onnxUrl = "https://github.com/jphein/VoxSherpa-TTS/releases/download/voices-v2/en_US-norman-medium.onnx",
                 tokensUrl = "https://github.com/jphein/VoxSherpa-TTS/releases/download/voices-v2/en_US-norman-medium.tokens.txt",
             ),
+            gender = VoiceGender.Male,
         ),
         CatalogEntry(
             id = "piper_reza_ibrahim_en_US_medium",
-            displayName = "Reza Ibrahim (Medium)",
+            displayName = "Reza Ibrahim",
             language = "en_US",
             sizeBytes = 63511169L,
             qualityLevel = QualityLevel.Medium,
@@ -521,10 +570,11 @@ object VoiceCatalog {
                 onnxUrl = "https://github.com/jphein/VoxSherpa-TTS/releases/download/voices-v2/en_US-reza_ibrahim-medium.onnx",
                 tokensUrl = "https://github.com/jphein/VoxSherpa-TTS/releases/download/voices-v2/en_US-reza_ibrahim-medium.tokens.txt",
             ),
+            gender = VoiceGender.Male,
         ),
         CatalogEntry(
             id = "piper_ryan_en_US_low",
-            displayName = "Ryan (Low)",
+            displayName = "Ryan",
             language = "en_US",
             sizeBytes = 63052430L,
             qualityLevel = QualityLevel.Low,
@@ -533,10 +583,11 @@ object VoiceCatalog {
                 onnxUrl = "https://github.com/jphein/VoxSherpa-TTS/releases/download/voices-v2/en_US-ryan-low.onnx",
                 tokensUrl = "https://github.com/jphein/VoxSherpa-TTS/releases/download/voices-v2/en_US-ryan-low.tokens.txt",
             ),
+            gender = VoiceGender.Male,
         ),
         CatalogEntry(
             id = "piper_ryan_en_US_medium",
-            displayName = "Ryan (Medium)",
+            displayName = "Ryan",
             language = "en_US",
             sizeBytes = 63149198L,
             qualityLevel = QualityLevel.Medium,
@@ -545,10 +596,11 @@ object VoiceCatalog {
                 onnxUrl = "https://github.com/jphein/VoxSherpa-TTS/releases/download/voices-v2/en_US-ryan-medium.onnx",
                 tokensUrl = "https://github.com/jphein/VoxSherpa-TTS/releases/download/voices-v2/en_US-ryan-medium.tokens.txt",
             ),
+            gender = VoiceGender.Male,
         ),
         CatalogEntry(
             id = "piper_sam_en_US_medium",
-            displayName = "Sam (Medium)",
+            displayName = "Sam",
             language = "en_US",
             sizeBytes = 62946438L,
             qualityLevel = QualityLevel.Medium,
@@ -557,6 +609,7 @@ object VoiceCatalog {
                 onnxUrl = "https://github.com/jphein/VoxSherpa-TTS/releases/download/voices-v2/en_US-sam-medium.onnx",
                 tokensUrl = "https://github.com/jphein/VoxSherpa-TTS/releases/download/voices-v2/en_US-sam-medium.tokens.txt",
             ),
+            // "Sam" is unisex — leave gender Unknown.
         ),
     )
 
@@ -565,9 +618,15 @@ object VoiceCatalog {
      *  rather than hardcoded inline so the rule lives in one place and
      *  stays unit-testable. The vast majority resolve to [QualityLevel.High];
      *  a curated few (see [VoiceTier.STUDIO_KOKORO_IDS]) get bumped to
-     *  [QualityLevel.Studio]. */
+     *  [QualityLevel.Studio].
+     *
+     *  Display names are clean (no flag prefix, no "(Language Gender)"
+     *  parenthetical) per #128 — the Voice Library composes the on-screen
+     *  title as `<flag> <displayName>` and the subtitle as
+     *  `<Engine> · <Tier> · <Gender>`. Language is already represented by
+     *  the rendered flag, so we don't repeat it. */
     private fun kokoroEntries(): List<CatalogEntry> {
-        fun kokoro(id: String, displayName: String, language: String, speakerId: Int): CatalogEntry =
+        fun kokoro(id: String, displayName: String, language: String, speakerId: Int, gender: VoiceGender): CatalogEntry =
             CatalogEntry(
                 id = id,
                 displayName = displayName,
@@ -576,61 +635,64 @@ object VoiceCatalog {
                 qualityLevel = VoiceTier.forKokoroId(id),
                 engineType = EngineType.Kokoro(speakerId = speakerId),
                 piper = null,
+                gender = gender,
             )
+        val F = VoiceGender.Female
+        val M = VoiceGender.Male
         return listOf(
-            kokoro("kokoro_alloy_en_US_0", "🇺🇸 Alloy (English Female)", "en_US", 0),
-            kokoro("kokoro_aoede_en_US_1", "🇺🇸 Aoede (English Female)", "en_US", 1),
-            kokoro("kokoro_bella_en_US_2", "🇺🇸 Bella (English Female)", "en_US", 2),
-            kokoro("kokoro_heart_en_US_3", "🇺🇸 Heart (English Female)", "en_US", 3),
-            kokoro("kokoro_jessica_en_US_4", "🇺🇸 Jessica (English Female)", "en_US", 4),
-            kokoro("kokoro_kore_en_US_5", "🇺🇸 Kore (English Female)", "en_US", 5),
-            kokoro("kokoro_nicole_en_US_6", "🇺🇸 Nicole (English Female)", "en_US", 6),
-            kokoro("kokoro_nova_en_US_7", "🇺🇸 Nova (English Female)", "en_US", 7),
-            kokoro("kokoro_river_en_US_8", "🇺🇸 River (English Female)", "en_US", 8),
-            kokoro("kokoro_sarah_en_US_9", "🇺🇸 Sarah (English Female)", "en_US", 9),
-            kokoro("kokoro_sky_en_US_10", "🇺🇸 Sky (English Female)", "en_US", 10),
-            kokoro("kokoro_adam_en_US_11", "🇺🇸 Adam (English Male)", "en_US", 11),
-            kokoro("kokoro_echo_en_US_12", "🇺🇸 Echo (English Male)", "en_US", 12),
-            kokoro("kokoro_eric_en_US_13", "🇺🇸 Eric (English Male)", "en_US", 13),
-            kokoro("kokoro_fenrir_en_US_14", "🇺🇸 Fenrir (English Male)", "en_US", 14),
-            kokoro("kokoro_liam_en_US_15", "🇺🇸 Liam (English Male)", "en_US", 15),
-            kokoro("kokoro_michael_en_US_16", "🇺🇸 Michael (English Male)", "en_US", 16),
-            kokoro("kokoro_onyx_en_US_17", "🇺🇸 Onyx (English Male)", "en_US", 17),
-            kokoro("kokoro_puck_en_US_18", "🇺🇸 Puck (English Male)", "en_US", 18),
-            kokoro("kokoro_santa_en_US_19", "🇺🇸 Santa (English Male)", "en_US", 19),
-            kokoro("kokoro_alice_en_GB_20", "🇬🇧 Alice (English Female)", "en_GB", 20),
-            kokoro("kokoro_emma_en_GB_21", "🇬🇧 Emma (English Female)", "en_GB", 21),
-            kokoro("kokoro_isabella_en_GB_22", "🇬🇧 Isabella (English Female)", "en_GB", 22),
-            kokoro("kokoro_lily_en_GB_23", "🇬🇧 Lily (English Female)", "en_GB", 23),
-            kokoro("kokoro_daniel_en_GB_24", "🇬🇧 Daniel (English Male)", "en_GB", 24),
-            kokoro("kokoro_fable_en_GB_25", "🇬🇧 Fable (English Male)", "en_GB", 25),
-            kokoro("kokoro_george_en_GB_26", "🇬🇧 George (English Male)", "en_GB", 26),
-            kokoro("kokoro_lewis_en_GB_27", "🇬🇧 Lewis (English Male)", "en_GB", 27),
-            kokoro("kokoro_dora_es_ES_28", "🇪🇸 Dora (Spanish Female)", "es_ES", 28),
-            kokoro("kokoro_alex_es_ES_29", "🇪🇸 Alex (Spanish Male)", "es_ES", 29),
-            kokoro("kokoro_siwis_fr_FR_30", "🇫🇷 Siwis (French Female)", "fr_FR", 30),
-            kokoro("kokoro_alpha_hi_IN_31", "🇮🇳 Alpha (Hindi Female)", "hi_IN", 31),
-            kokoro("kokoro_beta_hi_IN_32", "🇮🇳 Beta (Hindi Female)", "hi_IN", 32),
-            kokoro("kokoro_omega_hi_IN_33", "🇮🇳 Omega (Hindi Male)", "hi_IN", 33),
-            kokoro("kokoro_psi_hi_IN_34", "🇮🇳 Psi (Hindi Male)", "hi_IN", 34),
-            kokoro("kokoro_sara_it_IT_35", "🇮🇹 Sara (Italian Female)", "it_IT", 35),
-            kokoro("kokoro_nicola_it_IT_36", "🇮🇹 Nicola (Italian Male)", "it_IT", 36),
-            kokoro("kokoro_alpha_ja_JP_37", "🇯🇵 Alpha (Japanese Female)", "ja_JP", 37),
-            kokoro("kokoro_gongitsune_ja_JP_38", "🇯🇵 Gongitsune (Japanese Female)", "ja_JP", 38),
-            kokoro("kokoro_nezumi_ja_JP_39", "🇯🇵 Nezumi (Japanese Female)", "ja_JP", 39),
-            kokoro("kokoro_tebukuro_ja_JP_40", "🇯🇵 Tebukuro (Japanese Female)", "ja_JP", 40),
-            kokoro("kokoro_kumo_ja_JP_41", "🇯🇵 Kumo (Japanese Male)", "ja_JP", 41),
-            kokoro("kokoro_dora_pt_PT_42", "🇵🇹 Dora (Portuguese Female)", "pt_PT", 42),
-            kokoro("kokoro_alex_pt_PT_43", "🇵🇹 Alex (Portuguese Male)", "pt_PT", 43),
-            kokoro("kokoro_santa_pt_PT_44", "🇵🇹 Santa (Portuguese Male)", "pt_PT", 44),
-            kokoro("kokoro_xiaobei_zh_CN_45", "🇨🇳 Xiaobei (Chinese Female)", "zh_CN", 45),
-            kokoro("kokoro_xiaoni_zh_CN_46", "🇨🇳 Xiaoni (Chinese Female)", "zh_CN", 46),
-            kokoro("kokoro_xiaoxiao_zh_CN_47", "🇨🇳 Xiaoxiao (Chinese Female)", "zh_CN", 47),
-            kokoro("kokoro_xiaoyi_zh_CN_48", "🇨🇳 Xiaoyi (Chinese Female)", "zh_CN", 48),
-            kokoro("kokoro_yunjian_zh_CN_49", "🇨🇳 Yunjian (Chinese Male)", "zh_CN", 49),
-            kokoro("kokoro_yunxi_zh_CN_50", "🇨🇳 Yunxi (Chinese Male)", "zh_CN", 50),
-            kokoro("kokoro_yunxia_zh_CN_51", "🇨🇳 Yunxia (Chinese Male)", "zh_CN", 51),
-            kokoro("kokoro_yunyang_zh_CN_52", "🇨🇳 Yunyang (Chinese Male)", "zh_CN", 52),
+            kokoro("kokoro_alloy_en_US_0", "Alloy", "en_US", 0, F),
+            kokoro("kokoro_aoede_en_US_1", "Aoede", "en_US", 1, F),
+            kokoro("kokoro_bella_en_US_2", "Bella", "en_US", 2, F),
+            kokoro("kokoro_heart_en_US_3", "Heart", "en_US", 3, F),
+            kokoro("kokoro_jessica_en_US_4", "Jessica", "en_US", 4, F),
+            kokoro("kokoro_kore_en_US_5", "Kore", "en_US", 5, F),
+            kokoro("kokoro_nicole_en_US_6", "Nicole", "en_US", 6, F),
+            kokoro("kokoro_nova_en_US_7", "Nova", "en_US", 7, F),
+            kokoro("kokoro_river_en_US_8", "River", "en_US", 8, F),
+            kokoro("kokoro_sarah_en_US_9", "Sarah", "en_US", 9, F),
+            kokoro("kokoro_sky_en_US_10", "Sky", "en_US", 10, F),
+            kokoro("kokoro_adam_en_US_11", "Adam", "en_US", 11, M),
+            kokoro("kokoro_echo_en_US_12", "Echo", "en_US", 12, M),
+            kokoro("kokoro_eric_en_US_13", "Eric", "en_US", 13, M),
+            kokoro("kokoro_fenrir_en_US_14", "Fenrir", "en_US", 14, M),
+            kokoro("kokoro_liam_en_US_15", "Liam", "en_US", 15, M),
+            kokoro("kokoro_michael_en_US_16", "Michael", "en_US", 16, M),
+            kokoro("kokoro_onyx_en_US_17", "Onyx", "en_US", 17, M),
+            kokoro("kokoro_puck_en_US_18", "Puck", "en_US", 18, M),
+            kokoro("kokoro_santa_en_US_19", "Santa", "en_US", 19, M),
+            kokoro("kokoro_alice_en_GB_20", "Alice", "en_GB", 20, F),
+            kokoro("kokoro_emma_en_GB_21", "Emma", "en_GB", 21, F),
+            kokoro("kokoro_isabella_en_GB_22", "Isabella", "en_GB", 22, F),
+            kokoro("kokoro_lily_en_GB_23", "Lily", "en_GB", 23, F),
+            kokoro("kokoro_daniel_en_GB_24", "Daniel", "en_GB", 24, M),
+            kokoro("kokoro_fable_en_GB_25", "Fable", "en_GB", 25, M),
+            kokoro("kokoro_george_en_GB_26", "George", "en_GB", 26, M),
+            kokoro("kokoro_lewis_en_GB_27", "Lewis", "en_GB", 27, M),
+            kokoro("kokoro_dora_es_ES_28", "Dora", "es_ES", 28, F),
+            kokoro("kokoro_alex_es_ES_29", "Alex", "es_ES", 29, M),
+            kokoro("kokoro_siwis_fr_FR_30", "Siwis", "fr_FR", 30, F),
+            kokoro("kokoro_alpha_hi_IN_31", "Alpha", "hi_IN", 31, F),
+            kokoro("kokoro_beta_hi_IN_32", "Beta", "hi_IN", 32, F),
+            kokoro("kokoro_omega_hi_IN_33", "Omega", "hi_IN", 33, M),
+            kokoro("kokoro_psi_hi_IN_34", "Psi", "hi_IN", 34, M),
+            kokoro("kokoro_sara_it_IT_35", "Sara", "it_IT", 35, F),
+            kokoro("kokoro_nicola_it_IT_36", "Nicola", "it_IT", 36, M),
+            kokoro("kokoro_alpha_ja_JP_37", "Alpha", "ja_JP", 37, F),
+            kokoro("kokoro_gongitsune_ja_JP_38", "Gongitsune", "ja_JP", 38, F),
+            kokoro("kokoro_nezumi_ja_JP_39", "Nezumi", "ja_JP", 39, F),
+            kokoro("kokoro_tebukuro_ja_JP_40", "Tebukuro", "ja_JP", 40, F),
+            kokoro("kokoro_kumo_ja_JP_41", "Kumo", "ja_JP", 41, M),
+            kokoro("kokoro_dora_pt_PT_42", "Dora", "pt_PT", 42, F),
+            kokoro("kokoro_alex_pt_PT_43", "Alex", "pt_PT", 43, M),
+            kokoro("kokoro_santa_pt_PT_44", "Santa", "pt_PT", 44, M),
+            kokoro("kokoro_xiaobei_zh_CN_45", "Xiaobei", "zh_CN", 45, F),
+            kokoro("kokoro_xiaoni_zh_CN_46", "Xiaoni", "zh_CN", 46, F),
+            kokoro("kokoro_xiaoxiao_zh_CN_47", "Xiaoxiao", "zh_CN", 47, F),
+            kokoro("kokoro_xiaoyi_zh_CN_48", "Xiaoyi", "zh_CN", 48, F),
+            kokoro("kokoro_yunjian_zh_CN_49", "Yunjian", "zh_CN", 49, M),
+            kokoro("kokoro_yunxi_zh_CN_50", "Yunxi", "zh_CN", 50, M),
+            kokoro("kokoro_yunxia_zh_CN_51", "Yunxia", "zh_CN", 51, M),
+            kokoro("kokoro_yunyang_zh_CN_52", "Yunyang", "zh_CN", 52, M),
         )
     }
 
@@ -724,6 +786,11 @@ object VoiceCatalog {
 
 data class CatalogEntry(
     val id: String,
+    /** Clean voice name only — e.g. "Lessac", "Aoede". No tier
+     *  parentheticals, no flag prefix, no engine/quality clutter. The
+     *  ⭐ marker on curated entries stays inline (see [VoiceCatalog.featuredIds]).
+     *  See #128 — the Voice Library composes the on-screen title as
+     *  `<flag> <displayName>` and the subtitle as `<Engine> · <Tier> · <Gender>`. */
     val displayName: String,
     val language: String,
     val sizeBytes: Long,
@@ -742,6 +809,10 @@ data class CatalogEntry(
      * one-line change here, not a UI hunt.
      */
     val cost: VoiceCost? = null,
+    /** Best-effort gender from upstream metadata. Defaults to
+     *  [VoiceGender.Unknown] for Piper voices whose filenames don't
+     *  encode gender (e.g. "lessac" — a name, not a gender marker). */
+    val gender: VoiceGender = VoiceGender.Unknown,
 )
 
 data class PiperPaths(val onnxUrl: String, val tokensUrl: String)
@@ -762,3 +833,21 @@ data class VoiceCost(
     val centsPer1MChars: Int,
     val billedBy: String,
 )
+
+/** Map a BCP-47-ish language code (the catalog uses POSIX-style
+ *  `xx_YY`) to a country flag emoji. Falls back to a globe glyph for
+ *  any code we haven't enumerated — keeps the title prefix non-empty
+ *  so layout doesn't shift when a new language lands in the catalog
+ *  before its flag mapping does. */
+fun flagForLanguage(language: String): String = when (language) {
+    "en_US" -> "🇺🇸"
+    "en_GB" -> "🇬🇧"
+    "es_ES" -> "🇪🇸"
+    "fr_FR" -> "🇫🇷"
+    "hi_IN" -> "🇮🇳"
+    "it_IT" -> "🇮🇹"
+    "ja_JP" -> "🇯🇵"
+    "pt_PT" -> "🇵🇹"
+    "zh_CN" -> "🇨🇳"
+    else -> "🌐"
+}

--- a/core-playback/src/main/kotlin/in/jphe/storyvox/playback/voice/VoiceLibraryCollapse.kt
+++ b/core-playback/src/main/kotlin/in/jphe/storyvox/playback/voice/VoiceLibraryCollapse.kt
@@ -1,0 +1,128 @@
+package `in`.jphe.storyvox.playback.voice
+
+import android.content.Context
+import androidx.datastore.core.DataStore
+import androidx.datastore.preferences.core.Preferences
+import androidx.datastore.preferences.core.edit
+import androidx.datastore.preferences.core.stringSetPreferencesKey
+import androidx.datastore.preferences.preferencesDataStore
+import dagger.hilt.android.qualifiers.ApplicationContext
+import javax.inject.Inject
+import javax.inject.Singleton
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.map
+
+/**
+ * Per-engine collapse memory for the Voice Library (#130).
+ *
+ * The library renders engine sub-headers (Piper / Kokoro) under the
+ * Installed and Available section headers. Tapping an engine sub-header
+ * collapses the tier sub-headers and voice rows beneath it; tapping
+ * again expands them. This store persists those toggles across app
+ * restarts.
+ *
+ * **Default policy** — drives the meaning of "absent from the stored set":
+ * - Installed engines default to **expanded** (a user with installed
+ *   voices wants to see them at a glance — the section is small and
+ *   already-curated).
+ * - Available engines default to **collapsed** (the long tail of 50+
+ *   voices is what makes scrolling painful; first-paint should hide
+ *   them by default and let the user opt in per engine).
+ *
+ * The on-disk schema stores **flipped-from-default** keys only — i.e.
+ * an entry is present in the set iff its current state differs from
+ * the default for its section. This keeps the persisted set tiny in
+ * the common case (most users won't toggle anything) and means a
+ * fresh-install user with an empty set sees exactly the default
+ * layout. See [isCollapsed].
+ *
+ * Schema-evolution note: the DataStore name is suffixed `_v1`. If the
+ * default policy ever flips, mint a `_v2` rather than reinterpreting
+ * existing `_v1` entries — the meaning of the stored set is tied to
+ * the defaults at write time.
+ */
+private val Context.voiceLibraryCollapseStore: DataStore<Preferences> by preferencesDataStore(
+    name = "voice_library_collapsed_engines_v1",
+)
+
+private object CollapseKeys {
+    /** String set of engine keys whose state is **flipped** from the
+     *  default for their section. Each entry is `"<section>:<engine>"`,
+     *  e.g. `"installed:Piper"` or `"available:Kokoro"`. */
+    val FLIPPED = stringSetPreferencesKey("flipped_engine_keys")
+}
+
+/** Section discriminator for the collapse store. Starred has no engine
+ *  sub-headers (one flat list), so it isn't represented here. */
+enum class VoiceLibrarySection { Installed, Available }
+
+/** Composite key for an engine sub-header within a section. The
+ *  collapse store keys on the rendered string `"<section>:<engine>"`
+ *  so the on-disk format stays human-readable in case anyone ever
+ *  needs to inspect the prefs file. */
+data class EngineKey(val section: VoiceLibrarySection, val engine: VoiceEngineId) {
+    /** On-disk key — keep stable across refactors. */
+    fun storeKey(): String = "${section.name.lowercase()}:${engine.name}"
+}
+
+/** Mirror of the feature-module `VoiceEngine` enum, lifted into core
+ *  so the collapse store can key on it without a feature dependency.
+ *  Keep in lockstep with [VoiceEngine] in
+ *  `feature/.../voicelibrary/VoiceLibraryViewModel.kt`. */
+enum class VoiceEngineId { Piper, Kokoro, Azure }
+
+@Singleton
+class VoiceLibraryCollapse private constructor(
+    private val store: DataStore<Preferences>,
+) {
+    /** Hilt entry point. Uses [Context.voiceLibraryCollapseStore]. */
+    @Inject
+    constructor(@ApplicationContext context: Context) : this(context.voiceLibraryCollapseStore)
+
+    /** Reactive set of [EngineKey] entries currently flipped from
+     *  their section default. Empty on first launch. */
+    val flippedKeys: Flow<Set<String>> = store.data.map { prefs ->
+        prefs[CollapseKeys.FLIPPED].orEmpty()
+    }
+
+    /** Idempotent toggle — flips the (section, engine) pair's state
+     *  away from / back to its default. Use [isCollapsed] downstream
+     *  to derive the rendered state from the flipped set. */
+    suspend fun toggle(key: EngineKey) {
+        store.edit { prefs ->
+            val current = prefs[CollapseKeys.FLIPPED].orEmpty()
+            val storeKey = key.storeKey()
+            prefs[CollapseKeys.FLIPPED] = if (storeKey in current) {
+                current - storeKey
+            } else {
+                current + storeKey
+            }
+        }
+    }
+
+    companion object {
+        /** Derive the rendered "collapsed" state for an engine sub-header
+         *  given the persisted flipped-keys set. Encapsulates the
+         *  default policy described in the class kdoc:
+         *  Installed → default expanded → flipped means collapsed.
+         *  Available → default collapsed → flipped means expanded.
+         *  Returning a Boolean keeps the call site clean — composables
+         *  can `if (isCollapsed) skip rows`. */
+        fun isCollapsed(key: EngineKey, flipped: Set<String>): Boolean {
+            val isFlipped = key.storeKey() in flipped
+            val defaultExpanded = when (key.section) {
+                VoiceLibrarySection.Installed -> true
+                VoiceLibrarySection.Available -> false
+            }
+            // Collapsed = default-expanded XOR flipped.
+            //   Installed: expanded by default → flipped means collapsed.
+            //   Available: collapsed by default → flipped means expanded;
+            //     i.e. NOT flipped → collapsed.
+            return defaultExpanded == isFlipped
+        }
+
+        /** Test-only factory. */
+        fun forTesting(store: DataStore<Preferences>): VoiceLibraryCollapse =
+            VoiceLibraryCollapse(store)
+    }
+}

--- a/core-playback/src/main/kotlin/in/jphe/storyvox/playback/voice/VoiceManager.kt
+++ b/core-playback/src/main/kotlin/in/jphe/storyvox/playback/voice/VoiceManager.kt
@@ -394,5 +394,6 @@ class VoiceManager @Inject constructor(
         isInstalled = installed,
         qualityLevel = qualityLevel,
         engineType = engineType,
+        gender = gender,
     )
 }

--- a/core-playback/src/test/kotlin/in/jphe/storyvox/playback/voice/VoiceLibraryCollapseTest.kt
+++ b/core-playback/src/test/kotlin/in/jphe/storyvox/playback/voice/VoiceLibraryCollapseTest.kt
@@ -1,0 +1,162 @@
+package `in`.jphe.storyvox.playback.voice
+
+import androidx.datastore.core.DataStore
+import androidx.datastore.preferences.core.PreferenceDataStoreFactory
+import androidx.datastore.preferences.core.Preferences
+import java.io.File
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlinx.coroutines.test.runTest
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import org.junit.rules.TemporaryFolder
+
+/**
+ * Real-DataStore tests for [VoiceLibraryCollapse] (#130). Same shape
+ * as [VoiceFavoritesTest] — temp-file preferences DataStore against
+ * a [TemporaryFolder] so the persistence layer is exactly what
+ * production runs against; no Robolectric needed.
+ *
+ * The semantic interesting bit lives in [VoiceLibraryCollapse.isCollapsed]
+ * (default policy: Installed expanded, Available collapsed) and the
+ * way the on-disk set stores **flipped-from-default** keys only.
+ */
+@OptIn(ExperimentalCoroutinesApi::class)
+class VoiceLibraryCollapseTest {
+
+    @get:Rule
+    val tempFolder = TemporaryFolder()
+
+    private lateinit var scope: CoroutineScope
+    private lateinit var store: DataStore<Preferences>
+    private lateinit var collapse: VoiceLibraryCollapse
+
+    @Before
+    fun setUp() {
+        scope = CoroutineScope(SupervisorJob() + UnconfinedTestDispatcher())
+        val file = File(tempFolder.newFolder(), "voice_library_collapsed_engines_v1.preferences_pb")
+        store = PreferenceDataStoreFactory.create(
+            scope = scope,
+            produceFile = { file },
+        )
+        collapse = VoiceLibraryCollapse.forTesting(store)
+    }
+
+    @After
+    fun tearDown() {
+        scope.cancel()
+    }
+
+    @Test
+    fun `initial flipped set is empty`() = runTest {
+        assertEquals(emptySet<String>(), collapse.flippedKeys.first())
+    }
+
+    @Test
+    fun `installed default is expanded — empty set means not collapsed`() {
+        val key = EngineKey(VoiceLibrarySection.Installed, VoiceEngineId.Piper)
+        assertFalse(VoiceLibraryCollapse.isCollapsed(key, flipped = emptySet()))
+    }
+
+    @Test
+    fun `available default is collapsed — empty set means collapsed`() {
+        val key = EngineKey(VoiceLibrarySection.Available, VoiceEngineId.Piper)
+        assertTrue(VoiceLibraryCollapse.isCollapsed(key, flipped = emptySet()))
+    }
+
+    @Test
+    fun `flipping installed engine collapses it`() = runTest {
+        val key = EngineKey(VoiceLibrarySection.Installed, VoiceEngineId.Kokoro)
+        collapse.toggle(key)
+
+        val flipped = collapse.flippedKeys.first()
+        assertEquals(setOf("installed:Kokoro"), flipped)
+        assertTrue(VoiceLibraryCollapse.isCollapsed(key, flipped))
+    }
+
+    @Test
+    fun `flipping available engine expands it`() = runTest {
+        val key = EngineKey(VoiceLibrarySection.Available, VoiceEngineId.Kokoro)
+        collapse.toggle(key)
+
+        val flipped = collapse.flippedKeys.first()
+        assertEquals(setOf("available:Kokoro"), flipped)
+        assertFalse(VoiceLibraryCollapse.isCollapsed(key, flipped))
+    }
+
+    @Test
+    fun `toggle is idempotent — flip then unflip returns to default`() = runTest {
+        val key = EngineKey(VoiceLibrarySection.Installed, VoiceEngineId.Piper)
+        collapse.toggle(key)
+        collapse.toggle(key)
+
+        val flipped = collapse.flippedKeys.first()
+        assertEquals(emptySet<String>(), flipped)
+        // Default is expanded — back where we started.
+        assertFalse(VoiceLibraryCollapse.isCollapsed(key, flipped))
+    }
+
+    @Test
+    fun `flipping one engine doesn't affect the other in same section`() = runTest {
+        val piperKey = EngineKey(VoiceLibrarySection.Installed, VoiceEngineId.Piper)
+        val kokoroKey = EngineKey(VoiceLibrarySection.Installed, VoiceEngineId.Kokoro)
+
+        collapse.toggle(piperKey)
+
+        val flipped = collapse.flippedKeys.first()
+        assertTrue(VoiceLibraryCollapse.isCollapsed(piperKey, flipped))
+        // Kokoro under Installed still defaults to expanded.
+        assertFalse(VoiceLibraryCollapse.isCollapsed(kokoroKey, flipped))
+    }
+
+    @Test
+    fun `flipping installed Piper doesn't affect available Piper`() = runTest {
+        val installedKey = EngineKey(VoiceLibrarySection.Installed, VoiceEngineId.Piper)
+        val availableKey = EngineKey(VoiceLibrarySection.Available, VoiceEngineId.Piper)
+
+        collapse.toggle(installedKey)
+
+        val flipped = collapse.flippedKeys.first()
+        assertTrue(VoiceLibraryCollapse.isCollapsed(installedKey, flipped))
+        // Available default is still collapsed; not affected by the
+        // Installed flip even though the engine matches.
+        assertTrue(VoiceLibraryCollapse.isCollapsed(availableKey, flipped))
+    }
+
+    @Test
+    fun `round-trip survives reinitialization of the collapse facade`() = runTest {
+        val key = EngineKey(VoiceLibrarySection.Available, VoiceEngineId.Kokoro)
+        collapse.toggle(key)
+        assertEquals(setOf("available:Kokoro"), collapse.flippedKeys.first())
+
+        // Bind a fresh facade against the same underlying store —
+        // simulates app process restart against the persisted prefs.
+        val rebound = VoiceLibraryCollapse.forTesting(store)
+        assertEquals(setOf("available:Kokoro"), rebound.flippedKeys.first())
+    }
+
+    @Test
+    fun `storeKey format is section colon engine`() {
+        // The exact string is part of the on-disk schema (see _v1
+        // suffix on the DataStore name) — a future refactor that
+        // accidentally changes case or separator would silently
+        // ignore existing prefs. Pin the format here.
+        assertEquals(
+            "installed:Piper",
+            EngineKey(VoiceLibrarySection.Installed, VoiceEngineId.Piper).storeKey(),
+        )
+        assertEquals(
+            "available:Kokoro",
+            EngineKey(VoiceLibrarySection.Available, VoiceEngineId.Kokoro).storeKey(),
+        )
+    }
+}

--- a/feature/src/main/kotlin/in/jphe/storyvox/feature/engine/VoicePickerGate.kt
+++ b/feature/src/main/kotlin/in/jphe/storyvox/feature/engine/VoicePickerGate.kt
@@ -44,6 +44,7 @@ import `in`.jphe.storyvox.playback.voice.UiVoiceInfo
 import `in`.jphe.storyvox.playback.voice.VoiceCatalog
 import `in`.jphe.storyvox.playback.voice.VoiceManager
 import `in`.jphe.storyvox.playback.voice.VoiceManager.DownloadProgress
+import `in`.jphe.storyvox.playback.voice.flagForLanguage
 import `in`.jphe.storyvox.ui.component.BrassButton
 import `in`.jphe.storyvox.ui.component.BrassButtonVariant
 import `in`.jphe.storyvox.ui.component.MagicSkeletonTile
@@ -297,14 +298,19 @@ private fun VoiceTile(
     ) {
         Row(verticalAlignment = Alignment.CenterVertically) {
             Column(modifier = Modifier.fillMaxWidth().weight(1f)) {
+                // Title gains the language flag prefix per #128 — the
+                // catalog [displayName] is now flag-free, so we
+                // re-prefix it at render time. Subtitle keeps tier +
+                // size since this picker drives a download decision;
+                // language is already encoded in the flag.
                 Text(
-                    voice.displayName,
+                    "${flagForLanguage(voice.language)} ${voice.displayName}",
                     style = MaterialTheme.typography.titleMedium,
                     color = MaterialTheme.colorScheme.onSurface,
                 )
                 Spacer(Modifier.height(2.dp))
                 Text(
-                    "${voice.language} · ${voice.qualityLevel.name.lowercase()} · ${sizeMb} MB",
+                    "${voice.qualityLevel.name.lowercase()} · ${sizeMb} MB",
                     style = MaterialTheme.typography.bodySmall,
                     color = MaterialTheme.colorScheme.onSurfaceVariant,
                 )

--- a/feature/src/main/kotlin/in/jphe/storyvox/feature/voicelibrary/VoiceLibraryScreen.kt
+++ b/feature/src/main/kotlin/in/jphe/storyvox/feature/voicelibrary/VoiceLibraryScreen.kt
@@ -21,6 +21,8 @@ import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Star
 import androidx.compose.material.icons.outlined.Check
+import androidx.compose.material.icons.outlined.ExpandLess
+import androidx.compose.material.icons.outlined.ExpandMore
 import androidx.compose.material.icons.outlined.StarBorder
 import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.Icon
@@ -42,8 +44,13 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import `in`.jphe.storyvox.playback.voice.EngineKey
+import `in`.jphe.storyvox.playback.voice.EngineType
 import `in`.jphe.storyvox.playback.voice.QualityLevel
 import `in`.jphe.storyvox.playback.voice.UiVoiceInfo
+import `in`.jphe.storyvox.playback.voice.VoiceGender
+import `in`.jphe.storyvox.playback.voice.VoiceLibrarySection
+import `in`.jphe.storyvox.playback.voice.flagForLanguage
 import `in`.jphe.storyvox.ui.component.BrassButton
 import `in`.jphe.storyvox.ui.component.BrassButtonVariant
 import `in`.jphe.storyvox.ui.component.MagicSkeletonTile
@@ -137,29 +144,40 @@ fun VoiceLibraryScreen(
             } else {
                 installedByEngine.forEach { (engine, tiers) ->
                     val engineCount = tiers.values.sumOf { it.size }
+                    val engineKey = EngineKey(VoiceLibrarySection.Installed, engine.toCoreId())
+                    val isCollapsed = engineKey in state.collapsedEngines
                     item(key = "i-engine-${engine.name}") {
-                        EngineSubHeader(engine = engine, count = engineCount)
+                        EngineSubHeader(
+                            engine = engine,
+                            count = engineCount,
+                            isCollapsed = isCollapsed,
+                            onToggle = {
+                                viewModel.toggleEngineCollapsed(VoiceLibrarySection.Installed, engine)
+                            },
+                        )
                     }
-                    tiers.forEach { (tier, voicesInTier) ->
-                        item(key = "i-${engine.name}-tier-${tier.name}") {
-                            TierSubHeader(tier = tier, count = voicesInTier.size)
-                        }
-                        itemsIndexed(
-                            voicesInTier,
-                            key = { _, item -> "i-${item.id}" },
-                        ) { index, voice ->
-                            VoiceRow(
-                                voice = voice,
-                                isActive = voice.id == state.activeVoiceId,
-                                isFavorite = voice.id in state.favoriteIds,
-                                downloadingProgress = null,
-                                onTap = { viewModel.onRowTapped(voice) },
-                                onLongPress = { viewModel.requestDelete(voice) },
-                                onToggleFavorite = { viewModel.toggleFavorite(voice.id) },
-                                modifier = Modifier
-                                    .animateItem()
-                                    .cascadeReveal(index = index, key = voice.id),
-                            )
+                    if (!isCollapsed) {
+                        tiers.forEach { (tier, voicesInTier) ->
+                            item(key = "i-${engine.name}-tier-${tier.name}") {
+                                TierSubHeader(tier = tier, count = voicesInTier.size)
+                            }
+                            itemsIndexed(
+                                voicesInTier,
+                                key = { _, item -> "i-${item.id}" },
+                            ) { index, voice ->
+                                VoiceRow(
+                                    voice = voice,
+                                    isActive = voice.id == state.activeVoiceId,
+                                    isFavorite = voice.id in state.favoriteIds,
+                                    downloadingProgress = null,
+                                    onTap = { viewModel.onRowTapped(voice) },
+                                    onLongPress = { viewModel.requestDelete(voice) },
+                                    onToggleFavorite = { viewModel.toggleFavorite(voice.id) },
+                                    modifier = Modifier
+                                        .animateItem()
+                                        .cascadeReveal(index = index, key = voice.id),
+                                )
+                            }
                         }
                     }
                 }
@@ -175,31 +193,43 @@ fun VoiceLibraryScreen(
                 }
                 availableByEngine.forEach { (engine, tiers) ->
                     val engineCount = tiers.values.sumOf { it.size }
+                    val engineKey = EngineKey(VoiceLibrarySection.Available, engine.toCoreId())
+                    val isCollapsed = engineKey in state.collapsedEngines
                     item(key = "a-engine-${engine.name}") {
-                        EngineSubHeader(engine = engine, count = engineCount, dim = true)
+                        EngineSubHeader(
+                            engine = engine,
+                            count = engineCount,
+                            dim = true,
+                            isCollapsed = isCollapsed,
+                            onToggle = {
+                                viewModel.toggleEngineCollapsed(VoiceLibrarySection.Available, engine)
+                            },
+                        )
                     }
-                    tiers.forEach { (tier, voicesInTier) ->
-                        item(key = "a-${engine.name}-tier-${tier.name}") {
-                            TierSubHeader(tier = tier, count = voicesInTier.size, dim = true)
-                        }
-                        val downloading = state.currentDownload
-                        itemsIndexed(
-                            voicesInTier,
-                            key = { _, item -> "a-${item.id}" },
-                        ) { index, voice ->
-                            val rowProgress = if (downloading?.voiceId == voice.id) downloading.progress ?: -1f else null
-                            VoiceRow(
-                                voice = voice,
-                                isActive = false,
-                                isFavorite = voice.id in state.favoriteIds,
-                                downloadingProgress = rowProgress,
-                                onTap = { if (downloading == null) viewModel.onRowTapped(voice) },
-                                onLongPress = null,
-                                onToggleFavorite = { viewModel.toggleFavorite(voice.id) },
-                                modifier = Modifier
-                                    .animateItem()
-                                    .cascadeReveal(index = index, key = voice.id),
-                            )
+                    if (!isCollapsed) {
+                        tiers.forEach { (tier, voicesInTier) ->
+                            item(key = "a-${engine.name}-tier-${tier.name}") {
+                                TierSubHeader(tier = tier, count = voicesInTier.size, dim = true)
+                            }
+                            val downloading = state.currentDownload
+                            itemsIndexed(
+                                voicesInTier,
+                                key = { _, item -> "a-${item.id}" },
+                            ) { index, voice ->
+                                val rowProgress = if (downloading?.voiceId == voice.id) downloading.progress ?: -1f else null
+                                VoiceRow(
+                                    voice = voice,
+                                    isActive = false,
+                                    isFavorite = voice.id in state.favoriteIds,
+                                    downloadingProgress = rowProgress,
+                                    onTap = { if (downloading == null) viewModel.onRowTapped(voice) },
+                                    onLongPress = null,
+                                    onToggleFavorite = { viewModel.toggleFavorite(voice.id) },
+                                    modifier = Modifier
+                                        .animateItem()
+                                        .cascadeReveal(index = index, key = voice.id),
+                                )
+                            }
                         }
                     }
                 }
@@ -278,9 +308,21 @@ private fun SectionHeader(label: String, count: Int, dim: Boolean = false) {
  *  Kokoro). Visually slightly louder than the per-tier sub-header
  *  beneath it so the read order is Section → Engine → Tier → Row.
  *  Empty engine groups never reach this composable — the ViewModel's
- *  [groupByEngineThenTier] drops them. */
+ *  [groupByEngineThenTier] drops them.
+ *
+ *  Tappable per #130 — the whole row toggles the collapse state and
+ *  the trailing chevron flips between [Icons.Outlined.ExpandMore]
+ *  (collapsed) and [Icons.Outlined.ExpandLess] (expanded). The
+ *  chevron lives at the row's end via a `Spacer(weight = 1f)` so
+ *  the label/count stay left-aligned even on wide screens. */
 @Composable
-private fun EngineSubHeader(engine: VoiceEngine, count: Int, dim: Boolean = false) {
+private fun EngineSubHeader(
+    engine: VoiceEngine,
+    count: Int,
+    isCollapsed: Boolean,
+    onToggle: () -> Unit,
+    dim: Boolean = false,
+) {
     val baseColor = if (dim) {
         MaterialTheme.colorScheme.onSurfaceVariant
     } else {
@@ -298,7 +340,10 @@ private fun EngineSubHeader(engine: VoiceEngine, count: Int, dim: Boolean = fals
     }
     Row(
         verticalAlignment = Alignment.CenterVertically,
-        modifier = Modifier.padding(top = 6.dp, bottom = 2.dp),
+        modifier = Modifier
+            .fillMaxWidth()
+            .clickable(onClick = onToggle)
+            .padding(top = 6.dp, bottom = 2.dp),
     ) {
         Text(
             label,
@@ -310,6 +355,13 @@ private fun EngineSubHeader(engine: VoiceEngine, count: Int, dim: Boolean = fals
             "  ·  $count",
             style = MaterialTheme.typography.labelMedium,
             color = baseColor.copy(alpha = 0.65f),
+        )
+        Spacer(modifier = Modifier.weight(1f))
+        Icon(
+            imageVector = if (isCollapsed) Icons.Outlined.ExpandMore else Icons.Outlined.ExpandLess,
+            contentDescription = if (isCollapsed) "Expand $label" else "Collapse $label",
+            tint = baseColor.copy(alpha = 0.7f),
+            modifier = Modifier.size(20.dp),
         )
     }
 }
@@ -411,8 +463,12 @@ private fun VoiceRow(
                 )
                 Column(modifier = Modifier.weight(1f)) {
                     Row(verticalAlignment = Alignment.CenterVertically) {
+                        // Title: "<flag> <name>". Flag is derived from
+                        // language code at render time (see #128) so the
+                        // catalog stays render-agnostic and a flag mapping
+                        // change reaches every row in one edit.
                         Text(
-                            voice.displayName,
+                            "${flagForLanguage(voice.language)} ${voice.displayName}",
                             style = MaterialTheme.typography.titleMedium,
                             color = if (isAvailable && downloadingProgress == null) {
                                 MaterialTheme.colorScheme.onSurfaceVariant
@@ -424,8 +480,16 @@ private fun VoiceRow(
                             ActiveChip()
                         }
                     }
+                    // Subtitle: "<Engine> · <Tier> · <Gender>". Gender
+                    // segment is dropped when [VoiceGender.Unknown] so
+                    // the line collapses to "Engine · Tier" rather than
+                    // showing an empty trailing dot. Size/language data
+                    // moved out of the subtitle in #128 — language is
+                    // already encoded in the title flag, and per-voice
+                    // size is more useful in the delete-confirm dialog
+                    // (the only place it directly drives a decision).
                     Text(
-                        text = "${voice.language}  ·  ${formatBytes(voice.sizeBytes)}  ·  ${voice.qualityLevel}",
+                        text = voiceSubtitle(voice),
                         style = MaterialTheme.typography.bodySmall,
                         color = MaterialTheme.colorScheme.onSurfaceVariant,
                     )
@@ -517,6 +581,15 @@ private fun ActiveChip() {
     }
 }
 
+/** Trailing action surfaced on each [VoiceRow]. Three states only:
+ *  Downloading (text spinner copy), Installed-but-not-active (Activate
+ *  button), and Available (Download button). The active+installed case
+ *  used to render an "In use" Text — dropped in #127 because the brass
+ *  border + ACTIVE chip in the title row already mark active state, so
+ *  the trailing label was redundant clutter. Active+installed rows now
+ *  show no trailing action; the row is still tap-targeted via the
+ *  enclosing `combinedClickable` (a no-op while active, since
+ *  `onRowTapped` only switches if id != active). */
 @Composable
 private fun RowAction(
     voice: UiVoiceInfo,
@@ -530,11 +603,7 @@ private fun RowAction(
             style = MaterialTheme.typography.labelMedium,
             color = MaterialTheme.colorScheme.primary,
         )
-        voice.isInstalled && isActive -> Text(
-            "In use",
-            style = MaterialTheme.typography.labelMedium,
-            color = MaterialTheme.colorScheme.onSurfaceVariant,
-        )
+        voice.isInstalled && isActive -> Unit
         voice.isInstalled -> BrassButton(
             label = "Activate",
             onClick = onTap,
@@ -616,4 +685,32 @@ private fun formatBytes(bytes: Long): String = when {
     bytes >= 1_000_000L -> "%.0f MB".format(bytes / 1_000_000.0)
     bytes >= 1_000L -> "%.0f KB".format(bytes / 1_000.0)
     else -> "$bytes B"
+}
+
+/** Compose the per-row subtitle: `<Engine> · <Tier> · <Gender>`.
+ *  Gender is dropped from the line when [VoiceGender.Unknown] (a few
+ *  Piper multi-speaker corpora carry no gender metadata) so the
+ *  subtitle collapses cleanly to `<Engine> · <Tier>` rather than
+ *  showing an empty trailing segment. Pulled out of [VoiceRow] so
+ *  the format is unit-testable from a JVM test without spinning up
+ *  the screen — see [voicelibrary] tests. */
+internal fun voiceSubtitle(voice: UiVoiceInfo): String {
+    val engineLabel = when (voice.engineType) {
+        is EngineType.Piper -> "Piper"
+        is EngineType.Kokoro -> "Kokoro"
+        is EngineType.Azure -> "Azure"
+    }
+    val tierLabel = when (voice.qualityLevel) {
+        QualityLevel.Studio -> "Studio"
+        QualityLevel.High -> "High"
+        QualityLevel.Medium -> "Medium"
+        QualityLevel.Low -> "Low"
+    }
+    val genderLabel = when (voice.gender) {
+        VoiceGender.Female -> "Female"
+        VoiceGender.Male -> "Male"
+        VoiceGender.Unknown -> null
+    }
+    val parts = listOfNotNull(engineLabel, tierLabel, genderLabel)
+    return parts.joinToString(separator = "  ·  ")
 }

--- a/feature/src/main/kotlin/in/jphe/storyvox/feature/voicelibrary/VoiceLibraryViewModel.kt
+++ b/feature/src/main/kotlin/in/jphe/storyvox/feature/voicelibrary/VoiceLibraryViewModel.kt
@@ -4,11 +4,15 @@ import androidx.compose.runtime.Immutable
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import dagger.hilt.android.lifecycle.HiltViewModel
+import `in`.jphe.storyvox.playback.voice.EngineKey
 import `in`.jphe.storyvox.playback.voice.EngineType
 import `in`.jphe.storyvox.playback.voice.QualityLevel
 import `in`.jphe.storyvox.playback.voice.UiVoiceInfo
 import `in`.jphe.storyvox.playback.voice.VoiceCatalog
+import `in`.jphe.storyvox.playback.voice.VoiceEngineId
 import `in`.jphe.storyvox.playback.voice.VoiceFavorites
+import `in`.jphe.storyvox.playback.voice.VoiceLibraryCollapse
+import `in`.jphe.storyvox.playback.voice.VoiceLibrarySection
 import `in`.jphe.storyvox.playback.voice.VoiceManager
 import javax.inject.Inject
 import kotlinx.coroutines.CancellationException
@@ -54,6 +58,14 @@ data class VoiceLibraryUiState(
     val currentDownload: DownloadingVoice? = null,
     val pendingDelete: UiVoiceInfo? = null,
     val errorMessage: String? = null,
+    /** Engine sub-headers currently rendered as **collapsed** (#130).
+     *  Derived from [VoiceLibraryCollapse]'s flipped set + per-section
+     *  default policy in the ViewModel — the screen only needs to ask
+     *  "is this (section, engine) collapsed?" without knowing the
+     *  default rules. Empty on first launch for the Installed section
+     *  (defaults to expanded); will already include every Available
+     *  engine on first paint (Available defaults to collapsed). */
+    val collapsedEngines: Set<EngineKey> = emptySet(),
 )
 
 @Immutable
@@ -67,25 +79,28 @@ data class DownloadingVoice(
 class VoiceLibraryViewModel @Inject constructor(
     private val voiceManager: VoiceManager,
     private val voiceFavorites: VoiceFavorites,
+    private val voiceLibraryCollapse: VoiceLibraryCollapse,
 ) : ViewModel() {
 
     private val _currentDownload = MutableStateFlow<DownloadingVoice?>(null)
     private val _pendingDelete = MutableStateFlow<UiVoiceInfo?>(null)
     private val _error = MutableStateFlow<String?>(null)
 
-    private var downloadJob: Job? = null
-
     val uiState: StateFlow<VoiceLibraryUiState> = combine(
         voiceManager.installedVoices,
         flowOf(voiceManager.availableVoices),
         voiceManager.activeVoice,
         voiceFavorites.favoriteIds,
+        // Pack the three local mutable sources + collapse-store flipped
+        // set into one combined flow so the outer combine fits in 5 slots.
+        // Quintuple shape: download / pendingDelete / error / flipped.
         combine(
             _currentDownload.asStateFlow(),
             _pendingDelete.asStateFlow(),
             _error.asStateFlow(),
-        ) { d, p, e -> Triple(d, p, e) },
-    ) { installed, available, active, favIds, (downloading, pending, error) ->
+            voiceLibraryCollapse.flippedKeys,
+        ) { d, p, e, flipped -> CollapsedAndLocal(d, p, e, flipped) },
+    ) { installed, available, active, favIds, locals ->
         val installedIds = installed.mapTo(mutableSetOf()) { it.id }
         // Favourites pulls from installed first (preserving the
         // installed-flag) and falls back to the catalog for voices the
@@ -102,20 +117,38 @@ class VoiceLibraryViewModel @Inject constructor(
         val availableFiltered = available.filterNot {
             it.id in installedIds || it.id in favIds
         }
+        val installedGrouped = installedFiltered.groupByEngineThenTier()
+        val availableGrouped = availableFiltered.groupByEngineThenTier()
         VoiceLibraryUiState(
             favorites = favorites,
-            installedByEngine = installedFiltered.groupByEngineThenTier(),
-            availableByEngine = availableFiltered.groupByEngineThenTier(),
+            installedByEngine = installedGrouped,
+            availableByEngine = availableGrouped,
             favoriteIds = favIds,
             activeVoiceId = active?.id,
-            currentDownload = downloading,
-            pendingDelete = pending,
-            errorMessage = error,
+            currentDownload = locals.download,
+            pendingDelete = locals.pendingDelete,
+            errorMessage = locals.error,
+            collapsedEngines = computeCollapsedEngines(
+                installedEngines = installedGrouped.keys,
+                availableEngines = availableGrouped.keys,
+                flipped = locals.flipped,
+            ),
         )
     }.stateIn(viewModelScope, SharingStarted.WhileSubscribed(5_000), VoiceLibraryUiState())
 
+    private var downloadJob: Job? = null
+
     fun toggleFavorite(voiceId: String) {
         viewModelScope.launch { voiceFavorites.toggle(voiceId) }
+    }
+
+    /** User tapped an engine sub-header — flip its collapsed state in
+     *  the persisted store. The new state propagates to [uiState] via
+     *  the [voiceLibraryCollapse.flippedKeys] flow combined into the
+     *  main pipeline; the screen re-renders with rows hidden/shown. */
+    fun toggleEngineCollapsed(section: VoiceLibrarySection, engine: VoiceEngine) {
+        val key = EngineKey(section, engine.toCoreId())
+        viewModelScope.launch { voiceLibraryCollapse.toggle(key) }
     }
 
     fun onRowTapped(voice: UiVoiceInfo) {
@@ -216,13 +249,64 @@ class VoiceLibraryViewModel @Inject constructor(
  *  surface above the cloud section, even though Azure's quality tier is
  *  Studio. The visual cue (engine header) matters more than the tier
  *  sort here: users should reach for a free local voice before
- *  considering a paid cloud voice. */
+ *  considering a paid cloud voice.
+ *
+ *  Mirrored as [VoiceEngineId] in core-playback for the collapse store
+ *  (which lives in core so it can be Hilt-injected without dragging the
+ *  feature module). The two enums are kept in lockstep — see
+ *  [toCoreId]. */
 enum class VoiceEngine { Piper, Kokoro, Azure }
+
+internal fun VoiceEngine.toCoreId(): VoiceEngineId = when (this) {
+    VoiceEngine.Piper -> VoiceEngineId.Piper
+    VoiceEngine.Kokoro -> VoiceEngineId.Kokoro
+    VoiceEngine.Azure -> VoiceEngineId.Azure
+}
+
+internal fun VoiceEngineId.toFeatureEngine(): VoiceEngine = when (this) {
+    VoiceEngineId.Piper -> VoiceEngine.Piper
+    VoiceEngineId.Kokoro -> VoiceEngine.Kokoro
+    VoiceEngineId.Azure -> VoiceEngine.Azure
+}
 
 private fun UiVoiceInfo.voiceEngine(): VoiceEngine = when (engineType) {
     is EngineType.Piper -> VoiceEngine.Piper
     is EngineType.Kokoro -> VoiceEngine.Kokoro
     is EngineType.Azure -> VoiceEngine.Azure
+}
+
+/** Tuple holding the four "local + collapse" flow values that get
+ *  packed into a single nested combine slot — the outer combine is
+ *  capped at 5 sources, so we group these here instead of using
+ *  positional destructuring. Named for readability at the call site. */
+private data class CollapsedAndLocal(
+    val download: DownloadingVoice?,
+    val pendingDelete: UiVoiceInfo?,
+    val error: String?,
+    val flipped: Set<String>,
+)
+
+/** Compute the rendered collapsed-engines set from the persisted
+ *  flipped keys + the engines actually present in each section. We
+ *  only emit keys for engines the user can see — there's no point
+ *  carrying "available:Piper" if the user has installed every Piper
+ *  voice. The screen treats `key in collapsedEngines` as the source
+ *  of truth for whether to skip emission of tier rows. */
+internal fun computeCollapsedEngines(
+    installedEngines: Set<VoiceEngine>,
+    availableEngines: Set<VoiceEngine>,
+    flipped: Set<String>,
+): Set<EngineKey> {
+    val out = mutableSetOf<EngineKey>()
+    for (engine in installedEngines) {
+        val key = EngineKey(VoiceLibrarySection.Installed, engine.toCoreId())
+        if (VoiceLibraryCollapse.isCollapsed(key, flipped)) out += key
+    }
+    for (engine in availableEngines) {
+        val key = EngineKey(VoiceLibrarySection.Available, engine.toCoreId())
+        if (VoiceLibraryCollapse.isCollapsed(key, flipped)) out += key
+    }
+    return out
 }
 
 /** Tier order **within Piper** — ascending (Low → Medium → High). Piper

--- a/feature/src/test/kotlin/in/jphe/storyvox/feature/voicelibrary/VoiceLibraryCollapseDerivationTest.kt
+++ b/feature/src/test/kotlin/in/jphe/storyvox/feature/voicelibrary/VoiceLibraryCollapseDerivationTest.kt
@@ -1,0 +1,106 @@
+package `in`.jphe.storyvox.feature.voicelibrary
+
+import `in`.jphe.storyvox.playback.voice.EngineKey
+import `in`.jphe.storyvox.playback.voice.VoiceEngineId
+import `in`.jphe.storyvox.playback.voice.VoiceLibrarySection
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * Unit tests for [computeCollapsedEngines] — the pure helper that
+ * projects the persisted `flipped` set onto the engines actually
+ * present in each section, applying the per-section default policy
+ * along the way (Installed expanded; Available collapsed). The screen
+ * reads `state.collapsedEngines` directly, so this is the contract
+ * its rendering checks.
+ */
+class VoiceLibraryCollapseDerivationTest {
+
+    @Test
+    fun `default state collapses every available engine and no installed engines`() {
+        val collapsed = computeCollapsedEngines(
+            installedEngines = setOf(VoiceEngine.Piper, VoiceEngine.Kokoro),
+            availableEngines = setOf(VoiceEngine.Piper, VoiceEngine.Kokoro),
+            flipped = emptySet(),
+        )
+
+        // Available defaults to collapsed → both available engines in.
+        assertTrue(EngineKey(VoiceLibrarySection.Available, VoiceEngineId.Piper) in collapsed)
+        assertTrue(EngineKey(VoiceLibrarySection.Available, VoiceEngineId.Kokoro) in collapsed)
+        // Installed defaults to expanded → neither installed engine in.
+        assertFalse(EngineKey(VoiceLibrarySection.Installed, VoiceEngineId.Piper) in collapsed)
+        assertFalse(EngineKey(VoiceLibrarySection.Installed, VoiceEngineId.Kokoro) in collapsed)
+    }
+
+    @Test
+    fun `flipping installed engine adds it to collapsed set`() {
+        val collapsed = computeCollapsedEngines(
+            installedEngines = setOf(VoiceEngine.Piper),
+            availableEngines = emptySet(),
+            flipped = setOf("installed:Piper"),
+        )
+        assertEquals(
+            setOf(EngineKey(VoiceLibrarySection.Installed, VoiceEngineId.Piper)),
+            collapsed,
+        )
+    }
+
+    @Test
+    fun `flipping available engine removes it from collapsed set`() {
+        val collapsed = computeCollapsedEngines(
+            installedEngines = emptySet(),
+            availableEngines = setOf(VoiceEngine.Kokoro),
+            flipped = setOf("available:Kokoro"),
+        )
+        // Available + flipped = expanded → not in the collapsed set.
+        assertTrue(collapsed.isEmpty())
+    }
+
+    @Test
+    fun `engines absent from a section are never emitted even when flipped`() {
+        // User flipped both Installed engines but Kokoro isn't installed —
+        // the helper must not emit a key for an engine the user can't see.
+        val collapsed = computeCollapsedEngines(
+            installedEngines = setOf(VoiceEngine.Piper),
+            availableEngines = emptySet(),
+            flipped = setOf("installed:Piper", "installed:Kokoro"),
+        )
+        assertEquals(
+            setOf(EngineKey(VoiceLibrarySection.Installed, VoiceEngineId.Piper)),
+            collapsed,
+        )
+    }
+
+    @Test
+    fun `mixed flipping under both sections resolves independently`() {
+        val collapsed = computeCollapsedEngines(
+            installedEngines = setOf(VoiceEngine.Piper, VoiceEngine.Kokoro),
+            availableEngines = setOf(VoiceEngine.Piper, VoiceEngine.Kokoro),
+            // Flip Installed Piper (now collapsed) and Available Kokoro
+            // (now expanded). Leave the other two at their defaults.
+            flipped = setOf("installed:Piper", "available:Kokoro"),
+        )
+
+        // Installed Piper: flipped from default-expanded → collapsed.
+        assertTrue(EngineKey(VoiceLibrarySection.Installed, VoiceEngineId.Piper) in collapsed)
+        // Installed Kokoro: default expanded.
+        assertFalse(EngineKey(VoiceLibrarySection.Installed, VoiceEngineId.Kokoro) in collapsed)
+        // Available Piper: default collapsed → in the set.
+        assertTrue(EngineKey(VoiceLibrarySection.Available, VoiceEngineId.Piper) in collapsed)
+        // Available Kokoro: flipped from default-collapsed → expanded → not in.
+        assertFalse(EngineKey(VoiceLibrarySection.Available, VoiceEngineId.Kokoro) in collapsed)
+    }
+
+    @Test
+    fun `engine-to-core mapping round trips`() {
+        // The (feature) VoiceEngine → (core) VoiceEngineId mapping is
+        // load-bearing for the collapse keys. Pin it in tests so a
+        // future enum reorder can't silently break persistence.
+        assertEquals(VoiceEngineId.Piper, VoiceEngine.Piper.toCoreId())
+        assertEquals(VoiceEngineId.Kokoro, VoiceEngine.Kokoro.toCoreId())
+        assertEquals(VoiceEngine.Piper, VoiceEngineId.Piper.toFeatureEngine())
+        assertEquals(VoiceEngine.Kokoro, VoiceEngineId.Kokoro.toFeatureEngine())
+    }
+}

--- a/feature/src/test/kotlin/in/jphe/storyvox/feature/voicelibrary/VoiceNamingTest.kt
+++ b/feature/src/test/kotlin/in/jphe/storyvox/feature/voicelibrary/VoiceNamingTest.kt
@@ -1,0 +1,157 @@
+package `in`.jphe.storyvox.feature.voicelibrary
+
+import `in`.jphe.storyvox.playback.voice.EngineType
+import `in`.jphe.storyvox.playback.voice.QualityLevel
+import `in`.jphe.storyvox.playback.voice.UiVoiceInfo
+import `in`.jphe.storyvox.playback.voice.VoiceCatalog
+import `in`.jphe.storyvox.playback.voice.VoiceGender
+import `in`.jphe.storyvox.playback.voice.flagForLanguage
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * Spot-checks for the #128 voice-naming normalization.
+ *
+ * The contract: [VoiceCatalog] entries' [displayName] is the **clean
+ * voice name** only — no `(Tier)` suffix, no `(Language Gender)`
+ * parenthetical, no flag prefix. The Voice Library composes the
+ * on-screen title as `<flag> <displayName>` and the subtitle as
+ * `<Engine> · <Tier> · <Gender>` via [voiceSubtitle].
+ *
+ * Test coverage:
+ *  - 5 catalog spot-checks across Piper/Kokoro/curated/multi-speaker.
+ *  - End-to-end title + subtitle composition.
+ *  - Subtitle gracefully drops an unknown gender segment.
+ */
+class VoiceNamingTest {
+
+    @Test
+    fun `Piper Lessac high keeps star marker and drops tier paren`() {
+        val entry = VoiceCatalog.byId("piper_lessac_en_US_high")
+        requireNotNull(entry) { "piper_lessac_en_US_high must exist in catalog" }
+        // ⭐ marker stays inline (curated featured voice). Tier paren gone.
+        assertEquals("⭐ Lessac", entry.displayName)
+        assertFalse(
+            "displayName must not contain '(High)' parenthetical",
+            entry.displayName.contains("(High)"),
+        )
+        assertEquals(VoiceGender.Female, entry.gender)
+    }
+
+    @Test
+    fun `Piper Cori high has no flag prefix in displayName`() {
+        // Cori is the en_GB curated featured voice (referenced from
+        // VoiceCatalog.featuredIds) — flag belongs at render time.
+        val entry = VoiceCatalog.byId("piper_cori_en_GB_high")
+        requireNotNull(entry)
+        assertEquals("Cori", entry.displayName)
+        assertFalse(
+            "Piper displayName must not embed a flag emoji",
+            entry.displayName.contains("🇬🇧"),
+        )
+    }
+
+    @Test
+    fun `Kokoro Aoede has no flag prefix and no language-gender parenthetical`() {
+        val entry = VoiceCatalog.byId("kokoro_aoede_en_US_1")
+        requireNotNull(entry)
+        assertEquals("Aoede", entry.displayName)
+        assertFalse(
+            "Kokoro displayName must not embed a flag emoji",
+            entry.displayName.contains("🇺🇸"),
+        )
+        assertFalse(
+            "Kokoro displayName must not carry '(English Female)' parenthetical",
+            entry.displayName.contains("("),
+        )
+        assertEquals(VoiceGender.Female, entry.gender)
+    }
+
+    @Test
+    fun `Piper VCTK gets a clean name and Unknown gender for multi-speaker corpus`() {
+        // VCTK is a multi-speaker Piper corpus — gender shouldn't be
+        // claimed; the subtitle must collapse to "Piper · Medium".
+        val entry = VoiceCatalog.byId("piper_vctk_en_GB_medium")
+        requireNotNull(entry)
+        assertEquals("VCTK", entry.displayName)
+        assertEquals(VoiceGender.Unknown, entry.gender)
+    }
+
+    @Test
+    fun `Piper hfc female keeps gender out of title and into the gender field`() {
+        // Pre-#128 the title was "Hfc Female (Medium)" — gender baked
+        // into the title. Post-#128 the title is just the carrier name
+        // and the gender lives on the subtitle.
+        val entry = VoiceCatalog.byId("piper_hfc_female_en_US_medium")
+        requireNotNull(entry)
+        assertEquals("HFC", entry.displayName)
+        assertEquals(VoiceGender.Female, entry.gender)
+        assertFalse(
+            "Title must not redundantly carry 'Female' once it lives in the subtitle",
+            entry.displayName.contains("Female"),
+        )
+    }
+
+    @Test
+    fun `subtitle composes Engine Tier Gender for a Kokoro entry`() {
+        val voice = UiVoiceInfo(
+            id = "kokoro_aoede_en_US_1",
+            displayName = "Aoede",
+            language = "en_US",
+            sizeBytes = 0L,
+            isInstalled = true,
+            qualityLevel = QualityLevel.High,
+            engineType = EngineType.Kokoro(speakerId = 1),
+            gender = VoiceGender.Female,
+        )
+        assertEquals("Kokoro  ·  High  ·  Female", voiceSubtitle(voice))
+    }
+
+    @Test
+    fun `subtitle drops gender segment when Unknown`() {
+        // VCTK multi-speaker corpus — gender Unknown — subtitle should
+        // collapse to "Piper · Medium" with no trailing dot.
+        val voice = UiVoiceInfo(
+            id = "piper_vctk_en_GB_medium",
+            displayName = "VCTK",
+            language = "en_GB",
+            sizeBytes = 76952891L,
+            isInstalled = false,
+            qualityLevel = QualityLevel.Medium,
+            engineType = EngineType.Piper,
+            gender = VoiceGender.Unknown,
+        )
+        assertEquals("Piper  ·  Medium", voiceSubtitle(voice))
+    }
+
+    @Test
+    fun `flag mapping covers the languages used by the catalog`() {
+        // Pin the mappings the catalog actually relies on — a future
+        // refactor that drops one of these silently regresses to the
+        // 🌐 fallback for every voice in that language.
+        assertEquals("🇺🇸", flagForLanguage("en_US"))
+        assertEquals("🇬🇧", flagForLanguage("en_GB"))
+        assertEquals("🇨🇳", flagForLanguage("zh_CN"))
+        // Unknown language falls back to a globe — never empty.
+        assertTrue(flagForLanguage("xx_YY").isNotEmpty())
+    }
+
+    @Test
+    fun `every Piper title is free of tier parenthetical`() {
+        // Sweep across the whole catalog — the shape of the contract
+        // is "no `(Tier)` suffix anywhere". Catches any future entry
+        // that gets pasted in with the old format by accident.
+        val offenders = VoiceCatalog.voices.filter { entry ->
+            entry.engineType is EngineType.Piper &&
+                (entry.displayName.contains("(High)") ||
+                    entry.displayName.contains("(Medium)") ||
+                    entry.displayName.contains("(Low)"))
+        }
+        assertTrue(
+            "Piper voices retaining a tier parenthetical: ${offenders.map { it.id }}",
+            offenders.isEmpty(),
+        )
+    }
+}


### PR DESCRIPTION
## Summary

Three small concerns in the Voice Library, one focused PR. Closes #127, #128, #130.

- **#127** — drop redundant "In use" Text from the trailing `RowAction`. Active state is already conveyed by the brass border + ACTIVE chip in the title row.
- **#128** — normalize voice naming: title is now `<flag> <Name>` and subtitle is `<Engine> · <Tier> · <Gender>`. Dropped tier parentheticals from Piper titles, dropped the `(Language Gender)` parenthetical and inline flag from Kokoro titles (re-added at render time via `flagForLanguage`). Catalog gains a `gender` field; multi-speaker corpora keep gender `Unknown` and the subtitle collapses to `Engine · Tier`. ⭐ marker on the three curated voices stays inline. Same render pattern applied to `VoicePickerGate` for consistency.
- **#130** — collapsible engine sub-sections. Each engine sub-header (Piper / Kokoro) under Installed and Available is tappable with a chevron that flips between `ExpandLess` and `ExpandMore`. State is persisted via a new `VoiceLibraryCollapse` DataStore at `voice_library_collapsed_engines_v1`. Schema stores keys **flipped from per-section defaults** — Installed defaults to expanded, Available defaults to collapsed (long-tail UX win on first paint).

## Files

- `core-playback/.../voice/UiVoiceInfo.kt` — adds `VoiceGender` enum, `gender` field on `UiVoiceInfo`, kdoc clarifying the new title/subtitle composition.
- `core-playback/.../voice/VoiceCatalog.kt` — clean displayNames for all ~80 voices (Piper + Kokoro), `gender` per entry, top-level `flagForLanguage(language)` helper.
- `core-playback/.../voice/VoiceManager.kt` — pass `gender` through `toUiVoiceInfo`.
- `core-playback/.../voice/VoiceLibraryCollapse.kt` — **new** DataStore-backed collapse store; `EngineKey`/`VoiceEngineId`/`VoiceLibrarySection` types; `isCollapsed()` policy helper.
- `feature/.../voicelibrary/VoiceLibraryViewModel.kt` — injects `VoiceLibraryCollapse`, adds `collapsedEngines` to `VoiceLibraryUiState`, adds `toggleEngineCollapsed` action, `computeCollapsedEngines` derivation, engine ↔ core-id mapping.
- `feature/.../voicelibrary/VoiceLibraryScreen.kt` — uses `state.collapsedEngines` to skip emission of tier rows; `EngineSubHeader` becomes tappable with chevron; new `voiceSubtitle()` composer; `RowAction` drops "In use" branch.
- `feature/.../engine/VoicePickerGate.kt` — same flag-prefix render pattern for the first-launch picker.

## Test plan

All tests run via `:core-playback:testDebugUnitTest` and `:feature:testDebugUnitTest`.

- [x] `VoiceLibraryCollapseTest` (10) — real-DataStore round-trip, default policy, idempotent toggle, cross-section / cross-engine independence, persisted state survives facade rebind, on-disk key format.
- [x] `VoiceLibraryCollapseDerivationTest` (6) — pure helper that projects flipped set onto present engines + applies per-section defaults; absent engines never emit; mixed flipping resolves independently; engine ↔ core-id round-trip.
- [x] `VoiceNamingTest` (9) — catalog spot-checks (Lessac/Cori/Aoede/VCTK/HFC), subtitle composition with and without gender, flag mapping for catalog languages, full-catalog sweep verifying no Piper voice retains a `(Tier)` parenthetical.
- [x] `:app:assembleDebug` builds clean.
- [x] All existing tests still pass (`VoiceFavoritesTest`, `VoiceGroupingTest`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)