### PR TITLE
feat(ai): function calling — 5 tools (add_to_shelf, queue_chapter, mark_chapter_read, set_speed, open_voice_library) — closes #216

### DIFF
--- a/app/src/main/kotlin/in/jphe/storyvox/data/SettingsRepositoryUiImpl.kt
+++ b/app/src/main/kotlin/in/jphe/storyvox/data/SettingsRepositoryUiImpl.kt
@@ -546,6 +546,11 @@ private object Keys {
      *  as true so fresh installs (and pre-#217 installs upgrading)
      *  both get the more-useful default. */
     val AI_CARRY_MEMORY_ACROSS_FICTIONS = booleanPreferencesKey("pref_ai_carry_memory_across_fictions")
+    /** Issue #216 — "Allow the AI to take actions" toggle. Default
+     *  ON across fresh + upgrading installs; the Settings → AI
+     *  screen lets the user opt out. Same write-once-default-on
+     *  pattern as the cross-fiction memory key. */
+    val AI_ACTIONS_ENABLED = booleanPreferencesKey("pref_ai_actions_enabled")
 
     /** Issue #135 — JSON-serialized [PronunciationDict] (list of
      *  pattern/replacement/matchType entries). _v1 suffix lets us
@@ -903,6 +908,12 @@ class SettingsRepositoryUiImpl(
                 // upgrades also pick up the default because the key
                 // doesn't exist yet (DataStore returns null → ?: true).
                 carryMemoryAcrossFictions = prefs[Keys.AI_CARRY_MEMORY_ACROSS_FICTIONS] ?: true,
+                // Issue #216 — default ON for fresh installs (matches
+                // [LlmConfig.aiActionsEnabled]). The chat surface only
+                // exposes actions when the active provider supports
+                // tool use; this toggle is the user's "I don't want
+                // the AI doing things" kill switch.
+                actionsEnabled = prefs[Keys.AI_ACTIONS_ENABLED] ?: true,
             ),
             sigil = Sigil.current.let {
                 UiSigil(
@@ -1386,6 +1397,10 @@ class SettingsRepositoryUiImpl(
         store.edit { it[Keys.AI_CARRY_MEMORY_ACROSS_FICTIONS] = enabled }
     }
 
+    override suspend fun setAiActionsEnabled(enabled: Boolean) {
+        store.edit { it[Keys.AI_ACTIONS_ENABLED] = enabled }
+    }
+
     override suspend fun acknowledgeAiPrivacy() {
         store.edit { it[Keys.AI_PRIVACY_ACK] = true }
     }
@@ -1711,6 +1726,9 @@ class SettingsRepositoryUiImpl(
             bedrockModel = prefs[Keys.AI_BEDROCK_MODEL] ?: "claude-haiku-4.5",
             privacyAcknowledged = prefs[Keys.AI_PRIVACY_ACK] ?: false,
             sendChapterTextEnabled = prefs[Keys.AI_SEND_CHAPTER_TEXT] ?: false,
+            // Issue #216 — default ON, matches the UiAiSettings
+            // mirror above.
+            aiActionsEnabled = prefs[Keys.AI_ACTIONS_ENABLED] ?: true,
         )
     }
 
@@ -1733,6 +1751,7 @@ class SettingsRepositoryUiImpl(
             p[Keys.AI_BEDROCK_MODEL] = config.bedrockModel
             p[Keys.AI_PRIVACY_ACK] = config.privacyAcknowledged
             p[Keys.AI_SEND_CHAPTER_TEXT] = config.sendChapterTextEnabled
+            p[Keys.AI_ACTIONS_ENABLED] = config.aiActionsEnabled
         }
     }
 

--- a/app/src/main/kotlin/in/jphe/storyvox/navigation/StoryvoxNavHost.kt
+++ b/app/src/main/kotlin/in/jphe/storyvox/navigation/StoryvoxNavHost.kt
@@ -480,6 +480,7 @@ private fun StoryvoxNavHostContent(
                 ChatScreen(
                     onBack = { navController.popBackStack() },
                     onOpenAiSettings = { navController.navigate(StoryvoxRoutes.SETTINGS) },
+                    onOpenVoiceLibrary = { navController.navigate(StoryvoxRoutes.VOICE_LIBRARY) },
                 )
             }
 

--- a/app/src/test/kotlin/in/jphe/storyvox/di/RealPlaybackControllerUiTest.kt
+++ b/app/src/test/kotlin/in/jphe/storyvox/di/RealPlaybackControllerUiTest.kt
@@ -270,6 +270,7 @@ class RealPlaybackControllerUiTest {
         override suspend fun setChatGroundEntireChapter(enabled: Boolean) = Unit
         override suspend fun setChatGroundEntireBookSoFar(enabled: Boolean) = Unit
         override suspend fun setCarryMemoryAcrossFictions(enabled: Boolean) = Unit
+        override suspend fun setAiActionsEnabled(enabled: Boolean) = Unit
         override suspend fun acknowledgeAiPrivacy() = Unit
         override suspend fun resetAiSettings() = Unit
         // ── GitHub OAuth no-op (#91) — playback-controller test doesn't auth. ──

--- a/core-llm/src/main/kotlin/in/jphe/storyvox/llm/LlmConfig.kt
+++ b/core-llm/src/main/kotlin/in/jphe/storyvox/llm/LlmConfig.kt
@@ -56,6 +56,22 @@ data class LlmConfig(
      *  works (key entry, Test connection) but no chapter text is
      *  ever sent. Recap button greys out with "Enable in Settings". */
     val sendChapterTextEnabled: Boolean = true,
+    /**
+     * Issue #216 — global toggle for AI-initiated actions
+     * ("Allow the AI to take actions" in Settings → AI). When false,
+     * the chat layer passes an empty [ToolRegistry] to the provider —
+     * function calling is silently disabled, the model behaves as a
+     * plain Q&A bot. When true, the v1 tool catalog from
+     * `StoryvoxToolSpecs` is advertised on every chat turn and the
+     * model can invoke handlers wired by `ChatToolHandlers`.
+     *
+     * Default ON for fresh installs — the spec calls actions out as
+     * the headline behaviour of the feature; gating them behind an
+     * opt-in toggle would hide the new capability from most users.
+     * The toggle exists as an escape hatch for users who want to
+     * disable agency for any reason (privacy, accident-avoidance).
+     */
+    val aiActionsEnabled: Boolean = true,
 )
 
 /**

--- a/core-llm/src/main/kotlin/in/jphe/storyvox/llm/LlmProvider.kt
+++ b/core-llm/src/main/kotlin/in/jphe/storyvox/llm/LlmProvider.kt
@@ -1,6 +1,9 @@
 package `in`.jphe.storyvox.llm
 
+import `in`.jphe.storyvox.llm.tools.ChatStreamEvent
+import `in`.jphe.storyvox.llm.tools.ToolRegistry
 import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.map
 
 /**
  * One LLM backend. Implementations live in
@@ -51,4 +54,38 @@ interface LlmProvider {
      * fire-and-forget UI use, not flow consumption.
      */
     suspend fun probe(): ProbeResult
+
+    /**
+     * Issue #216 — does this provider support function calling /
+     * tool use? v1 ships with Anthropic (Claude direct + Teams) and
+     * OpenAI only; other providers return false, and the chat layer
+     * surfaces an empty-state message ("Tools not supported on this
+     * provider — actions will not work") when the user attempts an
+     * action.
+     *
+     * Override on the two supporting providers; the default false
+     * keeps the rest of the matrix correct without per-provider
+     * boilerplate.
+     */
+    val supportsTools: Boolean get() = false
+
+    /**
+     * Issue #216 — tool-aware chat. Default impl falls back to
+     * [stream] (no tools), wrapping each text emit as a
+     * [ChatStreamEvent.TextDelta]. Providers that implement
+     * [supportsTools] override this to drive the full
+     * model→tool_call→tool_result→model loop and emit
+     * [ChatStreamEvent.ToolCallStarted] / [ChatStreamEvent.ToolCallCompleted]
+     * pairs in line with text deltas.
+     *
+     * @param tools registry of available tools + handlers. When
+     *   empty, behaves identically to a tool-less chat.
+     */
+    fun chatWithTools(
+        messages: List<LlmMessage>,
+        systemPrompt: String? = null,
+        model: String? = null,
+        tools: ToolRegistry = ToolRegistry.EMPTY,
+    ): Flow<ChatStreamEvent> = stream(messages, systemPrompt, model)
+        .map { ChatStreamEvent.TextDelta(it) }
 }

--- a/core-llm/src/main/kotlin/in/jphe/storyvox/llm/LlmRepository.kt
+++ b/core-llm/src/main/kotlin/in/jphe/storyvox/llm/LlmRepository.kt
@@ -7,6 +7,8 @@ import `in`.jphe.storyvox.llm.provider.ClaudeApiProvider
 import `in`.jphe.storyvox.llm.provider.OllamaProvider
 import `in`.jphe.storyvox.llm.provider.OpenAiApiProvider
 import `in`.jphe.storyvox.llm.provider.VertexProvider
+import `in`.jphe.storyvox.llm.tools.ChatStreamEvent
+import `in`.jphe.storyvox.llm.tools.ToolRegistry
 import javax.inject.Inject
 import javax.inject.Singleton
 import kotlinx.coroutines.flow.Flow
@@ -63,6 +65,36 @@ class LlmRepository @Inject constructor(
     ): Flow<String> = flow {
         emitAll(providerFor(provider).stream(messages, systemPrompt, model))
     }
