### PR TITLE
fix(nav): add TopAppBar to Library + Fiction detail

### DIFF
--- a/feature/src/main/kotlin/in/jphe/storyvox/feature/fiction/FictionDetailScreen.kt
+++ b/feature/src/main/kotlin/in/jphe/storyvox/feature/fiction/FictionDetailScreen.kt
@@ -16,12 +16,17 @@ import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.ArrowBack
 import androidx.compose.material.icons.filled.Star
 import androidx.compose.material3.AlertDialog
+import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
+import androidx.compose.material3.TopAppBar
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
@@ -46,6 +51,7 @@ import `in`.jphe.storyvox.ui.component.FictionDetailSkeleton
 import `in`.jphe.storyvox.ui.layout.isAtLeastTablet
 import `in`.jphe.storyvox.ui.theme.LocalSpacing
 
+@OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun FictionDetailScreen(
     onOpenReader: (String, String) -> Unit,
@@ -105,7 +111,38 @@ fun FictionDetailScreen(
     }
 
     val fiction = state.fiction
-    Box(modifier = Modifier.fillMaxSize()) {
+    // Issue #257 — Fiction detail used to fade from the system status bar
+    // straight into the cover image with no app bar — no back arrow, no
+    // title, no place for overflow actions (Refresh, Mark all read, etc).
+    // Wrap in a Scaffold + TopAppBar so back-navigation has a visible
+    // affordance (in addition to OS gesture) and the fiction title sits
+    // at the top of the screen as standard for a detail surface. The
+    // existing Hero composable still renders the bigger title; the bar
+    // copy is intentionally compact so the dual rendering reads as
+    // 'context + content' not 'duplicate'.
+    Scaffold(
+        topBar = {
+            TopAppBar(
+                title = {
+                    Text(
+                        text = fiction?.title ?: "",
+                        style = MaterialTheme.typography.titleMedium,
+                        maxLines = 1,
+                        overflow = androidx.compose.ui.text.style.TextOverflow.Ellipsis,
+                    )
+                },
+                navigationIcon = {
+                    IconButton(onClick = onBack) {
+                        Icon(
+                            Icons.AutoMirrored.Filled.ArrowBack,
+                            contentDescription = "Back",
+                        )
+                    }
+                },
+            )
+        },
+    ) { scaffoldPadding ->
+    Box(modifier = Modifier.fillMaxSize().padding(scaffoldPadding)) {
         if (fiction == null && state.error != null) {
             // First-load failure with no cached fiction. Issue #169 —
             // this path used to be a dead-end (no Back, no Retry, only
@@ -220,6 +257,7 @@ fun FictionDetailScreen(
                 modifier = Modifier.align(Alignment.BottomCenter),
             )
         }
+    }
     }
 }
 

--- a/feature/src/main/kotlin/in/jphe/storyvox/feature/library/LibraryScreen.kt
+++ b/feature/src/main/kotlin/in/jphe/storyvox/feature/library/LibraryScreen.kt
@@ -18,6 +18,8 @@ import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Add
 import androidx.compose.material3.Card
 import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.CenterAlignedTopAppBar
+import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.FloatingActionButton
 import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
@@ -41,6 +43,7 @@ import `in`.jphe.storyvox.ui.theme.LocalSpacing
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.ui.text.style.TextAlign
 
+@OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun LibraryScreen(
     onOpenFiction: (String) -> Unit,
@@ -61,6 +64,19 @@ fun LibraryScreen(
     }
 
     Scaffold(
+        // Issue #255 — Library used to fade straight from the system status
+        // bar into a Resume card with no header — no 'Library' title, no
+        // identity. CenterAlignedTopAppBar gives the screen a hard
+        // identifier (matches Material 3 standard for home tabs) and a
+        // place to surface search/sort/filter actions later. For now the
+        // bar is bare title-only; the issue's deeper ask (search +
+        // sort/filter affordances) needs its own follow-up since neither
+        // exists in LibraryViewModel yet.
+        topBar = {
+            CenterAlignedTopAppBar(
+                title = { Text("Library", style = MaterialTheme.typography.titleMedium) },
+            )
+        },
         floatingActionButton = {
             FloatingActionButton(
                 onClick = viewModel::showAddByUrl,


### PR DESCRIPTION
## Summary
Two screens read as identity-less content shelves before this:
- **Library**: status bar bled into the Resume card — no 'Library' title, no place for search / sort / filter affordances.
- **Fiction detail**: status bar bled into the cover image — no back arrow (only OS gesture), no title until the Hero block.

Add:
- **Library**: \`CenterAlignedTopAppBar('Library')\`. FAB unchanged; issue mentions labeling/replacing it but that's a separate design call.
- **Fiction detail**: \`TopAppBar\` with fiction title + back-arrow nav icon. Compact title (truncates with ellipsis) so the existing Hero block still owns the bigger title; the bar copy reads as context, not duplicate.

## What changed
- \`feature/.../library/LibraryScreen.kt\` — \`topBar = CenterAlignedTopAppBar(...)\`.
- \`feature/.../fiction/FictionDetailScreen.kt\` — wrap the existing Box body in a Scaffold; \`topBar = TopAppBar(...)\` with title + back arrow.

## Why this approach
Doesn't add search / sort / filter on Library or overflow actions on Fiction detail — those are tracked as the issues' deeper asks but require new ViewModel surface. Bar shells unlock that future work.

Closes #255
Closes #257