### PR TITLE
fix(browse): per-source subtitle on Search empty state

### DIFF
--- a/feature/src/main/kotlin/in/jphe/storyvox/feature/browse/BrowseScreen.kt
+++ b/feature/src/main/kotlin/in/jphe/storyvox/feature/browse/BrowseScreen.kt
@@ -187,7 +187,7 @@ fun BrowseScreen(
 
         when {
             state.isLoading && state.items.isEmpty() -> SkeletonGrid()
-            state.tab == BrowseTab.Search && state.query.isBlank() && !state.isFilterActive -> SearchHint()
+            state.tab == BrowseTab.Search && state.query.isBlank() && !state.isFilterActive -> SearchHint(state.sourceKey)
             // First-load failure with no cached items: full-screen error.
             // Retry triggers viewModel.loadMore() which the paginator
             // resolves to the same page that failed.
@@ -405,7 +405,7 @@ private fun SkeletonGrid() {
 }
 
 @Composable
-private fun SearchHint() {
+private fun SearchHint(sourceKey: BrowseSourceKey) {
     val spacing = LocalSpacing.current
     Box(modifier = Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
         Column(
@@ -423,14 +423,29 @@ private fun SearchHint() {
                 style = MaterialTheme.typography.titleMedium,
                 color = MaterialTheme.colorScheme.onSurface,
             )
+            // Issue #271 — per-source empty-state subtitle. The old copy
+            // hard-coded "across Royal Road" even when RSS/GitHub/etc. was
+            // the selected source. Pick the right phrase from the source
+            // key — each source has its own corpus shape (RSS = "your
+            // subscribed feeds", GitHub = "indexed repositories", etc.).
             Text(
-                "Find fictions across Royal Road",
+                searchHintForSource(sourceKey),
                 style = MaterialTheme.typography.bodySmall,
                 color = MaterialTheme.colorScheme.onSurfaceVariant,
             )
             Spacer(Modifier.height(spacing.xxl))
         }
     }
+}
+
+/** Issue #271 — per-source subtitle for the Search empty state. */
+private fun searchHintForSource(sourceKey: BrowseSourceKey): String = when (sourceKey) {
+    BrowseSourceKey.RoyalRoad -> "Find fictions across Royal Road"
+    BrowseSourceKey.GitHub -> "Search indexed GitHub repositories"
+    BrowseSourceKey.MemPalace -> "Search your MemPalace knowledge base"
+    BrowseSourceKey.Rss -> "Search your subscribed feeds"
+    BrowseSourceKey.Epub -> "Search your local EPUB library"
+    BrowseSourceKey.Outline -> "Search your Outline notes"
 }
 
 private val BrowseTab.label: String


### PR DESCRIPTION
## Summary
- The Search tab's empty-state subtitle hard-coded "Find fictions across Royal Road" even when RSS / GitHub / MemPalace / EPUB / Outline was selected.
- Carry the source key through \`SearchHint\` and switch on it for the right phrase per source corpus shape.

## What changed
- \`feature/.../browse/BrowseScreen.kt\` — \`SearchHint(sourceKey: BrowseSourceKey)\`, new \`searchHintForSource\` helper with per-source strings.

Closes #271