### PR TITLE
fix(milestone): close v0.5.00 celebration window after v0.5.5 — closes #435 #439

### DIFF
--- a/app/src/main/kotlin/in/jphe/storyvox/sigil/Milestone.kt
+++ b/app/src/main/kotlin/in/jphe/storyvox/sigil/Milestone.kt
@@ -30,21 +30,34 @@ object Milestone {
     /** First version that qualifies for the v0.5.00 celebration. */
     private val V0500 = Triple(0, 5, 0)
 
-    /** True when the current build's [BuildConfig.VERSION_NAME] is
-     *  greater than or equal to the v0.5.00 threshold. Cached for the
-     *  process lifetime — VERSION_NAME doesn't change at runtime. */
+    /** Last version that qualifies for the v0.5.00 celebration. The
+     *  dialog is a "we crossed 0.5.0 together" moment — users who
+     *  install fresh on later builds didn't experience the crossing,
+     *  so the celebration window closes after v0.5.5. (#439 reported
+     *  the dialog firing on a fresh install of v0.5.36; the headline
+     *  still said "storyvox 0.5.00", which read as a dead placeholder.
+     *  Closing the window means fresh installers past v0.5.5 silently
+     *  never see it; users who already dismissed it stay dismissed.) */
+    private val V0500_WINDOW_END = Triple(0, 5, 5)
+
+    /** True when the current build's [BuildConfig.VERSION_NAME] falls
+     *  inside the v0.5.00 celebration window. Cached for the process
+     *  lifetime — VERSION_NAME doesn't change at runtime. */
     val isV0500OrLater: Boolean by lazy {
         qualifies(BuildConfig.VERSION_NAME)
     }
 
     /** Visible for testing — parse + compare without touching
-     *  BuildConfig. Returns false on any parse failure. */
+     *  BuildConfig. Returns false on any parse failure OR when the
+     *  build is past the celebration window. */
     internal fun qualifies(versionName: String): Boolean {
         val parts = versionName.split('.', '-', '+')
         val major = parts.getOrNull(0)?.toIntOrNull() ?: return false
         val minor = parts.getOrNull(1)?.toIntOrNull() ?: 0
         val patch = parts.getOrNull(2)?.toIntOrNull() ?: 0
-        return compareTriple(Triple(major, minor, patch), V0500) >= 0
+        val triple = Triple(major, minor, patch)
+        return compareTriple(triple, V0500) >= 0 &&
+            compareTriple(triple, V0500_WINDOW_END) <= 0
     }
 
     private fun compareTriple(a: Triple<Int, Int, Int>, b: Triple<Int, Int, Int>): Int {

--- a/app/src/test/kotlin/in/jphe/storyvox/sigil/MilestoneTest.kt
+++ b/app/src/test/kotlin/in/jphe/storyvox/sigil/MilestoneTest.kt
@@ -16,19 +16,23 @@ class MilestoneTest {
         assertTrue(Milestone.qualifies("0.5.00"))
     }
 
-    @Test fun `qualifies returns true for newer patch`() {
+    @Test fun `qualifies returns true for newer patch inside the window`() {
         assertTrue(Milestone.qualifies("0.5.1"))
-        assertTrue(Milestone.qualifies("0.5.17"))
+        assertTrue(Milestone.qualifies("0.5.5"))
     }
 
-    @Test fun `qualifies returns true for newer minor`() {
-        assertTrue(Milestone.qualifies("0.6.0"))
-        assertTrue(Milestone.qualifies("0.10.0"))
-    }
-
-    @Test fun `qualifies returns true for newer major`() {
-        assertTrue(Milestone.qualifies("1.0.0"))
-        assertTrue(Milestone.qualifies("2.3.4"))
+    // #439 — celebration window closes after v0.5.5. Anyone fresh-
+    // installing on a later build never lived through the crossing,
+    // so the dialog (which says "storyvox 0.5.00") would read as a
+    // dead placeholder. Window-end bound silently retires the dialog
+    // for fresh installs on later builds.
+    @Test fun `qualifies returns false past the celebration window`() {
+        assertFalse(Milestone.qualifies("0.5.17"))
+        assertFalse(Milestone.qualifies("0.5.36"))
+        assertFalse(Milestone.qualifies("0.6.0"))
+        assertFalse(Milestone.qualifies("0.10.0"))
+        assertFalse(Milestone.qualifies("1.0.0"))
+        assertFalse(Milestone.qualifies("2.3.4"))
     }
 
     @Test fun `qualifies returns false for prior v0_4_x`() {
@@ -43,7 +47,7 @@ class MilestoneTest {
 
     @Test fun `qualifies tolerates two-part version names`() {
         assertTrue(Milestone.qualifies("0.5"))
-        assertTrue(Milestone.qualifies("1.0"))
+        assertFalse(Milestone.qualifies("1.0")) // past window end
         assertFalse(Milestone.qualifies("0.4"))
     }
 


### PR DESCRIPTION
## Summary
- `Milestone.qualifies()` now has an upper bound — the v0.5.00 celebration window is `[v0.5.00, v0.5.5]`. Fresh installers past v0.5.5 silently never see the milestone dialog.
- Users who installed during the window saw the dialog once + dismissed it; their `KEY_V0500_MILESTONE_SEEN` flag is already persisted and the upper bound doesn't regress them.
- Closes #435 (the "storyvox 0.5.00" welcome card a fresh v0.5.36 user saw was the v0.5.00 milestone dialog firing in stale-state).
- Closes #439 (the About-page hardcoded version reference is intentional design — celebrates crossing v0.5.0 as a historical mark. Decision documented in commit body. Re-open as a copy revision if that reading is wrong now that fresh users never see the dialog itself.)

## Test plan
- [x] `./gradlew :app:testDebugUnitTest --tests "*MilestoneTest*"` — green (4 updated cases)
- [ ] Tablet: fresh install of next release — onboarding shows current version, no "storyvox 0.5.00" splash

🤖 Generated with [Claude Code](https://claude.com/claude-code)