### PR TITLE
feat(github): gists as drafts (#202)

### DIFF
--- a/app/src/main/kotlin/in/jphe/storyvox/di/AppBindings.kt
+++ b/app/src/main/kotlin/in/jphe/storyvox/di/AppBindings.kt
@@ -373,6 +373,13 @@ private class RealBrowseRepositoryUi(
                 // github fictionId.
                 BrowseSource.GitHubMyRepos -> repo.cacheBrowseListing(github.myRepos(page = page))
                 BrowseSource.GitHubStarred -> repo.cacheBrowseListing(github.starred(page = page))
+                // #202 — auth-gated `/gists` listing. Same caching
+                // pattern as MyRepos / Starred: rows land in the DB
+                // with their `github:gist:<id>` ids so tapping a gist
+                // card resolves through `fictionDetail` and the gist
+                // codepath in GitHubSource — not the RR fallback.
+                BrowseSource.GitHubGists ->
+                    repo.cacheBrowseListing(github.authenticatedUserGists(page = page))
             }
         }
 

--- a/core-data/src/main/kotlin/in/jphe/storyvox/data/source/UrlRouter.kt
+++ b/core-data/src/main/kotlin/in/jphe/storyvox/data/source/UrlRouter.kt
@@ -29,6 +29,26 @@ object UrlRouter {
         """^(?:github:)?([\w.-]+)/([\w.-]+?)(?:\.git)?$""",
     )
 
+    /**
+     * `https://gist.github.com/{user}/{id}` and the user-less variant
+     * `https://gist.github.com/{id}` GitHub still accepts. The id is
+     * a hex blob; the optional revision suffix `/<sha>` is tolerated
+     * but discarded — gists have no inter-revision identity in the
+     * fiction sense, so we always resolve to the head id.
+     */
+    private val GITHUB_GIST_PATTERN = Regex(
+        """^https?://gist\.github\.com/(?:([\w.-]+)/)?([0-9a-f]+)(?:/[0-9a-f]+)?/?$""",
+        RegexOption.IGNORE_CASE,
+    )
+
+    /** Short form `gist:<id>` (no scheme). Bare hex isn't accepted —
+     *  too easy to collide with arbitrary user input that happens to
+     *  be hex. The explicit prefix anchors intent. */
+    private val GITHUB_GIST_SHORT_PATTERN = Regex(
+        """^gist:([0-9a-f]+)$""",
+        RegexOption.IGNORE_CASE,
+    )
+
     data class Match(val sourceId: String, val fictionId: String)
 
     fun route(input: String): Match? {
@@ -39,8 +59,21 @@ object UrlRouter {
             return Match(SourceIds.ROYAL_ROAD, m.groupValues[1])
         }
 
+        // Gist URLs must be matched before the GitHub repo pattern —
+        // both live on github.com, but only the gist subdomain matters
+        // here; the repo pattern is anchored on `github.com` (no
+        // subdomain), so the order is actually safe either way.
+        GITHUB_GIST_PATTERN.matchEntire(trimmed)?.let { m ->
+            val gistId = m.groupValues[2].lowercase()
+            return Match(SourceIds.GITHUB, "${SourceIds.GITHUB}:gist:$gistId")
+        }
+
         GITHUB_HTTPS_PATTERN.matchEntire(trimmed)?.let { m ->
             return Match(SourceIds.GITHUB, "${SourceIds.GITHUB}:${m.groupValues[1].lowercase()}/${m.groupValues[2].lowercase()}")
+        }
+
+        GITHUB_GIST_SHORT_PATTERN.matchEntire(trimmed)?.let { m ->
+            return Match(SourceIds.GITHUB, "${SourceIds.GITHUB}:gist:${m.groupValues[1].lowercase()}")
         }
 
         // Reject ambiguous short form on URLs that look like a full path

--- a/core-data/src/test/kotlin/in/jphe/storyvox/data/source/UrlRouterTest.kt
+++ b/core-data/src/test/kotlin/in/jphe/storyvox/data/source/UrlRouterTest.kt
@@ -107,4 +107,46 @@ class UrlRouterTest {
         val m = UrlRouter.route("  https://www.royalroad.com/fiction/7  ")
         assertEquals(UrlRouter.Match("royalroad", "7"), m)
     }
+
+    // ── Gists ─────────────────────────────────────────────────────────────
+
+    @Test fun `gist url with user prefix routes to gist sub-prefix`() {
+        val m = UrlRouter.route("https://gist.github.com/jphein/abc123def456")
+        assertEquals(UrlRouter.Match("github", "github:gist:abc123def456"), m)
+    }
+
+    @Test fun `gist url without user prefix is accepted`() {
+        // GitHub still serves the user-less form for legacy gist URLs.
+        val m = UrlRouter.route("https://gist.github.com/abc123def456")
+        assertEquals(UrlRouter.Match("github", "github:gist:abc123def456"), m)
+    }
+
+    @Test fun `gist url with revision suffix discards revision`() {
+        val m = UrlRouter.route(
+            "https://gist.github.com/jphein/abc123def456/0123456789abcdef",
+        )
+        assertEquals(UrlRouter.Match("github", "github:gist:abc123def456"), m)
+    }
+
+    @Test fun `gist mixed-case id is normalised to lowercase`() {
+        val m = UrlRouter.route("https://gist.github.com/jphein/ABC123DEF456")
+        assertEquals(UrlRouter.Match("github", "github:gist:abc123def456"), m)
+    }
+
+    @Test fun `gist short form with prefix routes to gist sub-prefix`() {
+        val m = UrlRouter.route("gist:abc123def456")
+        assertEquals(UrlRouter.Match("github", "github:gist:abc123def456"), m)
+    }
+
+    @Test fun `bare hex without gist prefix is not mistaken for a gist`() {
+        // Bare hex is too easy to collide with arbitrary user input;
+        // require the explicit `gist:` prefix on the short form.
+        assertNull(UrlRouter.route("abc123def456"))
+    }
+
+    @Test fun `gist with non-hex id is rejected`() {
+        // GitHub gist ids are hex; rejecting non-hex avoids picking up
+        // arbitrary `gist.github.com/<anything>` typos.
+        assertNull(UrlRouter.route("https://gist.github.com/jphein/not-a-gist"))
+    }
 }

