### PR TITLE
fix(voice): chip-strip clipping on tablet initial render — closes #420

### DIFF
--- a/feature/src/main/kotlin/in/jphe/storyvox/feature/voicelibrary/VoiceLibraryScreen.kt
+++ b/feature/src/main/kotlin/in/jphe/storyvox/feature/voicelibrary/VoiceLibraryScreen.kt
@@ -219,11 +219,25 @@ fun VoiceLibraryScreen(
             // Secondary chip row — gender / tier / multilingual. These
             // pre-date JP's #264 primary-knob spec but stay useful, so
             // they hang below the language strip on their own scroll.
+            //
+            // Issue #420 — asymmetric end-padding (spacing.xl = 32dp vs
+            // start spacing.md = 16dp) so the rightmost chip
+            // ("Multilingual") lands as an obviously-partial chip on
+            // narrow viewports (e.g. the 800dp tablet portrait) rather
+            // than a 9-pixel sliver right at the screen edge. A clearly
+            // partial chip reads as "scroll for more →"; a 9-pixel
+            // sliver reads as a rendering glitch. Discovery fix only —
+            // the scroll itself was already wired up.
             Row(
                 modifier = Modifier
                     .fillMaxWidth()
                     .horizontalScroll(rememberScrollState())
-                    .padding(horizontal = spacing.md, vertical = spacing.xxs),
+                    .padding(
+                        start = spacing.md,
+                        end = spacing.xl,
+                        top = spacing.xxs,
+                        bottom = spacing.xxs,
+                    ),
                 horizontalArrangement = Arrangement.spacedBy(spacing.xs),
                 verticalAlignment = Alignment.CenterVertically,
             ) {


### PR DESCRIPTION
## Summary

- Voice library's secondary filter chip row clipped the rightmost "Multilingual" chip to a 9-pixel sliver at x=791..800 on the 800dp tablet portrait viewport on initial render — a discoverability bug, not a functional one (#420). The chip *was* fully scroll-reachable, but the sliver gave no visual signal that more chips existed past the right edge.
- Switched the row's `.padding(horizontal = spacing.md, vertical = spacing.xxs)` to asymmetric `start = spacing.md (16dp)`, `end = spacing.xl (32dp)`. The rightmost chip now lands as an obviously-partial chip on the tablet, reading as "scroll for more →" instead of a rendering glitch. Single-line layout, no chip relabeling, no fade-gradient overlay.

## Test plan

- [x] `./gradlew :feature:testDebugUnitTest` — green (15 existing tests in VoiceFilterTest.kt unaffected; layout fix is not unit-testable)
- [x] `./gradlew :app:assembleDebug` — green
- [x] Installed on **R83W80CAFZB** (Samsung SM-T227U tablet, 800dp portrait, the bug-repro device): chip row now shows ♀ Female, ♂ Male, Neutral, Studio, High, Med, Low + a clearly partial "M..." chip at the right edge on initial render. Swipe-left reveals "Multilingual" fully with end-gutter.
- [x] Installed on **R5CRB0W66MK** (Flip3, 1080px): chip row unaffected, no regression. Fewer chips shown initially (as before), cutoff is clean.
- [ ] Reviewer eyeball on a phone-class device of choice — visual change only.

Closes #420.