### PR TITLE
feat(llm): Anthropic Teams OAuth provider (#181)

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -169,6 +169,9 @@ dependencies {
     // Navigation
     implementation(libs.androidx.navigation.compose)
 
+    // Chrome Custom Tabs for the Anthropic Teams OAuth handoff (#181)
+    implementation(libs.androidx.browser)
+
     // Hilt
     implementation(libs.hilt.android)
     ksp(libs.hilt.compiler)

--- a/app/src/main/kotlin/in/jphe/storyvox/auth/anthropic/AnthropicTeamsSignInScreen.kt
+++ b/app/src/main/kotlin/in/jphe/storyvox/auth/anthropic/AnthropicTeamsSignInScreen.kt
@@ -1,0 +1,266 @@
+package `in`.jphe.storyvox.auth.anthropic
+
+import android.content.Context
+import android.content.Intent
+import android.net.Uri
+import android.widget.Toast
+import androidx.browser.customtabs.CustomTabsIntent
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.foundation.text.KeyboardOptions
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.ArrowBack
+import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.FilledIconButton
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButtonDefaults
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.text.input.KeyboardType
+import androidx.compose.ui.unit.dp
+import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import `in`.jphe.storyvox.ui.component.BrassButton
+import `in`.jphe.storyvox.ui.component.BrassButtonVariant
+import `in`.jphe.storyvox.ui.theme.LocalSpacing
+
+/**
+ * Anthropic Teams (OAuth) sign-in screen (#181).
+ *
+ * Mirrors `:app`'s `GitHubSignInScreen` shape — a full-screen modal
+ * pushed onto the nav stack from Settings → AI → "Sign in to Teams".
+ *
+ * Flow:
+ *  1. Idle / first-render — explains what's about to happen, big
+ *     "Open browser" button.
+ *  2. AwaitingCode — `CustomTabsIntent` launched on `claude.ai`, screen
+ *     shows the paste field plus a "Re-open browser" link if the user
+ *     dismissed the tab without authorizing.
+ *  3. Capturing — spinner while the code-for-token POST is in flight.
+ *  4. Captured — toast + popBackStack() back to Settings.
+ *  5. Failure — error copy + retry button.
+ */
+@Composable
+fun AnthropicTeamsSignInScreen(
+    onSignedIn: () -> Unit,
+    onCancelled: () -> Unit,
+    viewModel: AnthropicTeamsSignInViewModel = hiltViewModel(),
+) {
+    val state by viewModel.state.collectAsStateWithLifecycle()
+    val context = LocalContext.current
+    val spacing = LocalSpacing.current
+
+    LaunchedEffect(state) {
+        if (state is SignInState.Captured) {
+            Toast.makeText(context, "Signed in to Anthropic Teams", Toast.LENGTH_SHORT).show()
+            onSignedIn()
+        }
+    }
+
+    Scaffold { padding ->
+        Box(modifier = Modifier.fillMaxSize().padding(padding)) {
+            Column(
+                modifier = Modifier
+                    .fillMaxSize()
+                    .verticalScroll(rememberScrollState())
+                    .padding(spacing.lg),
+                verticalArrangement = Arrangement.spacedBy(spacing.md),
+            ) {
+                Text(
+                    "Sign in to Anthropic Teams",
+                    style = MaterialTheme.typography.headlineSmall,
+                    color = MaterialTheme.colorScheme.primary,
+                )
+                Text(
+                    "Storyvox uses your Claude.ai workspace login (no API key) so " +
+                        "Recap, character lookup, and chat run against your Teams " +
+                        "subscription — costs land on your console.anthropic.com bill, " +
+                        "not on storyvox.",
+                    style = MaterialTheme.typography.bodyMedium,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                )
+                StateBody(
+                    state = state,
+                    onOpenBrowser = {
+                        val url = viewModel.openBrowser()
+                        openInCustomTab(context, url)
+                    },
+                    onSubmit = viewModel::submitCode,
+                    onRetry = {
+                        val url = viewModel.openBrowser()
+                        openInCustomTab(context, url)
+                    },
+                )
+            }
+
+            FilledIconButton(
+                onClick = {
+                    viewModel.cancel()
+                    onCancelled()
+                },
+                modifier = Modifier.align(Alignment.TopStart).padding(12.dp).size(40.dp),
+                shape = CircleShape,
+                colors = IconButtonDefaults.filledIconButtonColors(
+                    containerColor = MaterialTheme.colorScheme.primary,
+                    contentColor = MaterialTheme.colorScheme.onPrimary,
+                ),
+            ) {
+                Icon(Icons.Default.ArrowBack, contentDescription = "Cancel sign-in")
+            }
+        }
+    }
+}
+
+@Composable
+private fun StateBody(
+    state: SignInState,
+    onOpenBrowser: () -> Unit,
+    onSubmit: (String) -> Unit,
+    onRetry: () -> Unit,
+) {
+    val spacing = LocalSpacing.current
+    when (state) {
+        SignInState.Idle -> {
+            Text(
+                "Step 1 — open Anthropic in your browser",
+                style = MaterialTheme.typography.titleMedium,
+            )
+            Text(
+                "Tapping the button opens claude.ai in a Custom Tab. Sign in, " +
+                    "click Authorize, and Anthropic will hand you back a code to paste here.",
+                style = MaterialTheme.typography.bodyMedium,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
+            BrassButton(
+                label = "Open browser",
+                onClick = onOpenBrowser,
+                variant = BrassButtonVariant.Primary,
+            )
+        }
+        is SignInState.AwaitingCode -> {
+            var draft by remember { mutableStateOf("") }
+            Text(
+                "Step 2 — paste the authorization code",
+                style = MaterialTheme.typography.titleMedium,
+            )
+            Text(
+                "Anthropic shows the code on the page after you click Authorize. " +
+                    "Copy it and paste it below.",
+                style = MaterialTheme.typography.bodyMedium,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
+            OutlinedTextField(
+                value = draft,
+                onValueChange = { draft = it },
+                label = { Text("Authorization code") },
+                modifier = Modifier.fillMaxWidth(),
+                keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Ascii),
+                singleLine = true,
+            )
+            Row(horizontalArrangement = Arrangement.spacedBy(spacing.xs)) {
+                BrassButton(
+                    label = "Sign in",
+                    onClick = { onSubmit(draft) },
+                    variant = BrassButtonVariant.Primary,
+                )
+                BrassButton(
+                    label = "Re-open browser",
+                    onClick = onOpenBrowser,
+                    variant = BrassButtonVariant.Text,
+                )
+            }
+        }
+        SignInState.Capturing -> {
+            Row(
+                verticalAlignment = Alignment.CenterVertically,
+                horizontalArrangement = Arrangement.spacedBy(spacing.sm),
+                modifier = Modifier.fillMaxWidth(),
+            ) {
+                CircularProgressIndicator(
+                    modifier = Modifier.size(24.dp),
+                    strokeWidth = 2.dp,
+                    color = MaterialTheme.colorScheme.primary,
+                )
+                Text("Exchanging code with Anthropic…", style = MaterialTheme.typography.bodyMedium)
+            }
+        }
+        SignInState.Captured -> {
+            // Captured fires popBackStack via LaunchedEffect; brief
+            // defensive copy in case of a recomposition race.
+            Text(
+                "Signed in.",
+                style = MaterialTheme.typography.titleMedium,
+                color = MaterialTheme.colorScheme.primary,
+            )
+        }
+        is SignInState.Failure -> {
+            Text(
+                "Sign-in failed",
+                style = MaterialTheme.typography.titleMedium,
+                color = MaterialTheme.colorScheme.error,
+            )
+            Text(
+                state.message,
+                style = MaterialTheme.typography.bodyMedium,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
+            if (state.retryable) {
+                BrassButton(
+                    label = "Try again",
+                    onClick = onRetry,
+                    variant = BrassButtonVariant.Primary,
+                )
+            }
+        }
+    }
+}
+
+/**
+ * Open the URL in a Chrome Custom Tab. Falls back to a plain
+ * `Intent.ACTION_VIEW` if no Custom-Tabs-aware browser is installed
+ * (rare but cheap to handle: GitHub's sign-in screen does the same).
+ */
+private fun openInCustomTab(context: Context, url: String) {
+    val customTab = runCatching {
+        CustomTabsIntent.Builder()
+            .setShowTitle(true)
+            .setUrlBarHidingEnabled(false)
+            .build()
+            .also { it.intent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK) }
+    }.getOrNull()
+    if (customTab != null) {
+        runCatching { customTab.launchUrl(context, Uri.parse(url)) }
+            .onFailure { fallbackOpen(context, url) }
+    } else {
+        fallbackOpen(context, url)
+    }
+}
+
+private fun fallbackOpen(context: Context, url: String) {
+    val intent = Intent(Intent.ACTION_VIEW, Uri.parse(url)).apply {
+        addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
+    }
+    runCatching { context.startActivity(intent) }.onFailure {
+        Toast.makeText(context, "No browser available", Toast.LENGTH_LONG).show()
+    }
+}

--- a/app/src/main/kotlin/in/jphe/storyvox/auth/anthropic/AnthropicTeamsSignInViewModel.kt
+++ b/app/src/main/kotlin/in/jphe/storyvox/auth/anthropic/AnthropicTeamsSignInViewModel.kt
@@ -1,0 +1,197 @@
+package `in`.jphe.storyvox.auth.anthropic
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import dagger.hilt.android.lifecycle.HiltViewModel
+import `in`.jphe.storyvox.llm.auth.AnthropicTeamsAuthApi
+import `in`.jphe.storyvox.llm.auth.AnthropicTeamsAuthConfig
+import `in`.jphe.storyvox.llm.auth.AnthropicTeamsAuthRepository
+import `in`.jphe.storyvox.llm.auth.PkcePair
+import `in`.jphe.storyvox.llm.auth.TokenResult
+import java.security.SecureRandom
+import javax.inject.Inject
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.launch
+
+/**
+ * State machine for the Anthropic Teams (OAuth) sign-in modal (#181).
+ *
+ * Mirrors the shape of `:app`'s `GitHubSignInViewModel` — the screen
+ * consumes a [SignInState] StateFlow and reports back via
+ * [openBrowser] (start the flow), [submitCode] (paste-callback), and
+ * [cancel].
+ *
+ * Flow:
+ *   1. [openBrowser] → generates a PKCE pair + state nonce, returns the
+ *      authorize URL the screen should hand to a CustomTabsIntent.
+ *      State transitions Idle → AwaitingCode.
+ *   2. After authorizing in the browser, the user copies the
+ *      authorization code Anthropic shows on the redirect page and
+ *      pastes it into the modal.
+ *   3. [submitCode] → POSTs to the token endpoint, captures the
+ *      bearer + refresh + scopes. State transitions
+ *      AwaitingCode → Capturing → Captured.
+ *   4. On any error → Failure(retryable) and the user can [openBrowser]
+ *      again.
+ *
+ * Why paste-the-code rather than scheme intent-filter: the public
+ * Claude Code OAuth client is registered with `console.anthropic.com/
+ * oauth/code/callback`, not a `storyvox://` custom scheme. The browser
+ * lands on Anthropic's callback page which renders the code in a
+ * copy-able block; the user pastes it back. No app-side intent-filter
+ * state to manage, no race between the browser callback and a stale
+ * activity instance, no "Open with…" picker to confuse users.
+ */
+@HiltViewModel
+class AnthropicTeamsSignInViewModel @Inject constructor(
+    private val authApi: AnthropicTeamsAuthApi,
+    private val auth: AnthropicTeamsAuthRepository,
+) : ViewModel() {
+
+    private val _state = MutableStateFlow<SignInState>(SignInState.Idle)
+    val state: StateFlow<SignInState> = _state.asStateFlow()
+
+    /** Test-only seam — production reads the constant. */
+    internal var clientIdOverride: String? = null
+    private val clientId: String
+        get() = clientIdOverride ?: AnthropicTeamsAuthConfig.DEFAULT_CLIENT_ID
+
+    /**
+     * Hold the PKCE verifier + state nonce across the browser handoff.
+     * The Compose screen exists for the full flow; if the user
+     * background+kills+reopens the screen, they restart with [openBrowser].
+     */
+    private var pendingVerifier: String? = null
+    private var pendingState: String? = null
+
+    /**
+     * Generate fresh PKCE + state, transition to AwaitingCode, and
+     * return the URL the caller should hand to the system browser.
+     */
+    fun openBrowser(): String {
+        val pkce = PkcePair.generate()
+        val state = randomStateNonce()
+        pendingVerifier = pkce.verifier
+        pendingState = state
+        val url = authApi.authorizeUrl(
+            clientId = clientId,
+            scopes = AnthropicTeamsAuthConfig.DEFAULT_SCOPES,
+            challenge = pkce.challenge,
+            state = state,
+        )
+        _state.value = SignInState.AwaitingCode(authorizeUrl = url)
+        return url
+    }
+
+    /**
+     * Exchange the pasted code for a bearer + refresh. The code's
+     * format on Anthropic's callback page is a plain string; we trim
+     * whitespace defensively for users pasting from a screen reader.
+     */
+    fun submitCode(rawCode: String) {
+        val code = rawCode.trim().takeIf { it.isNotBlank() }
+            ?: run {
+                _state.value = SignInState.Failure(
+                    message = "Paste the authorization code Anthropic showed you in the browser.",
+                    retryable = true,
+                )
+                return
+            }
+        val verifier = pendingVerifier ?: run {
+            _state.value = SignInState.Failure(
+                message = "Sign-in state missing — tap \"Open browser\" again.",
+                retryable = true,
+            )
+            return
+        }
+        val stateNonce = pendingState.orEmpty()
+        _state.value = SignInState.Capturing
+        viewModelScope.launch {
+            when (val r = authApi.exchangeCode(
+                clientId = clientId,
+                code = code,
+                verifier = verifier,
+                state = stateNonce,
+            )) {
+                is TokenResult.Success -> {
+                    val now = System.currentTimeMillis()
+                    auth.captureSession(
+                        bearer = r.accessToken,
+                        refreshToken = r.refreshToken,
+                        expiresAtEpochMillis = now + r.expiresInSeconds * 1000L,
+                        scopes = r.scopes.ifBlank {
+                            AnthropicTeamsAuthConfig.DEFAULT_SCOPES
+                        },
+                    )
+                    pendingVerifier = null
+                    pendingState = null
+                    _state.value = SignInState.Captured
+                }
+                is TokenResult.InvalidGrant -> {
+                    _state.value = SignInState.Failure(
+                        message = "Anthropic rejected that code — get a fresh one and try again. " +
+                            (r.message ?: ""),
+                        retryable = true,
+                    )
+                }
+                is TokenResult.AnthropicError -> {
+                    _state.value = SignInState.Failure(
+                        message = "Anthropic error: ${r.code}${r.message?.let { " — $it" } ?: ""}",
+                        retryable = true,
+                    )
+                }
+                is TokenResult.NetworkError -> {
+                    _state.value = SignInState.Failure(
+                        message = "Network error — ${r.cause.message ?: "request failed"}",
+                        retryable = true,
+                    )
+                }
+                is TokenResult.HttpError -> {
+                    _state.value = SignInState.Failure(
+                        message = "Anthropic returned HTTP ${r.code} — ${r.message}",
+                        retryable = true,
+                    )
+                }
+                is TokenResult.MalformedResponse -> {
+                    _state.value = SignInState.Failure(
+                        message = "Couldn't read Anthropic's response — ${r.message}",
+                        retryable = true,
+                    )
+                }
+            }
+        }
+    }
+
+    fun cancel() {
+        pendingVerifier = null
+        pendingState = null
+        _state.value = SignInState.Idle
+    }
+
+    /** Generates a 32-byte URL-safe Base64 nonce — enough entropy
+     *  to make `state` collisions cosmologically unlikely. */
+    private fun randomStateNonce(): String {
+        val bytes = ByteArray(32).also { SecureRandom().nextBytes(it) }
+        return android.util.Base64.encodeToString(
+            bytes,
+            android.util.Base64.URL_SAFE or
+                android.util.Base64.NO_PADDING or
+                android.util.Base64.NO_WRAP,
+        )
+    }
+}
+
+sealed class SignInState {
+    object Idle : SignInState()
+    /** Browser handoff in progress. The screen renders the URL the
+     *  user is about to land on (or just landed on) and the paste
+     *  field for the resulting code. */
+    data class AwaitingCode(val authorizeUrl: String) : SignInState()
+    /** Token exchange in flight. */
+    object Capturing : SignInState()
+    /** Bearer + refresh persisted; the screen pops back. */
+    object Captured : SignInState()
+    data class Failure(val message: String, val retryable: Boolean) : SignInState()
+}

--- a/app/src/main/kotlin/in/jphe/storyvox/data/SettingsRepositoryUiImpl.kt
+++ b/app/src/main/kotlin/in/jphe/storyvox/data/SettingsRepositoryUiImpl.kt
@@ -44,6 +44,8 @@ import `in`.jphe.storyvox.source.github.auth.GitHubScopePreferences
 import `in`.jphe.storyvox.source.github.auth.GitHubSession
 import `in`.jphe.storyvox.llm.LlmConfig
 import `in`.jphe.storyvox.llm.LlmConfigProvider
+import `in`.jphe.storyvox.llm.auth.AnthropicTeamsAuthRepository
+import `in`.jphe.storyvox.llm.auth.TeamsSession
 import `in`.jphe.storyvox.llm.LlmCredentialsStore
 import `in`.jphe.storyvox.llm.ProviderId
 import `in`.jphe.storyvox.sigil.Sigil
@@ -193,6 +195,7 @@ class SettingsRepositoryUiImpl(
     private val palaceApi: PalaceDaemonApi,
     private val llmCreds: LlmCredentialsStore,
     private val githubAuth: GitHubAuthRepository,
+    private val teamsAuth: AnthropicTeamsAuthRepository,
 ) : SettingsRepositoryUi,
     PlaybackBufferConfig,
     PlaybackModeConfig,
@@ -213,16 +216,18 @@ class SettingsRepositoryUiImpl(
         palaceApi: PalaceDaemonApi,
         llmCreds: LlmCredentialsStore,
         githubAuth: GitHubAuthRepository,
+        teamsAuth: AnthropicTeamsAuthRepository,
     ) : this(
         context.settingsDataStore, auth, hydrator,
-        palaceConfig, palaceApi, llmCreds, githubAuth,
+        palaceConfig, palaceApi, llmCreds, githubAuth, teamsAuth,
     )
 
     override val settings: Flow<UiSettings> = combine(
         store.data,
         palaceConfig.state,
         githubAuth.sessionState,
-    ) { prefs, palace, githubSession ->
+        teamsAuth.sessionState,
+    ) { prefs, palace, githubSession, teamsSession ->
         UiSettings(
             ttsEngine = "VoxSherpa",
             defaultVoiceId = prefs[Keys.DEFAULT_VOICE_ID],
@@ -264,6 +269,9 @@ class SettingsRepositoryUiImpl(
                 bedrockSecretKeyConfigured = !llmCreds.bedrockSecretKey().isNullOrBlank(),
                 bedrockRegion = prefs[Keys.AI_BEDROCK_REGION] ?: "us-east-1",
                 bedrockModel = prefs[Keys.AI_BEDROCK_MODEL] ?: "claude-haiku-4.5",
+                teamsSignedIn = teamsSession is TeamsSession.SignedIn,
+                teamsScopes = (teamsSession as? TeamsSession.SignedIn)?.scopes
+                    ?: llmCreds.teamsScopes().orEmpty(),
                 privacyAcknowledged = prefs[Keys.AI_PRIVACY_ACK] ?: false,
                 sendChapterTextEnabled = prefs[Keys.AI_SEND_CHAPTER_TEXT] ?: true,
             ),
@@ -538,6 +546,17 @@ class SettingsRepositoryUiImpl(
         store.edit { it[Keys.AI_PRIVACY_ACK] = true }
     }
 
+    override suspend fun signOutTeams() {
+        // Local sign-out — wipes the bearer + refresh + scope cache.
+        // Remote revoke at console.anthropic.com requires the
+        // client_secret we don't have (public-client posture). The
+        // Settings UI surfaces a deep-link to claude.ai if the user
+        // wants to fully revoke the session there. Going through the
+        // repo (not llmCreds directly) keeps the in-memory StateFlow
+        // in sync, which is what the Settings UI subscribes to.
+        teamsAuth.clearSession()
+    }
+
     override suspend fun resetAiSettings() {
         store.edit {
             it.remove(Keys.AI_PROVIDER)
@@ -555,6 +574,10 @@ class SettingsRepositoryUiImpl(
             it.remove(Keys.AI_SEND_CHAPTER_TEXT)
         }
         llmCreds.clearAll()
+        // llmCreds.clearAll() wipes the Teams encrypted-prefs entries;
+        // refresh the in-memory session flow so the UI flips to
+        // SignedOut without waiting for a separate emission.
+        teamsAuth.refreshFromStore()
     }
 
     // ── GitHub OAuth (#91) ─────────────────────────────────────────

--- a/app/src/main/kotlin/in/jphe/storyvox/navigation/StoryvoxNavHost.kt
+++ b/app/src/main/kotlin/in/jphe/storyvox/navigation/StoryvoxNavHost.kt
@@ -24,6 +24,7 @@ import androidx.navigation.compose.composable
 import androidx.navigation.compose.currentBackStackEntryAsState
 import androidx.navigation.navArgument
 import `in`.jphe.storyvox.auth.AuthWebViewScreen
+import `in`.jphe.storyvox.auth.anthropic.AnthropicTeamsSignInScreen
 import `in`.jphe.storyvox.auth.github.GitHubSignInScreen
 import `in`.jphe.storyvox.source.github.auth.GitHubAuthConfig
 import `in`.jphe.storyvox.feature.browse.BrowseScreen
@@ -57,6 +58,8 @@ object StoryvoxRoutes {
     const val AUTH_WEBVIEW = "auth/webview"
     /** Issue #91 — GitHub Device Flow sign-in modal. */
     const val GITHUB_SIGN_IN = "auth/github/signin"
+    /** Issue #181 — Anthropic Teams OAuth sign-in modal. */
+    const val TEAMS_SIGN_IN = "auth/anthropic-teams/signin"
     /** Q&A chat about a fiction (#81 follow-up). One chat history per
      *  fictionId; the screen pulls fiction title + current chapter
      *  context internally for the system prompt.
@@ -358,6 +361,7 @@ private fun StoryvoxNavHostContent(
                             )
                         }
                     },
+                    onOpenTeamsSignIn = { navController.navigate(StoryvoxRoutes.TEAMS_SIGN_IN) },
                     onOpenPronunciationDict = { navController.navigate(StoryvoxRoutes.SETTINGS_PRONUNCIATION) },
                 )
             }
@@ -414,6 +418,18 @@ private fun StoryvoxNavHostContent(
                 popExitTransition = popExit,
             ) {
                 GitHubSignInScreen(
+                    onSignedIn = { navController.popBackStack() },
+                    onCancelled = { navController.popBackStack() },
+                )
+            }
+            composable(
+                StoryvoxRoutes.TEAMS_SIGN_IN,
+                enterTransition = pushEnter,
+                exitTransition = pushExit,
+                popEnterTransition = popEnter,
+                popExitTransition = popExit,
+            ) {
+                AnthropicTeamsSignInScreen(
                     onSignedIn = { navController.popBackStack() },
                     onCancelled = { navController.popBackStack() },
                 )

--- a/app/src/test/kotlin/in/jphe/storyvox/data/SettingsRepositoryBufferTest.kt
+++ b/app/src/test/kotlin/in/jphe/storyvox/data/SettingsRepositoryBufferTest.kt
@@ -60,6 +60,7 @@ class SettingsRepositoryBufferTest {
             // no-op store is fine.
             llmCreds = `in`.jphe.storyvox.llm.LlmCredentialsStore.forTesting(),
             githubAuth = FakeGitHubAuth(),
+            teamsAuth = fakeTeamsAuth(),
         )
     }
 

--- a/app/src/test/kotlin/in/jphe/storyvox/data/SettingsRepositoryGitHubScopeTest.kt
+++ b/app/src/test/kotlin/in/jphe/storyvox/data/SettingsRepositoryGitHubScopeTest.kt
@@ -53,6 +53,7 @@ class SettingsRepositoryGitHubScopeTest {
             palaceApi = makeFakePalaceApi(),
             llmCreds = `in`.jphe.storyvox.llm.LlmCredentialsStore.forTesting(),
             githubAuth = FakeGitHubAuth(),
+            teamsAuth = fakeTeamsAuth(),
         )
     }
 

--- a/app/src/test/kotlin/in/jphe/storyvox/data/SettingsRepositoryModesTest.kt
+++ b/app/src/test/kotlin/in/jphe/storyvox/data/SettingsRepositoryModesTest.kt
@@ -56,6 +56,7 @@ class SettingsRepositoryModesTest {
             // Modes tests don't touch AI fields, so a no-op store is fine.
             llmCreds = `in`.jphe.storyvox.llm.LlmCredentialsStore.forTesting(),
             githubAuth = FakeGitHubAuth(),
+            teamsAuth = fakeTeamsAuth(),
         )
     }
 

--- a/app/src/test/kotlin/in/jphe/storyvox/data/SettingsRepositoryPitchTest.kt
+++ b/app/src/test/kotlin/in/jphe/storyvox/data/SettingsRepositoryPitchTest.kt
@@ -63,6 +63,7 @@ class SettingsRepositoryPitchTest {
             // GitHubAuth fake (#91) — pitch tests don't touch GitHub state;
             // mirrors the pattern in BufferTest / ModesTest / PunctuationPauseTest.
             githubAuth = FakeGitHubAuth(),
+            teamsAuth = fakeTeamsAuth(),
         )
     }
 

--- a/app/src/test/kotlin/in/jphe/storyvox/data/SettingsRepositoryPronunciationDictTest.kt
+++ b/app/src/test/kotlin/in/jphe/storyvox/data/SettingsRepositoryPronunciationDictTest.kt
@@ -61,6 +61,7 @@ class SettingsRepositoryPronunciationDictTest {
             // GitHubAuth fake (#91) — pronunciation-dict tests don't touch
             // GitHub state; mirrors BufferTest / ModesTest / PitchTest pattern.
             githubAuth = FakeGitHubAuth(),
+            teamsAuth = fakeTeamsAuth(),
         )
     }
 

--- a/app/src/test/kotlin/in/jphe/storyvox/data/SettingsRepositoryPunctuationPauseTest.kt
+++ b/app/src/test/kotlin/in/jphe/storyvox/data/SettingsRepositoryPunctuationPauseTest.kt
@@ -68,6 +68,7 @@ class SettingsRepositoryPunctuationPauseTest {
             // Punctuation-pause tests don't touch AI fields, so a no-op store is fine.
             llmCreds = `in`.jphe.storyvox.llm.LlmCredentialsStore.forTesting(),
             githubAuth = FakeGitHubAuth(),
+            teamsAuth = fakeTeamsAuth(),
         )
     }
 

--- a/app/src/test/kotlin/in/jphe/storyvox/data/SettingsRepositoryTestSupport.kt
+++ b/app/src/test/kotlin/in/jphe/storyvox/data/SettingsRepositoryTestSupport.kt
@@ -5,6 +5,8 @@ import androidx.datastore.preferences.core.PreferenceDataStoreFactory
 import `in`.jphe.storyvox.data.auth.SessionHydrator
 import `in`.jphe.storyvox.data.auth.SessionState
 import `in`.jphe.storyvox.data.repository.AuthRepository
+import `in`.jphe.storyvox.llm.LlmCredentialsStore
+import `in`.jphe.storyvox.llm.auth.AnthropicTeamsAuthRepository
 import `in`.jphe.storyvox.source.github.auth.GitHubAuthRepository
 import `in`.jphe.storyvox.source.github.auth.GitHubSession
 import `in`.jphe.storyvox.source.mempalace.config.PalaceConfig
@@ -70,6 +72,15 @@ internal class FakeGitHubAuth : GitHubAuthRepository {
     override suspend fun clearSession() { state.value = GitHubSession.Anonymous }
     override fun markExpired() { state.value = GitHubSession.Expired }
 }
+
+/**
+ * In-memory [AnthropicTeamsAuthRepository] for the settings tests (#181).
+ * Wraps the existing [LlmCredentialsStore.forTesting] no-op store —
+ * captureSession / clearSession just flip the in-memory state flow.
+ */
+internal fun fakeTeamsAuth(
+    store: LlmCredentialsStore = LlmCredentialsStore.forTesting(),
+): AnthropicTeamsAuthRepository = AnthropicTeamsAuthRepository(store)
 
 /**
  * Real [PalaceConfigImpl] backed by a temp DataStore + an in-memory

--- a/app/src/test/kotlin/in/jphe/storyvox/data/SettingsRepositoryVoiceSteadyTest.kt
+++ b/app/src/test/kotlin/in/jphe/storyvox/data/SettingsRepositoryVoiceSteadyTest.kt
@@ -59,6 +59,7 @@ class SettingsRepositoryVoiceSteadyTest {
             // GitHubAuth fake (#91) — voice-tuning tests don't touch GitHub
             // state; mirrors the pattern in BufferTest / ModesTest / etc.
             githubAuth = FakeGitHubAuth(),
+            teamsAuth = fakeTeamsAuth(),
         )
     }
 

--- a/app/src/test/kotlin/in/jphe/storyvox/di/RealPlaybackControllerUiTest.kt
+++ b/app/src/test/kotlin/in/jphe/storyvox/di/RealPlaybackControllerUiTest.kt
@@ -257,6 +257,7 @@ class RealPlaybackControllerUiTest {
         // ── GitHub OAuth no-op (#91) — playback-controller test doesn't auth. ──
         override suspend fun signOutGitHub() = Unit
         override suspend fun setGitHubPrivateReposEnabled(enabled: Boolean) = Unit
+        override suspend fun signOutTeams() = Unit
     }
 
     /** Chapter repo never invoked by the speed/pitch path under test. */

--- a/core-llm/src/main/kotlin/in/jphe/storyvox/llm/LlmCredentialsStore.kt
+++ b/core-llm/src/main/kotlin/in/jphe/storyvox/llm/LlmCredentialsStore.kt
@@ -74,6 +74,50 @@ open class LlmCredentialsStore @Inject constructor(
     open fun setTeamsBearerToken(token: String) =
         prefs.edit { putString(KEY_TEAMS, token) }
     open fun clearTeamsBearerToken() = prefs.edit { remove(KEY_TEAMS) }
+    open val hasTeamsToken: Boolean get() = teamsBearerToken() != null
+
+    /** Anthropic Teams refresh token (#181). Stored alongside the
+     *  bearer so the provider can transparently refresh on expiry
+     *  without bouncing the user back through the browser. */
+    open fun teamsRefreshToken(): String? = prefs.getString(KEY_TEAMS_REFRESH, null)
+    open fun setTeamsRefreshToken(token: String) =
+        prefs.edit { putString(KEY_TEAMS_REFRESH, token) }
+    open fun clearTeamsRefreshToken() = prefs.edit { remove(KEY_TEAMS_REFRESH) }
+
+    /** Epoch millis when the bearer token expires. Zero / missing means
+     *  "unknown" — caller falls back to using the bearer until the API
+     *  rejects it with 401 and then runs the refresh flow. */
+    open fun teamsExpiresAt(): Long = prefs.getLong(KEY_TEAMS_EXPIRES_AT, 0L)
+    open fun setTeamsExpiresAt(epochMillis: Long) =
+        prefs.edit { putLong(KEY_TEAMS_EXPIRES_AT, epochMillis) }
+    open fun clearTeamsExpiresAt() = prefs.edit { remove(KEY_TEAMS_EXPIRES_AT) }
+
+    /** Granted scopes — surfaced on the "Signed in" Settings row. */
+    open fun teamsScopes(): String? = prefs.getString(KEY_TEAMS_SCOPES, null)
+    open fun setTeamsScopes(scopes: String) =
+        prefs.edit { putString(KEY_TEAMS_SCOPES, scopes) }
+    open fun clearTeamsScopes() = prefs.edit { remove(KEY_TEAMS_SCOPES) }
+
+    /** Persist the entire Teams session in a single atomic edit. */
+    open fun setTeamsSession(
+        bearer: String,
+        refreshToken: String?,
+        expiresAtEpochMillis: Long,
+        scopes: String,
+    ) = prefs.edit {
+        putString(KEY_TEAMS, bearer)
+        if (refreshToken != null) putString(KEY_TEAMS_REFRESH, refreshToken)
+        putLong(KEY_TEAMS_EXPIRES_AT, expiresAtEpochMillis)
+        putString(KEY_TEAMS_SCOPES, scopes)
+    }
+
+    /** Forget the Anthropic Teams session entirely. */
+    open fun clearTeamsSession() = prefs.edit {
+        remove(KEY_TEAMS)
+        remove(KEY_TEAMS_REFRESH)
+        remove(KEY_TEAMS_EXPIRES_AT)
+        remove(KEY_TEAMS_SCOPES)
+    }
 
     /** Wipe every provider's credentials. The "Forget all AI
      *  settings" button. */
@@ -81,7 +125,9 @@ open class LlmCredentialsStore @Inject constructor(
         remove(KEY_CLAUDE)
         remove(KEY_OPENAI)
         remove(KEY_BEDROCK_ACCESS); remove(KEY_BEDROCK_SECRET)
-        remove(KEY_VERTEX); remove(KEY_FOUNDRY); remove(KEY_TEAMS)
+        remove(KEY_VERTEX); remove(KEY_FOUNDRY)
+        remove(KEY_TEAMS); remove(KEY_TEAMS_REFRESH)
+        remove(KEY_TEAMS_EXPIRES_AT); remove(KEY_TEAMS_SCOPES)
     }
 
     /**
@@ -108,6 +154,9 @@ open class LlmCredentialsStore @Inject constructor(
         internal const val KEY_VERTEX = "llm_api_key:vertex"
         internal const val KEY_FOUNDRY = "llm_api_key:foundry"
         internal const val KEY_TEAMS = "llm_api_key:teams"
+        internal const val KEY_TEAMS_REFRESH = "llm_api_key:teams:refresh"
+        internal const val KEY_TEAMS_EXPIRES_AT = "llm_api_key:teams:expires_at"
+        internal const val KEY_TEAMS_SCOPES = "llm_api_key:teams:scopes"
     }
 }
 

--- a/core-llm/src/main/kotlin/in/jphe/storyvox/llm/LlmRepository.kt
+++ b/core-llm/src/main/kotlin/in/jphe/storyvox/llm/LlmRepository.kt
@@ -1,5 +1,6 @@
 package `in`.jphe.storyvox.llm
 
+import `in`.jphe.storyvox.llm.provider.AnthropicTeamsProvider
 import `in`.jphe.storyvox.llm.provider.AzureFoundryProvider
 import `in`.jphe.storyvox.llm.provider.BedrockProvider
 import `in`.jphe.storyvox.llm.provider.ClaudeApiProvider
@@ -32,6 +33,7 @@ class LlmRepository @Inject constructor(
     private val vertex: VertexProvider,
     private val foundry: AzureFoundryProvider,
     private val bedrock: BedrockProvider,
+    private val teams: AnthropicTeamsProvider,
 ) {
 
     /** The provider currently picked in Settings, or null when AI
@@ -82,7 +84,6 @@ class LlmRepository @Inject constructor(
         ProviderId.Vertex -> vertex
         ProviderId.Foundry -> foundry
         ProviderId.Bedrock -> bedrock
-        ProviderId.Teams ->
-            throw LlmError.NotConfigured(id)
+        ProviderId.Teams -> teams
     }
 }

--- a/core-llm/src/main/kotlin/in/jphe/storyvox/llm/ProviderId.kt
+++ b/core-llm/src/main/kotlin/in/jphe/storyvox/llm/ProviderId.kt
@@ -33,7 +33,8 @@ enum class ProviderId {
      *  False ids are surfaced as "coming soon" in the AI Settings. */
     val implemented: Boolean
         get() = this == Claude || this == OpenAi || this == Ollama ||
-            this == Vertex || this == Foundry || this == Bedrock
+            this == Vertex || this == Foundry || this == Bedrock ||
+            this == Teams
 
     /** Human-friendly label for the Settings UI. Localization is a
      *  follow-up; English-only labels for now match the rest of the

--- a/core-llm/src/main/kotlin/in/jphe/storyvox/llm/auth/AnthropicTeamsAuthApi.kt
+++ b/core-llm/src/main/kotlin/in/jphe/storyvox/llm/auth/AnthropicTeamsAuthApi.kt
@@ -1,0 +1,242 @@
+package `in`.jphe.storyvox.llm.auth
+
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.suspendCancellableCoroutine
+import kotlinx.coroutines.withContext
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.json.Json
+import okhttp3.Call
+import okhttp3.Callback
+import okhttp3.MediaType.Companion.toMediaType
+import okhttp3.OkHttpClient
+import okhttp3.Request
+import okhttp3.RequestBody.Companion.toRequestBody
+import okhttp3.Response
+import java.io.IOException
+import javax.inject.Inject
+import javax.inject.Singleton
+import kotlin.coroutines.resume
+import kotlin.coroutines.resumeWithException
+
+/**
+ * Anthropic Teams OAuth 2.0 client (#181).
+ *
+ * Authorization Code + PKCE / S256 against `claude.ai/oauth/authorize`
+ * and `console.anthropic.com/v1/oauth/token`. Mirrors the layered shape
+ * of `:source-github`'s `DeviceFlowApi` — a thin HTTP wrapper that
+ * exposes typed result variants; the calling ViewModel owns the state
+ * machine (browser handoff, paste-code, exchange).
+ *
+ * Flow:
+ *   1. [authorizeUrl] builds the URL the browser opens.
+ *   2. User authorizes at `claude.ai`; Anthropic shows an authorization
+ *      code on the redirect-page.
+ *   3. User pastes the code back into storyvox.
+ *   4. [exchangeCode] swaps the code (+ PKCE verifier) for a bearer + refresh.
+ *   5. On expiry, [refreshToken] swaps the refresh token for a new bearer.
+ *
+ * Construction takes a vanilla [OkHttpClient] (no Bearer interceptor) —
+ * the token endpoint takes only a JSON form body and responds with the
+ * token; hitting it with an existing Authorization header would have
+ * undefined behaviour.
+ */
+@Singleton
+open class AnthropicTeamsAuthApi @Inject constructor(
+    private val httpClient: OkHttpClient,
+) {
+
+    open val authorizeBaseUrl: String = AnthropicTeamsAuthConfig.AUTHORIZE_URL
+    open val tokenUrl: String = AnthropicTeamsAuthConfig.TOKEN_URL
+
+    /**
+     * Build the URL the browser should open. The `state` parameter is
+     * an opaque random nonce the caller stores and verifies on the
+     * round-trip — same shape Anthropic's official client uses. The
+     * caller passes back the pair `(state, challenge)` to verify the
+     * redirect; PKCE [verifier] is held privately by the caller and
+     * presented at exchange time.
+     */
+    open fun authorizeUrl(
+        clientId: String,
+        scopes: String,
+        challenge: String,
+        state: String,
+    ): String {
+        val params = listOf(
+            "code" to "true",
+            "client_id" to clientId,
+            "response_type" to "code",
+            "redirect_uri" to AnthropicTeamsAuthConfig.REDIRECT_URI,
+            "scope" to scopes,
+            "code_challenge" to challenge,
+            "code_challenge_method" to "S256",
+            "state" to state,
+        )
+        val query = params.joinToString("&") { (k, v) ->
+            "$k=${java.net.URLEncoder.encode(v, "UTF-8")}"
+        }
+        return "$authorizeBaseUrl?$query"
+    }
+
+    /** Step 4 — exchange the pasted authorization code for a bearer + refresh. */
+    open suspend fun exchangeCode(
+        clientId: String,
+        code: String,
+        verifier: String,
+        state: String,
+    ): TokenResult = withContext(Dispatchers.IO) {
+        val body = ExchangeRequest(
+            grantType = "authorization_code",
+            code = code,
+            redirectUri = AnthropicTeamsAuthConfig.REDIRECT_URI,
+            clientId = clientId,
+            codeVerifier = verifier,
+            state = state,
+        )
+        val payload = JSON.encodeToString(ExchangeRequest.serializer(), body)
+        post(payload)
+    }
+
+    /** Step 5 — refresh the bearer using the stored refresh token. */
+    open suspend fun refreshToken(
+        clientId: String,
+        refreshToken: String,
+    ): TokenResult = withContext(Dispatchers.IO) {
+        val body = RefreshRequest(
+            grantType = "refresh_token",
+            refreshToken = refreshToken,
+            clientId = clientId,
+        )
+        val payload = JSON.encodeToString(RefreshRequest.serializer(), body)
+        post(payload)
+    }
+
+    private suspend fun post(payload: String): TokenResult {
+        val req = Request.Builder()
+            .url(tokenUrl)
+            .post(payload.toRequestBody(JSON_MEDIA))
+            .header("Accept", "application/json")
+            .header("Content-Type", "application/json")
+            .header("User-Agent", USER_AGENT)
+            .build()
+        val response = try {
+            httpClient.newCall(req).await()
+        } catch (e: IOException) {
+            return TokenResult.NetworkError(e)
+        }
+        return response.use { r ->
+            val raw = r.body?.string().orEmpty()
+            val parsed = try {
+                JSON.decodeFromString(TokenResponse.serializer(), raw)
+            } catch (e: Throwable) {
+                return@use if (r.isSuccessful) {
+                    TokenResult.MalformedResponse(e.message ?: "parse failed")
+                } else {
+                    TokenResult.HttpError(r.code, r.message)
+                }
+            }
+            when {
+                parsed.accessToken != null -> TokenResult.Success(
+                    accessToken = parsed.accessToken,
+                    refreshToken = parsed.refreshToken,
+                    expiresInSeconds = parsed.expiresIn ?: 0,
+                    scopes = parsed.scope.orEmpty(),
+                    tokenType = parsed.tokenType.orEmpty(),
+                )
+                parsed.error == "invalid_grant" -> TokenResult.InvalidGrant(
+                    message = parsed.errorDescription,
+                )
+                parsed.error != null -> TokenResult.AnthropicError(
+                    code = parsed.error,
+                    message = parsed.errorDescription,
+                )
+                !r.isSuccessful -> TokenResult.HttpError(r.code, r.message)
+                else -> TokenResult.MalformedResponse(
+                    "no access_token and no error in response",
+                )
+            }
+        }
+    }
+
+    @Serializable
+    private data class ExchangeRequest(
+        @SerialName("grant_type") val grantType: String,
+        val code: String,
+        @SerialName("redirect_uri") val redirectUri: String,
+        @SerialName("client_id") val clientId: String,
+        @SerialName("code_verifier") val codeVerifier: String,
+        val state: String,
+    )
+
+    @Serializable
+    private data class RefreshRequest(
+        @SerialName("grant_type") val grantType: String,
+        @SerialName("refresh_token") val refreshToken: String,
+        @SerialName("client_id") val clientId: String,
+    )
+
+    @Serializable
+    private data class TokenResponse(
+        @SerialName("access_token") val accessToken: String? = null,
+        @SerialName("refresh_token") val refreshToken: String? = null,
+        @SerialName("token_type") val tokenType: String? = null,
+        @SerialName("expires_in") val expiresIn: Long? = null,
+        val scope: String? = null,
+        val error: String? = null,
+        @SerialName("error_description") val errorDescription: String? = null,
+    )
+
+    companion object {
+        const val USER_AGENT: String = "storyvox/0.4 (+https://github.com/jphein/storyvox)"
+        private val JSON_MEDIA = "application/json".toMediaType()
+        private val JSON: Json = Json {
+            ignoreUnknownKeys = true
+            explicitNulls = false
+        }
+    }
+}
+
+/** Outcome of [AnthropicTeamsAuthApi.exchangeCode] / [AnthropicTeamsAuthApi.refreshToken]. */
+sealed class TokenResult {
+    data class Success(
+        val accessToken: String,
+        /** Refresh token — null on refresh-flow if Anthropic doesn't rotate it. */
+        val refreshToken: String?,
+        /** Lifetime in seconds; 0 means "didn't say." */
+        val expiresInSeconds: Long,
+        val scopes: String,
+        val tokenType: String,
+    ) : TokenResult()
+
+    /**
+     * `invalid_grant` — refresh token was revoked / expired, or the
+     * authorization code was reused. Caller surfaces "Session expired —
+     * sign in again."
+     */
+    data class InvalidGrant(val message: String?) : TokenResult()
+
+    /** Catch-all Anthropic error code (e.g. `invalid_client`, `invalid_request`). */
+    data class AnthropicError(val code: String, val message: String?) : TokenResult()
+
+    data class NetworkError(val cause: Throwable) : TokenResult()
+    data class HttpError(val code: Int, val message: String) : TokenResult()
+    data class MalformedResponse(val message: String) : TokenResult()
+}
+
+/** Suspending bridge over OkHttp's enqueue → callback API. */
+private suspend fun Call.await(): Response = suspendCancellableCoroutine { cont ->
+    enqueue(object : Callback {
+        override fun onResponse(call: Call, response: Response) {
+            cont.resume(response)
+        }
+
+        override fun onFailure(call: Call, e: IOException) {
+            if (cont.isCancelled) return
+            cont.resumeWithException(e)
+        }
+    })
+    cont.invokeOnCancellation {
+        runCatching { cancel() }
+    }
+}

--- a/core-llm/src/main/kotlin/in/jphe/storyvox/llm/auth/AnthropicTeamsAuthConfig.kt
+++ b/core-llm/src/main/kotlin/in/jphe/storyvox/llm/auth/AnthropicTeamsAuthConfig.kt
@@ -1,0 +1,72 @@
+package `in`.jphe.storyvox.llm.auth
+
+/**
+ * Static OAuth-app config for the Anthropic Teams (OAuth) provider (#181).
+ *
+ * Mirrors `:source-github`'s `GitHubAuthConfig` shape — public-client PKCE
+ * flow, the client_id ships in every APK by design, the secret-less posture
+ * is documented in the kdoc.
+ *
+ * Storyvox uses Claude Code's published public OAuth client to talk to
+ * `claude.ai/oauth/authorize` (Authorization Code + PKCE / S256). The
+ * browser handshake is identical to what Claude Code uses on the desktop;
+ * the `console.anthropic.com/oauth/code/callback` redirect URI is what
+ * Anthropic accepts for that client.
+ *
+ * If the public client_id ever rotates, bump the constant and ship a new
+ * build — same posture as `GitHubAuthConfig.DEFAULT_CLIENT_ID`.
+ */
+object AnthropicTeamsAuthConfig {
+
+    /**
+     * Public Claude Code OAuth client id. Same one used by the Claude
+     * Code CLI; visible in the binary, not a secret.
+     */
+    const val DEFAULT_CLIENT_ID: String = "9d1c250a-e61b-44d9-88ed-5944d1962f5e"
+
+    /**
+     * Scopes requested at sign-in.
+     *
+     * - `org:create_api_key` — required for full Messages API access.
+     * - `user:profile` — surfaces account info on the "Signed in" row.
+     * - `user:inference` — required to call the Messages API on behalf
+     *   of the signed-in workspace.
+     */
+    const val DEFAULT_SCOPES: String = "org:create_api_key user:profile user:inference"
+
+    /**
+     * Browser-facing authorize endpoint. PKCE-S256 code-flow; the device
+     * picks up the redirect via the `code` query param on the callback URL
+     * and exchanges it for a bearer token at [TOKEN_URL].
+     */
+    const val AUTHORIZE_URL: String = "https://claude.ai/oauth/authorize"
+
+    /** Token endpoint — exchanges authorization code or refresh token for a bearer. */
+    const val TOKEN_URL: String = "https://console.anthropic.com/v1/oauth/token"
+
+    /**
+     * The redirect URI that this OAuth client accepts. Anthropic shows
+     * the resulting code on the page after the user clicks "Authorize"
+     * — the user copy-pastes the code into storyvox; we don't claim a
+     * `storyvox://` scheme intent-filter here because the public OAuth
+     * client is registered with the console.anthropic.com URL only.
+     *
+     * The page after authorization renders the code in a copy-able block
+     * (Anthropic's standard out-of-band flow); the modal in `:app` shows
+     * a "Paste authorization code" field after the browser handoff.
+     */
+    const val REDIRECT_URI: String = "https://console.anthropic.com/oauth/code/callback"
+
+    /**
+     * `anthropic-beta` header value required when calling Messages API
+     * with an OAuth bearer token. The `2025-04-20` value is the OAuth
+     * beta gate; without this header the bearer is rejected as "use an
+     * API key instead." See `cc-usage` for the same usage at
+     * `~/Projects/claude-code-switcher/cc-usage`.
+     */
+    const val OAUTH_BETA_HEADER: String = "oauth-2025-04-20"
+
+    /** Anthropic's account/profile endpoint — used to surface the user
+     *  identity after sign-in. */
+    const val PROFILE_URL: String = "https://api.anthropic.com/api/oauth/profile"
+}

--- a/core-llm/src/main/kotlin/in/jphe/storyvox/llm/auth/AnthropicTeamsAuthRepository.kt
+++ b/core-llm/src/main/kotlin/in/jphe/storyvox/llm/auth/AnthropicTeamsAuthRepository.kt
@@ -1,0 +1,73 @@
+package `in`.jphe.storyvox.llm.auth
+
+import `in`.jphe.storyvox.llm.LlmCredentialsStore
+import javax.inject.Inject
+import javax.inject.Singleton
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+
+/**
+ * Public Teams (OAuth) session surface (#181).
+ *
+ * Mirrors the [`in`.jphe.storyvox.source.github.auth.GitHubAuthRepository]
+ * shape — a hot StateFlow that the UI layer subscribes to so the
+ * Settings row updates the moment a sign-in completes (or the refresh
+ * token gets revoked mid-session).
+ *
+ * The token + refresh + scope cache live in [LlmCredentialsStore]
+ * (encrypted prefs); this class is the in-memory mirror so callers
+ * don't need to poll prefs to see state changes. The [`AnthropicTeamsProvider`]
+ * also clears the session via [LlmCredentialsStore.clearTeamsSession]
+ * on `invalid_grant` — we listen there too via [refreshFromStore].
+ */
+sealed interface TeamsSession {
+    data object SignedOut : TeamsSession
+    data class SignedIn(val scopes: String) : TeamsSession
+}
+
+@Singleton
+open class AnthropicTeamsAuthRepository @Inject constructor(
+    private val store: LlmCredentialsStore,
+) {
+    private val _state = MutableStateFlow<TeamsSession>(initialState())
+    val sessionState: StateFlow<TeamsSession> = _state.asStateFlow()
+
+    /** Persist a freshly-issued session and flip the in-memory flag. */
+    fun captureSession(
+        bearer: String,
+        refreshToken: String?,
+        expiresAtEpochMillis: Long,
+        scopes: String,
+    ) {
+        store.setTeamsSession(
+            bearer = bearer,
+            refreshToken = refreshToken,
+            expiresAtEpochMillis = expiresAtEpochMillis,
+            scopes = scopes,
+        )
+        _state.value = TeamsSession.SignedIn(scopes = scopes)
+    }
+
+    /** Forget the entire Teams session (local-only — see [`SettingsRepositoryUi.signOutTeams`]). */
+    fun clearSession() {
+        store.clearTeamsSession()
+        _state.value = TeamsSession.SignedOut
+    }
+
+    /**
+     * Re-read prefs and emit. Called by callers that bypass [captureSession]
+     * — for now that's just [`AnthropicTeamsProvider.refreshOrInvalidate`]
+     * when it wipes the session on `invalid_grant`.
+     */
+    fun refreshFromStore() {
+        _state.value = initialState()
+    }
+
+    private fun initialState(): TeamsSession =
+        if (store.hasTeamsToken) {
+            TeamsSession.SignedIn(scopes = store.teamsScopes().orEmpty())
+        } else {
+            TeamsSession.SignedOut
+        }
+}

--- a/core-llm/src/main/kotlin/in/jphe/storyvox/llm/auth/PkcePair.kt
+++ b/core-llm/src/main/kotlin/in/jphe/storyvox/llm/auth/PkcePair.kt
@@ -1,0 +1,41 @@
+package `in`.jphe.storyvox.llm.auth
+
+import android.util.Base64
+import java.security.MessageDigest
+import java.security.SecureRandom
+
+/**
+ * PKCE (RFC 7636) verifier + S256 challenge pair for the Anthropic
+ * Teams OAuth flow (#181).
+ *
+ * The verifier is a cryptographically random 64-byte URL-safe Base64
+ * string; the challenge is `BASE64URL(SHA256(verifier))`. Per RFC 7636
+ * §4.2, the verifier MUST be 43-128 characters; 64 random bytes
+ * encode to exactly 86 URL-safe Base64 characters (no padding).
+ */
+data class PkcePair(
+    val verifier: String,
+    val challenge: String,
+) {
+    companion object {
+        /**
+         * Generate a fresh PKCE pair. `SecureRandom` is the JVM standard
+         * RNG — backed by `/dev/urandom` on Android, which is the right
+         * source for OAuth nonces.
+         */
+        fun generate(): PkcePair {
+            val bytes = ByteArray(64).also { SecureRandom().nextBytes(it) }
+            val verifier = Base64.encodeToString(
+                bytes,
+                Base64.URL_SAFE or Base64.NO_PADDING or Base64.NO_WRAP,
+            )
+            val digest = MessageDigest.getInstance("SHA-256")
+                .digest(verifier.toByteArray(Charsets.US_ASCII))
+            val challenge = Base64.encodeToString(
+                digest,
+                Base64.URL_SAFE or Base64.NO_PADDING or Base64.NO_WRAP,
+            )
+            return PkcePair(verifier = verifier, challenge = challenge)
+        }
+    }
+}

--- a/core-llm/src/main/kotlin/in/jphe/storyvox/llm/di/LlmModule.kt
+++ b/core-llm/src/main/kotlin/in/jphe/storyvox/llm/di/LlmModule.kt
@@ -2,6 +2,7 @@ package `in`.jphe.storyvox.llm.di
 
 import `in`.jphe.storyvox.llm.LlmConfig
 import `in`.jphe.storyvox.llm.LlmConfigProvider
+import `in`.jphe.storyvox.llm.auth.AnthropicTeamsAuthApi
 import dagger.Module
 import dagger.Provides
 import dagger.hilt.InstallIn
@@ -69,4 +70,15 @@ object LlmModule {
     @Singleton
     fun provideConfigFlow(provider: LlmConfigProvider): Flow<LlmConfig> =
         provider.config
+
+    /**
+     * Anthropic Teams OAuth client (#181). Reuses the [LlmHttp] vanilla
+     * OkHttpClient — that one has no Bearer interceptor, which is
+     * exactly what the token endpoint needs (it takes the bearer in
+     * the JSON body, not as an Authorization header).
+     */
+    @Provides
+    @Singleton
+    fun provideAnthropicTeamsAuthApi(@LlmHttp http: OkHttpClient): AnthropicTeamsAuthApi =
+        AnthropicTeamsAuthApi(http)
 }

--- a/core-llm/src/main/kotlin/in/jphe/storyvox/llm/provider/AnthropicTeamsProvider.kt
+++ b/core-llm/src/main/kotlin/in/jphe/storyvox/llm/provider/AnthropicTeamsProvider.kt
@@ -1,0 +1,306 @@
+package `in`.jphe.storyvox.llm.provider
+
+import `in`.jphe.storyvox.llm.LlmConfig
+import `in`.jphe.storyvox.llm.LlmCredentialsStore
+import `in`.jphe.storyvox.llm.LlmError
+import `in`.jphe.storyvox.llm.LlmMessage
+import `in`.jphe.storyvox.llm.LlmProvider
+import `in`.jphe.storyvox.llm.ProbeResult
+import `in`.jphe.storyvox.llm.ProviderId
+import `in`.jphe.storyvox.llm.auth.AnthropicTeamsAuthApi
+import `in`.jphe.storyvox.llm.auth.AnthropicTeamsAuthConfig
+import `in`.jphe.storyvox.llm.auth.AnthropicTeamsAuthRepository
+import `in`.jphe.storyvox.llm.auth.TokenResult
+import `in`.jphe.storyvox.llm.di.LlmHttp
+import `in`.jphe.storyvox.llm.sse.SseLineParser
+import javax.inject.Inject
+import javax.inject.Singleton
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.flow.flow
+import kotlinx.coroutines.flow.flowOn
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
+import kotlinx.serialization.encodeToString
+import kotlinx.serialization.json.Json
+import okhttp3.OkHttpClient
+import okhttp3.Request
+import okhttp3.RequestBody.Companion.toRequestBody
+import java.io.IOException
+
+/**
+ * Anthropic Teams (OAuth) provider — issue #181.
+ *
+ * Wire format is identical to [ClaudeApiProvider] (Anthropic Messages
+ * API, SSE `content_block_delta`); only the auth differs:
+ *
+ * - Bearer token in `Authorization: Bearer <token>` instead of `x-api-key`.
+ * - `anthropic-beta: oauth-2025-04-20` header is required for the OAuth
+ *   bearer to be accepted (without it Anthropic responds 401 with "use
+ *   an API key instead").
+ * - On 401 we run the refresh-token flow once; if that also fails the
+ *   user is bounced back to the sign-in screen.
+ *
+ * The bearer is short-lived (typically hours). [ensureFreshToken]
+ * pre-emptively refreshes when the persisted `expires_at` is within
+ * [REFRESH_LEAD_MILLIS]; that way listeners don't get a single failed
+ * request mid-recap before the refresh kicks in. The retry-on-401
+ * behaviour is the safety net for the case where Anthropic invalidates
+ * the token early (revocation, server-side rotation).
+ */
+@Singleton
+open class AnthropicTeamsProvider @Inject constructor(
+    @LlmHttp private val http: OkHttpClient,
+    private val store: LlmCredentialsStore,
+    private val configFlow: Flow<LlmConfig>,
+    private val authApi: AnthropicTeamsAuthApi,
+    private val authRepo: AnthropicTeamsAuthRepository,
+    private val json: Json,
+) : LlmProvider {
+
+    override val id: ProviderId = ProviderId.Teams
+
+    /** Override hook for tests — Messages API endpoint. */
+    protected open val endpointUrl: String = ENDPOINT
+
+    /** Serialize concurrent refresh attempts so a recap + a chat both
+     *  hitting an expired token only refresh once. */
+    private val refreshLock = Mutex()
+
+    override fun stream(
+        messages: List<LlmMessage>,
+        systemPrompt: String?,
+        model: String?,
+    ): Flow<String> = flow {
+        val cfg = configFlow.first()
+        val resolvedModel = (model ?: cfg.claudeModel).resolveAnthropic()
+
+        val body = AnthropicRequest(
+            model = resolvedModel,
+            maxTokens = MAX_TOKENS,
+            messages = messages.map {
+                AnthropicMessage(it.role.name, it.content)
+            },
+            system = systemPrompt,
+            stream = true,
+        )
+        val payload = json.encodeToString(body)
+
+        // Refresh proactively if the persisted expires_at is close.
+        ensureFreshToken()
+
+        val firstAttempt = doStreamRequest(payload)
+        if (firstAttempt.code != 401) {
+            firstAttempt.use { resp -> consumeResponse(resp).collect { emit(it) } }
+            return@flow
+        }
+        // 401 — try one refresh + retry, mirroring how the GitHub
+        // interceptor treats 401 as "token's gone". If the refresh
+        // itself fails, bubble up AuthFailed and let the user re-sign-in.
+        firstAttempt.close()
+        if (!refreshOrInvalidate()) {
+            throw LlmError.AuthFailed(
+                ProviderId.Teams,
+                "Teams session expired — sign in again.",
+            )
+        }
+        val retry = doStreamRequest(payload)
+        retry.use { resp ->
+            when {
+                resp.code == 401 || resp.code == 403 ->
+                    throw LlmError.AuthFailed(
+                        ProviderId.Teams,
+                        resp.message.ifBlank { "HTTP ${resp.code}" },
+                    )
+                !resp.isSuccessful -> {
+                    val excerpt = resp.body?.string()?.take(256) ?: resp.message
+                    throw LlmError.ProviderError(
+                        ProviderId.Teams, resp.code, excerpt,
+                    )
+                }
+            }
+            consumeResponse(resp).collect { emit(it) }
+        }
+    }.flowOn(Dispatchers.IO)
+
+    private suspend fun doStreamRequest(payload: String): okhttp3.Response {
+        val bearer = store.teamsBearerToken()
+            ?: throw LlmError.NotConfigured(ProviderId.Teams)
+        val request = Request.Builder()
+            .url(endpointUrl)
+            .header("Authorization", "Bearer $bearer")
+            .header("anthropic-version", API_VERSION)
+            .header("anthropic-beta", AnthropicTeamsAuthConfig.OAUTH_BETA_HEADER)
+            .header("content-type", "application/json")
+            .header("accept", "text/event-stream")
+            .post(payload.toRequestBody(JSON_MEDIA_TYPE))
+            .build()
+        return try {
+            http.newCall(request).executeAsync()
+        } catch (e: IOException) {
+            throw LlmError.Transport(ProviderId.Teams, e)
+        }
+    }
+
+    private fun consumeResponse(resp: okhttp3.Response): Flow<String> = flow {
+        when {
+            resp.code == 401 || resp.code == 403 ->
+                throw LlmError.AuthFailed(
+                    ProviderId.Teams,
+                    resp.message.ifBlank { "HTTP ${resp.code}" },
+                )
+            !resp.isSuccessful -> {
+                val excerpt = resp.body?.string()?.take(256) ?: resp.message
+                throw LlmError.ProviderError(
+                    ProviderId.Teams, resp.code, excerpt,
+                )
+            }
+        }
+        val source = resp.body
+            ?: throw LlmError.Transport(
+                ProviderId.Teams,
+                IOException("Empty response body"),
+            )
+        source.source().use { src ->
+            while (!src.exhausted()) {
+                val line = src.readUtf8Line() ?: break
+                val token = SseLineParser.anthropic(line, json) ?: continue
+                emit(token)
+            }
+        }
+    }
+
+    /**
+     * Refresh proactively if the stored expiry is within
+     * [REFRESH_LEAD_MILLIS]. No-op if there's no refresh token (the user
+     * never completed the OAuth flow), or if the bearer is comfortably
+     * fresh, or if the expiry is unknown (legacy / probe-only sessions).
+     */
+    private suspend fun ensureFreshToken() {
+        val expiresAt = store.teamsExpiresAt()
+        if (expiresAt <= 0L) return // unknown — fall through; 401 retry will catch it
+        val now = System.currentTimeMillis()
+        if (now < expiresAt - REFRESH_LEAD_MILLIS) return
+        refreshOrInvalidate()
+    }
+
+    /**
+     * Run the refresh flow once. Returns true iff the bearer was
+     * replaced with a fresh one; false on any failure (no refresh
+     * token, network error, `invalid_grant`, etc.). On
+     * `invalid_grant` the session is wiped — the user has to sign in
+     * again.
+     */
+    private suspend fun refreshOrInvalidate(): Boolean = refreshLock.withLock {
+        val refresh = store.teamsRefreshToken() ?: return@withLock false
+        when (val r = authApi.refreshToken(
+            clientId = AnthropicTeamsAuthConfig.DEFAULT_CLIENT_ID,
+            refreshToken = refresh,
+        )) {
+            is TokenResult.Success -> {
+                val now = System.currentTimeMillis()
+                store.setTeamsSession(
+                    bearer = r.accessToken,
+                    refreshToken = r.refreshToken ?: refresh,
+                    expiresAtEpochMillis = now + r.expiresInSeconds * 1000L,
+                    scopes = r.scopes.ifBlank { store.teamsScopes().orEmpty() },
+                )
+                true
+            }
+            is TokenResult.InvalidGrant -> {
+                // Refresh token revoked — wipe the entire session so
+                // Settings flips back to "not signed in" and the user
+                // re-runs the OAuth flow. Keeping the dead refresh
+                // token would just keep failing. Also flip the in-memory
+                // session flag so any UI subscribed to it sees the
+                // change without polling the credential store.
+                authRepo.clearSession()
+                false
+            }
+            is TokenResult.AnthropicError,
+            is TokenResult.NetworkError,
+            is TokenResult.HttpError,
+            is TokenResult.MalformedResponse -> false
+        }
+    }
+
+    override suspend fun probe(): ProbeResult {
+        if (store.teamsBearerToken() == null) {
+            return ProbeResult.Misconfigured("Sign in to Teams first")
+        }
+        ensureFreshToken()
+        val bearer = store.teamsBearerToken()
+            ?: return ProbeResult.Misconfigured("Sign in to Teams first")
+        // 1-token POST against the Messages API. Anthropic doesn't
+        // expose a free-tier reachability endpoint, but the cost is
+        // negligible (~1 cent) and the OAuth bearer + beta header
+        // round-trip is exactly what the Recap flow uses.
+        val body = AnthropicRequest(
+            model = LlmConfig().claudeModel.resolveAnthropic(),
+            maxTokens = 1,
+            messages = listOf(AnthropicMessage("user", "ping")),
+            stream = false,
+        )
+        val request = Request.Builder()
+            .url(endpointUrl)
+            .header("Authorization", "Bearer $bearer")
+            .header("anthropic-version", API_VERSION)
+            .header("anthropic-beta", AnthropicTeamsAuthConfig.OAUTH_BETA_HEADER)
+            .header("content-type", "application/json")
+            .post(json.encodeToString(body).toRequestBody(JSON_MEDIA_TYPE))
+            .build()
+        return try {
+            http.newCall(request).executeAsync().use { resp ->
+                when {
+                    resp.isSuccessful -> ProbeResult.Ok
+                    resp.code == 401 || resp.code == 403 -> {
+                        // One-shot refresh-and-retry, mirroring the
+                        // stream path. If refresh succeeds, retry the
+                        // probe; if it fails, surface the auth error.
+                        if (refreshOrInvalidate()) {
+                            // Recursive retry — bounded depth is 1
+                            // because refreshOrInvalidate clears the
+                            // token on failure, so the next call sees
+                            // null bearer and returns Misconfigured.
+                            probe()
+                        } else {
+                            ProbeResult.AuthError("Teams session expired — sign in again")
+                        }
+                    }
+                    else -> ProbeResult.NotReachable(
+                        "Anthropic returned ${resp.code}",
+                    )
+                }
+            }
+        } catch (e: IOException) {
+            ProbeResult.NotReachable(e.message ?: "Connection failed")
+        }
+    }
+
+    /**
+     * Mirror of [ClaudeApiProvider.resolveAnthropic] — Teams uses the
+     * same model id space (it's the same Messages API) so the canonical
+     * → wire-name mapping is identical.
+     */
+    private fun String.resolveAnthropic(): String = when (this) {
+        "claude-opus-4.6" -> "claude-opus-4-6"
+        "claude-sonnet-4.6" -> "claude-sonnet-4-6"
+        "claude-haiku-4.5" -> "claude-haiku-4-5-20251001"
+        "claude-opus-4.5" -> "claude-opus-4-5-20251101"
+        "claude-sonnet-4.5" -> "claude-sonnet-4-5-20250929"
+        else -> this
+    }
+
+    private companion object {
+        const val ENDPOINT = "https://api.anthropic.com/v1/messages"
+        const val API_VERSION = "2023-06-01"
+        const val MAX_TOKENS = 1024
+
+        /** Refresh the bearer if the persisted expiry is within 60 s.
+         *  Long enough to absorb a slow request + slow refresh; short
+         *  enough that the listener doesn't see the bearer rotate
+         *  every other recap. */
+        const val REFRESH_LEAD_MILLIS = 60_000L
+    }
+}

--- a/core-llm/src/test/kotlin/in/jphe/storyvox/llm/auth/AnthropicTeamsAuthApiTest.kt
+++ b/core-llm/src/test/kotlin/in/jphe/storyvox/llm/auth/AnthropicTeamsAuthApiTest.kt
@@ -1,0 +1,172 @@
+package `in`.jphe.storyvox.llm.auth
+
+import kotlinx.coroutines.test.runTest
+import okhttp3.OkHttpClient
+import okhttp3.mockwebserver.MockResponse
+import okhttp3.mockwebserver.MockWebServer
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+
+/**
+ * Anthropic Teams OAuth client tests (#181).
+ *
+ * Mirrors the shape of `:source-github`'s `DeviceFlowApiTest` —
+ * MockWebServer-backed asserts on the request shape + response
+ * decoding for the three result variants we care about (Success,
+ * InvalidGrant, AnthropicError).
+ */
+class AnthropicTeamsAuthApiTest {
+
+    private lateinit var server: MockWebServer
+    private lateinit var api: AnthropicTeamsAuthApi
+
+    @Before
+    fun setUp() {
+        server = MockWebServer()
+        server.start()
+        api = object : AnthropicTeamsAuthApi(OkHttpClient()) {
+            override val tokenUrl: String =
+                server.url("/v1/oauth/token").toString()
+        }
+    }
+
+    @After
+    fun tearDown() {
+        server.shutdown()
+    }
+
+    @Test
+    fun `authorizeUrl includes PKCE challenge state and redirect`() {
+        val url = api.authorizeUrl(
+            clientId = "test-client",
+            scopes = "user:profile user:inference",
+            challenge = "abc123",
+            state = "state-nonce",
+        )
+        assertTrue(url.startsWith("https://claude.ai/oauth/authorize?"))
+        assertTrue(url.contains("client_id=test-client"))
+        assertTrue(url.contains("code_challenge=abc123"))
+        assertTrue(url.contains("code_challenge_method=S256"))
+        assertTrue(url.contains("state=state-nonce"))
+        assertTrue(url.contains("response_type=code"))
+        assertTrue(url.contains("redirect_uri=https"))
+    }
+
+    @Test
+    fun `exchangeCode returns Success on 200 with access_token`() = runTest {
+        server.enqueue(
+            MockResponse()
+                .setResponseCode(200)
+                .setHeader("Content-Type", "application/json")
+                .setBody(
+                    """
+                    {
+                      "access_token": "bearer-123",
+                      "refresh_token": "refresh-456",
+                      "expires_in": 3600,
+                      "token_type": "Bearer",
+                      "scope": "user:profile user:inference"
+                    }
+                    """.trimIndent(),
+                ),
+        )
+        val r = api.exchangeCode(
+            clientId = "test-client",
+            code = "auth-code",
+            verifier = "pkce-verifier",
+            state = "state-nonce",
+        )
+        assertTrue("expected Success, got $r", r is TokenResult.Success)
+        val success = r as TokenResult.Success
+        assertEquals("bearer-123", success.accessToken)
+        assertEquals("refresh-456", success.refreshToken)
+        assertEquals(3600L, success.expiresInSeconds)
+        assertEquals("user:profile user:inference", success.scopes)
+        // Confirm the request body carried the PKCE verifier + auth code.
+        val req = server.takeRequest()
+        val body = req.body.readUtf8()
+        assertTrue(body.contains("\"code\":\"auth-code\""))
+        assertTrue(body.contains("\"code_verifier\":\"pkce-verifier\""))
+        assertTrue(body.contains("\"grant_type\":\"authorization_code\""))
+    }
+
+    @Test
+    fun `exchangeCode returns InvalidGrant on invalid_grant error`() = runTest {
+        server.enqueue(
+            MockResponse()
+                .setResponseCode(400)
+                .setHeader("Content-Type", "application/json")
+                .setBody(
+                    """{"error":"invalid_grant","error_description":"code expired"}""",
+                ),
+        )
+        val r = api.exchangeCode(
+            clientId = "test-client",
+            code = "bad-code",
+            verifier = "pkce-verifier",
+            state = "state-nonce",
+        )
+        assertTrue("expected InvalidGrant, got $r", r is TokenResult.InvalidGrant)
+        assertEquals("code expired", (r as TokenResult.InvalidGrant).message)
+    }
+
+    @Test
+    fun `refreshToken returns Success on 200`() = runTest {
+        server.enqueue(
+            MockResponse()
+                .setResponseCode(200)
+                .setHeader("Content-Type", "application/json")
+                .setBody(
+                    """
+                    {
+                      "access_token": "fresh-bearer",
+                      "expires_in": 7200,
+                      "token_type": "Bearer"
+                    }
+                    """.trimIndent(),
+                ),
+        )
+        val r = api.refreshToken(
+            clientId = "test-client",
+            refreshToken = "refresh-old",
+        )
+        assertTrue("expected Success, got $r", r is TokenResult.Success)
+        val success = r as TokenResult.Success
+        assertEquals("fresh-bearer", success.accessToken)
+        // Anthropic doesn't always rotate the refresh token — null is OK,
+        // the caller falls back to keeping the existing one.
+        assertEquals(null, success.refreshToken)
+        assertEquals(7200L, success.expiresInSeconds)
+        // Body carries grant_type + refresh_token, not code/verifier.
+        val req = server.takeRequest()
+        val body = req.body.readUtf8()
+        assertTrue(body.contains("\"grant_type\":\"refresh_token\""))
+        assertTrue(body.contains("\"refresh_token\":\"refresh-old\""))
+    }
+
+    @Test
+    fun `exchangeCode returns AnthropicError on unrecognized error`() = runTest {
+        server.enqueue(
+            MockResponse()
+                .setResponseCode(400)
+                .setHeader("Content-Type", "application/json")
+                .setBody(
+                    """{"error":"invalid_client","error_description":"client_id rejected"}""",
+                ),
+        )
+        val r = api.exchangeCode(
+            clientId = "test-client",
+            code = "code",
+            verifier = "v",
+            state = "s",
+        )
+        assertTrue("expected AnthropicError, got $r", r is TokenResult.AnthropicError)
+        val err = r as TokenResult.AnthropicError
+        assertEquals("invalid_client", err.code)
+        assertNotNull(err.message)
+    }
+}

--- a/core-llm/src/test/kotlin/in/jphe/storyvox/llm/auth/PkcePairTest.kt
+++ b/core-llm/src/test/kotlin/in/jphe/storyvox/llm/auth/PkcePairTest.kt
@@ -1,0 +1,51 @@
+package `in`.jphe.storyvox.llm.auth
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+import java.security.MessageDigest
+
+/**
+ * PKCE pair shape tests (#181). Robolectric-backed because [PkcePair]
+ * uses `android.util.Base64` (not java.util.Base64) for the URL-safe
+ * encoding — same as the rest of `:core-llm`'s test suite.
+ */
+@RunWith(RobolectricTestRunner::class)
+@Config(manifest = Config.NONE)
+class PkcePairTest {
+
+    @Test
+    fun `verifier is URL-safe base64 within RFC 7636 length bounds`() {
+        val pair = PkcePair.generate()
+        // RFC 7636 §4.1: 43-128 unreserved-character verifier. 64 random
+        // bytes encode to 86 URL-safe Base64 chars (no padding).
+        assertTrue(pair.verifier.length in 43..128)
+        // URL-safe alphabet: A-Z a-z 0-9 - _
+        assertTrue(pair.verifier.all { it.isLetterOrDigit() || it == '-' || it == '_' })
+    }
+
+    @Test
+    fun `challenge is SHA256 of verifier in URL-safe base64`() {
+        val pair = PkcePair.generate()
+        val expected = android.util.Base64.encodeToString(
+            MessageDigest.getInstance("SHA-256")
+                .digest(pair.verifier.toByteArray(Charsets.US_ASCII)),
+            android.util.Base64.URL_SAFE or
+                android.util.Base64.NO_PADDING or
+                android.util.Base64.NO_WRAP,
+        )
+        assertEquals(expected, pair.challenge)
+    }
+
+    @Test
+    fun `each generate yields a fresh pair`() {
+        val a = PkcePair.generate()
+        val b = PkcePair.generate()
+        assertNotEquals(a.verifier, b.verifier)
+        assertNotEquals(a.challenge, b.challenge)
+    }
+}

--- a/core-llm/src/test/kotlin/in/jphe/storyvox/llm/feature/ChapterRecapTest.kt
+++ b/core-llm/src/test/kotlin/in/jphe/storyvox/llm/feature/ChapterRecapTest.kt
@@ -93,6 +93,7 @@ class ChapterRecapTest {
             vertex = fakeProvider.asVertex(),
             foundry = fakeProvider.asFoundry(),
             bedrock = fakeProvider.asBedrock(),
+            teams = fakeProvider.asTeams(),
         )
         recap = ChapterRecap(
             chapterDao = db.chapterDao(),
@@ -301,4 +302,25 @@ private class FakeProvider {
         }
         override suspend fun probe(): ProbeResult = ProbeResult.Ok
     }
+
+    fun asTeams(): `in`.jphe.storyvox.llm.provider.AnthropicTeamsProvider =
+        object : `in`.jphe.storyvox.llm.provider.AnthropicTeamsProvider(
+            http = OkHttpClient(),
+            store = FakeStore(),
+            configFlow = flowOf(LlmConfig()),
+            authApi = `in`.jphe.storyvox.llm.auth.AnthropicTeamsAuthApi(OkHttpClient()),
+            authRepo = `in`.jphe.storyvox.llm.auth.AnthropicTeamsAuthRepository(FakeStore()),
+            json = Json,
+        ) {
+            override fun stream(
+                messages: List<LlmMessage>,
+                systemPrompt: String?,
+                model: String?,
+            ): Flow<String> {
+                lastMessages = messages
+                lastSystemPrompt = systemPrompt
+                return flowOf(*tokens.toTypedArray())
+            }
+            override suspend fun probe(): ProbeResult = ProbeResult.Ok
+        }
 }

--- a/feature/src/main/kotlin/in/jphe/storyvox/feature/api/UiContracts.kt
+++ b/feature/src/main/kotlin/in/jphe/storyvox/feature/api/UiContracts.kt
@@ -416,6 +416,16 @@ data class UiAiSettings(
     val bedrockSecretKeyConfigured: Boolean = false,
     val bedrockRegion: String = "us-east-1",
     val bedrockModel: String = "claude-haiku-4.5",
+    /**
+     * Anthropic Teams (OAuth) session state (#181). The bearer token
+     * itself never crosses into the UI — Settings only needs to know
+     * whether the user has signed in and (optionally) which scopes
+     * the workspace granted. Token refresh is handled inside the
+     * provider; the UI flips to "not signed in" only when the refresh
+     * token also gets revoked (mid-session expiry rotates the bearer
+     * silently). */
+    val teamsSignedIn: Boolean = false,
+    val teamsScopes: String = "",
     val privacyAcknowledged: Boolean = false,
     val sendChapterTextEnabled: Boolean = true,
 )
@@ -696,6 +706,13 @@ interface SettingsRepositoryUi {
     suspend fun setBedrockModel(model: String)
     suspend fun setSendChapterTextEnabled(enabled: Boolean)
     suspend fun acknowledgeAiPrivacy()
+    /**
+     * Anthropic Teams (OAuth) — local sign-out. Wipes the bearer +
+     * refresh + scope cache. Remote revoke at console.anthropic.com
+     * requires a client_secret we don't have (public-client posture);
+     * Settings UI deep-links the user to manage sessions there. (#181)
+     */
+    suspend fun signOutTeams()
     /** Wipe all AI configuration — provider/keys/URLs. */
     suspend fun resetAiSettings()
 

--- a/feature/src/main/kotlin/in/jphe/storyvox/feature/settings/SettingsScreen.kt
+++ b/feature/src/main/kotlin/in/jphe/storyvox/feature/settings/SettingsScreen.kt
@@ -79,6 +79,7 @@ fun SettingsScreen(
     onOpenSignIn: () -> Unit,
     onOpenGitHubSignIn: () -> Unit,
     onOpenGitHubRevoke: () -> Unit = {},
+    onOpenTeamsSignIn: () -> Unit = {},
     onOpenPronunciationDict: () -> Unit,
     viewModel: SettingsViewModel = hiltViewModel(),
 ) {
@@ -246,6 +247,8 @@ fun SettingsScreen(
             onTestConnection = viewModel::testAiConnection,
             onClearProbeOutcome = viewModel::clearProbeOutcome,
             onResetAi = viewModel::resetAiSettings,
+            onOpenTeamsSignIn = onOpenTeamsSignIn,
+            onSignOutTeams = viewModel::signOutTeams,
         )
         }
 
@@ -1018,6 +1021,8 @@ private fun AiSection(
     onTestConnection: (UiLlmProvider) -> Unit,
     onClearProbeOutcome: () -> Unit,
     onResetAi: () -> Unit,
+    onOpenTeamsSignIn: () -> Unit,
+    onSignOutTeams: () -> Unit,
 ) {
     val spacing = LocalSpacing.current
     // Header is now emitted by the call site (SettingsScreen). Indent
@@ -1064,12 +1069,10 @@ private fun AiSection(
         ProviderChip(label = "Bedrock", selected = ai.provider == UiLlmProvider.Bedrock) {
             onSetProvider(UiLlmProvider.Bedrock)
         }
+        ProviderChip(label = "Teams", selected = ai.provider == UiLlmProvider.Teams) {
+            onSetProvider(UiLlmProvider.Teams)
+        }
     }
-    Text(
-        "Anthropic Teams (OAuth) coming soon.",
-        style = MaterialTheme.typography.bodySmall,
-        color = MaterialTheme.colorScheme.onSurfaceVariant,
-    )
 
     when (ai.provider) {
         UiLlmProvider.Claude -> ClaudeProviderRows(
@@ -1106,17 +1109,11 @@ private fun AiSection(
             onSetRegion = onSetBedrockRegion,
             onSetModel = onSetBedrockModel,
         )
-        UiLlmProvider.Teams -> {
-            // Selected via the (currently disabled) chip; defensive
-            // catch-all that surfaces a friendly message rather than
-            // letting the user fall into a half-built UI.
-            Text(
-                "${ai.provider!!.displayName} is in the design spec but not yet " +
-                    "implemented. Pick another provider for now.",
-                style = MaterialTheme.typography.bodySmall,
-                color = MaterialTheme.colorScheme.onSurfaceVariant,
-            )
-        }
+        UiLlmProvider.Teams -> AnthropicTeamsProviderRows(
+            ai = ai,
+            onOpenSignIn = onOpenTeamsSignIn,
+            onSignOut = onSignOutTeams,
+        )
         null -> { /* Off — nothing more to show */ }
     }
 
@@ -1717,4 +1714,73 @@ private fun ProbeOutcomeMessage(probe: ProbeOutcome?, onClear: () -> Unit) {
         is ProbeOutcome.Failure -> probe.message
     }
     Text(text = text, style = MaterialTheme.typography.bodySmall, color = color)
+}
+
+/**
+ * Anthropic Teams (OAuth) provider rows (#181). Replaces the
+ * "coming soon" stub with a real sign-in entry. The bearer token
+ * round-trips through OAuth — there's nothing to paste, so the
+ * row is just a button + a status line that flips between
+ * "Sign in to Teams" and "Signed in" once the flow completes.
+ */
+@OptIn(ExperimentalMaterial3Api::class, ExperimentalLayoutApi::class)
+@Composable
+private fun AnthropicTeamsProviderRows(
+    ai: UiAiSettings,
+    onOpenSignIn: () -> Unit,
+    onSignOut: () -> Unit,
+) {
+    val spacing = LocalSpacing.current
+    Column(verticalArrangement = Arrangement.spacedBy(spacing.xs)) {
+        Text(
+            "Anthropic Teams uses your Claude.ai workspace login — no API key " +
+                "to paste. Tap the button below to authorize storyvox in your " +
+                "browser; we'll capture the bearer token and refresh it as needed.",
+            style = MaterialTheme.typography.bodySmall,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+        )
+        if (ai.teamsSignedIn) {
+            Text(
+                "Signed in to Anthropic Teams",
+                style = MaterialTheme.typography.bodyMedium,
+                color = MaterialTheme.colorScheme.primary,
+            )
+            if (ai.teamsScopes.isNotBlank()) {
+                Text(
+                    "Granted scopes: ${ai.teamsScopes}",
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                )
+            }
+            Row(horizontalArrangement = Arrangement.spacedBy(spacing.xs)) {
+                BrassButton(
+                    label = "Sign out",
+                    onClick = onSignOut,
+                    variant = BrassButtonVariant.Secondary,
+                )
+                BrassButton(
+                    label = "Re-authorize",
+                    onClick = onOpenSignIn,
+                    variant = BrassButtonVariant.Text,
+                )
+            }
+        } else {
+            BrassButton(
+                label = "Sign in to Teams",
+                onClick = onOpenSignIn,
+                variant = BrassButtonVariant.Primary,
+            )
+        }
+        Text(
+            "Model: ${ai.claudeModel}",
+            style = MaterialTheme.typography.bodySmall,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+        )
+        Text(
+            "Costs are covered by your Teams subscription — Anthropic counts " +
+                "tokens against your workspace quota at console.anthropic.com.",
+            style = MaterialTheme.typography.bodySmall,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+        )
+    }
 }

--- a/feature/src/main/kotlin/in/jphe/storyvox/feature/settings/SettingsViewModel.kt
+++ b/feature/src/main/kotlin/in/jphe/storyvox/feature/settings/SettingsViewModel.kt
@@ -160,6 +160,9 @@ class SettingsViewModel @Inject constructor(
     fun setSendChapterTextEnabled(enabled: Boolean) =
         viewModelScope.launch { repo.setSendChapterTextEnabled(enabled) }
     fun acknowledgeAiPrivacy() = viewModelScope.launch { repo.acknowledgeAiPrivacy() }
+    /** Anthropic Teams (OAuth) — local sign-out. Remote revoke deep-links
+     *  to claude.ai/settings. (#181) */
+    fun signOutTeams() = viewModelScope.launch { repo.signOutTeams() }
     fun resetAiSettings() = viewModelScope.launch {
         repo.resetAiSettings()
         _probe.value = null

--- a/feature/src/test/kotlin/in/jphe/storyvox/feature/chat/ChatViewModelTest.kt
+++ b/feature/src/test/kotlin/in/jphe/storyvox/feature/chat/ChatViewModelTest.kt
@@ -307,6 +307,7 @@ private fun unreachableLlmRepository(): LlmRepository {
         vertex = unreachableVertex(),
         foundry = unreachableFoundry(),
         bedrock = unreachableBedrock(),
+        teams = unreachableTeams(),
     )
 }
 
@@ -369,6 +370,19 @@ private fun unreachableBedrock(): `in`.jphe.storyvox.llm.provider.BedrockProvide
         http = okhttp3.OkHttpClient(),
         store = NullStore,
         configFlow = flowOf(LlmConfig()),
+        json = kotlinx.serialization.json.Json,
+    ) {
+        override fun stream(messages: List<LlmMessage>, systemPrompt: String?, model: String?) =
+            error("unreachable")
+    }
+
+private fun unreachableTeams(): `in`.jphe.storyvox.llm.provider.AnthropicTeamsProvider =
+    object : `in`.jphe.storyvox.llm.provider.AnthropicTeamsProvider(
+        http = okhttp3.OkHttpClient(),
+        store = NullStore,
+        configFlow = flowOf(LlmConfig()),
+        authApi = `in`.jphe.storyvox.llm.auth.AnthropicTeamsAuthApi(okhttp3.OkHttpClient()),
+        authRepo = `in`.jphe.storyvox.llm.auth.AnthropicTeamsAuthRepository(NullStore),
         json = kotlinx.serialization.json.Json,
     ) {
         override fun stream(messages: List<LlmMessage>, systemPrompt: String?, model: String?) =

--- a/feature/src/test/kotlin/in/jphe/storyvox/feature/settings/SettingsViewModelBufferTest.kt
+++ b/feature/src/test/kotlin/in/jphe/storyvox/feature/settings/SettingsViewModelBufferTest.kt
@@ -12,6 +12,9 @@ import `in`.jphe.storyvox.feature.api.VoiceProviderUi
 import `in`.jphe.storyvox.llm.LlmConfig
 import `in`.jphe.storyvox.llm.LlmRepository
 import `in`.jphe.storyvox.llm.provider.AzureFoundryProvider
+import `in`.jphe.storyvox.llm.auth.AnthropicTeamsAuthApi
+import `in`.jphe.storyvox.llm.auth.AnthropicTeamsAuthRepository
+import `in`.jphe.storyvox.llm.provider.AnthropicTeamsProvider
 import `in`.jphe.storyvox.llm.provider.BedrockProvider
 import `in`.jphe.storyvox.llm.provider.ClaudeApiProvider
 import `in`.jphe.storyvox.llm.provider.OllamaProvider
@@ -171,6 +174,7 @@ class SettingsViewModelBufferTest {
         override suspend fun resetAiSettings() = Unit
         override suspend fun signOutGitHub() = Unit
         override suspend fun setGitHubPrivateReposEnabled(enabled: Boolean) = Unit
+        override suspend fun signOutTeams() = Unit
     }
 
     /** Construct an LlmRepository with real-but-stubbed provider
@@ -190,6 +194,12 @@ class SettingsViewModelBufferTest {
             vertex = VertexProvider(http, store, cfg, json),
             foundry = AzureFoundryProvider(http, store, cfg, json),
             bedrock = BedrockProvider(http, store, cfg, json),
+            teams = AnthropicTeamsProvider(
+                http, store, cfg,
+                AnthropicTeamsAuthApi(http),
+                AnthropicTeamsAuthRepository(store),
+                json,
+            ),
         )
     }
 

--- a/feature/src/test/kotlin/in/jphe/storyvox/feature/settings/SettingsViewModelModesTest.kt
+++ b/feature/src/test/kotlin/in/jphe/storyvox/feature/settings/SettingsViewModelModesTest.kt
@@ -12,6 +12,9 @@ import `in`.jphe.storyvox.feature.api.VoiceProviderUi
 import `in`.jphe.storyvox.llm.LlmConfig
 import `in`.jphe.storyvox.llm.LlmRepository
 import `in`.jphe.storyvox.llm.provider.AzureFoundryProvider
+import `in`.jphe.storyvox.llm.auth.AnthropicTeamsAuthApi
+import `in`.jphe.storyvox.llm.auth.AnthropicTeamsAuthRepository
+import `in`.jphe.storyvox.llm.provider.AnthropicTeamsProvider
 import `in`.jphe.storyvox.llm.provider.BedrockProvider
 import `in`.jphe.storyvox.llm.provider.ClaudeApiProvider
 import `in`.jphe.storyvox.llm.provider.OllamaProvider
@@ -246,6 +249,7 @@ class SettingsViewModelModesTest {
         override suspend fun resetAiSettings() = Unit
         override suspend fun signOutGitHub() = Unit
         override suspend fun setGitHubPrivateReposEnabled(enabled: Boolean) = Unit
+        override suspend fun signOutTeams() = Unit
     }
 
     private class FakeVoiceProvider : VoiceProviderUi {
@@ -270,6 +274,12 @@ class SettingsViewModelModesTest {
             vertex = VertexProvider(http, store, cfg, json),
             foundry = AzureFoundryProvider(http, store, cfg, json),
             bedrock = BedrockProvider(http, store, cfg, json),
+            teams = AnthropicTeamsProvider(
+                http, store, cfg,
+                AnthropicTeamsAuthApi(http),
+                AnthropicTeamsAuthRepository(store),
+                json,
+            ),
         )
     }
 }

--- a/feature/src/test/kotlin/in/jphe/storyvox/feature/settings/SettingsViewModelPunctuationPauseTest.kt
+++ b/feature/src/test/kotlin/in/jphe/storyvox/feature/settings/SettingsViewModelPunctuationPauseTest.kt
@@ -13,6 +13,9 @@ import `in`.jphe.storyvox.feature.api.VoiceProviderUi
 import `in`.jphe.storyvox.llm.LlmConfig
 import `in`.jphe.storyvox.llm.LlmRepository
 import `in`.jphe.storyvox.llm.provider.AzureFoundryProvider
+import `in`.jphe.storyvox.llm.auth.AnthropicTeamsAuthApi
+import `in`.jphe.storyvox.llm.auth.AnthropicTeamsAuthRepository
+import `in`.jphe.storyvox.llm.provider.AnthropicTeamsProvider
 import `in`.jphe.storyvox.llm.provider.BedrockProvider
 import `in`.jphe.storyvox.llm.provider.ClaudeApiProvider
 import `in`.jphe.storyvox.llm.provider.OllamaProvider
@@ -184,6 +187,7 @@ class SettingsViewModelPunctuationPauseTest {
         override suspend fun resetAiSettings() = Unit
         override suspend fun signOutGitHub() = Unit
         override suspend fun setGitHubPrivateReposEnabled(enabled: Boolean) = Unit
+        override suspend fun signOutTeams() = Unit
     }
 
     private class FakeVoiceProvider : VoiceProviderUi {
@@ -208,6 +212,12 @@ class SettingsViewModelPunctuationPauseTest {
             vertex = VertexProvider(http, store, cfg, json),
             foundry = AzureFoundryProvider(http, store, cfg, json),
             bedrock = BedrockProvider(http, store, cfg, json),
+            teams = AnthropicTeamsProvider(
+                http, store, cfg,
+                AnthropicTeamsAuthApi(http),
+                AnthropicTeamsAuthRepository(store),
+                json,
+            ),
         )
     }
 }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -35,6 +35,7 @@ okhttp = "4.12.0"
 jsoup = "1.18.1"
 commonmark = "0.24.0"
 androidx-webkit = "1.12.1"
+androidx-browser = "1.8.0"
 
 # Concurrency
 coroutines = "1.9.0"
@@ -118,6 +119,7 @@ okhttp-logging = { module = "com.squareup.okhttp3:logging-interceptor", version.
 jsoup = { module = "org.jsoup:jsoup", version.ref = "jsoup" }
 commonmark = { module = "org.commonmark:commonmark", version.ref = "commonmark" }
 androidx-webkit = { module = "androidx.webkit:webkit", version.ref = "androidx-webkit" }
+androidx-browser = { module = "androidx.browser:browser", version.ref = "androidx-browser" }
 
 # Coroutines
 kotlinx-coroutines-core = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-core", version.ref = "coroutines" }


### PR DESCRIPTION
## Summary

Seventh and final LLM provider in the matrix. Uses the user's Claude.ai workspace login (no API key to paste) so storyvox's Recap / character lookup / chat features run against their Teams subscription rather than per-token billing.

- OAuth 2.0 Authorization Code + PKCE/S256 against `claude.ai/oauth/authorize` → `console.anthropic.com/v1/oauth/token`. Public-client posture mirrors source-github (#91) — the client_id ships in the APK by design, no secret.
- Wire format identical to ClaudeApiProvider; auth differs (Bearer + `anthropic-beta: oauth-2025-04-20`).
- Browser handoff via androidx.browser CustomTabsIntent. Anthropic's callback page renders the auth code; user copy-pastes it into the modal (same out-of-band flow Claude Code CLI uses). No `storyvox://` scheme needed.
- **Token refresh** runs proactively (60s lead-time on every stream) + as a single retry on 401. `invalid_grant` wipes the entire session via the in-memory `AnthropicTeamsAuthRepository` so Settings flips back to "not signed in" without polling.
- Settings UI: replaces "Anthropic Teams (OAuth) coming soon" copy with a real "Teams" chip + a `BrassButton(label = "Sign in to Teams")`. Post-sign-in shows "Signed in" + granted scopes + Sign out / Re-authorize buttons.

## Files

| Module | New / changed |
|---|---|
| `core-llm/auth/` | `AnthropicTeamsAuthConfig`, `AnthropicTeamsAuthApi`, `AnthropicTeamsAuthRepository`, `PkcePair` (+ MockWebServer + Robolectric tests) |
| `core-llm/provider/AnthropicTeamsProvider` | Bearer-auth Messages client with refresh-on-expiry |
| `core-llm LlmCredentialsStore` | Extended with `bearer / refresh / expires_at / scopes` fields under the existing `KEY_TEAMS` namespace |
| `core-llm LlmRepository`, `ProviderId.implemented` | Teams flips on |
| `app/auth/anthropic/` | `AnthropicTeamsSignInViewModel` + `AnthropicTeamsSignInScreen` (CustomTabs + paste-the-code flow); wired into `StoryvoxNavHost` |
| `feature SettingsScreen` | New `AnthropicTeamsProviderRows` composable; Teams chip in the picker strip |
| `SettingsRepositoryUiImpl` | Combines `teamsAuth.sessionState` into `UiSettings` flow so the row updates synchronously on sign-in/out |
| `libs.versions.toml` | Adds `androidx.browser` 1.8.0 |

## Test plan

- [x] `:core-llm:testDebugUnitTest` — green (4 new auth tests + the existing suite, including the AnthropicTeams branch added to ChapterRecapTest's LlmRepository fixture)
- [x] `:app:testDebugUnitTest` — green (FakeSettingsRepo / RealPlaybackControllerUiTest fakes implement the new `signOutTeams` member)
- [x] `:feature:testDebugUnitTest` — green (3 SettingsViewModel tests' LlmRepository constructions wire the new `teams =` param)
- [x] `assembleDebug` builds clean for `:app` and `:wear`
- [x] APK installs + foregrounds on R83W80CAFZB without crash; the new "Teams" chip appears in Settings → AI; tapping "Sign in to Teams" opens the modal (full OAuth round-trip not exercised on tablet — that requires a Teams workspace).

Closes #181