### PR TITLE
feat(library): shelves (Reading/Read/Wishlist) — closes #116

### DIFF
--- a/core-data/build.gradle.kts
+++ b/core-data/build.gradle.kts
@@ -39,6 +39,20 @@ android {
             java.srcDirs("src/main/kotlin")
         }
     }
+
+    // Robolectric-backed unit tests need the exported Room schemas on the
+    // assets path so `MigrationTestHelper` can resolve them. The schemas
+    // are exported by KSP at `core-data/schemas/`.
+    sourceSets {
+        getByName("androidTest").assets.srcDirs("$projectDir/schemas")
+        getByName("test").assets.srcDirs("$projectDir/schemas")
+    }
+
+    testOptions {
+        unitTests {
+            isIncludeAndroidResources = true
+        }
+    }
 }
 
 ksp {
@@ -75,4 +89,8 @@ dependencies {
     // Test
     testImplementation(libs.junit)
     testImplementation(libs.kotlinx.coroutines.test)
+    testImplementation(libs.robolectric)
+    testImplementation("androidx.room:room-testing:2.6.1")
+    testImplementation("androidx.test:core:1.6.1")
+    testImplementation("androidx.test.ext:junit:1.2.1")
 }

--- a/core-data/schemas/in.jphe.storyvox.data.db.StoryvoxDatabase/5.json
+++ b/core-data/schemas/in.jphe.storyvox.data.db.StoryvoxDatabase/5.json
@@ -1,0 +1,725 @@
+{
+  "formatVersion": 1,
+  "database": {
+    "version": 5,
+    "identityHash": "afd1f30188b94ff632f5d77d827c215d",
+    "entities": [
+      {
+        "tableName": "fiction",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `sourceId` TEXT NOT NULL, `title` TEXT NOT NULL, `author` TEXT NOT NULL, `authorId` TEXT, `coverUrl` TEXT, `description` TEXT, `genres` TEXT NOT NULL, `tags` TEXT NOT NULL, `status` TEXT NOT NULL, `chapterCount` INTEGER NOT NULL, `wordCount` INTEGER, `rating` REAL, `views` INTEGER, `followers` INTEGER, `lastUpdatedAt` INTEGER, `firstSeenAt` INTEGER NOT NULL, `metadataFetchedAt` INTEGER NOT NULL, `inLibrary` INTEGER NOT NULL, `addedToLibraryAt` INTEGER, `followedRemotely` INTEGER NOT NULL, `downloadMode` TEXT, `pinnedVoiceId` TEXT, `pinnedVoiceLocale` TEXT, `notesEverSeen` INTEGER NOT NULL, `lastSeenRevision` TEXT, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "sourceId",
+            "columnName": "sourceId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "title",
+            "columnName": "title",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "author",
+            "columnName": "author",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "authorId",
+            "columnName": "authorId",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "coverUrl",
+            "columnName": "coverUrl",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "description",
+            "columnName": "description",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "genres",
+            "columnName": "genres",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "tags",
+            "columnName": "tags",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "status",
+            "columnName": "status",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "chapterCount",
+            "columnName": "chapterCount",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "wordCount",
+            "columnName": "wordCount",
+            "affinity": "INTEGER",
+            "notNull": false
+          },
+          {
+            "fieldPath": "rating",
+            "columnName": "rating",
+            "affinity": "REAL",
+            "notNull": false
+          },
+          {
+            "fieldPath": "views",
+            "columnName": "views",
+            "affinity": "INTEGER",
+            "notNull": false
+          },
+          {
+            "fieldPath": "followers",
+            "columnName": "followers",
+            "affinity": "INTEGER",
+            "notNull": false
+          },
+          {
+            "fieldPath": "lastUpdatedAt",
+            "columnName": "lastUpdatedAt",
+            "affinity": "INTEGER",
+            "notNull": false
+          },
+          {
+            "fieldPath": "firstSeenAt",
+            "columnName": "firstSeenAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "metadataFetchedAt",
+            "columnName": "metadataFetchedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "inLibrary",
+            "columnName": "inLibrary",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "addedToLibraryAt",
+            "columnName": "addedToLibraryAt",
+            "affinity": "INTEGER",
+            "notNull": false
+          },
+          {
+            "fieldPath": "followedRemotely",
+            "columnName": "followedRemotely",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "downloadMode",
+            "columnName": "downloadMode",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "pinnedVoiceId",
+            "columnName": "pinnedVoiceId",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "pinnedVoiceLocale",
+            "columnName": "pinnedVoiceLocale",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "notesEverSeen",
+            "columnName": "notesEverSeen",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastSeenRevision",
+            "columnName": "lastSeenRevision",
+            "affinity": "TEXT",
+            "notNull": false
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_fiction_inLibrary",
+            "unique": false,
+            "columnNames": [
+              "inLibrary"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_fiction_inLibrary` ON `${TABLE_NAME}` (`inLibrary`)"
+          },
+          {
+            "name": "index_fiction_followedRemotely",
+            "unique": false,
+            "columnNames": [
+              "followedRemotely"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_fiction_followedRemotely` ON `${TABLE_NAME}` (`followedRemotely`)"
+          },
+          {
+            "name": "index_fiction_sourceId_lastUpdatedAt",
+            "unique": false,
+            "columnNames": [
+              "sourceId",
+              "lastUpdatedAt"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_fiction_sourceId_lastUpdatedAt` ON `${TABLE_NAME}` (`sourceId`, `lastUpdatedAt`)"
+          }
+        ],
+        "foreignKeys": []
+      },
+      {
+        "tableName": "chapter",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `fictionId` TEXT NOT NULL, `sourceChapterId` TEXT NOT NULL, `index` INTEGER NOT NULL, `title` TEXT NOT NULL, `publishedAt` INTEGER, `wordCount` INTEGER, `htmlBody` TEXT, `plainBody` TEXT, `bodyFetchedAt` INTEGER, `bodyChecksum` TEXT, `downloadState` TEXT NOT NULL, `lastDownloadAttemptAt` INTEGER, `lastDownloadError` TEXT, `notesAuthor` TEXT, `notesAuthorPosition` TEXT, `userMarkedRead` INTEGER NOT NULL, `firstReadAt` INTEGER, `bookmarkCharOffset` INTEGER, PRIMARY KEY(`id`), FOREIGN KEY(`fictionId`) REFERENCES `fiction`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "fictionId",
+            "columnName": "fictionId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "sourceChapterId",
+            "columnName": "sourceChapterId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "index",
+            "columnName": "index",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "title",
+            "columnName": "title",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "publishedAt",
+            "columnName": "publishedAt",
+            "affinity": "INTEGER",
+            "notNull": false
+          },
+          {
+            "fieldPath": "wordCount",
+            "columnName": "wordCount",
+            "affinity": "INTEGER",
+            "notNull": false
+          },
+          {
+            "fieldPath": "htmlBody",
+            "columnName": "htmlBody",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "plainBody",
+            "columnName": "plainBody",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "bodyFetchedAt",
+            "columnName": "bodyFetchedAt",
+            "affinity": "INTEGER",
+            "notNull": false
+          },
+          {
+            "fieldPath": "bodyChecksum",
+            "columnName": "bodyChecksum",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "downloadState",
+            "columnName": "downloadState",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastDownloadAttemptAt",
+            "columnName": "lastDownloadAttemptAt",
+            "affinity": "INTEGER",
+            "notNull": false
+          },
+          {
+            "fieldPath": "lastDownloadError",
+            "columnName": "lastDownloadError",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "notesAuthor",
+            "columnName": "notesAuthor",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "notesAuthorPosition",
+            "columnName": "notesAuthorPosition",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "userMarkedRead",
+            "columnName": "userMarkedRead",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "firstReadAt",
+            "columnName": "firstReadAt",
+            "affinity": "INTEGER",
+            "notNull": false
+          },
+          {
+            "fieldPath": "bookmarkCharOffset",
+            "columnName": "bookmarkCharOffset",
+            "affinity": "INTEGER",
+            "notNull": false
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_chapter_fictionId",
+            "unique": false,
+            "columnNames": [
+              "fictionId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_chapter_fictionId` ON `${TABLE_NAME}` (`fictionId`)"
+          },
+          {
+            "name": "index_chapter_fictionId_index",
+            "unique": true,
+            "columnNames": [
+              "fictionId",
+              "index"
+            ],
+            "orders": [],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_chapter_fictionId_index` ON `${TABLE_NAME}` (`fictionId`, `index`)"
+          },
+          {
+            "name": "index_chapter_downloadState",
+            "unique": false,
+            "columnNames": [
+              "downloadState"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_chapter_downloadState` ON `${TABLE_NAME}` (`downloadState`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "fiction",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "fictionId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "playback_position",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`fictionId` TEXT NOT NULL, `chapterId` TEXT NOT NULL, `charOffset` INTEGER NOT NULL, `paragraphIndex` INTEGER NOT NULL, `playbackSpeed` REAL NOT NULL, `durationEstimateMs` INTEGER NOT NULL, `updatedAt` INTEGER NOT NULL, PRIMARY KEY(`fictionId`), FOREIGN KEY(`fictionId`) REFERENCES `fiction`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE , FOREIGN KEY(`chapterId`) REFERENCES `chapter`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "fictionId",
+            "columnName": "fictionId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "chapterId",
+            "columnName": "chapterId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "charOffset",
+            "columnName": "charOffset",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "paragraphIndex",
+            "columnName": "paragraphIndex",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "playbackSpeed",
+            "columnName": "playbackSpeed",
+            "affinity": "REAL",
+            "notNull": true
+          },
+          {
+            "fieldPath": "durationEstimateMs",
+            "columnName": "durationEstimateMs",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "updatedAt",
+            "columnName": "updatedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "fictionId"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_playback_position_chapterId",
+            "unique": false,
+            "columnNames": [
+              "chapterId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_playback_position_chapterId` ON `${TABLE_NAME}` (`chapterId`)"
+          },
+          {
+            "name": "index_playback_position_updatedAt",
+            "unique": false,
+            "columnNames": [
+              "updatedAt"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_playback_position_updatedAt` ON `${TABLE_NAME}` (`updatedAt`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "fiction",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "fictionId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          },
+          {
+            "table": "chapter",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "chapterId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "auth_cookie",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`sourceId` TEXT NOT NULL, `userDisplayName` TEXT, `userId` TEXT, `capturedAt` INTEGER NOT NULL, `expiresAt` INTEGER, `lastVerifiedAt` INTEGER NOT NULL, PRIMARY KEY(`sourceId`))",
+        "fields": [
+          {
+            "fieldPath": "sourceId",
+            "columnName": "sourceId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "userDisplayName",
+            "columnName": "userDisplayName",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "userId",
+            "columnName": "userId",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "capturedAt",
+            "columnName": "capturedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "expiresAt",
+            "columnName": "expiresAt",
+            "affinity": "INTEGER",
+            "notNull": false
+          },
+          {
+            "fieldPath": "lastVerifiedAt",
+            "columnName": "lastVerifiedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "sourceId"
+          ]
+        },
+        "indices": [],
+        "foreignKeys": []
+      },
+      {
+        "tableName": "llm_session",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `name` TEXT NOT NULL, `provider` TEXT NOT NULL, `model` TEXT NOT NULL, `systemPrompt` TEXT, `createdAt` INTEGER NOT NULL, `lastUsedAt` INTEGER NOT NULL, `featureKind` TEXT, `anchorFictionId` TEXT, `anchorChapterId` TEXT, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "provider",
+            "columnName": "provider",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "model",
+            "columnName": "model",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "systemPrompt",
+            "columnName": "systemPrompt",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "createdAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastUsedAt",
+            "columnName": "lastUsedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "featureKind",
+            "columnName": "featureKind",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "anchorFictionId",
+            "columnName": "anchorFictionId",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "anchorChapterId",
+            "columnName": "anchorChapterId",
+            "affinity": "TEXT",
+            "notNull": false
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [],
+        "foreignKeys": []
+      },
+      {
+        "tableName": "llm_message",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `sessionId` TEXT NOT NULL, `role` TEXT NOT NULL, `content` TEXT NOT NULL, `createdAt` INTEGER NOT NULL, FOREIGN KEY(`sessionId`) REFERENCES `llm_session`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "sessionId",
+            "columnName": "sessionId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "role",
+            "columnName": "role",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "content",
+            "columnName": "content",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "createdAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_llm_message_sessionId",
+            "unique": false,
+            "columnNames": [
+              "sessionId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_llm_message_sessionId` ON `${TABLE_NAME}` (`sessionId`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "llm_session",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "sessionId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "fiction_shelf",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`fictionId` TEXT NOT NULL, `shelf` TEXT NOT NULL, `addedAt` INTEGER NOT NULL, PRIMARY KEY(`fictionId`, `shelf`), FOREIGN KEY(`fictionId`) REFERENCES `fiction`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "fictionId",
+            "columnName": "fictionId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "shelf",
+            "columnName": "shelf",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "addedAt",
+            "columnName": "addedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "fictionId",
+            "shelf"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_fiction_shelf_shelf",
+            "unique": false,
+            "columnNames": [
+              "shelf"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_fiction_shelf_shelf` ON `${TABLE_NAME}` (`shelf`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "fiction",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "fictionId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      }
+    ],
+    "views": [],
+    "setupQueries": [
+      "CREATE TABLE IF NOT EXISTS room_master_table (id INTEGER PRIMARY KEY,identity_hash TEXT)",
+      "INSERT OR REPLACE INTO room_master_table (id,identity_hash) VALUES(42, 'afd1f30188b94ff632f5d77d827c215d')"
+    ]
+  }
+}

--- a/core-data/src/main/kotlin/in/jphe/storyvox/data/db/StoryvoxDatabase.kt
+++ b/core-data/src/main/kotlin/in/jphe/storyvox/data/db/StoryvoxDatabase.kt
@@ -7,12 +7,14 @@ import `in`.jphe.storyvox.data.db.converter.Converters
 import `in`.jphe.storyvox.data.db.dao.AuthDao
 import `in`.jphe.storyvox.data.db.dao.ChapterDao
 import `in`.jphe.storyvox.data.db.dao.FictionDao
+import `in`.jphe.storyvox.data.db.dao.FictionShelfDao
 import `in`.jphe.storyvox.data.db.dao.LlmMessageDao
 import `in`.jphe.storyvox.data.db.dao.LlmSessionDao
 import `in`.jphe.storyvox.data.db.dao.PlaybackDao
 import `in`.jphe.storyvox.data.db.entity.AuthCookie
 import `in`.jphe.storyvox.data.db.entity.Chapter
 import `in`.jphe.storyvox.data.db.entity.Fiction
+import `in`.jphe.storyvox.data.db.entity.FictionShelf
 import `in`.jphe.storyvox.data.db.entity.LlmSession
 import `in`.jphe.storyvox.data.db.entity.LlmStoredMessage
 import `in`.jphe.storyvox.data.db.entity.PlaybackPosition
@@ -26,8 +28,10 @@ import `in`.jphe.storyvox.data.db.entity.PlaybackPosition
         // v3 (#81 AI integration) — multi-session chat tables.
         LlmSession::class,
         LlmStoredMessage::class,
+        // v5 (#116 library shelves) — many-to-many junction.
+        FictionShelf::class,
     ],
-    version = 4,
+    version = 5,
     exportSchema = true,
 )
 @TypeConverters(Converters::class)
@@ -38,6 +42,7 @@ abstract class StoryvoxDatabase : RoomDatabase() {
     abstract fun authDao(): AuthDao
     abstract fun llmSessionDao(): LlmSessionDao
     abstract fun llmMessageDao(): LlmMessageDao
+    abstract fun fictionShelfDao(): FictionShelfDao
 
     companion object {
         const val NAME: String = "storyvox.db"

--- a/core-data/src/main/kotlin/in/jphe/storyvox/data/db/dao/FictionShelfDao.kt
+++ b/core-data/src/main/kotlin/in/jphe/storyvox/data/db/dao/FictionShelfDao.kt
@@ -1,0 +1,69 @@
+package `in`.jphe.storyvox.data.db.dao
+
+import androidx.room.Dao
+import androidx.room.Insert
+import androidx.room.OnConflictStrategy
+import androidx.room.Query
+import `in`.jphe.storyvox.data.db.entity.Fiction
+import `in`.jphe.storyvox.data.db.entity.FictionShelf
+import kotlinx.coroutines.flow.Flow
+
+/**
+ * Read/write surface for the `fiction_shelf` junction table (issue #116).
+ *
+ * - Reading lists (chip-filtered Library view) join through this table and
+ *   only return library rows so that an item that was unlibraried but is
+ *   still referenced by an orphan junction row (shouldn't happen — CASCADE
+ *   covers it — but the join is the durable defence) doesn't show up.
+ * - The membership-toggle path is a plain insert/delete pair; idempotent
+ *   inserts via [OnConflictStrategy.REPLACE] keep "add the same book to the
+ *   same shelf twice" a no-op rather than a crash.
+ */
+@Dao
+interface FictionShelfDao {
+
+    // ── Observers ────────────────────────────────────────────────────────
+
+    /**
+     * Library fictions on a given shelf, newest-first by addedToLibraryAt
+     * (the same ordering as `FictionDao.observeLibrary`). Filtering
+     * `f.inLibrary = 1` keeps "shelved but un-libraried" off the chip
+     * results — the user removed the book from their library, so they
+     * shouldn't see it on a shelf either.
+     */
+    @Query(
+        """
+        SELECT f.* FROM fiction f
+        INNER JOIN fiction_shelf fs ON fs.fictionId = f.id
+        WHERE fs.shelf = :shelfName AND f.inLibrary = 1
+        ORDER BY f.addedToLibraryAt DESC
+        """,
+    )
+    fun observeByShelf(shelfName: String): Flow<List<Fiction>>
+
+    /** Shelf membership for a fiction, as the persisted enum-name strings. */
+    @Query("SELECT shelf FROM fiction_shelf WHERE fictionId = :fictionId")
+    fun observeShelvesForFiction(fictionId: String): Flow<List<String>>
+
+    /** One-shot variant — used by repository code paths that aren't flow-backed. */
+    @Query("SELECT shelf FROM fiction_shelf WHERE fictionId = :fictionId")
+    suspend fun shelvesForFiction(fictionId: String): List<String>
+
+    // ── Mutators ─────────────────────────────────────────────────────────
+
+    /**
+     * Insert is REPLACE so adding the same (fictionId, shelf) pair twice is
+     * a no-op refresh of [FictionShelf.addedAt] rather than a crash. UI is
+     * idempotent — flipping a toggle while the underlying state is already
+     * matching shouldn't break.
+     */
+    @Insert(onConflict = OnConflictStrategy.REPLACE)
+    suspend fun insert(row: FictionShelf)
+
+    @Query("DELETE FROM fiction_shelf WHERE fictionId = :fictionId AND shelf = :shelfName")
+    suspend fun remove(fictionId: String, shelfName: String)
+
+    /** Drop every shelf membership for a fiction — e.g. on library removal. */
+    @Query("DELETE FROM fiction_shelf WHERE fictionId = :fictionId")
+    suspend fun clearForFiction(fictionId: String)
+}

--- a/core-data/src/main/kotlin/in/jphe/storyvox/data/db/entity/FictionShelf.kt
+++ b/core-data/src/main/kotlin/in/jphe/storyvox/data/db/entity/FictionShelf.kt
@@ -1,0 +1,52 @@
+package `in`.jphe.storyvox.data.db.entity
+
+import androidx.room.Entity
+import androidx.room.ForeignKey
+import androidx.room.Index
+
+/**
+ * Issue #116 — junction table for the many-to-many shelf membership.
+ *
+ * One row = one fiction sits on one shelf. A fiction with two memberships
+ * (e.g. Reading + Wishlist) has two rows here, keyed by (fictionId, shelf).
+ *
+ * `shelf` stores [Shelf.name] as a string. Doing this rather than persisting
+ * the ordinal means we can add a fourth shelf in v2 (Favourites,
+ * "Did-Not-Finish", ...) by appending a new enum value with no schema
+ * migration — exactly the same pattern as `provider` / `featureKind` on
+ * `llm_session` (see [Migrations.MIGRATION_2_3]).
+ *
+ * `ON DELETE CASCADE` on the fiction FK guarantees that purging a fiction
+ * (e.g. via `FictionDao.deleteIfTransient`) also drops its shelf
+ * memberships — leaving them orphaned would manifest as ghost entries on a
+ * shelf with no card to render.
+ */
+@Entity(
+    tableName = "fiction_shelf",
+    primaryKeys = ["fictionId", "shelf"],
+    foreignKeys = [
+        ForeignKey(
+            entity = Fiction::class,
+            parentColumns = ["id"],
+            childColumns = ["fictionId"],
+            onDelete = ForeignKey.CASCADE,
+        ),
+    ],
+    indices = [
+        // Shelf-scoped read path (`observeByShelf`) needs an index on the
+        // shelf column. The composite PK already covers fictionId-first
+        // queries, so no second index there.
+        Index(value = ["shelf"]),
+    ],
+)
+data class FictionShelf(
+    val fictionId: String,
+    /** [Shelf.name] persisted as a string — see class kdoc. */
+    val shelf: String,
+    /** Wall-clock millis at the moment the user added the fiction to this
+     *  shelf. Currently unused for ordering (shelves render in
+     *  library-add order via the `fiction` table), but recorded now so a
+     *  future "recently shelved" surface or sync timestamp doesn't need a
+     *  schema bump. */
+    val addedAt: Long,
+)

--- a/core-data/src/main/kotlin/in/jphe/storyvox/data/db/entity/Shelf.kt
+++ b/core-data/src/main/kotlin/in/jphe/storyvox/data/db/entity/Shelf.kt
@@ -1,0 +1,38 @@
+package `in`.jphe.storyvox.data.db.entity
+
+/**
+ * Issue #116 — predefined library shelves. JP's decision (recorded on the
+ * issue): three fixed built-in shelves; user-defined custom shelves are
+ * explicitly out of scope for v1.
+ *
+ * A fiction may belong to multiple shelves simultaneously (e.g. Reading AND
+ * Wishlist) — many-to-many membership via [FictionShelf]. The enum is the
+ * source of truth; the junction row stores the enum name as a string so
+ * adding a new value later (e.g. Favourites) requires no schema migration.
+ *
+ * **Display labels are deliberately in this file, not the UI module.** The
+ * three names are the user-facing strings ("Reading" / "Read" / "Wishlist")
+ * and that mapping is part of the data contract — every surface that
+ * mentions a shelf shows the same word. If we ever localize, this is the
+ * single attachment point.
+ */
+enum class Shelf(val displayName: String) {
+    Reading("Reading"),
+    Read("Read"),
+    Wishlist("Wishlist"),
+    ;
+
+    companion object {
+        /** Stable iteration order for chip rows and the manage-shelves sheet. */
+        val ALL: List<Shelf> = listOf(Reading, Read, Wishlist)
+
+        /**
+         * Decode the persisted string back to a [Shelf]. Returns null for an
+         * unknown name — callers either skip the row or surface a "stale
+         * schema" warning. We don't throw because the FK + named-enum design
+         * means an unknown value can only appear if someone hand-edited the
+         * DB; refusing to crash on that is the lighter blast radius.
+         */
+        fun fromName(name: String): Shelf? = entries.firstOrNull { it.name == name }
+    }
+}

--- a/core-data/src/main/kotlin/in/jphe/storyvox/data/db/migration/Migrations.kt
+++ b/core-data/src/main/kotlin/in/jphe/storyvox/data/db/migration/Migrations.kt
@@ -84,4 +84,41 @@ val MIGRATION_3_4: Migration = object : Migration(3, 4) {
     }
 }
 
-val ALL_MIGRATIONS: Array<Migration> = arrayOf(MIGRATION_1_2, MIGRATION_2_3, MIGRATION_3_4)
+/**
+ * v5 — issue #116: predefined library shelves (Reading / Read /
+ * Wishlist) with many-to-many membership. New junction table only; no
+ * existing data touched, no backfill needed (existing library rows
+ * simply have zero shelf memberships until the user pins them).
+ *
+ * `shelf` is TEXT to match the enum-name-as-string pattern from
+ * [MIGRATION_2_3] — adding a fourth shelf value in v2 requires no
+ * further migration. Index name matches Room's default
+ * `index_<table>_<col>` convention so the schema diff stays clean.
+ */
+val MIGRATION_4_5: Migration = object : Migration(4, 5) {
+    override fun migrate(db: SupportSQLiteDatabase) {
+        db.execSQL(
+            """
+            CREATE TABLE IF NOT EXISTS `fiction_shelf` (
+                `fictionId` TEXT NOT NULL,
+                `shelf` TEXT NOT NULL,
+                `addedAt` INTEGER NOT NULL,
+                PRIMARY KEY(`fictionId`, `shelf`),
+                FOREIGN KEY(`fictionId`) REFERENCES `fiction`(`id`)
+                  ON UPDATE NO ACTION ON DELETE CASCADE
+            )
+            """.trimIndent(),
+        )
+        db.execSQL(
+            "CREATE INDEX IF NOT EXISTS `index_fiction_shelf_shelf` " +
+                "ON `fiction_shelf` (`shelf`)",
+        )
+    }
+}
+
+val ALL_MIGRATIONS: Array<Migration> = arrayOf(
+    MIGRATION_1_2,
+    MIGRATION_2_3,
+    MIGRATION_3_4,
+    MIGRATION_4_5,
+)

--- a/core-data/src/main/kotlin/in/jphe/storyvox/data/di/DataModule.kt
+++ b/core-data/src/main/kotlin/in/jphe/storyvox/data/di/DataModule.kt
@@ -15,6 +15,7 @@ import `in`.jphe.storyvox.data.db.StoryvoxDatabase
 import `in`.jphe.storyvox.data.db.dao.AuthDao
 import `in`.jphe.storyvox.data.db.dao.ChapterDao
 import `in`.jphe.storyvox.data.db.dao.FictionDao
+import `in`.jphe.storyvox.data.db.dao.FictionShelfDao
 import `in`.jphe.storyvox.data.db.dao.LlmMessageDao
 import `in`.jphe.storyvox.data.db.dao.LlmSessionDao
 import `in`.jphe.storyvox.data.db.dao.PlaybackDao
@@ -32,6 +33,8 @@ import `in`.jphe.storyvox.data.repository.LibraryRepository
 import `in`.jphe.storyvox.data.repository.LibraryRepositoryImpl
 import `in`.jphe.storyvox.data.repository.PlaybackPositionRepository
 import `in`.jphe.storyvox.data.repository.PlaybackPositionRepositoryImpl
+import `in`.jphe.storyvox.data.repository.ShelfRepository
+import `in`.jphe.storyvox.data.repository.ShelfRepositoryImpl
 import `in`.jphe.storyvox.data.repository.WorkManagerChapterDownloadScheduler
 import javax.inject.Singleton
 
@@ -58,6 +61,7 @@ object DataModule {
     @Provides fun authDao(db: StoryvoxDatabase): AuthDao = db.authDao()
     @Provides fun llmSessionDao(db: StoryvoxDatabase): LlmSessionDao = db.llmSessionDao()
     @Provides fun llmMessageDao(db: StoryvoxDatabase): LlmMessageDao = db.llmMessageDao()
+    @Provides fun fictionShelfDao(db: StoryvoxDatabase): FictionShelfDao = db.fictionShelfDao()
 
     @Provides
     @Singleton
@@ -98,6 +102,9 @@ abstract class RepositoryBindings {
 
     @Binds @Singleton
     abstract fun bindFollowsRepository(impl: FollowsRepositoryImpl): FollowsRepository
+
+    @Binds @Singleton
+    abstract fun bindShelfRepository(impl: ShelfRepositoryImpl): ShelfRepository
 
     @Binds @Singleton
     abstract fun bindChapterDownloadScheduler(

--- a/core-data/src/main/kotlin/in/jphe/storyvox/data/repository/ShelfRepository.kt
+++ b/core-data/src/main/kotlin/in/jphe/storyvox/data/repository/ShelfRepository.kt
@@ -1,0 +1,91 @@
+package `in`.jphe.storyvox.data.repository
+
+import `in`.jphe.storyvox.data.db.dao.FictionShelfDao
+import `in`.jphe.storyvox.data.db.entity.FictionShelf
+import `in`.jphe.storyvox.data.db.entity.Shelf
+import `in`.jphe.storyvox.data.source.model.FictionSummary
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.withContext
+import javax.inject.Inject
+import javax.inject.Singleton
+
+/**
+ * Read/write surface for the predefined-shelves feature (issue #116).
+ *
+ * UI talks only to this interface — never to [FictionShelfDao] directly —
+ * so the mapping from persisted enum-name strings (the DB shape) to
+ * [Shelf] (the type-safe shape) lives in one place.
+ */
+interface ShelfRepository {
+
+    /**
+     * Fictions sitting on [shelf], newest-library-add first. Only includes
+     * rows where `fiction.inLibrary = 1` (a fiction the user removed from
+     * Library shouldn't haunt its shelves).
+     */
+    fun observeByShelf(shelf: Shelf): Flow<List<FictionSummary>>
+
+    /**
+     * The set of shelves a fiction currently sits on. Stable order
+     * matching [Shelf.ALL] so toggling a chip doesn't reshuffle the row.
+     */
+    fun observeShelvesForFiction(fictionId: String): Flow<Set<Shelf>>
+
+    /** One-shot variant of [observeShelvesForFiction] for non-flow call sites. */
+    suspend fun shelvesForFiction(fictionId: String): Set<Shelf>
+
+    /** Add the fiction to a shelf. Idempotent — toggling on an already-on row is a no-op. */
+    suspend fun add(fictionId: String, shelf: Shelf)
+
+    /** Remove the fiction from a shelf. Idempotent. */
+    suspend fun remove(fictionId: String, shelf: Shelf)
+
+    /** Convenience — flip the membership bit. */
+    suspend fun toggle(fictionId: String, shelf: Shelf) {
+        if (shelf in shelvesForFiction(fictionId)) remove(fictionId, shelf) else add(fictionId, shelf)
+    }
+
+    /** Drop every shelf membership for a fiction (called when removing from library). */
+    suspend fun clearForFiction(fictionId: String)
+}
+
+@Singleton
+class ShelfRepositoryImpl @Inject constructor(
+    private val shelfDao: FictionShelfDao,
+) : ShelfRepository {
+
+    override fun observeByShelf(shelf: Shelf): Flow<List<FictionSummary>> =
+        shelfDao.observeByShelf(shelf.name).map { rows -> rows.map { it.toSummary() } }
+
+    override fun observeShelvesForFiction(fictionId: String): Flow<Set<Shelf>> =
+        shelfDao.observeShelvesForFiction(fictionId).map { names ->
+            // mapNotNull tolerates unknown names — see `Shelf.fromName` kdoc.
+            // Sort by enum order so the manage-sheet toggles render in
+            // Reading / Read / Wishlist order regardless of insertion order.
+            names.mapNotNull(Shelf::fromName).toSortedSet(compareBy { it.ordinal })
+        }
+
+    override suspend fun shelvesForFiction(fictionId: String): Set<Shelf> = withContext(Dispatchers.IO) {
+        shelfDao.shelvesForFiction(fictionId).mapNotNull(Shelf::fromName).toSet()
+    }
+
+    override suspend fun add(fictionId: String, shelf: Shelf) = withContext(Dispatchers.IO) {
+        shelfDao.insert(
+            FictionShelf(
+                fictionId = fictionId,
+                shelf = shelf.name,
+                addedAt = System.currentTimeMillis(),
+            ),
+        )
+    }
+
+    override suspend fun remove(fictionId: String, shelf: Shelf) = withContext(Dispatchers.IO) {
+        shelfDao.remove(fictionId, shelf.name)
+    }
+
+    override suspend fun clearForFiction(fictionId: String) = withContext(Dispatchers.IO) {
+        shelfDao.clearForFiction(fictionId)
+    }
+}

--- a/core-data/src/test/kotlin/in/jphe/storyvox/data/db/dao/FictionShelfDaoTest.kt
+++ b/core-data/src/test/kotlin/in/jphe/storyvox/data/db/dao/FictionShelfDaoTest.kt
@@ -1,0 +1,144 @@
+package `in`.jphe.storyvox.data.db.dao
+
+import android.content.Context
+import androidx.room.Room
+import androidx.test.core.app.ApplicationProvider
+import `in`.jphe.storyvox.data.db.StoryvoxDatabase
+import `in`.jphe.storyvox.data.db.entity.Fiction
+import `in`.jphe.storyvox.data.db.entity.FictionShelf
+import `in`.jphe.storyvox.data.db.entity.Shelf
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.test.runTest
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+
+/**
+ * Roundtrip exercise of [FictionShelfDao] against an in-memory Room
+ * database. Covers the three operations the UI relies on:
+ *
+ *  - add → observeByShelf returns the fiction
+ *  - second add to a different shelf → both shelves observable for fiction
+ *  - remove → observeByShelf no longer returns it
+ *  - un-library → observeByShelf filters it out (junction row persists)
+ *  - CASCADE delete of fiction → junction rows disappear
+ */
+@RunWith(RobolectricTestRunner::class)
+@Config(manifest = Config.NONE)
+class FictionShelfDaoTest {
+
+    private lateinit var db: StoryvoxDatabase
+    private lateinit var dao: FictionShelfDao
+    private lateinit var fictionDao: FictionDao
+
+    private val fiction = Fiction(
+        id = "f1",
+        sourceId = "royalroad",
+        title = "Sky Pride",
+        author = "Anonymous",
+        firstSeenAt = 0L,
+        metadataFetchedAt = 0L,
+        inLibrary = true,
+    )
+
+    @Before
+    fun setUp() {
+        val ctx = ApplicationProvider.getApplicationContext<Context>()
+        db = Room.inMemoryDatabaseBuilder(ctx, StoryvoxDatabase::class.java)
+            .allowMainThreadQueries()
+            .build()
+        dao = db.fictionShelfDao()
+        fictionDao = db.fictionDao()
+    }
+
+    @After
+    fun tearDown() {
+        db.close()
+    }
+
+    @Test
+    fun add_thenObserveByShelf_returnsTheFiction() = runTest {
+        fictionDao.upsert(fiction)
+        dao.insert(FictionShelf("f1", Shelf.Reading.name, addedAt = 1L))
+
+        val rows = dao.observeByShelf(Shelf.Reading.name).first()
+        assertEquals(1, rows.size)
+        assertEquals("f1", rows[0].id)
+    }
+
+    @Test
+    fun addToTwoShelves_shelvesForFiction_returnsBoth() = runTest {
+        fictionDao.upsert(fiction)
+        dao.insert(FictionShelf("f1", Shelf.Reading.name, addedAt = 1L))
+        dao.insert(FictionShelf("f1", Shelf.Wishlist.name, addedAt = 2L))
+
+        val names = dao.shelvesForFiction("f1").toSet()
+        assertEquals(setOf("Reading", "Wishlist"), names)
+    }
+
+    @Test
+    fun insertDuplicate_isIdempotent_refreshesAddedAt() = runTest {
+        fictionDao.upsert(fiction)
+        dao.insert(FictionShelf("f1", Shelf.Reading.name, addedAt = 1L))
+        // REPLACE on conflict — second insert should not throw.
+        dao.insert(FictionShelf("f1", Shelf.Reading.name, addedAt = 999L))
+
+        val names = dao.shelvesForFiction("f1")
+        assertEquals(listOf("Reading"), names)
+    }
+
+    @Test
+    fun remove_thenObserveByShelf_isEmpty() = runTest {
+        fictionDao.upsert(fiction)
+        dao.insert(FictionShelf("f1", Shelf.Read.name, addedAt = 1L))
+        dao.remove("f1", Shelf.Read.name)
+
+        val rows = dao.observeByShelf(Shelf.Read.name).first()
+        assertTrue("expected empty after remove, got $rows", rows.isEmpty())
+    }
+
+    @Test
+    fun unlibraried_fiction_doesNotAppearOnShelfQueries() = runTest {
+        // Library row…
+        fictionDao.upsert(fiction)
+        dao.insert(FictionShelf("f1", Shelf.Wishlist.name, addedAt = 1L))
+
+        // …then unlibrary it. The chip-filtered query filters on
+        // `fiction.inLibrary = 1`, so the row should drop out even though
+        // the junction row still exists.
+        fictionDao.setInLibrary("f1", false, now = 0L)
+
+        val rows = dao.observeByShelf(Shelf.Wishlist.name).first()
+        assertTrue("unlibraried fiction must not surface on shelf views", rows.isEmpty())
+        // …but the junction itself is preserved (re-libraries restore shelf membership).
+        assertEquals(listOf("Wishlist"), dao.shelvesForFiction("f1"))
+    }
+
+    @Test
+    fun deletingFiction_cascadesShelfRows() = runTest {
+        // A transient fiction (not in library, not followed) is eligible for
+        // deleteIfTransient. CASCADE on the FK should drop its junction rows.
+        val transient = fiction.copy(id = "tmp", inLibrary = false, followedRemotely = false)
+        fictionDao.upsert(transient)
+        dao.insert(FictionShelf("tmp", Shelf.Reading.name, addedAt = 1L))
+
+        val deleted = fictionDao.deleteIfTransient("tmp")
+        assertEquals(1, deleted)
+        assertTrue(dao.shelvesForFiction("tmp").isEmpty())
+    }
+
+    @Test
+    fun clearForFiction_dropsAllMemberships() = runTest {
+        fictionDao.upsert(fiction)
+        dao.insert(FictionShelf("f1", Shelf.Reading.name, addedAt = 1L))
+        dao.insert(FictionShelf("f1", Shelf.Wishlist.name, addedAt = 2L))
+
+        dao.clearForFiction("f1")
+        assertTrue(dao.shelvesForFiction("f1").isEmpty())
+    }
+}

--- a/core-data/src/test/kotlin/in/jphe/storyvox/data/db/migration/Migration4to5Test.kt
+++ b/core-data/src/test/kotlin/in/jphe/storyvox/data/db/migration/Migration4to5Test.kt
@@ -1,0 +1,100 @@
+package `in`.jphe.storyvox.data.db.migration
+
+import androidx.room.Room
+import androidx.room.testing.MigrationTestHelper
+import androidx.sqlite.db.framework.FrameworkSQLiteOpenHelperFactory
+import androidx.test.core.app.ApplicationProvider
+import androidx.test.platform.app.InstrumentationRegistry
+import `in`.jphe.storyvox.data.db.StoryvoxDatabase
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotNull
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+
+/**
+ * Issue #116 — verifies the v4 → v5 migration produces the same schema
+ * Room expects when we open a fresh v5 database, and that the new
+ * `fiction_shelf` table accepts roundtrips after the migration runs.
+ *
+ * `MigrationTestHelper` reads schema JSON from `core-data/schemas/` —
+ * exported by the Room compiler at every build, wired into the test
+ * classpath via `core-data/build.gradle.kts`.
+ */
+@RunWith(RobolectricTestRunner::class)
+@Config(manifest = Config.NONE)
+class Migration4to5Test {
+
+    private val testDbName = "shelves-migration-test"
+
+    @get:Rule
+    val helper: MigrationTestHelper = MigrationTestHelper(
+        InstrumentationRegistry.getInstrumentation(),
+        StoryvoxDatabase::class.java,
+        emptyList(),
+        FrameworkSQLiteOpenHelperFactory(),
+    )
+
+    @Test
+    fun migrate4to5_addsFictionShelfTable_andAcceptsRoundtrips() {
+        // Open v4 and seed a fiction row so the FK target exists when we
+        // insert the shelf row after the migration.
+        helper.createDatabase(testDbName, 4).use { db ->
+            db.execSQL(
+                """
+                INSERT INTO fiction (
+                    id, sourceId, title, author,
+                    firstSeenAt, metadataFetchedAt,
+                    inLibrary, followedRemotely,
+                    chapterCount, notesEverSeen,
+                    genres, tags, status
+                ) VALUES (
+                    'f1', 'royalroad', 'Sky Pride', 'Anonymous',
+                    0, 0,
+                    1, 0,
+                    0, 0,
+                    '', '', 'ONGOING'
+                )
+                """.trimIndent(),
+            )
+        }
+
+        // Run the migration, validating that Room's expected v5 schema matches.
+        val migrated = helper.runMigrationsAndValidate(testDbName, 5, true, MIGRATION_4_5)
+        migrated.use { db ->
+            db.execSQL(
+                "INSERT INTO fiction_shelf (fictionId, shelf, addedAt) VALUES ('f1', 'Reading', 123)",
+            )
+            db.query("SELECT fictionId, shelf, addedAt FROM fiction_shelf WHERE fictionId = 'f1'").use { c ->
+                assertNotNull(c)
+                assertEquals(true, c.moveToFirst())
+                assertEquals("f1", c.getString(0))
+                assertEquals("Reading", c.getString(1))
+                assertEquals(123L, c.getLong(2))
+            }
+        }
+    }
+
+    /**
+     * Sanity check that opening the real Room builder with the full
+     * migration array succeeds end-to-end after the v4→v5 step ran. This
+     * is the path the app actually takes on a first launch after upgrade.
+     */
+    @Test
+    fun openWithAllMigrations_afterUpgrade_succeeds() {
+        helper.createDatabase(testDbName, 4).close()
+
+        val db = Room.databaseBuilder(
+            ApplicationProvider.getApplicationContext(),
+            StoryvoxDatabase::class.java,
+            testDbName,
+        )
+            .addMigrations(*ALL_MIGRATIONS)
+            .build()
+        // Touching a DAO forces Room to actually open + validate the DB.
+        db.fictionShelfDao()
+        db.close()
+    }
+}

--- a/feature/src/main/kotlin/in/jphe/storyvox/feature/library/LibraryScreen.kt
+++ b/feature/src/main/kotlin/in/jphe/storyvox/feature/library/LibraryScreen.kt
@@ -1,6 +1,8 @@
 package `in`.jphe.storyvox.feature.library
 
+import androidx.compose.foundation.ExperimentalFoundationApi
 import androidx.compose.foundation.clickable
+import androidx.compose.foundation.combinedClickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -32,6 +34,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import `in`.jphe.storyvox.data.db.entity.Shelf
 import `in`.jphe.storyvox.data.repository.ContinueListeningEntry
 import `in`.jphe.storyvox.ui.component.BrassButton
 import `in`.jphe.storyvox.ui.component.BrassButtonVariant
@@ -44,7 +47,7 @@ import `in`.jphe.storyvox.ui.theme.LocalSpacing
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.ui.text.style.TextAlign
 
-@OptIn(ExperimentalMaterial3Api::class)
+@OptIn(ExperimentalMaterial3Api::class, ExperimentalFoundationApi::class)
 @Composable
 fun LibraryScreen(
     onOpenFiction: (String) -> Unit,
@@ -53,6 +56,7 @@ fun LibraryScreen(
 ) {
     val state by viewModel.uiState.collectAsStateWithLifecycle()
     val addByUrlState by viewModel.addByUrlState.collectAsStateWithLifecycle()
+    val manageShelvesState by viewModel.manageShelvesState.collectAsStateWithLifecycle()
     val spacing = LocalSpacing.current
 
     // #328 — dedupe defensively before the LazyVerticalGrid sees the list.
@@ -107,9 +111,25 @@ fun LibraryScreen(
             }
         },
     ) { scaffoldPadding ->
-        Box(modifier = Modifier.fillMaxSize().padding(scaffoldPadding).padding(top = spacing.md)) {
-            if (!state.isLoading && state.fictions.isEmpty() && state.resume == null) {
-                EmptyLibrary()
+        Column(modifier = Modifier.fillMaxSize().padding(scaffoldPadding).padding(top = spacing.md)) {
+            // Issue #116 — chip strip lives above the grid (and above
+            // the Resume card) so it's always reachable regardless of
+            // scroll. Selecting a chip swaps the underlying flow in the
+            // VM, which re-emits a filtered grid.
+            ShelfChipRow(
+                selected = state.filter,
+                onSelect = viewModel::selectFilter,
+            )
+
+            // Empty-state branch needs to know which chip we're on — the
+            // "library is empty" copy makes sense for All but reads as
+            // wrong on a shelf with zero pinned books.
+            val isEmpty = !state.isLoading && state.fictions.isEmpty() && state.resume == null
+            if (isEmpty) {
+                when (val f = state.filter) {
+                    ShelfFilter.All -> EmptyLibrary()
+                    is ShelfFilter.OneShelf -> EmptyShelf(f.shelf)
+                }
             } else {
                 LazyVerticalGrid(
                     columns = GridCells.Adaptive(minSize = 140.dp),
@@ -117,26 +137,32 @@ fun LibraryScreen(
                     horizontalArrangement = Arrangement.spacedBy(spacing.sm),
                     verticalArrangement = Arrangement.spacedBy(spacing.md),
                 ) {
-                    state.resume?.let { resume ->
-                        item(span = { androidx.compose.foundation.lazy.grid.GridItemSpan(maxLineSpan) }) {
-                            ResumeCard(resume, onResume = viewModel::resume)
-                        }
-                        // #265 — the Resume card used to sit one
-                        // `verticalArrangement.spacedBy(md)` gap above the
-                        // grid's first row, reading as another grid item
-                        // rather than a hero zone. The brass "Your library"
-                        // caption now labels the grid as a separate section.
-                        // Spacer + caption live in one full-span item so we
-                        // only pay one inter-row gap from the grid's
-                        // vertical arrangement (two items would double it).
-                        item(span = { androidx.compose.foundation.lazy.grid.GridItemSpan(maxLineSpan) }) {
-                            Column(modifier = Modifier.padding(top = spacing.xs)) {
-                                Text(
-                                    text = "Your library",
-                                    style = MaterialTheme.typography.labelLarge,
-                                    color = MaterialTheme.colorScheme.primary,
-                                    modifier = Modifier.padding(bottom = spacing.xxs),
-                                )
+                    // Hide the Resume card on shelf-filtered views — it's
+                    // a library-wide affordance, and surfacing it inside
+                    // a Wishlist filter (a book the user hasn't started)
+                    // is visually confusing.
+                    if (state.filter is ShelfFilter.All) {
+                        state.resume?.let { resume ->
+                            item(span = { androidx.compose.foundation.lazy.grid.GridItemSpan(maxLineSpan) }) {
+                                ResumeCard(resume, onResume = viewModel::resume)
+                            }
+                            // #265 — the Resume card used to sit one
+                            // `verticalArrangement.spacedBy(md)` gap above the
+                            // grid's first row, reading as another grid item
+                            // rather than a hero zone. The brass "Your library"
+                            // caption now labels the grid as a separate section.
+                            // Spacer + caption live in one full-span item so we
+                            // only pay one inter-row gap from the grid's
+                            // vertical arrangement (two items would double it).
+                            item(span = { androidx.compose.foundation.lazy.grid.GridItemSpan(maxLineSpan) }) {
+                                Column(modifier = Modifier.padding(top = spacing.xs)) {
+                                    Text(
+                                        text = "Your library",
+                                        style = MaterialTheme.typography.labelLarge,
+                                        color = MaterialTheme.colorScheme.primary,
+                                        modifier = Modifier.padding(bottom = spacing.xxs),
+                                    )
+                                }
                             }
                         }
                     }
@@ -153,9 +179,17 @@ fun LibraryScreen(
                                 coverUrl = fiction.coverUrl,
                                 title = fiction.title,
                                 monogram = fictionMonogram(fiction.author, fiction.title),
+                                // Long-press → manage-shelves bottom sheet
+                                // (issue #116). combinedClickable keeps
+                                // the tap-to-open path identical to
+                                // before; the long-press is an additive
+                                // overlay handler.
                                 modifier = Modifier
                                     .fillMaxWidth()
-                                    .clickable { viewModel.openFiction(fiction.id) },
+                                    .combinedClickable(
+                                        onClick = { viewModel.openFiction(fiction.id) },
+                                        onLongClick = { viewModel.openManageShelves(fiction) },
+                                    ),
                             )
                             Text(
                                 fiction.title,
@@ -181,6 +215,12 @@ fun LibraryScreen(
         state = addByUrlState,
         onSubmit = viewModel::submitAddByUrl,
         onDismiss = viewModel::dismissAddByUrl,
+    )
+
+    ManageShelvesSheet(
+        state = manageShelvesState,
+        onToggle = viewModel::toggleShelf,
+        onDismiss = viewModel::dismissManageShelves,
     )
 }
 
@@ -281,6 +321,43 @@ private fun EmptyLibrary() {
         Spacer(Modifier.height(spacing.xs))
         Text(
             "Browse Royal Road or paste a fiction URL with the + button to start collecting.",
+            style = MaterialTheme.typography.bodyMedium,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+            textAlign = TextAlign.Center,
+        )
+    }
+}
+
+/**
+ * Issue #116 — empty state per shelf. The library-wide [EmptyLibrary]
+ * doesn't fit here: the user *has* books in their library, they just
+ * haven't pinned any to this particular shelf. Same brass-realm rhythm
+ * as the rest of the empty-state vocabulary (sigil tile, titleMedium
+ * primary headline, bodyMedium body) so it reads as part of the family.
+ */
+@Composable
+private fun EmptyShelf(shelf: Shelf) {
+    val spacing = LocalSpacing.current
+    Column(
+        modifier = Modifier.fillMaxSize().padding(spacing.lg),
+        horizontalAlignment = Alignment.CenterHorizontally,
+        verticalArrangement = Arrangement.Center,
+    ) {
+        MagicSkeletonTile(
+            modifier = Modifier.size(width = 160.dp, height = 220.dp),
+            shape = MaterialTheme.shapes.medium,
+            glyphSize = 80.dp,
+        )
+        Spacer(Modifier.height(spacing.lg))
+        Text(
+            "Nothing on the ${shelf.displayName} shelf yet",
+            style = MaterialTheme.typography.titleMedium,
+            color = MaterialTheme.colorScheme.primary,
+            textAlign = TextAlign.Center,
+        )
+        Spacer(Modifier.height(spacing.xs))
+        Text(
+            "Long-press a book to add it.",
             style = MaterialTheme.typography.bodyMedium,
             color = MaterialTheme.colorScheme.onSurfaceVariant,
             textAlign = TextAlign.Center,

--- a/feature/src/main/kotlin/in/jphe/storyvox/feature/library/LibraryViewModel.kt
+++ b/feature/src/main/kotlin/in/jphe/storyvox/feature/library/LibraryViewModel.kt
@@ -4,9 +4,11 @@ import androidx.compose.runtime.Immutable
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import dagger.hilt.android.lifecycle.HiltViewModel
+import `in`.jphe.storyvox.data.db.entity.Shelf
 import `in`.jphe.storyvox.data.repository.ContinueListeningEntry
 import `in`.jphe.storyvox.data.repository.FictionRepository
 import `in`.jphe.storyvox.data.repository.PlaybackPositionRepository
+import `in`.jphe.storyvox.data.repository.ShelfRepository
 import `in`.jphe.storyvox.data.repository.playback.PlaybackResumePolicyConfig
 import `in`.jphe.storyvox.data.source.model.FictionSummary
 import `in`.jphe.storyvox.feature.api.DownloadMode
@@ -20,17 +22,46 @@ import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.combine
+import kotlinx.coroutines.flow.flatMapLatest
 import kotlinx.coroutines.flow.receiveAsFlow
 import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.launch
+
+/**
+ * Issue #116 — which row of the chip-filter strip is selected. `All` is
+ * the default (current behaviour pre-shelves); the three [Shelf] options
+ * filter the grid to fictions that sit on that shelf.
+ */
+@Immutable
+sealed interface ShelfFilter {
+    data object All : ShelfFilter
+    data class OneShelf(val shelf: Shelf) : ShelfFilter
+}
 
 @Immutable
 data class LibraryUiState(
     /** Topmost continue-listening entry — null until the user has played anything. */
     val resume: ContinueListeningEntry? = null,
     val fictions: List<FictionSummary> = emptyList(),
+    /** Currently-active chip — drives both the grid filter and which empty state shows. */
+    val filter: ShelfFilter = ShelfFilter.All,
     val isLoading: Boolean = true,
 )
+
+/**
+ * Long-press → manage-shelves bottom-sheet state. Tracks the fiction being
+ * managed plus the live set of shelves it currently sits on (kept in sync
+ * with the DB so toggling a switch updates immediately).
+ */
+@Immutable
+sealed interface ManageShelvesSheetState {
+    data object Hidden : ManageShelvesSheetState
+    data class Open(
+        val fictionId: String,
+        val fictionTitle: String,
+        val memberOf: Set<Shelf>,
+    ) : ManageShelvesSheetState
+}
 
 sealed interface LibraryUiEvent {
     data class OpenFiction(val fictionId: String) : LibraryUiEvent
@@ -51,9 +82,11 @@ sealed interface AddByUrlSheetState {
 }
 
 @HiltViewModel
+@OptIn(kotlinx.coroutines.ExperimentalCoroutinesApi::class)
 class LibraryViewModel @Inject constructor(
     fictionRepo: FictionRepository,
     positionRepo: PlaybackPositionRepository,
+    private val shelfRepo: ShelfRepository,
     private val uiRepo: FictionRepositoryUi,
     private val playback: PlaybackControllerUi,
     /** #90 — read the user's last play/pause intent to decide whether
@@ -67,16 +100,81 @@ class LibraryViewModel @Inject constructor(
     private val _addByUrlState = MutableStateFlow<AddByUrlSheetState>(AddByUrlSheetState.Hidden)
     val addByUrlState: StateFlow<AddByUrlSheetState> = _addByUrlState.asStateFlow()
 
+    private val _filter = MutableStateFlow<ShelfFilter>(ShelfFilter.All)
+
+    private val _manageShelves = MutableStateFlow<ManageShelvesSheetState>(ManageShelvesSheetState.Hidden)
+    val manageShelvesState: StateFlow<ManageShelvesSheetState> = _manageShelves.asStateFlow()
+
+    /**
+     * The fiction list flow swaps between the full library and a
+     * shelf-scoped flow depending on the active filter. flatMapLatest
+     * cancels the previous subscription so flipping chips doesn't pile
+     * up Room flows.
+     */
+    private val fictionsFlow = _filter.flatMapLatest { f ->
+        when (f) {
+            ShelfFilter.All -> fictionRepo.observeLibrary()
+            is ShelfFilter.OneShelf -> shelfRepo.observeByShelf(f.shelf)
+        }
+    }
+
     val uiState: StateFlow<LibraryUiState> = combine(
-        fictionRepo.observeLibrary(),
+        fictionsFlow,
         positionRepo.observeMostRecentContinueListening(),
-    ) { library, resume ->
+        _filter,
+    ) { library, resume, filter ->
         LibraryUiState(
             resume = resume,
             fictions = library,
+            filter = filter,
             isLoading = false,
         )
     }.stateIn(viewModelScope, SharingStarted.WhileSubscribed(5_000), LibraryUiState())
+
+    // ─── chips ────────────────────────────────────────────────────────────
+
+    /** Top-of-screen chip row taps. */
+    fun selectFilter(filter: ShelfFilter) {
+        _filter.value = filter
+    }
+
+    // ─── manage-shelves bottom sheet ──────────────────────────────────────
+
+    /** Long-press on a library card → open the manage-shelves sheet. */
+    fun openManageShelves(fiction: FictionSummary) {
+        viewModelScope.launch {
+            val current = shelfRepo.shelvesForFiction(fiction.id)
+            _manageShelves.value = ManageShelvesSheetState.Open(
+                fictionId = fiction.id,
+                fictionTitle = fiction.title,
+                memberOf = current,
+            )
+        }
+    }
+
+    fun dismissManageShelves() {
+        _manageShelves.value = ManageShelvesSheetState.Hidden
+    }
+
+    /** Flip a single shelf for the currently-managed fiction. */
+    fun toggleShelf(fictionId: String, shelf: Shelf) {
+        viewModelScope.launch {
+            shelfRepo.toggle(fictionId, shelf)
+            // Refresh the sheet's local cache of memberships so the toggle
+            // visibly settles. Re-reading from the DB after the write is
+            // the cheapest correctness — observeShelvesForFiction would
+            // also work but pulls the sheet into a flow lifecycle we don't
+            // need (it dismisses cleanly without lingering state).
+            val sheet = _manageShelves.value
+            if (sheet is ManageShelvesSheetState.Open && sheet.fictionId == fictionId) {
+                _manageShelves.value = sheet.copy(
+                    memberOf = shelfRepo.shelvesForFiction(fictionId),
+                )
+            }
+        }
+    }
+
+    // ─── existing surface (unchanged behaviour) ───────────────────────────
 
     fun openFiction(id: String) {
         viewModelScope.launch { _events.send(LibraryUiEvent.OpenFiction(id)) }

--- a/feature/src/main/kotlin/in/jphe/storyvox/feature/library/ManageShelvesSheet.kt
+++ b/feature/src/main/kotlin/in/jphe/storyvox/feature/library/ManageShelvesSheet.kt
@@ -1,0 +1,85 @@
+package `in`.jphe.storyvox.feature.library
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.ModalBottomSheet
+import androidx.compose.material3.Switch
+import androidx.compose.material3.Text
+import androidx.compose.material3.rememberModalBottomSheetState
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import `in`.jphe.storyvox.data.db.entity.Shelf
+import `in`.jphe.storyvox.ui.theme.LocalSpacing
+
+/**
+ * Issue #116 — bottom sheet opened by long-pressing a library card.
+ * One row per [Shelf] with a toggle; flipping a toggle calls
+ * [onToggle] which adds or removes the membership through
+ * [LibraryViewModel.toggleShelf].
+ *
+ * Display labels come from [Shelf.displayName] — the data-layer owns
+ * the user-facing strings so every shelf-aware surface shows the same
+ * word (chip row, sheet, future "where is this book?" hint).
+ */
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun ManageShelvesSheet(
+    state: ManageShelvesSheetState,
+    onToggle: (String, Shelf) -> Unit,
+    onDismiss: () -> Unit,
+) {
+    if (state !is ManageShelvesSheetState.Open) return
+    val sheetState = rememberModalBottomSheetState(skipPartiallyExpanded = true)
+    val spacing = LocalSpacing.current
+
+    ModalBottomSheet(
+        onDismissRequest = onDismiss,
+        sheetState = sheetState,
+        containerColor = MaterialTheme.colorScheme.surfaceContainerHigh,
+    ) {
+        Column(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(horizontal = spacing.lg, vertical = spacing.md),
+            verticalArrangement = Arrangement.spacedBy(spacing.sm),
+        ) {
+            Text(
+                text = "Manage shelves",
+                style = MaterialTheme.typography.titleMedium,
+                color = MaterialTheme.colorScheme.primary,
+            )
+            if (state.fictionTitle.isNotBlank()) {
+                Text(
+                    text = state.fictionTitle,
+                    style = MaterialTheme.typography.bodyMedium,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                )
+            }
+            Shelf.ALL.forEach { shelf ->
+                val isMember = shelf in state.memberOf
+                Row(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .padding(vertical = spacing.xs),
+                    verticalAlignment = Alignment.CenterVertically,
+                    horizontalArrangement = Arrangement.SpaceBetween,
+                ) {
+                    Text(
+                        text = shelf.displayName,
+                        style = MaterialTheme.typography.bodyLarge,
+                    )
+                    Switch(
+                        checked = isMember,
+                        onCheckedChange = { onToggle(state.fictionId, shelf) },
+                    )
+                }
+            }
+        }
+    }
+}

--- a/feature/src/main/kotlin/in/jphe/storyvox/feature/library/ShelfChipRow.kt
+++ b/feature/src/main/kotlin/in/jphe/storyvox/feature/library/ShelfChipRow.kt
@@ -1,0 +1,67 @@
+package `in`.jphe.storyvox.feature.library
+
+import androidx.compose.foundation.horizontalScroll
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.material3.FilterChip
+import androidx.compose.material3.FilterChipDefaults
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import `in`.jphe.storyvox.data.db.entity.Shelf
+import `in`.jphe.storyvox.ui.theme.LocalSpacing
+
+/**
+ * Issue #116 — chip strip above the library grid. Four chips: All
+ * (default) + the three predefined shelves. Tapping a chip filters the
+ * grid; All restores the un-filtered view.
+ *
+ * Horizontally scrollable to match the [VoiceLibraryScreen] chip row
+ * pattern — Flip3 portrait can fit all four today but new shelves in v2
+ * would otherwise force a layout rethink. Brass palette via
+ * `primaryContainer` for the selected state, same as the rest of
+ * Library Nocturne's chip surfaces.
+ */
+@Composable
+fun ShelfChipRow(
+    selected: ShelfFilter,
+    onSelect: (ShelfFilter) -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    val spacing = LocalSpacing.current
+    Row(
+        modifier = modifier
+            .fillMaxWidth()
+            .horizontalScroll(rememberScrollState())
+            .padding(horizontal = spacing.md, vertical = spacing.xxs),
+        horizontalArrangement = Arrangement.spacedBy(spacing.xs),
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        FilterChip(
+            selected = selected is ShelfFilter.All,
+            onClick = { onSelect(ShelfFilter.All) },
+            label = { Text("All") },
+            colors = brassFilterChipColors(),
+        )
+        Shelf.ALL.forEach { shelf ->
+            val isSelected = selected is ShelfFilter.OneShelf && selected.shelf == shelf
+            FilterChip(
+                selected = isSelected,
+                onClick = { onSelect(ShelfFilter.OneShelf(shelf)) },
+                label = { Text(shelf.displayName) },
+                colors = brassFilterChipColors(),
+            )
+        }
+    }
+}
+
+@Composable
+private fun brassFilterChipColors() = FilterChipDefaults.filterChipColors(
+    selectedContainerColor = MaterialTheme.colorScheme.primaryContainer,
+    selectedLabelColor = MaterialTheme.colorScheme.onPrimaryContainer,
+)


### PR DESCRIPTION
## Summary

Implements [#116](https://github.com/jphein/storyvox/issues/116) — predefined library shelves with multi-shelf membership, per JP's decision on the issue:

> Three built-in shelf names (Reading / Read / Wishlist), no user-defined custom shelves in v1, Goodreads-style multi-shelf membership.

### Data layer

- `Shelf` **enum** (not a Room entity, since the values are fixed). Display labels live on the enum so every shelf-aware surface shows the same word and v2 localisation has one attachment point.
- `FictionShelf` junction entity, PK `(fictionId, shelf)`, `ON DELETE CASCADE` on the fiction FK, `shelf` stored as the enum **name string** (matching the `provider` / `featureKind` pattern in `MIGRATION_2_3` — adding a fourth shelf in v2 needs no further migration).
- `FictionShelfDao` — `observeByShelf` joins `fiction.inLibrary = 1` so un-libraried rows can't haunt chip results. Insert uses `REPLACE` for idempotent toggles.
- `ShelfRepository` interface + Hilt binding in `DataModule`.
- Room **migration 4 → 5** + new `schemas/.../5.json`. App version bumped `4 → 5`.

### UI layer

- `ShelfChipRow` — four `FilterChip`s above the grid: **All** (default) / **Reading** / **Read** / **Wishlist**. Brass `primaryContainer` for the selected state, horizontally scrollable.
- `ManageShelvesSheet` — long-press on a library card → bottom sheet with one `Switch` per shelf. Idempotent toggles via `ShelfRepository.toggle`.
- `LibraryViewModel` — new `filter` state, `flatMapLatest` over the fictions flow; resume card hidden on shelf-filtered views.
- Per-shelf empty state: *"Nothing on the Reading shelf yet — long-press a book to add."*

Scope kept tight in `LibraryScreen.kt` (chip row + long-press + grid filter + empty-shelf state only) per the orchestrator's heads-up about #158 also touching this file.

## Test plan

- [x] `:core-data:compileDebugKotlin` clean
- [x] `:core-data:testDebugUnitTest` — 113 tests pass, including new `Migration4to5Test` (Robolectric `MigrationTestHelper`) and `FictionShelfDaoTest` (roundtrip + CASCADE + un-library filter + clearForFiction)
- [x] `:feature:compileDebugKotlin` + `:feature:testDebugUnitTest` clean
- [x] `:app:assembleDebug` clean
- [x] Installed on R5CRB0W66MK — migration 4→5 ran without data loss, app foregrounded cleanly (logcat clean)
- [ ] Manual: long-press a library card → manage-shelves sheet opens; toggle Reading → chip filter shows only that book; toggle off All → returns to full library
- [ ] Manual: empty-shelf copy renders correctly when zero books pinned
- [ ] Copilot review

Out of scope (follow-up PRs): per-shelf sort order, auto-shelves ("Started but not finished"), user-defined custom shelves, InstantDB sync.

Closes #116

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>