### PR TITLE
feat(source-slack): channels-as-fictions via Slack Bot API — closes #454

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -285,6 +285,10 @@ dependencies {
     implementation(project(":source-plos"))
     implementation(project(":source-discord"))
     implementation(project(":source-telegram"))
+    // Issue #454 — Slack Web API backend. Channels-as-fictions via
+    // Bot Token auth (xoxb-…). Mirrors :source-telegram's leaf
+    // shape; the SlackConfigImpl + DataStore wiring lives in :app.
+    implementation(project(":source-slack"))
     // Issue #472 — magic-link Readability catch-all. Must be on the
     // app classpath so its KSP-generated SourcePluginDescriptor binding
     // joins the Hilt multibinding set the registry consumes.

--- a/app/src/main/kotlin/in/jphe/storyvox/data/SlackConfigImpl.kt
+++ b/app/src/main/kotlin/in/jphe/storyvox/data/SlackConfigImpl.kt
@@ -1,0 +1,165 @@
+package `in`.jphe.storyvox.data
+
+import android.content.Context
+import android.content.SharedPreferences
+import androidx.datastore.core.DataStore
+import androidx.datastore.preferences.core.Preferences
+import androidx.datastore.preferences.core.edit
+import androidx.datastore.preferences.core.stringPreferencesKey
+import androidx.datastore.preferences.preferencesDataStore
+import dagger.hilt.android.qualifiers.ApplicationContext
+import `in`.jphe.storyvox.source.slack.config.SlackConfig
+import `in`.jphe.storyvox.source.slack.config.SlackConfigState
+import `in`.jphe.storyvox.source.slack.config.SlackDefaults
+import javax.inject.Inject
+import javax.inject.Singleton
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.combine
+import kotlinx.coroutines.flow.distinctUntilChanged
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.flow.map
+
+/**
+ * Issue #454 — DataStore for the small slice of Slack config that
+ * isn't secret. Mirrors the Discord shape: plaintext bits in
+ * DataStore (workspace name + url, captured at `auth.test` time for
+ * empty-state copy), the bot token in EncryptedSharedPreferences.
+ */
+private val Context.slackDataStore: DataStore<Preferences> by preferencesDataStore(
+    name = "storyvox_slack",
+)
+
+private object SlackKeys {
+    /** Cached workspace name from the last successful `auth.test`,
+     *  so the Settings card can render "Browsing TechEmpower"
+     *  without an extra round-trip. Empty until the user authenticates. */
+    val WORKSPACE_NAME = stringPreferencesKey("pref_slack_workspace_name")
+
+    /** Cached workspace URL (e.g. `https://techempower.slack.com/`)
+     *  from the last successful `auth.test`. */
+    val WORKSPACE_URL = stringPreferencesKey("pref_slack_workspace_url")
+}
+
+/** EncryptedSharedPreferences key for the Slack bot token. Lives
+ *  next to the Discord / Telegram tokens in `storyvox.secrets`.
+ *  The literal key string is the spec-provided one from issue
+ *  #454; matches the entry in
+ *  [`in`.jphe.storyvox.sync.domain.SecretsSyncer.SECRET_KEY_NAMES]
+ *  so the token syncs cross-device through InstantDB. */
+internal const val SLACK_BOT_TOKEN_PREF = "pref_source_slack_token"
+
+/**
+ * Issue #454 — production [SlackConfig]. Workspace name/url in
+ * plaintext DataStore (cached labels, no secrets), bot token in
+ * EncryptedSharedPreferences alongside the other source tokens.
+ *
+ * Mirrors [DiscordConfigImpl] and [TelegramConfigImpl] — the
+ * parallel structure keeps the secrets store one consistent surface
+ * across `:source-discord`, `:source-telegram`, `:source-slack`,
+ * `:source-notion`, and `:source-outline`.
+ *
+ * Defaults: empty token + empty workspace metadata (no baked-in
+ * default — any default would imply storyvox auto-knows your
+ * workspace, which doesn't fit the ToS posture).
+ */
+@Singleton
+class SlackConfigImpl(
+    private val store: DataStore<Preferences>,
+    private val secrets: SharedPreferences,
+) : SlackConfig {
+
+    @Inject constructor(
+        @ApplicationContext context: Context,
+        secrets: SharedPreferences,
+    ) : this(context.slackDataStore, secrets)
+
+    /**
+     * Tick bumped whenever [setApiToken] runs so the [state] flow
+     * re-emits with the fresh token value. SharedPreferences doesn't
+     * expose a Flow on its own — same pattern as `DiscordConfigImpl`
+     * / `TelegramConfigImpl` / `OutlineConfigImpl` use for their
+     * token legs.
+     */
+    private val secretsTick = MutableStateFlow(0L)
+
+    override val state: Flow<SlackConfigState> = combine(
+        store.data.map { prefs ->
+            (prefs[SlackKeys.WORKSPACE_NAME].orEmpty()) to
+                (prefs[SlackKeys.WORKSPACE_URL].orEmpty())
+        }.distinctUntilChanged(),
+        secretsTick,
+    ) { (name, url), _ ->
+        val token = secrets.getString(SLACK_BOT_TOKEN_PREF, "") ?: ""
+        SlackConfigState(
+            apiToken = token,
+            workspaceName = name,
+            workspaceUrl = url,
+            baseUrl = SlackDefaults.BASE_URL,
+        )
+    }.distinctUntilChanged()
+
+    override suspend fun current(): SlackConfigState {
+        val prefs = store.data.first()
+        val token = secrets.getString(SLACK_BOT_TOKEN_PREF, "") ?: ""
+        return SlackConfigState(
+            apiToken = token,
+            workspaceName = prefs[SlackKeys.WORKSPACE_NAME].orEmpty(),
+            workspaceUrl = prefs[SlackKeys.WORKSPACE_URL].orEmpty(),
+            baseUrl = SlackDefaults.BASE_URL,
+        )
+    }
+
+    /**
+     * Persist the bot token. Null/blank clears the store entry so
+     * the source returns AuthRequired on subsequent calls. Bumps
+     * [secretsTick] so the state flow re-emits without an explicit
+     * Settings re-fetch.
+     */
+    fun setApiToken(token: String?) {
+        if (token.isNullOrBlank()) {
+            secrets.edit().remove(SLACK_BOT_TOKEN_PREF).apply()
+        } else {
+            secrets.edit().putString(SLACK_BOT_TOKEN_PREF, token.trim()).apply()
+        }
+        secretsTick.value = secretsTick.value + 1
+    }
+
+    /** True when a non-empty bot token is stored. Drives the UI's
+     *  `slackTokenConfigured: Boolean` projection. */
+    fun isTokenConfigured(): Boolean =
+        !secrets.getString(SLACK_BOT_TOKEN_PREF, "").isNullOrBlank()
+
+    /**
+     * Persist the workspace metadata captured at `auth.test` time
+     * so the Settings card can render the friendly name without an
+     * extra round-trip on the next open. Empty input wipes the
+     * stored values (Settings "Forget Slack" path).
+     */
+    suspend fun setWorkspace(name: String, url: String) {
+        val trimmedName = name.trim()
+        val trimmedUrl = url.trim()
+        store.edit { prefs ->
+            if (trimmedName.isBlank() && trimmedUrl.isBlank()) {
+                prefs.remove(SlackKeys.WORKSPACE_NAME)
+                prefs.remove(SlackKeys.WORKSPACE_URL)
+            } else {
+                prefs[SlackKeys.WORKSPACE_NAME] = trimmedName
+                prefs[SlackKeys.WORKSPACE_URL] = trimmedUrl
+            }
+        }
+    }
+
+    /** Wipe workspace metadata + token — Settings "Forget Slack"
+     *  path (no UI affordance yet; available for diagnostics +
+     *  tests). After this call the source falls back to
+     *  AuthRequired on every fetch. */
+    suspend fun clear() {
+        store.edit { prefs ->
+            prefs.remove(SlackKeys.WORKSPACE_NAME)
+            prefs.remove(SlackKeys.WORKSPACE_URL)
+        }
+        secrets.edit().remove(SLACK_BOT_TOKEN_PREF).apply()
+        secretsTick.value = secretsTick.value + 1
+    }
+}

--- a/app/src/main/kotlin/in/jphe/storyvox/di/AppBindings.kt
+++ b/app/src/main/kotlin/in/jphe/storyvox/di/AppBindings.kt
@@ -209,6 +209,17 @@ object AppBindings {
     @Provides @Singleton
     fun provideTelegramConfig(impl: `in`.jphe.storyvox.data.TelegramConfigImpl): `in`.jphe.storyvox.source.telegram.config.TelegramConfig = impl
 
+    /** Bridges source-slack SlackConfig (#454) to the app-side
+     *  DataStore + EncryptedSharedPreferences impl. Bot token
+     *  encrypted under `pref_source_slack_token` in the shared
+     *  `storyvox.secrets` store (also listed in
+     *  [`in`.jphe.storyvox.sync.domain.SecretsSyncer.SECRET_KEY_NAMES]
+     *  so it syncs cross-device via InstantDB). Workspace name +
+     *  URL cached in plaintext DataStore for empty-state copy
+     *  without an extra `auth.test` round-trip. */
+    @Provides @Singleton
+    fun provideSlackConfig(impl: `in`.jphe.storyvox.data.SlackConfigImpl): `in`.jphe.storyvox.source.slack.config.SlackConfig = impl
+
     /**
      * Same singleton instance as [provideSettingsRepositoryUi], exposed under
      * the [PlaybackBufferConfig] contract so `core-playback`'s [EnginePlayer]

--- a/core-data/src/main/kotlin/in/jphe/storyvox/data/source/SourceIds.kt
+++ b/core-data/src/main/kotlin/in/jphe/storyvox/data/source/SourceIds.kt
@@ -155,6 +155,17 @@ object SourceIds {
      *  high-friction. v1 ships no search (Bot API has no
      *  full-text search endpoint). */
     const val TELEGRAM: String = "telegram"
+    /** Slack (#454) — fifth chat-platform backend in the storyvox
+     *  roster. Mapping: workspace → token scope (one token = one
+     *  workspace), channel → one fiction, message → one chapter.
+     *  Auth model is user-supplied Slack Bot Token (`xoxb-…`) — the
+     *  user creates a Slack app at api.slack.com, installs to a
+     *  workspace, copies the Bot User OAuth Token, and pastes it
+     *  in Settings. No bundled default token, no auto-join, no
+     *  legacy-token / xoxc cookie automation. Default OFF on fresh
+     *  installs because bot-token onboarding is high-friction and
+     *  Slack workspaces are private by default. */
+    const val SLACK: String = "slack"
     /** Palace Project (#502) — first library-borrowing backend. The
      *  Palace Project is open-source library management software backing
      *  many US public libraries (NYPL, BPL, etc.); the "Palace" mobile

--- a/core-sync/src/main/kotlin/in/jphe/storyvox/sync/domain/SecretsSyncer.kt
+++ b/core-sync/src/main/kotlin/in/jphe/storyvox/sync/domain/SecretsSyncer.kt
@@ -267,6 +267,12 @@ class SecretsSyncer @Inject constructor(
          */
         val SECRET_KEY_NAMES: Set<String> = setOf(
             "pref_source_discord_token",
+            // Issue #454 — Slack Bot Token (xoxb-…). Same posture as
+            // the Discord token: high-sensitivity workspace-scoped
+            // credential whose leak would expose the user's channel
+            // history. Synced through InstantDB to the user's other
+            // devices so a token paste on one device propagates.
+            "pref_source_slack_token",
         )
     }
 }

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -69,6 +69,12 @@ include(":source-discord")
 // twin to :source-discord but simpler — no thread coalescing, no
 // search, no server picker.
 include(":source-telegram")
+// Issue #454 — Slack Web API backend. Channels-as-fictions /
+// messages-as-chapters, mirrors :source-telegram's leaf shape but
+// with Slack's cursor-based pagination. Bot Token (xoxb-…) auth via
+// Settings. Default OFF on fresh installs because workspaces are
+// private and bot-token onboarding is high-friction.
+include(":source-slack")
 // Issue #472 — Readability4J catch-all for the magic-link paste flow.
 // Always-on, lowest-confidence match (0.1) so any HTTP(S) URL not
 // otherwise claimed by one of the 17 specialized backends still

