### PR TITLE
feat(browse): GitHub Public/Private/Both visibility filter (#204)

### DIFF
--- a/feature/src/main/kotlin/in/jphe/storyvox/feature/api/UiContracts.kt
+++ b/feature/src/main/kotlin/in/jphe/storyvox/feature/api/UiContracts.kt
@@ -220,6 +220,12 @@ data class GitHubSearchFilter(
      *  qualifier. `ActiveOnly` adds `archived:false`; `ArchivedOnly`
      *  adds `archived:true`. */
     val archivedStatus: GitHubArchivedStatus = GitHubArchivedStatus.Any,
+    /** Repository visibility (#204). `Both` (default) omits the qualifier
+     *  and matches GitHub's API default. `PublicOnly` adds `is:public`;
+     *  `PrivateOnly` adds `is:private` and is only meaningful when the
+     *  user has granted the `repo` OAuth scope — the GitHubFilterSheet
+     *  hides the chip row otherwise so visibility stays at `Both`. */
+    val visibility: GitHubVisibilityFilter = GitHubVisibilityFilter.Both,
 )
 
 /** GitHub `pushed:>YYYY-MM-DD` cutoffs. `Any` omits the qualifier. */
@@ -232,6 +238,13 @@ enum class GitHubSort { BestMatch, Stars, Updated }
 /** GitHub `archived:` qualifier (#205). `Any` omits the qualifier and
  *  returns both active and archived repos (the GitHub default). */
 enum class GitHubArchivedStatus { Any, ActiveOnly, ArchivedOnly }
+
+/** GitHub `is:public` / `is:private` qualifier (#204). `Both` omits the
+ *  qualifier — matches GitHub's default behaviour for callers without
+ *  the `repo` scope (only public repos are visible anyway).
+ *  `PrivateOnly` only returns matches when the user has authorized
+ *  `repo`; otherwise GitHub silently returns nothing. */
+enum class GitHubVisibilityFilter { Both, PublicOnly, PrivateOnly }
 
 /**
  * MemPalace-shaped filter for Browse → Palace (#191). Single dimension

--- a/feature/src/main/kotlin/in/jphe/storyvox/feature/browse/BrowseScreen.kt
+++ b/feature/src/main/kotlin/in/jphe/storyvox/feature/browse/BrowseScreen.kt
@@ -304,6 +304,7 @@ fun BrowseScreen(
                     showFilterSheet = false
                 },
                 onDismiss = { showFilterSheet = false },
+                showVisibilityChips = state.hasGitHubRepoScope,
             )
             BrowseSourceKey.MemPalace -> MemPalaceFilterSheet(
                 filter = state.palaceFilter,

--- a/feature/src/main/kotlin/in/jphe/storyvox/feature/browse/BrowseViewModel.kt
+++ b/feature/src/main/kotlin/in/jphe/storyvox/feature/browse/BrowseViewModel.kt
@@ -127,6 +127,12 @@ data class BrowseUiState(
     /** True when an OAuth session is captured (#200). Drives the
      *  `MyRepos` tab visibility on the GitHub source. */
     val githubSignedIn: Boolean = false,
+    /** True when the user has a GitHub OAuth session that includes the
+     *  `repo` scope (#203 / #204). Drives the visibility chip row in
+     *  the GitHub filter sheet — the `is:public` / `is:private`
+     *  qualifiers are only meaningful for callers with private-repo
+     *  access. */
+    val hasGitHubRepoScope: Boolean = false,
 )
 
 /** Typed view of a paginator's five state flows. Lifted into its own
@@ -155,6 +161,7 @@ private data class ControlsView(
     val githubFilter: GitHubSearchFilter,
     val palaceFilter: MemPalaceFilter,
     val githubSignedIn: Boolean,
+    val hasGitHubRepoScope: Boolean,
 )
 
 /**
@@ -198,6 +205,21 @@ class BrowseViewModel @Inject constructor(
         .map { it.github is UiGitHubAuthState.SignedIn }
         .distinctUntilChanged()
         .stateIn(viewModelScope, SharingStarted.WhileSubscribed(5_000), false)
+
+    /** True when the user is signed in to GitHub with the `repo` scope
+     *  granted. The scopes string is space-separated per RFC 6749; the
+     *  Settings impl persists exactly what GitHub returned. Drives the
+     *  GitHub filter sheet's visibility chip row — without `repo` the
+     *  `is:private` qualifier silently returns nothing, so we hide the
+     *  knob entirely instead of letting users wander into an empty grid. */
+    private val hasGitHubRepoScope: kotlinx.coroutines.flow.Flow<Boolean> =
+        settings.settings
+            .map { s ->
+                val auth = s.github
+                auth is UiGitHubAuthState.SignedIn &&
+                    auth.scopes.split(' ').any { it == "repo" }
+            }
+            .distinctUntilChanged()
 
     /** Active paginator for the current tuple; null when the search tab
      *  has neither a query nor active filters (the empty search hint is
@@ -254,16 +276,17 @@ class BrowseViewModel @Inject constructor(
     }
 
     /** All user-controlled knobs collapsed into one typed record. The
-     *  inner 5-arg combine builds the base tuple; outer combines fold
-     *  in palaceFilter (#191) and githubSignedIn (#200) without
-     *  exceeding the `combine` 5-arg overload. */
+     *  inner 5-arg combine builds the base tuple; outer combine folds
+     *  in palaceFilter (#191), githubSignedIn (#200), and the
+     *  has-`repo`-scope flag (#204) without exceeding the `combine`
+     *  5-arg overload. */
     private val controls: kotlinx.coroutines.flow.Flow<ControlsView> = run {
         val baseTuple = combine(
             _sourceKey, _tab, _query, _filter, _githubFilter,
         ) { sourceKey, tab, q, filter, ghFilter ->
             ResolveTuple(sourceKey, tab, q, filter, ghFilter)
         }
-        combine(baseTuple, _palaceFilter, githubSignedIn) { tup, palaceFilter, signedIn ->
+        combine(baseTuple, _palaceFilter, githubSignedIn, hasGitHubRepoScope) { tup, palaceFilter, signedIn, repoScope ->
             ControlsView(
                 sourceKey = tup.sourceKey,
                 tab = tup.tab,
@@ -272,6 +295,7 @@ class BrowseViewModel @Inject constructor(
                 githubFilter = tup.ghFilter,
                 palaceFilter = palaceFilter,
                 githubSignedIn = signedIn,
+                hasGitHubRepoScope = repoScope,
             )
         }
     }
@@ -297,6 +321,7 @@ class BrowseViewModel @Inject constructor(
                     palaceFilter = c.palaceFilter,
                     palaceWings = wings,
                     githubSignedIn = c.githubSignedIn,
+                    hasGitHubRepoScope = c.hasGitHubRepoScope,
                 )
             }
         } else {
@@ -330,6 +355,7 @@ class BrowseViewModel @Inject constructor(
                     palaceFilter = c.palaceFilter,
                     palaceWings = wings,
                     githubSignedIn = c.githubSignedIn,
+                    hasGitHubRepoScope = c.hasGitHubRepoScope,
                 )
             }
         }

--- a/feature/src/main/kotlin/in/jphe/storyvox/feature/browse/GitHubFilterQuery.kt
+++ b/feature/src/main/kotlin/in/jphe/storyvox/feature/browse/GitHubFilterQuery.kt
@@ -4,6 +4,7 @@ import `in`.jphe.storyvox.feature.api.GitHubArchivedStatus
 import `in`.jphe.storyvox.feature.api.GitHubPushedSince
 import `in`.jphe.storyvox.feature.api.GitHubSearchFilter
 import `in`.jphe.storyvox.feature.api.GitHubSort
+import `in`.jphe.storyvox.feature.api.GitHubVisibilityFilter
 import java.time.LocalDate
 import java.time.format.DateTimeFormatter
 
@@ -72,6 +73,11 @@ fun composeGitHubQuery(
         append(archQ)
     }
 
+    filter.visibility.toQualifier()?.let { visQ ->
+        if (isNotEmpty()) append(' ')
+        append(visQ)
+    }
+
     filter.sort.toQualifier()?.let { sortQ ->
         if (isNotEmpty()) append(' ')
         append(sortQ)
@@ -86,7 +92,8 @@ fun GitHubSearchFilter.isActive(): Boolean =
         pushedSince != GitHubPushedSince.Any ||
         sort != GitHubSort.BestMatch ||
         tags.isNotEmpty() ||
-        archivedStatus != GitHubArchivedStatus.Any
+        archivedStatus != GitHubArchivedStatus.Any ||
+        visibility != GitHubVisibilityFilter.Both
 
 fun GitHubSearchFilter.activeCount(): Int {
     var n = 0
@@ -96,6 +103,7 @@ fun GitHubSearchFilter.activeCount(): Int {
     if (sort != GitHubSort.BestMatch) n++
     if (tags.isNotEmpty()) n++
     if (archivedStatus != GitHubArchivedStatus.Any) n++
+    if (visibility != GitHubVisibilityFilter.Both) n++
     return n
 }
 
@@ -103,6 +111,12 @@ private fun GitHubArchivedStatus.toQualifier(): String? = when (this) {
     GitHubArchivedStatus.Any -> null
     GitHubArchivedStatus.ActiveOnly -> "archived:false"
     GitHubArchivedStatus.ArchivedOnly -> "archived:true"
+}
+
+private fun GitHubVisibilityFilter.toQualifier(): String? = when (this) {
+    GitHubVisibilityFilter.Both -> null
+    GitHubVisibilityFilter.PublicOnly -> "is:public"
+    GitHubVisibilityFilter.PrivateOnly -> "is:private"
 }
 
 private fun GitHubPushedSince.toCutoffDate(today: LocalDate): LocalDate? = when (this) {

--- a/feature/src/main/kotlin/in/jphe/storyvox/feature/browse/GitHubFilterSheet.kt
+++ b/feature/src/main/kotlin/in/jphe/storyvox/feature/browse/GitHubFilterSheet.kt
@@ -31,6 +31,7 @@ import `in`.jphe.storyvox.feature.api.GitHubArchivedStatus
 import `in`.jphe.storyvox.feature.api.GitHubPushedSince
 import `in`.jphe.storyvox.feature.api.GitHubSearchFilter
 import `in`.jphe.storyvox.feature.api.GitHubSort
+import `in`.jphe.storyvox.feature.api.GitHubVisibilityFilter
 import `in`.jphe.storyvox.ui.component.BrassButton
 import `in`.jphe.storyvox.ui.component.BrassButtonVariant
 import `in`.jphe.storyvox.ui.theme.LocalSpacing
@@ -49,6 +50,11 @@ fun GitHubFilterSheet(
     onApply: (GitHubSearchFilter) -> Unit,
     onReset: () -> Unit,
     onDismiss: () -> Unit,
+    /** Controls whether the Public/Private/Both visibility chip row is
+     *  rendered. The caller passes `true` only when the user has the
+     *  `repo` OAuth scope — otherwise `is:private` would silently match
+     *  nothing on github.com and the filter would feel broken. */
+    showVisibilityChips: Boolean = false,
 ) {
     val sheetState = rememberModalBottomSheetState(skipPartiallyExpanded = true)
     val spacing = LocalSpacing.current
@@ -148,6 +154,26 @@ fun GitHubFilterSheet(
                 }
                 ArchivedChip("Archived only", local.archivedStatus == GitHubArchivedStatus.ArchivedOnly) {
                     local = local.copy(archivedStatus = GitHubArchivedStatus.ArchivedOnly)
+                }
+            }
+
+            // Visibility (#204) — only meaningful with the `repo` scope.
+            // Without it, GitHub returns no private hits anyway, so we
+            // hide the row entirely rather than offering a knob that
+            // silently empties the grid.
+            if (showVisibilityChips) {
+                HorizontalDivider()
+                SectionLabel("Visibility")
+                Row(horizontalArrangement = Arrangement.spacedBy(spacing.xs)) {
+                    ArchivedChip("Both", local.visibility == GitHubVisibilityFilter.Both) {
+                        local = local.copy(visibility = GitHubVisibilityFilter.Both)
+                    }
+                    ArchivedChip("Public", local.visibility == GitHubVisibilityFilter.PublicOnly) {
+                        local = local.copy(visibility = GitHubVisibilityFilter.PublicOnly)
+                    }
+                    ArchivedChip("Private", local.visibility == GitHubVisibilityFilter.PrivateOnly) {
+                        local = local.copy(visibility = GitHubVisibilityFilter.PrivateOnly)
+                    }
                 }
             }
 

--- a/feature/src/test/kotlin/in/jphe/storyvox/feature/browse/GitHubFilterQueryTest.kt
+++ b/feature/src/test/kotlin/in/jphe/storyvox/feature/browse/GitHubFilterQueryTest.kt
@@ -3,6 +3,7 @@ package `in`.jphe.storyvox.feature.browse
 import `in`.jphe.storyvox.feature.api.GitHubPushedSince
 import `in`.jphe.storyvox.feature.api.GitHubSearchFilter
 import `in`.jphe.storyvox.feature.api.GitHubSort
+import `in`.jphe.storyvox.feature.api.GitHubVisibilityFilter
 import java.time.LocalDate
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
@@ -155,6 +156,32 @@ class GitHubFilterQueryTest {
         assertTrue(empty.copy(sort = GitHubSort.Stars).isActive())
     }
 
+    @Test fun `visibility Both omits qualifier`() {
+        assertEquals(
+            "",
+            composeGitHubQuery("", empty.copy(visibility = GitHubVisibilityFilter.Both), today),
+        )
+    }
+
+    @Test fun `visibility PublicOnly emits is colon public`() {
+        assertEquals(
+            "is:public",
+            composeGitHubQuery("", empty.copy(visibility = GitHubVisibilityFilter.PublicOnly), today),
+        )
+    }
+
+    @Test fun `visibility PrivateOnly emits is colon private`() {
+        assertEquals(
+            "is:private",
+            composeGitHubQuery("", empty.copy(visibility = GitHubVisibilityFilter.PrivateOnly), today),
+        )
+    }
+
+    @Test fun `non-default visibility is active`() {
+        assertTrue(empty.copy(visibility = GitHubVisibilityFilter.PrivateOnly).isActive())
+        assertFalse(empty.copy(visibility = GitHubVisibilityFilter.Both).isActive())
+    }
+
     // -- activeCount -------------------------------------------------------------
 
     @Test fun `default activeCount is 0`() {
@@ -167,8 +194,9 @@ class GitHubFilterQueryTest {
             language = "en",
             pushedSince = GitHubPushedSince.Last7Days,
             sort = GitHubSort.Updated,
+            visibility = GitHubVisibilityFilter.PrivateOnly,
         )
-        assertEquals(4, filter.activeCount())
+        assertEquals(5, filter.activeCount())
     }
 
     @Test fun `partial filter counts only set knobs`() {


### PR DESCRIPTION
## Summary

Adds a visibility chip row to the GitHub filter sheet that emits GitHub's `is:public` / `is:private` qualifiers. The row only renders when the user has the `repo` OAuth scope (#203's toggle is ON) — without it, `is:private` matches nothing on github.com and the knob would feel broken.

Closes #204.

## Changes

- **`UiContracts.kt`** — new `GitHubVisibilityFilter` enum (`Both`, `PublicOnly`, `PrivateOnly`) and `visibility` field on `GitHubSearchFilter`. Defaults to `Both` so the field is purely additive; existing call sites and tests need no changes.
- **`GitHubFilterQuery.kt`** — emits `is:public` / `is:private` when non-`Both`; `isActive()` and `activeCount()` count the new dimension.
- **`BrowseViewModel.kt`** — now also injects `SettingsRepositoryUi`. Derives `hasGitHubRepoScope` from `s.github.scopes` (split on space, look for `"repo"`) and surfaces it on `BrowseUiState`.
- **`GitHubFilterSheet.kt`** — new `showVisibilityChips: Boolean = false` parameter. When true, renders a Both/Public/Private chip row using the same `BrassButton`-backed chip helper as the archive-status row.
- **`BrowseScreen.kt`** — passes `state.hasGitHubRepoScope` into `showVisibilityChips`.

## Test plan

- [x] `:feature:testDebugUnitTest` green — new `GitHubFilterQueryTest` cases cover all three visibility states + activeCount of a fully-loaded filter.
- [x] `:app:assembleDebug` builds clean.
- [ ] Manual smoke: signed-out → no chip row. Signed-in with `read:user public_repo` → no chip row. Signed-in with `repo` → row visible, picks Public/Private and applies. (Tablet smoke deferred to orchestrator's post-merge install since sibling agents are concurrently building against the same device.)

## Coordination notes

Sibling-agent overlap on `UiContracts.kt`, `GitHubFilterQuery.kt`, `GitHubFilterSheet.kt`, `BrowseViewModel.kt`, `BrowseScreen.kt` is expected per the bundle brief. All changes are additive (new enum value, new optional field, new optional parameter, new state field) — orchestrator rebases handle the ordering.

🤖 Generated with [Claude Code](https://claude.com/claude-code)