### PR TITLE
feat(pcm-cache): PR E — cache-hit playback via CacheFileSource

### DIFF
--- a/core-playback/src/main/kotlin/in/jphe/storyvox/playback/tts/EnginePlayer.kt
+++ b/core-playback/src/main/kotlin/in/jphe/storyvox/playback/tts/EnginePlayer.kt
@@ -46,6 +46,7 @@ import `in`.jphe.storyvox.playback.TtsVolumeRamp
 import `in`.jphe.storyvox.playback.cache.PcmAppender
 import `in`.jphe.storyvox.playback.cache.PcmCache
 import `in`.jphe.storyvox.playback.cache.PcmCacheKey
+import `in`.jphe.storyvox.playback.tts.source.CacheFileSource
 import `in`.jphe.storyvox.playback.tts.source.EngineStreamingSource
 import `in`.jphe.storyvox.playback.tts.source.PcmSource
 import `in`.jphe.storyvox.playback.voice.EngineType
@@ -1348,59 +1349,105 @@ class EnginePlayer @AssistedInject constructor(
             )
         } else null
 
-        // Open the appender. If a partial entry exists from a prior
-        // killed render (meta.json on disk, idx.json absent), wipe it
-        // first — PR-D's resume policy is "abandon, restart". Resuming
-        // mid-chapter PCM across boots adds verification complexity
-        // (is the .pcm file's tail aligned to a sentence boundary?
-        // What sentence index do we restart from?) for negligible
-        // payoff: the kill-mid-render case is rare, and a fresh render
-        // takes the same wall time as a partial-resume would after
-        // verification.
+        // PR-E (#86) — cache-hit dispatch. If the cache for this key
+        // is COMPLETE (the .idx.json sidecar landed from a previous
+        // play's natural end), open a CacheFileSource and skip the
+        // engine pipeline entirely. The consumer thread treats the
+        // source uniformly via the PcmSource interface; cached
+        // chapters get instant first-byte + zero inter-sentence gaps.
         //
-        // If the entry is COMPLETE (idx.json present), don't wipe —
-        // PR-E will short-circuit before this branch ever runs by
-        // constructing a CacheFileSource instead. PR-D-only world: a
-        // complete entry means the user replayed the chapter and the
-        // streaming source overwrites it with identical bytes (same
-        // key → same content). The overwrite is wasted work but
-        // harmless. PR-E removes this waste.
+        // Touch the .pcm mtime so LRU eviction in PcmCache.evictTo
+        // prefers genuinely-cold entries (sort key: mtime ascending
+        // within (isAzure) groups).
         //
