### PR TITLE
feat(widget): adaptive now-playing widget with transport — closes #159

### DIFF
--- a/app/proguard-rules.pro
+++ b/app/proguard-rules.pro
@@ -199,3 +199,21 @@
 # ----------------------------------------------------------------------
 -keep class in.jphe.storyvox.source.** implements in.jphe.storyvox.data.source.FictionSource { *; }
 -keep class in.jphe.storyvox.source.**.*Source { *; }
+
+# ----------------------------------------------------------------------
+# Home-screen widget (#159)
+# ----------------------------------------------------------------------
+# NowPlayingWidgetProvider is referenced from AndroidManifest.xml by
+# fully-qualified name; Android system instantiates it via reflection
+# (Class.forName + newInstance) whenever the AppWidgetHost dispatches
+# APPWIDGET_UPDATE or our custom action broadcasts. R8 doesn't see the
+# manifest → class edge, so without this rule the class is stripped on
+# the minified build and every widget update crashes with
+# ClassNotFoundException inside the framework's broadcast dispatch.
+#
+# `{ *; }` keeps the constructor + onUpdate/onReceive/etc. methods.
+# Companion-object string constants are read by manifest <action>
+# matching and from the same Kotlin file's own callsites; the rule
+# covers them too.
+-keep class in.jphe.storyvox.widget.NowPlayingWidgetProvider { *; }
+-keep class in.jphe.storyvox.widget.NowPlayingWidgetProvider$WidgetEntryPoint { *; }

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -82,6 +82,47 @@
         </provider>
 
         <!--
+            Issue #159 — home-screen now-playing widget. Adaptive
+            RemoteViews provider (1x1 / 4x1 / 4x2 buckets), Material You
+            tinted on Android 12+. The receiver also handles transport-
+            button broadcasts (ACTION_PLAY_PAUSE / ACTION_NEXT_CHAPTER /
+            ACTION_SLEEP_TOGGLE) from the widget's own PendingIntents —
+            those land in-process, but exported="true" is required for
+            the launcher / AppWidgetHost (a different process) to fire
+            APPWIDGET_UPDATE.
+
+            android:exported="true" is the AppWidget contract; the
+            framework itself is the broadcaster. Custom-action
+            broadcasts are scoped to our own package via explicit
+            ComponentName in every PendingIntent
+            (NowPlayingWidgetProvider builds them with
+            `Intent(context, NowPlayingWidgetProvider::class.java)`),
+            so a third-party app cannot fire our transport actions
+            even though the receiver is exported.
+
+            R8 keep-rule: `-keep class
+            in.jphe.storyvox.widget.NowPlayingWidgetProvider { *; }`
+            in proguard-rules.pro — Android system instantiates this
+            class by FQN reflection from the manifest, an edge R8's
+            tree-shake doesn't see.
+        -->
+        <receiver
+            android:name=".widget.NowPlayingWidgetProvider"
+            android:exported="true"
+            android:label="@string/widget_now_playing_label">
+            <intent-filter>
+                <action android:name="android.appwidget.action.APPWIDGET_UPDATE" />
+                <action android:name="in.jphe.storyvox.widget.action.PLAY_PAUSE" />
+                <action android:name="in.jphe.storyvox.widget.action.NEXT_CHAPTER" />
+                <action android:name="in.jphe.storyvox.widget.action.SLEEP_TOGGLE" />
+                <action android:name="in.jphe.storyvox.widget.action.REFRESH" />
+            </intent-filter>
+            <meta-data
+                android:name="android.appwidget.provider"
+                android:resource="@xml/widget_now_playing_info" />
+        </receiver>
+
+        <!--
             Issue #117 — FileProvider for EPUB exports. Grants ACTION_SEND
             recipients (and SAF ACTION_CREATE_DOCUMENT target apps) read
             access to files we write under cacheDir/exports/. The authority

--- a/app/src/main/kotlin/in/jphe/storyvox/StoryvoxApp.kt
+++ b/app/src/main/kotlin/in/jphe/storyvox/StoryvoxApp.kt
@@ -18,6 +18,7 @@ import `in`.jphe.storyvox.data.work.WorkScheduler
 import `in`.jphe.storyvox.feature.api.SettingsRepositoryUi
 import `in`.jphe.storyvox.playback.VoiceEngineQualityBridge
 import `in`.jphe.storyvox.sync.coordinator.SyncCoordinator