--- a/source-slack/build.gradle.kts
+++ b/source-slack/build.gradle.kts
@@ -1,0 +1,45 @@
+plugins {
+    alias(libs.plugins.android.library)
+    alias(libs.plugins.kotlin.android)
+    alias(libs.plugins.ksp)
+    alias(libs.plugins.hilt)
+    alias(libs.plugins.kotlin.serialization)
+}
+
+android {
+    namespace = "in.jphe.storyvox.source.slack"
+    compileSdk = 35
+
+    defaultConfig {
+        minSdk = 26
+    }
+
+    compileOptions {
+        sourceCompatibility = JavaVersion.VERSION_17
+        targetCompatibility = JavaVersion.VERSION_17
+    }
+
+    kotlinOptions {
+        jvmTarget = "17"
+    }
+}
+
+dependencies {
+    implementation(project(":core-data"))
+    implementation(libs.kotlinx.coroutines.android)
+    implementation(libs.kotlinx.serialization.json)
+    implementation(libs.okhttp)
+    implementation(libs.okhttp.logging)
+
+    implementation(libs.hilt.android)
+    ksp(libs.hilt.compiler)
+
+    // Plugin-seam Phase 2 (#384) — emits the @SourcePlugin → @IntoSet
+    // SourcePluginDescriptor Hilt module for SlackSource. The matching
+    // legacy @IntoMap binding in di/SlackModule.kt is also present
+    // (dual-wire) until Phase 3 retires the legacy map.
+    ksp(project(":core-plugin-ksp"))
+
+    testImplementation(libs.junit)
+    testImplementation(libs.kotlinx.coroutines.test)
+}

--- a/source-slack/src/main/AndroidManifest.xml
+++ b/source-slack/src/main/AndroidManifest.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="utf-8"?>
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
+
+    <!-- Slack Web API at slack.com over HTTPS — needs INTERNET. No
+         background-network surface; all calls happen on user-driven
+         flows (Browse fetch, fiction-detail open, chapter open). -->
+    <uses-permission android:name="android.permission.INTERNET" />
+    <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
+
+</manifest>

