### PR TITLE
feat(llm): Azure AI Foundry provider — deployed + serverless (#81 follow-up)

### DIFF
--- a/app/src/main/kotlin/in/jphe/storyvox/data/SettingsRepositoryUiImpl.kt
+++ b/app/src/main/kotlin/in/jphe/storyvox/data/SettingsRepositoryUiImpl.kt
@@ -147,6 +147,16 @@ private object Keys {
     val AI_OLLAMA_BASE_URL = stringPreferencesKey("pref_ai_ollama_base_url")
     val AI_OLLAMA_MODEL = stringPreferencesKey("pref_ai_ollama_model")
     val AI_VERTEX_MODEL = stringPreferencesKey("pref_ai_vertex_model")
+    /** Azure Foundry — endpoint URL the user pasted (e.g.
+     *  `https://my-resource.openai.azure.com`). Empty/missing = not
+     *  configured. */
+    val AI_FOUNDRY_ENDPOINT = stringPreferencesKey("pref_ai_foundry_endpoint")
+    /** Azure Foundry — deployment name (deployed mode) or catalog
+     *  model id (serverless mode). */
+    val AI_FOUNDRY_DEPLOYMENT = stringPreferencesKey("pref_ai_foundry_deployment")
+    /** Azure Foundry — true selects the serverless URL shape;
+     *  default (false) selects per-model deployed URLs. */
+    val AI_FOUNDRY_SERVERLESS = booleanPreferencesKey("pref_ai_foundry_serverless")
     val AI_PRIVACY_ACK = booleanPreferencesKey("pref_ai_privacy_ack")
     val AI_SEND_CHAPTER_TEXT = booleanPreferencesKey("pref_ai_send_chapter_text")
 
@@ -235,6 +245,10 @@ class SettingsRepositoryUiImpl(
                 ollamaModel = prefs[Keys.AI_OLLAMA_MODEL] ?: "llama3.3",
                 vertexModel = prefs[Keys.AI_VERTEX_MODEL] ?: "gemini-2.5-flash",
                 vertexKeyConfigured = llmCreds.hasVertexKey,
+                foundryEndpoint = prefs[Keys.AI_FOUNDRY_ENDPOINT] ?: "",
+                foundryDeployment = prefs[Keys.AI_FOUNDRY_DEPLOYMENT] ?: "",
+                foundryServerless = prefs[Keys.AI_FOUNDRY_SERVERLESS] ?: false,
+                foundryKeyConfigured = llmCreds.hasFoundryKey,
                 privacyAcknowledged = prefs[Keys.AI_PRIVACY_ACK] ?: false,
                 sendChapterTextEnabled = prefs[Keys.AI_SEND_CHAPTER_TEXT] ?: true,
             ),
@@ -437,6 +451,23 @@ class SettingsRepositoryUiImpl(
         store.edit { it[Keys.AI_VERTEX_MODEL] = model }
     }
 
+    override suspend fun setFoundryApiKey(key: String?) {
+        if (key == null) llmCreds.clearFoundryApiKey()
+        else llmCreds.setFoundryApiKey(key)
+    }
+
+    override suspend fun setFoundryEndpoint(url: String) {
+        store.edit { it[Keys.AI_FOUNDRY_ENDPOINT] = url }
+    }
+
+    override suspend fun setFoundryDeployment(deployment: String) {
+        store.edit { it[Keys.AI_FOUNDRY_DEPLOYMENT] = deployment }
+    }
+
+    override suspend fun setFoundryServerless(serverless: Boolean) {
+        store.edit { it[Keys.AI_FOUNDRY_SERVERLESS] = serverless }
+    }
+
     override suspend fun setSendChapterTextEnabled(enabled: Boolean) {
         store.edit { it[Keys.AI_SEND_CHAPTER_TEXT] = enabled }
     }
@@ -453,6 +484,9 @@ class SettingsRepositoryUiImpl(
             it.remove(Keys.AI_OLLAMA_BASE_URL)
             it.remove(Keys.AI_OLLAMA_MODEL)
             it.remove(Keys.AI_VERTEX_MODEL)
+            it.remove(Keys.AI_FOUNDRY_ENDPOINT)
+            it.remove(Keys.AI_FOUNDRY_DEPLOYMENT)
+            it.remove(Keys.AI_FOUNDRY_SERVERLESS)
             it.remove(Keys.AI_PRIVACY_ACK)
             it.remove(Keys.AI_SEND_CHAPTER_TEXT)
         }
@@ -534,6 +568,9 @@ class SettingsRepositoryUiImpl(
             ollamaBaseUrl = prefs[Keys.AI_OLLAMA_BASE_URL] ?: "http://10.0.0.1:11434",
             ollamaModel = prefs[Keys.AI_OLLAMA_MODEL] ?: "llama3.3",
             vertexModel = prefs[Keys.AI_VERTEX_MODEL] ?: "gemini-2.5-flash",
+            foundryEndpoint = prefs[Keys.AI_FOUNDRY_ENDPOINT] ?: "",
+            foundryDeployment = prefs[Keys.AI_FOUNDRY_DEPLOYMENT] ?: "",
+            foundryServerless = prefs[Keys.AI_FOUNDRY_SERVERLESS] ?: false,
             privacyAcknowledged = prefs[Keys.AI_PRIVACY_ACK] ?: false,
             sendChapterTextEnabled = prefs[Keys.AI_SEND_CHAPTER_TEXT] ?: true,
         )
@@ -551,6 +588,9 @@ class SettingsRepositoryUiImpl(
             p[Keys.AI_OLLAMA_BASE_URL] = config.ollamaBaseUrl
             p[Keys.AI_OLLAMA_MODEL] = config.ollamaModel
             p[Keys.AI_VERTEX_MODEL] = config.vertexModel
+            p[Keys.AI_FOUNDRY_ENDPOINT] = config.foundryEndpoint
+            p[Keys.AI_FOUNDRY_DEPLOYMENT] = config.foundryDeployment
+            p[Keys.AI_FOUNDRY_SERVERLESS] = config.foundryServerless
             p[Keys.AI_PRIVACY_ACK] = config.privacyAcknowledged
             p[Keys.AI_SEND_CHAPTER_TEXT] = config.sendChapterTextEnabled
         }

--- a/app/src/test/kotlin/in/jphe/storyvox/di/RealPlaybackControllerUiTest.kt
+++ b/app/src/test/kotlin/in/jphe/storyvox/di/RealPlaybackControllerUiTest.kt
@@ -238,6 +238,10 @@ class RealPlaybackControllerUiTest {
         override suspend fun setOllamaModel(model: String) = Unit
         override suspend fun setVertexApiKey(key: String?) = Unit
         override suspend fun setVertexModel(model: String) = Unit
+        override suspend fun setFoundryApiKey(key: String?) = Unit
+        override suspend fun setFoundryEndpoint(url: String) = Unit
+        override suspend fun setFoundryDeployment(deployment: String) = Unit
+        override suspend fun setFoundryServerless(serverless: Boolean) = Unit
         override suspend fun setSendChapterTextEnabled(enabled: Boolean) = Unit
         override suspend fun acknowledgeAiPrivacy() = Unit
         override suspend fun resetAiSettings() = Unit

--- a/core-llm/src/main/kotlin/in/jphe/storyvox/llm/LlmConfig.kt
+++ b/core-llm/src/main/kotlin/in/jphe/storyvox/llm/LlmConfig.kt
@@ -39,6 +39,13 @@ data class LlmConfig(
     val vertexModel: String = "gemini-2.5-flash",
     val foundryEndpoint: String = "",
     val foundryDeployment: String = "",
+    /** Foundry has two deployment models: per-model "deployed" URLs
+     *  (`/openai/deployments/{name}/...`, default) and a single
+     *  "serverless" catalog URL (`/models/chat/completions`). The
+     *  toggle is required because the URL templates differ AND the
+     *  request bodies differ — deployed omits `model`, serverless
+     *  includes it. See [provider.AzureFoundryProvider.buildUrl]. */
+    val foundryServerless: Boolean = false,
 
     // Cross-provider toggles
     /** First-time-activation modal acknowledged. Reset when the user
@@ -87,5 +94,18 @@ object LlmModels {
         "gemini-2.5-flash",
         "gemini-2.5-pro",
         "gemini-2.5-flash-lite",
+    )
+
+    /** Azure Foundry **serverless** catalog short-list — surfaces a
+     *  small grid in Settings when the user picks the Serverless
+     *  toggle. Deployed mode shows no chips because the deployment
+     *  name is whatever the user typed in the Azure portal. */
+    val foundryServerless: List<String> = listOf(
+        "gpt-4o",
+        "gpt-4o-mini",
+        "Llama-3.3-70B-Instruct",
+        "DeepSeek-R1",
+        "Phi-4",
+        "grok-3",
     )
 }

--- a/core-llm/src/main/kotlin/in/jphe/storyvox/llm/LlmCredentialsStore.kt
+++ b/core-llm/src/main/kotlin/in/jphe/storyvox/llm/LlmCredentialsStore.kt
@@ -68,6 +68,7 @@ open class LlmCredentialsStore @Inject constructor(
     open fun setFoundryApiKey(key: String) =
         prefs.edit { putString(KEY_FOUNDRY, key) }
     open fun clearFoundryApiKey() = prefs.edit { remove(KEY_FOUNDRY) }
+    open val hasFoundryKey: Boolean get() = foundryApiKey() != null
 
     open fun teamsBearerToken(): String? = prefs.getString(KEY_TEAMS, null)
     open fun setTeamsBearerToken(token: String) =

--- a/core-llm/src/main/kotlin/in/jphe/storyvox/llm/LlmRepository.kt
+++ b/core-llm/src/main/kotlin/in/jphe/storyvox/llm/LlmRepository.kt
@@ -1,5 +1,6 @@
 package `in`.jphe.storyvox.llm
 
+import `in`.jphe.storyvox.llm.provider.AzureFoundryProvider
 import `in`.jphe.storyvox.llm.provider.ClaudeApiProvider
 import `in`.jphe.storyvox.llm.provider.OllamaProvider
 import `in`.jphe.storyvox.llm.provider.OpenAiApiProvider
@@ -28,6 +29,7 @@ class LlmRepository @Inject constructor(
     private val openAi: OpenAiApiProvider,
     private val ollama: OllamaProvider,
     private val vertex: VertexProvider,
+    private val foundry: AzureFoundryProvider,
 ) {
 
     /** The provider currently picked in Settings, or null when AI
@@ -76,8 +78,8 @@ class LlmRepository @Inject constructor(
         ProviderId.OpenAi -> openAi
         ProviderId.Ollama -> ollama
         ProviderId.Vertex -> vertex
+        ProviderId.Foundry -> foundry
         ProviderId.Bedrock,
-        ProviderId.Foundry,
         ProviderId.Teams ->
             throw LlmError.NotConfigured(id)
     }

--- a/core-llm/src/main/kotlin/in/jphe/storyvox/llm/ProviderId.kt
+++ b/core-llm/src/main/kotlin/in/jphe/storyvox/llm/ProviderId.kt
@@ -32,7 +32,8 @@ enum class ProviderId {
     /** True if a real LlmProvider implementation exists for this id.
      *  False ids are surfaced as "coming soon" in the AI Settings. */
     val implemented: Boolean
-        get() = this == Claude || this == OpenAi || this == Ollama || this == Vertex
+        get() = this == Claude || this == OpenAi || this == Ollama ||
+            this == Vertex || this == Foundry
 
     /** Human-friendly label for the Settings UI. Localization is a
      *  follow-up; English-only labels for now match the rest of the

--- a/core-llm/src/main/kotlin/in/jphe/storyvox/llm/provider/AzureFoundryProvider.kt
+++ b/core-llm/src/main/kotlin/in/jphe/storyvox/llm/provider/AzureFoundryProvider.kt
@@ -1,0 +1,229 @@
+package `in`.jphe.storyvox.llm.provider
+
+import `in`.jphe.storyvox.llm.LlmConfig
+import `in`.jphe.storyvox.llm.LlmCredentialsStore
+import `in`.jphe.storyvox.llm.LlmError
+import `in`.jphe.storyvox.llm.LlmMessage
+import `in`.jphe.storyvox.llm.LlmProvider
+import `in`.jphe.storyvox.llm.ProbeResult
+import `in`.jphe.storyvox.llm.ProviderId
+import `in`.jphe.storyvox.llm.di.LlmHttp
+import `in`.jphe.storyvox.llm.sse.SseLineParser
+import javax.inject.Inject
+import javax.inject.Singleton
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.flow.flow
+import kotlinx.coroutines.flow.flowOn
+import kotlinx.serialization.encodeToString
+import kotlinx.serialization.json.Json
+import okhttp3.OkHttpClient
+import okhttp3.Request
+import okhttp3.RequestBody.Companion.toRequestBody
+import java.io.IOException
+
+/**
+ * Azure AI Foundry chat-completions client. Two URL shapes depending
+ * on which Azure deployment model the user picked:
+ *
+ *  - **Deployed** ("Azure OpenAI Service"-style): the model is baked
+ *    into the URL as a deployment name; the request body omits the
+ *    `model` field. Used for OpenAI models served through Azure.
+ *  - **Serverless** ("Azure AI model catalog"-style): a single
+ *    `/models/chat/completions` endpoint that takes the model id in
+ *    the body. Used for Llama / Phi / DeepSeek / Grok / Cohere /
+ *    Mistral via Azure's pay-per-token catalog.
+ *
+ * Wire format is otherwise identical to OpenAI's chat-completions —
+ * same SSE shape, same body shape (modulo the `model` field). We
+ * reuse [SseLineParser.openAiCompat] and [OpenAiRequest] / [OpenAiMessage].
+ *
+ * Auth is **`api-key: <key>`** as a header — Azure rejects
+ * `Authorization: Bearer` on these endpoints. Ported from
+ * `cloud-chat-assistant/llm_stream.py`'s `azure` branch.
+ *
+ * Distinct from `:source-azure` (TTS via Azure Speech). This is
+ * `:core-llm` LLM inference; the two share nothing beyond a brand.
+ */
+@Singleton
+open class AzureFoundryProvider @Inject constructor(
+    @LlmHttp private val http: OkHttpClient,
+    private val store: LlmCredentialsStore,
+    private val configFlow: Flow<LlmConfig>,
+    private val json: Json,
+) : LlmProvider {
+
+    override val id: ProviderId = ProviderId.Foundry
+
+    override fun stream(
+        messages: List<LlmMessage>,
+        systemPrompt: String?,
+        model: String?,
+    ): Flow<String> = flow {
+        val cfg = configFlow.first()
+        val apiKey = store.foundryApiKey()
+            ?: throw LlmError.NotConfigured(ProviderId.Foundry)
+        val endpoint = cfg.foundryEndpoint.takeIf { it.isNotBlank() }
+            ?: throw LlmError.NotConfigured(ProviderId.Foundry)
+        val resolvedModel = model
+            ?: cfg.foundryDeployment.takeIf { it.isNotBlank() }
+            ?: throw LlmError.NotConfigured(ProviderId.Foundry)
+
+        val systemMsg = systemPrompt?.takeIf { it.isNotBlank() }
+            ?.let { listOf(OpenAiMessage("system", it)) }
+            .orEmpty()
+        val openAiMsgs = systemMsg + messages.map {
+            OpenAiMessage(it.role.name, it.content)
+        }
+
+        val url = buildUrl(endpoint, resolvedModel, cfg.foundryServerless)
+        // Deployed mode pins the model in the URL; the body must NOT
+        // also include `model` (Azure rejects with 400). Serverless
+        // mode picks the model via the body field.
+        val bodyJson = if (cfg.foundryServerless) {
+            json.encodeToString(
+                OpenAiRequest(
+                    model = resolvedModel,
+                    messages = openAiMsgs,
+                    stream = true,
+                ),
+            )
+        } else {
+            json.encodeToString(
+                FoundryDeployedRequest(
+                    messages = openAiMsgs,
+                    stream = true,
+                ),
+            )
+        }
+
+        val request = Request.Builder()
+            .url(url)
+            .header("api-key", apiKey)
+            .header("content-type", "application/json")
+            .header("accept", "text/event-stream")
+            .post(bodyJson.toRequestBody(JSON_MEDIA_TYPE))
+            .build()
+
+        val response = try {
+            http.newCall(request).executeAsync()
+        } catch (e: IOException) {
+            throw LlmError.Transport(ProviderId.Foundry, e)
+        }
+
+        response.use { resp ->
+            when {
+                resp.code == 401 || resp.code == 403 ->
+                    throw LlmError.AuthFailed(
+                        ProviderId.Foundry,
+                        resp.message.ifBlank { "HTTP ${resp.code}" },
+                    )
+                !resp.isSuccessful -> {
+                    val excerpt = resp.body?.string()?.take(256) ?: resp.message
+                    throw LlmError.ProviderError(
+                        ProviderId.Foundry, resp.code, excerpt,
+                    )
+                }
+            }
+            val src = resp.body?.source()
+                ?: throw LlmError.Transport(
+                    ProviderId.Foundry,
+                    IOException("Empty response body"),
+                )
+            src.use {
+                while (!it.exhausted()) {
+                    val line = it.readUtf8Line() ?: break
+                    val token = SseLineParser.openAiCompat(line, json) ?: continue
+                    emit(token)
+                }
+            }
+        }
+    }.flowOn(Dispatchers.IO)
+
+    override suspend fun probe(): ProbeResult {
+        val apiKey = store.foundryApiKey()
+            ?: return ProbeResult.Misconfigured("No Azure Foundry API key")
+        val cfg = configFlow.first()
+        val endpoint = cfg.foundryEndpoint.takeIf { it.isNotBlank() }
+            ?: return ProbeResult.Misconfigured("No Azure Foundry endpoint")
+        val deployment = cfg.foundryDeployment.takeIf { it.isNotBlank() }
+            ?: return ProbeResult.Misconfigured("No Foundry model / deployment")
+
+        // Foundry has no equivalent of OpenAI's `/v1/models` cheap
+        // probe — `GET` against the chat-completions URL returns 405,
+        // and 405 with the right `api-key` header is positive evidence
+        // the endpoint exists and the key is accepted. Anything 401/
+        // 403 → auth bad; network failure → not reachable.
+        val request = Request.Builder()
+            .url(buildUrl(endpoint, deployment, cfg.foundryServerless))
+            .header("api-key", apiKey)
+            .get()
+            .build()
+        return try {
+            http.newCall(request).executeAsync().use { resp ->
+                when {
+                    resp.code == 401 || resp.code == 403 ->
+                        ProbeResult.AuthError("Invalid Azure Foundry API key")
+                    // 200 (unlikely on chat-completions) or 405 both
+                    // mean "endpoint exists, key accepted".
+                    resp.isSuccessful || resp.code == 405 -> ProbeResult.Ok
+                    resp.code == 404 ->
+                        ProbeResult.NotReachable(
+                            "Azure returned 404 — check endpoint URL and " +
+                                "deployment / model id",
+                        )
+                    else -> ProbeResult.NotReachable(
+                        "Azure Foundry returned ${resp.code}",
+                    )
+                }
+            }
+        } catch (e: IOException) {
+            ProbeResult.NotReachable(e.message ?: "Connection failed")
+        }
+    }
+
+    companion object {
+        /**
+         * Build the chat-completions URL for either Foundry deployment
+         * mode. Pure function — exposed for unit testing without a
+         * MockWebServer. The trailing slash on [endpoint] is tolerated
+         * (and stripped) so users who paste either form get the same
+         * URL out.
+         *
+         * @param endpoint base URL the user pasted, e.g.
+         *   `https://my-resource.openai.azure.com` (deployed) or
+         *   `https://my-project.services.ai.azure.com` (serverless).
+         * @param model deployment name (deployed) or catalog model id
+         *   (serverless).
+         * @param serverless `true` selects the `/models/...` shape;
+         *   `false` selects `/openai/deployments/{model}/...`.
+         */
+        fun buildUrl(endpoint: String, model: String, serverless: Boolean): String {
+            val base = endpoint.trimEnd('/')
+            return if (serverless) {
+                "$base/models/chat/completions?api-version=$API_VERSION"
+            } else {
+                "$base/openai/deployments/$model/chat/completions?api-version=$API_VERSION"
+            }
+        }
+
+        /**
+         * Catalog model ids surfaced as Foundry serverless choices.
+         * Mirrors a small subset of cloud-chat-assistant's
+         * `AZURE_SERVERLESS` list — we don't need every model
+         * Microsoft offers; users can override by typing any id into
+         * the model field.
+         */
+        val SERVERLESS_MODELS: List<String> = listOf(
+            "gpt-4o",
+            "gpt-4o-mini",
+            "Llama-3.3-70B-Instruct",
+            "DeepSeek-R1",
+            "Phi-4",
+            "grok-3",
+        )
+
+        private const val API_VERSION = "2024-12-01-preview"
+    }
+}

--- a/core-llm/src/main/kotlin/in/jphe/storyvox/llm/provider/Wire.kt
+++ b/core-llm/src/main/kotlin/in/jphe/storyvox/llm/provider/Wire.kt
@@ -73,3 +73,18 @@ internal data class VertexGenerationConfig(
     val temperature: Float? = null,
     @SerialName("maxOutputTokens") val maxOutputTokens: Int? = null,
 )
+
+// ── Azure Foundry deployed-mode chat completions ───────────────────
+//
+// Same shape as [OpenAiRequest] minus `model` — Foundry pins the
+// model in the URL (`/openai/deployments/{name}/...`) and rejects
+// requests that also carry the field in the body. Serverless-mode
+// Foundry reuses [OpenAiRequest] verbatim. Tested against
+// `cloud-chat-assistant/llm_stream.py`'s `azure` branch (line ~272).
+
+@Serializable
+internal data class FoundryDeployedRequest(
+    val messages: List<OpenAiMessage>,
+    @SerialName("max_tokens") val maxTokens: Int = 1024,
+    val stream: Boolean = true,
+)

--- a/core-llm/src/test/kotlin/in/jphe/storyvox/llm/feature/ChapterRecapTest.kt
+++ b/core-llm/src/test/kotlin/in/jphe/storyvox/llm/feature/ChapterRecapTest.kt
@@ -14,6 +14,7 @@ import `in`.jphe.storyvox.llm.LlmProvider
 import `in`.jphe.storyvox.llm.LlmRepository
 import `in`.jphe.storyvox.llm.ProbeResult
 import `in`.jphe.storyvox.llm.ProviderId
+import `in`.jphe.storyvox.llm.provider.AzureFoundryProvider
 import `in`.jphe.storyvox.llm.provider.ClaudeApiProvider
 import `in`.jphe.storyvox.llm.provider.FakeStore
 import `in`.jphe.storyvox.llm.provider.OllamaProvider
@@ -89,6 +90,7 @@ class ChapterRecapTest {
             openAi = fakeProvider.asOpenAi(),
             ollama = fakeProvider.asOllama(),
             vertex = fakeProvider.asVertex(),
+            foundry = fakeProvider.asFoundry(),
         )
         recap = ChapterRecap(
             chapterDao = db.chapterDao(),
@@ -245,6 +247,24 @@ private class FakeProvider {
     }
 
     fun asVertex(): VertexProvider = object : VertexProvider(
+        http = OkHttpClient(),
+        store = FakeStore(),
+        configFlow = flowOf(LlmConfig()),
+        json = Json,
+    ) {
+        override fun stream(
+            messages: List<LlmMessage>,
+            systemPrompt: String?,
+            model: String?,
+        ): Flow<String> {
+            lastMessages = messages
+            lastSystemPrompt = systemPrompt
+            return flowOf(*tokens.toTypedArray())
+        }
+        override suspend fun probe(): ProbeResult = ProbeResult.Ok
+    }
+
+    fun asFoundry(): AzureFoundryProvider = object : AzureFoundryProvider(
         http = OkHttpClient(),
         store = FakeStore(),
         configFlow = flowOf(LlmConfig()),

--- a/core-llm/src/test/kotlin/in/jphe/storyvox/llm/provider/AzureFoundryProviderTest.kt
+++ b/core-llm/src/test/kotlin/in/jphe/storyvox/llm/provider/AzureFoundryProviderTest.kt
@@ -1,0 +1,237 @@
+package `in`.jphe.storyvox.llm.provider
+
+import `in`.jphe.storyvox.llm.LlmConfig
+import `in`.jphe.storyvox.llm.LlmError
+import `in`.jphe.storyvox.llm.LlmMessage
+import `in`.jphe.storyvox.llm.ProbeResult
+import `in`.jphe.storyvox.llm.ProviderId
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.flow.toList
+import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.test.runTest
+import kotlinx.serialization.json.Json
+import okhttp3.OkHttpClient
+import okhttp3.mockwebserver.MockResponse
+import okhttp3.mockwebserver.MockWebServer
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertThrows
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+import java.util.concurrent.TimeUnit
+
+/**
+ * Coverage for both Foundry deployment modes against a MockWebServer.
+ * The two modes share a parser path (OpenAI-compat SSE) but diverge on
+ * URL shape, body shape, and auth header — all of which need to land
+ * correctly or Azure rejects.
+ *
+ * Sister to [AzureFoundryUrlBuilderTest] (pure URL coverage) and
+ * [OpenAiApiProviderTest] (the body / SSE shape these tests share).
+ */
+class AzureFoundryProviderTest {
+
+    private lateinit var server: MockWebServer
+    private val json = Json { ignoreUnknownKeys = true }
+    private lateinit var http: OkHttpClient
+
+    @Before
+    fun setUp() {
+        server = MockWebServer()
+        server.start()
+        http = OkHttpClient.Builder().readTimeout(2, TimeUnit.SECONDS).build()
+    }
+
+    @After fun tearDown() { server.shutdown() }
+
+    private fun providerWith(
+        key: String?,
+        deployment: String = "gpt-4o-prod",
+        serverless: Boolean = false,
+    ): AzureFoundryProvider {
+        val baseUrl = server.url("/").toString().trimEnd('/')
+        return AzureFoundryProvider(
+            http = http,
+            store = FakeStore(foundry = key),
+            configFlow = flowOf(
+                LlmConfig(
+                    foundryEndpoint = baseUrl,
+                    foundryDeployment = deployment,
+                    foundryServerless = serverless,
+                ),
+            ),
+            json = json,
+        )
+    }
+
+    // Standard happy-path SSE body. OpenAI-compat shape — same delta
+    // structure as OpenAI / Ollama.
+    private val happySse = listOf(
+        """data: {"choices":[{"delta":{"role":"assistant"}}]}""",
+        """data: {"choices":[{"delta":{"content":"Hello "}}]}""",
+        """data: {"choices":[{"delta":{"content":"world."}}]}""",
+        """data: [DONE]""",
+    ).joinToString("\n") + "\n"
+
+    @Test
+    fun `deployed mode hits openai-deployments path with api-key header and no model in body`() = runTest {
+        server.enqueue(
+            MockResponse()
+                .setHeader("Content-Type", "text/event-stream")
+                .setBody(happySse)
+                .setResponseCode(200),
+        )
+        val tokens = providerWith(key = "k", deployment = "gpt-4o-prod", serverless = false)
+            .stream(
+                messages = listOf(LlmMessage(LlmMessage.Role.user, "hi")),
+                systemPrompt = "be a librarian",
+            ).toList()
+        assertEquals(listOf("Hello ", "world."), tokens)
+
+        val req = server.takeRequest()
+        // URL: /openai/deployments/{name}/chat/completions
+        assertTrue(
+            "expected deployments path, got ${req.path}",
+            req.path?.contains("/openai/deployments/gpt-4o-prod/chat/completions") == true,
+        )
+        assertTrue(
+            "missing api-version query string",
+            req.path?.contains("api-version=2024-12-01-preview") == true,
+        )
+        // Auth: api-key header (NOT Authorization Bearer).
+        assertEquals("k", req.getHeader("api-key"))
+        assertNull("Foundry must not send Authorization", req.getHeader("Authorization"))
+        // Body: deployed mode omits the `model` field (it's in the URL).
+        val body = req.body.readUtf8()
+        assertFalse(
+            "deployed body must not include `model` field — Azure rejects it",
+            body.contains(""""model":"""),
+        )
+        // System prompt threaded as a regular message at head of array.
+        assertTrue(body.contains(""""role":"system""""))
+        assertTrue(body.contains("be a librarian"))
+    }
+
+    @Test
+    fun `serverless mode hits models path with model in body`() = runTest {
+        server.enqueue(
+            MockResponse()
+                .setHeader("Content-Type", "text/event-stream")
+                .setBody(happySse)
+                .setResponseCode(200),
+        )
+        val tokens = providerWith(key = "k", deployment = "Llama-3.3-70B-Instruct", serverless = true)
+            .stream(
+                messages = listOf(LlmMessage(LlmMessage.Role.user, "hi")),
+                systemPrompt = null,
+            ).toList()
+        assertEquals(listOf("Hello ", "world."), tokens)
+
+        val req = server.takeRequest()
+        assertTrue(
+            "expected /models/chat/completions, got ${req.path}",
+            req.path?.startsWith("/models/chat/completions") == true,
+        )
+        assertEquals("k", req.getHeader("api-key"))
+        val body = req.body.readUtf8()
+        // Serverless body MUST contain the model id — that's how the
+        // catalog endpoint routes the call.
+        assertTrue(
+            "serverless body must include the model field",
+            body.contains(""""model":"Llama-3.3-70B-Instruct""""),
+        )
+    }
+
+    @Test
+    fun `401 raises AuthFailed`() = runTest {
+        server.enqueue(MockResponse().setResponseCode(401).setBody("nope"))
+        val ex = assertThrows(LlmError.AuthFailed::class.java) {
+            runBlocking {
+                providerWith(key = "k").stream(
+                    listOf(LlmMessage(LlmMessage.Role.user, "x")),
+                ).toList()
+            }
+        }
+        assertEquals(ProviderId.Foundry, ex.provider)
+    }
+
+    @Test
+    fun `5xx raises ProviderError with body excerpt`() = runTest {
+        server.enqueue(MockResponse().setResponseCode(503).setBody("upstream busy"))
+        val ex = assertThrows(LlmError.ProviderError::class.java) {
+            runBlocking {
+                providerWith(key = "k").stream(
+                    listOf(LlmMessage(LlmMessage.Role.user, "x")),
+                ).toList()
+            }
+        }
+        assertEquals(ProviderId.Foundry, ex.provider)
+        assertEquals(503, ex.status)
+        assertTrue(ex.detail.contains("upstream busy"))
+    }
+
+    @Test
+    fun `missing key raises NotConfigured`() = runTest {
+        val ex = assertThrows(LlmError.NotConfigured::class.java) {
+            runBlocking {
+                providerWith(key = null).stream(
+                    listOf(LlmMessage(LlmMessage.Role.user, "x")),
+                ).toList()
+            }
+        }
+        assertEquals(ProviderId.Foundry, ex.provider)
+    }
+
+    @Test
+    fun `missing endpoint raises NotConfigured even with key`() = runTest {
+        val provider = AzureFoundryProvider(
+            http = http,
+            store = FakeStore(foundry = "k"),
+            configFlow = flowOf(
+                LlmConfig(
+                    foundryEndpoint = "",
+                    foundryDeployment = "gpt-4o",
+                ),
+            ),
+            json = json,
+        )
+        val ex = assertThrows(LlmError.NotConfigured::class.java) {
+            runBlocking {
+                provider.stream(listOf(LlmMessage(LlmMessage.Role.user, "x"))).toList()
+            }
+        }
+        assertEquals(ProviderId.Foundry, ex.provider)
+    }
+
+    @Test
+    fun `probe returns Ok when key accepted`() = runTest {
+        // Foundry chat-completions returns 405 for GET — that's the
+        // "endpoint exists, key accepted" signal we treat as Ok.
+        server.enqueue(MockResponse().setResponseCode(405))
+        val result = providerWith(key = "k").probe()
+        assertEquals(ProbeResult.Ok, result)
+    }
+
+    @Test
+    fun `probe returns AuthError on 401`() = runTest {
+        server.enqueue(MockResponse().setResponseCode(401))
+        val result = providerWith(key = "k").probe()
+        assertTrue(result is ProbeResult.AuthError)
+    }
+
+    @Test
+    fun `probe returns Misconfigured when no key`() = runTest {
+        val result = providerWith(key = null).probe()
+        assertTrue(result is ProbeResult.Misconfigured)
+    }
+
+    @Test
+    fun `probe returns NotReachable on 404`() = runTest {
+        server.enqueue(MockResponse().setResponseCode(404))
+        val result = providerWith(key = "k").probe()
+        assertTrue(result is ProbeResult.NotReachable)
+    }
+}

--- a/core-llm/src/test/kotlin/in/jphe/storyvox/llm/provider/AzureFoundryUrlBuilderTest.kt
+++ b/core-llm/src/test/kotlin/in/jphe/storyvox/llm/provider/AzureFoundryUrlBuilderTest.kt
@@ -1,0 +1,76 @@
+package `in`.jphe.storyvox.llm.provider
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+/**
+ * Pure-Kotlin URL-builder coverage. The two Azure Foundry deployment
+ * modes have visibly different URL templates and the templating rules
+ * are easy to break with a typo (api-version drift, missing slash,
+ * lowercased path segments). Cheap to lock down without spinning up
+ * MockWebServer.
+ */
+class AzureFoundryUrlBuilderTest {
+
+    @Test
+    fun `deployed mode renders openai-deployments path`() {
+        val url = AzureFoundryProvider.buildUrl(
+            endpoint = "https://my-resource.openai.azure.com",
+            model = "gpt-4o-prod",
+            serverless = false,
+        )
+        assertEquals(
+            "https://my-resource.openai.azure.com/openai/deployments/gpt-4o-prod" +
+                "/chat/completions?api-version=2024-12-01-preview",
+            url,
+        )
+    }
+
+    @Test
+    fun `serverless mode renders models path with model in body not url`() {
+        val url = AzureFoundryProvider.buildUrl(
+            endpoint = "https://my-project.services.ai.azure.com",
+            model = "Llama-3.3-70B-Instruct",
+            serverless = true,
+        )
+        // Note: serverless URL does NOT contain the model id — that
+        // goes in the body. Asserting the absence is part of the
+        // contract.
+        assertEquals(
+            "https://my-project.services.ai.azure.com/models/chat/completions" +
+                "?api-version=2024-12-01-preview",
+            url,
+        )
+    }
+
+    @Test
+    fun `trailing slash on endpoint is tolerated`() {
+        val deployed = AzureFoundryProvider.buildUrl(
+            endpoint = "https://r.openai.azure.com/",
+            model = "m",
+            serverless = false,
+        )
+        val serverless = AzureFoundryProvider.buildUrl(
+            endpoint = "https://r.services.ai.azure.com/",
+            model = "m",
+            serverless = true,
+        )
+        assertEquals(
+            "https://r.openai.azure.com/openai/deployments/m/chat/completions" +
+                "?api-version=2024-12-01-preview",
+            deployed,
+        )
+        assertEquals(
+            "https://r.services.ai.azure.com/models/chat/completions" +
+                "?api-version=2024-12-01-preview",
+            serverless,
+        )
+    }
+
+    @Test
+    fun `serverless ignores model in url so different deployment names produce same url`() {
+        val a = AzureFoundryProvider.buildUrl("https://x", "m1", serverless = true)
+        val b = AzureFoundryProvider.buildUrl("https://x", "m2", serverless = true)
+        assertEquals(a, b)
+    }
+}

--- a/core-llm/src/test/kotlin/in/jphe/storyvox/llm/provider/ClaudeApiProviderTest.kt
+++ b/core-llm/src/test/kotlin/in/jphe/storyvox/llm/provider/ClaudeApiProviderTest.kt
@@ -126,8 +126,10 @@ internal class FakeStore(
     private val claude: String? = null,
     private val openAi: String? = null,
     private val vertex: String? = null,
+    private val foundry: String? = null,
 ) : LlmCredentialsStore() {
     override fun claudeApiKey(): String? = claude
     override fun openAiApiKey(): String? = openAi
     override fun vertexApiKey(): String? = vertex
+    override fun foundryApiKey(): String? = foundry
 }

--- a/feature/src/main/kotlin/in/jphe/storyvox/feature/api/UiContracts.kt
+++ b/feature/src/main/kotlin/in/jphe/storyvox/feature/api/UiContracts.kt
@@ -303,7 +303,8 @@ enum class UiLlmProvider {
     /** Whether this provider has a real implementation.
      *  Matches `ProviderId.implemented`. */
     val implemented: Boolean
-        get() = this == Claude || this == OpenAi || this == Ollama || this == Vertex
+        get() = this == Claude || this == OpenAi || this == Ollama ||
+            this == Vertex || this == Foundry
 
     val displayName: String
         get() = when (this) {
@@ -331,6 +332,18 @@ data class UiAiSettings(
     val ollamaModel: String = "llama3.3",
     val vertexModel: String = "gemini-2.5-flash",
     val vertexKeyConfigured: Boolean = false,
+    /** Azure Foundry endpoint URL the user pasted (e.g.
+     *  `https://my-resource.openai.azure.com`). Empty = not set. */
+    val foundryEndpoint: String = "",
+    /** Deployment name (deployed mode) or catalog model id
+     *  (serverless mode). The same field is reused across both modes
+     *  because the URL builder reads it differently per mode. */
+    val foundryDeployment: String = "",
+    /** True selects Azure's serverless `/models/...` URL shape;
+     *  false selects the per-model `/openai/deployments/{name}/...`
+     *  shape (default — matches "Azure OpenAI Service" deployments). */
+    val foundryServerless: Boolean = false,
+    val foundryKeyConfigured: Boolean = false,
     val privacyAcknowledged: Boolean = false,
     val sendChapterTextEnabled: Boolean = true,
 )
@@ -581,6 +594,13 @@ interface SettingsRepositoryUi {
     suspend fun setOllamaModel(model: String)
     suspend fun setVertexApiKey(key: String?)   // null = clear
     suspend fun setVertexModel(model: String)
+    /** Azure Foundry mutators (this PR). [setFoundryApiKey] with `null`
+     *  clears the encrypted key. [setFoundryServerless] flips the URL
+     *  template + body shape — see `AzureFoundryProvider.buildUrl`. */
+    suspend fun setFoundryApiKey(key: String?)
+    suspend fun setFoundryEndpoint(url: String)
+    suspend fun setFoundryDeployment(deployment: String)
+    suspend fun setFoundryServerless(serverless: Boolean)
     suspend fun setSendChapterTextEnabled(enabled: Boolean)
     suspend fun acknowledgeAiPrivacy()
     /** Wipe all AI configuration — provider/keys/URLs. */

--- a/feature/src/main/kotlin/in/jphe/storyvox/feature/settings/SettingsScreen.kt
+++ b/feature/src/main/kotlin/in/jphe/storyvox/feature/settings/SettingsScreen.kt
@@ -255,6 +255,10 @@ fun SettingsScreen(
             onSetOllamaModel = viewModel::setOllamaModel,
             onSetVertexKey = viewModel::setVertexApiKey,
             onSetVertexModel = viewModel::setVertexModel,
+            onSetFoundryKey = viewModel::setFoundryApiKey,
+            onSetFoundryEndpoint = viewModel::setFoundryEndpoint,
+            onSetFoundryDeployment = viewModel::setFoundryDeployment,
+            onSetFoundryServerless = viewModel::setFoundryServerless,
             onSetSendChapterText = viewModel::setSendChapterTextEnabled,
             onTestConnection = viewModel::testAiConnection,
             onClearProbeOutcome = viewModel::clearProbeOutcome,
@@ -985,6 +989,10 @@ private fun AiSection(
     onSetOllamaModel: (String) -> Unit,
     onSetVertexKey: (String?) -> Unit,
     onSetVertexModel: (String) -> Unit,
+    onSetFoundryKey: (String?) -> Unit,
+    onSetFoundryEndpoint: (String) -> Unit,
+    onSetFoundryDeployment: (String) -> Unit,
+    onSetFoundryServerless: (Boolean) -> Unit,
     onSetSendChapterText: (Boolean) -> Unit,
     onTestConnection: (UiLlmProvider) -> Unit,
     onClearProbeOutcome: () -> Unit,
@@ -1021,9 +1029,12 @@ private fun AiSection(
         ProviderChip(label = "Vertex", selected = ai.provider == UiLlmProvider.Vertex) {
             onSetProvider(UiLlmProvider.Vertex)
         }
+        ProviderChip(label = "Foundry", selected = ai.provider == UiLlmProvider.Foundry) {
+            onSetProvider(UiLlmProvider.Foundry)
+        }
     }
     Text(
-        "Coming soon: AWS Bedrock, Azure AI Foundry, Anthropic Teams. " +
+        "Coming soon: AWS Bedrock, Anthropic Teams. " +
             "See the design spec at docs/superpowers/specs/2026-05-08-ai-integration-design.md.",
         style = MaterialTheme.typography.bodySmall,
         color = MaterialTheme.colorScheme.onSurfaceVariant,
@@ -1050,8 +1061,14 @@ private fun AiSection(
             onSetVertexKey = onSetVertexKey,
             onSetVertexModel = onSetVertexModel,
         )
+        UiLlmProvider.Foundry -> AzureFoundryProviderRows(
+            ai = ai,
+            onSetFoundryKey = onSetFoundryKey,
+            onSetFoundryEndpoint = onSetFoundryEndpoint,
+            onSetFoundryDeployment = onSetFoundryDeployment,
+            onSetFoundryServerless = onSetFoundryServerless,
+        )
         UiLlmProvider.Bedrock,
-        UiLlmProvider.Foundry,
         UiLlmProvider.Teams -> {
             // Selected via the (currently disabled) chip; defensive
             // catch-all that surfaces a friendly message rather than
@@ -1359,6 +1376,146 @@ private fun VertexProviderRows(
             style = MaterialTheme.typography.bodySmall,
             color = MaterialTheme.colorScheme.onSurfaceVariant,
         )
+    }
+}
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+private fun AzureFoundryProviderRows(
+    ai: UiAiSettings,
+    onSetFoundryKey: (String?) -> Unit,
+    onSetFoundryEndpoint: (String) -> Unit,
+    onSetFoundryDeployment: (String) -> Unit,
+    onSetFoundryServerless: (Boolean) -> Unit,
+) {
+    val spacing = LocalSpacing.current
+    var keyDraft by remember { mutableStateOf("") }
+    var showKey by remember { mutableStateOf(false) }
+    var endpointDraft by remember(ai.foundryEndpoint) { mutableStateOf(ai.foundryEndpoint) }
+    var deploymentDraft by remember(ai.foundryDeployment) { mutableStateOf(ai.foundryDeployment) }
+
+    Column(verticalArrangement = Arrangement.spacedBy(spacing.xs)) {
+        // ── Mode toggle ────────────────────────────────────────────
+        // Picked first so the deployment-id field's hint copy can
+        // adapt. Default is Deployed (the more common Azure path —
+        // an Azure OpenAI Service resource with named deployments).
+        Text(
+            "Mode",
+            style = MaterialTheme.typography.bodyMedium,
+        )
+        Row(horizontalArrangement = Arrangement.spacedBy(spacing.xs)) {
+            ProviderChip(
+                label = "Deployed",
+                selected = !ai.foundryServerless,
+            ) { onSetFoundryServerless(false) }
+            ProviderChip(
+                label = "Serverless",
+                selected = ai.foundryServerless,
+            ) { onSetFoundryServerless(true) }
+        }
+        Text(
+            if (ai.foundryServerless)
+                "Serverless: one /models/chat/completions URL, model id in the body. " +
+                    "Use for the Azure model catalog (Llama / Phi / DeepSeek / Grok / …)."
+            else
+                "Deployed: per-deployment /openai/deployments/{name}/... URL. " +
+                    "Use for an Azure OpenAI Service resource — type the deployment name " +
+                    "you set in the Azure portal.",
+            style = MaterialTheme.typography.bodySmall,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+        )
+
+        // ── Endpoint URL ──────────────────────────────────────────
+        OutlinedTextField(
+            value = endpointDraft,
+            onValueChange = { endpointDraft = it },
+            label = { Text("Endpoint URL") },
+            placeholder = {
+                Text(
+                    if (ai.foundryServerless) "https://my-project.services.ai.azure.com"
+                    else "https://my-resource.openai.azure.com",
+                )
+            },
+            keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Uri),
+            modifier = Modifier.fillMaxWidth(),
+            singleLine = true,
+        )
+
+        // ── API key (encrypted) ───────────────────────────────────
+        Text(
+            if (ai.foundryKeyConfigured) "Foundry API key — set"
+            else "Foundry API key — not set",
+            style = MaterialTheme.typography.bodyMedium,
+        )
+        OutlinedTextField(
+            value = keyDraft,
+            onValueChange = { keyDraft = it },
+            label = { Text("Paste new Foundry api-key") },
+            visualTransformation = if (showKey) VisualTransformation.None else PasswordVisualTransformation(),
+            keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Password),
+            modifier = Modifier.fillMaxWidth(),
+            singleLine = true,
+        )
+
+        // ── Deployment / model id ─────────────────────────────────
+        OutlinedTextField(
+            value = deploymentDraft,
+            onValueChange = { deploymentDraft = it },
+            label = {
+                Text(if (ai.foundryServerless) "Model id" else "Deployment name")
+            },
+            placeholder = {
+                Text(if (ai.foundryServerless) "gpt-4o" else "gpt-4o-prod")
+            },
+            modifier = Modifier.fillMaxWidth(),
+            singleLine = true,
+        )
+        if (ai.foundryServerless) {
+            // Catalog model chips for serverless. Deployed mode shows
+            // no chips — the deployment name is entirely the user's
+            // (it's whatever they typed in the Azure portal).
+            Row(horizontalArrangement = Arrangement.spacedBy(spacing.xs)) {
+                listOf("gpt-4o", "gpt-4o-mini", "Llama-3.3-70B-Instruct").forEach { m ->
+                    BrassButton(
+                        label = m,
+                        onClick = { deploymentDraft = m; onSetFoundryDeployment(m) },
+                        variant = if (ai.foundryDeployment == m)
+                            BrassButtonVariant.Primary
+                        else
+                            BrassButtonVariant.Secondary,
+                    )
+                }
+            }
+        }
+
+        // ── Save / clear ──────────────────────────────────────────
+        Row(horizontalArrangement = Arrangement.spacedBy(spacing.xs)) {
+            BrassButton(
+                label = if (showKey) "Hide" else "Show",
+                onClick = { showKey = !showKey },
+                variant = BrassButtonVariant.Text,
+            )
+            BrassButton(
+                label = "Save",
+                onClick = {
+                    onSetFoundryEndpoint(endpointDraft.trim())
+                    onSetFoundryDeployment(deploymentDraft.trim())
+                    if (keyDraft.isNotBlank()) {
+                        onSetFoundryKey(keyDraft)
+                        keyDraft = ""
+                        showKey = false
+                    }
+                },
+                variant = BrassButtonVariant.Primary,
+            )
+            if (ai.foundryKeyConfigured) {
+                BrassButton(
+                    label = "Clear key",
+                    onClick = { onSetFoundryKey(null) },
+                    variant = BrassButtonVariant.Text,
+                )
+            }
+        }
     }
 }
 

--- a/feature/src/main/kotlin/in/jphe/storyvox/feature/settings/SettingsViewModel.kt
+++ b/feature/src/main/kotlin/in/jphe/storyvox/feature/settings/SettingsViewModel.kt
@@ -142,6 +142,12 @@ class SettingsViewModel @Inject constructor(
     fun setOllamaModel(model: String) = viewModelScope.launch { repo.setOllamaModel(model) }
     fun setVertexApiKey(key: String?) = viewModelScope.launch { repo.setVertexApiKey(key) }
     fun setVertexModel(model: String) = viewModelScope.launch { repo.setVertexModel(model) }
+    fun setFoundryApiKey(key: String?) = viewModelScope.launch { repo.setFoundryApiKey(key) }
+    fun setFoundryEndpoint(url: String) = viewModelScope.launch { repo.setFoundryEndpoint(url) }
+    fun setFoundryDeployment(deployment: String) =
+        viewModelScope.launch { repo.setFoundryDeployment(deployment) }
+    fun setFoundryServerless(serverless: Boolean) =
+        viewModelScope.launch { repo.setFoundryServerless(serverless) }
     fun setSendChapterTextEnabled(enabled: Boolean) =
         viewModelScope.launch { repo.setSendChapterTextEnabled(enabled) }
     fun acknowledgeAiPrivacy() = viewModelScope.launch { repo.acknowledgeAiPrivacy() }

--- a/feature/src/test/kotlin/in/jphe/storyvox/feature/settings/SettingsViewModelBufferTest.kt
+++ b/feature/src/test/kotlin/in/jphe/storyvox/feature/settings/SettingsViewModelBufferTest.kt
@@ -11,6 +11,7 @@ import `in`.jphe.storyvox.feature.api.UiVoice
 import `in`.jphe.storyvox.feature.api.VoiceProviderUi
 import `in`.jphe.storyvox.llm.LlmConfig
 import `in`.jphe.storyvox.llm.LlmRepository
+import `in`.jphe.storyvox.llm.provider.AzureFoundryProvider
 import `in`.jphe.storyvox.llm.provider.ClaudeApiProvider
 import `in`.jphe.storyvox.llm.provider.OllamaProvider
 import `in`.jphe.storyvox.llm.provider.OpenAiApiProvider
@@ -156,6 +157,10 @@ class SettingsViewModelBufferTest {
         override suspend fun setOllamaModel(model: String) = Unit
         override suspend fun setVertexApiKey(key: String?) = Unit
         override suspend fun setVertexModel(model: String) = Unit
+        override suspend fun setFoundryApiKey(key: String?) = Unit
+        override suspend fun setFoundryEndpoint(url: String) = Unit
+        override suspend fun setFoundryDeployment(deployment: String) = Unit
+        override suspend fun setFoundryServerless(serverless: Boolean) = Unit
         override suspend fun setSendChapterTextEnabled(enabled: Boolean) = Unit
         override suspend fun acknowledgeAiPrivacy() = Unit
         override suspend fun resetAiSettings() = Unit
@@ -177,6 +182,7 @@ class SettingsViewModelBufferTest {
             openAi = OpenAiApiProvider(http, store, cfg, json),
             ollama = OllamaProvider(http, cfg, json),
             vertex = VertexProvider(http, store, cfg, json),
+            foundry = AzureFoundryProvider(http, store, cfg, json),
         )
     }
 

--- a/feature/src/test/kotlin/in/jphe/storyvox/feature/settings/SettingsViewModelModesTest.kt
+++ b/feature/src/test/kotlin/in/jphe/storyvox/feature/settings/SettingsViewModelModesTest.kt
@@ -11,6 +11,7 @@ import `in`.jphe.storyvox.feature.api.UiVoice
 import `in`.jphe.storyvox.feature.api.VoiceProviderUi
 import `in`.jphe.storyvox.llm.LlmConfig
 import `in`.jphe.storyvox.llm.LlmRepository
+import `in`.jphe.storyvox.llm.provider.AzureFoundryProvider
 import `in`.jphe.storyvox.llm.provider.ClaudeApiProvider
 import `in`.jphe.storyvox.llm.provider.OllamaProvider
 import `in`.jphe.storyvox.llm.provider.OpenAiApiProvider
@@ -231,6 +232,10 @@ class SettingsViewModelModesTest {
         override suspend fun setOllamaModel(model: String) = Unit
         override suspend fun setVertexApiKey(key: String?) = Unit
         override suspend fun setVertexModel(model: String) = Unit
+        override suspend fun setFoundryApiKey(key: String?) = Unit
+        override suspend fun setFoundryEndpoint(url: String) = Unit
+        override suspend fun setFoundryDeployment(deployment: String) = Unit
+        override suspend fun setFoundryServerless(serverless: Boolean) = Unit
         override suspend fun setSendChapterTextEnabled(enabled: Boolean) = Unit
         override suspend fun acknowledgeAiPrivacy() = Unit
         override suspend fun resetAiSettings() = Unit
@@ -257,6 +262,7 @@ class SettingsViewModelModesTest {
             openAi = OpenAiApiProvider(http, store, cfg, json),
             ollama = OllamaProvider(http, cfg, json),
             vertex = VertexProvider(http, store, cfg, json),
+            foundry = AzureFoundryProvider(http, store, cfg, json),
         )
     }
 }

--- a/feature/src/test/kotlin/in/jphe/storyvox/feature/settings/SettingsViewModelPunctuationPauseTest.kt
+++ b/feature/src/test/kotlin/in/jphe/storyvox/feature/settings/SettingsViewModelPunctuationPauseTest.kt
@@ -12,6 +12,7 @@ import `in`.jphe.storyvox.feature.api.UiVoice
 import `in`.jphe.storyvox.feature.api.VoiceProviderUi
 import `in`.jphe.storyvox.llm.LlmConfig
 import `in`.jphe.storyvox.llm.LlmRepository
+import `in`.jphe.storyvox.llm.provider.AzureFoundryProvider
 import `in`.jphe.storyvox.llm.provider.ClaudeApiProvider
 import `in`.jphe.storyvox.llm.provider.OllamaProvider
 import `in`.jphe.storyvox.llm.provider.OpenAiApiProvider
@@ -169,6 +170,10 @@ class SettingsViewModelPunctuationPauseTest {
         override suspend fun setOllamaModel(model: String) = Unit
         override suspend fun setVertexApiKey(key: String?) = Unit
         override suspend fun setVertexModel(model: String) = Unit
+        override suspend fun setFoundryApiKey(key: String?) = Unit
+        override suspend fun setFoundryEndpoint(url: String) = Unit
+        override suspend fun setFoundryDeployment(deployment: String) = Unit
+        override suspend fun setFoundryServerless(serverless: Boolean) = Unit
         override suspend fun setSendChapterTextEnabled(enabled: Boolean) = Unit
         override suspend fun acknowledgeAiPrivacy() = Unit
         override suspend fun resetAiSettings() = Unit
@@ -195,6 +200,7 @@ class SettingsViewModelPunctuationPauseTest {
             openAi = OpenAiApiProvider(http, store, cfg, json),
             ollama = OllamaProvider(http, cfg, json),
             vertex = VertexProvider(http, store, cfg, json),
+            foundry = AzureFoundryProvider(http, store, cfg, json),
         )
     }
 }


### PR DESCRIPTION
## Summary
- New `AzureFoundryProvider` (`:core-llm`) implementing the `LlmProvider` interface for Azure AI Foundry chat-completions, with both deployment modes wired: per-model **Deployed** (`/openai/deployments/{name}/chat/completions`) and catalog **Serverless** (`/models/chat/completions`).
- Auth is `api-key: <key>` header (never `Authorization: Bearer`), and the body shape adapts: deployed mode omits the `model` field (Azure rejects it when present), serverless mode includes it. Reuses the existing OpenAI-compat SSE parser path.
- Settings → AI gains a `Foundry` provider chip and a new `AzureFoundryProviderRows` composable: mode toggle (Deployed / Serverless), endpoint URL, encrypted `api-key` field, deployment-or-model-id field. Encrypted-prefs key namespace was already reserved in the introducing PR.

## Implementation notes
- Pure OkHttp + kotlinx-serialization. **No Azure SDK / MSAL** dependency added per spec.
- `LlmConfig` gains `foundryServerless: Boolean` (the existing `foundryEndpoint` and `foundryDeployment` placeholder fields are now wired).
- `ProviderId.Foundry.implemented` flips `true`; `LlmRepository.providerFor` dispatches to the new provider; the "coming soon" copy in Settings now lists Bedrock / Vertex / Teams only.
- Naming kept explicit (`AzureFoundry*`, never bare `Azure*`) so it is unambiguous in code search vs the unrelated `:source-azure` (Azure HD TTS) module.

## Test plan
- [x] `:core-llm:testDebugUnitTest` — new `AzureFoundryUrlBuilderTest` (4 cases: deployed path, serverless path, trailing-slash tolerance, serverless model-isn't-in-URL invariant) and `AzureFoundryProviderTest` (10 cases: deployed body omits `model`, serverless body includes `model`, `api-key` header set / `Authorization` header absent, 401 → AuthFailed, 5xx → ProviderError, NotConfigured for missing key + missing endpoint, probe Ok / AuthError / Misconfigured / NotReachable). All green.
- [x] `:feature:testDebugUnitTest` — existing settings-VM tests updated for the new `setFoundry*` mutators and the extra `LlmRepository` constructor parameter. All green.
- [x] `:app:testDebugUnitTest` — `RealPlaybackControllerUiTest`'s `FakeSettings` updated for the new mutators. All green.
- [x] `:app:assembleDebug` — APK builds cleanly.
- [ ] Manual smoke test on R83W80CAFZB tablet (post-merge — this PR is part of a four-agent dreamteam bundle and Davis is queueing tablet validation after the bundle lands).

Spec: `docs/superpowers/specs/2026-05-08-ai-integration-design.md` "## Azure AI Foundry"
Reference port from: `~/Projects/cloud-chat-assistant/llm_stream.py` `azure` branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)