### PR TITLE
fix(browse): render Search as icon-only tab to fit Flip3

### DIFF
--- a/feature/src/main/kotlin/in/jphe/storyvox/feature/browse/BrowseScreen.kt
+++ b/feature/src/main/kotlin/in/jphe/storyvox/feature/browse/BrowseScreen.kt
@@ -105,13 +105,33 @@ fun BrowseScreen(
                     Tab(
                         selected = tab == state.tab,
                         onClick = { viewModel.selectTab(tab) },
-                        text = {
-                            Text(
-                                text = tab.label,
-                                style = MaterialTheme.typography.labelLarge,
-                                maxLines = 1,
-                                softWrap = false,
-                            )
+                        // Issues #258 + #270 — render Search as an icon-only
+                        // tab so the row fits on Flip3 (1080px inner display
+                        // and similar narrow phones). When "Search" was a
+                        // text tab between Best Rated and the filter funnel,
+                        // it got clipped to 'S' and dragged the row into
+                        // horizontal-scroll territory, which then clipped
+                        // 'Popular' to 'ar' on the other edge. Magnifying-
+                        // glass is the universal affordance for search and
+                        // the contentDescription keeps a11y intact.
+                        icon = if (tab == BrowseTab.Search) {
+                            {
+                                Icon(
+                                    imageVector = Icons.Filled.Search,
+                                    contentDescription = "Search",
+                                    modifier = Modifier.size(20.dp),
+                                )
+                            }
+                        } else null,
+                        text = if (tab == BrowseTab.Search) null else {
+                            {
+                                Text(
+                                    text = tab.label,
+                                    style = MaterialTheme.typography.labelLarge,
+                                    maxLines = 1,
+                                    softWrap = false,
+                                )
+                            }
                         },
                     )
                 }


### PR DESCRIPTION
## Summary
- The Search **text** tab between 'Best Rated' and the filter funnel was the overflow trigger on Flip3 (1080px) and other narrow phones.
- It pushed the strip into horizontal-scroll territory, which clipped 'S' on the right edge AND clipped 'Popular' to 'ar' on the left whenever the user landed on Search/Filter.
- Render Search as an icon-only Tab (magnifying glass + contentDesc='Search'). With Popular | New | Best Rated | [icon] | filter-funnel the row fits 1080px without scroll.

## What changed
- \`feature/.../browse/BrowseScreen.kt\` — when \`tab == BrowseTab.Search\`, pass \`icon = { Icon(Search) }\` and \`text = null\`. All other tabs unchanged.

## Why this approach
The 'replace Search with a SearchBar overlay' option in the issues would require a separate expanded-search state in \`BrowseViewModel\`, threading state through every source-specific OutlinedTextField branch, and rewriting how the Search-tab text field below the tab strip works. The icon-only Tab is a stock M3 API and ships the visible fix today; the larger SearchBar refactor can land separately.

Closes #258
Closes #270