### PR TITLE
fix(voice-library): wrap names to 2 lines so Multilingual/Turbo/Studio survive

### DIFF
--- a/feature/src/main/kotlin/in/jphe/storyvox/feature/voicelibrary/VoiceLibraryScreen.kt
+++ b/feature/src/main/kotlin/in/jphe/storyvox/feature/voicelibrary/VoiceLibraryScreen.kt
@@ -485,7 +485,14 @@ private fun VoiceRow(
                                 MaterialTheme.colorScheme.onSurfaceVariant
                             } else MaterialTheme.colorScheme.onSurface,
                             fontWeight = if (isActive) FontWeight.SemiBold else FontWeight.Normal,
-                            maxLines = 1,
+                            // Issue #263 — Azure variant suffixes (Multilingual /
+                            // Turbo / Studio / HD) fall exactly where the
+                            // 1-line cutoff used to clip on Flip3's 1080px
+                            // inner display, so users couldn't distinguish
+                            // 'Adam Multilingual' from 'Adam Studio'. Allow
+                            // two lines; ellipsis still kicks in past that
+                            // for the rare 30+ char name.
+                            maxLines = 2,
                             overflow = androidx.compose.ui.text.style.TextOverflow.Ellipsis,
                             modifier = Modifier.weight(1f, fill = false),
                         )


### PR DESCRIPTION
## Summary
Azure voice names with variant suffixes ('Multilingual', 'Turbo', 'Studio', 'HD') clipped at ~16 chars on Flip3's 1080px inner display — the variant is exactly where the cut landed. Users couldn't tell 'Adam Multilingual' from 'Adam Studio'.

Bump VoiceRow title \`maxLines\` from 1 to 2; ellipsis still kicks in past two lines.

## What changed
- \`feature/.../voicelibrary/VoiceLibraryScreen.kt\` — \`maxLines = 2\` on the title Text.

## Why this approach
The issue suggests icon-only 'Activate' to free width, or chip variants on a second row. Both are design calls; this is the minimum readability win and ships today.

Closes #263