### PR TITLE
feat(browse): MemPalace wing dropdown filter (#191)

### DIFF
--- a/app/src/main/kotlin/in/jphe/storyvox/di/AppBindings.kt
+++ b/app/src/main/kotlin/in/jphe/storyvox/di/AppBindings.kt
@@ -334,7 +334,18 @@ private class RealBrowseRepositoryUi(
                     ),
                     sourceId = sourceId,
                 )
+                is BrowseSource.ByGenre -> repo.browseByGenre(
+                    genre = source.genre,
+                    page = page,
+                    sourceId = sourceId,
+                )
             }
+        }
+
+    override suspend fun genres(sourceId: String): List<String> =
+        when (val r = repo.genres(sourceId)) {
+            is FictionResult.Success -> r.value
+            else -> emptyList()
         }
 }
 

--- a/feature/src/main/kotlin/in/jphe/storyvox/feature/api/UiContracts.kt
+++ b/feature/src/main/kotlin/in/jphe/storyvox/feature/api/UiContracts.kt
@@ -100,6 +100,14 @@ interface BrowseRepositoryUi {
         source: BrowseSource,
         sourceId: String = `in`.jphe.storyvox.data.source.SourceIds.ROYAL_ROAD,
     ): BrowsePaginator
+
+    /**
+     * Genres / tags / wings supported by [sourceId]. MemPalace returns
+     * its top-level wing names; Royal Road returns the curated tag list;
+     * GitHub returns an empty list (no genre concept). Used by
+     * BrowseViewModel to populate the MemPalace wing filter chips.
+     */
+    suspend fun genres(sourceId: String): List<String>
 }
 
 /** What kind of listing the paginator should fetch. The repository
@@ -121,6 +129,13 @@ sealed interface BrowseSource {
         val query: String,
         val filter: GitHubSearchFilter,
     ) : BrowseSource
+    /**
+     * MemPalace wing-scoped listing (#191). Routes through
+     * `FictionRepository.browseByGenre(genre)`, which on MemPalace's
+     * source resolves to `MemPalaceSource.byGenre(wing)` — top rooms
+     * inside the wing by drawer count.
+     */
+    data class ByGenre(val genre: String) : BrowseSource
 }
 
 /** A page-by-page accumulating cursor over a remote fiction listing.
@@ -209,6 +224,19 @@ enum class GitHubSort { BestMatch, Stars, Updated }
 /** GitHub `archived:` qualifier (#205). `Any` omits the qualifier and
  *  returns both active and archived repos (the GitHub default). */
 enum class GitHubArchivedStatus { Any, ActiveOnly, ArchivedOnly }
+
+/**
+ * MemPalace-shaped filter for Browse → Palace (#191). Single dimension
+ * today: which wing of the palace to scope the listing to. Null wing
+ * means "all wings" — Browse falls back to Popular/NewReleases tabs as
+ * before. Lives in `:feature/api` so the wing dropdown sheet and the
+ * ViewModel can hold it without taking a dep on `:source-mempalace`.
+ */
+data class MemPalaceFilter(
+    /** Wing name as returned by `MemPalaceSource.genres()`. Null = no
+     *  wing filter; Browse renders the unscoped Popular tab. */
+    val wing: String? = null,
+)
 
 data class UiPlaybackState(
     val fictionId: String?,

--- a/feature/src/main/kotlin/in/jphe/storyvox/feature/browse/BrowseScreen.kt
+++ b/feature/src/main/kotlin/in/jphe/storyvox/feature/browse/BrowseScreen.kt
@@ -19,8 +19,11 @@ import androidx.compose.foundation.lazy.grid.itemsIndexed
 import androidx.compose.foundation.lazy.grid.items
 import androidx.compose.foundation.lazy.grid.rememberLazyGridState
 import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Close
 import androidx.compose.material.icons.filled.Search
 import androidx.compose.material.icons.outlined.FilterAlt
+import androidx.compose.material3.AssistChip
+import androidx.compose.material3.AssistChipDefaults
 import androidx.compose.material3.Badge
 import androidx.compose.material3.BadgedBox
 import androidx.compose.material3.CircularProgressIndicator
@@ -117,12 +120,25 @@ fun BrowseScreen(
                 activeCount = when (state.sourceKey) {
                     BrowseSourceKey.RoyalRoad -> state.filter.activeCount()
                     BrowseSourceKey.GitHub -> state.githubFilter.activeCount()
-                    // MemPalace has no filter dimensions in v1 — the wing
-                    // dropdown is a TODO. Show 0 active so the badge stays
-                    // hidden; clicking still pops a sheet (placeholder).
-                    BrowseSourceKey.MemPalace -> 0
+                    // #191 — single dimension (wing) so badge counts at
+                    // most 1.
+                    BrowseSourceKey.MemPalace -> if (state.palaceFilter.wing != null) 1 else 0
                 },
                 onClick = { showFilterSheet = true },
+            )
+        }
+
+        // Active wing hint — surface the selected wing prominently
+        // below the tab row so users always know the listing is scoped.
+        // Tapping the chip clears the wing (one-tap reset path) without
+        // having to reopen the sheet.
+        if (state.sourceKey == BrowseSourceKey.MemPalace && state.palaceFilter.wing != null) {
+            ActiveWingChip(
+                wing = state.palaceFilter.wing!!,
+                onClear = { viewModel.resetPalaceFilter() },
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(horizontal = spacing.md, vertical = spacing.xs),
             )
         }
 