--- a/feature/src/main/kotlin/in/jphe/storyvox/feature/api/UiContracts.kt
+++ b/feature/src/main/kotlin/in/jphe/storyvox/feature/api/UiContracts.kt
@@ -137,6 +137,7 @@ sealed interface BrowseSource {
         val query: String,
         val filter: GitHubSearchFilter,
     ) : BrowseSource
+
     /**
      * MemPalace wing-scoped listing (#191). Routes through
      * `FictionRepository.browseByGenre(genre)`, which on MemPalace's
@@ -160,6 +161,22 @@ sealed interface BrowseSource {
      * by `UiSettings.github`; the adapter routes to `GitHubAuthedSource`.
      */
     data object GitHubStarred : BrowseSource
+
+    /**
+     * Gists for the signed-in GitHub user (#202). Routes through
+     * `GET /gists` (authenticated) so secret gists show up alongside
+     * public ones; the `:source-github` source layer handles the
+     * empty/anonymous case by surfacing an empty page rather than
+     * erroring out.
+     *
+     * The repository adapter routes this onto
+     * `GitHubAuthedSource.authenticatedUserGists(page)`. There's no
+     * Royal Road or MemPalace analogue — the BrowseSource contract
+     * has source-specific variants on purpose (`Filtered` vs
+     * `FilteredGitHub`, `GitHubMyRepos` vs `GitHubStarred` vs
+     * `GitHubGists`).
+     */
+    data object GitHubGists : BrowseSource
 }
 
 /** A page-by-page accumulating cursor over a remote fiction listing.

--- a/feature/src/main/kotlin/in/jphe/storyvox/feature/browse/BrowseScreen.kt
+++ b/feature/src/main/kotlin/in/jphe/storyvox/feature/browse/BrowseScreen.kt
@@ -396,6 +396,7 @@ private val BrowseTab.label: String
         BrowseTab.Search -> "Search"
         BrowseTab.MyRepos -> "My Repos"
         BrowseTab.Starred -> "Starred"
+        BrowseTab.Gists -> "Gists"
     }
 
 /**

--- a/feature/src/main/kotlin/in/jphe/storyvox/feature/browse/BrowseViewModel.kt
+++ b/feature/src/main/kotlin/in/jphe/storyvox/feature/browse/BrowseViewModel.kt
@@ -33,7 +33,7 @@ import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.launch
 
-enum class BrowseTab { Popular, NewReleases, BestRated, Search, MyRepos, Starred }
+enum class BrowseTab { Popular, NewReleases, BestRated, Search, MyRepos, Starred, Gists }
 
 /**
  * Top-level source picker on the Browse screen. Chooses which
@@ -61,8 +61,9 @@ enum class BrowseSourceKey(val sourceId: String, val displayName: String) {
  *  +{userQuery}`.
  *
  *  [githubSignedIn] gates the auth-only tabs on the GitHub source —
- *  `MyRepos` (#200) and `Starred` (#201) — visible only when the user
- *  has captured an OAuth session via the Device Flow. Defaulting false
+ *  `MyRepos` (#200), `Starred` (#201), and `Gists` (#202) — visible
+ *  only when the user has captured an OAuth session via the Device
+ *  Flow. Defaulting false
  *  keeps existing call sites (tests, screens that don't observe
  *  settings yet) on the anonymous tab list. */
 fun BrowseSourceKey.supportedTabs(githubSignedIn: Boolean = false): List<BrowseTab> = when (this) {
@@ -78,6 +79,7 @@ fun BrowseSourceKey.supportedTabs(githubSignedIn: Boolean = false): List<BrowseT
         if (githubSignedIn) {
             add(BrowseTab.MyRepos)
             add(BrowseTab.Starred)
+            add(BrowseTab.Gists)
         }
         add(BrowseTab.Search)
     }
@@ -127,8 +129,10 @@ data class BrowseUiState(
      *  lazily on first switch to MemPalace; empty until the daemon
      *  responds (or daemon unreachable). */
     val palaceWings: List<String> = emptyList(),
-    /** True when an OAuth session is captured (#200). Drives the
-     *  `MyRepos` tab visibility on the GitHub source. */
+    /** True when an OAuth session is captured. Drives the `MyRepos`
+     *  (#200) and `Gists` (#202) tab visibility on the GitHub
+     *  source. Sourced from `SettingsRepositoryUi.settings.github`
+     *  and flips back to false on sign-out / token expiry. */
     val githubSignedIn: Boolean = false,
     /** True when the user has a GitHub OAuth session that includes the
      *  `repo` scope (#203 / #204). Drives the visibility chip row in
@@ -163,6 +167,10 @@ private data class ControlsView(
     val filter: BrowseFilter,
     val githubFilter: GitHubSearchFilter,
     val palaceFilter: MemPalaceFilter,
+    /** Snapshot of the GitHub auth state — true when the user has a
+     *  captured session (`UiGitHubAuthState.SignedIn`). Drives the
+     *  `MyRepos` (#200) and `Gists` (#202) tab visibility conditions
+     *  in [BrowseUiState]. */
     val githubSignedIn: Boolean,
     val hasGitHubRepoScope: Boolean,
 )
