### PR TITLE
fix(library): confirm before destructive remove + Back nav on dead-end error (#169)

### DIFF
--- a/app/src/main/kotlin/in/jphe/storyvox/navigation/StoryvoxNavHost.kt
+++ b/app/src/main/kotlin/in/jphe/storyvox/navigation/StoryvoxNavHost.kt
@@ -237,6 +237,7 @@ private fun StoryvoxNavHostContent(
             ) {
                 FictionDetailScreen(
                     onOpenReader = { f, c -> navController.navigate(StoryvoxRoutes.reader(f, c)) },
+                    onBack = { navController.popBackStack() },
                 )
             }
 

--- a/app/src/test/kotlin/in/jphe/storyvox/data/SettingsRepositoryPronunciationDictTest.kt
+++ b/app/src/test/kotlin/in/jphe/storyvox/data/SettingsRepositoryPronunciationDictTest.kt
@@ -58,6 +58,9 @@ class SettingsRepositoryPronunciationDictTest {
             palaceConfig = makeFakePalaceConfig(tempFolder.newFolder("palace_ds"), scope),
             palaceApi = makeFakePalaceApi(),
             llmCreds = `in`.jphe.storyvox.llm.LlmCredentialsStore.forTesting(),
+            // GitHubAuth fake (#91) — pronunciation-dict tests don't touch
+            // GitHub state; mirrors BufferTest / ModesTest / PitchTest pattern.
+            githubAuth = FakeGitHubAuth(),
         )
     }
 

