### PR TITLE
feat(library): auto-add fiction to library on Listen tap

### DIFF
--- a/feature/src/main/kotlin/in/jphe/storyvox/feature/fiction/FictionDetailViewModel.kt
+++ b/feature/src/main/kotlin/in/jphe/storyvox/feature/fiction/FictionDetailViewModel.kt
@@ -79,6 +79,16 @@ class FictionDetailViewModel @Inject constructor(
     }
 
     fun listen(chapterId: String) {
+        // Issue #288 — tapping Listen is a stronger intent than tapping
+        // 'Add to library'. The user is committing to listen RIGHT NOW.
+        // Silently follow the fiction if it isn't already in their
+        // library so it survives app restart and the Resume card can
+        // surface it on Library. Mirror the gesture-only-add pattern
+        // (no confirm dialog) — remove-from-library still requires the
+        // explicit AlertDialog from issue #169.
+        if (!uiState.value.isInLibrary) {
+            viewModelScope.launch { repo.follow(fictionId, true) }
+        }
         playback.startListening(fictionId, chapterId)
         viewModelScope.launch { _events.send(FictionDetailUiEvent.OpenReader(fictionId, chapterId)) }
     }


### PR DESCRIPTION
## Summary
- Tapping Listen from Browse → Fiction detail started playback but left the fiction outside Library. Users could sample several chapters then lose their way back after restart — the fiction simply wasn't in any UI surface they'd check.
- Listen is a stronger intent than Add-to-library; the user is committing to listen NOW. Silently follow the fiction at listen time so it survives restart and the Resume card surfaces it.

## What changed
- \`feature/.../fiction/FictionDetailViewModel.kt\` — \`listen(chapterId)\` checks \`uiState.value.isInLibrary\` and calls \`repo.follow(fictionId, true)\` if not already in. No-op when already in the library.

## Why this approach
Mirrors the existing gesture-only-add pattern from \`#169\`: additive single-tap path, no confirm dialog. Remove-from-library still gates behind the explicit AlertDialog. The cleanest seam is the ViewModel — the playback layer doesn't have a FictionRepository dep, and the Listen button is the trigger we want.

Closes #288