### PR TITLE
docs(site): realm-sigil + dark.realm.watch + v0.5.00 callout

### DIFF
--- a/.github/workflows/release-docs-sync.yml
+++ b/.github/workflows/release-docs-sync.yml
@@ -57,6 +57,24 @@ jobs:
           echo "version=${TAG#v}"  >> "$GITHUB_OUTPUT"
           echo "Syncing docs for tag: $TAG"
 
+      - name: Verify tag points at main HEAD before binding sigil
+        env:
+          TAG: ${{ steps.tag.outputs.tag }}
+        run: |
+          # realm-sigil's build.sh reads HASH from `git rev-parse HEAD`.
+          # We've checked out main; if the tag doesn't point at main's tip
+          # (e.g. someone pushed to main between tag creation and this run),
+          # the sigil hash would bind to the wrong commit. Refuse to proceed.
+          TAG_SHA=$(git rev-parse --verify "refs/tags/$TAG")
+          MAIN_SHA=$(git rev-parse --verify HEAD)
+          if [ "$TAG_SHA" != "$MAIN_SHA" ]; then
+            echo "::error::Tag $TAG ($TAG_SHA) does not point at main HEAD ($MAIN_SHA)."
+            echo "::error::Refusing to sync — the realm-sigil hash would bind to the wrong commit."
+            echo "::error::Fast-forward main to the tag (or re-tag main's current tip) and retry."
+            exit 1
+          fi
+          echo "Tag and main agree on $TAG_SHA — proceeding."
+
       - name: Clone realm-sigil
         run: git clone --depth=1 https://github.com/jphein/sigil.realm.watch "$RUNNER_TEMP/realm-sigil"
 

