### PR TITLE
feat(browse): soft-gate RR listings on sign-in — closes #241

### DIFF
--- a/app/src/main/kotlin/in/jphe/storyvox/navigation/StoryvoxNavHost.kt
+++ b/app/src/main/kotlin/in/jphe/storyvox/navigation/StoryvoxNavHost.kt
@@ -352,6 +352,10 @@ private fun StoryvoxNavHostContent(
             ) {
                 BrowseScreen(
                     onOpenFiction = { id -> navController.navigate(StoryvoxRoutes.fictionDetail(id)) },
+                    // #241 — RR Browse listings are gated on sign-in; the CTA in
+                    // the empty state routes through the same WebView that
+                    // Settings → Royal Road and Follows → Sign-In use.
+                    onOpenRoyalRoadSignIn = { navController.navigate(StoryvoxRoutes.AUTH_WEBVIEW) },
                 )
             }
 

--- a/feature/src/main/kotlin/in/jphe/storyvox/feature/browse/BrowseScreen.kt
+++ b/feature/src/main/kotlin/in/jphe/storyvox/feature/browse/BrowseScreen.kt
@@ -55,6 +55,8 @@ import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import `in`.jphe.storyvox.feature.api.BrowseFilter
+import `in`.jphe.storyvox.ui.component.BrassButton
+import `in`.jphe.storyvox.ui.component.BrassButtonVariant
 import `in`.jphe.storyvox.ui.component.cascadeReveal
 import `in`.jphe.storyvox.ui.component.ErrorBlock
 import `in`.jphe.storyvox.ui.component.friendlyErrorMessage
@@ -62,12 +64,17 @@ import `in`.jphe.storyvox.ui.component.ErrorPlacement
 import `in`.jphe.storyvox.ui.component.FictionCardSkeleton
 import `in`.jphe.storyvox.ui.component.FictionCoverThumb
 import `in`.jphe.storyvox.ui.component.fictionMonogram
+import `in`.jphe.storyvox.ui.component.MagicSkeletonTile
 import `in`.jphe.storyvox.ui.component.MagicSpinner
 import `in`.jphe.storyvox.ui.theme.LocalSpacing
 
 @Composable
 fun BrowseScreen(
     onOpenFiction: (String) -> Unit,
+    /** Issue #241 — navigates to the Royal Road sign-in WebView. Surfaced
+     *  on the listing tabs (Popular / NewReleases / BestRated) when the
+     *  user is not signed in to RR; Search keeps working anonymously. */
+    onOpenRoyalRoadSignIn: () -> Unit,
     viewModel: BrowseViewModel = hiltViewModel(),
 ) {
     val state by viewModel.uiState.collectAsStateWithLifecycle()
@@ -215,6 +222,14 @@ fun BrowseScreen(
         }
 
         when {
+            // Issue #241 — RR listings are gated on sign-in. CTA sits ahead
+            // of the SkeletonGrid branch so the user never sees a loading
+            // shimmer for a request the resolver wasn't going to fire.
+            // Search stays open (the resolver in BrowseViewModel exempts
+            // it), so the CTA is suppressed when the user is on Search.
+            state.sourceKey == BrowseSourceKey.RoyalRoad &&
+                !state.royalRoadSignedIn &&
+                state.tab != BrowseTab.Search -> RoyalRoadSignedOutCta(onOpenRoyalRoadSignIn)
             state.isLoading && state.items.isEmpty() -> SkeletonGrid()
             state.tab == BrowseTab.Search && state.query.isBlank() && !state.isFilterActive -> SearchHint(state.sourceKey)
             // First-load failure with no cached items: full-screen error.
@@ -573,6 +588,56 @@ private fun ActiveWingChip(
         },
         modifier = modifier,
     )
+}
+
+/**
+ * Issue #241 — empty state shown on the Royal Road listing tabs
+ * (Popular / NewReleases / BestRated / filter-active) when the user
+ * is not signed in. Mirrors FollowsScreen's `SignedOutEmpty` rhythm
+ * (sigil tile + titleMedium primary headline + bodyMedium body +
+ * brass primary CTA) so the two surfaces read as part of the same
+ * family — the same brass voice asking the user to authorize before
+ * we hit RR's listing endpoints on their behalf.
+ *
+ * The Search tab is intentionally suppressed in BrowseScreen's
+ * `when` branch — search and Add-by-URL keep working anonymously per
+ * the #241 spec, since they target specific URLs the user already
+ * knows (not anonymous discovery of the catalog).
+ */
+@Composable
+private fun RoyalRoadSignedOutCta(onOpenSignIn: () -> Unit) {
+    val spacing = LocalSpacing.current
+    Column(
+        modifier = Modifier.fillMaxSize().padding(spacing.lg),
+        horizontalAlignment = Alignment.CenterHorizontally,
+        verticalArrangement = Arrangement.Center,
+    ) {
+        MagicSkeletonTile(
+            modifier = Modifier.size(width = 160.dp, height = 220.dp),
+            shape = MaterialTheme.shapes.medium,
+            glyphSize = 80.dp,
+        )
+        Spacer(Modifier.height(spacing.lg))
+        Text(
+            "Sign in to browse Royal Road",
+            style = MaterialTheme.typography.titleMedium,
+            color = MaterialTheme.colorScheme.primary,
+            textAlign = TextAlign.Center,
+        )
+        Spacer(Modifier.height(spacing.xs))
+        Text(
+            "Storyvox uses your Royal Road session to fetch listings on your behalf — a logged-in reader, not an anonymous one. Search and paste-URL still work without signing in.",
+            style = MaterialTheme.typography.bodyMedium,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+            textAlign = TextAlign.Center,
+        )
+        Spacer(Modifier.height(spacing.lg))
+        BrassButton(
+            label = "Sign in to Royal Road",
+            onClick = onOpenSignIn,
+            variant = BrassButtonVariant.Primary,
+        )
+    }
 }
 
 /** Number of independent filter knobs the user has actively set. */

