### PR TITLE
feat(nav): promote Voices to bottom-nav, move Settings to per-screen gear

### DIFF
--- a/app/src/main/kotlin/in/jphe/storyvox/navigation/StoryvoxNavHost.kt
+++ b/app/src/main/kotlin/in/jphe/storyvox/navigation/StoryvoxNavHost.kt
@@ -102,7 +102,7 @@ object StoryvoxRoutes {
         else "$base?prefill=${Uri.encode(prefill)}"
     }
 
-    private val HOME_ROUTES = setOf(PLAYING, LIBRARY, FOLLOWS, BROWSE, SETTINGS)
+    private val HOME_ROUTES = setOf(PLAYING, LIBRARY, FOLLOWS, BROWSE, VOICE_LIBRARY)
     fun isHome(route: String?) = route in HOME_ROUTES
 
     /** Issue #267 — Reader / Audiobook routes ARE the player surface, just
@@ -183,7 +183,7 @@ private fun StoryvoxNavHostContent(
                         currentRoute == StoryvoxRoutes.PLAYING -> HomeTab.Playing
                         currentRoute == StoryvoxRoutes.FOLLOWS -> HomeTab.Follows
                         currentRoute == StoryvoxRoutes.BROWSE -> HomeTab.Browse
-                        currentRoute == StoryvoxRoutes.SETTINGS -> HomeTab.Settings
+                        currentRoute == StoryvoxRoutes.VOICE_LIBRARY -> HomeTab.Voices
                         // Issue #267 — the Reader / Audiobook drill-downs ARE
                         // the player surface, so light the Playing tab while
                         // we're on them. Without this branch they'd fall
@@ -198,7 +198,7 @@ private fun StoryvoxNavHostContent(
                             HomeTab.Library -> StoryvoxRoutes.LIBRARY
                             HomeTab.Follows -> StoryvoxRoutes.FOLLOWS
                             HomeTab.Browse -> StoryvoxRoutes.BROWSE
-                            HomeTab.Settings -> StoryvoxRoutes.SETTINGS
+                            HomeTab.Voices -> StoryvoxRoutes.VOICE_LIBRARY
                         }
                         if (target != currentRoute) {
                             // Pop everything above the start destination so
@@ -302,6 +302,7 @@ private fun StoryvoxNavHostContent(
                 HybridReaderScreen(
                     onPickVoice = { navController.navigate(StoryvoxRoutes.VOICE_LIBRARY) },
                     onOpenAiSettings = { navController.navigate(StoryvoxRoutes.SETTINGS) },
+                    onOpenSettings = { navController.navigate(StoryvoxRoutes.SETTINGS) },
                     onOpenChat = { fId, prefill -> navController.navigate(StoryvoxRoutes.chat(fId, prefill)) },
                     // ResumeEmptyPrompt's "Browse the realms" CTA — only
                     // matters when the user has no continue-listening
@@ -329,6 +330,7 @@ private fun StoryvoxNavHostContent(
                 LibraryScreen(
                     onOpenFiction = { id -> navController.navigate(StoryvoxRoutes.fictionDetail(id)) },
                     onOpenReader = { f, c -> navController.navigate(StoryvoxRoutes.reader(f, c)) },
+                    onOpenSettings = { navController.navigate(StoryvoxRoutes.SETTINGS) },
                 )
             }
             composable(
@@ -341,6 +343,7 @@ private fun StoryvoxNavHostContent(
                 FollowsScreen(
                     onOpenFiction = { id -> navController.navigate(StoryvoxRoutes.fictionDetail(id)) },
                     onOpenSignIn = { navController.navigate(StoryvoxRoutes.AUTH_WEBVIEW) },
+                    onOpenSettings = { navController.navigate(StoryvoxRoutes.SETTINGS) },
                 )
             }
             composable(
@@ -356,6 +359,7 @@ private fun StoryvoxNavHostContent(
                     // (anonymous-listing CTA) and FictionDetail (Follow
                     // button) and Settings → Royal Road.
                     onOpenRoyalRoadSignIn = { navController.navigate(StoryvoxRoutes.AUTH_WEBVIEW) },
+                    onOpenSettings = { navController.navigate(StoryvoxRoutes.SETTINGS) },
                 )
             }
 
@@ -390,6 +394,7 @@ private fun StoryvoxNavHostContent(
                 HybridReaderScreen(
                     onPickVoice = { navController.navigate(StoryvoxRoutes.VOICE_LIBRARY) },
                     onOpenAiSettings = { navController.navigate(StoryvoxRoutes.SETTINGS) },
+                    onOpenSettings = { navController.navigate(StoryvoxRoutes.SETTINGS) },
                     onOpenChat = { fId, prefill -> navController.navigate(StoryvoxRoutes.chat(fId, prefill)) },
                 )
             }
@@ -408,6 +413,7 @@ private fun StoryvoxNavHostContent(
                 HybridReaderScreen(
                     onPickVoice = { navController.navigate(StoryvoxRoutes.VOICE_LIBRARY) },
                     onOpenAiSettings = { navController.navigate(StoryvoxRoutes.SETTINGS) },
+                    onOpenSettings = { navController.navigate(StoryvoxRoutes.SETTINGS) },
                     onOpenChat = { fId, prefill -> navController.navigate(StoryvoxRoutes.chat(fId, prefill)) },
                 )
             }
@@ -508,13 +514,13 @@ private fun StoryvoxNavHostContent(
             }
             composable(
                 StoryvoxRoutes.VOICE_LIBRARY,
-                enterTransition = pushEnter,
-                exitTransition = pushExit,
-                popEnterTransition = popEnter,
-                popExitTransition = popExit,
+                enterTransition = homeEnter,
+                exitTransition = homeExit,
+                popEnterTransition = homeEnter,
+                popExitTransition = homeExit,
             ) {
                 VoiceLibraryScreen(
-                    onBack = { navController.popBackStack() },
+                    onOpenSettings = { navController.navigate(StoryvoxRoutes.SETTINGS) },
                 )
             }
             composable(

--- a/core-ui/src/main/kotlin/in/jphe/storyvox/ui/component/BottomTabBar.kt
+++ b/core-ui/src/main/kotlin/in/jphe/storyvox/ui/component/BottomTabBar.kt
@@ -25,12 +25,12 @@ import androidx.compose.material.icons.filled.AutoStories
 import androidx.compose.material.icons.filled.Bookmarks
 import androidx.compose.material.icons.filled.Explore
 import androidx.compose.material.icons.filled.Headphones
-import androidx.compose.material.icons.filled.Settings
+import androidx.compose.material.icons.filled.RecordVoiceOver
 import androidx.compose.material.icons.outlined.AutoStories
 import androidx.compose.material.icons.outlined.Bookmarks
 import androidx.compose.material.icons.outlined.Explore
 import androidx.compose.material.icons.outlined.Headphones
-import androidx.compose.material.icons.outlined.Settings
+import androidx.compose.material.icons.outlined.RecordVoiceOver
 import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
@@ -55,7 +55,7 @@ enum class HomeTab(val label: String, val filled: ImageVector, val outlined: Ima
     Library("Library", Icons.Filled.AutoStories, Icons.Outlined.AutoStories),
     Follows("Follows", Icons.Filled.Bookmarks, Icons.Outlined.Bookmarks),
     Browse("Browse", Icons.Filled.Explore, Icons.Outlined.Explore),
-    Settings("Settings", Icons.Filled.Settings, Icons.Outlined.Settings),
+    Voices("Voices", Icons.Filled.RecordVoiceOver, Icons.Outlined.RecordVoiceOver),
 }
 
 /**

--- a/feature/src/main/kotlin/in/jphe/storyvox/feature/browse/BrowseScreen.kt
+++ b/feature/src/main/kotlin/in/jphe/storyvox/feature/browse/BrowseScreen.kt
@@ -23,16 +23,19 @@ import androidx.compose.material.icons.filled.Add
 import androidx.compose.material.icons.filled.Close
 import androidx.compose.material.icons.filled.Search
 import androidx.compose.material.icons.outlined.FilterAlt
+import androidx.compose.material.icons.outlined.Settings
 import androidx.compose.material3.AssistChip
 import androidx.compose.material3.AssistChipDefaults
 import androidx.compose.material3.Badge
 import androidx.compose.material3.BadgedBox
+import androidx.compose.material3.CenterAlignedTopAppBar
 import androidx.compose.material3.FloatingActionButton
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Scaffold
 import androidx.compose.material3.SecondaryScrollableTabRow
 import androidx.compose.material3.SegmentedButton
 import androidx.compose.material3.SegmentedButtonDefaults
@@ -70,6 +73,7 @@ import `in`.jphe.storyvox.ui.component.MagicSkeletonTile
 import `in`.jphe.storyvox.ui.component.MagicSpinner
 import `in`.jphe.storyvox.ui.theme.LocalSpacing
 
+@OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun BrowseScreen(
     onOpenFiction: (String) -> Unit,
@@ -77,6 +81,7 @@ fun BrowseScreen(
      *  on the listing tabs (Popular / NewReleases / BestRated) when the
      *  user is not signed in to RR; Search keeps working anonymously. */
     onOpenRoyalRoadSignIn: () -> Unit,
