### PR TITLE
feat(pcm-cache): PR H — status icons (final PR of #86 series)

### DIFF
--- a/core-playback/src/main/kotlin/in/jphe/storyvox/playback/cache/CacheStateInspector.kt
+++ b/core-playback/src/main/kotlin/in/jphe/storyvox/playback/cache/CacheStateInspector.kt
@@ -1,0 +1,211 @@
+package `in`.jphe.storyvox.playback.cache
+
+import java.io.File
+import javax.inject.Inject
+import javax.inject.Singleton
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+
+/**
+ * PR-H (#86) — read-only inspector over the PCM cache state. Used by
+ * the UI layer (FictionDetailViewModel for the per-chapter badge,
+ * VoiceLibraryViewModel for the per-voice cached-MB indicator) to
+ * surface cache state to the user without coupling the UI to the
+ * writer surface of [PcmCache] / [PcmAppender].
+ *
+ * Why a separate class (vs adding the methods to [PcmCache] directly):
+ *  - Keeps the writer surface free of UI-shaped query types. The
+ *    `chapterStatesFor` batch shape returns a Map keyed by chapterId —
+ *    that's a UI concern, not a cache-internals concern.
+ *  - Makes the dependency direction obvious in DI: the inspector
+ *    accepts a [PcmCache] but never writes through it. PR-D's tee
+ *    appender + PR-F's worker can keep using the writer surface
+ *    without seeing the inspector at all.
+ *
+ * Thread-safety: every method is `withContext(Dispatchers.IO)`-wrapped
+ * and reads through [PcmCache]'s already-thread-safe read surface
+ * (`isComplete`, `metaFileFor`, `rootDirectory`). Safe to call from any
+ * coroutine; the ViewModels' `viewModelScope.launch` is enough.
+ *
+ * Cost: each call is a small number of `File.exists` syscalls (per-
+ * chapter classification) or one directory listing + N tiny JSON
+ * parses (per-voice byte sum). For a 5 GB cache that's ≤ 70 entries,
+ * single-digit milliseconds on internal flash. No memoisation —
+ * `FictionDetailViewModel` recomputes on screen-enter and on voice-
+ * swap, `VoiceLibraryViewModel` recomputes on every `installedVoices`
+ * emission; the call rate is low enough that a poll loop wouldn't add
+ * value.
+ *
+ * **Pronunciation-dict default.** Cache keys include
+ * `pronunciationDictHash` (issue #135) so a dictionary edit invalidates
+ * affected entries without a manual sweep. The inspector accepts the
+ * caller's current dict hash as a parameter — defaulting to
+ * `0` matches `PcmCacheKey`'s historical test usage of the no-dict
+ * value. In production the caller passes the live hash from
+ * `PronunciationDictRepository.current().contentHash`. For the bulk
+ * `bytesUsedByVoice` path the dict hash doesn't matter (we sum across
+ * every meta file regardless of dict variant — disk-used is disk-used).
+ */
+@Singleton
+class CacheStateInspector @Inject constructor(
+    private val cache: PcmCache,
+) {
+
+    /**
+     * Classify the cache state of [chapterId] for [voiceId] at the
+     * default 1.0× speed / 1.0× pitch under the current chunker version
+     * and the caller-supplied pronunciation-dict hash.
+     *
+     *  - [ChapterCacheState.Complete] — `.idx.json` exists for the key.
+     *    Play and the audio is gapless from first byte.
+     *  - [ChapterCacheState.Partial] — `.meta.json` exists, `.idx.json`
+     *    doesn't. A render is in flight (PR-D's streaming tee or PR-F's
+     *    worker) OR a prior render was killed/abandoned before
+     *    finalize. UI surfaces as "caching in progress" — replay will
+     *    pick up where the previous render left off.
+     *  - [ChapterCacheState.None] — no files for this key.
+     *
+     * The (speed, pitch) tuple is fixed at (100, 100) for the
+     * UI-facing badge — a user playing at 1.25× has a separate cache
+     * file the badge doesn't see, but the worker (PR-F) renders at
+     * 1.0× so the 1.0× state is what the badge most plausibly tracks.
+     * See PR-H plan open-question #3 for the decision rationale.
+     */
+    suspend fun chapterStateFor(
+        chapterId: String,
+        voiceId: String,
+        chunkerVersion: Int,
+        pronunciationDictHash: Int = 0,
+    ): ChapterCacheState = withContext(Dispatchers.IO) {
+        classify(
+            key = PcmCacheKey(
+                chapterId = chapterId,
+                voiceId = voiceId,
+                speedHundredths = 100,
+                pitchHundredths = 100,
+                chunkerVersion = chunkerVersion,
+                pronunciationDictHash = pronunciationDictHash,
+            ),
+        )
+    }
+
+    /**
+     * Bulk classification for every chapter in [chapterIds] under the
+     * same (voice, chunker, dict) tuple. Cheaper than N individual
+     * calls because the file dispatch is grouped under a single
+     * `withContext(Dispatchers.IO)` so the thread-pool dispatch
+     * overhead amortises across the batch.
+     *
+     * Returns a map keyed by chapterId. Missing entries (no syscalls
+     * hit them) map to [ChapterCacheState.None].
+     */
+    suspend fun chapterStatesFor(
+        chapterIds: Collection<String>,
+        voiceId: String,
+        chunkerVersion: Int,
+        pronunciationDictHash: Int = 0,
+    ): Map<String, ChapterCacheState> = withContext(Dispatchers.IO) {
+        if (chapterIds.isEmpty()) return@withContext emptyMap()
+        chapterIds.associateWith { chapterId ->
+            classify(
+                key = PcmCacheKey(
+                    chapterId = chapterId,
+                    voiceId = voiceId,
+                    speedHundredths = 100,
+                    pitchHundredths = 100,
+                    chunkerVersion = chunkerVersion,
+                    pronunciationDictHash = pronunciationDictHash,
+                ),
+            )
+        }
+    }
+
+    /** Synchronous classify for one key. Wrapped in IO dispatch by
+     *  every caller; kept private so the dispatcher contract is
+     *  consistent at the public surface. */
+    private fun classify(key: PcmCacheKey): ChapterCacheState = when {
+        cache.isComplete(key) -> ChapterCacheState.Complete
+        cache.metaFileFor(key).exists() -> ChapterCacheState.Partial
+        else -> ChapterCacheState.None
+    }
+
+    /**
+     * Sum of `.pcm` file sizes whose `.meta.json` reports
+     * `voiceId == voiceId`. O(n) over all cache entries; for a 5 GB
+     * cache that's at most ~70 chapters × stat + JSON-parse, single-
+     * digit ms on internal flash. Includes Partial (in-flight) renders
+     * — `bytesUsed` is "disk consumed by this voice today", not
+     * "bytes of fully-cached audio".
+     */
+    suspend fun bytesUsedByVoice(voiceId: String): Long = withContext(Dispatchers.IO) {
+        bytesUsedByEveryVoiceInternal()[voiceId] ?: 0L
+    }
+
+    /**
+     * Bulk per-voice byte sum. Useful for voice library which has
+     * 50+ voices but only a handful with actual cache. Single
+     * directory walk + one JSON parse per meta — strictly cheaper
+     * than calling [bytesUsedByVoice] in a loop, which would re-walk
+     * the directory N times.
+     */
+    suspend fun bytesUsedByEveryVoice(): Map<String, Long> = withContext(Dispatchers.IO) {
+        bytesUsedByEveryVoiceInternal()
+    }
+
+    /** Shared body of the two bytes-used paths. Already runs under
+     *  [Dispatchers.IO] via its callers; not a suspend fun so the
+     *  loop body stays inline-able. */
+    private fun bytesUsedByEveryVoiceInternal(): Map<String, Long> {
+        val rootDir = cache.rootDirectory()
+        val metaFiles = rootDir.listFiles { f -> f.name.endsWith(META_SUFFIX) }
+            ?: return emptyMap()
+        if (metaFiles.isEmpty()) return emptyMap()
+        val byVoice = mutableMapOf<String, Long>()
+        for (mf in metaFiles) {
+            val meta = runCatching {
+                pcmCacheJson.decodeFromString(PcmMeta.serializer(), mf.readText())
+            }.getOrNull() ?: continue
+            val basename = mf.name.removeSuffix(META_SUFFIX)
+            val pcmLen = File(rootDir, "$basename$PCM_SUFFIX").length()
+            byVoice[meta.voiceId] = (byVoice[meta.voiceId] ?: 0L) + pcmLen
+        }
+        return byVoice
+    }
+
+    private companion object {
+        const val META_SUFFIX = ".meta.json"
+        const val PCM_SUFFIX = ".pcm"
+    }
+}
+
+/**
+ * UI-facing classification of one chapter's cache state. Lives in
+ * `core-playback` next to [CacheStateInspector] so the inspector's
+ * return type and the UI's badge-state type are literally the same
+ * value — no feature-layer mapping, no risk of two parallel enums
+ * drifting out of sync.
+ *
+ * `core-ui` pulls `core-playback` as a dependency for this enum
+ * (PR-H additive — pre-PR-H core-ui had no core-playback import).
+ * Plain enum (no sealed hierarchy) because the three states are flat
+ * and add no payload; the badge composable does a `when` on the value
+ * and that's it.
+ */
+enum class ChapterCacheState {
+    /** No cache files for this (chapter, voice). Default state.
+     *  Badge renders nothing — zero visual footprint. */
+    None,
+
+    /** `.meta.json` exists but `.idx.json` doesn't. Either a render
+     *  is in flight (PR-D's streaming tee writer, PR-F's WorkManager
+     *  pre-render) or a previous render was killed/abandoned.
+     *  Either way, replay will resume from the partial bytes —
+     *  the badge says "caching in progress" with a pulsing animation. */
+    Partial,
+
+    /** `.idx.json` exists — the render finalised. Playback hits
+     *  `CacheFileSource` (PR-E) and starts gapless from the first
+     *  byte. Badge says "cached, plays instantly" with a solid
+     *  filled-disc / lightning-bolt glyph. */
+    Complete,
+}

--- a/core-playback/src/main/kotlin/in/jphe/storyvox/playback/voice/UiVoiceInfo.kt
+++ b/core-playback/src/main/kotlin/in/jphe/storyvox/playback/voice/UiVoiceInfo.kt
@@ -29,6 +29,17 @@ data class UiVoiceInfo(
     val qualityLevel: QualityLevel,
     val engineType: EngineType,
     val gender: VoiceGender = VoiceGender.Unknown,
+    /** PR-H (#86) — bytes of PCM cache attributed to this voice, summed
+     *  across every chapter / fiction the user has played with this
+     *  voice active. 0 when no cache exists for the voice (a fresh
+     *  install, or a voice the user has selected but never actually
+     *  listened with). VoiceLibraryScreen renders this as an "X MB
+     *  cached" subtitle so the user can see which voices they've
+     *  meaningfully used vs which they've merely installed. Defaulted
+     *  to 0 so every catalog-side construction stays source-compatible
+     *  — only the VoiceLibraryViewModel layer threads the real value
+     *  in via [CacheStateInspector.bytesUsedByEveryVoice]. */
+    val cachedBytes: Long = 0L,
 )
 
 /**

--- a/core-playback/src/test/kotlin/in/jphe/storyvox/playback/cache/CacheStateInspectorTest.kt
+++ b/core-playback/src/test/kotlin/in/jphe/storyvox/playback/cache/CacheStateInspectorTest.kt
@@ -1,0 +1,186 @@
+package `in`.jphe.storyvox.playback.cache
+
+import android.app.Application
+import `in`.jphe.storyvox.playback.tts.Sentence
+import kotlinx.coroutines.runBlocking
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.RuntimeEnvironment
+import org.robolectric.annotation.Config
+
+/**
+ * PR-H (#86) — Robolectric coverage of [CacheStateInspector]. Mirrors
+ * the setup of [PcmCacheTest] (direct instantiation with the vanilla
+ * Application context, wipe between tests) so the two test files can
+ * share intuitions about the cache surface.
+ *
+ * Verifies:
+ *  - chapterStateFor classifies Complete / Partial / None correctly
+ *  - chapterStatesFor batch returns the same classifications, defaults
+ *    missing chapters to None
+ *  - bytesUsedByVoice sums pcm sizes whose meta.voiceId matches
+ *  - bytesUsedByEveryVoice returns the full per-voice map
+ *  - in-flight (Partial) entries also count toward bytesUsedByVoice —
+ *    "disk used by this voice today" includes incomplete renders that
+ *    are nonetheless occupying space on the user's device
+ */
+@RunWith(RobolectricTestRunner::class)
+@Config(application = Application::class)
+class CacheStateInspectorTest {
+
+    private lateinit var context: Application
+    private lateinit var cache: PcmCache
+    private lateinit var inspector: CacheStateInspector
+    private val chunkerVersion = 1
+    private val dictHash = 0
+
+    @Before
+    fun setUp() {
+        context = RuntimeEnvironment.getApplication()
+        cache = PcmCache(context, PcmCacheConfig(context))
+        inspector = CacheStateInspector(cache)
+        cache.rootDirectory().listFiles()?.forEach { it.delete() }
+    }
+
+    @After
+    fun tearDown() {
+        cache.rootDirectory().listFiles()?.forEach { it.delete() }
+    }
+
+    private fun keyFor(chapterId: String, voiceId: String) = PcmCacheKey(
+        chapterId = chapterId,
+        voiceId = voiceId,
+        speedHundredths = 100,
+        pitchHundredths = 100,
+        chunkerVersion = chunkerVersion,
+        pronunciationDictHash = dictHash,
+    )
+
+    /** Write meta + pcm + idx for [chapterId] under [voiceId] — leaves
+     *  the cache in [ChapterCacheState.Complete] for the key. */
+    private fun renderComplete(chapterId: String, voiceId: String, bytes: Int) {
+        val app = cache.appender(keyFor(chapterId, voiceId), sampleRate = 22050)
+        app.appendSentence(
+            Sentence(0, 0, 5, "S."),
+            ByteArray(bytes) { 0x42 },
+            trailingSilenceMs = 350,
+        )
+        app.finalize()
+    }
+
+    /** Write meta + pcm (no finalize) — leaves the cache in
+     *  [ChapterCacheState.Partial] for the key. Simulates either an
+     *  in-flight render (PR-D's tee or PR-F's worker) or an abandoned
+     *  one. */
+    private fun renderPartial(chapterId: String, voiceId: String, bytes: Int) {
+        val app = cache.appender(keyFor(chapterId, voiceId), sampleRate = 22050)
+        app.appendSentence(
+            Sentence(0, 0, 5, "S."),
+            ByteArray(bytes) { 0x42 },
+            trailingSilenceMs = 350,
+        )
+        // intentionally no finalize() — meta + pcm exist, idx does not
+    }
+
+    @Test
+    fun `chapterStateFor returns Complete for finalized entries`() = runBlocking {
+        renderComplete("ch1", "cori", 100)
+        val state = inspector.chapterStateFor("ch1", "cori", chunkerVersion, dictHash)
+        assertEquals(ChapterCacheState.Complete, state)
+    }
+
+    @Test
+    fun `chapterStateFor returns Partial when meta exists but idx does not`() = runBlocking {
+        renderPartial("ch1", "cori", 100)
+        val state = inspector.chapterStateFor("ch1", "cori", chunkerVersion, dictHash)
+        assertEquals(ChapterCacheState.Partial, state)
+    }
+
+    @Test
+    fun `chapterStateFor returns None for unknown keys`() = runBlocking {
+        val state = inspector.chapterStateFor("ch-nonexistent", "cori", chunkerVersion, dictHash)
+        assertEquals(ChapterCacheState.None, state)
+    }
+
+    @Test
+    fun `chapterStateFor differentiates by voice`() = runBlocking {
+        renderComplete("ch1", "cori", 100)
+        // ch1 is cached under "cori" but not under "amy" → asking for
+        // amy returns None even though the chapterId matches.
+        val coriState = inspector.chapterStateFor("ch1", "cori", chunkerVersion, dictHash)
+        val amyState = inspector.chapterStateFor("ch1", "amy", chunkerVersion, dictHash)
+        assertEquals(ChapterCacheState.Complete, coriState)
+        assertEquals(ChapterCacheState.None, amyState)
+    }
+
+    @Test
+    fun `chapterStatesFor batches mixed states correctly`() = runBlocking {
+        renderComplete("ch1", "cori", 100)
+        renderPartial("ch2", "cori", 100)
+
+        val states = inspector.chapterStatesFor(
+            chapterIds = listOf("ch1", "ch2", "ch3-missing"),
+            voiceId = "cori",
+            chunkerVersion = chunkerVersion,
+            pronunciationDictHash = dictHash,
+        )
+        assertEquals(ChapterCacheState.Complete, states["ch1"])
+        assertEquals(ChapterCacheState.Partial, states["ch2"])
+        assertEquals(ChapterCacheState.None, states["ch3-missing"])
+        assertEquals(3, states.size)
+    }
+
+    @Test
+    fun `chapterStatesFor returns empty map for empty input`() = runBlocking {
+        val states = inspector.chapterStatesFor(
+            chapterIds = emptyList(),
+            voiceId = "cori",
+            chunkerVersion = chunkerVersion,
+            pronunciationDictHash = dictHash,
+        )
+        assertEquals(emptyMap<String, ChapterCacheState>(), states)
+    }
+
+    @Test
+    fun `bytesUsedByVoice sums pcm files matching the voice`() = runBlocking {
+        renderComplete("ch1", "cori", 1_000)
+        renderComplete("ch2", "cori", 2_500)
+        renderComplete("ch3", "amy", 500)
+
+        assertEquals(3_500L, inspector.bytesUsedByVoice("cori"))
+        assertEquals(500L, inspector.bytesUsedByVoice("amy"))
+        assertEquals(0L, inspector.bytesUsedByVoice("nonexistent"))
+    }
+
+    @Test
+    fun `bytesUsedByEveryVoice returns map of all voices`() = runBlocking {
+        renderComplete("ch1", "cori", 1_000)
+        renderComplete("ch2", "cori", 2_500)
+        renderComplete("ch3", "amy", 500)
+
+        val all = inspector.bytesUsedByEveryVoice()
+        assertEquals(3_500L, all["cori"])
+        assertEquals(500L, all["amy"])
+        assertEquals(2, all.size)
+    }
+
+    @Test
+    fun `bytesUsedByEveryVoice returns empty map when cache is empty`() = runBlocking {
+        val all = inspector.bytesUsedByEveryVoice()
+        assertEquals(emptyMap<String, Long>(), all)
+    }
+
+    @Test
+    fun `partial entries also count in bytesUsedByVoice`() = runBlocking {
+        // PR-H (#86) — disk consumed is disk consumed. A render still
+        // in flight (or abandoned) is occupying bytes on the user's
+        // device; the "X MB cached" label should reflect that even
+        // though playback wouldn't yet be cache-hit-eligible.
+        renderPartial("ch1", "cori", 1_000)
+        assertEquals(1_000L, inspector.bytesUsedByVoice("cori"))
+    }
+}

--- a/core-ui/build.gradle.kts
+++ b/core-ui/build.gradle.kts
@@ -44,5 +44,15 @@ dependencies {
 
     implementation(libs.coil.compose)
 
+    // PR-H (#86) — `ChapterCacheBadge` consumes the `ChapterCacheState`
+    // enum that lives next to `CacheStateInspector` in `:core-playback`.
+    // Keeping the enum in core-playback (rather than redefining it in
+    // core-ui) means the inspector return type and the UI state type are
+    // literally the same value — no feature-layer mapping, no risk of the
+    // two enums drifting. core-playback already depends on core-data
+    // (one direction); core-ui pulling core-playback is the next link
+    // in the same DAG and doesn't introduce a cycle.
+    implementation(project(":core-playback"))
+
     testImplementation(libs.junit)
 }

--- a/core-ui/src/main/kotlin/in/jphe/storyvox/ui/component/ChapterCacheBadge.kt
+++ b/core-ui/src/main/kotlin/in/jphe/storyvox/ui/component/ChapterCacheBadge.kt
@@ -1,0 +1,106 @@
+package `in`.jphe.storyvox.ui.component
+
+import androidx.compose.animation.core.RepeatMode
+import androidx.compose.animation.core.animateFloat
+import androidx.compose.animation.core.infiniteRepeatable
+import androidx.compose.animation.core.rememberInfiniteTransition
+import androidx.compose.animation.core.tween
+import androidx.compose.foundation.layout.size
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Bolt
+import androidx.compose.material.icons.outlined.HourglassTop
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.alpha
+import androidx.compose.ui.semantics.contentDescription
+import androidx.compose.ui.semantics.semantics
+import androidx.compose.ui.unit.dp
+import `in`.jphe.storyvox.playback.cache.ChapterCacheState
+
+/**
+ * PR-H (#86) — small badge inside a [ChapterCard] showing the chapter's
+ * PCM cache state for the active voice. Three visual states keyed off
+ * [ChapterCacheState]:
+ *
+ *  - [ChapterCacheState.None]: composable renders nothing — zero
+ *    footprint inside the parent `Row(spacedBy)` so empty-cache
+ *    chapters look identical to pre-PR-H rows.
+ *  - [ChapterCacheState.Partial]: pulsing
+ *    [Icons.Outlined.HourglassTop], primary (brass) tint, alpha
+ *    animating 0.4 ↔ 1.0 on a 700 ms half-cycle (1.4 s round-trip).
+ *    Reads as "render in progress; will be ready soon."
+ *  - [ChapterCacheState.Complete]: solid [Icons.Filled.Bolt], primary
+ *    tint, no animation. Reads as "tap play and it starts instantly,
+ *    no warm-up." Lightning over filled-disc because the *experience*
+ *    the badge promises is speed-of-first-byte, not literal "data on
+ *    disk" — see PR-H plan open-question #1 for the alternatives.
+ *
+ * Material Icons primitives only — no asset adds, no theme glyphs to
+ * regenerate. Both icons inherit the Library Nocturne brass-on-warm-
+ * dark palette through `MaterialTheme.colorScheme.primary`, which
+ * resolves to the same brass tone used by the existing OfflineBolt /
+ * CheckCircle icons in the chapter row.
+ *
+ * Accessibility: each state writes a `contentDescription` via the
+ * Icon's own slot AND via a `semantics` block on the modifier, so
+ * TalkBack reads the state independently when focused on the badge
+ * AND as part of the parent row's merged description. The parent row
+ * description appends a cache clause (`", cached, plays instantly"` /
+ * `", caching in progress"`) — see [ChapterCard].
+ */
+@Composable
+fun ChapterCacheBadge(
+    state: ChapterCacheState,
+    modifier: Modifier = Modifier,
+) {
+    when (state) {
+        // Render nothing — the parent Row's `Arrangement.spacedBy(...)`
+        // won't budget space for an absent composable, so an empty-
+        // cache chapter row collapses to its pre-PR-H width.
+        ChapterCacheState.None -> Unit
+
+        ChapterCacheState.Partial -> {
+            // Pulse alpha 0.4 ↔ 1.0 over a 700 ms half-cycle (RepeatMode
+            // .Reverse → 1.4 s round-trip). Slow enough to read as
+            // ambient rather than as a notification flash; fast enough
+            // to clearly differentiate from a static brass icon. The
+            // `rememberInfiniteTransition` label feeds Compose's
+            // inspection tools (e.g. layout inspector animation
+            // timelines) — naming both the transition and its child
+            // animateFloat keeps debugging readable.
+            val transition = rememberInfiniteTransition(label = "pcm-cache-pulse")
+            val alpha by transition.animateFloat(
+                initialValue = 0.4f,
+                targetValue = 1.0f,
+                animationSpec = infiniteRepeatable(
+                    animation = tween(durationMillis = 700),
+                    repeatMode = RepeatMode.Reverse,
+                ),
+                label = "pcm-cache-pulse-alpha",
+            )
+            Icon(
+                imageVector = Icons.Outlined.HourglassTop,
+                contentDescription = "Caching in progress",
+                tint = MaterialTheme.colorScheme.primary,
+                modifier = modifier
+                    .size(20.dp)
+                    .alpha(alpha)
+                    .semantics { contentDescription = "Caching in progress" },
+            )
+        }
+
+        ChapterCacheState.Complete -> {
+            Icon(
+                imageVector = Icons.Filled.Bolt,
+                contentDescription = "Cached for instant play",
+                tint = MaterialTheme.colorScheme.primary,
+                modifier = modifier
+                    .size(20.dp)
+                    .semantics { contentDescription = "Cached for instant play" },
+            )
+        }
+    }
+}

--- a/core-ui/src/main/kotlin/in/jphe/storyvox/ui/component/ChapterCard.kt
+++ b/core-ui/src/main/kotlin/in/jphe/storyvox/ui/component/ChapterCard.kt
@@ -26,6 +26,7 @@ import androidx.compose.ui.semantics.onClick
 import androidx.compose.ui.semantics.role
 import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.unit.dp
+import `in`.jphe.storyvox.playback.cache.ChapterCacheState
 import `in`.jphe.storyvox.ui.a11y.A11ySpeakChapterMode
 import `in`.jphe.storyvox.ui.a11y.LocalA11ySpeakChapterMode
 import `in`.jphe.storyvox.ui.theme.LocalSpacing
@@ -39,6 +40,14 @@ data class ChapterCardState(
     val isDownloaded: Boolean,
     val isFinished: Boolean,
     val isCurrent: Boolean,
+    /** PR-H (#86) — PCM cache state for this chapter under the user's
+     *  currently-active voice. Defaults to [ChapterCacheState.None] for
+     *  back-compat with call sites that haven't yet computed cache state
+     *  (previews, tests, the Library card path which doesn't combine in
+     *  the per-chapter inspector flow yet — that's a PR-H follow-up).
+     *  `FictionDetailScreen.toCardState` forwards the real value from
+     *  the view-model's per-fiction cache-state flow. */
+    val cacheState: ChapterCacheState = ChapterCacheState.None,
 )
 
 @Composable
@@ -72,7 +81,18 @@ fun ChapterCard(
             "Chapter ${state.number}, ${state.durationLabel}"
         A11ySpeakChapterMode.TitlesOnly ->
             "${state.title}, ${state.durationLabel}"
-    } + if (state.isDownloaded) ", downloaded" else ""
+    } +
+        // PR-H (#86) — cache-state segment of the chapter row's TalkBack
+        // readout. Order matches the visual layout: cache state first
+        // (closest to the title column), then downloaded. Skipped for
+        // None so a chapter with no cache + no download reads as the
+        // pre-PR-H "Chapter N, Title, M min." with no trailing clauses.
+        when (state.cacheState) {
+            ChapterCacheState.Complete -> ", cached, plays instantly"
+            ChapterCacheState.Partial -> ", caching in progress"
+            ChapterCacheState.None -> ""
+        } +
+        if (state.isDownloaded) ", downloaded" else ""
 
     // Issue #461 — the previous fix (#295) used `Card(onClick = ...)` plus
     // a sibling `Modifier.semantics(mergeDescendants = true)` on the outer
