### PR TITLE
feat(library): reading history sub-tab — closes #158

### DIFF
--- a/core-data/build.gradle.kts
+++ b/core-data/build.gradle.kts
@@ -38,18 +38,20 @@ android {
         getByName("main") {
             java.srcDirs("src/main/kotlin")
         }
-    }
-
-    // Robolectric-backed unit tests need the exported Room schemas on the
-    // assets path so `MigrationTestHelper` can resolve them. The schemas
-    // are exported by KSP at `core-data/schemas/`.
-    sourceSets {
+        // Room's MigrationTestHelper needs the schema JSONs visible
+        // on the test classpath so it can reconstruct the prior-version
+        // databases. Without this entry it fails with
+        // "Cannot find the schema file in the assets folder."
+        getByName("test") {
+            assets.srcDirs(files("$projectDir/schemas"))
+        }
         getByName("androidTest").assets.srcDirs("$projectDir/schemas")
-        getByName("test").assets.srcDirs("$projectDir/schemas")
     }
 
     testOptions {
         unitTests {
+            // Robolectric needs Android resources on the unit-test classpath
+            // so MigrationTestHelper can spin up a real SQLiteOpenHelper.
             isIncludeAndroidResources = true
         }
     }
@@ -89,8 +91,8 @@ dependencies {
     // Test
     testImplementation(libs.junit)
     testImplementation(libs.kotlinx.coroutines.test)
+    testImplementation(libs.androidx.room.testing)
     testImplementation(libs.robolectric)
-    testImplementation("androidx.room:room-testing:2.6.1")
     testImplementation("androidx.test:core:1.6.1")
     testImplementation("androidx.test.ext:junit:1.2.1")
 }

--- a/core-data/src/main/kotlin/in/jphe/storyvox/data/db/StoryvoxDatabase.kt
+++ b/core-data/src/main/kotlin/in/jphe/storyvox/data/db/StoryvoxDatabase.kt
@@ -6,6 +6,7 @@ import androidx.room.TypeConverters
 import `in`.jphe.storyvox.data.db.converter.Converters
 import `in`.jphe.storyvox.data.db.dao.AuthDao
 import `in`.jphe.storyvox.data.db.dao.ChapterDao
+import `in`.jphe.storyvox.data.db.dao.ChapterHistoryDao
 import `in`.jphe.storyvox.data.db.dao.FictionDao
 import `in`.jphe.storyvox.data.db.dao.FictionShelfDao
 import `in`.jphe.storyvox.data.db.dao.LlmMessageDao
@@ -13,6 +14,7 @@ import `in`.jphe.storyvox.data.db.dao.LlmSessionDao
 import `in`.jphe.storyvox.data.db.dao.PlaybackDao
 import `in`.jphe.storyvox.data.db.entity.AuthCookie
 import `in`.jphe.storyvox.data.db.entity.Chapter
+import `in`.jphe.storyvox.data.db.entity.ChapterHistory
 import `in`.jphe.storyvox.data.db.entity.Fiction
 import `in`.jphe.storyvox.data.db.entity.FictionShelf
 import `in`.jphe.storyvox.data.db.entity.LlmSession
@@ -30,14 +32,18 @@ import `in`.jphe.storyvox.data.db.entity.PlaybackPosition
         LlmStoredMessage::class,
         // v5 (#116 library shelves) — many-to-many junction.
         FictionShelf::class,
+        // v6 (#158 reading history) — one row per (fiction, chapter)
+        // pair, upserted on every open. Forever retention.
+        ChapterHistory::class,
     ],
-    version = 5,
+    version = 6,
     exportSchema = true,
 )
 @TypeConverters(Converters::class)
 abstract class StoryvoxDatabase : RoomDatabase() {
     abstract fun fictionDao(): FictionDao
     abstract fun chapterDao(): ChapterDao
+    abstract fun chapterHistoryDao(): ChapterHistoryDao
     abstract fun playbackDao(): PlaybackDao
     abstract fun authDao(): AuthDao
     abstract fun llmSessionDao(): LlmSessionDao

--- a/core-data/src/main/kotlin/in/jphe/storyvox/data/db/dao/ChapterHistoryDao.kt
+++ b/core-data/src/main/kotlin/in/jphe/storyvox/data/db/dao/ChapterHistoryDao.kt
@@ -1,0 +1,135 @@
+package `in`.jphe.storyvox.data.db.dao
+
+import androidx.room.Dao
+import androidx.room.Query
+import androidx.room.Upsert
+import `in`.jphe.storyvox.data.db.entity.ChapterHistory
+import kotlinx.coroutines.flow.Flow
+
+/**
+ * Issue #158 — reading-history DAO.
+ *
+ * The `observeAll` / `observeForFiction` feeds project a denormalized join
+ * over `fiction` + `chapter` directly into [ChapterHistoryRow] so the UI
+ * never has to fan out follow-up lookups (mirrors the
+ * [PlaybackDao.observeMostRecentContinueListening] pattern in the same
+ * package). We deliberately skip the multi-MB `chapter.plainBody` / `htmlBody`
+ * columns — the History row only needs titles, the cover URL, and chapter
+ * index, all small fields. Same disk-I/O reasoning as [ChapterDao]'s
+ * `ChapterInfoRow` projection.
+ *
+ * No `LIMIT` on `observeAll` because the Library History tab is a
+ * scrollable LazyColumn — Compose's lazy layout already windows the render.
+ * If feeds get huge (10k+ rows) we can add `LIMIT` + paging later; for now
+ * the simpler API beats premature pagination.
+ */
+@Dao
+interface ChapterHistoryDao {
+
+    /**
+     * All history rows across every fiction, most-recent-open first. Powers
+     * the Library "History" sub-tab. Joins back through `fiction` + `chapter`
+     * to bring in display fields; if either parent row is gone the LEFT JOIN
+     * still emits the row with nulls — but FK cascade should make that
+     * unreachable in practice.
+     */
+    @Query(
+        """
+        SELECT
+            h.fictionId     AS fictionId,
+            h.chapterId     AS chapterId,
+            h.openedAt      AS openedAt,
+            h.completed     AS completed,
+            h.fractionRead  AS fractionRead,
+            f.title         AS fictionTitle,
+            f.author        AS fictionAuthor,
+            f.coverUrl      AS coverUrl,
+            c.title         AS chapterTitle,
+            c.`index`       AS chapterIndex
+          FROM chapter_history h
+          LEFT JOIN fiction f ON f.id = h.fictionId
+          LEFT JOIN chapter c ON c.id = h.chapterId
+         ORDER BY h.openedAt DESC
+        """,
+    )
+    fun observeAll(): Flow<List<ChapterHistoryRow>>
+
+    /**
+     * Per-fiction history (deferred FictionDetail surface in #158 — wired
+     * up here so the repo can expose it without another schema change
+     * later). Same join shape as [observeAll] so the UI can share a row
+     * composable.
+     */
+    @Query(
+        """
+        SELECT
+            h.fictionId     AS fictionId,
+            h.chapterId     AS chapterId,
+            h.openedAt      AS openedAt,
+            h.completed     AS completed,
+            h.fractionRead  AS fractionRead,
+            f.title         AS fictionTitle,
+            f.author        AS fictionAuthor,
+            f.coverUrl      AS coverUrl,
+            c.title         AS chapterTitle,
+            c.`index`       AS chapterIndex
+          FROM chapter_history h
+          LEFT JOIN fiction f ON f.id = h.fictionId
+          LEFT JOIN chapter c ON c.id = h.chapterId
+         WHERE h.fictionId = :fictionId
+         ORDER BY h.openedAt DESC
+        """,
+    )
+    fun observeForFiction(fictionId: String): Flow<List<ChapterHistoryRow>>
+
+    /** One-row lookup used by the repository's `logOpen` to preserve `completed`/`fractionRead` on re-open. */
+    @Query("SELECT * FROM chapter_history WHERE fictionId = :fictionId AND chapterId = :chapterId")
+    suspend fun get(fictionId: String, chapterId: String): ChapterHistory?
+
+    @Upsert
+    suspend fun upsert(row: ChapterHistory)
+
+    /**
+     * Mark a chapter as completed. We use a direct UPDATE rather than a
+     * read-modify-write so the end-of-chapter path (which races with the
+     * `logOpen` upsert from `loadAndPlay`) stays atomic. The COALESCE on
+     * `fractionRead` lets callers pass null to "leave the existing value
+     * alone" — e.g. when end-of-chapter fires without a fresh measure.
+     */
+    @Query(
+        """
+        UPDATE chapter_history
+           SET completed = 1,
+               fractionRead = COALESCE(:fraction, fractionRead),
+               openedAt = :now
+         WHERE fictionId = :fictionId AND chapterId = :chapterId
+        """,
+    )
+    suspend fun markCompleted(fictionId: String, chapterId: String, fraction: Float?, now: Long)
+}
+
+/**
+ * Denormalized history row — fiction + chapter columns inlined so the
+ * Library History list can render straight off a single SQL feed without
+ * follow-up lookups. Mirrors [ContinueListeningRow]'s shape on the
+ * playback DAO; we keep the column names un-prefixed here because the
+ * row isn't reconstructing a public [FictionSummary] (that lives in the
+ * repository projection layer).
+ *
+ * `fictionTitle` / `chapterTitle` / `coverUrl` may be null if the parent
+ * rows got cascade-deleted between the history write and a UI emission —
+ * the row composable should treat them as "(unknown)" / a fallback monogram
+ * rather than crashing.
+ */
+data class ChapterHistoryRow(
+    val fictionId: String,
+    val chapterId: String,
+    val openedAt: Long,
+    val completed: Boolean,
+    val fractionRead: Float?,
+    val fictionTitle: String?,
+    val fictionAuthor: String?,
+    val coverUrl: String?,
+    val chapterTitle: String?,
+    val chapterIndex: Int?,
+)

--- a/core-data/src/main/kotlin/in/jphe/storyvox/data/db/entity/ChapterHistory.kt
+++ b/core-data/src/main/kotlin/in/jphe/storyvox/data/db/entity/ChapterHistory.kt
@@ -1,0 +1,70 @@
+package `in`.jphe.storyvox.data.db.entity
+
+import androidx.room.Entity
+import androidx.room.ForeignKey
+import androidx.room.Index
+
+/**
+ * Issue #158 — reading-history breadcrumb. One row per `(fictionId, chapterId)`
+ * pair, upserted on every chapter open. Powers the Library "History" sub-tab
+ * (chronological, most-recent-first, all fictions interleaved).
+ *
+ * Why composite PK (not append-only):
+ *  - JP's product call: "forever retention" but a single row per chapter, so
+ *    re-opening the same chapter twenty times doesn't blow up the table or the
+ *    History list with duplicate "Ch. 1" entries. We update `openedAt` in
+ *    place — the row is the *last-open* timestamp, not an audit log.
+ *  - O(library) bound on storage instead of O(opens). For a long-running
+ *    listener with 50 fictions × 500 chapters that's 25k rows worst case,
+ *    well within Room's sweet spot.
+ *
+ * Index on [openedAt] makes the History feed query `ORDER BY openedAt DESC`
+ * cheap — that's the only sort the UI uses.
+ *
+ * Cascading deletes on both parent tables: removing a fiction (or its
+ * chapters) from the library shouldn't leave dangling history rows pointing
+ * at gone metadata. The Library History tab joins back through fiction +
+ * chapter for display data anyway, so an orphan would just render blank.
+ */
+@Entity(
+    tableName = "chapter_history",
+    primaryKeys = ["fictionId", "chapterId"],
+    foreignKeys = [
+        ForeignKey(
+            entity = Fiction::class,
+            parentColumns = ["id"],
+            childColumns = ["fictionId"],
+            onDelete = ForeignKey.CASCADE,
+        ),
+        ForeignKey(
+            entity = Chapter::class,
+            parentColumns = ["id"],
+            childColumns = ["chapterId"],
+            onDelete = ForeignKey.CASCADE,
+        ),
+    ],
+    indices = [
+        Index(value = ["openedAt"]),
+        // Room requires an index on the child side of any FK whose parent
+        // column isn't the leading edge of the PK — without this Room
+        // emits a warning ("missing index on chapterId"). Composite PK
+        // covers fictionId via its leading position; chapterId needs its
+        // own index for the cascade-delete planner to find rows fast.
+        Index(value = ["chapterId"]),
+    ],
+)
+data class ChapterHistory(
+    val fictionId: String,
+    val chapterId: String,
+    /** Epoch millis of the most recent open. Updated in place on re-open. */
+    val openedAt: Long,
+    /** True once the user has finished the chapter (end-of-chapter event). */
+    val completed: Boolean = false,
+    /**
+     * Optional fraction-read snapshot at the most recent open/completion
+     * (0.0..1.0). Null when we don't have a reliable measure yet — kept
+     * forward-compatible so a future progress-tracker can populate it
+     * without another migration.
+     */
+    val fractionRead: Float? = null,
+)

--- a/core-data/src/main/kotlin/in/jphe/storyvox/data/db/migration/Migrations.kt
+++ b/core-data/src/main/kotlin/in/jphe/storyvox/data/db/migration/Migrations.kt
@@ -116,9 +116,55 @@ val MIGRATION_4_5: Migration = object : Migration(4, 5) {
     }
 }
 
