### PR TITLE
fix(browse): scrollable LazyRow of source chips — closes #407

### DIFF
--- a/core-data/src/test/kotlin/in/jphe/storyvox/data/db/dao/ChapterDaoTest.kt
+++ b/core-data/src/test/kotlin/in/jphe/storyvox/data/db/dao/ChapterDaoTest.kt
@@ -1,0 +1,462 @@
+package `in`.jphe.storyvox.data.db.dao
+
+import android.content.Context
+import androidx.room.Room
+import androidx.test.core.app.ApplicationProvider
+import `in`.jphe.storyvox.data.db.StoryvoxDatabase
+import `in`.jphe.storyvox.data.db.entity.Chapter
+import `in`.jphe.storyvox.data.db.entity.ChapterDownloadState
+import `in`.jphe.storyvox.data.db.entity.Fiction
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.test.runTest
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+
+/**
+ * Issue #48 — Room+Robolectric DAO test for [ChapterDao].
+ *
+ * Focus on the non-trivial SQL the repository's fake-DAO tests can't reach:
+ *
+ *  - [ChapterDao.observeChapterInfosByFiction] — slim projection, must not
+ *    drag the multi-MB plainBody/htmlBody columns off disk on every emission.
+ *  - [ChapterDao.upsertChaptersForFiction] — two-phase parked-then-upsert
+ *    transaction; the UNIQUE constraint on (fictionId, index) means a naive
+ *    upsertAll mid-reorder would crash. Test the wrapping `@Transaction`.
+ *  - [ChapterDao.parkChapterIndexesFor] — composite WHERE clause (`>= 0 AND
+ *    < 100000`) that keeps previously-parked rows from drifting.
+ *  - [ChapterDao.setBody] — writes a *bundle* of columns atomically.
+ *  - [ChapterDao.trimDownloadedBodies] — keep-last predicate with a SELECT MAX
+ *    subquery; correctness depends on the subquery scoping to fictionId.
+ *  - [ChapterDao.cacheUsage] — aggregate with COALESCE for empty cases.
+ */
+@RunWith(RobolectricTestRunner::class)
+@Config(manifest = Config.NONE)
+class ChapterDaoTest {
+
+    private lateinit var db: StoryvoxDatabase
+    private lateinit var dao: ChapterDao
+    private lateinit var fictionDao: FictionDao
+
+    private val fiction = Fiction(
+        id = "f1",
+        sourceId = "royalroad",
+        title = "Sky Pride",
+        author = "Anonymous",
+        coverUrl = "https://example.test/cover.jpg",
+        firstSeenAt = 0L,
+        metadataFetchedAt = 0L,
+        inLibrary = true,
+    )
+
+    private fun chapter(
+        id: String,
+        index: Int,
+        title: String = "Chapter $index",
+        publishedAt: Long? = null,
+        wordCount: Int? = null,
+        plainBody: String? = null,
+        htmlBody: String? = null,
+        downloadState: ChapterDownloadState = ChapterDownloadState.NOT_DOWNLOADED,
+        userMarkedRead: Boolean = false,
+        fictionId: String = "f1",
+    ) = Chapter(
+        id = id,
+        fictionId = fictionId,
+        sourceChapterId = "src-$index",
+        index = index,
+        title = title,
+        publishedAt = publishedAt,
+        wordCount = wordCount,
+        plainBody = plainBody,
+        htmlBody = htmlBody,
+        downloadState = downloadState,
+        userMarkedRead = userMarkedRead,
+    )
+
+    @Before
+    fun setUp() {
+        val ctx = ApplicationProvider.getApplicationContext<Context>()
+        db = Room.inMemoryDatabaseBuilder(ctx, StoryvoxDatabase::class.java)
+            .allowMainThreadQueries()
+            .build()
+        dao = db.chapterDao()
+        fictionDao = db.fictionDao()
+    }
+
+    @After
+    fun tearDown() {
+        db.close()
+    }
+
+    // ----- slim projection contract (PR #40 -- must survive future edits) -------
+
+    @Test
+    fun observeChapterInfosByFiction_returnsSlimProjectionOrderedByIndex() = runTest {
+        fictionDao.upsert(fiction)
+        dao.upsertAll(
+            listOf(
+                chapter("c3", index = 3, title = "Third", publishedAt = 30L, wordCount = 1500),
+                chapter("c1", index = 1, title = "First", publishedAt = 10L, wordCount = 1000),
+                chapter("c2", index = 2, title = "Second", publishedAt = 20L, wordCount = 1200),
+            ),
+        )
+
+        val rows = dao.observeChapterInfosByFiction("f1").first()
+        assertEquals(listOf(1, 2, 3), rows.map { it.index })
+        assertEquals(listOf("First", "Second", "Third"), rows.map { it.title })
+        assertEquals(listOf("c1", "c2", "c3"), rows.map { it.id })
+        assertEquals(listOf("src-1", "src-2", "src-3"), rows.map { it.sourceChapterId })
+        assertEquals(listOf(10L, 20L, 30L), rows.map { it.publishedAt })
+        assertEquals(listOf(1000, 1200, 1500), rows.map { it.wordCount })
+    }
+
+    @Test
+    fun observeChapterInfosByFiction_filtersByFictionId() = runTest {
+        val other = fiction.copy(id = "f2")
+        fictionDao.upsert(fiction)
+        fictionDao.upsert(other)
+        dao.upsertAll(
+            listOf(
+                chapter("c1", index = 1, fictionId = "f1"),
+                chapter("d1", index = 1, fictionId = "f2"),
+            ),
+        )
+
+        val rows = dao.observeChapterInfosByFiction("f1").first()
+        assertEquals(listOf("c1"), rows.map { it.id })
+    }
+
+    // ----- single-chapter helpers ------------------------------------------------
+
+    @Test
+    fun get_unknown_isNull() = runTest {
+        assertNull(dao.get("nope"))
+    }
+
+    @Test
+    fun maxIndex_emptyFiction_isNull() = runTest {
+        fictionDao.upsert(fiction)
+        assertNull(dao.maxIndex("f1"))
+    }
+
+    @Test
+    fun maxIndex_returnsHighestIndex() = runTest {
+        fictionDao.upsert(fiction)
+        dao.upsertAll(
+            listOf(
+                chapter("c1", index = 1),
+                chapter("c2", index = 2),
+                chapter("c5", index = 5),
+            ),
+        )
+        assertEquals(5, dao.maxIndex("f1"))
+    }
+
+    @Test
+    fun nextAndPreviousChapterId_walkInIndexOrder() = runTest {
+        fictionDao.upsert(fiction)
+        dao.upsertAll(
+            listOf(
+                chapter("c1", index = 1),
+                chapter("c2", index = 2),
+                chapter("c3", index = 3),
+            ),
+        )
+        assertEquals("c2", dao.nextChapterId("c1"))
+        assertEquals("c3", dao.nextChapterId("c2"))
+        assertNull(dao.nextChapterId("c3"))
+        assertEquals("c2", dao.previousChapterId("c3"))
+        assertNull(dao.previousChapterId("c1"))
+    }
+
+    // ----- @Transaction upsertChaptersForFiction (#349 RSS reorder) -------------
+
+    @Test
+    fun upsertChaptersForFiction_canReorderWithoutUniqueConstraintConflict() = runTest {
+        fictionDao.upsert(fiction)
+        // Existing live rows occupying indexes 0..2.
+        dao.upsertAll(
+            listOf(
+                chapter("c1", index = 0, title = "Old A"),
+                chapter("c2", index = 1, title = "Old B"),
+                chapter("c3", index = 2, title = "Old C"),
+            ),
+        )
+
+        // Same PKs, reshuffled indexes — would crash a naive upsertAll on
+        // (fictionId, index) UNIQUE. Wrapped in @Transaction it must succeed.
+        dao.upsertChaptersForFiction(
+            "f1",
+            listOf(
+                chapter("c3", index = 0, title = "New A"),
+                chapter("c1", index = 1, title = "New B"),
+                chapter("c2", index = 2, title = "New C"),
+            ),
+        )
+
+        val rows = dao.observeChapterInfosByFiction("f1").first()
+        assertEquals(
+            listOf("c3" to "New A", "c1" to "New B", "c2" to "New C"),
+            rows.map { it.id to it.title },
+        )
+    }
+
+    @Test
+    fun upsertChaptersForFiction_droppedRowsSurviveAtParkedIndexes() = runTest {
+        fictionDao.upsert(fiction)
+        dao.upsertAll(
+            listOf(
+                chapter("c1", index = 0, plainBody = "preserve me"),
+                chapter("c2", index = 1),
+            ),
+        )
+
+        // Only c2 is in the new feed; c1 drops off but its body must
+        // survive (per the parking-range design: dropped rows stay
+        // parked above PARK_OFFSET = 100000 so their downloaded bodies
+        // are still available for later playback).
+        dao.upsertChaptersForFiction("f1", listOf(chapter("c2", index = 0, title = "Now first")))
+
+        // c1 still exists with its body preserved, parked above 100000.
+        val parked = dao.get("c1")
+        assertNotNull("dropped chapter must survive parked", parked)
+        assertEquals("preserve me", parked!!.plainBody)
+        assertTrue("parked row index must be >= 100000, was ${parked.index}", parked.index >= 100000)
+
+        // c2 is at its new positive index.
+        assertEquals(0, dao.get("c2")!!.index)
+    }
+
+    @Test
+    fun parkChapterIndexesFor_doesNotReParkAlreadyParkedRows() = runTest {
+        fictionDao.upsert(fiction)
+        dao.upsertAll(listOf(chapter("c1", index = 0)))
+        dao.parkChapterIndexesFor("f1") // c1 → 100000
+        dao.parkChapterIndexesFor("f1") // c1 should stay at 100000, not jump to 200000
+
+        assertEquals(100000, dao.get("c1")!!.index)
+    }
+
+    // ----- setBody and setDownloadState ----------------------------------------
+
+    @Test
+    fun setBody_writesAllBundledColumnsAtomically() = runTest {
+        fictionDao.upsert(fiction)
+        dao.upsert(chapter("c1", index = 0))
+
+        dao.setBody(
+            id = "c1",
+            html = "<p>hi</p>",
+            plain = "hi",
+            checksum = "deadbeef",
+            notesAuthor = "Author's note",
+            notesAuthorPosition = null,
+            now = 999L,
+            audioUrl = "https://example.test/audio.mp3",
+        )
+
+        val row = dao.get("c1")!!
+        assertEquals("<p>hi</p>", row.htmlBody)
+        assertEquals("hi", row.plainBody)
+        assertEquals("deadbeef", row.bodyChecksum)
+        assertEquals(999L, row.bodyFetchedAt)
+        assertEquals(999L, row.lastDownloadAttemptAt)
+        assertEquals(ChapterDownloadState.DOWNLOADED, row.downloadState)
+        assertNull(row.lastDownloadError)
+        assertEquals("Author's note", row.notesAuthor)
+        assertEquals("https://example.test/audio.mp3", row.audioUrl)
+    }
+
+    @Test
+    fun setDownloadState_writesStateAndError() = runTest {
+        fictionDao.upsert(fiction)
+        dao.upsert(chapter("c1", index = 0))
+
+        dao.setDownloadState("c1", ChapterDownloadState.FAILED, now = 1L, error = "boom")
+
+        val row = dao.get("c1")!!
+        assertEquals(ChapterDownloadState.FAILED, row.downloadState)
+        assertEquals("boom", row.lastDownloadError)
+        assertEquals(1L, row.lastDownloadAttemptAt)
+    }
+
+    @Test
+    fun setRead_setsFirstReadAtOnFirstReadOnly() = runTest {
+        fictionDao.upsert(fiction)
+        dao.upsert(chapter("c1", index = 0))
+
+        dao.setRead("c1", read = true, now = 100L)
+        assertEquals(100L, dao.get("c1")!!.firstReadAt)
+
+        // Re-mark read at a later time — firstReadAt must NOT advance.
+        dao.setRead("c1", read = true, now = 999L)
+        assertEquals(100L, dao.get("c1")!!.firstReadAt)
+    }
+
+    // ----- trimDownloadedBodies -------------------------------------------------
+
+    @Test
+    fun trimDownloadedBodies_keepsLastN_clearsRest() = runTest {
+        fictionDao.upsert(fiction)
+        dao.upsertAll(
+            (1..5).map { i ->
+                chapter(
+                    id = "c$i",
+                    index = i,
+                    plainBody = "body-$i",
+                    htmlBody = "<p>$i</p>",
+                    downloadState = ChapterDownloadState.DOWNLOADED,
+                )
+            },
+        )
+
+        // Keep last 2; rows with index < (max - 2) = 3 get cleared.
+        // max = 5, so cleared = indexes < 3 (indexes 1, 2).
+        dao.trimDownloadedBodies("f1", keepLast = 2)
+
+        assertNull(dao.get("c1")!!.plainBody)
+        assertNull(dao.get("c2")!!.plainBody)
+        // c3 is at the boundary (< MAX - 2 = 3 is FALSE) so it is kept.
+        assertEquals("body-3", dao.get("c3")!!.plainBody)
+        assertEquals("body-4", dao.get("c4")!!.plainBody)
+        assertEquals("body-5", dao.get("c5")!!.plainBody)
+    }
+
+    @Test
+    fun trimDownloadedBodies_doesNotTouchOtherFiction() = runTest {
+        val other = fiction.copy(id = "f2")
+        fictionDao.upsert(fiction)
+        fictionDao.upsert(other)
+        dao.upsertAll(
+            listOf(
+                chapter("a1", index = 0, plainBody = "f1-body", fictionId = "f1"),
+                chapter("b1", index = 0, plainBody = "f2-body", fictionId = "f2"),
+            ),
+        )
+
+        dao.trimDownloadedBodies("f1", keepLast = 0)
+
+        assertEquals("f2-body", dao.get("b1")!!.plainBody)
+    }
+
+    // ----- bookmarks (#121) -----------------------------------------------------
+
+    @Test
+    fun setBookmark_andGet_roundTrip() = runTest {
+        fictionDao.upsert(fiction)
+        dao.upsert(chapter("c1", index = 0))
+
+        assertNull(dao.getBookmark("c1"))
+
+        dao.setBookmark("c1", 1234)
+        assertEquals(1234, dao.getBookmark("c1"))
+
+        dao.setBookmark("c1", null)
+        assertNull(dao.getBookmark("c1"))
+    }
+
+    @Test
+    fun allBookmarks_returnsOnlyRowsWithNonNullOffset() = runTest {
+        fictionDao.upsert(fiction)
+        dao.upsertAll(
+            listOf(
+                chapter("c1", index = 0),
+                chapter("c2", index = 1),
+                chapter("c3", index = 2),
+            ),
+        )
+        dao.setBookmark("c1", 100)
+        dao.setBookmark("c3", 300)
+
+        val rows = dao.allBookmarks().sortedBy { it.chapterId }
+        assertEquals(2, rows.size)
+        assertEquals("c1", rows[0].chapterId)
+        assertEquals(100, rows[0].charOffset)
+        assertEquals("c3", rows[1].chapterId)
+        assertEquals(300, rows[1].charOffset)
+    }
+
+    // ----- cacheUsage (#293) ----------------------------------------------------
+
+    @Test
+    fun cacheUsage_emptyDb_returnsZeros() = runTest {
+        val usage = dao.cacheUsage()
+        assertEquals(0, usage.count)
+        assertEquals(0L, usage.bytes)
+    }
+
+    @Test
+    fun cacheUsage_countsOnlyRowsWithNonEmptyPlainBody() = runTest {
+        fictionDao.upsert(fiction)
+        dao.upsertAll(
+            listOf(
+                chapter("c1", index = 0, plainBody = "abcd"), // 4 chars
+                chapter("c2", index = 1, plainBody = ""), // excluded (<> '')
+                chapter("c3", index = 2, plainBody = null), // excluded (NULL)
+                chapter("c4", index = 3, plainBody = "abcdef"), // 6 chars
+            ),
+        )
+
+        val usage = dao.cacheUsage()
+        assertEquals(2, usage.count)
+        // The DAO multiplies CHAR length by 2 as a conservative byte estimate.
+        assertEquals((4 + 6) * 2L, usage.bytes)
+    }
+
+    // ----- unread / played feeds ------------------------------------------------
+
+    @Test
+    fun unreadChapters_filtersToLibraryAndUnread_orderedByPublishedAtDesc() = runTest {
+        val notInLibrary = fiction.copy(id = "f2", inLibrary = false)
+        fictionDao.upsert(fiction)
+        fictionDao.upsert(notInLibrary)
+        dao.upsertAll(
+            listOf(
+                chapter("c1", index = 0, publishedAt = 10L, userMarkedRead = true, fictionId = "f1"),
+                chapter("c2", index = 1, publishedAt = 30L, fictionId = "f1"),
+                chapter("c3", index = 2, publishedAt = 20L, fictionId = "f1"),
+                chapter("c4", index = 0, publishedAt = 999L, fictionId = "f2"), // excluded — not in library
+            ),
+        )
+
+        val rows = dao.unreadChapters(limit = 10)
+        assertEquals(listOf("c2", "c3"), rows.map { it.chapterId })
+    }
+
+    @Test
+    fun observePlayedChapterIds_returnsOnlyMarkedRead() = runTest {
+        fictionDao.upsert(fiction)
+        dao.upsertAll(
+            listOf(
+                chapter("c1", index = 0, userMarkedRead = true),
+                chapter("c2", index = 1, userMarkedRead = false),
+                chapter("c3", index = 2, userMarkedRead = true),
+            ),
+        )
+
+        val played = dao.observePlayedChapterIds("f1").first().toSet()
+        assertEquals(setOf("c1", "c3"), played)
+    }
+
+    // ----- CASCADE delete -------------------------------------------------------
+
+    @Test
+    fun deletingFiction_cascadesChapters() = runTest {
+        val transient = fiction.copy(id = "transient", inLibrary = false, followedRemotely = false)
+        fictionDao.upsert(transient)
+        dao.upsert(chapter("c1", index = 0, fictionId = "transient"))
+
+        val deleted = fictionDao.deleteIfTransient("transient")
+        assertEquals(1, deleted)
+
+        assertNull(dao.get("c1"))
+    }
+}

