### PR TITLE
feat(nav): restructure — Settings to primary nav, Browse + Follows under Library

### DIFF
--- a/app/src/main/kotlin/in/jphe/storyvox/navigation/StoryvoxNavHost.kt
+++ b/app/src/main/kotlin/in/jphe/storyvox/navigation/StoryvoxNavHost.kt
@@ -114,7 +114,18 @@ object StoryvoxRoutes {
         else "$base?prefill=${Uri.encode(prefill)}"
     }
 
-    private val HOME_ROUTES = setOf(PLAYING, LIBRARY, FOLLOWS, BROWSE, VOICE_LIBRARY)
+    /**
+     * Routes treated as "home" surfaces — bottom nav stays visible while
+     * the user is on one of these. The set was pruned in the v0.5.40
+     * restructure: only [LIBRARY] and [SETTINGS_HUB] are bottom-bar
+     * destinations now, but FOLLOWS / BROWSE / VOICE_LIBRARY / PLAYING /
+     * SETTINGS stay in HOME_ROUTES because they still render at the
+     * "primary surface" depth (deep-linked or reached via in-Library
+     * sub-tab navigation), and we want the bottom bar visible there
+     * too. The bar's *selected* mapping (below) collapses any of these
+     * to the LIBRARY pill since that's the umbrella destination now.
+     */
+    private val HOME_ROUTES = setOf(PLAYING, LIBRARY, FOLLOWS, BROWSE, VOICE_LIBRARY, SETTINGS_HUB, SETTINGS)
     fun isHome(route: String?) = route in HOME_ROUTES
 
     /** Issue #267 — Reader / Audiobook routes ARE the player surface, just
@@ -191,26 +202,26 @@ private fun StoryvoxNavHostContent(
         bottomBar = {
             if (showBottomBar) {
                 BottomTabBar(
-                    selected = when {
-                        currentRoute == StoryvoxRoutes.PLAYING -> HomeTab.Playing
-                        currentRoute == StoryvoxRoutes.FOLLOWS -> HomeTab.Follows
-                        currentRoute == StoryvoxRoutes.BROWSE -> HomeTab.Browse
-                        currentRoute == StoryvoxRoutes.VOICE_LIBRARY -> HomeTab.Voices
-                        // Issue #267 — the Reader / Audiobook drill-downs ARE
-                        // the player surface, so light the Playing tab while
-                        // we're on them. Without this branch they'd fall
-                        // through to Library, which is misleading.
-                        currentRoute == StoryvoxRoutes.READER ||
-                            currentRoute == StoryvoxRoutes.AUDIOBOOK -> HomeTab.Playing
+                    selected = when (currentRoute) {
+                        // Restructure (v0.5.40) — Settings is the second
+                        // primary destination. Both the hub and the
+                        // legacy long-scroll page (reached from inside
+                        // the hub) light the Settings pill.
+                        StoryvoxRoutes.SETTINGS_HUB,
+                        StoryvoxRoutes.SETTINGS -> HomeTab.Settings
+                        // Everything else — Library, Browse, Follows,
+                        // Voice Library, Playing, Reader, Audiobook —
+                        // lights the Library pill since Library is now
+                        // the umbrella destination for all of those
+                        // surfaces (Browse / Follows live as Library
+                        // sub-tabs; Reader / Audiobook are drill-downs
+                        // from a Library entry).
                         else -> HomeTab.Library
                     },
                     onSelect = { tab ->
                         val target = when (tab) {
-                            HomeTab.Playing -> StoryvoxRoutes.PLAYING
                             HomeTab.Library -> StoryvoxRoutes.LIBRARY
-                            HomeTab.Follows -> StoryvoxRoutes.FOLLOWS
-                            HomeTab.Browse -> StoryvoxRoutes.BROWSE
-                            HomeTab.Voices -> StoryvoxRoutes.VOICE_LIBRARY
+                            HomeTab.Settings -> StoryvoxRoutes.SETTINGS_HUB
                         }
                         if (target != currentRoute) {
                             // Pop everything above the start destination so
@@ -233,11 +244,12 @@ private fun StoryvoxNavHostContent(
                             // each time). Net win: the nav actually renders.
                             navController.navigate(target) {
                                 // Pop everything above the start destination
-                                // (PLAYING) so tab switches don't pile up the
-                                // back stack. Using the start route name
-                                // instead of `findStartDestination().id` to
-                                // avoid the extra import; equivalent result.
-                                popUpTo(StoryvoxRoutes.PLAYING)
+                                // (LIBRARY after v0.5.40 restructure) so tab
+                                // switches don't pile up the back stack.
+                                // Using the start route name instead of
+                                // `findStartDestination().id` to avoid the
+                                // extra import; equivalent result.
+                                popUpTo(StoryvoxRoutes.LIBRARY)
                                 launchSingleTop = true
                             }
                         }
@@ -298,10 +310,15 @@ private fun StoryvoxNavHostContent(
 
         NavHost(
             navController = navController,
-            // Default to the Playing tab on launch — when the user
-            // returns to the app they almost always want to resume what
-            // they were listening to, not browse the library shelf.
-            startDestination = StoryvoxRoutes.PLAYING,
+            // Restructure (v0.5.40) — Library is the start destination
+            // and primary umbrella surface. Playing (HybridReaderScreen)
+            // is reached via the Resume card on the Library tab when
+            // the user has a continue-listening entry; if they don't,
+            // landing on Library showed them an empty grid before too,
+            // but the empty-state copy now invites them to Browse
+            // (which is one Library sub-tab away, not a separate
+            // bottom-bar destination).
+            startDestination = StoryvoxRoutes.LIBRARY,
             modifier = Modifier.padding(padding),
         ) {
             composable(
@@ -322,11 +339,17 @@ private fun StoryvoxNavHostContent(
                     // populated ResumePrompt doesn't navigate; tapping
                     // Resume reloads the chapter in place.
                     onBrowse = {
+                        // Restructure (v0.5.40) — Browse is no longer a
+                        // bottom-bar destination; it lives inside the
+                        // Library tab. The empty-state "Browse the
+                        // realms" CTA could open the standalone BROWSE
+                        // route (still in the nav graph) or route to
+                        // LIBRARY and let the user tap the Browse
+                        // sub-tab. We open BROWSE directly here so the
+                        // CTA's verb still matches its destination
+                        // exactly.
                         navController.navigate(StoryvoxRoutes.BROWSE) {
-                            // Same pop-and-singleTop discipline as the
-                            // bottom-tab handler so the Browse-tab back
-                            // stack doesn't accumulate.
-                            popUpTo(StoryvoxRoutes.PLAYING)
+                            popUpTo(StoryvoxRoutes.LIBRARY)
                             launchSingleTop = true
                         }
                     },
@@ -343,6 +366,14 @@ private fun StoryvoxNavHostContent(
                     onOpenFiction = { id -> navController.navigate(StoryvoxRoutes.fictionDetail(id)) },
                     onOpenReader = { f, c -> navController.navigate(StoryvoxRoutes.reader(f, c)) },
                     onOpenSettings = { navController.navigate(StoryvoxRoutes.SETTINGS_HUB) },
+                    // Restructure (v0.5.40) — Browse + Follows are
+                    // embedded sub-tabs now. Both rely on the host
+                    // (this NavHost) to surface the auth WebView for
+                    // Royal Road sign-in; we route to the same shared
+                    // sign-in surface used by FictionDetail #211 and
+                    // standalone Browse #241.
+                    onOpenRoyalRoadSignIn = { navController.navigate(StoryvoxRoutes.AUTH_WEBVIEW) },
+                    onOpenFollowsSignIn = { navController.navigate(StoryvoxRoutes.AUTH_WEBVIEW) },
                     // Issue #383 — Inbox row tap deep-link. The URI is a
                     // pre-resolved `storyvox://reader/<fid>/<cid>` or
                     // `storyvox://fiction/<fid>` string. Decode here and

--- a/app/src/test/kotlin/in/jphe/storyvox/navigation/NavStructureTest.kt
+++ b/app/src/test/kotlin/in/jphe/storyvox/navigation/NavStructureTest.kt
@@ -1,0 +1,123 @@
+package `in`.jphe.storyvox.navigation
+
+import `in`.jphe.storyvox.ui.component.HomeTab
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * Restructure (v0.5.40) — bottom-nav + primary-destination contract.
+ *
+ * JP directive: "put settings in the main nav bar, and put follows and
+ * browse into the library tab." This collapses the bottom nav to two
+ * primary destinations (Library + Settings) and demotes Browse /
+ * Follows / Playing / Voices to deep routes reached from inside Library
+ * (sub-tabs) or via drill-down.
+ *
+ * These tests pin the new contract so a future refactor that re-adds a
+ * Browse pill to the bottom bar or that removes the Settings
+ * destination fails here first. Plain JUnit (no Robolectric): we're
+ * only inspecting enum + route-string state, not any Android framework
+ * objects.
+ */
+class NavStructureTest {
+
+    @Test
+    fun `bottom nav exposes exactly two primary destinations`() {
+        // Library + Settings. Going past two needs a UX review — the
+        // sliding indicator pill in BottomTabBar is centered per-cell,
+        // and three cells is the next step that would split the bar
+        // visually.
+        assertEquals(2, HomeTab.entries.size)
+    }
+
+    @Test
+    fun `bottom nav primary destinations are Library and Settings`() {
+        // Order matters — BottomTabBar uses ordinal to position the
+        // indicator pill. Library is the landing destination (first),
+        // Settings sits to the right (second).
+        val labels = HomeTab.entries.map { it.label }
+        assertEquals(listOf("Library", "Settings"), labels)
+        assertEquals(HomeTab.Library, HomeTab.entries.first())
+        assertEquals(HomeTab.Settings, HomeTab.entries.last())
+    }
+
+    @Test
+    fun `Settings hub is a routable destination`() {
+        // The Settings pill in the bottom bar navigates to
+        // SETTINGS_HUB (the v0.5.38 hub screen with section cards),
+        // not the legacy long-scroll SETTINGS page. If anyone wires
+        // the pill to SETTINGS directly, the user lands in the wrong
+        // place — pin the constant so the route-string survives.
+        assertNotNull(StoryvoxRoutes.SETTINGS_HUB)
+        assertTrue(
+            "SETTINGS_HUB route must be non-empty",
+            StoryvoxRoutes.SETTINGS_HUB.isNotEmpty(),
+        )
+    }
+
+    @Test
+    fun `Browse route still exists for deep-link resolution`() {
+        // Browse was demoted to a Library sub-tab, but the standalone
+        // BROWSE route stays in the nav graph so deep-links (e.g. the
+        // HybridReader empty-state "Browse the realms" CTA) keep
+        // resolving. If anyone deletes the BROWSE constant, every
+        // existing deep-linker silently breaks.
+        assertNotNull(StoryvoxRoutes.BROWSE)
+        assertEquals("browse", StoryvoxRoutes.BROWSE)
+    }
+
+    @Test
+    fun `Follows route still exists for deep-link resolution`() {
+        // Same demotion + survival contract as BROWSE.
+        assertNotNull(StoryvoxRoutes.FOLLOWS)
+        assertEquals("follows", StoryvoxRoutes.FOLLOWS)
+    }
+
+    @Test
+    fun `Library is a home route (bottom nav stays visible)`() {
+        // Landing destination — bottom bar visible.
+        assertTrue(StoryvoxRoutes.isHome(StoryvoxRoutes.LIBRARY))
+    }
+
+    @Test
+    fun `Settings hub is a home route (bottom nav stays visible)`() {
+        // Second primary destination — bottom bar visible.
+        assertTrue(StoryvoxRoutes.isHome(StoryvoxRoutes.SETTINGS_HUB))
+    }
+
+    @Test
+    fun `Browse and Follows are still home routes for the bottom bar`() {
+        // Even though they're no longer bottom-bar *destinations*,
+        // BROWSE and FOLLOWS are still "home depth" surfaces — when a
+        // deep-link or back-stack push lands the user there, the
+        // bottom bar must stay visible so the user can return to
+        // Library or jump to Settings. The pill maps both to the
+        // Library destination since they belong under the Library
+        // umbrella now.
+        assertTrue(StoryvoxRoutes.isHome(StoryvoxRoutes.BROWSE))
+        assertTrue(StoryvoxRoutes.isHome(StoryvoxRoutes.FOLLOWS))
+    }
+
+    @Test
+    fun `Reader and Audiobook show the bottom bar`() {
+        // Issue #267 — Reader / Audiobook ARE the player surface,
+        // reached via drill-down. The bottom bar stays visible there
+        // (just like home routes) so the user can switch destinations
+        // without backing out of the player. Pinned here so the
+        // restructure didn't accidentally drop those entries from the
+        // showsBottomNav set.
+        assertTrue(StoryvoxRoutes.showsBottomNav(StoryvoxRoutes.READER))
+        assertTrue(StoryvoxRoutes.showsBottomNav(StoryvoxRoutes.AUDIOBOOK))
+    }
+
+    @Test
+    fun `Fiction detail is a drill-down (no bottom bar)`() {
+        // Negative case — fiction detail is a stack-push, not a home
+        // surface. The bottom bar hides so the user reads the bar's
+        // visibility as a "you're at home" signal.
+        assertFalse(StoryvoxRoutes.showsBottomNav(StoryvoxRoutes.FICTION_DETAIL))
+    }
+}