+import `in`.jphe.storyvox.widget.WidgetStateObserver
 import javax.inject.Inject
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
@@ -86,6 +87,13 @@ class StoryvoxApp : Application(), Configuration.Provider {
      *  the singleton isn't materialised on the cold-launch main thread;
      *  initScope's coroutine pulls it on IO and calls [start()]. */
     @Inject lateinit var prerenderModeWatcher: Lazy<PrerenderModeWatcher>
+
+    /** Issue #159 — push-driven RemoteViews refresher for the home-
+     *  screen now-playing widget. Subscribes to PlaybackController.state
+     *  and broadcasts a refresh to NowPlayingWidgetProvider on every
+     *  user-visible change. Started off the cold-launch main thread
+     *  via the [Lazy] wrapper. */
+    @Inject lateinit var widgetStateObserver: Lazy<WidgetStateObserver>
 
     override val workManagerConfiguration: Configuration
         get() = Configuration.Builder()
@@ -157,6 +165,14 @@ class StoryvoxApp : Application(), Configuration.Provider {
         // singleton scope.
         initScope.launch {
             prerenderModeWatcher.get().start()
+        }
+        // Issue #159 — start the widget state observer once the Hilt
+        // graph is warm. The observer is a thin coroutine that
+        // re-broadcasts when PlaybackController.state changes; doing
+        // it on IO means no cold-launch frame budget impact even on
+        // P22T-class hardware. Idempotent — re-starting is a no-op.
+        initScope.launch {
+            widgetStateObserver.get().start()
         }
     }
 

--- a/app/src/main/kotlin/in/jphe/storyvox/widget/NowPlayingSnapshot.kt
+++ b/app/src/main/kotlin/in/jphe/storyvox/widget/NowPlayingSnapshot.kt
@@ -1,0 +1,62 @@
+package `in`.jphe.storyvox.widget
+
+import `in`.jphe.storyvox.playback.PlaybackState
+
+/**
+ * Issue #159 — minimal projection of [PlaybackState] that the widget
+ * surface actually needs. Keeping the renderer working from this
+ * narrow type rather than the full PlaybackState means:
+ *  - tests can construct exact widget scenarios without standing up
+ *    the full PlaybackState constructor (which transitively pulls
+ *    SentenceRange, PlaybackError, etc.),
+ *  - the equality check WidgetStateObserver uses for distinctUntilChanged
+ *    only fires when a widget-relevant field actually changes, not
+ *    when (e.g.) a sentence-range crosses a boundary.
+ *
+ * `coverUri` carries the same string format `PlaybackState.coverUri`
+ * does — file path, content:// uri, or http(s) url. The renderer
+ * passes it straight through to `RemoteViews.setImageViewUri` for
+ * local file/content URIs; remote URLs fall back to the placeholder
+ * (RemoteViews can't load arbitrary HTTP; a follow-up issue can wire
+ * a Coil-side bitmap fetch + setImageViewBitmap if anyone asks).
+ */
+data class NowPlayingSnapshot(
+    val isIdle: Boolean,
+    val isPlaying: Boolean,
+    val bookTitle: String?,
+    val chapterTitle: String?,
+    val coverUri: String?,
+    val fictionId: String?,
+    val chapterId: String?,
+    val sleepTimerRemainingMs: Long?,
+) {
+    companion object {
+        /** No fiction loaded — drives the "Nothing playing" copy and
+         *  routes taps to MainActivity → Library instead of a reader. */
+        val Idle = NowPlayingSnapshot(
+            isIdle = true,
+            isPlaying = false,
+            bookTitle = null,
+            chapterTitle = null,
+            coverUri = null,
+            fictionId = null,
+            chapterId = null,
+            sleepTimerRemainingMs = null,
+        )
+
+        fun from(state: PlaybackState): NowPlayingSnapshot {
+            val idle = state.currentFictionId.isNullOrBlank() ||
+                state.currentChapterId.isNullOrBlank()
+            return NowPlayingSnapshot(
+                isIdle = idle,
+                isPlaying = state.isPlaying,
+                bookTitle = state.bookTitle?.takeIf { it.isNotBlank() },
+                chapterTitle = state.chapterTitle?.takeIf { it.isNotBlank() },
+                coverUri = state.coverUri?.takeIf { it.isNotBlank() },
+                fictionId = state.currentFictionId,
+                chapterId = state.currentChapterId,
+                sleepTimerRemainingMs = state.sleepTimerRemainingMs,
+            )
+        }
+    }
+}

--- a/app/src/main/kotlin/in/jphe/storyvox/widget/NowPlayingWidgetProvider.kt
+++ b/app/src/main/kotlin/in/jphe/storyvox/widget/NowPlayingWidgetProvider.kt
@@ -1,0 +1,243 @@
+package `in`.jphe.storyvox.widget
+
+import android.app.PendingIntent
+import android.appwidget.AppWidgetManager
+import android.appwidget.AppWidgetProvider
+import android.content.ComponentName
+import android.content.Context
+import android.content.Intent
+import android.os.Bundle
+import android.util.Log
+import dagger.hilt.EntryPoint
+import dagger.hilt.EntryPoints
+import dagger.hilt.InstallIn
+import dagger.hilt.components.SingletonComponent
+import `in`.jphe.storyvox.playback.PlaybackController
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.launch
+
+/**
+ * Issue #159 — home-screen now-playing widget.
+ *
+ * Adaptive RemoteViews: three layout buckets selected by cell size:
+ *  - 1x1 (≤2x1): cover only.
+ *  - 4x1 (height = 1): cover + title + Play/Pause + Next chapter.
+ *  - 4x2 (default): cover + title + chapter + sleep timer + full transport.
+ *
+ * State flow:
+ *  1. [WidgetStateObserver] (owned by [`in`.jphe.storyvox.StoryvoxApp])
+ *     subscribes to [PlaybackController.state] and re-broadcasts a
+ *     [ACTION_REFRESH] intent to every widget host whenever a
+ *     user-visible field changes (title, chapter, isPlaying, sleep
+ *     timer). That broadcast lands in [onReceive] which rebuilds the
+ *     RemoteViews from the latest snapshot — no `WorkManager` periodic
+ *     because the controller is already the source of truth.
+ *  2. Transport buttons dispatch [ACTION_PLAY_PAUSE], [ACTION_NEXT_CHAPTER]
+ *     and [ACTION_SLEEP_TOGGLE] back to this provider via PendingIntent.
+ *     Each one materializes the singleton [PlaybackController] via a
+ *     [WidgetEntryPoint] lookup and invokes the same methods that the
+ *     in-app transport row uses — no service-side duplication.
+ *  3. Tapping the cover routes through a [PendingIntent.getActivity]
+ *     into MainActivity with the same `EXTRA_OPEN_READER_*` extras the
+ *     notification carries (see DeepLinkResolver in navigation/), so
+ *     the user lands on the audiobook screen for the playing chapter.
+ *
+ * R8 keep:
+ *   `-keep class in.jphe.storyvox.widget.NowPlayingWidgetProvider { *; }`
+ *   (proguard-rules.pro) — Android system instantiates AppWidgetProvider
+ *   subclasses via reflection from the FQN in AndroidManifest.xml. R8
+ *   doesn't see that edge and would strip / rename the class.
+ *
+ * Threading:
+ *   onReceive runs on the main thread (BroadcastReceiver contract). We
+ *   `goAsync()` only for the `nextChapter` path because it's a suspend
+ *   call; the synchronous transport methods (`togglePlayPause`,
+ *   `toggleSleepTimer`) return immediately.
+ */
+class NowPlayingWidgetProvider : AppWidgetProvider() {
+
+    @EntryPoint
+    @InstallIn(SingletonComponent::class)
+    interface WidgetEntryPoint {
+        fun playbackController(): PlaybackController
+    }
+
+    override fun onUpdate(
+        context: Context,
+        appWidgetManager: AppWidgetManager,
+        appWidgetIds: IntArray,
+    ) {
+        // Either freshly added, or the system periodic update fired
+        // (we set updatePeriodMillis=0 so this only runs on enable /
+        // resize / explicit refresh). Re-render every host with the
+        // current PlaybackController snapshot.
+        val snapshot = readSnapshot(context)
+        for (id in appWidgetIds) {
+            val views = NowPlayingWidgetRenderer.build(
+                context = context,
+                appWidgetId = id,
+                appWidgetManager = appWidgetManager,
+                snapshot = snapshot,
+            )
+            appWidgetManager.updateAppWidget(id, views)
+        }
+    }
+
+    override fun onAppWidgetOptionsChanged(
+        context: Context,
+        appWidgetManager: AppWidgetManager,
+        appWidgetId: Int,
+        newOptions: Bundle,
+    ) {
+        // Re-pick the layout bucket whenever the user resizes. The
+        // host calls this whenever the cell width/height changes; we
+        // don't need to track the previous bucket because
+        // NowPlayingWidgetRenderer is pure-functional over the
+        // current options bundle.
+        val snapshot = readSnapshot(context)
+        val views = NowPlayingWidgetRenderer.build(
+            context = context,
+            appWidgetId = appWidgetId,
+            appWidgetManager = appWidgetManager,
+            snapshot = snapshot,
+        )
+        appWidgetManager.updateAppWidget(appWidgetId, views)
+    }
+
+    override fun onReceive(context: Context, intent: Intent) {
+        super.onReceive(context, intent)
+        when (intent.action) {
+            ACTION_PLAY_PAUSE -> {
+                runSafely(context) { it.togglePlayPause() }
+                pushRefresh(context)
+            }
+            ACTION_NEXT_CHAPTER -> {
+                // suspend call — defer to a coroutine. goAsync() keeps
+                // the receiver alive until pendingResult.finish() runs
+                // on the same scope after the suspend returns.
+                val pending = goAsync()
+                val scope = CoroutineScope(SupervisorJob() + Dispatchers.Default)
+                scope.launch {
+                    try {
+                        runSuspendSafely(context) { it.nextChapter() }
+                        pushRefresh(context)
+                    } finally {
+                        pending.finish()
+                    }
+                }
+            }
+            ACTION_SLEEP_TOGGLE -> {
+                runSafely(context) { it.toggleSleepTimer() }
+                pushRefresh(context)
+            }
+            ACTION_REFRESH -> {
+                // External broadcast (from WidgetStateObserver or
+                // anything else that wants the widget redrawn). Just
+                // re-run onUpdate manually for every host id.
+                val mgr = AppWidgetManager.getInstance(context)
+                val ids = mgr.getAppWidgetIds(
+                    ComponentName(context, NowPlayingWidgetProvider::class.java),
+                )
+                onUpdate(context, mgr, ids)
+            }
+        }
+    }
+
+    /**
+     * Issue #159 — broadcast a refresh to ourselves. Cheaper than
+     * calling AppWidgetManager.updateAppWidget directly because
+     * onReceive(ACTION_REFRESH) handles host-id enumeration in one
+     * place. Used by [WidgetStateObserver] every time a user-visible
+     * field on [PlaybackController.state] changes.
+     */
+    private fun pushRefresh(context: Context) {
+        val refresh = Intent(context, NowPlayingWidgetProvider::class.java).apply {
+            action = ACTION_REFRESH
+        }
+        context.sendBroadcast(refresh)
+    }
+
+    private fun readSnapshot(context: Context): NowPlayingSnapshot {
+        return try {
+            val controller = EntryPoints
+                .get(context.applicationContext, WidgetEntryPoint::class.java)
+                .playbackController()
+            NowPlayingSnapshot.from(controller.state.value)
+        } catch (t: Throwable) {
+            // Hilt graph not ready yet (extremely unlikely at this
+            // point — Application.onCreate has already run by the
+            // time any widget broadcast lands) or another bind
+            // failure. Render the idle layout rather than crashing
+            // the host process; widget receivers crashing leave
+            // ghost layouts on the launcher until the user re-adds
+            // the widget.
+            Log.w(TAG, "Failed to read playback snapshot for widget: ${t.message}")
+            NowPlayingSnapshot.Idle
+        }
+    }
+
+    private inline fun runSafely(context: Context, block: (PlaybackController) -> Unit) {
+        try {
+            val controller = EntryPoints
+                .get(context.applicationContext, WidgetEntryPoint::class.java)
+                .playbackController()
+            block(controller)
+        } catch (t: Throwable) {
+            Log.w(TAG, "Widget transport action failed: ${t.message}")
+        }
+    }
+
+    private suspend inline fun runSuspendSafely(
+        context: Context,
+        block: (PlaybackController) -> Unit,
+    ) {
+        try {
+            val controller = EntryPoints
+                .get(context.applicationContext, WidgetEntryPoint::class.java)
+                .playbackController()
+            block(controller)
+        } catch (t: Throwable) {
+            Log.w(TAG, "Widget async action failed: ${t.message}")
+        }
+    }
+
+    companion object {
+        private const val TAG = "NowPlayingWidget"
+
+        /** Toggle play/pause on the active chapter. No-op when nothing is loaded. */
+        const val ACTION_PLAY_PAUSE = "in.jphe.storyvox.widget.action.PLAY_PAUSE"
+
+        /** Advance to the next chapter. Uses PlaybackController.nextChapter()
+         *  which is a suspend call; we wrap with goAsync(). */
+        const val ACTION_NEXT_CHAPTER = "in.jphe.storyvox.widget.action.NEXT_CHAPTER"
+
+        /** Start a 15min sleep timer, or cancel the active one — same
+         *  PlaybackController.toggleSleepTimer() the bluetooth long-press
+         *  fires. */
+        const val ACTION_SLEEP_TOGGLE = "in.jphe.storyvox.widget.action.SLEEP_TOGGLE"
+
+        /** Internal — pushed by [WidgetStateObserver] every time a
+         *  user-visible PlaybackState field changes. Rebroadcasts to
+         *  every active widget id. */
+        const val ACTION_REFRESH = "in.jphe.storyvox.widget.action.REFRESH"
+
+        /** Convenience for [WidgetStateObserver] — emits a refresh
+         *  broadcast without needing to import the action constant
+         *  + build the intent inline. */
+        fun broadcastRefresh(context: Context) {
+            val intent = Intent(context, NowPlayingWidgetProvider::class.java).apply {
+                action = ACTION_REFRESH
+            }
+            context.sendBroadcast(intent)
+        }
+
+        /** PendingIntent flags appropriate for widget transport
+         *  broadcasts — IMMUTABLE is required on API 31+, UPDATE_CURRENT
+         *  so repeat-rendering with new extras (per-widget-id requests)
+         *  overwrites the prior intent payload. */
+        const val PENDING_FLAGS =
+            PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_IMMUTABLE
+    }
+}

--- a/app/src/main/kotlin/in/jphe/storyvox/widget/NowPlayingWidgetRenderer.kt
+++ b/app/src/main/kotlin/in/jphe/storyvox/widget/NowPlayingWidgetRenderer.kt
@@ -1,0 +1,267 @@
+package `in`.jphe.storyvox.widget
+
+import android.app.PendingIntent
+import android.appwidget.AppWidgetManager
+import android.content.ComponentName
+import android.content.Context
+import android.content.Intent
+import android.net.Uri
+import android.os.Build
+import android.os.Bundle
+import android.view.View
+import android.widget.RemoteViews
+import androidx.annotation.LayoutRes
+import `in`.jphe.storyvox.R
+
+/**
+ * Issue #159 — pure-functional RemoteViews builder. Given the current
+ * snapshot + the host's reported cell dimensions, picks one of three
+ * layouts and wires up text / image / PendingIntent fields.
+ *
+ * Layout buckets:
+ *  - 1x1: height < ~110dp AND width < ~180dp → cover only.
+ *  - 4x1: height < ~110dp                     → cover + title + 2 transport.
+ *  - 4x2: default                             → full layout.
+ *
+ * (The size thresholds are AppWidgetOptions' min-cell reports in dp.
+ * The system also supplies `targetCellWidth` / `targetCellHeight` on
+ * API 31+ which we prefer when present — that's the user's actual
+ * grid dimension, not the launcher's announce-on-add fallback.)
+ */
+internal object NowPlayingWidgetRenderer {
+
+    fun build(
+        context: Context,
+        appWidgetId: Int,
+        appWidgetManager: AppWidgetManager,
+        snapshot: NowPlayingSnapshot,
+    ): RemoteViews {
+        // AppWidgetManager.getAppWidgetOptions can return null on rare
+        // legacy launcher implementations — guard with an empty bundle.
+        val opts: Bundle = appWidgetManager.getAppWidgetOptions(appWidgetId) ?: Bundle()
+        val cellWidth = readCellCount(
+            opts,
+            preferKey = AppWidgetManager.OPTION_APPWIDGET_MIN_WIDTH,
+            api31Key = "appWidgetSizeRequestedCellWidth",
+            fallbackCells = 4,
+        )
+        val cellHeight = readCellCount(
+            opts,
+            preferKey = AppWidgetManager.OPTION_APPWIDGET_MIN_HEIGHT,
+            api31Key = "appWidgetSizeRequestedCellHeight",
+            fallbackCells = 2,
+        )
+
+        @LayoutRes val layoutId = pickLayout(cellWidth, cellHeight)
+        val views = RemoteViews(context.packageName, layoutId)
+        bind(context, views, layoutId, snapshot)
+        return views
+    }
+
+    /**
+     * Pick the layout bucket from reported cell counts. The thresholds
+     * are deliberately generous on the small side so a user who shrinks
+     * to "almost 1x1" doesn't get a layout with overflowing text.
+     */
+    @LayoutRes
+    private fun pickLayout(cellWidth: Int, cellHeight: Int): Int = when {
+        cellWidth <= 1 && cellHeight <= 1 -> R.layout.widget_now_playing_1x1
+        cellHeight <= 1 -> R.layout.widget_now_playing_4x1
+        else -> R.layout.widget_now_playing_4x2
+    }
+
+    private fun bind(
+        context: Context,
+        views: RemoteViews,
+        @LayoutRes layoutId: Int,
+        snapshot: NowPlayingSnapshot,
+    ) {
+        // Cover — common to every layout.
+        bindCover(views, snapshot)
+
+        // Title block — text on the 4x1 and 4x2 variants only.
+        if (layoutId != R.layout.widget_now_playing_1x1) {
+            bindTextBlock(context, views, snapshot)
+        }
+
+        // Transport buttons — Play/Pause + Next on 4x1, plus Sleep on 4x2.
+        if (layoutId == R.layout.widget_now_playing_4x1 ||
+            layoutId == R.layout.widget_now_playing_4x2
+        ) {
+            bindTransport(context, views, snapshot, includeSleep = layoutId == R.layout.widget_now_playing_4x2)
+        }
+
+        // Cover / text tap → reader deep-link. Wired on every layout
+        // so even the 1x1 cover-only variant is interactive.
+        val openReader = PendingIntent.getActivity(
+            context,
+            REQ_OPEN_READER,
+            buildOpenReaderIntent(context, snapshot),
+            NowPlayingWidgetProvider.PENDING_FLAGS,
+        )
+        views.setOnClickPendingIntent(R.id.widget_root, openReader)
+    }
+
+    private fun bindCover(views: RemoteViews, snapshot: NowPlayingSnapshot) {
+        val coverUri = snapshot.coverUri
+        if (coverUri != null && isLocalUri(coverUri)) {
+            // RemoteViews.setImageViewUri works for content://, file://,
+            // and absolute file paths. Remote http(s) URIs need a
+            // bitmap-fetched setImageViewBitmap (Coil-side load is a
+            // follow-up; widget is not the right surface to do
+            // synchronous network work).
+            views.setImageViewUri(R.id.widget_cover, Uri.parse(coverUri))
+        } else {
+            views.setImageViewResource(R.id.widget_cover, R.drawable.ic_widget_book_placeholder)
+        }
+    }
+
+    private fun bindTextBlock(
+        context: Context,
+        views: RemoteViews,
+        snapshot: NowPlayingSnapshot,
+    ) {
+        val bookTitle = snapshot.bookTitle ?: context.getString(R.string.widget_idle_title)
+        val chapterTitle = snapshot.chapterTitle ?: context.getString(R.string.widget_idle_body)
+        views.setTextViewText(R.id.widget_book_title, bookTitle)
+        views.setTextViewText(R.id.widget_chapter_title, chapterTitle)
+
+        // Sleep-timer remaining (4x2 only — element absent from the
+        // 4x1 layout, RemoteViews silently no-ops setViewVisibility
+        // on absent ids so we always try the show/hide and let the
+        // layout dictate whether the view exists).
+        val remainingMs = snapshot.sleepTimerRemainingMs
+        if (remainingMs != null && remainingMs > 0) {
+            val formatted = formatRemaining(remainingMs)
+            views.setTextViewText(
+                R.id.widget_sleep_remaining,
+                context.getString(R.string.widget_sleep_remaining, formatted),
+            )
+            views.setViewVisibility(R.id.widget_sleep_remaining, View.VISIBLE)
+        } else {
+            views.setViewVisibility(R.id.widget_sleep_remaining, View.GONE)
+        }
+    }
+
+    private fun bindTransport(
+        context: Context,
+        views: RemoteViews,
+        snapshot: NowPlayingSnapshot,
+        includeSleep: Boolean,
+    ) {
+        // Play/Pause toggle icon depends on `isPlaying`.
+        val playIcon = if (snapshot.isPlaying) {
+            R.drawable.ic_widget_pause
+        } else {
+            R.drawable.ic_widget_play
+        }
+        views.setImageViewResource(R.id.widget_btn_play_pause, playIcon)
+        views.setOnClickPendingIntent(
+            R.id.widget_btn_play_pause,
+            broadcast(context, NowPlayingWidgetProvider.ACTION_PLAY_PAUSE, REQ_PLAY_PAUSE),
+        )
+
+        // Next chapter — disabled visually when idle, but tap still
+        // arms the controller (no-op if no chapter loaded; matches
+        // bluetooth next-button behavior).
+        views.setOnClickPendingIntent(
+            R.id.widget_btn_next,
+            broadcast(context, NowPlayingWidgetProvider.ACTION_NEXT_CHAPTER, REQ_NEXT),
+        )
+
+        if (includeSleep) {
+            views.setOnClickPendingIntent(
+                R.id.widget_btn_sleep,
+                broadcast(context, NowPlayingWidgetProvider.ACTION_SLEEP_TOGGLE, REQ_SLEEP),
+            )
+        }
+    }
+
+    private fun broadcast(context: Context, action: String, requestCode: Int): PendingIntent {
+        val intent = Intent(context, NowPlayingWidgetProvider::class.java).apply {
+            this.action = action
+        }
+        return PendingIntent.getBroadcast(
+            context,
+            requestCode,
+            intent,
+            NowPlayingWidgetProvider.PENDING_FLAGS,
+        )
+    }
+
+    private fun buildOpenReaderIntent(
+        context: Context,
+        snapshot: NowPlayingSnapshot,
+    ): Intent {
+        // Reuse DeepLinkResolver's notification-tap extras so the same
+        // navigation path lights up. When idle, omit the extras —
+        // MainActivity defaults to Library.
+        val intent = Intent().apply {
+            component = ComponentName(context, MAIN_ACTIVITY_FQN)
+            flags = Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_CLEAR_TOP
+        }
+        if (!snapshot.isIdle) {
+            intent.putExtra(EXTRA_OPEN_READER_FICTION_ID, snapshot.fictionId)
+            intent.putExtra(EXTRA_OPEN_READER_CHAPTER_ID, snapshot.chapterId)
+        }
+        return intent
+    }
+
+    /**
+     * AppWidgetOptions returns sizes in dp. Cell math is approximate
+     * (different launchers use different cell sizes; canonical Pixel
+     * is ~74dp per cell on a 5-column grid). We treat ≤110dp height
+     * as "1 row" and ≤180dp width as "≤2 columns", which lines up
+     * with both the Pixel launcher and Samsung One UI grids.
+     *
+     * On API 31+ the system also exposes `appWidgetSizeRequested*`
+     * keys carrying the user's grid coordinates directly — when
+     * present we use them, when absent we fall back to the dp math.
+     */
+    private fun readCellCount(
+        opts: Bundle,
+        preferKey: String,
+        api31Key: String,
+        fallbackCells: Int,
+    ): Int {
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
+            val cells = opts.getInt(api31Key, -1)
+            if (cells > 0) return cells
+        }
+        val sizeDp = opts.getInt(preferKey, -1)
+        if (sizeDp <= 0) return fallbackCells
+        // 74dp per cell on canonical Pixel; round to nearest.
+        return ((sizeDp + 36) / 74).coerceAtLeast(1)
+    }
+
+    private fun isLocalUri(value: String): Boolean {
+        return value.startsWith("content://") ||
+            value.startsWith("file://") ||
+            value.startsWith("/")
+    }
+
+    private fun formatRemaining(ms: Long): String {
+        val totalSeconds = (ms / 1000L).coerceAtLeast(0L)
+        val minutes = totalSeconds / 60L
+        val seconds = totalSeconds % 60L
+        return "%d:%02d".format(minutes, seconds)
+    }
+
+    private const val MAIN_ACTIVITY_FQN = "in.jphe.storyvox.MainActivity"
+
+    // Keep these in lockstep with DeepLinkResolver.EXTRA_OPEN_READER_*.
+    // We literal-string them here so :app's widget module doesn't take
+    // a hard dep on the navigation package, but the values must match.
+    private const val EXTRA_OPEN_READER_FICTION_ID = "storyvox.open_reader.fiction_id"
+    private const val EXTRA_OPEN_READER_CHAPTER_ID = "storyvox.open_reader.chapter_id"
+
+    // Distinct request codes per PendingIntent so the system caches
+    // them separately. Without unique codes, PendingIntent.getBroadcast
+    // returns the same instance for every action and only the last
+    // .setExtras() wins.
+    private const val REQ_PLAY_PAUSE = 0x10_01
+    private const val REQ_NEXT = 0x10_02
+    private const val REQ_SLEEP = 0x10_03
+    private const val REQ_OPEN_READER = 0x10_04
+}
+

