### PR TITLE
feat(source): PLOS backend (open-access peer-reviewed science) — closes #380

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -162,6 +162,7 @@ dependencies {
     implementation(project(":source-wikipedia"))
     implementation(project(":source-kvmr"))
     implementation(project(":source-notion"))
+    implementation(project(":source-plos"))
     implementation(project(":source-azure"))
     implementation(project(":core-sync"))
     implementation(project(":feature"))

--- a/app/src/main/kotlin/in/jphe/storyvox/data/SettingsRepositoryUiImpl.kt
+++ b/app/src/main/kotlin/in/jphe/storyvox/data/SettingsRepositoryUiImpl.kt
@@ -255,6 +255,11 @@ internal object LegacySourceKeys {
             Spec(booleanPreferencesKey("pref_source_kvmr_enabled"), defaultValue = true),
         `in`.jphe.storyvox.data.source.SourceIds.NOTION to
             Spec(booleanPreferencesKey("pref_source_notion_enabled"), defaultValue = true),
+        // #380 — PLOS open-access peer-reviewed science. Academic
+        // content is an opt-in surface; fresh installs ship with this
+        // off and the user flips it on from Settings.
+        `in`.jphe.storyvox.data.source.SourceIds.PLOS to
+            Spec(booleanPreferencesKey("pref_source_plos_enabled"), defaultValue = false),
     )
 }
 
@@ -367,6 +372,10 @@ private object Keys {
      *  AuthRequired on every call until the user pastes an integration
      *  token via Settings → Library & Sync → Notion. */
     val SOURCE_NOTION_ENABLED = booleanPreferencesKey("pref_source_notion_enabled")
+    /** Issue #380 — PLOS open-access peer-reviewed science backend
+     *  on/off. Default false for fresh installs; opt-in surface like
+     *  Wikipedia. */
+    val SOURCE_PLOS_ENABLED = booleanPreferencesKey("pref_source_plos_enabled")
 
     // ── Plugin-seam Phase 1 (#384) ────────────────────────────────
     /**
@@ -644,6 +653,7 @@ class SettingsRepositoryUiImpl(
             // until the user pastes an integration token. Existing
             // users with a stored preference keep it.
             sourceNotionEnabled = prefs[Keys.SOURCE_NOTION_ENABLED] ?: true,
+            sourcePlosEnabled = prefs[Keys.SOURCE_PLOS_ENABLED] ?: false,
             // Plugin-seam Phase 1 (#384) — derive the per-plugin map
             // from the JSON blob seeded by SourcePluginsMapMigration.
             // Empty map (parse error / missing key in a race) falls
@@ -1297,6 +1307,11 @@ class SettingsRepositoryUiImpl(
     override suspend fun setSourceNotionEnabled(enabled: Boolean) {
         store.edit { it[Keys.SOURCE_NOTION_ENABLED] = enabled }
         writePluginEnabledIntoMap(`in`.jphe.storyvox.data.source.SourceIds.NOTION, enabled)
+    }
+
+    override suspend fun setSourcePlosEnabled(enabled: Boolean) {
+        store.edit { it[Keys.SOURCE_PLOS_ENABLED] = enabled }
+        writePluginEnabledIntoMap(`in`.jphe.storyvox.data.source.SourceIds.PLOS, enabled)
     }
 
     /**

--- a/app/src/test/kotlin/in/jphe/storyvox/di/RealPlaybackControllerUiTest.kt
+++ b/app/src/test/kotlin/in/jphe/storyvox/di/RealPlaybackControllerUiTest.kt
@@ -296,6 +296,7 @@ class RealPlaybackControllerUiTest {
         override suspend fun setWikipediaLanguageCode(code: String) = Unit
         override suspend fun setSourceKvmrEnabled(enabled: Boolean) = Unit
         override suspend fun setSourceNotionEnabled(enabled: Boolean) = Unit
+        override suspend fun setSourcePlosEnabled(enabled: Boolean) = Unit
         override suspend fun setSourcePluginEnabled(id: String, enabled: Boolean) = Unit
         override suspend fun setNotionDatabaseId(id: String) = Unit
         override suspend fun setNotionApiToken(token: String?) = Unit

--- a/core-data/src/main/kotlin/in/jphe/storyvox/data/source/SourceIds.kt
+++ b/core-data/src/main/kotlin/in/jphe/storyvox/data/source/SourceIds.kt
@@ -82,4 +82,13 @@ object SourceIds {
      *  surfaces TechEmpower content without configuration once the
      *  user supplies the integration token. */
     const val NOTION: String = "notion"
+    /** PLOS / Public Library of Science (#380) — open-access peer-
+     *  reviewed science. Each article is one fiction (DOI = id);
+     *  v1 renders the abstract + first ~3 body sections as a single
+     *  chapter. Same architectural seam as Wikipedia — Solr-backed
+     *  search API + per-article HTML pages, all CC-licensed content.
+     *  Default OFF on fresh installs (academic content is opt-in;
+     *  not what a fresh-install user expects in the picker until
+     *  they go looking for it). */
+    const val PLOS: String = "plos"
 }