@@ -287,12 +303,19 @@ fun BrowseScreen(
                 },
                 onDismiss = { showFilterSheet = false },
             )
-            // MemPalace filter sheet is a P1 follow-up — wing dropdown
-            // populated from `genres()`. For v1 we just dismiss so the
-            // tap doesn't strand the user with an empty sheet.
-            BrowseSourceKey.MemPalace -> {
-                showFilterSheet = false
-            }
+            BrowseSourceKey.MemPalace -> MemPalaceFilterSheet(
+                filter = state.palaceFilter,
+                wings = state.palaceWings,
+                onApply = { applied ->
+                    viewModel.setPalaceFilter(applied)
+                    showFilterSheet = false
+                },
+                onReset = {
+                    viewModel.resetPalaceFilter()
+                    showFilterSheet = false
+                },
+                onDismiss = { showFilterSheet = false },
+            )
         }
     }
 }
@@ -403,6 +426,32 @@ private fun BrowseSourcePicker(
             }
         }
     }
+}
+
+/**
+ * Hint chip surfaced under the tab row when MemPalace browse is scoped
+ * to a wing (#191). The leading "Wing:" label keeps the source of the
+ * filter unambiguous (vs a bare wing name); the trailing close icon
+ * gives one-tap reset without re-opening the filter sheet.
+ */
+@Composable
+private fun ActiveWingChip(
+    wing: String,
+    onClear: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    AssistChip(
+        onClick = onClear,
+        label = { Text("Wing: ${prettifyWing(wing)}") },
+        trailingIcon = {
+            Icon(
+                Icons.Filled.Close,
+                contentDescription = "Clear wing filter",
+                modifier = Modifier.size(AssistChipDefaults.IconSize),
+            )
+        },
+        modifier = modifier,
+    )
 }
 
 /** Number of independent filter knobs the user has actively set. */

--- a/feature/src/main/kotlin/in/jphe/storyvox/feature/browse/BrowseViewModel.kt
+++ b/feature/src/main/kotlin/in/jphe/storyvox/feature/browse/BrowseViewModel.kt
@@ -10,6 +10,7 @@ import `in`.jphe.storyvox.feature.api.BrowsePaginator
 import `in`.jphe.storyvox.feature.api.BrowseRepositoryUi
 import `in`.jphe.storyvox.feature.api.BrowseSource
 import `in`.jphe.storyvox.feature.api.GitHubSearchFilter
+import `in`.jphe.storyvox.feature.api.MemPalaceFilter
 import `in`.jphe.storyvox.feature.api.UiFiction
 import `in`.jphe.storyvox.feature.api.UiSearchOrder
 import `in`.jphe.storyvox.feature.api.UiSortDirection
@@ -105,6 +106,15 @@ data class BrowseUiState(
      *  the [BrowseViewModel.selectSource] reset policy). */
     val githubFilter: GitHubSearchFilter = GitHubSearchFilter(),
     val isGitHubFilterActive: Boolean = false,