--- a/app/src/main/kotlin/in/jphe/storyvox/widget/WidgetStateObserver.kt
+++ b/app/src/main/kotlin/in/jphe/storyvox/widget/WidgetStateObserver.kt
@@ -1,0 +1,113 @@
+package `in`.jphe.storyvox.widget
+
+import android.content.Context
+import dagger.hilt.android.qualifiers.ApplicationContext
+import `in`.jphe.storyvox.playback.PlaybackController
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.flow.distinctUntilChanged
+import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.launch
+import javax.inject.Inject
+import javax.inject.Singleton
+
+/**
+ * Issue #159 — pushes [NowPlayingWidgetProvider] refresh broadcasts
+ * whenever the user-visible slice of [PlaybackController.state]
+ * changes. Owned by [`in`.jphe.storyvox.StoryvoxApp]; started in
+ * the deferred-init coroutine that materializes the rest of the Hilt
+ * graph so the collector spins up after the cold-launch frame budget.
+ *
+ * Why not WorkManager periodic?
+ *   PlaybackController.state is already a hot StateFlow with the
+ *   exact data we render. A WorkManager periodic adds 15-minute
+ *   latency and burns battery sampling state that hasn't moved. A
+ *   collector on the existing StateFlow is push-driven and costs
+ *   one coroutine + one extra broadcast per state change.
+ *
+ * Why not call AppWidgetManager.updateAppWidget directly here?
+ *   The broadcast roundtrip keeps the host-id enumeration + layout-
+ *   picking in ONE place ([NowPlayingWidgetProvider.onReceive]).
+ *   Without it, this class would need to know about every layout
+ *   bucket and every PendingIntent the provider wires — duplicating
+ *   the renderer. The broadcast overhead is microseconds; the code-
+ *   shape win is worth it.
+ *
+ * Why a singleton on the app classpath?
+ *   :app is the only module that can take a hard dep on
+ *   [PlaybackController] AND own the widget receiver, since
+ *   AppWidgetProvider must live in the application's manifest. The
+ *   :core-playback module doesn't know about widgets; the widget
+ *   receiver couldn't go there anyway per Android constraints.
+ */
+@Singleton
+class WidgetStateObserver @Inject constructor(
+    @ApplicationContext private val context: Context,
+    private val controller: PlaybackController,
+) {
+    private val scope = CoroutineScope(SupervisorJob() + Dispatchers.Default)
+    private var job: Job? = null
+
+    /**
+     * Idempotent — calling [start] twice is a no-op. The caller
+     * (StoryvoxApp.onCreate's deferred-init block) invokes this
+     * once at startup after the Hilt graph is materialized.
+     */
+    fun start() {
+        if (job?.isActive == true) return
+        job = scope.launch {
+            controller.state
+                // Project to the same slice the renderer consumes.
+                // Without distinctUntilChanged the widget would re-
+                // render at every sentence boundary (the
+                // currentSentenceRange field on PlaybackState ticks
+                // 5-10x/sec under playback). distinctUntilChanged on
+                // a narrow projection means we broadcast only when
+                // a user-visible field actually moved.
+                .map { state ->
+                    WidgetVisibleSlice(
+                        isPlaying = state.isPlaying,
+                        bookTitle = state.bookTitle,
+                        chapterTitle = state.chapterTitle,
+                        coverUri = state.coverUri,
+                        fictionId = state.currentFictionId,
+                        chapterId = state.currentChapterId,
+                        // Round to whole seconds so the 1Hz timer
+                        // tick doesn't pummel the widget host.
+                        sleepRemainingSec = state.sleepTimerRemainingMs?.div(1000L),
+                    )
+                }
+                .distinctUntilChanged()
+                .collect {
+                    NowPlayingWidgetProvider.broadcastRefresh(context)
+                }
+        }
+    }
+
+    /** Test / shutdown hook. Not wired today — the app process is the
+     *  observer's natural lifetime. Future: tear down on
+     *  ComponentCallbacks2.TRIM_MEMORY_UI_HIDDEN if profile data shows
+     *  the collector is meaningful idle-state cost. */
+    internal fun stop() {
+        job?.cancel()
+        job = null
+    }
+}
+
+/**
+ * Internal equality basis for [WidgetStateObserver]'s
+ * `distinctUntilChanged`. Mirrors [NowPlayingSnapshot] but with a
+ * second-resolution sleep timer so a 1-second timer tick collapses
+ * to no broadcast unless the displayed value actually changes.
+ */
+private data class WidgetVisibleSlice(
+    val isPlaying: Boolean,
+    val bookTitle: String?,
+    val chapterTitle: String?,
+    val coverUri: String?,
+    val fictionId: String?,
+    val chapterId: String?,
+    val sleepRemainingSec: Long?,
+)

