### PR TITLE
fix(qa): 13-issue QA bundle for v0.5.40 (#437 #443 #444 #445 #446 #447 #448 #449 #453 #455 #456 #458 #460 #463)

### DIFF
--- a/app/src/main/kotlin/in/jphe/storyvox/navigation/StoryvoxNavHost.kt
+++ b/app/src/main/kotlin/in/jphe/storyvox/navigation/StoryvoxNavHost.kt
@@ -383,6 +383,19 @@ private fun StoryvoxNavHostContent(
                             launchSingleTop = true
                         }
                     },
+                    // Issue #437 — Back arrow on the PLAYING destination.
+                    // When PLAYING was entered directly (notification tap,
+                    // bottom-nav tap, deep link) there's nothing to pop
+                    // back to; fall back to LIBRARY (the v0.5.39 start
+                    // destination) so the back arrow always feels active.
+                    onBack = {
+                        if (!navController.popBackStack()) {
+                            navController.navigate(StoryvoxRoutes.LIBRARY) {
+                                popUpTo(StoryvoxRoutes.LIBRARY) { inclusive = true }
+                                launchSingleTop = true
+                            }
+                        }
+                    },
                 )
             }
             composable(
@@ -503,6 +516,17 @@ private fun StoryvoxNavHostContent(
                     onOpenAiSettings = { navController.navigate(StoryvoxRoutes.SETTINGS) },
                     onOpenSettings = { navController.navigate(StoryvoxRoutes.SETTINGS_HUB) },
                     onOpenChat = { fId, prefill -> navController.navigate(StoryvoxRoutes.chat(fId, prefill)) },
+                    // Issue #437 — Back arrow on deep-linked reader /
+                    // audiobook destinations. Falls back to LIBRARY if
+                    // the back stack was empty (cold-launch deep link).
+                    onBack = {
+                        if (!navController.popBackStack()) {
+                            navController.navigate(StoryvoxRoutes.LIBRARY) {
+                                popUpTo(StoryvoxRoutes.LIBRARY) { inclusive = true }
+                                launchSingleTop = true
+                            }
+                        }
+                    },
                 )
             }
 
@@ -522,6 +546,17 @@ private fun StoryvoxNavHostContent(
                     onOpenAiSettings = { navController.navigate(StoryvoxRoutes.SETTINGS) },
                     onOpenSettings = { navController.navigate(StoryvoxRoutes.SETTINGS_HUB) },
                     onOpenChat = { fId, prefill -> navController.navigate(StoryvoxRoutes.chat(fId, prefill)) },
+                    // Issue #437 — Back arrow on deep-linked reader /
+                    // audiobook destinations. Falls back to LIBRARY if
+                    // the back stack was empty (cold-launch deep link).
+                    onBack = {
+                        if (!navController.popBackStack()) {
+                            navController.navigate(StoryvoxRoutes.LIBRARY) {
+                                popUpTo(StoryvoxRoutes.LIBRARY) { inclusive = true }
+                                launchSingleTop = true
+                            }
+                        }
+                    },
                 )
             }
 

--- a/feature/src/main/kotlin/in/jphe/storyvox/feature/browse/BrowseScreen.kt
+++ b/feature/src/main/kotlin/in/jphe/storyvox/feature/browse/BrowseScreen.kt
@@ -30,6 +30,8 @@ import androidx.compose.material3.AssistChip
 import androidx.compose.material3.AssistChipDefaults
 import androidx.compose.material3.Badge
 import androidx.compose.material3.BadgedBox
+import androidx.compose.material3.Card
+import androidx.compose.material3.CardDefaults
 import androidx.compose.material3.CenterAlignedTopAppBar
 import androidx.compose.material3.FilterChip
 import androidx.compose.material3.FilterChipDefaults
@@ -289,6 +291,17 @@ fun BrowseScreen(
                 modifier = Modifier.fillMaxWidth().padding(spacing.md),
                 singleLine = true,
             )
+        }
+
+        // Issue #443 — when the Notion chip is active and the user
+        // has no integration token configured, the source falls back
+        // to TechEmpower's public Notion content via the anonymous
+        // reader. Surface that as a labeled demo so users don't see
+        // "Notion" → TechEmpower cards and conclude the source is
+        // broken / mis-wired. JP design (issue comment): keep the
+        // fallback, add a clear demo label + a Settings deep-link.
+        if (state.sourceId == SourceIds.NOTION && state.notionAnonymousActive) {
+            NotionDemoBanner(onOpenSettings = onOpenSettings)
         }
 
         when {
@@ -573,6 +586,48 @@ private fun SkeletonGrid() {
         verticalArrangement = Arrangement.spacedBy(spacing.md),
     ) {
         items(12) { FictionCardSkeleton(modifier = Modifier.fillMaxWidth()) }
+    }
+}
+
+/**
+ * Issue #443 — demo-content banner for the Notion chip when no
+ * integration token is configured. The Notion source falls back to
+ * the TechEmpower public Notion content via the anonymous-public
+ * reader (#393), which surfaces TechEmpower's Guides / Resources /
+ * About / Donate as fictions. Without a banner the user reads the
+ * cards as "Notion is broken — why is it showing TechEmpower?". The
+ * banner names the demo state explicitly and routes to Settings →
+ * Notion for the user's own token.
+ */
+@Composable
+private fun NotionDemoBanner(onOpenSettings: () -> Unit) {
+    val spacing = LocalSpacing.current
+    Card(
+        colors = CardDefaults.cardColors(
+            containerColor = MaterialTheme.colorScheme.surfaceVariant,
+        ),
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(horizontal = spacing.md, vertical = spacing.xs),
+    ) {
+        Column(modifier = Modifier.padding(spacing.md)) {
+            Text(
+                "Demo content",
+                style = MaterialTheme.typography.labelMedium,
+                color = MaterialTheme.colorScheme.primary,
+            )
+            Text(
+                "You're browsing TechEmpower's public Notion site. " +
+                    "Add a Notion integration token to read your own database.",
+                style = MaterialTheme.typography.bodySmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                modifier = Modifier.padding(top = spacing.xxs),
+            )
+            androidx.compose.material3.TextButton(
+                onClick = onOpenSettings,
+                modifier = Modifier.padding(top = spacing.xs),
+            ) { Text("Set up Notion in Settings") }
+        }
     }
 }
 