--- a/.github/workflows/release-docs-sync.yml
+++ b/.github/workflows/release-docs-sync.yml
@@ -1,0 +1,178 @@
+name: Release docs sync
+
+# Fires on every tag push (vX.Y.Z) and regenerates everything that should
+# follow the release version: realm-sigil version.json + meta tag, README
+# headline callout, docs/index.md "What just shipped" headline, wiki Home
+# current-version line, and the repo About homepage URL. Commits the result
+# back to main with [skip ci] so we don't re-trigger the Android build.
+
+on:
+  push:
+    tags: ['v*']
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: 'Tag to sync (e.g. v0.5.00). Blank = latest tag.'
+        required: false
+
+concurrency:
+  group: release-docs-${{ github.ref }}
+  cancel-in-progress: false
+
+permissions:
+  contents: write
+
+jobs:
+  sync:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: Checkout main (full history for commit-back)
+        uses: actions/checkout@v4
+        with:
+          ref: main
+          fetch-depth: 0
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Resolve tag to sync
+        id: tag
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          INPUT_TAG: ${{ inputs.tag }}
+          REF_NAME: ${{ github.ref_name }}
+        run: |
+          if [ "$EVENT_NAME" = "workflow_dispatch" ] && [ -n "$INPUT_TAG" ]; then
+            TAG="$INPUT_TAG"
+          elif [ "$EVENT_NAME" = "push" ]; then
+            TAG="$REF_NAME"
+          else
+            TAG=$(git tag --sort=-version:refname | head -1)
+          fi
+          # Sanity-check: only allow plausible semver-ish tags
+          case "$TAG" in
+            v[0-9]*.[0-9]*.[0-9]*) : ;;
+            *) echo "Refusing to sync for non-version tag: $TAG"; exit 1 ;;
+          esac
+          echo "tag=$TAG"          >> "$GITHUB_OUTPUT"
+          echo "version=${TAG#v}"  >> "$GITHUB_OUTPUT"
+          echo "Syncing docs for tag: $TAG"
+
+      - name: Clone realm-sigil
+        run: git clone --depth=1 https://github.com/jphein/sigil.realm.watch "$RUNNER_TEMP/realm-sigil"
+
+      - name: Regenerate docs/version.json + meta tag
+        working-directory: docs
+        env:
+          REPO: ${{ github.repository }}
+        run: |
+          "$RUNNER_TEMP/realm-sigil/static/build.sh" \
+            --name storyvox \
+            --description "Neural-voice audiobook player for any text you have — offline TTS, optional Azure HD cloud voices, Library Nocturne aesthetic" \
+            --realm fantasy \
+            --repo "https://github.com/$REPO" \
+            --dir . \
+            --html _layouts/default.html
+
+      - name: Bump README headline callout
+        env:
+          TAG: ${{ steps.tag.outputs.tag }}
+        run: |
+          python3 - <<'PY'
+          import os, re, pathlib
+          tag = os.environ['TAG']
+          p = pathlib.Path('README.md')
+          s = p.read_text()
+          s2, n = re.subn(r'^> \*\*v\d+\.\d+\.\d+\*\* —',
+                          f'> **{tag}** —', s, count=1, flags=re.M)
+          if n:
+              p.write_text(s2)
+              print(f'README.md: bumped headline to {tag}')
+          else:
+              print('README.md: no headline pattern matched; skipping')
+          PY
+
+      - name: Bump docs/index.md "What just shipped" callout + release link
+        env:
+          TAG: ${{ steps.tag.outputs.tag }}
+        run: |
+          python3 - <<'PY'
+          import os, re, pathlib
+          tag = os.environ['TAG']
+          p = pathlib.Path('docs/index.md')
+          s = p.read_text()
+          # First <strong>vX.Y.Z</strong> = "What just shipped" headline
+          s2, n1 = re.subn(r'<strong>v\d+\.\d+\.\d+</strong>',
+                            f'<strong>{tag}</strong>', s, count=1)
+          # First release-notes link nearest to that headline
+          s2, n2 = re.subn(r'releases/tag/v\d+\.\d+\.\d+',
+                            f'releases/tag/{tag}', s2, count=1)
+          if n1 or n2:
+              p.write_text(s2)
+              print(f'docs/index.md: headline={n1} link={n2} -> {tag}')
+          else:
+              print('docs/index.md: no patterns matched; skipping')
+          PY
+
+      - name: Update repo About homepage
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
+          OWNER: ${{ github.repository_owner }}
+          NAME: ${{ github.event.repository.name }}
+        continue-on-error: true
+        run: |
+          gh repo edit "$REPO" --homepage "https://$OWNER.github.io/$NAME"
+
+      - name: Update wiki Home current-version line
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TAG: ${{ steps.tag.outputs.tag }}
+          REPO: ${{ github.repository }}
+        continue-on-error: true
+        run: |
+          WIKI_DIR="$RUNNER_TEMP/wiki"
+          if ! git clone "https://x-access-token:${GH_TOKEN}@github.com/${REPO}.wiki.git" "$WIKI_DIR" 2>/dev/null; then
+            echo "Wiki not initialized or no access; skipping wiki update."
+            exit 0
+          fi
+          cd "$WIKI_DIR"
+          [ -f Home.md ] || { echo "No Home.md; skipping."; exit 0; }
+          python3 - <<'PY'
+          import os, re, pathlib
+          tag = os.environ['TAG']
+          p = pathlib.Path('Home.md')
+          s = p.read_text()
+          marker = re.compile(r'^_Current version: v\d+\.\d+\.\d+_\s*$', re.M)
+          line = f'_Current version: {tag}_'
+          if marker.search(s):
+              s2 = marker.sub(line, s)
+          else:
+              # Insert after first H1 if present
+              s2 = re.sub(r'(\A#[^\n]+\n)', lambda m: m.group(1) + '\n' + line + '\n', s, count=1)
+          if s2 != s:
+              p.write_text(s2)
+              print(f'Home.md: set version to {tag}')
+          else:
+              print('Home.md: already current')
+          PY
+          if ! git diff --quiet; then
+            git config user.email "github-actions[bot]@users.noreply.github.com"
+            git config user.name  "github-actions[bot]"
+            git add Home.md
+            git commit -m "docs(wiki): bump current version to ${TAG}"
+            git push
+          fi
+
+      - name: Commit docs back to main
+        env:
+          TAG: ${{ steps.tag.outputs.tag }}
+        run: |
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git config user.name  "github-actions[bot]"
+          git add README.md docs/index.md docs/version.json docs/_layouts/default.html
+          if git diff --staged --quiet; then
+            echo "No docs changes to commit."
+            exit 0
+          fi
+          git commit -m "chore(release): docs sync for ${TAG} [skip ci]"
+          git push origin main

