### PR TITLE
feat(browse): RSS feed management migrates to a Browse FAB — closes #247

### DIFF
--- a/feature/src/main/kotlin/in/jphe/storyvox/feature/browse/BrowseRssManageSheet.kt
+++ b/feature/src/main/kotlin/in/jphe/storyvox/feature/browse/BrowseRssManageSheet.kt
@@ -1,0 +1,248 @@
+package `in`.jphe.storyvox.feature.browse
+
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.heightIn
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.HorizontalDivider
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.ModalBottomSheet
+import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.SheetState
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.material3.rememberModalBottomSheetState
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.dp
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import `in`.jphe.storyvox.feature.api.SuggestedFeed
+import `in`.jphe.storyvox.feature.api.SuggestedFeedKind
+import `in`.jphe.storyvox.ui.component.BrassButton
+import `in`.jphe.storyvox.ui.component.BrassButtonVariant
+import `in`.jphe.storyvox.ui.theme.LocalSpacing
+
+/**
+ * Issue #247 — RSS feed management bottom sheet, opened by the FAB on
+ * Browse → RSS. Replaces the inline "RSS feeds" rows that used to
+ * live in Settings → Library & Sync (the source on/off toggle stays
+ * in Settings — that's a different control).
+ *
+ * Three sections:
+ *  1. Add by URL — `OutlinedTextField` + `Add` button.
+ *  2. Subscribed feeds — flat list with per-row `Remove` action.
+ *  3. Suggested feeds — collapsible curated list grouped by category,
+ *     one-tap subscribe.
+ *
+ * Voice and rhythm mirror the existing `AddByUrlSheet` for Library so
+ * the two add-affordances feel like the same family — the user is
+ * paste-something-and-tap-Add in both surfaces.
+ */
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+internal fun BrowseRssManageSheet(
+    viewModel: BrowseViewModel,
+    onDismiss: () -> Unit,
+) {
+    val sheetState: SheetState = rememberModalBottomSheetState(skipPartiallyExpanded = true)
+    val spacing = LocalSpacing.current
+    val subs by viewModel.rssSubscriptions.collectAsStateWithLifecycle()
+    val suggested by viewModel.suggestedRssFeeds.collectAsStateWithLifecycle()
+
+    var draftUrl by remember { mutableStateOf("") }
+    var suggestionsExpanded by remember { mutableStateOf(false) }
+
+    ModalBottomSheet(
+        onDismissRequest = onDismiss,
+        sheetState = sheetState,
+    ) {
+        Column(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(horizontal = spacing.md)
+                .padding(bottom = spacing.xl)
+                .verticalScroll(rememberScrollState()),
+            verticalArrangement = Arrangement.spacedBy(spacing.sm),
+        ) {
+            Text(
+                "Manage RSS feeds",
+                style = MaterialTheme.typography.titleLarge,
+                modifier = Modifier.padding(top = spacing.sm),
+            )
+            Text(
+                "Subscribe to any feed that publishes RSS or Atom. Storyvox treats each feed as one fiction; each item is a chapter.",
+                style = MaterialTheme.typography.bodyMedium,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
+
+            // ── Add by URL ───────────────────────────────────────────
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                verticalAlignment = Alignment.CenterVertically,
+            ) {
+                OutlinedTextField(
+                    value = draftUrl,
+                    onValueChange = { draftUrl = it },
+                    label = { Text("Feed URL") },
+                    placeholder = { Text("https://example.com/feed.xml") },
+                    singleLine = true,
+                    modifier = Modifier.weight(1f),
+                )
+                BrassButton(
+                    label = "Add",
+                    onClick = {
+                        val trimmed = draftUrl.trim()
+                        if (trimmed.isNotEmpty()) {
+                            viewModel.addRssFeed(trimmed)
+                            draftUrl = ""
+                        }
+                    },
+                    variant = BrassButtonVariant.Primary,
+                    modifier = Modifier.padding(start = spacing.sm),
+                )
+            }
+
+            HorizontalDivider(modifier = Modifier.padding(vertical = spacing.xs))
+
+            // ── Subscribed feeds ─────────────────────────────────────
+            Text(
+                text = if (subs.isEmpty()) "No subscriptions yet" else "Your feeds (${subs.size})",
+                style = MaterialTheme.typography.labelMedium,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
+            if (subs.isEmpty()) {
+                Text(
+                    "Paste a feed URL above to subscribe, or pick from the suggested list below.",
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                )
+            } else {
+                subs.forEach { url ->
+                    Row(
+                        modifier = Modifier.fillMaxWidth().padding(vertical = 2.dp),
+                        verticalAlignment = Alignment.CenterVertically,
+                    ) {
+                        Text(
+                            text = url,
+                            style = MaterialTheme.typography.bodySmall,
+                            modifier = Modifier.weight(1f),
+                            maxLines = 1,
+                            overflow = TextOverflow.Ellipsis,
+                        )
+                        TextButton(onClick = { viewModel.removeRssFeedByUrl(url) }) {
+                            Text("Remove")
+                        }
+                    }
+                }
+            }
+
+            HorizontalDivider(modifier = Modifier.padding(vertical = spacing.xs))
+
+            // ── Suggested feeds (collapsible) ────────────────────────
+            // Collapsed by default so users who already have their own
+            // feeds don't trip over a long curated list. Tap header to
+            // expand.
+            Row(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .clickable { suggestionsExpanded = !suggestionsExpanded }
+                    .padding(vertical = 4.dp),
+                verticalAlignment = Alignment.CenterVertically,
+            ) {
+                Text(
+                    text = if (suggestionsExpanded) "▾  Suggested feeds" else "▸  Suggested feeds",
+                    style = MaterialTheme.typography.labelMedium,
+                    color = MaterialTheme.colorScheme.primary,
+                    modifier = Modifier.weight(1f),
+                )
+            }
+            if (!suggestionsExpanded) {
+                Text(
+                    text = "Tap to browse curated feeds (Buddhist & dharma, more coming).",
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                )
+            } else {
+                SuggestedFeedsList(
+                    suggested = suggested,
+                    canonicalSubs = subs.map { it.lowercase() }.toSet(),
+                    onAdd = viewModel::addRssFeed,
+                )
+            }
+        }
+    }
+}
+
+@Composable
+private fun SuggestedFeedsList(
+    suggested: List<SuggestedFeed>,
+    canonicalSubs: Set<String>,
+    onAdd: (String) -> Unit,
+) {
+    val spacing = LocalSpacing.current
+    val byCategory = suggested.groupBy { it.category }
+    byCategory.forEach { (category, suggestions) ->
+        Text(
+            text = category,
+            style = MaterialTheme.typography.labelSmall,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+            modifier = Modifier.padding(top = spacing.sm, bottom = 2.dp),
+        )
+        suggestions.forEach { feed ->
+            val alreadyAdded = feed.url.lowercase() in canonicalSubs
+            Column(modifier = Modifier.padding(vertical = 4.dp)) {
+                Row(verticalAlignment = Alignment.CenterVertically) {
+                    Column(modifier = Modifier.weight(1f)) {
+                        Text(
+                            text = feed.title,
+                            style = MaterialTheme.typography.bodyMedium,
+                        )
+                        Text(
+                            text = feed.description,
+                            style = MaterialTheme.typography.bodySmall,
+                            color = MaterialTheme.colorScheme.onSurfaceVariant,
+                        )
+                        Text(
+                            text = when (feed.kind) {
+                                SuggestedFeedKind.Text ->
+                                    "Text articles — narrate well"
+                                SuggestedFeedKind.AudioPodcast ->
+                                    "Audio podcast — storyvox narrates show notes only"
+                            },
+                            style = MaterialTheme.typography.labelSmall,
+                            color = MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.7f),
+                        )
+                    }
+                    if (alreadyAdded) {
+                        Text(
+                            text = "Added",
+                            style = MaterialTheme.typography.labelSmall,
+                            color = MaterialTheme.colorScheme.primary,
+                            modifier = Modifier.padding(start = spacing.sm, end = spacing.sm),
+                        )
+                    } else {
+                        BrassButton(
+                            label = "Add",
+                            onClick = { onAdd(feed.url) },
+                            variant = BrassButtonVariant.Text,
+                            modifier = Modifier.padding(start = spacing.sm),
+                        )
+                    }
+                }
+            }
+        }
+    }
+}

