### PR TITLE
feat(github): "Enable private repos" Settings toggle (#203)

### DIFF
--- a/app/src/main/kotlin/in/jphe/storyvox/auth/github/GitHubSignInViewModel.kt
+++ b/app/src/main/kotlin/in/jphe/storyvox/auth/github/GitHubSignInViewModel.kt
@@ -8,6 +8,7 @@ import `in`.jphe.storyvox.source.github.auth.DeviceFlowApi
 import `in`.jphe.storyvox.source.github.auth.GitHubAuthConfig
 import `in`.jphe.storyvox.source.github.auth.GitHubAuthRepository
 import `in`.jphe.storyvox.source.github.auth.GitHubProfileService
+import `in`.jphe.storyvox.source.github.auth.GitHubScopePreferences
 import `in`.jphe.storyvox.source.github.auth.ProfileResult
 import `in`.jphe.storyvox.source.github.auth.TokenPollResult
 import javax.inject.Inject
@@ -48,6 +49,7 @@ class GitHubSignInViewModel @Inject constructor(
     private val deviceFlow: DeviceFlowApi,
     private val auth: GitHubAuthRepository,
     private val profile: GitHubProfileService,
+    private val scopePrefs: GitHubScopePreferences,
 ) : ViewModel() {
 
     private val _state = MutableStateFlow<SignInState>(SignInState.Idle)
@@ -69,9 +71,15 @@ class GitHubSignInViewModel @Inject constructor(
         cancelPolling()
         _state.value = SignInState.RequestingCode
         viewModelScope.launch {
+            // #203 — pick the scope set off the user's persisted "Enable
+            // private repos" toggle. ON re-runs Device Flow with the
+            // `repo` scope (full repo, includes private); OFF stays on
+            // `public_repo`. Read at sign-in time so a freshly-flipped
+            // toggle takes effect on the next attempt.
+            val scopes = GitHubAuthConfig.scopesFor(scopePrefs.privateReposEnabled())
             when (val result = deviceFlow.requestDeviceCode(
                 clientId = clientId,
-                scopes = GitHubAuthConfig.DEFAULT_SCOPES,
+                scopes = scopes,
             )) {
                 is DeviceCodeResult.Success -> {
                     _state.value = SignInState.AwaitingUser(

--- a/app/src/main/kotlin/in/jphe/storyvox/data/SettingsRepositoryUiImpl.kt
+++ b/app/src/main/kotlin/in/jphe/storyvox/data/SettingsRepositoryUiImpl.kt
@@ -40,6 +40,7 @@ import `in`.jphe.storyvox.feature.api.UiPalaceConfig
 import `in`.jphe.storyvox.feature.api.UiSettings
 import `in`.jphe.storyvox.feature.api.UiSigil
 import `in`.jphe.storyvox.source.github.auth.GitHubAuthRepository
+import `in`.jphe.storyvox.source.github.auth.GitHubScopePreferences
 import `in`.jphe.storyvox.source.github.auth.GitHubSession
 import `in`.jphe.storyvox.llm.LlmConfig
 import `in`.jphe.storyvox.llm.LlmConfigProvider
@@ -162,6 +163,12 @@ private object Keys {
     val AI_BEDROCK_REGION = stringPreferencesKey("pref_ai_bedrock_region")
     val AI_BEDROCK_MODEL = stringPreferencesKey("pref_ai_bedrock_model")
 
+    /** Issue #203 — "Enable private repos" toggle. Default false keeps
+     *  the least-privilege public-only baseline; ON makes the next
+     *  Device Flow request the `repo` scope. _v1 suffix matches the
+     *  versioning convention used by other v1-tagged keys here. */
+    val GITHUB_PRIVATE_REPOS_ENABLED = booleanPreferencesKey("pref_github_private_repos_enabled_v1")
+
     /** Issue #135 — JSON-serialized [PronunciationDict] (list of
      *  pattern/replacement/matchType entries). _v1 suffix lets us
      *  rev the schema later without a destructive migration; an
@@ -191,7 +198,8 @@ class SettingsRepositoryUiImpl(
     PlaybackModeConfig,
     VoiceTuningConfig,
     PronunciationDictRepository,
-    LlmConfigProvider {
+    LlmConfigProvider,
+    GitHubScopePreferences {
 
     /** Hilt entry point — pulls the production DataStore from the app context.
      *  The primary constructor takes the store directly so tests can swap in
@@ -235,6 +243,7 @@ class SettingsRepositoryUiImpl(
             voiceSteady = prefs[Keys.VOICE_STEADY] ?: true,
             palace = UiPalaceConfig(host = palace.host, apiKey = palace.apiKey),
             github = githubSession.toUi(),
+            githubPrivateReposEnabled = prefs[Keys.GITHUB_PRIVATE_REPOS_ENABLED] ?: false,
             ai = UiAiSettings(
                 provider = prefs[Keys.AI_PROVIDER]
                     ?.takeIf { it.isNotBlank() }
@@ -558,6 +567,19 @@ class SettingsRepositoryUiImpl(
         // github.com/settings/applications for users who want full revoke.
         githubAuth.clearSession()
     }
+
+    override suspend fun setGitHubPrivateReposEnabled(enabled: Boolean) {
+        store.edit { it[Keys.GITHUB_PRIVATE_REPOS_ENABLED] = enabled }
+    }
+
+    /**
+     * Issue #203 — [GitHubScopePreferences] surface for the
+     * `GitHubSignInViewModel`. Read at the moment Device Flow starts so
+     * a freshly-flipped toggle takes effect on the next sign-in
+     * attempt. Defaults false to match the least-privilege baseline.
+     */
+    override suspend fun privateReposEnabled(): Boolean =
+        store.data.map { it[Keys.GITHUB_PRIVATE_REPOS_ENABLED] ?: false }.first()
 
     // ── PronunciationDictRepository (issue #135) ───────────────────
 

--- a/app/src/main/kotlin/in/jphe/storyvox/di/AppBindings.kt
+++ b/app/src/main/kotlin/in/jphe/storyvox/di/AppBindings.kt
@@ -156,6 +156,17 @@ object AppBindings {
     ): PronunciationDictRepository = impl
 
     /**
+     * Issue #203 — narrow [GitHubScopePreferences] surface for the
+     * `GitHubSignInViewModel`. Same singleton as the rest; the
+     * `:source-github` module reads only the toggle flag, never the
+     * full settings repo.
+     */
+    @Provides @Singleton
+    fun provideGitHubScopePreferences(
+        impl: SettingsRepositoryUiImpl,
+    ): `in`.jphe.storyvox.source.github.auth.GitHubScopePreferences = impl
+
+    /**
      * Same singleton instance as [provideSettingsRepositoryUi], exposed
      * under the [`in`.jphe.storyvox.llm.LlmConfigProvider] contract so
      * `core-llm`'s provider classes can read the user's chosen

--- a/app/src/test/kotlin/in/jphe/storyvox/auth/github/GitHubSignInViewModelTest.kt
+++ b/app/src/test/kotlin/in/jphe/storyvox/auth/github/GitHubSignInViewModelTest.kt
@@ -4,6 +4,7 @@ import `in`.jphe.storyvox.source.github.auth.DeviceCodeResult
 import `in`.jphe.storyvox.source.github.auth.DeviceFlowApi
 import `in`.jphe.storyvox.source.github.auth.GitHubAuthRepository
 import `in`.jphe.storyvox.source.github.auth.GitHubProfileService
+import `in`.jphe.storyvox.source.github.auth.GitHubScopePreferences
 import `in`.jphe.storyvox.source.github.auth.GitHubSession
 import `in`.jphe.storyvox.source.github.auth.ProfileResult
 import `in`.jphe.storyvox.source.github.auth.TokenPollResult
@@ -55,9 +56,11 @@ class GitHubSignInViewModelTest {
         deviceFlow: DeviceFlowApi,
         auth: GitHubAuthRepository = FakeAuth(),
         profile: GitHubProfileService = FakeProfile(ProfileResult.Success("octocat", "Octo Cat", 1L)),
-    ): GitHubSignInViewModel = GitHubSignInViewModel(deviceFlow, auth, profile).also {
-        it.clientIdOverride = "test-client"
-    }
+        scopePrefs: GitHubScopePreferences = FakeScopePrefs(),
+    ): GitHubSignInViewModel =
+        GitHubSignInViewModel(deviceFlow, auth, profile, scopePrefs).also {
+            it.clientIdOverride = "test-client"
+        }
 
     @Test
     fun `successful flow transitions Idle to AwaitingUser to Captured`() = runTest(dispatcher) {
@@ -225,6 +228,46 @@ class GitHubSignInViewModelTest {
         assertEquals(SignInState.Idle, vm.state.value)
     }
 
+    // ── #203 Private repos toggle ──────────────────────────────────
+
+    @Test
+    fun `private repos disabled requests public_repo scope`() = runTest(dispatcher) {
+        val flow = ScriptedDeviceFlow(
+            deviceCode = DeviceCodeResult.Success(
+                deviceCode = "dev-1",
+                userCode = "ABCD-EFGH",
+                verificationUri = "https://github.com/login/device",
+                verificationUriComplete = null,
+                expiresInSeconds = 900,
+                intervalSeconds = 5,
+            ),
+            tokenPolls = arrayListOf(TokenPollResult.Denied),
+        )
+        val vm = makeVm(flow, scopePrefs = FakeScopePrefs(privateRepos = false))
+        vm.start()
+        advanceUntilIdle()
+        assertEquals("read:user public_repo", flow.lastRequestedScopes)
+    }
+
+    @Test
+    fun `private repos enabled requests repo scope`() = runTest(dispatcher) {
+        val flow = ScriptedDeviceFlow(
+            deviceCode = DeviceCodeResult.Success(
+                deviceCode = "dev-1",
+                userCode = "ABCD-EFGH",
+                verificationUri = "https://github.com/login/device",
+                verificationUriComplete = null,
+                expiresInSeconds = 900,
+                intervalSeconds = 5,
+            ),
+            tokenPolls = arrayListOf(TokenPollResult.Denied),
+        )
+        val vm = makeVm(flow, scopePrefs = FakeScopePrefs(privateRepos = true))
+        vm.start()
+        advanceUntilIdle()
+        assertEquals("read:user repo", flow.lastRequestedScopes)
+    }
+
     // ── Test fakes ──────────────────────────────────────────────────
 
     /**
@@ -241,8 +284,14 @@ class GitHubSignInViewModelTest {
         private val polls = LinkedBlockingDeque(tokenPolls)
         private var lastPoll: TokenPollResult? = null
 
-        override suspend fun requestDeviceCode(clientId: String, scopes: String): DeviceCodeResult =
-            deviceCode
+        /** Captures the scopes argument of the most recent [requestDeviceCode] call. */
+        var lastRequestedScopes: String? = null
+            private set
+
+        override suspend fun requestDeviceCode(clientId: String, scopes: String): DeviceCodeResult {
+            lastRequestedScopes = scopes
+            return deviceCode
+        }
 
         override suspend fun pollAccessToken(clientId: String, deviceCode: String): TokenPollResult {
             val next = polls.pollFirst() ?: lastPoll ?: TokenPollResult.Pending
@@ -263,5 +312,11 @@ class GitHubSignInViewModelTest {
 
     private class FakeProfile(private val result: ProfileResult) : GitHubProfileService(OkHttpClient()) {
         override suspend fun getCurrentUser(): ProfileResult = result
+    }
+
+    private class FakeScopePrefs(
+        private val privateRepos: Boolean = false,
+    ) : GitHubScopePreferences {
+        override suspend fun privateReposEnabled(): Boolean = privateRepos
     }
 }

--- a/app/src/test/kotlin/in/jphe/storyvox/data/SettingsRepositoryGitHubScopeTest.kt
+++ b/app/src/test/kotlin/in/jphe/storyvox/data/SettingsRepositoryGitHubScopeTest.kt
@@ -1,0 +1,86 @@
+package `in`.jphe.storyvox.data
+
+import androidx.datastore.core.DataStore
+import androidx.datastore.preferences.core.PreferenceDataStoreFactory
+import androidx.datastore.preferences.core.Preferences
+import java.io.File
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlinx.coroutines.test.runTest
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import org.junit.rules.TemporaryFolder
+
+/**
+ * Real-DataStore tests for the issue #203 "Enable private repos" toggle.
+ *
+ * Same shape as [SettingsRepositoryModesTest]: spins up a temp-file
+ * DataStore so persistence is identical to production. Verifies the
+ * default is OFF (least-privilege baseline), the setter round-trips
+ * through both the `UiSettings` flow and the `GitHubScopePreferences`
+ * surface that `GitHubSignInViewModel` reads.
+ */
+@OptIn(ExperimentalCoroutinesApi::class)
+class SettingsRepositoryGitHubScopeTest {
+
+    @get:Rule
+    val tempFolder = TemporaryFolder()
+
+    private lateinit var scope: CoroutineScope
+    private lateinit var store: DataStore<Preferences>
+    private lateinit var repo: SettingsRepositoryUiImpl
+
+    @Before
+    fun setUp() {
+        scope = CoroutineScope(SupervisorJob() + UnconfinedTestDispatcher())
+        val file = File(tempFolder.newFolder(), "storyvox_settings.preferences_pb")
+        store = PreferenceDataStoreFactory.create(
+            scope = scope,
+            produceFile = { file },
+        )
+        repo = SettingsRepositoryUiImpl(
+            store = store,
+            auth = FakeAuth(),
+            hydrator = FakeHydrator(),
+            palaceConfig = makeFakePalaceConfig(tempFolder.newFolder("palace_ds"), scope),
+            palaceApi = makeFakePalaceApi(),
+            llmCreds = `in`.jphe.storyvox.llm.LlmCredentialsStore.forTesting(),
+            githubAuth = FakeGitHubAuth(),
+        )
+    }
+
+    @After
+    fun tearDown() {
+        scope.cancel()
+    }
+
+    @Test
+    fun `default private repos enabled is off`() = runTest {
+        // Least-privilege baseline. Mirrors GitHubAuthConfig.DEFAULT_SCOPES,
+        // which is `read:user public_repo`.
+        assertEquals(false, repo.privateReposEnabled())
+        assertEquals(false, repo.settings.first().githubPrivateReposEnabled)
+    }
+
+    @Test
+    fun `setGitHubPrivateReposEnabled persists and re-emits on settings flow`() = runTest {
+        repo.setGitHubPrivateReposEnabled(true)
+        assertEquals(true, repo.privateReposEnabled())
+        assertEquals(true, repo.settings.first().githubPrivateReposEnabled)
+    }
+
+    @Test
+    fun `setGitHubPrivateReposEnabled round-trips both directions`() = runTest {
+        repo.setGitHubPrivateReposEnabled(true)
+        assertEquals(true, repo.privateReposEnabled())
+        repo.setGitHubPrivateReposEnabled(false)
+        assertEquals(false, repo.privateReposEnabled())
+    }
+}

--- a/app/src/test/kotlin/in/jphe/storyvox/di/RealPlaybackControllerUiTest.kt
+++ b/app/src/test/kotlin/in/jphe/storyvox/di/RealPlaybackControllerUiTest.kt
@@ -251,6 +251,7 @@ class RealPlaybackControllerUiTest {
         override suspend fun resetAiSettings() = Unit
         // ── GitHub OAuth no-op (#91) — playback-controller test doesn't auth. ──
         override suspend fun signOutGitHub() = Unit
+        override suspend fun setGitHubPrivateReposEnabled(enabled: Boolean) = Unit
     }
 
     /** Chapter repo never invoked by the speed/pitch path under test. */

--- a/feature/src/main/kotlin/in/jphe/storyvox/feature/api/UiContracts.kt
+++ b/feature/src/main/kotlin/in/jphe/storyvox/feature/api/UiContracts.kt
@@ -443,6 +443,16 @@ data class UiSettings(
      * only the login + state. See [UiGitHubAuthState].
      */
     val github: UiGitHubAuthState = UiGitHubAuthState.Anonymous,
+    /**
+     * Issue #203 — when true, the next GitHub Device Flow run requests
+     * the `repo` scope (full repo, read/write, includes private). When
+     * false (default), Device Flow uses [`GitHubAuthConfig.DEFAULT_SCOPES`]
+     * (`read:user public_repo`). Toggling this on a signed-in account
+     * doesn't auto-upgrade the live token — the user has to re-run
+     * sign-in for the new scope to take effect; the existing session
+     * keeps its original scopes until then.
+     */
+    val githubPrivateReposEnabled: Boolean = false,
 )
 
 /**
@@ -644,6 +654,15 @@ interface SettingsRepositoryUi {
      * `github.com/settings/applications` if they want to revoke fully.
      */
     suspend fun signOutGitHub()
+
+    /**
+     * Issue #203 — toggle "Enable private repos" preference. ON makes the
+     * next Device Flow request the `repo` scope; OFF goes back to
+     * `public_repo`. The currently-signed-in token is unaffected —
+     * existing sessions keep the scopes they were granted with until the
+     * user re-signs-in.
+     */
+    suspend fun setGitHubPrivateReposEnabled(enabled: Boolean)
 }
 
 /** Outcome of [`SettingsRepositoryUi.testPalaceConnection`]. */

--- a/feature/src/main/kotlin/in/jphe/storyvox/feature/settings/SettingsScreen.kt
+++ b/feature/src/main/kotlin/in/jphe/storyvox/feature/settings/SettingsScreen.kt
@@ -316,9 +316,11 @@ fun SettingsScreen(
             // (lifts the anon 60 req/hr cap to 5,000 req/hr).
             GitHubSignInRow(
                 state = s.github,
+                privateReposEnabled = s.githubPrivateReposEnabled,
                 onSignIn = onOpenGitHubSignIn,
                 onSignOut = viewModel::signOutGitHub,
                 onOpenRevokePage = onOpenGitHubRevoke,
+                onSetPrivateReposEnabled = viewModel::setGitHubPrivateReposEnabled,
             )
         }
 
@@ -386,14 +388,22 @@ fun SettingsScreen(
  *  - SignedIn → "Signed in as @login" + Sign-out button + revoke deep-link.
  *  - Expired → "Session expired — sign in again" CTA + same revoke link.
  *
+ * Issue #203 adds an "Enable private repos" SettingsSwitchRow that's
+ * only visible when signed in. Toggling it doesn't auto-upgrade the
+ * live token — the user has to sign out + back in for the new scope
+ * to take effect; the subtitle nudges them when their current scope
+ * doesn't match the requested scope.
+ *
  * Spec § Settings UI surface, lines 384-395 of the design doc.
  */
 @Composable
 private fun GitHubSignInRow(
     state: UiGitHubAuthState,
+    privateReposEnabled: Boolean,
     onSignIn: () -> Unit,
     onSignOut: () -> Unit,
     onOpenRevokePage: () -> Unit,
+    onSetPrivateReposEnabled: (Boolean) -> Unit,
 ) {
     when (state) {
         UiGitHubAuthState.Anonymous -> {
@@ -422,6 +432,30 @@ private fun GitHubSignInRow(
                         variant = BrassButtonVariant.Secondary,
                     )
                 },
+            )
+            // #203 — "Enable private repos" toggle. Only visible
+            // signed-in. Token-scope upgrade is opt-in and triggered
+            // by the user re-running sign-in; the subtitle calls that
+            // out when the live session's scope doesn't yet match.
+            val tokenHasRepoScope = state.scopes.split(' ', ',').any { it.trim() == "repo" }
+            val needsResign = privateReposEnabled && !tokenHasRepoScope
+            val downgradePending = !privateReposEnabled && tokenHasRepoScope
+            SettingsSwitchRow(
+                title = "Enable private repos",
+                subtitle = when {
+                    needsResign ->
+                        "ON. Sign out and back in to upgrade to the `repo` scope " +
+                            "(read/write to private + public repos)."
+                    downgradePending ->
+                        "OFF. Current token still carries the `repo` scope; sign out " +
+                            "and back in to drop down to `public_repo`."
+                    privateReposEnabled ->
+                        "Sign-in requests `repo` (full repo, read/write, includes private)."
+                    else ->
+                        "Sign-in requests `public_repo` only (least privilege)."
+                },
+                checked = privateReposEnabled,
+                onCheckedChange = onSetPrivateReposEnabled,
             )
             SettingsLinkRow(
                 title = "Revoke at github.com",

--- a/feature/src/main/kotlin/in/jphe/storyvox/feature/settings/SettingsViewModel.kt
+++ b/feature/src/main/kotlin/in/jphe/storyvox/feature/settings/SettingsViewModel.kt
@@ -96,6 +96,11 @@ class SettingsViewModel @Inject constructor(
     fun signOut() = viewModelScope.launch { repo.signOut() }
     /** GitHub OAuth (#91) — local sign-out. Remote revoke deep-links to github.com. */
     fun signOutGitHub() = viewModelScope.launch { repo.signOutGitHub() }
+    /** Issue #203 — toggle "Enable private repos." Takes effect on the
+     *  next sign-in; existing sessions keep their original scope until
+     *  the user re-runs Device Flow. */
+    fun setGitHubPrivateReposEnabled(enabled: Boolean) =
+        viewModelScope.launch { repo.setGitHubPrivateReposEnabled(enabled) }
     fun previewVoice(voice: UiVoice) = voices.previewVoice(voice)
 
     // ─── Memory Palace (#79) ────────────────────────────────────────────

--- a/feature/src/test/kotlin/in/jphe/storyvox/feature/settings/SettingsViewModelBufferTest.kt
+++ b/feature/src/test/kotlin/in/jphe/storyvox/feature/settings/SettingsViewModelBufferTest.kt
@@ -170,6 +170,7 @@ class SettingsViewModelBufferTest {
         override suspend fun acknowledgeAiPrivacy() = Unit
         override suspend fun resetAiSettings() = Unit
         override suspend fun signOutGitHub() = Unit
+        override suspend fun setGitHubPrivateReposEnabled(enabled: Boolean) = Unit
     }
 
     /** Construct an LlmRepository with real-but-stubbed provider

--- a/feature/src/test/kotlin/in/jphe/storyvox/feature/settings/SettingsViewModelModesTest.kt
+++ b/feature/src/test/kotlin/in/jphe/storyvox/feature/settings/SettingsViewModelModesTest.kt
@@ -245,6 +245,7 @@ class SettingsViewModelModesTest {
         override suspend fun acknowledgeAiPrivacy() = Unit
         override suspend fun resetAiSettings() = Unit
         override suspend fun signOutGitHub() = Unit
+        override suspend fun setGitHubPrivateReposEnabled(enabled: Boolean) = Unit
     }
 
     private class FakeVoiceProvider : VoiceProviderUi {

--- a/feature/src/test/kotlin/in/jphe/storyvox/feature/settings/SettingsViewModelPunctuationPauseTest.kt
+++ b/feature/src/test/kotlin/in/jphe/storyvox/feature/settings/SettingsViewModelPunctuationPauseTest.kt
@@ -183,6 +183,7 @@ class SettingsViewModelPunctuationPauseTest {
         override suspend fun acknowledgeAiPrivacy() = Unit
         override suspend fun resetAiSettings() = Unit
         override suspend fun signOutGitHub() = Unit
+        override suspend fun setGitHubPrivateReposEnabled(enabled: Boolean) = Unit
     }
 
     private class FakeVoiceProvider : VoiceProviderUi {

--- a/source-github/src/main/kotlin/in/jphe/storyvox/source/github/auth/GitHubAuthConfig.kt
+++ b/source-github/src/main/kotlin/in/jphe/storyvox/source/github/auth/GitHubAuthConfig.kt
@@ -30,6 +30,24 @@ object GitHubAuthConfig {
      */
     const val DEFAULT_SCOPES: String = "read:user public_repo"
 
+    /**
+     * Scopes requested when the user has opted in to "Enable private
+     * repos" in Settings (#203). The `repo` scope is a strict superset
+     * of `public_repo` (full repo: read/write to private + public),
+     * so flipping ON re-runs Device Flow and the new token replaces
+     * the old. Flipping OFF on next sign-in downgrades back to
+     * [DEFAULT_SCOPES].
+     */
+    const val PRIVATE_REPO_SCOPES: String = "read:user repo"
+
+    /**
+     * Resolve the scope string for a fresh Device Flow request given the
+     * user's "Enable private repos" preference. Centralised so the
+     * ViewModel and any tests pick the same value off one switch.
+     */
+    fun scopesFor(privateReposEnabled: Boolean): String =
+        if (privateReposEnabled) PRIVATE_REPO_SCOPES else DEFAULT_SCOPES
+
     /** Device Flow endpoints live on the *website* domain, not api.github.com. */
     const val DEVICE_CODE_URL: String = "https://github.com/login/device/code"
     const val ACCESS_TOKEN_URL: String = "https://github.com/login/oauth/access_token"

--- a/source-github/src/main/kotlin/in/jphe/storyvox/source/github/auth/GitHubScopePreferences.kt
+++ b/source-github/src/main/kotlin/in/jphe/storyvox/source/github/auth/GitHubScopePreferences.kt
@@ -1,0 +1,21 @@
+package `in`.jphe.storyvox.source.github.auth
+
+/**
+ * Tiny port for the user-controlled "Enable private repos" toggle
+ * (#203). The Device Flow code lives in `:source-github`; the toggle
+ * itself is owned by `:app`'s settings DataStore. This interface is
+ * the seam — kept narrow so the source module doesn't take a
+ * dependency on `:feature/api`'s broader `SettingsRepositoryUi`.
+ *
+ * The Hilt binding lives in `:app`'s `AppBindings` and forwards to
+ * the same `SettingsRepositoryUiImpl` singleton that backs
+ * `SettingsRepositoryUi`.
+ */
+interface GitHubScopePreferences {
+    /**
+     * Read the persisted "Enable private repos" preference. Returns
+     * false (least-privilege) when the user hasn't opted in, which
+     * matches the v0.4.x baseline behaviour for existing installs.
+     */
+    suspend fun privateReposEnabled(): Boolean
+}


### PR DESCRIPTION
## Summary

Adds a `SettingsSwitchRow` to Settings → Account → GitHub for "Enable private repos" (visible only when signed in). Toggling ON makes the next Device Flow run request the `repo` scope (full repo access, includes private); OFF keeps the least-privilege default `public_repo`.

- The toggle is persisted via DataStore (`pref_github_private_repos_enabled_v1`, default `false`) and read at sign-in time, so a freshly-flipped pref takes effect on the next sign-in attempt.
- Existing live sessions are not auto-upgraded — the user has to re-run sign-in. The row's subtitle calls this out when the live token's scope doesn't match the toggle (e.g. "ON. Sign out and back in to upgrade…").
- `GitHubAuthConfig.scopesFor(privateReposEnabled)` centralises the scope decision; `PRIVATE_REPO_SCOPES = "read:user repo"`.
- New narrow `GitHubScopePreferences` interface in `:source-github` so the source module reads only the toggle, not the full settings repo. `SettingsRepositoryUiImpl` implements both contracts; one DataStore key, one Hilt binding in `AppBindings`.

## Test plan

- [x] `:source-github`, `:feature`, `:app` unit tests green
- [x] New `SettingsRepositoryGitHubScopeTest` round-trips the toggle through real DataStore
- [x] New `GitHubSignInViewModelTest` cases assert `read:user public_repo` vs `read:user repo` are sent to Device Flow based on the toggle
- [x] Debug APK builds and installs on R83W80CAFZB; storyvox launches without crashing
- [ ] Manual: sign in with toggle OFF → token shows `public_repo` scope; flip ON → row subtitle prompts re-sign-in; sign out + in → token shows `repo` scope

Closes #203

🤖 Generated with [Claude Code](https://claude.com/claude-code)