--- a/source-slack/src/main/kotlin/in/jphe/storyvox/source/slack/SlackSource.kt
+++ b/source-slack/src/main/kotlin/in/jphe/storyvox/source/slack/SlackSource.kt
@@ -1,0 +1,509 @@
+package `in`.jphe.storyvox.source.slack
+
+import `in`.jphe.storyvox.data.source.FictionSource
+import `in`.jphe.storyvox.data.source.RouteMatch
+import `in`.jphe.storyvox.data.source.SourceIds
+import `in`.jphe.storyvox.data.source.UrlMatcher
+import `in`.jphe.storyvox.data.source.model.ChapterContent
+import `in`.jphe.storyvox.data.source.model.ChapterInfo
+import `in`.jphe.storyvox.data.source.model.FictionDetail
+import `in`.jphe.storyvox.data.source.model.FictionResult
+import `in`.jphe.storyvox.data.source.model.FictionStatus
+import `in`.jphe.storyvox.data.source.model.FictionSummary
+import `in`.jphe.storyvox.data.source.model.ListPage
+import `in`.jphe.storyvox.data.source.model.SearchQuery
+import `in`.jphe.storyvox.data.source.plugin.SourceCategory
+import `in`.jphe.storyvox.data.source.plugin.SourcePlugin
+import `in`.jphe.storyvox.source.slack.config.SlackConfig
+import `in`.jphe.storyvox.source.slack.config.SlackDefaults
+import `in`.jphe.storyvox.source.slack.net.SlackApi
+import `in`.jphe.storyvox.source.slack.net.SlackChannel
+import `in`.jphe.storyvox.source.slack.net.SlackMessage
+import javax.inject.Inject
+import javax.inject.Singleton
+
+/**
+ * Issue #454 — Slack as a fiction backend (Web API + Bot Token).
+ *
+ * **Mapping**
+ *
+ *  - **Workspace** = the token's scope. One token = one workspace.
+ *    Slack's API (unlike Discord's `users/@me/guilds`) doesn't have
+ *    a "list of workspaces this token spans" endpoint; the token IS
+ *    the workspace selector.
+ *  - **Channel** = one fiction. Channel name → fiction title,
+ *    channel topic → description, workspace name → "author"
+ *    placeholder.
+ *  - **Message** = one chapter. Slack's UX strongly favours
+ *    one-thought-per-message (vs. Discord's chat-burst pattern), so
+ *    v1 doesn't coalesce; a follow-up issue can add Discord-style
+ *    same-author coalescing if user feedback indicates it would help.
+ *  - **Attachments + files** = filenames + titles surfaced in the
+ *    chapter body so TTS narrates them ("Attachment:
+ *    dragon-sketch.png", "File: world-map-v2.jpg").
+ *  - **Threads** = surfaced as flat messages within the parent
+ *    channel for v1 (Discord-parity); each thread reply becomes its
+ *    own chapter in the channel timeline. A follow-up could map
+ *    thread parents to nested fictions.
+ *
+ * **Auth**: user-supplied **Bot User OAuth Token** (`xoxb-…`). The
+ * user creates a Slack app at api.slack.com, installs it to a
+ * workspace they're a member of, copies the Bot User OAuth Token,
+ * and pastes it in Settings → Library & Sync → Slack. Read scopes
+ * the bot needs: `channels:read`, `channels:history`,
+ * `groups:read`, `groups:history`, `users:read`. No bundled default
+ * token, no auto-install, no legacy user-token / xoxc cookie
+ * automation (banned by Slack ToS). Default OFF on fresh installs
+ * — Slack workspaces are private by definition and shouldn't show
+ * up in a fresh-install Browse picker.
+ *
+ * **Fiction ids**: `slack:<channelId>`. **Chapter ids**:
+ * `slack:<channelId>::ts-<messageTs>` where `messageTs` is Slack's
+ * string-encoded float ts (e.g. `1747340531.123456`). The ts is the
+ * canonical message identity in Slack — there's no separate
+ * snowflake id like Discord uses.
+ *
+ * **`supportsFollow = false`**: Slack channels don't have a follow
+ * semantic distinct from "the bot is a member". The user already
+ * chose to be in the channel (via the install + invite step); a
+ * per-channel follow toggle would be UI inconsistency.
+ *
+ * **`supportsSearch = false` in v1**: Slack's `search.messages`
+ * endpoint requires the `search:read` scope which is restricted on
+ * certain plan tiers (and not available to bot tokens on free
+ * workspaces at all — that endpoint is technically a User Token
+ * surface). v1 leaves Search off; a follow-up can add it behind a
+ * graceful-degrade empty state per the issue spec.
+ */
+@SourcePlugin(
+    id = SourceIds.SLACK,
+    displayName = "Slack",
+    // Default OFF on fresh installs — Slack workspaces are private
+    // by default and require a token before anything renders. The
+    // plugin manager card surfaces the integration so users who
+    // want it can enable it from Settings → Plugins.
+    defaultEnabled = false,
+    category = SourceCategory.Text,
+    supportsFollow = false,
+    supportsSearch = false,
+    description = "Bot-token-authed channel reader · workspace = scope, channel = fiction, message = chapter",
+    sourceUrl = "https://slack.com",
+)
+@Singleton
+internal class SlackSource @Inject constructor(
+    private val api: SlackApi,
+    private val config: SlackConfig,
+) : FictionSource, UrlMatcher {
+
+    override val id: String = SourceIds.SLACK
+    override val displayName: String = "Slack"
+    override val supportsFollow: Boolean = false
+
+    /** Issue #454 magic-link claim — `<workspace>.slack.com/archives/<CHANNEL>`
+     *  (Slack's canonical channel-archive URL shape) or the bare
+     *  `slack.com/archives/<CHANNEL>` form. Group 1 captures the
+     *  channel id; group 2 captures the optional `/p<TIMESTAMP>`
+     *  deep-link to a specific message (unused for routing in v1
+     *  but parsed so the regex doesn't reject the link).
+     *
+     *  We intentionally claim only the archive shape, not the
+     *  generic `slack.com/...` host — Slack hosts non-channel URLs
+     *  (`slack.com/intl/...`, marketing pages, `app.slack.com/client/...`)
+     *  that shouldn't surface as fictions. Confidence is set to
+     *  0.9 so a future, more specific Slack matcher (e.g. one
+     *  that resolves message permalinks to thread-as-fiction)
+     *  could override. */
+    override fun matchUrl(url: String): RouteMatch? {
+        val m = SLACK_ARCHIVE_URL_PATTERN.matchEntire(url.trim()) ?: return null
+        val channelId = m.groupValues[1]
+        return RouteMatch(
+            sourceId = SourceIds.SLACK,
+            fictionId = slackFictionId(channelId),
+            confidence = 0.9f,
+            label = "Slack channel",
+        )
+    }
+
+    // ─── browse ────────────────────────────────────────────────────────
+
+    /**
+     * Front-page = "channels in this workspace that the bot is a
+     * member of". v1 walks `conversations.list` once and renders
+     * every is_member=true channel as a fiction summary; pagination
+     * within the page-1 fetch chains cursors automatically (a
+     * workspace with >200 channels triggers a follow-up
+     * `cursor=<…>` call until exhausted).
+     */
+    override suspend fun popular(page: Int): FictionResult<ListPage<FictionSummary>> {
+        val state = config.current()
+        if (state.apiToken.isBlank()) {
+            return FictionResult.AuthRequired(
+                "Slack bot token not configured. " +
+                    "Paste a Bot User OAuth Token (xoxb-…) in " +
+                    "Settings → Library & Sync → Slack.",
+            )
+        }
+        if (page > 1) {
+            return FictionResult.Success(ListPage(items = emptyList(), page = page, hasNext = false))
+        }
+        val channels = when (val r = fetchAllChannels()) {
+            is FictionResult.Success -> r.value
+            is FictionResult.Failure -> return r
+        }
+        val items = channels
+            // Bots can only read history for channels they've been
+            // invited to. Non-member channels in the list response
+            // are visible-but-unread; filtering them keeps the
+            // Browse view honest.
+            .filter { it.isMember }
+            .sortedBy { it.name.lowercase() }
+            .map { it.toSummary(state.workspaceName) }
+        return FictionResult.Success(ListPage(items = items, page = 1, hasNext = false))
+    }
+
+    override suspend fun latestUpdates(page: Int): FictionResult<ListPage<FictionSummary>> =
+        // Slack doesn't expose a "recently-active channels" ordering
+        // distinct from the channel list. Collapse to popular() for
+        // v1; activity-based reordering would require N round-trips
+        // to fetch the last message per channel.
+        popular(page)
+
+    override suspend fun byGenre(
+        genre: String,
+        page: Int,
+    ): FictionResult<ListPage<FictionSummary>> =
+        // Slack has no built-in genre/category faceting.
+        FictionResult.Success(ListPage(items = emptyList(), page = 1, hasNext = false))
+
+    override suspend fun genres(): FictionResult<List<String>> =
+        FictionResult.Success(emptyList())
+
+    /**
+     * `search.messages` requires `search:read` scope on a User Token
+     * (bot tokens can't call it on most plan tiers). v1 returns an
+     * empty page so the UI renders the no-results empty state
+     * cleanly; the `@SourcePlugin(supportsSearch = false)` annotation
+     * keeps the Search tab hidden in Browse. A follow-up can add
+     * the endpoint behind the documented graceful-degrade empty
+     * state per the issue spec.
+     */
+    override suspend fun search(query: SearchQuery): FictionResult<ListPage<FictionSummary>> =
+        FictionResult.Success(ListPage(items = emptyList(), page = 1, hasNext = false))
+
+    // ─── detail ────────────────────────────────────────────────────────
+
+    /**
+     * One channel's recent history → chapter list. Walks
+     * `conversations.history` paginated (cursor-based), reverses to
+     * chronological order, filters out system-subtype messages
+     * (joins, leaves, pins, etc.), and renders each remaining
+     * message as a chapter.
+     *
+     * The chapter title is the first ~60 chars of the message text,
+     * collapsed to a single line, falling back to "Attachment:
+     * {name}" / "(empty message)" for media-only or empty posts.
+     */
+    override suspend fun fictionDetail(fictionId: String): FictionResult<FictionDetail> {
+        val state = config.current()
+        if (state.apiToken.isBlank()) {
+            return FictionResult.AuthRequired(
+                "Slack bot token not configured.",
+            )
+        }
+        val channelId = fictionId.toChannelId()
+            ?: return FictionResult.NotFound("Slack fiction id not recognized: $fictionId")
+
+        val channels = when (val r = fetchAllChannels()) {
+            is FictionResult.Success -> r.value
+            is FictionResult.Failure -> return r
+        }
+        val channel = channels.firstOrNull { it.id == channelId }
+            ?: return FictionResult.NotFound(
+                "Slack channel $channelId not found in workspace (bot may not be a member).",
+            )
+
+        val messages = when (val r = fetchAllMessages(channelId)) {
+            is FictionResult.Success -> r.value
+            is FictionResult.Failure -> return r
+        }
+
+        // Slack returns newest-first; reverse for chronological
+        // reading. Filter out system-subtype messages (joins,
+        // leaves, pins, etc.) — they don't belong in an audiobook
+        // chapter list.
+        val chronological = messages.asReversed().filter { it.isUserContentMessage() }
+
+        val chapters = chronological.mapIndexed { idx, msg ->
+            ChapterInfo(
+                id = chapterIdFor(fictionId, msg.ts),
+                sourceChapterId = "ts-${msg.ts}",
+                index = idx,
+                title = msg.titlePreview(),
+                publishedAt = msg.tsMillis(),
+            )
+        }
+
+        val summary = channel.toSummary(state.workspaceName).copy(
+            chapterCount = chapters.size,
+        )
+        return FictionResult.Success(FictionDetail(summary = summary, chapters = chapters))
+    }
+
+    /**
+     * One chapter body. Re-fetches the channel's recent history,
+     * locates the message whose ts matches the chapter, and renders
+     * the plain-text + attachment-filename body.
+     *
+     * We re-fetch rather than caching because the repository layer
+     * owns caching for storyvox; this source is stateless w.r.t.
+     * the caller.
+     */
+    override suspend fun chapter(
+        fictionId: String,
+        chapterId: String,
+    ): FictionResult<ChapterContent> {
+        val state = config.current()
+        if (state.apiToken.isBlank()) {
+            return FictionResult.AuthRequired(
+                "Slack bot token not configured.",
+            )
+        }
+        val channelId = fictionId.toChannelId()
+            ?: return FictionResult.NotFound("Slack fiction id not recognized: $fictionId")
+        val messageTs = chapterId.substringAfterLast("::ts-", "")
+            .takeIf { it.isNotBlank() }
+            ?: return FictionResult.NotFound("Slack chapter id not recognized: $chapterId")
+
+        val messages = when (val r = fetchAllMessages(channelId)) {
+            is FictionResult.Success -> r.value
+            is FictionResult.Failure -> return r
+        }
+        val chronological = messages.asReversed().filter { it.isUserContentMessage() }
+        val target = chronological.firstOrNull { it.ts == messageTs }
+            ?: return FictionResult.NotFound(
+                "Slack message $messageTs not in recent history for channel $channelId.",
+            )
+        val info = ChapterInfo(
+            id = chapterId,
+            sourceChapterId = "ts-${target.ts}",
+            index = chronological.indexOf(target),
+            title = target.titlePreview(),
+            publishedAt = target.tsMillis(),
+        )
+        return FictionResult.Success(
+            ChapterContent(
+                info = info,
+                htmlBody = target.toHtml(),
+                plainBody = target.toPlainText(),
+            ),
+        )
+    }
+
+    // ─── follow ────────────────────────────────────────────────────────
+
+    override suspend fun followsList(page: Int): FictionResult<ListPage<FictionSummary>> =
+        FictionResult.Success(ListPage(items = emptyList(), page = 1, hasNext = false))
+
+    override suspend fun setFollowed(
+        fictionId: String,
+        followed: Boolean,
+    ): FictionResult<Unit> = FictionResult.Success(Unit)
+
+    // ─── helpers ───────────────────────────────────────────────────────
+
+    /**
+     * Walk `conversations.list` pages until the cursor is empty (or
+     * we hit a safety cap). Slack's pagination is cursor-based; an
+     * empty `next_cursor` means "no more pages". Cap at
+     * [SlackDefaults.HISTORY_MAX_PAGES] to bound the worst case on
+     * massive workspaces.
+     */
+    private suspend fun fetchAllChannels(): FictionResult<List<SlackChannel>> {
+        val collected = mutableListOf<SlackChannel>()
+        var cursor = ""
+        var pages = 0
+        while (pages < SlackDefaults.HISTORY_MAX_PAGES) {
+            val page = when (val r = api.listConversations(cursor = cursor)) {
+                is FictionResult.Success -> r.value
+                is FictionResult.Failure -> return r
+            }
+            collected += page.channels
+            val nextCursor = page.responseMetadata?.nextCursor.orEmpty()
+            if (nextCursor.isBlank()) break
+            cursor = nextCursor
+            pages += 1
+        }
+        return FictionResult.Success(collected)
+    }
+
+    /**
+     * Walk `conversations.history` pages for one channel until
+     * `has_more` is false (or we hit the safety cap). Slack returns
+     * messages newest-first; we accumulate in that order and let
+     * the caller reverse for chronological rendering.
+     */
+    private suspend fun fetchAllMessages(channelId: String): FictionResult<List<SlackMessage>> {
+        val collected = mutableListOf<SlackMessage>()
+        var cursor = ""
+        var pages = 0
+        while (pages < SlackDefaults.HISTORY_MAX_PAGES) {
+            val page = when (val r = api.listMessages(channelId, cursor = cursor)) {
+                is FictionResult.Success -> r.value
+                is FictionResult.Failure -> return r
+            }
+            collected += page.messages
+            val nextCursor = page.responseMetadata?.nextCursor.orEmpty()
+            if (!page.hasMore || nextCursor.isBlank()) break
+            cursor = nextCursor
+            pages += 1
+        }
+        return FictionResult.Success(collected)
+    }
+
+    private fun SlackChannel.toSummary(workspaceName: String): FictionSummary {
+        val descriptionText = topic?.value?.takeIf { it.isNotBlank() }
+            ?: purpose?.value?.takeIf { it.isNotBlank() }
+        return FictionSummary(
+            id = slackFictionId(id),
+            sourceId = SourceIds.SLACK,
+            title = "#${name.ifBlank { id }}",
+            author = workspaceName.ifBlank { "Slack" },
+            description = descriptionText,
+            status = if (isArchived) FictionStatus.COMPLETED else FictionStatus.ONGOING,
+        )
+    }
+}
+
+// ─── helpers ──────────────────────────────────────────────────────────
+
+/** Slack archive-URL pattern. Captures the channel id (group 1) and
+ *  optional `/p<TIMESTAMP>` message permalink (group 2). Accepts the
+ *  three documented hostname shapes: workspace subdomain
+ *  (`<ws>.slack.com`), the bare apex (`slack.com`), and the web-app
+ *  shape (`app.slack.com/client/<TEAM>/<CHANNEL>` is intentionally
+ *  NOT matched here — that's a different URL grammar and would
+ *  require a separate matcher with team-id-aware fiction routing). */
+internal val SLACK_ARCHIVE_URL_PATTERN: Regex = Regex(
+    """^https?://(?:[\w-]+\.)?slack\.com/archives/([A-Z][A-Z0-9]+)(/p\d+)?(?:\?.*)?$""",
+    RegexOption.IGNORE_CASE,
+)
+
+/** Stable Slack fiction id from a channel id. */
+internal fun slackFictionId(channelId: String): String = "${SourceIds.SLACK}:$channelId"
+
+/** Compose a chapter id from a fiction id + Slack message ts. The
+ *  ts is Slack's canonical per-channel message identity — a
+ *  string-encoded float seconds-since-epoch like
+ *  `"1747340531.123456"`. We keep it as a string in the chapter id
+ *  to avoid float-rounding losing the microsecond suffix that
+ *  Slack relies on for uniqueness. */
+internal fun chapterIdFor(fictionId: String, messageTs: String): String =
+    "$fictionId::ts-$messageTs"
+
+/** Decode the channel id from a Slack fiction id, or null when the
+ *  id doesn't carry the `slack:` prefix. */
+internal fun String.toChannelId(): String? =
+    if (startsWith("${SourceIds.SLACK}:")) {
+        removePrefix("${SourceIds.SLACK}:").substringBefore("::").takeIf { it.isNotBlank() }
+    } else {
+        null
+    }
+
+/** Slack message subtypes that don't carry user-readable content
+ *  (channel joins, leaves, pin events, etc.). Filtered out at the
+ *  source layer — they don't belong in an audiobook chapter list.
+ *  Empty subtype = regular user message; included by default. */
+private val SYSTEM_SUBTYPES: Set<String> = setOf(
+    "channel_join",
+    "channel_leave",
+    "channel_topic",
+    "channel_purpose",
+    "channel_name",
+    "channel_archive",
+    "channel_unarchive",
+    "pinned_item",
+    "unpinned_item",
+    "group_join",
+    "group_leave",
+    "group_topic",
+    "group_purpose",
+    "group_name",
+    "group_archive",
+    "group_unarchive",
+    "tombstone",
+    "reminder_add",
+    "reminder_delete",
+)
+
+/** True when this message carries user-authored content worth
+ *  rendering as a chapter. Filters out system / join / leave /
+ *  pin / topic-change messages, but keeps regular user messages
+ *  (empty subtype) and `bot_message` (an actual bot post with text). */
+internal fun SlackMessage.isUserContentMessage(): Boolean {
+    val st = subtype ?: ""
+    if (st.isBlank()) return true
+    if (st == "bot_message" || st == "thread_broadcast") return true
+    return st !in SYSTEM_SUBTYPES
+}
+
+/** Build a chapter title from a Slack message: first ~60 chars of
+ *  text, newlines collapsed to spaces. Falls back to "Attachment:
+ *  filename" for file-only posts, then "(empty message)". */
+internal fun SlackMessage.titlePreview(): String {
+    val body = text.takeIf { it.isNotBlank() }
+    if (body != null) {
+        val flat = body.replace('\n', ' ').replace('\r', ' ').trim()
+        return if (flat.length <= 60) flat else flat.take(57).trimEnd() + "…"
+    }
+    val firstFile = files?.firstOrNull()
+    if (firstFile != null) {
+        val label = firstFile.title?.takeIf { it.isNotBlank() }
+            ?: firstFile.name?.takeIf { it.isNotBlank() }
+        if (label != null) return "Attachment: $label"
+    }
+    return "(empty message)"
+}
+
+/** Render a Slack message as HTML — text as a `<p>`, attachments
+ *  surfaced as `<p>Attachment: …</p>` lines so the reader view +
+ *  TTS both mention them. */
+internal fun SlackMessage.toHtml(): String {
+    val parts = buildList {
+        if (text.isNotBlank()) add("<p>${htmlEscape(text)}</p>")
+        files?.forEach { f ->
+            val label = f.title?.takeIf { it.isNotBlank() }
+                ?: f.name?.takeIf { it.isNotBlank() }
+            if (label != null) add("<p>Attachment: ${htmlEscape(label)}</p>")
+        }
+    }
+    return parts.joinToString("\n")
+}
+
+/** Plain-text projection for TTS. Strips markup; attachments become
+ *  natural-language lines so they narrate cleanly. */
+internal fun SlackMessage.toPlainText(): String {
+    val lines = buildList {
+        if (text.isNotBlank()) add(text)
+        files?.forEach { f ->
+            val label = f.title?.takeIf { it.isNotBlank() }
+                ?: f.name?.takeIf { it.isNotBlank() }
+            if (label != null) add("Attachment: $label")
+        }
+    }
+    return lines.joinToString("\n\n").trim()
+}
+
+/** Parse the Slack ts string into unix milliseconds. Slack's ts is
+ *  a string-encoded float seconds-since-epoch (e.g.
+ *  `"1747340531.123456"`); converting via Double preserves the
+ *  microsecond suffix to within milli precision, which is plenty
+ *  for chapter timestamps. Returns null if the string isn't
+ *  parseable. */
+internal fun SlackMessage.tsMillis(): Long? = ts.toDoubleOrNull()?.let { (it * 1000.0).toLong() }
+
+/** Minimal HTML escape — angle brackets, ampersand, double-quote. */
+internal fun htmlEscape(s: String): String = s
+    .replace("&", "&amp;")
+    .replace("<", "&lt;")
+    .replace(">", "&gt;")
+    .replace("\"", "&quot;")

