### PR TITLE
fix(library): make chapter rows tappable on Fiction detail

### DIFF
--- a/core-ui/src/main/kotlin/in/jphe/storyvox/ui/component/ChapterCard.kt
+++ b/core-ui/src/main/kotlin/in/jphe/storyvox/ui/component/ChapterCard.kt
@@ -55,7 +55,14 @@ fun ChapterCard(
         onClick = onClick,
         modifier = modifier
             .fillMaxWidth()
-            .semantics {
+            // Issue #266 — the un-merged `semantics {}` here used to split the
+            // a11y tree: this node got role=Button + contentDescription, while
+            // the Card's own clickable lived on a child node. Espresso/
+            // UIAutomator reported clickable='false' on the row because the
+            // role node and the action node were different. Merging
+            // descendants flattens them, so the row reads as a single
+            // clickable Button with our content-desc.
+            .semantics(mergeDescendants = true) {
                 role = Role.Button
                 contentDescription = "Chapter ${state.number}, ${state.title}, ${state.durationLabel}" +
                     if (state.isDownloaded) ", downloaded" else ""


### PR DESCRIPTION
## Summary
- Chapter rows in Fiction detail showed `clickable='false'` in UI dumps even though `Card(onClick = ...)` was wired.
- Cause: the `.semantics{}` block put `role = Role.Button` + `contentDescription` on a different node than Card's internal `clickable`. UIAutomator (and TalkBack) walked the tree and never saw a single \"clickable Button\" node.
- Fix: switch to `semantics(mergeDescendants = true)` so the row coalesces into one Button node carrying both the click action and the description.

## What changed
- `core-ui/src/main/kotlin/in/jphe/storyvox/ui/component/ChapterCard.kt` — one-line modifier change + kdoc explaining the future-state plan per the loud-guard pattern.

## Why this approach
The `ViewModel.listen(chapterId)` path was already correct (takes a chapter id and starts there). The bug was purely an a11y-tree split — the cheapest fix is consolidating the semantics, not rewriting the click wiring.

Closes #266