### PR TITLE
Improve accessibility labels for shared rows and chat affordances

### DIFF
--- a/feature/src/main/kotlin/in/jphe/storyvox/feature/chat/ChatScreen.kt
+++ b/feature/src/main/kotlin/in/jphe/storyvox/feature/chat/ChatScreen.kt
@@ -56,6 +56,8 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.alpha
 import androidx.compose.ui.draw.clip
+import androidx.compose.ui.semantics.contentDescription
+import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
@@ -330,6 +332,9 @@ private fun ReadAloudButton(
     }
     androidx.compose.material3.TextButton(
         onClick = onClick,
+        modifier = Modifier.semantics(mergeDescendants = true) {
+            contentDescription = label
+        },
         contentPadding = androidx.compose.foundation.layout.PaddingValues(
             horizontal = 8.dp, vertical = 0.dp,
         ),
@@ -443,6 +448,9 @@ private fun ToolCallCard(event: ToolCallEvent) {
     Row(
         modifier = Modifier
             .fillMaxWidth()
+            .semantics(mergeDescendants = true) {
+                contentDescription = statusText
+            }
             .border(BorderStroke(1.dp, borderColor), RoundedCornerShape(8.dp))
             .background(
                 MaterialTheme.colorScheme.surfaceVariant.copy(alpha = 0.4f),

--- a/feature/src/main/kotlin/in/jphe/storyvox/feature/settings/SettingsComposables.kt
+++ b/feature/src/main/kotlin/in/jphe/storyvox/feature/settings/SettingsComposables.kt
@@ -40,6 +40,8 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.semantics.Role
+import androidx.compose.ui.semantics.contentDescription
+import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
@@ -160,6 +162,9 @@ fun SettingsRow(
         .fillMaxWidth()
         .heightIn(min = 64.dp)
         .let { m -> if (onClick != null) m.clickable(role = Role.Button, onClick = onClick) else m }
+        .semantics(mergeDescendants = true) {
+            contentDescription = listOfNotNull(title, subtitle).joinToString(", ")
+        }
         .padding(horizontal = spacing.md, vertical = spacing.sm)
 
     Row(


### PR DESCRIPTION
This tightens a few of the accessibility audit findings by merging semantics for shared settings rows and the chat read-aloud/tool-call affordances. The visible icon labels remain decorative where adjacent text already explains the action, while TalkBack now receives the row/action text as a single useful announcement instead of encountering unlabeled glyphs or fragmented descendants.