### PR TITLE
feat(source): arXiv backend (open-access academic papers) — closes #378

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -162,6 +162,8 @@ dependencies {
     implementation(project(":source-wikipedia"))
     implementation(project(":source-kvmr"))
     implementation(project(":source-notion"))
+    // Issue #378 — arXiv backend (open-access academic papers).
+    implementation(project(":source-arxiv"))
     implementation(project(":source-azure"))
     implementation(project(":core-sync"))
     implementation(project(":feature"))

--- a/app/src/main/kotlin/in/jphe/storyvox/data/SettingsRepositoryUiImpl.kt
+++ b/app/src/main/kotlin/in/jphe/storyvox/data/SettingsRepositoryUiImpl.kt
@@ -255,6 +255,9 @@ internal object LegacySourceKeys {
             Spec(booleanPreferencesKey("pref_source_kvmr_enabled"), defaultValue = true),
         `in`.jphe.storyvox.data.source.SourceIds.NOTION to
             Spec(booleanPreferencesKey("pref_source_notion_enabled"), defaultValue = true),
+        // #378 — arXiv: default OFF, same posture as Wikipedia.
+        `in`.jphe.storyvox.data.source.SourceIds.ARXIV to
+            Spec(booleanPreferencesKey("pref_source_arxiv_enabled"), defaultValue = false),
     )
 }
 
@@ -367,6 +370,10 @@ private object Keys {
      *  AuthRequired on every call until the user pastes an integration
      *  token via Settings → Library & Sync → Notion. */
     val SOURCE_NOTION_ENABLED = booleanPreferencesKey("pref_source_notion_enabled")
+    /** Issue #378 — arXiv backend on/off. Default false for fresh
+     *  installs; second non-fiction-shaped source after Wikipedia
+     *  follows the same opt-in posture. */
+    val SOURCE_ARXIV_ENABLED = booleanPreferencesKey("pref_source_arxiv_enabled")
 
     // ── Plugin-seam Phase 1 (#384) ────────────────────────────────
     /**
@@ -644,6 +651,8 @@ class SettingsRepositoryUiImpl(
             // until the user pastes an integration token. Existing
             // users with a stored preference keep it.
             sourceNotionEnabled = prefs[Keys.SOURCE_NOTION_ENABLED] ?: true,
+            // #378 — arXiv: default OFF, same posture as Wikipedia.
+            sourceArxivEnabled = prefs[Keys.SOURCE_ARXIV_ENABLED] ?: false,
             // Plugin-seam Phase 1 (#384) — derive the per-plugin map
             // from the JSON blob seeded by SourcePluginsMapMigration.
             // Empty map (parse error / missing key in a race) falls
@@ -1297,6 +1306,11 @@ class SettingsRepositoryUiImpl(
     override suspend fun setSourceNotionEnabled(enabled: Boolean) {
         store.edit { it[Keys.SOURCE_NOTION_ENABLED] = enabled }
         writePluginEnabledIntoMap(`in`.jphe.storyvox.data.source.SourceIds.NOTION, enabled)
+    }
+
+    override suspend fun setSourceArxivEnabled(enabled: Boolean) {
+        store.edit { it[Keys.SOURCE_ARXIV_ENABLED] = enabled }
+        writePluginEnabledIntoMap(`in`.jphe.storyvox.data.source.SourceIds.ARXIV, enabled)
     }
 
     /**

--- a/app/src/test/kotlin/in/jphe/storyvox/di/RealPlaybackControllerUiTest.kt
+++ b/app/src/test/kotlin/in/jphe/storyvox/di/RealPlaybackControllerUiTest.kt
@@ -296,6 +296,7 @@ class RealPlaybackControllerUiTest {
         override suspend fun setWikipediaLanguageCode(code: String) = Unit
         override suspend fun setSourceKvmrEnabled(enabled: Boolean) = Unit
         override suspend fun setSourceNotionEnabled(enabled: Boolean) = Unit
+        override suspend fun setSourceArxivEnabled(enabled: Boolean) = Unit
         override suspend fun setSourcePluginEnabled(id: String, enabled: Boolean) = Unit
         override suspend fun setNotionDatabaseId(id: String) = Unit
         override suspend fun setNotionApiToken(token: String?) = Unit

--- a/core-data/src/main/kotlin/in/jphe/storyvox/data/source/SourceIds.kt
+++ b/core-data/src/main/kotlin/in/jphe/storyvox/data/source/SourceIds.kt
@@ -82,4 +82,13 @@ object SourceIds {
      *  surfaces TechEmpower content without configuration once the
      *  user supplies the integration token. */
     const val NOTION: String = "notion"
+    /** arXiv (#378) — open-access academic papers backend. Second non-
+     *  fiction-shaped source after [WIKIPEDIA]. Each arXiv paper is one
+     *  fiction; the v1 chapter shape is a single "Abstract" chapter
+     *  rendered from the paper's `arxiv.org/abs/<id>` HTML page (title
+     *  + author byline + subjects + comments + abstract paragraph).
+     *  Full-PDF text extraction is an explicit follow-up scope cut from
+     *  #378's acceptance criteria. Default category for the browse
+     *  landing is `cs.AI`; a category picker is a v2 surface. */
+    const val ARXIV: String = "arxiv"
 }

