### PR TITLE
feat(debug): surface Azure synth latency, queue depth, voice cache age (closes #291)

### DIFF
--- a/app/src/main/kotlin/in/jphe/storyvox/di/AppBindings.kt
+++ b/app/src/main/kotlin/in/jphe/storyvox/di/AppBindings.kt
@@ -125,6 +125,8 @@ object AppBindings {
         settings: SettingsRepositoryUi,
         azureCreds: `in`.jphe.storyvox.source.azure.AzureCredentials,
         azureEngine: `in`.jphe.storyvox.source.azure.AzureVoiceEngine,
+        azureSpeechClient: `in`.jphe.storyvox.source.azure.AzureSpeechClient,
+        azureVoiceRoster: `in`.jphe.storyvox.source.azure.AzureVoiceRoster,
         chapterRepo: `in`.jphe.storyvox.data.repository.ChapterRepository,
     ): `in`.jphe.storyvox.feature.api.DebugRepositoryUi =
         RealDebugRepositoryUi(
@@ -133,6 +135,8 @@ object AppBindings {
             settings = settings,
             azureCreds = azureCreds,
             azureEngine = azureEngine,
+            azureSpeechClient = azureSpeechClient,
+            azureVoiceRoster = azureVoiceRoster,
             chapterRepo = chapterRepo,
         )
 

--- a/app/src/main/kotlin/in/jphe/storyvox/di/RealDebugRepositoryUi.kt
+++ b/app/src/main/kotlin/in/jphe/storyvox/di/RealDebugRepositoryUi.kt
@@ -28,7 +28,9 @@ import `in`.jphe.storyvox.playback.PlaybackState
 import `in`.jphe.storyvox.playback.PlaybackUiEvent
 import `in`.jphe.storyvox.source.azure.AzureCredentials
 import `in`.jphe.storyvox.source.azure.AzureError
+import `in`.jphe.storyvox.source.azure.AzureSpeechClient
 import `in`.jphe.storyvox.source.azure.AzureVoiceEngine
+import `in`.jphe.storyvox.source.azure.AzureVoiceRoster
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.SupervisorJob
@@ -76,6 +78,8 @@ internal class RealDebugRepositoryUi(
     private val settings: SettingsRepositoryUi,
     private val azureCreds: AzureCredentials,
     private val azureEngine: AzureVoiceEngine,
+    private val azureSpeechClient: AzureSpeechClient,
+    private val azureVoiceRoster: AzureVoiceRoster,
     private val chapterRepo: ChapterRepository,
 ) : DebugRepositoryUi {
 
@@ -413,10 +417,17 @@ internal class RealDebugRepositoryUi(
             azure = DebugAzure(
                 isConfigured = azureCreds.isConfigured,
                 regionId = azureCreds.regionId(),
-                pendingRequests = 0,
-                lastLatencyMs = null,
+                // Issue #291 — wired live from AzureSpeechClient's
+                // synth-path instrumentation + AzureVoiceRoster's
+                // fetch timestamp. Cache age computed at read time
+                // from elapsedRealtime delta so a 1Hz snapshot
+                // doesn't need a separate ticker on the roster
+                // side.
+                pendingRequests = azureSpeechClient.pendingRequests.value,
+                lastLatencyMs = azureSpeechClient.lastSynthLatencyMs.value,
                 lastErrorTag = mapAzureErrorTag(azureErr),
-                voiceCacheAgeSec = null,
+                voiceCacheAgeSec = azureVoiceRoster.lastFetchAtElapsedMs.value
+                    ?.let { (SystemClock.elapsedRealtime() - it) / 1000 },
             ),
             network = DebugNetwork(
                 online = isOnline(),

--- a/source-azure/src/main/kotlin/in/jphe/storyvox/source/azure/AzureSpeechClient.kt
+++ b/source-azure/src/main/kotlin/in/jphe/storyvox/source/azure/AzureSpeechClient.kt
@@ -1,9 +1,15 @@
 package `in`.jphe.storyvox.source.azure
 
+import android.os.SystemClock
 import `in`.jphe.storyvox.data.source.AzureVoiceDescriptor
 import `in`.jphe.storyvox.source.azure.di.AzureHttp
 import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.flow
+import kotlinx.coroutines.flow.onCompletion
+import kotlinx.coroutines.flow.onStart
 import okhttp3.MediaType.Companion.toMediaType
 import okhttp3.OkHttpClient
 import okhttp3.Request
@@ -86,6 +92,31 @@ open class AzureSpeechClient @Inject constructor(
     @AzureHttp private val http: OkHttpClient,
     private val credentials: AzureCredentials,
 ) {
+
+    /**
+     * Issue #291 — wall-clock round-trip latency for the most recent
+     * synthesize() (buffered or streaming). null until the first call
+     * returns. Resets on every call entry — observers see the
+     * `pendingRequests > 0` flag alongside to distinguish "in flight"
+     * from "this is the value for the call that just completed".
+     *
+     * Read by RealDebugRepositoryUi for the Debug overlay's Azure
+     * latency row. Off the hot path; updating a StateFlow is a single
+     * volatile write.
+     */
+    private val _lastSynthLatencyMs = MutableStateFlow<Long?>(null)
+    open val lastSynthLatencyMs: StateFlow<Long?> = _lastSynthLatencyMs.asStateFlow()
+
+    /**
+     * Issue #291 — count of in-flight synthesize() calls. Buffered
+     * synthesize() is normally single-flight per chapter; the
+     * streaming variant can briefly overlap with a follow-up sentence
+     * while the audio pipeline drains the previous one. Useful for
+     * spotting "Azure is stuck and we keep firing new requests".
+     */
+    private val _pendingRequests = MutableStateFlow(0)
+    open val pendingRequests: StateFlow<Int> = _pendingRequests.asStateFlow()
+
     /** Open for tests — MockWebServer overrides this to point at a
      *  local URL. Production callers leave it at the default. */
     protected open fun endpointUrlFor(regionId: String): String =
@@ -160,8 +191,22 @@ open class AzureSpeechClient @Inject constructor(
      * @throws AzureError.ServerError  on 5xx
      * @throws AzureError.NetworkError on TCP / TLS / DNS failure
      */
-    open fun synthesize(ssml: String): ByteArray = withRetry {
-        synthesizeOnce(ssml)
+    open fun synthesize(ssml: String): ByteArray {
+        // Issue #291 — instrument the buffered synthesis path so the
+        // Debug overlay can show last-latency + pendingRequests. The
+        // wall-clock measurement spans the retry budget (any 429 /
+        // server-error backoff is counted) — what the user actually
+        // waited for an audible result. try/finally guarantees the
+        // counter and latency get updated even when AzureError types
+        // propagate up.
+        val start = SystemClock.elapsedRealtime()
+        _pendingRequests.value = _pendingRequests.value + 1
+        try {
+            return withRetry { synthesizeOnce(ssml) }
+        } finally {
+            _lastSynthLatencyMs.value = SystemClock.elapsedRealtime() - start
+            _pendingRequests.value = (_pendingRequests.value - 1).coerceAtLeast(0)
+        }
     }
 
     /**
@@ -186,6 +231,15 @@ open class AzureSpeechClient @Inject constructor(
      * sentence and moving on.
      */
     open fun synthesizeStreaming(ssml: String): Flow<ByteArray> = flow {
+        // Issue #291 — instrument the streaming synth path. The
+        // measurement here is "time from request start to flow
+        // completion (or cancellation)" — what callers experienced
+        // end-to-end, not just first-byte. onStart/onCompletion
+        // would also work but inline lets us read `start` in the
+        // failure path that re-throws after recording latency.
+        val streamStart = SystemClock.elapsedRealtime()
+        _pendingRequests.value = _pendingRequests.value + 1
+        try {
         val key = credentials.key()
             ?: throw AzureError.AuthFailed("No Azure subscription key configured")
         val regionId = credentials.regionId()
@@ -250,6 +304,10 @@ open class AzureSpeechClient @Inject constructor(
                         "Unexpected HTTP ${resp.code} from Azure",
                     )
             }
+        }
+        } finally {
+            _lastSynthLatencyMs.value = SystemClock.elapsedRealtime() - streamStart
+            _pendingRequests.value = (_pendingRequests.value - 1).coerceAtLeast(0)
         }
     }
 

--- a/source-azure/src/main/kotlin/in/jphe/storyvox/source/azure/AzureVoiceRoster.kt
+++ b/source-azure/src/main/kotlin/in/jphe/storyvox/source/azure/AzureVoiceRoster.kt
@@ -1,5 +1,6 @@
 package `in`.jphe.storyvox.source.azure
 
+import android.os.SystemClock
 import android.util.Log
 import `in`.jphe.storyvox.data.source.AzureVoiceDescriptor
 import `in`.jphe.storyvox.data.source.AzureVoiceProvider
@@ -11,6 +12,7 @@ import kotlinx.coroutines.Job
 import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.onStart
 import kotlinx.coroutines.launch
@@ -51,6 +53,22 @@ class AzureVoiceRoster @Inject constructor(
     private var lastFetchedRegion: String? = null
     private val scope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
 
+    /**
+     * Issue #291 — elapsedRealtime() at the moment of the last
+     * successful voices/list fetch. null until the first fetch
+     * succeeds; cleared back to null when the user removes their key
+     * (the roster collapses to empty in that path).
+     *
+     * Consumers (Debug overlay) compute the cache age in seconds as
+     * `(SystemClock.elapsedRealtime() - this.value) / 1000`. We expose
+     * the timestamp rather than a derived `cacheAgeSec` so a 1Hz
+     * snapshot doesn't need a separate ticker coroutine to keep the
+     * age value fresh — the elapsedRealtime delta is recomputed at
+     * read time.
+     */
+    private val _lastFetchAtElapsedMs = MutableStateFlow<Long?>(null)
+    val lastFetchAtElapsedMs: StateFlow<Long?> = _lastFetchAtElapsedMs.asStateFlow()
+
     /** Public flow — kicks the first refresh when something starts
      *  collecting (typically the picker UI on app start). The refresh
      *  is async so the first emission is the cached snapshot
@@ -77,6 +95,7 @@ class AzureVoiceRoster @Inject constructor(
                 state.value = emptyList()
                 lastFetchedKey = null
                 lastFetchedRegion = null
+                _lastFetchAtElapsedMs.value = null
                 return
             }
             if (key == lastFetchedKey &&
@@ -92,6 +111,7 @@ class AzureVoiceRoster @Inject constructor(
                 state.value = voices
                 lastFetchedKey = key
                 lastFetchedRegion = region
+                _lastFetchAtElapsedMs.value = SystemClock.elapsedRealtime()
                 Log.i(TAG, "Fetched ${voices.size} voices for region=$region")
             } catch (t: Throwable) {
                 Log.w(TAG, "Roster fetch failed: ${t.javaClass.simpleName}: ${t.message}")


### PR DESCRIPTION
## Summary

Wires the Debug screen's Azure section to live values instead of the hardcoded placeholders left from #289.

| Field | Source |
|---|---|
| `lastLatencyMs` | `AzureSpeechClient.lastSynthLatencyMs: StateFlow<Long?>` — elapsedRealtime delta around `synthesize()` / `synthesizeStreaming()`, including any retry budget |
| `pendingRequests` | `AzureSpeechClient.pendingRequests: StateFlow<Int>` — incremented on entry, decremented in `finally` |
| `voiceCacheAgeSec` | derived from `AzureVoiceRoster.lastFetchAtElapsedMs: StateFlow<Long?>` — RealDebugRepositoryUi computes `(now - fetchAt) / 1000` at snapshot read time |

## Why this shape

- Exposed the **fetch timestamp** rather than a `cacheAgeSec` flow so the debug snapshot (which already polls at 1Hz) doesn't need a separate ticker coroutine on the roster side to keep the age value fresh
- `try/finally` around the streaming flow body (rather than `onStart`/`onCompletion`) so the latency + pendingRequests counter are correctly reset on cancellation paths — same shape that the buffered `synthesize()` call uses

## Test plan

- [x] `:app:compileDebugKotlin` clean
- [x] `:app:testDebugUnitTest` + `:source-azure:testDebugUnitTest` pass
- [ ] Manual on tablet: configure Azure Speech key → open Debug screen → Azure section shows region + cache age once voices load
- [ ] Manual: play a chapter with an Azure voice → lastLatencyMs populates (typically 200–600ms for streaming first-byte, 2–4s for Dragon HD buffered)
- [ ] Manual: trigger a few rapid sentences → pendingRequests briefly > 0

## Out of scope

#290 (EnginePlayer producer queue depth + audioBufferMs) — still placeholders for follow-up. That one needs deeper plumbing through the synth pipeline; this PR is the cleaner of the two follow-ups.

🤖 Generated with [Claude Code](https://claude.com/claude-code)