### PR TITLE
feat(reader): player UX polish — closes #525 #526 #527 #529 #537 #543(UI)

### DIFF
--- a/feature/build.gradle.kts
+++ b/feature/build.gradle.kts
@@ -29,6 +29,14 @@ android {
 
     buildFeatures {
         compose = true
+        // Issue #529 — feature module needs BuildConfig.DEBUG to gate the
+        // on-reader DebugOverlay so it can never render in release builds
+        // regardless of the legacy DataStore `pref_show_debug_overlay` flag.
+        // A user who flipped the toggle on in v0.5.4x would otherwise carry
+        // it forward into release shipments. BuildConfig.DEBUG is the
+        // belt-and-suspenders gate; the DataStore flag stays so debug-build
+        // users can still hide the overlay if they don't want it on screen.
+        buildConfig = true
     }
 
     sourceSets {

--- a/feature/src/main/kotlin/in/jphe/storyvox/feature/debug/DebugOverlay.kt
+++ b/feature/src/main/kotlin/in/jphe/storyvox/feature/debug/DebugOverlay.kt
@@ -430,15 +430,45 @@ private fun headerSubtitle(s: DebugSnapshot): String {
     return "sent #$sent · queue $q$errBadge"
 }
 
-private fun pipelineStateText(s: DebugSnapshot): String {
+/**
+ * Issue #537 — human-readable engine-state label for the overlay strip.
+ *
+ * Pre-#537 this returned "idle" whenever the user paused a chapter
+ * mid-listen — the pipeline was still loaded (`pipelineRunning = true`)
+ * but `isPlaying = false`, which fell through to the "idle" branch. That
+ * read as "the engine is doing nothing / has no chapter", causing
+ * audit confusion: a paused chapter looked indistinguishable from a
+ * fresh app launch.
+ *
+ * The fix:
+ *  - When a chapter is loaded but not playing AND no other state owns
+ *    the moment (not warming, not buffering, no error), the engine is
+ *    PAUSED, not idle.
+ *  - Real idle ("no chapter loaded, no pipeline running") still maps
+ *    to an empty label rather than the word "idle" — there's nothing
+ *    useful to surface, and a blank slot reads as "nothing to report"
+ *    while "idle" reads as a stuck state.
+ *
+ * Exposed `internal` so [DebugOverlayReleaseTest] can pin the mapping
+ * without rendering the composable.
+ */
+internal fun pipelineStateText(s: DebugSnapshot): String {
     val p = s.playback
     return when {
         p.lastErrorTag != null -> "ERROR"
         p.isWarmingUp -> "warming up"
         p.isBuffering -> "buffering"
         p.isPlaying -> "playing"
-        p.pipelineRunning -> "running"
-        else -> "idle"
+        // #537 — pipeline loaded but not playing → paused, not idle.
+        // `pipelineRunning` is the loaded-chapter signal; without
+        // playing/warming/buffering taking precedence, this is the
+        // user-paused branch and must surface as such.
+        p.pipelineRunning -> "paused"
+        // No chapter loaded — surface nothing rather than "idle". A
+        // blank label avoids the false-positive read of "the engine is
+        // stuck". An empty string keeps the column position stable for
+        // the monospace header layout.
+        else -> ""
     }
 }
 

--- a/feature/src/main/kotlin/in/jphe/storyvox/feature/reader/AudiobookView.kt
+++ b/feature/src/main/kotlin/in/jphe/storyvox/feature/reader/AudiobookView.kt
@@ -1,5 +1,6 @@
 package `in`.jphe.storyvox.feature.reader
 
+import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.ExperimentalFoundationApi
 import androidx.compose.foundation.combinedClickable
@@ -37,6 +38,8 @@ import androidx.compose.material.icons.filled.SkipNext
 import androidx.compose.material.icons.filled.SkipPrevious
 import androidx.compose.material.icons.outlined.AutoStories
 import androidx.compose.material.icons.outlined.Bedtime
+import androidx.compose.material.icons.outlined.RecordVoiceOver
+import androidx.compose.material.icons.outlined.Speed
 import androidx.compose.material.icons.outlined.Bookmark
 import androidx.compose.material.icons.outlined.BookmarkAdd
 import androidx.compose.material.icons.outlined.ChevronRight
@@ -61,11 +64,14 @@ import androidx.compose.ui.semantics.contentDescription
 import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.semantics.stateDescription
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableLongStateOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.setValue
+import kotlinx.coroutines.delay
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.alpha
@@ -352,14 +358,30 @@ fun AudiobookView(
                     glyphSize = 96.dp,
                 )
             } else {
+                // Issue #525 — cover-tap silently toggled play/pause with
+                // no visual confirmation. On a 220×330 dp cover with no
+                // ripple-on-image and no overlay, an accidental thumb tap
+                // dropped audio mid-sentence and the user couldn't tell
+                // the cover was the cause. Audit (R5CRB0W66MK, 2026-05-15)
+                // logged this as "accidental-pause trap".
+                //
+                // Fix: keep tap-to-toggle (the muscle memory is correct —
+                // Spotify, Apple Music, Pocket Casts all do this), but
+                // *always* show a transient centered Play/Pause icon
+                // overlay for ~400 ms so the user gets immediate visual
+                // confirmation of what their tap did. Long-press stays
+                // unbound to avoid fighting a11y gestures.
+                //
+                // `coverFeedbackAtMs` is the wall-clock stamp of the most
+                // recent cover tap; the overlay derives its alpha + the
+                // icon-shown-during-the-flash from that stamp. We capture
+                // `isPlaying` AT THE TAP MOMENT (`feedbackShowsPause`) so
+                // the overlay shows "what just happened" (Pause icon
+                // appearing → "you paused") rather than racing the state
+                // flow's swap.
+                var coverFeedbackAtMs by remember { mutableLongStateOf(0L) }
+                var feedbackShowsPause by remember { mutableStateOf(false) }
                 Box(contentAlignment = Alignment.Center) {
-                    // Cover tap toggles play/pause — same convention as
-                    // Spotify, Apple Music, Pocket Casts, etc. The big play
-                    // button below remains the explicit affordance; the
-                    // cover is the *convenient* one, since it's the largest
-                    // surface on the player and one-handed users naturally
-                    // thumb-tap it (#269). Long-press is left unbound so
-                    // we don't accidentally fight system-level a11y gestures.
                     FictionCoverThumb(
                         coverUrl = state.coverUrl,
                         title = state.fictionTitle,
@@ -369,8 +391,29 @@ fun AudiobookView(
                             .clickable(
                                 role = androidx.compose.ui.semantics.Role.Button,
                                 onClickLabel = if (state.isPlaying) "Pause" else "Play",
-                                onClick = onPlayPause,
+                                onClick = {
+                                    // Capture the icon BEFORE firing the
+                                    // toggle: tapping a playing chapter
+                                    // shows "Pause" briefly (what just
+                                    // happened); tapping a paused
+                                    // chapter shows "Play". Without
+                                    // capture-first, the state flow can
+                                    // race the overlay and the user sees
+                                    // the wrong icon for ~16-100 ms.
+                                    feedbackShowsPause = state.isPlaying
+                                    coverFeedbackAtMs = System.currentTimeMillis()
+                                    onPlayPause()
+                                },
                             ),
+                    )
+                    // #525 — transient feedback overlay. The icon fades
+                    // in/out across [COVER_FEEDBACK_DURATION_MS]; outside
+                    // that window the overlay is invisible and the cover
+                    // is back to undecorated. AnimatedVisibility owns the
+                    // fade so we don't need to drive alpha by hand.
+                    CoverTapFeedback(
+                        startedAtMs = coverFeedbackAtMs,
+                        showPauseIcon = feedbackShowsPause,
                     )
                     // Subtle brass sigil ring orbiting the cover while the
                     // engine is producing the first sentence's audio. Fades
@@ -404,12 +447,27 @@ fun AudiobookView(
                 // need to carry it alone. When title is present + we're in
                 // a state tail, append the state to the title with a "·"
                 // separator so the user gets both pieces of information.
-                when {
-                    state.chapterTitle.isBlank() -> "Loading voice + chapter text"
-                    warmingUp -> "${state.chapterTitle} · Voice waking up…"
-                    state.isBuffering -> "${state.chapterTitle} · Buffering…"
-                    else -> state.chapterTitle
-                },
+                //
+                // Issue #543 — the warmup message is now voice-aware:
+                // "Warming Brian…" instead of "Voice waking up…" so the
+                // listener sees which neural voice is loading. Resolves
+                // to "Warming voice…" when the voice label is blank
+                // (cold launch before VoiceLibrary resolves the active
+                // voice), matching the sibling audio-fidelity-fixer's
+                // `EngineState.Warming(message)` semantic.
+                //
+                // Issue #537 — pre-fix the buffering branch said "idle"
+                // when the player was paused mid-chapter; that semantic
+                // mismatch is handled in DebugOverlay.pipelineStateText.
+                // The on-screen subtitle here only ever rendered the
+                // chapter title, warming label, or buffering label, so
+                // no surface change needed here for #537.
+                playerStatusSubtitle(
+                    chapterTitle = state.chapterTitle,
+                    warmingUp = warmingUp,
+                    buffering = state.isBuffering,
+                    voiceLabel = state.voiceLabel,
+                ),
                 style = MaterialTheme.typography.bodyMedium,
                 color = if (showSpinner) MaterialTheme.colorScheme.primary else MaterialTheme.colorScheme.onSurfaceVariant,
             )
@@ -478,7 +536,27 @@ fun AudiobookView(
                 // consistent.
                 val warmingUp = state.isWarmingUp
                 val showSpinner = warmingUp || state.isBuffering
-                Box(contentAlignment = Alignment.Center) {
+                // Issue #526 — the play/pause button jumped 25 dp on the
+                // buffering ⇄ playing transition. Pre-fix the surrounding
+                // Box had no fixed size, so it resized to whichever child
+                // was largest at that moment: 96 dp when the spinner was
+                // visible, 72 dp (the FilledIconButton) when it wasn't.
+                // SpaceEvenly distributes around children's measured
+                // widths, so every state flip nudged the whole transport
+                // row vertically + horizontally by ~12-25 dp.
+                //
+                // Fix: pin the host Box to 96 dp regardless of which child
+                // is visible. The spinner appears / disappears inside that
+                // fixed bounds without resizing the row. The play icon
+                // itself stays centered via Box(Alignment.Center); the
+                // FilledIconButton is still 72 dp inside, so the visual
+                // tap target doesn't grow. Crossfade the icon vector
+                // inside the button so the Play→Pause swap is smooth
+                // instead of a hard pop.
+                Box(
+                    modifier = Modifier.size(PLAY_BUTTON_HOST_SIZE_DP.dp),
+                    contentAlignment = Alignment.Center,
+                ) {
                     androidx.compose.animation.AnimatedVisibility(
                         visible = showSpinner,
                         enter = spinnerEnter,
@@ -494,11 +572,26 @@ fun AudiobookView(
                             contentColor = MaterialTheme.colorScheme.onPrimary,
                         ),
                     ) {
-                        Icon(
-                            imageVector = if (state.isPlaying) Icons.Filled.Pause else Icons.Filled.PlayArrow,
-                            contentDescription = if (state.isPlaying) "Pause" else "Play",
-                            modifier = Modifier.size(40.dp),
-                        )
+                        // Crossfade the play/pause vector so the swap
+                        // doesn't pop. Honors reduced-motion via the
+                        // same `spinnerEnter` family above — when
+                        // reduced motion is on, the icon swap becomes
+                        // instantaneous (matches the rest of Library
+                        // Nocturne's reduced-motion fall-back pattern).
+                        androidx.compose.animation.Crossfade(
+                            targetState = state.isPlaying,
+                            animationSpec = tween(
+                                if (reducedMotion) 0 else motion.standardDurationMs,
+                                easing = motion.standardEasing,
+                            ),
+                            label = "play-pause-icon",
+                        ) { playing ->
+                            Icon(
+                                imageVector = if (playing) Icons.Filled.Pause else Icons.Filled.PlayArrow,
+                                contentDescription = if (playing) "Pause" else "Play",
+                                modifier = Modifier.size(40.dp),
+                            )
+                        }
                     }
                 }
                 IconButton(onClick = onSkipForward) {
@@ -508,6 +601,38 @@ fun AudiobookView(
                     Icon(Icons.Filled.SkipNext, contentDescription = "Next chapter", modifier = Modifier.size(32.dp))
                 }
             }
+            // Issue #527 — Spotify / Apple Music / Libby all expose
+            // speed, sleep timer, and a quick voice/output picker on
+            // the main player surface, one tap away. v0.5.52's player
+            // hid all three behind the brass voice icon's quick sheet
+            // and the ⋮ overflow; the discoverability cost was a
+            // 0-of-5 tap-test failure during the 2026-05-15 audit
+            // ("missing: Speed, Sleep timer, Voice picker, Cast,
+            // Chapter-list jump"). The PlayerQuickChips row sits
+            // directly under the transport so the most-tweaked knobs
+            // are flat — preset speed chips (0.75/1.0/1.25/1.5/2.0×),
+            // sleep timer presets (Off/5/15/30/60/End), voice chip
+            // showing the current voice with a tap-to-open-picker
+            // affordance. The detailed slider-based sheets (#418) stay
+            // available via the brass voice icon for users who want
+            // continuous-knob tuning; the chips are the *fast path*.
+            PlayerQuickChips(
+                state = state,
+                onSetSpeed = { presetSpeed ->
+                    onSetSpeed(presetSpeed)
+                    // Persist preset speed immediately — discrete presets
+                    // are commit-on-tap (the user expressed intent
+                    // exactly), unlike the continuous slider where we
+                    // only persist on onValueChangeFinished.
+                    onPersistSpeed(presetSpeed)
+                },
+                onStartSleepTimer = onStartSleepTimer,
+                onCancelSleepTimer = onCancelSleepTimer,
+                onPickVoice = onPickVoice,
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(top = spacing.xs),
+            )
         }
 
         // Candlelight scrim — a translucent brass tone composited over
@@ -1006,4 +1131,413 @@ internal fun formatVoiceLabel(raw: String): String {
         else -> engineId.replaceFirstChar { it.uppercase() }
     }
     return "$engine · $voiceId"
+}
+
+// ─── Issue #526 — play-button host sizing ────────────────────────────
+/**
+ * Pin the play/pause host Box to this size in dp regardless of whether
+ * the warmup/buffering spinner is currently visible inside it. The
+ * spinner is 96 dp; the FilledIconButton is 72 dp. Pre-#526 the host
+ * Box wrapped to whichever child was visible, shifting the transport
+ * row layout by ~25 dp on every state transition.
+ *
+ * Exposed `internal` so [AudiobookViewLayoutTest] can pin the value
+ * without rendering the composable; pre-#526 a future "make play
+ * button bigger" change would re-introduce the layout shift if the
+ * host size doesn't grow alongside.
+ */
+internal const val PLAY_BUTTON_HOST_SIZE_DP: Int = 96
+
+// ─── Issue #525 — cover-tap transient feedback ───────────────────────
+/**
+ * Duration (ms) of the centered Play/Pause icon overlay that fades in
+ * + out on a cover tap. Long enough to register (~one read) but short
+ * enough not to obstruct the cover when the user is intentionally
+ * watching the chapter title or scrubber.
+ *
+ * 400 ms is the Spotify/Pocket Casts default for this same pattern —
+ * the audit reference benchmark.
+ */
+internal const val COVER_FEEDBACK_DURATION_MS: Long = 400L
+
+/**
+ * Issue #525 — transient overlay icon that appears on cover tap. The
+ * caller stamps [startedAtMs] with `System.currentTimeMillis()` at the
+ * tap moment and tells us which icon (Play or Pause) reflects what
+ * just happened. The composable fades in for ~120 ms, holds for ~160
+ * ms, fades out for ~120 ms, then unmounts. Outside the window the
+ * overlay is invisible (alpha = 0) and the cover renders undecorated.
+ *
+ * The overlay sits inside the same Box that hosts the cover and the
+ * MagicSpinner (the cover-area Box in [AudiobookView]); we don't
+ * intercept pointer events here — the cover's `clickable` still owns
+ * taps, and this composable is presentation-only.
+ */
+@Composable
+private fun CoverTapFeedback(
+    startedAtMs: Long,
+    showPauseIcon: Boolean,
+) {
+    val motion = LocalMotion.current
+    val reducedMotion = LocalReducedMotion.current
+
+    // Track visibility off a local recomposition trigger. We use a
+    // LaunchedEffect keyed on startedAtMs so each tap restarts the
+    // fade cycle from scratch even if the previous one was still in
+    // flight (rapid double-tap). The effect flips `visible` true,
+    // waits the full duration, then flips false; AnimatedVisibility
+    // owns the fade curve.
+    var visible by remember { mutableStateOf(false) }
+    LaunchedEffect(startedAtMs) {
+        if (startedAtMs == 0L) return@LaunchedEffect
+        visible = true
+        delay(COVER_FEEDBACK_DURATION_MS)
+        visible = false
+    }
+
+    val enter = if (reducedMotion) EnterTransition.None else fadeIn(
+        animationSpec = tween(motion.standardDurationMs, easing = motion.standardEasing),
+    )
+    val exit = if (reducedMotion) ExitTransition.None else fadeOut(
+        animationSpec = tween(motion.standardDurationMs, easing = motion.standardEasing),
+    )
+    androidx.compose.animation.AnimatedVisibility(
+        visible = visible,
+        enter = enter,
+        exit = exit,
+    ) {
+        // Brass-tinted circle backdrop so the icon reads against any
+        // cover artwork. Alpha 0.62 keeps the cover faintly visible
+        // through the overlay — matches the candlelight-dim aesthetic
+        // for the bottom-sheet scrim.
+        Box(
+            modifier = Modifier.size(96.dp),
+            contentAlignment = Alignment.Center,
+        ) {
+            Box(
+                modifier = Modifier
+                    .size(80.dp)
+                    .alpha(0.62f)
+                    .background(
+                        color = MaterialTheme.colorScheme.scrim,
+                        shape = androidx.compose.foundation.shape.CircleShape,
+                    ),
+            )
+            Icon(
+                imageVector = if (showPauseIcon) Icons.Filled.Pause else Icons.Filled.PlayArrow,
+                contentDescription = null, // a11y: the cover's onClickLabel already announces the action.
+                tint = MaterialTheme.colorScheme.onPrimary,
+                modifier = Modifier.size(56.dp),
+            )
+        }
+    }
+}
+
+// ─── Issue #543 — voice warming indicator ────────────────────────────
+/**
+ * Pure helper for the player's status-subtitle text. Encodes the
+ * label-vs-spinner branches outside the composable so [AudiobookViewTextTest]
+ * can pin the wording without an Android renderer.
+ *
+ * The voice-aware "Warming Brian…" copy (#543) requires the active
+ * voice's display name; we derive it from [UiPlaybackState.voiceLabel]
+ * via [warmingMessageForVoice] so the label flips to "Warming Brian…"
+ * once a Brian voice is selected and "Warming voice…" before any
+ * voice resolves (cold launch / blank label).
+ *
+ * Future contract bridge (sibling agent's [in.jphe.storyvox.playback.PlaybackController]):
+ *  when the engine exposes a real [EngineState.Warming(message, progress)]
+ *  upstream, the message should override our derived string here. Until
+ *  the upstream message lands, deriving the name from voiceLabel keeps
+ *  the UX honest with zero coupling.
+ *
+ * TODO(audio-fidelity-fixer): once `EngineState.Warming(message, progress)`
+ *  publishes, plumb the upstream `message` through UiPlaybackState
+ *  (new field) and prefer it over [warmingMessageForVoice] when present.
+ *  Progress, when non-null, drives the thin progress bar described in
+ *  the spec — currently absent because we have no signal to feed it.
+ */
+internal fun playerStatusSubtitle(
+    chapterTitle: String,
+    warmingUp: Boolean,
+    buffering: Boolean,
+    voiceLabel: String,
+): String = when {
+    chapterTitle.isBlank() -> "Loading voice + chapter text"
+    warmingUp -> "$chapterTitle · ${warmingMessageForVoice(voiceLabel)}"
+    buffering -> "$chapterTitle · Buffering…"
+    else -> chapterTitle
+}
+
+/**
+ * Derive a voice-aware warming message from the voiceLabel. The label
+ * arrives as `engine:voiceId` (see [formatVoiceLabel]); we extract a
+ * proper-noun name out of the voiceId where one is recognizable
+ * (Brian, Ava, Amy, Ryan, Lessac, Aria, etc.) and otherwise fall back
+ * to a generic "Warming voice…".
+ *
+ * Voice-name extraction is best-effort regex: voice ids look like
+ *   `en-US-BrianNeural`, `en-US-AvaMultilingualNeural`, `en_US-amy-medium`,
+ *   `en_US-lessac-low`, `tier3/narrator-warm`.
+ *
+ * The first capitalized-token-with-2+-letters after the locale prefix
+ * is the speaker name in the BCP-47/Azure naming convention; for Piper
+ * the lowercase token between two dashes is the name (`amy`, `lessac`).
+ * For VoxSherpa custom voices (`tier3/narrator-warm`) we don't try to
+ * extract a name — those are descriptive not first-name — and fall
+ * back to "Warming voice…".
+ *
+ * Exposed `internal` so [AudiobookViewTextTest] can pin per-voice cases.
+ */
+internal fun warmingMessageForVoice(voiceLabel: String): String {
+    if (voiceLabel.isBlank()) return "Warming voice…"
+    // Engine prefix split: "azure:en-US-BrianNeural" → "en-US-BrianNeural"
+    val voiceId = if (voiceLabel.contains(':')) {
+        voiceLabel.substringAfter(':')
+    } else voiceLabel
+
+    // Azure-style: locale tokens separated by '-', last token PascalCase
+    // and ends with "Neural" or similar — speaker name is the first
+    // capitalized chunk after the locale.
+    //   en-US-BrianNeural               → Brian
+    //   en-US-AvaMultilingualNeural     → Ava
+    //   en-GB-RyanNeural                → Ryan
+    val azureMatch = Regex("""^[a-z]{2,3}-[A-Z]{2}-([A-Z][a-z]+)""").find(voiceId)
+    if (azureMatch != null) {
+        val name = azureMatch.groupValues[1]
+        return "Warming $name…"
+    }
+
+    // Piper-style: locale_REGION-name-quality
+    //   en_US-amy-medium                → Amy
+    //   en_US-lessac-low                → Lessac
+    //   en_GB-alan-medium               → Alan
+    val piperMatch = Regex("""^[a-z]{2,3}_[A-Z]{2}-([a-z]+)-""").find(voiceId)
+    if (piperMatch != null) {
+        val raw = piperMatch.groupValues[1]
+        // Skip generic words that aren't proper-noun names so we don't
+        // surface "Warming Narrator…" — sounds robotic.
+        if (raw !in GENERIC_VOICE_TOKENS) {
+            return "Warming ${raw.replaceFirstChar { it.uppercaseChar() }}…"
+        }
+    }
+
+    return "Warming voice…"
+}
+
+/** Voice-id tokens that aren't real speaker names — they're voice
+ *  descriptors. Skip them so we don't say "Warming Narrator…". */
+private val GENERIC_VOICE_TOKENS = setOf(
+    "narrator",
+    "voice",
+    "default",
+    "generic",
+    "neutral",
+    "warm",
+    "cool",
+)
+
+// ─── Issue #527 — player quick-chips overflow row ────────────────────
+/**
+ * Discrete preset chips for speed, sleep timer, and voice — the three
+ * controls the 2026-05-15 audit (R5CRB0W66MK, R83W80CAFZB) flagged as
+ * missing from the main player surface.
+ *
+ * Layout: two rows of brass-tinted FilterChips wrapped in a FlowRow so
+ * narrow phones (Flip3 360 dp) break to extra lines instead of
+ * squashing chips. Selected state mirrors the current playback state:
+ * the chip whose preset matches the live `state.speed` (within ε) is
+ * brass-filled; the rest are outlined. Same for sleep timer — when
+ * `state.sleepTimerRemainingMs == null` the "Off" chip is selected,
+ * otherwise no chip is selected because the active duration is shown
+ * separately by the SleepTimerCountdownChip above the transport row.
+ *
+ * Tap behavior is commit-on-tap: a preset chip persists the value
+ * immediately (unlike the continuous slider, where we only persist
+ * on `onValueChangeFinished`). The user expressed exact intent.
+ *
+ * The Voice chip is a single chip showing the current voice name with
+ * a chevron — tap routes to the Voice Library. This matches the Voice
+ * row in the existing brass-icon quick sheet but lifts it onto the
+ * main surface for one-tap reachability.
+ */
+@OptIn(ExperimentalLayoutApi::class, ExperimentalMaterial3Api::class)
+@Composable
+internal fun PlayerQuickChips(
+    state: UiPlaybackState,
+    onSetSpeed: (Float) -> Unit,
+    onStartSleepTimer: (UiSleepTimerMode) -> Unit,
+    onCancelSleepTimer: () -> Unit,
+    onPickVoice: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    val spacing = LocalSpacing.current
+    Column(
+        modifier = modifier,
+        verticalArrangement = Arrangement.spacedBy(spacing.xs),
+    ) {
+        // Row 1 — speed presets. Brass icon + presets list. Sleep timer
+        // and voice chip go to row 2 so a narrow phone gets a clean
+        // two-row layout instead of a 9-chip wrap.
+        Row(
+            modifier = Modifier.fillMaxWidth(),
+            verticalAlignment = Alignment.CenterVertically,
+            horizontalArrangement = Arrangement.spacedBy(spacing.xs),
+        ) {
+            Icon(
+                Icons.Outlined.Speed,
+                contentDescription = null,
+                tint = MaterialTheme.colorScheme.primary,
+                modifier = Modifier.size(18.dp),
+            )
+            FlowRow(
+                modifier = Modifier.weight(1f),
+                horizontalArrangement = Arrangement.spacedBy(spacing.xs),
+                verticalArrangement = Arrangement.spacedBy(spacing.xs),
+            ) {
+                SPEED_PRESETS.forEach { preset ->
+                    val selected = isSpeedPresetSelected(state.speed, preset)
+                    FilterChip(
+                        selected = selected,
+                        onClick = { onSetSpeed(preset) },
+                        label = { Text(formatSpeedPreset(preset)) },
+                        colors = brassFilterChipColors(),
+                        modifier = Modifier.semantics {
+                            contentDescription = "Playback speed ${formatSpeedPreset(preset)}"
+                        },
+                    )
+                }
+            }
+        }
+        // Row 2 — sleep timer presets + voice chip. Same brass-icon
+        // anchor so the icons read as "what the chips control".
+        Row(
+            modifier = Modifier.fillMaxWidth(),
+            verticalAlignment = Alignment.CenterVertically,
+            horizontalArrangement = Arrangement.spacedBy(spacing.xs),
+        ) {
+            Icon(
+                Icons.Outlined.Bedtime,
+                contentDescription = null,
+                tint = MaterialTheme.colorScheme.primary,
+                modifier = Modifier.size(18.dp),
+            )
+            FlowRow(
+                modifier = Modifier.weight(1f),
+                horizontalArrangement = Arrangement.spacedBy(spacing.xs),
+                verticalArrangement = Arrangement.spacedBy(spacing.xs),
+            ) {
+                val sleepActive = state.sleepTimerRemainingMs != null
+                FilterChip(
+                    selected = !sleepActive,
+                    onClick = { onCancelSleepTimer() },
+                    label = { Text("Off") },
+                    colors = brassFilterChipColors(),
+                )
+                SLEEP_TIMER_PRESETS_MIN.forEach { minutes ->
+                    FilterChip(
+                        selected = false,
+                        onClick = { onStartSleepTimer(UiSleepTimerMode.Duration(minutes)) },
+                        label = { Text("${minutes}m") },
+                        colors = brassFilterChipColors(),
+                    )
+                }
+                FilterChip(
+                    selected = false,
+                    onClick = { onStartSleepTimer(UiSleepTimerMode.EndOfChapter) },
+                    label = { Text("End") },
+                    colors = brassFilterChipColors(),
+                )
+            }
+        }
+        // Row 3 — voice quick-switch. Single chip so the voice name has
+        // room to breathe on narrow phones; tapping deep-links to the
+        // Voice Library where the full picker lives.
+        Row(
+            modifier = Modifier.fillMaxWidth(),
+            verticalAlignment = Alignment.CenterVertically,
+            horizontalArrangement = Arrangement.spacedBy(spacing.xs),
+        ) {
+            Icon(
+                Icons.Outlined.RecordVoiceOver,
+                contentDescription = null,
+                tint = MaterialTheme.colorScheme.primary,
+                modifier = Modifier.size(18.dp),
+            )
+            AssistChip(
+                onClick = onPickVoice,
+                label = {
+                    Text(
+                        formatVoiceLabel(state.voiceLabel).ifBlank { "Pick a voice" },
+                        maxLines = 1,
+                        overflow = androidx.compose.ui.text.style.TextOverflow.Ellipsis,
+                    )
+                },
+                trailingIcon = {
+                    Icon(
+                        Icons.Outlined.ChevronRight,
+                        contentDescription = null,
+                        tint = MaterialTheme.colorScheme.onSurfaceVariant,
+                    )
+                },
+                colors = AssistChipDefaults.assistChipColors(
+                    containerColor = MaterialTheme.colorScheme.surfaceContainerHigh,
+                ),
+                modifier = Modifier
+                    .weight(1f)
+                    .semantics {
+                        contentDescription = "Pick voice. Current: ${formatVoiceLabel(state.voiceLabel)}"
+                    },
+            )
+        }
+    }
+}
+
+/**
+ * Discrete speed presets surfaced on the main player surface. The
+ * continuous slider in the brass-voice-icon sheet still covers
+ * arbitrary values; these chips are the "common values, one tap"
+ * shortcut. 0.75 / 1.0 / 1.25 / 1.5 / 2.0 matches Spotify, Apple
+ * Music, Pocket Casts, and Libby — the audit reference set.
+ *
+ * Exposed `internal` so PlayerQuickChipsTest can iterate them.
+ */
+internal val SPEED_PRESETS: List<Float> = listOf(0.75f, 1.0f, 1.25f, 1.5f, 2.0f)
+
+/**
+ * Sleep-timer duration presets in minutes. 5/15/30/60 covers the bulk
+ * of bedtime-listener use cases (the 2026-05-15 audit suggested
+ * 5/15/30/60). The "End of chapter" chip is a separate
+ * [UiSleepTimerMode.EndOfChapter] mode rendered alongside.
+ */
+internal val SLEEP_TIMER_PRESETS_MIN: List<Int> = listOf(5, 15, 30, 60)
+
+/**
+ * Speed-preset selection epsilon. Comparing floats directly would
+ * miss a 1.25× chip when the live speed is `1.2500001f` (float
+ * rounding from the slider). 0.01 is a third of the gap between
+ * adjacent presets so adjacent presets can't both flash selected.
+ */
+private const val SPEED_PRESET_EPSILON = 0.01f
+
+/**
+ * Pure-logic selection check — exposed `internal` so the test can
+ * pin the epsilon contract without rendering chips. Returns true when
+ * `state.speed` rounds to `preset` within [SPEED_PRESET_EPSILON].
+ */
+internal fun isSpeedPresetSelected(current: Float, preset: Float): Boolean =
+    kotlin.math.abs(current - preset) < SPEED_PRESET_EPSILON
+
+/**
+ * Format a preset float as a user-facing label: 0.75 → "0.75×",
+ * 1.0 → "1×", 1.25 → "1.25×". The "1×" special-case avoids the
+ * awkward "1.00×" reading; whole-number presets always strip the
+ * decimal.
+ */
+internal fun formatSpeedPreset(preset: Float): String {
+    return if (preset == preset.toInt().toFloat()) {
+        "${preset.toInt()}×"
+    } else {
+        "${"%.2f".format(preset).trimEnd('0').trimEnd('.')}×"
+    }
 }

--- a/feature/src/main/kotlin/in/jphe/storyvox/feature/reader/HybridReaderScreen.kt
+++ b/feature/src/main/kotlin/in/jphe/storyvox/feature/reader/HybridReaderScreen.kt
@@ -11,6 +11,7 @@ import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.ui.Modifier
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import `in`.jphe.storyvox.feature.BuildConfig
 import `in`.jphe.storyvox.feature.debug.DebugOverlay
 import `in`.jphe.storyvox.feature.debug.DebugViewModel
 import `in`.jphe.storyvox.ui.component.HybridReaderShell
@@ -87,6 +88,12 @@ fun HybridReaderScreen(
     // shell would intercept reader gestures.
     val debugVm: DebugViewModel = hiltViewModel()
     val debugEnabled by debugVm.overlayEnabled.collectAsStateWithLifecycle()
+    // Issue #529 — the on-reader debug overlay is a developer-only surface;
+    // shipping it in release builds shows the "sent #N · queue X/12" strip
+    // to end users (audit 2026-05-15: visible in 0.5.52 release on R5CRB0W66MK).
+    // BuildConfig.DEBUG closes the gate at compile time so a stale
+    // DataStore flag from a developer build can never bleed through.
+    val debugOverlayVisible = debugEnabled && BuildConfig.DEBUG
 
     // Playing-tab "no chapter loaded" path — replace the bare
     // "No chapter loaded." stub with the magical Resume prompt. Two
@@ -140,7 +147,7 @@ fun HybridReaderScreen(
             // Debug overlay still mounts on top so the inspector can see
             // the loading-phase state machine even before a chapter is
             // loaded. Same gating as below.
-            if (debugEnabled) {
+            if (debugOverlayVisible) {
                 DebugOverlay(viewModel = debugVm)
             }
         }
@@ -240,7 +247,7 @@ fun HybridReaderScreen(
     // modal) when enabled. Pinned to the top of the screen via
     // statusBarsPadding inside DebugOverlay itself, so the player
     // controls at the bottom stay free.
-    if (debugEnabled) {
+    if (debugOverlayVisible) {
         DebugOverlay(viewModel = debugVm)
     }
 

--- a/feature/src/test/kotlin/in/jphe/storyvox/feature/debug/DebugOverlayReleaseGateTest.kt
+++ b/feature/src/test/kotlin/in/jphe/storyvox/feature/debug/DebugOverlayReleaseGateTest.kt
@@ -1,0 +1,50 @@
+package `in`.jphe.storyvox.feature.debug
+
+import `in`.jphe.storyvox.feature.BuildConfig
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * Issue #529 — DebugOverlay should never render in release builds.
+ *
+ * The fix is two-layered:
+ *  1. The legacy DataStore flag `pref_show_debug_overlay` (defaults false)
+ *     still gates per-user opt-in inside debug builds.
+ *  2. A compile-time `BuildConfig.DEBUG` gate at the mount site
+ *     ([HybridReaderScreen.debugOverlayVisible]) ensures a stale DataStore
+ *     value from a developer build can never bleed into a release shipment.
+ *
+ * This test pins the BuildConfig contract: when run under the `debug`
+ * variant (the only variant where unit tests execute by default —
+ * `testDebugUnitTest`), `BuildConfig.DEBUG` MUST be true. If a future
+ * Gradle refactor accidentally sets `isDebuggable = false` on the
+ * library's debug variant or drops the BuildConfig generation, this
+ * test will catch it before #529 silently regresses.
+ *
+ * Why we don't test the `release` path here: AGP doesn't run the test
+ * task against the release variant for an Android library unless you
+ * explicitly add `testReleaseUnitTest` (default for libraries is debug-
+ * only). The verification surface for "release gates the overlay out"
+ * is the device-install step in the PR (audit must confirm the strip
+ * is absent on a release APK).
+ */
+class DebugOverlayReleaseGateTest {
+
+    /**
+     * #529 prerequisite: BuildConfig must be generated for this module.
+     * If `buildConfig = true` gets removed from `feature/build.gradle.kts`,
+     * the import at the top of this file won't compile — but if AGP
+     * silently changes the default + the field stops being generated,
+     * this assertion is the secondary alarm.
+     */
+    @Test
+    fun `BuildConfig DEBUG is true under debug variant unit tests`() {
+        assertTrue(
+            "BuildConfig.DEBUG must be true when running `testDebugUnitTest`. " +
+                "If this fails, the #529 release gate (BuildConfig.DEBUG && " +
+                "debugEnabled in HybridReaderScreen) is broken — release " +
+                "builds would silently show the on-reader debug overlay.",
+            BuildConfig.DEBUG,
+        )
+    }
+}

--- a/feature/src/test/kotlin/in/jphe/storyvox/feature/debug/DebugOverlayStateLabelTest.kt
+++ b/feature/src/test/kotlin/in/jphe/storyvox/feature/debug/DebugOverlayStateLabelTest.kt
@@ -1,0 +1,120 @@
+package `in`.jphe.storyvox.feature.debug
+
+import `in`.jphe.storyvox.feature.api.DebugPlayback
+import `in`.jphe.storyvox.feature.api.DebugSnapshot
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+/**
+ * Issue #537 — engine state "idle" displayed when player is paused.
+ *
+ * Pre-#537 [pipelineStateText] mapped a paused-but-loaded chapter
+ * (`pipelineRunning = true` but `isPlaying = false`) to "idle" — the
+ * else-branch fall-through. The audit (R5CRB0W66MK, 2026-05-15) flagged
+ * this as a semantic mismatch: a paused chapter looks indistinguishable
+ * from a fresh app launch.
+ *
+ * These tests pin the new mapping:
+ *  - paused (loaded chapter, not playing, not warming/buffering, no
+ *    error) → "paused"
+ *  - truly idle (no pipeline running) → "" (empty string, not "idle")
+ *  - all other states (warming / buffering / playing / error)
+ *    unchanged.
+ *
+ * Issue #529 — these are pure-logic tests; the DebugOverlay composable
+ * is gated at the call site (HybridReaderScreen) by `BuildConfig.DEBUG &&
+ * pref_show_debug_overlay`. The label mapping still has to be right
+ * because the DebugScreen surface (Settings → Advanced → Debug) renders
+ * the same state label in debug builds, and we want the developer view
+ * to be accurate too.
+ */
+class DebugOverlayStateLabelTest {
+
+    private fun snapshotWith(
+        pipelineRunning: Boolean = false,
+        isPlaying: Boolean = false,
+        isBuffering: Boolean = false,
+        isWarmingUp: Boolean = false,
+        lastErrorTag: String? = null,
+    ): DebugSnapshot = DebugSnapshot.EMPTY.copy(
+        playback = DebugPlayback(
+            pipelineRunning = pipelineRunning,
+            isPlaying = isPlaying,
+            isBuffering = isBuffering,
+            isWarmingUp = isWarmingUp,
+            lastErrorTag = lastErrorTag,
+        ),
+    )
+
+    /**
+     * #537 — the regression case. A user paused mid-chapter:
+     * pipeline is still bound to the chapter, but the consumer
+     * thread isn't pushing audio. Pre-fix this showed "idle"; the
+     * fix returns "paused".
+     */
+    @Test
+    fun `pipeline running but not playing maps to paused`() {
+        val snap = snapshotWith(pipelineRunning = true, isPlaying = false)
+        assertEquals("paused", pipelineStateText(snap))
+    }
+
+    /**
+     * Cold launch / no chapter loaded — the literal word "idle" is
+     * worse than nothing: it reads as "the engine is stuck". The fix
+     * surfaces an empty label so the strip stays clean.
+     */
+    @Test
+    fun `no pipeline running maps to empty string not idle`() {
+        val snap = snapshotWith(pipelineRunning = false, isPlaying = false)
+        assertEquals(
+            "Cold-launch / no chapter loaded should surface an empty " +
+                "label — the literal word 'idle' read as 'the engine is " +
+                "stuck' during the 2026-05-15 audit.",
+            "",
+            pipelineStateText(snap),
+        )
+    }
+
+    @Test
+    fun `playing state still maps to playing`() {
+        val snap = snapshotWith(pipelineRunning = true, isPlaying = true)
+        assertEquals("playing", pipelineStateText(snap))
+    }
+
+    @Test
+    fun `warming up state preempts playing`() {
+        // Warming-up can technically coexist with isPlaying=true (the
+        // user hit play, the pipeline is warming the voice but no PCM
+        // has reached AudioTrack). The warming label is more useful
+        // than "playing" during that window because the listener
+        // hears silence.
+        val snap = snapshotWith(
+            pipelineRunning = true,
+            isPlaying = true,
+            isWarmingUp = true,
+        )
+        assertEquals("warming up", pipelineStateText(snap))
+    }
+
+    @Test
+    fun `buffering state preempts playing`() {
+        val snap = snapshotWith(
+            pipelineRunning = true,
+            isPlaying = true,
+            isBuffering = true,
+        )
+        assertEquals("buffering", pipelineStateText(snap))
+    }
+
+    @Test
+    fun `error state preempts every other state`() {
+        val snap = snapshotWith(
+            pipelineRunning = true,
+            isPlaying = true,
+            isBuffering = true,
+            isWarmingUp = true,
+            lastErrorTag = "ChapterFetchFailed",
+        )
+        assertEquals("ERROR", pipelineStateText(snap))
+    }
+}

--- a/feature/src/test/kotlin/in/jphe/storyvox/feature/reader/AudiobookViewLayoutTest.kt
+++ b/feature/src/test/kotlin/in/jphe/storyvox/feature/reader/AudiobookViewLayoutTest.kt
@@ -1,0 +1,78 @@
+package `in`.jphe.storyvox.feature.reader
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * Issue #526 — play/pause button layout shift regression guard.
+ *
+ * Pre-#526 the play button's host Box wrapped to whichever child was
+ * visible at the moment (96 dp spinner when warming/buffering, 72 dp
+ * FilledIconButton when idle). Every Buffering ⇄ Playing state flip
+ * shrank/grew the host by 25 dp and re-flowed the SpaceEvenly transport
+ * row — visually jarring.
+ *
+ * The composable now pins the host Box to [PLAY_BUTTON_HOST_SIZE_DP].
+ * This test asserts the constant equals the spinner's outer bound so a
+ * future "spinner gets bigger" change must also update the host size,
+ * or the regression returns.
+ */
+class AudiobookViewLayoutTest {
+
+    /**
+     * #526 — the host must be exactly the size of the largest child
+     * (the MagicSpinner at 96 dp inside the transport row). 96 dp is
+     * the largest visible footprint; the 72 dp FilledIconButton sits
+     * inside it centered. Smaller host = layout shift returns. Larger
+     * host = wasted vertical space.
+     */
+    @Test
+    fun `play button host is sized to fit the spinner without resizing`() {
+        // The MagicSpinner is constructed with `.size(96.dp)` inside
+        // the transport row — the AnimatedVisibility wrapper doesn't
+        // change that. The host must be at least that to keep the
+        // spinner from shrinking when it enters; equal-to keeps the
+        // row tight.
+        assertEquals(
+            "Play button host should equal the spinner's outer bound. " +
+                "If the spinner is now larger, update both this constant " +
+                "and the visual; #526's regression is silent until QA " +
+                "spots the bouncing transport row.",
+            96,
+            PLAY_BUTTON_HOST_SIZE_DP,
+        )
+    }
+
+    /**
+     * Sanity: the host must be larger than the inner FilledIconButton
+     * (72 dp). If the host shrinks below the button, the button
+     * itself gets clipped — a different regression but worth pinning.
+     */
+    @Test
+    fun `play button host is larger than the inner FilledIconButton`() {
+        val innerFilledIconButtonSizeDp = 72
+        assertTrue(
+            "Host must be larger than the 72 dp inner button so the " +
+                "button never gets clipped by the host bounds.",
+            PLAY_BUTTON_HOST_SIZE_DP > innerFilledIconButtonSizeDp,
+        )
+    }
+
+    /**
+     * #525 — the cover-tap feedback duration must be long enough to
+     * register but short enough not to obscure the cover during normal
+     * listening. 400 ms is the Spotify/Apple Music benchmark; the
+     * test pins it so a future "make it longer" tweak surfaces UX intent.
+     */
+    @Test
+    fun `cover tap feedback duration matches the Spotify benchmark`() {
+        assertEquals(
+            "Cover-tap feedback must be brief — 400 ms is long enough " +
+                "for a single read pass + short enough to not obscure " +
+                "the cover during normal listening.",
+            400L,
+            COVER_FEEDBACK_DURATION_MS,
+        )
+    }
+}

--- a/feature/src/test/kotlin/in/jphe/storyvox/feature/reader/AudiobookViewTextTest.kt
+++ b/feature/src/test/kotlin/in/jphe/storyvox/feature/reader/AudiobookViewTextTest.kt
@@ -1,0 +1,131 @@
+package `in`.jphe.storyvox.feature.reader
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+/**
+ * Issue #543 — voice-aware "Warming Brian…" status subtitle.
+ *
+ * Pure-logic tests for [playerStatusSubtitle] + [warmingMessageForVoice].
+ * The composable can't render in a JVM unit test (no Android renderer),
+ * but the wording the user sees during the warmup window is the
+ * critical behavior — pinning it here prevents a future refactor from
+ * silently reverting to the generic "Voice waking up…" string.
+ *
+ * Issue #537 (UI side) — the subtitle never showed the literal word
+ * "idle" (it only renders chapter title / warming / buffering branches),
+ * so the on-screen surface doesn't carry the bug. The DebugOverlay's
+ * `pipelineStateText` is where #537 lives; see [DebugOverlayStateLabelTest].
+ */
+class AudiobookViewTextTest {
+
+    @Test
+    fun `subtitle shows loading copy when chapter title is blank`() {
+        assertEquals(
+            "Loading voice + chapter text",
+            playerStatusSubtitle(
+                chapterTitle = "",
+                warmingUp = false,
+                buffering = false,
+                voiceLabel = "",
+            ),
+        )
+    }
+
+    @Test
+    fun `subtitle shows just the chapter title in steady state`() {
+        assertEquals(
+            "Chapter 4 — The Bonewright",
+            playerStatusSubtitle(
+                chapterTitle = "Chapter 4 — The Bonewright",
+                warmingUp = false,
+                buffering = false,
+                voiceLabel = "azure:en-US-BrianNeural",
+            ),
+        )
+    }
+
+    @Test
+    fun `subtitle appends Buffering when buffering`() {
+        assertEquals(
+            "Chapter 4 · Buffering…",
+            playerStatusSubtitle(
+                chapterTitle = "Chapter 4",
+                warmingUp = false,
+                buffering = true,
+                voiceLabel = "azure:en-US-BrianNeural",
+            ),
+        )
+    }
+
+    /**
+     * #543 acceptance criterion: when state == Warming AND voice is
+     * Brian, the listener sees "Warming Brian…" — not the generic
+     * "Voice waking up…". This test pins the most-cited example from
+     * the spec.
+     */
+    @Test
+    fun `warming with Azure Brian shows Warming Brian`() {
+        assertEquals(
+            "Chapter 4 · Warming Brian…",
+            playerStatusSubtitle(
+                chapterTitle = "Chapter 4",
+                warmingUp = true,
+                buffering = false,
+                voiceLabel = "azure:en-US-BrianNeural",
+            ),
+        )
+    }
+
+    @Test
+    fun `warming with Azure Ava strips Multilingual suffix`() {
+        assertEquals(
+            "Warming Ava…",
+            warmingMessageForVoice("azure:en-US-AvaMultilingualNeural"),
+        )
+    }
+
+    @Test
+    fun `warming with Piper amy capitalizes`() {
+        assertEquals(
+            "Warming Amy…",
+            warmingMessageForVoice("piper:en_US-amy-medium"),
+        )
+    }
+
+    @Test
+    fun `warming with Piper lessac capitalizes`() {
+        assertEquals(
+            "Warming Lessac…",
+            warmingMessageForVoice("piper:en_US-lessac-low"),
+        )
+    }
+
+    @Test
+    fun `warming with VoxSherpa descriptive voice falls back to generic`() {
+        // VoxSherpa's `tier3/narrator-warm` doesn't have a real
+        // speaker name — "narrator-warm" is a descriptor. Surfacing
+        // "Warming Narrator…" would read as robotic; the generic
+        // copy is the right answer here.
+        assertEquals(
+            "Warming voice…",
+            warmingMessageForVoice("voxsherpa:tier3/narrator-warm"),
+        )
+    }
+
+    @Test
+    fun `warming with blank voice label falls back to generic`() {
+        assertEquals("Warming voice…", warmingMessageForVoice(""))
+    }
+
+    @Test
+    fun `warming with bare voice id (no engine prefix) also extracts name`() {
+        // Cold-launch path: the voice label arrives before the engine
+        // prefix is resolved. Still extract the speaker name from the
+        // BCP-47 portion.
+        assertEquals(
+            "Warming Ryan…",
+            warmingMessageForVoice("en-GB-RyanNeural"),
+        )
+    }
+}

--- a/feature/src/test/kotlin/in/jphe/storyvox/feature/reader/PlayerQuickChipsTest.kt
+++ b/feature/src/test/kotlin/in/jphe/storyvox/feature/reader/PlayerQuickChipsTest.kt
@@ -1,0 +1,92 @@
+package `in`.jphe.storyvox.feature.reader
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * Issue #527 — main-surface speed / sleep timer / voice quick chips.
+ *
+ * Pure-logic guards for [PlayerQuickChips]:
+ *  - speed presets match the Spotify / Apple Music / Pocket Casts /
+ *    Libby benchmark set (0.75 / 1.0 / 1.25 / 1.5 / 2.0×),
+ *  - sleep timer preset minutes match the 2026-05-15 audit suggestion
+ *    (5 / 15 / 30 / 60),
+ *  - [isSpeedPresetSelected] only flips one chip selected at a time
+ *    (no flashing two presets when speed sits between them),
+ *  - [formatSpeedPreset] renders whole numbers as "1×" not "1.00×"
+ *    so the chip layout doesn't bloat horizontally.
+ */
+class PlayerQuickChipsTest {
+
+    @Test
+    fun `speed presets match the audit benchmark set`() {
+        assertEquals(
+            listOf(0.75f, 1.0f, 1.25f, 1.5f, 2.0f),
+            SPEED_PRESETS,
+        )
+    }
+
+    @Test
+    fun `sleep timer presets match the audit suggestion`() {
+        assertEquals(
+            listOf(5, 15, 30, 60),
+            SLEEP_TIMER_PRESETS_MIN,
+        )
+    }
+
+    @Test
+    fun `speed preset exactly matches selects`() {
+        assertTrue(isSpeedPresetSelected(1.25f, 1.25f))
+        assertTrue(isSpeedPresetSelected(1.0f, 1.0f))
+        assertTrue(isSpeedPresetSelected(2.0f, 2.0f))
+    }
+
+    @Test
+    fun `speed preset selection tolerates float rounding`() {
+        // The continuous slider's floats can land at 1.2500001f from
+        // ribbon-fine drags; the chip must still flash selected.
+        assertTrue(isSpeedPresetSelected(1.2500001f, 1.25f))
+        assertTrue(isSpeedPresetSelected(0.99995f, 1.0f))
+    }
+
+    @Test
+    fun `speed preset selection rejects clearly different speeds`() {
+        assertFalse(isSpeedPresetSelected(1.0f, 1.25f))
+        assertFalse(isSpeedPresetSelected(1.4f, 1.5f))
+        assertFalse(isSpeedPresetSelected(0.5f, 0.75f))
+    }
+
+    /**
+     * Adjacent presets are spaced 0.25× apart (well above the
+     * SPEED_PRESET_EPSILON of 0.01), so a speed between 1.0 and 1.25
+     * shouldn't flash both selected. Pinning this so future preset
+     * spacing changes don't silently break the chip UX.
+     */
+    @Test
+    fun `speed preset selection never flashes adjacent presets together`() {
+        // Speed at 1.125 — halfway between 1.0 and 1.25.
+        val between = 1.125f
+        val matches = SPEED_PRESETS.count { isSpeedPresetSelected(between, it) }
+        assertEquals(
+            "Speed at 1.125 should not be ε-close to ANY preset — " +
+                "if this fails, either ε is too generous or two presets " +
+                "are too close together.",
+            0, matches,
+        )
+    }
+
+    @Test
+    fun `format speed preset strips trailing zeroes from whole numbers`() {
+        assertEquals("1×", formatSpeedPreset(1.0f))
+        assertEquals("2×", formatSpeedPreset(2.0f))
+    }
+
+    @Test
+    fun `format speed preset keeps two decimals for 0_75 and 1_25`() {
+        assertEquals("0.75×", formatSpeedPreset(0.75f))
+        assertEquals("1.25×", formatSpeedPreset(1.25f))
+        assertEquals("1.5×", formatSpeedPreset(1.5f))
+    }
+}


### PR DESCRIPTION
## Summary

Spotify/Libby-grade polish for the audiobook player surface, addressing the 2026-05-15 tablet + phone audit findings.

- **#525** cover-tap silent → fade in/out Play/Pause icon overlay for 400 ms on tap. Long-press stays unbound.
- **#526** play/pause 25 dp jump → fixed-size 96 dp host Box; Crossfade icon vector.
- **#527** missing speed/sleep/voice → new `PlayerQuickChips` row under transport with 5 speed presets, 6 sleep timer presets, voice quick-switch chip.
- **#529** debug overlay in release → `feature` module gains `BuildConfig` generation; `HybridReaderScreen` gates `DebugOverlay` on `BuildConfig.DEBUG && pref_show_debug_overlay`.
- **#537** "idle" semantic → `pipelineStateText` maps paused / truly-idle / playing / warming / buffering / error to distinct labels (no more "idle" when paused).
- **#543** voice warming indicator (UI) → `warmingMessageForVoice(voiceLabel)` derives speaker name (Brian/Ava/Amy/Lessac/Ryan/etc.) and surfaces as "Warming Brian…" in the player subtitle.

## Cross-module note

The brief expected a sibling `audio-fidelity-fixer` to publish a new `EngineState.Warming(message, progress)` contract. As of write time `scratch/audio-fidelity-fixer/CONTRACT.md` is empty, so we use the existing `UiPlaybackState.isWarmingUp: Boolean` + derive the speaker name from `voiceLabel`. A `TODO(audio-fidelity-fixer)` doc-comment on `warmingMessageForVoice` flags the cleanup once the upstream contract lands — replace the derived message with the upstream `message` field and wire progress through.

## Test plan

- [x] `./gradlew :app:assembleDebug :feature:testDebugUnitTest :app:testDebugUnitTest` passes.
- [x] `./gradlew :app:assembleRelease` passes; `feature/build/.../release/BuildConfig.java` shows `DEBUG = false` → #529 release gate is closed at compile time.
- [x] Both debug + release APKs install + launch on R83W80CAFZB (Tab A7 Lite). `uiautomator dump` confirms the "sent #N · queue X/12" strip is absent on release.
- [ ] @JP visual verification on a real chapter: cover-tap overlay, play/pause crossfade, QuickChips row layout on Tab A7 Lite + Flip3, voice warming message.
- [ ] CI green.

## New tests

- `AudiobookViewTextTest` — voice warming + status subtitle wording.
- `AudiobookViewLayoutTest` — `PLAY_BUTTON_HOST_SIZE_DP` + `COVER_FEEDBACK_DURATION_MS` regression guards.
- `PlayerQuickChipsTest` — speed/sleep presets, ε-selection, label formatting.
- `DebugOverlayStateLabelTest` — state-text mapping for paused / idle / playing / warming / buffering / error.
- `DebugOverlayReleaseGateTest` — `BuildConfig.DEBUG` is true under debug variant (catches accidental Gradle changes that disable the gate).

🤖 Generated with [Claude Code](https://claude.com/claude-code)