### PR TITLE
fix: phone narrow-width clipping + Emergency Help dial fallback — closes #532 #533 #534 #535 #546

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -18,6 +18,22 @@
     <uses-permission android:name="android.permission.POST_NOTIFICATIONS" />
     <uses-permission android:name="android.permission.RECEIVE_BOOT_COMPLETED" />
 
+    <!-- Issue #546 — telephony is OPTIONAL. The TechEmpower Emergency
+         Help card surfaces 988 / 211 / 911 dial affordances that only
+         work on devices with telephony hardware (phones, not WiFi-only
+         tablets). Marking `required="false"` keeps storyvox eligible
+         for install on tablets in the Play Store; the in-app
+         [dialOrSurfaceFallback] helper probes
+         PackageManager.FEATURE_TELEPHONY at runtime and surfaces a
+         "this device can't make calls" dialog with copy-to-clipboard
+         + web-fallback when telephony is absent (rather than letting
+         ACTION_DIAL route the user to the AOSP contact picker — the
+         documented default fallback, and the wrong UX for a crisis
+         surface). -->
+    <uses-feature
+        android:name="android.hardware.telephony"
+        android:required="false" />
+
     <application
         android:name=".StoryvoxApp"
         android:allowBackup="true"

--- a/feature/src/main/kotlin/in/jphe/storyvox/feature/browse/BrowseScreen.kt
+++ b/feature/src/main/kotlin/in/jphe/storyvox/feature/browse/BrowseScreen.kt
@@ -204,13 +204,18 @@ fun BrowseScreen(
         ) {
             // Scrollable so 'Popular' / 'Best Rated' don't truncate when
             // sharing the row with the filter funnel on narrow phones.
-            // edgePadding=0 keeps the active-tab indicator flush with the
-            // left edge to match the tighter tab look from the previous
-            // SecondaryTabRow.
+            //
+            // Issue #535 — edgePadding bumped from 0 to spacing.md so
+            // the rightmost AO3 tab ("Marked") lands as an
+            // obviously-partial chip on Flip3 narrow rather than
+            // sitting 5dp from the screen edge (which reads as a
+            // rendering glitch and hides the scroll affordance). Same
+            // discoverability fix the Library tab row got for #532 and
+            // the VoiceLibrary chip row got for #420.
             SecondaryScrollableTabRow(
                 selectedTabIndex = supportedTabs.indexOf(state.tab).coerceAtLeast(0),
                 modifier = Modifier.weight(1f),
-                edgePadding = 0.dp,
+                edgePadding = spacing.md,
             ) {
                 supportedTabs.forEach { tab ->
                     Tab(

--- a/feature/src/main/kotlin/in/jphe/storyvox/feature/library/LibraryScreen.kt
+++ b/feature/src/main/kotlin/in/jphe/storyvox/feature/library/LibraryScreen.kt
@@ -13,6 +13,7 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.grid.GridCells
 import androidx.compose.foundation.lazy.grid.LazyVerticalGrid
@@ -176,6 +177,16 @@ fun LibraryScreen(
             CenterAlignedTopAppBar(
                 title = { Text("Library", style = MaterialTheme.typography.titleMedium) },
                 actions = {
+                    // Issue #533 — top-bar action icons used to pack
+                    // flush together at 0dp gap on the Flip3 (1080dp
+                    // narrow). Four 48dp Boxes (2x TechEmpower help +
+                    // SyncCloudIcon + Settings IconButton) lined up
+                    // edge-to-edge made mis-taps trivial. Inserting an
+                    // 8dp Spacer between each icon adds the visual
+                    // breathing room (and tap-target separation) that
+                    // Material 3 spec recommends for grouped action
+                    // icons without bumping the row past Flip3 width.
+                    //
                     // Issue #517 — TechEmpower help icons (phone +
                     // Discord) — leftmost so the cross-cutting "I
                     // need help" affordances read before the
@@ -184,6 +195,7 @@ fun LibraryScreen(
                     // opens the peer-support invite URL. See
                     // [TechEmpowerHelpIcons] for the design rationale.
                     TechEmpowerHelpIcons()
+                    Spacer(Modifier.width(spacing.xs))
                     // Issue #500 — brass cloud-icon affordance for the
                     // InstantDB sync surface. Sits to the LEFT of the
                     // Settings gear so the "primary" cross-cutting state
@@ -195,6 +207,7 @@ fun LibraryScreen(
                     `in`.jphe.storyvox.feature.sync.SyncCloudIcon(
                         onClick = { syncSheetOpen = true },
                     )
+                    Spacer(Modifier.width(spacing.xs))
                     IconButton(onClick = onOpenSettings) {
                         Icon(Icons.Outlined.Settings, contentDescription = "Settings")
                     }
@@ -225,10 +238,20 @@ fun LibraryScreen(
             // on Tab.Library — on Tab.Browse / Follows the embedded
             // surfaces own their own scoping, on Tab.Inbox / History
             // the chip row isn't meaningful.
+            // Issue #532 — the tab row used to use `edgePadding = 0.dp`
+            // which lined the rightmost tab flush with the screen edge.
+            // On the Flip3 cover (1080dp narrow) only 4 of the 5 tabs
+            // fit visibly with no visual hint that "History" (the
+            // fifth) is reachable by horizontal swipe. Bumping
+            // edgePadding to spacing.md (16dp) lets the rightmost
+            // visible tab land as an obviously-partial chip — the same
+            // "scroll for more →" discoverability fix the
+            // VoiceLibrary chip row uses (#420 + #534). Scroll
+            // mechanics were already wired; this is the discovery fix.
             SecondaryScrollableTabRow(
                 selectedTabIndex = state.tab.ordinal,
                 modifier = Modifier.fillMaxWidth(),
-                edgePadding = 0.dp,
+                edgePadding = spacing.md,
             ) {
                 LibraryTab.entries.forEach { tab ->
                     Tab(

--- a/feature/src/main/kotlin/in/jphe/storyvox/feature/techempower/TechEmpowerHelpIcons.kt
+++ b/feature/src/main/kotlin/in/jphe/storyvox/feature/techempower/TechEmpowerHelpIcons.kt
@@ -1,24 +1,27 @@
 package `in`.jphe.storyvox.feature.techempower
 
-import android.content.Intent
-import android.net.Uri
 import androidx.compose.foundation.ExperimentalFoundationApi
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.combinedClickable
 import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Forum
 import androidx.compose.material.icons.filled.Phone
 import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.semantics.Role
 import androidx.compose.ui.unit.dp
-import `in`.jphe.storyvox.data.TechEmpowerLinks
 
 /**
  * Issue #517 — paired brass-tinted help icons (Phone + Discord Forum)
@@ -52,44 +55,42 @@ import `in`.jphe.storyvox.data.TechEmpowerLinks
 fun TechEmpowerHelpIcons() {
     val context = LocalContext.current
 
+    // Issue #546 — fallback dialog state for the top-app-bar phone
+    // icon. Without this, a tap on a WiFi-only tablet routes to the
+    // contact picker. The shared [NoTelephonyDialog]-equivalent path
+    // is owned by [TechEmpowerHomeScreen]; here we use the same
+    // [dialOrSurfaceFallback] helper and surface the dialog locally
+    // so Library users get the same protection.
+    var noTelephonyTarget by remember { mutableStateOf<EmergencyTarget?>(null) }
+
     // ─── Call 211 (primary) / 988 (long-press) ───────────────────────
     // tel: URIs go through ACTION_DIAL so the user lands in the dialer
     // with the number pre-filled but NOT auto-dialled — accidental
     // top-app-bar taps surface as "huh, the dialer opened" rather than
     // an actual phone call. ACTION_CALL would require CALL_PHONE
     // permission and is the wrong UX for an in-bar shortcut.
+    //
+    // Issue #546 — both tap and long-press route through
+    // [dialOrSurfaceFallback] so devices without telephony land on the
+    // explanatory fallback dialog instead of the AOSP contact picker.
     Box(
         modifier = Modifier
             .size(48.dp)
             .combinedClickable(
                 role = Role.Button,
                 onClick = {
-                    runCatching {
-                        context.startActivity(
-                            Intent(
-                                Intent.ACTION_DIAL,
-                                Uri.parse(
-                                    TechEmpowerLinks.telUri(
-                                        TechEmpowerLinks.PRIMARY_HELP_NUMBER,
-                                    ),
-                                ),
-                            ).apply { addFlags(Intent.FLAG_ACTIVITY_NEW_TASK) },
-                        )
-                    }
+                    dialOrSurfaceFallback(
+                        context = context,
+                        target = EmergencyTarget.Help211,
+                        onNoTelephony = { noTelephonyTarget = it },
+                    )
                 },
                 onLongClick = {
-                    runCatching {
-                        context.startActivity(
-                            Intent(
-                                Intent.ACTION_DIAL,
-                                Uri.parse(
-                                    TechEmpowerLinks.telUri(
-                                        TechEmpowerLinks.CRISIS_HELP_NUMBER,
-                                    ),
-                                ),
-                            ).apply { addFlags(Intent.FLAG_ACTIVITY_NEW_TASK) },
-                        )
-                    }
+                    dialOrSurfaceFallback(
+                        context = context,
+                        target = EmergencyTarget.Crisis988,
+                        onNoTelephony = { noTelephonyTarget = it },
+                    )
                 },
             ),
         contentAlignment = Alignment.Center,
@@ -102,6 +103,13 @@ fun TechEmpowerHelpIcons() {
             modifier = Modifier.size(24.dp),
         )
     }
+
+    // Issue #533 — 8dp gap between the phone and Discord icons. The
+    // two 48dp Boxes used to pack flush together, making mis-taps
+    // trivial on the Flip3 (1080dp narrow). Spacer keeps both icons
+    // at their full 48dp tap targets while giving the user enough
+    // visual + finger separation to choose one deliberately.
+    Spacer(Modifier.width(8.dp))
 
     // ─── Open peer-support Discord ───────────────────────────────────
     // The Forum icon is the most thematically-correct standard Material
@@ -123,6 +131,18 @@ fun TechEmpowerHelpIcons() {
             contentDescription = "Open the TechEmpower peer-support Discord.",
             tint = MaterialTheme.colorScheme.primary,
             modifier = Modifier.size(24.dp),
+        )
+    }
+
+    // Issue #546 — render the fallback dialog when telephony is
+    // absent. Same content/affordances as [TechEmpowerHomeScreen]'s
+    // dialog so users see consistent recovery regardless of which
+    // entry point they tapped (top-bar icon vs Emergency Help card).
+    val target = noTelephonyTarget
+    if (target != null) {
+        NoTelephonyFallbackDialog(
+            target = target,
+            onDismiss = { noTelephonyTarget = null },
         )
     }
 }

--- a/feature/src/main/kotlin/in/jphe/storyvox/feature/techempower/TechEmpowerHomeScreen.kt
+++ b/feature/src/main/kotlin/in/jphe/storyvox/feature/techempower/TechEmpowerHomeScreen.kt
@@ -1,7 +1,5 @@
 package `in`.jphe.storyvox.feature.techempower
 
-import android.content.Intent
-import android.net.Uri
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
 import androidx.compose.foundation.border
@@ -18,7 +16,6 @@ import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
-import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.LazyRow
 import androidx.compose.foundation.lazy.grid.GridCells
 import androidx.compose.foundation.lazy.grid.GridItemSpan
@@ -38,6 +35,10 @@ import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
@@ -98,6 +99,12 @@ fun TechEmpowerHomeScreen(
     val spacing = LocalSpacing.current
     val context = LocalContext.current
 
+    // Issue #546 — when telephony is absent (WiFi-only tablets), pop a
+    // fallback dialog instead of routing the user into the contact
+    // picker. Hoisted to the screen scope so all dial entry points
+    // (Call 211 card + each EmergencyDialButton) can drive it.
+    var noTelephonyTarget by remember { mutableStateOf<EmergencyTarget?>(null) }
+
     Scaffold(
         topBar = {
             CenterAlignedTopAppBar(
@@ -156,24 +163,22 @@ fun TechEmpowerHomeScreen(
                     onClick = { launchDiscord(context) },
                 )
             }
+            // Issue #546 — surface a "no-telephony" fallback dialog if
+            // the device can't dial. Without this guard, WiFi-only
+            // tablets like the Tab A7 Lite route ACTION_DIAL to the
+            // system Contacts picker — exactly the wrong UX when the
+            // user explicitly wants to reach 211 / 988 / 911.
             item {
                 TechEmpowerCard(
                     title = "Call 211",
                     body = "Local help — housing, food, utilities, mental health referrals via United Way.",
                     icon = Icons.Filled.Phone,
                     onClick = {
-                        runCatching {
-                            context.startActivity(
-                                Intent(
-                                    Intent.ACTION_DIAL,
-                                    Uri.parse(
-                                        TechEmpowerLinks.telUri(
-                                            TechEmpowerLinks.PRIMARY_HELP_NUMBER,
-                                        ),
-                                    ),
-                                ).apply { addFlags(Intent.FLAG_ACTIVITY_NEW_TASK) },
-                            )
-                        }
+                        dialOrSurfaceFallback(
+                            context = context,
+                            target = EmergencyTarget.Help211,
+                            onNoTelephony = { noTelephonyTarget = it },
+                        )
                     },
                 )
             }
@@ -184,7 +189,9 @@ fun TechEmpowerHomeScreen(
             // the full row width keeps the 988 / 211 / 911 trio
             // visible without scrolling on the Flip3 cover.
             item(span = { GridItemSpan(maxLineSpan) }) {
-                TechEmpowerEmergencyCard()
+                TechEmpowerEmergencyCard(
+                    onNoTelephony = { noTelephonyTarget = it },
+                )
             }
             item {
                 TechEmpowerCard(
@@ -200,6 +207,21 @@ fun TechEmpowerHomeScreen(
                 FeaturedGuidesStrip(onOpenFiction = onOpenFiction)
             }
         }
+    }
+
+    // Issue #546 — no-telephony fallback dialog. The user explicitly
+    // asked to dial a helpline; on a WiFi-only tablet we owe them a
+    // clear "this device can't make calls" message plus actionable
+    // recovery (copy the number, open the helpline's web resource).
+    // Routing them to a contact picker — the AOSP default fallback
+    // for ACTION_DIAL on a device without telephony — is dangerous in
+    // a crisis.
+    val target = noTelephonyTarget
+    if (target != null) {
+        NoTelephonyFallbackDialog(
+            target = target,
+            onDismiss = { noTelephonyTarget = null },
+        )
     }
 }
 
@@ -336,7 +358,9 @@ private fun TechEmpowerCard(
  * [TechEmpowerLinks.EMERGENCY_DISPATCH_NUMBER] kdoc).
  */
 @Composable
-private fun TechEmpowerEmergencyCard() {
+private fun TechEmpowerEmergencyCard(
+    onNoTelephony: (EmergencyTarget) -> Unit,
+) {
     val spacing = LocalSpacing.current
     val brass = MaterialTheme.colorScheme.primary
     val substrate = MaterialTheme.colorScheme.surfaceContainerHigh
@@ -383,21 +407,18 @@ private fun TechEmpowerEmergencyCard() {
         )
         // ─── 988 — Suicide & Crisis Lifeline (top of the list) ────
         EmergencyDialButton(
-            number = TechEmpowerLinks.CRISIS_HELP_NUMBER,
-            label = "Suicide & Crisis Lifeline",
-            body = "National 24/7 mental health crisis support.",
+            target = EmergencyTarget.Crisis988,
+            onNoTelephony = onNoTelephony,
         )
         // ─── 211 — United Way social services ─────────────────────
         EmergencyDialButton(
-            number = TechEmpowerLinks.PRIMARY_HELP_NUMBER,
-            label = "United Way social services",
-            body = "Housing, food, utilities, mental health referrals.",
+            target = EmergencyTarget.Help211,
+            onNoTelephony = onNoTelephony,
         )
         // ─── 911 — Emergency dispatch (last on purpose) ───────────
         EmergencyDialButton(
-            number = TechEmpowerLinks.EMERGENCY_DISPATCH_NUMBER,
-            label = "Emergency dispatch",
-            body = "Life-threatening situations — police, fire, ambulance.",
+            target = EmergencyTarget.Dispatch911,
+            onNoTelephony = onNoTelephony,
         )
     }
 }
@@ -428,9 +449,8 @@ private fun TechEmpowerEmergencyCard() {
  */
 @Composable
 private fun EmergencyDialButton(
-    number: String,
-    label: String,
-    body: String,
+    target: EmergencyTarget,
+    onNoTelephony: (EmergencyTarget) -> Unit,
 ) {
     val spacing = LocalSpacing.current
     val context = LocalContext.current
@@ -448,14 +468,11 @@ private fun EmergencyDialButton(
             .clickable(
                 role = Role.Button,
                 onClick = {
-                    runCatching {
-                        context.startActivity(
-                            Intent(
-                                Intent.ACTION_DIAL,
-                                Uri.parse(TechEmpowerLinks.telUri(number)),
-                            ).apply { addFlags(Intent.FLAG_ACTIVITY_NEW_TASK) },
-                        )
-                    }
+                    dialOrSurfaceFallback(
+                        context = context,
+                        target = target,
+                        onNoTelephony = onNoTelephony,
+                    )
                 },
             )
             .padding(horizontal = spacing.md, vertical = spacing.sm),
@@ -469,7 +486,7 @@ private fun EmergencyDialButton(
         // body-adjacent surfaces; bumping to Bold would clash with the
         // titleMedium "Emergency Help" header above.
         Text(
-            text = number,
+            text = target.number,
             style = MaterialTheme.typography.headlineSmall,
             color = brass,
             fontWeight = FontWeight.SemiBold,
@@ -481,13 +498,13 @@ private fun EmergencyDialButton(
             verticalArrangement = Arrangement.spacedBy(spacing.xxs),
         ) {
             Text(
-                text = label,
+                text = target.label,
                 style = MaterialTheme.typography.titleSmall,
                 color = brass,
                 fontWeight = FontWeight.SemiBold,
             )
             Text(
-                text = body,
+                text = target.body,
                 style = MaterialTheme.typography.bodySmall,
                 color = MaterialTheme.colorScheme.onSurfaceVariant,
                 maxLines = 2,
@@ -495,6 +512,13 @@ private fun EmergencyDialButton(
         }
     }
 }
+
+// [EmergencyTarget], [dialOrSurfaceFallback], and the no-telephony
+// fallback dialog live in [TechEmpowerIntents.kt] because they're
+// shared between the Emergency Help card here AND the top-app-bar
+// phone icon in [TechEmpowerHelpIcons]. Keeping them in one place
+// means a behavioural change (e.g., add a new helpline, swap a
+// fallback URL) is a one-file edit.
 
 /**
  * Horizontal strip of the eight hand-curated TechEmpower guides. The

--- a/feature/src/main/kotlin/in/jphe/storyvox/feature/techempower/TechEmpowerIntents.kt
+++ b/feature/src/main/kotlin/in/jphe/storyvox/feature/techempower/TechEmpowerIntents.kt
@@ -1,10 +1,36 @@
 package `in`.jphe.storyvox.feature.techempower
 
 import android.content.ActivityNotFoundException
+import android.content.ClipData
+import android.content.ClipboardManager
 import android.content.Context
 import android.content.Intent
+import android.content.pm.PackageManager
 import android.net.Uri
+import android.widget.Toast
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.ContentCopy
+import androidx.compose.material.icons.filled.OpenInNew
+import androidx.compose.material3.AlertDialog
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.unit.dp
 import `in`.jphe.storyvox.data.TechEmpowerLinks
+import `in`.jphe.storyvox.ui.theme.LocalSpacing
 
 /**
  * Issue #517 — shared intent launchers for the TechEmpower surfaces.
@@ -46,4 +72,219 @@ internal fun launchDiscord(context: Context) {
             )
         }
     }
+}
+
+/**
+ * Issue #546 — single source of truth for the three Emergency Help
+ * helplines + the everyday "Call 211" card. Each target bundles the
+ * dial number with the label/body shown in the in-card chip and the
+ * web fallback URL surfaced when telephony is unavailable.
+ *
+ * The web fallback is what saves the user on a WiFi-only tablet: a
+ * `tel:` URI on a device without telephony routes to the AOSP contact
+ * picker by default — which is exactly the wrong landing for someone
+ * in a crisis. With a web URL in hand we can offer "open in your
+ * browser" as a real alternative to dialling.
+ *
+ * 911 has no real web counterpart (you cannot place an emergency
+ * dispatch through a webpage), so the web fallback is the FCC's
+ * informational page on text-to-911 — the closest the public web gets
+ * to "here is how you reach 911 without a regular voice call".
+ */
+internal enum class EmergencyTarget(
+    val number: String,
+    val label: String,
+    val body: String,
+    val webFallback: String,
+) {
+    Crisis988(
+        number = TechEmpowerLinks.CRISIS_HELP_NUMBER,
+        label = "Suicide & Crisis Lifeline",
+        body = "National 24/7 mental health crisis support.",
+        // 988lifeline.org has a Chat option that works WITHOUT
+        // telephony — the user can reach a counsellor right now from
+        // a WiFi-only device. This is the killer fallback for #546.
+        webFallback = "https://988lifeline.org/chat/",
+    ),
+    Help211(
+        number = TechEmpowerLinks.PRIMARY_HELP_NUMBER,
+        label = "United Way social services",
+        body = "Housing, food, utilities, mental health referrals.",
+        // 211.org has a "search by ZIP" tool plus a chat option — both
+        // work without telephony.
+        webFallback = "https://www.211.org/",
+    ),
+    Dispatch911(
+        number = TechEmpowerLinks.EMERGENCY_DISPATCH_NUMBER,
+        label = "Emergency dispatch",
+        body = "Life-threatening situations — police, fire, ambulance.",
+        // 911 has no real WiFi-only equivalent — point the user at the
+        // FCC's text-to-911 guidance, which is the official US
+        // resource for "I can't make a voice call right now".
+        webFallback = "https://www.fcc.gov/consumers/guides/what-you-need-know-about-text-911",
+    ),
+}
+
+/**
+ * Issue #546 — entry point for every "dial a helpline" affordance on
+ * the TechEmpower surfaces. Probes [PackageManager.FEATURE_TELEPHONY]
+ * BEFORE firing ACTION_DIAL so that WiFi-only devices land on a real
+ * fallback dialog instead of the AOSP contact-picker (the documented
+ * default behaviour when no dialer activity is registered).
+ *
+ * Why a single `hasSystemFeature` check is sufficient: telephony is
+ * the hardware feature backing the dialer app on AOSP. A device that
+ * lacks `android.hardware.telephony` cannot place a call, and the
+ * ACTION_DIAL intent reliably falls through to a contact picker in
+ * that state. The check is fast (constant-time lookup against the
+ * system features table) and has no permission requirements.
+ *
+ * 911 is handled identically — even though "emergency call routing on
+ * WiFi-only devices" is a real concept in some regions, in practice
+ * Android tablets without telephony cannot place 911 calls. The
+ * fallback dialog still surfaces the number for a user to dial from
+ * another device or via the FCC text-to-911 path.
+ */
+internal fun dialOrSurfaceFallback(
+    context: Context,
+    target: EmergencyTarget,
+    onNoTelephony: (EmergencyTarget) -> Unit,
+) {
+    val hasTelephony = context.packageManager
+        .hasSystemFeature(PackageManager.FEATURE_TELEPHONY)
+    if (!hasTelephony) {
+        onNoTelephony(target)
+        return
+    }
+    runCatching {
+        context.startActivity(
+            Intent(
+                Intent.ACTION_DIAL,
+                Uri.parse(TechEmpowerLinks.telUri(target.number)),
+            ).apply { addFlags(Intent.FLAG_ACTIVITY_NEW_TASK) },
+        )
+    }.onFailure {
+        // ACTION_DIAL failed even with telephony reported — extremely
+        // rare (a custom ROM with no dialer) but the fallback dialog
+        // is the right UX here too.
+        onNoTelephony(target)
+    }
+}
+
+/**
+ * Issue #546 — fallback dialog shown when a user taps a helpline on a
+ * device without telephony. Surfaces the number prominently, offers
+ * copy-to-clipboard (so they can dial from another device), and a
+ * "Open in browser" affordance pointing at the helpline's web
+ * counterpart (988 chat, 211 search, FCC text-to-911 guidance).
+ *
+ * Why an AlertDialog instead of a bottom sheet: a crisis surface
+ * needs a modal, focus-stealing affordance with a single primary
+ * action. Bottom sheets dismiss on outside-tap and stack with the
+ * scaffold; AlertDialog is the right semantic for "we owe you an
+ * explanation before you proceed".
+ *
+ * Why no telephony icon: the user just tried to make a call — a
+ * crossed-out phone glyph reads as failure-shaming. Plain text is
+ * kinder: "This device can't make calls."
+ *
+ * Lives here (next to [dialOrSurfaceFallback] + [EmergencyTarget])
+ * because both [TechEmpowerHomeScreen]'s Emergency Help card AND
+ * [TechEmpowerHelpIcons]'s top-app-bar phone icon need this surface,
+ * and centralising the composable keeps the recovery UX consistent
+ * across entry points.
+ */
+@Composable
+internal fun NoTelephonyFallbackDialog(
+    target: EmergencyTarget,
+    onDismiss: () -> Unit,
+) {
+    val context = LocalContext.current
+    val spacing = LocalSpacing.current
+    val brass = MaterialTheme.colorScheme.primary
+    AlertDialog(
+        onDismissRequest = onDismiss,
+        title = {
+            Text(
+                text = "This device can't make calls",
+                style = MaterialTheme.typography.titleMedium,
+                color = brass,
+                fontWeight = FontWeight.SemiBold,
+            )
+        },
+        text = {
+            Column(verticalArrangement = Arrangement.spacedBy(spacing.sm)) {
+                Text(
+                    text = "${target.label} — call ${target.number} from a phone, or use the web option below.",
+                    style = MaterialTheme.typography.bodyMedium,
+                )
+                // The number itself, large-and-brass — matches the
+                // EmergencyDialButton visual ranking so the user
+                // anchors on it as the actionable atom.
+                Text(
+                    text = target.number,
+                    style = MaterialTheme.typography.displaySmall,
+                    color = brass,
+                    fontWeight = FontWeight.SemiBold,
+                    textAlign = TextAlign.Center,
+                    modifier = Modifier.fillMaxWidth(),
+                )
+                // Two side-by-side affordances: copy the number, open
+                // the web fallback. Spacing.md gap so the user can hit
+                // either with a thumb-down tap.
+                Row(
+                    modifier = Modifier.fillMaxWidth(),
+                    horizontalArrangement = Arrangement.spacedBy(spacing.md),
+                ) {
+                    TextButton(
+                        modifier = Modifier.weight(1f),
+                        onClick = {
+                            val cm = context.getSystemService(Context.CLIPBOARD_SERVICE)
+                                as? ClipboardManager
+                            cm?.setPrimaryClip(
+                                ClipData.newPlainText(target.label, target.number),
+                            )
+                            Toast.makeText(
+                                context,
+                                "${target.number} copied",
+                                Toast.LENGTH_SHORT,
+                            ).show()
+                        },
+                    ) {
+                        Icon(
+                            Icons.Filled.ContentCopy,
+                            contentDescription = null,
+                            modifier = Modifier.size(18.dp),
+                        )
+                        Spacer(Modifier.width(spacing.xs))
+                        Text("Copy")
+                    }
+                    TextButton(
+                        modifier = Modifier.weight(1f),
+                        onClick = {
+                            runCatching {
+                                context.startActivity(
+                                    Intent(
+                                        Intent.ACTION_VIEW,
+                                        Uri.parse(target.webFallback),
+                                    ).apply { addFlags(Intent.FLAG_ACTIVITY_NEW_TASK) },
+                                )
+                            }
+                        },
+                    ) {
+                        Icon(
+                            Icons.Filled.OpenInNew,
+                            contentDescription = null,
+                            modifier = Modifier.size(18.dp),
+                        )
+                        Spacer(Modifier.width(spacing.xs))
+                        Text("Open web")
+                    }
+                }
+            }
+        },
+        confirmButton = {
+            TextButton(onClick = onDismiss) { Text("Close") }
+        },
+    )
 }

--- a/feature/src/main/kotlin/in/jphe/storyvox/feature/voicelibrary/VoiceLibraryScreen.kt
+++ b/feature/src/main/kotlin/in/jphe/storyvox/feature/voicelibrary/VoiceLibraryScreen.kt
@@ -197,10 +197,24 @@ fun VoiceLibraryScreen(
             // every chip on first paint — the 1188-voice catalog has
             // long since taught us not to render the whole world
             // upfront. Brass-pill colors match the Library/Browse chips.
+            //
+            // Issue #534 — asymmetric end-padding (spacing.xl = 32dp vs
+            // start spacing.md = 16dp) via contentPadding so the
+            // rightmost chip lands as an obviously-partial chip on
+            // narrow Flip3 portrait — clear "scroll for more →"
+            // affordance. Mirrors the secondary chip row pattern below
+            // (#420). The outer horizontal padding moved INTO
+            // contentPadding so the LazyRow's lazy clipping kicks in
+            // at the right place — without this, an outer padding clips
+            // chips before they can pan into view.
             LazyRow(
                 modifier = Modifier
                     .fillMaxWidth()
-                    .padding(horizontal = spacing.md, vertical = spacing.xxs),
+                    .padding(vertical = spacing.xxs),
+                contentPadding = ComposePaddingValues(
+                    start = spacing.md,
+                    end = spacing.xl,
+                ),
                 horizontalArrangement = Arrangement.spacedBy(spacing.xs),
                 verticalAlignment = Alignment.CenterVertically,
             ) {


### PR DESCRIPTION
## Summary

Five small surgical fixes — four phone-narrow-width discoverability fixes and one safety-critical bug.

### Phone narrow-width clipping (Flip3, 1080×2640)

- **#532** Library tab strip: `SecondaryScrollableTabRow` already scrollable but `edgePadding=0.dp` hid scroll affordance. Bumped to `spacing.md` so rightmost tab lands as partial chip.
- **#533** Top-bar 4 action icons packed flush at 0dp. Added `spacing.xs` (8dp) `Spacer`s between each — phone/Discord/sync/settings now have clean 72px gaps.
- **#534** VoiceLibrary language chip `LazyRow` had outer `Modifier.padding` clipping chips before lazy clipping could pan them in. Moved horizontal padding into `contentPadding` with asymmetric end (`xl=32dp`) — same #420 pattern.
- **#535** AO3 Browse tab strip's "Marked" sat 5dp from edge. Bumped `edgePadding=0.dp` → `spacing.md`.

### Emergency Help dial-fallback safety (#546)

**The dangerous one.** On a WiFi-only Tab A7 Lite, tapping 988/211/911 routed to the contact picker — the AOSP default fallback when `ACTION_DIAL` fires on a device without telephony. In a crisis, the user expects to dial; they got a contact picker.

Fix: probe `PackageManager.hasSystemFeature(FEATURE_TELEPHONY)` before firing the intent. When telephony is absent, surface a clear `AlertDialog`:
- the number large-and-brass
- **Copy** to clipboard (dial from another device)
- **Open web** fallback — `988lifeline.org/chat` (988), `211.org` (211), FCC text-to-911 guidance (911)
- **Close**

Shared helpers (`EmergencyTarget`, `dialOrSurfaceFallback`, `NoTelephonyFallbackDialog`) live in `TechEmpowerIntents.kt` so all three entry points (Emergency Help card, "Call 211" card, top-app-bar phone icon) surface consistent recovery.

`AndroidManifest.xml`: added `<uses-feature android:name="android.hardware.telephony" android:required="false"/>` so storyvox stays installable on tablets in Play Store.

## Test plan

- [x] `./gradlew :app:assembleRelease :feature:testDebugUnitTest :app:testDebugUnitTest` — passes
- [x] Tab A7 Lite (R83W80CAFZB, WiFi-only): tapping 988 button → "This device can't make calls" dialog with Copy / Open web / Close. Verified 211 + 911 + top-bar phone icon all route through the same dialog.
- [x] Flip3 (R5CRB0W66MK, telephony): `ACTION_DIAL` fires as before — `PackageManager.FEATURE_TELEPHONY` confirms `true`, so the dial path is taken.
- [x] Flip3 top-bar: 4 icons now visibly spaced (72px gaps) instead of packed at 0dp.
- [x] Flip3 Library tab strip: edgePadding visible, History reachable via swipe.
- [x] Flip3 Browse → AO3: "Marked" tab clears the screen edge (was 5dp, now ~17dp).
- [x] Flip3 Voices: language chip row scrolls cleanly past initial 6 chips.

Co-authored by Claude Opus 4.7 (1M context).

🤖 Generated with [Claude Code](https://claude.com/claude-code)