### PR TITLE
feat(browse): GitHub My Repos tab gated on OAuth sign-in (#200)

### DIFF
--- a/app/src/main/kotlin/in/jphe/storyvox/di/AppBindings.kt
+++ b/app/src/main/kotlin/in/jphe/storyvox/di/AppBindings.kt
@@ -94,8 +94,10 @@ object AppBindings {
         RealFictionRepositoryUi(repo)
 
     @Provides @Singleton
-    fun provideBrowseRepositoryUi(repo: FictionRepository): BrowseRepositoryUi =
-        RealBrowseRepositoryUi(repo)
+    fun provideBrowseRepositoryUi(
+        repo: FictionRepository,
+        github: `in`.jphe.storyvox.source.github.GitHubAuthedSource,
+    ): BrowseRepositoryUi = RealBrowseRepositoryUi(repo, github)
 
     @Provides @Singleton
     fun providePlaybackControllerUi(
@@ -300,6 +302,7 @@ private fun relativeTime(epochMs: Long?): String {
  */
 private class RealBrowseRepositoryUi(
     private val repo: FictionRepository,
+    private val github: `in`.jphe.storyvox.source.github.GitHubAuthedSource,
 ) : BrowseRepositoryUi {
     override fun paginator(source: BrowseSource, sourceId: String): BrowsePaginator =
         RealBrowsePaginator { page ->
@@ -341,6 +344,16 @@ private class RealBrowseRepositoryUi(
                     page = page,
                     sourceId = sourceId,
                 )
+                // #200 — auth-gated `/user/repos` listing. Bypasses the
+                // FictionRepository.search path because the endpoint
+                // shape doesn't fit `SearchQuery` (no qualifier syntax,
+                // affiliation filter only). Routes directly to the
+                // source surface, then funnels the result through
+                // `cacheBrowseListing` so each row lands in the DB with
+                // its `sourceId="github"` — without that, tapping a
+                // card hits `refreshDetail`'s "no row → fall back to
+                // RR source" branch and 404s on the github fictionId.
+                BrowseSource.GitHubMyRepos -> repo.cacheBrowseListing(github.myRepos(page = page))
             }
         }
 

--- a/core-data/src/main/kotlin/in/jphe/storyvox/data/repository/FictionRepository.kt
+++ b/core-data/src/main/kotlin/in/jphe/storyvox/data/repository/FictionRepository.kt
@@ -61,6 +61,22 @@ interface FictionRepository {
         sourceId: String = SourceIds.ROYAL_ROAD,
     ): FictionResult<ListPage<FictionSummary>>
 
+    /**
+     * Cache an externally-fetched browse listing the same way
+     * [browsePopular] / [search] do — `upsertAllPreservingUserState` so
+     * a subsequent `refreshDetail(id)` finds a row with the right
+     * `sourceId` and routes to the correct source.
+     *
+     * Used by source-specific listing endpoints that don't fit
+     * [SearchQuery] (e.g. GitHub `/user/repos` for #200) so their
+     * results materialize as DB-backed fictions when the user taps a
+     * card. [result] is returned untouched on either success or
+     * failure; callers use this as a transparent passthrough.
+     */
+    suspend fun cacheBrowseListing(
+        result: FictionResult<ListPage<FictionSummary>>,
+    ): FictionResult<ListPage<FictionSummary>>
+
     suspend fun genres(
         sourceId: String = SourceIds.ROYAL_ROAD,
     ): FictionResult<List<String>>
@@ -178,6 +194,10 @@ class FictionRepositoryImpl @Inject constructor(
 
     override suspend fun genres(sourceId: String): FictionResult<List<String>> =
         sourceFor(sourceId).genres()
+
+    override suspend fun cacheBrowseListing(
+        result: FictionResult<ListPage<FictionSummary>>,
+    ): FictionResult<ListPage<FictionSummary>> = cacheListing(result)
 
     override suspend fun refreshDetail(id: String): FictionResult<Unit> = withContext(Dispatchers.IO) {
         // Look up the persisted row to route to the correct source. Falls

--- a/feature/src/main/kotlin/in/jphe/storyvox/feature/api/UiContracts.kt
+++ b/feature/src/main/kotlin/in/jphe/storyvox/feature/api/UiContracts.kt
@@ -136,6 +136,14 @@ sealed interface BrowseSource {
      * inside the wing by drawer count.
      */
     data class ByGenre(val genre: String) : BrowseSource
+
+    /**
+     * Auth-gated `/user/repos` listing for the signed-in GitHub user
+     * (#200). Only meaningful when `BrowseSourceKey.GitHub` is selected
+     * AND `UiSettings.github` is signed-in; the BrowseViewModel gates
+     * the tab visibility, the adapter routes to `GitHubAuthedSource`.
+     */
+    data object GitHubMyRepos : BrowseSource
 }
 
 /** A page-by-page accumulating cursor over a remote fiction listing.

--- a/feature/src/main/kotlin/in/jphe/storyvox/feature/browse/BrowseScreen.kt
+++ b/feature/src/main/kotlin/in/jphe/storyvox/feature/browse/BrowseScreen.kt
@@ -82,7 +82,9 @@ fun BrowseScreen(
             modifier = Modifier.fillMaxWidth().padding(horizontal = spacing.md),
         )
 
-        val supportedTabs = remember(state.sourceKey) { state.sourceKey.supportedTabs() }
+        val supportedTabs = remember(state.sourceKey, state.githubSignedIn) {
+            state.sourceKey.supportedTabs(state.githubSignedIn)
+        }
         Row(
             modifier = Modifier.fillMaxWidth(),
             verticalAlignment = Alignment.CenterVertically,
@@ -391,6 +393,7 @@ private val BrowseTab.label: String
         BrowseTab.NewReleases -> "New"
         BrowseTab.BestRated -> "Best Rated"
         BrowseTab.Search -> "Search"
+        BrowseTab.MyRepos -> "My Repos"
     }
 
 /**

--- a/feature/src/main/kotlin/in/jphe/storyvox/feature/browse/BrowseViewModel.kt
+++ b/feature/src/main/kotlin/in/jphe/storyvox/feature/browse/BrowseViewModel.kt
@@ -11,7 +11,9 @@ import `in`.jphe.storyvox.feature.api.BrowseRepositoryUi
 import `in`.jphe.storyvox.feature.api.BrowseSource
 import `in`.jphe.storyvox.feature.api.GitHubSearchFilter
 import `in`.jphe.storyvox.feature.api.MemPalaceFilter
+import `in`.jphe.storyvox.feature.api.SettingsRepositoryUi
 import `in`.jphe.storyvox.feature.api.UiFiction
+import `in`.jphe.storyvox.feature.api.UiGitHubAuthState
 import `in`.jphe.storyvox.feature.api.UiSearchOrder
 import `in`.jphe.storyvox.feature.api.UiSortDirection
 import javax.inject.Inject
@@ -31,7 +33,7 @@ import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.launch
 
-enum class BrowseTab { Popular, NewReleases, BestRated, Search }
+enum class BrowseTab { Popular, NewReleases, BestRated, Search, MyRepos }
 
 /**
  * Top-level source picker on the Browse screen. Chooses which
@@ -56,19 +58,26 @@ enum class BrowseSourceKey(val sourceId: String, val displayName: String) {
  *  curator rating but doesn't yet sort by it), so it's hidden on
  *  GitHub. Search is wired as of step 8b — flips
  *  `GitHubSource.search()` to `/search/repositories?q=topic:fiction
- *  +{userQuery}`. */
-fun BrowseSourceKey.supportedTabs(): List<BrowseTab> = when (this) {
+ *  +{userQuery}`.
+ *
+ *  [githubSignedIn] gates the `MyRepos` tab on the GitHub source
+ *  (#200) — visible only when the user has captured an OAuth session
+ *  via the Device Flow. Defaulting false keeps existing call sites
+ *  (tests, screens that don't observe settings yet) on the anonymous
+ *  tab list. */
+fun BrowseSourceKey.supportedTabs(githubSignedIn: Boolean = false): List<BrowseTab> = when (this) {
     BrowseSourceKey.RoyalRoad -> listOf(
         BrowseTab.Popular,
         BrowseTab.NewReleases,
         BrowseTab.BestRated,
         BrowseTab.Search,
     )
-    BrowseSourceKey.GitHub -> listOf(
-        BrowseTab.Popular,
-        BrowseTab.NewReleases,
-        BrowseTab.Search,
-    )
+    BrowseSourceKey.GitHub -> buildList {
+        add(BrowseTab.Popular)
+        add(BrowseTab.NewReleases)
+        if (githubSignedIn) add(BrowseTab.MyRepos)
+        add(BrowseTab.Search)
+    }
     // Spec: docs/superpowers/specs/2026-05-08-mempalace-integration-design.md.
     // - Popular = Wings tab (top-N rooms by drawer count).
     // - NewReleases = Recent tab (rooms ordered by latest drawer).
@@ -115,6 +124,9 @@ data class BrowseUiState(
      *  lazily on first switch to MemPalace; empty until the daemon
      *  responds (or daemon unreachable). */
     val palaceWings: List<String> = emptyList(),
+    /** True when an OAuth session is captured (#200). Drives the
+     *  `MyRepos` tab visibility on the GitHub source. */
+    val githubSignedIn: Boolean = false,
 )
 
 /** Typed view of a paginator's five state flows. Lifted into its own
@@ -129,11 +141,12 @@ private data class PaginatorView(
 )
 
 /** Bundled view of the user-controllable knobs (source picker, tab,
- *  query, RR filter, GitHub filter, MemPalace filter). Lifted into its
- *  own record so the outer combines stay within the 5-arg `combine`
- *  overload as we add filter shapes per source. The MemPalace filter
- *  is folded in via a nested combine (see [BrowseViewModel.controls])
- *  to keep within the overload arity. */
+ *  query, RR filter, GitHub filter, MemPalace filter, GH sign-in).
+ *  Lifted into its own record so the outer combines stay within the
+ *  5-arg `combine` overload as we add filter shapes per source. The
+ *  MemPalace filter and the sign-in flag are folded in via nested
+ *  combines (see [BrowseViewModel.controls]) to keep within the
+ *  overload arity. */
 private data class ControlsView(
     val sourceKey: BrowseSourceKey,
     val tab: BrowseTab,
@@ -141,6 +154,7 @@ private data class ControlsView(
     val filter: BrowseFilter,
     val githubFilter: GitHubSearchFilter,
     val palaceFilter: MemPalaceFilter,
+    val githubSignedIn: Boolean,
 )
 
 /**
@@ -160,6 +174,7 @@ private data class ControlsView(
 @HiltViewModel
 class BrowseViewModel @Inject constructor(
     private val repo: BrowseRepositoryUi,
+    settings: SettingsRepositoryUi,
 ) : ViewModel() {
 
     private val _sourceKey = MutableStateFlow(BrowseSourceKey.RoyalRoad)
@@ -175,13 +190,22 @@ class BrowseViewModel @Inject constructor(
     private var palaceWingsLoaded = false
     val query: StateFlow<String> = _query.asStateFlow()
 
+    /** Github sign-in projection — drives MyRepos tab visibility (#200).
+     *  `Expired` reads as signed-out: the disk copy is intact for Settings
+     *  to render "session expired" but the listing endpoint would 401, so
+     *  hiding the tab keeps the user from a guaranteed-failure path. */
+    private val githubSignedIn: StateFlow<Boolean> = settings.settings
+        .map { it.github is UiGitHubAuthState.SignedIn }
+        .distinctUntilChanged()
+        .stateIn(viewModelScope, SharingStarted.WhileSubscribed(5_000), false)
+
     /** Active paginator for the current tuple; null when the search tab
      *  has neither a query nor active filters (the empty search hint is
-     *  shown instead). Two-step combine: first the 5-arg base tuple
-     *  (source/tab/query/RRFilter/GHFilter), then merged with the
-     *  MemPalace filter to keep within `combine`'s 5-arg overload. */
-    private val paginator: StateFlow<BrowsePaginator?> = combine(
-        combine(
+     *  shown instead). Multi-step combine: the 5-arg overload is full
+     *  with source/tab/query/RRFilter/GHFilter, so palaceFilter (#191)
+     *  and githubSignedIn (#200) layer on top in nested combines. */
+    private val paginator: StateFlow<BrowsePaginator?> = run {
+        val baseTuple = combine(
             _sourceKey,
             _tab,
             _query.debounce(300),
@@ -189,15 +213,22 @@ class BrowseViewModel @Inject constructor(
             _githubFilter,
         ) { sourceKey, tab, q, filter, ghFilter ->
             ResolveTuple(sourceKey, tab, q, filter, ghFilter)
-        },
-        _palaceFilter,
-    ) { tup, palaceFilter ->
-        resolveSource(tup.sourceKey, tup.tab, tup.q, tup.filter, tup.ghFilter, palaceFilter)
-            ?.let { source -> source to tup.sourceKey.sourceId }
+        }
+        combine(baseTuple, _palaceFilter, githubSignedIn) { tup, palaceFilter, signedIn ->
+            resolveSource(
+                sourceKey = tup.sourceKey,
+                tab = tup.tab,
+                q = tup.q,
+                filter = tup.filter,
+                githubFilter = tup.ghFilter,
+                palaceFilter = palaceFilter,
+                githubSignedIn = signedIn,
+            )?.let { source -> source to tup.sourceKey.sourceId }
+        }
+            .distinctUntilChanged()
+            .map { pair -> pair?.let { (source, sourceId) -> repo.paginator(source, sourceId) } }
+            .stateIn(viewModelScope, SharingStarted.WhileSubscribed(5_000), null)
     }
-        .distinctUntilChanged()
-        .map { pair -> pair?.let { (source, sourceId) -> repo.paginator(source, sourceId) } }
-        .stateIn(viewModelScope, SharingStarted.WhileSubscribed(5_000), null)
 
     init {
         // Kick off the initial page whenever a fresh paginator lands.
@@ -208,19 +239,41 @@ class BrowseViewModel @Inject constructor(
         viewModelScope.launch {
             paginator.collectLatest { p -> p?.loadNext() }
         }
+        // Auto-snap off `MyRepos` when the user signs out (#200). The
+        // tab disappears from `supportedTabs(githubSignedIn=false)`, so
+        // leaving the value pinned would render an empty grid driven by
+        // a null BrowseSource. Snap to Popular so the screen has
+        // something to draw.
+        viewModelScope.launch {
+            githubSignedIn.collectLatest { signedIn ->
+                if (!signedIn && _tab.value == BrowseTab.MyRepos) {
+                    _tab.value = BrowseTab.Popular
+                }
+            }
+        }
     }
 
-    /** All user-controlled knobs collapsed into one typed record so the
-     *  outer combines below stay within the 5-arg `combine` overload.
-     *  The MemPalace filter is folded in via a nested combine to stay
-     *  within the overload arity. */
-    private val controls: kotlinx.coroutines.flow.Flow<ControlsView> = combine(
-        combine(_sourceKey, _tab, _query, _filter, _githubFilter) { sourceKey, tab, q, filter, ghFilter ->
+    /** All user-controlled knobs collapsed into one typed record. The
+     *  inner 5-arg combine builds the base tuple; outer combines fold
+     *  in palaceFilter (#191) and githubSignedIn (#200) without
+     *  exceeding the `combine` 5-arg overload. */
+    private val controls: kotlinx.coroutines.flow.Flow<ControlsView> = run {
+        val baseTuple = combine(
+            _sourceKey, _tab, _query, _filter, _githubFilter,
+        ) { sourceKey, tab, q, filter, ghFilter ->
             ResolveTuple(sourceKey, tab, q, filter, ghFilter)
-        },
-        _palaceFilter,
-    ) { tup, palaceFilter ->
-        ControlsView(tup.sourceKey, tup.tab, tup.q, tup.filter, tup.ghFilter, palaceFilter)
+        }
+        combine(baseTuple, _palaceFilter, githubSignedIn) { tup, palaceFilter, signedIn ->
+            ControlsView(
+                sourceKey = tup.sourceKey,
+                tab = tup.tab,
+                query = tup.q,
+                filter = tup.filter,
+                githubFilter = tup.ghFilter,
+                palaceFilter = palaceFilter,
+                githubSignedIn = signedIn,
+            )
+        }
     }
 
     val uiState: StateFlow<BrowseUiState> = paginator.flatMapLatest { p ->
@@ -243,6 +296,7 @@ class BrowseViewModel @Inject constructor(
                     isGitHubFilterActive = c.githubFilter.isActive(),
                     palaceFilter = c.palaceFilter,
                     palaceWings = wings,
+                    githubSignedIn = c.githubSignedIn,
                 )
             }
         } else {
@@ -275,6 +329,7 @@ class BrowseViewModel @Inject constructor(
                     isGitHubFilterActive = c.githubFilter.isActive(),
                     palaceFilter = c.palaceFilter,
                     palaceWings = wings,
+                    githubSignedIn = c.githubSignedIn,
                 )
             }
         }
@@ -285,9 +340,9 @@ class BrowseViewModel @Inject constructor(
         _sourceKey.value = key
         // If the previously-selected tab isn't supported on the new
         // source (e.g. user was on BestRated/Search on RR and switches
-        // to GitHub), snap to Popular so the screen has something
-        // sensible to render.
-        if (_tab.value !in key.supportedTabs()) {
+        // to GitHub, or MyRepos when not on GitHub), snap to Popular so
+        // the screen has something sensible to render.
+        if (_tab.value !in key.supportedTabs(githubSignedIn.value)) {
             _tab.value = BrowseTab.Popular
         }
         // Per-source filter shapes don't translate, so clear the
@@ -364,12 +419,16 @@ private fun resolveSource(
     filter: BrowseFilter,
     githubFilter: GitHubSearchFilter,
     palaceFilter: MemPalaceFilter,
+    githubSignedIn: Boolean,
 ): BrowseSource? = when (sourceKey) {
     // GitHub: filter takes priority over tab. When filter is active OR
     // user is on Search with a typed query, route to FilteredGitHub so
     // the qualifier-laden query lands. Otherwise the tab decides
-    // (Popular/NewReleases/Search). Search-with-blank-query stays null
-    // so the screen renders SearchHint.
+    // (Popular/NewReleases/MyRepos/Search). MyRepos is sign-in-gated;
+    // a stale tab value when the user has signed out maps to null
+    // (BrowseScreen will see the tab missing from supportedTabs and
+    // re-snap). Search-with-blank-query stays null so the screen
+    // renders SearchHint.
     BrowseSourceKey.GitHub -> when {
         githubFilter.isActive() -> BrowseSource.FilteredGitHub(
             query = if (tab == BrowseTab.Search) q else "",
@@ -377,6 +436,7 @@ private fun resolveSource(
         )
         tab == BrowseTab.Popular -> BrowseSource.Popular
         tab == BrowseTab.NewReleases -> BrowseSource.NewReleases
+        tab == BrowseTab.MyRepos -> if (githubSignedIn) BrowseSource.GitHubMyRepos else null
         tab == BrowseTab.Search -> if (q.isBlank()) null else BrowseSource.Search(q)
         else -> null
     }

--- a/source-github/src/main/kotlin/in/jphe/storyvox/source/github/GitHubAuthedSource.kt
+++ b/source-github/src/main/kotlin/in/jphe/storyvox/source/github/GitHubAuthedSource.kt
@@ -1,0 +1,34 @@
+package `in`.jphe.storyvox.source.github
+
+import `in`.jphe.storyvox.data.source.model.FictionResult
+import `in`.jphe.storyvox.data.source.model.FictionSummary
+import `in`.jphe.storyvox.data.source.model.ListPage
+
+/**
+ * Auth-gated GitHub listings exposed across the module boundary.
+ *
+ * The base [`in`.jphe.storyvox.data.source.FictionSource] surface is
+ * source-agnostic; entries here are *GitHub-specific* and only meaningful
+ * when the user has signed in via the OAuth Device Flow (#91). Each
+ * implementation method internally requires the bearer token attached
+ * by [`in`.jphe.storyvox.source.github.auth.GitHubAuthInterceptor]; an
+ * anonymous caller gets a `FictionResult.NetworkError` (the 401 maps
+ * through `mapResponse` → `HttpError(401, ...)` → `NetworkError`).
+ *
+ * Surfaced as a public interface so the app-module Browse adapter can
+ * route `BrowseSource.GitHubMyRepos` to this surface without exposing
+ * the package-internal [GitHubSource] implementation type. Hilt binds
+ * [GitHubSource] to this interface in
+ * [`in`.jphe.storyvox.source.github.di.GitHubBindings].
+ */
+interface GitHubAuthedSource {
+    /**
+     * `/user/repos?affiliation=owner,collaborator&sort=updated`. One
+     * page of the signed-in user's repos. Each result maps to a
+     * GitHub fiction id (`github:owner/repo`) consumable by
+     * `GitHubSource.fictionDetail` — the Browse → My Repos row uses
+     * this exactly like the Popular/NewReleases tabs use the curated
+     * registry.
+     */
+    suspend fun myRepos(page: Int): FictionResult<ListPage<FictionSummary>>
+}

--- a/source-github/src/main/kotlin/in/jphe/storyvox/source/github/GitHubSource.kt
+++ b/source-github/src/main/kotlin/in/jphe/storyvox/source/github/GitHubSource.kt
@@ -53,7 +53,7 @@ internal class GitHubSource @Inject constructor(
     private val api: GitHubApi,
     private val registry: Registry,
     private val markdownRenderer: MarkdownChapterRenderer,
-) : FictionSource {
+) : FictionSource, GitHubAuthedSource {
 
     override val id: String = SourceIds.GITHUB
     override val displayName: String = "GitHub"
@@ -148,6 +148,47 @@ internal class GitHubSource @Inject constructor(
             )
         }
     }
+
+    /**
+     * `GET /user/repos` — auth-gated listing of the signed-in user's
+     * repos (#200). Maps each row through [toFictionSummary] so they
+     * route through the same `fictionDetail(github:owner/repo)` path
+     * as curated-registry entries; manifest detection still applies,
+     * so a repo without `book.toml` falls back to the bare-repo dir
+     * listing. `hasNext` infers from page-fill (no Link-header parsing
+     * yet) — a full page strongly implies another exists; a short
+     * page is always the last one.
+     */
+    override suspend fun myRepos(page: Int): FictionResult<ListPage<FictionSummary>> =
+        when (val r = api.myRepos(page = page, perPage = MY_REPOS_PER_PAGE)) {
+            is GitHubApiResult.Success -> {
+                val items = r.value.map { it.toFictionSummary() }
+                FictionResult.Success(
+                    ListPage(
+                        items = items,
+                        page = page,
+                        hasNext = items.size >= MY_REPOS_PER_PAGE,
+                    ),
+                )
+            }
+            is GitHubApiResult.NotFound -> FictionResult.Success(
+                ListPage(items = emptyList(), page = page, hasNext = false),
+            )
+            is GitHubApiResult.RateLimited -> FictionResult.RateLimited(
+                retryAfter = r.retryAfterSeconds?.let { it.toDuration(DurationUnit.SECONDS) },
+            )
+            is GitHubApiResult.HttpError -> FictionResult.NetworkError(
+                message = "GitHub error ${r.code}: ${r.message}",
+            )
+            is GitHubApiResult.NetworkError -> FictionResult.NetworkError(
+                message = "Could not reach GitHub",
+                cause = r.cause,
+            )
+            is GitHubApiResult.ParseError -> FictionResult.NetworkError(
+                message = "Malformed /user/repos response",
+                cause = r.cause,
+            )
+        }
 
     /**
      * Map a GitHub repo into the cross-source [FictionSummary]. Cover
@@ -516,5 +557,9 @@ internal class GitHubSource @Inject constructor(
 
     private companion object {
         const val STEP_3F_AUTH = "GitHub source auth-gated calls not implemented yet — lands in step 3f (optional PAT support)"
+        /** `/user/repos` per_page. 20 mirrors the search endpoint default
+         *  used elsewhere in the source so the BrowsePaginator hands the
+         *  user a consistent grid density across tabs. */
+        const val MY_REPOS_PER_PAGE: Int = 20
     }
 }

--- a/source-github/src/main/kotlin/in/jphe/storyvox/source/github/di/GitHubModule.kt
+++ b/source-github/src/main/kotlin/in/jphe/storyvox/source/github/di/GitHubModule.kt
@@ -9,6 +9,7 @@ import dagger.multibindings.IntoMap
 import dagger.multibindings.StringKey
 import `in`.jphe.storyvox.data.source.FictionSource
 import `in`.jphe.storyvox.data.source.SourceIds
+import `in`.jphe.storyvox.source.github.GitHubAuthedSource
 import `in`.jphe.storyvox.source.github.GitHubSource
 import `in`.jphe.storyvox.source.github.auth.DeviceFlowApi
 import `in`.jphe.storyvox.source.github.auth.GitHubAuthInterceptor
@@ -107,6 +108,15 @@ internal abstract class GitHubBindings {
     @IntoMap
     @StringKey(SourceIds.GITHUB)
     abstract fun bindFictionSource(impl: GitHubSource): FictionSource
+
+    /**
+     * Cross-module binding so the Browse adapter (in `:app`) can route
+     * auth-gated GitHub listings (`/user/repos`, `/user/starred`, ...)
+     * without exposing the package-internal [GitHubSource] type. #200.
+     */
+    @Binds
+    @Singleton
+    abstract fun bindGitHubAuthedSource(impl: GitHubSource): GitHubAuthedSource
 
     @Binds
     @Singleton

--- a/source-github/src/main/kotlin/in/jphe/storyvox/source/github/net/GitHubApi.kt
+++ b/source-github/src/main/kotlin/in/jphe/storyvox/source/github/net/GitHubApi.kt
@@ -140,6 +140,27 @@ internal open class GitHubApi @Inject constructor(
         )
     }
 
+    /**
+     * `GET /user/repos?affiliation=owner,collaborator&sort=updated&page=N&per_page=P`.
+     *
+     * Issue #200. Returns repos the authenticated user owns or has been
+     * granted collaborator access to, ordered by most-recently-pushed.
+     * The auth bearer is attached transparently by [`in`.jphe.storyvox.
+     * source.github.auth.GitHubAuthInterceptor]; an unauthenticated
+     * caller gets a 401 mapped to `HttpError(401, ...)`.
+     *
+     * Pagination is by `Link: rel=next` header on GitHub's side; we
+     * don't parse it — the caller infers `hasNext` from
+     * `items.size >= perPage` (a full page strongly implies another
+     * exists; a short page is always the last one).
+     */
+    open suspend fun myRepos(
+        page: Int = 1,
+        perPage: Int = 20,
+    ): GitHubApiResult<List<GhRepo>> = get(
+        "$BASE_URL/user/repos?affiliation=owner,collaborator&sort=updated&page=$page&per_page=$perPage",
+    )
+
     private suspend inline fun <reified T> get(url: String): GitHubApiResult<T> =
         withContext(Dispatchers.IO) {
             val req = Request.Builder()

--- a/source-github/src/test/kotlin/in/jphe/storyvox/source/github/GitHubSourceTest.kt
+++ b/source-github/src/test/kotlin/in/jphe/storyvox/source/github/GitHubSourceTest.kt
@@ -446,6 +446,90 @@ class GitHubSourceTest {
         assertEquals(FictionStatus.COMPLETED, r.value.items.single().status)
     }
 
+    // ─── myRepos (#200) ────────────────────────────────────────────────
+
+    @Test fun `myRepos maps each repo to a github FictionSummary`() = runBlocking {
+        val api = FakeGitHubApi(
+            myReposByPage = mapOf(
+                1 to GitHubApiResult.Success(
+                    listOf(
+                        ghRepo(owner = "octocat", name = "private-novel", desc = "WIP."),
+                        ghRepo(owner = "octocat", name = "side-saga", topics = listOf("fiction")),
+                    ),
+                    etag = null,
+                ),
+            ),
+        )
+        val r = source(api = api).myRepos(page = 1) as FictionResult.Success
+        assertEquals(2, r.value.items.size)
+        val first = r.value.items.first()
+        assertEquals("github:octocat/private-novel", first.id)
+        assertEquals(SourceIds.GITHUB, first.sourceId)
+        assertEquals("private-novel", first.title)
+        assertEquals("octocat", first.author)
+        assertEquals("WIP.", first.description)
+    }
+
+    @Test fun `myRepos hasNext is true when a full page comes back`() = runBlocking {
+        val items = (1..20).map { ghRepo(owner = "me", name = "repo-$it") }
+        val api = FakeGitHubApi(
+            myReposByPage = mapOf(1 to GitHubApiResult.Success(items, etag = null)),
+        )
+        val r = source(api = api).myRepos(page = 1) as FictionResult.Success
+        assertEquals(20, r.value.items.size)
+        assertEquals(true, r.value.hasNext)
+    }
+
+    @Test fun `myRepos hasNext is false on a short page`() = runBlocking {
+        val items = (1..5).map { ghRepo(owner = "me", name = "r-$it") }
+        val api = FakeGitHubApi(
+            myReposByPage = mapOf(1 to GitHubApiResult.Success(items, etag = null)),
+        )
+        val r = source(api = api).myRepos(page = 1) as FictionResult.Success
+        assertEquals(5, r.value.items.size)
+        assertEquals(false, r.value.hasNext)
+    }
+
+    @Test fun `myRepos NotFound surfaces as empty page hasNext-false`() = runBlocking {
+        val r = source(api = FakeGitHubApi()).myRepos(page = 1) as FictionResult.Success
+        assertTrue(r.value.items.isEmpty())
+        assertEquals(false, r.value.hasNext)
+    }
+
+    @Test fun `myRepos RateLimited propagates with retry-after`() = runBlocking {
+        val api = FakeGitHubApi(
+            myReposByPage = mapOf(1 to GitHubApiResult.RateLimited(retryAfterSeconds = 30)),
+        )
+        val r = source(api = api).myRepos(page = 1)
+        assertTrue("got $r", r is FictionResult.RateLimited)
+    }
+
+    @Test fun `myRepos HttpError 401 propagates as NetworkError so UI surfaces auth issue`() = runBlocking {
+        // The auth interceptor is what fires `markExpired()` on 401; the
+        // source-level mapping just produces a generic NetworkError with
+        // the GitHub error code embedded so the Browse paginator can
+        // display it. The Settings row shows "session expired"
+        // independently from the interceptor's side-effect.
+        val api = FakeGitHubApi(
+            myReposByPage = mapOf(1 to GitHubApiResult.HttpError(401, "Bad credentials")),
+        )
+        val r = source(api = api).myRepos(page = 1)
+        assertTrue("got $r", r is FictionResult.NetworkError)
+    }
+
+    @Test fun `myRepos archived repos map to COMPLETED status`() = runBlocking {
+        val api = FakeGitHubApi(
+            myReposByPage = mapOf(
+                1 to GitHubApiResult.Success(
+                    listOf(ghRepo(owner = "me", name = "old", archived = true)),
+                    etag = null,
+                ),
+            ),
+        )
+        val r = source(api = api).myRepos(page = 1) as FictionResult.Success
+        assertEquals(FictionStatus.COMPLETED, r.value.items.single().status)
+    }
+
     // ─── Still-stubbed surfaces ────────────────────────────────────────
 
     @Test fun `followsList and setFollowed still throw NotImplementedError`() {
@@ -608,6 +692,12 @@ class GitHubSourceTest {
          *  composed query. First key whose substring is contained in
          *  the actual query wins. */
         private val searches: List<Pair<String, GitHubApiResult<`in`.jphe.storyvox.source.github.model.GhSearchResponse>>> = emptyList(),
+        /** Per-page `/user/repos` response. Page 1 returns
+         *  `myReposByPage[1]` (or NotFound if absent); page 2 returns
+         *  `myReposByPage[2]`; etc. Tests covering hasNext/RateLimited
+         *  drop in a `GitHubApiResult.RateLimited` etc. instead of
+         *  Success. */
+        private val myReposByPage: Map<Int, GitHubApiResult<List<GhRepo>>> = emptyMap(),
     ) : GitHubApi(httpClient = OkHttpClient()) {
 
         override suspend fun getRepo(owner: String, repo: String): GitHubApiResult<GhRepo> =
@@ -669,6 +759,12 @@ class GitHubSourceTest {
                 etag = null,
             )
         }
+
+        override suspend fun myRepos(
+            page: Int,
+            perPage: Int,
+        ): GitHubApiResult<List<GhRepo>> =
+            myReposByPage[page] ?: GitHubApiResult.NotFound("no /user/repos page $page")
     }
 
 }


### PR DESCRIPTION
## Summary

Adds a **My Repos** tab to Browse → GitHub that's visible only when an OAuth session has been captured. Lists `/user/repos?affiliation=owner,collaborator&sort=updated`. Each result maps to a GitHub fiction id consumable by the existing `GitHubSource.fictionDetail()` flow (manifest detection + bare-repo fallback) — no per-feature fork in the read path.

- `GitHubApi.myRepos(page)` calls the authenticated endpoint. The pre-existing `GitHubAuthInterceptor` attaches the bearer; an unauthenticated caller gets a 401 → `NetworkError`.
- New public `GitHubAuthedSource` interface bound to `GitHubSource` so the app-module Browse adapter can route the listing without exposing the package-internal source type.
- New `BrowseSource.GitHubMyRepos` variant. The adapter wraps the call in `repo.cacheBrowseListing(...)` so each row's `sourceId` lands in the DB — without that, tapping a card hits `refreshDetail`'s "no row → fall back to RR source" branch and 404s on the github fictionId.
- `BrowseViewModel` injects `SettingsRepositoryUi` to derive a `githubSignedIn` `StateFlow`. Tab visibility, source resolution, and source-switch reset all consult it. An init-time collector auto-snaps to `Popular` if the user signs out while on `MyRepos`.
- `supportedTabs(githubSignedIn = false)` gains the gated `MyRepos` entry on the GitHub source. Default `false` keeps existing call sites on the anonymous tab list.
- `Expired` reads as signed-out: the disk copy stays so Settings can render "session expired", but the tab hides because the listing endpoint would 401 anyway.

## Test plan

- [x] `:source-github:testDebugUnitTest` — adds 7 tests covering empty/full/short page mapping, NotFound→empty, RateLimited propagation, 401→NetworkError, archived→COMPLETED.
- [x] `:feature:testDebugUnitTest`, `:app:testDebugUnitTest` — green.
- [x] `:app:assembleDebug` — green.
- [x] Installed on R83W80CAFZB; app launches cleanly, no fatals in logcat.
- [ ] Manual: sign in via Settings → GitHub, switch to Browse → GitHub, verify "My Repos" tab appears. Tap a repo, verify FictionDetail loads. Sign out, verify tab disappears and view snaps to Popular.

Closes #200