### PR TITLE
fix(library): chapter-played indicator updates after auto-advance

### DIFF
--- a/app/src/main/kotlin/in/jphe/storyvox/di/AppBindings.kt
+++ b/app/src/main/kotlin/in/jphe/storyvox/di/AppBindings.kt
@@ -305,7 +305,17 @@ private class RealFictionRepositoryUi(
         chapters.getChapter(chapterId)?.text
 
     override fun chaptersFor(fictionId: String): Flow<List<UiChapter>> =
-        repo.observeFiction(fictionId).map { detail ->
+        // Issue #282 — the previous mapping hard-coded `isFinished = false`,
+        // so the played-indicator on the Fiction detail chapter list never
+        // updated after auto-advance (or any markChapterPlayed call). Now
+        // combine the chapter list with the observable set of "user marked
+        // played" chapter ids so the circle fills as soon as the DB row
+        // flips. Both flows are Room-backed and re-emit on any relevant
+        // write; downstream combine fires once with whichever lands last.
+        kotlinx.coroutines.flow.combine(
+            repo.observeFiction(fictionId),
+            chapters.observePlayedChapterIds(fictionId),
+        ) { detail, playedIds ->
             detail?.chapters.orEmpty().map { ch ->
                 UiChapter(
                     id = ch.id,
@@ -314,7 +324,7 @@ private class RealFictionRepositoryUi(
                     publishedRelative = relativeTime(ch.publishedAt),
                     durationLabel = ch.wordCount?.let { "${(it / 250).coerceAtLeast(1)} min" } ?: "",
                     isDownloaded = false,
-                    isFinished = false,
+                    isFinished = ch.id in playedIds,
                 )
             }
         }

--- a/app/src/test/kotlin/in/jphe/storyvox/di/RealPlaybackControllerUiTest.kt
+++ b/app/src/test/kotlin/in/jphe/storyvox/di/RealPlaybackControllerUiTest.kt
@@ -303,6 +303,10 @@ class RealPlaybackControllerUiTest {
         override fun observeChapter(chapterId: String): Flow<ChapterContent?> = flowOf(null)
         override fun observeDownloadState(fictionId: String): Flow<Map<String, ChapterDownloadState>> =
             flowOf(emptyMap())
+        // Issue #282 — played-chapter set query, added so the chapter-list
+        // flow can compute `isFinished` after auto-advance. No-op here.
+        override fun observePlayedChapterIds(fictionId: String): Flow<Set<String>> =
+            flowOf(emptySet())
         override suspend fun queueChapterDownload(
             fictionId: String,
             chapterId: String,

--- a/core-data/src/main/kotlin/in/jphe/storyvox/data/db/dao/ChapterDao.kt
+++ b/core-data/src/main/kotlin/in/jphe/storyvox/data/db/dao/ChapterDao.kt
@@ -42,6 +42,22 @@ interface ChapterDao {
     @Query("SELECT id, downloadState FROM chapter WHERE fictionId = :fictionId")
     fun observeDownloadStates(fictionId: String): Flow<List<ChapterDownloadStateRow>>
 
+    /**
+     * Issue #282 — observable per-fiction "which chapters are played"
+     * projection, separate from [observeChapterInfosByFiction]. Reading
+     * `userMarkedRead` would mean adding the column to [ChapterInfoRow]
+     * (which mirrors the source-side [ChapterInfo] model and is a 1:1
+     * mapper today) or denormalizing the chapter list. A slim sibling
+     * flow keeps the source/UI contract intact: AppBindings combines
+     * the chapter-list flow with this set to compute `isFinished`.
+     *
+     * Selecting only the rows where `userMarkedRead = 1` keeps the
+     * emission small for users with mostly-unplayed long fictions; the
+     * combine in AppBindings does a set-contains check per chapter.
+     */
+    @Query("SELECT id FROM chapter WHERE fictionId = :fictionId AND userMarkedRead = 1")
+    fun observePlayedChapterIds(fictionId: String): Flow<List<String>>
+
     @Query(
         """
         SELECT * FROM chapter

--- a/core-data/src/main/kotlin/in/jphe/storyvox/data/repository/ChapterRepository.kt
+++ b/core-data/src/main/kotlin/in/jphe/storyvox/data/repository/ChapterRepository.kt
@@ -25,6 +25,16 @@ interface ChapterRepository {
 
     fun observeDownloadState(fictionId: String): Flow<Map<String, ChapterDownloadState>>
 
+    /**
+     * Issue #282 — observable set of chapter ids the user has marked
+     * played for this fiction. The UI combines this with [observeChapters]
+     * to render the `isFinished` indicator on each chapter row. Distinct
+     * from [observeDownloadState] because download-state and play-state
+     * are independent axes (a chapter may be downloaded but unplayed,
+     * or played without being downloaded if streamed live).
+     */
+    fun observePlayedChapterIds(fictionId: String): Flow<Set<String>>
+
     /** Schedule a single chapter download via WorkManager. */
     suspend fun queueChapterDownload(
         fictionId: String,
@@ -83,6 +93,9 @@ class ChapterRepositoryImpl @Inject constructor(
                 notesAuthorPosition = row.notesAuthorPosition,
             )
         }
+
+    override fun observePlayedChapterIds(fictionId: String): Flow<Set<String>> =
+        dao.observePlayedChapterIds(fictionId).map { it.toSet() }
 
     override fun observeDownloadState(fictionId: String): Flow<Map<String, ChapterDownloadState>> =
         dao.observeDownloadStates(fictionId).map { rows ->

--- a/core-data/src/test/kotlin/in/jphe/storyvox/data/repository/ChapterRepositoryImplTest.kt
+++ b/core-data/src/test/kotlin/in/jphe/storyvox/data/repository/ChapterRepositoryImplTest.kt
@@ -76,6 +76,12 @@ class ChapterRepositoryImplTest {
         override fun observeDownloadStates(fictionId: String): Flow<List<ChapterDownloadStateRow>> =
             stateFeeds.getOrPut(fictionId) { MutableStateFlow(stateRows(fictionId)) }
 
+        // Issue #282 — played-chapter set query for the chapter-list
+        // `isFinished` indicator. The dao tests don't exercise played
+        // tracking; emit empty so the new override compiles.
+        override fun observePlayedChapterIds(fictionId: String): Flow<List<String>> =
+            MutableStateFlow(emptyList())
+
         override suspend fun missingForFiction(fictionId: String): List<Chapter> {
             callLog += "missingForFiction($fictionId)"
             return rows.values

--- a/core-data/src/test/kotlin/in/jphe/storyvox/data/repository/FictionRepositoryImplTest.kt
+++ b/core-data/src/test/kotlin/in/jphe/storyvox/data/repository/FictionRepositoryImplTest.kt
@@ -238,6 +238,12 @@ class FictionRepositoryImplTest {
         override fun observeDownloadStates(fictionId: String): Flow<List<ChapterDownloadStateRow>> =
             MutableStateFlow(emptyList())
 
+        // Issue #282 — played-chapter set query. FictionRepository tests
+        // don't exercise played tracking; emit empty so the override
+        // compiles.
+        override fun observePlayedChapterIds(fictionId: String): Flow<List<String>> =
+            MutableStateFlow(emptyList())
+
         override suspend fun missingForFiction(fictionId: String): List<Chapter> =
             rows.values.filter {
                 it.fictionId == fictionId && it.downloadState == ChapterDownloadState.NOT_DOWNLOADED


### PR DESCRIPTION
## Summary
- The chapter row's right-side circle on Fiction detail never filled in after a chapter finished (auto-advance or manual \`markChapterPlayed\`).
- Root cause: AppBindings's \`chaptersFor\` mapper hard-coded \`isFinished = false\`. The UI was wired correctly, but the value was never sourced from the DB.

## What changed
- \`core-data/.../ChapterDao.kt\` — new \`observePlayedChapterIds(fictionId): Flow<List<String>>\` selecting chapter ids where \`userMarkedRead = 1\`.
- \`core-data/.../ChapterRepository.kt\` — new \`observePlayedChapterIds(fictionId): Flow<Set<String>>\` interface + impl.
- \`app/.../AppBindings.kt\` — \`chaptersFor\` combines \`repo.observeFiction\` with the new set; \`isFinished = ch.id in playedIds\`.
- Test stubs in \`:app\` and \`:core-data\` updated with no-op overrides.

## Why this approach
A slim sibling flow keeps the source-side \`ChapterInfo\` contract intact (no need to thread \`userMarkedRead\` through the source data class). The query only returns played ids, so emissions stay small for users with mostly-unplayed long fictions.

Closes #282