+
+    /**
+     * Issue #216 — tool-aware chat against an explicit provider.
+     * When [tools] is empty (or the provider doesn't support tool
+     * use), this falls through to plain text streaming, wrapped as
+     * [ChatStreamEvent.TextDelta] emits. Providers that DO support
+     * tools execute the model→tool→model loop internally and emit
+     * tool-call events as they happen.
+     */
+    fun chatWithToolsOn(
+        provider: ProviderId,
+        messages: List<LlmMessage>,
+        systemPrompt: String? = null,
+        model: String? = null,
+        tools: ToolRegistry = ToolRegistry.EMPTY,
+    ): Flow<ChatStreamEvent> = flow {
+        emitAll(
+            providerFor(provider).chatWithTools(
+                messages = messages,
+                systemPrompt = systemPrompt,
+                model = model,
+                tools = tools,
+            ),
+        )
+    }
+
+    /** Issue #216 — quick "does this provider support tool use?"
+     *  check for UI gating (empty-state on unsupported providers). */
+    fun supportsTools(provider: ProviderId): Boolean =
+        provider.implemented && providerFor(provider).supportsTools
 
     /** Run a probe on the named provider. Returns
      *  [ProbeResult.Misconfigured] for spec-only providers since they

--- a/core-llm/src/main/kotlin/in/jphe/storyvox/llm/LlmSessionRepository.kt
+++ b/core-llm/src/main/kotlin/in/jphe/storyvox/llm/LlmSessionRepository.kt
@@ -4,6 +4,8 @@ import `in`.jphe.storyvox.data.db.dao.LlmMessageDao
 import `in`.jphe.storyvox.data.db.dao.LlmSessionDao
 import `in`.jphe.storyvox.data.db.entity.LlmSession
 import `in`.jphe.storyvox.data.db.entity.LlmStoredMessage
+import `in`.jphe.storyvox.llm.tools.ChatStreamEvent
+import `in`.jphe.storyvox.llm.tools.ToolRegistry
 import java.util.UUID
 import javax.inject.Inject
 import javax.inject.Singleton
@@ -121,6 +123,72 @@ open class LlmSessionRepository @Inject constructor(
             model = session.model,
         )
             .onEach { replyBuf.append(it) }
+            .onCompletion { cause ->
+                if (cause == null) {
+                    messageDao.insert(
+                        LlmStoredMessage(
+                            sessionId = sessionId,
+                            role = "assistant",
+                            content = replyBuf.toString(),
+                            createdAt = System.currentTimeMillis(),
+                        ),
+                    )
+                    sessionDao.touchLastUsed(
+                        sessionId,
+                        System.currentTimeMillis(),
+                    )
+                }
+            }
+        emitAll(replyFlow)
+    }
+
+    /**
+     * Issue #216 — tool-aware variant of [chat]. Same persistence
+     * shape (user turn before stream, assistant turn on completion),
+     * but emits [ChatStreamEvent] instead of plain strings so the
+     * chat ViewModel can render tool-call cards in the timeline.
+     *
+     * When [tools] is empty the underlying provider falls through to
+     * plain streaming and the only events emitted are
+     * [ChatStreamEvent.TextDelta]. The persistence side concatenates
+     * every [ChatStreamEvent.TextDelta] into the saved assistant
+     * message; tool-call events are NOT persisted in v1 (the chat
+     * timeline shows them live and they disappear on rehydration).
+     * A future PR can add a `LlmToolCall` table when we want them to
+     * survive process death.
+     */
+    open fun chatWithTools(
+        sessionId: String,
+        userMessage: String,
+        tools: ToolRegistry,
+    ): Flow<ChatStreamEvent> = flow {
+        val session = sessionDao.get(sessionId)
+            ?: throw IllegalStateException("Session $sessionId not found")
+        val provider = ProviderId.valueOf(session.provider)
+
+        messageDao.insert(
+            LlmStoredMessage(
+                sessionId = sessionId,
+                role = "user",
+                content = userMessage,
+                createdAt = System.currentTimeMillis(),
+            ),
+        )
+        val history = messageDao.getBySession(sessionId).mapNotNull { it.toWire() }
+
+        val replyBuf = StringBuilder()
+        val replyFlow = llm.chatWithToolsOn(
+            provider = provider,
+            messages = history,
+            systemPrompt = session.systemPrompt,
+            model = session.model,
+            tools = tools,
+        )
+            .onEach { event ->
+                if (event is ChatStreamEvent.TextDelta) {
+                    replyBuf.append(event.text)
+                }
+            }
             .onCompletion { cause ->
                 if (cause == null) {
                     messageDao.insert(

--- a/core-llm/src/main/kotlin/in/jphe/storyvox/llm/provider/AnthropicTeamsProvider.kt
+++ b/core-llm/src/main/kotlin/in/jphe/storyvox/llm/provider/AnthropicTeamsProvider.kt
@@ -13,6 +13,10 @@ import `in`.jphe.storyvox.llm.auth.AnthropicTeamsAuthRepository
 import `in`.jphe.storyvox.llm.auth.TokenResult
 import `in`.jphe.storyvox.llm.di.LlmHttp
 import `in`.jphe.storyvox.llm.sse.SseLineParser
+import `in`.jphe.storyvox.llm.tools.ChatStreamEvent
+import `in`.jphe.storyvox.llm.tools.ToolCallRequest
+import `in`.jphe.storyvox.llm.tools.ToolRegistry
+import `in`.jphe.storyvox.llm.tools.ToolResult
 import javax.inject.Inject
 import javax.inject.Singleton
 import kotlinx.coroutines.Dispatchers
@@ -20,10 +24,19 @@ import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.flow.flowOn
+import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
 import kotlinx.serialization.encodeToString
 import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonElement
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.buildJsonObject
+import kotlinx.serialization.json.contentOrNull
+import kotlinx.serialization.json.jsonArray
+import kotlinx.serialization.json.jsonObject
+import kotlinx.serialization.json.jsonPrimitive
+import kotlinx.serialization.json.put
 import okhttp3.OkHttpClient
 import okhttp3.Request
 import okhttp3.RequestBody.Companion.toRequestBody
@@ -60,6 +73,10 @@ open class AnthropicTeamsProvider @Inject constructor(
 ) : LlmProvider {
 
     override val id: ProviderId = ProviderId.Teams
+
+    /** Issue #216 — same Messages API as Claude direct, so the same
+     *  tool-use shape applies. */
+    override val supportsTools: Boolean = true
 
     /** Override hook for tests — Messages API endpoint. */
     protected open val endpointUrl: String = ENDPOINT
@@ -279,6 +296,181 @@ open class AnthropicTeamsProvider @Inject constructor(
     }
 
     /**
+     * Issue #216 — tool-aware chat. Same wire shape as
+     * [ClaudeApiProvider.chatWithTools], plus the Teams-specific
+     * bearer + refresh-on-401 dance. We share the [ToolCallRequest]
+     * parser by inlining the same content-block walk; the duplication
+     * is tolerable for v1 (two providers) and avoids cross-class
+     * helpers leaking package-private state.
+     */
+    override fun chatWithTools(
+        messages: List<LlmMessage>,
+        systemPrompt: String?,
+        model: String?,
+        tools: ToolRegistry,
+    ): Flow<ChatStreamEvent> {
+        if (tools.catalog.isEmpty()) {
+            return stream(messages, systemPrompt, model)
+                .map { ChatStreamEvent.TextDelta(it) }
+        }
+        return flow {
+            val cfg = configFlow.first()
+            val resolvedModel = (model ?: cfg.claudeModel).resolveAnthropic()
+            val toolDecls = tools.catalog.map { spec ->
+                AnthropicToolDecl(
+                    name = spec.name,
+                    description = spec.description,
+                    inputSchema = spec.toAnthropicInputSchema(),
+                )
+            }
+            val conversation = ArrayList<AnthropicToolMessage>(
+                messages.map { msg ->
+                    AnthropicToolMessage(
+                        role = msg.role.name,
+                        content = listOf(buildJsonObject {
+                            put("type", "text")
+                            put("text", msg.content)
+                        }),
+                    )
+                },
+            )
+
+            var round = 0
+            while (round < MAX_TOOL_ROUNDS) {
+                round++
+                val body = AnthropicToolRequest(
+                    model = resolvedModel,
+                    maxTokens = MAX_TOKENS,
+                    messages = conversation,
+                    system = systemPrompt,
+                    tools = toolDecls,
+                    stream = false,
+                )
+                val response = postToolRequestWithRefresh(json.encodeToString(body))
+                val content = response["content"]?.jsonArray ?: kotlinx.serialization.json.JsonArray(emptyList())
+                val text = buildString {
+                    for (block in content) {
+                        val obj = block.jsonObject
+                        if (obj["type"]?.jsonPrimitive?.contentOrNull == "text") {
+                            obj["text"]?.jsonPrimitive?.contentOrNull?.let(::append)
+                        }
+                    }
+                }
+                val toolCalls = content.mapNotNull { block ->
+                    val obj = block.jsonObject
+                    if (obj["type"]?.jsonPrimitive?.contentOrNull != "tool_use") return@mapNotNull null
+                    val id = obj["id"]?.jsonPrimitive?.contentOrNull ?: return@mapNotNull null
+                    val name = obj["name"]?.jsonPrimitive?.contentOrNull ?: return@mapNotNull null
+                    val input = obj["input"]?.jsonObject ?: JsonObject(emptyMap())
+                    ToolCallRequest(id = id, name = name, arguments = input)
+                }
+                val stopReason = response["stop_reason"]?.jsonPrimitive?.contentOrNull
+                if (toolCalls.isEmpty() || stopReason != "tool_use") {
+                    if (text.isNotEmpty()) emit(ChatStreamEvent.TextDelta(text))
+                    return@flow
+                }
+                conversation.add(
+                    AnthropicToolMessage(
+                        role = "assistant",
+                        content = content.map { it as JsonElement },
+                    ),
+                )
+                val resultBlocks = ArrayList<JsonElement>(toolCalls.size)
+                for (call in toolCalls) {
+                    emit(ChatStreamEvent.ToolCallStarted(call))
+                    val handler = tools.handler(call.name)
+                    val result = if (handler == null) {
+                        ToolResult.Error("Unknown tool: ${call.name}")
+                    } else {
+                        try {
+                            handler.execute(call.arguments)
+                        } catch (t: Throwable) {
+                            ToolResult.Error(
+                                "Tool ${call.name} failed: ${t.message ?: t.javaClass.simpleName}",
+                            )
+                        }
+                    }
+                    emit(ChatStreamEvent.ToolCallCompleted(call.id, call.name, result))
+                    resultBlocks.add(buildJsonObject {
+                        put("type", "tool_result")
+                        put("tool_use_id", call.id)
+                        put("content", result.message)
+                        if (result is ToolResult.Error) put("is_error", true)
+                    })
+                }
+                conversation.add(
+                    AnthropicToolMessage(role = "user", content = resultBlocks),
+                )
+            }
+            emit(
+                ChatStreamEvent.TextDelta(
+                    "(Stopped after $MAX_TOOL_ROUNDS tool rounds.)",
+                ),
+            )
+        }.flowOn(Dispatchers.IO)
+    }
+
+    /** Issue #216 — POST a non-streaming JSON body to the Messages API
+     *  with the same refresh-on-401 dance as [stream]. Returns the
+     *  parsed top-level response object. */
+    private suspend fun postToolRequestWithRefresh(payload: String): JsonObject {
+        ensureFreshToken()
+        val first = doToolRequest(payload)
+        if (first.code != 401) {
+            return first.use { parseToolResponse(it) }
+        }
+        first.close()
+        if (!refreshOrInvalidate()) {
+            throw LlmError.AuthFailed(
+                ProviderId.Teams,
+                "Teams session expired — sign in again.",
+            )
+        }
+        val retry = doToolRequest(payload)
+        return retry.use { parseToolResponse(it) }
+    }
+
+    private suspend fun doToolRequest(payload: String): okhttp3.Response {
+        val bearer = store.teamsBearerToken()
+            ?: throw LlmError.NotConfigured(ProviderId.Teams)
+        val request = Request.Builder()
+            .url(endpointUrl)
+            .header("Authorization", "Bearer $bearer")
+            .header("anthropic-version", API_VERSION)
+            .header("anthropic-beta", AnthropicTeamsAuthConfig.OAUTH_BETA_HEADER)
+            .header("content-type", "application/json")
+            .post(payload.toRequestBody(JSON_MEDIA_TYPE))
+            .build()
+        return try {
+            http.newCall(request).executeAsync()
+        } catch (e: IOException) {
+            throw LlmError.Transport(ProviderId.Teams, e)
+        }
+    }
+
+    private fun parseToolResponse(resp: okhttp3.Response): JsonObject {
+        when {
+            resp.code == 401 || resp.code == 403 ->
+                throw LlmError.AuthFailed(
+                    ProviderId.Teams,
+                    resp.message.ifBlank { "HTTP ${resp.code}" },
+                )
+            !resp.isSuccessful -> {
+                val excerpt = resp.body?.string()?.take(256) ?: resp.message
+                throw LlmError.ProviderError(
+                    ProviderId.Teams, resp.code, excerpt,
+                )
+            }
+        }
+        val text = resp.body?.string()
+            ?: throw LlmError.Transport(
+                ProviderId.Teams,
+                IOException("Empty response body"),
+            )
+        return json.parseToJsonElement(text).jsonObject
+    }
+
+    /**
      * Mirror of [ClaudeApiProvider.resolveAnthropic] — Teams uses the
      * same model id space (it's the same Messages API) so the canonical
      * → wire-name mapping is identical.
@@ -302,5 +494,8 @@ open class AnthropicTeamsProvider @Inject constructor(
          *  enough that the listener doesn't see the bearer rotate
          *  every other recap. */
         const val REFRESH_LEAD_MILLIS = 60_000L
+
+        /** See [ClaudeApiProvider.MAX_TOOL_ROUNDS]. */
+        const val MAX_TOOL_ROUNDS = 5
     }
 }

--- a/core-llm/src/main/kotlin/in/jphe/storyvox/llm/provider/ClaudeApiProvider.kt
+++ b/core-llm/src/main/kotlin/in/jphe/storyvox/llm/provider/ClaudeApiProvider.kt
@@ -9,6 +9,10 @@ import `in`.jphe.storyvox.llm.ProbeResult
 import `in`.jphe.storyvox.llm.ProviderId
 import `in`.jphe.storyvox.llm.di.LlmHttp
 import `in`.jphe.storyvox.llm.sse.SseLineParser
+import `in`.jphe.storyvox.llm.tools.ChatStreamEvent
+import `in`.jphe.storyvox.llm.tools.ToolCallRequest
+import `in`.jphe.storyvox.llm.tools.ToolRegistry
+import `in`.jphe.storyvox.llm.tools.ToolResult
 import javax.inject.Inject
 import javax.inject.Singleton
 import kotlinx.coroutines.Dispatchers
@@ -16,8 +20,21 @@ import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.flow.flowOn
+import kotlinx.coroutines.flow.map
 import kotlinx.serialization.encodeToString
 import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonArray
+import kotlinx.serialization.json.JsonElement
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.JsonPrimitive
+import kotlinx.serialization.json.add
+import kotlinx.serialization.json.buildJsonArray
+import kotlinx.serialization.json.buildJsonObject
+import kotlinx.serialization.json.contentOrNull
+import kotlinx.serialization.json.jsonArray
+import kotlinx.serialization.json.jsonObject
+import kotlinx.serialization.json.jsonPrimitive
+import kotlinx.serialization.json.put
 import okhttp3.OkHttpClient
 import okhttp3.Request
 import okhttp3.RequestBody.Companion.toRequestBody
@@ -43,6 +60,12 @@ open class ClaudeApiProvider @Inject constructor(
 ) : LlmProvider {
 
     override val id: ProviderId = ProviderId.Claude
+
+    /** Issue #216 — Anthropic supports function calling on every
+     *  Claude model we surface. The chat layer offers tool use; the
+     *  Settings actions toggle gates whether the catalog is actually
+     *  passed to [chatWithTools]. */
+    override val supportsTools: Boolean = true
 
     /** Anthropic Messages endpoint. Open so tests can override to
      *  point at MockWebServer. */
@@ -149,6 +172,207 @@ open class ClaudeApiProvider @Inject constructor(
     }
 
     /**
+     * Issue #216 — tool-aware chat. When [tools] is empty, falls
+     * through to plain [stream] (cheaper, streaming). When tools are
+     * registered, switches to a non-streaming request so we can
+     * parse the full content-blocks array in one shot — Anthropic's
+     * `tool_use` blocks are easier to handle from the final response
+     * than from the partial-JSON SSE deltas.
+     *
+     * Loop:
+     *  1. Send messages + system + tools (non-streaming).
+     *  2. If response.stop_reason == "tool_use", execute every
+     *     `tool_use` block via [ToolRegistry.handler], append a
+     *     `tool_result` user-message, re-request.
+     *  3. Repeat up to [MAX_TOOL_ROUNDS] times — guards against the
+     *     model getting stuck in a tool-calling loop.
+     *  4. On the first `end_turn` (text-only) response, emit
+     *     [ChatStreamEvent.TextDelta] with the joined text and stop.
+     *
+     * Emits [ChatStreamEvent.ToolCallStarted] / [ChatStreamEvent.ToolCallCompleted]
+     * pairs before re-requesting so the UI can show progress.
+     */
+    override fun chatWithTools(
+        messages: List<LlmMessage>,
+        systemPrompt: String?,
+        model: String?,
+        tools: ToolRegistry,
+    ): Flow<ChatStreamEvent> {
+        if (tools.catalog.isEmpty()) {
+            return stream(messages, systemPrompt, model)
+                .map { ChatStreamEvent.TextDelta(it) }
+        }
+        return flow {
+            val cfg = configFlow.first()
+            val apiKey = store.claudeApiKey()
+                ?: throw LlmError.NotConfigured(ProviderId.Claude)
+            val resolvedModel = (model ?: cfg.claudeModel).resolveAnthropic()
+
+            val toolDecls = tools.catalog.map { spec ->
+                AnthropicToolDecl(
+                    name = spec.name,
+                    description = spec.description,
+                    inputSchema = spec.toAnthropicInputSchema(),
+                )
+            }
+
+            // Build the seed turns. Each existing LlmMessage carries
+            // plain text; wrap it in a single `text` block to match
+            // the content-array shape Anthropic requires here.
+            val conversation = ArrayList<AnthropicToolMessage>(
+                messages.map { msg ->
+                    AnthropicToolMessage(
+                        role = msg.role.name,
+                        content = listOf(textBlock(msg.content)),
+                    )
+                },
+            )
+
+            var round = 0
+            while (round < MAX_TOOL_ROUNDS) {
+                round++
+                val body = AnthropicToolRequest(
+                    model = resolvedModel,
+                    maxTokens = MAX_TOKENS,
+                    messages = conversation,
+                    system = systemPrompt,
+                    tools = toolDecls,
+                    stream = false,
+                )
+                val response = postToolRequest(apiKey, body)
+                val text = collectText(response)
+                val toolCalls = collectToolCalls(response)
+                val stopReason = response["stop_reason"]
+                    ?.jsonPrimitive?.contentOrNull
+
+                if (toolCalls.isEmpty() || stopReason != "tool_use") {
+                    if (text.isNotEmpty()) emit(ChatStreamEvent.TextDelta(text))
+                    return@flow
+                }
+
+                // Add the assistant's tool-call turn verbatim so the
+                // follow-up's `tool_use_id` references resolve.
+                val assistantContent = response["content"]?.jsonArray
+                    ?.map { it as JsonElement } ?: emptyList()
+                conversation.add(
+                    AnthropicToolMessage(
+                        role = "assistant",
+                        content = assistantContent,
+                    ),
+                )
+
+                // Run each tool, build a single user-turn carrying
+                // every `tool_result` block. Anthropic requires all
+                // tool_result blocks for one model turn to be batched
+                // into one follow-up user message.
+                val resultBlocks = ArrayList<JsonElement>(toolCalls.size)
+                for (call in toolCalls) {
+                    emit(ChatStreamEvent.ToolCallStarted(call))
+                    val handler = tools.handler(call.name)
+                    val result = if (handler == null) {
+                        ToolResult.Error("Unknown tool: ${call.name}")
+                    } else {
+                        try {
+                            handler.execute(call.arguments)
+                        } catch (t: Throwable) {
+                            ToolResult.Error(
+                                "Tool ${call.name} failed: ${t.message ?: t.javaClass.simpleName}",
+                            )
+                        }
+                    }
+                    emit(ChatStreamEvent.ToolCallCompleted(call.id, call.name, result))
+                    resultBlocks.add(
+                        buildJsonObject {
+                            put("type", "tool_result")
+                            put("tool_use_id", call.id)
+                            put("content", result.message)
+                            if (result is ToolResult.Error) put("is_error", true)
+                        },
+                    )
+                }
+                conversation.add(
+                    AnthropicToolMessage(role = "user", content = resultBlocks),
+                )
+            }
+            // Bail-out — if we hit the loop cap, surface a tail text
+            // so the user sees *something* even on a misbehaving model.
+            emit(
+                ChatStreamEvent.TextDelta(
+                    "(Stopped after $MAX_TOOL_ROUNDS tool rounds.)",
+                ),
+            )
+        }.flowOn(Dispatchers.IO)
+    }
+
+    private fun textBlock(text: String): JsonElement = buildJsonObject {
+        put("type", "text")
+        put("text", text)
+    }
+
+    private suspend fun postToolRequest(
+        apiKey: String,
+        body: AnthropicToolRequest,
+    ): JsonObject {
+        val request = Request.Builder()
+            .url(endpointUrl)
+            .header("x-api-key", apiKey)
+            .header("anthropic-version", API_VERSION)
+            .header("content-type", "application/json")
+            .post(json.encodeToString(body).toRequestBody(JSON_MEDIA_TYPE))
+            .build()
+        val resp = try {
+            http.newCall(request).executeAsync()
+        } catch (e: IOException) {
+            throw LlmError.Transport(ProviderId.Claude, e)
+        }
+        resp.use { r ->
+            when {
+                r.code == 401 || r.code == 403 ->
+                    throw LlmError.AuthFailed(
+                        ProviderId.Claude,
+                        r.message.ifBlank { "HTTP ${r.code}" },
+                    )
+                !r.isSuccessful -> {
+                    val excerpt = r.body?.string()?.take(256) ?: r.message
+                    throw LlmError.ProviderError(
+                        ProviderId.Claude, r.code, excerpt,
+                    )
+                }
+            }
+            val text = r.body?.string()
+                ?: throw LlmError.Transport(
+                    ProviderId.Claude,
+                    IOException("Empty response body"),
+                )
+            return json.parseToJsonElement(text).jsonObject
+        }
+    }
+
+    private fun collectText(response: JsonObject): String {
+        val content = response["content"]?.jsonArray ?: return ""
+        val sb = StringBuilder()
+        for (block in content) {
+            val obj = block.jsonObject
+            if (obj["type"]?.jsonPrimitive?.contentOrNull == "text") {
+                obj["text"]?.jsonPrimitive?.contentOrNull?.let(sb::append)
+            }
+        }
+        return sb.toString()
+    }
+
+    private fun collectToolCalls(response: JsonObject): List<ToolCallRequest> {
+        val content = response["content"]?.jsonArray ?: return emptyList()
+        return content.mapNotNull { block ->
+            val obj = block.jsonObject
+            if (obj["type"]?.jsonPrimitive?.contentOrNull != "tool_use") return@mapNotNull null
+            val id = obj["id"]?.jsonPrimitive?.contentOrNull ?: return@mapNotNull null
+            val name = obj["name"]?.jsonPrimitive?.contentOrNull ?: return@mapNotNull null
+            val input = obj["input"]?.jsonObject ?: JsonObject(emptyMap())
+            ToolCallRequest(id = id, name = name, arguments = input)
+        }
+    }
+
+    /**
      * Map our canonical model name (e.g. "claude-haiku-4.5") to
      * Anthropic's wire format ("claude-haiku-4-5-20251001").
      * Direct port of `cloud-chat-assistant/llm_stream.py:MODEL_MAP`.
@@ -170,5 +394,11 @@ open class ClaudeApiProvider @Inject constructor(
         const val ENDPOINT = "https://api.anthropic.com/v1/messages"
         const val API_VERSION = "2023-06-01"
         const val MAX_TOKENS = 1024
+        /** Issue #216 — defensive cap on tool-call rounds per chat
+         *  turn. The model very occasionally gets stuck in a loop
+         *  (call → "let me also check" → call → ...). Five rounds
+         *  is plenty for any v1 flow and bounds worst-case token
+         *  spend at predictable levels. */
+        const val MAX_TOOL_ROUNDS = 5
     }
 }

--- a/core-llm/src/main/kotlin/in/jphe/storyvox/llm/provider/OpenAiApiProvider.kt
+++ b/core-llm/src/main/kotlin/in/jphe/storyvox/llm/provider/OpenAiApiProvider.kt
@@ -9,6 +9,10 @@ import `in`.jphe.storyvox.llm.ProbeResult
 import `in`.jphe.storyvox.llm.ProviderId
 import `in`.jphe.storyvox.llm.di.LlmHttp
 import `in`.jphe.storyvox.llm.sse.SseLineParser
+import `in`.jphe.storyvox.llm.tools.ChatStreamEvent
+import `in`.jphe.storyvox.llm.tools.ToolCallRequest
+import `in`.jphe.storyvox.llm.tools.ToolRegistry
+import `in`.jphe.storyvox.llm.tools.ToolResult
 import javax.inject.Inject
 import javax.inject.Singleton
 import kotlinx.coroutines.Dispatchers
@@ -16,8 +20,19 @@ import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.flow.flowOn
+import kotlinx.coroutines.flow.map
 import kotlinx.serialization.encodeToString
 import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.JsonPrimitive
+import kotlinx.serialization.json.add
+import kotlinx.serialization.json.buildJsonArray
+import kotlinx.serialization.json.buildJsonObject
+import kotlinx.serialization.json.contentOrNull
+import kotlinx.serialization.json.jsonArray
+import kotlinx.serialization.json.jsonObject
+import kotlinx.serialization.json.jsonPrimitive
+import kotlinx.serialization.json.put
 import okhttp3.OkHttpClient
 import okhttp3.Request
 import okhttp3.RequestBody.Companion.toRequestBody
@@ -43,6 +58,10 @@ open class OpenAiApiProvider @Inject constructor(
 ) : LlmProvider {
 
     override val id: ProviderId = ProviderId.OpenAi
+
+    /** Issue #216 — OpenAI's `gpt-4o` family supports function
+     *  calling out of the box. */
+    override val supportsTools: Boolean = true
 
     /** Chat-completions endpoint. Open for tests. */
     protected open val endpointUrl: String = ENDPOINT
@@ -140,7 +159,171 @@ open class OpenAiApiProvider @Inject constructor(
         }
     }
 
+    /**
+     * Issue #216 — tool-aware chat. Same pattern as
+     * [ClaudeApiProvider.chatWithTools]: non-streaming request/
+     * response loop when tools are involved, fall through to
+     * streaming text when they aren't. OpenAI's `tool_calls` arrive
+     * in `choices[0].message.tool_calls`; we issue a follow-up turn
+     * with the assistant message preserved verbatim plus one
+     * `role: "tool"` message per call.
+     */
+    override fun chatWithTools(
+        messages: List<LlmMessage>,
+        systemPrompt: String?,
+        model: String?,
+        tools: ToolRegistry,
+    ): Flow<ChatStreamEvent> {
+        if (tools.catalog.isEmpty()) {
+            return stream(messages, systemPrompt, model)
+                .map { ChatStreamEvent.TextDelta(it) }
+        }
+        return flow {
+            val cfg = configFlow.first()
+            val apiKey = store.openAiApiKey()
+                ?: throw LlmError.NotConfigured(ProviderId.OpenAi)
+            val resolvedModel = model ?: cfg.openAiModel
+
+            val toolDecls = tools.catalog.map { spec ->
+                OpenAiToolDecl(
+                    type = "function",
+                    function = OpenAiToolFunction(
+                        name = spec.name,
+                        description = spec.description,
+                        parameters = spec.toOpenAiParameters(),
+                    ),
+                )
+            }
+
+            val conversation = ArrayList<JsonObject>()
+            systemPrompt?.takeIf { it.isNotBlank() }?.let { sp ->
+                conversation.add(buildJsonObject {
+                    put("role", "system")
+                    put("content", sp)
+                })
+            }
+            messages.forEach { msg ->
+                conversation.add(buildJsonObject {
+                    put("role", msg.role.name)
+                    put("content", msg.content)
+                })
+            }
+
+            var round = 0
+            while (round < MAX_TOOL_ROUNDS) {
+                round++
+                val body = OpenAiToolRequest(
+                    model = resolvedModel,
+                    messages = conversation,
+                    tools = toolDecls,
+                    stream = false,
+                )
+                val response = postToolRequest(apiKey, body)
+                val choice = response["choices"]?.jsonArray
+                    ?.firstOrNull()?.jsonObject ?: break
+                val finishReason = choice["finish_reason"]
+                    ?.jsonPrimitive?.contentOrNull
+                val message = choice["message"]?.jsonObject ?: break
+                val toolCalls = parseToolCalls(message)
+                val text = message["content"]?.jsonPrimitive?.contentOrNull.orEmpty()
+
+                if (toolCalls.isEmpty() || finishReason != "tool_calls") {
+                    if (text.isNotEmpty()) emit(ChatStreamEvent.TextDelta(text))
+                    return@flow
+                }
+                // Replay the assistant turn (with tool_calls preserved
+                // verbatim) so the follow-up message's `tool_call_id`s
+                // resolve.
+                conversation.add(message)
+                for (call in toolCalls) {
+                    emit(ChatStreamEvent.ToolCallStarted(call))
+                    val handler = tools.handler(call.name)
+                    val result = if (handler == null) {
+                        ToolResult.Error("Unknown tool: ${call.name}")
+                    } else {
+                        try {
+                            handler.execute(call.arguments)
+                        } catch (t: Throwable) {
+                            ToolResult.Error(
+                                "Tool ${call.name} failed: ${t.message ?: t.javaClass.simpleName}",
+                            )
+                        }
+                    }
+                    emit(ChatStreamEvent.ToolCallCompleted(call.id, call.name, result))
+                    conversation.add(buildJsonObject {
+                        put("role", "tool")
+                        put("tool_call_id", call.id)
+                        put("content", result.message)
+                    })
+                }
+            }
+            emit(
+                ChatStreamEvent.TextDelta(
+                    "(Stopped after $MAX_TOOL_ROUNDS tool rounds.)",
+                ),
+            )
+        }.flowOn(Dispatchers.IO)
+    }
+
+    private suspend fun postToolRequest(
+        apiKey: String,
+        body: OpenAiToolRequest,
+    ): JsonObject {
+        val request = Request.Builder()
+            .url(endpointUrl)
+            .header("Authorization", "Bearer $apiKey")
+            .header("content-type", "application/json")
+            .post(json.encodeToString(body).toRequestBody(JSON_MEDIA_TYPE))
+            .build()
+        val resp = try {
+            http.newCall(request).executeAsync()
+        } catch (e: IOException) {
+            throw LlmError.Transport(ProviderId.OpenAi, e)
+        }
+        resp.use { r ->
+            when {
+                r.code == 401 || r.code == 403 ->
+                    throw LlmError.AuthFailed(
+                        ProviderId.OpenAi,
+                        r.message.ifBlank { "HTTP ${r.code}" },
+                    )
+                !r.isSuccessful -> {
+                    val excerpt = r.body?.string()?.take(256) ?: r.message
+                    throw LlmError.ProviderError(
+                        ProviderId.OpenAi, r.code, excerpt,
+                    )
+                }
+            }
+            val text = r.body?.string()
+                ?: throw LlmError.Transport(
+                    ProviderId.OpenAi,
+                    IOException("Empty response body"),
+                )
+            return json.parseToJsonElement(text).jsonObject
+        }
+    }
+
+    private fun parseToolCalls(message: JsonObject): List<ToolCallRequest> {
+        val raw = message["tool_calls"]?.jsonArray ?: return emptyList()
+        return raw.mapNotNull { el ->
+            val obj = el.jsonObject
+            val id = obj["id"]?.jsonPrimitive?.contentOrNull
+                ?: return@mapNotNull null
+            val fn = obj["function"]?.jsonObject ?: return@mapNotNull null
+            val name = fn["name"]?.jsonPrimitive?.contentOrNull
+                ?: return@mapNotNull null
+            val argsRaw = fn["arguments"]?.jsonPrimitive?.contentOrNull.orEmpty()
+            val parsed = runCatching {
+                if (argsRaw.isBlank()) JsonObject(emptyMap())
+                else json.parseToJsonElement(argsRaw).jsonObject
+            }.getOrDefault(JsonObject(emptyMap()))
+            ToolCallRequest(id = id, name = name, arguments = parsed)
+        }
+    }
+
     private companion object {
         const val ENDPOINT = "https://api.openai.com/v1/chat/completions"
+        /** See [ClaudeApiProvider.MAX_TOOL_ROUNDS]. */
+        const val MAX_TOOL_ROUNDS = 5
     }
 }

--- a/core-llm/src/main/kotlin/in/jphe/storyvox/llm/provider/Wire.kt
+++ b/core-llm/src/main/kotlin/in/jphe/storyvox/llm/provider/Wire.kt
@@ -89,6 +89,72 @@ internal data class FoundryDeployedRequest(
     val stream: Boolean = true,
 )
 
+// ── Tool-aware Anthropic (#216) ─────────────────────────────────────
+//
+// Distinct shape from [AnthropicRequest] because Anthropic's tool-use
+// path requires the content field to be an array of typed blocks
+// (text / tool_use / tool_result) rather than a single string. We
+// keep [AnthropicRequest] for the plain-text path (cheaper, easier to
+// debug) and use these when at least one tool is registered.
+
+@Serializable
+internal data class AnthropicToolRequest(
+    val model: String,
+    @SerialName("max_tokens") val maxTokens: Int,
+    val messages: List<AnthropicToolMessage>,
+    val system: String? = null,
+    val tools: List<AnthropicToolDecl>? = null,
+    val stream: Boolean = false,
+)
+
+@Serializable
+internal data class AnthropicToolMessage(
+    val role: String,        // "user" or "assistant"
+    val content: List<kotlinx.serialization.json.JsonElement>,
+)
+
+@Serializable
+internal data class AnthropicToolDecl(
+    val name: String,
+    val description: String,
+    @SerialName("input_schema")
+    val inputSchema: kotlinx.serialization.json.JsonObject,
+)
+
+// ── Tool-aware OpenAI (#216) ────────────────────────────────────────
+//
+// OpenAI's chat completions schema accepts an optional `tools` array
+// + per-message `tool_calls` array; messages with `role: "tool"`
+// carry `tool_call_id` + result content. We keep [OpenAiRequest]
+// for the plain-text path and use these when tools are registered.
+
+@Serializable
+internal data class OpenAiToolRequest(
+    val model: String,
+    val messages: List<kotlinx.serialization.json.JsonObject>,
+    @SerialName("max_tokens") val maxTokens: Int = 1024,
+    val tools: List<OpenAiToolDecl>? = null,
+    val stream: Boolean = false,
+)
+
+@Serializable
+internal data class OpenAiToolDecl(
+    /** Always emitted (no default) so a strict OpenAI receiver that
+     *  reads `type` first sees it on the wire. The OpenAI API does in
+     *  practice accept a missing type field, but `function` is the
+     *  only documented value, and emitting it is one byte cheaper to
+     *  reason about. */
+    val type: String,
+    val function: OpenAiToolFunction,
+)
+
+@Serializable
+internal data class OpenAiToolFunction(
+    val name: String,
+    val description: String,
+    val parameters: kotlinx.serialization.json.JsonObject,
+)
+
 // ── AWS Bedrock converse-stream ────────────────────────────────────
 //
 // Body shape: { modelId, messages:[{role, content:[{text}]}],

--- a/core-llm/src/main/kotlin/in/jphe/storyvox/llm/tools/ChatStreamEvent.kt
+++ b/core-llm/src/main/kotlin/in/jphe/storyvox/llm/tools/ChatStreamEvent.kt
@@ -1,0 +1,30 @@
+package `in`.jphe.storyvox.llm.tools
+
+/**
+ * Issue #216 — rich event stream from the tool-aware chat path.
+ * Distinct from `Flow<String>` (text-only stream) because the chat UI
+ * needs to render tool-call cards in-line as they happen, not after
+ * the fact.
+ *
+ * Order guarantee: events arrive in the order the model emitted
+ * them — interleaved [TextDelta] + [ToolCallStarted] / [ToolCallCompleted]
+ * pairs. The UI can map this directly onto a turn timeline.
+ */
+sealed class ChatStreamEvent {
+    /** A text token (or chunk) from the assistant. Same semantics as
+     *  the legacy `Flow<String>` emit. */
+    data class TextDelta(val text: String) : ChatStreamEvent()
+
+    /** Model decided to call a tool. The corresponding
+     *  [ToolCallCompleted] follows after the handler finishes. */
+    data class ToolCallStarted(val call: ToolCallRequest) : ChatStreamEvent()
+
+    /** Tool handler finished. The chat layer reissues the request to
+     *  the model with the tool result threaded in; the model's next
+     *  text response arrives as [TextDelta] emits after this. */
+    data class ToolCallCompleted(
+        val id: String,
+        val name: String,
+        val result: ToolResult,
+    ) : ChatStreamEvent()
+}

--- a/core-llm/src/main/kotlin/in/jphe/storyvox/llm/tools/StoryvoxToolSpecs.kt
+++ b/core-llm/src/main/kotlin/in/jphe/storyvox/llm/tools/StoryvoxToolSpecs.kt
@@ -1,0 +1,144 @@
+package `in`.jphe.storyvox.llm.tools
+
+/**
+ * Issue #216 — the v1 catalog of AI-callable storyvox actions.
+ *
+ * Each [ToolSpec] is paired with a [ToolHandler] in
+ * `:feature/chat/tools/ChatToolHandlers.kt` at the app DI layer. The
+ * specs live here because (a) tests assert against them, (b) the
+ * provider classes serialize them into the wire request, and (c)
+ * `:feature/chat` already depends on `:core-llm` so the import path
+ * is downstream-only.
+ *
+ * Adding a tool:
+ *  1. Define a new [ToolSpec] here.
+ *  2. Add the matching [ToolHandler] in `ChatToolHandlers`.
+ *  3. Add a contract test in `:core-llm` and a behaviour test in
+ *     `:feature/chat`.
+ *
+ * Descriptions are written in present-tense imperative ("Move a
+ * fiction onto…") because that's the voice the model seems to weigh
+ * most heavily when picking between tools — verified empirically
+ * against Claude Haiku 4.5 + GPT-4o-mini.
+ */
+object StoryvoxToolSpecs {
+
+    /** Tool name constants — re-exported so handler bindings and
+     *  tests can refer to them symbolically rather than re-typing
+     *  the snake_case strings. */
+    const val ADD_TO_SHELF = "add_to_shelf"
+    const val QUEUE_CHAPTER = "queue_chapter"
+    const val MARK_CHAPTER_READ = "mark_chapter_read"
+    const val SET_SPEED = "set_speed"
+    const val OPEN_VOICE_LIBRARY = "open_voice_library"
+
+    /** Allowed values for the `shelf` parameter of [ADD_TO_SHELF]. */
+    val SHELVES: List<String> = listOf("Reading", "Read", "Wishlist")
+
+    /** Minimum / maximum playback speed accepted by [SET_SPEED]. The
+     *  player itself enforces the same range; this is the same
+     *  range the user sees on the playback speed slider. */
+    const val SPEED_MIN: Float = 0.5f
+    const val SPEED_MAX: Float = 2.5f
+
+    val addToShelf: ToolSpec = ToolSpec(
+        name = ADD_TO_SHELF,
+        description = "Move a fiction onto one of the user's three " +
+            "library shelves: Reading, Read, or Wishlist. Use this " +
+            "when the user asks to 'add this book to my Reading " +
+            "shelf', 'mark this as read', or similar. The active " +
+            "fiction's id is in the chat context — pass it unless " +
+            "the user explicitly names a different book.",
+        parameters = listOf(
+            ToolParameter.StringParam(
+                name = "fictionId",
+                description = "The stable id of the fiction to shelve. " +
+                    "Use the active fiction's id from the chat context.",
+            ),
+            ToolParameter.StringParam(
+                name = "shelf",
+                description = "Which shelf to move the fiction onto.",
+                allowedValues = SHELVES,
+            ),
+        ),
+    )
+
+    val queueChapter: ToolSpec = ToolSpec(
+        name = QUEUE_CHAPTER,
+        description = "Start playback of a specific chapter. Use this " +
+            "when the user asks to 'play chapter N', 'queue the next " +
+            "chapter', or similar navigation. The chapter index is " +
+            "zero-based — chapter 1 is index 0, chapter 5 is index 4.",
+        parameters = listOf(
+            ToolParameter.StringParam(
+                name = "fictionId",
+                description = "The stable id of the fiction whose " +
+                    "chapter to play. Use the active fiction's id " +
+                    "from the chat context.",
+            ),
+            ToolParameter.IntParam(
+                name = "chapterIndex",
+                description = "Zero-based chapter index in reading " +
+                    "order. Chapter 1 is index 0.",
+                min = 0,
+            ),
+        ),
+    )
+
+    val markChapterRead: ToolSpec = ToolSpec(
+        name = MARK_CHAPTER_READ,
+        description = "Mark a chapter as read (or unread). Use this " +
+            "when the user says 'I finished chapter 3', 'mark this " +
+            "as read', or 'I haven't actually read that chapter yet'.",
+        parameters = listOf(
+            ToolParameter.StringParam(
+                name = "fictionId",
+                description = "The stable id of the fiction. Use the " +
+                    "active fiction's id from the chat context.",
+            ),
+            ToolParameter.IntParam(
+                name = "chapterIndex",
+                description = "Zero-based chapter index in reading " +
+                    "order. Chapter 1 is index 0.",
+                min = 0,
+            ),
+        ),
+    )
+
+    val setSpeed: ToolSpec = ToolSpec(
+        name = SET_SPEED,
+        description = "Set the playback speed slider. Use this when " +
+            "the user asks to 'speed it up', 'slow down', 'set " +
+            "playback to 1.5x', etc. The speed value is a " +
+            "multiplier — 1.0 is normal speed, 0.5 is half speed, " +
+            "2.0 is double speed.",
+        parameters = listOf(
+            ToolParameter.FloatParam(
+                name = "speed",
+                description = "Playback speed multiplier. 1.0 is " +
+                    "normal speed.",
+                min = SPEED_MIN,
+                max = SPEED_MAX,
+            ),
+        ),
+    )
+
+    val openVoiceLibrary: ToolSpec = ToolSpec(
+        name = OPEN_VOICE_LIBRARY,
+        description = "Open the voice library screen so the user can " +
+            "pick or download a different TTS voice. Use this when " +
+            "the user asks to 'change the voice', 'pick a different " +
+            "narrator', 'see what voices I have', or similar.",
+        parameters = emptyList(),
+    )
+
+    /** Ordered list of all v1 tools. Iteration order is the order
+     *  they appear in this file. */
+    val ALL: List<ToolSpec> = listOf(
+        addToShelf,
+        queueChapter,
+        markChapterRead,
+        setSpeed,
+        openVoiceLibrary,
+    )
+}

--- a/core-llm/src/main/kotlin/in/jphe/storyvox/llm/tools/ToolCall.kt
+++ b/core-llm/src/main/kotlin/in/jphe/storyvox/llm/tools/ToolCall.kt
@@ -1,0 +1,59 @@
+package `in`.jphe.storyvox.llm.tools
+
+import kotlinx.serialization.json.JsonObject
+
+/**
+ * Issue #216 — wire-shaped record of one tool invocation requested by
+ * the AI. Captured during stream parsing; passed to the matching
+ * [ToolHandler] for execution.
+ *
+ * [id] is the provider-issued call id. Anthropic ships `tool_use.id`
+ * (e.g. `toolu_01ABC...`); OpenAI ships `tool_calls[].id`
+ * (e.g. `call_abc123`). We round-trip it back unchanged in the
+ * follow-up message so the provider can correlate the result.
+ */
+data class ToolCallRequest(
+    val id: String,
+    val name: String,
+    /** Parsed JSON arguments. Always non-null; empty object when the
+     *  tool takes no parameters. The [ToolHandler] is responsible for
+     *  pulling typed values out and validating them. */
+    val arguments: JsonObject,
+)
+
+/**
+ * Output of a [ToolHandler.execute]. Threaded back into the chat as
+ * a tool-result message so the model can react ("Added — anything
+ * else?" / "I couldn't find that book in your library.").
+ */
+sealed class ToolResult {
+    abstract val message: String
+
+    /** Tool ran successfully. [message] is a short natural-language
+     *  result the AI can echo back ("Added \"Frankenstein\" to your
+     *  Reading shelf."). Keep it under ~140 chars — it ends up
+     *  inlined in the AI's reply context window. */
+    data class Success(override val message: String) : ToolResult()
+
+    /** Tool failed (invalid args, missing entity, provider not
+     *  reachable, etc.). The model will typically apologize + ask
+     *  for clarification. */
+    data class Error(override val message: String) : ToolResult()
+}
+
+/**
+ * One round of "AI called a tool" surfaced through the UI layer. The
+ * chat screen renders a brass-edged card per event. After settling
+ * (Success or Error), the card collapses to a one-line summary.
+ *
+ * Distinct from [ToolCallRequest] (wire shape) because the UI also
+ * wants to know "did this finish yet?" — `result` is null while the
+ * handler is running.
+ */
+data class ToolCallEvent(
+    val id: String,
+    val name: String,
+    val arguments: JsonObject,
+    /** null while the handler is in flight; set on completion. */
+    val result: ToolResult? = null,
+)

--- a/core-llm/src/main/kotlin/in/jphe/storyvox/llm/tools/ToolHandler.kt
+++ b/core-llm/src/main/kotlin/in/jphe/storyvox/llm/tools/ToolHandler.kt
@@ -1,0 +1,72 @@
+package `in`.jphe.storyvox.llm.tools
+
+import kotlinx.serialization.json.JsonObject
+
+/**
+ * Issue #216 — the executable side of a [ToolSpec]. Lives in
+ * `:core-llm` as a pure interface; concrete implementations live in
+ * `:feature/chat` where they can talk to ShelfRepository,
+ * ChapterRepository, PlaybackControllerUi, etc.
+ *
+ * The handler is a single suspending function so it can hop a
+ * Dispatcher without making the caller pick one. The receiving
+ * provider runs it under the same coroutine scope that drives the
+ * stream, so cancelling the chat send aborts in-flight tool calls
+ * too.
+ */
+fun interface ToolHandler {
+    /** Run the tool against the given parsed [arguments]. Implementations
+     *  should:
+     *   1. Pull typed values out of [arguments]; return Error on
+     *      missing/wrong-typed args.
+     *   2. Validate domain constraints (e.g. shelf name is one of
+     *      Reading / Read / Wishlist); return Error on rejection.
+     *   3. Execute against the storyvox repo/controller layer;
+     *      return Success with a short natural-language summary.
+     *
+     *  Don't throw — wrap any expected failure mode as
+     *  [ToolResult.Error]. Unhandled throws bubble up and abort the
+     *  whole chat send, which is rarely what the user wants. */
+    suspend fun execute(arguments: JsonObject): ToolResult
+}
+
+/**
+ * Registry binding tool name → handler. Built once at app startup
+ * (via Hilt) and consumed by the chat layer. A [ToolCatalog] is
+ * derived from the same map by mapping `name → ToolSpec`, so the
+ * advertised tools and the executable tools are guaranteed to stay
+ * in lockstep.
+ */
+class ToolRegistry(
+    private val entries: Map<String, Pair<ToolSpec, ToolHandler>>,
+) {
+    /** All registered tool specs, in registration order. */
+    val catalog: List<ToolSpec> = entries.values.map { it.first }
+
+    /** Look up a handler by name; null when the model called a
+     *  function that isn't registered (shouldn't happen — the model
+     *  only sees [catalog] — but possible on bad caching). */
+    fun handler(name: String): ToolHandler? = entries[name]?.second
+
+    companion object {
+        /** Convenience builder. Pass `name to (spec to handler)` pairs. */
+        fun of(vararg pairs: Triple<String, ToolSpec, ToolHandler>): ToolRegistry =
+            ToolRegistry(pairs.associate { it.first to (it.second to it.third) })
+
+        /** Build from a [ToolSpec] list + lookup function. The lookup
+         *  must return non-null for every spec — throws on missing. */
+        fun build(
+            specs: List<ToolSpec>,
+            lookup: (String) -> ToolHandler,
+        ): ToolRegistry = ToolRegistry(
+            specs.associate { spec ->
+                spec.name to (spec to lookup(spec.name))
+            },
+        )
+
+        /** Empty registry — used when the user has disabled actions
+         *  in Settings → AI. Providers see an empty catalog and skip
+         *  the tools array in the request body. */
+        val EMPTY: ToolRegistry = ToolRegistry(emptyMap())
+    }
+}

--- a/core-llm/src/main/kotlin/in/jphe/storyvox/llm/tools/ToolSpec.kt
+++ b/core-llm/src/main/kotlin/in/jphe/storyvox/llm/tools/ToolSpec.kt
@@ -1,0 +1,124 @@
+package `in`.jphe.storyvox.llm.tools
+
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.add
+import kotlinx.serialization.json.buildJsonArray
+import kotlinx.serialization.json.buildJsonObject
+import kotlinx.serialization.json.put
+
+/**
+ * Issue #216 — declarative description of a single AI-callable
+ * function. Pairs with [ToolHandler], which executes the function
+ * against storyvox state.
+ *
+ * The schema is written by hand (one [JsonObject] per parameter)
+ * rather than derived from a Kotlin type. v1 has five tools with at
+ * most two scalar params apiece — pulling in a JSON-schema generator
+ * library (or `kotlinx.serialization`'s `descriptor` walk) would add
+ * far more weight than the surface justifies. Hand-rolled schemas
+ * also let us write descriptions tuned for an LLM audience without
+ * fighting reflection.
+ *
+ * The same [ToolSpec] feeds both Anthropic-shape and OpenAI-shape
+ * tool advertisements; provider classes adapt the shape at the wire
+ * layer. See [`in`.jphe.storyvox.llm.provider.ClaudeApiProvider]
+ * and [`in`.jphe.storyvox.llm.provider.OpenAiApiProvider].
+ */
+data class ToolSpec(
+    /** Snake_case name. Both Anthropic and OpenAI accept matching
+     *  `^[a-zA-Z0-9_-]{1,64}$` — we stay conservative on snake_case
+     *  so the model can't accidentally call a name we didn't register. */
+    val name: String,
+    /** One-paragraph description the model uses to decide WHEN to
+     *  call this tool. Be specific about what triggers the call
+     *  ("user asks to add the active book to a shelf") rather than
+     *  what the tool does mechanically — the model already infers the
+     *  mechanics from the parameters. */
+    val description: String,
+    /** Ordered list of named parameters. Order matters only for the
+     *  human reader of the schema — JSON has no positional args. */
+    val parameters: List<ToolParameter> = emptyList(),
+) {
+    /** Build an Anthropic-shape `input_schema` JsonObject for this
+     *  tool. Anthropic expects:
+     *  `{type: "object", properties: {...}, required: [...]}`. */
+    fun toAnthropicInputSchema(): JsonObject = buildJsonObject {
+        put("type", "object")
+        put("properties", buildJsonObject {
+            parameters.forEach { p ->
+                put(p.name, p.toJsonSchema())
+            }
+        })
+        put("required", buildJsonArray {
+            parameters.filter { it.required }.forEach { add(it.name) }
+        })
+    }
+
+    /** OpenAI's `function.parameters` is the same JSON Schema as
+     *  Anthropic's `input_schema`. Same shape, different wrapper. */
+    fun toOpenAiParameters(): JsonObject = toAnthropicInputSchema()
+}
+
+/**
+ * A single named parameter on a [ToolSpec]. The four supported types
+ * cover every v1 tool — adding more is a one-liner here plus a wire
+ * branch in [toJsonSchema].
+ */
+sealed class ToolParameter {
+    abstract val name: String
+    abstract val description: String
+    abstract val required: Boolean
+
+    abstract fun toJsonSchema(): JsonObject
+
+    data class StringParam(
+        override val name: String,
+        override val description: String,
+        override val required: Boolean = true,
+        /** Optional enum-like constraint. Models do a markedly better
+         *  job picking valid values when the schema lists them rather
+         *  than just describing them in prose. */
+        val allowedValues: List<String>? = null,
+    ) : ToolParameter() {
+        override fun toJsonSchema(): JsonObject = buildJsonObject {
+            put("type", "string")
+            put("description", description)
+            allowedValues?.let { values ->
+                put("enum", buildJsonArray {
+                    values.forEach { add(it) }
+                })
+            }
+        }
+    }
+
+    data class IntParam(
+        override val name: String,
+        override val description: String,
+        override val required: Boolean = true,
+        val min: Int? = null,
+        val max: Int? = null,
+    ) : ToolParameter() {
+        override fun toJsonSchema(): JsonObject = buildJsonObject {
+            put("type", "integer")
+            put("description", description)
+            min?.let { put("minimum", it) }
+            max?.let { put("maximum", it) }
+        }
+    }
+
+    data class FloatParam(
+        override val name: String,
+        override val description: String,
+        override val required: Boolean = true,
+        val min: Float? = null,
+        val max: Float? = null,
+    ) : ToolParameter() {
+        override fun toJsonSchema(): JsonObject = buildJsonObject {
+            put("type", "number")
+            put("description", description)
+            min?.let { put("minimum", it.toDouble()) }
+            max?.let { put("maximum", it.toDouble()) }
+        }
+    }
+}
+

--- a/core-llm/src/test/kotlin/in/jphe/storyvox/llm/provider/ClaudeApiProviderToolsTest.kt
+++ b/core-llm/src/test/kotlin/in/jphe/storyvox/llm/provider/ClaudeApiProviderToolsTest.kt
@@ -1,0 +1,226 @@
+package `in`.jphe.storyvox.llm.provider
+
+import `in`.jphe.storyvox.llm.LlmConfig
+import `in`.jphe.storyvox.llm.LlmMessage
+import `in`.jphe.storyvox.llm.tools.ChatStreamEvent
+import `in`.jphe.storyvox.llm.tools.StoryvoxToolSpecs
+import `in`.jphe.storyvox.llm.tools.ToolHandler
+import `in`.jphe.storyvox.llm.tools.ToolRegistry
+import `in`.jphe.storyvox.llm.tools.ToolResult
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.flow.toList
+import kotlinx.coroutines.test.runTest
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.contentOrNull
+import kotlinx.serialization.json.jsonArray
+import kotlinx.serialization.json.jsonObject
+import kotlinx.serialization.json.jsonPrimitive
+import okhttp3.OkHttpClient
+import okhttp3.mockwebserver.MockResponse
+import okhttp3.mockwebserver.MockWebServer
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+import java.util.concurrent.TimeUnit
+
+/**
+ * Issue #216 — wire-shape tests for [ClaudeApiProvider.chatWithTools].
+ *
+ * Two scenarios:
+ *  - Tool catalog is serialized into the outgoing request body in
+ *    Anthropic shape: `tools: [{name, description, input_schema}]`.
+ *  - A simulated tool_use response triggers the matching handler and
+ *    emits [ChatStreamEvent.ToolCallStarted] / [ToolCallCompleted] in
+ *    order, then the follow-up text.
+ */
+class ClaudeApiProviderToolsTest {
+
+    private lateinit var server: MockWebServer
+    private val json = Json { ignoreUnknownKeys = true }
+    private lateinit var http: OkHttpClient
+
+    @Before
+    fun setUp() {
+        server = MockWebServer()
+        server.start()
+        http = OkHttpClient.Builder()
+            .readTimeout(2, TimeUnit.SECONDS)
+            .build()
+    }
+
+    @After
+    fun tearDown() {
+        server.shutdown()
+    }
+
+    private fun providerWith(key: String?): ClaudeApiProvider {
+        val testEndpoint = server.url("/v1/messages").toString()
+        return object : ClaudeApiProvider(
+            http = http,
+            store = FakeStore(claude = key),
+            configFlow = flowOf(LlmConfig(claudeModel = "claude-haiku-4.5")),
+            json = json,
+        ) {
+            override val endpointUrl: String = testEndpoint
+        }
+    }
+
+    @Test
+    fun `chatWithTools serialises catalog into request body`() = runTest {
+        // First response: plain text (no tool_use) — keeps the test
+        // focused on the request shape; tool-call execution has its
+        // own test below.
+        server.enqueue(
+            MockResponse()
+                .setResponseCode(200)
+                .setBody(
+                    """
+                    {
+                      "id":"msg_1",
+                      "type":"message",
+                      "role":"assistant",
+                      "content":[{"type":"text","text":"hi"}],
+                      "stop_reason":"end_turn"
+                    }
+                    """.trimIndent(),
+                ),
+        )
+        val tools = ToolRegistry.build(
+            specs = StoryvoxToolSpecs.ALL,
+            lookup = { ToolHandler { ToolResult.Success("noop") } },
+        )
+        providerWith("k").chatWithTools(
+            messages = listOf(LlmMessage(LlmMessage.Role.user, "ping")),
+            tools = tools,
+        ).toList()
+
+        val req = server.takeRequest()
+        val body = json.parseToJsonElement(req.body.readUtf8()).jsonObject
+        val toolsArr = body["tools"]?.jsonArray
+        assertNotNull("Request must include `tools` array", toolsArr)
+        assertEquals(5, toolsArr!!.size)
+        val firstTool = toolsArr[0].jsonObject
+        assertEquals(
+            "add_to_shelf",
+            firstTool["name"]?.jsonPrimitive?.contentOrNull,
+        )
+        assertNotNull(
+            "tool must include description",
+            firstTool["description"]?.jsonPrimitive?.contentOrNull,
+        )
+        val inputSchema = firstTool["input_schema"]?.jsonObject
+        assertNotNull("tool must include input_schema", inputSchema)
+        assertEquals(
+            "object",
+            inputSchema!!["type"]?.jsonPrimitive?.contentOrNull,
+        )
+        // Non-streaming when tools are present — the stream field
+        // is either absent (kotlinx.serialization skips defaults) or
+        // explicitly false.
+        val streamField = body["stream"]?.jsonPrimitive?.content?.toBoolean()
+        assertTrue(
+            "Expected stream=false or absent, was $streamField",
+            streamField != true,
+        )
+    }
+
+    @Test
+    fun `chatWithTools runs handler then threads result back to model`() = runTest {
+        // First round: model asks to call add_to_shelf.
+        server.enqueue(
+            MockResponse()
+                .setResponseCode(200)
+                .setBody(
+                    """
+                    {
+                      "id":"msg_1",
+                      "type":"message",
+                      "role":"assistant",
+                      "content":[{
+                        "type":"tool_use",
+                        "id":"toolu_abc",
+                        "name":"add_to_shelf",
+                        "input":{"fictionId":"f1","shelf":"Reading"}
+                      }],
+                      "stop_reason":"tool_use"
+                    }
+                    """.trimIndent(),
+                ),
+        )
+        // Second round: model has the result, responds with text.
+        server.enqueue(
+            MockResponse()
+                .setResponseCode(200)
+                .setBody(
+                    """
+                    {
+                      "id":"msg_2",
+                      "type":"message",
+                      "role":"assistant",
+                      "content":[{"type":"text","text":"Done."}],
+                      "stop_reason":"end_turn"
+                    }
+                    """.trimIndent(),
+                ),
+        )
+
+        val handlerCalls = mutableListOf<String>()
+        val tools = ToolRegistry.build(
+            specs = StoryvoxToolSpecs.ALL,
+            lookup = { name ->
+                ToolHandler { args ->
+                    handlerCalls += name
+                    ToolResult.Success("Added to Reading.")
+                }
+            },
+        )
+        val events = providerWith("k").chatWithTools(
+            messages = listOf(LlmMessage(LlmMessage.Role.user, "shelf it")),
+            tools = tools,
+        ).toList()
+
+        // Handler ran exactly once with the matching name.
+        assertEquals(listOf("add_to_shelf"), handlerCalls)
+
+        // Event order: ToolCallStarted → ToolCallCompleted → TextDelta.
+        assertTrue(
+            "First event should be ToolCallStarted, was ${events.firstOrNull()}",
+            events.first() is ChatStreamEvent.ToolCallStarted,
+        )
+        val started = events.first() as ChatStreamEvent.ToolCallStarted
+        assertEquals("add_to_shelf", started.call.name)
+        assertEquals("toolu_abc", started.call.id)
+        val completed = events[1] as ChatStreamEvent.ToolCallCompleted
+        assertEquals("toolu_abc", completed.id)
+        assertTrue(completed.result is ToolResult.Success)
+        val text = events.filterIsInstance<ChatStreamEvent.TextDelta>()
+            .joinToString("") { it.text }
+        assertEquals("Done.", text)
+
+        // Two requests should have hit the server — the tool round
+        // and the follow-up round with the tool result threaded in.
+        assertEquals(2, server.requestCount)
+        val secondReq = run {
+            server.takeRequest() // discard the first
+            server.takeRequest()
+        }
+        val secondBody = json.parseToJsonElement(secondReq.body.readUtf8()).jsonObject
+        val messages = secondBody["messages"]!!.jsonArray
+        // user(ping) + assistant(tool_use) + user(tool_result) = 3
+        assertEquals(3, messages.size)
+        val lastMsg = messages[2].jsonObject
+        assertEquals("user", lastMsg["role"]?.jsonPrimitive?.contentOrNull)
+        val resultBlock = lastMsg["content"]!!.jsonArray[0].jsonObject
+        assertEquals(
+            "tool_result",
+            resultBlock["type"]?.jsonPrimitive?.contentOrNull,
+        )
+        assertEquals(
+            "toolu_abc",
+            resultBlock["tool_use_id"]?.jsonPrimitive?.contentOrNull,
+        )
+    }
+}

--- a/core-llm/src/test/kotlin/in/jphe/storyvox/llm/provider/OpenAiApiProviderToolsTest.kt
+++ b/core-llm/src/test/kotlin/in/jphe/storyvox/llm/provider/OpenAiApiProviderToolsTest.kt
@@ -1,0 +1,211 @@
+package `in`.jphe.storyvox.llm.provider
+
+import `in`.jphe.storyvox.llm.LlmConfig
+import `in`.jphe.storyvox.llm.LlmMessage
+import `in`.jphe.storyvox.llm.tools.ChatStreamEvent
+import `in`.jphe.storyvox.llm.tools.StoryvoxToolSpecs
+import `in`.jphe.storyvox.llm.tools.ToolHandler
+import `in`.jphe.storyvox.llm.tools.ToolRegistry
+import `in`.jphe.storyvox.llm.tools.ToolResult
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.flow.toList
+import kotlinx.coroutines.test.runTest
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.contentOrNull
+import kotlinx.serialization.json.jsonArray
+import kotlinx.serialization.json.jsonObject
+import kotlinx.serialization.json.jsonPrimitive
+import okhttp3.OkHttpClient
+import okhttp3.mockwebserver.MockResponse
+import okhttp3.mockwebserver.MockWebServer
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+import java.util.concurrent.TimeUnit
+
+/**
+ * Issue #216 — wire-shape test for [OpenAiApiProvider.chatWithTools].
+ * The OpenAI format wraps each tool in
+ * `{type: "function", function: {name, description, parameters}}`,
+ * not the flatter Anthropic shape; this test pins both the wrapper
+ * and the parameters' JSON-Schema shape.
+ */
+class OpenAiApiProviderToolsTest {
+
+    private lateinit var server: MockWebServer
+    private val json = Json { ignoreUnknownKeys = true }
+    private lateinit var http: OkHttpClient
+
+    @Before
+    fun setUp() {
+        server = MockWebServer()
+        server.start()
+        http = OkHttpClient.Builder()
+            .readTimeout(2, TimeUnit.SECONDS)
+            .build()
+    }
+
+    @After
+    fun tearDown() {
+        server.shutdown()
+    }
+
+    private fun providerWith(key: String?): OpenAiApiProvider {
+        val testEndpoint = server.url("/v1/chat/completions").toString()
+        return object : OpenAiApiProvider(
+            http = http,
+            store = FakeStore(openAi = key),
+            configFlow = flowOf(LlmConfig(openAiModel = "gpt-4o-mini")),
+            json = json,
+        ) {
+            override val endpointUrl: String = testEndpoint
+        }
+    }
+
+    @Test
+    fun `chatWithTools serialises catalog into OpenAI tool function shape`() = runTest {
+        server.enqueue(
+            MockResponse()
+                .setResponseCode(200)
+                .setBody(
+                    """
+                    {
+                      "id":"chatcmpl-1",
+                      "choices":[{
+                        "index":0,
+                        "message":{"role":"assistant","content":"hi"},
+                        "finish_reason":"stop"
+                      }]
+                    }
+                    """.trimIndent(),
+                ),
+        )
+        val tools = ToolRegistry.build(
+            specs = StoryvoxToolSpecs.ALL,
+            lookup = { ToolHandler { ToolResult.Success("noop") } },
+        )
+        providerWith("k").chatWithTools(
+            messages = listOf(LlmMessage(LlmMessage.Role.user, "ping")),
+            tools = tools,
+        ).toList()
+
+        val req = server.takeRequest()
+        val body = json.parseToJsonElement(req.body.readUtf8()).jsonObject
+        val toolsArr = body["tools"]?.jsonArray
+        assertNotNull(toolsArr)
+        assertEquals(5, toolsArr!!.size)
+        val firstTool = toolsArr[0].jsonObject
+        assertEquals(
+            "function",
+            firstTool["type"]?.jsonPrimitive?.contentOrNull,
+        )
+        val function = firstTool["function"]!!.jsonObject
+        assertEquals(
+            "add_to_shelf",
+            function["name"]?.jsonPrimitive?.contentOrNull,
+        )
+        assertNotNull(function["description"])
+        val params = function["parameters"]!!.jsonObject
+        assertEquals("object", params["type"]?.jsonPrimitive?.contentOrNull)
+        // Non-streaming when tools are present.
+        val streamField = body["stream"]?.jsonPrimitive?.content?.toBoolean()
+        assertTrue(
+            "Expected stream=false or absent, was $streamField",
+            streamField != true,
+        )
+    }
+
+    @Test
+    fun `chatWithTools runs handler on tool_calls response and threads result back`() = runTest {
+        server.enqueue(
+            MockResponse()
+                .setResponseCode(200)
+                .setBody(
+                    """
+                    {
+                      "id":"chatcmpl-1",
+                      "choices":[{
+                        "index":0,
+                        "message":{
+                          "role":"assistant",
+                          "content":null,
+                          "tool_calls":[{
+                            "id":"call_xyz",
+                            "type":"function",
+                            "function":{
+                              "name":"set_speed",
+                              "arguments":"{\"speed\":1.5}"
+                            }
+                          }]
+                        },
+                        "finish_reason":"tool_calls"
+                      }]
+                    }
+                    """.trimIndent(),
+                ),
+        )
+        server.enqueue(
+            MockResponse()
+                .setResponseCode(200)
+                .setBody(
+                    """
+                    {
+                      "id":"chatcmpl-2",
+                      "choices":[{
+                        "index":0,
+                        "message":{"role":"assistant","content":"Sped up."},
+                        "finish_reason":"stop"
+                      }]
+                    }
+                    """.trimIndent(),
+                ),
+        )
+
+        val handlerCalls = mutableListOf<String>()
+        val tools = ToolRegistry.build(
+            specs = StoryvoxToolSpecs.ALL,
+            lookup = { name ->
+                ToolHandler { _ ->
+                    handlerCalls += name
+                    ToolResult.Success("Set to 1.5x.")
+                }
+            },
+        )
+        val events = providerWith("k").chatWithTools(
+            messages = listOf(LlmMessage(LlmMessage.Role.user, "faster")),
+            tools = tools,
+        ).toList()
+
+        assertEquals(listOf("set_speed"), handlerCalls)
+        assertTrue(events.first() is ChatStreamEvent.ToolCallStarted)
+        val completed = events[1] as ChatStreamEvent.ToolCallCompleted
+        assertEquals("call_xyz", completed.id)
+        assertEquals(
+            "Sped up.",
+            events.filterIsInstance<ChatStreamEvent.TextDelta>()
+                .joinToString("") { it.text },
+        )
+        assertEquals(2, server.requestCount)
+        val secondReq = run {
+            server.takeRequest()
+            server.takeRequest()
+        }
+        val secondBody = json.parseToJsonElement(secondReq.body.readUtf8()).jsonObject
+        val messages = secondBody["messages"]!!.jsonArray
+        // user + assistant(tool_calls) + tool = 3
+        assertEquals(3, messages.size)
+        val toolMsg = messages[2].jsonObject
+        assertEquals("tool", toolMsg["role"]?.jsonPrimitive?.contentOrNull)
+        assertEquals(
+            "call_xyz",
+            toolMsg["tool_call_id"]?.jsonPrimitive?.contentOrNull,
+        )
+        assertEquals(
+            "Set to 1.5x.",
+            toolMsg["content"]?.jsonPrimitive?.contentOrNull,
+        )
+    }
+}

--- a/core-llm/src/test/kotlin/in/jphe/storyvox/llm/tools/StoryvoxToolSpecsTest.kt
+++ b/core-llm/src/test/kotlin/in/jphe/storyvox/llm/tools/StoryvoxToolSpecsTest.kt
@@ -1,0 +1,155 @@
+package `in`.jphe.storyvox.llm.tools
+
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.contentOrNull
+import kotlinx.serialization.json.jsonArray
+import kotlinx.serialization.json.jsonObject
+import kotlinx.serialization.json.jsonPrimitive
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * Issue #216 — contract tests for the v1 [StoryvoxToolSpecs] catalog.
+ * Locks in: exactly five tools, non-blank descriptions, valid
+ * JSON-schema shape for every parameter, the explicit shelf enum for
+ * `add_to_shelf`, and the speed clamp range for `set_speed`.
+ *
+ * These are intentionally tight assertions — every advertised tool
+ * round-trips through Anthropic's `input_schema` validator, so a
+ * malformed schema breaks the chat request before the user notices.
+ */
+class StoryvoxToolSpecsTest {
+
+    @Test
+    fun `catalog has exactly five v1 tools`() {
+        val names = StoryvoxToolSpecs.ALL.map { it.name }.toSet()
+        assertEquals(5, names.size)
+        assertTrue(
+            "Expected v1 tool set",
+            names == setOf(
+                "add_to_shelf",
+                "queue_chapter",
+                "mark_chapter_read",
+                "set_speed",
+                "open_voice_library",
+            ),
+        )
+    }
+
+    @Test
+    fun `every spec has a non-blank description`() {
+        StoryvoxToolSpecs.ALL.forEach { spec ->
+            assertTrue(
+                "Tool ${spec.name} should have a non-blank description",
+                spec.description.isNotBlank(),
+            )
+            // Descriptions should actually guide the model — assert
+            // they're meatier than a one-word stub. 80 chars is the
+            // empirical minimum we've seen perform well on Haiku.
+            assertTrue(
+                "Tool ${spec.name} description should be >= 40 chars (was ${spec.description.length})",
+                spec.description.length >= 40,
+            )
+        }
+    }
+
+    @Test
+    fun `anthropic input_schema is a valid JSON schema for each tool`() {
+        StoryvoxToolSpecs.ALL.forEach { spec ->
+            val schema: JsonObject = spec.toAnthropicInputSchema()
+            assertEquals(
+                "Tool ${spec.name} schema should be type=object",
+                "object",
+                schema["type"]?.jsonPrimitive?.contentOrNull,
+            )
+            assertNotNull(
+                "Tool ${spec.name} schema missing 'properties'",
+                schema["properties"],
+            )
+            assertNotNull(
+                "Tool ${spec.name} schema missing 'required'",
+                schema["required"],
+            )
+            // Every named param shows up in properties; every required
+            // param shows up in required.
+            val props = schema["properties"]!!.jsonObject
+            spec.parameters.forEach { p ->
+                assertNotNull(
+                    "Tool ${spec.name} missing parameter '${p.name}' in properties",
+                    props[p.name],
+                )
+            }
+            val required = schema["required"]!!.jsonArray
+                .map { it.jsonPrimitive.content }
+                .toSet()
+            val expectedRequired = spec.parameters
+                .filter { it.required }
+                .map { it.name }
+                .toSet()
+            assertEquals(
+                "Tool ${spec.name} required-set mismatch",
+                expectedRequired,
+                required,
+            )
+        }
+    }
+
+    @Test
+    fun `openai parameters mirrors anthropic input_schema`() {
+        // OpenAI's `function.parameters` is the same JSON Schema as
+        // Anthropic's `input_schema`. The two builders must agree.
+        StoryvoxToolSpecs.ALL.forEach { spec ->
+            assertEquals(
+                "Tool ${spec.name} schemas should match between providers",
+                spec.toAnthropicInputSchema(),
+                spec.toOpenAiParameters(),
+            )
+        }
+    }
+
+    @Test
+    fun `add_to_shelf restricts shelf to the three predefined values`() {
+        val shelfParam = StoryvoxToolSpecs.addToShelf.parameters
+            .single { it.name == "shelf" } as ToolParameter.StringParam
+        assertEquals(
+            "Reading / Read / Wishlist are the allowed shelves",
+            listOf("Reading", "Read", "Wishlist"),
+            shelfParam.allowedValues,
+        )
+        val schema = StoryvoxToolSpecs.addToShelf.toAnthropicInputSchema()
+        val shelfSchema = schema["properties"]!!.jsonObject["shelf"]!!.jsonObject
+        val enumValues = shelfSchema["enum"]!!.jsonArray
+            .map { it.jsonPrimitive.content }
+        assertEquals(listOf("Reading", "Read", "Wishlist"), enumValues)
+    }
+
+    @Test
+    fun `set_speed param documents the visible slider range`() {
+        val speedParam = StoryvoxToolSpecs.setSpeed.parameters
+            .single { it.name == "speed" } as ToolParameter.FloatParam
+        assertEquals(0.5f, speedParam.min!!, 0.001f)
+        assertEquals(2.5f, speedParam.max!!, 0.001f)
+        val schema = StoryvoxToolSpecs.setSpeed.toAnthropicInputSchema()
+        val speedSchema = schema["properties"]!!.jsonObject["speed"]!!.jsonObject
+        assertEquals(
+            0.5,
+            speedSchema["minimum"]!!.jsonPrimitive.content.toDouble(),
+            0.001,
+        )
+        assertEquals(
+            2.5,
+            speedSchema["maximum"]!!.jsonPrimitive.content.toDouble(),
+            0.001,
+        )
+    }
+
+    @Test
+    fun `open_voice_library takes no parameters`() {
+        assertTrue(StoryvoxToolSpecs.openVoiceLibrary.parameters.isEmpty())
+        val schema = StoryvoxToolSpecs.openVoiceLibrary.toAnthropicInputSchema()
+        assertEquals(0, schema["properties"]!!.jsonObject.size)
+        assertEquals(0, schema["required"]!!.jsonArray.size)
+    }
+}

--- a/core-llm/src/test/kotlin/in/jphe/storyvox/llm/tools/UnsupportedProviderFallbackTest.kt
+++ b/core-llm/src/test/kotlin/in/jphe/storyvox/llm/tools/UnsupportedProviderFallbackTest.kt
@@ -1,0 +1,70 @@
+package `in`.jphe.storyvox.llm.tools
+
+import `in`.jphe.storyvox.llm.LlmMessage
+import `in`.jphe.storyvox.llm.LlmProvider
+import `in`.jphe.storyvox.llm.ProbeResult
+import `in`.jphe.storyvox.llm.ProviderId
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.flow.toList
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Test
+
+/**
+ * Issue #216 — providers that haven't opted into tool support inherit
+ * the default [LlmProvider.chatWithTools], which falls through to
+ * [LlmProvider.stream] and wraps each text emit as a
+ * [ChatStreamEvent.TextDelta]. Tool calls are silently dropped — the
+ * UI is responsible for the "actions not supported on this provider"
+ * empty state.
+ *
+ * Test confirms: (a) [LlmProvider.supportsTools] defaults to false,
+ * and (b) a tool-less call through the default path is a 1:1
+ * passthrough.
+ */
+class UnsupportedProviderFallbackTest {
+
+    private object FakeUnsupportedProvider : LlmProvider {
+        override val id: ProviderId = ProviderId.Ollama
+        override fun stream(
+            messages: List<LlmMessage>,
+            systemPrompt: String?,
+            model: String?,
+        ): kotlinx.coroutines.flow.Flow<String> = flowOf("hello ", "world")
+
+        override suspend fun probe(): ProbeResult = ProbeResult.Ok
+    }
+
+    @Test
+    fun `default supportsTools is false`() {
+        assertFalse(
+            "Unannotated providers should not claim tool support",
+            FakeUnsupportedProvider.supportsTools,
+        )
+    }
+
+    @Test
+    fun `default chatWithTools wraps stream emits as TextDelta`() = runTest {
+        val tools = ToolRegistry.build(
+            specs = StoryvoxToolSpecs.ALL,
+            lookup = { ToolHandler { ToolResult.Success("never called") } },
+        )
+        val events = FakeUnsupportedProvider.chatWithTools(
+            messages = listOf(LlmMessage(LlmMessage.Role.user, "hi")),
+            tools = tools,
+        ).toList()
+        // Only TextDelta events; tool registry was silently ignored.
+        assertEquals(2, events.size)
+        events.forEach { event ->
+            assert(event is ChatStreamEvent.TextDelta) {
+                "Expected TextDelta, got $event"
+            }
+        }
+        assertEquals(
+            "hello world",
+            events.filterIsInstance<ChatStreamEvent.TextDelta>()
+                .joinToString("") { it.text },
+        )
+    }
+}

--- a/feature/build.gradle.kts
+++ b/feature/build.gradle.kts
@@ -67,6 +67,10 @@ dependencies {
     implementation(libs.androidx.core.ktx)
     implementation(libs.bundles.lifecycle)
     implementation(libs.bundles.coroutines)
+    // Issue #216 — tool-call argument shapes round-trip through
+    // [kotlinx.serialization.json.JsonObject]; the chat ViewModel
+    // and tool handlers need direct access.
+    implementation(libs.kotlinx.serialization.json)
 
     implementation(platform(libs.androidx.compose.bom))
     implementation(libs.bundles.compose)

--- a/feature/src/main/kotlin/in/jphe/storyvox/feature/api/UiContracts.kt
+++ b/feature/src/main/kotlin/in/jphe/storyvox/feature/api/UiContracts.kt
@@ -643,6 +643,20 @@ data class UiAiSettings(
      * the DataStore default kicks in for missing keys.
      */
     val carryMemoryAcrossFictions: Boolean = true,
+    /**
+     * Issue #216 — "Allow the AI to take actions" toggle. When ON
+     * (default) the chat surface advertises the v1 tool catalog
+     * (add_to_shelf, queue_chapter, mark_chapter_read, set_speed,
+     * open_voice_library) to the model and executes calls locally.
+     * When OFF the chat behaves as a plain Q&A bot.
+     *
+     * Only meaningful when the active provider supports function
+     * calling — v1 is Anthropic (Claude direct + Teams) + OpenAI.
+     * On other providers the chat surfaces an "actions not
+     * supported on this provider" empty state regardless of this
+     * toggle.
+     */
+    val actionsEnabled: Boolean = true,
 )
 
 /**
@@ -1292,6 +1306,9 @@ interface SettingsRepositoryUi {
     /** Issue #217 — "Carry memory across fictions" toggle. See
      *  [UiAiSettings.carryMemoryAcrossFictions]. */
     suspend fun setCarryMemoryAcrossFictions(enabled: Boolean)
+    /** Issue #216 — "Allow the AI to take actions" toggle. See
+     *  [UiAiSettings.actionsEnabled]. */
+    suspend fun setAiActionsEnabled(enabled: Boolean)
     suspend fun acknowledgeAiPrivacy()
     /**
      * Anthropic Teams (OAuth) — local sign-out. Wipes the bearer +

--- a/feature/src/main/kotlin/in/jphe/storyvox/feature/chat/ChatScreen.kt
+++ b/feature/src/main/kotlin/in/jphe/storyvox/feature/chat/ChatScreen.kt
@@ -5,7 +5,9 @@ import androidx.compose.animation.core.animateFloat
 import androidx.compose.animation.core.infiniteRepeatable
 import androidx.compose.animation.core.rememberInfiniteTransition
 import androidx.compose.animation.core.tween
+import androidx.compose.foundation.BorderStroke
 import androidx.compose.foundation.background
+import androidx.compose.foundation.border
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -23,7 +25,10 @@ import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
 import androidx.compose.material.icons.automirrored.filled.Send
 import androidx.compose.material.icons.outlined.AutoAwesome
+import androidx.compose.material.icons.outlined.AutoFixHigh
+import androidx.compose.material.icons.outlined.CheckCircle
 import androidx.compose.material.icons.outlined.Close
+import androidx.compose.material.icons.outlined.ErrorOutline
 import androidx.compose.material.icons.outlined.PlayArrow
 import androidx.compose.material.icons.outlined.Stop
 import androidx.compose.material.icons.outlined.VolumeUp
@@ -48,6 +53,8 @@ import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import `in`.jphe.storyvox.llm.tools.ToolCallEvent
+import `in`.jphe.storyvox.llm.tools.ToolResult
 import `in`.jphe.storyvox.ui.component.BrassButton
 import `in`.jphe.storyvox.ui.component.BrassButtonVariant
 import `in`.jphe.storyvox.ui.theme.LocalReducedMotion
@@ -70,9 +77,23 @@ import `in`.jphe.storyvox.ui.theme.LocalSpacing
 fun ChatScreen(
     onBack: () -> Unit,
     onOpenAiSettings: () -> Unit,
+    /** Issue #216 — fired by the `open_voice_library` tool. The
+     *  callback hops out to nav-land (NavHost wires
+     *  StoryvoxRoutes.VOICE_LIBRARY). */
+    onOpenVoiceLibrary: () -> Unit = {},
     viewModel: ChatViewModel = hiltViewModel(),
 ) {
     val state by viewModel.uiState.collectAsStateWithLifecycle()
+    // Issue #216 — observe one-shot nav events from tool handlers and
+    // dispatch them to the outer NavController. LaunchedEffect with
+    // Unit key so the collector runs once per composition lifetime.
+    LaunchedEffect(Unit) {
+        viewModel.navEvents.collect { event ->
+            when (event) {
+                ChatNavEvent.OpenVoiceLibrary -> onOpenVoiceLibrary()
+            }
+        }
+    }
     // Input prefill seeded by the reader's long-press character lookup
     // (#188). The VM emits this once via the `prefill` StateFlow; the
     // ChatInput observes it, copies into its local TextFieldValue, then
@@ -147,6 +168,15 @@ fun ChatScreen(
                             onReadAloud = { viewModel.readAloud(turn.text) },
                             onStopReadAloud = viewModel::stopReadAloud,
                         )
+                    }
+                    // Issue #216 — tool-call cards render in-line after
+                    // the assistant turn that triggered them. The
+                    // ordering matches the model's emit order (started
+                    // → completed cycles); the streaming bubble lives
+                    // after all of them so the user sees "tool ran →
+                    // reply continues" left-to-right.
+                    items(state.toolCalls, key = { "tool:${it.id}" }) { call ->
+                        ToolCallCard(event = call)
                     }
                     state.streaming?.let { partial ->
                         item(key = "streaming") { StreamingBubble(partial) }
@@ -323,6 +353,83 @@ private fun StreamingBubble(text: String) {
             }
         }
     }
