### PR TITLE
fix(library): strip redundant 'Ch. N -' prefix from chapter rows

### DIFF
--- a/core-ui/src/main/kotlin/in/jphe/storyvox/ui/component/ChapterCard.kt
+++ b/core-ui/src/main/kotlin/in/jphe/storyvox/ui/component/ChapterCard.kt
@@ -82,7 +82,14 @@ fun ChapterCard(
             )
             Column(modifier = Modifier.weight(1f)) {
                 Text(
-                    state.title,
+                    // Issue #256 — the left-side brass index already shows the
+                    // chapter number (e.g. "06"), so titles that start with
+                    // their own "Ch. N -" / "Chapter N:" prefix produced two
+                    // numbers racing on the same row: brass '06' + 'CH. 116
+                    // - Insurmountable Foe'. Strip the redundant prefix so
+                    // the visible title is the actual title; the brass
+                    // numeral remains the canonical chapter number.
+                    stripChapterPrefix(state.title),
                     style = MaterialTheme.typography.titleMedium,
                     maxLines = 2,
                 )
@@ -111,4 +118,28 @@ fun ChapterCard(
             )
         }
     }
+}
+
+/**
+ * Issue #256 — strip a redundant chapter-number prefix from a chapter
+ * title. RR titles routinely look like:
+ *   "Ch. 116 - Insurmountable Foe"
+ *   "Chapter 7: The Brass Sigil"
+ *   "Ch.7 - Greed"
+ *   "CH. 0 - "
+ * which collide with the brass left-side index. The regex covers the
+ * common shapes; if no prefix matches the title is returned untouched
+ * so non-conforming sources (mdbook chapters, RSS items) keep rendering
+ * as-is. The trailing colon strip in #265 lives at a different layer
+ * (source side) but the same intent — collapse double signals into one.
+ */
+internal fun stripChapterPrefix(title: String): String {
+    // Matches: optional `Ch`/`Chapter` (case-insensitive), optional `.`,
+    // whitespace, integer, optional whitespace + dash/colon/em-dash,
+    // followed by optional whitespace.
+    val regex = Regex("^(?:ch(?:apter)?\\.?)\\s*\\d+\\s*[-:—–]\\s*", RegexOption.IGNORE_CASE)
+    val stripped = regex.replaceFirst(title, "").trim()
+    // Don't return an empty string — that'd render as a blank row.
+    // Fall back to the original if stripping leaves nothing readable.
+    return stripped.ifEmpty { title }
 }

--- a/core-ui/src/test/kotlin/in/jphe/storyvox/ui/component/StripChapterPrefixTest.kt
+++ b/core-ui/src/test/kotlin/in/jphe/storyvox/ui/component/StripChapterPrefixTest.kt
@@ -1,0 +1,64 @@
+package `in`.jphe.storyvox.ui.component
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+/**
+ * Issue #256 — regression coverage for the chapter-title prefix strip
+ * that runs in the ChapterCard composable. The brass left-side index
+ * already shows the chapter number; titles like "Ch. 116 - Insurmountable
+ * Foe" used to render two numbers racing on the same row.
+ */
+class StripChapterPrefixTest {
+
+    @Test
+    fun `strips the common Ch dot N dash variant`() {
+        assertEquals("Insurmountable Foe", stripChapterPrefix("Ch. 116 - Insurmountable Foe"))
+    }
+
+    @Test
+    fun `strips Chapter N colon variant`() {
+        assertEquals("The Brass Sigil", stripChapterPrefix("Chapter 7: The Brass Sigil"))
+    }
+
+    @Test
+    fun `strips Ch dot N space-less variant`() {
+        // RR titles occasionally drop the space after the period.
+        assertEquals("Greed", stripChapterPrefix("Ch.7 - Greed"))
+    }
+
+    @Test
+    fun `case-insensitive match`() {
+        assertEquals("Insurmountable Foe", stripChapterPrefix("CH. 116 - Insurmountable Foe"))
+        assertEquals("Insurmountable Foe", stripChapterPrefix("ch. 116 - Insurmountable Foe"))
+        assertEquals("Brass Sigil", stripChapterPrefix("CHAPTER 7: Brass Sigil"))
+    }
+
+    @Test
+    fun `em-dash and en-dash separators`() {
+        assertEquals("Greed", stripChapterPrefix("Ch. 7 — Greed"))
+        assertEquals("Greed", stripChapterPrefix("Ch. 7 – Greed"))
+    }
+
+    @Test
+    fun `untouched when title has no prefix`() {
+        assertEquals("The Brass Sigil", stripChapterPrefix("The Brass Sigil"))
+        assertEquals("Lion's Roar Is Hiring a Copy Editor", stripChapterPrefix("Lion's Roar Is Hiring a Copy Editor"))
+    }
+
+    @Test
+    fun `falls back to original when strip leaves empty`() {
+        // Edge case: the title IS just the prefix. Empty isn't a useful
+        // render so we fall back; the brass left-side index still
+        // communicates the chapter number.
+        assertEquals("Ch. 0 - ", stripChapterPrefix("Ch. 0 - "))
+        assertEquals("Chapter 1:", stripChapterPrefix("Chapter 1:"))
+    }
+
+    @Test
+    fun `does not strip mid-string prefixes`() {
+        // The strip is anchored to start-of-string; a title like
+        // "Vol 2 Ch. 6 - Greed" keeps the volume context intact.
+        assertEquals("Vol 2 Ch. 6 - Greed", stripChapterPrefix("Vol 2 Ch. 6 - Greed"))
+    }
+}


### PR DESCRIPTION
## Summary
Fiction detail chapter list rendered TWO numbers per row: brass left-side index ('06') and the title's own embedded prefix ('CH. 116 - Insurmountable Foe'). First-time users wondered whether '06' was a re-index, a list ordinal, or something else.

\`stripChapterPrefix()\` runs on the title before render. Covers the common shapes (\`Ch. N -\`, \`Ch.N -\`, \`Chapter N:\`, em-dash and en-dash separators, case-insensitive). Mid-string prefixes left alone (\`Vol 2 Ch. 6 - Greed\` untouched). Empty result falls back to the original title.

## What changed
- \`core-ui/.../ChapterCard.kt\` — wrap \`state.title\` in \`stripChapterPrefix\` before render; add the regex helper at the bottom.
- \`core-ui/.../StripChapterPrefixTest.kt\` — 8 cases pinning the regex contract.

Closes #256