### PR TITLE
fix(ai-settings): immediate Save label update via local just-saved flag (closes #338)

### DIFF
--- a/feature/src/main/kotlin/in/jphe/storyvox/feature/settings/SettingsScreen.kt
+++ b/feature/src/main/kotlin/in/jphe/storyvox/feature/settings/SettingsScreen.kt
@@ -2086,9 +2086,15 @@ private fun ClaudeProviderRows(
     val spacing = LocalSpacing.current
     var keyDraft by remember { mutableStateOf("") }
     var showKey by remember { mutableStateOf(false) }
+    // #338 — local "just saved" override. EncryptedSharedPreferences
+    // changes don't tick the settings StateFlow that ai.*KeyConfigured
+    // is derived from, so the configured label would otherwise stay
+    // "not set" for ~30s after a successful Save. The flag flips back
+    // to false on Clear so the label is honest both ways.
+    var keyJustSaved by remember { mutableStateOf(false) }
     Column(verticalArrangement = Arrangement.spacedBy(spacing.xs)) {
         Text(
-            if (ai.claudeKeyConfigured) "Claude API key — set"
+            if (ai.claudeKeyConfigured || keyJustSaved) "Claude API key — set"
             else "Claude API key — not set",
             style = MaterialTheme.typography.bodyMedium,
         )
@@ -2114,14 +2120,18 @@ private fun ClaudeProviderRows(
                         onSetClaudeKey(keyDraft)
                         keyDraft = ""
                         showKey = false
+                        keyJustSaved = true
                     }
                 },
                 variant = BrassButtonVariant.Primary,
             )
-            if (ai.claudeKeyConfigured) {
+            if (ai.claudeKeyConfigured || keyJustSaved) {
                 BrassButton(
                     label = "Clear",
-                    onClick = { onSetClaudeKey(null) },
+                    onClick = {
+                        onSetClaudeKey(null)
+                        keyJustSaved = false
+                    },
                     variant = BrassButtonVariant.Text,
                 )
             }
@@ -2159,9 +2169,12 @@ private fun OpenAiProviderRows(
     val spacing = LocalSpacing.current
     var keyDraft by remember { mutableStateOf("") }
     var showKey by remember { mutableStateOf(false) }
+    // #338 — see ClaudeProviderRows for the rationale.
+    var keyJustSaved by remember { mutableStateOf(false) }
     Column(verticalArrangement = Arrangement.spacedBy(spacing.xs)) {
         Text(
-            if (ai.openAiKeyConfigured) "OpenAI API key — set" else "OpenAI API key — not set",
+            if (ai.openAiKeyConfigured || keyJustSaved) "OpenAI API key — set"
+            else "OpenAI API key — not set",
             style = MaterialTheme.typography.bodyMedium,
         )
         OutlinedTextField(
@@ -2186,14 +2199,18 @@ private fun OpenAiProviderRows(
                         onSetOpenAiKey(keyDraft)
                         keyDraft = ""
                         showKey = false
+                        keyJustSaved = true
                     }
                 },
                 variant = BrassButtonVariant.Primary,
             )
-            if (ai.openAiKeyConfigured) {
+            if (ai.openAiKeyConfigured || keyJustSaved) {
                 BrassButton(
                     label = "Clear",
-                    onClick = { onSetOpenAiKey(null) },
+                    onClick = {
+                        onSetOpenAiKey(null)
+                        keyJustSaved = false
+                    },
                     variant = BrassButtonVariant.Text,
                 )
             }
@@ -2268,9 +2285,11 @@ private fun VertexProviderRows(
     val spacing = LocalSpacing.current
     var keyDraft by remember { mutableStateOf("") }
     var showKey by remember { mutableStateOf(false) }
+    // #338 — see ClaudeProviderRows for the rationale.
+    var keyJustSaved by remember { mutableStateOf(false) }
     Column(verticalArrangement = Arrangement.spacedBy(spacing.xs)) {
         Text(
-            if (ai.vertexKeyConfigured) "Vertex API key — set"
+            if (ai.vertexKeyConfigured || keyJustSaved) "Vertex API key — set"
             else "Vertex API key — not set",
             style = MaterialTheme.typography.bodyMedium,
         )
@@ -2296,14 +2315,18 @@ private fun VertexProviderRows(
                         onSetVertexKey(keyDraft)
                         keyDraft = ""
                         showKey = false
+                        keyJustSaved = true
                     }
                 },
                 variant = BrassButtonVariant.Primary,
             )
-            if (ai.vertexKeyConfigured) {
+            if (ai.vertexKeyConfigured || keyJustSaved) {
                 BrassButton(
                     label = "Clear",
-                    onClick = { onSetVertexKey(null) },
+                    onClick = {
+                        onSetVertexKey(null)
+                        keyJustSaved = false
+                    },
                     variant = BrassButtonVariant.Text,
                 )
             }
@@ -2345,6 +2368,11 @@ private fun AzureFoundryProviderRows(
     var showKey by remember { mutableStateOf(false) }
     var endpointDraft by remember(ai.foundryEndpoint) { mutableStateOf(ai.foundryEndpoint) }
     var deploymentDraft by remember(ai.foundryDeployment) { mutableStateOf(ai.foundryDeployment) }
+    // #338 — see ClaudeProviderRows. Foundry's Save persists endpoint
+    // + deployment to DataStore (which the settings flow does observe,
+    // so those labels update fine) plus the API key to EncryptedSharedPrefs
+    // (which doesn't). Only the API-key label needs the local override.
+    var keyJustSaved by remember { mutableStateOf(false) }
 
     Column(verticalArrangement = Arrangement.spacedBy(spacing.xs)) {
         // ── Mode toggle ────────────────────────────────────────────
@@ -2395,7 +2423,7 @@ private fun AzureFoundryProviderRows(
 
         // ── API key (encrypted) ───────────────────────────────────
         Text(
-            if (ai.foundryKeyConfigured) "Foundry API key — set"
+            if (ai.foundryKeyConfigured || keyJustSaved) "Foundry API key — set"
             else "Foundry API key — not set",
             style = MaterialTheme.typography.bodyMedium,
         )
@@ -2456,14 +2484,18 @@ private fun AzureFoundryProviderRows(
                         onSetFoundryKey(keyDraft)
                         keyDraft = ""
                         showKey = false
+                        keyJustSaved = true
                     }
                 },
                 variant = BrassButtonVariant.Primary,
             )
-            if (ai.foundryKeyConfigured) {
+            if (ai.foundryKeyConfigured || keyJustSaved) {
                 BrassButton(
                     label = "Clear key",
-                    onClick = { onSetFoundryKey(null) },
+                    onClick = {
+                        onSetFoundryKey(null)
+                        keyJustSaved = false
+                    },
                     variant = BrassButtonVariant.Text,
                 )
             }
@@ -2485,10 +2517,14 @@ private fun BedrockProviderRows(
     var secretDraft by remember { mutableStateOf("") }
     var showAccess by remember { mutableStateOf(false) }
     var showSecret by remember { mutableStateOf(false) }
+    // #338 — see ClaudeProviderRows. Bedrock has two independent
+    // per-field Saves so it needs two local override flags.
+    var accessJustSaved by remember { mutableStateOf(false) }
+    var secretJustSaved by remember { mutableStateOf(false) }
     Column(verticalArrangement = Arrangement.spacedBy(spacing.xs)) {
         // ── Access key ────────────────────────────────────────────
         Text(
-            if (ai.bedrockAccessKeyConfigured) "AWS access key id — set"
+            if (ai.bedrockAccessKeyConfigured || accessJustSaved) "AWS access key id — set"
             else "AWS access key id — not set",
             style = MaterialTheme.typography.bodyMedium,
         )
@@ -2515,21 +2551,25 @@ private fun BedrockProviderRows(
                         onSetAccessKey(accessDraft)
                         accessDraft = ""
                         showAccess = false
+                        accessJustSaved = true
                     }
                 },
                 variant = BrassButtonVariant.Primary,
             )
-            if (ai.bedrockAccessKeyConfigured) {
+            if (ai.bedrockAccessKeyConfigured || accessJustSaved) {
                 BrassButton(
                     label = "Clear",
-                    onClick = { onSetAccessKey(null) },
+                    onClick = {
+                        onSetAccessKey(null)
+                        accessJustSaved = false
+                    },
                     variant = BrassButtonVariant.Text,
                 )
             }
         }
         // ── Secret key ────────────────────────────────────────────
         Text(
-            if (ai.bedrockSecretKeyConfigured) "AWS secret access key — set"
+            if (ai.bedrockSecretKeyConfigured || secretJustSaved) "AWS secret access key — set"
             else "AWS secret access key — not set",
             style = MaterialTheme.typography.bodyMedium,
         )
@@ -2556,14 +2596,18 @@ private fun BedrockProviderRows(
                         onSetSecretKey(secretDraft)
                         secretDraft = ""
                         showSecret = false
+                        secretJustSaved = true
                     }
                 },
                 variant = BrassButtonVariant.Primary,
             )
-            if (ai.bedrockSecretKeyConfigured) {
+            if (ai.bedrockSecretKeyConfigured || secretJustSaved) {
                 BrassButton(
                     label = "Clear",
-                    onClick = { onSetSecretKey(null) },
+                    onClick = {
+                        onSetSecretKey(null)
+                        secretJustSaved = false
+                    },
                     variant = BrassButtonVariant.Text,
                 )
             }

--- a/feature/src/main/kotlin/in/jphe/storyvox/feature/settings/SettingsScreen.kt
+++ b/feature/src/main/kotlin/in/jphe/storyvox/feature/settings/SettingsScreen.kt
@@ -2086,15 +2086,18 @@ private fun ClaudeProviderRows(
     val spacing = LocalSpacing.current
     var keyDraft by remember { mutableStateOf("") }
     var showKey by remember { mutableStateOf(false) }
-    // #338 — local "just saved" override. EncryptedSharedPreferences
-    // changes don't tick the settings StateFlow that ai.*KeyConfigured
-    // is derived from, so the configured label would otherwise stay
-    // "not set" for ~30s after a successful Save. The flag flips back
-    // to false on Clear so the label is honest both ways.
-    var keyJustSaved by remember { mutableStateOf(false) }
+    // #338 — tri-state local override. EncryptedSharedPreferences changes
+    // don't tick the settings StateFlow that ai.*KeyConfigured is derived
+    // from, so both Save (→ "set") and Clear (→ "not set") would otherwise
+    // lag by ~30s until something else triggered a recomposition. A
+    // nullable override takes precedence over the (possibly stale) snapshot
+    // value — Save sets it to true, Clear sets it to false, leaving null
+    // when nothing has happened yet means we trust the snapshot.
+    var keyConfiguredOverride by remember { mutableStateOf<Boolean?>(null) }
+    val keyConfigured = keyConfiguredOverride ?: ai.claudeKeyConfigured
     Column(verticalArrangement = Arrangement.spacedBy(spacing.xs)) {
         Text(
-            if (ai.claudeKeyConfigured || keyJustSaved) "Claude API key — set"
+            if (keyConfigured) "Claude API key — set"
             else "Claude API key — not set",
             style = MaterialTheme.typography.bodyMedium,
         )
@@ -2120,17 +2123,17 @@ private fun ClaudeProviderRows(
                         onSetClaudeKey(keyDraft)
                         keyDraft = ""
                         showKey = false
-                        keyJustSaved = true
+                        keyConfiguredOverride = true
                     }
                 },
                 variant = BrassButtonVariant.Primary,
             )
-            if (ai.claudeKeyConfigured || keyJustSaved) {
+            if (keyConfigured) {
                 BrassButton(
                     label = "Clear",
                     onClick = {
                         onSetClaudeKey(null)
-                        keyJustSaved = false
+                        keyConfiguredOverride = false
                     },
                     variant = BrassButtonVariant.Text,
                 )
@@ -2170,10 +2173,11 @@ private fun OpenAiProviderRows(
     var keyDraft by remember { mutableStateOf("") }
     var showKey by remember { mutableStateOf(false) }
     // #338 — see ClaudeProviderRows for the rationale.
-    var keyJustSaved by remember { mutableStateOf(false) }
+    var keyConfiguredOverride by remember { mutableStateOf<Boolean?>(null) }
+    val keyConfigured = keyConfiguredOverride ?: ai.openAiKeyConfigured
     Column(verticalArrangement = Arrangement.spacedBy(spacing.xs)) {
         Text(
-            if (ai.openAiKeyConfigured || keyJustSaved) "OpenAI API key — set"
+            if (keyConfigured) "OpenAI API key — set"
             else "OpenAI API key — not set",
             style = MaterialTheme.typography.bodyMedium,
         )
@@ -2199,17 +2203,17 @@ private fun OpenAiProviderRows(
                         onSetOpenAiKey(keyDraft)
                         keyDraft = ""
                         showKey = false
-                        keyJustSaved = true
+                        keyConfiguredOverride = true
                     }
                 },
                 variant = BrassButtonVariant.Primary,
             )
-            if (ai.openAiKeyConfigured || keyJustSaved) {
+            if (keyConfigured) {
                 BrassButton(
                     label = "Clear",
                     onClick = {
                         onSetOpenAiKey(null)
-                        keyJustSaved = false
+                        keyConfiguredOverride = false
                     },
                     variant = BrassButtonVariant.Text,
                 )
@@ -2286,10 +2290,11 @@ private fun VertexProviderRows(
     var keyDraft by remember { mutableStateOf("") }
     var showKey by remember { mutableStateOf(false) }
     // #338 — see ClaudeProviderRows for the rationale.
-    var keyJustSaved by remember { mutableStateOf(false) }
+    var keyConfiguredOverride by remember { mutableStateOf<Boolean?>(null) }
+    val keyConfigured = keyConfiguredOverride ?: ai.vertexKeyConfigured
     Column(verticalArrangement = Arrangement.spacedBy(spacing.xs)) {
         Text(
-            if (ai.vertexKeyConfigured || keyJustSaved) "Vertex API key — set"
+            if (keyConfigured) "Vertex API key — set"
             else "Vertex API key — not set",
             style = MaterialTheme.typography.bodyMedium,
         )
@@ -2315,17 +2320,17 @@ private fun VertexProviderRows(
                         onSetVertexKey(keyDraft)
                         keyDraft = ""
                         showKey = false
-                        keyJustSaved = true
+                        keyConfiguredOverride = true
                     }
                 },
                 variant = BrassButtonVariant.Primary,
             )
-            if (ai.vertexKeyConfigured || keyJustSaved) {
+            if (keyConfigured) {
                 BrassButton(
                     label = "Clear",
                     onClick = {
                         onSetVertexKey(null)
-                        keyJustSaved = false
+                        keyConfiguredOverride = false
                     },
                     variant = BrassButtonVariant.Text,
                 )
@@ -2372,7 +2377,8 @@ private fun AzureFoundryProviderRows(
     // + deployment to DataStore (which the settings flow does observe,
     // so those labels update fine) plus the API key to EncryptedSharedPrefs
     // (which doesn't). Only the API-key label needs the local override.
-    var keyJustSaved by remember { mutableStateOf(false) }
+    var keyConfiguredOverride by remember { mutableStateOf<Boolean?>(null) }
+    val keyConfigured = keyConfiguredOverride ?: ai.foundryKeyConfigured
 
     Column(verticalArrangement = Arrangement.spacedBy(spacing.xs)) {
         // ── Mode toggle ────────────────────────────────────────────
@@ -2423,7 +2429,7 @@ private fun AzureFoundryProviderRows(
 
         // ── API key (encrypted) ───────────────────────────────────
         Text(
-            if (ai.foundryKeyConfigured || keyJustSaved) "Foundry API key — set"
+            if (keyConfigured) "Foundry API key — set"
             else "Foundry API key — not set",
             style = MaterialTheme.typography.bodyMedium,
         )
@@ -2484,17 +2490,17 @@ private fun AzureFoundryProviderRows(
                         onSetFoundryKey(keyDraft)
                         keyDraft = ""
                         showKey = false
-                        keyJustSaved = true
+                        keyConfiguredOverride = true
                     }
                 },
                 variant = BrassButtonVariant.Primary,
             )
-            if (ai.foundryKeyConfigured || keyJustSaved) {
+            if (keyConfigured) {
                 BrassButton(
                     label = "Clear key",
                     onClick = {
                         onSetFoundryKey(null)
-                        keyJustSaved = false
+                        keyConfiguredOverride = false
                     },
                     variant = BrassButtonVariant.Text,
                 )
@@ -2518,13 +2524,16 @@ private fun BedrockProviderRows(
     var showAccess by remember { mutableStateOf(false) }
     var showSecret by remember { mutableStateOf(false) }
     // #338 — see ClaudeProviderRows. Bedrock has two independent
-    // per-field Saves so it needs two local override flags.
-    var accessJustSaved by remember { mutableStateOf(false) }
-    var secretJustSaved by remember { mutableStateOf(false) }
+    // per-field Saves so it needs two tri-state overrides (true on
+    // Save, false on Clear, null when nothing has happened yet).
+    var accessConfiguredOverride by remember { mutableStateOf<Boolean?>(null) }
+    var secretConfiguredOverride by remember { mutableStateOf<Boolean?>(null) }
+    val accessConfigured = accessConfiguredOverride ?: ai.bedrockAccessKeyConfigured
+    val secretConfigured = secretConfiguredOverride ?: ai.bedrockSecretKeyConfigured
     Column(verticalArrangement = Arrangement.spacedBy(spacing.xs)) {
         // ── Access key ────────────────────────────────────────────
         Text(
-            if (ai.bedrockAccessKeyConfigured || accessJustSaved) "AWS access key id — set"
+            if (accessConfigured) "AWS access key id — set"
             else "AWS access key id — not set",
             style = MaterialTheme.typography.bodyMedium,
         )
@@ -2551,17 +2560,17 @@ private fun BedrockProviderRows(
                         onSetAccessKey(accessDraft)
                         accessDraft = ""
                         showAccess = false
-                        accessJustSaved = true
+                        accessConfiguredOverride = true
                     }
                 },
                 variant = BrassButtonVariant.Primary,
             )
-            if (ai.bedrockAccessKeyConfigured || accessJustSaved) {
+            if (accessConfigured) {
                 BrassButton(
                     label = "Clear",
                     onClick = {
                         onSetAccessKey(null)
-                        accessJustSaved = false
+                        accessConfiguredOverride = false
                     },
                     variant = BrassButtonVariant.Text,
                 )
@@ -2569,7 +2578,7 @@ private fun BedrockProviderRows(
         }
         // ── Secret key ────────────────────────────────────────────
         Text(
-            if (ai.bedrockSecretKeyConfigured || secretJustSaved) "AWS secret access key — set"
+            if (secretConfigured) "AWS secret access key — set"
             else "AWS secret access key — not set",
             style = MaterialTheme.typography.bodyMedium,
         )
@@ -2596,17 +2605,17 @@ private fun BedrockProviderRows(
                         onSetSecretKey(secretDraft)
                         secretDraft = ""
                         showSecret = false
-                        secretJustSaved = true
+                        secretConfiguredOverride = true
                     }
                 },
                 variant = BrassButtonVariant.Primary,
             )
-            if (ai.bedrockSecretKeyConfigured || secretJustSaved) {
+            if (secretConfigured) {
                 BrassButton(
                     label = "Clear",
                     onClick = {
                         onSetSecretKey(null)
-                        secretJustSaved = false
+                        secretConfiguredOverride = false
                     },
                     variant = BrassButtonVariant.Text,
                 )


### PR DESCRIPTION
## Summary

Every per-field Save in the AI section writes to EncryptedSharedPreferences, which doesn't tick the settings StateFlow → configured-label stayed "not set" for ~30s after a successful Save. Added a local `keyJustSaved` flag per section, OR'd into the configured check.

## Affected sections

- ClaudeProviderRows
- OpenAiProviderRows
- VertexProviderRows
- AzureFoundryProviderRows (key field only — endpoint + deployment go through DataStore so their labels were already fine)
- BedrockProviderRows (two flags: access + secret)

Azure Speech wasn't affected — it already uses write-through `onValueChange` instead of a Save button.

## Test plan

- [x] `:feature:compileDebugKotlin` clean (one pre-existing Divider deprecation warning, unrelated)
- [ ] Manual: type Bedrock access key → tap Save → label flips to "set" immediately + Clear button appears
- [ ] Manual: tap Clear → label flips back to "not set" + Clear button disappears

## Out of scope

The cross-navigation case still has the bug — leave the screen and come back, the `remember{}` resets and the label is back to "not set" until something else ticks. The proper fix is an `OnSharedPreferenceChangeListener` on `LlmCredentialsStore` feeding a StateFlow the settings flow combines with. Tracked as a follow-up if anyone hits it; in-session UX (the path users actually take after typing a key) is what this PR fixes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)