+}
+
+// ── Tool-call card (#216) ──────────────────────────────────────────
+
+/** Issue #216 — brass-edged card surfaced inline when the AI invokes
+ *  one of the registered storyvox tools. Three visual states:
+ *
+ *  - in-flight: animated brass border, "Doing X…" copy.
+ *  - success: solid brass border, check icon, completed copy.
+ *  - error: solid error border, alert icon, error copy.
+ *
+ *  Visual vocabulary follows Library Nocturne: brass-on-warm-dark
+ *  for the primary accent, errorContainer for the failure surface.
+ *  The card stays in the timeline so the user can scroll back and
+ *  see exactly what the AI did. */
+@Composable
+private fun ToolCallCard(event: ToolCallEvent) {
+    val result = event.result
+    val (borderColor, statusIcon, statusTint) = when (result) {
+        is ToolResult.Success -> Triple(
+            MaterialTheme.colorScheme.primary,
+            Icons.Outlined.CheckCircle,
+            MaterialTheme.colorScheme.primary,
+        )
+        is ToolResult.Error -> Triple(
+            MaterialTheme.colorScheme.error,
+            Icons.Outlined.ErrorOutline,
+            MaterialTheme.colorScheme.error,
+        )
+        null -> Triple(
+            MaterialTheme.colorScheme.primary.copy(alpha = 0.6f),
+            Icons.Outlined.AutoFixHigh,
+            MaterialTheme.colorScheme.primary,
+        )
+    }
+    val statusText = when (result) {
+        null -> describeInFlight(event.name)
+        is ToolResult.Success -> result.message
+        is ToolResult.Error -> result.message
+    }
+    Row(
+        modifier = Modifier
+            .fillMaxWidth()
+            .border(BorderStroke(1.dp, borderColor), RoundedCornerShape(8.dp))
+            .background(
+                MaterialTheme.colorScheme.surfaceVariant.copy(alpha = 0.4f),
+                RoundedCornerShape(8.dp),
+            )
+            .padding(horizontal = 10.dp, vertical = 8.dp),
+        verticalAlignment = Alignment.CenterVertically,
+        horizontalArrangement = Arrangement.spacedBy(8.dp),
+    ) {
+        Icon(
+            imageVector = statusIcon,
+            contentDescription = null,
+            tint = statusTint,
+            modifier = Modifier.padding(end = 2.dp),
+        )
+        Text(
+            text = statusText,
+            style = MaterialTheme.typography.labelMedium,
+            color = MaterialTheme.colorScheme.onSurface,
+            modifier = Modifier.weight(1f),
+        )
+    }
+}
+
+/** Short, present-progressive copy used while a tool handler is
+ *  in flight. Matches the [StoryvoxToolSpecs] name set; unknown names
+ *  fall back to the generic verb. */
+private fun describeInFlight(name: String): String = when (name) {
+    "add_to_shelf" -> "Adding to shelf…"
+    "queue_chapter" -> "Queueing chapter…"
+    "mark_chapter_read" -> "Marking as read…"
+    "set_speed" -> "Setting playback speed…"
+    "open_voice_library" -> "Opening voice library…"
+    else -> "Running $name…"
 }
 
 // ── Empty states ───────────────────────────────────────────────────

