### PR TITLE
feat(tts): KittenTTS as third in-process voice family — closes #119

### DIFF
--- a/core-playback/build.gradle.kts
+++ b/core-playback/build.gradle.kts
@@ -99,7 +99,14 @@ dependencies {
     // Settings requires the next voice load — Storyvox forces this
     // by calling VoiceEngineQualityBridge.applyLexicon/applyLang
     // BEFORE the engine instantiates for the new voice on switch.
-    implementation("com.github.techempower-org:VoxSherpa-TTS:v2.7.14")
+    // v2.8.0 (storyvox #119) adds KittenEngine — third in-process
+    // voice family wrapping sherpa-onnx's OfflineTtsKittenModelConfig
+    // path. Smallest tier: ~25 MB fp16 nano model, 8 voices, 24 kHz,
+    // Apache-2.0. Structural twin of KokoroEngine (multi-speaker
+    // shared model + speaker index, public no-arg ctor for Tier 3
+    // parallelism, XNNPACK→CPU fallback). Storyvox dispatches via
+    // EngineType.Kitten in this PR.
+    implementation("com.github.techempower-org:VoxSherpa-TTS:v2.8.0")
     implementation("com.github.k2-fsa:sherpa-onnx:1.12.26")
 
     // Media3 — session, player base classes

--- a/core-playback/src/main/kotlin/in/jphe/storyvox/playback/tts/EnginePlayer.kt
+++ b/core-playback/src/main/kotlin/in/jphe/storyvox/playback/tts/EnginePlayer.kt
@@ -14,6 +14,7 @@ import androidx.media3.common.PlaybackParameters
 import androidx.media3.common.Player
 import androidx.media3.common.SimpleBasePlayer
 import androidx.media3.common.util.UnstableApi
+import com.CodeBySonu.VoxSherpa.KittenEngine
 import com.CodeBySonu.VoxSherpa.KokoroEngine
 import com.CodeBySonu.VoxSherpa.VoiceEngine
 import com.google.common.collect.ImmutableList
@@ -206,6 +207,15 @@ class EnginePlayer @AssistedInject constructor(
 
     @Volatile
     private var secondaryKokoroEngines: List<com.CodeBySonu.VoxSherpa.KokoroEngine> = emptyList()
+
+    /** Issue #119 — Kitten secondaries for the Tier 3 parallel-synth
+     *  slider. Each loaded Kitten session is small (~60–80 MB resident
+     *  on the fp16 nano model), so an 8-way fan-out fits comfortably
+     *  even on a 2 GB device — Kitten is the friendliest engine for the
+     *  parallel slider on low-end hardware. Owned per-engine-type like
+     *  the other two; voice swap away from Kitten frees this list. */
+    @Volatile
+    private var secondaryKittenEngines: List<com.CodeBySonu.VoxSherpa.KittenEngine> = emptyList()
 
     /**
      * Issue #98 — Mode B (Catch-up Pause) live cache. Gates the consumer
@@ -803,15 +813,20 @@ class EnginePlayer @AssistedInject constructor(
             engineMutex.withLock {
                 when (active.engineType) {
                     EngineType.Piper -> {
-                        // Voice swap AWAY from Kokoro → free its
-                        // secondaries. Tier 3 (#88) honors the slider
-                        // for both engine families now; secondaries
-                        // are owned per-engine-type and torn down on
-                        // type-change.
+                        // Voice swap AWAY from Kokoro/Kitten → free
+                        // their secondaries. Tier 3 (#88) honors the
+                        // slider for all in-process engine families
+                        // now; secondaries are owned per-engine-type
+                        // and torn down on type-change.
                         secondaryKokoroEngines.forEach {
                             runCatching { it.destroy() }
                         }
                         secondaryKokoroEngines = emptyList()
+                        // Issue #119 — Kitten secondaries.
+                        secondaryKittenEngines.forEach {
+                            runCatching { it.destroy() }
+                        }
+                        secondaryKittenEngines = emptyList()
 
                         val voiceDir = voiceManager.voiceDirFor(active.id)
                         val onnx = File(voiceDir, "model.onnx").absolutePath
@@ -888,13 +903,18 @@ class EnginePlayer @AssistedInject constructor(
                         primaryResult ?: "Error: load returned null"
                     }
                     is EngineType.Kokoro -> {
-                        // Voice swap AWAY from Piper → free its
+                        // Voice swap AWAY from Piper/Kitten → free their
                         // secondaries. Tier 3 secondaries are
                         // engine-type-specific.
                         secondaryPiperEngines.forEach {
                             runCatching { it.destroy() }
                         }
                         secondaryPiperEngines = emptyList()
+                        // Issue #119 — Kitten secondaries.
+                        secondaryKittenEngines.forEach {
+                            runCatching { it.destroy() }
+                        }
+                        secondaryKittenEngines = emptyList()
                         // All 53 Kokoro speakers share a single ~325MB fp32
                         // multi-speaker model. Switching speakers reuses the
                         // loaded engine; first load takes 30+s as sherpa-onnx
@@ -959,14 +979,72 @@ class EnginePlayer @AssistedInject constructor(
                         secondaryKokoroEngines = kokoroSecondaries
                         primaryResult ?: "Error: load returned null"
                     }
+                    is EngineType.Kitten -> {
+                        // Issue #119 — Kitten parallels Kokoro: all 8
+                        // Kitten speakers share a single ~25 MB fp16 ONNX
+                        // multi-speaker model. Switching speakers reuses
+                        // the loaded engine via setActiveSpeakerId; first
+                        // load is fast (~2–4 s) because the model is tiny.
+                        secondaryPiperEngines.forEach {
+                            runCatching { it.destroy() }
+                        }
+                        secondaryPiperEngines = emptyList()
+                        secondaryKokoroEngines.forEach {
+                            runCatching { it.destroy() }
+                        }
+                        secondaryKokoroEngines = emptyList()
+                        val sharedDir = voiceManager.kittenSharedDir()
+                        val onnx = File(sharedDir, "model.onnx").absolutePath
+                        val tokens = File(sharedDir, "tokens.txt").absolutePath
+                        val voicesBin = File(sharedDir, "voices.bin").absolutePath
+                        KittenEngine.getInstance().setActiveSpeakerId(
+                            (active.engineType as EngineType.Kitten).speakerId,
+                        )
+                        val parallelState = parallelSynthConfig.currentParallelSynthState()
+                        val nt = parallelState.threadsPerInstance
+                        val primaryResult = KittenEngine.getInstance()
+                            .loadModel(context, onnx, tokens, voicesBin, nt)
+                        // Tier 3 (#88) — Kitten N-instance support.
+                        // Each loaded Kitten session is small (~60–80 MB
+                        // resident on the fp16 nano model), so even an
+                        // 8-way fan-out fits in 1 GB. Kitten is the
+                        // friendliest engine for the parallel slider on
+                        // low-end hardware.
+                        secondaryKittenEngines.forEach { runCatching { it.destroy() } }
+                        secondaryKittenEngines = emptyList()
+                        val kittenSecondaries = mutableListOf<com.CodeBySonu.VoxSherpa.KittenEngine>()
+                        for (i in 1 until parallelState.instances) {
+                            val secondary = com.CodeBySonu.VoxSherpa.KittenEngine()
+                            secondary.setActiveSpeakerId(
+                                (active.engineType as EngineType.Kitten).speakerId,
+                            )
+                            val r = secondary.loadModel(context, onnx, tokens, voicesBin, nt)
+                            if (r == "Success") {
+                                kittenSecondaries += secondary
+                            } else {
+                                runCatching { secondary.destroy() }
+                                android.util.Log.w(
+                                    "EnginePlayer",
+                                    "Tier 3 secondary $i (Kitten) load failed: " +
+                                        "$r — capping at ${kittenSecondaries.size + 1} instances.",
+                                )
+                                break
+                            }
+                        }
+                        secondaryKittenEngines = kittenSecondaries
+                        primaryResult ?: "Error: load returned null"
+                    }
                     is EngineType.Azure -> {
                         // Tier 3 (#88) — voice swap AWAY from local
-                        // engines: free both Piper + Kokoro secondaries
-                        // to recover memory.
+                        // engines: free all local secondaries (Piper,
+                        // Kokoro, Kitten) to recover memory.
                         secondaryPiperEngines.forEach { runCatching { it.destroy() } }
                         secondaryPiperEngines = emptyList()
                         secondaryKokoroEngines.forEach { runCatching { it.destroy() } }
                         secondaryKokoroEngines = emptyList()
+                        // Issue #119 — Kitten secondaries.
+                        secondaryKittenEngines.forEach { runCatching { it.destroy() } }
+                        secondaryKittenEngines = emptyList()
                         // PR-4 (#183) — cloud voice activation. Nothing
                         // to load JNI-side; the "model" is the remote
                         // synthesis endpoint. Credentials gate is the
@@ -1048,6 +1126,9 @@ class EnginePlayer @AssistedInject constructor(
         val engineType = activeEngineType
         val sampleRate = when (engineType) {
             is EngineType.Kokoro -> KokoroEngine.getInstance().sampleRate
+            // Issue #119 — Kitten native sample rate is 24 kHz (same as
+            // Kokoro) but the runtime accessor is the source of truth.
+            is EngineType.Kitten -> KittenEngine.getInstance().sampleRate
             is EngineType.Azure -> azureVoiceEngine.sampleRate
             else -> VoiceEngine.getInstance().sampleRate
         }.takeIf { it > 0 } ?: DEFAULT_SAMPLE_RATE
@@ -1099,6 +1180,24 @@ class EnginePlayer @AssistedInject constructor(
                 }
             }
             is EngineType.Kokoro -> secondaryKokoroEngines.map { eng ->
+                object : EngineStreamingSource.VoiceEngineHandle {
+                    override val sampleRate: Int =
+                        eng.sampleRate.takeIf { it > 0 } ?: DEFAULT_SAMPLE_RATE
+                    override fun generateAudioPCM(
+                        text: String, speed: Float, pitch: Float,
+                    ): ByteArray? {
+                        AndroidProcess.setThreadPriority(
+                            AndroidProcess.THREAD_PRIORITY_URGENT_AUDIO,
+                        )
+                        return eng.generateAudioPCM(text, speed, pitch)
+                    }
+                }
+            }
+            // Issue #119 — Kitten secondaries. Same wrapping shape as
+            // Kokoro because both engines are multi-speaker singletons
+            // with the same `generateAudioPCM(text, speed, pitch)` Java
+            // signature.
+            is EngineType.Kitten -> secondaryKittenEngines.map { eng ->
                 object : EngineStreamingSource.VoiceEngineHandle {
                     override val sampleRate: Int =
                         eng.sampleRate.takeIf { it > 0 } ?: DEFAULT_SAMPLE_RATE
@@ -1407,6 +1506,8 @@ class EnginePlayer @AssistedInject constructor(
             else -> object : EngineStreamingSource.VoiceEngineHandle {
                 override val sampleRate: Int = when (engineType) {
                     is EngineType.Kokoro -> KokoroEngine.getInstance().sampleRate
+                    // Issue #119 — Kitten dispatch.
+                    is EngineType.Kitten -> KittenEngine.getInstance().sampleRate
                     else -> VoiceEngine.getInstance().sampleRate
                 }.takeIf { it > 0 } ?: DEFAULT_SAMPLE_RATE
 
@@ -1414,6 +1515,9 @@ class EnginePlayer @AssistedInject constructor(
                     AndroidProcess.setThreadPriority(AndroidProcess.THREAD_PRIORITY_URGENT_AUDIO)
                     return when (engineType) {
                         is EngineType.Kokoro -> KokoroEngine.getInstance()
+                            .generateAudioPCM(text, speed, pitch)
+                        // Issue #119 — Kitten dispatch.
+                        is EngineType.Kitten -> KittenEngine.getInstance()
                             .generateAudioPCM(text, speed, pitch)
                         else -> VoiceEngine.getInstance()
                             .generateAudioPCM(text, speed, pitch)
@@ -2106,6 +2210,23 @@ class EnginePlayer @AssistedInject constructor(
                         KokoroEngine.getInstance().loadModel(context, onnx, tokens, voicesBin)
                             ?: "Error: load returned null"
                     }
+                    is EngineType.Kitten -> {
+                        // Issue #119 — Kitten recap path. Tier 3
+                        // secondaries are NOT spun up here (recap is a
+                        // one-off short read; the primary engine is
+                        // sufficient). KittenEngine doesn't expose a
+                        // silence-scale knob — it produces cleaner
+                        // punctuation cadence at baseline than Kokoro.
+                        val sharedDir = voiceManager.kittenSharedDir()
+                        val onnx = File(sharedDir, "model.onnx").absolutePath
+                        val tokens = File(sharedDir, "tokens.txt").absolutePath
+                        val voicesBin = File(sharedDir, "voices.bin").absolutePath
+                        KittenEngine.getInstance().setActiveSpeakerId(
+                            (active.engineType as EngineType.Kitten).speakerId,
+                        )
+                        KittenEngine.getInstance().loadModel(context, onnx, tokens, voicesBin)
+                            ?: "Error: load returned null"
+                    }
                     is EngineType.Azure -> return@withContext "Error: Azure unsupported in recap"
                 }
             }
@@ -2128,6 +2249,8 @@ class EnginePlayer @AssistedInject constructor(
         val engineType = activeEngineType
         val sampleRate = when (engineType) {
             is EngineType.Kokoro -> KokoroEngine.getInstance().sampleRate
+            // Issue #119 — Kitten recap sample rate.
+            is EngineType.Kitten -> KittenEngine.getInstance().sampleRate
             else -> VoiceEngine.getInstance().sampleRate
         }.takeIf { it > 0 } ?: DEFAULT_SAMPLE_RATE
         val track = createAudioTrack(sampleRate)

--- a/core-playback/src/main/kotlin/in/jphe/storyvox/playback/voice/UiVoiceInfo.kt
+++ b/core-playback/src/main/kotlin/in/jphe/storyvox/playback/voice/UiVoiceInfo.kt
@@ -68,6 +68,25 @@ sealed interface EngineType {
     data class Kokoro(val speakerId: Int) : EngineType
 
     /**
+     * KittenTTS speaker — shared Kitten model, picks a speaker by index.
+     *
+     * Issue #119 — third in-process voice family, slotted **below**
+     * Piper-low as storyvox's smallest tier. Wraps VoxSherpa-TTS's
+     * `KittenEngine` (v2.8.0+), which in turn wraps sherpa-onnx's
+     * `OfflineTtsKittenModelConfig` path.
+     *
+     * Architecturally a twin of [Kokoro]: a single shared model (~25 MB
+     * fp16 int8 ONNX + voices.bin + tokens.txt) supports 8 speakers
+     * selected at synth time by [speakerId]. Picking any Kitten voice
+     * triggers the shared-model download exactly once; subsequent picks
+     * just flip the active speaker index with no additional payload.
+     * The 25 MB footprint makes it the friendliest "try a neural voice"
+     * first-launch onboarding path — a step beneath the 14 MB Piper-low
+     * voices, but with multi-speaker variety.
+     */
+    data class Kitten(val speakerId: Int) : EngineType
+
+    /**
      * Azure Speech Services HD voice. Cloud-rendered TTS over HTTPS;
      * no local model. [voiceName] is the Azure voice id (e.g.
      * `en-US-AvaDragonHDLatestNeural`, `en-US-AndrewMultilingualNeural`).

--- a/core-playback/src/main/kotlin/in/jphe/storyvox/playback/voice/VoiceCatalog.kt
+++ b/core-playback/src/main/kotlin/in/jphe/storyvox/playback/voice/VoiceCatalog.kt
@@ -5,13 +5,13 @@ import `in`.jphe.storyvox.data.source.AzureVoiceTier
 
 object VoiceCatalog {
     /**
-     * The static catalog — Piper and Kokoro entries that ship in-app.
-     * Azure voices are NOT here anymore; they're populated at runtime
-     * from the live roster (see [azureEntriesFromRoster] and
+     * The static catalog — Piper, Kokoro, and Kitten entries that ship
+     * in-app. Azure voices are NOT here anymore; they're populated at
+     * runtime from the live roster (see [azureEntriesFromRoster] and
      * `AzureVoiceProvider`). Combine via [voicesWithAzure] when you
      * need a unified list.
      */
-    val voices: List<CatalogEntry> = piperEntries() + kokoroEntries()
+    val voices: List<CatalogEntry> = piperEntries() + kokoroEntries() + kittenEntries()
 
     /**
      * Combine the static catalog with the live Azure roster — used by
@@ -736,6 +736,62 @@ object VoiceCatalog {
             kokoro("kokoro_yunxi_zh_CN_50", "Yunxi", "zh_CN", 50, M),
             kokoro("kokoro_yunxia_zh_CN_51", "Yunxia", "zh_CN", 51, M),
             kokoro("kokoro_yunyang_zh_CN_52", "Yunyang", "zh_CN", 52, M),
+        )
+    }
+
+    /** KittenTTS entries — 8 speakers all sharing one ~25 MB fp16 model.
+     *  Issue #119 — the smallest in-process tier, slotted below Piper-low
+     *  as the friendliest "try a neural voice" first-launch onboarding
+     *  path for slow devices (Raspberry Pi, old phones, wearables).
+     *
+     *  Shape mirrors Kokoro's: one shared model on disk (`_kitten_shared`
+     *  dir handled by VoiceManager), 8 speaker indices baked into the
+     *  voice ID. Picking any Kitten voice triggers the shared-model
+     *  download exactly once; subsequent picks just flip the active
+     *  speaker. The `kitten-nano-en-v0_1-fp16` upstream model ships 4
+     *  female + 4 male English voices labelled `expr-voice-2-f`,
+     *  `expr-voice-2-m`, etc. Display names are simplified (F1..F4 /
+     *  M1..M4) so the picker row stays readable.
+     *
+     *  Tier is [QualityLevel.Low] because Kitten produces audibly
+     *  more-compressed audio than Piper-medium and notably less prosody
+     *  variety than Kokoro (it's optimized for size, not quality). The
+     *  Low tier sits naturally below Piper's existing Low entries; the
+     *  picker's group-by-engine ordering will surface Kitten beneath
+     *  Piper / above Kokoro per the VoiceLibraryViewModel engine-sort
+     *  rule. */
+    private fun kittenEntries(): List<CatalogEntry> {
+        fun kitten(id: String, displayName: String, speakerId: Int, gender: VoiceGender): CatalogEntry =
+            CatalogEntry(
+                id = id,
+                displayName = displayName,
+                language = "en_US",
+                // sizeBytes mirrors Kokoro's 0L sentinel — Kitten voices
+                // share one ~25 MB download, so per-voice byte counts
+                // are misleading. The Voice Library suppresses the size
+                // chip when sizeBytes == 0L (same code path as Kokoro).
+                sizeBytes = 0L,
+                qualityLevel = QualityLevel.Low,
+                engineType = EngineType.Kitten(speakerId = speakerId),
+                piper = null,
+                gender = gender,
+            )
+        val F = VoiceGender.Female
+        val M = VoiceGender.Male
+        // Speaker order matches sherpa-onnx's voices.bin layout for
+        // `kitten-nano-en-v0_1-fp16`: 4 female embeddings (indices 0..3)
+        // followed by 4 male embeddings (indices 4..7). Names follow
+        // upstream's `expr-voice-N-{f,m}` convention but rendered as
+        // F1..F4 / M1..M4 for picker readability.
+        return listOf(
+            kitten("kitten_f1_en_US_0", "Kitten F1", 0, F),
+            kitten("kitten_f2_en_US_1", "Kitten F2", 1, F),
+            kitten("kitten_f3_en_US_2", "Kitten F3", 2, F),
+            kitten("kitten_f4_en_US_3", "Kitten F4", 3, F),
+            kitten("kitten_m1_en_US_4", "Kitten M1", 4, M),
+            kitten("kitten_m2_en_US_5", "Kitten M2", 5, M),
+            kitten("kitten_m3_en_US_6", "Kitten M3", 6, M),
+            kitten("kitten_m4_en_US_7", "Kitten M4", 7, M),
         )
     }
 

--- a/core-playback/src/main/kotlin/in/jphe/storyvox/playback/voice/VoiceLibraryCollapse.kt
+++ b/core-playback/src/main/kotlin/in/jphe/storyvox/playback/voice/VoiceLibraryCollapse.kt
@@ -69,7 +69,7 @@ data class EngineKey(val section: VoiceLibrarySection, val engine: VoiceEngineId
  *  so the collapse store can key on it without a feature dependency.
  *  Keep in lockstep with [VoiceEngine] in
  *  `feature/.../voicelibrary/VoiceLibraryViewModel.kt`. */
-enum class VoiceEngineId { Piper, Kokoro, Azure }
+enum class VoiceEngineId { Piper, Kokoro, Kitten, Azure }
 
 @Singleton
 class VoiceLibraryCollapse private constructor(

--- a/core-playback/src/main/kotlin/in/jphe/storyvox/playback/voice/VoiceManager.kt
+++ b/core-playback/src/main/kotlin/in/jphe/storyvox/playback/voice/VoiceManager.kt
@@ -176,10 +176,15 @@ class VoiceManager @Inject constructor(
         .combine(azureVoiceProvider.voices) { prefs, roster ->
             val installedIds = prefs[VoiceKeys.INSTALLED_IDS].orEmpty().map(::normalizeId).toSet()
             val kokoroReady = isKokoroSharedModelInstalled()
+            // Issue #119 — Kitten parallels Kokoro: shared-model presence
+            // is the single source of truth for "every Kitten voice is
+            // playable." Each speaker is just an index into voices.bin.
+            val kittenReady = isKittenSharedModelInstalled()
             VoiceCatalog.voicesWithAzure(roster)
                 .filter {
                     it.id in installedIds ||
                         (it.engineType is EngineType.Kokoro && kokoroReady) ||
+                        (it.engineType is EngineType.Kitten && kittenReady) ||
                         it.engineType is EngineType.Azure
                 }
                 .map { it.toUiVoiceInfo(installed = true) }
@@ -194,6 +199,7 @@ class VoiceManager @Inject constructor(
             val entry = VoiceCatalog.byIdWithAzure(activeId, roster) ?: return@combine null
             val isInstalled = activeId in installed ||
                 (entry.engineType is EngineType.Kokoro && isKokoroSharedModelInstalled()) ||
+                (entry.engineType is EngineType.Kitten && isKittenSharedModelInstalled()) ||
                 entry.engineType is EngineType.Azure
             entry.toUiVoiceInfo(installed = isInstalled)
         }
@@ -207,6 +213,16 @@ class VoiceManager @Inject constructor(
 
     private fun isKokoroSharedModelInstalled(): Boolean {
         val dir = kokoroSharedDir()
+        return File(dir, "model.onnx").exists() &&
+            File(dir, "voices.bin").exists() &&
+            File(dir, "tokens.txt").exists()
+    }
+
+    /** Issue #119 — Kitten parallels Kokoro: one ~25 MB shared model
+     *  underpins all 8 speakers, so "installed" for any Kitten voice
+     *  means "the shared dir is populated." Mirrors [isKokoroSharedModelInstalled]. */
+    private fun isKittenSharedModelInstalled(): Boolean {
+        val dir = kittenSharedDir()
         return File(dir, "model.onnx").exists() &&
             File(dir, "voices.bin").exists() &&
             File(dir, "tokens.txt").exists()
@@ -250,6 +266,70 @@ class VoiceManager @Inject constructor(
                 // flow.
                 error("Azure voices have no downloadable assets — " +
                     "credential-keyed activation arrives in PR-4. (#85)")
+            }
+            is EngineType.Kitten -> {
+                // Issue #119 — Kitten parallels Kokoro: one shared model
+                // (~25 MB total — fp16 ONNX + voices.bin + tokens.txt)
+                // underpins all 8 speakers, first install lands the model,
+                // subsequent voice picks just flip the active speaker index
+                // with no additional payload.
+                val sharedDir = kittenSharedDir()
+                val onnxFile = File(sharedDir, "model.onnx")
+                val tokensFile = File(sharedDir, "tokens.txt")
+                val voicesFile = File(sharedDir, "voices.bin")
+                if (!onnxFile.exists() || !voicesFile.exists() || !tokensFile.exists()) {
+                    sharedDir.mkdirs()
+                    try {
+                        // kitten-nano-en-v0_1-fp16 sizes (sherpa-onnx
+                        // tts-models release, repackaged onto the
+                        // jphein/VoxSherpa-TTS voices-v2 release for
+                        // flat per-file URLs the OkHttp loop can
+                        // stream — the upstream tar.bz2 would require
+                        // in-app extraction we don't want to add).
+                        // Total ~23 MB on first install, dominated by
+                        // the ONNX. voices.bin is tiny (8 KB — just
+                        // the per-speaker embedding table).
+                        val modelBytes = 23_848_586L
+                        val voicesBytes = 8_192L
+                        val totalBytes = modelBytes + voicesBytes  // tokens is ~1 KB, negligible
+                        downloadFile(
+                            url = "https://github.com/jphein/VoxSherpa-TTS/releases/download/voices-v2/kitten-nano-en-v0_1-model.onnx",
+                            target = onnxFile,
+                            knownTotalBytes = modelBytes,
+                        ) { read, _ -> emit(DownloadProgress.Downloading(read, totalBytes)) }
+                        downloadFile(
+                            url = "https://github.com/jphein/VoxSherpa-TTS/releases/download/voices-v2/kitten-nano-en-v0_1-voices.bin",
+                            target = voicesFile,
+                            knownTotalBytes = voicesBytes,
+                        ) { read, _ ->
+                            // Continue progress from where the model
+                            // left off so the bar keeps moving.
+                            emit(DownloadProgress.Downloading(modelBytes + read, totalBytes))
+                        }
+                        downloadFile(
+                            url = "https://github.com/jphein/VoxSherpa-TTS/releases/download/voices-v2/kitten-nano-en-v0_1-tokens.txt",
+                            target = tokensFile,
+                            knownTotalBytes = 0L,
+                        ) { _, _ -> }
+                    } catch (ce: CancellationException) {
+                        // User-driven cancel — re-throw to honour
+                        // structured concurrency. Mirrors the Kokoro
+                        // branch's shape: partial files survive (no
+                        // wipe on cancel) so a sibling that finished
+                        // before the cancel doesn't get re-fetched.
+                        throw ce
+                    } catch (t: Throwable) {
+                        // Real failure: wipe shared dir to keep retries
+                        // deterministic. Trade-off matches Kokoro's
+                        // branch; re-fetch cost on Kitten is tiny
+                        // (~24 MB) so the wipe is essentially free.
+                        sharedDir.deleteRecursively()
+                        emit(DownloadProgress.Failed(t.message ?: t::class.java.simpleName))
+                        return@flow
+                    }
+                }
+                markInstalled(voiceId)
+                emit(DownloadProgress.Done)
             }
             is EngineType.Kokoro -> {
                 // Kokoro speakers all share one ~168MB multi-speaker model
@@ -380,6 +460,12 @@ class VoiceManager @Inject constructor(
 
     /** Shared Kokoro multi-speaker model dir (one install per device, used by all 53 speakers). */
     fun kokoroSharedDir(): File = File(context.filesDir, "voices/_kokoro_shared")
+
+    /** Issue #119 — shared Kitten multi-speaker model dir (one install
+     *  per device, used by all 8 Kitten speakers). Public for the same
+     *  reason as [kokoroSharedDir] — playback paths need the absolute
+     *  paths to hand to `KittenEngine.loadModel`. */
+    fun kittenSharedDir(): File = File(context.filesDir, "voices/_kitten_shared")
 
     // ----- internals -----
 

--- a/core-playback/src/test/kotlin/in/jphe/storyvox/playback/voice/EngineTypeKittenDispatchTest.kt
+++ b/core-playback/src/test/kotlin/in/jphe/storyvox/playback/voice/EngineTypeKittenDispatchTest.kt
@@ -1,0 +1,111 @@
+package `in`.jphe.storyvox.playback.voice
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * Issue #119 — pinning the cross-engine dispatcher's discriminator
+ * layout so a Kitten regression can't silently fall through into the
+ * Piper branch (or vice versa).
+ *
+ * Background: `EnginePlayer.loadAndPlay` switches on `active.engineType`
+ * to pick the right loadModel call. The switch is non-exhaustive at the
+ * Kotlin compiler level only because `EngineType` is `sealed` — adding
+ * a fourth variant without updating the dispatcher would be a compile
+ * error in production code. But the *catalog* could still misclassify
+ * (e.g. a `kitten_*` ID accidentally typed as `EngineType.Piper`),
+ * which would route the load through `VoiceEngine.loadModel` and crash
+ * at runtime with a missing-onnx error.
+ *
+ * These tests exercise the catalog's classification so that mistake
+ * fails CI rather than a tablet.
+ */
+class EngineTypeKittenDispatchTest {
+
+    @Test
+    fun `every kitten_ catalog id is typed as EngineType Kitten`() {
+        // Naming convention is load-bearing — VoiceManager strips the
+        // historical `_int8` suffix before lookup but it never rewrites
+        // a `kitten_` prefix, so a misclassified entry would silently
+        // route through the wrong engine. Walk the catalog and confirm
+        // every id with the Kitten prefix is in fact EngineType.Kitten.
+        val mismatches = VoiceCatalog.voices
+            .filter { it.id.startsWith("kitten_") }
+            .filter { it.engineType !is EngineType.Kitten }
+        assertTrue(
+            "kitten_-prefixed entries must be EngineType.Kitten, " +
+                "but found mismatches: ${mismatches.map { it.id }}",
+            mismatches.isEmpty(),
+        )
+    }
+
+    @Test
+    fun `every EngineType Kitten catalog id starts with kitten_ prefix`() {
+        // The converse — if EngineType.Kitten is the source of truth,
+        // every voice that carries that type must also use the
+        // catalog's naming convention. Storyvox's analytics + crash
+        // breadcrumbs grep on the prefix, and the `featuredIds` list
+        // and gate UI key on the prefix indirectly. A future entry
+        // without the prefix would split-brain those paths.
+        val mismatches = VoiceCatalog.voices
+            .filter { it.engineType is EngineType.Kitten }
+            .filter { !it.id.startsWith("kitten_") }
+        assertTrue(
+            "EngineType.Kitten entries must start with `kitten_`, " +
+                "but found: ${mismatches.map { it.id }}",
+            mismatches.isEmpty(),
+        )
+    }
+
+    @Test
+    fun `Kitten entries do NOT carry a Piper payload`() {
+        // The CatalogEntry shape carries an Optional `piper: PiperPaths?`
+        // field used only for the Piper-per-voice-onnx download path.
+        // Kitten uses a shared model (resolved via VoiceManager's
+        // kittenSharedDir()), so the piper field must stay null on
+        // every Kitten entry — a non-null value would let the download
+        // path route through the wrong branch in a future refactor
+        // that accidentally collapses the `when (engineType)` dispatch.
+        VoiceCatalog.voices
+            .filter { it.engineType is EngineType.Kitten }
+            .forEach { entry ->
+                assertEquals(
+                    "Kitten entry ${entry.id} should have null piper paths",
+                    null, entry.piper,
+                )
+            }
+    }
+
+    @Test
+    fun `Piper Kokoro Kitten and Azure are all distinct EngineType subclasses`() {
+        // Sanity: the four engine families need to remain distinguishable
+        // by `is`-check. If a future refactor merges Kitten into Kokoro
+        // (e.g. as a shared `MultiSpeakerLocal` base), the dispatcher
+        // sites in EnginePlayer would need restructuring — pin the
+        // four-way distinction here so that refactor surfaces in CI.
+        val piper: EngineType = EngineType.Piper
+        val kokoro: EngineType = EngineType.Kokoro(speakerId = 0)
+        val kitten: EngineType = EngineType.Kitten(speakerId = 0)
+        val azure: EngineType = EngineType.Azure(voiceName = "test", region = "test")
+
+        // Piper is data object — same instance.
+        assertNotNull(piper)
+        assertTrue("Piper is EngineType.Piper", piper is EngineType.Piper)
+
+        // The three data classes are distinct types.
+        assertTrue("Kokoro is EngineType.Kokoro", kokoro is EngineType.Kokoro)
+        assertTrue("Kitten is EngineType.Kitten", kitten is EngineType.Kitten)
+        assertTrue("Azure is EngineType.Azure", azure is EngineType.Azure)
+
+        // Cross-checks: a Kitten instance is NOT a Kokoro instance,
+        // even though both wrap a speakerId int. This is the property
+        // that makes EnginePlayer's `is EngineType.Kitten ->` branch
+        // safe to add alongside `is EngineType.Kokoro ->`.
+        @Suppress("USELESS_IS_CHECK")
+        assertTrue("Kitten is not Kokoro", kitten !is EngineType.Kokoro)
+        @Suppress("USELESS_IS_CHECK")
+        assertTrue("Kokoro is not Kitten", kokoro !is EngineType.Kitten)
+    }
+}

--- a/core-playback/src/test/kotlin/in/jphe/storyvox/playback/voice/KittenCatalogTest.kt
+++ b/core-playback/src/test/kotlin/in/jphe/storyvox/playback/voice/KittenCatalogTest.kt
@@ -1,0 +1,134 @@
+package `in`.jphe.storyvox.playback.voice
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * Issue #119 — pinning the Kitten section of [VoiceCatalog] against
+ * regression. Three properties matter:
+ *
+ * 1. **Eight entries** — the upstream `kitten-nano-en-v0_1-fp16` model
+ *    ships exactly 8 speakers (4 female, 4 male). Adding a 9th by
+ *    mistake (or losing one) silently breaks the picker — Kitten is
+ *    the smallest tier so a missing voice is a hard-to-spot UX dent.
+ *
+ * 2. **Speaker IDs 0..7 contiguous** — `KittenEngine.setActiveSpeakerId`
+ *    treats the int as a direct index into voices.bin. A gap (e.g. 0,
+ *    1, 2, 5, 6) would produce a runtime IndexOutOfBoundsException
+ *    inside sherpa-onnx that the caller has no clean way to recover
+ *    from, so this guard is load-bearing.
+ *
+ * 3. **All Low tier + all en_US + sizeBytes = 0L** — Kitten's value
+ *    proposition is "smallest tier, on-device English voice for slow
+ *    hardware." The Voice Library composes its subtitle around these
+ *    fields; a future PR that adds a multilingual Kitten model needs to
+ *    relax this guard explicitly rather than passively.
+ *
+ * Pure-JVM (no Robolectric, no emulator). [VoiceCatalog] is a singleton
+ * object built from kotlin-only data, so we can interrogate it directly.
+ */
+class KittenCatalogTest {
+
+    private val kittenEntries: List<CatalogEntry>
+        get() = VoiceCatalog.voices.filter { it.engineType is EngineType.Kitten }
+
+    @Test
+    fun `Kitten catalog ships exactly eight speakers`() {
+        // sherpa-onnx's kitten-nano-en-v0_1-fp16 release exposes 8 voice
+        // embeddings in voices.bin (4 female + 4 male). If upstream adds
+        // a 9th OR the catalog accidentally drops one, the picker no
+        // longer reflects the model — this guard catches both.
+        assertEquals(8, kittenEntries.size)
+    }
+
+    @Test
+    fun `Kitten speaker ids cover 0 through 7 contiguously`() {
+        // KittenEngine.setActiveSpeakerId hands the int straight to
+        // sherpa-onnx as a voices.bin row index. A gap or duplicate
+        // would produce a runtime crash on voice activation; pinning
+        // the contiguous 0..7 invariant here means catalog edits fail
+        // CI rather than the picker.
+        val speakerIds = kittenEntries
+            .map { (it.engineType as EngineType.Kitten).speakerId }
+            .toSet()
+        assertEquals((0..7).toSet(), speakerIds)
+    }
+
+    @Test
+    fun `every Kitten entry is en_US Low tier with zero sizeBytes`() {
+        // The Kitten section in v0.5.34 is English-only at Low tier
+        // (the nano fp16 model). sizeBytes = 0L is the shared-model
+        // sentinel that VoiceLibraryScreen reads as "suppress the size
+        // chip" (Kokoro uses the same pattern — per-voice byte counts
+        // are misleading when one model serves N speakers).
+        //
+        // If a future PR adds a kitten-mini variant or a multilingual
+        // pack, this guard must be relaxed deliberately — not silently
+        // edge-cased — so the picker keeps composing subtitles
+        // consistently.
+        kittenEntries.forEach { entry ->
+            assertEquals(
+                "Kitten entry ${entry.id} should be Low tier",
+                QualityLevel.Low, entry.qualityLevel,
+            )
+            assertEquals(
+                "Kitten entry ${entry.id} should be en_US",
+                "en_US", entry.language,
+            )
+            assertEquals(
+                "Kitten entry ${entry.id} should have sizeBytes = 0L (shared model)",
+                0L, entry.sizeBytes,
+            )
+        }
+    }
+
+    @Test
+    fun `Kitten entries split four female four male`() {
+        // The expressivity of the engine comes from the speaker
+        // variety — four of each gender matches upstream's
+        // expr-voice-N-{f,m} layout. The Voice Library's gender filter
+        // chips would shrink to "Female (0)" on a regression that
+        // dropped a row.
+        val females = kittenEntries.count { it.gender == VoiceGender.Female }
+        val males = kittenEntries.count { it.gender == VoiceGender.Male }
+        assertEquals("four female Kitten speakers", 4, females)
+        assertEquals("four male Kitten speakers", 4, males)
+    }
+
+    @Test
+    fun `Kitten ids resolve via byId without an Azure roster`() {
+        // VoiceCatalog.byId is the pre-PR-4 lookup that the playback
+        // path uses to resolve an active voice ID before any Azure
+        // roster is fetched. Kitten entries are local, so byId must
+        // surface them directly. (byIdWithAzure includes them too —
+        // but that's covered by the byId fallback in the production
+        // VoiceManager paths.)
+        val entry = VoiceCatalog.byId("kitten_f1_en_US_0")
+        assertNotNull("byId should find kitten_f1_en_US_0", entry)
+        assertTrue(
+            "engineType should be Kitten",
+            entry!!.engineType is EngineType.Kitten,
+        )
+        assertEquals(0, (entry.engineType as EngineType.Kitten).speakerId)
+    }
+
+    @Test
+    fun `EngineType Kitten equality is structural over speakerId`() {
+        // Mirrors AzureCatalogTest's structural-equality guard.
+        // EngineType.Kitten is a data class, so this is testing the
+        // data-class contract — but pinning it here makes the contract
+        // load-bearing: VoiceManager's installed-set filter compares
+        // by `is EngineType.Kitten`, not by id, so structural equality
+        // is what makes "all 8 speakers visible once shared model
+        // installed" work.
+        val a = EngineType.Kitten(speakerId = 3)
+        val b = EngineType.Kitten(speakerId = 3)
+        val c = EngineType.Kitten(speakerId = 4)
+        assertEquals("same speakerId equal", a, b)
+        assertEquals("same hashCode", a.hashCode(), b.hashCode())
+        assertFalse("different speakerId not equal", a == c)
+    }
+}

--- a/core-playback/src/test/kotlin/in/jphe/storyvox/playback/voice/VoiceManagerTest.kt
+++ b/core-playback/src/test/kotlin/in/jphe/storyvox/playback/voice/VoiceManagerTest.kt
@@ -218,6 +218,76 @@ class VoiceManagerTest {
             progress.last() is VoiceManager.DownloadProgress.Failed)
     }
 
+    /**
+     * Issue #119 — Kitten path mirrors Kokoro's shape (one shared model
+     * underpins all 8 speakers), and so must mirror Kokoro's #28 partial-
+     * cleanup policy: HTTP 500 on the first asset wipes the shared dir
+     * before Failed emits. Pre-seeding `voices.bin` simulates a partially-
+     * completed prior run; if the wipe is skipped that sibling silently
+     * survives the `if (!exists())` check on retry and we'd ship a
+     * half-state to the engine — same failure mode as Kokoro.
+     */
+    @Test
+    fun kitten_realFailure_wipesSharedDir() = runBlocking {
+        val vm = VoiceManager(context, EmptyAzureProvider)
+        vm.http = httpClientReturning500()
+
+        val sharedDir = vm.kittenSharedDir().also { it.mkdirs() }
+        val seeded = File(sharedDir, "voices.bin").apply { writeText("partial-from-prior-run") }
+        assertTrue("precondition: seeded sibling exists", seeded.exists())
+
+        val progress = vm.download("kitten_f1_en_US_0").toList()
+
+        val failed = progress.last()
+        assertTrue("expected Failed terminal, got $failed", failed is VoiceManager.DownloadProgress.Failed)
+
+        assertFalse(
+            "Kitten shared dir must be wiped on real failure (#28 policy carries over from Kokoro)",
+            sharedDir.exists(),
+        )
+    }
+
+    /**
+     * Issue #119 — Kitten download Resolving→…→Done shape with a happy-
+     * path 200. Mirrors Kokoro's shape test. With a 200 OkHttpClient
+     * returning a small body, all three asset fetches (model, voices,
+     * tokens) succeed, the markInstalled call lands, and the terminal
+     * Done emits. Catches regressions like a missing branch in the
+     * `when (engineType)` block silently falling through to a no-op.
+     */
+    @Test
+    fun kitten_happyPath_emitsResolvingDownloadingDone() = runBlocking {
+        val vm = VoiceManager(context, EmptyAzureProvider)
+        // 16 KiB body — small enough to keep the test fast, big enough
+        // that the OkHttp body iterator emits at least one Downloading
+        // tick before EOF.
+        vm.http = httpClientReturningBody(ByteArray(16 * 1024))
+
+        val progress = vm.download("kitten_f1_en_US_0").toList()
+
+        assertTrue(
+            "first emission must be Resolving, got ${progress.firstOrNull()}",
+            progress.first() is VoiceManager.DownloadProgress.Resolving,
+        )
+        assertTrue(
+            "must contain at least one Downloading frame",
+            progress.any { it is VoiceManager.DownloadProgress.Downloading },
+        )
+        assertTrue(
+            "last emission must be Done, got ${progress.lastOrNull()}",
+            progress.last() is VoiceManager.DownloadProgress.Done,
+        )
+
+        // Shared dir + the three asset files exist after Done — the
+        // engine load path will find them in place when EnginePlayer
+        // resolves `kittenSharedDir() / "model.onnx"` etc.
+        val sharedDir = vm.kittenSharedDir()
+        assertTrue("shared dir should exist", sharedDir.exists())
+        assertTrue("model.onnx should land", File(sharedDir, "model.onnx").exists())
+        assertTrue("voices.bin should land", File(sharedDir, "voices.bin").exists())
+        assertTrue("tokens.txt should land", File(sharedDir, "tokens.txt").exists())
+    }
+
     // ----- helpers -----
 
     /**

--- a/feature/src/main/kotlin/in/jphe/storyvox/feature/voicelibrary/VoiceFilter.kt
+++ b/feature/src/main/kotlin/in/jphe/storyvox/feature/voicelibrary/VoiceFilter.kt
@@ -72,6 +72,8 @@ internal fun UiVoiceInfo.matchesQuery(query: String): Boolean {
     val engineLabel = when (engineType) {
         is EngineType.Piper -> "piper"
         is EngineType.Kokoro -> "kokoro"
+        // Issue #119 — Kitten search label.
+        is EngineType.Kitten -> "kitten"
         is EngineType.Azure -> "azure"
     }
     return engineLabel.contains(needle, ignoreCase = true)

--- a/feature/src/main/kotlin/in/jphe/storyvox/feature/voicelibrary/VoiceLibraryScreen.kt
+++ b/feature/src/main/kotlin/in/jphe/storyvox/feature/voicelibrary/VoiceLibraryScreen.kt
@@ -611,6 +611,10 @@ private fun EngineSubHeader(
     val label = when (engine) {
         VoiceEngine.Piper -> "Piper"
         VoiceEngine.Kokoro -> "Kokoro"
+        // Issue #119 — third in-process voice family. "Lite" tag set
+        // off the engine name communicates the value proposition (this
+        // is the smallest tier) without making it sound like a beta.
+        VoiceEngine.Kitten -> "Kitten (Lite)"
         // Azure HD voices land in their own sub-header so the cloud
         // round-trip story is one glance away. Catalog labels carry a
         // ☁️ glyph, but the section header restates "Azure" plainly so
@@ -999,6 +1003,9 @@ internal fun voiceSubtitle(voice: UiVoiceInfo): String {
     val engineLabel = when (voice.engineType) {
         is EngineType.Piper -> "Piper"
         is EngineType.Kokoro -> "Kokoro"
+        // Issue #119 — third in-process voice family. Surfaces in the
+        // Voice Library subtitle as "Kitten · Low · Female" etc.
+        is EngineType.Kitten -> "Kitten"
         is EngineType.Azure -> "Azure"
     }
     val tierLabel = when (voice.qualityLevel) {

--- a/feature/src/main/kotlin/in/jphe/storyvox/feature/voicelibrary/VoiceLibraryViewModel.kt
+++ b/feature/src/main/kotlin/in/jphe/storyvox/feature/voicelibrary/VoiceLibraryViewModel.kt
@@ -450,23 +450,28 @@ private data class PerVoiceOverrides(
  *  (which lives in core so it can be Hilt-injected without dragging the
  *  feature module). The two enums are kept in lockstep — see
  *  [toCoreId]. */
-enum class VoiceEngine { Piper, Kokoro, Azure }
+enum class VoiceEngine { Piper, Kokoro, Kitten, Azure }
 
 internal fun VoiceEngine.toCoreId(): VoiceEngineId = when (this) {
     VoiceEngine.Piper -> VoiceEngineId.Piper
     VoiceEngine.Kokoro -> VoiceEngineId.Kokoro
+    // Issue #119 — Kitten section discriminator.
+    VoiceEngine.Kitten -> VoiceEngineId.Kitten
     VoiceEngine.Azure -> VoiceEngineId.Azure
 }
 
 internal fun VoiceEngineId.toFeatureEngine(): VoiceEngine = when (this) {
     VoiceEngineId.Piper -> VoiceEngine.Piper
     VoiceEngineId.Kokoro -> VoiceEngine.Kokoro
+    VoiceEngineId.Kitten -> VoiceEngine.Kitten
     VoiceEngineId.Azure -> VoiceEngine.Azure
 }
 
 private fun UiVoiceInfo.voiceEngine(): VoiceEngine = when (engineType) {
     is EngineType.Piper -> VoiceEngine.Piper
     is EngineType.Kokoro -> VoiceEngine.Kokoro
+    // Issue #119 — Kitten branch.
+    is EngineType.Kitten -> VoiceEngine.Kitten
     is EngineType.Azure -> VoiceEngine.Azure
 }
 
@@ -541,17 +546,35 @@ private val AZURE_TIER_ORDER: List<QualityLevel> = listOf(
     QualityLevel.Low,
 )
 
+/** Issue #119 — Tier order **within Kitten**. All Kitten voices ship at
+ *  [QualityLevel.Low] today (the fp16 nano model trades quality for
+ *  size). Listing the higher tiers anyway keeps the sort future-proof
+ *  against a possible Kitten-mini (80 MB, better quality) variant
+ *  landing in a follow-up. */
+private val KITTEN_TIER_ORDER: List<QualityLevel> = listOf(
+    QualityLevel.High,
+    QualityLevel.Medium,
+    QualityLevel.Low,
+)
+
 private fun tierOrderFor(engine: VoiceEngine): List<QualityLevel> = when (engine) {
     VoiceEngine.Piper -> PIPER_TIER_ORDER
     VoiceEngine.Kokoro -> KOKORO_TIER_ORDER
+    // Issue #119 — Kitten tier order.
+    VoiceEngine.Kitten -> KITTEN_TIER_ORDER
     VoiceEngine.Azure -> AZURE_TIER_ORDER
 }
 
-/** Engine display order — Piper section first, Kokoro second, Azure
- *  third. Drives outer iteration order of [groupByEngineThenTier]. */
+/** Engine display order — Piper section first, Kokoro second, Kitten
+ *  third (issue #119 — the smallest local tier sits BELOW Kokoro in the
+ *  list so users see the higher-quality local options first; Kitten
+ *  surfaces last among the local engines as a "lite alternative for slow
+ *  devices" section), Azure last. Drives outer iteration order of
+ *  [groupByEngineThenTier]. */
 private val ENGINE_DISPLAY_ORDER: List<VoiceEngine> = listOf(
     VoiceEngine.Piper,
     VoiceEngine.Kokoro,
+    VoiceEngine.Kitten,
     VoiceEngine.Azure,
 )
 


### PR DESCRIPTION
## Summary

- Adds **KittenTTS** as the third in-process voice family alongside Piper and Kokoro — smallest tier, ~25 MB int8 fp16 nano model, 8 voices, 24 kHz, Apache-2.0. Designed for slow devices where even Piper-low struggles.
- Mirrors Kokoro's shape: one shared model on disk (`_kitten_shared/`) underpins all 8 speaker indices; first install lands the ~25 MB, every subsequent Kitten pick just flips the active speaker.
- Voice Library gains a "Kitten (Lite)" section between Kokoro and Azure; subtitle reads "Kitten · Low · Female" etc.

## Companion change

VoxSherpa-TTS v2.8.0 ([techempower-org/VoxSherpa-TTS#2](https://github.com/techempower-org/VoxSherpa-TTS/pull/2), merged) adds the new `KittenEngine.java` wrapping sherpa-onnx's `OfflineTtsKittenModelConfig`. This PR bumps the JitPack coordinate to v2.8.0 and wires `EngineType.Kitten(speakerId)` end-to-end through the dispatcher.

## What's new

| File | Change |
|------|--------|
| `core-playback/build.gradle.kts` | JitPack `v2.7.14` → `v2.8.0` |
| `UiVoiceInfo.kt` | `EngineType.Kitten(speakerId)` added to the sealed interface |
| `VoiceCatalog.kt` | `kittenEntries()` — 8 voices (F1..F4, M1..M4), Low tier, en_US, sizeBytes=0L shared-model sentinel |
| `VoiceManager.kt` | `kittenSharedDir()` + `isKittenSharedModelInstalled()` + Kitten download branch (model.onnx + voices.bin + tokens.txt to shared dir) |
| `VoiceLibraryCollapse.kt` | `VoiceEngineId.Kitten` for the collapse store discriminator |
| `EnginePlayer.kt` | Kitten dispatch added at four sites: `loadAndPlay`, `ensureVoiceLoaded`, `startPlaybackPipeline` (sample rate + secondaryHandles), `activeVoiceEngineHandle`. Tier 3 parallel-synth via new `secondaryKittenEngines` field. |
| `VoiceLibraryViewModel.kt` | `VoiceEngine.Kitten` enum + `KITTEN_TIER_ORDER` + section between Kokoro and Azure in `ENGINE_DISPLAY_ORDER` |
| `VoiceLibraryScreen.kt` | "Kitten (Lite)" section header label |
| `VoiceFilter.kt` | "kitten" engine search label |

## Tests (10 new, all green)

- `KittenCatalogTest` (6) — pins 8 entries / contiguous speaker IDs 0..7 / Low tier en_US / 4F+4M split / byId resolution / structural equality.
- `EngineTypeKittenDispatchTest` (4) — every `kitten_` ID classifies as `EngineType.Kitten`, no Piper payload, four engine families distinguishable by `is`-check.
- `VoiceManagerTest` +2 — `kitten_realFailure_wipesSharedDir` and `kitten_happyPath_emitsResolvingDownloadingDone` pin the same #28 partial-cleanup policy Kokoro carries.

CI gauntlet from the spec: `./gradlew :app:assembleDebug :app:testDebugUnitTest :core-playback:testDebugUnitTest` — BUILD SUCCESSFUL.

## On-device verification (pending merge)

- [ ] Install on R83W80CAFZB
- [ ] Download a Kitten voice via Settings → Voice & Playback → Voice → Kitten (Lite)
- [ ] Pick as active voice
- [ ] Play a sample chapter — verify clean playback, no crash

## Release plan

- versionCode/versionName **not** bumped here — orchestrator bundles into v0.5.34 alongside other in-flight work.
- Closes #119.

🤖 Generated with [Claude Code](https://claude.com/claude-code)