### PR TITLE
feat(source-royalroad): two-way tag sync — closes #178

### DIFF
--- a/app/src/main/kotlin/in/jphe/storyvox/StoryvoxApp.kt
+++ b/app/src/main/kotlin/in/jphe/storyvox/StoryvoxApp.kt
@@ -95,6 +95,17 @@ class StoryvoxApp : Application(), Configuration.Provider {
      *  via the [Lazy] wrapper. */
     @Inject lateinit var widgetStateObserver: Lazy<WidgetStateObserver>
 
+    /**
+     * Issue #178 — Royal Road tag-sync periodic worker + sign-in
+     * observer. The scheduler enqueues the 24h periodic worker
+     * (idempotent KEEP policy). The observer subscribes to
+     * AuthRepository's RR session state and kicks the coordinator
+     * once on the Anonymous → Authenticated edge, so first-sync
+     * happens immediately after sign-in rather than waiting ~24h.
+     */
+    @Inject lateinit var tagSyncScheduler: Lazy<`in`.jphe.storyvox.source.royalroad.tagsync.RoyalRoadTagSyncScheduler>
+    @Inject lateinit var tagSyncCoordinator: Lazy<`in`.jphe.storyvox.source.royalroad.tagsync.RoyalRoadTagSyncCoordinator>
+
     override val workManagerConfiguration: Configuration
         get() = Configuration.Builder()
             .setWorkerFactory(workerFactory)
@@ -173,6 +184,39 @@ class StoryvoxApp : Application(), Configuration.Provider {
         // P22T-class hardware. Idempotent — re-starting is a no-op.
         initScope.launch {
             widgetStateObserver.get().start()
+        }
+        // Issue #178 — Royal Road tag-sync. Two coroutines:
+        //   1. Schedule the 24h periodic worker (idempotent, KEEP).
+        //   2. Watch the RR session state and trigger an immediate
+        //      sync on the Anonymous → Authenticated edge so the
+        //      first round-trip happens within seconds of sign-in
+        //      rather than at the next periodic tick. Subsequent
+        //      sign-outs cancel the worker so we don't sit on an
+        //      empty schedule.
+        initScope.launch {
+            tagSyncScheduler.get().schedule()
+        }
+        initScope.launch {
+            var wasAuthed = false
+            authRepository.get().sessionState.collect { state ->
+                val nowAuthed = state is `in`.jphe.storyvox.data.auth.SessionState.Authenticated
+                if (nowAuthed && !wasAuthed) {
+                    // Sign-in edge — first sync immediately. Fire-
+                    // and-forget; failures are silent (#178 spec).
+                    runCatching { tagSyncCoordinator.get().syncNow() }
+                }
+                if (!nowAuthed && wasAuthed) {
+                    // Sign-out — cancel the periodic so we stop
+                    // hitting RR with credentialed-but-stale calls.
+                    tagSyncScheduler.get().cancel()
+                }
+                if (nowAuthed && !wasAuthed) {
+                    // Re-enqueue on each new sign-in (KEEP no-ops
+                    // if one is already scheduled).
+                    tagSyncScheduler.get().schedule()
+                }
+                wasAuthed = nowAuthed
+            }
         }
     }
 

--- a/app/src/main/kotlin/in/jphe/storyvox/data/FollowedTagsStoreImpl.kt
+++ b/app/src/main/kotlin/in/jphe/storyvox/data/FollowedTagsStoreImpl.kt
@@ -1,0 +1,242 @@
+package `in`.jphe.storyvox.data
+
+import android.content.Context
+import androidx.datastore.core.DataStore
+import androidx.datastore.preferences.core.Preferences
+import androidx.datastore.preferences.core.booleanPreferencesKey
+import androidx.datastore.preferences.core.edit
+import androidx.datastore.preferences.core.longPreferencesKey
+import androidx.datastore.preferences.core.stringPreferencesKey
+import androidx.datastore.preferences.preferencesDataStore
+import dagger.hilt.android.qualifiers.ApplicationContext
+import `in`.jphe.storyvox.data.repository.sync.FollowedTagsStore
+import javax.inject.Inject
+import javax.inject.Singleton
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.flow.map
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonElement
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.JsonPrimitive
+import kotlinx.serialization.json.contentOrNull
+import kotlinx.serialization.json.jsonObject
+import kotlinx.serialization.json.longOrNull
+
+/**
+ * Single-file owner of the per-source followed-tags set + tombstones
+ * + sync metadata (issue #178).
+ *
+ * **Two DataStores, by design:**
+ *
+ *  - `storyvox_tag_sync` — large per-source JSON payloads (the
+ *    followed-tag set + tombstone map). Intentionally NOT
+ *    round-tripped through `:core-sync` because the tag set
+ *    itself is mirrored via Royal Road's server-side preference
+ *    (the canonical source-of-truth for RR-side tags), and double-
+ *    merging through both InstantDB LWW and RR LWW would risk
+ *    collisions with different freshness windows.
+ *
+ *  - `storyvox_settings` — the two metadata keys (`pref_rr_tag_sync_enabled`,
+ *    `pref_rr_tag_sync_last_synced_at`). Both ARE in the
+ *    `:core-sync` allowlist (see [SettingsRepositoryUiImpl.SYNC_ALLOWLIST])
+ *    so a user who flips "sync with RR off" on their phone sees
+ *    the toggle reflected on their tablet, and so the "Last
+ *    synced" pill shows the freshest stamp across devices.
+ *
+ *    DataStore is a per-name singleton per process — opening
+ *    `storyvox_settings` from this file points at the same
+ *    on-disk file `SettingsRepositoryUiImpl.settingsDataStore`
+ *    uses. Concurrent writes are safe because DataStore
+ *    serialises all `edit` calls internally.
+ *
+ * Wire shapes (storyvox_tag_sync):
+ *  - `tags:<sourceId>` → JSON `{ "tags": ["action", "litrpg", ...] }`
+ *  - `tombstones:<sourceId>` → JSON `{ "action": 1715000000000, ... }`
+ *
+ * Wire shapes (storyvox_settings):
+ *  - `pref_rr_tag_sync_enabled` → Boolean
+ *  - `pref_rr_tag_sync_last_synced_at` → Long
+ *
+ * The per-sourceId keying for the large payloads means a future
+ * AO3 / Discord tag-sync doesn't need a new file or schema —
+ * just a different sourceId argument at the call site.
+ */
+private val Context.tagSyncDataStore: DataStore<Preferences> by preferencesDataStore(
+    name = "storyvox_tag_sync",
+)
+
+/**
+ * Second handle on the main settings DataStore — shared with
+ * [SettingsRepositoryUiImpl] (file-local `settingsDataStore`).
+ * DataStore is a per-name singleton per process, so this points
+ * at the same on-disk file. Used exclusively to read/write the
+ * two synced metadata keys, never anything else.
+ */
+private val Context.tagSyncMetadataStore: DataStore<Preferences> by preferencesDataStore(
+    name = "storyvox_settings",
+)
+
+@Singleton
+class FollowedTagsStoreImpl @Inject constructor(
+    @ApplicationContext private val context: Context,
+) : FollowedTagsStore {
+
+    private val store: DataStore<Preferences> get() = context.tagSyncDataStore
+    private val metadataStore: DataStore<Preferences> get() = context.tagSyncMetadataStore
+
+    private fun tagsKey(sourceId: String) = stringPreferencesKey("tags:$sourceId")
+    private fun tombstonesKey(sourceId: String) = stringPreferencesKey("tombstones:$sourceId")
+
+    /**
+     * Issue #178 — per-source last-synced metadata key. Today
+     * scoped only to Royal Road; the per-sourceId pattern leaves
+     * room for AO3 / Discord without touching the wire schema.
+     * The `pref_rr_*` literal name is preserved for RR because
+     * it's already in the `:core-sync` allowlist; future sources
+     * would add their own keyed entries.
+     */
+    private fun lastSyncedAtKey(sourceId: String) = longPreferencesKey(
+        when (sourceId) {
+            `in`.jphe.storyvox.data.source.SourceIds.ROYAL_ROAD -> "pref_rr_tag_sync_last_synced_at"
+            else -> "pref_${sourceId}_tag_sync_last_synced_at"
+        }
+    )
+
+    private fun syncEnabledKey(sourceId: String) = booleanPreferencesKey(
+        when (sourceId) {
+            `in`.jphe.storyvox.data.source.SourceIds.ROYAL_ROAD -> "pref_rr_tag_sync_enabled"
+            else -> "pref_${sourceId}_tag_sync_enabled"
+        }
+    )
+
+    override fun followedTags(sourceId: String): Flow<Set<String>> {
+        val key = tagsKey(sourceId)
+        return store.data.map { prefs -> decodeTagSet(prefs[key]) }
+    }
+
+    override suspend fun snapshotFollowedTags(sourceId: String): Set<String> =
+        followedTags(sourceId).first()
+
+    override suspend fun tombstones(sourceId: String): Map<String, Long> {
+        val raw = store.data.first()[tombstonesKey(sourceId)]
+        return decodeTombstones(raw)
+    }
+
+    override suspend fun replaceFollowedTags(sourceId: String, tags: Set<String>) {
+        val key = tagsKey(sourceId)
+        store.edit { prefs -> prefs[key] = encodeTagSet(tags) }
+    }
+
+    override suspend fun setTagFollowed(
+        sourceId: String,
+        tag: String,
+        followed: Boolean,
+        at: Long,
+    ) {
+        val tagsK = tagsKey(sourceId)
+        val tombsK = tombstonesKey(sourceId)
+        store.edit { prefs ->
+            val existingTags = decodeTagSet(prefs[tagsK])
+            val existingTombs = decodeTombstones(prefs[tombsK])
+            if (followed) {
+                prefs[tagsK] = encodeTagSet(existingTags + tag)
+                // Re-add clears the tombstone — the user changed
+                // their mind, the prior remove is no longer load-
+                // bearing for merge.
+                if (existingTombs.containsKey(tag)) {
+                    val cleared = existingTombs.toMutableMap().apply { remove(tag) }
+                    prefs[tombsK] = encodeTombstones(cleared)
+                }
+            } else {
+                prefs[tagsK] = encodeTagSet(existingTags - tag)
+                // Record (or overwrite) the tombstone with the
+                // current wall-clock stamp — the merge layer uses
+                // this for the 5-min prefer-local window.
+                val newTombs = existingTombs.toMutableMap().apply { put(tag, at) }
+                prefs[tombsK] = encodeTombstones(newTombs)
+            }
+        }
+    }
+
+    override suspend fun forgetTombstone(sourceId: String, tag: String) {
+        val key = tombstonesKey(sourceId)
+        store.edit { prefs ->
+            val existing = decodeTombstones(prefs[key])
+            if (existing.containsKey(tag)) {
+                val cleared = existing.toMutableMap().apply { remove(tag) }
+                prefs[key] = encodeTombstones(cleared)
+            }
+        }
+    }
+
+    override fun lastSyncedAt(sourceId: String): Flow<Long> {
+        val key = lastSyncedAtKey(sourceId)
+        // Round-tripped via `:core-sync` so the freshest stamp
+        // across devices wins (issue #178). Reads/writes hit the
+        // main settings DataStore.
+        return metadataStore.data.map { prefs -> prefs[key] ?: 0L }
+    }
+
+    override suspend fun stampSyncedAt(sourceId: String, at: Long) {
+        val key = lastSyncedAtKey(sourceId)
+        metadataStore.edit { prefs -> prefs[key] = at }
+    }
+
+    override fun syncEnabled(sourceId: String): Flow<Boolean> {
+        val key = syncEnabledKey(sourceId)
+        // Default true — once a user is signed in to a source
+        // we want sync on by default. The Settings UI's toggle
+        // writes the explicit false when the user opts out.
+        // Round-tripped via `:core-sync` (issue #178 — "Add to
+        // :core-sync allowlist so the sync state round-trips
+        // across devices.")
+        return metadataStore.data.map { prefs -> prefs[key] ?: true }
+    }
+
+    override suspend fun setSyncEnabled(sourceId: String, enabled: Boolean) {
+        val key = syncEnabledKey(sourceId)
+        metadataStore.edit { prefs -> prefs[key] = enabled }
+    }
+
+    // ── Codec helpers ────────────────────────────────────────────
+
+    private val json: Json = Json { ignoreUnknownKeys = true }
+
+    private fun encodeTagSet(tags: Set<String>): String {
+        // Stable order so two devices with the same set produce
+        // byte-identical wire payloads (matches the contract in
+        // SettingsSnapshotSource.snapshot's kdoc).
+        val sorted = tags.toSortedSet().toList()
+        val arr = kotlinx.serialization.json.JsonArray(sorted.map { JsonPrimitive(it) })
+        val obj: JsonElement = JsonObject(mapOf("tags" to arr))
+        return obj.toString()
+    }
+
+    private fun decodeTagSet(raw: String?): Set<String> {
+        if (raw.isNullOrBlank()) return emptySet()
+        return runCatching {
+            val obj = json.parseToJsonElement(raw).jsonObject
+            val arr = obj["tags"] ?: return emptySet()
+            val list = (arr as? kotlinx.serialization.json.JsonArray) ?: return emptySet()
+            list.mapNotNull { (it as? JsonPrimitive)?.contentOrNull }.toSet()
+        }.getOrDefault(emptySet())
+    }
+
+    private fun encodeTombstones(map: Map<String, Long>): String {
+        val sorted = map.toSortedMap()
+        val obj: JsonElement = JsonObject(sorted.mapValues { JsonPrimitive(it.value) as JsonElement })
+        return obj.toString()
+    }
+
+    private fun decodeTombstones(raw: String?): Map<String, Long> {
+        if (raw.isNullOrBlank()) return emptyMap()
+        return runCatching {
+            val obj = json.parseToJsonElement(raw).jsonObject
+            obj.mapNotNull { (k, v) ->
+                val stamp = (v as? JsonPrimitive)?.longOrNull ?: return@mapNotNull null
+                k to stamp
+            }.toMap()
+        }.getOrDefault(emptyMap())
+    }
+}

--- a/app/src/main/kotlin/in/jphe/storyvox/data/SettingsRepositoryUiImpl.kt
+++ b/app/src/main/kotlin/in/jphe/storyvox/data/SettingsRepositoryUiImpl.kt
@@ -2244,6 +2244,7 @@ class SettingsRepositoryUiImpl(
                 SyncedType.INT -> editor[intPreferencesKey(keyName)] = value.toInt()
                 SyncedType.FLOAT -> editor[floatPreferencesKey(keyName)] = value.toFloat()
                 SyncedType.STRING -> editor[stringPreferencesKey(keyName)] = value
+                SyncedType.LONG -> editor[longPreferencesKey(keyName)] = value.toLong()
             }
         }
     }
