### PR TITLE
fix(mempalace): empty-state copy points to Settings when host unconfigured (#164)

### DIFF
--- a/source-mempalace/src/main/kotlin/in/jphe/storyvox/source/mempalace/MemPalaceSource.kt
+++ b/source-mempalace/src/main/kotlin/in/jphe/storyvox/source/mempalace/MemPalaceSource.kt
@@ -14,6 +14,7 @@ import `in`.jphe.storyvox.source.mempalace.model.PalaceDrawer
 import `in`.jphe.storyvox.source.mempalace.model.PalaceGraph
 import `in`.jphe.storyvox.source.mempalace.net.PalaceDaemonApi
 import `in`.jphe.storyvox.source.mempalace.net.PalaceDaemonResult
+import java.io.IOException
 import javax.inject.Inject
 import javax.inject.Singleton
 
@@ -331,10 +332,34 @@ internal class MemPalaceSource @Inject constructor(
         is PalaceDaemonResult.Degraded -> FictionResult.NetworkError(
             message = "Palace is rebuilding — try again shortly.",
         )
-        is PalaceDaemonResult.NotReachable -> FictionResult.NetworkError(
-            message = "Could not reach the palace daemon. Reconnect on home network.",
-            cause = cause,
-        )
+        is PalaceDaemonResult.NotReachable -> {
+            // Palace API surfaces "host not configured" (empty Settings →
+            // Memory Palace host textfield) as a NotReachable with that
+            // exact IOException message — see PalaceDaemonApi.kt's
+            // `if (!cfg.isConfigured)` early returns at lines 95 + 144.
+            // Without this branch, an unconfigured user sees "Reconnect
+            // on home network" — wrong cause, no actionable path. Issue
+            // #164. The proper fix for this is a typed-result error
+            // kind (mirroring PR #154's RecapUiState.ErrorKind shape)
+            // with a dedicated "Open Settings" CTA in the empty state;
+            // tracked as a follow-up. The copy fix here closes the
+            // immediate user-impact gap by directing them to the right
+            // place in Settings instead of telling them to reconnect
+            // a Wi-Fi connection that's already fine.
+            val isUnconfigured = (cause as? IOException)?.message ==
+                "Palace host not configured"
+            if (isUnconfigured) {
+                FictionResult.NetworkError(
+                    message = "Set up your Memory Palace host in Settings → Memory Palace to browse your private fictions.",
+                    cause = cause,
+                )
+            } else {
+                FictionResult.NetworkError(
+                    message = "Could not reach the palace daemon. Reconnect on home network or check the host address.",
+                    cause = cause,
+                )
+            }
+        }
         is PalaceDaemonResult.HostRejected -> FictionResult.NetworkError(
             message = "Palace host '${host}' is not on the home network.",
         )

--- a/source-mempalace/src/test/kotlin/in/jphe/storyvox/source/mempalace/MemPalaceSourceTest.kt
+++ b/source-mempalace/src/test/kotlin/in/jphe/storyvox/source/mempalace/MemPalaceSourceTest.kt
@@ -80,6 +80,33 @@ class MemPalaceSourceTest {
         assertTrue("expected NetworkError, got $r", r is FictionResult.NetworkError)
     }
 
+    @Test fun `unconfigured host surfaces a Settings-pointing message, not Reconnect-on-home-network (#164)`() {
+        // PalaceDaemonApi early-returns a NotReachable wrapping
+        // `IOException("Palace host not configured")` when the user
+        // hasn't filled in the Settings → Memory Palace host textfield.
+        // Issue #164 was that this got mapped to the generic
+        // "Reconnect on home network" copy — wrong cause attribution
+        // and no actionable path forward. Lock the new copy here so a
+        // future tweak to toFictionFailure can't silently regress.
+        val src = source(
+            graphResult = PalaceDaemonResult.NotReachable(
+                java.io.IOException("Palace host not configured"),
+            ),
+        )
+        val r = runBlocking { src.popular() }
+        assertTrue("expected NetworkError, got $r", r is FictionResult.NetworkError)
+        val msg = (r as FictionResult.NetworkError).message
+        assertTrue(
+            "expected message to point at Settings → Memory Palace; got: $msg",
+            msg.contains("Settings", ignoreCase = true) &&
+                msg.contains("Memory Palace", ignoreCase = true),
+        )
+        assertTrue(
+            "expected message NOT to say 'Reconnect on home network'; got: $msg",
+            !msg.contains("Reconnect on home network", ignoreCase = true),
+        )
+    }
+
     @Test fun `genres returns sorted wing list`() {
         val src = source(graph = sample3WingGraph())
         val r = runBlocking { src.genres() } as FictionResult.Success


### PR DESCRIPTION
## Summary
- When Settings → Memory Palace host textfield is blank, Browse → Memory Palace was showing \"Reconnect on home network\" — wrong cause, no path forward.
- \`MemPalaceSource.toFictionFailure\`'s NotReachable branch now detects the well-known \`IOException(\"Palace host not configured\")\` cause and emits a Settings-pointing copy instead.
- New test pins the contract.

## Why
Hazel reproduced on v0.4.33 from R83W80CAFZB while on-network (tablet at 10.0.6.127). Logcat confirmed the cause is the early-return in \`PalaceDaemonApi.kt:97/146\` when \`cfg.isConfigured\` is false. The generic \"Reconnect on home network\" was misleading — both the diagnosis (network is fine) and the remedy (no Wi-Fi reconnect will help when the host textfield is empty).

The proper architectural fix (typed \`ErrorKind\` discriminator carrying through ViewModel + UI for an \"Open Settings\" CTA — same shape as PR #154's RecapUiState.ErrorKind) ripples through 4-5 files across module boundaries (FictionResult variant or paginator state-shape change). That's escalation territory for a Lyra-shaped PR; flagged in the kdoc. **This PR fixes the user-visible copy half of #164** — the wrong cause attribution and no-path-forward text. The CTA-shape fix is a follow-up.

## Test plan
- [x] \`:source-mempalace:testDebugUnitTest\` green — new test \`unconfigured host surfaces a Settings-pointing message, not Reconnect-on-home-network (#164)\` passes; existing \`popular surfaces NotReachable as NetworkError\` test still passes
- [x] \`:source-mempalace:assembleDebug\` green
- [x] \`:app:assembleDebug\` green
- [ ] Manual on-tablet (orchestrator): Settings → Memory Palace, clear host textfield → Browse → Memory Palace → confirm copy now reads \"Set up your Memory Palace host in Settings → Memory Palace…\"

Closes #164.