### PR TITLE
feat(chat): grounding-level toggles for system prompt (#212)

### DIFF
--- a/app/src/main/kotlin/in/jphe/storyvox/data/SettingsRepositoryUiImpl.kt
+++ b/app/src/main/kotlin/in/jphe/storyvox/data/SettingsRepositoryUiImpl.kt
@@ -34,6 +34,7 @@ import `in`.jphe.storyvox.feature.api.PalaceProbeResult
 import `in`.jphe.storyvox.feature.api.SettingsRepositoryUi
 import `in`.jphe.storyvox.feature.api.ThemeOverride
 import `in`.jphe.storyvox.feature.api.UiAiSettings
+import `in`.jphe.storyvox.feature.api.UiChatGrounding
 import `in`.jphe.storyvox.feature.api.UiGitHubAuthState
 import `in`.jphe.storyvox.feature.api.UiLlmProvider
 import `in`.jphe.storyvox.feature.api.UiPalaceConfig
@@ -169,6 +170,14 @@ private object Keys {
      *  versioning convention used by other v1-tagged keys here. */
     val GITHUB_PRIVATE_REPOS_ENABLED = booleanPreferencesKey("pref_github_private_repos_enabled_v1")
 
+    // ── Chat grounding (issue #212) ────────────────────────────────
+    /** Defaults match pre-#212 ChatViewModel behaviour: chapter title
+     *  on, every more-expensive level off. */
+    val AI_CHAT_GROUND_CHAPTER_TITLE = booleanPreferencesKey("pref_ai_chat_ground_chapter_title")
+    val AI_CHAT_GROUND_CURRENT_SENTENCE = booleanPreferencesKey("pref_ai_chat_ground_current_sentence")
+    val AI_CHAT_GROUND_ENTIRE_CHAPTER = booleanPreferencesKey("pref_ai_chat_ground_entire_chapter")
+    val AI_CHAT_GROUND_ENTIRE_BOOK = booleanPreferencesKey("pref_ai_chat_ground_entire_book")
+
     /** Issue #135 — JSON-serialized [PronunciationDict] (list of
      *  pattern/replacement/matchType entries). _v1 suffix lets us
      *  rev the schema later without a destructive migration; an
@@ -266,6 +275,12 @@ class SettingsRepositoryUiImpl(
                 bedrockModel = prefs[Keys.AI_BEDROCK_MODEL] ?: "claude-haiku-4.5",
                 privacyAcknowledged = prefs[Keys.AI_PRIVACY_ACK] ?: false,
                 sendChapterTextEnabled = prefs[Keys.AI_SEND_CHAPTER_TEXT] ?: true,
+                chatGrounding = UiChatGrounding(
+                    includeChapterTitle = prefs[Keys.AI_CHAT_GROUND_CHAPTER_TITLE] ?: true,
+                    includeCurrentSentence = prefs[Keys.AI_CHAT_GROUND_CURRENT_SENTENCE] ?: false,
+                    includeEntireChapter = prefs[Keys.AI_CHAT_GROUND_ENTIRE_CHAPTER] ?: false,
+                    includeEntireBookSoFar = prefs[Keys.AI_CHAT_GROUND_ENTIRE_BOOK] ?: false,
+                ),
             ),
             sigil = Sigil.current.let {
                 UiSigil(
@@ -534,6 +549,24 @@ class SettingsRepositoryUiImpl(
         store.edit { it[Keys.AI_SEND_CHAPTER_TEXT] = enabled }
     }
 
+    // ── Chat grounding (#212) ──────────────────────────────────────
+
+    override suspend fun setChatGroundChapterTitle(enabled: Boolean) {
+        store.edit { it[Keys.AI_CHAT_GROUND_CHAPTER_TITLE] = enabled }
+    }
+
+    override suspend fun setChatGroundCurrentSentence(enabled: Boolean) {
+        store.edit { it[Keys.AI_CHAT_GROUND_CURRENT_SENTENCE] = enabled }
+    }
+
+    override suspend fun setChatGroundEntireChapter(enabled: Boolean) {
+        store.edit { it[Keys.AI_CHAT_GROUND_ENTIRE_CHAPTER] = enabled }
+    }
+
+    override suspend fun setChatGroundEntireBookSoFar(enabled: Boolean) {
+        store.edit { it[Keys.AI_CHAT_GROUND_ENTIRE_BOOK] = enabled }
+    }
+
     override suspend fun acknowledgeAiPrivacy() {
         store.edit { it[Keys.AI_PRIVACY_ACK] = true }
     }
@@ -553,6 +586,10 @@ class SettingsRepositoryUiImpl(
             it.remove(Keys.AI_BEDROCK_MODEL)
             it.remove(Keys.AI_PRIVACY_ACK)
             it.remove(Keys.AI_SEND_CHAPTER_TEXT)
+            it.remove(Keys.AI_CHAT_GROUND_CHAPTER_TITLE)
+            it.remove(Keys.AI_CHAT_GROUND_CURRENT_SENTENCE)
+            it.remove(Keys.AI_CHAT_GROUND_ENTIRE_CHAPTER)
+            it.remove(Keys.AI_CHAT_GROUND_ENTIRE_BOOK)
         }
         llmCreds.clearAll()
     }

--- a/app/src/main/kotlin/in/jphe/storyvox/di/AppBindings.kt
+++ b/app/src/main/kotlin/in/jphe/storyvox/di/AppBindings.kt
@@ -90,8 +90,10 @@ import kotlinx.coroutines.launch
 object AppBindings {
 
     @Provides @Singleton
-    fun provideFictionRepositoryUi(repo: FictionRepository): FictionRepositoryUi =
-        RealFictionRepositoryUi(repo)
+    fun provideFictionRepositoryUi(
+        repo: FictionRepository,
+        chapters: ChapterRepository,
+    ): FictionRepositoryUi = RealFictionRepositoryUi(repo, chapters)
 
     @Provides @Singleton
     fun provideBrowseRepositoryUi(
@@ -210,6 +212,7 @@ object AppBindings {
  */
 private class RealFictionRepositoryUi(
     private val repo: FictionRepository,
+    private val chapters: ChapterRepository,
 ) : FictionRepositoryUi {
 
     override val library: Flow<List<UiFiction>> =
@@ -242,6 +245,9 @@ private class RealFictionRepositoryUi(
     }
 
     override fun fictionLoadError(id: String): Flow<String?> = errorState(id).asStateFlow()
+
+    override suspend fun chapterTextById(chapterId: String): String? =
+        chapters.getChapter(chapterId)?.text
 
     override fun chaptersFor(fictionId: String): Flow<List<UiChapter>> =
         repo.observeFiction(fictionId).map { detail ->

--- a/app/src/test/kotlin/in/jphe/storyvox/di/RealPlaybackControllerUiTest.kt
+++ b/app/src/test/kotlin/in/jphe/storyvox/di/RealPlaybackControllerUiTest.kt
@@ -252,6 +252,10 @@ class RealPlaybackControllerUiTest {
         override suspend fun setBedrockRegion(region: String) = Unit
         override suspend fun setBedrockModel(model: String) = Unit
         override suspend fun setSendChapterTextEnabled(enabled: Boolean) = Unit
+        override suspend fun setChatGroundChapterTitle(enabled: Boolean) = Unit
+        override suspend fun setChatGroundCurrentSentence(enabled: Boolean) = Unit
+        override suspend fun setChatGroundEntireChapter(enabled: Boolean) = Unit
+        override suspend fun setChatGroundEntireBookSoFar(enabled: Boolean) = Unit
         override suspend fun acknowledgeAiPrivacy() = Unit
         override suspend fun resetAiSettings() = Unit
         // ── GitHub OAuth no-op (#91) — playback-controller test doesn't auth. ──

--- a/core-data/src/main/kotlin/in/jphe/storyvox/data/db/dao/LlmSessionDao.kt
+++ b/core-data/src/main/kotlin/in/jphe/storyvox/data/db/dao/LlmSessionDao.kt
@@ -29,6 +29,16 @@ interface LlmSessionDao {
     @Query("UPDATE llm_session SET lastUsedAt = :ts WHERE id = :id")
     suspend fun touchLastUsed(id: String, ts: Long)
 
+    /**
+     * Issue #212 — refresh the session's system prompt without
+     * touching createdAt / lastUsedAt / message history. The chat
+     * ViewModel rebuilds the prompt from current grounding settings
+     * on every send so a user can flip a toggle and see the next
+     * reply use the new context level immediately.
+     */
+    @Query("UPDATE llm_session SET systemPrompt = :systemPrompt WHERE id = :id")
+    suspend fun updateSystemPrompt(id: String, systemPrompt: String?)
+
     @Query("DELETE FROM llm_session WHERE id = :id")
     suspend fun delete(id: String)
 

--- a/core-llm/src/main/kotlin/in/jphe/storyvox/llm/LlmSessionRepository.kt
+++ b/core-llm/src/main/kotlin/in/jphe/storyvox/llm/LlmSessionRepository.kt
@@ -143,6 +143,17 @@ open class LlmSessionRepository @Inject constructor(
     open suspend fun deleteSession(sessionId: String) {
         sessionDao.delete(sessionId)   // cascades to messages
     }
+
+    /**
+     * Issue #212 — replace [sessionId]'s persisted system prompt
+     * in-place. Used by the chat ViewModel to swap in a freshly
+     * built prompt before each send when grounding settings have
+     * changed. No-op (silent) if the session doesn't exist yet —
+     * the next [createSession] will set the prompt.
+     */
+    open suspend fun updateSystemPrompt(sessionId: String, systemPrompt: String?) {
+        sessionDao.updateSystemPrompt(sessionId, systemPrompt)
+    }
 }
 
 /** UI-facing projection of [LlmSession] with strongly-typed

--- a/feature/src/main/kotlin/in/jphe/storyvox/feature/api/UiContracts.kt
+++ b/feature/src/main/kotlin/in/jphe/storyvox/feature/api/UiContracts.kt
@@ -66,6 +66,14 @@ interface FictionRepositoryUi {
      */
     fun fictionLoadError(id: String): Flow<String?>
     fun chaptersFor(fictionId: String): Flow<List<UiChapter>>
+    /**
+     * Issue #212 — fetch the plain-text body of a downloaded chapter
+     * for AI grounding. Returns null if the chapter row doesn't exist
+     * or its body hasn't been downloaded yet. Suspends because the
+     * underlying DAO read is suspending; callers should treat this
+     * as a one-shot, not a stream.
+     */
+    suspend fun chapterTextById(chapterId: String): String?
     suspend fun setDownloadMode(fictionId: String, mode: DownloadMode)
     suspend fun follow(fictionId: String, follow: Boolean)
     suspend fun markAllCaughtUp()
@@ -418,6 +426,39 @@ data class UiAiSettings(
     val bedrockModel: String = "claude-haiku-4.5",
     val privacyAcknowledged: Boolean = false,
     val sendChapterTextEnabled: Boolean = true,
+    /**
+     * Issue #212 — what the chat ViewModel injects into its system
+     * prompt to ground replies in what the user is currently reading.
+     * The fiction title is always sent (no toggle); the four fields
+     * here are the per-grounding-level opt-ins.
+     *
+     * Token cost ramps fast on the bottom two: "entire chapter" is
+     * a few thousand tokens per turn; "entire book so far" can hit
+     * 50k+ tokens on long fictions, which is fine on Claude / OpenAI
+     * but blows past Ollama's default 8k context. The Settings UI
+     * surfaces a per-toggle estimate so users understand the cost.
+     */
+    val chatGrounding: UiChatGrounding = UiChatGrounding(),
+)
+
+/**
+ * Per-toggle grounding settings for the Q&A chat ViewModel
+ * ([in.jphe.storyvox.feature.chat.ChatViewModel.buildSystemPrompt]).
+ * Issue #212.
+ *
+ * Defaults match the pre-#212 behaviour: only the chapter title is
+ * included (when the user is actively listening to the same fiction);
+ * everything more expensive is opt-in.
+ */
+data class UiChatGrounding(
+    /** Pre-#212 default behaviour. Cheap (a few words). */
+    val includeChapterTitle: Boolean = true,
+    /** ~50 tokens. The exact sentence the listener is on right now. */
+    val includeCurrentSentence: Boolean = false,
+    /** ~2-5k tokens depending on chapter length. */
+    val includeEntireChapter: Boolean = false,
+    /** Chapter 1 → current sentence. 50k+ tokens on long fictions. */
+    val includeEntireBookSoFar: Boolean = false,
 )
 
 data class UiSettings(
@@ -695,6 +736,11 @@ interface SettingsRepositoryUi {
     suspend fun setBedrockRegion(region: String)
     suspend fun setBedrockModel(model: String)
     suspend fun setSendChapterTextEnabled(enabled: Boolean)
+    /** Issue #212 — chat grounding-level toggles. See [UiChatGrounding]. */
+    suspend fun setChatGroundChapterTitle(enabled: Boolean)
+    suspend fun setChatGroundCurrentSentence(enabled: Boolean)
+    suspend fun setChatGroundEntireChapter(enabled: Boolean)
+    suspend fun setChatGroundEntireBookSoFar(enabled: Boolean)
     suspend fun acknowledgeAiPrivacy()
     /** Wipe all AI configuration — provider/keys/URLs. */
     suspend fun resetAiSettings()

--- a/feature/src/main/kotlin/in/jphe/storyvox/feature/chat/ChatViewModel.kt
+++ b/feature/src/main/kotlin/in/jphe/storyvox/feature/chat/ChatViewModel.kt
@@ -7,6 +7,8 @@ import androidx.lifecycle.viewModelScope
 import dagger.hilt.android.lifecycle.HiltViewModel
 import `in`.jphe.storyvox.feature.api.FictionRepositoryUi
 import `in`.jphe.storyvox.feature.api.PlaybackControllerUi
+import `in`.jphe.storyvox.feature.api.SettingsRepositoryUi
+import `in`.jphe.storyvox.feature.api.UiChatGrounding
 import `in`.jphe.storyvox.llm.FeatureKind
 import `in`.jphe.storyvox.llm.LlmConfig
 import `in`.jphe.storyvox.llm.LlmError
@@ -104,6 +106,7 @@ class ChatViewModel @Inject constructor(
     private val fictionRepo: FictionRepositoryUi,
     private val playback: PlaybackControllerUi,
     private val configFlow: Flow<LlmConfig>,
+    private val settingsRepo: SettingsRepositoryUi,
     private val savedState: SavedStateHandle,
 ) : ViewModel() {
 
@@ -185,6 +188,11 @@ class ChatViewModel @Inject constructor(
             }
 
             ensureSession(cfg, provider)
+            // Issue #212 — rebuild the system prompt from the live
+            // grounding settings before every send. Lets the user
+            // flip a toggle and have the next reply use the new
+            // context level immediately, without restarting the chat.
+            sessionRepo.updateSystemPrompt(sessionId, buildSystemPrompt())
 
             val buf = StringBuilder()
             _streaming.value = ""
@@ -232,38 +240,112 @@ class ChatViewModel @Inject constructor(
     }
 
     /**
-     * Build the librarian system prompt. Pulls the live playback
-     * state to learn what chapter the user is on right now — if they
-     * happen to be reading the same fiction this chat is about, we
-     * ground the AI in the chapter title. If not (chat opened from
-     * the fiction detail screen, no playback), we ground in the
-     * fiction itself only.
+     * Build the librarian system prompt. The fiction title is always
+     * included — it's the bare minimum context. Everything else is
+     * gated by user-controlled grounding toggles in Settings → AI
+     * (issue #212): chapter title, current sentence, entire chapter,
+     * and entire-book-so-far. Token cost ramps fast on the bottom
+     * two; users opt in based on their provider's context window.
+     *
+     * Grounding only injects book content when the user is actively
+     * listening to *this* fiction. A chat opened from the fiction
+     * detail screen with no playback active falls back to the
+     * title-only prompt — there's no "current sentence" without
+     * playback state, and grabbing chapter 1 unprompted would
+     * surprise the user.
      *
      * Spoiler-prevention is a soft hint, not a hard wall: the AI
-     * doesn't actually have future-chapter text in context anyway,
-     * but the prompt makes its limits explicit so users get a
-     * coherent "I can only speak to what I've read with you" voice.
+     * doesn't have future-chapter text in context anyway, but the
+     * prompt makes its limits explicit so users get a coherent
+     * "I can only speak to what I've read with you" voice.
      */
     private suspend fun buildSystemPrompt(): String {
         val fictionTitle = fictionRepo.fictionById(fictionId).first()?.title
             ?: "this fiction"
+        val grounding = settingsRepo.settings.first().ai.chatGrounding
         val pb = playback.state.first()
         val onSameFiction = pb.fictionId == fictionId
-        val chapterClause = if (onSameFiction && pb.chapterTitle.isNotBlank()) {
-            "The reader is currently on \"${pb.chapterTitle}\". "
-        } else {
-            ""
-        }
+
         return buildString {
             append("You are a careful, literate librarian-companion ")
             append("to a reader of \"")
             append(fictionTitle)
             append("\". ")
-            append(chapterClause)
+
+            if (onSameFiction) {
+                appendGroundingClauses(grounding, pb)
+            }
+
             append("Answer questions about plot, characters, pacing, ")
             append("and writing craft. Quote sparingly. Don't invent ")
             append("details. Don't spoil future chapters — speak only ")
             append("to what the reader has likely read so far.")
+        }
+    }
+
+    /**
+     * Append per-toggle context clauses. Order matters — coarse to
+     * fine: book-so-far → entire chapter → current sentence →
+     * chapter title. Models tend to weight later context more, so
+     * the most-precise "what they're on right now" clause goes last.
+     *
+     * Each section is delimited with markdown-ish headers so the
+     * model can tell prefixes apart from the text it's grounding in.
+     */
+    private suspend fun StringBuilder.appendGroundingClauses(
+        grounding: UiChatGrounding,
+        pb: `in`.jphe.storyvox.feature.api.UiPlaybackState,
+    ) {
+        val chapterId = pb.chapterId
+
+        if (grounding.includeEntireBookSoFar && chapterId != null) {
+            val all = fictionRepo.chaptersFor(fictionId).first()
+            val currentIdx = all.indexOfFirst { it.id == chapterId }
+            if (currentIdx >= 0) {
+                val priorChapters = all.subList(0, currentIdx)
+                val priorTexts = priorChapters.mapNotNull { ch ->
+                    fictionRepo.chapterTextById(ch.id)?.let { text -> ch.title to text }
+                }
+                if (priorTexts.isNotEmpty()) {
+                    append("\n\n## Story so far (chapters before the current one)\n\n")
+                    priorTexts.forEach { (title, text) ->
+                        append("### ").append(title).append("\n")
+                        append(text).append("\n\n")
+                    }
+                }
+            }
+        }
+
+        if (grounding.includeEntireChapter && chapterId != null) {
+            val chapterText = fictionRepo.chapterTextById(chapterId)
+            if (!chapterText.isNullOrBlank()) {
+                append("\n\n## Current chapter (\"")
+                    .append(pb.chapterTitle)
+                    .append("\") in full\n\n")
+                append(chapterText).append("\n\n")
+            }
+        }
+
+        if (grounding.includeCurrentSentence) {
+            // chapterText flow exposes the live chapter body the
+            // playback layer is reading. Slicing with sentenceStart..
+            // sentenceEnd matches the highlighted sentence in the
+            // reader UI, so "current sentence" means exactly what the
+            // user sees on-screen.
+            val text = playback.chapterText.first()
+            val end = pb.sentenceEnd.coerceAtMost(text.length)
+            val start = pb.sentenceStart.coerceIn(0, end)
+            if (end > start) {
+                append("The reader is currently on this sentence: \"")
+                append(text.substring(start, end).trim())
+                append("\". ")
+            }
+        }
+
+        if (grounding.includeChapterTitle && pb.chapterTitle.isNotBlank()) {
+            append("The reader is in the chapter \"")
+            append(pb.chapterTitle)
+            append("\". ")
         }
     }
 

--- a/feature/src/main/kotlin/in/jphe/storyvox/feature/settings/SettingsScreen.kt
+++ b/feature/src/main/kotlin/in/jphe/storyvox/feature/settings/SettingsScreen.kt
@@ -65,6 +65,7 @@ import `in`.jphe.storyvox.feature.api.PUNCTUATION_PAUSE_OFF_MULTIPLIER
 import `in`.jphe.storyvox.feature.api.PalaceProbeResult
 import `in`.jphe.storyvox.feature.api.ThemeOverride
 import `in`.jphe.storyvox.feature.api.UiAiSettings
+import `in`.jphe.storyvox.feature.api.UiChatGrounding
 import `in`.jphe.storyvox.feature.api.UiGitHubAuthState
 import `in`.jphe.storyvox.feature.api.UiLlmProvider
 import `in`.jphe.storyvox.feature.api.UiPalaceConfig
@@ -243,6 +244,10 @@ fun SettingsScreen(
             onSetBedrockRegion = viewModel::setBedrockRegion,
             onSetBedrockModel = viewModel::setBedrockModel,
             onSetSendChapterText = viewModel::setSendChapterTextEnabled,
+            onSetChatGroundChapterTitle = viewModel::setChatGroundChapterTitle,
+            onSetChatGroundCurrentSentence = viewModel::setChatGroundCurrentSentence,
+            onSetChatGroundEntireChapter = viewModel::setChatGroundEntireChapter,
+            onSetChatGroundEntireBookSoFar = viewModel::setChatGroundEntireBookSoFar,
             onTestConnection = viewModel::testAiConnection,
             onClearProbeOutcome = viewModel::clearProbeOutcome,
             onResetAi = viewModel::resetAiSettings,
@@ -1015,6 +1020,10 @@ private fun AiSection(
     onSetBedrockRegion: (String) -> Unit,
     onSetBedrockModel: (String) -> Unit,
     onSetSendChapterText: (Boolean) -> Unit,
+    onSetChatGroundChapterTitle: (Boolean) -> Unit,
+    onSetChatGroundCurrentSentence: (Boolean) -> Unit,
+    onSetChatGroundEntireChapter: (Boolean) -> Unit,
+    onSetChatGroundEntireBookSoFar: (Boolean) -> Unit,
     onTestConnection: (UiLlmProvider) -> Unit,
     onClearProbeOutcome: () -> Unit,
     onResetAi: () -> Unit,
@@ -1140,12 +1149,89 @@ private fun AiSection(
             checked = ai.sendChapterTextEnabled,
             onCheckedChange = onSetSendChapterText,
         )
+        // Issue #212 — chat grounding-level toggles. The fiction title
+        // is always sent (no toggle); each row below adds a layer of
+        // context to the chat ViewModel's system prompt. Token estimates
+        // assume the rough chars / 4 ≈ tokens convention.
+        ChatGroundingSubsection(
+            grounding = ai.chatGrounding,
+            enabled = ai.sendChapterTextEnabled,
+            onSetChapterTitle = onSetChatGroundChapterTitle,
+            onSetCurrentSentence = onSetChatGroundCurrentSentence,
+            onSetEntireChapter = onSetChatGroundEntireChapter,
+            onSetEntireBookSoFar = onSetChatGroundEntireBookSoFar,
+        )
         BrassButton(
             label = "Forget all AI settings",
             onClick = onResetAi,
             variant = BrassButtonVariant.Text,
         )
     }
+    }
+}
+
+/**
+ * Issue #212 — chat grounding-level subsection. Four switches that
+ * decide what context the chat ViewModel injects into its system
+ * prompt. Disabled (greyed out) when the parent "Allow chapter text
+ * to AI" toggle is off, since none of these can ship to the model
+ * with that gate closed.
+ *
+ * Subtitles include rough token-cost estimates so a user weighing
+ * the privacy / latency / quota trade-off can decide. Estimates
+ * assume the standard chars / 4 ≈ tokens English text rule.
+ */
+@Composable
+private fun ChatGroundingSubsection(
+    grounding: UiChatGrounding,
+    enabled: Boolean,
+    onSetChapterTitle: (Boolean) -> Unit,
+    onSetCurrentSentence: (Boolean) -> Unit,
+    onSetEntireChapter: (Boolean) -> Unit,
+    onSetEntireBookSoFar: (Boolean) -> Unit,
+) {
+    val spacing = LocalSpacing.current
+    Column(verticalArrangement = Arrangement.spacedBy(spacing.xs)) {
+        Text(
+            "Chat grounding — what context the chat AI sees",
+            style = MaterialTheme.typography.titleSmall,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+        )
+        Text(
+            "The fiction title is always included. Each layer below adds " +
+                "more text to every chat turn — better answers, more tokens.",
+            style = MaterialTheme.typography.bodySmall,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+        )
+        SettingsSwitchRow(
+            title = "Include current chapter title",
+            subtitle = "~10 tokens. \"The reader is currently on …\" prefix.",
+            checked = grounding.includeChapterTitle,
+            onCheckedChange = onSetChapterTitle,
+            enabled = enabled,
+        )
+        SettingsSwitchRow(
+            title = "Include current sentence",
+            subtitle = "~50 tokens. The exact sentence the listener is on.",
+            checked = grounding.includeCurrentSentence,
+            onCheckedChange = onSetCurrentSentence,
+            enabled = enabled,
+        )
+        SettingsSwitchRow(
+            title = "Include entire current chapter",
+            subtitle = "~2 000–5 000 tokens. Full chapter text in every turn.",
+            checked = grounding.includeEntireChapter,
+            onCheckedChange = onSetEntireChapter,
+            enabled = enabled,
+        )
+        SettingsSwitchRow(
+            title = "Include entire book so far",
+            subtitle = "50 000+ tokens on long fictions. Chapter 1 → current sentence. " +
+                "Cloud providers (Claude, OpenAI) only — local models will run out of context.",
+            checked = grounding.includeEntireBookSoFar,
+            onCheckedChange = onSetEntireBookSoFar,
+            enabled = enabled,
+        )
     }
 }
 

--- a/feature/src/main/kotlin/in/jphe/storyvox/feature/settings/SettingsViewModel.kt
+++ b/feature/src/main/kotlin/in/jphe/storyvox/feature/settings/SettingsViewModel.kt
@@ -159,6 +159,15 @@ class SettingsViewModel @Inject constructor(
     fun setBedrockModel(model: String) = viewModelScope.launch { repo.setBedrockModel(model) }
     fun setSendChapterTextEnabled(enabled: Boolean) =
         viewModelScope.launch { repo.setSendChapterTextEnabled(enabled) }
+    // Issue #212 — chat grounding-level toggles.
+    fun setChatGroundChapterTitle(enabled: Boolean) =
+        viewModelScope.launch { repo.setChatGroundChapterTitle(enabled) }
+    fun setChatGroundCurrentSentence(enabled: Boolean) =
+        viewModelScope.launch { repo.setChatGroundCurrentSentence(enabled) }
+    fun setChatGroundEntireChapter(enabled: Boolean) =
+        viewModelScope.launch { repo.setChatGroundEntireChapter(enabled) }
+    fun setChatGroundEntireBookSoFar(enabled: Boolean) =
+        viewModelScope.launch { repo.setChatGroundEntireBookSoFar(enabled) }
     fun acknowledgeAiPrivacy() = viewModelScope.launch { repo.acknowledgeAiPrivacy() }
     fun resetAiSettings() = viewModelScope.launch {
         repo.resetAiSettings()

--- a/feature/src/test/kotlin/in/jphe/storyvox/feature/chat/ChatViewModelTest.kt
+++ b/feature/src/test/kotlin/in/jphe/storyvox/feature/chat/ChatViewModelTest.kt
@@ -7,8 +7,15 @@ import `in`.jphe.storyvox.data.db.entity.LlmSession
 import `in`.jphe.storyvox.data.db.entity.LlmStoredMessage
 import `in`.jphe.storyvox.feature.api.DownloadMode
 import `in`.jphe.storyvox.feature.api.FictionRepositoryUi
+import `in`.jphe.storyvox.feature.api.PalaceProbeResult
 import `in`.jphe.storyvox.feature.api.PlaybackControllerUi
+import `in`.jphe.storyvox.feature.api.SettingsRepositoryUi
+import `in`.jphe.storyvox.feature.api.ThemeOverride
 import `in`.jphe.storyvox.feature.api.UiAddByUrlResult
+import `in`.jphe.storyvox.feature.api.UiAiSettings
+import `in`.jphe.storyvox.feature.api.UiChatGrounding
+import `in`.jphe.storyvox.feature.api.UiLlmProvider
+import `in`.jphe.storyvox.feature.api.UiSettings
 import `in`.jphe.storyvox.feature.api.UiChapter
 import `in`.jphe.storyvox.feature.api.UiFiction
 import `in`.jphe.storyvox.feature.api.UiFollow
@@ -76,6 +83,7 @@ class ChatViewModelTest {
             fictionRepo = FakeFictionRepo(fictionId, fictionTitle),
             playback = FakePlayback(playbackState),
             configFlow = flowOf(config),
+            settingsRepo = FakeSettingsRepo(),
             savedState = SavedStateHandle(mapOf("fictionId" to fictionId)),
         )
         return vm to session
@@ -258,6 +266,10 @@ private class FakeSessionRepo(
         return explicitId ?: "fake-session"
     }
 
+    override suspend fun updateSystemPrompt(sessionId: String, systemPrompt: String?) {
+        lastSystemPrompt = systemPrompt
+    }
+
     override fun chat(sessionId: String, userMessage: String): Flow<String> = flow {
         chatCalls += sessionId to userMessage
         // Persist the user turn synchronously, mirroring real repo
@@ -280,6 +292,8 @@ private object ThrowingSessionDao : LlmSessionDao {
     override fun observeAll(): Flow<List<LlmSession>> = error("not used in fake")
     override suspend fun get(id: String): LlmSession? = error("not used in fake")
     override suspend fun touchLastUsed(id: String, ts: Long) = error("not used in fake")
+    override suspend fun updateSystemPrompt(id: String, systemPrompt: String?) =
+        error("not used in fake")
     override suspend fun delete(id: String) = error("not used in fake")
     override suspend fun deleteAll() = error("not used in fake")
 }
@@ -414,6 +428,7 @@ private class FakeFictionRepo(
         flowOf(if (id == fictionId && title != null) uiFictionOf(id, title) else null)
     override fun fictionLoadError(id: String): Flow<String?> = flowOf(null)
     override fun chaptersFor(fictionId: String): Flow<List<UiChapter>> = flowOf(emptyList())
+    override suspend fun chapterTextById(chapterId: String): String? = null
     override suspend fun setDownloadMode(fictionId: String, mode: DownloadMode) = Unit
     override suspend fun follow(fictionId: String, follow: Boolean) = Unit
     override suspend fun markAllCaughtUp() = Unit
@@ -453,4 +468,69 @@ private class FakePlayback(initial: UiPlaybackState) : PlaybackControllerUi {
     override fun cancelSleepTimer() = Unit
     override suspend fun speakText(text: String) = Unit
     override fun stopSpeaking() = Unit
+}
+
+/** Minimal settings stub — only the [settings] flow is read by
+ *  ChatViewModel, but [SettingsRepositoryUi] is a wide interface so
+ *  every method must be implemented; setters are no-ops. */
+private class FakeSettingsRepo(
+    chatGrounding: UiChatGrounding = UiChatGrounding(),
+) : SettingsRepositoryUi {
+    private val ai = UiAiSettings(chatGrounding = chatGrounding)
+    override val settings: Flow<UiSettings> = flowOf(
+        UiSettings(
+            ttsEngine = "VoxSherpa",
+            defaultVoiceId = null,
+            defaultSpeed = 1f,
+            defaultPitch = 1f,
+            themeOverride = ThemeOverride.System,
+            downloadOnWifiOnly = true,
+            pollIntervalHours = 6,
+            isSignedIn = false,
+            ai = ai,
+        ),
+    )
+    override suspend fun setTheme(override: ThemeOverride) = Unit
+    override suspend fun setDefaultSpeed(speed: Float) = Unit
+    override suspend fun setDefaultPitch(pitch: Float) = Unit
+    override suspend fun setDefaultVoice(voiceId: String?) = Unit
+    override suspend fun setDownloadOnWifiOnly(enabled: Boolean) = Unit
+    override suspend fun setPollIntervalHours(hours: Int) = Unit
+    override suspend fun setPunctuationPauseMultiplier(multiplier: Float) = Unit
+    override suspend fun setPlaybackBufferChunks(chunks: Int) = Unit
+    override suspend fun setWarmupWait(enabled: Boolean) = Unit
+    override suspend fun setCatchupPause(enabled: Boolean) = Unit
+    override suspend fun setVoiceSteady(enabled: Boolean) = Unit
+    override suspend fun signIn() = Unit
+    override suspend fun signOut() = Unit
+    override suspend fun setPalaceHost(host: String) = Unit
+    override suspend fun setPalaceApiKey(apiKey: String) = Unit
+    override suspend fun clearPalaceConfig() = Unit
+    override suspend fun testPalaceConnection(): PalaceProbeResult = PalaceProbeResult.NotConfigured
+    override suspend fun setAiProvider(provider: UiLlmProvider?) = Unit
+    override suspend fun setClaudeApiKey(key: String?) = Unit
+    override suspend fun setClaudeModel(model: String) = Unit
+    override suspend fun setOpenAiApiKey(key: String?) = Unit
+    override suspend fun setOpenAiModel(model: String) = Unit
+    override suspend fun setOllamaBaseUrl(url: String) = Unit
+    override suspend fun setOllamaModel(model: String) = Unit
+    override suspend fun setVertexApiKey(key: String?) = Unit
+    override suspend fun setVertexModel(model: String) = Unit
+    override suspend fun setFoundryApiKey(key: String?) = Unit
+    override suspend fun setFoundryEndpoint(url: String) = Unit
+    override suspend fun setFoundryDeployment(deployment: String) = Unit
+    override suspend fun setFoundryServerless(serverless: Boolean) = Unit
+    override suspend fun setBedrockAccessKey(key: String?) = Unit
+    override suspend fun setBedrockSecretKey(key: String?) = Unit
+    override suspend fun setBedrockRegion(region: String) = Unit
+    override suspend fun setBedrockModel(model: String) = Unit
+    override suspend fun setSendChapterTextEnabled(enabled: Boolean) = Unit
+    override suspend fun setChatGroundChapterTitle(enabled: Boolean) = Unit
+    override suspend fun setChatGroundCurrentSentence(enabled: Boolean) = Unit
+    override suspend fun setChatGroundEntireChapter(enabled: Boolean) = Unit
+    override suspend fun setChatGroundEntireBookSoFar(enabled: Boolean) = Unit
+    override suspend fun acknowledgeAiPrivacy() = Unit
+    override suspend fun resetAiSettings() = Unit
+    override suspend fun signOutGitHub() = Unit
+    override suspend fun setGitHubPrivateReposEnabled(enabled: Boolean) = Unit
 }

--- a/feature/src/test/kotlin/in/jphe/storyvox/feature/settings/SettingsViewModelBufferTest.kt
+++ b/feature/src/test/kotlin/in/jphe/storyvox/feature/settings/SettingsViewModelBufferTest.kt
@@ -167,6 +167,10 @@ class SettingsViewModelBufferTest {
         override suspend fun setBedrockRegion(region: String) = Unit
         override suspend fun setBedrockModel(model: String) = Unit
         override suspend fun setSendChapterTextEnabled(enabled: Boolean) = Unit
+        override suspend fun setChatGroundChapterTitle(enabled: Boolean) = Unit
+        override suspend fun setChatGroundCurrentSentence(enabled: Boolean) = Unit
+        override suspend fun setChatGroundEntireChapter(enabled: Boolean) = Unit
+        override suspend fun setChatGroundEntireBookSoFar(enabled: Boolean) = Unit
         override suspend fun acknowledgeAiPrivacy() = Unit
         override suspend fun resetAiSettings() = Unit
         override suspend fun signOutGitHub() = Unit

--- a/feature/src/test/kotlin/in/jphe/storyvox/feature/settings/SettingsViewModelModesTest.kt
+++ b/feature/src/test/kotlin/in/jphe/storyvox/feature/settings/SettingsViewModelModesTest.kt
@@ -242,6 +242,10 @@ class SettingsViewModelModesTest {
         override suspend fun setBedrockRegion(region: String) = Unit
         override suspend fun setBedrockModel(model: String) = Unit
         override suspend fun setSendChapterTextEnabled(enabled: Boolean) = Unit
+        override suspend fun setChatGroundChapterTitle(enabled: Boolean) = Unit
+        override suspend fun setChatGroundCurrentSentence(enabled: Boolean) = Unit
+        override suspend fun setChatGroundEntireChapter(enabled: Boolean) = Unit
+        override suspend fun setChatGroundEntireBookSoFar(enabled: Boolean) = Unit
         override suspend fun acknowledgeAiPrivacy() = Unit
         override suspend fun resetAiSettings() = Unit
         override suspend fun signOutGitHub() = Unit

--- a/feature/src/test/kotlin/in/jphe/storyvox/feature/settings/SettingsViewModelPunctuationPauseTest.kt
+++ b/feature/src/test/kotlin/in/jphe/storyvox/feature/settings/SettingsViewModelPunctuationPauseTest.kt
@@ -180,6 +180,10 @@ class SettingsViewModelPunctuationPauseTest {
         override suspend fun setBedrockRegion(region: String) = Unit
         override suspend fun setBedrockModel(model: String) = Unit
         override suspend fun setSendChapterTextEnabled(enabled: Boolean) = Unit
+        override suspend fun setChatGroundChapterTitle(enabled: Boolean) = Unit
+        override suspend fun setChatGroundCurrentSentence(enabled: Boolean) = Unit
+        override suspend fun setChatGroundEntireChapter(enabled: Boolean) = Unit
+        override suspend fun setChatGroundEntireBookSoFar(enabled: Boolean) = Unit
         override suspend fun acknowledgeAiPrivacy() = Unit
         override suspend fun resetAiSettings() = Unit
         override suspend fun signOutGitHub() = Unit


### PR DESCRIPTION
Closes #212.

## Summary

- Adds four Settings → AI toggles for chat system-prompt grounding: chapter title (default on), current sentence, entire chapter, entire book so far. Fiction title is always sent.
- Each toggle subtitle shows a token-cost estimate so users can weigh context vs. their provider's window.
- `ChatViewModel.buildSystemPrompt` reads live grounding settings + playback state on every send; the persisted session prompt is refreshed via a new `LlmSessionDao.updateSystemPrompt` query so flipping a toggle takes effect on the next reply without restarting the chat.
- `FictionRepositoryUi.chapterTextById` exposes downloaded chapter bodies to the chat layer for "entire chapter" / "entire book so far" grounding.

## Files

- `feature/.../api/UiContracts.kt` — new `UiChatGrounding` data class composed into `UiAiSettings`; 4 setters added to `SettingsRepositoryUi`; `chapterTextById` added to `FictionRepositoryUi`.
- `app/.../data/SettingsRepositoryUiImpl.kt` — DataStore keys + setters + reset wiring.
- `app/.../di/AppBindings.kt` — `RealFictionRepositoryUi` now takes `ChapterRepository` and exposes plain-text bodies via `getChapter(id)`.
- `feature/.../settings/SettingsScreen.kt` — new `ChatGroundingSubsection` composable with 4 `SettingsSwitchRow` rows and token-cost subtitles. Greyed out when "Allow chapter text to AI" is off.
- `feature/.../chat/ChatViewModel.kt` — `buildSystemPrompt` rewritten to honor toggles; called per-send via `sessionRepo.updateSystemPrompt`.
- `core-data/.../dao/LlmSessionDao.kt` + `core-llm/.../LlmSessionRepository.kt` — narrow `updateSystemPrompt` path that doesn't clobber createdAt/lastUsedAt.
- Tests: 4 fakes updated with the 4 new setters; `ChatViewModelTest`'s `FakeSessionRepo` now overrides `updateSystemPrompt` (which is what writes `lastSystemPrompt` for the existing system-prompt assertions).

## Test plan

- [x] `./gradlew :feature:compileDebugKotlin :app:compileDebugKotlin` — green.
- [x] `./gradlew :feature:testDebugUnitTest :app:testDebugUnitTest :core-llm:testDebugUnitTest :core-data:testDebugUnitTest` — green; existing `system prompt includes fiction title and current chapter` and `omits chapter clause when listening to a different fiction` tests still pass against the new `updateSystemPrompt` path.
- [x] `./gradlew :app:assembleDebug` — green.
- [x] Installed on R83W80CAFZB and foregrounded; Settings → AI shows the new "Chat grounding" subsection with the 4 toggles disabled when "Allow chapter text to AI" is off.

## Notes for reviewers

- Default behaviour is preserved: only `includeChapterTitle` is on by default; the on-same-fiction chapter-clause path matches the pre-#212 prompt shape (just rendered as `The reader is in the chapter "X".` instead of `The reader is currently on "X".` to match the new toggle's wording).
- The new `LlmSessionDao.updateSystemPrompt` is the cheapest path I could find to refresh the prompt per-turn without re-upserting the row (which would clobber createdAt). Open to a different shape if you'd rather pass the prompt fresh through `chat()` instead.
- Possible conflict with #181 (teams-oauth) on `UiAiSettings` — purely additive on my side, but the orchestrator may need to rebase one of us.