### PR TITLE
fix(docs): screenshots gallery 404s — use baseurl-aware paths (#176)

### DIFF
--- a/docs/screenshots.md
+++ b/docs/screenshots.md
@@ -11,58 +11,58 @@ Captured on a Galaxy Tab A7 Lite (800×1340 px) running storyvox in the Library 
 ## Browse
 
 <figure>
-  <img src="screenshots/01-browse.png" alt="Browse tab — Royal Road and GitHub fiction sources side by side, infinite scroll grid." />
+  <img src="{{ '/screenshots/01-browse.png' | relative_url }}" alt="Browse tab — Royal Road and GitHub fiction sources side by side, infinite scroll grid." />
   <figcaption>Browse — Royal Road infinite-scroll grid with cover art and pinned source picker.</figcaption>
 </figure>
 
 ## Filters
 
 <figure>
-  <img src="screenshots/06-filter.png" alt="Royal Road filter sheet — exclude tags, length and rating sliders, content-warning pills, Reset and Apply buttons." />
+  <img src="{{ '/screenshots/06-filter.png' | relative_url }}" alt="Royal Road filter sheet — exclude tags, length and rating sliders, content-warning pills, Reset and Apply buttons." />
   <figcaption>The full Royal Road filter set — tags include / exclude, status, type, length, rating, sort order, plus content-warning pills (Profanity, Sexual, Violence, Sensitive, AI-assisted, AI-generated).</figcaption>
 </figure>
 
 <figure>
-  <img src="screenshots/06b-filter-github.png" alt="GitHub filter sheet — minimum stars slider, ISO language code, last-pushed dropdown, sort order, Reset and Apply buttons." />
+  <img src="{{ '/screenshots/06b-filter-github.png' | relative_url }}" alt="GitHub filter sheet — minimum stars slider, ISO language code, last-pushed dropdown, sort order, Reset and Apply buttons." />
   <figcaption>The GitHub filter sheet — minimum stars, language code, last-pushed window, sort order.</figcaption>
 </figure>
 
 ## Fiction detail
 
 <figure>
-  <img src="screenshots/02-detail.png" alt="Fiction detail — cover, synopsis, tags, chapter list with read state." />
+  <img src="{{ '/screenshots/02-detail.png' | relative_url }}" alt="Fiction detail — cover, synopsis, tags, chapter list with read state." />
   <figcaption>Fiction detail — synopsis, tags, chapter list, follow / unfollow, jump to first unread.</figcaption>
 </figure>
 
 ## Reader / audiobook view
 
 <figure>
-  <img src="screenshots/03-reader.png" alt="Reader playing The Archmage Coefficient with the spoken sentence highlighted in brass." />
+  <img src="{{ '/screenshots/03-reader.png' | relative_url }}" alt="Reader playing The Archmage Coefficient with the spoken sentence highlighted in brass." />
   <figcaption>Reader — the spoken sentence glides in brass as TTS plays. Swipe left for the audiobook view (cover, scrubber, transport controls).</figcaption>
 </figure>
 
 ## Library
 
 <figure>
-  <img src="screenshots/04-library.png" alt="Library tab — currently-listening fictions with cover, progress, last-read sentence, resume button." />
+  <img src="{{ '/screenshots/04-library.png' | relative_url }}" alt="Library tab — currently-listening fictions with cover, progress, last-read sentence, resume button." />
   <figcaption>Library — currently-listening fictions with cover, progress, last-read sentence, resume button.</figcaption>
 </figure>
 
 ## Settings
 
 <figure>
-  <img src="screenshots/05-settings.png" alt="Settings — voice library, speed, pitch, punctuation cadence, audio buffer slider, theme override, Wi-Fi only, poll interval, account, version." />
+  <img src="{{ '/screenshots/05-settings.png' | relative_url }}" alt="Settings — voice library, speed, pitch, punctuation cadence, audio buffer slider, theme override, Wi-Fi only, poll interval, account, version." />
   <figcaption>Settings — voice picker, speed, pitch, punctuation cadence, buffer slider, theme override, Wi-Fi-only, poll interval, account, version. (Settings UI is being redesigned in <a href="https://github.com/jphein/storyvox/issues/104">#104</a> — these screenshots reflect v0.4.x layout.)</figcaption>
 </figure>
 
 ## Follows
 
 <figure>
-  <img src="screenshots/07-follows-loading.png" alt="Follows tab loading — skeleton placeholders while Royal Road follow list syncs." />
+  <img src="{{ '/screenshots/07-follows-loading.png' | relative_url }}" alt="Follows tab loading — skeleton placeholders while Royal Road follow list syncs." />
   <figcaption>Follows — sync in progress.</figcaption>
 </figure>
 
 <figure>
-  <img src="screenshots/07-follows.png" alt="Follows tab loaded — bookmarked Royal Road fictions in a list." />
+  <img src="{{ '/screenshots/07-follows.png' | relative_url }}" alt="Follows tab loaded — bookmarked Royal Road fictions in a list." />
   <figcaption>Follows — bookmarked fictions, signed in.</figcaption>
 </figure>


### PR DESCRIPTION
## Summary

- Closes #176 (screenshot images broken on the GH Pages gallery)
- Replaces stuck PR #177 (Claude bot stalled after the Initial plan commit, no diff)

## Root cause

`docs/_config.yml` has `permalink: pretty`, so `screenshots.md` renders at URL `/storyvox/screenshots/`. Relative `<img src=\"screenshots/X.png\">` references on that page resolved against `/storyvox/screenshots/`, producing `/storyvox/screenshots/screenshots/X.png` — doubled path, 404.

Verified live:
- `curl /storyvox/screenshots/01-browse.png` → 200 (file exists)
- `curl /storyvox/screenshots/screenshots/01-browse.png` → 404 (what the page was actually loading)

## Fix

Replace relative paths with `{{ '/screenshots/X.png' | relative_url }}` so Jekyll prepends `site.baseurl` (`/storyvox`) and the URL stops doubling.

`index.md` is unaffected — it renders at `/storyvox/` root where the relative paths still resolve correctly.

## Test plan

- [ ] CI green
- [ ] Merge → Pages rebuilds → load `https://jphein.github.io/storyvox/screenshots/` and confirm all 9 images render

🤖 Generated with [Claude Code](https://claude.com/claude-code)