### PR TITLE
feat(playing): magical resume prompt on Playing tab

### DIFF
--- a/app/src/main/kotlin/in/jphe/storyvox/navigation/StoryvoxNavHost.kt
+++ b/app/src/main/kotlin/in/jphe/storyvox/navigation/StoryvoxNavHost.kt
@@ -303,6 +303,20 @@ private fun StoryvoxNavHostContent(
                     onPickVoice = { navController.navigate(StoryvoxRoutes.VOICE_LIBRARY) },
                     onOpenAiSettings = { navController.navigate(StoryvoxRoutes.SETTINGS) },
                     onOpenChat = { fId, prefill -> navController.navigate(StoryvoxRoutes.chat(fId, prefill)) },
+                    // ResumeEmptyPrompt's "Browse the realms" CTA — only
+                    // matters when the user has no continue-listening
+                    // entry at all (first launch / wiped data). The
+                    // populated ResumePrompt doesn't navigate; tapping
+                    // Resume reloads the chapter in place.
+                    onBrowse = {
+                        navController.navigate(StoryvoxRoutes.BROWSE) {
+                            // Same pop-and-singleTop discipline as the
+                            // bottom-tab handler so the Browse-tab back
+                            // stack doesn't accumulate.
+                            popUpTo(StoryvoxRoutes.PLAYING)
+                            launchSingleTop = true
+                        }
+                    },
                 )
             }
             composable(

--- a/feature/src/main/kotlin/in/jphe/storyvox/feature/reader/HybridReaderScreen.kt
+++ b/feature/src/main/kotlin/in/jphe/storyvox/feature/reader/HybridReaderScreen.kt
@@ -2,15 +2,12 @@ package `in`.jphe.storyvox.feature.reader
 
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.fillMaxSize
-import androidx.compose.material3.MaterialTheme
-import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.runtime.LaunchedEffect
-import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
@@ -40,11 +37,21 @@ fun HybridReaderScreen(
      *  a non-null prefill of the form `Who is X?`. Pass `null` for
      *  prefill from non-lookup entry points. */
     onOpenChat: (fictionId: String, prefill: String?) -> Unit = { _, _ -> },
+    /**
+     * Route the empty-empty Resume prompt's "Browse the realms" CTA to
+     * the Browse tab. Default no-op for previews/tests; production
+     * callsites pass a real `navController.navigate(BROWSE)`. The
+     * populated Resume prompt's two buttons don't need any nav — they
+     * load the chapter into the playback controller, and the state flow
+     * naturally swaps the prompt for the player view in place.
+     */
+    onBrowse: () -> Unit = {},
     viewModel: ReaderViewModel = hiltViewModel(),
 ) {
     val state by viewModel.uiState.collectAsStateWithLifecycle()
     val recapState by viewModel.recap.collectAsStateWithLifecycle()
     val recapPlayback by viewModel.recapPlayback.collectAsStateWithLifecycle()
+    val resumeEntry by viewModel.resumeEntry.collectAsStateWithLifecycle()
     val playback = state.playback
 
     // Calliope (v0.5.00) — first-natural-chapter-completion confetti.
@@ -69,11 +76,71 @@ fun HybridReaderScreen(
     val debugVm: DebugViewModel = hiltViewModel()
     val debugEnabled by debugVm.overlayEnabled.collectAsStateWithLifecycle()
 
-    if (playback == null) {
-        Box(modifier = Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
-            Text("No chapter loaded.", style = MaterialTheme.typography.bodyMedium)
+    // Playing-tab "no chapter loaded" path — replace the bare
+    // "No chapter loaded." stub with the magical Resume prompt. Two
+    // sub-cases:
+    //  - we have a most-recent continue-listening entry → ResumePrompt
+    //    (cover + sigil ring + brass-shimmer Resume CTA + "From the
+    //    start"). Tapping Resume loads via the playback controller; the
+    //    state flow flips `playback` non-null and the prompt naturally
+    //    dissolves into the player view — no nav transition.
+    //  - no entry at all (first launch, wiped data) → ResumeEmptyPrompt
+    //    with a "Browse the realms" CTA into the Browse tab.
+    //
+    // We also short-circuit through the same prompt when the loader hit
+    // [LoadingPhase.TimedOut] AND we have a resume entry — same user
+    // outcome (give them a clean way back into their book) without the
+    // generic error-block surface. The retry path inside AudiobookView
+    // still fires for the case where there's no resume entry to fall
+    // back on.
+    val timedOut = state.loadingPhase == LoadingPhase.TimedOut
+    // Show the Resume prompt whenever we don't have a real chapter to
+    // render — three cases:
+    //  (a) playback is null (cold-start, app-killed)
+    //  (b) playback exists but its fictionId/chapterId are still null
+    //      (controller initialized but no chapter queued yet)
+    //  (c) the loading timer hit TimedOut AND we have a resume entry to
+    //      fall back on (otherwise AudiobookView's friendlier
+    //      Retry/Pick-voice error block handles the dead-end case).
+    //
+    // We compute the cases below in two steps so Kotlin's smart-cast
+    // on `playback != null` stays usable for the rest of the screen.
+    val showPromptForNullPlayback = playback == null
+    val showPromptForBlankIds = playback != null &&
+        playback.fictionId == null &&
+        playback.chapterId == null
+    val showPromptForTimedOutWithEntry =
+        playback != null && timedOut && resumeEntry != null
+    if (showPromptForNullPlayback || showPromptForBlankIds ||
+        showPromptForTimedOutWithEntry
+    ) {
+        Box(modifier = Modifier.fillMaxSize()) {
+            val entry = resumeEntry
+            if (entry != null) {
+                ResumePrompt(
+                    entry = entry,
+                    onResume = { viewModel.resume(fromStart = false) },
+                    onFromStart = { viewModel.resume(fromStart = true) },
+                )
+            } else {
+                ResumeEmptyPrompt(onBrowse = onBrowse)
+            }
+            // Debug overlay still mounts on top so the inspector can see
+            // the loading-phase state machine even before a chapter is
+            // loaded. Same gating as below.
+            if (debugEnabled) {
+                DebugOverlay(viewModel = debugVm)
+            }
         }
         return
+    }
+    // Past here, `playback` is guaranteed non-null — the compound
+    // predicate above covered the null case. The local `playback` val
+    // doesn't smart-cast through that, so explicitly bind a non-null
+    // alias here. `playbackState` for clarity at call sites (the
+    // existing AudiobookView arg is called `state`).
+    val playbackState = requireNotNull(playback) {
+        "playback should be non-null past the resume-prompt branch"
     }
 
     Box(modifier = Modifier.fillMaxSize()) {
@@ -82,7 +149,7 @@ fun HybridReaderScreen(
         onViewChange = viewModel::setActivePane,
         audiobookContent = {
             AudiobookView(
-                state = playback,
+                state = playbackState,
                 onPlayPause = viewModel::playPause,
                 onSeekTo = viewModel::seekTo,
                 onSkipForward = viewModel::skipForward,
@@ -100,7 +167,7 @@ fun HybridReaderScreen(
                 onCancelSleepTimer = viewModel::cancelSleepTimer,
                 onRequestRecap = viewModel::requestRecap,
                 onOpenChat = {
-                    playback.fictionId?.let { onOpenChat(it, null) }
+                    playbackState.fictionId?.let { onOpenChat(it, null) }
                 },
                 // Issue #278 — surface loading-phase + retry path. The
                 // view decides what to render based on phase (regular /
@@ -116,7 +183,7 @@ fun HybridReaderScreen(
         },
         readerContent = {
             ReaderTextView(
-                state = playback,
+                state = playbackState,
                 chapterText = state.chapterText,
                 onPlayPause = viewModel::playPause,
                 onSeekToChar = viewModel::seekToChar,
@@ -125,7 +192,7 @@ fun HybridReaderScreen(
                     // prebuilt "Who is X?" question as a chat prefill.
                     // The chat surface auto-fills the input — the user
                     // can edit before sending or send as-is.
-                    playback.fictionId?.let { onOpenChat(it, question) }
+                    playbackState.fictionId?.let { onOpenChat(it, question) }
                 },
             )
         },

--- a/feature/src/main/kotlin/in/jphe/storyvox/feature/reader/ReaderViewModel.kt
+++ b/feature/src/main/kotlin/in/jphe/storyvox/feature/reader/ReaderViewModel.kt
@@ -5,6 +5,9 @@ import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import dagger.hilt.android.lifecycle.HiltViewModel
+import `in`.jphe.storyvox.data.repository.ContinueListeningEntry
+import `in`.jphe.storyvox.data.repository.PlaybackPositionRepository
+import `in`.jphe.storyvox.data.repository.playback.PlaybackResumePolicyConfig
 import `in`.jphe.storyvox.feature.api.PlaybackControllerUi
 import `in`.jphe.storyvox.feature.api.SettingsRepositoryUi
 import `in`.jphe.storyvox.feature.api.UiPlaybackState
@@ -113,6 +116,21 @@ class ReaderViewModel @Inject constructor(
     private val playback: PlaybackControllerUi,
     private val settings: SettingsRepositoryUi,
     private val chapterRecap: ChapterRecap,
+    /**
+     * Source for the Playing-tab Resume prompt (#? Lyra). Same flow
+     * LibraryViewModel reads for its "Continue listening" tile — keeps
+     * the two surfaces visually in lock-step (same fiction, same chapter,
+     * same updatedAt).
+     */
+    private val positionRepo: PlaybackPositionRepository,
+    /**
+     * #90 — the smart-resume policy. When the user explicitly paused
+     * before, the Resume CTA should load-but-not-auto-play. When the app
+     * was killed mid-playback (no explicit pause), the flag stays true
+     * and Resume auto-plays. Identical wiring to
+     * [`in`.jphe.storyvox.feature.library.LibraryViewModel.resume].
+     */
+    private val resumePolicy: PlaybackResumePolicyConfig,
     @Suppress("UnusedPrivateProperty") savedState: SavedStateHandle,
 ) : ViewModel() {
 
@@ -242,6 +260,19 @@ class ReaderViewModel @Inject constructor(
         )
     }.stateIn(viewModelScope, SharingStarted.WhileSubscribed(5_000), ReaderUiState())
 
+    /**
+     * Most-recent continue-listening entry. Drives the magical Resume
+     * prompt that [HybridReaderScreen] renders when the player has no
+     * chapter loaded yet, or when the loading timer hit [LoadingPhase.TimedOut]
+     * with stale ids. Null while the DAO row is unset (first-launch /
+     * wiped-data) — in that case the screen renders [ResumeEmptyPrompt]
+     * instead. Same flow LibraryViewModel reads for its tile so both
+     * surfaces stay in lock-step.
+     */
+    val resumeEntry: StateFlow<ContinueListeningEntry?> = positionRepo
+        .observeMostRecentContinueListening()
+        .stateIn(viewModelScope, SharingStarted.WhileSubscribed(5_000), null)
+
     /** Issue #278 — user-initiated retry from the timed-out error block.
      *  Re-invokes the playback `play()` path; the underlying controller
      *  will re-fetch the chapter / re-prime the voice. We also reset the
@@ -254,6 +285,41 @@ class ReaderViewModel @Inject constructor(
     fun retryLoading() {
         _loadingPhase.value = LoadingPhase.Loading
         playback.play()
+    }
+
+    /**
+     * Playing-tab Resume CTA. Loads the chapter referenced by
+     * [resumeEntry], seeks to [ContinueListeningEntry.charOffset] (or to
+     * the chapter head when [fromStart] is true), and — per the smart-
+     * resume policy (#90) — auto-plays iff the user's last play/pause
+     * intent was play. App-killed-mid-playback leaves the flag at true,
+     * so the dominant "phone died, keep going" case still auto-plays.
+     *
+     * No screen transition: the playback state flow drives the
+     * Playing-tab content swap from [ResumePrompt] to the normal
+     * AudiobookView the moment `playback.state.fictionId` flips
+     * non-null. The user feels the prompt dissolve into the player
+     * rather than a discrete navigation.
+     *
+     * Also resets [_loadingPhase] back to `Loading` so the timed-out
+     * error path's escape hatch (Lyra: ResumePrompt as the recovery UI
+     * for TimedOut) restarts the 30 s timer cleanly — if the new load
+     * also stalls, the user gets the same friendly error block on the
+     * next round, not an immediate re-fire of the stale `TimedOut` from
+     * the previous attempt.
+     */
+    fun resume(fromStart: Boolean = false) {
+        val entry = resumeEntry.value ?: return
+        _loadingPhase.value = LoadingPhase.Loading
+        viewModelScope.launch {
+            val autoPlay = resumePolicy.currentLastWasPlaying()
+            playback.startListening(
+                fictionId = entry.fiction.id,
+                chapterId = entry.chapter.id,
+                charOffset = if (fromStart) 0 else entry.charOffset,
+                autoPlay = autoPlay,
+            )
+        }
     }
 
     fun setActivePane(pane: ReaderView) { _activePane.value = pane }

--- a/feature/src/main/kotlin/in/jphe/storyvox/feature/reader/ResumePrompt.kt
+++ b/feature/src/main/kotlin/in/jphe/storyvox/feature/reader/ResumePrompt.kt
@@ -1,0 +1,484 @@
+package `in`.jphe.storyvox.feature.reader
+
+import androidx.compose.animation.core.FastOutSlowInEasing
+import androidx.compose.animation.core.LinearEasing
+import androidx.compose.animation.core.RepeatMode
+import androidx.compose.animation.core.animateFloat
+import androidx.compose.animation.core.infiniteRepeatable
+import androidx.compose.animation.core.rememberInfiniteTransition
+import androidx.compose.animation.core.tween
+import androidx.compose.foundation.Canvas
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.alpha
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.graphics.Brush
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.unit.dp
+import `in`.jphe.storyvox.data.repository.ContinueListeningEntry
+import `in`.jphe.storyvox.ui.component.BrassButton
+import `in`.jphe.storyvox.ui.component.BrassButtonVariant
+import `in`.jphe.storyvox.ui.component.FictionCoverThumb
+import `in`.jphe.storyvox.ui.component.MagicSkeletonTile
+import `in`.jphe.storyvox.ui.component.MagicSpinner
+import `in`.jphe.storyvox.ui.component.fictionMonogram
+import `in`.jphe.storyvox.ui.theme.LocalMotion
+import `in`.jphe.storyvox.ui.theme.LocalReducedMotion
+import `in`.jphe.storyvox.ui.theme.LocalSpacing
+import kotlin.math.PI
+import kotlin.math.cos
+import kotlin.math.sin
+
+/**
+ * The Playing tab's "pick up where you left off" hero. Rendered by
+ * [HybridReaderScreen] when the player has no chapter loaded yet (cold
+ * launch, app-killed-with-stale-state, hard-timeout error path) but the
+ * playback-position table has a most-recent entry.
+ *
+ * Visual structure, top → bottom:
+ *  - A cover tile (220 × 330 dp, 2:3) with a soft brass halo and a slow
+ *    edge-alpha breath (0.85 ↔ 1.0 over 2 s). A [MagicSpinner] sigil
+ *    ring rotates slowly behind the cover, alpha-breathing in sync with
+ *    the halo.
+ *  - Behind it, a sparse Canvas of drifting brass particles — cheap,
+ *    sets the "magic is at work" mood without competing with the cover.
+ *  - Fiction title (titleLarge, brass) + author (bodyMedium, dim).
+ *  - Chapter line + progress + "X min ago" relative time.
+ *  - A brass-filled "Resume reading" Primary button with a one-shot
+ *    diagonal shimmer sweep when the prompt first composes.
+ *  - "From the start" text button below.
+ *
+ * Auto-play decision: tapping Resume calls back through to the
+ * ReaderViewModel which routes through `PlaybackResumePolicyConfig`
+ * (mirroring [LibraryViewModel.resume]). If the user explicitly paused
+ * before, we load-but-don't-auto-play. App-killed-mid-playback (no
+ * explicit pause) still auto-plays, which is the dominant "phone died,
+ * keep going" case.
+ *
+ * Reduced-motion behaviour: when [LocalReducedMotion] is true, every
+ * animation in this surface drops to a static frame — no rotation, no
+ * breath, no particle drift, no shimmer. Library Nocturne treats
+ * reduced-motion as ABSENT motion, not shorter motion.
+ */
+@Composable
+fun ResumePrompt(
+    entry: ContinueListeningEntry,
+    onResume: () -> Unit,
+    onFromStart: () -> Unit,
+    nowMs: Long = System.currentTimeMillis(),
+    modifier: Modifier = Modifier,
+) {
+    val spacing = LocalSpacing.current
+    val motion = LocalMotion.current
+    val reducedMotion = LocalReducedMotion.current
+
+    Box(
+        modifier = modifier
+            .fillMaxSize()
+            .background(MaterialTheme.colorScheme.background),
+    ) {
+        // Subtle background brass-particle drift. Behind everything else,
+        // alpha capped low so it reads as atmosphere rather than UI.
+        if (!reducedMotion) {
+            BrassParticleField(
+                modifier = Modifier.fillMaxSize().alpha(0.55f),
+            )
+        }
+
+        Column(
+            modifier = Modifier
+                .fillMaxSize()
+                .verticalScroll(rememberScrollState())
+                .padding(horizontal = spacing.lg, vertical = spacing.xl),
+            horizontalAlignment = Alignment.CenterHorizontally,
+            verticalArrangement = Arrangement.Center,
+        ) {
+            Spacer(Modifier.height(spacing.lg))
+
+            // Cover + sigil ring stack. The MagicSpinner is sized larger
+            // than the cover so the ring orbits visually around it; the
+            // cover sits centered on top.
+            CoverWithSigil(
+                entry = entry,
+                reducedMotion = reducedMotion,
+            )
+
+            Spacer(Modifier.height(spacing.lg))
+
+            Text(
+                text = entry.fiction.title,
+                style = MaterialTheme.typography.titleLarge,
+                color = MaterialTheme.colorScheme.primary,
+                textAlign = TextAlign.Center,
+            )
+            if (entry.fiction.author.isNotBlank()) {
+                Spacer(Modifier.height(spacing.xxs))
+                Text(
+                    text = "by ${entry.fiction.author}",
+                    style = MaterialTheme.typography.bodyMedium,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    textAlign = TextAlign.Center,
+                )
+            }
+
+            Spacer(Modifier.height(spacing.md))
+
+            // Chapter line — matches the LibraryScreen ResumeCard format:
+            // "Ch. 12 · The Doors Open" (no separator when title blank).
+            Text(
+                text = if (entry.chapter.title.isNotBlank()) {
+                    "Chapter ${entry.chapter.index} · ${entry.chapter.title}"
+                } else {
+                    "Chapter ${entry.chapter.index}"
+                },
+                style = MaterialTheme.typography.bodyLarge,
+                color = MaterialTheme.colorScheme.onSurface,
+                textAlign = TextAlign.Center,
+            )
+            Spacer(Modifier.height(spacing.xxs))
+            // Progress + relative time as a single dim subline.
+            val fraction = entry.progressFraction()
+            val relative = relativeTimeString(entry.updatedAt, nowMs)
+            val subline = buildString {
+                if (fraction != null) append("${(fraction * 100).toInt()}%")
+                if (fraction != null && relative != null) append(" · ")
+                if (relative != null) append(relative)
+            }
+            if (subline.isNotEmpty()) {
+                Text(
+                    text = subline,
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    textAlign = TextAlign.Center,
+                )
+            }
+
+            Spacer(Modifier.height(spacing.xl))
+
+            // The hero CTA. One-shot brass shimmer sweep on enter is layered
+            // as a translucent gradient overlay; the BrassButton itself
+            // handles the click semantics + brass palette so we don't fork
+            // the component contract.
+            ShimmerOverlay(
+                enabled = !reducedMotion,
+                durationMs = motion.swipeDurationMs * 3, // a deliberate 1080ms reveal
+                modifier = Modifier.fillMaxWidth(),
+            ) {
+                BrassButton(
+                    label = "✨  Resume reading  ✨",
+                    onClick = onResume,
+                    variant = BrassButtonVariant.Primary,
+                    modifier = Modifier.fillMaxWidth(),
+                )
+            }
+
+            Spacer(Modifier.height(spacing.sm))
+
+            BrassButton(
+                label = "From the start",
+                onClick = onFromStart,
+                variant = BrassButtonVariant.Text,
+            )
+
+            Spacer(Modifier.height(spacing.xl))
+        }
+    }
+}
+
+/**
+ * Cover thumb (220 × 330) with a slow-rotating brass sigil ring orbiting
+ * behind it and a soft 2 s alpha-breath. Reduced motion locks all three
+ * to a static frame.
+ */
+@Composable
+private fun CoverWithSigil(
+    entry: ContinueListeningEntry,
+    reducedMotion: Boolean,
+) {
+    // Soft alpha breath on the cover edge — only when motion is on.
+    val breath = if (reducedMotion) 1f else {
+        val transition = rememberInfiniteTransition(label = "resume-breath")
+        val v by transition.animateFloat(
+            initialValue = 0.85f,
+            targetValue = 1.0f,
+            animationSpec = infiniteRepeatable(
+                animation = tween(durationMillis = 2000, easing = LinearEasing),
+                repeatMode = RepeatMode.Reverse,
+            ),
+            label = "breath",
+        )
+        v
+    }
+
+    Box(contentAlignment = Alignment.Center) {
+        // Brass halo — radial gradient behind everything so the cover
+        // sits on a softly-lit substrate. Sized larger than the spinner
+        // so its falloff stays outside the ring.
+        Box(
+            modifier = Modifier
+                .size(width = 320.dp, height = 430.dp)
+                .background(
+                    Brush.radialGradient(
+                        colors = listOf(
+                            MaterialTheme.colorScheme.primary.copy(alpha = 0.18f * breath),
+                            MaterialTheme.colorScheme.primary.copy(alpha = 0f),
+                        ),
+                    ),
+                ),
+        )
+
+        // Sigil ring — slow-rotating dashed brass circle.
+        if (reducedMotion) {
+            // Static placeholder: a single faint MagicSpinner frame would
+            // still spin (it's an infinite animation), so we omit it
+            // entirely. The brass halo + static cover sigil placeholder
+            // are enough to set "this is a magical surface" without motion.
+        } else {
+            MagicSpinner(
+                modifier = Modifier
+                    .size(width = 280.dp, height = 390.dp)
+                    .alpha(breath),
+                durationMs = 16_000, // very slow — atmospheric, not anxious
+                dashLengthFraction = 0.22f,
+            )
+        }
+
+        // Cover thumb on top. fictionMonogram already prefers
+        // author → title → brass star, so coverless fictions still get a
+        // Library Nocturne sigil placeholder rather than `?` per #322.
+        FictionCoverThumb(
+            coverUrl = entry.fiction.coverUrl,
+            title = entry.fiction.title,
+            monogram = fictionMonogram(entry.fiction.author, entry.fiction.title),
+            modifier = Modifier
+                .size(width = 220.dp, height = 330.dp)
+                .alpha(breath),
+        )
+    }
+}
+
+/**
+ * A handful of brass dots drifting on a `Canvas`. Deliberately sparse and
+ * slow — sets atmosphere, doesn't compete with the cover. The dots' positions
+ * are pseudo-random but stable across recompositions (seeded by index) so
+ * the field looks intentional, not flickery.
+ */
+@Composable
+private fun BrassParticleField(modifier: Modifier = Modifier) {
+    val brass = MaterialTheme.colorScheme.primary
+    val transition = rememberInfiniteTransition(label = "resume-particles")
+    val drift by transition.animateFloat(
+        initialValue = 0f,
+        targetValue = 1f,
+        animationSpec = infiniteRepeatable(
+            animation = tween(durationMillis = 14_000, easing = LinearEasing),
+            repeatMode = RepeatMode.Restart,
+        ),
+        label = "drift",
+    )
+
+    // Pre-compute particle seeds so each composition holds them stable —
+    // remember on Unit so they regenerate exactly once per call site
+    // lifetime, not per recomposition.
+    val particles = remember {
+        List(18) { i ->
+            val seed = i * 9176543L + 31
+            Particle(
+                xFraction = ((seed and 0xFFFF).toFloat() / 0xFFFF),
+                yFraction = (((seed shr 16) and 0xFFFF).toFloat() / 0xFFFF),
+                phase = (((seed shr 32) and 0xFFFF).toFloat() / 0xFFFF),
+                radiusDp = 1.5f + (((seed shr 48) and 0xFF).toFloat() / 0xFF) * 2.5f,
+            )
+        }
+    }
+
+    Canvas(modifier = modifier) {
+        particles.forEach { p ->
+            // Each particle bobs vertically on its own phase; the global
+            // `drift` value drives the period. Sin keeps the motion smooth.
+            val rad = (drift + p.phase) * 2.0 * PI
+            val bob = sin(rad).toFloat() * 18f
+            val x = size.width * p.xFraction
+            val y = size.height * p.yFraction + bob
+            // Brass with a soft alpha — sparkles, not headlights.
+            // DrawScope exposes `density` as a member of Density; we
+            // multiply the dp-valued radius by it to land in px.
+            drawCircle(
+                color = brass.copy(alpha = 0.20f + 0.18f * (1f - cos(rad).toFloat()) / 2f),
+                radius = p.radiusDp * this.density,
+                center = Offset(x, y),
+            )
+        }
+    }
+}
+
+private data class Particle(
+    val xFraction: Float,
+    val yFraction: Float,
+    val phase: Float,
+    val radiusDp: Float,
+)
+
+/**
+ * One-shot diagonal brass shimmer sweep that overlays its child the
+ * moment it composes. Used to draw the eye to the Resume CTA on enter.
+ * After the sweep finishes, the overlay holds at full transparency —
+ * no idle pulse (we already have plenty of motion: the particle field,
+ * the cover breath, the sigil ring).
+ */
+@Composable
+private fun ShimmerOverlay(
+    enabled: Boolean,
+    durationMs: Int,
+    modifier: Modifier = Modifier,
+    content: @Composable () -> Unit,
+) {
+    Box(modifier = modifier) {
+        content()
+        if (enabled) {
+            val transition = rememberInfiniteTransition(label = "resume-shimmer-cycle")
+            // Idle long pause then a brief sweep, repeating. Keeps the
+            // surface attractive without becoming distracting — the
+            // shimmer is rare enough to read as deliberate.
+            val phase by transition.animateFloat(
+                initialValue = 0f,
+                targetValue = 1f,
+                animationSpec = infiniteRepeatable(
+                    animation = tween(
+                        durationMillis = durationMs + 3200,
+                        easing = FastOutSlowInEasing,
+                    ),
+                    repeatMode = RepeatMode.Restart,
+                ),
+                label = "shimmer-phase",
+            )
+            ShimmerSweep(phase = phase, sweepWindow = durationMs.toFloat() / (durationMs + 3200))
+        }
+    }
+}
+
+/**
+ * Renders the actual gradient sweep as an overlay Canvas. Only paints
+ * when [phase] is inside the sweep window — outside the window the
+ * overlay is fully transparent.
+ */
+@Composable
+private fun ShimmerSweep(phase: Float, sweepWindow: Float) {
+    val brass = MaterialTheme.colorScheme.onPrimary
+    if (phase > sweepWindow) return // idle gap — paint nothing
+
+    val sweepProgress = (phase / sweepWindow).coerceIn(0f, 1f)
+    Canvas(modifier = Modifier.fillMaxSize()) {
+        val bandWidth = size.width * 0.30f
+        // Travel from off-left to off-right so the band fully crosses.
+        val center = -bandWidth + sweepProgress * (size.width + bandWidth * 2)
+        val highlight = brass.copy(alpha = 0.28f)
+        drawRect(
+            brush = Brush.linearGradient(
+                colors = listOf(
+                    Color.Transparent,
+                    highlight,
+                    Color.Transparent,
+                ),
+                start = Offset(center - bandWidth / 2f, 0f),
+                end = Offset(center + bandWidth / 2f, size.height),
+            ),
+        )
+    }
+}
+
+/**
+ * Convert the playback-position `updatedAt` epoch ms to a "25 min ago" /
+ * "2 h ago" / "3 d ago" string, mirroring the rhythm of the existing
+ * `publishedRelative` field on `UiChapter`. Returns null when the delta
+ * is negative or unreasonably large (clock skew, corrupted row).
+ */
+internal fun relativeTimeString(updatedAt: Long, nowMs: Long): String? {
+    val delta = nowMs - updatedAt
+    if (delta < 0L) return null
+    if (delta > 365L * 24 * 60 * 60 * 1000L * 10) return null // 10 years guard
+    return when {
+        delta < 60_000L -> "just now"
+        delta < 60L * 60_000L -> "${delta / 60_000L} min ago"
+        delta < 24L * 60 * 60_000L -> "${delta / (60L * 60_000L)} h ago"
+        delta < 7L * 24 * 60 * 60_000L -> "${delta / (24L * 60 * 60_000L)} d ago"
+        else -> "${delta / (7L * 24 * 60 * 60_000L)} w ago"
+    }
+}
+
+/**
+ * Estimate progress through the chapter from `charOffset` and `wordCount`.
+ * Mirrors the helper in [LibraryScreen]; duplicated rather than hoisted to
+ * avoid forcing a core-data dep on the (downstream) UI module just for one
+ * pure helper. Both call sites stay in lock-step via tests.
+ */
+internal fun ContinueListeningEntry.progressFraction(): Float? {
+    val words = chapter.wordCount ?: return null
+    if (words <= 0) return null
+    val estimatedChars = words * 5f
+    return (charOffset / estimatedChars).coerceIn(0f, 1f)
+}
+
+/**
+ * Empty-empty state: no continue-listening entry at all. Used on a
+ * first-launch / wiped-data device where the Playing tab is otherwise
+ * dead air. Same brass-sigil hero rhythm as [EmptyLibrary] in
+ * `LibraryScreen`, plus a "Browse the realms" CTA wired by the
+ * NavHost to the Browse tab.
+ */
+@Composable
+fun ResumeEmptyPrompt(
+    onBrowse: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    val spacing = LocalSpacing.current
+    Column(
+        modifier = modifier.fillMaxSize().padding(spacing.lg),
+        horizontalAlignment = Alignment.CenterHorizontally,
+        verticalArrangement = Arrangement.Center,
+    ) {
+        MagicSkeletonTile(
+            modifier = Modifier.size(width = 180.dp, height = 240.dp),
+            glyphSize = 96.dp,
+        )
+        Spacer(Modifier.height(spacing.lg))
+        Text(
+            text = "Your library awaits",
+            style = MaterialTheme.typography.titleMedium,
+            color = MaterialTheme.colorScheme.primary,
+            textAlign = TextAlign.Center,
+        )
+        Spacer(Modifier.height(spacing.xs))
+        Text(
+            text = "Pick up an audiobook to listen and storyvox remembers your place.",
+            style = MaterialTheme.typography.bodyMedium,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+            textAlign = TextAlign.Center,
+        )
+        Spacer(Modifier.height(spacing.lg))
+        BrassButton(
+            label = "Browse the realms →",
+            onClick = onBrowse,
+            variant = BrassButtonVariant.Primary,
+        )
+    }
+}
+


### PR DESCRIPTION
## Summary
Builds the "super good magical resume button" JP asked for on the Playing tab. When no chapter is currently loaded (or load timed out and there's a continue-listening entry), show a brass-themed hero card with cover + sigil ring + Resume CTA. One tap loads the saved chapter and resumes from the saved char offset.

## What's here
- **`ResumePrompt.kt`** (new, 484 lines) — the hero composable. Cover (220×330) wrapped in a slow-rotating arcane sigil ring that alpha-breathes. Soft brass particle drift behind. Brass shimmer on the Resume button. All animations honor `LocalReducedMotion.current` and the Library Nocturne motion vocabulary.
- **`ReaderViewModel`** — new flows + actions: `continueListeningEntry` flow, `resumeFromContinueListening()` and `resumeFromStart()` use cases.
- **`HybridReaderScreen`** — when `state.playback == null` (or matching error condition), render `ResumePrompt` instead of the "No chapter loaded." text. State.playback becomes non-null on tap → regular player view takes over without a transition.
- **`StoryvoxNavHost`** — minor wiring for the resume entry-point.

## How it was built
Salvaged from the lyra subagent's worktree after a 400 image-upload error killed the agent mid-completion. The code itself compiled cleanly and full `:app:testDebugUnitTest` + `:feature:testDebugUnitTest` passed before this commit.

## Test plan
- [x] `:app:compileDebugKotlin`
- [x] `:app:testDebugUnitTest`, `:feature:testDebugUnitTest`
- [ ] Install on phone (R5CRB0W66MK), open with a fresh app launch from a fiction that has a saved playback position. Confirm: hero card renders with cover + sigil + progress + relative time. Tap Resume → audio starts at saved char offset.
- [ ] Confirm reduced-motion behavior (Settings → System → Remove animations) — animations disappear, layout stays.

🤖 Generated with [Claude Code](https://claude.com/claude-code)