### PR TITLE
fix(browse): hide filter icon for sources with no filter sheet (#330)

### DIFF
--- a/feature/src/main/kotlin/in/jphe/storyvox/feature/browse/BrowseScreen.kt
+++ b/feature/src/main/kotlin/in/jphe/storyvox/feature/browse/BrowseScreen.kt
@@ -138,28 +138,40 @@ fun BrowseScreen(
                 }
             }
             // Filter sheet is per-source: RR has its `/fictions/search`
-            // form, GitHub has the `/search/repositories` qualifier set.
-            // Both surface through the same FilterButton; the badge
-            // count and the sheet that opens both branch on sourceKey.
-            FilterButton(
-                activeCount = when (state.sourceKey) {
-                    BrowseSourceKey.RoyalRoad -> state.filter.activeCount()
-                    BrowseSourceKey.GitHub -> state.githubFilter.activeCount()
-                    // #191 — single dimension (wing) so badge counts at
-                    // most 1.
-                    BrowseSourceKey.MemPalace -> if (state.palaceFilter.wing != null) 1 else 0
-                    // #236 — RSS has no filter sheet (subscription list
-                    // is the entire surface); count is always zero.
-                    BrowseSourceKey.Rss -> 0
-                    // #235 — EPUB also has no filter sheet (folder
-                    // picker is in Settings).
-                    BrowseSourceKey.Epub -> 0
-                    // #245 — Outline has no filter sheet (host + API
-                    // key are in Settings).
-                    BrowseSourceKey.Outline -> 0
-                },
-                onClick = { showFilterSheet = true },
-            )
+            // form, GitHub has the `/search/repositories` qualifier set,
+            // MemPalace has a wing chooser. RSS / EPUB / Outline have
+            // no filter sheet (configuration lives in Settings) — hide
+            // the button entirely for those sources, since the click
+            // handler is a documented no-op (`showFilterSheet = false`
+            // at the bottom of the file) and presenting a tappable icon
+            // that does nothing reads as a bug to users (phone audit
+            // pass 2).
+            val filterableSource = when (state.sourceKey) {
+                BrowseSourceKey.RoyalRoad,
+                BrowseSourceKey.GitHub,
+                BrowseSourceKey.MemPalace -> true
+                BrowseSourceKey.Rss,
+                BrowseSourceKey.Epub,
+                BrowseSourceKey.Outline -> false
+            }
+            if (filterableSource) {
+                FilterButton(
+                    activeCount = when (state.sourceKey) {
+                        BrowseSourceKey.RoyalRoad -> state.filter.activeCount()
+                        BrowseSourceKey.GitHub -> state.githubFilter.activeCount()
+                        // #191 — single dimension (wing) so badge counts at
+                        // most 1.
+                        BrowseSourceKey.MemPalace -> if (state.palaceFilter.wing != null) 1 else 0
+                        // Gated by `filterableSource` above; the
+                        // non-filterable branches are unreachable here
+                        // but Kotlin still wants exhaustive coverage.
+                        BrowseSourceKey.Rss,
+                        BrowseSourceKey.Epub,
+                        BrowseSourceKey.Outline -> 0
+                    },
+                    onClick = { showFilterSheet = true },
+                )
+            }
         }
 
         // Active wing hint — surface the selected wing prominently


### PR DESCRIPTION
## Summary

- Hides the Browse filter icon when the current source has no filter sheet (RSS / EPUB / Outline).
- Previously the icon rendered for every source but tapping it was a no-op for those three — the click handler set `showFilterSheet = true`, then the per-source `when` block at the bottom of the screen immediately set it back to `false` in the same composition pass. To users this reads as a broken button.
- Filed as #330 from phone audit pass 2 (Galaxy Z Flip3, R5CRB0W66MK, inner display 1080×2640).

## Phone verification (R5CRB0W66MK, today's build)

- Browse → RSS source → filter icon absent, search icon still present, content (tricycle.org / lionsroar.com brass monograms) renders cleanly.
- Browse → Royal Road source → filter icon present; tapping opens the "Filter Royal Road" sheet (Sort by / Status / Type / Include tags / Reset / Apply); back dismisses.
- No regression on the tab row, source picker, search field, or grid.

## Test plan

- [x] Built and installed `:app:assembleDebug` on R5CRB0W66MK
- [x] Manual: RSS source has no filter icon
- [x] Manual: Royal Road source filter sheet still opens / dismisses cleanly
- [ ] CI (Copilot review + unit tests / lint)

🤖 Generated with [Claude Code](https://claude.com/claude-code)