### PR TITLE
fix(browse): add ellipsis when fiction title / author truncate

### DIFF
--- a/feature/src/main/kotlin/in/jphe/storyvox/feature/browse/BrowseScreen.kt
+++ b/feature/src/main/kotlin/in/jphe/storyvox/feature/browse/BrowseScreen.kt
@@ -283,9 +283,27 @@ fun BrowseScreen(
                                 authorInitial = fiction.author.firstOrNull()?.uppercaseChar() ?: '?',
                                 modifier = Modifier.fillMaxWidth(),
                             )
-                            Text(fiction.title, style = MaterialTheme.typography.titleSmall, maxLines = 2)
+                            // Issue #272 — titles longer than 2 lines were silently
+                            // cut mid-token ("…[Vols", "…(OP", "the I"), reading as
+                            // broken data rather than UI truncation. Set
+                            // overflow = Ellipsis so the cut becomes "…" and the
+                            // user knows the text continues. Author already has
+                            // the same treatment below (maxLines = 1) but no
+                            // overflow set; same fix.
+                            Text(
+                                fiction.title,
+                                style = MaterialTheme.typography.titleSmall,
+                                maxLines = 2,
+                                overflow = androidx.compose.ui.text.style.TextOverflow.Ellipsis,
+                            )
                             if (fiction.author.isNotBlank()) {
-                                Text(fiction.author, style = MaterialTheme.typography.bodySmall, color = MaterialTheme.colorScheme.onSurfaceVariant, maxLines = 1)
+                                Text(
+                                    fiction.author,
+                                    style = MaterialTheme.typography.bodySmall,
+                                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                                    maxLines = 1,
+                                    overflow = androidx.compose.ui.text.style.TextOverflow.Ellipsis,
+                                )
                             }
                         }
                     }


### PR DESCRIPTION
## Summary
Browse card titles allowed two lines and silently cut at line 2 with no ellipsis — long titles read as broken data ("…[Vols", "…(OP", "the I"). Set \`overflow = TextOverflow.Ellipsis\` on title (maxLines=2) and author (maxLines=1) so the cut becomes "…".

## What changed
- \`feature/.../browse/BrowseScreen.kt\` — overflow param on the title + author Text composables.

Closes #272