### PR TITLE
feat(fiction-detail): Follow on Royal Road button — closes #211

### DIFF
--- a/app/src/main/kotlin/in/jphe/storyvox/di/AppBindings.kt
+++ b/app/src/main/kotlin/in/jphe/storyvox/di/AppBindings.kt
@@ -350,6 +350,19 @@ private class RealFictionRepositoryUi(
         if (follow) repo.addToLibrary(fictionId, mode = null) else repo.removeFromLibrary(fictionId)
     }
 
+    override suspend fun setFollowedRemote(
+        fictionId: String,
+        followed: Boolean,
+    ): `in`.jphe.storyvox.feature.api.SetFollowedRemoteResult =
+        when (val r = repo.setFollowedRemote(fictionId, followed)) {
+            is FictionResult.Success ->
+                `in`.jphe.storyvox.feature.api.SetFollowedRemoteResult.Success
+            is FictionResult.AuthRequired ->
+                `in`.jphe.storyvox.feature.api.SetFollowedRemoteResult.AuthRequired
+            is FictionResult.Failure ->
+                `in`.jphe.storyvox.feature.api.SetFollowedRemoteResult.Error(r.message)
+        }
+
     override suspend fun markAllCaughtUp() {
         // No-op for v1 — chapter-level "read" tracking lands when the reader is wired.
     }

--- a/app/src/main/kotlin/in/jphe/storyvox/navigation/StoryvoxNavHost.kt
+++ b/app/src/main/kotlin/in/jphe/storyvox/navigation/StoryvoxNavHost.kt
@@ -352,9 +352,9 @@ private fun StoryvoxNavHostContent(
             ) {
                 BrowseScreen(
                     onOpenFiction = { id -> navController.navigate(StoryvoxRoutes.fictionDetail(id)) },
-                    // #241 — RR Browse listings are gated on sign-in; the CTA in
-                    // the empty state routes through the same WebView that
-                    // Settings → Royal Road and Follows → Sign-In use.
+                    // #241 / #211 — RR sign-in CTA shared between Browse
+                    // (anonymous-listing CTA) and FictionDetail (Follow
+                    // button) and Settings → Royal Road.
                     onOpenRoyalRoadSignIn = { navController.navigate(StoryvoxRoutes.AUTH_WEBVIEW) },
                 )
             }
@@ -370,6 +370,9 @@ private fun StoryvoxNavHostContent(
                 FictionDetailScreen(
                     onOpenReader = { f, c -> navController.navigate(StoryvoxRoutes.reader(f, c)) },
                     onBack = { navController.popBackStack() },
+                    // #211 — Follow on Royal Road button routes to the
+                    // shared sign-in WebView when the user is anonymous.
+                    onOpenRoyalRoadSignIn = { navController.navigate(StoryvoxRoutes.AUTH_WEBVIEW) },
                 )
             }
 