--- a/app/src/main/res/drawable/ic_widget_book_placeholder.xml
+++ b/app/src/main/res/drawable/ic_widget_book_placeholder.xml
@@ -1,0 +1,22 @@
+<!--
+  Widget cover placeholder — open-book glyph at 48dp on a brass-tinted
+  background. Used by the 1x1 and 4x1 layouts when no fiction is
+  currently loaded (cold-start, after `stopSelf`, or in the launcher's
+  picker preview). Mirrors the ic_storyvox_notif.xml outline so the
+  widget reads as "the same app" even when nothing is playing.
+-->
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="48dp"
+    android:height="48dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24"
+    android:tint="?attr/colorControlNormal">
+    <path
+        android:fillColor="@android:color/white"
+        android:fillAlpha="0.85"
+        android:pathData="M3,5.5C3,4.7 3.7,4 4.5,4H11V18.5L4.5,18.5C3.7,18.5 3,17.8 3,17V5.5ZM5,6V16.5L9.5,16.5V6L5,6Z" />
+    <path
+        android:fillColor="@android:color/white"
+        android:fillAlpha="0.85"
+        android:pathData="M13,4H19.5C20.3,4 21,4.7 21,5.5V17C21,17.8 20.3,18.5 19.5,18.5H13V4ZM14.5,6V16.5L19,16.5V6L14.5,6Z" />
+</vector>