@@ -2385,6 +2386,18 @@ class SettingsRepositoryUiImpl(
             "pref_a11y_reading_direction",
             // Issue #517 — TechEmpower Home onboarding gate.
             "pref_techempower_home_seen",
+            // Issue #178 — Royal Road tag-sync metadata. The actual
+            // followed-tags set (`pref_rr_tag_sync_followed_tags_v1`)
+            // is intentionally NOT in this allowlist: it's mirrored
+            // through RR's own server-side preference store (the
+            // "saved tags" UI on royalroad.com) rather than through
+            // InstantDB. Round-tripping it through both would risk
+            // double-merge collisions (InstantDB-LWW vs RR-LWW with
+            // different freshness windows). The two metadata keys
+            // ARE synced so a user who flips "sync with RR off" on
+            // their phone sees the toggle reflected on their tablet.
+            "pref_rr_tag_sync_enabled",
+            "pref_rr_tag_sync_last_synced_at",
         )
 
         /**
@@ -2475,11 +2488,14 @@ class SettingsRepositoryUiImpl(
             "pref_a11y_reading_direction" to SyncedType.STRING,
             // Issue #517 — TechEmpower Home onboarding gate.
             "pref_techempower_home_seen" to SyncedType.BOOLEAN,
+            // Issue #178 — Royal Road tag-sync metadata.
+            "pref_rr_tag_sync_enabled" to SyncedType.BOOLEAN,
+            "pref_rr_tag_sync_last_synced_at" to SyncedType.LONG,
         )
     }
 
     /** Synced-preference value type tag for [parseAndPut]. */
-    internal enum class SyncedType { BOOLEAN, INT, FLOAT, STRING }
+    internal enum class SyncedType { BOOLEAN, INT, FLOAT, STRING, LONG }
 }
 
 /**

--- a/app/src/main/kotlin/in/jphe/storyvox/di/AppBindings.kt
+++ b/app/src/main/kotlin/in/jphe/storyvox/di/AppBindings.kt
@@ -299,6 +299,29 @@ object AppBindings {
         impl: SettingsRepositoryUiImpl,
     ): `in`.jphe.storyvox.data.repository.sync.SettingsSnapshotSource = impl
 
+    /**
+     * Issue #178 — followed-tags store binding. The impl lives in
+     * `:app` (`FollowedTagsStoreImpl`) because it owns a DataStore
+     * file, and the interface is in `:core-data` so
+     * `:source-royalroad`'s tag-sync coordinator can consume it
+     * without depending on `:app`.
+     */
+    @Provides @Singleton
+    fun provideFollowedTagsStore(
+        impl: `in`.jphe.storyvox.data.FollowedTagsStoreImpl,
+    ): `in`.jphe.storyvox.data.repository.sync.FollowedTagsStore = impl
+
+    /**
+     * Issue #178 — feature-api facade for the Settings tag-sync
+     * row. The implementation glues `:core-data`'s store +
+     * `:source-royalroad`'s coordinator together; the row in
+     * `:feature` only sees this UI-shaped interface.
+     */
+    @Provides @Singleton
+    fun provideRoyalRoadTagSyncUi(
+        impl: RealRoyalRoadTagSyncUi,
+    ): `in`.jphe.storyvox.feature.api.RoyalRoadTagSyncUi = impl
+
     // Tier 2 secrets sync (this PR — extends #360): all three tokens
     // (Notion / Discord / Outline) actually live in
     // EncryptedSharedPreferences already (Notion: `notion.api_token`,

--- a/app/src/main/kotlin/in/jphe/storyvox/di/RealRoyalRoadTagSyncUi.kt
+++ b/app/src/main/kotlin/in/jphe/storyvox/di/RealRoyalRoadTagSyncUi.kt
@@ -1,0 +1,49 @@
+package `in`.jphe.storyvox.di
+
+import `in`.jphe.storyvox.data.repository.sync.FollowedTagsStore
+import `in`.jphe.storyvox.data.source.SourceIds
+import `in`.jphe.storyvox.feature.api.RoyalRoadTagSyncUi
+import `in`.jphe.storyvox.feature.api.UiTagSyncOutcome
+import `in`.jphe.storyvox.source.royalroad.tagsync.RoyalRoadTagSyncCoordinator
+import javax.inject.Inject
+import javax.inject.Singleton
+import kotlinx.coroutines.flow.Flow
+
+/**
+ * `:app`-side bridge between the feature/api facade
+ * [RoyalRoadTagSyncUi] (consumed by `RoyalRoadTagSyncViewModel`)
+ * and the concrete `:source-royalroad` coordinator + store
+ * (issue #178).
+ *
+ * Pure adapter — no business logic of its own. Same shape as the
+ * other `Real*Ui` bindings in this package.
+ */
+@Singleton
+class RealRoyalRoadTagSyncUi @Inject internal constructor(
+    private val store: FollowedTagsStore,
+    private val coordinator: RoyalRoadTagSyncCoordinator,
+) : RoyalRoadTagSyncUi {
+
+    override val syncEnabled: Flow<Boolean> = store.syncEnabled(SourceIds.ROYAL_ROAD)
+    override val lastSyncedAt: Flow<Long> = store.lastSyncedAt(SourceIds.ROYAL_ROAD)
+
+    override suspend fun setSyncEnabled(enabled: Boolean) {
+        store.setSyncEnabled(SourceIds.ROYAL_ROAD, enabled)
+    }
+
+    override suspend fun syncNow(): UiTagSyncOutcome =
+        coordinator.syncNow().toUi()
+
+    private fun RoyalRoadTagSyncCoordinator.Outcome.toUi(): UiTagSyncOutcome = when (this) {
+        is RoyalRoadTagSyncCoordinator.Outcome.Ok -> UiTagSyncOutcome.Ok(
+            tagsPulledIn = tagsPulledIn,
+            tagsPushedOut = tagsPushedOut,
+            tagsRemovedLocally = tagsRemovedLocally,
+            tagsRemovedRemotely = tagsRemovedRemotely,
+            syncedAt = syncedAt,
+        )
+        RoyalRoadTagSyncCoordinator.Outcome.NotAuthenticated -> UiTagSyncOutcome.NotAuthenticated
+        RoyalRoadTagSyncCoordinator.Outcome.Disabled -> UiTagSyncOutcome.Disabled
+        is RoyalRoadTagSyncCoordinator.Outcome.Failed -> UiTagSyncOutcome.Failed(message)
+    }
+}

