### PR TITLE
feat(reader): read chapter recap aloud (#189)

### DIFF
--- a/app/src/main/kotlin/in/jphe/storyvox/di/AppBindings.kt
+++ b/app/src/main/kotlin/in/jphe/storyvox/di/AppBindings.kt
@@ -47,12 +47,14 @@ import `in`.jphe.storyvox.feature.api.UiChapter
 import `in`.jphe.storyvox.feature.api.UiFiction
 import `in`.jphe.storyvox.feature.api.UiFollow
 import `in`.jphe.storyvox.feature.api.UiPlaybackState
+import `in`.jphe.storyvox.feature.api.UiRecapPlaybackState
 import `in`.jphe.storyvox.feature.api.UiSleepTimerMode
 import `in`.jphe.storyvox.feature.api.VoiceProviderUi
 import `in`.jphe.storyvox.feature.browse.RealBrowsePaginator
 import `in`.jphe.storyvox.feature.browse.toUiFiction
 import `in`.jphe.storyvox.playback.PlaybackController
 import `in`.jphe.storyvox.playback.PlaybackState
+import `in`.jphe.storyvox.playback.tts.RecapPlaybackState
 import `in`.jphe.storyvox.playback.SPEED_BASELINE_CHARS_PER_SECOND
 import `in`.jphe.storyvox.playback.SleepTimerMode
 import `in`.jphe.storyvox.playback.StoryvoxPlaybackService
@@ -560,6 +562,26 @@ internal class RealPlaybackControllerUi(
     }
 
     override fun cancelSleepTimer() = controller.cancelSleepTimer()
+
+    /** Issue #189 — recap-aloud TTS pipeline state, mapped from
+     *  core-playback's RecapPlaybackState onto the feature-side
+     *  [UiRecapPlaybackState]. Distinct flow from [state] so the chapter
+     *  playback observers don't recompose on every recap toggle. */
+    override val recapPlayback: Flow<UiRecapPlaybackState> = controller.recapPlayback
+        .map {
+            when (it) {
+                RecapPlaybackState.Idle -> UiRecapPlaybackState.Idle
+                RecapPlaybackState.Speaking -> UiRecapPlaybackState.Speaking
+            }
+        }
+
+    override suspend fun speakText(text: String) {
+        controller.speakText(text)
+    }
+
+    override fun stopSpeaking() {
+        controller.stopSpeaking()
+    }
 
     override fun startListening(fictionId: String, chapterId: String, charOffset: Int) {
         // Start the service synchronously while we still have the click's foreground

--- a/app/src/test/kotlin/in/jphe/storyvox/di/RealPlaybackControllerUiTest.kt
+++ b/app/src/test/kotlin/in/jphe/storyvox/di/RealPlaybackControllerUiTest.kt
@@ -13,6 +13,7 @@ import `in`.jphe.storyvox.feature.api.ThemeOverride
 import `in`.jphe.storyvox.feature.api.UiSettings
 import `in`.jphe.storyvox.playback.PlaybackController
 import `in`.jphe.storyvox.playback.PlaybackState
+import `in`.jphe.storyvox.playback.tts.RecapPlaybackState
 import `in`.jphe.storyvox.playback.PlaybackUiEvent
 import `in`.jphe.storyvox.playback.SleepTimerMode
 import kotlinx.coroutines.ExperimentalCoroutinesApi
@@ -165,6 +166,8 @@ class RealPlaybackControllerUiTest {
         override val state: StateFlow<PlaybackState> = MutableStateFlow(PlaybackState()).asStateFlow()
         override val events: SharedFlow<PlaybackUiEvent> =
             MutableSharedFlow<PlaybackUiEvent>().asSharedFlow()
+        override val recapPlayback: StateFlow<RecapPlaybackState> =
+            MutableStateFlow(RecapPlaybackState.Idle).asStateFlow()
 
         override suspend fun play(fictionId: String, chapterId: String, charOffset: Int) = Unit
         override fun pause() = Unit
@@ -187,6 +190,8 @@ class RealPlaybackControllerUiTest {
         override fun startSleepTimer(mode: SleepTimerMode) = Unit
         override fun cancelSleepTimer() = Unit
         override fun toggleSleepTimer() = Unit
+        override suspend fun speakText(text: String) = Unit
+        override fun stopSpeaking() = Unit
     }
 
     /**

--- a/core-playback/src/main/kotlin/in/jphe/storyvox/playback/PlaybackController.kt
+++ b/core-playback/src/main/kotlin/in/jphe/storyvox/playback/PlaybackController.kt
@@ -1,6 +1,7 @@
 package `in`.jphe.storyvox.playback
 
 import `in`.jphe.storyvox.playback.tts.EnginePlayer
+import `in`.jphe.storyvox.playback.tts.RecapPlaybackState
 import `in`.jphe.storyvox.playback.tts.SentenceChunker
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
@@ -18,6 +19,11 @@ import javax.inject.Singleton
 interface PlaybackController {
     val state: StateFlow<PlaybackState>
     val events: SharedFlow<PlaybackUiEvent>
+
+    /** Issue #189 — recap-aloud TTS pipeline state. Idle until [speakText]
+     *  is called; flips to Speaking while the one-shot utterance is playing,
+     *  back to Idle when it finishes naturally or [stopSpeaking] is called. */
+    val recapPlayback: StateFlow<RecapPlaybackState>
 
     suspend fun play(fictionId: String, chapterId: String, charOffset: Int = 0)
     fun pause()
@@ -39,6 +45,16 @@ interface PlaybackController {
     fun startSleepTimer(mode: SleepTimerMode)
     fun cancelSleepTimer()
     fun toggleSleepTimer()
+
+    /** Issue #189 — synthesize and play [text] as a one-shot utterance via
+     *  the active voice. Used by the chapter-recap modal to read the
+     *  AI-generated recap aloud. The caller is responsible for pausing
+     *  active fiction playback before calling — the engine is shared and
+     *  overlapping audio would muddy the listener experience. */
+    suspend fun speakText(text: String)
+
+    /** Issue #189 — cancel an in-flight recap-aloud utterance. Idempotent. */
+    fun stopSpeaking()
 }
 
 /**
@@ -69,6 +85,12 @@ class DefaultPlaybackController @Inject constructor(
 
     private var player: EnginePlayer? = null
 
+    /** Issue #189 — mirror of the bound player's recap-aloud state. Idle
+     *  before any player binds (and between bindings); reflects the
+     *  active player's flow while bound. */
+    private val _recapPlayback = MutableStateFlow(RecapPlaybackState.Idle)
+    override val recapPlayback: StateFlow<RecapPlaybackState> = _recapPlayback.asStateFlow()
+
     init {
         scope.launch {
             sleepTimer.remainingMs.collect { remaining ->
@@ -84,10 +106,14 @@ class DefaultPlaybackController @Inject constructor(
                 _state.value = update.copy(sleepTimerRemainingMs = sleepTimer.remainingMs.value)
             }
         }
+        scope.launch {
+            p.recapPlayback.collect { _recapPlayback.value = it }
+        }
     }
 
     fun unbindPlayer() {
         player = null
+        _recapPlayback.value = RecapPlaybackState.Idle
     }
 
     override suspend fun play(fictionId: String, chapterId: String, charOffset: Int) {
@@ -150,6 +176,14 @@ class DefaultPlaybackController @Inject constructor(
     override fun toggleSleepTimer() {
         if (state.value.sleepTimerRemainingMs != null) cancelSleepTimer()
         else startSleepTimer(SleepTimerMode.Duration(15))
+    }
+
+    override suspend fun speakText(text: String) {
+        player?.speak(text)
+    }
+
+    override fun stopSpeaking() {
+        player?.stopSpeaking()
     }
 
     internal fun emitEvent(event: PlaybackUiEvent) {

--- a/core-playback/src/main/kotlin/in/jphe/storyvox/playback/tts/EnginePlayer.kt
+++ b/core-playback/src/main/kotlin/in/jphe/storyvox/playback/tts/EnginePlayer.kt
@@ -93,6 +93,14 @@ import kotlinx.coroutines.withContext
  * Pause/seek tear down the AudioTrack and re-create on resume; cheaper than
  * trying to keep state coherent across a `pause()` call.
  */
+/**
+ * Issue #189 — playback state for the one-shot recap-aloud TTS pipeline.
+ * Distinct from [PlaybackState] because the recap is a transient utterance
+ * with its own AudioTrack; conflating the two would force every chapter
+ * playback observer to also reason about recap state.
+ */
+enum class RecapPlaybackState { Idle, Speaking }
+
 @UnstableApi
 class EnginePlayer @AssistedInject constructor(
     @Assisted private val context: Context,
@@ -401,6 +409,26 @@ class EnginePlayer @AssistedInject constructor(
 
     private val _uiEvents = MutableSharedFlow<PlaybackUiEvent>(extraBufferCapacity = 4)
     val uiEvents: SharedFlow<PlaybackUiEvent> = _uiEvents.asSharedFlow()
+
+    /** Issue #189 — one-shot recap-aloud TTS pipeline state. Distinct from
+     *  the chapter pipeline because the recap is a transient utterance, not
+     *  a chapter: it doesn't update charOffset, doesn't bind to a fiction
+     *  id, doesn't persist a position. The two pipelines share the engine
+     *  (via [engineMutex]) but have independent AudioTrack + consumer-thread
+     *  state. The chapter pipeline must be paused before [speak] starts —
+     *  the caller does that, this state is purely for the recap UI's
+     *  play/pause toggle. */
+    private val _recapPlayback = MutableStateFlow(RecapPlaybackState.Idle)
+    val recapPlayback: StateFlow<RecapPlaybackState> = _recapPlayback.asStateFlow()
+
+    /** Recap-only AudioTrack. Lives independently from [audioTrack] so a
+     *  recap doesn't tear down chapter playback state. Released by the
+     *  recap consumer thread on its own finally block, matching the
+     *  chapter-pipeline shape (release-from-writer-thread, no JNI race). */
+    private var recapAudioTrack: AudioTrack? = null
+    private var recapPcmSource: PcmSource? = null
+    private var recapConsumerThread: Thread? = null
+    private val recapPipelineRunning = AtomicBoolean(false)
 
     override fun getState(): State {
         val s = _observableState.value
@@ -1209,8 +1237,194 @@ class EnginePlayer @AssistedInject constructor(
 
     fun releaseEngine() {
         kotlinx.coroutines.runBlocking { persistPosition() }
+        stopRecapPipeline()
         stopPlaybackPipeline()
         scope.cancel()
+    }
+
+    // ----- Issue #189: one-shot recap-aloud TTS -----
+
+    /**
+     * Issue #189 — synthesize and play [text] as a one-shot utterance via
+     * the active voice. Used by the chapter-recap modal to read the
+     * AI-generated recap aloud. Distinct from [loadAndPlay] in that:
+     *  - No fiction/chapter binding; doesn't move charOffset.
+     *  - Uses a dedicated [recapAudioTrack] + consumer thread; chapter
+     *    pipeline state is left untouched (chapter pause is the caller's
+     *    job — see ReaderViewModel.toggleRecapAloud).
+     *  - When playback ends naturally, [recapPlayback] flips to Idle. The
+     *    caller decides whether to auto-resume the fiction (we don't —
+     *    the UX is "fiction stays paused so the listener can absorb").
+     *
+     * Reuses [engineMutex] so the engine isn't entered twice — a recap
+     * starting while a chapter generator's JNI call is in flight will
+     * wait for it to complete (or for the caller's pause to tear it down).
+     *
+     * No-op if a voice can't be activated (returns silently; the UI will
+     * see [recapPlayback] never leaves Idle and can choose its own
+     * fallback). Existing recap playback is stopped before a new one
+     * starts.
+     */
+    suspend fun speak(text: String) {
+        if (text.isBlank()) return
+        stopRecapPipeline()
+        if (!ensureVoiceLoaded()) return
+        val recapSentences = chunker.chunk(text)
+        if (recapSentences.isEmpty()) return
+        startRecapPipeline(recapSentences)
+    }
+
+    /** Issue #189 — stop an in-flight recap utterance. Idempotent. */
+    fun stopSpeaking() {
+        stopRecapPipeline()
+    }
+
+    /**
+     * Issue #189 — extracted from [loadAndPlay]'s model-load path so
+     * [speak] can warm up the active voice without going through the
+     * chapter-binding flow. Returns true if a model is loaded and the
+     * engine is ready to generate; false if no active voice or load
+     * failed (caller renders the failure however it wants — for recap
+     * we silently bail and the UI's Read-aloud button stays in its
+     * pre-tap state).
+     *
+     * Skips the load if the same voice is already loaded — the chapter
+     * pipeline's [loadedVoiceId] is the canonical signal.
+     */
+    private suspend fun ensureVoiceLoaded(): Boolean {
+        val active = voiceManager.activeVoice.first() ?: return false
+        // Already loaded? Nothing to do — the engine is hot.
+        if (loadedVoiceId == active.id && activeEngineType != null) return true
+
+        val loadResult: String = withContext(Dispatchers.IO) {
+            engineMutex.withLock {
+                when (active.engineType) {
+                    EngineType.Piper -> {
+                        val voiceDir = voiceManager.voiceDirFor(active.id)
+                        val onnx = File(voiceDir, "model.onnx").absolutePath
+                        val tokens = File(voiceDir, "tokens.txt").absolutePath
+                        VoiceEngine.getInstance().loadModel(context, onnx, tokens)
+                            ?: "Error: load returned null"
+                    }
+                    is EngineType.Kokoro -> {
+                        val sharedDir = voiceManager.kokoroSharedDir()
+                        val onnx = File(sharedDir, "model.onnx").absolutePath
+                        val tokens = File(sharedDir, "tokens.txt").absolutePath
+                        val voicesBin = File(sharedDir, "voices.bin").absolutePath
+                        KokoroEngine.getInstance().setActiveSpeakerId(
+                            (active.engineType as EngineType.Kokoro).speakerId,
+                        )
+                        KokoroEngine.getInstance().loadModel(context, onnx, tokens, voicesBin)
+                            ?: "Error: load returned null"
+                    }
+                    is EngineType.Azure -> return@withContext "Error: Azure unsupported in recap"
+                }
+            }
+        }
+        if (loadResult != "Success") return false
+        activeEngineType = active.engineType
+        loadedVoiceId = active.id
+        return true
+    }
+
+    /**
+     * Issue #189 — recap-only producer/consumer pair. Lifted shape from
+     * [startPlaybackPipeline] but stripped to the essentials:
+     *  - No buffering UI (a 200-word recap is short; underrun is fine).
+     *  - No catchup-pause / sleep-timer plumbing.
+     *  - On natural end, flips [recapPlayback] back to Idle. No chapter
+     *    advance, no position persistence.
+     */
+    private fun startRecapPipeline(recapSentences: List<Sentence>) {
+        val engineType = activeEngineType
+        val sampleRate = when (engineType) {
+            is EngineType.Kokoro -> KokoroEngine.getInstance().sampleRate
+            else -> VoiceEngine.getInstance().sampleRate
+        }.takeIf { it > 0 } ?: DEFAULT_SAMPLE_RATE
+        val track = createAudioTrack(sampleRate)
+        recapAudioTrack = track
+
+        val source = EngineStreamingSource(
+            sentences = recapSentences,
+            startSentenceIndex = 0,
+            engine = activeVoiceEngineHandle(engineType),
+            speed = currentSpeed,
+            pitch = currentPitch,
+            engineMutex = engineMutex,
+            punctuationPauseMultiplier = currentPunctuationPauseMultiplier,
+            queueCapacity = cachedBufferChunks.coerceIn(2, 1500),
+            pronunciationDictApply = cachedPronunciationDict::apply,
+        )
+        recapPcmSource = source
+        recapPipelineRunning.set(true)
+        _recapPlayback.value = RecapPlaybackState.Speaking
+
+        recapConsumerThread = Thread({
+            AndroidProcess.setThreadPriority(AndroidProcess.THREAD_PRIORITY_URGENT_AUDIO)
+            var firstSentence = true
+            try {
+                runCatching { track.play() }
+                while (recapPipelineRunning.get()) {
+                    val chunk = try {
+                        runBlocking { source.nextChunk() }
+                    } catch (_: Throwable) {
+                        null
+                    } ?: break
+
+                    if (firstSentence) {
+                        runCatching { track.setVolume(1f) }
+                        firstSentence = false
+                    }
+
+                    var written = 0
+                    while (written < chunk.pcm.size && recapPipelineRunning.get()) {
+                        val n = track.write(chunk.pcm, written, chunk.pcm.size - written)
+                        if (n < 0) break
+                        written += n
+                    }
+                    var remaining = chunk.trailingSilenceBytes
+                    while (remaining > 0 && recapPipelineRunning.get()) {
+                        val sz = remaining.coerceAtMost(SILENCE_CHUNK.size)
+                        val n = track.write(SILENCE_CHUNK, 0, sz)
+                        if (n < 0) break
+                        remaining -= n
+                    }
+                }
+            } finally {
+                runCatching { track.pause() }
+                runCatching { track.flush() }
+                runCatching { track.release() }
+                // Only flip back to Idle if we're still the active recap
+                // pipeline — a stop-then-start race could otherwise have
+                // the dying old thread reset state for the new one.
+                if (recapPipelineRunning.compareAndSet(true, false)) {
+                    scope.launch { _recapPlayback.value = RecapPlaybackState.Idle }
+                }
+            }
+        }, "storyvox-recap-out").apply {
+            isDaemon = true
+            start()
+        }
+    }
+
+    private fun stopRecapPipeline() {
+        recapPipelineRunning.set(false)
+        val track = recapAudioTrack
+        recapAudioTrack = null
+        track?.let {
+            runCatching { it.pause() }
+            runCatching { it.flush() }
+        }
+        val src = recapPcmSource
+        recapPcmSource = null
+        if (src != null) runBlocking { src.close() }
+        val t = recapConsumerThread
+        recapConsumerThread = null
+        if (t != null && t !== Thread.currentThread()) {
+            t.interrupt()
+            try { t.join(2_000) } catch (_: InterruptedException) {}
+        }
+        _recapPlayback.value = RecapPlaybackState.Idle
     }
 
     private companion object {

--- a/feature/src/main/kotlin/in/jphe/storyvox/feature/api/UiContracts.kt
+++ b/feature/src/main/kotlin/in/jphe/storyvox/feature/api/UiContracts.kt
@@ -258,9 +258,17 @@ sealed class UiSleepTimerMode {
     data object EndOfChapter : UiSleepTimerMode()
 }
 
+/** Issue #189 — feature-side mirror of core-playback's RecapPlaybackState.
+ *  Idle = no recap utterance in flight. Speaking = recap audio is playing
+ *  through the dedicated AudioTrack. The Reader UI's "Read aloud" button
+ *  toggles between the two states. */
+enum class UiRecapPlaybackState { Idle, Speaking }
+
 interface PlaybackControllerUi {
     val state: Flow<UiPlaybackState>
     val chapterText: Flow<String>
+    /** Issue #189 — recap-aloud TTS pipeline state. See [UiRecapPlaybackState]. */
+    val recapPlayback: Flow<UiRecapPlaybackState>
     fun play()
     fun pause()
     fun seekTo(ms: Long)
@@ -284,6 +292,15 @@ interface PlaybackControllerUi {
     fun startListening(fictionId: String, chapterId: String, charOffset: Int = 0)
     fun startSleepTimer(mode: UiSleepTimerMode)
     fun cancelSleepTimer()
+
+    /** Issue #189 — synthesize and play [text] as a one-shot utterance via
+     *  the active voice. The caller (ReaderViewModel.toggleRecapAloud) is
+     *  responsible for pausing fiction playback before calling — see the
+     *  PlaybackController interface for the full contract. */
+    suspend fun speakText(text: String)
+
+    /** Issue #189 — cancel an in-flight recap-aloud utterance. Idempotent. */
+    fun stopSpeaking()
 }
 
 data class UiVoice(

--- a/feature/src/main/kotlin/in/jphe/storyvox/feature/reader/HybridReaderScreen.kt
+++ b/feature/src/main/kotlin/in/jphe/storyvox/feature/reader/HybridReaderScreen.kt
@@ -33,6 +33,7 @@ fun HybridReaderScreen(
 ) {
     val state by viewModel.uiState.collectAsStateWithLifecycle()
     val recapState by viewModel.recap.collectAsStateWithLifecycle()
+    val recapPlayback by viewModel.recapPlayback.collectAsStateWithLifecycle()
     val playback = state.playback
 
     if (playback == null) {
@@ -81,11 +82,13 @@ fun HybridReaderScreen(
     // ReaderViewModel.requestRecap().
     RecapModal(
         state = recapState,
+        recapPlayback = recapPlayback,
         onCancel = viewModel::cancelRecap,
         onRetry = viewModel::requestRecap,
         onOpenSettings = {
             viewModel.cancelRecap()
             onOpenAiSettings()
         },
+        onToggleReadAloud = viewModel::toggleRecapAloud,
     )
 }

--- a/feature/src/main/kotlin/in/jphe/storyvox/feature/reader/ReaderViewModel.kt
+++ b/feature/src/main/kotlin/in/jphe/storyvox/feature/reader/ReaderViewModel.kt
@@ -8,6 +8,7 @@ import dagger.hilt.android.lifecycle.HiltViewModel
 import `in`.jphe.storyvox.feature.api.PlaybackControllerUi
 import `in`.jphe.storyvox.feature.api.SettingsRepositoryUi
 import `in`.jphe.storyvox.feature.api.UiPlaybackState
+import `in`.jphe.storyvox.feature.api.UiRecapPlaybackState
 import `in`.jphe.storyvox.feature.api.UiSleepTimerMode
 import `in`.jphe.storyvox.llm.LlmError
 import `in`.jphe.storyvox.llm.feature.ChapterRecap
@@ -82,6 +83,15 @@ class ReaderViewModel @Inject constructor(
     /** Recap modal state. Reader UI collects this and renders the
      *  modal when not [RecapUiState.Hidden]. */
     val recap: StateFlow<RecapUiState> = _recap.asStateFlow()
+
+    /** Issue #189 — recap-aloud TTS pipeline state, surfaced from the
+     *  PlaybackController so the modal's Read-aloud button can render the
+     *  right play/pause icon. The chapter-recap modal collects this
+     *  alongside [recap] (the modal-content state) — they're independent
+     *  axes: the modal can be Done while the audio is Idle (button shows
+     *  Play), or Done while Speaking (button shows Pause). */
+    val recapPlayback: StateFlow<UiRecapPlaybackState> = playback.recapPlayback
+        .stateIn(viewModelScope, SharingStarted.WhileSubscribed(5_000), UiRecapPlaybackState.Idle)
 
     /** The currently in-flight recap stream, or null when no recap is
      *  running. Cancelling this Job cancels the underlying OkHttp
@@ -172,11 +182,40 @@ class ReaderViewModel @Inject constructor(
     }
 
     /** Hide the modal. Cancels the in-flight stream — partial recap
-     *  is discarded. */
+     *  is discarded. Also stops any in-flight recap-aloud utterance
+     *  (#189) so closing the modal silences the audio. */
     fun cancelRecap() {
         recapJob?.cancel()
         recapJob = null
+        playback.stopSpeaking()
         _recap.value = RecapUiState.Hidden
+    }
+
+    /**
+     * Issue #189 — toggle the recap-aloud TTS. Tapped from the Read-aloud
+     * button in [RecapModal] when the recap is in [RecapUiState.Done].
+     *
+     * Behaviour:
+     *  - If a recap utterance is already speaking, stop it. (Button
+     *    rendered as a Pause icon — second tap silences.)
+     *  - Otherwise, pause the active fiction (so the recap and the
+     *    chapter audio don't overlap), then synthesize the recap text
+     *    via the active voice. Per the spec we leave fiction paused
+     *    when the recap finishes — auto-resume would feel aggressive.
+     */
+    fun toggleRecapAloud() {
+        if (recapPlayback.value == UiRecapPlaybackState.Speaking) {
+            playback.stopSpeaking()
+            return
+        }
+        val text = (recap.value as? RecapUiState.Done)?.text ?: return
+        if (text.isBlank()) return
+        // Pause active fiction first — engine is shared, overlapping audio
+        // would be muddy.
+        if (uiState.value.playback?.isPlaying == true) playback.pause()
+        viewModelScope.launch {
+            playback.speakText(text)
+        }
     }
 
     private fun mapErrorToUi(e: Throwable): RecapUiState.Error = when (e) {

--- a/feature/src/main/kotlin/in/jphe/storyvox/feature/reader/RecapModal.kt
+++ b/feature/src/main/kotlin/in/jphe/storyvox/feature/reader/RecapModal.kt
@@ -14,7 +14,14 @@ import androidx.compose.foundation.layout.heightIn
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Pause
+import androidx.compose.material.icons.filled.PlayArrow
 import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.IconButtonDefaults
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.ModalBottomSheet
 import androidx.compose.material3.Text
@@ -24,9 +31,14 @@ import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.alpha
+import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.semantics.Role
+import androidx.compose.ui.semantics.role
+import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
+import `in`.jphe.storyvox.feature.api.UiRecapPlaybackState
 import `in`.jphe.storyvox.ui.component.BrassButton
 import `in`.jphe.storyvox.ui.component.BrassButtonVariant
 import `in`.jphe.storyvox.ui.component.MagicSpinner
@@ -43,19 +55,25 @@ import `in`.jphe.storyvox.ui.theme.LocalSpacing
  *  - Hidden — modal not rendered.
  *  - Loading — "Asking the librarian…" + spinner; Cancel is live.
  *  - Streaming — partial text + blinking cursor; Cancel is live.
- *  - Done — full text + Close button (and a "Read aloud" button
- *    that's greyed out with "coming soon" tooltip — the synth-from-
- *    arbitrary-text path lands in a follow-up PR).
+ *  - Done — full text + Close button + Read-aloud icon button (#189).
  *  - Error — error message + recovery action (Settings link / Try
  *    again / Close).
+ *
+ * The Read-aloud icon button (issue #189) appears in the Done state.
+ * Tap toggles between Play and Pause according to [recapPlayback]
+ * (Idle → tap → Speaking; Speaking → tap → Idle). The TTS pipeline
+ * lives in :core-playback so the audio survives modal recomposition;
+ * the button is just the toggle UI.
  */
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun RecapModal(
     state: RecapUiState,
+    recapPlayback: UiRecapPlaybackState,
     onCancel: () -> Unit,
     onRetry: () -> Unit,
     onOpenSettings: () -> Unit,
+    onToggleReadAloud: () -> Unit,
 ) {
     if (state is RecapUiState.Hidden) return
 
@@ -134,10 +152,10 @@ fun RecapModal(
                             onClick = onCancel,
                             variant = BrassButtonVariant.Secondary,
                         )
-                        // Read-aloud is P1 — surfaced greyed-out with a
-                        // tooltip-on-press in a follow-up PR. For PR-1
-                        // we leave the slot empty so the modal doesn't
-                        // promise something we don't deliver.
+                        ReadAloudIconButton(
+                            playbackState = recapPlayback,
+                            onClick = onToggleReadAloud,
+                        )
                     }
                     is RecapUiState.Error -> {
                         when (state.kind) {
@@ -173,6 +191,41 @@ fun RecapModal(
                 }
             }
         }
+    }
+}
+
+/**
+ * Issue #189 — brass-tinted icon button toggling the recap-aloud TTS.
+ * Renders a Play icon when [playbackState] is Idle, Pause when Speaking.
+ * Driven by `ReaderViewModel.toggleRecapAloud`; the audio pipeline lives
+ * in :core-playback so the button is purely a state toggle.
+ */
+@Composable
+private fun ReadAloudIconButton(
+    playbackState: UiRecapPlaybackState,
+    onClick: () -> Unit,
+) {
+    val isSpeaking = playbackState == UiRecapPlaybackState.Speaking
+    val brass = MaterialTheme.colorScheme.primary
+    val (icon, label) = if (isSpeaking) {
+        Icons.Filled.Pause to "Pause read aloud"
+    } else {
+        Icons.Filled.PlayArrow to "Read aloud"
+    }
+    IconButton(
+        onClick = onClick,
+        modifier = Modifier
+            .clip(CircleShape)
+            .semantics { role = Role.Button },
+        colors = IconButtonDefaults.iconButtonColors(
+            // Tonal brass background so the button reads as a primary
+            // action without competing with the BrassButton "Close"
+            // sibling (which is already brass-outlined Secondary).
+            containerColor = brass.copy(alpha = 0.16f),
+            contentColor = brass,
+        ),
+    ) {
+        Icon(imageVector = icon, contentDescription = label)
     }
 }
 

--- a/feature/src/test/kotlin/in/jphe/storyvox/feature/chat/ChatViewModelTest.kt
+++ b/feature/src/test/kotlin/in/jphe/storyvox/feature/chat/ChatViewModelTest.kt
@@ -13,6 +13,7 @@ import `in`.jphe.storyvox.feature.api.UiChapter
 import `in`.jphe.storyvox.feature.api.UiFiction
 import `in`.jphe.storyvox.feature.api.UiFollow
 import `in`.jphe.storyvox.feature.api.UiPlaybackState
+import `in`.jphe.storyvox.feature.api.UiRecapPlaybackState
 import `in`.jphe.storyvox.feature.api.UiSleepTimerMode
 import `in`.jphe.storyvox.llm.FeatureKind
 import `in`.jphe.storyvox.llm.LlmConfig
@@ -434,6 +435,7 @@ private fun uiFictionOf(id: String, title: String) = UiFiction(
 private class FakePlayback(initial: UiPlaybackState) : PlaybackControllerUi {
     override val state: StateFlow<UiPlaybackState> = MutableStateFlow(initial).asStateFlow()
     override val chapterText: Flow<String> = flowOf("")
+    override val recapPlayback: Flow<UiRecapPlaybackState> = flowOf(UiRecapPlaybackState.Idle)
     override fun play() = Unit
     override fun pause() = Unit
     override fun seekTo(ms: Long) = Unit
@@ -449,4 +451,6 @@ private class FakePlayback(initial: UiPlaybackState) : PlaybackControllerUi {
     override fun startListening(fictionId: String, chapterId: String, charOffset: Int) = Unit
     override fun startSleepTimer(mode: UiSleepTimerMode) = Unit
     override fun cancelSleepTimer() = Unit
+    override suspend fun speakText(text: String) = Unit
+    override fun stopSpeaking() = Unit
 }


### PR DESCRIPTION
## Summary

Adds a brass-tinted Read aloud / Pause icon button to the chapter recap modal's Done state. Tap streams the recap text through the active VoxSherpa / Kokoro voice using a dedicated AudioTrack + consumer thread that lives alongside the chapter playback pipeline, guarded by the same `engineMutex` so the shared engine never gets two in-flight generates at once.

- **core-playback**: `EnginePlayer.speak / stopSpeaking` + `RecapPlaybackState` flow. Recap pipeline shares the engine but has its own AudioTrack + consumer thread; chapter playback is paused before recap synthesis starts (caller's job — the engine + AudioFlinger speech route are shared and overlapping audio would muddy the listener experience).
- **PlaybackController + RealPlaybackControllerUi** expose `speakText` / `stopSpeaking` and the Idle / Speaking flow.
- **ReaderViewModel.toggleRecapAloud** pauses fiction first, then starts the utterance; second tap stops it. `cancelRecap` (modal close) also silences the audio so dismissing the modal doesn't leave it speaking. Per the spec, when recap audio ends naturally we leave the fiction paused — auto-resume would be aggressive UX.
- **RecapModal** renders the icon button next to Close in the Done state; icon flips between PlayArrow (Idle) and Pause (Speaking) per the observed RecapPlaybackState.

## Test plan

- [x] `./gradlew :core-playback:compileDebugKotlin :feature:compileDebugKotlin :app:compileDebugKotlin` green
- [x] `./gradlew :feature:testDebugUnitTest :app:testDebugUnitTest :core-playback:testDebugUnitTest` green (existing FakePlayback + RecordingController fakes updated for the new `speakText` / `stopSpeaking` / `recapPlayback` surface)
- [x] `./gradlew :app:assembleDebug` produces a runnable APK
- [x] Installed on tablet R83W80CAFZB without runtime crashes
- [ ] Manual smoke: open a chapter with a recap, wait for Done, tap Read aloud — fiction pauses, recap audio plays, button flips to Pause; tap again to stop; close modal mid-speech to verify cancellation
- [ ] Manual smoke: trigger recap during active fiction playback to confirm pause-before-speak ordering

Closes #189