### PR TITLE
feat(loading): brass spinners + BrassProgressBar across the app

### DIFF
--- a/app/src/main/kotlin/in/jphe/storyvox/auth/AuthWebViewScreen.kt
+++ b/app/src/main/kotlin/in/jphe/storyvox/auth/AuthWebViewScreen.kt
@@ -8,7 +8,6 @@ import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.ArrowBack
-import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.FilledIconButton
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButtonDefaults
@@ -28,6 +27,7 @@ import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import `in`.jphe.storyvox.feature.auth.AuthViewModel
 import `in`.jphe.storyvox.feature.auth.CaptureState
 import `in`.jphe.storyvox.source.royalroad.auth.RoyalRoadAuthWebView
+import `in`.jphe.storyvox.ui.component.MagicSpinner
 
 /**
  * Hosts the Royal Road login WebView and pipes captured cookies into
@@ -83,15 +83,15 @@ fun AuthWebViewScreen(
             }
 
             if (capture is CaptureState.Capturing) {
-                CircularProgressIndicator(
+                MagicSpinner(
                     // TalkBack #160 — without contentDescription the spinner
                     // announces nothing, leaving a screen-reader user
                     // wondering if the OAuth flow froze. Mirror the visible
                     // semantics of "we're working on it".
                     modifier = Modifier
                         .align(Alignment.Center)
+                        .size(40.dp)
                         .semantics { contentDescription = "Loading sign-in page" },
-                    color = MaterialTheme.colorScheme.primary,
                 )
             }
         }

--- a/app/src/main/kotlin/in/jphe/storyvox/auth/anthropic/AnthropicTeamsSignInScreen.kt
+++ b/app/src/main/kotlin/in/jphe/storyvox/auth/anthropic/AnthropicTeamsSignInScreen.kt
@@ -19,7 +19,6 @@ import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.ArrowBack
-import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.FilledIconButton
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButtonDefaults
@@ -42,6 +41,7 @@ import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import `in`.jphe.storyvox.ui.component.BrassButton
 import `in`.jphe.storyvox.ui.component.BrassButtonVariant
+import `in`.jphe.storyvox.ui.component.MagicSpinner
 import `in`.jphe.storyvox.ui.theme.LocalSpacing
 
 /**
@@ -196,11 +196,7 @@ private fun StateBody(
                 horizontalArrangement = Arrangement.spacedBy(spacing.sm),
                 modifier = Modifier.fillMaxWidth(),
             ) {
-                CircularProgressIndicator(
-                    modifier = Modifier.size(24.dp),
-                    strokeWidth = 2.dp,
-                    color = MaterialTheme.colorScheme.primary,
-                )
+                MagicSpinner(modifier = Modifier.size(24.dp))
                 Text("Exchanging code with Anthropic…", style = MaterialTheme.typography.bodyMedium)
             }
         }

--- a/app/src/main/kotlin/in/jphe/storyvox/auth/github/GitHubSignInScreen.kt
+++ b/app/src/main/kotlin/in/jphe/storyvox/auth/github/GitHubSignInScreen.kt
@@ -19,7 +19,6 @@ import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.ArrowBack
-import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.FilledIconButton
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButtonDefaults
@@ -40,6 +39,7 @@ import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import `in`.jphe.storyvox.ui.component.BrassButton
 import `in`.jphe.storyvox.ui.component.BrassButtonVariant
+import `in`.jphe.storyvox.ui.component.MagicSpinner
 import `in`.jphe.storyvox.ui.theme.LocalSpacing
 
 /**
@@ -149,11 +149,7 @@ private fun StateBody(
                 horizontalArrangement = Arrangement.spacedBy(spacing.sm),
                 modifier = Modifier.fillMaxWidth(),
             ) {
-                CircularProgressIndicator(
-                    modifier = Modifier.size(24.dp),
-                    strokeWidth = 2.dp,
-                    color = MaterialTheme.colorScheme.primary,
-                )
+                MagicSpinner(modifier = Modifier.size(24.dp))
                 Text("Asking GitHub for a code…", style = MaterialTheme.typography.bodyMedium)
             }
         }
@@ -200,11 +196,7 @@ private fun StateBody(
                 verticalAlignment = Alignment.CenterVertically,
                 horizontalArrangement = Arrangement.spacedBy(spacing.sm),
             ) {
-                CircularProgressIndicator(
-                    modifier = Modifier.size(18.dp),
-                    strokeWidth = 2.dp,
-                    color = MaterialTheme.colorScheme.primary,
-                )
+                MagicSpinner(modifier = Modifier.size(18.dp))
                 Text(
                     "Waiting for confirmation…",
                     style = MaterialTheme.typography.bodySmall,
@@ -218,11 +210,7 @@ private fun StateBody(
                 horizontalArrangement = Arrangement.spacedBy(spacing.sm),
                 modifier = Modifier.fillMaxWidth(),
             ) {
-                CircularProgressIndicator(
-                    modifier = Modifier.size(24.dp),
-                    strokeWidth = 2.dp,
-                    color = MaterialTheme.colorScheme.primary,
-                )
+                MagicSpinner(modifier = Modifier.size(24.dp))
                 Text("Fetching your profile…", style = MaterialTheme.typography.bodyMedium)
             }
         }

--- a/core-ui/src/main/kotlin/in/jphe/storyvox/ui/component/BrassButton.kt
+++ b/core-ui/src/main/kotlin/in/jphe/storyvox/ui/component/BrassButton.kt
@@ -1,14 +1,19 @@
 package `in`.jphe.storyvox.ui.component
 
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.size
 import androidx.compose.material3.Button
 import androidx.compose.material3.ButtonDefaults
+import androidx.compose.material3.LocalContentColor
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.OutlinedButton
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.alpha
 import androidx.compose.ui.semantics.Role
 import androidx.compose.ui.semantics.role
 import androidx.compose.ui.semantics.semantics
@@ -16,6 +21,16 @@ import androidx.compose.ui.unit.dp
 
 enum class BrassButtonVariant { Primary, Secondary, Text }
 
+/**
+ * The realm's brass button.
+ *
+ * @param loading when true, the button reads disabled and renders a small
+ *   [MagicSpinner] over the label position. The label itself is rendered
+ *   at 0 alpha so the button keeps its measured width — start/stop of an
+ *   async action doesn't reflow the surrounding row. This replaces the
+ *   older "swap to inline CircularProgressIndicator + Text" pattern that
+ *   caused a width jump and broke the brass palette.
+ */
 @Composable
 fun BrassButton(
     label: String,
@@ -23,6 +38,7 @@ fun BrassButton(
     modifier: Modifier = Modifier,
     variant: BrassButtonVariant = BrassButtonVariant.Primary,
     enabled: Boolean = true,
+    loading: Boolean = false,
 ) {
     val padding = PaddingValues(horizontal = 24.dp, vertical = 12.dp)
     val sem = Modifier.semantics { role = Role.Button }
@@ -30,44 +46,82 @@ fun BrassButton(
     // M3's default `onSurface * 0.12 / 0.38`, which renders as cool grey and
     // breaks the brass aesthetic during reachable disabled flows (e.g.,
     // VoicePickerGate during voice download).
+    //
+    // When `loading` is set, we keep the brass at full opacity so the
+    // button reads as "working", not "broken / unavailable".
     val brass = MaterialTheme.colorScheme.primary
     val onBrass = MaterialTheme.colorScheme.onPrimary
+    val effectiveEnabled = enabled && !loading
+    val disabledBrassAlpha = if (loading) 1.0f else 0.12f
+    val disabledOnBrassAlpha = if (loading) 1.0f else 0.38f
+    val disabledOutlineAlpha = if (loading) 1.0f else 0.38f
     when (variant) {
         BrassButtonVariant.Primary -> Button(
             onClick = onClick,
-            enabled = enabled,
+            enabled = effectiveEnabled,
             modifier = modifier.then(sem),
             colors = ButtonDefaults.buttonColors(
                 containerColor = brass,
                 contentColor = onBrass,
-                disabledContainerColor = brass.copy(alpha = 0.12f),
-                disabledContentColor = onBrass.copy(alpha = 0.38f),
+                disabledContainerColor = brass.copy(alpha = disabledBrassAlpha),
+                disabledContentColor = onBrass.copy(alpha = disabledOnBrassAlpha),
             ),
             shape = MaterialTheme.shapes.medium,
             contentPadding = padding,
-        ) { Text(label, style = MaterialTheme.typography.labelLarge) }
+        ) { ButtonContent(label, loading) }
 
         BrassButtonVariant.Secondary -> OutlinedButton(
             onClick = onClick,
-            enabled = enabled,
+            enabled = effectiveEnabled,
             modifier = modifier.then(sem),
             colors = ButtonDefaults.outlinedButtonColors(
                 contentColor = brass,
-                disabledContentColor = brass.copy(alpha = 0.38f),
+                disabledContentColor = brass.copy(alpha = disabledOutlineAlpha),
             ),
             shape = MaterialTheme.shapes.medium,
             contentPadding = padding,
-        ) { Text(label, style = MaterialTheme.typography.labelLarge) }
+        ) { ButtonContent(label, loading) }
 
         BrassButtonVariant.Text -> TextButton(
             onClick = onClick,
-            enabled = enabled,
+            enabled = effectiveEnabled,
             modifier = modifier.then(sem),
             colors = ButtonDefaults.textButtonColors(
                 contentColor = brass,
-                disabledContentColor = brass.copy(alpha = 0.38f),
+                disabledContentColor = brass.copy(alpha = disabledOutlineAlpha),
             ),
             contentPadding = PaddingValues(horizontal = 12.dp, vertical = 8.dp),
-        ) { Text(label, style = MaterialTheme.typography.labelLarge) }
+        ) { ButtonContent(label, loading) }
+    }
+}
+
+/**
+ * Renders the label and, when [loading], hides it (alpha 0) while
+ * overlaying a [MagicSpinner]. Using a Box keeps the button width stable
+ * — the label's measured size always wins.
+ *
+ * The spinner inherits its color from `LocalContentColor`, which Material
+ * sets from each variant's `contentColor`. So Primary gets onPrimary
+ * brass, Secondary/Text get brass — all correct for the realm.
+ */
+@Composable
+private fun ButtonContent(label: String, loading: Boolean) {
+    Box(contentAlignment = Alignment.Center) {
+        Text(
+            label,
+            style = MaterialTheme.typography.labelLarge,
+            modifier = if (loading) Modifier.alpha(0f) else Modifier,
+        )
+        if (loading) {
+            // Use the variant's content color so the spinner stays visible
+            // on Primary (onBrass on brass) and on Secondary/Text (brass on
+            // surface). Hardcoding `primary` would make Primary spinners
+            // brass-on-brass and invisible.
+            MagicSpinner(
+                modifier = Modifier.size(18.dp),
+                strokeWidth = 2.dp,
+                color = LocalContentColor.current,
+            )
+        }
     }
 }

