### PR TITLE
fix: InstantDB login crash + 60s background resume crash — closes #559 #544

### DIFF
--- a/core-sync/src/main/kotlin/in/jphe/storyvox/sync/client/InstantTransport.kt
+++ b/core-sync/src/main/kotlin/in/jphe/storyvox/sync/client/InstantTransport.kt
@@ -1,5 +1,7 @@
 package `in`.jphe.storyvox.sync.client
 
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
 import okhttp3.MediaType.Companion.toMediaType
 import okhttp3.OkHttpClient
 import okhttp3.Request
@@ -15,12 +17,22 @@ import java.io.IOException
  * thin (4 endpoints, all POST JSON, no streaming) that decoupling lets unit
  * tests cover the InstantClient logic without spinning a MockWebServer
  * thread pool. The production class is a one-liner around OkHttp.
+ *
+ * **Issue #559 (v0.5.58)** — [postJson] is `suspend` for a reason: callers
+ * from `:feature/sync` launch through `viewModelScope` which defaults to
+ * `Dispatchers.Main.immediate`. A blocking `OkHttpClient.newCall().execute()`
+ * on that dispatcher trips `StrictMode`'s `NetworkOnMainThreadException`
+ * and kills the process the instant the user taps "Send code." The
+ * production transport must dispatch onto IO; the interface contract is
+ * "this may block, callers don't need to wrap it." Test fakes that
+ * complete synchronously remain trivially correct because `suspend` is a
+ * superset of blocking in the kotlinx-coroutines model.
  */
 interface InstantHttpTransport {
     /** Returns the response body as a string. Throws [IOException] on
      *  network failure; returns the body even on non-2xx so callers can
      *  surface server-side error messages. */
-    fun postJson(url: String, jsonBody: String): TransportResult
+    suspend fun postJson(url: String, jsonBody: String): TransportResult
 }
 
 data class TransportResult(
@@ -35,24 +47,31 @@ class OkHttpInstantTransport(
     private val client: OkHttpClient = defaultClient(),
 ) : InstantHttpTransport {
 
-    override fun postJson(url: String, jsonBody: String): TransportResult {
-        val req = Request.Builder()
-            .url(url)
-            .post(jsonBody.toRequestBody(JSON_MEDIA))
-            .build()
-        return try {
-            client.newCall(req).execute().use { resp: Response ->
-                TransportResult(
-                    code = resp.code,
-                    body = resp.body?.string().orEmpty(),
-                )
+    override suspend fun postJson(url: String, jsonBody: String): TransportResult =
+        // Issue #559 — explicit IO dispatch. OkHttp's synchronous
+        // `execute()` performs DNS + TCP + TLS on the calling thread,
+        // and the magic-code endpoints aren't cached, so this is a
+        // guaranteed-blocking path. `viewModelScope.launch { ... }`
+        // by default runs on `Main.immediate`; without this switch the
+        // first sign-in tap throws NetworkOnMainThreadException.
+        withContext(Dispatchers.IO) {
+            val req = Request.Builder()
+                .url(url)
+                .post(jsonBody.toRequestBody(JSON_MEDIA))
+                .build()
+            try {
+                client.newCall(req).execute().use { resp: Response ->
+                    TransportResult(
+                        code = resp.code,
+                        body = resp.body?.string().orEmpty(),
+                    )
+                }
+            } catch (e: IOException) {
+                // Wrap as a synthetic "0" code so callers can branch on
+                // transient-network with the same shape as a real error body.
+                TransportResult(code = 0, body = e.message ?: "network failure")
             }
-        } catch (e: IOException) {
-            // Wrap as a synthetic "0" code so callers can branch on
-            // transient-network with the same shape as a real error body.
-            TransportResult(code = 0, body = e.message ?: "network failure")
         }
-    }
 
     private companion object {
         val JSON_MEDIA = "application/json; charset=utf-8".toMediaType()

--- a/core-sync/src/test/kotlin/in/jphe/storyvox/sync/InstantClientTest.kt
+++ b/core-sync/src/test/kotlin/in/jphe/storyvox/sync/InstantClientTest.kt
@@ -21,7 +21,7 @@ class InstantClientTest {
         private val responses: Map<String, TransportResult>,
     ) : InstantHttpTransport {
         val calls = mutableListOf<Pair<String, String>>()
-        override fun postJson(url: String, jsonBody: String): TransportResult {
+        override suspend fun postJson(url: String, jsonBody: String): TransportResult {
             calls += url to jsonBody
             // Match by suffix so the test doesn't need to spell the full URL.
             val match = responses.entries.firstOrNull { url.endsWith(it.key) }


### PR DESCRIPTION
## Summary

Two crash bugs from v0.5.57/.58 device testing:

- **#559** — Tapping **Send code** on the InstantDB email sign-in flow crashed the app instantly on both R5CRB0W66MK (Z Flip 3) and R83W80CAFZB (Tab A7 Lite).
  - **Stack trace**: `FATAL EXCEPTION: main / android.os.NetworkOnMainThreadException` at `Inet6AddressImpl.lookupHostByName` → OkHttp dispatcher chain → `T5.n.invokeSuspend` (`OkHttpInstantTransport.postJson`).
  - **Root cause**: `InstantHttpTransport.postJson` was non-suspend and called blocking `client.newCall(req).execute()`. The whole call chain `SyncAuthViewModel.sendCode → viewModelScope.launch → InstantClient.sendMagicCode → transport.postJson` ran on `Dispatchers.Main.immediate`, so the DNS lookup hit StrictMode and killed the process.
  - **Fix**: make the transport interface `suspend` and wrap the OkHttp `execute()` block in `withContext(Dispatchers.IO)`. All four runtime auth endpoints (`send_magic_code`, `verify_magic_code`, `verify_refresh_token`, `signout`) flow through this single seam.

- **#544** — App crashes when resuming from 60s+ background.
  - **Already resolved by #522 (v0.5.53)**, which added the WorkManager `SystemForegroundService foregroundServiceType="dataSync"` manifest override and the duplicate-DataStore singleton fix. The manifest entry is at `app/src/main/AndroidManifest.xml:150-153`.
  - **Verification**: 90-second background → resume sweeps on both devices in this session ran without crashes; the system dropbox shows no `foregroundServiceType=0x00000001` crash since v0.5.51 on either device. Closing this issue alongside #559.

## Device verification

| Device | #559 before | #559 after | #544 90s background |
|---|---|---|---|
| R5CRB0W66MK (Z Flip 3) | FATAL `NetworkOnMainThreadException` at 03:15:19 | App alive, surfaces server "Validation failed" message | No crash, no dropbox entry |
| R83W80CAFZB (Tab A7 Lite) | FATAL same path | App alive, same server error message | No crash, no dropbox entry |

## Test plan

- [x] `./gradlew :core-sync:testDebugUnitTest` passes
- [x] `./gradlew :app:testDebugUnitTest` passes
- [x] `./gradlew :app:assembleRelease` produces a working APK
- [x] Sign-in flow on R5CRB0W66MK: cloud icon → Sign in to sync → email → Send code completes network round trip
- [x] Sign-in flow on R83W80CAFZB: same path completes network round trip
- [x] R5CRB0W66MK: 90s background → resume, no crash
- [x] R83W80CAFZB: 90s background → resume, no crash

🤖 Generated with [Claude Code](https://claude.com/claude-code)