### PR TITLE
refactor(auth): inject @ApplicationScope into AuthRepository — closes #30

### DIFF
--- a/core-data/src/main/kotlin/in/jphe/storyvox/data/coroutines/ApplicationScope.kt
+++ b/core-data/src/main/kotlin/in/jphe/storyvox/data/coroutines/ApplicationScope.kt
@@ -1,0 +1,18 @@
+package `in`.jphe.storyvox.data.coroutines
+
+import javax.inject.Qualifier
+
+/**
+ * Distinguishes the singleton, app-lifetime [kotlinx.coroutines.CoroutineScope]
+ * from any other `CoroutineScope` someone might bind in the Hilt graph.
+ *
+ * The bound scope uses [kotlinx.coroutines.SupervisorJob] +
+ * [kotlinx.coroutines.Dispatchers.Default], so a thrown exception in one
+ * child coroutine doesn't kill the scope itself. Suitable for fire-and-forget
+ * hydrators on `@Singleton` repositories (e.g. [`in`.jphe.storyvox.data.repository.AuthRepositoryImpl]'s
+ * init block) that need structured concurrency but aren't tied to any
+ * viewmodel.
+ */
+@Qualifier
+@Retention(AnnotationRetention.BINARY)
+annotation class ApplicationScope

--- a/core-data/src/main/kotlin/in/jphe/storyvox/data/di/DataModule.kt
+++ b/core-data/src/main/kotlin/in/jphe/storyvox/data/di/DataModule.kt
@@ -11,7 +11,11 @@ import dagger.Provides
 import dagger.hilt.InstallIn
 import dagger.hilt.android.qualifiers.ApplicationContext
 import dagger.hilt.components.SingletonComponent
+import `in`.jphe.storyvox.data.coroutines.ApplicationScope
 import `in`.jphe.storyvox.data.db.StoryvoxDatabase
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
 import `in`.jphe.storyvox.data.db.dao.AuthDao
 import `in`.jphe.storyvox.data.db.dao.ChapterDao
 import `in`.jphe.storyvox.data.db.dao.ChapterHistoryDao
@@ -70,6 +74,23 @@ object DataModule {
     @Provides fun llmMessageDao(db: StoryvoxDatabase): LlmMessageDao = db.llmMessageDao()
     @Provides fun fictionShelfDao(db: StoryvoxDatabase): FictionShelfDao = db.fictionShelfDao()
     @Provides fun inboxEventDao(db: StoryvoxDatabase): InboxEventDao = db.inboxEventDao()
+
+    /**
+     * Long-lived [CoroutineScope] for singleton repositories that need to fire
+     * "init" coroutines outside the lifecycle of a viewmodel / Hilt component.
+     *
+     * - [SupervisorJob] means a child failure doesn't poison sibling children.
+     * - [Dispatchers.Default] is the safe default; consumers can override with
+     *   `withContext(Dispatchers.IO)` for blocking I/O. This avoids pinning a
+     *   whole-process scope to the IO pool.
+     * - Qualified with [ApplicationScope] so test doubles can swap in a
+     *   `TestScope` without colliding with other `CoroutineScope` bindings.
+     */
+    @Provides
+    @Singleton
+    @ApplicationScope
+    fun provideApplicationScope(): CoroutineScope =
+        CoroutineScope(SupervisorJob() + Dispatchers.Default)
 
     @Provides
     @Singleton

--- a/core-data/src/main/kotlin/in/jphe/storyvox/data/repository/AuthRepository.kt
+++ b/core-data/src/main/kotlin/in/jphe/storyvox/data/repository/AuthRepository.kt
@@ -2,6 +2,7 @@ package `in`.jphe.storyvox.data.repository
 
 import android.content.SharedPreferences
 import `in`.jphe.storyvox.data.auth.SessionState
+import `in`.jphe.storyvox.data.coroutines.ApplicationScope
 import `in`.jphe.storyvox.data.db.dao.AuthDao
 import `in`.jphe.storyvox.data.db.entity.AuthCookie
 import `in`.jphe.storyvox.data.source.FictionSource
@@ -55,6 +56,7 @@ class AuthRepositoryImpl @Inject constructor(
     private val dao: AuthDao,
     private val prefs: SharedPreferences,
     private val sources: Map<String, @JvmSuppressWildcards FictionSource>,
+    @ApplicationScope private val appScope: CoroutineScope,
 ) : AuthRepository {
 
     private val state = MutableStateFlow<SessionState>(SessionState.Anonymous)
@@ -88,14 +90,23 @@ class AuthRepositoryImpl @Inject constructor(
                 expiresAt = null,
                 userDisplayName = null,
             )
-            CoroutineScope(Dispatchers.IO).launch {
-                val row = dao.get(sourceId)
-                if (row != null) {
-                    state.value = SessionState.Authenticated(
-                        cookieHeader = cookie,
-                        expiresAt = row.expiresAt,
-                        userDisplayName = row.userDisplayName,
-                    )
+            // Hydrate the rest of the session metadata off the main thread.
+            // Routed through the injected @ApplicationScope (SupervisorJob +
+            // Dispatchers.Default) so:
+            //   - a throw from dao.get() doesn't poison sibling coroutines,
+            //   - the coroutine is part of a structured tree (cancellable in
+            //     tests and torn down with the process), and
+            //   - tests can swap a TestScope without mocking the global launch.
+            appScope.launch {
+                withContext(Dispatchers.IO) {
+                    val row = dao.get(sourceId)
+                    if (row != null) {
+                        state.value = SessionState.Authenticated(
+                            cookieHeader = cookie,
+                            expiresAt = row.expiresAt,
+                            userDisplayName = row.userDisplayName,
+                        )
+                    }
                 }
             }
         }


### PR DESCRIPTION
## Summary

Replaces the bare `CoroutineScope(Dispatchers.IO).launch { ... }` in `AuthRepositoryImpl.init` with an injected `@ApplicationScope CoroutineScope` from Hilt.

The scope is bound as `SupervisorJob + Dispatchers.Default` (so a child throw doesn't poison siblings), and the launch wraps blocking DAO work in `withContext(Dispatchers.IO)` — same I/O dispatcher behavior, structured-concurrency tree, swappable with a `TestScope` in unit tests.

## What changed

- New `@Qualifier` annotation `ApplicationScope` in `core-data/.../coroutines/`.
- New `@Provides @Singleton @ApplicationScope fun provideApplicationScope()` in `DataModule`.
- `AuthRepositoryImpl` adopts the new constructor parameter and uses `appScope.launch { withContext(IO) { ... } }` instead of the bare scope.

No behavioral change at runtime — `AuthRepositoryImpl` is `@Singleton`, the hydrator still runs exactly once on Hilt's first injection, same DAO calls on the same dispatcher.

## Why now

Captures the v1.0 hardening recommended in the issue body. Single-file mechanical refactor; safe to land before larger v1.0 prep starts.

## Test plan

- [x] `./gradlew :core-data:compileDebugKotlin` — clean
- [x] `./gradlew :core-data:testDebugUnitTest` — all green (existing migration + DAO + repo tests still pass with the new constructor parameter wired)
- [x] `./gradlew :app:assembleDebug` — full app builds; Hilt graph resolves

Closes #30.

🤖 Generated with [Claude Code](https://claude.com/claude-code)