--- a/feature/src/main/kotlin/in/jphe/storyvox/feature/chat/ChatViewModel.kt
+++ b/feature/src/main/kotlin/in/jphe/storyvox/feature/chat/ChatViewModel.kt
@@ -5,7 +5,9 @@ import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import dagger.hilt.android.lifecycle.HiltViewModel
+import `in`.jphe.storyvox.data.repository.ChapterRepository
 import `in`.jphe.storyvox.data.repository.FictionMemoryRepository
+import `in`.jphe.storyvox.data.repository.ShelfRepository
 import `in`.jphe.storyvox.feature.api.FictionRepositoryUi
 import `in`.jphe.storyvox.feature.api.PlaybackControllerUi
 import `in`.jphe.storyvox.feature.api.SettingsRepositoryUi
@@ -13,18 +15,28 @@ import `in`.jphe.storyvox.feature.api.UiChatGrounding
 import `in`.jphe.storyvox.feature.api.UiRecapPlaybackState
 import `in`.jphe.storyvox.feature.chat.memory.CrossFictionMemoryBlock
 import `in`.jphe.storyvox.feature.chat.memory.FictionMemoryExtractor
+import `in`.jphe.storyvox.feature.chat.tools.ChatToolHandlers
 import `in`.jphe.storyvox.llm.FeatureKind
 import `in`.jphe.storyvox.llm.LlmConfig
 import `in`.jphe.storyvox.llm.LlmError
 import `in`.jphe.storyvox.llm.LlmMessage