@@ -200,10 +208,11 @@ class BrowseViewModel @Inject constructor(
     private var palaceWingsLoaded = false
     val query: StateFlow<String> = _query.asStateFlow()
 
-    /** Github sign-in projection — drives MyRepos tab visibility (#200).
-     *  `Expired` reads as signed-out: the disk copy is intact for Settings
-     *  to render "session expired" but the listing endpoint would 401, so
-     *  hiding the tab keeps the user from a guaranteed-failure path. */
+    /** Github sign-in projection — drives MyRepos (#200) and Gists
+     *  (#202) tab visibility. `Expired` reads as signed-out: the disk
+     *  copy is intact for Settings to render "session expired" but the
+     *  listing endpoints would 401, so hiding the tabs keeps the user
+     *  from a guaranteed-failure path. */
     private val githubSignedIn: StateFlow<Boolean> = settings.settings
         .map { it.github is UiGitHubAuthState.SignedIn }
         .distinctUntilChanged()
@@ -264,8 +273,8 @@ class BrowseViewModel @Inject constructor(
         viewModelScope.launch {
             paginator.collectLatest { p -> p?.loadNext() }
         }
-        // Auto-snap off auth-only tabs (`MyRepos` #200, `Starred` #201)
-        // when the user signs out. They disappear from
+        // Auto-snap off auth-only tabs (`MyRepos` #200, `Starred` #201,
+        // `Gists` #202) when the user signs out. They disappear from
         // `supportedTabs(githubSignedIn=false)`, so leaving the value
         // pinned would render an empty grid driven by a null
         // BrowseSource. Snap to Popular so the screen has something to
@@ -281,7 +290,7 @@ class BrowseViewModel @Inject constructor(
 
     /** All user-controlled knobs collapsed into one typed record. The
      *  inner 5-arg combine builds the base tuple; outer combine folds
-     *  in palaceFilter (#191), githubSignedIn (#200), and the
+     *  in palaceFilter (#191), githubSignedIn (#200/#202), and the
      *  has-`repo`-scope flag (#204) without exceeding the `combine`
      *  5-arg overload. */
     private val controls: kotlinx.coroutines.flow.Flow<ControlsView> = run {
@@ -370,8 +379,8 @@ class BrowseViewModel @Inject constructor(
         _sourceKey.value = key
         // If the previously-selected tab isn't supported on the new
         // source (e.g. user was on BestRated/Search on RR and switches
-        // to GitHub, or MyRepos when not on GitHub), snap to Popular so
-        // the screen has something sensible to render.
+        // to GitHub, or MyRepos/Gists when not on GitHub), snap to
+        // Popular so the screen has something sensible to render.
         if (_tab.value !in key.supportedTabs(githubSignedIn.value)) {
             _tab.value = BrowseTab.Popular
         }
@@ -434,7 +443,7 @@ class BrowseViewModel @Inject constructor(
 /** Tabs on the GitHub source that require an OAuth session.
  *  Used by the auto-snap watcher to bounce the user off the tab
  *  cleanly when their session goes away (sign-out, expired). */
-private val AUTH_ONLY_GH_TABS: Set<BrowseTab> = setOf(BrowseTab.MyRepos, BrowseTab.Starred)
+private val AUTH_ONLY_GH_TABS: Set<BrowseTab> = setOf(BrowseTab.MyRepos, BrowseTab.Starred, BrowseTab.Gists)
 
 /** 5-arg shoehorn so the inner [combine] stays within the overload
  *  arity. Folded back into [ControlsView] (or consumed directly by
@@ -459,16 +468,20 @@ private fun resolveSource(
     // GitHub: filter takes priority over tab. When filter is active OR
     // user is on Search with a typed query, route to FilteredGitHub so
     // the qualifier-laden query lands. Otherwise the tab decides
-    // (Popular/NewReleases/MyRepos/Search). MyRepos is sign-in-gated;
-    // a stale tab value when the user has signed out maps to null
-    // (BrowseScreen will see the tab missing from supportedTabs and
-    // re-snap). Search-with-blank-query stays null so the screen
-    // renders SearchHint.
+    // (Popular/NewReleases/MyRepos/Gists/Search). MyRepos and Gists
+    // are sign-in-gated; a stale tab value when the user has signed
+    // out maps to null (BrowseScreen will see the tab missing from
+    // supportedTabs and re-snap). Search-with-blank-query stays null
+    // so the screen renders SearchHint. The GitHub filter doesn't
+    // apply to Gists (no `/search/gists` endpoint shape matches the
+    // repo-search qualifiers) so an active filter just means the tab
+    // still pages through gists.
     BrowseSourceKey.GitHub -> when {
         // Auth-only tabs short-circuit ahead of the filter check —
-        // search qualifiers don't apply to `/user/{repos,starred}`.
+        // search qualifiers don't apply to `/user/{repos,starred,gists}`.
         tab == BrowseTab.MyRepos -> if (githubSignedIn) BrowseSource.GitHubMyRepos else null
         tab == BrowseTab.Starred -> if (githubSignedIn) BrowseSource.GitHubStarred else null
+        tab == BrowseTab.Gists -> if (githubSignedIn) BrowseSource.GitHubGists else null
         githubFilter.isActive() -> BrowseSource.FilteredGitHub(
             query = if (tab == BrowseTab.Search) q else "",
             filter = githubFilter,

--- a/source-github/src/main/kotlin/in/jphe/storyvox/source/github/GitHubAuthedSource.kt
+++ b/source-github/src/main/kotlin/in/jphe/storyvox/source/github/GitHubAuthedSource.kt
@@ -39,4 +39,22 @@ interface GitHubAuthedSource {
      * → GitHub uses). Drives the Browse → Starred tab (#201).
      */
     suspend fun starred(page: Int): FictionResult<ListPage<FictionSummary>>
+
+    /**
+     * `/gists` — the authenticated user's gists. Includes secret
+     * gists when the bearer token has the `gist` scope (#202).
+     * Each gist maps to a fiction id (`github:gist:<id>`) the
+     * existing `fictionDetail` path can resolve into a multi-chapter
+     * fiction, one chapter per file.
+     */
+    suspend fun authenticatedUserGists(page: Int): FictionResult<ListPage<FictionSummary>>
+
+    /**
+     * `/users/{user}/gists` — public gists for [user] (#202).
+     * Anonymous-compatible (uses the public endpoint) but still
+     * benefits from higher rate limits when a token is attached.
+     * Reserved for the URL-resolved "view someone's gist roster"
+     * flow; not surfaced in Browse today.
+     */
+    suspend fun userGists(user: String, page: Int): FictionResult<ListPage<FictionSummary>>
 }

--- a/source-github/src/main/kotlin/in/jphe/storyvox/source/github/GitHubSource.kt
+++ b/source-github/src/main/kotlin/in/jphe/storyvox/source/github/GitHubSource.kt
@@ -13,6 +13,7 @@ import `in`.jphe.storyvox.data.source.model.SearchQuery
 import `in`.jphe.storyvox.source.github.manifest.BookManifest
 import `in`.jphe.storyvox.source.github.manifest.ManifestChapter
 import `in`.jphe.storyvox.source.github.manifest.ManifestParser
+import `in`.jphe.storyvox.source.github.model.GhGist
 import `in`.jphe.storyvox.source.github.model.GhRepo
 import `in`.jphe.storyvox.source.github.model.decodedText
 import `in`.jphe.storyvox.source.github.net.GitHubApi
@@ -257,6 +258,12 @@ internal class GitHubSource @Inject constructor(
     )
 
     override suspend fun fictionDetail(fictionId: String): FictionResult<FictionDetail> {
+        // Gist fictions take a separate codepath: no manifest, no
+        // bare-repo dir-listing fallback — just the gist's `files` map
+        // mapped 1:1 into chapters.
+        parseGistFictionId(fictionId)?.let { gistId ->
+            return gistFictionDetail(fictionId, gistId)
+        }
         val coords = parseFictionId(fictionId)
             ?: return FictionResult.NotFound(message = "Not a GitHub fiction id: $fictionId")
         val (owner, repo) = coords
@@ -323,6 +330,13 @@ internal class GitHubSource @Inject constructor(
         fictionId: String,
         chapterId: String,
     ): FictionResult<ChapterContent> {
+        // Gist chapter id format: `<fictionId>:<filename>`. Gists have
+        // no commit history; we re-fetch the whole gist and pick the
+        // file out — the listing-stub `content` field is null, so this
+        // is the only path that yields the body.
+        parseGistFictionId(fictionId)?.let { gistId ->
+            return gistChapter(fictionId, gistId, chapterId)
+        }
         val coords = parseFictionId(fictionId)
             ?: return FictionResult.NotFound(message = "Not a GitHub fiction id: $fictionId")
         val (owner, repo) = coords
@@ -393,6 +407,12 @@ internal class GitHubSource @Inject constructor(
      * "fall back to the full path" rather than aborting the whole poll.
      */
     override suspend fun latestRevisionToken(fictionId: String): FictionResult<String?> {
+        // Gists have no commit history exposed via REST; fall back to
+        // the full `fictionDetail` path on every poll for now. Returning
+        // null instead of NotFound so the worker treats it as "no
+        // cheap-poll token, run the full path" rather than dropping the
+        // fiction entirely.
+        if (parseGistFictionId(fictionId) != null) return FictionResult.Success(null)
         val coords = parseFictionId(fictionId)
             ?: return FictionResult.NotFound(message = "Not a GitHub fiction id: $fictionId")
         val (owner, repo) = coords
@@ -569,13 +589,222 @@ internal class GitHubSource @Inject constructor(
         else -> FictionStatus.ONGOING
     }
 
-    /** `github:owner/repo` → `(owner, repo)` or null. */
+    /** `github:owner/repo` → `(owner, repo)` or null. Rejects gist
+     *  fiction ids (those use the [GIST_PREFIX] sub-prefix). */
     private fun parseFictionId(fictionId: String): Pair<String, String>? {
         val stripped = fictionId.removePrefix("${SourceIds.GITHUB}:")
         if (stripped == fictionId) return null
+        if (stripped.startsWith(GIST_PREFIX)) return null
         val slash = stripped.indexOf('/')
         if (slash <= 0 || slash == stripped.length - 1) return null
         return stripped.substring(0, slash) to stripped.substring(slash + 1)
+    }
+
+    /**
+     * `github:gist:<id>` → `<id>` or null. The `gist:` sub-prefix
+     * disambiguates gist fictions from owner/repo fictions, since
+     * gist ids overlap the alphanumeric space that owner/repo path
+     * segments occupy. Must be checked before [parseFictionId].
+     */
+    private fun parseGistFictionId(fictionId: String): String? {
+        val stripped = fictionId.removePrefix("${SourceIds.GITHUB}:")
+        if (stripped == fictionId) return null
+        if (!stripped.startsWith(GIST_PREFIX)) return null
+        val gistId = stripped.removePrefix(GIST_PREFIX)
+        if (gistId.isBlank() || '/' in gistId) return null
+        return gistId
+    }
+
+    // ─── gists ────────────────────────────────────────────────────────
+
+    /**
+     * Public list of [user]'s gists, mapped to [FictionSummary] for the
+     * Browse → GitHub → Gists tab (#202). Excludes secret gists by
+     * construction (the public `/users/{user}/gists` endpoint never
+     * surfaces them, even with a token); the [authenticatedUserGists]
+     * path is what the Settings-account-aware flow uses to include
+     * private/secret gists.
+     *
+     * Gist titles fall back through: [GhGist.description] →
+     * first-file filename → "Untitled gist". GitHub UIs use the same
+     * order; matching it keeps storyvox consistent with what users
+     * see at gist.github.com.
+     */
+    override suspend fun userGists(user: String, page: Int): FictionResult<ListPage<FictionSummary>> =
+        gistsPage(api.userGists(user, page = page), page)
+
+    /**
+     * Authenticated-user gists — `GET /gists`. Includes secret gists
+     * when the bearer token has the `gist` scope. The OkHttp
+     * interceptor attaches the token automatically; an anonymous call
+     * comes back as a 401 → mapped to `NetworkError(403)` by the API
+     * layer, which the caller surfaces as "sign in to see your gists."
+     */
+    override suspend fun authenticatedUserGists(page: Int): FictionResult<ListPage<FictionSummary>> =
+        gistsPage(api.authenticatedUserGists(page = page), page)
+
+    private fun gistsPage(
+        result: GitHubApiResult<List<GhGist>>,
+        page: Int,
+    ): FictionResult<ListPage<FictionSummary>> = when (result) {
+        is GitHubApiResult.Success -> {
+            val items = result.value.map { it.toFictionSummary() }
+            FictionResult.Success(
+                ListPage(
+                    items = items,
+                    page = page,
+                    // Default per_page=30 on the gists endpoints; signal
+                    // end-of-list when the page came back short.
+                    hasNext = items.size >= 30,
+                ),
+            )
+        }
+        is GitHubApiResult.NotFound -> FictionResult.Success(
+            ListPage(items = emptyList(), page = page, hasNext = false),
+        )
+        is GitHubApiResult.RateLimited -> FictionResult.RateLimited(
+            retryAfter = result.retryAfterSeconds?.let { it.toDuration(DurationUnit.SECONDS) },
+        )
+        is GitHubApiResult.HttpError -> FictionResult.NetworkError(
+            message = "GitHub error ${result.code}: ${result.message}",
+        )
+        is GitHubApiResult.NetworkError -> FictionResult.NetworkError(
+            message = "Could not reach GitHub",
+            cause = result.cause,
+        )
+        is GitHubApiResult.ParseError -> FictionResult.NetworkError(
+            message = "Malformed gists response",
+            cause = result.cause,
+        )
+    }
+
+    private fun GhGist.toFictionSummary(): FictionSummary {
+        val title = description?.takeIf { it.isNotBlank() }
+            ?: files.keys.firstOrNull()
+            ?: "Untitled gist"
+        return FictionSummary(
+            id = "${SourceIds.GITHUB}:$GIST_PREFIX$id",
+            sourceId = SourceIds.GITHUB,
+            title = title,
+            author = owner?.login.orEmpty(),
+            coverUrl = null,
+            description = if (public) null else "Secret gist",
+            tags = listOfNotNull(files.values.firstOrNull()?.language?.lowercase()),
+            // Gists have no lifecycle in the fiction sense; mark them
+            // ONGOING so they don't render with the COMPLETED badge.
+            status = FictionStatus.ONGOING,
+            chapterCount = files.size,
+            rating = null,
+        )
+    }
+
+    private suspend fun gistFictionDetail(
+        fictionId: String,
+        gistId: String,
+    ): FictionResult<FictionDetail> = when (val r = api.getGist(gistId)) {
+        is GitHubApiResult.Success -> FictionResult.Success(toGistFictionDetail(fictionId, r.value))
+        is GitHubApiResult.NotFound -> FictionResult.NotFound(message = r.message)
+        is GitHubApiResult.RateLimited -> FictionResult.RateLimited(
+            retryAfter = r.retryAfterSeconds?.let { it.toDuration(DurationUnit.SECONDS) },
+        )
+        is GitHubApiResult.HttpError -> FictionResult.NetworkError(
+            message = "GitHub error ${r.code}: ${r.message}",
+        )
+        is GitHubApiResult.NetworkError -> FictionResult.NetworkError(
+            message = "Could not reach GitHub",
+            cause = r.cause,
+        )
+        is GitHubApiResult.ParseError -> FictionResult.NetworkError(
+            message = "Malformed gist response",
+            cause = r.cause,
+        )
+    }
+
+    private fun toGistFictionDetail(fictionId: String, gist: GhGist): FictionDetail {
+        val title = gist.description?.takeIf { it.isNotBlank() }
+            ?: gist.files.keys.firstOrNull()
+            ?: "Untitled gist"
+        val author = gist.owner?.login.orEmpty()
+        // Each file in the gist's `files` map becomes a chapter. Single-
+        // file gists get one chapter titled after the file (the title
+        // field already shows the gist description); multi-file gists
+        // get the file map order GitHub returned, which matches the UI.
+        val chapters = gist.files.entries.mapIndexed { index, (filename, _) ->
+            ChapterInfo(
+                id = "$fictionId:$filename",
+                sourceChapterId = filename,
+                index = index,
+                title = filename,
+            )
+        }
+        return FictionDetail(
+            summary = FictionSummary(
+                id = fictionId,
+                sourceId = SourceIds.GITHUB,
+                title = title,
+                author = author,
+                coverUrl = null,
+                description = if (gist.public) gist.description else "Secret gist",
+                tags = listOfNotNull(gist.files.values.firstOrNull()?.language?.lowercase()),
+                status = FictionStatus.ONGOING,
+                chapterCount = chapters.size,
+                rating = null,
+            ),
+            chapters = chapters,
+            genres = emptyList(),
+            wordCount = null,
+            views = null,
+            followers = null,
+            lastUpdatedAt = null,
+            authorId = author.takeIf { it.isNotBlank() },
+        )
+    }
+
+    private suspend fun gistChapter(
+        fictionId: String,
+        gistId: String,
+        chapterId: String,
+    ): FictionResult<ChapterContent> {
+        val filename = chapterId.removePrefix("$fictionId:")
+        if (filename.isBlank() || filename == chapterId) {
+            return FictionResult.NotFound(message = "Malformed gist chapter id: $chapterId")
+        }
+        return when (val r = api.getGist(gistId)) {
+            is GitHubApiResult.Success -> {
+                val file = r.value.files[filename]
+                    ?: return FictionResult.NotFound(message = "Gist file not found: $filename")
+                val text = file.content
+                    ?: return FictionResult.NetworkError(
+                        message = "Gist file $filename had no inline content (truncated by GitHub)",
+                    )
+                val info = ChapterInfo(
+                    id = chapterId,
+                    sourceChapterId = filename,
+                    index = 0,
+                    title = filename,
+                )
+                // Gist files are typically markdown / plaintext; the
+                // existing markdown renderer handles both (a non-md
+                // source still yields a usable plainBody — markdown's
+                // graceful degradation is good enough here).
+                FictionResult.Success(markdownRenderer.render(info, text))
+            }
+            is GitHubApiResult.NotFound -> FictionResult.NotFound(message = r.message)
+            is GitHubApiResult.RateLimited -> FictionResult.RateLimited(
+                retryAfter = r.retryAfterSeconds?.let { it.toDuration(DurationUnit.SECONDS) },
+            )
+            is GitHubApiResult.HttpError -> FictionResult.NetworkError(
+                message = "GitHub error ${r.code}: ${r.message}",
+            )
+            is GitHubApiResult.NetworkError -> FictionResult.NetworkError(
+                message = "Could not reach GitHub",
+                cause = r.cause,
+            )
+            is GitHubApiResult.ParseError -> FictionResult.NetworkError(
+                message = "Malformed gist response",
+                cause = r.cause,
+            )
+        }
     }
 
     private suspend fun registryPage(
@@ -601,9 +830,20 @@ internal class GitHubSource @Inject constructor(
 
     private companion object {
         const val STEP_3F_AUTH = "GitHub source auth-gated calls not implemented yet — lands in step 3f (optional PAT support)"
+
         /** Per-page size for the auth-only feeds (#200, #201). 20 mirrors
          *  the search endpoint default so BrowsePaginator hands the user
          *  a consistent grid density across tabs. */
         const val MY_REPOS_PER_PAGE: Int = 20
+
+        /**
+         * Sub-prefix that separates a gist fiction id from an
+         * owner/repo fiction id. Both share the `github:` source
+         * prefix; `github:gist:<id>` resolves to the gist source path,
+         * `github:<owner>/<repo>` to the repo source path. Public
+         * because [latestRevisionToken] doesn't yet support gists and
+         * the cheap-poll worker uses this prefix to skip them.
+         */
+        const val GIST_PREFIX = "gist:"
     }
 }

--- a/source-github/src/main/kotlin/in/jphe/storyvox/source/github/auth/GitHubAuthConfig.kt
+++ b/source-github/src/main/kotlin/in/jphe/storyvox/source/github/auth/GitHubAuthConfig.kt
@@ -25,10 +25,14 @@ object GitHubAuthConfig {
 
     /**
      * Default scopes requested at sign-in. Spec § Scope minimization:
-     * least-privilege default. `repo` (private) and `gist` are deferred
-     * to opt-in toggles in future PRs.
+     * least-privilege default. `gist` was added (#202) so the GitHub
+     * source can list and resolve the user's gists as drafts. `repo`
+     * (full private-repo access) remains opt-in via the Settings
+     * toggle (#203). Existing signed-in users with the older scope set
+     * see a fresh Device Flow on next sign-in attempt — Sky's auth
+     * substrate detects the scope mismatch and re-authorizes.
      */
-    const val DEFAULT_SCOPES: String = "read:user public_repo"
+    const val DEFAULT_SCOPES: String = "read:user public_repo gist"
 
     /**
      * Scopes requested when the user has opted in to "Enable private

--- a/source-github/src/main/kotlin/in/jphe/storyvox/source/github/model/GitHubModels.kt
+++ b/source-github/src/main/kotlin/in/jphe/storyvox/source/github/model/GitHubModels.kt
@@ -146,3 +146,45 @@ internal data class GhCommitFile(
     @SerialName("sha") val sha: String? = null,
     @SerialName("previous_filename") val previousFilename: String? = null,
 )
+
+/**
+ * Subset of `GET /users/{user}/gists` and `GET /gists/{id}`. Listing
+ * responses carry a stub of [files] (no `content`); the per-gist
+ * `GET /gists/{id}` fetch carries the full body inline. The gist
+ * source layer (#202) treats single-file gists as single-chapter
+ * fictions and multi-file gists as multi-chapter ones.
+ *
+ * https://docs.github.com/en/rest/gists/gists
+ */
+@Serializable
+internal data class GhGist(
+    @SerialName("id") val id: String,
+    @SerialName("description") val description: String? = null,
+    @SerialName("html_url") val htmlUrl: String,
+    @SerialName("public") val public: Boolean = true,
+    @SerialName("owner") val owner: GhOwner? = null,
+    @SerialName("created_at") val createdAt: String? = null,
+    @SerialName("updated_at") val updatedAt: String? = null,
+    /**
+     * Map of filename → file metadata. The listing endpoint omits
+     * `content`; only the per-gist fetch populates it. Order is
+     * preserved as GitHub returns it (insertion order on the JSON
+     * object), which matches what the user sees in the gist UI.
+     */
+    @SerialName("files") val files: Map<String, GhGistFile> = emptyMap(),
+)
+
+@Serializable
+internal data class GhGistFile(
+    @SerialName("filename") val filename: String,
+    @SerialName("type") val type: String? = null, // mime, e.g. "text/markdown"
+    @SerialName("language") val language: String? = null,
+    @SerialName("size") val size: Long = 0,
+    /** Inline body — only present on `GET /gists/{id}`, not the listing. */
+    @SerialName("content") val content: String? = null,
+    @SerialName("raw_url") val rawUrl: String? = null,
+    /** True when the listing-endpoint omitted [content] because it was
+     *  too large; the fetch shape on `GET /gists/{id}` will then also
+     *  omit it. Storyvox doesn't render truncated gists today. */
+    @SerialName("truncated") val truncated: Boolean = false,
+)

--- a/source-github/src/main/kotlin/in/jphe/storyvox/source/github/net/GitHubApi.kt
+++ b/source-github/src/main/kotlin/in/jphe/storyvox/source/github/net/GitHubApi.kt
@@ -3,6 +3,7 @@ package `in`.jphe.storyvox.source.github.net
 import `in`.jphe.storyvox.source.github.di.GitHubHttp
 import `in`.jphe.storyvox.source.github.model.GhCommitRef
 import `in`.jphe.storyvox.source.github.model.GhCompareResponse
+import `in`.jphe.storyvox.source.github.model.GhGist
 import `in`.jphe.storyvox.source.github.model.GhSearchResponse
 import `in`.jphe.storyvox.source.github.model.GhContent
 import `in`.jphe.storyvox.source.github.model.GhRepo
@@ -178,6 +179,48 @@ internal open class GitHubApi @Inject constructor(
     ): GitHubApiResult<List<GhRepo>> = get(
         "$BASE_URL/user/starred?sort=updated&page=$page&per_page=$perPage",
     )
+
+    /**
+     * `GET /users/{user}/gists` — public gists for [user]. The listing
+     * shape returns metadata + a stub `files` map without `content`;
+     * use [getGist] to fetch a single gist with bodies inline.
+     *
+     * https://docs.github.com/en/rest/gists/gists#list-gists-for-a-user
+     */
+    open suspend fun userGists(
+        user: String,
+        page: Int = 1,
+        perPage: Int = 30,
+    ): GitHubApiResult<List<GhGist>> {
+        val safeUser = java.net.URLEncoder.encode(user.trim(), "UTF-8")
+        return get("$BASE_URL/users/$safeUser/gists?page=$page&per_page=$perPage")
+    }
+
+    /**
+     * `GET /gists` — gists for the authenticated user. Includes
+     * private/secret gists in the response when the bearer token has
+     * the `gist` scope. Falls back to public-only when the token is
+     * absent or scope-deficient.
+     *
+     * https://docs.github.com/en/rest/gists/gists#list-gists-for-the-authenticated-user
+     */
+    open suspend fun authenticatedUserGists(
+        page: Int = 1,
+        perPage: Int = 30,
+    ): GitHubApiResult<List<GhGist>> =
+        get("$BASE_URL/gists?page=$page&per_page=$perPage")
+
+    /**
+     * `GET /gists/{gist_id}` — fetch a single gist with full inline
+     * file bodies. The listing endpoints omit `files[*].content`; this
+     * is the canonical fetch path for rendering.
+     *
+     * https://docs.github.com/en/rest/gists/gists#get-a-gist
+     */
+    open suspend fun getGist(gistId: String): GitHubApiResult<GhGist> {
+        val safeId = java.net.URLEncoder.encode(gistId.trim(), "UTF-8")
+        return get("$BASE_URL/gists/$safeId")
+    }
 
     private suspend inline fun <reified T> get(url: String): GitHubApiResult<T> =
         withContext(Dispatchers.IO) {

--- a/source-github/src/test/kotlin/in/jphe/storyvox/source/github/GitHubSourceTest.kt
+++ b/source-github/src/test/kotlin/in/jphe/storyvox/source/github/GitHubSourceTest.kt
@@ -852,6 +852,155 @@ class GitHubSourceTest {
             perPage: Int,
         ): GitHubApiResult<List<GhRepo>> =
             myReposByPage[page] ?: GitHubApiResult.NotFound("no /user/repos page $page")
+
+        override suspend fun userGists(
+            user: String,
+            page: Int,
+            perPage: Int,
+        ): GitHubApiResult<List<`in`.jphe.storyvox.source.github.model.GhGist>> =
+            GitHubApiResult.Success(emptyList(), etag = null)
+
+        override suspend fun authenticatedUserGists(
+            page: Int,
+            perPage: Int,
+        ): GitHubApiResult<List<`in`.jphe.storyvox.source.github.model.GhGist>> =
+            GitHubApiResult.Success(emptyList(), etag = null)
+
+        override suspend fun getGist(
+            gistId: String,
+        ): GitHubApiResult<`in`.jphe.storyvox.source.github.model.GhGist> =
+            GitHubApiResult.NotFound("gist not found")
+    }
+
+    // ─── Gists (#202) ──────────────────────────────────────────────────
+
+    private fun ghGist(
+        id: String,
+        description: String? = null,
+        ownerLogin: String? = "octocat",
+        public: Boolean = true,
+        files: Map<String, String> = mapOf("file.md" to "body"),
+    ): `in`.jphe.storyvox.source.github.model.GhGist =
+        `in`.jphe.storyvox.source.github.model.GhGist(
+            id = id,
+            description = description,
+            htmlUrl = "https://gist.github.com/$ownerLogin/$id",
+            public = public,
+            owner = ownerLogin?.let { GhOwner(login = it) },
+            files = files.mapValues { (name, body) ->
+                `in`.jphe.storyvox.source.github.model.GhGistFile(
+                    filename = name,
+                    content = body,
+                    size = body.length.toLong(),
+                )
+            },
+        )
+
+    private class GistFakeApi(
+        private val gists: Map<String, `in`.jphe.storyvox.source.github.model.GhGist> = emptyMap(),
+        private val authedList: List<`in`.jphe.storyvox.source.github.model.GhGist> = emptyList(),
+    ) : GitHubApi(httpClient = OkHttpClient()) {
+        override suspend fun getRepo(owner: String, repo: String) =
+            GitHubApiResult.NotFound("not used")
+        override suspend fun authenticatedUserGists(page: Int, perPage: Int) =
+            GitHubApiResult.Success(authedList, etag = null)
+        override suspend fun getGist(gistId: String) =
+            gists[gistId]?.let { GitHubApiResult.Success(it, etag = null) }
+                ?: GitHubApiResult.NotFound("gist not found")
+    }
+
+    @Test fun `authenticatedUserGists maps gist titles via description, then first filename`() = runBlocking {
+        val src = source(
+            api = GistFakeApi(
+                authedList = listOf(
+                    ghGist("a", description = "My snippet"),
+                    ghGist("b", description = null, files = mapOf("notes.md" to "x")),
+                    ghGist("c", description = "  ", files = mapOf("first.md" to "x", "second.md" to "y")),
+                ),
+            ),
+        )
+        val r = src.authenticatedUserGists(page = 1) as FictionResult.Success
+        assertEquals(3, r.value.items.size)
+        assertEquals("My snippet", r.value.items[0].title)
+        // Blank description still falls through to filename.
+        assertEquals("first.md", r.value.items[2].title)
+        assertEquals("notes.md", r.value.items[1].title)
+        assertEquals("github:gist:a", r.value.items[0].id)
+        assertEquals(SourceIds.GITHUB, r.value.items[0].sourceId)
+    }
+
+    @Test fun `gist fictionDetail builds chapters from files map preserving order`() = runBlocking {
+        val src = source(
+            api = GistFakeApi(
+                gists = mapOf(
+                    "abc" to ghGist(
+                        id = "abc",
+                        description = "Two-part gist",
+                        files = linkedMapOf(
+                            "01-intro.md" to "Hello world",
+                            "02-end.md" to "Goodbye",
+                        ),
+                    ),
+                ),
+            ),
+        )
+        val r = src.fictionDetail("github:gist:abc") as FictionResult.Success
+        val d = r.value
+        assertEquals("github:gist:abc", d.summary.id)
+        assertEquals("Two-part gist", d.summary.title)
+        assertEquals(2, d.chapters.size)
+        assertEquals("01-intro.md", d.chapters[0].title)
+        assertEquals("github:gist:abc:01-intro.md", d.chapters[0].id)
+        assertEquals("02-end.md", d.chapters[1].title)
+        assertEquals(0, d.chapters[0].index)
+        assertEquals(1, d.chapters[1].index)
+    }
+
+    @Test fun `gist chapter renders file content via markdown renderer`() = runBlocking {
+        val src = source(
+            api = GistFakeApi(
+                gists = mapOf(
+                    "abc" to ghGist(
+                        id = "abc",
+                        files = mapOf("only.md" to "# Title\n\nBody text."),
+                    ),
+                ),
+            ),
+        )
+        val r = src.chapter("github:gist:abc", "github:gist:abc:only.md") as FictionResult.Success
+        assertTrue(r.value.htmlBody.contains("<h1>Title</h1>"))
+        assertTrue(r.value.plainBody.contains("Body text"))
+        assertEquals("only.md", r.value.info.title)
+    }
+
+    @Test fun `gist chapter surfaces NotFound when file absent`() = runBlocking {
+        val src = source(
+            api = GistFakeApi(
+                gists = mapOf("abc" to ghGist(id = "abc", files = mapOf("a.md" to ""))),
+            ),
+        )
+        val r = src.chapter("github:gist:abc", "github:gist:abc:b.md")
+        assertTrue(r is FictionResult.NotFound)
+    }
+
+    @Test fun `gist fiction id is rejected by parseFictionId so repo path is not entered`() = runBlocking {
+        // Repo-coords parser must reject `gist:`-prefixed ids so the
+        // gist codepath wins. A fiction id that confused the two would
+        // try to fetch `getRepo("gist", "abc")` which doesn't exist.
+        val src = source(api = GistFakeApi())
+        val r = src.fictionDetail("github:gist:abc")
+        // GistFakeApi.getGist returns NotFound for unknown ids.
+        assertTrue("got $r", r is FictionResult.NotFound)
+    }
+
+    @Test fun `latestRevisionToken on gist returns null without calling the API`() = runBlocking {
+        // Gists have no revision tokens — return Success(null) so the
+        // worker treats it as "no token, use full path" rather than
+        // dropping the fiction.
+        val src = source(api = GistFakeApi())
+        val r = src.latestRevisionToken("github:gist:abc")
+        assertTrue("got $r", r is FictionResult.Success)
+        assertEquals(null, (r as FictionResult.Success).value)
     }
 
 }


### PR DESCRIPTION
## Summary

GitHub Gists as fiction drafts (#202 — OAuth follow-up F3).

- **Scope upgrade**: `GitHubAuthConfig.DEFAULT_SCOPES` now includes `gist`. Existing signed-in users see a fresh Device Flow on next sign-in.
- **API**: `GitHubApi.userGists`, `authenticatedUserGists`, `getGist`. New `GhGist` + `GhGistFile` models.
- **Source mapping**: gist fictionIds use `github:gist:<id>`; single-file gists → single chapter, multi-file → multi-chapter. `latestRevisionToken` short-circuits to `Success(null)` for gists (no commit history via REST).
- **Browse**: new **Gists** tab visible only when a GitHub session is captured. Sign-out snaps back to Popular. Routes through new `BrowseSource.GitHubGists` variant.
- **URL router**: recognises `https://gist.github.com/[user/]<id>` and short form `gist:<id>`.
- **Public facade**: `GitHubGistsService` exposes the gist methods to `:app` (the source class itself stays effectively internal — only the constructor is internal).

## Test plan

- [x] `:source-github:test` — new gist tests cover title fallback (description → filename), chapter ordering, file-not-found, fictionId parser disambiguation, revision-token short-circuit.
- [x] `:core-data:test` — new gist URL routing tests (with/without user prefix, revision suffix, mixed-case, short form, hex requirement).
- [x] `:feature:test` — green.
- [x] `:app:assembleDebug` — green.
- [ ] Smoke test on tablet: Browse → GitHub → Gists → tap-through to a gist's chapter list.

## Files

- `source-github/.../auth/GitHubAuthConfig.kt`
- `source-github/.../net/GitHubApi.kt`
- `source-github/.../model/GitHubModels.kt`
- `source-github/.../GitHubSource.kt`
- `source-github/.../GitHubGistsService.kt` (new)
- `core-data/.../source/UrlRouter.kt`
- `feature/.../api/UiContracts.kt` — `BrowseSource.GitHubGists`
- `feature/.../browse/BrowseViewModel.kt` — `BrowseTab.Gists` + `supportedTabsFor`
- `feature/.../browse/BrowseScreen.kt`
- `app/.../di/AppBindings.kt`

Closes #202

Sibling PRs touch the same Browse + GitHubApi files (#200 / #201 / #203 / #204) — orchestrator handles rebases.

🤖 Generated with [Claude Code](https://claude.com/claude-code)