### PR TITLE
perf(fiction-detail): stable keys on chapter list LazyColumn

### DIFF
--- a/feature/src/main/kotlin/in/jphe/storyvox/feature/fiction/FictionDetailScreen.kt
+++ b/feature/src/main/kotlin/in/jphe/storyvox/feature/fiction/FictionDetailScreen.kt
@@ -189,7 +189,7 @@ fun FictionDetailScreen(
                     modifier = Modifier.weight(0.58f).fillMaxSize(),
                     contentPadding = PaddingValues(top = spacing.md, bottom = 96.dp),
                 ) {
-                    items(state.chapters) { ch ->
+                    items(state.chapters, key = { it.id }) { ch ->
                         ChapterCard(
                             state = ch.toCardState(currentId = null),
                             onClick = { viewModel.listen(ch.id) },
@@ -232,7 +232,7 @@ fun FictionDetailScreen(
                 }
                 item { Hero(fiction) }
                 item { Synopsis(fiction.synopsis) }
-                items(state.chapters) { ch ->
+                items(state.chapters, key = { it.id }) { ch ->
                     ChapterCard(
                         state = ch.toCardState(currentId = null),
                         onClick = { viewModel.listen(ch.id) },


### PR DESCRIPTION
## Summary

Adds `key = { it.id }` to both `items(state.chapters)` calls in FictionDetailScreen. Without stable keys Compose can't reconcile rows by identity — every emission of `state.chapters` re-composes + re-lays-out every visible row.

## Impact

For 500+ chapter Royal Road serials this is the main source of jank when the chapter list re-emits (download-state flip, played-set update, new chapter arrival from poll). Now only the row whose `UiChapter` actually changed recomposes.

## Audit

Swept the rest of `feature/`:
- LibraryScreen ✓ (already keyed)
- BrowseScreen ✓ (already keyed)
- FollowsScreen ✓ (live list keyed; skeleton intentionally not)
- VoiceLibraryScreen ✓ (all items keyed, even sub-headers)

Only `FictionDetailScreen` was missing them — two-character fix per call site.

## Test plan

- [x] `:feature:compileDebugKotlin` clean
- [ ] Manual on tablet with a long-running serial: open chapter list, scrub rapidly, observe no row flicker on background poll
🤖 Generated with [Claude Code](https://claude.com/claude-code)