### PR TITLE
fix(a11y, reader): TalkBack slider semantics + pitch label '×' (#160, #162)

### DIFF
--- a/app/src/main/kotlin/in/jphe/storyvox/auth/AuthWebViewScreen.kt
+++ b/app/src/main/kotlin/in/jphe/storyvox/auth/AuthWebViewScreen.kt
@@ -20,6 +20,8 @@ import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.semantics.contentDescription
+import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
@@ -82,7 +84,13 @@ fun AuthWebViewScreen(
 
             if (capture is CaptureState.Capturing) {
                 CircularProgressIndicator(
-                    modifier = Modifier.align(Alignment.Center),
+                    // TalkBack #160 — without contentDescription the spinner
+                    // announces nothing, leaving a screen-reader user
+                    // wondering if the OAuth flow froze. Mirror the visible
+                    // semantics of "we're working on it".
+                    modifier = Modifier
+                        .align(Alignment.Center)
+                        .semantics { contentDescription = "Loading sign-in page" },
                     color = MaterialTheme.colorScheme.primary,
                 )
             }

--- a/app/src/test/kotlin/in/jphe/storyvox/data/SettingsRepositoryPitchTest.kt
+++ b/app/src/test/kotlin/in/jphe/storyvox/data/SettingsRepositoryPitchTest.kt
@@ -60,6 +60,9 @@ class SettingsRepositoryPitchTest {
             palaceConfig = makeFakePalaceConfig(tempFolder.newFolder("palace_ds"), scope),
             palaceApi = makeFakePalaceApi(),
             llmCreds = `in`.jphe.storyvox.llm.LlmCredentialsStore.forTesting(),
+            // GitHubAuth fake (#91) — pitch tests don't touch GitHub state;
+            // mirrors the pattern in BufferTest / ModesTest / PunctuationPauseTest.
+            githubAuth = FakeGitHubAuth(),
         )
     }
 

--- a/app/src/test/kotlin/in/jphe/storyvox/data/SettingsRepositoryVoiceSteadyTest.kt
+++ b/app/src/test/kotlin/in/jphe/storyvox/data/SettingsRepositoryVoiceSteadyTest.kt
@@ -56,6 +56,9 @@ class SettingsRepositoryVoiceSteadyTest {
             // Test-only LlmCredentialsStore — voice-tuning tests don't touch
             // AI fields; a no-op store is fine.
             llmCreds = `in`.jphe.storyvox.llm.LlmCredentialsStore.forTesting(),
+            // GitHubAuth fake (#91) — voice-tuning tests don't touch GitHub
+            // state; mirrors the pattern in BufferTest / ModesTest / etc.
+            githubAuth = FakeGitHubAuth(),
         )
     }
 

--- a/feature/src/main/kotlin/in/jphe/storyvox/feature/browse/BrowseFilterSheet.kt
+++ b/feature/src/main/kotlin/in/jphe/storyvox/feature/browse/BrowseFilterSheet.kt
@@ -32,6 +32,9 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.semantics.contentDescription
+import androidx.compose.ui.semantics.semantics
+import androidx.compose.ui.semantics.stateDescription
 import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.foundation.text.KeyboardOptions
 import `in`.jphe.storyvox.feature.api.BrowseFilter
@@ -152,6 +155,13 @@ fun BrowseFilterSheet(
                 },
                 valueRange = 0f..PAGES_MAX,
                 steps = 0,
+                // TalkBack #160 — RangeSlider announces a raw float pair
+                // by default. State description mirrors the visible
+                // pagesLabel() (e.g. "100 to 5000 pages") for parity.
+                modifier = Modifier.semantics {
+                    contentDescription = "Filter by page count"
+                    stateDescription = local.pagesLabel()
+                },
             )
 
             // Rating
@@ -167,6 +177,11 @@ fun BrowseFilterSheet(
                 },
                 valueRange = 0f..5f,
                 steps = 9,
+                // TalkBack #160 — same rationale as the pages slider above.
+                modifier = Modifier.semantics {
+                    contentDescription = "Filter by star rating"
+                    stateDescription = local.ratingLabel()
+                },
             )
 
             HorizontalDivider()