--- a/source-slack/src/main/kotlin/in/jphe/storyvox/source/slack/SlackWorkspaceDirectory.kt
+++ b/source-slack/src/main/kotlin/in/jphe/storyvox/source/slack/SlackWorkspaceDirectory.kt
@@ -1,0 +1,92 @@
+package `in`.jphe.storyvox.source.slack
+
+import `in`.jphe.storyvox.data.source.model.FictionResult
+import `in`.jphe.storyvox.source.slack.net.SlackApi
+import javax.inject.Inject
+import javax.inject.Singleton
+
+/**
+ * Issue #454 — public-visibility lookup surface for Settings.
+ *
+ * Two roles:
+ *  - **Authenticate** — `auth.test` returns the bot identity +
+ *    workspace metadata, so the Settings card can confirm
+ *    "Authenticated as @bot in <workspace>" after a token paste.
+ *  - **Probe** — `conversations.list` reports back the channels the
+ *    bot is a member of. The Settings empty state can then surface
+ *    a friendly "your bot is in N channels" line vs. the more
+ *    anxious "your bot has not been invited to any channels yet."
+ *
+ * Declared as an interface (rather than a class) so test modules
+ * in `:app` can supply a no-op fake without reaching across the
+ * internal-visibility wall to the production constructor.
+ */
+interface SlackWorkspaceDirectory {
+
+    /**
+     * Verify the bot token + return the (workspace name, bot
+     * user-handle) pair, or null when unset / token invalid /
+     * network out. The workspace name is what the Settings card
+     * surfaces in its "authenticated as @bot in <workspace>" line.
+     */
+    suspend fun authenticate(): SlackAuth?
+
+    /**
+     * One walk of `conversations.list` filtered to channels the
+     * bot is a member of. Returns `(channelId, displayTitle)` pairs
+     * sorted by title. Empty on token failure or no joined
+     * channels.
+     */
+    suspend fun listChannels(): List<Pair<String, String>>
+
+    companion object {
+        /** Empty / no-op fake for tests that don't exercise the
+         *  Settings probe flow. */
+        val Empty: SlackWorkspaceDirectory = object : SlackWorkspaceDirectory {
+            override suspend fun authenticate(): SlackAuth? = null
+            override suspend fun listChannels(): List<Pair<String, String>> = emptyList()
+        }
+    }
+}
+
+/** Workspace authentication snapshot returned by
+ *  [SlackWorkspaceDirectory.authenticate]. Both fields may be empty
+ *  strings when Slack's `auth.test` doesn't return them (free-tier
+ *  workspaces sometimes redact the workspace url for bot tokens).
+ *  Carry the values plain so the Settings UI can fall back to
+ *  generic copy without a separate "is this populated" flag. */
+data class SlackAuth(
+    val workspaceName: String,
+    val workspaceUrl: String,
+    val botUser: String,
+)
+
+@Singleton
+internal class SlackWorkspaceDirectoryImpl @Inject constructor(
+    private val api: SlackApi,
+) : SlackWorkspaceDirectory {
+
+    override suspend fun authenticate(): SlackAuth? {
+        val resp = when (val r = api.authTest()) {
+            is FictionResult.Success -> r.value
+            is FictionResult.Failure -> return null
+        }
+        if (!resp.ok) return null
+        return SlackAuth(
+            workspaceName = resp.team.orEmpty(),
+            workspaceUrl = resp.url.orEmpty(),
+            botUser = resp.user.orEmpty(),
+        )
+    }
+
+    override suspend fun listChannels(): List<Pair<String, String>> {
+        val resp = when (val r = api.listConversations()) {
+            is FictionResult.Success -> r.value
+            is FictionResult.Failure -> return emptyList()
+        }
+        return resp.channels
+            .filter { it.isMember }
+            .map { it.id to "#${it.name.ifBlank { it.id }}" }
+            .sortedBy { it.second.lowercase() }
+    }
+}

--- a/source-slack/src/main/kotlin/in/jphe/storyvox/source/slack/config/SlackConfig.kt
+++ b/source-slack/src/main/kotlin/in/jphe/storyvox/source/slack/config/SlackConfig.kt
@@ -1,0 +1,79 @@
+package `in`.jphe.storyvox.source.slack.config
+
+import kotlinx.coroutines.flow.Flow
+
+/**
+ * Issue #454 — abstraction over the Slack source's persistent
+ * config. Mirrors the leaf-source pattern from `:source-discord` /
+ * `:source-telegram` / `:source-notion` / `:source-outline`: this
+ * module declares the interface + state shape; the host app supplies
+ * the EncryptedSharedPreferences-backed implementation.
+ *
+ * Auth model: **Bot Token only** (Slack OAuth `xoxb-…`). The user
+ * creates a Slack app at api.slack.com, installs it to a workspace
+ * they're a member of (or admin of, for shared deployments), and
+ * pastes the **Bot User OAuth Token** into Settings → Library &
+ * Sync → Slack. Read scopes the bot needs: `channels:read`,
+ * `channels:history`, `groups:read`, `groups:history`, `users:read`.
+ *
+ * One token = one workspace. Slack's API (unlike Discord's
+ * `users/@me/guilds`) doesn't expose a "list of workspaces this token
+ * spans"; the token IS the workspace selector. The optional
+ * `workspaceName` / `workspaceUrl` legs cache the human-readable
+ * workspace label so the empty-state copy can name the workspace
+ * without an extra `auth.test` round-trip.
+ *
+ * No bundled default token, no anonymous mode (Slack provides no
+ * public REST surface for workspace content), and no legacy
+ * user-token / xoxc cookie path (banned by Slack's API ToS).
+ *
+ * The token is stored in `storyvox.secrets` (Tink-backed
+ * EncryptedSharedPreferences) under the `pref_source_slack_token`
+ * key. There are no plaintext prefs that affect the source's wire
+ * calls in v1 — the channel list comes from `conversations.list`,
+ * not user-configured.
+ */
+interface SlackConfig {
+    /** Hot stream of the current config state. */
+    val state: Flow<SlackConfigState>
+
+    /** Synchronous snapshot for code paths that can't suspend. */
+    suspend fun current(): SlackConfigState
+}
+
+/**
+ * One Slack config state. Bot token is user-controlled; workspace
+ * name/url are derived from `auth.test` and cached for empty-state
+ * copy. Base URL is overridable for test fakes.
+ */
+data class SlackConfigState(
+    /** Slack Bot User OAuth Token. Format: `xoxb-<digits>-<digits>-<random>`
+     *  (e.g. `xoxb-1234567890-1234567890123-AbCdEfGhIjKl`). Empty
+     *  means the source returns AuthRequired on every call. Stored
+     *  encrypted; never exposed to the UI as a readable string
+     *  (the UiSettings projection only carries a
+     *  `tokenConfigured: Boolean`). */
+    val apiToken: String = "",
+
+    /** Optional human-readable workspace name, captured at
+     *  authentication time from `auth.test`'s `team` field, so the
+     *  empty-state CTA can say "Browsing TechEmpower" rather than
+     *  blank. Re-derived lazily on the next `auth.test` refresh. */
+    val workspaceName: String = "",
+
+    /** Optional workspace URL (e.g. `https://techempower.slack.com/`)
+     *  captured at authentication time from `auth.test`'s `url`
+     *  field. Used both for empty-state copy and as the canonical
+     *  host pattern for [`in`.jphe.storyvox.source.slack.SlackSource.matchUrl]. */
+    val workspaceUrl: String = "",
+
+    /** Slack Web API base URL. Defaults to slack.com; overridable
+     *  for test fakes. */
+    val baseUrl: String = `in`.jphe.storyvox.source.slack.config.SlackDefaults.BASE_URL,
+) {
+    /** True when the source can make API calls. Only requirement is
+     *  a configured bot token — channel discovery is automatic via
+     *  `conversations.list`, no server picker like Discord. */
+    val isConfigured: Boolean
+        get() = apiToken.isNotBlank()
+}

--- a/source-slack/src/main/kotlin/in/jphe/storyvox/source/slack/config/SlackDefaults.kt
+++ b/source-slack/src/main/kotlin/in/jphe/storyvox/source/slack/config/SlackDefaults.kt
@@ -1,0 +1,52 @@
+package `in`.jphe.storyvox.source.slack.config
+
+/**
+ * Issue #454 — Slack backend defaults. Minimal: no bundled bot
+ * token (ToS posture — storyvox doesn't ship credentials and won't
+ * auto-install into anyone's workspace), no default workspace (one
+ * token = one workspace; the user picks it via the install step
+ * on api.slack.com).
+ *
+ * The Slack Web API is hosted at `slack.com/api/<method>`. v1 only
+ * uses the stable, documented Web API surface — no RTM / Events
+ * websocket API (storyvox doesn't need real-time push for the
+ * channels-as-fictions read model), and no MCP / Socket Mode (those
+ * require a separate websocket server which doesn't fit the
+ * on-demand-fetch pattern the rest of the backends use).
+ */
+object SlackDefaults {
+    /** Slack Web API base URL. Methods are GET-able as
+     *  `https://slack.com/api/<method>?token=…&…`, though storyvox
+     *  uses the `Authorization: Bearer <token>` header form for
+     *  parity with the other backends. Overridable for test fakes
+     *  (the test classes inject a copy-of-SlackConfigState with their
+     *  own base URL). */
+    const val BASE_URL: String = "https://slack.com"
+
+    /** User-Agent header. Slack doesn't require a specific UA but
+     *  identifying ourselves makes abuse-team contact easier if a
+     *  bot misbehaves. Mirrors the Discord / Telegram UA pattern. */
+    const val USER_AGENT: String =
+        "Storyvox-Slack/1.0 (+https://github.com/techempower-org/storyvox)"
+
+    /** `conversations.list` page size. Slack caps this at 1000 but
+     *  recommends staying ≤200 for performance + rate-limit
+     *  friendliness (the endpoint is Tier 2 — ~20 req/min). 200 is
+     *  enough for the vast majority of workspaces in one page. */
+    const val CHANNELS_PAGE_SIZE: Int = 200
+
+    /** `conversations.history` page size. Slack caps at 1000;
+     *  storyvox uses 200 for parity with channels and to keep
+     *  per-page bandwidth modest on mobile. The source layer
+     *  exhausts pagination only on explicit chapter-list refresh,
+     *  so 200 messages per round-trip is a comfortable default. */
+    const val HISTORY_PAGE_SIZE: Int = 200
+
+    /** Max pages of `conversations.history` to walk per fiction
+     *  detail. Slack's pagination is cursor-based and unbounded;
+     *  capping at 5 pages (≤1000 messages = ~1000 chapters) prevents
+     *  a runaway loop on workspaces with massive channels. A
+     *  follow-up issue can lift this when storyvox grows a
+     *  load-more-chapters affordance in the Detail UI. */
+    const val HISTORY_MAX_PAGES: Int = 5
+}

--- a/source-slack/src/main/kotlin/in/jphe/storyvox/source/slack/di/SlackModule.kt
+++ b/source-slack/src/main/kotlin/in/jphe/storyvox/source/slack/di/SlackModule.kt
@@ -1,0 +1,86 @@
+package `in`.jphe.storyvox.source.slack.di
+
+import dagger.Binds
+import dagger.Module
+import dagger.Provides
+import dagger.hilt.InstallIn
+import dagger.hilt.components.SingletonComponent
+import dagger.multibindings.IntoMap
+import dagger.multibindings.StringKey
+import `in`.jphe.storyvox.data.source.FictionSource
+import `in`.jphe.storyvox.data.source.SourceIds
+import `in`.jphe.storyvox.source.slack.SlackSource
+import okhttp3.OkHttpClient
+import javax.inject.Qualifier
+import javax.inject.Singleton
+import java.util.concurrent.TimeUnit
+
+@Qualifier
+@Retention(AnnotationRetention.BINARY)
+annotation class SlackHttp
+
+/**
+ * Dedicated OkHttp client for the Slack Web API. Tight connect
+ * timeout (slack.com is on a fast global edge), generous read
+ * timeout (a 200-message `conversations.history` page can be ~300KB
+ * once file/attachment metadata is inlined). Connect retries handle
+ * the occasional transient TLS hiccup we see on cellular.
+ *
+ * Slack uses HTTP/2 keep-alive; OkHttp pools connections so a
+ * fictionDetail → chapter flow shares the same TLS handshake.
+ */
+@Module
+@InstallIn(SingletonComponent::class)
+internal object SlackHttpModule {
+
+    @Provides
+    @Singleton
+    @SlackHttp
+    fun provideClient(): OkHttpClient =
+        OkHttpClient.Builder()
+            .connectTimeout(5, TimeUnit.SECONDS)
+            .readTimeout(30, TimeUnit.SECONDS)
+            .writeTimeout(15, TimeUnit.SECONDS)
+            .followRedirects(true)
+            .followSslRedirects(true)
+            .retryOnConnectionFailure(true)
+            .build()
+
+    @Provides
+    @Singleton
+    fun provideSlackApi(
+        @SlackHttp client: OkHttpClient,
+        config: `in`.jphe.storyvox.source.slack.config.SlackConfig,
+    ): `in`.jphe.storyvox.source.slack.net.SlackApi =
+        `in`.jphe.storyvox.source.slack.net.SlackApi(client, config)
+}
+
+/**
+ * Issue #454 — contributes [SlackSource] into the multi-source
+ * `Map<String, FictionSource>` so the repository can route
+ * `sourceId = "slack"` fictions to it. Legacy Phase-2 dual-wire
+ * binding — the matching `@SourcePlugin` annotation on
+ * [SlackSource] adds the registry-driven descriptor binding
+ * alongside it. Phase 3 removes this Module once all backends
+ * migrate; until then, both bindings coexist (matches
+ * `:source-discord`, `:source-telegram` pattern).
+ */
+@Module
+@InstallIn(SingletonComponent::class)
+internal abstract class SlackBindings {
+
+    @Binds
+    @Singleton
+    @IntoMap
+    @StringKey(SourceIds.SLACK)
+    abstract fun bindFictionSource(impl: SlackSource): FictionSource
+
+    /** Public-visibility wrapper around the internal SlackApi so
+     *  :app can render the Settings authentication probe + channel
+     *  list without depending on the internal wire types. */
+    @Binds
+    @Singleton
+    abstract fun bindSlackWorkspaceDirectory(
+        impl: `in`.jphe.storyvox.source.slack.SlackWorkspaceDirectoryImpl,
+    ): `in`.jphe.storyvox.source.slack.SlackWorkspaceDirectory
+}