+/**
+ * v6 — issue #158: chapter_history table backing the Library "History"
+ * sub-tab. Single CREATE TABLE + two indexes (openedAt for the ordering
+ * the History feed uses, chapterId for the FK cascade-delete planner).
+ * Purely additive — no existing data touched.
+ *
+ * The composite PK + UPSERT semantics mean re-opening the same chapter
+ * twenty times produces one row, not twenty audit entries — see the
+ * kdoc on [`in`.jphe.storyvox.data.db.entity.ChapterHistory] for the
+ * product call.
+ *
+ * Originally authored as MIGRATION_4_5 against pre-shelves main;
+ * renumbered to 5→6 at merge time because #116 (shelves) landed first
+ * and claimed the v5 slot. SQL is unchanged — chapter_history doesn't
+ * touch any shelves columns, so ordering is independent.
+ */
+val MIGRATION_5_6: Migration = object : Migration(5, 6) {
+    override fun migrate(db: SupportSQLiteDatabase) {
+        db.execSQL(
+            """
+            CREATE TABLE IF NOT EXISTS `chapter_history` (
+                `fictionId` TEXT NOT NULL,
+                `chapterId` TEXT NOT NULL,
+                `openedAt` INTEGER NOT NULL,
+                `completed` INTEGER NOT NULL DEFAULT 0,
+                `fractionRead` REAL,
+                PRIMARY KEY(`fictionId`, `chapterId`),
+                FOREIGN KEY(`fictionId`) REFERENCES `fiction`(`id`)
+                  ON UPDATE NO ACTION ON DELETE CASCADE,
+                FOREIGN KEY(`chapterId`) REFERENCES `chapter`(`id`)
+                  ON UPDATE NO ACTION ON DELETE CASCADE
+            )
+            """.trimIndent(),
+        )
+        db.execSQL(
+            "CREATE INDEX IF NOT EXISTS `index_chapter_history_openedAt` " +
+                "ON `chapter_history` (`openedAt`)",
+        )
+        db.execSQL(
+            "CREATE INDEX IF NOT EXISTS `index_chapter_history_chapterId` " +
+                "ON `chapter_history` (`chapterId`)",
+        )
+    }
+}
+
 val ALL_MIGRATIONS: Array<Migration> = arrayOf(
     MIGRATION_1_2,
     MIGRATION_2_3,
     MIGRATION_3_4,
     MIGRATION_4_5,
+    MIGRATION_5_6,
 )

--- a/core-data/src/main/kotlin/in/jphe/storyvox/data/di/DataModule.kt
+++ b/core-data/src/main/kotlin/in/jphe/storyvox/data/di/DataModule.kt
@@ -14,6 +14,7 @@ import dagger.hilt.components.SingletonComponent
 import `in`.jphe.storyvox.data.db.StoryvoxDatabase
 import `in`.jphe.storyvox.data.db.dao.AuthDao
 import `in`.jphe.storyvox.data.db.dao.ChapterDao
+import `in`.jphe.storyvox.data.db.dao.ChapterHistoryDao
 import `in`.jphe.storyvox.data.db.dao.FictionDao
 import `in`.jphe.storyvox.data.db.dao.FictionShelfDao
 import `in`.jphe.storyvox.data.db.dao.LlmMessageDao
@@ -29,6 +30,8 @@ import `in`.jphe.storyvox.data.repository.FictionRepository
 import `in`.jphe.storyvox.data.repository.FictionRepositoryImpl
 import `in`.jphe.storyvox.data.repository.FollowsRepository
 import `in`.jphe.storyvox.data.repository.FollowsRepositoryImpl
+import `in`.jphe.storyvox.data.repository.HistoryRepository
+import `in`.jphe.storyvox.data.repository.HistoryRepositoryImpl
 import `in`.jphe.storyvox.data.repository.LibraryRepository
 import `in`.jphe.storyvox.data.repository.LibraryRepositoryImpl
 import `in`.jphe.storyvox.data.repository.PlaybackPositionRepository