--- a/app/src/main/res/drawable/ic_widget_next.xml
+++ b/app/src/main/res/drawable/ic_widget_next.xml
@@ -1,0 +1,16 @@
+<!--
+  Widget transport — Next chapter. Material Symbols "skip_next" at 24dp.
+  Triangle + bar; this maps to PlaybackController.nextChapter() (not
+  next-sentence). The widget surfaces chapter-granular nav because at
+  home-screen scale, sentence steps are too granular to be useful.
+-->
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24"
+    android:tint="?attr/colorControlNormal">
+    <path
+        android:fillColor="@android:color/white"
+        android:pathData="M6,18L14.5,12L6,6V18ZM16,6V18H18V6H16Z" />
+</vector>

--- a/app/src/main/res/drawable/ic_widget_pause.xml
+++ b/app/src/main/res/drawable/ic_widget_pause.xml
@@ -1,0 +1,14 @@
+<!--
+  Widget transport — Pause. Material Symbols "pause" filled at 24dp.
+  Two solid bars; tint behavior identical to ic_widget_play.xml.
+-->
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24"
+    android:tint="?attr/colorControlNormal">
+    <path
+        android:fillColor="@android:color/white"
+        android:pathData="M6,5H10V19H6V5ZM14,5H18V19H14V5Z" />
+</vector>

--- a/app/src/main/res/drawable/ic_widget_play.xml
+++ b/app/src/main/res/drawable/ic_widget_play.xml
@@ -1,0 +1,17 @@
+<!--
+  Widget transport — Play. Material Symbols "play_arrow" filled at 24dp.
+  Drawn as a solid white triangle; the RemoteViews ImageView tints this
+  to the brass accent (widget_on_surface) at render time via
+  setColorFilter / android:tint on the layout. White source pixels mean
+  the tint reads cleanly regardless of the runtime accent color.
+-->
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24"
+    android:tint="?attr/colorControlNormal">
+    <path
+        android:fillColor="@android:color/white"
+        android:pathData="M8,5V19L19,12L8,5Z" />
+</vector>

--- a/app/src/main/res/drawable/ic_widget_sleep.xml
+++ b/app/src/main/res/drawable/ic_widget_sleep.xml
@@ -1,0 +1,17 @@
+<!--
+  Widget transport — Sleep timer toggle. Material Symbols "bedtime"
+  (crescent moon) at 24dp. Tapping invokes
+  PlaybackController.toggleSleepTimer() which starts a 15-minute timer
+  if none is armed, or cancels the running one — matching the
+  bluetooth long-press behaviour in MediaButtonHandler.
+-->
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24"
+    android:tint="?attr/colorControlNormal">
+    <path
+        android:fillColor="@android:color/white"
+        android:pathData="M9.5,2C5.36,2 2,5.36 2,9.5C2,13.64 5.36,17 9.5,17C13.64,17 17,13.64 17,9.5C17,9.16 16.97,8.82 16.93,8.5C16.07,9.42 14.85,10 13.5,10C10.74,10 8.5,7.76 8.5,5C8.5,3.65 9.08,2.43 10,1.57C9.68,1.53 9.34,1.5 9.5,1.5C9.5,1.5 9.5,2 9.5,2Z" />
+</vector>

--- a/app/src/main/res/drawable/widget_background.xml
+++ b/app/src/main/res/drawable/widget_background.xml
@@ -1,0 +1,18 @@
+<!--
+  Widget chrome — rounded warm-dark surface that backstops every size
+  variant. The fill is a fallback for pre-Android-12 devices that
+  cannot resolve `?attr/colorSurfaceContainer` through Material-You
+  dynamic theming; on Android 12+ the AppWidgetProvider re-tints to
+  the device wallpaper accent at render time (see
+  NowPlayingWidgetProvider.buildRemoteViews).
+
+  Corner radius is 24dp — matches the Material You launcher-widget
+  corner expectation. The widget host on most launchers also rounds
+  via WindowInsets; 24dp here just keeps us looking right on
+  launchers that don't auto-round.
+-->
+<shape xmlns:android="http://schemas.android.com/apk/res/android"
+    android:shape="rectangle">
+    <solid android:color="@color/widget_surface" />
+    <corners android:radius="24dp" />
+</shape>

