### PR TITLE
perf(cold-launch): defer Hilt graph materialisation — partial fix for #409 (ongoing)

### DIFF
--- a/app/src/main/kotlin/in/jphe/storyvox/MainActivity.kt
+++ b/app/src/main/kotlin/in/jphe/storyvox/MainActivity.kt
@@ -13,11 +13,12 @@ import androidx.activity.result.contract.ActivityResultContracts
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.remember
 import androidx.compose.runtime.snapshotFlow
 import androidx.core.content.ContextCompat
 import androidx.navigation.compose.rememberNavController
 import androidx.compose.foundation.isSystemInDarkTheme
-import androidx.compose.runtime.getValue
+import dagger.Lazy
 import dagger.hilt.android.AndroidEntryPoint
 import `in`.jphe.storyvox.feature.api.SettingsRepositoryUi
 import `in`.jphe.storyvox.feature.api.ThemeOverride
@@ -26,7 +27,9 @@ import `in`.jphe.storyvox.navigation.DeepLinkResolver
 import `in`.jphe.storyvox.navigation.StoryvoxNavHost
 import javax.inject.Inject
 import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.emitAll
 import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.flow.flow
 
 @AndroidEntryPoint
 class MainActivity : ComponentActivity() {
@@ -46,8 +49,16 @@ class MainActivity : ComponentActivity() {
      * theme wrapper defaulted to `isSystemInDarkTheme()` and the saved
      * preference was purely cosmetic (showed checked in Settings, never
      * applied).
+     *
+     * Issue #409 — wrapped in [Lazy] so the 20-arg [SettingsRepositoryUi]
+     * graph isn't materialised inside `@AndroidEntryPoint` activity
+     * injection (which runs on the main thread during `super.onCreate`).
+     * We resolve it inside [setContent]'s lambda, which Compose already
+     * runs after the first measure pass and on a frame that's allowed
+     * to take its time. On the Helio P22T tablet that lift was a
+     * material chunk of cold-launch wall-clock.
      */
-    @Inject lateinit var settingsRepo: SettingsRepositoryUi
+    @Inject lateinit var settingsRepo: Lazy<SettingsRepositoryUi>
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
@@ -67,7 +78,16 @@ class MainActivity : ComponentActivity() {
             // force the corresponding palette regardless of device
             // setting. Without this, the Settings → Reading → Theme
             // picker was cosmetic-only.
-            val settings by settingsRepo.settings.collectAsState(initial = null)
+            //
+            // #409 — wrap the [Lazy] resolution in a flow so the actual
+            // graph construction happens once, lazily, off the
+            // composition-creation hot path. The initial `null` keeps
+            // first-frame rendering on the system-theme fallback while
+            // the real preference loads.
+            val settingsFlow = remember {
+                flow { emitAll(settingsRepo.get().settings) }
+            }
+            val settings by settingsFlow.collectAsState(initial = null)
             val systemDark = isSystemInDarkTheme()
             val darkTheme = when (settings?.themeOverride ?: ThemeOverride.System) {
                 ThemeOverride.System -> systemDark

--- a/app/src/main/kotlin/in/jphe/storyvox/StoryvoxApp.kt
+++ b/app/src/main/kotlin/in/jphe/storyvox/StoryvoxApp.kt
@@ -4,6 +4,7 @@ import android.app.Application
 import android.util.Log
 import androidx.hilt.work.HiltWorkerFactory
 import androidx.work.Configuration
+import dagger.Lazy
 import dagger.hilt.android.HiltAndroidApp
 import `in`.jphe.storyvox.BuildConfig
 import `in`.jphe.storyvox.data.auth.SessionHydrator
@@ -22,12 +23,36 @@ import kotlinx.coroutines.launch
 @HiltAndroidApp
 class StoryvoxApp : Application(), Configuration.Provider {
 
+    /**
+     * Issue #409 — cold launch on the Tab A7 Lite (Helio P22T) was 6.8s
+     * vs 1.2s on the Z Flip3 (SD888). Logcat traced ~3.3s of that to the
+     * synchronous `super.onCreate()` block below: `@Inject lateinit var`
+     * fields are materialized eagerly when Hilt's
+     * [HiltAndroidApp]-generated subclass calls `inject(this)` from
+     * `attachBaseContext` / `onCreate`, and on a low-end SoC, building a
+     * 6-field graph that transitively constructs ~25 [Singleton]s (esp.
+     * the 20-arg [SettingsRepositoryUiImpl] and the 16-syncer
+     * [SyncCoordinator] set-binding) before the first frame budget even
+     * starts is a meaningful percentage of the cold-launch wall-clock.
+     *
+     * Switching to `Lazy<T>` defers actual construction to the moment of
+     * `.get()`, which we punt to a background coroutine in [onCreate].
+     * The Hilt graph is still fully wired (still type-safe, still
+     * @Singleton-scoped); we just stop *materialising* it on the main
+     * thread before the splash screen disappears.
+     *
+     * Only [workerFactory] stays eager — Android's `WorkManager`
+     * initializer queries [Configuration.Provider.workManagerConfiguration]
+     * the first time `WorkManager.getInstance(context)` is called, and
+     * that getter reads [workerFactory]. We need it ready before any
+     * worker is enqueued.
+     */
     @Inject lateinit var workerFactory: HiltWorkerFactory
-    @Inject lateinit var workScheduler: WorkScheduler
-    @Inject lateinit var authRepository: AuthRepository
-    @Inject lateinit var sessionHydrator: SessionHydrator
-    @Inject lateinit var syncCoordinator: SyncCoordinator
-    @Inject lateinit var settingsRepo: SettingsRepositoryUi
+    @Inject lateinit var workScheduler: Lazy<WorkScheduler>
+    @Inject lateinit var authRepository: Lazy<AuthRepository>
+    @Inject lateinit var sessionHydrator: Lazy<SessionHydrator>
+    @Inject lateinit var syncCoordinator: Lazy<SyncCoordinator>
+    @Inject lateinit var settingsRepo: Lazy<SettingsRepositoryUi>
 
     override val workManagerConfiguration: Configuration
         get() = Configuration.Builder()
@@ -35,16 +60,36 @@ class StoryvoxApp : Application(), Configuration.Provider {
             .setMinimumLoggingLevel(if (BuildConfig.DEBUG) Log.DEBUG else Log.INFO)
             .build()
 
+    /**
+     * Long-lived scope for the deferred init coroutines. Survives the
+     * Application lifetime; uses a [SupervisorJob] so a failure in one
+     * init step doesn't poison the others.
+     */
+    private val initScope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
+
     override fun onCreate() {
         super.onCreate()
-        workScheduler.ensurePeriodicWorkScheduled()
+        // Issue #409 — every previous-eager step is now scheduled on
+        // [Dispatchers.IO] via the [Lazy] accessors. The main thread
+        // returns from onCreate as fast as the Hilt component-injection
+        // boilerplate allows, so the splash screen → first-frame budget
+        // is dominated by Compose work, not Application init.
+        initScope.launch {
+            // ensurePeriodicWorkScheduled hits SQLite via WorkManager's
+            // internal database; on the Helio P22T that's ~150-300ms of
+            // disk I/O. Off the main thread → invisible to cold launch.
+            workScheduler.get().ensurePeriodicWorkScheduled()
+        }
         rehydrateRoyalRoadCookies()
         applyPitchQualityFromSettings()
         applyPerVoiceEngineKnobsFromSettings()
         // InstantDB sync — if a refresh token is stored, validate it and
         // pull every per-domain syncer. No-op when no one is signed in.
-        // Fire-and-forget: the coordinator launches its own coroutines.
-        syncCoordinator.initialize()
+        // Fire-and-forget: the coordinator launches its own coroutines
+        // once [Lazy.get] materialises it on IO.
+        initScope.launch {
+            syncCoordinator.get().initialize()
+        }
     }
 
     /**
@@ -55,8 +100,8 @@ class StoryvoxApp : Application(), Configuration.Provider {
      * re-applied on cold start, before the first chapter renders.
      */
     private fun applyPitchQualityFromSettings() {
-        CoroutineScope(SupervisorJob() + Dispatchers.IO).launch {
-            val highQuality = settingsRepo.settings.first().pitchInterpolationHighQuality
+        initScope.launch {
+            val highQuality = settingsRepo.get().settings.first().pitchInterpolationHighQuality
             VoiceEngineQualityBridge.applyPitchQuality(highQuality)
         }
     }
@@ -76,8 +121,8 @@ class StoryvoxApp : Application(), Configuration.Provider {
      * completes.
      */
     private fun applyPerVoiceEngineKnobsFromSettings() {
-        CoroutineScope(SupervisorJob() + Dispatchers.IO).launch {
-            val settings = settingsRepo.settings.first()
+        initScope.launch {
+            val settings = settingsRepo.get().settings.first()
             VoiceEngineQualityBridge.applyLexicon(settings.effectiveLexicon)
             VoiceEngineQualityBridge.applyPhonemizerLang(settings.effectivePhonemizerLang)
         }
@@ -90,8 +135,8 @@ class StoryvoxApp : Application(), Configuration.Provider {
      * / chapter / follows fetch is authed without making the user re-sign-in.
      */
     private fun rehydrateRoyalRoadCookies() {
-        CoroutineScope(SupervisorJob() + Dispatchers.IO).launch {
-            val header = authRepository.cookieHeader() ?: return@launch
+        initScope.launch {
+            val header = authRepository.get().cookieHeader() ?: return@launch
             // Cookie header is "name1=value1; name2=value2; ..." — parse back
             // into the Map<String,String> shape SessionHydrator expects.
             val cookies = header.split("; ")
@@ -100,7 +145,7 @@ class StoryvoxApp : Application(), Configuration.Provider {
                     if (eq <= 0) null else pair.substring(0, eq) to pair.substring(eq + 1)
                 }
                 .toMap()
-            if (cookies.isNotEmpty()) sessionHydrator.hydrate(cookies)
+            if (cookies.isNotEmpty()) sessionHydrator.get().hydrate(cookies)
         }
     }
 }


### PR DESCRIPTION
## Summary

- Wrap every `@Inject lateinit var` in `StoryvoxApp` (except the `HiltWorkerFactory` WorkManager needs eagerly) in `dagger.Lazy<T>`, and punt `workScheduler.ensurePeriodicWorkScheduled()` + `syncCoordinator.initialize()` off the main thread onto `Dispatchers.IO`.
- Wrap `MainActivity.settingsRepo` in `dagger.Lazy<SettingsRepositoryUi>` — the 20-arg constructor was the biggest single graph node, and the `collectAsState(initial = null)` consumer never needed the value synchronously. Resolution now lands on a composition coroutine via `remember { flow { ... } }`, not on the main-thread activity-injection path.

## Phase 1: measurements

Confirmed the 5x gap reproduces on v0.5.34. Logcat trace showed:

| t (relative to process start) | event |
|---|---|
| 0.000 | process start |
| ~3.34 s | `WM-PackageManagerHelper` (WorkManager lazy-init triggered by `workScheduler` on main) |
| ~6.60 s | first frame draw |
| ~6.68 s | **Choreographer: Skipped 160 frames** (~2.7s of main-thread work in first composition) |

Root cause: `super.onCreate()` in `StoryvoxApp` materialises a Hilt graph of ~25 singletons synchronously on the main thread before any frame can render. `MainActivity@AndroidEntryPoint` then materialises the 20-arg `SettingsRepositoryUiImpl` graph again during activity-component injection. On the Helio P22T's slow class loader + low-end CPU, that's ~1s of unnecessary cold-launch wall-clock.

## Phase 2: measurements

5x cold-launch each, `am start -W -n in.jphe.storyvox/.MainActivity`, force-stopped between runs:

| Device | Before (avg) | After (avg) | Delta |
|---|---|---|---|
| Tab A7 Lite (R83W80CAFZB, Helio P22T) | **6825 ms** | **5861 ms** | **-964 ms (-14%)** |
| Z Flip3 (R5CRB0W66MK, SD888) | 1240 ms | 1200 ms | -40 ms (noise, no regression) |

Logcat after fix: tablet Choreographer skip dropped from 160 frames → 142 frames (~300ms saved in first-composition path because the graph is smaller).

## What this does NOT fix

The remaining ~5.9s on the tablet is dominated by **Compose first-recomposition cost on a 2.0GHz Cortex-A53** — the same work the SD888 does in one frame. The `VoicePickerGate` renders the entire `NavHost` graph behind it unconditionally on first launch, so the Playing-tab + bottom-bar composition is in the cold-launch budget regardless of whether the gate is showing. The right next step is a Macrobenchmark `@StartupCheckpoint` target on the tablet to slice the remaining 2.4s of first-frame Compose work span-by-span, then defer the lowest-priority spans (e.g. the Settings-tab plugin manager descriptors). Tracked as #409 ongoing.

## Test plan

- [x] `./gradlew :app:assembleDebug` — clean
- [x] `./gradlew :app:testDebugUnitTest` — clean
- [x] Install + cold-launch on Tab A7 Lite (R83W80CAFZB) — confirmed 5861ms avg over 5 runs (was 6825ms)
- [x] Install + cold-launch on Z Flip3 (R5CRB0W66MK) — confirmed 1200ms avg over 5 runs (was 1240ms, no regression)
- [x] Verified app launches normally, no crashes; the `Lazy<SettingsRepositoryUi>` materialises within the first frame so theme + settings flow still works.

Refs #409