### PR TITLE
feat(plugins): voice bundles in Plugin Manager — closes #501

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,13 @@ Entries before v0.5.12 are reconstructed from the git log — see
 
 ## [Unreleased]
 
+### Added — Voice bundles in Plugin Manager
+- **Plugin Manager grows a fully-iterated Voice bundles section** (closes #501). Settings → Plugins now lists every installed voice family as a brass-edged card alongside Fiction sources and Audio streams: **Piper** (local neural, per-voice ONNX), **Kokoro** (~330 MB shared model, 53 speakers), **KittenTTS** (~24 MB shared, 8 en_US speakers), **Azure HD voices** (BYOK cloud, surfaces "Configure →" CTA when no key is set), and a **VoxSherpa upstreams** placeholder card signalling future engine-lib additions. Each card has the same shape as Fiction-source cards: brass voice-glyph monogram, On/Off toggle (disabled families are filtered out of the Voice Library), Local/Cloud/BYOK + live voice-count capability chips, and a "Manage voices →" link that deep-links to the Voice Library (Azure unconfigured swaps to "Configure →" routing to Settings → Cloud voices).
+- **`VoiceFamilyRegistry` singleton** in `:core-playback` enumerates the five families with declarative metadata (display name, description, license, size hint, source URL, defaultEnabled, BYOK flag). Adding a new family is one descriptor entry plus an `EngineType.X` case in `voiceFamilyId()`. A future out-of-tree `:source-foo` voice engine can graduate to a Hilt multibinding (or a `@VoiceFamilyPlugin` annotation) without breaking the registry contract.
+- **`voiceFamiliesEnabled` settings map** persists per-family on/off state under `pref_voice_families_enabled_v1` (JSON, schema-revvable). Twin codec `VoiceFamiliesEnabledCodec` mirrors the `sourcePluginsEnabled` shape. Absent ids fall back to each family's `defaultEnabled` so a fresh install sees Piper/Kokoro/Kitten on, Azure off until configured.
+- **Voice Library filter** (in `VoiceLibraryViewModel`): when a family is OFF the picker hides its voices across favourites, installed, and available buckets.
+- **Tests**: codec round-trip (`VoiceFamiliesEnabledCodecTest`, `:core-data`), registry shape + `EngineType.voiceFamilyId()` mapping for every static catalog entry (`VoiceFamilyRegistryTest`, `:core-playback`), filter logic + On/Off/All semantics + placeholder exclusion (`VoiceFamilyFilterTest`, `:feature`).
+
 ## [0.5.48] — 2026-05-15
 
 ### Fixed

--- a/app/src/main/kotlin/in/jphe/storyvox/data/SettingsRepositoryUiImpl.kt
+++ b/app/src/main/kotlin/in/jphe/storyvox/data/SettingsRepositoryUiImpl.kt
@@ -531,6 +531,17 @@ private object Keys {
      */
     val SOURCE_PLUGINS_ENABLED_JSON = stringPreferencesKey("pref_source_plugins_enabled_v1")
 
+    /**
+     * Plugin-seam Phase 4 (#501) — JSON-encoded
+     * `Map<voiceFamilyId, Boolean>` for the Plugin Manager's Voice
+     * bundles section. Twin of [SOURCE_PLUGINS_ENABLED_JSON]; missing
+     * ids fall back to each family's `defaultEnabled` in
+     * `VoiceFamilyRegistry`. The `_v1` suffix lets us rev the schema
+     * later (e.g. per-family richer state than a bare boolean) without
+     * a destructive migration.
+     */
+    val VOICE_FAMILIES_ENABLED_JSON = stringPreferencesKey("pref_voice_families_enabled_v1")
+
     // ── Sleep timer shake-to-extend (issue #150) ───────────────────
     val SLEEP_SHAKE_TO_EXTEND_ENABLED = booleanPreferencesKey("pref_sleep_shake_to_extend_enabled")
 
@@ -887,6 +898,13 @@ class SettingsRepositoryUiImpl(
                     }
                 }
             },
+            // Plugin-seam Phase 4 (#501) — Voice bundles in Plugin
+            // Manager. The map is empty on a fresh install; the
+            // ViewModel falls back to each family's `defaultEnabled`
+            // when its id is absent, so no migration shim is needed.
+            voiceFamiliesEnabled = `in`.jphe.storyvox.data.source.plugin.decodeVoiceFamiliesEnabledJson(
+                prefs[Keys.VOICE_FAMILIES_ENABLED_JSON],
+            ),
             notionDatabaseId = notion.databaseId,
             notionTokenConfigured = notion.apiToken.isNotBlank(),
             // Issue #393 — surface the anonymous-mode posture so the
