### PR TITLE
fix(player-options): drop dotted track from Speed + Pitch sliders (closes #260)

### DIFF
--- a/feature/src/main/kotlin/in/jphe/storyvox/feature/reader/AudiobookView.kt
+++ b/feature/src/main/kotlin/in/jphe/storyvox/feature/reader/AudiobookView.kt
@@ -521,10 +521,18 @@ private fun PlayerOptionsSheet(
         // #260 — Settings → Voice & Playback's Speed/Pitch sliders
         // are continuous (no `steps`) so they render as solid brass
         // bars; this sheet used to pass `steps = 49 / 79`, which
-        // painted dotted tracks. Two surfaces, same parameter, two
-        // identities. JP prefers the solid look here too — the brass
-        // identity carries via the ▲ tick anchor at the natural value
-        // (added by #273) rather than via tick dots on the rail.
+        // painted dotted tracks. Same parameter rendered two ways.
+        // Solid is the chosen identity; the brass thumb + active
+        // track already carry the realm aesthetic without the dots.
+        //
+        // Trade-off: dropping `steps` means `onValueChange` fires
+        // per drag-pixel instead of per step-boundary, so more
+        // setSpeed / setPitch calls reach the engine during a drag.
+        // Sonic.setRate and KokoroEngine.setPitch are both designed
+        // for continuous live-tuning (cheap per-call), so the extra
+        // churn shouldn't surface. If it ever does, the right
+        // mitigation is a ViewModel-side debounce, not re-introducing
+        // a tick grid the user can't perceive.
         SheetHeader("Speed", "${"%.2f".format(state.speed)}×")
         Slider(
             value = state.speed,

--- a/feature/src/main/kotlin/in/jphe/storyvox/feature/reader/AudiobookView.kt
+++ b/feature/src/main/kotlin/in/jphe/storyvox/feature/reader/AudiobookView.kt
@@ -518,13 +518,19 @@ private fun PlayerOptionsSheet(
             .padding(horizontal = spacing.lg, vertical = spacing.md),
         verticalArrangement = Arrangement.spacedBy(spacing.md),
     ) {
+        // #260 — Settings → Voice & Playback's Speed/Pitch sliders
+        // are continuous (no `steps`) so they render as solid brass
+        // bars; this sheet used to pass `steps = 49 / 79`, which
+        // painted dotted tracks. Two surfaces, same parameter, two
+        // identities. JP prefers the solid look here too — the brass
+        // identity carries via the ▲ tick anchor at the natural value
+        // (added by #273) rather than via tick dots on the rail.
         SheetHeader("Speed", "${"%.2f".format(state.speed)}×")
         Slider(
             value = state.speed,
             onValueChange = onSetSpeed,
             onValueChangeFinished = { onPersistSpeed(state.speed) },
             valueRange = 0.5f..3.0f,
-            steps = 49, // 0.05× per step
             // TalkBack #160 — without these, the slider announces a raw
             // float ("1.25") instead of a meaningful value ("Speech speed,
             // 1.25 times").
@@ -544,7 +550,6 @@ private fun PlayerOptionsSheet(
             // narrator-baritone headroom. Hard floor at 0.6 — below ~0.7
             // Sonic introduces audible artifacts on Piper-medium voices.
             valueRange = 0.6f..1.4f,
-            steps = 79, // 0.01 per step
             // TalkBack #160 — neutral pitch is 1.0 (no shift); semantics
             // calls that out so users know what the number references.
             modifier = Modifier.semantics {


### PR DESCRIPTION
## Summary

Per JP's preference (raised after a wrong-direction first attempt in #336 — closed): unify by dropping the dots, not by adding them. The ▲ tick anchor from #273 carries the brass identity at the natural-value position; tick dots on the rail were redundant visual noise.

Removed `steps = 49 / 79` from the Player options sheet's Speed/Pitch sliders. Both surfaces (Settings + Player options) now render the same: solid brass track, continuous drag, no step-grid snapping.

## Behavior change

The Player options sliders no longer snap to 0.05× / 0.01 step boundaries. The saved value is whatever the user landed on. Settings already behaved this way; this brings the Player options into parity.

Closes #260.

🤖 Generated with [Claude Code](https://claude.com/claude-code)