@@ -57,6 +60,7 @@ object DataModule {
 
     @Provides fun fictionDao(db: StoryvoxDatabase): FictionDao = db.fictionDao()
     @Provides fun chapterDao(db: StoryvoxDatabase): ChapterDao = db.chapterDao()
+    @Provides fun chapterHistoryDao(db: StoryvoxDatabase): ChapterHistoryDao = db.chapterHistoryDao()
     @Provides fun playbackDao(db: StoryvoxDatabase): PlaybackDao = db.playbackDao()
     @Provides fun authDao(db: StoryvoxDatabase): AuthDao = db.authDao()
     @Provides fun llmSessionDao(db: StoryvoxDatabase): LlmSessionDao = db.llmSessionDao()
@@ -105,6 +109,9 @@ abstract class RepositoryBindings {
 
     @Binds @Singleton
     abstract fun bindShelfRepository(impl: ShelfRepositoryImpl): ShelfRepository
+
+    @Binds @Singleton
+    abstract fun bindHistoryRepository(impl: HistoryRepositoryImpl): HistoryRepository
 
     @Binds @Singleton
     abstract fun bindChapterDownloadScheduler(

--- a/core-data/src/main/kotlin/in/jphe/storyvox/data/repository/HistoryRepository.kt
+++ b/core-data/src/main/kotlin/in/jphe/storyvox/data/repository/HistoryRepository.kt
@@ -1,0 +1,123 @@
+package `in`.jphe.storyvox.data.repository
+
+import `in`.jphe.storyvox.data.db.dao.ChapterHistoryDao
+import `in`.jphe.storyvox.data.db.dao.ChapterHistoryRow
+import `in`.jphe.storyvox.data.db.entity.ChapterHistory
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.map
+import javax.inject.Inject
+import javax.inject.Singleton
+
+/**
+ * Issue #158 — reading-history surface.
+ *
+ * Two-method write API (`logOpen`, `markCompleted`) so the playback layer
+ * doesn't have to know about Room entities or `openedAt` epoch semantics.
+ * Read API exposes denormalized [HistoryEntry]s the UI can render directly
+ * — same projection-layer pattern as [PlaybackPositionRepository]'s
+ * `ContinueListeningEntry`.
+ */
+interface HistoryRepository {
+
+    /** All history rows across every fiction, most-recent open first. */
+    fun observeAll(): Flow<List<HistoryEntry>>
+
+    /** Per-fiction history (deferred UI in #158 — wired here for the future FictionDetail surface). */
+    fun observeForFiction(fictionId: String): Flow<List<HistoryEntry>>
+
+    /**
+     * Stamp a (fiction, chapter) open. Upserts so re-opens update
+     * `openedAt` in place. Preserves any existing `completed` /
+     * `fractionRead` so the end-of-chapter [markCompleted] write isn't
+     * clobbered by a subsequent re-open before the user actually reads
+     * the chapter again.
+     */
+    suspend fun logOpen(fictionId: String, chapterId: String)
+
+    /**
+     * End-of-chapter event. Sets `completed = true` and optionally a
+     * `fractionRead` snapshot. Idempotent — calling twice doesn't double-
+     * count anything.
+     */
+    suspend fun markCompleted(fictionId: String, chapterId: String, fraction: Float? = null)
+}
+
+/**
+ * Public projection of one history row. Fiction/chapter title may be null
+ * if the parent rows were cascade-deleted between the write and the read
+ * (race window is tiny but FK CASCADE means it's possible). The UI is
+ * expected to render a sigil-monogram fallback in that case — see
+ * `fictionMonogram` in core-ui.
+ */
+data class HistoryEntry(
+    val fictionId: String,
+    val chapterId: String,
+    val openedAt: Long,
+    val completed: Boolean,
+    val fractionRead: Float?,
+    val fictionTitle: String?,
+    val fictionAuthor: String?,
+    val coverUrl: String?,
+    val chapterTitle: String?,
+    val chapterIndex: Int?,
+)
+
+@Singleton
+class HistoryRepositoryImpl @Inject constructor(
+    private val dao: ChapterHistoryDao,
+) : HistoryRepository {
+
+    override fun observeAll(): Flow<List<HistoryEntry>> =
+        dao.observeAll().map { rows -> rows.map(ChapterHistoryRow::toEntry) }
+
+    override fun observeForFiction(fictionId: String): Flow<List<HistoryEntry>> =
+        dao.observeForFiction(fictionId).map { rows -> rows.map(ChapterHistoryRow::toEntry) }
+
+    override suspend fun logOpen(fictionId: String, chapterId: String) {
+        // Read-then-upsert so we preserve the existing completed /
+        // fractionRead — a fresh open after the user finished a chapter
+        // should keep `completed = true`. The window between get + upsert
+        // is single-coroutine-scoped (callers always invoke from the
+        // playback Main-dispatcher coroutine), so racing writes from a
+        // second coroutine aren't a concern in practice. If that
+        // assumption ever breaks the right fix is a SQL `INSERT ...
+        // ON CONFLICT DO UPDATE` with COALESCE — not adding a mutex.
+        val existing = dao.get(fictionId, chapterId)
+        dao.upsert(
+            ChapterHistory(
+                fictionId = fictionId,
+                chapterId = chapterId,
+                openedAt = System.currentTimeMillis(),
+                completed = existing?.completed ?: false,
+                fractionRead = existing?.fractionRead,
+            ),
+        )
+    }
+
+    override suspend fun markCompleted(
+        fictionId: String,
+        chapterId: String,
+        fraction: Float?,
+    ) {
+        // No-op if there's no history row yet — the SQL UPDATE is a no-op
+        // matching zero rows. That's the desired behaviour: a chapter the
+        // user never opened via the player can't be "completed". The
+        // playback layer always calls logOpen first inside loadAndPlay
+        // (see EnginePlayer), so this should be unreachable in normal use,
+        // but the guard keeps it idempotent.
+        dao.markCompleted(fictionId, chapterId, fraction, System.currentTimeMillis())
+    }
+}
+
+private fun ChapterHistoryRow.toEntry(): HistoryEntry = HistoryEntry(
+    fictionId = fictionId,
+    chapterId = chapterId,
+    openedAt = openedAt,
+    completed = completed,
+    fractionRead = fractionRead,
+    fictionTitle = fictionTitle,
+    fictionAuthor = fictionAuthor,
+    coverUrl = coverUrl,
+    chapterTitle = chapterTitle,
+    chapterIndex = chapterIndex,
+)

--- a/core-data/src/test/kotlin/in/jphe/storyvox/data/db/StoryvoxDatabaseMigrationTest.kt
+++ b/core-data/src/test/kotlin/in/jphe/storyvox/data/db/StoryvoxDatabaseMigrationTest.kt
@@ -1,0 +1,167 @@
+package `in`.jphe.storyvox.data.db
+
+import android.app.Instrumentation
+import androidx.room.Room
+import androidx.room.testing.MigrationTestHelper
+import androidx.sqlite.db.framework.FrameworkSQLiteOpenHelperFactory
+import `in`.jphe.storyvox.data.db.migration.MIGRATION_4_5
+import `in`.jphe.storyvox.data.db.migration.MIGRATION_5_6
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertTrue
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+
+/**
+ * Issue #158 — schema migration coverage for v5 → v6 (chapter_history).
+ *
+ * Originally authored as v4→v5 against pre-shelves main; renumbered to
+ * v5→v6 at merge time when #116 (shelves) claimed v5 first. Coverage and
+ * assertions are unchanged — chapter_history doesn't touch shelves
+ * tables, so the migration is independent.
+ *
+ * Patterned after the Robolectric usage in
+ * `app/src/test/.../StoryvoxRoutesTest.kt`. We avoid the default Hilt
+ * application via `@Config(application = Application::class)` —
+ * MigrationTestHelper only needs a Context for the temp database dir,
+ * not a real DI graph.
+ *
+ * What this test pins:
+ *   1. The 5→6 migration applies without error against the v5 schema
+ *      snapshot (`schemas/in.jphe.storyvox.data.db.StoryvoxDatabase/5.json`).
+ *      That alone catches a malformed CREATE TABLE / missing FK column.
+ *   2. The post-migration table exists with the expected structure
+ *      (PK on (fictionId, chapterId), an index on openedAt).
+ *   3. Inserting + selecting a row round-trips, proving the table is
+ *      writable and the PK definition matches the entity.
+ *
+ * The Room runtime also performs an automatic identity-hash check on
+ * open: if the generated v6 schema (`6.json`) doesn't match what the
+ * migration produces, opening the migrated DB through Room throws
+ * `IllegalStateException: Migration didn't properly handle...`. The
+ * test triggers that path explicitly via `runMigrationsAndValidate`.
+ */
+@RunWith(RobolectricTestRunner::class)
+@org.robolectric.annotation.Config(application = android.app.Application::class)
+class StoryvoxDatabaseMigrationTest {
+
+    private val robolectricInstrumentation: Instrumentation =
+        object : Instrumentation() {
+            override fun getTargetContext(): android.content.Context =
+                org.robolectric.RuntimeEnvironment.getApplication()
+            override fun getContext(): android.content.Context =
+                org.robolectric.RuntimeEnvironment.getApplication()
+        }
+
+    @get:Rule
+    val helper: MigrationTestHelper = MigrationTestHelper(
+        robolectricInstrumentation,
+        StoryvoxDatabase::class.java,
+        emptyList(),
+        FrameworkSQLiteOpenHelperFactory(),
+    )
+
+    @Test fun `migrate v5 to v6 creates chapter_history table`() {
+        val dbName = "history-migration-test.db"
+
+        // Start at v5 — the shelves migration has already run, so the
+        // v5 schema is the "real" pre-history baseline. Bring the DB up
+        // to v5 first via the chain, then exercise 5→6 on top.
+        helper.createDatabase(dbName, 4).close()
+        helper.runMigrationsAndValidate(dbName, 5, true, MIGRATION_4_5).close()
+
+        val db = helper.runMigrationsAndValidate(
+            dbName,
+            6,
+            /* validateDroppedTables = */ true,
+            MIGRATION_5_6,
+        )
+
+        db.query(
+            "SELECT name FROM sqlite_master WHERE type='table' AND name='chapter_history'",
+        ).use { c ->
+            assertTrue("chapter_history table must exist post-migration", c.moveToFirst())
+        }
+
+        db.query(
+            "SELECT name FROM sqlite_master WHERE type='index' AND tbl_name='chapter_history'",
+        ).use { c ->
+            val indexes = mutableListOf<String>()
+            while (c.moveToNext()) indexes += c.getString(0)
+            assertTrue(
+                "index_chapter_history_openedAt must exist (sort feed)",
+                indexes.any { it == "index_chapter_history_openedAt" },
+            )
+            assertTrue(
+                "index_chapter_history_chapterId must exist (FK cascade planner)",
+                indexes.any { it == "index_chapter_history_chapterId" },
+            )
+        }
+
+        db.close()
+    }
+
+    @Test fun `migrated v6 db round-trips a chapter_history row`() {
+        val dbName = "history-roundtrip-test.db"
+        helper.createDatabase(dbName, 4).close()
+        helper.runMigrationsAndValidate(dbName, 5, true, MIGRATION_4_5).close()
+        helper.runMigrationsAndValidate(dbName, 6, true, MIGRATION_5_6).close()
+
+        val ctx = org.robolectric.RuntimeEnvironment.getApplication() as android.content.Context
+        val db = Room.databaseBuilder(ctx, StoryvoxDatabase::class.java, dbName)
+            .addMigrations(MIGRATION_4_5, MIGRATION_5_6)
+            .build()
+
+        try {
+            db.openHelper.writableDatabase.execSQL(
+                """
+                INSERT INTO fiction(
+                    id, sourceId, title, author, genres, tags, status,
+                    chapterCount, firstSeenAt, metadataFetchedAt,
+                    inLibrary, followedRemotely, notesEverSeen
+                ) VALUES (
+                    'rr:42', 'royalroad', 'Mother of Learning', 'nobody103',
+                    '[]', '[]', 'ONGOING', 0, 0, 0, 0, 0, 0
+                )
+                """.trimIndent(),
+            )
+            db.openHelper.writableDatabase.execSQL(
+                """
+                INSERT INTO chapter(
+                    id, fictionId, sourceChapterId, `index`, title,
+                    downloadState, userMarkedRead
+                ) VALUES (
+                    'rr:42:0', 'rr:42', '0', 0, 'Good Morning Brother',
+                    'NOT_DOWNLOADED', 0
+                )
+                """.trimIndent(),
+            )
+            db.openHelper.writableDatabase.execSQL(
+                "INSERT INTO chapter_history(fictionId, chapterId, openedAt, completed) " +
+                    "VALUES ('rr:42', 'rr:42:0', 1234, 0)",
+            )
+
+            db.openHelper.readableDatabase.query(
+                "SELECT fictionId, chapterId, openedAt, completed, fractionRead " +
+                    "FROM chapter_history",
+            ).use { c ->
+                assertTrue(c.moveToFirst())
+                assertEquals("rr:42", c.getString(0))
+                assertEquals("rr:42:0", c.getString(1))
+                assertEquals(1234L, c.getLong(2))
+                assertEquals(0, c.getInt(3))
+                assertEquals(
+                    "fractionRead defaults to NULL when omitted",
+                    true,
+                    c.isNull(4),
+                )
+            }
+        } finally {
+            db.close()
+        }
+
+        assertNotNull("smoke-only sentinel — kept to fail-fast if the try block was no-op'd", helper)
+    }
+}

--- a/core-data/src/test/kotlin/in/jphe/storyvox/data/repository/HistoryRepositoryImplTest.kt
+++ b/core-data/src/test/kotlin/in/jphe/storyvox/data/repository/HistoryRepositoryImplTest.kt
@@ -1,0 +1,246 @@
+package `in`.jphe.storyvox.data.repository
+
+import `in`.jphe.storyvox.data.db.dao.ChapterHistoryDao
+import `in`.jphe.storyvox.data.db.dao.ChapterHistoryRow
+import `in`.jphe.storyvox.data.db.entity.ChapterHistory
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * Issue #158 — repository-level coverage for the reading-history surface.
+ *
+ * The DAO is faked (same pattern as [ChapterRepositoryImplTest]) so these
+ * tests run on plain JVM without Robolectric or an emulator. The fake
+ * mirrors the production SQL invariants we actually depend on:
+ *   - upsert by composite (fictionId, chapterId)
+ *   - ORDER BY openedAt DESC on observeAll / observeForFiction
+ *   - markCompleted as an atomic UPDATE that preserves prior state
+ *     when called against a row that doesn't exist yet (no-op).
+ *
+ * The Room-generated SQL is exercised by the schema-export step on
+ * every build (KSP would fail KSP if the query was malformed); the
+ * tests here cover repository semantics (read-then-upsert preserving
+ * `completed`, the timestamp behaviour) that schema export alone
+ * doesn't catch.
+ */
+@OptIn(ExperimentalCoroutinesApi::class)
+class HistoryRepositoryImplTest {
+
+    private class FakeChapterHistoryDao : ChapterHistoryDao {
+        val rows = mutableMapOf<Pair<String, String>, ChapterHistory>()
+        val callLog = mutableListOf<String>()
+        private val allFeed = MutableStateFlow<List<ChapterHistoryRow>>(emptyList())
+        private val perFictionFeeds = mutableMapOf<String, MutableStateFlow<List<ChapterHistoryRow>>>()
+
+        // Optional join metadata — tests can pre-populate to verify the
+        // denormalized projection without spinning up a real fiction +
+        // chapter table.
+        data class Meta(
+            val fictionTitle: String? = null,
+            val fictionAuthor: String? = null,
+            val coverUrl: String? = null,
+            val chapterTitle: String? = null,
+            val chapterIndex: Int? = null,
+        )
+        val meta = mutableMapOf<Pair<String, String>, Meta>()
+
+        private fun rebuild(): List<ChapterHistoryRow> =
+            rows.values
+                .sortedByDescending { it.openedAt }
+                .map { h ->
+                    val m = meta[h.fictionId to h.chapterId] ?: Meta()
+                    ChapterHistoryRow(
+                        fictionId = h.fictionId,
+                        chapterId = h.chapterId,
+                        openedAt = h.openedAt,
+                        completed = h.completed,
+                        fractionRead = h.fractionRead,
+                        fictionTitle = m.fictionTitle,
+                        fictionAuthor = m.fictionAuthor,
+                        coverUrl = m.coverUrl,
+                        chapterTitle = m.chapterTitle,
+                        chapterIndex = m.chapterIndex,
+                    )
+                }
+
+        private fun publish() {
+            val full = rebuild()
+            allFeed.value = full
+            perFictionFeeds.forEach { (fictionId, f) ->
+                f.value = full.filter { it.fictionId == fictionId }
+            }
+        }
+
+        override fun observeAll(): Flow<List<ChapterHistoryRow>> {
+            allFeed.value = rebuild()
+            return allFeed
+        }
+
+        override fun observeForFiction(fictionId: String): Flow<List<ChapterHistoryRow>> {
+            val feed = perFictionFeeds.getOrPut(fictionId) {
+                MutableStateFlow(rebuild().filter { it.fictionId == fictionId })
+            }
+            return feed
+        }
+
+        override suspend fun get(fictionId: String, chapterId: String): ChapterHistory? {
+            callLog += "get($fictionId, $chapterId)"
+            return rows[fictionId to chapterId]
+        }
+
+        override suspend fun upsert(row: ChapterHistory) {
+            callLog += "upsert(${row.fictionId}, ${row.chapterId}, openedAt=${row.openedAt}, completed=${row.completed})"
+            rows[row.fictionId to row.chapterId] = row
+            publish()
+        }
+
+        override suspend fun markCompleted(
+            fictionId: String,
+            chapterId: String,
+            fraction: Float?,
+            now: Long,
+        ) {
+            callLog += "markCompleted($fictionId, $chapterId, fraction=$fraction)"
+            val existing = rows[fictionId to chapterId] ?: return // no-op
+            rows[fictionId to chapterId] = existing.copy(
+                completed = true,
+                fractionRead = fraction ?: existing.fractionRead,
+                openedAt = now,
+            )
+            publish()
+        }
+    }
+
+    @Test fun `logOpen creates a fresh history row`() = runTest {
+        val dao = FakeChapterHistoryDao()
+        val repo = HistoryRepositoryImpl(dao)
+
+        repo.logOpen(fictionId = "f1", chapterId = "f1:0")
+
+        val entries = repo.observeAll().first()
+        assertEquals(1, entries.size)
+        val entry = entries.first()
+        assertEquals("f1", entry.fictionId)
+        assertEquals("f1:0", entry.chapterId)
+        assertEquals(false, entry.completed)
+        assertNull(entry.fractionRead)
+    }
+
+    @Test fun `re-opening the same chapter upserts in place, not append`() = runTest {
+        val dao = FakeChapterHistoryDao()
+        val repo = HistoryRepositoryImpl(dao)
+
+        // Three opens of the same (fiction, chapter). One row at the end.
+        repo.logOpen("f1", "f1:0")
+        repo.logOpen("f1", "f1:0")
+        repo.logOpen("f1", "f1:0")
+
+        val entries = repo.observeAll().first()
+        assertEquals("re-open should NOT append duplicate rows", 1, entries.size)
+        assertEquals("f1:0", entries.first().chapterId)
+    }
+
+    @Test fun `logOpen after markCompleted preserves completed flag`() = runTest {
+        val dao = FakeChapterHistoryDao()
+        val repo = HistoryRepositoryImpl(dao)
+
+        repo.logOpen("f1", "f1:0")
+        repo.markCompleted("f1", "f1:0", fraction = 1f)
+        // User re-opens the same finished chapter to skim again.
+        repo.logOpen("f1", "f1:0")
+
+        val entry = repo.observeAll().first().single()
+        assertEquals("completed must survive a subsequent re-open", true, entry.completed)
+        assertEquals("fractionRead must survive a subsequent re-open", 1f, entry.fractionRead)
+    }
+
+    @Test fun `observeAll orders most-recent open first across fictions`() = runTest {
+        val dao = FakeChapterHistoryDao()
+        val repo = HistoryRepositoryImpl(dao)
+
+        // Three opens in known order. Manually upsert at known timestamps
+        // because logOpen uses System.currentTimeMillis which would race.
+        dao.upsert(ChapterHistory("f1", "f1:0", openedAt = 1_000L))
+        dao.upsert(ChapterHistory("f2", "f2:0", openedAt = 3_000L))
+        dao.upsert(ChapterHistory("f1", "f1:1", openedAt = 2_000L))
+
+        val entries = repo.observeAll().first()
+        assertEquals(listOf("f2:0", "f1:1", "f1:0"), entries.map { it.chapterId })
+    }
+
+    @Test fun `observeForFiction filters to one fiction's rows only`() = runTest {
+        val dao = FakeChapterHistoryDao()
+        val repo = HistoryRepositoryImpl(dao)
+
+        dao.upsert(ChapterHistory("f1", "f1:0", openedAt = 1_000L))
+        dao.upsert(ChapterHistory("f2", "f2:0", openedAt = 2_000L))
+        dao.upsert(ChapterHistory("f1", "f1:1", openedAt = 3_000L))
+
+        val f1 = repo.observeForFiction("f1").first()
+        assertEquals(listOf("f1:1", "f1:0"), f1.map { it.chapterId })
+        val f2 = repo.observeForFiction("f2").first()
+        assertEquals(listOf("f2:0"), f2.map { it.chapterId })
+    }
+
+    @Test fun `markCompleted is a no-op when no history row exists yet`() = runTest {
+        val dao = FakeChapterHistoryDao()
+        val repo = HistoryRepositoryImpl(dao)
+
+        // Never logged the open. End-of-chapter event fires anyway (unreachable
+        // in normal use, but the contract is idempotent).
+        repo.markCompleted("f1", "ghost", fraction = 1f)
+
+        val entries = repo.observeAll().first()
+        assertTrue("markCompleted on missing row must not synthesize a phantom history", entries.isEmpty())
+    }
+
+    @Test fun `markCompleted with null fraction preserves prior fractionRead`() = runTest {
+        val dao = FakeChapterHistoryDao()
+        val repo = HistoryRepositoryImpl(dao)
+
+        // Seed with a non-null fraction, then mark completed with null —
+        // the dao SQL uses COALESCE so the prior value should survive.
+        dao.upsert(
+            ChapterHistory(
+                fictionId = "f1",
+                chapterId = "f1:0",
+                openedAt = 1_000L,
+                fractionRead = 0.42f,
+            ),
+        )
+        repo.markCompleted("f1", "f1:0", fraction = null)
+
+        val entry = repo.observeAll().first().single()
+        assertEquals(true, entry.completed)
+        assertEquals("null fraction must preserve previously-known progress", 0.42f, entry.fractionRead)
+    }
+
+    @Test fun `projection passes through denormalized join columns`() = runTest {
+        val dao = FakeChapterHistoryDao()
+        val repo = HistoryRepositoryImpl(dao)
+        dao.meta["f1" to "f1:0"] = FakeChapterHistoryDao.Meta(
+            fictionTitle = "Mother of Learning",
+            fictionAuthor = "nobody103",
+            coverUrl = "https://example/cover.jpg",
+            chapterTitle = "Good Morning Brother",
+            chapterIndex = 1,
+        )
+        dao.upsert(ChapterHistory("f1", "f1:0", openedAt = 1_000L))
+
+        val entry = repo.observeAll().first().single()
+        assertEquals("Mother of Learning", entry.fictionTitle)
+        assertEquals("nobody103", entry.fictionAuthor)
+        assertEquals("https://example/cover.jpg", entry.coverUrl)
+        assertEquals("Good Morning Brother", entry.chapterTitle)
+        assertEquals(1, entry.chapterIndex)
+        assertNotNull("openedAt round-trips", entry.openedAt)
+    }
+}

--- a/core-playback/src/main/kotlin/in/jphe/storyvox/playback/tts/EnginePlayer.kt
+++ b/core-playback/src/main/kotlin/in/jphe/storyvox/playback/tts/EnginePlayer.kt
@@ -23,6 +23,7 @@ import dagger.assisted.Assisted
 import dagger.assisted.AssistedFactory
 import dagger.assisted.AssistedInject
 import `in`.jphe.storyvox.data.repository.ChapterRepository
+import `in`.jphe.storyvox.data.repository.HistoryRepository
 import `in`.jphe.storyvox.data.repository.PlaybackPositionRepository
 import `in`.jphe.storyvox.data.repository.playback.NOISE_SCALE_EXPRESSIVE
 import `in`.jphe.storyvox.data.repository.playback.NOISE_SCALE_STEADY
@@ -107,6 +108,13 @@ class EnginePlayer @AssistedInject constructor(
     private val chunker: SentenceChunker,
     private val chapterRepo: ChapterRepository,
     private val positionRepo: PlaybackPositionRepository,
+    /**
+     * Issue #158 — reading-history breadcrumb. Written on every
+     * chapter-load inside [loadAndPlay] and stamped `completed = true`
+     * inside [handleChapterDone]. Forever retention; powers the
+     * Library "History" sub-tab.
+     */
+    private val historyRepo: HistoryRepository,
     private val sleepTimer: SleepTimer,
     private val voiceManager: VoiceManager,
     private val volumeRamp: TtsVolumeRamp,
@@ -732,6 +740,16 @@ class EnginePlayer @AssistedInject constructor(
                 error = null,
             )
         }
+        // Issue #158 — stamp the History breadcrumb right after the state
+        // flips to a new currentChapterId. We log the open BEFORE the
+        // pipeline starts because the row should land even if the user
+        // taps a chapter and immediately backs out before audio starts
+        // — that still counts as "opened" in the History tab's sense.
+        // Upsert semantics mean re-opens move the row to the top
+        // without creating dupes. No try/catch: a Room write failure
+        // here would already crash the player on the next position-save,
+        // and history is non-load-bearing for playback.
+        historyRepo.logOpen(fictionId, chapterId)
         invalidateState()
 
         // #89 — stop the OLD pipeline FIRST, before we destroy any of
@@ -1665,8 +1683,20 @@ class EnginePlayer @AssistedInject constructor(
 
     private suspend fun handleChapterDone() {
         val chapterId = _observableState.value.currentChapterId
+        val fictionId = _observableState.value.currentFictionId
         persistPosition()
         if (chapterId != null) chapterRepo.markChapterPlayed(chapterId)
+        // Issue #158 — piggyback the History `completed` flag on the
+        // existing end-of-chapter event. Mirrors `markChapterPlayed`
+        // above; both fire on the same trigger (chapter naturally
+        // ended, not user-skipped via Next). `fractionRead = 1f`
+        // because we reached end-of-chapter — the only call-site that
+        // passes a partial fraction would be a future "user skipped
+        // 90% of the way through" path, which isn't in scope for this
+        // issue.
+        if (fictionId != null && chapterId != null) {
+            historyRepo.markCompleted(fictionId, chapterId, fraction = 1f)
+        }
         // Calliope (v0.5.00) — distinguish "chapter naturally finished" from
         // "user tapped Next chapter". Emit BEFORE advanceChapter so the
         // confetti overlay's observer sees ChapterDone first; the

--- a/feature/src/main/kotlin/in/jphe/storyvox/feature/library/LibraryScreen.kt
+++ b/feature/src/main/kotlin/in/jphe/storyvox/feature/library/LibraryScreen.kt
@@ -13,9 +13,11 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.grid.GridCells
 import androidx.compose.foundation.lazy.grid.LazyVerticalGrid
 import androidx.compose.foundation.lazy.grid.itemsIndexed
+import androidx.compose.foundation.lazy.items
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Add
 import androidx.compose.material3.Card
@@ -26,6 +28,8 @@ import androidx.compose.material3.FloatingActionButton
 import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Scaffold
+import androidx.compose.material3.SecondaryTabRow
+import androidx.compose.material3.Tab
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
@@ -36,6 +40,8 @@ import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import `in`.jphe.storyvox.data.db.entity.Shelf
 import `in`.jphe.storyvox.data.repository.ContinueListeningEntry
+import `in`.jphe.storyvox.data.repository.HistoryEntry
+import `in`.jphe.storyvox.data.source.model.FictionSummary
 import `in`.jphe.storyvox.ui.component.BrassButton
 import `in`.jphe.storyvox.ui.component.BrassButtonVariant
 import `in`.jphe.storyvox.ui.component.BrassProgressBar
@@ -111,101 +117,74 @@ fun LibraryScreen(
             }
         },
     ) { scaffoldPadding ->
-        Column(modifier = Modifier.fillMaxSize().padding(scaffoldPadding).padding(top = spacing.md)) {
-            // Issue #116 — chip strip lives above the grid (and above
-            // the Resume card) so it's always reachable regardless of
-            // scroll. Selecting a chip swaps the underlying flow in the
-            // VM, which re-emits a filtered grid.
-            ShelfChipRow(
-                selected = state.filter,
-                onSelect = viewModel::selectFilter,
-            )
-
-            // Empty-state branch needs to know which chip we're on — the
-            // "library is empty" copy makes sense for All but reads as
-            // wrong on a shelf with zero pinned books.
-            val isEmpty = !state.isLoading && state.fictions.isEmpty() && state.resume == null
-            if (isEmpty) {
-                when (val f = state.filter) {
-                    ShelfFilter.All -> EmptyLibrary()
-                    is ShelfFilter.OneShelf -> EmptyShelf(f.shelf)
-                }
-            } else {
-                LazyVerticalGrid(
-                    columns = GridCells.Adaptive(minSize = 140.dp),
-                    contentPadding = PaddingValues(spacing.md),
-                    horizontalArrangement = Arrangement.spacedBy(spacing.sm),
-                    verticalArrangement = Arrangement.spacedBy(spacing.md),
-                ) {
-                    // Hide the Resume card on shelf-filtered views — it's
-                    // a library-wide affordance, and surfacing it inside
-                    // a Wishlist filter (a book the user hasn't started)
-                    // is visually confusing.
-                    if (state.filter is ShelfFilter.All) {
-                        state.resume?.let { resume ->
-                            item(span = { androidx.compose.foundation.lazy.grid.GridItemSpan(maxLineSpan) }) {
-                                ResumeCard(resume, onResume = viewModel::resume)
-                            }
-                            // #265 — the Resume card used to sit one
-                            // `verticalArrangement.spacedBy(md)` gap above the
-                            // grid's first row, reading as another grid item
-                            // rather than a hero zone. The brass "Your library"
-                            // caption now labels the grid as a separate section.
-                            // Spacer + caption live in one full-span item so we
-                            // only pay one inter-row gap from the grid's
-                            // vertical arrangement (two items would double it).
-                            item(span = { androidx.compose.foundation.lazy.grid.GridItemSpan(maxLineSpan) }) {
-                                Column(modifier = Modifier.padding(top = spacing.xs)) {
-                                    Text(
-                                        text = "Your library",
-                                        style = MaterialTheme.typography.labelLarge,
-                                        color = MaterialTheme.colorScheme.primary,
-                                        modifier = Modifier.padding(bottom = spacing.xxs),
-                                    )
-                                }
-                            }
-                        }
-                    }
-                    itemsIndexed(dedupedFictions, key = { _, item -> item.id }) { index, fiction ->
-                        Column(
-                            modifier = Modifier
-                                .fillMaxWidth()
-                                .animateItem()
-                                .cascadeReveal(index = index, key = fiction.id),
-                            horizontalAlignment = Alignment.Start,
-                            verticalArrangement = Arrangement.spacedBy(spacing.xs),
-                        ) {
-                            FictionCoverThumb(
-                                coverUrl = fiction.coverUrl,
-                                title = fiction.title,
-                                monogram = fictionMonogram(fiction.author, fiction.title),
-                                // Long-press → manage-shelves bottom sheet
-                                // (issue #116). combinedClickable keeps
-                                // the tap-to-open path identical to
-                                // before; the long-press is an additive
-                                // overlay handler.
-                                modifier = Modifier
-                                    .fillMaxWidth()
-                                    .combinedClickable(
-                                        onClick = { viewModel.openFiction(fiction.id) },
-                                        onLongClick = { viewModel.openManageShelves(fiction) },
-                                    ),
-                            )
+        Column(modifier = Modifier.fillMaxSize().padding(scaffoldPadding)) {
+            // Issue #158 — Library sub-tabs. SecondaryTabRow rather than the
+            // PrimaryTabRow used by the bottom-level top-bar tabs, because
+            // these are *inside* a tab — Material 3 reserves the primary
+            // indicator for the top-level surface (BottomTabBar) and uses
+            // secondary for nested division.
+            //
+            // Layering with #116 (shelves): Tab.Reading coerces the chip
+            // filter to OneShelf(Reading) in the VM, so the same shelf-
+            // scoped Room flow drives both surfaces. The chip row is shown
+            // only on Tab.All — on Tab.Reading the tab itself IS the
+            // filter, on Tab.History the chip row isn't meaningful.
+            SecondaryTabRow(
+                selectedTabIndex = state.tab.ordinal,
+                modifier = Modifier.fillMaxWidth(),
+            ) {
+                LibraryTab.entries.forEach { tab ->
+                    Tab(
+                        selected = state.tab == tab,
+                        onClick = { viewModel.selectTab(tab) },
+                        text = {
                             Text(
-                                fiction.title,
-                                style = MaterialTheme.typography.titleSmall,
-                                maxLines = 2,
+                                text = tab.label,
+                                style = MaterialTheme.typography.labelLarge,
+                                maxLines = 1,
+                                softWrap = false,
                             )
-                            if (fiction.author.isNotBlank()) {
-                                Text(
-                                    fiction.author,
-                                    style = MaterialTheme.typography.bodySmall,
-                                    color = MaterialTheme.colorScheme.onSurfaceVariant,
-                                    maxLines = 1,
-                                )
-                            }
-                        }
-                    }
+                        },
+                    )
+                }
+            }
+
+            when (state.tab) {
+                LibraryTab.All -> Column(modifier = Modifier.fillMaxSize().padding(top = spacing.md)) {
+                    // #116 — chip strip lives above the grid (and above
+                    // the Resume card) so it's always reachable regardless of
+                    // scroll. Only shown on Tab.All — Reading shelf has its
+                    // own tab now.
+                    ShelfChipRow(
+                        selected = state.filter,
+                        onSelect = viewModel::selectFilter,
+                    )
+                    LibraryGridBody(
+                        state = state,
+                        dedupedFictions = dedupedFictions,
+                        onResume = viewModel::resume,
+                        onOpenFiction = viewModel::openFiction,
+                        onLongPress = viewModel::openManageShelves,
+                    )
+                }
+
+                LibraryTab.Reading -> Box(modifier = Modifier.fillMaxSize().padding(top = spacing.md)) {
+                    // Reading tab: filter is auto-coerced to Reading shelf
+                    // in the VM. No chip row — the tab is the filter.
+                    LibraryGridBody(
+                        state = state,
+                        dedupedFictions = dedupedFictions,
+                        onResume = viewModel::resume,
+                        onOpenFiction = viewModel::openFiction,
+                        onLongPress = viewModel::openManageShelves,
+                    )
+                }
+
+                LibraryTab.History -> Box(modifier = Modifier.fillMaxSize().padding(top = spacing.md)) {
+                    HistoryList(
+                        entries = state.history,
+                        onOpenChapter = viewModel::openHistoryEntry,
+                    )
                 }
             }
         }
@@ -374,4 +353,260 @@ private fun ContinueListeningEntry.progressFraction(): Float? {
     if (words <= 0) return null
     val estimatedChars = words * 5f
     return (charOffset / estimatedChars).coerceIn(0f, 1f)
+}
+
+/**
+ * Issue #158 — All / Reading library grid. Extracted from the inlined body
+ * so the same composable serves both sub-tabs without duplication. The
+ * Resume card + "Your library" caption hero zone is preserved as the
+ * first full-span rows in the grid (unchanged from the pre-sub-tabs
+ * implementation).
+ */
+/**
+ * The unified library grid body. Renders the chip-aware empty state, the
+ * Resume hero (only on filter == All, so it doesn't surface inside a
+ * Wishlist scope), and the cascading grid with long-press → manage-shelves.
+ *
+ * Shared between [LibraryTab.All] (chips visible above) and
+ * [LibraryTab.Reading] (chips hidden — tab is the filter).
+ */
+@OptIn(ExperimentalFoundationApi::class)
+@Composable
+private fun LibraryGridBody(
+    state: LibraryUiState,
+    dedupedFictions: List<FictionSummary>,
+    onResume: () -> Unit,
+    onOpenFiction: (String) -> Unit,
+    onLongPress: (FictionSummary) -> Unit,
+) {
+    val spacing = LocalSpacing.current
+    val isEmpty = !state.isLoading && dedupedFictions.isEmpty() && state.resume == null
+    if (isEmpty) {
+        when (val f = state.filter) {
+            ShelfFilter.All -> EmptyLibrary()
+            is ShelfFilter.OneShelf -> EmptyShelf(f.shelf)
+        }
+        return
+    }
+    LazyVerticalGrid(
+        columns = GridCells.Adaptive(minSize = 140.dp),
+        contentPadding = PaddingValues(spacing.md),
+        horizontalArrangement = Arrangement.spacedBy(spacing.sm),
+        verticalArrangement = Arrangement.spacedBy(spacing.md),
+    ) {
+        // Hide the Resume card on shelf-filtered views — it's a
+        // library-wide affordance, and surfacing it inside a Wishlist
+        // filter (a book the user hasn't started) is visually confusing.
+        if (state.filter is ShelfFilter.All) {
+            state.resume?.let { entry ->
+                item(span = { androidx.compose.foundation.lazy.grid.GridItemSpan(maxLineSpan) }) {
+                    ResumeCard(entry, onResume = onResume)
+                }
+                // #265 — single full-span caption row labelling the grid
+                // as a separate section beneath the Resume hero. See the
+                // kdoc on the original implementation for the gap-doubling
+                // rationale.
+                item(span = { androidx.compose.foundation.lazy.grid.GridItemSpan(maxLineSpan) }) {
+                    Column(modifier = Modifier.padding(top = spacing.xs)) {
+                        Text(
+                            text = "Your library",
+                            style = MaterialTheme.typography.labelLarge,
+                            color = MaterialTheme.colorScheme.primary,
+                            modifier = Modifier.padding(bottom = spacing.xxs),
+                        )
+                    }
+                }
+            }
+        }
+        itemsIndexed(dedupedFictions, key = { _, item -> item.id }) { index, fiction ->
+            Column(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .animateItem()
+                    .cascadeReveal(index = index, key = fiction.id),
+                horizontalAlignment = Alignment.Start,
+                verticalArrangement = Arrangement.spacedBy(spacing.xs),
+            ) {
+                FictionCoverThumb(
+                    coverUrl = fiction.coverUrl,
+                    title = fiction.title,
+                    monogram = fictionMonogram(fiction.author, fiction.title),
+                    // Long-press → manage-shelves bottom sheet (#116).
+                    // combinedClickable keeps the tap-to-open path
+                    // identical to before; long-press is additive.
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .combinedClickable(
+                            onClick = { onOpenFiction(fiction.id) },
+                            onLongClick = { onLongPress(fiction) },
+                        ),
+                )
+                Text(
+                    fiction.title,
+                    style = MaterialTheme.typography.titleSmall,
+                    maxLines = 2,
+                )
+                if (fiction.author.isNotBlank()) {
+                    Text(
+                        fiction.author,
+                        style = MaterialTheme.typography.bodySmall,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                        maxLines = 1,
+                    )
+                }
+            }
+        }
+    }
+}
+
+/**
+ * Issue #158 — chronological reading-history list. Most-recent open at the
+ * top. Each row: cover thumb, fiction title, chapter title, "2h ago"
+ * relative timestamp. Tap → reader at that chapter.
+ *
+ * LazyColumn (not LazyVerticalGrid) because History is a single-column
+ * timeline — the visual rhythm is closer to a chat log than a poster
+ * wall. Brass-themed cover thumbs match the Library grid aesthetic.
+ *
+ * Empty state mirrors [EmptyLibrary]: same sigil + heading + invitation
+ * pattern, just worded for the no-history case ("Start listening and
+ * chapters will show up here.").
+ */
+@Composable
+private fun HistoryList(
+    entries: List<HistoryEntry>,
+    onOpenChapter: (HistoryEntry) -> Unit,
+) {
+    val spacing = LocalSpacing.current
+    if (entries.isEmpty()) {
+        EmptyHistory()
+        return
+    }
+    LazyColumn(
+        contentPadding = PaddingValues(spacing.md),
+        verticalArrangement = Arrangement.spacedBy(spacing.sm),
+    ) {
+        items(entries, key = { entry -> "${entry.fictionId}::${entry.chapterId}" }) { entry ->
+            HistoryRow(entry, onClick = { onOpenChapter(entry) })
+        }
+    }
+}
+
+@Composable
+private fun HistoryRow(entry: HistoryEntry, onClick: () -> Unit) {
+    val spacing = LocalSpacing.current
+    Card(
+        modifier = Modifier
+            .fillMaxWidth()
+            .clickable(onClick = onClick),
+        colors = CardDefaults.cardColors(
+            containerColor = MaterialTheme.colorScheme.surfaceContainerHigh,
+            contentColor = MaterialTheme.colorScheme.onSurface,
+        ),
+        shape = MaterialTheme.shapes.medium,
+    ) {
+        Row(
+            modifier = Modifier.padding(spacing.sm).fillMaxWidth(),
+            verticalAlignment = Alignment.CenterVertically,
+            horizontalArrangement = Arrangement.spacedBy(spacing.sm),
+        ) {
+            FictionCoverThumb(
+                coverUrl = entry.coverUrl,
+                title = entry.fictionTitle.orEmpty(),
+                // Fallback monogram if a cascade-delete race left us with
+                // a null fictionTitle (see ChapterHistoryRow kdoc). Empty
+                // strings here just produce a brass sigil placeholder
+                // instead of a "?" — see #322's fictionMonogram.
+                monogram = fictionMonogram(entry.fictionAuthor.orEmpty(), entry.fictionTitle.orEmpty()),
+                modifier = Modifier.size(width = 44.dp, height = 64.dp),
+            )
+            Column(modifier = Modifier.weight(1f)) {
+                Text(
+                    text = entry.fictionTitle ?: "(removed)",
+                    style = MaterialTheme.typography.titleSmall,
+                    maxLines = 1,
+                )
+                // Match Resume card formatting: "Ch. N · title" with the
+                // dangling-separator guard for blank titles (see #265).
+                val chapterLabel = buildString {
+                    entry.chapterIndex?.let { append("Ch. $it") }
+                    val title = entry.chapterTitle.orEmpty()
+                    if (entry.chapterIndex != null && title.isNotBlank()) append(" · ")
+                    if (title.isNotBlank()) append(title)
+                    if (isEmpty()) append("(chapter removed)")
+                }
+                Text(
+                    text = chapterLabel,
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    maxLines = 1,
+                )
+                Text(
+                    text = relativeTimeLabel(entry.openedAt),
+                    style = MaterialTheme.typography.labelSmall,
+                    color = MaterialTheme.colorScheme.primary,
+                )
+            }
+        }
+    }
+}
+
+@Composable
+private fun EmptyHistory() {
+    val spacing = LocalSpacing.current
+    Column(
+        modifier = Modifier.fillMaxSize().padding(spacing.lg),
+        horizontalAlignment = Alignment.CenterHorizontally,
+        verticalArrangement = Arrangement.Center,
+    ) {
+        MagicSkeletonTile(
+            modifier = Modifier.size(width = 160.dp, height = 220.dp),
+            shape = MaterialTheme.shapes.medium,
+            glyphSize = 80.dp,
+        )
+        Spacer(Modifier.height(spacing.lg))
+        Text(
+            "Nothing here yet",
+            style = MaterialTheme.typography.titleMedium,
+            color = MaterialTheme.colorScheme.primary,
+            textAlign = TextAlign.Center,
+        )
+        Spacer(Modifier.height(spacing.xs))
+        Text(
+            "Start listening and the chapters you open will show up here, newest first.",
+            style = MaterialTheme.typography.bodyMedium,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+            textAlign = TextAlign.Center,
+        )
+    }
+}
+
+/**
+ * Coarse "how long ago" label for the History list. Bucketed for human
+ * scanability rather than precise: "just now" (under a minute), "Nm ago"
+ * (under an hour), "Nh ago" (under a day), "Nd ago" (under a week),
+ * "Nw ago" otherwise. Past ~12 weeks we still emit "Nw ago" — for a
+ * forever-retention surface we'd rather over-emit weeks than introduce a
+ * month-or-year boundary that would render dates inconsistently across
+ * locales. If JP wants absolute dates we add them as a tooltip later.
+ *
+ * Uses `System.currentTimeMillis()` so the label is point-in-time-of-
+ * composition; Compose recomposes the History list whenever the
+ * underlying flow emits (i.e. on every new open). For a forever-running
+ * Library screen the labels eventually drift — that's fine, the next
+ * compositional kick (tab switch, new open, app foreground) refreshes
+ * them. We deliberately don't run a per-second ticker for what's
+ * essentially a secondary-priority caption.
+ */
+private fun relativeTimeLabel(openedAt: Long): String {
+    val deltaMs = (System.currentTimeMillis() - openedAt).coerceAtLeast(0L)
+    val minutes = deltaMs / 60_000L
+    if (minutes < 1L) return "just now"
+    if (minutes < 60L) return "${minutes}m ago"
+    val hours = minutes / 60L
+    if (hours < 24L) return "${hours}h ago"
+    val days = hours / 24L
+    if (days < 7L) return "${days}d ago"
+    val weeks = days / 7L
+    return "${weeks}w ago"
 }

--- a/feature/src/main/kotlin/in/jphe/storyvox/feature/library/LibraryViewModel.kt
+++ b/feature/src/main/kotlin/in/jphe/storyvox/feature/library/LibraryViewModel.kt
@@ -7,6 +7,8 @@ import dagger.hilt.android.lifecycle.HiltViewModel
 import `in`.jphe.storyvox.data.db.entity.Shelf
 import `in`.jphe.storyvox.data.repository.ContinueListeningEntry
 import `in`.jphe.storyvox.data.repository.FictionRepository
+import `in`.jphe.storyvox.data.repository.HistoryEntry
+import `in`.jphe.storyvox.data.repository.HistoryRepository
 import `in`.jphe.storyvox.data.repository.PlaybackPositionRepository
 import `in`.jphe.storyvox.data.repository.ShelfRepository
 import `in`.jphe.storyvox.data.repository.playback.PlaybackResumePolicyConfig
@@ -28,9 +30,30 @@ import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.launch
 
 /**
+ * Issue #158 — top-level sub-tabs inside the Library screen. Order matters:
+ * the enum's `ordinal` drives [SecondaryTabRow]'s `selectedTabIndex`.
+ *
+ *  - [All] mirrors the pre-#158 Library grid (Resume card + alphabetical
+ *    library grid) — the user's full collection. Chip row from #116 is
+ *    visible here to let the user drill into Read/Wishlist shelves
+ *    without leaving the tab.
+ *  - [Reading] uses the #116 [Shelf.Reading] filter under the hood; on
+ *    select we coerce [ShelfFilter] to `OneShelf(Reading)` so the grid
+ *    swaps without the chip row needing to show.
+ *  - [History] is the chronological chapter-open feed.
+ */
+enum class LibraryTab(val label: String) {
+    All("All"),
+    Reading("Reading"),
+    History("History"),
+}
+
+/**
  * Issue #116 — which row of the chip-filter strip is selected. `All` is
  * the default (current behaviour pre-shelves); the three [Shelf] options
- * filter the grid to fictions that sit on that shelf.
+ * filter the grid to fictions that sit on that shelf. Coexists with
+ * [LibraryTab]: [LibraryTab.Reading] coerces this to `OneShelf(Reading)`
+ * internally so the same filtering machinery serves both surfaces.
  */
 @Immutable
 sealed interface ShelfFilter {
@@ -43,7 +66,11 @@ data class LibraryUiState(
     /** Topmost continue-listening entry — null until the user has played anything. */
     val resume: ContinueListeningEntry? = null,
     val fictions: List<FictionSummary> = emptyList(),
-    /** Currently-active chip — drives both the grid filter and which empty state shows. */
+    /** Issue #158 — chronological history feed, most-recent-open first. */
+    val history: List<HistoryEntry> = emptyList(),
+    /** Selected sub-tab (#158). */
+    val tab: LibraryTab = LibraryTab.All,
+    /** Active chip filter (#116) — only meaningful while tab == All. */
     val filter: ShelfFilter = ShelfFilter.All,
     val isLoading: Boolean = true,
 )
@@ -87,6 +114,8 @@ class LibraryViewModel @Inject constructor(
     fictionRepo: FictionRepository,
     positionRepo: PlaybackPositionRepository,
     private val shelfRepo: ShelfRepository,
+    /** Issue #158 — reading history backing the new "History" sub-tab. */
+    historyRepo: HistoryRepository,
     private val uiRepo: FictionRepositoryUi,
     private val playback: PlaybackControllerUi,
     /** #90 — read the user's last play/pause intent to decide whether
@@ -101,6 +130,13 @@ class LibraryViewModel @Inject constructor(
     val addByUrlState: StateFlow<AddByUrlSheetState> = _addByUrlState.asStateFlow()
 
     private val _filter = MutableStateFlow<ShelfFilter>(ShelfFilter.All)
+
+    /**
+     * Selected sub-tab. Hoisted out of the combined `uiState` flow so a
+     * tab-switch doesn't have to wait for the library/resume/history
+     * flows to all emit — pressing the tab feels instant.
+     */
+    private val _tab = MutableStateFlow(LibraryTab.All)
 
     private val _manageShelves = MutableStateFlow<ManageShelvesSheetState>(ManageShelvesSheetState.Hidden)
     val manageShelvesState: StateFlow<ManageShelvesSheetState> = _manageShelves.asStateFlow()
@@ -121,24 +157,57 @@ class LibraryViewModel @Inject constructor(
     val uiState: StateFlow<LibraryUiState> = combine(
         fictionsFlow,
         positionRepo.observeMostRecentContinueListening(),
+        historyRepo.observeAll(),
+        _tab,
         _filter,
-    ) { library, resume, filter ->
+    ) { library, resume, history, tab, filter ->
         LibraryUiState(
             resume = resume,
             fictions = library,
+            history = history,
+            tab = tab,
             filter = filter,
             isLoading = false,
         )
     }.stateIn(viewModelScope, SharingStarted.WhileSubscribed(5_000), LibraryUiState())
 
-    // ─── chips ────────────────────────────────────────────────────────────
+    // ─── sub-tabs (#158) ──────────────────────────────────────────────────
 
-    /** Top-of-screen chip row taps. */
+    /**
+     * Tab.Reading coerces the chip filter so the same shelf-scoped flow
+     * machinery serves both surfaces. Tab.All restores filter to All so
+     * leaving Reading doesn't strand the user on a hidden filter.
+     */
+    fun selectTab(tab: LibraryTab) {
+        _tab.value = tab
+        when (tab) {
+            LibraryTab.Reading -> _filter.value = ShelfFilter.OneShelf(Shelf.Reading)
+            LibraryTab.All -> _filter.value = ShelfFilter.All
+            LibraryTab.History -> { /* history feed renders from state.history */ }
+        }
+    }
+
+    /**
+     * Issue #158 — History row tap. Navigates to the reader at that
+     * (fictionId, chapterId). We deliberately *don't* call
+     * `playback.startListening` here: the user might be browsing history
+     * to find context, not to start playing right now. Reader opens the
+     * chapter view; if they want audio they tap play from there.
+     */
+    fun openHistoryEntry(entry: HistoryEntry) {
+        viewModelScope.launch {
+            _events.send(LibraryUiEvent.OpenReader(entry.fictionId, entry.chapterId))
+        }
+    }
+
+    // ─── chips (#116) ─────────────────────────────────────────────────────
+
+    /** Top-of-screen chip row taps (only visible on Tab.All). */
     fun selectFilter(filter: ShelfFilter) {
         _filter.value = filter
     }
 
-    // ─── manage-shelves bottom sheet ──────────────────────────────────────
+    // ─── manage-shelves bottom sheet (#116) ───────────────────────────────
 
     /** Long-press on a library card → open the manage-shelves sheet. */
     fun openManageShelves(fiction: FictionSummary) {
@@ -160,11 +229,6 @@ class LibraryViewModel @Inject constructor(
     fun toggleShelf(fictionId: String, shelf: Shelf) {
         viewModelScope.launch {
             shelfRepo.toggle(fictionId, shelf)
-            // Refresh the sheet's local cache of memberships so the toggle
-            // visibly settles. Re-reading from the DB after the write is
-            // the cheapest correctness — observeShelvesForFiction would
-            // also work but pulls the sheet into a flow lifecycle we don't
-            // need (it dismisses cleanly without lingering state).
             val sheet = _manageShelves.value
             if (sheet is ManageShelvesSheetState.Open && sheet.fictionId == fictionId) {
                 _manageShelves.value = sheet.copy(
@@ -191,9 +255,6 @@ class LibraryViewModel @Inject constructor(
             // common "phone died, want to keep listening" case
             // auto-resumes as before.
             val autoPlay = resumePolicy.currentLastWasPlaying()
-            // Cold-start: the controller may have nothing loaded (fresh app launch),
-            // in which case `play()` is a no-op. `startListening` queues the chapter
-            // download and kicks the TTS engine, which is what we actually want.
             playback.startListening(
                 entry.fiction.id,
                 entry.chapter.id,

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -104,6 +104,7 @@ androidx-hilt-compiler = { module = "androidx.hilt:hilt-compiler", version.ref =
 androidx-room-runtime = { module = "androidx.room:room-runtime", version.ref = "room" }
 androidx-room-ktx = { module = "androidx.room:room-ktx", version.ref = "room" }
 androidx-room-compiler = { module = "androidx.room:room-compiler", version.ref = "room" }
+androidx-room-testing = { module = "androidx.room:room-testing", version.ref = "room" }
 
 # WorkManager
 androidx-work-runtime-ktx = { module = "androidx.work:work-runtime-ktx", version.ref = "work" }


### PR DESCRIPTION
## Summary

Issue #158 — Library tab now has three sub-tabs (All / Reading / History) with a forever-retention chronological History feed. Per JP's product call on the issue.

- **Data**: new `chapter_history` Room table, composite PK on `(fictionId, chapterId)` so re-opens upsert in place rather than appending. `HistoryRepository` exposes `logOpen` / `markCompleted` + observe APIs. Same denormalized-join projection pattern as `ContinueListeningRow` so the UI doesn't fan out follow-up lookups.
- **Playback**: `EnginePlayer.loadAndPlay` stamps the history breadcrumb right after `currentChapterId` flips; `handleChapterDone` piggybacks on the existing end-of-chapter event to mark `completed = true` (same trigger as the existing `markChapterPlayed` call).
- **UI**: `SecondaryTabRow` (M3 nested-tab pattern, matches BrowseScreen). History list is a `LazyColumn` of brass-themed cards with cover thumb + chapter title + relative timestamp ("2h ago"). Empty state mirrors `EmptyLibrary`'s sigil-monogram aesthetic.
- **Tests**: Robolectric-backed `StoryvoxDatabaseMigrationTest` (4→5 migration + Room round-trip with Room's full validation path) and a fake-DAO `HistoryRepositoryImplTest` covering upsert-by-PK, ordering, completed-preservation, and `markCompleted` no-op semantics.

## Schema version note

Bumped to **v5** with `MIGRATION_4_5`. The #116 (library shelves) sibling agent is also bumping to v5; if that PR lands first the orchestrator should promote this migration to `MIGRATION_5_6` at merge time — it's a purely mechanical rename (the SQL is additive and doesn't touch `fiction` / `chapter`). The kdoc on `MIGRATION_4_5` calls this out.

## Reading tab

The `Reading` sub-tab is wired but renders the full library as a placeholder — the actual "Reading shelf" filter belongs to #116. Once shelves merge a one-line change in `LibraryScreen`'s `when (state.tab)` switches the source list.

## Test plan

- [ ] CI: `./gradlew :core-data:testDebugUnitTest :app:testDebugUnitTest` passes
- [ ] On device (Pixel 5, R5CRB0W66MK — already installed): open Library → History tab is visible, taps don't crash
- [ ] Play any chapter, return to Library → History → see the chapter near the top
- [ ] Tap a history row → reader opens at that chapter
- [ ] Re-open the same chapter twice → still only one history row, moved to top
- [ ] Finish a chapter → row stays after `loadAndPlay` of the next chapter (verifies `completed` survives re-open)
- [ ] Confirm fresh install: history table comes up empty, no crash on first open
- [ ] Confirm upgrade from v4: existing data survives, History tab works

🤖 Generated with [Claude Code](https://claude.com/claude-code)