--- a/docs/_layouts/default.html
+++ b/docs/_layouts/default.html
@@ -45,8 +45,8 @@
       <a href="https://github.com/jphein/storyvox/blob/main/LICENSE">GPL-3.0</a>
     </p>
     <p class="muted">© {{ 'now' | date: '%Y' }} JP Hein. Built with Claude Code.</p>
-    <p class="sigil-mark muted" aria-label="Realm sigil version">
-      <span aria-hidden="true">✦</span> <span class="sigil-version">sigil bound</span>
+    <p class="sigil-mark muted" aria-hidden="true">
+      <span>✦</span> <span class="sigil-version">sigil bound</span>
     </p>
   </footer>
   <script src="{{ '/assets/dark/dark.js' | relative_url }}"></script>

--- a/docs/_layouts/default.html
+++ b/docs/_layouts/default.html
@@ -7,10 +7,14 @@
   <meta name="description" content="{{ page.description | default: site.description }}" />
   {%- seo title=false -%}
   <link rel="icon" href="{{ '/assets/favicon.svg' | relative_url }}" type="image/svg+xml" />
+  {%- comment -%} dark.realm.watch Tier 2 — inlined locally (dark.realm.watch not yet on DNS) {%- endcomment -%}
+  <script>(()=>{try{var s=localStorage.getItem('drw-theme');if(s==='dark'||s==='light')document.documentElement.setAttribute('data-theme',s)}catch(_){}})()</script>
+  <link rel="stylesheet" href="{{ '/assets/dark/dark.css' | relative_url }}" />
   <link rel="preconnect" href="https://fonts.googleapis.com" />
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
   <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=EB+Garamond:ital,wght@0,400;0,500;0,600;1,400&family=Inter:wght@400;500;600;700&display=swap" />
   <link rel="stylesheet" href="{{ '/assets/css/style.css' | relative_url }}" />
+  <meta name="realm-version" content='{"name": "storyvox", "description": "Neural-voice audiobook player for any text you have \u2014 offline TTS, optional Azure HD cloud voices, Library Nocturne aesthetic", "version": "Noble Grimoire \u00b7 63f5826", "hash": "63f5826", "branch": "docs/sigil-and-dark-realm", "dirty": false, "built": "2026-05-11T01:46:47Z", "realm": "fantasy", "repo": "https://github.com/jphein/storyvox", "commit_url": "https://github.com/jphein/storyvox/commit/63f5826"}'>
 </head>
 <body>
   <header class="site-header">
@@ -25,6 +29,9 @@
       <a href="{{ '/screenshots/' | relative_url }}">Screenshots</a>
       <a href="https://github.com/jphein/storyvox/wiki">Wiki</a>
       <a href="https://github.com/jphein/storyvox" class="nav-cta">GitHub</a>
+      <button id="theme-toggle" class="theme-toggle" type="button" aria-label="Cycle theme: system, dark, light" title="Cycle theme">
+        <span class="theme-toggle-icon" aria-hidden="true">◐</span>
+      </button>
     </nav>
   </header>
   <main class="site-main">
@@ -38,6 +45,48 @@
       <a href="https://github.com/jphein/storyvox/blob/main/LICENSE">GPL-3.0</a>
     </p>
     <p class="muted">© {{ 'now' | date: '%Y' }} JP Hein. Built with Claude Code.</p>
+    <p class="sigil-mark muted" aria-label="Realm sigil version">
+      <span aria-hidden="true">✦</span> <span class="sigil-version">sigil bound</span>
+    </p>
   </footer>
