### PR TITLE
feat(reader): in-chapter bookmarks (#121)

### DIFF
--- a/app/src/main/kotlin/in/jphe/storyvox/di/AppBindings.kt
+++ b/app/src/main/kotlin/in/jphe/storyvox/di/AppBindings.kt
@@ -737,6 +737,22 @@ internal class RealPlaybackControllerUi(
         controller.stopSpeaking()
     }
 
+    // Issue #121 — bookmark fan-out. controller methods are suspend
+    // because they touch ChapterRepository, but the UI contract is
+    // fire-and-forget per the rest of this interface; we launch on the
+    // shared scope and let the controller handle ordering.
+    override fun bookmarkHere() {
+        scope.launch { controller.bookmarkHere() }
+    }
+
+    override fun clearBookmark() {
+        scope.launch { controller.clearBookmark() }
+    }
+
+    override fun jumpToBookmark() {
+        scope.launch { controller.jumpToBookmark() }
+    }
+
     override fun startListening(
         fictionId: String,
         chapterId: String,

--- a/app/src/test/kotlin/in/jphe/storyvox/di/RealPlaybackControllerUiTest.kt
+++ b/app/src/test/kotlin/in/jphe/storyvox/di/RealPlaybackControllerUiTest.kt
@@ -198,6 +198,9 @@ class RealPlaybackControllerUiTest {
         override suspend fun speakText(text: String) = Unit
         override fun stopSpeaking() = Unit
         override fun bufferTelemetry() = `in`.jphe.storyvox.playback.BufferTelemetry()
+        override suspend fun bookmarkHere() = Unit
+        override suspend fun clearBookmark() = Unit
+        override suspend fun jumpToBookmark(): Boolean = false
     }
 
     /**
@@ -322,5 +325,7 @@ class RealPlaybackControllerUiTest {
         override suspend fun getPreviousChapterId(currentChapterId: String): String? = null
         override suspend fun cachedBodyUsage() =
             `in`.jphe.storyvox.data.repository.CachedBodyUsage(count = 0, bytesEstimate = 0L)
+        override suspend fun setChapterBookmark(chapterId: String, charOffset: Int?) = Unit
+        override suspend fun chapterBookmark(chapterId: String): Int? = null
     }
 }

--- a/core-data/schemas/in.jphe.storyvox.data.db.StoryvoxDatabase/4.json
+++ b/core-data/schemas/in.jphe.storyvox.data.db.StoryvoxDatabase/4.json
@@ -1,0 +1,670 @@
+{
+  "formatVersion": 1,
+  "database": {
+    "version": 4,
+    "identityHash": "93542fd94c560b01f3d138eac36aba27",
+    "entities": [
+      {
+        "tableName": "fiction",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `sourceId` TEXT NOT NULL, `title` TEXT NOT NULL, `author` TEXT NOT NULL, `authorId` TEXT, `coverUrl` TEXT, `description` TEXT, `genres` TEXT NOT NULL, `tags` TEXT NOT NULL, `status` TEXT NOT NULL, `chapterCount` INTEGER NOT NULL, `wordCount` INTEGER, `rating` REAL, `views` INTEGER, `followers` INTEGER, `lastUpdatedAt` INTEGER, `firstSeenAt` INTEGER NOT NULL, `metadataFetchedAt` INTEGER NOT NULL, `inLibrary` INTEGER NOT NULL, `addedToLibraryAt` INTEGER, `followedRemotely` INTEGER NOT NULL, `downloadMode` TEXT, `pinnedVoiceId` TEXT, `pinnedVoiceLocale` TEXT, `notesEverSeen` INTEGER NOT NULL, `lastSeenRevision` TEXT, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "sourceId",
+            "columnName": "sourceId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "title",
+            "columnName": "title",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "author",
+            "columnName": "author",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "authorId",
+            "columnName": "authorId",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "coverUrl",
+            "columnName": "coverUrl",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "description",
+            "columnName": "description",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "genres",
+            "columnName": "genres",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "tags",
+            "columnName": "tags",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "status",
+            "columnName": "status",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "chapterCount",
+            "columnName": "chapterCount",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "wordCount",
+            "columnName": "wordCount",
+            "affinity": "INTEGER",
+            "notNull": false
+          },
+          {
+            "fieldPath": "rating",
+            "columnName": "rating",
+            "affinity": "REAL",
+            "notNull": false
+          },
+          {
+            "fieldPath": "views",
+            "columnName": "views",
+            "affinity": "INTEGER",
+            "notNull": false
+          },
+          {
+            "fieldPath": "followers",
+            "columnName": "followers",
+            "affinity": "INTEGER",
+            "notNull": false
+          },
+          {
+            "fieldPath": "lastUpdatedAt",
+            "columnName": "lastUpdatedAt",
+            "affinity": "INTEGER",
+            "notNull": false
+          },
+          {
+            "fieldPath": "firstSeenAt",
+            "columnName": "firstSeenAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "metadataFetchedAt",
+            "columnName": "metadataFetchedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "inLibrary",
+            "columnName": "inLibrary",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "addedToLibraryAt",
+            "columnName": "addedToLibraryAt",
+            "affinity": "INTEGER",
+            "notNull": false
+          },
+          {
+            "fieldPath": "followedRemotely",
+            "columnName": "followedRemotely",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "downloadMode",
+            "columnName": "downloadMode",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "pinnedVoiceId",
+            "columnName": "pinnedVoiceId",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "pinnedVoiceLocale",
+            "columnName": "pinnedVoiceLocale",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "notesEverSeen",
+            "columnName": "notesEverSeen",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastSeenRevision",
+            "columnName": "lastSeenRevision",
+            "affinity": "TEXT",
+            "notNull": false
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_fiction_inLibrary",
+            "unique": false,
+            "columnNames": [
+              "inLibrary"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_fiction_inLibrary` ON `${TABLE_NAME}` (`inLibrary`)"
+          },
+          {
+            "name": "index_fiction_followedRemotely",
+            "unique": false,
+            "columnNames": [
+              "followedRemotely"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_fiction_followedRemotely` ON `${TABLE_NAME}` (`followedRemotely`)"
+          },
+          {
+            "name": "index_fiction_sourceId_lastUpdatedAt",
+            "unique": false,
+            "columnNames": [
+              "sourceId",
+              "lastUpdatedAt"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_fiction_sourceId_lastUpdatedAt` ON `${TABLE_NAME}` (`sourceId`, `lastUpdatedAt`)"
+          }
+        ],
+        "foreignKeys": []
+      },
+      {
+        "tableName": "chapter",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `fictionId` TEXT NOT NULL, `sourceChapterId` TEXT NOT NULL, `index` INTEGER NOT NULL, `title` TEXT NOT NULL, `publishedAt` INTEGER, `wordCount` INTEGER, `htmlBody` TEXT, `plainBody` TEXT, `bodyFetchedAt` INTEGER, `bodyChecksum` TEXT, `downloadState` TEXT NOT NULL, `lastDownloadAttemptAt` INTEGER, `lastDownloadError` TEXT, `notesAuthor` TEXT, `notesAuthorPosition` TEXT, `userMarkedRead` INTEGER NOT NULL, `firstReadAt` INTEGER, `bookmarkCharOffset` INTEGER, PRIMARY KEY(`id`), FOREIGN KEY(`fictionId`) REFERENCES `fiction`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "fictionId",
+            "columnName": "fictionId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "sourceChapterId",
+            "columnName": "sourceChapterId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "index",
+            "columnName": "index",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "title",
+            "columnName": "title",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "publishedAt",
+            "columnName": "publishedAt",
+            "affinity": "INTEGER",
+            "notNull": false
+          },
+          {
+            "fieldPath": "wordCount",
+            "columnName": "wordCount",
+            "affinity": "INTEGER",
+            "notNull": false
+          },
+          {
+            "fieldPath": "htmlBody",
+            "columnName": "htmlBody",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "plainBody",
+            "columnName": "plainBody",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "bodyFetchedAt",
+            "columnName": "bodyFetchedAt",
+            "affinity": "INTEGER",
+            "notNull": false
+          },
+          {
+            "fieldPath": "bodyChecksum",
+            "columnName": "bodyChecksum",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "downloadState",
+            "columnName": "downloadState",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastDownloadAttemptAt",
+            "columnName": "lastDownloadAttemptAt",
+            "affinity": "INTEGER",
+            "notNull": false
+          },
+          {
+            "fieldPath": "lastDownloadError",
+            "columnName": "lastDownloadError",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "notesAuthor",
+            "columnName": "notesAuthor",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "notesAuthorPosition",
+            "columnName": "notesAuthorPosition",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "userMarkedRead",
+            "columnName": "userMarkedRead",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "firstReadAt",
+            "columnName": "firstReadAt",
+            "affinity": "INTEGER",
+            "notNull": false
+          },
+          {
+            "fieldPath": "bookmarkCharOffset",
+            "columnName": "bookmarkCharOffset",
+            "affinity": "INTEGER",
+            "notNull": false
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_chapter_fictionId",
+            "unique": false,
+            "columnNames": [
+              "fictionId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_chapter_fictionId` ON `${TABLE_NAME}` (`fictionId`)"
+          },
+          {
+            "name": "index_chapter_fictionId_index",
+            "unique": true,
+            "columnNames": [
+              "fictionId",
+              "index"
+            ],
+            "orders": [],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_chapter_fictionId_index` ON `${TABLE_NAME}` (`fictionId`, `index`)"
+          },
+          {
+            "name": "index_chapter_downloadState",
+            "unique": false,
+            "columnNames": [
+              "downloadState"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_chapter_downloadState` ON `${TABLE_NAME}` (`downloadState`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "fiction",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "fictionId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "playback_position",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`fictionId` TEXT NOT NULL, `chapterId` TEXT NOT NULL, `charOffset` INTEGER NOT NULL, `paragraphIndex` INTEGER NOT NULL, `playbackSpeed` REAL NOT NULL, `durationEstimateMs` INTEGER NOT NULL, `updatedAt` INTEGER NOT NULL, PRIMARY KEY(`fictionId`), FOREIGN KEY(`fictionId`) REFERENCES `fiction`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE , FOREIGN KEY(`chapterId`) REFERENCES `chapter`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "fictionId",
+            "columnName": "fictionId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "chapterId",
+            "columnName": "chapterId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "charOffset",
+            "columnName": "charOffset",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "paragraphIndex",
+            "columnName": "paragraphIndex",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "playbackSpeed",
+            "columnName": "playbackSpeed",
+            "affinity": "REAL",
+            "notNull": true
+          },
+          {
+            "fieldPath": "durationEstimateMs",
+            "columnName": "durationEstimateMs",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "updatedAt",
+            "columnName": "updatedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "fictionId"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_playback_position_chapterId",
+            "unique": false,
+            "columnNames": [
+              "chapterId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_playback_position_chapterId` ON `${TABLE_NAME}` (`chapterId`)"
+          },
+          {
+            "name": "index_playback_position_updatedAt",
+            "unique": false,
+            "columnNames": [
+              "updatedAt"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_playback_position_updatedAt` ON `${TABLE_NAME}` (`updatedAt`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "fiction",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "fictionId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          },
+          {
+            "table": "chapter",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "chapterId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "auth_cookie",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`sourceId` TEXT NOT NULL, `userDisplayName` TEXT, `userId` TEXT, `capturedAt` INTEGER NOT NULL, `expiresAt` INTEGER, `lastVerifiedAt` INTEGER NOT NULL, PRIMARY KEY(`sourceId`))",
+        "fields": [
+          {
+            "fieldPath": "sourceId",
+            "columnName": "sourceId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "userDisplayName",
+            "columnName": "userDisplayName",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "userId",
+            "columnName": "userId",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "capturedAt",
+            "columnName": "capturedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "expiresAt",
+            "columnName": "expiresAt",
+            "affinity": "INTEGER",
+            "notNull": false
+          },
+          {
+            "fieldPath": "lastVerifiedAt",
+            "columnName": "lastVerifiedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "sourceId"
+          ]
+        },
+        "indices": [],
+        "foreignKeys": []
+      },
+      {
+        "tableName": "llm_session",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `name` TEXT NOT NULL, `provider` TEXT NOT NULL, `model` TEXT NOT NULL, `systemPrompt` TEXT, `createdAt` INTEGER NOT NULL, `lastUsedAt` INTEGER NOT NULL, `featureKind` TEXT, `anchorFictionId` TEXT, `anchorChapterId` TEXT, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "provider",
+            "columnName": "provider",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "model",
+            "columnName": "model",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "systemPrompt",
+            "columnName": "systemPrompt",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "createdAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastUsedAt",
+            "columnName": "lastUsedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "featureKind",
+            "columnName": "featureKind",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "anchorFictionId",
+            "columnName": "anchorFictionId",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "anchorChapterId",
+            "columnName": "anchorChapterId",
+            "affinity": "TEXT",
+            "notNull": false
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [],
+        "foreignKeys": []
+      },
+      {
+        "tableName": "llm_message",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `sessionId` TEXT NOT NULL, `role` TEXT NOT NULL, `content` TEXT NOT NULL, `createdAt` INTEGER NOT NULL, FOREIGN KEY(`sessionId`) REFERENCES `llm_session`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "sessionId",
+            "columnName": "sessionId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "role",
+            "columnName": "role",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "content",
+            "columnName": "content",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "createdAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_llm_message_sessionId",
+            "unique": false,
+            "columnNames": [
+              "sessionId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_llm_message_sessionId` ON `${TABLE_NAME}` (`sessionId`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "llm_session",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "sessionId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      }
+    ],
+    "views": [],
+    "setupQueries": [
+      "CREATE TABLE IF NOT EXISTS room_master_table (id INTEGER PRIMARY KEY,identity_hash TEXT)",
+      "INSERT OR REPLACE INTO room_master_table (id,identity_hash) VALUES(42, '93542fd94c560b01f3d138eac36aba27')"
+    ]
+  }
+}

--- a/core-data/src/main/kotlin/in/jphe/storyvox/data/db/StoryvoxDatabase.kt
+++ b/core-data/src/main/kotlin/in/jphe/storyvox/data/db/StoryvoxDatabase.kt
@@ -27,7 +27,7 @@ import `in`.jphe.storyvox.data.db.entity.PlaybackPosition
         LlmSession::class,
         LlmStoredMessage::class,
     ],
-    version = 3,
+    version = 4,
     exportSchema = true,
 )
 @TypeConverters(Converters::class)

--- a/core-data/src/main/kotlin/in/jphe/storyvox/data/db/dao/ChapterDao.kt
+++ b/core-data/src/main/kotlin/in/jphe/storyvox/data/db/dao/ChapterDao.kt
@@ -238,6 +238,19 @@ interface ChapterDao {
     suspend fun trimDownloadedBodies(fictionId: String, keepLast: Int)
 
     /**
+     * Issue #121 — set or clear the per-chapter bookmark. Passing null
+     * for [charOffset] is the "clear bookmark" path; an Int value sets
+     * the bookmark at that offset into the chapter's plainBody. One
+     * bookmark per chapter per the planning-session decision.
+     */
+    @Query("UPDATE chapter SET bookmarkCharOffset = :charOffset WHERE id = :id")
+    suspend fun setBookmark(id: String, charOffset: Int?)
+
+    /** Issue #121 — read the persisted bookmark offset, or null. */
+    @Query("SELECT bookmarkCharOffset FROM chapter WHERE id = :id")
+    suspend fun getBookmark(id: String): Int?
+
+    /**
      * Issue #293 — debug-surface storage diagnostic. Single round-trip
      * returns both the count of cached chapters AND the rough byte usage
      * of their text bodies. SQLite's `LENGTH()` on a TEXT column returns

--- a/core-data/src/main/kotlin/in/jphe/storyvox/data/db/entity/Chapter.kt
+++ b/core-data/src/main/kotlin/in/jphe/storyvox/data/db/entity/Chapter.kt
@@ -46,6 +46,16 @@ data class Chapter(
     val notesAuthorPosition: NotePosition? = null,
     val userMarkedRead: Boolean = false,
     val firstReadAt: Long? = null,
+    /**
+     * Issue #121 — in-chapter bookmark position.
+     *
+     * One bookmark per chapter (per the planning-session decision). Null
+     * = no bookmark. Otherwise the char offset into [plainBody] where
+     * the user said "remember this." Persisted independently of
+     * [PlaybackPosition] so a bookmark survives the user listening past
+     * it — the playhead moves forward, the bookmark stays put.
+     */
+    val bookmarkCharOffset: Int? = null,
 )
 
 enum class ChapterDownloadState {

--- a/core-data/src/main/kotlin/in/jphe/storyvox/data/db/migration/Migrations.kt
+++ b/core-data/src/main/kotlin/in/jphe/storyvox/data/db/migration/Migrations.kt
@@ -73,4 +73,15 @@ val MIGRATION_2_3: Migration = object : Migration(2, 3) {
     }
 }
 
-val ALL_MIGRATIONS: Array<Migration> = arrayOf(MIGRATION_1_2, MIGRATION_2_3)
+/**
+ * v4 — issue #121: per-chapter bookmark. One nullable column on the
+ * chapter table; null on existing rows is the "no bookmark" sentinel
+ * the entity already understands. Pure additive, no data backfill.
+ */
+val MIGRATION_3_4: Migration = object : Migration(3, 4) {
+    override fun migrate(db: SupportSQLiteDatabase) {
+        db.execSQL("ALTER TABLE chapter ADD COLUMN bookmarkCharOffset INTEGER")
+    }
+}
+
+val ALL_MIGRATIONS: Array<Migration> = arrayOf(MIGRATION_1_2, MIGRATION_2_3, MIGRATION_3_4)

--- a/core-data/src/main/kotlin/in/jphe/storyvox/data/repository/ChapterRepository.kt
+++ b/core-data/src/main/kotlin/in/jphe/storyvox/data/repository/ChapterRepository.kt
@@ -82,6 +82,17 @@ interface ChapterRepository {
      * on the storage diagnostic.
      */
     suspend fun cachedBodyUsage(): CachedBodyUsage
+
+    /**
+     * Issue #121 — set or clear the per-chapter bookmark. Passing null
+     * clears. The bookmark is a char-offset into the chapter's plainBody,
+     * mirroring how the player addresses positions throughout the
+     * pipeline (no time-based offset that would shift with speed).
+     */
+    suspend fun setChapterBookmark(chapterId: String, charOffset: Int?)
+
+    /** Issue #121 — read the persisted bookmark for a chapter, or null. */
+    suspend fun chapterBookmark(chapterId: String): Int?
 }
 
 /** Issue #293 — paired count/bytes return for [ChapterRepository.cachedBodyUsage]. */
@@ -173,4 +184,11 @@ class ChapterRepositoryImpl @Inject constructor(
         val row = dao.cacheUsage()
         return CachedBodyUsage(count = row.count, bytesEstimate = row.bytes)
     }
+
+    override suspend fun setChapterBookmark(chapterId: String, charOffset: Int?) {
+        dao.setBookmark(chapterId, charOffset)
+    }
+
+    override suspend fun chapterBookmark(chapterId: String): Int? =
+        dao.getBookmark(chapterId)
 }