--- a/core-ui/src/main/kotlin/in/jphe/storyvox/ui/component/BrassProgressBar.kt
+++ b/core-ui/src/main/kotlin/in/jphe/storyvox/ui/component/BrassProgressBar.kt
@@ -1,0 +1,156 @@
+package `in`.jphe.storyvox.ui.component
+
+import androidx.compose.animation.core.LinearEasing
+import androidx.compose.animation.core.RepeatMode
+import androidx.compose.animation.core.animateFloat
+import androidx.compose.animation.core.animateFloatAsState
+import androidx.compose.animation.core.infiniteRepeatable
+import androidx.compose.animation.core.rememberInfiniteTransition
+import androidx.compose.animation.core.tween
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.draw.drawBehind
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.geometry.Size
+import androidx.compose.ui.graphics.Brush
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.dp
+import `in`.jphe.storyvox.ui.theme.LocalReducedMotion
+
+/**
+ * Library Nocturne progress bar. Brass fill on a thin rail.
+ *
+ * - Determinate: pass `progress` in `0f..1f`. Fill animates smoothly to the
+ *   target. Standalone progress bar — caller is responsible for showing
+ *   bytes/percent labels above or beside it. Use this for downloads, sync
+ *   progress, chapter-fraction in library cards.
+ * - Indeterminate: pass `progress = null`. A brass shimmer sweeps across
+ *   the rail at a slow, deliberate cadence (1800ms loop) — feels alive,
+ *   not anxious. The Library Nocturne motion vocabulary is "warm and
+ *   slow"; M3's `LinearProgressIndicator` indeterminate at ~750ms reads
+ *   as urgent in this context.
+ * - Reduced motion: indeterminate collapses to a static brass-tinted rail
+ *   at 30% fill. Determinate skips the entry animation and snaps to the
+ *   current value. The user still sees "something is happening" via the
+ *   surrounding text label, just without movement.
+ *
+ * Distinct from [BrassProgressTrack], which is the **interactive** seek
+ * control on the audiobook player. This component is passive — observers
+ * can't drag it.
+ *
+ * @param progress 0..1 fraction. `null` for indeterminate.
+ * @param modifier sizing modifier; height defaults to 4.dp via the rail
+ *   parameter.
+ * @param railHeight thickness of the rail; 4.dp is the default and matches
+ *   M3's `LinearProgressIndicator` so existing layouts don't reflow.
+ * @param trackColor the rail substrate. Defaults to `outlineVariant` so
+ *   the bar reads against any card.
+ * @param fillColor the brass fill. Defaults to `primary`.
+ */
+@Composable
+fun BrassProgressBar(
+    progress: Float?,
+    modifier: Modifier = Modifier,
+    railHeight: Dp = 4.dp,
+    trackColor: Color = MaterialTheme.colorScheme.outlineVariant,
+    fillColor: Color = MaterialTheme.colorScheme.primary,
+) {
+    val reducedMotion = LocalReducedMotion.current
+    val shape = MaterialTheme.shapes.small
+
+    if (progress != null) {
+        val clamped = progress.coerceIn(0f, 1f)
+        // Smooth-animate the fill on changes — feels like the bar is
+        // chasing the current value, not snapping. 360ms matches the
+        // standard `swipeDurationMs` so progress updates feel of-a-piece
+        // with reader<->audiobook swipes happening on the same screen.
+        val animated by animateFloatAsState(
+            targetValue = clamped,
+            animationSpec = tween(
+                durationMillis = if (reducedMotion) 0 else 360,
+                easing = LinearEasing,
+            ),
+            label = "brass-progress-fill",
+        )
+        Box(
+            modifier = modifier
+                .fillMaxWidth()
+                .height(railHeight)
+                .clip(shape)
+                .drawBehind {
+                    drawRect(trackColor, size = size)
+                    drawRect(
+                        fillColor,
+                        size = Size(size.width * animated, size.height),
+                    )
+                },
+        )
+    } else if (reducedMotion) {
+        // Static brass-tinted rail. The user reads "in flight" from the
+        // surrounding label, not from motion.
+        Box(
+            modifier = modifier
+                .fillMaxWidth()
+                .height(railHeight)
+                .clip(shape)
+                .drawBehind {
+                    drawRect(trackColor, size = size)
+                    drawRect(
+                        fillColor.copy(alpha = 0.4f),
+                        size = Size(size.width * 0.30f, size.height),
+                    )
+                },
+        )
+    } else {
+        // Indeterminate: a brass comet slides along the rail with a soft
+        // gradient halo. The comet width is 35% of the rail and its
+        // center travels from -0.175 to 1.175 (so the leading edge slides
+        // off-screen rather than truncating awkwardly at the edges).
+        val transition = rememberInfiniteTransition(label = "brass-progress-sweep")
+        val phase by transition.animateFloat(
+            initialValue = -0.175f,
+            targetValue = 1.175f,
+            animationSpec = infiniteRepeatable(
+                animation = tween(durationMillis = 1800, easing = LinearEasing),
+                repeatMode = RepeatMode.Restart,
+            ),
+            label = "phase",
+        )
+        Box(
+            modifier = modifier
+                .fillMaxWidth()
+                .height(railHeight)
+                .clip(shape)
+                .drawBehind {
+                    drawRect(trackColor, size = size)
+                    val cometWidthFraction = 0.35f
+                    val cometWidth = size.width * cometWidthFraction
+                    val cometCenter = size.width * phase
+                    val cometStart = cometCenter - cometWidth / 2f
+                    val brush = Brush.linearGradient(
+                        colors = listOf(
+                            fillColor.copy(alpha = 0.0f),
+                            fillColor.copy(alpha = 0.85f),
+                            fillColor,
+                            fillColor.copy(alpha = 0.85f),
+                            fillColor.copy(alpha = 0.0f),
+                        ),
+                        start = Offset(cometStart, 0f),
+                        end = Offset(cometStart + cometWidth, 0f),
+                    )
+                    drawRect(
+                        brush = brush,
+                        topLeft = Offset(cometStart, 0f),
+                        size = Size(cometWidth, size.height),
+                    )
+                },
+        )
+    }
+}