+  <script src="{{ '/assets/dark/dark.js' | relative_url }}"></script>
+  <script>
+    (() => {
+      const btn = document.getElementById('theme-toggle');
+      if (!btn || !window.Dark) return;
+      const icons = { system: '◐', dark: '☾', light: '☀' };
+      const sync = () => {
+        const cur = Dark.current();
+        btn.querySelector('.theme-toggle-icon').textContent = icons[cur] || '◐';
+        btn.setAttribute('data-state', cur);
+      };
+      btn.addEventListener('click', () => Dark.cycle());
+      document.addEventListener('dark:change', sync);
+      sync();
+    })();
+    (() => {
+      const meta = document.querySelector('meta[name="realm-version"]');
+      const mark = document.querySelector('.sigil-version');
+      if (!meta || !mark) return;
+      try {
+        const d = JSON.parse(meta.content);
+        const realm = d.realm || 'fantasy';
+        const ver = d.version || 'sigil bound';
+        mark.textContent = '';
+        if (d.commit_url) {
+          const a = document.createElement('a');
+          a.href = d.commit_url;
+          a.textContent = ver;
+          mark.appendChild(a);
+        } else {
+          mark.appendChild(document.createTextNode(ver));
+        }
+        mark.appendChild(document.createTextNode(' · realm '));
+        const em = document.createElement('em');
+        em.textContent = realm;
+        mark.appendChild(em);
+      } catch (_) { /* leave fallback text */ }
+    })();
+  </script>
 </body>
 </html>

--- a/docs/assets/css/style.css
+++ b/docs/assets/css/style.css
@@ -20,8 +20,21 @@
   --radius-md: 10px;
 }
 