--- a/source-slack/src/main/kotlin/in/jphe/storyvox/source/slack/net/SlackApi.kt
+++ b/source-slack/src/main/kotlin/in/jphe/storyvox/source/slack/net/SlackApi.kt
@@ -1,0 +1,278 @@
+package `in`.jphe.storyvox.source.slack.net
+
+import `in`.jphe.storyvox.data.source.model.FictionResult
+import `in`.jphe.storyvox.source.slack.config.SlackConfig
+import `in`.jphe.storyvox.source.slack.config.SlackConfigState
+import `in`.jphe.storyvox.source.slack.config.SlackDefaults
+import kotlinx.serialization.json.Json
+import okhttp3.HttpUrl.Companion.toHttpUrl
+import okhttp3.OkHttpClient
+import okhttp3.Request
+import java.io.IOException
+import javax.inject.Inject
+import javax.inject.Singleton
+import kotlin.time.Duration.Companion.seconds
+
+/**
+ * Issue #454 — minimal Slack Web API client. Four endpoints:
+ *
+ *  - **`GET /api/auth.test`** — verify token + return workspace
+ *    metadata (team name, team id, bot user id, workspace URL).
+ *    Drives the Settings "authenticated as @bot in <workspace>"
+ *    confirmation.
+ *  - **`GET /api/conversations.list?types=public_channel,private_channel`** —
+ *    paginated channel list. Each channel becomes one storyvox
+ *    fiction in the channels-as-fictions mapping; v1 filters to
+ *    `is_member=true` since bots only have history access to
+ *    channels they've been invited to.
+ *  - **`GET /api/conversations.history?channel={C}&limit={N}&cursor={c}`** —
+ *    paginated channel history. Newest-first; the source layer
+ *    reverses for chronological reading.
+ *  - **`GET /api/users.info?user={U}`** — resolve `<@U012345>` user
+ *    mentions to display names. Aggressively cached at the source
+ *    layer because workspace user lists are stable.
+ *
+ * Auth: every call carries `Authorization: Bearer <token>` (Slack
+ * also accepts `token=<…>` as a query parameter, but the bearer
+ * form is the documented modern shape and keeps the token out of
+ * server-side request logs). The token is read from [SlackConfig]
+ * at call time so a runtime config change applies on the next
+ * fetch without process restart.
+ *
+ * Rate limits: Slack uses **tier-based limits** rather than the
+ * Discord-style per-route buckets. Tier 2 endpoints
+ * (`conversations.list`, `conversations.history`,
+ * `users.info`) cap at ~20 req/min per workspace per method; the
+ * `auth.test` Tier 1 endpoint caps at ~1 req/min. On 429 the
+ * response carries a `Retry-After` header (integer seconds) which
+ * we surface through [FictionResult.RateLimited]. Storyvox's
+ * read-only Browse + Detail workload rarely approaches the limit.
+ *
+ * Slack's response envelope: every method returns `{"ok": true,
+ * ...}` on success or `{"ok": false, "error": "<code>"}` on
+ * failure. **HTTP 200 is the norm even on logical errors** — the
+ * status line is about transport, not API semantics. The decoder
+ * inspects `ok` after parsing and maps known error codes
+ * (`invalid_auth`, `token_revoked`, `account_inactive`,
+ * `ratelimited`, `not_authed`) to the appropriate [FictionResult]
+ * failure variant.
+ *
+ * No bundled bot token. Without a configured token, every endpoint
+ * fast-fails with [FictionResult.AuthRequired] so the UI can route
+ * the user to the Settings → Slack onboarding flow.
+ */
+@Singleton
+internal class SlackApi @Inject constructor(
+    private val client: OkHttpClient,
+    private val config: SlackConfig,
+) {
+    private val json = Json { ignoreUnknownKeys = true; isLenient = true }
+
+    /**
+     * Verify the bot token + return workspace metadata. Drives the
+     * Settings "authenticated as @bot in <workspace>" confirmation
+     * plus caches the workspace name/url back into [SlackConfig] for
+     * empty-state copy.
+     */
+    suspend fun authTest(): FictionResult<SlackAuthTest> {
+        val state = config.current()
+        requireToken<SlackAuthTest>(state)?.let { return it }
+        val url = "${state.baseUrl}/api/auth.test"
+        return getJson<SlackAuthTest>(url, state)
+    }
+
+    /**
+     * List conversations (channels) in the workspace. Slack returns
+     * both public and private channels in one response when the
+     * caller asks for both types; v1 requests both shapes since the
+     * source treats them identically. Pagination is cursor-based —
+     * the [cursor] parameter is the [SlackResponseMetadata.nextCursor]
+     * from a prior call (empty string = first page).
+     */
+    suspend fun listConversations(
+        cursor: String = "",
+        limit: Int = SlackDefaults.CHANNELS_PAGE_SIZE,
+    ): FictionResult<SlackConversationsList> {
+        val state = config.current()
+        requireToken<SlackConversationsList>(state)?.let { return it }
+        val builder = "${state.baseUrl}/api/conversations.list"
+            .toHttpUrl().newBuilder()
+            .addQueryParameter("types", "public_channel,private_channel")
+            .addQueryParameter("limit", limit.coerceIn(1, 1000).toString())
+            .addQueryParameter("exclude_archived", "false")
+        if (cursor.isNotBlank()) builder.addQueryParameter("cursor", cursor)
+        return getJson<SlackConversationsList>(builder.build().toString(), state)
+    }
+
+    /**
+     * Fetch one page of message history for a channel, newest-first.
+     *
+     * Slack's API returns newest-first regardless of how the caller
+     * asks; the source layer reverses for chronological reading.
+     * [cursor] is the [SlackResponseMetadata.nextCursor] from a
+     * prior call (empty string = first page = most-recent
+     * [limit] messages).
+     */
+    suspend fun listMessages(
+        channelId: String,
+        cursor: String = "",
+        limit: Int = SlackDefaults.HISTORY_PAGE_SIZE,
+    ): FictionResult<SlackConversationsHistory> {
+        val state = config.current()
+        requireToken<SlackConversationsHistory>(state)?.let { return it }
+        val builder = "${state.baseUrl}/api/conversations.history"
+            .toHttpUrl().newBuilder()
+            .addQueryParameter("channel", channelId)
+            .addQueryParameter("limit", limit.coerceIn(1, 1000).toString())
+        if (cursor.isNotBlank()) builder.addQueryParameter("cursor", cursor)
+        return getJson<SlackConversationsHistory>(builder.build().toString(), state)
+    }
+
+    /**
+     * Resolve a Slack user id to a display name. Used by the source
+     * layer to expand `<@U012345>` mentions into something more
+     * narratable. v1's source doesn't yet do mention rewriting (we
+     * surface raw text in the chapter body), so this endpoint is
+     * declared for the [`in`.jphe.storyvox.source.slack.SlackWorkspaceDirectory]
+     * surface only — a follow-up can wire it into the chapter
+     * renderer with workspace-scoped caching.
+     */
+    suspend fun userInfo(userId: String): FictionResult<SlackUserInfoResponse> {
+        val state = config.current()
+        requireToken<SlackUserInfoResponse>(state)?.let { return it }
+        val url = "${state.baseUrl}/api/users.info"
+            .toHttpUrl().newBuilder()
+            .addQueryParameter("user", userId)
+            .build().toString()
+        return getJson<SlackUserInfoResponse>(url, state)
+    }
+
+    // ─── transport ────────────────────────────────────────────────────
+
+    private inline fun <reified T> getJson(url: String, state: SlackConfigState): FictionResult<T> =
+        when (val raw = doRequest(url, state)) {
+            is FictionResult.Success -> try {
+                val parsed = json.decodeFromString<T>(raw.value)
+                // Inspect the {ok: false, error: "..."} envelope BEFORE
+                // returning success. Slack returns HTTP 200 with a
+                // failure envelope on most logical errors; we have to
+                // peek at the `ok` field via a parallel decode to
+                // surface the right failure variant.
+                val envelope = runCatching {
+                    json.decodeFromString<SlackError>(raw.value)
+                }.getOrNull()
+                if (envelope != null && !envelope.ok) {
+                    mapSlackError<T>(envelope.error, envelope.warning)
+                } else {
+                    FictionResult.Success(parsed)
+                }
+            } catch (e: kotlinx.serialization.SerializationException) {
+                FictionResult.NetworkError("Slack returned unexpected JSON shape", e)
+            }
+            is FictionResult.Failure -> raw
+        }
+
+    /** Map a Slack error code to the right [FictionResult] failure
+     *  variant. Slack documents error codes per-method, but the
+     *  auth + rate-limit codes are stable across all methods. */
+    private fun <T> mapSlackError(code: String, warning: String?): FictionResult<T> {
+        val message = listOfNotNull(code.takeIf { it.isNotBlank() }, warning)
+            .joinToString(" / ")
+            .ifBlank { "Slack returned an unspecified error" }
+        return when (code) {
+            "not_authed",
+            "invalid_auth",
+            "token_revoked",
+            "token_expired",
+            "account_inactive",
+            "missing_scope",
+            "no_permission" ->
+                FictionResult.AuthRequired(message)
+            "channel_not_found",
+            "not_in_channel",
+            "user_not_found",
+            "not_found" ->
+                FictionResult.NotFound(message)
+            "ratelimited",
+            "rate_limited" ->
+                FictionResult.RateLimited(retryAfter = null, message = message)
+            else ->
+                FictionResult.NetworkError(message, IOException("slack error: $code"))
+        }
+    }
+
+    /**
+     * Single GET with Slack's required headers + structured failure
+     * mapping. Token comes from [state] (a fresh snapshot per call)
+     * so a Settings change applies on the next request.
+     */
+    private fun doRequest(
+        url: String,
+        state: SlackConfigState,
+    ): FictionResult<String> {
+        return try {
+            val request = Request.Builder()
+                .url(url)
+                // `Bearer <token>` is Slack's documented modern auth
+                // header form; the legacy `token` query parameter
+                // works but exposes the token in server-side logs.
+                .header("Authorization", "Bearer ${state.apiToken}")
+                .header("Accept", "application/json")
+                .header("User-Agent", SlackDefaults.USER_AGENT)
+                .get()
+                .build()
+            client.newCall(request).execute().use { resp ->
+                val text = resp.body?.string().orEmpty()
+                when {
+                    resp.code == 401 || resp.code == 403 ->
+                        FictionResult.AuthRequired(
+                            "Slack rejected the bot token (HTTP ${resp.code})",
+                        )
+                    resp.code == 404 ->
+                        FictionResult.NotFound("Slack resource not found")
+                    resp.code == 429 ->
+                        // Slack's Retry-After is integer seconds.
+                        // Some upstream proxies emit fractional values;
+                        // we parse loosely and round up.
+                        FictionResult.RateLimited(
+                            retryAfter = resp.header("Retry-After")
+                                ?.toDoubleOrNull()
+                                ?.let { kotlin.math.ceil(it).toLong().seconds },
+                            message = "Slack rate-limited the request",
+                        )
+                    resp.code in 500..599 ->
+                        FictionResult.NetworkError(
+                            "Slack server error HTTP ${resp.code}",
+                            IOException("HTTP ${resp.code}"),
+                        )
+                    !resp.isSuccessful && text.isBlank() ->
+                        FictionResult.NetworkError(
+                            "HTTP ${resp.code} from Slack",
+                            IOException("HTTP ${resp.code}"),
+                        )
+                    // Slack returns HTTP 200 with `{ok: false}` for
+                    // logical errors. The envelope decoder above
+                    // handles that; pass the body through here.
+                    else -> FictionResult.Success(text)
+                }
+            }
+        } catch (e: IOException) {
+            FictionResult.NetworkError(e.message ?: "fetch failed", e)
+        }
+    }
+
+    /**
+     * Fast-fail with [FictionResult.AuthRequired] if [state] has no
+     * bot token configured.
+     */
+    private fun <T> requireToken(state: SlackConfigState): FictionResult<T>? {
+        if (state.apiToken.isBlank()) {
+            return FictionResult.AuthRequired(
+                "Slack bot token not configured. " +
+                    "Install a Slack app and paste its xoxb- " +
+                    "Bot User OAuth Token in Settings → Library & Sync → Slack.",
+            )
+        }
+        return null
+    }
+}