--- a/feature/src/main/kotlin/in/jphe/storyvox/feature/browse/BrowseScreen.kt
+++ b/feature/src/main/kotlin/in/jphe/storyvox/feature/browse/BrowseScreen.kt
@@ -19,6 +19,7 @@ import androidx.compose.foundation.lazy.grid.itemsIndexed
 import androidx.compose.foundation.lazy.grid.items
 import androidx.compose.foundation.lazy.grid.rememberLazyGridState
 import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Add
 import androidx.compose.material.icons.filled.Close
 import androidx.compose.material.icons.filled.Search
 import androidx.compose.material.icons.outlined.FilterAlt
@@ -26,6 +27,7 @@ import androidx.compose.material3.AssistChip
 import androidx.compose.material3.AssistChipDefaults
 import androidx.compose.material3.Badge
 import androidx.compose.material3.BadgedBox
+import androidx.compose.material3.FloatingActionButton
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
@@ -80,6 +82,9 @@ fun BrowseScreen(
     val state by viewModel.uiState.collectAsStateWithLifecycle()
     val spacing = LocalSpacing.current
     var showFilterSheet by remember { mutableStateOf(false) }
+    /** Issue #247 — RSS feed management moved out of Settings into a
+     *  FAB-launched sheet visible only when sourceKey=Rss. */
+    var showRssManageSheet by remember { mutableStateOf(false) }
 
     // #328 — see LibraryScreen.kt; hoist distinctBy out of the grid
     // builder so allocations happen once per state.items change instead
@@ -97,6 +102,7 @@ fun BrowseScreen(
         out
     }
 
+    Box(modifier = Modifier.fillMaxSize()) {
     Column(modifier = Modifier.fillMaxSize().padding(top = spacing.md)) {
         // Top-level source picker. Switches the multibinding lookup in
         // FictionRepository between Royal Road and GitHub. Tabs and the
@@ -379,6 +385,31 @@ fun BrowseScreen(
                 }
             }
         }
+    }
+
+    // Issue #247 — FAB for RSS feed management. Only visible on the
+    // RSS source; other backends manage subscriptions elsewhere
+    // (Settings folder picker for EPUB, host config for Outline,
+    // sign-in for RR/GitHub).
+    if (state.sourceKey == BrowseSourceKey.Rss) {
+        FloatingActionButton(
+            onClick = { showRssManageSheet = true },
+            containerColor = MaterialTheme.colorScheme.primary,
+            contentColor = MaterialTheme.colorScheme.onPrimary,
+            modifier = Modifier
+                .align(Alignment.BottomEnd)
+                .padding(spacing.lg),
+        ) {
+            Icon(Icons.Filled.Add, contentDescription = "Add RSS feed")
+        }
+    }
+    }  // Box
+
+    if (showRssManageSheet) {
+        BrowseRssManageSheet(
+            viewModel = viewModel,
+            onDismiss = { showRssManageSheet = false },
+        )
     }
 
     if (showFilterSheet) {

--- a/feature/src/main/kotlin/in/jphe/storyvox/feature/browse/BrowseViewModel.kt
+++ b/feature/src/main/kotlin/in/jphe/storyvox/feature/browse/BrowseViewModel.kt
@@ -257,7 +257,7 @@ private data class ControlsView(
 @HiltViewModel
 class BrowseViewModel @Inject constructor(
     private val repo: BrowseRepositoryUi,
-    settings: SettingsRepositoryUi,
+    private val settings: SettingsRepositoryUi,
 ) : ViewModel() {
 
     private val _sourceKey = MutableStateFlow(BrowseSourceKey.RoyalRoad)
@@ -608,6 +608,36 @@ class BrowseViewModel @Inject constructor(
      *  calls. */
     fun loadMore() {
         viewModelScope.launch { paginator.value?.loadNext() }
+    }
+
+    // ─── RSS feed management (#247) ────────────────────────────────────
+    // Moved from SettingsViewModel as part of the "whole move" of feed
+    // add/remove out of Settings into a FAB-launched sheet on Browse →
+    // RSS. The underlying repository surface didn't change; we just
+    // changed where the user reaches it. SettingsScreen still owns the
+    // RSS source on/off toggle (that's a "source enable" call, not
+    // "feed management").
+
+    /** Hot stream of currently-subscribed feed URLs. Drives the
+     *  removable-feeds list in the Browse RSS management sheet. */
+    val rssSubscriptions: StateFlow<List<String>> =
+        settings.rssSubscriptions
+            .stateIn(viewModelScope, SharingStarted.WhileSubscribed(5_000), emptyList())
+
+    /** Hot stream of curated suggested feeds. Backed by the
+     *  jphein/storyvox-feeds registry (#246) with a baked-in seed list
+     *  so the sheet's "Suggested" section has something to render
+     *  before the network fetch resolves. */
+    val suggestedRssFeeds: StateFlow<List<`in`.jphe.storyvox.feature.api.SuggestedFeed>> =
+        settings.suggestedRssFeeds
+            .stateIn(viewModelScope, SharingStarted.WhileSubscribed(5_000), emptyList())
+
+    fun addRssFeed(url: String) {
+        viewModelScope.launch { settings.addRssFeed(url) }
+    }
+
+    fun removeRssFeedByUrl(url: String) {
+        viewModelScope.launch { settings.removeRssFeedByUrl(url) }
     }
 }
 

--- a/feature/src/main/kotlin/in/jphe/storyvox/feature/settings/SettingsScreen.kt
+++ b/feature/src/main/kotlin/in/jphe/storyvox/feature/settings/SettingsScreen.kt
@@ -459,18 +459,14 @@ fun SettingsScreen(
             )
             SettingsSwitchRow(
                 title = "RSS / Atom feeds",
-                subtitle = "Subscribe to feeds and read new entries as chapters.",
+                subtitle = "Subscribe to feeds and read new entries as chapters. Manage your subscriptions in Browse → RSS.",
                 checked = s.sourceRssEnabled,
                 onCheckedChange = viewModel::setSourceRssEnabled,
             )
-            // Feed-list management surface — only meaningful when RSS
-            // is enabled. Tapping opens an inline editor that lists
-            // current subscriptions and lets the user add a new feed
-            // by URL.
-            if (s.sourceRssEnabled) {
-                RssFeedManagementRow(viewModel = viewModel)
-                RssSuggestedFeedsRow(viewModel = viewModel)
-            }
+            // Issue #247 — feed add/remove/suggested moved to a FAB-
+            // launched sheet on Browse → RSS. Only the source on/off
+            // toggle stays here; that's a "source enable" call, not
+            // "feed management".
             SettingsSwitchRow(
                 title = "Local EPUB files",
                 subtitle = "Read .epub files from a folder you pick.",
@@ -2766,78 +2762,6 @@ private fun AnthropicTeamsProviderRows(
 }
 
 
-/**
- * Issue #236 — inline feed-list management for the RSS backend.
- * Lists current subscriptions and offers an add-by-URL field.
- * Removal is a small "x" button per row; add is the right-side
- * BrassButton on the input field.
- */
-@Composable
-private fun RssFeedManagementRow(viewModel: SettingsViewModel) {
-    val subs by viewModel.rssSubscriptions.collectAsStateWithLifecycle()
-    var draftUrl by remember { mutableStateOf("") }
-    val spacing = LocalSpacing.current
-
-    Column(modifier = Modifier.padding(horizontal = spacing.md, vertical = spacing.sm)) {
-        Text(
-            "Subscribed feeds",
-            style = MaterialTheme.typography.labelMedium,
-            color = MaterialTheme.colorScheme.onSurfaceVariant,
-            modifier = Modifier.padding(bottom = spacing.xs),
-        )
-        if (subs.isEmpty()) {
-            Text(
-                "No feeds yet. Paste an RSS or Atom feed URL below.",
-                style = MaterialTheme.typography.bodySmall,
-                color = MaterialTheme.colorScheme.onSurfaceVariant,
-                modifier = Modifier.padding(bottom = spacing.sm),
-            )
-        } else {
-            subs.forEach { url ->
-                Row(
-                    modifier = Modifier.fillMaxWidth().padding(vertical = 2.dp),
-                    verticalAlignment = androidx.compose.ui.Alignment.CenterVertically,
-                ) {
-                    Text(
-                        text = url,
-                        style = MaterialTheme.typography.bodySmall,
-                        modifier = Modifier.weight(1f),
-                        maxLines = 1,
-                        overflow = androidx.compose.ui.text.style.TextOverflow.Ellipsis,
-                    )
-                    androidx.compose.material3.TextButton(onClick = {
-                        viewModel.removeRssFeedByUrl(url)
-                    }) { Text("Remove") }
-                }
-            }
-        }
-        Row(
-            modifier = Modifier.fillMaxWidth().padding(top = spacing.sm),
-            verticalAlignment = androidx.compose.ui.Alignment.CenterVertically,
-        ) {
-            androidx.compose.material3.OutlinedTextField(
-                value = draftUrl,
-                onValueChange = { draftUrl = it },
-                label = { Text("Feed URL") },
-                placeholder = { Text("https://example.com/feed.xml") },
-                singleLine = true,
-                modifier = Modifier.weight(1f),
-            )
-            BrassButton(
-                label = "Add",
-                onClick = {
-                    val trimmed = draftUrl.trim()
-                    if (trimmed.isNotEmpty()) {
-                        viewModel.addRssFeed(trimmed)
-                        draftUrl = ""
-                    }
-                },
-                variant = BrassButtonVariant.Primary,
-                modifier = Modifier.padding(start = spacing.sm),
-            )
-        }
-    }
-}
 
 /**
  * Issue #235 — folder-picker row for the EPUB backend. SAF tree
@@ -2911,105 +2835,6 @@ private fun abbreviateSafUri(raw: String): String {
     return runCatching { java.net.URLDecoder.decode(tree, "UTF-8") }.getOrDefault(tree)
 }
 
-/**
- * Issue #236 follow-up — collapsible "Suggested feeds" section.
- * Renders [SUGGESTED_FEEDS] grouped by category with one-tap Add.
- * Stays collapsed by default to keep the picker clean for users
- * who already have their own feeds.
- */
-@Composable
-private fun RssSuggestedFeedsRow(viewModel: SettingsViewModel) {
-    val subs by viewModel.rssSubscriptions.collectAsStateWithLifecycle()
-    val spacing = LocalSpacing.current
-    var expanded by remember { mutableStateOf(false) }
-
-    Column(modifier = Modifier.padding(horizontal = spacing.md, vertical = spacing.sm)) {
-        Row(
-            modifier = Modifier
-                .fillMaxWidth()
-                .clickable { expanded = !expanded }
-                .padding(vertical = 4.dp),
-            verticalAlignment = androidx.compose.ui.Alignment.CenterVertically,
-        ) {
-            Text(
-                text = if (expanded) "▾  Suggested feeds" else "▸  Suggested feeds",
-                style = MaterialTheme.typography.labelMedium,
-                color = MaterialTheme.colorScheme.primary,
-                modifier = Modifier.weight(1f),
-            )
-        }
-        if (!expanded) {
-            Text(
-                text = "Tap to browse curated feeds (Buddhist & dharma, more coming).",
-                style = MaterialTheme.typography.bodySmall,
-                color = MaterialTheme.colorScheme.onSurfaceVariant,
-            )
-            return@Column
-        }
-
-        // Group by category, render each category as a small header
-        // followed by the suggestion rows. List is fetched from
-        // jphein/storyvox-feeds at runtime (#246) — falls back to
-        // BAKED_IN_SUGGESTED_FEEDS while the fetch is in flight.
-        val suggested by viewModel.suggestedRssFeeds.collectAsStateWithLifecycle()
-        val byCategory = suggested.groupBy { it.category }
-        val canonicalSubs = subs.map { it.lowercase() }.toSet()
-        byCategory.forEach { (category, suggestions) ->
-            Text(
-                text = category,
-                style = MaterialTheme.typography.labelSmall,
-                color = MaterialTheme.colorScheme.onSurfaceVariant,
-                modifier = Modifier.padding(top = spacing.sm, bottom = 2.dp),
-            )
-            suggestions.forEach { feed ->
-                val alreadyAdded = feed.url.lowercase() in canonicalSubs
-                Column(modifier = Modifier.padding(vertical = 4.dp)) {
-                    Row(verticalAlignment = androidx.compose.ui.Alignment.CenterVertically) {
-                        Column(modifier = Modifier.weight(1f)) {
-                            Text(
-                                text = feed.title,
-                                style = MaterialTheme.typography.bodyMedium,
-                            )
-                            Text(
-                                text = feed.description,
-                                style = MaterialTheme.typography.bodySmall,
-                                color = MaterialTheme.colorScheme.onSurfaceVariant,
-                            )
-                            // Show the kind hint inline so users know the
-                            // audio-podcast caveat (storyvox narrates show
-                            // notes, not the audio file itself).
-                            Text(
-                                text = when (feed.kind) {
-                                    `in`.jphe.storyvox.feature.api.SuggestedFeedKind.Text ->
-                                        "Text articles — narrate well"
-                                    `in`.jphe.storyvox.feature.api.SuggestedFeedKind.AudioPodcast ->
-                                        "Audio podcast — storyvox narrates show notes only"
-                                },
-                                style = MaterialTheme.typography.labelSmall,
-                                color = MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.7f),
-                            )
-                        }
-                        if (alreadyAdded) {
-                            Text(
-                                text = "Added",
-                                style = MaterialTheme.typography.labelSmall,
-                                color = MaterialTheme.colorScheme.primary,
-                                modifier = Modifier.padding(start = spacing.sm, end = spacing.sm),
-                            )
-                        } else {
-                            BrassButton(
-                                label = "Add",
-                                onClick = { viewModel.addRssFeed(feed.url) },
-                                variant = BrassButtonVariant.Text,
-                                modifier = Modifier.padding(start = spacing.sm),
-                            )
-                        }
-                    }
-                }
-            }
-        }
-    }
-}
 
 /**
  * Issue #245 — host + API-key entry for the Outline self-hosted-wiki


### PR DESCRIPTION
## Summary
- New `+ Add feed` FAB on Browse → RSS opens a ModalBottomSheet that owns the entire feed-management surface: add by URL, list/remove subscribed feeds, browse suggested feeds.
- The two RSS management blocks (`RssFeedManagementRow`, `RssSuggestedFeedsRow`) are removed from Settings → Library & Sync. The source on/off toggle stays — that's a different control.
- Repository surface (`SettingsRepositoryUi.{addRssFeed, removeRssFeedByUrl, rssSubscriptions, suggestedRssFeeds}`) is unchanged; `BrowseViewModel` calls it directly now instead of going through `SettingsViewModel`.

## Why
The management UX was discoverable only after the user had already toggled the source on in Settings, and even then lived two screens away from where feeds actually appear. Browse becomes the single home: tap RSS → tap FAB → paste URL → done.

## Test plan
- [x] `./gradlew :app:assembleDebug` — clean build
- [x] `./gradlew test` — all 942 tasks green
- [ ] On-device (R83W80CAFZB): Browse → RSS → FAB → paste a feed URL → Add → feed appears in the grid → reopen sheet → Remove → grid empties; the suggested feeds section expands and one-tap subscribes work
- [ ] Settings → Library & Sync → RSS toggle still works; the inline feed list is gone; subtitle hints at Browse

## What I considered and rejected
- Keeping a "Manage feeds → Browse" back-link in Settings — the subtitle already tells the user where to go; a tappable shortcut row would duplicate the bottom-nav Browse tab one finger away.
- Moving the on/off toggle too — JP confirmed "whole move" applies only to feed *management*; the toggle still belongs with the other source enable/disable controls.

🤖 Generated with [Claude Code](https://claude.com/claude-code)