### PR TITLE
fix(rr): read cover from data-src for lazy-loaded browse images

### DIFF
--- a/source-royalroad/src/main/kotlin/in/jphe/storyvox/source/royalroad/parser/BrowseParser.kt
+++ b/source-royalroad/src/main/kotlin/in/jphe/storyvox/source/royalroad/parser/BrowseParser.kt
@@ -73,7 +73,24 @@ internal object BrowseParser {
     }
 
     private fun absoluteCoverUrl(img: Element): String? {
-        val src = img.attr("src").ifEmpty { return null }
+        // Issue #283 — Royal Road's browse listing switched to lazy-loaded
+        // images sometime in late 2025: the `<img>` element now carries
+        // the real cover URL on `data-src` (or `data-lazy-src`), and
+        // the literal `src` attribute is a placeholder
+        // (typically `nocover-new-min.png` or a 1×1 pixel data URI)
+        // until JavaScript swaps it in on viewport entry. Since our
+        // parser runs on raw HTML with no JS execution, reading `src`
+        // alone yielded the placeholder and we mapped it to null →
+        // every browse card showed the brass '?' placeholder.
+        //
+        // Prefer the lazy attributes when present; fall through to
+        // `src` as a defensive fallback so the parser keeps working if
+        // RR reverts to non-lazy markup. The placeholder check below
+        // still strips the nocover sentinel either way.
+        val src = listOf("data-src", "data-lazy-src", "src")
+            .map { img.attr(it) }
+            .firstOrNull { it.isNotBlank() && !it.startsWith("data:") }
+            ?: return null
         if (src.endsWith("/dist/img/nocover-new-min.png")) return null
         return when {
             src.startsWith("http") -> src

--- a/source-royalroad/src/main/kotlin/in/jphe/storyvox/source/royalroad/parser/FollowsParser.kt
+++ b/source-royalroad/src/main/kotlin/in/jphe/storyvox/source/royalroad/parser/FollowsParser.kt
@@ -54,7 +54,16 @@ internal object FollowsParser {
         val fictionId = extractFictionIdFromHref(href) ?: return null
         val title = titleAnchor.text().trim().ifEmpty { return null }
 
-        val cover = row.selectFirst("figure img")?.let { absoluteCoverUrl(it.attr("src")) }
+        val cover = row.selectFirst("figure img")?.let { img ->
+            // Issue #283 — prefer the lazy-load src attributes so we get
+            // the real cover instead of the placeholder. See the kdoc
+            // on BrowseParser.absoluteCoverUrl for the full story.
+            val raw = listOf("data-src", "data-lazy-src", "src")
+                .map { img.attr(it) }
+                .firstOrNull { it.isNotBlank() && !it.startsWith("data:") }
+                ?: ""
+            absoluteCoverUrl(raw)
+        }
 
         val tags = row.select("a.fiction-tag").mapNotNull { tag ->
             tag.attr("href").substringAfter("tagsAdd=", "").substringBefore("&").trim()


### PR DESCRIPTION
## Summary
- Every Royal Road browse card displayed the brass '?' placeholder. Real RR covers never loaded.
- Root cause: RR's browse listing lazy-loads cover images — \`<figure img src=…>\` is a placeholder (\`nocover-new-min.png\` or a 1×1 pixel data URI) until JS swaps in the real URL on viewport entry. Our parser runs on raw HTML with no JS execution, so it only ever saw the placeholder and mapped it to null.
- Read \`data-src\` / \`data-lazy-src\` first, fall through to \`src\` as defensive fallback. Skip \`data:\` URIs explicitly.

## What changed
- \`source-royalroad/.../BrowseParser.kt\` — multi-attr lookup with comment explaining the failure mode.
- \`source-royalroad/.../FollowsParser.kt\` — same lookup pattern (same browse-row shape).
- \`FictionDetailParser\` untouched: it reads from JSON-LD \`image\`, which is server-rendered and unaffected.

## Why this approach
Defensive lookup order (\`data-src\` → \`data-lazy-src\` → \`src\`) keeps the parser working if RR ever reverts to non-lazy markup. Skipping \`data:\` URIs prevents 1×1 placeholders from being treated as real covers.

Closes #283