--- a/app/src/main/res/drawable/widget_button_background.xml
+++ b/app/src/main/res/drawable/widget_button_background.xml
@@ -1,0 +1,14 @@
+<!--
+  Transport-button background — circular brass-tinted surface that
+  reads as a tappable target on both light and dark wallpapers.
+  Used by Play/Pause/Next/Sleep ImageButtons in widget_now_playing_4x1
+  and _4x2. Mirrors the Material 3 filled-tonal-icon-button shape.
+
+  Pre-31 devices see the brass fallback (@color/widget_button_surface);
+  Android 12+ launchers re-tint via the AppWidget Material You theme
+  hook in NowPlayingWidgetProvider.
+-->
+<shape xmlns:android="http://schemas.android.com/apk/res/android"
+    android:shape="oval">
+    <solid android:color="@color/widget_button_surface" />
+</shape>

--- a/app/src/main/res/layout/widget_now_playing_1x1.xml
+++ b/app/src/main/res/layout/widget_now_playing_1x1.xml
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  1x1 layout — cover only. Bucket selected by NowPlayingWidgetProvider
+  when the host reports a target cell smaller than 2x1 (see
+  pickLayout()). Tapping the cover routes through the same
+  EXTRA_OPEN_READER_* deep-link the notification uses; the receiver
+  resolves to the audiobook screen for whatever's currently playing
+  (or MainActivity → Library when nothing is loaded).
+
+  RemoteViews limits: every interactive surface must be a child of a
+  PendingIntent-wrapped view. The root FrameLayout carries the open-
+  reader intent; transport controls don't fit at 1x1 so we drop them
+  entirely rather than miniaturize them past a tappable target.
+-->
+<FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:id="@+id/widget_root"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:background="@drawable/widget_background"
+    android:padding="8dp">
+
+    <ImageView
+        android:id="@+id/widget_cover"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:scaleType="centerCrop"
+        android:src="@drawable/ic_widget_book_placeholder"
+        android:contentDescription="@string/widget_now_playing_label" />
+</FrameLayout>

--- a/app/src/main/res/layout/widget_now_playing_4x1.xml
+++ b/app/src/main/res/layout/widget_now_playing_4x1.xml
@@ -1,0 +1,84 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  4x1 layout — cover + title + Play/Pause + Next. Selected by
+  pickLayout() when the host reports `targetCellHeight == 1` (or a
+  legacy AppWidgetOptions minHeight < 110dp).
+
+  Sleep-timer toggle is dropped at 4x1 because it's the least-used of
+  the four controls; users who arm a sleep timer typically do so from
+  the audiobook screen or via a bluetooth long-press. Bumping up to
+  4x2 reveals it (and the chapter line). All three remaining surfaces
+  (cover, title block, transport row) are PendingIntent-wired
+  separately so each tap target hits the right action.
+-->
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:id="@+id/widget_root"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:orientation="horizontal"
+    android:background="@drawable/widget_background"
+    android:padding="10dp"
+    android:gravity="center_vertical">
+
+    <ImageView
+        android:id="@+id/widget_cover"
+        android:layout_width="56dp"
+        android:layout_height="56dp"
+        android:scaleType="centerCrop"
+        android:src="@drawable/ic_widget_book_placeholder"
+        android:contentDescription="@string/widget_now_playing_label" />
+
+    <LinearLayout
+        android:id="@+id/widget_text_block"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:layout_weight="1"
+        android:layout_marginStart="10dp"
+        android:layout_marginEnd="6dp"
+        android:orientation="vertical">
+
+        <TextView
+            android:id="@+id/widget_book_title"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:textSize="14sp"
+            android:textStyle="bold"
+            android:textColor="@color/widget_on_surface"
+            android:maxLines="1"
+            android:ellipsize="end"
+            tools:ignore="UnusedAttribute"
+            android:text="@string/widget_idle_title" />
+
+        <TextView
+            android:id="@+id/widget_chapter_title"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:textSize="12sp"
+            android:textColor="@color/widget_on_surface_variant"
+            android:maxLines="1"
+            android:ellipsize="end"
+            android:text="@string/widget_idle_body" />
+    </LinearLayout>
+
+    <ImageButton
+        android:id="@+id/widget_btn_play_pause"
+        android:layout_width="40dp"
+        android:layout_height="40dp"
+        android:background="@drawable/widget_button_background"
+        android:src="@drawable/ic_widget_play"
+        android:scaleType="centerInside"
+        android:padding="8dp"
+        android:contentDescription="@string/widget_action_play" />
+
+    <ImageButton
+        android:id="@+id/widget_btn_next"
+        android:layout_width="40dp"
+        android:layout_height="40dp"
+        android:layout_marginStart="6dp"
+        android:background="@drawable/widget_button_background"
+        android:src="@drawable/ic_widget_next"
+        android:scaleType="centerInside"
+        android:padding="8dp"
+        android:contentDescription="@string/widget_action_next" />
+</LinearLayout>

--- a/app/src/main/res/layout/widget_now_playing_4x2.xml
+++ b/app/src/main/res/layout/widget_now_playing_4x2.xml
@@ -1,0 +1,121 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  4x2 layout — cover + book/chapter title + sleep-timer remaining +
+  full transport row (Play/Pause / Next / Sleep). Default cell size
+  declared in xml/widget_now_playing_info.xml (targetCellWidth=4,
+  targetCellHeight=2).
+
+  Row 1: cover (left) + title block (book + chapter + optional sleep-
+         timer remaining countdown).
+  Row 2: transport buttons centred horizontally.
+
+  Tap behaviour:
+   - Cover or text-block → audiobook deep-link for current chapter.
+   - Each transport button is its own PendingIntent broadcasting back
+     to NowPlayingWidgetProvider (see ACTION_* constants).
+-->
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:id="@+id/widget_root"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:orientation="vertical"
+    android:background="@drawable/widget_background"
+    android:padding="12dp">
+
+    <LinearLayout
+        android:layout_width="match_parent"
+        android:layout_height="0dp"
+        android:layout_weight="1"
+        android:orientation="horizontal"
+        android:gravity="center_vertical">
+
+        <ImageView
+            android:id="@+id/widget_cover"
+            android:layout_width="64dp"
+            android:layout_height="64dp"
+            android:scaleType="centerCrop"
+            android:src="@drawable/ic_widget_book_placeholder"
+            android:contentDescription="@string/widget_now_playing_label" />
+
+        <LinearLayout
+            android:id="@+id/widget_text_block"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginStart="12dp"
+            android:orientation="vertical">
+
+            <TextView
+                android:id="@+id/widget_book_title"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:textSize="15sp"
+                android:textStyle="bold"
+                android:textColor="@color/widget_on_surface"
+                android:maxLines="1"
+                android:ellipsize="end"
+                android:text="@string/widget_idle_title" />
+
+            <TextView
+                android:id="@+id/widget_chapter_title"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:textSize="13sp"
+                android:textColor="@color/widget_on_surface_variant"
+                android:maxLines="1"
+                android:ellipsize="end"
+                android:text="@string/widget_idle_body" />
+
+            <TextView
+                android:id="@+id/widget_sleep_remaining"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:textSize="11sp"
+                android:textColor="@color/widget_accent"
+                android:maxLines="1"
+                android:ellipsize="end"
+                android:visibility="gone"
+                tools:ignore="UnusedAttribute" />
+        </LinearLayout>
+    </LinearLayout>
+
+    <LinearLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="8dp"
+        android:orientation="horizontal"
+        android:gravity="center">
+
+        <ImageButton
+            android:id="@+id/widget_btn_play_pause"
+            android:layout_width="44dp"
+            android:layout_height="44dp"
+            android:background="@drawable/widget_button_background"
+            android:src="@drawable/ic_widget_play"
+            android:scaleType="centerInside"
+            android:padding="10dp"
+            android:contentDescription="@string/widget_action_play" />
+
+        <ImageButton
+            android:id="@+id/widget_btn_next"
+            android:layout_width="44dp"
+            android:layout_height="44dp"
+            android:layout_marginStart="12dp"
+            android:background="@drawable/widget_button_background"
+            android:src="@drawable/ic_widget_next"
+            android:scaleType="centerInside"
+            android:padding="10dp"
+            android:contentDescription="@string/widget_action_next" />
+
+        <ImageButton
+            android:id="@+id/widget_btn_sleep"
+            android:layout_width="44dp"
+            android:layout_height="44dp"
+            android:layout_marginStart="12dp"
+            android:background="@drawable/widget_button_background"
+            android:src="@drawable/ic_widget_sleep"
+            android:scaleType="centerInside"
+            android:padding="10dp"
+            android:contentDescription="@string/widget_action_sleep_start" />
+    </LinearLayout>
+</LinearLayout>

