### PR TITLE
ci: shrink Gradle cache to deps only (modules-2)

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -34,13 +34,22 @@ jobs:
         with:
           accept-android-sdk-licenses: true
 
-      - name: Cache Gradle
+      - name: Cache Gradle (deps only)
+        # Cache only resolved dependency files, not the whole ~/.gradle
+        # tree. The full tree includes transformed AARs / R8 mapping /
+        # build outputs and balloons to ~3 GB per build — fast to
+        # rebuild but expensive to store on the 2 GB free-tier quota.
+        # Dependency files alone are ~300-500 MB and what actually
+        # earns its keep across runs. Key is stable across day-to-day
+        # commits (only changes when Gradle wrapper or version catalog
+        # moves), so we get a single shared cache instead of one per
+        # gradle-file edit.
         uses: actions/cache@v4
         with:
           path: |
-            ~/.gradle/caches
+            ~/.gradle/caches/modules-2
             ~/.gradle/wrapper
-          key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle*', '**/gradle-wrapper.properties', 'gradle/libs.versions.toml') }}
+          key: ${{ runner.os }}-gradle-${{ hashFiles('**/gradle-wrapper.properties', 'gradle/libs.versions.toml') }}
           restore-keys: |
             ${{ runner.os }}-gradle-
 


### PR DESCRIPTION
## Summary

Just hit the 2 GB GitHub Actions storage cap. **9.7 GB across 3 active Gradle caches** was the culprit — not artifacts. Already pruned the live caches; this PR fixes the workflow so they don't grow back this fast.

## Root cause

The cache step was caching `~/.gradle/caches` wholesale, which pulls in:
- Resolved dependency files (~300-500 MB) ← what you actually want
- Transformed AARs, R8 mapping, build outputs (~2-3 GB) ← noise

Each commit changed *some* gradle file, busting the cache key (`hashFiles('**/*.gradle*')`) and creating a new 3 GB cache. Three day's commits = 9.7 GB.

## Fix

1. **Cache path narrows** to `~/.gradle/caches/modules-2` + `~/.gradle/wrapper` — drops cache size from ~3 GB to ~300-500 MB.
2. **Cache key narrows** to `hashFiles('**/gradle-wrapper.properties', 'gradle/libs.versions.toml')` — keys only flip on toolchain / version-catalog bumps, so day-to-day commits share one cache.

Combined with #323's upload-artifact tag-gate, Actions storage spend now scales with `releases × 70 MB APK + 1 shared 500 MB cache that turns over slowly` instead of `every CI run × 3 GB`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)