### PR TITLE
feat(debug): Library Nocturne debug overlay + Debug screen

### DIFF
--- a/app/src/main/kotlin/in/jphe/storyvox/data/SettingsRepositoryUiImpl.kt
+++ b/app/src/main/kotlin/in/jphe/storyvox/data/SettingsRepositoryUiImpl.kt
@@ -206,6 +206,12 @@ private object Keys {
     // ── Sleep timer shake-to-extend (issue #150) ───────────────────
     val SLEEP_SHAKE_TO_EXTEND_ENABLED = booleanPreferencesKey("pref_sleep_shake_to_extend_enabled")
 
+    // ── Debug overlay (Vesper, v0.4.97) ────────────────────────────
+    /** Master switch for the on-Reader debug overlay. Default false;
+     *  power users opt in from Settings → Developer. The dedicated
+     *  /debug screen is reachable regardless of this toggle. */
+    val SHOW_DEBUG_OVERLAY = booleanPreferencesKey("pref_show_debug_overlay")
+
     // ── Azure offline-fallback (issue #185, PR-6) ──────────────────
     val AZURE_FALLBACK_ENABLED = booleanPreferencesKey("pref_azure_fallback_enabled")
     val AZURE_FALLBACK_VOICE_ID = stringPreferencesKey("pref_azure_fallback_voice_id")
@@ -372,6 +378,7 @@ class SettingsRepositoryUiImpl(
             sourceEpubEnabled = prefs[Keys.SOURCE_EPUB_ENABLED] ?: false,
             sourceOutlineEnabled = prefs[Keys.SOURCE_OUTLINE_ENABLED] ?: false,
             sleepShakeToExtendEnabled = prefs[Keys.SLEEP_SHAKE_TO_EXTEND_ENABLED] ?: true,
+            showDebugOverlay = prefs[Keys.SHOW_DEBUG_OVERLAY] ?: false,
             azure = run {
                 // #182 — read the encrypted snapshot imperatively each
                 // emission. The azureTick flow above guarantees a fresh
@@ -907,6 +914,10 @@ class SettingsRepositoryUiImpl(
 
     override suspend fun setSleepShakeToExtendEnabled(enabled: Boolean) {
         store.edit { it[Keys.SLEEP_SHAKE_TO_EXTEND_ENABLED] = enabled }
+    }
+
+    override suspend fun setShowDebugOverlay(enabled: Boolean) {
+        store.edit { it[Keys.SHOW_DEBUG_OVERLAY] = enabled }
     }
 
     // ── Azure Speech Services BYOK (#182, PR-3) ────────────────────

--- a/app/src/main/kotlin/in/jphe/storyvox/di/AppBindings.kt
+++ b/app/src/main/kotlin/in/jphe/storyvox/di/AppBindings.kt
@@ -109,6 +109,24 @@ object AppBindings {
         settings: SettingsRepositoryUi,
     ): PlaybackControllerUi = RealPlaybackControllerUi(context, controller, chapters, settings)
 
+    /**
+     * Vesper (v0.4.97) — debug snapshot binding. Sits alongside
+     * [providePlaybackControllerUi] because the debug surface shares the
+     * same controller singleton + adds Azure for the cloud-voice
+     * diagnostics row. Construction is cheap (no flow allocation until
+     * subscribed); WhileSubscribed in [RealDebugRepositoryUi] keeps the
+     * combine cold when nothing's looking.
+     */
+    @Provides @Singleton
+    fun provideDebugRepositoryUi(
+        @ApplicationContext context: Context,
+        controller: PlaybackController,
+        settings: SettingsRepositoryUi,
+        azureCreds: `in`.jphe.storyvox.source.azure.AzureCredentials,
+        azureEngine: `in`.jphe.storyvox.source.azure.AzureVoiceEngine,
+    ): `in`.jphe.storyvox.feature.api.DebugRepositoryUi =
+        RealDebugRepositoryUi(context, controller, settings, azureCreds, azureEngine)
+
     @Provides @Singleton
     fun provideVoiceProviderUi(impl: VoiceProviderUiImpl): VoiceProviderUi = impl
 

--- a/app/src/main/kotlin/in/jphe/storyvox/di/RealDebugRepositoryUi.kt
+++ b/app/src/main/kotlin/in/jphe/storyvox/di/RealDebugRepositoryUi.kt
@@ -1,0 +1,346 @@
+package `in`.jphe.storyvox.di
+
+import android.content.Context
+import android.net.ConnectivityManager
+import android.net.NetworkCapabilities
+import android.os.SystemClock
+import `in`.jphe.storyvox.feature.api.DebugAudio
+import `in`.jphe.storyvox.feature.api.DebugAzure
+import `in`.jphe.storyvox.feature.api.DebugBuildInfo
+import `in`.jphe.storyvox.feature.api.DebugEngine
+import `in`.jphe.storyvox.feature.api.DebugEvent
+import `in`.jphe.storyvox.feature.api.DebugEventKind
+import `in`.jphe.storyvox.feature.api.DebugNetwork
+import `in`.jphe.storyvox.feature.api.DebugPlayback
+import `in`.jphe.storyvox.feature.api.DebugRepositoryUi
+import `in`.jphe.storyvox.feature.api.DebugSnapshot
+import `in`.jphe.storyvox.feature.api.DebugStorage
+import `in`.jphe.storyvox.feature.api.SettingsRepositoryUi
+import `in`.jphe.storyvox.playback.PlaybackController
+import `in`.jphe.storyvox.playback.PlaybackError
+import `in`.jphe.storyvox.playback.PlaybackState
+import `in`.jphe.storyvox.playback.PlaybackUiEvent
+import `in`.jphe.storyvox.source.azure.AzureCredentials
+import `in`.jphe.storyvox.source.azure.AzureError
+import `in`.jphe.storyvox.source.azure.AzureVoiceEngine
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.SharingStarted
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.combine
+import kotlinx.coroutines.flow.distinctUntilChanged
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.flow.flow
+import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.flow.sample
+import kotlinx.coroutines.flow.shareIn
+import kotlinx.coroutines.launch
+
+/**
+ * Production [DebugRepositoryUi]. Joins live state from
+ * [PlaybackController], the Azure singleton, and a small in-process
+ * event ring driven by [PlaybackController.events].
+ *
+ * Throttled at 1 Hz on the seam ([kotlinx.coroutines.flow.sample]) so
+ * the overlay redraws at a deliberate cadence rather than at
+ * sentence-boundary frequency (which could fire 5+ times per second on
+ * short sentences and trash both battery and frame budget). This is
+ * Vesper's design call from the mission brief: "Numeric values update
+ * at 1Hz (not 60Hz — that's wasteful)".
+ *
+ * `sample` is kotlinx-coroutines preview API today. Its semantics
+ * ("emit the most recent value once per interval, drop intermediates")
+ * are stable across versions even if the API moves out of
+ * `@FlowPreview`; the OptIn is a defensive marker, not a "this might
+ * change behavior" signal.
+ *
+ * Never persists — the overlay is read-only. The single mutating
+ * surface (the master switch) lives in
+ * [SettingsRepositoryUi.setShowDebugOverlay]; this class just *reads*.
+ */
+@OptIn(kotlinx.coroutines.FlowPreview::class)
+internal class RealDebugRepositoryUi(
+    private val context: Context,
+    private val controller: PlaybackController,
+    private val settings: SettingsRepositoryUi,
+    private val azureCreds: AzureCredentials,
+    private val azureEngine: AzureVoiceEngine,
+) : DebugRepositoryUi {
+
+    private val scope = CoroutineScope(SupervisorJob() + Dispatchers.Default)
+
+    /**
+     * Rolling 20-event ring. Newest first per the [DebugSnapshot] contract.
+     * Wrapped as a StateFlow so the snapshot combiner picks up additions
+     * without polling. The ring's read path is a copy, so subscribers
+     * never see a torn list mid-update.
+     */
+    private val events = MutableStateFlow<List<DebugEvent>>(emptyList())
+
+    /**
+     * Last successful chapter fetch elapsedRealtime ms. Recorded on every
+     * `chapterId` change in the controller state stream — close-enough
+     * proxy for "the playback layer is making progress." Sticky `null`
+     * until a chapter loads (fresh session, no chapter yet).
+     */
+    @Volatile private var lastChapterFetchElapsedMs: Long? = null
+
+    /** Last engine display name, for engine-swap event emission. */
+    @Volatile private var lastEngineName: String? = null
+    /** Last chapter id, for chapter-loaded event emission. */
+    @Volatile private var lastChapterId: String? = null
+    /** Last error tag, for error-change event emission. */
+    @Volatile private var lastErrorTag: String? = null
+
+    init {
+        // Drive the event ring from the playback controller's state +
+        // event stream. The state stream gives us the implicit events
+        // (chapter change, error appearing); the explicit event flow gives
+        // us BookFinished / ChapterChanged / EngineMissing / AzureFellBack.
+        scope.launch {
+            controller.state.collect { s ->
+                onStateChange(s)
+            }
+        }
+        scope.launch {
+            controller.events.collect { ev ->
+                onControllerEvent(ev)
+            }
+        }
+        scope.launch {
+            azureEngine.lastError
+                .map { mapAzureErrorTag(it) }
+                .distinctUntilChanged()
+                .collect { tag ->
+                    if (tag != null) {
+                        pushEvent(DebugEventKind.Error, "Azure: $tag")
+                    }
+                }
+        }
+    }
+
+    private fun onStateChange(s: PlaybackState) {
+        // Chapter change → emit a "chapter loaded" event + stamp the
+        // fetch wall time. Skip the no-op same-chapter re-emissions.
+        if (s.currentChapterId != null && s.currentChapterId != lastChapterId) {
+            lastChapterId = s.currentChapterId
+            lastChapterFetchElapsedMs = SystemClock.elapsedRealtime()
+            val title = s.chapterTitle?.takeIf { it.isNotBlank() } ?: "untitled"
+            pushEvent(DebugEventKind.Chapter, "Loaded: $title")
+        }
+        // Error appears/changes → emit error event.
+        val tag = s.error?.let { mapPlaybackErrorTag(it) }
+        if (tag != lastErrorTag) {
+            lastErrorTag = tag
+            if (tag != null) pushEvent(DebugEventKind.Error, "Playback: $tag")
+        }
+        // Voice id swap → engine event.
+        val engine = displayEngineName(s.voiceId)
+        if (lastEngineName != null && engine != lastEngineName) {
+            pushEvent(DebugEventKind.Engine, "Engine → $engine")
+        }
+        lastEngineName = engine
+    }
+
+    private fun onControllerEvent(ev: PlaybackUiEvent) {
+        when (ev) {
+            PlaybackUiEvent.BookFinished ->
+                pushEvent(DebugEventKind.Pipeline, "Book finished")
+            is PlaybackUiEvent.ChapterChanged ->
+                pushEvent(DebugEventKind.Chapter, "Auto-advance → ${ev.chapterId.takeLast(16)}")
+            is PlaybackUiEvent.EngineMissing ->
+                pushEvent(DebugEventKind.Error, "Engine missing")
+            is PlaybackUiEvent.AzureFellBack ->
+                pushEvent(DebugEventKind.Engine, "Azure → ${ev.fallbackVoiceLabel} (fallback)")
+        }
+    }
+
+    private fun pushEvent(kind: DebugEventKind, message: String) {
+        val entry = DebugEvent(
+            timestampMs = System.currentTimeMillis(),
+            kind = kind,
+            message = message,
+        )
+        events.value = (listOf(entry) + events.value).take(EVENT_RING_SIZE)
+    }
+
+    /**
+     * 1 Hz combined snapshot. Resamples the controller state and settings
+     * flows on a steady cadence; the overlay collector never has to
+     * worry about over-frequent recompositions even when the pipeline
+     * is firing sentence boundaries 5/sec.
+     *
+     * Implementation note: combine emits whenever any upstream emits.
+     * We `sample(1000)` afterward so a flurry of upstream emissions in
+     * the same second collapses to one downstream tick.
+     */
+    override val snapshot: Flow<DebugSnapshot> = combine(
+        controller.state,
+        settings.settings,
+        events,
+        azureEngine.lastError,
+    ) { playback, ui, ring, azureErr ->
+        buildSnapshot(playback, ui, ring, azureErr)
+    }
+        .sample(REFRESH_INTERVAL_MS)
+        .shareIn(scope, SharingStarted.WhileSubscribed(5_000), replay = 1)
+
+    override suspend fun captureSnapshot(): DebugSnapshot {
+        // One-shot read of the current values. controller.state is a
+        // StateFlow, so .value is the freshest. settings.settings is a
+        // generic Flow per the interface; we pull the first emission —
+        // fast in practice because DataStore caches in-memory.
+        val playback = controller.state.value
+        val ui = settings.settings.first()
+        return buildSnapshot(playback, ui, events.value, azureEngine.lastError.value)
+    }
+
+    private fun buildSnapshot(
+        playback: PlaybackState,
+        ui: `in`.jphe.storyvox.feature.api.UiSettings,
+        ring: List<DebugEvent>,
+        azureErr: AzureError?,
+    ): DebugSnapshot {
+        val engineName = displayEngineName(playback.voiceId)
+        val voiceLabel = playback.voiceId.orEmpty().substringAfterLast(":")
+            .ifBlank { playback.voiceId.orEmpty() }
+        return DebugSnapshot(
+            playback = DebugPlayback(
+                pipelineRunning = playback.isPlaying || playback.isBuffering,
+                isPlaying = playback.isPlaying,
+                isBuffering = playback.isBuffering,
+                isWarmingUp = playback.isPlaying && playback.currentSentenceRange == null,
+                currentSentenceIndex = playback.currentSentenceRange?.sentenceIndex ?: -1,
+                totalSentences = 0, // not surfaced from PlaybackState today; future enhancement
+                currentChapterId = playback.currentChapterId,
+                currentFictionId = playback.currentFictionId,
+                chapterTitle = playback.chapterTitle.orEmpty(),
+                charOffset = playback.charOffset,
+                lastErrorTag = playback.error?.let { mapPlaybackErrorTag(it) },
+            ),
+            engine = DebugEngine(
+                displayName = engineName,
+                voiceId = playback.voiceId,
+                voiceLabel = voiceLabel,
+                tier = tierFor(engineName, ui),
+                parallelInstances = ui.parallelSynthInstances,
+                threadsPerInstance = ui.synthThreadsPerInstance,
+                speed = playback.speed,
+                pitch = playback.pitch,
+                punctuationPauseMultiplier = ui.punctuationPauseMultiplier,
+            ),
+            audio = DebugAudio(
+                producerQueueDepth = 0, // not exposed from EnginePlayer today
+                producerQueueCapacity = ui.playbackBufferChunks,
+                audioBufferMs = 0L, // see follow-up issue
+                reorderBufferOccupancy = 0,
+                sampleRate = 0,
+                outputDevice = "",
+            ),
+            azure = DebugAzure(
+                isConfigured = azureCreds.isConfigured,
+                regionId = azureCreds.regionId(),
+                pendingRequests = 0,
+                lastLatencyMs = null,
+                lastErrorTag = mapAzureErrorTag(azureErr),
+                voiceCacheAgeSec = null,
+            ),
+            network = DebugNetwork(
+                online = isOnline(),
+                lastChapterFetchAgeMs = lastChapterFetchElapsedMs?.let {
+                    SystemClock.elapsedRealtime() - it
+                },
+                lastFetchError = null,
+            ),
+            storage = DebugStorage(
+                cachedChapters = 0,
+                cachedChapterBytes = 0L,
+                voiceModelBytes = 0L,
+            ),
+            build = DebugBuildInfo(
+                versionName = ui.sigil.versionName,
+                hash = ui.sigil.hash,
+                branch = ui.sigil.branch,
+                dirty = ui.sigil.dirty,
+                built = ui.sigil.built,
+                sigilName = ui.sigil.name,
+            ),
+            events = ring,
+            snapshotAtMs = System.currentTimeMillis(),
+        )
+    }
+
+    /**
+     * Best-effort engine label from a voice id. Voice ids follow the
+     * pattern `<engine-prefix>:<voice-name>` in storyvox — Piper voices
+     * carry `piper:`, Kokoro `kokoro:`, Azure `azure:`, Android TTS
+     * `android:`. Unknown prefixes pass through as the raw prefix label.
+     */
+    private fun displayEngineName(voiceId: String?): String {
+        if (voiceId.isNullOrBlank()) return "—"
+        return when {
+            voiceId.startsWith("azure:") -> "Azure"
+            voiceId.startsWith("kokoro:") -> "VoxSherpa · Kokoro"
+            voiceId.startsWith("piper:") -> "VoxSherpa · Piper"
+            voiceId.startsWith("android:") -> "Android TTS"
+            else -> voiceId.substringBefore(":").ifBlank { "Unknown" }
+        }
+    }
+
+    private fun tierFor(engineName: String, ui: `in`.jphe.storyvox.feature.api.UiSettings): String {
+        if (engineName.startsWith("Azure")) return "Streaming (Azure)"
+        val instances = ui.parallelSynthInstances
+        return when {
+            instances <= 1 -> "Tier 1 / 2 (serial / streaming)"
+            else -> "Tier 3 ($instances× parallel)"
+        }
+    }
+
+    private fun mapPlaybackErrorTag(e: PlaybackError): String = when (e) {
+        is PlaybackError.EngineUnavailable -> "EngineUnavailable"
+        is PlaybackError.ChapterFetchFailed -> "ChapterFetchFailed"
+        is PlaybackError.TtsSpeakFailed -> "TtsSpeakFailed"
+        is PlaybackError.AzureAuthFailed -> "AzureAuthFailed"
+        is PlaybackError.AzureThrottled -> "AzureThrottled"
+        is PlaybackError.AzureNetworkUnavailable -> "AzureNetworkUnavailable"
+        is PlaybackError.AzureServerError -> "AzureServerError(${e.httpCode})"
+    }
+
+    private fun mapAzureErrorTag(e: AzureError?): String? = when (e) {
+        null -> null
+        is AzureError.AuthFailed -> "AuthFailed"
+        is AzureError.Throttled -> "Throttled"
+        is AzureError.NetworkError -> "NetworkError"
+        is AzureError.ServerError -> "ServerError(${e.httpCode})"
+        is AzureError.BadRequest -> "BadRequest(${e.httpCode})"
+    }
+
+    /**
+     * Cheap one-shot connectivity check. Not Flow-bound — runs on each
+     * snapshot tick (1 Hz). Cheaper than registering a NetworkCallback +
+     * tearing it down on subscriber lifecycle, and the latency of a 1s
+     * stale answer is well under what the overlay would care about.
+     */
+    private fun isOnline(): Boolean {
+        return try {
+            val cm = context.getSystemService(ConnectivityManager::class.java) ?: return false
+            val nw = cm.activeNetwork ?: return false
+            val caps = cm.getNetworkCapabilities(nw) ?: return false
+            caps.hasCapability(NetworkCapabilities.NET_CAPABILITY_VALIDATED)
+        } catch (_: Throwable) {
+            false
+        }
+    }
+
+    companion object {
+        /** Per the [DebugSnapshot] contract. */
+        const val EVENT_RING_SIZE = 20
+
+        /** 1 Hz — matches Vesper's mission brief: "Numeric values update at
+         *  1Hz (not 60Hz — that's wasteful)". */
+        const val REFRESH_INTERVAL_MS = 1_000L
+    }
+}

--- a/app/src/main/kotlin/in/jphe/storyvox/navigation/StoryvoxNavHost.kt
+++ b/app/src/main/kotlin/in/jphe/storyvox/navigation/StoryvoxNavHost.kt
@@ -29,6 +29,7 @@ import `in`.jphe.storyvox.auth.github.GitHubSignInScreen
 import `in`.jphe.storyvox.source.github.auth.GitHubAuthConfig
 import `in`.jphe.storyvox.feature.browse.BrowseScreen
 import `in`.jphe.storyvox.feature.chat.ChatScreen
+import `in`.jphe.storyvox.feature.debug.DebugScreen
 import `in`.jphe.storyvox.feature.engine.VoicePickerGate
 import `in`.jphe.storyvox.feature.fiction.FictionDetailScreen
 import `in`.jphe.storyvox.feature.follows.FollowsScreen
@@ -57,6 +58,10 @@ object StoryvoxRoutes {
      *  recap history, navigate back into the chat surface, delete
      *  individual sessions. */
     const val SETTINGS_AI_SESSIONS = "settings/ai/sessions"
+    /** Vesper (v0.4.97) — Settings → Developer → Debug. Pipeline/engine/
+     *  Azure live diagnostics + 20-event ring + clipboard export for bug
+     *  reports. */
+    const val SETTINGS_DEBUG = "settings/debug"
     const val AUTH_WEBVIEW = "auth/webview"
     /** Issue #91 — GitHub Device Flow sign-in modal. */
     const val GITHUB_SIGN_IN = "auth/github/signin"
@@ -373,7 +378,17 @@ private fun StoryvoxNavHostContent(
                     onOpenTeamsSignIn = { navController.navigate(StoryvoxRoutes.TEAMS_SIGN_IN) },
                     onOpenPronunciationDict = { navController.navigate(StoryvoxRoutes.SETTINGS_PRONUNCIATION) },
                     onOpenAiSessions = { navController.navigate(StoryvoxRoutes.SETTINGS_AI_SESSIONS) },
+                    onOpenDebug = { navController.navigate(StoryvoxRoutes.SETTINGS_DEBUG) },
                 )
+            }
+            composable(
+                StoryvoxRoutes.SETTINGS_DEBUG,
+                enterTransition = pushEnter,
+                exitTransition = pushExit,
+                popEnterTransition = popEnter,
+                popExitTransition = popExit,
+            ) {
+                DebugScreen(onBack = { navController.popBackStack() })
             }
             composable(
                 StoryvoxRoutes.SETTINGS_AI_SESSIONS,

--- a/app/src/test/kotlin/in/jphe/storyvox/di/RealPlaybackControllerUiTest.kt
+++ b/app/src/test/kotlin/in/jphe/storyvox/di/RealPlaybackControllerUiTest.kt
@@ -176,6 +176,11 @@ class RealPlaybackControllerUiTest {
         override fun seekTo(charOffset: Int) = Unit
         override fun skipForward30s() = Unit
         override fun skipBack30s() = Unit
+        // #120 — sentence stepping. Vesper drive-by fix: test wasn't
+        // updated when PlaybackController grew these two; the missing
+        // overrides broke `:app:compileDebugUnitTestKotlin` until now.
+        override fun nextSentence() = Unit
+        override fun previousSentence() = Unit
         override suspend fun nextChapter() = Unit
         override suspend fun previousChapter() = Unit
         override suspend fun jumpToChapter(chapterId: String) = Unit

--- a/feature/src/main/kotlin/in/jphe/storyvox/feature/api/DebugContracts.kt
+++ b/feature/src/main/kotlin/in/jphe/storyvox/feature/api/DebugContracts.kt
@@ -1,0 +1,220 @@
+package `in`.jphe.storyvox.feature.api
+
+import androidx.compose.runtime.Immutable
+import kotlinx.coroutines.flow.Flow
+
+/**
+ * Read-only diagnostic surface for storyvox's debug overlay + Debug
+ * screen (`/debug`). Distinct from [SettingsRepositoryUi] so the test
+ * fakes can stay focused on settings without dragging a debug snapshot
+ * through every stub, and so the orchestrating app/di module can build
+ * the snapshot from many small sources without those sources knowing
+ * about the UI shape.
+ *
+ * **Surface invariants**
+ *  - `snapshot` MUST emit at most ~1 Hz. Listeners (overlay, screen) draw
+ *    every emission; collecting at audio-frame cadence (44.1 kHz) would
+ *    melt the UI thread and serve no user purpose since the overlay's
+ *    smallest useful unit is "how does it look right now."
+ *  - Read-only. No writers; the overlay is purely a window on engine state.
+ *    Persistence (showOverlay toggle) lives in [SettingsRepositoryUi] —
+ *    it's a user UX preference, not a debug datum.
+ *  - Snapshot must never carry secrets. Azure key, OAuth tokens, etc. are
+ *    represented as flags (`isConfigured: Boolean`) or short
+ *    user-controlled identifiers (region id), never raw key material.
+ *    A user pulling logs / screenshots for a bug report must be able to
+ *    share what they see without leaking creds.
+ *
+ * Vesper, v0.4.97 — debut surface for the Debug overlay/screen.
+ */
+interface DebugRepositoryUi {
+    /**
+     * Hot flow of the latest snapshot. App impl combines flows from the
+     * playback controller, Azure engine, network state, etc. Re-throttled
+     * at ~1 Hz at the impl seam so transient bursts (rapid sentence
+     * boundaries, retry storms) don't flood subscribers.
+     */
+    val snapshot: Flow<DebugSnapshot>
+
+    /**
+     * Build a single one-shot snapshot suitable for "copy to clipboard"
+     * export. Distinct from [snapshot] because the export path wants the
+     * current value once, with no subscriber lifecycle.
+     */
+    suspend fun captureSnapshot(): DebugSnapshot
+}
+
+/**
+ * Frozen state of the audio + engine pipeline at one moment in time.
+ *
+ * Composition is intentionally flat per-section (no deep nesting) so the
+ * overlay can render compact rows ("4 sentences in flight | 740ms buffer
+ * | 22 lookahead chunks") without unwrapping nested optionals.
+ *
+ * All nullable fields read as "not applicable / not yet known"; the UI
+ * shows an em-dash. Fields with a sensible zero (`audioBufferMs = 0`)
+ * use that instead of `null` so we can chart them.
+ */
+@Immutable
+data class DebugSnapshot(
+    val playback: DebugPlayback,
+    val engine: DebugEngine,
+    val audio: DebugAudio,
+    val azure: DebugAzure,
+    val network: DebugNetwork,
+    val storage: DebugStorage,
+    val build: DebugBuildInfo,
+    /**
+     * Newest first. Implementations hold a ring of size 20; older events
+     * fall off. The overlay shows the top 5; the screen shows all 20.
+     */
+    val events: List<DebugEvent> = emptyList(),
+    /** Engineer's clock at snapshot time, ms since epoch. */
+    val snapshotAtMs: Long,
+) {
+    companion object {
+        /** Empty initial snapshot — used until the first real emission lands. */
+        val EMPTY = DebugSnapshot(
+            playback = DebugPlayback(),
+            engine = DebugEngine(),
+            audio = DebugAudio(),
+            azure = DebugAzure(),
+            network = DebugNetwork(),
+            storage = DebugStorage(),
+            build = DebugBuildInfo(),
+            snapshotAtMs = 0L,
+        )
+    }
+}
+
+@Immutable
+data class DebugPlayback(
+    val pipelineRunning: Boolean = false,
+    val isPlaying: Boolean = false,
+    val isBuffering: Boolean = false,
+    val isWarmingUp: Boolean = false,
+    val currentSentenceIndex: Int = -1,
+    val totalSentences: Int = 0,
+    val currentChapterId: String? = null,
+    val currentFictionId: String? = null,
+    val chapterTitle: String = "",
+    val charOffset: Int = 0,
+    /** Last [PlaybackError] subclass name; null when error-free. */
+    val lastErrorTag: String? = null,
+)
+
+@Immutable
+data class DebugEngine(
+    /** "VoxSherpa / Piper", "VoxSherpa / Kokoro", "Azure", "Android TTS". */
+    val displayName: String = "—",
+    val voiceId: String? = null,
+    val voiceLabel: String = "",
+    /** Tier descriptor: "Tier 1 (serial)" / "Tier 2 (streaming)" /
+     *  "Tier 3 (4× parallel)". Pre-load reads as "—". */
+    val tier: String = "—",
+    /** Parallel-synth: how many engine instances are loaded (primary + secondaries). */
+    val parallelInstances: Int = 1,
+    /** Threads per instance (0 = Auto from sherpa-onnx heuristic). */
+    val threadsPerInstance: Int = 0,
+    /** Speed × pitch applied to the current pipeline. */
+    val speed: Float = 1.0f,
+    val pitch: Float = 1.0f,
+    /** Inter-sentence pause multiplier (issue #90/#109). */
+    val punctuationPauseMultiplier: Float = 1f,
+)
+
+@Immutable
+data class DebugAudio(
+    /** Producer-side queue occupancy (chunks waiting to be played). */
+    val producerQueueDepth: Int = 0,
+    /** Configured queue capacity ([UiSettings.playbackBufferChunks]). */
+    val producerQueueCapacity: Int = 0,
+    /** Estimated audio buffered behind the playhead, in ms. */
+    val audioBufferMs: Long = 0L,
+    /** Tier 3 — reorder buffer occupancy when parallel synth is on. */
+    val reorderBufferOccupancy: Int = 0,
+    /** AudioTrack sample rate (Hz). */
+    val sampleRate: Int = 0,
+    /** Current routed output device label ("Speaker", "Wired headphones",
+     *  "BT — Pixel Buds Pro"). Empty when no AudioTrack yet. */
+    val outputDevice: String = "",
+)
+
+@Immutable
+data class DebugAzure(
+    val isConfigured: Boolean = false,
+    /** Region id only ("eastus") — never the key. */
+    val regionId: String = "",
+    /** Request queue depth on AzureSpeechClient (best-effort, may be 0
+     *  if Azure isn't the active engine). */
+    val pendingRequests: Int = 0,
+    /** Last successful synthesize round-trip in ms. */
+    val lastLatencyMs: Long? = null,
+    /** Last [AzureError] subclass name; null when error-free. */
+    val lastErrorTag: String? = null,
+    /** Age in seconds of the cached `voices/list` payload. */
+    val voiceCacheAgeSec: Long? = null,
+)
+
+@Immutable
+data class DebugNetwork(
+    val online: Boolean = true,
+    /** ms since last successful chapter fetch (null = never). */
+    val lastChapterFetchAgeMs: Long? = null,
+    /** Last fetch-failed reason for the most recent attempted chapter. */
+    val lastFetchError: String? = null,
+)
+
+@Immutable
+data class DebugStorage(
+    /** Count of chapters in the local Room cache. */
+    val cachedChapters: Int = 0,
+    /** Approximate bytes in chapter cache (sum of plainBody lengths × 2). */
+    val cachedChapterBytes: Long = 0L,
+    /** Bytes occupied by installed voice models. */
+    val voiceModelBytes: Long = 0L,
+)
+
+@Immutable
+data class DebugBuildInfo(
+    val versionName: String = "",
+    val hash: String = "",
+    val branch: String = "",
+    val dirty: Boolean = false,
+    val built: String = "",
+    val sigilName: String = "",
+)
+
+/**
+ * One entry in the rolling event ring. The overlay surfaces a fixed
+ * 20-event window — *not* a scrolling console (deliberately kept short
+ * for readability per Vesper's design brief).
+ */
+@Immutable
+data class DebugEvent(
+    val timestampMs: Long,
+    val kind: DebugEventKind,
+    /** One-line human-readable summary. Examples:
+     *  - "Chapter loaded: 12 — The Bonewright"
+     *  - "Engine switched: Piper → Azure"
+     *  - "Sentence 47 emitted (340 ms latency)"
+     *  - "Auto-advance fired: chapter 13"
+     *  - "Azure: 429 throttled, backing off 250ms"
+     */
+    val message: String,
+)
+
+enum class DebugEventKind {
+    /** Chapter download / chapter swap. */
+    Chapter,
+    /** Engine swap / voice change. */
+    Engine,
+    /** Per-sentence boundary tick (mostly visible during Tier 3 debug). */
+    Sentence,
+    /** Errors of any flavor — emphasized in deep red in the UI. */
+    Error,
+    /** Pipeline lifecycle: start/stop/auto-advance/sleep-timer. */
+    Pipeline,
+    /** Generic info (network online/offline transitions, etc). */
+    Info,
+}

--- a/feature/src/main/kotlin/in/jphe/storyvox/feature/api/UiContracts.kt
+++ b/feature/src/main/kotlin/in/jphe/storyvox/feature/api/UiContracts.kt
@@ -753,6 +753,18 @@ data class UiSettings(
      * core count + thermal envelope.
      */
     val synthThreadsPerInstance: Int = 0,
+    /**
+     * Vesper (v0.4.97) — debug overlay master switch. When true, the
+     * Reader and home shells draw [DebugOverlay] on top of their
+     * normal content as a swipe-down-to-collapse card. Wires through
+     * to the same DataStore key as every other Boolean toggle. Default
+     * `false` — power users opt in from Settings → Developer.
+     *
+     * The dedicated `/debug` screen is reachable from Settings →
+     * Developer regardless of this toggle; the switch only controls
+     * the *overlay* surface.
+     */
+    val showDebugOverlay: Boolean = false,
 ) {
     /** Speed value the engine should run at right now — the active
      *  voice's override if set, otherwise the global default (#195). */
@@ -1084,6 +1096,17 @@ interface SettingsRepositoryUi {
      *  1..[PARALLEL_SYNTH_MAX_INSTANCES] = explicit value passed to
      *  sherpa-onnx. */
     suspend fun setSynthThreadsPerInstance(count: Int)
+
+    /**
+     * Vesper (v0.4.97) — toggle the debug overlay master switch
+     * ([UiSettings.showDebugOverlay]). Default implementation no-ops so
+     * existing fakes in the feature test suite don't need to be touched
+     * — only the real DataStore impl persists the value. Test fakes
+     * that *do* care about the overlay's persistence can override.
+     */
+    suspend fun setShowDebugOverlay(enabled: Boolean) {
+        // default no-op for test fakes; SettingsRepositoryUiImpl overrides.
+    }
 }
 
 /** Tier 3 (#88) slider bounds. Min 1 (serial), max 8 (the Snapdragon

--- a/feature/src/main/kotlin/in/jphe/storyvox/feature/debug/DebugFormatters.kt
+++ b/feature/src/main/kotlin/in/jphe/storyvox/feature/debug/DebugFormatters.kt
@@ -1,0 +1,66 @@
+package `in`.jphe.storyvox.feature.debug
+
+import java.text.SimpleDateFormat
+import java.util.Date
+import java.util.Locale
+import kotlin.math.abs
+
+/**
+ * Pure formatters for the debug overlay/screen. Extracted so previews +
+ * tests don't pull in viewmodels. Library Nocturne idiom is "monospace
+ * for numerics, full prose for everything else" — these helpers produce
+ * the monospace-ready strings.
+ */
+internal object DebugFormatters {
+
+    /** "12.4 KB", "1.20 MB", "—" for null/zero. */
+    fun bytes(b: Long?): String {
+        if (b == null || b <= 0L) return "—"
+        val kb = b / 1024.0
+        if (kb < 1.0) return "$b B"
+        val mb = kb / 1024.0
+        if (mb < 1.0) return "%.1f KB".format(Locale.US, kb)
+        val gb = mb / 1024.0
+        if (gb < 1.0) return "%.2f MB".format(Locale.US, mb)
+        return "%.2f GB".format(Locale.US, gb)
+    }
+
+    /** "240 ms", "1.4 s", "12 min", "—" for null. */
+    fun duration(ms: Long?): String {
+        if (ms == null) return "—"
+        val abs = abs(ms)
+        return when {
+            abs < 1_000 -> "$abs ms"
+            abs < 60_000 -> "%.1f s".format(Locale.US, abs / 1000.0)
+            abs < 3_600_000 -> "%d min %d s".format(Locale.US, abs / 60_000, (abs % 60_000) / 1000)
+            else -> "%.1f h".format(Locale.US, abs / 3_600_000.0)
+        }
+    }
+
+    /** Relative time like "just now", "12 s ago", "4 min ago", "1 h ago". */
+    fun ago(timestampMs: Long, nowMs: Long = System.currentTimeMillis()): String {
+        val diff = nowMs - timestampMs
+        if (diff < 0L) return "now"
+        return when {
+            diff < 2_000 -> "now"
+            diff < 60_000 -> "${diff / 1000} s ago"
+            diff < 3_600_000 -> "${diff / 60_000} min ago"
+            diff < 86_400_000 -> "${diff / 3_600_000} h ago"
+            else -> "${diff / 86_400_000} d ago"
+        }
+    }
+
+    /** "HH:mm:ss" — wall-clock time stamp for log rows. */
+    fun clockTime(timestampMs: Long): String =
+        try {
+            SimpleDateFormat("HH:mm:ss", Locale.US).format(Date(timestampMs))
+        } catch (_: Throwable) {
+            "--:--:--"
+        }
+
+    /** Pads / truncates an id to a fixed width so columns line up. */
+    fun id(id: String?, width: Int = 16): String {
+        val s = id.orEmpty()
+        return if (s.length <= width) s.padEnd(width) else "…" + s.takeLast(width - 1)
+    }
+}

--- a/feature/src/main/kotlin/in/jphe/storyvox/feature/debug/DebugOverlay.kt
+++ b/feature/src/main/kotlin/in/jphe/storyvox/feature/debug/DebugOverlay.kt
@@ -1,0 +1,474 @@
+package `in`.jphe.storyvox.feature.debug
+
+import androidx.compose.animation.AnimatedVisibility
+import androidx.compose.animation.core.tween
+import androidx.compose.animation.fadeIn
+import androidx.compose.animation.fadeOut
+import androidx.compose.animation.slideInVertically
+import androidx.compose.animation.slideOutVertically
+import androidx.compose.foundation.background
+import androidx.compose.foundation.border
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.gestures.detectVerticalDragGestures
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.statusBarsPadding
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.outlined.BugReport
+import androidx.compose.material.icons.outlined.ExpandLess
+import androidx.compose.material.icons.outlined.ExpandMore
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.saveable.rememberSaveable
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.input.pointer.pointerInput
+import androidx.compose.ui.text.font.FontFamily
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import `in`.jphe.storyvox.feature.api.DebugEventKind
+import `in`.jphe.storyvox.feature.api.DebugSnapshot
+import `in`.jphe.storyvox.ui.theme.LibraryNocturneTheme
+
+/**
+ * Library Nocturne brass accent for the overlay's hairline border.
+ * Pulled into a named constant so the preview and the live composable
+ * read the same value. Matches the brass-on-deep-purple aesthetic that
+ * the v0.4.96 shimmer skeletons (Vesper's previous PR) established as
+ * the loading-state language.
+ */
+private val BrassHairline = Color(0xFFC9A05F).copy(alpha = 0.40f)
+
+/**
+ * Deep-purple overlay substrate — the same warm dark used by surface
+ * dark mode, alpha'd to 0.92 so the player below stays a hint visible
+ * for "I haven't lost my place". Per the design brief in Vesper's
+ * mission spec: "deep purple semi-transparent (alpha ~0.92) with
+ * subtle brass border".
+ */
+private val OverlaySubstrate = Color(0xFF15131A).copy(alpha = 0.92f)
+
+/**
+ * Status pill colors. Brass for "good", deep red for "error", warm gray
+ * for "neutral". The error red (`#A04535`) is darker than the Material
+ * `error` token so it reads as "bug to investigate" rather than
+ * "the chat is on fire".
+ */
+private val StatusBrass = Color(0xFFC9A05F)
+private val StatusError = Color(0xFFA04535)
+private val StatusNeutral = Color(0xFF8B7E6A)
+
+/**
+ * The on-Reader debug overlay.
+ *
+ * Lifecycle:
+ *  - Mounted by Reader / Player shells when [DebugViewModel.overlayEnabled]
+ *    is true.
+ *  - Internally tracks an expanded/collapsed state, persisted across
+ *    process death via [rememberSaveable].
+ *  - The collapsed shape is a single-line strip pinned beneath the
+ *    status bar; the expanded shape is a multi-section card.
+ *  - Swipe down on the header dismisses (collapses) the card.
+ *
+ * Quality bar (from the mission brief):
+ *  - The overlay must NOT obscure playback controls — by living at the
+ *    top of the screen, transport controls at the bottom stay clean.
+ *  - Numeric values update at 1Hz — the repo is throttled.
+ *  - On narrow phones (Flip3, 360dp), the collapsed strip fits without
+ *    truncation thanks to compact identifiers + ellipsis on titles.
+ */
+@Composable
+fun DebugOverlay(
+    modifier: Modifier = Modifier,
+    viewModel: DebugViewModel = hiltViewModel(),
+) {
+    val snapshot by viewModel.snapshot.collectAsStateWithLifecycle()
+    DebugOverlayContent(
+        snapshot = snapshot,
+        modifier = modifier,
+    )
+}
+
+@Composable
+internal fun DebugOverlayContent(
+    snapshot: DebugSnapshot,
+    modifier: Modifier = Modifier,
+) {
+    var expanded by rememberSaveable { mutableStateOf(false) }
+    val coroutineScope = rememberCoroutineScope()
+    var dismissed by remember { mutableStateOf(false) }
+
+    AnimatedVisibility(
+        visible = !dismissed,
+        enter = fadeIn(tween(220)) + slideInVertically(
+            animationSpec = tween(260),
+            initialOffsetY = { -it / 2 },
+        ),
+        exit = fadeOut(tween(180)) + slideOutVertically(
+            animationSpec = tween(220),
+            targetOffsetY = { -it / 2 },
+        ),
+        modifier = modifier,
+    ) {
+        Column(
+            modifier = Modifier
+                .fillMaxWidth()
+                .statusBarsPadding()
+                .padding(horizontal = 12.dp, vertical = 8.dp)
+                .clip(RoundedCornerShape(12.dp))
+                .background(OverlaySubstrate)
+                .border(
+                    width = 1.dp,
+                    color = BrassHairline,
+                    shape = RoundedCornerShape(12.dp),
+                ),
+        ) {
+            // Header — always visible. Tap to expand/collapse, swipe
+            // down to dismiss the whole card.
+            OverlayHeader(
+                snapshot = snapshot,
+                expanded = expanded,
+                onToggle = { expanded = !expanded },
+                onSwipeDown = { dismissed = true },
+            )
+            AnimatedVisibility(
+                visible = expanded,
+                enter = fadeIn(tween(260)),
+                exit = fadeOut(tween(180)),
+            ) {
+                OverlayBody(snapshot = snapshot)
+            }
+        }
+    }
+}
+
+@Composable
+private fun OverlayHeader(
+    snapshot: DebugSnapshot,
+    expanded: Boolean,
+    onToggle: () -> Unit,
+    onSwipeDown: () -> Unit,
+) {
+    val playback = snapshot.playback
+    val tone = when {
+        snapshot.playback.lastErrorTag != null || snapshot.azure.lastErrorTag != null -> StatusError
+        playback.pipelineRunning -> StatusBrass
+        else -> StatusNeutral
+    }
+    Row(
+        modifier = Modifier
+            .fillMaxWidth()
+            .clickable(onClick = onToggle)
+            .pointerInput(Unit) {
+                detectVerticalDragGestures { _, dragAmount ->
+                    if (dragAmount > 18f) onSwipeDown()
+                }
+            }
+            .padding(horizontal = 14.dp, vertical = 10.dp),
+        verticalAlignment = Alignment.CenterVertically,
+        horizontalArrangement = Arrangement.spacedBy(10.dp),
+    ) {
+        // Status dot — pulses subtly. Brass when playing, red on
+        // error, warm gray when idle.
+        Box(
+            modifier = Modifier
+                .size(8.dp)
+                .clip(RoundedCornerShape(50))
+                .background(tone),
+        )
+        Icon(
+            imageVector = Icons.Outlined.BugReport,
+            contentDescription = null,
+            tint = StatusBrass,
+            modifier = Modifier.size(16.dp),
+        )
+        // One-line status — "engine · sentence · state".
+        Column(modifier = Modifier.weight(1f)) {
+            Text(
+                text = headerSummary(snapshot),
+                style = MaterialTheme.typography.labelMedium,
+                color = Color(0xFFE8DCC8),
+                fontFamily = FontFamily.Monospace,
+                fontSize = 11.sp,
+                maxLines = 1,
+            )
+            Text(
+                text = headerSubtitle(snapshot),
+                style = MaterialTheme.typography.labelSmall,
+                color = Color(0xFFB8AE9F),
+                fontFamily = FontFamily.Monospace,
+                fontSize = 10.sp,
+                maxLines = 1,
+            )
+        }
+        Icon(
+            imageVector = if (expanded) Icons.Outlined.ExpandLess else Icons.Outlined.ExpandMore,
+            contentDescription = if (expanded) "Collapse debug overlay" else "Expand debug overlay",
+            tint = Color(0xFFC9A774),
+            modifier = Modifier.size(20.dp),
+        )
+    }
+}
+
+@Composable
+private fun OverlayBody(snapshot: DebugSnapshot) {
+    Column(
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(horizontal = 14.dp, vertical = 4.dp),
+        verticalArrangement = Arrangement.spacedBy(8.dp),
+    ) {
+        DebugDivider()
+        OverlaySection(title = "Pipeline") {
+            DebugRow("state", pipelineStateText(snapshot))
+            DebugRow("sentence", "#${snapshot.playback.currentSentenceIndex} @ ${snapshot.playback.charOffset}")
+            DebugRow("chapter", DebugFormatters.id(snapshot.playback.currentChapterId, width = 22))
+        }
+        OverlaySection(title = "Engine") {
+            DebugRow("name", snapshot.engine.displayName)
+            DebugRow("voice", snapshot.engine.voiceLabel.ifBlank { "—" })
+            DebugRow("tier", snapshot.engine.tier)
+            DebugRow(
+                "speed × pitch",
+                "%.2f× · %.2f×".format(snapshot.engine.speed, snapshot.engine.pitch),
+            )
+        }
+        OverlaySection(title = "Buffer / Audio") {
+            DebugRow(
+                "producer queue",
+                "${snapshot.audio.producerQueueDepth} / ${snapshot.audio.producerQueueCapacity}",
+            )
+            DebugRow("audio buffered", DebugFormatters.duration(snapshot.audio.audioBufferMs))
+            if (snapshot.engine.parallelInstances > 1) {
+                DebugRow("reorder buf", "${snapshot.audio.reorderBufferOccupancy}")
+            }
+        }
+        if (snapshot.azure.isConfigured) {
+            OverlaySection(title = "Azure") {
+                DebugRow("region", snapshot.azure.regionId)
+                DebugRow("pending", "${snapshot.azure.pendingRequests}")
+                DebugRow("last latency", DebugFormatters.duration(snapshot.azure.lastLatencyMs))
+                val err = snapshot.azure.lastErrorTag
+                if (err != null) DebugRow("error", err, isError = true)
+            }
+        }
+        OverlaySection(title = "Network") {
+            DebugRow("online", if (snapshot.network.online) "yes" else "no",
+                isError = !snapshot.network.online)
+            DebugRow("last fetch", DebugFormatters.duration(snapshot.network.lastChapterFetchAgeMs) + " ago")
+        }
+        // Recent events — top 5 only; the full 20 live on the screen.
+        if (snapshot.events.isNotEmpty()) {
+            OverlaySection(title = "Recent") {
+                snapshot.events.take(5).forEach { ev ->
+                    EventRow(
+                        time = DebugFormatters.clockTime(ev.timestampMs),
+                        kind = ev.kind,
+                        message = ev.message,
+                    )
+                }
+            }
+        }
+        Spacer(Modifier.height(4.dp))
+        Text(
+            text = "Swipe down to dismiss · tap to collapse",
+            style = MaterialTheme.typography.labelSmall,
+            color = Color(0xFF8B7E6A),
+            fontSize = 9.sp,
+            modifier = Modifier.padding(bottom = 2.dp),
+        )
+    }
+}
+
+@Composable
+private fun OverlaySection(title: String, content: @Composable () -> Unit) {
+    Column(verticalArrangement = Arrangement.spacedBy(2.dp)) {
+        Text(
+            text = title,
+            // Serif for section headers per the design brief; matches the
+            // Library Nocturne header rhythm where chapter-headings use
+            // BookBodyFamily (Garamond).
+            style = MaterialTheme.typography.titleSmall,
+            color = StatusBrass,
+            fontSize = 11.sp,
+            fontWeight = FontWeight.SemiBold,
+        )
+        content()
+    }
+}
+
+@Composable
+private fun DebugRow(label: String, value: String, isError: Boolean = false) {
+    Row(
+        modifier = Modifier.fillMaxWidth(),
+        horizontalArrangement = Arrangement.SpaceBetween,
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        Text(
+            text = label,
+            color = Color(0xFFB8AE9F),
+            fontSize = 10.sp,
+            fontFamily = FontFamily.Monospace,
+        )
+        Text(
+            text = value,
+            color = if (isError) StatusError else Color(0xFFE8DCC8),
+            fontSize = 10.sp,
+            fontFamily = FontFamily.Monospace,
+            fontWeight = if (isError) FontWeight.SemiBold else FontWeight.Normal,
+            maxLines = 1,
+        )
+    }
+}
+
+@Composable
+private fun EventRow(time: String, kind: DebugEventKind, message: String) {
+    val tone = when (kind) {
+        DebugEventKind.Error -> StatusError
+        DebugEventKind.Engine, DebugEventKind.Chapter -> StatusBrass
+        else -> Color(0xFFB8AE9F)
+    }
+    Row(
+        modifier = Modifier.fillMaxWidth().padding(vertical = 1.dp),
+        verticalAlignment = Alignment.CenterVertically,
+        horizontalArrangement = Arrangement.spacedBy(8.dp),
+    ) {
+        Text(
+            text = time,
+            color = Color(0xFF8B7E6A),
+            fontSize = 9.sp,
+            fontFamily = FontFamily.Monospace,
+        )
+        Box(
+            modifier = Modifier
+                .size(4.dp)
+                .clip(RoundedCornerShape(50))
+                .background(tone),
+        )
+        Text(
+            text = message,
+            color = if (kind == DebugEventKind.Error) StatusError else Color(0xFFE8DCC8),
+            fontSize = 10.sp,
+            fontFamily = FontFamily.Monospace,
+            maxLines = 1,
+            modifier = Modifier.weight(1f),
+        )
+    }
+}
+
+@Composable
+private fun DebugDivider() {
+    Box(
+        modifier = Modifier
+            .fillMaxWidth()
+            .height(1.dp)
+            .background(BrassHairline.copy(alpha = 0.25f)),
+    )
+}
+
+private fun headerSummary(s: DebugSnapshot): String {
+    val state = pipelineStateText(s)
+    val engine = s.engine.displayName
+    return "$engine · $state"
+}
+
+private fun headerSubtitle(s: DebugSnapshot): String {
+    val sent = s.playback.currentSentenceIndex.coerceAtLeast(0)
+    val q = "${s.audio.producerQueueDepth}/${s.audio.producerQueueCapacity}"
+    val errBadge = s.playback.lastErrorTag?.let { " · ⚠ $it" } ?: ""
+    return "sent #$sent · queue $q$errBadge"
+}
+
+private fun pipelineStateText(s: DebugSnapshot): String {
+    val p = s.playback
+    return when {
+        p.lastErrorTag != null -> "ERROR"
+        p.isWarmingUp -> "warming up"
+        p.isBuffering -> "buffering"
+        p.isPlaying -> "playing"
+        p.pipelineRunning -> "running"
+        else -> "idle"
+    }
+}
+
+// region Previews
+
+@Preview(name = "Overlay — playing", widthDp = 360, heightDp = 200)
+@Composable
+private fun PreviewOverlayPlaying() = LibraryNocturneTheme(darkTheme = true) {
+    val sample = DebugSnapshot.EMPTY.copy(
+        playback = DebugSnapshot.EMPTY.playback.copy(
+            pipelineRunning = true,
+            isPlaying = true,
+            currentSentenceIndex = 47,
+            charOffset = 12_344,
+            currentChapterId = "rr:fiction/123/ch/47",
+            chapterTitle = "The Bonewright",
+        ),
+        engine = DebugSnapshot.EMPTY.engine.copy(
+            displayName = "VoxSherpa · Piper",
+            voiceLabel = "en_US-amy-medium",
+            tier = "Tier 1 / 2 (serial / streaming)",
+            speed = 1.4f,
+            pitch = 1.0f,
+        ),
+        audio = DebugSnapshot.EMPTY.audio.copy(
+            producerQueueDepth = 6,
+            producerQueueCapacity = 8,
+            audioBufferMs = 2_400L,
+        ),
+        snapshotAtMs = System.currentTimeMillis(),
+    )
+    DebugOverlayContent(snapshot = sample)
+}
+
+@Preview(name = "Overlay — error (Azure)", widthDp = 360, heightDp = 240)
+@Composable
+private fun PreviewOverlayError() = LibraryNocturneTheme(darkTheme = true) {
+    val sample = DebugSnapshot.EMPTY.copy(
+        playback = DebugSnapshot.EMPTY.playback.copy(
+            pipelineRunning = false,
+            isPlaying = false,
+            lastErrorTag = "AzureThrottled",
+            currentSentenceIndex = 12,
+            currentChapterId = "azure:test",
+        ),
+        engine = DebugSnapshot.EMPTY.engine.copy(
+            displayName = "Azure",
+            voiceLabel = "en-US-AvaMultilingualNeural",
+            tier = "Streaming (Azure)",
+        ),
+        azure = DebugSnapshot.EMPTY.azure.copy(
+            isConfigured = true,
+            regionId = "eastus",
+            lastErrorTag = "Throttled",
+        ),
+        network = DebugSnapshot.EMPTY.network.copy(online = true),
+        snapshotAtMs = System.currentTimeMillis(),
+    )
+    DebugOverlayContent(snapshot = sample)
+}
+
+// endregion

--- a/feature/src/main/kotlin/in/jphe/storyvox/feature/debug/DebugScreen.kt
+++ b/feature/src/main/kotlin/in/jphe/storyvox/feature/debug/DebugScreen.kt
@@ -1,0 +1,620 @@
+package `in`.jphe.storyvox.feature.debug
+
+import android.content.ClipData
+import android.content.ClipboardManager
+import android.content.Context
+import androidx.compose.foundation.background
+import androidx.compose.foundation.border
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.outlined.ArrowBack
+import androidx.compose.material.icons.outlined.BugReport
+import androidx.compose.material.icons.outlined.ContentCopy
+import androidx.compose.material3.Card
+import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Switch
+import androidx.compose.material3.SwitchDefaults
+import androidx.compose.material3.Text
+import androidx.compose.material3.TopAppBar
+import androidx.compose.material3.TopAppBarDefaults
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.text.font.FontFamily
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import `in`.jphe.storyvox.feature.api.DebugEvent
+import `in`.jphe.storyvox.feature.api.DebugEventKind
+import `in`.jphe.storyvox.feature.api.DebugSnapshot
+import `in`.jphe.storyvox.ui.theme.LibraryNocturneTheme
+import `in`.jphe.storyvox.ui.theme.LocalSpacing
+import kotlinx.coroutines.launch
+
+/**
+ * Dedicated `/debug` screen. Lives behind Settings → Developer →
+ * "Open debug screen". Reads identical data to the overlay but renders
+ * it as a full-page control panel with breathing room, drill-down
+ * sections, and the export-to-clipboard button.
+ *
+ * Sections (in order of debugging utility):
+ *  1. Status header — at-a-glance pipeline state pill
+ *  2. Pipeline + Engine
+ *  3. Audio buffer + routing
+ *  4. Azure cloud-voice diagnostics (only when configured)
+ *  5. Network state
+ *  6. Storage (cached chapters + voice models)
+ *  7. Build info — version, hash, sigil
+ *  8. Event log (full 20-event ring)
+ *  9. Export — single-tap "Copy snapshot" to clipboard
+ *
+ * Library Nocturne aesthetic: brass section headers, monospace numerics,
+ * card substrate. Reuses the [Card] from M3 with the same
+ * `surfaceContainerHigh` substrate the Settings groups use, so the
+ * screen feels like a sibling of Settings rather than a console dump.
+ */
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun DebugScreen(
+    onBack: () -> Unit,
+    viewModel: DebugViewModel = hiltViewModel(),
+) {
+    val snapshot by viewModel.snapshot.collectAsStateWithLifecycle()
+    val overlayEnabled by viewModel.overlayEnabled.collectAsStateWithLifecycle()
+    val context = LocalContext.current
+    val scope = rememberCoroutineScope()
+    var copyFlashAt by remember { mutableStateOf(0L) }
+
+    DebugScreenContent(
+        snapshot = snapshot,
+        overlayEnabled = overlayEnabled,
+        copyFlashAt = copyFlashAt,
+        onBack = onBack,
+        onToggleOverlay = viewModel::setOverlayEnabled,
+        onCopy = {
+            scope.launch {
+                val snap = viewModel.captureForExport()
+                copySnapshotToClipboard(context, snap)
+                copyFlashAt = System.currentTimeMillis()
+            }
+        },
+    )
+}
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+internal fun DebugScreenContent(
+    snapshot: DebugSnapshot,
+    overlayEnabled: Boolean,
+    copyFlashAt: Long,
+    onBack: () -> Unit,
+    onToggleOverlay: (Boolean) -> Unit,
+    onCopy: () -> Unit,
+) {
+    val spacing = LocalSpacing.current
+    val flashVisible = copyFlashAt > 0L &&
+        (System.currentTimeMillis() - copyFlashAt) < 2_000L
+    Scaffold(
+        topBar = {
+            TopAppBar(
+                title = {
+                    Row(
+                        verticalAlignment = Alignment.CenterVertically,
+                        horizontalArrangement = Arrangement.spacedBy(8.dp),
+                    ) {
+                        Icon(
+                            imageVector = Icons.Outlined.BugReport,
+                            contentDescription = null,
+                            tint = MaterialTheme.colorScheme.primary,
+                            modifier = Modifier.size(20.dp),
+                        )
+                        Text("Debug")
+                    }
+                },
+                navigationIcon = {
+                    IconButton(onClick = onBack) {
+                        Icon(
+                            imageVector = Icons.AutoMirrored.Outlined.ArrowBack,
+                            contentDescription = "Back",
+                        )
+                    }
+                },
+                actions = {
+                    IconButton(onClick = onCopy) {
+                        Icon(
+                            imageVector = Icons.Outlined.ContentCopy,
+                            contentDescription = "Copy snapshot to clipboard",
+                            tint = MaterialTheme.colorScheme.primary,
+                        )
+                    }
+                },
+                colors = TopAppBarDefaults.topAppBarColors(),
+            )
+        },
+    ) { padding ->
+        Column(
+            modifier = Modifier
+                .fillMaxSize()
+                .padding(padding)
+                .verticalScroll(rememberScrollState())
+                .padding(horizontal = spacing.md, vertical = spacing.sm),
+            verticalArrangement = Arrangement.spacedBy(spacing.md),
+        ) {
+            // Top — pulse pill summarizing pipeline state.
+            StatusHeader(snapshot)
+
+            // Overlay master switch — surfaced here too so power users
+            // can flip it without bouncing to Settings → Developer.
+            OverlayToggleCard(
+                enabled = overlayEnabled,
+                onToggle = onToggleOverlay,
+            )
+
+            DebugSection(title = "Pipeline") {
+                MetricRow("running", snapshot.playback.pipelineRunning.toLabel())
+                MetricRow("playing", snapshot.playback.isPlaying.toLabel())
+                MetricRow("buffering", snapshot.playback.isBuffering.toLabel())
+                MetricRow("warming up", snapshot.playback.isWarmingUp.toLabel())
+                MetricRow("sentence index", "#${snapshot.playback.currentSentenceIndex}")
+                MetricRow("char offset", "${snapshot.playback.charOffset}")
+                MetricRow("chapter id", snapshot.playback.currentChapterId ?: "—")
+                MetricRow("fiction id", snapshot.playback.currentFictionId ?: "—")
+                snapshot.playback.lastErrorTag?.let {
+                    MetricRow("error", it, isError = true)
+                }
+            }
+
+            DebugSection(title = "Engine") {
+                MetricRow("name", snapshot.engine.displayName)
+                MetricRow("voice id", snapshot.engine.voiceId ?: "—")
+                MetricRow("tier", snapshot.engine.tier)
+                MetricRow("parallel instances", "${snapshot.engine.parallelInstances}")
+                MetricRow(
+                    "threads / instance",
+                    if (snapshot.engine.threadsPerInstance == 0) "auto" else "${snapshot.engine.threadsPerInstance}",
+                )
+                MetricRow("speed", "%.2f×".format(snapshot.engine.speed))
+                MetricRow("pitch", "%.2f×".format(snapshot.engine.pitch))
+                MetricRow(
+                    "punctuation pause",
+                    "%.2f×".format(snapshot.engine.punctuationPauseMultiplier),
+                )
+            }
+
+            DebugSection(title = "Audio") {
+                MetricRow(
+                    "producer queue",
+                    "${snapshot.audio.producerQueueDepth} / ${snapshot.audio.producerQueueCapacity}",
+                )
+                MetricRow("audio buffered", DebugFormatters.duration(snapshot.audio.audioBufferMs))
+                if (snapshot.engine.parallelInstances > 1) {
+                    MetricRow("reorder buffer", "${snapshot.audio.reorderBufferOccupancy}")
+                }
+                MetricRow(
+                    "sample rate",
+                    if (snapshot.audio.sampleRate <= 0) "—" else "${snapshot.audio.sampleRate} Hz",
+                )
+                MetricRow(
+                    "output device",
+                    snapshot.audio.outputDevice.ifBlank { "—" },
+                )
+            }
+
+            if (snapshot.azure.isConfigured) {
+                DebugSection(title = "Azure") {
+                    MetricRow("region", snapshot.azure.regionId)
+                    MetricRow("pending requests", "${snapshot.azure.pendingRequests}")
+                    MetricRow(
+                        "last latency",
+                        DebugFormatters.duration(snapshot.azure.lastLatencyMs),
+                    )
+                    MetricRow(
+                        "voice cache age",
+                        snapshot.azure.voiceCacheAgeSec?.let { "${it}s" } ?: "—",
+                    )
+                    snapshot.azure.lastErrorTag?.let {
+                        MetricRow("last error", it, isError = true)
+                    }
+                }
+            }
+
+            DebugSection(title = "Network") {
+                MetricRow("online", snapshot.network.online.toLabel(), isError = !snapshot.network.online)
+                MetricRow(
+                    "last chapter fetch",
+                    DebugFormatters.duration(snapshot.network.lastChapterFetchAgeMs)
+                        .let { if (it == "—") it else "$it ago" },
+                )
+                snapshot.network.lastFetchError?.let {
+                    MetricRow("last fetch error", it, isError = true)
+                }
+            }
+
+            DebugSection(title = "Storage") {
+                MetricRow("cached chapters", "${snapshot.storage.cachedChapters}")
+                MetricRow("chapter cache", DebugFormatters.bytes(snapshot.storage.cachedChapterBytes))
+                MetricRow("voice model cache", DebugFormatters.bytes(snapshot.storage.voiceModelBytes))
+            }
+
+            DebugSection(title = "Build") {
+                MetricRow("version", snapshot.build.versionName.ifBlank { "—" })
+                MetricRow("hash", snapshot.build.hash.ifBlank { "—" })
+                MetricRow("branch", snapshot.build.branch.ifBlank { "—" })
+                if (snapshot.build.dirty) MetricRow("dirty", "yes", isError = true)
+                MetricRow("built", snapshot.build.built.ifBlank { "—" })
+                MetricRow("sigil", snapshot.build.sigilName.ifBlank { "—" })
+            }
+
+            DebugSection(title = "Recent events (20)") {
+                if (snapshot.events.isEmpty()) {
+                    Text(
+                        "No events yet — start playback to see chapter / engine / error events here.",
+                        style = MaterialTheme.typography.bodySmall,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                        modifier = Modifier.padding(vertical = 8.dp),
+                    )
+                } else {
+                    snapshot.events.forEach { ev ->
+                        FullEventRow(ev)
+                    }
+                }
+            }
+
+            if (flashVisible) {
+                Text(
+                    text = "Snapshot copied to clipboard.",
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.primary,
+                    fontFamily = FontFamily.Monospace,
+                )
+            }
+
+            Spacer(Modifier.height(spacing.md))
+        }
+    }
+}
+
+@Composable
+private fun StatusHeader(snapshot: DebugSnapshot) {
+    val tone = when {
+        snapshot.playback.lastErrorTag != null || snapshot.azure.lastErrorTag != null ->
+            MaterialTheme.colorScheme.error
+        snapshot.playback.pipelineRunning ->
+            MaterialTheme.colorScheme.primary
+        else ->
+            MaterialTheme.colorScheme.outline
+    }
+    val label = when {
+        snapshot.playback.lastErrorTag != null -> "ERROR · ${snapshot.playback.lastErrorTag}"
+        snapshot.azure.lastErrorTag != null -> "Azure · ${snapshot.azure.lastErrorTag}"
+        snapshot.playback.isWarmingUp -> "warming up"
+        snapshot.playback.isBuffering -> "buffering"
+        snapshot.playback.isPlaying -> "playing · ${snapshot.engine.displayName}"
+        snapshot.playback.pipelineRunning -> "pipeline running"
+        else -> "idle"
+    }
+    Card(
+        modifier = Modifier.fillMaxWidth(),
+        colors = CardDefaults.cardColors(
+            containerColor = MaterialTheme.colorScheme.surfaceContainerHigh,
+        ),
+        shape = MaterialTheme.shapes.large,
+    ) {
+        Row(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(horizontal = 16.dp, vertical = 14.dp),
+            verticalAlignment = Alignment.CenterVertically,
+            horizontalArrangement = Arrangement.spacedBy(12.dp),
+        ) {
+            Box(
+                modifier = Modifier
+                    .size(12.dp)
+                    .clip(RoundedCornerShape(50))
+                    .background(tone),
+            )
+            Column(modifier = Modifier.weight(1f)) {
+                Text(
+                    text = label,
+                    style = MaterialTheme.typography.titleMedium,
+                    color = MaterialTheme.colorScheme.onSurface,
+                )
+                Text(
+                    text = "sentence #${snapshot.playback.currentSentenceIndex} · queue ${snapshot.audio.producerQueueDepth}/${snapshot.audio.producerQueueCapacity}",
+                    style = MaterialTheme.typography.bodySmall,
+                    fontFamily = FontFamily.Monospace,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                )
+            }
+        }
+    }
+}
+
+@Composable
+private fun OverlayToggleCard(enabled: Boolean, onToggle: (Boolean) -> Unit) {
+    val brassColors = SwitchDefaults.colors(
+        checkedThumbColor = MaterialTheme.colorScheme.primary,
+        checkedTrackColor = MaterialTheme.colorScheme.primaryContainer,
+        checkedBorderColor = MaterialTheme.colorScheme.primary,
+        uncheckedThumbColor = MaterialTheme.colorScheme.outline,
+    )
+    Card(
+        modifier = Modifier.fillMaxWidth(),
+        colors = CardDefaults.cardColors(
+            containerColor = MaterialTheme.colorScheme.surfaceContainerHigh,
+        ),
+        shape = MaterialTheme.shapes.large,
+    ) {
+        Row(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(horizontal = 16.dp, vertical = 12.dp),
+            verticalAlignment = Alignment.CenterVertically,
+            horizontalArrangement = Arrangement.spacedBy(12.dp),
+        ) {
+            Column(modifier = Modifier.weight(1f)) {
+                Text(
+                    text = "Show debug overlay",
+                    style = MaterialTheme.typography.bodyLarge,
+                )
+                Text(
+                    text = "Floats a compact pipeline-state card above the reader / player.",
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                )
+            }
+            Switch(
+                checked = enabled,
+                onCheckedChange = onToggle,
+                colors = brassColors,
+            )
+        }
+    }
+}
+
+@Composable
+private fun DebugSection(
+    title: String,
+    content: @Composable () -> Unit,
+) {
+    Column(verticalArrangement = Arrangement.spacedBy(6.dp)) {
+        // Section heading — brass label, mirrors the Library Nocturne
+        // rhythm Settings uses but tighter (the overlay screen is denser
+        // than Settings).
+        Text(
+            text = title,
+            style = MaterialTheme.typography.labelLarge,
+            color = MaterialTheme.colorScheme.primary,
+            modifier = Modifier.padding(start = 4.dp),
+        )
+        Card(
+            modifier = Modifier.fillMaxWidth(),
+            colors = CardDefaults.cardColors(
+                containerColor = MaterialTheme.colorScheme.surfaceContainerHigh,
+            ),
+            shape = MaterialTheme.shapes.large,
+        ) {
+            Column(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(horizontal = 16.dp, vertical = 12.dp),
+                verticalArrangement = Arrangement.spacedBy(6.dp),
+            ) {
+                content()
+            }
+        }
+    }
+}
+
+@Composable
+private fun MetricRow(label: String, value: String, isError: Boolean = false) {
+    Row(
+        modifier = Modifier.fillMaxWidth(),
+        horizontalArrangement = Arrangement.SpaceBetween,
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        Text(
+            text = label,
+            style = MaterialTheme.typography.bodyMedium,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+        )
+        Text(
+            text = value,
+            style = MaterialTheme.typography.bodyMedium.copy(
+                fontFamily = FontFamily.Monospace,
+                fontWeight = if (isError) FontWeight.SemiBold else FontWeight.Normal,
+            ),
+            color = if (isError) MaterialTheme.colorScheme.error
+            else MaterialTheme.colorScheme.onSurface,
+            maxLines = 2,
+        )
+    }
+}
+
+@Composable
+private fun FullEventRow(ev: DebugEvent) {
+    val tone = when (ev.kind) {
+        DebugEventKind.Error -> MaterialTheme.colorScheme.error
+        DebugEventKind.Engine, DebugEventKind.Chapter -> MaterialTheme.colorScheme.primary
+        DebugEventKind.Sentence -> MaterialTheme.colorScheme.outline
+        DebugEventKind.Pipeline -> MaterialTheme.colorScheme.tertiary
+        DebugEventKind.Info -> MaterialTheme.colorScheme.onSurfaceVariant
+    }
+    Row(
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(vertical = 3.dp),
+        verticalAlignment = Alignment.CenterVertically,
+        horizontalArrangement = Arrangement.spacedBy(10.dp),
+    ) {
+        Text(
+            text = DebugFormatters.clockTime(ev.timestampMs),
+            style = MaterialTheme.typography.bodySmall.copy(fontFamily = FontFamily.Monospace),
+            color = MaterialTheme.colorScheme.outline,
+            fontSize = 11.sp,
+        )
+        Box(
+            modifier = Modifier
+                .size(6.dp)
+                .clip(RoundedCornerShape(50))
+                .background(tone),
+        )
+        Text(
+            text = ev.message,
+            style = MaterialTheme.typography.bodyMedium.copy(fontFamily = FontFamily.Monospace),
+            color = if (ev.kind == DebugEventKind.Error) MaterialTheme.colorScheme.error
+            else MaterialTheme.colorScheme.onSurface,
+            modifier = Modifier.weight(1f),
+            maxLines = 2,
+        )
+    }
+}
+
+/**
+ * Serializes the snapshot to a JSON-ish blob suitable for pasting into
+ * a bug report. Intentionally hand-rolled (not kotlinx.serialization) so
+ * we don't pull a serialization plugin onto every Immutable type just
+ * for the export path. The output reads cleanly and never carries
+ * secrets — see the [DebugSnapshot] kdoc invariants.
+ */
+internal fun copySnapshotToClipboard(context: Context, snapshot: DebugSnapshot) {
+    val json = renderSnapshotAsText(snapshot)
+    val cm = context.getSystemService(Context.CLIPBOARD_SERVICE) as? ClipboardManager ?: return
+    cm.setPrimaryClip(ClipData.newPlainText("storyvox debug snapshot", json))
+}
+
+internal fun renderSnapshotAsText(s: DebugSnapshot): String {
+    return buildString {
+        appendLine("storyvox debug snapshot @ ${DebugFormatters.clockTime(s.snapshotAtMs)}")
+        appendLine("=" + "=".repeat(48))
+        appendLine("[build]")
+        appendLine("  version=${s.build.versionName}  branch=${s.build.branch}  hash=${s.build.hash}  dirty=${s.build.dirty}")
+        appendLine("  sigil=${s.build.sigilName}  built=${s.build.built}")
+        appendLine("[playback]")
+        appendLine("  running=${s.playback.pipelineRunning}  playing=${s.playback.isPlaying}")
+        appendLine("  buffering=${s.playback.isBuffering}  warmingUp=${s.playback.isWarmingUp}")
+        appendLine("  sentence=#${s.playback.currentSentenceIndex}  charOffset=${s.playback.charOffset}")
+        appendLine("  chapter=${s.playback.currentChapterId}  fiction=${s.playback.currentFictionId}")
+        s.playback.lastErrorTag?.let { appendLine("  error=$it") }
+        appendLine("[engine]")
+        appendLine("  ${s.engine.displayName}  voice=${s.engine.voiceId}")
+        appendLine("  tier=${s.engine.tier}  instances=${s.engine.parallelInstances}  threads=${s.engine.threadsPerInstance}")
+        appendLine("  speed=%.2f  pitch=%.2f  pauseMul=%.2f".format(
+            s.engine.speed, s.engine.pitch, s.engine.punctuationPauseMultiplier
+        ))
+        appendLine("[audio]")
+        appendLine("  queue=${s.audio.producerQueueDepth}/${s.audio.producerQueueCapacity}")
+        appendLine("  audioBufferedMs=${s.audio.audioBufferMs}  reorderBuf=${s.audio.reorderBufferOccupancy}")
+        appendLine("  outputDevice=${s.audio.outputDevice.ifBlank { "(none)" }}")
+        if (s.azure.isConfigured) {
+            appendLine("[azure]")
+            appendLine("  region=${s.azure.regionId}  pending=${s.azure.pendingRequests}")
+            appendLine("  lastLatencyMs=${s.azure.lastLatencyMs}  lastError=${s.azure.lastErrorTag}")
+        }
+        appendLine("[network]")
+        appendLine("  online=${s.network.online}  lastFetchAgeMs=${s.network.lastChapterFetchAgeMs}")
+        s.network.lastFetchError?.let { appendLine("  lastFetchError=$it") }
+        appendLine("[events]  (newest first, ${s.events.size} entries)")
+        s.events.forEach { ev ->
+            appendLine("  ${DebugFormatters.clockTime(ev.timestampMs)}  [${ev.kind}]  ${ev.message}")
+        }
+    }
+}
+
+private fun Boolean.toLabel(): String = if (this) "yes" else "no"
+
+@Preview(name = "Debug screen — idle", widthDp = 360, heightDp = 720)
+@Composable
+private fun PreviewDebugScreenIdle() = LibraryNocturneTheme(darkTheme = true) {
+    DebugScreenContent(
+        snapshot = DebugSnapshot.EMPTY.copy(
+            build = DebugSnapshot.EMPTY.build.copy(
+                versionName = "0.4.97",
+                hash = "abcd123",
+                branch = "feat/debug-overlay",
+                built = "2026-05-10T01:23:45Z",
+                sigilName = "Spectral Lantern · abcd123",
+            ),
+            snapshotAtMs = System.currentTimeMillis(),
+        ),
+        overlayEnabled = false,
+        copyFlashAt = 0L,
+        onBack = {},
+        onToggleOverlay = {},
+        onCopy = {},
+    )
+}
+
+@Preview(name = "Debug screen — playing", widthDp = 360, heightDp = 720)
+@Composable
+private fun PreviewDebugScreenPlaying() = LibraryNocturneTheme(darkTheme = true) {
+    DebugScreenContent(
+        snapshot = DebugSnapshot.EMPTY.copy(
+            playback = DebugSnapshot.EMPTY.playback.copy(
+                pipelineRunning = true,
+                isPlaying = true,
+                currentSentenceIndex = 47,
+                charOffset = 12_344,
+                currentChapterId = "rr:fiction/123/ch/47",
+                chapterTitle = "The Bonewright",
+            ),
+            engine = DebugSnapshot.EMPTY.engine.copy(
+                displayName = "VoxSherpa · Piper",
+                voiceId = "piper:en_US-amy-medium",
+                voiceLabel = "en_US-amy-medium",
+                tier = "Tier 1 / 2 (serial / streaming)",
+                speed = 1.4f, pitch = 1.0f,
+            ),
+            audio = DebugSnapshot.EMPTY.audio.copy(
+                producerQueueDepth = 6, producerQueueCapacity = 8,
+                audioBufferMs = 2_400L,
+            ),
+            events = listOf(
+                DebugEvent(System.currentTimeMillis(), DebugEventKind.Sentence, "Sentence 47 emitted"),
+                DebugEvent(System.currentTimeMillis() - 4_000, DebugEventKind.Chapter, "Loaded: The Bonewright"),
+                DebugEvent(System.currentTimeMillis() - 12_000, DebugEventKind.Engine, "Engine → VoxSherpa · Piper"),
+            ),
+            build = DebugSnapshot.EMPTY.build.copy(
+                versionName = "0.4.97",
+                hash = "abcd123",
+                branch = "feat/debug-overlay",
+                sigilName = "Spectral Lantern · abcd123",
+            ),
+            snapshotAtMs = System.currentTimeMillis(),
+        ),
+        overlayEnabled = true,
+        copyFlashAt = 0L,
+        onBack = {},
+        onToggleOverlay = {},
+        onCopy = {},
+    )
+}

--- a/feature/src/main/kotlin/in/jphe/storyvox/feature/debug/DebugViewModel.kt
+++ b/feature/src/main/kotlin/in/jphe/storyvox/feature/debug/DebugViewModel.kt
@@ -1,0 +1,59 @@
+package `in`.jphe.storyvox.feature.debug
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import dagger.hilt.android.lifecycle.HiltViewModel
+import `in`.jphe.storyvox.feature.api.DebugRepositoryUi
+import `in`.jphe.storyvox.feature.api.DebugSnapshot
+import `in`.jphe.storyvox.feature.api.SettingsRepositoryUi
+import javax.inject.Inject
+import kotlinx.coroutines.flow.SharingStarted
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.flow.stateIn
+import kotlinx.coroutines.launch
+
+/**
+ * Surface for the debug screen + overlay. Owns:
+ *  - the live snapshot (1 Hz heartbeat from [DebugRepositoryUi])
+ *  - the overlay master switch (persisted in [SettingsRepositoryUi])
+ *  - the one-shot "export snapshot to clipboard" action
+ *
+ * One ViewModel serves both surfaces because both consume the same
+ * snapshot stream. Hilt gives us one instance per screen — when the
+ * overlay is mounted above the reader it gets its own instance, but
+ * the underlying [DebugRepositoryUi] is a singleton so the flow seam
+ * still shares the combiner.
+ */
+@HiltViewModel
+class DebugViewModel @Inject constructor(
+    private val debug: DebugRepositoryUi,
+    private val settings: SettingsRepositoryUi,
+) : ViewModel() {
+
+    /** Always-on; the screen and overlay both observe this. */
+    val snapshot: StateFlow<DebugSnapshot> = debug.snapshot.stateIn(
+        viewModelScope,
+        SharingStarted.WhileSubscribed(5_000),
+        DebugSnapshot.EMPTY,
+    )
+
+    /**
+     * Master switch state. Reads from the settings flow so any toggle
+     * from the Settings → Developer section propagates to whatever
+     * shell currently mounts the overlay.
+     */
+    val overlayEnabled: StateFlow<Boolean> = settings.settings
+        .map { it.showDebugOverlay }
+        .stateIn(viewModelScope, SharingStarted.WhileSubscribed(5_000), false)
+
+    /** Writes through to DataStore. */
+    fun setOverlayEnabled(enabled: Boolean) = viewModelScope.launch {
+        settings.setShowDebugOverlay(enabled)
+    }
+
+    /** Suspending one-shot capture for clipboard export — invoked by the
+     *  Debug screen's "Copy snapshot" button. The screen wraps this in
+     *  a coroutine so the suspend is invisible. */
+    suspend fun captureForExport(): DebugSnapshot = debug.captureSnapshot()
+}

--- a/feature/src/main/kotlin/in/jphe/storyvox/feature/reader/HybridReaderScreen.kt
+++ b/feature/src/main/kotlin/in/jphe/storyvox/feature/reader/HybridReaderScreen.kt
@@ -10,6 +10,8 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import `in`.jphe.storyvox.feature.debug.DebugOverlay
+import `in`.jphe.storyvox.feature.debug.DebugViewModel
 import `in`.jphe.storyvox.ui.component.HybridReaderShell
 
 @Composable
@@ -40,6 +42,16 @@ fun HybridReaderScreen(
     val recapPlayback by viewModel.recapPlayback.collectAsStateWithLifecycle()
     val playback = state.playback
 
+    // Vesper (v0.4.97) — debug overlay. The DebugViewModel pulls the
+    // master switch from SettingsRepositoryUi so toggling in Settings →
+    // Developer immediately reflects here without a navController round-
+    // trip. The overlay is mounted INSIDE the shell so the reader's
+    // playback controls still respond to taps (the overlay only takes
+    // pointer events on its own bounding box). Hoisting outside the
+    // shell would intercept reader gestures.
+    val debugVm: DebugViewModel = hiltViewModel()
+    val debugEnabled by debugVm.overlayEnabled.collectAsStateWithLifecycle()
+
     if (playback == null) {
         Box(modifier = Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
             Text("No chapter loaded.", style = MaterialTheme.typography.bodyMedium)
@@ -47,6 +59,7 @@ fun HybridReaderScreen(
         return
     }
 
+    Box(modifier = Modifier.fillMaxSize()) {
     HybridReaderShell(
         current = state.activePane,
         onViewChange = viewModel::setActivePane,
@@ -104,4 +117,13 @@ fun HybridReaderScreen(
         },
         onToggleReadAloud = viewModel::toggleRecapAloud,
     )
+
+    // Debug overlay — sits on top of everything (including the recap
+    // modal) when enabled. Pinned to the top of the screen via
+    // statusBarsPadding inside DebugOverlay itself, so the player
+    // controls at the bottom stay free.
+    if (debugEnabled) {
+        DebugOverlay(viewModel = debugVm)
+    }
+    }
 }

--- a/feature/src/main/kotlin/in/jphe/storyvox/feature/settings/SettingsScreen.kt
+++ b/feature/src/main/kotlin/in/jphe/storyvox/feature/settings/SettingsScreen.kt
@@ -21,6 +21,7 @@ import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.outlined.AccountCircle
 import androidx.compose.material.icons.outlined.AutoAwesome
 import androidx.compose.material.icons.outlined.AutoStories
+import androidx.compose.material.icons.outlined.BugReport
 import androidx.compose.material.icons.outlined.Cloud
 import androidx.compose.material.icons.outlined.Info
 import androidx.compose.material.icons.automirrored.outlined.LibraryBooks
@@ -96,6 +97,10 @@ fun SettingsScreen(
     onOpenTeamsSignIn: () -> Unit = {},
     onOpenPronunciationDict: () -> Unit,
     onOpenAiSessions: () -> Unit = {},
+    /** Vesper (v0.4.97) — opens Settings → Developer → Debug. The
+     *  default no-op is preview/test-only; production callsites wire
+     *  this through `navController.navigate(SETTINGS_DEBUG)`. */
+    onOpenDebug: () -> Unit = {},
     viewModel: SettingsViewModel = hiltViewModel(),
 ) {
     val state by viewModel.uiState.collectAsStateWithLifecycle()
@@ -586,7 +591,38 @@ fun SettingsScreen(
             )
         }
 
-        // ── 9. About ─────────────────────────────────────────────────
+        // ── 9. Developer ─────────────────────────────────────────────
+        // Vesper (v0.4.97) — power-user diagnostics. The overlay master
+        // switch lives here so it's discoverable in the same section
+        // tree as every other UX preference; the dedicated /debug screen
+        // is one tap away for deeper drill-down. Section sits just
+        // before About because both are "you only look here when
+        // something's wrong" surfaces, and About is the very last
+        // bookend.
+        SectionHeading(
+            label = "Developer",
+            icon = Icons.Outlined.BugReport,
+            descriptor = "Live pipeline diagnostics + bug-report export.",
+        )
+        SettingsGroupCard {
+            SettingsSwitchRow(
+                title = "Show debug overlay",
+                subtitle = if (s.showDebugOverlay) {
+                    "A compact pipeline-state card floats above the reader."
+                } else {
+                    "Off — the reader stays clean."
+                },
+                checked = s.showDebugOverlay,
+                onCheckedChange = viewModel::setShowDebugOverlay,
+            )
+            SettingsLinkRow(
+                title = "Open Debug screen",
+                subtitle = "Pipeline · engine · Azure · network · events · export.",
+                onClick = onOpenDebug,
+            )
+        }
+
+        // ── 10. About ────────────────────────────────────────────────
         // Realm-sigil "name" is deterministic adjective+noun from the
         // fantasy realm word list, keyed on the build's git hash. Same
         // hash → same name across rebuilds. The brass sigil name is

--- a/feature/src/main/kotlin/in/jphe/storyvox/feature/settings/SettingsViewModel.kt
+++ b/feature/src/main/kotlin/in/jphe/storyvox/feature/settings/SettingsViewModel.kt
@@ -192,6 +192,10 @@ class SettingsViewModel @Inject constructor(
     fun setSleepShakeToExtendEnabled(enabled: Boolean) =
         viewModelScope.launch { repo.setSleepShakeToExtendEnabled(enabled) }
 
+    /** Vesper (v0.4.97) — debug overlay master switch. */
+    fun setShowDebugOverlay(enabled: Boolean) =
+        viewModelScope.launch { repo.setShowDebugOverlay(enabled) }
+
     fun previewVoice(voice: UiVoice) = voices.previewVoice(voice)
 
     // ─── Memory Palace (#79) ────────────────────────────────────────────

--- a/feature/src/test/kotlin/in/jphe/storyvox/feature/debug/DebugFormattersTest.kt
+++ b/feature/src/test/kotlin/in/jphe/storyvox/feature/debug/DebugFormattersTest.kt
@@ -1,0 +1,83 @@
+package `in`.jphe.storyvox.feature.debug
+
+import `in`.jphe.storyvox.feature.api.DebugEvent
+import `in`.jphe.storyvox.feature.api.DebugEventKind
+import `in`.jphe.storyvox.feature.api.DebugSnapshot
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class DebugFormattersTest {
+
+    @Test fun `bytes formats nulls and zero as em dash`() {
+        assertEquals("—", DebugFormatters.bytes(null))
+        assertEquals("—", DebugFormatters.bytes(0L))
+        assertEquals("—", DebugFormatters.bytes(-5L))
+    }
+
+    @Test fun `bytes scales through KB MB GB`() {
+        assertEquals("500 B", DebugFormatters.bytes(500L))
+        assertEquals("1.5 KB", DebugFormatters.bytes(1_536L))
+        // 2 MB == 2 × 1024 × 1024 = 2097152
+        assertEquals("2.00 MB", DebugFormatters.bytes(2_097_152L))
+        // 3 GB
+        assertEquals("3.00 GB", DebugFormatters.bytes(3L * 1024 * 1024 * 1024))
+    }
+
+    @Test fun `duration formats sub-second ms`() {
+        assertEquals("240 ms", DebugFormatters.duration(240L))
+    }
+
+    @Test fun `duration formats seconds`() {
+        assertEquals("1.4 s", DebugFormatters.duration(1_400L))
+    }
+
+    @Test fun `duration nullable returns em dash`() {
+        assertEquals("—", DebugFormatters.duration(null))
+    }
+
+    @Test fun `ago renders relative buckets`() {
+        val now = 10_000_000L
+        assertEquals("now", DebugFormatters.ago(now - 500, now))
+        assertEquals("3 s ago", DebugFormatters.ago(now - 3_500, now))
+        assertEquals("4 min ago", DebugFormatters.ago(now - 240_000, now))
+    }
+
+    @Test fun `id truncates with leading ellipsis`() {
+        val id = "github:jphein/storyvox:src/chapter-01.md"
+        val s = DebugFormatters.id(id, width = 10)
+        assertEquals(10, s.length)
+        assertTrue("expected leading ellipsis", s.startsWith("…"))
+    }
+
+    @Test fun `id pads short input to width`() {
+        val s = DebugFormatters.id("abc", width = 8)
+        assertEquals(8, s.length)
+        assertEquals("abc", s.trimEnd())
+    }
+
+    @Test fun `renderSnapshotAsText includes all sections`() {
+        val s = DebugSnapshot.EMPTY.copy(
+            build = DebugSnapshot.EMPTY.build.copy(
+                versionName = "0.4.97",
+                hash = "abcd123",
+                sigilName = "Spectral Lantern · abcd123",
+            ),
+            events = listOf(
+                DebugEvent(1_000L, DebugEventKind.Chapter, "Loaded: chapter 1"),
+            ),
+            snapshotAtMs = 1_000L,
+        )
+        val text = renderSnapshotAsText(s)
+        assertTrue("must mention version", text.contains("0.4.97"))
+        assertTrue("must mention sigil", text.contains("Spectral Lantern"))
+        assertTrue("must mention event", text.contains("Loaded: chapter 1"))
+        assertTrue("must include build header", text.contains("[build]"))
+        assertTrue("must include events header", text.contains("[events]"))
+    }
+
+    @Test fun `renderSnapshotAsText skips azure section when not configured`() {
+        val text = renderSnapshotAsText(DebugSnapshot.EMPTY)
+        assertTrue("azure header should be absent", !text.contains("[azure]"))
+    }
+}


### PR DESCRIPTION
## Summary

Vesper's mission: a beautiful, intuitive **debugging overlay** that lives on top of the Reader/Player AND a dedicated **Debug screen** with deeper drill-down, both styled in the Library Nocturne brass-on-deep-purple aesthetic that v0.4.96's shimmer skeletons established as storyvox's loading-state language.

Built on the existing PlaybackController state stream + Azure singletons + the realm-sigil build info — no new flows added to core-playback, no contracts polluted on existing test fakes. New surface is one focused interface (`DebugRepositoryUi`) implemented entirely in `:app`.

## Screenshots (Compose Preview)

**Overlay — playing**

A single-line collapsed strip pinned beneath the status bar. Brass status dot · bug-report icon · monospace summary line ("VoxSherpa · Piper · playing" + "sent #47 · queue 6/8") · expand chevron. Tap expands to a multi-section card: Pipeline / Engine / Buffer / Azure / Network / Recent (top 5 events). Swipe-down on the header dismisses the whole card.

**Overlay — error (Azure)**

Status dot flips deep-red (#A04535), header reads "Azure · idle", a dedicated Azure section appears with "error: Throttled" highlighted in the same red. Brass hairline border stays consistent so the error state doesn't feel like a different surface — it feels like the same overlay carrying bad news.

**Debug screen — playing**

Full-bleed Scaffold with TopAppBar carrying a brass bug-report icon, back arrow, and content-copy action. StatusHeader pill at top ("playing · VoxSherpa · Piper" with a brass dot). Overlay master-switch card next, so power users can flip the switch without bouncing to Settings. Then card-per-section: Pipeline / Engine / Audio / Azure / Network / Storage / Build / Recent 20 events. All numeric values monospace; section titles brass labelLarge matching the Settings rhythm. Copy-snapshot action drops a JSON-ish text blob in the clipboard with a 2-second "Snapshot copied to clipboard" flash.

## What got built

**Data layer (`:app`):**
- `feature.api.DebugRepositoryUi` + `DebugSnapshot` — read-only diagnostic surface. Throttled at **1 Hz on the seam** (`Flow.sample(1000ms)`) so sentence-boundary flurries don't cascade into UI recompositions.
- `RealDebugRepositoryUi` — Hilt-singleton implementation joining `PlaybackController.state`, `PlaybackController.events`, `AzureVoiceEngine.lastError`, `AzureCredentials`, settings sigil + an in-process **20-event ring**.
- Master switch persisted via `SettingsRepositoryUi.setShowDebugOverlay` (default `false`, behind a default-no-op interface method so test fakes don't have to be touched).
- `DebugSnapshot` deliberately carries **no secrets** — Azure key, OAuth tokens etc. are represented as `isConfigured: Boolean` or short user-controlled identifiers (region id), never raw key material.

**UI layer (`:feature/debug`):**
- `DebugOverlay.kt` — compact card, swipe-down dismiss, expand/collapse with `rememberSaveable`, brass-tinted status dot, monospace numerics, error tone for failures
- `DebugScreen.kt` — full-page control panel, drill-down sections, clipboard export
- `DebugFormatters.kt` — pure helpers (bytes/duration/ago/id), unit-tested
- `DebugViewModel.kt` — single VM serves both surfaces

**Wiring:**
- Settings → new "Developer" section (between Cloud voices and About) with toggle + link
- `StoryvoxRoutes.SETTINGS_DEBUG` composable destination
- `HybridReaderScreen` mounts the overlay inside its root `Box` — sharing the reader's gesture surface so the overlay only intercepts taps on its own bounding box

**Tests:**
- `DebugFormattersTest` covers bytes/duration/ago/id formatters + `renderSnapshotAsText` section presence
- Drive-by: fixed pre-existing `RecordingController` missing-override compile error in `RealPlaybackControllerUiTest` (predates this branch — PlaybackController grew `nextSentence`/`previousSentence` in #120 and the test stub wasn't updated)

## What I cut for time (and why)

Honest list per the mission brief:

1. **Producer queue depth + audio buffer ms** — `RealDebugRepositoryUi` reads `producerQueueCapacity` from settings but `producerQueueDepth` / `audioBufferMs` come back as 0. Surfacing these needs `EnginePlayer.startPlaybackPipeline()` to expose a `Flow<BufferTelemetry>` from the consumer thread; that's a real cross-module change that should land as its own PR (filed: see follow-ups). The overlay's UX still shows the field with a "0" so the section doesn't look broken — it just doesn't yet *measure*.
2. **Per-engine latency / per-chapter Azure cost** — same shape: needs telemetry hooks inside synth/RTT paths. The DebugAzure type carries `lastLatencyMs` as nullable already; once `AzureSpeechClient` exposes a `lastSynthLatency` StateFlow, the UI lights up with zero overlay-side change.
3. **Output device routing** — `DebugAudio.outputDevice` is wired through but the snapshot leaves it blank. Needs an `AudioManager.getRoutedDevice()` hook on every AudioTrack reconfigure; left for a follow-up so this PR stays focused on the UI shell.
4. **Storage section** — cachedChapters/bytes return 0. Wiring needs a `chapters.countAll()` + `voiceManager.modelBytes()` query; same "data not yet flowing" pattern as above.

In all four cases the **UI is finished and shaped right** — once each source flows, the row populates without re-touching this PR's code. Critically the four "live state" sections that the mission brief listed as most important — pipeline state, engine identity/tier, Azure region+error, network online + last-fetch-age, recent events, build info — *do* populate and update live.

## Follow-ups to file as issues

I'll open these next:
- "Surface EnginePlayer producer-queue depth + audio-buffer ms into DebugRepositoryUi"
- "Surface Azure synth latency + per-chapter request count into DebugRepositoryUi"
- "Surface AudioManager output device routing into DebugRepositoryUi"
- "Surface chapter/voice-model storage usage into DebugRepositoryUi"

## Test plan

- [ ] `./gradlew assembleDebug` — green ✓
- [ ] `./gradlew test` — green ✓
- [ ] Install on tablet (R83W80CAFZB) — open Settings → Developer, flip the switch, return to Reader, confirm the overlay slides in
- [ ] Swipe-down on the overlay header dismisses; reopening Settings → Reader brings it back when toggle is on
- [ ] Tap "Open Debug screen", confirm pipeline state matches what the overlay shows, tap copy icon, paste into a notes app, confirm the blob reads cleanly with no secrets
- [ ] Verify Flip3 (narrow 360dp) layout doesn't truncate the collapsed strip
- [ ] Verify the overlay does not intercept play/pause/scrub gestures at the bottom of the reader

Closes (no existing debug issue — checked `gh issue list --search debug`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)