### PR TITLE
feat(wear): Library Nocturne theme + circular scrubber on NowPlayingScreen — closes #192

### DIFF
--- a/wear/build.gradle.kts
+++ b/wear/build.gradle.kts
@@ -75,6 +75,13 @@ dependencies {
     // Compose
     implementation(platform(libs.androidx.compose.bom))
     implementation(libs.bundles.compose)
+    // Library Nocturne theme on Wear pulls EB Garamond + Inter from Google Fonts
+    // via GMS, same provider configured in :core-ui font_certs.xml.
+    implementation(libs.androidx.compose.ui.text.google.fonts)
+    // Coil — loads PlaybackState.coverUri inside the circular scrubber. Same
+    // version as the phone/tablet so a cover image already cached on the phone
+    // doesn't need a fresh decode on the watch.
+    implementation(libs.coil.compose)
     debugImplementation(libs.androidx.compose.ui.tooling)
 
     // Wear Compose

--- a/wear/src/main/kotlin/in/jphe/storyvox/wear/WearApp.kt
+++ b/wear/src/main/kotlin/in/jphe/storyvox/wear/WearApp.kt
@@ -9,6 +9,7 @@ import androidx.compose.runtime.remember
 import androidx.compose.ui.platform.LocalContext
 import `in`.jphe.storyvox.wear.playback.WearPlaybackBridge
 import `in`.jphe.storyvox.wear.screens.NowPlayingScreen
+import `in`.jphe.storyvox.wear.theme.WearLibraryNocturneTheme
 
 class WearMainActivity : ComponentActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
@@ -25,5 +26,7 @@ fun WearAppRoot() {
         bridge.start()
         onDispose { bridge.stop() }
     }
-    NowPlayingScreen(bridge = bridge)
+    WearLibraryNocturneTheme {
+        NowPlayingScreen(bridge = bridge)
+    }
 }

--- a/wear/src/main/kotlin/in/jphe/storyvox/wear/components/ChapterCover.kt
+++ b/wear/src/main/kotlin/in/jphe/storyvox/wear/components/ChapterCover.kt
@@ -1,0 +1,66 @@
+package `in`.jphe.storyvox.wear.components
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.sp
+import androidx.wear.compose.material.MaterialTheme
+import androidx.wear.compose.material.Text
+import coil.compose.AsyncImage
+import `in`.jphe.storyvox.ui.component.fictionMonogram
+import `in`.jphe.storyvox.wear.theme.BrassMuted
+import `in`.jphe.storyvox.wear.theme.BrassPrimary
+
+/**
+ * Chapter cover artwork — renders inside the circular scrubber.
+ *
+ * If [coverUri] is non-null we hand it to Coil's [AsyncImage]; otherwise we
+ * render the brass-on-warm-dark monogram (same `fictionMonogram` helper the
+ * phone/tablet uses — see issue #322 for the rationale on `✦` vs `?` as the
+ * final-fallback glyph).
+ *
+ * The cover is clipped to a circle so it nests cleanly inside the brass ring;
+ * on square Wear faces (rare) the call site can pass a rounded-rect modifier
+ * to override the clip.
+ */
+@Composable
+fun ChapterCover(
+    coverUri: String?,
+    title: String?,
+    author: String?,
+    modifier: Modifier = Modifier,
+) {
+    Box(
+        modifier = modifier
+            .clip(CircleShape)
+            .background(BrassMuted),
+        contentAlignment = Alignment.Center,
+    ) {
+        if (!coverUri.isNullOrBlank()) {
+            AsyncImage(
+                model = coverUri,
+                contentDescription = title?.let { "Cover for $it" } ?: "Chapter cover",
+                modifier = Modifier.fillMaxSize(),
+                contentScale = ContentScale.Crop,
+            )
+        } else {
+            Text(
+                text = fictionMonogram(
+                    author = author.orEmpty(),
+                    title = title.orEmpty(),
+                ),
+                color = BrassPrimary,
+                fontSize = 36.sp,
+                fontWeight = FontWeight.SemiBold,
+                style = MaterialTheme.typography.display1,
+            )
+        }
+    }
+}

