### PR TITLE
feat(pcm-cache): PR D — streaming-tee writer wiring PcmAppender into EngineStreamingSource

### DIFF
--- a/core-playback/src/main/kotlin/in/jphe/storyvox/playback/tts/EnginePlayer.kt
+++ b/core-playback/src/main/kotlin/in/jphe/storyvox/playback/tts/EnginePlayer.kt
@@ -43,6 +43,9 @@ import `in`.jphe.storyvox.playback.SPEED_BASELINE_CHARS_PER_SECOND
 import `in`.jphe.storyvox.playback.SentenceRange
 import `in`.jphe.storyvox.playback.SleepTimer
 import `in`.jphe.storyvox.playback.TtsVolumeRamp
+import `in`.jphe.storyvox.playback.cache.PcmAppender
+import `in`.jphe.storyvox.playback.cache.PcmCache
+import `in`.jphe.storyvox.playback.cache.PcmCacheKey
 import `in`.jphe.storyvox.playback.tts.source.EngineStreamingSource
 import `in`.jphe.storyvox.playback.tts.source.PcmSource
 import `in`.jphe.storyvox.playback.voice.EngineType
@@ -144,6 +147,11 @@ class EnginePlayer @AssistedInject constructor(
      *  it emits 0 and the producer's existing punctuation-pause path
      *  keeps the audiobook-tuned default. */
     private val a11yPacingConfig: `in`.jphe.storyvox.data.repository.playback.A11yPacingConfig,
+    /** PR-D (#86) — on-disk PCM cache. EnginePlayer is the only thing
+     *  that knows the (chapter, voice, speed, pitch, dict) identity at
+     *  pipeline-construction time, so it owns key construction here.
+     *  The cache itself is a `@Singleton` injected by Hilt. */
+    private val pcmCache: PcmCache,
 ) : SimpleBasePlayer(Looper.getMainLooper()) {
 
     @AssistedFactory
@@ -1318,6 +1326,62 @@ class EnginePlayer @AssistedInject constructor(
             }
             else -> emptyList()
         }