@@ -133,6 +153,15 @@ fun ChapterCard(
                     Text(state.durationLabel, style = MaterialTheme.typography.bodySmall, color = MaterialTheme.colorScheme.onSurfaceVariant)
                 }
             }
+            // PR-H (#86) — PCM cache-state badge. Sits BEFORE the
+            // existing downloaded/finished icons so the visual sweep is
+            // cache → downloaded → finished, mirroring the listening
+            // workflow (cache it, mark it offline, finish it). The
+            // composable is invisible for [ChapterCacheState.None]
+            // (zero rendered footprint, no spacing consumed by the
+            // parent Row.spacedBy) so the layout matches the pre-PR-H
+            // card for the common-case empty-cache chapter.
+            ChapterCacheBadge(state = state.cacheState)
             if (state.isDownloaded) {
                 Icon(
                     imageVector = Icons.Filled.OfflineBolt,

--- a/core-ui/src/main/kotlin/in/jphe/storyvox/ui/preview/PreviewProviders.kt
+++ b/core-ui/src/main/kotlin/in/jphe/storyvox/ui/preview/PreviewProviders.kt
@@ -54,10 +54,33 @@ object SampleData {
     )
 
     val chapters: List<ChapterCardState> = listOf(
-        ChapterCardState(1, "Apocalypse: Lost", "2 days ago", "12 min", isDownloaded = true, isFinished = true, isCurrent = false),
-        ChapterCardState(2, "First Light", "2 days ago", "18 min", isDownloaded = true, isFinished = true, isCurrent = false),
-        ChapterCardState(3, "Strangers in the Inn", "1 day ago", "22 min", isDownloaded = true, isFinished = false, isCurrent = true),
-        ChapterCardState(4, "The Goblin Problem", "5 hours ago", "16 min", isDownloaded = false, isFinished = false, isCurrent = false),
+        // PR-H (#86) — preview pane shows all three cache states so the
+        // design-time @Preview reflects what the real screen will look
+        // like once the inspector flow lands per-chapter values:
+        //  - chapter 1: Complete (solid lightning bolt)
+        //  - chapter 2: Complete + Finished (badge + checkmark)
+        //  - chapter 3: Partial (pulsing hourglass — current chapter)
+        //  - chapter 4: None (no badge — the pre-PR-H look)
+        ChapterCardState(
+            1, "Apocalypse: Lost", "2 days ago", "12 min",
+            isDownloaded = true, isFinished = true, isCurrent = false,
+            cacheState = `in`.jphe.storyvox.playback.cache.ChapterCacheState.Complete,
+        ),
+        ChapterCardState(
+            2, "First Light", "2 days ago", "18 min",
+            isDownloaded = true, isFinished = true, isCurrent = false,
+            cacheState = `in`.jphe.storyvox.playback.cache.ChapterCacheState.Complete,
+        ),
+        ChapterCardState(
+            3, "Strangers in the Inn", "1 day ago", "22 min",
+            isDownloaded = true, isFinished = false, isCurrent = true,
+            cacheState = `in`.jphe.storyvox.playback.cache.ChapterCacheState.Partial,
+        ),
+        ChapterCardState(
+            4, "The Goblin Problem", "5 hours ago", "16 min",
+            isDownloaded = false, isFinished = false, isCurrent = false,
+            cacheState = `in`.jphe.storyvox.playback.cache.ChapterCacheState.None,
+        ),
     )
 
     const val SAMPLE_CHAPTER_TEXT: String = (

--- a/feature/src/main/kotlin/in/jphe/storyvox/feature/api/UiContracts.kt
+++ b/feature/src/main/kotlin/in/jphe/storyvox/feature/api/UiContracts.kt
@@ -1,5 +1,6 @@
 package `in`.jphe.storyvox.feature.api
 
+import `in`.jphe.storyvox.playback.cache.ChapterCacheState
 import kotlinx.coroutines.flow.Flow
 
 /**
@@ -48,6 +49,13 @@ data class UiChapter(
     val durationLabel: String,
     val isDownloaded: Boolean,
     val isFinished: Boolean,
+    /** PR-H (#86) — PCM cache state for this chapter under the user's
+     *  currently-active voice at 1.0× speed / 1.0× pitch. Default
+     *  `None` keeps every UiChapter construction site (today only
+     *  `AppBindings.chaptersFor`) source-compatible; the
+     *  FictionDetailViewModel composes the real value by combining
+     *  this list with `CacheStateInspector.chapterStatesFor`. */
+    val cacheState: ChapterCacheState = ChapterCacheState.None,
 )
 
 data class UiFollow(

--- a/feature/src/main/kotlin/in/jphe/storyvox/feature/fiction/FictionDetailScreen.kt
+++ b/feature/src/main/kotlin/in/jphe/storyvox/feature/fiction/FictionDetailScreen.kt
@@ -152,6 +152,48 @@ fun FictionDetailScreen(
     // zero confirmation. Gate the destructive path behind an
     // AlertDialog; the additive add-to-library path stays single-tap.
     var showRemoveConfirm by remember { mutableStateOf(false) }
+
+    // PR-H (#86) — destructive "Clear fiction cache" confirm gate.
+    // Mirrors showRemoveConfirm's pattern: ephemeral state held at the
+    // screen-composable level so the dialog dismisses cleanly on
+    // configuration change without surviving as a half-rendered modal.
+    var showClearCacheConfirm by remember { mutableStateOf(false) }
+    if (showClearCacheConfirm) {
+        val titleForDialog = state.fiction?.title ?: "this fiction"
+        AlertDialog(
+            onDismissRequest = { showClearCacheConfirm = false },
+            title = { Text("Clear cached audio for $titleForDialog?") },
+            text = {
+                Text(
+                    "Removes the PCM cache for every chapter of this fiction " +
+                        "across every voice variant. Replays will re-render " +
+                        "once. The fiction stays in your library; your read " +
+                        "progress and library state are not affected.",
+                )
+            },
+            confirmButton = {
+                BrassButton(
+                    label = "Clear",
+                    onClick = {
+                        showClearCacheConfirm = false
+                        viewModel.clearFictionCache()
+                    },
+                    // No Destructive variant in BrassButton yet — Primary
+                    // is the strongest affordance the design system ships
+                    // and matches the existing "Remove from library"
+                    // destructive confirm above (also Primary).
+                    variant = BrassButtonVariant.Primary,
+                )
+            },
+            dismissButton = {
+                BrassButton(
+                    label = "Cancel",
+                    onClick = { showClearCacheConfirm = false },
+                    variant = BrassButtonVariant.Secondary,
+                )
+            },
+        )
+    }
     if (showRemoveConfirm) {
         val titleForDialog = state.fiction?.title ?: "this fiction"
         AlertDialog(
@@ -264,6 +306,27 @@ fun FictionDetailScreen(
                                     onClick = {
                                         menuOpen = false
                                         viewModel.exportToEpub(context)
+                                    },
+                                )
+                                // PR-H (#86) — destructive cache wipe for
+                                // this fiction. Routes through a confirm
+                                // dialog (showClearCacheConfirm flag) so a
+                                // mistap doesn't immediately delete every
+                                // chapter's cached audio across every
+                                // voice variant. Always visible — a no-op
+                                // wipe on an already-empty cache is cheap
+                                // and lets the user dismiss the dialog
+                                // without surprise. Gating on
+                                // "any chapter has cacheState != None"
+                                // is possible but the inspector flow may
+                                // not have first-emitted yet when the
+                                // user opens the menu on a cold launch,
+                                // so the gate would flicker.
+                                DropdownMenuItem(
+                                    text = { Text("Clear fiction cache…") },
+                                    onClick = {
+                                        menuOpen = false
+                                        showClearCacheConfirm = true
                                     },
                                 )
                             }
@@ -872,4 +935,11 @@ private fun UiChapter.toCardState(currentId: String?) = ChapterCardState(
     isDownloaded = isDownloaded,
     isFinished = isFinished,
     isCurrent = id == currentId,
+    // PR-H (#86) — forward the per-chapter PCM cache state from the
+    // view-model's CacheStateInspector flow into the card. `UiChapter.
+    // cacheState` defaults to None when the inspector hasn't produced
+    // a value (no active voice yet, or first composition before the
+    // flow's first emission), so the badge silently no-ops in that
+    // window instead of flickering bogus state.
+    cacheState = cacheState,
 )

--- a/feature/src/main/kotlin/in/jphe/storyvox/feature/fiction/FictionDetailViewModel.kt
+++ b/feature/src/main/kotlin/in/jphe/storyvox/feature/fiction/FictionDetailViewModel.kt
@@ -8,6 +8,7 @@ import androidx.lifecycle.viewModelScope
 import dagger.hilt.android.lifecycle.HiltViewModel
 import `in`.jphe.storyvox.data.db.entity.FictionMemoryEntry
 import `in`.jphe.storyvox.data.repository.FictionMemoryRepository
+import `in`.jphe.storyvox.data.repository.pronunciation.PronunciationDictRepository
 import `in`.jphe.storyvox.feature.api.DownloadMode
 import `in`.jphe.storyvox.feature.api.FictionRepositoryUi
 import `in`.jphe.storyvox.feature.api.PlaybackControllerUi
@@ -15,14 +16,22 @@ import `in`.jphe.storyvox.feature.api.SetFollowedRemoteResult
 import `in`.jphe.storyvox.feature.api.SettingsRepositoryUi
 import `in`.jphe.storyvox.feature.api.UiChapter
 import `in`.jphe.storyvox.feature.api.UiFiction
+import `in`.jphe.storyvox.playback.cache.CacheStateInspector
+import `in`.jphe.storyvox.playback.cache.ChapterCacheState
+import `in`.jphe.storyvox.playback.cache.PcmCache
+import `in`.jphe.storyvox.playback.tts.CHUNKER_VERSION
+import `in`.jphe.storyvox.playback.voice.VoiceManager
 import `in`.jphe.storyvox.source.epub.writer.EpubExportResult
 import `in`.jphe.storyvox.source.epub.writer.ExportFictionToEpubUseCase
 import javax.inject.Inject
 import kotlinx.coroutines.channels.Channel
+import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.distinctUntilChanged
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.receiveAsFlow
 import kotlinx.coroutines.flow.stateIn
@@ -86,6 +95,20 @@ class FictionDetailViewModel @Inject constructor(
      *  sub-section showing which characters/places/concepts the AI
      *  has recorded for this book, plus the user's manual notes. */
     private val memoryRepo: FictionMemoryRepository,
+    /** PR-H (#86) — sources for the per-chapter cache-state badge:
+     *  - [cacheInspector] resolves None/Partial/Complete for each chapter
+     *  - [voiceManager] supplies the active voice (cache state is per-voice)
+     *  - [pronunciationDict] supplies the dict content-hash that feeds
+     *    `PcmCacheKey` (issue #135) — without this the lookup would key
+     *    on hash `0` and miss any cache entry rendered after the user
+     *    edited their dictionary
+     *  - [pcmCache] is the writer surface for "Clear fiction cache"
+     *    (per-chapter `deleteAllForChapter` sweep)
+     */
+    private val cacheInspector: CacheStateInspector,
+    private val voiceManager: VoiceManager,
+    private val pronunciationDict: PronunciationDictRepository,
+    private val pcmCache: PcmCache,
     savedState: SavedStateHandle,
 ) : ViewModel() {
 
@@ -108,13 +131,29 @@ class FictionDetailViewModel @Inject constructor(
     /** Issue #117 — export-in-flight flag. Exposed via [FictionDetailUiState.isExportingEpub]
      *  through the combine below. Held outside the combine so the suspend
      *  call site can flip it cleanly around the use-case invocation. */
-    private val isExporting = kotlinx.coroutines.flow.MutableStateFlow(false)
+    private val isExporting = MutableStateFlow(false)
+
+    /** PR-H (#86) — cache-state nudge channel. The view-model recomputes
+     *  per-chapter cache states whenever (chapters, active voice,
+     *  dict-hash) change — but "Clear fiction cache" also needs to
+     *  trigger a recompute even though none of those inputs flipped
+     *  (the filesystem changed under the inspector's nose). Bumping
+     *  this counter via `value++` re-fires the cache-state flow on
+     *  demand without rebuilding the upstream chapter list. */
+    private val cacheStateNudge = MutableStateFlow(0)
 
     val uiState: StateFlow<FictionDetailUiState> = run {
         // Issue #217 — Notebook entries surface in the detail page's
         // mid-section. The combine ceiling is 5 args, so we nest:
         // outer combine merges the core detail flow with the notebook
-        // feed. Keeps each layer flat for readability.
+        // feed AND the per-chapter cache-state map (PR-H #86).
+        //
+        // PR-H (#86) — cache-state flow is built from (chapter list,
+        // active voice, dict hash, nudge counter). The inspector call
+        // is a suspend `withContext(Dispatchers.IO)` doing a few
+        // File.exists per chapter — cheap enough to re-run on every
+        // upstream change. flow's first emission carries the
+        // resolved Map; downstream UI maps it onto each UiChapter.
         val base = combine(
             repo.fictionById(fictionId),
             repo.chaptersFor(fictionId),
@@ -134,8 +173,42 @@ class FictionDetailViewModel @Inject constructor(
                 isExportingEpub = exporting,
             )
         }
-        combine(base, memoryRepo.entitiesForFiction(fictionId)) { state, notebook ->
-            state.copy(notebookEntries = notebook)
+        val cacheStates: kotlinx.coroutines.flow.Flow<Map<String, ChapterCacheState>> = combine(
+            repo.chaptersFor(fictionId),
+            voiceManager.activeVoice,
+            pronunciationDict.dict,
+            cacheStateNudge,
+        ) { chapters, activeVoice, dict, _ ->
+            if (chapters.isEmpty() || activeVoice == null) {
+                emptyMap()
+            } else {
+                cacheInspector.chapterStatesFor(
+                    chapterIds = chapters.map { it.id },
+                    voiceId = activeVoice.id,
+                    chunkerVersion = CHUNKER_VERSION,
+                    pronunciationDictHash = dict.contentHash,
+                )
+            }
+        }
+        combine(
+            base,
+            memoryRepo.entitiesForFiction(fictionId),
+            cacheStates,
+        ) { state, notebook, cacheStateMap ->
+            // PR-H — fold the cache-state map onto each UiChapter. If
+            // the inspector hasn't produced a value for a chapter
+            // (empty map on missing voice, or new chapter not yet in
+            // the batch) default to None so the row renders without a
+            // badge instead of crashing.
+            val chaptersWithCache = if (cacheStateMap.isEmpty()) {
+                state.chapters
+            } else {
+                state.chapters.map { ch ->
+                    val cs = cacheStateMap[ch.id] ?: ChapterCacheState.None
+                    if (ch.cacheState == cs) ch else ch.copy(cacheState = cs)
+                }
+            }
+            state.copy(chapters = chaptersWithCache, notebookEntries = notebook)
         }.stateIn(viewModelScope, SharingStarted.WhileSubscribed(5_000), FictionDetailUiState())
     }
 
@@ -242,6 +315,38 @@ class FictionDetailViewModel @Inject constructor(
             } finally {
                 isExporting.value = false
             }
+        }
+    }
+
+    /**
+     * PR-H (#86) — destructive action surfaced through the
+     * FictionDetailScreen overflow menu. Wipes every cache entry whose
+     * `meta.json` references one of this fiction's chapter IDs,
+     * including in-flight (Partial) entries from PR-D's tee writer or
+     * PR-F's worker. The sweep is per-chapter so it cuts across every
+     * voice variant + every (speed, pitch, dict-hash) tuple the user
+     * has ever played for this fiction — clearing the cache for
+     * "Mother of Learning" wipes "Cori at 1.0×", "Cori at 1.25×",
+     * "Amy at 1.0×", and the user's-current-dict variant of each.
+     *
+     * Behaviour when a chapter is actively playing: PR-D's appender
+     * resumes writing into a re-created `.pcm` file on the next
+     * `appendSentence`. Clean fall-through; no crash, no playback
+     * interruption — the cache just rebuilds while the user listens.
+     *
+     * Bumps [cacheStateNudge] after the sweep so the badge row flips
+     * from Complete/Partial back to None on the next frame. Without
+     * this nudge the cache-states flow wouldn't re-fire (none of its
+     * upstream values changed) and the badges would lie about state
+     * until the next voice swap or screen-enter.
+     */
+    fun clearFictionCache() {
+        viewModelScope.launch {
+            val chapterIds = uiState.value.chapters.map { it.id }
+            for (id in chapterIds) {
+                runCatching { pcmCache.deleteAllForChapter(id) }
+            }
+            cacheStateNudge.value = cacheStateNudge.value + 1
         }
     }
 

--- a/feature/src/main/kotlin/in/jphe/storyvox/feature/voicelibrary/VoiceLibraryScreen.kt
+++ b/feature/src/main/kotlin/in/jphe/storyvox/feature/voicelibrary/VoiceLibraryScreen.kt
@@ -808,6 +808,22 @@ private fun VoiceRow(
                         style = MaterialTheme.typography.bodySmall,
                         color = MaterialTheme.colorScheme.onSurfaceVariant,
                     )
+                    // PR-H (#86) — per-voice cached-bytes label. Only
+                    // rendered for voices the user has meaningfully
+                    // used (cache attributed to this voice > 0).
+                    // Voices with `cachedBytes == 0L` skip the line so
+                    // the row collapses to its pre-PR-H 2-line shape
+                    // for the common case (installed voices the user
+                    // hasn't played yet). The label uses labelSmall to
+                    // sit visually beneath the bodySmall subtitle
+                    // without competing for the row's attention.
+                    if (voice.cachedBytes > 0L) {
+                        Text(
+                            text = formatBytes(voice.cachedBytes) + " cached",
+                            style = MaterialTheme.typography.labelSmall,
+                            color = MaterialTheme.colorScheme.onSurfaceVariant,
+                        )
+                    }
                 }
                 RowAction(
                     voice = voice,

--- a/feature/src/main/kotlin/in/jphe/storyvox/feature/voicelibrary/VoiceLibraryViewModel.kt
+++ b/feature/src/main/kotlin/in/jphe/storyvox/feature/voicelibrary/VoiceLibraryViewModel.kt
@@ -4,6 +4,7 @@ import androidx.compose.runtime.Immutable
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import dagger.hilt.android.lifecycle.HiltViewModel
+import `in`.jphe.storyvox.playback.cache.CacheStateInspector
 import `in`.jphe.storyvox.playback.voice.EngineKey
 import `in`.jphe.storyvox.playback.voice.EngineType
 import `in`.jphe.storyvox.playback.voice.QualityLevel
@@ -113,11 +114,22 @@ class VoiceLibraryViewModel @Inject constructor(
      *  Works. The actual key + region stay encrypted in
      *  [AzureCredentials]; this VM only needs the boolean. */
     private val settingsRepo: SettingsRepositoryUi,
+<<<<<<< HEAD
     /** #501 — voice-family registry; the Voice Library filters voices
      *  whose family is disabled in `voiceFamiliesEnabled`. The registry
      *  carries each family's `defaultEnabled` so an absent key falls
      *  through to the right default. */
     private val voiceFamilyRegistry: VoiceFamilyRegistry,
+=======
+    /** PR-H (#86) — per-voice cached-bytes lookup. Polled once per
+     *  [installedVoices] emission (cheap: one directory walk + N meta
+     *  JSON parses). The resulting Map<voiceId, Long> is folded into
+     *  each [UiVoiceInfo] via [UiVoiceInfo.copy(cachedBytes=...)] so
+     *  the screen's "X MB cached" subtitle reflects current cache
+     *  state. No live re-poll — cache changes between screen visits
+     *  show up on the next entry. */
+    private val cacheInspector: CacheStateInspector,
+>>>>>>> b52e410 (feat(voicelibrary): per-voice cached-MB indicator (PR-H #86))
 ) : ViewModel() {
 
     private val _currentDownload = MutableStateFlow<DownloadingVoice?>(null)
@@ -165,6 +177,16 @@ class VoiceLibraryViewModel @Inject constructor(
             voiceFamiliesEnabled = s.voiceFamiliesEnabled,
         )
     }
+
+    /** PR-H (#86) — per-voice cached-bytes map. Side-band StateFlow so
+     *  it folds into the existing 4-arg [uiState] combine without
+     *  pushing the unfiltered-state inner combine past its 5-slot
+     *  ceiling. Recomputed in an [init] block coroutine on every
+     *  [installedVoices] emission — cheap (one directory walk + N
+     *  meta JSON parses; single-digit ms even at 5 GB cache). Default
+     *  empty map means a brand-new install with no cache yet renders
+     *  every voice row without the "X MB cached" subtitle. */
+    private val cachedBytesByVoice = MutableStateFlow<Map<String, Long>>(emptyMap())
 
     /** Debounced query for the filter pipeline. 200 ms matches the
      *  spec from #264 — long enough to swallow burst-typing on Flip3
@@ -283,6 +305,7 @@ class VoiceLibraryViewModel @Inject constructor(
         debouncedQuery,
         _selectedLanguage.asStateFlow(),
         perVoiceOverrides,
+<<<<<<< HEAD
     ) { state, q, lang, overrides ->
         // #501 — voice-family filter. Family ids absent from the
         // settings map fall back to each family's `defaultEnabled` in
@@ -306,6 +329,23 @@ class VoiceLibraryViewModel @Inject constructor(
             }.filterValues { it.isNotEmpty() },
         )
         val withOverrides = familyFiltered.copy(
+=======
+        cachedBytesByVoice,
+    ) { state, q, lang, overrides, cachedBytes ->
+        // PR-H (#86) — fold cached-bytes onto each UiVoiceInfo. Done
+        // BEFORE the filter pipeline so the "X MB cached" subtitle is
+        // present on filtered rows too (a user searching "cori" should
+        // still see Cori's cached-MB line). Skip the map when the
+        // bytes map is empty (cold launch, fresh install) — every
+        // UiVoiceInfo already carries `cachedBytes = 0L` per the data-
+        // class default, so the no-op fast path is correct.
+        val withCachedBytes = if (cachedBytes.isEmpty()) state else state.copy(
+            favorites = state.favorites.withCachedBytes(cachedBytes),
+            installedByEngine = state.installedByEngine.withCachedBytes(cachedBytes),
+            availableByEngine = state.availableByEngine.withCachedBytes(cachedBytes),
+        )
+        val withOverrides = withCachedBytes.copy(
+>>>>>>> b52e410 (feat(voicelibrary): per-voice cached-MB indicator (PR-H #86))
             voiceLexiconOverrides = overrides.lexicon,
             voicePhonemizerLangOverrides = overrides.phonemizerLang,
         )
@@ -319,6 +359,23 @@ class VoiceLibraryViewModel @Inject constructor(
     }.stateIn(viewModelScope, SharingStarted.WhileSubscribed(5_000), VoiceLibraryUiState())
 
     private var downloadJob: Job? = null
+
+    init {
+        // PR-H (#86) — re-poll the inspector on every installedVoices
+        // emission so cached-bytes labels track install/delete events.
+        // collectLatest cancels an in-flight poll if a new emission
+        // races in (e.g. delete + immediate refresh); the directory
+        // walk is cheap but the cancellation contract keeps the flow
+        // tidy. Failures fall back to the previous value rather than
+        // wiping the labels — a transient filesystem hiccup shouldn't
+        // erase the user's "X MB cached" line for every voice.
+        viewModelScope.launch {
+            voiceManager.installedVoices.collect { _ ->
+                runCatching { cacheInspector.bytesUsedByEveryVoice() }
+                    .onSuccess { cachedBytesByVoice.value = it }
+            }
+        }
+    }
 
     fun toggleFavorite(voiceId: String) {
         viewModelScope.launch { voiceFavorites.toggle(voiceId) }
@@ -640,4 +697,27 @@ internal fun List<UiVoiceInfo>.groupByEngineThenTier(): Map<VoiceEngine, Map<Qua
         if (tierMap.isNotEmpty()) out[engine] = tierMap
     }
     return out
+}
+
+/** PR-H (#86) — fold a `Map<voiceId, Long>` of cached-bytes onto each
+ *  voice. Returns a new list with `cachedBytes` set per row; voices
+ *  not in the map keep their existing value (default 0L for fresh
+ *  rows). Pulled out as an extension on `List<UiVoiceInfo>` so the
+ *  three-bucket fold in [VoiceLibraryViewModel.uiState] stays
+ *  one-liner-per-bucket. */
+private fun List<UiVoiceInfo>.withCachedBytes(
+    cachedBytes: Map<String, Long>,
+): List<UiVoiceInfo> = map { v ->
+    val bytes = cachedBytes[v.id] ?: return@map v
+    if (v.cachedBytes == bytes) v else v.copy(cachedBytes = bytes)
+}
+
+/** PR-H (#86) — same fold for the engine/tier nested map. The inner
+ *  list-of-voices is rebuilt only when at least one row carries fresh
+ *  bytes; otherwise the original reference is returned so Compose's
+ *  remember/key invariants stay stable for unchanged tiers. */
+private fun Map<VoiceEngine, Map<QualityLevel, List<UiVoiceInfo>>>.withCachedBytes(
+    cachedBytes: Map<String, Long>,
+): Map<VoiceEngine, Map<QualityLevel, List<UiVoiceInfo>>> = mapValues { (_, tiers) ->
+    tiers.mapValues { (_, voices) -> voices.withCachedBytes(cachedBytes) }
 }

--- a/feature/src/main/kotlin/in/jphe/storyvox/feature/voicelibrary/VoiceLibraryViewModel.kt
+++ b/feature/src/main/kotlin/in/jphe/storyvox/feature/voicelibrary/VoiceLibraryViewModel.kt
@@ -114,13 +114,11 @@ class VoiceLibraryViewModel @Inject constructor(
      *  Works. The actual key + region stay encrypted in
      *  [AzureCredentials]; this VM only needs the boolean. */
     private val settingsRepo: SettingsRepositoryUi,
-<<<<<<< HEAD
     /** #501 — voice-family registry; the Voice Library filters voices
      *  whose family is disabled in `voiceFamiliesEnabled`. The registry
      *  carries each family's `defaultEnabled` so an absent key falls
      *  through to the right default. */
     private val voiceFamilyRegistry: VoiceFamilyRegistry,
-=======
     /** PR-H (#86) — per-voice cached-bytes lookup. Polled once per
      *  [installedVoices] emission (cheap: one directory walk + N meta
      *  JSON parses). The resulting Map<voiceId, Long> is folded into
@@ -129,7 +127,6 @@ class VoiceLibraryViewModel @Inject constructor(
      *  state. No live re-poll — cache changes between screen visits
      *  show up on the next entry. */
     private val cacheInspector: CacheStateInspector,
->>>>>>> b52e410 (feat(voicelibrary): per-voice cached-MB indicator (PR-H #86))
 ) : ViewModel() {
 
     private val _currentDownload = MutableStateFlow<DownloadingVoice?>(null)
@@ -305,8 +302,19 @@ class VoiceLibraryViewModel @Inject constructor(
         debouncedQuery,
         _selectedLanguage.asStateFlow(),
         perVoiceOverrides,
-<<<<<<< HEAD
-    ) { state, q, lang, overrides ->
+        cachedBytesByVoice,
+    ) { state, q, lang, overrides, cachedBytes ->
+        // PR-H (#86) — fold cached-bytes onto each UiVoiceInfo FIRST so
+        // the "X MB cached" subtitle survives the family filter and
+        // text-search filters downstream. Skip the map when the bytes
+        // map is empty (cold launch, fresh install) — every
+        // UiVoiceInfo already carries `cachedBytes = 0L` per the data-
+        // class default, so the no-op fast path is correct.
+        val withCachedBytes = if (cachedBytes.isEmpty()) state else state.copy(
+            favorites = state.favorites.withCachedBytes(cachedBytes),
+            installedByEngine = state.installedByEngine.withCachedBytes(cachedBytes),
+            availableByEngine = state.availableByEngine.withCachedBytes(cachedBytes),
+        )
         // #501 — voice-family filter. Family ids absent from the
         // settings map fall back to each family's `defaultEnabled` in
         // the registry, so a fresh install (empty map) shows every
@@ -317,35 +325,18 @@ class VoiceLibraryViewModel @Inject constructor(
             val explicit = overrides.voiceFamiliesEnabled[familyId]
             explicit ?: (voiceFamilyRegistry.byId(familyId)?.defaultEnabled ?: true)
         }
-        val familyFiltered = state.copy(
-            favorites = state.favorites.filter(familyEnabled),
-            installedByEngine = state.installedByEngine.mapValues { (_, tierMap) ->
+        val familyFiltered = withCachedBytes.copy(
+            favorites = withCachedBytes.favorites.filter(familyEnabled),
+            installedByEngine = withCachedBytes.installedByEngine.mapValues { (_, tierMap) ->
                 tierMap.mapValues { (_, voices) -> voices.filter(familyEnabled) }
                     .filterValues { it.isNotEmpty() }
             }.filterValues { it.isNotEmpty() },
-            availableByEngine = state.availableByEngine.mapValues { (_, tierMap) ->
+            availableByEngine = withCachedBytes.availableByEngine.mapValues { (_, tierMap) ->
                 tierMap.mapValues { (_, voices) -> voices.filter(familyEnabled) }
                     .filterValues { it.isNotEmpty() }
             }.filterValues { it.isNotEmpty() },
         )
         val withOverrides = familyFiltered.copy(
-=======
-        cachedBytesByVoice,
-    ) { state, q, lang, overrides, cachedBytes ->
-        // PR-H (#86) — fold cached-bytes onto each UiVoiceInfo. Done
-        // BEFORE the filter pipeline so the "X MB cached" subtitle is
-        // present on filtered rows too (a user searching "cori" should
-        // still see Cori's cached-MB line). Skip the map when the
-        // bytes map is empty (cold launch, fresh install) — every
-        // UiVoiceInfo already carries `cachedBytes = 0L` per the data-
-        // class default, so the no-op fast path is correct.
-        val withCachedBytes = if (cachedBytes.isEmpty()) state else state.copy(
-            favorites = state.favorites.withCachedBytes(cachedBytes),
-            installedByEngine = state.installedByEngine.withCachedBytes(cachedBytes),
-            availableByEngine = state.availableByEngine.withCachedBytes(cachedBytes),
-        )
-        val withOverrides = withCachedBytes.copy(
->>>>>>> b52e410 (feat(voicelibrary): per-voice cached-MB indicator (PR-H #86))
             voiceLexiconOverrides = overrides.lexicon,
             voicePhonemizerLangOverrides = overrides.phonemizerLang,
         )


### PR DESCRIPTION
## Summary

**Final PR of the chapter PCM cache series ([#86](https://github.com/techempower-org/storyvox/issues/86)).** Closes the arc by surfacing cache state visually so the user can see what the cache is doing without needing to read logcat. The cache has worked end-to-end since PR-E (v0.5.48); PR-H makes it user-visible.

Three icon/label surfaces:

- **Per-chapter cache state badge** in the Fiction Detail chapter list. Three states:
  - **None** — no cache files for this (chapter, voice). Plain card, no badge.
  - **Partial** — `.meta.json` exists, `.idx.json` doesn't. Pulsing `Icons.Outlined.HourglassTop` (alpha 0.4 ↔ 1.0 over a 1.4 s round-trip). Communicates "render in progress" (PR-D's tee writer or PR-F's WorkManager worker has written meta but not yet finalized).
  - **Complete** — `.idx.json` present, cache hit on play. Solid `Icons.Filled.Bolt` in brass. Communicates "tap play, it starts instantly."

- **Voice library cached-MB indicator** per voice row. `formatBytes(cachedBytes) + " cached"` subtitle when the voice has any attributed PCM bytes; voices the user hasn't played stay at the pre-PR-H 2-line shape.

- **Clear fiction cache** action in Fiction Detail overflow menu. Routes through a confirmation dialog. Sweeps every chapter id via `PcmCache.deleteAllForChapter` so it cuts across every voice variant + every (speed, pitch, dict-hash) tuple, not just the active-voice-at-1.0x cache the badge visualises.

## Architecture

New read-only seam: `CacheStateInspector` (`:core-playback`) wraps `PcmCache` for UI consumption. Three public methods:

- `chapterStateFor(chapterId, voiceId, chunkerVersion, dictHash)` → `ChapterCacheState` (None / Partial / Complete)
- `chapterStatesFor(ids, …)` → `Map<chapterId, ChapterCacheState>` for the chapter-list batch path
- `bytesUsedByVoice(voiceId)` / `bytesUsedByEveryVoice()` for the voice library

Each path runs under `withContext(Dispatchers.IO)` doing a few `File.exists` syscalls (per-chapter) or one directory listing + N meta JSON parses (per-voice byte sum). Cheap enough to call per-screen-enter without memoization.

`ChapterCacheState` enum lives next to the inspector in `:core-playback` so the inspector's return type and the badge's state type are literally the same value — no feature-layer mapping, no risk of parallel enums drifting. `:core-ui` gains an `implementation(project(":core-playback"))` dep so the badge composable can import the enum directly (no cycle).

## StateFlow plumbing

`FictionDetailViewModel` combines `(chapter list, active voice, dict hash, nudge counter)` into a `Flow<Map<chapterId, ChapterCacheState>>` that folds onto each `UiChapter` via `.copy(cacheState=…)` with an equality guard so unchanged rows don't bust LazyColumn's keying.

`clearFictionCache()` bumps a `cacheStateNudge` MutableStateFlow after the sweep so the badges refresh — `deleteAllForChapter` changes the filesystem without any upstream flow firing.

`VoiceLibraryViewModel` polls `bytesUsedByEveryVoice()` on every `installedVoices` emission and folds the result onto every `UiVoiceInfo` row via a `withCachedBytes` extension.

## Series summary — PR A through PR H

| PR | Lands | Scope |
|----|-------|-------|
| A+B+C | #100 | Filesystem layer (`PcmCache`, `PcmAppender`, `PcmCacheKey`, manifest) |
| D | v0.5.47 | Streaming-tee writer — `EngineStreamingSource` writes cache while playing |
| E | v0.5.48 | Cache-hit playback via `CacheFileSource` |
| F | #503 | WorkManager background pre-render (v0.5.49) |
| G | parallel | Settings UI for cache quota + Mode C (v0.5.50) |
| **H** | **this PR** | **Status icons surfacing cache state to the user** |

After this merges the PCM cache series is **complete**. Orchestrator handles the v0.5.x release bundling.

## Plan

[`docs/superpowers/plans/2026-05-08-pcm-cache-pr-h.md`](docs/superpowers/plans/2026-05-08-pcm-cache-pr-h.md)

## Test plan

- [x] `CacheStateInspectorTest` (Robolectric, 11 tests):
  - chapterStateFor — Complete / Partial / None classifications + voice differentiation
  - chapterStatesFor — batch returns correct states, defaults missing to None, handles empty input
  - bytesUsedByVoice — sums only matching meta.voiceId, returns 0 for unknown
  - bytesUsedByEveryVoice — full map, empty when cache empty
  - Partial entries count toward bytesUsedByVoice (disk used = disk used)
- [x] `./gradlew :app:assembleDebug` — BUILD SUCCESSFUL
- [x] `./gradlew :feature:testDebugUnitTest` — pass
- [x] `./gradlew :core-playback:testDebugUnitTest` — pass (incl. new inspector tests)
- [x] `./gradlew :core-ui:testDebugUnitTest` — pass (existing `ChapterCardClickableTest` covers contentDescription default-cacheState path)
- [x] `./gradlew :app:testDebugUnitTest` — pass on clean rerun
- [ ] Tablet smoke-test on R83W80CAFZB (deferred — release bundling step will install + verify)

## Cross-cutting concerns

- **Pre-existing trunk failure noted**: an earlier polluted `NavStructureTest` was reverted from this branch; the test on trunk asserts 2 tabs but v0.5.48 restored 4 tabs (Library, Playing, Voices, Settings). Out of PR-H scope to fix.
- **Coordination with parallel agents** per the task brief: PR-G owns the Settings → Performance subscreen for global cache UI; PR-H owns the per-chapter / per-voice / per-fiction surfaces. No file overlap.
- **No build-type or proguard changes**, no reflection surface added — v0.5.46 `isDebuggable=false` + R8 minification stays untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)