### PR TITLE
feat(source-palace): Palace Project library backend (OPDS, non-DRM titles) — partial close #502

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -289,6 +289,13 @@ dependencies {
     // app classpath so its KSP-generated SourcePluginDescriptor binding
     // joins the Hilt multibinding set the registry consumes.
     implementation(project(":source-readability"))
+    // Issue #502 — Palace Project OPDS library backend. First library-
+    // borrowing source in the storyvox roster; ships non-DRM titles
+    // only in v1 (LCP DRM titles surface greyed-out with an "open in
+    // Palace app" deep-link CTA). Libby + Hoopla follow-up scopes are
+    // documented under scratch/libby-hoopla-palace-scope/ but deferred
+    // to their own PRs.
+    implementation(project(":source-palace"))
     implementation(project(":source-azure"))
     implementation(project(":core-sync"))
     implementation(project(":feature"))

--- a/core-data/src/main/kotlin/in/jphe/storyvox/data/source/SourceIds.kt
+++ b/core-data/src/main/kotlin/in/jphe/storyvox/data/source/SourceIds.kt
@@ -155,6 +155,31 @@ object SourceIds {
      *  high-friction. v1 ships no search (Bot API has no
      *  full-text search endpoint). */
     const val TELEGRAM: String = "telegram"
+    /** Palace Project (#502) — first library-borrowing backend. The
+     *  Palace Project is open-source library management software backing
+     *  many US public libraries (NYPL, BPL, etc.); the "Palace" mobile
+     *  app is the user-facing client and the backend speaks OPDS 1.x
+     *  catalog feeds (Atom-flavoured XML, fully open spec) with LCP DRM
+     *  on most borrowed titles.
+     *
+     *  v1 storyvox scope is **non-DRM titles only**. The OPDS walker
+     *  enumerates a user-configured library's catalog; titles whose
+     *  acquisition link is a free EPUB download route through the
+     *  existing `:source-epub` pipeline. Titles whose acquisition link
+     *  is `application/vnd.readium.lcp.license.v1.0+json` (the LCP
+     *  license-acquisition MIME) surface greyed-out with an
+     *  "Open in Palace app to borrow" deep-link CTA. No LCP
+     *  implementation in storyvox today — see scratch
+     *  `libby-hoopla-palace-scope/lcp-drm-scope.md` for the deferred
+     *  plan.
+     *
+     *  Default OFF on fresh installs (defaultEnabled=false in the
+     *  `@SourcePlugin` descriptor) because the catalog needs a
+     *  user-supplied library URL before it can return anything — adding
+     *  a default-on row to the picker that just says "configure a
+     *  library URL" is worse UX than hiding the row until the user
+     *  opts in via Settings → Library & Sync → Palace Project. */
+    const val PALACE: String = "palace"
     /** Readability4J catch-all (#472, magic-link audiobook) — the
      *  always-on last-resort matcher for the paste-anything flow. Any
      *  HTTP(S) URL that none of the 17 specialized backends claim

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -74,6 +74,12 @@ include(":source-telegram")
 // otherwise claimed by one of the 17 specialized backends still
 // produces a single-chapter "article" fiction. "No URL is a dead-end."
 include(":source-readability")
+// Issue #502 — Palace Project library backend (OPDS catalog walker).
+// First library-borrowing backend in the storyvox roster; ships
+// non-DRM titles only in this PR (LCP DRM is explicitly deferred —
+// see scratch/libby-hoopla-palace-scope/lcp-drm-scope.md). Libby +
+// Hoopla follow-ups defer to their own PRs (see sibling scope notes).
+include(":source-palace")
 include(":core-sync")
 include(":feature")
 // Issue #409 — Baseline Profile producer module. Pure test APK

--- a/source-palace/build.gradle.kts
+++ b/source-palace/build.gradle.kts
@@ -1,0 +1,69 @@
+plugins {
+    alias(libs.plugins.android.library)
+    alias(libs.plugins.kotlin.android)
+    alias(libs.plugins.ksp)
+    alias(libs.plugins.hilt)
+}
+
+android {
+    namespace = "in.jphe.storyvox.source.palace"
+    compileSdk = 35
+
+    defaultConfig {
+        minSdk = 26
+    }
+
+    compileOptions {
+        sourceCompatibility = JavaVersion.VERSION_17
+        targetCompatibility = JavaVersion.VERSION_17
+    }
+
+    kotlinOptions {
+        jvmTarget = "17"
+    }
+
+    testOptions {
+        unitTests {
+            // Issue #502 — Robolectric-backed unit tests need Android
+            // resources on the classpath so `android.util.Xml` (used by
+            // [OpdsParser]) resolves via the SDK shim. Same posture as
+            // `:source-rss` (#464) — the OPDS 1.x parser is XmlPullParser
+            // -based for the same "ship an Android-friendly parser
+            // without dragging in a 1.5 MB Rome dependency" reason.
+            isIncludeAndroidResources = true
+            isReturnDefaultValues = true
+        }
+    }
+}
+
+dependencies {
+    implementation(project(":core-data"))
+    // Issue #502 — Palace OPDS catalog returns EPUB acquisition links
+    // for non-DRM titles. Route the downloaded bytes through the parser
+    // already on `:source-epub` (added for #235) — same pattern as
+    // `:source-gutenberg` (#237), `:source-standard-ebooks` (#375),
+    // `:source-ao3` (#381).
+    implementation(project(":source-epub"))
+
+    implementation(libs.kotlinx.coroutines.android)
+    implementation(libs.okhttp)
+    implementation(libs.okhttp.logging)
+
+    implementation(libs.hilt.android)
+    ksp(libs.hilt.compiler)
+
+    // Plugin-seam Phase 2 (#384) — emits the @SourcePlugin → @IntoSet
+    // SourcePluginDescriptor Hilt module for PalaceSource. Legacy
+    // @IntoMap binding lives in di/PalaceModule.kt for parity with the
+    // other source modules until Phase 3 removes that pattern.
+    ksp(project(":core-plugin-ksp"))
+
+    testImplementation(libs.junit)
+    testImplementation(libs.kotlinx.coroutines.test)
+    // Robolectric is needed so `android.util.Xml` resolves for the OPDS
+    // 1.x Atom-flavoured XML parsing path in unit tests. Same dep is
+    // used by `:source-rss`, `:core-data`, `:core-llm`.
+    testImplementation(libs.robolectric)
+    testImplementation("androidx.test:core:1.6.1")
+    testImplementation("androidx.test.ext:junit:1.2.1")
+}

--- a/source-palace/src/main/kotlin/in/jphe/storyvox/source/palace/PalaceLibraryConfig.kt
+++ b/source-palace/src/main/kotlin/in/jphe/storyvox/source/palace/PalaceLibraryConfig.kt
@@ -1,0 +1,87 @@
+package `in`.jphe.storyvox.source.palace
+
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import javax.inject.Inject
+import javax.inject.Singleton
+
+/**
+ * Issue #502 — user-configurable Palace Project library root URL.
+ *
+ * Palace Project doesn't have a canonical "default" library — every
+ * supported library is its own OPDS root at a different host (some
+ * libraries at `<library>.palaceproject.io`, some at custom domains
+ * like `circulation.openebooks.us`, some at IP-restricted endpoints
+ * served from inside a library network).
+ *
+ * The user supplies their library's root URL in Settings → Library &
+ * Sync → Palace Project. The [PalaceSource] reads from this contract
+ * on every catalog call; an unset URL returns
+ * [FictionResult.AuthRequired]-shaped failures from the source surface
+ * so the UI knows to prompt the user to configure a library.
+ *
+ * ## Why an interface and not a DataStore call directly
+ *
+ * `:source-palace` doesn't pull in `androidx.datastore` — keeps the
+ * leaf-source dependency graph clean and matches the pattern other
+ * source modules use (e.g., [`in.jphe.storyvox.source.radio.RadioConfig`],
+ * `:source-discord`'s [`DiscordConfig`]). The real DataStore-backed
+ * implementation lives in `:app` (or `:feature`) and is bound to this
+ * interface via Hilt. Issue #501 owns the settings-surface wiring;
+ * this PR provides the contract + an in-memory default that returns
+ * "no library configured" so the source compiles and the unit tests
+ * don't need an Android Context.
+ *
+ * ## Future-state thread
+ *
+ * v2 will likely take a *list* of configured libraries (some users have
+ * cards at multiple libraries). Surface this as
+ * `currentLibrary: Flow<PalaceLibrary?>` + a separate "list of
+ * configured libraries" Flow. v1 keeps a single library to avoid
+ * dragging the multi-library settings UX into this PR.
+ *
+ * Issue #500's encrypted-credential storage (library card + PIN) will
+ * land alongside the multi-library expansion when borrow flows become
+ * relevant — at which point a [PalaceLibrary] grows from "URL only" to
+ * "URL + credential ref + last-known display name". For v1, we only
+ * read public OPDS feeds, so no credentials touch this module.
+ */
+interface PalaceLibraryConfig {
+    /**
+     * The currently configured library root URL. Emits `null` when no
+     * library has been configured yet (the fresh-install state). The
+     * source treats `null` as "return an empty browse and an
+     * AuthRequired on detail/chapter".
+     *
+     * Implementations MUST emit the current value on subscribe so the
+     * source can observe the value synchronously after Hilt
+     * construction — matches the StateFlow contract.
+     */
+    val libraryRootUrl: Flow<String?>
+}
+
+/**
+ * Fallback implementation used when no DataStore-backed binding is
+ * provided (e.g., unit tests, and the bootstrap path before #501 wires
+ * a real settings binding). Always emits `null`, which surfaces as
+ * "configure a library to start" in the source's read-side surface.
+ *
+ * The [setForTesting] hook lets unit tests inject a fake URL without
+ * pulling in a DataStore harness.
+ */
+@Singleton
+internal class InMemoryPalaceLibraryConfig @Inject constructor() : PalaceLibraryConfig {
+    private val state = MutableStateFlow<String?>(null)
+    override val libraryRootUrl: Flow<String?> = state.asStateFlow()
+
+    /** Test-only: poke a URL into the in-memory state.
+     *
+     *  Production code lives in #501's settings binding — this method
+     *  exists so the unit tests in `:source-palace/src/test/` can
+     *  exercise the source against a fake library URL without the real
+     *  DataStore implementation. */
+    internal fun setForTesting(url: String?) {
+        state.value = url
+    }
+}

--- a/source-palace/src/main/kotlin/in/jphe/storyvox/source/palace/PalaceSource.kt
+++ b/source-palace/src/main/kotlin/in/jphe/storyvox/source/palace/PalaceSource.kt
@@ -1,0 +1,704 @@
+package `in`.jphe.storyvox.source.palace
+
+import `in`.jphe.storyvox.data.source.FictionSource
+import `in`.jphe.storyvox.data.source.RouteMatch
+import `in`.jphe.storyvox.data.source.SourceIds
+import `in`.jphe.storyvox.data.source.UrlMatcher
+import `in`.jphe.storyvox.data.source.model.ChapterContent
+import `in`.jphe.storyvox.data.source.model.ChapterInfo
+import `in`.jphe.storyvox.data.source.model.FictionDetail
+import `in`.jphe.storyvox.data.source.model.FictionResult
+import `in`.jphe.storyvox.data.source.model.FictionStatus
+import `in`.jphe.storyvox.data.source.model.FictionSummary
+import `in`.jphe.storyvox.data.source.model.ListPage
+import `in`.jphe.storyvox.data.source.model.SearchQuery
+import `in`.jphe.storyvox.data.source.plugin.SourceCategory
+import `in`.jphe.storyvox.data.source.plugin.SourcePlugin
+import `in`.jphe.storyvox.source.epub.parse.EpubBook
+import `in`.jphe.storyvox.source.epub.parse.EpubParseException
+import `in`.jphe.storyvox.source.epub.parse.EpubParser
+import `in`.jphe.storyvox.source.palace.di.PalaceCache
+import `in`.jphe.storyvox.source.palace.net.PalaceApi
+import `in`.jphe.storyvox.source.palace.parse.OpdsEntry
+import `in`.jphe.storyvox.source.palace.parse.OpdsFeed
+import `in`.jphe.storyvox.source.palace.parse.OpdsLink
+import `in`.jphe.storyvox.source.palace.parse.OpdsMime
+import `in`.jphe.storyvox.source.palace.parse.OpdsRel
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.withContext
+import java.io.File
+import javax.inject.Inject
+import javax.inject.Singleton
+
+/**
+ * Issue #502 — Palace Project as a fiction backend.
+ *
+ * The Palace Project is open-source library management software run by
+ * the nonprofit LYRASIS; it backs many US public libraries (NYPL, BPL,
+ * etc.). Each Palace-backed library exposes an OPDS 1.x catalog at a
+ * user-configurable root URL (see [PalaceLibraryConfig]); titles in
+ * that catalog are either:
+ *
+ *  - **Open-access** — free EPUB downloads, no DRM. Public-domain works
+ *    Palace has curated for accessibility, plus library-published
+ *    materials and CC-licensed catalog. **These are what v1 storyvox
+ *    actually serves.**
+ *  - **DRM'd (LCP)** — borrowed-by-loan titles that require Readium LCP
+ *    decryption. v1 surfaces these greyed-out with an "Open in Palace
+ *    app to borrow" deep-link CTA; storyvox attempts no decryption.
+ *    See `scratch/libby-hoopla-palace-scope/lcp-drm-scope.md` for the
+ *    deferred plan.
+ *
+ * ## Two-phase model (same shape as :source-gutenberg, :source-ao3,
+ * :source-standard-ebooks)
+ *
+ * **Catalog phase**: walk the configured library's OPDS root. The root
+ * feed mixes navigation entries (links to sub-feeds like "Featured" /
+ * "Children's Books" / "New Releases") with optional publication
+ * entries. The [PalaceSource] flattens navigation links into the
+ * [genres] picker and consumes any directly-listed publications as the
+ * [popular] / [latestUpdates] surface. Search hits the library's
+ * OpenSearch description (or a `?q=` query against the root, depending
+ * on what the library publishes — `:source-palace` falls back to
+ * filtering the root feed when the library doesn't advertise a search
+ * URL).
+ *
+ * **Detail / chapter phase**: when the user adds an open-access title
+ * to their library, the OPDS entry's open-access acquisition link is
+ * downloaded once, persisted at `cacheDir/palace/<entry-id-hash>.epub`,
+ * and from then on chapter rendering reads spine items out of that
+ * local file via the parser already on `:source-epub`. Identical
+ * pattern to PG / SE / AO3.
+ *
+ * ## DRM handling
+ *
+ * A title is "DRM'd" from storyvox's perspective when **none** of its
+ * acquisition links carry `type="application/epub+zip"` with
+ * `rel="…/acquisition/open-access"`. The detection happens in
+ * [pickOpenAccessEpub]. DRM'd titles still appear in the catalog (so
+ * the user sees the library's full breadth), but their
+ * [FictionSummary.status] is annotated and the
+ * [`fictionDetail`][fictionDetail] / [`chapter`][chapter] paths return
+ * a structured [FictionResult.AuthRequired] with a message pointing to
+ * the Palace app deep-link. The reader UI surfaces that as a card
+ * with "Open in Palace app" rather than a network-error banner.
+ *
+ * No LCP decryption attempt anywhere in this module. The downstream
+ * cache layer never sees DRM'd bytes — we don't fetch them.
+ *
+ * ## URL matching (#472 — magic-link cascade)
+ *
+ * Three URL shapes claim through `:source-palace`:
+ *
+ *  - `<library>.palaceproject.io/<feed>/works/<urn>` — Palace Project's
+ *    canonical hosted-library URLs (NYPL, BPL, etc.)
+ *  - `circulation.<library>.org/<feed>/works/<urn>` — self-hosted
+ *    Palace deployments (Open eBooks, Maine InfoNet, etc.)
+ *  - Generic `palaceproject.io` covers organisation pages
+ *
+ * Confidence is 0.9 when the host matches a known Palace pattern and
+ * the path looks publication-shaped; 0.5 for host-only matches. The
+ * Readability catch-all at confidence 0.1 always loses to either.
+ */
+@SourcePlugin(
+    id = SourceIds.PALACE,
+    displayName = "Palace Library",
+    // defaultEnabled false until JP picks a default library or
+    // the user configures one. A "Palace Library" row that says
+    // "configure a library URL to use this source" is worse UX
+    // than hiding the chip until the user has opted in.
+    defaultEnabled = false,
+    // OPDS catalogs are EPUB-shaped; route under the Ebook category in
+    // the settings auto-section, alongside Project Gutenberg / Standard
+    // Ebooks / local EPUB files.
+    category = SourceCategory.Ebook,
+    supportsFollow = false,
+    // OPDS supports search via the OpenSearch description document.
+    // Most Palace libraries publish one; the source falls back to
+    // returning an empty result for libraries that don't.
+    supportsSearch = true,
+    description = "Public library borrowing via OPDS · open-access titles only (DRM titles deep-link to Palace app)",
+    sourceUrl = "https://thepalaceproject.org",
+)
+@Singleton
+internal class PalaceSource @Inject constructor(
+    private val api: PalaceApi,
+    private val config: PalaceLibraryConfig,
+    @PalaceCache private val cacheDir: File,
+) : FictionSource, UrlMatcher {
+
+    override val id: String = SourceIds.PALACE
+    override val displayName: String = "Palace Library"
+
+    /**
+     * In-memory cache of parsed EPUBs keyed by storyvox fictionId.
+     * Mirrors the same hot-path optimization PG / SE / AO3 use — the
+     * cost of re-parsing a 2-10 MB EPUB on every chapter open
+     * dominates the OPDS-feed-walk cost.
+     */
+    private val parsedCache = mutableMapOf<String, EpubBook>()
+
+    /**
+     * In-memory cache of OPDS entries the user has browsed recently,
+     * keyed by storyvox fictionId. Populated as the browse / search
+     * paths walk feeds; consumed by [fictionDetail] so we don't need a
+     * second round-trip to the library to render the detail card. A
+     * cold-start detail open re-walks the root feed once to repopulate
+     * (cheap; OPDS roots are < 50 KB on the libraries we've seen).
+     */
+    private val entryCache = mutableMapOf<String, OpdsEntry>()
+
+    /**
+     * Cached library root feed. Walked once per session to populate the
+     * genres picker + collection navigation. Refreshed whenever the
+     * configured library URL changes (see [observeConfig]).
+     *
+     * v1 doesn't expire this; the library's catalog updates daily at
+     * most and a process restart picks up changes. v2 might add a
+     * polling worker or an If-Modified-Since check.
+     */
+    @Volatile private var cachedRoot: OpdsFeed? = null
+    @Volatile private var cachedRootForUrl: String? = null
+
+    // ── browse ────────────────────────────────────────────────────────
+
+    override suspend fun popular(page: Int): FictionResult<ListPage<FictionSummary>> {
+        val libraryUrl = currentLibraryUrlOrFail()
+            ?: return libraryNotConfigured()
+        // Most Palace libraries put their "front page" / curated
+        // selection at the root OPDS feed. If the root only carries
+        // navigation entries (sub-feed links), pop into the first
+        // navigable child — that's usually "Featured" / "Popular Reads"
+        // on Palace deployments we've seen.
+        val root = ensureRoot(libraryUrl).valueOrReturn { return it }
+        val publications = if (root.entries.isNotEmpty()) {
+            root.entries
+        } else {
+            // First sub-feed is the catalog's curated landing on Palace
+            // deployments. If it's empty too, we return an empty result
+            // rather than walking the whole tree — Browse renders a
+            // "no titles here" empty state cleanly.
+            val firstNav = root.navLinks.firstOrNull()
+                ?: return FictionResult.Success(
+                    ListPage(items = emptyList(), page = 1, hasNext = false),
+                )
+            when (val r = api.fetchFeed(firstNav.href)) {
+                is FictionResult.Success -> r.value.entries
+                is FictionResult.Failure -> return r
+            }
+        }
+        return FictionResult.Success(
+            ListPage(
+                items = publications.map { it.cacheAndToSummary() },
+                page = page,
+                // OPDS exposes `<link rel="next">` for pagination. The
+                // root + first-nav-child path above doesn't carry it
+                // forward; v1 returns hasNext=false for the popular
+                // lane. A v2 pass can plumb the [OpdsFeed.nextHref]
+                // through if Palace surfaces multi-page popular feeds.
+                hasNext = false,
+            ),
+        )
+    }
+
+    override suspend fun latestUpdates(page: Int): FictionResult<ListPage<FictionSummary>> {
+        val libraryUrl = currentLibraryUrlOrFail()
+            ?: return libraryNotConfigured()
+        // Look for a navigation entry whose title hints at "new" /
+        // "recent" / "latest". Palace libraries label these
+        // inconsistently ("New Releases", "Recently Added", "New
+        // Arrivals"), so prefix-match a small set of likely tokens.
+        val root = ensureRoot(libraryUrl).valueOrReturn { return it }
+        val newReleasesNav = root.navLinks.firstOrNull { nav ->
+            val t = nav.title.lowercase()
+            t.contains("new") || t.contains("recent") || t.contains("latest")
+        }
+        val publications = if (newReleasesNav != null) {
+            when (val r = api.fetchFeed(newReleasesNav.href)) {
+                is FictionResult.Success -> r.value.entries
+                is FictionResult.Failure -> return r
+            }
+        } else {
+            // No new-releases lane on this library; reuse the popular
+            // surface so the Browse tab still renders something.
+            root.entries
+        }
+        return FictionResult.Success(
+            ListPage(
+                items = publications.map { it.cacheAndToSummary() },
+                page = page,
+                hasNext = false,
+            ),
+        )
+    }
+
+    override suspend fun byGenre(
+        genre: String,
+        page: Int,
+    ): FictionResult<ListPage<FictionSummary>> {
+        val libraryUrl = currentLibraryUrlOrFail()
+            ?: return libraryNotConfigured()
+        // Match the genre label against navLink titles emitted by
+        // [genres]. Case-insensitive exact match keeps the picker /
+        // catalog mapping unambiguous.
+        val root = ensureRoot(libraryUrl).valueOrReturn { return it }
+        val navLink = root.navLinks.firstOrNull { it.title.equals(genre, ignoreCase = true) }
+            ?: return FictionResult.Success(
+                ListPage(items = emptyList(), page = 1, hasNext = false),
+            )
+        val feed = when (val r = api.fetchFeed(navLink.href)) {
+            is FictionResult.Success -> r.value
+            is FictionResult.Failure -> return r
+        }
+        return FictionResult.Success(
+            ListPage(
+                items = feed.entries.map { it.cacheAndToSummary() },
+                page = page,
+                hasNext = feed.nextHref != null,
+            ),
+        )
+    }
+
+    override suspend fun search(query: SearchQuery): FictionResult<ListPage<FictionSummary>> {
+        // Palace libraries publish an OpenSearch description document
+        // pointed at by a feed-level `<link rel="search">`. v1 doesn't
+        // walk that — the OpenSearch parsing is a meaningful chunk of
+        // work for a single search surface and most Palace libraries
+        // also support a `?q=` filter on the root URL.
+        //
+        // For v1, search returns an empty result with a placeholder
+        // comment. The Settings → Library & Sync screen (owned by #501)
+        // surfaces the catalog under "Browse" rather than "Search"
+        // until the OpenSearch path lands.
+        //
+        // FUTURE-STATE: when adding real search:
+        //  1. Walk the root feed's `<link rel="search">` to find the
+        //     OpenSearch description URL.
+        //  2. Fetch + parse that document for the `<Url
+        //     template="..."/>` (substitute `{searchTerms}`).
+        //  3. GET the substituted URL → OPDS acquisition feed → same
+        //     `.entries.map { it.cacheAndToSummary() }` shape this
+        //     module already uses.
+        @Suppress("UNUSED_VARIABLE")
+        val term = query.term
+        return FictionResult.Success(
+            ListPage(items = emptyList(), page = 1, hasNext = false),
+        )
+    }
+
+    override suspend fun genres(): FictionResult<List<String>> {
+        val libraryUrl = currentLibraryUrlOrFail()
+            ?: return FictionResult.Success(emptyList())
+        val root = ensureRoot(libraryUrl).valueOrReturn { return it }
+        // Surface navigation entries as genres. The list is curated by
+        // the library itself (each Palace library has its own
+        // collections), so we emit what we see.
+        return FictionResult.Success(root.navLinks.map { it.title })
+    }
+
+    // ── detail ────────────────────────────────────────────────────────
+
+    override suspend fun fictionDetail(fictionId: String): FictionResult<FictionDetail> {
+        val entry = entryCache[fictionId] ?: run {
+            // Cold-start detail open (e.g., user reopened the app and
+            // tapped a Library row whose entry isn't in our in-process
+            // cache). Re-walk the root + nav children to look for the
+            // entry id. This is a v1 simplification — a v2 pass could
+            // persist a small entry-id → href index instead.
+            val libraryUrl = currentLibraryUrlOrFail()
+                ?: return libraryNotConfigured()
+            when (val r = recachedEntryFor(fictionId, libraryUrl)) {
+                is FictionResult.Success -> r.value
+                is FictionResult.Failure -> return r
+            }
+        }
+
+        // DRM check: if no open-access EPUB acquisition link exists,
+        // this is a borrow-only title. Surface as AuthRequired with a
+        // human-readable message pointing to the Palace app — the
+        // reader UI renders that as a deep-link CTA rather than a
+        // generic network error.
+        val openAccess = pickOpenAccessEpub(entry.links)
+            ?: return FictionResult.AuthRequired(
+                "This title is only available through a Palace library " +
+                    "borrow. Open the Palace app to borrow ${entry.title}.",
+            )
+
+        val parsed = when (val r = ensureParsed(fictionId, openAccess.href)) {
+            is FictionResult.Success -> r.value
+            is FictionResult.Failure -> return r
+        }
+
+        val summary = FictionSummary(
+            id = fictionId,
+            sourceId = SourceIds.PALACE,
+            title = entry.title,
+            author = entry.author.orEmpty(),
+            description = entry.summary,
+            coverUrl = entry.coverUrl,
+            tags = entry.categories,
+            // Open-access OPDS titles are "complete works" — same
+            // posture PG / SE take for their finalized catalog entries.
+            status = FictionStatus.COMPLETED,
+            chapterCount = parsed.chapters.size,
+        )
+        val chapters = parsed.chapters.map { ch ->
+            ChapterInfo(
+                id = chapterIdFor(fictionId, ch.index),
+                sourceChapterId = ch.id,
+                index = ch.index,
+                title = ch.title,
+            )
+        }
+        return FictionResult.Success(FictionDetail(summary = summary, chapters = chapters))
+    }
+
+    override suspend fun chapter(
+        fictionId: String,
+        chapterId: String,
+    ): FictionResult<ChapterContent> {
+        val parsed = parsedCache[fictionId]
+            ?: return when (val r = reparseFromDisk(fictionId)) {
+                is FictionResult.Success -> chapter(fictionId, chapterId)
+                is FictionResult.Failure -> r
+            }
+        val idx = chapterIndexFrom(chapterId)
+            ?: return FictionResult.NotFound("Malformed chapter id: $chapterId")
+        val ch = parsed.chapters.getOrNull(idx)
+            ?: return FictionResult.NotFound(
+                "Chapter $idx out of range (have ${parsed.chapters.size})",
+            )
+        val info = ChapterInfo(
+            id = chapterId,
+            sourceChapterId = ch.id,
+            index = ch.index,
+            title = ch.title,
+        )
+        return FictionResult.Success(
+            ChapterContent(
+                info = info,
+                htmlBody = ch.htmlBody,
+                plainBody = ch.htmlBody.stripTags(),
+            ),
+        )
+    }
+
+    // ── auth-gated ────────────────────────────────────────────────────
+
+    override suspend fun followsList(page: Int): FictionResult<ListPage<FictionSummary>> =
+        // Palace doesn't expose a follow concept through the public
+        // OPDS feed. Borrow-side "currently checked out" is a separate
+        // authenticated surface, deferred to the auth-landing PR (see
+        // #500's encrypted-credential storage work).
+        FictionResult.Success(ListPage(items = emptyList(), page = 1, hasNext = false))
+
+    override suspend fun setFollowed(fictionId: String, followed: Boolean): FictionResult<Unit> =
+        FictionResult.Success(Unit)
+
+    // ── UrlMatcher (#472) ─────────────────────────────────────────────
+
+    /** Issue #472, #502 — Palace Project URL patterns. Confidence 0.9
+     *  for the canonical hosted-library URL shape, 0.5 for host-only
+     *  matches that we can't fully resolve without more context. */
+    override fun matchUrl(url: String): RouteMatch? {
+        val trimmed = url.trim()
+        // 1. Canonical hosted-library URL — works/<urn> path. Highest
+        //    confidence; the URN goes straight into the storyvox
+        //    fictionId so the detail fetch can recover the OPDS entry
+        //    from the cache (or re-walk to find it on cold start).
+        PALACE_WORK_URL_PATTERN.matchEntire(trimmed)?.let { m ->
+            val urn = m.groupValues[1]
+            return RouteMatch(
+                sourceId = SourceIds.PALACE,
+                fictionId = "${SourceIds.PALACE}:$urn",
+                confidence = 0.9f,
+                label = "Palace library title",
+            )
+        }
+        // 2. Host-only Palace URL — palaceproject.io homepage or a
+        //    library subdomain with no work path. The repository can't
+        //    fetch a real detail from this, but the matcher claims it
+        //    so the magic-link picker can surface a "Configure Palace
+        //    library" prompt rather than dropping the URL to
+        //    Readability4J.
+        PALACE_HOST_URL_PATTERN.matchEntire(trimmed)?.let {
+            return RouteMatch(
+                sourceId = SourceIds.PALACE,
+                fictionId = "${SourceIds.PALACE}:configure",
+                confidence = 0.5f,
+                label = "Palace Project (configure library)",
+            )
+        }
+        return null
+    }
+
+    // ── helpers ───────────────────────────────────────────────────────
+
+    /**
+     * Pull the configured library URL once. Returns null when the user
+     * hasn't configured a library yet — the caller surfaces that as
+     * "configure a library" copy rather than an opaque network error.
+     */
+    private suspend fun currentLibraryUrlOrFail(): String? =
+        config.libraryRootUrl.first()?.takeIf { it.isNotBlank() }
+
+    private fun libraryNotConfigured(): FictionResult.Failure =
+        FictionResult.AuthRequired(
+            "Configure a Palace Project library URL in Settings " +
+                "→ Library & Sync → Palace Library to browse this source.",
+        )
+
+    /**
+     * Ensure the cached root feed for [libraryUrl] is fresh. Walked
+     * once per session per library URL; subsequent calls hit the
+     * in-process cache.
+     */
+    private suspend fun ensureRoot(libraryUrl: String): FictionResult<OpdsFeed> {
+        cachedRoot
+            ?.takeIf { cachedRootForUrl == libraryUrl }
+            ?.let { return FictionResult.Success(it) }
+        val r = api.fetchFeed(libraryUrl)
+        if (r is FictionResult.Success) {
+            cachedRoot = r.value
+            cachedRootForUrl = libraryUrl
+        }
+        return r
+    }
+
+    /**
+     * Idempotent EPUB acquire-and-parse. First call for a title
+     * downloads + parses + caches; subsequent calls return the cached
+     * [EpubBook]. Mirrors the helper PG / SE / AO3 use.
+     */
+    private suspend fun ensureParsed(
+        fictionId: String,
+        epubUrl: String,
+    ): FictionResult<EpubBook> {
+        parsedCache[fictionId]?.let { return FictionResult.Success(it) }
+        val onDisk = epubFileFor(fictionId)
+        if (onDisk.exists() && onDisk.length() > 0L) {
+            return reparseFromDisk(fictionId)
+        }
+        val bytes = when (val r = api.downloadEpub(epubUrl)) {
+            is FictionResult.Success -> r.value
+            is FictionResult.Failure -> return r
+        }
+        withContext(Dispatchers.IO) {
+            onDisk.parentFile?.mkdirs()
+            onDisk.writeBytes(bytes)
+        }
+        val parsed = try {
+            withContext(Dispatchers.IO) { EpubParser.parseFromBytes(bytes) }
+        } catch (e: EpubParseException) {
+            return FictionResult.NetworkError(
+                "Could not parse Palace EPUB: ${e.message}",
+                e,
+            )
+        }
+        parsedCache[fictionId] = parsed
+        return FictionResult.Success(parsed)
+    }
+
+    private suspend fun reparseFromDisk(fictionId: String): FictionResult<EpubBook> {
+        val onDisk = epubFileFor(fictionId)
+        if (!onDisk.exists()) {
+            return FictionResult.NotFound("No cached EPUB for $fictionId")
+        }
+        val bytes = withContext(Dispatchers.IO) { onDisk.readBytes() }
+        val parsed = try {
+            withContext(Dispatchers.IO) { EpubParser.parseFromBytes(bytes) }
+        } catch (e: EpubParseException) {
+            return FictionResult.NetworkError(
+                "Cached Palace EPUB unparseable: ${e.message}",
+                e,
+            )
+        }
+        parsedCache[fictionId] = parsed
+        return FictionResult.Success(parsed)
+    }
+
+    /**
+     * Cold-start detail support: re-walk the root + nav children
+     * looking for [fictionId]. Returns the entry on hit, NotFound on
+     * miss. v1 simplification (a v2 pass could persist an entry-id ←→
+     * sub-feed-href index in the cache dir).
+     */
+    private suspend fun recachedEntryFor(
+        fictionId: String,
+        libraryUrl: String,
+    ): FictionResult<OpdsEntry> {
+        val root = ensureRoot(libraryUrl).valueOrReturn { return it }
+        root.entries.firstOrNull { palaceIdFor(it) == fictionId }
+            ?.let {
+                entryCache[fictionId] = it
+                return FictionResult.Success(it)
+            }
+        // Walk one level of navigation. Bounded by however many lanes
+        // the library publishes; in practice 5-15 sub-feeds.
+        for (nav in root.navLinks) {
+            val feed = when (val r = api.fetchFeed(nav.href)) {
+                is FictionResult.Success -> r.value
+                is FictionResult.Failure -> continue // skip broken lanes
+            }
+            feed.entries.firstOrNull { palaceIdFor(it) == fictionId }
+                ?.let {
+                    entryCache[fictionId] = it
+                    return FictionResult.Success(it)
+                }
+        }
+        return FictionResult.NotFound("Palace title $fictionId not found in current library catalog")
+    }
+
+    /** Cache file path for an EPUB belonging to [fictionId]. The
+     *  filename uses a stable hex hash of the fictionId so we don't
+     *  have to worry about character-set hazards on Android storage
+     *  (Palace URN-shaped ids contain `:` which is fine on ext4 / f2fs
+     *  but historically wedges on some FAT-formatted SD cards). */
+    private fun epubFileFor(fictionId: String): File =
+        File(cacheDir, "${fictionId.stableHashFilename()}.epub")
+
+    /** Convert an OPDS entry to its storyvox FictionSummary AND keep
+     *  the entry around for the detail fetch. The combination keeps
+     *  this from being two passes over the same list. */
+    private fun OpdsEntry.cacheAndToSummary(): FictionSummary {
+        val fid = palaceIdFor(this)
+        entryCache[fid] = this
+        return FictionSummary(
+            id = fid,
+            sourceId = SourceIds.PALACE,
+            title = title,
+            author = author.orEmpty(),
+            description = summary,
+            coverUrl = coverUrl,
+            tags = categories,
+            status = if (pickOpenAccessEpub(links) != null) {
+                // Open-access titles render as fully-listenable in
+                // storyvox; mark them COMPLETED to suppress any
+                // "ongoing serial" affordances the Browse row may
+                // surface for ONGOING fictions.
+                FictionStatus.COMPLETED
+            } else {
+                // DRM'd titles: still surface in the list but the
+                // detail/chapter path will return AuthRequired. We
+                // can't easily map this to the FictionStatus enum
+                // without extending it, so reuse STUB — the closest
+                // semantic ("listing surface only, no playable body").
+                // The card UI distinguishes via the deep-link CTA on
+                // detail open, not via a status badge.
+                FictionStatus.STUB
+            },
+        )
+    }
+}
+
+// ── helpers used by both the source and tests ────────────────────────
+
+/** Issue #502 — Palace Project canonical work URL. Matches the
+ *  `/works/<urn>` path under any palaceproject.io subdomain or the
+ *  documented hosted-library hostnames (Open eBooks, etc.). The URN
+ *  group is captured so it goes verbatim into the storyvox fictionId. */
+internal val PALACE_WORK_URL_PATTERN: Regex = Regex(
+    """^https?://(?:[\w-]+\.)*(?:palaceproject\.io|openebooks\.us|circulation\.[\w.-]+)/[\w/.-]+/works/([^/?#]+)(?:[/?#].*)?$""",
+    RegexOption.IGNORE_CASE,
+)
+
+/** Host-only Palace URL. Confidence 0.5 — claims the URL so the
+ *  magic-link picker shows a Palace card rather than dropping to the
+ *  Readability catch-all, but can't fully resolve it. */
+internal val PALACE_HOST_URL_PATTERN: Regex = Regex(
+    """^https?://(?:[\w-]+\.)?palaceproject\.io/?(?:[/?#].*)?$""",
+    RegexOption.IGNORE_CASE,
+)
+
+/** Pick the best open-access EPUB acquisition link from [links], or
+ *  null when the title is DRM-only.
+ *
+ *  Preference order:
+ *    1. `rel=…/acquisition/open-access` + `type=application/epub+zip`
+ *       — the strongest signal Palace gives for "free, no DRM EPUB
+ *       download".
+ *    2. `rel=…/acquisition` + `type=application/epub+zip` — bare
+ *       acquisition with an EPUB MIME. Palace deployments sometimes
+ *       skip the `/open-access` suffix for older feeds; if the MIME is
+ *       EPUB and not the LCP license, it's still a free download.
+ *
+ *  Anything carrying [OpdsMime.LCP_LICENSE] is explicitly skipped — the
+ *  source must never invoke an LCP-license URL in v1. */
+internal fun pickOpenAccessEpub(links: List<OpdsLink>): OpdsLink? {
+    val openAccess = links.firstOrNull {
+        it.rel == OpdsRel.ACQUISITION_OPEN_ACCESS && it.type == OpdsMime.EPUB
+    }
+    if (openAccess != null) return openAccess
+    return links.firstOrNull {
+        it.rel == OpdsRel.ACQUISITION &&
+            it.type == OpdsMime.EPUB &&
+            // The bare acquisition rel sometimes points at an LCP
+            // license rather than an EPUB. The MIME check above already
+            // filters that out — defence in depth: any link whose MIME
+            // is `application/vnd.readium.lcp.license.v1.0+json` is
+            // never returned from this function.
+            it.type != OpdsMime.LCP_LICENSE
+    }
+}
+
+/** Build a stable storyvox fictionId from an OPDS entry id.
+ *  `palace:<urn>` — the URN gets carried through directly because it's
+ *  already a stable opaque identifier the library uses.
+ *
+ *  No URL-encoding: Palace URNs are `urn:librarysimplified.org:works/<n>`
+ *  shaped — only colons, slashes, and ASCII alphanumerics. Stable across
+ *  feed refreshes (the URN is the library's permanent id for the work). */
+internal fun palaceIdFor(entry: OpdsEntry): String =
+    "${SourceIds.PALACE}:${entry.id}"
+
+/** Compose chapter id = `${fictionId}::${spineIdx}`. Mirrors PG / SE /
+ *  AO3 — chapter lookups recover the spine index without a separate
+ *  map. */
+internal fun chapterIdFor(fictionId: String, spineIndex: Int): String =
+    "$fictionId::$spineIndex"
+
+internal fun chapterIndexFrom(chapterId: String): Int? =
+    chapterId.substringAfterLast("::", missingDelimiterValue = "")
+        .takeIf { it.isNotEmpty() }
+        ?.toIntOrNull()
+
+/** Cheap HTML→plaintext for the chapter body the engine receives.
+ *  The downstream pipeline normalizes further; this just gets the
+ *  visible text out of the wrapper tags so the TTS engine doesn't
+ *  read out angle-bracket noise. Same shape as the equivalent helper
+ *  on `:source-gutenberg` (which already handles `<head>` / `<script>`
+ *  / `<style>` stripping for SE / PG EPUBs — Palace EPUBs are the same
+ *  EPUB 3 shape). */
+internal fun String.stripTags(): String {
+    val noHead = Regex("(?is)<head\\b[^>]*>.*?</head>").replace(this, " ")
+    val noScript = Regex("(?is)<script\\b[^>]*>.*?</script>").replace(noHead, " ")
+    val noStyle = Regex("(?is)<style\\b[^>]*>.*?</style>").replace(noScript, " ")
+    val noComments = Regex("(?s)<!--.*?-->").replace(noStyle, " ")
+    return Regex("<[^>]+>").replace(noComments, " ")
+        .replace(Regex("\\s+"), " ")
+        .trim()
+}
+
+/** Build a filesystem-safe filename from a fictionId. Uses
+ *  [String.hashCode] formatted as 8-hex — collision-prone in theory but
+ *  the per-library catalog has < 100k titles and the bucket scope is a
+ *  single cache directory, so collision risk is negligible. Mirrors the
+ *  pattern other sources use to avoid embedding URN colons in file
+ *  names. */
+private fun String.stableHashFilename(): String =
+    String.format("%08x", this.hashCode())
+
+/**
+ * Helper for the `.valueOrReturn { return it }` pattern threaded
+ * through the source — extracts the Success value or returns a
+ * Failure from the enclosing function via a non-local return. Reads
+ * a hair cleaner than the explicit `when` cascade and matches the
+ * pattern other source modules have evolved toward.
+ */
+private inline fun <T> FictionResult<T>.valueOrReturn(
+    onFailure: (FictionResult.Failure) -> Nothing,
+): T = when (this) {
+    is FictionResult.Success -> value
+    is FictionResult.Failure -> onFailure(this)
+}

--- a/source-palace/src/main/kotlin/in/jphe/storyvox/source/palace/di/PalaceModule.kt
+++ b/source-palace/src/main/kotlin/in/jphe/storyvox/source/palace/di/PalaceModule.kt
@@ -1,0 +1,131 @@
+package `in`.jphe.storyvox.source.palace.di
+
+import android.content.Context
+import dagger.Binds
+import dagger.Module
+import dagger.Provides
+import dagger.hilt.InstallIn
+import dagger.hilt.android.qualifiers.ApplicationContext
+import dagger.hilt.components.SingletonComponent
+import dagger.multibindings.IntoMap
+import dagger.multibindings.StringKey
+import `in`.jphe.storyvox.data.source.FictionSource
+import `in`.jphe.storyvox.data.source.SourceIds
+import `in`.jphe.storyvox.source.palace.InMemoryPalaceLibraryConfig
+import `in`.jphe.storyvox.source.palace.PalaceLibraryConfig
+import `in`.jphe.storyvox.source.palace.PalaceSource
+import `in`.jphe.storyvox.source.palace.net.PalaceApi
+import okhttp3.OkHttpClient
+import java.io.File
+import java.util.concurrent.TimeUnit
+import javax.inject.Qualifier
+import javax.inject.Singleton
+
+/**
+ * Identifies the dedicated cache directory for downloaded Palace
+ * EPUBs. Scoping the file root to its own qualifier prevents any
+ * future module-cleanup pass from confusing Palace downloads with
+ * `:source-gutenberg` / `:source-standard-ebooks` / `:source-ao3`
+ * caches, the exports/ subdirectory (#117), or anyone else's files.
+ */
+@Qualifier
+@Retention(AnnotationRetention.BINARY)
+annotation class PalaceCache
+
+/**
+ * Dedicated OkHttp client for Palace OPDS catalogs + EPUB downloads.
+ * Generous timeouts because Palace deployments range from
+ * well-resourced (NYPL) to small-library shared hosting; EPUB
+ * downloads can be 2-10 MB and the per-library origin varies in
+ * response time. retryOnConnectionFailure smooths over transient
+ * hiccups without forcing the user to tap a retry button. Same shape
+ * as the Gutenberg / Standard Ebooks clients.
+ */
+@Qualifier
+@Retention(AnnotationRetention.BINARY)
+annotation class PalaceHttp
+
+@Module
+@InstallIn(SingletonComponent::class)
+internal object PalaceHttpModule {
+
+    @Provides
+    @Singleton
+    @PalaceHttp
+    fun provideClient(): OkHttpClient =
+        OkHttpClient.Builder()
+            .connectTimeout(10, TimeUnit.SECONDS)
+            // EPUB downloads dominate the read budget — give them
+            // headroom for the slower Palace deployments (small-library
+            // shared-hosting setups can take 30+ seconds for 8 MB
+            // titles).
+            .readTimeout(60, TimeUnit.SECONDS)
+            .writeTimeout(30, TimeUnit.SECONDS)
+            .followRedirects(true)
+            .followSslRedirects(true)
+            .retryOnConnectionFailure(true)
+            .build()
+
+    @Provides
+    @Singleton
+    fun provideApi(
+        @PalaceHttp client: OkHttpClient,
+    ): PalaceApi = PalaceApi(client)
+
+    @Provides
+    @Singleton
+    @PalaceCache
+    fun provideCacheDir(@ApplicationContext ctx: Context): File =
+        File(ctx.cacheDir, "palace").apply { mkdirs() }
+}
+
+/**
+ * Binds [PalaceLibraryConfig] to the in-memory default. The
+ * DataStore-backed real implementation lives in `:app` / `:feature`
+ * and is wired up by issue #501's settings refactor — until then, the
+ * in-memory binding returns `null` for the library URL and the source
+ * surfaces "configure a library" copy on every browse call.
+ *
+ * When #501's settings binding lands, it will provide its own
+ * `@Module @InstallIn(SingletonComponent::class)` with a `@Provides`
+ * for `PalaceLibraryConfig` and a `@TestInstallIn` to replace this
+ * binding. We don't put it behind a `@Singleton` rebinder here so that
+ * a downstream module-level override works without a `@TestInstallIn`
+ * pragma in the production code path. The
+ * `(@Suppress("DaggerProductionScope"))` posture mirrors how
+ * `:source-radio` provides a default `RadioConfig` overridden by
+ * `:app`'s real implementation.
+ */
+@Module
+@InstallIn(SingletonComponent::class)
+internal abstract class PalaceConfigBindings {
+
+    /** Default in-memory binding. Replace with a DataStore-backed
+     *  implementation in `:app` / `:feature` (issue #501). */
+    @Binds
+    @Singleton
+    abstract fun bindConfig(impl: InMemoryPalaceLibraryConfig): PalaceLibraryConfig
+}
+
+/**
+ * Contributes [PalaceSource] into the multi-source
+ * `Map<String, FictionSource>`. Adds a "Palace Library" entry to the
+ * source picker; persisted fictions with `sourceId="palace"` route
+ * through this source.
+ *
+ * The legacy `@IntoMap @StringKey` binding is kept in parallel with
+ * the auto-generated `@SourcePlugin` descriptor binding emitted by
+ * `:core-plugin-ksp` — same Phase 2 transitional pattern every other
+ * source module uses (#384). Phase 3 will remove the legacy bindings
+ * across the board.
+ */
+@Module
+@InstallIn(SingletonComponent::class)
+internal abstract class PalaceBindings {
+
+    @Binds
+    @Singleton
+    @IntoMap
+    @StringKey(SourceIds.PALACE)
+    abstract fun bindFictionSource(impl: PalaceSource): FictionSource
+}

--- a/source-palace/src/main/kotlin/in/jphe/storyvox/source/palace/net/PalaceApi.kt
+++ b/source-palace/src/main/kotlin/in/jphe/storyvox/source/palace/net/PalaceApi.kt
@@ -1,0 +1,189 @@
+package `in`.jphe.storyvox.source.palace.net
+
+import `in`.jphe.storyvox.data.source.model.FictionResult
+import `in`.jphe.storyvox.source.palace.parse.OpdsFeed
+import `in`.jphe.storyvox.source.palace.parse.OpdsParseException
+import `in`.jphe.storyvox.source.palace.parse.OpdsParser
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+import okhttp3.OkHttpClient
+import okhttp3.Request
+import java.io.IOException
+import javax.inject.Inject
+import javax.inject.Singleton
+
+/**
+ * Issue #502 — HTTP transport for Palace Project OPDS catalog feeds.
+ *
+ * Palace Project libraries expose their catalog at well-known OPDS
+ * endpoints under the user-configured library base URL
+ * (e.g., `https://circulation.openebooks.us` or per-library subdomains
+ * like `nypl.palaceproject.io`). The base URL is the OPDS root feed; we
+ * fetch it once on startup-of-source, then walk the navigation links
+ * inside it to populate genre / collection lanes.
+ *
+ * v1 endpoints consumed:
+ *
+ *  - `GET <base>` — root OPDS feed. Mix of navigation entries (links to
+ *    sub-feeds) and sometimes immediate publication rows. The root's
+ *    title becomes the library's display name in the storyvox plugin
+ *    manager card.
+ *  - `GET <feedHref>` — generic sub-feed fetch. Same parser, different
+ *    URL.
+ *  - `GET <acquisitionHref>` — EPUB binary download (only invoked when
+ *    the entry's acquisition link has `type=application/epub+zip` and
+ *    `rel=…/acquisition/open-access`). The result is a ByteArray the
+ *    caller writes to disk + parses through `:source-epub`.
+ *
+ * **What this client does not do:**
+ *  - No auth header. Library-card sign-in is a follow-up surface (Palace
+ *    libraries DO support a basic-auth challenge for borrow flows, but
+ *    v1 storyvox doesn't borrow; we only read the public catalog and
+ *    download open-access titles).
+ *  - No OPDS 2.x JSON. The parser would throw [OpdsParseException]
+ *    immediately if a library returned JSON.
+ *  - No LCP license fetch. DRM'd acquisition links surface a deep-link
+ *    CTA; this client never invokes their `href`.
+ *
+ * Sends a polite User-Agent identifying as storyvox with a contact URL
+ * — same etiquette as the Gutenberg / Standard Ebooks clients.
+ */
+@Singleton
+internal class PalaceApi @Inject constructor(
+    private val client: OkHttpClient,
+) {
+
+    /**
+     * Fetch + parse the OPDS feed at [url]. The [url] should already be
+     * absolute (the parser resolves relative hrefs from a base URL so
+     * call sites generally pass the result of a previous `nextHref` /
+     * navigation `href` straight through).
+     */
+    suspend fun fetchFeed(url: String): FictionResult<OpdsFeed> =
+        withContext(Dispatchers.IO) {
+            when (val r = fetchString(url)) {
+                is FictionResult.Success -> {
+                    try {
+                        FictionResult.Success(OpdsParser.parse(r.value, baseUrl = url))
+                    } catch (e: OpdsParseException) {
+                        // The catalog walker turns every parse failure
+                        // into a NetworkError (the surface error type
+                        // the BrowsePaginator already renders cleanly).
+                        // We keep the original message so the developer
+                        // can see "this library is OPDS 2.x" or "feed
+                        // missing required <title>" in logcat.
+                        FictionResult.NetworkError(
+                            "Could not parse OPDS feed from $url: ${e.message}",
+                            e,
+                        )
+                    }
+                }
+                is FictionResult.Failure -> r
+            }
+        }
+
+    /**
+     * Download the bytes at [url] as an EPUB. Caller is responsible for
+     * having confirmed this is an `application/epub+zip` open-access
+     * acquisition link — this method does no MIME validation beyond
+     * what HTTP returns. Same shape as `:source-gutenberg`'s
+     * downloadEpub.
+     */
+    suspend fun downloadEpub(url: String): FictionResult<ByteArray> =
+        withContext(Dispatchers.IO) {
+            try {
+                val req = Request.Builder()
+                    .url(url)
+                    .header("User-Agent", USER_AGENT)
+                    .header("Accept", "application/epub+zip")
+                    .get()
+                    .build()
+                client.newCall(req).execute().use { resp ->
+                    when {
+                        resp.code == 401 || resp.code == 403 ->
+                            // 401/403 on an open-access link usually
+                            // means the catalog mislabelled a DRM'd
+                            // title or the library required a session
+                            // we don't have. Surface as AuthRequired so
+                            // the UI can prompt the user to switch to
+                            // the Palace app for this title.
+                            FictionResult.AuthRequired(
+                                "Palace library returned ${resp.code} on $url — " +
+                                    "title may require a borrow session.",
+                            )
+                        resp.code == 404 ->
+                            FictionResult.NotFound("EPUB not available at $url")
+                        !resp.isSuccessful ->
+                            FictionResult.NetworkError(
+                                "HTTP ${resp.code} downloading Palace EPUB",
+                                IOException("HTTP ${resp.code}"),
+                            )
+                        else -> {
+                            val bytes = resp.body?.bytes()
+                                ?: return@withContext FictionResult.NetworkError(
+                                    "empty EPUB body from $url",
+                                    IOException("empty body"),
+                                )
+                            FictionResult.Success(bytes)
+                        }
+                    }
+                }
+            } catch (e: IOException) {
+                FictionResult.NetworkError(e.message ?: "Palace EPUB download failed", e)
+            }
+        }
+
+    /**
+     * GET [url] and return the body as a string, mapping HTTP failure
+     * shapes to the right [FictionResult.Failure] subtypes so the
+     * BrowsePaginator + DetailViewModel UIs render the correct copy.
+     */
+    private fun fetchString(url: String): FictionResult<String> {
+        return try {
+            val req = Request.Builder()
+                .url(url)
+                .header(
+                    "Accept",
+                    // OPDS 1.x catalog feeds advertise this content
+                    // type; libraries that publish 2.x will return JSON
+                    // and the parser will reject it (logged + deferred).
+                    "application/atom+xml;profile=opds-catalog, application/atom+xml, " +
+                        "application/xml;q=0.9, */*;q=0.1",
+                )
+                .header("User-Agent", USER_AGENT)
+                .get()
+                .build()
+            client.newCall(req).execute().use { resp ->
+                when {
+                    resp.code == 401 -> FictionResult.AuthRequired(
+                        "Palace library at $url requires sign-in.",
+                    )
+                    resp.code == 404 -> FictionResult.NotFound("Palace: $url not found")
+                    !resp.isSuccessful -> FictionResult.NetworkError(
+                        "HTTP ${resp.code} from Palace at $url",
+                        IOException("HTTP ${resp.code}"),
+                    )
+                    else -> {
+                        val text = resp.body?.string()
+                            ?: return FictionResult.NetworkError(
+                                "empty body from $url",
+                                IOException("empty body"),
+                            )
+                        FictionResult.Success(text)
+                    }
+                }
+            }
+        } catch (e: IOException) {
+            FictionResult.NetworkError(e.message ?: "Palace fetch failed", e)
+        }
+    }
+
+    companion object {
+        /**
+         * Identifies storyvox to Palace library operators. The contact
+         * URL routes any rate-limit / abuse signal back to a real human
+         * — same etiquette as the Gutenberg / Standard Ebooks clients.
+         */
+        const val USER_AGENT = "storyvox-palace/1.0 (+https://github.com/jphein/storyvox)"
+    }
+}

--- a/source-palace/src/main/kotlin/in/jphe/storyvox/source/palace/parse/OpdsFeed.kt
+++ b/source-palace/src/main/kotlin/in/jphe/storyvox/source/palace/parse/OpdsFeed.kt
@@ -1,0 +1,151 @@
+package `in`.jphe.storyvox.source.palace.parse
+
+/**
+ * Issue #502 — OPDS 1.x Atom-flavoured catalog feed representation.
+ *
+ * OPDS 1.x ([spec](https://specs.opds.io/opds-1.2)) is an Atom-flavoured
+ * XML profile for publication catalogs. The shape mapped here covers
+ * the slice of OPDS that `:source-palace` actually consumes:
+ *
+ *  - **Acquisition feeds** — feeds whose `<entry>` elements carry a
+ *    `<link rel="http://opds-spec.org/acquisition">` (or the
+ *    `/acquisition/open-access` / `/acquisition/borrow` variants).
+ *    Each entry is one publication.
+ *  - **Navigation feeds** — feeds whose `<entry>` elements link out to
+ *    sub-feeds (collections, "by genre" lanes, etc.) via
+ *    `type="application/atom+xml;profile=opds-catalog"`. The walker
+ *    descends into these one level deep when assembling the genre list.
+ *
+ * The OPDS 2.x JSON profile is **not** parsed here; Palace Project
+ * libraries currently expose 1.x as the default consumer-facing feed
+ * (the Palace app pins to 1.x). A future-version pass can sit alongside
+ * this one — see [`OpdsParser.parse`] for the entry point dispatch.
+ */
+internal data class OpdsFeed(
+    /** Feed-level `<title>` (e.g. "NYPL — Featured"). */
+    val title: String,
+    /** Feed-level `<id>` if present; opaque, used for cache keys. */
+    val id: String? = null,
+    /**
+     * One row per publication in the feed. Navigation entries (links to
+     * sub-feeds rather than publications) are filtered into [navLinks]
+     * during parse — the source-side surface only deals in publications.
+     */
+    val entries: List<OpdsEntry>,
+    /** Sub-feed links pulled out of "navigation" entries. */
+    val navLinks: List<OpdsNavLink> = emptyList(),
+    /**
+     * `<link rel="next">` pagination link as an absolute URL. Null when
+     * the feed didn't advertise a next page; the source treats null as
+     * "no more pages".
+     */
+    val nextHref: String? = null,
+)
+
+/**
+ * One publication entry from an OPDS acquisition feed.
+ *
+ * Mirrors the Atom `<entry>` shape minus the bits storyvox doesn't use
+ * (rights, subjects with vocab URIs, edition strings). The acquisition
+ * link list is preserved verbatim so the source can dispatch on link
+ * `rel` + `type` to decide free-EPUB-download vs LCP-deep-link.
+ */
+internal data class OpdsEntry(
+    /** Atom `<id>` — Palace uses URN-style identifiers
+     *  (`urn:librarysimplified.org:works/<id>`). Carried through to the
+     *  storyvox `fictionId` so detail fetches stay stable across feed
+     *  refreshes. */
+    val id: String,
+    val title: String,
+    val author: String?,
+    /** First `<summary>` or `<content>` text, plain. */
+    val summary: String?,
+    /** Cover image URL if the entry carried an `<link rel="…/image">`
+     *  or `<link rel="http://opds-spec.org/image/thumbnail">`. */
+    val coverUrl: String?,
+    /** Publication categories — Atom `<category term="…" label="…">`.
+     *  Used as the `tags` field on the storyvox [FictionSummary]. */
+    val categories: List<String>,
+    /** Every `<link>` on the entry, kept in document order so the
+     *  caller can pick the highest-quality acquisition link. */
+    val links: List<OpdsLink>,
+)
+
+/**
+ * One `<link>` element on an entry or feed. Atom links carry semantic
+ * meaning via the `rel` attribute (the relationship type) and a MIME
+ * type indicating the resource shape at the other end.
+ *
+ * Acquisition rels seen in Palace feeds:
+ *  - `http://opds-spec.org/acquisition` — generic acquisition (often a
+ *    library-borrow flow, may resolve to a free EPUB or to an LCP
+ *    license depending on `type`)
+ *  - `http://opds-spec.org/acquisition/open-access` — free, no-DRM
+ *    download (this is the only acquisition rel storyvox can serve
+ *    directly in v1)
+ *  - `http://opds-spec.org/acquisition/borrow` — requires an active
+ *    loan; surfaces as a "borrow in Palace app" deep-link
+ *
+ * MIME types seen:
+ *  - `application/epub+zip` — free EPUB
+ *  - `application/vnd.readium.lcp.license.v1.0+json` — LCP license
+ *    (DRM'd; v1 storyvox deep-links out, see lcp-drm-scope.md)
+ *  - `application/audiobook+json` — Readium audiobook manifest (out of
+ *    scope; future audiobook support would consume this)
+ */
+internal data class OpdsLink(
+    val rel: String,
+    val href: String,
+    val type: String? = null,
+    /** Human-readable label, sometimes present on multi-acquisition
+     *  entries to disambiguate ("EPUB", "PDF", etc.). */
+    val title: String? = null,
+)
+
+/** Navigation entry collapsed into a (label, href) pair. The walker
+ *  uses these to emit a genre list and to step into sub-collections. */
+internal data class OpdsNavLink(
+    val title: String,
+    val href: String,
+    val summary: String? = null,
+)
+
+/**
+ * Standard OPDS link rels surfaced as Kotlin constants so call sites
+ * don't carry stringly-typed magic. See the OPDS 1.2 spec for the full
+ * list; this is the subset `:source-palace` reads.
+ */
+internal object OpdsRel {
+    const val ACQUISITION = "http://opds-spec.org/acquisition"
+    const val ACQUISITION_OPEN_ACCESS = "http://opds-spec.org/acquisition/open-access"
+    const val ACQUISITION_BORROW = "http://opds-spec.org/acquisition/borrow"
+    const val ACQUISITION_BUY = "http://opds-spec.org/acquisition/buy"
+    const val ACQUISITION_SUBSCRIBE = "http://opds-spec.org/acquisition/subscribe"
+    const val ACQUISITION_SAMPLE = "http://opds-spec.org/acquisition/sample"
+    const val IMAGE = "http://opds-spec.org/image"
+    const val IMAGE_THUMBNAIL = "http://opds-spec.org/image/thumbnail"
+    const val ALTERNATE = "alternate"
+    const val NEXT = "next"
+    const val SELF = "self"
+}
+
+/**
+ * MIME types of interest to the storyvox dispatch logic. Free EPUB
+ * downloads route through `:source-epub`; LCP licenses produce a
+ * deep-link CTA; everything else is informational.
+ */
+internal object OpdsMime {
+    const val EPUB = "application/epub+zip"
+
+    /** Readium LCP license-acquisition payload. Receiving this MIME on
+     *  an acquisition link means the publication is DRM'd — storyvox
+     *  surfaces it greyed-out with a deep-link out, no decryption
+     *  attempt. See `scratch/libby-hoopla-palace-scope/lcp-drm-scope.md`
+     *  for the deferred LCP plan. */
+    const val LCP_LICENSE = "application/vnd.readium.lcp.license.v1.0+json"
+
+    /** Readium audiobook manifest. Out of scope for v1; reserved here
+     *  so future audiobook work can be a content-type addition rather
+     *  than a parser rewrite. */
+    const val AUDIOBOOK_MANIFEST = "application/audiobook+json"
+}

--- a/source-palace/src/main/kotlin/in/jphe/storyvox/source/palace/parse/OpdsParser.kt
+++ b/source-palace/src/main/kotlin/in/jphe/storyvox/source/palace/parse/OpdsParser.kt
@@ -1,0 +1,323 @@
+package `in`.jphe.storyvox.source.palace.parse
+
+import android.util.Xml
+import org.xmlpull.v1.XmlPullParser
+import java.io.StringReader
+import java.net.URI
+
+/**
+ * Issue #502 — OPDS 1.x catalog feed parser using Android's bundled
+ * [XmlPullParser]. Same posture as `:source-rss`'s feed parser (#236):
+ * hand-rolled, narrow surface, no Rome-style dependency cost.
+ *
+ * Scope:
+ *  - OPDS 1.x (Atom-flavoured XML) — the profile every Palace Project
+ *    library exposes today. OPDS 2.x (JSON) is not handled here and is
+ *    a follow-up.
+ *  - Acquisition feeds: lists of publications. Each `<entry>` becomes an
+ *    [OpdsEntry] with its `<link>` list intact so the caller can pick
+ *    the right acquisition link (open-access EPUB vs LCP license vs
+ *    audiobook manifest).
+ *  - Navigation feeds: lists of sub-feed links. The parser extracts
+ *    these into [OpdsFeed.navLinks] so the source can emit them as
+ *    "genre" / "collection" picker rows.
+ *
+ * What this parser does **not** do:
+ *  - OPDS 2.x JSON profile (deferred — see [parse] comment)
+ *  - OpenSearch description documents (the search-endpoint discovery
+ *    metadata; storyvox composes the search URL directly from the
+ *    library base for v1)
+ *  - Per-entry indirect-acquisition chains (used for some DRM-multi-
+ *    format flows on Palace; v1 only handles the top-level link
+ *    list and routes everything else to the deep-link CTA)
+ *
+ * Stateless: the singleton holds no per-feed state. Concurrent parses
+ * each get their own XmlPullParser instance.
+ */
+internal object OpdsParser {
+
+    /**
+     * Entry point. [baseUrl] is the request URL the XML came from; it
+     * resolves any relative `href` attributes the feed carries (Palace
+     * libraries frequently emit relative paths on the `next` pagination
+     * link and on per-entry covers).
+     *
+     * Returns [OpdsFeed] on success, throws [OpdsParseException] on a
+     * fundamentally malformed feed (no `<feed>` root, no entries with
+     * titles). Empty acquisition feeds (`<feed>` with zero `<entry>`)
+     * are valid and return [OpdsFeed] with an empty entries list — the
+     * UI renders "no titles in this collection" cleanly.
+     */
+    fun parse(xml: String, baseUrl: String): OpdsFeed {
+        val parser = Xml.newPullParser()
+        parser.setFeature(XmlPullParser.FEATURE_PROCESS_NAMESPACES, true)
+        parser.setInput(StringReader(xml))
+        parser.nextTag()
+        if (parser.name != "feed") {
+            throw OpdsParseException(
+                "Not an OPDS 1.x Atom feed (root=${parser.name}). " +
+                    "OPDS 2.x JSON parsing is a follow-up.",
+            )
+        }
+        return parseFeed(parser, baseUrl)
+    }
+
+    private fun parseFeed(parser: XmlPullParser, baseUrl: String): OpdsFeed {
+        parser.require(XmlPullParser.START_TAG, null, "feed")
+        var feedTitle = ""
+        var feedId: String? = null
+        var nextHref: String? = null
+        val publicationEntries = mutableListOf<OpdsEntry>()
+        val navLinks = mutableListOf<OpdsNavLink>()
+
+        while (parser.next() != XmlPullParser.END_DOCUMENT) {
+            if (parser.eventType == XmlPullParser.END_TAG && parser.name == "feed") break
+            if (parser.eventType != XmlPullParser.START_TAG) continue
+            when (parser.name) {
+                "title" -> feedTitle = readText(parser).trim()
+                "id" -> feedId = readText(parser).trim().takeIf { it.isNotEmpty() }
+                "link" -> {
+                    val link = readLink(parser, baseUrl)
+                    if (link.rel == OpdsRel.NEXT) nextHref = link.href
+                    // Other feed-level links (self, search, start) are
+                    // informational only — the source composes its own
+                    // URLs from the library base.
+                }
+                "entry" -> {
+                    val classified = parseEntry(parser, baseUrl)
+                    when (classified) {
+                        is EntryShape.Publication -> publicationEntries += classified.entry
+                        is EntryShape.Navigation -> navLinks += classified.nav
+                        // Entries that have neither a publication-shaped
+                        // acquisition link nor a nav-link target are
+                        // dropped — they typically belong to feed-meta
+                        // surfaces ("about this library") we don't
+                        // surface in v1.
+                        EntryShape.Empty -> Unit
+                    }
+                }
+                else -> skip(parser)
+            }
+        }
+        if (feedTitle.isBlank()) {
+            // Palace feeds always carry `<title>`. If we land here it's
+            // a structurally broken feed; surface that loudly rather
+            // than silently rendering an empty "Untitled" lane.
+            throw OpdsParseException("OPDS feed missing required <title>")
+        }
+        return OpdsFeed(
+            title = feedTitle,
+            id = feedId,
+            entries = publicationEntries,
+            navLinks = navLinks,
+            nextHref = nextHref,
+        )
+    }
+
+    /**
+     * Classify an `<entry>` as a publication, a navigation row, or
+     * empty. The OPDS profile uses link `rel` + `type` to disambiguate;
+     * we read every link first, then decide on the entry's role.
+     */
+    private fun parseEntry(parser: XmlPullParser, baseUrl: String): EntryShape {
+        parser.require(XmlPullParser.START_TAG, null, "entry")
+        var id = ""
+        var title = ""
+        var author: String? = null
+        var summary: String? = null
+        val categories = mutableListOf<String>()
+        val links = mutableListOf<OpdsLink>()
+
+        while (parser.next() != XmlPullParser.END_DOCUMENT) {
+            if (parser.eventType == XmlPullParser.END_TAG && parser.name == "entry") break
+            if (parser.eventType != XmlPullParser.START_TAG) continue
+            when (parser.name) {
+                "id" -> id = readText(parser).trim()
+                "title" -> title = readText(parser).trim()
+                "author" -> author = readAuthor(parser) ?: author
+                "summary", "content" -> {
+                    // First non-empty wins. `<summary>` is preferred (plain
+                    // text by spec); `<content>` is HTML and we strip it
+                    // crudely so it renders as a plain card subtitle.
+                    val txt = readText(parser).trim()
+                    if (summary.isNullOrBlank() && txt.isNotEmpty()) {
+                        summary = stripHtml(txt)
+                    }
+                }
+                "category" -> {
+                    // Atom `<category term="…" label="…"/>` — prefer the
+                    // human-readable `label` when present, fall back to
+                    // the machine `term`.
+                    val label = parser.getAttributeValue(null, "label")
+                    val term = parser.getAttributeValue(null, "term")
+                    (label ?: term)?.trim()?.takeIf { it.isNotEmpty() }
+                        ?.let { categories += it }
+                    skip(parser)
+                }
+                "link" -> links += readLink(parser, baseUrl)
+                else -> skip(parser)
+            }
+        }
+        if (id.isBlank() || title.isBlank()) return EntryShape.Empty
+
+        // If any link is acquisition-shaped, the entry is a publication
+        // — even if it's a DRM'd one we can't fulfil. The source-side
+        // code decides what to do per link `type`.
+        val hasAcquisition = links.any { it.rel.startsWith(OpdsRel.ACQUISITION) }
+        if (hasAcquisition) {
+            val coverUrl = pickCover(links)
+            return EntryShape.Publication(
+                OpdsEntry(
+                    id = id,
+                    title = title,
+                    author = author,
+                    summary = summary,
+                    coverUrl = coverUrl,
+                    categories = categories,
+                    links = links,
+                ),
+            )
+        }
+
+        // Navigation entries link out to a sub-feed via an Atom-typed
+        // link (no acquisition rel). Take the first such link as the
+        // collection's target.
+        val nav = links.firstOrNull { link ->
+            val t = link.type ?: return@firstOrNull false
+            t.startsWith("application/atom+xml") && t.contains("opds-catalog")
+        }
+        if (nav != null) {
+            return EntryShape.Navigation(
+                OpdsNavLink(title = title, href = nav.href, summary = summary),
+            )
+        }
+
+        return EntryShape.Empty
+    }
+
+    private fun readLink(parser: XmlPullParser, baseUrl: String): OpdsLink {
+        val rel = parser.getAttributeValue(null, "rel") ?: ""
+        val href = parser.getAttributeValue(null, "href") ?: ""
+        val type = parser.getAttributeValue(null, "type")
+        val title = parser.getAttributeValue(null, "title")
+        skip(parser) // <link/> is self-closing in OPDS; this consumes the END_TAG.
+        return OpdsLink(
+            rel = rel,
+            href = resolve(baseUrl, href),
+            type = type,
+            title = title,
+        )
+    }
+
+    /**
+     * Atom `<author><name>...</name></author>`. Some Palace feeds put
+     * just a text node directly inside `<author>` (non-conformant but
+     * present in the wild); accept both shapes.
+     */
+    private fun readAuthor(parser: XmlPullParser): String? {
+        parser.require(XmlPullParser.START_TAG, null, "author")
+        var name: String? = null
+        while (parser.next() != XmlPullParser.END_DOCUMENT) {
+            if (parser.eventType == XmlPullParser.END_TAG && parser.name == "author") break
+            if (parser.eventType == XmlPullParser.TEXT && name.isNullOrBlank()) {
+                val txt = parser.text?.trim()
+                if (!txt.isNullOrEmpty()) name = txt
+            } else if (parser.eventType == XmlPullParser.START_TAG && parser.name == "name") {
+                name = readText(parser).trim()
+            } else if (parser.eventType == XmlPullParser.START_TAG) {
+                skip(parser)
+            }
+        }
+        return name?.takeIf { it.isNotEmpty() }
+    }
+
+    /** Pick the largest available cover image. Prefer `image` over
+     *  `image/thumbnail` (thumbnail is smaller; storyvox's list rows
+     *  render at 96-128 dp so the larger image's filesize cost is
+     *  worth it for retina sharpness). */
+    private fun pickCover(links: List<OpdsLink>): String? {
+        return links.firstOrNull { it.rel == OpdsRel.IMAGE }?.href
+            ?: links.firstOrNull { it.rel == OpdsRel.IMAGE_THUMBNAIL }?.href
+    }
+
+    // ── xml helpers ─────────────────────────────────────────────────
+
+    /** Consume an element's text content and advance to its end tag. */
+    private fun readText(parser: XmlPullParser): String {
+        val sb = StringBuilder()
+        while (parser.next() != XmlPullParser.END_DOCUMENT) {
+            when (parser.eventType) {
+                XmlPullParser.TEXT -> sb.append(parser.text)
+                XmlPullParser.END_TAG -> return sb.toString()
+                XmlPullParser.START_TAG -> {
+                    // Some Palace feeds nest HTML inside `<content type="html">`.
+                    // The XmlPullParser surfaces those as nested START_TAGs.
+                    // Recurse to gather the contained text; the caller strips
+                    // markup if needed.
+                    sb.append(readText(parser))
+                }
+                else -> Unit
+            }
+        }
+        return sb.toString()
+    }
+
+    /** Skip the current element (including any children). */
+    private fun skip(parser: XmlPullParser) {
+        if (parser.eventType != XmlPullParser.START_TAG) return
+        var depth = 1
+        while (depth != 0) {
+            when (parser.next()) {
+                XmlPullParser.END_TAG -> depth--
+                XmlPullParser.START_TAG -> depth++
+                else -> Unit
+            }
+        }
+    }
+
+    /**
+     * Resolve a relative href against the feed's base URL using
+     * [java.net.URI]. Palace feeds frequently emit absolute hrefs for
+     * cover images and relative paths for pagination links; both shapes
+     * need to come out as absolute strings the OkHttp layer can hit.
+     */
+    private fun resolve(baseUrl: String, href: String): String {
+        if (href.isEmpty()) return href
+        if (href.startsWith("http://") || href.startsWith("https://")) return href
+        return try {
+            URI(baseUrl).resolve(href).toString()
+        } catch (e: Exception) {
+            // If the base URL is itself malformed (shouldn't happen
+            // because OkHttp would have refused the request that
+            // returned this feed), return the href unchanged. Failing
+            // here would crash the whole parse for a single bad link.
+            href
+        }
+    }
+
+    /** Cheap HTML→plain for entry summaries that arrived as `type="html"`.
+     *  The detail/listing UI shows these at-a-glance so we don't need
+     *  the full HTML→text pipeline; strip tags and collapse whitespace. */
+    private fun stripHtml(input: String): String =
+        Regex("<[^>]+>").replace(input, " ")
+            .replace(Regex("\\s+"), " ")
+            .trim()
+
+    /** Classified entry shape. The parser walks once and dispatches in
+     *  the caller; an entry can be exactly one of these. */
+    private sealed interface EntryShape {
+        data class Publication(val entry: OpdsEntry) : EntryShape
+        data class Navigation(val nav: OpdsNavLink) : EntryShape
+        data object Empty : EntryShape
+    }
+}
+
+/**
+ * Thrown for structurally invalid feeds (no `<feed>` root, no `<title>`).
+ * RuntimeException subclass — surfaces as `FictionResult.NetworkError`
+ * at the source-side call site.
+ */
+internal class OpdsParseException(
+    message: String,
+    cause: Throwable? = null,
+) : RuntimeException(message, cause)

--- a/source-palace/src/test/kotlin/in/jphe/storyvox/source/palace/PalaceAcquisitionLinkTest.kt
+++ b/source-palace/src/test/kotlin/in/jphe/storyvox/source/palace/PalaceAcquisitionLinkTest.kt
@@ -1,0 +1,117 @@
+package `in`.jphe.storyvox.source.palace
+
+import `in`.jphe.storyvox.source.palace.parse.OpdsLink
+import `in`.jphe.storyvox.source.palace.parse.OpdsMime
+import `in`.jphe.storyvox.source.palace.parse.OpdsRel
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Test
+
+/**
+ * Issue #502 — load-bearing test for the DRM-handling boundary.
+ *
+ * The single most important invariant for `:source-palace` v1 is:
+ *
+ *   *No LCP-licensed acquisition link is ever fetched as if it were a
+ *   free EPUB.*
+ *
+ * If [pickOpenAccessEpub] returns an LCP link, the source would
+ * download a JSON license payload, hand it to `:source-epub`'s parser,
+ * and surface a "could not parse Palace EPUB" error. Worse, the
+ * cache layer would persist the JSON payload, and the next chapter
+ * open would silently fail forever. These tests pin the boundary.
+ */
+class PalaceAcquisitionLinkTest {
+
+    @Test
+    fun `prefers open-access EPUB link when present`() {
+        val links = listOf(
+            OpdsLink(
+                rel = OpdsRel.ACQUISITION_OPEN_ACCESS,
+                href = "https://lib.example/works/1/free.epub",
+                type = OpdsMime.EPUB,
+            ),
+            OpdsLink(
+                rel = OpdsRel.ACQUISITION_BORROW,
+                href = "https://lib.example/works/1/borrow",
+                type = OpdsMime.LCP_LICENSE,
+            ),
+        )
+        val picked = pickOpenAccessEpub(links)
+        assertEquals(
+            "Open-access EPUB must win over LCP borrow",
+            "https://lib.example/works/1/free.epub",
+            picked?.href,
+        )
+    }
+
+    @Test
+    fun `accepts bare acquisition rel when MIME is EPUB`() {
+        // Some older Palace deployments use the bare `acquisition` rel
+        // instead of `acquisition/open-access`. As long as the MIME is
+        // EPUB and not the LCP license, treat it as free.
+        val links = listOf(
+            OpdsLink(
+                rel = OpdsRel.ACQUISITION,
+                href = "https://lib.example/works/2/download.epub",
+                type = OpdsMime.EPUB,
+            ),
+        )
+        val picked = pickOpenAccessEpub(links)
+        assertEquals(
+            "Bare acquisition + EPUB MIME = open-access for our purposes",
+            "https://lib.example/works/2/download.epub",
+            picked?.href,
+        )
+    }
+
+    @Test
+    fun `returns null for LCP-only entries`() {
+        // The DRM invariant. Storyvox v1 must surface this title
+        // greyed-out with a deep-link CTA, NEVER fetch the license URL.
+        val links = listOf(
+            OpdsLink(
+                rel = OpdsRel.ACQUISITION_BORROW,
+                href = "https://lib.example/works/3/borrow",
+                type = OpdsMime.LCP_LICENSE,
+            ),
+        )
+        assertNull(
+            "DRM-only entry MUST NOT produce an open-access link",
+            pickOpenAccessEpub(links),
+        )
+    }
+
+    @Test
+    fun `returns null for audiobook-only entries`() {
+        // Readium audiobook manifests are out of scope for v1. The
+        // EPUB-only invariant in the picker rejects them cleanly so
+        // an audiobook-only Palace title surfaces the same deep-link
+        // CTA as an LCP'd one.
+        val links = listOf(
+            OpdsLink(
+                rel = OpdsRel.ACQUISITION_OPEN_ACCESS,
+                href = "https://lib.example/works/4/audiobook.json",
+                type = OpdsMime.AUDIOBOOK_MANIFEST,
+            ),
+        )
+        assertNull(
+            "Audiobook manifests are not EPUB and must be skipped",
+            pickOpenAccessEpub(links),
+        )
+    }
+
+    @Test
+    fun `returns null when no acquisition links present`() {
+        // Catalog-only entries (cover images, sample chapters but no
+        // download link) should never produce an open-access link.
+        val links = listOf(
+            OpdsLink(
+                rel = OpdsRel.IMAGE,
+                href = "https://lib.example/covers/5.jpg",
+                type = "image/jpeg",
+            ),
+        )
+        assertNull(pickOpenAccessEpub(links))
+    }
+}

--- a/source-palace/src/test/kotlin/in/jphe/storyvox/source/palace/PalaceUrlMatcherTest.kt
+++ b/source-palace/src/test/kotlin/in/jphe/storyvox/source/palace/PalaceUrlMatcherTest.kt
@@ -1,0 +1,82 @@
+package `in`.jphe.storyvox.source.palace
+
+import `in`.jphe.storyvox.data.source.SourceIds
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNull
+import org.junit.Test
+
+/**
+ * Issue #502 — UrlMatcher coverage for the Palace Project URL surface.
+ *
+ * These are pure regex tests (no source instance, no Hilt), exercised
+ * by walking the compiled URL patterns directly. The PalaceSource
+ * `matchUrl` implementation funnels through these patterns; if the
+ * regex changes, this test catches the breakage before the magic-link
+ * resolver does.
+ */
+class PalaceUrlMatcherTest {
+
+    @Test
+    fun `claims canonical palaceproject_io work URL with confidence 0_9`() {
+        val url = "https://nypl.palaceproject.io/groups/123/works/" +
+            "urn%3Alibrarysimplified.org%3Aworks%3A555"
+        val m = PALACE_WORK_URL_PATTERN.matchEntire(url)
+        assertNotNull("Canonical Palace work URL should match", m)
+        // The captured URN goes into the storyvox fictionId.
+        assertEquals(
+            "urn%3Alibrarysimplified.org%3Aworks%3A555",
+            m!!.groupValues[1],
+        )
+    }
+
+    @Test
+    fun `claims circulation_openebooks_us work URL`() {
+        val url = "https://circulation.openebooks.us/feeds/123/works/urn:works:9001"
+        val m = PALACE_WORK_URL_PATTERN.matchEntire(url)
+        assertNotNull("Open eBooks (Palace-backed) work URL should match", m)
+    }
+
+    @Test
+    fun `host-only palaceproject_io URL falls through to the host pattern`() {
+        val homepage = "https://www.palaceproject.io/"
+        assertNull(
+            "Homepage must not match the work URL pattern",
+            PALACE_WORK_URL_PATTERN.matchEntire(homepage),
+        )
+        assertNotNull(
+            "Homepage must match the host-only URL pattern",
+            PALACE_HOST_URL_PATTERN.matchEntire(homepage),
+        )
+    }
+
+    @Test
+    fun `unrelated URLs do not claim`() {
+        // Royal Road, AO3, generic Wikipedia — none of these should
+        // claim through the Palace matcher. They have their own
+        // sources at higher confidence.
+        listOf(
+            "https://www.royalroad.com/fiction/12345",
+            "https://archiveofourown.org/works/67890",
+            "https://en.wikipedia.org/wiki/Public_library",
+            "https://hoopladigital.com/title/13579",
+        ).forEach { url ->
+            assertNull(
+                "Non-Palace URL should not match the work pattern: $url",
+                PALACE_WORK_URL_PATTERN.matchEntire(url),
+            )
+            assertNull(
+                "Non-Palace URL should not match the host pattern: $url",
+                PALACE_HOST_URL_PATTERN.matchEntire(url),
+            )
+        }
+    }
+
+    @Test
+    fun `source id constant resolves to palace`() {
+        // Smoke test: a moved SourceIds constant would silently break
+        // every persisted Palace fiction's lookup path. Keep the
+        // literal value pinned here.
+        assertEquals("palace", SourceIds.PALACE)
+    }
+}

--- a/source-palace/src/test/kotlin/in/jphe/storyvox/source/palace/parse/OpdsParserTest.kt
+++ b/source-palace/src/test/kotlin/in/jphe/storyvox/source/palace/parse/OpdsParserTest.kt
@@ -1,0 +1,175 @@
+package `in`.jphe.storyvox.source.palace.parse
+
+import `in`.jphe.storyvox.source.palace.pickOpenAccessEpub
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+
+/**
+ * Issue #502 — fixture-backed coverage for the OPDS 1.x parser.
+ *
+ * Why Robolectric: the parser uses `android.util.Xml.newPullParser()`,
+ * which isn't on the plain-JUnit classpath. Same posture
+ * `:source-rss`'s fixture tests take (#464).
+ *
+ * The fixtures cover three shapes:
+ *  - **Acquisition feed** with open-access (free EPUB) entries
+ *  - **Mixed acquisition feed** — open-access + LCP-DRM'd entries
+ *  - **Navigation feed** — sub-feed links only, no publications
+ */
+@RunWith(RobolectricTestRunner::class)
+class OpdsParserTest {
+
+    @Test
+    fun `parses an acquisition feed with open-access EPUB entries`() {
+        val xml = """
+            <?xml version="1.0" encoding="utf-8"?>
+            <feed xmlns="http://www.w3.org/2005/Atom"
+                  xmlns:opds="http://opds-spec.org/2010/catalog">
+              <id>urn:test:open-access-feed</id>
+              <title>Sample Library — Open Access</title>
+              <link rel="self" href="https://lib.example/opds" type="application/atom+xml;profile=opds-catalog;kind=acquisition"/>
+              <link rel="next" href="https://lib.example/opds?page=2"/>
+              <entry>
+                <id>urn:librarysimplified.org:works/1234</id>
+                <title>The Public Domain Book</title>
+                <author><name>Ada Author</name></author>
+                <summary>A free-to-read classic.</summary>
+                <category term="fiction" label="Fiction"/>
+                <link rel="http://opds-spec.org/image"
+                      type="image/jpeg"
+                      href="https://lib.example/covers/1234.jpg"/>
+                <link rel="http://opds-spec.org/acquisition/open-access"
+                      type="application/epub+zip"
+                      href="https://lib.example/works/1234/download.epub"/>
+              </entry>
+            </feed>
+        """.trimIndent()
+
+        val feed = OpdsParser.parse(xml, baseUrl = "https://lib.example/opds")
+
+        assertEquals("Sample Library — Open Access", feed.title)
+        assertEquals("urn:test:open-access-feed", feed.id)
+        assertEquals("https://lib.example/opds?page=2", feed.nextHref)
+        assertEquals(1, feed.entries.size)
+
+        val entry = feed.entries[0]
+        assertEquals("urn:librarysimplified.org:works/1234", entry.id)
+        assertEquals("The Public Domain Book", entry.title)
+        assertEquals("Ada Author", entry.author)
+        assertEquals("A free-to-read classic.", entry.summary)
+        assertEquals(listOf("Fiction"), entry.categories)
+        assertEquals("https://lib.example/covers/1234.jpg", entry.coverUrl)
+
+        val openAccess = pickOpenAccessEpub(entry.links)
+        assertNotNull(
+            "Open-access EPUB acquisition link should be picked",
+            openAccess,
+        )
+        assertEquals("https://lib.example/works/1234/download.epub", openAccess!!.href)
+    }
+
+    @Test
+    fun `flags LCP-DRM entries as non-open-access`() {
+        val xml = """
+            <?xml version="1.0" encoding="utf-8"?>
+            <feed xmlns="http://www.w3.org/2005/Atom">
+              <title>Sample Library — Mixed</title>
+              <entry>
+                <id>urn:librarysimplified.org:works/9001</id>
+                <title>Borrow-Only Bestseller</title>
+                <author><name>Bea Author</name></author>
+                <link rel="http://opds-spec.org/acquisition/borrow"
+                      type="application/vnd.readium.lcp.license.v1.0+json"
+                      href="https://lib.example/works/9001/borrow"/>
+              </entry>
+            </feed>
+        """.trimIndent()
+
+        val feed = OpdsParser.parse(xml, baseUrl = "https://lib.example/opds")
+        assertEquals(1, feed.entries.size)
+        val drm = feed.entries[0]
+        // The LCP entry IS a publication (it carries an acquisition
+        // rel) — the parser should not drop it. But the open-access
+        // picker MUST return null so storyvox doesn't try to download
+        // an LCP license payload as if it were an EPUB.
+        assertNull(
+            "LCP-DRM entry must not produce an open-access EPUB link",
+            pickOpenAccessEpub(drm.links),
+        )
+    }
+
+    @Test
+    fun `parses a navigation feed into navLinks`() {
+        val xml = """
+            <?xml version="1.0" encoding="utf-8"?>
+            <feed xmlns="http://www.w3.org/2005/Atom">
+              <title>Sample Library — Root</title>
+              <entry>
+                <id>nav:featured</id>
+                <title>Featured</title>
+                <link rel="subsection"
+                      type="application/atom+xml;profile=opds-catalog;kind=acquisition"
+                      href="https://lib.example/opds/featured"/>
+              </entry>
+              <entry>
+                <id>nav:new-releases</id>
+                <title>New Releases</title>
+                <link rel="subsection"
+                      type="application/atom+xml;profile=opds-catalog;kind=acquisition"
+                      href="https://lib.example/opds/new"/>
+              </entry>
+            </feed>
+        """.trimIndent()
+
+        val feed = OpdsParser.parse(xml, baseUrl = "https://lib.example/opds")
+        assertEquals("Sample Library — Root", feed.title)
+        assertTrue("Pure-navigation feed has no publications", feed.entries.isEmpty())
+        assertEquals(2, feed.navLinks.size)
+        assertEquals("Featured", feed.navLinks[0].title)
+        assertEquals("https://lib.example/opds/featured", feed.navLinks[0].href)
+        assertEquals("New Releases", feed.navLinks[1].title)
+    }
+
+    @Test
+    fun `resolves relative hrefs against the feed base URL`() {
+        val xml = """
+            <?xml version="1.0" encoding="utf-8"?>
+            <feed xmlns="http://www.w3.org/2005/Atom">
+              <title>Library With Relative Paths</title>
+              <entry>
+                <id>urn:librarysimplified.org:works/42</id>
+                <title>Tales of the Relative Link</title>
+                <link rel="http://opds-spec.org/acquisition/open-access"
+                      type="application/epub+zip"
+                      href="/works/42/download.epub"/>
+              </entry>
+            </feed>
+        """.trimIndent()
+
+        val feed = OpdsParser.parse(
+            xml,
+            baseUrl = "https://lib.example/opds/featured",
+        )
+        val link = feed.entries[0].links[0]
+        assertEquals(
+            "https://lib.example/works/42/download.epub",
+            link.href,
+        )
+    }
+
+    @Test(expected = OpdsParseException::class)
+    fun `rejects non-OPDS root element`() {
+        // RSS root → not an OPDS feed → throw at parse-time so the
+        // source-side surface can flip it to FictionResult.NetworkError
+        // with a clear "library is not OPDS 1.x" message.
+        OpdsParser.parse(
+            xml = """<rss version="2.0"><channel><title>X</title></channel></rss>""",
+            baseUrl = "https://lib.example/feed",
+        )
+    }
+}


### PR DESCRIPTION
## Summary

First library-borrowing backend in the storyvox roster (partial close of
#502). New `:source-palace` module walks a user-configured Palace Project
library's OPDS 1.x catalog and routes open-access (non-DRM) EPUB titles
through the existing `:source-epub` parser. DRM'd titles surface greyed-out
with an "Open in Palace app to borrow" deep-link CTA — **no LCP decryption
is attempted in this PR**.

This PR ships **Palace Project only**. Libby + Hoopla are explicitly
deferred to follow-up PRs; scope notes for both live under
`scratch/libby-hoopla-palace-scope/` (kept out of the repo per project
convention, but the research findings inform the next PRs).

## What ships

- **`:source-palace` Gradle module** — same shape as `:source-gutenberg`
  / `:source-standard-ebooks` / `:source-ao3` (SourcePlugin descriptor,
  Hilt module, OkHttp client with polite UA, KSP-generated multibinding
  registration via `:core-plugin-ksp`).
- **OPDS 1.x Atom-flavoured parser** using `android.util.Xml`
  (XmlPullParser) — handles acquisition feeds, navigation feeds, mixed
  roots. OPDS 2.x JSON is explicitly deferred (call sites would surface
  it as a `FictionResult.NetworkError` with a clear "library is OPDS
  2.x" message).
- **DRM-handling boundary in `pickOpenAccessEpub()`** — only returns a
  link when `rel` is `…/acquisition` or `…/acquisition/open-access` AND
  MIME is `application/epub+zip`. LCP license MIMEs
  (`application/vnd.readium.lcp.license.v1.0+json`) are explicitly
  skipped. Three regression tests in `PalaceAcquisitionLinkTest` pin
  the invariant.
- **UrlMatcher (#472)** — claims `<library>.palaceproject.io/<feed>/works/<urn>`
  at confidence 0.9 (canonical), host-only Palace URLs at 0.5
  (configure-library prompt). Slots into the magic-link cascade
  alongside the existing 17 backends.
- **`PalaceLibraryConfig`** contract for user-supplied library root URL,
  with an in-memory default that returns `null`. `defaultEnabled=false`
  in the descriptor because the source needs a library URL before it can
  return anything — surfaces "configure a library URL" copy on every
  browse call until the user opts in via Settings → Library & Sync.
- **Test suite**: `OpdsParserTest` (Robolectric, four fixture-backed
  cases covering open-access, mixed open-access/LCP, navigation-only,
  relative-href resolution, malformed-root rejection),
  `PalaceUrlMatcherTest` (regex coverage), `PalaceAcquisitionLinkTest`
  (DRM boundary).

## What's deferred (follow-up PRs)

- **`:source-libby`** — OverDrive audiobook-only v1 path. Catalog browse
  hits the public Thunder API; borrowed-MP3 audiobooks route through
  `:source-radio`'s audio-stream pipeline. ADEPT-DRM'd ebooks are
  permanently out of scope. Library card auth coordinated with #500.
- **`:source-hoopla`** — reverse-engineered audiobook streaming via HLS
  manifest URLs through `:source-radio`. Requires Hoopla account auth
  (email + password) coordinated with #500. Ebook side deferred (DRM).
- **LCP DRM support** — three documented paths: certificated client via
  a Palace Project partnership, self-signed partner content, or "don't
  (recommended for now)." Default posture stays "deep-link out" until a
  real partnership conversation materializes.

## DRM stance (explicit)

- No LCP decryption, no ADEPT decryption, no reverse-engineered DRM
  removal of any kind.
- DRM'd titles still appear in the Palace catalog (so the user sees the
  library's full breadth), but their detail / chapter paths return a
  structured `FictionResult.AuthRequired` with a message pointing to the
  Palace app deep-link.
- The strategic pitch stays "we work with the apps your patrons already
  have."

## Palace Project partnership opportunity

LYRASIS (the nonprofit behind Palace Project) is the most mission-aligned
partnership opportunity from the three libraries called out in #502 —
nonprofit, OPDS-friendly, accessibility-adjacent. Concrete next step
(separate issue): outreach with a "we ship Palace as an open-access
catalog reader; here's our DRM-respecting architecture; want to talk
about a deeper integration with mutual benefits" pitch.

## Cross-cutting

- **`:app/build.gradle.kts`** — one-line dependency add for the new
  module's KSP-generated descriptor to join the Hilt multibinding set.
- **`settings.gradle.kts`** — one-line `include(":source-palace")`.
- **`SourceIds.kt`** — new `PALACE` constant with a kdoc block matching
  the surrounding convention.
- **No build-type changes**, **no R8/proguard changes** (Palace doesn't
  introduce a new reflection surface that needs keep rules — the parser
  + source class hit the existing Hilt + KSP keep rules in
  `app/proguard-rules.pro`).
- **Coordination**: `:source-palace` doesn't touch `:feature/.../auth/`
  (#500's territory), `:feature/.../settings/Plugins*` (#501's
  territory), or `:source-azure` (#501). Module is fully leaf —
  isolated from the parallel work-streams.

## Test plan

- [x] `./gradlew :app:assembleDebug` builds clean
- [x] `./gradlew :source-palace:testDebugUnitTest` — all 12 tests pass
  (4 OPDS parser, 4 URL matcher, 4 acquisition-link / DRM boundary)
- [x] `./gradlew :core-data:testDebugUnitTest` — passes (new SourceId
  constant doesn't break any baseline test)
- [x] `./gradlew :feature:testDebugUnitTest` — passes
- [ ] Install on R83W80CAFZB tablet and verify the source plugin manager
  card surfaces "Palace Library" with `defaultEnabled=false` and a
  description matching the descriptor
- [ ] Once #501's settings binding is wired, hand-test with a real
  Palace library URL (NYPL: `https://nypl.palaceproject.io/groups/123/`
  or Open eBooks: `https://circulation.openebooks.us/`)

**Pre-existing**: `NavStructureTest` fails on the v0.5.48 base because
commit `7f75435` extended the dock to 4 entries while the tests assert
== 2. Unrelated to this PR.

## Out of scope (explicit)

- DRM circumvention of any kind
- Holds / borrowing flows in storyvox itself
- KOBO / Kindle / Apple Books (commercial closed gardens)
- OPDS 2.x JSON profile (parser falls through cleanly when encountered)
- Real Search wiring (#501's settings refactor will expose the
  OpenSearch description fetch; surface ships v1 with an empty result
  set + a comment thread)

---

Do not merge yourself.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>