@@ -1630,6 +1648,23 @@ class SettingsRepositoryUiImpl(
             current[id] = enabled
             prefs[Keys.SOURCE_PLUGINS_ENABLED_JSON] =
                 `in`.jphe.storyvox.data.source.plugin.encodeSourcePluginsEnabledJson(current)
+        }
+    }
+
+    /**
+     * Plugin-seam Phase 4 (#501) — twin of [setSourcePluginEnabled]
+     * for the voice family map. Single setter for the Plugin Manager's
+     * Voice bundles section; absent ids fall back to each family's
+     * `defaultEnabled` in `VoiceFamilyRegistry`.
+     */
+    override suspend fun setVoiceFamilyEnabled(id: String, enabled: Boolean) {
+        store.edit { prefs ->
+            val current = `in`.jphe.storyvox.data.source.plugin.decodeVoiceFamiliesEnabledJson(
+                prefs[Keys.VOICE_FAMILIES_ENABLED_JSON],
+            ).toMutableMap()
+            current[id] = enabled
+            prefs[Keys.VOICE_FAMILIES_ENABLED_JSON] =
+                `in`.jphe.storyvox.data.source.plugin.encodeVoiceFamiliesEnabledJson(current)
         }
     }
     override suspend fun setNotionDatabaseId(id: String) {

--- a/app/src/main/kotlin/in/jphe/storyvox/navigation/StoryvoxNavHost.kt
+++ b/app/src/main/kotlin/in/jphe/storyvox/navigation/StoryvoxNavHost.kt
@@ -706,6 +706,14 @@ private fun StoryvoxNavHostContent(
             ) {
                 `in`.jphe.storyvox.feature.settings.plugins.PluginManagerScreen(
                     onNavigateBack = { navController.popBackStack() },
+                    // #501 — Voice bundles section deep-links into the
+                    // Voice Library for per-family voice management and
+                    // into the long-scroll Settings for Azure BYOK key
+                    // entry. The long-scroll page anchors the Azure
+                    // card; a future dedicated Settings → Cloud Voices
+                    // subscreen would replace this target.
+                    onOpenVoiceLibrary = { navController.navigate(StoryvoxRoutes.VOICE_LIBRARY) },
+                    onOpenAzureSettings = { navController.navigate(StoryvoxRoutes.SETTINGS) },
                 )
             }
             composable(

--- a/app/src/test/kotlin/in/jphe/storyvox/di/RealPlaybackControllerUiTest.kt
+++ b/app/src/test/kotlin/in/jphe/storyvox/di/RealPlaybackControllerUiTest.kt
@@ -296,6 +296,7 @@ class RealPlaybackControllerUiTest {
         override suspend fun probeTelegramBot(): String? = null
         override suspend fun fetchTelegramChannels(): List<Pair<String, String>> = emptyList()
         override suspend fun setSourcePluginEnabled(id: String, enabled: Boolean) = Unit
+        override suspend fun setVoiceFamilyEnabled(id: String, enabled: Boolean) = Unit
         override suspend fun setNotionDatabaseId(id: String) = Unit
         override suspend fun setNotionApiToken(token: String?) = Unit
         override val suggestedRssFeeds: kotlinx.coroutines.flow.Flow<List<`in`.jphe.storyvox.feature.api.SuggestedFeed>> = kotlinx.coroutines.flow.flowOf(emptyList())

--- a/core-data/src/main/kotlin/in/jphe/storyvox/data/source/plugin/VoiceFamiliesEnabledCodec.kt
+++ b/core-data/src/main/kotlin/in/jphe/storyvox/data/source/plugin/VoiceFamiliesEnabledCodec.kt
@@ -1,0 +1,49 @@
+package `in`.jphe.storyvox.data.source.plugin
+
+import kotlinx.serialization.builtins.MapSerializer
+import kotlinx.serialization.builtins.serializer
+import kotlinx.serialization.json.Json
+
+/**
+ * Plugin-seam Phase 4 (#501) — JSON codec for the
+ * `Map<voiceFamilyId, Boolean>` persisted under the
+ * `pref_voice_families_enabled_v1` DataStore key.
+ *
+ * Twin of [encodeSourcePluginsEnabledJson] / [decodeSourcePluginsEnabledJson]
+ * for the Voice bundles section of the Plugin Manager. Voice families
+ * (Piper, Kokoro, KittenTTS, Azure HD, future VoxSherpa upstreams) carry
+ * the same on/off semantic as fiction sources — when a family is OFF,
+ * its voices are filtered out of the Voice Library.
+ *
+ * Lives in `:core-data` (not in `:app`) so any module that wants to
+ * read or write the persisted shape doesn't have to depend on the
+ * app module. The actual DataStore I/O still happens in
+ * `SettingsRepositoryUiImpl` — this file is just the codec.
+ *
+ * `ignoreUnknownKeys = true` so a future schema bump doesn't lose data
+ * on the way down. `encodeDefaults = true` so a `false` toggle
+ * round-trips intact even when `false` is the default.
+ */
+private val VoiceFamiliesJson = Json {
+    ignoreUnknownKeys = true
+    encodeDefaults = true
+}
+
+private val MapSerializer = MapSerializer(String.serializer(), Boolean.serializer())
+
+/** Serialize [map] to a JSON object for DataStore storage. */
+fun encodeVoiceFamiliesEnabledJson(map: Map<String, Boolean>): String =
+    VoiceFamiliesJson.encodeToString(MapSerializer, map)
+
+/**
+ * Parse a JSON blob produced by [encodeVoiceFamiliesEnabledJson].
+ * Returns an empty map for null / blank / parse-failed input — a
+ * corrupted blob shouldn't crash startup; consumers fall back to each
+ * family's `defaultEnabled` when its id is absent from the map.
+ */
+fun decodeVoiceFamiliesEnabledJson(blob: String?): Map<String, Boolean> {
+    if (blob.isNullOrBlank()) return emptyMap()
+    return runCatching {
+        VoiceFamiliesJson.decodeFromString(MapSerializer, blob)
+    }.getOrDefault(emptyMap())
+}

--- a/core-data/src/test/kotlin/in/jphe/storyvox/data/source/plugin/VoiceFamiliesEnabledCodecTest.kt
+++ b/core-data/src/test/kotlin/in/jphe/storyvox/data/source/plugin/VoiceFamiliesEnabledCodecTest.kt
@@ -1,0 +1,53 @@
+package `in`.jphe.storyvox.data.source.plugin
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+/**
+ * Plugin-seam Phase 4 (#501) — codec round-trip tests for the JSON
+ * map persisted under `pref_voice_families_enabled_v1`. Twin of
+ * [SourcePluginsEnabledCodecTest] — same failure-mode contracts.
+ */
+class VoiceFamiliesEnabledCodecTest {
+
+    @Test fun `null input decodes to empty map`() {
+        assertEquals(emptyMap<String, Boolean>(), decodeVoiceFamiliesEnabledJson(null))
+    }
+
+    @Test fun `blank input decodes to empty map`() {
+        assertEquals(emptyMap<String, Boolean>(), decodeVoiceFamiliesEnabledJson(""))
+        assertEquals(emptyMap<String, Boolean>(), decodeVoiceFamiliesEnabledJson("   "))
+    }
+
+    @Test fun `unparseable input decodes to empty map without throwing`() {
+        assertEquals(emptyMap<String, Boolean>(), decodeVoiceFamiliesEnabledJson("not json"))
+        assertEquals(emptyMap<String, Boolean>(), decodeVoiceFamiliesEnabledJson("{garbage"))
+    }
+
+    @Test fun `round-trip preserves true and false values`() {
+        val original = mapOf(
+            "voice_piper" to true,
+            "voice_kokoro" to true,
+            "voice_kitten" to false,
+            "voice_azure" to false,
+        )
+        val encoded = encodeVoiceFamiliesEnabledJson(original)
+        val decoded = decodeVoiceFamiliesEnabledJson(encoded)
+        assertEquals(original, decoded)
+    }
+
+    @Test fun `empty map round-trips`() {
+        val encoded = encodeVoiceFamiliesEnabledJson(emptyMap())
+        val decoded = decodeVoiceFamiliesEnabledJson(encoded)
+        assertEquals(emptyMap<String, Boolean>(), decoded)
+    }
+
+    @Test fun `forward-rolled payload with extra fields does not crash`() {
+        // A future schema might add a per-family object instead of a
+        // bare boolean. Today's decoder should reject the alien shape
+        // by returning empty rather than crashing.
+        val alien = """{"voice_piper":{"enabled":true,"version":2}}"""
+        val decoded = decodeVoiceFamiliesEnabledJson(alien)
+        assertEquals(emptyMap<String, Boolean>(), decoded)
+    }
+}

--- a/core-playback/src/main/kotlin/in/jphe/storyvox/playback/voice/VoiceFamilyRegistry.kt
+++ b/core-playback/src/main/kotlin/in/jphe/storyvox/playback/voice/VoiceFamilyRegistry.kt
@@ -1,0 +1,181 @@
+package `in`.jphe.storyvox.playback.voice
+
+import javax.inject.Inject
+import javax.inject.Singleton
+
+/**
+ * Plugin-seam Phase 4 (#501) — known voice families, surfaced as cards
+ * in the Plugin Manager's Voice bundles section.
+ *
+ * A "voice family" is a TTS engine + its bundle of voices. storyvox
+ * ships four installed families (Piper, Kokoro, KittenTTS, Azure HD)
+ * and reserves the "VoxSherpa upstreams" id as a placeholder for
+ * future engine-lib additions.
+ *
+ * The family ids here are the **registry keys** — they're persisted in
+ * `UiSettings.voiceFamiliesEnabled` and surfaced by [VoiceFamilyRegistry].
+ * They are **not** voice ids — those are per-voice (`piper_lessac_*`,
+ * `kokoro_alloy_*`, etc.) and live in [VoiceCatalog].
+ *
+ * @property id Stable key for `voiceFamiliesEnabled` and routing.
+ * @property displayName Card title (e.g. "Piper", "Azure HD voices").
+ * @property description One-line subtitle for the card.
+ * @property sourceUrl Canonical upstream URL for the details modal.
+ * @property license Human-readable license string for the details modal.
+ * @property sizeHint Human-readable size info (e.g. "~14–30 MB each",
+ *  "~330 MB single download"). Empty when not meaningful.
+ * @property requiresConfiguration True for BYOK families (Azure) where
+ *  the family is "installed" but unusable until the user provides
+ *  credentials. The card surfaces a "Configure → Settings" CTA in
+ *  place of the "Manage voices →" link.
+ * @property isPlaceholder True for the "VoxSherpa upstreams" entry that
+ *  represents future engine-lib voice families. Renders with a muted
+ *  outline and no toggle / Manage voices link.
+ * @property defaultEnabled Whether a fresh install seeds this family's
+ *  toggle as ON.
+ * @property engineFamily Categorisation chip shown on the card —
+ *  "Local" (on-device synth) or "Cloud" (network-backed).
+ */
+data class VoiceFamilyDescriptor(
+    val id: String,
+    val displayName: String,
+    val description: String,
+    val sourceUrl: String,
+    val license: String,
+    val sizeHint: String,
+    val requiresConfiguration: Boolean = false,
+    val isPlaceholder: Boolean = false,
+    val defaultEnabled: Boolean = true,
+    val engineFamily: VoiceEngineFamily = VoiceEngineFamily.Local,
+)
+
+/** Coarse engine classification for the family card's capability chip. */
+enum class VoiceEngineFamily { Local, Cloud }
+
+/**
+ * Canonical voice-family ids — also the keys in
+ * `UiSettings.voiceFamiliesEnabled`. Kept as constants so consumers
+ * (Voice Library filter, Plugin Manager card row, settings codec)
+ * don't drift on string literals.
+ */
+object VoiceFamilyIds {
+    const val PIPER = "voice_piper"
+    const val KOKORO = "voice_kokoro"
+    const val KITTEN = "voice_kitten"
+    const val AZURE = "voice_azure"
+    /** Placeholder for future engine-lib voice families. Has no
+     *  toggle in the manager card — exists so users can see the
+     *  shape of "the next thing that lands here". */
+    const val VOXSHERPA_UPSTREAMS = "voice_voxsherpa_upstreams"
+}
+
+/**
+ * Plugin-seam Phase 4 (#501) — runtime registry of every voice family
+ * the Plugin Manager surfaces as a brass-edged card.
+ *
+ * The list is **static** today: the four installed engines plus the
+ * VoxSherpa-upstreams placeholder. Each [VoiceFamilyDescriptor] is
+ * declarative metadata — the engine code itself (`KokoroEngine`,
+ * `KittenEngine`, `AzureVoiceEngine`) is wired through the playback
+ * pipeline independently of this registry.
+ *
+ * Adding a new family is a two-line change here. When a `:source-foo`
+ * module lands and wants to surface a new family card without touching
+ * this file, the natural next step is to migrate the list to a Hilt
+ * multibinding (`Set<VoiceFamilyDescriptor>`), mirroring
+ * `SourcePluginRegistry`. The static list is the cheaper Phase-4 form
+ * for the four in-tree families.
+ *
+ * The `voiceFamily` extension on [EngineType] (in this file's
+ * companion code) maps a per-voice [EngineType] to the matching family
+ * id, so the Voice Library can filter voices by enabled family in O(N)
+ * without touching the registry itself.
+ */
+@Singleton
+class VoiceFamilyRegistry @Inject constructor() {
+
+    /** All known voice families, in display order. The
+     *  in-process families come first (Piper / Kokoro / Kitten),
+     *  then cloud (Azure), then placeholders. */
+    val descriptors: List<VoiceFamilyDescriptor> = listOf(
+        VoiceFamilyDescriptor(
+            id = VoiceFamilyIds.PIPER,
+            displayName = "Piper",
+            description = "Local neural voices · per-voice ONNX download",
+            sourceUrl = "https://github.com/rhasspy/piper-voices",
+            license = "MIT (sherpa-onnx) · CC-BY / CC0 voice datasets",
+            sizeHint = "~14–30 MB per voice (low / medium tier), ~120 MB high tier",
+            defaultEnabled = true,
+            engineFamily = VoiceEngineFamily.Local,
+        ),
+        VoiceFamilyDescriptor(
+            id = VoiceFamilyIds.KOKORO,
+            displayName = "Kokoro",
+            description = "Local multi-speaker · one shared ~330 MB model",
+            sourceUrl = "https://huggingface.co/hexgrad/Kokoro-82M",
+            license = "Apache 2.0",
+            sizeHint = "~330 MB single download, 53 speakers share the model",
+            defaultEnabled = true,
+            engineFamily = VoiceEngineFamily.Local,
+        ),
+        VoiceFamilyDescriptor(
+            id = VoiceFamilyIds.KITTEN,
+            displayName = "KittenTTS",
+            description = "Local lightweight · ~24 MB shared, 8 en_US speakers",
+            sourceUrl = "https://github.com/KittenML/KittenTTS",
+            license = "Apache 2.0",
+            sizeHint = "~24 MB shared model, 8 en_US speakers (F1–F4 / M1–M4)",
+            defaultEnabled = true,
+            engineFamily = VoiceEngineFamily.Local,
+        ),
+        VoiceFamilyDescriptor(
+            id = VoiceFamilyIds.AZURE,
+            displayName = "Azure HD voices",
+            description = "Cloud · BYOK · Dragon HD + Multilingual + Neural tiers",
+            sourceUrl = "https://learn.microsoft.com/en-us/azure/ai-services/speech-service/language-support",
+            license = "Proprietary · billed by Azure ($30 / 1M chars)",
+            sizeHint = "0 MB local — synthesis happens server-side",
+            requiresConfiguration = true,
+            // Default OFF so a fresh install doesn't pretend to have Azure
+            // voices ready; the user opts in by configuring credentials.
+            defaultEnabled = false,
+            engineFamily = VoiceEngineFamily.Cloud,
+        ),
+        VoiceFamilyDescriptor(
+            id = VoiceFamilyIds.VOXSHERPA_UPSTREAMS,
+            displayName = "VoxSherpa upstreams",
+            description = "Placeholder for future engine-lib voice families",
+            sourceUrl = "https://github.com/techempower-org/VoxSherpa-TTS",
+            license = "—",
+            sizeHint = "—",
+            isPlaceholder = true,
+            defaultEnabled = false,
+            engineFamily = VoiceEngineFamily.Local,
+        ),
+    )
+
+    /** Lookup by stable family id. */
+    fun byId(id: String): VoiceFamilyDescriptor? = descriptors.firstOrNull { it.id == id }
+
+    /** All non-placeholder family ids — the set that participates in
+     *  Voice Library filtering. The placeholder has no voices and is
+     *  never toggled. */
+    val toggleableIds: List<String> = descriptors.filterNot { it.isPlaceholder }.map { it.id }
+}
+
+/**
+ * Map a per-voice [EngineType] to the [VoiceFamilyDescriptor.id] that
+ * owns it. Used by the Voice Library filter to hide voices belonging
+ * to a disabled family.
+ *
+ * Unknown engine types fall back to [VoiceFamilyIds.VOXSHERPA_UPSTREAMS]
+ * — they're never enabled, so unrecognised engines surface as filtered
+ * out by default. This keeps a future `EngineType.Foo` from leaking
+ * into the Voice Library before its family card lands.
+ */
+fun EngineType.voiceFamilyId(): String = when (this) {
+    is EngineType.Piper -> VoiceFamilyIds.PIPER
+    is EngineType.Kokoro -> VoiceFamilyIds.KOKORO
+    is EngineType.Kitten -> VoiceFamilyIds.KITTEN
+    is EngineType.Azure -> VoiceFamilyIds.AZURE
+}

--- a/core-playback/src/test/kotlin/in/jphe/storyvox/playback/voice/VoiceFamilyRegistryTest.kt
+++ b/core-playback/src/test/kotlin/in/jphe/storyvox/playback/voice/VoiceFamilyRegistryTest.kt
@@ -1,0 +1,83 @@
+package `in`.jphe.storyvox.playback.voice
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * Plugin-seam Phase 4 (#501) — registry shape + EngineType mapping
+ * tests for [VoiceFamilyRegistry].
+ *
+ * Lives in `:core-playback` (the registry's home module) so the
+ * `EngineType.voiceFamilyId()` extension can be exercised against
+ * each [EngineType] variant directly. The Plugin Manager card
+ * filter logic is covered separately in
+ * `:feature`'s `VoiceFamilyFilterTest`.
+ */
+class VoiceFamilyRegistryTest {
+
+    @Test fun `registry exposes Piper Kokoro Kitten Azure and the upstream placeholder`() {
+        val registry = VoiceFamilyRegistry()
+        val ids = registry.descriptors.map { it.id }
+        assertEquals(
+            "Registry should ship exactly five descriptors today",
+            5,
+            registry.descriptors.size,
+        )
+        assertTrue(VoiceFamilyIds.PIPER in ids)
+        assertTrue(VoiceFamilyIds.KOKORO in ids)
+        assertTrue(VoiceFamilyIds.KITTEN in ids)
+        assertTrue(VoiceFamilyIds.AZURE in ids)
+        assertTrue(VoiceFamilyIds.VOXSHERPA_UPSTREAMS in ids)
+    }
+
+    @Test fun `byId returns null for unknown ids`() {
+        val registry = VoiceFamilyRegistry()
+        assertEquals(null, registry.byId("voice_does_not_exist"))
+    }
+
+    @Test fun `EngineType Piper maps to PIPER family`() {
+        assertEquals(VoiceFamilyIds.PIPER, EngineType.Piper.voiceFamilyId())
+    }
+
+    @Test fun `EngineType Kokoro maps to KOKORO family regardless of speakerId`() {
+        assertEquals(VoiceFamilyIds.KOKORO, EngineType.Kokoro(speakerId = 0).voiceFamilyId())
+        assertEquals(VoiceFamilyIds.KOKORO, EngineType.Kokoro(speakerId = 52).voiceFamilyId())
+    }
+
+    @Test fun `EngineType Kitten maps to KITTEN family regardless of speakerId`() {
+        assertEquals(VoiceFamilyIds.KITTEN, EngineType.Kitten(speakerId = 0).voiceFamilyId())
+        assertEquals(VoiceFamilyIds.KITTEN, EngineType.Kitten(speakerId = 7).voiceFamilyId())
+    }
+
+    @Test fun `EngineType Azure maps to AZURE family regardless of voice name`() {
+        assertEquals(
+            VoiceFamilyIds.AZURE,
+            EngineType.Azure(voiceName = "en-US-AvaDragonHDLatestNeural", region = "eastus").voiceFamilyId(),
+        )
+    }
+
+    @Test fun `placeholder descriptor is not toggleable`() {
+        val registry = VoiceFamilyRegistry()
+        val placeholder = registry.byId(VoiceFamilyIds.VOXSHERPA_UPSTREAMS)
+        assertNotNull(placeholder)
+        assertTrue(placeholder!!.isPlaceholder)
+        assertFalse(VoiceFamilyIds.VOXSHERPA_UPSTREAMS in registry.toggleableIds)
+    }
+
+    @Test fun `every voice in VoiceCatalog maps to a known family`() {
+        val knownFamilies = VoiceFamilyRegistry().descriptors.mapTo(mutableSetOf()) { it.id }
+        // VoiceCatalog.voices covers Piper / Kokoro / Kitten (Azure is
+        // populated at runtime from the roster, not here). Every static
+        // catalog entry's engine should land on a registered family.
+        VoiceCatalog.voices.forEach { entry ->
+            val familyId = entry.engineType.voiceFamilyId()
+            assertTrue(
+                "Voice ${entry.id} (engine ${entry.engineType}) maps to $familyId which is not in the registry",
+                familyId in knownFamilies,
+            )
+        }
+    }
+}

--- a/feature/src/main/kotlin/in/jphe/storyvox/feature/api/UiContracts.kt
+++ b/feature/src/main/kotlin/in/jphe/storyvox/feature/api/UiContracts.kt
@@ -865,6 +865,22 @@ data class UiSettings(
      * migration completes still surfaces the right default-on chips.
      */
     val sourcePluginsEnabled: Map<String, Boolean> = emptyMap(),
+    /**
+     * Plugin-seam Phase 4 (#501) — per-voice-family on/off keyed by
+     * stable family id (`voice_piper`, `voice_kokoro`, `voice_kitten`,
+     * `voice_azure`). Twin of [sourcePluginsEnabled] for the Plugin
+     * Manager's Voice bundles section.
+     *
+     * When a family id maps to `false`, voices belonging to that
+     * family are filtered out of the Voice Library and the picker.
+     * Missing ids fall through to each family's `defaultEnabled` in
+     * [`in.jphe.storyvox.playback.voice.VoiceFamilyRegistry`].
+     *
+     * Reads: a fresh install sees an empty map and every family
+     * resolves to its declared default; subsequent toggles route
+     * through `SettingsRepositoryUi.setVoiceFamilyEnabled(id, enabled)`.
+     */
+    val voiceFamiliesEnabled: Map<String, Boolean> = emptyMap(),
     /** Notion database id (#233 + #390). Defaults to the baked-in
      *  techempower.org placeholder from `NotionDefaults`; existing
      *  users with a different stored value keep it. Notion accepts
@@ -1457,6 +1473,16 @@ interface SettingsRepositoryUi {
      * collapsed into this one entry point.
      */
     suspend fun setSourcePluginEnabled(id: String, enabled: Boolean)
+
+    /**
+     * Plugin-seam Phase 4 (#501) — toggle a voice family by its stable
+     * id (`voice_piper`, `voice_kokoro`, `voice_kitten`, `voice_azure`).
+     * Updates [UiSettings.voiceFamiliesEnabled]; the Voice Library
+     * projection filters voices whose engine type maps to a disabled
+     * family. Unknown ids are still written so a future family that
+     * pre-toggles its state before its registry entry lands round-trips.
+     */
+    suspend fun setVoiceFamilyEnabled(id: String, enabled: Boolean)
 
     /** Issue #245 — Outline self-hosted-wiki backend config. */
     val outlineHost: Flow<String>

--- a/feature/src/main/kotlin/in/jphe/storyvox/feature/settings/plugins/PluginManagerScreen.kt
+++ b/feature/src/main/kotlin/in/jphe/storyvox/feature/settings/plugins/PluginManagerScreen.kt
@@ -36,6 +36,7 @@ import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Switch
 import androidx.compose.material3.SwitchDefaults
 import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
 import androidx.compose.material3.rememberModalBottomSheetState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
@@ -53,35 +54,48 @@ import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import `in`.jphe.storyvox.data.source.plugin.SourcePluginDescriptor
+import `in`.jphe.storyvox.playback.voice.VoiceEngineFamily
+import `in`.jphe.storyvox.playback.voice.VoiceFamilyDescriptor
 import `in`.jphe.storyvox.ui.component.fictionMonogram
 import `in`.jphe.storyvox.ui.theme.LocalSpacing
 
 /**
- * Plugin manager screen (#404) — Settings → Plugins.
+ * Plugin manager screen (#404, #501) — Settings → Plugins.
  *
  * Registry-driven brass-edged card list. Each card has:
  *  - Brass monogram icon (`fictionMonogram(displayName)`).
  *  - Display name + plugin description (subtitle).
- *  - Capability chips (Follow, Search, Audio, Anonymous/PAT).
+ *  - Capability chips (Follow, Search, Audio, Anonymous/PAT for
+ *    fiction sources; Local/Cloud + size hint for voice families).
  *  - Brass-edged switch.
  *  - Tap to open details sheet.
  *
  * Three category sections: Fiction sources, Audio streams, Voice
- * bundles (placeholder for v2).
+ * bundles. As of v0.5.49 (#501) the Voice bundles section is fully
+ * iterated — Piper / Kokoro / KittenTTS / Azure HD cards plus the
+ * VoxSherpa upstreams placeholder, all sourced from
+ * `VoiceFamilyRegistry`.
  *
  * The top of the screen has a search input + 3 filter chips
  * (On / Off / All). Search is substring on displayName/description/id.
+ *
+ * The Voice bundle cards delegate to a `onOpenVoiceLibrary` callback
+ * (wired by the NavHost) for the "Manage voices →" link, and to
+ * `onOpenAzureSettings` for the Azure family's BYOK configure CTA.
  */
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun PluginManagerScreen(
     onNavigateBack: () -> Unit,
+    onOpenVoiceLibrary: () -> Unit = {},
+    onOpenAzureSettings: () -> Unit = {},
     viewModel: PluginManagerViewModel = hiltViewModel(),
 ) {
     val state by viewModel.uiState.collectAsStateWithLifecycle()
     val spacing = LocalSpacing.current
 
     var detailsForId by remember { mutableStateOf<String?>(null) }
+    var voiceFamilyDetailsForId by remember { mutableStateOf<String?>(null) }
 
     val sections = remember(state.plugins) { groupPluginsForManager(state.plugins) }
     val fictionVisible = remember(sections.fiction, state.searchQuery, state.filterChip) {
@@ -89,6 +103,9 @@ fun PluginManagerScreen(
     }
     val audioVisible = remember(sections.audio, state.searchQuery, state.filterChip) {
         filterPlugins(sections.audio, state.searchQuery, state.filterChip)
+    }
+    val voiceFamiliesVisible = remember(state.voiceFamilies, state.searchQuery, state.filterChip) {
+        filterVoiceFamilies(state.voiceFamilies, state.searchQuery, state.filterChip)
     }
 
     Scaffold(
@@ -181,26 +198,29 @@ fun PluginManagerScreen(
                 )
             }
 
-            // Voice bundles — v2 placeholder
+            // Voice bundles section (#501) — Piper / Kokoro / Kitten /
+            // Azure HD cards + VoxSherpa upstreams placeholder, all
+            // sourced from VoiceFamilyRegistry. Each card has the
+            // same brass-edged shape as the fiction cards.
             item("voice-header") {
                 CategoryHeader(
                     title = "Voice bundles",
-                    count = 0,
+                    count = voiceFamiliesVisible.count { !it.descriptor.isPlaceholder },
                 )
             }
-            item("voice-coming-soon") {
-                Text(
-                    "Coming in v2: voice bundle registry. Voice files will surface here as " +
-                        "`@SourcePlugin`-style annotations land.",
-                    style = MaterialTheme.typography.bodySmall,
-                    color = MaterialTheme.colorScheme.onSurfaceVariant,
-                    modifier = Modifier.padding(horizontal = spacing.sm),
+            items(voiceFamiliesVisible) { row ->
+                VoiceFamilyCard(
+                    row = row,
+                    onToggle = { enabled -> viewModel.toggleVoiceFamily(row.descriptor.id, enabled) },
+                    onTap = { voiceFamilyDetailsForId = row.descriptor.id },
+                    onManageVoices = onOpenVoiceLibrary,
+                    onConfigure = onOpenAzureSettings,
                 )
             }
         }
     }
 
-    // Details sheet
+    // Fiction / Audio source details sheet
     val detailRow = state.plugins.firstOrNull { it.descriptor.id == detailsForId }
     if (detailRow != null) {
         val sheetState = rememberModalBottomSheetState(skipPartiallyExpanded = true)
@@ -209,6 +229,28 @@ fun PluginManagerScreen(
             sheetState = sheetState,
         ) {
             PluginDetailsContent(row = detailRow)
+        }
+    }
+
+    // Voice family details sheet (#501)
+    val voiceFamilyDetailRow = state.voiceFamilies.firstOrNull { it.descriptor.id == voiceFamilyDetailsForId }
+    if (voiceFamilyDetailRow != null) {
+        val sheetState = rememberModalBottomSheetState(skipPartiallyExpanded = true)
+        ModalBottomSheet(
+            onDismissRequest = { voiceFamilyDetailsForId = null },
+            sheetState = sheetState,
+        ) {
+            VoiceFamilyDetailsContent(
+                row = voiceFamilyDetailRow,
+                onManageVoices = {
+                    voiceFamilyDetailsForId = null
+                    onOpenVoiceLibrary()
+                },
+                onConfigure = {
+                    voiceFamilyDetailsForId = null
+                    onOpenAzureSettings()
+                },
+            )
         }
     }
 }
@@ -393,5 +435,254 @@ private fun PluginDetailsContent(row: PluginManagerRow) {
             color = MaterialTheme.colorScheme.outline,
         )
         Spacer(Modifier.height(spacing.md))
+    }
+}
+
+/**
+ * Plugin-seam Phase 4 (#501) — twin of [PluginCard] for voice family
+ * rows. Same brass-edged shape; the differences are:
+ *
+ * - Subtitle is the family's declared `description` (e.g.
+ *   "Local neural voices · per-voice ONNX download").
+ * - Capability chips show **Local / Cloud / BYOK / Shared model** and
+ *   a live voice count when known.
+ * - Placeholder rows (VoxSherpa upstreams) skip the toggle and use a
+ *   muted outline so they read as "future shape preview".
+ * - The status line at the bottom carries a "Manage voices →" or
+ *   "Configure Azure key →" affordance.
+ */
+@Composable
+private fun VoiceFamilyCard(
+    row: VoiceFamilyRow,
+    onToggle: (Boolean) -> Unit,
+    onTap: () -> Unit,
+    onManageVoices: () -> Unit,
+    onConfigure: () -> Unit,
+) {
+    val spacing = LocalSpacing.current
+    val brass = MaterialTheme.colorScheme.primary
+    val brassColors = SwitchDefaults.colors(
+        checkedThumbColor = brass,
+        checkedTrackColor = MaterialTheme.colorScheme.primaryContainer,
+        checkedBorderColor = brass,
+        uncheckedThumbColor = MaterialTheme.colorScheme.outline,
+    )
+    val descriptor = row.descriptor
+    val borderColor = when {
+        descriptor.isPlaceholder -> MaterialTheme.colorScheme.outlineVariant
+        row.enabled -> brass
+        else -> MaterialTheme.colorScheme.outlineVariant
+    }
+    Column(
+        modifier = Modifier
+            .fillMaxWidth()
+            .clip(RoundedCornerShape(12.dp))
+            .border(width = 1.dp, color = borderColor, shape = RoundedCornerShape(12.dp))
+            .background(MaterialTheme.colorScheme.surface)
+            .clickable(
+                role = Role.Button,
+                onClickLabel = "Open ${descriptor.displayName} details",
+                onClick = onTap,
+            )
+            .padding(spacing.md),
+        verticalArrangement = Arrangement.spacedBy(spacing.sm),
+    ) {
+        Row(
+            verticalAlignment = Alignment.CenterVertically,
+            horizontalArrangement = Arrangement.spacedBy(spacing.md),
+        ) {
+            Box(
+                modifier = Modifier
+                    .size(40.dp)
+                    .clip(CircleShape)
+                    .background(MaterialTheme.colorScheme.primaryContainer),
+                contentAlignment = Alignment.Center,
+            ) {
+                Text(
+                    text = fictionMonogram(descriptor.displayName, descriptor.displayName),
+                    style = MaterialTheme.typography.titleMedium,
+                    fontWeight = FontWeight.SemiBold,
+                    color = MaterialTheme.colorScheme.onPrimaryContainer,
+                )
+            }
+            Column(modifier = Modifier.weight(1f)) {
+                Text(
+                    descriptor.displayName,
+                    style = MaterialTheme.typography.titleMedium,
+                    fontWeight = FontWeight.Medium,
+                )
+                if (descriptor.description.isNotBlank()) {
+                    Text(
+                        descriptor.description,
+                        style = MaterialTheme.typography.bodySmall,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    )
+                }
+            }
+            // Placeholder rows have no toggle — they're for visibility,
+            // not user control.
+            if (!descriptor.isPlaceholder) {
+                val toggleLabel = "Enable ${descriptor.displayName}"
+                Switch(
+                    checked = row.enabled,
+                    onCheckedChange = onToggle,
+                    colors = brassColors,
+                    modifier = Modifier.semantics { contentDescription = toggleLabel },
+                )
+            }
+        }
+        Row(horizontalArrangement = Arrangement.spacedBy(spacing.xs)) {
+            CapabilityChip(
+                when (descriptor.engineFamily) {
+                    VoiceEngineFamily.Local -> "Local"
+                    VoiceEngineFamily.Cloud -> "Cloud"
+                },
+            )
+            if (descriptor.requiresConfiguration) {
+                CapabilityChip(if (row.isConfigured) "BYOK ✓" else "BYOK")
+            }
+            // Voice count chip — surfaced for non-Azure families (Azure
+            // count is roster-dependent and shown in the details modal
+            // as the size hint string instead).
+            if (!descriptor.requiresConfiguration && !descriptor.isPlaceholder) {
+                CapabilityChip(
+                    if (row.voiceCount == 1) "1 voice" else "${row.voiceCount} voices",
+                )
+            }
+            if (descriptor.isPlaceholder) {
+                CapabilityChip("Coming soon")
+            }
+        }
+        // Bottom row: status + manage-voices link.
+        // - For placeholder: just a status line.
+        // - For Azure unconfigured: "Configure Azure key →".
+        // - For everything else: "Manage voices →".
+        if (descriptor.isPlaceholder) {
+            Text(
+                "Future engine-lib families will surface here.",
+                style = MaterialTheme.typography.labelSmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
+        } else {
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                verticalAlignment = Alignment.CenterVertically,
+                horizontalArrangement = Arrangement.SpaceBetween,
+            ) {
+                Text(
+                    "Status: ${if (row.enabled) "enabled" else "disabled"} · Tap for details",
+                    style = MaterialTheme.typography.labelSmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                )
+                if (descriptor.requiresConfiguration && !row.isConfigured) {
+                    TextButton(onClick = onConfigure) {
+                        Text("Configure →", style = MaterialTheme.typography.labelMedium)
+                    }
+                } else {
+                    TextButton(onClick = onManageVoices) {
+                        Text("Manage voices →", style = MaterialTheme.typography.labelMedium)
+                    }
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun VoiceFamilyDetailsContent(
+    row: VoiceFamilyRow,
+    onManageVoices: () -> Unit,
+    onConfigure: () -> Unit,
+) {
+    val spacing = LocalSpacing.current
+    val descriptor: VoiceFamilyDescriptor = row.descriptor
+    Column(
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(horizontal = spacing.lg, vertical = spacing.md),
+        verticalArrangement = Arrangement.spacedBy(spacing.sm),
+    ) {
+        Text(
+            descriptor.displayName,
+            style = MaterialTheme.typography.headlineSmall,
+        )
+        if (descriptor.description.isNotBlank()) {
+            Text(
+                descriptor.description,
+                style = MaterialTheme.typography.bodyMedium,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
+        }
+        HorizontalDivider(modifier = Modifier.padding(vertical = spacing.sm))
+        DetailRow(label = "Engine", value = when (descriptor.engineFamily) {
+            VoiceEngineFamily.Local -> "Local (on-device)"
+            VoiceEngineFamily.Cloud -> "Cloud (network)"
+        })
+        // Voice count: -1 sentinel = "roster not yet loaded" for Azure
+        // when configured. 0 = no voices (Azure not configured, or
+        // placeholder). Otherwise show the static-catalog count.
+        DetailRow(label = "Voices", value = when {
+            descriptor.isPlaceholder -> "—"
+            row.voiceCount == -1 -> "Live from Azure roster"
+            row.voiceCount == 0 && descriptor.requiresConfiguration -> "Configure to load roster"
+            else -> "${row.voiceCount}"
+        })
+        if (descriptor.sizeHint.isNotBlank()) {
+            DetailRow(label = "Size", value = descriptor.sizeHint)
+        }
+        if (descriptor.license.isNotBlank()) {
+            DetailRow(label = "License", value = descriptor.license)
+        }
+        if (descriptor.sourceUrl.isNotBlank()) {
+            DetailRow(label = "Source", value = descriptor.sourceUrl)
+        }
+        if (descriptor.requiresConfiguration) {
+            DetailRow(
+                label = "Status",
+                value = if (row.isConfigured) "Configured" else "Not configured",
+            )
+        }
+        if (row.activeVoiceId != null) {
+            DetailRow(label = "Current voice", value = row.activeVoiceId)
+        }
+        Text(
+            "Family id: ${descriptor.id}",
+            style = MaterialTheme.typography.labelSmall,
+            color = MaterialTheme.colorScheme.outline,
+        )
+        Spacer(Modifier.height(spacing.sm))
+        if (!descriptor.isPlaceholder) {
+            if (descriptor.requiresConfiguration && !row.isConfigured) {
+                TextButton(onClick = onConfigure) {
+                    Text("Configure ${descriptor.displayName} →")
+                }
+            } else {
+                TextButton(onClick = onManageVoices) {
+                    Text("Manage voices →")
+                }
+            }
+        }
+        Spacer(Modifier.height(spacing.md))
+    }
+}
+
+@Composable
+private fun DetailRow(label: String, value: String) {
+    val spacing = LocalSpacing.current
+    Row(
+        modifier = Modifier.fillMaxWidth(),
+        horizontalArrangement = Arrangement.spacedBy(spacing.sm),
+    ) {
+        Text(
+            "$label:",
+            style = MaterialTheme.typography.labelMedium,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+            modifier = Modifier.weight(0.35f),
+        )
+        Text(
+            value,
+            style = MaterialTheme.typography.bodySmall,
+            modifier = Modifier.weight(0.65f),
+        )
     }
 }

--- a/feature/src/main/kotlin/in/jphe/storyvox/feature/settings/plugins/PluginManagerViewModel.kt
+++ b/feature/src/main/kotlin/in/jphe/storyvox/feature/settings/plugins/PluginManagerViewModel.kt
@@ -8,6 +8,12 @@ import `in`.jphe.storyvox.data.source.plugin.SourceCategory
 import `in`.jphe.storyvox.data.source.plugin.SourcePluginDescriptor
 import `in`.jphe.storyvox.data.source.plugin.SourcePluginRegistry
 import `in`.jphe.storyvox.feature.api.SettingsRepositoryUi
+import `in`.jphe.storyvox.playback.voice.EngineType
+import `in`.jphe.storyvox.playback.voice.VoiceCatalog
+import `in`.jphe.storyvox.playback.voice.VoiceFamilyDescriptor
+import `in`.jphe.storyvox.playback.voice.VoiceFamilyIds
+import `in`.jphe.storyvox.playback.voice.VoiceFamilyRegistry
+import `in`.jphe.storyvox.playback.voice.voiceFamilyId
 import javax.inject.Inject
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharingStarted
@@ -43,6 +49,32 @@ data class PluginManagerRow(
     val enabled: Boolean,
 )
 
+/**
+ * Plugin manager (#501) — UI row for a single voice family card.
+ *
+ * Twin of [PluginManagerRow] for the Voice bundles section. Wraps a
+ * [VoiceFamilyDescriptor] with:
+ * - the resolved enabled state (from `voiceFamiliesEnabled` settings
+ *   with `defaultEnabled` as fallback),
+ * - the live voice count from [VoiceCatalog] (Azure count reflects the
+ *   roster fetched at runtime; 0 when not yet loaded),
+ * - the configuration status (for BYOK families like Azure).
+ *
+ * The current-selection field is left as an id-only string so the
+ * details modal can render "Currently using: Lessac (en_US, High)"
+ * without making the row depend on the picker's rich `UiVoiceInfo`.
+ */
+@Immutable
+data class VoiceFamilyRow(
+    val descriptor: VoiceFamilyDescriptor,
+    val enabled: Boolean,
+    val voiceCount: Int,
+    val isConfigured: Boolean,
+    /** Active voice id for this family, or null when the user's
+     *  current default voice belongs to a different family. */
+    val activeVoiceId: String?,
+)
+
 /** Plugin manager (#404) — Compose-facing UI state. */
 @Immutable
 data class PluginManagerUiState(
@@ -50,23 +82,38 @@ data class PluginManagerUiState(
      *  renderer slices this by category and then filters by the
      *  search/chip state. */
     val plugins: List<PluginManagerRow> = emptyList(),
+    /** Plugin-seam Phase 4 (#501) — all voice families, regardless
+     *  of filter/search. The screen filters via [filterVoiceFamilies]. */
+    val voiceFamilies: List<VoiceFamilyRow> = emptyList(),
     val searchQuery: String = "",
     val filterChip: PluginFilterChip = PluginFilterChip.All,
 )
 
 /**
- * Plugin manager (#404) — ViewModel.
+ * Plugin manager (#404, #501) — ViewModel.
  *
- * Iterates `SourcePluginRegistry.descriptors`, joining each with the
- * user's `sourcePluginsEnabled` map (with the plugin's
- * `defaultEnabled` as fallback for unseeded ids). The Compose tree
- * filters by category + search + chip state at render time; the
- * state object stays a single source of truth and the screen handles
- * the three filter axes without needing further ViewModel state.
+ * Iterates `SourcePluginRegistry.descriptors` and
+ * `VoiceFamilyRegistry.descriptors`, joining each with the user's
+ * `sourcePluginsEnabled` / `voiceFamiliesEnabled` maps (with each
+ * descriptor's `defaultEnabled` as fallback for unseeded ids). The
+ * Compose tree filters by category + search + chip state at render
+ * time; the state object stays a single source of truth and the
+ * screen handles the three filter axes without needing further
+ * ViewModel state.
+ *
+ * Voice family rows additionally project:
+ * - voice count: `VoiceCatalog.voices` filtered by engine family, plus
+ *   the live Azure roster count when the family is Azure.
+ * - configuration status: derived from `UiSettings.azure.isConfigured`
+ *   for the Azure family; always true for local families.
+ * - active voice id: resolved by mapping the user's `defaultVoiceId`
+ *   to its `EngineType` via `VoiceCatalog.byId`, then matching the
+ *   family id.
  */
 @HiltViewModel
 class PluginManagerViewModel @Inject constructor(
     private val registry: SourcePluginRegistry,
+    private val voiceFamilyRegistry: VoiceFamilyRegistry,
     private val settings: SettingsRepositoryUi,
 ) : ViewModel() {
 
@@ -85,11 +132,56 @@ class PluginManagerViewModel @Inject constructor(
             }
         }
 
+    private val voiceFamiliesFlow: kotlinx.coroutines.flow.Flow<List<VoiceFamilyRow>> =
+        settings.settings.map { s ->
+            // Live voice count from the static catalog, grouped by
+            // family id. Azure entries from the static catalog are
+            // empty (live roster lives in AzureVoiceRoster), so the
+            // Azure count is derived separately below.
+            val staticCountsByFamily = VoiceCatalog.voices
+                .groupBy { it.engineType.voiceFamilyId() }
+                .mapValues { it.value.size }
+
+            val activeId = s.defaultVoiceId
+            val activeFamily = activeId
+                ?.let { VoiceCatalog.byId(it) }
+                ?.engineType
+                ?.voiceFamilyId()
+
+            voiceFamilyRegistry.descriptors.map { descriptor ->
+                val explicit = s.voiceFamiliesEnabled[descriptor.id]
+                val effective = explicit ?: descriptor.defaultEnabled
+                val count = when (descriptor.id) {
+                    // Azure voices live in the runtime roster, not in
+                    // the static VoiceCatalog. Surface the configured
+                    // BYOK state as a count proxy: 0 = not yet
+                    // configured, ~330 = Dragon HD eastus rendered
+                    // count. The Plugin Manager details modal shows
+                    // the size hint string regardless, so a "—" count
+                    // for "unknown until first roster fetch" is fine.
+                    VoiceFamilyIds.AZURE -> if (s.azure.isConfigured) -1 else 0
+                    else -> staticCountsByFamily[descriptor.id] ?: 0
+                }
+                val isConfigured = when (descriptor.id) {
+                    VoiceFamilyIds.AZURE -> s.azure.isConfigured
+                    else -> true
+                }
+                VoiceFamilyRow(
+                    descriptor = descriptor,
+                    enabled = effective,
+                    voiceCount = count,
+                    isConfigured = isConfigured,
+                    activeVoiceId = if (activeFamily == descriptor.id) activeId else null,
+                )
+            }
+        }
+
     val uiState: StateFlow<PluginManagerUiState> = combine(
-        pluginsFlow, _searchQuery, _filterChip,
-    ) { plugins, query, chip ->
+        pluginsFlow, voiceFamiliesFlow, _searchQuery, _filterChip,
+    ) { plugins, families, query, chip ->
         PluginManagerUiState(
             plugins = plugins,
+            voiceFamilies = families,
             searchQuery = query,
             filterChip = chip,
         )
@@ -100,6 +192,12 @@ class PluginManagerViewModel @Inject constructor(
 
     fun togglePlugin(id: String, enabled: Boolean) {
         viewModelScope.launch { settings.setSourcePluginEnabled(id, enabled) }
+    }
+
+    /** Plugin-seam Phase 4 (#501) — twin of [togglePlugin] for the
+     *  Voice bundles section. */
+    fun toggleVoiceFamily(id: String, enabled: Boolean) {
+        viewModelScope.launch { settings.setVoiceFamilyEnabled(id, enabled) }
     }
 }
 
@@ -138,14 +236,45 @@ fun filterPlugins(
 }
 
 /**
+ * Plugin manager (#501) — twin of [filterPlugins] for voice family
+ * rows. Same search/chip semantics; matches on displayName,
+ * description, and id.
+ *
+ * Placeholder rows (e.g. "VoxSherpa upstreams") are excluded from
+ * the On / Off filters since they have no toggle; they only surface
+ * under [PluginFilterChip.All].
+ */
+fun filterVoiceFamilies(
+    families: List<VoiceFamilyRow>,
+    query: String,
+    chip: PluginFilterChip,
+): List<VoiceFamilyRow> {
+    val byChip = when (chip) {
+        PluginFilterChip.On -> families.filter { it.enabled && !it.descriptor.isPlaceholder }
+        PluginFilterChip.Off -> families.filter { !it.enabled && !it.descriptor.isPlaceholder }
+        PluginFilterChip.All -> families
+    }
+    if (query.isBlank()) return byChip
+    val needle = query.trim().lowercase()
+    return byChip.filter { row ->
+        row.descriptor.displayName.lowercase().contains(needle) ||
+            row.descriptor.description.lowercase().contains(needle) ||
+            row.descriptor.id.lowercase().contains(needle)
+    }
+}
+
+/**
  * Plugin manager (#404) — group [plugins] into the manager's three
  * section buckets: Fiction sources (every Text + Ebook + Database +
  * Other category), Audio streams (AudioStream category), and the
- * Voice bundles placeholder section.
+ * Voice bundles section.
  *
- * Voice bundles aren't `@SourcePlugin`-annotated yet (the v2 voice
- * bundle registry is a follow-up issue); they render as a "Coming in
- * v2" placeholder, so the bucket is always empty in v1.
+ * As of #501 the Voice bundles bucket is populated by
+ * [VoiceFamilyRegistry] independently — voice families are not
+ * `@SourcePlugin`-annotated. The `voiceBundles` field here stays
+ * empty and the screen renders [PluginManagerUiState.voiceFamilies]
+ * directly. The field is preserved on [PluginManagerSections] for
+ * test stability.
  */
 fun groupPluginsForManager(plugins: List<PluginManagerRow>): PluginManagerSections {
     val fiction = plugins.filter { it.descriptor.category != SourceCategory.AudioStream }

--- a/feature/src/main/kotlin/in/jphe/storyvox/feature/voicelibrary/VoiceLibraryViewModel.kt
+++ b/feature/src/main/kotlin/in/jphe/storyvox/feature/voicelibrary/VoiceLibraryViewModel.kt
@@ -10,6 +10,8 @@ import `in`.jphe.storyvox.playback.voice.QualityLevel
 import `in`.jphe.storyvox.playback.voice.UiVoiceInfo
 import `in`.jphe.storyvox.playback.voice.VoiceCatalog
 import `in`.jphe.storyvox.playback.voice.VoiceEngineId
+import `in`.jphe.storyvox.playback.voice.VoiceFamilyRegistry
+import `in`.jphe.storyvox.playback.voice.voiceFamilyId
 import `in`.jphe.storyvox.playback.voice.VoiceFavorites
 import `in`.jphe.storyvox.playback.voice.VoiceLibraryCollapse
 import `in`.jphe.storyvox.playback.voice.VoiceLibrarySection
@@ -111,6 +113,11 @@ class VoiceLibraryViewModel @Inject constructor(
      *  Works. The actual key + region stay encrypted in
      *  [AzureCredentials]; this VM only needs the boolean. */
     private val settingsRepo: SettingsRepositoryUi,
+    /** #501 — voice-family registry; the Voice Library filters voices
+     *  whose family is disabled in `voiceFamiliesEnabled`. The registry
+     *  carries each family's `defaultEnabled` so an absent key falls
+     *  through to the right default. */
+    private val voiceFamilyRegistry: VoiceFamilyRegistry,
 ) : ViewModel() {
 
     private val _currentDownload = MutableStateFlow<DownloadingVoice?>(null)
@@ -151,6 +158,11 @@ class VoiceLibraryViewModel @Inject constructor(
         PerVoiceOverrides(
             lexicon = s.voiceLexiconOverrides,
             phonemizerLang = s.voicePhonemizerLangOverrides,
+            // #501 — voice-family on/off keyed by family id
+            // (`voice_piper`, `voice_kokoro`, ...). When a family is
+            // OFF its voices are filtered out of every bucket here so
+            // the picker / library never surfaces them.
+            voiceFamiliesEnabled = s.voiceFamiliesEnabled,
         )
     }
 
@@ -272,7 +284,28 @@ class VoiceLibraryViewModel @Inject constructor(
         _selectedLanguage.asStateFlow(),
         perVoiceOverrides,
     ) { state, q, lang, overrides ->
-        val withOverrides = state.copy(
+        // #501 — voice-family filter. Family ids absent from the
+        // settings map fall back to each family's `defaultEnabled` in
+        // the registry, so a fresh install (empty map) shows every
+        // default-on family's voices. Only voices whose family
+        // resolves to OFF are excluded.
+        val familyEnabled: (UiVoiceInfo) -> Boolean = { v ->
+            val familyId = v.engineType.voiceFamilyId()
+            val explicit = overrides.voiceFamiliesEnabled[familyId]
+            explicit ?: (voiceFamilyRegistry.byId(familyId)?.defaultEnabled ?: true)
+        }
+        val familyFiltered = state.copy(
+            favorites = state.favorites.filter(familyEnabled),
+            installedByEngine = state.installedByEngine.mapValues { (_, tierMap) ->
+                tierMap.mapValues { (_, voices) -> voices.filter(familyEnabled) }
+                    .filterValues { it.isNotEmpty() }
+            }.filterValues { it.isNotEmpty() },
+            availableByEngine = state.availableByEngine.mapValues { (_, tierMap) ->
+                tierMap.mapValues { (_, voices) -> voices.filter(familyEnabled) }
+                    .filterValues { it.isNotEmpty() }
+            }.filterValues { it.isNotEmpty() },
+        )
+        val withOverrides = familyFiltered.copy(
             voiceLexiconOverrides = overrides.lexicon,
             voicePhonemizerLangOverrides = overrides.phonemizerLang,
         )
@@ -433,6 +466,10 @@ class VoiceLibraryViewModel @Inject constructor(
 private data class PerVoiceOverrides(
     val lexicon: Map<String, String>,
     val phonemizerLang: Map<String, String>,
+    /** #501 — voice-family on/off map. Empty = every family enabled
+     *  by default; an explicit `false` removes the family's voices
+     *  from the picker. */
+    val voiceFamiliesEnabled: Map<String, Boolean> = emptyMap(),
 )
 
 /** Engine grouping discriminator used by the voice library UI. The

--- a/feature/src/test/kotlin/in/jphe/storyvox/feature/chat/ChatViewModelTest.kt
+++ b/feature/src/test/kotlin/in/jphe/storyvox/feature/chat/ChatViewModelTest.kt
@@ -782,6 +782,7 @@ private class FakeSettingsRepo(
         override suspend fun probeTelegramBot(): String? = null
         override suspend fun fetchTelegramChannels(): List<Pair<String, String>> = emptyList()
         override suspend fun setSourcePluginEnabled(id: String, enabled: Boolean) = Unit
+        override suspend fun setVoiceFamilyEnabled(id: String, enabled: Boolean) = Unit
         override suspend fun setNotionDatabaseId(id: String) = Unit
         override suspend fun setNotionApiToken(token: String?) = Unit
         override val outlineHost: kotlinx.coroutines.flow.Flow<String> = kotlinx.coroutines.flow.flowOf("")

--- a/feature/src/test/kotlin/in/jphe/storyvox/feature/chat/tools/ChatToolHandlersTest.kt
+++ b/feature/src/test/kotlin/in/jphe/storyvox/feature/chat/tools/ChatToolHandlersTest.kt
@@ -346,6 +346,7 @@ private class FakeSettings : SettingsRepositoryUi {
     override suspend fun signOutGitHub() = Unit
     override suspend fun setGitHubPrivateReposEnabled(enabled: Boolean) = Unit
     override suspend fun setSourcePluginEnabled(id: String, enabled: Boolean) = Unit
+    override suspend fun setVoiceFamilyEnabled(id: String, enabled: Boolean) = Unit
     override suspend fun setOutlineHost(host: String) = Unit
     override suspend fun setOutlineApiKey(apiKey: String) = Unit
     override suspend fun clearOutlineConfig() = Unit

--- a/feature/src/test/kotlin/in/jphe/storyvox/feature/settings/SettingsViewModelBufferTest.kt
+++ b/feature/src/test/kotlin/in/jphe/storyvox/feature/settings/SettingsViewModelBufferTest.kt
@@ -200,6 +200,7 @@ class SettingsViewModelBufferTest {
         override suspend fun probeTelegramBot(): String? = null
         override suspend fun fetchTelegramChannels(): List<Pair<String, String>> = emptyList()
         override suspend fun setSourcePluginEnabled(id: String, enabled: Boolean) = Unit
+        override suspend fun setVoiceFamilyEnabled(id: String, enabled: Boolean) = Unit
         override suspend fun setNotionDatabaseId(id: String) = Unit
         override suspend fun setNotionApiToken(token: String?) = Unit
         override val outlineHost: kotlinx.coroutines.flow.Flow<String> = kotlinx.coroutines.flow.flowOf("")

--- a/feature/src/test/kotlin/in/jphe/storyvox/feature/settings/SettingsViewModelModesTest.kt
+++ b/feature/src/test/kotlin/in/jphe/storyvox/feature/settings/SettingsViewModelModesTest.kt
@@ -275,6 +275,7 @@ class SettingsViewModelModesTest {
         override suspend fun probeTelegramBot(): String? = null
         override suspend fun fetchTelegramChannels(): List<Pair<String, String>> = emptyList()
         override suspend fun setSourcePluginEnabled(id: String, enabled: Boolean) = Unit
+        override suspend fun setVoiceFamilyEnabled(id: String, enabled: Boolean) = Unit
         override suspend fun setNotionDatabaseId(id: String) = Unit
         override suspend fun setNotionApiToken(token: String?) = Unit
         override val outlineHost: kotlinx.coroutines.flow.Flow<String> = kotlinx.coroutines.flow.flowOf("")

--- a/feature/src/test/kotlin/in/jphe/storyvox/feature/settings/SettingsViewModelPunctuationPauseTest.kt
+++ b/feature/src/test/kotlin/in/jphe/storyvox/feature/settings/SettingsViewModelPunctuationPauseTest.kt
@@ -213,6 +213,7 @@ class SettingsViewModelPunctuationPauseTest {
         override suspend fun probeTelegramBot(): String? = null
         override suspend fun fetchTelegramChannels(): List<Pair<String, String>> = emptyList()
         override suspend fun setSourcePluginEnabled(id: String, enabled: Boolean) = Unit
+        override suspend fun setVoiceFamilyEnabled(id: String, enabled: Boolean) = Unit
         override suspend fun setNotionDatabaseId(id: String) = Unit
         override suspend fun setNotionApiToken(token: String?) = Unit
         override val outlineHost: kotlinx.coroutines.flow.Flow<String> = kotlinx.coroutines.flow.flowOf("")

--- a/feature/src/test/kotlin/in/jphe/storyvox/feature/settings/plugins/VoiceFamilyFilterTest.kt
+++ b/feature/src/test/kotlin/in/jphe/storyvox/feature/settings/plugins/VoiceFamilyFilterTest.kt
@@ -1,0 +1,179 @@
+package `in`.jphe.storyvox.feature.settings.plugins
+
+import `in`.jphe.storyvox.playback.voice.VoiceEngineFamily
+import `in`.jphe.storyvox.playback.voice.VoiceFamilyDescriptor
+import `in`.jphe.storyvox.playback.voice.VoiceFamilyIds
+import `in`.jphe.storyvox.playback.voice.VoiceFamilyRegistry
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * Plugin manager (#501) — voice-family filter logic.
+ *
+ * Twin of [PluginManagerLogicTest] for the Voice bundles section.
+ * Covers:
+ * - [filterVoiceFamilies] with each filter chip and search query.
+ * - Placeholder family exclusion from On/Off filter buckets.
+ * - [VoiceFamilyRegistry] ships the expected family ids and counts.
+ */
+class VoiceFamilyFilterTest {
+
+    private val piper = row(VoiceFamilyIds.PIPER, "Piper", "Local Piper", enabled = true)
+    private val kokoro = row(VoiceFamilyIds.KOKORO, "Kokoro", "Local Kokoro multi-speaker", enabled = true)
+    private val kitten = row(VoiceFamilyIds.KITTEN, "KittenTTS", "Local lightweight", enabled = false)
+    private val azure = row(
+        id = VoiceFamilyIds.AZURE,
+        displayName = "Azure HD voices",
+        description = "Cloud BYOK",
+        enabled = false,
+        engineFamily = VoiceEngineFamily.Cloud,
+        requiresConfiguration = true,
+    )
+    private val placeholder = row(
+        id = VoiceFamilyIds.VOXSHERPA_UPSTREAMS,
+        displayName = "VoxSherpa upstreams",
+        description = "Future engine-lib families",
+        enabled = false,
+        isPlaceholder = true,
+    )
+
+    private val all = listOf(piper, kokoro, kitten, azure, placeholder)
+
+    // ─── filterVoiceFamilies ─────────────────────────────────────────
+
+    @Test fun `On chip keeps only enabled families and excludes placeholders`() {
+        val filtered = filterVoiceFamilies(all, query = "", chip = PluginFilterChip.On)
+        assertEquals(
+            listOf(VoiceFamilyIds.PIPER, VoiceFamilyIds.KOKORO),
+            filtered.map { it.descriptor.id },
+        )
+    }
+
+    @Test fun `Off chip keeps disabled families and excludes placeholders`() {
+        val filtered = filterVoiceFamilies(all, query = "", chip = PluginFilterChip.Off)
+        assertEquals(
+            listOf(VoiceFamilyIds.KITTEN, VoiceFamilyIds.AZURE),
+            filtered.map { it.descriptor.id },
+        )
+    }
+
+    @Test fun `All chip keeps everything including the placeholder`() {
+        val filtered = filterVoiceFamilies(all, query = "", chip = PluginFilterChip.All)
+        assertEquals(all.size, filtered.size)
+        assertTrue(filtered.any { it.descriptor.isPlaceholder })
+    }
+
+    @Test fun `search matches display name substring case-insensitively`() {
+        val filtered = filterVoiceFamilies(all, query = "AZURE", chip = PluginFilterChip.All)
+        assertEquals(listOf(VoiceFamilyIds.AZURE), filtered.map { it.descriptor.id })
+    }
+
+    @Test fun `search matches description`() {
+        val filtered = filterVoiceFamilies(all, query = "multi-speaker", chip = PluginFilterChip.All)
+        assertEquals(listOf(VoiceFamilyIds.KOKORO), filtered.map { it.descriptor.id })
+    }
+
+    @Test fun `search matches family id`() {
+        val filtered = filterVoiceFamilies(all, query = "voice_kitten", chip = PluginFilterChip.All)
+        assertEquals(listOf(VoiceFamilyIds.KITTEN), filtered.map { it.descriptor.id })
+    }
+
+    @Test fun `blank search keeps everything`() {
+        val filtered = filterVoiceFamilies(all, query = "  ", chip = PluginFilterChip.All)
+        assertEquals(all.size, filtered.size)
+    }
+
+    @Test fun `On + cloud yields only enabled cloud families`() {
+        // Azure (cloud) is disabled, Piper/Kokoro (local) are enabled —
+        // "cloud" only matches Azure description, but Azure is off.
+        val filtered = filterVoiceFamilies(all, query = "cloud", chip = PluginFilterChip.On)
+        assertTrue(filtered.isEmpty())
+    }
+
+    // ─── VoiceFamilyRegistry contract ────────────────────────────────
+
+    @Test fun `registry ships the four installed families plus the placeholder`() {
+        val registry = VoiceFamilyRegistry()
+        val ids = registry.descriptors.map { it.id }
+        assertTrue("Piper missing", VoiceFamilyIds.PIPER in ids)
+        assertTrue("Kokoro missing", VoiceFamilyIds.KOKORO in ids)
+        assertTrue("Kitten missing", VoiceFamilyIds.KITTEN in ids)
+        assertTrue("Azure missing", VoiceFamilyIds.AZURE in ids)
+        assertTrue("VoxSherpa placeholder missing", VoiceFamilyIds.VOXSHERPA_UPSTREAMS in ids)
+    }
+
+    @Test fun `toggleableIds excludes the placeholder`() {
+        val registry = VoiceFamilyRegistry()
+        assertFalse(
+            "Placeholder must not be toggleable",
+            VoiceFamilyIds.VOXSHERPA_UPSTREAMS in registry.toggleableIds,
+        )
+        // The four installed families are all toggleable.
+        assertEquals(4, registry.toggleableIds.size)
+    }
+
+    @Test fun `Azure family defaults OFF and the local families default ON`() {
+        val registry = VoiceFamilyRegistry()
+        val piperDesc = registry.byId(VoiceFamilyIds.PIPER)
+        val kokoroDesc = registry.byId(VoiceFamilyIds.KOKORO)
+        val kittenDesc = registry.byId(VoiceFamilyIds.KITTEN)
+        val azureDesc = registry.byId(VoiceFamilyIds.AZURE)
+        assertNotNull(piperDesc)
+        assertNotNull(kokoroDesc)
+        assertNotNull(kittenDesc)
+        assertNotNull(azureDesc)
+        assertTrue("Piper should default ON", piperDesc!!.defaultEnabled)
+        assertTrue("Kokoro should default ON", kokoroDesc!!.defaultEnabled)
+        assertTrue("Kitten should default ON", kittenDesc!!.defaultEnabled)
+        // Azure defaults OFF — a fresh install shouldn't pretend the
+        // BYOK family is "ready" until credentials are configured.
+        assertFalse("Azure should default OFF", azureDesc!!.defaultEnabled)
+    }
+
+    @Test fun `Azure family carries the requiresConfiguration flag`() {
+        val registry = VoiceFamilyRegistry()
+        val azureDesc = registry.byId(VoiceFamilyIds.AZURE)
+        assertNotNull(azureDesc)
+        assertTrue(azureDesc!!.requiresConfiguration)
+    }
+
+    @Test fun `Piper Kokoro and Kitten are Local Azure is Cloud`() {
+        val registry = VoiceFamilyRegistry()
+        assertEquals(VoiceEngineFamily.Local, registry.byId(VoiceFamilyIds.PIPER)?.engineFamily)
+        assertEquals(VoiceEngineFamily.Local, registry.byId(VoiceFamilyIds.KOKORO)?.engineFamily)
+        assertEquals(VoiceEngineFamily.Local, registry.byId(VoiceFamilyIds.KITTEN)?.engineFamily)
+        assertEquals(VoiceEngineFamily.Cloud, registry.byId(VoiceFamilyIds.AZURE)?.engineFamily)
+    }
+
+    // ─── fixtures ────────────────────────────────────────────────────
+
+    private fun row(
+        id: String,
+        displayName: String,
+        description: String,
+        enabled: Boolean,
+        engineFamily: VoiceEngineFamily = VoiceEngineFamily.Local,
+        requiresConfiguration: Boolean = false,
+        isPlaceholder: Boolean = false,
+    ): VoiceFamilyRow = VoiceFamilyRow(
+        descriptor = VoiceFamilyDescriptor(
+            id = id,
+            displayName = displayName,
+            description = description,
+            sourceUrl = "",
+            license = "",
+            sizeHint = "",
+            requiresConfiguration = requiresConfiguration,
+            isPlaceholder = isPlaceholder,
+            defaultEnabled = enabled,
+            engineFamily = engineFamily,
+        ),
+        enabled = enabled,
+        voiceCount = 0,
+        isConfigured = !requiresConfiguration,
+        activeVoiceId = null,
+    )
+}


### PR DESCRIPTION
## Summary

The Plugin Manager's **Voice bundles** section grows from a v2 placeholder to a fully-iterated brass-edged card list, matching the shape of the Fiction sources section. Closes #501.

- **5 cards** surface installed voice families: **Piper** (local, per-voice ONNX), **Kokoro** (~330 MB shared, 53 speakers), **KittenTTS** (~24 MB shared, 8 en_US speakers), **Azure HD voices** (BYOK cloud), and a **VoxSherpa upstreams** placeholder for future engine-lib additions.
- **Per-card UX**: brass voice-glyph monogram + name + description; On/Off toggle that filters the family's voices out of the Voice Library; Local/Cloud/BYOK + live voice-count capability chips; tap-for-details modal with size/license/source URL/voice count/current selection/configuration status; "Manage voices →" deep-link to the Voice Library (Azure unconfigured swaps to "Configure →" routing to Settings → Cloud voices).
- **Adding a new family is one descriptor + an `EngineType` case** in `voiceFamilyId()`.

## Architecture

Picked path (c) — static `VoiceFamilyRegistry` singleton in `:core-playback` — over (a) extending `SourceCategory` (would force a nullable `FictionSource` field on `SourcePluginDescriptor`) and (b) introducing `@VoiceFamilyPlugin` (~2× scaffolding for ~4 in-tree families clustered in `:core-playback`). Full reasoning in `scratch/voice-bundles-plugin-manager/decisions.md`.

The persisted shape (`voiceFamiliesEnabled: Map<String, Boolean>` under `pref_voice_families_enabled_v1`, JSON-encoded) mirrors `sourcePluginsEnabled` exactly so an out-of-tree voice engine module could later contribute via a Hilt multibinding or graduate to `@VoiceFamilyPlugin` without breaking the registry contract.

## Cross-cutting

- `:feature/.../settings/plugins/Plugins*` — view-model + screen rewrite
- `:feature/.../voicelibrary/VoiceLibraryViewModel` — family filter folded into the existing per-voice-overrides combine slot (no new outer slot, stays at 4 args)
- `:core-data/.../plugin/VoiceFamiliesEnabledCodec` — twin of `SourcePluginsEnabledCodec`
- `:core-playback/.../voice/VoiceFamilyRegistry` — descriptor enumeration + `EngineType.voiceFamilyId()` mapper
- `:app/.../SettingsRepositoryUiImpl` — new `Keys.VOICE_FAMILIES_ENABLED_JSON` + setter + UiSettings projection
- `:app/.../navigation/StoryvoxNavHost` — `onOpenVoiceLibrary` + `onOpenAzureSettings` wired
- `UiContracts` — new `voiceFamiliesEnabled` field + `setVoiceFamilyEnabled(id, enabled)` interface method (with overrides added to all 6 `SettingsRepositoryUi` fakes)

## Test plan

- [x] `./gradlew :core-data:testDebugUnitTest` — codec round-trip (`VoiceFamiliesEnabledCodecTest`) passes
- [x] `./gradlew :core-playback:testDebugUnitTest` — registry shape + `EngineType.voiceFamilyId()` for every static catalog entry (`VoiceFamilyRegistryTest`) passes
- [x] `./gradlew :feature:testDebugUnitTest` — filter logic + On/Off/All chip semantics + placeholder exclusion (`VoiceFamilyFilterTest`) passes
- [x] `./gradlew :source-azure:testDebugUnitTest` — unchanged, passes
- [x] `./gradlew :app:assembleDebug` — debug APK builds cleanly
- [ ] Manual tablet smoke: open Settings → Plugins → scroll to Voice bundles → flip Piper off → verify Voice Library no longer surfaces Piper voices → flip Piper back on → verify they return; tap Azure card → "Configure →" routes to Settings
- [ ] Copilot review

> `:app:testDebugUnitTest` shows 2 pre-existing failures in `NavStructureTest` (commit f9ce1c3's bottom-dock change to 4 cells vs the test's pinned 2-cell contract) — unrelated to this PR; verified by stashing the change and re-running.

🤖 Generated with [Claude Code](https://claude.com/claude-code)