### PR TITLE
feat(debug): surface chapter cache + voice model storage (closes #293)

### DIFF
--- a/app/src/main/kotlin/in/jphe/storyvox/di/AppBindings.kt
+++ b/app/src/main/kotlin/in/jphe/storyvox/di/AppBindings.kt
@@ -125,8 +125,16 @@ object AppBindings {
         settings: SettingsRepositoryUi,
         azureCreds: `in`.jphe.storyvox.source.azure.AzureCredentials,
         azureEngine: `in`.jphe.storyvox.source.azure.AzureVoiceEngine,
+        chapterRepo: `in`.jphe.storyvox.data.repository.ChapterRepository,
     ): `in`.jphe.storyvox.feature.api.DebugRepositoryUi =
-        RealDebugRepositoryUi(context, controller, settings, azureCreds, azureEngine)
+        RealDebugRepositoryUi(
+            context = context,
+            controller = controller,
+            settings = settings,
+            azureCreds = azureCreds,
+            azureEngine = azureEngine,
+            chapterRepo = chapterRepo,
+        )
 
     @Provides @Singleton
     fun provideVoiceProviderUi(impl: VoiceProviderUiImpl): VoiceProviderUi = impl

--- a/app/src/main/kotlin/in/jphe/storyvox/di/RealDebugRepositoryUi.kt
+++ b/app/src/main/kotlin/in/jphe/storyvox/di/RealDebugRepositoryUi.kt
@@ -4,6 +4,7 @@ import android.content.Context
 import android.net.ConnectivityManager
 import android.net.NetworkCapabilities
 import android.os.SystemClock
+import `in`.jphe.storyvox.data.repository.ChapterRepository
 import `in`.jphe.storyvox.feature.api.DebugAudio
 import `in`.jphe.storyvox.feature.api.DebugAzure
 import `in`.jphe.storyvox.feature.api.DebugBuildInfo
@@ -37,7 +38,9 @@ import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.sample
 import kotlinx.coroutines.flow.shareIn
+import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
+import java.io.File
 
 /**
  * Production [DebugRepositoryUi]. Joins live state from
@@ -68,6 +71,7 @@ internal class RealDebugRepositoryUi(
     private val settings: SettingsRepositoryUi,
     private val azureCreds: AzureCredentials,
     private val azureEngine: AzureVoiceEngine,
+    private val chapterRepo: ChapterRepository,
 ) : DebugRepositoryUi {
 
     private val scope = CoroutineScope(SupervisorJob() + Dispatchers.Default)
@@ -95,6 +99,15 @@ internal class RealDebugRepositoryUi(
     /** Last error tag, for error-change event emission. */
     @Volatile private var lastErrorTag: String? = null
 
+    /**
+     * Issue #293 — cached storage snapshot. Polled every 10s by a
+     * background coroutine while the class scope is alive; buildSnapshot
+     * reads `.value` synchronously so the 1Hz combine never blocks on a
+     * Room query or filesystem walk. Initial value is "—" (zeroes) until
+     * the first poll completes a few ms after construction.
+     */
+    private val storageSnapshot = MutableStateFlow(DebugStorage())
+
     init {
         // Drive the event ring from the playback controller's state +
         // event stream. The state stream gives us the implicit events
@@ -120,6 +133,50 @@ internal class RealDebugRepositoryUi(
                     }
                 }
         }
+        // Issue #293 — storage diagnostic poll. Refreshes the cached
+        // DebugStorage snapshot every STORAGE_POLL_INTERVAL_MS so the
+        // 1Hz combine reads a fresh-enough number without paying the
+        // Room query + filesystem walk on every tick. Storage usage
+        // changes on download/delete events, neither of which are
+        // sub-second; 10s is generous.
+        scope.launch {
+            while (true) {
+                storageSnapshot.value = readStorageSnapshot()
+                delay(STORAGE_POLL_INTERVAL_MS)
+            }
+        }
+    }
+
+    /**
+     * Issue #293 — compute the storage diagnostic in one read pass.
+     * Cheap Room aggregate + a single-level filesystem walk of
+     * `filesDir/voices/`. Each installed voice is a small directory
+     * (3-200 MB onnx + json + assets); summing top-level dir sizes is
+     * orders of magnitude faster than a deep recursive walk and
+     * accurate enough for the debug row's purposes.
+     */
+    private suspend fun readStorageSnapshot(): DebugStorage {
+        val cache = runCatching { chapterRepo.cachedBodyUsage() }.getOrNull()
+        val voiceBytes = runCatching { voiceModelBytes() }.getOrNull() ?: 0L
+        return DebugStorage(
+            cachedChapters = cache?.count ?: 0,
+            cachedChapterBytes = cache?.bytesEstimate ?: 0L,
+            voiceModelBytes = voiceBytes,
+        )
+    }
+
+    /**
+     * Sum of bytes under `filesDir/voices/`. Each voice lives in its
+     * own subdirectory; we sum each voice dir recursively (only one
+     * level deep in practice, but `walkBottomUp` is robust to nested
+     * shared assets like the kokoro `_kokoro_shared/voices.bin` layout).
+     */
+    private fun voiceModelBytes(): Long {
+        val root = File(context.filesDir, "voices")
+        if (!root.isDirectory) return 0L
+        return root.walkBottomUp()
+            .filter { it.isFile }
+            .sumOf { it.length() }
     }
 
     private fun onStateChange(s: PlaybackState) {
@@ -261,11 +318,7 @@ internal class RealDebugRepositoryUi(
                 },
                 lastFetchError = null,
             ),