--- a/core-data/src/test/kotlin/in/jphe/storyvox/data/db/dao/FictionDaoTest.kt
+++ b/core-data/src/test/kotlin/in/jphe/storyvox/data/db/dao/FictionDaoTest.kt
@@ -1,0 +1,279 @@
+package `in`.jphe.storyvox.data.db.dao
+
+import android.content.Context
+import androidx.room.Room
+import androidx.test.core.app.ApplicationProvider
+import `in`.jphe.storyvox.data.db.StoryvoxDatabase
+import `in`.jphe.storyvox.data.db.entity.DownloadMode
+import `in`.jphe.storyvox.data.db.entity.Fiction
+import `in`.jphe.storyvox.data.source.model.FictionStatus
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.test.runTest
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+
+/**
+ * Issue #48 — Room+Robolectric DAO test for [FictionDao].
+ *
+ * Goal: exercise the SQL itself end-to-end, not the repository's coordination
+ * logic. The repository tests use fakes that bypass Room; those would silently
+ * tolerate things like a typoed column name in a `@Query` or a wrong index in
+ * a composite WHERE clause. These tests catch:
+ *
+ *  - schema-affecting migrations that forget to update an `@Insert`/`@Query`
+ *  - `setX(...)` queries that point at a renamed/removed column
+ *  - `@Transaction` boundary mistakes inside [FictionDao.upsertAllPreservingUserState]
+ *  - composite-predicate correctness for [FictionDao.deleteIfTransient]
+ *  - ordering / projection contracts the UI relies on
+ */
+@RunWith(RobolectricTestRunner::class)
+@Config(manifest = Config.NONE)
+class FictionDaoTest {
+
+    private lateinit var db: StoryvoxDatabase
+    private lateinit var dao: FictionDao
+
+    private fun fixture(
+        id: String = "f1",
+        sourceId: String = "royalroad",
+        title: String = "Sky Pride",
+        inLibrary: Boolean = false,
+        followedRemotely: Boolean = false,
+        addedToLibraryAt: Long? = null,
+        lastUpdatedAt: Long? = null,
+    ) = Fiction(
+        id = id,
+        sourceId = sourceId,
+        title = title,
+        author = "Anonymous",
+        firstSeenAt = 0L,
+        metadataFetchedAt = 0L,
+        inLibrary = inLibrary,
+        addedToLibraryAt = addedToLibraryAt,
+        followedRemotely = followedRemotely,
+        lastUpdatedAt = lastUpdatedAt,
+    )
+
+    @Before
+    fun setUp() {
+        val ctx = ApplicationProvider.getApplicationContext<Context>()
+        db = Room.inMemoryDatabaseBuilder(ctx, StoryvoxDatabase::class.java)
+            .allowMainThreadQueries()
+            .build()
+        dao = db.fictionDao()
+    }
+
+    @After
+    fun tearDown() {
+        db.close()
+    }
+
+    // ----- core CRUD round-trip -------------------------------------------------
+
+    @Test
+    fun upsertThenGet_roundtripsAllColumns() = runTest {
+        val f = fixture().copy(
+            description = "A flight of fancy",
+            tags = listOf("Adventure", "Magic"),
+            status = FictionStatus.COMPLETED,
+            chapterCount = 42,
+            rating = 4.5f,
+            inLibrary = true,
+            addedToLibraryAt = 1_000L,
+            downloadMode = DownloadMode.EAGER,
+            pinnedVoiceId = "voice-x",
+            pinnedVoiceLocale = "en-US",
+            lastSeenRevision = "abc123",
+        )
+        dao.upsert(f)
+
+        val out = dao.get("f1")
+        assertEquals(f, out)
+    }
+
+    @Test
+    fun get_unknownId_isNull() = runTest {
+        assertNull(dao.get("nope"))
+    }
+
+    @Test
+    fun getMany_returnsRowsForKnownIdsOnly() = runTest {
+        dao.upsert(fixture(id = "a"))
+        dao.upsert(fixture(id = "b"))
+
+        val rows = dao.getMany(listOf("a", "missing", "b")).map { it.id }.toSet()
+        assertEquals(setOf("a", "b"), rows)
+    }
+
+    // ----- observeLibrary / observeFollowsRemote --------------------------------
+
+    @Test
+    fun observeLibrary_filtersAndOrdersByAddedToLibraryAtDesc() = runTest {
+        dao.upsert(fixture(id = "old", inLibrary = true, addedToLibraryAt = 100L))
+        dao.upsert(fixture(id = "new", inLibrary = true, addedToLibraryAt = 999L))
+        dao.upsert(fixture(id = "transient", inLibrary = false))
+
+        val ids = dao.observeLibrary().first().map { it.id }
+        assertEquals(listOf("new", "old"), ids)
+    }
+
+    @Test
+    fun observeFollowsRemote_filtersAndOrdersByLastUpdatedAtDesc() = runTest {
+        dao.upsert(fixture(id = "stale", followedRemotely = true, lastUpdatedAt = 5L))
+        dao.upsert(fixture(id = "fresh", followedRemotely = true, lastUpdatedAt = 50L))
+        dao.upsert(fixture(id = "unfollowed", followedRemotely = false, lastUpdatedAt = 999L))
+
+        val ids = dao.observeFollowsRemote().first().map { it.id }
+        assertEquals(listOf("fresh", "stale"), ids)
+    }
+
+    // ----- setX queries: each must hit the right column -------------------------
+
+    @Test
+    fun setInLibrary_true_setsAddedToLibraryAt() = runTest {
+        dao.upsert(fixture(id = "f1", inLibrary = false, addedToLibraryAt = null))
+
+        dao.setInLibrary("f1", inLibrary = true, now = 42L)
+
+        val row = dao.get("f1")!!
+        assertTrue(row.inLibrary)
+        assertEquals(42L, row.addedToLibraryAt)
+    }
+
+    @Test
+    fun setInLibrary_false_preservesExistingAddedToLibraryAt() = runTest {
+        dao.upsert(fixture(id = "f1", inLibrary = true, addedToLibraryAt = 100L))
+
+        dao.setInLibrary("f1", inLibrary = false, now = 999L)
+
+        val row = dao.get("f1")!!
+        assertFalse(row.inLibrary)
+        // CASE WHEN guards the column; un-libraried row keeps its historical timestamp.
+        assertEquals(100L, row.addedToLibraryAt)
+    }
+
+    @Test
+    fun setFollowedRemote_togglesFollowedFlag() = runTest {
+        dao.upsert(fixture(id = "f1", followedRemotely = false))
+        dao.setFollowedRemote("f1", true)
+        assertTrue(dao.get("f1")!!.followedRemotely)
+        dao.setFollowedRemote("f1", false)
+        assertFalse(dao.get("f1")!!.followedRemotely)
+    }
+
+    @Test
+    fun setDownloadMode_writesAndClears() = runTest {
+        dao.upsert(fixture(id = "f1"))
+
+        dao.setDownloadMode("f1", DownloadMode.SUBSCRIBE)
+        assertEquals(DownloadMode.SUBSCRIBE, dao.get("f1")!!.downloadMode)
+
+        dao.setDownloadMode("f1", null)
+        assertNull(dao.get("f1")!!.downloadMode)
+    }
+
+    @Test
+    fun setPinnedVoice_writesBothColumns() = runTest {
+        dao.upsert(fixture(id = "f1"))
+
+        dao.setPinnedVoice("f1", "voice-en-US-Tony", "en-US")
+
+        val row = dao.get("f1")!!
+        assertEquals("voice-en-US-Tony", row.pinnedVoiceId)
+        assertEquals("en-US", row.pinnedVoiceLocale)
+    }
+
+    @Test
+    fun touchMetadata_writesTimestamp() = runTest {
+        dao.upsert(fixture(id = "f1").copy(metadataFetchedAt = 0L))
+        dao.touchMetadata("f1", 12345L)
+        assertEquals(12345L, dao.get("f1")!!.metadataFetchedAt)
+    }
+
+    @Test
+    fun setLastSeenRevision_roundTrip() = runTest {
+        dao.upsert(fixture(id = "f1").copy(lastSeenRevision = null))
+        assertNull(dao.getLastSeenRevision("f1"))
+
+        dao.setLastSeenRevision("f1", "sha-abc")
+        assertEquals("sha-abc", dao.getLastSeenRevision("f1"))
+
+        dao.setLastSeenRevision("f1", null)
+        assertNull(dao.getLastSeenRevision("f1"))
+    }
+
+    // ----- @Transaction upsertAllPreservingUserState ----------------------------
+
+    @Test
+    fun upsertAllPreservingUserState_preservesUserOwnedColumns() = runTest {
+        // Existing library row with user-owned state.
+        dao.upsert(
+            fixture(id = "f1", inLibrary = true, followedRemotely = true, addedToLibraryAt = 100L)
+                .copy(
+                    downloadMode = DownloadMode.EAGER,
+                    pinnedVoiceId = "tony",
+                    pinnedVoiceLocale = "en-US",
+                    notesEverSeen = true,
+                    firstSeenAt = 50L,
+                    lastSeenRevision = "rev-1",
+                ),
+        )
+
+        // Listing-page upsert: only knows source-side fields, no library/follow.
+        val listingPage = fixture(id = "f1", inLibrary = false, followedRemotely = false)
+            .copy(title = "Sky Pride (Revised)", firstSeenAt = 999L)
+        dao.upsertAllPreservingUserState(listOf(listingPage))
+
+        val row = dao.get("f1")!!
+        // Source-side metadata advanced —
+        assertEquals("Sky Pride (Revised)", row.title)
+        // — user-owned state preserved.
+        assertTrue("inLibrary must survive listing-page upsert", row.inLibrary)
+        assertTrue("followedRemotely must survive listing-page upsert", row.followedRemotely)
+        assertEquals(100L, row.addedToLibraryAt)
+        assertEquals(DownloadMode.EAGER, row.downloadMode)
+        assertEquals("tony", row.pinnedVoiceId)
+        assertEquals("en-US", row.pinnedVoiceLocale)
+        assertTrue(row.notesEverSeen)
+        // firstSeenAt is preserved (not overwritten with the listing's 999).
+        assertEquals(50L, row.firstSeenAt)
+        // lastSeenRevision is preserved (only the poll worker writes it).
+        assertEquals("rev-1", row.lastSeenRevision)
+    }
+
+    @Test
+    fun upsertAllPreservingUserState_insertsNewRowsUnchanged() = runTest {
+        val incoming = fixture(id = "new", inLibrary = false, addedToLibraryAt = null)
+        dao.upsertAllPreservingUserState(listOf(incoming))
+
+        val row = dao.get("new")
+        assertNotNull(row)
+        assertEquals(incoming, row)
+    }
+
+    // ----- deleteIfTransient -----------------------------------------------------
+
+    @Test
+    fun deleteIfTransient_deletesOnlyWhenBothFlagsAreFalse() = runTest {
+        dao.upsert(fixture(id = "transient", inLibrary = false, followedRemotely = false))
+        dao.upsert(fixture(id = "library", inLibrary = true, followedRemotely = false))
+        dao.upsert(fixture(id = "followed", inLibrary = false, followedRemotely = true))
+
+        assertEquals(1, dao.deleteIfTransient("transient"))
+        assertEquals(0, dao.deleteIfTransient("library"))
+        assertEquals(0, dao.deleteIfTransient("followed"))
+
+        assertNull(dao.get("transient"))
+        assertNotNull(dao.get("library"))
+        assertNotNull(dao.get("followed"))
+    }
+}