--- a/core-data/src/main/kotlin/in/jphe/storyvox/data/repository/sync/FollowedTagsStore.kt
+++ b/core-data/src/main/kotlin/in/jphe/storyvox/data/repository/sync/FollowedTagsStore.kt
@@ -1,0 +1,93 @@
+package `in`.jphe.storyvox.data.repository.sync
+
+import kotlinx.coroutines.flow.Flow
+
+/**
+ * Per-source followed-tags set + per-tag tombstones, owned by
+ * `:app`'s DataStore and exposed up to `:source-royalroad` (and
+ * any future tag-sync-capable source) through this thin
+ * interface (issue #178).
+ *
+ * **Why an interface in `:core-data`** — same shape as
+ * [SettingsSnapshotSource]. The DataStore implementation lives in
+ * `:app`'s `SettingsRepositoryUiImpl` (single owner of the
+ * `"storyvox_settings"` store), and `:source-royalroad` consumes
+ * the abstraction so it doesn't have to depend on `:app`.
+ *
+ * **Per-source** — every implementation that supports server-side
+ * tag-sync (Royal Road today; AO3 / Discord may follow) keys its
+ * tags under a sourceId. The local mirror's wire shape is a JSON
+ * object stored in `pref_rr_tag_sync_followed_tags_v1` (etc),
+ * but callers see a plain `Set<String>` here — the store handles
+ * serialisation.
+ *
+ * **Tombstones** — when the user explicitly unfollows a tag on
+ * this device, the store records the removal timestamp under
+ * [tombstones]. The next sync round consults the tombstones to
+ * decide whether a remote re-add wins (per
+ * [TagSyncMerge.PREFER_LOCAL_WINDOW_MS]).
+ */
+interface FollowedTagsStore {
+
+    /**
+     * Hot stream of the currently-followed-tags set for [sourceId].
+     * Settings UI and the sync coordinator both observe this.
+     */
+    fun followedTags(sourceId: String): Flow<Set<String>>
+
+    /** One-shot snapshot of the followed-tags set for [sourceId]. */
+    suspend fun snapshotFollowedTags(sourceId: String): Set<String>
+
+    /** Map of tag → epoch-ms timestamp of an explicit local removal. */
+    suspend fun tombstones(sourceId: String): Map<String, Long>
+
+    /**
+     * Replace the followed-tags set for [sourceId] with [tags].
+     * Used by the sync coordinator to apply a remote-merged set.
+     * Stamps a wall-clock write so [SettingsSnapshotSource.lastLocalWriteAt]
+     * advances and the next round-trip pushes the new state.
+     */
+    suspend fun replaceFollowedTags(sourceId: String, tags: Set<String>)
+
+    /**
+     * Toggle a single tag on or off for [sourceId]. On removal,
+     * records a tombstone at [at]. On re-add, clears any
+     * existing tombstone (the user re-followed something they
+     * had removed — that's a positive intent, the tombstone is
+     * obsolete).
+     */
+    suspend fun setTagFollowed(
+        sourceId: String,
+        tag: String,
+        followed: Boolean,
+        at: Long = System.currentTimeMillis(),
+    )
+
+    /**
+     * Drop the tombstone for [tag] under [sourceId]. The sync
+     * coordinator calls this after a successful push so the
+     * tombstone log doesn't grow without bound.
+     */
+    suspend fun forgetTombstone(sourceId: String, tag: String)
+
+    /**
+     * Epoch-ms timestamp of the last successful tag sync round-
+     * trip with the remote (RR). Driven by the sync coordinator
+     * itself, surfaced to the UI for the "Last synced: <relative>"
+     * affordance.
+     */
+    fun lastSyncedAt(sourceId: String): Flow<Long>
+
+    /** Stamp a successful sync round-trip at [at]. */
+    suspend fun stampSyncedAt(sourceId: String, at: Long = System.currentTimeMillis())
+
+    /**
+     * Whether tag-sync is enabled for [sourceId]. Defaults to
+     * `true` when the user is signed in to that source. Issue
+     * #178: `pref_rr_tag_sync_enabled` boolean.
+     */
+    fun syncEnabled(sourceId: String): Flow<Boolean>
+
+    /** Set the sync-enabled toggle for [sourceId]. */
+    suspend fun setSyncEnabled(sourceId: String, enabled: Boolean)
+}

--- a/feature/src/main/kotlin/in/jphe/storyvox/feature/api/UiContracts.kt
+++ b/feature/src/main/kotlin/in/jphe/storyvox/feature/api/UiContracts.kt
@@ -1884,3 +1884,55 @@ sealed class AzureProbeResult {
     /** No key configured — Test button still fires this for clarity. */
     object NotConfigured : AzureProbeResult()
 }
+
+/**
+ * Issue #178 — UI-side facade for Royal Road's saved-tags ↔
+ * storyvox-followed-tags two-way mirror. Lives in `:feature/api`
+ * (this file) so the Settings → Account composable can consume
+ * the surface without `:feature` depending on `:source-royalroad`.
+ *
+ * Implementation lives in `:app`'s
+ * [`in.jphe.storyvox.di.RealRoyalRoadTagSyncUi`], which bridges
+ * to the `:source-royalroad`'s `RoyalRoadTagSyncCoordinator` and
+ * `FollowedTagsStore`. Same shape as the existing
+ * [SettingsRepositoryUi] / [FictionRepositoryUi] split.
+ */
+interface RoyalRoadTagSyncUi {
+    /** Hot stream of the `pref_rr_tag_sync_enabled` toggle. */
+    val syncEnabled: Flow<Boolean>
+
+    /** Hot stream of the `pref_rr_tag_sync_last_synced_at` Long
+     *  (epoch ms), or `0L` if no sync has happened yet. */
+    val lastSyncedAt: Flow<Long>
+
+    /** Toggle the periodic + per-action sync on or off. Default
+     *  true once the user is signed in to Royal Road. */
+    suspend fun setSyncEnabled(enabled: Boolean)
+
+    /** Fire a single sync round-trip immediately. Used by the
+     *  "Sync now" brass button. Returns a UI-visible outcome
+     *  so the row can render a one-shot status line. */
+    suspend fun syncNow(): UiTagSyncOutcome
+}
+
+/** UI-side projection of `RoyalRoadTagSyncCoordinator.Outcome`. */
+sealed interface UiTagSyncOutcome {
+    data class Ok(
+        val tagsPulledIn: Int,
+        val tagsPushedOut: Int,
+        val tagsRemovedLocally: Int,
+        val tagsRemovedRemotely: Int,
+        val syncedAt: Long,
+    ) : UiTagSyncOutcome
+
+    /** User isn't signed in to RR — skipped silently. */
+    data object NotAuthenticated : UiTagSyncOutcome
+
+    /** User disabled sync. */
+    data object Disabled : UiTagSyncOutcome
+
+    /** Network or parser failure. Spec #178: don't surface these
+     *  as toasts; the Settings row shows a dim status line and
+     *  the next 24h periodic retries silently. */
+    data class Failed(val message: String) : UiTagSyncOutcome
+}

--- a/feature/src/main/kotlin/in/jphe/storyvox/feature/settings/AccountSettingsScreen.kt
+++ b/feature/src/main/kotlin/in/jphe/storyvox/feature/settings/AccountSettingsScreen.kt
@@ -61,6 +61,10 @@ fun AccountSettingsScreen(
                             )
                         },
                     )