+/* Light palette — applied explicitly via [data-theme="light"] or via system pref
+ * when no explicit theme is set. dark.realm.watch toggles data-theme on <html>. */
+:root[data-theme="light"] {
+  --warm-bg: #f5ecd8;
+  --warm-bg-elev: #fff8e8;
+  --warm-bg-card: #fffaef;
+  --warm-fg: #2a2015;
+  --warm-fg-muted: #6d5d44;
+  --warm-rule: #d9c89e;
+  --brass-300: #8a5f17;
+  --brass-400: #6f4a10;
+  --brass-500: #b8862a;
+}
 @media (prefers-color-scheme: light) {
-  :root {
+  :root:not([data-theme="dark"]) {
     --warm-bg: #f5ecd8;
     --warm-bg-elev: #fff8e8;
     --warm-bg-card: #fffaef;
@@ -50,9 +63,11 @@ body {
 
 a { color: var(--brass-300); text-decoration: none; }
 a:hover { color: var(--brass-400); text-decoration: underline; }
+:root[data-theme="light"] a { color: var(--brass-400); }
+:root[data-theme="light"] a:hover { color: var(--brass-500); }
 @media (prefers-color-scheme: light) {
-  a { color: var(--brass-400); }
-  a:hover { color: var(--brass-500); }
+  :root:not([data-theme="dark"]) a { color: var(--brass-400); }
+  :root:not([data-theme="dark"]) a:hover { color: var(--brass-500); }
 }
 
 code {
@@ -385,6 +400,48 @@ li { margin: 0.25em 0; }
 /* Section spacing on the landing page */
 section { margin-bottom: 2.5em; }
 section:first-of-type { margin-top: 0; }
+
+/* Theme toggle button — brass coin in the nav */
+.theme-toggle {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 2.1em;
+  height: 2.1em;
+  padding: 0;
+  border: 1px solid var(--brass-600);
+  border-radius: 999px;
+  background: transparent;
+  color: var(--brass-300);
+  font-size: 1.05em;
+  line-height: 1;
+  cursor: pointer;
+  transition: border-color 0.15s ease, color 0.15s ease, background 0.15s ease;
+}
+.theme-toggle:hover {
+  border-color: var(--brass-400);
+  color: var(--brass-400);
+  background: var(--warm-bg-card);
+}
+.theme-toggle:focus-visible {
+  outline: 2px solid var(--brass-400);
+  outline-offset: 2px;
+}
+.theme-toggle .theme-toggle-icon {
+  display: inline-block;
+  transform: translateY(-1px);
+}
+
+/* Realm sigil mark — bottom-of-footer watermark from version.json meta tag */
+.sigil-mark {
+  margin-top: 0.4em !important;
+  font-size: 0.78em;
+  letter-spacing: 0.05em;
+  opacity: 0.7;
+}
+.sigil-mark a { color: inherit; border-bottom: 1px dotted currentColor; }
+.sigil-mark a:hover { color: var(--brass-300); text-decoration: none; }
+.sigil-mark em { font-style: normal; color: var(--brass-300); }
 
 /* Reduced motion */
 @media (prefers-reduced-motion: reduce) {

--- a/docs/assets/dark/dark.css
+++ b/docs/assets/dark/dark.css
@@ -1,0 +1,16 @@
+/* dark.realm.watch — schema-agnostic dark/light selector preset.
+   Pairs <html data-theme="..."> with prefers-color-scheme.
+   Three states: data-theme="light"  -> explicit light
+                 data-theme="dark"   -> explicit dark
+                 (attribute absent)  -> follow system */
+
+:root[data-theme="light"] { color-scheme: light; }
+:root[data-theme="dark"]  { color-scheme: dark; }
+
+@media (prefers-color-scheme: light) {
+  :root:not([data-theme="dark"]) { color-scheme: light; }
+}
+
+@media (prefers-color-scheme: dark) {
+  :root:not([data-theme="light"]) { color-scheme: dark; }
+}

--- a/docs/assets/dark/dark.js
+++ b/docs/assets/dark/dark.js
@@ -1,0 +1,87 @@
+// dark.realm.watch — system-aware dark/light theming engine.
+// Public API: window.Dark.{current, effective, set, cycle, config}.
+// Three states: 'light', 'dark', 'system' (system = absence of stored value).
+
+(function () {
+  var VALID = ['light', 'dark', 'system'];
+  var storageKey = 'drw-theme';
+  var mediaQuery = null;
+
+  function readPref() {
+    try {
+      var v = localStorage.getItem(storageKey);
+      return v === 'light' || v === 'dark' ? v : 'system';
+    } catch (_) {
+      return 'system';
+    }
+  }
+
+  function writePref(v) {
+    try {
+      if (v === 'system') localStorage.removeItem(storageKey);
+      else localStorage.setItem(storageKey, v);
+    } catch (_) {}
+  }
+
+  function effective() {
+    var p = readPref();
+    if (p !== 'system') return p;
+    if (!mediaQuery) mediaQuery = matchMedia('(prefers-color-scheme: dark)');
+    return mediaQuery.matches ? 'dark' : 'light';
+  }
+
+  function apply() {
+    var p = readPref();
+    var root = document.documentElement;
+    if (p === 'system') root.removeAttribute('data-theme');
+    else root.setAttribute('data-theme', p);
+    document.dispatchEvent(new CustomEvent('dark:change', {
+      detail: { theme: p, effective: effective() },
+    }));
+  }
+
+  function set(v) {
+    if (VALID.indexOf(v) === -1) {
+      throw new Error('Dark.set: invalid value: ' + v);
+    }
+    writePref(v);
+    apply();
+  }
+
+  function cycle() {
+    var p = readPref();
+    var next = p === 'system' ? 'dark' : p === 'dark' ? 'light' : 'system';
+    set(next);
+  }
+
+  function config(opts) {
+    if (opts && typeof opts.storage === 'string') {
+      storageKey = opts.storage;
+      apply();
+    }
+  }
+
+  function init() {
+    if (!mediaQuery) mediaQuery = matchMedia('(prefers-color-scheme: dark)');
+    if (mediaQuery.addEventListener) {
+      mediaQuery.addEventListener('change', function () {
+        if (readPref() === 'system') apply();
+      });
+    }
+    apply();
+  }
+
+  window.Dark = {
+    current: readPref,
+    effective: effective,
+    set: set,
+    cycle: cycle,
+    config: config,
+  };
+
+  if (document.readyState === 'loading') {
+    document.addEventListener('DOMContentLoaded', init);
+  } else {
+    init();
+  }
+})();

--- a/docs/index.md
+++ b/docs/index.md
@@ -117,13 +117,16 @@ description: Offline neural TTS, optional Azure HD cloud voices. Six sources —
 <section class="recent">
   <h2>What just shipped</h2>
   <p>
-    <strong>v0.4.83</strong> — Tier 3 multi-engine parallel synthesis with twin
-    Engines/Threads sliders in Settings → Performance, smart-resume CTA so the Library
-    button respects your last paused/playing intent, and a Tier 3 voice-swap engine-leak fix.
-    <a href="https://github.com/jphein/storyvox/releases/tag/v0.4.83">Full release notes →</a>
+    <strong>v0.5.00</strong> — Library Nocturne UX milestone. Full brass-on-warm-dark
+    polish pass across player, library, settings, and browse: TopAppBar nav across
+    detail screens, single back-nav pattern, chapter rows tappable with played
+    indicators, infinite-scroll Browse across every tab, brass spinners and progress
+    bars everywhere, deliberate first-time defaults, and a confetti milestone dialog.
+    <a href="https://github.com/jphein/storyvox/releases/tag/v0.5.00">Full release notes →</a>
   </p>
   <p>
-    <strong>v0.4 highlights since v0.4.55:</strong> Azure Cognitive Services HD voices as
+    <strong>Earlier in v0.4:</strong> Tier 3 multi-engine parallel synthesis with twin
+    Engines/Threads sliders (v0.4.78); smart-resume CTA (v0.4.83); Azure Cognitive Services HD voices as
     an optional remote TTS backend (BYOK, with offline fallback, error retries, full roster
     and cache eviction priority — <a href="https://github.com/jphein/storyvox/issues/182">#182</a>–<a href="https://github.com/jphein/storyvox/issues/186">#186</a>);
     EPUB import (<a href="https://github.com/jphein/storyvox/issues/235">#235</a>) via the

--- a/docs/version.json
+++ b/docs/version.json
@@ -1,0 +1,12 @@
+{
+  "name": "storyvox",
+  "description": "Neural-voice audiobook player for any text you have \u2014 offline TTS, optional Azure HD cloud voices, Library Nocturne aesthetic",
+  "version": "Noble Grimoire \u00b7 63f5826",
+  "hash": "63f5826",
+  "branch": "docs/sigil-and-dark-realm",
+  "dirty": false,
+  "built": "2026-05-11T01:46:47Z",
+  "realm": "fantasy",
+  "repo": "https://github.com/jphein/storyvox",
+  "commit_url": "https://github.com/jphein/storyvox/commit/63f5826"
+}


### PR DESCRIPTION
## Summary

Wire the docs site (Jekyll → GitHub Pages) into JP's standard realm toolchain and bring the headline callout current.

### realm-sigil (per CLAUDE.md "Unified Versioning")

- Ran `realm-sigil/static/build.sh` with `--realm fantasy` → bound the storyvox docs to **Noble Grimoire · 63f5826**.
- New `docs/version.json` (published at `https://jphein.github.io/storyvox/version.json`).
- `<meta name="realm-version">` injected into the Jekyll layout — every page now carries the sigil.
- New footer badge: `✦ <a href="commit">Noble Grimoire · 63f5826</a> · realm fantasy` — rendered client-side from the meta tag via safe DOM (no `innerHTML`).

### dark.realm.watch Tier 2

- No-FOUC inline head snippet, `dark.css`, `dark.js` — **inlined** into `docs/assets/dark/` because `dark.realm.watch` isn't on DNS yet (curl resolves to NXDOMAIN; only `realm.watch` root is up).
- Tri-state cycle button in the nav with `◐` (system) / `☾` (dark) / `☀` (light), wired to `Dark.cycle()` and updated on `dark:change`.
- Existing `@media (prefers-color-scheme: light)` blocks adapted: now mirror into `:root[data-theme="light"]`, and the system-pref block scoped with `:not([data-theme="dark"])` so an explicit dark choice wins.

### Callout refresh

- `docs/index.md` "What just shipped" was 13 releases stale at v0.4.83.
- Bumped to **v0.5.00 — Library Nocturne UX milestone** with a one-paragraph summary of the brass-on-everything polish pass.
- Old paragraph relabelled "Earlier in v0.4" with the cumulative v0.4.x highlights.

## Follow-ups

- Deploy `dark.realm.watch` and switch the `<link>`/`<script>` back to the CDN URL when DNS is live. The inlined copy is small (3KB total) so the cutover is just two lines in the layout.
- Add `https://jphein.github.io/storyvox/version.json` to `status.realm.watch/checks.json` once this merges (separate repo, separate PR).
- Hook `build.sh` into a release-time step so `version.json` regenerates per release instead of staying frozen at PR-time hash.

## Test plan

- [ ] GitHub Pages build succeeds (CI)
- [ ] `/version.json` is reachable on the published site
- [ ] Theme toggle cycles system → dark → light → system without FOUC on reload
- [ ] Sigil badge renders the linked version string + realm at the bottom of every page
- [ ] Light theme honors the brass-on-parchment palette as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)