### PR TITLE
feat(debug): EnginePlayer producer queue depth + audio buffer ms (closes #290)

### DIFF
--- a/app/src/main/kotlin/in/jphe/storyvox/di/RealDebugRepositoryUi.kt
+++ b/app/src/main/kotlin/in/jphe/storyvox/di/RealDebugRepositoryUi.kt
@@ -406,14 +406,27 @@ internal class RealDebugRepositoryUi(
                 pitch = playback.pitch,
                 punctuationPauseMultiplier = ui.punctuationPauseMultiplier,
             ),
-            audio = DebugAudio(
-                producerQueueDepth = 0, // not exposed from EnginePlayer today
-                producerQueueCapacity = ui.playbackBufferChunks,
-                audioBufferMs = 0L, // see follow-up issue
-                reorderBufferOccupancy = 0,
-                sampleRate = 0,
-                outputDevice = outputDeviceLabel.value,
-            ),
+            audio = run {
+                // Issue #290 — pull producer-queue depth + audioBufferMs
+                // from the bound player's BufferTelemetry snapshot.
+                // Returns zeros when no pipeline is active. Capacity
+                // falls back to the configured slider value when the
+                // source hasn't reported its own (cache sources have
+                // no queue).
+                val tel = controller.bufferTelemetry()
+                DebugAudio(
+                    producerQueueDepth = tel.producerQueueDepth,
+                    producerQueueCapacity = if (tel.producerQueueCapacity > 0) {
+                        tel.producerQueueCapacity
+                    } else {
+                        ui.playbackBufferChunks
+                    },
+                    audioBufferMs = tel.audioBufferMs,
+                    reorderBufferOccupancy = 0,
+                    sampleRate = 0,
+                    outputDevice = outputDeviceLabel.value,
+                )
+            },
             azure = DebugAzure(
                 isConfigured = azureCreds.isConfigured,
                 regionId = azureCreds.regionId(),

--- a/app/src/test/kotlin/in/jphe/storyvox/di/RealPlaybackControllerUiTest.kt
+++ b/app/src/test/kotlin/in/jphe/storyvox/di/RealPlaybackControllerUiTest.kt
@@ -197,6 +197,7 @@ class RealPlaybackControllerUiTest {
         override fun setShakeToExtendEnabled(enabled: Boolean) = Unit
         override suspend fun speakText(text: String) = Unit
         override fun stopSpeaking() = Unit
+        override fun bufferTelemetry() = `in`.jphe.storyvox.playback.BufferTelemetry()
     }
 
     /**

--- a/core-playback/src/main/kotlin/in/jphe/storyvox/playback/BufferTelemetry.kt
+++ b/core-playback/src/main/kotlin/in/jphe/storyvox/playback/BufferTelemetry.kt
@@ -1,0 +1,24 @@
+package `in`.jphe.storyvox.playback
+
+/**
+ * Issue #290 — point-in-time snapshot of the playback pipeline's
+ * producer-consumer state. Surfaced in the Debug overlay's Audio
+ * section so JP can spot "producer can't keep up" (queue near 0)
+ * vs "consumer is paused" (queue near capacity, buffered ms high)
+ * vs "everything's idle" (both zero).
+ *
+ * Polled at the 1Hz debug snapshot cadence; not allocated on the
+ * hot path. The producer-side fields come from the active
+ * `PcmSource` (cache sources report 0 / 0 since they have no
+ * queue); audioBufferMs comes from the consumer-side AudioTrack
+ * write tally minus its current playback-head position.
+ */
+data class BufferTelemetry(
+    /** Chunks currently waiting in the producer's bounded queue. */
+    val producerQueueDepth: Int = 0,
+    /** Configured queue capacity (the bound). UI renders `depth/capacity`. */
+    val producerQueueCapacity: Int = 0,
+    /** Estimated ms of audio that the AudioTrack has accepted but
+     *  not yet played out the speaker. 0 when no track is bound. */
+    val audioBufferMs: Long = 0L,
+)

--- a/core-playback/src/main/kotlin/in/jphe/storyvox/playback/PlaybackController.kt
+++ b/core-playback/src/main/kotlin/in/jphe/storyvox/playback/PlaybackController.kt
@@ -65,6 +65,13 @@ interface PlaybackController {
 
     /** Issue #189 — cancel an in-flight recap-aloud utterance. Idempotent. */
     fun stopSpeaking()
+
+    /**
+     * Issue #290 — point-in-time snapshot of the active player's
+     * producer queue + AudioTrack buffer state. Returns zeros when no
+     * player is bound. Read by the Debug overlay at 1Hz.
+     */
+    fun bufferTelemetry(): BufferTelemetry
 }
 
 /**
@@ -246,6 +253,9 @@ class DefaultPlaybackController @Inject constructor(
     override fun stopSpeaking() {
         player?.stopSpeaking()
     }
+
+    override fun bufferTelemetry(): BufferTelemetry =
+        player?.bufferTelemetry() ?: BufferTelemetry()
 
     internal fun emitEvent(event: PlaybackUiEvent) {
         _events.tryEmit(event)

--- a/core-playback/src/main/kotlin/in/jphe/storyvox/playback/tts/EnginePlayer.kt
+++ b/core-playback/src/main/kotlin/in/jphe/storyvox/playback/tts/EnginePlayer.kt
@@ -557,6 +557,21 @@ class EnginePlayer @AssistedInject constructor(
      *  file exists for `(chapterId, voiceId, speed, pitch, chunkerVersion)`. */
     private var pcmSource: PcmSource? = null
 
+    /**
+     * Issue #290 — running tally of audio frames written to the main
+     * AudioTrack since the last pipeline build. One frame = one PCM
+     * sample on the single mono channel; at 24 kHz that's 1/24000 s
+     * per frame. The Debug overlay's `audio buffered` row computes
+     * `(framesWritten - track.playbackHeadPosition) * 1000 / sampleRate`
+     * to express buffered ms.
+     *
+     * Updated from the consumer thread inside the write loop. Volatile
+     * read on the snapshot path; the consumer is single-threaded so no
+     * atomic increment is needed. Reset to 0 on every new pipeline
+     * build so the delta against playbackHeadPosition stays meaningful.
+     */
+    @Volatile private var totalFramesWritten: Long = 0L
+
     /** Inter-chunk gap measurement (Tab A7 Lite TTS perf lane). Off by
      *  default — reads a marker file at every chunkStart so a developer
      *  can `adb shell touch /data/data/in.jphe.storyvox/files/chunk-gap-log`
@@ -1100,6 +1115,11 @@ class EnginePlayer @AssistedInject constructor(
         )
         pcmSource = source
         pipelineRunning.set(true)
+        // Issue #290 — reset the frames-written tally so the debug
+        // overlay's `audio buffered ms` reads against the fresh
+        // AudioTrack's playbackHeadPosition rather than a stale total
+        // from the previous pipeline.
+        totalFramesWritten = 0L
         // Clear the prev-chunk-end anchor so the first chunk of this
         // pipeline lifetime doesn't get a "gap" attributed to user
         // pause time, seek time, or model load time.
@@ -1268,6 +1288,10 @@ class EnginePlayer @AssistedInject constructor(
                         val n = track.write(chunk.pcm, written, chunk.pcm.size - written)
                         if (n < 0) break // error code from AudioTrack
                         written += n
+                        // Issue #290 — frames written tally for the
+                        // debug overlay's "audio buffered ms" row.
+                        // 16-bit mono PCM = 2 bytes per frame.
+                        if (n > 0) totalFramesWritten += n / 2
                     }
                     // Spool trailing silence from a shared zero-filled
                     // buffer (no per-sentence allocation).
@@ -1282,6 +1306,8 @@ class EnginePlayer @AssistedInject constructor(
                         val n = track.write(SILENCE_CHUNK, 0, sz)
                         if (n < 0) break
                         remaining -= n
+                        // Silence frames count toward the buffer too.
+                        if (n > 0) totalFramesWritten += n / 2
                     }
 
                     // End-of-chunk: AudioTrack has accepted every byte of
@@ -1786,6 +1812,36 @@ class EnginePlayer @AssistedInject constructor(
     /** Issue #189 — stop an in-flight recap utterance. Idempotent. */
     fun stopSpeaking() {
         stopRecapPipeline()
+    }
+
+    /**
+     * Issue #290 — point-in-time snapshot of the producer queue +
+     * AudioTrack buffer state. Read by the Debug overlay at its 1Hz
+     * snapshot cadence; off the hot path entirely.
+     *
+     * Returns zeros when no pipeline is active (queue/track not bound).
+     * `audioBufferMs` is best-effort: AudioTrack's playbackHeadPosition
+     * wraps every 2^31 / sampleRate seconds (~24 hours at 24 kHz) — the
+     * mask-to-unsigned-int handles single wraps; longer-running pipelines
+     * with no rebuild would need an explicit overflow counter (deferred
+     * — current chapters rebuild the pipeline on chapter-end well before
+     * the wrap window).
+     */
+    fun bufferTelemetry(): `in`.jphe.storyvox.playback.BufferTelemetry {
+        val src = pcmSource
+        val track = audioTrack
+        val audioBufferMs = if (track != null && track.sampleRate > 0) {
+            val head = track.playbackHeadPosition.toLong() and 0xFFFFFFFFL
+            val pendingFrames = (totalFramesWritten - head).coerceAtLeast(0)
+            pendingFrames * 1000L / track.sampleRate
+        } else {
+            0L
+        }
+        return `in`.jphe.storyvox.playback.BufferTelemetry(
+            producerQueueDepth = src?.producerQueueDepth() ?: 0,
+            producerQueueCapacity = src?.producerQueueCapacity() ?: 0,
+            audioBufferMs = audioBufferMs,
+        )
     }
 
     /**

--- a/core-playback/src/main/kotlin/in/jphe/storyvox/playback/tts/source/EngineStreamingSource.kt
+++ b/core-playback/src/main/kotlin/in/jphe/storyvox/playback/tts/source/EngineStreamingSource.kt
@@ -199,6 +199,15 @@ class EngineStreamingSource(
      */
     val bufferHeadroomMs: StateFlow<Long> = _bufferHeadroomMs.asStateFlow()
 
+    /**
+     * Issue #290 — PcmSource interface overrides. Surfaces queue depth +
+     * configured capacity to the Debug overlay's Audio section. O(1)
+     * on LinkedBlockingQueue (delegates to ConcurrentLinkedQueue's
+     * size counter); safe to call from any thread.
+     */
+    override fun producerQueueDepth(): Int = queue.size
+    override fun producerQueueCapacity(): Int = queueCapacity
+
     /** ms of audio represented by [bytes] of PCM at this source's sample rate.
      *  16-bit signed mono → 2 bytes per sample, 1 channel. */
     private fun pcmDurationMs(bytes: Int): Long =

--- a/core-playback/src/main/kotlin/in/jphe/storyvox/playback/tts/source/PcmSource.kt
+++ b/core-playback/src/main/kotlin/in/jphe/storyvox/playback/tts/source/PcmSource.kt
@@ -81,6 +81,20 @@ sealed interface PcmSource {
      * preserves the buffered behavior for Piper / Kokoro / cache.
      */
     val isStreaming: Boolean get() = false
+
+    /**
+     * Issue #290 — current count of chunks waiting in the producer-side
+     * queue. Streaming sources back-fill this from their bounded queue;
+     * cache sources have no queue and report 0. Read by the Debug
+     * overlay's Audio section. Default 0 keeps the seam non-breaking
+     * for sources that have no queue concept.
+     */
+    fun producerQueueDepth(): Int = 0
+
+    /** Companion: configured queue capacity (the bound). Streaming
+     *  sources report their `queueCapacity`; cache sources report 0
+     *  (no queue). The overlay renders `depth/capacity`. */
+    fun producerQueueCapacity(): Int = 0
 }
 
 /**


### PR DESCRIPTION
## Summary

Wires the Debug overlay's `producer queue` and `audio buffered` rows to live values instead of hardcoded zeros.

## Stack

- `PcmSource.producerQueueDepth()` / `producerQueueCapacity()` — interface defaults return 0 (cache sources have no queue); `EngineStreamingSource` overrides with O(1) `LinkedBlockingQueue.size`
- `EnginePlayer.totalFramesWritten: Long` — running tally incremented from inside the consumer's `track.write` loop, reset on every pipeline build
- `EnginePlayer.bufferTelemetry()` — `(totalFramesWritten - track.playbackHeadPosition) * 1000 / sampleRate`
- `PlaybackController.bufferTelemetry()` — passthrough
- `RealDebugRepositoryUi.buildSnapshot` — reads at 1Hz, fills `DebugAudio`

## Hot-path cost

Per `AudioTrack.write` call:
- 1 integer divide (frames = bytes / 2)
- 1 volatile long add

Per snapshot read (1 Hz):
- 1 long subtract
- 1 multiply + divide

No allocation per emit. Cancellation paths preserved by existing `pipelineRunning` guards.

## Caveat

`playbackHeadPosition` returns an unsigned int that wraps every ~24 hours at 24 kHz. Mask-to-unsigned-long handles single wraps; longer-running pipelines would need an explicit overflow counter. Current pipelines rebuild on chapter-end well within the wrap window, so this is fine in practice.

## Test plan

- [x] `:app:compileDebugKotlin` clean (after test fake stub update)
- [x] `:app:testDebugUnitTest` + `:core-playback:testDebugUnitTest` pass
- [ ] Manual on tablet: play chapter → open Debug screen → `producer queue X/8` shows non-zero counts; `audio buffered` shows ~500–1500 ms during normal playback

🤖 Generated with [Claude Code](https://claude.com/claude-code)