### PR TITLE
fix(settings): brass 1× anchor under Speed + Pitch sliders (closes #273)

### DIFF
--- a/feature/src/main/kotlin/in/jphe/storyvox/feature/settings/SettingsScreen.kt
+++ b/feature/src/main/kotlin/in/jphe/storyvox/feature/settings/SettingsScreen.kt
@@ -155,38 +155,59 @@ fun SettingsScreen(
             // user's perspective; the persistence is per-voice
             // silently. Switching voices brings their stored values
             // back automatically.
+            // Speed range 0.5..4.0 puts the natural 1× thumb at ~14 %
+            // from the left, which made the Pitch slider (0.6..1.4,
+            // 1× at 50 %) look "set higher" even when both read 1.00×.
+            // A single brass tick label anchors the natural value
+            // explicitly so the visual offset reads as designed instead
+            // of as a glitch (#273). Same pattern as
+            // PunctuationPauseTickLabels — tap snaps the slider to 1×.
             SettingsSliderBlock(
                 title = "Speed",
                 valueLabel = "${"%.2f".format(s.effectiveSpeed)}×",
                 slider = {
-                    Slider(
-                        value = s.effectiveSpeed,
-                        onValueChange = viewModel::setSpeed,
-                        // Widened past Thalia's P1 #5 (commute listeners
-                        // benefit from 3-4× on familiar narrators).
-                        valueRange = 0.5f..4.0f,
-                        modifier = Modifier.semantics {
-                            contentDescription = "Default speech speed"
-                            stateDescription = "%.2f times".format(s.effectiveSpeed)
-                        },
-                    )
+                    androidx.compose.foundation.layout.Column {
+                        Slider(
+                            value = s.effectiveSpeed,
+                            onValueChange = viewModel::setSpeed,
+                            // Widened past Thalia's P1 #5 (commute listeners
+                            // benefit from 3-4× on familiar narrators).
+                            valueRange = 0.5f..4.0f,
+                            modifier = Modifier.semantics {
+                                contentDescription = "Default speech speed"
+                                stateDescription = "%.2f times".format(s.effectiveSpeed)
+                            },
+                        )
+                        SliderTickLabels(
+                            // 1× position = (1.0 − 0.5) / (4.0 − 0.5) ≈ 0.143
+                            ticks = listOf("▲ 1×" to ((1.0f - 0.5f) / (4.0f - 0.5f))),
+                            onTickTap = { viewModel.setSpeed(1.0f) },
+                        )
+                    }
                 },
             )
             SettingsSliderBlock(
                 title = "Pitch",
                 valueLabel = "${"%.2f".format(s.effectivePitch)}×",
                 slider = {
-                    Slider(
-                        value = s.effectivePitch,
-                        onValueChange = viewModel::setPitch,
-                        // Narration-friendly band — matches AudiobookView. Hard
-                        // floor at 0.6: Sonic introduces artifacts below ~0.7.
-                        valueRange = 0.6f..1.4f,
-                        modifier = Modifier.semantics {
-                            contentDescription = "Default pitch"
-                            stateDescription = "%.2f, neutral at one".format(s.effectivePitch)
-                        },
-                    )
+                    androidx.compose.foundation.layout.Column {
+                        Slider(
+                            value = s.effectivePitch,
+                            onValueChange = viewModel::setPitch,
+                            // Narration-friendly band — matches AudiobookView. Hard
+                            // floor at 0.6: Sonic introduces artifacts below ~0.7.
+                            valueRange = 0.6f..1.4f,
+                            modifier = Modifier.semantics {
+                                contentDescription = "Default pitch"
+                                stateDescription = "%.2f, neutral at one".format(s.effectivePitch)
+                            },
+                        )
+                        SliderTickLabels(
+                            // 1× position = (1.0 − 0.6) / (1.4 − 0.6) = 0.5 (centered)
+                            ticks = listOf("▲ 1×" to 0.5f),
+                            onTickTap = { viewModel.setPitch(1.0f) },
+                        )
+                    }
                 },
             )
             // Punctuation cadence — #109 continuous slider (was 3-stop

--- a/feature/src/main/kotlin/in/jphe/storyvox/feature/settings/SettingsScreen.kt
+++ b/feature/src/main/kotlin/in/jphe/storyvox/feature/settings/SettingsScreen.kt
@@ -162,50 +162,59 @@ fun SettingsScreen(
             // explicitly so the visual offset reads as designed instead
             // of as a glitch (#273). Same pattern as
             // PunctuationPauseTickLabels — tap snaps the slider to 1×.
+            //
+            // Range constants are declared once and reused by both the
+            // Slider's `valueRange` and the tick's fraction calc so the
+            // tick can't drift if a range is ever rebalanced.
+            val speedMin = 0.5f
+            val speedMax = 4.0f
+            val naturalValue = 1.0f
+            val speedNaturalFraction = (naturalValue - speedMin) / (speedMax - speedMin)
             SettingsSliderBlock(
                 title = "Speed",
                 valueLabel = "${"%.2f".format(s.effectiveSpeed)}×",
                 slider = {
-                    androidx.compose.foundation.layout.Column {
+                    Column {
                         Slider(
                             value = s.effectiveSpeed,
                             onValueChange = viewModel::setSpeed,
                             // Widened past Thalia's P1 #5 (commute listeners
                             // benefit from 3-4× on familiar narrators).
-                            valueRange = 0.5f..4.0f,
+                            valueRange = speedMin..speedMax,
                             modifier = Modifier.semantics {
                                 contentDescription = "Default speech speed"
                                 stateDescription = "%.2f times".format(s.effectiveSpeed)
                             },
                         )
                         SliderTickLabels(
-                            // 1× position = (1.0 − 0.5) / (4.0 − 0.5) ≈ 0.143
-                            ticks = listOf("▲ 1×" to ((1.0f - 0.5f) / (4.0f - 0.5f))),
-                            onTickTap = { viewModel.setSpeed(1.0f) },
+                            ticks = listOf("▲ 1×" to speedNaturalFraction),
+                            onTickTap = { viewModel.setSpeed(naturalValue) },
                         )
                     }
                 },
             )
+            val pitchMin = 0.6f
+            val pitchMax = 1.4f
+            val pitchNaturalFraction = (naturalValue - pitchMin) / (pitchMax - pitchMin)
             SettingsSliderBlock(
                 title = "Pitch",
                 valueLabel = "${"%.2f".format(s.effectivePitch)}×",
                 slider = {
-                    androidx.compose.foundation.layout.Column {
+                    Column {
                         Slider(
                             value = s.effectivePitch,
                             onValueChange = viewModel::setPitch,
                             // Narration-friendly band — matches AudiobookView. Hard
                             // floor at 0.6: Sonic introduces artifacts below ~0.7.
-                            valueRange = 0.6f..1.4f,
+                            valueRange = pitchMin..pitchMax,
                             modifier = Modifier.semantics {
                                 contentDescription = "Default pitch"
                                 stateDescription = "%.2f, neutral at one".format(s.effectivePitch)
                             },
                         )
                         SliderTickLabels(
-                            // 1× position = (1.0 − 0.6) / (1.4 − 0.6) = 0.5 (centered)
-                            ticks = listOf("▲ 1×" to 0.5f),
-                            onTickTap = { viewModel.setPitch(1.0f) },
+                            ticks = listOf("▲ 1×" to pitchNaturalFraction),
+                            onTickTap = { viewModel.setPitch(naturalValue) },
                         )
                     }
                 },


### PR DESCRIPTION
## Summary

The Speed slider's range (0.5..4.0) puts the natural 1× thumb at ~14% from the left; the Pitch slider's range (0.6..1.4) puts 1× dead-center at 50%. Both labels show "1.00×" but the thumbs sit in visibly different positions — users were misreading "Pitch is set higher" when both were neutral.

Added a brass **`▲ 1×`** tick label under each slider at the natural-value position. Same SliderTickLabels pattern used by PunctuationPauseTickLabels — tap snaps the slider back to 1×.

The asymmetric range stays — commute listeners want 2-4× audiobook speed and there's no point compressing the upper range just to symmetrize the slider. The tick anchor makes the asymmetry read as designed.

## Verified

On R83W80CAFZB: Settings → Voice & Playback shows Speed thumb at ~14% with the `▲ 1×` tick under it, Pitch thumb at 50% with the `▲ 1×` tick also under it. Each slider tells its own truth.

Closes #273.

🤖 Generated with [Claude Code](https://claude.com/claude-code)