+    /** MemPalace-shaped filter (#191) — applied when sourceKey is
+     *  MemPalace. Coexists with [filter] / [githubFilter] across
+     *  source switches per [BrowseViewModel.selectSource] reset
+     *  policy. */
+    val palaceFilter: MemPalaceFilter = MemPalaceFilter(),
+    /** Available wing names for the MemPalace filter sheet. Loaded
+     *  lazily on first switch to MemPalace; empty until the daemon
+     *  responds (or daemon unreachable). */
+    val palaceWings: List<String> = emptyList(),
 )
 
 /** Typed view of a paginator's five state flows. Lifted into its own
@@ -119,15 +129,18 @@ private data class PaginatorView(
 )
 
 /** Bundled view of the user-controllable knobs (source picker, tab,
- *  query, RR filter, GitHub filter). Lifted into its own record so the
- *  outer combines stay within the 5-arg `combine` overload as we add
- *  filter shapes per source. */
+ *  query, RR filter, GitHub filter, MemPalace filter). Lifted into its
+ *  own record so the outer combines stay within the 5-arg `combine`
+ *  overload as we add filter shapes per source. The MemPalace filter
+ *  is folded in via a nested combine (see [BrowseViewModel.controls])
+ *  to keep within the overload arity. */
 private data class ControlsView(
     val sourceKey: BrowseSourceKey,
     val tab: BrowseTab,
     val query: String,
     val filter: BrowseFilter,
     val githubFilter: GitHubSearchFilter,
+    val palaceFilter: MemPalaceFilter,
 )
 
 /**
@@ -154,19 +167,33 @@ class BrowseViewModel @Inject constructor(
     private val _query = MutableStateFlow("")
     private val _filter = MutableStateFlow(BrowseFilter())
     private val _githubFilter = MutableStateFlow(GitHubSearchFilter())
+    private val _palaceFilter = MutableStateFlow(MemPalaceFilter())
+    private val _palaceWings = MutableStateFlow<List<String>>(emptyList())
+    /** Latches once the wings have been fetched (or attempted) so we
+     *  don't re-hit the daemon on every source switch. Reset only on
+     *  process death; a stale list is acceptable in v1. */
+    private var palaceWingsLoaded = false
     val query: StateFlow<String> = _query.asStateFlow()
 
     /** Active paginator for the current tuple; null when the search tab
      *  has neither a query nor active filters (the empty search hint is
-     *  shown instead). */
+     *  shown instead). Two-step combine: first the 5-arg base tuple
+     *  (source/tab/query/RRFilter/GHFilter), then merged with the
+     *  MemPalace filter to keep within `combine`'s 5-arg overload. */
     private val paginator: StateFlow<BrowsePaginator?> = combine(
-        _sourceKey,
-        _tab,
-        _query.debounce(300),
-        _filter,
-        _githubFilter,
-    ) { sourceKey, tab, q, filter, ghFilter ->
-        resolveSource(sourceKey, tab, q, filter, ghFilter)?.let { source -> source to sourceKey.sourceId }
+        combine(
+            _sourceKey,
+            _tab,
+            _query.debounce(300),
+            _filter,
+            _githubFilter,
+        ) { sourceKey, tab, q, filter, ghFilter ->
+            ResolveTuple(sourceKey, tab, q, filter, ghFilter)
+        },
+        _palaceFilter,
+    ) { tup, palaceFilter ->
+        resolveSource(tup.sourceKey, tup.tab, tup.q, tup.filter, tup.ghFilter, palaceFilter)
+            ?.let { source -> source to tup.sourceKey.sourceId }
     }
         .distinctUntilChanged()
         .map { pair -> pair?.let { (source, sourceId) -> repo.paginator(source, sourceId) } }
