### PR TITLE
feat(reader): long-press a word to ask the AI 'Who is X?' (#188)

### DIFF
--- a/app/src/main/kotlin/in/jphe/storyvox/navigation/StoryvoxNavHost.kt
+++ b/app/src/main/kotlin/in/jphe/storyvox/navigation/StoryvoxNavHost.kt
@@ -59,8 +59,14 @@ object StoryvoxRoutes {
     const val GITHUB_SIGN_IN = "auth/github/signin"
     /** Q&A chat about a fiction (#81 follow-up). One chat history per
      *  fictionId; the screen pulls fiction title + current chapter
-     *  context internally for the system prompt. */
-    const val CHAT = "chat/{fictionId}"
+     *  context internally for the system prompt.
+     *
+     *  Optional `prefill` query param (#188 character lookup): when the
+     *  reader's long-press dialog routes here, it passes a prebuilt
+     *  "Who is X?" question to seed the input field. The arg is read
+     *  once on session creation by `ChatViewModel`; it does not auto-send.
+     */
+    const val CHAT = "chat/{fictionId}?prefill={prefill}"
 
     // Encode ids: GitHubSource fictionIds contain `/` (e.g. "github:owner/repo")
     // and chapterIds contain even more (e.g. "github:owner/repo:src/chapter-01.md"),
@@ -69,7 +75,21 @@ object StoryvoxRoutes {
     fun fictionDetail(fictionId: String) = "fiction/${Uri.encode(fictionId)}"
     fun reader(fictionId: String, chapterId: String) = "reader/${Uri.encode(fictionId)}/${Uri.encode(chapterId)}"
     fun audiobook(fictionId: String, chapterId: String) = "audiobook/${Uri.encode(fictionId)}/${Uri.encode(chapterId)}"
-    fun chat(fictionId: String) = "chat/${Uri.encode(fictionId)}"
+    /** Build a chat route. `prefill` (optional, #188) seeds the chat
+     *  input with a starter question; pass null/empty to leave the
+     *  input untouched on open. The query value is percent-encoded so
+     *  free-text questions ("Who is Frodo?") survive the URL roundtrip.
+     *
+     *  Compose Navigation matches the optional `?prefill={prefill}`
+     *  template against routes with OR without the query string —
+     *  omitting it when there's no prefill keeps the route minimal AND
+     *  preserves the pre-existing single-segment shape that
+     *  StoryvoxRoutesTest pins. */
+    fun chat(fictionId: String, prefill: String? = null): String {
+        val base = "chat/${Uri.encode(fictionId)}"
+        return if (prefill.isNullOrEmpty()) base
+        else "$base?prefill=${Uri.encode(prefill)}"
+    }
 
     private val HOME_ROUTES = setOf(PLAYING, LIBRARY, FOLLOWS, BROWSE, SETTINGS)
     fun isHome(route: String?) = route in HOME_ROUTES
@@ -195,7 +215,7 @@ private fun StoryvoxNavHostContent(
                 HybridReaderScreen(
                     onPickVoice = { navController.navigate(StoryvoxRoutes.VOICE_LIBRARY) },
                     onOpenAiSettings = { navController.navigate(StoryvoxRoutes.SETTINGS) },
-                    onOpenChat = { fId -> navController.navigate(StoryvoxRoutes.chat(fId)) },
+                    onOpenChat = { fId, prefill -> navController.navigate(StoryvoxRoutes.chat(fId, prefill)) },
                 )
             }
             composable(
@@ -262,7 +282,7 @@ private fun StoryvoxNavHostContent(
                 HybridReaderScreen(
                     onPickVoice = { navController.navigate(StoryvoxRoutes.VOICE_LIBRARY) },
                     onOpenAiSettings = { navController.navigate(StoryvoxRoutes.SETTINGS) },
-                    onOpenChat = { fId -> navController.navigate(StoryvoxRoutes.chat(fId)) },
+                    onOpenChat = { fId, prefill -> navController.navigate(StoryvoxRoutes.chat(fId, prefill)) },
                 )
             }
 
@@ -280,7 +300,7 @@ private fun StoryvoxNavHostContent(
                 HybridReaderScreen(
                     onPickVoice = { navController.navigate(StoryvoxRoutes.VOICE_LIBRARY) },
                     onOpenAiSettings = { navController.navigate(StoryvoxRoutes.SETTINGS) },
-                    onOpenChat = { fId -> navController.navigate(StoryvoxRoutes.chat(fId)) },
+                    onOpenChat = { fId, prefill -> navController.navigate(StoryvoxRoutes.chat(fId, prefill)) },
                 )
             }
 
@@ -288,6 +308,17 @@ private fun StoryvoxNavHostContent(
                 route = StoryvoxRoutes.CHAT,
                 arguments = listOf(
                     navArgument("fictionId") { type = NavType.StringType },
+                    // Optional prefill for the input field, passed by the
+                    // reader's long-press character lookup (#188). Default
+                    // is empty string — ChatViewModel treats blank as "no
+                    // prefill" and leaves the input untouched. Compose
+                    // Navigation only honors `defaultValue` when the param
+                    // is declared optional via `?prefill={prefill}` in the
+                    // route template (see StoryvoxRoutes.CHAT).
+                    navArgument("prefill") {
+                        type = NavType.StringType
+                        defaultValue = ""
+                    },
                 ),
                 enterTransition = pushEnter,
                 exitTransition = pushExit,

--- a/app/src/test/kotlin/in/jphe/storyvox/navigation/StoryvoxRoutesTest.kt
+++ b/app/src/test/kotlin/in/jphe/storyvox/navigation/StoryvoxRoutesTest.kt
@@ -96,6 +96,42 @@ class StoryvoxRoutesTest {
     }
 
     @Test
+    fun chat_withPrefill_appendsEncodedQueryAndRoundTrips() {
+        // #188 character lookup: long-press dialog routes here with a
+        // pre-built "Who is X?" question. The query value must survive
+        // percent-encoding (spaces, `?`, quotes) so the chat input
+        // field renders the literal question.
+        val fictionId = "github:jphein/example-fiction"
+        val prefill = "Who is Frodo?"
+        val route = StoryvoxRoutes.chat(fictionId, prefill)
+        // Path part stays single-segment; the query string is the only
+        // addition, separated by a single `?`.
+        assertEquals(1, route.count { it == '?' })
+        val (path, query) = route.split('?')
+        assertEquals(1, path.count { it == '/' })
+        val pathParts = path.split('/')
+        assertEquals("chat", pathParts[0])
+        assertEquals(fictionId, Uri.decode(pathParts[1]))
+        // Query is `prefill=<encoded>`.
+        val (key, value) = query.split('=')
+        assertEquals("prefill", key)
+        assertEquals(prefill, Uri.decode(value))
+    }
+
+    @Test
+    fun chat_withNullOrBlankPrefill_omitsQueryString() {
+        // Backwards-compat: callsites that don't need a prefill (the
+        // existing player-options "Smart features" entry point) must
+        // continue to produce the bare `chat/{fictionId}` route so the
+        // single-segment shape pinned by `chat_githubId_…` still holds.
+        val fictionId = "royalroad:12345"
+        assertEquals(StoryvoxRoutes.chat(fictionId), StoryvoxRoutes.chat(fictionId, null))
+        assertEquals(StoryvoxRoutes.chat(fictionId), StoryvoxRoutes.chat(fictionId, ""))
+        // No `?` means the route is just `chat/<encoded-id>`.
+        assertEquals(0, StoryvoxRoutes.chat(fictionId).count { it == '?' })
+    }
+
+    @Test
     fun fictionDetail_royalRoadId_roundTripsCleanly() {
         // Sanity: the encoding helper must not corrupt the simple
         // royalroad ids that worked pre-v0.4.25 — they have no `/` so

--- a/core-ui/src/main/kotlin/in/jphe/storyvox/ui/component/SentenceHighlight.kt
+++ b/core-ui/src/main/kotlin/in/jphe/storyvox/ui/component/SentenceHighlight.kt
@@ -32,6 +32,9 @@ import `in`.jphe.storyvox.ui.theme.LocalReducedMotion
  * @param highlightStart UTF-16 char index where the current sentence begins
  * @param highlightEnd UTF-16 char index where the current sentence ends (exclusive)
  * @param onTapWord optional — invoked with char index of the word the user tapped (for "start TTS from here")
+ * @param onLongPressWord optional — invoked with the long-pressed word (extracted via `TextLayoutResult.getWordBoundary`).
+ *                        Used by the reader for the "Ask AI: who is X?" character-lookup affordance (#188); the long-press
+ *                        does NOT fire `onTapWord`, so a deliberate long-press never accidentally seeks playback.
  * @param onLayout optional — emits the text layout each time it changes; reader uses it to auto-scroll
  *                the highlighted sentence into view.
  */
@@ -42,6 +45,7 @@ fun SentenceHighlight(
     highlightEnd: Int,
     modifier: Modifier = Modifier,
     onTapWord: ((Int) -> Unit)? = null,
+    onLongPressWord: ((String) -> Unit)? = null,
     onLayout: ((TextLayoutResult) -> Unit)? = null,
 ) {
     val brass = MaterialTheme.colorScheme.primary
@@ -132,22 +136,48 @@ fun SentenceHighlight(
         modifier = modifier
             .fillMaxWidth()
             .padding(horizontal = 4.dp)
-            // Tap-to-seek: convert the tap position into a UTF-16 offset via
-            // the captured TextLayoutResult and forward to onTapWord. The
-            // pointerInput is keyed on `text` AND `onTapWord` so a chapter
-            // switch (which changes both text content and length) re-installs
-            // the gesture handler with the fresh closure — otherwise tap
-            // offsets would be clamped against the previous chapter's length
-            // and produce wrong seek positions.
+            // Tap-to-seek + long-press-to-look-up. Convert pointer position
+            // into a UTF-16 offset via the captured TextLayoutResult and
+            // forward to the appropriate callback. The pointerInput is keyed
+            // on `text` AND both callbacks so a chapter switch (which changes
+            // both text content and length) re-installs the gesture handler
+            // with fresh closures — otherwise tap/press offsets would be
+            // clamped against the previous chapter's length.
+            //
+            // Long-press resolves the word boundary at the press position via
+            // `TextLayoutResult.getWordBoundary` (a `TextRange`) and passes
+            // the substring to onLongPressWord. detectTapGestures dispatches
+            // either onTap OR onLongPress for a given gesture, never both, so
+            // a long-press never accidentally seeks.
             .then(
-                if (onTapWord != null) {
-                    Modifier.pointerInput(onTapWord, text) {
-                        detectTapGestures { tap ->
-                            val l = layout ?: return@detectTapGestures
-                            val charIndex = l.getOffsetForPosition(tap)
-                                .coerceIn(0, text.length)
-                            onTapWord(charIndex)
-                        }
+                if (onTapWord != null || onLongPressWord != null) {
+                    Modifier.pointerInput(onTapWord, onLongPressWord, text) {
+                        detectTapGestures(
+                            onTap = if (onTapWord != null) {
+                                { tap ->
+                                    val l = layout
+                                    if (l != null) {
+                                        val charIndex = l.getOffsetForPosition(tap)
+                                            .coerceIn(0, text.length)
+                                        onTapWord(charIndex)
+                                    }
+                                }
+                            } else null,
+                            onLongPress = if (onLongPressWord != null) {
+                                { press ->
+                                    val l = layout
+                                    if (l != null && text.isNotEmpty()) {
+                                        val charIndex = l.getOffsetForPosition(press)
+                                            .coerceIn(0, (text.length - 1).coerceAtLeast(0))
+                                        val range = l.getWordBoundary(charIndex)
+                                        val safeStart = range.start.coerceIn(0, text.length)
+                                        val safeEnd = range.end.coerceIn(safeStart, text.length)
+                                        val word = text.substring(safeStart, safeEnd).trim()
+                                        if (word.isNotEmpty()) onLongPressWord(word)
+                                    }
+                                }
+                            } else null,
+                        )
                     }
                 } else {
                     Modifier

--- a/feature/src/main/kotlin/in/jphe/storyvox/feature/chat/ChatScreen.kt
+++ b/feature/src/main/kotlin/in/jphe/storyvox/feature/chat/ChatScreen.kt
@@ -70,6 +70,12 @@ fun ChatScreen(
     viewModel: ChatViewModel = hiltViewModel(),
 ) {
     val state by viewModel.uiState.collectAsStateWithLifecycle()
+    // Input prefill seeded by the reader's long-press character lookup
+    // (#188). The VM emits this once via the `prefill` StateFlow; the
+    // ChatInput observes it, copies into its local TextFieldValue, then
+    // calls `consumePrefill()` so a subsequent recomposition can't
+    // overwrite the user's edits.
+    val prefill by viewModel.prefill.collectAsStateWithLifecycle()
     val spacing = LocalSpacing.current
     val listState = rememberLazyListState()
 
@@ -151,6 +157,8 @@ fun ChatScreen(
                 ChatInput(
                     enabled = state.streaming == null,
                     onSend = viewModel::send,
+                    prefill = prefill,
+                    onPrefillConsumed = viewModel::consumePrefill,
                 )
             }
         }
@@ -332,9 +340,24 @@ private val QuickActionPrompts: List<String> = listOf(
 private fun ChatInput(
     enabled: Boolean,
     onSend: (String) -> Unit,
+    /** One-shot starter text from the long-press lookup deep-link
+     *  (#188). When non-null+non-blank, the input field is seeded with
+     *  this value (replacing whatever the user had typed — but this
+     *  only fires on first emission per nav, so a typing user never
+     *  sees their text wiped mid-flow). After applying we call
+     *  [onPrefillConsumed] so the VM clears the latch. */
+    prefill: String? = null,
+    onPrefillConsumed: () -> Unit = {},
 ) {
     val spacing = LocalSpacing.current
     var text by remember { mutableStateOf("") }
+
+    LaunchedEffect(prefill) {
+        if (!prefill.isNullOrBlank()) {
+            text = prefill
+            onPrefillConsumed()
+        }
+    }
 
     androidx.compose.foundation.layout.Column(modifier = Modifier.fillMaxWidth()) {
         if (enabled && text.isBlank()) {

--- a/feature/src/main/kotlin/in/jphe/storyvox/feature/chat/ChatViewModel.kt
+++ b/feature/src/main/kotlin/in/jphe/storyvox/feature/chat/ChatViewModel.kt
@@ -104,7 +104,7 @@ class ChatViewModel @Inject constructor(
     private val fictionRepo: FictionRepositoryUi,
     private val playback: PlaybackControllerUi,
     private val configFlow: Flow<LlmConfig>,
-    savedState: SavedStateHandle,
+    private val savedState: SavedStateHandle,
 ) : ViewModel() {
 
     private val fictionId: String = checkNotNull(savedState["fictionId"]) {
@@ -115,6 +115,27 @@ class ChatViewModel @Inject constructor(
      *  history for this book. Mirrors ChapterRecap's
      *  `recap:fictionId:chapterId` shape (LlmSession.id kdoc). */
     private val sessionId: String = "chat:$fictionId"
+
+    /** One-shot input prefill from the long-press character lookup
+     *  (#188). The reader navigates here with `?prefill=Who is X?`, the
+     *  composable consumes it once via [consumePrefill] and seeds the
+     *  text field. We hold it in a MutableStateFlow rather than as a
+     *  raw String so the ChatScreen's `LaunchedEffect` reliably observes
+     *  the initial value even on configuration change before consume. */
+    private val _prefill = MutableStateFlow<String?>(
+        (savedState.get<String>("prefill") ?: "").ifEmpty { null },
+    )
+    val prefill: StateFlow<String?> = _prefill.asStateFlow()
+
+    /** Called by the input field after applying the prefill so a
+     *  subsequent recomposition (e.g. config change) doesn't keep
+     *  re-injecting the same starter text over the user's edits. Also
+     *  clears the SavedStateHandle key so process death + restore
+     *  doesn't replay the prefill either. */
+    fun consumePrefill() {
+        _prefill.value = null
+        savedState["prefill"] = ""
+    }
 
     private val _streaming = MutableStateFlow<String?>(null)
     private val _error = MutableStateFlow<ChatError?>(null)

--- a/feature/src/main/kotlin/in/jphe/storyvox/feature/reader/HybridReaderScreen.kt
+++ b/feature/src/main/kotlin/in/jphe/storyvox/feature/reader/HybridReaderScreen.kt
@@ -26,9 +26,13 @@ fun HybridReaderScreen(
     onOpenAiSettings: () -> Unit = {},
     /** Open the Q&A chat surface for the currently-loaded fiction
      *  (#81 follow-up). No-op default is preview/test-only — production
-     *  callsites pass a real `navController.navigate(chat(fictionId))`.
-     *  Surfaced in the player-options sheet's "Smart features" group. */
-    onOpenChat: (fictionId: String) -> Unit = {},
+     *  callsites pass a real
+     *  `navController.navigate(chat(fictionId, prefill))`.
+     *  Surfaced in the player-options sheet's "Smart features" group, and
+     *  by long-press character-lookup in the reader (#188), which passes
+     *  a non-null prefill of the form `Who is X?`. Pass `null` for
+     *  prefill from non-lookup entry points. */
+    onOpenChat: (fictionId: String, prefill: String?) -> Unit = { _, _ -> },
     viewModel: ReaderViewModel = hiltViewModel(),
 ) {
     val state by viewModel.uiState.collectAsStateWithLifecycle()
@@ -63,7 +67,7 @@ fun HybridReaderScreen(
                 onCancelSleepTimer = viewModel::cancelSleepTimer,
                 onRequestRecap = viewModel::requestRecap,
                 onOpenChat = {
-                    playback.fictionId?.let(onOpenChat)
+                    playback.fictionId?.let { onOpenChat(it, null) }
                 },
             )
         },
@@ -73,6 +77,13 @@ fun HybridReaderScreen(
                 chapterText = state.chapterText,
                 onPlayPause = viewModel::playPause,
                 onSeekToChar = viewModel::seekToChar,
+                onAskAiAbout = { question ->
+                    // Long-press character lookup (#188): forward the
+                    // prebuilt "Who is X?" question as a chat prefill.
+                    // The chat surface auto-fills the input — the user
+                    // can edit before sending or send as-is.
+                    playback.fictionId?.let { onOpenChat(it, question) }
+                },
             )
         },
     )

--- a/feature/src/main/kotlin/in/jphe/storyvox/feature/reader/ReaderView.kt
+++ b/feature/src/main/kotlin/in/jphe/storyvox/feature/reader/ReaderView.kt
@@ -14,12 +14,15 @@ import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Pause
 import androidx.compose.material.icons.filled.PlayArrow
+import androidx.compose.material.icons.outlined.AutoAwesome
+import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.FilledIconButton
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButtonDefaults
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
@@ -57,6 +60,12 @@ fun ReaderTextView(
     chapterText: String,
     onPlayPause: () -> Unit,
     onSeekToChar: (Int) -> Unit = {},
+    /** Long-press a word in the chapter body → open the chat surface
+     *  with `Who is <word>?` pre-filled in the input field. The reader
+     *  doesn't know about navigation, so HybridReaderScreen wires this
+     *  to `navController.navigate(StoryvoxRoutes.chat(fId, prefill = q))`.
+     *  No-op default keeps preview/test callsites working unchanged. */
+    onAskAiAbout: (String) -> Unit = {},
     modifier: Modifier = Modifier,
 ) {
     val spacing = LocalSpacing.current
@@ -68,6 +77,14 @@ fun ReaderTextView(
     var bodyTopPx by remember { mutableFloatStateOf(0f) }
     var viewportHeightPx by remember { mutableFloatStateOf(0f) }
     var textLayout by remember { mutableStateOf<TextLayoutResult?>(null) }
+
+    // Long-press lookup state. When non-null, the dialog is showing for
+    // this word — tapping its primary action navigates to the chat
+    // surface with `Who is <word>?` pre-filled. The state lives on
+    // ReaderTextView (not the SentenceHighlight) because the SentenceHighlight
+    // is a low-level rendering primitive shared with the audiobook view —
+    // putting the popup here keeps that primitive stateless.
+    var lookupWord by remember { mutableStateOf<String?>(null) }
 
     // Manual-scroll grace: each time the user starts dragging we stamp wall-clock time;
     // auto-scroll respects the grace window before resuming.
@@ -128,6 +145,7 @@ fun ReaderTextView(
                         highlightStart = state.sentenceStart,
                         highlightEnd = state.sentenceEnd,
                         onTapWord = onSeekToChar,
+                        onLongPressWord = { word -> lookupWord = word },
                         onLayout = { layout -> textLayout = layout },
                     )
                 }
@@ -170,6 +188,56 @@ fun ReaderTextView(
                     )
                 }
             }
+        }
+
+        // Character-lookup popup (#188). Long-press a word → AlertDialog
+        // with the librarian sigil + a primary "Ask AI" action. We use
+        // AlertDialog rather than a popup-at-position because the M3 dialog
+        // already gives us the brass scrim, dismiss-on-outside-tap, and
+        // back-button handling for free; pinning a popup to the press
+        // coordinate would ride on top of the moving sentence underline
+        // and obscure the very word the user just selected.
+        lookupWord?.let { word ->
+            AlertDialog(
+                onDismissRequest = { lookupWord = null },
+                icon = {
+                    Icon(
+                        Icons.Outlined.AutoAwesome,
+                        contentDescription = null,
+                        tint = MaterialTheme.colorScheme.primary,
+                    )
+                },
+                title = {
+                    Text(
+                        text = "Ask AI: who is \"$word\"?",
+                        style = MaterialTheme.typography.titleMedium,
+                    )
+                },
+                text = {
+                    Text(
+                        text = "The librarian-companion will answer based on what you've " +
+                            "read so far — no spoilers from later chapters.",
+                        style = MaterialTheme.typography.bodyMedium,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    )
+                },
+                confirmButton = {
+                    TextButton(
+                        onClick = {
+                            val q = "Who is $word?"
+                            lookupWord = null
+                            onAskAiAbout(q)
+                        },
+                    ) {
+                        Text("Ask AI")
+                    }
+                },
+                dismissButton = {
+                    TextButton(onClick = { lookupWord = null }) {
+                        Text("Cancel")
+                    }
+                },
+            )
         }
     }
 }


### PR DESCRIPTION
## Summary

- Long-press any word in the reader → brass dialog ("Ask AI: who is &lt;word&gt;?"). Tapping it navigates to the per-fiction chat surface with the question pre-filled — the user can edit before sending or send as-is.
- Bridges the `core-ui` SentenceHighlight primitive (gesture detection, word-boundary resolution) to the existing chat surface via a new optional `?prefill=` query param on the chat route.
- Long-press never seeks: `detectTapGestures` fires either `onTap` or `onLongPress` per gesture, never both.

Closes #188.

## Implementation

- **core-ui** — `SentenceHighlight` gains `onLongPressWord: ((String) -> Unit)?`. The shared `pointerInput` now handles both onTap (existing tap-to-seek) and onLongPress, resolving the pressed word via `TextLayoutResult.getWordBoundary(charIndex)`.
- **feature/reader** — `ReaderTextView` owns the lookup dialog state (Material `AlertDialog` with the brass librarian sigil + "Ask AI" / "Cancel" actions) so `SentenceHighlight` stays a stateless rendering primitive. `HybridReaderScreen` widens its existing `onOpenChat` to `(fictionId, prefill: String?)`.
- **navigation** — `StoryvoxRoutes.CHAT` becomes `chat/{fictionId}?prefill={prefill}` with `defaultValue = ""`. `chat()` helper omits the query string when prefill is null/blank so the existing single-segment route shape pinned by `StoryvoxRoutesTest` is preserved for the player-options entry point.
- **chat** — `ChatViewModel` reads the prefill once from `SavedStateHandle` on init, exposes it as a `StateFlow<String?>`, and clears it via `consumePrefill()` after the input field consumes it. `ChatInput`'s local `text` state is seeded by a `LaunchedEffect(prefill)` so a typing user is never overwritten mid-flow.

## Test plan

- [x] `:app:test` green (existing + 2 new `StoryvoxRoutesTest` cases for the prefill query encoding).
- [x] `assembleDebug` clean.
- [x] Installed on R83W80CAFZB; app launches without crash, focused window confirmed.
- [ ] Manual smoke (next session): open a chapter → long-press a word → confirm the dialog appears → tap "Ask AI" → confirm chat opens with `Who is &lt;word&gt;?` pre-filled in the input field.