### PR TITLE
fix(library): Resume card hierarchy + chapter-title separator guard (closes #265)

### DIFF
--- a/feature/src/main/kotlin/in/jphe/storyvox/feature/library/LibraryScreen.kt
+++ b/feature/src/main/kotlin/in/jphe/storyvox/feature/library/LibraryScreen.kt
@@ -124,20 +124,20 @@ fun LibraryScreen(
                         // #265 — the Resume card used to sit one
                         // `verticalArrangement.spacedBy(md)` gap above the
                         // grid's first row, reading as another grid item
-                        // rather than a hero zone. A small spacer-row +
-                        // brass "Your library" caption gives the resume
-                        // its own band and labels the grid as a separate
-                        // section.
+                        // rather than a hero zone. The brass "Your library"
+                        // caption now labels the grid as a separate section.
+                        // Spacer + caption live in one full-span item so we
+                        // only pay one inter-row gap from the grid's
+                        // vertical arrangement (two items would double it).
                         item(span = { androidx.compose.foundation.lazy.grid.GridItemSpan(maxLineSpan) }) {
-                            Spacer(modifier = Modifier.height(spacing.xs))
-                        }
-                        item(span = { androidx.compose.foundation.lazy.grid.GridItemSpan(maxLineSpan) }) {
-                            Text(
-                                text = "Your library",
-                                style = MaterialTheme.typography.labelLarge,
-                                color = MaterialTheme.colorScheme.primary,
-                                modifier = Modifier.padding(top = spacing.xs, bottom = spacing.xxs),
-                            )
+                            Column(modifier = Modifier.padding(top = spacing.xs)) {
+                                Text(
+                                    text = "Your library",
+                                    style = MaterialTheme.typography.labelLarge,
+                                    color = MaterialTheme.colorScheme.primary,
+                                    modifier = Modifier.padding(bottom = spacing.xxs),
+                                )
+                            }
                         }
                     }
                     itemsIndexed(dedupedFictions, key = { _, item -> item.id }) { index, fiction ->

--- a/feature/src/main/kotlin/in/jphe/storyvox/feature/library/LibraryScreen.kt
+++ b/feature/src/main/kotlin/in/jphe/storyvox/feature/library/LibraryScreen.kt
@@ -121,6 +121,24 @@ fun LibraryScreen(
                         item(span = { androidx.compose.foundation.lazy.grid.GridItemSpan(maxLineSpan) }) {
                             ResumeCard(resume, onResume = viewModel::resume)
                         }
+                        // #265 — the Resume card used to sit one
+                        // `verticalArrangement.spacedBy(md)` gap above the
+                        // grid's first row, reading as another grid item
+                        // rather than a hero zone. A small spacer-row +
+                        // brass "Your library" caption gives the resume
+                        // its own band and labels the grid as a separate
+                        // section.
+                        item(span = { androidx.compose.foundation.lazy.grid.GridItemSpan(maxLineSpan) }) {
+                            Spacer(modifier = Modifier.height(spacing.xs))
+                        }
+                        item(span = { androidx.compose.foundation.lazy.grid.GridItemSpan(maxLineSpan) }) {
+                            Text(
+                                text = "Your library",
+                                style = MaterialTheme.typography.labelLarge,
+                                color = MaterialTheme.colorScheme.primary,
+                                modifier = Modifier.padding(top = spacing.xs, bottom = spacing.xxs),
+                            )
+                        }
                     }
                     itemsIndexed(dedupedFictions, key = { _, item -> item.id }) { index, fiction ->
                         Column(
@@ -193,8 +211,17 @@ private fun ResumeCard(entry: ContinueListeningEntry, onResume: () -> Unit) {
             Column(modifier = Modifier.weight(1f)) {
                 Text("Resume", style = MaterialTheme.typography.labelMedium, color = MaterialTheme.colorScheme.primary)
                 Text(entry.fiction.title, style = MaterialTheme.typography.titleMedium, maxLines = 1)
+                // #265 — when chapter.title is blank (RSS feeds where only
+                // the index was parsed, first-cold-launch state), the old
+                // format produced "Ch. 0 · " with a dangling separator
+                // that read as missing data. Drop the separator entirely
+                // in that case so the line ends cleanly with "Ch. 0".
                 Text(
-                    "Ch. ${entry.chapter.index} · ${entry.chapter.title}",
+                    text = if (entry.chapter.title.isNotBlank()) {
+                        "Ch. ${entry.chapter.index} · ${entry.chapter.title}"
+                    } else {
+                        "Ch. ${entry.chapter.index}"
+                    },
                     style = MaterialTheme.typography.bodySmall,
                     color = MaterialTheme.colorScheme.onSurfaceVariant,
                     maxLines = 1,


### PR DESCRIPTION
## Summary

Two related Library hierarchy fixes called out by the same issue:

1. **Resume card needed its own band** — the card sat one `verticalArrangement.spacedBy(md)` gap above the cover grid and read as a top-row grid item rather than a hero zone. Added a spacer-row and a brass **"Your library"** caption between the Resume and the first grid row, so the band split is unmistakable.

2. **Dangling `Ch. 0 · ` separator** — the chapter line had no guard on empty title, producing `"Ch. 0 · "` with a trailing separator for RSS feeds where only the index was parsed. Now drops the separator entirely when `entry.chapter.title.isBlank()`.

## Verified on R83W80CAFZB

- Library now renders: Resume hero → brass "Your library" section label → 2-column grid
- Chapter line shows `"Ch. 0 · 1 - Master Elric and The Spirit Orbs"` when title present, or `"Ch. 0"` when blank — no dangling separator either way

Closes #265.

🤖 Generated with [Claude Code](https://claude.com/claude-code)