### PR TITLE
fix(settings): destructive 'Forget AI' gets error tint + confirm dialog

### DIFF
--- a/feature/src/main/kotlin/in/jphe/storyvox/feature/settings/SettingsScreen.kt
+++ b/feature/src/main/kotlin/in/jphe/storyvox/feature/settings/SettingsScreen.kt
@@ -49,8 +49,9 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
-import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.text.KeyboardOptions
+import androidx.compose.material.icons.outlined.DeleteOutline
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
@@ -1864,11 +1865,57 @@ private fun AiSection(
                 onSetEntireBookSoFar = onSetChatGroundEntireBookSoFar,
             )
         }
-        BrassButton(
-            label = "Forget all AI settings",
-            onClick = onResetAi,
-            variant = BrassButtonVariant.Text,
-        )
+        // Issue #262 — destructive AI-reset path. Previously a plain
+        // brass-tinted TextButton that looked identical to a 'Save' or
+        // 'Show' affordance. Now error-tinted with a leading Delete icon
+        // + a confirmation AlertDialog so a single mis-tap can't erase
+        // every endpoint URL, API key, and chat history.
+        var showResetAiConfirm by androidx.compose.runtime.remember { androidx.compose.runtime.mutableStateOf(false) }
+        androidx.compose.material3.TextButton(
+            onClick = { showResetAiConfirm = true },
+            colors = androidx.compose.material3.ButtonDefaults.textButtonColors(
+                contentColor = MaterialTheme.colorScheme.error,
+            ),
+        ) {
+            androidx.compose.material3.Icon(
+                imageVector = androidx.compose.material.icons.Icons.Outlined.DeleteOutline,
+                contentDescription = null,
+                tint = MaterialTheme.colorScheme.error,
+            )
+            Spacer(androidx.compose.ui.Modifier.size(8.dp))
+            Text("Forget all AI settings")
+        }
+        if (showResetAiConfirm) {
+            androidx.compose.material3.AlertDialog(
+                onDismissRequest = { showResetAiConfirm = false },
+                title = { Text("Forget all AI settings?") },
+                text = {
+                    Text(
+                        "This erases your endpoint URLs, API keys, model " +
+                            "selections, and chat session history. " +
+                            "You'll need to re-enter every provider's " +
+                            "credentials to use AI features again.",
+                    )
+                },
+                confirmButton = {
+                    BrassButton(
+                        label = "Forget everything",
+                        onClick = {
+                            showResetAiConfirm = false
+                            onResetAi()
+                        },
+                        variant = BrassButtonVariant.Primary,
+                    )
+                },
+                dismissButton = {
+                    BrassButton(
+                        label = "Cancel",
+                        onClick = { showResetAiConfirm = false },
+                        variant = BrassButtonVariant.Secondary,
+                    )
+                },
+            )
+        }
     }
     }
 }


### PR DESCRIPTION
## Summary
'Forget all AI settings' was a plain brass-tinted TextButton, visually identical to 'Save' / 'Show'. Single tap erased every endpoint URL, API key, model selection, and chat history with zero confirmation.

## What changed
- \`feature/.../settings/SettingsScreen.kt\`
  - Replace the BrassButton.Text with a Material TextButton tinted \`colorScheme.error\` + leading \`Icons.Outlined.DeleteOutline\` icon.
  - Tap shows an AlertDialog with the scope of the deletion. Primary confirm = 'Forget everything'; Secondary 'Cancel' dismisses.

## Why this approach
Mirrors the destructive-confirm pattern from issue #169 (Fiction detail remove-from-library). No new shared component — single-instance use, inline implementation keeps the diff focused. A reusable \`DestructiveSettingsRow\` can come later if Settings grows more destructive paths.

Closes #262