### PR TITLE
docs(site): landing overhaul — 17-source grid, 3-voice tier grid, dynamic APK CTA, CNAME

### DIFF
--- a/docs/CNAME
+++ b/docs/CNAME
@@ -1,0 +1,1 @@
+storyvox.techempower.org

--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -1,7 +1,10 @@
 title: storyvox
-description: A neural-voice audiobook player for any text you have. Offline TTS with optional Azure HD cloud voices, brass-on-warm-dark Library Nocturne aesthetic, six fiction sources (Royal Road, GitHub, RSS, EPUB, Outline, Memory Palace), no per-character billing.
-url: https://jphein.github.io
-baseurl: /storyvox
+description: A neural-voice audiobook player for any text you have. Seventeen fiction backends, three in-process neural voice families, optional Azure HD cloud voices. Brass-on-warm-dark Library Nocturne aesthetic. Free, GPL-3.0, no telemetry, no per-character billing.
+url: https://storyvox.techempower.org
+baseurl: ""
+
+# Default social-share card (override per-page via front-matter image:)
+image: /screenshots/03-reader.png
 
 # Use a minimal theme; we override most styling via _sass / assets/css.
 theme: minima

--- a/docs/assets/css/style.css
+++ b/docs/assets/css/style.css
@@ -443,6 +443,200 @@ section:first-of-type { margin-top: 0; }
 .sigil-mark a:hover { color: var(--brass-300); text-decoration: none; }
 .sigil-mark em { font-style: normal; color: var(--brass-300); }
 