--- a/core-data/src/main/kotlin/in/jphe/storyvox/data/repository/FictionRepository.kt
+++ b/core-data/src/main/kotlin/in/jphe/storyvox/data/repository/FictionRepository.kt
@@ -388,6 +388,7 @@ internal fun Fiction.toSummary(): FictionSummary = FictionSummary(
     status = status,
     chapterCount = chapterCount,
     rating = rating,
+    followedRemotely = followedRemotely,
 )
 
 internal fun FictionSummary.toEntity(now: Long): Fiction = Fiction(

--- a/core-data/src/main/kotlin/in/jphe/storyvox/data/source/model/FictionSummary.kt
+++ b/core-data/src/main/kotlin/in/jphe/storyvox/data/source/model/FictionSummary.kt
@@ -17,4 +17,10 @@ data class FictionSummary(
     val status: FictionStatus = FictionStatus.ONGOING,
     val chapterCount: Int? = null,
     val rating: Float? = null,
+    /** Issue #211 — true when storyvox has pushed a follow to the
+     *  source's account (e.g. Royal Road's `/fictions/setbookmark`)
+     *  or the periodic pull observed the user follows this fiction.
+     *  Defaults to false; only meaningful for sources with an
+     *  account-side follow concept (RR today). */
+    val followedRemotely: Boolean = false,
 )

--- a/feature/src/main/kotlin/in/jphe/storyvox/feature/api/UiContracts.kt
+++ b/feature/src/main/kotlin/in/jphe/storyvox/feature/api/UiContracts.kt
@@ -21,6 +21,17 @@ data class UiFiction(
     val chapterCount: Int,
     val isOngoing: Boolean,
     val synopsis: String,
+    /** Issue #211 — the FictionSource this fiction came from. Drives
+     *  the "Follow on Royal Road" affordance on FictionDetail; non-RR
+     *  sources don't have a source-side follow concept. Defaulted to
+     *  empty so existing construction sites stay compatible. */
+    val sourceId: String = "",
+    /** Issue #211 — true when storyvox has pushed a follow to the
+     *  source's account (via [FictionRepositoryUi.setFollowedRemote])
+     *  OR when the periodic /my/follows pull observed the user
+     *  follows this fiction on RR. Drives the Follow-button label
+     *  (Follow / Following). */
+    val isFollowedRemote: Boolean = false,
 )
 
 data class UiChapter(
@@ -63,6 +74,17 @@ enum class SuggestedFeedKind {
     AudioPodcast,
 }
 
+/** Outcome of a source-side follow toggle (#211). */
+sealed class SetFollowedRemoteResult {
+    /** Push succeeded; storyvox's local copy already updated. */
+    data object Success : SetFollowedRemoteResult()
+    /** Source rejected without a session — caller should route the
+     *  user to sign-in (Royal Road today). */
+    data object AuthRequired : SetFollowedRemoteResult()
+    /** Anything else — `message` is user-facing copy. */
+    data class Error(val message: String) : SetFollowedRemoteResult()
+}
+
 /** Outcome of pasting a URL into the add-fiction sheet. */
 sealed class UiAddByUrlResult {
     /** Resolved + persisted; UI navigates to the detail screen. */
@@ -99,6 +121,15 @@ interface FictionRepositoryUi {
     suspend fun chapterTextById(chapterId: String): String?
     suspend fun setDownloadMode(fictionId: String, mode: DownloadMode)
     suspend fun follow(fictionId: String, follow: Boolean)
+    /**
+     * Issue #211 — push a follow/unfollow to the *source* (Royal Road's
+     * account, not storyvox's local library). The source layer
+     * handles auth: returns silently on AuthRequired so callers can
+     * pre-check sign-in and route to the appropriate screen instead
+     * of swallowing the no-op. Distinct from [follow], which is local
+     * library Add/Remove.
+     */
+    suspend fun setFollowedRemote(fictionId: String, followed: Boolean): SetFollowedRemoteResult
     suspend fun markAllCaughtUp()
     /**
      * Best-effort refresh of the user's source-side follows list. No-op if

--- a/feature/src/main/kotlin/in/jphe/storyvox/feature/browse/RealBrowsePaginator.kt
+++ b/feature/src/main/kotlin/in/jphe/storyvox/feature/browse/RealBrowsePaginator.kt
@@ -84,4 +84,6 @@ fun toUiFiction(s: FictionSummary): UiFiction = UiFiction(
     chapterCount = s.chapterCount ?: 0,
     isOngoing = s.status == FictionStatus.ONGOING,
     synopsis = s.description.orEmpty(),
+    sourceId = s.sourceId,
+    isFollowedRemote = s.followedRemotely,
 )

--- a/feature/src/main/kotlin/in/jphe/storyvox/feature/fiction/FictionDetailScreen.kt
+++ b/feature/src/main/kotlin/in/jphe/storyvox/feature/fiction/FictionDetailScreen.kt
@@ -76,6 +76,11 @@ fun FictionDetailScreen(
      *  preview/test use working but should never be the production
      *  callsite. */
     onBack: () -> Unit = {},
+    /** Issue #211 — routes the Royal Road sign-in flow when the user
+     *  taps Follow on RR without an active session. Same destination
+     *  as Settings → Royal Road and the Browse anonymous-CTA from
+     *  #241. */
+    onOpenRoyalRoadSignIn: () -> Unit = {},
     viewModel: FictionDetailViewModel = hiltViewModel(),
 ) {
     val state by viewModel.uiState.collectAsStateWithLifecycle()
@@ -122,6 +127,9 @@ fun FictionDetailScreen(
                 is FictionDetailUiEvent.OpenReader -> onOpenReader(event.fictionId, event.chapterId)
                 is FictionDetailUiEvent.EpubExported -> pendingExport = event.result
                 is FictionDetailUiEvent.EpubExportFailed ->
+                    snackbarHostState.showSnackbar(event.message)
+                FictionDetailUiEvent.OpenRoyalRoadSignIn -> onOpenRoyalRoadSignIn()
+                is FictionDetailUiEvent.FollowFailed ->
                     snackbarHostState.showSnackbar(event.message)
             }
         }
@@ -303,6 +311,8 @@ fun FictionDetailScreen(
 
             BottomBar(
                 isInLibrary = state.isInLibrary,
+                followOnSource = fiction.takeIf { it.sourceId == "royalroad" }
+                    ?.let { FollowOnSourceUiState(isFollowed = it.isFollowedRemote) },
                 onFollow = {
                     // Issue #169 — gate the destructive path behind a
                     // confirm dialog; the additive path stays single-tap.
@@ -312,6 +322,7 @@ fun FictionDetailScreen(
                         viewModel.toggleFollow(true)
                     }
                 },
+                onFollowOnSource = viewModel::toggleFollowOnSource,
                 onListen = { state.chapters.firstOrNull()?.id?.let(viewModel::listen) },
                 modifier = Modifier.align(Alignment.BottomCenter),
             )
@@ -345,6 +356,8 @@ fun FictionDetailScreen(
 
             BottomBar(
                 isInLibrary = state.isInLibrary,
+                followOnSource = fiction.takeIf { it.sourceId == "royalroad" }
+                    ?.let { FollowOnSourceUiState(isFollowed = it.isFollowedRemote) },
                 onFollow = {
                     // Issue #169 — gate the destructive path behind a
                     // confirm dialog; the additive path stays single-tap.
@@ -354,6 +367,7 @@ fun FictionDetailScreen(
                         viewModel.toggleFollow(true)
                     }
                 },
+                onFollowOnSource = viewModel::toggleFollowOnSource,
                 onListen = { state.chapters.firstOrNull()?.id?.let(viewModel::listen) },
                 modifier = Modifier.align(Alignment.BottomCenter),
             )
@@ -542,7 +556,14 @@ private fun Synopsis(text: String) {
 @Composable
 private fun BottomBar(
     isInLibrary: Boolean,
+    /** Issue #211 — non-null only for Royal Road fictions. When set,
+     *  surfaces an inline "Follow" / "Following" toggle next to the
+     *  library button so users can push a follow to RR without
+     *  leaving the page. The label reads `Following` when storyvox
+     *  has observed the user already follows on RR. */
+    followOnSource: FollowOnSourceUiState? = null,
     onFollow: () -> Unit,
+    onFollowOnSource: () -> Unit = {},
     onListen: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
@@ -563,6 +584,14 @@ private fun BottomBar(
                 variant = BrassButtonVariant.Secondary,
                 modifier = Modifier.weight(1f),
             )
+            if (followOnSource != null) {
+                BrassButton(
+                    label = if (followOnSource.isFollowed) "Following" else "Follow",
+                    onClick = onFollowOnSource,
+                    variant = BrassButtonVariant.Secondary,
+                    modifier = Modifier.weight(1f),
+                )
+            }
             BrassButton(
                 label = "Listen",
                 onClick = onListen,
@@ -572,6 +601,14 @@ private fun BottomBar(
         }
     }
 }
+
+/** Issue #211 — payload for the source-side follow chip. Held as a
+ *  small struct rather than separate booleans so the BottomBar
+ *  composable's signature stays compact; the screen passes null when
+ *  the fiction isn't from a follow-aware source. */
+private data class FollowOnSourceUiState(
+    val isFollowed: Boolean,
+)
 
 private fun UiChapter.toCardState(currentId: String?) = ChapterCardState(
     number = number,

--- a/feature/src/main/kotlin/in/jphe/storyvox/feature/fiction/FictionDetailViewModel.kt
+++ b/feature/src/main/kotlin/in/jphe/storyvox/feature/fiction/FictionDetailViewModel.kt
@@ -9,6 +9,8 @@ import dagger.hilt.android.lifecycle.HiltViewModel
 import `in`.jphe.storyvox.feature.api.DownloadMode
 import `in`.jphe.storyvox.feature.api.FictionRepositoryUi
 import `in`.jphe.storyvox.feature.api.PlaybackControllerUi
+import `in`.jphe.storyvox.feature.api.SetFollowedRemoteResult
+import `in`.jphe.storyvox.feature.api.SettingsRepositoryUi
 import `in`.jphe.storyvox.feature.api.UiChapter
 import `in`.jphe.storyvox.feature.api.UiFiction
 import `in`.jphe.storyvox.source.epub.writer.EpubExportResult
@@ -18,6 +20,8 @@ import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.combine
+import kotlinx.coroutines.flow.distinctUntilChanged
+import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.receiveAsFlow
 import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.launch
@@ -54,6 +58,14 @@ sealed interface FictionDetailUiEvent {
     /** Issue #117 — surfaces non-fatal export failures (no network for
      *  the cover, disk write error, etc) so the screen can toast. */
     data class EpubExportFailed(val message: String) : FictionDetailUiEvent
+    /** Issue #211 — RR follow tapped while anonymous. Screen routes
+     *  the user to the Royal Road sign-in WebView (same destination
+     *  Settings → Royal Road and the #241 Browse CTA use). */
+    data object OpenRoyalRoadSignIn : FictionDetailUiEvent
+    /** Issue #211 — RR returned a non-auth error on the follow POST
+     *  (network, CSRF token miss, 500). Surfaced as a toast so the
+     *  user knows the tap didn't take. */
+    data class FollowFailed(val message: String) : FictionDetailUiEvent
 }
 
 @HiltViewModel
@@ -61,8 +73,18 @@ class FictionDetailViewModel @Inject constructor(
     private val repo: FictionRepositoryUi,
     private val playback: PlaybackControllerUi,
     private val exportEpub: ExportFictionToEpubUseCase,
+    settings: SettingsRepositoryUi,
     savedState: SavedStateHandle,
 ) : ViewModel() {
+
+    /** Issue #211 — Royal Road sign-in projection. Read at button-tap
+     *  time to decide whether to call the source push or route the
+     *  user to AUTH_WEBVIEW. StateFlow (not cold Flow) so the
+     *  imperative .value read in [toggleFollowOnSource] is correct. */
+    private val royalRoadSignedIn: StateFlow<Boolean> = settings.settings
+        .map { it.isSignedIn }
+        .distinctUntilChanged()
+        .stateIn(viewModelScope, SharingStarted.WhileSubscribed(5_000), false)
 
     private val fictionId: String = checkNotNull(savedState["fictionId"]) {
         "FictionDetailScreen requires a `fictionId` nav arg"
@@ -98,6 +120,43 @@ class FictionDetailViewModel @Inject constructor(
 
     fun toggleFollow(follow: Boolean) {
         viewModelScope.launch { repo.follow(fictionId, follow) }
+    }
+
+    /**
+     * Issue #211 — push a follow/unfollow to Royal Road's account
+     * (distinct from [toggleFollow], which is local library Add/Remove).
+     *
+     * Pre-checks sign-in: if the user isn't signed in we route them to
+     * the Royal Road sign-in WebView via [FictionDetailUiEvent.OpenRoyalRoadSignIn]
+     * rather than calling the source and silently no-op-ing. After a
+     * successful sign-in the user lands back here and taps again.
+     *
+     * Errors that aren't AuthRequired surface as toast events so the
+     * tap isn't a black hole; the button's optimistic UI flips when
+     * the source confirms via the underlying Fiction.followedRemotely
+     * flow.
+     */
+    fun toggleFollowOnSource() {
+        val current = uiState.value.fiction ?: return
+        if (!royalRoadSignedIn.value) {
+            viewModelScope.launch { _events.send(FictionDetailUiEvent.OpenRoyalRoadSignIn) }
+            return
+        }
+        val newValue = !current.isFollowedRemote
+        viewModelScope.launch {
+            when (val r = repo.setFollowedRemote(fictionId, newValue)) {
+                SetFollowedRemoteResult.Success -> { /* UI flips via the flow */ }
+                SetFollowedRemoteResult.AuthRequired -> {
+                    // Belt-and-braces: pre-check said signed in but the
+                    // session may have expired between then and the
+                    // POST. Route to sign-in to refresh.
+                    _events.send(FictionDetailUiEvent.OpenRoyalRoadSignIn)
+                }
+                is SetFollowedRemoteResult.Error -> {
+                    _events.send(FictionDetailUiEvent.FollowFailed(r.message))
+                }
+            }
+        }
     }
 
     fun setMode(mode: DownloadMode) {

--- a/feature/src/test/kotlin/in/jphe/storyvox/feature/chat/ChatViewModelTest.kt
+++ b/feature/src/test/kotlin/in/jphe/storyvox/feature/chat/ChatViewModelTest.kt
@@ -445,6 +445,11 @@ private class FakeFictionRepo(
     override suspend fun chapterTextById(chapterId: String): String? = null
     override suspend fun setDownloadMode(fictionId: String, mode: DownloadMode) = Unit
     override suspend fun follow(fictionId: String, follow: Boolean) = Unit
+    override suspend fun setFollowedRemote(
+        fictionId: String,
+        followed: Boolean,
+    ): `in`.jphe.storyvox.feature.api.SetFollowedRemoteResult =
+        `in`.jphe.storyvox.feature.api.SetFollowedRemoteResult.Success
     override suspend fun markAllCaughtUp() = Unit
     override suspend fun refreshFollows() = Unit
     override suspend fun addByUrl(url: String): UiAddByUrlResult = UiAddByUrlResult.UnrecognizedUrl


### PR DESCRIPTION
## Summary
Inline FictionDetail bottom bar gets a *Follow* / *Following* button next to *Add to library* and *Listen*. Pushes the follow state to RR's account via the existing `RoyalRoadSource.setFollowed()` (CSRF-token + POST to `/fictions/setbookmark`). Visible only on RR-sourced fictions; non-RR sources don't have a source-side follow concept.

## Sign-in handling (per #211 design call)
Always-shown, opens sign-in if anonymous. Tapping when not signed in routes to `AUTH_WEBVIEW` (the same destination Settings → Royal Road and the Browse anonymous-CTA from #241 use). Belt-and-braces on `AuthRequired` post-POST so a session-expired-between-check-and-call race still routes the user to sign-in cleanly.

## Pull side was already there
`FollowsViewModel.refreshFollows()` scrapes `/my/follows` on every Follows-tab refresh, so the periodic pull-from-RR loop has been live since v0.4.x. This PR adds the push direction, completing the two-way sync JP asked for in the issue answer.

## Test plan
- [x] `./gradlew :app:assembleDebug` — clean build
- [x] `./gradlew test` — 942 tasks green; `FakeFictionRepo` in `ChatViewModelTest` gains a `setFollowedRemote` stub
- [ ] On-device (R83W80CAFZB): open a RR fiction → Follow button shows → not-signed-in tap routes to WebView → after sign-in, tap again → button flips to "Following" → tap once more → flips back. Open a non-RR fiction → Follow button absent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)