### PR TITLE
feat(source): generalize FictionDetail Follow via supportsFollow capability — closes #382

### DIFF
--- a/core-data/src/main/kotlin/in/jphe/storyvox/data/repository/FictionRepository.kt
+++ b/core-data/src/main/kotlin/in/jphe/storyvox/data/repository/FictionRepository.kt
@@ -145,17 +145,29 @@ class FictionRepositoryImpl @Inject constructor(
         sources[sourceId]
             ?: error("No FictionSource for id=$sourceId; bound: ${sources.keys}")
 
+    // Issue #382 — small helper to look up `supportsFollow` on the
+    // FictionSource the row came from. Returns false for unknown
+    // sourceIds (a fiction row whose backend module has since been
+    // unbound), which is the safest UI default — hides the Follow
+    // button rather than wiring a never-firing path.
+    private fun supportsFollowFor(sourceId: String): Boolean =
+        sources[sourceId]?.supportsFollow ?: false
+
     override fun observeLibrary(): Flow<List<FictionSummary>> =
-        fictionDao.observeLibrary().map { rows -> rows.map { it.toSummary() } }
+        fictionDao.observeLibrary().map { rows ->
+            rows.map { it.toSummary(supportsFollow = supportsFollowFor(it.sourceId)) }
+        }
 
     override fun observeFollowsRemote(): Flow<List<FictionSummary>> =
-        fictionDao.observeFollowsRemote().map { rows -> rows.map { it.toSummary() } }
+        fictionDao.observeFollowsRemote().map { rows ->
+            rows.map { it.toSummary(supportsFollow = supportsFollowFor(it.sourceId)) }
+        }
 
     override fun observeFiction(id: String): Flow<FictionDetail?> =
         fictionDao.observe(id).combine(chapterDao.observeChapterInfosByFiction(id)) { fiction, chapters ->
             fiction?.let {
                 FictionDetail(
-                    summary = it.toSummary(),
+                    summary = it.toSummary(supportsFollow = supportsFollowFor(it.sourceId)),
                     chapters = chapters.map(::toInfo),
                     genres = it.genres,
                     wordCount = it.wordCount,
@@ -377,7 +389,7 @@ class FictionRepositoryImpl @Inject constructor(
 
 // ─── mappers ──────────────────────────────────────────────────────────────
 
-internal fun Fiction.toSummary(): FictionSummary = FictionSummary(
+internal fun Fiction.toSummary(supportsFollow: Boolean = false): FictionSummary = FictionSummary(
     id = id,
     sourceId = sourceId,
     title = title,
@@ -389,6 +401,7 @@ internal fun Fiction.toSummary(): FictionSummary = FictionSummary(
     chapterCount = chapterCount,
     rating = rating,
     followedRemotely = followedRemotely,
+    supportsFollow = supportsFollow,
 )
 
 internal fun FictionSummary.toEntity(now: Long): Fiction = Fiction(

--- a/core-data/src/main/kotlin/in/jphe/storyvox/data/source/FictionSource.kt
+++ b/core-data/src/main/kotlin/in/jphe/storyvox/data/source/FictionSource.kt
@@ -28,6 +28,19 @@ interface FictionSource {
     /** Human-readable name for UI, e.g. `"Royal Road"`. */
     val displayName: String
 
+    /**
+     * Issue #382 — true when this source has a meaningful account-side
+     * follow concept that storyvox can push to via [setFollowed]. False
+     * (the default) means the FictionDetail Follow button stays hidden
+     * for fictions from this source. Royal Road overrides to true today;
+     * AO3 / GitHub / Wikipedia can override when their respective
+     * sign-in flows land.
+     *
+     * The default-false posture means a backend that never overrides
+     * gets the right (no-Follow-button) behavior automatically.
+     */
+    val supportsFollow: Boolean get() = false
+
     // ─── browse ───────────────────────────────────────────────────────────
 
     /** Front-page popular / "best" list, paginated. */

--- a/core-data/src/main/kotlin/in/jphe/storyvox/data/source/model/FictionSummary.kt
+++ b/core-data/src/main/kotlin/in/jphe/storyvox/data/source/model/FictionSummary.kt
@@ -23,4 +23,9 @@ data class FictionSummary(
      *  Defaults to false; only meaningful for sources with an
      *  account-side follow concept (RR today). */
     val followedRemotely: Boolean = false,
+    /** Issue #382 — populated from `FictionSource.supportsFollow` at
+     *  the repository mapper layer. Drives the FictionDetail Follow
+     *  button's visibility on the UI side without each consumer
+     *  needing to know which sources happen to support follow. */
+    val supportsFollow: Boolean = false,
 )

--- a/feature/src/main/kotlin/in/jphe/storyvox/feature/api/UiContracts.kt
+++ b/feature/src/main/kotlin/in/jphe/storyvox/feature/api/UiContracts.kt
@@ -32,6 +32,12 @@ data class UiFiction(
      *  follows this fiction on RR. Drives the Follow-button label
      *  (Follow / Following). */
     val isFollowedRemote: Boolean = false,
+    /** Issue #382 — generalized from #211's hardcoded RR check.
+     *  True when the originating FictionSource exposes a follow
+     *  action via `FictionSource.supportsFollow`. Drives the
+     *  Follow-button *visibility* on FictionDetail; absent / false
+     *  means the button is hidden regardless of sign-in state. */
+    val sourceSupportsFollow: Boolean = false,
 )
 
 data class UiChapter(

--- a/feature/src/main/kotlin/in/jphe/storyvox/feature/browse/RealBrowsePaginator.kt
+++ b/feature/src/main/kotlin/in/jphe/storyvox/feature/browse/RealBrowsePaginator.kt
@@ -86,4 +86,5 @@ fun toUiFiction(s: FictionSummary): UiFiction = UiFiction(
     synopsis = s.description.orEmpty(),
     sourceId = s.sourceId,
     isFollowedRemote = s.followedRemotely,
+    sourceSupportsFollow = s.supportsFollow,
 )

--- a/feature/src/main/kotlin/in/jphe/storyvox/feature/fiction/FictionDetailScreen.kt
+++ b/feature/src/main/kotlin/in/jphe/storyvox/feature/fiction/FictionDetailScreen.kt
@@ -311,7 +311,7 @@ fun FictionDetailScreen(
 
             BottomBar(
                 isInLibrary = state.isInLibrary,
-                followOnSource = fiction.takeIf { it.sourceId == "royalroad" }
+                followOnSource = fiction.takeIf { it.sourceSupportsFollow }
                     ?.let { FollowOnSourceUiState(isFollowed = it.isFollowedRemote) },
                 onFollow = {
                     // Issue #169 — gate the destructive path behind a
@@ -356,7 +356,7 @@ fun FictionDetailScreen(
 
             BottomBar(
                 isInLibrary = state.isInLibrary,
-                followOnSource = fiction.takeIf { it.sourceId == "royalroad" }
+                followOnSource = fiction.takeIf { it.sourceSupportsFollow }
                     ?.let { FollowOnSourceUiState(isFollowed = it.isFollowedRemote) },
                 onFollow = {
                     // Issue #169 — gate the destructive path behind a

--- a/source-royalroad/src/main/kotlin/in/jphe/storyvox/source/royalroad/RoyalRoadSource.kt
+++ b/source-royalroad/src/main/kotlin/in/jphe/storyvox/source/royalroad/RoyalRoadSource.kt
@@ -52,6 +52,11 @@ class RoyalRoadSource @Inject internal constructor(
 
     override val id: String = RoyalRoadIds.SOURCE_ID
     override val displayName: String = RoyalRoadIds.SOURCE_NAME
+    // Issue #382 — RR is the canonical follow-supporting source today.
+    // The push path: [setFollowed] POSTs to /fictions/setbookmark with
+    // a fresh __RequestVerificationToken; pull is the periodic
+    // /my/follows scrape from FollowsViewModel.refreshFollows.
+    override val supportsFollow: Boolean = true
 
     override suspend fun popular(page: Int): FictionResult<ListPage<FictionSummary>> =
         fetchBrowsePage(browseUrl("/fictions/active-popular", page), page)


### PR DESCRIPTION
## Summary
Replaces the hardcoded `state.fiction.sourceId == "royalroad"` check on FictionDetail's Follow button with a generic `FictionSource.supportsFollow: Boolean` capability flag. Plumbed through `FictionSummary.supportsFollow` (populated at the repository mapper) and `UiFiction.sourceSupportsFollow` (populated by `toUiFiction`) so the screen decides visibility without knowing source ids.

RoyalRoadSource overrides to `true`. Every other source inherits the default `false` and the Follow button stays correctly hidden.

When AO3 / GitHub watch-star / Wikipedia watchlist / Hacker News save / etc opt in by overriding the flag, the button appears with zero UI changes. Sign-in routing stays source-specific until a second source uses it (premature abstraction otherwise).

## Test plan
- [x] `./gradlew :app:assembleDebug`
- [x] `./gradlew test`
- [ ] On-device: RR fiction still shows Follow button; non-RR fictions still don't

🤖 Generated with [Claude Code](https://claude.com/claude-code)