### PR TITLE
fix(settings): single back-nav pattern across all sub-screens

### DIFF
--- a/feature/src/main/kotlin/in/jphe/storyvox/feature/settings/pronunciation/PronunciationDictScreen.kt
+++ b/feature/src/main/kotlin/in/jphe/storyvox/feature/settings/pronunciation/PronunciationDictScreen.kt
@@ -9,9 +9,13 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.itemsIndexed
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.ArrowBack
 import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.Divider
 import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.Scaffold
@@ -61,7 +65,23 @@ fun PronunciationDictScreen(
     var editor by remember { mutableStateOf<EditorTarget?>(null) }
 
     Scaffold(
-        topBar = { TopAppBar(title = { Text("Pronunciation") }) },
+        topBar = {
+            TopAppBar(
+                title = { Text("Pronunciation") },
+                // Issues #275 + #276 — standardize the back affordance
+                // across all settings sub-screens to the TopAppBar arrow
+                // (matching Sessions). The old inline 'Back' BrassButton
+                // mid-screen was iOS-style and the only one of its kind.
+                navigationIcon = {
+                    IconButton(onClick = onBack) {
+                        Icon(
+                            Icons.AutoMirrored.Filled.ArrowBack,
+                            contentDescription = "Back",
+                        )
+                    }
+                },
+            )
+        },
     ) { padding ->
         Column(
             modifier = Modifier.fillMaxSize().padding(padding).padding(spacing.md),
@@ -107,13 +127,10 @@ fun PronunciationDictScreen(
                 }
             }
 
-            Box(modifier = Modifier.fillMaxWidth()) {
-                BrassButton(
-                    label = "Back",
-                    onClick = onBack,
-                    variant = BrassButtonVariant.Text,
-                )
-            }
+            // Issues #275 + #276 — the inline 'Back' BrassButton that
+            // used to live here was iOS-modal style and the only such
+            // affordance in the settings stack. Back-navigation is now
+            // exclusively the TopAppBar arrow above (and OS gesture-back).
         }
 
         editor?.let { target ->

--- a/feature/src/main/kotlin/in/jphe/storyvox/feature/voicelibrary/VoiceLibraryScreen.kt
+++ b/feature/src/main/kotlin/in/jphe/storyvox/feature/voicelibrary/VoiceLibraryScreen.kt
@@ -19,6 +19,7 @@ import androidx.compose.foundation.lazy.itemsIndexed
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.ArrowBack
 import androidx.compose.material.icons.filled.Star
 import androidx.compose.material.icons.outlined.Check
 import androidx.compose.material.icons.outlined.ExpandLess
@@ -26,6 +27,7 @@ import androidx.compose.material.icons.outlined.ExpandMore
 import androidx.compose.material.icons.outlined.StarBorder
 import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.SnackbarHost
@@ -76,6 +78,21 @@ fun VoiceLibraryScreen(
         topBar = {
             TopAppBar(
                 title = { Text("Voice library") },
+                // Issues #275 + #276 — all settings sub-screens get a
+                // back arrow on the left of the TopAppBar, matching the
+                // Sessions screen pattern (which is already canonical).
+                // Voice library had a TopAppBar but no navigationIcon;
+                // Pronunciation had no TopAppBar at all and a bare
+                // 'Back' BrassButton mid-screen — three different
+                // patterns for the same role across three screens.
+                navigationIcon = {
+                    IconButton(onClick = onBack) {
+                        Icon(
+                            Icons.AutoMirrored.Filled.ArrowBack,
+                            contentDescription = "Back",
+                        )
+                    }
+                },
             )
         },
         snackbarHost = { SnackbarHost(snackbar) },


### PR DESCRIPTION
## Summary
Three different back-navigation patterns lived in the Settings sub-screens:
- **Voice library**: TopAppBar without back arrow → only gesture works
- **Pronunciation**: TopAppBar + inline BrassButton 'Back' (iOS modal style, only of its kind)
- **Sessions**: TopAppBar with back arrow + title (Material 3 standard)

Promote Sessions to canonical:

## What changed
- \`feature/.../voicelibrary/VoiceLibraryScreen.kt\` — add \`navigationIcon = IconButton(...)\` on the existing TopAppBar.
- \`feature/.../settings/pronunciation/PronunciationDictScreen.kt\` — same \`navigationIcon\`; remove the inline BrassButton 'Back' (duplicate affordance).
- Sessions already canonical (no change).
- Settings → Developer → Debug (added in #289) already uses arrow back too — no further work.

Closes #275
Closes #276