--- a/feature/src/main/kotlin/in/jphe/storyvox/feature/browse/BrowseViewModel.kt
+++ b/feature/src/main/kotlin/in/jphe/storyvox/feature/browse/BrowseViewModel.kt
@@ -169,6 +169,14 @@ data class BrowseUiState(
      *  qualifiers are only meaningful for callers with private-repo
      *  access. */
     val hasGitHubRepoScope: Boolean = false,
+    /** Issue #241 — Royal Road sign-in state. Drives the soft-gate on
+     *  RR listing tabs (Popular / NewReleases / BestRated / filter-
+     *  active): when false, those tabs render a sign-in CTA empty
+     *  state rather than firing an anonymous request that returns the
+     *  same content but carries the "bot" framing. Search and
+     *  Add-by-URL keep working anonymously — they target specific
+     *  URLs the user already knows. */
+    val royalRoadSignedIn: Boolean = false,
     /** Sources the user has enabled in Settings (#221). Drives the
      *  BrowseSourcePicker membership — disabled sources are hidden from
      *  the chip strip. Default to all three so a fresh-install user sees
@@ -207,6 +215,11 @@ private data class ControlsView(
      *  in [BrowseUiState]. */
     val githubSignedIn: Boolean,
     val hasGitHubRepoScope: Boolean,
+    /** Issue #241 — sourced from `SettingsRepositoryUi.settings.isSignedIn`
+     *  (Royal Road cookie state). Drives the soft-gate on RR listing
+     *  tabs in [resolveSource] and the sign-in CTA empty state in
+     *  BrowseScreen. */
+    val royalRoadSignedIn: Boolean,
     /** Backends the user has not toggled off in Settings (#221).
      *  Drives [BrowseSourcePicker] membership and an auto-snap when the
      *  currently-selected source disappears. */
@@ -256,6 +269,16 @@ class BrowseViewModel @Inject constructor(
         .distinctUntilChanged()
         .stateIn(viewModelScope, SharingStarted.WhileSubscribed(5_000), false)
 
+    /** Issue #241 — Royal Road sign-in projection. Single boolean
+     *  derived from `UiSettings.isSignedIn` (the RR cookie state).
+     *  Drives the soft-gate on listing tabs in [resolveSource] and the
+     *  empty-state CTA in BrowseScreen. StateFlow so [selectSource]'s
+     *  init-block auto-snap can read `.value` synchronously. */
+    private val royalRoadSignedIn: StateFlow<Boolean> = settings.settings
+        .map { it.isSignedIn }
+        .distinctUntilChanged()
+        .stateIn(viewModelScope, SharingStarted.WhileSubscribed(5_000), false)
+
     /** True when the user is signed in to GitHub with the `repo` scope
      *  granted. The scopes string is space-separated per RFC 6749; the
      *  Settings impl persists exactly what GitHub returned. Drives the
@@ -270,6 +293,20 @@ class BrowseViewModel @Inject constructor(
                     auth.scopes.split(' ').any { it == "repo" }
             }
             .distinctUntilChanged()
+
+    /** Bundled auth signals — flows into the controls combine as one arg
+     *  to stay within the 5-arg overload after #241 added a third boolean.
+     *  Recomposes on any field change; downstream code reads what it needs. */
+    private data class AuthSnapshot(
+        val githubSignedIn: Boolean,
+        val hasGitHubRepoScope: Boolean,
+        val royalRoadSignedIn: Boolean,
+    )
+
+    private val authSnapshot: kotlinx.coroutines.flow.Flow<AuthSnapshot> =
+        combine(githubSignedIn, hasGitHubRepoScope, royalRoadSignedIn) { gh, repo, rr ->
+            AuthSnapshot(gh, repo, rr)
+        }.distinctUntilChanged()
 
     /** Per-backend on/off projection (#221). The Settings screen exposes
      *  three switches; this collapses them to a [Set] of enabled keys so
@@ -307,7 +344,7 @@ class BrowseViewModel @Inject constructor(
         ) { sourceKey, tab, q, filter, ghFilter ->
             ResolveTuple(sourceKey, tab, q, filter, ghFilter)
         }
-        combine(baseTuple, _palaceFilter, githubSignedIn) { tup, palaceFilter, signedIn ->
+        combine(baseTuple, _palaceFilter, githubSignedIn, royalRoadSignedIn) { tup, palaceFilter, ghSignedIn, rrSignedIn ->
             resolveSource(
                 sourceKey = tup.sourceKey,
                 tab = tup.tab,
@@ -315,7 +352,8 @@ class BrowseViewModel @Inject constructor(
                 filter = tup.filter,
                 githubFilter = tup.ghFilter,
                 palaceFilter = palaceFilter,
-                githubSignedIn = signedIn,
+                githubSignedIn = ghSignedIn,
+                royalRoadSignedIn = rrSignedIn,
             )?.let { source -> source to tup.sourceKey.sourceId }
         }
             .distinctUntilChanged()
@@ -372,17 +410,18 @@ class BrowseViewModel @Inject constructor(
         ) { sourceKey, tab, q, filter, ghFilter ->
             ResolveTuple(sourceKey, tab, q, filter, ghFilter)
         }
-        // 5-arg combine — at the overload ceiling. If a 6th controls
-        // flow ever needs to land, lift one of these into a side
-        // StateFlow consumed inside the lambda rather than reaching for
-        // the variadic overload.
+        // 4-arg combine — under the ceiling thanks to [authSnapshot]
+        // bundling the three auth-related booleans (github sign-in,
+        // github repo-scope, royal-road sign-in #241). If a 6th
+        // independent controls flow ever needs to land, lift one of
+        // these into a side StateFlow consumed inside the lambda
+        // rather than reaching for the variadic overload.
         combine(
             baseTuple,
             _palaceFilter,
-            githubSignedIn,
-            hasGitHubRepoScope,
+            authSnapshot,
             enabledSources,
-        ) { tup, palaceFilter, signedIn, repoScope, enabled ->
+        ) { tup, palaceFilter, auth, enabled ->
             ControlsView(
                 sourceKey = tup.sourceKey,
                 tab = tup.tab,
@@ -390,8 +429,9 @@ class BrowseViewModel @Inject constructor(
                 filter = tup.filter,
                 githubFilter = tup.ghFilter,
                 palaceFilter = palaceFilter,
-                githubSignedIn = signedIn,
-                hasGitHubRepoScope = repoScope,
+                githubSignedIn = auth.githubSignedIn,
+                hasGitHubRepoScope = auth.hasGitHubRepoScope,
+                royalRoadSignedIn = auth.royalRoadSignedIn,
                 enabledSources = enabled,
             )
         }
@@ -419,6 +459,7 @@ class BrowseViewModel @Inject constructor(
                     palaceWings = wings,
                     githubSignedIn = c.githubSignedIn,
                     hasGitHubRepoScope = c.hasGitHubRepoScope,
+                    royalRoadSignedIn = c.royalRoadSignedIn,
                     enabledSources = c.enabledSources,
                 )
             }
@@ -454,6 +495,7 @@ class BrowseViewModel @Inject constructor(
                     palaceWings = wings,
                     githubSignedIn = c.githubSignedIn,
                     hasGitHubRepoScope = c.hasGitHubRepoScope,
+                    royalRoadSignedIn = c.royalRoadSignedIn,
                     enabledSources = c.enabledSources,
                 )
             }
@@ -569,6 +611,7 @@ private fun resolveSource(
     githubFilter: GitHubSearchFilter,
     palaceFilter: MemPalaceFilter,
     githubSignedIn: Boolean,
+    royalRoadSignedIn: Boolean,
 ): BrowseSource? = when (sourceKey) {
     // GitHub: filter takes priority over tab. When filter is active OR
     // user is on Search with a typed query, route to FilteredGitHub so
@@ -596,14 +639,22 @@ private fun resolveSource(
         tab == BrowseTab.Search -> if (q.isBlank()) null else BrowseSource.Search(q)
         else -> null
     }
+    // Issue #241 — soft-gate on RR sign-in. Listing tabs
+    // (Popular / NewReleases / BestRated / any filter-active tab)
+    // return null when the user is not signed in to RR; the screen
+    // renders a sign-in CTA empty state instead of firing an
+    // anonymous request. Search and Add-by-URL stay open: they
+    // target specific URLs the user already knows, which is
+    // structurally distinct from anonymous browsing.
     BrowseSourceKey.RoyalRoad -> when {
+        tab == BrowseTab.Search -> if (q.isBlank()) null else BrowseSource.Search(q)
+        !royalRoadSignedIn -> null
         filter.isActive() -> BrowseSource.Filtered(
             if (tab == BrowseTab.Search && q.isNotBlank()) filter.copy(term = q) else filter,
         )
         tab == BrowseTab.Popular -> BrowseSource.Popular
         tab == BrowseTab.NewReleases -> BrowseSource.NewReleases
         tab == BrowseTab.BestRated -> BrowseSource.BestRated
-        tab == BrowseTab.Search -> if (q.isBlank()) null else BrowseSource.Search(q)
         else -> null
     }
     // MemPalace: when a wing is selected, route through ByGenre so the


### PR DESCRIPTION
## Summary
- Royal Road Browse listings (Popular / NewReleases / BestRated / filter-active) now gate on `UiSettings.isSignedIn`. Anonymous visitors see a brass sign-in CTA; signed-in visitors browse as before.
- Search and paste-URL stay open anonymously — they target specific URLs the user already knows, which is structurally distinct from anonymous catalog browsing.
- Supersedes #240 (closed). The soft gate keeps the RR module in the dependency graph; the strict alternative (no RR module at all) is still available later if the Play Store path forces it.

## Why
A signed-in user is already authorized by RR to access fictions. A storyvox client acting on their behalf is request-shape-equivalent to a logged-in browser session. Authenticated traffic removes the "anonymous bot" framing — every request carries a real RR session cookie. The ToS issue doesn't go away, but the cleanest "you're scraping" framing does.

## Changes
- `BrowseViewModel` — new `royalRoadSignedIn: StateFlow<Boolean>` projection from settings. Bundled into a private `AuthSnapshot` flow alongside `githubSignedIn` and `hasGitHubRepoScope` so the outer controls combine stays under the 5-arg overload ceiling (was at 5; now at 4 with the bundle).
- `resolveSource` for RR — Search short-circuits ahead of the gate (stays open anonymously); listing branches return null when `!royalRoadSignedIn` so the paginator never fires.
- `BrowseUiState.royalRoadSignedIn` — surfaces the boolean to the screen.
- `BrowseScreen.RoyalRoadSignedOutCta` — mirrors `FollowsScreen.SignedOutEmpty`'s rhythm (sigil tile, titleMedium primary headline, brass primary CTA) so the two surfaces feel like the same family.
- `StoryvoxNavHost` — wires `onOpenRoyalRoadSignIn` to the same `AUTH_WEBVIEW` route that Settings → Royal Road and Follows → Sign-In already use.

## Test plan
- [x] `./gradlew :app:assembleDebug` — clean build
- [x] `./gradlew test` — all 896 tasks green
- [ ] On-device (R83W80CAFZB): sign out of RR in Settings → open Browse → RR Popular/NewReleases/BestRated show the CTA; Search still works; tap CTA → AUTH_WEBVIEW
- [ ] Signed in: RR Browse behaves exactly as today

🤖 Generated with [Claude Code](https://claude.com/claude-code)