### PR TITLE
feat(techempower): Emergency Help card with 211/988/911 — closes #516

### DIFF
--- a/core-data/src/main/kotlin/in/jphe/storyvox/data/TechEmpowerLinks.kt
+++ b/core-data/src/main/kotlin/in/jphe/storyvox/data/TechEmpowerLinks.kt
@@ -117,12 +117,30 @@ object TechEmpowerLinks {
      * who needs the social-services line (the much-more-common case)
      * doesn't have to scroll past a crisis-line option to reach it.
      *
-     * 911 is intentionally NOT on the top-app-bar — accidental 911
-     * misfires are costly, and storyvox isn't an emergency app. A
-     * dedicated "Emergency" card on TechEmpower Home is the right
-     * surface if/when JP wants 911 reachable in-app.
+     * Also surfaced as the *top* button on the TechEmpower Home
+     * Emergency Help card (issue #516) — the card is the discoverable
+     * companion to the hidden long-press affordance.
      */
     const val CRISIS_HELP_NUMBER: String = "988"
+
+    /**
+     * Issue #516 — **911 emergency dispatch**, surfaced ONLY on the
+     * TechEmpower Home Emergency Help card. Intentionally NOT on the
+     * top-app-bar phone icon: a stray tap on a top-bar shortcut that
+     * dials emergency services is the wrong UX (accidental misdials
+     * waste dispatch capacity). On the card surface, the user has
+     * already chosen "I'm looking at emergency numbers" — context-
+     * aware enough that a tap-to-dial affordance is appropriate.
+     *
+     * `ACTION_DIAL` (not `ACTION_CALL`) keeps storyvox out of the
+     * permission-requiring path; the user lands in the system dialer
+     * with `911` pre-filled and has to hit the green button to
+     * actually place the call.
+     *
+     * V1 is US-only. CA/UK/AU have different emergency numbers
+     * (999/000/etc.) — localisation is a v2 issue (see #516).
+     */
+    const val EMERGENCY_DISPATCH_NUMBER: String = "911"
 
     /**
      * Building a `tel:` URI for [Intent.ACTION_DIAL]. Returns a String

--- a/feature/src/main/kotlin/in/jphe/storyvox/feature/techempower/TechEmpowerHomeScreen.kt
+++ b/feature/src/main/kotlin/in/jphe/storyvox/feature/techempower/TechEmpowerHomeScreen.kt
@@ -17,6 +17,7 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.LazyRow
 import androidx.compose.foundation.lazy.grid.GridCells
@@ -28,6 +29,7 @@ import androidx.compose.material.icons.automirrored.filled.ArrowBack
 import androidx.compose.material.icons.filled.Forum
 import androidx.compose.material.icons.filled.Info
 import androidx.compose.material.icons.filled.Phone
+import androidx.compose.material.icons.filled.Warning
 import androidx.compose.material3.CenterAlignedTopAppBar
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Icon
@@ -60,13 +62,14 @@ import `in`.jphe.storyvox.ui.theme.LocalSpacing
  *  - Brass-on-warm-dark top-app-bar with back arrow + help icons
  *    (phone for 211 / 988, forum for Discord) on the right.
  *  - Hero: TechEmpower sun-disk logo + mission tagline.
- *  - Brass-edged card grid (4 cards):
+ *  - Brass-edged card grid (5 cards):
  *      1. Browse Resources → opens Browse (Notion's anonymous-mode
  *         four-fiction layout is the default tile set today).
  *      2. Peer Support Discord → ACTION_VIEW Discord invite URL.
- *      3. Call 211 → ACTION_DIAL tel:211 (long-press 988 via the
- *         top-app-bar phone icon).
- *      4. About TechEmpower → drill-down to [TechEmpowerAboutScreen].
+ *      3. Call 211 → ACTION_DIAL tel:211 (United Way social services).
+ *      4. Emergency Help → 3-button card (988 / 211 / 911) — see
+ *         issue #516 and [TechEmpowerEmergencyCard].
+ *      5. About TechEmpower → drill-down to [TechEmpowerAboutScreen].
  *  - Featured guides strip: horizontal row of the 8 hand-curated
  *    TechEmpower guide chapters (read directly off the anonymous
  *    Notion delegate's curated list — keeps this screen plumbing-
@@ -82,6 +85,7 @@ import `in`.jphe.storyvox.ui.theme.LocalSpacing
  * copy), not theme.
  *
  * v0.5.51 — first pass.
+ * v0.5.52 — added Emergency Help card (issue #516).
  */
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
@@ -155,7 +159,7 @@ fun TechEmpowerHomeScreen(
             item {
                 TechEmpowerCard(
                     title = "Call 211",
-                    body = "Local help — housing, food, utilities, mental health. Long-press the top-bar phone for 988.",
+                    body = "Local help — housing, food, utilities, mental health referrals via United Way.",
                     icon = Icons.Filled.Phone,
                     onClick = {
                         runCatching {
@@ -172,6 +176,15 @@ fun TechEmpowerHomeScreen(
                         }
                     },
                 )
+            }
+            // ─── Emergency Help (issue #516) ──────────────────────
+            // Full-width because the card stacks three brass-edged
+            // sub-buttons vertically; squeezing it into a 160dp grid
+            // cell would push the third number off-screen. Spanning
+            // the full row width keeps the 988 / 211 / 911 trio
+            // visible without scrolling on the Flip3 cover.
+            item(span = { GridItemSpan(maxLineSpan) }) {
+                TechEmpowerEmergencyCard()
             }
             item {
                 TechEmpowerCard(
@@ -289,6 +302,195 @@ private fun TechEmpowerCard(
                 style = MaterialTheme.typography.bodySmall,
                 color = MaterialTheme.colorScheme.onSurfaceVariant,
                 maxLines = 4,
+            )
+        }
+    }
+}
+
+/**
+ * Issue #516 — Emergency Help card. Brass-edged outer container with
+ * three brass-edged sub-buttons (988 / 211 / 911), each dialling its
+ * respective number via `ACTION_DIAL` so the user lands in the system
+ * dialer with the number pre-filled but NOT auto-placed.
+ *
+ * Why a card with three buttons instead of three separate top-level
+ * cards: the trio reads as one cognitive unit ("emergency numbers")
+ * and bundling them under one heading lets the user scan all three
+ * affordances together. Three separate cards would be visually
+ * indistinguishable from the regular brass-edged action cards and
+ * lose the "this is the emergency section" signal.
+ *
+ * Visual ranking is 988 → 211 → 911 (per issue #516 spec, not numeric
+ * order): 988 is the most likely first-touch for someone in immediate
+ * distress, 211 is everyday social services, 911 is true life-or-
+ * limb. 911 last keeps it discoverable without inviting a stray tap
+ * — accidental 911 misdials waste dispatch capacity.
+ *
+ * The outer card has no click handler; only the sub-buttons dial.
+ * Tapping the card's title row or the gap between sub-buttons does
+ * nothing — by design. The user has to land their tap on a specific
+ * number, and the brass edge around each sub-button telegraphs that.
+ *
+ * V1 ships US-only. The number constants live in [TechEmpowerLinks];
+ * localising for CA/UK/AU is a v2 follow-up (see issue #516 + the
+ * [TechEmpowerLinks.EMERGENCY_DISPATCH_NUMBER] kdoc).
+ */
+@Composable
+private fun TechEmpowerEmergencyCard() {
+    val spacing = LocalSpacing.current
+    val brass = MaterialTheme.colorScheme.primary
+    val substrate = MaterialTheme.colorScheme.surfaceContainerHigh
+    Column(
+        modifier = Modifier
+            .fillMaxWidth()
+            .clip(MaterialTheme.shapes.large)
+            .background(substrate)
+            .border(
+                width = 1.5.dp,
+                color = brass.copy(alpha = 0.55f),
+                shape = MaterialTheme.shapes.large,
+            )
+            .padding(spacing.md),
+        verticalArrangement = Arrangement.spacedBy(spacing.sm),
+    ) {
+        // Header row: warning icon + title. Warning glyph anchors the
+        // "this is the emergency section" semantic — brass-tinted to
+        // match the card edge, no red-on-red panic colouring (the
+        // Library Nocturne palette doesn't have a panic-red, and the
+        // dialer itself surfaces the call confirmation, so we don't
+        // need to scream the affordance).
+        Row(
+            verticalAlignment = Alignment.CenterVertically,
+            horizontalArrangement = Arrangement.spacedBy(spacing.sm),
+        ) {
+            Icon(
+                imageVector = Icons.Filled.Warning,
+                contentDescription = null,
+                tint = brass,
+                modifier = Modifier.size(28.dp),
+            )
+            Text(
+                text = "Emergency Help",
+                style = MaterialTheme.typography.titleMedium,
+                color = brass,
+                fontWeight = FontWeight.SemiBold,
+            )
+        }
+        Text(
+            text = "Three US helplines. Each opens the dialer with the number pre-filled — tap the green button to actually place the call.",
+            style = MaterialTheme.typography.bodySmall,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+        )
+        // ─── 988 — Suicide & Crisis Lifeline (top of the list) ────
+        EmergencyDialButton(
+            number = TechEmpowerLinks.CRISIS_HELP_NUMBER,
+            label = "Suicide & Crisis Lifeline",
+            body = "National 24/7 mental health crisis support.",
+        )
+        // ─── 211 — United Way social services ─────────────────────
+        EmergencyDialButton(
+            number = TechEmpowerLinks.PRIMARY_HELP_NUMBER,
+            label = "United Way social services",
+            body = "Housing, food, utilities, mental health referrals.",
+        )
+        // ─── 911 — Emergency dispatch (last on purpose) ───────────
+        EmergencyDialButton(
+            number = TechEmpowerLinks.EMERGENCY_DISPATCH_NUMBER,
+            label = "Emergency dispatch",
+            body = "Life-threatening situations — police, fire, ambulance.",
+        )
+    }
+}
+
+/**
+ * Issue #516 — single brass-edged dial button inside
+ * [TechEmpowerEmergencyCard]. The number renders large-and-brass on
+ * the left (the affordance — it's what the user is looking for and
+ * what they'll tap), with label + body stacked to the right.
+ *
+ * Tap fires `ACTION_DIAL` (not `ACTION_CALL`) — `ACTION_DIAL` works
+ * without the `CALL_PHONE` runtime permission and lands the user in
+ * the system dialer with the number pre-filled but NOT auto-placed.
+ * The user has to hit the green button to actually place the call;
+ * this is the right UX for "emergency menu" affordances where a
+ * stray tap shouldn't dispatch police.
+ *
+ * `runCatching` swallows `ActivityNotFoundException` — a device
+ * without a dialer activity (rare, but tablets without telephony)
+ * just no-ops the button. We don't show a toast because (a) the
+ * other two buttons might still work, and (b) the user can always
+ * find the number written on the card and dial manually from
+ * another device.
+ *
+ * `Role.Button` plus a content description on the icon-less row
+ * gives TalkBack users "988, Suicide and Crisis Lifeline, button" —
+ * matching the visual reading order top-to-bottom.
+ */
+@Composable
+private fun EmergencyDialButton(
+    number: String,
+    label: String,
+    body: String,
+) {
+    val spacing = LocalSpacing.current
+    val context = LocalContext.current
+    val brass = MaterialTheme.colorScheme.primary
+    Row(
+        modifier = Modifier
+            .fillMaxWidth()
+            .clip(MaterialTheme.shapes.medium)
+            .background(MaterialTheme.colorScheme.surfaceContainerHighest)
+            .border(
+                width = 1.dp,
+                color = brass.copy(alpha = 0.45f),
+                shape = MaterialTheme.shapes.medium,
+            )
+            .clickable(
+                role = Role.Button,
+                onClick = {
+                    runCatching {
+                        context.startActivity(
+                            Intent(
+                                Intent.ACTION_DIAL,
+                                Uri.parse(TechEmpowerLinks.telUri(number)),
+                            ).apply { addFlags(Intent.FLAG_ACTIVITY_NEW_TASK) },
+                        )
+                    }
+                },
+            )
+            .padding(horizontal = spacing.md, vertical = spacing.sm),
+        verticalAlignment = Alignment.CenterVertically,
+        horizontalArrangement = Arrangement.spacedBy(spacing.md),
+    ) {
+        // The number itself is the primary visual + the tap target's
+        // raison d'être — render it large-and-brass so it reads at a
+        // glance from arm's length. SemiBold (not Bold) because the
+        // Library Nocturne typography ramp tops out at SemiBold for
+        // body-adjacent surfaces; bumping to Bold would clash with the
+        // titleMedium "Emergency Help" header above.
+        Text(
+            text = number,
+            style = MaterialTheme.typography.headlineSmall,
+            color = brass,
+            fontWeight = FontWeight.SemiBold,
+            modifier = Modifier.width(56.dp),
+            textAlign = TextAlign.Start,
+        )
+        Column(
+            modifier = Modifier.fillMaxWidth(),
+            verticalArrangement = Arrangement.spacedBy(spacing.xxs),
+        ) {
+            Text(
+                text = label,
+                style = MaterialTheme.typography.titleSmall,
+                color = brass,
+                fontWeight = FontWeight.SemiBold,
+            )
+            Text(
+                text = body,
+                style = MaterialTheme.typography.bodySmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                maxLines = 2,
             )
         }
     }

--- a/feature/src/test/kotlin/in/jphe/storyvox/feature/techempower/EmergencyHelpCardContractTest.kt
+++ b/feature/src/test/kotlin/in/jphe/storyvox/feature/techempower/EmergencyHelpCardContractTest.kt
@@ -1,0 +1,134 @@
+package `in`.jphe.storyvox.feature.techempower
+
+import `in`.jphe.storyvox.data.TechEmpowerLinks
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * Issue #516 — pins the contract of the Emergency Help card on
+ * TechEmpower Home. The card itself is a private composable inside
+ * [TechEmpowerHomeScreen], so this test exercises the *data contract*
+ * the card depends on rather than rendering the composable:
+ *
+ *  1. The three US helpline numbers (988 / 211 / 911) exist on
+ *     [TechEmpowerLinks] with the exact string values the dialer
+ *     expects. A typo here (e.g. "9-1-1" or "988 ") would silently
+ *     break the `ACTION_DIAL` intent — the dialer parses `tel:` URIs
+ *     strictly.
+ *  2. [TechEmpowerLinks.telUri] produces the canonical `tel:<n>`
+ *     shape — no whitespace, no `tel://` (Android dialer treats
+ *     `tel://211` as a non-resolvable URI on some OEM dialers).
+ *  3. The three numbers are *distinct*. Bundling them into one card
+ *     only works if each constant points to a different line; a copy-
+ *     paste regression that sets 911 = "988" would silently route
+ *     emergency taps to the crisis line.
+ *  4. The card composable [TechEmpowerHomeScreen] still exists with
+ *     the same public signature — Compose synthesises the function
+ *     as `TechEmpowerHomeScreenKt`, and a reflection load catches
+ *     accidental renames.
+ *
+ * Why pin via data + reflection instead of a Compose UI test:
+ * `:feature` ships JVM unit tests only (no androidx.compose.ui.test
+ * dependency yet — see [SettingsSubscreenContractTest] for the same
+ * rationale). Once that infra lands, this test can grow assertions
+ * that click each of the three sub-buttons and verify the dispatched
+ * intent's action + data. Until then, the data-shape contract is the
+ * cheapest regression net for the high-value "wrong number dialled
+ * in an emergency" failure mode.
+ */
+class EmergencyHelpCardContractTest {
+
+    @Test
+    fun `crisis helpline constant is 988`() {
+        // Exact string match — `tel:988` is the URI the dialer
+        // resolves. Any whitespace, punctuation, or alternate
+        // formatting (e.g. "9-8-8") would break the intent.
+        assertEquals("988", TechEmpowerLinks.CRISIS_HELP_NUMBER)
+    }
+
+    @Test
+    fun `primary helpline constant is 211`() {
+        assertEquals("211", TechEmpowerLinks.PRIMARY_HELP_NUMBER)
+    }
+
+    @Test
+    fun `emergency dispatch constant is 911`() {
+        // Issue #516 introduced this constant. Pin its exact value
+        // so a refactor that touches TechEmpowerLinks can't silently
+        // drop or mis-spell the 911 surface.
+        assertEquals("911", TechEmpowerLinks.EMERGENCY_DISPATCH_NUMBER)
+    }
+
+    @Test
+    fun `telUri produces canonical tel scheme for every emergency number`() {
+        // The dialer parses `tel:<digits>` strictly. `tel://211`
+        // (with two slashes) is treated as a non-resolvable URI on
+        // some OEM dialers — Samsung's stock dialer was the failure
+        // mode JP hit during v0.5.51 development.
+        assertEquals(
+            "tel:988",
+            TechEmpowerLinks.telUri(TechEmpowerLinks.CRISIS_HELP_NUMBER),
+        )
+        assertEquals(
+            "tel:211",
+            TechEmpowerLinks.telUri(TechEmpowerLinks.PRIMARY_HELP_NUMBER),
+        )
+        assertEquals(
+            "tel:911",
+            TechEmpowerLinks.telUri(TechEmpowerLinks.EMERGENCY_DISPATCH_NUMBER),
+        )
+    }
+
+    @Test
+    fun `three emergency numbers are distinct`() {
+        // A copy-paste regression that sets two of the constants to
+        // the same value would silently route taps to the wrong line.
+        // Especially dangerous for 911 — an emergency tap going to
+        // 988 (or vice-versa) is a user-facing failure mode that no
+        // CI signal would catch downstream.
+        val numbers = setOf(
+            TechEmpowerLinks.CRISIS_HELP_NUMBER,
+            TechEmpowerLinks.PRIMARY_HELP_NUMBER,
+            TechEmpowerLinks.EMERGENCY_DISPATCH_NUMBER,
+        )
+        assertEquals(3, numbers.size)
+    }
+
+    @Test
+    fun `TechEmpowerHomeScreen composable still exists`() {
+        // Compose-emitted top-level functions land on a synthetic
+        // class named `<FileName>Kt`. Asserting the class loads is
+        // the cheapest smoke test for "the surface still exists" —
+        // a rename or accidental deletion turns into ClassNotFound.
+        val cls = runCatching {
+            Class.forName("in.jphe.storyvox.feature.techempower.TechEmpowerHomeScreenKt")
+        }.getOrNull()
+        assertNotNull(
+            "TechEmpowerHomeScreen composable missing — the Emergency Help card lives inside it.",
+            cls,
+        )
+    }
+
+    @Test
+    fun `all three emergency-number constants are non-empty digit strings`() {
+        // Defensive: the dialer happily opens with an empty `tel:`
+        // URI but the user lands in an empty dial pad, which reads
+        // as "the app is broken." Pin that each constant is non-blank
+        // and digits-only (the only shape that round-trips cleanly
+        // through `tel:` on every Android dialer JP has tested).
+        val constants = listOf(
+            TechEmpowerLinks.CRISIS_HELP_NUMBER,
+            TechEmpowerLinks.PRIMARY_HELP_NUMBER,
+            TechEmpowerLinks.EMERGENCY_DISPATCH_NUMBER,
+        )
+        for (n in constants) {
+            assertTrue("Emergency number must be non-blank: '$n'", n.isNotBlank())
+            assertTrue(
+                "Emergency number must be digits-only: '$n'",
+                n.all { it.isDigit() },
+            )
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Closes #516. Adds a dedicated brass-edged **Emergency Help** card on TechEmpower Home, sitting alongside the existing 4 cards (Browse Resources / Peer Support Discord / Call 211 / About). Card lists three US helplines as brass-edged sub-buttons:

- **988** — Suicide & Crisis Lifeline (top — most common immediate-help)
- **211** — United Way social services (middle — everyday)
- **911** — Emergency dispatch (bottom — true emergencies)

Each sub-button fires `Intent.ACTION_DIAL` with `tel:<n>` so the user lands in the system dialer with the number pre-filled but NOT auto-placed (no `CALL_PHONE` permission, no accidental dispatch on a stray tap). The outer card has no click handler — only the three sub-buttons dial.

## Why this shape

The v0.5.51 top-app-bar phone icon (`tap=211`, `long-press=988`) hides 988 behind a discovery-hostile gesture. The card lays all three out plainly, with full names + descriptions, so users see what each does before they dial. The top-bar icon stays as one-tap quick-call; the card is for considered choice + discovery. Both surfaces serve different intents.

Visual ranking is **988 → 211 → 911** (per #516 spec, not numeric order): 988 first because immediate mental-health crisis is the highest-leverage tap, 211 second because it's the everyday social-services line, 911 last because emergency dispatch should be discoverable but not invite a stray first-tap.

911 is intentionally **only** on the card, not on the top-app-bar — accidental top-bar 911 misfires waste dispatch capacity. In the card context, the user has already chosen "I'm looking at emergency numbers" — that context-shift makes a tap-to-dial affordance appropriate.

## US-only v1

Three US-specific helplines. CA/UK/AU users get 988 + 211 (work in Canada), but **999** (UK), **000** (AU), **13 11 14** (AU Lifeline), and **116 123** (UK Samaritans) are not yet surfaced. Localisation is a v2 follow-up — `TechEmpowerLinks.EMERGENCY_DISPATCH_NUMBER` kdoc documents the plan.

## Files

- `core-data/.../TechEmpowerLinks.kt` — adds `EMERGENCY_DISPATCH_NUMBER = "911"` constant; expands `CRISIS_HELP_NUMBER` kdoc to reference the new card.
- `feature/.../TechEmpowerHomeScreen.kt` — adds `TechEmpowerEmergencyCard` + `EmergencyDialButton` private composables; injects the new card into the existing grid as a full-width item (so the three sub-buttons fit without horizontal scroll on the Flip3 cover); drops the now-redundant "long-press the top-bar phone for 988" hint from the Call 211 card body.
- `feature/.../EmergencyHelpCardContractTest.kt` (new) — pins the data contract: number constants are exact strings, `telUri` produces canonical `tel:<n>` (no `tel://` double-slash that breaks Samsung's stock dialer), the three numbers are distinct (so a copy-paste regression can't route 911 taps to 988), and the host composable still exists by reflection.

## Test plan

- [x] `./gradlew :app:assembleDebug :app:testDebugUnitTest :feature:testDebugUnitTest` — green (2m37s)
- [x] `EmergencyHelpCardContractTest` — 7 tests, all pass
- [ ] Install APK on R83W80CAFZB, open Library → TechEmpower hero → verify Emergency Help card renders between Call 211 and About, with all three numbers visible at arm's length
- [ ] Tap each sub-button → verify dialer opens with the correct number pre-filled but not auto-dialled
- [ ] TalkBack swipe-through — each sub-button announces as "988, Suicide and Crisis Lifeline, button" (visual reading order top-to-bottom)

🤖 Generated with [Claude Code](https://claude.com/claude-code)