### PR TITLE
fix(playback): persist new chapter id on auto-advance

### DIFF
--- a/core-playback/src/main/kotlin/in/jphe/storyvox/playback/tts/EnginePlayer.kt
+++ b/core-playback/src/main/kotlin/in/jphe/storyvox/playback/tts/EnginePlayer.kt
@@ -1625,6 +1625,15 @@ class EnginePlayer @AssistedInject constructor(
         chapterRepo.queueChapterDownload(fiction, nextId, requireUnmetered = false)
         chapterRepo.observeChapter(nextId).filterNotNull().first()
         loadAndPlay(fiction, nextId, charOffset = 0)
+        // Issue #287 — persist the new chapter's id immediately so the
+        // Library "Continue listening" join sees the freshly-loaded
+        // chapter on its next emission. Without this the playback_position
+        // row stays pointed at the PREVIOUS chapter until the next save
+        // tick (e.g. user pauses, or next sentence boundary triggers a
+        // persistPosition), and the Resume card paints the new chapter's
+        // title alongside the old chapter's index/number — a confusing
+        // mismatch every auto-advance.
+        persistPosition()
         _uiEvents.tryEmit(PlaybackUiEvent.ChapterChanged(nextId))
     }
 
@@ -1632,6 +1641,8 @@ class EnginePlayer @AssistedInject constructor(
         val chapterId = _observableState.value.currentChapterId
         persistPosition()
         if (chapterId != null) chapterRepo.markChapterPlayed(chapterId)
+        // advanceChapter now persists the new chapter's id internally
+        // (issue #287 — see the comment on advanceChapter).
         advanceChapter(direction = 1)
     }
 


### PR DESCRIPTION
## Summary
- Library Resume card painted the new chapter's title alongside the previous chapter's index after auto-advance — e.g. \`Ch. 9 · The Antidote to Greed, Hatred & Ignorance\` where 'Antidote...' is actually chapter 10.
- Root cause: \`handleChapterDone\` persisted position BEFORE \`advanceChapter\`, leaving \`playback_position.chapterId\` pointed at the OLD chapter. \`advanceChapter\` then updated \`EnginePlayer\` state but never wrote a new position row — that only happened on the next user-initiated persist (pause / sentence boundary).
- Fix: call \`persistPosition()\` at the end of \`advanceChapter()\` so the new chapter's id lands in \`playback_position\` immediately, before the \`ChapterChanged\` event flows out.

## What changed
- \`core-playback/.../EnginePlayer.kt\` — append \`persistPosition()\` call to \`advanceChapter\`, after \`loadAndPlay\` returns and the observable state has been swapped to the new chapter.

## Why this approach
The leading \`persistPosition()\` in \`handleChapterDone\` still fires so the finished chapter's final \`charOffset\` gets recorded; that's the position the user would resume at if they re-opened the previous chapter. The new trailing persist guarantees the latest \`playback_position\` row always describes the chapter that is currently playing, which is the contract the Library "Continue listening" join expects.

Closes #287