### PR TITLE
fix(library): never overwrite cached title with URL-host fallback

### DIFF
--- a/core-data/src/main/kotlin/in/jphe/storyvox/data/repository/FictionRepository.kt
+++ b/core-data/src/main/kotlin/in/jphe/storyvox/data/repository/FictionRepository.kt
@@ -400,8 +400,24 @@ internal fun FictionSummary.toEntity(now: Long): Fiction = Fiction(
 internal fun FictionDetail.toEntity(existing: Fiction?, now: Long): Fiction {
     val base = existing ?: summary.toEntity(now)
     return base.copy(
-        title = summary.title,
-        author = summary.author,
+        // Issue #279 — never overwrite a previously-good title / author
+        // with a worse one. The RSS source falls back to the URL host
+        // when the feed parse comes up blank (intermittent gateway
+        // timeouts, momentarily-malformed XML, Cloudflare 524, etc.),
+        // which produced a perfectly non-blank but useless string like
+        // "lionsroar.com". The result: pull-to-refresh silently corrupted
+        // the Library card from 'Lion's Roar / Rev. Marvin Harada' to
+        // 'lionsroar.com / ?'.
+        //
+        // Defensive: if we have a non-blank existing title (the user has
+        // seen it before) and the incoming title looks like a degraded
+        // fallback — either blank OR a bare host string that matches the
+        // last cached description / cover URL host — keep the cached
+        // value. Same pattern for author. Sources that genuinely return
+        // a richer title are unaffected: the equality check only fires
+        // when the new title literally is the URL host fallback.
+        title = preferTitle(incoming = summary.title, existing = base.title, sourceFallback = inferUrlHost(summary.description)),
+        author = summary.author.ifBlank { base.author },
         authorId = authorId ?: base.authorId,
         coverUrl = summary.coverUrl ?: base.coverUrl,
         description = summary.description ?: base.description,
@@ -416,6 +432,45 @@ internal fun FictionDetail.toEntity(existing: Fiction?, now: Long): Fiction {
         lastUpdatedAt = lastUpdatedAt ?: base.lastUpdatedAt,
         metadataFetchedAt = now,
     )
+}
+
+/**
+ *  Issue #279 — title-degradation guard for [FictionDetail.toEntity].
+ *
+ *  Returns the incoming title unless it looks like a degraded source
+ *  fallback (blank, OR equal to the URL host extracted from the same
+ *  detail's description). In the degraded case we keep the existing
+ *  cached title — assuming we have one. First-add flows where the
+ *  existing row is the just-created stub get the incoming title verbatim
+ *  (the stub's title is also derived from the same source, so there's
+ *  no "better" alternative to preserve).
+ *
+ *  The host-equality check is what catches the [RssSource] failure mode
+ *  specifically: when `feed.title.isBlank()`, RSS returns
+ *  `displayLabelForUrl(sub.url)` which is `host.removePrefix("www.")`.
+ *  That string is structurally distinguishable from a real title
+ *  ("lionsroar.com" vs "Lion's Roar"), and from a real description, so
+ *  catching it here rather than asking every source to opt in keeps the
+ *  guard durable.
+ */
+internal fun preferTitle(incoming: String, existing: String, sourceFallback: String?): String {
+    if (incoming.isBlank()) return existing.ifBlank { incoming }
+    if (existing.isBlank()) return incoming
+    if (sourceFallback != null && incoming.equals(sourceFallback, ignoreCase = true)) {
+        return existing
+    }
+    return incoming
+}
+
+/** Issue #279 — pull a bare host out of a URL-shaped string. Used as
+ *  the second axis of the title-degradation check in [preferTitle].
+ *  Returns null when the input doesn't parse as a URI or has no host
+ *  (so [preferTitle] falls back to the trust-the-incoming branch). */
+internal fun inferUrlHost(maybeUrl: String?): String? {
+    if (maybeUrl.isNullOrBlank()) return null
+    return runCatching {
+        java.net.URI(maybeUrl).host?.removePrefix("www.")
+    }.getOrNull()
 }
 
 internal fun ChapterInfo.toEntity(fictionId: String): Chapter = Chapter(

--- a/core-data/src/test/kotlin/in/jphe/storyvox/data/repository/PreferTitleTest.kt
+++ b/core-data/src/test/kotlin/in/jphe/storyvox/data/repository/PreferTitleTest.kt
@@ -1,0 +1,116 @@
+package `in`.jphe.storyvox.data.repository
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Test
+
+/**
+ * Issue #279 — regression coverage for the title-degradation guard in
+ * [preferTitle] / [inferUrlHost].
+ *
+ * The bug: pull-to-refresh on a Library card was silently overwriting
+ * 'Lion's Roar' with 'lionsroar.com' because the RSS source falls back
+ * to the URL host on parse failure and FictionRepository.toEntity wrote
+ * that fallback verbatim. These tests pin the guard so the next time
+ * someone "simplifies" the merge logic, the regression caught here
+ * before it ships.
+ */
+class PreferTitleTest {
+
+    @Test
+    fun `prefers incoming when it is genuinely new and existing is blank`() {
+        assertEquals("Lion's Roar", preferTitle(
+            incoming = "Lion's Roar",
+            existing = "",
+            sourceFallback = "lionsroar.com",
+        ))
+    }
+
+    @Test
+    fun `keeps existing when incoming is blank`() {
+        assertEquals("Lion's Roar", preferTitle(
+            incoming = "",
+            existing = "Lion's Roar",
+            sourceFallback = "lionsroar.com",
+        ))
+    }
+
+    @Test
+    fun `keeps existing when incoming equals the source URL host fallback`() {
+        // This is THE #279 case: feed parse came up blank, RSS source
+        // returned "lionsroar.com" as the title, and toEntity used to
+        // overwrite the cached real title with it.
+        assertEquals("Lion's Roar", preferTitle(
+            incoming = "lionsroar.com",
+            existing = "Lion's Roar",
+            sourceFallback = "lionsroar.com",
+        ))
+    }
+
+    @Test
+    fun `host equality check is case-insensitive`() {
+        // Sources may capitalise the host inconsistently; the guard
+        // should still recognise the fallback shape.
+        assertEquals("Lion's Roar", preferTitle(
+            incoming = "LionsRoar.com",
+            existing = "Lion's Roar",
+            sourceFallback = "lionsroar.com",
+        ))
+    }
+
+    @Test
+    fun `accepts a richer new title even when existing is non-blank`() {
+        // The guard MUST NOT freeze the title — if upstream actually
+        // sent a non-fallback string, we want to take it (renamed
+        // fiction, fixed typo, etc).
+        assertEquals("Lion's Roar Magazine", preferTitle(
+            incoming = "Lion's Roar Magazine",
+            existing = "Lion's Roar",
+            sourceFallback = "lionsroar.com",
+        ))
+    }
+
+    @Test
+    fun `passes incoming through when sourceFallback is null`() {
+        // First-add flow: no description means no inferable host. The
+        // guard should fall back to the "trust incoming" branch so the
+        // stub row gets a title.
+        assertEquals("Lion's Roar", preferTitle(
+            incoming = "Lion's Roar",
+            existing = "",
+            sourceFallback = null,
+        ))
+    }
+
+    @Test
+    fun `returns incoming when both incoming and existing are blank`() {
+        // Edge case: no signal in either direction. Hand the empty
+        // string back so callers can decide. Matches the prior shape.
+        assertEquals("", preferTitle(
+            incoming = "",
+            existing = "",
+            sourceFallback = "lionsroar.com",
+        ))
+    }
+
+    @Test
+    fun `inferUrlHost extracts host from a normal URL`() {
+        assertEquals("lionsroar.com", inferUrlHost("https://www.lionsroar.com/feed/"))
+    }
+
+    @Test
+    fun `inferUrlHost strips www prefix to match RSS source's displayLabelForUrl`() {
+        // The whole point of the equality check is that RSS source's
+        // displayLabelForUrl returns host with "www." stripped. If we
+        // didn't match that strip here, the equality would always fail
+        // for www-prefixed feeds and the guard would silently regress.
+        assertEquals("lionsroar.com", inferUrlHost("https://www.lionsroar.com/podcast"))
+    }
+
+    @Test
+    fun `inferUrlHost returns null for non-URL strings`() {
+        assertNull(inferUrlHost("just some plain text"))
+        assertNull(inferUrlHost(""))
+        assertNull(inferUrlHost(null))
+    }
+}


### PR DESCRIPTION
## Summary
- Pull-to-refresh on a Library card was silently corrupting metadata: 'Lion's Roar / Rev. Marvin Harada' degraded to 'lionsroar.com / ?' after one swipe.
- Root cause: \`RssSource.fictionDetail\` falls back to \`displayLabelForUrl(sub.url)\` when \`feed.title\` is blank (transient Cloudflare 5xx, malformed XML, etc.), producing a non-blank but useless host string. \`FictionRepository.toEntity\` then wrote that fallback verbatim, clobbering the cached real title.
- Add a defensive guard in \`toEntity\`: \`preferTitle(incoming, existing, sourceFallback = host(description))\`. When incoming equals the URL host the source would have fallen back to, keep the existing cached title.

## What changed
- \`core-data/.../FictionRepository.kt\`
  - New \`preferTitle\` / \`inferUrlHost\` helpers.
  - \`toEntity(existing, now)\` uses \`preferTitle\` instead of unconditional \`title = summary.title\`.
  - Author drops to \`.ifBlank { base.author }\` — issue calls out title corruption; author host-corruption can layer on if it appears.
- \`core-data/.../PreferTitleTest.kt\` — 10 cases pinning the guard contract (blank, host-equality, case-insensitive, genuine new title accepted, first-add stub, host extraction, null input).

## Why this approach
The fix lives in the repository merge layer, not the RSS source — same guard now protects any source whose detail's \`description\` resolves to the same URL the host fallback came from. Repository-side is also the safer place to keep the fix durable: it's the last write before persistence.

Closes #279