--- a/core-ui/src/main/kotlin/in/jphe/storyvox/ui/component/ErrorBlock.kt
+++ b/core-ui/src/main/kotlin/in/jphe/storyvox/ui/component/ErrorBlock.kt
@@ -47,7 +47,14 @@ enum class ErrorPlacement {
  * @param message body copy explaining what happened in plain English
  * @param onRetry primary action; pass null to omit the retry button
  *   (e.g. when the only retry path is to leave and re-enter the screen)
- * @param retryLabel button label, defaults to "Try again"
+ * @param retryLabel primary button label, defaults to "Try again"
+ * @param onBack optional secondary action — usually a Back nav. Issue
+ *   #169 fix: a full-screen error must never be a dead-end; if the
+ *   call site can't usefully retry (`onRetry = null`), it should at
+ *   least pass `onBack` so the user has a way out other than the OS
+ *   back gesture. Banner placement ignores `onBack` (the surrounding
+ *   screen still has its own nav).
+ * @param backLabel secondary button label, defaults to "Back"
  * @param placement [ErrorPlacement.FullScreen] or [ErrorPlacement.Banner]
  */
 @Composable
@@ -57,6 +64,8 @@ fun ErrorBlock(
     onRetry: (() -> Unit)?,
     modifier: Modifier = Modifier,
     retryLabel: String = "Try again",
+    onBack: (() -> Unit)? = null,
+    backLabel: String = "Back",
     placement: ErrorPlacement = ErrorPlacement.FullScreen,
 ) {
     val spacing = LocalSpacing.current
@@ -85,13 +94,26 @@ fun ErrorBlock(
                 color = MaterialTheme.colorScheme.onSurfaceVariant,
                 textAlign = TextAlign.Center,
             )
-            if (onRetry != null) {
+            if (onRetry != null || onBack != null) {
                 Spacer(Modifier.height(spacing.lg))
-                BrassButton(
-                    label = retryLabel,
-                    onClick = onRetry,
-                    variant = BrassButtonVariant.Primary,
-                )
+                Row(
+                    horizontalArrangement = Arrangement.spacedBy(spacing.sm),
+                ) {
+                    if (onBack != null) {
+                        BrassButton(
+                            label = backLabel,
+                            onClick = onBack,
+                            variant = BrassButtonVariant.Secondary,
+                        )
+                    }
+                    if (onRetry != null) {
+                        BrassButton(
+                            label = retryLabel,
+                            onClick = onRetry,
+                            variant = BrassButtonVariant.Primary,
+                        )
+                    }
+                }
             }
         }
 

--- a/feature/src/main/kotlin/in/jphe/storyvox/feature/fiction/FictionDetailScreen.kt
+++ b/feature/src/main/kotlin/in/jphe/storyvox/feature/fiction/FictionDetailScreen.kt
@@ -17,6 +17,7 @@ import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Star
+import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
@@ -47,6 +48,12 @@ import `in`.jphe.storyvox.ui.theme.LocalSpacing
 @Composable
 fun FictionDetailScreen(
     onOpenReader: (String, String) -> Unit,
+    /** Issue #169 — the no-cache full-page error path was a dead-end
+     *  with no nav (no Back, no Retry, only OS back). AppNav wires
+     *  this so the user always has a way out. Default `{}` keeps
+     *  preview/test use working but should never be the production
+     *  callsite. */
+    onBack: () -> Unit = {},
     viewModel: FictionDetailViewModel = hiltViewModel(),
 ) {
     val state by viewModel.uiState.collectAsStateWithLifecycle()
@@ -59,17 +66,58 @@ fun FictionDetailScreen(
         }
     }
 
+    // Issue #169 — destructive removeFromLibrary used to fire on a
+    // single tap of the "In library" button (which reads as a status,
+    // not an action). User lost their fiction + read progress with
+    // zero confirmation. Gate the destructive path behind an
+    // AlertDialog; the additive add-to-library path stays single-tap.
+    var showRemoveConfirm by remember { mutableStateOf(false) }
+    if (showRemoveConfirm) {
+        val titleForDialog = state.fiction?.title ?: "this fiction"
+        AlertDialog(
+            onDismissRequest = { showRemoveConfirm = false },
+            title = { Text("Remove $titleForDialog from your library?") },
+            text = {
+                Text(
+                    "Your read progress will be lost. You can re-add it from " +
+                        "Browse anytime, but the position you've reached won't be restored.",
+                )
+            },
+            confirmButton = {
+                BrassButton(
+                    label = "Remove",
+                    onClick = {
+                        showRemoveConfirm = false
+                        viewModel.toggleFollow(false)
+                    },
+                    variant = BrassButtonVariant.Primary,
+                )
+            },
+            dismissButton = {
+                BrassButton(
+                    label = "Cancel",
+                    onClick = { showRemoveConfirm = false },
+                    variant = BrassButtonVariant.Secondary,
+                )
+            },
+        )
+    }
+
     val fiction = state.fiction
     Box(modifier = Modifier.fillMaxSize()) {
         if (fiction == null && state.error != null) {
-            // First-load failure with no cached fiction. No retry button —
-            // backing out and re-entering re-subscribes to fictionById,
-            // which triggers the underlying refreshDetail. Surfacing this
-            // path inside the error message keeps users from getting stuck.
+            // First-load failure with no cached fiction. Issue #169 —
+            // this path used to be a dead-end (no Back, no Retry, only
+            // OS back). Now wires onBack so the user always has a way
+            // out without leaning on the OS gesture. Still no Retry —
+            // the underlying refreshDetail re-fires when the user
+            // re-enters the screen via Back + re-tap, so a Retry CTA
+            // here would just blink the same error.
             ErrorBlock(
                 title = "Couldn't load this fiction",
                 message = state.error ?: "We couldn't reach Royal Road. Go back and try again in a moment.",
                 onRetry = null,
+                onBack = onBack,
                 placement = ErrorPlacement.FullScreen,
             )
         } else if (fiction == null) {
@@ -116,7 +164,15 @@ fun FictionDetailScreen(
 
             BottomBar(
                 isInLibrary = state.isInLibrary,
-                onFollow = { viewModel.toggleFollow(!state.isInLibrary) },
+                onFollow = {
+                    // Issue #169 — gate the destructive path behind a
+                    // confirm dialog; the additive path stays single-tap.
+                    if (state.isInLibrary) {
+                        showRemoveConfirm = true
+                    } else {
+                        viewModel.toggleFollow(true)
+                    }
+                },
                 onListen = { state.chapters.firstOrNull()?.id?.let(viewModel::listen) },
                 modifier = Modifier.align(Alignment.BottomCenter),
             )
@@ -150,7 +206,15 @@ fun FictionDetailScreen(
 
             BottomBar(
                 isInLibrary = state.isInLibrary,
-                onFollow = { viewModel.toggleFollow(!state.isInLibrary) },
+                onFollow = {
+                    // Issue #169 — gate the destructive path behind a
+                    // confirm dialog; the additive path stays single-tap.
+                    if (state.isInLibrary) {
+                        showRemoveConfirm = true
+                    } else {
+                        viewModel.toggleFollow(true)
+                    }
+                },
                 onListen = { state.chapters.firstOrNull()?.id?.let(viewModel::listen) },
                 modifier = Modifier.align(Alignment.BottomCenter),
             )


### PR DESCRIPTION
## Summary
**HIGH-severity data loss fix.** Tapping the \"In library\" button on a fiction detail screen used to silently remove the fiction (no confirmation, no undo) AND route to a refetch that dead-ended on a full-page error with no Back button. Hazel lost Sky Pride during testing.

Two-part fix:
1. **Confirmation dialog** before destructive remove. Add stays single-tap; remove now opens an AlertDialog with the fiction's title, a Cancel default, and a primary \"Remove\" confirm.
2. **Error screen gains a Back button.** ErrorBlock gains optional \`onBack\`/\`backLabel\`. FictionDetailScreen's no-cache full-page ErrorBlock now passes \`onBack\` wired through StoryvoxNavHost. User always has a way out without OS-back.

Plus drive-by: \`SettingsRepositoryPronunciationDictTest\` was missing \`githubAuth = FakeGitHubAuth()\` after Cora's #135 merge — same shape as my prior #163 sweep. \`:app:test\` is green now.

## Why
v0.4.33 \"In library\" reads as a status indicator (most users won't realize it's a destructive toggle). Same outline-button visual as \"Add to library\", same position, no remove icon, no destructive red, no \"Remove\" verb. Single-tap silently wipes the fiction + read progress. Then routes to an error page with no nav, only OS back gesture. Lost Sky Pride during Hazel's testing.

The dialog gates the destructive path without slowing the additive add-to-library path. The Back button on the error screen guarantees the user always has a way out — pre-existing \`onRetry\`-only call sites are unchanged (default \`onBack = null\`).

## Test plan
- [x] \`:feature:assembleDebug\` green
- [x] \`:app:assembleDebug\` green
- [x] \`:feature:testDebugUnitTest\` green
- [x] \`:app:testDebugUnitTest\` green (was broken pre-PR from Cora's #135 ctor expansion; the drive-by restores it)
- [ ] Manual on-tablet (orchestrator):
  - Library tab → tap a fiction → tap \"In library\" → confirm AlertDialog appears with the fiction title and a Remove/Cancel pair
  - Tap Remove → fiction is removed; tap Cancel → no change
  - When refetch fails post-remove (the original #169 path), confirm the full-page error now shows a Back button that returns to Library

## Notes for Reeve
- ErrorBlock signature change is additive (default \`onBack = null\`), so all existing call sites compile unchanged. No other surface needs touching.
- Long-term follow-up: \"In library\" label should also gain an action-verb cue (\"In library ✓ — tap to remove\") so the dialog isn't the only safety net. Tracked as a follow-up; out of scope for this surgical fix.

Closes #169.