+/* --- CTAs extended --- */
+.cta-tertiary {
+  display: inline-block;
+  align-self: center;
+  color: var(--brass-300);
+  text-decoration: none;
+  font-size: 0.98em;
+  padding: 0.5em 0.2em;
+}
+.cta-tertiary:hover { color: var(--brass-400); text-decoration: underline; }
+
+.cta-primary .cta-version {
+  font-weight: 500;
+  opacity: 0.8;
+  font-variant-numeric: tabular-nums;
+}
+
+.cta-fineprint {
+  margin-top: 0.7em !important;
+  font-size: 0.88em;
+}
+
+/* --- Sources grid (17 fiction backends) --- */
+.sources-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  gap: 0.9em;
+  margin: 1.5em 0 1em;
+}
+
+.source-card {
+  display: block;
+  background: var(--warm-bg-card);
+  border: 1px solid var(--warm-rule);
+  border-radius: var(--radius-md);
+  padding: 1.05em 1.1em 1em;
+  color: var(--warm-fg);
+  text-decoration: none;
+  transition: border-color 0.15s ease, transform 0.08s ease, box-shadow 0.15s ease;
+  position: relative;
+  overflow: hidden;
+}
+.source-card::before {
+  content: "";
+  position: absolute;
+  inset: 0 auto 0 0;
+  width: 3px;
+  background: linear-gradient(180deg, var(--brass-400), var(--brass-600));
+  opacity: 0.55;
+  transition: opacity 0.15s ease;
+}
+.source-card:hover {
+  border-color: var(--brass-500);
+  transform: translateY(-1px);
+  box-shadow: 0 8px 24px rgba(0,0,0,0.35), 0 0 0 1px var(--brass-600);
+  text-decoration: none;
+  color: var(--warm-fg);
+}
+.source-card:hover::before { opacity: 1; }
+
+.source-glyph {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-width: 2.4em;
+  height: 1.7em;
+  padding: 0 0.55em;
+  background: var(--warm-bg-elev);
+  border: 1px solid var(--brass-600);
+  border-radius: 6px;
+  color: var(--brass-300);
+  font-family: var(--sans);
+  font-weight: 700;
+  font-size: 0.78em;
+  letter-spacing: 0.04em;
+  margin-bottom: 0.55em;
+}
+
+.source-card h3 {
+  margin: 0 0 0.3em;
+  font-size: 1.08em;
+  color: var(--brass-300);
+}
+
+.source-card p {
+  margin: 0;
+  font-size: 0.92em;
+  line-height: 1.5;
+  color: var(--warm-fg-muted);
+}
+
+.source-card p a {
+  color: var(--brass-300);
+}
+
+/* --- Voice family grid --- */
+.voice-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+  gap: 1.1em;
+  margin: 1.6em 0 1em;
+}
+
+.voice-card {
+  background: var(--warm-bg-card);
+  border: 1px solid var(--warm-rule);
+  border-radius: var(--radius-lg);
+  padding: 1.3em 1.4em 1.2em;
+  position: relative;
+  display: flex;
+  flex-direction: column;
+}
+
+.voice-card-flagship {
+  border-color: var(--brass-600);
+  background: linear-gradient(180deg, var(--warm-bg-card), var(--warm-bg-elev));
+  box-shadow: 0 10px 28px rgba(0,0,0,0.35), inset 0 0 0 1px rgba(184, 134, 42, 0.08);
+}
+
+.voice-tier {
+  font-family: var(--sans);
+  font-size: 0.72em;
+  font-weight: 700;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  color: var(--brass-300);
+  margin-bottom: 0.35em;
+}
+
+.voice-card h3 {
+  margin: 0 0 0.2em;
+  color: var(--brass-300);
+  font-size: 1.4em;
+}
+
+.voice-size {
+  font-family: var(--serif);
+  font-style: italic;
+  color: var(--warm-fg);
+  margin: 0 0 0.6em !important;
+  font-size: 0.98em;
+}
+
+.voice-meta {
+  margin-top: auto !important;
+  font-size: 0.85em !important;
+  padding-top: 0.4em;
+}
+
+.voices-cloud {
+  background: var(--warm-bg-elev);
+  border: 1px dashed var(--brass-600);
+  border-radius: var(--radius-md);
+  padding: 0.9em 1.2em;
+  margin: 1.4em 0 0 !important;
+  font-size: 0.95em;
+}
+
+/* --- Open / virtues grid --- */
+.open-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  gap: 1em;
+  margin: 1.4em 0 0.5em;
+}
+
+.open-card {
+  background: var(--warm-bg-card);
+  border: 1px solid var(--warm-rule);
+  border-left: 3px solid var(--brass-500);
+  border-radius: var(--radius-md);
+  padding: 1em 1.2em 0.9em;
+}
+
+.open-card h3 {
+  margin: 0 0 0.35em;
+  color: var(--brass-300);
+  font-size: 1.1em;
+}
+
+.open-card p {
+  margin: 0;
+  font-size: 0.93em;
+  line-height: 1.55;
+  color: var(--warm-fg-muted);
+}
+
+/* Section headings: soften the underline on the new sections for visual rhythm */
+section.sources > h2,
+section.voices > h2,
+section.open > h2 {
+  border-bottom-color: var(--brass-600);
+}
+
 /* Reduced motion */
 @media (prefers-reduced-motion: reduce) {
   * { transition: none !important; animation: none !important; }

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,25 +1,37 @@
 ---
 layout: default
 title: storyvox — neural-voice audiobook player for any text you have
-description: Offline neural TTS, optional Azure HD cloud voices. Twelve sources — Royal Road, GitHub, RSS / Atom feeds, local EPUB files, Outline wikis, Memory Palace, Project Gutenberg, Archive of Our Own, Standard Ebooks, Wikipedia, KVMR live radio, Notion. AI chat per fiction across seven LLM providers. Brass-on-warm-dark Library Nocturne aesthetic. Free, GPL-3.0, no per-character billing.
+description: Seventeen fiction backends, three in-process neural voice families, optional Azure HD cloud voices. Stream chapters from Royal Road, GitHub, RSS, EPUB, Outline, Memory Palace, Project Gutenberg, AO3, Standard Ebooks, Wikipedia, Wikisource, Radio (30k stations), Notion, Hacker News, arXiv, PLOS, and Discord. Brass-on-warm-dark Library Nocturne aesthetic. Free, GPL-3.0, no telemetry.
+image: /screenshots/03-reader.png
 ---
 
 <section class="hero">
   <div class="hero-text">
     <h1>storyvox</h1>
-    <p class="tagline">A neural-voice audiobook player for any text you have.</p>
+    <p class="tagline">Audiobook everything. Stream chapters from anywhere, read aloud in a brass-warm neural voice.</p>
     <p>
-      Stream chapters from <a href="https://royalroad.com">Royal Road</a>,
-      <a href="https://github.com/techempower-org/storyvox-registry">GitHub</a>, an
-      <a href="https://www.getoutline.com">Outline</a> wiki, an RSS / Atom feed, a
-      <a href="https://github.com/techempower-org/mempalace">Memory Palace</a> you host yourself,
-      or a folder of EPUB files on your device — read aloud by an
-      <strong>offline neural TTS engine</strong> (with optional Azure HD cloud voices),
-      and a hybrid reader/audiobook view that highlights the spoken sentence as you listen.
+      Seventeen fiction backends side by side — <a href="https://royalroad.com">Royal Road</a>,
+      <a href="https://github.com">GitHub</a>, RSS feeds, EPUB files on your device,
+      <a href="https://www.getoutline.com">Outline</a> wikis, your self-hosted
+      <a href="https://github.com/techempower-org/mempalace">Memory Palace</a>,
+      <a href="https://www.gutenberg.org/">Project Gutenberg</a>, AO3, Standard Ebooks, Wikipedia,
+      Wikisource, Radio (30k+ stations), <a href="https://notion.so">Notion</a>, Hacker News,
+      arXiv, PLOS, Discord — all read aloud by an <strong>in-process neural TTS engine</strong>
+      that runs entirely on-device. A hybrid reader/audiobook view highlights the spoken sentence
+      in brass as you listen.
     </p>
     <p class="cta-row">
-      <a class="cta-primary" href="install/">Install</a>
+      <a class="cta-primary" id="cta-download"
+         href="https://github.com/techempower-org/storyvox/releases/latest"
+         data-base-href="https://github.com/techempower-org/storyvox/releases">
+        <span class="cta-label">Download latest APK</span>
+        <span class="cta-version" aria-hidden="true"></span>
+      </a>
       <a class="cta-secondary" href="https://github.com/techempower-org/storyvox">Source on GitHub</a>
+      <a class="cta-tertiary" href="install/">Install guide →</a>
+    </p>
+    <p class="cta-fineprint muted">
+      Sideload, Android 8.0+, ~50 MB APK. No Play Store. No tracking. No in-app purchases.
     </p>
   </div>
   <div class="hero-art">
@@ -36,132 +48,303 @@ description: Offline neural TTS, optional Azure HD cloud voices. Twelve sources 
   <h2>Why storyvox</h2>
   <div class="why-grid">
     <div class="card">
-      <h3>Offline neural TTS</h3>
+      <h3>On-device neural TTS</h3>
       <p>
-        Two voice families ship — <a href="https://github.com/rhasspy/piper">Piper</a> (compact, ~14–30 MB)
-        and <a href="https://github.com/hexgrad/kokoro">Kokoro</a> (multi-speaker, ~330 MB).
-        Voices download once, then live on-device. No cloud, no API keys, no per-character billing.
-      </p>
-    </div>
-    <div class="card">
-      <h3>Brass on warm dark</h3>
-      <p>
-        Library Nocturne theme — brass accents, EB Garamond chapter body, Inter UI. Light mode is
-        parchment cream. Adaptive grid for phones (2 col), tablets (5 col), and foldables.
-      </p>
-    </div>
-    <div class="card">
-      <h3>Twelve fiction sources</h3>
-      <p>
-        Royal Road with the full filter set, GitHub fiction repos via the curated
-        <a href="https://github.com/techempower-org/storyvox-registry">storyvox-registry</a>,
-        any RSS / Atom feed (with a managed suggested-feeds list), a self-hosted
-        <a href="https://www.getoutline.com">Outline</a> wiki, your own
-        <a href="https://github.com/techempower-org/mempalace">Memory Palace</a>, a folder of
-        EPUB files on your device, <strong>Project Gutenberg's</strong> 70,000+
-        public-domain books, <strong>Archive of Our Own</strong> per-tag feeds,
-        <strong>Standard Ebooks'</strong> hand-curated classics, any <strong>Wikipedia</strong>
-        article (heading-split chapters), <strong>KVMR Community Radio</strong> live audio, and a
-        <strong>Notion</strong> database (defaults to the techempower.org content DB).
-        Each backend has its own on/off toggle.
+        Three voice families ship — <a href="https://github.com/rhasspy/piper">Piper</a> (compact),
+        <a href="https://github.com/hexgrad/kokoro">Kokoro</a> (multi-speaker), and
+        <strong>KittenTTS</strong> (lightest tier, designed for slow devices). Voices download
+        once, then live on-device. No cloud, no API keys, no per-character billing.
       </p>
     </div>
     <div class="card">
       <h3>Reader view, in sync</h3>
       <p>
         Swipe between audiobook view (cover + scrubber + transport) and reader view (chapter text).
-        The current sentence glides along in brass, matching the read-aloud rhythm.
+        The current sentence glides along in brass, matching the read-aloud rhythm — so you can
+        listen, read, or both at once.
+      </p>
+    </div>
+    <div class="card">
+      <h3>AI chat per fiction</h3>
+      <p>
+        Per-book chat across seven LLM providers, with grounding (current sentence / chapter /
+        whole book), cross-fiction memory, function calling ("queue chapter 5", "open Voice
+        Library"), and multi-modal image input. Brass-edged tool cards show in-flight state.
       </p>
     </div>
     <div class="card">
       <h3>Smooth on slow hardware</h3>
       <p>
-        Tier 3 multi-engine parallel synthesis (1–8 VoxSherpa instances × N threads each,
-        twin sliders in Settings → Performance), a producer pinned to <code>URGENT_AUDIO</code>,
-        and PCM cache buffering keep playback gapless even when Piper-high struggles on a
-        Helio P22T. Tuned on a Galaxy Tab A7 Lite.
+        Tier 3 multi-engine parallel synthesis — 1–8 VoxSherpa instances × N threads each, twin
+        sliders in Settings → Performance. A producer pinned to <code>URGENT_AUDIO</code> and PCM
+        cache buffering keep playback gapless even when Piper-high struggles on a Helio P22T.
       </p>
     </div>
     <div class="card">
-      <h3>Optional cloud voices</h3>
+      <h3>Optional cloud voices (BYOK)</h3>
       <p>
-        Bring your own Azure key for studio-grade <a href="https://learn.microsoft.com/azure/ai-services/speech-service/text-to-speech">Azure HD voices</a>.
-        Offline fallback to your local voice if the network drops or your key expires.
-        Opt-in, never required, never billed by storyvox.
+        Bring your own Azure key for studio-grade
+        <a href="https://learn.microsoft.com/azure/ai-services/speech-service/text-to-speech">Azure HD voices</a>.
+        Offline fallback to your local voice if the network drops or your key expires. Opt-in,
+        never required, never billed by storyvox.
       </p>
     </div>
     <div class="card">
-      <h3>Free and open</h3>
+      <h3>Brass on warm dark</h3>
       <p>
-        GPL-3.0. Inheritable from the TTS engine, but also a posture: no telemetry, no analytics,
-        no upsell. Sideload the APK from <a href="https://github.com/techempower-org/storyvox/releases">Releases</a>
-        and you're done.
+        Library Nocturne theme — brass accents, EB Garamond chapter body, Inter UI. Light mode
+        is parchment cream. Wear OS gets the same theme with a circular brass scrubber. Adaptive
+        grid: phones (2 col), tablets (5), foldables (more).
       </p>
     </div>
   </div>
 </section>
 
+<section class="sources">
+  <h2>Seventeen fiction backends, side by side</h2>
+  <p class="muted">
+    A plugin-seam architecture means each backend is ~4 touchpoints. Adding a new one auto-surfaces
+    in <strong>Settings → Plugins</strong>. Each has its own on/off toggle.
+  </p>
+  <div class="sources-grid">
+    <a class="source-card" href="https://royalroad.com">
+      <span class="source-glyph" aria-hidden="true">RR</span>
+      <h3>Royal Road</h3>
+      <p>The full filter set — tags include/exclude, status, type, length, rating, content warnings, sort. Follows tab syncs your bookmarks.</p>
+    </a>
+    <a class="source-card" href="https://github.com/techempower-org/storyvox-registry">
+      <span class="source-glyph" aria-hidden="true">GH</span>
+      <h3>GitHub</h3>
+      <p>Curated <a href="https://github.com/techempower-org/storyvox-registry">storyvox-registry</a> plus live <code>/search/repositories</code>. OAuth Device Flow lifts the 60→5000 req/hr cap.</p>
+    </a>
+    <a class="source-card" href="https://github.com/techempower-org/storyvox-feeds">
+      <span class="source-glyph" aria-hidden="true">RSS</span>
+      <h3>RSS / Atom feeds</h3>
+      <p>Any RSS or Atom feed, plus a managed suggested-feeds list from <a href="https://github.com/techempower-org/storyvox-feeds">storyvox-feeds</a>.</p>
+    </a>
+    <a class="source-card" href="https://www.getoutline.com">
+      <span class="source-glyph" aria-hidden="true">OL</span>
+      <h3>Outline</h3>
+      <p>Self-hosted Outline wiki as a fiction backend. Paste your URL + API token; collections become fictions, documents become chapters.</p>
+    </a>
+    <a class="source-card" href="https://github.com/techempower-org/mempalace">
+      <span class="source-glyph" aria-hidden="true">MP</span>
+      <h3>Memory Palace</h3>
+      <p>Your own self-hosted <a href="https://github.com/techempower-org/mempalace">Memory Palace</a>. Drawers become chapters; the palace becomes a personal canon.</p>
+    </a>
+    <a class="source-card">
+      <span class="source-glyph" aria-hidden="true">EPUB</span>
+      <h3>Local EPUB</h3>
+      <p>Open any folder via the system file picker. OPF parser splits EPUBs into chapters; works fully offline.</p>
+    </a>
+    <a class="source-card" href="https://www.gutenberg.org/">
+      <span class="source-glyph" aria-hidden="true">PG</span>
+      <h3>Project Gutenberg</h3>
+      <p>70,000+ public-domain books. Search by author, title, or subject; download EPUB or read inline.</p>
+    </a>
+    <a class="source-card" href="https://archiveofourown.org/">
+      <span class="source-glyph" aria-hidden="true">AO3</span>
+      <h3>Archive of Our Own</h3>
+      <p>Per-tag feeds and official EPUBs. Browse by fandom, ship, or trope tag.</p>
+    </a>
+    <a class="source-card" href="https://standardebooks.org/">
+      <span class="source-glyph" aria-hidden="true">SE</span>
+      <h3>Standard Ebooks</h3>
+      <p>Hand-curated, typographically polished public-domain classics. The good edition.</p>
+    </a>
+    <a class="source-card" href="https://en.wikipedia.org/">
+      <span class="source-glyph" aria-hidden="true">W</span>
+      <h3>Wikipedia</h3>
+      <p>Any article, heading-split into chapters. Long-form articles become quick audiobooks.</p>
+    </a>
+    <a class="source-card" href="https://en.wikisource.org/">
+      <span class="source-glyph" aria-hidden="true">WS</span>
+      <h3>Wikisource</h3>
+      <p>Walks multi-part works as <code>/Subpage</code> chapters. Free, primary-source texts.</p>
+    </a>
+    <a class="source-card" href="https://www.radio-browser.info/">
+      <span class="source-glyph" aria-hidden="true">FM</span>
+      <h3>Radio</h3>
+      <p>Five curated stations (KVMR, Cap Public, KQED, KCSB, SomaFM) plus <a href="https://www.radio-browser.info/">Radio Browser</a> search across 30,000+ stations.</p>
+    </a>
+    <a class="source-card" href="https://notion.so">
+      <span class="source-glyph" aria-hidden="true">N</span>
+      <h3>Notion</h3>
+      <p>Any Notion database — defaults to the techempower.org content DB. Paste an integration token and you're in.</p>
+    </a>
+    <a class="source-card" href="https://news.ycombinator.com/">
+      <span class="source-glyph" aria-hidden="true">HN</span>
+      <h3>Hacker News</h3>
+      <p>Top stories + Ask HN / Show HN threads with comments narrated in order.</p>
+    </a>
+    <a class="source-card" href="https://arxiv.org/">
+      <span class="source-glyph" aria-hidden="true">arX</span>
+      <h3>arXiv</h3>
+      <p>Abstracts in cs.AI and other categories — let the neural voice read the cutting edge while you commute.</p>
+    </a>
+    <a class="source-card" href="https://plos.org/">
+      <span class="source-glyph" aria-hidden="true">PLOS</span>
+      <h3>PLOS</h3>
+      <p>Open-access, peer-reviewed science papers. Hear research instead of skimming it.</p>
+    </a>
+    <a class="source-card" href="https://discord.com/">
+      <span class="source-glyph" aria-hidden="true">DC</span>
+      <h3>Discord</h3>
+      <p>Serialized fiction in Discord channels — channels are fictions, messages are chapters. Bot-token auth.</p>
+    </a>
+  </div>
+</section>
+
+<section class="voices">
+  <h2>Three voice families, all on-device</h2>
+  <p class="muted">
+    Voices download on demand from the <code>voices-v2</code> release; nothing is bundled in the APK.
+    The voice picker shows what's installed and what's available. <a href="voices/">Full voice catalog →</a>
+  </p>
+  <div class="voice-grid">
+    <div class="voice-card">
+      <div class="voice-tier">Compact</div>
+      <h3>Piper</h3>
+      <p class="voice-size">~14–30 MB per voice</p>
+      <p>
+        Single-speaker neural voices in dozens of languages. Quality / x-low / low / medium /
+        high tiers per voice. Punches well above its weight on phones from 2018.
+      </p>
+      <p class="voice-meta muted">
+        <a href="https://github.com/rhasspy/piper">rhasspy/piper</a>
+      </p>
+    </div>
+    <div class="voice-card voice-card-flagship">
+      <div class="voice-tier">Multi-speaker</div>
+      <h3>Kokoro</h3>
+      <p class="voice-size">~330 MB (shared across voices)</p>
+      <p>
+        One model, many speakers — male, female, and accent variants share weights. The sweet
+        spot for modern Android tablets. Brass-warm narration that doesn't sound robotic.
+      </p>
+      <p class="voice-meta muted">
+        <a href="https://github.com/hexgrad/kokoro">hexgrad/kokoro</a>
+      </p>
+    </div>
+    <div class="voice-card">
+      <div class="voice-tier">Lightest</div>
+      <h3>KittenTTS</h3>
+      <p class="voice-size">~24 MB (shared, 8 en_US speakers)</p>
+      <p>
+        The new lightest tier — designed for slow devices where Piper-high struggles. Eight en_US
+        speakers share a single 24 MB model. The "first chapter in 10 seconds" voice family.
+      </p>
+      <p class="voice-meta muted">In-tree (storyvox · v0.5.x)</p>
+    </div>
+  </div>
+  <p class="voices-cloud">
+    <strong>Optional cloud:</strong> Bring your own
+    <a href="https://learn.microsoft.com/azure/ai-services/speech-service/text-to-speech">Azure HD</a>
+    key for studio-grade narration on slow devices. Offline fallback to your local voice if your
+    key fails or the network drops. Opt-in, never required.
+  </p>
+</section>
+
 <section class="screens">
   <h2>What it looks like</h2>
-  <p class="muted">Galaxy Tab A7 Lite, 800×1340 px. <a href="screenshots/">Full gallery →</a></p>
+  <p class="muted">Galaxy Tab A7 Lite, 800×1340 px. Tap the theme toggle (top right) to flip light/dark. <a href="screenshots/">Full gallery →</a></p>
   <div class="screens-grid">
     <figure>
       <dark-image src-dark="screenshots/01-browse.png" src-light="screenshots/01-browse-light.png" alt="Browse tab">
-        <img src="screenshots/01-browse.png" alt="Browse tab" />
+        <img src="screenshots/01-browse.png" alt="Browse tab" loading="lazy" />
       </dark-image>
-      <figcaption>Browse</figcaption>
+      <figcaption>Browse — infinite-scroll across every source.</figcaption>
     </figure>
     <figure>
       <dark-image src-dark="screenshots/02-detail.png" src-light="screenshots/02-detail-light.png" alt="Fiction detail">
-        <img src="screenshots/02-detail.png" alt="Fiction detail" />
+        <img src="screenshots/02-detail.png" alt="Fiction detail" loading="lazy" />
       </dark-image>
-      <figcaption>Fiction detail</figcaption>
+      <figcaption>Fiction detail — synopsis, tags, chapter list with read state.</figcaption>
     </figure>
     <figure>
       <dark-image src-dark="screenshots/04-library.png" src-light="screenshots/04-library-light.png" alt="Library tab">
-        <img src="screenshots/04-library.png" alt="Library tab" />
+        <img src="screenshots/04-library.png" alt="Library tab" loading="lazy" />
       </dark-image>
-      <figcaption>Library</figcaption>
+      <figcaption>Library — currently-listening with progress + smart resume.</figcaption>
     </figure>
     <figure>
-      <dark-image src-dark="screenshots/05-settings.png" src-light="screenshots/05-settings-light.png" alt="Settings">
-        <img src="screenshots/05-settings.png" alt="Settings" />
+      <dark-image src-dark="screenshots/06-filter-dark.png" src-light="screenshots/06-filter.png" alt="Royal Road filter sheet">
+        <img src="screenshots/06-filter-dark.png" alt="Royal Road filter sheet" loading="lazy" />
       </dark-image>
-      <figcaption>Settings</figcaption>
+      <figcaption>Royal Road filters — sort, tags include/exclude, content warnings.</figcaption>
     </figure>
+    <figure>
+      <dark-image src-dark="screenshots/06b-filter-github-dark.png" src-light="screenshots/06b-filter-github.png" alt="GitHub filter sheet">
+        <img src="screenshots/06b-filter-github-dark.png" alt="GitHub filter sheet" loading="lazy" />
+      </dark-image>
+      <figcaption>GitHub filters — stars, language, topics, last-pushed.</figcaption>
+    </figure>
+    <figure>
+      <dark-image src-dark="screenshots/05-settings.png" src-light="screenshots/05-settings-light.png" alt="Settings hub">
+        <img src="screenshots/05-settings.png" alt="Settings hub" loading="lazy" />
+      </dark-image>
+      <figcaption>Settings — brass-edged section hub, eight cards.</figcaption>
+    </figure>
+  </div>
+</section>
+
+<section class="open">
+  <h2>Open. Free. Yours.</h2>
+  <div class="open-grid">
+    <div class="open-card">
+      <h3>GPL-3.0</h3>
+      <p>
+        Inherited from the TTS engine — also a posture. Read the source, modify it, ship your
+        fork. No closed components. <a href="https://github.com/techempower-org/storyvox/blob/main/LICENSE">License →</a>
+      </p>
+    </div>
+    <div class="open-card">
+      <h3>No telemetry</h3>
+      <p>
+        Zero analytics. Zero crash reporting. Zero "anonymous usage". The app talks to the
+        backends you opt into, the voice repo for downloads, and nothing else.
+      </p>
+    </div>
+    <div class="open-card">
+      <h3>No in-app purchases</h3>
+      <p>
+        No subscriptions, no premium tier, no upsell. Azure HD is BYOK — you pay Microsoft
+        directly if you want it. storyvox doesn't take a cut.
+      </p>
+    </div>
+    <div class="open-card">
+      <h3>Sideload from GitHub</h3>
+      <p>
+        Not on the Play Store yet. <a href="https://github.com/techempower-org/storyvox/releases">Grab the APK from Releases</a>,
+        enable "Install unknown apps" once, open the file. Three taps and you're in.
+      </p>
+    </div>
   </div>
 </section>
 
 <section class="recent">
   <h2>What just shipped</h2>
   <p>
-    <strong>v0.5.31</strong> — Library Nocturne UX milestone. Full brass-on-warm-dark
-    polish pass across player, library, settings, and browse: TopAppBar nav across
-    detail screens, single back-nav pattern, chapter rows tappable with played
-    indicators, infinite-scroll Browse across every tab, brass spinners and progress
-    bars everywhere, deliberate first-time defaults, and a confetti milestone dialog.
-    <a href="https://github.com/techempower-org/storyvox/releases/tag/v0.5.31">Full release notes →</a>
+    <strong>v0.5.39</strong> — Nav restructure: Settings becomes a primary nav destination,
+    Browse and Follows tuck under Library. InstantDB sync brings settings + secrets across
+    devices. The Settings hub gets follow-through — seven remaining hub cards land as dedicated
+    subscreens. Four QA findings closed (#450, #452, #459, #461).
+    <a href="https://github.com/techempower-org/storyvox/releases/tag/v0.5.39">Full release notes →</a>
   </p>
   <p>
-    <strong>Earlier in v0.4:</strong> Tier 3 multi-engine parallel synthesis with twin
-    Engines/Threads sliders (v0.4.78); smart-resume CTA (v0.4.83); Azure Cognitive Services HD voices as
-    an optional remote TTS backend (BYOK, with offline fallback, error retries, full roster
-    and cache eviction priority — <a href="https://github.com/techempower-org/storyvox/issues/182">#182</a>–<a href="https://github.com/techempower-org/storyvox/issues/186">#186</a>);
-    EPUB import (<a href="https://github.com/techempower-org/storyvox/issues/235">#235</a>) via the
-    Storage Access Framework + an OPF parser; RSS / Atom feeds
-    (<a href="https://github.com/techempower-org/storyvox/issues/236">#236</a>) with a managed
-    suggested-feeds list from <a href="https://github.com/techempower-org/storyvox-feeds">storyvox-feeds</a>;
-    self-hosted Outline wikis as a backend
-    (<a href="https://github.com/techempower-org/storyvox/issues/245">#245</a>); AI Sessions surface
-    (<a href="https://github.com/techempower-org/storyvox/issues/218">#218</a>); read-aloud per AI
-    assistant turn (<a href="https://github.com/techempower-org/storyvox/issues/214">#214</a>);
-    per-voice speed and pitch defaults
-    (<a href="https://github.com/techempower-org/storyvox/issues/195">#195</a>); and stable debug
-    keystore for clean upgrades over older debug builds.
+    <strong>Earlier in v0.5:</strong> <strong>seventeen fiction backends</strong> behind a
+    plugin-seam (Hacker News, arXiv, PLOS, Discord, Wikisource, Radio Browser); <strong>three
+    voice families</strong> with KittenTTS as the new lightest tier; <strong>AI heavies</strong>
+    — cross-fiction memory (<a href="https://github.com/techempower-org/storyvox/issues/217">#217</a>),
+    function calling (<a href="https://github.com/techempower-org/storyvox/issues/216">#216</a>),
+    multi-modal image input (<a href="https://github.com/techempower-org/storyvox/issues/215">#215</a>);
+    magical brass voice-settings icon on the play screen; Plugin manager Settings hub iterating
+    the registry; Wear OS Library Nocturne with circular brass scrubber on round watches.
   </p>
   <p class="muted">
-    See the <a href="https://github.com/techempower-org/storyvox/wiki">wiki</a> for build, voice catalog,
-    and troubleshooting reference, or <a href="architecture/">how the modules fit together</a>.
+    See the <a href="https://github.com/techempower-org/storyvox/wiki">wiki</a> for build, voice
+    catalog, and troubleshooting reference, or <a href="architecture/">how the modules fit
+    together</a>.
   </p>
 </section>
 
@@ -169,7 +352,33 @@ description: Offline neural TTS, optional Azure HD cloud voices. Twelve sources 
   <p>
     storyvox is licensed under the
     <a href="https://github.com/techempower-org/storyvox/blob/main/LICENSE">GNU General Public License v3.0</a>.
-    Built by <a href="https://github.com/techempower-org">JP Hein</a>
+    Built by <a href="https://github.com/jphein">JP Hein</a>
     with teams of <a href="https://www.anthropic.com/claude-code">Claude Code</a> agents.
   </p>
 </footer>
+
+<script>
+  // Resolve the "Download latest APK" button to the actual signed APK asset from
+  // the latest release on GitHub. Falls back to the Releases page on any error.
+  (() => {
+    const btn = document.getElementById('cta-download');
+    if (!btn) return;
+    const versionEl = btn.querySelector('.cta-version');
+    fetch('https://api.github.com/repos/techempower-org/storyvox/releases/latest', {
+      headers: { 'Accept': 'application/vnd.github+json' }
+    })
+      .then(r => r.ok ? r.json() : Promise.reject(r.status))
+      .then(rel => {
+        if (!rel || !rel.tag_name) return;
+        // Prefer the signed APK asset; otherwise just deep-link to the release page.
+        const apk = (rel.assets || []).find(a => /\.apk$/i.test(a.name));
+        if (apk && apk.browser_download_url) {
+          btn.href = apk.browser_download_url;
+        } else if (rel.html_url) {
+          btn.href = rel.html_url;
+        }
+        if (versionEl) versionEl.textContent = ' · ' + rel.tag_name;
+      })
+      .catch(() => { /* keep static fallback href */ });
+  })();
+</script>


### PR DESCRIPTION
## Summary

Rebuild the storyvox landing page around what v0.5.39 actually ships, and point GitHub Pages at the new `storyvox.techempower.org` subdomain.

- **17 fiction backends as a visual source-grid** — Royal Road, GitHub, RSS, EPUB, Outline, Memory Palace, Project Gutenberg, AO3, Standard Ebooks, Wikipedia, Wikisource, Radio, Notion, Hacker News, arXiv, PLOS, Discord. Replaces the stale "twelve sources" prose paragraph. Each card is a brass-railed link to the backend's home.
- **3-voice-families tier grid** — Piper (Compact) / Kokoro (Multi-speaker, flagship card) / KittenTTS (Lightest) with size + use-case copy. Azure HD BYOK callout below the grid.
- **Dynamic "Download latest APK" CTA** — resolves the signed APK asset from `api.github.com/repos/techempower-org/storyvox/releases/latest` at page load, with a static fallback to the Releases page if the fetch fails. Pill on the button shows the resolved version. No hardcoded version that goes stale.
- **"Open. Free. Yours." section** — reframes sideload / GPL-3 / no-Play-Store / no-IAP as virtues rather than caveats.
- **Sharper hero copy** — "audiobook everything", tightened tagline, lazy-loaded below-fold screenshots.
- **Recent block bumped** from v0.5.31 to v0.5.39 with the right release highlights (nav restructure, InstantDB sync, settings hub follow-through).
- **`_config.yml`** description aligned to "seventeen fiction backends, three voice families"; default `og:image` set to the dark reader shot for share cards.
- **CNAME at `docs/CNAME`** points GitHub Pages to `storyvox.techempower.org`. `url`/`baseurl` in `_config.yml` move to the apex of the new subdomain (subpath disappears).

### Doesn't touch

- `docs/version.json` (status.realm.watch dependency)
- `_layouts/default.html` (already brass-themed via dark.realm.watch Tier 2)
- `favicon.svg` (brass-diamond aesthetic already matches the app's launcher)
- Inner long-form docs (`architecture.md`, `install.md`, `voices.md`, `sync.md`, `ROADMAP.md`) — they inherit the brass theme via the layout and the copy is mostly fine

### CSS additions

- `source-card` with brass left-rail + hover lift + glyph badge
- `voice-card` + `voice-card-flagship` variant for Kokoro
- `voices-cloud` dashed-brass BYOK callout
- `open-card` virtue cards with brass left border
- `cta-version` pill on the dynamic CTA + `cta-tertiary` text link

## Follow-ups (separate, deferred)

- **`status.realm.watch/checks.json` line 558** — bump storyvox version-check URL from `https://jphein.github.io/storyvox/version.json` to `https://storyvox.techempower.org/version.json` once DNS lands. Doing it pre-DNS would break the existing check during the cutover window.

## Test plan

- [ ] Cloudflare DNS: `storyvox.techempower.org` → `techempower-org.github.io` CNAME (orchestrator handles)
- [ ] GitHub Pages: SSL cert provisioned for the custom domain (auto, ~10 min after DNS)
- [ ] Visit `https://storyvox.techempower.org/` — hero, source grid (17 cards), voice grid (3 cards), screenshots, "Open. Free. Yours.", recent block all render
- [ ] Theme toggle cycles system → dark → light; both palettes look right
- [ ] "Download latest APK" button shows `· v0.5.39` pill and `href` resolves to the signed `.apk` asset URL (not just the releases page)
- [ ] `og:image` resolves to the dark reader screenshot when sharing the URL on Slack / iMessage / Discord
- [ ] All subpages (`/install/`, `/voices/`, `/architecture/`, `/screenshots/`) still reachable from the nav
- [ ] `/version.json` still serves the realm-sigil payload (status.realm.watch check)

🤖 Generated with [Claude Code](https://claude.com/claude-code)