--- a/source-slack/src/main/kotlin/in/jphe/storyvox/source/slack/net/SlackModels.kt
+++ b/source-slack/src/main/kotlin/in/jphe/storyvox/source/slack/net/SlackModels.kt
@@ -1,0 +1,265 @@
+package `in`.jphe.storyvox.source.slack.net
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+/**
+ * Issue #454 — minimal Slack Web API response shapes.
+ *
+ * Only the fields storyvox actually reads are declared. Slack's API
+ * returns dozens of fields per object (channel boost flags, member
+ * counts, shared-channel metadata, etc.); declaring them all would
+ * just be future-fragile noise. `Json.ignoreUnknownKeys = true`
+ * drops what we don't ask for, and Slack's API guarantees additive
+ * evolution within the documented stable surface so unknown new
+ * fields don't break us.
+ *
+ * Every Slack Web API response carries an `{"ok": true, ...}` /
+ * `{"ok": false, "error": "..."}` envelope. The transport layer
+ * ([SlackApi]) inspects `ok` before handing the result to the
+ * source layer.
+ *
+ * **Cursor pagination**: list-shaped endpoints (`conversations.list`,
+ * `conversations.history`) return a `response_metadata.next_cursor`
+ * string. When non-empty, the next page is fetched with `cursor=<…>`;
+ * an empty cursor means "no more pages". Slack's cursors are opaque
+ * tokens, not before/after timestamps like Discord uses.
+ */
+
+/**
+ * Result of `auth.test`. Confirms the bot token + carries workspace
+ * metadata used to populate the Settings "authenticated as @bot in
+ * <workspace>" confirmation.
+ */
+@Serializable
+internal data class SlackAuthTest(
+    val ok: Boolean = false,
+    /** Free-form error code on `ok=false` (e.g. `"invalid_auth"`,
+     *  `"not_authed"`, `"token_revoked"`). */
+    val error: String? = null,
+    /** Workspace name as set by the workspace admin. */
+    val team: String? = null,
+    /** Workspace id (`T012345`). */
+    @SerialName("team_id")
+    val teamId: String? = null,
+    /** Bot user id within the workspace (`U012345` or `B012345`). */
+    @SerialName("user_id")
+    val userId: String? = null,
+    /** Bot user display name. */
+    val user: String? = null,
+    /** Workspace URL (`https://techempower.slack.com/`). Trailing
+     *  slash included. */
+    val url: String? = null,
+)
+
+/**
+ * Response shape for `conversations.list`. Wraps a list of
+ * [SlackChannel] plus a `response_metadata.next_cursor` for
+ * pagination.
+ */
+@Serializable
+internal data class SlackConversationsList(
+    val ok: Boolean = false,
+    val error: String? = null,
+    val channels: List<SlackChannel> = emptyList(),
+    @SerialName("response_metadata")
+    val responseMetadata: SlackResponseMetadata? = null,
+)
+
+/**
+ * One element of `conversations.list`. Each public/private channel
+ * the bot has access to. v1 surfaces channels the bot is a member of
+ * (`is_member == true`); channels listed but un-joined are filtered
+ * out at the source layer.
+ */
+@Serializable
+internal data class SlackChannel(
+    /** Channel id, e.g. `C012345` (public) or `G012345` /
+     *  `C0123ABC` (private — Slack unified the prefix to `C` in
+     *  2018 but legacy `G` ids may still surface for very old
+     *  private channels). */
+    val id: String,
+    /** Channel name (without the `#` prefix). */
+    val name: String = "",
+    /** True for public channels in this workspace. */
+    @SerialName("is_channel")
+    val isChannel: Boolean = false,
+    /** True for private channels. v1 surfaces both shapes
+     *  identically — the difference is only relevant to admins
+     *  picking what to install the bot into. */
+    @SerialName("is_private")
+    val isPrivate: Boolean = false,
+    /** True when the bot is a member of the channel. v1 filters
+     *  to is_member=true since bots can only read channels
+     *  they've been invited to. */
+    @SerialName("is_member")
+    val isMember: Boolean = false,
+    /** True for archived channels — read-only, no new messages.
+     *  v1 still surfaces them (archived channels may contain
+     *  the most interesting historical content) but a follow-up
+     *  could hide them by default. */
+    @SerialName("is_archived")
+    val isArchived: Boolean = false,
+    /** Channel topic — `{value, creator, last_set}`. v1 reads
+     *  only the value text. */
+    val topic: SlackTextBlock? = null,
+    /** Channel purpose — same shape as topic, slightly different
+     *  semantic ("what is this channel for" vs "current topic").
+     *  v1 surfaces topic preferentially, falling back to purpose
+     *  when topic is empty. */
+    val purpose: SlackTextBlock? = null,
+    /** Unix-seconds timestamp of channel creation. Unused in v1
+     *  but cheap to parse. */
+    val created: Long = 0,
+    /** Approximate member count. Unused in v1. */
+    @SerialName("num_members")
+    val numMembers: Int = 0,
+)
+
+/** Slack's `{value, creator, last_set}` shape used for both topic
+ *  and purpose on a channel. */
+@Serializable
+internal data class SlackTextBlock(
+    val value: String = "",
+    val creator: String = "",
+    @SerialName("last_set")
+    val lastSet: Long = 0,
+)
+
+/**
+ * Response shape for `conversations.history`. Wraps a list of
+ * [SlackMessage] in newest-first order plus
+ * `response_metadata.next_cursor` for pagination.
+ */
+@Serializable
+internal data class SlackConversationsHistory(
+    val ok: Boolean = false,
+    val error: String? = null,
+    val messages: List<SlackMessage> = emptyList(),
+    /** True when more messages exist beyond this page — Slack
+     *  exposes this in addition to `response_metadata.next_cursor`
+     *  so callers can decide whether to keep walking without
+     *  inspecting the cursor string. */
+    @SerialName("has_more")
+    val hasMore: Boolean = false,
+    @SerialName("response_metadata")
+    val responseMetadata: SlackResponseMetadata? = null,
+)
+
+/**
+ * One message in a channel's history. Each message becomes one
+ * chapter in the channels-as-fictions mapping (v1 doesn't
+ * coalesce — Slack's UX is one-thought-per-message far more often
+ * than Discord's, where short bursts of replies are common).
+ */
+@Serializable
+internal data class SlackMessage(
+    /** Slack message timestamp — string-encoded float seconds since
+     *  epoch (e.g. `"1747340531.123456"`). Doubles as the message id
+     *  within a channel (no separate `id` field; `ts` is unique
+     *  per-channel). The source layer uses `ts` for the chapter id
+     *  + chronological ordering. */
+    val ts: String = "",
+    /** Message subtype. Empty for regular user messages. Non-empty
+     *  for bot/system messages: `"channel_join"`, `"channel_leave"`,
+     *  `"bot_message"`, `"pinned_item"`, `"thread_broadcast"`, etc.
+     *  The source layer filters out system subtypes (keep regular
+     *  user messages + bot messages with text content). */
+    val subtype: String? = null,
+    /** Slack user id of the message author (e.g. `U012345`). Null
+     *  for some bot messages where `bot_id` is used instead. */
+    val user: String? = null,
+    /** Display name for bot messages — Slack populates this when
+     *  the sender is a bot rather than a user. */
+    val username: String? = null,
+    /** Bot id when the sender is a bot. */
+    @SerialName("bot_id")
+    val botId: String? = null,
+    /** Message text. Slack's mrkdwn flavor; may contain
+     *  `<@U012345>` user mentions and `<#C012345|channel-name>`
+     *  channel mentions. v1 keeps these as-is in the chapter body
+     *  (the reader view + TTS pronounce them as raw tokens; a
+     *  follow-up could resolve them via `users.info`). */
+    val text: String = "",
+    /** Optional file attachments. Slack returns full file metadata
+     *  (name, mimetype, url_private, thumbnail urls). v1 surfaces
+     *  the filename + title in the chapter body so TTS narrates
+     *  them ("Attachment: dragon-sketch.png"). */
+    val files: List<SlackFile>? = null,
+    /** Thread parent ts for thread replies. Equal to [ts] for
+     *  thread parents themselves. v1 treats threaded replies as
+     *  flat messages within the parent channel (Discord-parity);
+     *  a follow-up could surface threads as nested fictions. */
+    @SerialName("thread_ts")
+    val threadTs: String? = null,
+)
+
+@Serializable
+internal data class SlackFile(
+    val id: String = "",
+    val name: String? = null,
+    val title: String? = null,
+    val mimetype: String? = null,
+    /** File size in bytes. */
+    val size: Long? = null,
+)
+
+/**
+ * Response shape for `users.info`. Returns one user's full profile.
+ * v1 reads only the display name fields for `<@U012345>` mention
+ * resolution; the rest of the profile (real name, avatar, email,
+ * timezone) is unused but `ignoreUnknownKeys = true` drops it
+ * cleanly.
+ */
+@Serializable
+internal data class SlackUserInfoResponse(
+    val ok: Boolean = false,
+    val error: String? = null,
+    val user: SlackUser? = null,
+)
+
+@Serializable
+internal data class SlackUser(
+    val id: String = "",
+    val name: String = "",
+    @SerialName("real_name")
+    val realName: String? = null,
+    val profile: SlackUserProfile? = null,
+    /** True when the user is a deactivated account. */
+    val deleted: Boolean = false,
+    /** True when the user account is actually a bot. Bot mentions
+     *  via `<@U…>` resolve through the same endpoint. */
+    @SerialName("is_bot")
+    val isBot: Boolean = false,
+)
+
+@Serializable
+internal data class SlackUserProfile(
+    @SerialName("display_name")
+    val displayName: String? = null,
+    @SerialName("display_name_normalized")
+    val displayNameNormalized: String? = null,
+    @SerialName("real_name")
+    val realName: String? = null,
+    @SerialName("real_name_normalized")
+    val realNameNormalized: String? = null,
+)
+
+/** Cursor envelope shared across paginated list endpoints. */
+@Serializable
+internal data class SlackResponseMetadata(
+    @SerialName("next_cursor")
+    val nextCursor: String? = null,
+)
+
+/** Generic Slack error envelope for surfaces where the API
+ *  doesn't return a structured body shape (`ok=false` with just
+ *  `error` and optional warnings). Decoded for human-readable
+ *  surfacing in the [`in`.jphe.storyvox.data.source.model.FictionResult.Failure]
+ *  message field. */
+@Serializable
+internal data class SlackError(
+    val ok: Boolean = false,
+    val error: String = "",
+    val warning: String? = null,
+)