+    onOpenSettings: () -> Unit = {},
     viewModel: BrowseViewModel = hiltViewModel(),
 ) {
     val state by viewModel.uiState.collectAsStateWithLifecycle()
@@ -102,7 +107,19 @@ fun BrowseScreen(
         out
     }
 
-    Box(modifier = Modifier.fillMaxSize()) {
+    Scaffold(
+        topBar = {
+            CenterAlignedTopAppBar(
+                title = { Text("Browse", style = MaterialTheme.typography.titleMedium) },
+                actions = {
+                    IconButton(onClick = onOpenSettings) {
+                        Icon(Icons.Outlined.Settings, contentDescription = "Settings")
+                    }
+                },
+            )
+        },
+    ) { scaffoldPadding ->
+    Box(modifier = Modifier.fillMaxSize().padding(scaffoldPadding)) {
     Column(modifier = Modifier.fillMaxSize().padding(top = spacing.md)) {
         // Top-level source picker. Switches the multibinding lookup in
         // FictionRepository between Royal Road and GitHub. Tabs and the
@@ -404,6 +421,7 @@ fun BrowseScreen(
         }
     }
     }  // Box
+    }  // Scaffold
 
     if (showRssManageSheet) {
         BrowseRssManageSheet(

--- a/feature/src/main/kotlin/in/jphe/storyvox/feature/follows/FollowsScreen.kt
+++ b/feature/src/main/kotlin/in/jphe/storyvox/feature/follows/FollowsScreen.kt
@@ -14,9 +14,13 @@ import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.grid.GridCells
 import androidx.compose.foundation.lazy.grid.LazyVerticalGrid
 import androidx.compose.foundation.lazy.items
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.outlined.Settings
 import androidx.compose.material3.Badge
 import androidx.compose.material3.Card
 import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.material3.TopAppBar
@@ -47,6 +51,7 @@ import androidx.compose.foundation.lazy.grid.items as gridItems
 fun FollowsScreen(
     onOpenFiction: (String) -> Unit,
     onOpenSignIn: () -> Unit,
+    onOpenSettings: () -> Unit = {},
     viewModel: FollowsViewModel = hiltViewModel(),
 ) {
     val state by viewModel.uiState.collectAsStateWithLifecycle()
@@ -87,6 +92,9 @@ fun FollowsScreen(
                             onClick = viewModel::markAllCaughtUp,
                             variant = BrassButtonVariant.Text,
                         )
+                    }
+                    IconButton(onClick = onOpenSettings) {
+                        Icon(Icons.Outlined.Settings, contentDescription = "Settings")
                     }
                 },
                 colors = TopAppBarDefaults.topAppBarColors(

--- a/feature/src/main/kotlin/in/jphe/storyvox/feature/library/LibraryScreen.kt
+++ b/feature/src/main/kotlin/in/jphe/storyvox/feature/library/LibraryScreen.kt
@@ -20,12 +20,14 @@ import androidx.compose.foundation.lazy.grid.itemsIndexed
 import androidx.compose.foundation.lazy.items
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Add
+import androidx.compose.material.icons.outlined.Settings
 import androidx.compose.material3.Card
 import androidx.compose.material3.CardDefaults
 import androidx.compose.material3.CenterAlignedTopAppBar
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.FloatingActionButton
 import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.SecondaryTabRow
@@ -58,6 +60,7 @@ import androidx.compose.ui.text.style.TextAlign
 fun LibraryScreen(
     onOpenFiction: (String) -> Unit,
     onOpenReader: (String, String) -> Unit,
+    onOpenSettings: () -> Unit = {},
     viewModel: LibraryViewModel = hiltViewModel(),
 ) {
     val state by viewModel.uiState.collectAsStateWithLifecycle()
@@ -105,6 +108,11 @@ fun LibraryScreen(
         topBar = {
             CenterAlignedTopAppBar(
                 title = { Text("Library", style = MaterialTheme.typography.titleMedium) },
+                actions = {
+                    IconButton(onClick = onOpenSettings) {
+                        Icon(Icons.Outlined.Settings, contentDescription = "Settings")
+                    }
+                },
             )
         },
         floatingActionButton = {

--- a/feature/src/main/kotlin/in/jphe/storyvox/feature/reader/AudiobookView.kt
+++ b/feature/src/main/kotlin/in/jphe/storyvox/feature/reader/AudiobookView.kt
@@ -38,6 +38,7 @@ import androidx.compose.material.icons.outlined.BookmarkAdd
 import androidx.compose.material.icons.outlined.ChevronRight
 import androidx.compose.material.icons.outlined.MoreVert
 import androidx.compose.material.icons.outlined.RecordVoiceOver
+import androidx.compose.material.icons.outlined.Settings
 import androidx.compose.material3.AssistChip
 import androidx.compose.material3.AssistChipDefaults
 import androidx.compose.material3.ExperimentalMaterial3Api
@@ -114,6 +115,10 @@ fun AudiobookView(
      *  fictionId on the playback state, so callees can rely on it
      *  being a fully-routed navigation. */
     onOpenChat: () -> Unit = {},
+    /** Open the Settings screen. Surfaced as a leading gear icon in the
+     *  top bar so playback's per-screen Settings affordance matches the
+     *  other home screens (Library/Browse/Follows/Voices). */
+    onOpenSettings: () -> Unit = {},
     /** Issue #278 — loading-phase from the ReaderViewModel. Drives the
      *  soft "Still working…" hint at 10s and the hard timeout/retry
      *  error block at 30s. Defaults to NotLoading so previews / tests
@@ -187,6 +192,12 @@ fun AudiobookView(
                     .fillMaxWidth()
                     .padding(vertical = spacing.xs),
             ) {
+                IconButton(
+                    onClick = onOpenSettings,
+                    modifier = Modifier.align(Alignment.CenterStart),
+                ) {
+                    Icon(Icons.Outlined.Settings, contentDescription = "Settings")
+                }
                 Column(
                     modifier = Modifier
                         .align(Alignment.Center)

--- a/feature/src/main/kotlin/in/jphe/storyvox/feature/reader/HybridReaderScreen.kt
+++ b/feature/src/main/kotlin/in/jphe/storyvox/feature/reader/HybridReaderScreen.kt
@@ -46,6 +46,12 @@ fun HybridReaderScreen(
      * naturally swaps the prompt for the player view in place.
      */
     onBrowse: () -> Unit = {},
+    /** Open the Settings screen. Surfaced as a leading gear in the
+     *  AudiobookView top bar — matches the per-screen Settings
+     *  affordance on Library/Browse/Follows/Voices. Default no-op for
+     *  previews/tests; production callsites pass a real
+     *  `navController.navigate(SETTINGS)`. */
+    onOpenSettings: () -> Unit = {},
     viewModel: ReaderViewModel = hiltViewModel(),
 ) {
     val state by viewModel.uiState.collectAsStateWithLifecycle()
@@ -169,6 +175,7 @@ fun HybridReaderScreen(
                 onOpenChat = {
                     playbackState.fictionId?.let { onOpenChat(it, null) }
                 },
+                onOpenSettings = onOpenSettings,
                 // Issue #278 — surface loading-phase + retry path. The
                 // view decides what to render based on phase (regular /
                 // slow-hint at 10s / full error block at 30s).

--- a/feature/src/main/kotlin/in/jphe/storyvox/feature/voicelibrary/VoiceLibraryScreen.kt
+++ b/feature/src/main/kotlin/in/jphe/storyvox/feature/voicelibrary/VoiceLibraryScreen.kt
@@ -19,11 +19,11 @@ import androidx.compose.foundation.lazy.itemsIndexed
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.automirrored.filled.ArrowBack
 import androidx.compose.material.icons.filled.Star
 import androidx.compose.material.icons.outlined.Check
 import androidx.compose.material.icons.outlined.ExpandLess
 import androidx.compose.material.icons.outlined.ExpandMore
+import androidx.compose.material.icons.outlined.Settings
 import androidx.compose.material.icons.outlined.StarBorder
 import androidx.compose.foundation.horizontalScroll
 import androidx.compose.foundation.layout.PaddingValues as ComposePaddingValues
@@ -71,7 +71,7 @@ import `in`.jphe.storyvox.ui.theme.LocalSpacing
 
 @Composable
 fun VoiceLibraryScreen(
-    onBack: () -> Unit,
+    onOpenSettings: () -> Unit = {},
     viewModel: VoiceLibraryViewModel = hiltViewModel(),
 ) {
     val state by viewModel.uiState.collectAsStateWithLifecycle()
@@ -88,18 +88,16 @@ fun VoiceLibraryScreen(
         topBar = {
             TopAppBar(
                 title = { Text("Voice library") },
-                // Issues #275 + #276 — all settings sub-screens get a
-                // back arrow on the left of the TopAppBar, matching the
-                // Sessions screen pattern (which is already canonical).
-                // Voice library had a TopAppBar but no navigationIcon;
-                // Pronunciation had no TopAppBar at all and a bare
-                // 'Back' BrassButton mid-screen — three different
-                // patterns for the same role across three screens.
-                navigationIcon = {
-                    IconButton(onClick = onBack) {
+                // Voice Library was promoted to a first-class home tab
+                // (issue #264 follow-up), so it no longer has a back
+                // arrow — peer of Library/Browse/Follows/Playing. The
+                // gear here matches the other home screens' per-screen
+                // Settings affordance.
+                actions = {
+                    IconButton(onClick = onOpenSettings) {
                         Icon(
-                            Icons.AutoMirrored.Filled.ArrowBack,
-                            contentDescription = "Back",
+                            Icons.Outlined.Settings,
+                            contentDescription = "Settings",
                         )
                     }
                 },


### PR DESCRIPTION
## Summary

Promotes the Voice Library to a first-class bottom-nav slot (last position, replacing Settings). Settings moves to a per-screen gear icon (`Icons.Outlined.Settings`) in the `TopAppBar actions` of every main screen.

## Why

Voice-picking is high-frequency for an audio-first app — not a set-once preference buried in Settings. The 1188-voice catalog is arguably storyvox's most distinctive surface; it deserves a top-tier slot.

Trade-off: Settings loses its permanent bottom-nav slot. Recovered via a gear IconButton in every main screen's top bar — one tap from anywhere.

## Test plan
- [x] `./gradlew :app:assembleDebug`
- [x] `./gradlew test`
- [ ] On-device: Voices tab appears in 5th bottom-nav slot with RecordVoiceOver icon
- [ ] On-device: gear on Library/Browse/Follows/Playing/Voices opens Settings
- [ ] On-device: Settings route hides the bottom nav (reads as sub-screen)
- [ ] On-device: OS Back from Settings returns to the originating screen