### PR TITLE
feat(ai): multi-modal image input in chat composer — closes #215

### DIFF
--- a/core-llm/src/main/kotlin/in/jphe/storyvox/llm/LlmContentBlock.kt
+++ b/core-llm/src/main/kotlin/in/jphe/storyvox/llm/LlmContentBlock.kt
@@ -1,0 +1,42 @@
+package `in`.jphe.storyvox.llm
+
+/**
+ * Issue #215 — multi-modal content blocks for a chat message.
+ *
+ * For v1 we model only **text + image** because that's what the
+ * implemented providers' multi-modal endpoints actually accept
+ * (Anthropic Messages, OpenAI Chat Completions on gpt-4o+). Audio /
+ * video blocks would slot in as new sealed-class variants when their
+ * provider support is wired.
+ *
+ * The block list is the source of truth for what gets serialized to
+ * the wire. [LlmMessage] keeps its plain-text [LlmMessage.content]
+ * field for Room storage + legacy callers — when [LlmMessage.parts] is
+ * non-null, providers serialize from the block list instead of the
+ * string content.
+ *
+ * Image bytes are carried as base64 (rather than URIs / file paths)
+ * because that's the format every provider's API actually wants on
+ * the wire, and because the bytes need to survive a process hop
+ * between the Compose-side picker and the OkHttp call inside the
+ * provider. We resize + JPEG-encode before base64 to keep payload
+ * under each provider's per-request size limit (~5 MB on Anthropic,
+ * 20 MB on OpenAI, but we target ~500 KB as a kindness to slower
+ * uplinks — see `ImageResizer`).
+ */
+sealed class LlmContentBlock {
+    /** Plain text. The text-only fallback path for providers that
+     *  don't support images wraps the message's [LlmMessage.content]
+     *  in a single [Text] block. */
+    data class Text(val content: String) : LlmContentBlock()
+
+    /** Inline image, base64-encoded. [mimeType] must match the
+     *  encoded bytes (e.g. `image/jpeg`, `image/png`, `image/webp`).
+     *  Provider serializers branch on this — Anthropic wraps as
+     *  `{type:"image", source:{type:"base64", media_type, data}}`,
+     *  OpenAI as `{type:"image_url", image_url:{url:"data:<mt>;base64,<…>"}}`. */
+    data class Image(
+        val base64: String,
+        val mimeType: String,
+    ) : LlmContentBlock()
+}

--- a/core-llm/src/main/kotlin/in/jphe/storyvox/llm/LlmMessage.kt
+++ b/core-llm/src/main/kotlin/in/jphe/storyvox/llm/LlmMessage.kt
@@ -1,6 +1,7 @@
 package `in`.jphe.storyvox.llm
 
 import kotlinx.serialization.Serializable