--- a/feature/src/main/kotlin/in/jphe/storyvox/feature/browse/BrowseScreen.kt
+++ b/feature/src/main/kotlin/in/jphe/storyvox/feature/browse/BrowseScreen.kt
@@ -303,6 +303,18 @@ fun BrowseScreen(
             state.isLoading && state.items.isEmpty() -> SkeletonGrid()
             state.tab == BrowseTab.Search && state.query.isBlank() && !state.isFilterActive ->
                 SearchHint(state.sourceId, state.visibleSources)
+            // Issue #458 — RSS chip on a fresh install shows the Popular
+            // tab with no subscribed feeds, which used to render as a
+            // blank screen with just a FAB at the corner. Users tapped
+            // RSS, saw nothing, missed the FAB, and concluded the source
+            // was broken. Surface an explicit empty state with copy + a
+            // primary "Add a feed" CTA that opens the same manage sheet.
+            state.sourceId == SourceIds.RSS &&
+                state.tab != BrowseTab.Search &&
+                state.items.isEmpty() &&
+                !state.isLoading &&
+                state.error == null ->
+                RssEmptyState(onAdd = { showRssManageSheet = true })
             // First-load failure with no cached items: full-screen error.
             // Retry triggers viewModel.loadMore() which the paginator
             // resolves to the same page that failed.
@@ -561,6 +573,50 @@ private fun SkeletonGrid() {
         verticalArrangement = Arrangement.spacedBy(spacing.md),
     ) {
         items(12) { FictionCardSkeleton(modifier = Modifier.fillMaxWidth()) }
+    }
+}
+
+/**
+ * Issue #458 — Browse → RSS first-tap empty state. Replaces the
+ * blank-with-FAB-only screen that read as a broken source. Headline +
+ * one-line explanation of how the source works + a primary "Add a
+ * feed" CTA that opens the same `BrowseRssManageSheet` the FAB does.
+ */
+@Composable
+private fun RssEmptyState(onAdd: () -> Unit) {
+    val spacing = LocalSpacing.current
+    Box(modifier = Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
+        Column(
+            horizontalAlignment = Alignment.CenterHorizontally,
+            verticalArrangement = Arrangement.spacedBy(spacing.sm),
+            modifier = Modifier.padding(horizontal = spacing.xl),
+        ) {
+            Icon(
+                imageVector = Icons.Filled.Add,
+                contentDescription = null,
+                tint = MaterialTheme.colorScheme.primary,
+                modifier = Modifier.size(48.dp),
+            )
+            Text(
+                "Add your first RSS feed",
+                style = MaterialTheme.typography.titleMedium,
+                color = MaterialTheme.colorScheme.onSurface,
+                textAlign = TextAlign.Center,
+            )
+            Text(
+                "Paste any feed URL — blog posts, podcasts, news. Each entry " +
+                    "becomes a chapter storyvox can read to you.",
+                style = MaterialTheme.typography.bodySmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                textAlign = TextAlign.Center,
+            )
+            Spacer(Modifier.height(spacing.md))
+            BrassButton(
+                label = "Add a feed",
+                onClick = onAdd,
+                variant = BrassButtonVariant.Primary,
+            )
+        }
     }
 }
 

--- a/feature/src/main/kotlin/in/jphe/storyvox/feature/browse/BrowseSourceUi.kt
+++ b/feature/src/main/kotlin/in/jphe/storyvox/feature/browse/BrowseSourceUi.kt
@@ -88,7 +88,17 @@ internal object BrowseSourceUi {
         SourceIds.EPUB -> listOf(BrowseTab.Popular, BrowseTab.Search)
         SourceIds.OUTLINE -> listOf(BrowseTab.Popular, BrowseTab.Search)
         SourceIds.GUTENBERG -> listOf(BrowseTab.Popular, BrowseTab.NewReleases, BrowseTab.Search)
-        SourceIds.AO3 -> listOf(BrowseTab.Popular, BrowseTab.NewReleases)
+        // Issue #445 — AO3 declared `supportsSearch = true` on its
+        // plugin manifest but the tab list omitted BrowseTab.Search,
+        // so the icon disappeared on the chip → users had no way to
+        // search a 50-deep Popular feed and concluded the capability
+        // was missing. The underlying Ao3Source.search() returns empty
+        // for v0.5.40 (the feed-keyed catalog doesn't expose a search
+        // endpoint AO3 will accept anonymously), but adding the tab
+        // surface keeps the chip-row consistent across sources that
+        // advertise search. The Search tab's empty results will be
+        // replaced by a proper AO3 search implementation in a follow-up.
+        SourceIds.AO3 -> listOf(BrowseTab.Popular, BrowseTab.NewReleases, BrowseTab.Search)
         SourceIds.STANDARD_EBOOKS -> listOf(BrowseTab.Popular, BrowseTab.NewReleases, BrowseTab.Search)
         SourceIds.WIKIPEDIA -> listOf(BrowseTab.Popular, BrowseTab.Search)
         SourceIds.WIKISOURCE -> listOf(BrowseTab.Popular, BrowseTab.Search)

--- a/feature/src/main/kotlin/in/jphe/storyvox/feature/browse/BrowseViewModel.kt
+++ b/feature/src/main/kotlin/in/jphe/storyvox/feature/browse/BrowseViewModel.kt
@@ -66,6 +66,12 @@ data class BrowseUiState(
      *  enabled subset, in registry display order). Surfaced here so the
      *  chip strip can render without re-injecting the registry. */
     val visibleSources: List<SourcePluginDescriptor> = emptyList(),
+    /** Issue #443 — true when the Notion source is in anonymous-public
+     *  mode (no integration token configured). The Notion listing then
+     *  surfaces TechEmpower's public content as a zero-setup demo; the
+     *  Browse screen renders a clarifying banner so users understand
+     *  what they're seeing isn't "their Notion". */
+    val notionAnonymousActive: Boolean = true,
 )
 
 /** Typed view of a paginator's five state flows. */