--- a/core-data/src/test/kotlin/in/jphe/storyvox/data/db/dao/PlaybackDaoTest.kt
+++ b/core-data/src/test/kotlin/in/jphe/storyvox/data/db/dao/PlaybackDaoTest.kt
@@ -1,0 +1,208 @@
+package `in`.jphe.storyvox.data.db.dao
+
+import android.content.Context
+import androidx.room.Room
+import androidx.test.core.app.ApplicationProvider
+import `in`.jphe.storyvox.data.db.StoryvoxDatabase
+import `in`.jphe.storyvox.data.db.entity.Chapter
+import `in`.jphe.storyvox.data.db.entity.Fiction
+import `in`.jphe.storyvox.data.db.entity.PlaybackPosition
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.test.runTest
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNull
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+
+/**
+ * Issue #48 — Room+Robolectric DAO test for [PlaybackDao].
+ *
+ * The hot path is [PlaybackDao.observeMostRecentContinueListening] — the
+ * `LIMIT 1` + slim projection introduced for the Library Resume tile. A
+ * regression in either dimension (wrong row, wrong columns) ships a
+ * user-visible bug, so this is the single most valuable DAO test surface.
+ *
+ *  - LIMIT 1 means only the topmost row by `updatedAt DESC` may emit.
+ *  - The projection is hand-rolled `f.col AS f_col` aliasing — typos in
+ *    either side compile fine and silently produce wrong values.
+ *  - `f.inLibrary = 1` filters out un-libraried fictions even if a
+ *    `playback_position` row still exists for them.
+ *
+ * Also covers recent() + the cascade delete from chapter / fiction.
+ */
+@RunWith(RobolectricTestRunner::class)
+@Config(manifest = Config.NONE)
+class PlaybackDaoTest {
+
+    private lateinit var db: StoryvoxDatabase
+    private lateinit var dao: PlaybackDao
+    private lateinit var fictionDao: FictionDao
+    private lateinit var chapterDao: ChapterDao
+
+    private fun fiction(
+        id: String = "f1",
+        title: String = "Sky Pride",
+        inLibrary: Boolean = true,
+        coverUrl: String? = "https://example.test/$id.jpg",
+    ) = Fiction(
+        id = id,
+        sourceId = "royalroad",
+        title = title,
+        author = "Anonymous",
+        coverUrl = coverUrl,
+        description = "desc-$id",
+        tags = listOf("Adventure"),
+        firstSeenAt = 0L,
+        metadataFetchedAt = 0L,
+        inLibrary = inLibrary,
+    )
+
+    private fun chapter(
+        id: String,
+        fictionId: String,
+        index: Int = 0,
+        title: String = "Ch-$id",
+    ) = Chapter(
+        id = id,
+        fictionId = fictionId,
+        sourceChapterId = "src-$id",
+        index = index,
+        title = title,
+        publishedAt = 0L,
+        wordCount = 100,
+    )
+
+    @Before
+    fun setUp() {
+        val ctx = ApplicationProvider.getApplicationContext<Context>()
+        db = Room.inMemoryDatabaseBuilder(ctx, StoryvoxDatabase::class.java)
+            .allowMainThreadQueries()
+            .build()
+        dao = db.playbackDao()
+        fictionDao = db.fictionDao()
+        chapterDao = db.chapterDao()
+    }
+
+    @After
+    fun tearDown() {
+        db.close()
+    }
+
+    @Test
+    fun observeMostRecentContinueListening_returnsTopRowByUpdatedAtDesc() = runTest {
+        fictionDao.upsert(fiction("f1", title = "Old"))
+        fictionDao.upsert(fiction("f2", title = "New"))
+        chapterDao.upsert(chapter("c1", "f1"))
+        chapterDao.upsert(chapter("c2", "f2"))
+        dao.upsert(PlaybackPosition(fictionId = "f1", chapterId = "c1", updatedAt = 100L))
+        dao.upsert(PlaybackPosition(fictionId = "f2", chapterId = "c2", updatedAt = 200L))
+
+        val row = dao.observeMostRecentContinueListening().first()
+        assertNotNull(row)
+        assertEquals("f2", row!!.f_id)
+        assertEquals("New", row.f_title)
+        assertEquals("c2", row.c_id)
+    }
+
+    @Test
+    fun observeMostRecentContinueListening_excludesUnLibrariedFiction() = runTest {
+        fictionDao.upsert(fiction("f1", title = "Library", inLibrary = true))
+        fictionDao.upsert(fiction("f2", title = "Transient", inLibrary = false))
+        chapterDao.upsert(chapter("c1", "f1"))
+        chapterDao.upsert(chapter("c2", "f2"))
+
+        // The un-libraried fiction has the more recent updatedAt, but
+        // observeMostRecentContinueListening must skip it.
+        dao.upsert(PlaybackPosition("f1", "c1", updatedAt = 100L))
+        dao.upsert(PlaybackPosition("f2", "c2", updatedAt = 999L))
+
+        val row = dao.observeMostRecentContinueListening().first()
+        assertNotNull(row)
+        assertEquals("f1", row!!.f_id)
+    }
+
+    @Test
+    fun observeMostRecentContinueListening_emptyDb_emitsNull() = runTest {
+        val row = dao.observeMostRecentContinueListening().first()
+        assertNull(row)
+    }
+
+    @Test
+    fun observeMostRecentContinueListening_projectionAliasesAreCorrect() = runTest {
+        // Defensive: build a row where every aliased column has a distinct
+        // value, then verify the SELECT...AS...AS mapping doesn't transpose
+        // anything. Catches typos like `f.title AS c_title` that would compile.
+        fictionDao.upsert(
+            fiction("f1", title = "Fiction title", coverUrl = "https://cover.test/x.jpg"),
+        )
+        chapterDao.upsert(chapter("c1", "f1", index = 7, title = "Chapter title"))
+        dao.upsert(
+            PlaybackPosition(
+                fictionId = "f1",
+                chapterId = "c1",
+                charOffset = 1234,
+                playbackSpeed = 1.5f,
+                updatedAt = 500L,
+            ),
+        )
+
+        val row = dao.observeMostRecentContinueListening().first()!!
+        assertEquals("f1", row.f_id)
+        assertEquals("Fiction title", row.f_title)
+        assertEquals("https://cover.test/x.jpg", row.f_coverUrl)
+        assertEquals("c1", row.c_id)
+        assertEquals(7, row.c_index)
+        assertEquals("Chapter title", row.c_title)
+        assertEquals(1234, row.charOffset)
+        assertEquals(1.5f, row.playbackSpeed, 0.0001f)
+        assertEquals(500L, row.updatedAt)
+    }
+
+    @Test
+    fun recent_joinsAndOrdersByUpdatedAtDesc_respectsLimit() = runTest {
+        fictionDao.upsert(fiction("f1", title = "A"))
+        fictionDao.upsert(fiction("f2", title = "B"))
+        fictionDao.upsert(fiction("f3", title = "C"))
+        chapterDao.upsert(chapter("c1", "f1"))
+        chapterDao.upsert(chapter("c2", "f2"))
+        chapterDao.upsert(chapter("c3", "f3"))
+        dao.upsert(PlaybackPosition("f1", "c1", updatedAt = 10L))
+        dao.upsert(PlaybackPosition("f2", "c2", updatedAt = 30L))
+        dao.upsert(PlaybackPosition("f3", "c3", updatedAt = 20L))
+
+        val rows = dao.recent(limit = 2)
+        assertEquals(listOf("f2", "f3"), rows.map { it.fictionId })
+        assertEquals("B", rows[0].bookTitle)
+    }
+
+    @Test
+    fun deleteFiction_cascadesPlaybackPosition() = runTest {
+        // A transient fiction so we can use deleteIfTransient as the trigger.
+        val transient = fiction("transient", inLibrary = false)
+        fictionDao.upsert(transient)
+        chapterDao.upsert(chapter("ct", "transient"))
+        dao.upsert(PlaybackPosition("transient", "ct", updatedAt = 1L))
+
+        fictionDao.deleteIfTransient("transient")
+
+        assertNull(dao.get("transient"))
+    }
+
+    @Test
+    fun upsertThenDelete_isIdempotent() = runTest {
+        fictionDao.upsert(fiction("f1"))
+        chapterDao.upsert(chapter("c1", "f1"))
+        dao.upsert(PlaybackPosition("f1", "c1", updatedAt = 1L))
+        dao.delete("f1")
+
+        assertNull(dao.get("f1"))
+
+        // Second delete is a no-op, must not throw.
+        dao.delete("f1")
+    }
+}