--- a/core-data/src/test/kotlin/in/jphe/storyvox/data/repository/ChapterRepositoryImplTest.kt
+++ b/core-data/src/test/kotlin/in/jphe/storyvox/data/repository/ChapterRepositoryImplTest.kt
@@ -167,6 +167,19 @@ class ChapterRepositoryImplTest {
             )
         }
 
+        // Issue #121 — bookmark read/write. Reflect the underlying rows
+        // so getBookmark stays consistent after setBookmark; matches the
+        // SQL update + select pair on the real DAO.
+        override suspend fun setBookmark(id: String, charOffset: Int?) {
+            callLog += "setBookmark($id, $charOffset)"
+            val r = rows[id] ?: return
+            rows[id] = r.copy(bookmarkCharOffset = charOffset)
+            publishRow(id)
+        }
+
+        override suspend fun getBookmark(id: String): Int? =
+            rows[id]?.bookmarkCharOffset
+
         // Issue #349 — fake the index parking so the FakeChapterDao
         // models the real two-phase upsert path. Live-range rows
         // (0..99_999) shift to +100_000; already-parked rows stay.

--- a/core-data/src/test/kotlin/in/jphe/storyvox/data/repository/FictionRepositoryImplTest.kt
+++ b/core-data/src/test/kotlin/in/jphe/storyvox/data/repository/FictionRepositoryImplTest.kt
@@ -267,6 +267,10 @@ class FictionRepositoryImplTest {
         override suspend fun parkChapterIndexesFor(fictionId: String) {
             callLog += "parkChapterIndexesFor($fictionId)"
         }
+        // Issue #121 — bookmark stubs; fiction repo tests don't drive
+        // the bookmark path, so a no-op + null read are sufficient.
+        override suspend fun setBookmark(id: String, charOffset: Int?) = Unit
+        override suspend fun getBookmark(id: String): Int? = null
         override suspend fun setDownloadState(
             id: String,
             state: ChapterDownloadState,

--- a/core-playback/src/main/kotlin/in/jphe/storyvox/playback/PlaybackController.kt
+++ b/core-playback/src/main/kotlin/in/jphe/storyvox/playback/PlaybackController.kt
@@ -72,6 +72,28 @@ interface PlaybackController {
      * player is bound. Read by the Debug overlay at 1Hz.
      */
     fun bufferTelemetry(): BufferTelemetry
+
+    /**
+     * Issue #121 — bookmark the current playback position into the
+     * currently-loaded chapter. No-op when no chapter is loaded. The
+     * bookmark is persisted to the chapter row so it survives app
+     * restarts and the playhead moving past it.
+     */
+    suspend fun bookmarkHere()
+
+    /**
+     * Issue #121 — clear the currently-loaded chapter's bookmark, if
+     * any. No-op when no chapter is loaded or no bookmark exists.
+     */
+    suspend fun clearBookmark()
+
+    /**
+     * Issue #121 — seek to the currently-loaded chapter's bookmark. No-op
+     * when no chapter is loaded or no bookmark exists. Returns true if
+     * the seek fired, false otherwise — callers can use this to surface
+     * "no bookmark to jump to" feedback.
+     */
+    suspend fun jumpToBookmark(): Boolean
 }
 
 /**
@@ -93,6 +115,10 @@ class DefaultPlaybackController @Inject constructor(
     /** #90 — write the user's last play/pause intent so the
      *  Library Resume CTA can decide whether to auto-start. */
     private val resumePolicy: `in`.jphe.storyvox.data.repository.playback.PlaybackResumePolicyConfig,
+    /** #121 — per-chapter bookmark read/write. Controller persists +
+     *  jumps to bookmark positions; the player layer needs no
+     *  awareness of bookmarks (they're a chapter-metadata concern). */
+    private val chapterRepo: `in`.jphe.storyvox.data.repository.ChapterRepository,
 ) : PlaybackController {
 
     private val scope = CoroutineScope(SupervisorJob() + Dispatchers.Default)
@@ -256,6 +282,24 @@ class DefaultPlaybackController @Inject constructor(
 
     override fun bufferTelemetry(): BufferTelemetry =
         player?.bufferTelemetry() ?: BufferTelemetry()
+
+    override suspend fun bookmarkHere() {
+        val chapterId = state.value.currentChapterId ?: return
+        val offset = state.value.charOffset
+        chapterRepo.setChapterBookmark(chapterId, offset)
+    }
+
+    override suspend fun clearBookmark() {
+        val chapterId = state.value.currentChapterId ?: return
+        chapterRepo.setChapterBookmark(chapterId, null)
+    }
+
+    override suspend fun jumpToBookmark(): Boolean {
+        val chapterId = state.value.currentChapterId ?: return false
+        val offset = chapterRepo.chapterBookmark(chapterId) ?: return false
+        player?.seekToCharOffset(offset)
+        return true
+    }
 
     internal fun emitEvent(event: PlaybackUiEvent) {
         _events.tryEmit(event)

--- a/feature/src/main/kotlin/in/jphe/storyvox/feature/api/UiContracts.kt
+++ b/feature/src/main/kotlin/in/jphe/storyvox/feature/api/UiContracts.kt
@@ -441,6 +441,26 @@ interface PlaybackControllerUi {
 
     /** Issue #189 — cancel an in-flight recap-aloud utterance. Idempotent. */
     fun stopSpeaking()
+
+    /**
+     * Issue #121 — bookmark the current playback position. No-op when
+     * no chapter is loaded; otherwise persists the current char offset
+     * as that chapter's single bookmark, replacing any previous bookmark.
+     */
+    fun bookmarkHere()
+
+    /** Issue #121 — clear the currently-loaded chapter's bookmark. No-op
+     *  when nothing's loaded or no bookmark exists. */
+    fun clearBookmark()
+
+    /**
+     * Issue #121 — seek to the currently-loaded chapter's bookmark
+     * position, if any. Backed by a callback rather than a Flow because
+     * "is there a bookmark?" is a one-shot question the menu asks when
+     * it opens; observing every change would force the player options
+     * sheet to re-collect on every chapter change.
+     */
+    fun jumpToBookmark()
 }
 
 data class UiVoice(

--- a/feature/src/main/kotlin/in/jphe/storyvox/feature/reader/AudiobookView.kt
+++ b/feature/src/main/kotlin/in/jphe/storyvox/feature/reader/AudiobookView.kt
@@ -33,6 +33,8 @@ import androidx.compose.material.icons.filled.SkipNext
 import androidx.compose.material.icons.filled.SkipPrevious
 import androidx.compose.material.icons.outlined.AutoStories
 import androidx.compose.material.icons.outlined.Bedtime
+import androidx.compose.material.icons.outlined.Bookmark
+import androidx.compose.material.icons.outlined.BookmarkAdd
 import androidx.compose.material.icons.outlined.ChevronRight
 import androidx.compose.material.icons.outlined.MoreVert
 import androidx.compose.material.icons.outlined.RecordVoiceOver
@@ -123,6 +125,12 @@ fun AudiobookView(
      *  error block. Goes to the voice library; the controller will pick
      *  the new voice up next time play() is invoked. */
     onCancelLoading: () -> Unit = {},
+    /** Issue #121 — drop a bookmark at the current playhead in the active
+     *  chapter. One bookmark per chapter; setting again overwrites. */
+    onBookmarkHere: () -> Unit = {},
+    /** Issue #121 — seek to the active chapter's bookmark, if any. No-op
+     *  when the chapter has none. */
+    onJumpToBookmark: () -> Unit = {},
     modifier: Modifier = Modifier,
 ) {
     val spacing = LocalSpacing.current
@@ -427,6 +435,16 @@ fun AudiobookView(
                         showSheet = false
                         onOpenChat()
                     },
+                    onBookmarkHere = {
+                        coroutineScope.launch { sheetState.hide() }
+                        showSheet = false
+                        onBookmarkHere()
+                    },
+                    onJumpToBookmark = {
+                        coroutineScope.launch { sheetState.hide() }
+                        showSheet = false
+                        onJumpToBookmark()
+                    },
                 )
             }
         }
@@ -509,6 +527,10 @@ private fun PlayerOptionsSheet(
     onNextSentence: () -> Unit = {},
     onRequestRecap: () -> Unit = {},
     onOpenChat: () -> Unit = {},
+    /** Issue #121 — bookmark the current playback position. */
+    onBookmarkHere: () -> Unit = {},
+    /** Issue #121 — seek to the chapter's bookmark, if any. */
+    onJumpToBookmark: () -> Unit = {},
 ) {
     val spacing = LocalSpacing.current
     Column(
@@ -599,6 +621,56 @@ private fun PlayerOptionsSheet(
             onStart = onStartSleepTimer,
             onCancel = onCancelSleepTimer,
         )
+
+        // Issue #121 — in-chapter bookmark. Two rows: "Bookmark here"
+        // drops a marker at the current playback position; "Jump to
+        // bookmark" seeks to it. Both fire-and-forget; the controller
+        // no-ops gracefully when nothing is loaded / no bookmark exists.
+        SheetHeader("Bookmark", null)
+        Row(
+            modifier = Modifier
+                .fillMaxWidth()
+                .clickable(onClick = onBookmarkHere)
+                .padding(vertical = spacing.xs),
+            verticalAlignment = Alignment.CenterVertically,
+            horizontalArrangement = Arrangement.spacedBy(spacing.sm),
+        ) {
+            Icon(
+                Icons.Outlined.BookmarkAdd,
+                contentDescription = null,
+                tint = MaterialTheme.colorScheme.primary,
+            )
+            Column(modifier = Modifier.weight(1f)) {
+                Text("Bookmark here", style = MaterialTheme.typography.bodyMedium)
+                Text(
+                    "Drop a marker at the current position",
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                )
+            }
+        }
+        Row(
+            modifier = Modifier
+                .fillMaxWidth()
+                .clickable(onClick = onJumpToBookmark)
+                .padding(vertical = spacing.xs),
+            verticalAlignment = Alignment.CenterVertically,
+            horizontalArrangement = Arrangement.spacedBy(spacing.sm),
+        ) {
+            Icon(
+                Icons.Outlined.Bookmark,
+                contentDescription = null,
+                tint = MaterialTheme.colorScheme.primary,
+            )
+            Column(modifier = Modifier.weight(1f)) {
+                Text("Jump to bookmark", style = MaterialTheme.typography.bodyMedium)
+                Text(
+                    "Resume from the marker you set",
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                )
+            }
+        }
 
         SheetHeader("Voice", null)
         // Issue #284 + #277 — the whole row must be clickable, not just

--- a/feature/src/main/kotlin/in/jphe/storyvox/feature/reader/HybridReaderScreen.kt
+++ b/feature/src/main/kotlin/in/jphe/storyvox/feature/reader/HybridReaderScreen.kt
@@ -107,6 +107,11 @@ fun HybridReaderScreen(
                 // slow-hint at 10s / full error block at 30s).
                 loadingPhase = state.loadingPhase,
                 onRetryLoading = viewModel::retryLoading,
+                // Issue #121 — bookmark drop / jump. The controller side
+                // resolves "current chapter" + char-offset from the
+                // playback state, so the UI just forwards the verbs.
+                onBookmarkHere = viewModel::bookmarkHere,
+                onJumpToBookmark = viewModel::jumpToBookmark,
             )
         },
         readerContent = {

--- a/feature/src/main/kotlin/in/jphe/storyvox/feature/reader/ReaderViewModel.kt
+++ b/feature/src/main/kotlin/in/jphe/storyvox/feature/reader/ReaderViewModel.kt
@@ -291,6 +291,13 @@ class ReaderViewModel @Inject constructor(
     fun startSleepTimer(mode: UiSleepTimerMode) = playback.startSleepTimer(mode)
     fun cancelSleepTimer() = playback.cancelSleepTimer()
 
+    // Issue #121 — in-chapter bookmark fan-out. ReaderViewModel stays
+    // the single seam ChapterView talks to; controller delegate handles
+    // the suspend-vs-fire-and-forget seam internally.
+    fun bookmarkHere() = playback.bookmarkHere()
+    fun clearBookmark() = playback.clearBookmark()
+    fun jumpToBookmark() = playback.jumpToBookmark()
+
     // ── Chapter Recap (issue #81) ──────────────────────────────────
 
     /** Open the modal and stream a recap for the current chapter.

--- a/feature/src/test/kotlin/in/jphe/storyvox/feature/chat/ChatViewModelTest.kt
+++ b/feature/src/test/kotlin/in/jphe/storyvox/feature/chat/ChatViewModelTest.kt
@@ -488,6 +488,9 @@ private class FakePlayback(initial: UiPlaybackState) : PlaybackControllerUi {
     override fun cancelSleepTimer() = Unit
     override suspend fun speakText(text: String) = Unit
     override fun stopSpeaking() = Unit
+    override fun bookmarkHere() = Unit
+    override fun clearBookmark() = Unit
+    override fun jumpToBookmark() = Unit
 }
 
 /** Minimal settings stub — only the [settings] flow is read by


### PR DESCRIPTION
## Summary
- One bookmark per chapter, persisted as `bookmarkCharOffset` on the chapter row (migration 3→4)
- Player options sheet gets two new rows: "Bookmark here" (drop) + "Jump to bookmark" (seek)
- Bookmark is independent of playhead — listening past it leaves the marker put, exactly like a paperback dog-ear

Closes #121.

## Design notes
Chose chapter-row storage over a separate `Bookmark` entity because the data is *always* a chapter pointer (chapter id + char offset). One column, one migration, one DAO method pair, no new repository or DI binding. The decision was captured in the issue thread during the 2026-05-12 planning session ("one per chapter, long-press to set" — long-press route can come later; sheet entry is the v1).

Wiring chain (each hop has one responsibility):
```
PlayerOptionsSheet  → captures gesture, no nav coupling
AudiobookView       → forwards verbs upward
HybridReaderScreen  → routes through ViewModel
ReaderViewModel     → owns lifecycle / scope
PlaybackControllerUi→ test seam (interface)
DefaultPlaybackCtrl → resolves chapter+offset from state, persists via ChapterRepository
```
UI never needs to know what's currently playing — the controller pulls `currentChapterId` + `charOffset` from `state.value` at the moment the user taps.

## Test plan
- [x] Compile: `:app:compileDebugKotlin` ✔
- [x] Unit tests: `:app:`, `:core-data:`, `:core-playback:`, `:feature:testDebugUnitTest` ✔
- [ ] Tablet (Tab S6 Lite): open chapter, tap ⋮, tap "Bookmark here", listen past it, tap ⋮ → "Jump to bookmark", verify playhead snaps back
- [ ] Survives app kill — relaunch, jump to bookmark, position restored

🤖 Generated with [Claude Code](https://claude.com/claude-code)