### PR TITLE
feat(llm): Vertex AI Gemini provider — BYOK API key (#81 follow-up)

### DIFF
--- a/app/src/main/kotlin/in/jphe/storyvox/data/SettingsRepositoryUiImpl.kt
+++ b/app/src/main/kotlin/in/jphe/storyvox/data/SettingsRepositoryUiImpl.kt
@@ -146,6 +146,7 @@ private object Keys {
     val AI_OPENAI_MODEL = stringPreferencesKey("pref_ai_openai_model")
     val AI_OLLAMA_BASE_URL = stringPreferencesKey("pref_ai_ollama_base_url")
     val AI_OLLAMA_MODEL = stringPreferencesKey("pref_ai_ollama_model")
+    val AI_VERTEX_MODEL = stringPreferencesKey("pref_ai_vertex_model")
     val AI_PRIVACY_ACK = booleanPreferencesKey("pref_ai_privacy_ack")
     val AI_SEND_CHAPTER_TEXT = booleanPreferencesKey("pref_ai_send_chapter_text")
 
@@ -232,6 +233,8 @@ class SettingsRepositoryUiImpl(
                 openAiKeyConfigured = llmCreds.hasOpenAiKey,
                 ollamaBaseUrl = prefs[Keys.AI_OLLAMA_BASE_URL] ?: "http://10.0.0.1:11434",
                 ollamaModel = prefs[Keys.AI_OLLAMA_MODEL] ?: "llama3.3",
+                vertexModel = prefs[Keys.AI_VERTEX_MODEL] ?: "gemini-2.5-flash",
+                vertexKeyConfigured = llmCreds.hasVertexKey,
                 privacyAcknowledged = prefs[Keys.AI_PRIVACY_ACK] ?: false,
                 sendChapterTextEnabled = prefs[Keys.AI_SEND_CHAPTER_TEXT] ?: true,
             ),
@@ -425,6 +428,15 @@ class SettingsRepositoryUiImpl(
         store.edit { it[Keys.AI_OLLAMA_MODEL] = model }
     }
 
+    override suspend fun setVertexApiKey(key: String?) {
+        if (key == null) llmCreds.clearVertexApiKey()
+        else llmCreds.setVertexApiKey(key)
+    }
+
+    override suspend fun setVertexModel(model: String) {
+        store.edit { it[Keys.AI_VERTEX_MODEL] = model }
+    }
+
     override suspend fun setSendChapterTextEnabled(enabled: Boolean) {
         store.edit { it[Keys.AI_SEND_CHAPTER_TEXT] = enabled }
     }
@@ -440,6 +452,7 @@ class SettingsRepositoryUiImpl(
             it.remove(Keys.AI_OPENAI_MODEL)
             it.remove(Keys.AI_OLLAMA_BASE_URL)
             it.remove(Keys.AI_OLLAMA_MODEL)
+            it.remove(Keys.AI_VERTEX_MODEL)
             it.remove(Keys.AI_PRIVACY_ACK)
             it.remove(Keys.AI_SEND_CHAPTER_TEXT)
         }
@@ -520,6 +533,7 @@ class SettingsRepositoryUiImpl(
             openAiModel = prefs[Keys.AI_OPENAI_MODEL] ?: "gpt-4o-mini",
             ollamaBaseUrl = prefs[Keys.AI_OLLAMA_BASE_URL] ?: "http://10.0.0.1:11434",
             ollamaModel = prefs[Keys.AI_OLLAMA_MODEL] ?: "llama3.3",
+            vertexModel = prefs[Keys.AI_VERTEX_MODEL] ?: "gemini-2.5-flash",
             privacyAcknowledged = prefs[Keys.AI_PRIVACY_ACK] ?: false,
             sendChapterTextEnabled = prefs[Keys.AI_SEND_CHAPTER_TEXT] ?: true,
         )
@@ -536,6 +550,7 @@ class SettingsRepositoryUiImpl(
             p[Keys.AI_OPENAI_MODEL] = config.openAiModel
             p[Keys.AI_OLLAMA_BASE_URL] = config.ollamaBaseUrl
             p[Keys.AI_OLLAMA_MODEL] = config.ollamaModel
+            p[Keys.AI_VERTEX_MODEL] = config.vertexModel
             p[Keys.AI_PRIVACY_ACK] = config.privacyAcknowledged
             p[Keys.AI_SEND_CHAPTER_TEXT] = config.sendChapterTextEnabled
         }

--- a/app/src/test/kotlin/in/jphe/storyvox/di/RealPlaybackControllerUiTest.kt
+++ b/app/src/test/kotlin/in/jphe/storyvox/di/RealPlaybackControllerUiTest.kt
@@ -236,6 +236,8 @@ class RealPlaybackControllerUiTest {
         override suspend fun setOpenAiModel(model: String) = Unit
         override suspend fun setOllamaBaseUrl(url: String) = Unit
         override suspend fun setOllamaModel(model: String) = Unit
+        override suspend fun setVertexApiKey(key: String?) = Unit
+        override suspend fun setVertexModel(model: String) = Unit
         override suspend fun setSendChapterTextEnabled(enabled: Boolean) = Unit
         override suspend fun acknowledgeAiPrivacy() = Unit
         override suspend fun resetAiSettings() = Unit

--- a/core-llm/src/main/kotlin/in/jphe/storyvox/llm/LlmConfig.kt
+++ b/core-llm/src/main/kotlin/in/jphe/storyvox/llm/LlmConfig.kt
@@ -79,4 +79,13 @@ object LlmModels {
         "mistral",
         "phi3",
     )
+
+    /** Mirrors cloud-chat-assistant's Gemini list. The `-lite` tier is
+     *  the cheapest; `-pro` is the smartest; `-flash` is the default
+     *  middle ground. */
+    val vertex = listOf(
+        "gemini-2.5-flash",
+        "gemini-2.5-pro",
+        "gemini-2.5-flash-lite",
+    )
 }

--- a/core-llm/src/main/kotlin/in/jphe/storyvox/llm/LlmCredentialsStore.kt
+++ b/core-llm/src/main/kotlin/in/jphe/storyvox/llm/LlmCredentialsStore.kt
@@ -62,6 +62,7 @@ open class LlmCredentialsStore @Inject constructor(
     open fun setVertexApiKey(key: String) =
         prefs.edit { putString(KEY_VERTEX, key) }
     open fun clearVertexApiKey() = prefs.edit { remove(KEY_VERTEX) }
+    open val hasVertexKey: Boolean get() = vertexApiKey() != null
 
     open fun foundryApiKey(): String? = prefs.getString(KEY_FOUNDRY, null)
     open fun setFoundryApiKey(key: String) =

--- a/core-llm/src/main/kotlin/in/jphe/storyvox/llm/LlmRepository.kt
+++ b/core-llm/src/main/kotlin/in/jphe/storyvox/llm/LlmRepository.kt
@@ -3,6 +3,7 @@ package `in`.jphe.storyvox.llm
 import `in`.jphe.storyvox.llm.provider.ClaudeApiProvider
 import `in`.jphe.storyvox.llm.provider.OllamaProvider
 import `in`.jphe.storyvox.llm.provider.OpenAiApiProvider
+import `in`.jphe.storyvox.llm.provider.VertexProvider
 import javax.inject.Inject
 import javax.inject.Singleton
 import kotlinx.coroutines.flow.Flow
@@ -26,6 +27,7 @@ class LlmRepository @Inject constructor(
     private val claude: ClaudeApiProvider,
     private val openAi: OpenAiApiProvider,
     private val ollama: OllamaProvider,
+    private val vertex: VertexProvider,
 ) {
 
     /** The provider currently picked in Settings, or null when AI
@@ -73,8 +75,8 @@ class LlmRepository @Inject constructor(
         ProviderId.Claude -> claude
         ProviderId.OpenAi -> openAi
         ProviderId.Ollama -> ollama
+        ProviderId.Vertex -> vertex
         ProviderId.Bedrock,
-        ProviderId.Vertex,
         ProviderId.Foundry,
         ProviderId.Teams ->
             throw LlmError.NotConfigured(id)

--- a/core-llm/src/main/kotlin/in/jphe/storyvox/llm/ProviderId.kt
+++ b/core-llm/src/main/kotlin/in/jphe/storyvox/llm/ProviderId.kt
@@ -32,7 +32,7 @@ enum class ProviderId {
     /** True if a real LlmProvider implementation exists for this id.
      *  False ids are surfaced as "coming soon" in the AI Settings. */
     val implemented: Boolean
-        get() = this == Claude || this == OpenAi || this == Ollama
+        get() = this == Claude || this == OpenAi || this == Ollama || this == Vertex
 
     /** Human-friendly label for the Settings UI. Localization is a
      *  follow-up; English-only labels for now match the rest of the

--- a/core-llm/src/main/kotlin/in/jphe/storyvox/llm/provider/VertexProvider.kt
+++ b/core-llm/src/main/kotlin/in/jphe/storyvox/llm/provider/VertexProvider.kt
@@ -1,0 +1,172 @@
+package `in`.jphe.storyvox.llm.provider
+
+import `in`.jphe.storyvox.llm.LlmConfig
+import `in`.jphe.storyvox.llm.LlmCredentialsStore
+import `in`.jphe.storyvox.llm.LlmError
+import `in`.jphe.storyvox.llm.LlmMessage
+import `in`.jphe.storyvox.llm.LlmProvider
+import `in`.jphe.storyvox.llm.ProbeResult
+import `in`.jphe.storyvox.llm.ProviderId
+import `in`.jphe.storyvox.llm.di.LlmHttp
+import `in`.jphe.storyvox.llm.sse.SseLineParser
+import javax.inject.Inject
+import javax.inject.Singleton
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.flow.flow
+import kotlinx.coroutines.flow.flowOn
+import kotlinx.serialization.encodeToString
+import kotlinx.serialization.json.Json
+import okhttp3.HttpUrl.Companion.toHttpUrl
+import okhttp3.OkHttpClient
+import okhttp3.Request
+import okhttp3.RequestBody.Companion.toRequestBody
+import java.io.IOException
+
+/**
+ * Google Vertex AI / Gemini streaming client. Wire format documented
+ * here:
+ *   https://ai.google.dev/api/rest/v1beta/models/streamGenerateContent
+ *
+ * BYOK auth via API key in the URL query string (`?key=…`). Direct
+ * port of `cloud-chat-assistant/llm_stream.py`'s `google` branch —
+ * the `generativelanguage.googleapis.com` endpoint accepts the same
+ * key format that an end-user generates from
+ * https://aistudio.google.com/app/apikey, so we don't pull in the
+ * Google Cloud auth library or implement OAuth token refresh. If a
+ * future spec wants service-account JSON / Vertex Enterprise auth,
+ * that's a separate provider class.
+ *
+ * The endpoint emits true SSE when called with `?alt=sse`, so we
+ * reuse [SseLineParser]'s `vertex` branch — the JSON body inside the
+ * `data:` lines is Gemini-shaped, not OpenAI-compat.
+ */
+@Singleton
+open class VertexProvider @Inject constructor(
+    @LlmHttp private val http: OkHttpClient,
+    private val store: LlmCredentialsStore,
+    private val configFlow: Flow<LlmConfig>,
+    private val json: Json,
+) : LlmProvider {
+
+    override val id: ProviderId = ProviderId.Vertex
+
+    /** Base URL up to but not including `models/{model}:…`. Open so
+     *  tests can point at MockWebServer. */
+    protected open val baseUrl: String = BASE_URL
+
+    override fun stream(
+        messages: List<LlmMessage>,
+        systemPrompt: String?,
+        model: String?,
+    ): Flow<String> = flow {
+        val cfg = configFlow.first()
+        val apiKey = store.vertexApiKey()
+            ?: throw LlmError.NotConfigured(ProviderId.Vertex)
+        val resolvedModel = model ?: cfg.vertexModel
+
+        // Gemini's role names: user is "user", assistant is "model".
+        // System prompt rides outside the contents array on its own
+        // top-level field — same shape as Anthropic in spirit.
+        val contents = messages.map {
+            VertexContent(
+                role = if (it.role == LlmMessage.Role.assistant) "model" else "user",
+                parts = listOf(VertexPart(it.content)),
+            )
+        }
+        val systemInstruction = systemPrompt?.takeIf { it.isNotBlank() }
+            ?.let { VertexContent(parts = listOf(VertexPart(it))) }
+
+        val body = VertexRequest(
+            contents = contents,
+            systemInstruction = systemInstruction,
+            generationConfig = VertexGenerationConfig(maxOutputTokens = MAX_OUTPUT_TOKENS),
+        )
+
+        val request = Request.Builder()
+            .url(streamUrl(resolvedModel, apiKey))
+            .header("content-type", "application/json")
+            .header("accept", "text/event-stream")
+            .post(json.encodeToString(body).toRequestBody(JSON_MEDIA_TYPE))
+            .build()
+
+        val response = try {
+            http.newCall(request).executeAsync()
+        } catch (e: IOException) {
+            throw LlmError.Transport(ProviderId.Vertex, e)
+        }
+
+        response.use { resp ->
+            when {
+                resp.code == 401 || resp.code == 403 ->
+                    throw LlmError.AuthFailed(
+                        ProviderId.Vertex,
+                        resp.message.ifBlank { "HTTP ${resp.code}" },
+                    )
+                !resp.isSuccessful -> {
+                    val excerpt = resp.body?.string()?.take(256) ?: resp.message
+                    throw LlmError.ProviderError(
+                        ProviderId.Vertex, resp.code, excerpt,
+                    )
+                }
+            }
+            val src = resp.body?.source()
+                ?: throw LlmError.Transport(
+                    ProviderId.Vertex,
+                    IOException("Empty response body"),
+                )
+            src.use {
+                while (!it.exhausted()) {
+                    val line = it.readUtf8Line() ?: break
+                    val token = SseLineParser.vertex(line, json) ?: continue
+                    emit(token)
+                }
+            }
+        }
+    }.flowOn(Dispatchers.IO)
+
+    override suspend fun probe(): ProbeResult {
+        val apiKey = store.vertexApiKey()
+            ?: return ProbeResult.Misconfigured("No Vertex API key")
+        // GET /v1beta/models — instant, free, doesn't burn token
+        // budget. Same trick OpenAI's probe uses.
+        val url = baseUrl.toHttpUrl().newBuilder()
+            .addPathSegments("v1beta/models")
+            .addQueryParameter("key", apiKey)
+            .build()
+        val request = Request.Builder().url(url).get().build()
+        return try {
+            http.newCall(request).executeAsync().use { resp ->
+                when {
+                    resp.isSuccessful -> ProbeResult.Ok
+                    resp.code == 401 || resp.code == 403 ->
+                        ProbeResult.AuthError("Invalid Vertex API key")
+                    else -> ProbeResult.NotReachable(
+                        "Vertex returned ${resp.code}",
+                    )
+                }
+            }
+        } catch (e: IOException) {
+            ProbeResult.NotReachable(e.message ?: "Connection failed")
+        }
+    }
+
+    private fun streamUrl(model: String, apiKey: String): okhttp3.HttpUrl =
+        baseUrl.toHttpUrl().newBuilder()
+            // Path is `v1beta/models/{model}:streamGenerateContent` —
+            // the colon-suffix is part of the path segment per
+            // Google's protobuf-derived URL convention. addPathSegment
+            // url-encodes the colon, which Vertex accepts.
+            .addPathSegments("v1beta/models/$model:streamGenerateContent")
+            .addQueryParameter("alt", "sse")
+            .addQueryParameter("key", apiKey)
+            .build()
+
+    private companion object {
+        const val BASE_URL = "https://generativelanguage.googleapis.com/"
+        /** Generous cap. Vertex bills per output token; the user can
+         *  cancel mid-stream via flow cancellation. */
+        const val MAX_OUTPUT_TOKENS = 1024
+    }
+}

--- a/core-llm/src/main/kotlin/in/jphe/storyvox/llm/provider/Wire.kt
+++ b/core-llm/src/main/kotlin/in/jphe/storyvox/llm/provider/Wire.kt
@@ -4,13 +4,13 @@ import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 
 /**
- * Wire-format data classes for the three implemented providers.
- * Anthropic and OpenAI/Ollama have different shapes; both are kept
- * narrow (only the fields we send) so we don't accidentally
- * over-specify and break on minor API changes.
+ * Wire-format data classes for the implemented providers.
+ * Anthropic, OpenAI/Ollama, and Vertex/Gemini all have distinct
+ * shapes; each is kept narrow (only the fields we send) so we don't
+ * accidentally over-specify and break on minor API changes.
  *
- * Spec-only providers (Bedrock, Vertex, Foundry, Teams) get their
- * own wire types when those classes ship.
+ * Spec-only providers (Bedrock, Foundry, Teams) get their own wire
+ * types when those classes ship.
  */
 
 // ── Anthropic Messages API ──────────────────────────────────────────
@@ -44,4 +44,32 @@ internal data class OpenAiRequest(
 internal data class OpenAiMessage(
     val role: String,        // "system", "user", or "assistant"
     val content: String,
+)
+
+// ── Google Vertex AI / Gemini ───────────────────────────────────────
+
+@Serializable
+internal data class VertexRequest(
+    val contents: List<VertexContent>,
+    @SerialName("system_instruction") val systemInstruction: VertexContent? = null,
+    val generationConfig: VertexGenerationConfig? = null,
+)
+
+@Serializable
+internal data class VertexContent(
+    /** "user" or "model" — Gemini calls the assistant role "model".
+     *  Optional on `system_instruction` (Gemini ignores it there). */
+    val role: String? = null,
+    val parts: List<VertexPart>,
+)
+
+@Serializable
+internal data class VertexPart(
+    val text: String,
+)
+
+@Serializable
+internal data class VertexGenerationConfig(
+    val temperature: Float? = null,
+    @SerialName("maxOutputTokens") val maxOutputTokens: Int? = null,
 )

--- a/core-llm/src/main/kotlin/in/jphe/storyvox/llm/sse/SseLineParser.kt
+++ b/core-llm/src/main/kotlin/in/jphe/storyvox/llm/sse/SseLineParser.kt
@@ -7,17 +7,18 @@ import kotlinx.serialization.json.jsonObject
 import kotlinx.serialization.json.jsonPrimitive
 
 /**
- * Two SSE line parsers covering the full LLM provider matrix:
+ * Three SSE line parsers covering the full LLM provider matrix:
  *  - [anthropic] — Claude direct, Anthropic Teams (same wire format).
  *  - [openAiCompat] — OpenAI, Ollama, DigitalOcean, Puter, Foundry
  *    serverless, Foundry deployed. Most of the field shares this.
+ *  - [vertex] — Google Vertex AI / Gemini. True SSE (when called with
+ *    `?alt=sse`) but the JSON shape is Gemini's, not OpenAI's.
  *
  * Direct Kotlin port of `cloud-chat-assistant/llm_stream.py`'s
- * `_parse_sse_line`. Bedrock + Vertex use different formats (binary
- * event-stream and Gemini-shaped JSON respectively); they get their
- * own parsers when those providers ship.
+ * `_parse_sse_line`. Bedrock uses a binary event-stream format and
+ * gets its own parser when that provider ships.
  *
- * Both functions return `null` for "no token in this line" — junk
+ * All functions return `null` for "no token in this line" — junk
  * lines, comments, the `[DONE]` sentinel, malformed JSON. Callers
  * pass through and continue reading. Returning a token (non-null
  * String) means "emit this".
@@ -59,5 +60,27 @@ object SseLineParser {
         if (choices.isEmpty()) return null
         return choices[0].jsonObject["delta"]?.jsonObject
             ?.get("content")?.jsonPrimitive?.contentOrNull
+    }
+
+    /**
+     * Vertex / Gemini events. Each `data:` line is a full
+     * `GenerateContentResponse` whose token text is at
+     * `candidates[0].content.parts[0].text`. Unlike OpenAI there's no
+     * `[DONE]` sentinel — the server simply closes the stream when
+     * the last frame's `finishReason` is set; the caller's read loop
+     * terminates naturally on EOF.
+     */
+    fun vertex(line: String, json: Json): String? {
+        if (!line.startsWith("data: ")) return null
+        val data = line.substring(6)
+        if (data.isBlank()) return null
+        val obj = runCatching { json.parseToJsonElement(data) }
+            .getOrNull()?.jsonObject ?: return null
+        val candidates = obj["candidates"]?.jsonArray ?: return null
+        if (candidates.isEmpty()) return null
+        val parts = candidates[0].jsonObject["content"]?.jsonObject
+            ?.get("parts")?.jsonArray ?: return null
+        if (parts.isEmpty()) return null
+        return parts[0].jsonObject["text"]?.jsonPrimitive?.contentOrNull
     }
 }

--- a/core-llm/src/test/kotlin/in/jphe/storyvox/llm/feature/ChapterRecapTest.kt
+++ b/core-llm/src/test/kotlin/in/jphe/storyvox/llm/feature/ChapterRecapTest.kt
@@ -18,6 +18,7 @@ import `in`.jphe.storyvox.llm.provider.ClaudeApiProvider
 import `in`.jphe.storyvox.llm.provider.FakeStore
 import `in`.jphe.storyvox.llm.provider.OllamaProvider
 import `in`.jphe.storyvox.llm.provider.OpenAiApiProvider
+import `in`.jphe.storyvox.llm.provider.VertexProvider
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.flow.toList
@@ -87,6 +88,7 @@ class ChapterRecapTest {
             claude = fakeProvider.asClaude(),
             openAi = fakeProvider.asOpenAi(),
             ollama = fakeProvider.asOllama(),
+            vertex = fakeProvider.asVertex(),
         )
         recap = ChapterRecap(
             chapterDao = db.chapterDao(),
@@ -227,6 +229,24 @@ private class FakeProvider {
 
     fun asOllama(): OllamaProvider = object : OllamaProvider(
         http = OkHttpClient(),
+        configFlow = flowOf(LlmConfig()),
+        json = Json,
+    ) {
+        override fun stream(
+            messages: List<LlmMessage>,
+            systemPrompt: String?,
+            model: String?,
+        ): Flow<String> {
+            lastMessages = messages
+            lastSystemPrompt = systemPrompt
+            return flowOf(*tokens.toTypedArray())
+        }
+        override suspend fun probe(): ProbeResult = ProbeResult.Ok
+    }
+
+    fun asVertex(): VertexProvider = object : VertexProvider(
+        http = OkHttpClient(),
+        store = FakeStore(),
         configFlow = flowOf(LlmConfig()),
         json = Json,
     ) {

--- a/core-llm/src/test/kotlin/in/jphe/storyvox/llm/provider/ClaudeApiProviderTest.kt
+++ b/core-llm/src/test/kotlin/in/jphe/storyvox/llm/provider/ClaudeApiProviderTest.kt
@@ -125,7 +125,9 @@ class ClaudeApiProviderTest {
 internal class FakeStore(
     private val claude: String? = null,
     private val openAi: String? = null,
+    private val vertex: String? = null,
 ) : LlmCredentialsStore() {
     override fun claudeApiKey(): String? = claude
     override fun openAiApiKey(): String? = openAi
+    override fun vertexApiKey(): String? = vertex
 }

--- a/core-llm/src/test/kotlin/in/jphe/storyvox/llm/provider/VertexProviderTest.kt
+++ b/core-llm/src/test/kotlin/in/jphe/storyvox/llm/provider/VertexProviderTest.kt
@@ -1,0 +1,244 @@
+package `in`.jphe.storyvox.llm.provider
+
+import `in`.jphe.storyvox.llm.LlmConfig
+import `in`.jphe.storyvox.llm.LlmError
+import `in`.jphe.storyvox.llm.LlmMessage
+import `in`.jphe.storyvox.llm.ProbeResult
+import `in`.jphe.storyvox.llm.ProviderId
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.flow.toList
+import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.test.runTest
+import kotlinx.serialization.encodeToString
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.jsonArray
+import kotlinx.serialization.json.jsonObject
+import kotlinx.serialization.json.jsonPrimitive
+import okhttp3.OkHttpClient
+import okhttp3.mockwebserver.MockResponse
+import okhttp3.mockwebserver.MockWebServer
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertThrows
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+import java.util.concurrent.TimeUnit
+
+class VertexProviderTest {
+
+    private lateinit var server: MockWebServer
+    private val json = Json { ignoreUnknownKeys = true }
+    private lateinit var http: OkHttpClient
+
+    @Before
+    fun setUp() {
+        server = MockWebServer()
+        server.start()
+        http = OkHttpClient.Builder().readTimeout(2, TimeUnit.SECONDS).build()
+    }
+
+    @After fun tearDown() { server.shutdown() }
+
+    private fun providerWith(key: String?): VertexProvider {
+        val mockBase = server.url("/").toString()
+        return object : VertexProvider(
+            http = http,
+            store = FakeStore(vertex = key),
+            configFlow = flowOf(LlmConfig(vertexModel = "gemini-2.5-flash")),
+            json = json,
+        ) {
+            override val baseUrl: String = mockBase
+        }
+    }
+
+    @Test
+    fun `streams text deltas in order`() = runTest {
+        // Three SSE frames + a final one with no content (just
+        // finishReason). The parser should emit only the text-bearing
+        // frames, in order.
+        val sse = listOf(
+            """data: {"candidates":[{"content":{"role":"model","parts":[{"text":"Once "}]}}]}""",
+            """data: {"candidates":[{"content":{"role":"model","parts":[{"text":"upon "}]}}]}""",
+            """data: {"candidates":[{"content":{"role":"model","parts":[{"text":"a time."}]}}]}""",
+            """data: {"candidates":[{"content":{"parts":[]},"finishReason":"STOP"}]}""",
+        ).joinToString("\n") + "\n"
+        server.enqueue(
+            MockResponse()
+                .setHeader("Content-Type", "text/event-stream")
+                .setBody(sse)
+                .setResponseCode(200),
+        )
+        val tokens = providerWith("k").stream(
+            messages = listOf(LlmMessage(LlmMessage.Role.user, "hi")),
+            systemPrompt = "be a librarian",
+        ).toList()
+        assertEquals(listOf("Once ", "upon ", "a time."), tokens)
+
+        val req = server.takeRequest()
+        // Path includes the model + the colon-suffixed RPC name.
+        assertTrue(
+            "Path was ${req.path}",
+            req.path?.startsWith(
+                "/v1beta/models/gemini-2.5-flash:streamGenerateContent",
+            ) == true,
+        )
+        // Auth is in the URL query string, not a header.
+        assertTrue(req.path?.contains("key=k") == true)
+        assertTrue(req.path?.contains("alt=sse") == true)
+        // No Authorization header — Vertex API key auth doesn't use one.
+        assertNull(req.getHeader("Authorization"))
+
+        // Body should round-trip to a Vertex shape: contents[].parts[].text
+        // with role mapping (user → "user"), and system_instruction
+        // outside the contents array.
+        val body = req.body.readUtf8()
+        val parsed = json.parseToJsonElement(body).jsonObject
+        assertNotNull(parsed["contents"])
+        assertNotNull(parsed["system_instruction"])
+        // assistant role would map to "model"; we only sent a user
+        // message so the only role here is "user".
+        assertTrue(body.contains(""""role":"user""""))
+        assertTrue(body.contains(""""text":"hi""""))
+        assertTrue(body.contains("be a librarian"))
+    }
+
+    @Test
+    fun `assistant role maps to model in wire body`() = runTest {
+        server.enqueue(
+            MockResponse()
+                .setHeader("Content-Type", "text/event-stream")
+                .setBody("data: {\"candidates\":[]}\n")
+                .setResponseCode(200),
+        )
+        providerWith("k").stream(
+            messages = listOf(
+                LlmMessage(LlmMessage.Role.user, "first"),
+                LlmMessage(LlmMessage.Role.assistant, "reply"),
+                LlmMessage(LlmMessage.Role.user, "follow-up"),
+            ),
+        ).toList()
+        val body = server.takeRequest().body.readUtf8()
+        // Gemini calls the assistant turn "model" not "assistant".
+        assertTrue("Body had no model role: $body", body.contains(""""role":"model""""))
+        assertTrue(body.contains(""""role":"user""""))
+        // No system_instruction when no system prompt was passed.
+        val parsed = json.parseToJsonElement(body).jsonObject
+        assertNull(parsed["system_instruction"])
+    }
+
+    @Test
+    fun `401 raises AuthFailed`() = runTest {
+        server.enqueue(MockResponse().setResponseCode(401).setBody("nope"))
+        val ex = assertThrows(LlmError.AuthFailed::class.java) {
+            runBlocking {
+                providerWith("k").stream(
+                    listOf(LlmMessage(LlmMessage.Role.user, "x")),
+                ).toList()
+            }
+        }
+        assertEquals(ProviderId.Vertex, ex.provider)
+    }
+
+    @Test
+    fun `5xx raises ProviderError`() = runTest {
+        server.enqueue(MockResponse().setResponseCode(503).setBody("upstream busy"))
+        val ex = assertThrows(LlmError.ProviderError::class.java) {
+            runBlocking {
+                providerWith("k").stream(
+                    listOf(LlmMessage(LlmMessage.Role.user, "x")),
+                ).toList()
+            }
+        }
+        assertEquals(ProviderId.Vertex, ex.provider)
+        assertEquals(503, ex.status)
+        assertTrue(ex.detail.contains("upstream busy"))
+    }
+
+    @Test
+    fun `missing key raises NotConfigured`() = runTest {
+        val ex = assertThrows(LlmError.NotConfigured::class.java) {
+            runBlocking {
+                providerWith(null).stream(
+                    listOf(LlmMessage(LlmMessage.Role.user, "x")),
+                ).toList()
+            }
+        }
+        assertEquals(ProviderId.Vertex, ex.provider)
+    }
+
+    @Test
+    fun `probe ok on 200 from models endpoint`() = runTest {
+        server.enqueue(MockResponse().setResponseCode(200).setBody("""{"models":[]}"""))
+        val result = providerWith("k").probe()
+        assertEquals(ProbeResult.Ok, result)
+
+        val req = server.takeRequest()
+        assertEquals("GET", req.method)
+        assertTrue(
+            "Probe path was ${req.path}",
+            req.path?.startsWith("/v1beta/models?") == true,
+        )
+        assertTrue(req.path?.contains("key=k") == true)
+    }
+
+    @Test
+    fun `probe auth-error on 401`() = runTest {
+        server.enqueue(MockResponse().setResponseCode(401))
+        val result = providerWith("k").probe()
+        assertTrue(result is ProbeResult.AuthError)
+    }
+
+    @Test
+    fun `probe misconfigured when no key`() = runTest {
+        val result = providerWith(null).probe()
+        assertTrue(result is ProbeResult.Misconfigured)
+    }
+
+    // Round-trip + JSON-shape test for the Vertex wire body. Cassia
+    // explicitly asks for this; it lives next to the network tests
+    // because the data classes are package-private to provider/.
+    @Test
+    fun `wire body round-trips with Vertex JSON shape`() {
+        val req = VertexRequest(
+            contents = listOf(
+                VertexContent(role = "user", parts = listOf(VertexPart("hello"))),
+                VertexContent(role = "model", parts = listOf(VertexPart("hi back"))),
+            ),
+            systemInstruction = VertexContent(parts = listOf(VertexPart("be terse"))),
+            generationConfig = VertexGenerationConfig(temperature = 0.7f, maxOutputTokens = 256),
+        )
+        val encoded = Json.encodeToString(req)
+        val parsed = Json.parseToJsonElement(encoded).jsonObject
+
+        // contents[0].parts[0].text == "hello", role "user".
+        val contents = parsed["contents"]!!.jsonArray
+        assertEquals(2, contents.size)
+        val first = contents[0].jsonObject
+        assertEquals("user", first["role"]!!.jsonPrimitive.content)
+        assertEquals(
+            "hello",
+            first["parts"]!!.jsonArray[0].jsonObject["text"]!!.jsonPrimitive.content,
+        )
+        // contents[1].role == "model" (Gemini's name for assistant).
+        assertEquals(
+            "model",
+            contents[1].jsonObject["role"]!!.jsonPrimitive.content,
+        )
+
+        // system_instruction is at the top level (NOT inside contents).
+        // It carries the same `parts: [{text}]` shape but no role.
+        val sys = parsed["system_instruction"]!!.jsonObject
+        assertEquals(
+            "be terse",
+            sys["parts"]!!.jsonArray[0].jsonObject["text"]!!.jsonPrimitive.content,
+        )
+
+        // generationConfig.maxOutputTokens (camel-cased as Gemini wants).
+        val gen = parsed["generationConfig"]!!.jsonObject
+        assertEquals("256", gen["maxOutputTokens"]!!.jsonPrimitive.content)
+        assertEquals("0.7", gen["temperature"]!!.jsonPrimitive.content)
+    }
+}

--- a/core-llm/src/test/kotlin/in/jphe/storyvox/llm/sse/SseLineParserTest.kt
+++ b/core-llm/src/test/kotlin/in/jphe/storyvox/llm/sse/SseLineParserTest.kt
@@ -75,4 +75,29 @@ class SseLineParserTest {
         assertNull(SseLineParser.openAiCompat("", json))
         assertNull(SseLineParser.openAiCompat(": keep-alive", json))
     }
+
+    @Test
+    fun `vertex returns text from candidates parts`() {
+        val line = """data: {"candidates":[{"content":{"role":"model","parts":[{"text":"Hello "}]}}]}"""
+        assertEquals("Hello ", SseLineParser.vertex(line, json))
+    }
+
+    @Test
+    fun `vertex finishReason-only frame returns null`() {
+        val line = """data: {"candidates":[{"content":{"parts":[]},"finishReason":"STOP"}]}"""
+        assertNull(SseLineParser.vertex(line, json))
+    }
+
+    @Test
+    fun `vertex empty candidates returns null`() {
+        val line = """data: {"candidates":[]}"""
+        assertNull(SseLineParser.vertex(line, json))
+    }
+
+    @Test
+    fun `vertex ignores non-data line and malformed json`() {
+        assertNull(SseLineParser.vertex("", json))
+        assertNull(SseLineParser.vertex(": keep-alive", json))
+        assertNull(SseLineParser.vertex("data: {not json", json))
+    }
 }

--- a/feature/src/main/kotlin/in/jphe/storyvox/feature/api/UiContracts.kt
+++ b/feature/src/main/kotlin/in/jphe/storyvox/feature/api/UiContracts.kt
@@ -300,10 +300,10 @@ interface VoiceProviderUi {
 enum class UiLlmProvider {
     Claude, OpenAi, Ollama, Bedrock, Vertex, Foundry, Teams;
 
-    /** Whether this provider has a real implementation in PR-1.
+    /** Whether this provider has a real implementation.
      *  Matches `ProviderId.implemented`. */
     val implemented: Boolean
-        get() = this == Claude || this == OpenAi || this == Ollama
+        get() = this == Claude || this == OpenAi || this == Ollama || this == Vertex
 
     val displayName: String
         get() = when (this) {
@@ -329,6 +329,8 @@ data class UiAiSettings(
     val openAiKeyConfigured: Boolean = false,
     val ollamaBaseUrl: String = "http://10.0.0.1:11434",
     val ollamaModel: String = "llama3.3",
+    val vertexModel: String = "gemini-2.5-flash",
+    val vertexKeyConfigured: Boolean = false,
     val privacyAcknowledged: Boolean = false,
     val sendChapterTextEnabled: Boolean = true,
 )
@@ -577,6 +579,8 @@ interface SettingsRepositoryUi {
     suspend fun setOpenAiModel(model: String)
     suspend fun setOllamaBaseUrl(url: String)
     suspend fun setOllamaModel(model: String)
+    suspend fun setVertexApiKey(key: String?)   // null = clear
+    suspend fun setVertexModel(model: String)
     suspend fun setSendChapterTextEnabled(enabled: Boolean)
     suspend fun acknowledgeAiPrivacy()
     /** Wipe all AI configuration — provider/keys/URLs. */

--- a/feature/src/main/kotlin/in/jphe/storyvox/feature/settings/SettingsScreen.kt
+++ b/feature/src/main/kotlin/in/jphe/storyvox/feature/settings/SettingsScreen.kt
@@ -253,6 +253,8 @@ fun SettingsScreen(
             onSetOpenAiModel = viewModel::setOpenAiModel,
             onSetOllamaBaseUrl = viewModel::setOllamaBaseUrl,
             onSetOllamaModel = viewModel::setOllamaModel,
+            onSetVertexKey = viewModel::setVertexApiKey,
+            onSetVertexModel = viewModel::setVertexModel,
             onSetSendChapterText = viewModel::setSendChapterTextEnabled,
             onTestConnection = viewModel::testAiConnection,
             onClearProbeOutcome = viewModel::clearProbeOutcome,
@@ -981,6 +983,8 @@ private fun AiSection(
     onSetOpenAiModel: (String) -> Unit,
     onSetOllamaBaseUrl: (String) -> Unit,
     onSetOllamaModel: (String) -> Unit,
+    onSetVertexKey: (String?) -> Unit,
+    onSetVertexModel: (String) -> Unit,
     onSetSendChapterText: (Boolean) -> Unit,
     onTestConnection: (UiLlmProvider) -> Unit,
     onClearProbeOutcome: () -> Unit,
@@ -1014,9 +1018,12 @@ private fun AiSection(
         ProviderChip(label = "Ollama", selected = ai.provider == UiLlmProvider.Ollama) {
             onSetProvider(UiLlmProvider.Ollama)
         }
+        ProviderChip(label = "Vertex", selected = ai.provider == UiLlmProvider.Vertex) {
+            onSetProvider(UiLlmProvider.Vertex)
+        }
     }
     Text(
-        "Coming soon: AWS Bedrock, Google Vertex AI, Azure AI Foundry, Anthropic Teams. " +
+        "Coming soon: AWS Bedrock, Azure AI Foundry, Anthropic Teams. " +
             "See the design spec at docs/superpowers/specs/2026-05-08-ai-integration-design.md.",
         style = MaterialTheme.typography.bodySmall,
         color = MaterialTheme.colorScheme.onSurfaceVariant,
@@ -1038,8 +1045,12 @@ private fun AiSection(
             onSetOllamaBaseUrl = onSetOllamaBaseUrl,
             onSetOllamaModel = onSetOllamaModel,
         )
+        UiLlmProvider.Vertex -> VertexProviderRows(
+            ai = ai,
+            onSetVertexKey = onSetVertexKey,
+            onSetVertexModel = onSetVertexModel,
+        )
         UiLlmProvider.Bedrock,
-        UiLlmProvider.Vertex,
         UiLlmProvider.Foundry,
         UiLlmProvider.Teams -> {
             // Selected via the (currently disabled) chip; defensive
@@ -1272,6 +1283,79 @@ private fun OllamaProviderRows(
         Text(
             "Default URL is intentionally a placeholder — fix it to your LAN host (e.g. " +
                 "http://10.0.6.50:11434) before testing.",
+            style = MaterialTheme.typography.bodySmall,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+        )
+    }
+}
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+private fun VertexProviderRows(
+    ai: UiAiSettings,
+    onSetVertexKey: (String?) -> Unit,
+    onSetVertexModel: (String) -> Unit,
+) {
+    val spacing = LocalSpacing.current
+    var keyDraft by remember { mutableStateOf("") }
+    var showKey by remember { mutableStateOf(false) }
+    Column(verticalArrangement = Arrangement.spacedBy(spacing.xs)) {
+        Text(
+            if (ai.vertexKeyConfigured) "Vertex API key — set"
+            else "Vertex API key — not set",
+            style = MaterialTheme.typography.bodyMedium,
+        )
+        OutlinedTextField(
+            value = keyDraft,
+            onValueChange = { keyDraft = it },
+            label = { Text("Paste new Vertex (Gemini) key") },
+            visualTransformation = if (showKey) VisualTransformation.None else PasswordVisualTransformation(),
+            keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Password),
+            modifier = Modifier.fillMaxWidth(),
+            singleLine = true,
+        )
+        Row(horizontalArrangement = Arrangement.spacedBy(spacing.xs)) {
+            BrassButton(
+                label = if (showKey) "Hide" else "Show",
+                onClick = { showKey = !showKey },
+                variant = BrassButtonVariant.Text,
+            )
+            BrassButton(
+                label = "Save",
+                onClick = {
+                    if (keyDraft.isNotBlank()) {
+                        onSetVertexKey(keyDraft)
+                        keyDraft = ""
+                        showKey = false
+                    }
+                },
+                variant = BrassButtonVariant.Primary,
+            )
+            if (ai.vertexKeyConfigured) {
+                BrassButton(
+                    label = "Clear",
+                    onClick = { onSetVertexKey(null) },
+                    variant = BrassButtonVariant.Text,
+                )
+            }
+        }
+        Text(
+            "Model: ${ai.vertexModel}",
+            style = MaterialTheme.typography.bodySmall,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+        )
+        Row(horizontalArrangement = Arrangement.spacedBy(spacing.xs)) {
+            listOf("gemini-2.5-flash", "gemini-2.5-pro", "gemini-2.5-flash-lite").forEach { m ->
+                BrassButton(
+                    label = m.removePrefix("gemini-"),
+                    onClick = { onSetVertexModel(m) },
+                    variant = if (ai.vertexModel == m) BrassButtonVariant.Primary else BrassButtonVariant.Secondary,
+                )
+            }
+        }
+        Text(
+            "Generate a key at aistudio.google.com/app/apikey. " +
+                "Flash is the cheapest, Pro is the smartest, Flash-Lite is the lightest.",
             style = MaterialTheme.typography.bodySmall,
             color = MaterialTheme.colorScheme.onSurfaceVariant,
         )

--- a/feature/src/main/kotlin/in/jphe/storyvox/feature/settings/SettingsViewModel.kt
+++ b/feature/src/main/kotlin/in/jphe/storyvox/feature/settings/SettingsViewModel.kt
@@ -140,6 +140,8 @@ class SettingsViewModel @Inject constructor(
     fun setOpenAiModel(model: String) = viewModelScope.launch { repo.setOpenAiModel(model) }
     fun setOllamaBaseUrl(url: String) = viewModelScope.launch { repo.setOllamaBaseUrl(url) }
     fun setOllamaModel(model: String) = viewModelScope.launch { repo.setOllamaModel(model) }
+    fun setVertexApiKey(key: String?) = viewModelScope.launch { repo.setVertexApiKey(key) }
+    fun setVertexModel(model: String) = viewModelScope.launch { repo.setVertexModel(model) }
     fun setSendChapterTextEnabled(enabled: Boolean) =
         viewModelScope.launch { repo.setSendChapterTextEnabled(enabled) }
     fun acknowledgeAiPrivacy() = viewModelScope.launch { repo.acknowledgeAiPrivacy() }

--- a/feature/src/test/kotlin/in/jphe/storyvox/feature/settings/SettingsViewModelBufferTest.kt
+++ b/feature/src/test/kotlin/in/jphe/storyvox/feature/settings/SettingsViewModelBufferTest.kt
@@ -14,6 +14,7 @@ import `in`.jphe.storyvox.llm.LlmRepository
 import `in`.jphe.storyvox.llm.provider.ClaudeApiProvider
 import `in`.jphe.storyvox.llm.provider.OllamaProvider
 import `in`.jphe.storyvox.llm.provider.OpenAiApiProvider
+import `in`.jphe.storyvox.llm.provider.VertexProvider
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.Flow
@@ -153,16 +154,18 @@ class SettingsViewModelBufferTest {
         override suspend fun setOpenAiModel(model: String) = Unit
         override suspend fun setOllamaBaseUrl(url: String) = Unit
         override suspend fun setOllamaModel(model: String) = Unit
+        override suspend fun setVertexApiKey(key: String?) = Unit
+        override suspend fun setVertexModel(model: String) = Unit
         override suspend fun setSendChapterTextEnabled(enabled: Boolean) = Unit
         override suspend fun acknowledgeAiPrivacy() = Unit
         override suspend fun resetAiSettings() = Unit
         override suspend fun signOutGitHub() = Unit
     }
 
-    /** Construct an LlmRepository with three real-but-stubbed
-     *  provider instances. The buffer tests don't call any LLM
-     *  methods, so we just need an LlmRepository that doesn't blow
-     *  up at construction. */
+    /** Construct an LlmRepository with real-but-stubbed provider
+     *  instances. The buffer tests don't call any LLM methods, so we
+     *  just need an LlmRepository that doesn't blow up at
+     *  construction. */
     private fun fakeLlm(): LlmRepository {
         val cfg = flowOf(LlmConfig())
         val store = `in`.jphe.storyvox.llm.LlmCredentialsStore.forTesting()
@@ -173,6 +176,7 @@ class SettingsViewModelBufferTest {
             claude = ClaudeApiProvider(http, store, cfg, json),
             openAi = OpenAiApiProvider(http, store, cfg, json),
             ollama = OllamaProvider(http, cfg, json),
+            vertex = VertexProvider(http, store, cfg, json),
         )
     }
 

--- a/feature/src/test/kotlin/in/jphe/storyvox/feature/settings/SettingsViewModelModesTest.kt
+++ b/feature/src/test/kotlin/in/jphe/storyvox/feature/settings/SettingsViewModelModesTest.kt
@@ -14,6 +14,7 @@ import `in`.jphe.storyvox.llm.LlmRepository
 import `in`.jphe.storyvox.llm.provider.ClaudeApiProvider
 import `in`.jphe.storyvox.llm.provider.OllamaProvider
 import `in`.jphe.storyvox.llm.provider.OpenAiApiProvider
+import `in`.jphe.storyvox.llm.provider.VertexProvider
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.Flow
@@ -228,6 +229,8 @@ class SettingsViewModelModesTest {
         override suspend fun setOpenAiModel(model: String) = Unit
         override suspend fun setOllamaBaseUrl(url: String) = Unit
         override suspend fun setOllamaModel(model: String) = Unit
+        override suspend fun setVertexApiKey(key: String?) = Unit
+        override suspend fun setVertexModel(model: String) = Unit
         override suspend fun setSendChapterTextEnabled(enabled: Boolean) = Unit
         override suspend fun acknowledgeAiPrivacy() = Unit
         override suspend fun resetAiSettings() = Unit
@@ -253,6 +256,7 @@ class SettingsViewModelModesTest {
             claude = ClaudeApiProvider(http, store, cfg, json),
             openAi = OpenAiApiProvider(http, store, cfg, json),
             ollama = OllamaProvider(http, cfg, json),
+            vertex = VertexProvider(http, store, cfg, json),
         )
     }
 }

--- a/feature/src/test/kotlin/in/jphe/storyvox/feature/settings/SettingsViewModelPunctuationPauseTest.kt
+++ b/feature/src/test/kotlin/in/jphe/storyvox/feature/settings/SettingsViewModelPunctuationPauseTest.kt
@@ -15,6 +15,7 @@ import `in`.jphe.storyvox.llm.LlmRepository
 import `in`.jphe.storyvox.llm.provider.ClaudeApiProvider
 import `in`.jphe.storyvox.llm.provider.OllamaProvider
 import `in`.jphe.storyvox.llm.provider.OpenAiApiProvider
+import `in`.jphe.storyvox.llm.provider.VertexProvider
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.Flow
@@ -166,6 +167,8 @@ class SettingsViewModelPunctuationPauseTest {
         override suspend fun setOpenAiModel(model: String) = Unit
         override suspend fun setOllamaBaseUrl(url: String) = Unit
         override suspend fun setOllamaModel(model: String) = Unit
+        override suspend fun setVertexApiKey(key: String?) = Unit
+        override suspend fun setVertexModel(model: String) = Unit
         override suspend fun setSendChapterTextEnabled(enabled: Boolean) = Unit
         override suspend fun acknowledgeAiPrivacy() = Unit
         override suspend fun resetAiSettings() = Unit
@@ -191,6 +194,7 @@ class SettingsViewModelPunctuationPauseTest {
             claude = ClaudeApiProvider(http, store, cfg, json),
             openAi = OpenAiApiProvider(http, store, cfg, json),
             ollama = OllamaProvider(http, cfg, json),
+            vertex = VertexProvider(http, store, cfg, json),
         )
     }
 }


### PR DESCRIPTION
## Summary

Adds the **Google Vertex AI / Gemini** LLM provider per Cassia's spec
(`docs/superpowers/specs/2026-05-08-ai-integration-design.md`,
`## Google Vertex AI`). This is the third "live" backend after Claude
direct, OpenAI, and Ollama, and the first BYOK Google integration.

- `core-llm/.../provider/VertexProvider.kt` — POSTs to
  `generativelanguage.googleapis.com/v1beta/models/{model}:streamGenerateContent?alt=sse&key={apiKey}`.
  Pure OkHttp + kotlinx-serialization — no Google auth library, no
  GCP SDK, no token refresh; the API key in the URL query string is
  the simplest BYOK shape.
- `Wire.kt` gains `VertexRequest` / `VertexContent` / `VertexPart` /
  `VertexGenerationConfig`. Distinct from OpenAI's shape: `contents`
  + `system_instruction` + camel-cased `generationConfig`, with the
  assistant turn renamed to `"model"`.
- `SseLineParser.vertex` parses tokens out of
  `candidates[0].content.parts[0].text`. Vertex emits true SSE when
  called with `?alt=sse`, so it shares the same `data:` line plumbing
  the OpenAI/Anthropic parsers use.
- Wired into `LlmRepository` (4th provider), `ProviderId.implemented`,
  `LlmCredentialsStore.hasVertexKey`, `UiLlmProvider`, the
  `UiAiSettings` contract, and `setVertexApiKey`/`setVertexModel`
  through `SettingsViewModel`/`SettingsRepositoryUiImpl`.
- Settings AI section gains a **Vertex** chip + `VertexProviderRows`
  composable (one encrypted-prefs API key + a 3-button model row:
  `gemini-2.5-flash`, `gemini-2.5-pro`, `gemini-2.5-flash-lite`),
  mirroring `ClaudeProviderRows`. The "Coming soon" copy drops Vertex
  and now lists Bedrock / Foundry / Teams only.

Authoritative reference: `~/Projects/cloud-chat-assistant/llm_stream.py`
— the `google` branch (~L291) for the request shape and
`_parse_sse_line` (~L209) for the response shape.

## Test plan

- [x] `./gradlew :core-llm:testDebugUnitTest` — green, including new
      `VertexProviderTest` (stream ordering, role mapping
      assistant→model, 401/5xx error mapping, NotConfigured guard,
      probe path/method, wire-body JSON round-trip) and
      `SseLineParserTest` vertex cases.
- [x] `./gradlew :feature:testDebugUnitTest :app:testDebugUnitTest`
      — green; existing `SettingsRepositoryUi` test fakes gained
      `setVertexApiKey` / `setVertexModel` no-ops, and the test
      `LlmRepository` constructors now pass a `VertexProvider`.
- [x] `./gradlew assembleDebug` — green.
- [ ] Manual on R83W80CAFZB: pick **Vertex** chip in Settings → AI,
      paste a Gemini key from aistudio.google.com/app/apikey, hit
      **Test connection**, then trigger Recap on a downloaded
      chapter.

## Out of scope

- Service-account JSON / OAuth token refresh (per spec § Open
  Question — settled in favour of the URL-key path).
- Vertex Enterprise endpoints under `*-aiplatform.googleapis.com`
  (different auth model — own provider class if/when needed).
- Token cost telemetry — same trajectory as the other BYOK providers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)