--- a/feature/src/main/kotlin/in/jphe/storyvox/feature/browse/BrowseScreen.kt
+++ b/feature/src/main/kotlin/in/jphe/storyvox/feature/browse/BrowseScreen.kt
@@ -12,12 +12,14 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.lazy.LazyRow
 import androidx.compose.foundation.lazy.grid.GridCells
 import androidx.compose.foundation.lazy.grid.GridItemSpan
 import androidx.compose.foundation.lazy.grid.LazyVerticalGrid
 import androidx.compose.foundation.lazy.grid.itemsIndexed
 import androidx.compose.foundation.lazy.grid.items
 import androidx.compose.foundation.lazy.grid.rememberLazyGridState
+import androidx.compose.foundation.lazy.items
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Add
 import androidx.compose.material.icons.filled.Close
@@ -29,6 +31,8 @@ import androidx.compose.material3.AssistChipDefaults
 import androidx.compose.material3.Badge
 import androidx.compose.material3.BadgedBox
 import androidx.compose.material3.CenterAlignedTopAppBar
+import androidx.compose.material3.FilterChip
+import androidx.compose.material3.FilterChipDefaults
 import androidx.compose.material3.FloatingActionButton
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
@@ -37,9 +41,6 @@ import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.SecondaryScrollableTabRow
-import androidx.compose.material3.SegmentedButton
-import androidx.compose.material3.SegmentedButtonDefaults
-import androidx.compose.material3.SingleChoiceSegmentedButtonRow
 import androidx.compose.material3.Tab
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
@@ -128,7 +129,10 @@ fun BrowseScreen(
             selected = state.sourceKey,
             onSelect = viewModel::selectSource,
             enabledKeys = state.enabledSources,
-            modifier = Modifier.fillMaxWidth().padding(horizontal = spacing.md),
+            // Picker now handles its own horizontal padding via LazyRow's
+            // contentPadding so off-screen chips can pan into view without
+            // an outer padding clipping them at the edges.
+            modifier = Modifier.fillMaxWidth(),
         )
 
         val supportedTabs = remember(state.sourceKey, state.githubSignedIn) {
@@ -654,11 +658,25 @@ private val BrowseTab.label: String
     }
 
 /**
- * Two-segment source picker pinned above the tab row. Material 3
- * `SingleChoiceSegmentedButtonRow` with brass-tinted selection so it
- * reads as part of the realm aesthetic and not a generic Material
- * widget. Adding a new source is one more `forEach` entry once
- * `BrowseSourceKey` grows.
+ * Horizontally scrollable backend-picker strip pinned above the tab row.
+ *
+ * Each enabled backend gets its own [FilterChip] at its natural label
+ * width inside a [LazyRow]. The previous implementation used Material 3
+ * `SingleChoiceSegmentedButtonRow`, which divides the parent's width
+ * evenly between every segment — fine for 2-3 backends, but with 11+
+ * enabled it forces the label to wrap mid-word inside ~50dp segments
+ * and clips the off-screen backends entirely (no horizontal scroll on
+ * segmented rows). See #407.
+ *
+ * Filter chips:
+ *  - keep each label on one line (`softWrap = false`, `maxLines = 1`,
+ *    overflow = ellipsis for paranoia on very narrow tablets),
+ *  - allow the strip to grow as long as needed and pan freely on a
+ *    one-finger horizontal swipe (LazyRow handles fling + clipping),
+ *  - keep the brass-primary selection treatment so the strip still
+ *    reads as part of the realm aesthetic.
+ *
+ * Adding a new backend stays one entry in `BrowseSourceKey.entries`.
  */
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
@@ -668,6 +686,7 @@ private fun BrowseSourcePicker(
     enabledKeys: Set<BrowseSourceKey>,
     modifier: Modifier = Modifier,
 ) {
+    val spacing = LocalSpacing.current
     // Filter to user-enabled sources (#221) — when a backend is toggled
     // off in Settings, drop it from the picker entirely so Browse stops
     // trying to talk to it. If the user disables their currently-selected
@@ -676,22 +695,29 @@ private fun BrowseSourcePicker(
         BrowseSourceKey.entries.filter { it in enabledKeys }
     }
     if (keys.isEmpty()) return
-    SingleChoiceSegmentedButtonRow(modifier = modifier) {
-        keys.forEachIndexed { index, key ->
-            SegmentedButton(
+    LazyRow(
+        modifier = modifier,
+        horizontalArrangement = Arrangement.spacedBy(spacing.sm),
+        contentPadding = PaddingValues(horizontal = spacing.md),
+    ) {
+        items(keys, key = { it.name }) { key ->
+            FilterChip(
                 selected = key == selected,
                 onClick = { onSelect(key) },
-                shape = SegmentedButtonDefaults.itemShape(
-                    index = index,
-                    count = keys.size,
+                label = {
+                    Text(
+                        text = key.displayName,
+                        style = MaterialTheme.typography.labelLarge,
+                        maxLines = 1,
+                        softWrap = false,
+                        overflow = androidx.compose.ui.text.style.TextOverflow.Ellipsis,
+                    )
+                },
+                colors = FilterChipDefaults.filterChipColors(
+                    selectedContainerColor = MaterialTheme.colorScheme.primaryContainer,
+                    selectedLabelColor = MaterialTheme.colorScheme.onPrimaryContainer,
                 ),
-                colors = SegmentedButtonDefaults.colors(
-                    activeContainerColor = MaterialTheme.colorScheme.primaryContainer,
-                    activeContentColor = MaterialTheme.colorScheme.onPrimaryContainer,
-                ),
-            ) {
-                Text(key.displayName, style = MaterialTheme.typography.labelLarge)
-            }
+            )
         }
     }
 }


### PR DESCRIPTION
## Summary

Replaces `SingleChoiceSegmentedButtonRow` in `BrowseSourcePicker` with a `LazyRow` of `FilterChip`s.

## Root cause

`SingleChoiceSegmentedButtonRow` divides its parent's width evenly between every segment. With 11+ enabled backends the segment width collapses to ~50dp, the label wraps mid-word, and the row has no horizontal-scroll affordance — backends past index ~8 are unreachable.

## Fix

- `LazyRow` so the strip pans on a horizontal swipe, no clipping.
- `FilterChip` per backend with `softWrap = false`, `maxLines = 1`, ellipsis overflow as a paranoia fallback. Label sizes naturally to its content.
- Brass-primary selection treatment preserved (`selectedContainerColor` = `MaterialTheme.colorScheme.primaryContainer`).
- Horizontal padding moved from outer modifier into the LazyRow's `contentPadding` so first/last chip aren't clipped at the gutter when the strip is scrolled to the edge.

## Test plan

- [x] `./gradlew :feature:compileDebugKotlin` — clean (no unused-import warnings).
- [x] `./gradlew :app:assembleDebug` — APK builds.
- [ ] On-tablet visual check (QA): chip strip pans, every label fits one line, arXiv and PLOS chips reachable.

Adds a new `LazyRow` + `items` foundation import; drops the now-unused `SegmentedButton` / `SegmentedButtonDefaults` / `SingleChoiceSegmentedButtonRow` imports.

Closes #407.

🤖 Generated with [Claude Code](https://claude.com/claude-code)