### PR TITLE
feat(source): anonymous Notion-site reader mode for :source-notion — closes #393

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,26 @@ Entries before v0.5.12 are reconstructed from the git log — see
 
 ## [Unreleased]
 
+## [0.5.25] — 2026-05-13
+
+### Added
+- **Anonymous Notion-site reader mode** (#393, closes the v0.5.24 known limitation) — `:source-notion` now reads public-shared Notion pages via the *unofficial* `www.notion.so/api/v3` surface (`loadPageChunk`, `queryCollection`, `syncRecordValuesMain`, `getPublicPageData` — the same set [react-notion-x](https://github.com/NotionX/react-notion-x)'s `notion-client` package uses). Zero setup: a fresh install opens Browse → Notion and immediately surfaces TechEmpower's content as narratable audio, with no integration token required.
+- **Single-fiction, multi-chapter TechEmpower** — Browse → Notion shows one tile, "Welcome to TechEmpower.org" by TechEmpower, with four chapters mapped to the site's top-level navigation: **Guides** (the root page's own content, with internal `header` blocks preserved as inline sub-headings), **Resources** (an HTML list of the Resources database's ~80 row titles, queried via `queryCollection`), **About**, and **Donate**. Internal sub-page links (the 8 individual guide pages) render as bridge paragraphs inside the Guides chapter so the listener hears their titles without the chapter mid-jumping.
+- **`NotionConfig` mode enum** — new `NotionMode { ANONYMOUS_PUBLIC, OFFICIAL_PAT }` selects the read path. Anonymous mode reads any public-shared root page id; PAT mode keeps the original integration-token + database-id flow for private workspaces. The mode is implicit: blank token → anonymous, non-blank token → PAT. Existing users with a stored PAT keep their current experience unchanged.
+
+### Fixed
+- **Stale "TODO placeholder" rejection in `NotionApi.requireConfigured`** — v0.5.23 shipped a check that fast-failed when `databaseId == TECHEMPOWER_DATABASE_ID`; v0.5.24 replaced that id with the real TechEmpower Resources DB but left the check, silently breaking the bundled default for anyone with a PAT shared to the Resources DB. v0.5.25 removes the equality check; gating is now token presence alone in PAT mode and root-page-id presence in anonymous mode.
+
+### Implementation
+- `NotionUnofficialApi` (new) — OkHttp client for the four `/api/v3` endpoints with hand-crafted JSON bodies (the queryCollection loader shape is deeply nested; full kotlinx-serialization round-trips would be more code than the bodies). Process-lifetime in-memory cache keyed on hyphenated page id; deduplicates round-trips within a Browse → detail flow. Every HTTP call is wrapped in `withContext(Dispatchers.IO)` so the source can be safely called from any coroutine context.
+- `AnonymousNotionDelegate` (new) — implements the FictionSource surface against `NotionUnofficialApi`. Builds a single Browse tile from the configured root page and resolves its chapter list from `NotionDefaults.techempowerChapters` (a hand-curated list of `ChapterSpec.Page` / `ChapterSpec.Collection` entries). Page chapters render their underlying Notion page's blocks via `renderPageBody`; collection chapters query the database via `queryCollection` and render a row-title list. Tombstoned blocks (`alive:false`) are filtered.
+- `NotionConfigImpl` (modified) — persists a new `pref_notion_root_page_id` DataStore key. Defaults to `NotionDefaults.TECHEMPOWER_ROOT_PAGE_ID` on first install; users can override via Settings.
+- `NotionApi.requireConfigured` (bug fix) — removed the stale `databaseId == TECHEMPOWER_DATABASE_ID` placeholder check that v0.5.24 silently broke when it baked the real DB id into the same constant.
+- 23 new unit tests in `AnonymousNotionDelegateTest` + `NotionUnofficialModelsTest` covering the recordMap envelope decode, decoration-array title extraction, page-id hyphenation, collection_view metadata read, chapter spec resolution (TechEmpower vs. generic), page-body rendering with tombstone filtering, collection-row title extraction + sorting, HTML/plain projection of the unofficial block types, mode-posture defaults, and tolerance for unknown top-level recordMap fields.
+
+### Known caveats
+- The unofficial `www.notion.so/api/v3` endpoints are undocumented; Notion may change their shape without notice. Storyvox decodes permissively (all block-payload fields are `JsonElement`) so unknown variants degrade silently rather than breaking parsing. Surface errors come back as structured `NotionUnofficialError` envelopes (`{isNotionError, errorId, name, message}`) which we map to standard `FictionResult.AuthRequired`/`NotFound`/`RateLimited`/`NetworkError`.
+
 ## [0.5.24] — 2026-05-13
 
 ### Fixed

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -33,8 +33,8 @@ android {
         applicationId = "in.jphe.storyvox"
         minSdk = 26
         targetSdk = 35
-        versionCode = 135
-        versionName = "0.5.24"
+        versionCode = 136
+        versionName = "0.5.25"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
         vectorDrawables.useSupportLibrary = true

--- a/app/src/main/kotlin/in/jphe/storyvox/data/NotionConfigImpl.kt
+++ b/app/src/main/kotlin/in/jphe/storyvox/data/NotionConfigImpl.kt
@@ -11,6 +11,7 @@ import dagger.hilt.android.qualifiers.ApplicationContext
 import `in`.jphe.storyvox.source.notion.config.NotionConfig
 import `in`.jphe.storyvox.source.notion.config.NotionConfigState
 import `in`.jphe.storyvox.source.notion.config.NotionDefaults
+import `in`.jphe.storyvox.source.notion.config.NotionMode
 import javax.inject.Inject
 import javax.inject.Singleton
 import kotlinx.coroutines.flow.Flow
@@ -24,9 +25,17 @@ private val Context.notionDataStore: DataStore<Preferences> by preferencesDataSt
 
 private object NotionKeys {
     /** Notion database id — the database the source treats as the
-     *  fiction catalog. Stored as the user enters it (trimmed); the
-     *  Notion API accepts both hyphenated UUID and 32-hex forms. */
+     *  fiction catalog in [NotionMode.OFFICIAL_PAT]. Stored as the user
+     *  enters it (trimmed); the Notion API accepts both hyphenated UUID
+     *  and 32-hex forms. */
     val DATABASE_ID = stringPreferencesKey("pref_notion_database_id")
+
+    /** Issue #393 — root page id for [NotionMode.ANONYMOUS_PUBLIC].
+     *  Defaults to [NotionDefaults.TECHEMPOWER_ROOT_PAGE_ID] when unset
+     *  so fresh installs read TechEmpower's public Notion tree without
+     *  configuration. Users can override to point at any public Notion
+     *  page via Settings. */
+    val ROOT_PAGE_ID = stringPreferencesKey("pref_notion_root_page_id")
 }
 
 /** EncryptedSharedPreferences key for the Notion integration token.
@@ -70,20 +79,35 @@ class NotionConfigImpl(
     private val secretsTick = MutableStateFlow(0L)
 
     override val state: Flow<NotionConfigState> = combine(
-        store.data.map { it[NotionKeys.DATABASE_ID].orEmpty() }.distinctUntilChanged(),
+        store.data.map { prefs ->
+            prefs[NotionKeys.DATABASE_ID].orEmpty() to prefs[NotionKeys.ROOT_PAGE_ID].orEmpty()
+        }.distinctUntilChanged(),
         secretsTick,
-    ) { storedDbId, _ ->
+    ) { (storedDbId, storedRootId), _ ->
+        val token = secrets.getString(NOTION_API_TOKEN_PREF, "") ?: ""
+        // Issue #393 — mode is implicit: a non-blank token means the
+        // user wants the PAT-driven workspace path; blank → anonymous
+        // public reader. Same shape across `state` and `current()`.
+        val mode = if (token.isNotBlank()) NotionMode.OFFICIAL_PAT else NotionMode.ANONYMOUS_PUBLIC
         NotionConfigState(
+            mode = mode,
             databaseId = if (storedDbId.isBlank()) NotionDefaults.TECHEMPOWER_DATABASE_ID else storedDbId,
-            apiToken = secrets.getString(NOTION_API_TOKEN_PREF, "") ?: "",
+            rootPageId = if (storedRootId.isBlank()) NotionDefaults.TECHEMPOWER_ROOT_PAGE_ID else storedRootId,
+            apiToken = token,
         )
     }.distinctUntilChanged()
 
     override suspend fun current(): NotionConfigState {
-        val storedDbId = store.data.first()[NotionKeys.DATABASE_ID].orEmpty()
+        val prefs = store.data.first()
+        val storedDbId = prefs[NotionKeys.DATABASE_ID].orEmpty()
+        val storedRootId = prefs[NotionKeys.ROOT_PAGE_ID].orEmpty()
+        val token = secrets.getString(NOTION_API_TOKEN_PREF, "") ?: ""
+        val mode = if (token.isNotBlank()) NotionMode.OFFICIAL_PAT else NotionMode.ANONYMOUS_PUBLIC
         return NotionConfigState(
+            mode = mode,
             databaseId = if (storedDbId.isBlank()) NotionDefaults.TECHEMPOWER_DATABASE_ID else storedDbId,
-            apiToken = secrets.getString(NOTION_API_TOKEN_PREF, "") ?: "",
+            rootPageId = if (storedRootId.isBlank()) NotionDefaults.TECHEMPOWER_ROOT_PAGE_ID else storedRootId,
+            apiToken = token,
         )
     }
 
@@ -122,10 +146,31 @@ class NotionConfigImpl(
     fun isTokenConfigured(): Boolean =
         !secrets.getString(NOTION_API_TOKEN_PREF, "").isNullOrBlank()
 
-    /** Wipe both database id + token — Settings "Forget Notion" path
-     *  (no UI affordance yet; available for diagnostics + tests). */
+    /**
+     * Persist the anonymous-mode root page id. Trims whitespace. Empty
+     * input wipes the stored value so the state flow falls back to
+     * [NotionDefaults.TECHEMPOWER_ROOT_PAGE_ID]. Accepts hyphenated or
+     * compact 32-hex forms — the unofficial API client hyphenates
+     * before each call.
+     */
+    suspend fun setRootPageId(id: String) {
+        val trimmed = id.trim()
+        if (trimmed.isBlank()) {
+            store.edit { it.remove(NotionKeys.ROOT_PAGE_ID) }
+        } else {
+            store.edit { it[NotionKeys.ROOT_PAGE_ID] = trimmed }
+        }
+    }
+
+    /** Wipe database id, root page id, and token — Settings "Forget
+     *  Notion" path (no UI affordance yet; available for diagnostics +
+     *  tests). After this call the source falls back to the bundled
+     *  TechEmpower defaults in anonymous mode. */
     suspend fun clear() {
-        store.edit { it.remove(NotionKeys.DATABASE_ID) }
+        store.edit {
+            it.remove(NotionKeys.DATABASE_ID)
+            it.remove(NotionKeys.ROOT_PAGE_ID)
+        }
         secrets.edit().remove(NOTION_API_TOKEN_PREF).apply()
         secretsTick.value = secretsTick.value + 1
     }

--- a/app/src/main/kotlin/in/jphe/storyvox/data/SettingsRepositoryUiImpl.kt
+++ b/app/src/main/kotlin/in/jphe/storyvox/data/SettingsRepositoryUiImpl.kt
@@ -511,6 +511,12 @@ class SettingsRepositoryUiImpl(
             sourceNotionEnabled = prefs[Keys.SOURCE_NOTION_ENABLED] ?: true,
             notionDatabaseId = notion.databaseId,
             notionTokenConfigured = notion.apiToken.isNotBlank(),
+            // Issue #393 — surface the anonymous-mode posture so the
+            // Settings UI can render a "Reading TechEmpower content
+            // anonymously" affordance and the user understands the PAT
+            // field is opt-in for private workspaces.
+            notionMode = notion.mode.name,
+            notionRootPageId = notion.rootPageId,
             sleepShakeToExtendEnabled = prefs[Keys.SLEEP_SHAKE_TO_EXTEND_ENABLED] ?: true,
             showDebugOverlay = prefs[Keys.SHOW_DEBUG_OVERLAY] ?: false,
             azure = run {

--- a/feature/src/main/kotlin/in/jphe/storyvox/feature/api/UiContracts.kt
+++ b/feature/src/main/kotlin/in/jphe/storyvox/feature/api/UiContracts.kt
@@ -821,14 +821,26 @@ data class UiSettings(
     /** Notion database id (#233 + #390). Defaults to the baked-in
      *  techempower.org placeholder from `NotionDefaults`; existing
      *  users with a different stored value keep it. Notion accepts
-     *  both hyphenated UUID and compact 32-hex forms. */
+     *  both hyphenated UUID and compact 32-hex forms. Used only in
+     *  [notionMode] = `OFFICIAL_PAT`. */
     val notionDatabaseId: String = "",
     /** True when a Notion Internal Integration Token has been stored.
      *  The token itself is never surfaced to the UI — only this
-     *  boolean. Empty token = source returns AuthRequired on every
-     *  call (Notion has no anonymous tier), but the toggle stays
-     *  visible so the user can paste a token via the Settings row. */
+     *  boolean. Empty token = anonymous-mode reader (#393). */
     val notionTokenConfigured: Boolean = false,
+    /** Issue #393 — read-path selector. Anonymous-mode (default for
+     *  fresh installs and the token-less case) reads the public
+     *  techempower.org Notion tree via `www.notion.so/api/v3` without
+     *  setup; PAT-mode (set automatically when the user pastes a
+     *  token) reads a private workspace database via the official
+     *  Notion REST API. Carried as a string here to keep
+     *  `:feature-settings` independent of `:source-notion`. Values:
+     *  `"ANONYMOUS_PUBLIC"` or `"OFFICIAL_PAT"`. */
+    val notionMode: String = "ANONYMOUS_PUBLIC",
+    /** Issue #393 — anonymous-mode root page id. The public Notion
+     *  page storyvox walks for fictions. Defaults to TechEmpower's
+     *  root; users can override to any public Notion page. */
+    val notionRootPageId: String = "",
     /** Issue #150 — when ON, a shake during the sleep timer's fade
      *  tail re-arms the timer. Default ON; users with bumpy commutes
      *  can disable to avoid accidental extensions. */

--- a/feature/src/main/kotlin/in/jphe/storyvox/feature/settings/SettingsScreen.kt
+++ b/feature/src/main/kotlin/in/jphe/storyvox/feature/settings/SettingsScreen.kt
@@ -558,7 +558,14 @@ fun SettingsScreen(
             // at their own Notion DB.
             SettingsSwitchRow(
                 title = "Notion",
-                subtitle = "Read a Notion database as fiction. Heading-1 boundaries split chapters.",
+                // Issue #393 — anonymous-mode is the default for token-less
+                // installs; the subtitle reflects what the user actually
+                // gets out of the box (TechEmpower content) rather than
+                // the PAT-only past behavior.
+                subtitle = if (s.notionMode == "ANONYMOUS_PUBLIC")
+                    "Reads TechEmpower.org as one fiction with chapters for Guides, Resources, About, and Donate. No setup. Paste a token below to read your own private database instead."
+                else
+                    "Read a Notion database as fiction. Heading-1 boundaries split chapters.",
                 checked = s.sourceNotionEnabled,
                 onCheckedChange = viewModel::setSourceNotionEnabled,
             )

--- a/source-notion/src/main/kotlin/in/jphe/storyvox/source/notion/AnonymousNotionDelegate.kt
+++ b/source-notion/src/main/kotlin/in/jphe/storyvox/source/notion/AnonymousNotionDelegate.kt
@@ -1,0 +1,543 @@
+package `in`.jphe.storyvox.source.notion
+
+import `in`.jphe.storyvox.data.source.SourceIds
+import `in`.jphe.storyvox.data.source.model.ChapterContent
+import `in`.jphe.storyvox.data.source.model.ChapterInfo
+import `in`.jphe.storyvox.data.source.model.FictionDetail
+import `in`.jphe.storyvox.data.source.model.FictionResult
+import `in`.jphe.storyvox.data.source.model.FictionStatus
+import `in`.jphe.storyvox.data.source.model.FictionSummary
+import `in`.jphe.storyvox.data.source.model.ListPage
+import `in`.jphe.storyvox.source.notion.config.NotionConfigState
+import `in`.jphe.storyvox.source.notion.config.NotionDefaults
+import `in`.jphe.storyvox.source.notion.net.NotionChunkResponse
+import `in`.jphe.storyvox.source.notion.net.NotionRecordMap
+import `in`.jphe.storyvox.source.notion.net.NotionUnofficialApi
+import `in`.jphe.storyvox.source.notion.net.block
+import `in`.jphe.storyvox.source.notion.net.contentIds
+import kotlinx.serialization.json.JsonArray
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.JsonPrimitive
+import kotlinx.serialization.json.booleanOrNull
+import kotlinx.serialization.json.contentOrNull
+import javax.inject.Inject
+import javax.inject.Singleton
+
+/**
+ * Issue #393 — anonymous-mode read path.
+ *
+ * **Design (v0.5.25)**: Browse → Notion surfaces a **single tile** for
+ * the configured root page (TechEmpower.org by default). The fiction's
+ * chapter list is a structural overview of the top-level sections —
+ * one chapter per logical area of the site, not one fiction per page.
+ *
+ * For TechEmpower the chapters are:
+ *  1. **Guides** — content of the root page itself ("Welcome to
+ *     TechEmpower.org" + the bridge text linking to each individual
+ *     guide). Internal headings inside the root page split into
+ *     sub-headings within the chapter body, preserved as `<h2>`/`<h3>`
+ *     in the HTML view; TTS narrates them inline. The 8 individual
+ *     guide pages stay reachable through their authored links inside
+ *     the body, but they aren't *separate fictions* — keeping them as
+ *     one chapter matches JP's "single fiction, multi-chapter" call.
+ *  2. **Resources** — overview of the Resources database. Renders as
+ *     a flat HTML list of row titles + brief descriptions (queried via
+ *     `queryCollection` once per fictionDetail). The full database has
+ *     ~80 rows; rendering all of them keeps the chapter narratable
+ *     without forcing the user to drill into each row.
+ *  3. **About** — content of the About page.
+ *  4. **Donate** — content of the Donate page.
+ *
+ * Each chapter's body is built by walking the underlying Notion page's
+ * blocks through [renderPageBody], which respects `alive:false`
+ * tombstones, projects `header`/`sub_header`/`text`/`bulleted_list`
+ * to HTML, and skips embeds.
+ *
+ * The chapter map is keyed by section name (stable across rebuilds);
+ * configurable in [NotionDefaults.techempowerChapters] so a future
+ * iteration can extend the surface (Non-discrimination policy, etc.)
+ * without rewriting the delegate.
+ */
+@Singleton
+internal class AnonymousNotionDelegate @Inject constructor(
+    private val api: NotionUnofficialApi,
+) {
+
+    /**
+     * The single Browse tile. Returns one [FictionSummary] for the
+     * configured root page; page > 1 returns empty (no pagination).
+     * The tile is built from the root page's loadPageChunk response
+     * (title + cover image come from the page block itself).
+     */
+    suspend fun popular(
+        state: NotionConfigState,
+        page: Int,
+    ): FictionResult<ListPage<FictionSummary>> {
+        if (page > 1) {
+            return FictionResult.Success(ListPage(items = emptyList(), page = page, hasNext = false))
+        }
+        val rootResult = api.loadPageChunk(state.rootPageId)
+        val root = when (rootResult) {
+            is FictionResult.Success -> rootResult.value
+            is FictionResult.Failure -> return rootResult
+        }
+        val tile = buildRootSummary(state, root)
+            ?: return FictionResult.NotFound(
+                "Notion root page has no readable title: ${state.rootPageId}",
+            )
+        return FictionResult.Success(
+            ListPage(items = listOf(tile), page = 1, hasNext = false),
+        )
+    }
+
+    /**
+     * Fiction detail for the single Browse tile. Builds the chapter
+     * list from [NotionDefaults.techempowerChapters] (or a derived
+     * generic chapter list for non-TechEmpower root pages — out of
+     * scope for v0.5.25; for now we treat any root as TechEmpower-
+     * shaped). We do *not* fetch each chapter's body here — only the
+     * titles and chapter ids. The body fetch happens lazily in
+     * [chapter] when the user taps a chapter.
+     */
+    suspend fun fictionDetail(
+        state: NotionConfigState,
+        fictionId: String,
+    ): FictionResult<FictionDetail> {
+        val pageId = fictionId.toPageId()
+            ?: return FictionResult.NotFound("Notion fiction id not recognized: $fictionId")
+        // Validate that the fiction id matches the configured root —
+        // anonymous mode only exposes one fiction at a time.
+        val rootResult = api.loadPageChunk(state.rootPageId)
+        val root = when (rootResult) {
+            is FictionResult.Success -> rootResult.value
+            is FictionResult.Failure -> return rootResult
+        }
+        val tile = buildRootSummary(state, root) ?: FictionSummary(
+            id = fictionId,
+            sourceId = SourceIds.NOTION,
+            title = "TechEmpower.org",
+            author = "TechEmpower",
+            description = null,
+            status = FictionStatus.ONGOING,
+        )
+        val chapterSpecs = chapterSpecsFor(state.rootPageId, pageId)
+        val chapters = chapterSpecs.mapIndexed { idx, spec ->
+            ChapterInfo(
+                id = chapterIdFor(fictionId, idx),
+                sourceChapterId = "section-$idx",
+                index = idx,
+                title = spec.title,
+                publishedAt = null,
+            )
+        }
+        return FictionResult.Success(
+            FictionDetail(
+                summary = tile.copy(chapterCount = chapters.size),
+                chapters = chapters,
+            ),
+        )
+    }
+
+    /**
+     * Render one chapter's body. Looks up the chapter's source page id
+     * in [chapterSpecsFor], loads its blocks, and projects them to
+     * HTML + plain text. The "Resources" chapter has special handling
+     * because its underlying block is a collection (not a page) — we
+     * call queryCollection and render the row titles as a list.
+     */
+    suspend fun chapter(
+        state: NotionConfigState,
+        fictionId: String,
+        chapterId: String,
+    ): FictionResult<ChapterContent> {
+        val pageId = fictionId.toPageId()
+            ?: return FictionResult.NotFound("Notion fiction id not recognized: $fictionId")
+        val sectionIndex = chapterId.substringAfterLast("::section-", "")
+            .toIntOrNull()
+            ?: return FictionResult.NotFound("Notion chapter id not recognized: $chapterId")
+        val specs = chapterSpecsFor(state.rootPageId, pageId)
+        val spec = specs.getOrNull(sectionIndex)
+            ?: return FictionResult.NotFound(
+                "Section $sectionIndex not found for Notion fiction $pageId",
+            )
+        val info = ChapterInfo(
+            id = chapterId,
+            sourceChapterId = "section-$sectionIndex",
+            index = sectionIndex,
+            title = spec.title,
+        )
+        return when (spec) {
+            is ChapterSpec.Page -> renderPageChapter(info, spec.pageId)
+            is ChapterSpec.Collection -> renderCollectionChapter(info, spec)
+        }
+    }
+
+    /**
+     * Search — the anonymous-mode tile is single-fiction, so search
+     * either matches the one tile's title/description or returns
+     * nothing. Keeps the source consistent with the rest of Browse
+     * (search returns a ListPage; the empty case is fine).
+     */
+    suspend fun search(
+        state: NotionConfigState,
+        term: String,
+    ): FictionResult<ListPage<FictionSummary>> {
+        val rootResult = api.loadPageChunk(state.rootPageId)
+        val root = when (rootResult) {
+            is FictionResult.Success -> rootResult.value
+            is FictionResult.Failure -> return rootResult
+        }
+        val tile = buildRootSummary(state, root)
+            ?: return FictionResult.Success(ListPage(items = emptyList(), page = 1, hasNext = false))
+        val termLc = term.trim().lowercase()
+        val matches = termLc.isEmpty() ||
+            tile.title.lowercase().contains(termLc) ||
+            tile.description?.lowercase()?.contains(termLc) == true
+        return FictionResult.Success(
+            ListPage(
+                items = if (matches) listOf(tile) else emptyList(),
+                page = 1,
+                hasNext = false,
+            ),
+        )
+    }
+
+    // ─── internals ────────────────────────────────────────────────────
+
+    /** Build the FictionSummary for the configured root page. Used in
+     *  both [popular] and [fictionDetail]. Null when the recordMap
+     *  doesn't contain a usable title (signals "this page isn't shared
+     *  publicly" or "Notion returned an empty chunk"). */
+    private fun buildRootSummary(
+        state: NotionConfigState,
+        root: NotionChunkResponse,
+    ): FictionSummary? {
+        val block = root.recordMap.findBlock(state.rootPageId) ?: return null
+        val title = readTitle(block) ?: return null
+        val description = readDescriptionFromBlocks(root.recordMap, block)
+        return FictionSummary(
+            id = notionFictionId(state.rootPageId),
+            sourceId = SourceIds.NOTION,
+            title = title,
+            author = "TechEmpower",
+            description = description,
+            coverUrl = readCoverUrl(block),
+            tags = emptyList(),
+            status = FictionStatus.ONGOING,
+        )
+    }
+
+    /** Render a chapter that points at a Notion page block. */
+    private suspend fun renderPageChapter(
+        info: ChapterInfo,
+        pageId: String,
+    ): FictionResult<ChapterContent> {
+        val chunkResult = api.loadPageChunk(pageId)
+        val chunk = when (chunkResult) {
+            is FictionResult.Success -> chunkResult.value
+            is FictionResult.Failure -> return chunkResult
+        }
+        val pageBlock = chunk.recordMap.findBlock(pageId)
+            ?: return FictionResult.NotFound("Notion page $pageId not in recordMap")
+        val (html, plain) = renderPageBody(chunk.recordMap, pageBlock)
+        return FictionResult.Success(
+            ChapterContent(
+                info = info,
+                htmlBody = html,
+                plainBody = plain,
+            ),
+        )
+    }
+
+    /** Render a chapter that points at a Notion collection (database).
+     *  Queries the collection's first view and emits an HTML list of
+     *  row titles. */
+    private suspend fun renderCollectionChapter(
+        info: ChapterInfo,
+        spec: ChapterSpec.Collection,
+    ): FictionResult<ChapterContent> {
+        // Step 1: load the collection_view block to discover its
+        // collection_id + view_ids. (Required because the unofficial
+        // queryCollection needs both ids; the configured spec only has
+        // the block id.)
+        val chunkResult = api.loadPageChunk(spec.blockId)
+        val chunk = when (chunkResult) {
+            is FictionResult.Success -> chunkResult.value
+            is FictionResult.Failure -> return chunkResult
+        }
+        val viewBlock = chunk.recordMap.findBlock(spec.blockId)
+            ?: return FictionResult.NotFound("Collection block ${spec.blockId} not in recordMap")
+        val collectionId = viewBlock.collectionId()
+            ?: return FictionResult.NotFound("Collection ${spec.blockId} has no collection_id")
+        val viewId = viewBlock.firstViewId()
+            ?: return FictionResult.NotFound("Collection ${spec.blockId} has no view_ids")
+
+        // Step 2: query the rows.
+        val rowsResult = api.queryCollection(collectionId, viewId, limit = 200)
+        val rowsResp = when (rowsResult) {
+            is FictionResult.Success -> rowsResult.value
+            is FictionResult.Failure -> return rowsResult
+        }
+        val rowTitles = collectRowTitles(rowsResp.recordMap)
+        return FictionResult.Success(
+            ChapterContent(
+                info = info,
+                htmlBody = renderRowsAsHtml(spec.title, rowTitles),
+                plainBody = renderRowsAsPlain(spec.title, rowTitles),
+            ),
+        )
+    }
+}
+
+// ─── chapter spec ─────────────────────────────────────────────────────
+
+/**
+ * One chapter's structural description. Either backed by a single
+ * Notion page or by a collection (database) — chapter rendering
+ * branches on the variant.
+ */
+internal sealed class ChapterSpec {
+    abstract val title: String
+
+    data class Page(override val title: String, val pageId: String) : ChapterSpec()
+    data class Collection(override val title: String, val blockId: String) : ChapterSpec()
+}
+
+/**
+ * Resolve the chapter list for a given (rootPageId, fictionId) pair.
+ *
+ * Today we only know one root page — TechEmpower — so any fiction id
+ * whose page id matches the TechEmpower root uses the hand-curated
+ * chapter list from [NotionDefaults]. A future iteration can support
+ * arbitrary roots by walking the root page's content[] and projecting
+ * each child page/collection into a chapter automatically.
+ *
+ * Returns an empty list when the fiction id doesn't match the root —
+ * which then surfaces as "Section N not found" at the chapter call
+ * site, the right shape for "this fiction doesn't exist anymore".
+ */
+internal fun chapterSpecsFor(rootPageId: String, fictionPageId: String): List<ChapterSpec> {
+    val compactRoot = rootPageId.replace("-", "")
+    val compactFiction = fictionPageId.replace("-", "")
+    if (compactFiction != compactRoot) return emptyList()
+    return if (compactRoot == NotionDefaults.TECHEMPOWER_ROOT_PAGE_ID) {
+        NotionDefaults.techempowerChapters
+    } else {
+        // Generic root: one chapter that renders the whole root page.
+        // Reasonable fallback for arbitrary public Notion pages; the
+        // chapter title falls back to the page's own title.
+        listOf(ChapterSpec.Page(title = "Contents", pageId = compactRoot))
+    }
+}
+
+// ─── recordMap helpers ────────────────────────────────────────────────
+
+/** Find a block in a recordMap by id. Accepts hyphenated or compact
+ *  ids and tries both forms (recordMap keys are hyphenated; storyvox's
+ *  internal id is compact). */
+internal fun NotionRecordMap.findBlock(rawId: String): JsonObject? {
+    val hyphenated = NotionUnofficialApi.hyphenatePageId(rawId)
+    val direct = block[hyphenated] ?: block[rawId]
+    return direct?.block()
+}
+
+/** Read the block type discriminator. */
+internal fun JsonObject.blockType(): String? =
+    (this["type"] as? JsonPrimitive)?.contentOrNull
+
+/** Read a Notion page block's title from its `properties.title` array. */
+internal fun readTitle(block: JsonObject): String? {
+    val props = block["properties"] as? JsonObject ?: return null
+    val titleArr = props["title"] as? JsonArray ?: return null
+    return joinDecorationArray(titleArr).ifBlank { null }
+}
+
+/** Pull a page block's cover URL from `format.page_cover`. */
+internal fun readCoverUrl(block: JsonObject): String? {
+    val fmt = block["format"] as? JsonObject ?: return null
+    val cover = (fmt["page_cover"] as? JsonPrimitive)?.contentOrNull
+    return cover?.takeIf { it.isNotBlank() }
+}
+
+/**
+ * Read a one-line description for a page from the recordMap. Walks
+ * the first few text-bearing blocks under the page to find one that
+ * isn't whitespace; returns null if none exists.
+ */
+internal fun readDescriptionFromBlocks(
+    rm: NotionRecordMap,
+    pageBlock: JsonObject,
+): String? {
+    for (childId in pageBlock.contentIds().take(5)) {
+        val child = rm.findBlock(childId) ?: continue
+        val type = child.blockType()
+        // Skip embedded subpages / collection_views / dividers in the
+        // search for a description — they don't carry narratable text.
+        if (type != "text" && type != "callout" && type != "quote") continue
+        val text = plainTextOfBlock(child)
+        if (text.isNotBlank()) return text.take(280)
+    }
+    return null
+}
+
+/** Pull collection_view's underlying collection id. */
+internal fun JsonObject.collectionId(): String? =
+    (this["collection_id"] as? JsonPrimitive)?.contentOrNull
+
+/** Pull the first view id from a collection_view's view_ids array. */
+internal fun JsonObject.firstViewId(): String? {
+    val arr = this["view_ids"] as? JsonArray ?: return null
+    val first = arr.firstOrNull() as? JsonPrimitive ?: return null
+    return first.contentOrNull
+}
+
+/**
+ * Concatenate a Notion decoration array into plain text. Each entry is
+ * `[plain_text, decoration[]?]`; we take element 0.
+ */
+internal fun joinDecorationArray(arr: JsonArray): String {
+    val sb = StringBuilder()
+    for (entry in arr) {
+        val inner = entry as? JsonArray ?: continue
+        val first = inner.firstOrNull() as? JsonPrimitive ?: continue
+        val s = first.contentOrNull ?: continue
+        sb.append(s)
+    }
+    return sb.toString()
+}
+
+/**
+ * Pull a block's plain-text content. For text/header/quote/callout
+ * blocks the content lives at `properties.title` (Notion's name for
+ * the inline text of any block, regardless of type — confusing but
+ * stable). For other blocks we return "".
+ */
+internal fun plainTextOfBlock(block: JsonObject): String {
+    val props = block["properties"] as? JsonObject ?: return ""
+    val title = props["title"] as? JsonArray ?: return ""
+    return joinDecorationArray(title)
+}
+
+/** Render a Notion unofficial-API block to HTML. Mirrors the official
+ *  toHtml() but maps the v3 block types (`header`, `sub_header`,
+ *  `sub_sub_header`, `text`, `bulleted_list`, `numbered_list`, ...).
+ *
+ *  Unlike the old per-chapter split, here we emit `<h1>` for `header`
+ *  too — the single-fiction model preserves internal heading_1s as
+ *  inline section headers in the chapter body. */
+internal fun blockToHtml(rm: NotionRecordMap, block: JsonObject): String {
+    val type = block.blockType() ?: return ""
+    val raw = plainTextOfBlock(block)
+    val text = htmlEscape(raw)
+    return when (type) {
+        "header" -> if (text.isBlank()) "" else "<h1>$text</h1>"
+        "sub_header" -> if (text.isBlank()) "" else "<h2>$text</h2>"
+        "sub_sub_header" -> if (text.isBlank()) "" else "<h3>$text</h3>"
+        "header_4" -> if (text.isBlank()) "" else "<h4>$text</h4>"
+        "text" -> if (text.isBlank()) "" else "<p>$text</p>"
+        "bulleted_list" -> if (text.isBlank()) "" else "<li>$text</li>"
+        "numbered_list" -> if (text.isBlank()) "" else "<li>$text</li>"
+        "quote" -> if (text.isBlank()) "" else "<blockquote>$text</blockquote>"
+        "callout" -> if (text.isBlank()) "" else "<aside>$text</aside>"
+        "code" -> if (text.isBlank()) "" else "<pre><code>$text</code></pre>"
+        "divider" -> "<hr/>"
+        "to_do" -> if (text.isBlank()) "" else "<p>$text</p>"
+        "toggle" -> if (text.isBlank()) "" else "<p>$text</p>"
+        // Embedded page links (child pages, mentions) — emit a
+        // bridge paragraph so the chapter narrates "See also: <Title>"
+        // rather than going silent on the page's internal navigation.
+        // We can't render the linked content here (would balloon the
+        // chapter), but a visible reference is better than nothing.
+        "page" -> {
+            val pageTitle = htmlEscape(readTitle(block).orEmpty())
+            if (pageTitle.isBlank()) "" else "<p><strong>$pageTitle</strong></p>"
+        }
+        else -> ""
+    }
+}
+
+/** Plain-text projection of a block, for TTS. Mirrors [blockToHtml]
+ *  but strips markup; headings are read aloud as plain text. */
+internal fun blockToPlain(block: JsonObject): String {
+    val type = block.blockType() ?: return ""
+    return when (type) {
+        "divider" -> ""
+        "page" -> readTitle(block).orEmpty()
+        else -> plainTextOfBlock(block)
+    }
+}
+
+/**
+ * Render a single page's content as one chapter body. Returns a pair
+ * (htmlBody, plainBody). All `alive:false` tombstones are filtered.
+ * Page blocks embedded in the content (sub-pages) render as bridge
+ * paragraphs ("<strong>Sub-page title</strong>") rather than being
+ * expanded inline.
+ */
+internal fun renderPageBody(
+    rm: NotionRecordMap,
+    pageBlock: JsonObject,
+): Pair<String, String> {
+    val html = StringBuilder()
+    val plain = StringBuilder()
+    for (id in pageBlock.contentIds()) {
+        val block = rm.findBlock(id) ?: continue
+        val alive = (block["alive"] as? JsonPrimitive)?.booleanOrNull
+        if (alive == false) continue
+        val htmlPart = blockToHtml(rm, block)
+        if (htmlPart.isNotEmpty()) {
+            if (html.isNotEmpty()) html.append('\n')
+            html.append(htmlPart)
+        }
+        val plainPart = blockToPlain(block)
+        if (plainPart.isNotEmpty()) {
+            if (plain.isNotEmpty()) plain.append("\n\n")
+            plain.append(plainPart)
+        }
+    }
+    return html.toString().trim() to plain.toString().trim()
+}
+
+/**
+ * Pull row titles out of a queryCollection recordMap. Every `page`
+ * block in the recordMap is a row; we project to (id, title) and
+ * filter to titled rows.
+ */
+internal fun collectRowTitles(rm: NotionRecordMap): List<String> {
+    val out = mutableListOf<String>()
+    for ((_, env) in rm.block) {
+        val block = env.block() ?: continue
+        if (block.blockType() != "page") continue
+        val alive = (block["alive"] as? JsonPrimitive)?.booleanOrNull
+        if (alive == false) continue
+        val title = readTitle(block) ?: continue
+        out.add(title)
+    }
+    out.sort()
+    return out
+}
+
+/** HTML rendering of a collection chapter — header + ordered list of
+ *  row titles. */
+internal fun renderRowsAsHtml(chapterTitle: String, titles: List<String>): String {
+    if (titles.isEmpty()) {
+        return "<p>${htmlEscape(chapterTitle)} is empty.</p>"
+    }
+    val sb = StringBuilder()
+    sb.append("<p>")
+    sb.append(htmlEscape("TechEmpower's $chapterTitle database has ${titles.size} entries:"))
+    sb.append("</p>\n<ul>\n")
+    for (title in titles) {
+        sb.append("<li>").append(htmlEscape(title)).append("</li>\n")
+    }
+    sb.append("</ul>")
+    return sb.toString()
+}
+
+/** Plain-text rendering of a collection chapter — short intro + a
+ *  newline-separated list of titles. Reads aloud as a clean list. */
+internal fun renderRowsAsPlain(chapterTitle: String, titles: List<String>): String {
+    if (titles.isEmpty()) return "$chapterTitle is empty."
+    val intro = "TechEmpower's $chapterTitle database has ${titles.size} entries."
+    return intro + "\n\n" + titles.joinToString("\n")
+}

--- a/source-notion/src/main/kotlin/in/jphe/storyvox/source/notion/NotionSource.kt
+++ b/source-notion/src/main/kotlin/in/jphe/storyvox/source/notion/NotionSource.kt
@@ -11,6 +11,8 @@ import `in`.jphe.storyvox.data.source.model.FictionSummary
 import `in`.jphe.storyvox.data.source.model.ListPage
 import `in`.jphe.storyvox.data.source.model.SearchQuery
 import `in`.jphe.storyvox.data.source.model.map
+import `in`.jphe.storyvox.source.notion.config.NotionConfig
+import `in`.jphe.storyvox.source.notion.config.NotionMode
 import `in`.jphe.storyvox.source.notion.net.NotionApi
 import `in`.jphe.storyvox.source.notion.net.NotionBlock
 import `in`.jphe.storyvox.source.notion.net.NotionPage
@@ -55,6 +57,8 @@ import javax.inject.Singleton
 @Singleton
 internal class NotionSource @Inject constructor(
     private val api: NotionApi,
+    private val anonymous: AnonymousNotionDelegate,
+    private val config: NotionConfig,
 ) : FictionSource {
 
     override val id: String = SourceIds.NOTION
@@ -63,6 +67,10 @@ internal class NotionSource @Inject constructor(
     // ─── browse ────────────────────────────────────────────────────────
 
     override suspend fun popular(page: Int): FictionResult<ListPage<FictionSummary>> {
+        val state = config.current()
+        if (state.mode == NotionMode.ANONYMOUS_PUBLIC) {
+            return anonymous.popular(state, page)
+        }
         // Notion paginates via opaque `start_cursor` strings, not integer
         // page numbers. Our BrowsePaginator drives 1-indexed page numbers;
         // we collapse "first call" = page 1 = cursor=null. Page 2+ from a
@@ -108,6 +116,10 @@ internal class NotionSource @Inject constructor(
         FictionResult.Success(emptyList())
 
     override suspend fun search(query: SearchQuery): FictionResult<ListPage<FictionSummary>> {
+        val state = config.current()
+        if (state.mode == NotionMode.ANONYMOUS_PUBLIC) {
+            return anonymous.search(state, query.term)
+        }
         // v1 — client-side filter over the database's first 100 pages.
         // Notion's /search endpoint exists but searches the user's whole
         // workspace, not just the configured database; that's the wrong
@@ -129,6 +141,10 @@ internal class NotionSource @Inject constructor(
     // ─── detail ────────────────────────────────────────────────────────
 
     override suspend fun fictionDetail(fictionId: String): FictionResult<FictionDetail> {
+        val state = config.current()
+        if (state.mode == NotionMode.ANONYMOUS_PUBLIC) {
+            return anonymous.fictionDetail(state, fictionId)
+        }
         val pageId = fictionId.toPageId()
             ?: return FictionResult.NotFound("Notion fiction id not recognized: $fictionId")
         // Two-call pattern: page metadata + block children. Same shape
@@ -170,6 +186,10 @@ internal class NotionSource @Inject constructor(
         fictionId: String,
         chapterId: String,
     ): FictionResult<ChapterContent> {
+        val state = config.current()
+        if (state.mode == NotionMode.ANONYMOUS_PUBLIC) {
+            return anonymous.chapter(state, fictionId, chapterId)
+        }
         val pageId = fictionId.toPageId()
             ?: return FictionResult.NotFound("Notion fiction id not recognized: $fictionId")
         val sectionIndex = chapterId.substringAfterLast("::section-", "")

--- a/source-notion/src/main/kotlin/in/jphe/storyvox/source/notion/config/NotionConfig.kt
+++ b/source-notion/src/main/kotlin/in/jphe/storyvox/source/notion/config/NotionConfig.kt
@@ -5,17 +5,29 @@ import kotlinx.coroutines.flow.Flow
 /**
  * Issue #233 — abstraction over the Notion source's persistent config.
  *
- * Three knobs:
- *   - **databaseId**: the Notion database that storyvox treats as a
- *     fiction catalog. Each page in this database becomes one fiction.
- *     Defaults to [NotionDefaults.TECHEMPOWER_DATABASE_ID] per #390 —
- *     fresh installs land pre-pointed at the techempower.org content DB.
- *   - **apiToken**: a Notion *Internal Integration* PAT (starts with
- *     `ntn_` or `secret_`). Stored in EncryptedSharedPreferences. Empty
- *     means the source is read-disabled and Browse → Notion renders an
- *     empty-state with a "configure token" CTA. Notion's REST API
- *     requires auth on every call — there is no anonymous tier.
- *   - **baseUrl**: configurable for testing; defaults to api.notion.com.
+ * Mode-aware (issue #393):
+ *   - [NotionMode.ANONYMOUS_PUBLIC] (zero-setup default) — reads
+ *     public-shared Notion pages via the *unofficial*
+ *     `www.notion.so/api/v3` endpoints (`loadPageChunk`,
+ *     `queryCollection`, `syncRecordValuesMain`, `getPublicPageData`).
+ *     Same surface react-notion-x uses. No token required. The
+ *     [rootPageId] points at a public Notion page; storyvox walks its
+ *     child blocks to expose Guides + Collections + sub-pages as
+ *     individual fictions. Defaults to TechEmpower's root page id
+ *     so fresh installs land on the TechEmpower content tree.
+ *   - [NotionMode.OFFICIAL_PAT] — the original integration-token flow.
+ *     Reads a single database via the *official* `api.notion.com/v1`
+ *     REST endpoints. Required for private workspaces. Existing users
+ *     who pasted a PAT in v0.5.23/.24 continue on this path
+ *     unchanged.
+ *
+ * Mode selection (per [SettingsRepositoryUiImpl] / [NotionConfigImpl]):
+ *   - Blank [apiToken] → [NotionMode.ANONYMOUS_PUBLIC].
+ *   - Non-blank [apiToken] → [NotionMode.OFFICIAL_PAT].
+ *
+ * This means the user can switch modes simply by pasting (or clearing)
+ * a PAT. The UI surfaces both knobs side-by-side; the default view is
+ * the anonymous one with the TechEmpower root pre-populated.
  *
  * Implementation lives in :app on top of DataStore + the shared
  * `storyvox.secrets` EncryptedSharedPreferences — same pattern as
@@ -33,28 +45,73 @@ interface NotionConfig {
 }
 
 /**
- * One Notion config state. Empty [apiToken] disables the source
- * entirely — Notion's API has no anonymous tier.
+ * Issue #393 — read-mode selector.
+ *
+ * - [ANONYMOUS_PUBLIC] uses the unofficial `www.notion.so/api/v3`
+ *   surface and a public-shared root page id. Zero setup: out of the
+ *   box, storyvox reads TechEmpower's public Notion tree.
+ * - [OFFICIAL_PAT] uses the official `api.notion.com/v1` REST API with
+ *   a per-user integration token. Required for private workspaces.
+ */
+enum class NotionMode {
+    /** Read public-shared Notion pages anonymously via the unofficial
+     *  `www.notion.so/api/v3` surface. The default for fresh installs. */
+    ANONYMOUS_PUBLIC,
+
+    /** Read a private workspace database via `api.notion.com/v1` with
+     *  an Internal Integration token. */
+    OFFICIAL_PAT,
+}
+
+/**
+ * One Notion config state. The active read path depends on [mode];
+ * fields not needed by the chosen mode are tolerated (anonymous mode
+ * ignores [apiToken]; PAT mode ignores [rootPageId]).
  */
 data class NotionConfigState(
-    /** The Notion database id the source surfaces as the Browse catalog.
-     *  Hyphenated (8-4-4-4-12) or compact (32 hex chars) — Notion accepts
-     *  both. Defaults to [NotionDefaults.TECHEMPOWER_DATABASE_ID] for #390. */
+    /** Read-path selector. See [NotionMode]. Defaults to anonymous
+     *  because the zero-setup TechEmpower experience is the new
+     *  default (#393); existing PAT-holding users get
+     *  [NotionMode.OFFICIAL_PAT] reactively via [apiToken] presence. */
+    val mode: NotionMode = NotionMode.ANONYMOUS_PUBLIC,
+
+    /** The Notion database id the source surfaces as the Browse catalog
+     *  in [NotionMode.OFFICIAL_PAT]. Hyphenated (8-4-4-4-12) or compact
+     *  (32 hex chars) — Notion accepts both. Defaults to
+     *  [NotionDefaults.TECHEMPOWER_DATABASE_ID]. Ignored in anonymous
+     *  mode (the root page id drives discovery instead). */
     val databaseId: String = NotionDefaults.TECHEMPOWER_DATABASE_ID,
+
+    /** Root public page id for [NotionMode.ANONYMOUS_PUBLIC]. The source
+     *  walks this page's child blocks and exposes child pages /
+     *  collections as fictions. Defaults to
+     *  [NotionDefaults.TECHEMPOWER_ROOT_PAGE_ID]. Ignored in PAT mode. */
+    val rootPageId: String = NotionDefaults.TECHEMPOWER_ROOT_PAGE_ID,
+
     /** PAT-style "Internal Integration Token" from
-     *  notion.so/my-integrations. Empty disables the source. Stored
+     *  notion.so/my-integrations. Empty enables anonymous mode. Stored
      *  encrypted; never exposed to the UI as a readable string (the
      *  UiSettings projection only carries a `tokenConfigured: Boolean`). */
     val apiToken: String = "",
-    /** Notion REST API base URL. Defaults to api.notion.com; overridable
-     *  for test infra without rewriting the source. */
+
+    /** Official Notion REST API base URL. Defaults to api.notion.com;
+     *  overridable for test infra without rewriting the source. */
     val baseUrl: String = NotionDefaults.BASE_URL,
+
+    /** Unofficial Notion API base URL. Defaults to
+     *  https://www.notion.so/api/v3; overridable for test fakes. */
+    val unofficialBaseUrl: String = NotionDefaults.UNOFFICIAL_BASE_URL,
+
     /** Notion REST API version header — pinned in the source rather than
      *  the user config so storyvox + Notion never drift apart silently. */
     val apiVersion: String = NotionDefaults.API_VERSION,
 ) {
-    /** True when the source can make API calls. Token presence is the
-     *  one hard gate — Notion has no anonymous tier. */
+    /** True when the source can make API calls. In anonymous mode this
+     *  is true whenever [rootPageId] is non-blank; in PAT mode it
+     *  requires both [apiToken] and [databaseId]. */
     val isConfigured: Boolean
-        get() = apiToken.isNotBlank() && databaseId.isNotBlank()
+        get() = when (mode) {
+            NotionMode.ANONYMOUS_PUBLIC -> rootPageId.isNotBlank()
+            NotionMode.OFFICIAL_PAT -> apiToken.isNotBlank() && databaseId.isNotBlank()
+        }
 }

--- a/source-notion/src/main/kotlin/in/jphe/storyvox/source/notion/config/NotionDefaults.kt
+++ b/source-notion/src/main/kotlin/in/jphe/storyvox/source/notion/config/NotionDefaults.kt
@@ -47,8 +47,35 @@ object NotionDefaults {
     const val TECHEMPOWER_DATABASE_ID: String =
         "2a3d706803c649409e74e9ce5ccd4c4b"
 
+    /**
+     * Issue #393 — TechEmpower's root **page** id (the parent of the
+     * Resources database and all 8 Guide pages). Used in
+     * `NotionMode.ANONYMOUS_PUBLIC` mode: storyvox loads this page's
+     * child blocks via the unofficial `loadPageChunk` endpoint and
+     * expands collection_view children + page children into individual
+     * fictions. Sourced from `techempower/site.config.ts`
+     * `rootNotionPageId` (line 5) — the same id `techempower.org` uses
+     * as its top-level Notion page.
+     */
+    const val TECHEMPOWER_ROOT_PAGE_ID: String =
+        "0959e44599984143acabc80187305001"
+
     /** Notion REST API host. */
     const val BASE_URL: String = "https://api.notion.com"
+
+    /**
+     * Issue #393 — base URL for the *unofficial* Notion API
+     * (`www.notion.so/api/v3`). This is the same surface
+     * `react-notion-x`'s `notion-client` package hits — it's how the
+     * notion.site renderer works without a token. Notion serves
+     * `loadPageChunk`, `queryCollection`, `syncRecordValuesMain`, and
+     * `getPublicPageData` on this host without `Authorization`.
+     *
+     * Caveat: this endpoint is undocumented and Notion may change it.
+     * We pin to the v3 path and add structured error decoding so we
+     * surface useful messages if Notion shifts shape.
+     */
+    const val UNOFFICIAL_BASE_URL: String = "https://www.notion.so/api/v3"
 
     /**
      * Notion REST API version pin. Notion's API requires a
@@ -68,4 +95,44 @@ object NotionDefaults {
      */
     const val USER_AGENT: String =
         "storyvox-notion/1.0 (+https://github.com/techempower-org/storyvox)"
+
+    /**
+     * Issue #393 — chapter list for the single TechEmpower fiction in
+     * anonymous mode. Browse → Notion surfaces one tile
+     * ("TechEmpower.org"); this list defines its chapter spine.
+     *
+     * Order matches `site.config.ts` `navigationLinks`: Guides
+     * (the root page itself), Resources (the database), About, Donate.
+     * Each entry resolves to either a Notion page (rendered via the
+     * page's own block content) or a Notion collection (rendered as
+     * an overview list of row titles).
+     *
+     * Adding a new chapter — e.g. the non-discrimination policy at
+     * `cdbe9906ae2441a1a9bb3aec601a5a6c` — is a one-line append. The
+     * delegate doesn't hardcode chapter count anywhere; this list IS
+     * the schema.
+     */
+    internal val techempowerChapters: List<`in`.jphe.storyvox.source.notion.ChapterSpec> = listOf(
+        `in`.jphe.storyvox.source.notion.ChapterSpec.Page(
+            title = "Guides",
+            // The root page itself — its block content includes the
+            // intro paragraphs, the 8 guide sub-page references, and
+            // the link to Resources. Internal `header` blocks render
+            // as `<h1>` inline so the chapter reader sees them as
+            // sub-headings within "Guides".
+            pageId = TECHEMPOWER_ROOT_PAGE_ID,
+        ),
+        `in`.jphe.storyvox.source.notion.ChapterSpec.Collection(
+            title = "Resources",
+            blockId = TECHEMPOWER_DATABASE_ID,
+        ),
+        `in`.jphe.storyvox.source.notion.ChapterSpec.Page(
+            title = "About",
+            pageId = "dbf0ddece2ce468fb2bf9049e6322e8a",
+        ),
+        `in`.jphe.storyvox.source.notion.ChapterSpec.Page(
+            title = "Donate",
+            pageId = "59d8a4dab0cc484f8b044d33f240ce1d",
+        ),
+    )
 }

--- a/source-notion/src/main/kotlin/in/jphe/storyvox/source/notion/di/NotionModule.kt
+++ b/source-notion/src/main/kotlin/in/jphe/storyvox/source/notion/di/NotionModule.kt
@@ -53,6 +53,20 @@ internal object NotionHttpModule {
         config: `in`.jphe.storyvox.source.notion.config.NotionConfig,
     ): `in`.jphe.storyvox.source.notion.net.NotionApi =
         `in`.jphe.storyvox.source.notion.net.NotionApi(client, config)
+
+    /**
+     * Issue #393 — anonymous-mode reader against the unofficial
+     * `www.notion.so/api/v3` surface. Shares the [NotionHttp] OkHttp
+     * client with the PAT-mode reader so both flows benefit from the
+     * same connection pool + timeouts.
+     */
+    @Provides
+    @Singleton
+    fun provideNotionUnofficialApi(
+        @NotionHttp client: OkHttpClient,
+        config: `in`.jphe.storyvox.source.notion.config.NotionConfig,
+    ): `in`.jphe.storyvox.source.notion.net.NotionUnofficialApi =
+        `in`.jphe.storyvox.source.notion.net.NotionUnofficialApi(client, config)
 }
 
 /**

--- a/source-notion/src/main/kotlin/in/jphe/storyvox/source/notion/net/NotionApi.kt
+++ b/source-notion/src/main/kotlin/in/jphe/storyvox/source/notion/net/NotionApi.kt
@@ -224,16 +224,22 @@ internal class NotionApi @Inject constructor(
      * fail without bothering Notion. `null` means "good to go".
      */
     private fun <T> requireConfigured(state: NotionConfigState): FictionResult<T>? {
+        // v0.5.23 shipped with a TODO placeholder database id and this
+        // method rejected it as "not configured". v0.5.24 replaced the
+        // placeholder with TechEmpower's real Resources DB id, but the
+        // rejection check stayed — silently breaking the bundled
+        // default for anyone with an integration token shared to the
+        // Resources DB. v0.5.25 (#393) removes the equality check; the
+        // anonymous-mode path runs without a token, and PAT mode is
+        // gated by token presence alone.
         if (state.apiToken.isBlank()) {
             return FictionResult.AuthRequired(
                 "Notion integration token not configured",
             )
         }
-        if (state.databaseId.isBlank() ||
-            state.databaseId == NotionDefaults.TECHEMPOWER_DATABASE_ID
-        ) {
+        if (state.databaseId.isBlank()) {
             return FictionResult.NotFound(
-                "Notion database id not configured (TODO placeholder still in use)",
+                "Notion database id not configured",
             )
         }
         return null

--- a/source-notion/src/main/kotlin/in/jphe/storyvox/source/notion/net/NotionUnofficialApi.kt
+++ b/source-notion/src/main/kotlin/in/jphe/storyvox/source/notion/net/NotionUnofficialApi.kt
@@ -1,0 +1,318 @@
+package `in`.jphe.storyvox.source.notion.net
+
+import `in`.jphe.storyvox.data.source.model.FictionResult
+import `in`.jphe.storyvox.source.notion.config.NotionConfig
+import `in`.jphe.storyvox.source.notion.config.NotionConfigState
+import `in`.jphe.storyvox.source.notion.config.NotionDefaults
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+import kotlinx.serialization.json.Json
+import okhttp3.MediaType.Companion.toMediaType
+import okhttp3.OkHttpClient
+import okhttp3.Request
+import okhttp3.RequestBody.Companion.toRequestBody
+import java.io.IOException
+import java.util.Locale
+import java.util.concurrent.ConcurrentHashMap
+import javax.inject.Inject
+import javax.inject.Singleton
+import kotlin.time.Duration.Companion.seconds
+
+/**
+ * Issue #393 — anonymous reader-mode client for Notion's *unofficial*
+ * `www.notion.so/api/v3` surface. Same set react-notion-x's
+ * `notion-client` package hits; we hand-craft the JSON bodies because
+ * the queryCollection loader shape is deeply nested and full kotlinx-
+ * serialization round-tripping is more code than the bodies themselves.
+ *
+ * Endpoints wrapped:
+ *
+ *  - **POST `/loadPageChunk`** — fetch a page's blocks (the structural
+ *    tree). Body: `{pageId, limit, chunkNumber, cursor:{stack:[]}, verticalColumns:false}`.
+ *    The response's recordMap.block[pageId].value.value.content is the
+ *    ordered array of child block ids; child block payloads are in the
+ *    same recordMap.
+ *
+ *  - **POST `/queryCollection`** — list rows of a database. Body wraps
+ *    `{collection:{id}, collectionView:{id}, source, loader:{reducer...}}`.
+ *    The reducer query is the same shape react-notion-x sends, with
+ *    `collection_group_results` capped at 100. Larger collections are
+ *    expected to page; for TechEmpower the Resources collection has
+ *    ~80 rows so one call covers it. We do not yet stream — first 100
+ *    rows is the visible Browse-page surface; pagination is a TODO.
+ *
+ *  - **POST `/syncRecordValuesMain`** — fetch a specific block by id
+ *    (used to resolve a child page when its block payload isn't yet
+ *    in any in-memory recordMap — typically a deep link from Library).
+ *    Body: `{requests:[{id, table:"block", version:-1}]}`.
+ *
+ *  - **POST `/getPublicPageData`** — verify a page is publicly shared.
+ *    Body: `{type:"block-space",name:"page",blockId,saveParent:false,
+ *    showMoveTo:false,showWebsiteLogin:true}`. 200 + `publicAccessRole`
+ *    populated = public; 4xx (or `requireLogin:true`) = gated. We use
+ *    this only as a one-shot diagnostic when a user-supplied root page
+ *    id can't be loaded, not on every read.
+ *
+ * Caching: in-memory `pageId → NotionChunkResponse` map keyed on the
+ * page id. Lives for the process lifetime — Android process kill
+ * clears it, which is exactly the eviction policy we want (a fresh
+ * cold start re-reads current Notion content; a warm session
+ * deduplicates round-trips). Concurrent access is rare (Browse +
+ * detail are sequential), but we use ConcurrentHashMap to keep the
+ * paths thread-safe.
+ *
+ * Notion may rate-limit the unofficial endpoint without a Retry-After
+ * header. We surface 429 as `FictionResult.RateLimited` with retryAfter
+ * defaulting to 30s so the caller can back off without guessing.
+ */
+@Singleton
+internal class NotionUnofficialApi @Inject constructor(
+    private val client: OkHttpClient,
+    private val config: NotionConfig,
+) {
+    private val json = Json { ignoreUnknownKeys = true; isLenient = true }
+    private val mediaTypeJson = "application/json".toMediaType()
+
+    /**
+     * Process-lifetime cache of pageId → loadPageChunk response. Same
+     * keying as react-notion-x: hyphenated page id strings. We never
+     * evict — Notion content changes on the order of hours/days, well
+     * past a typical Browse session.
+     */
+    private val pageCache = ConcurrentHashMap<String, NotionChunkResponse>()
+
+    /**
+     * Fetch a page's blocks via `loadPageChunk`. Returns the full
+     * recordMap (with the requested page at `recordMap.block[pageId]`).
+     * Cached per process.
+     */
+    suspend fun loadPageChunk(pageId: String): FictionResult<NotionChunkResponse> {
+        val hyphenated = hyphenatePageId(pageId)
+        pageCache[hyphenated]?.let { return FictionResult.Success(it) }
+        val state = config.current()
+        val body = """{"pageId":"$hyphenated","limit":100,"chunkNumber":0,"cursor":{"stack":[]},"verticalColumns":false}"""
+        return postEndpoint<NotionChunkResponse>(state.unofficialBaseUrl, "loadPageChunk", body)
+            .also { result ->
+                if (result is FictionResult.Success) {
+                    pageCache[hyphenated] = result.value
+                }
+            }
+    }
+
+    /**
+     * Query a database (collection) for rows. The loader shape is a
+     * verbatim port of the body react-notion-x sends — type:"reducer"
+     * with a single `collection_group_results` reducer at limit=100.
+     * We do not surface filters/sort yet; storyvox's Browse paginator
+     * doesn't drive them. TechEmpower's Resources collection currently
+     * has ~80 rows so a single non-paginated call covers everything.
+     */
+    suspend fun queryCollection(
+        collectionId: String,
+        collectionViewId: String,
+        limit: Int = 100,
+    ): FictionResult<NotionQueryCollectionResponse> {
+        val state = config.current()
+        val collId = hyphenatePageId(collectionId)
+        val viewId = hyphenatePageId(collectionViewId)
+        val safeLimit = limit.coerceIn(1, 999)
+        val body = buildString {
+            append('{')
+            append("\"collection\":{\"id\":\"").append(collId).append("\"},")
+            append("\"collectionView\":{\"id\":\"").append(viewId).append("\"},")
+            append("\"source\":{\"type\":\"collection\",\"id\":\"").append(collId).append("\"},")
+            append("\"loader\":{")
+            append("\"type\":\"reducer\",")
+            append("\"reducers\":{\"collection_group_results\":{\"type\":\"results\",\"limit\":")
+                .append(safeLimit).append(",\"loadContentCover\":true}},")
+            append("\"sort\":[],")
+            append("\"filter\":{\"filters\":[],\"operator\":\"and\"},")
+            append("\"searchQuery\":\"\",")
+            append("\"userTimeZone\":\"America/Los_Angeles\"")
+            append('}')
+            append('}')
+        }
+        return postEndpoint<NotionQueryCollectionResponse>(state.unofficialBaseUrl, "queryCollection", body)
+    }
+
+    /**
+     * Fetch a specific block by id via `syncRecordValuesMain`. Used to
+     * resolve a child page's block payload when it isn't present in any
+     * cached recordMap — typically when a deep link drops the user
+     * straight into Library without going through Browse first.
+     *
+     * The spec doc lists this as `getRecordValues`, but that endpoint
+     * has been returning `502 MemcachedCrossCellError` for
+     * cross-workspace requests since at least 2024; `syncRecordValuesMain`
+     * is the working successor and what react-notion-x v7 now hits.
+     */
+    suspend fun syncRecordValues(blockIds: List<String>): FictionResult<NotionChunkResponse> {
+        if (blockIds.isEmpty()) return FictionResult.Success(NotionChunkResponse())
+        val state = config.current()
+        val body = buildString {
+            append("{\"requests\":[")
+            for ((i, id) in blockIds.withIndex()) {
+                if (i > 0) append(',')
+                append("{\"id\":\"").append(hyphenatePageId(id))
+                append("\",\"table\":\"block\",\"version\":-1}")
+            }
+            append("]}")
+        }
+        return postEndpoint<NotionChunkResponse>(state.unofficialBaseUrl, "syncRecordValuesMain", body)
+    }
+
+    /**
+     * Probe a page's public-share status via `getPublicPageData`. Used
+     * for one-shot diagnostics when a configured root page id fails to
+     * load — lets us tell the user "this page isn't shared publicly"
+     * vs. "Notion is unreachable" without guessing from a 4xx code.
+     */
+    suspend fun getPublicPageData(pageId: String): FictionResult<NotionPublicPageData> {
+        val state = config.current()
+        val hyphenated = hyphenatePageId(pageId)
+        val body = """{"type":"block-space","name":"page","blockId":"$hyphenated","saveParent":false,"showMoveTo":false,"showWebsiteLogin":true}"""
+        return postEndpoint<NotionPublicPageData>(state.unofficialBaseUrl, "getPublicPageData", body)
+    }
+
+    /** Wipe the in-memory page cache. Hook for tests + a future
+     *  "refresh content" affordance in Settings. */
+    fun clearCache() {
+        pageCache.clear()
+    }
+
+    // ─── transport ────────────────────────────────────────────────────
+
+    /**
+     * Run the network call on the IO dispatcher. The FictionSource
+     * contract is suspend-and-callable-from-anywhere, but storyvox's
+     * Browse paginator dispatches some suspend points on the Main
+     * thread (Compose state updates ride alongside the source call),
+     * so a `suspend` function that issues a synchronous OkHttp request
+     * will NPE with [android.os.NetworkOnMainThreadException]. Wrap
+     * every HTTP call here so callers don't have to think about it.
+     */
+    private suspend inline fun <reified T> postEndpoint(
+        baseUrl: String,
+        endpoint: String,
+        body: String,
+    ): FictionResult<T> = withContext(Dispatchers.IO) {
+        when (val raw = doPost("$baseUrl/$endpoint", body)) {
+            is FictionResult.Success -> try {
+                FictionResult.Success(json.decodeFromString<T>(raw.value))
+            } catch (e: kotlinx.serialization.SerializationException) {
+                FictionResult.NetworkError(
+                    "Notion (unofficial) returned unexpected JSON shape — endpoint may have changed",
+                    e,
+                )
+            }
+            is FictionResult.Failure -> raw
+        }
+    }
+
+    private fun doPost(url: String, body: String): FictionResult<String> {
+        return try {
+            val reqBuilder = Request.Builder()
+                .url(url)
+                .header("Accept", "application/json")
+                // Notion's edge accepts our project-specific UA on the
+                // unofficial endpoint — same string the official-API
+                // client uses for consistency. Spoofing a browser UA
+                // would be misleading and the unofficial endpoint
+                // doesn't gate on it anyway.
+                .header("User-Agent", NotionDefaults.USER_AGENT)
+                .post(body.toRequestBody(mediaTypeJson))
+            client.newCall(reqBuilder.build()).execute().use { resp ->
+                val text = resp.body?.string().orEmpty()
+                // The unofficial endpoint sometimes returns HTTP 200 with
+                // an `isNotionError:true` envelope (Cloudflare/edge errors
+                // come back this way). We sniff for that shape before
+                // claiming success so the caller sees the real error.
+                val notionError = decodeNotionError(text)
+                when {
+                    notionError != null -> mapNotionError(resp.code, notionError, text)
+                    resp.code == 401 || resp.code == 403 ->
+                        FictionResult.AuthRequired(
+                            "Notion page is not publicly shared (or share was revoked)",
+                        )
+                    resp.code == 404 ->
+                        FictionResult.NotFound(
+                            "Notion page not found via unofficial API",
+                        )
+                    resp.code == 429 ->
+                        FictionResult.RateLimited(
+                            retryAfter = (resp.header("Retry-After")
+                                ?.toLongOrNull() ?: 30L).seconds,
+                            message = "Notion rate-limited the unofficial endpoint",
+                        )
+                    !resp.isSuccessful ->
+                        FictionResult.NetworkError(
+                            "HTTP ${resp.code} from Notion (unofficial)",
+                            IOException("HTTP ${resp.code}"),
+                        )
+                    else -> FictionResult.Success(text)
+                }
+            }
+        } catch (e: IOException) {
+            FictionResult.NetworkError(e.message ?: "fetch failed", e)
+        }
+    }
+
+    /**
+     * Decode a structured `isNotionError` envelope if the body looks
+     * like one. Returns null on any non-error JSON shape (success
+     * payloads also parse permissively, so we gate on the
+     * `isNotionError` boolean).
+     */
+    private fun decodeNotionError(body: String): NotionUnofficialError? = runCatching {
+        if (body.isBlank() || !body.contains("\"isNotionError\"")) return null
+        val err = json.decodeFromString<NotionUnofficialError>(body)
+        if (err.isNotionError) err else null
+    }.getOrNull()
+
+    private fun <T> mapNotionError(
+        httpCode: Int,
+        err: NotionUnofficialError,
+        rawBody: String,
+    ): FictionResult<T> {
+        val msg = err.message ?: err.debugMessage ?: "Notion error"
+        val nameLower = err.name?.lowercase(Locale.ROOT) ?: ""
+        return when {
+            nameLower.contains("unauthorized") || nameLower.contains("permission") ->
+                FictionResult.AuthRequired(msg)
+            nameLower.contains("notfound") || nameLower.contains("not_found") ->
+                FictionResult.NotFound(msg)
+            nameLower.contains("ratelimit") || httpCode == 429 ->
+                FictionResult.RateLimited(retryAfter = 30.seconds, message = msg)
+            else -> FictionResult.NetworkError(msg, IOException(rawBody.take(200)))
+        }
+    }
+
+    companion object {
+        /**
+         * Notion's unofficial API requires page ids in the hyphenated
+         * UUID form (8-4-4-4-12). We accept compact 32-hex or
+         * already-hyphenated forms and normalize.
+         *
+         * - "0959e44599984143acabc80187305001" → "0959e445-9998-4143-acab-c80187305001"
+         * - "0959e445-9998-4143-acab-c80187305001" → unchanged
+         * - Other inputs returned as-is so the API can surface its
+         *   own error if the id is genuinely malformed.
+         */
+        internal fun hyphenatePageId(id: String): String {
+            if (id.isEmpty()) return id
+            if (id.contains('-')) return id
+            if (id.length != 32) return id
+            return buildString(36) {
+                append(id, 0, 8)
+                append('-')
+                append(id, 8, 12)
+                append('-')
+                append(id, 12, 16)
+                append('-')
+                append(id, 16, 20)
+                append('-')
+                append(id, 20, 32)
+            }
+        }
+    }
+}

--- a/source-notion/src/main/kotlin/in/jphe/storyvox/source/notion/net/NotionUnofficialModels.kt
+++ b/source-notion/src/main/kotlin/in/jphe/storyvox/source/notion/net/NotionUnofficialModels.kt
@@ -1,0 +1,172 @@
+package `in`.jphe.storyvox.source.notion.net
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.json.JsonArray
+import kotlinx.serialization.json.JsonElement
+import kotlinx.serialization.json.JsonObject
+
+/**
+ * Issue #393 — wire types for the **unofficial** Notion API surface at
+ * `www.notion.so/api/v3`. Same set react-notion-x's `notion-client` hits
+ * (we reverse-engineered the shapes by probing TechEmpower's public
+ * Notion tree on 2026-05-13).
+ *
+ * Endpoints modelled:
+ *
+ *  - **POST `/api/v3/loadPageChunk`** — fetch a page's blocks as a
+ *    "recordMap" (Notion's flat keyed-by-uuid store). Body:
+ *    `{pageId, limit, chunkNumber, cursor:{stack:[]}, verticalColumns:false}`.
+ *    Response wraps a [NotionRecordMap]; the page id key in
+ *    `recordMap.block` holds the page block with a `content` array of
+ *    child block ids in display order.
+ *
+ *  - **POST `/api/v3/queryCollection`** — query a database (collection)
+ *    for rows. Body wraps `{collection:{id},collectionView:{id},source,loader}`
+ *    where loader is the reducer-typed query shape react-notion-x uses.
+ *    Response: `{result:{reducerResults:{collection_group_results:{blockIds:[...]}}}, recordMap}`.
+ *    The recordMap contains the row pages by id.
+ *
+ *  - **POST `/api/v3/syncRecordValuesMain`** — fetch individual block
+ *    records by id (used when a child page block isn't already in the
+ *    parent's recordMap — e.g. when the user opens a deep link). Body:
+ *    `{requests:[{id, table:"block", version:-1}]}`. Response: a
+ *    [NotionRecordMap]. Note: the spec doc says `getRecordValues` but
+ *    that endpoint returns 502 MemcachedCrossCellError; `syncRecordValuesMain`
+ *    is the working successor.
+ *
+ *  - **POST `/api/v3/getPublicPageData`** — verify a page is publicly
+ *    shared and resolve its space metadata. Body:
+ *    `{type:"block-space",name:"page",blockId,saveParent:false,showMoveTo:false,showWebsiteLogin:true}`.
+ *    Response: [NotionPublicPageData]. 200 with `publicAccessRole`
+ *    means public; 4xx (or 200 with `requireLogin:true`) means gated.
+ *
+ * Notion's response payloads are large + recursive. We model the
+ * structural keys (block envelopes, properties, content[]) and keep
+ * everything below as `JsonElement` so unknown block types don't fail
+ * decoding — same permissive posture as the official-API models.
+ */
+
+/** Top-level recordMap that every unofficial endpoint returns. */
+@Serializable
+internal data class NotionRecordMap(
+    @SerialName("__version__") val version: Int = 0,
+    val block: Map<String, NotionBlockEnvelope> = emptyMap(),
+    val collection: Map<String, NotionCollectionEnvelope> = emptyMap(),
+    @SerialName("collection_view") val collectionView: Map<String, JsonElement> = emptyMap(),
+    @SerialName("notion_user") val notionUser: Map<String, JsonElement> = emptyMap(),
+    val space: Map<String, JsonElement> = emptyMap(),
+)
+
+/** Envelope around every block entry — `value.value` is the actual block. */
+@Serializable
+internal data class NotionBlockEnvelope(
+    @SerialName("spaceId") val spaceId: String? = null,
+    val role: String? = null,
+    /** Notion wraps each block in `{spaceId, value:{value:{...block...}, role}}`.
+     *  We only care about the inner value, which we read via the [block] helper. */
+    val value: JsonElement? = null,
+)
+
+/** Envelope around every collection entry. */
+@Serializable
+internal data class NotionCollectionEnvelope(
+    @SerialName("spaceId") val spaceId: String? = null,
+    val role: String? = null,
+    val value: JsonElement? = null,
+)
+
+/**
+ * Top-level response shape for `loadPageChunk` and `syncRecordValuesMain`.
+ * The recordMap is the only field we actually consume; the cursor field
+ * is reserved for streaming long pages but TechEmpower-sized trees fit
+ * in chunkNumber=0 + limit=100.
+ */
+@Serializable
+internal data class NotionChunkResponse(
+    val cursor: JsonElement? = null,
+    val recordMap: NotionRecordMap = NotionRecordMap(),
+)
+
+/**
+ * Response shape for `queryCollection`. We pull the row block ids out
+ * of `result.reducerResults.collection_group_results.blockIds` and
+ * resolve them in `recordMap.block`.
+ */
+@Serializable
+internal data class NotionQueryCollectionResponse(
+    val result: JsonElement? = null,
+    val recordMap: NotionRecordMap = NotionRecordMap(),
+    val allBlockIds: List<String> = emptyList(),
+)
+
+/** `getPublicPageData` response. We use [publicAccessRole] /
+ *  [requireLogin] as the "is this readable anonymously" probe. */
+@Serializable
+internal data class NotionPublicPageData(
+    val pageId: String? = null,
+    val spaceName: String? = null,
+    val spaceId: String? = null,
+    val spaceDomain: String? = null,
+    val publicAccessRole: String? = null,
+    val requireLogin: Boolean = false,
+    val isDeleted: Boolean = false,
+    val betaEnabled: Boolean = false,
+)
+
+/**
+ * Structured Notion v3 error envelope. The unofficial API returns
+ * `{isNotionError:true, errorId, name, debugMessage, message, status}`
+ * on failure. We surface [message] (human) and decode the [name]
+ * machine-readable identifier for telemetry.
+ */
+@Serializable
+internal data class NotionUnofficialError(
+    val isNotionError: Boolean = false,
+    val errorId: String? = null,
+    val name: String? = null,
+    val debugMessage: String? = null,
+    val message: String? = null,
+    val status: Int? = null,
+)
+
+// ─── helpers ──────────────────────────────────────────────────────────
+
+/**
+ * Pull the inner block JSON out of an envelope. Notion wraps every
+ * block as `{spaceId, value:{value:{...}, role:...}}`; we want the
+ * inner object. Returns null when the envelope is malformed.
+ */
+internal fun NotionBlockEnvelope.block(): JsonObject? {
+    val outer = value as? JsonObject ?: return null
+    return outer["value"] as? JsonObject
+}
+
+/**
+ * Pull the inner collection JSON the same way as [block].
+ */
+internal fun NotionCollectionEnvelope.collection(): JsonObject? {
+    val outer = value as? JsonObject ?: return null
+    return outer["value"] as? JsonObject
+}
+
+/**
+ * Pull a child id list out of a block's `content` field. Notion's
+ * unofficial API stores child block ids in display order under
+ * `content:[uuid, uuid, ...]`. Returns empty list when the field is
+ * missing or not an array.
+ */
+internal fun JsonObject.contentIds(): List<String> {
+    val arr = this["content"] as? JsonArray ?: return emptyList()
+    val out = ArrayList<String>(arr.size)
+    for (e in arr) {
+        val s = (e as? kotlinx.serialization.json.JsonPrimitive)
+            ?.contentOrNullStrict() ?: continue
+        out.add(s)
+    }
+    return out
+}
+
+/** Safe primitive→string extraction guarded against non-string primitives. */
+internal fun kotlinx.serialization.json.JsonPrimitive.contentOrNullStrict(): String? =
+    if (isString) content else null

--- a/source-notion/src/test/kotlin/in/jphe/storyvox/source/notion/AnonymousNotionDelegateTest.kt
+++ b/source-notion/src/test/kotlin/in/jphe/storyvox/source/notion/AnonymousNotionDelegateTest.kt
@@ -1,0 +1,351 @@
+package `in`.jphe.storyvox.source.notion
+
+import `in`.jphe.storyvox.source.notion.config.NotionDefaults
+import `in`.jphe.storyvox.source.notion.config.NotionMode
+import `in`.jphe.storyvox.source.notion.net.NotionBlockEnvelope
+import `in`.jphe.storyvox.source.notion.net.NotionRecordMap
+import `in`.jphe.storyvox.source.notion.net.NotionUnofficialApi
+import `in`.jphe.storyvox.source.notion.net.contentIds
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonObject
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * Issue #393 — focused unit tests for the anonymous-mode parsing
+ * surface: recordMap envelope unwrapping, decoration-array title
+ * extraction, page-id hyphenation, content[] traversal, chapter
+ * spec resolution, and HTML/plain rendering of a TechEmpower-shaped
+ * page body.
+ *
+ * No HTTP mocking — the network layer is exercised at integration
+ * level. These tests pin the pure mapping logic that took the most
+ * reverse-engineering effort.
+ */
+class AnonymousNotionDelegateTest {
+
+    private val json = Json { ignoreUnknownKeys = true; isLenient = true }
+
+    // ─── page-id hyphenation ──────────────────────────────────────────
+
+    @Test
+    fun `hyphenatePageId converts 32-hex to 8-4-4-4-12`() {
+        assertEquals(
+            "0959e445-9998-4143-acab-c80187305001",
+            NotionUnofficialApi.hyphenatePageId("0959e44599984143acabc80187305001"),
+        )
+    }
+
+    @Test
+    fun `hyphenatePageId leaves hyphenated id unchanged`() {
+        assertEquals(
+            "0959e445-9998-4143-acab-c80187305001",
+            NotionUnofficialApi.hyphenatePageId("0959e445-9998-4143-acab-c80187305001"),
+        )
+    }
+
+    @Test
+    fun `hyphenatePageId returns malformed input as-is`() {
+        // The API will reject malformed ids; we don't try to be clever.
+        assertEquals("not-a-uuid", NotionUnofficialApi.hyphenatePageId("not-a-uuid"))
+        assertEquals("", NotionUnofficialApi.hyphenatePageId(""))
+    }
+
+    // ─── recordMap envelope unwrapping ────────────────────────────────
+
+    @Test
+    fun `findBlock unwraps envelope and accepts compact id`() {
+        val rm = recordMapWith(
+            "0959e445-9998-4143-acab-c80187305001" to """
+                {"value":{"value":{"id":"0959e445-9998-4143-acab-c80187305001","type":"page","properties":{"title":[["Welcome"]]},"content":["a","b"]}}}
+            """.trimIndent(),
+        )
+        // Compact 32-hex form — findBlock must hyphenate before lookup.
+        val block = rm.findBlock("0959e44599984143acabc80187305001")
+        assertNotNull(block)
+        assertEquals("page", block!!.blockType())
+        assertEquals("Welcome", readTitle(block))
+    }
+
+    @Test
+    fun `findBlock returns null for unknown id`() {
+        val rm = NotionRecordMap()
+        assertNull(rm.findBlock("ffffffff-ffff-ffff-ffff-ffffffffffff"))
+    }
+
+    // ─── title + content traversal ────────────────────────────────────
+
+    @Test
+    fun `readTitle joins decoration array`() {
+        val block = parseBlock("""
+            {"properties":{"title":[["Hello ", []],["world", []],["!"]]}}
+        """.trimIndent())
+        assertEquals("Hello world!", readTitle(block))
+    }
+
+    @Test
+    fun `readTitle returns null when title array missing`() {
+        assertNull(readTitle(parseBlock("""{"properties":{}}""")))
+    }
+
+    @Test
+    fun `contentIds yields child ids in display order`() {
+        val block = parseBlock("""
+            {"content":["a","b","c"]}
+        """.trimIndent())
+        assertEquals(listOf("a", "b", "c"), block.contentIds())
+    }
+
+    @Test
+    fun `contentIds returns empty list when content missing`() {
+        assertTrue(parseBlock("""{"type":"text"}""").contentIds().isEmpty())
+    }
+
+    // ─── collection_view metadata ─────────────────────────────────────
+
+    @Test
+    fun `collection_view exposes collection_id and first view`() {
+        val block = parseBlock("""
+            {
+              "type":"collection_view",
+              "collection_id":"8cb5379d-fe78-4a15-9f3a-d539f5a60387",
+              "view_ids":["329a4ee6-9520-8199-bc52-000caf9e1475","329a4ee6-9520-8109-8eea-000c7c8208dc"]
+            }
+        """.trimIndent())
+        assertEquals("8cb5379d-fe78-4a15-9f3a-d539f5a60387", block.collectionId())
+        assertEquals("329a4ee6-9520-8199-bc52-000caf9e1475", block.firstViewId())
+    }
+
+    @Test
+    fun `firstViewId returns null when view_ids missing`() {
+        val block = parseBlock("""{"type":"collection_view","collection_id":"x"}""")
+        assertNull(block.firstViewId())
+    }
+
+    // ─── chapter spec resolution ──────────────────────────────────────
+
+    @Test
+    fun `chapterSpecsFor returns TechEmpower chapters when root matches`() {
+        val specs = chapterSpecsFor(
+            rootPageId = NotionDefaults.TECHEMPOWER_ROOT_PAGE_ID,
+            fictionPageId = NotionDefaults.TECHEMPOWER_ROOT_PAGE_ID,
+        )
+        assertEquals(4, specs.size)
+        assertEquals("Guides", specs[0].title)
+        assertTrue(specs[0] is ChapterSpec.Page)
+        assertEquals("Resources", specs[1].title)
+        assertTrue(specs[1] is ChapterSpec.Collection)
+        assertEquals("About", specs[2].title)
+        assertEquals("Donate", specs[3].title)
+    }
+
+    @Test
+    fun `chapterSpecsFor tolerates hyphenated and compact id forms`() {
+        val hyphenatedRoot = "0959e445-9998-4143-acab-c80187305001"
+        val specs = chapterSpecsFor(
+            rootPageId = hyphenatedRoot,
+            fictionPageId = NotionDefaults.TECHEMPOWER_ROOT_PAGE_ID,
+        )
+        assertEquals(4, specs.size)
+    }
+
+    @Test
+    fun `chapterSpecsFor returns generic chapter for non-TechEmpower roots`() {
+        val specs = chapterSpecsFor(
+            rootPageId = "deadbeefdeadbeefdeadbeefdeadbeef",
+            fictionPageId = "deadbeefdeadbeefdeadbeefdeadbeef",
+        )
+        assertEquals(1, specs.size)
+        assertEquals("Contents", specs[0].title)
+        assertTrue(specs[0] is ChapterSpec.Page)
+    }
+
+    @Test
+    fun `chapterSpecsFor returns empty when fiction id doesn't match root`() {
+        val specs = chapterSpecsFor(
+            rootPageId = NotionDefaults.TECHEMPOWER_ROOT_PAGE_ID,
+            fictionPageId = "deadbeefdeadbeefdeadbeefdeadbeef",
+        )
+        assertTrue(specs.isEmpty())
+    }
+
+    // ─── page body rendering ──────────────────────────────────────────
+
+    @Test
+    fun `renderPageBody concatenates blocks and skips tombstones`() {
+        val rm = recordMapWith(
+            "root" to envelope("""{"type":"page","content":["t1","dead","h1","t2"]}"""),
+            "t1" to envelope("""{"type":"text","properties":{"title":[["Lead paragraph."]]}}"""),
+            "dead" to envelope("""{"type":"text","alive":false,"properties":{"title":[["Tombstone."]]}}"""),
+            "h1" to envelope("""{"type":"header","properties":{"title":[["Section heading"]]}}"""),
+            "t2" to envelope("""{"type":"text","properties":{"title":[["Second paragraph."]]}}"""),
+        )
+        val root = rm.findBlock("root")!!
+        val (html, plain) = renderPageBody(rm, root)
+        assertTrue(html.contains("<p>Lead paragraph.</p>"))
+        assertTrue(html.contains("<h1>Section heading</h1>"))
+        assertTrue(html.contains("<p>Second paragraph.</p>"))
+        assertFalse(html.contains("Tombstone"))
+        assertTrue(plain.contains("Lead paragraph."))
+        assertTrue(plain.contains("Section heading"))
+        assertFalse(plain.contains("Tombstone"))
+    }
+
+    @Test
+    fun `renderPageBody embeds sub-page titles as bridge paragraphs`() {
+        // Sub-pages stay reachable through their authored titles; the
+        // chapter doesn't expand them inline (would balloon).
+        val rm = recordMapWith(
+            "root" to envelope("""{"type":"page","content":["intro","subp"]}"""),
+            "intro" to envelope("""{"type":"text","properties":{"title":[["See our guides:"]]}}"""),
+            "subp" to envelope("""{"type":"page","properties":{"title":[["How to use TechEmpower"]]}}"""),
+        )
+        val root = rm.findBlock("root")!!
+        val (html, plain) = renderPageBody(rm, root)
+        assertTrue(html.contains("<p><strong>How to use TechEmpower</strong></p>"))
+        assertTrue(plain.contains("How to use TechEmpower"))
+    }
+
+    // ─── collection rendering ────────────────────────────────────────
+
+    @Test
+    fun `collectRowTitles pulls titled pages out of a recordMap and sorts them`() {
+        val rm = recordMapWith(
+            "row1" to envelope("""{"type":"page","properties":{"title":[["Cursor for Students"]]}}"""),
+            "row2" to envelope("""{"type":"page","properties":{"title":[["1yr Google AI Pro free"]]}}"""),
+            "rowdead" to envelope("""{"type":"page","alive":false,"properties":{"title":[["Expired offer"]]}}"""),
+            "rownotitle" to envelope("""{"type":"page","properties":{}}"""),
+        )
+        val titles = collectRowTitles(rm)
+        assertEquals(listOf("1yr Google AI Pro free", "Cursor for Students"), titles)
+    }
+
+    @Test
+    fun `renderRowsAsHtml emits an unordered list`() {
+        val html = renderRowsAsHtml("Resources", listOf("Alpha", "Bravo", "Charlie"))
+        assertTrue(html.contains("<ul>"))
+        assertTrue(html.contains("<li>Alpha</li>"))
+        assertTrue(html.contains("<li>Bravo</li>"))
+        assertTrue(html.contains("3 entries"))
+    }
+
+    @Test
+    fun `renderRowsAsHtml handles empty collection`() {
+        val html = renderRowsAsHtml("Resources", emptyList())
+        assertTrue(html.contains("is empty"))
+        assertFalse(html.contains("<ul>"))
+    }
+
+    @Test
+    fun `renderRowsAsPlain emits readable text for TTS`() {
+        val plain = renderRowsAsPlain("Resources", listOf("Alpha", "Bravo"))
+        assertTrue(plain.contains("2 entries"))
+        assertTrue(plain.contains("Alpha"))
+        assertTrue(plain.contains("Bravo"))
+    }
+
+    // ─── block-type → HTML projection ─────────────────────────────────
+
+    @Test
+    fun `blockToHtml maps unofficial block types correctly`() {
+        val rm = NotionRecordMap()
+        assertEquals(
+            "<p>Hello.</p>",
+            blockToHtml(rm, parseBlock("""{"type":"text","properties":{"title":[["Hello."]]}}""")),
+        )
+        assertEquals(
+            "<h1>Top heading</h1>",
+            blockToHtml(rm, parseBlock("""{"type":"header","properties":{"title":[["Top heading"]]}}""")),
+        )
+        assertEquals(
+            "<h2>Subhead</h2>",
+            blockToHtml(rm, parseBlock("""{"type":"sub_header","properties":{"title":[["Subhead"]]}}""")),
+        )
+        assertEquals(
+            "<h3>Sub-sub</h3>",
+            blockToHtml(rm, parseBlock("""{"type":"sub_sub_header","properties":{"title":[["Sub-sub"]]}}""")),
+        )
+        assertEquals(
+            "<li>Item</li>",
+            blockToHtml(rm, parseBlock("""{"type":"bulleted_list","properties":{"title":[["Item"]]}}""")),
+        )
+        assertEquals(
+            "<blockquote>Quoted</blockquote>",
+            blockToHtml(rm, parseBlock("""{"type":"quote","properties":{"title":[["Quoted"]]}}""")),
+        )
+        assertEquals(
+            "<aside>Note</aside>",
+            blockToHtml(rm, parseBlock("""{"type":"callout","properties":{"title":[["Note"]]}}""")),
+        )
+        assertEquals(
+            "<hr/>",
+            blockToHtml(rm, parseBlock("""{"type":"divider"}""")),
+        )
+        // Unknown types render blank — the unofficial API has dozens
+        // of block types and storyvox only narrates the textual subset.
+        assertEquals(
+            "",
+            blockToHtml(rm, parseBlock("""{"type":"embed","properties":{"title":[["x"]]}}""")),
+        )
+    }
+
+    @Test
+    fun `htmlEscape escapes the four chars`() {
+        // Sanity check — the existing official-mode helper is reused.
+        assertEquals("&amp;&lt;&gt;&quot;", htmlEscape("&<>\""))
+    }
+
+    // ─── NotionConfigState mode posture ───────────────────────────────
+
+    @Test
+    fun `default NotionConfigState is anonymous`() {
+        val s = `in`.jphe.storyvox.source.notion.config.NotionConfigState()
+        assertEquals(NotionMode.ANONYMOUS_PUBLIC, s.mode)
+        assertTrue(s.isConfigured) // root page id has a baked default
+    }
+
+    @Test
+    fun `OFFICIAL_PAT mode requires both token and databaseId`() {
+        val empty = `in`.jphe.storyvox.source.notion.config.NotionConfigState(
+            mode = NotionMode.OFFICIAL_PAT,
+            apiToken = "",
+            databaseId = "",
+        )
+        assertFalse(empty.isConfigured)
+        val tokenOnly = empty.copy(apiToken = "ntn_token")
+        assertFalse(tokenOnly.isConfigured)
+        val both = tokenOnly.copy(databaseId = "abc")
+        assertTrue(both.isConfigured)
+    }
+
+    @Test
+    fun `ANONYMOUS_PUBLIC mode requires only rootPageId`() {
+        val withDefault = `in`.jphe.storyvox.source.notion.config.NotionConfigState(
+            mode = NotionMode.ANONYMOUS_PUBLIC,
+            apiToken = "",
+        )
+        // Default rootPageId is TechEmpower's; isConfigured is true.
+        assertTrue(withDefault.isConfigured)
+        val blank = withDefault.copy(rootPageId = "")
+        assertFalse(blank.isConfigured)
+    }
+
+    // ─── test helpers ─────────────────────────────────────────────────
+
+    private fun parseBlock(jsonText: String): JsonObject =
+        json.parseToJsonElement(jsonText) as JsonObject
+
+    private fun envelope(blockJson: String): String =
+        """{"value":{"value":$blockJson}}"""
+
+    private fun recordMapWith(vararg entries: Pair<String, String>): NotionRecordMap {
+        val blocks = entries.associate { (id, envelopeJson) ->
+            id to json.decodeFromString<NotionBlockEnvelope>(envelopeJson)
+        }
+        return NotionRecordMap(block = blocks)
+    }
+}

--- a/source-notion/src/test/kotlin/in/jphe/storyvox/source/notion/NotionUnofficialModelsTest.kt
+++ b/source-notion/src/test/kotlin/in/jphe/storyvox/source/notion/NotionUnofficialModelsTest.kt
@@ -1,0 +1,131 @@
+package `in`.jphe.storyvox.source.notion
+
+import `in`.jphe.storyvox.source.notion.net.NotionChunkResponse
+import `in`.jphe.storyvox.source.notion.net.NotionQueryCollectionResponse
+import `in`.jphe.storyvox.source.notion.net.NotionRecordMap
+import `in`.jphe.storyvox.source.notion.net.NotionUnofficialError
+import `in`.jphe.storyvox.source.notion.net.contentIds
+import kotlinx.serialization.json.Json
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * Issue #393 — round-trip tests for the unofficial-API wire shapes.
+ * Uses verbatim fragments from the live TechEmpower responses
+ * (captured 2026-05-13) so we'd catch a schema-shift regression
+ * against the actual Notion edge response.
+ */
+class NotionUnofficialModelsTest {
+
+    private val json = Json { ignoreUnknownKeys = true; isLenient = true }
+
+    @Test
+    fun `loadPageChunk response decodes a TechEmpower-shaped recordMap`() {
+        // Trimmed but structurally faithful — root page + one child block.
+        val raw = """
+        {
+          "cursor":{"stack":[]},
+          "recordMap":{
+            "__version__":3,
+            "block":{
+              "0959e445-9998-4143-acab-c80187305001":{
+                "spaceId":"70f6edce-ef9d-4a38-9d00-7618cde046d0",
+                "value":{"value":{
+                  "id":"0959e445-9998-4143-acab-c80187305001",
+                  "type":"page",
+                  "properties":{"title":[["Welcome to TechEmpower.org"]]},
+                  "content":["a7192a1d-3fd9-4d50-b5da-ac1f94480f7e","2a3d7068-03c6-4940-9e74-e9ce5ccd4c4b"]
+                },"role":"reader"}
+              },
+              "2a3d7068-03c6-4940-9e74-e9ce5ccd4c4b":{
+                "spaceId":"70f6edce-ef9d-4a38-9d00-7618cde046d0",
+                "value":{"value":{
+                  "id":"2a3d7068-03c6-4940-9e74-e9ce5ccd4c4b",
+                  "type":"collection_view",
+                  "collection_id":"8cb5379d-fe78-4a15-9f3a-d539f5a60387",
+                  "view_ids":["329a4ee6-9520-8199-bc52-000caf9e1475"]
+                },"role":"reader"}
+              }
+            }
+          }
+        }
+        """.trimIndent()
+        val parsed = json.decodeFromString<NotionChunkResponse>(raw)
+        val rm = parsed.recordMap
+        val root = rm.findBlock("0959e44599984143acabc80187305001")
+        assertNotNull(root)
+        assertEquals("Welcome to TechEmpower.org", readTitle(root!!))
+        assertEquals(
+            listOf("a7192a1d-3fd9-4d50-b5da-ac1f94480f7e", "2a3d7068-03c6-4940-9e74-e9ce5ccd4c4b"),
+            root.contentIds(),
+        )
+        val coll = rm.findBlock("2a3d706803c649409e74e9ce5ccd4c4b")
+        assertNotNull(coll)
+        assertEquals("collection_view", coll!!.blockType())
+        assertEquals("8cb5379d-fe78-4a15-9f3a-d539f5a60387", coll.collectionId())
+        assertEquals("329a4ee6-9520-8199-bc52-000caf9e1475", coll.firstViewId())
+    }
+
+    @Test
+    fun `queryCollection response decodes recordMap and result envelope`() {
+        // Fragment from the live Resources DB query — one row + the
+        // reducerResults shape.
+        val raw = """
+        {
+          "result":{
+            "type":"reducer",
+            "reducerResults":{
+              "collection_group_results":{
+                "type":"results",
+                "blockIds":["309a4ee6-9520-817a-aa23-ebc00eebbe32"]
+              }
+            },
+            "sizeHint":1
+          },
+          "recordMap":{
+            "__version__":3,
+            "block":{
+              "309a4ee6-9520-817a-aa23-ebc00eebbe32":{
+                "spaceId":"70f6edce-ef9d-4a38-9d00-7618cde046d0",
+                "value":{"value":{
+                  "id":"309a4ee6-9520-817a-aa23-ebc00eebbe32",
+                  "type":"page",
+                  "properties":{"title":[["GitHub Student Developer Pack"]]}
+                },"role":"reader"}
+              }
+            },
+            "collection":{}
+          }
+        }
+        """.trimIndent()
+        val parsed = json.decodeFromString<NotionQueryCollectionResponse>(raw)
+        assertEquals(1, parsed.recordMap.block.size)
+        val first = parsed.recordMap.findBlock("309a4ee6-9520-817a-aa23-ebc00eebbe32")
+        assertNotNull(first)
+        assertEquals("GitHub Student Developer Pack", readTitle(first!!))
+    }
+
+    @Test
+    fun `NotionUnofficialError decodes Notion error envelope`() {
+        val raw = """
+        {"isNotionError":true,"errorId":"abc","name":"MemcachedCrossCellError","debugMessage":"Cross-cell memcached access is not allowed","message":"Something went wrong. (502)"}
+        """.trimIndent()
+        val err = json.decodeFromString<NotionUnofficialError>(raw)
+        assertTrue(err.isNotionError)
+        assertEquals("MemcachedCrossCellError", err.name)
+        assertEquals("Something went wrong. (502)", err.message)
+    }
+
+    @Test
+    fun `recordMap tolerates unknown top-level fields`() {
+        // Notion adds fields to recordMap over time (automation,
+        // collection_view, ...). Decoding must not throw on unknowns.
+        val raw = """
+        {"recordMap":{"__version__":3,"block":{},"automation":{"foo":{}},"new_field_2027":{}}}
+        """.trimIndent()
+        val parsed = json.decodeFromString<NotionChunkResponse>(raw)
+        assertEquals(0, parsed.recordMap.block.size)
+    }
+}


### PR DESCRIPTION
## Summary

- Browse → Notion now reads **TechEmpower.org** anonymously via the unofficial `www.notion.so/api/v3` endpoints (`loadPageChunk`, `queryCollection`, `syncRecordValuesMain`, `getPublicPageData` — same set [react-notion-x](https://github.com/NotionX/react-notion-x)'s `notion-client` package uses). **Zero setup: no token needed.**
- One Browse tile — **"Welcome to TechEmpower.org"** by TechEmpower — with **four chapters** mapped to the site's top-level navigation: **Guides** (root page body), **Resources** (database row-title list), **About**, **Donate**.
- `NotionConfig` grows a `mode: NotionMode { ANONYMOUS_PUBLIC, OFFICIAL_PAT }` enum. Mode is implicit (blank token → anonymous; non-blank token → PAT). Existing PAT-holding users keep their current experience unchanged. New `rootPageId` field configures the anonymous reader's root; defaults to TechEmpower's `0959e44599984143acabc80187305001`.
- Also fixes the stale `databaseId == TECHEMPOWER_DATABASE_ID` placeholder check in `NotionApi.requireConfigured` that v0.5.24 silently broke when it baked the real DB id into the same constant.

versionCode 135 → 136; versionName 0.5.24 → 0.5.25.

## What works (verified on R83W80CAFZB)

- Cold install → Browse → Notion shows one tile, **no integration token required**.
- Tap tile → fictionDetail screen shows 4 chapters: Guides / Resources / About / Donate.
- Tap Resources → 12-min synthesized chapter narrating the ~80 row titles from the live TechEmpower Resources database.
- Pasting a PAT in Settings → Library & Sync → Notion still routes through the original `api.notion.com/v1` flow (mode auto-switches to `OFFICIAL_PAT`).
- No `NetworkOnMainThreadException`. All HTTP calls wrapped in `withContext(Dispatchers.IO)`.

## Known caveats

- The unofficial `www.notion.so/api/v3` endpoints are undocumented and Notion may change them. We decode permissively (block payloads stay as `JsonElement`) so unknown variants degrade silently rather than breaking parsing. Errors come back as structured `NotionUnofficialError` envelopes mapped to standard `FictionResult.AuthRequired`/`NotFound`/`RateLimited`/`NetworkError`.
- Resources chapter currently lists row *titles* only — not their bodies/links. The data model question (sub-fictions vs. fully-rendered rows in chapter HTML) is a follow-up; this PR ships the cheaper shipping option.
- Generic public Notion pages (non-TechEmpower roots) work but fall back to a single "Contents" chapter rendering the whole root page. Per-site chapter spines would be a future configuration.

## Test plan

- [ ] Cold install fresh, confirm Browse → Notion surfaces "Welcome to TechEmpower.org" with no token paste
- [ ] Tap tile → 4 chapters visible
- [ ] Play **Guides** chapter → root page content narrates with internal sub-headings audible as sub-section transitions
- [ ] Play **Resources** chapter → row titles narrate as a list
- [ ] Play **About** + **Donate** chapters → each page's content narrates
- [ ] Paste a PAT in Settings → mode auto-switches to PAT; the old Resources-database flow works
- [ ] Clear PAT → mode auto-returns to anonymous
- [ ] Verify `./gradlew :source-notion:testDebugUnitTest :app:testDebugUnitTest` passes (23 new unit tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)