@@ -184,18 +211,23 @@ class BrowseViewModel @Inject constructor(
     }
 
     /** All user-controlled knobs collapsed into one typed record so the
-     *  outer combines below stay within the 5-arg `combine` overload. */
+     *  outer combines below stay within the 5-arg `combine` overload.
+     *  The MemPalace filter is folded in via a nested combine to stay
+     *  within the overload arity. */
     private val controls: kotlinx.coroutines.flow.Flow<ControlsView> = combine(
-        _sourceKey, _tab, _query, _filter, _githubFilter,
-    ) { sourceKey, tab, q, filter, ghFilter ->
-        ControlsView(sourceKey, tab, q, filter, ghFilter)
+        combine(_sourceKey, _tab, _query, _filter, _githubFilter) { sourceKey, tab, q, filter, ghFilter ->
+            ResolveTuple(sourceKey, tab, q, filter, ghFilter)
+        },
+        _palaceFilter,
+    ) { tup, palaceFilter ->
+        ControlsView(tup.sourceKey, tup.tab, tup.q, tup.filter, tup.ghFilter, palaceFilter)
     }
 
     val uiState: StateFlow<BrowseUiState> = paginator.flatMapLatest { p ->
         if (p == null) {
             // Empty-search/no-filter: surface a quiet idle state so the
             // screen renders SearchHint rather than the skeleton grid.
-            controls.map { c ->
+            combine(controls, _palaceWings) { c, wings ->
                 BrowseUiState(
                     sourceKey = c.sourceKey,
                     tab = c.tab,
@@ -209,6 +241,8 @@ class BrowseViewModel @Inject constructor(
                     isFilterActive = c.filter.isActive(),
                     githubFilter = c.githubFilter,
                     isGitHubFilterActive = c.githubFilter.isActive(),
+                    palaceFilter = c.palaceFilter,
+                    palaceWings = wings,
                 )
             }
         } else {
@@ -225,7 +259,7 @@ class BrowseViewModel @Inject constructor(
             ) { items, loading, appending, more, error ->
                 PaginatorView(items, loading, appending, more, error)
             }
-            combine(paginatorView, controls) { view, c ->
+            combine(paginatorView, controls, _palaceWings) { view, c, wings ->
                 BrowseUiState(
                     sourceKey = c.sourceKey,
                     tab = c.tab,
@@ -239,6 +273,8 @@ class BrowseViewModel @Inject constructor(
                     isFilterActive = c.filter.isActive(),
                     githubFilter = c.githubFilter,
                     isGitHubFilterActive = c.githubFilter.isActive(),
+                    palaceFilter = c.palaceFilter,
+                    palaceWings = wings,
                 )
             }
         }
@@ -255,22 +291,41 @@ class BrowseViewModel @Inject constructor(
             _tab.value = BrowseTab.Popular
         }
         // Per-source filter shapes don't translate, so clear the
-        // *other* source's filter on switch. Symmetrical: leaving
-        // GitHub clears the GH filter; leaving RR clears the RR
-        // filter. Always clear the query so a half-typed term doesn't
-        // leak across sources.
+        // *other* sources' filters on switch. Always clear the query
+        // so a half-typed term doesn't leak across sources.
         _query.value = ""
         when (key) {
-            BrowseSourceKey.RoyalRoad -> _githubFilter.value = GitHubSearchFilter()
-            BrowseSourceKey.GitHub -> _filter.value = BrowseFilter()
-            // MemPalace has no source-specific filter shape today — the
-            // wing dropdown reuses BrowseFilter.tagsInclude (each wing
-            // appears as a single tag on its rooms). Clearing both the
-            // RR and GH filters keeps the picker idempotent.
+            BrowseSourceKey.RoyalRoad -> {
+                _githubFilter.value = GitHubSearchFilter()
+                _palaceFilter.value = MemPalaceFilter()
+            }
+            BrowseSourceKey.GitHub -> {
+                _filter.value = BrowseFilter()
+                _palaceFilter.value = MemPalaceFilter()
+            }
             BrowseSourceKey.MemPalace -> {
                 _filter.value = BrowseFilter()
                 _githubFilter.value = GitHubSearchFilter()
+                // Lazy-load the wing list on first switch — keeps the
+                // daemon round-trip off the cold-start path for users
+                // who never visit the palace tab.
+                ensurePalaceWingsLoaded()
             }
+        }
+    }
+
+    private fun ensurePalaceWingsLoaded() {
+        if (palaceWingsLoaded) return
+        palaceWingsLoaded = true
+        viewModelScope.launch {
+            // Empty list on failure — the sheet renders an "All" chip
+            // only and the user sees no wing options, which matches
+            // the "palace unreachable / unconfigured" empty state.
+            // Reset the latch on failure so a subsequent switch retries.
+            val wings = runCatching { repo.genres(BrowseSourceKey.MemPalace.sourceId) }
+                .getOrDefault(emptyList())
+            if (wings.isEmpty()) palaceWingsLoaded = false
+            _palaceWings.value = wings
         }
     }
 
@@ -280,6 +335,8 @@ class BrowseViewModel @Inject constructor(
     fun resetFilter() { _filter.value = BrowseFilter() }
     fun setGitHubFilter(filter: GitHubSearchFilter) { _githubFilter.value = filter }
     fun resetGitHubFilter() { _githubFilter.value = GitHubSearchFilter() }
+    fun setPalaceFilter(filter: MemPalaceFilter) { _palaceFilter.value = filter }
+    fun resetPalaceFilter() { _palaceFilter.value = MemPalaceFilter() }
 
     /** Called by the grid when the user nears the end of the visible
      *  list. Idempotent — the paginator's mutex collapses concurrent
@@ -289,12 +346,24 @@ class BrowseViewModel @Inject constructor(
     }
 }
 
+/** 5-arg shoehorn so the inner [combine] stays within the overload
+ *  arity. Folded back into [ControlsView] (or consumed directly by
+ *  [resolveSource]) at the next combine layer. */
+private data class ResolveTuple(
+    val sourceKey: BrowseSourceKey,
+    val tab: BrowseTab,
+    val q: String,
+    val filter: BrowseFilter,
+    val ghFilter: GitHubSearchFilter,
+)
+
 private fun resolveSource(
     sourceKey: BrowseSourceKey,
     tab: BrowseTab,
     q: String,
     filter: BrowseFilter,
     githubFilter: GitHubSearchFilter,
+    palaceFilter: MemPalaceFilter,
 ): BrowseSource? = when (sourceKey) {
     // GitHub: filter takes priority over tab. When filter is active OR
     // user is on Search with a typed query, route to FilteredGitHub so
@@ -321,15 +390,16 @@ private fun resolveSource(
         tab == BrowseTab.Search -> if (q.isBlank()) null else BrowseSource.Search(q)
         else -> null
     }
-    // MemPalace tabs map straight to the existing BrowseSource enum —
-    // Popular = Wings (top rooms by drawer count), NewReleases = Recent
-    // (rooms by latest drawer). No filtered/search variant in v1; spec
-    // P1 surfaces the daemon's /search endpoint behind a feature flag.
-    BrowseSourceKey.MemPalace -> when (tab) {
-        BrowseTab.Popular -> BrowseSource.Popular
-        BrowseTab.NewReleases -> BrowseSource.NewReleases
-        BrowseTab.BestRated -> null
-        BrowseTab.Search -> null
+    // MemPalace: when a wing is selected, route through ByGenre so the
+    // daemon scopes the listing to that wing (overrides tab). Wing-less
+    // requests fall through to the tab-driven Popular/NewReleases pair.
+    // Spec P1 surfaces the daemon's /search endpoint behind a feature
+    // flag; today Search is hidden on MemPalace.
+    BrowseSourceKey.MemPalace -> when {
+        palaceFilter.wing != null -> BrowseSource.ByGenre(palaceFilter.wing)
+        tab == BrowseTab.Popular -> BrowseSource.Popular
+        tab == BrowseTab.NewReleases -> BrowseSource.NewReleases
+        else -> null
     }
 }
 

--- a/feature/src/main/kotlin/in/jphe/storyvox/feature/browse/MemPalaceFilterSheet.kt
+++ b/feature/src/main/kotlin/in/jphe/storyvox/feature/browse/MemPalaceFilterSheet.kt
@@ -1,0 +1,132 @@
+package `in`.jphe.storyvox.feature.browse
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.ExperimentalLayoutApi
+import androidx.compose.foundation.layout.FlowRow
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material3.Button
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.ModalBottomSheet
+import androidx.compose.material3.OutlinedButton
+import androidx.compose.material3.Text
+import androidx.compose.material3.rememberModalBottomSheetState
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import `in`.jphe.storyvox.feature.api.MemPalaceFilter
+import `in`.jphe.storyvox.ui.component.BrassButton
+import `in`.jphe.storyvox.ui.component.BrassButtonVariant
+import `in`.jphe.storyvox.ui.theme.LocalSpacing
+
+/**
+ * MemPalace wing-picker bottom sheet (#191). Single-dimension filter:
+ * which wing to scope the listing to. The "All" chip clears the filter
+ * and falls Browse back to the wing-less Popular/NewReleases tabs.
+ *
+ * The wing list is supplied by the caller (BrowseViewModel populates it
+ * lazily on first switch to MemPalace via `MemPalaceSource.genres()`).
+ * An empty list collapses the sheet to just the "All" chip + an
+ * unconfigured-state hint.
+ */
+@OptIn(ExperimentalMaterial3Api::class, ExperimentalLayoutApi::class)
+@Composable
+fun MemPalaceFilterSheet(
+    filter: MemPalaceFilter,
+    wings: List<String>,
+    onApply: (MemPalaceFilter) -> Unit,
+    onReset: () -> Unit,
+    onDismiss: () -> Unit,
+) {
+    val sheetState = rememberModalBottomSheetState(skipPartiallyExpanded = true)
+    val spacing = LocalSpacing.current
+    var local by remember { mutableStateOf(filter) }
+
+    ModalBottomSheet(
+        onDismissRequest = onDismiss,
+        sheetState = sheetState,
+    ) {
+        Column(
+            modifier = Modifier
+                .fillMaxWidth()
+                .verticalScroll(rememberScrollState())
+                .padding(horizontal = spacing.md)
+                .padding(bottom = spacing.xl),
+            verticalArrangement = Arrangement.spacedBy(spacing.md),
+        ) {
+            Text(
+                "Filter by wing",
+                style = MaterialTheme.typography.titleLarge,
+                modifier = Modifier.padding(top = spacing.sm),
+            )
+
+            if (wings.isEmpty()) {
+                Text(
+                    "No wings reachable. Confirm your palace daemon is configured under Settings → Memory Palace.",
+                    style = MaterialTheme.typography.bodyMedium,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                )
+            }
+
+            FlowRow(
+                modifier = Modifier.fillMaxWidth(),
+                horizontalArrangement = Arrangement.spacedBy(spacing.xs),
+                verticalArrangement = Arrangement.spacedBy(spacing.xs),
+            ) {
+                WingChip(
+                    label = "All",
+                    selected = local.wing == null,
+                    onClick = { local = local.copy(wing = null) },
+                )
+                wings.forEach { wing ->
+                    WingChip(
+                        label = prettifyWing(wing),
+                        selected = local.wing == wing,
+                        onClick = { local = local.copy(wing = wing) },
+                    )
+                }
+            }
+
+            Row(
+                modifier = Modifier.fillMaxWidth().padding(top = spacing.md),
+                horizontalArrangement = Arrangement.spacedBy(spacing.sm),
+            ) {
+                OutlinedButton(
+                    onClick = onReset,
+                    modifier = Modifier.weight(1f),
+                ) { Text("Reset") }
+                Button(
+                    onClick = { onApply(local) },
+                    modifier = Modifier.weight(2f),
+                ) { Text("Apply") }
+            }
+        }
+    }
+}
+
+@Composable
+private fun WingChip(label: String, selected: Boolean, onClick: () -> Unit) {
+    BrassButton(
+        label = label,
+        onClick = onClick,
+        variant = if (selected) BrassButtonVariant.Primary else BrassButtonVariant.Secondary,
+    )
+}
+
+/** Capitalise + de-snake_case a wing name for display. Mirrors
+ *  `MemPalaceIds.prettify` from `:source-mempalace` (which `:feature`
+ *  doesn't depend on) so we don't pull a module dep over a one-liner. */
+internal fun prettifyWing(raw: String): String =
+    raw.replace('_', ' ')
+        .split(' ')
+        .joinToString(" ") { word ->
+            if (word.isEmpty()) word else word.replaceFirstChar { it.uppercase() }
+        }


### PR DESCRIPTION
## Summary
- New `MemPalaceFilterSheet` replaces the placeholder filter sheet on Browse → Palace. FlowRow of wing chips with brass-primary selection, plus an "All" reset chip.
- Selected wing surfaces as a one-tap-clear AssistChip below the tab row so users always know the listing is scoped.
- Routes through new `BrowseSource.ByGenre` → `FictionRepository.browseByGenre` → `MemPalaceSource.byGenre(wing)` instead of latest/popular when a wing is set. Filter button badge counts 1 when a wing is selected (was hardcoded to 0).
- Wing list loads lazily from `MemPalaceSource.genres()` on first switch to MemPalace so cold-start stays off the daemon.

## Test plan
- [x] `:feature` + `:core-data` unit tests pass.
- [x] `:app:assembleDebug` builds clean.
- [x] Installed on tablet R83W80CAFZB; Browse → Palace foregrounded without crash, filter sheet renders, wing chip + AssistChip clear path works.
- [ ] Verify against a configured palace daemon that `byGenre(wing)` returns the expected room set (smoked locally; reviewer to spot-check on their palace).

Closes #191