### PR TITLE
fix(fiction): hide synopsis block when description is empty (#170)

### DIFF
--- a/feature/src/main/kotlin/in/jphe/storyvox/feature/fiction/FictionDetailScreen.kt
+++ b/feature/src/main/kotlin/in/jphe/storyvox/feature/fiction/FictionDetailScreen.kt
@@ -256,6 +256,7 @@ private fun Hero(fiction: UiFiction) {
 
 @Composable
 private fun Synopsis(text: String) {
+    if (text.isBlank()) return
     val spacing = LocalSpacing.current
     var expanded by remember { mutableStateOf(false) }
     Column(


### PR DESCRIPTION
## Summary

Closes #170

When a fiction has no description (Sky Pride on Royal Road, observed by Hazel on v0.4.33), the detail screen rendered a lone "Read more" / "Show less" toggle that flipped its label but expanded nothing — a no-op the user could poke forever.

Guard `Synopsis()` with an `if (text.isBlank()) return` so the entire block (text + toggle) disappears when the description is empty or whitespace-only. Non-empty descriptions render exactly as before.

Touched: `feature/src/main/kotlin/in/jphe/storyvox/feature/fiction/FictionDetailScreen.kt` (+1 line).

## Test plan

- [ ] Build green (`:feature:compileDebugKotlin`) — verified locally
- [ ] Open Sky Pride fiction detail on tablet — description column is empty, no "Read more" link visible
- [ ] Open a normal fiction (e.g. one with a long synopsis) — Read more / Show less still works as before
- [ ] Open a fiction with a short (≤4 line) synopsis — still renders the text; toggle is functionally a no-op there but that's a separate pre-existing concern out of scope for #170