--- a/app/src/main/res/values-night/widget_colors.xml
+++ b/app/src/main/res/values-night/widget_colors.xml
@@ -1,0 +1,24 @@
+<!--
+  Widget palette — dark-mode counterpart to values/widget_colors.xml.
+  Pre-Android-12 night fallback: BrassRamp.Brass400 (slightly brighter
+  for AA contrast on the warm-dark surface) and SurfaceTokens dark
+  values.
+
+  Android 12+ launchers running in night mode get the dynamic
+  Material You tint instead (NowPlayingWidgetProvider re-binds the
+  accent at render time). These values only apply where the launcher
+  doesn't honor the wallpaper accent — e.g. a pre-31 device or a
+  third-party launcher running its own theme engine.
+-->
+<resources>
+    <!-- BrassRamp.Brass400 (#C9A774) — brighter on dark for AA. -->
+    <color name="widget_accent">#FFC9A774</color>
+    <!-- SurfaceTokens.SurfaceContainerDark. -->
+    <color name="widget_surface">#FF15131A</color>
+    <!-- SurfaceTokens.SurfaceContainerHighDark — button chip. -->
+    <color name="widget_button_surface">#FF1B1822</color>
+    <!-- SurfaceTokens.OnSurfaceDark — title text. -->
+    <color name="widget_on_surface">#FFE8DFD1</color>
+    <!-- SurfaceTokens.OnSurfaceVariantDark — secondary text. -->
+    <color name="widget_on_surface_variant">#FFB8AE9F</color>
+</resources>

--- a/app/src/main/res/values/widget_colors.xml
+++ b/app/src/main/res/values/widget_colors.xml
@@ -1,0 +1,28 @@
+<!--
+  Widget palette — brass-on-cream fallback values used pre-Android-12
+  and as the light-mode source-of-truth on Android 12+ launchers that
+  don't extract a Material You accent. Values mirror the
+  `:core-ui` Library Nocturne palette (BrassRamp / SurfaceTokens.Light)
+  so the widget reads as part of the same app even with no dynamic
+  color in play.
+
+  On Android 12+ the AppWidgetProvider overrides these with
+  `android.R.color.system_accent1_*` references at runtime so the
+  widget tracks the user's wallpaper. See
+  NowPlayingWidgetProvider.applyMaterialYouTint.
+
+  Light-mode (this file) — paper-cream surfaces, deep brass text.
+  Night-mode counterpart at values-night/widget_colors.xml.
+-->
+<resources>
+    <!-- BrassRamp.Brass500 (#B48C5A) — primary accent. -->
+    <color name="widget_accent">#FFB48C5A</color>
+    <!-- SurfaceTokens.SurfaceContainerLight — widget chrome. -->
+    <color name="widget_surface">#FFEBE2D3</color>
+    <!-- SurfaceTokens.SurfaceContainerHighLight — button chip. -->
+    <color name="widget_button_surface">#FFE5DCCB</color>
+    <!-- SurfaceTokens.OnSurfaceLight — title/body text. -->
+    <color name="widget_on_surface">#FF1A1614</color>
+    <!-- SurfaceTokens.OnSurfaceVariantLight — secondary text (chapter title). -->
+    <color name="widget_on_surface_variant">#FF4A4338</color>
+</resources>

--- a/app/src/main/res/values/widget_strings.xml
+++ b/app/src/main/res/values/widget_strings.xml
@@ -1,0 +1,18 @@
+<!--
+  Widget-facing strings. Kept in a separate file from strings.xml so the
+  widget concern doesn't bloat the main bundle when scanning for the
+  app name. Pluralized strings would land in res/values/plurals.xml;
+  none today (no count-bearing widget copy).
+-->
+<resources>
+    <string name="widget_now_playing_label">storyvox — Now playing</string>
+    <string name="widget_now_playing_description">Now-playing chapter with transport controls. Resize to reveal cover, title, chapter, and sleep-timer toggle.</string>
+    <string name="widget_idle_title">Nothing playing</string>
+    <string name="widget_idle_body">Open storyvox to start an audiobook</string>
+    <string name="widget_action_play">Play</string>
+    <string name="widget_action_pause">Pause</string>
+    <string name="widget_action_next">Next chapter</string>
+    <string name="widget_action_sleep_start">Start sleep timer</string>
+    <string name="widget_action_sleep_stop">Cancel sleep timer</string>
+    <string name="widget_sleep_remaining">Sleep in %1$s</string>
+</resources>

--- a/app/src/main/res/xml/widget_now_playing_info.xml
+++ b/app/src/main/res/xml/widget_now_playing_info.xml
@@ -1,0 +1,48 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  AppWidgetProvider metadata for the storyvox now-playing widget
+  (#159).
+
+  Sizing strategy — adaptive RemoteViews:
+   - `minWidth` / `minHeight` set the smallest legal grid bucket
+     (80dp ≈ 1x1 on the canonical Pixel launcher cell).
+   - `targetCellWidth` / `targetCellHeight` (API 31+) request the
+     default landing size on Material You launchers — a 4x2 strip.
+   - `maxResizeWidth` / `maxResizeHeight` cap the resize ceiling so
+     the widget doesn't get stretched into a useless billboard. The
+     widget itself picks one of three layouts inside
+     NowPlayingWidgetProvider.onAppWidgetOptionsChanged based on the
+     reported cell size.
+   - `resizeMode="horizontal|vertical"` lets the user drag both axes.
+
+  `widgetCategory="home_screen"` — keyguard widgets were deprecated in
+  API 21; home-screen-only matches everything from a Pixel launcher to
+  Nova / Smart Launcher.
+
+  `initialLayout` is the 4x2 variant because that's the default cell
+  size and what the host shows in the picker. The actual rendered
+  layout switches via updateAppWidget(...) the first time the OS
+  reports the real grid size to onAppWidgetOptionsChanged.
+
+  `previewLayout` (API 31+) — using `initialLayout` directly until we
+  add a separate static preview asset. The picker shows the layout
+  with the idle/placeholder strings.
+
+  `configure` left unset — no per-instance configuration; the widget
+  always reflects the global playback state (this matches Pocket Casts
+  / Spotify / The Voice app pattern; per-fiction pinning is a
+  follow-up issue if anyone asks).
+-->
+<appwidget-provider xmlns:android="http://schemas.android.com/apk/res/android"
+    android:minWidth="80dp"
+    android:minHeight="80dp"
+    android:targetCellWidth="4"
+    android:targetCellHeight="2"
+    android:maxResizeWidth="400dp"
+    android:maxResizeHeight="220dp"
+    android:updatePeriodMillis="0"
+    android:initialLayout="@layout/widget_now_playing_4x2"
+    android:previewLayout="@layout/widget_now_playing_4x2"
+    android:resizeMode="horizontal|vertical"
+    android:widgetCategory="home_screen"
+    android:description="@string/widget_now_playing_description" />

--- a/app/src/test/kotlin/in/jphe/storyvox/widget/NowPlayingSnapshotTest.kt
+++ b/app/src/test/kotlin/in/jphe/storyvox/widget/NowPlayingSnapshotTest.kt
@@ -1,0 +1,97 @@
+package `in`.jphe.storyvox.widget
+
+import `in`.jphe.storyvox.playback.PlaybackState
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * Issue #159 — projection from PlaybackState to the widget's narrow
+ * visible-slice. These tests exist because the widget's
+ * distinctUntilChanged depends on this projection collapsing
+ * irrelevant churn (sentence-range ticking 10x/sec, buffering toggle,
+ * error transitions). If the projection accidentally widens, the
+ * widget will broadcast on every frame and burn host CPU.
+ */
+class NowPlayingSnapshotTest {
+
+    @Test fun `idle when no chapter loaded`() {
+        val state = PlaybackState() // defaults — no fictionId/chapterId
+        val snap = NowPlayingSnapshot.from(state)
+        assertTrue(snap.isIdle)
+        assertFalse(snap.isPlaying)
+        assertNull(snap.bookTitle)
+        assertNull(snap.chapterTitle)
+    }
+
+    @Test fun `idle when fiction id is blank`() {
+        val state = PlaybackState(
+            currentFictionId = "",
+            currentChapterId = "ch-1",
+            bookTitle = "x",
+        )
+        assertTrue(NowPlayingSnapshot.from(state).isIdle)
+    }
+
+    @Test fun `idle when chapter id is blank`() {
+        val state = PlaybackState(
+            currentFictionId = "fid-1",
+            currentChapterId = "",
+            bookTitle = "x",
+        )
+        assertTrue(NowPlayingSnapshot.from(state).isIdle)
+    }
+
+    @Test fun `active snapshot carries book and chapter titles`() {
+        val state = PlaybackState(
+            currentFictionId = "fid-1",
+            currentChapterId = "ch-1",
+            bookTitle = "Worth the Candle",
+            chapterTitle = "Chapter 1: Tabletop",
+            isPlaying = true,
+        )
+        val snap = NowPlayingSnapshot.from(state)
+        assertFalse(snap.isIdle)
+        assertTrue(snap.isPlaying)
+        assertEquals("Worth the Candle", snap.bookTitle)
+        assertEquals("Chapter 1: Tabletop", snap.chapterTitle)
+        assertEquals("fid-1", snap.fictionId)
+        assertEquals("ch-1", snap.chapterId)
+    }
+
+    @Test fun `blank string titles project to null so the widget falls back to idle copy`() {
+        val state = PlaybackState(
+            currentFictionId = "fid-1",
+            currentChapterId = "ch-1",
+            bookTitle = "   ",
+            chapterTitle = "",
+            isPlaying = true,
+        )
+        val snap = NowPlayingSnapshot.from(state)
+        // Still "playing" (we have ids) — but the renderer will use
+        // the idle strings because both titles came back null.
+        assertFalse(snap.isIdle)
+        assertNull(snap.bookTitle)
+        assertNull(snap.chapterTitle)
+    }
+
+    @Test fun `sleep timer remaining flows through unchanged`() {
+        val state = PlaybackState(
+            currentFictionId = "fid-1",
+            currentChapterId = "ch-1",
+            sleepTimerRemainingMs = 15 * 60 * 1000L,
+        )
+        assertEquals(15 * 60 * 1000L, NowPlayingSnapshot.from(state).sleepTimerRemainingMs)
+    }
+
+    @Test fun `idle constant has no ids and is not playing`() {
+        val snap = NowPlayingSnapshot.Idle
+        assertTrue(snap.isIdle)
+        assertFalse(snap.isPlaying)
+        assertNull(snap.fictionId)
+        assertNull(snap.chapterId)
+        assertNull(snap.coverUri)
+    }
+}


### PR DESCRIPTION
## Summary

- Adds a home-screen now-playing widget (closes #159). Adaptive RemoteViews: 1x1 (cover-only), 4x1 (cover + title + Play/Pause + Next), 4x2 (full — adds sleep-timer toggle + remaining-time chip). Default landing is 4x2.
- Material You tinting on Android 12+; brass-on-warm-dark fallback palette pre-31 mirrors the in-app `:core-ui` Library Nocturne palette.
- Transport buttons (`Play/Pause`, `Next chapter`, `Sleep toggle`) dispatch to a singleton `PlaybackController` resolved via a Hilt `@EntryPoint`, sharing the exact methods the in-app transport row and bluetooth multi-tap handler use — zero duplication.
- Cover/text tap routes through the existing `DeepLinkResolver.EXTRA_OPEN_READER_*` extras the playback notification uses, so the user lands on the audiobook screen for the currently-playing chapter (or Library when idle).
- Live updates: a `WidgetStateObserver` collects `PlaybackController.state` on a narrow visible-slice projection (book/chapter title, isPlaying, sleep-timer remaining in whole seconds, cover URI, ids). `distinctUntilChanged` collapses the 5-10Hz sentence-range churn so we only broadcast on user-visible changes — no `WorkManager` periodic, no fixed-interval poll.
- R8 keep rules added for `NowPlayingWidgetProvider` + its Hilt `EntryPoint` interface (the receiver is loaded by FQN reflection from the manifest; R8 cannot see that edge).

## Files

New code:
- `app/src/main/kotlin/in/jphe/storyvox/widget/NowPlayingWidgetProvider.kt` — `AppWidgetProvider` subclass; handles `APPWIDGET_UPDATE`, `onAppWidgetOptionsChanged` (re-pick layout on resize), and the four custom action broadcasts.
- `NowPlayingSnapshot.kt` — narrow projection of `PlaybackState` used by the renderer and tests.
- `NowPlayingWidgetRenderer.kt` — pure-functional `RemoteViews` builder; layout picker reads `targetCellWidth/Height` (API 31+) and falls back to dp math otherwise.
- `WidgetStateObserver.kt` — `@Singleton` collector started from `StoryvoxApp.onCreate`'s deferred-init block.

New resources:
- `res/xml/widget_now_playing_info.xml` — provider info: `minWidth=80dp`, `minHeight=80dp`, `targetCellWidth=4`, `targetCellHeight=2`, `maxResize=400dp/220dp`, `resizeMode=horizontal|vertical`, `updatePeriodMillis=0` (push-driven).
- `res/layout/widget_now_playing_{1x1,4x1,4x2}.xml`
- `res/drawable/ic_widget_{play,pause,next,sleep,book_placeholder}.xml`
- `res/drawable/widget_{background,button_background}.xml`
- `res/values{,-night}/widget_colors.xml` — brass-on-cream / brass-on-warm-dark palettes mirroring `:core-ui`'s `BrassRamp` + `SurfaceTokens`.
- `res/values/widget_strings.xml`

Modified:
- `AndroidManifest.xml` — receiver declared with `exported="true"` (AppWidget contract; transport broadcasts are scoped to our package via explicit `ComponentName` in every `PendingIntent`).
- `proguard-rules.pro` — keep rules.
- `StoryvoxApp.kt` — injects + starts `WidgetStateObserver` in the deferred-init scope.
- New `NowPlayingSnapshotTest` (7 cases).

## Test plan

- [x] `./gradlew :app:assembleDebug :app:testDebugUnitTest :core-playback:testDebugUnitTest :feature:testDebugUnitTest` — BUILD SUCCESSFUL, R8 minification passes.
- [x] `NowPlayingSnapshotTest` — 7/7 pass, covers idle/active projection edge cases (blank ids, blank titles, sleep-timer flow-through).
- [x] Installed APK on Tab A7 Lite (R83W80CAFZB); HoneySpace launcher's `addWidgetToList` logged the new provider in its picker.
- [x] Triggered each transport action via `am broadcast` — `PLAY_PAUSE`, `NEXT_CHAPTER`, `SLEEP_TOGGLE`, `REFRESH` — all return `result=0`, no FATAL exceptions in logcat, idle-state handling is graceful (`runSafely` swallows the no-op).
- [ ] Manual: pin the widget to the home screen, start an audiobook, verify cover + title populate, Play/Pause toggles the icon, Sleep-timer toggle starts a 15min countdown shown as `MM:SS` in the 4x2 chip.
- [ ] Manual: resize from 4x2 → 4x1 → 1x1 and back; verify each bucket renders correctly without overflowing text.
- [ ] Copilot review pass.

Closes #159.