-            storage = DebugStorage(
-                cachedChapters = 0,
-                cachedChapterBytes = 0L,
-                voiceModelBytes = 0L,
-            ),
+            storage = storageSnapshot.value,
             build = DebugBuildInfo(
                 versionName = ui.sigil.versionName,
                 hash = ui.sigil.hash,
@@ -348,5 +401,11 @@ internal class RealDebugRepositoryUi(
         /** 1 Hz — matches Vesper's mission brief: "Numeric values update at
          *  1Hz (not 60Hz — that's wasteful)". */
         const val REFRESH_INTERVAL_MS = 1_000L
+
+        /** Issue #293 — storage diagnostic poll cadence. Storage usage
+         *  only changes on download/delete events (neither sub-second);
+         *  10s is generous and keeps the room query + filesystem walk
+         *  off the 1Hz snapshot path. */
+        const val STORAGE_POLL_INTERVAL_MS = 10_000L
     }
 }

--- a/app/src/test/kotlin/in/jphe/storyvox/di/RealPlaybackControllerUiTest.kt
+++ b/app/src/test/kotlin/in/jphe/storyvox/di/RealPlaybackControllerUiTest.kt
@@ -319,5 +319,7 @@ class RealPlaybackControllerUiTest {
         override suspend fun getChapter(id: String): PlaybackChapter? = null
         override suspend fun getNextChapterId(currentChapterId: String): String? = null
         override suspend fun getPreviousChapterId(currentChapterId: String): String? = null
+        override suspend fun cachedBodyUsage() =
+            `in`.jphe.storyvox.data.repository.CachedBodyUsage(count = 0, bytesEstimate = 0L)
     }
 }

