### PR TITLE
refactor(auth): generalize AuthRepository for multi-source sign-in (PR1 of #426)

### DIFF
--- a/app/src/test/kotlin/in/jphe/storyvox/data/SettingsRepositoryTestSupport.kt
+++ b/app/src/test/kotlin/in/jphe/storyvox/data/SettingsRepositoryTestSupport.kt
@@ -39,15 +39,17 @@ import okhttp3.OkHttpClient
 internal class FakeAuth : AuthRepository {
     private val state = MutableStateFlow<SessionState>(SessionState.Anonymous)
     override val sessionState: StateFlow<SessionState> = state.asStateFlow()
+    override fun sessionState(sourceId: String): StateFlow<SessionState> = state.asStateFlow()
     override suspend fun captureSession(
         cookieHeader: String,
         userDisplayName: String?,
         userId: String?,
         expiresAt: Long?,
+        sourceId: String,
     ) = Unit
-    override suspend fun clearSession() = Unit
-    override suspend fun cookieHeader(): String? = null
-    override suspend fun verifyOrExpire(): SessionState = SessionState.Anonymous
+    override suspend fun clearSession(sourceId: String) = Unit
+    override suspend fun cookieHeader(sourceId: String): String? = null
+    override suspend fun verifyOrExpire(sourceId: String): SessionState = SessionState.Anonymous
 }
 
 internal class FakeHydrator : SessionHydrator {

--- a/core-data/src/main/kotlin/in/jphe/storyvox/data/auth/AuthSource.kt
+++ b/core-data/src/main/kotlin/in/jphe/storyvox/data/auth/AuthSource.kt
@@ -1,0 +1,68 @@
+package `in`.jphe.storyvox.data.auth
+
+/**
+ * Declares that a [`in`.jphe.storyvox.data.source.FictionSource] supports
+ * WebView-based sign-in (#426).
+ *
+ * Source modules contribute an [AuthSource] to the Hilt graph via
+ *
+ * ```kotlin
+ * @Binds
+ * @IntoMap
+ * @StringKey(SourceIds.ROYAL_ROAD)
+ * abstract fun bindAuthSource(impl: RoyalRoadAuthSource): AuthSource
+ * ```
+ *
+ * `:core-data`'s [`in`.jphe.storyvox.data.repository.AuthRepository] consumes
+ * the resulting `Map<String, AuthSource>` to look up per-source WebView
+ * configuration (sign-in URL, identity-cookie name, cookie host) when
+ * [`in`.jphe.storyvox.feature.auth.AuthViewModel] captures a session.
+ *
+ * Today Royal Road is the only contributor. PR2 of #426 adds AO3; the
+ * same shape will host any future source (GitHub PAT-equivalent flows
+ * keep their own auth path via [`in`.jphe.storyvox.source.github.auth.GitHubAuthRepository]
+ * for now — the WebView cookie-capture model in [AuthSource] doesn't
+ * fit token-pasting flows).
+ *
+ * Lives in `:core-data` (not `:feature`) so the data layer can route
+ * by sourceId without taking a hard dep on any source module. The
+ * source module owns the actual implementation; `:core-data` only sees
+ * this interface.
+ */
+interface AuthSource {
+
+    /**
+     * Stable sourceId this auth provider attaches to — matches the
+     * corresponding [`in`.jphe.storyvox.data.source.FictionSource.id]
+     * and the Hilt `@StringKey` used at the binding site.
+     */
+    val sourceId: String
+
+    /**
+     * URL the WebView should load to start the sign-in flow. The
+     * source-owned WebView host watches navigation and harvests
+     * cookies once [identityCookieName] appears in the host's
+     * cookie jar.
+     */
+    val signInUrl: String
+
+    /**
+     * Name of the cookie whose presence signals "login complete".
+     * Royal Road uses `.AspNetCore.Identity.Application`; AO3 uses
+     * `_otwarchive_session` (PR2 wires this).
+     *
+     * Used by the WebView capture path to decide when to deliver
+     * the captured cookie map back to [`in`.jphe.storyvox.feature.auth.AuthViewModel].
+     */
+    val identityCookieName: String
+
+    /**
+     * Host (eTLD+1, e.g. `royalroad.com`) under which to store
+     * captured cookies in the source's OkHttp [`in`.jphe.storyvox.data.auth.SessionHydrator].
+     * The hydrator implementation owns the canonical host string —
+     * exposing it here so future cross-source dispatch (e.g. choosing
+     * which hydrator to call by sourceId) doesn't need to reach into
+     * each source's internals.
+     */
+    val cookieHost: String
+}

--- a/core-data/src/main/kotlin/in/jphe/storyvox/data/repository/AuthRepository.kt
+++ b/core-data/src/main/kotlin/in/jphe/storyvox/data/repository/AuthRepository.kt
@@ -16,19 +16,43 @@ import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
+import java.util.concurrent.ConcurrentHashMap
 import javax.inject.Inject
 import javax.inject.Singleton
 
 /**
- * Owns the captured WebView session for a single source (Royal Road in v1).
+ * Owns the captured WebView session for any auth-supporting source.
+ *
+ * Originally Royal-Road-only; #426 generalizes the store so AO3 (and any
+ * future WebView-cookie-capture source) can share the same plumbing. Every
+ * method takes an optional `sourceId` parameter — callers that don't pass
+ * one get the historical Royal Road behaviour bit-identically, so existing
+ * RR sign-in / sign-out / verify call sites keep compiling and behaving.
  *
  * The actual cookie value is persisted in `EncryptedSharedPreferences` —
- * never in Room — so it doesn't end up in the SQLite plaintext file.
+ * never in Room — so it doesn't end up in the SQLite plaintext file. The
+ * encrypted-prefs key is `cookie:$sourceId` (already keyed this way pre-
+ * #426, so no migration is needed when AO3 starts writing through the
+ * same store).
+ *
+ * Per-source [SessionState] flows are kept independent: capturing an AO3
+ * session must not flip the RR state to `Authenticated` and vice versa.
+ * The legacy `sessionState` accessor returns the RR flow so existing UI
+ * observers (Settings sign-in row, [`in`.jphe.storyvox.data.work.SessionRefreshWorker])
+ * see the same stream they did before.
  */
 interface AuthRepository {
 
-    /** Hot stream of the session state. Initialized from disk on first read. */
+    /**
+     * Hot stream of the Royal Road session state, initialized from disk
+     * on first read. Equivalent to `sessionState(SourceIds.ROYAL_ROAD)`
+     * — kept as a top-level field for backwards compatibility with the
+     * pre-#426 call sites that observed a single source.
+     */
     val sessionState: StateFlow<SessionState>
+
+    /** Per-source session state. Each sourceId gets its own flow. */
+    fun sessionState(sourceId: String): StateFlow<SessionState>
 
     /** Persist a captured WebView cookie. Transitions state → Authenticated. */
     suspend fun captureSession(
@@ -36,19 +60,25 @@ interface AuthRepository {
         userDisplayName: String?,
         userId: String?,
         expiresAt: Long?,
+        sourceId: String = SourceIds.ROYAL_ROAD,
     )
 
-    /** Clear all session data. Transitions state → Anonymous. */
-    suspend fun clearSession()
-
-    /** Returns the raw Cookie header to attach to outgoing fetches, or null. */
-    suspend fun cookieHeader(): String?
+    /** Clear all session data for [sourceId]. Transitions state → Anonymous. */
+    suspend fun clearSession(sourceId: String = SourceIds.ROYAL_ROAD)
 
     /**
-     * Validate by hitting an authed endpoint. Updates `lastVerifiedAt` on
-     * success or transitions to [SessionState.Expired] on auth failure.
+     * Returns the raw Cookie header to attach to outgoing fetches for
+     * [sourceId], or null if no session is captured for that source.
      */
-    suspend fun verifyOrExpire(): SessionState
+    suspend fun cookieHeader(sourceId: String = SourceIds.ROYAL_ROAD): String?
+
+    /**
+     * Validate by hitting an authed endpoint on the source. Updates
+     * `lastVerifiedAt` on success or transitions to [SessionState.Expired]
+     * on auth failure. No-op (returns current state) for sources that
+     * aren't wired up in the source map.
+     */
+    suspend fun verifyOrExpire(sourceId: String = SourceIds.ROYAL_ROAD): SessionState
 }
 
 @Singleton
@@ -59,33 +89,60 @@ class AuthRepositoryImpl @Inject constructor(
     @ApplicationScope private val appScope: CoroutineScope,
 ) : AuthRepository {
 
-    private val state = MutableStateFlow<SessionState>(SessionState.Anonymous)
-    override val sessionState: StateFlow<SessionState> = state.asStateFlow()
+    // Per-source state flows. ConcurrentHashMap because [sessionState] /
+    // capture / clear can be called from any thread — Hilt-scoped singletons
+    // don't synchronize their callers for us.
+    private val states: MutableMap<String, MutableStateFlow<SessionState>> =
+        ConcurrentHashMap()
 
-    // Auth is per-source. Royal Road is the only source with a
-    // SessionHydrator wired today; GitHub source (3d-detail-and-chapter
-    // and beyond) has no auth flow until step 3f adds optional PAT
-    // support. Pin to Royal Road explicitly. When GitHub auth lands
-    // this becomes a per-call lookup — the cookie store is already
-    // keyed `cookie:$sourceId` so the data layer doesn't need
-    // migration.
-    private val source: FictionSource = sources[SourceIds.ROYAL_ROAD]
-        ?: error("AuthRepository: expected $sources to bind ${SourceIds.ROYAL_ROAD}; got ${sources.keys}")
-    private val sourceId: String get() = source.id
-    private val cookieKey: String get() = "cookie:$sourceId"
+    private fun stateFlow(sourceId: String): MutableStateFlow<SessionState> =
+        states.getOrPut(sourceId) { MutableStateFlow(SessionState.Anonymous) }
+
+    override val sessionState: StateFlow<SessionState>
+        get() = stateFlow(SourceIds.ROYAL_ROAD).asStateFlow()
+
+    override fun sessionState(sourceId: String): StateFlow<SessionState> =
+        stateFlow(sourceId).asStateFlow()
+
+    private fun cookieKey(sourceId: String): String = "$COOKIE_KEY_PREFIX$sourceId"
+
+    private companion object {
+        // EncryptedSharedPreferences key prefix. Pre-#426 this string was
+        // inlined as "cookie:$sourceId"; the constant centralizes it so
+        // init() can scan disk for every persisted source without that
+        // string drifting between the writer and the scanner.
+        const val COOKIE_KEY_PREFIX = "cookie:"
+    }
 
     init {
-        // Hydrate on construction from the encrypted store + DAO row.
-        // Hilt creates this on the singleton component, so blocking IO here
-        // is acceptable (it runs before any coroutine touches the StateFlow).
-        val cookie = prefs.getString(cookieKey, null)
-        if (cookie != null) {
+        // Hydrate every source we have a cookie for on construction.
+        // Pre-#426 this was hardcoded to ROYAL_ROAD; #426 scans every
+        // `cookie:*` key on disk so an AO3 cookie persisted in PR2 gets
+        // the same on-construction hydration even if the AO3 source
+        // binding isn't loaded yet. Hilt creates this on the singleton
+        // component, so blocking IO here is acceptable (it runs before
+        // any coroutine touches a StateFlow).
+        //
+        // Walking the prefs (not `sources.keys`) is what keeps disk
+        // state authoritative: the cookie store is keyed by sourceId,
+        // not by FictionSource binding, and the prior contract was
+        // "if a cookie exists on disk, surface Authenticated immediately
+        // on cold start" — regardless of whether the FictionSource is
+        // currently wired.
+        val cookieKeys: Set<String> = prefs.all.keys
+            .filter { it.startsWith(COOKIE_KEY_PREFIX) }
+            .toSet()
+        val candidateIds: Set<String> = cookieKeys
+            .map { it.removePrefix(COOKIE_KEY_PREFIX) }
+            .toSet() + SourceIds.ROYAL_ROAD
+        for (sourceId in candidateIds) {
+            val cookie = prefs.getString(cookieKey(sourceId), null) ?: continue
             // Best-effort: pull metadata sync from a parallel scope; the
             // StateFlow is updated as soon as the row arrives. Until then,
             // treat as Authenticated with whatever metadata is in the cookie
             // header itself — Anonymous would be a wrong default since the
             // disk store says we have a session.
-            state.value = SessionState.Authenticated(
+            stateFlow(sourceId).value = SessionState.Authenticated(
                 cookieHeader = cookie,
                 expiresAt = null,
                 userDisplayName = null,
@@ -101,7 +158,7 @@ class AuthRepositoryImpl @Inject constructor(
                 withContext(Dispatchers.IO) {
                     val row = dao.get(sourceId)
                     if (row != null) {
-                        state.value = SessionState.Authenticated(
+                        stateFlow(sourceId).value = SessionState.Authenticated(
                             cookieHeader = cookie,
                             expiresAt = row.expiresAt,
                             userDisplayName = row.userDisplayName,
@@ -117,9 +174,10 @@ class AuthRepositoryImpl @Inject constructor(
         userDisplayName: String?,
         userId: String?,
         expiresAt: Long?,
+        sourceId: String,
     ) = withContext(Dispatchers.IO) {
         val now = System.currentTimeMillis()
-        prefs.edit { putString(cookieKey, cookieHeader) }
+        prefs.edit { putString(cookieKey(sourceId), cookieHeader) }
         dao.upsert(
             AuthCookie(
                 sourceId = sourceId,
@@ -130,32 +188,45 @@ class AuthRepositoryImpl @Inject constructor(
                 lastVerifiedAt = now,
             ),
         )
-        state.value = SessionState.Authenticated(cookieHeader, expiresAt, userDisplayName)
+        stateFlow(sourceId).value =
+            SessionState.Authenticated(cookieHeader, expiresAt, userDisplayName)
     }
 
-    override suspend fun clearSession() = withContext(Dispatchers.IO) {
-        prefs.edit { remove(cookieKey) }
+    override suspend fun clearSession(sourceId: String) = withContext(Dispatchers.IO) {
+        prefs.edit { remove(cookieKey(sourceId)) }
         dao.clear(sourceId)
-        state.value = SessionState.Anonymous
+        stateFlow(sourceId).value = SessionState.Anonymous
     }
 
-    override suspend fun cookieHeader(): String? = withContext(Dispatchers.IO) {
-        prefs.getString(cookieKey, null)
+    override suspend fun cookieHeader(sourceId: String): String? = withContext(Dispatchers.IO) {
+        prefs.getString(cookieKey(sourceId), null)
     }
 
-    override suspend fun verifyOrExpire(): SessionState = withContext(Dispatchers.IO) {
+    override suspend fun verifyOrExpire(sourceId: String): SessionState = withContext(Dispatchers.IO) {
+        val state = stateFlow(sourceId)
         // Capture the cookie up front. Re-reading from prefs after the
         // network call would race with a concurrent clearSession() and
         // the prior `cookieHeader()!!` would crash on the resulting null.
-        val cookie = cookieHeader() ?: run {
+        val cookie = cookieHeader(sourceId) ?: run {
             state.value = SessionState.Anonymous
             return@withContext state.value
         }
-        when (val result = source.followsList(page = 1)) {
+        val source = sources[sourceId]
+        if (source == null) {
+            // The source isn't bound (e.g. a test fixture or a source
+            // module disabled at compile time). We can't verify, but the
+            // cookie store says we're authed — keep the existing state
+            // rather than hard-erroring. Pre-#426 this branch couldn't
+            // exist (RR was the only binding and was checked at init);
+            // post-#426 it's reachable when callers verify a source that
+            // hasn't been wired yet (e.g. AO3 between PR1 and PR2).
+            return@withContext state.value
+        }
+        when (source.followsList(page = 1)) {
             is FictionResult.Success -> {
                 dao.touchVerified(sourceId, System.currentTimeMillis())
                 // If the session was cleared mid-flight, don't reinstate it.
-                if (cookieHeader() == null) {
+                if (cookieHeader(sourceId) == null) {
                     state.value = SessionState.Anonymous
                 } else {
                     // Keep current state; refresh expiresAt from latest row.

--- a/core-data/src/test/kotlin/in/jphe/storyvox/data/repository/AuthRepositoryImplTest.kt
+++ b/core-data/src/test/kotlin/in/jphe/storyvox/data/repository/AuthRepositoryImplTest.kt
@@ -1,0 +1,300 @@
+package `in`.jphe.storyvox.data.repository
+
+import android.content.SharedPreferences
+import `in`.jphe.storyvox.data.auth.SessionState
+import `in`.jphe.storyvox.data.db.dao.AuthDao
+import `in`.jphe.storyvox.data.db.entity.AuthCookie
+import `in`.jphe.storyvox.data.source.FictionSource
+import `in`.jphe.storyvox.data.source.FictionSourceEvent
+import `in`.jphe.storyvox.data.source.SourceIds
+import `in`.jphe.storyvox.data.source.model.ChapterContent
+import `in`.jphe.storyvox.data.source.model.FictionDetail
+import `in`.jphe.storyvox.data.source.model.FictionResult
+import `in`.jphe.storyvox.data.source.model.FictionSummary
+import `in`.jphe.storyvox.data.source.model.ListPage
+import `in`.jphe.storyvox.data.source.model.SearchQuery
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.test.TestScope
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * Contract tests for [AuthRepositoryImpl] — covers the existing Royal
+ * Road sign-in / sign-out behaviour AND the multi-source semantics
+ * introduced by #426 (PR1).
+ *
+ * The pre-#426 implementation pinned to a single hardcoded source
+ * (Royal Road); the post-refactor implementation routes by sourceId.
+ * Both shapes must keep RR existing call sites bit-identical and let
+ * PR2 add an AO3 binding without code changes to `:core-data`.
+ *
+ * Robolectric isn't pulled in — the SharedPreferences and AuthDao
+ * dependencies are stubbed with hand-rolled in-memory fakes so the
+ * test runs in milliseconds on plain JUnit.
+ */
+@OptIn(ExperimentalCoroutinesApi::class)
+class AuthRepositoryImplTest {
+
+    // -- repo() ---------------------------------------------------------------
+
+    private fun repo(
+        sources: Map<String, FictionSource> = mapOf(SourceIds.ROYAL_ROAD to FakeSource(SourceIds.ROYAL_ROAD)),
+        prefs: FakePrefs = FakePrefs(),
+        dao: FakeAuthDao = FakeAuthDao(),
+        scope: CoroutineScope = TestScope(UnconfinedTestDispatcher()),
+    ): Triple<AuthRepositoryImpl, FakePrefs, FakeAuthDao> {
+        val impl = AuthRepositoryImpl(dao, prefs, sources, scope)
+        return Triple(impl, prefs, dao)
+    }
+
+    // -- backwards-compat: RR default ----------------------------------------
+
+    @Test fun `captureSession defaults to royal road sourceId`() = runTest {
+        val (r, prefs, dao) = repo()
+        r.captureSession(
+            cookieHeader = "id=rr",
+            userDisplayName = "alice",
+            userId = "1",
+            expiresAt = 123L,
+        )
+        // Stored under the RR-shaped key, not under some new
+        // "default" string — so a v0.5.x install upgrading into
+        // this build keeps reading its own cookie back.
+        assertEquals("id=rr", prefs.getString("cookie:${SourceIds.ROYAL_ROAD}", null))
+        assertEquals("alice", dao.rows[SourceIds.ROYAL_ROAD]?.userDisplayName)
+        // Legacy single-flow accessor still flips to Authenticated.
+        val state = r.sessionState.value
+        assertTrue(state is SessionState.Authenticated)
+        assertEquals("id=rr", (state as SessionState.Authenticated).cookieHeader)
+    }
+
+    @Test fun `clearSession defaults to royal road and tears down both stores`() = runTest {
+        val (r, prefs, dao) = repo()
+        r.captureSession("id=rr", null, null, null)
+        assertNotNull(prefs.getString("cookie:${SourceIds.ROYAL_ROAD}", null))
+
+        r.clearSession()
+        assertNull(prefs.getString("cookie:${SourceIds.ROYAL_ROAD}", null))
+        assertNull(dao.rows[SourceIds.ROYAL_ROAD])
+        assertEquals(SessionState.Anonymous, r.sessionState.value)
+    }
+
+    @Test fun `cookieHeader defaults to royal road`() = runTest {
+        val (r, _, _) = repo()
+        assertNull(r.cookieHeader())
+        r.captureSession("id=rr", null, null, null)
+        assertEquals("id=rr", r.cookieHeader())
+    }
+
+    // -- pre-existing RR session is rehydrated on init -----------------------
+
+    @Test fun `init rehydrates an RR cookie persisted on disk`() = runTest {
+        val prefs = FakePrefs().apply {
+            edit().putString("cookie:${SourceIds.ROYAL_ROAD}", "id=rr").commit()
+        }
+        val dao = FakeAuthDao().apply {
+            rows[SourceIds.ROYAL_ROAD] = AuthCookie(
+                sourceId = SourceIds.ROYAL_ROAD,
+                userDisplayName = "alice",
+                userId = "1",
+                capturedAt = 0L,
+                expiresAt = 999L,
+                lastVerifiedAt = 0L,
+            )
+        }
+        val (r, _, _) = repo(prefs = prefs, dao = dao)
+        val state = r.sessionState.value
+        assertTrue(state is SessionState.Authenticated)
+        assertEquals("id=rr", (state as SessionState.Authenticated).cookieHeader)
+    }
+
+    // -- multi-source: PR1 generalization ------------------------------------
+
+    @Test fun `capture for two source ids keeps their states independent`() = runTest {
+        val (r, prefs, _) = repo(
+            sources = mapOf(
+                SourceIds.ROYAL_ROAD to FakeSource(SourceIds.ROYAL_ROAD),
+                SourceIds.AO3 to FakeSource(SourceIds.AO3),
+            ),
+        )
+        r.captureSession("id=rr", null, null, null, sourceId = SourceIds.ROYAL_ROAD)
+        r.captureSession("id=ao3", null, null, null, sourceId = SourceIds.AO3)
+
+        // Encrypted prefs keys are per-source.
+        assertEquals("id=rr", prefs.getString("cookie:${SourceIds.ROYAL_ROAD}", null))
+        assertEquals("id=ao3", prefs.getString("cookie:${SourceIds.AO3}", null))
+
+        // Each flow reflects its own source.
+        val rr = r.sessionState(SourceIds.ROYAL_ROAD).value
+        val ao3 = r.sessionState(SourceIds.AO3).value
+        assertTrue(rr is SessionState.Authenticated)
+        assertTrue(ao3 is SessionState.Authenticated)
+        assertEquals("id=rr", (rr as SessionState.Authenticated).cookieHeader)
+        assertEquals("id=ao3", (ao3 as SessionState.Authenticated).cookieHeader)
+
+        // Clearing one source must not touch the other.
+        r.clearSession(SourceIds.ROYAL_ROAD)
+        assertEquals(SessionState.Anonymous, r.sessionState(SourceIds.ROYAL_ROAD).value)
+        val ao3After = r.sessionState(SourceIds.AO3).value
+        assertTrue(ao3After is SessionState.Authenticated)
+    }
+
+    @Test fun `cookieHeader is per source`() = runTest {
+        val (r, _, _) = repo(
+            sources = mapOf(
+                SourceIds.ROYAL_ROAD to FakeSource(SourceIds.ROYAL_ROAD),
+                SourceIds.AO3 to FakeSource(SourceIds.AO3),
+            ),
+        )
+        r.captureSession("id=rr", null, null, null, sourceId = SourceIds.ROYAL_ROAD)
+        r.captureSession("id=ao3", null, null, null, sourceId = SourceIds.AO3)
+        assertEquals("id=rr", r.cookieHeader(SourceIds.ROYAL_ROAD))
+        assertEquals("id=ao3", r.cookieHeader(SourceIds.AO3))
+    }
+
+    // -- verifyOrExpire -------------------------------------------------------
+
+    @Test fun `verifyOrExpire transitions to Expired on AuthRequired`() = runTest {
+        val src = FakeSource(SourceIds.ROYAL_ROAD).apply {
+            followsListResult = FictionResult.AuthRequired()
+        }
+        val (r, _, _) = repo(sources = mapOf(SourceIds.ROYAL_ROAD to src))
+        r.captureSession("id=rr", null, null, null)
+        val state = r.verifyOrExpire()
+        assertEquals(SessionState.Expired, state)
+    }
+
+    @Test fun `verifyOrExpire success stamps lastVerifiedAt and keeps Authenticated`() = runTest {
+        val src = FakeSource(SourceIds.ROYAL_ROAD).apply {
+            followsListResult = FictionResult.Success(ListPage(emptyList(), 1, false))
+        }
+        val (r, _, dao) = repo(sources = mapOf(SourceIds.ROYAL_ROAD to src))
+        r.captureSession("id=rr", null, null, null)
+        val before = dao.rows[SourceIds.ROYAL_ROAD]?.lastVerifiedAt
+        val state = r.verifyOrExpire()
+        assertTrue(state is SessionState.Authenticated)
+        val after = dao.rows[SourceIds.ROYAL_ROAD]?.lastVerifiedAt
+        // The fake DAO touchVerified updates lastVerifiedAt to the
+        // current time; both before and after are non-null and after
+        // is >= before. We just assert it didn't get nulled out.
+        assertNotNull(after)
+        assertTrue(after!! >= (before ?: 0L))
+    }
+
+    @Test fun `verifyOrExpire with no cookie flips to Anonymous`() = runTest {
+        val src = FakeSource(SourceIds.ROYAL_ROAD)
+        val (r, _, _) = repo(sources = mapOf(SourceIds.ROYAL_ROAD to src))
+        val state = r.verifyOrExpire()
+        assertEquals(SessionState.Anonymous, state)
+        // Source must not be called — there was nothing to verify.
+        assertEquals(emptyList<String>(), src.callLog)
+    }
+
+    @Test fun `verifyOrExpire for an unbound sourceId keeps current state`() = runTest {
+        val (r, prefs, _) = repo(
+            sources = mapOf(SourceIds.ROYAL_ROAD to FakeSource(SourceIds.ROYAL_ROAD)),
+        )
+        // Simulate PR2: a cookie persisted for AO3 but the AO3 source
+        // binding hasn't landed yet. The repo MUST NOT throw; it
+        // should preserve the existing state.
+        prefs.edit().putString("cookie:${SourceIds.AO3}", "id=ao3").commit()
+        // Re-build the repo so init() picks up the disk state.
+        val (r2, _, _) = repo(
+            sources = mapOf(SourceIds.ROYAL_ROAD to FakeSource(SourceIds.ROYAL_ROAD)),
+            prefs = prefs,
+        )
+        val state = r2.verifyOrExpire(SourceIds.AO3)
+        // Existing state was Authenticated (from init's hydration); the
+        // unbound-source branch keeps it Authenticated rather than
+        // erroring.
+        assertTrue(state is SessionState.Authenticated)
+    }
+
+    // -- fakes ---------------------------------------------------------------
+
+    private class FakePrefs : SharedPreferences {
+        private val map = mutableMapOf<String, Any?>()
+        override fun getAll(): MutableMap<String, *> = map
+        override fun getString(key: String, defValue: String?): String? =
+            map[key] as? String ?: defValue
+        override fun getStringSet(key: String, defValues: MutableSet<String>?) = defValues
+        override fun getInt(key: String, defValue: Int): Int = (map[key] as? Int) ?: defValue
+        override fun getLong(key: String, defValue: Long): Long = (map[key] as? Long) ?: defValue
+        override fun getFloat(key: String, defValue: Float): Float = (map[key] as? Float) ?: defValue
+        override fun getBoolean(key: String, defValue: Boolean): Boolean = (map[key] as? Boolean) ?: defValue
+        override fun contains(key: String): Boolean = key in map
+        override fun edit(): SharedPreferences.Editor = object : SharedPreferences.Editor {
+            override fun putString(k: String, v: String?) = apply { map[k] = v }
+            override fun putStringSet(k: String, v: MutableSet<String>?) = apply { map[k] = v }
+            override fun putInt(k: String, v: Int) = apply { map[k] = v }
+            override fun putLong(k: String, v: Long) = apply { map[k] = v }
+            override fun putFloat(k: String, v: Float) = apply { map[k] = v }
+            override fun putBoolean(k: String, v: Boolean) = apply { map[k] = v }
+            override fun remove(k: String) = apply { map.remove(k) }
+            override fun clear() = apply { map.clear() }
+            override fun commit(): Boolean = true
+            override fun apply() = Unit
+        }
+        override fun registerOnSharedPreferenceChangeListener(l: SharedPreferences.OnSharedPreferenceChangeListener?) = Unit
+        override fun unregisterOnSharedPreferenceChangeListener(l: SharedPreferences.OnSharedPreferenceChangeListener?) = Unit
+    }
+
+    private class FakeAuthDao : AuthDao {
+        val rows = mutableMapOf<String, AuthCookie>()
+        private val flows = mutableMapOf<String, MutableStateFlow<AuthCookie?>>()
+        private fun flowFor(id: String) = flows.getOrPut(id) { MutableStateFlow(rows[id]) }
+
+        override fun observe(sourceId: String): Flow<AuthCookie?> = flowFor(sourceId).asStateFlow()
+        override suspend fun get(sourceId: String): AuthCookie? = rows[sourceId]
+        override suspend fun upsert(cookie: AuthCookie) {
+            rows[cookie.sourceId] = cookie
+            flowFor(cookie.sourceId).value = cookie
+        }
+        override suspend fun touchVerified(sourceId: String, now: Long) {
+            val existing = rows[sourceId] ?: return
+            val updated = existing.copy(lastVerifiedAt = now)
+            rows[sourceId] = updated
+            flowFor(sourceId).value = updated
+        }
+        override suspend fun clear(sourceId: String) {
+            rows.remove(sourceId)
+            flowFor(sourceId).value = null
+        }
+    }
+
+    /**
+     * Minimal [FictionSource] stub that records its own follows-list
+     * calls and lets each test stub the result. Other methods aren't
+     * touched by [AuthRepositoryImpl] — left as TODO() so any
+     * unintended use surfaces immediately.
+     */
+    private class FakeSource(override val id: String) : FictionSource {
+        override val displayName: String = "Fake $id"
+        var followsListResult: FictionResult<ListPage<FictionSummary>> =
+            FictionResult.NetworkError("not stubbed")
+        val callLog = mutableListOf<String>()
+
+        override suspend fun popular(page: Int) = TODO("unused")
+        override suspend fun latestUpdates(page: Int) = TODO("unused")
+        override suspend fun byGenre(genre: String, page: Int) = TODO("unused")
+        override suspend fun search(query: SearchQuery) = TODO("unused")
+        override suspend fun fictionDetail(fictionId: String): FictionResult<FictionDetail> = TODO("unused")
+        override suspend fun chapter(fictionId: String, chapterId: String): FictionResult<ChapterContent> = TODO("unused")
+        override suspend fun followsList(page: Int): FictionResult<ListPage<FictionSummary>> {
+            callLog += "followsList($page)"
+            return followsListResult
+        }
+        override suspend fun setFollowed(fictionId: String, followed: Boolean) = TODO("unused")
+        override suspend fun genres() = TODO("unused")
+    }
+}

--- a/feature/src/main/kotlin/in/jphe/storyvox/feature/auth/AuthViewModel.kt
+++ b/feature/src/main/kotlin/in/jphe/storyvox/feature/auth/AuthViewModel.kt
@@ -44,6 +44,15 @@ class AuthViewModel @Inject constructor(
         _captureState.value = CaptureState.Capturing
         viewModelScope.launch {
             val cookieHeader = cookies.entries.joinToString("; ") { (k, v) -> "$k=$v" }
+            // TODO(PR2 / #426): take a sourceId parameter on captureCookies()
+            // and pass it through to captureSession + hydrator + settings.
+            // AuthRepository.captureSession defaults to ROYAL_ROAD so the
+            // RR sign-in flow is unchanged today; PR2 wires the AO3 path
+            // and `auth.captureSession(..., sourceId = SourceIds.AO3)` /
+            // an AO3-aware [SessionHydrator] dispatch land here. Same goes
+            // for the `fictionRepo.refreshRemoteFollows()` fire-and-forget
+            // below — RR is the only source that has a follows concept
+            // wired today, so leaving it RR-only until PR2 is correct.
             auth.captureSession(
                 cookieHeader = cookieHeader,
                 userDisplayName = null,

--- a/source-royalroad/src/main/kotlin/in/jphe/storyvox/source/royalroad/auth/RoyalRoadAuthSource.kt
+++ b/source-royalroad/src/main/kotlin/in/jphe/storyvox/source/royalroad/auth/RoyalRoadAuthSource.kt
@@ -1,0 +1,46 @@
+package `in`.jphe.storyvox.source.royalroad.auth
+
+import `in`.jphe.storyvox.data.auth.AuthSource
+import `in`.jphe.storyvox.data.source.SourceIds
+import `in`.jphe.storyvox.source.royalroad.model.RoyalRoadIds
+import javax.inject.Inject
+import javax.inject.Singleton
+
+/**
+ * Royal Road's contribution to the cross-source [AuthSource] map (#426).
+ *
+ * The WebView capture configuration here mirrors the long-standing
+ * literals in [RoyalRoadAuthWebView]: load `/account/login`, watch for
+ * `.AspNetCore.Identity.Application`, hydrate the captured cookies into
+ * the OkHttp jar at the `royalroad.com` eTLD+1.
+ *
+ * `:source-royalroad`'s [RoyalRoadAuthWebView] composable is what
+ * actually drives the WebView today and the literals live there as
+ * private constants; this class re-exposes the same values through
+ * the [AuthSource] interface so PR2's AO3 sign-in screen — and any
+ * future cross-source sign-in router — can pick the right configuration
+ * by sourceId rather than referencing a source's internal composable.
+ */
+@Singleton
+internal class RoyalRoadAuthSource @Inject constructor() : AuthSource {
+
+    override val sourceId: String = SourceIds.ROYAL_ROAD
+
+    override val signInUrl: String = "${RoyalRoadIds.BASE_URL}/account/login"
+
+    /**
+     * Royal Road runs on ASP.NET Core; the identity-cookie name is the
+     * default `.AspNetCore.Identity.Application` and persists for as
+     * long as the user stays signed in. Matches the literal in
+     * [RoyalRoadAuthWebView].
+     */
+    override val identityCookieName: String = ".AspNetCore.Identity.Application"
+
+    /**
+     * eTLD+1 host the [RoyalRoadSessionHydrator] keys cookies under.
+     * Royal Road serves from both `www.royalroad.com` and the bare
+     * domain; the cookie jar stores under the bare domain so OkHttp's
+     * Set-Cookie attachment routes both back to the server.
+     */
+    override val cookieHost: String = "royalroad.com"
+}

--- a/source-royalroad/src/main/kotlin/in/jphe/storyvox/source/royalroad/di/RoyalRoadModule.kt
+++ b/source-royalroad/src/main/kotlin/in/jphe/storyvox/source/royalroad/di/RoyalRoadModule.kt
@@ -1,9 +1,11 @@
 package `in`.jphe.storyvox.source.royalroad.di
 
+import `in`.jphe.storyvox.data.auth.AuthSource
 import `in`.jphe.storyvox.data.auth.SessionHydrator
 import `in`.jphe.storyvox.data.source.FictionSource
 import `in`.jphe.storyvox.data.source.SourceIds
 import `in`.jphe.storyvox.source.royalroad.RoyalRoadSource
+import `in`.jphe.storyvox.source.royalroad.auth.RoyalRoadAuthSource
 import `in`.jphe.storyvox.source.royalroad.auth.RoyalRoadSessionHydrator
 import `in`.jphe.storyvox.source.royalroad.model.RoyalRoadIds
 import `in`.jphe.storyvox.source.royalroad.net.RateLimitedClient
@@ -87,4 +89,21 @@ internal abstract class RoyalRoadBindings {
     @Binds
     @Singleton
     abstract fun bindSessionHydrator(impl: RoyalRoadSessionHydrator): SessionHydrator
+
+    /**
+     * Contributes [RoyalRoadAuthSource] into the cross-source
+     * `Map<String, AuthSource>` consumed by
+     * [`in`.jphe.storyvox.data.repository.AuthRepository] (#426).
+     *
+     * PR2 will add an analogous binding in `:source-ao3` keyed by
+     * [SourceIds.AO3]. The legacy single-source binding in
+     * [`in`.jphe.storyvox.data.repository.AuthRepositoryImpl] is
+     * replaced by the map; this binding is what keeps the RR sign-in
+     * flow finding its WebView configuration after the refactor.
+     */
+    @Binds
+    @Singleton
+    @IntoMap
+    @StringKey(SourceIds.ROYAL_ROAD)
+    abstract fun bindAuthSource(impl: RoyalRoadAuthSource): AuthSource
 }


### PR DESCRIPTION
## Summary

PR1 of #426 — generalizes `AuthRepository` from RR-pinned to multi-source-routed, leaving AO3 wiring as the slot PR2 fills.

- `AuthSource` interface in `:core-data` (sign-in URL / identity-cookie name / cookie host); `:source-royalroad` contributes `RoyalRoadAuthSource` via Hilt `@IntoMap @StringKey(ROYAL_ROAD)`.
- `AuthRepository` methods grow optional `sourceId: String` defaulting to `SourceIds.ROYAL_ROAD` — every existing call site (`AuthViewModel`, `SettingsRepositoryUiImpl.signOut`, `SessionRefreshWorker`, `StoryvoxApp.rehydrateRoyalRoadCookies`) keeps compiling and behaving bit-identically.
- `AuthRepositoryImpl` maintains a `ConcurrentHashMap<String, MutableStateFlow<SessionState>>` and scans `cookie:*` keys in EncryptedSharedPreferences at init so any persisted source hydrates on cold start.
- `TODO(PR2 / #426)` marker placed in `AuthViewModel.captureCookies` at the exact spot AO3 plugs in.
- Contract tests cover RR default-sourceId back-compat, init rehydration, per-source isolation, verifyOrExpire (Authenticated / Expired / Anonymous / unbound-source).

## Test plan

- [x] `./gradlew :app:assembleDebug` green
- [x] `./gradlew :core-data:testDebugUnitTest` — 226 tests pass (new `AuthRepositoryImplTest` adds 9)
- [x] `./gradlew :source-royalroad:testDebugUnitTest` green
- [x] `./gradlew :feature:testDebugUnitTest` green
- [x] `./gradlew :app:testDebugUnitTest` green (includes `FakeAuth` interface update)
- [ ] Smoke: existing Royal Road sign-in flow on tablet (auto-mode iterate after merge)

## Out of scope (lands in PR2)

- AO3 `AuthSource` contribution + `Ao3AuthWebView` + cookie-capture flow
- AO3 sourceId pass-through in `AuthViewModel.captureCookies` (the TODO marker)
- AO3 subscriptions tab

🤖 Generated with [Claude Code](https://claude.com/claude-code)