### PR TITLE
feat(settings): deliberate first-time defaults per Lyra's UX audit

### DIFF
--- a/app/src/main/kotlin/in/jphe/storyvox/data/SettingsRepositoryUiImpl.kt
+++ b/app/src/main/kotlin/in/jphe/storyvox/data/SettingsRepositoryUiImpl.kt
@@ -73,7 +73,12 @@ import kotlinx.coroutines.flow.map
 
 private val Context.settingsDataStore: DataStore<Preferences> by preferencesDataStore(
     name = "storyvox_settings",
-    produceMigrations = { _ -> listOf(PunctuationPauseEnumToMultiplierMigration) },
+    produceMigrations = { _ ->
+        listOf(
+            PunctuationPauseEnumToMultiplierMigration,
+            FirstTimeDefaultVoiceMigration,
+        )
+    },
 )
 
 /**
@@ -111,6 +116,40 @@ internal val PunctuationPauseEnumToMultiplierMigration: DataMigration<Preference
             }
             mutable[newKey] = mapped
             mutable.remove(oldKey)
+            return mutable.toPreferences()
+        }
+
+        override suspend fun cleanUp() = Unit
+    }
+
+/**
+ * Issue #294 — seed `pref_default_voice_id` to `piper_cori_en_GB_high`
+ * on a fresh install. The VoicePickerGate's ordering already shows
+ * Cori first (see VoiceCatalog.featuredIds[0]), but the "no voice
+ * activated yet" state would otherwise leave defaultVoiceId null until
+ * the user explicitly picks one — that pushes the first-run friction
+ * onto a picker tap.
+ *
+ * Runs once per process at first DataStore read. Idempotent —
+ * `shouldMigrate` returns false the moment the key is present, so a
+ * user who picks a different voice on first launch (or who upgraded
+ * from a build that already has a stored voice) gets their choice
+ * preserved verbatim.
+ *
+ * Cori High is a 114 MB download. The VoicePickerGate's three featured
+ * tiles still offer Lessac High and Aoede Kokoro as alternatives, so a
+ * connection-sensitive user can swap before the install completes.
+ */
+internal val FirstTimeDefaultVoiceMigration: DataMigration<Preferences> =
+    object : DataMigration<Preferences> {
+        private val voiceKey = stringPreferencesKey("pref_default_voice_id")
+
+        override suspend fun shouldMigrate(currentData: Preferences): Boolean =
+            currentData[voiceKey] == null
+
+        override suspend fun migrate(currentData: Preferences): Preferences {
+            val mutable = currentData.toMutablePreferences()
+            mutable[voiceKey] = "piper_cori_en_GB_high"
             return mutable.toPreferences()
         }
 
@@ -348,7 +387,11 @@ class SettingsRepositoryUiImpl(
         UiSettings(
             ttsEngine = "VoxSherpa",
             defaultVoiceId = prefs[Keys.DEFAULT_VOICE_ID],
-            defaultSpeed = prefs[Keys.DEFAULT_SPEED] ?: 1.0f,
+            // Issue #294 — web-fiction listeners consistently prefer 1.10×;
+            // 1.00× is audiobook tempo, too slow for serial fiction.
+            // Existing users keep their stored value via the prefs lookup;
+            // only the fallback for a fresh install changed.
+            defaultSpeed = prefs[Keys.DEFAULT_SPEED] ?: 1.1f,
             defaultPitch = prefs[Keys.DEFAULT_PITCH] ?: 1.0f,
             voiceSpeedOverrides = decodeVoiceFloatMap(prefs[Keys.VOICE_SPEED_OVERRIDES]),
             voicePitchOverrides = decodeVoiceFloatMap(prefs[Keys.VOICE_PITCH_OVERRIDES]),
@@ -370,8 +413,18 @@ class SettingsRepositoryUiImpl(
             palace = UiPalaceConfig(host = palace.host, apiKey = palace.apiKey),
             github = githubSession.toUi(),
             githubPrivateReposEnabled = prefs[Keys.GITHUB_PRIVATE_REPOS_ENABLED] ?: false,
-            // RSS-only default (2026-05-09) — see kdoc on UiSettings.
-            sourceRoyalRoadEnabled = prefs[Keys.SOURCE_ROYALROAD_ENABLED] ?: false,
+            // Issue #294 — Royal Road is the de-facto primary source
+            // storyvox was built around; defaulting OFF meant a new user
+            // opened Browse and saw the empty-picker state. Flip to ON
+            // for fresh installs alongside RSS. Existing users keep their
+            // stored toggle via the prefs lookup; only the fallback
+            // changed.
+            //
+            // The playstore build flavor (#240, not yet landed) is
+            // expected to override this to FALSE at the BuildConfig level
+            // to satisfy the Play Store's anti-scraping posture. Until
+            // that lands, this default is ON for all builds.
+            sourceRoyalRoadEnabled = prefs[Keys.SOURCE_ROYALROAD_ENABLED] ?: true,
             sourceGitHubEnabled = prefs[Keys.SOURCE_GITHUB_ENABLED] ?: false,
             sourceMemPalaceEnabled = prefs[Keys.SOURCE_MEMPALACE_ENABLED] ?: false,
             sourceRssEnabled = prefs[Keys.SOURCE_RSS_ENABLED] ?: true,
@@ -411,8 +464,14 @@ class SettingsRepositoryUiImpl(
                 claudeKeyConfigured = llmCreds.hasClaudeKey,
                 openAiModel = prefs[Keys.AI_OPENAI_MODEL] ?: "gpt-4o-mini",
                 openAiKeyConfigured = llmCreds.hasOpenAiKey,
-                ollamaBaseUrl = prefs[Keys.AI_OLLAMA_BASE_URL] ?: "http://10.0.0.1:11434",
-                ollamaModel = prefs[Keys.AI_OLLAMA_MODEL] ?: "llama3.3",
+                // Issue #294 — JP's LAN address shouldn't be baked into
+                // every fresh install. Default empty; the UI surfaces a
+                // placeholder.
+                ollamaBaseUrl = prefs[Keys.AI_OLLAMA_BASE_URL] ?: "",
+                // Issue #294 — llama3.2:3b actually fits on phone-class
+                // hardware; 3.3 (70B) doesn't run locally for most users
+                // even when they have ollama on a LAN host.
+                ollamaModel = prefs[Keys.AI_OLLAMA_MODEL] ?: "llama3.2:3b",
                 vertexModel = prefs[Keys.AI_VERTEX_MODEL] ?: "gemini-2.5-flash",
                 vertexKeyConfigured = llmCreds.hasVertexKey,
                 foundryEndpoint = prefs[Keys.AI_FOUNDRY_ENDPOINT] ?: "",
@@ -427,10 +486,19 @@ class SettingsRepositoryUiImpl(
                 teamsScopes = (teamsSession as? TeamsSession.SignedIn)?.scopes
                     ?: llmCreds.teamsScopes().orEmpty(),
                 privacyAcknowledged = prefs[Keys.AI_PRIVACY_ACK] ?: false,
-                sendChapterTextEnabled = prefs[Keys.AI_SEND_CHAPTER_TEXT] ?: true,
+                // Issue #294 — privacy-first: chapter text is the user's
+                // content, and AI grounding is opt-in by default. Recap
+                // and chat fall back to title + current-sentence
+                // grounding (still useful) until the user opts in. This
+                // is a behavioural change worth flagging in release
+                // notes.
+                sendChapterTextEnabled = prefs[Keys.AI_SEND_CHAPTER_TEXT] ?: false,
                 chatGrounding = UiChatGrounding(
                     includeChapterTitle = prefs[Keys.AI_CHAT_GROUND_CHAPTER_TITLE] ?: true,
-                    includeCurrentSentence = prefs[Keys.AI_CHAT_GROUND_CURRENT_SENTENCE] ?: false,
+                    // Issue #294 — current-sentence grounding is ~50
+                    // tokens; tiny cost for outsized context gain. Ship
+                    // ON by default so first-launch chats are useful.
+                    includeCurrentSentence = prefs[Keys.AI_CHAT_GROUND_CURRENT_SENTENCE] ?: true,
                     includeEntireChapter = prefs[Keys.AI_CHAT_GROUND_ENTIRE_CHAPTER] ?: false,
                     includeEntireBookSoFar = prefs[Keys.AI_CHAT_GROUND_ENTIRE_BOOK] ?: false,
                 ),
@@ -1079,8 +1147,11 @@ class SettingsRepositoryUiImpl(
                 ?.let { runCatching { ProviderId.valueOf(it) }.getOrNull() },
             claudeModel = prefs[Keys.AI_CLAUDE_MODEL] ?: "claude-haiku-4.5",
             openAiModel = prefs[Keys.AI_OPENAI_MODEL] ?: "gpt-4o-mini",
-            ollamaBaseUrl = prefs[Keys.AI_OLLAMA_BASE_URL] ?: "http://10.0.0.1:11434",
-            ollamaModel = prefs[Keys.AI_OLLAMA_MODEL] ?: "llama3.3",
+            // Issue #294 — mirror the UiSettings fallbacks at the
+            // LlmConfig export site so both surfaces report the same
+            // first-time defaults.
+            ollamaBaseUrl = prefs[Keys.AI_OLLAMA_BASE_URL] ?: "",
+            ollamaModel = prefs[Keys.AI_OLLAMA_MODEL] ?: "llama3.2:3b",
             vertexModel = prefs[Keys.AI_VERTEX_MODEL] ?: "gemini-2.5-flash",
             foundryEndpoint = prefs[Keys.AI_FOUNDRY_ENDPOINT] ?: "",
             foundryDeployment = prefs[Keys.AI_FOUNDRY_DEPLOYMENT] ?: "",
@@ -1088,7 +1159,7 @@ class SettingsRepositoryUiImpl(
             bedrockRegion = prefs[Keys.AI_BEDROCK_REGION] ?: "us-east-1",
             bedrockModel = prefs[Keys.AI_BEDROCK_MODEL] ?: "claude-haiku-4.5",
             privacyAcknowledged = prefs[Keys.AI_PRIVACY_ACK] ?: false,
-            sendChapterTextEnabled = prefs[Keys.AI_SEND_CHAPTER_TEXT] ?: true,
+            sendChapterTextEnabled = prefs[Keys.AI_SEND_CHAPTER_TEXT] ?: false,
         )
     }
 

--- a/feature/src/main/kotlin/in/jphe/storyvox/feature/api/UiContracts.kt
+++ b/feature/src/main/kotlin/in/jphe/storyvox/feature/api/UiContracts.kt
@@ -837,8 +837,13 @@ data class UiAzureConfig(
     val isConfigured: Boolean get() = key.isNotBlank()
 }
 
-/** Default queue depth — current hardcoded `EngineStreamingSource(queueCapacity = 8)`. */
-const val BUFFER_DEFAULT_CHUNKS: Int = 8
+/** Default queue depth.
+ *
+ *  Issue #294 — bumped from 8 → 12. The original 8 was the bare minimum
+ *  from #84's exploratory probe era; ~12 hides voice startup spikes on
+ *  Flip3-class hardware without entering the amber zone (recommended
+ *  max is 64). Per Lyra's first-time-defaults audit. */
+const val BUFFER_DEFAULT_CHUNKS: Int = 12
 
 /** Lower bound — 1 in flight + 1 queued is the minimum that gives any back-pressure benefit. */
 const val BUFFER_MIN_CHUNKS: Int = 2
@@ -886,7 +891,12 @@ const val BUFFER_DANGER_MULTIPLIER: Int = 4
  */
 const val PUNCTUATION_PAUSE_MIN_MULTIPLIER: Float = 0f
 const val PUNCTUATION_PAUSE_MAX_MULTIPLIER: Float = 4f
-const val PUNCTUATION_PAUSE_DEFAULT_MULTIPLIER: Float = 1f
+/** Issue #294 — bumped from 1.0× → 0.85×. Web fiction has more dialogue
+ *  tags and short paragraphs than audiobooks; 1.00× felt stilted on a
+ *  Royal Road / RSS reading session. 0.85× still respects terminators
+ *  but lets the cadence flow with the source. Per Lyra's first-time-
+ *  defaults audit. */
+const val PUNCTUATION_PAUSE_DEFAULT_MULTIPLIER: Float = 0.85f
 
 /** Legacy enum stop multipliers — used by the migration shim and tick labels. */
 const val PUNCTUATION_PAUSE_OFF_MULTIPLIER: Float = 0f


### PR DESCRIPTION
## Summary
Per #294, storyvox's defaults were never deliberately chosen — they were whatever shipped first as each feature landed. This PR applies the deliberate set Lyra proposed in the audit.

**Existing users keep all their stored choices verbatim** — the prefs lookup is unchanged; only the \`?: fallback\` for unset keys moved.

## Defaults updated
| Setting | Before | After | Reason |
|---|---|---|---|
| Default voice | unset (gate ordering decides) | \`piper_cori_en_GB_high\` (via new \`FirstTimeDefaultVoiceMigration\`) | UK Cori has cleaner Piper intonation than US Lessac |
| Default speed | 1.0× | 1.10× | Web-fiction tempo, not audiobook tempo |
| Punctuation pause | 1.0× | 0.85× | Web fiction has more dialogue tags than audiobooks |
| Buffer chunks | 8 | 12 | Hides voice startup spikes on Flip3-class hardware |
| sourceRoyalRoadEnabled | false | true | De-facto primary source |
| Ollama base URL | \`http://10.0.0.1:11434\` | \`""\` | JP's LAN address shouldn't ship |
| Ollama model | \`llama3.3\` | \`llama3.2:3b\` | Actually fits phone-class hardware |
| sendChapterTextEnabled | true | false | Privacy-first |
| AI chat grounding (current sentence) | false | true | Tiny cost, big context gain |

## What changed
- \`app/.../SettingsRepositoryUiImpl.kt\`
  - New \`FirstTimeDefaultVoiceMigration\` — idempotent, runs once at first DataStore read, no-op for users with a stored voice.
  - Updated prefs-fallback values at both the \`UiSettings\` flow site and the \`LlmConfig\` export site (so both report the same first-time defaults).
- \`feature/.../UiContracts.kt\`
  - \`BUFFER_DEFAULT_CHUNKS\`: 8 → 12.
  - \`PUNCTUATION_PAUSE_DEFAULT_MULTIPLIER\`: 1f → 0.85f.

## Skipped from Lyra's spec
- VoicePickerGate ordering already shows Cori first via \`VoiceCatalog.featuredIds[0]\` — no code change.
- Play Store flavor override on \`sourceRoyalRoadEnabled\` is left to #240's PR; kdoc on the default flags the dependency.
- Skip-duration chip set in Settings is a separate UI feature (mentioned but not part of the defaults overhaul itself).

## Test plan
- Existing unit tests pass (no test pinned the old defaults explicitly).
- Fresh install verification + upgrade-preserves-choices verification have to happen on-device per Lyra's spec.

Closes #294