### PR TITLE
feat(voice): Sonic pitch-interpolation quality toggle — closes #193

### DIFF
--- a/app/src/main/kotlin/in/jphe/storyvox/StoryvoxApp.kt
+++ b/app/src/main/kotlin/in/jphe/storyvox/StoryvoxApp.kt
@@ -9,11 +9,14 @@ import `in`.jphe.storyvox.BuildConfig
 import `in`.jphe.storyvox.data.auth.SessionHydrator
 import `in`.jphe.storyvox.data.repository.AuthRepository
 import `in`.jphe.storyvox.data.work.WorkScheduler
+import `in`.jphe.storyvox.feature.api.SettingsRepositoryUi
+import `in`.jphe.storyvox.playback.VoiceEngineQualityBridge
 import `in`.jphe.storyvox.sync.coordinator.SyncCoordinator
 import javax.inject.Inject
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.launch
 
 @HiltAndroidApp
@@ -24,6 +27,7 @@ class StoryvoxApp : Application(), Configuration.Provider {
     @Inject lateinit var authRepository: AuthRepository
     @Inject lateinit var sessionHydrator: SessionHydrator
     @Inject lateinit var syncCoordinator: SyncCoordinator
+    @Inject lateinit var settingsRepo: SettingsRepositoryUi
 
     override val workManagerConfiguration: Configuration
         get() = Configuration.Builder()
@@ -35,10 +39,25 @@ class StoryvoxApp : Application(), Configuration.Provider {
         super.onCreate()
         workScheduler.ensurePeriodicWorkScheduled()
         rehydrateRoyalRoadCookies()
+        applyPitchQualityFromSettings()
         // InstantDB sync — if a refresh token is stored, validate it and
         // pull every per-domain syncer. No-op when no one is signed in.
         // Fire-and-forget: the coordinator launches its own coroutines.
         syncCoordinator.initialize()
+    }
+
+    /**
+     * Issue #193 — seed the VoxSherpa engine static `sonicQuality`
+     * fields from the user's persisted Settings toggle. The field
+     * default in VoxSherpa-TTS v2.7.13 is 1 (high quality), but a
+     * user who flipped to OFF in a prior session needs that pref
+     * re-applied on cold start, before the first chapter renders.
+     */
+    private fun applyPitchQualityFromSettings() {
+        CoroutineScope(SupervisorJob() + Dispatchers.IO).launch {
+            val highQuality = settingsRepo.settings.first().pitchInterpolationHighQuality
+            VoiceEngineQualityBridge.applyPitchQuality(highQuality)
+        }
     }
 
     /**

--- a/app/src/main/kotlin/in/jphe/storyvox/data/SettingsRepositoryUiImpl.kt
+++ b/app/src/main/kotlin/in/jphe/storyvox/data/SettingsRepositoryUiImpl.kt
@@ -179,6 +179,10 @@ private object Keys {
      *  maps existing installs forward. Default = 1× preserves the
      *  audiobook-tuned baseline on fresh installs. */
     val PUNCTUATION_PAUSE_MULTIPLIER = floatPreferencesKey("pref_punctuation_pause_multiplier_v2")
+    /** Issue #193 — Sonic pitch-interpolation quality toggle. true = quality=1,
+     *  false = quality=0 (Sonic's upstream default). Defaults to true on
+     *  fresh installs. */
+    val PITCH_INTERP_HIGH_QUALITY = booleanPreferencesKey("pref_pitch_interp_high_quality")
     /** Pre-synth queue depth (sentence-chunks). Issue #84 — the slider is an
      *  exploratory probe for where Android's LMK kills the app on slow
      *  devices, so the persisted value is intentionally NOT clamped at a
@@ -419,6 +423,7 @@ class SettingsRepositoryUiImpl(
             downloadOnWifiOnly = prefs[Keys.DOWNLOAD_WIFI_ONLY] ?: true,
             pollIntervalHours = prefs[Keys.POLL_INTERVAL_HOURS] ?: 6,
             isSignedIn = prefs[Keys.SIGNED_IN] ?: false,
+            pitchInterpolationHighQuality = prefs[Keys.PITCH_INTERP_HIGH_QUALITY] ?: true,
             punctuationPauseMultiplier = (prefs[Keys.PUNCTUATION_PAUSE_MULTIPLIER]
                 ?: PUNCTUATION_PAUSE_DEFAULT_MULTIPLIER)
                 .coerceIn(PUNCTUATION_PAUSE_MIN_MULTIPLIER, PUNCTUATION_PAUSE_MAX_MULTIPLIER),
@@ -601,6 +606,16 @@ class SettingsRepositoryUiImpl(
             it[Keys.PUNCTUATION_PAUSE_MULTIPLIER] = multiplier
                 .coerceIn(PUNCTUATION_PAUSE_MIN_MULTIPLIER, PUNCTUATION_PAUSE_MAX_MULTIPLIER)
         }
+    }
+
+    override suspend fun setPitchInterpolationHighQuality(enabled: Boolean) {
+        store.edit { it[Keys.PITCH_INTERP_HIGH_QUALITY] = enabled }
+        // Push to both engine fields immediately so the next
+        // chapter pre-render uses the new setting without waiting
+        // for a process restart. Sonic instances are created fresh
+        // inside each generateAudioPCM call, so the volatile read
+        // there picks up the new value.
+        `in`.jphe.storyvox.playback.VoiceEngineQualityBridge.applyPitchQuality(enabled)
     }
 
     override suspend fun setPlaybackBufferChunks(chunks: Int) {

--- a/app/src/test/kotlin/in/jphe/storyvox/di/RealPlaybackControllerUiTest.kt
+++ b/app/src/test/kotlin/in/jphe/storyvox/di/RealPlaybackControllerUiTest.kt
@@ -226,6 +226,7 @@ class RealPlaybackControllerUiTest {
         override suspend fun setDownloadOnWifiOnly(enabled: Boolean) = Unit
         override suspend fun setPollIntervalHours(hours: Int) = Unit
         override suspend fun setPunctuationPauseMultiplier(multiplier: Float) = Unit
+        override suspend fun setPitchInterpolationHighQuality(enabled: Boolean) = Unit
         override suspend fun setPlaybackBufferChunks(chunks: Int) = Unit
         override suspend fun setWarmupWait(enabled: Boolean) = Unit
         override suspend fun setCatchupPause(enabled: Boolean) = Unit

--- a/core-playback/build.gradle.kts
+++ b/core-playback/build.gradle.kts
@@ -75,7 +75,13 @@ dependencies {
     // single-module path `com.github.jphein:VoxSherpa-TTS:vX.Y.Z` (it
     // collapses multi-module configs to one root coordinate). The actual
     // AAR file at this URL is engine-lib's release artifact.
-    implementation("com.github.jphein:VoxSherpa-TTS:v2.7.11")
+    // v2.7.13 (storyvox #193) parameterizes Sonic.setQuality via
+    // VoiceEngine.sonicQuality / KokoroEngine.sonicQuality static
+    // fields (default 1 — high quality). Storyvox exposes a
+    // Settings toggle that writes both fields via
+    // [VoiceEngineQualityBridge]. Pre-rendered PCM (post-#97) means
+    // the ~20% CPU hit lands once per chapter, not per playback.
+    implementation("com.github.jphein:VoxSherpa-TTS:v2.7.13")
     implementation("com.github.k2-fsa:sherpa-onnx:1.12.26")
 
     // Media3 — session, player base classes

--- a/core-playback/src/main/kotlin/in/jphe/storyvox/playback/VoiceEngineQualityBridge.kt
+++ b/core-playback/src/main/kotlin/in/jphe/storyvox/playback/VoiceEngineQualityBridge.kt
@@ -1,0 +1,32 @@
+package `in`.jphe.storyvox.playback
+
+import com.CodeBySonu.VoxSherpa.KokoroEngine
+import com.CodeBySonu.VoxSherpa.VoiceEngine
+
+/**
+ * Issue #193 — bridge between storyvox's user-facing Settings toggle
+ * and the two VoxSherpa-TTS engine classes' `sonicQuality` static
+ * fields. Both engines instantiate a fresh `Sonic` per
+ * `generateAudioPCM` call and read `sonicQuality` at construction
+ * time, so flipping these fields takes effect on the *next* chapter
+ * render (any in-flight render keeps its existing Sonic instance).
+ *
+ * Kept here in `:core-playback` rather than `:app` because the
+ * VoxSherpa-TTS dep lives here. `:app`'s SettingsRepositoryUiImpl
+ * routes through this bridge to avoid a direct compile-time
+ * dependency on the Java engine classes.
+ */
+object VoiceEngineQualityBridge {
+
+    /**
+     * Apply the user's "high-quality pitch interpolation" preference
+     * to both engines. true → quality=1 (smoother, ~20% slower);
+     * false → quality=0 (Sonic's upstream default — virtually as
+     * good at neutral pitch, gritty at non-neutral).
+     */
+    fun applyPitchQuality(highQuality: Boolean) {
+        val q = if (highQuality) 1 else 0
+        VoiceEngine.sonicQuality = q
+        KokoroEngine.sonicQuality = q
+    }
+}

--- a/feature/src/main/kotlin/in/jphe/storyvox/feature/api/UiContracts.kt
+++ b/feature/src/main/kotlin/in/jphe/storyvox/feature/api/UiContracts.kt
@@ -637,6 +637,16 @@ data class UiSettings(
      * `:app`'s `SettingsRepositoryUiImpl` for the mapping.
      */
     val punctuationPauseMultiplier: Float = PUNCTUATION_PAUSE_DEFAULT_MULTIPLIER,
+    /**
+     * Issue #193 — VoxSherpa-TTS v2.7.13 — Sonic pitch-interpolation
+     * quality. Default true (quality=1) for smoother pitch-shifted
+     * output. Costs ~20% extra CPU per pitch-shifted chunk, which is
+     * fine for storyvox because chapter PCM is pre-rendered and
+     * cached (post-#97). Users on slow hardware can flip this off to
+     * fall back to Sonic's upstream default (quality=0, faster but
+     * audibly grittier at non-neutral pitch).
+     */
+    val pitchInterpolationHighQuality: Boolean = true,
     val sigil: UiSigil = UiSigil.UNKNOWN,
     val ai: UiAiSettings = UiAiSettings(),
     /**
@@ -1028,6 +1038,10 @@ interface SettingsRepositoryUi {
      * Replaces the pre-#109 `setPunctuationPause(mode: PunctuationPause)`.
      */
     suspend fun setPunctuationPauseMultiplier(multiplier: Float)
+    /** Issue #193 — toggle high-quality Sonic pitch interpolation
+     *  (quality=1 vs upstream default 0). See
+     *  [UiSettings.pitchInterpolationHighQuality]. */
+    suspend fun setPitchInterpolationHighQuality(enabled: Boolean)
     suspend fun setPlaybackBufferChunks(chunks: Int)
     /** Issue #98 — Mode A toggle. See [UiSettings.warmupWait]. */
     suspend fun setWarmupWait(enabled: Boolean)

--- a/feature/src/main/kotlin/in/jphe/storyvox/feature/settings/SettingsScreen.kt
+++ b/feature/src/main/kotlin/in/jphe/storyvox/feature/settings/SettingsScreen.kt
@@ -228,6 +228,20 @@ fun SettingsScreen(
                 multiplier = s.punctuationPauseMultiplier,
                 onMultiplierChange = viewModel::setPunctuationPauseMultiplier,
             )
+            // Issue #193 — Sonic pitch-interpolation quality toggle.
+            // Default ON for chapter-PCM-cached storyvox (post-#97);
+            // OFF available for users on slow hardware who'd rather
+            // burn the CPU cycles elsewhere.
+            SettingsSwitchRow(
+                title = "High-quality pitch interpolation",
+                subtitle = if (s.pitchInterpolationHighQuality) {
+                    "Smoother pitch-shifted audio. ~20% extra CPU per chapter render."
+                } else {
+                    "Faster pitch shifting. Some grittiness at non-neutral pitch."
+                },
+                checked = s.pitchInterpolationHighQuality,
+                onCheckedChange = viewModel::setPitchInterpolationHighQuality,
+            )
             SettingsLinkRow(
                 title = "Pronunciation",
                 subtitle = "Teach the voice how to say specific names and words.",

--- a/feature/src/main/kotlin/in/jphe/storyvox/feature/settings/SettingsViewModel.kt
+++ b/feature/src/main/kotlin/in/jphe/storyvox/feature/settings/SettingsViewModel.kt
@@ -107,6 +107,10 @@ class SettingsViewModel @Inject constructor(
      *  range; the slider in the screen passes a raw Float. */
     fun setPunctuationPauseMultiplier(multiplier: Float) =
         viewModelScope.launch { repo.setPunctuationPauseMultiplier(multiplier) }
+
+    /** Issue #193 — high-quality Sonic pitch interpolation toggle. */
+    fun setPitchInterpolationHighQuality(enabled: Boolean) =
+        viewModelScope.launch { repo.setPitchInterpolationHighQuality(enabled) }
     fun setPlaybackBufferChunks(n: Int) = viewModelScope.launch { repo.setPlaybackBufferChunks(n) }
     /** Issue #98 — Mode A toggle. */
     fun setWarmupWait(enabled: Boolean) = viewModelScope.launch { repo.setWarmupWait(enabled) }

--- a/feature/src/test/kotlin/in/jphe/storyvox/feature/chat/ChatViewModelTest.kt
+++ b/feature/src/test/kotlin/in/jphe/storyvox/feature/chat/ChatViewModelTest.kt
@@ -525,6 +525,7 @@ private class FakeSettingsRepo(
     override suspend fun setDownloadOnWifiOnly(enabled: Boolean) = Unit
     override suspend fun setPollIntervalHours(hours: Int) = Unit
     override suspend fun setPunctuationPauseMultiplier(multiplier: Float) = Unit
+        override suspend fun setPitchInterpolationHighQuality(enabled: Boolean) = Unit
     override suspend fun setPlaybackBufferChunks(chunks: Int) = Unit
     override suspend fun setWarmupWait(enabled: Boolean) = Unit
     override suspend fun setCatchupPause(enabled: Boolean) = Unit

--- a/feature/src/test/kotlin/in/jphe/storyvox/feature/settings/SettingsViewModelBufferTest.kt
+++ b/feature/src/test/kotlin/in/jphe/storyvox/feature/settings/SettingsViewModelBufferTest.kt
@@ -127,6 +127,7 @@ class SettingsViewModelBufferTest {
         override suspend fun setPunctuationPauseMultiplier(multiplier: Float) {
             state.value = state.value.copy(punctuationPauseMultiplier = multiplier)
         }
+        override suspend fun setPitchInterpolationHighQuality(enabled: Boolean) = Unit
         override suspend fun setPlaybackBufferChunks(chunks: Int) {
             bufferWrites += chunks
             state.value = state.value.copy(playbackBufferChunks = chunks)

--- a/feature/src/test/kotlin/in/jphe/storyvox/feature/settings/SettingsViewModelModesTest.kt
+++ b/feature/src/test/kotlin/in/jphe/storyvox/feature/settings/SettingsViewModelModesTest.kt
@@ -200,6 +200,7 @@ class SettingsViewModelModesTest {
         override suspend fun setPunctuationPauseMultiplier(multiplier: Float) {
             state.value = state.value.copy(punctuationPauseMultiplier = multiplier)
         }
+        override suspend fun setPitchInterpolationHighQuality(enabled: Boolean) = Unit
         override suspend fun setPlaybackBufferChunks(chunks: Int) {
             state.value = state.value.copy(playbackBufferChunks = chunks)
         }

--- a/feature/src/test/kotlin/in/jphe/storyvox/feature/settings/SettingsViewModelPunctuationPauseTest.kt
+++ b/feature/src/test/kotlin/in/jphe/storyvox/feature/settings/SettingsViewModelPunctuationPauseTest.kt
@@ -141,6 +141,7 @@ class SettingsViewModelPunctuationPauseTest {
             punctuationPauseMultiplierWrites += multiplier
             state.value = state.value.copy(punctuationPauseMultiplier = multiplier)
         }
+        override suspend fun setPitchInterpolationHighQuality(enabled: Boolean) = Unit
         override suspend fun setPlaybackBufferChunks(chunks: Int) {
             state.value = state.value.copy(playbackBufferChunks = chunks)
         }


### PR DESCRIPTION
## Summary
Cross-repo change. VoxSherpa-TTS v2.7.13 (tagged today) parameterizes `Sonic.setQuality` via `VoiceEngine.sonicQuality` / `KokoroEngine.sonicQuality` static fields (default 1). This PR wires those fields to a user-facing Settings toggle.

Default ON: smoother pitch-shifted audio (~20% extra CPU per chunk, fine because chapter PCM is pre-rendered and cached). OFF: Sonic's upstream default (faster, gritty at non-neutral pitch).

## Where
**Settings → Voice & Playback → "High-quality pitch interpolation"** — subtitle flips between the two trade-offs based on state.

## Plumbing
- `:core-playback` bumps VoxSherpa-TTS to v2.7.13.
- New `VoiceEngineQualityBridge.applyPitchQuality(highQuality)` in `:core-playback` writes both engine static fields.
- `UiSettings.pitchInterpolationHighQuality: Boolean = true` (persisted key `pref_pitch_interp_high_quality`).
- `SettingsRepositoryUi.setPitchInterpolationHighQuality(enabled)` writes the pref AND immediately calls the bridge.
- `StoryvoxApp.onCreate()` seeds the field from the persisted pref at cold start.
- Five `SettingsRepositoryUi` test fakes get the new stub.

## Test plan
- [x] `./gradlew :app:assembleDebug` — green
- [x] `./gradlew test` — 942 tasks green
- [ ] On-device (R83W80CAFZB): Settings → Voice & Playback shows the new switch ON by default; toggle OFF → play a chapter at pitch ≠ 1.0 → audibly grittier; toggle back ON → smooth again

🤖 Generated with [Claude Code](https://claude.com/claude-code)