--- a/core-data/src/main/kotlin/in/jphe/storyvox/data/db/dao/ChapterDao.kt
+++ b/core-data/src/main/kotlin/in/jphe/storyvox/data/db/dao/ChapterDao.kt
@@ -189,12 +189,44 @@ interface ChapterDao {
         """,
     )
     suspend fun trimDownloadedBodies(fictionId: String, keepLast: Int)
+
+    /**
+     * Issue #293 — debug-surface storage diagnostic. Single round-trip
+     * returns both the count of cached chapters AND the rough byte usage
+     * of their text bodies. SQLite's `LENGTH()` on a TEXT column returns
+     * the **character** count, not the on-disk UTF-8 byte count; we
+     * multiply by 2 as a conservative upper-bound for mixed ASCII +
+     * occasional smart-punctuation prose (most of which is single-byte).
+     *
+     * Polled by RealDebugRepositoryUi on the debug screen's storage
+     * row; non-load-bearing for playback, so an imprecise estimate is
+     * fine. The COALESCE guards an empty cache returning NULL from SUM.
+     */
+    @Query(
+        """
+        SELECT
+          COUNT(*) AS count,
+          COALESCE(SUM(LENGTH(plainBody) * 2), 0) AS bytes
+          FROM chapter
+         WHERE plainBody IS NOT NULL AND plainBody <> ''
+        """,
+    )
+    suspend fun cacheUsage(): ChapterCacheUsageRow
 }
 
 /** Light projection used by [ChapterDao.observeDownloadStates]. */
 data class ChapterDownloadStateRow(
     val id: String,
     val downloadState: ChapterDownloadState,
+)
+
+/** Issue #293 — combined count + estimated byte usage of cached chapter
+ *  bodies. Both columns come from a single SQL aggregate so the DAO
+ *  read is one round-trip; the storage debug row updates on a 10s
+ *  poll, so cost is negligible. */
+data class ChapterCacheUsageRow(
+    val count: Int,
+    val bytes: Long,
 )
 
 /**

--- a/core-data/src/main/kotlin/in/jphe/storyvox/data/repository/ChapterRepository.kt
+++ b/core-data/src/main/kotlin/in/jphe/storyvox/data/repository/ChapterRepository.kt
@@ -71,7 +71,24 @@ interface ChapterRepository {
 
     /** ID of the previous chapter in reading order, or null at the start. */
     suspend fun getPreviousChapterId(currentChapterId: String): String?
+
+    /**
+     * Issue #293 — debug-surface storage diagnostic. Returns count of
+     * chapters with a cached body + estimated byte usage. Single
+     * SQL aggregate; safe to call on a poll cadence (~10s on the debug
+     * screen). Bytes are an upper-bound estimate (char count × 2);
+     * exact UTF-8 byte cost would require LENGTH(CAST(plainBody AS BLOB))
+     * which is more expensive on a large table for no practical gain
+     * on the storage diagnostic.
+     */
+    suspend fun cachedBodyUsage(): CachedBodyUsage
 }
+
+/** Issue #293 — paired count/bytes return for [ChapterRepository.cachedBodyUsage]. */
+data class CachedBodyUsage(
+    val count: Int,
+    val bytesEstimate: Long,
+)
 
 @Singleton
 class ChapterRepositoryImpl @Inject constructor(
@@ -151,4 +168,9 @@ class ChapterRepositoryImpl @Inject constructor(
 
     override suspend fun getPreviousChapterId(currentChapterId: String): String? =
         dao.previousChapterId(currentChapterId)
+
+    override suspend fun cachedBodyUsage(): CachedBodyUsage {
+        val row = dao.cacheUsage()
+        return CachedBodyUsage(count = row.count, bytesEstimate = row.bytes)
+    }
 }

--- a/core-data/src/test/kotlin/in/jphe/storyvox/data/repository/ChapterRepositoryImplTest.kt
+++ b/core-data/src/test/kotlin/in/jphe/storyvox/data/repository/ChapterRepositoryImplTest.kt
@@ -159,6 +159,14 @@ class ChapterRepositoryImplTest {
             publishRow(id)
         }
 
+        override suspend fun cacheUsage(): `in`.jphe.storyvox.data.db.dao.ChapterCacheUsageRow {
+            val cached = rows.values.filter { !it.plainBody.isNullOrEmpty() }
+            return `in`.jphe.storyvox.data.db.dao.ChapterCacheUsageRow(
+                count = cached.size,
+                bytes = cached.sumOf { (it.plainBody?.length ?: 0).toLong() * 2 },
+            )
+        }
+
         override suspend fun trimDownloadedBodies(fictionId: String, keepLast: Int) {
             callLog += "trimDownloadedBodies($fictionId, $keepLast)"
             val ids = rows.values

--- a/core-data/src/test/kotlin/in/jphe/storyvox/data/repository/FictionRepositoryImplTest.kt
+++ b/core-data/src/test/kotlin/in/jphe/storyvox/data/repository/FictionRepositoryImplTest.kt
@@ -258,6 +258,8 @@ class FictionRepositoryImplTest {
         override suspend fun unreadChapters(limit: Int): List<UnreadChapterRow> = emptyList()
         override suspend fun setRead(id: String, read: Boolean, now: Long) {}
         override suspend fun trimDownloadedBodies(fictionId: String, keepLast: Int) {}
+        override suspend fun cacheUsage(): `in`.jphe.storyvox.data.db.dao.ChapterCacheUsageRow =
+            `in`.jphe.storyvox.data.db.dao.ChapterCacheUsageRow(count = 0, bytes = 0L)
         override suspend fun setDownloadState(
             id: String,
             state: ChapterDownloadState,


### PR DESCRIPTION
## Summary

Replaces the hardcoded zeros in the Debug screen's Storage section with real numbers.

Stack:
- New `ChapterDao.cacheUsage()` — single SQL aggregate returning `COUNT(*)` + `COALESCE(SUM(LENGTH(plainBody) * 2), 0)` for chapters with a downloaded body
- New `ChapterRepository.cachedBodyUsage()` exposing it via a small `CachedBodyUsage` data class
- `RealDebugRepositoryUi` gains a `chapterRepo` dep + a 10s-interval poll that updates a `storageSnapshot: StateFlow`. `buildSnapshot` reads `.value` synchronously so the 1Hz combine never blocks
- Voice model bytes computed by walking `filesDir/voices/` bottom-up — robust to the Kokoro `_kokoro_shared` nested-asset layout

## Why

Three of the Storage row's metrics were placeholders (`cached chapters 0`, `chapter cache —`, `voice model cache —`). Vesper's debug overlay was specifically built to surface state — and storage is one of the most actionable diagnostics ("am I about to run out of room?").

## Test plan

- [x] `:app:compileDebugKotlin` clean
- [x] `:app:testDebugUnitTest` + `:core-data:testDebugUnitTest` pass after fake-stub updates
- [ ] Manual: open Debug screen on tablet → Storage row shows non-zero values for cached chapters + voice models
- [ ] Manual: download a chapter → wait ≤10s → cached chapter count goes up

## Trade-offs

- Char-count × 2 byte estimate over `LENGTH(plainBody)` rather than `LENGTH(CAST(plainBody AS BLOB))`. Upper-bound for mixed ASCII + smart-punctuation prose; exact UTF-8 byte count would force Room to materialize each row's body which defeats the aggregate
- 10s poll cadence keeps the Room query + filesystem walk off the snapshot hot path; storage doesn't change at sub-second rates
- Voice walk is bottom-up over `walkBottomUp().filter { isFile }.sumOf { length() }` — for ~1k Azure voice metadata files + a handful of Piper/Kokoro onnx files this is in the single-digit ms range

🤖 Generated with [Claude Code](https://claude.com/claude-code)