### PR TITLE
fix(ui): brass-sigil monogram placeholder instead of '?' (closes #322)

### DIFF
--- a/core-ui/src/main/kotlin/in/jphe/storyvox/ui/component/FictionCoverThumb.kt
+++ b/core-ui/src/main/kotlin/in/jphe/storyvox/ui/component/FictionCoverThumb.kt
@@ -1,7 +1,9 @@
 package `in`.jphe.storyvox.ui.component
 
+import androidx.compose.foundation.Canvas
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.BoxWithConstraints
 import androidx.compose.foundation.layout.aspectRatio
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.material3.MaterialTheme
@@ -10,18 +12,30 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
+import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.graphics.Brush
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.Path
+import androidx.compose.ui.graphics.drawscope.DrawScope
+import androidx.compose.ui.graphics.drawscope.Stroke
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.semantics.contentDescription
 import androidx.compose.ui.semantics.semantics
+import androidx.compose.ui.unit.sp
 import coil.compose.SubcomposeAsyncImage
+import kotlin.math.cos
+import kotlin.math.min
+import kotlin.math.sin
 
 /**
- * Async cover image with a brass-tinted placeholder.
+ * Async cover image with a brass-tinted sigil placeholder.
  *
- * Placeholder shows a single-character monogram in brass on the warm-dark
- * (or parchment-cream in light mode) card. Callers compute the monogram
- * via [fictionMonogram] which prefers author → title → brass star, so RSS
+ * When [coverUrl] is null or fails to load, draws a static Library
+ * Nocturne sigil — faint brass ring + six-pointed star encircling the
+ * fiction's [monogram]. The same visual family as [MagicSkeletonTile]
+ * but static: a sigil reads as "this fiction is bound to this mark",
+ * not "we're conjuring something". Callers compute [monogram] via
+ * [fictionMonogram] which prefers author → title → brass star, so RSS
  * feeds and other coverless-and-authorless fictions still render an
  * intentional Library Nocturne mark rather than a `?` (#322).
  */
@@ -33,12 +47,6 @@ fun FictionCoverThumb(
     modifier: Modifier = Modifier,
     contentScale: ContentScale = ContentScale.Crop,
 ) {
-    val placeholderBrush = Brush.linearGradient(
-        colors = listOf(
-            MaterialTheme.colorScheme.surfaceContainerHigh,
-            MaterialTheme.colorScheme.surfaceContainerHighest,
-        ),
-    )
     Box(
         modifier = modifier
             .aspectRatio(2f / 3f)
@@ -50,24 +58,106 @@ fun FictionCoverThumb(
             contentDescription = null,
             contentScale = contentScale,
             modifier = Modifier.fillMaxSize(),
-            loading = {
-                Box(modifier = Modifier.fillMaxSize().background(placeholderBrush), contentAlignment = Alignment.Center) {
-                    Text(
-                        text = monogram,
-                        style = MaterialTheme.typography.displayMedium,
-                        color = MaterialTheme.colorScheme.primary,
-                    )
-                }
-            },
-            error = {
-                Box(modifier = Modifier.fillMaxSize().background(placeholderBrush), contentAlignment = Alignment.Center) {
-                    Text(
-                        text = monogram,
-                        style = MaterialTheme.typography.displayMedium,
-                        color = MaterialTheme.colorScheme.primary,
-                    )
-                }
-            },
+            loading = { MonogramSigilTile(monogram = monogram) },
+            error = { MonogramSigilTile(monogram = monogram) },
         )
     }
+}
+
+/**
+ * Static brass-sigil placeholder shown in place of a cover image when one
+ * isn't available. Visual family deliberately matches [MagicSkeletonTile]
+ * (the loading-state version) — same substrate, ring, six-pointed star,
+ * brass palette — but holds still: a sigil reads as "this fiction is
+ * bound to this mark," not "we're conjuring something."
+ *
+ * Monogram font-size scales with the container's smaller dimension via
+ * [BoxWithConstraints] so the same component looks right in both the
+ * 56-dp Follows thumbnail and the 220-dp audiobook player cover.
+ */
+@Composable
+private fun MonogramSigilTile(monogram: String) {
+    val brass = MaterialTheme.colorScheme.primary
+    val brassDim = brass.copy(alpha = 0.40f)
+    val brassFaint = brass.copy(alpha = 0.18f)
+    val substrate = MaterialTheme.colorScheme.surfaceContainerHigh
+
+    BoxWithConstraints(
+        modifier = Modifier
+            .fillMaxSize()
+            .background(substrate),
+        contentAlignment = Alignment.Center,
+    ) {
+        // Aged-leather radial wash: lighter at the edges, slightly
+        // darker at the center so the sigil reads against a faint
+        // halo instead of a flat substrate.
+        Box(
+            modifier = Modifier
+                .fillMaxSize()
+                .background(
+                    Brush.radialGradient(
+                        colors = listOf(
+                            substrate.copy(alpha = 0f),
+                            substrate.copy(alpha = 0.45f),
+                        ),
+                    ),
+                ),
+        )
+        // Brass sigil — outer ring + six-pointed star, sized to ~70%
+        // of the tile so the monogram can sit comfortably inside.
+        Canvas(modifier = Modifier.fillMaxSize(0.72f)) {
+            val center = Offset(size.width / 2f, size.height / 2f)
+            val radius = size.minDimension / 2f
+            val ringStroke = (radius * 0.05f).coerceAtLeast(1.5f)
+            val starStroke = (radius * 0.07f).coerceAtLeast(2.0f)
+
+            drawCircle(
+                color = brassFaint,
+                radius = radius * 0.95f,
+                center = center,
+                style = Stroke(width = ringStroke),
+            )
+            // Six-pointed star = two overlaid equilateral triangles
+            drawTriangle(center, radius * 0.86f, 0f, brassDim, starStroke)
+            drawTriangle(
+                center,
+                radius * 0.86f,
+                60f,
+                brassDim.copy(alpha = brassDim.alpha * 0.85f),
+                starStroke,
+            )
+        }
+        // Monogram letter inside the sigil — serif, brass, size scales
+        // with the container so it looks right at 56 dp and 220 dp.
+        val smallerDim = min(maxWidth.value, maxHeight.value)
+        val monogramSize = (smallerDim * 0.32f).coerceIn(14f, 56f).sp
+        Text(
+            text = monogram,
+            style = MaterialTheme.typography.displayMedium.copy(fontSize = monogramSize),
+            color = brass,
+        )
+    }
+}
+
+/**
+ * Draw an equilateral triangle inscribed in [radius] around [center],
+ * rotated by [degreesOffset]. Stroke only. Mirrors the same helper used
+ * by [MagicSkeletonTile] so both visuals trace the same star geometry.
+ */
+private fun DrawScope.drawTriangle(
+    center: Offset,
+    radius: Float,
+    degreesOffset: Float,
+    color: Color,
+    strokeWidth: Float,
+) {
+    val path = Path()
+    for (i in 0..2) {
+        val angle = Math.toRadians(degreesOffset.toDouble() + i * 120.0 - 90.0)
+        val x = center.x + radius * cos(angle).toFloat()
+        val y = center.y + radius * sin(angle).toFloat()
+        if (i == 0) path.moveTo(x, y) else path.lineTo(x, y)
+    }
+    path.close()
+    drawPath(path = path, color = color, style = Stroke(width = strokeWidth))
 }

--- a/core-ui/src/main/kotlin/in/jphe/storyvox/ui/component/FictionCoverThumb.kt
+++ b/core-ui/src/main/kotlin/in/jphe/storyvox/ui/component/FictionCoverThumb.kt
@@ -18,13 +18,18 @@ import coil.compose.SubcomposeAsyncImage
 
 /**
  * Async cover image with a brass-tinted placeholder.
- * Placeholder shows the author's first initial in brass on warm dark.
+ *
+ * Placeholder shows a single-character monogram in brass on the warm-dark
+ * (or parchment-cream in light mode) card. Callers compute the monogram
+ * via [fictionMonogram] which prefers author → title → brass star, so RSS
+ * feeds and other coverless-and-authorless fictions still render an
+ * intentional Library Nocturne mark rather than a `?` (#322).
  */
 @Composable
 fun FictionCoverThumb(
     coverUrl: String?,
     title: String,
-    authorInitial: Char,
+    monogram: String,
     modifier: Modifier = Modifier,
     contentScale: ContentScale = ContentScale.Crop,
 ) {
@@ -48,7 +53,7 @@ fun FictionCoverThumb(
             loading = {
                 Box(modifier = Modifier.fillMaxSize().background(placeholderBrush), contentAlignment = Alignment.Center) {
                     Text(
-                        text = authorInitial.toString(),
+                        text = monogram,
                         style = MaterialTheme.typography.displayMedium,
                         color = MaterialTheme.colorScheme.primary,
                     )
@@ -57,7 +62,7 @@ fun FictionCoverThumb(
             error = {
                 Box(modifier = Modifier.fillMaxSize().background(placeholderBrush), contentAlignment = Alignment.Center) {
                     Text(
-                        text = authorInitial.toString(),
+                        text = monogram,
                         style = MaterialTheme.typography.displayMedium,
                         color = MaterialTheme.colorScheme.primary,
                     )

--- a/core-ui/src/main/kotlin/in/jphe/storyvox/ui/component/FictionMonogram.kt
+++ b/core-ui/src/main/kotlin/in/jphe/storyvox/ui/component/FictionMonogram.kt
@@ -1,0 +1,22 @@
+package `in`.jphe.storyvox.ui.component
+
+/**
+ * Derives the single-character monogram shown on a fiction's cover when
+ * we have no cover image. Resolution order:
+ *
+ * 1. First letter / digit of the **author** (most identifying)
+ * 2. First letter / digit of the **title** (RSS feeds, GitHub repos, and
+ *    other backends often carry no author field — title is the next-best
+ *    discriminator)
+ * 3. The brass star `✦` as a final fallback. Reads as an intentional
+ *    Library Nocturne mark instead of the previous `?`, which looked
+ *    like a broken-image placeholder (#322).
+ *
+ * The result is `uppercaseChar()`-folded so locale-driven case mapping
+ * doesn't make the same fiction render differently across devices.
+ */
+fun fictionMonogram(author: String, title: String): String {
+    val ch = author.firstOrNull { it.isLetterOrDigit() }?.uppercaseChar()
+        ?: title.firstOrNull { it.isLetterOrDigit() }?.uppercaseChar()
+    return ch?.toString() ?: "✦"
+}

--- a/feature/src/main/kotlin/in/jphe/storyvox/feature/browse/BrowseScreen.kt
+++ b/feature/src/main/kotlin/in/jphe/storyvox/feature/browse/BrowseScreen.kt
@@ -61,6 +61,7 @@ import `in`.jphe.storyvox.ui.component.friendlyErrorMessage
 import `in`.jphe.storyvox.ui.component.ErrorPlacement
 import `in`.jphe.storyvox.ui.component.FictionCardSkeleton
 import `in`.jphe.storyvox.ui.component.FictionCoverThumb
+import `in`.jphe.storyvox.ui.component.fictionMonogram
 import `in`.jphe.storyvox.ui.component.MagicSpinner
 import `in`.jphe.storyvox.ui.theme.LocalSpacing
 
@@ -280,7 +281,7 @@ fun BrowseScreen(
                             FictionCoverThumb(
                                 coverUrl = fiction.coverUrl,
                                 title = fiction.title,
-                                authorInitial = fiction.author.firstOrNull()?.uppercaseChar() ?: '?',
+                                monogram = fictionMonogram(fiction.author, fiction.title),
                                 modifier = Modifier.fillMaxWidth(),
                             )
                             // Issue #272 — titles longer than 2 lines were silently

--- a/feature/src/main/kotlin/in/jphe/storyvox/feature/fiction/FictionDetailScreen.kt
+++ b/feature/src/main/kotlin/in/jphe/storyvox/feature/fiction/FictionDetailScreen.kt
@@ -47,6 +47,7 @@ import `in`.jphe.storyvox.ui.component.ErrorBlock
 import `in`.jphe.storyvox.ui.component.ErrorPlacement
 import `in`.jphe.storyvox.ui.component.friendlyErrorMessage
 import `in`.jphe.storyvox.ui.component.FictionCoverThumb
+import `in`.jphe.storyvox.ui.component.fictionMonogram
 import `in`.jphe.storyvox.ui.component.FictionDetailSkeleton
 import `in`.jphe.storyvox.ui.layout.isAtLeastTablet
 import `in`.jphe.storyvox.ui.theme.LocalSpacing
@@ -271,7 +272,7 @@ private fun Hero(fiction: UiFiction) {
         FictionCoverThumb(
             coverUrl = fiction.coverUrl,
             title = fiction.title,
-            authorInitial = fiction.author.firstOrNull()?.uppercaseChar() ?: '?',
+            monogram = fictionMonogram(fiction.author, fiction.title),
             modifier = Modifier.size(width = 120.dp, height = 180.dp),
         )
         Column(

--- a/feature/src/main/kotlin/in/jphe/storyvox/feature/follows/FollowsScreen.kt
+++ b/feature/src/main/kotlin/in/jphe/storyvox/feature/follows/FollowsScreen.kt
@@ -33,6 +33,7 @@ import `in`.jphe.storyvox.feature.api.UiFollow
 import `in`.jphe.storyvox.ui.component.BrassButton
 import `in`.jphe.storyvox.ui.component.BrassButtonVariant
 import `in`.jphe.storyvox.ui.component.FictionCoverThumb
+import `in`.jphe.storyvox.ui.component.fictionMonogram
 import `in`.jphe.storyvox.ui.component.MagicSkeletonTile
 import `in`.jphe.storyvox.ui.component.SkeletonBlock
 import `in`.jphe.storyvox.ui.layout.isAtLeastTablet
@@ -254,7 +255,7 @@ private fun FollowCard(follow: UiFollow, onClick: () -> Unit) {
             FictionCoverThumb(
                 coverUrl = follow.fiction.coverUrl,
                 title = follow.fiction.title,
-                authorInitial = follow.fiction.author.firstOrNull()?.uppercaseChar() ?: '?',
+                monogram = fictionMonogram(follow.fiction.author, follow.fiction.title),
                 modifier = Modifier.size(width = 56.dp, height = 84.dp),
             )
             Column(modifier = Modifier.weight(1f)) {

--- a/feature/src/main/kotlin/in/jphe/storyvox/feature/library/LibraryScreen.kt
+++ b/feature/src/main/kotlin/in/jphe/storyvox/feature/library/LibraryScreen.kt
@@ -37,6 +37,7 @@ import `in`.jphe.storyvox.ui.component.BrassButton
 import `in`.jphe.storyvox.ui.component.BrassButtonVariant
 import `in`.jphe.storyvox.ui.component.BrassProgressBar
 import `in`.jphe.storyvox.ui.component.FictionCoverThumb
+import `in`.jphe.storyvox.ui.component.fictionMonogram
 import `in`.jphe.storyvox.ui.component.MagicSkeletonTile
 import `in`.jphe.storyvox.ui.component.cascadeReveal
 import `in`.jphe.storyvox.ui.theme.LocalSpacing
@@ -114,7 +115,7 @@ fun LibraryScreen(
                             FictionCoverThumb(
                                 coverUrl = fiction.coverUrl,
                                 title = fiction.title,
-                                authorInitial = fiction.author.firstOrNull()?.uppercaseChar() ?: '?',
+                                monogram = fictionMonogram(fiction.author, fiction.title),
                                 modifier = Modifier
                                     .fillMaxWidth()
                                     .clickable { viewModel.openFiction(fiction.id) },
@@ -167,7 +168,7 @@ private fun ResumeCard(entry: ContinueListeningEntry, onResume: () -> Unit) {
             FictionCoverThumb(
                 coverUrl = entry.fiction.coverUrl,
                 title = entry.fiction.title,
-                authorInitial = entry.fiction.author.firstOrNull()?.uppercaseChar() ?: '?',
+                monogram = fictionMonogram(entry.fiction.author, entry.fiction.title),
                 modifier = Modifier.size(width = 68.dp, height = 100.dp),
             )
             Column(modifier = Modifier.weight(1f)) {

--- a/feature/src/main/kotlin/in/jphe/storyvox/feature/reader/AudiobookView.kt
+++ b/feature/src/main/kotlin/in/jphe/storyvox/feature/reader/AudiobookView.kt
@@ -73,6 +73,7 @@ import `in`.jphe.storyvox.ui.component.BrassProgressTrack
 import `in`.jphe.storyvox.ui.component.ErrorBlock
 import `in`.jphe.storyvox.ui.component.ErrorPlacement
 import `in`.jphe.storyvox.ui.component.FictionCoverThumb
+import `in`.jphe.storyvox.ui.component.fictionMonogram
 import `in`.jphe.storyvox.ui.component.MagicSkeletonTile
 import `in`.jphe.storyvox.ui.component.MagicSpinner
 import `in`.jphe.storyvox.ui.theme.LocalMotion
@@ -209,7 +210,7 @@ fun AudiobookView(
                     FictionCoverThumb(
                         coverUrl = state.coverUrl,
                         title = state.fictionTitle,
-                        authorInitial = state.fictionTitle.firstOrNull()?.uppercaseChar() ?: '?',
+                        monogram = fictionMonogram(author = "", title = state.fictionTitle),
                         modifier = Modifier.size(width = 220.dp, height = 330.dp),
                     )
                     // Subtle brass sigil ring orbiting the cover while the


### PR DESCRIPTION
## Summary

Replaces the giant `?` shown on cover-less fictions (RSS feeds, etc.) with a brass-sigil monogram that visually matches the loading skeleton — same warm-dark substrate, faint dashed outer ring, six-pointed brass star — but held still. The fiction's monogram letter sits at the center.

Side-by-side meaning: the *animated* sigil reads as "we're conjuring this fiction"; the *static* sigil reads as "this fiction is bound to this mark."

## Implementation

1. **`fictionMonogram(author, title)`** — single helper for the resolution chain across all six callers (Browse, Library Resume, Library grid, Fiction detail, Follows row, Audiobook player). Author's first letter/digit → title's first letter/digit → brass star `✦` final fallback. AudiobookView's hand-rolled title-fallback now goes through the same helper for contract symmetry.

2. **`MonogramSigilTile`** in `FictionCoverThumb.kt` — private Composable that draws:
   - `surfaceContainerHigh` substrate (matches `MagicSkeletonTile`)
   - Radial wash (subtle warm halo, also matches the skeleton)
   - Faint outer ring + six-pointed brass star (static; no animation)
   - Monogram letter at center, EB Garamond serif, brass color
   - `BoxWithConstraints` scales font-size to container — looks right at both 56-dp Follows thumbnails and 220-dp audiobook player covers
   - `drawTriangle` helper inlined; mirrors the private one in `SkeletonShimmer.kt`

3. **`FictionCoverThumb`** API change: `authorInitial: Char` → `monogram: String`. Six call sites updated via the helper.

## Verified

Built + installed on R83W80CAFZB (Galaxy Tab A7 Lite, v0.5.00). The lionsroar.com Library card now renders a brass **L** inside the six-pointed sigil instead of a bare `?`.

Closes #322.

🤖 Generated with [Claude Code](https://claude.com/claude-code)