### PR TITLE
fix(source): wrap Wikipedia + Wikisource HTTP calls in Dispatchers.IO — closes #419

### DIFF
--- a/source-wikipedia/src/main/kotlin/in/jphe/storyvox/source/wikipedia/net/WikipediaApi.kt
+++ b/source-wikipedia/src/main/kotlin/in/jphe/storyvox/source/wikipedia/net/WikipediaApi.kt
@@ -2,7 +2,9 @@ package `in`.jphe.storyvox.source.wikipedia.net
 
 import `in`.jphe.storyvox.data.source.model.FictionResult
 import `in`.jphe.storyvox.source.wikipedia.config.WikipediaConfig
+import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.withContext
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.JsonArray
@@ -145,12 +147,17 @@ internal class WikipediaApi @Inject constructor(
             is FictionResult.Failure -> raw
         }
 
-    private fun getRaw(url: String): FictionResult<String> {
-        return try {
+    private suspend fun getRaw(url: String): FictionResult<String> = withContext(Dispatchers.IO) {
+        try {
             // Accept-Language mirrors the host's language code so any
             // edge-cached payload comes back in the user's chosen
             // Wikipedia rather than negotiating into a different one.
-            // Pulled out of the URL itself to keep transport non-suspend.
+            //
+            // #419 — `execute()` is a blocking OkHttp call; the whole
+            // method MUST be off the main thread, hence the suspend
+            // signature + `withContext(Dispatchers.IO)` wrapper. The
+            // original non-suspend shape crashed Browse → Wikipedia
+            // with NetworkOnMainThreadException on first chip tap.
             val req = Request.Builder()
                 .url(url)
                 .header("Accept", "application/json")
@@ -176,7 +183,7 @@ internal class WikipediaApi @Inject constructor(
                         )
                     else -> {
                         val text = resp.body?.string()
-                            ?: return FictionResult.NetworkError("empty body", IOException("empty body"))
+                            ?: return@withContext FictionResult.NetworkError("empty body", IOException("empty body"))
                         FictionResult.Success(text)
                     }
                 }

--- a/source-wikisource/src/main/kotlin/in/jphe/storyvox/source/wikisource/net/WikisourceApi.kt
+++ b/source-wikisource/src/main/kotlin/in/jphe/storyvox/source/wikisource/net/WikisourceApi.kt
@@ -1,6 +1,8 @@
 package `in`.jphe.storyvox.source.wikisource.net
 
 import `in`.jphe.storyvox.data.source.model.FictionResult
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.json.Json
 import okhttp3.OkHttpClient
@@ -182,8 +184,12 @@ internal class WikisourceApi @Inject constructor(
             is FictionResult.Failure -> raw
         }
 
-    private fun getRaw(url: String): FictionResult<String> {
-        return try {
+    // #419 — `execute()` is blocking; without the suspend + Dispatchers.IO
+    // wrapper the whole method runs on whatever coroutine context called
+    // it, which is the main thread in Compose. Crashed Browse → Wikisource
+    // with NetworkOnMainThreadException on first chip tap.
+    private suspend fun getRaw(url: String): FictionResult<String> = withContext(Dispatchers.IO) {
+        try {
             val req = Request.Builder()
                 .url(url)
                 .header("Accept", "application/json")
@@ -209,7 +215,7 @@ internal class WikisourceApi @Inject constructor(
                         )
                     else -> {
                         val text = resp.body?.string()
-                            ?: return FictionResult.NetworkError("empty body", IOException("empty body"))
+                            ?: return@withContext FictionResult.NetworkError("empty body", IOException("empty body"))
                         FictionResult.Success(text)
                     }
                 }


### PR DESCRIPTION
## Summary
- `WikipediaApi.getRaw` / `WikisourceApi.getRaw` are now `suspend` and wrapped in `withContext(Dispatchers.IO)` — they were doing blocking `client.newCall(req).execute()` without an off-main-thread hop, which crashed Browse → Wikipedia and Browse → Wikisource with `NetworkOnMainThreadException` on first chip tap.
- Same class of bug as the earlier `:source-gutenberg` fix.
- Caught by the QA-rerespawn agent against v0.5.29 on tablet R83W80CAFZB + Flip3 R5CRB0W66MK. See [#419](https://github.com/techempower-org/storyvox/issues/419) for the captured logcat stacks.

## Test plan
- [x] `./gradlew :source-wikipedia:compileDebugKotlin :source-wikisource:compileDebugKotlin` green
- [x] `./gradlew :app:assembleDebug` green
- [x] `./gradlew :source-wikipedia:testDebugUnitTest :source-wikisource:testDebugUnitTest` green
- [ ] Install v0.5.30 on tablet + Flip3 once bundled; verify Browse → Wikipedia and Browse → Wikisource load fictions without crashing

🤖 Generated with [Claude Code](https://claude.com/claude-code)