--- a/wear/src/main/kotlin/in/jphe/storyvox/wear/components/CircularScrubber.kt
+++ b/wear/src/main/kotlin/in/jphe/storyvox/wear/components/CircularScrubber.kt
@@ -1,0 +1,74 @@
+package `in`.jphe.storyvox.wear.components
+
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.dp
+import androidx.wear.compose.material.CircularProgressIndicator
+import `in`.jphe.storyvox.wear.theme.BrassPrimary
+import `in`.jphe.storyvox.wear.theme.BrassRingTrack
+
+/**
+ * Circular brass scrubber for round Wear faces.
+ *
+ * The chapter cover art sits in the center, the brass ring wraps around it
+ * showing playback progress. Stroke width is deliberately chunky (6dp) so the
+ * brass reads at a glance from the wrist; ring track is the warm-dark outline
+ * variant so the unfilled portion still has presence.
+ *
+ * The touch-to-scrub overlay isn't implemented in v1 — wiring scrub commands
+ * back through `WearPlaybackBridge` needs a `CMD_SEEK` path on the bridge that
+ * doesn't exist yet. Filed as a follow-up; for now the ring is read-only.
+ * Touching the ring is reserved (no-op) so we don't accidentally swallow a
+ * swipe-to-dismiss gesture before the seek protocol lands.
+ *
+ * @param progress 0f..1f scrub position, typically from
+ *   [in.jphe.storyvox.playback.scrubProgress].
+ * @param indeterminate when true (buffering), animates a sweep around the ring
+ *   instead of a frozen progress arc — matches the phone's buffering spinner.
+ */
+@Composable
+fun CircularScrubber(
+    progress: Float,
+    modifier: Modifier = Modifier,
+    indeterminate: Boolean = false,
+    strokeWidth: Dp = 6.dp,
+    content: @Composable () -> Unit,
+) {
+    Box(modifier = modifier, contentAlignment = Alignment.Center) {
+        if (indeterminate) {
+            CircularProgressIndicator(
+                modifier = Modifier.fillMaxSize(),
+                indicatorColor = BrassPrimary,
+                trackColor = BrassRingTrack,
+                strokeWidth = strokeWidth,
+            )
+        } else {
+            CircularProgressIndicator(
+                progress = progress.coerceIn(0f, 1f),
+                modifier = Modifier.fillMaxSize(),
+                indicatorColor = BrassPrimary,
+                trackColor = BrassRingTrack,
+                strokeWidth = strokeWidth,
+                startAngle = 270f,
+            )
+        }
+        // Cover artwork sits inside the ring with a small inset so the brass
+        // doesn't visually graze the artwork edge.
+        Box(
+            modifier = Modifier
+                .padding(strokeWidth * 2)
+                .fillMaxSize()
+                .clip(CircleShape),
+            contentAlignment = Alignment.Center,
+        ) {
+            content()
+        }
+    }
+}

--- a/wear/src/main/kotlin/in/jphe/storyvox/wear/components/LinearScrubber.kt
+++ b/wear/src/main/kotlin/in/jphe/storyvox/wear/components/LinearScrubber.kt
@@ -1,0 +1,54 @@
+package `in`.jphe.storyvox.wear.components
+
+import androidx.compose.foundation.Canvas
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.graphics.StrokeCap
+import androidx.compose.ui.unit.dp
+import `in`.jphe.storyvox.wear.theme.BrassPrimary
+import `in`.jphe.storyvox.wear.theme.BrassRingTrack
+
+/**
+ * Brass-skinned linear progress for square Wear faces.
+ *
+ * Square watches are rare-but-supported per the issue; on these the circular
+ * ring around the cover art reads awkwardly inside the rectangular safe area.
+ * We fall back to a horizontal brass track. Read-only in v1 (touch-to-seek is
+ * a follow-up; same constraint as [CircularScrubber]).
+ */
+@Composable
+fun LinearScrubber(
+    progress: Float,
+    modifier: Modifier = Modifier,
+) {
+    val clamped = progress.coerceIn(0f, 1f)
+    Canvas(
+        modifier = modifier
+            .fillMaxWidth()
+            .height(4.dp),
+    ) {
+        val mid = size.height / 2f
+        val trackEnd = size.width
+        // Track
+        drawLine(
+            color = BrassRingTrack,
+            start = Offset(0f, mid),
+            end = Offset(trackEnd, mid),
+            strokeWidth = size.height,
+            cap = StrokeCap.Round,
+        )
+        // Filled portion
+        if (clamped > 0f) {
+            drawLine(
+                color = BrassPrimary,
+                start = Offset(0f, mid),
+                end = Offset(trackEnd * clamped, mid),
+                strokeWidth = size.height,
+                cap = StrokeCap.Round,
+            )
+        }
+    }
+}

