### PR TITLE
fix(player): SkipPrevious rewinds to chapter start past 3s in (closes #285)

### DIFF
--- a/core-playback/src/main/kotlin/in/jphe/storyvox/playback/PlaybackController.kt
+++ b/core-playback/src/main/kotlin/in/jphe/storyvox/playback/PlaybackController.kt
@@ -184,7 +184,24 @@ class DefaultPlaybackController @Inject constructor(
     override fun previousSentence() { player?.seekSentence(direction = -1) }
 
     override suspend fun nextChapter() { player?.advanceChapter(direction = 1) }
-    override suspend fun previousChapter() { player?.advanceChapter(direction = -1) }
+    override suspend fun previousChapter() {
+        // #285 — standard media-player UX. Pressing Previous past a few
+        // seconds into the current chapter rewinds to its start; only
+        // pressing Previous *while near the start* goes to the previous
+        // chapter. Without this, a stray tap during chapter 2 silently
+        // dumps the user back to chapter 1, with no confirm, no
+        // animation, and lost reading position. Apple Music, Spotify,
+        // Pocket Casts, and every major player work this way — users
+        // expect it.
+        val s = state.value
+        val charsPerSec = SPEED_BASELINE_CHARS_PER_SECOND * s.speed
+        val rewindThresholdChars = (charsPerSec * REWIND_TO_START_THRESHOLD_SEC).toInt()
+        if (s.charOffset > rewindThresholdChars) {
+            player?.seekToCharOffset(0)
+        } else {
+            player?.advanceChapter(direction = -1)
+        }
+    }
     override suspend fun jumpToChapter(chapterId: String) {
         val fictionId = state.value.currentFictionId ?: return
         play(fictionId, chapterId, charOffset = 0)
@@ -232,5 +249,15 @@ class DefaultPlaybackController @Inject constructor(
 
     internal fun emitEvent(event: PlaybackUiEvent) {
         _events.tryEmit(event)
+    }
+
+    companion object {
+        /** Issue #285 — seconds-from-start threshold for the SkipPrevious
+         *  rewind-to-start UX. Past this point in a chapter, tapping
+         *  SkipPrevious seeks to char 0 of the current chapter; under it
+         *  goes to the previous chapter. 3 seconds is the de-facto
+         *  standard across Apple Music, Spotify, Pocket Casts, and the
+         *  Android MediaSession default behavior. */
+        internal const val REWIND_TO_START_THRESHOLD_SEC = 3f
     }
 }


### PR DESCRIPTION
## Summary

`PlaybackController.previousChapter()` used to unconditionally call `advanceChapter(-1)`. Now it checks the current position — past the 3-second mark, the first tap seeks to position 0 of the current chapter; near the start, it walks to the previous chapter.

## Why

JP hit the bug while listening to Sky Pride: chapter 2 playing at 2:06, stray tap near the controls → silent jump back to chapter 1 at 0:01, minutes of listening progress lost with no animation, no confirm, no undo. The fix matches Apple Music / Spotify / Pocket Casts / Android MediaSession defaults — universal expectation.

## Test plan

- [x] `:core-playback:compileDebugKotlin` clean
- [ ] Manual on tablet: play chapter past 3s → tap SkipPrevious → position resets to 0 of *same* chapter
- [ ] Manual on tablet: play chapter, immediately (under 3s in) tap SkipPrevious → walks to previous chapter
- [ ] Manual: at chapter 1 (no previous), under 3s in, SkipPrevious → no-op (matches advanceChapter's existing null-guard)

## Threshold

Uses `SPEED_BASELINE_CHARS_PER_SECOND * speed * 3` to map chars→seconds — same scaling `skipBack30s` already uses. At 1× speed that's ~38 chars; at 2× ~75 chars. Constant lives on PlaybackController.Companion as `REWIND_TO_START_THRESHOLD_SEC`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)