### PR TITLE
refactor(settings): factor reusable SliderTickLabels (covers buffer slider + punctuation)

### DIFF
--- a/feature/src/main/kotlin/in/jphe/storyvox/feature/settings/SettingsScreen.kt
+++ b/feature/src/main/kotlin/in/jphe/storyvox/feature/settings/SettingsScreen.kt
@@ -558,13 +558,16 @@ private fun BufferSlider(
 }
 
 /**
- * A discrete label rendered at the slider's tick fraction. Two-row layout:
- *  - Spacer that takes up `tickFraction × parentWidth` on the left
- *  - Small caret-and-label group anchored at that x
+ * A discrete label rendered at the slider's tick fraction. Delegates
+ * placement to [SliderTickLabels] so the visual ▲ caret aligns with the
+ * Material3 Slider thumb position for the given value (rather than the
+ * raw row-width fraction, which the legacy weight-spacer layout used and
+ * which drifted by the label's intrinsic width — same root cause Tessa
+ * fixed for the punctuation slider in #146).
  *
  * Doesn't paint onto the slider canvas (Material3 Slider's track-painter
- * customization is verbose for what we need); just renders below the slider
- * at the correct horizontal offset.
+ * customization is verbose for what we need); renders below the slider
+ * at the thumb-anchored horizontal offset.
  */
 @Composable
 private fun TickMarker(
@@ -573,16 +576,7 @@ private fun TickMarker(
     max: Int,
 ) {
     val fraction = ((tickValue - min).toFloat() / (max - min).toFloat()).coerceIn(0f, 1f)
-    Row(modifier = Modifier.fillMaxWidth(), verticalAlignment = Alignment.CenterVertically) {
-        // Eat the left fraction of the row's width.
-        Box(modifier = Modifier.weight(fraction.coerceAtLeast(0.001f)))
-        Text(
-            text = "▲ $tickValue",
-            style = MaterialTheme.typography.labelSmall,
-            color = MaterialTheme.colorScheme.onSurfaceVariant,
-        )
-        Box(modifier = Modifier.weight((1f - fraction).coerceAtLeast(0.001f)))
-    }
+    SliderTickLabels(ticks = listOf("▲ $tickValue" to fraction))
 }
 
 /**
@@ -655,38 +649,64 @@ private fun PunctuationPauseSlider(
 
 /**
  * Anchored row of legacy-stop labels under [PunctuationPauseSlider]. Each
- * label sits at its true fractional position along the [0..4] range using
- * a [Layout] composable, so the visual ▲ caret on each label aligns with
- * the slider thumb position for that value. Labels include the legacy stop
- * names (Off / Normal / Long) so users coming from the 3-stop selector
- * can find their preferred cadence at a glance.
- *
- * Why not the [TickMarker] weight-spacer trick? With multiple labels in a
- * single [Row], Compose's weight system divides only the *remaining* width
- * after measuring unweighted children (the Texts themselves), so each label
- * drifts right by the cumulative widths of preceding labels. With four
- * labels the drift visibly mismatches the thumb position (issue #139).
- *
- * We also account for the M3 [Slider]'s internal track padding (half the
- * thumb width = 10dp on each side), which the surrounding Column does not
- * inherit. Fraction 0 in the parent layout maps to track-x = 0 + padding,
- * not to the leftmost pixel of the parent.
+ * label sits at its true fractional position along the [0..4] range, with
+ * placement delegated to [SliderTickLabels]. Labels include the legacy
+ * stop names (Off / Normal / Long) so users coming from the 3-stop
+ * selector can find their preferred cadence at a glance.
  */
 @Composable
 private fun PunctuationPauseTickLabels() {
     val total = PUNCTUATION_PAUSE_MAX_MULTIPLIER - PUNCTUATION_PAUSE_MIN_MULTIPLIER
-    val ticks = listOf(
-        "▲ Off" to ((PUNCTUATION_PAUSE_OFF_MULTIPLIER - PUNCTUATION_PAUSE_MIN_MULTIPLIER) / total),
-        "▲ 1×" to ((PUNCTUATION_PAUSE_NORMAL_MULTIPLIER - PUNCTUATION_PAUSE_MIN_MULTIPLIER) / total),
-        "▲ Long" to ((PUNCTUATION_PAUSE_LONG_MULTIPLIER - PUNCTUATION_PAUSE_MIN_MULTIPLIER) / total),
-        "▲ 4×" to 1f,
+    SliderTickLabels(
+        ticks = listOf(
+            "▲ Off" to ((PUNCTUATION_PAUSE_OFF_MULTIPLIER - PUNCTUATION_PAUSE_MIN_MULTIPLIER) / total),
+            "▲ 1×" to ((PUNCTUATION_PAUSE_NORMAL_MULTIPLIER - PUNCTUATION_PAUSE_MIN_MULTIPLIER) / total),
+            "▲ Long" to ((PUNCTUATION_PAUSE_LONG_MULTIPLIER - PUNCTUATION_PAUSE_MIN_MULTIPLIER) / total),
+            "▲ 4×" to 1f,
+        ),
     )
+}
 
-    // M3 Slider reserves half the thumb diameter as track padding on each
-    // side (default thumb is 20dp, so 10dp). Hardcoded here because
-    // SliderDefaults doesn't expose this constant publicly. If the thumb
-    // size ever changes, the labels will drift by ≤10dp — visible only on
-    // the extreme ends — so this stays a load-bearing constant.
+/**
+ * Reusable row of slider tick labels, anchored to their true fractional
+ * positions along the slider track. Extracted from the punctuation
+ * slider (#139, Tessa's #146) so the buffer slider's `▲ N` recommended-
+ * max marker can share the same thumb-aligned placement math instead of
+ * the legacy weight-spacer trick.
+ *
+ * Why not [Row] with weight spacers? With multiple labels in a single
+ * [Row], Compose's weight system divides only the *remaining* width
+ * after measuring unweighted children (the Texts themselves), so each
+ * label drifts right by the cumulative widths of preceding labels.
+ * With four labels under the punctuation slider the drift visibly
+ * mismatched the thumb position (#139). Even the single-label
+ * [TickMarker] case for the buffer slider's `▲ 64` marker had the same
+ * intrinsic-width-leak — by 64-on-a-1500-wide-range the drift was
+ * subpixel, but at higher tick fractions or smaller parent widths the
+ * label slid right of the thumb just like the punctuation case.
+ *
+ * We also account for the M3 [Slider]'s internal track padding (half
+ * the thumb width = 10dp on each side), which the surrounding Column
+ * does not inherit. Fraction 0 in the parent layout maps to
+ * track-x = 0 + padding, not to the leftmost pixel of the parent.
+ *
+ * Each entry is `(label, fraction)` where `fraction ∈ [0, 1]` is the
+ * position along the slider track. Labels render in the order given;
+ * the last entry is right-aligned so its trailing characters don't
+ * overflow the parent edge.
+ */
+@Composable
+private fun SliderTickLabels(
+    ticks: List<Pair<String, Float>>,
+) {
+    if (ticks.isEmpty()) return
+
+    // M3 Slider reserves half the thumb diameter as track padding on
+    // each side (default thumb is 20dp, so 10dp). Hardcoded here
+    // because SliderDefaults doesn't expose this constant publicly. If
+    // the thumb size ever changes, the labels will drift by ≤10dp —
+    // visible only on the extreme ends — so this stays a load-bearing
+    // constant.
     val trackPaddingDp = SLIDER_TRACK_PADDING_DP
 
     Layout(
@@ -709,12 +729,21 @@ private fun PunctuationPauseTickLabels() {
         layout(rowWidth, height) {
             placeables.forEachIndexed { i, placeable ->
                 val frac = ticks[i].second
+                // The right-align rule exists to keep the rightmost-of-
+                // many label from running off the parent's right edge
+                // when its preceding labels have already consumed track
+                // space. With only one tick there's nothing preceding,
+                // so we anchor at the thumb-x just like a middle tick —
+                // this is what makes the buffer slider's `▲ 64` align
+                // with the thumb at value 64 instead of pinning to the
+                // right edge of the parent.
+                val isLast = ticks.size > 1 && i == ticks.lastIndex
                 val x = computeTickLabelX(
                     rowWidthPx = rowWidth,
                     trackPaddingPx = trackPaddingPx,
                     fraction = frac,
                     labelWidthPx = placeable.width,
-                    isLast = i == ticks.lastIndex,
+                    isLast = isLast,
                 )
                 placeable.place(x, 0)
             }
@@ -726,7 +755,7 @@ private fun PunctuationPauseTickLabels() {
 private const val SLIDER_TRACK_PADDING_DP: Int = 10
 
 /**
- * Pure placement math for [PunctuationPauseTickLabels], extracted for unit
+ * Pure placement math for [SliderTickLabels], extracted for unit
  * testing. Returns the integer x-offset (in pixels) at which a tick label
  * should be placed inside the parent so its visual ▲ caret sits at the
  * slider thumb position for the given [fraction].

--- a/feature/src/test/kotlin/in/jphe/storyvox/feature/settings/BufferTickPlacementTest.kt
+++ b/feature/src/test/kotlin/in/jphe/storyvox/feature/settings/BufferTickPlacementTest.kt
@@ -1,0 +1,101 @@
+package `in`.jphe.storyvox.feature.settings
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+/**
+ * Unit tests for [computeTickLabelX] applied to the **buffer slider**'s
+ * single recommended-max tick (`▲ 64` at fraction 64/(1500−2)). The
+ * legacy `TickMarker` used a [androidx.compose.foundation.layout.Row] of
+ * weight-spacers, which had the same intrinsic-width-leaks-into-position
+ * flaw Tessa fixed for the punctuation slider in #146 — at small tick
+ * fractions the drift was subpixel-ish on tablet widths but still wrong
+ * in principle, and at higher fractions or smaller parent widths it
+ * would visibly diverge from the slider thumb.
+ *
+ * After Lyra's [SliderTickLabels] extraction, both sliders share the
+ * thumb-aligned placement math. These tests pin the buffer-slider
+ * single-tick contract so a future TickMarker tweak doesn't silently
+ * regress.
+ *
+ * The right-align rule (`isLast = true`) is suppressed inside
+ * SliderTickLabels when the tick list has only one entry — there's
+ * no preceding label whose width could push the rightmost off the
+ * edge, so a 1-tick row anchors at the thumb-x like a middle tick.
+ *
+ * Mirrors [PunctuationPauseTickPlacementTest]'s shape — pure math, no
+ * Compose runtime, JVM-only.
+ */
+class BufferTickPlacementTest {
+
+    /**
+     * The buffer slider's recommended-max marker is a single tick at
+     * fraction (64 − 2) / (1500 − 2) ≈ 0.04138. The label needs to sit
+     * at trackPaddingPx + fraction × (parentWidth − 2 × trackPaddingPx),
+     * matching the M3 Slider thumb's position at value 64 — NOT at
+     * row-x = fraction × parentWidth (the legacy weight-spacer behavior,
+     * which leaked label width into placement).
+     */
+    @Test
+    fun `buffer recommended-max tick anchored at thumb x not raw row fraction`() {
+        // BUFFER_MIN_CHUNKS = 2, BUFFER_RECOMMENDED_MAX_CHUNKS = 64,
+        // BUFFER_MAX_CHUNKS = 1500. fraction = (64 - 2) / (1500 - 2).
+        val fraction = 62f / 1498f
+        val x = computeTickLabelX(
+            rowWidthPx = 600,
+            trackPaddingPx = 10,
+            fraction = fraction,
+            labelWidthPx = 40,
+            isLast = false,
+        )
+        // 10 + (fraction × 580).toInt()
+        val expected = 10 + (fraction * 580f).toInt()
+        assertEquals(expected, x)
+    }
+
+    /**
+     * For the buffer slider TickMarker case, SliderTickLabels passes
+     * `isLast = false` (because `ticks.size > 1 && i == lastIndex` is
+     * false when size == 1), so even a fraction-1 single tick stays
+     * thumb-anchored. This is the seam that makes a single-tick
+     * SliderTickLabels caller render at fraction-x instead of pinning
+     * to the right edge.
+     */
+    @Test
+    fun `single tick at fraction 1 with isLast=false anchors at track end`() {
+        val x = computeTickLabelX(
+            rowWidthPx = 600,
+            trackPaddingPx = 10,
+            fraction = 1f,
+            labelWidthPx = 40,
+            isLast = false,
+        )
+        // anchorX = 10 + (1.0 × 580).toInt() = 590
+        // clamped to (600 - 40) = 560 so label doesn't overflow right
+        assertEquals(560, x)
+    }
+
+    /**
+     * Realistic buffer-slider value (1347 chunks, the slider max
+     * observed on Hazel's tablet) — verifies the thumb-anchored
+     * placement holds at high-fraction values too. Even when fraction
+     * approaches 1, the label clamps to (rowWidth − labelWidth) so
+     * the trailing characters stay on screen.
+     */
+    @Test
+    fun `high-fraction single tick clamps to keep label on screen`() {
+        // Hypothetical 1347-chunk tick: (1347 - 2) / (1500 - 2) ≈ 0.898.
+        val fraction = (1347f - 2f) / (1500f - 2f)
+        val x = computeTickLabelX(
+            rowWidthPx = 600,
+            trackPaddingPx = 10,
+            fraction = fraction,
+            labelWidthPx = 50, // "▲ 1347" is wider
+            isLast = false,
+        )
+        // anchorX = 10 + (0.898 × 580).toInt() = 10 + 521 = 531
+        // (600 - 50) = 550 floor → 531 fits, no clamp.
+        val expected = 10 + (fraction * 580f).toInt()
+        assertEquals(expected, x)
+    }
+}


### PR DESCRIPTION
## Summary
- Extract Tessa's punctuation-slider Layout fix into a reusable \`SliderTickLabels(ticks: List<Pair<String, Float>>)\` composable.
- Route the buffer slider's \`TickMarker\` through it so its \`▲ 64\` recommended-max marker uses the same thumb-aligned placement math instead of the legacy weight-spacer trick.
- Suppress the right-align rule when there's only one tick (single-tick caller anchors at thumb-x like a middle tick — the right-align exists to prevent rightmost-of-many overflow, and there's nothing to overflow when there's only one).
- New \`BufferTickPlacementTest\` (3 tests) pins the single-tick contract.

## Why
Tessa's #146 fixed the punctuation cadence slider's four-tick drift by switching from a \`Row\` of weight-spacers to a custom Compose \`Layout\` that measures label widths and anchors each at \`trackPadding + fraction × trackWidth\` (the M3 Slider thumb position). The buffer slider's \`TickMarker\` had the **same intrinsic-width-leak** — subpixel-ish on tablet widths at fraction 0.04 (▲ 64 in a 1500-wide range), but architecturally identical and primed to drift visibly at higher fractions or smaller parents. Sharing the math means a future tick-rendering site (or buffer-slider re-scale, or a shorter parent layout) inherits the fix automatically.

The single-tick fix-up matters: routing \`TickMarker\` naively through \`SliderTickLabels\` would have pinned the buffer slider's \`▲ 64\` to the parent's right edge (because \`i == ticks.lastIndex\` is true when size == 1), which is worse than the legacy bug. Suppressed cleanly with \`isLast = ticks.size > 1 && i == ticks.lastIndex\`.

## Test plan
- [x] Tessa's \`PunctuationPauseTickPlacementTest\` (7 tests) passes unchanged — the placement helper is the same.
- [x] New \`BufferTickPlacementTest\` (3 tests) — buffer recommended-max thumb-anchored; fraction-1 clamps to keep label on screen; 1347-chunk hypothetical stays thumb-anchored.
- [x] \`:feature:assembleDebug\` green
- [x] \`:app:assembleDebug\` green
- [x] \`:feature:testDebugUnitTest\` green
- [ ] Manual on-tablet (orchestrator): verify \`▲ 64\` on buffer slider sits at the thumb-x for value 64 (not at the row-fraction 0.04 × parent-width position)

Follow-up to #146.