### PR TITLE
fix(player): cover tap toggles play/pause (closes #269)

### DIFF
--- a/feature/src/main/kotlin/in/jphe/storyvox/feature/reader/AudiobookView.kt
+++ b/feature/src/main/kotlin/in/jphe/storyvox/feature/reader/AudiobookView.kt
@@ -243,11 +243,24 @@ fun AudiobookView(
                 )
             } else {
                 Box(contentAlignment = Alignment.Center) {
+                    // Cover tap toggles play/pause — same convention as
+                    // Spotify, Apple Music, Pocket Casts, etc. The big play
+                    // button below remains the explicit affordance; the
+                    // cover is the *convenient* one, since it's the largest
+                    // surface on the player and one-handed users naturally
+                    // thumb-tap it (#269). Long-press is left unbound so
+                    // we don't accidentally fight system-level a11y gestures.
                     FictionCoverThumb(
                         coverUrl = state.coverUrl,
                         title = state.fictionTitle,
                         monogram = fictionMonogram(author = "", title = state.fictionTitle),
-                        modifier = Modifier.size(width = 220.dp, height = 330.dp),
+                        modifier = Modifier
+                            .size(width = 220.dp, height = 330.dp)
+                            .clickable(
+                                role = androidx.compose.ui.semantics.Role.Button,
+                                onClickLabel = if (state.isPlaying) "Pause" else "Play",
+                                onClick = onPlayPause,
+                            ),
                     )
                     // Subtle brass sigil ring orbiting the cover while the
                     // engine is producing the first sentence's audio. Fades


### PR DESCRIPTION
## Summary

The player cover was a large no-op tap target. Adopted the Spotify / Apple Music / Pocket Casts convention: **tap cover = toggle play/pause**, with TalkBack announcing "Pause" / "Play" instead of "Button".

The explicit play button below stays as the primary affordance; the cover-tap is the *convenient* one — biggest surface, where one-handed users naturally thumb-tap. Long-press is left unbound on purpose to keep system-level a11y gestures clean.

## Trade-offs considered

The issue body proposed card-flip-to-chapter-list (more elaborate). That's a meaningful chunk of new UI state + animation work and was filed as P3. Tap-to-play/pause is the smallest reversible win that closes the "wasted real estate" complaint without adding new state. If you want the card-flip later, this PR doesn't preclude it — just swap `onPlayPause` for the flip handler.

Closes #269.

🤖 Generated with [Claude Code](https://claude.com/claude-code)