--- a/source-slack/src/test/kotlin/in/jphe/storyvox/source/slack/SlackModelsTest.kt
+++ b/source-slack/src/test/kotlin/in/jphe/storyvox/source/slack/SlackModelsTest.kt
@@ -1,0 +1,316 @@
+package `in`.jphe.storyvox.source.slack
+
+import `in`.jphe.storyvox.source.slack.net.SlackAuthTest
+import `in`.jphe.storyvox.source.slack.net.SlackConversationsHistory
+import `in`.jphe.storyvox.source.slack.net.SlackConversationsList
+import `in`.jphe.storyvox.source.slack.net.SlackError
+import `in`.jphe.storyvox.source.slack.net.SlackUserInfoResponse
+import kotlinx.serialization.json.Json
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * Issue #454 — JSON parsing checks for the Slack Web API responses
+ * storyvox reads. These run against captured-from-docs fixtures,
+ * not live Slack; they guarantee storyvox keeps parsing the
+ * documented shapes even if Slack adds new fields (the
+ * `ignoreUnknownKeys = true` posture).
+ */
+class SlackModelsTest {
+
+    private val json = Json { ignoreUnknownKeys = true; isLenient = true }
+
+    @Test
+    fun `parses auth test success response`() {
+        // Real response shape from Slack's docs for auth.test on a
+        // bot token. Carries the workspace name, workspace url,
+        // bot user id, and bot display name we use for the Settings
+        // confirmation card.
+        val body = """
+            {
+              "ok": true,
+              "url": "https://techempower.slack.com/",
+              "team": "TechEmpower",
+              "user": "storyvox_bot",
+              "team_id": "T012345678",
+              "user_id": "U012345678",
+              "bot_id": "B012345678",
+              "is_enterprise_install": false
+            }
+        """.trimIndent()
+
+        val auth = json.decodeFromString<SlackAuthTest>(body)
+
+        assertTrue(auth.ok)
+        assertEquals("TechEmpower", auth.team)
+        assertEquals("https://techempower.slack.com/", auth.url)
+        assertEquals("storyvox_bot", auth.user)
+        assertEquals("U012345678", auth.userId)
+        assertEquals("T012345678", auth.teamId)
+        assertNull(auth.error)
+    }
+
+    @Test
+    fun `parses auth test failure response`() {
+        // Real failure response — `ok=false` with an error code.
+        // The transport layer maps `invalid_auth` to AuthRequired.
+        val body = """
+            {
+              "ok": false,
+              "error": "invalid_auth"
+            }
+        """.trimIndent()
+
+        val auth = json.decodeFromString<SlackAuthTest>(body)
+        val err = json.decodeFromString<SlackError>(body)
+
+        assertFalse(auth.ok)
+        assertEquals("invalid_auth", auth.error)
+        assertFalse(err.ok)
+        assertEquals("invalid_auth", err.error)
+    }
+
+    @Test
+    fun `parses conversations list response with mixed channel types`() {
+        // Public + private + archived channels in one response.
+        // The source layer filters to `is_member=true`; this test
+        // verifies the wire shape preserves the fields the filter
+        // depends on.
+        val body = """
+            {
+              "ok": true,
+              "channels": [
+                {
+                  "id": "C0123ABCDEF",
+                  "name": "general",
+                  "is_channel": true,
+                  "is_private": false,
+                  "is_member": true,
+                  "is_archived": false,
+                  "created": 1500000000,
+                  "topic": {
+                    "value": "Workspace-wide chat",
+                    "creator": "U0123",
+                    "last_set": 1500000100
+                  },
+                  "purpose": {
+                    "value": "Talk about anything",
+                    "creator": "U0123",
+                    "last_set": 1500000100
+                  },
+                  "num_members": 42
+                },
+                {
+                  "id": "C0456PRIVATE",
+                  "name": "secret-project",
+                  "is_channel": false,
+                  "is_private": true,
+                  "is_member": true,
+                  "topic": {"value": "", "creator": "", "last_set": 0},
+                  "purpose": {"value": "Top secret stuff", "creator": "", "last_set": 0}
+                },
+                {
+                  "id": "C0789NOTJOIN",
+                  "name": "no-bot-here",
+                  "is_channel": true,
+                  "is_member": false
+                },
+                {
+                  "id": "C0ABCARCHIV",
+                  "name": "old-channel",
+                  "is_channel": true,
+                  "is_member": true,
+                  "is_archived": true
+                }
+              ],
+              "response_metadata": {
+                "next_cursor": ""
+              }
+            }
+        """.trimIndent()
+
+        val list = json.decodeFromString<SlackConversationsList>(body)
+
+        assertTrue(list.ok)
+        assertEquals(4, list.channels.size)
+
+        // Public channel with full metadata
+        val general = list.channels[0]
+        assertEquals("C0123ABCDEF", general.id)
+        assertEquals("general", general.name)
+        assertTrue(general.isMember)
+        assertEquals("Workspace-wide chat", general.topic?.value)
+        assertEquals("Talk about anything", general.purpose?.value)
+
+        // Private channel — different is_channel/is_private flags
+        val secret = list.channels[1]
+        assertTrue(secret.isPrivate)
+        assertEquals("", secret.topic?.value)
+
+        // Non-member channel — filter target
+        assertFalse(list.channels[2].isMember)
+
+        // Archived channel
+        assertTrue(list.channels[3].isArchived)
+
+        // Empty cursor = no more pages
+        assertEquals("", list.responseMetadata?.nextCursor)
+    }
+
+    @Test
+    fun `parses conversations history with messages and attachments`() {
+        // Mix of regular user message, message with file attachment,
+        // and a system join message. The source layer filters the
+        // join out via SYSTEM_SUBTYPES.
+        val body = """
+            {
+              "ok": true,
+              "messages": [
+                {
+                  "type": "message",
+                  "ts": "1747340531.123456",
+                  "user": "U012345",
+                  "text": "Has anyone seen the dragon chapter?"
+                },
+                {
+                  "type": "message",
+                  "ts": "1747340500.123456",
+                  "user": "U098765",
+                  "text": "Posting the sketch here",
+                  "files": [
+                    {
+                      "id": "F0123",
+                      "name": "dragon-sketch.png",
+                      "title": "Dragon sketch v3",
+                      "mimetype": "image/png",
+                      "size": 245678
+                    }
+                  ]
+                },
+                {
+                  "type": "message",
+                  "subtype": "channel_join",
+                  "ts": "1747340000.000100",
+                  "user": "U111111",
+                  "text": "<@U111111> has joined the channel"
+                },
+                {
+                  "type": "message",
+                  "subtype": "bot_message",
+                  "ts": "1747339900.000200",
+                  "bot_id": "B012345",
+                  "username": "GitHub",
+                  "text": "PR #454 opened"
+                }
+              ],
+              "has_more": true,
+              "response_metadata": {
+                "next_cursor": "bmV4dF90czoxNjQwMDAwMDAw"
+              }
+            }
+        """.trimIndent()
+
+        val history = json.decodeFromString<SlackConversationsHistory>(body)
+
+        assertTrue(history.ok)
+        assertEquals(4, history.messages.size)
+        assertTrue(history.hasMore)
+        assertEquals("bmV4dF90czoxNjQwMDAwMDAw", history.responseMetadata?.nextCursor)
+
+        // User message — no subtype, has text
+        val first = history.messages[0]
+        assertEquals("1747340531.123456", first.ts)
+        assertEquals("U012345", first.user)
+        assertNull(first.subtype)
+        assertTrue(first.isUserContentMessage())
+
+        // File-bearing message
+        val withFile = history.messages[1]
+        assertEquals(1, withFile.files?.size)
+        assertEquals("dragon-sketch.png", withFile.files?.first()?.name)
+        assertEquals("Dragon sketch v3", withFile.files?.first()?.title)
+        assertEquals(245678L, withFile.files?.first()?.size)
+
+        // System join message — filtered out by the source
+        val join = history.messages[2]
+        assertEquals("channel_join", join.subtype)
+        assertFalse(join.isUserContentMessage())
+
+        // Bot message — kept
+        val bot = history.messages[3]
+        assertEquals("bot_message", bot.subtype)
+        assertEquals("B012345", bot.botId)
+        assertEquals("GitHub", bot.username)
+        assertTrue(bot.isUserContentMessage())
+    }
+
+    @Test
+    fun `parses users info response`() {
+        val body = """
+            {
+              "ok": true,
+              "user": {
+                "id": "U012345",
+                "name": "alice.dev",
+                "real_name": "Alice Developer",
+                "deleted": false,
+                "is_bot": false,
+                "profile": {
+                  "display_name": "Alice",
+                  "display_name_normalized": "alice",
+                  "real_name": "Alice Developer",
+                  "real_name_normalized": "alice developer"
+                }
+              }
+            }
+        """.trimIndent()
+
+        val resp = json.decodeFromString<SlackUserInfoResponse>(body)
+
+        assertTrue(resp.ok)
+        assertNotNull(resp.user)
+        assertEquals("U012345", resp.user?.id)
+        assertEquals("Alice", resp.user?.profile?.displayName)
+        assertEquals("Alice Developer", resp.user?.realName)
+        assertFalse(resp.user?.isBot == true)
+    }
+
+    @Test
+    fun `parses cursor pagination empty cursor as no more pages`() {
+        // Two consecutive responses — first has a cursor, second has
+        // empty cursor. The source's pagination loop terminates on
+        // the empty cursor.
+        val firstPage = """{"ok":true,"channels":[],"response_metadata":{"next_cursor":"abc123"}}"""
+        val lastPage = """{"ok":true,"channels":[],"response_metadata":{"next_cursor":""}}"""
+
+        val first = json.decodeFromString<SlackConversationsList>(firstPage)
+        val last = json.decodeFromString<SlackConversationsList>(lastPage)
+
+        assertEquals("abc123", first.responseMetadata?.nextCursor)
+        assertEquals("", last.responseMetadata?.nextCursor)
+    }
+
+    @Test
+    fun `parses error envelope with warning`() {
+        // Slack sometimes returns ok=false alongside a warning text
+        // (e.g. when a token is expiring soon). The source maps the
+        // error code to the right FictionResult variant and surfaces
+        // the warning in the human-readable message.
+        val body = """
+            {
+              "ok": false,
+              "error": "token_expired",
+              "warning": "Token will expire in 24 hours"
+            }
+        """.trimIndent()
+
+        val err = json.decodeFromString<SlackError>(body)
+        assertFalse(err.ok)
+        assertEquals("token_expired", err.error)
+        assertEquals("Token will expire in 24 hours", err.warning)
+    }
+}