--- a/wear/src/main/kotlin/in/jphe/storyvox/wear/components/TransportRow.kt
+++ b/wear/src/main/kotlin/in/jphe/storyvox/wear/components/TransportRow.kt
@@ -1,0 +1,99 @@
+package `in`.jphe.storyvox.wear.components
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.size
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Pause
+import androidx.compose.material.icons.filled.PlayArrow
+import androidx.compose.material.icons.filled.SkipNext
+import androidx.compose.material.icons.filled.SkipPrevious
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.unit.dp
+import androidx.wear.compose.material.Button
+import androidx.wear.compose.material.ButtonDefaults
+import androidx.wear.compose.material.Icon
+import `in`.jphe.storyvox.wear.theme.BrassMuted
+import `in`.jphe.storyvox.wear.theme.BrassPrimary
+import `in`.jphe.storyvox.wear.theme.WarmDarkSurface
+
+/**
+ * Brass transport controls — Skip Previous | Play/Pause | Skip Next.
+ *
+ * The center play/pause button is the "active" affordance and gets the full
+ * brass fill; flanking skip buttons get the muted brass tint so the eye lands
+ * on play/pause first. This mirrors the phone reader pattern where the active
+ * sentence carries the brass underline and surrounding text is muted.
+ *
+ * Skip buttons map to `CMD_SKIP_BACK` / `CMD_SKIP_FWD` (30s seek) rather than
+ * chapter nav — same defaults as the phone notification controls.
+ */
+@Composable
+fun TransportRow(
+    isPlaying: Boolean,
+    onPlayPause: () -> Unit,
+    onSkipBack: () -> Unit,
+    onSkipForward: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    Row(
+        modifier = modifier.fillMaxWidth(),
+        horizontalArrangement = Arrangement.SpaceEvenly,
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        TransportButton(
+            icon = Icons.Filled.SkipPrevious,
+            contentDescription = "Skip back 30 seconds",
+            onClick = onSkipBack,
+            isPrimary = false,
+        )
+        TransportButton(
+            icon = if (isPlaying) Icons.Filled.Pause else Icons.Filled.PlayArrow,
+            contentDescription = if (isPlaying) "Pause" else "Play",
+            onClick = onPlayPause,
+            isPrimary = true,
+        )
+        TransportButton(
+            icon = Icons.Filled.SkipNext,
+            contentDescription = "Skip forward 30 seconds",
+            onClick = onSkipForward,
+            isPrimary = false,
+        )
+    }
+}
+
+@Composable
+private fun TransportButton(
+    icon: ImageVector,
+    contentDescription: String,
+    onClick: () -> Unit,
+    isPrimary: Boolean,
+) {
+    val size = if (isPrimary) 44.dp else 36.dp
+    val iconSize = if (isPrimary) 24.dp else 20.dp
+    Button(
+        onClick = onClick,
+        modifier = Modifier.size(size),
+        colors = if (isPrimary) {
+            ButtonDefaults.primaryButtonColors(
+                backgroundColor = BrassPrimary,
+                contentColor = WarmDarkSurface,
+            )
+        } else {
+            ButtonDefaults.secondaryButtonColors(
+                backgroundColor = BrassMuted,
+                contentColor = BrassPrimary,
+            )
+        },
+    ) {
+        Icon(
+            imageVector = icon,
+            contentDescription = contentDescription,
+            modifier = Modifier.size(iconSize),
+        )
+    }
+}

--- a/wear/src/main/kotlin/in/jphe/storyvox/wear/screens/NowPlayingScreen.kt
+++ b/wear/src/main/kotlin/in/jphe/storyvox/wear/screens/NowPlayingScreen.kt
@@ -1,58 +1,297 @@
 package `in`.jphe.storyvox.wear.screens
 
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.aspectRatio
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalConfiguration
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.tooling.preview.Devices
+import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
-import androidx.compose.runtime.rememberCoroutineScope
-import androidx.wear.compose.material.Button
-import `in`.jphe.storyvox.playback.wear.PhoneWearBridge
-import kotlinx.coroutines.launch
 import androidx.wear.compose.material.MaterialTheme
 import androidx.wear.compose.material.Scaffold
 import androidx.wear.compose.material.Text
 import androidx.wear.compose.material.TimeText