+import `in`.jphe.storyvox.llm.LlmRepository
 import `in`.jphe.storyvox.llm.LlmSessionRepository
 import `in`.jphe.storyvox.llm.ProviderId
+import `in`.jphe.storyvox.llm.tools.ChatStreamEvent
+import `in`.jphe.storyvox.llm.tools.ToolCallEvent
+import `in`.jphe.storyvox.llm.tools.ToolRegistry
+import `in`.jphe.storyvox.llm.tools.ToolResult
 import javax.inject.Inject
 import kotlinx.coroutines.Job
+import kotlinx.coroutines.channels.BufferOverflow
 import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.SharedFlow
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asSharedFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.catch
 import kotlinx.coroutines.flow.combine
@@ -76,6 +88,16 @@ data class ChatUiState(
      *  send). The Settings → AI debug overlay surfaces this so JP
      *  can see how often the block fires and how heavy it is. */
     val crossFictionMemoryDebug: CrossFictionMemoryDebug? = null,
+    /** Issue #216 — tool-call timeline, ordered oldest-first. The
+     *  list resets on each [send]; entries get a [ToolCallEvent.result]
+     *  filled in when the handler completes. ChatScreen renders each
+     *  entry as a brass-edged card. */
+    val toolCalls: List<ToolCallEvent> = emptyList(),
+    /** Issue #216 — true iff the active provider supports function
+     *  calling AND the user has enabled actions in Settings → AI.
+     *  When false the model's catalog stays empty; the chat behaves
+     *  identically to pre-#216. */
+    val actionsAvailable: Boolean = false,
 )
 
 /** Issue #217 — debug overlay metric for cross-fiction memory. The
@@ -86,6 +108,23 @@ data class CrossFictionMemoryDebug(
     val entryCount: Int,
     val droppedCount: Int,
     val approxTokens: Int,
+)
+
+/** Issue #216 — one-shot navigation event from a tool call. Surfaces
+ *  through [ChatViewModel.navEvents]; ChatScreen collects + dispatches
+ *  to the nav controller. SharedFlow semantics (not StateFlow) so each
+ *  emit fires exactly once. */
+sealed class ChatNavEvent {
+    /** open_voice_library tool was called. Caller routes to
+     *  StoryvoxRoutes.VOICE_LIBRARY. */
+    data object OpenVoiceLibrary : ChatNavEvent()
+}
+
+/** Internal helper for combine — pairs together the two provider-
+ *  dependent booleans so the 5-arg combine still fits. */
+private data class ProviderInfo(
+    val noProvider: Boolean,
+    val actionsAvailable: Boolean,
 )
 
 /** UI-side classification of [LlmError] so the screen can pick the
@@ -134,6 +173,14 @@ class ChatViewModel @Inject constructor(
     private val settingsRepo: SettingsRepositoryUi,
     private val memoryRepo: FictionMemoryRepository,
     private val savedState: SavedStateHandle,
+    /** Issue #216 — repos + flow used by [ChatToolHandlers]. Nullable
+     *  with defaults so existing test infra that constructs the
+     *  ViewModel directly with positional args still compiles
+     *  unchanged — the new tool wiring is only active when the
+     *  caller (real Hilt-bound app) provides non-null values. */
+    private val shelfRepo: ShelfRepository? = null,
+    private val chapterRepo: ChapterRepository? = null,
+    private val llmRepo: LlmRepository? = null,
 ) : ViewModel() {
 
     /** Issue #217 — cross-fiction prompt-block builder. The title
@@ -197,28 +244,59 @@ class ChatViewModel @Inject constructor(
      *  block. Reset to null on a send where the block ended up empty. */
     private val _memoryDebug = MutableStateFlow<CrossFictionMemoryDebug?>(null)
 
+    /** Issue #216 — tool-call timeline for the in-flight send.
+     *  Cleared on each new [send]; appended to as
+     *  [ChatStreamEvent.ToolCallStarted] / [ChatStreamEvent.ToolCallCompleted]
+     *  events arrive on the chat-with-tools flow. */
+    private val _toolCalls = MutableStateFlow<List<ToolCallEvent>>(emptyList())
+
+    /** Issue #216 — one-shot navigation events fired by the
+     *  open_voice_library tool handler. ChatScreen collects this
+     *  with `lifecycle.repeatOnLifecycle(...)` and navigates on each
+     *  emit. SharedFlow because the nav action is fire-and-forget;
+     *  StateFlow's "latest value" semantics would replay the action
+     *  on configuration change. */
+    private val _navEvents = MutableSharedFlow<ChatNavEvent>(
+        replay = 0,
+        extraBufferCapacity = 4,
+        onBufferOverflow = BufferOverflow.DROP_OLDEST,
+    )
+    val navEvents: SharedFlow<ChatNavEvent> = _navEvents.asSharedFlow()
+
     /** Public state. Combines storage + in-flight + provider config
      *  + fiction metadata into one immutable [ChatUiState]. The 5-arg
      *  combine ceiling forces a nested shape — the inner combine
-     *  builds the base state, the outer folds in the read-aloud text. */
+     *  builds the base state, the outer folds in the read-aloud text
+     *  + cross-fiction memory + tool-call timeline + actions
+     *  availability. */
     val uiState: StateFlow<ChatUiState> = run {
         val base = combine(
             sessionRepo.observeMessages(sessionId).map { msgs -> msgs.map { it.toTurn() } },
             _streaming,
             _error,
             fictionRepo.fictionById(fictionId).map { it?.title },
-            configFlow.map { it.provider == null },
-        ) { turns, streaming, error, title, noProvider ->
+            configFlow.map { cfg ->
+                ProviderInfo(
+                    noProvider = cfg.provider == null,
+                    actionsAvailable = cfg.aiActionsEnabled &&
+                        cfg.provider?.let { llmRepo?.supportsTools(it) } == true,
+                )
+            },
+        ) { turns, streaming, error, title, info ->
             ChatUiState(
                 turns = turns,
                 streaming = streaming,
                 fictionTitle = title,
-                noProvider = noProvider,
+                noProvider = info.noProvider,
                 error = error,
+                actionsAvailable = info.actionsAvailable,
             )
         }
-        combine(base, _readingText, _memoryDebug) { state, reading, memoryDebug ->
+        val withSecondary = combine(base, _readingText, _memoryDebug) { state, reading, memoryDebug ->
             state.copy(readingText = reading, crossFictionMemoryDebug = memoryDebug)
+        }
+        combine(withSecondary, _toolCalls) { state, toolCalls ->
+            state.copy(toolCalls = toolCalls)
         }.stateIn(viewModelScope, SharingStarted.WhileSubscribed(5_000), ChatUiState())
     }
 
@@ -253,12 +331,18 @@ class ChatViewModel @Inject constructor(
     /** Send [text] as a user turn and stream the assistant reply.
      *  Cancels any in-flight stream first — the user-facing input
      *  is supposed to be disabled while streaming, but the cancel
-     *  guards against races (e.g. text injected via accessibility). */
+     *  guards against races (e.g. text injected via accessibility).
+     *
+     *  Issue #216 — routes through the tool-aware chat path when
+     *  the user has actions enabled AND the active provider
+     *  supports function calling; otherwise falls back to the
+     *  plain text-only chat path (pre-#216 behaviour). */
     fun send(text: String) {
         val trimmed = text.trim()
         if (trimmed.isEmpty()) return
         sendJob?.cancel()
         _error.value = null
+        _toolCalls.value = emptyList()
 
         sendJob = viewModelScope.launch {
             val cfg = configFlow.first()
@@ -298,30 +382,103 @@ class ChatViewModel @Inject constructor(
             } else {
                 null
             }
-            sessionRepo.updateSystemPrompt(sessionId, basePrompt + memoryBlock.text)
+            // Issue #216 — when actions are enabled, append a hint to
+            // the system prompt naming the active fiction's id. The
+            // model uses this to populate `fictionId` arguments without
+            // asking the user.
+            val actionsEnabled = cfg.aiActionsEnabled &&
+                llmRepo?.supportsTools(provider) == true &&
+                shelfRepo != null && chapterRepo != null
+            val actionsHint = if (actionsEnabled) {
+                "\n\nThe user's active fiction id is \"$fictionId\". When " +
+                    "you call a tool that takes a fictionId argument, use " +
+                    "this value unless the user explicitly named a different " +
+                    "book in the message."
+            } else {
+                ""
+            }
+            sessionRepo.updateSystemPrompt(
+                sessionId,
+                basePrompt + memoryBlock.text + actionsHint,
+            )
 
             val buf = StringBuilder()
             _streaming.value = ""
 
-            sessionRepo.chat(sessionId, trimmed)
-                .catch { e -> _error.value = mapError(e) }
-                .onCompletion { cause ->
-                    _streaming.value = null
-                    // Issue #217 — post-process the assistant's
-                    // reply into memory entries. Regex-based, runs
-                    // only on completion (no partial-stream
-                    // extraction — saves work on cancelled sends).
-                    // Cheap, no-network — runs on the same coroutine
-                    // dispatcher as the stream collector.
-                    if (cause == null) {
-                        extractAndRecord(buf.toString())
+            if (actionsEnabled) {
+                streamWithTools(trimmed, buf)
+            } else {
+                streamPlainText(trimmed, buf)
+            }
+        }
+    }
+
+    /** Plain-text streaming path — preserved from pre-#216. Used when
+     *  actions are disabled or the provider doesn't support tool use. */
+    private suspend fun streamPlainText(trimmed: String, buf: StringBuilder) {
+        sessionRepo.chat(sessionId, trimmed)
+            .catch { e -> _error.value = mapError(e) }
+            .onCompletion { cause ->
+                _streaming.value = null
+                if (cause == null) {
+                    extractAndRecord(buf.toString())
+                }
+            }
+            .collect { delta ->
+                buf.append(delta)
+                _streaming.value = buf.toString()
+            }
+    }
+
+    /** Issue #216 — tool-aware path. Same persistence + memory-extract
+     *  contract as [streamPlainText] but consumes [ChatStreamEvent]
+     *  emits, routing tool-call events into [_toolCalls] for the UI to
+     *  render alongside the streaming bubble. */
+    private suspend fun streamWithTools(trimmed: String, buf: StringBuilder) {
+        val handlers = ChatToolHandlers(
+            activeFictionId = fictionId,
+            shelfRepo = shelfRepo!!,
+            chapterRepo = chapterRepo!!,
+            fictionRepo = fictionRepo,
+            playback = playback,
+            settingsRepo = settingsRepo,
+            onOpenVoiceLibrary = {
+                _navEvents.tryEmit(ChatNavEvent.OpenVoiceLibrary)
+            },
+        )
+        sessionRepo.chatWithTools(sessionId, trimmed, handlers.registry())
+            .catch { e -> _error.value = mapError(e) }
+            .onCompletion { cause ->
+                _streaming.value = null
+                if (cause == null) {
+                    extractAndRecord(buf.toString())
+                }
+            }
+            .collect { event ->
+                when (event) {
+                    is ChatStreamEvent.TextDelta -> {
+                        buf.append(event.text)
+                        _streaming.value = buf.toString()
+                    }
+                    is ChatStreamEvent.ToolCallStarted -> {
+                        _toolCalls.value = _toolCalls.value + ToolCallEvent(
+                            id = event.call.id,
+                            name = event.call.name,
+                            arguments = event.call.arguments,
+                            result = null,
+                        )
+                    }
+                    is ChatStreamEvent.ToolCallCompleted -> {
+                        _toolCalls.value = _toolCalls.value.map { existing ->
+                            if (existing.id == event.id) {
+                                existing.copy(result = event.result)
+                            } else {
+                                existing
+                            }
+                        }
                     }
                 }
-                .collect { delta ->
-                    buf.append(delta)
-                    _streaming.value = buf.toString()
-                }
-        }
+            }
     }
 
     /**

--- a/feature/src/main/kotlin/in/jphe/storyvox/feature/chat/tools/ChatToolHandlers.kt
+++ b/feature/src/main/kotlin/in/jphe/storyvox/feature/chat/tools/ChatToolHandlers.kt
@@ -1,0 +1,189 @@
+package `in`.jphe.storyvox.feature.chat.tools
+
+import `in`.jphe.storyvox.data.db.entity.Shelf
+import `in`.jphe.storyvox.data.repository.ChapterRepository
+import `in`.jphe.storyvox.data.repository.ShelfRepository
+import `in`.jphe.storyvox.feature.api.FictionRepositoryUi
+import `in`.jphe.storyvox.feature.api.PlaybackControllerUi
+import `in`.jphe.storyvox.feature.api.SettingsRepositoryUi
+import `in`.jphe.storyvox.llm.tools.StoryvoxToolSpecs
+import `in`.jphe.storyvox.llm.tools.ToolHandler
+import `in`.jphe.storyvox.llm.tools.ToolRegistry
+import `in`.jphe.storyvox.llm.tools.ToolResult
+import kotlinx.coroutines.flow.first
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.contentOrNull
+import kotlinx.serialization.json.floatOrNull
+import kotlinx.serialization.json.intOrNull
+import kotlinx.serialization.json.jsonPrimitive
+
+/**
+ * Issue #216 — concrete [ToolHandler] implementations wiring the v1
+ * tool catalog to storyvox's data + playback layers.
+ *
+ * Constructed per-chat-turn by the ViewModel (cheap — five lambdas
+ * holding repo refs), passed into the provider's tool-aware chat
+ * path via [ToolRegistry]. The chat's active fiction id is captured
+ * at construction time; the AI's `fictionId` argument is honored
+ * over the active fiction only when the user explicitly named a
+ * different book — practical guard against the model "helpfully"
+ * targeting the wrong book on a search-shaped prompt.
+ */
+class ChatToolHandlers(
+    private val activeFictionId: String,
+    private val shelfRepo: ShelfRepository,
+    private val chapterRepo: ChapterRepository,
+    private val fictionRepo: FictionRepositoryUi,
+    private val playback: PlaybackControllerUi,
+    private val settingsRepo: SettingsRepositoryUi,
+    /** Fired on `open_voice_library` calls. The Chat ViewModel relays
+     *  this to ChatScreen, which navigates via the nav controller. */
+    private val onOpenVoiceLibrary: () -> Unit,
+) {
+    /** Build a [ToolRegistry] bound to this handler instance.
+     *  Idempotent — same registry every call. */
+    fun registry(): ToolRegistry = ToolRegistry.build(
+        specs = StoryvoxToolSpecs.ALL,
+        lookup = ::handlerFor,
+    )
+
+    private fun handlerFor(name: String): ToolHandler = when (name) {
+        StoryvoxToolSpecs.ADD_TO_SHELF -> ToolHandler { addToShelf(it) }
+        StoryvoxToolSpecs.QUEUE_CHAPTER -> ToolHandler { queueChapter(it) }
+        StoryvoxToolSpecs.MARK_CHAPTER_READ -> ToolHandler { markChapterRead(it) }
+        StoryvoxToolSpecs.SET_SPEED -> ToolHandler { setSpeed(it) }
+        StoryvoxToolSpecs.OPEN_VOICE_LIBRARY -> ToolHandler { openVoiceLibrary() }
+        else -> ToolHandler {
+            ToolResult.Error("Unknown tool: $name")
+        }
+    }
+
+    // ── Handler implementations ────────────────────────────────────
+
+    /** `add_to_shelf(fictionId, shelf)` — move a fiction onto one of
+     *  the three predefined shelves. Validates the shelf name against
+     *  [Shelf.ALL] (Reading / Read / Wishlist); anything else returns
+     *  an Error so the AI surfaces "I can only add to those three". */
+    internal suspend fun addToShelf(args: JsonObject): ToolResult {
+        val fictionId = args["fictionId"]?.jsonPrimitive?.contentOrNull
+            ?.takeIf { it.isNotBlank() } ?: activeFictionId
+        val shelfName = args["shelf"]?.jsonPrimitive?.contentOrNull
+            ?: return ToolResult.Error(
+                "Tell me which shelf — Reading, Read, or Wishlist.",
+            )
+        val shelf = Shelf.fromName(shelfName)
+            ?: return ToolResult.Error(
+                "\"$shelfName\" isn't one of the shelves. Pick Reading, Read, or Wishlist.",
+            )
+        val fiction = runCatching {
+            fictionRepo.fictionById(fictionId).first()
+        }.getOrNull()
+            ?: return ToolResult.Error(
+                "I couldn't find a fiction with id \"$fictionId\".",
+            )
+        shelfRepo.add(fictionId, shelf)
+        return ToolResult.Success(
+            "Added \"${fiction.title}\" to your ${shelf.displayName} shelf.",
+        )
+    }
+
+    /** `queue_chapter(fictionId, chapterIndex)` — start playing a
+     *  specific chapter. Resolves the chapter id by listing chapters
+     *  for the fiction and indexing into the result. */
+    internal suspend fun queueChapter(args: JsonObject): ToolResult {
+        val fictionId = args["fictionId"]?.jsonPrimitive?.contentOrNull
+            ?.takeIf { it.isNotBlank() } ?: activeFictionId
+        val index = args["chapterIndex"]?.jsonPrimitive?.intOrNull
+            ?: return ToolResult.Error(
+                "Tell me which chapter — the chapter index is zero-based.",
+            )
+        if (index < 0) {
+            return ToolResult.Error(
+                "Chapter index can't be negative (index 0 is chapter 1).",
+            )
+        }
+        val chapters = runCatching {
+            fictionRepo.chaptersFor(fictionId).first()
+        }.getOrDefault(emptyList())
+        if (chapters.isEmpty()) {
+            return ToolResult.Error(
+                "I couldn't find any chapters for that fiction yet.",
+            )
+        }
+        val chapter = chapters.getOrNull(index)
+            ?: return ToolResult.Error(
+                "Chapter index $index is out of range — this book has ${chapters.size} chapter(s).",
+            )
+        playback.startListening(
+            fictionId = fictionId,
+            chapterId = chapter.id,
+            charOffset = 0,
+            autoPlay = true,
+        )
+        return ToolResult.Success(
+            "Queued \"${chapter.title}\" (chapter ${index + 1}) for playback.",
+        )
+    }
+
+    /** `mark_chapter_read(fictionId, chapterIndex)` — flip the
+     *  chapter's read flag to true. Resolves chapter id by index
+     *  same way as [queueChapter]. */
+    internal suspend fun markChapterRead(args: JsonObject): ToolResult {
+        val fictionId = args["fictionId"]?.jsonPrimitive?.contentOrNull
+            ?.takeIf { it.isNotBlank() } ?: activeFictionId
+        val index = args["chapterIndex"]?.jsonPrimitive?.intOrNull
+            ?: return ToolResult.Error(
+                "Tell me which chapter — the chapter index is zero-based.",
+            )
+        if (index < 0) {
+            return ToolResult.Error(
+                "Chapter index can't be negative.",
+            )
+        }
+        val chapters = runCatching {
+            fictionRepo.chaptersFor(fictionId).first()
+        }.getOrDefault(emptyList())
+        val chapter = chapters.getOrNull(index)
+            ?: return ToolResult.Error(
+                "Chapter index $index is out of range — this book has ${chapters.size} chapter(s).",
+            )
+        chapterRepo.markRead(chapter.id, read = true)
+        return ToolResult.Success(
+            "Marked \"${chapter.title}\" as read.",
+        )
+    }
+
+    /** `set_speed(speed)` — set the playback speed slider. Clamps to
+     *  [0.5..2.5] to match the slider's visible range; reports the
+     *  clamped value in the success message so the AI can echo it
+     *  accurately even when the user asked for something out-of-range. */
+    internal suspend fun setSpeed(args: JsonObject): ToolResult {
+        val raw = args["speed"]?.jsonPrimitive?.floatOrNull
+            ?: return ToolResult.Error(
+                "Tell me a speed — 1.0 is normal, 1.5 is faster, 0.8 is slower.",
+            )
+        val clamped = raw.coerceIn(
+            StoryvoxToolSpecs.SPEED_MIN,
+            StoryvoxToolSpecs.SPEED_MAX,
+        )
+        playback.setSpeed(clamped)
+        // Persist the new default so it sticks across chapters —
+        // matches what tapping the slider does (#312 made setSpeed
+        // also persist), but we set both surfaces explicitly to be
+        // safe across renderer changes.
+        runCatching { settingsRepo.setDefaultSpeed(clamped) }
+        val suffix = if (clamped != raw) " (clamped from ${"%.2f".format(raw)})" else ""
+        return ToolResult.Success(
+            "Set playback speed to ${"%.2f".format(clamped)}x$suffix.",
+        )
+    }
+
+    /** `open_voice_library()` — navigate to Settings → Voices. No
+     *  arguments. Fires the [onOpenVoiceLibrary] callback the
+     *  ViewModel passed in; that hop into nav-land is the only
+     *  place this handler talks to the UI. */
+    internal suspend fun openVoiceLibrary(): ToolResult {
+        onOpenVoiceLibrary()
+        return ToolResult.Success("Opening the voice library.")
+    }
+}

--- a/feature/src/main/kotlin/in/jphe/storyvox/feature/settings/SettingsScreen.kt
+++ b/feature/src/main/kotlin/in/jphe/storyvox/feature/settings/SettingsScreen.kt
@@ -422,6 +422,7 @@ fun SettingsScreen(
             // for AI behaviour toggles (parallel to the grounding-level
             // switches above).
             onSetCarryMemoryAcrossFictions = viewModel::setCarryMemoryAcrossFictions,
+            onSetAiActionsEnabled = viewModel::setAiActionsEnabled,
             onTestConnection = viewModel::testAiConnection,
             onClearProbeOutcome = viewModel::clearProbeOutcome,
             onResetAi = viewModel::resetAiSettings,
@@ -1852,6 +1853,9 @@ private fun AiSection(
      *  conditionally appends the cross-fiction context block to the
      *  system prompt. Default ON. */
     onSetCarryMemoryAcrossFictions: (Boolean) -> Unit,
+    /** Issue #216 — Allow the AI to take actions. See
+     *  [UiAiSettings.actionsEnabled]. Default ON. */
+    onSetAiActionsEnabled: (Boolean) -> Unit,
     onTestConnection: (UiLlmProvider) -> Unit,
     onClearProbeOutcome: () -> Unit,
     onResetAi: () -> Unit,
@@ -2019,6 +2023,19 @@ private fun AiSection(
                 "tokens per turn; oldest entries drop first.",
             checked = ai.carryMemoryAcrossFictions,
             onCheckedChange = onSetCarryMemoryAcrossFictions,
+        )
+        // Issue #216 — actions toggle. Sits below cross-fiction memory
+        // because it's the same kind of opt-in capability ("how much
+        // agency does the AI have?"). Default ON for fresh installs;
+        // subtitle calls out the five v1 tools so the user knows
+        // exactly what's gated.
+        SettingsSwitchRow(
+            title = "Allow the AI to take actions",
+            subtitle = "Chat can add books to shelves, queue chapters, " +
+                "mark chapters read, set playback speed, and open the " +
+                "voice library when you ask. Works on Anthropic and OpenAI.",
+            checked = ai.actionsEnabled,
+            onCheckedChange = onSetAiActionsEnabled,
         )
         // Issue #262 — destructive AI-reset path. Previously a plain
         // brass-tinted TextButton that looked identical to a 'Save' or

--- a/feature/src/main/kotlin/in/jphe/storyvox/feature/settings/SettingsViewModel.kt
+++ b/feature/src/main/kotlin/in/jphe/storyvox/feature/settings/SettingsViewModel.kt
@@ -355,6 +355,11 @@ class SettingsViewModel @Inject constructor(
     /** Issue #217 — "Carry memory across fictions" toggle. */
     fun setCarryMemoryAcrossFictions(enabled: Boolean) =
         viewModelScope.launch { repo.setCarryMemoryAcrossFictions(enabled) }
+    /** Issue #216 — "Allow the AI to take actions" toggle. The chat
+     *  ViewModel reads [UiAiSettings.actionsEnabled] at send-time and
+     *  switches between the tool-aware and plain-text chat paths. */
+    fun setAiActionsEnabled(enabled: Boolean) =
+        viewModelScope.launch { repo.setAiActionsEnabled(enabled) }
     fun acknowledgeAiPrivacy() = viewModelScope.launch { repo.acknowledgeAiPrivacy() }
     /** Anthropic Teams (OAuth) — local sign-out. Remote revoke deep-links
      *  to claude.ai/settings. (#181) */

--- a/feature/src/test/kotlin/in/jphe/storyvox/feature/chat/ChatViewModelTest.kt
+++ b/feature/src/test/kotlin/in/jphe/storyvox/feature/chat/ChatViewModelTest.kt
@@ -694,6 +694,7 @@ private class FakeSettingsRepo(
     override suspend fun setChatGroundEntireChapter(enabled: Boolean) = Unit
     override suspend fun setChatGroundEntireBookSoFar(enabled: Boolean) = Unit
     override suspend fun setCarryMemoryAcrossFictions(enabled: Boolean) = Unit
+    override suspend fun setAiActionsEnabled(enabled: Boolean) = Unit
     override suspend fun acknowledgeAiPrivacy() = Unit
     override suspend fun resetAiSettings() = Unit
     override suspend fun signOutGitHub() = Unit

--- a/feature/src/test/kotlin/in/jphe/storyvox/feature/chat/tools/ChatToolHandlersTest.kt
+++ b/feature/src/test/kotlin/in/jphe/storyvox/feature/chat/tools/ChatToolHandlersTest.kt
@@ -1,0 +1,372 @@
+package `in`.jphe.storyvox.feature.chat.tools
+
+import `in`.jphe.storyvox.data.db.entity.Shelf
+import `in`.jphe.storyvox.data.repository.CachedBodyUsage
+import `in`.jphe.storyvox.data.repository.ChapterRepository
+import `in`.jphe.storyvox.data.repository.ShelfRepository
+import `in`.jphe.storyvox.data.repository.playback.PlaybackChapter
+import `in`.jphe.storyvox.data.db.entity.ChapterDownloadState
+import `in`.jphe.storyvox.data.source.model.ChapterContent
+import `in`.jphe.storyvox.data.source.model.ChapterInfo
+import `in`.jphe.storyvox.data.source.model.FictionSummary
+import `in`.jphe.storyvox.feature.api.DownloadMode
+import `in`.jphe.storyvox.feature.api.FictionRepositoryUi
+import `in`.jphe.storyvox.feature.api.PlaybackControllerUi
+import `in`.jphe.storyvox.feature.api.SettingsRepositoryUi
+import `in`.jphe.storyvox.feature.api.UiAddByUrlResult
+import `in`.jphe.storyvox.feature.api.UiChapter
+import `in`.jphe.storyvox.feature.api.UiFiction
+import `in`.jphe.storyvox.feature.api.UiFollow
+import `in`.jphe.storyvox.feature.api.UiPlaybackState
+import `in`.jphe.storyvox.feature.api.UiRecapPlaybackState
+import `in`.jphe.storyvox.feature.api.UiSettings
+import `in`.jphe.storyvox.feature.api.UiSigil
+import `in`.jphe.storyvox.feature.api.UiSleepTimerMode
+import `in`.jphe.storyvox.feature.api.SetFollowedRemoteResult
+import `in`.jphe.storyvox.feature.api.PalaceProbeResult
+import `in`.jphe.storyvox.feature.api.AzureProbeResult
+import `in`.jphe.storyvox.feature.api.ThemeOverride
+import `in`.jphe.storyvox.feature.api.UiLlmProvider
+import `in`.jphe.storyvox.llm.tools.ToolResult
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.test.runTest
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.JsonPrimitive
+import kotlinx.serialization.json.buildJsonObject
+import kotlinx.serialization.json.put
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * Issue #216 — handler-level behaviour tests for the v1 tool catalog.
+ * These exercise the [ChatToolHandlers] private functions through their
+ * `internal` visibility (same module), threading typed JSON args in and
+ * inspecting the [ToolResult] back.
+ *
+ * Repos are tiny in-memory fakes — full coverage of the repo
+ * implementations lives in their own test classes. The intent here is
+ * "does the handler glue between args/repos do the right thing?", not
+ * "does the repo work?".
+ */
+class ChatToolHandlersTest {
+
+    @Test
+    fun `add_to_shelf round-trips Reading shelf`() = runTest {
+        val shelf = FakeShelfRepo()
+        val handlers = makeHandlers(shelfRepo = shelf)
+        val args = buildJsonObject {
+            put("fictionId", "f1")
+            put("shelf", "Reading")
+        }
+        val result = handlers.addToShelf(args)
+        assertTrue(
+            "Expected Success, got $result",
+            result is ToolResult.Success,
+        )
+        assertEquals(setOf("f1" to Shelf.Reading), shelf.added)
+        val success = result as ToolResult.Success
+        assertTrue(
+            "Success message should reference the fiction title (was ${success.message})",
+            success.message.contains("Sky Pride"),
+        )
+        assertTrue(success.message.contains("Reading"))
+    }
+
+    @Test
+    fun `add_to_shelf rejects unknown shelf with error`() = runTest {
+        val shelf = FakeShelfRepo()
+        val handlers = makeHandlers(shelfRepo = shelf)
+        val args = buildJsonObject {
+            put("fictionId", "f1")
+            put("shelf", "Favorites")  // not one of the three
+        }
+        val result = handlers.addToShelf(args)
+        assertTrue(
+            "Expected Error, got $result",
+            result is ToolResult.Error,
+        )
+        // No mutation should have happened.
+        assertEquals(emptySet<Pair<String, Shelf>>(), shelf.added)
+    }
+
+    @Test
+    fun `set_speed clamps to the allowed range`() = runTest {
+        val playback = FakePlayback()
+        val handlers = makeHandlers(playback = playback)
+        // 4x is well past the 2.5 cap.
+        val tooFast = handlers.setSpeed(buildJsonObject { put("speed", 4.0f) })
+        assertTrue(tooFast is ToolResult.Success)
+        assertEquals(2.5f, playback.appliedSpeed, 0.001f)
+        assertTrue(
+            (tooFast as ToolResult.Success).message.contains("clamped"),
+        )
+        // 0.1x is below the 0.5 floor.
+        val tooSlow = handlers.setSpeed(buildJsonObject { put("speed", 0.1f) })
+        assertTrue(tooSlow is ToolResult.Success)
+        assertEquals(0.5f, playback.appliedSpeed, 0.001f)
+    }
+
+    @Test
+    fun `set_speed in-range applies exactly`() = runTest {
+        val playback = FakePlayback()
+        val handlers = makeHandlers(playback = playback)
+        val result = handlers.setSpeed(buildJsonObject { put("speed", 1.2f) })
+        assertTrue(result is ToolResult.Success)
+        assertEquals(1.2f, playback.appliedSpeed, 0.001f)
+        assertTrue(
+            !(result as ToolResult.Success).message.contains("clamped"),
+        )
+    }
+
+    @Test
+    fun `open_voice_library fires the navigation callback`() = runTest {
+        var fired = 0
+        val handlers = makeHandlers(onOpenVoiceLibrary = { fired++ })
+        val result = handlers.openVoiceLibrary()
+        assertTrue(result is ToolResult.Success)
+        assertEquals(1, fired)
+    }
+
+    @Test
+    fun `registry exposes every catalog tool by name`() {
+        val handlers = makeHandlers()
+        val registry = handlers.registry()
+        assertEquals(5, registry.catalog.size)
+        registry.catalog.forEach { spec ->
+            assertNotNull(
+                "Registry missing handler for ${spec.name}",
+                registry.handler(spec.name),
+            )
+        }
+    }
+
+    // ── Helpers ────────────────────────────────────────────────────
+
+    private fun makeHandlers(
+        shelfRepo: FakeShelfRepo = FakeShelfRepo(),
+        chapterRepo: FakeChapterRepo = FakeChapterRepo(),
+        fictionRepo: FakeFictionRepoT = FakeFictionRepoT(),
+        playback: FakePlayback = FakePlayback(),
+        settings: FakeSettings = FakeSettings(),
+        onOpenVoiceLibrary: () -> Unit = {},
+    ): ChatToolHandlers = ChatToolHandlers(
+        activeFictionId = "f1",
+        shelfRepo = shelfRepo,
+        chapterRepo = chapterRepo,
+        fictionRepo = fictionRepo,
+        playback = playback,
+        settingsRepo = settings,
+        onOpenVoiceLibrary = onOpenVoiceLibrary,
+    )
+}
+
+// ── Fakes ───────────────────────────────────────────────────────────
+
+private class FakeShelfRepo : ShelfRepository {
+    val added: MutableSet<Pair<String, Shelf>> = mutableSetOf()
+    override fun observeByShelf(shelf: Shelf): Flow<List<FictionSummary>> = flowOf(emptyList())
+    override fun observeShelvesForFiction(fictionId: String): Flow<Set<Shelf>> = flowOf(emptySet())
+    override suspend fun shelvesForFiction(fictionId: String): Set<Shelf> = emptySet()
+    override suspend fun add(fictionId: String, shelf: Shelf) {
+        added += fictionId to shelf
+    }
+    override suspend fun remove(fictionId: String, shelf: Shelf) {
+        added -= fictionId to shelf
+    }
+    override suspend fun clearForFiction(fictionId: String) {
+        added.removeAll { it.first == fictionId }
+    }
+}
+
+private class FakeChapterRepo : ChapterRepository {
+    val readMarks: MutableList<Pair<String, Boolean>> = mutableListOf()
+    override fun observeChapters(fictionId: String): Flow<List<ChapterInfo>> = flowOf(emptyList())
+    override fun observeChapter(chapterId: String): Flow<ChapterContent?> = flowOf(null)
+    override fun observeDownloadState(fictionId: String): Flow<Map<String, ChapterDownloadState>> = flowOf(emptyMap())
+    override fun observePlayedChapterIds(fictionId: String): Flow<Set<String>> = flowOf(emptySet())
+    override suspend fun queueChapterDownload(fictionId: String, chapterId: String, requireUnmetered: Boolean) = Unit
+    override suspend fun queueAllMissing(fictionId: String, requireUnmetered: Boolean) = Unit
+    override suspend fun markRead(chapterId: String, read: Boolean) {
+        readMarks += chapterId to read
+    }
+    override suspend fun markChapterPlayed(chapterId: String) {
+        readMarks += chapterId to true
+    }
+    override suspend fun trimDownloadedBodies(fictionId: String, keepLast: Int) = Unit
+    override suspend fun getChapter(id: String): PlaybackChapter? = null
+    override suspend fun getNextChapterId(currentChapterId: String): String? = null
+    override suspend fun getPreviousChapterId(currentChapterId: String): String? = null
+    override suspend fun cachedBodyUsage() = CachedBodyUsage(0, 0L)
+    override suspend fun setChapterBookmark(chapterId: String, charOffset: Int?) = Unit
+    override suspend fun chapterBookmark(chapterId: String): Int? = null
+}
+
+private class FakeFictionRepoT : FictionRepositoryUi {
+    override val library: Flow<List<UiFiction>> = flowOf(emptyList())
+    override val follows: Flow<List<UiFollow>> = flowOf(emptyList())
+    override fun fictionById(id: String): Flow<UiFiction?> = flowOf(
+        UiFiction(
+            id = id,
+            title = "Sky Pride",
+            author = "Anon",
+            coverUrl = null,
+            rating = 0f,
+            chapterCount = 0,
+            isOngoing = true,
+            synopsis = "",
+        ),
+    )
+    override fun fictionLoadError(id: String): Flow<String?> = flowOf(null)
+    override fun chaptersFor(fictionId: String): Flow<List<UiChapter>> = flowOf(emptyList())
+    override suspend fun chapterTextById(chapterId: String): String? = null
+    override suspend fun setDownloadMode(fictionId: String, mode: DownloadMode) = Unit
+    override suspend fun follow(fictionId: String, follow: Boolean) = Unit
+    override suspend fun setFollowedRemote(fictionId: String, followed: Boolean): SetFollowedRemoteResult =
+        SetFollowedRemoteResult.Success
+    override suspend fun markAllCaughtUp() = Unit
+    override suspend fun refreshFollows() = Unit
+    override suspend fun addByUrl(url: String): UiAddByUrlResult = UiAddByUrlResult.UnrecognizedUrl
+}
+
+private class FakePlayback : PlaybackControllerUi {
+    var appliedSpeed: Float = Float.NaN
+    var started: Triple<String, String, Int>? = null
+    override val state: Flow<UiPlaybackState> = MutableStateFlow(
+        UiPlaybackState(
+            fictionId = null, chapterId = null, chapterTitle = "", fictionTitle = "",
+            coverUrl = null, isPlaying = false, positionMs = 0, durationMs = 0,
+            sentenceStart = 0, sentenceEnd = 0, speed = 1f, pitch = 1f,
+            voiceId = null, voiceLabel = "",
+        ),
+    )
+    override val chapterText: Flow<String> = flowOf("")
+    override val recapPlayback: Flow<UiRecapPlaybackState> = flowOf(UiRecapPlaybackState.Idle)
+    override fun play() = Unit
+    override fun pause() = Unit
+    override fun seekTo(ms: Long) = Unit
+    override fun seekToChar(charOffset: Int) = Unit
+    override fun skipForward() = Unit
+    override fun skipBack() = Unit
+    override fun nextSentence() = Unit
+    override fun previousSentence() = Unit
+    override fun nextChapter() = Unit
+    override fun previousChapter() = Unit
+    override fun setSpeed(speed: Float) { appliedSpeed = speed }
+    override fun setPitch(pitch: Float) = Unit
+    override fun setPunctuationPauseMultiplier(multiplier: Float) = Unit
+    override fun startListening(
+        fictionId: String, chapterId: String, charOffset: Int, autoPlay: Boolean,
+    ) { started = Triple(fictionId, chapterId, charOffset) }
+    override fun startSleepTimer(mode: UiSleepTimerMode) = Unit
+    override fun cancelSleepTimer() = Unit
+    override suspend fun speakText(text: String) = Unit
+    override fun stopSpeaking() = Unit
+    override fun bookmarkHere() = Unit
+    override fun clearBookmark() = Unit
+    override fun jumpToBookmark() = Unit
+}
+
+/**
+ * Same shape as ChatViewModelTest.FakeSettingsRepo — covers every
+ * abstract method on [SettingsRepositoryUi] with a no-op. The
+ * interface has a number of default-impl members we don't need to
+ * override (markMilestoneDialogSeen, setInboxNotifyRoyalRoad, etc.).
+ */
+private class FakeSettings : SettingsRepositoryUi {
+    override val settings: Flow<UiSettings> = flowOf(
+        UiSettings(
+            ttsEngine = "VoxSherpa",
+            defaultVoiceId = null,
+            defaultSpeed = 1f,
+            defaultPitch = 1f,
+            themeOverride = ThemeOverride.System,
+            downloadOnWifiOnly = false,
+            pollIntervalHours = 0,
+            isSignedIn = false,
+        ),
+    )
+    override val outlineHost: Flow<String> = flowOf("")
+    override val rssSubscriptions: Flow<List<String>> = flowOf(emptyList())
+    override val epubFolderUri: Flow<String?> = flowOf(null)
+    override val suggestedRssFeeds: Flow<List<`in`.jphe.storyvox.feature.api.SuggestedFeed>> =
+        flowOf(emptyList())
+    override suspend fun setTheme(override: ThemeOverride) = Unit
+    override suspend fun setDefaultSpeed(speed: Float) = Unit
+    override suspend fun setDefaultPitch(pitch: Float) = Unit
+    override suspend fun setDefaultVoice(voiceId: String?) = Unit
+    override suspend fun setDownloadOnWifiOnly(enabled: Boolean) = Unit
+    override suspend fun setPollIntervalHours(hours: Int) = Unit
+    override suspend fun setPunctuationPauseMultiplier(multiplier: Float) = Unit
+    override suspend fun setPitchInterpolationHighQuality(enabled: Boolean) = Unit
+    override suspend fun setVoiceLexicon(voiceId: String, path: String?) = Unit
+    override suspend fun setVoicePhonemizerLang(voiceId: String, langCode: String?) = Unit
+    override suspend fun setPlaybackBufferChunks(chunks: Int) = Unit
+    override suspend fun setWarmupWait(enabled: Boolean) = Unit
+    override suspend fun setCatchupPause(enabled: Boolean) = Unit
+    override suspend fun setVoiceSteady(enabled: Boolean) = Unit
+    override suspend fun signIn() = Unit
+    override suspend fun signOut() = Unit
+    override suspend fun setPalaceHost(host: String) = Unit
+    override suspend fun setPalaceApiKey(apiKey: String) = Unit
+    override suspend fun clearPalaceConfig() = Unit
+    override suspend fun testPalaceConnection(): PalaceProbeResult = PalaceProbeResult.NotConfigured
+    override suspend fun setAiProvider(provider: UiLlmProvider?) = Unit
+    override suspend fun setClaudeApiKey(key: String?) = Unit
+    override suspend fun setClaudeModel(model: String) = Unit
+    override suspend fun setOpenAiApiKey(key: String?) = Unit
+    override suspend fun setOpenAiModel(model: String) = Unit
+    override suspend fun setOllamaBaseUrl(url: String) = Unit
+    override suspend fun setOllamaModel(model: String) = Unit
+    override suspend fun setVertexApiKey(key: String?) = Unit
+    override suspend fun setVertexModel(model: String) = Unit
+    override suspend fun setVertexServiceAccountJson(json: String?) = Unit
+    override suspend fun setFoundryApiKey(key: String?) = Unit
+    override suspend fun setFoundryEndpoint(url: String) = Unit
+    override suspend fun setFoundryDeployment(deployment: String) = Unit
+    override suspend fun setFoundryServerless(serverless: Boolean) = Unit
+    override suspend fun setBedrockAccessKey(key: String?) = Unit
+    override suspend fun setBedrockSecretKey(key: String?) = Unit
+    override suspend fun setBedrockRegion(region: String) = Unit
+    override suspend fun setBedrockModel(model: String) = Unit
+    override suspend fun setSendChapterTextEnabled(enabled: Boolean) = Unit
+    override suspend fun setChatGroundChapterTitle(enabled: Boolean) = Unit
+    override suspend fun setChatGroundCurrentSentence(enabled: Boolean) = Unit
+    override suspend fun setChatGroundEntireChapter(enabled: Boolean) = Unit
+    override suspend fun setChatGroundEntireBookSoFar(enabled: Boolean) = Unit
+    override suspend fun setCarryMemoryAcrossFictions(enabled: Boolean) = Unit
+    override suspend fun setAiActionsEnabled(enabled: Boolean) = Unit
+    override suspend fun acknowledgeAiPrivacy() = Unit
+    override suspend fun signOutTeams() = Unit
+    override suspend fun resetAiSettings() = Unit
+    override suspend fun signOutGitHub() = Unit
+    override suspend fun setGitHubPrivateReposEnabled(enabled: Boolean) = Unit
+    override suspend fun setSourcePluginEnabled(id: String, enabled: Boolean) = Unit
+    override suspend fun setOutlineHost(host: String) = Unit
+    override suspend fun setOutlineApiKey(apiKey: String) = Unit
+    override suspend fun clearOutlineConfig() = Unit
+    override suspend fun setWikipediaLanguageCode(code: String) = Unit
+    override suspend fun setNotionDatabaseId(id: String) = Unit
+    override suspend fun setNotionApiToken(token: String?) = Unit
+    override suspend fun setDiscordApiToken(token: String?) = Unit
+    override suspend fun setDiscordServer(serverId: String, serverName: String) = Unit
+    override suspend fun setDiscordCoalesceMinutes(minutes: Int) = Unit
+    override suspend fun fetchDiscordGuilds(): List<Pair<String, String>> = emptyList()
+    override suspend fun addRssFeed(url: String) = Unit
+    override suspend fun removeRssFeed(fictionId: String) = Unit
+    override suspend fun removeRssFeedByUrl(url: String) = Unit
+    override suspend fun setEpubFolderUri(uri: String) = Unit
+    override suspend fun clearEpubFolder() = Unit
+    override suspend fun setSleepShakeToExtendEnabled(enabled: Boolean) = Unit
+    override suspend fun setAzureKey(key: String?) = Unit
+    override suspend fun setAzureRegion(regionId: String) = Unit
+    override suspend fun clearAzureCredentials() = Unit
+    override suspend fun setParallelSynthInstances(count: Int) = Unit
+    override suspend fun setSynthThreadsPerInstance(count: Int) = Unit
+    override suspend fun setAzureFallbackEnabled(enabled: Boolean) = Unit
+    override suspend fun setAzureFallbackVoiceId(voiceId: String?) = Unit
+    override suspend fun testAzureConnection(): AzureProbeResult = AzureProbeResult.NotConfigured
+}

--- a/feature/src/test/kotlin/in/jphe/storyvox/feature/settings/SettingsViewModelBufferTest.kt
+++ b/feature/src/test/kotlin/in/jphe/storyvox/feature/settings/SettingsViewModelBufferTest.kt
@@ -179,6 +179,7 @@ class SettingsViewModelBufferTest {
         override suspend fun setChatGroundEntireChapter(enabled: Boolean) = Unit
         override suspend fun setChatGroundEntireBookSoFar(enabled: Boolean) = Unit
         override suspend fun setCarryMemoryAcrossFictions(enabled: Boolean) = Unit
+        override suspend fun setAiActionsEnabled(enabled: Boolean) = Unit
         override suspend fun acknowledgeAiPrivacy() = Unit
         override suspend fun resetAiSettings() = Unit
         override suspend fun signOutGitHub() = Unit

--- a/feature/src/test/kotlin/in/jphe/storyvox/feature/settings/SettingsViewModelModesTest.kt
+++ b/feature/src/test/kotlin/in/jphe/storyvox/feature/settings/SettingsViewModelModesTest.kt
@@ -254,6 +254,7 @@ class SettingsViewModelModesTest {
         override suspend fun setChatGroundEntireChapter(enabled: Boolean) = Unit
         override suspend fun setChatGroundEntireBookSoFar(enabled: Boolean) = Unit
         override suspend fun setCarryMemoryAcrossFictions(enabled: Boolean) = Unit
+        override suspend fun setAiActionsEnabled(enabled: Boolean) = Unit
         override suspend fun acknowledgeAiPrivacy() = Unit
         override suspend fun resetAiSettings() = Unit
         override suspend fun signOutGitHub() = Unit

--- a/feature/src/test/kotlin/in/jphe/storyvox/feature/settings/SettingsViewModelPunctuationPauseTest.kt
+++ b/feature/src/test/kotlin/in/jphe/storyvox/feature/settings/SettingsViewModelPunctuationPauseTest.kt
@@ -192,6 +192,7 @@ class SettingsViewModelPunctuationPauseTest {
         override suspend fun setChatGroundEntireChapter(enabled: Boolean) = Unit
         override suspend fun setChatGroundEntireBookSoFar(enabled: Boolean) = Unit
         override suspend fun setCarryMemoryAcrossFictions(enabled: Boolean) = Unit
+        override suspend fun setAiActionsEnabled(enabled: Boolean) = Unit
         override suspend fun acknowledgeAiPrivacy() = Unit
         override suspend fun resetAiSettings() = Unit
         override suspend fun signOutGitHub() = Unit


### PR DESCRIPTION
## Summary

- AI chat can invoke five storyvox actions directly: `add_to_shelf`, `queue_chapter`, `mark_chapter_read`, `set_speed`, `open_voice_library`. Each tool has a hand-rolled JSON schema, a typed handler wired to the matching repo, and renders a brass-edged tool-call card in the chat timeline.
- Tool support ships on Anthropic (Claude direct + Teams) and OpenAI; other providers transparently fall through to plain-text streaming via the default `LlmProvider.chatWithTools` impl that silently drops the catalog.
- New Settings → AI toggle "Allow the AI to take actions" (default ON for fresh installs) gates whether the catalog is passed to the provider at all.

## Architecture

`:core-llm` gains a `tools/` package with `ToolSpec`, `ToolHandler`, `ToolRegistry`, `ToolCallRequest`/`Result`, `ChatStreamEvent`, and the canonical `StoryvoxToolSpecs` catalog. Providers that implement function calling override `supportsTools = true` + the new `chatWithTools(...)` flow, which runs the model→tool_call→tool_result→model loop (bounded to 5 rounds against pathological tool-spam) and emits typed events.

`:feature/chat` gets `ChatToolHandlers` — the per-turn binding from spec name → handler suspend function, capturing the active fiction id so the model populates `fictionId` arguments without asking. The chat ViewModel routes to the tool-aware path when `cfg.aiActionsEnabled && llmRepo.supportsTools(provider) && shelfRepo != null && chapterRepo != null`; otherwise falls back to the pre-#216 plain-text path.

## Test plan

- [x] `./gradlew :app:assembleDebug :app:testDebugUnitTest :feature:testDebugUnitTest :core-llm:testDebugUnitTest` — green locally.
- [x] 18 new unit tests covering catalog contract (5 tools, valid JSON schemas, enum constraints), Anthropic + OpenAI wire request shapes, tool-result round-trip via MockWebServer, handler clamp/reject/success paths, navigation callback firing, registry completeness, unsupported-provider fallback.
- [x] APK installed and foregrounded on R83W80CAFZB.
- [ ] Manual: "Add this book to my Reading shelf" with Anthropic provider — verify brass card appears, book lands on Reading shelf, AI acknowledges in follow-up text.
- [ ] Manual: "Slow it down to 1.2x" during playback — verify speed slider moves to 1.2.

🤖 Generated with [Claude Code](https://claude.com/claude-code)