+                    // Issue #178 — two-way tag-sync row. Only
+                    // surfaces when signed in to RR because the
+                    // affordance is meaningless without a session.
+                    RoyalRoadTagSyncRow()
                 } else {
                     SettingsRow(
                         title = "Royal Road",

--- a/feature/src/main/kotlin/in/jphe/storyvox/feature/settings/RoyalRoadTagSyncRow.kt
+++ b/feature/src/main/kotlin/in/jphe/storyvox/feature/settings/RoyalRoadTagSyncRow.kt
@@ -1,0 +1,203 @@
+package `in`.jphe.storyvox.feature.settings
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.height
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Switch
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import dagger.hilt.android.lifecycle.HiltViewModel
+import `in`.jphe.storyvox.feature.api.RoyalRoadTagSyncUi
+import `in`.jphe.storyvox.feature.api.UiTagSyncOutcome
+import `in`.jphe.storyvox.ui.component.BrassButton
+import `in`.jphe.storyvox.ui.component.BrassButtonVariant
+import `in`.jphe.storyvox.ui.theme.LocalSpacing
+import javax.inject.Inject
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.SharingStarted
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.combine
+import kotlinx.coroutines.flow.stateIn
+import kotlinx.coroutines.launch
+
+/**
+ * Settings → Account row for "Sync saved tags with Royal Road"
+ * (issue #178).
+ *
+ * Surfaces three affordances:
+ *  - A status text: "Last synced with RR: <relative time>" (or
+ *    "never" if no sync has happened, or "off" if disabled).
+ *  - A toggle: turn the periodic sync on or off
+ *    (`pref_rr_tag_sync_enabled`).
+ *  - A "Sync now" brass button that fires
+ *    [RoyalRoadTagSyncCoordinator.syncNow] immediately. Useful
+ *    for power users who want to test the round-trip after
+ *    flipping a tag.
+ *
+ * Lives in its own file/ViewModel so the existing massive
+ * [SettingsViewModel] doesn't need a new constructor parameter.
+ * The composable expects to be called from inside an existing
+ * `SettingsGroupCard` (it doesn't paint its own card chrome).
+ */
+@HiltViewModel
+class RoyalRoadTagSyncViewModel @Inject internal constructor(
+    private val tagSync: RoyalRoadTagSyncUi,
+) : ViewModel() {
+
+    data class State(
+        val enabled: Boolean = true,
+        val lastSyncedAt: Long = 0L,
+        val syncInFlight: Boolean = false,
+        val lastOutcome: String? = null,
+    )
+
+    private val inFlight = MutableStateFlow(false)
+    private val lastOutcome = MutableStateFlow<String?>(null)
+
+    val state: StateFlow<State> = combine(
+        tagSync.syncEnabled,
+        tagSync.lastSyncedAt,
+        inFlight,
+        lastOutcome,
+    ) { enabled, lastSyncedAt, busy, outcome ->
+        State(
+            enabled = enabled,
+            lastSyncedAt = lastSyncedAt,
+            syncInFlight = busy,
+            lastOutcome = outcome,
+        )
+    }.stateIn(viewModelScope, SharingStarted.WhileSubscribed(5_000), State())
+
+    fun setEnabled(enabled: Boolean) {
+        viewModelScope.launch { tagSync.setSyncEnabled(enabled) }
+    }
+
+    fun syncNow() {
+        viewModelScope.launch {
+            if (inFlight.value) return@launch
+            inFlight.value = true
+            try {
+                val outcome = tagSync.syncNow()
+                lastOutcome.value = describeOutcome(outcome)
+            } finally {
+                inFlight.value = false
+            }
+        }
+    }
+
+    private fun describeOutcome(outcome: UiTagSyncOutcome): String =
+        when (outcome) {
+            is UiTagSyncOutcome.Ok ->
+                "Synced — pulled ${outcome.tagsPulledIn} tag(s), pushed ${outcome.tagsPushedOut}"
+            UiTagSyncOutcome.NotAuthenticated ->
+                "Sign in to Royal Road to sync"
+            UiTagSyncOutcome.Disabled ->
+                "Sync is turned off"
+            is UiTagSyncOutcome.Failed ->
+                "Sync failed — will retry"
+        }
+}
+
+/**
+ * Compose-side widget. Renders inside an existing
+ * [SettingsGroupCard]; expects an outer signed-in gate so it
+ * doesn't show on signed-out users (the affordance is
+ * meaningless without a session).
+ */
+@Composable
+fun RoyalRoadTagSyncRow(
+    viewModel: RoyalRoadTagSyncViewModel = hiltViewModel(),
+) {
+    val s by viewModel.state.collectAsState()
+    val spacing = LocalSpacing.current
+    Column(modifier = Modifier.fillMaxWidth().padding(horizontal = spacing.md, vertical = spacing.sm)) {
+        Row(
+            modifier = Modifier.fillMaxWidth(),
+            verticalAlignment = Alignment.CenterVertically,
+        ) {
+            Column(modifier = Modifier.weight(1f)) {
+                Text(
+                    text = "Sync saved tags with Royal Road",
+                    style = MaterialTheme.typography.titleSmall,
+                )
+                Text(
+                    text = lastSyncedLine(s),
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                )
+            }
+            Switch(
+                checked = s.enabled,
+                onCheckedChange = { viewModel.setEnabled(it) },
+            )
+        }
+
+        Spacer(Modifier.height(spacing.xs))
+
+        Row(
+            modifier = Modifier.fillMaxWidth(),
+            horizontalArrangement = Arrangement.End,
+            verticalAlignment = Alignment.CenterVertically,
+        ) {
+            // Surfaces the last-sync outcome (if any) — useful for
+            // power users diagnosing why their tag set didn't move.
+            // Most users will never glance at this row.
+            s.lastOutcome?.let { msg ->
+                Text(
+                    text = msg,
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    modifier = Modifier.weight(1f),
+                )
+            } ?: Spacer(Modifier.weight(1f))
+
+            BrassButton(
+                label = if (s.syncInFlight) "Syncing…" else "Sync now",
+                onClick = { viewModel.syncNow() },
+                variant = BrassButtonVariant.Text,
+                enabled = s.enabled && !s.syncInFlight,
+            )
+        }
+    }
+}
+
+/** Format a "Last synced" status line for the row. */
+private fun lastSyncedLine(s: RoyalRoadTagSyncViewModel.State): String {
+    if (!s.enabled) return "Off"
+    if (s.lastSyncedAt == 0L) return "Last synced with RR: never"
+    val rel = relativeTimeSince(s.lastSyncedAt, System.currentTimeMillis())
+    return "Last synced with RR: $rel"
+}
+
+/** Coarse-grained relative-time formatter. Picks the largest unit
+ *  that fits — "3 days ago", "5 hours ago", "just now". Kept here
+ *  rather than pulled in from `DateUtils` to keep the row pure-
+ *  Kotlin and unit-testable. */
+private fun relativeTimeSince(then: Long, now: Long): String {
+    val diff = (now - then).coerceAtLeast(0L)
+    val sec = diff / 1_000L
+    val min = sec / 60L
+    val hr = min / 60L
+    val day = hr / 24L
+    return when {
+        sec < 30L -> "just now"
+        sec < 60L -> "${sec}s ago"
+        min < 60L -> "${min}m ago"
+        hr < 24L -> "${hr}h ago"
+        day < 30L -> "${day}d ago"
+        else -> "long ago"
+    }
+}

--- a/source-royalroad/build.gradle.kts
+++ b/source-royalroad/build.gradle.kts
@@ -43,8 +43,16 @@ dependencies {
     implementation(libs.androidx.compose.foundation)
     implementation(libs.androidx.webkit)
 
+    // WorkManager — Royal Road tag-sync periodic worker (#178). The
+    // shared schedule helper lives in `:core-data`'s WorkScheduler,
+    // but the @HiltWorker class itself is here next to the
+    // tag-sync coordinator because it's RR-specific.
+    implementation(libs.androidx.work.runtime.ktx)
+    implementation(libs.androidx.hilt.work)
+
     implementation(libs.hilt.android)
     ksp(libs.hilt.compiler)
+    ksp(libs.androidx.hilt.compiler)
 
     // Plugin-seam Phase 2 (#384) — emits the @SourcePlugin → @IntoSet
     // SourcePluginDescriptor Hilt module for RoyalRoadSource. The
@@ -54,4 +62,5 @@ dependencies {
     ksp(project(":core-plugin-ksp"))
 
     testImplementation(libs.junit)
+    testImplementation(libs.kotlinx.coroutines.test)
 }

--- a/source-royalroad/src/main/kotlin/in/jphe/storyvox/source/royalroad/tagsync/RoyalRoadTagSyncCoordinator.kt
+++ b/source-royalroad/src/main/kotlin/in/jphe/storyvox/source/royalroad/tagsync/RoyalRoadTagSyncCoordinator.kt
@@ -1,0 +1,162 @@
+package `in`.jphe.storyvox.source.royalroad.tagsync
+
+import `in`.jphe.storyvox.data.auth.SessionState
+import `in`.jphe.storyvox.data.repository.AuthRepository
+import `in`.jphe.storyvox.data.repository.sync.FollowedTagsStore
+import `in`.jphe.storyvox.data.source.SourceIds
+import javax.inject.Inject
+import javax.inject.Singleton
+import kotlinx.coroutines.flow.first
+
+/**
+ * Orchestrates a single sync round-trip for Royal Road's saved-
+ * tags ↔ storyvox-followed-tags mirror (issue #178).
+ *
+ * Triggers (per #178 spec):
+ *
+ * 1. **On initial RR sign-in** — `:app` observes
+ *    [AuthRepository.sessionState] flipping to
+ *    [SessionState.Authenticated] and invokes [syncNow] once. The
+ *    first sync pulls RR's saved tags into the local mirror and
+ *    pushes any local-only tags the user had set before signing in.
+ *
+ * 2. **Periodically** — `WorkManager` enqueues a
+ *    [RoyalRoadTagSyncWorker] with a 24h cadence + battery-not-low
+ *    + connected-network constraints. Each tick invokes [syncNow].
+ *
+ * 3. **On every local tag toggle** — the storyvox follow-filter
+ *    surface calls [pushImmediateChange] right after writing the
+ *    local mirror. Best-effort; failures are silent and the next
+ *    24h periodic re-pushes from the canonical local state.
+ *
+ * 4. **Sync now button** — the Settings UI calls [syncNow]
+ *    directly when the user taps the brass "Sync now" button.
+ *
+ * Conflict policy: timestamp-based last-write-wins with a 5-min
+ * prefer-local window. Implemented in pure form by [TagSyncMerge];
+ * this coordinator is just plumbing.
+ */
+@Singleton
+class RoyalRoadTagSyncCoordinator @Inject internal constructor(
+    private val source: RoyalRoadTagSyncSource,
+    private val store: FollowedTagsStore,
+    private val auth: AuthRepository,
+) {
+
+    /**
+     * Run one full round-trip. Idempotent and safe to call
+     * concurrently — the underlying [RateLimitedClient] serialises
+     * all RR requests via its mutex.
+     *
+     * Returns a structured [Outcome] for the worker / UI so the
+     * "Last synced" affordance can surface state ("skipped — not
+     * signed in", "ok — 3 tags merged", etc).
+     */
+    suspend fun syncNow(): Outcome {
+        // Cheap guards first.
+        if (!store.syncEnabled(SourceIds.ROYAL_ROAD).first()) return Outcome.Disabled
+        val session = auth.sessionState(SourceIds.ROYAL_ROAD).first()
+        if (session !is SessionState.Authenticated) return Outcome.NotAuthenticated
+
+        // 1. Snapshot local.
+        val localTags = store.snapshotFollowedTags(SourceIds.ROYAL_ROAD)
+        val localTombs = store.tombstones(SourceIds.ROYAL_ROAD)
+        val lastSyncedAt = store.lastSyncedAt(SourceIds.ROYAL_ROAD).first()
+
+        // 2. Pull remote.
+        val remotePull = source.fetchSavedTags()
+        val parsed = when (remotePull) {
+            is RoyalRoadTagSyncSource.Result.Ok -> remotePull.value
+            RoyalRoadTagSyncSource.Result.NotAuthenticated -> return Outcome.NotAuthenticated
+            is RoyalRoadTagSyncSource.Result.Error -> return Outcome.Failed(remotePull.message)
+        }
+
+        // 3. Merge.
+        val now = System.currentTimeMillis()
+        val merge = TagSyncMerge.merge(
+            localTags = localTags,
+            localTombstones = localTombs,
+            remoteTags = parsed.savedTags,
+            lastSyncedAt = lastSyncedAt,
+            now = now,
+        )
+
+        // 4. Apply locally — replace with the canonical set. The
+        //    store stamps a fresh local-write so SettingsSnapshotSource
+        //    knows there's something new to push to InstantDB.
+        if (merge.toAddLocally.isNotEmpty() || merge.toRemoveLocally.isNotEmpty()) {
+            store.replaceFollowedTags(SourceIds.ROYAL_ROAD, merge.merged)
+        }
+
+        // 5. Push to RR if there are remote-side changes to apply,
+        //    OR if any local tombstone is still effective (we need
+        //    to tell RR about an active removal).
+        val remoteNeedsUpdate =
+            merge.toAddRemotely.isNotEmpty() || merge.toRemoveRemotely.isNotEmpty()
+        val pushedOk = if (remoteNeedsUpdate) {
+            val token = parsed.csrfToken
+                ?: return Outcome.Failed("No antiforgery token on read — RR markup changed")
+            when (val push = source.pushSavedTags(merge.merged, token)) {
+                is RoyalRoadTagSyncSource.Result.Ok -> true
+                RoyalRoadTagSyncSource.Result.NotAuthenticated -> return Outcome.NotAuthenticated
+                is RoyalRoadTagSyncSource.Result.Error -> {
+                    // Spec: "we don't surface them" — return Failed
+                    // so the UI can render a dim "last sync failed"
+                    // pill but don't trigger any user-visible toast.
+                    return Outcome.Failed(push.message)
+                }
+            }
+        } else {
+            // No remote changes to push, but record the sync
+            // round as successful — we did pull and merge.
+            true
+        }
+
+        // 6. Hygiene — forget tombstones now reflected on the
+        //    remote side. Only safe to do after a successful push.
+        if (pushedOk) {
+            for (tag in merge.tombstonesToForget) {
+                store.forgetTombstone(SourceIds.ROYAL_ROAD, tag)
+            }
+            store.stampSyncedAt(SourceIds.ROYAL_ROAD, now)
+        }
+
+        return Outcome.Ok(
+            tagsPulledIn = merge.toAddLocally.size,
+            tagsPushedOut = merge.toAddRemotely.size,
+            tagsRemovedLocally = merge.toRemoveLocally.size,
+            tagsRemovedRemotely = merge.toRemoveRemotely.size,
+            syncedAt = now,
+        )
+    }
+
+    /**
+     * Best-effort immediate push after a local follow/unfollow.
+     * Spec: "Network failures are retried at 24h next-sync; we
+     * don't surface them." So we just call [syncNow] under the
+     * hood — it pulls + merges + pushes, which is the safest
+     * thing to do whether the local change was an add or a
+     * remove. Returns the [Outcome] anyway for testability.
+     */
+    suspend fun pushImmediateChange(): Outcome = syncNow()
+
+    sealed interface Outcome {
+        data class Ok(
+            val tagsPulledIn: Int,
+            val tagsPushedOut: Int,
+            val tagsRemovedLocally: Int,
+            val tagsRemovedRemotely: Int,
+            val syncedAt: Long,
+        ) : Outcome
+
+        /** User isn't signed in to RR — skipped silently. */
+        data object NotAuthenticated : Outcome
+
+        /** User has tag-sync disabled in Settings. */
+        data object Disabled : Outcome
+
+        /** Network / parser failure. Surfaced to UI as a dim status
+         *  pill, NOT a toast — spec: "we don't surface them." */
+        data class Failed(val message: String) : Outcome
+    }
+}

--- a/source-royalroad/src/main/kotlin/in/jphe/storyvox/source/royalroad/tagsync/RoyalRoadTagSyncEndpoints.kt
+++ b/source-royalroad/src/main/kotlin/in/jphe/storyvox/source/royalroad/tagsync/RoyalRoadTagSyncEndpoints.kt
@@ -1,0 +1,67 @@
+package `in`.jphe.storyvox.source.royalroad.tagsync
+
+import `in`.jphe.storyvox.source.royalroad.model.RoyalRoadIds
+
+/**
+ * One-place collection of every URL the Royal Road tag-sync flow
+ * touches. Pulled out so a future WebView-driven endpoint
+ * verification (run by JP on a real signed-in tablet) can update
+ * the literals here without spelunking through
+ * [RoyalRoadTagSyncSource].
+ *
+ * Endpoint inspection 2026-05-15 — see
+ * `scratch/rr-tag-sync/api-notes.md` for the full audit. The short
+ * version: RR does not publish an "API" for saved-tag preferences,
+ * but the search-page form carries the user's saved-filter set in
+ * its rendered HTML when `globalFilters=true` is passed. The
+ * read direction parses that form; the write direction POSTs back
+ * to the same search route with the antiforgery token harvested
+ * the same way [`in`.jphe.storyvox.source.royalroad.RoyalRoadSource.setFollowed]
+ * harvests its token (issue #178).
+ *
+ * Every URL is the bare `royalroad.com` route — no `www.` prefix —
+ * so the cookie jar (keyed at `royalroad.com` eTLD+1 per
+ * [`in`.jphe.storyvox.source.royalroad.auth.RoyalRoadAuthSource])
+ * attaches credentials uniformly across read and write.
+ */
+internal object RoyalRoadTagSyncEndpoints {
+
+    /**
+     * The "saved-filter" search page. When passed `globalFilters=true`
+     * while authed, the response pre-renders the user's saved tag
+     * preferences on the form (`button.search-tag.selected`). The
+     * read direction GETs this and parses the selected set.
+     */
+    val readUrl: String =
+        "${RoyalRoadIds.BASE_URL}/fictions/search?globalFilters=true"
+
+    /**
+     * The write target — RR's search-filter save endpoint. POST body:
+     *   - `tagsAdd=<slug>` repeated for every tag in the user's preferred set
+     *   - `globalFilters=true`
+     *   - `saveAsFilter=true` (the "save these filters" toggle)
+     *   - `__RequestVerificationToken=<csrf>` (harvested from the GET
+     *     of [readUrl])
+     *
+     * Because RR's actual save endpoint is undocumented and may
+     * differ from /fictions/search, the writer treats any 2xx/3xx
+     * as success and any 4xx (other than the expected 401 unauthed)
+     * as "endpoint changed, skip writes until the next sync window."
+     */
+    val writeUrl: String =
+        "${RoyalRoadIds.BASE_URL}/fictions/search"
+
+    /**
+     * Referer header for the write POST. Match what a browser would
+     * send — the search results page itself. Some ASP.NET Core
+     * antiforgery checks require a same-origin Referer.
+     */
+    val writeReferer: String = readUrl
+
+    /**
+     * Sentinel returned by the parser when the response was a 302
+     * redirect to /account/login (the unauthed case). The syncer
+     * treats this as "no session, skip this round."
+     */
+    const val UNAUTHED_PATH_PREFIX: String = "/account/login"
+}

--- a/source-royalroad/src/main/kotlin/in/jphe/storyvox/source/royalroad/tagsync/RoyalRoadTagSyncScheduler.kt
+++ b/source-royalroad/src/main/kotlin/in/jphe/storyvox/source/royalroad/tagsync/RoyalRoadTagSyncScheduler.kt
@@ -1,0 +1,66 @@
+package `in`.jphe.storyvox.source.royalroad.tagsync
+
+import android.content.Context
+import androidx.work.Constraints
+import androidx.work.ExistingPeriodicWorkPolicy
+import androidx.work.NetworkType
+import androidx.work.PeriodicWorkRequestBuilder
+import androidx.work.WorkManager
+import dagger.hilt.android.qualifiers.ApplicationContext
+import java.time.Duration
+import javax.inject.Inject
+import javax.inject.Singleton
+
+/**
+ * Schedules / cancels [RoyalRoadTagSyncWorker]. Lives in
+ * `:source-royalroad` because the worker class itself is here —
+ * the shared `:core-data`'s `WorkScheduler` already does the
+ * generic scheduling, but would have to depend on
+ * `:source-royalroad` to enqueue this one, so this thin helper
+ * keeps the dependency direction clean (issue #178).
+ *
+ * Called from `:app`'s startup wiring after the shared
+ * `WorkScheduler.ensurePeriodicWorkScheduled` completes, gated on
+ * "user has at least once been signed in to RR." The KEEP policy
+ * means we don't re-enqueue on every launch.
+ */
+@Singleton
+class RoyalRoadTagSyncScheduler @Inject constructor(
+    @ApplicationContext private val context: Context,
+) {
+
+    private val workManager: WorkManager get() = WorkManager.getInstance(context)
+
+    /**
+     * Enqueue the 24h periodic tag-sync worker. Idempotent (KEEP
+     * existing schedule). The first tick fires ~24h from now;
+     * for the immediate-on-sign-in case, `:app` observes the
+     * AuthRepository state flip and invokes the coordinator
+     * directly without going through WorkManager.
+     */
+    fun schedule() {
+        val constraints = Constraints.Builder()
+            .setRequiredNetworkType(NetworkType.CONNECTED)
+            .setRequiresBatteryNotLow(true)
+            .build()
+
+        val request = PeriodicWorkRequestBuilder<RoyalRoadTagSyncWorker>(
+            Duration.ofHours(RoyalRoadTagSyncWorker.TAG_SYNC_INTERVAL_HOURS)
+        )
+            .setConstraints(constraints)
+            .addTag(RoyalRoadTagSyncWorker.TAG)
+            .build()
+
+        workManager.enqueueUniquePeriodicWork(
+            RoyalRoadTagSyncWorker.UNIQUE_NAME,
+            ExistingPeriodicWorkPolicy.KEEP,
+            request,
+        )
+    }
+
+    /** Cancel the periodic worker. Called when the user signs out
+     *  of RR or disables tag-sync in Settings. */
+    fun cancel() {
+        workManager.cancelUniqueWork(RoyalRoadTagSyncWorker.UNIQUE_NAME)
+    }
+}

--- a/source-royalroad/src/main/kotlin/in/jphe/storyvox/source/royalroad/tagsync/RoyalRoadTagSyncSource.kt
+++ b/source-royalroad/src/main/kotlin/in/jphe/storyvox/source/royalroad/tagsync/RoyalRoadTagSyncSource.kt
@@ -1,0 +1,117 @@
+package `in`.jphe.storyvox.source.royalroad.tagsync
+
+import `in`.jphe.storyvox.source.royalroad.net.CloudflareAwareFetcher
+import `in`.jphe.storyvox.source.royalroad.net.FetchOutcome
+import `in`.jphe.storyvox.source.royalroad.net.RateLimitedClient
+import javax.inject.Inject
+import javax.inject.Singleton
+import okhttp3.FormBody
+
+/**
+ * Two-way Royal Road saved-tags mirror (issue #178).
+ *
+ * **Read direction** ([fetchSavedTags]): GETs the saved-filter
+ * search page, parses the user's preferred tag set + antiforgery
+ * token. Returns [Result.NotAuthenticated] when the session is
+ * missing — the syncer treats that as "skip this round, the user
+ * will sign in eventually."
+ *
+ * **Write direction** ([pushSavedTags]): POSTs back the canonical
+ * set, gated on a fresh token from [fetchSavedTags]. The endpoint
+ * shape is documented (with the verified-by-real-RR uncertainty
+ * called out) in `scratch/rr-tag-sync/api-notes.md`. Any 2xx/3xx
+ * is success; any 4xx (other than 401) is treated as "endpoint
+ * shape changed, skip writes until the next 24h window."
+ *
+ * The 24h cadence is chosen because:
+ *  - RR's `robots.txt` plus our 1 req/sec [RateLimitedClient]
+ *    floor already keep us well under any plausible budget.
+ *  - The user's saved-tag set isn't a hot-path preference — a 24h
+ *    propagation delay is acceptable for the most common case
+ *    (sign in on tablet, see tablet's saved tags appear on phone
+ *    the next day).
+ *  - Per-action immediate writes (the "fire on every follow/
+ *    unfollow" branch) make a best-effort POST too; the 24h
+ *    periodic exists as the backstop when the immediate write
+ *    fails network-side. See [RoyalRoadTagSyncOutcome].
+ */
+@Singleton
+internal class RoyalRoadTagSyncSource @Inject constructor(
+    private val fetcher: CloudflareAwareFetcher,
+    private val client: RateLimitedClient,
+) {
+
+    sealed interface Result<out T> {
+        data class Ok<T>(val value: T) : Result<T>
+        data object NotAuthenticated : Result<Nothing>
+        data class Error(val message: String) : Result<Nothing>
+    }
+
+    /**
+     * Pull the user's saved-tag set + a fresh CSRF token from RR.
+     * Returns the parsed [SavedTagsParser.Parsed] payload on
+     * success.
+     */
+    suspend fun fetchSavedTags(): Result<SavedTagsParser.Parsed> =
+        when (val outcome = fetcher.fetchHtml(RoyalRoadTagSyncEndpoints.readUrl)) {
+            is FetchOutcome.Body -> when (
+                val parsed = SavedTagsParser.parse(outcome.html, outcome.finalUrl)
+            ) {
+                is SavedTagsParser.Result.Ok -> Result.Ok(parsed.parsed)
+                SavedTagsParser.Result.NotAuthenticated -> Result.NotAuthenticated
+            }
+            FetchOutcome.NotFound ->
+                // RR removed the filter page — treat as endpoint-
+                // shape-changed: not a crash, just a skipped sync.
+                Result.Error("Saved-tags read URL returned 404 — endpoint shape changed")
+            is FetchOutcome.CloudflareChallenge ->
+                Result.Error("Cloudflare challenge on saved-tags read")
+            is FetchOutcome.RateLimited ->
+                Result.Error("Rate limited on saved-tags read")
+            is FetchOutcome.HttpError -> when (outcome.code) {
+                401, 403 -> Result.NotAuthenticated
+                else -> Result.Error("HTTP ${outcome.code}: ${outcome.message}")
+            }
+        }
+
+    /**
+     * Push the canonical [tags] set back to RR. Requires a fresh
+     * [csrfToken] from a recent [fetchSavedTags] call — RR's
+     * antiforgery tokens are per-session-per-page so a token
+     * harvested mid-sync is the safest bet.
+     *
+     * Returns [Result.Ok] of Unit on success, [Result.NotAuthenticated]
+     * when the POST is rejected for auth reasons, [Result.Error]
+     * otherwise. The caller's policy on errors: skip-and-retry-at-
+     * next-24h, never surface the failure to the user (issue #178
+     * spec: "Network failures are retried at 24h next-sync; we
+     * don't surface them.")
+     */
+    suspend fun pushSavedTags(tags: Set<String>, csrfToken: String): Result<Unit> {
+        val body = FormBody.Builder().apply {
+            add("globalFilters", "true")
+            add("saveAsFilter", "true")
+            for (tag in tags) add("tagsAdd", tag)
+            add("__RequestVerificationToken", csrfToken)
+        }.build()
+        return runCatching {
+            client.post(
+                RoyalRoadTagSyncEndpoints.writeUrl,
+                body,
+                extraHeaders = mapOf("Referer" to RoyalRoadTagSyncEndpoints.writeReferer),
+            ).use { resp ->
+                when {
+                    resp.code == 401 || resp.code == 403 -> Result.NotAuthenticated
+                    resp.isSuccessful || resp.isRedirect -> Result.Ok(Unit)
+                    // 4xx other than auth — endpoint shape changed
+                    // (RR removed or renamed the save endpoint).
+                    // Treat as transient so we retry next window.
+                    resp.code in 400..499 -> Result.Error(
+                        "Saved-tags write rejected: HTTP ${resp.code} — endpoint shape may have changed"
+                    )
+                    else -> Result.Error("Saved-tags write failed: HTTP ${resp.code}: ${resp.message}")
+                }
+            }
+        }.getOrElse { Result.Error("Saved-tags write threw: ${it.message}") }
+    }
+}

--- a/source-royalroad/src/main/kotlin/in/jphe/storyvox/source/royalroad/tagsync/RoyalRoadTagSyncWorker.kt
+++ b/source-royalroad/src/main/kotlin/in/jphe/storyvox/source/royalroad/tagsync/RoyalRoadTagSyncWorker.kt
@@ -1,0 +1,59 @@
+package `in`.jphe.storyvox.source.royalroad.tagsync
+
+import android.content.Context
+import androidx.hilt.work.HiltWorker
+import androidx.work.CoroutineWorker
+import androidx.work.Data
+import androidx.work.WorkerParameters
+import dagger.assisted.Assisted
+import dagger.assisted.AssistedInject
+
+/**
+ * Periodic worker — pulls a single tag-sync round-trip (RR ↔
+ * storyvox) on a 24h cadence (issue #178).
+ *
+ * Constraints (set by the `:core-data` `WorkScheduler` when it
+ * enqueues this — see [TAG_SYNC_INTERVAL_HOURS]):
+ *
+ *  - Network: `CONNECTED` — RR is online-only by definition.
+ *  - Battery not low: yes — saved tags aren't load-bearing
+ *    enough to drain a phone that's already running on fumes.
+ *
+ * The actual sync logic lives in [RoyalRoadTagSyncCoordinator] —
+ * this worker is just the WorkManager surface. Failures return
+ * `Result.success(...)` with a tagged Data payload (telemetry)
+ * rather than `Result.failure()`, because we don't want
+ * WorkManager's exponential backoff stacking up: the spec is
+ * "retry at next 24h tick," and `Result.success` is the right
+ * code for that.
+ */
+@HiltWorker
+class RoyalRoadTagSyncWorker @AssistedInject internal constructor(
+    @Assisted appContext: Context,
+    @Assisted params: WorkerParameters,
+    private val coordinator: RoyalRoadTagSyncCoordinator,
+) : CoroutineWorker(appContext, params) {
+
+    override suspend fun doWork(): Result {
+        val outcome = coordinator.syncNow()
+        val tag = when (outcome) {
+            is RoyalRoadTagSyncCoordinator.Outcome.Ok -> "ok"
+            RoyalRoadTagSyncCoordinator.Outcome.NotAuthenticated -> "not-authenticated"
+            RoyalRoadTagSyncCoordinator.Outcome.Disabled -> "disabled"
+            is RoyalRoadTagSyncCoordinator.Outcome.Failed -> "failed"
+        }
+        return Result.success(Data.Builder().putString(KEY_STATE, tag).build())
+    }
+
+    companion object {
+        const val TAG: String = "royalroad:tag-sync"
+        const val UNIQUE_NAME: String = "royalroad:tag-sync"
+        const val KEY_STATE: String = "state"
+
+        /** Issue #178 — 24h periodic cadence. The first tick fires
+         *  ~24h after the worker is enqueued; first-sync-on-sign-in
+         *  is handled separately by `:app` observing the
+         *  AuthRepository state flip. */
+        const val TAG_SYNC_INTERVAL_HOURS: Long = 24
+    }
+}

--- a/source-royalroad/src/main/kotlin/in/jphe/storyvox/source/royalroad/tagsync/SavedTagsParser.kt
+++ b/source-royalroad/src/main/kotlin/in/jphe/storyvox/source/royalroad/tagsync/SavedTagsParser.kt
@@ -1,0 +1,85 @@
+package `in`.jphe.storyvox.source.royalroad.tagsync
+
+import org.jsoup.Jsoup
+import org.jsoup.nodes.Document
+
+/**
+ * Parses the user's saved-tag preference set out of the
+ * `/fictions/search?globalFilters=true` page (issue #178).
+ *
+ * When the user is signed in to Royal Road and has the "global
+ * filters" toggle on, the rendered search form pre-selects their
+ * saved tags as `<button class="btn default search-tag selected"
+ * data-tag="action">` rows. We harvest the set by walking every
+ * `button.search-tag.selected` and collecting `data-tag`.
+ *
+ * The page also serves the antiforgery token under the form's
+ * hidden `__RequestVerificationToken` input — the writer needs
+ * that token to POST back. We surface both in [Parsed].
+ *
+ * Forgiving by design: a future RR redesign that renames the
+ * `selected` class will leave us with an empty set rather than a
+ * crash. The 24h sync window picks up the redesign at the next
+ * read; in the meantime the local mirror (`pref_followed_tags_v1`)
+ * keeps storyvox itself coherent.
+ */
+internal object SavedTagsParser {
+
+    sealed interface Result {
+        data class Ok(val parsed: Parsed) : Result
+        /** Endpoint returned the login redirect (302 → /account/login). */
+        data object NotAuthenticated : Result
+    }
+
+    data class Parsed(
+        /** Tag slugs ("action", "litrpg", "high_fantasy") the user
+         *  has saved as preferred filters on RR. */
+        val savedTags: Set<String>,
+        /** Antiforgery token to attach to the write POST. May be null
+         *  when the page didn't include the hidden input (the writer
+         *  treats absent token as "skip write this round" rather
+         *  than failing the whole sync). */
+        val csrfToken: String?,
+    )
+
+    fun parse(html: String, finalUrl: String): Result {
+        if (looksUnauthed(finalUrl)) return Result.NotAuthenticated
+        val doc = Jsoup.parse(html)
+
+        // Defensive: if RR shows the login form prominently in-body
+        // (instead of redirecting), treat as unauthed so we don't
+        // mis-parse "0 saved tags" from a fully signed-out page.
+        if (doc.selectFirst("form.form-login-details") != null) {
+            return Result.NotAuthenticated
+        }
+
+        val saved = doc.select("button.search-tag.selected")
+            .mapNotNull { it.attr("data-tag").trim().takeIf { s -> s.isNotEmpty() } }
+            .toSet()
+
+        // Fallback selector — some RR layouts emit the selected
+        // state as `data-selected="true"` or `aria-pressed="true"`
+        // instead of the `selected` class. Union both to keep the
+        // parser robust across small markup tweaks.
+        val ariaSaved = doc.select("button.search-tag[aria-pressed=true]")
+            .mapNotNull { it.attr("data-tag").trim().takeIf { s -> s.isNotEmpty() } }
+            .toSet()
+
+        val token = doc.selectFirst("input[name=__RequestVerificationToken]")
+            ?.attr("value")
+            ?.takeIf { it.isNotBlank() }
+
+        return Result.Ok(Parsed(savedTags = saved + ariaSaved, csrfToken = token))
+    }
+
+    private fun looksUnauthed(finalUrl: String): Boolean {
+        // The cookie-redirect flow lands on /account/login?ReturnUrl=...
+        // The body still has the same shell HTML, so we key off the
+        // resolved URL, not the body bytes.
+        return RoyalRoadTagSyncEndpoints.UNAUTHED_PATH_PREFIX in finalUrl
+    }
+
+    @Suppress("unused")
+    internal fun parseFromDocument(doc: Document, finalUrl: String): Result =
+        parse(doc.outerHtml(), finalUrl)
+}

--- a/source-royalroad/src/main/kotlin/in/jphe/storyvox/source/royalroad/tagsync/TagSyncMerge.kt
+++ b/source-royalroad/src/main/kotlin/in/jphe/storyvox/source/royalroad/tagsync/TagSyncMerge.kt
@@ -1,0 +1,123 @@
+package `in`.jphe.storyvox.source.royalroad.tagsync
+
+/**
+ * Pure merge logic for the RR ↔ storyvox tag-sync mirror (issue
+ * #178). Extracted from the syncer so it can be tested in isolation
+ * against a fixed clock and a deterministic input set.
+ *
+ * Policy (per issue #178 spec):
+ *
+ * **Adds** — union. If either side has a tag the other doesn't,
+ * keep it. Reasoning: a tag-add is monotonically additive; the
+ * cost of carrying an extra tag is small (the user's filter set
+ * grows by one), the cost of losing one is large (the user's
+ * intent to track that tag is silently dropped).
+ *
+ * **Removes** — timestamp-based last-write-wins, with a
+ * **5-minute prefer-local window**. If both sides changed within
+ * that window, prefer storyvox's local change (the user's intent
+ * on *this* device is the most current). Outside the window, the
+ * side with the newer timestamp wins.
+ *
+ * **Tombstones** — per-tag local-remove timestamps live in
+ * [TagSyncState.localTombstones]. A tag is "tombstoned" on the
+ * local side when the user explicitly unfollowed it. The merge
+ * applies tombstones to the remote set so a re-add by the remote
+ * doesn't resurrect a tag the user actively removed.
+ *
+ * **Last-sync stamp** — [TagSyncState.lastSyncedAt] is the wall-
+ * clock time of the *previous* successful sync. Used for the
+ * 5-minute conflict window only.
+ */
+internal object TagSyncMerge {
+
+    /** Milliseconds that count as "both modified at the same time"
+     *  for the prefer-local tiebreaker. Issue #178 spec: 5 minutes. */
+    const val PREFER_LOCAL_WINDOW_MS: Long = 5 * 60 * 1_000L
+
+    /**
+     * Merge a local view (storyvox's [`pref_followed_tags_v1`] set
+     * + per-tag tombstones) with the remote view (RR's saved-tags
+     * set, just-fetched). Returns the canonical set that both
+     * sides should end up holding.
+     *
+     *  - [localTags]: the user's currently-followed-tags set in storyvox.
+     *  - [localTombstones]: per-tag epoch-ms timestamps for tags the
+     *    user explicitly removed on this device. Tags absent from
+     *    the map were never explicitly removed locally.
+     *  - [remoteTags]: the saved-tags set fetched from RR right now.
+     *  - [lastSyncedAt]: epoch-ms of the previous successful sync.
+     *    Used to compute the 5-minute prefer-local window — any
+     *    local tombstone newer than [lastSyncedAt] is considered
+     *    "new since last sync" and wins over a remote re-add.
+     *  - [now]: clock injected for testability.
+     */
+    fun merge(
+        localTags: Set<String>,
+        localTombstones: Map<String, Long>,
+        remoteTags: Set<String>,
+        lastSyncedAt: Long,
+        now: Long,
+    ): MergeResult {
+        // 1. Union the adds. Both sides keep what they had, plus
+        //    whatever the other side has.
+        val unioned = localTags + remoteTags
+
+        // 2. Apply tombstones — any tag the user explicitly removed
+        //    locally since the last sync, OR within the 5-min
+        //    prefer-local window of remote re-add, gets dropped.
+        //    Outside the window, a tombstone older than the
+        //    apparent remote add stamp can lose; we don't have
+        //    per-tag remote stamps (RR doesn't expose them), so we
+        //    proxy with `now - PREFER_LOCAL_WINDOW_MS` — any
+        //    tombstone stamped within that window of `now` wins.
+        val effectiveTombstones = localTombstones.filter { (_, stamp) ->
+            // A tombstone wins if either:
+            //   - it was recorded after the last successful sync
+            //     (we never told the remote about it yet), OR
+            //   - it was recorded within PREFER_LOCAL_WINDOW_MS of
+            //     now (the user's intent on this device is fresh
+            //     enough to beat any remote re-add).
+            stamp > lastSyncedAt || (now - stamp) <= PREFER_LOCAL_WINDOW_MS
+        }
+        val merged = unioned - effectiveTombstones.keys
+
+        // 3. Compute the diff vs each side so the caller knows
+        //    what to apply where.
+        val toAddLocally = (merged - localTags)
+        val toRemoveLocally = (localTags - merged)
+        val toAddRemotely = (merged - remoteTags)
+        val toRemoveRemotely = (remoteTags - merged)
+
+        // 4. Tombstone hygiene — any tombstone stamped older than
+        //    the new "now" sync stamp can be forgotten once
+        //    persisted, because the remote side has now been told
+        //    about the removal. The syncer is the right place to
+        //    drop them after a successful push.
+        val tombstonesToForget = localTombstones.keys - effectiveTombstones.keys
+
+        return MergeResult(
+            merged = merged,
+            toAddLocally = toAddLocally,
+            toRemoveLocally = toRemoveLocally,
+            toAddRemotely = toAddRemotely,
+            toRemoveRemotely = toRemoveRemotely,
+            tombstonesToForget = tombstonesToForget,
+        )
+    }
+
+    data class MergeResult(
+        /** The canonical set both sides should hold post-merge. */
+        val merged: Set<String>,
+        /** Tags to add to the local storyvox set. */
+        val toAddLocally: Set<String>,
+        /** Tags to remove from the local storyvox set. */
+        val toRemoveLocally: Set<String>,
+        /** Tags to push to the RR side (the writer needs this list). */
+        val toAddRemotely: Set<String>,
+        /** Tags to push as removed on the RR side. */
+        val toRemoveRemotely: Set<String>,
+        /** Tombstones the syncer can forget after a successful push. */
+        val tombstonesToForget: Set<String>,
+    )
+}

--- a/source-royalroad/src/test/kotlin/in/jphe/storyvox/source/royalroad/tagsync/SavedTagsParserTest.kt
+++ b/source-royalroad/src/test/kotlin/in/jphe/storyvox/source/royalroad/tagsync/SavedTagsParserTest.kt
@@ -1,0 +1,103 @@
+package `in`.jphe.storyvox.source.royalroad.tagsync
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class SavedTagsParserTest {
+
+    @Test
+    fun `parses selected tags from saved-filter search page`() {
+        val html = """
+            <html><body>
+              <form>
+                <input type="hidden" name="__RequestVerificationToken" value="abc123"/>
+                <button class="btn default search-tag selected" data-tag="action" data-label="Action">
+                  <span class="tag-label">Action</span>
+                </button>
+                <button class="btn default search-tag" data-tag="adventure" data-label="Adventure">
+                  <span class="tag-label">Adventure</span>
+                </button>
+                <button class="btn default search-tag selected" data-tag="litrpg" data-label="LitRPG">
+                  <span class="tag-label">LitRPG</span>
+                </button>
+              </form>
+            </body></html>
+        """.trimIndent()
+
+        val result = SavedTagsParser.parse(html, "https://www.royalroad.com/fictions/search?globalFilters=true")
+            as SavedTagsParser.Result.Ok
+
+        assertEquals(setOf("action", "litrpg"), result.parsed.savedTags)
+        assertEquals("abc123", result.parsed.csrfToken)
+    }
+
+    @Test
+    fun `also picks up aria-pressed selected state`() {
+        val html = """
+            <html><body>
+              <button class="btn default search-tag" data-tag="comedy" aria-pressed="true">
+                <span class="tag-label">Comedy</span>
+              </button>
+              <button class="btn default search-tag selected" data-tag="drama">
+                <span class="tag-label">Drama</span>
+              </button>
+            </body></html>
+        """.trimIndent()
+
+        val result = SavedTagsParser.parse(html, "https://www.royalroad.com/fictions/search?globalFilters=true")
+            as SavedTagsParser.Result.Ok
+
+        assertEquals(setOf("comedy", "drama"), result.parsed.savedTags)
+    }
+
+    @Test
+    fun `unauthed redirect surfaces as NotAuthenticated`() {
+        val result = SavedTagsParser.parse(
+            html = "<html><body>Login required</body></html>",
+            finalUrl = "https://www.royalroad.com/account/login?ReturnUrl=%2Ffictions%2Fsearch",
+        )
+        assertEquals(SavedTagsParser.Result.NotAuthenticated, result)
+    }
+
+    @Test
+    fun `inline login form treated as unauthed`() {
+        val html = """
+            <html><body>
+              <form class="form-login-details"><input name="email"/></form>
+            </body></html>
+        """.trimIndent()
+        val result = SavedTagsParser.parse(html, "https://www.royalroad.com/fictions/search?globalFilters=true")
+        assertEquals(SavedTagsParser.Result.NotAuthenticated, result)
+    }
+
+    @Test
+    fun `no selected buttons produces empty set without crashing`() {
+        val html = """
+            <html><body>
+              <input type="hidden" name="__RequestVerificationToken" value="token"/>
+              <button class="btn default search-tag" data-tag="action">Action</button>
+              <button class="btn default search-tag" data-tag="comedy">Comedy</button>
+            </body></html>
+        """.trimIndent()
+
+        val result = SavedTagsParser.parse(html, "https://www.royalroad.com/fictions/search?globalFilters=true")
+            as SavedTagsParser.Result.Ok
+        assertTrue(result.parsed.savedTags.isEmpty())
+        assertNotNull(result.parsed.csrfToken)
+    }
+
+    @Test
+    fun `null csrf token when hidden input missing`() {
+        val html = """
+            <html><body>
+              <button class="btn default search-tag selected" data-tag="action">Action</button>
+            </body></html>
+        """.trimIndent()
+        val result = SavedTagsParser.parse(html, "https://www.royalroad.com/fictions/search?globalFilters=true")
+            as SavedTagsParser.Result.Ok
+        assertEquals(setOf("action"), result.parsed.savedTags)
+        assertEquals(null, result.parsed.csrfToken)
+    }
+}

--- a/source-royalroad/src/test/kotlin/in/jphe/storyvox/source/royalroad/tagsync/TagSyncMergeTest.kt
+++ b/source-royalroad/src/test/kotlin/in/jphe/storyvox/source/royalroad/tagsync/TagSyncMergeTest.kt
@@ -1,0 +1,121 @@
+package `in`.jphe.storyvox.source.royalroad.tagsync
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class TagSyncMergeTest {
+
+    private val now = 1_700_000_000_000L
+
+    @Test
+    fun `union of adds when neither side has tombstones`() {
+        val result = TagSyncMerge.merge(
+            localTags = setOf("action", "litrpg"),
+            localTombstones = emptyMap(),
+            remoteTags = setOf("litrpg", "high_fantasy"),
+            lastSyncedAt = now - 60_000L,
+            now = now,
+        )
+
+        // Union: action + litrpg + high_fantasy
+        assertEquals(setOf("action", "litrpg", "high_fantasy"), result.merged)
+        // Local needs to add high_fantasy; nothing to remove locally.
+        assertEquals(setOf("high_fantasy"), result.toAddLocally)
+        assertEquals(emptySet<String>(), result.toRemoveLocally)
+        // Remote needs to add action; nothing to remove remotely.
+        assertEquals(setOf("action"), result.toAddRemotely)
+        assertEquals(emptySet<String>(), result.toRemoveRemotely)
+    }
+
+    @Test
+    fun `tombstone newer than last sync wins over remote re-add`() {
+        // User unfollowed "comedy" locally 30s ago; remote still
+        // has it. The tombstone is newer than last-sync, so the
+        // merge drops "comedy" and pushes the removal.
+        val tombStamp = now - 30_000L
+        val result = TagSyncMerge.merge(
+            localTags = setOf("action"),
+            localTombstones = mapOf("comedy" to tombStamp),
+            remoteTags = setOf("action", "comedy"),
+            lastSyncedAt = now - 60_000L,
+            now = now,
+        )
+
+        assertEquals(setOf("action"), result.merged)
+        assertTrue("comedy" in result.toRemoveRemotely)
+        assertTrue(result.toRemoveLocally.isEmpty()) // already removed locally
+    }
+
+    @Test
+    fun `tombstone within 5-minute window beats remote re-add even if older than last-sync`() {
+        // Tombstone stamped just before last-sync, but well within
+        // the 5-min prefer-local window. Spec #178: prefer local.
+        val tombStamp = now - (4 * 60 * 1_000L) // 4 min ago
+        val lastSync = now - (2 * 60 * 1_000L) // 2 min ago
+        val result = TagSyncMerge.merge(
+            localTags = emptySet(),
+            localTombstones = mapOf("drama" to tombStamp),
+            remoteTags = setOf("drama"),
+            lastSyncedAt = lastSync,
+            now = now,
+        )
+
+        // Drama tombstone is older than last-sync but within the
+        // 5-min prefer-local window → still wins.
+        assertEquals(emptySet<String>(), result.merged)
+        assertEquals(setOf("drama"), result.toRemoveRemotely)
+    }
+
+    @Test
+    fun `stale tombstone outside 5-min window is forgotten and remote re-add wins`() {
+        // Tombstone is 10 min old, also older than last-sync.
+        // Outside the window → remote re-add wins.
+        val tombStamp = now - (10 * 60 * 1_000L)
+        val lastSync = now - (8 * 60 * 1_000L)
+        val result = TagSyncMerge.merge(
+            localTags = emptySet(),
+            localTombstones = mapOf("mystery" to tombStamp),
+            remoteTags = setOf("mystery"),
+            lastSyncedAt = lastSync,
+            now = now,
+        )
+
+        // The tombstone is outside both the window and the
+        // last-sync gate, so remote wins.
+        assertEquals(setOf("mystery"), result.merged)
+        // And the stale tombstone is queued for forget.
+        assertTrue("mystery" in result.tombstonesToForget)
+    }
+
+    @Test
+    fun `empty inputs produce empty merge`() {
+        val result = TagSyncMerge.merge(
+            localTags = emptySet(),
+            localTombstones = emptyMap(),
+            remoteTags = emptySet(),
+            lastSyncedAt = 0L,
+            now = now,
+        )
+        assertEquals(emptySet<String>(), result.merged)
+        assertEquals(emptySet<String>(), result.toAddLocally)
+        assertEquals(emptySet<String>(), result.toAddRemotely)
+    }
+
+    @Test
+    fun `identical sets produce no-op diff`() {
+        val tags = setOf("action", "litrpg", "high_fantasy")
+        val result = TagSyncMerge.merge(
+            localTags = tags,
+            localTombstones = emptyMap(),
+            remoteTags = tags,
+            lastSyncedAt = now - 1000L,
+            now = now,
+        )
+        assertEquals(tags, result.merged)
+        assertEquals(emptySet<String>(), result.toAddLocally)
+        assertEquals(emptySet<String>(), result.toRemoveLocally)
+        assertEquals(emptySet<String>(), result.toAddRemotely)
+        assertEquals(emptySet<String>(), result.toRemoveRemotely)
+    }
+}


### PR DESCRIPTION
## Summary

- Two-way mirror between Royal Road's saved-tag preferences and storyvox's followed-tags set (issue #178).
- Read path GETs `/fictions/search?globalFilters=true` and parses `button.search-tag.selected`. Write path POSTs the canonical set with a fresh antiforgery token harvested the same way the existing follow-toggle uses.
- Sync triggers: (1) immediate first-sync on RR sign-in edge, (2) 24h `WorkManager` periodic with `CONNECTED` + battery-not-low constraints, (3) "Sync now" brass button in Settings → Account.
- Conflict policy: union-of-adds + last-write-wins-on-removes with a 5-min prefer-local window. Pure-Kotlin `TagSyncMerge`, 6 JUnit cases.
- DataStore split: per-source JSON tag/tombstone payloads live in a separate `storyvox_tag_sync` store; the two synced metadata keys (`pref_rr_tag_sync_enabled`, `pref_rr_tag_sync_last_synced_at`) live in the main `storyvox_settings` store and ride `:core-sync`'s InstantDB round-trip.

## RR endpoints used

- `GET /fictions/search?globalFilters=true` — read direction. The form pre-selects the user's saved-tag set as `.selected` buttons.
- `POST /fictions/search` — write direction with `tagsAdd=` repeated form fields + `__RequestVerificationToken` + `saveAsFilter=true`.

Full endpoint inspection (live-probed against RR on 2026-05-15) in `scratch/rr-tag-sync/api-notes.md`. RR doesn't publish an "API" for saved-tag preferences, so the writer treats any 2xx/3xx as success and any 4xx (other than 401) as "endpoint shape changed — retry next 24h window."

## Files

- `:source-royalroad/tagsync/` — `RoyalRoadTagSyncSource` (HTTP), `SavedTagsParser`, `TagSyncMerge` (pure), `RoyalRoadTagSyncCoordinator`, `RoyalRoadTagSyncWorker` (`@HiltWorker`), `RoyalRoadTagSyncScheduler`, `RoyalRoadTagSyncEndpoints`.
- `:core-data/repository/sync/FollowedTagsStore.kt` — interface, per-source.
- `:app/data/FollowedTagsStoreImpl.kt` — DataStore impl. `:app/di/RealRoyalRoadTagSyncUi.kt` — feature-api bridge.
- `:feature/api/UiContracts.kt` — `RoyalRoadTagSyncUi` + `UiTagSyncOutcome`.
- `:feature/settings/RoyalRoadTagSyncRow.kt` — Settings → Account row + ViewModel.
- `:app/StoryvoxApp.kt` — first-sync-on-signin observer + `WorkManager` enqueue/cancel.

## Test plan

- [x] `:source-royalroad:testDebugUnitTest` — 12 new tests (6 merge, 6 parser), all green.
- [x] `:app:assembleDebug` builds clean.
- [x] `:app:testDebugUnitTest` — SettingsRepository sync invariant (`SYNC_ALLOWLIST ↔ SYNC_KEY_TYPES` lockstep) passes with the two new metadata keys.
- [x] `:feature:testDebugUnitTest` + `:core-sync:testDebugUnitTest` green.
- [ ] Manual: install on R83W80CAFZB, sign in to RR, watch the row in Settings → Account → "Sync now" → confirm `Last synced` flips to `just now`. (Cannot run in agent; awaiting JP's tablet verification.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)