+        // PR-D (#86) — build the cache key for this (chapter, voice,
+        // speed, pitch, dict) tuple. All five pieces of identity must
+        // be known; if any is null we skip the cache write entirely
+        // (the source gets cacheAppender = null and behaves as
+        // pre-PR-D). Captured here at pipeline-construction time so a
+        // mid-pipeline state mutation can't shift the key out from
+        // under the live appender.
+        val chapterIdForCache = _observableState.value.currentChapterId
+        val voiceIdForCache = loadedVoiceId
+        val cacheKey: PcmCacheKey? = if (
+            chapterIdForCache != null && voiceIdForCache != null
+        ) {
+            PcmCacheKey(
+                chapterId = chapterIdForCache,
+                voiceId = voiceIdForCache,
+                speedHundredths = PcmCacheKey.quantize(currentSpeed),
+                pitchHundredths = PcmCacheKey.quantize(currentPitch),
+                chunkerVersion = CHUNKER_VERSION,
+                pronunciationDictHash = pronunciationDict.contentHash,
+            )
+        } else null
+
+        // Open the appender. If a partial entry exists from a prior
+        // killed render (meta.json on disk, idx.json absent), wipe it
+        // first — PR-D's resume policy is "abandon, restart". Resuming
+        // mid-chapter PCM across boots adds verification complexity
+        // (is the .pcm file's tail aligned to a sentence boundary?
+        // What sentence index do we restart from?) for negligible
+        // payoff: the kill-mid-render case is rare, and a fresh render
+        // takes the same wall time as a partial-resume would after
+        // verification.
+        //
+        // If the entry is COMPLETE (idx.json present), don't wipe —
+        // PR-E will short-circuit before this branch ever runs by
+        // constructing a CacheFileSource instead. PR-D-only world: a
+        // complete entry means the user replayed the chapter and the
+        // streaming source overwrites it with identical bytes (same
+        // key → same content). The overwrite is wasted work but
+        // harmless. PR-E removes this waste.
+        //
+        // runBlocking is acceptable here: startPlaybackPipeline is
+        // already called synchronously from a coroutine (or from
+        // suspend functions like loadAndPlay), so the blocking wait
+        // for pcmCache.delete is brief (a few File.delete syscalls on
+        // Dispatchers.IO — single-digit ms). Lifting startPlaybackPipeline
+        // to suspend is a bigger refactor punted to a follow-up.
+        val appender: PcmAppender? = cacheKey?.let { key ->
+            runBlocking {
+                if (pcmCache.metaFileFor(key).exists() && !pcmCache.isComplete(key)) {
+                    // Stale partial — wipe before opening fresh.
+                    pcmCache.delete(key)
+                }
+                pcmCache.appender(key, sampleRate = sampleRate)
+            }
+        }
+
         val source = EngineStreamingSource(
             sentences = sentences,
             startSentenceIndex = currentSentenceIndex,
@@ -1325,6 +1389,7 @@ class EnginePlayer @AssistedInject constructor(
             speed = currentSpeed,
             pitch = currentPitch,
             engineMutex = engineMutex,
+            cacheAppender = appender,
             punctuationPauseMultiplier = currentPunctuationPauseMultiplier,
             // #486 / #488 — TalkBack inter-sentence pad. Snapshot at
             // pipeline-construction time; mid-listen slider edits take
@@ -1570,6 +1635,33 @@ class EnginePlayer @AssistedInject constructor(
                     }
                 }
                 if (naturalEnd && pipelineRunning.get()) {
+                    // PR-D (#86) — finalize the cache on natural end so
+                    // the index sidecar lands and the cache is complete
+                    // for next play. Must happen BEFORE the chapter-done
+                    // coroutine because handleChapterDone advances and
+                    // calls loadAndPlay → startPlaybackPipeline, which
+                    // constructs a NEW source and overwrites the field.
+                    // We call finalizeCache on the SAME `source` local
+                    // captured by the Thread closure, so the field
+                    // reassignment doesn't affect us.
+                    runCatching { source.finalizeCache() }
+                    // Eviction runs AFTER finalize so the just-finalized
+                    // entry isn't visible to evictTo as an oldest LRU
+                    // candidate (it has the freshest mtime). The pinned
+                    // set is the just-finalized basename — defense in
+                    // depth in case mtime granularity makes it look
+                    // "old" relative to a same-second-finalized
+                    // neighbor. Runs on scope (Main+SupervisorJob); the
+                    // suspend body delegates to Dispatchers.IO inside
+                    // PcmCache.evictTo.
+                    scope.launch {
+                        runCatching {
+                            pcmCache.evictToQuota(
+                                pinnedBasenames = cacheKey?.let { setOf(it.fileBaseName()) }
+                                    ?: emptySet(),
+                            )
+                        }
+                    }
                     scope.launch {
                         sleepTimer.signalChapterEnd()
                         handleChapterDone()

--- a/core-playback/src/main/kotlin/in/jphe/storyvox/playback/tts/source/EngineStreamingSource.kt
+++ b/core-playback/src/main/kotlin/in/jphe/storyvox/playback/tts/source/EngineStreamingSource.kt
@@ -2,6 +2,7 @@ package `in`.jphe.storyvox.playback.tts.source
 
 import android.os.Process as AndroidProcess
 import `in`.jphe.storyvox.playback.SentenceRange
+import `in`.jphe.storyvox.playback.cache.PcmAppender
 import `in`.jphe.storyvox.playback.tts.Sentence
 import java.util.concurrent.Executors
 import java.util.concurrent.LinkedBlockingQueue
@@ -73,6 +74,28 @@ class EngineStreamingSource(
      *  loadModel().destroy() while the prior source's generator is still
      *  inside the JNI generate(...) call, corrupting native state. */
     private val engineMutex: Mutex,
+    /**
+     * PR-D (#86) — optional write-through to the on-disk PCM cache. When
+     * non-null, every sentence the producer generates is mirrored into
+     * this appender via [PcmAppender.appendSentence]. On [close] (which
+     * fires on user pause + pipeline teardown, voice swap, and
+     * seek-induced restart) the appender is [PcmAppender.abandon]'d so
+     * the partial files don't lie around looking like a complete cache.
+     * On natural end-of-chapter (the consumer thread reaches the
+     * END_PILL), the consumer calls [finalizeCache] which writes the
+     * index sidecar and marks the cache complete for PR-E's
+     * `CacheFileSource` to pick up on next play.
+     *
+     * Null in tests that don't care about the cache, and in pre-cache
+     * environments where the feature flag is off (PR-F gates).
+     *
+     * Note: NOT a `val` — we shadow it as a private mutable field below
+     * so that abandon-on-seek / abandon-on-close can null it out and
+     * subsequent tee writes from a restarted producer no-op safely.
+     * Reassigning a constructor `val` parameter is a compile error in
+     * Kotlin, hence the shadow.
+     */
+    cacheAppender: PcmAppender? = null,
     private val punctuationPauseMultiplier: Float = 1f,
     /**
      * Accessibility scaffold Phase 2 (#486 / #488, v0.5.43) — extra
@@ -197,7 +220,31 @@ class EngineStreamingSource(
     private val running = AtomicBoolean(true)
     private val queue = LinkedBlockingQueue<Item>(queueCapacity)
 
+    /**
+     * PR-D (#86) — mutable shadow of the constructor's `cacheAppender`
+     * param so [seekToCharOffset] and [close] can null it out after
+     * abandon. Volatile because the producer reads it on the dedicated
+     * producer thread while [seekToCharOffset] / [close] runs on the
+     * caller's thread.
+     */
+    @Volatile private var cacheAppender: PcmAppender? = cacheAppender
+
     private val _bufferHeadroomMs = MutableStateFlow(0L)
+
+    private val _cacheTeeErrors = MutableStateFlow(0)
+
+    /**
+     * PR-D (#86) — count of cache-tee write failures since this source
+     * was constructed. Exposed for diagnostic logging — the cache writes
+     * are best-effort (a write failure doesn't block playback) so a
+     * non-zero value indicates the on-disk cache for THIS chapter run
+     * won't be usable. The next play will see `isComplete = false` and
+     * re-render fresh.
+     *
+     * Stays at 0 in normal operation; spikes signal full storage or a
+     * permissions regression on the cache directory.
+     */
+    val cacheTeeErrors: StateFlow<Int> = _cacheTeeErrors.asStateFlow()
 
     /**
      * Total ms of audio currently buffered in the queue (sum of pcm
@@ -268,6 +315,13 @@ class EngineStreamingSource(
             .takeIf { it >= 0 } ?: 0
         producerJob.cancel()
         queue.clear()
+        // PR-D (#86) — abandon the in-progress cache. A sparse cache
+        // (sentences 0-3 then 12+ because the user seeked forward) is
+        // worse than no cache; PR-E's CacheFileSource expects sequential
+        // byte offsets. Null the field so the restarted producer below
+        // sees no appender and the tee no-ops.
+        runCatching { cacheAppender?.abandon() }
+        cacheAppender = null
         producerJob = startProducer(target)
     }
 
@@ -277,6 +331,13 @@ class EngineStreamingSource(
         queue.clear()
         // Wake any consumer blocked in take() so nextChunk returns null.
         queue.offer(END_PILL)
+        // PR-D (#86) — abandon any partial cache. If the consumer
+        // already called [finalizeCache] on natural end, the appender
+        // has been nulled out and abandon() is a no-op. Idempotent
+        // either way — [PcmAppender.abandon] no-ops on a closed
+        // appender too.
+        runCatching { cacheAppender?.abandon() }
+        cacheAppender = null
         scope.cancel()
         // Tier 2 (#87) — shut the dedicated producer executor down so
         // the daemon thread exits and isn't leaked across pipeline
@@ -300,6 +361,32 @@ class EngineStreamingSource(
         runCatching {
             producerExecutor.awaitTermination(5, java.util.concurrent.TimeUnit.SECONDS)
         }
+    }
+
+    /**
+     * PR-D (#86) — mark the cache entry for this run complete. Called
+     * from the consumer thread's natural-end-of-chapter branch in
+     * [`in`.jphe.storyvox.playback.tts.EnginePlayer.startPlaybackPipeline]'s
+     * consumer loop, AFTER the AudioTrack write loop has drained the
+     * last chunk and the END_PILL surfaced from [nextChunk]. Idempotent
+     * — calling on a null appender (no cache configured, or after a
+     * previous finalize / abandon nulled it out) is a no-op.
+     *
+     * MUST be called BEFORE [close] for the cache write to land. After
+     * [close] (or after the abandoning behavior triggered by
+     * [seekToCharOffset]), the appender has been nulled out and this
+     * method silently no-ops.
+     *
+     * Wrapped in runCatching for the same reason the tee write is —
+     * a finalize-time disk failure (e.g. atomic rename can't write the
+     * `.tmp` due to ENOSPC) shouldn't break a chapter that the listener
+     * just heard end-to-end. Next play will see incomplete cache + re-render.
+     */
+    fun finalizeCache() {
+        val ap = cacheAppender ?: return
+        cacheAppender = null
+        runCatching { ap.finalize() }
+            .onFailure { _cacheTeeErrors.update { it + 1 } }
     }
 
     private fun startProducer(fromIndex: Int): Job =
@@ -479,6 +566,27 @@ class EngineStreamingSource(
                     it + pcmDurationMs(chunk.pcm.size) +
                         pcmDurationMs(chunk.trailingSilenceBytes)
                 }
+                // PR-D (#86) — tee write FROM THE SEQUENCER. Workers in
+                // [runParallelWorker] complete out of order (sentence 3
+                // may finish before sentence 1); writing the cache from
+                // a worker would record non-monotonic byte offsets and
+                // produce a sparse / mis-ordered PCM file. The sequencer
+                // drains the `completed` map in monotonic `next` order,
+                // matching the order the consumer sees, which is the
+                // same invariant PR-E's CacheFileSource will expect on
+                // read-back.
+                //
+                // Best-effort like the serial path — disk failures
+                // increment cacheTeeErrors and the cache for this run
+                // won't complete, but playback continues.
+                if (running.get()) {
+                    cacheAppender?.let { ap ->
+                        val s = sentences[next]
+                        val totalPauseMs = pcmDurationMs(chunk.trailingSilenceBytes).toInt()
+                        runCatching { ap.appendSentence(s, chunk.pcm, totalPauseMs) }
+                            .onFailure { _cacheTeeErrors.update { it + 1 } }
+                    }
+                }
                 next++
             }
             // Natural end — push pill once all workers are drained.
@@ -584,7 +692,8 @@ class EngineStreamingSource(
                 // value is 0 outside TalkBack and v0.5.42's math is
                 // preserved bit-identical for sighted listeners.
                 val a11yPadMs = extraA11ySilenceMs.toFloat() / speed.coerceAtLeast(0.5f)
-                val silenceBytes = silenceBytesFor((basePauseMs + a11yPadMs).toInt(), sampleRate)
+                val totalPauseMs = (basePauseMs + a11yPadMs).toInt()
+                val silenceBytes = silenceBytesFor(totalPauseMs, sampleRate)
                 val chunk = PcmChunk(
                     sentenceIndex = i,
                     range = SentenceRange(s.index, s.startChar, s.endChar),
@@ -594,6 +703,27 @@ class EngineStreamingSource(
                 runInterruptible { queue.put(Item(chunk)) }
                 _bufferHeadroomMs.update {
                     it + pcmDurationMs(pcm.size) + pcmDurationMs(silenceBytes)
+                }
+                // PR-D (#86) — tee write. Mirror every generated
+                // sentence into the on-disk cache. Synchronous, on the
+                // producer's dedicated thread. The appender's
+                // FileOutputStream.write+flush is microseconds compared
+                // to the generateAudioPCM call (Piper-high synthesis is
+                // the slow path; disk I/O on internal flash is
+                // >100 MB/s). Wrapped in runCatching because a transient
+                // I/O failure (storage full, parent dir wiped) shouldn't
+                // take down the playback pipeline — the listener still
+                // hears the sentence; the cache simply won't complete
+                // this run.
+                //
+                // `totalPauseMs` is the same value passed to
+                // silenceBytesFor — recorded here so PR-E's
+                // CacheFileSource can replay the cadence without
+                // recomputing trailingPauseMs.
+                if (!running.get()) return@launch
+                cacheAppender?.let { ap ->
+                    runCatching { ap.appendSentence(s, pcm, totalPauseMs) }
+                        .onFailure { _cacheTeeErrors.update { it + 1 } }
                 }
             }
             // Natural end-of-chapter: push the pill so the consumer's

--- a/core-playback/src/test/kotlin/in/jphe/storyvox/playback/tts/source/EngineStreamingSourceCacheTeeTest.kt
+++ b/core-playback/src/test/kotlin/in/jphe/storyvox/playback/tts/source/EngineStreamingSourceCacheTeeTest.kt
@@ -1,0 +1,214 @@
+package `in`.jphe.storyvox.playback.tts.source
+
+import android.app.Application
+import `in`.jphe.storyvox.playback.cache.PcmCache
+import `in`.jphe.storyvox.playback.cache.PcmCacheConfig
+import `in`.jphe.storyvox.playback.cache.PcmCacheKey
+import `in`.jphe.storyvox.playback.tts.CHUNKER_VERSION
+import `in`.jphe.storyvox.playback.tts.Sentence
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.sync.Mutex
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.RuntimeEnvironment
+import org.robolectric.annotation.Config
+
+/**
+ * PR-D (#86) — cache-tee write semantics for [EngineStreamingSource].
+ *
+ * Robolectric-backed because PcmCache touches `Context.cacheDir` (same
+ * shape as PR-C's [`in`.jphe.storyvox.playback.cache.PcmCacheTest]).
+ * Verifies the four invariants in the plan:
+ *  1. Tee fires for each generated sentence; pcm-file bytes = concat
+ *     of engine outputs.
+ *  2. finalizeCache lands the index → isComplete = true.
+ *  3. close abandons → pcm + meta + idx all gone.
+ *  4. seekToCharOffset abandons (sparse-cache prevention).
+ *  5. null appender path is a behavioral no-op (pre-PR-D back-compat).
+ */
+@RunWith(RobolectricTestRunner::class)
+@Config(application = Application::class)
+class EngineStreamingSourceCacheTeeTest {
+
+    private lateinit var context: Application
+    private lateinit var cache: PcmCache
+    private lateinit var config: PcmCacheConfig
+
+    @Before
+    fun setUp() {
+        context = RuntimeEnvironment.getApplication()
+        config = PcmCacheConfig(context)
+        cache = PcmCache(context, config)
+        cache.rootDirectory().listFiles()?.forEach { it.delete() }
+    }
+
+    @After
+    fun tearDown() {
+        cache.rootDirectory().listFiles()?.forEach { it.delete() }
+    }
+
+    private val key = PcmCacheKey(
+        chapterId = "ch1",
+        voiceId = "cori",
+        speedHundredths = 100,
+        pitchHundredths = 100,
+        chunkerVersion = CHUNKER_VERSION,
+        pronunciationDictHash = 0,
+    )
+
+    private val sentences = listOf(
+        Sentence(0, 0, 10, "First."),
+        Sentence(1, 11, 20, "Second."),
+        Sentence(2, 21, 30, "Third."),
+    )
+
+    /** Engine that returns a deterministic 100-byte PCM per sentence. */
+    private fun fakeEngine() = object : EngineStreamingSource.VoiceEngineHandle {
+        override val sampleRate: Int = 22050
+        override fun generateAudioPCM(text: String, speed: Float, pitch: Float): ByteArray =
+            ByteArray(100) { 0x42 }
+    }
+
+    @Test
+    fun `tee writes one cache entry per sentence then finalize completes the cache`() = runBlocking {
+        val appender = cache.appender(key, sampleRate = 22050)
+        val source = EngineStreamingSource(
+            sentences = sentences,
+            startSentenceIndex = 0,
+            engine = fakeEngine(),
+            speed = 1f,
+            pitch = 1f,
+            engineMutex = Mutex(),
+            cacheAppender = appender,
+        )
+
+        // Drain the source — pull every sentence + the END_PILL. This
+        // is what the consumer thread does in EnginePlayer; the
+        // produced bytes also flow into the tee on the producer side.
+        var pulled = 0
+        while (true) {
+            val c = source.nextChunk() ?: break
+            pulled++
+            assertEquals(100, c.pcm.size)
+        }
+        assertEquals(3, pulled)
+
+        // Pre-finalize: pcm + meta exist, idx absent.
+        assertTrue(cache.pcmFileFor(key).exists())
+        assertTrue(cache.metaFileFor(key).exists())
+        assertFalse(cache.isComplete(key))
+
+        source.finalizeCache()
+
+        // Post-finalize: idx lands. Cache complete.
+        assertTrue(cache.isComplete(key))
+        // Total bytes = 3 sentences * 100 bytes
+        assertEquals(300L, cache.pcmFileFor(key).length())
+
+        source.close()
+    }
+
+    @Test
+    fun `close abandons the in-progress cache (no index lands)`() = runBlocking {
+        val appender = cache.appender(key, sampleRate = 22050)
+        val source = EngineStreamingSource(
+            sentences = sentences,
+            startSentenceIndex = 0,
+            engine = fakeEngine(),
+            speed = 1f,
+            pitch = 1f,
+            engineMutex = Mutex(),
+            cacheAppender = appender,
+        )
+
+        // Pull two of three sentences so at least one tee fired.
+        source.nextChunk()
+        source.nextChunk()
+
+        source.close()
+
+        // abandon() deletes the triple. (PR-C contract: abandon
+        // unlinks pcm + meta + idx + idx.tmp.)
+        assertFalse(cache.pcmFileFor(key).exists())
+        assertFalse(cache.metaFileFor(key).exists())
+        assertFalse(cache.isComplete(key))
+    }
+
+    @Test
+    fun `seek abandons cache progress`() = runBlocking {
+        val appender = cache.appender(key, sampleRate = 22050)
+        val source = EngineStreamingSource(
+            sentences = sentences,
+            startSentenceIndex = 0,
+            engine = fakeEngine(),
+            speed = 1f,
+            pitch = 1f,
+            engineMutex = Mutex(),
+            cacheAppender = appender,
+        )
+        source.nextChunk()                // pull one sentence to ensure
+                                          // a tee write hit disk before
+                                          // the seek-abandon fires.
+        source.seekToCharOffset(20)        // seek into sentence 2
+
+        // Wait briefly for the (cancelled) producer to settle.
+        delay(100)
+
+        // Cache files for this key should be gone — abandon ran.
+        assertFalse(cache.pcmFileFor(key).exists())
+        assertFalse(cache.isComplete(key))
+        source.close()
+    }
+
+    @Test
+    fun `null appender means no cache writes (back-compat)`() = runBlocking {
+        val source = EngineStreamingSource(
+            sentences = sentences,
+            startSentenceIndex = 0,
+            engine = fakeEngine(),
+            speed = 1f,
+            pitch = 1f,
+            engineMutex = Mutex(),
+            cacheAppender = null,        // pre-PR-D behavior
+        )
+        // Drain all three sentences.
+        repeat(3) { source.nextChunk() }
+        source.finalizeCache()           // no-op on null
+
+        // No cache files exist for this key.
+        assertFalse(cache.pcmFileFor(key).exists())
+        assertEquals(0, source.cacheTeeErrors.value)
+        source.close()
+    }
+
+    @Test
+    fun `finalize is idempotent — second call after finalize is a no-op`() = runBlocking {
+        val appender = cache.appender(key, sampleRate = 22050)
+        val source = EngineStreamingSource(
+            sentences = sentences,
+            startSentenceIndex = 0,
+            engine = fakeEngine(),
+            speed = 1f,
+            pitch = 1f,
+            engineMutex = Mutex(),
+            cacheAppender = appender,
+        )
+        // Drain.
+        while (source.nextChunk() != null) Unit
+        source.finalizeCache()
+        assertTrue(cache.isComplete(key))
+        // Second finalize: no-op. Doesn't throw, doesn't increment
+        // error counter, cache stays complete.
+        source.finalizeCache()
+        assertTrue(cache.isComplete(key))
+        assertEquals(0, source.cacheTeeErrors.value)
+        source.close()
+    }
+}


### PR DESCRIPTION
## Summary

PR-D of the chapter PCM cache spec'd in
[`docs/superpowers/plans/2026-05-08-pcm-cache-pr-d.md`](../blob/main/docs/superpowers/plans/2026-05-08-pcm-cache-pr-d.md). Wires the
**cache write side**: every PCM byte the producer in
`EngineStreamingSource` generates is mirrored into a `PcmAppender`
keyed on (chapter, voice, speed, pitch, chunkerVersion, dictHash).
On natural end-of-chapter the appender finalizes — the index sidecar
lands and the cache becomes 'complete' for PR-E's `CacheFileSource`
to pick up on next play. On user pause / seek / voice swap / speed
change the appender abandons (partial files deleted) so we never
have a half-written cache pretending to be whole.

Builds directly on PR-C (#100, `32cf85b`) which shipped the
filesystem layer (`PcmCache`, `PcmAppender`, `PcmCacheKey`,
`PcmCacheManifest`, `PcmCacheConfig`).

## What shipped

- **`EngineStreamingSource`** gains a nullable `cacheAppender` ctor
  param (shadowed as `@Volatile var` so seek/close can null it out).
  Serial producer tees right after the queue put; parallel producer
  tees from the **sequencer** (workers complete out of order — writing
  from a worker would record non-monotonic byte offsets and break
  PR-E's read-back invariant). `close()` and `seekToCharOffset()`
  abandon; new `finalizeCache()` writes the index sidecar.
  `cacheTeeErrors: StateFlow<Int>` exposes the best-effort write
  failure count for diagnostics.
- **`EnginePlayer`** injects `PcmCache` (Hilt singleton), constructs
  a `PcmCacheKey` in `startPlaybackPipeline` from the captured chapter
  / voice / speed / pitch / dict identity, wipes any stale partial
  entry (meta exists, idx absent — "abandon-and-restart" resume
  policy), opens the appender via `pcmCache.appender(key, sampleRate)`,
  and hands it to the source. Consumer-thread natural-end branch calls
  `source.finalizeCache()` BEFORE the chapter-done coroutine (which
  would otherwise rebuild the pipeline and overwrite the `source`
  field). Eviction (`pcmCache.evictToQuota`) runs after finalize,
  pinned to the just-finalized basename so it's never the LRU victim.

## What's NOT in this PR (deferred)

- **Cache hit playback path.** `EnginePlayer.loadAndPlay` does NOT
  yet check `PcmCache.isComplete()` to swap in a `CacheFileSource`
  — that's PR-E. After PR-D, replay still re-renders (writing the
  same bytes over the cache). Wasted work, harmless. PR-E short-circuits.
- **WorkManager / RenderScheduler.** Background renders for chapters
  NOT currently being played are PR-F.
- **Settings UI for cache size + Mode C.** PR-G.
- **Status icons.** PR-H.

## Implementation notes

- The tee is synchronous on the producer's dedicated thread
  (`generateAudioPCM` is the slow path; `FileOutputStream.write+flush`
  is microseconds).
- Disk failures increment `cacheTeeErrors` but never break playback —
  worst case the cache for THIS run won't complete and the next play
  re-renders.
- Resume policy on partial entries (meta exists, idx absent from a
  killed prior render) is **abandon-and-restart**. Spec rationale:
  resuming mid-chapter PCM across boots adds verification complexity
  (sentence-boundary alignment, restart-index discovery) for
  negligible payoff (the kill-mid-render case is rare; fresh render
  takes the same wall time either way).
- `PcmCacheKey` includes `pronunciationDictHash` (PR-C shipped 6
  fields, not the 5 the plan listed); the EnginePlayer key
  construction snapshots `cachedPronunciationDict.contentHash` so
  dict edits self-evict cleanly.

## Test plan

- [x] `core-playback`: `EngineStreamingSourceCacheTeeTest` (Robolectric)
  - tee writes one entry per sentence; pcm-file bytes = sum
  - finalize lands idx → `isComplete = true`
  - close abandons → pcm + meta + idx all gone
  - seek abandons (sparse cache prevention)
  - null appender = behavioral no-op (back-compat)
  - finalize is idempotent
- [x] `./gradlew :core-playback:testDebugUnitTest` green
- [x] `./gradlew :app:testDebugUnitTest :feature:testDebugUnitTest` green
- [x] `./gradlew :app:assembleDebug` green (R8 + Hilt graph satisfied
      with the new `PcmCache` constructor dep)
- [x] Debug APK installed on R83W80CAFZB and foreground-launches
      cleanly. Full play-to-natural-end cache-triple verification
      defers to orchestrator (v0.5.46 ships `isDebuggable=false` so
      `run-as` filesystem inspection is unavailable on the debug build
      installed via CI; PR-E + tablet smoke can verify the round-trip).

🤖 Generated with [Claude Code](https://claude.com/claude-code)