### PR TITLE
fix(player): give conjuring loading a slow hint + timeout/retry

### DIFF
--- a/feature/src/main/kotlin/in/jphe/storyvox/feature/reader/AudiobookView.kt
+++ b/feature/src/main/kotlin/in/jphe/storyvox/feature/reader/AudiobookView.kt
@@ -69,6 +69,8 @@ import `in`.jphe.storyvox.feature.api.UiSleepTimerMode
 import `in`.jphe.storyvox.ui.component.BrassButton
 import `in`.jphe.storyvox.ui.component.BrassButtonVariant
 import `in`.jphe.storyvox.ui.component.BrassProgressTrack
+import `in`.jphe.storyvox.ui.component.ErrorBlock
+import `in`.jphe.storyvox.ui.component.ErrorPlacement
 import `in`.jphe.storyvox.ui.component.FictionCoverThumb
 import `in`.jphe.storyvox.ui.component.MagicSkeletonTile
 import `in`.jphe.storyvox.ui.component.MagicSpinner
@@ -108,6 +110,17 @@ fun AudiobookView(
      *  fictionId on the playback state, so callees can rely on it
      *  being a fully-routed navigation. */
     onOpenChat: () -> Unit = {},
+    /** Issue #278 — loading-phase from the ReaderViewModel. Drives the
+     *  soft "Still working…" hint at 10s and the hard timeout/retry
+     *  error block at 30s. Defaults to NotLoading so previews / tests
+     *  that don't care about the loading lifecycle stay simple. */
+    loadingPhase: LoadingPhase = LoadingPhase.NotLoading,
+    /** Issue #278 — user tapped Retry on the timed-out error block. */
+    onRetryLoading: () -> Unit = {},
+    /** Issue #278 — user tapped "Pick a different voice" on the timed-out
+     *  error block. Goes to the voice library; the controller will pick
+     *  the new voice up next time play() is invoked. */
+    onCancelLoading: () -> Unit = {},
     modifier: Modifier = Modifier,
 ) {
     val spacing = LocalSpacing.current
@@ -123,6 +136,26 @@ fun AudiobookView(
     val spinnerExit = if (reducedMotion) ExitTransition.None else
         fadeOut(animationSpec = tween(motion.standardDurationMs, easing = motion.standardEasing))
     var showSheet by remember { mutableStateOf(false) }
+
+    // Issue #278 — full-screen error block when the loading state has
+    // been stuck for 30+ seconds. Replaces the eternal conjuring sigil
+    // with Retry + Pick voice + an escape via the bottom nav. The
+    // underlying load isn't cancelled; if it eventually completes the
+    // state flow takes over and we route back to the normal player UI.
+    if (loadingPhase == LoadingPhase.TimedOut) {
+        ErrorBlock(
+            title = "Couldn't load this chapter",
+            message = "The voice or chapter text is taking longer than expected. " +
+                "Try again, or pick a different voice — some take a moment to warm up.",
+            onRetry = onRetryLoading,
+            retryLabel = "Try again",
+            onBack = onPickVoice,
+            backLabel = "Pick a different voice",
+            placement = ErrorPlacement.FullScreen,
+            modifier = modifier,
+        )
+        return
+    }
 
     Box(modifier = modifier.fillMaxSize()) {
         Column(
@@ -219,6 +252,19 @@ fun AudiobookView(
                 style = MaterialTheme.typography.bodyMedium,
                 color = if (showSpinner) MaterialTheme.colorScheme.primary else MaterialTheme.colorScheme.onSurfaceVariant,
             )
+            // Issue #278 — soft slow hint: after the loading state has been
+            // stuck for 10s the user should know we're still trying. The
+            // hint appears under the existing "Loading voice + chapter text"
+            // / chapter-title subtitle and disappears as soon as state
+            // arrives. At 30s we flip to the full error block above and
+            // this hint never renders.
+            if (loadingPhase == LoadingPhase.Slow) {
+                Text(
+                    "Still working… slow voice or network. Hang tight.",
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                )
+            }
             Spacer(Modifier.height(spacing.xs))
             BrassProgressTrack(
                 positionMs = state.positionMs,

--- a/feature/src/main/kotlin/in/jphe/storyvox/feature/reader/HybridReaderScreen.kt
+++ b/feature/src/main/kotlin/in/jphe/storyvox/feature/reader/HybridReaderScreen.kt
@@ -85,6 +85,11 @@ fun HybridReaderScreen(
                 onOpenChat = {
                     playback.fictionId?.let { onOpenChat(it, null) }
                 },
+                // Issue #278 — surface loading-phase + retry path. The
+                // view decides what to render based on phase (regular /
+                // slow-hint at 10s / full error block at 30s).
+                loadingPhase = state.loadingPhase,
+                onRetryLoading = viewModel::retryLoading,
             )
         },
         readerContent = {

--- a/feature/src/main/kotlin/in/jphe/storyvox/feature/reader/ReaderViewModel.kt
+++ b/feature/src/main/kotlin/in/jphe/storyvox/feature/reader/ReaderViewModel.kt
@@ -15,12 +15,15 @@ import `in`.jphe.storyvox.llm.feature.ChapterRecap
 import `in`.jphe.storyvox.ui.component.ReaderView
 import javax.inject.Inject
 import kotlinx.coroutines.Job
+import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.catch
 import kotlinx.coroutines.flow.combine
+import kotlinx.coroutines.flow.distinctUntilChanged
+import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.onCompletion
 import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.launch
@@ -30,7 +33,38 @@ data class ReaderUiState(
     val playback: UiPlaybackState? = null,
     val chapterText: String = "",
     val activePane: ReaderView = ReaderView.Audiobook,
+    /** Issue #278 — how long the player has been stuck in the "no chapter
+     *  title + no chapter text" loading state. Drives the soft slow hint
+     *  + the hard timeout/retry error path in [AudiobookView]. Reset to
+     *  [LoadingPhase.NotLoading] as soon as either piece of state arrives. */
+    val loadingPhase: LoadingPhase = LoadingPhase.NotLoading,
 )
+
+/** Issue #278 — the player loading screen used to be a silent eternity:
+ *  if the chapter fetch or voice-model load hung, the user stared at
+ *  "Conjuring your chapter…" forever with no retry, no error, no escape.
+ *
+ *  This sealed surface tracks progress through the loading window so
+ *  [AudiobookView] can layer in:
+ *   - a soft "Still working… (slow voice / network)" hint at 10s, and
+ *   - a hard error block with Retry / Pick a different voice / Cancel
+ *     at 30s.
+ *
+ *  Once chapter text or a chapter title arrives, the phase snaps back to
+ *  [NotLoading] regardless of where we were on the timer. */
+enum class LoadingPhase {
+    /** Player has chapter title / chapter text — not loading. */
+    NotLoading,
+    /** First 10s of a fresh load — show the regular sigil + copy. */
+    Loading,
+    /** 10-30s into a load — show a "Still working…" secondary line so
+     *  the user knows we haven't deadlocked. */
+    Slow,
+    /** 30s+ — surface a friendly error block with Retry / Pick voice /
+     *  Cancel. The loading flow itself isn't cancelled; we just give the
+     *  user a way out. */
+    TimedOut,
+}
 
 /** UI state for the Chapter Recap modal. Sealed because the
  *  states are mutually exclusive — at any given moment the modal is
@@ -99,13 +133,76 @@ class ReaderViewModel @Inject constructor(
      *  billing). */
     private var recapJob: Job? = null
 
+    /** Issue #278 — derive a `isLoading` boolean directly from the
+     *  playback state so we can drive a timer off it. "Loading" matches
+     *  the same condition AudiobookView already uses for the brass
+     *  spinner: no chapter title yet AND no chapter text yet. As soon as
+     *  either arrives the flow flips false and the timer below resets. */
+    private val isLoading: StateFlow<Boolean> = combine(
+        playback.state,
+        playback.chapterText,
+    ) { state, text ->
+        state.chapterTitle.isBlank() && text.isBlank()
+    }.distinctUntilChanged().stateIn(
+        viewModelScope, SharingStarted.WhileSubscribed(5_000), true,
+    )
+
+    /** Issue #278 — phase tracker. When the loading edge flips true we
+     *  fire a coroutine that walks Loading → Slow (10s) → TimedOut (30s).
+     *  When it flips false we cancel the timer and reset to NotLoading.
+     *
+     *  The thresholds match the values called out in the issue body:
+     *  10s for the soft slow hint, 30s for the hard error path. They're
+     *  intentionally non-private so the unit test can pin them. */
+    private val _loadingPhase = MutableStateFlow(LoadingPhase.Loading)
+    private var loadingTimerJob: Job? = null
+
+    init {
+        viewModelScope.launch {
+            isLoading.collect { loading ->
+                loadingTimerJob?.cancel()
+                if (!loading) {
+                    _loadingPhase.value = LoadingPhase.NotLoading
+                    return@collect
+                }
+                _loadingPhase.value = LoadingPhase.Loading
+                loadingTimerJob = launch {
+                    delay(LOADING_SLOW_HINT_MS)
+                    _loadingPhase.value = LoadingPhase.Slow
+                    delay(LOADING_TIMEOUT_MS - LOADING_SLOW_HINT_MS)
+                    _loadingPhase.value = LoadingPhase.TimedOut
+                }
+            }
+        }
+    }
+
     val uiState: StateFlow<ReaderUiState> = combine(
         playback.state,
         playback.chapterText,
         _activePane,
-    ) { state, text, pane ->
-        ReaderUiState(playback = state, chapterText = text, activePane = pane)
+        _loadingPhase,
+    ) { state, text, pane, phase ->
+        ReaderUiState(
+            playback = state,
+            chapterText = text,
+            activePane = pane,
+            loadingPhase = phase,
+        )
     }.stateIn(viewModelScope, SharingStarted.WhileSubscribed(5_000), ReaderUiState())
+
+    /** Issue #278 — user-initiated retry from the timed-out error block.
+     *  Re-invokes the playback `play()` path; the underlying controller
+     *  will re-fetch the chapter / re-prime the voice. We also reset the
+     *  loading phase so the UI immediately shows the regular spinner
+     *  instead of staying on the error block.
+     *
+     *  No fictionId/chapterId check — the playback controller is the
+     *  source of truth for what's "currently loaded"; if neither is set,
+     *  play() is a documented no-op. */
+    fun retryLoading() {
+        _loadingPhase.value = LoadingPhase.Loading
+        playback.play()
+    }
 
     fun setActivePane(pane: ReaderView) { _activePane.value = pane }
 
@@ -216,6 +313,23 @@ class ReaderViewModel @Inject constructor(
         viewModelScope.launch {
             playback.speakText(text)
         }
+    }
+
+    companion object {
+        /** Issue #278 — soft hint threshold. After 10s of being stuck in
+         *  the loading state, the AudiobookView adds a "Still working…
+         *  (slow voice / network)" secondary line under the conjuring
+         *  copy. The threshold is conservative — real warmups on Flip3
+         *  routinely take 5-8s, so 10s is the cutoff between "expected"
+         *  and "starting to feel off." */
+        const val LOADING_SLOW_HINT_MS = 10_000L
+
+        /** Issue #278 — hard timeout threshold. At 30s we flip to a
+         *  user-actionable error: Retry / Pick voice / Cancel. The
+         *  underlying load isn't cancelled — if it eventually completes
+         *  the regular state flow takes over again — but the user has
+         *  a way out of the conjuring screen instead of staring forever. */
+        const val LOADING_TIMEOUT_MS = 30_000L
     }
 
     private fun mapErrorToUi(e: Throwable): RecapUiState.Error = when (e) {


### PR DESCRIPTION
## Summary
- The player loading screen ('Conjuring your chapter…') was a silent eternity: hung loads stared at the brass sigil forever with no retry, no error, no escape.
- New \`LoadingPhase\` (NotLoading / Loading / Slow / TimedOut) is computed in \`ReaderViewModel\` from the same \"chapterTitle + chapterText both blank\" condition the view already used for the cover spinner.
- AudiobookView layers in:
  - At 10s — a soft \"Still working… slow voice or network\" secondary line.
  - At 30s — a full-screen \`ErrorBlock\` with **Try again** + **Pick a different voice**.

## What changed
- \`feature/.../reader/ReaderViewModel.kt\`
  - Added \`LoadingPhase\` enum + \`loadingPhase\` field on \`ReaderUiState\`.
  - Added \`isLoading\` derived StateFlow + a coroutine timer (\`LOADING_SLOW_HINT_MS = 10_000\`, \`LOADING_TIMEOUT_MS = 30_000\`).
  - Added \`retryLoading()\` action — resets phase to \`Loading\` and re-invokes \`playback.play()\`.
- \`feature/.../reader/AudiobookView.kt\`
  - New optional params \`loadingPhase\`, \`onRetryLoading\`, \`onCancelLoading\` (defaults preserve preview / test callsites).
  - Early-return \`ErrorBlock\` for \`TimedOut\`; inline \`Still working…\` subtitle for \`Slow\`.
- \`feature/.../reader/HybridReaderScreen.kt\` — wires the new state + handler.

## Why this approach
The issue's spec asks for three actions on the timed-out block (Retry / Pick voice / Cancel). \`ErrorBlock\` supports two; \`Cancel\` is implicit now via the bottom nav from #267 (Library / Browse / Settings are all one tap away). Doesn't justify a new 3-action error component.

The underlying load isn't cancelled — if it eventually completes, the state flow takes over and the player resumes. The timer is purely a UX escape hatch.

Closes #278