--- a/source-slack/src/test/kotlin/in/jphe/storyvox/source/slack/SlackSourceTest.kt
+++ b/source-slack/src/test/kotlin/in/jphe/storyvox/source/slack/SlackSourceTest.kt
@@ -1,0 +1,276 @@
+package `in`.jphe.storyvox.source.slack
+
+import `in`.jphe.storyvox.source.slack.net.SlackFile
+import `in`.jphe.storyvox.source.slack.net.SlackMessage
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * Issue #454 — unit coverage for the pure helpers in [SlackSource].
+ * Network / cache flows are covered indirectly through the
+ * Discord-style integration shape; here we pin the input → output
+ * behavior of the in-source transform helpers, the URL claim regex,
+ * and the system-subtype filter.
+ */
+class SlackSourceTest {
+
+    // ─── id round-trips ────────────────────────────────────────────
+
+    @Test
+    fun `fictionId round-trips through channelId`() {
+        val id = slackFictionId("C0123ABCDEF")
+        assertEquals("slack:C0123ABCDEF", id)
+        assertEquals("C0123ABCDEF", id.toChannelId())
+    }
+
+    @Test
+    fun `toChannelId returns null for non-slack prefix`() {
+        assertNull("discord:123".toChannelId())
+        assertNull("telegram:-100".toChannelId())
+        assertNull("".toChannelId())
+        assertNull("slack:".toChannelId())
+    }
+
+    @Test
+    fun `toChannelId strips chapter suffix`() {
+        // The chapter id form embeds the channel id followed by
+        // `::ts-…`. Decoding the fiction id from a chapter id must
+        // yield just the channel id.
+        assertEquals(
+            "C0123ABCDEF",
+            "slack:C0123ABCDEF::ts-1747340531.123456".toChannelId(),
+        )
+    }
+
+    @Test
+    fun `chapterIdFor encodes ts prefix`() {
+        assertEquals(
+            "slack:C0123ABCDEF::ts-1747340531.123456",
+            chapterIdFor("slack:C0123ABCDEF", "1747340531.123456"),
+        )
+    }
+
+    // ─── URL matcher ───────────────────────────────────────────────
+    // The matchUrl path on SlackSource delegates straight to
+    // SLACK_ARCHIVE_URL_PATTERN; we test the regex shape here so
+    // these tests don't have to instantiate a SlackSource (which
+    // needs a SlackApi the test harness doesn't supply).
+
+    @Test
+    fun `SLACK_ARCHIVE_URL_PATTERN claims workspace-subdomain archive URL`() {
+        val m = SLACK_ARCHIVE_URL_PATTERN.matchEntire(
+            "https://techempower.slack.com/archives/C0123ABCDEF",
+        )
+        assertEquals("C0123ABCDEF", m?.groupValues?.get(1))
+    }
+
+    @Test
+    fun `SLACK_ARCHIVE_URL_PATTERN claims message-permalink archive URL`() {
+        // Slack's deep-link to a specific message has the
+        // /p<TIMESTAMP> suffix. The matcher accepts the URL but
+        // the source routes to the channel-level fiction (the
+        // message anchor is preserved for a follow-up that lands
+        // on the specific chapter).
+        val m = SLACK_ARCHIVE_URL_PATTERN.matchEntire(
+            "https://techempower.slack.com/archives/C0123ABCDEF/p1747340531123456",
+        )
+        assertEquals("C0123ABCDEF", m?.groupValues?.get(1))
+        assertEquals("/p1747340531123456", m?.groupValues?.get(2))
+    }
+
+    @Test
+    fun `SLACK_ARCHIVE_URL_PATTERN claims apex-host archive URL`() {
+        val m = SLACK_ARCHIVE_URL_PATTERN.matchEntire("https://slack.com/archives/C0123ABCDEF")
+        assertEquals("C0123ABCDEF", m?.groupValues?.get(1))
+    }
+
+    @Test
+    fun `SLACK_ARCHIVE_URL_PATTERN rejects non-archive slack URLs`() {
+        // Marketing pages, the apex landing page, the client app —
+        // none should claim. The catch-all readability backend will
+        // catch them.
+        assertNull(SLACK_ARCHIVE_URL_PATTERN.matchEntire("https://slack.com/intl/en-us/"))
+        assertNull(SLACK_ARCHIVE_URL_PATTERN.matchEntire("https://slack.com/"))
+        assertNull(SLACK_ARCHIVE_URL_PATTERN.matchEntire("https://api.slack.com/methods/auth.test"))
+        // The web-app URL grammar is intentionally NOT claimed —
+        // see the SLACK_ARCHIVE_URL_PATTERN kdoc.
+        assertNull(
+            SLACK_ARCHIVE_URL_PATTERN.matchEntire(
+                "https://app.slack.com/client/T012345/C0123ABCDEF",
+            ),
+        )
+    }
+
+    @Test
+    fun `SLACK_ARCHIVE_URL_PATTERN rejects non-slack hosts`() {
+        assertNull(SLACK_ARCHIVE_URL_PATTERN.matchEntire("https://example.com/archives/C123"))
+        assertNull(SLACK_ARCHIVE_URL_PATTERN.matchEntire("https://discord.com/channels/123/456"))
+    }
+
+    // ─── system-subtype filter ────────────────────────────────────
+
+    @Test
+    fun `isUserContentMessage keeps regular user messages`() {
+        val msg = makeMessage(subtype = null, text = "Hello!")
+        assertTrue(msg.isUserContentMessage())
+    }
+
+    @Test
+    fun `isUserContentMessage keeps bot messages`() {
+        val msg = makeMessage(subtype = "bot_message", text = "PR opened")
+        assertTrue(msg.isUserContentMessage())
+    }
+
+    @Test
+    fun `isUserContentMessage keeps thread broadcasts`() {
+        // Thread broadcasts are user-authored content re-posted to
+        // the channel — keep them.
+        val msg = makeMessage(subtype = "thread_broadcast", text = "Important update")
+        assertTrue(msg.isUserContentMessage())
+    }
+
+    @Test
+    fun `isUserContentMessage filters channel-join messages`() {
+        assertFalse(makeMessage(subtype = "channel_join").isUserContentMessage())
+        assertFalse(makeMessage(subtype = "channel_leave").isUserContentMessage())
+        assertFalse(makeMessage(subtype = "group_join").isUserContentMessage())
+        assertFalse(makeMessage(subtype = "group_leave").isUserContentMessage())
+    }
+
+    @Test
+    fun `isUserContentMessage filters topic and pin events`() {
+        assertFalse(makeMessage(subtype = "channel_topic").isUserContentMessage())
+        assertFalse(makeMessage(subtype = "channel_purpose").isUserContentMessage())
+        assertFalse(makeMessage(subtype = "channel_name").isUserContentMessage())
+        assertFalse(makeMessage(subtype = "pinned_item").isUserContentMessage())
+        assertFalse(makeMessage(subtype = "unpinned_item").isUserContentMessage())
+    }
+
+    // ─── title preview ─────────────────────────────────────────────
+
+    @Test
+    fun `titlePreview returns short text as-is`() {
+        val msg = makeMessage(text = "Hello world")
+        assertEquals("Hello world", msg.titlePreview())
+    }
+
+    @Test
+    fun `titlePreview truncates long bodies`() {
+        val long = "x".repeat(80)
+        val msg = makeMessage(text = long)
+        val title = msg.titlePreview()
+        assertTrue("expected ellipsis", title.endsWith("…"))
+        assertEquals(58, title.length) // 57 + ellipsis char
+    }
+
+    @Test
+    fun `titlePreview collapses newlines`() {
+        val msg = makeMessage(text = "Line one\nLine two\r\nLine three")
+        assertEquals("Line one Line two  Line three", msg.titlePreview())
+    }
+
+    @Test
+    fun `titlePreview surfaces attachment title when body blank`() {
+        val msg = makeMessage(
+            text = "",
+            files = listOf(SlackFile(id = "F1", name = "sketch.png", title = "Dragon sketch")),
+        )
+        assertEquals("Attachment: Dragon sketch", msg.titlePreview())
+    }
+
+    @Test
+    fun `titlePreview falls back to filename when title blank`() {
+        val msg = makeMessage(
+            text = "",
+            files = listOf(SlackFile(id = "F1", name = "sketch.png", title = null)),
+        )
+        assertEquals("Attachment: sketch.png", msg.titlePreview())
+    }
+
+    @Test
+    fun `titlePreview yields empty-marker when nothing present`() {
+        val msg = makeMessage(text = "", files = null)
+        assertEquals("(empty message)", msg.titlePreview())
+    }
+
+    // ─── body renderers ───────────────────────────────────────────
+
+    @Test
+    fun `toHtml escapes angle brackets`() {
+        // Slack messages routinely include <@U012345> mentions and
+        // <#C012345|channel-name> channel refs — they MUST render as
+        // text, not as HTML elements that the reader view tries to
+        // parse.
+        val msg = makeMessage(text = "Hello <@U012345> see <#C012345|general>")
+        val html = msg.toHtml()
+        assertTrue(html.contains("&lt;@U012345&gt;"))
+        assertTrue(html.contains("&lt;#C012345|general&gt;"))
+        assertFalse("must not leave raw <@…> in output", html.contains("<@U012345>"))
+    }
+
+    @Test
+    fun `toHtml lists attachment lines after text`() {
+        val msg = makeMessage(
+            text = "Check this out",
+            files = listOf(SlackFile(id = "F1", name = "doc.pdf", title = null)),
+        )
+        val html = msg.toHtml()
+        assertTrue(html.contains("<p>Check this out</p>"))
+        assertTrue(html.contains("<p>Attachment: doc.pdf</p>"))
+    }
+
+    @Test
+    fun `toPlainText narrates attachments naturally`() {
+        val msg = makeMessage(
+            text = "See the sketch",
+            files = listOf(SlackFile(id = "F1", name = "sketch.png", title = "Dragon sketch")),
+        )
+        val plain = msg.toPlainText()
+        assertTrue(plain.contains("See the sketch"))
+        assertTrue(plain.contains("Attachment: Dragon sketch"))
+    }
+
+    @Test
+    fun `toPlainText returns empty string when nothing to narrate`() {
+        val msg = makeMessage(text = "", files = null)
+        assertEquals("", msg.toPlainText())
+    }
+
+    // ─── ts parsing ────────────────────────────────────────────────
+
+    @Test
+    fun `tsMillis parses slack float-seconds string`() {
+        // Slack's ts is "<unix_seconds>.<micros>". Converting via
+        // Double preserves enough precision for chapter timestamps.
+        val msg = makeMessage(ts = "1747340531.123456")
+        // 1747340531.123456 seconds * 1000 = 1747340531123 millis
+        // (with the trailing .456 microseconds rounded down).
+        assertEquals(1747340531123L, msg.tsMillis())
+    }
+
+    @Test
+    fun `tsMillis returns null on unparseable ts`() {
+        val msg = makeMessage(ts = "")
+        assertNull(msg.tsMillis())
+        val msg2 = makeMessage(ts = "not-a-ts")
+        assertNull(msg2.tsMillis())
+    }
+
+    // ─── helpers ──────────────────────────────────────────────────
+
+    private fun makeMessage(
+        ts: String = "1747340531.123456",
+        subtype: String? = null,
+        text: String = "msg",
+        files: List<SlackFile>? = null,
+    ): SlackMessage = SlackMessage(
+        ts = ts,
+        subtype = subtype,
+        user = "U012345",
+        text = text,
+        files = files,
+    )
+}


### PR DESCRIPTION
## Summary

New `:source-slack` Gradle module — fifth chat-platform backend after Discord (#403) and Telegram (#462). Channels become fictions, messages become chapters. Bot Token (`xoxb-…`) auth via Settings (the `pref_source_slack_token` allowlist entry already in `SecretsSyncer.SECRET_KEY_NAMES` syncs the token cross-device).

- **Auth shape**: Slack Bot User OAuth Token (`xoxb-…`) carried as `Authorization: Bearer <token>`. One token = one workspace (no Discord-style `users/@me/guilds` "list workspaces" endpoint — the token IS the workspace selector). Token stored encrypted in `storyvox.secrets` under `pref_source_slack_token`; workspace name/URL cached in plaintext DataStore for empty-state copy.
- **Message pagination**: cursor-based via `response_metadata.next_cursor`, capped at 5 pages per fiction (≤1000 messages = ~1000 chapters) to bound massive-channel worst case. `conversations.list` walks similarly. The cursor convention is the load-bearing difference from Discord's snowflake-`before` paging.
- **Magic-link claim regex**: `^https?://(?:[\w-]+\.)?slack\.com/archives/([A-Z][A-Z0-9]+)(/p\d+)?(?:\?.*)?$` — claims workspace-subdomain + apex archive URLs and message permalinks at confidence 0.9. Marketing pages, `app.slack.com/client/…`, and `api.slack.com/methods/…` intentionally NOT claimed — they fall through to `:source-readability`.
- **Deferred**: Settings UI card (token paste field, channel probe), `search.messages` with graceful-degrade for restricted plan tiers, `<@U012345>` mention resolution with workspace-scoped `users.info` cache, threads-as-nested-fictions. v1 ships with `supportsSearch=false` + `defaultEnabled=false`.

## Test plan

- [x] `:source-slack:testDebugUnitTest` — JSON shapes (auth.test, conversations.list mixed types, conversations.history with attachments/joins/bot messages, users.info, error envelope, cursor pagination), system-subtype filter, title preview truncation, HTML escape on `<@U…>` mentions, ts → millis parsing, archive URL regex against 8 inputs (subdomain / permalink / apex / client / marketing / api / non-Slack hosts / random)
- [x] `:app:assembleDebug` — DI graph links cleanly, R8 catch-all keep rules from #409 cover the new `@Serializable` Slack models without per-module additions
- [x] `:app:testDebugUnitTest` — no regressions from the SettingsRepository / AppBindings additions
- [x] `:feature:testDebugUnitTest` — no surface changes to consumed contracts
- [x] `:core-sync:testDebugUnitTest` — `SECRET_KEY_NAMES` extension doesn't break the existing Discord token assertion or the "does not include non-secrets" negative test
- [ ] Manual: install on R83W80CAFZB, verify Settings → Plugins surfaces the Slack chip (defaultEnabled=false so the chip itself is hidden until the user toggles it on in the plugin manager — that's the intended posture per #454)
- [ ] Manual once Settings card lands: paste a real `xoxb-…` token, confirm `auth.test` reports the workspace name, confirm `conversations.list` enumerates the bot's joined channels

🤖 Generated with [Claude Code](https://claude.com/claude-code)