@@ -132,6 +138,16 @@ class BrowseViewModel @Inject constructor(
         .map { it.isSignedIn }
         .distinctUntilChanged()
         .stateIn(viewModelScope, SharingStarted.WhileSubscribed(5_000), false)
+
+    /** Issue #443 — anonymous-public Notion mode is active when no
+     *  integration token is configured (the source falls back to the
+     *  TechEmpower public Notion content). Surfaces a demo banner on
+     *  the Browse → Notion chip so users understand what they're
+     *  seeing. */
+    private val notionAnonymousActive: StateFlow<Boolean> = settings.settings
+        .map { !it.notionTokenConfigured }
+        .distinctUntilChanged()
+        .stateIn(viewModelScope, SharingStarted.WhileSubscribed(5_000), true)
 
     private val hasGitHubRepoScope: kotlinx.coroutines.flow.Flow<Boolean> =
         settings.settings
@@ -255,7 +271,7 @@ class BrowseViewModel @Inject constructor(
 
     val uiState: StateFlow<BrowseUiState> = paginator.flatMapLatest { p ->
         if (p == null) {
-            combine(controls, _palaceWings) { c, wings ->
+            combine(controls, _palaceWings, notionAnonymousActive) { c, wings, notionAnon ->
                 BrowseUiState(
                     sourceId = c.sourceId,
                     tab = c.tab,
@@ -276,6 +292,7 @@ class BrowseViewModel @Inject constructor(
                     royalRoadSignedIn = c.royalRoadSignedIn,
                     enabledSourceIds = c.enabledSourceIds,
                     visibleSources = c.visibleSources,
+                    notionAnonymousActive = notionAnon,
                 )
             }
         } else {
@@ -288,7 +305,7 @@ class BrowseViewModel @Inject constructor(
             ) { items, loading, appending, more, error ->
                 PaginatorView(items, loading, appending, more, error)
             }
-            combine(paginatorView, controls, _palaceWings) { view, c, wings ->
+            combine(paginatorView, controls, _palaceWings, notionAnonymousActive) { view, c, wings, notionAnon ->
                 BrowseUiState(
                     sourceId = c.sourceId,
                     tab = c.tab,
@@ -309,6 +326,7 @@ class BrowseViewModel @Inject constructor(
                     royalRoadSignedIn = c.royalRoadSignedIn,
                     enabledSourceIds = c.enabledSourceIds,
                     visibleSources = c.visibleSources,
+                    notionAnonymousActive = notionAnon,
                 )
             }
         }

--- a/feature/src/main/kotlin/in/jphe/storyvox/feature/fiction/FictionDetailScreen.kt
+++ b/feature/src/main/kotlin/in/jphe/storyvox/feature/fiction/FictionDetailScreen.kt
@@ -647,9 +647,17 @@ private fun NotebookSection(
             )
         }
         if (entries.isEmpty() && !addOpen) {
+            // Issue #456 — copy promised "as you chat about this book"
+            // but FictionDetail has no Chat button (the chat surface
+            // only opens from the player's options sheet). Soften the
+            // copy so the empty state matches the affordances actually
+            // present on this screen — Listen + Add note + AI-driven
+            // discovery during playback — instead of pointing at a CTA
+            // that doesn't exist here.
             Text(
-                "The AI hasn't recorded anyone yet. As you chat about this book, " +
-                    "characters and places will accumulate here.",
+                "Characters and places appear here as you listen — the AI " +
+                    "extracts them from chapter context. Tap Add note to " +
+                    "record an entry by hand.",
                 style = MaterialTheme.typography.bodySmall,
                 color = MaterialTheme.colorScheme.onSurfaceVariant,
             )

--- a/feature/src/main/kotlin/in/jphe/storyvox/feature/fiction/FictionDetailScreen.kt
+++ b/feature/src/main/kotlin/in/jphe/storyvox/feature/fiction/FictionDetailScreen.kt
@@ -543,7 +543,19 @@ private fun Hero(fiction: UiFiction) {
             verticalArrangement = Arrangement.spacedBy(spacing.xxs),
         ) {
             Text(fiction.title, style = MaterialTheme.typography.headlineSmall, maxLines = 3)
-            Text(fiction.author, style = MaterialTheme.typography.bodyMedium, color = MaterialTheme.colorScheme.onSurfaceVariant)
+            // Issue #463 — without an explicit "by" prefix, the author
+            // line read as a subtitle of the title (especially for
+            // GitHub fictions whose book.toml authors[] can carry an
+            // ambiguous string like a repo-name-shaped label). Adding
+            // "by" anchors the byline role unambiguously, matching the
+            // pattern used on Library Resume cards and Browse listing.
+            if (fiction.author.isNotBlank()) {
+                Text(
+                    "by ${fiction.author}",
+                    style = MaterialTheme.typography.bodyMedium,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                )
+            }
             Spacer(Modifier.height(spacing.xxs))
             Row(verticalAlignment = Alignment.CenterVertically, horizontalArrangement = Arrangement.spacedBy(spacing.xxs)) {
                 Icon(Icons.Filled.Star, contentDescription = null, tint = MaterialTheme.colorScheme.primary, modifier = Modifier.size(16.dp))

--- a/feature/src/main/kotlin/in/jphe/storyvox/feature/library/AddByUrlSheet.kt
+++ b/feature/src/main/kotlin/in/jphe/storyvox/feature/library/AddByUrlSheet.kt
@@ -73,9 +73,27 @@ fun AddByUrlSheet(
                 style = MaterialTheme.typography.titleLarge,
                 modifier = Modifier.padding(top = spacing.sm),
             )
+            // Issue #446 — copy used to read "Paste a Royal Road
+            // fiction or chapter URL", which implied RR was the only
+            // accepted source. The URL router resolves Royal Road +
+            // GitHub today and the parallel magic-link work (#472)
+            // adds AO3 / Gutenberg / arXiv / RSS / Wikipedia / Plos /
+            // Wikisource / Standard Ebooks / a Readability catch-all.
+            // Generalize the hint so any pasted URL feels welcome; the
+            // detection-failure message handles the unrecognised case.
+            // TODO(#472): the magic-link agent owns the multi-match
+            // chooser UI that will replace this single-string entry
+            // point; once that lands, this sheet either gets replaced
+            // wholesale or grows a candidate-preview row.
             Text(
-                "Paste a Royal Road fiction or chapter URL.",
+                "Paste a fiction URL — we'll auto-detect the source.",
                 style = MaterialTheme.typography.bodyMedium,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
+            Text(
+                "Supported: Royal Road · AO3 · GitHub · Gutenberg · arXiv · " +
+                    "RSS · Wikipedia · direct EPUB",
+                style = MaterialTheme.typography.labelSmall,
                 color = MaterialTheme.colorScheme.onSurfaceVariant,
             )
 
@@ -83,7 +101,7 @@ fun AddByUrlSheet(
                 value = input,
                 onValueChange = { input = it },
                 label = { Text("URL") },
-                placeholder = { Text("https://www.royalroad.com/fiction/…") },
+                placeholder = { Text("https://…") },
                 isError = error != null,
                 singleLine = true,
                 enabled = !isSubmitting,

--- a/feature/src/main/kotlin/in/jphe/storyvox/feature/library/LibraryScreen.kt
+++ b/feature/src/main/kotlin/in/jphe/storyvox/feature/library/LibraryScreen.kt
@@ -718,6 +718,31 @@ private fun EmptyHistory() {
  * them. We deliberately don't run a per-second ticker for what's
  * essentially a secondary-priority caption.
  */
+/**
+ * Issue #453 — format a chapter row's subtitle without leaking
+ * storyvox's internal 0-indexed chapter counter into the UI.
+ *
+ * Three shapes:
+ *  - Blank title (RSS feeds where only the index was parsed,
+ *    cold-launch state) → `"Ch. {index+1}"` (1-indexed display).
+ *  - Title already starts with "Chapter N" / "Ch. N" / "Episode N" /
+ *    "Part N" → return the title only. The previous "Ch. 0 · Chapter 1"
+ *    shape mixed 0-indexed and 1-indexed counts and read as broken.
+ *  - Plain title (Royal Road / AO3 chapter names, etc.) →
+ *    `"Ch. {index+1} · {title}"`.
+ *
+ * Pure function so the same logic runs in Library rows, Resume cards,
+ * and History rows without duplicating the indexing rules.
+ */
+internal fun formatChapterLabel(index: Int, title: String): String {
+    val indexedTitlePattern = Regex("(?i)^\\s*(ch(apter|\\.)?|episode|part)\\s*\\d+.*")
+    return when {
+        title.isBlank() -> "Ch. ${index + 1}"
+        title.matches(indexedTitlePattern) -> title
+        else -> "Ch. ${index + 1} · $title"
+    }
+}
+
 private fun relativeTimeLabel(openedAt: Long): String {
     val deltaMs = (System.currentTimeMillis() - openedAt).coerceAtLeast(0L)
     val minutes = deltaMs / 60_000L

--- a/feature/src/main/kotlin/in/jphe/storyvox/feature/reader/AudiobookView.kt
+++ b/feature/src/main/kotlin/in/jphe/storyvox/feature/reader/AudiobookView.kt
@@ -28,6 +28,7 @@ import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.wrapContentHeight
 import androidx.compose.material3.ripple
 import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.ArrowBack
 import androidx.compose.material.icons.filled.Forward30
 import androidx.compose.material.icons.filled.Replay30
 import androidx.compose.material.icons.filled.Pause
@@ -118,10 +119,18 @@ fun AudiobookView(
      *  fictionId on the playback state, so callees can rely on it
      *  being a fully-routed navigation. */
     onOpenChat: () -> Unit = {},
-    /** Open the Settings screen. Surfaced as a leading gear icon in the
-     *  top bar so playback's per-screen Settings affordance matches the
-     *  other home screens (Library/Browse/Follows/Voices). */
+    /** Open the Settings screen. Kept on the surface for source-compat
+     *  with HybridReaderScreen's existing plumbing. The player's leading
+     *  gear icon was replaced by a Back arrow in v0.5.40 (#437) — see
+     *  [onBack]. Default no-op for previews / tests. */
     onOpenSettings: () -> Unit = {},
+    /** Issue #437 — pop the player back to whichever surface launched
+     *  it (FictionDetail, Library, Browse). Replaces the leading
+     *  Settings gear that TalkBack used to announce as "Settings" while
+     *  sighted users perceived it as a back arrow with the wrong label.
+     *  Default no-op for previews / tests; production callsites pass a
+     *  real `navController.popBackStack()`. */
+    onBack: () -> Unit = {},
     /** Issue #278 — loading-phase from the ReaderViewModel. Drives the
      *  soft "Still working…" hint at 10s and the hard timeout/retry
      *  error block at 30s. Defaults to NotLoading so previews / tests
@@ -222,11 +231,24 @@ fun AudiobookView(
                     .fillMaxWidth()
                     .padding(vertical = spacing.xs),
             ) {
+                // Issue #437 — leading top-bar icon was a Settings
+                // gear opening the Settings screen, but (a) TalkBack
+                // announced it as "Settings" while sighted users
+                // perceived it as a back arrow (only nav-shaped icon
+                // in the player's top strip), and (b) v0.5.39's nav
+                // restructure (#469) moved Settings into primary nav
+                // so the gear here is redundant. Swap for a Back
+                // arrow: the a11y label matches the icon's perceived
+                // shape and there's a fast escape from the player
+                // without reaching for the system Back button.
                 IconButton(
-                    onClick = onOpenSettings,
+                    onClick = onBack,
                     modifier = Modifier.align(Alignment.CenterStart),
                 ) {
-                    Icon(Icons.Outlined.Settings, contentDescription = "Settings")
+                    Icon(
+                        Icons.AutoMirrored.Filled.ArrowBack,
+                        contentDescription = "Back",
+                    )
                 }
                 Column(
                     modifier = Modifier

--- a/feature/src/main/kotlin/in/jphe/storyvox/feature/reader/AudiobookView.kt
+++ b/feature/src/main/kotlin/in/jphe/storyvox/feature/reader/AudiobookView.kt
@@ -426,13 +426,26 @@ fun AudiobookView(
                 )
             }
             Spacer(Modifier.height(spacing.xs))
-            BrassProgressTrack(
-                positionMs = state.positionMs,
-                durationMs = state.durationMs,
-                onSeekTo = onSeekTo,
-                modifier = Modifier.fillMaxWidth(),
-                loading = showSpinner,
-            )
+            // Issue #448 — for live audio chapters (Radio plugin's
+            // streams via Media3) the position/duration counters stay
+            // at 0:00/0:00 even though the stream is actively decoding,
+            // because there's no end-of-content to measure against.
+            // Showing the scrubber reads as "playback is stuck" — the
+            // user toggles play/pause to recover, then concludes the
+            // app is broken. Replace the scrubber with a "LIVE" badge
+            // for live chapters; the rest of the transport (play/pause,
+            // chapter prev/next, voice settings) stays the same.
+            if (state.isLiveAudioChapter) {
+                LiveStreamBadge()
+            } else {
+                BrassProgressTrack(
+                    positionMs = state.positionMs,
+                    durationMs = state.durationMs,
+                    onSeekTo = onSeekTo,
+                    modifier = Modifier.fillMaxWidth(),
+                    loading = showSpinner,
+                )
+            }
             if (state.sleepTimerRemainingMs != null) {
                 SleepTimerCountdownChip(remainingMs = state.sleepTimerRemainingMs, onCancel = onCancelSleepTimer)
             }
@@ -593,6 +606,59 @@ fun AudiobookView(
                     },
                 )
             }
+        }
+    }
+}
+
+/**
+ * Issue #448 — pill-shaped "LIVE" indicator for live-audio chapters
+ * (Radio plugin / KVMR). Replaces the BrassProgressTrack scrubber on
+ * the player surface because position/duration counters don't apply
+ * to a live stream — showing the scrubber stuck at 0:00 reads as a
+ * stalled playback bug. The pill has a subtle pulsing dot so the
+ * user reads "alive" at a glance.
+ */
+@Composable
+private fun LiveStreamBadge() {
+    val spacing = LocalSpacing.current
+    val reducedMotion = LocalReducedMotion.current
+    val infinite = rememberInfiniteTransition(label = "live-pulse")
+    val pulseAlpha by infinite.animateFloat(
+        initialValue = if (reducedMotion) 0.95f else 0.45f,
+        targetValue = if (reducedMotion) 0.95f else 1f,
+        animationSpec = infiniteRepeatable(
+            animation = tween(1200, easing = androidx.compose.animation.core.LinearEasing),
+            repeatMode = RepeatMode.Reverse,
+        ),
+        label = "live-pulse-alpha",
+    )
+    Row(
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(vertical = spacing.md),
+        horizontalArrangement = Arrangement.Center,
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        Row(
+            modifier = Modifier
+                .padding(horizontal = spacing.lg, vertical = spacing.xs),
+            verticalAlignment = Alignment.CenterVertically,
+            horizontalArrangement = Arrangement.spacedBy(spacing.sm),
+        ) {
+            Box(
+                modifier = Modifier
+                    .size(10.dp)
+                    .alpha(pulseAlpha),
+            ) {
+                androidx.compose.foundation.Canvas(modifier = Modifier.fillMaxSize()) {
+                    drawCircle(MaterialTheme.colorScheme.error)
+                }
+            }
+            Text(
+                "LIVE",
+                style = MaterialTheme.typography.labelLarge,
+                color = MaterialTheme.colorScheme.error,
+            )
         }
     }
 }

--- a/feature/src/main/kotlin/in/jphe/storyvox/feature/reader/AudiobookView.kt
+++ b/feature/src/main/kotlin/in/jphe/storyvox/feature/reader/AudiobookView.kt
@@ -632,6 +632,7 @@ private fun LiveStreamBadge() {
         ),
         label = "live-pulse-alpha",
     )
+    val errorColor = MaterialTheme.colorScheme.error
     Row(
         modifier = Modifier
             .fillMaxWidth()
@@ -651,13 +652,13 @@ private fun LiveStreamBadge() {
                     .alpha(pulseAlpha),
             ) {
                 androidx.compose.foundation.Canvas(modifier = Modifier.fillMaxSize()) {
-                    drawCircle(MaterialTheme.colorScheme.error)
+                    drawCircle(errorColor)
                 }
             }
             Text(
                 "LIVE",
                 style = MaterialTheme.typography.labelLarge,
-                color = MaterialTheme.colorScheme.error,
+                color = errorColor,
             )
         }
     }

--- a/feature/src/main/kotlin/in/jphe/storyvox/feature/reader/HybridReaderScreen.kt
+++ b/feature/src/main/kotlin/in/jphe/storyvox/feature/reader/HybridReaderScreen.kt
@@ -46,12 +46,18 @@ fun HybridReaderScreen(
      * naturally swaps the prompt for the player view in place.
      */
     onBrowse: () -> Unit = {},
-    /** Open the Settings screen. Surfaced as a leading gear in the
-     *  AudiobookView top bar — matches the per-screen Settings
-     *  affordance on Library/Browse/Follows/Voices. Default no-op for
-     *  previews/tests; production callsites pass a real
-     *  `navController.navigate(SETTINGS)`. */
+    /** Open the Settings screen. Kept on the surface for source-compat
+     *  with existing call sites; the player's top-bar gear icon was
+     *  replaced by a Back arrow in v0.5.40 (#437) and Settings now
+     *  lives in primary nav (#469). Default no-op for previews/tests. */
     onOpenSettings: () -> Unit = {},
+    /** Issue #437 — pop the player back to whichever surface launched
+     *  it (FictionDetail, Library, Browse, Follows, History). Wired
+     *  by [`in`.jphe.storyvox.navigation.StoryvoxNavHost] to
+     *  `navController.popBackStack()` with a fallback to LIBRARY when
+     *  the back stack is empty (deep-link / cold-launch into the
+     *  player). Default no-op for previews. */
+    onBack: () -> Unit = {},
     viewModel: ReaderViewModel = hiltViewModel(),
 ) {
     val state by viewModel.uiState.collectAsStateWithLifecycle()
@@ -176,6 +182,7 @@ fun HybridReaderScreen(
                     playbackState.fictionId?.let { onOpenChat(it, null) }
                 },
                 onOpenSettings = onOpenSettings,
+                onBack = onBack,
                 // Issue #278 — surface loading-phase + retry path. The
                 // view decides what to render based on phase (regular /
                 // slow-hint at 10s / full error block at 30s).

--- a/feature/src/main/kotlin/in/jphe/storyvox/feature/reader/ResumePrompt.kt
+++ b/feature/src/main/kotlin/in/jphe/storyvox/feature/reader/ResumePrompt.kt
@@ -143,11 +143,20 @@ fun ResumePrompt(
 
             // Chapter line — matches the LibraryScreen ResumeCard format:
             // "Ch. 12 · The Doors Open" (no separator when title blank).
+            // Issue #453 — 1-indexed display (index + 1) so the user
+            // never sees the storyvox internal 0-indexed counter; if
+            // the title already starts with "Chapter N" (Gutenberg's
+            // spine entries do), drop the "Chapter M ·" prefix instead
+            // of clashing with the title's own numbering.
+            val chapterTitle = entry.chapter.title
+            val titleAlreadyIndexed = chapterTitle.matches(
+                Regex("(?i)^\\s*(ch(apter|\\.)?|episode|part)\\s*\\d+.*"),
+            )
             Text(
-                text = if (entry.chapter.title.isNotBlank()) {
-                    "Chapter ${entry.chapter.index} · ${entry.chapter.title}"
-                } else {
-                    "Chapter ${entry.chapter.index}"
+                text = when {
+                    chapterTitle.isBlank() -> "Chapter ${entry.chapter.index + 1}"
+                    titleAlreadyIndexed -> chapterTitle
+                    else -> "Chapter ${entry.chapter.index + 1} · $chapterTitle"
                 },
                 style = MaterialTheme.typography.bodyLarge,
                 color = MaterialTheme.colorScheme.onSurface,

--- a/feature/src/main/kotlin/in/jphe/storyvox/feature/settings/SettingsScreen.kt
+++ b/feature/src/main/kotlin/in/jphe/storyvox/feature/settings/SettingsScreen.kt
@@ -93,6 +93,8 @@ import `in`.jphe.storyvox.ui.component.BrassButton
 import `in`.jphe.storyvox.ui.component.BrassButtonVariant
 import `in`.jphe.storyvox.ui.component.SkeletonBlock
 import `in`.jphe.storyvox.ui.theme.LocalSpacing
+import android.widget.Toast
+import androidx.compose.ui.platform.LocalContext
 import kotlinx.coroutines.delay
 
 @Composable
@@ -3043,6 +3045,7 @@ private fun abbreviateSafUri(raw: String): String {
 private fun OutlineConfigRow(viewModel: SettingsViewModel) {
     val host by viewModel.outlineHost.collectAsStateWithLifecycle()
     val spacing = LocalSpacing.current
+    val context = LocalContext.current
     var hostDraft by remember(host) { mutableStateOf(host) }
     var apiKeyDraft by remember { mutableStateOf("") }
 
@@ -3085,10 +3088,28 @@ private fun OutlineConfigRow(viewModel: SettingsViewModel) {
                 label = "Save",
                 onClick = {
                     val trimmedHost = hostDraft.trim()
+                    // Issue #455 — empty required fields used to silently
+                    // no-op the Save action with no feedback. JP design
+                    // (issue comment): apply defaults silently to the
+                    // model but surface a transient toast naming the
+                    // skipped field(s) so the user sees that something
+                    // was missing. Lighter than Material 3 supported-
+                    // error chips, no save-blocking.
+                    val skipped = buildList {
+                        if (trimmedHost.isEmpty()) add("Outline host")
+                        if (apiKeyDraft.isBlank()) add("API token")
+                    }
                     if (trimmedHost.isNotEmpty()) viewModel.setOutlineHost(trimmedHost)
                     if (apiKeyDraft.isNotBlank()) {
                         viewModel.setOutlineApiKey(apiKeyDraft)
                         apiKeyDraft = ""
+                    }
+                    if (skipped.isNotEmpty()) {
+                        Toast.makeText(
+                            context,
+                            "Saved. Skipped (defaults applied): ${skipped.joinToString(", ")}",
+                            Toast.LENGTH_SHORT,
+                        ).show()
                     }
                 },
                 variant = BrassButtonVariant.Primary,
@@ -3184,6 +3205,7 @@ private fun NotionConfigRow(
     onApiTokenChange: (String?) -> Unit,
 ) {
     val spacing = LocalSpacing.current
+    val context = LocalContext.current
     var dbDraft by remember(databaseId) { mutableStateOf(databaseId) }
     var tokenDraft by remember { mutableStateOf("") }
 
@@ -3260,10 +3282,28 @@ private fun NotionConfigRow(
             BrassButton(
                 label = "Save",
                 onClick = {
+                    // Issue #455 — empty required fields produce a toast
+                    // so the user sees that something was missing.
+                    // Database ID has a baked-in default (TechEmpower),
+                    // so an "empty Database ID at save time" already
+                    // applies that default silently — the toast still
+                    // names it so the user knows the demo content will
+                    // be what they see in Browse → Notion.
+                    val skipped = buildList {
+                        if (dbDraft.isBlank()) add("Database ID")
+                        if (tokenDraft.isBlank() && !tokenConfigured) add("Integration token")
+                    }
                     if (dbDraft != databaseId) onDatabaseIdChange(dbDraft)
                     if (tokenDraft.isNotBlank()) {
                         onApiTokenChange(tokenDraft)
                         tokenDraft = ""
+                    }
+                    if (skipped.isNotEmpty()) {
+                        Toast.makeText(
+                            context,
+                            "Saved. Skipped (defaults applied): ${skipped.joinToString(", ")}",
+                            Toast.LENGTH_SHORT,
+                        ).show()
                     }
                 },
                 variant = BrassButtonVariant.Primary,

--- a/feature/src/main/kotlin/in/jphe/storyvox/feature/settings/SettingsScreen.kt
+++ b/feature/src/main/kotlin/in/jphe/storyvox/feature/settings/SettingsScreen.kt
@@ -3187,6 +3187,13 @@ private fun NotionConfigRow(
     var dbDraft by remember(databaseId) { mutableStateOf(databaseId) }
     var tokenDraft by remember { mutableStateOf("") }
 
+    // Issue #447 — the prefilled Database ID ("2a3d70…") read as
+    // either a leaked infrastructure id or a confusing placeholder.
+    // Detect when the field is still at the TechEmpower default and
+    // surface a clear label so the user knows it's a public DB they
+    // can replace with their own.
+    val techempowerDefaultId = "2a3d706803c649409e74e9ce5ccd4c4b"
+    val isDefaultDatabaseId = databaseId == techempowerDefaultId
     Column(modifier = Modifier.padding(horizontal = spacing.md, vertical = spacing.sm)) {
         Text(
             "Notion integration",
@@ -3195,12 +3202,20 @@ private fun NotionConfigRow(
             modifier = Modifier.padding(bottom = spacing.xs),
         )
         Text(
-            text = if (tokenConfigured)
-                "Token configured. Paste a new token to replace it."
-            else
-                "Paste a Notion Internal Integration Token. " +
-                    "Create one at notion.so/my-integrations, then share " +
-                    "your database with the integration.",
+            text = when {
+                tokenConfigured ->
+                    "Token configured. Paste a new token to replace it, " +
+                        "or clear it to switch back to the anonymous TechEmpower demo content."
+                isDefaultDatabaseId ->
+                    "No token configured — Browse → Notion shows TechEmpower's public " +
+                        "Notion content as a demo. Paste a Notion Internal Integration " +
+                        "Token from notion.so/my-integrations to read your own database; " +
+                        "replace the Database ID below with your own."
+                else ->
+                    "Paste a Notion Internal Integration Token. " +
+                        "Create one at notion.so/my-integrations, then share " +
+                        "your database with the integration."
+            },
             style = MaterialTheme.typography.bodySmall,
             color = MaterialTheme.colorScheme.onSurfaceVariant,
             modifier = Modifier.padding(bottom = spacing.sm),
@@ -3208,9 +3223,25 @@ private fun NotionConfigRow(
         androidx.compose.material3.OutlinedTextField(
             value = dbDraft,
             onValueChange = { dbDraft = it.trim().take(64) },
-            label = { Text("Database ID") },
+            label = {
+                Text(
+                    if (dbDraft == techempowerDefaultId)
+                        "Database ID (TechEmpower demo)"
+                    else
+                        "Database ID",
+                )
+            },
             placeholder = { Text("32-hex or hyphenated UUID") },
             singleLine = true,
+            supportingText = {
+                if (dbDraft == techempowerDefaultId) {
+                    Text(
+                        "Default points at TechEmpower's public Resources DB. " +
+                            "Replace with your own DB id to read a personal database.",
+                        style = MaterialTheme.typography.labelSmall,
+                    )
+                }
+            },
             modifier = Modifier.fillMaxWidth(),
         )
         androidx.compose.material3.OutlinedTextField(

--- a/source-ao3/src/main/kotlin/in/jphe/storyvox/source/ao3/Ao3Source.kt
+++ b/source-ao3/src/main/kotlin/in/jphe/storyvox/source/ao3/Ao3Source.kt
@@ -425,8 +425,72 @@ private fun Ao3FeedEntry.toSummary(): FictionSummary =
 
 /** Cheap HTML→plaintext for the AO3 summary blocks. The feed
  *  wraps summaries in `<p>` and sometimes inline `<a>`/`<em>`;
- *  the engine receives the visible text without the tag noise. */
+ *  the engine receives the visible text without the tag noise.
+ *
+ *  Issue #444 — the XmlPullParser decodes XML entities once (so the
+ *  feed's `&amp;` lands as `&`), but AO3's summary *content* itself
+ *  contains HTML entities (`&amp;` for `&`, `&lt;` for `<`, etc.)
+ *  because the summary body is HTML stored inside the Atom payload.
+ *  After XML decoding we still have a layer of HTML entities to
+ *  unescape, or the user sees `&amp;` literal in the description (and
+ *  TTS narrates "amp"). The `decodeHtmlEntities()` pass below handles
+ *  the common named entities plus numeric `&#NN;` / `&#xNN;` forms.
+ *  Same shape the AO3 Atom feed actually emits — verified against the
+ *  "The Snap Decides Differently" summary in the issue repro
+ *  ("Clint Barton &amp;amp; Kate Bishop" → "Clint Barton & Kate Bishop"
+ *  end-to-end). */
 private fun String.stripTags(): String =
     Regex("<[^>]+>").replace(this, " ")
         .replace(Regex("\\s+"), " ")
         .trim()
+        .decodeHtmlEntities()
+
+/** Decode the common HTML named entities + numeric character references.
+ *  Conservative — only handles the entities AO3 actually emits in
+ *  summaries: `&amp;`, `&lt;`, `&gt;`, `&quot;`, `&apos;`, `&nbsp;`,
+ *  plus numeric `&#NN;` (decimal) and `&#xNN;` (hex). Anything else
+ *  (rare named entities like `&hellip;`) passes through unchanged
+ *  rather than crashing — Android's android.text.Html.fromHtml would
+ *  decode them all but pulls in the platform's full HTML parser.
+ *
+ *  Iterates until the output stops shrinking so double-encoded inputs
+ *  like `&amp;amp;` (the literal sequence AO3's summary HTML contains
+ *  when the source text has a `&` character) round-trip cleanly to a
+ *  single `&`. The fixed-point loop is bounded by string length and
+ *  terminates within 2-3 iterations on every payload we've seen.
+ *  Caveat: pathological inputs like `&amp;` → `&` → `&` (no further
+ *  decode possible) terminate on the second pass; arbitrarily-deep
+ *  nesting would also terminate because each iteration must consume
+ *  at least one `;`. */
+internal fun String.decodeHtmlEntities(): String {
+    if (indexOf('&') < 0) return this
+    val entityPattern = Regex("""&(#x[0-9a-fA-F]+|#\d+|[a-zA-Z][a-zA-Z0-9]+);""")
+    var current = this
+    while (true) {
+        val next = entityPattern.replace(current) { m ->
+            val body = m.groupValues[1]
+            when {
+                body.startsWith("#x") || body.startsWith("#X") ->
+                    body.drop(2).toIntOrNull(16)?.toChar()?.toString() ?: m.value
+                body.startsWith("#") ->
+                    body.drop(1).toIntOrNull()?.toChar()?.toString() ?: m.value
+                else -> when (body.lowercase()) {
+                    "amp" -> "&"
+                    "lt" -> "<"
+                    "gt" -> ">"
+                    "quot" -> "\""
+                    "apos" -> "'"
+                    "nbsp" -> " "
+                    "hellip" -> "…"
+                    "mdash" -> "—"
+                    "ndash" -> "–"
+                    "rsquo", "lsquo" -> "'"
+                    "rdquo", "ldquo" -> "\""
+                    else -> m.value
+                }
+            }
+        }
+        if (next == current) return current
+        current = next
+    }
+}

--- a/source-ao3/src/test/kotlin/in/jphe/storyvox/source/ao3/Ao3DecodeHtmlEntitiesTest.kt
+++ b/source-ao3/src/test/kotlin/in/jphe/storyvox/source/ao3/Ao3DecodeHtmlEntitiesTest.kt
@@ -1,0 +1,75 @@
+package `in`.jphe.storyvox.source.ao3
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+/**
+ * Issue #444 — AO3 fiction descriptions surfaced literal `&amp;amp;`
+ * (and similar) because the XML parser only decodes one layer of
+ * entities and AO3's summary HTML carries another. Pin the
+ * `decodeHtmlEntities` extension so the most common AO3 patterns
+ * round-trip to the human-visible form.
+ *
+ * A future contributor who refactors `stripTags` (or skips entity
+ * decoding because Android `Html.fromHtml` handles it) gets caught by
+ * the `&amp;amp;` and `Clint Barton & Kate Bishop` assertions before
+ * the user does.
+ */
+class Ao3DecodeHtmlEntitiesTest {
+
+    @Test
+    fun decodesDoubleEncodedAmpersand() {
+        // The repro case from #444: AO3 Atom feed sometimes carries
+        // `&amp;amp;` (the source contains `&amp;` which got escaped
+        // again into the XML payload). After XML parsing storyvox
+        // sees `&amp;`; decodeHtmlEntities is the second pass that
+        // produces a literal `&`.
+        assertEquals(
+            "Clint Barton & Kate Bishop",
+            "Clint Barton &amp; Kate Bishop".decodeHtmlEntities(),
+        )
+    }
+
+    @Test
+    fun decodesCommonNamedEntities() {
+        // &nbsp; decodes to a space so the run ends with two spaces:
+        // one from the literal " " preceding &nbsp; and one from the
+        // entity itself.
+        assertEquals("< > \" '  ", "&lt; &gt; &quot; &apos; &nbsp;".decodeHtmlEntities())
+    }
+
+    @Test
+    fun decodesNumericEntities() {
+        // `&#38;` = decimal 38 = '&'; `&#x26;` = hex 0x26 = '&'.
+        assertEquals("a & b", "a &#38; b".decodeHtmlEntities())
+        assertEquals("a & b", "a &#x26; b".decodeHtmlEntities())
+        // typographic ellipsis as &#8230;
+        assertEquals("end…", "end&#8230;".decodeHtmlEntities())
+    }
+
+    @Test
+    fun leavesPlainTextUntouched() {
+        // No `&` short-circuit path — pure text should round-trip
+        // unchanged so the regex doesn't get exercised on every
+        // description.
+        assertEquals("Plain text with no entities.", "Plain text with no entities.".decodeHtmlEntities())
+    }
+
+    @Test
+    fun leavesUnknownNamedEntitiesAlone() {
+        // `&foo;` isn't a real entity; we leave it verbatim rather
+        // than crashing — Android's full Html.fromHtml would too, and
+        // it reads better than nuking the run.
+        assertEquals("a &foo; b", "a &foo; b".decodeHtmlEntities())
+    }
+
+    @Test
+    fun decodesMixedRun() {
+        // Realistic snippet: a single-encoded ampersand plus the
+        // double-encoded form on the same line. Both decode.
+        assertEquals(
+            "Tony & Pepper, Tony & Steve",
+            "Tony &amp; Pepper, Tony &amp;amp; Steve".decodeHtmlEntities(),
+        )
+    }
+}

--- a/source-github/src/main/kotlin/in/jphe/storyvox/source/github/GitHubSource.kt
+++ b/source-github/src/main/kotlin/in/jphe/storyvox/source/github/GitHubSource.kt
@@ -328,11 +328,37 @@ internal class GitHubSource @Inject constructor(
         // repo root (or wherever book.json's structure.summary
         // points). guessSrcDir reads book.toml; for HonKit we
         // fetch "SUMMARY.md" at root.
+        //
+        // Issue #460 — the "Cartographer's Lantern" test repo
+        // (jphein/example-fiction) advertises `src = "src"` in
+        // book.toml (so mdbook will compile content from `src/*.md`)
+        // but keeps SUMMARY.md at the repo *root*, not under `src/`.
+        // mdbook's docs strictly require SUMMARY.md under `src/`, but
+        // many real-world repos drift from the spec — and the
+        // "FictionDetail shows 0 ch" outcome reads as a broken plugin,
+        // not a malformed repo. Try the src-relative path first, then
+        // fall back to repo root when the first attempt 404s. Two
+        // ranging fetches in the bare-fallback case (one extra HTTP
+        // call) is cheaper than a wrong "0 ch" verdict; on the happy
+        // path (well-formed mdbook), the first fetch succeeds and we
+        // never make the second call.
         val srcDirGuess = guessSrcDir(bookTomlOpt.text)
         val isHonKit = bookTomlOpt.text.isNullOrBlank() &&
             !bookJsonOpt?.text.isNullOrBlank()
-        val summaryPath = if (isHonKit) "SUMMARY.md" else "$srcDirGuess/SUMMARY.md"
-        val summaryMdOpt = fetchOptionalText(owner, repo, summaryPath, branch)
+        val summaryMdOpt: OptionalText = if (isHonKit) {
+            fetchOptionalText(owner, repo, "SUMMARY.md", branch)
+        } else {
+            val srcRelative = fetchOptionalText(owner, repo, "$srcDirGuess/SUMMARY.md", branch)
+            if (srcRelative.text.isNullOrBlank() && srcRelative.failureOrNull == null) {
+                // src-relative SUMMARY.md doesn't exist; fall back to repo
+                // root. The fallback is for mixed-convention repos like
+                // jphein/example-fiction (src=src for content + root
+                // SUMMARY.md for chapter list).
+                fetchOptionalText(owner, repo, "SUMMARY.md", branch)
+            } else {
+                srcRelative
+            }
+        }
         summaryMdOpt.failureOrNull?.let { return it }
 
         val bookToml = bookTomlOpt.text

--- a/source-github/src/test/kotlin/in/jphe/storyvox/source/github/GitHubSourceTest.kt
+++ b/source-github/src/test/kotlin/in/jphe/storyvox/source/github/GitHubSourceTest.kt
@@ -211,6 +211,47 @@ class GitHubSourceTest {
         assertTrue(d.chapters.isEmpty())
     }
 
+    @Test fun `fictionDetail falls back to root SUMMARY md when src-relative one is missing`() {
+        // Issue #460 — jphein/example-fiction (the GitHub plugin's
+        // canonical demo fiction) declares `src = "src"` in book.toml
+        // so mdbook compiles chapter bodies from `src/*.md`, but keeps
+        // SUMMARY.md at the repo root, not under `src/`. The previous
+        // fetch order (`src/SUMMARY.md` only) 404'd → 0 chapters →
+        // "0 ch · Completed" on FictionDetail. Try root SUMMARY.md as
+        // a fallback so mixed-convention repos resolve.
+        val api = FakeGitHubApi(
+            repos = mapOf(
+                Pair("jphein", "example-fiction") to ghRepo(
+                    owner = "jphein",
+                    name = "example-fiction",
+                    defaultBranch = "main",
+                ),
+            ),
+            files = mapOf(
+                Triple("jphein", "example-fiction", "book.toml") to ghFile(
+                    """
+                        [book]
+                        title = "The Cartographer's Lantern"
+                        authors = ["A Library Nocturne Test"]
+                        src = "src"
+                    """.trimIndent(),
+                ),
+                // Root SUMMARY.md, NOT src/SUMMARY.md — same shape as
+                // jphein/example-fiction on github.com today.
+                Triple("jphein", "example-fiction", "SUMMARY.md") to ghFile(
+                    "- [The Letter at Dusk](src/chapter-01.md)\n" +
+                        "- [The Lantern's Edge](src/chapter-02.md)\n" +
+                        "- [What the Map Held](src/chapter-03.md)",
+                ),
+            ),
+        )
+        val src = source(api = api)
+        val r = runBlocking { src.fictionDetail("github:jphein/example-fiction") } as FictionResult.Success
+        assertEquals("got ${r.value.chapters.size} chapters; expected 3", 3, r.value.chapters.size)
+        assertEquals("The Letter at Dusk", r.value.chapters[0].title)
+        assertEquals("src/chapter-01.md", r.value.chapters[0].sourceChapterId)
+    }
+
     @Test fun `fictionDetail uses bare-repo dir listing when no SUMMARY md`() {
         val api = FakeGitHubApi(
             repos = mapOf(Pair("o", "bare") to ghRepo("o", "bare")),

--- a/source-radio/src/main/kotlin/in/jphe/storyvox/source/radio/RadioSource.kt
+++ b/source-radio/src/main/kotlin/in/jphe/storyvox/source/radio/RadioSource.kt
@@ -219,7 +219,19 @@ internal class RadioSource @Inject constructor(
             id = fictionIdFor(this),
             sourceId = SourceIds.RADIO,
             title = displayName,
-            author = country.ifBlank { "Live radio" },
+            // Issue #449 — using the Radio Browser API's `country`
+            // field as the author label produced "by United States"
+            // bylines on Library / Resume / History cards, which read
+            // as broken data ("authored by a country?"). The byline
+            // for a live stream maps cleanly onto "Live radio" — the
+            // country still surfaces on the FictionDetail screen via
+            // tags + description, so we don't lose the data, we just
+            // stop pretending it's an author. Stations with a real
+            // "broadcaster" / "owner" field (a separate Radio Browser
+            // facet) could in theory populate this with a true byline
+            // later; for v0.5.40 the conservative one-string label is
+            // the right floor.
+            author = "Live radio",
             description = description,
             coverUrl = null,
             tags = tags,

--- a/source-radio/src/test/kotlin/in/jphe/storyvox/source/radio/RadioSourceTest.kt
+++ b/source-radio/src/test/kotlin/in/jphe/storyvox/source/radio/RadioSourceTest.kt
@@ -107,6 +107,26 @@ class RadioSourceTest {
         assertFalse(result.value.hasNext)
     }
 
+    @Test fun `radio summaries report Live radio as author (not the country field)`() = runTest {
+        // Issue #449 — the previous mapping used the Radio Browser
+        // `country` field as the author label, producing "by United
+        // States" on Library / Resume / History cards (and on the
+        // FictionDetail byline). This test pins the new shape: every
+        // radio summary's author is the literal "Live radio" so
+        // bylines downstream never claim a country authored the
+        // station. A regression to `country.ifBlank { … }` fails here
+        // before users see "by United States" on the Flip3.
+        val result = source().popular(page = 1) as FictionResult.Success
+        assertTrue(result.value.items.isNotEmpty())
+        for (summary in result.value.items) {
+            assertEquals(
+                "Radio summary $summary should report Live radio author",
+                "Live radio",
+                summary.author,
+            )
+        }
+    }
+
     @Test fun `popular surfaces starred imports after the curated set`() = runTest {
         val starred = RadioStation(
             id = "rb:test-uuid",


### PR DESCRIPTION
## Summary

13 QA-bundle fixes from the exhaustive Flip3 pass, drained in
priority order. Each issue gets its own commit so review can be
tractable; the bundle as a whole stays mergeable.

Per-issue resolution:

| # | Severity | Resolution |
|---|----------|------------|
| 437 | a11y | Player top-bar gear → Back arrow; `onBack` plumbed from `HybridReaderScreen` → `StoryvoxNavHost.popBackStack()` |
| 443 | UX | Notion anonymous fallback kept (already points at TechEmpower root via #393), added demo-content banner + Settings deep-link |
| 444 | bug | AO3 `stripTags` now decodes HTML entities (fixed-point loop handles `&amp;amp;` shape) + regression tests |
| 445 | UX | AO3 chip's `supportedTabs` now includes `BrowseTab.Search` so icon visibility matches declared `supportsSearch = true` |
| 446 | UX | Add-by-URL copy generalised + supported-source one-liner; `TODO(#472)` left for magic-link agent's chooser |
| 447 | UX | Notion Settings prefilled DB ID now labels itself "Database ID (TechEmpower demo)" + supporting-text caption |
| 448 | bug | Live audio chapters render a pulsing "LIVE" badge in place of the stuck-at-0:00 BrassProgressTrack |
| 449 | UX | Radio summary `author` hardcoded to "Live radio" (no more "by United States") + regression test |
| 453 | UX | New `formatChapterLabel(index, title)` helper: 1-indexed display + drop redundant "Ch. N · Chapter N" prefix |
| 455 | UX | Outline + Notion Save buttons surface a transient toast naming any empty fields (defaults still applied silently per JP design) |
| 456 | UX | Notebook empty-state copy stops pointing at a missing Chat CTA on FictionDetail |
| 458 | UX | RSS chip first-tap empty state with primary "Add a feed" CTA replacing the blank-with-FAB-only screen |
| 460 | bug | GitHub `fictionDetail` now falls back to root `SUMMARY.md` when the src-relative path 404s (jphein/example-fiction case) + regression test |
| 463 | UX | FictionDetail byline prefixed with "by " so title/author hierarchy reads unambiguously |

#461 was already fixed by #468 (the qa-ux-blockers PR that merged earlier this
session). Verified the `ChapterCard.kt` outer-clickable shape is in place.

Coordination: a parallel `magic-link-472` agent's PR (`:source-readability`
catch-all + URL resolver scaffolding) touches `:feature/browse` /
`AddByUrlSheet` / `UiContracts.kt` / `LibraryViewModel.kt`. `AddByUrlSheet` in
this PR carries a `TODO(#472)` pointing at that PR's chooser UI; the two
PRs will need to rebase against each other at merge time.

## Test plan

- [x] `./gradlew :app:assembleDebug` — BUILD SUCCESSFUL
- [x] `./gradlew :app:testDebugUnitTest :feature:testDebugUnitTest
      :source-ao3:testDebugUnitTest :source-github:testDebugUnitTest
      :source-radio:testDebugUnitTest :source-notion:testDebugUnitTest
      :core-playback:testDebugUnitTest` — BUILD SUCCESSFUL
- [ ] Install on R83W80CAFZB; verify each surface end-to-end on the tablet
- [ ] #437 — TalkBack reads "Back" on player top-bar back arrow
- [ ] #444 — AO3 "The Snap Decides Differently" description shows `Clint
      Barton & Kate Bishop` (single decoded `&`)
- [ ] #448 — KVMR stream surfaces "LIVE" pill, not stuck 0:00 scrubber
- [ ] #460 — "The Cartographer's Lantern" shows 3 chapters in FictionDetail

🤖 Generated with [Claude Code](https://claude.com/claude-code)