+import kotlinx.serialization.Transient
 
 /**
  * Wire-layer chat message. Distinct from the Room-stored
@@ -12,11 +13,30 @@ import kotlinx.serialization.Serializable
  * it as a `system` role inside the array. This type intentionally
  * does NOT have a `system` role — the provider impl handles
  * placement, so callers don't have to reshape input per provider.
+ *
+ * Issue #215 — multi-modal extension. [parts] is a transient
+ * (in-memory only, not serialized to the wire model — providers walk
+ * the list and emit their own per-provider shape) sidecar that lets
+ * a user message carry image+text content for one send round. The
+ * persistence layer (Room) reads from [content] only, so an image
+ * attached to a turn doesn't survive a process restart — that's a v1
+ * trade-off. When [parts] is null the provider falls back to the
+ * text-only [content] field, preserving the pre-#215 behaviour for
+ * every text-only caller.
  */
 @Serializable
 data class LlmMessage(
     val role: Role,
     val content: String,
+    /** Multi-modal content blocks (#215). When non-null, providers
+     *  with image support serialize this list onto the wire instead
+     *  of [content]. The text portion of [parts] (concatenated)
+     *  should equal [content] so the storage layer's text-only view
+     *  stays correct on rehydration. `@Transient` because [parts] is
+     *  in-memory glue between the composer and the provider — never
+     *  read from the wire model on its own, and Room doesn't store it. */
+    @Transient
+    val parts: List<LlmContentBlock>? = null,
 ) {
     @Serializable
     enum class Role { user, assistant }

--- a/core-llm/src/main/kotlin/in/jphe/storyvox/llm/LlmProvider.kt
+++ b/core-llm/src/main/kotlin/in/jphe/storyvox/llm/LlmProvider.kt
@@ -70,6 +70,16 @@ interface LlmProvider {
     val supportsTools: Boolean get() = false
 
     /**
+     * Issue #215 — does this provider's wire format / configured
+     * model accept image content blocks alongside text? v1 enables
+     * this on Anthropic (Claude direct + Teams) and OpenAI (gpt-4o
+     * family). Vertex / Bedrock / Foundry / Ollama leave it false;
+     * the chat layer drops the attached image and surfaces a warning
+     * banner when the user sends an image to an unsupported provider.
+     */
+    val supportsImages: Boolean get() = false
+
+    /**
      * Issue #216 — tool-aware chat. Default impl falls back to
      * [stream] (no tools), wrapping each text emit as a
      * [ChatStreamEvent.TextDelta]. Providers that implement

--- a/core-llm/src/main/kotlin/in/jphe/storyvox/llm/LlmRepository.kt
+++ b/core-llm/src/main/kotlin/in/jphe/storyvox/llm/LlmRepository.kt
@@ -96,6 +96,13 @@ class LlmRepository @Inject constructor(
     fun supportsTools(provider: ProviderId): Boolean =
         provider.implemented && providerFor(provider).supportsTools
 
+    /** Issue #215 — quick "does this provider accept image content?"
+     *  check for UI gating. When false the chat composer drops the
+     *  attached image at send time and surfaces a "image input not
+     *  supported on this provider" warning. */
+    fun supportsImages(provider: ProviderId): Boolean =
+        provider.implemented && providerFor(provider).supportsImages
+
     /** Run a probe on the named provider. Returns
      *  [ProbeResult.Misconfigured] for spec-only providers since they
      *  have no implementation yet. */

--- a/core-llm/src/main/kotlin/in/jphe/storyvox/llm/LlmSessionRepository.kt
+++ b/core-llm/src/main/kotlin/in/jphe/storyvox/llm/LlmSessionRepository.kt
@@ -99,7 +99,17 @@ open class LlmSessionRepository @Inject constructor(
      * completion (success path only — partial replies on cancel are
      * NOT saved, consistent with how chat surfaces typically behave).
      */
-    open fun chat(sessionId: String, userMessage: String): Flow<String> = flow {
+    open fun chat(
+        sessionId: String,
+        userMessage: String,
+        /** Issue #215 — optional multi-modal content blocks. When
+         *  non-null, the latest (user) message in [history] gets
+         *  these parts attached so the provider can serialize them
+         *  onto the wire alongside the text. The persistence layer
+         *  stores only [userMessage] — image bytes don't survive a
+         *  process restart in v1, see [LlmMessage.parts] kdoc. */
+        userParts: List<LlmContentBlock>? = null,
+    ): Flow<String> = flow {
         val session = sessionDao.get(sessionId)
             ?: throw IllegalStateException("Session $sessionId not found")
         val provider = ProviderId.valueOf(session.provider)
@@ -113,7 +123,9 @@ open class LlmSessionRepository @Inject constructor(
                 createdAt = System.currentTimeMillis(),
             ),
         )
-        val history = messageDao.getBySession(sessionId).mapNotNull { it.toWire() }
+        val history = messageDao.getBySession(sessionId)
+            .mapNotNull { it.toWire() }
+            .let { attachPartsToLastUser(it, userParts) }
 
         val replyBuf = StringBuilder()
         val replyFlow = llm.streamWith(
@@ -161,6 +173,9 @@ open class LlmSessionRepository @Inject constructor(
         sessionId: String,
         userMessage: String,
         tools: ToolRegistry,
+        /** Issue #215 — see [chat]. Same shape, same persistence
+         *  trade-off (text-only DB row, image parts in-memory only). */
+        userParts: List<LlmContentBlock>? = null,
     ): Flow<ChatStreamEvent> = flow {
         val session = sessionDao.get(sessionId)
             ?: throw IllegalStateException("Session $sessionId not found")
@@ -174,7 +189,9 @@ open class LlmSessionRepository @Inject constructor(
                 createdAt = System.currentTimeMillis(),
             ),
         )
-        val history = messageDao.getBySession(sessionId).mapNotNull { it.toWire() }
+        val history = messageDao.getBySession(sessionId)
+            .mapNotNull { it.toWire() }
+            .let { attachPartsToLastUser(it, userParts) }
 
         val replyBuf = StringBuilder()
         val replyFlow = llm.chatWithToolsOn(
@@ -206,6 +223,22 @@ open class LlmSessionRepository @Inject constructor(
                 }
             }
         emitAll(replyFlow)
+    }
+
+    /** Issue #215 — attach the given content-block list to the last
+     *  user message in [history], leaving the rest untouched. The
+     *  returned list is what gets handed to the provider on the wire;
+     *  the persisted Room rows stay text-only. */
+    private fun attachPartsToLastUser(
+        history: List<LlmMessage>,
+        parts: List<LlmContentBlock>?,
+    ): List<LlmMessage> {
+        if (parts.isNullOrEmpty()) return history
+        val idx = history.indexOfLast { it.role == LlmMessage.Role.user }
+        if (idx < 0) return history
+        return history.toMutableList().apply {
+            this[idx] = this[idx].copy(parts = parts)
+        }
     }
 
     open suspend fun deleteSession(sessionId: String) {

--- a/core-llm/src/main/kotlin/in/jphe/storyvox/llm/imaging/ImageResizer.kt
+++ b/core-llm/src/main/kotlin/in/jphe/storyvox/llm/imaging/ImageResizer.kt
@@ -1,0 +1,162 @@
+package `in`.jphe.storyvox.llm.imaging
+
+import android.graphics.Bitmap
+import android.graphics.BitmapFactory
+import java.io.ByteArrayInputStream
+import java.io.ByteArrayOutputStream
+import java.util.Base64
+
+/**
+ * Issue #215 — downscale + JPEG-encode an inbound image so the
+ * provider payload stays well under per-request size caps. Anthropic
+ * accepts up to ~5 MB images, OpenAI up to 20 MB, but oversized
+ * images frequently 400 on Claude (related to anthropic-claude#59095
+ * — TLS / proxy buffering on the upload path is more reliable below
+ * ~1 MB). We target ~500 KB after resize as the safe band across
+ * every multi-modal provider we care about.
+ *
+ * Pipeline:
+ *  1. [computeTargetSize] (pure) — figures out the post-scale W×H so
+ *     the long edge doesn't exceed [maxLongEdge].
+ *  2. Decode the bytes via `BitmapFactory.decodeByteArray` with the
+ *     matching `inSampleSize` to avoid loading a 12 MP photo into
+ *     a Bitmap just to shrink it.
+ *  3. `Bitmap.createScaledBitmap` to land on the exact target size.
+ *  4. `Bitmap.compress(JPEG, [jpegQuality])` to bytes.
+ *
+ * The pure-Kotlin entry points ([computeTargetSize], [Base64.encode])
+ * are unit-testable on the JVM without Android stubs. The full
+ * [encodeForUpload] entry point uses `BitmapFactory`, which the
+ * Android JUnit runner treats as a stub — wrap it under Robolectric
+ * for end-to-end coverage, or call the pure helpers in tests.
+ */
+object ImageResizer {
+
+    /** Default max long edge for outbound images. Mirrors the
+     *  screenshot-compress hook's 1280px cap — the smallest size
+     *  where text and faces are still legible on the model's side. */
+    const val DEFAULT_MAX_LONG_EDGE: Int = 1280
+
+    /** Default JPEG quality. 85 is the sweet spot — visually
+     *  indistinguishable from 90+ but ~30 % smaller payload. */
+    const val DEFAULT_JPEG_QUALITY: Int = 85
+
+    /**
+     * Pure math: given source dimensions and a max-long-edge cap,
+     * return the post-scale dimensions. Pass-through when the source
+     * already fits inside the cap (no upscaling — we never grow an
+     * image).
+     *
+     * Aspect ratio is preserved to within a single pixel; the result
+     * floors the short edge so the bitmap allocator doesn't ever
+     * over-allocate. Caller is responsible for rejecting zero / negative
+     * inputs — we coerce to `1` for safety and let the caller surface
+     * the error if it cares.
+     */
+    fun computeTargetSize(
+        srcWidth: Int,
+        srcHeight: Int,
+        maxLongEdge: Int = DEFAULT_MAX_LONG_EDGE,
+    ): IntArray {
+        val w = srcWidth.coerceAtLeast(1)
+        val h = srcHeight.coerceAtLeast(1)
+        val longEdge = maxOf(w, h)
+        if (longEdge <= maxLongEdge) return intArrayOf(w, h)
+        val scale = maxLongEdge.toDouble() / longEdge.toDouble()
+        val newW = (w * scale).toInt().coerceAtLeast(1)
+        val newH = (h * scale).toInt().coerceAtLeast(1)
+        return intArrayOf(newW, newH)
+    }
+
+    /**
+     * Compute the smallest `inSampleSize` that, when passed to
+     * [BitmapFactory.Options], keeps the decoded bitmap ≥ the target
+     * dimensions. We over-decode by up to 2x then `createScaledBitmap`
+     * for an exact fit — that's the standard Android decode pattern.
+     *
+     * The math: `inSampleSize` is constrained to be a power of two by
+     * the decoder, with values >1 quartering the decoded buffer per
+     * step. We pick the largest pow-of-2 ≤ (srcLong / dstLong).
+     */
+    fun computeInSampleSize(
+        srcWidth: Int,
+        srcHeight: Int,
+        dstWidth: Int,
+        dstHeight: Int,
+    ): Int {
+        val srcLong = maxOf(srcWidth, srcHeight)
+        val dstLong = maxOf(dstWidth, dstHeight)
+        if (srcLong <= dstLong) return 1
+        var sample = 1
+        // Stop one step before the bitmap shrinks past the target so
+        // we still have pixels to scale from.
+        while ((srcLong / (sample * 2)) >= dstLong) {
+            sample *= 2
+        }
+        return sample
+    }
+
+    /**
+     * Full pipeline. Decodes [srcBytes], downscales to fit
+     * [maxLongEdge], JPEG-encodes at [jpegQuality], base64-encodes,
+     * and returns the result.
+     *
+     * Throws [IllegalArgumentException] when [srcBytes] doesn't
+     * decode (corrupt / unsupported format / not actually an image).
+     */
+    fun encodeForUpload(
+        srcBytes: ByteArray,
+        maxLongEdge: Int = DEFAULT_MAX_LONG_EDGE,
+        jpegQuality: Int = DEFAULT_JPEG_QUALITY,
+    ): Encoded {
+        // Pass 1 — bounds only, no pixel allocation.
+        val boundsOpts = BitmapFactory.Options().apply { inJustDecodeBounds = true }
+        BitmapFactory.decodeByteArray(srcBytes, 0, srcBytes.size, boundsOpts)
+        val srcW = boundsOpts.outWidth
+        val srcH = boundsOpts.outHeight
+        require(srcW > 0 && srcH > 0) {
+            "Image bytes did not decode to a valid bitmap"
+        }
+        val target = computeTargetSize(srcW, srcH, maxLongEdge)
+        val sample = computeInSampleSize(srcW, srcH, target[0], target[1])
+
+        // Pass 2 — actually decode (using the sample-size hint to
+        // avoid loading a 4032 × 3024 photo into a heap-busting bitmap
+        // when we're shrinking to 1280 anyway).
+        val decodeOpts = BitmapFactory.Options().apply { inSampleSize = sample }
+        val decoded = BitmapFactory.decodeByteArray(
+            srcBytes, 0, srcBytes.size, decodeOpts,
+        ) ?: throw IllegalArgumentException(
+            "Image bytes did not decode to a valid bitmap",
+        )
+        val scaled = if (decoded.width == target[0] && decoded.height == target[1]) {
+            decoded
+        } else {
+            val out = Bitmap.createScaledBitmap(decoded, target[0], target[1], true)
+            if (out != decoded) decoded.recycle()
+            out
+        }
+
+        val baos = ByteArrayOutputStream()
+        scaled.compress(Bitmap.CompressFormat.JPEG, jpegQuality, baos)
+        scaled.recycle()
+        val jpegBytes = baos.toByteArray()
+        val b64 = Base64.getEncoder().encodeToString(jpegBytes)
+        return Encoded(
+            base64 = b64,
+            mimeType = "image/jpeg",
+            widthPx = target[0],
+            heightPx = target[1],
+            byteCount = jpegBytes.size,
+        )
+    }
+
+    /** Result of a successful [encodeForUpload]. */
+    data class Encoded(
+        val base64: String,
+        val mimeType: String,
+        val widthPx: Int,
+        val heightPx: Int,
+        val byteCount: Int,
+    )
+}

--- a/core-llm/src/main/kotlin/in/jphe/storyvox/llm/provider/AnthropicTeamsProvider.kt
+++ b/core-llm/src/main/kotlin/in/jphe/storyvox/llm/provider/AnthropicTeamsProvider.kt
@@ -78,6 +78,11 @@ open class AnthropicTeamsProvider @Inject constructor(
      *  tool-use shape applies. */
     override val supportsTools: Boolean = true
 
+    /** Issue #215 — same Messages API as Claude direct, so image
+     *  content blocks serialize the same way. The Teams bearer auth
+     *  is the only thing that differs from [ClaudeApiProvider]. */
+    override val supportsImages: Boolean = true
+
     /** Override hook for tests — Messages API endpoint. */
     protected open val endpointUrl: String = ENDPOINT
 
@@ -93,16 +98,37 @@ open class AnthropicTeamsProvider @Inject constructor(
         val cfg = configFlow.first()
         val resolvedModel = (model ?: cfg.claudeModel).resolveAnthropic()
 
-        val body = AnthropicRequest(
-            model = resolvedModel,
-            maxTokens = MAX_TOKENS,
-            messages = messages.map {
-                AnthropicMessage(it.role.name, it.content)
-            },
-            system = systemPrompt,
-            stream = true,
-        )
-        val payload = json.encodeToString(body)
+        // Issue #215 — image-bearing messages serialize to the typed-
+        // block content array; text-only chats keep the lighter
+        // string-content [AnthropicRequest] shape.
+        val payload: String = if (messages.any { it.parts != null }) {
+            val imageBody = AnthropicImageRequest(
+                model = resolvedModel,
+                maxTokens = MAX_TOKENS,
+                messages = messages.map { msg ->
+                    val content = ContentBlocks.anthropic(msg)
+                        ?: listOf(buildJsonObject {
+                            put("type", "text")
+                            put("text", msg.content)
+                        })
+                    AnthropicToolMessage(role = msg.role.name, content = content)
+                },
+                system = systemPrompt,
+                stream = true,
+            )
+            json.encodeToString(imageBody)
+        } else {
+            val body = AnthropicRequest(
+                model = resolvedModel,
+                maxTokens = MAX_TOKENS,
+                messages = messages.map {
+                    AnthropicMessage(it.role.name, it.content)
+                },
+                system = systemPrompt,
+                stream = true,
+            )
+            json.encodeToString(body)
+        }
 
         // Refresh proactively if the persisted expires_at is close.
         ensureFreshToken()
@@ -323,15 +349,17 @@ open class AnthropicTeamsProvider @Inject constructor(
                     inputSchema = spec.toAnthropicInputSchema(),
                 )
             }
+            // Issue #215 — when a message carries image parts the
+            // content array picks them up via [ContentBlocks.anthropic];
+            // otherwise we wrap the plain text in a single text block.
             val conversation = ArrayList<AnthropicToolMessage>(
                 messages.map { msg ->
-                    AnthropicToolMessage(
-                        role = msg.role.name,
-                        content = listOf(buildJsonObject {
+                    val content = ContentBlocks.anthropic(msg)
+                        ?: listOf(buildJsonObject {
                             put("type", "text")
                             put("text", msg.content)
-                        }),
-                    )
+                        })
+                    AnthropicToolMessage(role = msg.role.name, content = content)
                 },
             )
 

--- a/core-llm/src/main/kotlin/in/jphe/storyvox/llm/provider/ClaudeApiProvider.kt
+++ b/core-llm/src/main/kotlin/in/jphe/storyvox/llm/provider/ClaudeApiProvider.kt
@@ -67,6 +67,13 @@ open class ClaudeApiProvider @Inject constructor(
      *  passed to [chatWithTools]. */
     override val supportsTools: Boolean = true
 
+    /** Issue #215 — Anthropic Messages API supports inline image
+     *  content blocks across the Claude 3+ family (every model we
+     *  ship). The chat layer attaches an image when the composer has
+     *  one queued; we serialize it into a `{type:"image", source:…}`
+     *  block inside the user message's content array. */
+    override val supportsImages: Boolean = true
+
     /** Anthropic Messages endpoint. Open so tests can override to
      *  point at MockWebServer. */
     protected open val endpointUrl: String = ENDPOINT
@@ -81,15 +88,35 @@ open class ClaudeApiProvider @Inject constructor(
             ?: throw LlmError.NotConfigured(ProviderId.Claude)
         val resolvedModel = (model ?: cfg.claudeModel).resolveAnthropic()
 
-        val body = AnthropicRequest(
-            model = resolvedModel,
-            maxTokens = MAX_TOKENS,
-            messages = messages.map {
-                AnthropicMessage(it.role.name, it.content)
-            },
-            system = systemPrompt,
-            stream = true,
-        )
+        // Issue #215 — when any message carries multi-modal parts we
+        // dispatch to the image-request wire shape (content is an
+        // array of typed blocks); otherwise the cheaper string-content
+        // [AnthropicRequest] handles the text-only hot path.
+        val payload: String = if (messages.any { it.parts != null }) {
+            val body = AnthropicImageRequest(
+                model = resolvedModel,
+                maxTokens = MAX_TOKENS,
+                messages = messages.map { msg ->
+                    val content = ContentBlocks.anthropic(msg)
+                        ?: listOf(textBlock(msg.content))
+                    AnthropicToolMessage(role = msg.role.name, content = content)
+                },
+                system = systemPrompt,
+                stream = true,
+            )
+            json.encodeToString(body)
+        } else {
+            val body = AnthropicRequest(
+                model = resolvedModel,
+                maxTokens = MAX_TOKENS,
+                messages = messages.map {
+                    AnthropicMessage(it.role.name, it.content)
+                },
+                system = systemPrompt,
+                stream = true,
+            )
+            json.encodeToString(body)
+        }
 
         val request = Request.Builder()
             .url(endpointUrl)
@@ -97,7 +124,7 @@ open class ClaudeApiProvider @Inject constructor(
             .header("anthropic-version", API_VERSION)
             .header("content-type", "application/json")
             .header("accept", "text/event-stream")
-            .post(json.encodeToString(body).toRequestBody(JSON_MEDIA_TYPE))
+            .post(payload.toRequestBody(JSON_MEDIA_TYPE))
             .build()
 
         val response = try {
@@ -219,12 +246,16 @@ open class ClaudeApiProvider @Inject constructor(
             // Build the seed turns. Each existing LlmMessage carries
             // plain text; wrap it in a single `text` block to match
             // the content-array shape Anthropic requires here.
+            //
+            // Issue #215 — when a message carries [LlmMessage.parts],
+            // serialize those blocks instead of the plain-text content
+            // (the latest user turn typically does, on an image-bearing
+            // send).
             val conversation = ArrayList<AnthropicToolMessage>(
                 messages.map { msg ->
-                    AnthropicToolMessage(
-                        role = msg.role.name,
-                        content = listOf(textBlock(msg.content)),
-                    )
+                    val content = ContentBlocks.anthropic(msg)
+                        ?: listOf(textBlock(msg.content))
+                    AnthropicToolMessage(role = msg.role.name, content = content)
                 },
             )
 

--- a/core-llm/src/main/kotlin/in/jphe/storyvox/llm/provider/ContentBlocks.kt
+++ b/core-llm/src/main/kotlin/in/jphe/storyvox/llm/provider/ContentBlocks.kt
@@ -1,0 +1,77 @@
+package `in`.jphe.storyvox.llm.provider
+
+import `in`.jphe.storyvox.llm.LlmContentBlock
+import `in`.jphe.storyvox.llm.LlmMessage
+import kotlinx.serialization.json.JsonElement
+import kotlinx.serialization.json.buildJsonObject
+import kotlinx.serialization.json.put
+
+/**
+ * Issue #215 — provider-side serializers for the multi-modal content
+ * blocks introduced on [LlmMessage.parts]. Each provider has a slightly
+ * different "what does the content array look like" shape, so this
+ * file collects the per-provider transforms in one place.
+ *
+ * Two providers (Anthropic family + OpenAI) actually accept image
+ * content blocks. The rest of the providers ignore [LlmMessage.parts]
+ * — they read the text-only [LlmMessage.content] field and pretend the
+ * image attachment never happened (the chat layer surfaces a warning
+ * banner to the user before sending so this isn't a silent drop).
+ */
+internal object ContentBlocks {
+
+    /**
+     * Anthropic Messages API content-block shape.
+     *
+     * Text-only message (no [LlmMessage.parts]) → `null` (caller uses
+     * the plain-string content path).
+     * Image-bearing message → array of `{type:"image", source:{type:"base64", media_type, data}}`
+     * + `{type:"text", text}` blocks, in the order Anthropic recommends
+     * (image first then text — the model attends to the image while
+     * reading the question).
+     */
+    fun anthropic(message: LlmMessage): List<JsonElement>? {
+        val parts = message.parts ?: return null
+        return parts.map { block ->
+            when (block) {
+                is LlmContentBlock.Text -> buildJsonObject {
+                    put("type", "text")
+                    put("text", block.content)
+                }
+                is LlmContentBlock.Image -> buildJsonObject {
+                    put("type", "image")
+                    put("source", buildJsonObject {
+                        put("type", "base64")
+                        put("media_type", block.mimeType)
+                        put("data", block.base64)
+                    })
+                }
+            }
+        }
+    }
+
+    /**
+     * OpenAI Chat Completions content-block shape. OpenAI accepts
+     * `image_url` as a data URI, so the base64 + mime get spliced
+     * into a single `data:<mime>;base64,<…>` string.
+     *
+     * Text-only message (no [LlmMessage.parts]) → `null`.
+     */
+    fun openAi(message: LlmMessage): List<JsonElement>? {
+        val parts = message.parts ?: return null
+        return parts.map { block ->
+            when (block) {
+                is LlmContentBlock.Text -> buildJsonObject {
+                    put("type", "text")
+                    put("text", block.content)
+                }
+                is LlmContentBlock.Image -> buildJsonObject {
+                    put("type", "image_url")
+                    put("image_url", buildJsonObject {
+                        put("url", "data:${block.mimeType};base64,${block.base64}")
+                    })
+                }
+            }
+        }
+    }
+}

--- a/core-llm/src/main/kotlin/in/jphe/storyvox/llm/provider/OpenAiApiProvider.kt
+++ b/core-llm/src/main/kotlin/in/jphe/storyvox/llm/provider/OpenAiApiProvider.kt
@@ -63,6 +63,13 @@ open class OpenAiApiProvider @Inject constructor(
      *  calling out of the box. */
     override val supportsTools: Boolean = true
 
+    /** Issue #215 — OpenAI's `gpt-4o` family (and every subsequent
+     *  Chat-Completions model JP has the Settings UI offer) accepts
+     *  `image_url` content blocks. The chat layer attaches an image
+     *  when the composer has one queued; we splice it into the user
+     *  message's content array as `{type:"image_url", image_url:{url:"data:…"}}`. */
+    override val supportsImages: Boolean = true
+
     /** Chat-completions endpoint. Open for tests. */
     protected open val endpointUrl: String = ENDPOINT
     /** /v1/models endpoint for [probe]. Open for tests. */
@@ -78,25 +85,57 @@ open class OpenAiApiProvider @Inject constructor(
             ?: throw LlmError.NotConfigured(ProviderId.OpenAi)
         val resolvedModel = model ?: cfg.openAiModel
 
-        // OpenAI wants system as a regular message at the head of the
-        // array (unlike Anthropic which has a top-level field).
-        val systemMsg = systemPrompt?.takeIf { it.isNotBlank() }
-            ?.let { listOf(OpenAiMessage("system", it)) }
-            .orEmpty()
-        val body = OpenAiRequest(
-            model = resolvedModel,
-            messages = systemMsg + messages.map {
-                OpenAiMessage(it.role.name, it.content)
-            },
-            stream = true,
-        )
+        // Issue #215 — when any message carries multi-modal parts we
+        // serialize each message as a JSON object whose `content` is
+        // a typed-block array. Text-only chats keep the cheaper
+        // string-content [OpenAiRequest] shape.
+        val payload: String = if (messages.any { it.parts != null }) {
+            val list = ArrayList<JsonObject>()
+            systemPrompt?.takeIf { it.isNotBlank() }?.let { sp ->
+                list.add(buildJsonObject {
+                    put("role", "system")
+                    put("content", sp)
+                })
+            }
+            messages.forEach { msg ->
+                val blocks = ContentBlocks.openAi(msg)
+                list.add(buildJsonObject {
+                    put("role", msg.role.name)
+                    if (blocks != null) {
+                        put("content", kotlinx.serialization.json.JsonArray(blocks))
+                    } else {
+                        put("content", msg.content)
+                    }
+                })
+            }
+            val body = OpenAiImageRequest(
+                model = resolvedModel,
+                messages = list,
+                stream = true,
+            )
+            json.encodeToString(body)
+        } else {
+            // OpenAI wants system as a regular message at the head of
+            // the array (unlike Anthropic which has a top-level field).
+            val systemMsg = systemPrompt?.takeIf { it.isNotBlank() }
+                ?.let { listOf(OpenAiMessage("system", it)) }
+                .orEmpty()
+            val body = OpenAiRequest(
+                model = resolvedModel,
+                messages = systemMsg + messages.map {
+                    OpenAiMessage(it.role.name, it.content)
+                },
+                stream = true,
+            )
+            json.encodeToString(body)
+        }
 
         val request = Request.Builder()
             .url(endpointUrl)
             .header("Authorization", "Bearer $apiKey")
             .header("content-type", "application/json")
             .header("accept", "text/event-stream")
-            .post(json.encodeToString(body).toRequestBody(JSON_MEDIA_TYPE))
+            .post(payload.toRequestBody(JSON_MEDIA_TYPE))
             .build()
 
         val response = try {
@@ -203,9 +242,17 @@ open class OpenAiApiProvider @Inject constructor(
                 })
             }
             messages.forEach { msg ->
+                // Issue #215 — image-bearing message → typed-block array;
+                // text-only → string content (cheaper to serialize and
+                // backward-compatible with every OpenAI-compat backend).
+                val blocks = ContentBlocks.openAi(msg)
                 conversation.add(buildJsonObject {
                     put("role", msg.role.name)
-                    put("content", msg.content)
+                    if (blocks != null) {
+                        put("content", kotlinx.serialization.json.JsonArray(blocks))
+                    } else {
+                        put("content", msg.content)
+                    }
                 })
             }
 

--- a/core-llm/src/main/kotlin/in/jphe/storyvox/llm/provider/Wire.kt
+++ b/core-llm/src/main/kotlin/in/jphe/storyvox/llm/provider/Wire.kt
@@ -155,6 +155,41 @@ internal data class OpenAiToolFunction(
     val parameters: kotlinx.serialization.json.JsonObject,
 )
 
+// ── Multi-modal Anthropic (#215) ────────────────────────────────────
+//
+// Anthropic's Messages API accepts image+text content blocks alongside
+// plain-text via a typed content array. We keep the [AnthropicRequest]
+// type (with string-content [AnthropicMessage]) for the text-only
+// streaming hot path (it's slightly cheaper to serialize), and use
+// this image-request type whenever any user message carries
+// [LlmContentBlock.Image] parts.
+
+@Serializable
+internal data class AnthropicImageRequest(
+    val model: String,
+    @SerialName("max_tokens") val maxTokens: Int,
+    val messages: List<AnthropicToolMessage>,
+    val system: String? = null,
+    val stream: Boolean = true,
+)
+
+// ── Multi-modal OpenAI (#215) ───────────────────────────────────────
+//
+// OpenAI's chat-completions API accepts image_url content blocks
+// inside the same `messages[].content` array used for tool-aware
+// chats. We need a wire type with `messages: List<JsonObject>` (so
+// each message's `content` can be either a string or an array). For
+// streaming we still set `stream: true` — image-bearing chats can
+// stream tokens just like text-only ones.
+
+@Serializable
+internal data class OpenAiImageRequest(
+    val model: String,
+    val messages: List<kotlinx.serialization.json.JsonObject>,
+    @SerialName("max_tokens") val maxTokens: Int = 1024,
+    val stream: Boolean = true,
+)
+
 // ── AWS Bedrock converse-stream ────────────────────────────────────
 //
 // Body shape: { modelId, messages:[{role, content:[{text}]}],

--- a/core-llm/src/test/kotlin/in/jphe/storyvox/llm/imaging/ImageResizerTest.kt
+++ b/core-llm/src/test/kotlin/in/jphe/storyvox/llm/imaging/ImageResizerTest.kt
@@ -1,0 +1,94 @@
+package `in`.jphe.storyvox.llm.imaging
+
+import java.util.Base64
+import org.junit.Assert.assertArrayEquals
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * Issue #215 — pure-math unit tests for [ImageResizer]. The full
+ * [ImageResizer.encodeForUpload] path uses `BitmapFactory` (Android
+ * framework) and would need Robolectric, but the math entry points
+ * are platform-independent.
+ */
+class ImageResizerTest {
+
+    @Test
+    fun `1080x2640 portrait downscales to fit 1280 long edge`() {
+        // The typical Android screenshot — tall, ~21:9. Long edge is
+        // height 2640 → scale to height 1280, width pro rata.
+        val target = ImageResizer.computeTargetSize(
+            srcWidth = 1080,
+            srcHeight = 2640,
+            maxLongEdge = 1280,
+        )
+        // 1080 * (1280 / 2640) = 523.6 → 523
+        assertEquals(523, target[0])
+        assertEquals(1280, target[1])
+    }
+
+    @Test
+    fun `4032x3024 landscape downscales to fit 1280 long edge`() {
+        // The typical phone-camera landscape — 4:3.
+        val target = ImageResizer.computeTargetSize(
+            srcWidth = 4032,
+            srcHeight = 3024,
+            maxLongEdge = 1280,
+        )
+        assertEquals(1280, target[0])
+        // 3024 * (1280 / 4032) = 960.0
+        assertEquals(960, target[1])
+    }
+
+    @Test
+    fun `under-cap image is left at native size`() {
+        val target = ImageResizer.computeTargetSize(
+            srcWidth = 800,
+            srcHeight = 600,
+            maxLongEdge = 1280,
+        )
+        assertEquals(800, target[0])
+        assertEquals(600, target[1])
+    }
+
+    @Test
+    fun `compute in-sample-size picks largest power-of-two that keeps target`() {
+        // 4032x3024 → target 1280x960. srcLong/dstLong = 3.15 → 2x.
+        assertEquals(
+            2,
+            ImageResizer.computeInSampleSize(4032, 3024, 1280, 960),
+        )
+        // 8000x6000 → target 1280x960. srcLong/dstLong = 6.25 → 4x.
+        assertEquals(
+            4,
+            ImageResizer.computeInSampleSize(8000, 6000, 1280, 960),
+        )
+        // Source ≤ target → sampleSize = 1 (no downsample).
+        assertEquals(
+            1,
+            ImageResizer.computeInSampleSize(800, 600, 1280, 960),
+        )
+    }
+
+    @Test
+    fun `base64 round-trips an arbitrary byte sequence`() {
+        // A handful of bytes that exercise every base64 sextet shape
+        // (including padding) and surface any bytewise corruption.
+        val source = byteArrayOf(
+            0x00, 0x01, 0x02.toByte(), 0x7F, 0x80.toByte(), 0xFF.toByte(),
+            'h'.code.toByte(), 'i'.code.toByte(),
+            0x00, 0x00, 0x00,
+        )
+        val encoded = Base64.getEncoder().encodeToString(source)
+        val decoded = Base64.getDecoder().decode(encoded)
+        assertArrayEquals(source, decoded)
+        // And the encoded form should be the standard padded shape
+        // (the multiple of 4 invariant) — Anthropic + OpenAI both
+        // expect padded base64 on the wire.
+        assertTrue(
+            "encoded base64 should be padded to a multiple of 4 chars",
+            encoded.length % 4 == 0,
+        )
+    }
+}

--- a/core-llm/src/test/kotlin/in/jphe/storyvox/llm/provider/ClaudeImageRequestTest.kt
+++ b/core-llm/src/test/kotlin/in/jphe/storyvox/llm/provider/ClaudeImageRequestTest.kt
@@ -1,0 +1,157 @@
+package `in`.jphe.storyvox.llm.provider
+
+import `in`.jphe.storyvox.llm.LlmConfig
+import `in`.jphe.storyvox.llm.LlmContentBlock
+import `in`.jphe.storyvox.llm.LlmMessage
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.flow.toList
+import kotlinx.coroutines.test.runTest
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.contentOrNull
+import kotlinx.serialization.json.jsonArray
+import kotlinx.serialization.json.jsonObject
+import kotlinx.serialization.json.jsonPrimitive
+import okhttp3.OkHttpClient
+import okhttp3.mockwebserver.MockResponse
+import okhttp3.mockwebserver.MockWebServer
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+import java.util.concurrent.TimeUnit
+
+/**
+ * Issue #215 — end-to-end wire test for the multi-modal request
+ * shape emitted by [ClaudeApiProvider.stream]. When the latest user
+ * message carries [LlmContentBlock.Image] parts, the payload posted
+ * to Anthropic must use the typed-block content array (not the
+ * string-content shape).
+ */
+class ClaudeImageRequestTest {
+
+    private lateinit var server: MockWebServer
+    private val json = Json { ignoreUnknownKeys = true }
+    private lateinit var http: OkHttpClient
+
+    @Before
+    fun setUp() {
+        server = MockWebServer()
+        server.start()
+        http = OkHttpClient.Builder()
+            .readTimeout(2, TimeUnit.SECONDS)
+            .build()
+    }
+
+    @After
+    fun tearDown() {
+        server.shutdown()
+    }
+
+    private fun providerWith(key: String?): ClaudeApiProvider {
+        val testEndpoint = server.url("/v1/messages").toString()
+        return object : ClaudeApiProvider(
+            http = http,
+            store = FakeStore(claude = key),
+            configFlow = flowOf(LlmConfig(claudeModel = "claude-haiku-4.5")),
+            json = json,
+        ) {
+            override val endpointUrl: String = testEndpoint
+        }
+    }
+
+    @Test
+    fun `image-bearing send posts typed-block content array`() = runTest {
+        val sse = """
+            data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"I see a cat."}}
+            data: {"type":"message_stop"}
+
+        """.trimIndent()
+        server.enqueue(
+            MockResponse()
+                .setHeader("Content-Type", "text/event-stream")
+                .setBody(sse)
+                .setResponseCode(200),
+        )
+
+        val tokens = providerWith("k").stream(
+            messages = listOf(
+                LlmMessage(
+                    role = LlmMessage.Role.user,
+                    content = "what's in this photo?",
+                    parts = listOf(
+                        LlmContentBlock.Image(
+                            base64 = "Zm9vYmFy",  // "foobar"
+                            mimeType = "image/jpeg",
+                        ),
+                        LlmContentBlock.Text("what's in this photo?"),
+                    ),
+                ),
+            ),
+        ).toList()
+        assertEquals(listOf("I see a cat."), tokens)
+
+        val req = server.takeRequest()
+        val body = json.parseToJsonElement(req.body.readUtf8()).jsonObject
+
+        // model + max_tokens stayed on the body; image-request shape
+        // doesn't drop them.
+        assertTrue(body.containsKey("model"))
+        assertTrue(body.containsKey("max_tokens"))
+        // messages[0].content is now an array (not a string).
+        val messages = body["messages"]!!.jsonArray
+        assertEquals(1, messages.size)
+        val msg = messages[0].jsonObject
+        assertEquals("user", msg["role"]?.jsonPrimitive?.contentOrNull)
+        val content = msg["content"]!!.jsonArray
+        assertEquals(2, content.size)
+        // Block 0: image with base64 source.
+        val img = content[0].jsonObject
+        assertEquals("image", img["type"]?.jsonPrimitive?.contentOrNull)
+        val src = img["source"]!!.jsonObject
+        assertEquals("base64", src["type"]?.jsonPrimitive?.contentOrNull)
+        assertEquals("image/jpeg", src["media_type"]?.jsonPrimitive?.contentOrNull)
+        assertEquals("Zm9vYmFy", src["data"]?.jsonPrimitive?.contentOrNull)
+        // Block 1: text.
+        val text = content[1].jsonObject
+        assertEquals("text", text["type"]?.jsonPrimitive?.contentOrNull)
+        assertEquals(
+            "what's in this photo?",
+            text["text"]?.jsonPrimitive?.contentOrNull,
+        )
+    }
+
+    @Test
+    fun `text-only send keeps the legacy string-content shape`() = runTest {
+        // Sanity check that the multi-modal dispatch doesn't bleed
+        // into the text-only hot path — text-only messages should
+        // still serialize as the simpler string-content shape that
+        // every Anthropic-compat backend handles.
+        val sse = """
+            data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"ok"}}
+            data: {"type":"message_stop"}
+
+        """.trimIndent()
+        server.enqueue(
+            MockResponse()
+                .setHeader("Content-Type", "text/event-stream")
+                .setBody(sse)
+                .setResponseCode(200),
+        )
+
+        providerWith("k").stream(
+            messages = listOf(
+                LlmMessage(LlmMessage.Role.user, "just text"),
+            ),
+        ).toList()
+
+        val req = server.takeRequest()
+        val body = json.parseToJsonElement(req.body.readUtf8()).jsonObject
+        val msg = body["messages"]!!.jsonArray[0].jsonObject
+        // content is a string, not an array.
+        assertEquals(
+            "just text",
+            msg["content"]?.jsonPrimitive?.contentOrNull,
+        )
+    }
+}

--- a/core-llm/src/test/kotlin/in/jphe/storyvox/llm/provider/ContentBlocksTest.kt
+++ b/core-llm/src/test/kotlin/in/jphe/storyvox/llm/provider/ContentBlocksTest.kt
@@ -1,0 +1,138 @@
+package `in`.jphe.storyvox.llm.provider
+
+import `in`.jphe.storyvox.llm.LlmContentBlock
+import `in`.jphe.storyvox.llm.LlmMessage
+import kotlinx.serialization.json.JsonArray
+import kotlinx.serialization.json.contentOrNull
+import kotlinx.serialization.json.jsonObject
+import kotlinx.serialization.json.jsonPrimitive
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Test
+
+/**
+ * Issue #215 — content-block serialization tests for the two
+ * providers that accept image input on the wire (Anthropic family
+ * + OpenAI).
+ *
+ * Snapshot-style assertions on the JSON shape because the test
+ * surface here is wire-format compliance — if the schema breaks,
+ * every multi-modal chat will 400 against the provider's API and
+ * the assertion gives us a localized diff to read.
+ */
+class ContentBlocksTest {
+
+    @Test
+    fun `anthropic content for text-only message is null`() {
+        val msg = LlmMessage(LlmMessage.Role.user, "no image here")
+        assertNull(
+            "messages without parts should signal text-only path to the provider",
+            ContentBlocks.anthropic(msg),
+        )
+    }
+
+    @Test
+    fun `anthropic content serialises image then text block`() {
+        val msg = LlmMessage(
+            role = LlmMessage.Role.user,
+            content = "what do you see?",
+            parts = listOf(
+                LlmContentBlock.Image(
+                    base64 = "AAAA",
+                    mimeType = "image/jpeg",
+                ),
+                LlmContentBlock.Text("what do you see?"),
+            ),
+        )
+        val blocks = ContentBlocks.anthropic(msg)
+        requireNotNull(blocks)
+        assertEquals(2, blocks.size)
+
+        // Block 0 — Anthropic image shape.
+        val img = blocks[0].jsonObject
+        assertEquals("image", img["type"]?.jsonPrimitive?.contentOrNull)
+        val source = img["source"]!!.jsonObject
+        assertEquals("base64", source["type"]?.jsonPrimitive?.contentOrNull)
+        assertEquals("image/jpeg", source["media_type"]?.jsonPrimitive?.contentOrNull)
+        assertEquals("AAAA", source["data"]?.jsonPrimitive?.contentOrNull)
+
+        // Block 1 — text.
+        val text = blocks[1].jsonObject
+        assertEquals("text", text["type"]?.jsonPrimitive?.contentOrNull)
+        assertEquals(
+            "what do you see?",
+            text["text"]?.jsonPrimitive?.contentOrNull,
+        )
+    }
+
+    @Test
+    fun `openai content for text-only message is null`() {
+        val msg = LlmMessage(LlmMessage.Role.user, "no image here")
+        assertNull(ContentBlocks.openAi(msg))
+    }
+
+    @Test
+    fun `openai content serialises image then text block as data URI`() {
+        val msg = LlmMessage(
+            role = LlmMessage.Role.user,
+            content = "transcribe this",
+            parts = listOf(
+                LlmContentBlock.Image(
+                    base64 = "ZGF0YQ==",  // "data" in base64
+                    mimeType = "image/png",
+                ),
+                LlmContentBlock.Text("transcribe this"),
+            ),
+        )
+        val blocks = ContentBlocks.openAi(msg)
+        requireNotNull(blocks)
+        assertEquals(2, blocks.size)
+
+        // Block 0 — OpenAI image_url shape with data URI.
+        val img = blocks[0].jsonObject
+        assertEquals("image_url", img["type"]?.jsonPrimitive?.contentOrNull)
+        val imageUrl = img["image_url"]!!.jsonObject
+        assertEquals(
+            "data:image/png;base64,ZGF0YQ==",
+            imageUrl["url"]?.jsonPrimitive?.contentOrNull,
+        )
+
+        // Block 1 — text.
+        val text = blocks[1].jsonObject
+        assertEquals("text", text["type"]?.jsonPrimitive?.contentOrNull)
+        assertEquals(
+            "transcribe this",
+            text["text"]?.jsonPrimitive?.contentOrNull,
+        )
+    }
+
+    @Test
+    fun `openai content preserves arbitrary block ordering`() {
+        // The chat layer puts image first then text, but the
+        // serializer must respect whatever order the caller gave us
+        // — a future "transcribe + summarize" path could send text
+        // first.
+        val msg = LlmMessage(
+            role = LlmMessage.Role.user,
+            content = "describe this scene",
+            parts = listOf(
+                LlmContentBlock.Text("describe this scene"),
+                LlmContentBlock.Image(
+                    base64 = "Zm9v",
+                    mimeType = "image/webp",
+                ),
+            ),
+        )
+        val blocks = ContentBlocks.openAi(msg)
+        requireNotNull(blocks)
+        assertEquals(2, blocks.size)
+        assertEquals(
+            "text",
+            blocks[0].jsonObject["type"]?.jsonPrimitive?.contentOrNull,
+        )
+        assertEquals(
+            "image_url",
+            blocks[1].jsonObject["type"]?.jsonPrimitive?.contentOrNull,
+        )
+    }
+}

--- a/core-llm/src/test/kotlin/in/jphe/storyvox/llm/provider/OpenAiImageRequestTest.kt
+++ b/core-llm/src/test/kotlin/in/jphe/storyvox/llm/provider/OpenAiImageRequestTest.kt
@@ -1,0 +1,163 @@
+package `in`.jphe.storyvox.llm.provider
+
+import `in`.jphe.storyvox.llm.LlmConfig
+import `in`.jphe.storyvox.llm.LlmContentBlock
+import `in`.jphe.storyvox.llm.LlmMessage
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.flow.toList
+import kotlinx.coroutines.test.runTest
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.contentOrNull
+import kotlinx.serialization.json.jsonArray
+import kotlinx.serialization.json.jsonObject
+import kotlinx.serialization.json.jsonPrimitive
+import okhttp3.OkHttpClient
+import okhttp3.mockwebserver.MockResponse
+import okhttp3.mockwebserver.MockWebServer
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+import java.util.concurrent.TimeUnit
+
+/**
+ * Issue #215 — end-to-end wire test for the multi-modal request shape
+ * emitted by [OpenAiApiProvider.stream] when the latest user message
+ * carries [LlmContentBlock.Image] parts.
+ */
+class OpenAiImageRequestTest {
+
+    private lateinit var server: MockWebServer
+    private val json = Json { ignoreUnknownKeys = true }
+    private lateinit var http: OkHttpClient
+
+    @Before
+    fun setUp() {
+        server = MockWebServer()
+        server.start()
+        http = OkHttpClient.Builder()
+            .readTimeout(2, TimeUnit.SECONDS)
+            .build()
+    }
+
+    @After
+    fun tearDown() {
+        server.shutdown()
+    }
+
+    private fun providerWith(key: String?): OpenAiApiProvider {
+        val testEndpoint = server.url("/v1/chat/completions").toString()
+        return object : OpenAiApiProvider(
+            http = http,
+            store = FakeStore(openAi = key),
+            configFlow = flowOf(LlmConfig(openAiModel = "gpt-4o-mini")),
+            json = json,
+        ) {
+            override val endpointUrl: String = testEndpoint
+        }
+    }
+
+    @Test
+    fun `image-bearing send posts data-URI image_url block`() = runTest {
+        // OpenAI's chat-completions SSE shape: data lines wrapping
+        // a `choices[0].delta.content` token, ending in [DONE].
+        val sse = """
+            data: {"choices":[{"delta":{"content":"a cat"}}]}
+            data: [DONE]
+
+        """.trimIndent()
+        server.enqueue(
+            MockResponse()
+                .setHeader("Content-Type", "text/event-stream")
+                .setBody(sse)
+                .setResponseCode(200),
+        )
+
+        providerWith("k").stream(
+            messages = listOf(
+                LlmMessage(
+                    role = LlmMessage.Role.user,
+                    content = "what's in this?",
+                    parts = listOf(
+                        LlmContentBlock.Image(
+                            base64 = "Zm9v",
+                            mimeType = "image/png",
+                        ),
+                        LlmContentBlock.Text("what's in this?"),
+                    ),
+                ),
+            ),
+        ).toList()
+
+        val req = server.takeRequest()
+        val body = json.parseToJsonElement(req.body.readUtf8()).jsonObject
+        val messages = body["messages"]!!.jsonArray
+        // First (and only) message — content is the typed-block array.
+        val msg = messages.last().jsonObject
+        assertEquals("user", msg["role"]?.jsonPrimitive?.contentOrNull)
+        val content = msg["content"]!!.jsonArray
+        assertEquals(2, content.size)
+        val img = content[0].jsonObject
+        assertEquals("image_url", img["type"]?.jsonPrimitive?.contentOrNull)
+        val imageUrl = img["image_url"]!!.jsonObject
+        assertEquals(
+            "data:image/png;base64,Zm9v",
+            imageUrl["url"]?.jsonPrimitive?.contentOrNull,
+        )
+        val text = content[1].jsonObject
+        assertEquals("text", text["type"]?.jsonPrimitive?.contentOrNull)
+        assertEquals(
+            "what's in this?",
+            text["text"]?.jsonPrimitive?.contentOrNull,
+        )
+    }
+
+    @Test
+    fun `system prompt is preserved as a string-content message`() = runTest {
+        // Image-bearing chats still need the system prompt as a
+        // regular message at the head of the messages array (OpenAI
+        // convention). The system message itself stays a string —
+        // it doesn't carry images.
+        val sse = """
+            data: {"choices":[{"delta":{"content":"ok"}}]}
+            data: [DONE]
+
+        """.trimIndent()
+        server.enqueue(
+            MockResponse()
+                .setHeader("Content-Type", "text/event-stream")
+                .setBody(sse)
+                .setResponseCode(200),
+        )
+
+        providerWith("k").stream(
+            messages = listOf(
+                LlmMessage(
+                    role = LlmMessage.Role.user,
+                    content = "x",
+                    parts = listOf(
+                        LlmContentBlock.Image("Zm9v", "image/jpeg"),
+                        LlmContentBlock.Text("x"),
+                    ),
+                ),
+            ),
+            systemPrompt = "you are a librarian",
+        ).toList()
+
+        val req = server.takeRequest()
+        val body = json.parseToJsonElement(req.body.readUtf8()).jsonObject
+        val messages = body["messages"]!!.jsonArray
+        assertEquals(2, messages.size)
+        val sys = messages[0].jsonObject
+        assertEquals("system", sys["role"]?.jsonPrimitive?.contentOrNull)
+        assertEquals(
+            "you are a librarian",
+            sys["content"]?.jsonPrimitive?.contentOrNull,
+        )
+        val user = messages[1].jsonObject
+        assertEquals("user", user["role"]?.jsonPrimitive?.contentOrNull)
+        // User content is the typed-block array.
+        assertTrue(user["content"] is kotlinx.serialization.json.JsonArray)
+    }
+}

--- a/feature/src/main/kotlin/in/jphe/storyvox/feature/chat/ChatScreen.kt
+++ b/feature/src/main/kotlin/in/jphe/storyvox/feature/chat/ChatScreen.kt
@@ -8,6 +8,10 @@ import androidx.compose.animation.core.tween
 import androidx.compose.foundation.BorderStroke
 import androidx.compose.foundation.background
 import androidx.compose.foundation.border
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.heightIn
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -24,11 +28,13 @@ import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
 import androidx.compose.material.icons.automirrored.filled.Send
+import androidx.compose.material.icons.outlined.AddPhotoAlternate
 import androidx.compose.material.icons.outlined.AutoAwesome
 import androidx.compose.material.icons.outlined.AutoFixHigh
 import androidx.compose.material.icons.outlined.CheckCircle
 import androidx.compose.material.icons.outlined.Close
 import androidx.compose.material.icons.outlined.ErrorOutline
+import androidx.compose.material.icons.outlined.Image
 import androidx.compose.material.icons.outlined.PlayArrow
 import androidx.compose.material.icons.outlined.Stop
 import androidx.compose.material.icons.outlined.VolumeUp
@@ -49,12 +55,15 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.alpha
+import androidx.compose.ui.draw.clip
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import `in`.jphe.storyvox.llm.tools.ToolCallEvent
 import `in`.jphe.storyvox.llm.tools.ToolResult
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
 import `in`.jphe.storyvox.ui.component.BrassButton
 import `in`.jphe.storyvox.ui.component.BrassButtonVariant
 import `in`.jphe.storyvox.ui.theme.LocalReducedMotion
@@ -184,6 +193,15 @@ fun ChatScreen(
                 }
             }
 
+            // Issue #215 — info banner shown when the just-sent message
+            // had an image attached but the active provider couldn't
+            // take it. Text-only request still went through; banner
+            // dismisses on next send or on tap-x.
+            if (state.imageDroppedWarning) {
+                ImageDroppedBanner(
+                    onDismiss = viewModel::dismissImageDroppedWarning,
+                )
+            }
             state.error?.let { err ->
                 ErrorBanner(
                     error = err,
@@ -198,6 +216,13 @@ fun ChatScreen(
                     onSend = viewModel::send,
                     prefill = prefill,
                     onPrefillConsumed = viewModel::consumePrefill,
+                    // Issue #215 — image-picker plumbing. The composer
+                    // owns picker launch; the VM owns encoding +
+                    // attach/detach state.
+                    imagesSupported = state.imagesSupported,
+                    pendingImage = state.pendingImage,
+                    onAttachImage = viewModel::attachImage,
+                    onClearImage = viewModel::clearPendingImage,
                 )
             }
         }
@@ -237,11 +262,33 @@ private fun TurnBubble(
                 .background(containerColor, RoundedCornerShape(12.dp))
                 .padding(horizontal = 12.dp, vertical = 8.dp),
         ) {
-            Text(
-                text = turn.text,
-                style = MaterialTheme.typography.bodyMedium,
-                color = textColor,
-            )
+            Column(verticalArrangement = Arrangement.spacedBy(6.dp)) {
+                // Issue #215 — inline image preview on user turns
+                // that were sent with an attachment. The 200dp max
+                // width sits comfortably inside the 320dp bubble
+                // even on the narrowest phone widths.
+                turn.imageUri?.let { uri ->
+                    coil.compose.AsyncImage(
+                        model = uri,
+                        contentDescription = "Attached image",
+                        modifier = Modifier
+                            .widthIn(max = 200.dp)
+                            .heightIn(max = 200.dp)
+                            .background(
+                                MaterialTheme.colorScheme.surface,
+                                RoundedCornerShape(8.dp),
+                            ),
+                        contentScale = androidx.compose.ui.layout.ContentScale.Fit,
+                    )
+                }
+                if (turn.text.isNotBlank()) {
+                    Text(
+                        text = turn.text,
+                        style = MaterialTheme.typography.bodyMedium,
+                        color = textColor,
+                    )
+                }
+            }
         }
         // Issue #214 — assistant turns get a Read-aloud / Stop
         // affordance below the bubble. Hidden on user turns (no point
@@ -525,9 +572,24 @@ private fun ChatInput(
      *  [onPrefillConsumed] so the VM clears the latch. */
     prefill: String? = null,
     onPrefillConsumed: () -> Unit = {},
+    /** Issue #215 — true when the active provider accepts image
+     *  content. Gates the attach button's visibility. */
+    imagesSupported: Boolean = false,
+    /** Issue #215 — image queued for the next send, or null. When
+     *  non-null, the thumbnail preview row is shown. */
+    pendingImage: ImageAttachment? = null,
+    /** Issue #215 — called with a freshly-resized + encoded image
+     *  after the user picks a file through the SAF picker. */
+    onAttachImage: (ImageAttachment) -> Unit = {},
+    /** Issue #215 — called when the user taps the x on the
+     *  thumbnail preview to detach without sending. */
+    onClearImage: () -> Unit = {},
 ) {
     val spacing = LocalSpacing.current
+    val context = androidx.compose.ui.platform.LocalContext.current
+    val scope = androidx.compose.runtime.rememberCoroutineScope()
     var text by remember { mutableStateOf("") }
+    var picking by remember { mutableStateOf(false) }
 
     LaunchedEffect(prefill) {
         if (!prefill.isNullOrBlank()) {
@@ -536,8 +598,48 @@ private fun ChatInput(
         }
     }
 
+    // Issue #215 — SAF picker for image attachment. OpenDocument
+    // returns a content:// URI; we open the InputStream off-main,
+    // hand the bytes to ImageResizer for downscale + JPEG-encode,
+    // and stuff the result onto the composer state. The picking
+    // boolean disables the send/attach affordances while the bytes
+    // are being processed so the user can't fire two encodes at once.
+    val imagePicker = androidx.activity.compose.rememberLauncherForActivityResult(
+        contract = androidx.activity.result.contract.ActivityResultContracts.OpenDocument(),
+    ) { uri ->
+        if (uri == null) {
+            picking = false
+            return@rememberLauncherForActivityResult
+        }
+        scope.launch {
+            try {
+                val encoded = withContext(kotlinx.coroutines.Dispatchers.IO) {
+                    val bytes = context.contentResolver.openInputStream(uri)?.use {
+                        it.readBytes()
+                    } ?: throw IllegalArgumentException("Could not read image")
+                    `in`.jphe.storyvox.llm.imaging.ImageResizer.encodeForUpload(bytes)
+                }
+                onAttachImage(
+                    ImageAttachment(
+                        uri = uri.toString(),
+                        base64 = encoded.base64,
+                        mimeType = encoded.mimeType,
+                        widthPx = encoded.widthPx,
+                        heightPx = encoded.heightPx,
+                    ),
+                )
+            } catch (_: Throwable) {
+                // Encoding failed — best effort, no error banner. The
+                // user can simply pick again. A future PR could
+                // surface this via the existing error banner.
+            } finally {
+                picking = false
+            }
+        }
+    }
+
     androidx.compose.foundation.layout.Column(modifier = Modifier.fillMaxWidth()) {
-        if (enabled && text.isBlank()) {
+        if (enabled && text.isBlank() && pendingImage == null) {
             androidx.compose.foundation.layout.FlowRow(
                 modifier = Modifier
                     .fillMaxWidth()
@@ -553,6 +655,64 @@ private fun ChatInput(
                 }
             }
         }
+        // Issue #215 — thumbnail preview row above the text input.
+        // Compact (64dp) so it leaves room for the composer; tap-the-x
+        // detaches without sending.
+        pendingImage?.let { img ->
+            Row(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(horizontal = spacing.md, vertical = spacing.xs),
+                verticalAlignment = Alignment.CenterVertically,
+                horizontalArrangement = Arrangement.spacedBy(spacing.sm),
+            ) {
+                Box(
+                    modifier = Modifier
+                        .size(64.dp)
+                        .clip(RoundedCornerShape(8.dp))
+                        .background(MaterialTheme.colorScheme.surfaceVariant),
+                ) {
+                    coil.compose.AsyncImage(
+                        model = img.uri,
+                        contentDescription = "Attached image preview",
+                        modifier = Modifier.fillMaxSize(),
+                        contentScale = androidx.compose.ui.layout.ContentScale.Crop,
+                    )
+                    // x affordance bottom-right of the thumbnail.
+                    Box(
+                        modifier = Modifier
+                            .align(Alignment.TopEnd)
+                            .padding(2.dp)
+                            .size(20.dp)
+                            .background(
+                                MaterialTheme.colorScheme.surface.copy(alpha = 0.85f),
+                                CircleShape,
+                            )
+                            .clickable { onClearImage() },
+                        contentAlignment = Alignment.Center,
+                    ) {
+                        Icon(
+                            Icons.Outlined.Close,
+                            contentDescription = "Remove image",
+                            modifier = Modifier.size(14.dp),
+                            tint = MaterialTheme.colorScheme.onSurface,
+                        )
+                    }
+                }
+                Column(modifier = Modifier.weight(1f)) {
+                    Text(
+                        text = "Image attached",
+                        style = MaterialTheme.typography.labelMedium,
+                        color = MaterialTheme.colorScheme.onSurface,
+                    )
+                    Text(
+                        text = "${img.widthPx} × ${img.heightPx}",
+                        style = MaterialTheme.typography.labelSmall,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    )
+                }
+            }
+        }
         Row(
             modifier = Modifier
                 .fillMaxWidth()
@@ -560,6 +720,28 @@ private fun ChatInput(
             verticalAlignment = Alignment.CenterVertically,
             horizontalArrangement = Arrangement.spacedBy(spacing.sm),
         ) {
+            // Issue #215 — attach button. Only rendered when the
+            // active provider can actually use the image; otherwise
+            // the chat composer behaves identically to pre-#215.
+            if (imagesSupported) {
+                IconButton(
+                    onClick = {
+                        picking = true
+                        imagePicker.launch(arrayOf("image/*"))
+                    },
+                    enabled = enabled && !picking && pendingImage == null,
+                ) {
+                    Icon(
+                        imageVector = Icons.Outlined.AddPhotoAlternate,
+                        contentDescription = "Attach image",
+                        tint = if (enabled && !picking && pendingImage == null) {
+                            MaterialTheme.colorScheme.primary
+                        } else {
+                            MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.38f)
+                        },
+                    )
+                }
+            }
             OutlinedTextField(
                 value = text,
                 onValueChange = { text = it },
@@ -572,23 +754,63 @@ private fun ChatInput(
             IconButton(
                 onClick = {
                     val toSend = text.trim()
-                    if (toSend.isNotEmpty()) {
+                    // Issue #215 — allow a send with an image even if
+                    // the text is empty ("describe this image" UX).
+                    if (toSend.isNotEmpty() || pendingImage != null) {
                         onSend(toSend)
                         text = ""
                     }
                 },
-                enabled = enabled && text.isNotBlank(),
+                enabled = enabled && (text.isNotBlank() || pendingImage != null),
             ) {
+                val sendEnabled = enabled && (text.isNotBlank() || pendingImage != null)
                 Icon(
                     Icons.AutoMirrored.Filled.Send,
                     contentDescription = "Send",
-                    tint = if (enabled && text.isNotBlank()) {
+                    tint = if (sendEnabled) {
                         MaterialTheme.colorScheme.primary
                     } else {
                         MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.38f)
                     },
                 )
             }
+        }
+    }
+}
+
+/** Issue #215 — info banner explaining that the image was dropped
+ *  because the active provider doesn't accept images. Uses the
+ *  surfaceVariant colour rather than errorContainer because the
+ *  message did still send — this is a "fyi" not a "fail". */
+@Composable
+private fun ImageDroppedBanner(onDismiss: () -> Unit) {
+    val spacing = LocalSpacing.current
+    Row(
+        modifier = Modifier
+            .fillMaxWidth()
+            .background(MaterialTheme.colorScheme.surfaceVariant)
+            .padding(horizontal = spacing.md, vertical = spacing.sm),
+        verticalAlignment = Alignment.CenterVertically,
+        horizontalArrangement = Arrangement.spacedBy(spacing.sm),
+    ) {
+        Icon(
+            Icons.Outlined.Image,
+            contentDescription = null,
+            tint = MaterialTheme.colorScheme.onSurfaceVariant,
+        )
+        Text(
+            text = "Image input not supported on this provider — " +
+                "ignoring attached image, sending text only.",
+            style = MaterialTheme.typography.bodySmall,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+            modifier = Modifier.weight(1f),
+        )
+        IconButton(onClick = onDismiss) {
+            Icon(
+                Icons.Outlined.Close,
+                contentDescription = "Dismiss",
+                tint = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
         }
     }
 }

--- a/feature/src/main/kotlin/in/jphe/storyvox/feature/chat/ChatViewModel.kt
+++ b/feature/src/main/kotlin/in/jphe/storyvox/feature/chat/ChatViewModel.kt
@@ -18,6 +18,7 @@ import `in`.jphe.storyvox.feature.chat.memory.FictionMemoryExtractor
 import `in`.jphe.storyvox.feature.chat.tools.ChatToolHandlers
 import `in`.jphe.storyvox.llm.FeatureKind
 import `in`.jphe.storyvox.llm.LlmConfig
+import `in`.jphe.storyvox.llm.LlmContentBlock
 import `in`.jphe.storyvox.llm.LlmError
 import `in`.jphe.storyvox.llm.LlmMessage
 import `in`.jphe.storyvox.llm.LlmRepository
@@ -54,9 +55,28 @@ import kotlinx.coroutines.launch
 data class ChatTurn(
     val role: Role,
     val text: String,
+    /** Issue #215 — non-null for user turns sent with an inline image.
+     *  Carries the original content:// URI so the bubble can render
+     *  a thumbnail via Coil. Ephemeral — only set on freshly-sent
+     *  turns; on rehydration from Room (where image bytes don't
+     *  survive) this stays null. */
+    val imageUri: String? = null,
 ) {
     enum class Role { User, Assistant }
 }
+
+/** Issue #215 — image queued by the composer for the next send.
+ *  Holds both the source URI (for thumbnail rendering) and the
+ *  base64-encoded JPEG (for the LLM request). After send, both are
+ *  cleared. */
+@Immutable
+data class ImageAttachment(
+    val uri: String,
+    val base64: String,
+    val mimeType: String,
+    val widthPx: Int,
+    val heightPx: Int,
+)
 
 /** Top-level UI state. Fields are independently observable so a token
  *  arriving doesn't reflow the whole list (Compose only diffs the
@@ -98,6 +118,20 @@ data class ChatUiState(
      *  When false the model's catalog stays empty; the chat behaves
      *  identically to pre-#216. */
     val actionsAvailable: Boolean = false,
+    /** Issue #215 — true iff the active provider accepts inline
+     *  image content. The chat composer hides the attach button when
+     *  false (and the [pendingImage] state stays null too). */
+    val imagesSupported: Boolean = false,
+    /** Issue #215 — image queued by the composer for the next send,
+     *  or null when no image is attached. Cleared on send (success
+     *  or failure) and on explicit detach via [clearPendingImage]. */
+    val pendingImage: ImageAttachment? = null,
+    /** Issue #215 — set when the user attached an image to a send
+     *  that landed on a provider that doesn't accept images. The
+     *  text portion of the message still went through; the image was
+     *  dropped. UI surfaces this as a one-shot info banner that
+     *  dismisses on the next send. */
+    val imageDroppedWarning: Boolean = false,
 )
 
 /** Issue #217 — debug overlay metric for cross-fiction memory. The
@@ -120,11 +154,13 @@ sealed class ChatNavEvent {
     data object OpenVoiceLibrary : ChatNavEvent()
 }
 
-/** Internal helper for combine — pairs together the two provider-
+/** Internal helper for combine — pairs together the three provider-
  *  dependent booleans so the 5-arg combine still fits. */
 private data class ProviderInfo(
     val noProvider: Boolean,
     val actionsAvailable: Boolean,
+    /** Issue #215 — image support gates the composer's attach button. */
+    val imagesSupported: Boolean,
 )
 
 /** UI-side classification of [LlmError] so the screen can pick the
@@ -250,6 +286,25 @@ class ChatViewModel @Inject constructor(
      *  events arrive on the chat-with-tools flow. */
     private val _toolCalls = MutableStateFlow<List<ToolCallEvent>>(emptyList())
 
+    /** Issue #215 — image queued by the composer for the next send.
+     *  See [attachImage] / [clearPendingImage]. Cleared automatically
+     *  on send so the next message doesn't accidentally re-attach. */
+    private val _pendingImage = MutableStateFlow<ImageAttachment?>(null)
+
+    /** Issue #215 — one-shot warning banner when a send dropped its
+     *  attached image because the active provider doesn't support
+     *  images. Cleared on the next send or via [dismissError]. */
+    private val _imageDropped = MutableStateFlow(false)
+
+    /** Issue #215 — map of `sentText -> imageUri` for the user turns
+     *  this session sent with an attached image. Populated on send,
+     *  read at observation time to overlay onto the matching
+     *  [ChatTurn]. Ephemeral — process restart loses the map and the
+     *  turn renders text-only (the bytes don't survive either; this
+     *  matches the v1 "single-image-per-message, single-session"
+     *  scope). */
+    private val _imageUriByText = MutableStateFlow<Map<String, String>>(emptyMap())
+
     /** Issue #216 — one-shot navigation events fired by the
      *  open_voice_library tool handler. ChatScreen collects this
      *  with `lifecycle.repeatOnLifecycle(...)` and navigates on each
@@ -270,8 +325,20 @@ class ChatViewModel @Inject constructor(
      *  + cross-fiction memory + tool-call timeline + actions
      *  availability. */
     val uiState: StateFlow<ChatUiState> = run {
-        val base = combine(
+        val turnsWithImages = combine(
             sessionRepo.observeMessages(sessionId).map { msgs -> msgs.map { it.toTurn() } },
+            _imageUriByText,
+        ) { turns, imageMap ->
+            if (imageMap.isEmpty()) turns
+            else turns.map { turn ->
+                if (turn.role == ChatTurn.Role.User) {
+                    val uri = imageMap[turn.text]
+                    if (uri != null) turn.copy(imageUri = uri) else turn
+                } else turn
+            }
+        }
+        val base = combine(
+            turnsWithImages,
             _streaming,
             _error,
             fictionRepo.fictionById(fictionId).map { it?.title },
@@ -280,6 +347,9 @@ class ChatViewModel @Inject constructor(
                     noProvider = cfg.provider == null,
                     actionsAvailable = cfg.aiActionsEnabled &&
                         cfg.provider?.let { llmRepo?.supportsTools(it) } == true,
+                    imagesSupported = cfg.provider?.let {
+                        llmRepo?.supportsImages(it)
+                    } == true,
                 )
             },
         ) { turns, streaming, error, title, info ->
@@ -290,13 +360,17 @@ class ChatViewModel @Inject constructor(
                 noProvider = info.noProvider,
                 error = error,
                 actionsAvailable = info.actionsAvailable,
+                imagesSupported = info.imagesSupported,
             )
         }
         val withSecondary = combine(base, _readingText, _memoryDebug) { state, reading, memoryDebug ->
             state.copy(readingText = reading, crossFictionMemoryDebug = memoryDebug)
         }
-        combine(withSecondary, _toolCalls) { state, toolCalls ->
+        val withTertiary = combine(withSecondary, _toolCalls) { state, toolCalls ->
             state.copy(toolCalls = toolCalls)
+        }
+        combine(withTertiary, _pendingImage, _imageDropped) { state, image, dropped ->
+            state.copy(pendingImage = image, imageDroppedWarning = dropped)
         }.stateIn(viewModelScope, SharingStarted.WhileSubscribed(5_000), ChatUiState())
     }
 
@@ -328,6 +402,20 @@ class ChatViewModel @Inject constructor(
         playback.stopSpeaking()
     }
 
+    /** Issue #215 — set the composer's queued image. Called by the
+     *  composable after the SAF picker resolves + the bytes are
+     *  resized + encoded. The image stays queued until the user
+     *  sends the next message or removes it via [clearPendingImage]. */
+    fun attachImage(image: ImageAttachment) {
+        _pendingImage.value = image
+    }
+
+    /** Issue #215 — clear the composer's queued image without
+     *  sending. Used by the x affordance on the thumbnail preview. */
+    fun clearPendingImage() {
+        _pendingImage.value = null
+    }
+
     /** Send [text] as a user turn and stream the assistant reply.
      *  Cancels any in-flight stream first — the user-facing input
      *  is supposed to be disabled while streaming, but the cancel
@@ -343,6 +431,17 @@ class ChatViewModel @Inject constructor(
         sendJob?.cancel()
         _error.value = null
         _toolCalls.value = emptyList()
+        // Issue #215 — clear last send's "image dropped" banner so
+        // it doesn't survive into an unrelated turn.
+        _imageDropped.value = false
+
+        // Issue #215 — snapshot the queued image (if any) and clear
+        // the composer state immediately so a slow send doesn't leave
+        // the thumbnail visible while the next message is composed.
+        // We capture the value here so even if the user re-attaches
+        // another image mid-send, this send's payload is stable.
+        val attached = _pendingImage.value
+        _pendingImage.value = null
 
         sendJob = viewModelScope.launch {
             val cfg = configFlow.first()
@@ -355,6 +454,32 @@ class ChatViewModel @Inject constructor(
             }
 
             ensureSession(cfg, provider)
+
+            // Issue #215 — decide whether the provider can take the
+            // attached image. If the repo says "no", drop the image
+            // and surface the warning banner; the text portion still
+            // goes through.
+            //
+            // When [llmRepo] is null (test-injection path) we treat
+            // "unknown" as "allow" — the providers themselves will
+            // silently ignore image parts if their wire format can't
+            // serialize them, so this is safe.
+            val supportsImages = llmRepo?.supportsImages(provider)
+            val providerAcceptsImages = attached != null &&
+                (supportsImages == true || supportsImages == null)
+            val effectiveImage = if (providerAcceptsImages) attached else null
+            if (attached != null && supportsImages == false) {
+                _imageDropped.value = true
+            }
+            // Stash the URI keyed by sent text so the bubble can show
+            // the thumbnail once the user-turn row arrives via
+            // observeMessages. We keep the keys around for the
+            // session's lifetime (process death clears them, which
+            // is fine — image bytes don't persist either).
+            if (effectiveImage != null) {
+                _imageUriByText.value = _imageUriByText.value +
+                    (trimmed to effectiveImage.uri)
+            }
             // Issue #212 — rebuild the system prompt from the live
             // grounding settings before every send. Lets the user
             // flip a toggle and have the next reply use the new
@@ -405,18 +530,41 @@ class ChatViewModel @Inject constructor(
             val buf = StringBuilder()
             _streaming.value = ""
 
+            // Issue #215 — build the multi-modal content blocks the
+            // session repo will attach to the latest user message.
+            // Image first then text mirrors Anthropic's documented
+            // best practice (the model attends to the image while
+            // reading the question).
+            val userParts: List<LlmContentBlock>? = effectiveImage?.let { img ->
+                listOf(
+                    LlmContentBlock.Image(
+                        base64 = img.base64,
+                        mimeType = img.mimeType,
+                    ),
+                    LlmContentBlock.Text(trimmed),
+                )
+            }
+
             if (actionsEnabled) {
-                streamWithTools(trimmed, buf)
+                streamWithTools(trimmed, buf, userParts)
             } else {
-                streamPlainText(trimmed, buf)
+                streamPlainText(trimmed, buf, userParts)
             }
         }
     }
 
     /** Plain-text streaming path — preserved from pre-#216. Used when
-     *  actions are disabled or the provider doesn't support tool use. */
-    private suspend fun streamPlainText(trimmed: String, buf: StringBuilder) {
-        sessionRepo.chat(sessionId, trimmed)
+     *  actions are disabled or the provider doesn't support tool use.
+     *
+     *  Issue #215 — [userParts], when non-null, carries multi-modal
+     *  content blocks attached to the latest user message; passed
+     *  through to the session repo unchanged. */
+    private suspend fun streamPlainText(
+        trimmed: String,
+        buf: StringBuilder,
+        userParts: List<LlmContentBlock>? = null,
+    ) {
+        sessionRepo.chat(sessionId, trimmed, userParts = userParts)
             .catch { e -> _error.value = mapError(e) }
             .onCompletion { cause ->
                 _streaming.value = null
@@ -433,8 +581,15 @@ class ChatViewModel @Inject constructor(
     /** Issue #216 — tool-aware path. Same persistence + memory-extract
      *  contract as [streamPlainText] but consumes [ChatStreamEvent]
      *  emits, routing tool-call events into [_toolCalls] for the UI to
-     *  render alongside the streaming bubble. */
-    private suspend fun streamWithTools(trimmed: String, buf: StringBuilder) {
+     *  render alongside the streaming bubble.
+     *
+     *  Issue #215 — [userParts] threads through the same image
+     *  attachment path as [streamPlainText]. */
+    private suspend fun streamWithTools(
+        trimmed: String,
+        buf: StringBuilder,
+        userParts: List<LlmContentBlock>? = null,
+    ) {
         val handlers = ChatToolHandlers(
             activeFictionId = fictionId,
             shelfRepo = shelfRepo!!,
@@ -446,7 +601,12 @@ class ChatViewModel @Inject constructor(
                 _navEvents.tryEmit(ChatNavEvent.OpenVoiceLibrary)
             },
         )
-        sessionRepo.chatWithTools(sessionId, trimmed, handlers.registry())
+        sessionRepo.chatWithTools(
+            sessionId = sessionId,
+            userMessage = trimmed,
+            tools = handlers.registry(),
+            userParts = userParts,
+        )
             .catch { e -> _error.value = mapError(e) }
             .onCompletion { cause ->
                 _streaming.value = null
@@ -519,6 +679,9 @@ class ChatViewModel @Inject constructor(
 
     /** Dismiss an error banner. Used by the UI's "X" affordance. */
     fun dismissError() { _error.value = null }
+
+    /** Issue #215 — dismiss the "image dropped" info banner. */
+    fun dismissImageDroppedWarning() { _imageDropped.value = false }
 
     /** Cancel an in-flight stream. The repo persists user turns
      *  immediately but only saves the assistant reply on completion

--- a/feature/src/test/kotlin/in/jphe/storyvox/feature/chat/ChatViewModelTest.kt
+++ b/feature/src/test/kotlin/in/jphe/storyvox/feature/chat/ChatViewModelTest.kt
@@ -323,6 +323,67 @@ class ChatViewModelTest {
             assertEquals("Vin", recorded.first().name)
             assertTrue(recorded.first().summary.contains("Mistborn"))
         }
+
+    // Issue #215 — multi-modal image input composer state.
+
+    @Test
+    fun `attachImage sets pending image and clearPendingImage removes it`() =
+        runTest(dispatcher) {
+            val (vm, _, _) = makeViewModel()
+            collectUiState(vm)
+            advanceUntilIdle()
+            assertNull(vm.uiState.value.pendingImage)
+
+            val attachment = ImageAttachment(
+                uri = "content://media/picture/123",
+                base64 = "Zm9v",
+                mimeType = "image/jpeg",
+                widthPx = 800,
+                heightPx = 600,
+            )
+            vm.attachImage(attachment)
+            advanceUntilIdle()
+            assertEquals(attachment, vm.uiState.value.pendingImage)
+
+            vm.clearPendingImage()
+            advanceUntilIdle()
+            assertNull(vm.uiState.value.pendingImage)
+        }
+
+    @Test
+    fun `send clears pending image and the next turn carries the URI`() =
+        runTest(dispatcher) {
+            val session = FakeSessionRepo(tokens = listOf("I see a cat."))
+            val (vm, _, _) = makeViewModel(session = session)
+            collectUiState(vm)
+            advanceUntilIdle()
+
+            val attachment = ImageAttachment(
+                uri = "content://media/picture/456",
+                base64 = "Zm9v",
+                mimeType = "image/jpeg",
+                widthPx = 1280,
+                heightPx = 720,
+            )
+            vm.attachImage(attachment)
+            vm.send("what's in this photo?")
+            advanceUntilIdle()
+
+            // The composer state cleared on send.
+            assertNull(vm.uiState.value.pendingImage)
+
+            // The user turn (most-recently appended) picks up the URI
+            // via the in-memory keyed-by-text overlay.
+            val userTurns = vm.uiState.value.turns.filter {
+                it.role == ChatTurn.Role.User
+            }
+            assertEquals(1, userTurns.size)
+            assertEquals("what's in this photo?", userTurns.first().text)
+            assertEquals(
+                "content://media/picture/456",
+                userTurns.first().imageUri,
+            )
+        }
 }
 
 // ── Fakes ──────────────────────────────────────────────────────────
@@ -370,7 +431,11 @@ private class FakeSessionRepo(
         lastSystemPrompt = systemPrompt
     }
 
-    override fun chat(sessionId: String, userMessage: String): Flow<String> = flow {
+    override fun chat(
+        sessionId: String,
+        userMessage: String,
+        userParts: List<`in`.jphe.storyvox.llm.LlmContentBlock>?,
+    ): Flow<String> = flow {
         chatCalls += sessionId to userMessage
         // Persist the user turn synchronously, mirroring real repo
         // behaviour ("user msg saved before stream begins").


### PR DESCRIPTION
## Summary

- Adds an attach-image button to the AI chat composer. Tap → SAF
  picker → image is downscaled to 1280px long edge + JPEG-encoded
  q=85 + base64'd, then attached to the next `send`.
- `:core-llm` gains `LlmContentBlock` (sealed `Text` / `Image`),
  a per-provider serializer (`ContentBlocks.anthropic` / `.openAi`),
  and `LlmProvider.supportsImages` capability flag (Claude direct,
  Claude Teams, and OpenAI return `true`; everyone else `false`).
- Unsupported providers silently drop the image parts at the
  provider level and the chat layer shows a one-shot info banner.

## Provider coverage

| Provider | Multi-modal in this PR | Wire shape |
|---|---|---|
| Anthropic (Claude direct) | yes | `{type:\"image\", source:{type:\"base64\", media_type, data}}` |
| Anthropic Teams (OAuth) | yes | same as Claude direct |
| OpenAI | yes | `{type:\"image_url\", image_url:{url:\"data:<mt>;base64,...\"}}` |
| Vertex / Gemini | text-only fallback (info banner) | parts dropped |
| Bedrock | text-only fallback | parts dropped |
| Azure Foundry | text-only fallback | parts dropped |
| Ollama | text-only fallback | parts dropped |

Image resize cap: 1280px long edge, JPEG q=85 — same downscale
pattern as the screenshot-compress hook. Keeps payload under
~500 KB to dodge oversized-image 400s on Claude (related to
anthropic-claude#59095 upstream).

## Tests added (8)

- `ContentBlocksTest` — Anthropic + OpenAI JSON shape snapshots.
- `ClaudeImageRequestTest` — end-to-end MockWebServer test verifying
  typed-block array shape on image sends, string-content shape on
  text-only sends.
- `OpenAiImageRequestTest` — same coverage on the `image_url` data-URI shape.
- `ImageResizerTest` — `1080×2640 → 523×1280`, `4032×3024 → 1280×960`,
  pass-through under cap, `computeInSampleSize` power-of-two math,
  base64 round-trip.
- `ChatViewModelTest` (2 new cases) — attach/detach state transitions,
  send-clears-pending-image + URI overlay onto the user turn.

## Test plan

- [ ] CI green on `:app:assembleDebug`, `:app:testDebugUnitTest`,
  `:feature:testDebugUnitTest`, `:core-llm:testDebugUnitTest`.
- [ ] Install on tablet R83W80CAFZB. Open AI chat for a fiction.
  Pick Anthropic provider in Settings → AI.
- [ ] Tap new attach button → pick any image from device. Verify
  thumbnail appears above the composer. Tap x → thumbnail clears.
- [ ] Pick image, type "what do you see?", send. Verify the AI reply
  references image content + the image renders inline in the user
  bubble.
- [ ] Switch provider to Ollama or Vertex; attach image, send. Verify
  the "Image input not supported on this provider — sending text only"
  banner appears and the text still went through.
- [ ] Send a text-only message after — verify the previous send's
  banner clears.

## Notes / trade-offs

- **DB persistence**: image bytes don't persist to Room — only the
  text portion of the user message survives a process restart. The
  inline thumbnail is gated by an in-memory `text -> URI` map that's
  also lost on restart. This matches the spec's v1 ephemeral scope
  and keeps the schema simple; a future PR can add a
  `LlmStoredMessageAttachment` table when full multi-modal history
  becomes a need.
- **Single image per message** in v1 (as specified). The block list
  is already a `List<LlmContentBlock>` so multi-attachment
  composition slots in without a schema change.
- **`LlmMessage.parts`** uses `@Transient` so the existing wire
  serialization model stays text-only-stable; providers explicitly
  walk `parts` when they want the multi-modal shape, so old
  serialization paths (Room storage, recap history, etc.) are
  unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)