### PR TITLE
feat(auth): wire live GitHub OAuth client id (#91) — v0.4.36

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -33,8 +33,8 @@ android {
         applicationId = "in.jphe.storyvox"
         minSdk = 26
         targetSdk = 35
-        versionCode = 47
-        versionName = "0.4.35"
+        versionCode = 48
+        versionName = "0.4.36"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
         vectorDrawables.useSupportLibrary = true

--- a/source-github/src/main/kotlin/in/jphe/storyvox/source/github/auth/GitHubAuthConfig.kt
+++ b/source-github/src/main/kotlin/in/jphe/storyvox/source/github/auth/GitHubAuthConfig.kt
@@ -5,45 +5,23 @@ package `in`.jphe.storyvox.source.github.auth
  *
  * Issue #91. Spec: docs/superpowers/specs/2026-05-08-github-oauth-design.md
  *
- * ## TODO(client_id) — JP must register the OAuth app
- *
  * The Device Flow is a *public-client* flow: only `client_id` is sent to
  * GitHub, never a `client_secret`. The `client_id` ships in every APK by
  * design (no secrecy), so a hardcoded constant here is the right shape —
  * this is a **deliberate exception** to CLAUDE.md's Vaultwarden rule, which
  * applies to actual secrets.
  *
- * Steps for JP after this PR merges (per Ember's spec § Open Question #1):
- *
- * 1. Visit https://github.com/settings/applications/new
- * 2. Name: `storyvox`
- * 3. Homepage: `https://github.com/jphein/storyvox`
- * 4. Authorization callback URL: `https://github.com/jphein/storyvox`
- *    (unused for Device Flow but the form requires *something*)
- * 5. **Check "Enable Device Flow"** — without this the `/login/device/code`
- *    endpoint returns `device_flow_disabled`.
- * 6. Save → copy the resulting 20-character `client_id`.
- * 7. Replace [DEFAULT_CLIENT_ID] below with the real value, OR wire it via
- *    `local.properties` → `BuildConfig.GITHUB_CLIENT_ID` (cleaner; matches
- *    realm-sigil's Gradle pattern).
- *
- * Until then, sign-in attempts will hit a hardcoded placeholder and fail
- * with `incorrect_client_credentials`. The auth substrate (token storage,
- * interceptor, polling, UI) is fully wired and tested — only the live
- * sign-in path needs the real id.
+ * The OAuth app is registered to JP's account; if it ever needs to rotate
+ * (e.g. compromised, or the public-client posture changes), bump the
+ * constant and ship a new build.
  */
 object GitHubAuthConfig {
 
     /**
-     * Placeholder. **Not a real GitHub OAuth app id.** See class kdoc for
-     * how JP wires the real value.
-     *
-     * Format check: real GitHub `client_id`s are 20 lowercase hex chars
-     * (e.g. `Iv1.b507a08c87ecfe98` for GitHub Apps; OAuth-App ids are
-     * shorter). Anything other than the placeholder will be tried verbatim
-     * against `https://github.com/login/device/code`.
+     * Live storyvox GitHub OAuth-app client id. Registered 2026-05-09 with
+     * Device Flow enabled; see class kdoc for the (no-)secret posture.
      */
-    const val DEFAULT_CLIENT_ID: String = "TODO_JP_REGISTER_OAUTH_APP"
+    const val DEFAULT_CLIENT_ID: String = "Ov23liJEGbBN5ohx95XM"
 
     /**
      * Default scopes requested at sign-in. Spec § Scope minimization:


### PR DESCRIPTION
## Summary

- Replaces `TODO_JP_REGISTER_OAUTH_APP` with the live client id JP just registered (`Ov23liJEGbBN5ohx95XM`)
- OAuth app registered with **Device Flow enabled** — public-client posture, no client_secret
- Bumps to v0.4.36 (versionCode 48) so the live sign-in path ships
- Closes #91

## Why this is safe to hardcode

Device Flow is a public-client flow. The `client_id` is sent to GitHub on every device-code request and is not a secret — every APK ships with it by design. CLAUDE.md's Vaultwarden rule applies to actual secrets; this is a documented exception.

## Test plan

- [ ] CI green
- [ ] APK lands on tablet R83W80CAFZB
- [ ] Settings → Account → Sign in with GitHub → verify device code modal renders
- [ ] Open `github.com/login/device` in a browser, paste the code, authorize
- [ ] Confirm storyvox shows signed-in state and `read:user public_repo` scopes
- [ ] No `incorrect_client_credentials` 400 in logcat

🤖 Generated with [Claude Code](https://claude.com/claude-code)