### PR TITLE
fix(palace): honor user-typed https:// scheme (closes #342)

### DIFF
--- a/source-mempalace/src/main/kotlin/in/jphe/storyvox/source/mempalace/net/PalaceDaemonApi.kt
+++ b/source-mempalace/src/main/kotlin/in/jphe/storyvox/source/mempalace/net/PalaceDaemonApi.kt
@@ -212,16 +212,18 @@ open class PalaceDaemonApi @Inject constructor(
         // daemons that don't have TLS yet. Previously we stripped + forced
         // http:// unconditionally, which made TLS-fronted proxies hit a
         // 308 redirect storyvox couldn't follow. See #342.
-        val scheme = when {
-            raw.startsWith("https://", ignoreCase = true) -> "https://"
-            raw.startsWith("http://", ignoreCase = true) -> "http://"
-            else -> "http://"
+        //
+        // Single case-insensitive regex strip handles mixed-case typos like
+        // `Https://host` — Copilot caught this on the first pass where the
+        // case-insensitive startsWith and case-sensitive removePrefix were
+        // out of sync, leaving `Https://host` un-stripped.
+        val schemeMatch = SCHEME_PREFIX.find(raw)
+        val scheme = schemeMatch?.value?.lowercase() ?: "http://"
+        val withoutScheme = if (schemeMatch != null) {
+            raw.substring(schemeMatch.range.last + 1)
+        } else {
+            raw
         }
-        val withoutScheme = raw
-            .removePrefix("https://")
-            .removePrefix("http://")
-            .removePrefix("HTTPS://")
-            .removePrefix("HTTP://")
         if (withoutScheme.isEmpty()) return null
         // Reject paths in the host field — we own the path entirely.
         if ('/' in withoutScheme) return null
@@ -291,6 +293,10 @@ open class PalaceDaemonApi @Inject constructor(
             isLenient = true
         }
         private val JSON_MEDIA_TYPE = "application/json".toMediaType()
+        /** Case-insensitive match for `http://` or `https://` at start of
+         *  string. Single regex avoids the case-mismatch bug between a
+         *  case-insensitive startsWith and case-sensitive removePrefix. */
+        private val SCHEME_PREFIX = Regex("^https?://", RegexOption.IGNORE_CASE)
     }
 }
 

