### PR TITLE
fix(ui): defensive distinctBy on LazyVerticalGrid keys (#328 RSS crash)

### DIFF
--- a/feature/src/main/kotlin/in/jphe/storyvox/feature/browse/BrowseScreen.kt
+++ b/feature/src/main/kotlin/in/jphe/storyvox/feature/browse/BrowseScreen.kt
@@ -269,7 +269,11 @@ fun BrowseScreen(
                             )
                         }
                     }
-                    itemsIndexed(state.items, key = { _, item -> item.id }) { index, fiction ->
+                    // #328 — see LibraryScreen.kt; same defensive distinctBy
+                    // guard so duplicate fiction ids (Royal Road occasionally
+                    // returns the same fiction twice on filter edge cases)
+                    // can't crash the grid via Compose's unique-key contract.
+                    itemsIndexed(state.items.distinctBy { it.id }, key = { _, item -> item.id }) { index, fiction ->
                         Column(
                             modifier = Modifier
                                 .fillMaxWidth()

--- a/feature/src/main/kotlin/in/jphe/storyvox/feature/browse/BrowseScreen.kt
+++ b/feature/src/main/kotlin/in/jphe/storyvox/feature/browse/BrowseScreen.kt
@@ -74,6 +74,22 @@ fun BrowseScreen(
     val spacing = LocalSpacing.current
     var showFilterSheet by remember { mutableStateOf(false) }
 
+    // #328 — see LibraryScreen.kt; hoist distinctBy out of the grid
+    // builder so allocations happen once per state.items change instead
+    // of every recomposition, and log when duplicates appear so the
+    // upstream RR / GitHub paginator that emitted them can be traced.
+    val dedupedItems = remember(state.items) {
+        val out = state.items.distinctBy { it.id }
+        val dropped = state.items.size - out.size
+        if (dropped > 0) {
+            android.util.Log.w(
+                "storyvox",
+                "BrowseScreen: dropped $dropped duplicate fiction id(s) (size ${state.items.size} -> ${out.size}) — see #328",
+            )
+        }
+        out
+    }
+
     Column(modifier = Modifier.fillMaxSize().padding(top = spacing.md)) {
         // Top-level source picker. Switches the multibinding lookup in
         // FictionRepository between Royal Road and GitHub. Tabs and the
@@ -269,11 +285,7 @@ fun BrowseScreen(
                             )
                         }
                     }
-                    // #328 — see LibraryScreen.kt; same defensive distinctBy
-                    // guard so duplicate fiction ids (Royal Road occasionally
-                    // returns the same fiction twice on filter edge cases)
-                    // can't crash the grid via Compose's unique-key contract.
-                    itemsIndexed(state.items.distinctBy { it.id }, key = { _, item -> item.id }) { index, fiction ->
+                    itemsIndexed(dedupedItems, key = { _, item -> item.id }) { index, fiction ->
                         Column(
                             modifier = Modifier
                                 .fillMaxWidth()

--- a/feature/src/main/kotlin/in/jphe/storyvox/feature/follows/FollowsScreen.kt
+++ b/feature/src/main/kotlin/in/jphe/storyvox/feature/follows/FollowsScreen.kt
@@ -53,6 +53,23 @@ fun FollowsScreen(
     val spacing = LocalSpacing.current
     val multiColumn = isAtLeastTablet()
 
+    // #328 — single deduped list shared by both the grid (multiColumn)
+    // and the linear LazyColumn branches below. Computed once per
+    // state.follows change via remember instead of per-recomposition.
+    // Logs when Royal Road sign-in cache hydration accidentally
+    // double-emits so the underlying race can be traced.
+    val dedupedFollows = androidx.compose.runtime.remember(state.follows) {
+        val out = state.follows.distinctBy { it.fiction.id }
+        val dropped = state.follows.size - out.size
+        if (dropped > 0) {
+            android.util.Log.w(
+                "storyvox",
+                "FollowsScreen: dropped $dropped duplicate follow id(s) (size ${state.follows.size} -> ${out.size}) — see #328",
+            )
+        }
+        out
+    }
+
     androidx.compose.runtime.LaunchedEffect(viewModel) {
         viewModel.events.collect { event ->
             if (event is FollowsUiEvent.OpenFiction) onOpenFiction(event.fictionId)
@@ -96,11 +113,7 @@ fun FollowsScreen(
                         horizontalArrangement = Arrangement.spacedBy(spacing.sm),
                         verticalArrangement = Arrangement.spacedBy(spacing.sm),
                     ) {
-                        // #328 — see LibraryScreen.kt. Royal Road follows
-                        // can occasionally double-emit during sign-in cache
-                        // hydration; defensive distinctBy keeps Compose's
-                        // unique-key contract honored regardless.
-                        gridItems(state.follows.distinctBy { it.fiction.id }, key = { it.fiction.id }) { follow ->
+                        gridItems(dedupedFollows, key = { it.fiction.id }) { follow ->
                             FollowCard(follow = follow, onClick = { viewModel.open(follow.fiction.id) })
                         }
                     }
@@ -110,7 +123,7 @@ fun FollowsScreen(
                         contentPadding = PaddingValues(spacing.md),
                         verticalArrangement = Arrangement.spacedBy(spacing.sm),
                     ) {
-                        items(state.follows.distinctBy { it.fiction.id }, key = { it.fiction.id }) { follow ->
+                        items(dedupedFollows, key = { it.fiction.id }) { follow ->
                             FollowCard(follow = follow, onClick = { viewModel.open(follow.fiction.id) })
                         }
                     }

--- a/feature/src/main/kotlin/in/jphe/storyvox/feature/follows/FollowsScreen.kt
+++ b/feature/src/main/kotlin/in/jphe/storyvox/feature/follows/FollowsScreen.kt
@@ -96,7 +96,11 @@ fun FollowsScreen(
                         horizontalArrangement = Arrangement.spacedBy(spacing.sm),
                         verticalArrangement = Arrangement.spacedBy(spacing.sm),
                     ) {
-                        gridItems(state.follows, key = { it.fiction.id }) { follow ->
+                        // #328 — see LibraryScreen.kt. Royal Road follows
+                        // can occasionally double-emit during sign-in cache
+                        // hydration; defensive distinctBy keeps Compose's
+                        // unique-key contract honored regardless.
+                        gridItems(state.follows.distinctBy { it.fiction.id }, key = { it.fiction.id }) { follow ->
                             FollowCard(follow = follow, onClick = { viewModel.open(follow.fiction.id) })
                         }
                     }
@@ -106,7 +110,7 @@ fun FollowsScreen(
                         contentPadding = PaddingValues(spacing.md),
                         verticalArrangement = Arrangement.spacedBy(spacing.sm),
                     ) {
-                        items(state.follows, key = { it.fiction.id }) { follow ->
+                        items(state.follows.distinctBy { it.fiction.id }, key = { it.fiction.id }) { follow ->
                             FollowCard(follow = follow, onClick = { viewModel.open(follow.fiction.id) })
                         }
                     }

--- a/feature/src/main/kotlin/in/jphe/storyvox/feature/library/LibraryScreen.kt
+++ b/feature/src/main/kotlin/in/jphe/storyvox/feature/library/LibraryScreen.kt
@@ -103,7 +103,14 @@ fun LibraryScreen(
                             ResumeCard(resume, onResume = viewModel::resume)
                         }
                     }
-                    itemsIndexed(state.fictions, key = { _, item -> item.id }) { index, fiction ->
+                    // #328 — dedupe defensively. LazyVerticalGrid keys must
+                    // be unique or Compose throws IllegalArgumentException
+                    // and crashes the activity. If anything upstream lets a
+                    // duplicate fiction id reach the UI (RSS re-import,
+                    // sync race, hash collision), this guard keeps the grid
+                    // healthy. Order is preserved (distinctBy retains the
+                    // first occurrence) so the user-visible list is stable.
+                    itemsIndexed(state.fictions.distinctBy { it.id }, key = { _, item -> item.id }) { index, fiction ->
                         Column(
                             modifier = Modifier
                                 .fillMaxWidth()

--- a/feature/src/main/kotlin/in/jphe/storyvox/feature/library/LibraryScreen.kt
+++ b/feature/src/main/kotlin/in/jphe/storyvox/feature/library/LibraryScreen.kt
@@ -55,6 +55,25 @@ fun LibraryScreen(
     val addByUrlState by viewModel.addByUrlState.collectAsStateWithLifecycle()
     val spacing = LocalSpacing.current
 
+    // #328 — dedupe defensively before the LazyVerticalGrid sees the list.
+    // Compose enforces unique item keys; duplicates throw and crash the
+    // activity. Hoisted out of the grid builder via remember so the
+    // distinctBy pass runs once per state.fictions change instead of on
+    // every recomposition. Logs at warn level when duplicates are dropped
+    // so the underlying source can be traced — silent-by-default would
+    // hide the upstream bug we're guarding around.
+    val dedupedFictions = androidx.compose.runtime.remember(state.fictions) {
+        val out = state.fictions.distinctBy { it.id }
+        val dropped = state.fictions.size - out.size
+        if (dropped > 0) {
+            android.util.Log.w(
+                "storyvox",
+                "LibraryScreen: dropped $dropped duplicate fiction id(s) (size ${state.fictions.size} -> ${out.size}) — see #328",
+            )
+        }
+        out
+    }
+
     androidx.compose.runtime.LaunchedEffect(viewModel) {
         viewModel.events.collect { event ->
             when (event) {
@@ -103,14 +122,7 @@ fun LibraryScreen(
                             ResumeCard(resume, onResume = viewModel::resume)
                         }
                     }
-                    // #328 — dedupe defensively. LazyVerticalGrid keys must
-                    // be unique or Compose throws IllegalArgumentException
-                    // and crashes the activity. If anything upstream lets a
-                    // duplicate fiction id reach the UI (RSS re-import,
-                    // sync race, hash collision), this guard keeps the grid
-                    // healthy. Order is preserved (distinctBy retains the
-                    // first occurrence) so the user-visible list is stable.
-                    itemsIndexed(state.fictions.distinctBy { it.id }, key = { _, item -> item.id }) { index, fiction ->
+                    itemsIndexed(dedupedFictions, key = { _, item -> item.id }) { index, fiction ->
                         Column(
                             modifier = Modifier
                                 .fillMaxWidth()


### PR DESCRIPTION
## Summary

LazyVerticalGrid crashed with `IllegalArgumentException: Key "159695" was already used` on JP's Flip3 with the lionsroar.com RSS feed in library. Compose's contract: unique keys per item, or the activity dies.

This PR is the **symptom-side guard** — `distinctBy { it.id }` before passing the list to `itemsIndexed` / `gridItems` / `items` at all four call sites:

- `LibraryScreen.kt:106` — Library grid
- `BrowseScreen.kt:272` — Browse grid
- `FollowsScreen.kt:99` — Follows grid (compact layout)
- `FollowsScreen.kt:109` — Follows list (linear layout)

distinctBy retains the first occurrence, so user-visible ordering is stable.

## Why guard symptom-side at all

The principle: a duplicate id reaching the UI is a real bug worth tracing, but it should never *crash* the app. Defense-in-depth: data layer should dedup, AND the UI should refuse to be the place a dup turns into a fatal exception.

## Root-cause follow-up (issue #328 body)

The reasons this can happen aren't fixed by this PR — the issue describes the candidate paths to investigate:
- `FictionRepository.observeLibrary` — how multi-source fictions are merged
- Royal Road sign-in cache hydration — possible double-emit during sync
- RSS reimport path
- Hash collision between `fictionIdForFeedUrl` (`String.hashCode`) and Royal Road's numeric ids (formats differ — `rss:hex` vs bare integer — but worth proving)

## Verified

Built + installed on R5CRB0W66MK. Library / Browse / Follows still render normally.

Filed via the bug audit JP requested for the Flip3.

🤖 Generated with [Claude Code](https://claude.com/claude-code)