### PR TITLE
docs: bump README callout to v0.5.00

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Stream chapters from [Royal Road](https://royalroad.com), [GitHub](https://githu
   <img src="docs/screenshots/03-reader.png" width="320" alt="storyvox reader playing The Archmage Coefficient" />
 </p>
 
-> **v0.4.83** — six fiction sources (Royal Road, GitHub, RSS, EPUB, Outline, Memory Palace), Azure HD voices as an optional cloud TTS backend (BYOK), Tier 3 multi-engine parallel synthesis (1–8 engines × N threads each), smart-resume CTA, AI chat per fiction across seven LLM providers, GitHub OAuth, Settings redesign (8 sections), shake-to-extend sleep timer. GPL-3.0 (downstream of the engine, not a posture choice — see [License](#license)).
+> **v0.5.00** — six fiction sources (Royal Road, GitHub, RSS, EPUB, Outline, Memory Palace), Azure HD voices as an optional cloud TTS backend (BYOK), Tier 3 multi-engine parallel synthesis (1–8 engines × N threads each), smart-resume CTA, AI chat per fiction across seven LLM providers, GitHub OAuth, Settings redesign (8 sections), shake-to-extend sleep timer. GPL-3.0 (downstream of the engine, not a posture choice — see [License](#license)).
 
 ---
 


### PR DESCRIPTION
## Summary
- README headline still read **v0.4.83** after the v0.5.00 milestone shipped.

## Context
Also serving as a Copilot rate-limit probe — today's 15-PR polish storm shipped on green CI without requesting Copilot, since it had silently dropped yesterday evening. Re-requesting here to see if it's recovered.

## Test plan
- [x] README diff is a one-character version bump; no behavior change

🤖 Generated with [Claude Code](https://claude.com/claude-code)