--- a/feature/src/main/kotlin/in/jphe/storyvox/feature/api/UiContracts.kt
+++ b/feature/src/main/kotlin/in/jphe/storyvox/feature/api/UiContracts.kt
@@ -834,6 +834,11 @@ data class UiSettings(
      *  the source visible in Browse so the empty-state can teach the
      *  user about the one-paste configuration step. */
     val sourceNotionEnabled: Boolean = true,
+    /** PLOS open-access peer-reviewed science backend (#380). Default
+     *  OFF on fresh installs — academic content is an opt-in surface;
+     *  not what a fresh-install user expects in the picker until they
+     *  go looking for it. Same opt-in posture as Wikipedia. */
+    val sourcePlosEnabled: Boolean = false,
     /**
      * Plugin-seam Phase 1 (#384) — per-plugin on/off keyed by stable
      * plugin id ("kvmr", "royalroad", "notion", ...). Replaces the
@@ -1317,6 +1322,9 @@ interface SettingsRepositoryUi {
 
     /** Issue #233 — Notion fiction backend on/off + config. */
     suspend fun setSourceNotionEnabled(enabled: Boolean)
+    /** Issue #380 — PLOS open-access peer-reviewed science backend
+     *  on/off. */
+    suspend fun setSourcePlosEnabled(enabled: Boolean)
     /** Issue #233 — set the Notion database id the source queries.
      *  Both hyphenated UUID and compact 32-hex forms accepted; the
      *  impl normalizes whitespace. Empty falls back to the baked-in

--- a/feature/src/main/kotlin/in/jphe/storyvox/feature/browse/BrowseScreen.kt
+++ b/feature/src/main/kotlin/in/jphe/storyvox/feature/browse/BrowseScreen.kt
@@ -215,6 +215,10 @@ fun BrowseScreen(
                 // filter body via /databases/{id}/query is the
                 // follow-up.
                 BrowseSourceKey.Notion -> false
+                // #380 — PLOS v1 has no filter sheet; the per-journal
+                // picker is the obvious follow-up. Same shape as
+                // Wikipedia today.
+                BrowseSourceKey.Plos -> false
             }
             if (filterableSource) {
                 FilterButton(
@@ -236,6 +240,7 @@ fun BrowseScreen(
                         BrowseSourceKey.Wikipedia -> 0
                         BrowseSourceKey.Kvmr -> 0
                         BrowseSourceKey.Notion -> 0
+                        BrowseSourceKey.Plos -> 0
                     },
                     onClick = { showFilterSheet = true },
                 )
@@ -516,6 +521,9 @@ fun BrowseScreen(
             // #233 — Notion v1 has no filter sheet; the configured
             // database id IS the filter scope.
             BrowseSourceKey.Notion -> { showFilterSheet = false }
+            // #380 — PLOS has no filter sheet in v1; same shape as
+            // Wikipedia. Free-form Search covers discovery.
+            BrowseSourceKey.Plos -> { showFilterSheet = false }
         }
     }
 }
@@ -608,6 +616,7 @@ private fun searchHintForSource(sourceKey: BrowseSourceKey): String = when (sour
     BrowseSourceKey.Wikipedia -> "Search Wikipedia — narrate any article"
     BrowseSourceKey.Kvmr -> "Tune in to KVMR — live community radio from Nevada City"
     BrowseSourceKey.Notion -> "Search your configured Notion database"
+    BrowseSourceKey.Plos -> "Search PLOS open-access peer-reviewed science"
 }
 
 private val BrowseTab.label: String

--- a/feature/src/main/kotlin/in/jphe/storyvox/feature/browse/BrowseViewModel.kt
+++ b/feature/src/main/kotlin/in/jphe/storyvox/feature/browse/BrowseViewModel.kt
@@ -97,6 +97,13 @@ enum class BrowseSourceKey(val sourceId: String, val displayName: String) {
      *  content database id as the default — once the user pastes a token
      *  in Settings, Browse → Notion surfaces TechEmpower content. */
     Notion(SourceIds.NOTION, "Notion"),
+    /** PLOS (#380) — open-access peer-reviewed science. Each article
+     *  is one fiction (DOI = id); v1 renders the abstract + first
+     *  ~3 body sections as a single chapter. Same Solr-backed
+     *  discovery surface as Wikipedia's opensearch — Popular = recent
+     *  PLOS ONE articles by publication date, Search hits the same
+     *  endpoint with a free-form `q=` term. */
+    Plos(SourceIds.PLOS, "PLOS"),
 }
 
 /** Tabs that are meaningful for [source]. GitHub registry doesn't
@@ -212,6 +219,16 @@ fun BrowseSourceKey.supportedTabs(githubSignedIn: Boolean = false): List<BrowseT
     // NewReleases collapses to Popular because Notion's default
     // ordering is already recency. BestRated has no analogue.
     BrowseSourceKey.Notion -> listOf(
+        BrowseTab.Popular,
+        BrowseTab.Search,
+    )
+    // PLOS (#380): Popular = `api.plos.org/search?q=*:*&fq=journal_key:PLOSONE
+    // &sort=publication_date+desc` — recent PLOS ONE articles. Search
+    // hits the same Solr endpoint with the user's free-form `q=`.
+    // BestRated / NewReleases collapse into Popular (publication-date
+    // desc IS the new-releases view, and PLOS doesn't expose a
+    // citation-count facet worth surfacing).
+    BrowseSourceKey.Plos -> listOf(
         BrowseTab.Popular,
         BrowseTab.Search,
     )
@@ -424,6 +441,7 @@ class BrowseViewModel @Inject constructor(
                     if (s.sourceWikipediaEnabled) add(BrowseSourceKey.Wikipedia)
                     if (s.sourceKvmrEnabled) add(BrowseSourceKey.Kvmr)
                     if (s.sourceNotionEnabled) add(BrowseSourceKey.Notion)
+                    if (s.sourcePlosEnabled) add(BrowseSourceKey.Plos)
                 }
             }
             .distinctUntilChanged()
@@ -697,6 +715,15 @@ class BrowseViewModel @Inject constructor(
                 _githubFilter.value = GitHubSearchFilter()
                 _palaceFilter.value = MemPalaceFilter()
             }
+            BrowseSourceKey.Plos -> {
+                // PLOS (#380) — Solr-backed catalog with no per-source
+                // filter sheet in v1; free-form Search covers
+                // discovery and Popular surfaces recent PLOS ONE.
+                // Same clear-siblings shape as Wikipedia.
+                _filter.value = BrowseFilter()
+                _githubFilter.value = GitHubSearchFilter()
+                _palaceFilter.value = MemPalaceFilter()
+            }
         }
     }
 
@@ -922,6 +949,16 @@ private fun resolveSource(
     // same first page in v1. Blank-search-with-blank-filter stays
     // null so the screen renders the SearchHint empty state.
     BrowseSourceKey.Notion -> when (tab) {
+        BrowseTab.Popular -> BrowseSource.Popular
+        BrowseTab.Search -> if (q.isBlank()) null else BrowseSource.Search(q)
+        else -> null
+    }
+    // PLOS (#380): Popular hits api.plos.org/search filtered to
+    // PLOS ONE sorted by publication date desc — the closest
+    // analogue to a "top stories" landing PLOS exposes. Search
+    // hits the same Solr endpoint with the user's free-form `q=`.
+    // No filter surface in v1.
+    BrowseSourceKey.Plos -> when (tab) {
         BrowseTab.Popular -> BrowseSource.Popular
         BrowseTab.Search -> if (q.isBlank()) null else BrowseSource.Search(q)
         else -> null

--- a/feature/src/main/kotlin/in/jphe/storyvox/feature/settings/SettingsScreen.kt
+++ b/feature/src/main/kotlin/in/jphe/storyvox/feature/settings/SettingsScreen.kt
@@ -580,6 +580,17 @@ fun SettingsScreen(
                     onApiTokenChange = viewModel::setNotionApiToken,
                 )
             }
+            // Issue #380 — PLOS open-access peer-reviewed science.
+            // Default OFF; academic content is opt-in. v1 renders the
+            // abstract + first ~3 body sections as a single chapter
+            // per article. Future PR splits on heading_1 boundaries
+            // into real per-section chapters.
+            SettingsSwitchRow(
+                title = "PLOS",
+                subtitle = "Open-access peer-reviewed science. Abstract plus the first body sections of each article — narratable in one sitting.",
+                checked = s.sourcePlosEnabled,
+                onCheckedChange = viewModel::setSourcePlosEnabled,
+            )
         }
 
         // ── Inbox notifications sub-card (#383) ────────────────────

--- a/feature/src/main/kotlin/in/jphe/storyvox/feature/settings/SettingsViewModel.kt
+++ b/feature/src/main/kotlin/in/jphe/storyvox/feature/settings/SettingsViewModel.kt
@@ -187,6 +187,10 @@ class SettingsViewModel @Inject constructor(
     /** Issue #233 — Notion backend on/off + config. */
     fun setSourceNotionEnabled(enabled: Boolean) =
         viewModelScope.launch { repo.setSourceNotionEnabled(enabled) }
+    /** Issue #380 — PLOS open-access peer-reviewed science backend
+     *  on/off. */
+    fun setSourcePlosEnabled(enabled: Boolean) =
+        viewModelScope.launch { repo.setSourcePlosEnabled(enabled) }
     fun setNotionDatabaseId(id: String) =
         viewModelScope.launch { repo.setNotionDatabaseId(id) }
     fun setNotionApiToken(token: String?) =