--- a/source-mempalace/src/main/kotlin/in/jphe/storyvox/source/mempalace/net/PalaceDaemonApi.kt
+++ b/source-mempalace/src/main/kotlin/in/jphe/storyvox/source/mempalace/net/PalaceDaemonApi.kt
@@ -207,16 +207,26 @@ open class PalaceDaemonApi @Inject constructor(
     internal fun baseUrlOrNull(cfg: PalaceConfigState): String? {
         val raw = cfg.host.trim().removeSuffix("/")
         if (raw.isEmpty()) return null
-        // Strip user-typed scheme so we always force http:// (LAN palace
-        // daemon, no TLS today). Accepts bare host[:port] or full URL.
+        // Honor user-typed scheme if present (https://palace.jphe.in for
+        // TLS-fronted setups), otherwise default to http:// for bare LAN
+        // daemons that don't have TLS yet. Previously we stripped + forced
+        // http:// unconditionally, which made TLS-fronted proxies hit a
+        // 308 redirect storyvox couldn't follow. See #342.
+        val scheme = when {
+            raw.startsWith("https://", ignoreCase = true) -> "https://"
+            raw.startsWith("http://", ignoreCase = true) -> "http://"
+            else -> "http://"
+        }
         val withoutScheme = raw
-            .removePrefix("http://")
             .removePrefix("https://")
+            .removePrefix("http://")
+            .removePrefix("HTTPS://")
+            .removePrefix("HTTP://")
         if (withoutScheme.isEmpty()) return null
         // Reject paths in the host field — we own the path entirely.
         if ('/' in withoutScheme) return null
 
-        val candidate = "http://$withoutScheme"
+        val candidate = "$scheme$withoutScheme"
         val uri = try {
             URI(candidate)
         } catch (_: IllegalArgumentException) {

--- a/source-mempalace/src/test/kotlin/in/jphe/storyvox/source/mempalace/PalaceDaemonApiTest.kt
+++ b/source-mempalace/src/test/kotlin/in/jphe/storyvox/source/mempalace/PalaceDaemonApiTest.kt
@@ -79,6 +79,21 @@ class PalaceDaemonApiTest {
         assertEquals("http://palace.local:8085", url)
     }
 
+    @Test fun `normalizes mixed-case scheme`() {
+        // Copilot caught: original implementation had case-insensitive
+        // startsWith but case-sensitive removePrefix, so `Https://host`
+        // would slip through un-stripped. Verify the regex-based strip
+        // handles mixed case AND emits a lowercase scheme.
+        assertEquals(
+            "https://palace.jphe.in",
+            api().baseUrlOrNull(cfg("HTTPS://palace.jphe.in")),
+        )
+        assertEquals(
+            "http://palace.local:8085",
+            api().baseUrlOrNull(cfg("HtTp://palace.local:8085")),
+        )
+    }
+
     @Test fun `unwraps MCP text envelope`() {
         val envelope = """
             {"jsonrpc":"2.0","id":1,"result":{"content":[

--- a/source-mempalace/src/test/kotlin/in/jphe/storyvox/source/mempalace/PalaceDaemonApiTest.kt
+++ b/source-mempalace/src/test/kotlin/in/jphe/storyvox/source/mempalace/PalaceDaemonApiTest.kt
@@ -58,8 +58,24 @@ class PalaceDaemonApiTest {
         assertNull(api().baseUrlOrNull(cfg("palace.local/api")))
     }
 
-    @Test fun `strips user-typed scheme and forces http`() {
-        val url = api().baseUrlOrNull(cfg("https://palace.local:8085"))
+    @Test fun `honors user-typed https scheme`() {
+        // #342 — TLS-fronted palace proxies (Caddy in front of the daemon)
+        // need the caller to opt into HTTPS by typing the scheme. Previously
+        // we stripped + forced http://, which made the request hit Caddy
+        // on :80 and bounce with a 308 redirect storyvox couldn't follow.
+        val url = api().baseUrlOrNull(cfg("https://palace.jphe.in"))
+        assertEquals("https://palace.jphe.in", url)
+    }
+
+    @Test fun `accepts user-typed http scheme`() {
+        val url = api().baseUrlOrNull(cfg("http://palace.local:8085"))
+        assertEquals("http://palace.local:8085", url)
+    }
+
+    @Test fun `defaults to http when no scheme typed`() {
+        // Bare hosts default to http:// — backwards-compatible with the
+        // pre-#342 behavior for users on LAN daemons without TLS.
+        val url = api().baseUrlOrNull(cfg("palace.local:8085"))
         assertEquals("http://palace.local:8085", url)
     }
 


### PR DESCRIPTION
## Summary

- Honor user-typed `https://` scheme in Memory Palace host field
- Bare hosts (no scheme) still default to `http://` (backwards-compatible)
- LAN-only authority check unchanged

## Why

After #340 unblocked the cleartext gate, the next failure mode surfaced: JP's `palace.jphe.in` is fronted by Caddy with valid TLS. Caddy on :80 returns `308 Permanent Redirect → https://palace.jphe.in`. Storyvox's PalaceHttpModule has `followSslRedirects(false)` (defensive), so the probe died at the 308 with "Daemon returned 308: Permanent Redirect."

Lets the user opt into HTTPS by typing `https://palace.jphe.in` in the host field. Direct connect to Caddy:443, no redirect dance, no cleartext leak of the X-API-Key. Also eliminates the security concern Copilot raised on #340 (cleartext channel exposing the API key).

## Test plan

- [x] Updated unit test (`PalaceDaemonApiTest`):
  - `honors user-typed https scheme` — `https://palace.jphe.in` → `https://palace.jphe.in`
  - `accepts user-typed http scheme` — `http://palace.local:8085` → `http://palace.local:8085`
  - `defaults to http when no scheme typed` — `palace.local:8085` → `http://palace.local:8085`
- [x] Local `./gradlew :source-mempalace:testDebugUnitTest` passes
- [x] Manual verify on R5CR80DJ7TR

## Follow-up

Once everyone's typing `https://`, the `palace.jphe.in` cleartext carveout in `network_security_config.xml` can be removed — TLS-by-default. Tracked for a future PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)