--- a/feature/src/main/kotlin/in/jphe/storyvox/feature/reader/AudiobookView.kt
+++ b/feature/src/main/kotlin/in/jphe/storyvox/feature/reader/AudiobookView.kt
@@ -47,6 +47,9 @@ import androidx.compose.material3.ModalBottomSheet
 import androidx.compose.material3.Slider
 import androidx.compose.material3.Text
 import androidx.compose.material3.rememberModalBottomSheetState
+import androidx.compose.ui.semantics.contentDescription
+import androidx.compose.ui.semantics.semantics
+import androidx.compose.ui.semantics.stateDescription
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
@@ -381,9 +384,16 @@ private fun PlayerOptionsSheet(
             onValueChangeFinished = { onPersistSpeed(state.speed) },
             valueRange = 0.5f..3.0f,
             steps = 49, // 0.05× per step
+            // TalkBack #160 — without these, the slider announces a raw
+            // float ("1.25") instead of a meaningful value ("Speech speed,
+            // 1.25 times").
+            modifier = Modifier.semantics {
+                contentDescription = "Speech speed"
+                stateDescription = "%.2f times".format(state.speed)
+            },
         )
 
-        SheetHeader("Pitch", "${"%.2f".format(state.pitch)}")
+        SheetHeader("Pitch", "${"%.2f".format(state.pitch)}×")
         Slider(
             value = state.pitch,
             onValueChange = onSetPitch,
@@ -394,6 +404,12 @@ private fun PlayerOptionsSheet(
             // Sonic introduces audible artifacts on Piper-medium voices.
             valueRange = 0.6f..1.4f,
             steps = 79, // 0.01 per step
+            // TalkBack #160 — neutral pitch is 1.0 (no shift); semantics
+            // calls that out so users know what the number references.
+            modifier = Modifier.semantics {
+                contentDescription = "Pitch"
+                stateDescription = "%.2f, neutral at one".format(state.pitch)
+            },
         )
 
         SheetHeader("Sleep timer", null)

--- a/feature/src/main/kotlin/in/jphe/storyvox/feature/settings/SettingsScreen.kt
+++ b/feature/src/main/kotlin/in/jphe/storyvox/feature/settings/SettingsScreen.kt
@@ -31,6 +31,9 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.layout.Layout
+import androidx.compose.ui.semantics.contentDescription
+import androidx.compose.ui.semantics.semantics
+import androidx.compose.ui.semantics.stateDescription
 import androidx.compose.ui.text.font.FontStyle
 import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.text.input.PasswordVisualTransformation
@@ -90,6 +93,12 @@ fun SettingsScreen(
             value = s.defaultSpeed,
             onValueChange = viewModel::setSpeed,
             valueRange = 0.5f..3.0f,
+            // TalkBack #160 — without these, the slider announces a raw
+            // float ("1.25") instead of "Default speech speed, 1.25 times".
+            modifier = Modifier.semantics {
+                contentDescription = "Default speech speed"
+                stateDescription = "%.2f times".format(s.defaultSpeed)
+            },
         )
         Text("Speed ${"%.2f".format(s.defaultSpeed)}×", style = MaterialTheme.typography.bodySmall)
         Slider(
@@ -102,6 +111,10 @@ fun SettingsScreen(
             // introducing audible artifacts on Piper-medium voices.
             valueRange = 0.6f..1.4f,
             steps = 79, // 0.01 per step
+            modifier = Modifier.semantics {
+                contentDescription = "Default pitch"
+                stateDescription = "%.2f, neutral at one".format(s.defaultPitch)
+            },
         )
         Text("Pitch ${"%.2f".format(s.defaultPitch)}×", style = MaterialTheme.typography.bodySmall)
 
@@ -247,6 +260,12 @@ fun SettingsScreen(
             onValueChange = { viewModel.setPollHours(it.toInt().coerceIn(1, 24)) },
             valueRange = 1f..24f,
             steps = 22,
+            // TalkBack #160 — units matter: raw "6" without context reads
+            // ambiguous ("6 minutes? days?"). State description spells it.
+            modifier = Modifier.semantics {
+                contentDescription = "Update check interval"
+                stateDescription = "Every ${s.pollIntervalHours} hours"
+            },
         )
 
         Divider()
@@ -611,6 +630,14 @@ private fun BufferSlider(
                 activeTrackColor = activeColor,
                 inactiveTrackColor = inactiveColor,
             ),
+            // TalkBack #160 — sighted users see the live readout above the
+            // slider; TalkBack users get the same information here. The
+            // recommended-max ceiling matters for the past-tick warning, so
+            // it's spelled out in the state description.
+            modifier = Modifier.semantics {
+                contentDescription = "Playback buffer size"
+                stateDescription = "$chunks chunks, recommended max $BUFFER_RECOMMENDED_MAX_CHUNKS"
+            },
         )
 
         // Recommended-max tick label, spatially anchored to its position
@@ -752,6 +779,18 @@ private fun PunctuationPauseSlider(
                 activeTrackColor = MaterialTheme.colorScheme.primary,
                 inactiveTrackColor = MaterialTheme.colorScheme.surfaceVariant,
             ),
+            // TalkBack #160 — "Off" is the visible label at multiplier 0,
+            // so we mirror that for screen-reader users; otherwise read
+            // the multiplier directly with a "times" suffix to match the
+            // visible "Pause after punctuation: 1.50×" line above.
+            modifier = Modifier.semantics {
+                contentDescription = "Pause after punctuation"
+                stateDescription = if (multiplier <= PUNCTUATION_PAUSE_MIN_MULTIPLIER) {
+                    "Off"
+                } else {
+                    "%.2f times".format(multiplier)
+                }
+            },
         )
 
         // Tick labels at the legacy stops + the new 4× ceiling. Spatial