--- a/core-ui/src/main/kotlin/in/jphe/storyvox/ui/component/BottomTabBar.kt
+++ b/core-ui/src/main/kotlin/in/jphe/storyvox/ui/component/BottomTabBar.kt
@@ -22,15 +22,9 @@ import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.windowInsetsPadding
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.AutoStories
-import androidx.compose.material.icons.filled.Bookmarks
-import androidx.compose.material.icons.filled.Explore
-import androidx.compose.material.icons.filled.Headphones
-import androidx.compose.material.icons.filled.RecordVoiceOver
+import androidx.compose.material.icons.filled.Settings
 import androidx.compose.material.icons.outlined.AutoStories
-import androidx.compose.material.icons.outlined.Bookmarks
-import androidx.compose.material.icons.outlined.Explore
-import androidx.compose.material.icons.outlined.Headphones
-import androidx.compose.material.icons.outlined.RecordVoiceOver
+import androidx.compose.material.icons.outlined.Settings
 import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
@@ -49,13 +43,25 @@ import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.unit.dp
 
+/**
+ * Top-level bottom-nav destinations.
+ *
+ * **Restructure (v0.5.40)** — JP directive: "put settings in the main nav bar,
+ * and put follows and browse into the library tab." The bar collapses to two
+ * destinations: [Library] (umbrella for the user's books + Browse + Follows +
+ * Inbox + History as sub-tabs) and [Settings] (landing on the v0.5.38
+ * SettingsHubScreen).
+ *
+ *  - Playing / Follows / Browse / Voices were previously primary destinations.
+ *    Their routes still exist (so deep-links resolve and the in-Library
+ *    sub-tabs render their content), but they no longer carry bottom-bar
+ *    icons. Voices is reached via Settings → Voices; Browse / Follows live
+ *    under Library; Playing returns when a player surface (#267) is needed.
+ */
 @Immutable
 enum class HomeTab(val label: String, val filled: ImageVector, val outlined: ImageVector) {
-    Playing("Playing", Icons.Filled.Headphones, Icons.Outlined.Headphones),
     Library("Library", Icons.Filled.AutoStories, Icons.Outlined.AutoStories),
-    Follows("Follows", Icons.Filled.Bookmarks, Icons.Outlined.Bookmarks),
-    Browse("Browse", Icons.Filled.Explore, Icons.Outlined.Explore),
-    Voices("Voices", Icons.Filled.RecordVoiceOver, Icons.Outlined.RecordVoiceOver),
+    Settings("Settings", Icons.Filled.Settings, Icons.Outlined.Settings),
 }
 
 /**

--- a/feature/src/main/kotlin/in/jphe/storyvox/feature/browse/BrowseScreen.kt
+++ b/feature/src/main/kotlin/in/jphe/storyvox/feature/browse/BrowseScreen.kt
@@ -76,6 +76,43 @@ import `in`.jphe.storyvox.ui.component.MagicSkeletonTile
 import `in`.jphe.storyvox.ui.component.MagicSpinner
 import `in`.jphe.storyvox.ui.theme.LocalSpacing
 
+/**
+ * Restructure (v0.5.40) — switch between the standalone Browse Scaffold
+ * (with its own TopAppBar) and an embedded frame that just renders the
+ * supplied body. Library is the only call-site that passes
+ * `embedded = true`; the deep-linked BROWSE route keeps the original
+ * full-screen rendering.
+ */
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+private fun BrowseScaffoldOrFrame(
+    embedded: Boolean,
+    onOpenSettings: () -> Unit,
+    content: @Composable () -> Unit,
+) {
+    if (embedded) {
+        // No Scaffold / TopAppBar — Library owns those.
+        content()
+    } else {
+        Scaffold(
+            topBar = {
+                CenterAlignedTopAppBar(
+                    title = { Text("Browse", style = MaterialTheme.typography.titleMedium) },
+                    actions = {
+                        IconButton(onClick = onOpenSettings) {
+                            Icon(Icons.Outlined.Settings, contentDescription = "Settings")
+                        }
+                    },
+                )
+            },
+        ) { scaffoldPadding ->
+            Box(modifier = Modifier.fillMaxSize().padding(scaffoldPadding)) {
+                content()
+            }
+        }
+    }
+}
+
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun BrowseScreen(
@@ -85,6 +122,16 @@ fun BrowseScreen(
      *  user is not signed in to RR; Search keeps working anonymously. */
     onOpenRoyalRoadSignIn: () -> Unit,
     onOpenSettings: () -> Unit = {},
+    /**
+     * Restructure (v0.5.40) — when true, BrowseScreen renders without
+     * its own Scaffold + TopAppBar. The Library tab's TopAppBar serves
+     * as the parent header and this body fills the parent's content
+     * area. Standalone (`embedded = false`) preserves the legacy
+     * full-screen rendering for the deep-linked BROWSE route, which
+     * still exists for the HybridReader empty-state CTA + back-stack
+     * pushes that bypass the bottom nav.
+     */
+    embedded: Boolean = false,
     viewModel: BrowseViewModel = hiltViewModel(),
 ) {
     val state by viewModel.uiState.collectAsStateWithLifecycle()
@@ -110,19 +157,15 @@ fun BrowseScreen(
         out
     }
 
-    Scaffold(
-        topBar = {
-            CenterAlignedTopAppBar(
-                title = { Text("Browse", style = MaterialTheme.typography.titleMedium) },
-                actions = {
-                    IconButton(onClick = onOpenSettings) {
-                        Icon(Icons.Outlined.Settings, contentDescription = "Settings")
-                    }
-                },
-            )
-        },
-    ) { scaffoldPadding ->
-    Box(modifier = Modifier.fillMaxSize().padding(scaffoldPadding)) {
+    // Restructure (v0.5.40) — when embedded under Library, skip the
+    // standalone Scaffold/TopAppBar: the parent screen already owns
+    // those. The inner Box stays in both branches because the RSS FAB
+    // uses `Modifier.align(Alignment.BottomEnd)` against it.
+    BrowseScaffoldOrFrame(
+        embedded = embedded,
+        onOpenSettings = onOpenSettings,
+    ) {
+    Box(modifier = Modifier.fillMaxSize()) {
     Column(modifier = Modifier.fillMaxSize().padding(top = spacing.md)) {
         // Top-level source picker. Switches the multibinding lookup in
         // FictionRepository between Royal Road and GitHub. Tabs and the
@@ -424,7 +467,7 @@ fun BrowseScreen(
         }
     }
     }  // Box
-    }  // Scaffold
+    }  // BrowseScaffoldOrFrame body
 
     if (showRssManageSheet) {
         BrowseRssManageSheet(

--- a/feature/src/main/kotlin/in/jphe/storyvox/feature/follows/FollowsScreen.kt
+++ b/feature/src/main/kotlin/in/jphe/storyvox/feature/follows/FollowsScreen.kt
@@ -52,6 +52,15 @@ fun FollowsScreen(
     onOpenFiction: (String) -> Unit,
     onOpenSignIn: () -> Unit,
     onOpenSettings: () -> Unit = {},
+    /**
+     * Restructure (v0.5.40) — when true, FollowsScreen renders without
+     * its own TopAppBar. The Library tab's TopAppBar serves as the
+     * parent header. The "Mark all caught up" action still surfaces,
+     * just as an inline header row above the list instead of in a
+     * TopAppBar slot. Standalone (`embedded = false`) preserves the
+     * legacy full-screen rendering for the deep-linked FOLLOWS route.
+     */
+    embedded: Boolean = false,
     viewModel: FollowsViewModel = hiltViewModel(),
 ) {
     val state by viewModel.uiState.collectAsStateWithLifecycle()
@@ -83,25 +92,48 @@ fun FollowsScreen(
 
     Box(modifier = Modifier.fillMaxSize()) {
         Column(modifier = Modifier.fillMaxSize()) {
-            TopAppBar(
-                title = { Text("Follows", style = MaterialTheme.typography.titleLarge) },
-                actions = {
-                    if (state.isSignedIn && state.follows.isNotEmpty()) {
-                        BrassButton(
-                            label = "Mark all caught up",
-                            onClick = viewModel::markAllCaughtUp,
-                            variant = BrassButtonVariant.Text,
-                        )
-                    }
-                    IconButton(onClick = onOpenSettings) {
-                        Icon(Icons.Outlined.Settings, contentDescription = "Settings")
-                    }
-                },
-                colors = TopAppBarDefaults.topAppBarColors(
-                    containerColor = MaterialTheme.colorScheme.surface,
-                    titleContentColor = MaterialTheme.colorScheme.onSurface,
-                ),
-            )
+            // Restructure (v0.5.40) — when embedded under Library, skip
+            // the standalone TopAppBar entirely (Library's bar serves
+            // as the parent header). The "Mark all caught up" action
+            // surfaces inline below as a TextButton in an aligned-end
+            // Row so it remains reachable.
+            if (!embedded) {
+                TopAppBar(
+                    title = { Text("Follows", style = MaterialTheme.typography.titleLarge) },
+                    actions = {
+                        if (state.isSignedIn && state.follows.isNotEmpty()) {
+                            BrassButton(
+                                label = "Mark all caught up",
+                                onClick = viewModel::markAllCaughtUp,
+                                variant = BrassButtonVariant.Text,
+                            )
+                        }
+                        IconButton(onClick = onOpenSettings) {
+                            Icon(Icons.Outlined.Settings, contentDescription = "Settings")
+                        }
+                    },
+                    colors = TopAppBarDefaults.topAppBarColors(
+                        containerColor = MaterialTheme.colorScheme.surface,
+                        titleContentColor = MaterialTheme.colorScheme.onSurface,
+                    ),
+                )
+            } else if (state.isSignedIn && state.follows.isNotEmpty()) {
+                // Embedded fallback for the "Mark all caught up"
+                // action — same affordance, just relocated below the
+                // parent TopAppBar.
+                Row(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .padding(horizontal = spacing.md, vertical = spacing.xs),
+                    horizontalArrangement = Arrangement.End,
+                ) {
+                    BrassButton(
+                        label = "Mark all caught up",
+                        onClick = viewModel::markAllCaughtUp,
+                        variant = BrassButtonVariant.Text,
+                    )
+                }
+            }
             when {
                 // Brass-sigil skeletons while the network refresh is in flight
                 // and we have no cached follows to show yet.

--- a/feature/src/main/kotlin/in/jphe/storyvox/feature/library/LibraryScreen.kt
+++ b/feature/src/main/kotlin/in/jphe/storyvox/feature/library/LibraryScreen.kt
@@ -32,7 +32,7 @@ import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Scaffold
-import androidx.compose.material3.SecondaryTabRow
+import androidx.compose.material3.SecondaryScrollableTabRow
 import androidx.compose.material3.Tab
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
@@ -48,6 +48,8 @@ import `in`.jphe.storyvox.data.db.entity.Shelf
 import `in`.jphe.storyvox.data.repository.ContinueListeningEntry
 import `in`.jphe.storyvox.data.repository.HistoryEntry
 import `in`.jphe.storyvox.data.source.model.FictionSummary
+import `in`.jphe.storyvox.feature.browse.BrowseScreen
+import `in`.jphe.storyvox.feature.follows.FollowsScreen
 import `in`.jphe.storyvox.ui.component.BrassButton
 import `in`.jphe.storyvox.ui.component.BrassButtonVariant
 import `in`.jphe.storyvox.ui.component.BrassProgressBar
@@ -73,6 +75,17 @@ fun LibraryScreen(
      * the app activity should always supply this.
      */
     onOpenInboxLink: (String) -> Unit = {},
+    /**
+     * Restructure (v0.5.40) — embedded BrowseScreen's RR sign-in CTA.
+     * Default no-op for tests / preview surfaces that don't exercise
+     * the Browse sub-tab.
+     */
+    onOpenRoyalRoadSignIn: () -> Unit = {},
+    /**
+     * Restructure (v0.5.40) — embedded FollowsScreen's sign-in CTA
+     * (Royal Road WebView for now; #241 shared sign-in surface).
+     */
+    onOpenFollowsSignIn: () -> Unit = {},
     viewModel: LibraryViewModel = hiltViewModel(),
 ) {
     val state by viewModel.uiState.collectAsStateWithLifecycle()
@@ -139,20 +152,23 @@ fun LibraryScreen(
         },
     ) { scaffoldPadding ->
         Column(modifier = Modifier.fillMaxSize().padding(scaffoldPadding)) {
-            // Issue #158 — Library sub-tabs. SecondaryTabRow rather than the
-            // PrimaryTabRow used by the bottom-level top-bar tabs, because
-            // these are *inside* a tab — Material 3 reserves the primary
-            // indicator for the top-level surface (BottomTabBar) and uses
-            // secondary for nested division.
+            // Issue #158 — Library sub-tabs. SecondaryScrollableTabRow
+            // rather than the fixed SecondaryTabRow because the
+            // restructure (v0.5.40) grew the tab count to five
+            // (Library / Browse / Follows / Inbox / History) and the
+            // labels do not fit the Flip3 portrait width laid out
+            // evenly. Scrollable is the same pattern BrowseScreen
+            // already uses for its narrow-viewport tab row, so this
+            // stays inside the existing visual vocabulary.
             //
-            // Layering with #116 (shelves): Tab.Reading coerces the chip
-            // filter to OneShelf(Reading) in the VM, so the same shelf-
-            // scoped Room flow drives both surfaces. The chip row is shown
-            // only on Tab.All — on Tab.Reading the tab itself IS the
-            // filter, on Tab.History the chip row isn't meaningful.
-            SecondaryTabRow(
+            // Layering with #116 (shelves): the chip row is shown only
+            // on Tab.Library — on Tab.Browse / Follows the embedded
+            // surfaces own their own scoping, on Tab.Inbox / History
+            // the chip row isn't meaningful.
+            SecondaryScrollableTabRow(
                 selectedTabIndex = state.tab.ordinal,
                 modifier = Modifier.fillMaxWidth(),
+                edgePadding = 0.dp,
             ) {
                 LibraryTab.entries.forEach { tab ->
                     Tab(
@@ -213,6 +229,30 @@ fun LibraryScreen(
                         onResume = viewModel::resume,
                         onOpenFiction = viewModel::openFiction,
                         onLongPress = viewModel::openManageShelves,
+                    )
+                }
+
+                // Restructure (v0.5.40) — Browse embedded under Library.
+                // BrowseScreen carries its own ViewModel (Hilt-scoped to
+                // this NavBackStackEntry) so its state survives sub-tab
+                // switches inside Library, same as it survived
+                // top-level tab switches before the restructure.
+                LibraryTab.Browse -> Box(modifier = Modifier.fillMaxSize()) {
+                    BrowseScreen(
+                        onOpenFiction = onOpenFiction,
+                        onOpenRoyalRoadSignIn = onOpenRoyalRoadSignIn,
+                        onOpenSettings = onOpenSettings,
+                        embedded = true,
+                    )
+                }
+
+                // Restructure (v0.5.40) — Follows embedded under Library.
+                LibraryTab.Follows -> Box(modifier = Modifier.fillMaxSize()) {
+                    FollowsScreen(
+                        onOpenFiction = onOpenFiction,
+                        onOpenSignIn = onOpenFollowsSignIn,
+                        onOpenSettings = onOpenSettings,
+                        embedded = true,
                     )
                 }
 

--- a/feature/src/main/kotlin/in/jphe/storyvox/feature/library/LibraryViewModel.kt
+++ b/feature/src/main/kotlin/in/jphe/storyvox/feature/library/LibraryViewModel.kt
@@ -50,25 +50,46 @@ import kotlinx.coroutines.launch
  * **#438 collapse** — v0.5.36 shipped four tabs (`All / Reading / Inbox /
  * History`) stacked directly above a four-chip shelf row (`All / Reading
  * / Read / Wishlist`), so the same strings (`All`, `Reading`) appeared in
- * two adjacent nested navigation surfaces — a Material 3 anti-pattern
- * that retrained users to ignore navigation. Collapsed to three tabs:
+ * two adjacent nested navigation surfaces — a Material 3 anti-pattern.
+ * Collapsed to three tabs (Library / Inbox / History) at the time.
  *
- *  - [Library] — the previous `All` tab renamed. Hosts the four-chip
- *    shelf strip below, so `Reading` lives there as a one-tap chip
- *    rather than competing for the same word with the tab row.
- *  - [Inbox] — chronological cross-source notification feed (#383).
+ * **Restructure (v0.5.40)** — JP directive: "put follows and browse into
+ * the library tab." The bottom nav drops to two destinations (Library +
+ * Settings), and the Library tab becomes the umbrella for everything
+ * book-related. Sub-tab order — left-to-right reading flow:
+ *
+ *  - [Library] — the user's own books (the existing shelf grid with the
+ *    chip-row #116 filter). First and default so a fresh launch lands
+ *    on what the user owns, not on a discovery surface.
+ *  - [Browse]  — the existing standalone Browse surface, embedded.
+ *    Source picker (RR / GitHub / Outline / etc.) + Popular / Search /
+ *    New Releases / Best Rated sub-tabs render inside the Library body.
+ *  - [Follows] — the existing standalone Follows surface, embedded.
+ *  - [Inbox]   — chronological cross-source notification feed (#383).
  *  - [History] — chronological chapter-open feed (#158).
  *
- * The pre-#438 `Reading` tab is reached in one tap via the shelf chip
- * row, so no functionality is lost; only the visual conflict is.
+ * Five tabs forces [SecondaryScrollableTabRow] (vs the fixed
+ * SecondaryTabRow used pre-restructure) because the labels do not fit
+ * the Flip3 portrait width when laid out evenly. Scrollable is the
+ * pattern already used by BrowseScreen's own narrow-viewport tab row,
+ * so this stays inside the existing visual vocabulary.
  */
 enum class LibraryTab(val label: String) {
     Library("Library"),
     /**
+     * Restructure (v0.5.40) — Browse folded under Library. The embedded
+     * BrowseScreen body renders here, source picker and all, sans its
+     * own TopAppBar (the Library TopAppBar serves both).
+     */
+    Browse("Browse"),
+    /**
+     * Restructure (v0.5.40) — Follows folded under Library. Same
+     * pattern as Browse: embedded body, no internal TopAppBar.
+     */
+    Follows("Follows"),
+    /**
      * Issue #383 — chronological cross-source notification feed.
-     * Sits between Library and History so the user finds it next to
-     * Library (the "what's current" surface) rather than buried after
-     * History. Carries a numeric badge driven by unread events.
+     * Carries a numeric badge driven by unread events.
      */
     Inbox("Inbox"),
     History("History"),
@@ -248,8 +269,14 @@ class LibraryViewModel @Inject constructor(
      */
     fun selectTab(tab: LibraryTab) {
         _tab.value = tab
+        // Restructure (v0.5.40) — Browse / Follows render their own
+        // embedded surfaces (own ViewModels via hiltViewModel), so the
+        // selectTab handler has nothing source-specific to coerce.
+        // Each branch is a documented no-op for grep symmetry.
         when (tab) {
             LibraryTab.Library -> { /* chip-row filter persists across tab switches */ }
+            LibraryTab.Browse -> { /* BrowseScreen owns its own state */ }
+            LibraryTab.Follows -> { /* FollowsScreen owns its own state */ }
             LibraryTab.History -> { /* history feed renders from state.history */ }
             LibraryTab.Inbox -> { /* inbox feed renders from state.inbox */ }
         }

--- a/feature/src/test/kotlin/in/jphe/storyvox/feature/library/LibraryTabCollapseTest.kt
+++ b/feature/src/test/kotlin/in/jphe/storyvox/feature/library/LibraryTabCollapseTest.kt
@@ -9,36 +9,41 @@ import org.junit.Assert.assertTrue
 import org.junit.Test
 
 /**
- * Issue #438 — regression guard for the four-tab/four-chip overlap.
+ * Issue #438 — regression guard for the four-tab/four-chip overlap, plus
+ * v0.5.40 nav-restructure follow-up.
  *
  * v0.5.36 stacked the four-entry `LibraryTab` strip (All / Reading /
  * Inbox / History) directly on top of the four-entry shelf chip row
  * (All / Reading / Read / Wishlist), so the same strings (`All`,
  * `Reading`) sat in two nested navigation surfaces. We collapsed
- * `LibraryTab` to three entries (`Library / Inbox / History`) and
- * surface the shelf filter as the canonical Reading affordance via
- * the chip row.
+ * `LibraryTab` to three entries (`Library / Inbox / History`) at the
+ * time.
  *
- * Tests pin the new contract so a future PR that re-introduces a
- * `Reading` (or other shelf-named) tab entry fails here first.
+ * v0.5.40 restructure — JP directive "put follows and browse into the
+ * library tab" — grew the tab strip back to five entries, but the
+ * #438 invariants still hold: no tab label may collide with a shelf
+ * chip label. The new tabs are [LibraryTab.Browse] and
+ * [LibraryTab.Follows], neither of which is a shelf name, so the
+ * collision contract is preserved.
  */
 class LibraryTabCollapseTest {
 
     @Test
-    fun `LibraryTab has exactly three entries`() {
-        // The pre-#438 enum had four entries (All / Reading / Inbox /
-        // History). Three is the new ceiling; growing past three needs
-        // a UX review, because the Flip3 portrait width gets tight at
-        // four labels even with single-word names.
-        assertEquals(3, LibraryTab.entries.size)
+    fun `LibraryTab has exactly five entries`() {
+        // v0.5.40 restructure — Library / Browse / Follows / Inbox /
+        // History. Five is the new ceiling; growing past five needs a
+        // UX review since SecondaryScrollableTabRow is already required
+        // to fit five labels on Flip3 portrait.
+        assertEquals(5, LibraryTab.entries.size)
     }
 
     @Test
     fun `LibraryTab labels do not collide with Shelf displayNames`() {
         // #438 — the structural fix: a tab label must never duplicate a
         // shelf chip label, since the chip row sits directly under the
-        // tab row. If anyone re-adds a `Reading` / `Read` / `Wishlist`
-        // tab without also re-thinking the chip strip, this fails.
+        // tab row on the Library sub-tab. If anyone re-adds a
+        // `Reading` / `Read` / `Wishlist` tab without also re-thinking
+        // the chip strip, this fails.
         val tabLabels = LibraryTab.entries.map { it.label.lowercase() }.toSet()
         val shelfLabels = Shelf.ALL.map { it.displayName.lowercase() }.toSet()
         val overlap = tabLabels intersect shelfLabels
@@ -68,21 +73,55 @@ class LibraryTabCollapseTest {
 
     @Test
     fun `Library is the first tab and is the default landing surface`() {
-        // The Library tab hosts the chip row; it must be the landing
-        // tab so a fresh launch shows the user their books, not the
-        // Inbox feed or History.
+        // The Library tab hosts the chip row + the user's books; it
+        // must be the landing tab so a fresh launch shows the user
+        // what they own, not the Browse / Follows / Inbox feeds.
         val first = LibraryTab.entries.first()
         assertEquals(LibraryTab.Library, first)
         assertEquals("Library", first.label)
     }
 
     @Test
+    fun `Browse and Follows are folded under Library as sub-tabs`() {
+        // v0.5.40 restructure pin — Browse / Follows are no longer
+        // top-level bottom-bar destinations; they're sub-tabs inside
+        // the Library destination. If anyone reverts to a top-bar
+        // Browse / Follows, this assertion still passes (the enum
+        // entries can coexist), but the bottom-nav assertions in
+        // BottomTabBar HomeTab.entries catch the regression there.
+        assertNotNull(
+            "LibraryTab.Browse missing — v0.5.40 folded Browse under Library.",
+            LibraryTab.entries.firstOrNull { it == LibraryTab.Browse },
+        )
+        assertNotNull(
+            "LibraryTab.Follows missing — v0.5.40 folded Follows under Library.",
+            LibraryTab.entries.firstOrNull { it == LibraryTab.Follows },
+        )
+    }
+
+    @Test
     fun `Inbox and History remain reachable as their own tabs`() {
         // These two tabs are NOT shelves — they're independent feeds
         // (events / chapter-opens). Keep them as tab entries so the
-        // #438 collapse doesn't accidentally bury them inside a sheet.
+        // restructure doesn't accidentally bury them inside a sheet.
         assertNotNull(LibraryTab.entries.firstOrNull { it == LibraryTab.Inbox })
         assertNotNull(LibraryTab.entries.firstOrNull { it == LibraryTab.History })
+    }
+
+    @Test
+    fun `LibraryTab order matches reading flow`() {
+        // Left-to-right: own-it (Library) → find-it (Browse / Follows)
+        // → new updates (Inbox) → revisit (History). The order isn't
+        // alphabetical or random; it's narratively grouped, and the
+        // SecondaryScrollableTabRow indicator pill follows this order.
+        val expectedOrder = listOf(
+            LibraryTab.Library,
+            LibraryTab.Browse,
+            LibraryTab.Follows,
+            LibraryTab.Inbox,
+            LibraryTab.History,
+        )
+        assertEquals(expectedOrder, LibraryTab.entries.toList())
     }
 
     @Test


### PR DESCRIPTION
## Summary

JP directive: *"put settings in the main nav bar, and put follows and browse into the library tab."* The bottom nav collapses to two primary destinations and the Library tab becomes the umbrella for everything book-related.

**Bottom nav** (was: Playing / Library / Follows / Browse / Voices):
- Library (default landing, umbrella destination)
- Settings (lands on `SettingsHubScreen`)

**Library sub-tabs** (was three after #438 collapse; now five, scrollable):
- **Library** — the user's books (chip row + grid + Resume card)
- **Browse** — embedded `BrowseScreen`, source picker + listing tabs preserved
- **Follows** — embedded `FollowsScreen`, "Mark all caught up" relocated inline
- **Inbox** (#383, unchanged)
- **History** (#158, unchanged)

`SecondaryScrollableTabRow` replaces the fixed `SecondaryTabRow` (5 labels don't fit on Flip3 portrait at fixed width — same scrollable pattern Browse already uses). `BROWSE` / `FOLLOWS` / `VOICE_LIBRARY` / `PLAYING` routes stay in the nav graph and in `HOME_ROUTES` so deep-links keep resolving and keep the bottom bar visible.

## Files

- `core-ui/.../BottomTabBar.kt` — `HomeTab` collapsed to `{Library, Settings}`
- `app/.../navigation/StoryvoxNavHost.kt` — `startDestination = LIBRARY`; bottom-bar selected mapping; LibraryScreen call gains `onOpenRoyalRoadSignIn` / `onOpenFollowsSignIn`
- `feature/.../library/LibraryViewModel.kt` — `LibraryTab` expanded to 5 entries in reading-flow order
- `feature/.../library/LibraryScreen.kt` — scrollable tab row, embedded Browse/Follows branches, new callbacks
- `feature/.../browse/BrowseScreen.kt` — `embedded: Boolean = false` param, `BrowseScaffoldOrFrame` switch
- `feature/.../follows/FollowsScreen.kt` — `embedded` param, inline "Mark all caught up" when embedded
- `app/.../navigation/NavStructureTest.kt` (new) — 10 tests pinning the two-destination contract
- `feature/.../library/LibraryTabCollapseTest.kt` — extended for the new 5-tab order; #438 no-collision invariant preserved

## Recovery context

Resumes from a cap-killed prior agent (multimodal-image API error, `anthropics/claude-code#59095`). Recovery diagnosis: previous agent's 7 modified files + 1 new test were already structurally complete and compile-clean. Verified by reading all files end-to-end, running full unit-test suite, and assembling debug APK. No structural changes added in recovery — only commit + push + PR.

Plan-vs-shipped delta: the original plan suggested renaming the inner Library sub-tab to "Shelf" to avoid name collision with the parent Library destination. The shipped code keeps "Library" as the sub-tab label; the `LibraryTabCollapseTest` was updated to pin this choice. Both readings are visually unambiguous because the TopAppBar reads "Library" and the active sub-tab pill reads "Library" — consistency, not collision.

## Test plan

- [x] `./gradlew :app:testDebugUnitTest` — PASS (`NavStructureTest` 10 tests)
- [x] `./gradlew :feature:testDebugUnitTest` — PASS (`LibraryTabCollapseTest` 8 tests)
- [x] `./gradlew :core-ui:testDebugUnitTest` — PASS
- [x] `./gradlew :app:assembleDebug` — PASS
- [ ] Install on tablet, verify bottom nav shows Library + Settings only
- [ ] Verify Library tab shows 5 sub-tabs scrollable
- [ ] Verify Browse sub-tab renders source picker + listings without its own TopAppBar
- [ ] Verify Follows sub-tab renders follow list with inline "Mark all caught up"
- [ ] Verify Settings pill navigates to `SettingsHubScreen`
- [ ] Verify HybridReader empty-state "Browse the realms" CTA still routes to BROWSE deep route