### PR TITLE
feat(reader,voicelibrary): chips instead of sliders + fix chips on phone

### DIFF
--- a/feature/src/main/kotlin/in/jphe/storyvox/feature/reader/AudiobookView.kt
+++ b/feature/src/main/kotlin/in/jphe/storyvox/feature/reader/AudiobookView.kt
@@ -4,6 +4,8 @@ import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.ExperimentalFoundationApi
 import androidx.compose.foundation.combinedClickable
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
 import androidx.compose.animation.EnterTransition
 import androidx.compose.animation.ExitTransition
 import androidx.compose.animation.animateColorAsState
@@ -219,8 +221,45 @@ fun AudiobookView(
     }
 
     Box(modifier = modifier.fillMaxSize()) {
+        // Issue #527 follow-up — phone-form-factor chip-row regression.
+        //
+        // Root cause: the player Column was `fillMaxSize()` with no
+        // scroll. The vertical content stack — top bar + cover (330 dp)
+        // + title + subtitle + scrubber + transport row (96 dp) + the
+        // 3-row [PlayerQuickChips] block — measures around ~770-820 dp
+        // tall. On the tablet (R83W80CAFZB, ~1006 dp tall) every row
+        // fits with breathing room. On the phone (R5CRB0W66MK, Z Flip3
+        // at ~880 dp tall after status / nav insets) the chips' first
+        // two rows (Speed presets + Sleep timer presets) get squeezed
+        // into the leftover ~13 dp between the transport row and the
+        // bottom-nav strip, while the third row (Pick voice) is the
+        // only one with measured bounds (it's the "weight(1f)" assist
+        // chip child, which still gets to claim its intrinsic width).
+        //
+        // Fix: wrap the player Column in `verticalScroll`. The cover +
+        // transport stay anchored at the top; the chips become
+        // reachable by a small scroll on narrow displays. Tablet keeps
+        // the existing "everything fits without scrolling" layout —
+        // the scroll modifier is a no-op when content fits the
+        // viewport. uiautomator's a11y dump now sees all 12 chips on
+        // both R5CRB0W66MK (phone) and R83W80CAFZB (tablet).
+        val scrollState = rememberScrollState()
+        // Modifier order matters: `verticalScroll` BEFORE `fillMaxWidth`.
+        // `fillMaxSize` would clash with `verticalScroll` (the latter
+        // makes the height unbounded, contradicting fillMaxSize's "fill
+        // parent's height"). The pattern is:
+        //   1. `fillMaxWidth` — column claims full viewport width
+        //   2. `verticalScroll` — vertical axis becomes scrollable
+        //   3. `padding` — interior insets, AFTER scroll so the scrollbar
+        //      (if shown) tracks the viewport edge, not the padded edge
+        // Without this order the chip rows on a narrow phone were
+        // measured at zero height (Compose's "infinity max height"
+        // warning silently downgrades to a zero-bound layout).
         Column(
-            modifier = Modifier.fillMaxSize().padding(spacing.lg),
+            modifier = Modifier
+                .fillMaxWidth()
+                .verticalScroll(scrollState)
+                .padding(spacing.lg),
             horizontalAlignment = Alignment.CenterHorizontally,
             verticalArrangement = Arrangement.spacedBy(spacing.md),
         ) {
@@ -1095,9 +1134,20 @@ private fun SleepTimerChips(
     }
 }
 
+/**
+ * Brass-themed [FilterChipDefaults.filterChipColors] used across the
+ * player surface chip rows (PlayerQuickChips) and the voice quick
+ * sheet's chip presets ([VoiceQuickSheetContent]). Selected state
+ * uses the brass primary-container fill so the active preset reads
+ * as the "currently set" anchor; unselected stays subtle so a row of
+ * 5-6 chips doesn't visually shout.
+ *
+ * Exposed `internal` so [VoiceQuickSheetContent] can use the same
+ * palette as [PlayerQuickChips] without duplicating the definition.
+ */
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
-private fun brassFilterChipColors() = FilterChipDefaults.filterChipColors(
+internal fun brassFilterChipColors() = FilterChipDefaults.filterChipColors(
     selectedContainerColor = MaterialTheme.colorScheme.primaryContainer,
     selectedLabelColor = MaterialTheme.colorScheme.onPrimaryContainer,
 )
@@ -1535,6 +1585,96 @@ internal fun isSpeedPresetSelected(current: Float, preset: Float): Boolean =
  * decimal.
  */
 internal fun formatSpeedPreset(preset: Float): String {
+    return if (preset == preset.toInt().toFloat()) {
+        "${preset.toInt()}×"
+    } else {
+        "${"%.2f".format(preset).trimEnd('0').trimEnd('.')}×"
+    }
+}
+
+/**
+ * Pitch presets surfaced as chips in [VoiceQuickSheetContent]. The
+ * continuous slider's range is 0.6×..1.4× (Sonic's "musical" zone —
+ * outside that band the voice sounds chipmunky or muddy). The chip
+ * set picks five anchors: neutral 1×, two "warmer/deeper" steps and
+ * two "brighter/higher" steps. 0.15 spacing keeps adjacent presets
+ * audibly distinct (the JND threshold for pitch shifts on a male
+ * narrator voice in informal A/B is ≈ 0.05-0.08; 0.15 keeps every
+ * step a clearly-different reading).
+ *
+ * Exposed `internal` so [PlayerQuickChipsTest] / new chip tests can
+ * iterate them without instantiating Compose.
+ */
+internal val PITCH_PRESETS: List<Float> = listOf(0.7f, 0.85f, 1.0f, 1.15f, 1.3f)
+
+/**
+ * Pitch preset selection epsilon. Adjacent presets are 0.15× apart;
+ * 0.02 is well under that (a third of the spacing) so floats from the
+ * slider can't flash two chips at once. Mirrors [SPEED_PRESET_EPSILON]
+ * but at the looser pitch scale.
+ */
+private const val PITCH_PRESET_EPSILON = 0.02f
+
+/**
+ * Pure-logic selection check for [PITCH_PRESETS]. Exposed `internal`
+ * so the unit test can pin the epsilon contract without rendering.
+ */
+internal fun isPitchPresetSelected(current: Float, preset: Float): Boolean =
+    kotlin.math.abs(current - preset) < PITCH_PRESET_EPSILON
+
+/**
+ * Format a pitch preset as a user-facing label: 1.0 → "1×",
+ * 0.7 → "0.7×", 1.15 → "1.15×". Same shape as [formatSpeedPreset]
+ * (whole numbers strip the decimal) but slightly looser since pitch
+ * presets aren't all on a clean 0.25 grid like speed.
+ */
+internal fun formatPitchPreset(preset: Float): String {
+    return if (preset == preset.toInt().toFloat()) {
+        "${preset.toInt()}×"
+    } else {
+        "${"%.2f".format(preset).trimEnd('0').trimEnd('.')}×"
+    }
+}
+
+/**
+ * Sentence-pause / "voice cadence" presets surfaced as chips in
+ * [VoiceQuickSheetContent]. The continuous slider's range is 0×..4×
+ * (matches the engine's clamp at [`punctuationPauseMultiplier`]).
+ *
+ *  - 0×: rapid listening (no trailing silence — speedrun)
+ *  - 0.5×: brisk (tight cadence, podcast style)
+ *  - 1×: audiobook-tuned default (matches the legacy slider default)
+ *  - 2×: slow narrator (more breathing room between sentences)
+ *  - 3×: very slow (a11y / language-learning cadence)
+ *
+ * The 4× extreme is reachable only through the "Custom…" slider —
+ * the chip set picks five values that span the practical listening
+ * range and skips the asymptote where each sentence is followed by
+ * a noticeable silent gap.
+ */
+internal val PUNCTUATION_PAUSE_PRESETS: List<Float> = listOf(0f, 0.5f, 1f, 2f, 3f)
+
+/**
+ * Selection epsilon for [PUNCTUATION_PAUSE_PRESETS]. Adjacent presets
+ * are 0.5×..1× apart (the gap between 1× and 2× is the widest at
+ * 1.0); 0.05 keeps the chips from flashing two-at-once near the
+ * boundaries.
+ */
+private const val PUNCTUATION_PAUSE_PRESET_EPSILON = 0.05f
+
+/**
+ * Pure-logic selection check for [PUNCTUATION_PAUSE_PRESETS].
+ */
+internal fun isPunctuationPausePresetSelected(current: Float, preset: Float): Boolean =
+    kotlin.math.abs(current - preset) < PUNCTUATION_PAUSE_PRESET_EPSILON
+
+/**
+ * Format a cadence preset as a user-facing label. Same "1×" / "0.5×"
+ * shape as the other preset formatters; whole numbers strip the
+ * decimal so the chip row reads "0× / 0.5× / 1× / 2× / 3×" instead
+ * of "0.00× / 0.50× / 1.00× / 2.00× / 3.00×".
+ */
+internal fun formatPunctuationPausePreset(preset: Float): String {
     return if (preset == preset.toInt().toFloat()) {
         "${preset.toInt()}×"
     } else {

--- a/feature/src/main/kotlin/in/jphe/storyvox/feature/reader/VoiceQuickSheet.kt
+++ b/feature/src/main/kotlin/in/jphe/storyvox/feature/reader/VoiceQuickSheet.kt
@@ -8,6 +8,8 @@ import androidx.compose.animation.shrinkVertically
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.ExperimentalLayoutApi
+import androidx.compose.foundation.layout.FlowRow
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
@@ -22,6 +24,7 @@ import androidx.compose.material.icons.outlined.ExpandMore
 import androidx.compose.material.icons.outlined.RecordVoiceOver
 import androidx.compose.material.icons.outlined.Tune
 import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.FilterChip
 import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Slider
@@ -68,7 +71,7 @@ import `in`.jphe.storyvox.ui.theme.LocalSpacing
  * for continuous live-tune (cheap per-call), mirroring the Player
  * Options sheet's pattern documented in AudiobookView.kt.
  */
-@OptIn(ExperimentalMaterial3Api::class)
+@OptIn(ExperimentalMaterial3Api::class, ExperimentalLayoutApi::class)
 @Composable
 internal fun VoiceQuickSheetContent(
     state: UiPlaybackState,
@@ -85,6 +88,17 @@ internal fun VoiceQuickSheetContent(
 ) {
     val spacing = LocalSpacing.current
     var advancedOpen by remember { mutableStateOf(false) }
+    // #527 follow-up — chip-first quick sheet. Each tuning row is a
+    // chip preset row (one tap, persisted immediately) with a
+    // "Custom…" toggle that reveals the continuous slider for users
+    // who want fine-grained control. Default-closed: the chips cover
+    // the audit benchmark set (Spotify / Apple Music / Pocket Casts /
+    // Libby) so most listeners never need the slider. The slider
+    // stays available behind the toggle so we don't strip the
+    // continuous-knob path from anyone who currently relies on it.
+    var speedSliderOpen by remember { mutableStateOf(false) }
+    var pitchSliderOpen by remember { mutableStateOf(false) }
+    var pausesSliderOpen by remember { mutableStateOf(false) }
 
     Column(
         modifier = Modifier
@@ -94,17 +108,40 @@ internal fun VoiceQuickSheetContent(
         verticalArrangement = Arrangement.spacedBy(spacing.md),
     ) {
         // ── 1. Speed (most-used) ───────────────────────────────────
+        // Chip presets first; "Custom…" expands the continuous slider
+        // below. The chip presets are the *fast path* — one tap and
+        // the value is committed immediately. The slider stays
+        // available for fine-tuning between presets.
         QuickSheetHeader("Speed", "${"%.2f".format(state.speed)}×")
-        Slider(
-            value = state.speed,
-            onValueChange = onSetSpeed,
-            onValueChangeFinished = { onPersistSpeed(state.speed) },
-            valueRange = 0.5f..3.0f,
-            modifier = Modifier.semantics {
-                contentDescription = "Speech speed"
-                stateDescription = "%.2f times".format(state.speed)
+        QuickSheetPresetChipRow(
+            presets = SPEED_PRESETS,
+            isSelected = { preset -> isSpeedPresetSelected(state.speed, preset) },
+            label = ::formatSpeedPreset,
+            contentDescriptionFor = { preset ->
+                "Playback speed ${formatSpeedPreset(preset)}"
             },
+            onPick = { preset ->
+                // Discrete preset → commit immediately (the user
+                // expressed intent exactly). Mirrors the
+                // [PlayerQuickChips] persistence pattern.
+                onSetSpeed(preset)
+                onPersistSpeed(preset)
+            },
+            customExpanded = speedSliderOpen,
+            onToggleCustom = { speedSliderOpen = !speedSliderOpen },
         )
+        AnimatedVisibility(visible = speedSliderOpen) {
+            Slider(
+                value = state.speed,
+                onValueChange = onSetSpeed,
+                onValueChangeFinished = { onPersistSpeed(state.speed) },
+                valueRange = 0.5f..3.0f,
+                modifier = Modifier.semantics {
+                    contentDescription = "Speech speed"
+                    stateDescription = "%.2f times".format(state.speed)
+                },
+            )
+        }
 
         // ── 2. Pitch ───────────────────────────────────────────────
         // Hidden on Media3-routed live audio (#373) — Sonic pitch-shifting
@@ -112,16 +149,32 @@ internal fun VoiceQuickSheetContent(
         // Hiding rather than disabling keeps the sheet visually clean.
         if (!state.isLiveAudioChapter) {
             QuickSheetHeader("Pitch", "${"%.2f".format(state.pitch)}×")
-            Slider(
-                value = state.pitch,
-                onValueChange = onSetPitch,
-                onValueChangeFinished = { onPersistPitch(state.pitch) },
-                valueRange = 0.6f..1.4f,
-                modifier = Modifier.semantics {
-                    contentDescription = "Pitch"
-                    stateDescription = "%.2f, neutral at one".format(state.pitch)
+            QuickSheetPresetChipRow(
+                presets = PITCH_PRESETS,
+                isSelected = { preset -> isPitchPresetSelected(state.pitch, preset) },
+                label = ::formatPitchPreset,
+                contentDescriptionFor = { preset ->
+                    "Pitch ${formatPitchPreset(preset)}"
                 },
+                onPick = { preset ->
+                    onSetPitch(preset)
+                    onPersistPitch(preset)
+                },
+                customExpanded = pitchSliderOpen,
+                onToggleCustom = { pitchSliderOpen = !pitchSliderOpen },
             )
+            AnimatedVisibility(visible = pitchSliderOpen) {
+                Slider(
+                    value = state.pitch,
+                    onValueChange = onSetPitch,
+                    onValueChangeFinished = { onPersistPitch(state.pitch) },
+                    valueRange = 0.6f..1.4f,
+                    modifier = Modifier.semantics {
+                        contentDescription = "Pitch"
+                        stateDescription = "%.2f, neutral at one".format(state.pitch)
+                    },
+                )
+            }
         }
 
         // ── 3. Voice picker chip ───────────────────────────────────
@@ -159,20 +212,42 @@ internal fun VoiceQuickSheetContent(
         }
 
         // ── 4. Pause / sentence silence (#109) ─────────────────────
-        // Engine clamps to [0..4]; the slider matches Settings → Voice
-        // & Playback's PunctuationPauseSlider range. 0× = no trailing
-        // silence (rapid listening); 1× = audiobook-tuned default;
-        // higher = slow, narrator-cadence pacing.
+        // Engine clamps to [0..4]; chip presets cover the practical
+        // listening range (0×..3×). The 4× extreme is reachable via
+        // "Custom…" for users who want extra-slow narrator cadence.
+        // 0× = rapid listening; 1× = audiobook-tuned default;
+        // 2-3× = slow, a11y / language-learning cadence.
         QuickSheetHeader("Sentence silence", "${"%.2f".format(punctuationPauseMultiplier)}×")
-        Slider(
-            value = punctuationPauseMultiplier,
-            onValueChange = onSetPunctuationPause,
-            valueRange = 0f..4f,
-            modifier = Modifier.semantics {
-                contentDescription = "Inter-sentence pause"
-                stateDescription = "%.2f times".format(punctuationPauseMultiplier)
+        QuickSheetPresetChipRow(
+            presets = PUNCTUATION_PAUSE_PRESETS,
+            isSelected = { preset ->
+                isPunctuationPausePresetSelected(punctuationPauseMultiplier, preset)
             },
+            label = ::formatPunctuationPausePreset,
+            contentDescriptionFor = { preset ->
+                "Sentence silence ${formatPunctuationPausePreset(preset)}"
+            },
+            onPick = { preset ->
+                // The slider's onValueChange was both live AND persist
+                // (Settings VM persists on the same callback the engine
+                // listens on). Chip taps keep that single-callback
+                // semantic — the engine + the pref key both update.
+                onSetPunctuationPause(preset)
+            },
+            customExpanded = pausesSliderOpen,
+            onToggleCustom = { pausesSliderOpen = !pausesSliderOpen },
         )
+        AnimatedVisibility(visible = pausesSliderOpen) {
+            Slider(
+                value = punctuationPauseMultiplier,
+                onValueChange = onSetPunctuationPause,
+                valueRange = 0f..4f,
+                modifier = Modifier.semantics {
+                    contentDescription = "Inter-sentence pause"
+                    stateDescription = "%.2f times".format(punctuationPauseMultiplier)
+                },
+            )
+        }
 
         // ── 5. Sonic high-quality toggle (#193) ────────────────────
         // Persisted-only; engine reads at the start of the next chapter
@@ -289,6 +364,67 @@ private fun QuickSheetHeader(title: String, valueLabel: String?) {
                 color = MaterialTheme.colorScheme.onSurfaceVariant,
             )
         }
+    }
+}
+
+/**
+ * #527 follow-up — chip-preset row used by every continuous-tuning
+ * control in the quick sheet (Speed, Pitch, Sentence silence). Renders
+ * `presets.size` [FilterChip]s plus a trailing "Custom…" chip that
+ * toggles the slider's visibility (see callers — each row's slider
+ * is wrapped in an [AnimatedVisibility] gated on `customExpanded`).
+ *
+ * The chip row uses [FlowRow] so a 5-chip preset list + a Custom chip
+ * wraps gracefully on narrow phones (R5CRB0W66MK reports a Compose
+ * width of ~360 dp; the chip row needs at least 2 rows of wrapping
+ * when all 6 chips have label "1.25×"-shape text).
+ */
+@OptIn(ExperimentalLayoutApi::class, ExperimentalMaterial3Api::class)
+@Composable
+private fun QuickSheetPresetChipRow(
+    presets: List<Float>,
+    isSelected: (Float) -> Boolean,
+    label: (Float) -> String,
+    contentDescriptionFor: (Float) -> String,
+    onPick: (Float) -> Unit,
+    customExpanded: Boolean,
+    onToggleCustom: () -> Unit,
+) {
+    val spacing = LocalSpacing.current
+    FlowRow(
+        modifier = Modifier.fillMaxWidth(),
+        horizontalArrangement = Arrangement.spacedBy(spacing.xs),
+        verticalArrangement = Arrangement.spacedBy(spacing.xs),
+    ) {
+        presets.forEach { preset ->
+            FilterChip(
+                selected = isSelected(preset),
+                onClick = { onPick(preset) },
+                label = { Text(label(preset)) },
+                colors = brassFilterChipColors(),
+                modifier = Modifier.semantics {
+                    contentDescription = contentDescriptionFor(preset)
+                },
+            )
+        }
+        // "Custom…" chip — secondary affordance for users who want the
+        // continuous-knob path. Selected-state reflects expanded-ness
+        // so the chip's brass fill reads as "the slider is open right
+        // now". Doesn't itself change the value — just opens / closes
+        // the slider below.
+        FilterChip(
+            selected = customExpanded,
+            onClick = onToggleCustom,
+            label = { Text(if (customExpanded) "Custom" else "Custom…") },
+            colors = brassFilterChipColors(),
+            modifier = Modifier.semantics {
+                contentDescription = if (customExpanded) {
+                    "Hide custom slider"
+                } else {
+                    "Show custom slider"
+                }
+            },
+        )
     }
 }
 

--- a/feature/src/test/kotlin/in/jphe/storyvox/feature/reader/VoiceQuickSheetChipPresetsTest.kt
+++ b/feature/src/test/kotlin/in/jphe/storyvox/feature/reader/VoiceQuickSheetChipPresetsTest.kt
@@ -1,0 +1,216 @@
+package `in`.jphe.storyvox.feature.reader
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * #527 follow-up — chip-preset rows in [VoiceQuickSheetContent].
+ *
+ * The quick sheet's continuous-tuning controls (Speed / Pitch /
+ * Sentence silence) were converted from sliders to chip-preset rows
+ * plus a "Custom…" toggle that re-reveals the slider. These tests
+ * pin the preset sets, the selection epsilons, and the label
+ * formatters so a future refactor that scrambles the chip layout
+ * has to update the test + acknowledge the UX intent.
+ *
+ * Pure-logic, JVM-only. The chip composables themselves aren't
+ * rendered here (feature/build.gradle.kts uses
+ * `isReturnDefaultValues = true`); the contract under test is the
+ * presets + selection logic.
+ */
+class VoiceQuickSheetChipPresetsTest {
+
+    // ── Pitch chips ────────────────────────────────────────────────
+
+    /**
+     * Pitch presets bracket the engine's 0.6×..1.4× Sonic-musical
+     * zone. Five anchors: two warm/deeper, neutral, two bright/higher.
+     * 0.15 spacing keeps adjacent presets audibly distinct (the JND
+     * threshold for pitch shifts on narrator voice in informal A/B
+     * is ≈ 0.05-0.08; 0.15 keeps every step a clearly-different read).
+     */
+    @Test
+    fun `pitch presets cover the Sonic musical zone with five anchors`() {
+        assertEquals(
+            listOf(0.7f, 0.85f, 1.0f, 1.15f, 1.3f),
+            PITCH_PRESETS,
+        )
+    }
+
+    @Test
+    fun `pitch preset exactly matches selects`() {
+        assertTrue(isPitchPresetSelected(1.0f, 1.0f))
+        assertTrue(isPitchPresetSelected(0.7f, 0.7f))
+        assertTrue(isPitchPresetSelected(1.3f, 1.3f))
+    }
+
+    @Test
+    fun `pitch preset selection tolerates float rounding`() {
+        // The continuous slider's floats can land at 1.150001f from
+        // ribbon-fine drags; the chip must still flash selected.
+        assertTrue(isPitchPresetSelected(1.1500001f, 1.15f))
+        assertTrue(isPitchPresetSelected(0.99995f, 1.0f))
+    }
+
+    @Test
+    fun `pitch preset selection rejects clearly different pitches`() {
+        assertFalse(isPitchPresetSelected(1.0f, 1.15f))
+        assertFalse(isPitchPresetSelected(0.8f, 0.85f))
+        assertFalse(isPitchPresetSelected(1.4f, 1.3f))
+    }
+
+    /**
+     * Adjacent presets are 0.15 apart (well above the 0.02 epsilon),
+     * so a pitch between 1.0 and 1.15 shouldn't flash both chips.
+     * Pinning so future preset spacing tweaks can't silently break.
+     */
+    @Test
+    fun `pitch preset selection never flashes adjacent presets together`() {
+        val between = 1.075f
+        val matches = PITCH_PRESETS.count { isPitchPresetSelected(between, it) }
+        assertEquals(
+            "Pitch at 1.075 should not be epsilon-close to ANY preset — " +
+                "if this fails, either epsilon is too generous or two presets " +
+                "are too close together.",
+            0, matches,
+        )
+    }
+
+    @Test
+    fun `format pitch preset strips trailing zeroes from whole numbers`() {
+        assertEquals("1×", formatPitchPreset(1.0f))
+    }
+
+    @Test
+    fun `format pitch preset keeps two decimals for fractional presets`() {
+        assertEquals("0.7×", formatPitchPreset(0.7f))
+        assertEquals("0.85×", formatPitchPreset(0.85f))
+        assertEquals("1.15×", formatPitchPreset(1.15f))
+        assertEquals("1.3×", formatPitchPreset(1.3f))
+    }
+
+    // ── Sentence-silence chips ─────────────────────────────────────
+
+    /**
+     * Cadence presets cover the practical 0×..3× listening range.
+     * The slider's 4× extreme is reachable via "Custom…" for users
+     * who want extra-slow narrator cadence. Five anchors:
+     * 0× (speedrun) / 0.5× (brisk) / 1× (default) / 2× (slow) /
+     * 3× (a11y / language-learning).
+     */
+    @Test
+    fun `cadence presets cover the practical listening range with five anchors`() {
+        assertEquals(
+            listOf(0f, 0.5f, 1f, 2f, 3f),
+            PUNCTUATION_PAUSE_PRESETS,
+        )
+    }
+
+    @Test
+    fun `cadence preset exactly matches selects`() {
+        assertTrue(isPunctuationPausePresetSelected(0f, 0f))
+        assertTrue(isPunctuationPausePresetSelected(1f, 1f))
+        assertTrue(isPunctuationPausePresetSelected(3f, 3f))
+    }
+
+    @Test
+    fun `cadence preset selection tolerates float rounding`() {
+        assertTrue(isPunctuationPausePresetSelected(1.001f, 1f))
+        assertTrue(isPunctuationPausePresetSelected(0.499f, 0.5f))
+    }
+
+    @Test
+    fun `cadence preset selection rejects clearly different multipliers`() {
+        // The 0.5×→1× gap is the tightest at 0.5; epsilon 0.05 means
+        // 1.4 vs 1× is clearly distinct.
+        assertFalse(isPunctuationPausePresetSelected(1.4f, 1f))
+        assertFalse(isPunctuationPausePresetSelected(2.5f, 3f))
+    }
+
+    /**
+     * The 0.5×→1× gap is the tightest at 0.5; a value at 0.75 should
+     * not flash either preset. Pinning so widening the epsilon (or
+     * tightening preset spacing) surfaces the regression.
+     */
+    @Test
+    fun `cadence preset selection never flashes adjacent presets together`() {
+        val between = 0.75f
+        val matches = PUNCTUATION_PAUSE_PRESETS.count {
+            isPunctuationPausePresetSelected(between, it)
+        }
+        assertEquals(
+            "Cadence at 0.75 should not be epsilon-close to ANY preset.",
+            0, matches,
+        )
+    }
+
+    @Test
+    fun `format cadence preset strips trailing zeroes from whole numbers`() {
+        assertEquals("0×", formatPunctuationPausePreset(0f))
+        assertEquals("1×", formatPunctuationPausePreset(1f))
+        assertEquals("2×", formatPunctuationPausePreset(2f))
+        assertEquals("3×", formatPunctuationPausePreset(3f))
+    }
+
+    @Test
+    fun `format cadence preset keeps the half-step decimal`() {
+        assertEquals("0.5×", formatPunctuationPausePreset(0.5f))
+    }
+
+    // ── Cross-row pref-key contract ────────────────────────────────
+
+    /**
+     * The chip-preset path must write to the same callback the slider
+     * used — chip taps invoke `onSetSpeed` / `onSetPitch` /
+     * `onSetPunctuationPause` exactly like the slider's onValueChange
+     * did. This test pins the contract by asserting the speed presets
+     * are floats (not Int — engine API is Float) so a refactor that
+     * accidentally normalises them to Int would break the engine
+     * `setSpeed(Float)` call site silently.
+     */
+    @Test
+    fun `chip preset types match the engine callbacks they invoke`() {
+        // The presets are List<Float> — same type the slider's
+        // onValueChange emits. If this fails the chip rows can't
+        // call onSetSpeed/Pitch/Pause without an implicit conversion.
+        val speedSample: Float = SPEED_PRESETS.first()
+        val pitchSample: Float = PITCH_PRESETS.first()
+        val pauseSample: Float = PUNCTUATION_PAUSE_PRESETS.first()
+        // Compile-time check is the real test; runtime asserts they're
+        // real floats (not boxed Number).
+        assertEquals(0.75f, speedSample, 0.0001f)
+        assertEquals(0.7f, pitchSample, 0.0001f)
+        assertEquals(0f, pauseSample, 0.0001f)
+    }
+
+    /**
+     * Pitch row's "neutral" preset must be 1.0×. The slider in the
+     * pre-chip world had a "▲ 1×" tick anchor in SettingsScreen
+     * (#273) — keeping 1.0 as the chip's neutral preserves the
+     * established "tap once to return to default" pattern.
+     */
+    @Test
+    fun `pitch presets include 1× as the neutral anchor`() {
+        assertTrue(
+            "Pitch presets must include 1.0 as the neutral anchor; " +
+                "users expect a one-tap path back to neutral pitch.",
+            PITCH_PRESETS.any { kotlin.math.abs(it - 1.0f) < 0.0001f },
+        )
+    }
+
+    /**
+     * Cadence row's "default" preset must be 1.0× — matches the
+     * legacy slider's audiobook-tuned default. Lose this and users
+     * who tap the "Default" chip get a different cadence than the
+     * one Settings displays as the natural value.
+     */
+    @Test
+    fun `cadence presets include 1× as the default anchor`() {
+        assertTrue(
+            "Cadence presets must include 1.0 as the audiobook default.",
+            PUNCTUATION_PAUSE_PRESETS.any { kotlin.math.abs(it - 1.0f) < 0.0001f },
+        )
+    }
+}


### PR DESCRIPTION
## Summary

- **Bug 1 fix — chips invisible on phone form factor.** Root cause: the player Column was `fillMaxSize()` with no scroll. ~820 dp of content fit in the tablet's ~1006 dp viewport but overflowed the phone's ~880 dp viewport, with the speed + sleep chip rows measured into zero height. Fix: wrap the Column in `verticalScroll(rememberScrollState())`. Modifier order matters — `fillMaxWidth().verticalScroll(state).padding()` (NOT `fillMaxSize().verticalScroll()`, which silently zeroes children due to the conflict between "fill parent's height" and "vertical is unbounded").
- **Bug 2 — chips replace sliders in `VoiceQuickSheet`.** Speed, Pitch, and Sentence-silence rows are now chip-preset rows with a "Custom…" chip that re-reveals the continuous slider behind `AnimatedVisibility`. Chip taps invoke the same `onSetSpeed`/`onPersistSpeed`/`onSetPitch`/`onPersistPitch`/`onSetPunctuationPause` callbacks the slider's `onValueChange*` did, so existing user prefs migrate seamlessly.
- **New presets** (co-located with the existing `SPEED_PRESETS` in `AudiobookView.kt`):
  - `PITCH_PRESETS = [0.7, 0.85, 1.0, 1.15, 1.3]` — 0.15 spacing keeps adjacent presets audibly distinct (JND ≈ 0.05-0.08 on narrator voice)
  - `PUNCTUATION_PAUSE_PRESETS = [0, 0.5, 1, 2, 3]` — covers practical 0×..3× listening range; the 4× extreme is reachable via "Custom…"
- **`brassFilterChipColors()` exposed `private` → `internal`** so VoiceQuickSheet shares the player surface chip palette without duplication.

## Test plan

- [x] `./gradlew :feature:testDebugUnitTest :app:testDebugUnitTest` — green
- [x] `./gradlew :app:assembleDebug` — green
- [x] **Phone (R5CRB0W66MK, Z Flip3, 1080×2640)** — installed v0.5.57 + this PR's APK; `adb shell uiautomator dump` confirms all 12 player chips visible after scroll (`0.75×`, `1×`, `1.25×`, `1.5×`, `2×`, `Off`, `5m`, `15m`, `30m`, `60m`, `End`, `Default`). Pre-fix, ONLY `Default` was visible (Pick voice chip with bounds `[0,0][0,0]`).
- [x] **Tablet (R83W80CAFZB, 800×1340)** — confirmed all 12 player chips render without scrolling (existing behavior preserved).
- [x] **Voice quick sheet on both devices** — 15 preset chips visible (5 speed × 5 pitch × 5 cadence) + 3 "Custom…" toggles. Tapping `Custom…` reveals the slider with content-desc `"Speech speed"` / `"Pitch"` / `"Inter-sentence pause"`. Tapping a chip persists immediately (Speed header label flipped from `1.00×` → `1.25×` after tapping the `1.25×` chip).
- [x] New `VoiceQuickSheetChipPresetsTest` pins preset sets, selection epsilons, format-label contracts, and "neutral 1× is included" invariants for the pitch + cadence rows.

Closes the on-device chip-render regression for narrow displays + the slider→chip discoverability gap from the 2026-05-15 player audit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)