### PR DESCRIPTION
## Summary
- **#160** — Add \`Modifier.semantics\` to 6 sliders (AudiobookView Speed/Pitch, SettingsScreen Speed/Pitch/Poll/Buffer/Punctuation, BrowseFilterSheet Pages/Rating RangeSliders) and to the AuthWebViewScreen OAuth spinner. TalkBack now announces meaningful values instead of raw floats / silence.
- **#162** — Pitch label in the Player options bottom-sheet now reads \`1.00×\` to match Speed (and the Settings-screen versions of both). One-char fix.
- **Drive-by test-fix sweep** — \`SettingsRepositoryPitchTest\` and \`SettingsRepositoryVoiceSteadyTest\` were broken on \`origin/main\` from #144 (GitHub OAuth) widening \`SettingsRepositoryUiImpl\`'s constructor. Adds \`githubAuth = FakeGitHubAuth()\` mirroring the existing pattern in BufferTest/ModesTest/PunctuationPauseTest. Same shape as my prior #133 sweep.

## Why
ScreenAudit (CHI 2025) found that Compose Material3 Slider has no default semantic value label, and TTS apps disproportionately have visually-impaired users who need TalkBack to work *over* the app's own narration. Six sliders + one spinner with semantic gaps was a real accessibility hole — small, mechanical, and embarrassing to ship into the upcoming compose-bom upgrade (#122) which highlights slider a11y.

The Pitch label inconsistency (#162) is polish-tier but pairs naturally with the a11y pass since the visible readout and the TalkBack \`stateDescription\` should match.

\`LibraryScreen.ResumeCard\` fix described in #160's body is skipped — the current code already routes clicks through a \`BrassButton\` with proper Button role, so the described semantic gap doesn't exist on main. Keeping the PR honest.

## Test plan
- [x] \`:feature:assembleDebug\` green
- [x] \`:app:assembleDebug\` green
- [x] \`:feature:testDebugUnitTest\` green
- [x] \`:app:testDebugUnitTest\` green (was broken pre-PR from #144 ctor expansion; the test-fix sweep restores it)
- [ ] Manual on-tablet (orchestrator): TalkBack on, scrub each slider, verify announced state is meaningful. Verify spinner announces \"Loading sign-in page\" during OAuth. Verify Pitch label in player sheet now shows \`1.00×\`.

## Notes for Reeve
- Doesn't conflict with #155 (Echo voicelibrary) or #157 (Lyra slider-ticks refactor) — separate file surfaces.

Closes #160.
Closes #162.