-        // runBlocking is acceptable here: startPlaybackPipeline is
-        // already called synchronously from a coroutine (or from
-        // suspend functions like loadAndPlay), so the blocking wait
-        // for pcmCache.delete is brief (a few File.delete syscalls on
-        // Dispatchers.IO — single-digit ms). Lifting startPlaybackPipeline
-        // to suspend is a bigger refactor punted to a follow-up.
-        val appender: PcmAppender? = cacheKey?.let { key ->
+        // On CacheFileSource.open failure (corrupt index, truncated
+        // pcm) we fall through to the streaming path. The next
+        // natural-end finalize will overwrite the bad entry with
+        // fresh bytes; a corrupt cache is a re-render trigger, not
+        // a crash. We log the failure so the cache-hit/miss ratio
+        // observability stays meaningful in logcat — adb run-as is
+        // gone post-isDebuggable=false, so logcat is the primary
+        // verification surface for cache behavior on the tablet.
+        val cacheHitSource: PcmSource? = cacheKey?.let { key ->
             runBlocking {
-                if (pcmCache.metaFileFor(key).exists() && !pcmCache.isComplete(key)) {
-                    // Stale partial — wipe before opening fresh.
-                    pcmCache.delete(key)
-                }
-                pcmCache.appender(key, sampleRate = sampleRate)
+                if (!pcmCache.isComplete(key)) return@runBlocking null
+                pcmCache.touch(key)
+                runCatching {
+                    CacheFileSource.open(
+                        pcmFile = pcmCache.pcmFileFor(key),
+                        indexFile = pcmCache.indexFileFor(key),
+                        startSentenceIndex = currentSentenceIndex,
+                    )
+                }.onSuccess {
+                    android.util.Log.i(
+                        "EnginePlayer",
+                        "pcm-cache HIT chapter=${key.chapterId} voice=${key.voiceId} " +
+                            "speed=${key.speedHundredths} pitch=${key.pitchHundredths} " +
+                            "fromSentence=$currentSentenceIndex base=${key.fileBaseName().take(12)}",
+                    )
+                }.onFailure { t ->
+                    android.util.Log.w(
+                        "EnginePlayer",
+                        "pcm-cache hit-open FAILED chapter=${key.chapterId} " +
+                            "base=${key.fileBaseName().take(12)} — falling back to streaming",
+                        t,
+                    )
+                }.getOrNull()
             }
         }
 
-        val source = EngineStreamingSource(
-            sentences = sentences,
-            startSentenceIndex = currentSentenceIndex,
-            engine = activeVoiceEngineHandle(engineType),
-            speed = currentSpeed,
-            pitch = currentPitch,
-            engineMutex = engineMutex,
-            cacheAppender = appender,
-            punctuationPauseMultiplier = currentPunctuationPauseMultiplier,
-            // #486 / #488 — TalkBack inter-sentence pad. Snapshot at
-            // pipeline-construction time; mid-listen slider edits take
-            // effect on next rebuild (matches the other live-config
-            // knobs). The volatile cache is kept in sync by
-            // [observeA11yPacing].
-            extraA11ySilenceMs = cachedA11yExtraSilenceMs,
-            queueCapacity = queueCapacity,
-            pronunciationDictApply = pronunciationDict::apply,
-            secondaryEngines = secondaryHandles,
-        )
+        val source: PcmSource = if (cacheHitSource != null) {
+            cacheHitSource
+        } else {
+            // Cache miss (or hit-open failed) — streaming source +
+            // tee appender path (PR-D). If a partial entry exists
+            // from a prior killed render (meta.json on disk,
+            // idx.json absent), wipe it first; PR-D's resume policy
+            // is "abandon, restart".
+            //
+            // runBlocking is acceptable here: startPlaybackPipeline
+            // is already called synchronously from a coroutine
+            // (or from suspend functions like loadAndPlay), so the
+            // blocking wait for pcmCache.delete is brief (a few
+            // File.delete syscalls on Dispatchers.IO — single-digit
+            // ms).
+            val appender: PcmAppender? = cacheKey?.let { key ->
+                runBlocking {
+                    if (pcmCache.metaFileFor(key).exists() && !pcmCache.isComplete(key)) {
+                        // Stale partial — wipe before opening fresh.
+                        pcmCache.delete(key)
+                    }
+                    pcmCache.appender(key, sampleRate = sampleRate)
+                }
+            }
+            cacheKey?.let { key ->
+                android.util.Log.i(
+                    "EnginePlayer",
+                    "pcm-cache MISS chapter=${key.chapterId} voice=${key.voiceId} " +
+                        "speed=${key.speedHundredths} pitch=${key.pitchHundredths} " +
+                        "fromSentence=$currentSentenceIndex base=${key.fileBaseName().take(12)}",
+                )
+            }
+            EngineStreamingSource(
+                sentences = sentences,
+                startSentenceIndex = currentSentenceIndex,
+                engine = activeVoiceEngineHandle(engineType),
+                speed = currentSpeed,
+                pitch = currentPitch,
+                engineMutex = engineMutex,
+                cacheAppender = appender,
+                punctuationPauseMultiplier = currentPunctuationPauseMultiplier,
+                // #486 / #488 — TalkBack inter-sentence pad. Snapshot
+                // at pipeline-construction time; mid-listen slider
+                // edits take effect on next rebuild (matches the
+                // other live-config knobs). The volatile cache is
+                // kept in sync by [observeA11yPacing].
+                extraA11ySilenceMs = cachedA11yExtraSilenceMs,
+                queueCapacity = queueCapacity,
+                pronunciationDictApply = pronunciationDict::apply,
+                secondaryEngines = secondaryHandles,
+            )
+        }
         pcmSource = source
         pipelineRunning.set(true)
         // Issue #290 — reset the frames-written tally so the debug

--- a/core-playback/src/main/kotlin/in/jphe/storyvox/playback/tts/source/CacheFileSource.kt
+++ b/core-playback/src/main/kotlin/in/jphe/storyvox/playback/tts/source/CacheFileSource.kt
@@ -1,0 +1,208 @@
+package `in`.jphe.storyvox.playback.tts.source
+
+import `in`.jphe.storyvox.playback.SentenceRange
+import `in`.jphe.storyvox.playback.cache.PcmIndex
+import `in`.jphe.storyvox.playback.cache.PcmIndexEntry
+import `in`.jphe.storyvox.playback.cache.pcmCacheJson
+import java.io.File
+import java.io.IOException
+import java.io.RandomAccessFile
+import java.nio.MappedByteBuffer
+import java.nio.channels.FileChannel
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.withContext
+
+/**
+ * PR-E (#86) — reads a finalized PCM cache entry from disk and serves
+ * [PcmChunk]s to [`in`.jphe.storyvox.playback.tts.EnginePlayer]'s
+ * consumer thread.
+ *
+ * Constructed by `EnginePlayer.startPlaybackPipeline` when
+ * [`in`.jphe.storyvox.playback.cache.PcmCache.isComplete] returns true
+ * for the (chapter, voice, speed, pitch, chunkerVersion, dictHash)
+ * key. The consumer treats this source identically to
+ * [EngineStreamingSource] — pull a chunk, write to AudioTrack, fire
+ * UI sentence-transition events. The difference: this source NEVER
+ * blocks meaningfully (no engine inference), so [bufferHeadroomMs]
+ * stays effectively unbounded and PR-B's pause-buffer-resume UI never
+ * fires for cached chapters.
+ *
+ * **Pacing.** The consumer's `track.write()` blocks once the AudioTrack
+ * hardware buffer is full (~2 s of audio at minBufferSize on Tab A7
+ * Lite). That's what regulates this source's effective rate — without
+ * that back-pressure, the consumer would freerun through the entire
+ * cached chapter in milliseconds and the UI would flash sentence
+ * boundaries faster than the audio plays.
+ *
+ * **mmap vs read.** The default path mmap's the entire `.pcm` file
+ * via `FileChannel.map(READ_ONLY, 0, len)`. mmap is preferable
+ * because the OS page cache absorbs the read cost — sequential mmap
+ * access on UFS 2.0 internal flash is >100 MB/s effective. Fallback:
+ * some 32-bit emulator kernels reject mmap requests > 1 GB with
+ * EINVAL. In that case we fall back to [RandomAccessFile.read] into
+ * a [ByteArray] per sentence, which is correctness-equivalent but
+ * allocates per chunk. The fallback is detected at construction
+ * time and never re-tried mid-playback.
+ */
+class CacheFileSource private constructor(
+    private val pcmFile: File,
+    private val index: PcmIndex,
+    startSentenceIndex: Int,
+    /** True if mmap succeeded; false → fallback to read path. */
+    private val mapped: MappedByteBuffer?,
+    private val randomAccess: RandomAccessFile,
+) : PcmSource {
+
+    override val sampleRate: Int = index.sampleRate
+
+    /** Cursor into [PcmIndex.sentences]. Mutated by [nextChunk] and
+     *  [seekToCharOffset]; single-threaded access (the consumer thread). */
+    @Volatile private var cursor: Int = startSentenceIndex.coerceIn(0, index.sentences.size)
+
+    private val _bufferHeadroomMs = MutableStateFlow(Long.MAX_VALUE)
+
+    /**
+     * Always reports an effectively unbounded headroom. Cache files
+     * never underrun — a cached chapter has every sentence already on
+     * disk. The streaming-source headroom flow drives PR-B's
+     * pause-buffer-resume UI; for the cache source we want that UI to
+     * never fire (which is correct), so we report a huge constant.
+     */
+    override val bufferHeadroomMs: StateFlow<Long> = _bufferHeadroomMs.asStateFlow()
+
+    /** Cache source has no producer queue. Reported as 0/0 to the
+     *  Debug overlay (issue #290). */
+    override fun producerQueueDepth(): Int = 0
+    override fun producerQueueCapacity(): Int = 0
+
+    /** No headroom tracking for cache files — they don't underrun. */
+    override fun decrementHeadroomForChunk(chunk: PcmChunk) = Unit
+
+    override suspend fun nextChunk(): PcmChunk? = withContext(Dispatchers.IO) {
+        val entries = index.sentences
+        val i = cursor
+        if (i >= entries.size) return@withContext null
+        val e = entries[i]
+        cursor = i + 1
+        val pcm = readPcmFor(e)
+        val silenceBytes = silenceBytesFor(e.trailingSilenceMs, sampleRate)
+        PcmChunk(
+            sentenceIndex = e.i,
+            range = SentenceRange(e.i, e.start, e.end),
+            pcm = pcm,
+            trailingSilenceBytes = silenceBytes,
+        )
+    }
+
+    override suspend fun seekToCharOffset(charOffset: Int) {
+        // Find the latest sentence whose start <= charOffset. Matches
+        // EngineStreamingSource.seekToCharOffset's mapping so both
+        // sources behave identically post-seek. Offset before the first
+        // sentence → cursor=0; offset past the last sentence → cursor
+        // at the last sentence (which then exhausts after one nextChunk).
+        val target = index.sentences.indexOfLast { it.start <= charOffset }
+            .takeIf { it >= 0 } ?: 0
+        cursor = target
+    }
+
+    override suspend fun close() = withContext(Dispatchers.IO) {
+        // Release the underlying RandomAccessFile so the file descriptor
+        // is returned. mmap'd MappedByteBuffer cleanup happens via
+        // GC + Cleaner; we can't force-unmap on JVM without sun.misc
+        // unsafe access. Closing the channel/file that produced the
+        // buffer is enough — the buffer remains valid until GC, and
+        // on Linux the kernel page-cache reclaim runs anyway.
+        runCatching { randomAccess.close() }
+        Unit
+    }
+
+    /**
+     * Cache source has no in-flight cache write to finalize — the
+     * file was finalized before this source was constructed (that's
+     * the [`in`.jphe.storyvox.playback.cache.PcmCache.isComplete]
+     * precondition). Inherited default would also no-op; override
+     * is explicit for documentation.
+     */
+    override fun finalizeCache() = Unit
+
+    /** Read the bytes for a single sentence's PCM range. mmap path:
+     *  slice the MappedByteBuffer view. Read path: position +
+     *  read into a fresh ByteArray. */
+    private fun readPcmFor(entry: PcmIndexEntry): ByteArray {
+        val mapped = this.mapped
+        if (mapped != null) {
+            // Slice view — no copy of the underlying bytes. We DO need
+            // to copy into a ByteArray because EnginePlayer's consumer
+            // thread calls `track.write(byteArray, off, len)`, which
+            // doesn't accept a ByteBuffer in the byte[] AudioTrack
+            // API path. Future optimization: extend PcmChunk to carry
+            // a ByteBuffer alongside the byte[]; saves one copy per
+            // sentence (~1 ms on Tab A7 Lite, not material).
+            val out = ByteArray(entry.byteLen)
+            mapped.position(entry.byteOffset.toInt())
+            mapped.get(out, 0, entry.byteLen)
+            return out
+        }
+        // Read-path fallback.
+        val raf = randomAccess
+        val out = ByteArray(entry.byteLen)
+        synchronized(raf) {
+            raf.seek(entry.byteOffset)
+            var read = 0
+            while (read < entry.byteLen) {
+                val n = raf.read(out, read, entry.byteLen - read)
+                if (n < 0) break
+                read += n
+            }
+        }
+        return out
+    }
+
+    companion object {
+        /**
+         * Open a `CacheFileSource` for an already-finalized cache entry.
+         * `EnginePlayer.startPlaybackPipeline` calls this when
+         * `PcmCache.isComplete(key)` returns true.
+         *
+         * @throws IOException if reading the index fails or the pcm
+         *  file is truncated. EnginePlayer catches this and falls
+         *  back to the streaming source — a corrupt cache should
+         *  re-render rather than crash playback.
+         */
+        @Throws(IOException::class)
+        suspend fun open(
+            pcmFile: File,
+            indexFile: File,
+            startSentenceIndex: Int = 0,
+        ): CacheFileSource = withContext(Dispatchers.IO) {
+            val index = pcmCacheJson.decodeFromString(
+                PcmIndex.serializer(),
+                indexFile.readText(),
+            )
+            // Validate: the .pcm file must be at least totalBytes long.
+            // PR-D's appender writes exactly totalBytes; a smaller file
+            // means truncation (disk-full mid-finalize, or wiped by
+            // the OS cache-dir reaper between finalize and open).
+            if (pcmFile.length() < index.totalBytes) {
+                throw IOException(
+                    "PCM cache file truncated: ${pcmFile.length()} < ${index.totalBytes}",
+                )
+            }
+            val raf = RandomAccessFile(pcmFile, "r")
+            val mapped: MappedByteBuffer? = runCatching {
+                raf.channel.map(FileChannel.MapMode.READ_ONLY, 0L, raf.length())
+            }.getOrNull()
+
+            CacheFileSource(
+                pcmFile = pcmFile,
+                index = index,
+                startSentenceIndex = startSentenceIndex,
+                mapped = mapped,
+                randomAccess = raf,
+            )
+        }
+    }
+}

--- a/core-playback/src/main/kotlin/in/jphe/storyvox/playback/tts/source/EngineStreamingSource.kt
+++ b/core-playback/src/main/kotlin/in/jphe/storyvox/playback/tts/source/EngineStreamingSource.kt
@@ -257,7 +257,7 @@ class EngineStreamingSource(
      * experience the gap as a clean pause rather than dribbling silence
      * out of an underrunning AudioTrack ring buffer.
      */
-    val bufferHeadroomMs: StateFlow<Long> = _bufferHeadroomMs.asStateFlow()
+    override val bufferHeadroomMs: StateFlow<Long> = _bufferHeadroomMs.asStateFlow()
 
     /**
      * Issue #290 — PcmSource interface overrides. Surfaces queue depth +
@@ -382,7 +382,7 @@ class EngineStreamingSource(
      * `.tmp` due to ENOSPC) shouldn't break a chapter that the listener
      * just heard end-to-end. Next play will see incomplete cache + re-render.
      */
-    fun finalizeCache() {
+    override fun finalizeCache() {
         val ap = cacheAppender ?: return
         cacheAppender = null
         runCatching { ap.finalize() }

--- a/core-playback/src/main/kotlin/in/jphe/storyvox/playback/tts/source/PcmSource.kt
+++ b/core-playback/src/main/kotlin/in/jphe/storyvox/playback/tts/source/PcmSource.kt
@@ -1,21 +1,24 @@
 package `in`.jphe.storyvox.playback.tts.source
 
 import `in`.jphe.storyvox.playback.SentenceRange
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
 
 /**
  * Source of PCM chunks for the EnginePlayer consumer to write to AudioTrack.
  *
- * Two impls (PR-A only ships [EngineStreamingSource]; `CacheFileSource`
- * follows in PR-E):
+ * Two impls:
  *  - [EngineStreamingSource] runs the VoxSherpa engine on a worker
  *    coroutine, putting generated PCM into a queue. [nextChunk] blocks
  *    on `queue.take`. Subject to producer-can't-keep-up underrun on
  *    slow voice + slow device combos (Piper-high on Tab A7 Lite).
- *  - `CacheFileSource` (PR-E) mmap-reads a pre-rendered chapter PCM file.
- *    Never blocks for long.
+ *  - [CacheFileSource] (PR-E) mmap-reads a pre-rendered chapter PCM
+ *    file. Never blocks meaningfully.
  *
- * The consumer treats both uniformly. When the source is exhausted
- * (chapter end), [nextChunk] returns null.
+ * The consumer treats both uniformly via this sealed interface — the
+ * dispatch from streaming → cache lives in
+ * [`in`.jphe.storyvox.playback.tts.EnginePlayer.startPlaybackPipeline].
+ * When the source is exhausted (chapter end), [nextChunk] returns null.
  */
 sealed interface PcmSource {
 
@@ -95,6 +98,45 @@ sealed interface PcmSource {
      *  sources report their `queueCapacity`; cache sources report 0
      *  (no queue). The overlay renders `depth/capacity`. */
     fun producerQueueCapacity(): Int = 0
+
+    /**
+     * PR-E (#86) — total ms of audio queued but not yet consumed.
+     * [EngineStreamingSource] tracks this dynamically as the producer
+     * puts and consumer takes; [CacheFileSource] reports
+     * [Long.MAX_VALUE] (cached chapters can't underrun, so the
+     * buffer-low UI gating in `EnginePlayer.startPlaybackPipeline`
+     * never fires for them).
+     *
+     * Hoisted to the interface in PR-E so the consumer thread can
+     * type its `source` reference as [PcmSource] and read this
+     * property without an `is`/`as` cast in the hot loop.
+     *
+     * Default impl returns a [StateFlow] holding [Long.MAX_VALUE].
+     * Subclasses with real producer/consumer flow accounting
+     * override with a live flow.
+     */
+    val bufferHeadroomMs: StateFlow<Long>
+        get() = MAX_HEADROOM
+
+    /**
+     * PR-E (#86) — mark the in-progress cache write (if any) complete.
+     * [EngineStreamingSource] uses this to land its index sidecar on
+     * natural end-of-chapter (PR-D); [CacheFileSource] has no cache
+     * write to finalize, so its impl is a no-op.
+     *
+     * Called from `EnginePlayer.startPlaybackPipeline`'s consumer
+     * thread on the natural-end branch. Idempotent — multiple calls
+     * are safe; the streaming impl nulls out its appender field
+     * after the first call.
+     */
+    fun finalizeCache() {}
+
+    private companion object {
+        /** Shared singleton "infinity" headroom for non-streaming sources.
+         *  Allocated once at class load so the default getter doesn't
+         *  churn a StateFlow per source instance. */
+        val MAX_HEADROOM: StateFlow<Long> = MutableStateFlow(Long.MAX_VALUE)
+    }
 }
 
 /**

--- a/core-playback/src/test/kotlin/in/jphe/storyvox/playback/tts/source/CacheFileSourceTest.kt
+++ b/core-playback/src/test/kotlin/in/jphe/storyvox/playback/tts/source/CacheFileSourceTest.kt
@@ -1,0 +1,333 @@
+package `in`.jphe.storyvox.playback.tts.source
+
+import android.app.Application
+import `in`.jphe.storyvox.playback.cache.PcmCache
+import `in`.jphe.storyvox.playback.cache.PcmCacheConfig
+import `in`.jphe.storyvox.playback.cache.PcmCacheKey
+import `in`.jphe.storyvox.playback.tts.CHUNKER_VERSION
+import `in`.jphe.storyvox.playback.tts.Sentence
+import kotlinx.coroutines.runBlocking
+import org.junit.After
+import org.junit.Assert.assertArrayEquals
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.RuntimeEnvironment
+import org.robolectric.annotation.Config
+import java.io.FileOutputStream
+
+/**
+ * PR-E (#86) — read-side semantics for [CacheFileSource].
+ *
+ * Robolectric-backed because [PcmCache] touches `Context.cacheDir`
+ * (same shape as PR-D's [EngineStreamingSourceCacheTeeTest]).
+ *
+ * Verifies:
+ *  - Sequential [CacheFileSource.nextChunk] returns sentences in
+ *    order with byte-for-byte equality to what [PcmAppender] wrote.
+ *  - [PcmIndexEntry.trailingSilenceMs] propagates to [PcmChunk.trailingSilenceBytes].
+ *  - [CacheFileSource.seekToCharOffset] jumps to the correct sentence
+ *    (with edge cases: before first, past last, mid-sentence).
+ *  - [CacheFileSource.bufferHeadroomMs] reports [Long.MAX_VALUE]
+ *    (cached chapters can't underrun).
+ *  - [CacheFileSource.close] releases the file descriptor.
+ *  - Truncated `.pcm` causes [CacheFileSource.open] to throw
+ *    [java.io.IOException] (corrupt cache → re-render, not crash).
+ *  - `startSentenceIndex` resumes mid-chapter (post-seek path).
+ */
+@RunWith(RobolectricTestRunner::class)
+@Config(application = Application::class)
+class CacheFileSourceTest {
+
+    private lateinit var context: Application
+    private lateinit var cache: PcmCache
+    private lateinit var config: PcmCacheConfig
+
+    @Before
+    fun setUp() {
+        context = RuntimeEnvironment.getApplication()
+        config = PcmCacheConfig(context)
+        cache = PcmCache(context, config)
+        cache.rootDirectory().listFiles()?.forEach { it.delete() }
+    }
+
+    @After
+    fun tearDown() {
+        cache.rootDirectory().listFiles()?.forEach { it.delete() }
+    }
+
+    private val key = PcmCacheKey(
+        chapterId = "ch1",
+        voiceId = "cori",
+        speedHundredths = 100,
+        pitchHundredths = 100,
+        chunkerVersion = CHUNKER_VERSION,
+        pronunciationDictHash = 0,
+    )
+
+    private val sentences = listOf(
+        Sentence(0, 0, 10, "First."),
+        Sentence(1, 11, 20, "Second."),
+        Sentence(2, 21, 30, "Third."),
+    )
+
+    /** Render three sentences with distinct deterministic PCM payloads
+     *  so the read-back can verify the right bytes came out. */
+    private fun renderCache() {
+        val app = cache.appender(key, sampleRate = 22050)
+        app.appendSentence(sentences[0], ByteArray(100) { 0xA1.toByte() }, trailingSilenceMs = 350)
+        app.appendSentence(sentences[1], ByteArray(80)  { 0xB2.toByte() }, trailingSilenceMs = 200)
+        app.appendSentence(sentences[2], ByteArray(120) { 0xC3.toByte() }, trailingSilenceMs = 350)
+        app.finalize()
+    }
+
+    @Test
+    fun `sequential nextChunk yields sentences in order with correct bytes`() = runBlocking {
+        renderCache()
+        val source = CacheFileSource.open(
+            pcmFile = cache.pcmFileFor(key),
+            indexFile = cache.indexFileFor(key),
+        )
+
+        val c0 = source.nextChunk()
+        assertEquals(0, c0?.sentenceIndex)
+        assertEquals(100, c0?.pcm?.size)
+        assertArrayEquals(ByteArray(100) { 0xA1.toByte() }, c0?.pcm)
+
+        val c1 = source.nextChunk()
+        assertEquals(1, c1?.sentenceIndex)
+        assertEquals(80, c1?.pcm?.size)
+        assertArrayEquals(ByteArray(80) { 0xB2.toByte() }, c1?.pcm)
+
+        val c2 = source.nextChunk()
+        assertEquals(2, c2?.sentenceIndex)
+        assertEquals(120, c2?.pcm?.size)
+        assertArrayEquals(ByteArray(120) { 0xC3.toByte() }, c2?.pcm)
+
+        // Source exhausted.
+        assertNull(source.nextChunk())
+
+        source.close()
+    }
+
+    @Test
+    fun `trailingSilenceBytes propagates from index`() = runBlocking {
+        renderCache()
+        val source = CacheFileSource.open(
+            pcmFile = cache.pcmFileFor(key),
+            indexFile = cache.indexFileFor(key),
+        )
+
+        // sentence 0: trailingSilenceMs=350 → 22050 Hz mono 16-bit
+        // = (22050 * 350 / 1000).toInt() * 2 = 7717 * 2 = 15434 bytes.
+        val c0 = source.nextChunk()!!
+        assertEquals(15434, c0.trailingSilenceBytes)
+
+        // sentence 1: trailingSilenceMs=200 → (22050*200/1000).toInt()*2
+        // = 4410 * 2 = 8820 bytes.
+        val c1 = source.nextChunk()!!
+        assertEquals(8820, c1.trailingSilenceBytes)
+
+        source.close()
+    }
+
+    @Test
+    fun `seekToCharOffset jumps to the correct sentence (mid-range)`() = runBlocking {
+        renderCache()
+        val source = CacheFileSource.open(
+            pcmFile = cache.pcmFileFor(key),
+            indexFile = cache.indexFileFor(key),
+        )
+
+        // Seek into char 15 — sentence 0 spans [0,10], sentence 1
+        // spans [11,20]. indexOfLast { start <= 15 } → sentence 1
+        // (start=11). Matches EngineStreamingSource.seekToCharOffset.
+        source.seekToCharOffset(15)
+        val c = source.nextChunk()
+        assertEquals(1, c?.sentenceIndex)
+        assertEquals(80, c?.pcm?.size)
+        source.close()
+    }
+
+    @Test
+    fun `seek before first sentence yields sentence 0`() = runBlocking {
+        renderCache()
+        val source = CacheFileSource.open(
+            pcmFile = cache.pcmFileFor(key),
+            indexFile = cache.indexFileFor(key),
+        )
+        source.seekToCharOffset(-100)
+        val c = source.nextChunk()
+        assertEquals(0, c?.sentenceIndex)
+        source.close()
+    }
+
+    @Test
+    fun `seek past last sentence yields last sentence then exhausts`() = runBlocking {
+        renderCache()
+        val source = CacheFileSource.open(
+            pcmFile = cache.pcmFileFor(key),
+            indexFile = cache.indexFileFor(key),
+        )
+        source.seekToCharOffset(10_000)
+        // Last sentence whose start <= 10000 is sentence 2 (start=21).
+        val c = source.nextChunk()
+        assertEquals(2, c?.sentenceIndex)
+        // Then exhausted.
+        assertNull(source.nextChunk())
+        source.close()
+    }
+
+    @Test
+    fun `truncated pcm file fails to open with IOException`() = runBlocking {
+        renderCache()
+        val pcmFile = cache.pcmFileFor(key)
+        // Truncate the .pcm to half its size while leaving the index
+        // intact. open() must detect the mismatch via the length check.
+        FileOutputStream(pcmFile, true).channel.use { ch ->
+            ch.truncate(pcmFile.length() / 2)
+        }
+        var threw = false
+        try {
+            CacheFileSource.open(pcmFile = pcmFile, indexFile = cache.indexFileFor(key))
+        } catch (e: java.io.IOException) {
+            threw = true
+            assertTrue(
+                "truncation message should mention truncated, got: ${e.message}",
+                e.message?.contains("truncated") == true,
+            )
+        }
+        assertTrue("CacheFileSource.open should throw on truncated pcm", threw)
+    }
+
+    @Test
+    fun `bufferHeadroomMs reports MAX_VALUE for cache source`() = runBlocking {
+        renderCache()
+        val source = CacheFileSource.open(
+            pcmFile = cache.pcmFileFor(key),
+            indexFile = cache.indexFileFor(key),
+        )
+        assertEquals(Long.MAX_VALUE, source.bufferHeadroomMs.value)
+        // Pull a chunk; headroom unchanged (cache is never underrunning).
+        source.nextChunk()
+        assertEquals(Long.MAX_VALUE, source.bufferHeadroomMs.value)
+        source.close()
+    }
+
+    @Test
+    fun `producer queue depth and capacity report zero for cache source`() = runBlocking {
+        renderCache()
+        val source = CacheFileSource.open(
+            pcmFile = cache.pcmFileFor(key),
+            indexFile = cache.indexFileFor(key),
+        )
+        assertEquals(0, source.producerQueueDepth())
+        assertEquals(0, source.producerQueueCapacity())
+        source.close()
+    }
+
+    @Test
+    fun `close releases file descriptor allowing delete`() = runBlocking {
+        renderCache()
+        val source = CacheFileSource.open(
+            pcmFile = cache.pcmFileFor(key),
+            indexFile = cache.indexFileFor(key),
+        )
+        source.close()
+        // After close, the .pcm file should be deletable on Linux
+        // (the only platform we run JVM tests on). Windows holds
+        // file locks differently but we don't ship there.
+        val deleted = cache.pcmFileFor(key).delete()
+        assertTrue("file delete after close should succeed", deleted)
+    }
+
+    @Test
+    fun `start sentence index defaults to zero`() = runBlocking {
+        renderCache()
+        val source = CacheFileSource.open(
+            pcmFile = cache.pcmFileFor(key),
+            indexFile = cache.indexFileFor(key),
+            // no startSentenceIndex param
+        )
+        val c = source.nextChunk()
+        assertEquals(0, c?.sentenceIndex)
+        source.close()
+    }
+
+    @Test
+    fun `start sentence index resumes mid-chapter`() = runBlocking {
+        renderCache()
+        val source = CacheFileSource.open(
+            pcmFile = cache.pcmFileFor(key),
+            indexFile = cache.indexFileFor(key),
+            startSentenceIndex = 1,
+        )
+        val c = source.nextChunk()
+        assertEquals(1, c?.sentenceIndex)
+        assertEquals(80, c?.pcm?.size)
+        source.close()
+    }
+
+    @Test
+    fun `start sentence index past end exhausts immediately`() = runBlocking {
+        renderCache()
+        val source = CacheFileSource.open(
+            pcmFile = cache.pcmFileFor(key),
+            indexFile = cache.indexFileFor(key),
+            startSentenceIndex = 99,
+        )
+        // The cursor is coerced into [0, sentences.size]; passing
+        // size means "exhausted on first call" without throwing.
+        assertNull(source.nextChunk())
+        source.close()
+    }
+
+    @Test
+    fun `finalizeCache on cache source is a no-op`() = runBlocking {
+        renderCache()
+        val source = CacheFileSource.open(
+            pcmFile = cache.pcmFileFor(key),
+            indexFile = cache.indexFileFor(key),
+        )
+        // finalizeCache is the natural-end branch in EnginePlayer's
+        // consumer; on cache source it must be a no-op (the file is
+        // already finalized — that's the precondition for opening it).
+        // Verify by calling and then checking the index is unchanged.
+        val idxBytesBefore = cache.indexFileFor(key).readBytes()
+        source.finalizeCache()
+        val idxBytesAfter = cache.indexFileFor(key).readBytes()
+        assertArrayEquals(idxBytesBefore, idxBytesAfter)
+        source.close()
+    }
+
+    @Test
+    fun `pcm sample rate is read from index`() = runBlocking {
+        renderCache()
+        val source = CacheFileSource.open(
+            pcmFile = cache.pcmFileFor(key),
+            indexFile = cache.indexFileFor(key),
+        )
+        assertEquals(22050, source.sampleRate)
+        source.close()
+    }
+
+    @Test
+    fun `sentence ranges round-trip through the chunk`() = runBlocking {
+        renderCache()
+        val source = CacheFileSource.open(
+            pcmFile = cache.pcmFileFor(key),
+            indexFile = cache.indexFileFor(key),
+        )
+        val c0 = source.nextChunk()!!
+        // Sentence 0 was Sentence(0, 0, 10, "First.") — the index
+        // entry's start/end propagate into the chunk's range.
+        assertEquals(0, c0.range.sentenceIndex)
+        assertEquals(0, c0.range.startCharInChapter)
+        assertEquals(10, c0.range.endCharInChapter)
+        source.close()
+    }
+}


### PR DESCRIPTION
## Summary

PR E of the chapter PCM cache series (#86). Implements the **read side** of the cache — cache-hit playback skips synthesis entirely.

Plan: [docs/superpowers/plans/2026-05-08-pcm-cache-pr-e.md](../blob/main/docs/superpowers/plans/2026-05-08-pcm-cache-pr-e.md).

After this PR, the second-and-subsequent play of any chapter is **gapless on Tab A7 Lite** — no engine warm-up, no synthesis CPU, no possibility of a buffering pause. Spec success criterion (\"high-quality voices play smoothly on slow devices\") holds for replays.

## What shipped

- **`CacheFileSource`** — second `PcmSource` impl. Reads finalized cache entries via mmap (`FileChannel.map READ_ONLY`) with a `RandomAccessFile.read` fallback for kernels that fail mmap on large files. Walks `PcmIndex.sentences`; per-chunk work is a slice + ByteArray copy (`track.write` needs `byte[]`).
- **`PcmSource` interface hoisting** — `bufferHeadroomMs: StateFlow<Long>` (default returns `Long.MAX_VALUE` constant) and `finalizeCache()` (default no-op) are now interface members. EngineStreamingSource overrides both with the existing PR-D logic; CacheFileSource uses the defaults / explicit no-op. Lets the consumer thread type `source` as `PcmSource` and read both without `is`/`as` casts.
- **`EnginePlayer.startPlaybackPipeline` dispatch** — before constructing a source, branch on `PcmCache.isComplete(cacheKey)`:
  - **HIT**: touch mtime (LRU favors live entries), open `CacheFileSource.open(pcmFile, indexFile, startSentenceIndex)`. On open failure (corrupt index, truncated pcm) log + fall through to streaming. Cached chapter plays from disk with no synthesis pipeline ever started.
  - **MISS**: existing PR-D path — wipe stale partial if any, construct `EngineStreamingSource` with the tee appender.

## Pacing (spec risk row 7)

`CacheFileSource.nextChunk` returns immediately (mmap read or RAF read). The consumer's `track.write` blocks on AudioTrack's full hardware buffer (~2 s on Tab A7 Lite) — that's what regulates the effective read rate. Without that back-pressure the consumer would freerun through the cached chapter in milliseconds and the UI would flash sentence boundaries faster than the audio plays. AudioTrack hardware-buffer back-pressure is the same mechanism that paces the streaming source today; nothing new for the cache path.

`bufferHeadroomMs` reports `Long.MAX_VALUE` from the cache source, so PR-B's pause-buffer-resume UI gating never fires for cached playback (correct: cached chapters can't underrun).

## Logcat observability

`adb run-as` is unavailable post-`isDebuggable=false` (v0.5.46), so logcat is now the primary verification surface for cache behavior on the tablet. Two new lines under tag `EnginePlayer`:

```
pcm-cache HIT chapter=<id> voice=<id> speed=<hundredths> pitch=<hundredths> fromSentence=<n> base=<sha12>
pcm-cache MISS chapter=<id> voice=<id> speed=<hundredths> pitch=<hundredths> fromSentence=<n> base=<sha12>
```

Plus `pcm-cache hit-open FAILED …` on the corrupt-cache fall-through path.

## What's NOT in this PR

- **Background renders** (PR F). First play of a never-played chapter still streams; PR F adds N+2 lookahead and library-add 1-3 pre-render so most chapters start cached.
- **Settings UI** (PR G).
- **Status icons** (PR H). No visual signal for cache state today — the user hears the difference (cached = instant + gapless; streaming = warm-up + possible buffering).

## Test coverage

Source-level contract tests via `CacheFileSourceTest` (Robolectric, real PcmCache against ApplicationContext.cacheDir):

- [x] Sequential read = byte-for-byte equality with PcmAppender writes
- [x] trailingSilenceMs from index → trailingSilenceBytes in chunks
- [x] seekToCharOffset → cursor jumps to right sentence (before-first, past-last, mid-range)
- [x] bufferHeadroomMs = Long.MAX_VALUE
- [x] producerQueueDepth / producerQueueCapacity = 0
- [x] close releases the file descriptor (deletable after)
- [x] Truncated .pcm fails open with IOException (corrupt cache → re-render, not crash)
- [x] startSentenceIndex resumes mid-chapter; past end exhausts immediately
- [x] finalizeCache on cache source is a no-op (index unchanged)
- [x] sampleRate is read from the index manifest
- [x] SentenceRange round-trips through PcmChunk

The EnginePlayer dispatch branch (cache hit picks CacheFileSource, miss picks EngineStreamingSource) is covered indirectly: both impls satisfy PcmSource, so the consumer doesn't care which one it has. End-to-end pipeline coverage is on-tablet (logcat HIT/MISS lines + audible gapless replay) — same pattern PR D used.

## CI

- [x] `./gradlew :core-playback:testDebugUnitTest` green (15 new tests + all prior PR-A/B/C/D)
- [x] `./gradlew :feature:testDebugUnitTest` green
- [x] `./gradlew :app:assembleDebug` green (R8 minification + Baseline Profile compile clean)

Don't merge — orchestrator handles the release bundling.

🤖 Generated with [Claude Code](https://claude.com/claude-code)