### PR TITLE
feat(pcm-cache): PR F — WorkManager background pre-render of N+1 / N+2 chapters

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -7,6 +7,14 @@
     <uses-permission android:name="android.permission.WAKE_LOCK" />
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE" />
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE_MEDIA_PLAYBACK" />
+    <!-- PR-F (#86) — ChapterRenderJob runs a foreground service with the
+         DATA_SYNC type while pre-rendering a chapter's PCM into the
+         cache. Local synthesis isn't a media playback workload (no
+         user-visible Media3 session) and isn't a download workload
+         (no network); DATA_SYNC is the closest WorkManager-supported
+         type per AOSP docs. Required on API 34+ to avoid the
+         "Missing foregroundServiceType" SecurityException. -->
+    <uses-permission android:name="android.permission.FOREGROUND_SERVICE_DATA_SYNC" />
     <uses-permission android:name="android.permission.POST_NOTIFICATIONS" />
     <uses-permission android:name="android.permission.RECEIVE_BOOT_COMPLETED" />
 

--- a/app/src/main/kotlin/in/jphe/storyvox/StoryvoxApp.kt
+++ b/app/src/main/kotlin/in/jphe/storyvox/StoryvoxApp.kt
@@ -7,6 +7,7 @@ import androidx.work.Configuration
 import dagger.Lazy
 import dagger.hilt.android.HiltAndroidApp
 import `in`.jphe.storyvox.BuildConfig
+import `in`.jphe.storyvox.data.PrerenderModeWatcher
 import `in`.jphe.storyvox.data.auth.SessionHydrator
 import `in`.jphe.storyvox.data.db.StoryvoxDatabase
 import `in`.jphe.storyvox.data.repository.AuthRepository
