### PR TITLE
fix(docs/dark): matchMedia feature-detect + legacy addListener fallback

### DIFF
--- a/docs/assets/dark/dark.js
+++ b/docs/assets/dark/dark.js
@@ -26,8 +26,10 @@
   function effective() {
     var p = readPref();
     if (p !== 'system') return p;
-    if (!mediaQuery) mediaQuery = matchMedia('(prefers-color-scheme: dark)');
-    return mediaQuery.matches ? 'dark' : 'light';
+    if (!mediaQuery && typeof window.matchMedia === 'function') {
+      mediaQuery = window.matchMedia('(prefers-color-scheme: dark)');
+    }
+    return mediaQuery && mediaQuery.matches ? 'dark' : 'light';
   }
 
   function apply() {
@@ -62,11 +64,19 @@
   }
 
   function init() {
-    if (!mediaQuery) mediaQuery = matchMedia('(prefers-color-scheme: dark)');
-    if (mediaQuery.addEventListener) {
-      mediaQuery.addEventListener('change', function () {
+    if (!mediaQuery && typeof window.matchMedia === 'function') {
+      mediaQuery = window.matchMedia('(prefers-color-scheme: dark)');
+    }
+    if (mediaQuery) {
+      var onChange = function () {
         if (readPref() === 'system') apply();
-      });
+      };
+      if (mediaQuery.addEventListener) {
+        mediaQuery.addEventListener('change', onChange);
+      } else if (mediaQuery.addListener) {
+        // Legacy MediaQueryList API (Safari < 14, older Chromium forks).
+        mediaQuery.addListener(onChange);
+      }
     }
     apply();
   }


### PR DESCRIPTION
## Summary

Addresses both Copilot review comments from #319 (`dark.js:31` and `dark.js:69`) that I'd previously filed as overcalibrated for a 2026 baseline. On re-evaluation: the diff is tiny, the resilience is real, and the comments deserved better than a dismissal.

## Changes (`docs/assets/dark/dark.js`)

1. **`effective()` and `init()` now feature-detect `window.matchMedia`** with `typeof === 'function'`. Browsers without it (rare embedded webviews, very old browsers) used to throw and break the entire toggle; now they degrade cleanly to `'light'`.

2. **The `prefers-color-scheme` change listener falls back to the deprecated `mediaQuery.addListener(...)`** when `addEventListener` isn't present. Safari < 14 only exposes the legacy API. Without the fallback, system-theme changes don't propagate while in 'system' mode on those browsers.

## Follow-up (not in this PR)

The upstream `dark.realm.watch` source at `~/Projects/dark.realm.watch/dark.js` should get the same patch — this is the vendored copy under `docs/assets/dark/`. Filing that as a separate task.

## Test plan

- [ ] No visual regression on dark/light/system cycle in current Chrome/Firefox/Safari
- [ ] No JS console errors on first paint
- [ ] Toggle still updates the sigil + theme on `dark:change`

🤖 Generated with [Claude Code](https://claude.com/claude-code)