### PR TITLE
fix(source-ao3): use numeric tag ids for Atom feed URLs — closes #408

### DIFF
--- a/source-ao3/src/main/kotlin/in/jphe/storyvox/source/ao3/Ao3Source.kt
+++ b/source-ao3/src/main/kotlin/in/jphe/storyvox/source/ao3/Ao3Source.kt
@@ -42,11 +42,19 @@ import javax.inject.Singleton
  *
  * AO3 doesn't expose a unified catalog — discovery is fundamentally
  * per-tag. v1 ships a curated handful of fandoms in the Browse
- * picker (see [CURATED_TAGS]); when no genre is selected the source
- * defaults to a broad "Original Work" feed so the picker has
- * something to render on first open. Users wanting other fandoms
- * use Search (deferred — AO3's search is HTML-only and we don't
- * want any scraping in v1) or a future tag-picker UI.
+ * picker (see [FANDOM_TAGS]); when no genre is selected the source
+ * defaults to the Marvel Cinematic Universe feed (the curated list's
+ * largest fandom) so the picker has something to render on first
+ * open. Users wanting other fandoms use Search (deferred — AO3's
+ * search is HTML-only and we don't want any scraping in v1) or a
+ * future tag-picker UI.
+ *
+ * #408 — the Atom feed URL is built from each tag's numeric AO3 id
+ * rather than its slug. AO3 dropped the slug→numeric redirect
+ * sometime in early 2026; `GET /tags/<slug>/feed.atom` now returns
+ * 404 outright. The numeric form (`/tags/<id>/feed.atom`) returns
+ * the same Atom XML it always has. See [FANDOM_TAGS] for the
+ * resolved (name, id) pairs.
  *
  * Legal posture: AO3 is run by the Organization for Transformative
  * Works, a 501(c)(3). Their ToS draws a hard line at commercial
@@ -93,12 +101,13 @@ internal class Ao3Source @Inject constructor(
 
     /**
      * No global "popular" surface on AO3 — works are popular *within*
-     * tags. v1 maps Popular = the default-tag feed (Original Work).
-     * The genre row picks specific fandoms; when the user has selected
-     * a fandom via [byGenre], that takes over and this never fires.
+     * tags. v1 maps Popular = the default-tag feed (MCU; see
+     * [DEFAULT_TAG_ID]). The genre row picks specific fandoms; when
+     * the user has selected a fandom via [byGenre], that takes over
+     * and this never fires.
      */
     override suspend fun popular(page: Int): FictionResult<ListPage<FictionSummary>> =
-        feedAsListPage(DEFAULT_TAG, page)
+        feedAsListPage(DEFAULT_TAG_ID, page)
 
     /**
      * Same surface as [popular] — the Atom feed is sorted by recency,
@@ -109,13 +118,20 @@ internal class Ao3Source @Inject constructor(
      * pretending we have a popularity signal we don't.
      */
     override suspend fun latestUpdates(page: Int): FictionResult<ListPage<FictionSummary>> =
-        feedAsListPage(DEFAULT_TAG, page)
+        feedAsListPage(DEFAULT_TAG_ID, page)
 
     override suspend fun byGenre(
         genre: String,
         page: Int,
-    ): FictionResult<ListPage<FictionSummary>> =
-        feedAsListPage(genre, page)
+    ): FictionResult<ListPage<FictionSummary>> {
+        // #408 — the genre string is the display name from [genres()];
+        // map it back to the canonical AO3 numeric tag id baked into
+        // [FANDOM_TAGS]. Unknown names fall back to the default tag
+        // rather than 404'ing, mirroring the same conservative
+        // posture [popular] uses.
+        val tagId = tagIdFor(genre) ?: DEFAULT_TAG_ID
+        return feedAsListPage(tagId, page)
+    }
 
     /**
      * Search is deferred per the issue spec — AO3's `/works/search`
@@ -129,14 +145,15 @@ internal class Ao3Source @Inject constructor(
         FictionResult.Success(ListPage(items = emptyList(), page = 1, hasNext = false))
 
     /**
-     * Curated tag list for the Browse genre picker. Six fandoms hand-
-     * picked for breadth — the v1 surface intentionally avoids the
-     * full AO3 tag taxonomy (a million-plus tags don't fit in a
+     * Curated tag list for the Browse genre picker. Three fandoms
+     * hand-picked for breadth — the v1 surface intentionally avoids
+     * the full AO3 tag taxonomy (a million-plus tags don't fit in a
      * picker). A follow-up issue will let the user add their own
-     * tags; until then this list is the surface.
+     * tags; until then this list is the surface. See [FANDOM_TAGS]
+     * for the (name, numeric-tag-id) pairs.
      */
     override suspend fun genres(): FictionResult<List<String>> =
-        FictionResult.Success(CURATED_TAGS)
+        FictionResult.Success(FANDOM_TAGS.map { it.first })
 
     // ─── detail ────────────────────────────────────────────────────────
 
@@ -234,10 +251,10 @@ internal class Ao3Source @Inject constructor(
     // ─── helpers ───────────────────────────────────────────────────────
 
     private suspend fun feedAsListPage(
-        tag: String,
+        tagId: Long,
         page: Int,
     ): FictionResult<ListPage<FictionSummary>> {
-        return when (val r = api.tagFeed(tag, page)) {
+        return when (val r = api.tagFeed(tagId, page)) {
             is FictionResult.Success -> FictionResult.Success(r.value.toListPage(page))
             is FictionResult.Failure -> r
         }
@@ -295,39 +312,60 @@ internal class Ao3Source @Inject constructor(
         return File(cacheDir, "$id.epub")
     }
 
+    /** Map a user-visible fandom name back to its AO3 numeric tag
+     *  id. Lookup is case-sensitive against the canonical names in
+     *  [FANDOM_TAGS]. Returns null when the user picked something
+     *  outside the curated list — callers (just [byGenre] today)
+     *  fall back to the default tag rather than 404'ing. */
+    private fun tagIdFor(name: String): Long? =
+        FANDOM_TAGS.firstOrNull { it.first == name }?.second
+
     companion object {
         /**
-         * Curated fandom tags for the v1 Browse picker. Six picks
-         * chosen for breadth — heavyweight commercial fandoms
-         * (Marvel, Star Wars, HP) plus the catch-all "Original Work"
-         * and a long-form genre canon (Sherlock Holmes). Keep the
+         * Curated fandom tags for the v1 Browse picker. Chosen for
+         * breadth — heavyweight commercial fandoms (Marvel, Star
+         * Wars) plus a long-form genre canon (Good Omens). Keep the
          * list short on purpose: AO3 has a million-plus tags and a
          * picker has to make a choice. Users wanting more
          * specificity get the tag-picker follow-up.
          *
-         * Strings here are the AO3 tag canonicals (URL-encoded by
-         * the API layer). Hyphens and ampersands are preserved
-         * verbatim — those are part of the tag, not punctuation.
+         * #408 — these are now `(displayName, numericTagId)` pairs.
+         * AO3 dropped the slug→tag-id redirect that used to back
+         * `/tags/<slug>/feed.atom` (now returns 404), so the Atom
+         * feed URL has to be built from the numeric tag id
+         * directly. The numeric ids below were resolved by parsing
+         * the `<link rel="alternate" type="application/atom+xml">`
+         * out of each tag's `/tags/<slug>/works` HTML page; that
+         * page still serves under the slug form and exposes the
+         * canonical feed URL, e.g. `/tags/414093/feed.atom` for
+         * Marvel Cinematic Universe.
+         *
+         * IDs are baked at build time — there's no per-app
+         * autocomplete resolver in v1 (a future tag-picker UI is
+         * tracked in the #408 follow-up). If AO3 ever renumbers a
+         * canonical tag (extremely rare — the id is a primary key)
+         * the corresponding genre tab will start returning empty
+         * Atom feeds and the line below needs an update.
          */
-        val CURATED_TAGS: List<String> = listOf(
-            "Marvel Cinematic Universe",
-            "Harry Potter - J. K. Rowling",
-            "Star Wars - All Media Types",
-            "Original Work",
-            "Sherlock Holmes & Related Fandoms - All Media Types",
-            "Good Omens (TV)",
+        val FANDOM_TAGS: List<Pair<String, Long>> = listOf(
+            "Marvel Cinematic Universe" to 414093L,
+            "Star Wars - All Media Types" to 101375L,
+            "Good Omens (TV)" to 27251507L,
         )
 
         /**
-         * Default tag for the Popular / NewReleases tabs when the
-         * user hasn't picked a fandom from the genre row. "Original
-         * Work" is the broadest fandom-neutral tag — works tagged
-         * here are mostly long-form prose written for AO3 directly
-         * rather than fanfic of a specific media property, which
-         * pairs well with the audiobook use case and avoids
-         * pre-picking a fandom on the user's behalf.
+         * Default tag id for the Popular / NewReleases tabs when the
+         * user hasn't picked a fandom from the genre row. Points at
+         * "Marvel Cinematic Universe" (id 414093) — the broadest of
+         * the curated fandoms, with the highest steady-state work
+         * count, so the Popular tab always has something to render
+         * on first open. Previously this was "Original Work" by
+         * slug, but resolving its numeric id requires a Cloudflare-
+         * fronted HTML fetch that's been flaky at build time; the
+         * follow-up tag-picker (#408 referenced issue) will let the
+         * user pick their own default.
          */
-        const val DEFAULT_TAG: String = "Original Work"
+        const val DEFAULT_TAG_ID: Long = 414093L
     }
 }
 

--- a/source-ao3/src/main/kotlin/in/jphe/storyvox/source/ao3/net/Ao3Api.kt
+++ b/source-ao3/src/main/kotlin/in/jphe/storyvox/source/ao3/net/Ao3Api.kt
@@ -6,7 +6,6 @@ import kotlinx.coroutines.withContext
 import okhttp3.OkHttpClient
 import okhttp3.Request
 import java.io.IOException
-import java.net.URLEncoder
 import javax.inject.Inject
 import javax.inject.Singleton
 
@@ -44,26 +43,22 @@ internal class Ao3Api @Inject constructor(
     private val client: OkHttpClient,
 ) {
     /**
-     * `GET /tags/<tag>/feed.atom` — the listing surface. Returns the
-     * raw XML body for [Ao3AtomFeed.parse] to turn into typed
+     * `GET /tags/<tagId>/feed.atom` — the listing surface. Returns
+     * the raw XML body for [Ao3AtomFeed.parse] to turn into typed
      * entries. AO3 paginates this feed via a `?page=N` query param;
      * the feed itself is fixed at ~20 entries per page.
+     *
+     * #408 — the URL now keys on AO3's internal numeric tag id, not
+     * the slug. AO3 dropped the slug→numeric redirect that used to
+     * back `GET /tags/<slug>/feed.atom`; that URL now returns 404
+     * outright. The numeric form has always worked and returns
+     * byte-identical Atom XML, so this is the minimum-surface fix.
+     * No slug encoding is needed — numeric ids are URL-safe by
+     * construction. See [Ao3Source.FANDOM_TAGS] for the resolved
+     * (name, id) pairs the [Ao3Source] passes in.
      */
-    suspend fun tagFeed(tag: String, page: Int = 1): FictionResult<Ao3AtomFeed> {
-        // AO3 tags are URL-encoded with spaces → `%20` and `/` → `*s*`
-        // (AO3's own escape token). We support the slash-form because
-        // many fandoms include slashes ("Sherlock Holmes & Related
-        // Fandoms - All Media Types" doesn't, but ship/relationship
-        // tags use them frequently). Curated v1 tags don't include
-        // slashes so the simple form works; the more complex escapes
-        // are deferred until the user-tag-picker lands.
-        val safeTag = URLEncoder.encode(tag, Charsets.UTF_8)
-            .replace("+", "%20")
-        val path = if (page <= 1) {
-            "/tags/$safeTag/feed.atom"
-        } else {
-            "/tags/$safeTag/feed.atom?page=$page"
-        }
+    suspend fun tagFeed(tagId: Long, page: Int = 1): FictionResult<Ao3AtomFeed> {
+        val path = tagFeedPath(tagId, page)
         return withContext(Dispatchers.IO) {
             requestText(path).let { res ->
                 when (res) {
@@ -72,7 +67,7 @@ internal class Ao3Api @Inject constructor(
                             FictionResult.Success(Ao3AtomFeed.parse(res.value))
                         } catch (e: Exception) {
                             FictionResult.NetworkError(
-                                "AO3 Atom feed for tag '$tag' unparseable: ${e.message}",
+                                "AO3 Atom feed for tag id $tagId unparseable: ${e.message}",
                                 e,
                             )
                         }
@@ -178,6 +173,19 @@ internal class Ao3Api @Inject constructor(
 
     companion object {
         const val BASE_URL = "https://archiveofourown.org"
+
+        /**
+         * Build the per-tag Atom feed path for `tagId` at `page`.
+         * Exposed package-private so the unit tests can pin the URL
+         * shape without exercising the OkHttp client. See
+         * [tagFeed] for the call site.
+         */
+        internal fun tagFeedPath(tagId: Long, page: Int = 1): String =
+            if (page <= 1) {
+                "/tags/$tagId/feed.atom"
+            } else {
+                "/tags/$tagId/feed.atom?page=$page"
+            }
 
         /**
          * Identifies storyvox in the User-Agent. AO3's Terms of Service

--- a/source-ao3/src/test/kotlin/in/jphe/storyvox/source/ao3/Ao3TagUrlTest.kt
+++ b/source-ao3/src/test/kotlin/in/jphe/storyvox/source/ao3/Ao3TagUrlTest.kt
@@ -1,0 +1,81 @@
+package `in`.jphe.storyvox.source.ao3
+
+import `in`.jphe.storyvox.source.ao3.net.Ao3Api
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * Issue #408 — pin the AO3 tag-feed URL shape and the curated
+ * [Ao3Source.FANDOM_TAGS] payload.
+ *
+ * The bug surfaced when AO3 dropped the implicit slug→numeric-id
+ * redirect that backed `/tags/<slug>/feed.atom`. The old URL builder
+ * URL-encoded the slug (with the `*s*`/`*a*` escapes the Archive uses
+ * for special characters); the fix keys the URL on AO3's internal
+ * numeric tag id instead, which is a primary key and doesn't depend
+ * on any redirect being in place. These tests pin both halves —
+ *
+ *  - the URL builder emits exactly `/tags/<numeric>/feed.atom`
+ *    (no slug, no encoding step that could regress to the old shape)
+ *  - [Ao3Source.FANDOM_TAGS] carries real (non-blank) display names
+ *    paired with positive numeric ids, with no duplicates
+ *
+ * A failure here is the right signal that someone tried to bring the
+ * slug form back without also resolving every numeric id.
+ */
+class Ao3TagUrlTest {
+
+    @Test
+    fun `tagFeedPath emits numeric id path on page 1`() {
+        val path = Ao3Api.tagFeedPath(tagId = 414093L, page = 1)
+        assertEquals("/tags/414093/feed.atom", path)
+        // No slug, no percent-encoding, no AO3 *s* / *a* escape sequences.
+        assertFalse("path must not contain a slug separator", path.contains("Marvel"))
+        assertFalse("path must not contain percent-encoding", path.contains('%'))
+        assertFalse("path must not carry AO3's slash escape", path.contains("*s*"))
+        assertFalse("path must not carry AO3's amp escape", path.contains("*a*"))
+    }
+
+    @Test
+    fun `tagFeedPath appends page query for paginated requests`() {
+        assertEquals("/tags/27251507/feed.atom?page=2", Ao3Api.tagFeedPath(27251507L, 2))
+        assertEquals("/tags/27251507/feed.atom?page=10", Ao3Api.tagFeedPath(27251507L, 10))
+    }
+
+    @Test
+    fun `tagFeedPath treats page 0 and negative as page 1 (no query)`() {
+        // Defensive — callers shouldn't pass <= 0, but if they do we
+        // return the canonical first-page URL rather than emit a
+        // malformed `?page=0` that AO3 might silently 200-with-empty.
+        assertEquals("/tags/414093/feed.atom", Ao3Api.tagFeedPath(414093L, 0))
+        assertEquals("/tags/414093/feed.atom", Ao3Api.tagFeedPath(414093L, -3))
+    }
+
+    @Test
+    fun `FANDOM_TAGS entries are well-formed`() {
+        val tags = Ao3Source.FANDOM_TAGS
+        assertTrue("curated list must not be empty", tags.isNotEmpty())
+        for ((name, id) in tags) {
+            assertTrue("display name must be non-blank, got '$name'", name.isNotBlank())
+            assertTrue("tag id must be positive, got $id for '$name'", id > 0L)
+        }
+        val names = tags.map { it.first }
+        assertEquals("display names must be unique", names.toSet().size, names.size)
+        val ids = tags.map { it.second }
+        assertEquals("tag ids must be unique", ids.toSet().size, ids.size)
+    }
+
+    @Test
+    fun `DEFAULT_TAG_ID is a real entry in FANDOM_TAGS`() {
+        // The default has to be a tag we actually surface, otherwise
+        // the Browse → AO3 → Popular tab will key off something the
+        // user can never re-select from the genre row.
+        val defaultId = Ao3Source.DEFAULT_TAG_ID
+        assertTrue(
+            "DEFAULT_TAG_ID $defaultId must appear in FANDOM_TAGS",
+            Ao3Source.FANDOM_TAGS.any { it.second == defaultId },
+        )
+    }
+}


### PR DESCRIPTION
## Summary

- AO3's slug→numeric-id redirect that backed `GET /tags/<slug>/feed.atom` is gone (404). The numeric form `/tags/<id>/feed.atom` still returns identical Atom XML, so the fix is just keying the URL on the numeric tag id instead of the slug.
- `Ao3Api.tagFeed(tag: String)` → `tagFeed(tagId: Long)`. `Ao3Source.CURATED_TAGS: List<String>` → `FANDOM_TAGS: List<Pair<String, Long>>`. `DEFAULT_TAG: String` → `DEFAULT_TAG_ID: Long`. No new deps, no scraping, no mirror swap.
- v1 ships 3 verified (name, id) pairs: Marvel Cinematic Universe → 414093, Star Wars - All Media Types → 101375, Good Omens (TV) → 27251507. AO3 Cloudflare 525'd the slug pages for HP / Original Work / Sherlock during ID discovery; those return in the follow-up tag-picker.

## Test plan

- [x] `:source-ao3:testDebugUnitTest` — 5 tests, 0 failures (new `Ao3TagUrlTest` pins URL shape + curated-list invariants).
- [x] `:app:assembleDebug` — green.
- [ ] `:app:testDebugUnitTest` — has a **pre-existing** failure in `SettingsRepositoryVoiceLexiconLangTest.kt` (constructor mismatch on `SettingsRepositoryUiImpl`); same failure on `main`'s tip (a20cd4e). Not introduced by this PR.
- [x] Installed APK on tablet R83W80CAFZB; launched via launcher intent.
- [ ] Manual: open Browse → AO3 on the tablet and confirm the Popular tab + the three genre tabs (MCU / Star Wars / Good Omens) actually populate with works against the live Atom feeds. (URL builder + tests pin the contract; live verification is the proof the slug→numeric switch is enough.)

## Out of scope

- Re-resolving HP / Original Work / Sherlock numeric ids. AO3's slug HTML pages are Cloudflare 525'ing intermittently; the follow-up tag-picker PR handles dynamic resolution properly instead of trying to bake more ids at build time.
- No `versionCode`/`versionName` bump — orchestrator bundles this into v0.5.31.

🤖 Generated with [Claude Code](https://claude.com/claude-code)