--- a/core-ui/src/main/kotlin/in/jphe/storyvox/ui/component/MagicSpinner.kt
+++ b/core-ui/src/main/kotlin/in/jphe/storyvox/ui/component/MagicSpinner.kt
@@ -20,6 +20,7 @@ import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.rotate
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.PathEffect
 import androidx.compose.ui.graphics.StrokeCap
 import androidx.compose.ui.graphics.drawscope.Stroke
@@ -40,6 +41,10 @@ import `in`.jphe.storyvox.ui.theme.LocalSpacing
  * @param strokeWidth thickness of the ring; defaults to 2.dp.
  * @param dashLengthFraction fraction of the circumference used by the
  *   dash pattern. Smaller = more "magical sweep" feel.
+ * @param color stroke color. Defaults to brass primary, but inside a
+ *   Primary [BrassButton] (brass background) the caller passes
+ *   `LocalContentColor` (= onPrimary) so the spinner stays visible
+ *   against the brass fill.
  */
 @Composable
 fun MagicSpinner(
@@ -47,8 +52,9 @@ fun MagicSpinner(
     strokeWidth: Dp = 2.dp,
     dashLengthFraction: Float = 0.18f,
     durationMs: Int = 1600,
+    color: Color = MaterialTheme.colorScheme.primary,
 ) {
-    val brass = MaterialTheme.colorScheme.primary
+    val brass = color
     val transition = rememberInfiniteTransition(label = "magic-spinner")
     val angle by transition.animateFloat(
         initialValue = 0f,

--- a/feature/src/main/kotlin/in/jphe/storyvox/feature/browse/BrowseScreen.kt
+++ b/feature/src/main/kotlin/in/jphe/storyvox/feature/browse/BrowseScreen.kt
@@ -26,7 +26,6 @@ import androidx.compose.material3.AssistChip
 import androidx.compose.material3.AssistChipDefaults
 import androidx.compose.material3.Badge
 import androidx.compose.material3.BadgedBox
-import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
@@ -61,6 +60,7 @@ import `in`.jphe.storyvox.ui.component.ErrorBlock
 import `in`.jphe.storyvox.ui.component.ErrorPlacement
 import `in`.jphe.storyvox.ui.component.FictionCardSkeleton
 import `in`.jphe.storyvox.ui.component.FictionCoverThumb
+import `in`.jphe.storyvox.ui.component.MagicSpinner
 import `in`.jphe.storyvox.ui.theme.LocalSpacing
 
 @Composable
@@ -270,7 +270,10 @@ fun BrowseScreen(
                                 modifier = Modifier.fillMaxWidth().padding(spacing.lg),
                                 contentAlignment = Alignment.Center,
                             ) {
-                                CircularProgressIndicator(modifier = Modifier.size(32.dp))
+                                // Brass MagicSpinner while the next page is being
+                                // fetched — matches the rest of the realm's loading
+                                // vocabulary instead of the cool-grey M3 default.
+                                MagicSpinner(modifier = Modifier.size(32.dp))
                             }
                         }
                     } else if (!state.hasMore && state.items.isNotEmpty()) {

--- a/feature/src/main/kotlin/in/jphe/storyvox/feature/engine/VoicePickerGate.kt
+++ b/feature/src/main/kotlin/in/jphe/storyvox/feature/engine/VoicePickerGate.kt
@@ -16,7 +16,6 @@ import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.verticalScroll
-import androidx.compose.material3.LinearProgressIndicator
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
@@ -47,6 +46,7 @@ import `in`.jphe.storyvox.playback.voice.VoiceManager.DownloadProgress
 import `in`.jphe.storyvox.playback.voice.flagForLanguage
 import `in`.jphe.storyvox.ui.component.BrassButton
 import `in`.jphe.storyvox.ui.component.BrassButtonVariant
+import `in`.jphe.storyvox.ui.component.BrassProgressBar
 import `in`.jphe.storyvox.ui.component.MagicSkeletonTile
 import `in`.jphe.storyvox.ui.theme.LocalSpacing
 
@@ -340,7 +340,9 @@ private fun DownloadProgressBlock(
         DownloadProgress.Resolving -> {
             Text("Resolving…", style = MaterialTheme.typography.bodySmall)
             Spacer(Modifier.height(spacing.xs))
-            LinearProgressIndicator(modifier = Modifier.fillMaxWidth())
+            // Indeterminate brass comet — the manifest fetch is brief but
+            // network-flaky enough that callers sit on this state for 1-3s.
+            BrassProgressBar(progress = null, modifier = Modifier.fillMaxWidth())
         }
         is DownloadProgress.Downloading -> {
             val pct = if (progress.totalBytes > 0L) {
@@ -353,14 +355,13 @@ private fun DownloadProgressBlock(
                 style = MaterialTheme.typography.bodySmall,
             )
             Spacer(Modifier.height(spacing.xs))
-            if (progress.totalBytes > 0L) {
-                LinearProgressIndicator(
-                    progress = { pct },
-                    modifier = Modifier.fillMaxWidth(),
-                )
-            } else {
-                LinearProgressIndicator(modifier = Modifier.fillMaxWidth())
-            }
+            // Determinate when we know totalBytes (sherpa-onnx serves
+            // Content-Length on the canonical CDN). Indeterminate fallback
+            // for rarer CDNs that omit it.
+            BrassProgressBar(
+                progress = if (progress.totalBytes > 0L) pct else null,
+                modifier = Modifier.fillMaxWidth(),
+            )
         }
         DownloadProgress.Done -> {
             Text(

--- a/feature/src/main/kotlin/in/jphe/storyvox/feature/library/LibraryScreen.kt
+++ b/feature/src/main/kotlin/in/jphe/storyvox/feature/library/LibraryScreen.kt
@@ -20,7 +20,6 @@ import androidx.compose.material3.Card
 import androidx.compose.material3.CardDefaults
 import androidx.compose.material3.FloatingActionButton
 import androidx.compose.material3.Icon
-import androidx.compose.material3.LinearProgressIndicator
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
@@ -34,6 +33,7 @@ import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import `in`.jphe.storyvox.data.repository.ContinueListeningEntry
 import `in`.jphe.storyvox.ui.component.BrassButton
 import `in`.jphe.storyvox.ui.component.BrassButtonVariant
+import `in`.jphe.storyvox.ui.component.BrassProgressBar
 import `in`.jphe.storyvox.ui.component.FictionCoverThumb
 import `in`.jphe.storyvox.ui.component.MagicSkeletonTile
 import `in`.jphe.storyvox.ui.component.cascadeReveal
@@ -164,13 +164,15 @@ private fun ResumeCard(entry: ContinueListeningEntry, onResume: () -> Unit) {
                     maxLines = 1,
                 )
                 if (fraction != null) {
-                    LinearProgressIndicator(
-                        progress = { fraction },
+                    // BrassProgressBar smooth-animates the fill on resume —
+                    // when the user opens Library mid-chapter the bar
+                    // visibly settles to current progress instead of
+                    // snapping. Same brass palette as the rest of the row.
+                    BrassProgressBar(
+                        progress = fraction,
                         modifier = Modifier
                             .fillMaxWidth()
                             .padding(top = spacing.xxs),
-                        color = MaterialTheme.colorScheme.primary,
-                        trackColor = MaterialTheme.colorScheme.outlineVariant,
                     )
                     Text(
                         "${(fraction * 100).toInt()}% through chapter ${entry.chapter.index}",

--- a/feature/src/main/kotlin/in/jphe/storyvox/feature/settings/SettingsScreen.kt
+++ b/feature/src/main/kotlin/in/jphe/storyvox/feature/settings/SettingsScreen.kt
@@ -10,7 +10,6 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
-import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.FilterChip
 import androidx.compose.material3.FilterChipDefaults
 import androidx.compose.ui.platform.LocalUriHandler
@@ -810,23 +809,17 @@ private fun MemoryPalaceSection(
     )
 
     Row(verticalAlignment = Alignment.CenterVertically, horizontalArrangement = Arrangement.spacedBy(spacing.sm)) {
-        if (probing) {
-            // Inline spinner; the BrassButton doesn't have a loading state
-            // and adding one for one site felt heavy. 16dp matches the
-            // text height on either side.
-            CircularProgressIndicator(
-                modifier = Modifier.size(16.dp),
-                strokeWidth = 2.dp,
-                color = MaterialTheme.colorScheme.primary,
-            )
-            Text("Testing…", style = MaterialTheme.typography.bodySmall)
-        } else {
-            BrassButton(
-                label = "Test connection",
-                onClick = onTest,
-                variant = BrassButtonVariant.Primary,
-            )
-        }
+        // BrassButton.loading keeps the button at its measured width and
+        // overlays a brass spinner — the row no longer reflows when the
+        // probe starts. Replaces the older swap-to-CircularProgressIndicator
+        // pattern (off-palette grey + width jump from "Test connection" to
+        // "Testing…").
+        BrassButton(
+            label = "Test connection",
+            onClick = onTest,
+            variant = BrassButtonVariant.Primary,
+            loading = probing,
+        )
         if (palace.isConfigured) {
             BrassButton(
                 label = "Clear",
@@ -836,6 +829,7 @@ private fun MemoryPalaceSection(
                     onClear()
                 },
                 variant = BrassButtonVariant.Secondary,
+                enabled = !probing,
             )
         }
     }
@@ -985,20 +979,12 @@ private fun AzureSection(
             verticalAlignment = Alignment.CenterVertically,
             horizontalArrangement = Arrangement.spacedBy(spacing.sm),
         ) {
-            if (probing) {
-                CircularProgressIndicator(
-                    modifier = Modifier.size(16.dp),
-                    strokeWidth = 2.dp,
-                    color = MaterialTheme.colorScheme.primary,
-                )
-                Text("Testing…", style = MaterialTheme.typography.bodySmall)
-            } else {
-                BrassButton(
-                    label = "Test connection",
-                    onClick = onTest,
-                    variant = BrassButtonVariant.Primary,
-                )
-            }
+            BrassButton(
+                label = "Test connection",
+                onClick = onTest,
+                variant = BrassButtonVariant.Primary,
+                loading = probing,
+            )
             if (azure.isConfigured) {
                 BrassButton(
                     label = "Forget key",
@@ -1007,6 +993,7 @@ private fun AzureSection(
                         onClear()
                     },
                     variant = BrassButtonVariant.Secondary,
+                    enabled = !probing,
                 )
             }
         }

--- a/feature/src/main/kotlin/in/jphe/storyvox/feature/voicelibrary/VoiceLibraryScreen.kt
+++ b/feature/src/main/kotlin/in/jphe/storyvox/feature/voicelibrary/VoiceLibraryScreen.kt
@@ -26,7 +26,6 @@ import androidx.compose.material.icons.outlined.ExpandMore
 import androidx.compose.material.icons.outlined.StarBorder
 import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.Icon
-import androidx.compose.material3.LinearProgressIndicator
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.SnackbarHost
@@ -53,6 +52,7 @@ import `in`.jphe.storyvox.playback.voice.VoiceLibrarySection
 import `in`.jphe.storyvox.playback.voice.flagForLanguage
 import `in`.jphe.storyvox.ui.component.BrassButton
 import `in`.jphe.storyvox.ui.component.BrassButtonVariant
+import `in`.jphe.storyvox.ui.component.BrassProgressBar
 import `in`.jphe.storyvox.ui.component.MagicSkeletonTile
 import `in`.jphe.storyvox.ui.component.cascadeReveal
 import `in`.jphe.storyvox.ui.theme.LocalSpacing
@@ -503,14 +503,14 @@ private fun VoiceRow(
             }
             if (downloadingProgress != null) {
                 Spacer(modifier = Modifier.size(spacing.xxs))
-                if (downloadingProgress < 0f) {
-                    LinearProgressIndicator(modifier = Modifier.fillMaxWidth())
-                } else {
-                    LinearProgressIndicator(
-                        progress = { downloadingProgress },
-                        modifier = Modifier.fillMaxWidth(),
-                    )
-                }
+                // Negative progress = the upstream signal has no
+                // Content-Length yet (sherpa-onnx HEAD probe in flight),
+                // so we render the indeterminate brass comet. Otherwise
+                // the determinate fill smooth-animates as bytes roll in.
+                BrassProgressBar(
+                    progress = if (downloadingProgress < 0f) null else downloadingProgress,
+                    modifier = Modifier.fillMaxWidth(),
+                )
             }
         }
     }


### PR DESCRIPTION
## Summary

Vesper's pass on every "something is happening" UI moment in storyvox — replace M3 default cool-grey spinners with brass MagicSpinner / BrassProgressBar so the Library Nocturne aesthetic doesn't break when a network fetch / model download / settings probe is in flight.

## Commits (6)

```
ce65c5e feat(library): BrassProgressBar on Resume row chapter progress
a3d8b03 feat(voices): BrassProgressBar on voice-download surfaces
24e0b3f feat(browse): brass MagicSpinner on infinite-scroll append
2a0da7f feat(settings): adopt BrassButton(loading=true) for Test-connection probes
45f875c feat(auth): brass MagicSpinner replaces M3 spinners on sign-in flows
6219b51 feat(core-ui): add BrassProgressBar + BrassButton loading state
```

## What changed

- **New `core-ui` primitives**: `BrassProgressBar` (determinate/indeterminate brass progress bar; brass-comet sweep on indeterminate; reduced-motion → static rail), `BrassButton.loading` parameter (overlays MagicSpinner, keeps width stable on label change), `MagicSpinner.color` parameter.
- **Auth screens** (Royal Road / GitHub / Anthropic Teams) — replaced M3 `CircularProgressIndicator` with brass `MagicSpinner`.
- **Settings probes** — Memory Palace + Azure "Test connection" buttons use `BrassButton(loading=true)` so the button width stays stable when label changes to "Testing…".
- **Browse infinite-scroll append** — brass `MagicSpinner` instead of M3 default.
- **VoicePickerGate + VoiceLibrary download bars** — `BrassProgressBar` instead of M3 LinearProgressIndicator (smooth-animating brass fill instead of M3's snap-to-value + anxious-pulse).
- **Library Resume row** — `BrassProgressBar` for chapter progress percentage.

## What didn't change

- ViewModel surfaces untouched.
- Theme tokens unchanged (uses existing `primary`, `onSurfaceVariant`, `error`, `surfaceContainerHigh`).
- No emoji added.
- `core-ui/.../theme/` files untouched.
- Already-good surfaces (AudiobookView, Reader, FictionDetail, Chat StreamingBubble, RecapModal) left alone.

## Tested

- [x] `:core-ui:test :feature:test :app:test :core-playback:test` all green
- [x] Rebased cleanly on top of v0.4.87 (Iona's settings overhaul + Azure live-fetch + lookahead all merged earlier)
- [ ] Manual: dark-mode + light-mode sweep on tablet (Tab A7 Lite, narrow) — verify brass tone matches in both
- [ ] Manual: Z Flip3 (foldable) — verify spinner animations smooth, BrassProgressBar fills don't stutter

## Follow-ups (out of scope)

- Bake `LocalReducedMotion` check into `MagicSpinner` itself (Vesper's note in `vesper-report.md`)
- Introduce named-size convention (Inline/Small/Large/Hero) for spinners
- `BufferSlider` warning copy still uses a `⚠️` emoji — separate cleanup (preserved as-is)

🤖 Generated with [Claude Code](https://claude.com/claude-code)