@@ -81,6 +82,11 @@ class StoryvoxApp : Application(), Configuration.Provider {
     @Inject lateinit var shelfRepository: Lazy<ShelfRepository>
     @Inject lateinit var playbackPositionRepository: Lazy<PlaybackPositionRepository>
 
+    /** PR-F (#86) — Mode C (fullPrerender) flow collector. `Lazy<>` so
+     *  the singleton isn't materialised on the cold-launch main thread;
+     *  initScope's coroutine pulls it on IO and calls [start()]. */
+    @Inject lateinit var prerenderModeWatcher: Lazy<PrerenderModeWatcher>
+
     override val workManagerConfiguration: Configuration
         get() = Configuration.Builder()
             .setWorkerFactory(workerFactory)
@@ -143,6 +149,14 @@ class StoryvoxApp : Application(), Configuration.Provider {
         // once [Lazy.get] materialises it on IO.
         initScope.launch {
             syncCoordinator.get().initialize()
+        }
+        // PR-F (#86) — Mode C flow collector. Started on IO so the
+        // PrerenderTriggers + FictionRepository + DataStore graph is
+        // materialised off the cold-launch critical path; start()
+        // launches its own long-running collector inside the watcher's
+        // singleton scope.
+        initScope.launch {
+            prerenderModeWatcher.get().start()
         }
     }
 

--- a/app/src/main/kotlin/in/jphe/storyvox/data/PrerenderModeWatcher.kt
+++ b/app/src/main/kotlin/in/jphe/storyvox/data/PrerenderModeWatcher.kt
@@ -1,0 +1,63 @@
+package `in`.jphe.storyvox.data
+
+import android.util.Log
+import `in`.jphe.storyvox.data.repository.FictionRepository
+import `in`.jphe.storyvox.data.repository.playback.PlaybackModeConfig
+import `in`.jphe.storyvox.playback.cache.PrerenderTriggers
+import javax.inject.Inject
+import javax.inject.Singleton
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.flow.collectLatest
+import kotlinx.coroutines.flow.distinctUntilChanged
+import kotlinx.coroutines.flow.drop
+import kotlinx.coroutines.flow.filter
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.launch
+
+/**
+ * PR-F (#86) — listens for [PlaybackModeConfig.fullPrerender] flips and,
+ * when it goes false → true, enqueues all library fictions' chapters
+ * via [PrerenderTriggers.onFullPrerenderEnabled]. Lives in `:app` to
+ * keep `:core-playback` free of the [FictionRepository] dependency
+ * (the playback layer should depend on the data layer, not the
+ * reverse).
+ *
+ * Started from [StoryvoxApp.onCreate] via [start]; the scope is
+ * Singleton-tied so the collector survives the app lifetime.
+ *
+ * Skips the initial emission via [drop] so a process restart with
+ * Mode C already on doesn't re-enqueue every chapter every cold
+ * launch (the scheduler's KEEP policy would dedupe but the wasted
+ * WorkManager round-trips are needless).
+ */
+@Singleton
+class PrerenderModeWatcher @Inject constructor(
+    private val modeConfig: PlaybackModeConfig,
+    private val triggers: PrerenderTriggers,
+    private val fictionRepo: FictionRepository,
+) {
+    private val scope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
+
+    fun start() {
+        scope.launch {
+            modeConfig.fullPrerender
+                .distinctUntilChanged()
+                .drop(1) // skip initial DataStore emission on cold start
+                .filter { it } // only on false → true
+                .collectLatest {
+                    val library = fictionRepo.observeLibrary().first()
+                    Log.i(
+                        LOG_TAG,
+                        "pcm-cache MODE-C-ENABLED libraryCount=${library.size}",
+                    )
+                    triggers.onFullPrerenderEnabled(library.map { it.id })
+                }
+        }
+    }
+
+    companion object {
+        private const val LOG_TAG = "PrerenderModeWatcher"
+    }
+}

--- a/app/src/main/kotlin/in/jphe/storyvox/data/SettingsRepositoryUiImpl.kt
+++ b/app/src/main/kotlin/in/jphe/storyvox/data/SettingsRepositoryUiImpl.kt
@@ -408,6 +408,13 @@ private object Keys {
      *  behavior on mid-stream underrun; OFF lets the consumer drain through
      *  underruns without raising the "Buffering…" UI. */
     val CATCHUP_PAUSE = booleanPreferencesKey("pref_catchup_pause_v1")
+    /** Issue #98 / PR-F (#86) — Mode C. Default false. When true, the
+     *  PCM cache pre-render scheduler expands library-add scheduling
+     *  from "chapters 1-3" to "all chapters in the fiction", and a flow
+     *  collector in `:app` ([PrerenderModeWatcher]) catches the false→true
+     *  flip and enqueues remaining chapters across every library fiction.
+     *  PR-F adds the persistence; PR-G surfaces the Settings toggle. */
+    val FULL_PRERENDER = booleanPreferencesKey("pref_full_prerender_v1")
     /** Issue #85 — Voice-Determinism preset. Default true = Steady, which
      *  preserves the pre-#85 calmed VITS defaults (0.35 / 0.667). false =
      *  Expressive (sherpa-onnx upstream Piper defaults 0.667 / 0.8 — more
@@ -849,6 +856,7 @@ class SettingsRepositoryUiImpl(
             // default back on (perf — see UiSettings.catchupPause kdoc).
             warmupWait = prefs[Keys.WARMUP_WAIT] ?: false,
             catchupPause = prefs[Keys.CATCHUP_PAUSE] ?: true,
+            fullPrerender = prefs[Keys.FULL_PRERENDER] ?: false,
             voiceSteady = prefs[Keys.VOICE_STEADY] ?: true,
             palace = UiPalaceConfig(host = palace.host, apiKey = palace.apiKey),
             github = githubSession.toUi(),
@@ -1173,6 +1181,11 @@ class SettingsRepositoryUiImpl(
         store.edit { it[Keys.CATCHUP_PAUSE] = enabled }
     }
 
+    /** PR-F (#86) — Mode C toggle. See [UiSettings.fullPrerender]. */
+    override suspend fun setFullPrerender(enabled: Boolean) {
+        store.edit { it[Keys.FULL_PRERENDER] = enabled }
+    }
+
     override suspend fun setVoiceSteady(enabled: Boolean) {
         store.edit { it[Keys.VOICE_STEADY] = enabled }
     }
@@ -1190,8 +1203,13 @@ class SettingsRepositoryUiImpl(
 
     override val warmupWait: Flow<Boolean> = store.data.map { it[Keys.WARMUP_WAIT] ?: false }
     override val catchupPause: Flow<Boolean> = store.data.map { it[Keys.CATCHUP_PAUSE] ?: true }
+    /** PR-F (#86) — see [PlaybackModeConfig.fullPrerender] kdoc for semantics.
+     *  Default false to keep the new-install footprint small. */
+    override val fullPrerender: Flow<Boolean> =
+        store.data.map { it[Keys.FULL_PRERENDER] ?: false }
     override suspend fun currentWarmupWait(): Boolean = warmupWait.first()
     override suspend fun currentCatchupPause(): Boolean = catchupPause.first()
+    override suspend fun currentFullPrerender(): Boolean = fullPrerender.first()
 
     // --- VoiceTuningConfig (issue #85, consumed by core-playback's EnginePlayer) ---
 

--- a/app/src/main/kotlin/in/jphe/storyvox/di/CacheBindingsModule.kt
+++ b/app/src/main/kotlin/in/jphe/storyvox/di/CacheBindingsModule.kt
@@ -1,0 +1,30 @@
+package `in`.jphe.storyvox.di
+
+import dagger.Binds
+import dagger.Module
+import dagger.hilt.InstallIn
+import dagger.hilt.components.SingletonComponent
+import `in`.jphe.storyvox.data.repository.FictionLibraryListener
+import `in`.jphe.storyvox.playback.cache.PrerenderTriggers
+
+/**
+ * PR-F (#86) — bind the cross-module seam between [FictionRepository]
+ * (in :core-data) and [PrerenderTriggers] (in :core-playback) so a
+ * `FictionRepository.addToLibrary` / `removeFromLibrary` call dispatches
+ * to the playback layer's pre-render scheduler without :core-data
+ * depending on :core-playback.
+ *
+ * Lives in :app because :app is the only Gradle module that depends
+ * on both :core-data and :core-playback. Keeping the binding here
+ * avoids a circular dep (core-data → core-playback → core-data) and
+ * keeps the playback layer free of FictionRepository.
+ */
+@Module
+@InstallIn(SingletonComponent::class)
+abstract class CacheBindingsModule {
+
+    @Binds
+    abstract fun bindFictionLibraryListener(
+        impl: PrerenderTriggers,
+    ): FictionLibraryListener
+}

--- a/app/src/test/kotlin/in/jphe/storyvox/di/RealPlaybackControllerUiTest.kt
+++ b/app/src/test/kotlin/in/jphe/storyvox/di/RealPlaybackControllerUiTest.kt
@@ -232,6 +232,7 @@ class RealPlaybackControllerUiTest {
         override suspend fun setPlaybackBufferChunks(chunks: Int) = Unit
         override suspend fun setWarmupWait(enabled: Boolean) = Unit
         override suspend fun setCatchupPause(enabled: Boolean) = Unit
+        override suspend fun setFullPrerender(enabled: Boolean) = Unit
         override suspend fun setVoiceSteady(enabled: Boolean) = Unit
         override suspend fun signIn() = Unit
         override suspend fun signOut() = Unit

--- a/core-data/src/main/kotlin/in/jphe/storyvox/data/repository/FictionLibraryListener.kt
+++ b/core-data/src/main/kotlin/in/jphe/storyvox/data/repository/FictionLibraryListener.kt
@@ -1,0 +1,46 @@
+package `in`.jphe.storyvox.data.repository
+
+/**
+ * Hook that listens for library-add / library-remove events. Bound by
+ * `:app`'s Hilt module to the playback layer's `PrerenderTriggers`
+ * (PR-F, #86) so [FictionRepository] can call into the cache layer
+ * without taking a `:core-playback` dependency directly. The interface
+ * is a one-way seam — :core-data calls; :core-playback (via :app's
+ * binding) listens.
+ *
+ * Default impl is a no-op so test doubles, alternate FictionRepository
+ * impls, and library-only consumers that don't run the playback layer
+ * never need to stub the methods.
+ *
+ * Default binding is the [NoOp] singleton so the graph compiles even
+ * when no PrerenderTriggers consumer is wired (e.g. instrumented tests
+ * that exercise FictionRepository in isolation). `:app`'s
+ * CacheBindingsModule overrides with the real PrerenderTriggers.
+ */
+interface FictionLibraryListener {
+    /**
+     * Called from [FictionRepository.addToLibrary] AFTER the row has
+     * been flipped in_library = true. The receiver typically schedules
+     * background pre-renders for the first few chapters.
+     *
+     * Suspending so the receiver can hit DataStore / SQLite without
+     * pinning the caller's coroutine — addToLibrary already runs on
+     * `Dispatchers.IO`.
+     */
+    suspend fun onLibraryAdded(fictionId: String) {}
+
+    /**
+     * Called from [FictionRepository.removeFromLibrary] AFTER the row
+     * has been flipped out of the library. The receiver typically
+     * cancels pending background renders for the fiction.
+     *
+     * Non-suspending so removeFromLibrary's "cancel-by-tag" call is
+     * synchronous from the repo's perspective — WorkManager's
+     * cancelAllWorkByTag is fire-and-forget.
+     */
+    fun onLibraryRemoved(fictionId: String) {}
+
+    /** No-op default. Used as the Hilt binding default when no
+     *  PrerenderTriggers is wired (tests, library-only consumers). */
+    object NoOp : FictionLibraryListener
+}

--- a/core-data/src/main/kotlin/in/jphe/storyvox/data/repository/FictionRepository.kt
+++ b/core-data/src/main/kotlin/in/jphe/storyvox/data/repository/FictionRepository.kt
@@ -172,6 +172,12 @@ class FictionRepositoryImpl @Inject constructor(
      *  a stub `Map<String, FictionSource>` keep compiling — they pass
      *  the empty resolver factory below. */
     private val urlResolver: UrlResolver? = null,
+    /** PR-F (#86) — listener that the playback layer's PrerenderTriggers
+     *  binds to. Defaults to [FictionLibraryListener.NoOp] so tests
+     *  and library-only consumers that don't run the playback layer
+     *  don't need to stub. `:app`'s CacheBindingsModule overrides
+     *  the binding to PrerenderTriggers in production. */
+    private val libraryListener: FictionLibraryListener = FictionLibraryListener.NoOp,
 ) : FictionRepository {
 
     /**
@@ -317,6 +323,12 @@ class FictionRepositoryImpl @Inject constructor(
         if (existing == null) refreshDetail(id) // best-effort; ignore failure
         fictionDao.setInLibrary(id, true, System.currentTimeMillis())
         if (mode != null) fictionDao.setDownloadMode(id, mode)
+        // PR-F (#86) — notify the playback layer so it can pre-render
+        // chapters 1-N (or all, in Mode C). runCatching guards against
+        // a listener that throws — library add must always succeed
+        // from the user's perspective even if pre-render scheduling
+        // hiccups.
+        runCatching { libraryListener.onLibraryAdded(id) }
         Unit
     }
 
@@ -325,6 +337,11 @@ class FictionRepositoryImpl @Inject constructor(
         // Eviction policy: keep the metadata around (no auto-evict per spec).
         // Caller may explicitly purge transient rows via deleteIfTransient.
         fictionDao.deleteIfTransient(id)
+        // PR-F (#86) — cancel any background pre-renders for this
+        // fiction. Listener is non-suspending so this is fire-and-
+        // forget from the repo's perspective; WorkManager's
+        // cancelAllWorkByTag is itself async internally.
+        runCatching { libraryListener.onLibraryRemoved(id) }
         Unit
     }
 

--- a/core-data/src/main/kotlin/in/jphe/storyvox/data/repository/playback/PlaybackModeConfig.kt
+++ b/core-data/src/main/kotlin/in/jphe/storyvox/data/repository/playback/PlaybackModeConfig.kt
@@ -42,10 +42,32 @@ interface PlaybackModeConfig {
     val catchupPause: Flow<Boolean>
 
     /**
+     * Live flow of **Mode C — Full Pre-render**. Default false.
+     *
+     * When true, library-add scheduling (PR-F PrerenderTriggers) expands
+     * from "chapters 1-3" to "every chapter in the fiction", and
+     * currently-in-library fictions enqueue any not-yet-cached chapters
+     * on flow flip false → true (via `PrerenderModeWatcher` in `:app`).
+     *
+     * Trades aggressive disk + CPU usage for a "play any chapter,
+     * instantly" experience. Off by default because the binge case
+     * (40-chapter fiction × 70 MB Piper-high each = 2.8 GB) blows past
+     * the default 2 GB quota — eviction then thrashes between renders.
+     * Power users who set quota to 5 GB or Unlimited and want the
+     * gapless-everywhere experience flip this on.
+     *
+     * PR-F adds the flow + DataStore plumbing. PR-G surfaces the
+     * Settings toggle.
+     */
+    val fullPrerender: Flow<Boolean>
+
+    /**
      * Snapshot reads for callers that need a single value without subscribing.
      * Implementations should return the most recent value, falling back to the
-     * documented default (true / true) if the underlying store hasn't emitted yet.
+     * documented default (true / true / false) if the underlying store hasn't
+     * emitted yet.
      */
     suspend fun currentWarmupWait(): Boolean
     suspend fun currentCatchupPause(): Boolean
+    suspend fun currentFullPrerender(): Boolean
 }

--- a/core-playback/build.gradle.kts
+++ b/core-playback/build.gradle.kts
@@ -129,6 +129,15 @@ dependencies {
     implementation(libs.hilt.android)
     ksp(libs.hilt.compiler)
 
+    // PR-F (#86) — background PCM cache pre-render via WorkManager.
+    // ChapterRenderJob is a @HiltWorker that synthesizes a chapter's
+    // PCM into the cache on a background coroutine, scheduled by
+    // PcmRenderScheduler from PrerenderTriggers' lifecycle hooks
+    // (library-add, chapter-natural-end, Mode C flow flip).
+    implementation(libs.androidx.work.runtime.ktx)
+    implementation(libs.androidx.hilt.work)
+    ksp(libs.androidx.hilt.compiler)
+
     // Compose — for the engine consent dialog atom
     implementation(platform(libs.androidx.compose.bom))
     implementation(libs.androidx.compose.material3)

--- a/core-playback/consumer-rules.pro
+++ b/core-playback/consumer-rules.pro
@@ -2,6 +2,16 @@
 -keep class in.jphe.storyvox.playback.StoryvoxPlaybackService
 -keep class in.jphe.storyvox.playback.auto.StoryvoxAutoBrowserService
 
+# PR-F (#86) — Hilt's WorkerFactory looks up CoroutineWorker subclasses
+# by FQN at runtime (the WorkManager runtime instantiates them
+# reflectively via the generated HiltWorkerFactory binding). R8 doesn't
+# always see HiltWorker-annotated classes as roots from its DCE pass —
+# `core-data`'s consumer-rules.pro pins `in.jphe.storyvox.data.work.**`
+# the same way for ChapterDownloadWorker; mirror that here for
+# `playback.cache.**` so ChapterRenderJob (and any future worker landing
+# in this package) survives minified builds.
+-keep class in.jphe.storyvox.playback.cache.ChapterRenderJob { *; }
+
 # Kotlinx serialization — keep generated serializers
 -keepattributes *Annotation*, InnerClasses
 -dontnote kotlinx.serialization.AnnotationsKt

--- a/core-playback/src/main/kotlin/in/jphe/storyvox/playback/cache/ChapterRenderJob.kt
+++ b/core-playback/src/main/kotlin/in/jphe/storyvox/playback/cache/ChapterRenderJob.kt
@@ -1,11 +1,32 @@
 package `in`.jphe.storyvox.playback.cache
 
+import android.app.Notification
+import android.app.NotificationChannel
+import android.app.NotificationManager
 import android.content.Context
+import android.os.Build
+import android.util.Log
+import androidx.core.app.NotificationCompat
 import androidx.hilt.work.HiltWorker
 import androidx.work.CoroutineWorker
+import androidx.work.ForegroundInfo
 import androidx.work.WorkerParameters
+import com.CodeBySonu.VoxSherpa.KittenEngine
+import com.CodeBySonu.VoxSherpa.KokoroEngine
+import com.CodeBySonu.VoxSherpa.VoiceEngine
 import dagger.assisted.Assisted
 import dagger.assisted.AssistedInject
+import `in`.jphe.storyvox.data.repository.ChapterRepository
+import `in`.jphe.storyvox.data.repository.pronunciation.PronunciationDict
+import `in`.jphe.storyvox.playback.tts.CHUNKER_VERSION
+import `in`.jphe.storyvox.playback.tts.SentenceChunker
+import `in`.jphe.storyvox.playback.tts.source.trailingPauseMs
+import `in`.jphe.storyvox.playback.voice.EngineType
+import `in`.jphe.storyvox.playback.voice.UiVoiceInfo
+import `in`.jphe.storyvox.playback.voice.VoiceManager
+import java.io.File
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.sync.withLock
 
 /**
  * Background WorkManager job that renders one chapter's PCM into the
@@ -13,22 +34,290 @@ import dagger.assisted.AssistedInject
  * [PrerenderTriggers]' lifecycle hooks (library-add, chapter
  * natural-end +2, fullPrerender flow flips).
  *
- * Body lands in the next commit — this stub exists so [PcmRenderScheduler]
- * compiles against `OneTimeWorkRequestBuilder<ChapterRenderJob>()` while
- * the wire-up + binding lands together.
+ * Lifecycle:
+ *  1. Re-read chapter text + active voice at run-time. Voice may have
+ *     changed between schedule-time and run-time — recompute the cache
+ *     key with the CURRENT voice.
+ *  2. If the cache is already complete for the recomputed key, skip
+ *     (someone else already rendered it; tee-write from foreground
+ *     playback or a sibling worker).
+ *  3. Skip Azure voices entirely — BYOK rate limits + cloud round-
+ *     trips make unsupervised background renders risky. Foreground
+ *     play of an Azure voice still tees normally via PR-D.
+ *  4. setForeground for the duration — render can take 30+ minutes on
+ *     Piper-high + Tab A7 Lite.
+ *  5. Acquire [EngineMutex.mutex] around loadModel + every
+ *     generateAudioPCM call. EnginePlayer.loadAndPlay also takes this
+ *     mutex; serialization is at sentence granularity so foreground
+ *     playback can interleave between worker sentences.
+ *  6. Loop sentences: generate PCM → [PcmAppender.appendSentence].
+ *  7. On completion finalize the appender + run evictToQuota.
+ *  8. On worker cancellation (user removed fiction, voice changed and
+ *     foreground render of same chapter started), abandon the
+ *     appender so partial files don't lie around.
+ *
+ * Speed/pitch quantization: PR-F's first cut renders at 1.0× / 1.0×
+ * regardless of the user's persisted default. A user who plays at
+ * 1.5× will hit a cache miss and the streaming path will tee a
+ * SECOND cache file at 1.5×. Disk usage grows linearly in distinct
+ * speed knobs the user explores; spec accepts this trade-off (open
+ * question 1 in the plan).
+ *
+ * Pronunciation dict snapshot: empty dict at worker time so the key
+ * is stable across schedule→run windows. A foreground play with a
+ * custom dict will tee a separate cache key.
+ *
+ * Retry semantics: chapter-body-not-yet-downloaded triggers
+ * [Result.retry] (ChapterDownloadWorker may still be running);
+ * model-load-failure and OOM trigger retry with the scheduler's
+ * exponential backoff (5-minute base). Worker cancellation
+ * (isStopped == true) returns [Result.failure] without retry —
+ * the cancel was deliberate.
  *
  * PR F of the PCM cache series (#86).
  */
 @HiltWorker
 class ChapterRenderJob @AssistedInject constructor(
-    @Assisted appContext: Context,
+    @Assisted private val appContext: Context,
     @Assisted params: WorkerParameters,
+    private val chapterRepo: ChapterRepository,
+    private val voiceManager: VoiceManager,
+    private val pcmCache: PcmCache,
+    private val engineMutex: EngineMutex,
+    private val chunker: SentenceChunker,
 ) : CoroutineWorker(appContext, params) {
 
-    override suspend fun doWork(): Result = Result.failure()
+    override suspend fun doWork(): Result {
+        val fictionId = inputData.getString(KEY_FICTION_ID)
+            ?: return Result.failure()
+        val chapterId = inputData.getString(KEY_CHAPTER_ID)
+            ?: return Result.failure()
+
+        Log.i(LOG_TAG, "pcm-cache PRERENDER-RUNNING chapterId=$chapterId fictionId=$fictionId")
+
+        // 1. Re-read chapter text. If the body isn't downloaded yet,
+        // retry — ChapterDownloadWorker may still be running.
+        val chapter = chapterRepo.getChapter(chapterId)
+        if (chapter == null) {
+            Log.i(LOG_TAG, "pcm-cache PRERENDER-SKIP-NOTEXT chapterId=$chapterId")
+            return Result.retry()
+        }
+
+        // Issue #373 — audio-stream chapters (audioUrl != null) bypass
+        // TTS entirely; there's nothing to pre-render.
+        if (chapter.audioUrl != null) {
+            Log.i(LOG_TAG, "pcm-cache PRERENDER-SKIP-AUDIOURL chapterId=$chapterId")
+            return Result.success()
+        }
+        if (chapter.text.isEmpty()) {
+            Log.i(LOG_TAG, "pcm-cache PRERENDER-SKIP-EMPTYTEXT chapterId=$chapterId")
+            return Result.success()
+        }
+
+        // 2. Re-read active voice at run-time.
+        val voice = voiceManager.activeVoice.first()
+        if (voice == null) {
+            Log.i(LOG_TAG, "pcm-cache PRERENDER-SKIP-NOVOICE chapterId=$chapterId")
+            return Result.retry()
+        }
+
+        // 3. Skip Azure voices — see kdoc.
+        if (voice.engineType is EngineType.Azure) {
+            Log.i(
+                LOG_TAG,
+                "pcm-cache PRERENDER-SKIP-AZURE chapterId=$chapterId voiceId=${voice.id}",
+            )
+            return Result.success()
+        }
+
+        // 4. Build the cache key. Render at the 1.0×/1.0× empty-dict
+        // identity — see kdoc on speed/pitch quantization.
+        val cacheKey = PcmCacheKey(
+            chapterId = chapterId,
+            voiceId = voice.id,
+            speedHundredths = PcmCacheKey.quantize(1.0f),
+            pitchHundredths = PcmCacheKey.quantize(1.0f),
+            chunkerVersion = CHUNKER_VERSION,
+            pronunciationDictHash = PronunciationDict.EMPTY.contentHash,
+        )
+
+        // 5. Skip if already complete.
+        if (pcmCache.isComplete(cacheKey)) {
+            Log.i(
+                LOG_TAG,
+                "pcm-cache PRERENDER-SKIP-COMPLETE chapterId=$chapterId " +
+                    "base=${cacheKey.fileBaseName().take(12)}",
+            )
+            return Result.success()
+        }
+
+        // 6. Wipe stale partial — same abandon-and-restart policy as
+        // the foreground streaming-tee path (PR-D).
+        if (pcmCache.metaFileFor(cacheKey).exists()) {
+            pcmCache.delete(cacheKey)
+        }
+
+        // 7. setForeground for long renders — render can run 30+ min on
+        // Piper-high on the Tab A7 Lite. runCatching guards against
+        // foreground-service start failures on locked devices /
+        // restricted-app states; the worker will run anyway, just at
+        // background priority and at risk of doze.
+        runCatching { setForeground(buildForegroundInfo(chapter.title)) }
+
+        // 8. Load the model (idempotent if EnginePlayer already loaded
+        // the same voice). Holds engineMutex.
+        val loadResult = engineMutex.mutex.withLock {
+            if (isStopped) return Result.failure()
+            loadModel(voice)
+        }
+        if (loadResult != "Success") {
+            Log.w(
+                LOG_TAG,
+                "pcm-cache PRERENDER-FAIL chapterId=$chapterId loadResult=$loadResult",
+            )
+            return Result.retry()
+        }
+
+        // 9. Generate sentences + write to cache.
+        val sentences = chunker.chunk(chapter.text)
+        val sampleRate = sampleRateFor(voice)
+        val appender = pcmCache.appender(cacheKey, sampleRate = sampleRate)
+        try {
+            for (s in sentences) {
+                if (isStopped) {
+                    appender.abandon()
+                    Log.i(LOG_TAG, "pcm-cache PRERENDER-CANCELLED chapterId=$chapterId")
+                    return Result.failure()
+                }
+                val pcm = engineMutex.mutex.withLock {
+                    if (isStopped) return@withLock null
+                    generateAudioPCM(voice, s.text)
+                } ?: continue
+                val pauseMs = trailingPauseMs(s.text)
+                runCatching { appender.appendSentence(s, pcm, pauseMs) }
+                    .onFailure {
+                        appender.abandon()
+                        Log.w(LOG_TAG, "pcm-cache PRERENDER-FAIL chapterId=$chapterId", it)
+                        return Result.retry()
+                    }
+            }
+            // 10. Finalize + evict. evictToQuota pins the just-finalized
+            // basename so mtime-tie races don't evict the fresh entry.
+            runCatching { appender.finalize() }
+                .onFailure {
+                    appender.abandon()
+                    Log.w(LOG_TAG, "pcm-cache PRERENDER-FAIL chapterId=$chapterId finalize", it)
+                    return Result.retry()
+                }
+            runCatching {
+                pcmCache.evictToQuota(pinnedBasenames = setOf(cacheKey.fileBaseName()))
+            }
+            Log.i(
+                LOG_TAG,
+                "pcm-cache PRERENDER-SUCCESS chapterId=$chapterId voice=${voice.id} " +
+                    "sentences=${sentences.size} base=${cacheKey.fileBaseName().take(12)}",
+            )
+            return Result.success()
+        } catch (t: Throwable) {
+            appender.abandon()
+            Log.w(LOG_TAG, "pcm-cache PRERENDER-FAIL chapterId=$chapterId threw", t)
+            return if (isStopped) Result.failure() else Result.retry()
+        }
+    }
+
+    // ── engine bridging ─────────────────────────────────────────────────
+
+    private fun loadModel(voice: UiVoiceInfo): String =
+        when (val type = voice.engineType) {
+            is EngineType.Piper -> {
+                val voiceDir = voiceManager.voiceDirFor(voice.id)
+                val onnx = File(voiceDir, "model.onnx").absolutePath
+                val tokens = File(voiceDir, "tokens.txt").absolutePath
+                VoiceEngine.getInstance().loadModel(appContext, onnx, tokens)
+                    ?: "Error: load returned null"
+            }
+            is EngineType.Kokoro -> {
+                val sharedDir = voiceManager.kokoroSharedDir()
+                val onnx = File(sharedDir, "model.onnx").absolutePath
+                val tokens = File(sharedDir, "tokens.txt").absolutePath
+                val voicesBin = File(sharedDir, "voices.bin").absolutePath
+                KokoroEngine.getInstance().setActiveSpeakerId(type.speakerId)
+                KokoroEngine.getInstance().loadModel(appContext, onnx, tokens, voicesBin)
+                    ?: "Error: load returned null"
+            }
+            is EngineType.Kitten -> {
+                val sharedDir = voiceManager.kittenSharedDir()
+                val onnx = File(sharedDir, "model.onnx").absolutePath
+                val tokens = File(sharedDir, "tokens.txt").absolutePath
+                val voicesBin = File(sharedDir, "voices.bin").absolutePath
+                KittenEngine.getInstance().setActiveSpeakerId(type.speakerId)
+                KittenEngine.getInstance().loadModel(appContext, onnx, tokens, voicesBin)
+                    ?: "Error: load returned null"
+            }
+            // Guarded above — defensive fall-through if surface evolves.
+            is EngineType.Azure -> "Error: Azure not supported in background pre-render"
+        }
+
+    private fun sampleRateFor(voice: UiVoiceInfo): Int =
+        when (voice.engineType) {
+            is EngineType.Kokoro -> KokoroEngine.getInstance().sampleRate
+            is EngineType.Kitten -> KittenEngine.getInstance().sampleRate
+            else -> VoiceEngine.getInstance().sampleRate
+        }.takeIf { it > 0 } ?: DEFAULT_SAMPLE_RATE_HZ
+
+    private fun generateAudioPCM(voice: UiVoiceInfo, text: String): ByteArray? =
+        when (voice.engineType) {
+            is EngineType.Kokoro -> KokoroEngine.getInstance()
+                .generateAudioPCM(text, 1.0f, 1.0f)
+            is EngineType.Kitten -> KittenEngine.getInstance()
+                .generateAudioPCM(text, 1.0f, 1.0f)
+            else -> VoiceEngine.getInstance()
+                .generateAudioPCM(text, 1.0f, 1.0f)
+        }
+
+    // ── foreground notification ─────────────────────────────────────────
+
+    private fun buildForegroundInfo(title: String): ForegroundInfo {
+        val nm = appContext.getSystemService(NotificationManager::class.java)
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O && nm != null) {
+            val ch = NotificationChannel(
+                CHANNEL_ID,
+                CHANNEL_NAME,
+                NotificationManager.IMPORTANCE_LOW,
+            ).apply { description = "Background audiobook caching" }
+            nm.createNotificationChannel(ch)
+        }
+        val notif: Notification = NotificationCompat.Builder(appContext, CHANNEL_ID)
+            .setContentTitle("Caching audiobook")
+            .setContentText(title)
+            .setSmallIcon(android.R.drawable.stat_notify_sync)
+            .setOngoing(true)
+            .setPriority(NotificationCompat.PRIORITY_LOW)
+            .build()
+        // FOREGROUND_SERVICE_TYPE_DATA_SYNC is the closest WorkManager
+        // type for "render audio in the background" — synthesis is
+        // local CPU work, no media playback, no user-visible Media3
+        // session attached. Required on API 34+ to avoid SecurityException.
+        return if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.UPSIDE_DOWN_CAKE) {
+            ForegroundInfo(
+                NOTIFICATION_ID,
+                notif,
+                android.content.pm.ServiceInfo.FOREGROUND_SERVICE_TYPE_DATA_SYNC,
+            )
+        } else {
+            ForegroundInfo(NOTIFICATION_ID, notif)
+        }
+    }
 
     companion object {
+        private const val LOG_TAG = "ChapterRenderJob"
         const val KEY_FICTION_ID = "fictionId"
         const val KEY_CHAPTER_ID = "chapterId"
+        private const val CHANNEL_ID = "pcm-render-channel"
+        private const val CHANNEL_NAME = "PCM render"
+        private const val NOTIFICATION_ID = 5042
+        /** Safe fallback if the engine reports `sampleRate == 0`. Matches
+         *  the Piper-high default. */
+        private const val DEFAULT_SAMPLE_RATE_HZ = 22_050
     }
 }

--- a/core-playback/src/main/kotlin/in/jphe/storyvox/playback/cache/ChapterRenderJob.kt
+++ b/core-playback/src/main/kotlin/in/jphe/storyvox/playback/cache/ChapterRenderJob.kt
@@ -1,0 +1,34 @@
+package `in`.jphe.storyvox.playback.cache
+
+import android.content.Context
+import androidx.hilt.work.HiltWorker
+import androidx.work.CoroutineWorker
+import androidx.work.WorkerParameters
+import dagger.assisted.Assisted
+import dagger.assisted.AssistedInject
+
+/**
+ * Background WorkManager job that renders one chapter's PCM into the
+ * cache. Triggered by [PcmRenderScheduler.scheduleRender] from
+ * [PrerenderTriggers]' lifecycle hooks (library-add, chapter
+ * natural-end +2, fullPrerender flow flips).
+ *
+ * Body lands in the next commit — this stub exists so [PcmRenderScheduler]
+ * compiles against `OneTimeWorkRequestBuilder<ChapterRenderJob>()` while
+ * the wire-up + binding lands together.
+ *
+ * PR F of the PCM cache series (#86).
+ */
+@HiltWorker
+class ChapterRenderJob @AssistedInject constructor(
+    @Assisted appContext: Context,
+    @Assisted params: WorkerParameters,
+) : CoroutineWorker(appContext, params) {
+
+    override suspend fun doWork(): Result = Result.failure()
+
+    companion object {
+        const val KEY_FICTION_ID = "fictionId"
+        const val KEY_CHAPTER_ID = "chapterId"
+    }
+}

--- a/core-playback/src/main/kotlin/in/jphe/storyvox/playback/cache/EngineMutex.kt
+++ b/core-playback/src/main/kotlin/in/jphe/storyvox/playback/cache/EngineMutex.kt
@@ -1,0 +1,42 @@
+package `in`.jphe.storyvox.playback.cache
+
+import javax.inject.Inject
+import javax.inject.Singleton
+import kotlinx.coroutines.sync.Mutex
+
+/**
+ * Process-wide mutex that serializes calls into the singleton VoxSherpa
+ * engines (Piper / Kokoro / Kitten). Held during:
+ *  - `VoiceEngine.loadModel` / `KokoroEngine.loadModel` / `KittenEngine.loadModel`
+ *    (model load + warm-up)
+ *  - `VoiceEngine.generateAudioPCM` / `KokoroEngine.generateAudioPCM` /
+ *    `KittenEngine.generateAudioPCM` (per-sentence inference)
+ *  - `engine.destroy` (release)
+ *
+ * Without this serialization, `loadModel` can free the native pointer
+ * while a `generateAudioPCM` call is mid-flight on another thread —
+ * SIGSEGV (issue #11).
+ *
+ * Two callers in the system:
+ *  - [`in`.jphe.storyvox.playback.tts.EnginePlayer] — foreground
+ *    playback, takes the mutex on every sentence the streaming source
+ *    generates AND on every `loadAndPlay` model swap.
+ *  - [`in`.jphe.storyvox.playback.cache.ChapterRenderJob] (PR-F) —
+ *    background WorkManager-driven pre-render. Takes the mutex
+ *    per-sentence in the rendering loop.
+ *
+ * Both share this `@Singleton`. Wraps a [Mutex] (kotlinx.coroutines) —
+ * re-entrancy is NOT supported. EnginePlayer's `loadAndPlay` doesn't
+ * currently re-enter (model load and generate are serialized, never
+ * nested), so this matches the current usage.
+ *
+ * Pre-PR-F this mutex was a private `Mutex()` inside `EnginePlayer`.
+ * Hoisting was needed so the background worker shares the SAME instance
+ * with the foreground player — a private `Mutex()` per ChapterRenderJob
+ * would still allow concurrent JNI calls between worker and player,
+ * which is the issue #11 race.
+ */
+@Singleton
+class EngineMutex @Inject constructor() {
+    val mutex: Mutex = Mutex()
+}

--- a/core-playback/src/main/kotlin/in/jphe/storyvox/playback/cache/PcmRenderScheduler.kt
+++ b/core-playback/src/main/kotlin/in/jphe/storyvox/playback/cache/PcmRenderScheduler.kt
@@ -1,0 +1,138 @@
+package `in`.jphe.storyvox.playback.cache
+
+import android.content.Context
+import android.util.Log
+import androidx.work.BackoffPolicy
+import androidx.work.Constraints
+import androidx.work.Data
+import androidx.work.ExistingWorkPolicy
+import androidx.work.NetworkType
+import androidx.work.OneTimeWorkRequestBuilder
+import androidx.work.WorkManager
+import dagger.hilt.android.qualifiers.ApplicationContext
+import java.time.Duration
+import javax.inject.Inject
+import javax.inject.Singleton
+
+/**
+ * Schedules background PCM cache renders for chapters likely to be played
+ * soon. Sits in front of WorkManager so trigger sources (FictionRepository's
+ * addToLibrary, EnginePlayer's handleChapterDone, the `:app`-level Mode C
+ * collector) stay free of `androidx.work` imports.
+ *
+ * Production binds [WorkManagerPcmRenderScheduler]; tests substitute a
+ * recording fake to assert call sequence + args without spinning up
+ * WorkManager (see `PrerenderTriggersTest`).
+ *
+ * Unique-name policy: `pcm-render-<chapterId>` with
+ * [ExistingWorkPolicy.KEEP] — repeated calls for the same chapter are
+ * no-ops while a prior request is queued or running. This is the spec's
+ * "single in-flight render at a time per chapter" enforcement at the
+ * WorkManager level. Process-wide engine concurrency is enforced
+ * separately by [EngineMutex] inside the worker.
+ *
+ * Cancellation paths:
+ *  - [cancelRender] — fine-grained by chapterId. Used when foreground
+ *    playback of the same key is about to start (the streaming source's
+ *    tee will populate the cache anyway).
+ *  - [cancelAllForFiction] — bulk cancel via the `pcm-render-fiction-<id>`
+ *    tag. Used by `FictionRepository.removeFromLibrary` to stop
+ *    background work for a fiction the user no longer wants.
+ *
+ * PR F of the PCM cache series (#86).
+ */
+interface PcmRenderScheduler {
+
+    /**
+     * Enqueue a render for [chapterId]. No-op if a render for the same
+     * chapterId is already queued or running (KEEP policy).
+     */
+    fun scheduleRender(fictionId: String, chapterId: String)
+
+    /** Cancel an in-flight or queued render for [chapterId]. Idempotent. */
+    fun cancelRender(chapterId: String)
+
+    /**
+     * Cancel all renders for any chapter belonging to [fictionId]. Used
+     * by [`in`.jphe.storyvox.data.repository.FictionRepository.removeFromLibrary]
+     * (via the FictionLibraryListener seam) to stop background work for
+     * a fiction the user no longer wants.
+     */
+    fun cancelAllForFiction(fictionId: String)
+}
+
+@Singleton
+class WorkManagerPcmRenderScheduler @Inject constructor(
+    @ApplicationContext private val context: Context,
+) : PcmRenderScheduler {
+
+    private val workManager: WorkManager get() = WorkManager.getInstance(context)
+
+    override fun scheduleRender(fictionId: String, chapterId: String) {
+        // Per spec — don't render at low battery (synthesis is CPU-heavy,
+        // ~30%+ on Helio P22T per chapter) or when storage is low (the
+        // cache writes can be 70+ MB per chapter on Piper-high; a render
+        // that gets killed mid-write by ENOSPC leaves a partial file
+        // for the next foreground play to wipe via PR-D's abandon-and-
+        // restart policy — works, but wasteful). NetworkType.NOT_REQUIRED
+        // because synthesis is purely local (Azure renders are excluded
+        // from background pre-render in PR-F's first cut — they round-
+        // trip to the cloud and BYOK rate limits make unsupervised
+        // pre-render risky).
+        val constraints = Constraints.Builder()
+            .setRequiresBatteryNotLow(true)
+            .setRequiresStorageNotLow(true)
+            .setRequiredNetworkType(NetworkType.NOT_REQUIRED)
+            .build()
+
+        val input = Data.Builder()
+            .putString(ChapterRenderJob.KEY_FICTION_ID, fictionId)
+            .putString(ChapterRenderJob.KEY_CHAPTER_ID, chapterId)
+            .build()
+
+        val request = OneTimeWorkRequestBuilder<ChapterRenderJob>()
+            .setConstraints(constraints)
+            .setInputData(input)
+            // Long backoff — a render that fails (model load failure,
+            // OOM mid-generate) is unlikely to succeed on a quick retry.
+            // Give the device time to clean up; if it keeps failing, the
+            // WorkManager backoff cap takes over.
+            .setBackoffCriteria(BackoffPolicy.EXPONENTIAL, Duration.ofMinutes(5))
+            .addTag(TAG)
+            .addTag(fictionTag(fictionId))
+            .build()
+
+        Log.i(
+            LOG_TAG,
+            "pcm-cache PRERENDER-ENQUEUED fictionId=$fictionId chapterId=$chapterId",
+        )
+        workManager.enqueueUniqueWork(
+            uniqueName(chapterId),
+            ExistingWorkPolicy.KEEP,
+            request,
+        )
+    }
+
+    override fun cancelRender(chapterId: String) {
+        Log.i(LOG_TAG, "pcm-cache PRERENDER-CANCEL chapterId=$chapterId")
+        workManager.cancelUniqueWork(uniqueName(chapterId))
+    }
+
+    override fun cancelAllForFiction(fictionId: String) {
+        Log.i(LOG_TAG, "pcm-cache PRERENDER-CANCEL-FICTION fictionId=$fictionId")
+        workManager.cancelAllWorkByTag(fictionTag(fictionId))
+    }
+
+    companion object {
+        /** Logcat tag — match the rest of the PCM cache layer's scheme. */
+        private const val LOG_TAG = "PcmRenderScheduler"
+
+        /** Shared WorkManager tag for *every* PCM render job; lets a
+         *  blanket cancelAllWorkByTag(TAG) wipe pre-renders without
+         *  also nuking ChapterDownloadWorker entries. */
+        const val TAG = "pcm-render"
+
+        fun uniqueName(chapterId: String): String = "pcm-render-$chapterId"
+        fun fictionTag(fictionId: String): String = "pcm-render-fiction-$fictionId"
+    }
+}

--- a/core-playback/src/main/kotlin/in/jphe/storyvox/playback/cache/PrerenderTriggers.kt
+++ b/core-playback/src/main/kotlin/in/jphe/storyvox/playback/cache/PrerenderTriggers.kt
@@ -1,0 +1,167 @@
+package `in`.jphe.storyvox.playback.cache
+
+import android.util.Log
+import `in`.jphe.storyvox.data.repository.ChapterRepository
+import `in`.jphe.storyvox.data.repository.FictionLibraryListener
+import `in`.jphe.storyvox.data.repository.playback.PlaybackModeConfig
+import javax.inject.Inject
+import javax.inject.Singleton
+import kotlinx.coroutines.flow.first
+
+/**
+ * Trigger glue for the PCM cache pre-render scheduler. Sits between
+ * trigger sources (FictionRepository, EnginePlayer, the `:app`-level
+ * fullPrerender flow collector) and the scheduler so none of those
+ * callers needs to know about WorkManager.
+ *
+ * Trigger semantics per spec (see
+ * `docs/superpowers/specs/2026-05-07-pcm-cache-design.md` § "Trigger
+ * points"):
+ *
+ *  - **Library add** ([onLibraryAdded]) — schedule renders for the
+ *    first [DEFAULT_PRERENDER_CHAPTERS] chapters in reading order, OR
+ *    all chapters if Mode C ([PlaybackModeConfig.fullPrerender]) is
+ *    on.
+ *  - **Chapter complete** ([onChapterCompleted]) — schedule a render
+ *    of chapter N+2 in reading order, where N is the just-completed
+ *    chapter. N+1 is usually already cached or in flight from the
+ *    previous chapter-completed trigger or from PR-D's foreground
+ *    tee while the user is actively listening.
+ *  - **Fiction removed** ([onLibraryRemoved]) — cancel all scheduled
+ *    renders for that fiction (via the `pcm-render-fiction-<id>` tag).
+ *  - **Mode C flow flip** false → true ([onFullPrerenderEnabled]) —
+ *    re-evaluate every library fiction and enqueue any not-yet-cached
+ *    chapters. Called from `:app`'s flow collector (PrerenderModeWatcher)
+ *    so this class doesn't need to take a FictionRepository dependency.
+ *
+ * Implements [FictionLibraryListener] (in :core-data) — :app's
+ * CacheBindingsModule binds this class as the listener so
+ * FictionRepository's addToLibrary / removeFromLibrary can dispatch
+ * without depending on :core-playback directly.
+ *
+ * NOT in this PR: cancel a render when the user is now actively
+ * playing the same (chapter, voice) key via the streaming source.
+ * The streaming source's tee writes to the SAME cache key; PR-D's
+ * appender's resume detection (meta exists, idx absent) means the
+ * foreground tee will collide with a worker that finalized first.
+ * Spec calls this "mutual exclusion contract"; PR-F's first cut
+ * handles it via the engineMutex (worker can't generate while
+ * foreground holds the mutex; serialization is at sentence
+ * granularity, effectively the worker pauses between sentences while
+ * foreground is active). A future cleanup adds explicit
+ * [PcmRenderScheduler.cancelRender] calls from
+ * EnginePlayer.startPlaybackPipeline for the matching key.
+ *
+ * PR F of the PCM cache series (#86).
+ */
+@Singleton
+class PrerenderTriggers @Inject constructor(
+    private val scheduler: PcmRenderScheduler,
+    private val chapterRepo: ChapterRepository,
+    private val modeConfig: PlaybackModeConfig,
+) : FictionLibraryListener {
+
+    /**
+     * Library-add: schedule chapters 1-N (per [DEFAULT_PRERENDER_CHAPTERS]
+     * or full-prerender). Order matches reading order from
+     * [ChapterRepository.observeChapters] — first emission is the
+     * current snapshot, sorted by chapter index.
+     */
+    override suspend fun onLibraryAdded(fictionId: String) {
+        val chapters = chapterRepo.observeChapters(fictionId).first()
+            .sortedBy { it.index }
+        if (chapters.isEmpty()) {
+            Log.i(
+                LOG_TAG,
+                "pcm-cache TRIGGER-LIBRARY-ADD fictionId=$fictionId chapters=0 (skipping)",
+            )
+            return
+        }
+        val limit = if (modeConfig.currentFullPrerender()) {
+            chapters.size
+        } else {
+            DEFAULT_PRERENDER_CHAPTERS
+        }
+        val targets = chapters.take(limit)
+        Log.i(
+            LOG_TAG,
+            "pcm-cache TRIGGER-LIBRARY-ADD fictionId=$fictionId " +
+                "scheduling=${targets.size} fullPrerender=${limit == chapters.size}",
+        )
+        for (chapter in targets) {
+            scheduler.scheduleRender(fictionId = fictionId, chapterId = chapter.id)
+        }
+    }
+
+    /**
+     * Chapter natural-end: schedule N+2. N+1 should already be cached
+     * (it was scheduled when N started OR is the next-up that the user
+     * is about to play and PR-D's tee will populate). N+2 keeps the
+     * pre-render window one chapter ahead of playback so the user
+     * never hits a streaming cold-start.
+     *
+     * Resolves the next-next chapter's fictionId via the chapter row —
+     * the trigger doesn't carry it and we don't want to assume.
+     */
+    suspend fun onChapterCompleted(currentChapterId: String) {
+        val nextId = chapterRepo.getNextChapterId(currentChapterId)
+        if (nextId == null) {
+            Log.i(
+                LOG_TAG,
+                "pcm-cache TRIGGER-CHAPTER-DONE chapterId=$currentChapterId " +
+                    "no-next (end of fiction)",
+            )
+            return
+        }
+        val nextNextId = chapterRepo.getNextChapterId(nextId) ?: return
+        val nextNextChapter = chapterRepo.getChapter(nextNextId) ?: return
+        Log.i(
+            LOG_TAG,
+            "pcm-cache TRIGGER-CHAPTER-DONE chapterId=$currentChapterId " +
+                "scheduling next-next=$nextNextId",
+        )
+        scheduler.scheduleRender(
+            fictionId = nextNextChapter.fictionId,
+            chapterId = nextNextId,
+        )
+    }
+
+    override fun onLibraryRemoved(fictionId: String) {
+        Log.i(LOG_TAG, "pcm-cache TRIGGER-LIBRARY-REMOVE fictionId=$fictionId")
+        scheduler.cancelAllForFiction(fictionId)
+    }
+
+    /**
+     * Mode C flow flip false → true. Re-evaluates every library
+     * fiction and enqueues any not-yet-cached chapters. Called by
+     * `:app`'s PrerenderModeWatcher flow collector (which knows
+     * about FictionRepository — this class deliberately doesn't, to
+     * keep `:core-playback` from depending on the library repository).
+     *
+     * The KEEP existing-work policy on the scheduler means re-scheduling
+     * an already-queued chapter is a no-op; we don't need to filter
+     * here, the scheduler dedupes.
+     */
+    suspend fun onFullPrerenderEnabled(fictionIds: Iterable<String>) {
+        for (fictionId in fictionIds) {
+            val chapters = chapterRepo.observeChapters(fictionId).first()
+                .sortedBy { it.index }
+            Log.i(
+                LOG_TAG,
+                "pcm-cache TRIGGER-FULL-PRERENDER fictionId=$fictionId " +
+                    "scheduling=${chapters.size}",
+            )
+            for (chapter in chapters) {
+                scheduler.scheduleRender(fictionId, chapter.id)
+            }
+        }
+    }
+
+    companion object {
+        private const val LOG_TAG = "PrerenderTriggers"
+
+        /** Per spec: library-add pre-renders the first three chapters in
+         *  reading order. Mode C expands to "all chapters". */
+        const val DEFAULT_PRERENDER_CHAPTERS = 3
+    }
+}

--- a/core-playback/src/main/kotlin/in/jphe/storyvox/playback/di/PlaybackModule.kt
+++ b/core-playback/src/main/kotlin/in/jphe/storyvox/playback/di/PlaybackModule.kt
@@ -10,6 +10,8 @@ import `in`.jphe.storyvox.playback.PlaybackController
 import `in`.jphe.storyvox.playback.SleepTimer
 import `in`.jphe.storyvox.playback.TtsVolumeRamp
 import `in`.jphe.storyvox.playback.VolumeRamp
+import `in`.jphe.storyvox.playback.cache.PcmRenderScheduler
+import `in`.jphe.storyvox.playback.cache.WorkManagerPcmRenderScheduler
 import javax.inject.Singleton
 
 @Module
@@ -23,6 +25,13 @@ abstract class PlaybackModule {
     @Binds
     @Singleton
     abstract fun bindVolumeRamp(impl: TtsVolumeRamp): VolumeRamp
+
+    /** PR-F (#86) — background PCM cache pre-render scheduler. */
+    @Binds
+    @Singleton
+    abstract fun bindPcmRenderScheduler(
+        impl: WorkManagerPcmRenderScheduler,
+    ): PcmRenderScheduler
 
     companion object {
         @Provides

--- a/core-playback/src/main/kotlin/in/jphe/storyvox/playback/tts/EnginePlayer.kt
+++ b/core-playback/src/main/kotlin/in/jphe/storyvox/playback/tts/EnginePlayer.kt
@@ -47,6 +47,7 @@ import `in`.jphe.storyvox.playback.cache.EngineMutex
 import `in`.jphe.storyvox.playback.cache.PcmAppender
 import `in`.jphe.storyvox.playback.cache.PcmCache
 import `in`.jphe.storyvox.playback.cache.PcmCacheKey
+import `in`.jphe.storyvox.playback.cache.PrerenderTriggers
 import `in`.jphe.storyvox.playback.tts.source.CacheFileSource
 import `in`.jphe.storyvox.playback.tts.source.EngineStreamingSource
 import `in`.jphe.storyvox.playback.tts.source.PcmSource
@@ -161,6 +162,13 @@ class EnginePlayer @AssistedInject constructor(
      *  concurrent with `loadAndPlay`'s `loadModel` — the issue #11
      *  SIGSEGV race. */
     private val engineMutexHolder: EngineMutex,
+    /** PR-F (#86) — chapter-natural-end trigger source. The streaming
+     *  pipeline's consumer thread calls [handleChapterDone] when the
+     *  end-of-stream pill arrives; that path forwards to
+     *  [PrerenderTriggers.onChapterCompleted] so the scheduler enqueues
+     *  the N+2 render (N+1 was scheduled when N started or is already
+     *  in flight). */
+    private val prerenderTriggers: PrerenderTriggers,
 ) : SimpleBasePlayer(Looper.getMainLooper()) {
 
     @AssistedFactory
@@ -2096,6 +2104,15 @@ class EnginePlayer @AssistedInject constructor(
         val fictionId = _observableState.value.currentFictionId
         persistPosition()
         if (chapterId != null) chapterRepo.markChapterPlayed(chapterId)
+        // PR-F (#86) — schedule chapter N+2's background render. N+1 is
+        // either already cached, in flight as the previous chapter-done
+        // trigger's enqueue, or about to be teed by PR-D as the user
+        // taps Next. Wrapped in runCatching so a scheduler hiccup
+        // doesn't block the natural-end flow (advanceChapter, history
+        // marker, ChapterDone event).
+        if (chapterId != null) {
+            runCatching { prerenderTriggers.onChapterCompleted(chapterId) }
+        }
         // Issue #158 — piggyback the History `completed` flag on the
         // existing end-of-chapter event. Mirrors `markChapterPlayed`
         // above; both fire on the same trigger (chapter naturally

--- a/core-playback/src/main/kotlin/in/jphe/storyvox/playback/tts/EnginePlayer.kt
+++ b/core-playback/src/main/kotlin/in/jphe/storyvox/playback/tts/EnginePlayer.kt
@@ -43,6 +43,7 @@ import `in`.jphe.storyvox.playback.SPEED_BASELINE_CHARS_PER_SECOND
 import `in`.jphe.storyvox.playback.SentenceRange
 import `in`.jphe.storyvox.playback.SleepTimer
 import `in`.jphe.storyvox.playback.TtsVolumeRamp
+import `in`.jphe.storyvox.playback.cache.EngineMutex
 import `in`.jphe.storyvox.playback.cache.PcmAppender
 import `in`.jphe.storyvox.playback.cache.PcmCache
 import `in`.jphe.storyvox.playback.cache.PcmCacheKey
@@ -153,6 +154,13 @@ class EnginePlayer @AssistedInject constructor(
      *  pipeline-construction time, so it owns key construction here.
      *  The cache itself is a `@Singleton` injected by Hilt. */
     private val pcmCache: PcmCache,
+    /** PR-F (#86) — process-wide engine mutex hoisted to a `@Singleton`
+     *  so the background [`in`.jphe.storyvox.playback.cache.ChapterRenderJob]
+     *  worker takes the SAME instance the foreground player uses.
+     *  Without sharing, a worker render could call `generateAudioPCM`
+     *  concurrent with `loadAndPlay`'s `loadModel` — the issue #11
+     *  SIGSEGV race. */
+    private val engineMutexHolder: EngineMutex,
 ) : SimpleBasePlayer(Looper.getMainLooper()) {
 
     @AssistedFactory
@@ -661,8 +669,15 @@ class EnginePlayer @AssistedInject constructor(
      *  fires at suspension points — a JNI call already in flight runs to
      *  completion. Without this mutex, the new pipeline's generator can call
      *  the engine *while the old one is still inside it*, corrupting the
-     *  internal state and producing garbled PCM. */
-    private val engineMutex = Mutex()
+     *  internal state and producing garbled PCM.
+     *
+     *  PR-F (#86) — was a private `Mutex()` here pre-PR-F; hoisted to a
+     *  Hilt `@Singleton` so the background [`in`.jphe.storyvox.playback.cache.ChapterRenderJob]
+     *  shares the same instance. Implementation is unchanged — the same
+     *  `kotlinx.coroutines.sync.Mutex`, same `withLock` callsites — just
+     *  read through the holder so production + background workers see
+     *  the same lock. */
+    private val engineMutex: Mutex get() = engineMutexHolder.mutex
 
     private val _observableState = MutableStateFlow(PlaybackState())
     val observableState: StateFlow<PlaybackState> = _observableState.asStateFlow()

--- a/core-playback/src/test/kotlin/in/jphe/storyvox/playback/cache/PrerenderTriggersTest.kt
+++ b/core-playback/src/test/kotlin/in/jphe/storyvox/playback/cache/PrerenderTriggersTest.kt
@@ -1,0 +1,253 @@
+package `in`.jphe.storyvox.playback.cache
+
+import `in`.jphe.storyvox.data.repository.CachedBodyUsage
+import `in`.jphe.storyvox.data.repository.ChapterRepository
+import `in`.jphe.storyvox.data.db.entity.ChapterDownloadState
+import `in`.jphe.storyvox.data.repository.playback.PlaybackChapter
+import `in`.jphe.storyvox.data.repository.playback.PlaybackModeConfig
+import `in`.jphe.storyvox.data.source.model.ChapterContent
+import `in`.jphe.storyvox.data.source.model.ChapterInfo
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.runBlocking
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+
+/**
+ * Unit tests for [PrerenderTriggers] schedule + cancel semantics. Uses
+ * fakes for [PcmRenderScheduler], [ChapterRepository], and
+ * [PlaybackModeConfig] so the tests run without WorkManager or any
+ * actual engine. RobolectricTestRunner is needed because the triggers
+ * call `android.util.Log.i` on the schedule paths (unmocked by default
+ * in pure-JVM JUnit tests) — Robolectric provides a real shadowed
+ * implementation. The other core-playback unit tests follow the same
+ * pattern (see VoiceManagerTest).
+ *
+ * PR F of the PCM cache series (#86).
+ */
+@RunWith(RobolectricTestRunner::class)
+@Config(sdk = [33])
+class PrerenderTriggersTest {
+
+    /** Recording fake — captures every scheduleRender / cancel call. */
+    private class RecordingScheduler : PcmRenderScheduler {
+        val scheduled = mutableListOf<Pair<String, String>>()
+        val cancelledChapters = mutableListOf<String>()
+        val cancelledFiction = mutableListOf<String>()
+
+        override fun scheduleRender(fictionId: String, chapterId: String) {
+            scheduled += fictionId to chapterId
+        }
+        override fun cancelRender(chapterId: String) {
+            cancelledChapters += chapterId
+        }
+        override fun cancelAllForFiction(fictionId: String) {
+            cancelledFiction += fictionId
+        }
+    }
+
+    private class FakeModeConfig(
+        full: Boolean = false,
+    ) : PlaybackModeConfig {
+        override val warmupWait = flowOf(false)
+        override val catchupPause = flowOf(true)
+        private val fullState = MutableStateFlow(full)
+        override val fullPrerender: Flow<Boolean> = fullState.asStateFlow()
+        override suspend fun currentWarmupWait() = false
+        override suspend fun currentCatchupPause() = true
+        override suspend fun currentFullPrerender() = fullState.value
+    }
+
+    /** Minimal ChapterRepo fake — implements just enough surface for
+     *  PrerenderTriggers to navigate the reading-order graph. */
+    private open class FakeChapterRepo(
+        private val byFiction: Map<String, List<ChapterInfo>>,
+    ) : ChapterRepository {
+        override fun observeChapters(fictionId: String): Flow<List<ChapterInfo>> =
+            flowOf(byFiction[fictionId].orEmpty())
+        override fun observeChapter(chapterId: String): Flow<ChapterContent?> =
+            flowOf(null)
+        override fun observeDownloadState(fictionId: String): Flow<Map<String, ChapterDownloadState>> =
+            flowOf(emptyMap())
+        override fun observePlayedChapterIds(fictionId: String): Flow<Set<String>> =
+            flowOf(emptySet())
+        override suspend fun queueChapterDownload(
+            fictionId: String, chapterId: String, requireUnmetered: Boolean,
+        ) = Unit
+        override suspend fun queueAllMissing(fictionId: String, requireUnmetered: Boolean) = Unit
+        override suspend fun markRead(chapterId: String, read: Boolean) = Unit
+        override suspend fun markChapterPlayed(chapterId: String) = Unit
+        override suspend fun trimDownloadedBodies(fictionId: String, keepLast: Int) = Unit
+        override suspend fun getChapter(id: String): PlaybackChapter? = null
+        override suspend fun getNextChapterId(currentChapterId: String): String? {
+            // Walk the flat reading order across all fictions — sufficient
+            // for the single-fiction test cases.
+            val all = byFiction.values.flatten()
+            val idx = all.indexOfFirst { it.id == currentChapterId }
+            return all.getOrNull(idx + 1)?.id
+        }
+        override suspend fun getPreviousChapterId(currentChapterId: String): String? {
+            val all = byFiction.values.flatten()
+            val idx = all.indexOfFirst { it.id == currentChapterId }
+            return all.getOrNull(idx - 1)?.id
+        }
+        override suspend fun cachedBodyUsage(): CachedBodyUsage =
+            CachedBodyUsage(count = 0, bytesEstimate = 0L)
+        override suspend fun setChapterBookmark(chapterId: String, charOffset: Int?) = Unit
+        override suspend fun chapterBookmark(chapterId: String): Int? = null
+    }
+
+    private fun chapter(num: Int, fictionPrefix: String) = ChapterInfo(
+        id = "$fictionPrefix-c$num",
+        sourceChapterId = "src-$num",
+        index = num,
+        title = "Chapter $num",
+    )
+
+    @Test
+    fun `onLibraryAdded enqueues first 3 chapters when fullPrerender off`() = runBlocking {
+        val scheduler = RecordingScheduler()
+        val repo = FakeChapterRepo(mapOf("f1" to (1..5).map { chapter(it, "f1") }))
+        val triggers = PrerenderTriggers(scheduler, repo, FakeModeConfig(full = false))
+
+        triggers.onLibraryAdded("f1")
+
+        assertEquals(3, scheduler.scheduled.size)
+        assertEquals(
+            listOf("f1-c1", "f1-c2", "f1-c3"),
+            scheduler.scheduled.map { it.second },
+        )
+        assertTrue(
+            "every scheduled render carries the source fictionId",
+            scheduler.scheduled.all { it.first == "f1" },
+        )
+    }
+
+    @Test
+    fun `onLibraryAdded enqueues all chapters when fullPrerender on`() = runBlocking {
+        val scheduler = RecordingScheduler()
+        val repo = FakeChapterRepo(mapOf("f1" to (1..5).map { chapter(it, "f1") }))
+        val triggers = PrerenderTriggers(scheduler, repo, FakeModeConfig(full = true))
+
+        triggers.onLibraryAdded("f1")
+
+        assertEquals(5, scheduler.scheduled.size)
+        assertEquals(
+            listOf("f1-c1", "f1-c2", "f1-c3", "f1-c4", "f1-c5"),
+            scheduler.scheduled.map { it.second },
+        )
+    }
+
+    @Test
+    fun `onLibraryAdded with fewer than DEFAULT chapters caps at chapters size`() = runBlocking {
+        val scheduler = RecordingScheduler()
+        // Fiction with only 2 chapters; default limit is 3 but we shouldn't
+        // try to schedule beyond what exists.
+        val repo = FakeChapterRepo(mapOf("f1" to (1..2).map { chapter(it, "f1") }))
+        val triggers = PrerenderTriggers(scheduler, repo, FakeModeConfig(full = false))
+
+        triggers.onLibraryAdded("f1")
+
+        assertEquals(2, scheduler.scheduled.size)
+    }
+
+    @Test
+    fun `onLibraryAdded with empty chapter list is a no-op`() = runBlocking {
+        val scheduler = RecordingScheduler()
+        val repo = FakeChapterRepo(emptyMap())
+        val triggers = PrerenderTriggers(scheduler, repo, FakeModeConfig(full = false))
+
+        triggers.onLibraryAdded("f1")
+
+        assertTrue("nothing scheduled for empty fiction", scheduler.scheduled.isEmpty())
+    }
+
+    @Test
+    fun `onLibraryRemoved cancels every render for that fiction`() {
+        val scheduler = RecordingScheduler()
+        val triggers = PrerenderTriggers(
+            scheduler,
+            FakeChapterRepo(emptyMap()),
+            FakeModeConfig(),
+        )
+
+        triggers.onLibraryRemoved("f1")
+
+        assertEquals(listOf("f1"), scheduler.cancelledFiction)
+    }
+
+    @Test
+    fun `onChapterCompleted schedules N+2`() = runBlocking {
+        val scheduler = RecordingScheduler()
+        // Stub getChapter so the next-next lookup returns a real
+        // PlaybackChapter with the right fictionId.
+        val repo = object : FakeChapterRepo(
+            mapOf("f1" to (1..5).map { chapter(it, "f1") }),
+        ) {
+            override suspend fun getChapter(id: String): PlaybackChapter? =
+                if (id == "f1-c3") PlaybackChapter(
+                    id = "f1-c3",
+                    fictionId = "f1",
+                    text = "body",
+                    title = "Chapter 3",
+                    bookTitle = "F1",
+                    coverUrl = null,
+                ) else null
+        }
+        val triggers = PrerenderTriggers(scheduler, repo, FakeModeConfig())
+
+        // Just-completed = c1 → next = c2 → next-next = c3 → schedule c3.
+        triggers.onChapterCompleted("f1-c1")
+
+        assertEquals(1, scheduler.scheduled.size)
+        assertEquals("f1" to "f1-c3", scheduler.scheduled.first())
+    }
+
+    @Test
+    fun `onChapterCompleted at penultimate chapter is a no-op`() = runBlocking {
+        val scheduler = RecordingScheduler()
+        // f1 has 3 chapters; completing c2 → next is c3 → next-next is null.
+        val repo = FakeChapterRepo(mapOf("f1" to (1..3).map { chapter(it, "f1") }))
+        val triggers = PrerenderTriggers(scheduler, repo, FakeModeConfig())
+
+        triggers.onChapterCompleted("f1-c2")
+
+        assertTrue("no N+2 to schedule at end of fiction", scheduler.scheduled.isEmpty())
+    }
+
+    @Test
+    fun `onChapterCompleted at last chapter is a no-op`() = runBlocking {
+        val scheduler = RecordingScheduler()
+        val repo = FakeChapterRepo(mapOf("f1" to (1..3).map { chapter(it, "f1") }))
+        val triggers = PrerenderTriggers(scheduler, repo, FakeModeConfig())
+
+        triggers.onChapterCompleted("f1-c3")
+
+        assertTrue("no next at end of fiction", scheduler.scheduled.isEmpty())
+    }
+
+    @Test
+    fun `onFullPrerenderEnabled enqueues every chapter of every fiction`() = runBlocking {
+        val scheduler = RecordingScheduler()
+        val repo = FakeChapterRepo(
+            mapOf(
+                "f1" to (1..3).map { chapter(it, "f1") },
+                "f2" to (1..4).map { chapter(it, "f2") },
+            ),
+        )
+        val triggers = PrerenderTriggers(scheduler, repo, FakeModeConfig())
+
+        triggers.onFullPrerenderEnabled(listOf("f1", "f2"))
+
+        // 3 + 4 = 7 renders across both fictions.
+        assertEquals(7, scheduler.scheduled.size)
+        val fictions = scheduler.scheduled.map { it.first }.toSet()
+        assertEquals(setOf("f1", "f2"), fictions)
+    }
+}

--- a/feature/src/main/kotlin/in/jphe/storyvox/feature/api/UiContracts.kt
+++ b/feature/src/main/kotlin/in/jphe/storyvox/feature/api/UiContracts.kt
@@ -788,6 +788,19 @@ data class UiSettings(
      *  separate UX call. */
     val catchupPause: Boolean = true,
     /**
+     * Issue #98 / PCM cache PR-F (#86). Mode C — Full Pre-render. When
+     * true, the background pre-render scheduler treats every chapter
+     * of a library fiction as a candidate; when false (default), it
+     * only renders chapters 1-3 on library-add and chapter N+2 on
+     * natural-end. Off by default because a 40-chapter fiction at
+     * Piper-high (~70 MB/chapter) blows past the 2 GB quota and
+     * thrashes the LRU.
+     *
+     * PR-F adds the persistence + plumbing; PR-G adds the Settings
+     * toggle. Field is invisible to users until PR-G ships.
+     */
+    val fullPrerender: Boolean = false,
+    /**
      * Issue #85 — Voice-Determinism preset for the VoxSherpa engine. When
      * true (default), the engine runs with VoxSherpa's calmed VITS defaults
      * (`noise_scale = 0.35`, `noise_scale_w = 0.667`); identical text
@@ -1350,6 +1363,8 @@ interface SettingsRepositoryUi {
     suspend fun setWarmupWait(enabled: Boolean)
     /** Issue #98 — Mode B toggle. See [UiSettings.catchupPause]. */
     suspend fun setCatchupPause(enabled: Boolean)
+    /** Issue #98 / PR-F (#86) — Mode C toggle. See [UiSettings.fullPrerender]. */
+    suspend fun setFullPrerender(enabled: Boolean)
     /** Issue #85 — Voice-Determinism preset. See [UiSettings.voiceSteady]. */
     suspend fun setVoiceSteady(enabled: Boolean)
     suspend fun signIn()

--- a/feature/src/test/kotlin/in/jphe/storyvox/feature/chat/ChatViewModelTest.kt
+++ b/feature/src/test/kotlin/in/jphe/storyvox/feature/chat/ChatViewModelTest.kt
@@ -730,6 +730,7 @@ private class FakeSettingsRepo(
     override suspend fun setPlaybackBufferChunks(chunks: Int) = Unit
     override suspend fun setWarmupWait(enabled: Boolean) = Unit
     override suspend fun setCatchupPause(enabled: Boolean) = Unit
+    override suspend fun setFullPrerender(enabled: Boolean) = Unit
     override suspend fun setVoiceSteady(enabled: Boolean) = Unit
     override suspend fun signIn() = Unit
     override suspend fun signOut() = Unit

--- a/feature/src/test/kotlin/in/jphe/storyvox/feature/chat/tools/ChatToolHandlersTest.kt
+++ b/feature/src/test/kotlin/in/jphe/storyvox/feature/chat/tools/ChatToolHandlersTest.kt
@@ -308,6 +308,7 @@ private class FakeSettings : SettingsRepositoryUi {
     override suspend fun setPlaybackBufferChunks(chunks: Int) = Unit
     override suspend fun setWarmupWait(enabled: Boolean) = Unit
     override suspend fun setCatchupPause(enabled: Boolean) = Unit
+    override suspend fun setFullPrerender(enabled: Boolean) = Unit
     override suspend fun setVoiceSteady(enabled: Boolean) = Unit
     override suspend fun signIn() = Unit
     override suspend fun signOut() = Unit

--- a/feature/src/test/kotlin/in/jphe/storyvox/feature/settings/SettingsViewModelBufferTest.kt
+++ b/feature/src/test/kotlin/in/jphe/storyvox/feature/settings/SettingsViewModelBufferTest.kt
@@ -140,6 +140,9 @@ class SettingsViewModelBufferTest {
         override suspend fun setCatchupPause(enabled: Boolean) {
             state.value = state.value.copy(catchupPause = enabled)
         }
+        override suspend fun setFullPrerender(enabled: Boolean) {
+            state.value = state.value.copy(fullPrerender = enabled)
+        }
         override suspend fun setVoiceSteady(enabled: Boolean) {
             state.value = state.value.copy(voiceSteady = enabled)
         }

--- a/feature/src/test/kotlin/in/jphe/storyvox/feature/settings/SettingsViewModelModesTest.kt
+++ b/feature/src/test/kotlin/in/jphe/storyvox/feature/settings/SettingsViewModelModesTest.kt
@@ -214,6 +214,9 @@ class SettingsViewModelModesTest {
             catchupPauseWrites += enabled
             state.value = state.value.copy(catchupPause = enabled)
         }
+        override suspend fun setFullPrerender(enabled: Boolean) {
+            state.value = state.value.copy(fullPrerender = enabled)
+        }
         override suspend fun setVoiceSteady(enabled: Boolean) {
             voiceSteadyWrites += enabled
             state.value = state.value.copy(voiceSteady = enabled)

--- a/feature/src/test/kotlin/in/jphe/storyvox/feature/settings/SettingsViewModelPunctuationPauseTest.kt
+++ b/feature/src/test/kotlin/in/jphe/storyvox/feature/settings/SettingsViewModelPunctuationPauseTest.kt
@@ -153,6 +153,9 @@ class SettingsViewModelPunctuationPauseTest {
         override suspend fun setCatchupPause(enabled: Boolean) {
             state.value = state.value.copy(catchupPause = enabled)
         }
+        override suspend fun setFullPrerender(enabled: Boolean) {
+            state.value = state.value.copy(fullPrerender = enabled)
+        }
         override suspend fun setVoiceSteady(enabled: Boolean) {
             state.value = state.value.copy(voiceSteady = enabled)
         }


### PR DESCRIPTION
Replaces the auto-closed #499 (its base branch \`feat/pcm-cache-pr-e\` was deleted on merge of PR E #498). Rebased clean onto main — PR E's three duplicate commits were dropped automatically by \`git rebase\` since they're already upstream.

## Summary

PR F of the PCM cache series (#86). While the user listens to chapter N, render N+1 (and optionally N+2) to cache in the background via WorkManager. By the time they tap "next", playback starts from cache.

## What ships

- **`PcmRenderScheduler` interface + WorkManager impl** — KEEP policy, battery/storage constraints, fiction tag for cancellation
- **`ChapterRenderJob` `@HiltWorker`** — `setForeground` with `DATA_SYNC`, holds `EngineMutex` per-sentence, handles Piper/Kokoro/Kitten engines, skips Azure (BYOK + per-character billing)
- **`PrerenderTriggers` + `FictionLibraryListener` seam** — \`:core-data\` → \`:app\` binding → \`:core-playback\`; \`EnginePlayer.handleChapterDone\` hook + \`PrerenderModeWatcher\` in \`:app\` for the Mode-C full-fiction pre-render switch
- **`PlaybackModeConfig.fullPrerender` flow + UiSettings field** — DataStore, no UI yet (lands as PR G)
- **`EngineMutex` `@Singleton` hoist** — #11 race protection; foreground playback and background render serialize on the same mutex so the engine never sees concurrent calls
- **R8 keep rule for `ChapterRenderJob`** in \`core-playback/consumer-rules.pro\` — Hilt's WorkerFactory looks up by FQN reflectively; without this R8 strips the class on minified builds
- **`AndroidManifest.xml`**: gains \`FOREGROUND_SERVICE_DATA_SYNC\` permission (API 34+)
- **9-case \`PrerenderTriggersTest\`** via RobolectricTestRunner (\`android.util.Log\` shadow required)

## Logcat events (tag \`pcm-cache\`)

- Scheduler/worker: \`PRERENDER-{ENQUEUED,RUNNING,SUCCESS,CANCEL,CANCEL-FICTION,SKIP-COMPLETE,SKIP-NOTEXT,SKIP-AUDIOURL,SKIP-EMPTYTEXT,SKIP-NOVOICE,SKIP-AZURE,CANCELLED,FAIL}\`
- Triggers: \`TRIGGER-{LIBRARY-ADD,LIBRARY-REMOVE,CHAPTER-DONE,FULL-PRERENDER}\`
- Mode watcher: \`MODE-C-ENABLED\`

## Deferred

- PR G: Settings UI for Mode C + quota selector
- PR H: status icons
- Cooperative cancel between worker + foreground (currently per-sentence \`engineMutex\` serialization)
- Worker speed/pitch parity with user default (renders at 1.0×/1.0× empty-dict)
- \`ChapterRenderJobTest\` (Hilt + @HiltWorker + Robolectric non-trivial)

## CI

\`:app:assembleDebug :app:testDebugUnitTest :feature:testDebugUnitTest :core-playback:testDebugUnitTest\` all green locally. Katana CI likely OOMs (carrying forward); orchestrator will fall back to local-build + release upload as on v0.5.46 and v0.5.48.

🤖 Generated with [Claude Code](https://claude.com/claude-code)