--- a/feature/src/test/kotlin/in/jphe/storyvox/feature/chat/ChatViewModelTest.kt
+++ b/feature/src/test/kotlin/in/jphe/storyvox/feature/chat/ChatViewModelTest.kt
@@ -584,6 +584,7 @@ private class FakeSettingsRepo(
         override suspend fun setWikipediaLanguageCode(code: String) = Unit
         override suspend fun setSourceKvmrEnabled(enabled: Boolean) = Unit
         override suspend fun setSourceNotionEnabled(enabled: Boolean) = Unit
+        override suspend fun setSourcePlosEnabled(enabled: Boolean) = Unit
         override suspend fun setSourcePluginEnabled(id: String, enabled: Boolean) = Unit
         override suspend fun setNotionDatabaseId(id: String) = Unit
         override suspend fun setNotionApiToken(token: String?) = Unit

--- a/feature/src/test/kotlin/in/jphe/storyvox/feature/settings/SettingsViewModelBufferTest.kt
+++ b/feature/src/test/kotlin/in/jphe/storyvox/feature/settings/SettingsViewModelBufferTest.kt
@@ -200,6 +200,7 @@ class SettingsViewModelBufferTest {
         override suspend fun setWikipediaLanguageCode(code: String) = Unit
         override suspend fun setSourceKvmrEnabled(enabled: Boolean) = Unit
         override suspend fun setSourceNotionEnabled(enabled: Boolean) = Unit
+        override suspend fun setSourcePlosEnabled(enabled: Boolean) = Unit
         override suspend fun setSourcePluginEnabled(id: String, enabled: Boolean) = Unit
         override suspend fun setNotionDatabaseId(id: String) = Unit
         override suspend fun setNotionApiToken(token: String?) = Unit

--- a/feature/src/test/kotlin/in/jphe/storyvox/feature/settings/SettingsViewModelModesTest.kt
+++ b/feature/src/test/kotlin/in/jphe/storyvox/feature/settings/SettingsViewModelModesTest.kt
@@ -275,6 +275,7 @@ class SettingsViewModelModesTest {
         override suspend fun setWikipediaLanguageCode(code: String) = Unit
         override suspend fun setSourceKvmrEnabled(enabled: Boolean) = Unit
         override suspend fun setSourceNotionEnabled(enabled: Boolean) = Unit
+        override suspend fun setSourcePlosEnabled(enabled: Boolean) = Unit
         override suspend fun setSourcePluginEnabled(id: String, enabled: Boolean) = Unit
         override suspend fun setNotionDatabaseId(id: String) = Unit
         override suspend fun setNotionApiToken(token: String?) = Unit

--- a/feature/src/test/kotlin/in/jphe/storyvox/feature/settings/SettingsViewModelPunctuationPauseTest.kt
+++ b/feature/src/test/kotlin/in/jphe/storyvox/feature/settings/SettingsViewModelPunctuationPauseTest.kt
@@ -213,6 +213,7 @@ class SettingsViewModelPunctuationPauseTest {
         override suspend fun setWikipediaLanguageCode(code: String) = Unit
         override suspend fun setSourceKvmrEnabled(enabled: Boolean) = Unit
         override suspend fun setSourceNotionEnabled(enabled: Boolean) = Unit
+        override suspend fun setSourcePlosEnabled(enabled: Boolean) = Unit
         override suspend fun setSourcePluginEnabled(id: String, enabled: Boolean) = Unit
         override suspend fun setNotionDatabaseId(id: String) = Unit
         override suspend fun setNotionApiToken(token: String?) = Unit

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -56,5 +56,9 @@ include(":source-standard-ebooks")
 include(":source-wikipedia")
 include(":source-kvmr")
 include(":source-notion")
+// Issue #380 — PLOS (Public Library of Science). Open-access
+// peer-reviewed science backend; Solr-backed search API + per-
+// article HTML pages. Same architectural seam as :source-wikipedia.
+include(":source-plos")
 include(":core-sync")
 include(":feature")

--- a/source-plos/build.gradle.kts
+++ b/source-plos/build.gradle.kts
@@ -1,0 +1,45 @@
+plugins {
+    alias(libs.plugins.android.library)
+    alias(libs.plugins.kotlin.android)
+    alias(libs.plugins.ksp)
+    alias(libs.plugins.hilt)
+    alias(libs.plugins.kotlin.serialization)
+}
+
+android {
+    namespace = "in.jphe.storyvox.source.plos"
+    compileSdk = 35
+
+    defaultConfig {
+        minSdk = 26
+    }
+
+    compileOptions {
+        sourceCompatibility = JavaVersion.VERSION_17
+        targetCompatibility = JavaVersion.VERSION_17
+    }
+
+    kotlinOptions {
+        jvmTarget = "17"
+    }
+}
+
+dependencies {
+    implementation(project(":core-data"))
+    implementation(libs.kotlinx.coroutines.android)
+    implementation(libs.kotlinx.serialization.json)
+    implementation(libs.okhttp)
+    implementation(libs.okhttp.logging)
+
+    implementation(libs.hilt.android)
+    ksp(libs.hilt.compiler)
+
+    // Plugin-seam Phase 2 (#384) — emits the @SourcePlugin → @IntoSet
+    // SourcePluginDescriptor Hilt module for PlosSource. Parallel
+    // @IntoMap binding still lives in di/PlosModule.kt; both bind
+    // sites co-exist while Phase 3 finishes consolidating callers.
+    ksp(project(":core-plugin-ksp"))
+
+    testImplementation(libs.junit)
+    testImplementation(libs.kotlinx.coroutines.test)
+}

--- a/source-plos/src/main/kotlin/in/jphe/storyvox/source/plos/PlosSource.kt
+++ b/source-plos/src/main/kotlin/in/jphe/storyvox/source/plos/PlosSource.kt
@@ -1,0 +1,502 @@
+package `in`.jphe.storyvox.source.plos
+
+import `in`.jphe.storyvox.data.source.FictionSource
+import `in`.jphe.storyvox.data.source.SourceIds
+import `in`.jphe.storyvox.data.source.model.ChapterContent
+import `in`.jphe.storyvox.data.source.model.ChapterInfo
+import `in`.jphe.storyvox.data.source.model.FictionDetail
+import `in`.jphe.storyvox.data.source.model.FictionResult
+import `in`.jphe.storyvox.data.source.model.FictionStatus
+import `in`.jphe.storyvox.data.source.model.FictionSummary
+import `in`.jphe.storyvox.data.source.model.ListPage
+import `in`.jphe.storyvox.data.source.model.SearchQuery
+import `in`.jphe.storyvox.data.source.model.map
+import `in`.jphe.storyvox.data.source.plugin.SourceCategory
+import `in`.jphe.storyvox.data.source.plugin.SourcePlugin
+import `in`.jphe.storyvox.source.plos.net.PlosApi
+import `in`.jphe.storyvox.source.plos.net.PlosArticleHit
+import javax.inject.Inject
+import javax.inject.Singleton
+
+/**
+ * Issue #380 — PLOS (Public Library of Science) as a fiction backend.
+ *
+ * PLOS publishes open-access peer-reviewed science across seven
+ * journals (PLOS ONE, PLOS Biology, PLOS Medicine, PLOS Computational
+ * Biology, PLOS Genetics, PLOS Pathogens, PLOS Neglected Tropical
+ * Diseases). Every article is released under a Creative Commons
+ * license (CC-BY 4.0 in modern years) — about as open as scholarly
+ * content gets. Same legal posture as Standard Ebooks / Gutenberg /
+ * Wikipedia: a content backend where the source's own license is the
+ * permission slip; no scraping required because PLOS publishes a
+ * documented JSON search API.
+ *
+ * Mapping (v1):
+ *
+ *  - Each article is one [FictionSummary]. The article-id is the DOI
+ *    (Digital Object Identifier), e.g. `10.1371/journal.pone.0123456`.
+ *  - Each article has **one chapter** in v1. The chapter body is the
+ *    article's abstract + the first ~3 body sections (Introduction,
+ *    Methods, Results — or whatever the first three top-level
+ *    `<h2>`-bounded sections happen to be in the article's HTML).
+ *    Splitting on `heading_1` boundaries into multiple chapters lands
+ *    in a follow-up PR; v1 keeps the chapter count predictable.
+ *
+ * Discovery shape:
+ *
+ *  - **popular()** — no global "top stories" exists; we surface recent
+ *    articles in PLOS ONE sorted by publication_date desc, which is
+ *    the closest thing PLOS has to a landing page. PLOS ONE alone
+ *    publishes ~200 articles/day so the result feels fresh.
+ *  - **search()** — same Solr endpoint, free-form query.
+ *  - **latestUpdates()** — collapses to popular() since the recent-PLOS-ONE
+ *    listing already IS the new-releases view.
+ *  - **byGenre()** — out of scope for v1; the genre concept maps to
+ *    "journal" here and the seven-journal set is small enough to land
+ *    as a filter sheet in a follow-up rather than a flat genre row.
+ *
+ * Fiction IDs: `plos:<DOI>`. The DOI is URL-safe-ish (carries `/` and
+ * `.`) so we keep it as-is in the id; the chapter id appends
+ * `::body` so the same id-shape pattern as Wikipedia / Notion holds.
+ *
+ * Same architectural seam as :source-wikipedia — OkHttp + kotlinx
+ * serialization, all calls public + read-only, no auth.
+ */
+@SourcePlugin(
+    id = SourceIds.PLOS,
+    displayName = "PLOS",
+    defaultEnabled = false,
+    category = SourceCategory.Text,
+    supportsFollow = false,
+    supportsSearch = true,
+)
+@Singleton
+internal class PlosSource @Inject constructor(
+    private val api: PlosApi,
+) : FictionSource {
+
+    override val id: String = SourceIds.PLOS
+    override val displayName: String = "PLOS"
+
+    // ─── browse ────────────────────────────────────────────────────────
+
+    override suspend fun popular(page: Int): FictionResult<ListPage<FictionSummary>> {
+        // PLOS Search supports an explicit start/rows pagination pair.
+        // We page in 50-row windows so a single Browse pull surfaces a
+        // good chunk of recent articles; hasNext is true while the
+        // backend returns a full page.
+        val rows = ROWS_PER_PAGE
+        val start = (page - 1).coerceAtLeast(0) * rows
+        return api.searchRecent(start = start, rows = rows).map { resp ->
+            val items = resp.response.docs.mapNotNull { it.toSummary() }
+            ListPage(
+                items = items,
+                page = page,
+                hasNext = items.size >= rows,
+            )
+        }
+    }
+
+    override suspend fun latestUpdates(page: Int): FictionResult<ListPage<FictionSummary>> =
+        // PLOS doesn't separate "most-read" from "newest"; the
+        // popular() listing is already publication-date desc.
+        popular(page)
+
+    override suspend fun byGenre(
+        genre: String,
+        page: Int,
+    ): FictionResult<ListPage<FictionSummary>> =
+        // v1: no genre concept surfaced. Follow-up PR adds the
+        // per-journal filter and routes journal_key → here.
+        FictionResult.Success(ListPage(items = emptyList(), page = 1, hasNext = false))
+
+    override suspend fun genres(): FictionResult<List<String>> =
+        FictionResult.Success(emptyList())
+
+    override suspend fun search(query: SearchQuery): FictionResult<ListPage<FictionSummary>> {
+        val term = query.term.trim()
+        if (term.isEmpty()) return popular(1)
+        val rows = ROWS_PER_PAGE
+        val start = (query.page - 1).coerceAtLeast(0) * rows
+        return api.searchQuery(term = term, start = start, rows = rows).map { resp ->
+            val items = resp.response.docs.mapNotNull { it.toSummary() }
+            ListPage(
+                items = items,
+                page = query.page.coerceAtLeast(1),
+                hasNext = items.size >= rows,
+            )
+        }
+    }
+
+    // ─── detail ────────────────────────────────────────────────────────
+
+    override suspend fun fictionDetail(fictionId: String): FictionResult<FictionDetail> {
+        val doi = fictionId.toPlosDoi()
+            ?: return FictionResult.NotFound("PLOS fiction id not recognized: $fictionId")
+        // Best-effort metadata via the search API filtered to this DOI —
+        // the Solr endpoint will hand back the single matching doc with
+        // title/author/abstract populated, which is cheaper than parsing
+        // the full article HTML twice (once for the preview card, once
+        // for the chapter body).
+        val metaResult = api.fetchByDoi(doi)
+        val meta = when (metaResult) {
+            is FictionResult.Success -> metaResult.value.response.docs.firstOrNull()
+            is FictionResult.Failure -> return metaResult
+        }
+        val summary = meta?.toSummary()?.copy(chapterCount = 1)
+            ?: FictionSummary(
+                id = fictionId,
+                sourceId = SourceIds.PLOS,
+                title = doi,
+                author = "PLOS",
+                description = null,
+                status = FictionStatus.COMPLETED,
+                chapterCount = 1,
+            )
+        val chapter = ChapterInfo(
+            id = chapterIdFor(fictionId),
+            sourceChapterId = BODY_CHAPTER_KEY,
+            index = 0,
+            title = "Article",
+            publishedAt = null,
+        )
+        return FictionResult.Success(FictionDetail(summary = summary, chapters = listOf(chapter)))
+    }
+
+    override suspend fun chapter(
+        fictionId: String,
+        chapterId: String,
+    ): FictionResult<ChapterContent> {
+        val doi = fictionId.toPlosDoi()
+            ?: return FictionResult.NotFound("PLOS fiction id not recognized: $fictionId")
+        if (!chapterId.endsWith("::$BODY_CHAPTER_KEY")) {
+            return FictionResult.NotFound("PLOS chapter id not recognized: $chapterId")
+        }
+        // Pull both abstract (cheap, structured Solr) and article HTML
+        // (the body sections). Abstract failure is non-fatal because the
+        // HTML body usually carries an abstract paragraph at the top
+        // anyway; HTML failure IS fatal — without it we have no chapter
+        // content to render.
+        val metaDoc = (api.fetchByDoi(doi) as? FictionResult.Success)
+            ?.value?.response?.docs?.firstOrNull()
+        val articleUrl = articleUrlForDoi(doi, metaDoc?.journal ?: DEFAULT_JOURNAL_SLUG)
+        val htmlResult = api.fetchArticleHtml(articleUrl)
+        val html = when (htmlResult) {
+            is FictionResult.Success -> htmlResult.value
+            is FictionResult.Failure -> return htmlResult
+        }
+        val body = extractArticleBody(
+            html = html,
+            abstract = metaDoc?.abstract?.firstOrNull(),
+            maxSections = MAX_BODY_SECTIONS,
+        )
+        val info = ChapterInfo(
+            id = chapterId,
+            sourceChapterId = BODY_CHAPTER_KEY,
+            index = 0,
+            title = metaDoc?.title ?: "Article",
+            publishedAt = null,
+        )
+        return FictionResult.Success(
+            ChapterContent(
+                info = info,
+                htmlBody = body.html,
+                plainBody = body.plain,
+            ),
+        )
+    }
+
+    // ─── auth-gated ─────────────────────────────────────────────────────
+
+    override suspend fun followsList(page: Int): FictionResult<ListPage<FictionSummary>> =
+        FictionResult.Success(ListPage(items = emptyList(), page = 1, hasNext = false))
+
+    override suspend fun setFollowed(
+        fictionId: String,
+        followed: Boolean,
+    ): FictionResult<Unit> = FictionResult.Success(Unit)
+
+    companion object {
+        internal const val ROWS_PER_PAGE: Int = 50
+        internal const val BODY_CHAPTER_KEY: String = "body"
+        internal const val DEFAULT_JOURNAL_SLUG: String = "plosone"
+        /** Soft cap on body sections rendered into the single v1
+         *  chapter. Three sections (Introduction + Methods + Results
+         *  or equivalent) is the sweet-spot length identified in #380:
+         *  long enough that listeners get the substantive content,
+         *  short enough that an hour-long Discussion section doesn't
+         *  blow up the chapter buffer. The split-into-real-chapters
+         *  follow-up rebuilds this on heading_1 boundaries. */
+        internal const val MAX_BODY_SECTIONS: Int = 3
+    }
+}
+
+// ─── helpers ──────────────────────────────────────────────────────────
+
+/** Compose a stable PLOS fiction id from a DOI. */
+internal fun plosFictionId(doi: String): String = "plos:" + doi.trim()
+
+/** Compose the single chapter id for an article: `plos:<doi>::body`. */
+internal fun chapterIdFor(fictionId: String): String = "${fictionId}::${PlosSource.BODY_CHAPTER_KEY}"
+
+/** Strip the `plos:` prefix and return the DOI; returns null on ids
+ *  that don't carry the prefix. Tolerates a trailing `::...` suffix
+ *  (chapter ids are passed through this same helper). */
+internal fun String.toPlosDoi(): String? =
+    if (startsWith("plos:")) removePrefix("plos:").substringBefore("::").ifBlank { null }
+    else null
+
+/**
+ * Map a PLOS DOI to its canonical article URL. DOIs at PLOS follow
+ * the pattern `10.1371/journal.<slug>.<id>` where `<slug>` identifies
+ * the journal (`pone` for PLOS ONE, `pbio` for PLOS Biology, ...).
+ * The article URL needs the journal's directory name on the
+ * journals.plos.org host, which doesn't quite match the DOI slug:
+ *
+ *  - `pone` → `plosone`
+ *  - `pbio` → `plosbiology`
+ *  - `pmed` → `plosmedicine`
+ *  - `pcbi` → `ploscompbiol`
+ *  - `pgen` → `plosgenetics`
+ *  - `ppat` → `plospathogens`
+ *  - `pntd` → `plosntds`
+ *
+ * The caller may pass a fallback [journalHint] (e.g. the `journal`
+ * field from the Solr response) when the DOI's slug isn't in our
+ * mapping table. If we can't pick a journal we fall back to PLOS ONE
+ * — the URL just emits a 404 in the unlikely case the article isn't
+ * actually there, and the fetch surfaces that as [FictionResult.NotFound].
+ */
+internal fun articleUrlForDoi(doi: String, journalHint: String? = null): String {
+    val slug = doi.substringAfter("journal.", "")
+        .substringBefore(".", "")
+        .takeIf { it.isNotBlank() }
+    val journalDir = when (slug) {
+        "pone" -> "plosone"
+        "pbio" -> "plosbiology"
+        "pmed" -> "plosmedicine"
+        "pcbi" -> "ploscompbiol"
+        "pgen" -> "plosgenetics"
+        "ppat" -> "plospathogens"
+        "pntd" -> "plosntds"
+        else -> journalHintToDir(journalHint) ?: "plosone"
+    }
+    // PLOS uses a query-string id rather than a path segment so the
+    // DOI's slash doesn't need URL-encoding.
+    return "https://journals.plos.org/$journalDir/article?id=$doi"
+}
+
+/** Best-effort fallback from the Solr `journal` field (e.g. "PLOS ONE",
+ *  "PLOS Biology") to the article-URL directory. Returns null if the
+ *  hint doesn't match anything we know about. */
+private fun journalHintToDir(hint: String?): String? {
+    if (hint.isNullOrBlank()) return null
+    val normalized = hint.lowercase().replace(Regex("[^a-z]"), "")
+    return when {
+        normalized.contains("plosone") -> "plosone"
+        normalized.contains("plosbiology") -> "plosbiology"
+        normalized.contains("plosmedicine") -> "plosmedicine"
+        normalized.contains("ploscompbiology") || normalized.contains("ploscomputationalbiology") -> "ploscompbiol"
+        normalized.contains("plosgenetics") -> "plosgenetics"
+        normalized.contains("plospathogens") -> "plospathogens"
+        normalized.contains("plosneglected") || normalized.contains("plosntd") -> "plosntds"
+        else -> null
+    }
+}
+
+private fun PlosArticleHit.toSummary(): FictionSummary? {
+    val doi = id?.trim()?.takeIf { it.isNotBlank() } ?: return null
+    return FictionSummary(
+        id = plosFictionId(doi),
+        sourceId = SourceIds.PLOS,
+        title = (title?.trim()?.takeIf { it.isNotBlank() } ?: doi).trimHtml(),
+        author = authorDisplay()?.takeIf { it.isNotBlank() } ?: "PLOS",
+        description = abstract?.firstOrNull()?.trim()?.takeIf { it.isNotBlank() }?.trimHtml(),
+        // Articles are published-once, not serialized — completed is
+        // the right shape (matches Gutenberg / Standard Ebooks).
+        status = FictionStatus.COMPLETED,
+    )
+}
+
+private fun PlosArticleHit.authorDisplay(): String? {
+    val list = authorDisplay ?: return null
+    if (list.isEmpty()) return null
+    return when {
+        list.size == 1 -> list.first()
+        list.size == 2 -> "${list[0]} and ${list[1]}"
+        else -> "${list.first()} et al."
+    }
+}
+
+private fun String.trimHtml(): String = htmlToPlainText().trim()
+
+// ─── article-body extraction ──────────────────────────────────────────
+
+internal data class PlosArticleBody(val html: String, val plain: String)
+
+/**
+ * Pull the abstract + first [maxSections] top-level body sections out
+ * of a PLOS article's HTML page. Returns one combined HTML/plain pair
+ * for the single v1 chapter.
+ *
+ * PLOS article pages render the JATS XML as semantic HTML with these
+ * landmarks:
+ *
+ *  - `<div class="abstract">...</div>` — the abstract (sometimes
+ *    `<div class="abstract abstract-type-abstract">`).
+ *  - `<div class="section" id="section1">...</div>` — body sections,
+ *    each opened by `<h2>` (Introduction, Methods, Results, ...).
+ *  - References, supplementary materials, author contributions live
+ *    below the body sections in their own divs we don't include.
+ *
+ * The combined output keeps the abstract first (so a TTS listener
+ * hears the punchline up-front), then the first [maxSections] body
+ * sections in document order, each with its `<h2>` heading preserved
+ * as an anchor.
+ *
+ * If neither abstract nor body sections are present, we fall back to
+ * a naive whole-page strip so the chapter is at least non-empty —
+ * better than a "Chapter body unavailable" empty state on a page that
+ * clearly has content, just in HTML the regex didn't recognize.
+ */
+internal fun extractArticleBody(
+    html: String,
+    abstract: String? = null,
+    maxSections: Int = PlosSource.MAX_BODY_SECTIONS,
+): PlosArticleBody {
+    val parts = mutableListOf<String>()
+    // Abstract — preferred source is the Solr-side `abstract` field
+    // (clean, no markup); fall back to the in-HTML abstract block.
+    val abstractHtml = abstract?.takeIf { it.isNotBlank() }?.let {
+        "<section><h2>Abstract</h2>${escapeInlineParagraphs(it)}</section>"
+    } ?: extractAbstractFromHtml(html)
+    if (abstractHtml != null) parts.add(abstractHtml)
+
+    // Body sections — each `<div class="section" id="sectionN">...`.
+    val sections = extractBodySections(html, maxSections)
+    parts.addAll(sections)
+
+    // Fallback: strip the whole page if we found nothing structured.
+    if (parts.isEmpty()) {
+        val raw = html.htmlToPlainText().trim()
+        return PlosArticleBody(html = raw, plain = raw)
+    }
+
+    val combinedHtml = parts.joinToString(separator = "\n")
+    return PlosArticleBody(
+        html = combinedHtml,
+        plain = combinedHtml.htmlToPlainText(),
+    )
+}
+
+/** Pull the first `<div class="abstract...">` block, if present. */
+private fun extractAbstractFromHtml(html: String): String? {
+    val re = Regex(
+        """<div\b[^>]*class="[^"]*\babstract\b[^"]*"[^>]*>(.*?)</div>""",
+        setOf(RegexOption.IGNORE_CASE, RegexOption.DOT_MATCHES_ALL),
+    )
+    val match = re.find(html) ?: return null
+    val inner = match.groupValues[1].trim()
+    if (inner.isBlank()) return null
+    return "<section><h2>Abstract</h2>$inner</section>"
+}
+
+/** Pull the first [max] `<div class="section" id="sectionN">` blocks,
+ *  in document order. */
+private fun extractBodySections(html: String, max: Int): List<String> {
+    if (max <= 0) return emptyList()
+    val opens = Regex(
+        """<div\b[^>]*class="[^"]*\bsection\b[^"]*"[^>]*>""",
+        RegexOption.IGNORE_CASE,
+    ).findAll(html).toList()
+    if (opens.isEmpty()) return emptyList()
+    val out = mutableListOf<String>()
+    for (open in opens) {
+        if (out.size >= max) break
+        val startIdx = open.range.last + 1
+        val endIdx = findMatchingClose(html, startIdx, "<div", "</div>")
+        if (endIdx < 0) continue
+        val sliced = html.substring(startIdx, endIdx).trim()
+        if (sliced.isNotBlank()) out.add("<section>$sliced</section>")
+    }
+    return out
+}
+
+/**
+ * Walk forward from [from] in [html] keeping a depth counter on
+ * [openMarker] / [closeMarker] occurrences and return the index of the
+ * `</...>` that closes the level the slice opened at. Returns -1 if
+ * the markers never balance (truncated input, unclosed div).
+ */
+private fun findMatchingClose(
+    html: String,
+    from: Int,
+    openMarker: String,
+    closeMarker: String,
+): Int {
+    var depth = 1
+    var i = from
+    while (i < html.length) {
+        val nextOpen = html.indexOf(openMarker, i, ignoreCase = true)
+        val nextClose = html.indexOf(closeMarker, i, ignoreCase = true)
+        if (nextClose < 0) return -1
+        if (nextOpen in 0 until nextClose) {
+            depth++
+            i = nextOpen + openMarker.length
+        } else {
+            depth--
+            if (depth == 0) return nextClose
+            i = nextClose + closeMarker.length
+        }
+    }
+    return -1
+}
+
+/** Wrap each newline-separated chunk of a plain-text abstract in
+ *  `<p>...</p>` so the renderer keeps paragraph breaks. PLOS sends
+ *  abstracts as a single string in Solr; the wire-side abstract from
+ *  HTML is already paragraphed. */
+private fun escapeInlineParagraphs(plain: String): String =
+    plain.split(Regex("\\n{2,}"))
+        .map { it.trim() }
+        .filter { it.isNotBlank() }
+        .joinToString(separator = "") { "<p>$it</p>" }
+
+/**
+ * Naive HTML → plain-text stripper. Same shape as the Wikipedia and
+ * Notion strippers — the TTS pipeline downstream handles sentence
+ * segmentation, abbreviation expansion, etc., so this only needs to
+ * drop tags and decode the half-dozen entities PLOS actually emits.
+ */
+internal fun String.htmlToPlainText(): String {
+    var out = this
+        .replace(Regex("<!--.*?-->", RegexOption.DOT_MATCHES_ALL), "")
+        .replace(
+            Regex("<script\\b.*?</script>", setOf(RegexOption.IGNORE_CASE, RegexOption.DOT_MATCHES_ALL)),
+            "",
+        )
+        .replace(
+            Regex("<style\\b.*?</style>", setOf(RegexOption.IGNORE_CASE, RegexOption.DOT_MATCHES_ALL)),
+            "",
+        )
+    out = out.replace(
+        Regex("</?(p|div|section|h[1-6]|li|tr|br)\\b[^>]*>", RegexOption.IGNORE_CASE),
+        "\n",
+    )
+    out = out.replace(Regex("<[^>]+>"), "")
+    out = out
+        .replace("&nbsp;", " ")
+        .replace("&amp;", "&")
+        .replace("&lt;", "<")
+        .replace("&gt;", ">")
+        .replace("&quot;", "\"")
+        .replace("&#39;", "'")
+        .replace("&apos;", "'")
+        .replace("&mdash;", "—")
+        .replace("&ndash;", "–")
+        .replace("&hellip;", "…")
+    out = out.replace(Regex("[ \\t]+"), " ")
+        .replace(Regex("\\n{3,}"), "\n\n")
+        .trim()
+    return out
+}

--- a/source-plos/src/main/kotlin/in/jphe/storyvox/source/plos/di/PlosModule.kt
+++ b/source-plos/src/main/kotlin/in/jphe/storyvox/source/plos/di/PlosModule.kt
@@ -1,0 +1,72 @@
+package `in`.jphe.storyvox.source.plos.di
+
+import dagger.Binds
+import dagger.Module
+import dagger.Provides
+import dagger.hilt.InstallIn
+import dagger.hilt.components.SingletonComponent
+import dagger.multibindings.IntoMap
+import dagger.multibindings.StringKey
+import `in`.jphe.storyvox.data.source.FictionSource
+import `in`.jphe.storyvox.data.source.SourceIds
+import `in`.jphe.storyvox.source.plos.PlosSource
+import `in`.jphe.storyvox.source.plos.net.PlosApi
+import okhttp3.OkHttpClient
+import java.util.concurrent.TimeUnit
+import javax.inject.Qualifier
+import javax.inject.Singleton
+
+@Qualifier
+@Retention(AnnotationRetention.BINARY)
+annotation class PlosHttp
+
+/**
+ * Dedicated OkHttp client for the PLOS API. Generous read timeout
+ * because the JATS-rendered article HTML pages can be 200kB-1MB for
+ * articles with lots of figures + supplementary refs; connect
+ * timeout stays tight because api.plos.org + journals.plos.org are
+ * reliably reachable on any reasonable connection.
+ */
+@Module
+@InstallIn(SingletonComponent::class)
+internal object PlosHttpModule {
+
+    @Provides
+    @Singleton
+    @PlosHttp
+    fun provideClient(): OkHttpClient =
+        OkHttpClient.Builder()
+            .connectTimeout(5, TimeUnit.SECONDS)
+            .readTimeout(30, TimeUnit.SECONDS)
+            .writeTimeout(15, TimeUnit.SECONDS)
+            .followRedirects(true)
+            .followSslRedirects(true)
+            .retryOnConnectionFailure(true)
+            .build()
+
+    @Provides
+    @Singleton
+    fun providePlosApi(@PlosHttp client: OkHttpClient): PlosApi = PlosApi(client)
+}
+
+/**
+ * Issue #380 — contributes [PlosSource] into the multi-source
+ * `Map<String, FictionSource>`. Adds a "PLOS" entry to the
+ * segmented source picker; persisted fictions with sourceId="plos"
+ * route through this source.
+ *
+ * The parallel `@SourcePlugin`-driven `@IntoSet` binding (Phase 2 of
+ * #384) is emitted by the KSP processor alongside this legacy
+ * `@IntoMap` binding. Phase 3 collapses to the registry-only shape;
+ * until then both bind sites coexist.
+ */
+@Module
+@InstallIn(SingletonComponent::class)
+internal abstract class PlosBindings {
+
+    @Binds
+    @Singleton
+    @IntoMap
+    @StringKey(SourceIds.PLOS)
+    abstract fun bindFictionSource(impl: PlosSource): FictionSource
+}

--- a/source-plos/src/main/kotlin/in/jphe/storyvox/source/plos/net/PlosApi.kt
+++ b/source-plos/src/main/kotlin/in/jphe/storyvox/source/plos/net/PlosApi.kt
@@ -1,0 +1,228 @@
+package `in`.jphe.storyvox.source.plos.net
+
+import `in`.jphe.storyvox.data.source.model.FictionResult
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.json.Json
+import okhttp3.OkHttpClient
+import okhttp3.Request
+import java.io.IOException
+import java.net.URLEncoder
+import javax.inject.Inject
+import javax.inject.Singleton
+import kotlin.time.Duration.Companion.seconds
+
+/**
+ * Issue #380 — minimal PLOS API client.
+ *
+ * Talks to two endpoints:
+ *
+ *  - **Solr search** — `https://api.plos.org/search?q=...&wt=json` —
+ *    drives both the Search tab (`q=<term>`) and the Popular tab
+ *    (`q=*:*&fq=journal_key:PLOSONE&sort=publication_date+desc`).
+ *    Solr is a tiered query API — pagination is `start` + `rows`
+ *    against the result window.
+ *  - **Article HTML page** — `journals.plos.org/<journal>/article?id=<doi>` —
+ *    used to pull the article body for the chapter renderer.
+ *
+ * The Solr API is anonymous + rate-limited at a generous per-IP
+ * threshold; we route every call through a single OkHttp client that
+ * carries an identifying `User-Agent` (per #380 acceptance "be a
+ * polite client"). PLOS doesn't publish a hard limit, but they
+ * publicly suggest no more than 7 requests / minute / IP sustained
+ * for bulk harvesting — well above what Browse can saturate.
+ *
+ * All endpoints are GET, public, no auth. Failures surface as
+ * [FictionResult.Failure] variants without leaking OkHttp / Solr-
+ * specific exceptions.
+ */
+@Singleton
+internal class PlosApi @Inject constructor(
+    private val client: OkHttpClient,
+) {
+    private val json = Json { ignoreUnknownKeys = true; isLenient = true }
+
+    // ─── search (Solr) ─────────────────────────────────────────────────
+
+    /**
+     * Recent articles in PLOS ONE — the Browse → Popular landing.
+     * PLOS doesn't expose a "top stories" feed; sorting PLOS ONE
+     * (their biggest journal by volume) by publication date desc
+     * gives a stable + fresh listing. `journal_key:PLOSONE` is the
+     * Solr-side filter for PLOS ONE specifically; the
+     * Solr-internal id is the all-caps form, not the URL slug.
+     */
+    suspend fun searchRecent(
+        start: Int = 0,
+        rows: Int = 50,
+    ): FictionResult<PlosSearchResponse> {
+        val url = "$BASE_SEARCH" +
+            "?q=" + URLEncoder.encode("*:*", "UTF-8") +
+            "&fq=" + URLEncoder.encode("journal_key:PLOSONE", "UTF-8") +
+            "&sort=" + URLEncoder.encode("publication_date desc", "UTF-8") +
+            "&start=$start" +
+            "&rows=$rows" +
+            "&fl=" + URLEncoder.encode(DEFAULT_FIELDS, "UTF-8") +
+            "&wt=json"
+        return getJson<PlosSearchResponse>(url)
+    }
+
+    /**
+     * Free-form search. Term is passed through to Solr's `q` parameter
+     * untouched (so Boolean operators like `AND` / `OR` and field-
+     * scoped queries like `title:climate` work as documented in the
+     * PLOS Search API spec). Results sort by relevance — caller's
+     * `start`/`rows` paginate.
+     */
+    suspend fun searchQuery(
+        term: String,
+        start: Int = 0,
+        rows: Int = 50,
+    ): FictionResult<PlosSearchResponse> {
+        val url = "$BASE_SEARCH" +
+            "?q=" + URLEncoder.encode(term, "UTF-8") +
+            "&start=$start" +
+            "&rows=$rows" +
+            "&fl=" + URLEncoder.encode(DEFAULT_FIELDS, "UTF-8") +
+            "&wt=json"
+        return getJson<PlosSearchResponse>(url)
+    }
+
+    /**
+     * Cheap one-doc fetch for a known DOI — drives [FictionDetail].
+     * Filtering on `id:<doi>` is the documented Solr way to pin a
+     * single article; the Solr `id` field IS the DOI in PLOS's index.
+     * The DOI string contains slashes and dots so we URL-encode the
+     * whole value.
+     */
+    suspend fun fetchByDoi(doi: String): FictionResult<PlosSearchResponse> {
+        val q = "id:\"$doi\""
+        val url = "$BASE_SEARCH" +
+            "?q=" + URLEncoder.encode(q, "UTF-8") +
+            "&rows=1" +
+            "&fl=" + URLEncoder.encode(DEFAULT_FIELDS, "UTF-8") +
+            "&wt=json"
+        return getJson<PlosSearchResponse>(url)
+    }
+
+    // ─── article HTML ─────────────────────────────────────────────────
+
+    /**
+     * Pull the article's HTML page. The caller composes the URL via
+     * [PlosSource]'s `articleUrlForDoi`; we just GET it as text so the
+     * source layer can slice the abstract + body sections.
+     */
+    suspend fun fetchArticleHtml(url: String): FictionResult<String> = getRaw(url)
+
+    // ─── transport ────────────────────────────────────────────────────
+
+    private suspend inline fun <reified T> getJson(url: String): FictionResult<T> =
+        when (val raw = getRaw(url)) {
+            is FictionResult.Success -> try {
+                FictionResult.Success(json.decodeFromString<T>(raw.value))
+            } catch (e: kotlinx.serialization.SerializationException) {
+                FictionResult.NetworkError("PLOS returned unexpected JSON shape", e)
+            }
+            is FictionResult.Failure -> raw
+        }
+
+    private fun getRaw(url: String): FictionResult<String> {
+        return try {
+            val req = Request.Builder()
+                .url(url)
+                .header("Accept", "application/json, text/html, */*")
+                .header("Accept-Language", "en")
+                .header("User-Agent", USER_AGENT)
+                .get()
+                .build()
+            client.newCall(req).execute().use { resp ->
+                when {
+                    resp.code == 404 ->
+                        FictionResult.NotFound("PLOS article or query not found")
+                    resp.code == 429 ->
+                        FictionResult.RateLimited(
+                            retryAfter = resp.header("Retry-After")
+                                ?.toLongOrNull()
+                                ?.seconds,
+                            message = "PLOS rate-limited the request",
+                        )
+                    !resp.isSuccessful ->
+                        FictionResult.NetworkError(
+                            "HTTP ${resp.code} from $url",
+                            IOException("HTTP ${resp.code}"),
+                        )
+                    else -> {
+                        val text = resp.body?.string()
+                            ?: return FictionResult.NetworkError("empty body", IOException("empty body"))
+                        FictionResult.Success(text)
+                    }
+                }
+            }
+        } catch (e: IOException) {
+            FictionResult.NetworkError(e.message ?: "fetch failed", e)
+        }
+    }
+
+    companion object {
+        /** PLOS Search API endpoint. Documented at
+         *  https://api.plos.org/solr/search-fields/ — Solr-backed, anonymous
+         *  GET, returns JSON with `wt=json`. */
+        const val BASE_SEARCH: String = "https://api.plos.org/search"
+
+        /** Subset of Solr fields we ask for in every search. Keeps the
+         *  response payload small (PLOS articles have ~100 fields total,
+         *  most of which we'd discard). `abstract` comes back as a
+         *  single-element array which we flatten on the source side. */
+        const val DEFAULT_FIELDS: String =
+            "id,title,abstract,author_display,journal,publication_date"
+
+        /** Polite-client User-Agent. PLOS doesn't strictly require it
+         *  (anonymous traffic works without one), but their public docs
+         *  ask harvesters to identify themselves so an op can reach out
+         *  if a client misbehaves. */
+        const val USER_AGENT: String =
+            "storyvox-plos/1.0 (https://github.com/jphein/storyvox; jp@jphein.com)"
+    }
+}
+
+// ─── wire types ───────────────────────────────────────────────────────
+
+/**
+ * Top-level Solr response shape. We keep only the `response` block
+ * (where the docs live) — `responseHeader` carries echoed query
+ * params and timing we don't need; `facet_counts` etc. only appear
+ * on facet queries (we don't issue any in v1).
+ */
+@Serializable
+internal data class PlosSearchResponse(
+    val response: PlosResponseBlock = PlosResponseBlock(),
+)
+
+@Serializable
+internal data class PlosResponseBlock(
+    val numFound: Int = 0,
+    val start: Int = 0,
+    val docs: List<PlosArticleHit> = emptyList(),
+)
+
+/**
+ * One article row from a Solr search response. PLOS exposes many
+ * more fields (subject, financial_disclosure, copyright, ...) but
+ * v1 only consumes the discovery essentials.
+ *
+ * The `abstract` field comes back as an array — Solr models the
+ * abstract as a multi-valued string field even though every doc
+ * has exactly one. We mirror that shape rather than trying to
+ * collapse on deserialization (kotlinx-serialization's "string OR
+ * array" is awkward; the source layer handles `.firstOrNull()`).
+ */
+@Serializable
+internal data class PlosArticleHit(
+    val id: String? = null,
+    val title: String? = null,
+    val abstract: List<String>? = null,
+    @kotlinx.serialization.SerialName("author_display")
+    val authorDisplay: List<String>? = null,
+    val journal: String? = null,
+    @kotlinx.serialization.SerialName("publication_date")
+    val publicationDate: String? = null,
+)

--- a/source-plos/src/test/kotlin/in/jphe/storyvox/source/plos/PlosSourceTest.kt
+++ b/source-plos/src/test/kotlin/in/jphe/storyvox/source/plos/PlosSourceTest.kt
@@ -1,0 +1,282 @@
+package `in`.jphe.storyvox.source.plos
+
+import `in`.jphe.storyvox.source.plos.net.PlosArticleHit
+import `in`.jphe.storyvox.source.plos.net.PlosResponseBlock
+import `in`.jphe.storyvox.source.plos.net.PlosSearchResponse
+import kotlinx.serialization.json.Json
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * Unit tests for the PLOS source (#380).
+ *
+ * Covers the three required surfaces:
+ *
+ *  1. Search JSON parses into [PlosSearchResponse] cleanly, even with
+ *     extra Solr fields we don't model.
+ *  2. Article HTML body extraction picks the right slices from a
+ *     representative PLOS article page fixture (abstract + first
+ *     three body sections; references etc. excluded).
+ *  3. DOI → article-URL composition handles the seven-journal slug
+ *     mapping correctly + falls back sensibly on unknown slugs.
+ */
+class PlosSourceTest {
+
+    private val json = Json { ignoreUnknownKeys = true; isLenient = true }
+
+    // ── 1. Search JSON parse ─────────────────────────────────────────
+
+    @Test
+    fun `parses representative PLOS search JSON`() {
+        // Real-shape Solr response — `responseHeader` and friends that
+        // we don't model are present so the parser has to honor
+        // ignoreUnknownKeys. `abstract` is the single-element array
+        // shape PLOS actually emits.
+        val raw = """
+            {
+              "responseHeader": { "status": 0, "QTime": 12 },
+              "response": {
+                "numFound": 1247,
+                "start": 0,
+                "docs": [
+                  {
+                    "id": "10.1371/journal.pone.0123456",
+                    "title": "On the migration of Arctic foxes",
+                    "abstract": ["Foxes migrate. We measured how far."],
+                    "author_display": ["Smith J", "Jones K", "Lee A"],
+                    "journal": "PLOS ONE",
+                    "publication_date": "2026-04-01T00:00:00Z"
+                  },
+                  {
+                    "id": "10.1371/journal.pbio.0099999",
+                    "title": "Crows count: evidence for numerical cognition",
+                    "abstract": ["Some crows can count."],
+                    "author_display": ["Park C"],
+                    "journal": "PLOS Biology",
+                    "publication_date": "2026-04-02T00:00:00Z"
+                  }
+                ]
+              }
+            }
+        """.trimIndent()
+        val parsed = json.decodeFromString<PlosSearchResponse>(raw)
+        assertEquals(1247, parsed.response.numFound)
+        assertEquals(2, parsed.response.docs.size)
+        val first = parsed.response.docs[0]
+        assertEquals("10.1371/journal.pone.0123456", first.id)
+        assertEquals("On the migration of Arctic foxes", first.title)
+        assertEquals(1, first.abstract?.size)
+        assertEquals(3, first.authorDisplay?.size)
+        assertEquals("PLOS ONE", first.journal)
+    }
+
+    @Test
+    fun `parses search response with missing optional fields`() {
+        // PLOS occasionally returns docs with no abstract (preprints,
+        // editorials) or no author_display (anonymous corrections).
+        // Both should deserialize as nulls rather than failing the
+        // whole batch.
+        val raw = """
+            {
+              "response": {
+                "numFound": 1,
+                "start": 0,
+                "docs": [
+                  { "id": "10.1371/journal.pone.0000001", "title": "Minimal doc" }
+                ]
+              }
+            }
+        """.trimIndent()
+        val parsed = json.decodeFromString<PlosSearchResponse>(raw)
+        assertEquals(1, parsed.response.docs.size)
+        assertEquals("10.1371/journal.pone.0000001", parsed.response.docs[0].id)
+        assertNull(parsed.response.docs[0].abstract)
+        assertNull(parsed.response.docs[0].authorDisplay)
+    }
+
+    // ── 2. Article HTML body extraction ──────────────────────────────
+
+    @Test
+    fun `extractArticleBody pulls abstract and first three sections`() {
+        // Minimal stand-in for a PLOS article page. The real article
+        // pages carry hundreds of nav/style/script tags around the
+        // landmark elements; the extractor only keys on the abstract
+        // div + section divs so this fixture exercises the same
+        // extraction path as a real fetch.
+        val html = """
+            <html><body>
+              <header>nav bar etc</header>
+              <article>
+                <div class="abstract abstract-type-abstract">
+                  <p>This is the abstract paragraph.</p>
+                </div>
+                <div class="section toc-section" id="section1">
+                  <h2>Introduction</h2>
+                  <p>Introduction prose.</p>
+                </div>
+                <div class="section toc-section" id="section2">
+                  <h2>Methods</h2>
+                  <p>Methods prose.</p>
+                </div>
+                <div class="section toc-section" id="section3">
+                  <h2>Results</h2>
+                  <p>Results prose.</p>
+                </div>
+                <div class="section toc-section" id="section4">
+                  <h2>Discussion</h2>
+                  <p>Discussion prose — should NOT appear in v1.</p>
+                </div>
+                <div class="section toc-section" id="section5">
+                  <h2>References</h2>
+                  <p>[1] cite cite cite</p>
+                </div>
+              </article>
+            </body></html>
+        """.trimIndent()
+
+        val body = extractArticleBody(html, abstract = null, maxSections = 3)
+        // Abstract present, first three sections present, fourth/fifth
+        // sections explicitly excluded.
+        assertTrue(body.html.contains("This is the abstract paragraph"))
+        assertTrue(body.plain.contains("Introduction prose"))
+        assertTrue(body.plain.contains("Methods prose"))
+        assertTrue(body.plain.contains("Results prose"))
+        assertFalse(body.plain.contains("Discussion prose"))
+        assertFalse(body.plain.contains("cite cite cite"))
+    }
+
+    @Test
+    fun `extractArticleBody prefers Solr abstract over HTML when supplied`() {
+        // Belt-and-braces: when the API hands back a clean
+        // Solr-side abstract (no HTML), we use it instead of the
+        // in-page abstract div. Avoids accidental double-rendering
+        // when the HTML abstract carries figure captions.
+        val html = """
+            <div class="abstract">
+              <p>HTML abstract — should NOT be used.</p>
+            </div>
+            <div class="section" id="section1"><h2>Intro</h2><p>Body.</p></div>
+        """.trimIndent()
+        val body = extractArticleBody(
+            html = html,
+            abstract = "Clean Solr abstract.",
+            maxSections = 1,
+        )
+        assertTrue(body.plain.contains("Clean Solr abstract"))
+        assertFalse(body.plain.contains("HTML abstract"))
+    }
+
+    @Test
+    fun `extractArticleBody falls back to whole-page strip when no landmarks`() {
+        // Articles with unrecognized markup shouldn't render an empty
+        // chapter — better to ship the whole-page text strip than a
+        // blank screen.
+        val html = "<html><body><p>No standard markup here, just prose.</p></body></html>"
+        val body = extractArticleBody(html)
+        assertTrue(body.plain.contains("No standard markup here"))
+    }
+
+    // ── 3. DOI → article URL composition ─────────────────────────────
+
+    @Test
+    fun `articleUrlForDoi maps each journal slug to the right directory`() {
+        // Spot-check every slug in the table. The DOI shape is
+        // `10.1371/journal.<slug>.<seq>` — slug determines the
+        // journals.plos.org directory.
+        assertEquals(
+            "https://journals.plos.org/plosone/article?id=10.1371/journal.pone.0123456",
+            articleUrlForDoi("10.1371/journal.pone.0123456"),
+        )
+        assertEquals(
+            "https://journals.plos.org/plosbiology/article?id=10.1371/journal.pbio.3000001",
+            articleUrlForDoi("10.1371/journal.pbio.3000001"),
+        )
+        assertEquals(
+            "https://journals.plos.org/plosmedicine/article?id=10.1371/journal.pmed.1000001",
+            articleUrlForDoi("10.1371/journal.pmed.1000001"),
+        )
+        assertEquals(
+            "https://journals.plos.org/ploscompbiol/article?id=10.1371/journal.pcbi.1000001",
+            articleUrlForDoi("10.1371/journal.pcbi.1000001"),
+        )
+        assertEquals(
+            "https://journals.plos.org/plosgenetics/article?id=10.1371/journal.pgen.1000001",
+            articleUrlForDoi("10.1371/journal.pgen.1000001"),
+        )
+        assertEquals(
+            "https://journals.plos.org/plospathogens/article?id=10.1371/journal.ppat.1000001",
+            articleUrlForDoi("10.1371/journal.ppat.1000001"),
+        )
+        assertEquals(
+            "https://journals.plos.org/plosntds/article?id=10.1371/journal.pntd.0001234",
+            articleUrlForDoi("10.1371/journal.pntd.0001234"),
+        )
+    }
+
+    @Test
+    fun `articleUrlForDoi falls back to PLOS ONE for unknown slug`() {
+        // A future journal we don't know about should still produce a
+        // URL — the worst case is a 404 surfaced as NotFound rather
+        // than a hard crash composing the URL.
+        val url = articleUrlForDoi("10.1371/journal.xxxx.0000001")
+        assertTrue(url.startsWith("https://journals.plos.org/plosone/"))
+        assertTrue(url.endsWith("?id=10.1371/journal.xxxx.0000001"))
+    }
+
+    @Test
+    fun `articleUrlForDoi honors the Solr journal hint when slug is unknown`() {
+        // When the DOI's slug is unfamiliar but the Solr `journal`
+        // field comes through, we should pick the matching directory
+        // from the human-readable journal name. Belt-and-braces for
+        // future journals before our slug table catches up.
+        val url = articleUrlForDoi(
+            doi = "10.1371/journal.xxxx.0000001",
+            journalHint = "PLOS Biology",
+        )
+        assertEquals(
+            "https://journals.plos.org/plosbiology/article?id=10.1371/journal.xxxx.0000001",
+            url,
+        )
+    }
+
+    // ── id round-trip + summary mapping ──────────────────────────────
+
+    @Test
+    fun `fictionId roundtrip preserves DOI`() {
+        val id = plosFictionId("10.1371/journal.pone.0123456")
+        assertEquals("plos:10.1371/journal.pone.0123456", id)
+        assertEquals("10.1371/journal.pone.0123456", id.toPlosDoi())
+        // Chapter id (with `::body` suffix) still resolves to the same
+        // DOI when run through the same parser — the chapter() entry
+        // point passes the fiction-id through toPlosDoi() and trims
+        // the suffix.
+        val chapter = chapterIdFor(id)
+        assertEquals("10.1371/journal.pone.0123456", chapter.toPlosDoi())
+    }
+
+    @Test
+    fun `toPlosDoi rejects ids without the plos prefix`() {
+        assertNull("wikipedia:Marie_Curie".toPlosDoi())
+        assertNull("plos:".toPlosDoi())
+        assertNotNull("plos:10.1371/journal.pone.0000001".toPlosDoi())
+    }
+
+    @Test
+    fun `htmlToPlainText strips PLOS-style markup`() {
+        val html = """
+            <article>
+              <h2>Methods</h2>
+              <p>We measured &mdash; carefully &mdash; the &alpha;-decay rate.</p>
+            </article>
+        """.trimIndent()
+        val plain = html.htmlToPlainText()
+        assertTrue(plain.contains("Methods"))
+        assertTrue(plain.contains("We measured — carefully — the"))
+        assertFalse(plain.contains("<p>"))
+        assertFalse(plain.contains("&mdash;"))
+    }
+}


### PR DESCRIPTION
## Summary

New `:source-plos` Gradle module surfaces PLOS (Public Library of Science) as a fiction backend. PLOS publishes ~200 articles/day across seven open-access journals (PLOS ONE / Biology / Medicine / Computational Biology / Genetics / Pathogens / Neglected Tropical Diseases) — all CC-licensed peer-reviewed science.

- Each article = one fiction (`plos:<DOI>` id). v1 renders the abstract + first ~3 body sections as a single chapter; per-section chapters via `heading_1` splits are a follow-up.
- Discovery via `api.plos.org/search` (Solr-backed JSON): Popular = recent PLOS ONE by publication date desc, Search = free-form `q=`. Article HTML pulled from `journals.plos.org/<journal>/article?id=<doi>`.
- Plugin seam from day one — `@SourcePlugin(id="plos", category=Text, supportsSearch=true)` + parallel `@IntoMap @StringKey("plos")` Hilt binding. Toggle row in Settings → Library & Sync, default OFF on fresh installs (academic content is opt-in, mirrors Wikipedia posture).

Closes #380. Same architectural seam as `:source-wikipedia` — OkHttp + kotlinx serialization, all calls public/read-only/no-auth.

## Test plan

- [x] 11 unit tests in `PlosSourceTest` (search JSON parse + missing-fields tolerance, article body extraction across well-formed + Solr-abstract-preferred + no-landmark-fallback fixtures, DOI→URL composition across all 7 journal slugs + journal-hint fallback + unknown-slug fallback, id round-trip, htmlToPlainText).
- [x] `./gradlew :source-plos:test` — green
- [x] `./gradlew :app:assembleDebug` — green
- [x] `./gradlew testDebugUnitTest` — full suite green
- [ ] CI green
- [ ] Manual smoke test on tablet (Browse → PLOS → Popular surfaces recent PLOS ONE; Search "climate" returns hits; tap → abstract + body renders).

Held for bundle merge with siblings per task instructions — please don't squash-merge until the parallel agents in the bundle land.

🤖 Generated with [Claude Code](https://claude.com/claude-code)