--- a/core-data/src/test/kotlin/in/jphe/storyvox/data/source/plugin/SourcePluginRegistryTest.kt
+++ b/core-data/src/test/kotlin/in/jphe/storyvox/data/source/plugin/SourcePluginRegistryTest.kt
@@ -119,6 +119,10 @@ class SourcePluginRegistryTest {
             SourceIds.WIKIPEDIA,
             SourceIds.KVMR,
             SourceIds.NOTION,
+            // #378 — arXiv: second non-fiction-shaped source after
+            // Wikipedia. Same Text category as the other long-form
+            // backends.
+            SourceIds.ARXIV,
         )
         val descriptors = expectedIds.map { id ->
             descriptor(
@@ -130,7 +134,7 @@ class SourcePluginRegistryTest {
 
         val registry = SourcePluginRegistry(descriptors.toSet())
 
-        assertEquals(12, registry.all.size)
+        assertEquals(13, registry.all.size)
         // Every expected id resolves via byId — order-independent so
         // the assertion stays robust against future sort changes.
         for (id in expectedIds) {

--- a/feature/src/main/kotlin/in/jphe/storyvox/feature/api/UiContracts.kt
+++ b/feature/src/main/kotlin/in/jphe/storyvox/feature/api/UiContracts.kt
@@ -834,6 +834,12 @@ data class UiSettings(
      *  the source visible in Browse so the empty-state can teach the
      *  user about the one-paste configuration step. */
     val sourceNotionEnabled: Boolean = true,
+    /** arXiv non-fiction backend (#378). Default OFF for fresh
+     *  installs — second non-fiction-shaped source after Wikipedia,
+     *  same opt-in posture. Users discover it from Settings →
+     *  Library & Sync rather than getting a Browse picker pre-
+     *  populated with academic-paper content they didn't ask for. */
+    val sourceArxivEnabled: Boolean = false,
     /**
      * Plugin-seam Phase 1 (#384) — per-plugin on/off keyed by stable
      * plugin id ("kvmr", "royalroad", "notion", ...). Replaces the
@@ -1301,6 +1307,8 @@ interface SettingsRepositoryUi {
     suspend fun setWikipediaLanguageCode(code: String)
     /** Issue #374 — KVMR community radio backend on/off. */
     suspend fun setSourceKvmrEnabled(enabled: Boolean)
+    /** Issue #378 — arXiv backend on/off. */
+    suspend fun setSourceArxivEnabled(enabled: Boolean)
 
     /**
      * Plugin-seam Phase 1 (#384) — toggle a `@SourcePlugin`-registered

--- a/feature/src/main/kotlin/in/jphe/storyvox/feature/browse/BrowseScreen.kt
+++ b/feature/src/main/kotlin/in/jphe/storyvox/feature/browse/BrowseScreen.kt
@@ -215,6 +215,10 @@ fun BrowseScreen(
                 // filter body via /databases/{id}/query is the
                 // follow-up.
                 BrowseSourceKey.Notion -> false
+                // #378 — arXiv has no filter sheet in v1; the default
+                // category (`cs.AI`) is the filter scope. A category
+                // picker UI is a v2 follow-up.
+                BrowseSourceKey.Arxiv -> false
             }
             if (filterableSource) {
                 FilterButton(
@@ -236,6 +240,7 @@ fun BrowseScreen(
                         BrowseSourceKey.Wikipedia -> 0
                         BrowseSourceKey.Kvmr -> 0
                         BrowseSourceKey.Notion -> 0
+                        BrowseSourceKey.Arxiv -> 0
                     },
                     onClick = { showFilterSheet = true },
                 )
@@ -516,6 +521,9 @@ fun BrowseScreen(
             // #233 — Notion v1 has no filter sheet; the configured
             // database id IS the filter scope.
             BrowseSourceKey.Notion -> { showFilterSheet = false }
+            // #378 — arXiv v1 has no filter sheet; the default
+            // category (`cs.AI`) is the filter scope.
+            BrowseSourceKey.Arxiv -> { showFilterSheet = false }
         }
     }
 }
@@ -608,6 +616,10 @@ private fun searchHintForSource(sourceKey: BrowseSourceKey): String = when (sour
     BrowseSourceKey.Wikipedia -> "Search Wikipedia — narrate any article"
     BrowseSourceKey.Kvmr -> "Tune in to KVMR — live community radio from Nevada City"
     BrowseSourceKey.Notion -> "Search your configured Notion database"
+    // #378 — arXiv's `all:<term>` query matches title, abstract,
+    // authors, and comments. The default landing category is cs.AI;
+    // search expands the search across all categories.
+    BrowseSourceKey.Arxiv -> "Search arXiv — open-access academic papers"
 }
 
 private val BrowseTab.label: String

--- a/feature/src/main/kotlin/in/jphe/storyvox/feature/browse/BrowseViewModel.kt
+++ b/feature/src/main/kotlin/in/jphe/storyvox/feature/browse/BrowseViewModel.kt
@@ -97,6 +97,12 @@ enum class BrowseSourceKey(val sourceId: String, val displayName: String) {
      *  content database id as the default — once the user pastes a token
      *  in Settings, Browse → Notion surfaces TechEmpower content. */
     Notion(SourceIds.NOTION, "Notion"),
+    /** arXiv (#378) — open-access academic papers. Second non-fiction-
+     *  shaped source after Wikipedia. Each paper is one fiction; the
+     *  v1 chapter shape is a single "Abstract" chapter (title + author
+     *  byline + abstract). Browse landing is "recent in cs.AI"; full-
+     *  paper PDF body extraction is a follow-up scope cut. */
+    Arxiv(SourceIds.ARXIV, "arXiv"),
 }
 
 /** Tabs that are meaningful for [source]. GitHub registry doesn't
@@ -212,6 +218,15 @@ fun BrowseSourceKey.supportedTabs(githubSignedIn: Boolean = false): List<BrowseT
     // NewReleases collapses to Popular because Notion's default
     // ordering is already recency. BestRated has no analogue.
     BrowseSourceKey.Notion -> listOf(
+        BrowseTab.Popular,
+        BrowseTab.Search,
+    )
+    // arXiv (#378): Popular = "recent in cs.AI" (sorted by
+    // submittedDate desc). NewReleases would collapse to the same
+    // surface (arXiv has no distinct "trending" vs "newest"), so we
+    // hide it. BestRated has no analogue. Search hits the public
+    // `all:<term>` query API.
+    BrowseSourceKey.Arxiv -> listOf(
         BrowseTab.Popular,
         BrowseTab.Search,
     )
@@ -424,6 +439,7 @@ class BrowseViewModel @Inject constructor(
                     if (s.sourceWikipediaEnabled) add(BrowseSourceKey.Wikipedia)
                     if (s.sourceKvmrEnabled) add(BrowseSourceKey.Kvmr)
                     if (s.sourceNotionEnabled) add(BrowseSourceKey.Notion)
+                    if (s.sourceArxivEnabled) add(BrowseSourceKey.Arxiv)
                 }
             }
             .distinctUntilChanged()
@@ -697,6 +713,16 @@ class BrowseViewModel @Inject constructor(
                 _githubFilter.value = GitHubSearchFilter()
                 _palaceFilter.value = MemPalaceFilter()
             }
+            BrowseSourceKey.Arxiv -> {
+                // arXiv (#378) — non-fiction long-form. No per-source
+                // filter in v1 (the category default rides on the
+                // Settings side; a category picker is a v2 surface).
+                // Clear sibling filters so switching back to RR/GH
+                // doesn't carry leftover state.
+                _filter.value = BrowseFilter()
+                _githubFilter.value = GitHubSearchFilter()
+                _palaceFilter.value = MemPalaceFilter()
+            }
         }
     }
 
@@ -922,6 +948,16 @@ private fun resolveSource(
     // same first page in v1. Blank-search-with-blank-filter stays
     // null so the screen renders the SearchHint empty state.
     BrowseSourceKey.Notion -> when (tab) {
+        BrowseTab.Popular -> BrowseSource.Popular
+        BrowseTab.Search -> if (q.isBlank()) null else BrowseSource.Search(q)
+        else -> null
+    }
+    // arXiv (#378): Popular hits the recent-in-default-category Atom
+    // feed (sorted by submittedDate desc); Search hits the public
+    // `all:<term>` query. Blank Search stays null so the screen
+    // renders the SearchHint empty state. NewReleases / BestRated /
+    // filter sheet hidden via supportedTabs.
+    BrowseSourceKey.Arxiv -> when (tab) {
         BrowseTab.Popular -> BrowseSource.Popular
         BrowseTab.Search -> if (q.isBlank()) null else BrowseSource.Search(q)
         else -> null

--- a/feature/src/main/kotlin/in/jphe/storyvox/feature/settings/SettingsScreen.kt
+++ b/feature/src/main/kotlin/in/jphe/storyvox/feature/settings/SettingsScreen.kt
@@ -539,6 +539,17 @@ fun SettingsScreen(
                     onLanguageCodeChange = viewModel::setWikipediaLanguageCode,
                 )
             }
+            // Issue #378 — arXiv: open-access academic papers. Second
+            // non-fiction-shaped source after Wikipedia; default OFF
+            // (opt-in like Wikipedia). v1 chapter shape is a single
+            // "Abstract" chapter per paper — full-PDF text extraction
+            // is a follow-up. Default landing category is cs.AI.
+            SettingsSwitchRow(
+                title = "arXiv",
+                subtitle = "Listen to abstracts of new open-access academic papers (default category: cs.AI).",
+                checked = s.sourceArxivEnabled,
+                onCheckedChange = viewModel::setSourceArxivEnabled,
+            )
             // Issue #374 (closes #373 first piece) — KVMR community
             // radio: first entry in the new audio-stream backend
             // category. Plays the live AAC stream through Media3

--- a/feature/src/main/kotlin/in/jphe/storyvox/feature/settings/SettingsViewModel.kt
+++ b/feature/src/main/kotlin/in/jphe/storyvox/feature/settings/SettingsViewModel.kt
@@ -187,6 +187,9 @@ class SettingsViewModel @Inject constructor(
     /** Issue #233 — Notion backend on/off + config. */
     fun setSourceNotionEnabled(enabled: Boolean) =
         viewModelScope.launch { repo.setSourceNotionEnabled(enabled) }
+    /** Issue #378 — arXiv backend on/off. */
+    fun setSourceArxivEnabled(enabled: Boolean) =
+        viewModelScope.launch { repo.setSourceArxivEnabled(enabled) }
     fun setNotionDatabaseId(id: String) =
         viewModelScope.launch { repo.setNotionDatabaseId(id) }
     fun setNotionApiToken(token: String?) =

--- a/feature/src/test/kotlin/in/jphe/storyvox/feature/chat/ChatViewModelTest.kt
+++ b/feature/src/test/kotlin/in/jphe/storyvox/feature/chat/ChatViewModelTest.kt
@@ -584,6 +584,7 @@ private class FakeSettingsRepo(
         override suspend fun setWikipediaLanguageCode(code: String) = Unit
         override suspend fun setSourceKvmrEnabled(enabled: Boolean) = Unit
         override suspend fun setSourceNotionEnabled(enabled: Boolean) = Unit
+        override suspend fun setSourceArxivEnabled(enabled: Boolean) = Unit
         override suspend fun setSourcePluginEnabled(id: String, enabled: Boolean) = Unit
         override suspend fun setNotionDatabaseId(id: String) = Unit
         override suspend fun setNotionApiToken(token: String?) = Unit

--- a/feature/src/test/kotlin/in/jphe/storyvox/feature/settings/SettingsViewModelBufferTest.kt
+++ b/feature/src/test/kotlin/in/jphe/storyvox/feature/settings/SettingsViewModelBufferTest.kt
@@ -200,6 +200,7 @@ class SettingsViewModelBufferTest {
         override suspend fun setWikipediaLanguageCode(code: String) = Unit
         override suspend fun setSourceKvmrEnabled(enabled: Boolean) = Unit
         override suspend fun setSourceNotionEnabled(enabled: Boolean) = Unit
+        override suspend fun setSourceArxivEnabled(enabled: Boolean) = Unit
         override suspend fun setSourcePluginEnabled(id: String, enabled: Boolean) = Unit
         override suspend fun setNotionDatabaseId(id: String) = Unit
         override suspend fun setNotionApiToken(token: String?) = Unit

--- a/feature/src/test/kotlin/in/jphe/storyvox/feature/settings/SettingsViewModelModesTest.kt
+++ b/feature/src/test/kotlin/in/jphe/storyvox/feature/settings/SettingsViewModelModesTest.kt
@@ -275,6 +275,7 @@ class SettingsViewModelModesTest {
         override suspend fun setWikipediaLanguageCode(code: String) = Unit
         override suspend fun setSourceKvmrEnabled(enabled: Boolean) = Unit
         override suspend fun setSourceNotionEnabled(enabled: Boolean) = Unit
+        override suspend fun setSourceArxivEnabled(enabled: Boolean) = Unit
         override suspend fun setSourcePluginEnabled(id: String, enabled: Boolean) = Unit
         override suspend fun setNotionDatabaseId(id: String) = Unit
         override suspend fun setNotionApiToken(token: String?) = Unit

--- a/feature/src/test/kotlin/in/jphe/storyvox/feature/settings/SettingsViewModelPunctuationPauseTest.kt
+++ b/feature/src/test/kotlin/in/jphe/storyvox/feature/settings/SettingsViewModelPunctuationPauseTest.kt
@@ -213,6 +213,7 @@ class SettingsViewModelPunctuationPauseTest {
         override suspend fun setWikipediaLanguageCode(code: String) = Unit
         override suspend fun setSourceKvmrEnabled(enabled: Boolean) = Unit
         override suspend fun setSourceNotionEnabled(enabled: Boolean) = Unit
+        override suspend fun setSourceArxivEnabled(enabled: Boolean) = Unit
         override suspend fun setSourcePluginEnabled(id: String, enabled: Boolean) = Unit
         override suspend fun setNotionDatabaseId(id: String) = Unit
         override suspend fun setNotionApiToken(token: String?) = Unit

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -56,5 +56,9 @@ include(":source-standard-ebooks")
 include(":source-wikipedia")
 include(":source-kvmr")
 include(":source-notion")
+// Issue #378 — arXiv open-access academic papers backend. Second
+// non-fiction-shaped source after :source-wikipedia (#377); each
+// paper is one fiction, single "Abstract" chapter for v1.
+include(":source-arxiv")
 include(":core-sync")
 include(":feature")

--- a/source-arxiv/build.gradle.kts
+++ b/source-arxiv/build.gradle.kts
@@ -1,0 +1,50 @@
+plugins {
+    alias(libs.plugins.android.library)
+    alias(libs.plugins.kotlin.android)
+    alias(libs.plugins.ksp)
+    alias(libs.plugins.hilt)
+}
+
+android {
+    namespace = "in.jphe.storyvox.source.arxiv"
+    compileSdk = 35
+
+    defaultConfig {
+        minSdk = 26
+    }
+
+    compileOptions {
+        sourceCompatibility = JavaVersion.VERSION_17
+        targetCompatibility = JavaVersion.VERSION_17
+    }
+
+    kotlinOptions {
+        jvmTarget = "17"
+    }
+
+    testOptions {
+        unitTests {
+            // ArxivAbstractParserTest reads the abs-fixture.html resource
+            // from src/test/resources; AGP defaults to including those.
+            // No extra config needed today — left here as a docs anchor.
+        }
+    }
+}
+
+dependencies {
+    implementation(project(":core-data"))
+    implementation(libs.kotlinx.coroutines.android)
+    implementation(libs.okhttp)
+    implementation(libs.okhttp.logging)
+
+    implementation(libs.hilt.android)
+    ksp(libs.hilt.compiler)
+
+    // Plugin-seam Phase 2 (#384) — emits the @SourcePlugin → @IntoSet
+    // SourcePluginDescriptor Hilt module for ArxivSource. Legacy
+    // @IntoMap binding in di/ArxivModule.kt is kept (Phase 3 removes).
+    ksp(project(":core-plugin-ksp"))
+
+    testImplementation(libs.junit)
+    testImplementation(libs.kotlinx.coroutines.test)
+}

--- a/source-arxiv/src/main/kotlin/in/jphe/storyvox/source/arxiv/ArxivSource.kt
+++ b/source-arxiv/src/main/kotlin/in/jphe/storyvox/source/arxiv/ArxivSource.kt
@@ -1,0 +1,253 @@
+package `in`.jphe.storyvox.source.arxiv
+
+import `in`.jphe.storyvox.data.source.FictionSource
+import `in`.jphe.storyvox.data.source.SourceIds
+import `in`.jphe.storyvox.data.source.model.ChapterContent
+import `in`.jphe.storyvox.data.source.model.ChapterInfo
+import `in`.jphe.storyvox.data.source.model.FictionDetail
+import `in`.jphe.storyvox.data.source.model.FictionResult
+import `in`.jphe.storyvox.data.source.model.FictionStatus
+import `in`.jphe.storyvox.data.source.model.FictionSummary
+import `in`.jphe.storyvox.data.source.model.ListPage
+import `in`.jphe.storyvox.data.source.model.SearchQuery
+import `in`.jphe.storyvox.data.source.model.map
+import `in`.jphe.storyvox.data.source.plugin.SourceCategory
+import `in`.jphe.storyvox.data.source.plugin.SourcePlugin
+import `in`.jphe.storyvox.source.arxiv.net.ArxivAbstractParser
+import `in`.jphe.storyvox.source.arxiv.net.ArxivApi
+import `in`.jphe.storyvox.source.arxiv.net.ArxivAtomFeed
+import `in`.jphe.storyvox.source.arxiv.net.ArxivFeedEntry
+import `in`.jphe.storyvox.source.arxiv.net.formatAuthors
+import javax.inject.Inject
+import javax.inject.Singleton
+
+/**
+ * Issue #378 — arXiv as a non-fiction long-form backend (the "open-
+ * access academic papers" surface). Second non-fiction shape after
+ * Wikipedia (#377); same posture — read-only, no auth, machine-friendly
+ * public API.
+ *
+ *  - Each arXiv **paper** is one fiction.
+ *  - The fiction has **one chapter** ("Abstract") whose body is the
+ *    title + author byline + subjects + comments + abstract paragraph,
+ *    extracted from the paper's `arxiv.org/abs/<id>` HTML page.
+ *
+ * Skipping full-PDF text extraction is an explicit v1 scope cut from
+ * #378's acceptance criteria — JP listens to "morning digest of new
+ * AI papers" via the abstract alone. A follow-up issue will land full-
+ * paper body extraction (the PDF → narratable-text pipeline is its
+ * own substantial backend).
+ *
+ * ## Browse landing
+ *
+ * Popular / NewReleases / BestRated all collapse to "recent in
+ * [ArxivApi.DEFAULT_CATEGORY]" — cs.AI for v1. arXiv exposes the same
+ * underlying query for each (sorted by submittedDate desc); browse
+ * tabs that don't fit (BestRated has no analogue on arXiv — papers
+ * aren't ranked) reuse the recent listing rather than show an empty
+ * picker. Search uses the `all:<term>` query.
+ *
+ * ## Fiction IDs
+ *
+ * `arxiv:<arxiv-id>` where `<arxiv-id>` is arXiv's canonical paper id
+ * stripped of any version suffix (`v1`, `v2`, ...). Examples:
+ *  - `arxiv:2401.12345` — post-2007 new-style ids
+ *  - `arxiv:cs/0703021` — pre-2007 archive-style ids with embedded slash
+ *
+ * ## Auth-gated calls
+ *
+ * arXiv has no per-user follow concept storyvox can push to. The
+ * `followsList` / `setFollowed` overrides return empty/Success so the
+ * Follow button stays hidden on the FictionDetail screen (`supportsFollow
+ * = false` on the [SourcePlugin] annotation).
+ */
+@SourcePlugin(
+    id = SourceIds.ARXIV,
+    displayName = "arXiv",
+    defaultEnabled = false,
+    category = SourceCategory.Text,
+    supportsFollow = false,
+    supportsSearch = true,
+)
+@Singleton
+internal class ArxivSource @Inject constructor(
+    private val api: ArxivApi,
+) : FictionSource {
+
+    override val id: String = SourceIds.ARXIV
+    override val displayName: String = "arXiv"
+
+    // ─── browse ────────────────────────────────────────────────────────
+
+    override suspend fun popular(page: Int): FictionResult<ListPage<FictionSummary>> {
+        val pageIdx = (page - 1).coerceAtLeast(0)
+        val start = pageIdx * ArxivApi.DEFAULT_PAGE_SIZE
+        return api.recent(start = start).map { feed ->
+            feed.toListPage(page)
+        }
+    }
+
+    override suspend fun latestUpdates(page: Int): FictionResult<ListPage<FictionSummary>> =
+        // arXiv's "submittedDate desc" is the same surface that powers
+        // [popular] — there's no distinct "trending" vs "newest" on the
+        // public API. Aliasing avoids a redundant fetch for the
+        // NewReleases tab.
+        popular(page)
+
+    override suspend fun byGenre(
+        genre: String,
+        page: Int,
+    ): FictionResult<ListPage<FictionSummary>> {
+        // Genre = arXiv category code (`cs.AI`, `cs.CL`, ...). Empty
+        // genre falls back to the default category for the bare
+        // "browse" hit path.
+        val cat = genre.ifBlank { ArxivApi.DEFAULT_CATEGORY }
+        val pageIdx = (page - 1).coerceAtLeast(0)
+        val start = pageIdx * ArxivApi.DEFAULT_PAGE_SIZE
+        return api.recent(category = cat, start = start).map { feed ->
+            feed.toListPage(page)
+        }
+    }
+
+    override suspend fun genres(): FictionResult<List<String>> =
+        // Curated subset of the arXiv category tree. The full list is
+        // huge (200+ codes across math/physics/cs/q-bio/...); for v1 we
+        // surface the CS subset since the default landing is cs.AI and
+        // the JP-shaped use case is AI/ML papers. A v2 follow-up can
+        // add a Settings-side picker that drives a richer list.
+        FictionResult.Success(
+            listOf(
+                "cs.AI", "cs.CL", "cs.LG", "cs.CV", "cs.RO",
+                "cs.NE", "cs.SE", "cs.DC", "cs.CR", "cs.DB",
+                "stat.ML", "math.OC",
+            )
+        )
+
+    override suspend fun search(query: SearchQuery): FictionResult<ListPage<FictionSummary>> {
+        val term = query.term.trim()
+        if (term.isEmpty()) return popular(1)
+        val pageIdx = (query.page - 1).coerceAtLeast(0)
+        val start = pageIdx * ArxivApi.DEFAULT_PAGE_SIZE
+        return api.search(term = term, start = start).map { feed ->
+            feed.toListPage(query.page)
+        }
+    }
+
+    // ─── detail ────────────────────────────────────────────────────────
+
+    override suspend fun fictionDetail(fictionId: String): FictionResult<FictionDetail> {
+        val arxivId = fictionId.toArxivId()
+            ?: return FictionResult.NotFound("arXiv fiction id not recognized: $fictionId")
+        // Two paths: query API (Atom — structured) and abstract page
+        // (HTML — has the comments field the Atom doesn't surface). We
+        // prefer the Atom for the summary card (canonical metadata),
+        // then layer the abstract-page parse into the chapter body in
+        // [chapter]. fictionDetail doesn't fetch chapter bodies — same
+        // contract as the other backends.
+        return when (val byId = api.byId(arxivId)) {
+            is FictionResult.Success -> {
+                val entry = byId.value.entries.firstOrNull()
+                    ?: return FictionResult.NotFound("arXiv paper not found: $arxivId")
+                val summary = entry.toSummary(fictionId)
+                val chapterInfo = ChapterInfo(
+                    id = chapterIdFor(fictionId),
+                    sourceChapterId = "abstract",
+                    index = 0,
+                    title = "Abstract",
+                    publishedAt = null,
+                )
+                FictionResult.Success(
+                    FictionDetail(
+                        summary = summary.copy(chapterCount = 1),
+                        chapters = listOf(chapterInfo),
+                    ),
+                )
+            }
+            is FictionResult.Failure -> byId
+        }
+    }
+
+    override suspend fun chapter(
+        fictionId: String,
+        chapterId: String,
+    ): FictionResult<ChapterContent> {
+        val arxivId = fictionId.toArxivId()
+            ?: return FictionResult.NotFound("arXiv fiction id not recognized: $fictionId")
+        if (!chapterId.endsWith("::abstract")) {
+            return FictionResult.NotFound("arXiv chapter id not recognized: $chapterId")
+        }
+        return when (val r = api.absPage(arxivId)) {
+            is FictionResult.Success -> {
+                val parsed = ArxivAbstractParser.parse(r.value)
+                val info = ChapterInfo(
+                    id = chapterId,
+                    sourceChapterId = "abstract",
+                    index = 0,
+                    title = "Abstract",
+                )
+                val htmlBody = ArxivAbstractParser.toChapterHtml(parsed)
+                val plainBody = ArxivAbstractParser.toChapterPlain(parsed)
+                FictionResult.Success(
+                    ChapterContent(
+                        info = info,
+                        htmlBody = htmlBody,
+                        plainBody = plainBody,
+                    ),
+                )
+            }
+            is FictionResult.Failure -> r
+        }
+    }
+
+    // ─── auth-gated ─────────────────────────────────────────────────────
+
+    override suspend fun followsList(page: Int): FictionResult<ListPage<FictionSummary>> =
+        // arXiv has no account-side follow concept storyvox can sync
+        // with — the public API is read-only and anonymous.
+        FictionResult.Success(ListPage(items = emptyList(), page = 1, hasNext = false))
+
+    override suspend fun setFollowed(
+        fictionId: String,
+        followed: Boolean,
+    ): FictionResult<Unit> = FictionResult.Success(Unit)
+}
+
+// ─── helpers ──────────────────────────────────────────────────────────
+
+/** Compose a stable arXiv fiction id from the bare arxiv-id. */
+internal fun arxivFictionId(arxivId: String): String =
+    "arxiv:" + arxivId.trim()
+
+/** Compose the canonical chapter id — every arXiv paper has exactly one
+ *  chapter ("Abstract") in v1, so the suffix is fixed. */
+internal fun chapterIdFor(fictionId: String): String =
+    "$fictionId::abstract"
+
+/** Strip the `arxiv:` prefix; returns null on ids that don't carry it. */
+internal fun String.toArxivId(): String? =
+    if (startsWith("arxiv:")) removePrefix("arxiv:").substringBefore("::")
+    else null
+
+private fun ArxivAtomFeed.toListPage(page: Int): ListPage<FictionSummary> {
+    val items = entries.map { it.toSummary() }
+    // arXiv returns whatever's left within the requested window. If we
+    // got a full page the user can keep scrolling; if it short-returned
+    // we're at the tail. Cheap-enough heuristic — opensearch:totalResults
+    // is exposed in [ArxivAtomFeed.totalResults] but isn't always
+    // populated, so the size-based check is the reliable signal.
+    val hasNext = items.size >= ArxivApi.DEFAULT_PAGE_SIZE
+    return ListPage(items = items, page = page, hasNext = hasNext)
+}
+
+internal fun ArxivFeedEntry.toSummary(
+    fictionId: String = arxivFictionId(arxivId),
+): FictionSummary = FictionSummary(
+    id = fictionId,
+    sourceId = SourceIds.ARXIV,
+    title = title.ifBlank { arxivId },
+    author = formatAuthors(authors).ifBlank { "arXiv" },
+    description = summary.ifBlank { null },
+    tags = categories,
+    status = FictionStatus.COMPLETED,
+    chapterCount = 1,
+)

--- a/source-arxiv/src/main/kotlin/in/jphe/storyvox/source/arxiv/di/ArxivModule.kt
+++ b/source-arxiv/src/main/kotlin/in/jphe/storyvox/source/arxiv/di/ArxivModule.kt
@@ -1,0 +1,76 @@
+package `in`.jphe.storyvox.source.arxiv.di
+
+import dagger.Binds
+import dagger.Module
+import dagger.Provides
+import dagger.hilt.InstallIn
+import dagger.hilt.components.SingletonComponent
+import dagger.multibindings.IntoMap
+import dagger.multibindings.StringKey
+import `in`.jphe.storyvox.data.source.FictionSource
+import `in`.jphe.storyvox.data.source.SourceIds
+import `in`.jphe.storyvox.source.arxiv.ArxivSource
+import okhttp3.OkHttpClient
+import javax.inject.Qualifier
+import javax.inject.Singleton
+import java.util.concurrent.TimeUnit
+
+@Qualifier
+@Retention(AnnotationRetention.BINARY)
+annotation class ArxivHttp
+
+/**
+ * Issue #378 — dedicated OkHttp client for the arXiv API. Generous read
+ * timeout because the Atom-feed response can carry up to 50 entries (each
+ * with a paragraph-length abstract); connect timeout stays tight because
+ * `export.arxiv.org` is CDN-fronted and reliably reachable.
+ *
+ * arXiv recommends following redirects so the `http://export.arxiv.org`
+ * → `https://` upgrade happens transparently.
+ */
+@Module
+@InstallIn(SingletonComponent::class)
+internal object ArxivHttpModule {
+
+    @Provides
+    @Singleton
+    @ArxivHttp
+    fun provideClient(): OkHttpClient =
+        OkHttpClient.Builder()
+            .connectTimeout(5, TimeUnit.SECONDS)
+            .readTimeout(30, TimeUnit.SECONDS)
+            .writeTimeout(15, TimeUnit.SECONDS)
+            .followRedirects(true)
+            .followSslRedirects(true)
+            .retryOnConnectionFailure(true)
+            .build()
+
+    @Provides
+    @Singleton
+    fun provideArxivApi(
+        @ArxivHttp client: OkHttpClient,
+    ): `in`.jphe.storyvox.source.arxiv.net.ArxivApi =
+        `in`.jphe.storyvox.source.arxiv.net.ArxivApi(client)
+}
+
+/**
+ * Issue #378 — contributes [ArxivSource] into the multi-source
+ * `Map<String, FictionSource>`. Adds an "arXiv" entry to the segmented
+ * source picker; persisted fictions with sourceId="arxiv" route through
+ * this source.
+ *
+ * Plugin-seam Phase 2 (#384) dual-wire: the `@SourcePlugin` annotation
+ * on [ArxivSource] also emits a Hilt `@IntoSet SourcePluginDescriptor`
+ * binding via the `:core-plugin-ksp` processor. The two views coexist
+ * until Phase 3 retires the legacy map binding.
+ */
+@Module
+@InstallIn(SingletonComponent::class)
+internal abstract class ArxivBindings {
+
+    @Binds
+    @Singleton
+    @IntoMap
+    @StringKey(SourceIds.ARXIV)
+    abstract fun bindFictionSource(impl: ArxivSource): FictionSource
+}

--- a/source-arxiv/src/main/kotlin/in/jphe/storyvox/source/arxiv/net/ArxivAbstractParser.kt
+++ b/source-arxiv/src/main/kotlin/in/jphe/storyvox/source/arxiv/net/ArxivAbstractParser.kt
@@ -1,0 +1,230 @@
+package `in`.jphe.storyvox.source.arxiv.net
+
+/**
+ * Issue #378 — focused regex extractor over the arXiv abstract page
+ * (`arxiv.org/abs/<id>`). Pulls a small, narrating-friendly set of
+ * fields out of the server-rendered HTML so the chapter body reads
+ * cleanly through TTS:
+ *
+ *  - **Title** (`<meta name="citation_title">` or the `<h1 class="title">`
+ *    block). The citation meta tag is the most machine-stable surface.
+ *  - **Authors** (`<meta name="citation_author">` repeated per author,
+ *    or the `<div class="authors">` link list).
+ *  - **Abstract** (`<meta name="citation_abstract">` or the
+ *    `<blockquote class="abstract">` block).
+ *  - **Subjects** (`<td class="tablecell subjects">`) — the comma-list
+ *    of arXiv categories, useful in the chapter intro.
+ *  - **Comments** (`<td class="tablecell comments">`) — author-supplied
+ *    notes (page count, conference accepted-at, ...). Optional.
+ *
+ * ## Why regex over jsoup
+ *
+ * Same posture as `:source-standard-ebooks`'s SeHtmlParser — arXiv's
+ * abstract pages have a stable, decade-old layout; the `<meta
+ * name="citation_*">` tags are part of arXiv's published metadata
+ * contract (they're how Google Scholar indexes papers). Regex over
+ * those anchors is plenty robust, runs on the plain JUnit classpath,
+ * and avoids pulling jsoup just for one parser pass.
+ */
+internal object ArxivAbstractParser {
+
+    /** `<meta name="citation_title" content="...">` — capture content. */
+    private val META_TITLE_REGEX = Regex(
+        """<meta\b[^>]*\bname="citation_title"[^>]*\bcontent="([^"]+)"""",
+        RegexOption.IGNORE_CASE,
+    )
+
+    /** `<meta name="citation_author" content="Last, First">` — repeated.
+     *  arXiv emits one per author in document order. */
+    private val META_AUTHOR_REGEX = Regex(
+        """<meta\b[^>]*\bname="citation_author"[^>]*\bcontent="([^"]+)"""",
+        RegexOption.IGNORE_CASE,
+    )
+
+    /** `<meta name="citation_abstract" content="...">`. arXiv emits the
+     *  abstract here on the abs/<id> page; multi-paragraph abstracts
+     *  arrive as one line with embedded newlines. */
+    private val META_ABSTRACT_REGEX = Regex(
+        """<meta\b[^>]*\bname="citation_abstract"[^>]*\bcontent="([^"]+)"""",
+        RegexOption.IGNORE_CASE,
+    )
+
+    /** Fallback abstract block when the meta tag is missing — `<blockquote
+     *  class="abstract"><span class="descriptor">Abstract:</span>...</blockquote>`. */
+    private val ABSTRACT_BLOCK_REGEX = Regex(
+        """<blockquote\b[^>]*\bclass="[^"]*\babstract\b[^"]*"[^>]*>([\s\S]*?)</blockquote>""",
+        RegexOption.IGNORE_CASE,
+    )
+
+    /** Fallback title block — `<h1 class="title mathjax"><span ...>Title:</span> Real Title</h1>`. */
+    private val H1_TITLE_REGEX = Regex(
+        """<h1\b[^>]*\bclass="[^"]*\btitle\b[^"]*"[^>]*>([\s\S]*?)</h1>""",
+        RegexOption.IGNORE_CASE,
+    )
+
+    /** Subjects row — `<td class="tablecell subjects">cs.AI; cs.CL</td>`. */
+    private val SUBJECTS_REGEX = Regex(
+        """<td\b[^>]*\bclass="[^"]*\bsubjects\b[^"]*"[^>]*>([\s\S]*?)</td>""",
+        RegexOption.IGNORE_CASE,
+    )
+
+    /** Comments row — author-supplied annotation
+     *  (`8 pages, 3 figures, accepted at NeurIPS 2025`). */
+    private val COMMENTS_REGEX = Regex(
+        """<td\b[^>]*\bclass="[^"]*\bcomments\b[^"]*"[^>]*>([\s\S]*?)</td>""",
+        RegexOption.IGNORE_CASE,
+    )
+
+    /**
+     * Parse a fetched abstract-page HTML string into a structured
+     * [ArxivAbstract]. Missing fields become empty/null; the chapter
+     * builder fills sensible defaults so a partial parse still renders.
+     */
+    fun parse(html: String): ArxivAbstract {
+        val title = META_TITLE_REGEX.find(html)?.groupValues?.get(1)
+            ?.let(::decodeXmlEntities)
+            ?.collapseWhitespace()
+            ?: H1_TITLE_REGEX.find(html)?.groupValues?.get(1)
+                ?.let(::stripTags)
+                ?.let(::decodeXmlEntities)
+                ?.collapseWhitespace()
+                // Descriptor span gets stripped above; the leading
+                // "Title:" label survives as raw text and needs to come
+                // off AFTER whitespace collapse (otherwise the leading
+                // newline / indent prevents the prefix match).
+                ?.removePrefix("Title:")
+                ?.trim()
+            ?: ""
+
+        val authors = META_AUTHOR_REGEX.findAll(html)
+            .map { decodeXmlEntities(it.groupValues[1]).collapseWhitespace() }
+            .filter { it.isNotBlank() }
+            .toList()
+
+        val abstract = META_ABSTRACT_REGEX.find(html)?.groupValues?.get(1)
+            ?.let(::decodeXmlEntities)
+            ?.collapseWhitespace()
+            ?: ABSTRACT_BLOCK_REGEX.find(html)?.groupValues?.get(1)
+                ?.let(::stripTags)
+                ?.let(::decodeXmlEntities)
+                ?.collapseWhitespace()
+                // Strip the leading "Abstract:" label AFTER whitespace
+                // collapses — same shape as the title fallback above.
+                ?.removePrefix("Abstract:")
+                ?.trim()
+            ?: ""
+
+        val subjects = SUBJECTS_REGEX.find(html)?.groupValues?.get(1)
+            ?.let(::stripTags)
+            ?.let(::decodeXmlEntities)
+            ?.collapseWhitespace()
+            .orEmpty()
+
+        val comments = COMMENTS_REGEX.find(html)?.groupValues?.get(1)
+            ?.let(::stripTags)
+            ?.let(::decodeXmlEntities)
+            ?.collapseWhitespace()
+            ?.takeIf { it.isNotBlank() }
+
+        return ArxivAbstract(
+            title = title,
+            authors = authors,
+            abstract = abstract,
+            subjects = subjects,
+            comments = comments,
+        )
+    }
+
+    /**
+     * Compose the narrating-friendly chapter body. Reads as one
+     * coherent paragraph: title (already in the fiction summary, but
+     * worth restating for cold-listen context), author list spoken as
+     * "by A, B, and C", subjects, optional author comments, then the
+     * abstract proper.
+     *
+     * Returned HTML is intentionally minimal — `<p>` wrappers only,
+     * no inline formatting — because the playback-side TTS pipeline
+     * does the heavy lifting. Same shape as the Wikipedia chapter
+     * cleanup output.
+     */
+    fun toChapterHtml(abstract: ArxivAbstract): String = buildString {
+        if (abstract.title.isNotBlank()) {
+            append("<h2>").append(escapeHtml(abstract.title)).append("</h2>")
+        }
+        val byline = formatAuthors(abstract.authors)
+        if (byline.isNotBlank()) {
+            append("<p><em>by ").append(escapeHtml(byline)).append("</em></p>")
+        }
+        if (abstract.subjects.isNotBlank()) {
+            append("<p><strong>Subjects:</strong> ")
+                .append(escapeHtml(abstract.subjects))
+                .append("</p>")
+        }
+        abstract.comments?.let {
+            append("<p><strong>Comments:</strong> ")
+                .append(escapeHtml(it))
+                .append("</p>")
+        }
+        if (abstract.abstract.isNotBlank()) {
+            append("<p><strong>Abstract.</strong> ")
+                .append(escapeHtml(abstract.abstract))
+                .append("</p>")
+        }
+    }
+
+    /** Plain-text rendering for the TTS pipeline. Mirrors the HTML
+     *  structure with explicit "Subjects:" / "Comments:" /
+     *  "Abstract." prefixes that read as natural sentences. */
+    fun toChapterPlain(abstract: ArxivAbstract): String = buildString {
+        if (abstract.title.isNotBlank()) {
+            append(abstract.title).append("\n\n")
+        }
+        val byline = formatAuthors(abstract.authors)
+        if (byline.isNotBlank()) {
+            append("by ").append(byline).append(".\n\n")
+        }
+        if (abstract.subjects.isNotBlank()) {
+            append("Subjects: ").append(abstract.subjects).append(".\n\n")
+        }
+        abstract.comments?.let {
+            append("Comments: ").append(it).append(".\n\n")
+        }
+        if (abstract.abstract.isNotBlank()) {
+            append("Abstract. ").append(abstract.abstract)
+        }
+    }.trim()
+
+    private fun stripTags(html: String): String =
+        html.replace(Regex("<[^>]+>"), "")
+
+    private fun escapeHtml(text: String): String =
+        text.replace("&", "&amp;")
+            .replace("<", "&lt;")
+            .replace(">", "&gt;")
+}
+
+/**
+ * Structured view of an arXiv abstract page. Most fields are required
+ * on a happy-path parse; [comments] is nullable because it's optional
+ * on arXiv (only present when the author supplied annotation text).
+ */
+internal data class ArxivAbstract(
+    val title: String,
+    val authors: List<String>,
+    val abstract: String,
+    val subjects: String,
+    val comments: String? = null,
+)
+
+/**
+ * Render an author list as "A", "A and B", "A, B, and C", or "" for
+ * the empty case. Oxford comma — keeps the spoken sentence parseable
+ * when one of the authors has a comma in their display name (rare but
+ * does happen with academic conventions like "Smith, John Q.").
+ */
+internal fun formatAuthors(authors: List<String>): String = when (authors.size) {
+    0 -> ""
+    1 -> authors[0]
+    2 -> "${authors[0]} and ${authors[1]}"
+    else -> authors.dropLast(1).joinToString(", ") + ", and ${authors.last()}"
+}

--- a/source-arxiv/src/main/kotlin/in/jphe/storyvox/source/arxiv/net/ArxivApi.kt
+++ b/source-arxiv/src/main/kotlin/in/jphe/storyvox/source/arxiv/net/ArxivApi.kt
@@ -1,0 +1,212 @@
+package `in`.jphe.storyvox.source.arxiv.net
+
+import `in`.jphe.storyvox.data.source.model.FictionResult
+import okhttp3.OkHttpClient
+import okhttp3.Request
+import java.io.IOException
+import java.net.URLEncoder
+import javax.inject.Inject
+import javax.inject.Singleton
+import kotlin.time.Duration.Companion.seconds
+
+/**
+ * Issue #378 — minimal arXiv API client. Talks to two surfaces:
+ *
+ *  - **Query API** (`export.arxiv.org/api/query`) — the public Atom-feed
+ *    search/listing endpoint. We use it for the browse landing
+ *    (category-filtered, sorted by submittedDate desc) and free-form
+ *    search (`all:<term>`). Documented at
+ *    https://info.arxiv.org/help/api/user-manual.html.
+ *  - **Abstract page** (`arxiv.org/abs/<id>`) — the per-paper HTML
+ *    landing page. We fetch this once per fictionDetail/chapter call
+ *    and extract the title + authors + abstract + comments via
+ *    [ArxivAbstractParser]. Skipping the full-PDF text-extraction is
+ *    an explicit v1 trade-off (#378 acceptance) — the abstract is the
+ *    "morning digest of new AI papers" use case.
+ *
+ * Both endpoints are GET, public, no auth, and have generous rate
+ * limits (arXiv's published policy is "1 request every 3 seconds"
+ * for the query API; storyvox's per-user fetch cadence is well under
+ * that). User-Agent identifies the project per arXiv's request to
+ * tag automated traffic.
+ *
+ * Failures surface as [FictionResult.Failure] without leaking
+ * OkHttp / arXiv-specific exceptions.
+ */
+@Singleton
+internal class ArxivApi @Inject constructor(
+    private val client: OkHttpClient,
+) {
+
+    // ─── browse / search via the Atom query API ────────────────────────
+
+    /**
+     * Recent papers in a category, newest first. The browse landing
+     * defaults to [DEFAULT_CATEGORY] (`cs.AI`) — JP's space. A category
+     * picker is a v2 follow-up (#378 lists it explicitly out of scope).
+     */
+    suspend fun recent(
+        category: String = DEFAULT_CATEGORY,
+        start: Int = 0,
+        maxResults: Int = DEFAULT_PAGE_SIZE,
+    ): FictionResult<ArxivAtomFeed> {
+        val url = composeRecentUrl(category, start, maxResults)
+        return getAtom(url)
+    }
+
+    /**
+     * Free-form search. Builds an `all:<term>` query — `all` matches the
+     * paper's title, abstract, authors, and comments. We keep the
+     * sort-order at submittedDate desc so the user sees the most recent
+     * matches first; arXiv's relevance-sort isn't exposed via the
+     * public API (only `submittedDate`, `lastUpdatedDate`, and
+     * `relevance` with the latter known to be flaky).
+     */
+    suspend fun search(
+        term: String,
+        start: Int = 0,
+        maxResults: Int = DEFAULT_PAGE_SIZE,
+    ): FictionResult<ArxivAtomFeed> {
+        val url = composeSearchUrl(term, start, maxResults)
+        return getAtom(url)
+    }
+
+    /**
+     * Fetch a single paper by its arXiv id via the `id_list` parameter.
+     * Returns the same Atom-feed shape as the listing call but with
+     * exactly one entry. Used by [fictionDetail] to pull the full
+     * metadata if the abstract-page HTML parse comes up short.
+     */
+    suspend fun byId(arxivId: String): FictionResult<ArxivAtomFeed> {
+        val url = "$QUERY_BASE?id_list=" + URLEncoder.encode(arxivId, "UTF-8")
+        return getAtom(url)
+    }
+
+    // ─── per-paper abstract page (HTML) ─────────────────────────────────
+
+    /**
+     * Raw HTML of the arXiv abstract page (`arxiv.org/abs/<id>`). The
+     * caller passes it through [ArxivAbstractParser.parse] to extract a
+     * narrating-friendly chapter body. Skipping the PDF body itself is
+     * the explicit v1 scope cut from #378.
+     */
+    suspend fun absPage(arxivId: String): FictionResult<String> {
+        val encoded = URLEncoder.encode(arxivId, "UTF-8").replace("+", "%20")
+        val url = "$ABS_BASE/$encoded"
+        return getRaw(url)
+    }
+
+    // ─── transport ─────────────────────────────────────────────────────
+
+    private fun getAtom(url: String): FictionResult<ArxivAtomFeed> =
+        when (val raw = getRaw(url)) {
+            is FictionResult.Success -> try {
+                FictionResult.Success(ArxivAtomFeed.parse(raw.value))
+            } catch (e: Throwable) {
+                FictionResult.NetworkError("arXiv returned unparseable Atom feed", e)
+            }
+            is FictionResult.Failure -> raw
+        }
+
+    private fun getRaw(url: String): FictionResult<String> {
+        return try {
+            val req = Request.Builder()
+                .url(url)
+                .header("Accept", "application/atom+xml, text/html;q=0.9, */*;q=0.5")
+                .header("User-Agent", USER_AGENT)
+                .get()
+                .build()
+            client.newCall(req).execute().use { resp ->
+                when {
+                    resp.code == 404 ->
+                        FictionResult.NotFound("arXiv paper not found")
+                    resp.code == 429 ->
+                        FictionResult.RateLimited(
+                            retryAfter = resp.header("Retry-After")
+                                ?.toLongOrNull()
+                                ?.seconds,
+                            message = "arXiv rate-limited the request",
+                        )
+                    !resp.isSuccessful ->
+                        FictionResult.NetworkError(
+                            "HTTP ${resp.code} from $url",
+                            IOException("HTTP ${resp.code}"),
+                        )
+                    else -> {
+                        val text = resp.body?.string()
+                            ?: return FictionResult.NetworkError(
+                                "empty body",
+                                IOException("empty body"),
+                            )
+                        FictionResult.Success(text)
+                    }
+                }
+            }
+        } catch (e: IOException) {
+            FictionResult.NetworkError(e.message ?: "fetch failed", e)
+        }
+    }
+
+    companion object {
+        /** Default browse landing category. cs.AI per #378 — JP's space.
+         *  Other categories ride alongside this; a v2 follow-up will
+         *  surface a Settings-side picker so the user can swap defaults. */
+        const val DEFAULT_CATEGORY: String = "cs.AI"
+
+        /** Page size for the listing/search responses. arXiv accepts up
+         *  to 2000 per call but recommends keeping it small for
+         *  responsiveness; 50 matches their suggested default in the
+         *  API user manual. */
+        const val DEFAULT_PAGE_SIZE: Int = 50
+
+        /** Atom-query endpoint host. arXiv directs automated clients to
+         *  `export.arxiv.org` rather than the user-facing `arxiv.org`
+         *  to keep CDN cache pressure off the read path. */
+        const val QUERY_BASE: String = "http://export.arxiv.org/api/query"
+
+        /** Per-paper abstract page host. */
+        const val ABS_BASE: String = "https://arxiv.org/abs"
+
+        /** arXiv requests an identifying User-Agent on automated traffic
+         *  (see https://info.arxiv.org/help/robots.html). */
+        const val USER_AGENT: String =
+            "storyvox-arxiv/1.0 (https://github.com/techempower-org/storyvox; jp@jphein.com)"
+    }
+}
+
+/**
+ * Compose the URL for the "recent in category" browse landing call.
+ * Pure function so unit tests can pin the query-string shape without
+ * spinning up an OkHttp client.
+ */
+internal fun composeRecentUrl(
+    category: String,
+    start: Int = 0,
+    maxResults: Int = ArxivApi.DEFAULT_PAGE_SIZE,
+): String {
+    val cat = category.trim().ifBlank { ArxivApi.DEFAULT_CATEGORY }
+    val query = "cat:" + URLEncoder.encode(cat, "UTF-8")
+    return ArxivApi.QUERY_BASE +
+        "?search_query=" + query +
+        "&sortBy=submittedDate&sortOrder=descending" +
+        "&start=$start&max_results=$maxResults"
+}
+
+/**
+ * Compose the URL for a free-form `all:<term>` search call. Pure
+ * function for test pinning — see [ArxivApiUrlTest].
+ */
+internal fun composeSearchUrl(
+    term: String,
+    start: Int = 0,
+    maxResults: Int = ArxivApi.DEFAULT_PAGE_SIZE,
+): String {
+    // `all:` matches title + abstract + authors + comments. Trim before
+    // URL-encoding so a stray newline / leading space doesn't break the
+    // query syntax on arXiv's side.
+    val q = "all:" + URLEncoder.encode(term.trim(), "UTF-8")
+    return ArxivApi.QUERY_BASE +
+        "?search_query=" + q +
+        "&sortBy=submittedDate&sortOrder=descending" +
+        "&start=$start&max_results=$maxResults"
+}

--- a/source-arxiv/src/main/kotlin/in/jphe/storyvox/source/arxiv/net/ArxivAtomFeed.kt
+++ b/source-arxiv/src/main/kotlin/in/jphe/storyvox/source/arxiv/net/ArxivAtomFeed.kt
@@ -1,0 +1,209 @@
+package `in`.jphe.storyvox.source.arxiv.net
+
+/**
+ * Issue #378 — typed view of an arXiv API Atom feed response from
+ * `export.arxiv.org/api/query`. arXiv returns a standard Atom 1.0
+ * document with `<entry>` per paper carrying `<title>`, `<summary>`
+ * (abstract), `<author><name/></author>` blocks, `<id>` (URL like
+ * `http://arxiv.org/abs/2401.12345v1`), and a `<link rel="alternate"
+ * type="text/html" href=".../abs/<id>">` plus `<link rel="related"
+ * title="pdf" href=".../pdf/<id>.pdf">`.
+ *
+ * ## Why hand-rolled regex parsing
+ *
+ * Same posture as `:source-standard-ebooks`'s SeHtmlParser — arXiv's
+ * Atom feeds are machine-stable (publicly documented at
+ * https://info.arxiv.org/help/api/user-manual.html). A regex pass over
+ * the small set of `<entry>`/`<title>`/`<summary>`/`<author>`/`<id>`/
+ * `<link>` anchors is faster than spinning up [android.util.Xml] +
+ * works on the plain JUnit test classpath (no Robolectric).
+ *
+ * If arXiv's feed shape ever shifts we re-key the regexes; the unit
+ * tests pin the canonical layout so a silent break surfaces at CI time.
+ */
+internal data class ArxivAtomFeed(
+    val totalResults: Long?,
+    val entries: List<ArxivFeedEntry>,
+) {
+    companion object {
+        /**
+         * Each entry begins with `<entry>` and ends at `</entry>`. arXiv
+         * doesn't nest entries inside other elements at the feed level —
+         * they're siblings under `<feed>` — so a non-greedy span suffices.
+         */
+        private val ENTRY_REGEX = Regex(
+            """<entry\b[^>]*>([\s\S]*?)</entry>""",
+            RegexOption.IGNORE_CASE,
+        )
+
+        /** OpenSearch extension: `<opensearch:totalResults>N</opensearch:totalResults>`. */
+        private val TOTAL_RESULTS_REGEX = Regex(
+            """<opensearch:totalResults\b[^>]*>(\d+)</opensearch:totalResults>""",
+            RegexOption.IGNORE_CASE,
+        )
+
+        private val TITLE_REGEX = Regex(
+            """<title\b[^>]*>([\s\S]*?)</title>""",
+            RegexOption.IGNORE_CASE,
+        )
+
+        private val SUMMARY_REGEX = Regex(
+            """<summary\b[^>]*>([\s\S]*?)</summary>""",
+            RegexOption.IGNORE_CASE,
+        )
+
+        private val ID_REGEX = Regex(
+            """<id\b[^>]*>([\s\S]*?)</id>""",
+            RegexOption.IGNORE_CASE,
+        )
+
+        private val UPDATED_REGEX = Regex(
+            """<updated\b[^>]*>([\s\S]*?)</updated>""",
+            RegexOption.IGNORE_CASE,
+        )
+
+        private val PUBLISHED_REGEX = Regex(
+            """<published\b[^>]*>([\s\S]*?)</published>""",
+            RegexOption.IGNORE_CASE,
+        )
+
+        /** `<author><name>...</name></author>` — strip the wrapper, capture the name. */
+        private val AUTHOR_NAME_REGEX = Regex(
+            """<author\b[^>]*>[\s\S]*?<name\b[^>]*>([\s\S]*?)</name>[\s\S]*?</author>""",
+            RegexOption.IGNORE_CASE,
+        )
+
+        /** `<category term="cs.AI" scheme="..."/>` — capture the term. */
+        private val CATEGORY_REGEX = Regex(
+            """<category\b[^>]*\bterm="([^"]+)"""",
+            RegexOption.IGNORE_CASE,
+        )
+
+        /** `<link rel="alternate" ... href="..." />` — the abstract page URL. */
+        private val LINK_ALT_REGEX = Regex(
+            """<link\b[^>]*\brel="alternate"[^>]*\bhref="([^"]+)"""",
+            RegexOption.IGNORE_CASE,
+        )
+
+        /** `<link ... title="pdf" href="..." />` — the PDF link. */
+        private val LINK_PDF_REGEX = Regex(
+            """<link\b[^>]*\btitle="pdf"[^>]*\bhref="([^"]+)"""",
+            RegexOption.IGNORE_CASE,
+        )
+
+        /**
+         * Parse an Atom feed XML string. Returns an empty feed on
+         * unrecognised input (the source layer maps that to an empty
+         * list rather than a parse error — arXiv occasionally returns
+         * an empty `<feed>` for esoteric category queries and an empty
+         * result is the right UX, not a failure dialog).
+         */
+        fun parse(xml: String): ArxivAtomFeed {
+            val total = TOTAL_RESULTS_REGEX.find(xml)?.groupValues?.get(1)?.toLongOrNull()
+            val entries = ENTRY_REGEX.findAll(xml).map { match ->
+                parseEntry(match.groupValues[1])
+            }.filter { it.arxivId.isNotBlank() }.toList()
+            return ArxivAtomFeed(totalResults = total, entries = entries)
+        }
+
+        private fun parseEntry(body: String): ArxivFeedEntry {
+            val title = TITLE_REGEX.find(body)?.groupValues?.get(1)
+                ?.let(::decodeXmlEntities)
+                ?.collapseWhitespace()
+                .orEmpty()
+
+            val summary = SUMMARY_REGEX.find(body)?.groupValues?.get(1)
+                ?.let(::decodeXmlEntities)
+                ?.collapseWhitespace()
+                .orEmpty()
+
+            val id = ID_REGEX.find(body)?.groupValues?.get(1)?.trim().orEmpty()
+            // `<id>http://arxiv.org/abs/2401.12345v1</id>` — pull the
+            // bare arxiv id from the tail; version suffixes (v1, v2...)
+            // are stripped because the abstract page resolves to the
+            // current revision automatically.
+            val arxivId = extractArxivId(id)
+
+            val updated = UPDATED_REGEX.find(body)?.groupValues?.get(1)?.trim()
+            val published = PUBLISHED_REGEX.find(body)?.groupValues?.get(1)?.trim()
+
+            val authors = AUTHOR_NAME_REGEX.findAll(body)
+                .map { decodeXmlEntities(it.groupValues[1]).collapseWhitespace() }
+                .filter { it.isNotBlank() }
+                .toList()
+
+            val categories = CATEGORY_REGEX.findAll(body)
+                .map { it.groupValues[1] }
+                .filter { it.isNotBlank() }
+                .toList()
+
+            val absUrl = LINK_ALT_REGEX.find(body)?.groupValues?.get(1)
+            val pdfUrl = LINK_PDF_REGEX.find(body)?.groupValues?.get(1)
+
+            return ArxivFeedEntry(
+                arxivId = arxivId,
+                title = title,
+                summary = summary,
+                authors = authors,
+                categories = categories,
+                updated = updated,
+                published = published,
+                absUrl = absUrl,
+                pdfUrl = pdfUrl,
+            )
+        }
+    }
+}
+
+/**
+ * One paper. Mirrors what we need from the Atom `<entry>`. `arxivId` is
+ * the canonical id without a version suffix (e.g. "2401.12345" or the
+ * pre-2007 "cs/0703021" form) — the abstract page at
+ * `arxiv.org/abs/<arxivId>` always resolves to the latest revision.
+ */
+internal data class ArxivFeedEntry(
+    val arxivId: String,
+    val title: String,
+    val summary: String,
+    val authors: List<String>,
+    val categories: List<String>,
+    val updated: String? = null,
+    val published: String? = null,
+    val absUrl: String? = null,
+    val pdfUrl: String? = null,
+)
+
+/**
+ * Pull the canonical arXiv id out of a `<id>` URL. arXiv emits ids like
+ *  - `http://arxiv.org/abs/2401.12345v1` (post-2007 new-style)
+ *  - `http://arxiv.org/abs/cs/0703021v1` (pre-2007 archive-style with
+ *    a slash in the id)
+ *
+ * Strips the version suffix (`v1`, `v2`, ...) — the abstract page
+ * resolves bare id → latest revision automatically. Returns "" on
+ * inputs that don't look like an arXiv abs URL so the parser drops
+ * them from the result list.
+ */
+internal fun extractArxivId(idUrl: String): String {
+    if (idUrl.isBlank()) return ""
+    val tail = idUrl.substringAfter("/abs/", missingDelimiterValue = "")
+    if (tail.isEmpty()) return ""
+    // Strip trailing version suffix; keep any slash in archive-style ids.
+    return tail.replace(Regex("v\\d+$"), "")
+}
+
+private val WHITESPACE_RE = Regex("""\s+""")
+
+/** Atom titles / summaries arrive multi-line with leading indentation; collapse. */
+internal fun String.collapseWhitespace(): String =
+    WHITESPACE_RE.replace(trim(), " ")
+
+/** Decode the half-dozen XML entities arXiv actually emits in titles/summaries. */
+internal fun decodeXmlEntities(text: String): String =
+    text
+        .replace("&lt;", "<")
+        .replace("&gt;", ">")
+        .replace("&quot;", "\"")
+        .replace("&apos;", "'")
+        .replace("&#39;", "'")
+        .replace("&amp;", "&")

--- a/source-arxiv/src/test/kotlin/in/jphe/storyvox/source/arxiv/ArxivAbstractParserTest.kt
+++ b/source-arxiv/src/test/kotlin/in/jphe/storyvox/source/arxiv/ArxivAbstractParserTest.kt
@@ -1,0 +1,106 @@
+package `in`.jphe.storyvox.source.arxiv
+
+import `in`.jphe.storyvox.source.arxiv.net.ArxivAbstractParser
+import `in`.jphe.storyvox.source.arxiv.net.formatAuthors
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * Issue #378 — pins the abstract-page parser against a real-shaped
+ * `arxiv.org/abs/<id>` fixture. The fixture lives at
+ * `src/test/resources/abs-fixture.html` so the parser is exercised
+ * against meta-tag + fallback-block paths the way arXiv actually
+ * emits them. A silent change in the citation_* meta-tag contract
+ * surfaces here at CI.
+ */
+class ArxivAbstractParserTest {
+
+    private val fixture: String = readFixture("abs-fixture.html")
+
+    @Test
+    fun `parses title, authors, abstract, subjects, and comments`() {
+        val parsed = ArxivAbstractParser.parse(fixture)
+        assertEquals("Attention Is All You Need", parsed.title)
+        // 8 authors in document order — citation_author meta tags drive
+        // the order; the `<div class="authors">` HTML block is a fallback.
+        assertEquals(8, parsed.authors.size)
+        assertEquals("Vaswani, Ashish", parsed.authors.first())
+        assertEquals("Polosukhin, Illia", parsed.authors.last())
+        // Abstract begins with the canonical line; whitespace collapses.
+        assertTrue(parsed.abstract.startsWith("The dominant sequence transduction models"))
+        // Subjects row preserves both primary and secondary entries.
+        assertTrue(parsed.subjects.contains("Computation and Language"))
+        assertTrue(parsed.subjects.contains("Machine Learning"))
+        // Comments row is optional; this fixture supplies it.
+        assertNotNull(parsed.comments)
+        assertTrue(parsed.comments!!.contains("NIPS 2017"))
+    }
+
+    @Test
+    fun `chapter html includes title byline subjects comments and abstract`() {
+        val parsed = ArxivAbstractParser.parse(fixture)
+        val html = ArxivAbstractParser.toChapterHtml(parsed)
+        assertTrue("title rendered", html.contains("<h2>Attention Is All You Need</h2>"))
+        assertTrue("byline rendered", html.contains("<em>by Vaswani, Ashish,"))
+        assertTrue("subjects rendered", html.contains("Subjects:"))
+        assertTrue("comments rendered", html.contains("NIPS 2017"))
+        assertTrue("abstract rendered", html.contains("Abstract."))
+        assertTrue("abstract body present", html.contains("Transformer"))
+    }
+
+    @Test
+    fun `chapter plain text reads as a narratable paragraph`() {
+        val parsed = ArxivAbstractParser.parse(fixture)
+        val plain = ArxivAbstractParser.toChapterPlain(parsed)
+        // Title on its own line so TTS gives it a pause.
+        assertTrue(plain.startsWith("Attention Is All You Need"))
+        // Byline reads as a natural sentence (not a comma-separated list).
+        assertTrue(plain.contains("by Vaswani, Ashish,"))
+        assertTrue(plain.contains("Subjects: "))
+        assertTrue(plain.contains("Abstract. The dominant sequence"))
+        // No raw HTML leaks through.
+        assertTrue("no `<` in plain output", !plain.contains("<"))
+        assertTrue("no `>` in plain output", !plain.contains(">"))
+    }
+
+    @Test
+    fun `formatAuthors handles zero, one, two, and many cases`() {
+        assertEquals("", formatAuthors(emptyList()))
+        assertEquals("Alice", formatAuthors(listOf("Alice")))
+        assertEquals("Alice and Bob", formatAuthors(listOf("Alice", "Bob")))
+        assertEquals(
+            "Alice, Bob, and Carol",
+            formatAuthors(listOf("Alice", "Bob", "Carol")),
+        )
+    }
+
+    @Test
+    fun `parse handles missing meta tags via block fallback`() {
+        // No citation_* meta tags at all — parser should fall through to
+        // the H1 / blockquote fallback path.
+        val noMeta = """
+            <html><body>
+              <h1 class="title mathjax"><span class="descriptor">Title:</span> Fallback Title</h1>
+              <blockquote class="abstract">
+                <span class="descriptor">Abstract:</span>
+                Fallback abstract body.
+              </blockquote>
+            </body></html>
+        """.trimIndent()
+        val parsed = ArxivAbstractParser.parse(noMeta)
+        assertEquals("Fallback Title", parsed.title)
+        assertTrue(parsed.abstract.startsWith("Fallback abstract body"))
+        assertTrue(parsed.authors.isEmpty())
+        // No comments row → nullable comments field stays null.
+        assertNull(parsed.comments)
+    }
+
+    private fun readFixture(name: String): String {
+        val stream = javaClass.classLoader!!.getResourceAsStream(name)
+            ?: error("Fixture not on test classpath: $name")
+        return stream.bufferedReader().use { it.readText() }
+    }
+}

--- a/source-arxiv/src/test/kotlin/in/jphe/storyvox/source/arxiv/ArxivApiUrlTest.kt
+++ b/source-arxiv/src/test/kotlin/in/jphe/storyvox/source/arxiv/ArxivApiUrlTest.kt
@@ -1,0 +1,67 @@
+package `in`.jphe.storyvox.source.arxiv
+
+import `in`.jphe.storyvox.source.arxiv.net.ArxivApi
+import `in`.jphe.storyvox.source.arxiv.net.composeRecentUrl
+import `in`.jphe.storyvox.source.arxiv.net.composeSearchUrl
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * Issue #378 — pins the URL composition for the two arXiv query
+ * surfaces. The constants live on [ArxivApi] (`QUERY_BASE`,
+ * `DEFAULT_CATEGORY`, `DEFAULT_PAGE_SIZE`); a quiet drift here would
+ * break the browse landing and search at CI time, which is exactly
+ * where we want a regression to surface.
+ */
+class ArxivApiUrlTest {
+
+    @Test
+    fun `composeRecentUrl defaults to cs_AI and 50 results`() {
+        val url = composeRecentUrl(category = ArxivApi.DEFAULT_CATEGORY)
+        // Pins the sort-order shape arXiv's user manual documents
+        // (https://info.arxiv.org/help/api/). URLEncoder leaves `:`
+        // alone since it's an unreserved sub-delim in query strings;
+        // arXiv accepts both `cat:` and `cat%3A`.
+        assertEquals(
+            "http://export.arxiv.org/api/query" +
+                "?search_query=cat:cs.AI" +
+                "&sortBy=submittedDate&sortOrder=descending" +
+                "&start=0&max_results=50",
+            url,
+        )
+    }
+
+    @Test
+    fun `composeRecentUrl paginates with start offset`() {
+        val url = composeRecentUrl(category = "cs.LG", start = 100, maxResults = 25)
+        assertTrue("starts with QUERY_BASE", url.startsWith(ArxivApi.QUERY_BASE))
+        assertTrue("category present", url.contains("search_query=cat:cs.LG"))
+        assertTrue("start offset wired", url.contains("&start=100"))
+        assertTrue("max_results override wired", url.contains("&max_results=25"))
+    }
+
+    @Test
+    fun `composeSearchUrl encodes the user term`() {
+        val url = composeSearchUrl(term = "attention is all you need")
+        // Spaces encode as `+` in URLEncoder default; arXiv accepts
+        // both `+` and `%20`. The `:` in the qualifier prefix stays
+        // literal — see [composeRecentUrl] test for the same call out.
+        assertEquals(
+            "http://export.arxiv.org/api/query" +
+                "?search_query=all:attention+is+all+you+need" +
+                "&sortBy=submittedDate&sortOrder=descending" +
+                "&start=0&max_results=50",
+            url,
+        )
+    }
+
+    @Test
+    fun `composeSearchUrl trims leading and trailing whitespace`() {
+        val url = composeSearchUrl(term = "  transformer  ")
+        assertTrue(url.contains("search_query=all:transformer&"))
+        // Internal sentinel check — the trimmed term doesn't leak a
+        // trailing encoded space into the URL.
+        assertTrue("no trailing space encoded", !url.contains("transformer+&"))
+    }
+}

--- a/source-arxiv/src/test/kotlin/in/jphe/storyvox/source/arxiv/ArxivAtomFeedTest.kt
+++ b/source-arxiv/src/test/kotlin/in/jphe/storyvox/source/arxiv/ArxivAtomFeedTest.kt
@@ -1,0 +1,120 @@
+package `in`.jphe.storyvox.source.arxiv
+
+import `in`.jphe.storyvox.source.arxiv.net.ArxivAtomFeed
+import `in`.jphe.storyvox.source.arxiv.net.extractArxivId
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * Issue #378 — pins the Atom-feed parser against the canonical shape
+ * arXiv emits from `export.arxiv.org/api/query`. Two-entry fixture
+ * covers the post-2007 new-style id (`2401.12345`) and the pre-2007
+ * archive-style id with embedded slash (`cs/0703021`). Both must
+ * round-trip through [extractArxivId] without losing the slash.
+ */
+class ArxivAtomFeedTest {
+
+    /**
+     * Two-entry feed. Author and category blocks repeat per entry;
+     * version suffixes (`v1`) on the `<id>` URL must be stripped by
+     * [extractArxivId].
+     */
+    private val twoEntryFeed = """
+        <?xml version="1.0" encoding="UTF-8"?>
+        <feed xmlns="http://www.w3.org/2005/Atom"
+              xmlns:opensearch="http://a9.com/-/spec/opensearch/1.1/">
+          <title>arXiv Query: cat:cs.AI</title>
+          <opensearch:totalResults>12345</opensearch:totalResults>
+          <opensearch:startIndex>0</opensearch:startIndex>
+          <opensearch:itemsPerPage>50</opensearch:itemsPerPage>
+          <entry>
+            <id>http://arxiv.org/abs/2401.12345v1</id>
+            <updated>2024-01-22T18:00:00Z</updated>
+            <published>2024-01-22T18:00:00Z</published>
+            <title>A Snappy Title About Transformers &amp; Attention</title>
+            <summary>
+              We propose a snappy new method for attention. It is good.
+              Multiple lines fold to one.
+            </summary>
+            <author><name>Alice Smith</name></author>
+            <author><name>Bob Jones</name></author>
+            <link rel="alternate" type="text/html" href="http://arxiv.org/abs/2401.12345v1"/>
+            <link title="pdf" rel="related" type="application/pdf"
+                  href="http://arxiv.org/pdf/2401.12345v1"/>
+            <category term="cs.AI" scheme="http://arxiv.org/schemas/atom"/>
+            <category term="cs.LG" scheme="http://arxiv.org/schemas/atom"/>
+          </entry>
+          <entry>
+            <id>http://arxiv.org/abs/cs/0703021v2</id>
+            <updated>2007-03-22T12:00:00Z</updated>
+            <title>An Old Archive-Style Paper</title>
+            <summary>A short paper from the cs/ archive era.</summary>
+            <author><name>Carol Tau</name></author>
+            <link rel="alternate" type="text/html" href="http://arxiv.org/abs/cs/0703021v2"/>
+            <category term="cs.DM" scheme="http://arxiv.org/schemas/atom"/>
+          </entry>
+        </feed>
+    """.trimIndent()
+
+    @Test
+    fun `parses both entries with stripped version suffixes`() {
+        val feed = ArxivAtomFeed.parse(twoEntryFeed)
+        assertEquals(2, feed.entries.size)
+        // totalResults from the opensearch extension survives the parse.
+        assertEquals(12345L, feed.totalResults)
+
+        val first = feed.entries[0]
+        assertEquals("2401.12345", first.arxivId)
+        // Title decodes XML entities and collapses internal whitespace.
+        assertEquals("A Snappy Title About Transformers & Attention", first.title)
+        // Multi-line summary collapses to one line.
+        assertTrue(first.summary.startsWith("We propose a snappy new method"))
+        assertTrue(first.summary.endsWith("fold to one."))
+        // Author list preserves document order.
+        assertEquals(listOf("Alice Smith", "Bob Jones"), first.authors)
+        // Categories captured in order.
+        assertEquals(listOf("cs.AI", "cs.LG"), first.categories)
+        assertEquals("http://arxiv.org/abs/2401.12345v1", first.absUrl)
+        assertEquals("http://arxiv.org/pdf/2401.12345v1", first.pdfUrl)
+
+        val second = feed.entries[1]
+        // Archive-style id with embedded slash survives.
+        assertEquals("cs/0703021", second.arxivId)
+        assertEquals("An Old Archive-Style Paper", second.title)
+        assertEquals(listOf("Carol Tau"), second.authors)
+        // PDF link absent on the second entry; nullable.
+        assertNull(second.pdfUrl)
+    }
+
+    @Test
+    fun `empty feed returns empty entry list without throwing`() {
+        val emptyFeed = """
+            <?xml version="1.0" encoding="UTF-8"?>
+            <feed xmlns="http://www.w3.org/2005/Atom">
+              <title>arXiv Query: cat:cs.zz.zz</title>
+              <opensearch:totalResults xmlns:opensearch="http://a9.com/-/spec/opensearch/1.1/">0</opensearch:totalResults>
+            </feed>
+        """.trimIndent()
+        val feed = ArxivAtomFeed.parse(emptyFeed)
+        assertTrue(feed.entries.isEmpty())
+        assertEquals(0L, feed.totalResults)
+    }
+
+    @Test
+    fun `extractArxivId handles new-style, archive-style, and malformed inputs`() {
+        // New-style with version
+        assertEquals("2401.12345", extractArxivId("http://arxiv.org/abs/2401.12345v1"))
+        // New-style without version
+        assertEquals("2401.12345", extractArxivId("http://arxiv.org/abs/2401.12345"))
+        // Archive-style with slash and version
+        assertEquals("cs/0703021", extractArxivId("http://arxiv.org/abs/cs/0703021v2"))
+        // Archive-style without version
+        assertEquals("math.AG/0307014", extractArxivId("http://arxiv.org/abs/math.AG/0307014"))
+        // Malformed — no /abs/ segment
+        assertEquals("", extractArxivId("http://arxiv.org/something-else"))
+        assertEquals("", extractArxivId(""))
+    }
+}

--- a/source-arxiv/src/test/resources/abs-fixture.html
+++ b/source-arxiv/src/test/resources/abs-fixture.html
@@ -1,0 +1,61 @@
+<!DOCTYPE html>
+<!-- Trimmed-but-verbatim fragment of an arxiv.org/abs/<id> page,
+     captured for ArxivAbstractParserTest. The full page is ~80kB of
+     navigation, related-papers panels, and MathJax bootstrap; only the
+     citation_* meta tags, the title block, and the abstract / subjects
+     / comments rows are exercised by the parser. -->
+<html lang="en">
+<head>
+  <meta charset="utf-8"/>
+  <meta name="citation_title" content="Attention Is All You Need"/>
+  <meta name="citation_author" content="Vaswani, Ashish"/>
+  <meta name="citation_author" content="Shazeer, Noam"/>
+  <meta name="citation_author" content="Parmar, Niki"/>
+  <meta name="citation_author" content="Uszkoreit, Jakob"/>
+  <meta name="citation_author" content="Jones, Llion"/>
+  <meta name="citation_author" content="Gomez, Aidan N."/>
+  <meta name="citation_author" content="Kaiser, Lukasz"/>
+  <meta name="citation_author" content="Polosukhin, Illia"/>
+  <meta name="citation_abstract" content="The dominant sequence transduction models are based on complex recurrent or convolutional neural networks that include an encoder and a decoder. The best performing models also connect the encoder and decoder through an attention mechanism. We propose a new simple network architecture, the Transformer, based solely on attention mechanisms, dispensing with recurrence and convolutions entirely."/>
+  <meta name="citation_arxiv_id" content="1706.03762"/>
+</head>
+<body>
+  <div id="content-inner">
+    <h1 class="title mathjax"><span class="descriptor">Title:</span> Attention Is All You Need</h1>
+    <div class="authors"><span class="descriptor">Authors:</span>
+      <a href="/a/vaswani_a_1.html">Ashish Vaswani</a>,
+      <a href="/a/shazeer_n_1.html">Noam Shazeer</a>,
+      <a href="/a/parmar_n_1.html">Niki Parmar</a>,
+      <a href="/a/uszkoreit_j_1.html">Jakob Uszkoreit</a>,
+      <a href="/a/jones_l_1.html">Llion Jones</a>,
+      <a href="/a/gomez_a_1.html">Aidan N. Gomez</a>,
+      <a href="/a/kaiser_l_1.html">Lukasz Kaiser</a>,
+      <a href="/a/polosukhin_i_1.html">Illia Polosukhin</a>
+    </div>
+    <blockquote class="abstract mathjax">
+      <span class="descriptor">Abstract:</span>
+      The dominant sequence transduction models are based on complex recurrent
+      or convolutional neural networks that include an encoder and a decoder.
+      The best performing models also connect the encoder and decoder through
+      an attention mechanism. We propose a new simple network architecture,
+      the Transformer, based solely on attention mechanisms, dispensing with
+      recurrence and convolutions entirely.
+    </blockquote>
+    <table summary="Additional metadata" class="tablecell">
+      <tbody>
+        <tr>
+          <td class="tablecell label">Comments:</td>
+          <td class="tablecell comments">15 pages, 5 figures. Published at NIPS 2017.</td>
+        </tr>
+        <tr>
+          <td class="tablecell label">Subjects:</td>
+          <td class="tablecell subjects">
+            <span class="primary-subject">Computation and Language (cs.CL)</span>;
+            Machine Learning (cs.LG)
+          </td>
+        </tr>
+      </tbody>
+    </table>
+  </div>
+</body>
+</html>


### PR DESCRIPTION
## Summary

Second non-fiction long-form backend after Wikipedia (#377). Each arXiv paper is one fiction with a single "Abstract" chapter (title + author byline + subjects + author comments + abstract paragraph) — JP's "morning digest of new AI papers" use case.

- New `:source-arxiv` module wired into `app/build.gradle.kts` + `settings.gradle.kts`. Uses the plugin seam from the start (`@SourcePlugin(id="arxiv", category=Text, supportsSearch=true)`) alongside the legacy `@IntoMap @StringKey("arxiv")` binding for the Phase 2 dual-wire pattern.
- Hand-rolled regex parsers for the Atom feed and the abstract page (same posture as `:source-standard-ebooks`' `SeHtmlParser`); 12 unit tests run on plain JUnit, no Robolectric needed.
- `SourceIds.ARXIV` constant + `sourceArxivEnabled = false` default + Settings → Library & Sync toggle row + `BrowseSourceKey.Arxiv` chip with Popular + Search tabs. Default landing category is `cs.AI`; full-PDF text extraction + category-picker UI are explicit follow-up scope cuts per #378's acceptance criteria.

Fiction id encoding: `arxiv:<arxiv-id>` (e.g. `arxiv:2401.12345`; archive-style ids with embedded slash like `arxiv:cs/0703021` are preserved). Version suffixes (`v1`, `v2`) are stripped — the abstract page resolves bare id → latest revision automatically.

## Test plan

- [x] `./gradlew :source-arxiv:testDebugUnitTest` — 12 tests, 0 failed
- [x] `./gradlew :app:assembleDebug` — Hilt graph healthy (no duplicate ids, KSP descriptor emitted)
- [x] `./gradlew testDebugUnitTest` — full app test suite green (no fakes left out)
- [ ] Manual install on R83W80CAFZB (deferred — sibling agents are in flight; orchestrator runs the device install post-bundle-merge per `feedback_install_test_each_iteration.md`)
- [ ] CI green (this PR holds for the bundle merge with Wikisource / HN / PLOS agents)

🤖 Generated with [Claude Code](https://claude.com/claude-code)