+import androidx.wear.tooling.preview.devices.WearDevices
+import `in`.jphe.storyvox.playback.PlaybackState
+import `in`.jphe.storyvox.playback.scrubProgress
+import `in`.jphe.storyvox.playback.wear.PhoneWearBridge
+import `in`.jphe.storyvox.wear.components.ChapterCover
+import `in`.jphe.storyvox.wear.components.CircularScrubber
+import `in`.jphe.storyvox.wear.components.LinearScrubber
+import `in`.jphe.storyvox.wear.components.TransportRow
 import `in`.jphe.storyvox.wear.playback.WearPlaybackBridge
+import `in`.jphe.storyvox.wear.theme.BrassPrimary
+import `in`.jphe.storyvox.wear.theme.ParchmentOnMuted
+import `in`.jphe.storyvox.wear.theme.WearLibraryNocturneTheme
+import kotlinx.coroutines.launch
 
 /**
- * Minimal Wear OS now-playing screen — chapter title + play/pause toggle.
+ * Now-playing surface — Library Nocturne styled, circular scrubber on round
+ * faces / brass linear scrubber on square faces. Closes #192.
  *
- * v1 stub. The richer Library Nocturne styling and circular scrubber land in a
- * polish pass; this skeleton proves the bridge end-to-end and compiles against
- * Wear Material 1.4.0 (M2). Once Wear Material 3 stabilizes we can swap.
+ * Layout (round form factor, the dominant Wear case):
+ *
+ * ```
+ * ┌──────────────────────┐
+ * │     [TimeText]       │
+ * │                      │
+ * │      ╭──────╮        │   ← brass ring (scrubProgress)
+ * │     │ cover │       │      EB Garamond chapter title above
+ * │      ╰──────╯        │      transport row below
+ * │   Chapter Title      │
+ * │  Book · Author       │
+ * │  ⏮   ⏯   ⏭          │
+ * └──────────────────────┘
+ * ```
+ *
+ * On square faces the ring becomes a horizontal brass track at the bottom.
+ *
+ * Audio plumbing — MediaSession state + transport — is unchanged; we still
+ * read from [WearPlaybackBridge] and send `PhoneWearBridge.CMD_*` over
+ * MessageClient. This PR is pure UI polish per the #192 spec.
  */
 @Composable
 fun NowPlayingScreen(bridge: WearPlaybackBridge) {
     val state by bridge.state.collectAsStateWithLifecycle()
     val scope = rememberCoroutineScope()
 
-    Scaffold(timeText = { TimeText() }) {
-        Box(Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
-            Column(
-                horizontalAlignment = Alignment.CenterHorizontally,
-                modifier = Modifier.padding(16.dp),
-            ) {
-                Text(
-                    text = state.bookTitle ?: "storyvox",
-                    style = MaterialTheme.typography.title3,
+    NowPlayingContent(
+        state = state,
+        onPlayPause = {
+            val cmd = if (state.isPlaying) PhoneWearBridge.CMD_PAUSE else PhoneWearBridge.CMD_PLAY
+            scope.launch { bridge.send(cmd) }
+        },
+        onSkipBack = { scope.launch { bridge.send(PhoneWearBridge.CMD_SKIP_BACK) } },
+        onSkipForward = { scope.launch { bridge.send(PhoneWearBridge.CMD_SKIP_FWD) } },
+    )
+}
+
+/**
+ * Stateless inner content — split out so previews can drive it with a fixed
+ * [PlaybackState] without spinning up the real DataClient bridge.
+ */
+@Composable
+internal fun NowPlayingContent(
+    state: PlaybackState,
+    onPlayPause: () -> Unit,
+    onSkipBack: () -> Unit,
+    onSkipForward: () -> Unit,
+) {
+    val configuration = LocalConfiguration.current
+    val isRound = configuration.isScreenRound
+    val progress = state.scrubProgress()
+
+    Scaffold(
+        timeText = { TimeText() },
+        modifier = Modifier.fillMaxSize(),
+    ) {
+        Box(
+            modifier = Modifier
+                .fillMaxSize()
+                .background(MaterialTheme.colors.background),
+            contentAlignment = Alignment.Center,
+        ) {
+            if (isRound) {
+                RoundNowPlaying(
+                    state = state,
+                    progress = progress,
+                    onPlayPause = onPlayPause,
+                    onSkipBack = onSkipBack,
+                    onSkipForward = onSkipForward,
                 )
-                Text(
-                    text = state.chapterTitle ?: "Tap to play",
-                    style = MaterialTheme.typography.body2,
+            } else {
+                SquareNowPlaying(
+                    state = state,
+                    progress = progress,
+                    onPlayPause = onPlayPause,
+                    onSkipBack = onSkipBack,
+                    onSkipForward = onSkipForward,
                 )
-                Button(onClick = {
-                    val cmd = if (state.isPlaying) PhoneWearBridge.CMD_PAUSE else PhoneWearBridge.CMD_PLAY
-                    scope.launch { bridge.send(cmd) }
-                }) {
-                    Text(if (state.isPlaying) "⏸" else "▶")
-                }
             }
         }
     }
 }
+
+@Composable
+private fun RoundNowPlaying(
+    state: PlaybackState,
+    progress: Float,
+    onPlayPause: () -> Unit,
+    onSkipBack: () -> Unit,
+    onSkipForward: () -> Unit,
+) {
+    Column(
+        modifier = Modifier
+            .fillMaxSize()
+            .padding(horizontal = 12.dp, vertical = 8.dp),
+        horizontalAlignment = Alignment.CenterHorizontally,
+        verticalArrangement = Arrangement.spacedBy(6.dp, Alignment.CenterVertically),
+    ) {
+        CircularScrubber(
+            progress = progress,
+            indeterminate = state.isBuffering,
+            modifier = Modifier
+                .size(116.dp)
+                .aspectRatio(1f),
+        ) {
+            ChapterCover(
+                coverUri = state.coverUri,
+                title = state.bookTitle,
+                author = null,
+                modifier = Modifier.fillMaxSize(),
+            )
+        }
+        ChapterMeta(state = state)
+        TransportRow(
+            isPlaying = state.isPlaying,
+            onPlayPause = onPlayPause,
+            onSkipBack = onSkipBack,
+            onSkipForward = onSkipForward,
+        )
+    }
+}
+
+@Composable
+private fun SquareNowPlaying(
+    state: PlaybackState,
+    progress: Float,
+    onPlayPause: () -> Unit,
+    onSkipBack: () -> Unit,
+    onSkipForward: () -> Unit,
+) {
+    Column(
+        modifier = Modifier
+            .fillMaxSize()
+            .padding(horizontal = 16.dp, vertical = 12.dp),
+        horizontalAlignment = Alignment.CenterHorizontally,
+        verticalArrangement = Arrangement.spacedBy(8.dp, Alignment.CenterVertically),
+    ) {
+        ChapterCover(
+            coverUri = state.coverUri,
+            title = state.bookTitle,
+            author = null,
+            modifier = Modifier.size(72.dp),
+        )
+        ChapterMeta(state = state)
+        LinearScrubber(progress = progress, modifier = Modifier.fillMaxWidth())
+        TransportRow(
+            isPlaying = state.isPlaying,
+            onPlayPause = onPlayPause,
+            onSkipBack = onSkipBack,
+            onSkipForward = onSkipForward,
+        )
+    }
+}
+
+@Composable
+private fun ChapterMeta(state: PlaybackState) {
+    Column(
+        horizontalAlignment = Alignment.CenterHorizontally,
+        modifier = Modifier.fillMaxWidth(),
+    ) {
+        Text(
+            text = state.chapterTitle ?: state.bookTitle ?: "storyvox",
+            style = MaterialTheme.typography.title3,
+            color = BrassPrimary,
+            maxLines = 1,
+            overflow = TextOverflow.Ellipsis,
+            textAlign = TextAlign.Center,
+        )
+        val book = state.bookTitle
+        if (!book.isNullOrBlank() && state.chapterTitle != null) {
+            Text(
+                text = book,
+                style = MaterialTheme.typography.caption2,
+                color = ParchmentOnMuted,
+                maxLines = 1,
+                overflow = TextOverflow.Ellipsis,
+                textAlign = TextAlign.Center,
+            )
+        }
+    }
+}
+
+// region --- Previews ---
+
+private fun samplePlaying() = PlaybackState(
+    isPlaying = true,
+    bookTitle = "The Brass Compendium",
+    chapterTitle = "Chapter 7 · The Long Stair",
+    durationEstimateMs = 600_000L,
+    charOffset = 22_500,
+    speed = 1.0f,
+)
+
+private fun samplePaused() = PlaybackState(
+    isPlaying = false,
+    bookTitle = "The Brass Compendium",
+    chapterTitle = "Chapter 7 · The Long Stair",
+    durationEstimateMs = 600_000L,
+    charOffset = 5_000,
+    speed = 1.0f,
+)
+
+private fun sampleBuffering() = PlaybackState(
+    isPlaying = true,
+    isBuffering = true,
+    bookTitle = "Lyra & the Lantern",
+    chapterTitle = "Chapter 1 · Sparks",
+    durationEstimateMs = 900_000L,
+    charOffset = 0,
+)
+
+@Preview(device = WearDevices.LARGE_ROUND, showSystemUi = true, name = "Round · Playing")
+@Composable
+private fun PreviewRoundPlaying() {
+    WearLibraryNocturneTheme {
+        NowPlayingContent(samplePlaying(), {}, {}, {})
+    }
+}
+
+@Preview(device = WearDevices.LARGE_ROUND, showSystemUi = true, name = "Round · Paused")
+@Composable
+private fun PreviewRoundPaused() {
+    WearLibraryNocturneTheme {
+        NowPlayingContent(samplePaused(), {}, {}, {})
+    }
+}
+
+@Preview(device = WearDevices.LARGE_ROUND, showSystemUi = true, name = "Round · Buffering")
+@Composable
+private fun PreviewRoundBuffering() {
+    WearLibraryNocturneTheme {
+        NowPlayingContent(sampleBuffering(), {}, {}, {})
+    }
+}
+
+@Preview(device = WearDevices.SMALL_ROUND, showSystemUi = true, name = "Small Round")
+@Composable
+private fun PreviewSmallRound() {
+    WearLibraryNocturneTheme {
+        NowPlayingContent(samplePlaying(), {}, {}, {})
+    }
+}
+
+@Preview(device = WearDevices.SQUARE, showSystemUi = true, name = "Square")
+@Composable
+private fun PreviewSquare() {
+    WearLibraryNocturneTheme {
+        NowPlayingContent(samplePlaying(), {}, {}, {})
+    }
+}
+
+// endregion

--- a/wear/src/main/kotlin/in/jphe/storyvox/wear/theme/WearLibraryNocturneTheme.kt
+++ b/wear/src/main/kotlin/in/jphe/storyvox/wear/theme/WearLibraryNocturneTheme.kt
@@ -1,0 +1,119 @@
+package `in`.jphe.storyvox.wear.theme
+
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.TextStyle
+import androidx.compose.ui.text.font.FontFamily
+import androidx.compose.ui.text.font.FontStyle
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.googlefonts.Font
+import androidx.compose.ui.text.googlefonts.GoogleFont
+import androidx.compose.ui.unit.sp
+import androidx.wear.compose.material.Colors
+import androidx.wear.compose.material.MaterialTheme
+import androidx.wear.compose.material.Typography
+import `in`.jphe.storyvox.ui.R as CoreUiR
+
+/**
+ * Wear OS port of the phone/tablet Library Nocturne palette.
+ *
+ * Wear Compose Material is still on M2 (`Colors`, not `ColorScheme`), and OLED
+ * watches prefer always-dark surfaces — there is no system "light theme" toggle
+ * here the way phones have one. So this theme is dark-only, brass-on-warm-dark.
+ *
+ * Light-mode parchment tokens stay in `:core-ui` for the phone/tablet code
+ * paths; if a future Wear watch ships with a daylight-readable LCD we can branch
+ * here, but for the OLED form factor that's the dominant case in 2026 the
+ * always-dark palette is the right default.
+ *
+ * Colors mirror [in.jphe.storyvox.ui.theme.BrassRamp] / [SurfaceTokens] one-to-
+ * one so the brass identity carries across surfaces.
+ */
+internal val BrassPrimary = Color(0xFFB48C5A)        // BrassRamp.Brass500
+internal val BrassPrimaryVariant = Color(0xFF7A5A30) // BrassRamp.Brass550
+internal val BrassTint = Color(0xFFC9A774)           // BrassRamp.Brass400
+internal val BrassMuted = Color(0xFF3A2A14)          // BrassRamp.Brass700
+internal val WarmDarkSurface = Color(0xFF0E0C12)     // SurfaceTokens.SurfaceDark
+internal val WarmDarkContainer = Color(0xFF15131A)   // SurfaceTokens.SurfaceContainerDark
+internal val WarmDarkContainerHigh = Color(0xFF1B1822) // SurfaceTokens.SurfaceContainerHighDark
+internal val ParchmentOn = Color(0xFFE8DFD1)         // SurfaceTokens.OnSurfaceDark
+internal val ParchmentOnMuted = Color(0xFFB8AE9F)    // SurfaceTokens.OnSurfaceVariantDark
+internal val BrassRingTrack = Color(0xFF3A3530)      // SurfaceTokens.OutlineVariantDark
+
+private val WearNocturneColors = Colors(
+    primary = BrassPrimary,
+    primaryVariant = BrassPrimaryVariant,
+    secondary = BrassTint,
+    secondaryVariant = BrassMuted,
+    background = WarmDarkSurface,
+    surface = WarmDarkContainer,
+    error = Color(0xFFE07A6A),
+    onPrimary = WarmDarkSurface,
+    onSecondary = WarmDarkSurface,
+    onBackground = ParchmentOn,
+    onSurface = ParchmentOn,
+    onSurfaceVariant = ParchmentOnMuted,
+    onError = WarmDarkSurface,
+)
+
+// Reuse the same Google Fonts provider config as :core-ui so the watch pulls
+// EB Garamond + Inter from Google Play Services (zero-bytes on-disk on every
+// Wear OS device that has GMS, which is "all of them").
+private val GoogleFontProvider = GoogleFont.Provider(
+    providerAuthority = "com.google.android.gms.fonts",
+    providerPackage = "com.google.android.gms",
+    certificates = CoreUiR.array.com_google_android_gms_fonts_certs,
+)
+
+private val EbGaramond = GoogleFont("EB Garamond")
+private val Inter = GoogleFont("Inter")
+
+private val BookFamily = FontFamily(
+    Font(googleFont = EbGaramond, fontProvider = GoogleFontProvider, weight = FontWeight.Normal),
+    Font(googleFont = EbGaramond, fontProvider = GoogleFontProvider, weight = FontWeight.Medium),
+    Font(googleFont = EbGaramond, fontProvider = GoogleFontProvider, weight = FontWeight.SemiBold),
+    Font(googleFont = EbGaramond, fontProvider = GoogleFontProvider, weight = FontWeight.Normal, style = FontStyle.Italic),
+)
+
+private val UiFamily = FontFamily(
+    Font(googleFont = Inter, fontProvider = GoogleFontProvider, weight = FontWeight.Normal),
+    Font(googleFont = Inter, fontProvider = GoogleFontProvider, weight = FontWeight.Medium),
+    Font(googleFont = Inter, fontProvider = GoogleFontProvider, weight = FontWeight.SemiBold),
+)
+
+/**
+ * Wear typography — tighter sizes than the phone, EB Garamond reserved for the
+ * book/chapter titles, Inter for everything else (transport labels, metadata).
+ * Wear M2's [Typography] has a different slot set than M3, so this isn't a
+ * direct copy of [in.jphe.storyvox.ui.theme.LibraryNocturneTypography].
+ */
+private val WearNocturneTypography = Typography(
+    display1 = TextStyle(fontFamily = BookFamily, fontWeight = FontWeight.SemiBold, fontSize = 40.sp, lineHeight = 46.sp),
+    display2 = TextStyle(fontFamily = BookFamily, fontWeight = FontWeight.SemiBold, fontSize = 32.sp, lineHeight = 38.sp),
+    display3 = TextStyle(fontFamily = BookFamily, fontWeight = FontWeight.SemiBold, fontSize = 24.sp, lineHeight = 30.sp),
+    title1 = TextStyle(fontFamily = BookFamily, fontWeight = FontWeight.SemiBold, fontSize = 20.sp, lineHeight = 24.sp),
+    title2 = TextStyle(fontFamily = BookFamily, fontWeight = FontWeight.Medium, fontSize = 16.sp, lineHeight = 20.sp),
+    title3 = TextStyle(fontFamily = BookFamily, fontWeight = FontWeight.Medium, fontSize = 14.sp, lineHeight = 18.sp),
+    body1 = TextStyle(fontFamily = UiFamily, fontWeight = FontWeight.Normal, fontSize = 14.sp, lineHeight = 18.sp, letterSpacing = 0.1.sp),
+    body2 = TextStyle(fontFamily = UiFamily, fontWeight = FontWeight.Normal, fontSize = 12.sp, lineHeight = 16.sp, letterSpacing = 0.25.sp),
+    button = TextStyle(fontFamily = UiFamily, fontWeight = FontWeight.Medium, fontSize = 13.sp, lineHeight = 16.sp, letterSpacing = 0.5.sp),
+    caption1 = TextStyle(fontFamily = UiFamily, fontWeight = FontWeight.Medium, fontSize = 11.sp, lineHeight = 14.sp, letterSpacing = 0.4.sp),
+    caption2 = TextStyle(fontFamily = UiFamily, fontWeight = FontWeight.Normal, fontSize = 10.sp, lineHeight = 13.sp, letterSpacing = 0.4.sp),
+    caption3 = TextStyle(fontFamily = UiFamily, fontWeight = FontWeight.Normal, fontSize = 9.sp, lineHeight = 12.sp, letterSpacing = 0.4.sp),
+)
+
+/**
+ * Library Nocturne theme wrapper for the Wear app.
+ *
+ * Drop-in replacement for [androidx.wear.compose.material.MaterialTheme] —
+ * call this once at [in.jphe.storyvox.wear.WearAppRoot] and every Wear
+ * Material composable below it inherits brass + parchment defaults.
+ */
+@Composable
+fun WearLibraryNocturneTheme(content: @Composable () -> Unit) {
+    MaterialTheme(
+        colors = WearNocturneColors,
+        typography = WearNocturneTypography,
+        content = content,
+    )
+}


### PR DESCRIPTION
## Summary

Closes #192. The Wear surface was a v1 stub (plain Material 1.4.0 / M2, single play/pause button, no scrubber, no chapter art). This pass brings it in line with the phone/tablet brass-on-warm-dark Library Nocturne aesthetic.

- **WearLibraryNocturneTheme** — Wear M2 `Colors` + `Typography` that mirror the phone's brass ramp / parchment-on-dark tokens. EB Garamond for chapter titles, Inter for transport + metadata. Dark-only by design — OLED watches prefer always-dark; there's no system light/dark toggle on Wear OS.
- **CircularScrubber** — brass ring wrapping the chapter cover art on round faces, driven by `PlaybackState.scrubProgress()`. Indeterminate mode for buffering. Read-only in v1; a `CMD_SEEK` bridge path is follow-up work (called out in the doc strings).
- **LinearScrubber** — brass-skinned horizontal track for square faces (rare-but-supported per the spec).
- **TransportRow** — Skip Back / Play-Pause / Skip Next; full brass on the center play/pause, muted brass-on-dark on the flanking skip buttons. Wired to existing `CMD_SKIP_BACK` / `CMD_PLAY` / `CMD_PAUSE` / `CMD_SKIP_FWD` bridge messages.
- **ChapterCover** — Coil `AsyncImage` for `PlaybackState.coverUri`; brass monogram fallback via the shared `fictionMonogram()` helper from `:core-ui` (#322 parity).
- **Five `@Preview` entries** — round/playing, round/paused, round/buffering, small-round, square. The Wear emulator isn't on ADB, so the visual diff is reviewable from Android Studio's preview pane.

Audio plumbing untouched. The Wear data path still flows through `WearPlaybackBridge` → `DataClient` → `PhoneWearBridge`.

`versionCode` / `versionName` deliberately not bumped — sibling agent (#403, Discord) will bump to v0.5.29 and combine into the bundle. Scope here is pure `:wear` UI; no file overlap with the Discord PR.

## Test plan

- [x] `./gradlew :wear:assembleDebug` — green
- [x] `./gradlew :wear:testDebugUnitTest` — green (no unit tests in `:wear`; task is `NO-SOURCE`)
- [x] `./gradlew :app:assembleDebug` — green (no regressions in the phone path)
- [ ] Visual verification in Android Studio preview pane (large round, small round, square) — falls to JP/QA next session since the Wear emulator isn't ADB-connected from this env
- [ ] Sideload `wear-debug.apk` to a real Wear OS 4 device if/when JP wants on-device verification

🤖 Generated with [Claude Code](https://claude.com/claude-code)