### PR TITLE
feat(playback): magical "why we are waiting" diagnostic — audio-out monitor + reason panel

### DIFF
--- a/app/src/main/kotlin/in/jphe/storyvox/di/AppBindings.kt
+++ b/app/src/main/kotlin/in/jphe/storyvox/di/AppBindings.kt
@@ -906,6 +906,13 @@ internal class RealPlaybackControllerUi(
      *  add a stale duplication seam. */
     override val events: Flow<PlaybackUiEvent> = controller.events
 
+    /** "Why are we waiting?" — forward the AudioOutputMonitor's
+     *  diagnostic flow through the UI contract. The monitor lives in
+     *  core-playback as a Singleton; this adapter doesn't transform the
+     *  value, just opens the seam for the feature layer to subscribe. */
+    override val waitReason: Flow<`in`.jphe.storyvox.playback.diagnostics.WaitReason?> =
+        controller.waitReason
+
     override suspend fun speakText(text: String) {
         controller.speakText(text)
     }

--- a/app/src/test/kotlin/in/jphe/storyvox/di/RealPlaybackControllerUiTest.kt
+++ b/app/src/test/kotlin/in/jphe/storyvox/di/RealPlaybackControllerUiTest.kt
@@ -177,6 +177,11 @@ class RealPlaybackControllerUiTest {
             ).asStateFlow()
         override val playbackPositionMs: StateFlow<Long> = MutableStateFlow(0L).asStateFlow()
         override val chapterDurationMs: StateFlow<Long> = MutableStateFlow(0L).asStateFlow()
+        // "Why are we waiting?" — test fakes default to null (audio
+        // flowing). Tests that exercise the diagnostic flow can swap
+        // in a MutableStateFlow if needed.
+        override val waitReason: StateFlow<`in`.jphe.storyvox.playback.diagnostics.WaitReason?> =
+            MutableStateFlow<`in`.jphe.storyvox.playback.diagnostics.WaitReason?>(null).asStateFlow()
 
         override suspend fun play(fictionId: String, chapterId: String, charOffset: Int) = Unit
         override fun pause() = Unit

--- a/core-playback/src/main/kotlin/in/jphe/storyvox/playback/PlaybackController.kt
+++ b/core-playback/src/main/kotlin/in/jphe/storyvox/playback/PlaybackController.kt
@@ -1,5 +1,7 @@
 package `in`.jphe.storyvox.playback
 
+import `in`.jphe.storyvox.playback.diagnostics.AudioOutputMonitor
+import `in`.jphe.storyvox.playback.diagnostics.WaitReason
 import `in`.jphe.storyvox.playback.tts.EnginePlayer
 import `in`.jphe.storyvox.playback.tts.RecapPlaybackState
 import `in`.jphe.storyvox.playback.tts.SentenceChunker
@@ -56,6 +58,20 @@ interface PlaybackController {
      *  is called; flips to Speaking while the one-shot utterance is playing,
      *  back to Idle when it finishes naturally or [stopSpeaking] is called. */
     val recapPlayback: StateFlow<RecapPlaybackState>
+
+    /**
+     * "Why are we waiting?" — the magical user-facing diagnostic that
+     * answers the core question "is audio actually coming out of the
+     * speakers, and if not, why?". Null when audio is genuinely flowing
+     * (or playback is idle/paused/errored — those have dedicated UI
+     * surfaces). Non-null with a typed [WaitReason] otherwise.
+     *
+     * Fed by [AudioOutputMonitor], which polls the truthful audio
+     * position from EnginePlayer's AudioTrack head-position counter +
+     * cross-references audio focus state, device volume, and route
+     * changes. See WaitReason.kt for the variant catalogue.
+     */
+    val waitReason: StateFlow<WaitReason?>
 
     suspend fun play(fictionId: String, chapterId: String, charOffset: Int = 0)
     fun pause()
@@ -167,6 +183,10 @@ class DefaultPlaybackController @Inject constructor(
      *  jumps to bookmark positions; the player layer needs no
      *  awareness of bookmarks (they're a chapter-metadata concern). */
     private val chapterRepo: `in`.jphe.storyvox.data.repository.ChapterRepository,
+    /** "Why are we waiting?" — Lazy break of the Singleton-graph cycle
+     *  (monitor depends on controller, controller exposes monitor's
+     *  flow). Resolved once on first [waitReason] access. */
+    private val audioOutputMonitor: dagger.Lazy<AudioOutputMonitor>,
 ) : PlaybackController {
 
     private val scope = CoroutineScope(SupervisorJob() + Dispatchers.Default)
@@ -253,6 +273,13 @@ class DefaultPlaybackController @Inject constructor(
      *  active player's flow while bound. */
     private val _recapPlayback = MutableStateFlow(RecapPlaybackState.Idle)
     override val recapPlayback: StateFlow<RecapPlaybackState> = _recapPlayback.asStateFlow()
+
+    /** "Why are we waiting?" — exposed via the monitor singleton. The
+     *  Lazy resolves on first access; consumers see a permanent
+     *  StateFlow that the monitor writes into. */
+    override val waitReason: StateFlow<WaitReason?> by lazy {
+        audioOutputMonitor.get().waitReason
+    }
 
     init {
         scope.launch {

--- a/core-playback/src/main/kotlin/in/jphe/storyvox/playback/StoryvoxPlaybackService.kt
+++ b/core-playback/src/main/kotlin/in/jphe/storyvox/playback/StoryvoxPlaybackService.kt
@@ -24,6 +24,7 @@ import androidx.media3.session.MediaSessionService
 import androidx.media3.session.MediaStyleNotificationHelper
 import androidx.media3.session.SimpleBitmapLoader
 import dagger.hilt.android.AndroidEntryPoint
+import `in`.jphe.storyvox.playback.diagnostics.AudioOutputMonitor
 import `in`.jphe.storyvox.playback.sleep.ShakeDetector
 import `in`.jphe.storyvox.playback.tts.EnginePlayer
 import `in`.jphe.storyvox.playback.wear.PhoneWearBridge
@@ -65,6 +66,14 @@ class StoryvoxPlaybackService : MediaSessionService() {
      *  Singleton instance via Hilt. */
     @Inject lateinit var audioFocus: AudioFocusController
 
+    /** "Why are we waiting?" — process-wide audio-output diagnostic
+     *  singleton. Started at onCreate so it's listening before the user
+     *  taps play; stopped at onDestroy. The monitor reads truthful
+     *  signals (head-position advance, focus state, route, volume) and
+     *  exposes a [WaitReason] flow that the reader UI surfaces in the
+     *  brass diagnostic panel above the cover. */
+    @Inject lateinit var audioOutputMonitor: AudioOutputMonitor
+
     private lateinit var session: MediaSession
     private lateinit var player: EnginePlayer
 
@@ -104,6 +113,12 @@ class StoryvoxPlaybackService : MediaSessionService() {
         audioFocus.setOnFocusLost {
             scope.launch { controller.pause() }
         }
+
+        // "Why are we waiting?" — start the diagnostic monitor here so
+        // it's live before the user taps play. The monitor's own start()
+        // is idempotent + re-anchors on every call, so a chapter advance
+        // mid-session doesn't fight itself.
+        audioOutputMonitor.start()
 
         session = MediaSession.Builder(this, player)
             .setCallback(StoryvoxSessionCallback(controller, scope))
@@ -317,6 +332,10 @@ class StoryvoxPlaybackService : MediaSessionService() {
 
     override fun onDestroy() {
         wearBridge.stop()
+        // "Why are we waiting?" — stop the diagnostic monitor before
+        // the controller unbinds; otherwise the tick loop would briefly
+        // see a null player + emit a spurious AudioOutputStuck reason.
+        audioOutputMonitor.stop()
         controller.unbindPlayer()
         session.release()
         player.releaseEngine()

--- a/core-playback/src/main/kotlin/in/jphe/storyvox/playback/diagnostics/AudioOutputMonitor.kt
+++ b/core-playback/src/main/kotlin/in/jphe/storyvox/playback/diagnostics/AudioOutputMonitor.kt
@@ -1,0 +1,414 @@
+package `in`.jphe.storyvox.playback.diagnostics
+
+import android.content.BroadcastReceiver
+import android.content.Context
+import android.content.Intent
+import android.content.IntentFilter
+import android.media.AudioDeviceCallback
+import android.media.AudioDeviceInfo
+import android.media.AudioManager
+import android.os.Handler
+import android.os.Looper
+import android.os.SystemClock
+import android.util.Log
+import dagger.hilt.android.qualifiers.ApplicationContext
+import `in`.jphe.storyvox.playback.AudioFocusController
+import `in`.jphe.storyvox.playback.EngineState
+import `in`.jphe.storyvox.playback.PlaybackController
+import `in`.jphe.storyvox.playback.PlaybackState
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.isActive
+import kotlinx.coroutines.launch
+import java.util.concurrent.atomic.AtomicLong
+import javax.inject.Inject
+import javax.inject.Provider
+import javax.inject.Singleton
+
+/**
+ * "Does storyvox KNOW if audio is actually coming out of the speakers?"
+ *
+ * Pre-monitor the answer was no. The engine reported `EngineState.Playing`
+ * the moment it pushed bytes into the AudioTrack write queue, but the
+ * framework could silently swallow those bytes (Bug 1 of the v0.5.57
+ * audit) — audio focus lost, device muted, route changed under us — and
+ * the UI cheerfully painted a Pause icon over dead air.
+ *
+ * The monitor closes that gap. It runs a 200 ms tick coroutine while
+ * playback is active and watches **truthful** signals:
+ *
+ *  1. The truthful position from [PlaybackController.playbackPositionMs] —
+ *     that flow is fed by `AudioTrack.getPlaybackHeadPosition` inside
+ *     EnginePlayer, which only advances when the framework actually
+ *     consumed frames. If that position stalls while engineState=Playing,
+ *     audio is NOT reaching the speakers.
+ *  2. [AudioFocusController.isHeld] — process-wide focus state. Lost
+ *     focus → known stall.
+ *  3. [AudioManager.getStreamVolume] / `isStreamMute` — device muted.
+ *  4. [AudioManager.getDevices] + [AudioDeviceCallback] — route changes.
+ *  5. [EngineState] — warming / buffering distinction.
+ *  6. [PlaybackState.currentChapterId] vs `chapterTitle` — chapter-load
+ *     vs sentence-buffer distinction.
+ *
+ * On every tick the monitor computes a [WaitReason] (or `null` when
+ * audio is genuinely flowing) and emits it through [waitReason].
+ *
+ * "EVERY time, beautifully" — the catch-all path is [WaitReason.AudioOutputStuck]
+ * with a `secondsSilent` counter; the panel never goes blank while the
+ * pipeline is stuck.
+ *
+ * Lifecycle: [start] from `StoryvoxPlaybackService.onCreate`, [stop] from
+ * `onDestroy`. Idempotent — `start` while already running re-anchors the
+ * silence counter.
+ */
+@Singleton
+class AudioOutputMonitor @Inject constructor(
+    @ApplicationContext private val context: Context,
+    /**
+     * Lazy provider — [PlaybackController] holds a back-reference to
+     * `monitor.waitReason` (so the UI can subscribe through one bus),
+     * which would form a constructor-injection cycle if we took
+     * PlaybackController directly. The provider breaks the cycle; we
+     * resolve it on `start()`, by which point the graph is fully built.
+     */
+    private val controllerProvider: Provider<PlaybackController>,
+    private val audioFocus: AudioFocusController,
+) {
+
+    private val audioManager: AudioManager? =
+        context.getSystemService(Context.AUDIO_SERVICE) as? AudioManager
+
+    private val scope = CoroutineScope(SupervisorJob() + Dispatchers.Default)
+
+    private val _waitReason = MutableStateFlow<WaitReason?>(null)
+    /** Null when audio is actually flowing through the speakers. Non-null
+     *  with a typed [WaitReason] otherwise. UI subscribes through
+     *  [PlaybackController.waitReason] which forwards this flow. */
+    val waitReason: StateFlow<WaitReason?> = _waitReason.asStateFlow()
+
+    /** Tick job. Non-null while monitor is running. */
+    private var tickJob: Job? = null
+    private var stateJob: Job? = null
+
+    /** Wall-clock ms of the most recent position-advance — i.e. the last
+     *  moment we have evidence audio actually came out. Tracked by the
+     *  tick loop. */
+    private val lastAudibleAdvanceMs = AtomicLong(SystemClock.elapsedRealtime())
+
+    /** Last [PlaybackController.playbackPositionMs] value we saw, used
+     *  to detect head-position advance between ticks. */
+    @Volatile
+    private var lastObservedPositionMs: Long = 0L
+
+    /** Wall-clock ms when the current play attempt started. Used to
+     *  compute `secondsWaiting` for [WaitReason.NetworkSlow] and similar
+     *  time-based payloads. Reset on every `engineState` transition into
+     *  Warming or Buffering. */
+    @Volatile
+    private var phaseStartedAtMs: Long = SystemClock.elapsedRealtime()
+
+    /** Wall-clock ms of the last audio-route-change event from the
+     *  [AudioDeviceCallback]. Used to surface
+     *  [WaitReason.AudioRouteChange] for ~3 s after the change, then
+     *  hand back to whatever the underlying reason is. */
+    @Volatile
+    private var lastRouteChangeAtMs: Long = 0L
+
+    /** Most-recently-seen voice id from PlaybackState. Cached so a
+     *  [WaitReason.WarmingVoice] doesn't have to recompute the label on
+     *  every 200 ms tick. */
+    @Volatile
+    private var lastVoiceLabel: String = "voice"
+
+    private val routeCallback = object : AudioDeviceCallback() {
+        override fun onAudioDevicesAdded(addedDevices: Array<out AudioDeviceInfo>?) {
+            lastRouteChangeAtMs = SystemClock.elapsedRealtime()
+            Log.i(LOG_TAG, "audio route added — count=${addedDevices?.size}")
+        }
+        override fun onAudioDevicesRemoved(removedDevices: Array<out AudioDeviceInfo>?) {
+            lastRouteChangeAtMs = SystemClock.elapsedRealtime()
+            Log.i(LOG_TAG, "audio route removed — count=${removedDevices?.size}")
+        }
+    }
+
+    private val noisyReceiver = object : BroadcastReceiver() {
+        override fun onReceive(ctx: Context?, intent: Intent?) {
+            if (intent?.action == AudioManager.ACTION_AUDIO_BECOMING_NOISY) {
+                lastRouteChangeAtMs = SystemClock.elapsedRealtime()
+                Log.i(LOG_TAG, "ACTION_AUDIO_BECOMING_NOISY — headphones unplugged")
+            }
+        }
+    }
+
+    /**
+     * Begin monitoring. Safe to call repeatedly — second + subsequent
+     * calls just re-anchor the silence counter so a fresh chapter
+     * starts with a clean "no silence yet" baseline.
+     */
+    fun start() {
+        // Re-anchor counters; this also covers the "already running"
+        // case where stop()/start() bracket a chapter advance.
+        val now = SystemClock.elapsedRealtime()
+        lastAudibleAdvanceMs.set(now)
+        phaseStartedAtMs = now
+        lastRouteChangeAtMs = 0L
+        if (tickJob?.isActive == true) return
+
+        registerSystemCallbacks()
+
+        val controller = controllerProvider.get()
+
+        stateJob = scope.launch {
+            controller.engineState.collect { es ->
+                // On every phase transition into Warming or Buffering,
+                // re-anchor `phaseStartedAtMs` so the NetworkSlow seconds
+                // counter measures the current phase, not the whole
+                // play() session.
+                if (es is EngineState.Warming || es is EngineState.Buffering) {
+                    phaseStartedAtMs = SystemClock.elapsedRealtime()
+                }
+            }
+        }
+
+        tickJob = scope.launch {
+            while (isActive) {
+                val controller = controllerProvider.get()
+                val state = controller.state.value
+                val engine = controller.engineState.value
+                val pos = controller.playbackPositionMs.value
+
+                // Cache the voice label for WarmingVoice — derived from
+                // the voiceId tail segment the same way
+                // PlaybackController.warmingMessageForCurrentVoice() does.
+                lastVoiceLabel = labelForVoiceId(state.voiceId) ?: lastVoiceLabel
+
+                // Head-position advanced since last tick? That's the
+                // only evidence we have that the listener actually heard
+                // PCM. Reset the silence anchor; clear the reason.
+                if (pos > lastObservedPositionMs) {
+                    lastObservedPositionMs = pos
+                    lastAudibleAdvanceMs.set(SystemClock.elapsedRealtime())
+                    if (engine is EngineState.Playing) {
+                        _waitReason.value = null
+                        delay(TICK_MS)
+                        continue
+                    }
+                }
+                lastObservedPositionMs = pos
+
+                // Derive a reason. Returns null only when audio is
+                // flowing AND engine is Playing.
+                _waitReason.value = diagnose(state, engine, pos)
+                delay(TICK_MS)
+            }
+        }
+        Log.i(LOG_TAG, "monitor started")
+    }
+
+    /** Stop monitoring. Safe to call when already stopped. */
+    fun stop() {
+        tickJob?.cancel()
+        tickJob = null
+        stateJob?.cancel()
+        stateJob = null
+        unregisterSystemCallbacks()
+        _waitReason.value = null
+        Log.i(LOG_TAG, "monitor stopped")
+    }
+
+    /**
+     * The diagnosis core. Returns null only when audio is genuinely
+     * flowing AND engine state is Playing. Otherwise emits a typed
+     * [WaitReason] so the panel always has something honest to show.
+     *
+     * Precedence (highest wins — first match short-circuits):
+     *  1. Engine reports Idle / Paused / Completed / Error → no panel
+     *     (those states have their own UI surfaces).
+     *  2. Recent audio-route change → AudioRouteChange (sticky 3 s).
+     *  3. AudioFocus lost → FocusLost.
+     *  4. Device muted (vol 0 or stream-mute) → DeviceMuted.
+     *  5. EngineState.Warming → WarmingVoice.
+     *  6. EngineState.Buffering AND chapterTitle blank → LoadingChapter.
+     *  7. EngineState.Buffering with chapter loaded → BufferingNextSentence.
+     *  8. Engine reports Playing but head-position stalled for >500 ms →
+     *     classify as Network/AudioOutputStuck based on how long.
+     */
+    internal fun diagnose(
+        state: PlaybackState,
+        engine: EngineState,
+        positionMs: Long,
+    ): WaitReason? {
+        // 1. No audio expected — paused, idle, completed, error. The
+        //    reader UI's existing surfaces (play icon, end-of-book card,
+        //    error block) handle these; the diagnostic panel stays hidden.
+        when (engine) {
+            EngineState.Idle, EngineState.Paused, EngineState.Completed -> return null
+            is EngineState.Error -> return null
+            else -> Unit
+        }
+
+        val now = SystemClock.elapsedRealtime()
+
+        // 2. Audio route changed within the last ROUTE_CHANGE_STICKY_MS.
+        //    Sticky so the user gets a beat to see "Audio output changed"
+        //    before whatever the next reason is takes over.
+        if (lastRouteChangeAtMs > 0L &&
+            (now - lastRouteChangeAtMs) < ROUTE_CHANGE_STICKY_MS
+        ) {
+            return WaitReason.AudioRouteChange
+        }
+
+        // 3. Audio focus lost → we asked the framework, the framework
+        //    said no. Translate the most-likely-cause (best effort —
+        //    Android doesn't expose the focus-stack contents).
+        if (!audioFocus.isHeld()) {
+            return WaitReason.FocusLost(cause = guessFocusCause())
+        }
+
+        // 4. Device-wide mute or volume zero. Both are user-actionable.
+        audioManager?.let { am ->
+            val vol = am.getStreamVolume(AudioManager.STREAM_MUSIC)
+            val muted = runCatching {
+                am.isStreamMute(AudioManager.STREAM_MUSIC)
+            }.getOrDefault(false)
+            if (vol == 0 || muted) return WaitReason.DeviceMuted
+        }
+
+        // 5. Engine is in its Warming phase — voice model load + first
+        //    inference. The label comes from the cached
+        //    [lastVoiceLabel] computed at the top of the tick loop.
+        if (engine is EngineState.Warming) {
+            return WaitReason.WarmingVoice(
+                voiceName = lastVoiceLabel,
+                progress = engine.progress,
+            )
+        }
+
+        // 6/7. Engine is Buffering — distinguish chapter-load (no title
+        //      yet) from mid-chapter underrun (sentence queue starved).
+        if (engine == EngineState.Buffering) {
+            val title = state.chapterTitle
+            val secondsInPhase = ((now - phaseStartedAtMs) / 1000L).toInt()
+            return if (title.isNullOrBlank() || state.currentChapterId == null) {
+                // No chapter body yet → loading.
+                if (secondsInPhase >= NETWORK_SLOW_THRESHOLD_SEC) {
+                    WaitReason.NetworkSlow(secondsWaiting = secondsInPhase)
+                } else {
+                    WaitReason.LoadingChapter(chapterTitle = title.orEmpty().ifBlank { "next chapter" })
+                }
+            } else {
+                WaitReason.BufferingNextSentence(queueDepth = 0)
+            }
+        }
+
+        // 8. Engine claims Playing but head-position hasn't advanced for
+        //    [STUCK_THRESHOLD_MS]. This is the dangerous silent-stuck
+        //    state from the v0.5.57 audit — focus held, volume up, but
+        //    no PCM reaching the speakers anyway. We surface it as the
+        //    catch-all so the user is never staring at dead air.
+        if (engine == EngineState.Playing) {
+            val silentMs = now - lastAudibleAdvanceMs.get()
+            if (silentMs >= STUCK_THRESHOLD_MS) {
+                val seconds = (silentMs / 1000L).toInt().coerceAtLeast(1)
+                return WaitReason.AudioOutputStuck(secondsSilent = seconds)
+            }
+            return null // genuinely playing
+        }
+
+        // Fallback — engine in an unknown state. Default to the
+        // catch-all so the panel still says SOMETHING. "EVERY time."
+        val silentMs = now - lastAudibleAdvanceMs.get()
+        val seconds = (silentMs / 1000L).toInt().coerceAtLeast(0)
+        return WaitReason.AudioOutputStuck(secondsSilent = seconds)
+    }
+
+    /**
+     * Best-effort translation of an audio-focus loss into a
+     * human-readable cause. Android doesn't expose the focus stack to
+     * non-system apps, so we infer from the active audio mode:
+     *  - MODE_IN_CALL / MODE_IN_COMMUNICATION → phone call
+     *  - MODE_RINGTONE → incoming call ringing
+     *  - active alarm stream → alarm
+     *  - otherwise → "another app"
+     */
+    internal fun guessFocusCause(): String {
+        val am = audioManager ?: return "another app"
+        return when (am.mode) {
+            AudioManager.MODE_IN_CALL, AudioManager.MODE_IN_COMMUNICATION -> "a phone call"
+            AudioManager.MODE_RINGTONE -> "an incoming call"
+            else -> {
+                // Heuristic — if the alarm stream is louder than music,
+                // an alarm is likely playing.
+                val musicVol = am.getStreamVolume(AudioManager.STREAM_MUSIC)
+                val alarmVol = runCatching {
+                    am.getStreamVolume(AudioManager.STREAM_ALARM)
+                }.getOrDefault(0)
+                if (alarmVol > musicVol && alarmVol > 0) "an alarm"
+                else "another app"
+            }
+        }
+    }
+
+    /** Extract a friendly label from a voice id (e.g. "kokoro-en-US-brian"
+     *  → "Brian"). Returns null when the id is null/empty. */
+    private fun labelForVoiceId(voiceId: String?): String? {
+        if (voiceId.isNullOrBlank()) return null
+        val tail = voiceId.substringAfterLast("-", missingDelimiterValue = "")
+        if (tail.isBlank() || tail.length !in 2..16) return "voice"
+        return tail.replaceFirstChar { it.uppercaseChar() }
+    }
+
+    private fun registerSystemCallbacks() {
+        val am = audioManager ?: return
+        runCatching {
+            am.registerAudioDeviceCallback(routeCallback, Handler(Looper.getMainLooper()))
+        }.onFailure { Log.w(LOG_TAG, "registerAudioDeviceCallback failed: ${it.message}") }
+        runCatching {
+            val filter = IntentFilter(AudioManager.ACTION_AUDIO_BECOMING_NOISY)
+            if (android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.TIRAMISU) {
+                context.registerReceiver(noisyReceiver, filter, Context.RECEIVER_NOT_EXPORTED)
+            } else {
+                @Suppress("UnspecifiedRegisterReceiverFlag")
+                context.registerReceiver(noisyReceiver, filter)
+            }
+        }.onFailure { Log.w(LOG_TAG, "registerReceiver(BECOMING_NOISY) failed: ${it.message}") }
+    }
+
+    private fun unregisterSystemCallbacks() {
+        val am = audioManager ?: return
+        runCatching { am.unregisterAudioDeviceCallback(routeCallback) }
+        runCatching { context.unregisterReceiver(noisyReceiver) }
+    }
+
+    companion object {
+        private const val LOG_TAG = "AudioOutputMonitor"
+
+        /** Tick cadence. 200 ms = 5 Hz — fast enough that "we noticed audio
+         *  stopped" surfaces within a frame or two, slow enough that the
+         *  monitor is not a CPU cost while playing. Matches the cadence
+         *  spec'd in the architecture brief. */
+        internal const val TICK_MS = 200L
+
+        /** Head-position must hold steady for this long before we
+         *  classify as stuck. 500 ms is what the architecture brief
+         *  spec'd; gives the AudioTrack a beat to refill its internal
+         *  buffer without flapping the panel. */
+        internal const val STUCK_THRESHOLD_MS = 500L
+
+        /** How long an audio-route change is sticky on the panel — gives
+         *  the user a beat to see "Audio output changed" before the
+         *  next reason takes over. */
+        internal const val ROUTE_CHANGE_STICKY_MS = 3_000L
+
+        /** When buffering a chapter body has run this long, escalate
+         *  from LoadingChapter to NetworkSlow. Matches the architecture
+         *  brief ("3 s of fetch"). */
+        internal const val NETWORK_SLOW_THRESHOLD_SEC = 3
+    }
+}

--- a/core-playback/src/main/kotlin/in/jphe/storyvox/playback/diagnostics/WaitReason.kt
+++ b/core-playback/src/main/kotlin/in/jphe/storyvox/playback/diagnostics/WaitReason.kt
@@ -1,0 +1,157 @@
+package `in`.jphe.storyvox.playback.diagnostics
+
+/**
+ * "Why is no audio coming out of the speakers right now?" — the user-facing
+ * answer the reader UI surfaces in a magical brass panel above the cover.
+ *
+ * The contract: [AudioOutputMonitor] derives a [WaitReason] every ~200 ms
+ * while playback is active, by reading the engine's truthful audio
+ * position alongside [in.jphe.storyvox.playback.AudioFocusController] state
+ * and [android.media.AudioManager] route/volume signals. When the user
+ * hears audio (head-position advancing), the monitor exposes `null`. The
+ * UI's `WhyAreWeWaitingPanel` listens to the resulting StateFlow and
+ * fades in / out accordingly.
+ *
+ * Why a sealed interface (not enum): each variant carries different
+ * structured payload (voice name, seconds-waiting, queue depth) that
+ * drives the magical panel's secondary line + optional retry chip. An
+ * enum would force every consumer to look the payload up in a side map,
+ * which is exactly the silent-stuck-state class of bug we're killing.
+ *
+ * "EVERY time, beautifully" — the catch-all [AudioOutputStuck] guarantees
+ * that any silence period falls into a typed reason rather than an empty
+ * panel. The UI's invariant is "if the engine is not Playing, the panel
+ * MUST be visible with a reason".
+ */
+sealed interface WaitReason {
+    /** Render-ready primary headline ("Warming Brian…", "Phone call has
+     *  audio focus", "Volume is muted"). EB Garamond 18sp brass in the
+     *  Library Nocturne panel. */
+    val message: String
+
+    /** Optional progress 0..1 — drives the thin brass progress bar
+     *  beneath the headline. `null` when progress is unknowable (e.g.
+     *  sherpa-onnx voice loads silently). */
+    val progressFraction: Float?
+
+    /** When true, the panel renders a "Retry" chip at the bottom right.
+     *  Tapping it dispatches the same code path that the user's manual
+     *  play tap would (the actual wire-up lives in the panel — the
+     *  reason itself just advertises retryability). */
+    val isRecoverable: Boolean
+
+    /** When true, the panel surfaces a chip inviting user action (Retry,
+     *  Open Settings, etc.). [isRecoverable] implies this; some reasons
+     *  are user-actionable without being mid-failure (e.g. DeviceMuted
+     *  → "Open volume controls"). */
+    val isUserActionable: Boolean
+
+    /**
+     * Sherpa-onnx (or piper, or Azure) is loading the voice model + first
+     * inference. Typical 1-15 s depending on tier; the longest tier-3
+     * Kokoro voices can run 8-12 s on a Tab A7 Lite cold start.
+     */
+    data class WarmingVoice(
+        val voiceName: String,
+        val progress: Float? = null,
+    ) : WaitReason {
+        override val message: String get() = "Warming $voiceName"
+        override val progressFraction: Float? get() = progress
+        override val isRecoverable: Boolean get() = false
+        override val isUserActionable: Boolean get() = false
+    }
+
+    /**
+     * Chapter body fetch hasn't completed yet — typically a Notion /
+     * Royal Road / EPUB body roundtrip. The TTS pipeline can't render
+     * anything because there's no text to feed it.
+     */
+    data class LoadingChapter(val chapterTitle: String) : WaitReason {
+        override val message: String get() = "Loading $chapterTitle"
+        override val progressFraction: Float? get() = null
+        override val isRecoverable: Boolean get() = false
+        override val isUserActionable: Boolean get() = false
+    }
+
+    /**
+     * Mid-chapter underrun: the AudioTrack drained faster than the
+     * producer could refill the sentence queue. The pipeline is alive;
+     * we're waiting for the next sentence's PCM to land.
+     */
+    data class BufferingNextSentence(val queueDepth: Int) : WaitReason {
+        override val message: String get() = "Buffering the next sentence"
+        override val progressFraction: Float? get() = null
+        override val isRecoverable: Boolean get() = false
+        override val isUserActionable: Boolean get() = false
+    }
+
+    /**
+     * Chapter source is a network endpoint and the fetch is taking too
+     * long (>3 s). Surfaced separately from [LoadingChapter] so the panel
+     * can show "Network is slow — N s elapsed" rather than a generic
+     * loading message.
+     */
+    data class NetworkSlow(val secondsWaiting: Int) : WaitReason {
+        override val message: String get() = "Network is slow ($secondsWaiting s)"
+        override val progressFraction: Float? get() = null
+        override val isRecoverable: Boolean get() = true
+        override val isUserActionable: Boolean get() = true
+    }
+
+    /**
+     * Another app or system service holds audio focus — a phone call, an
+     * alarm, a video in another app, the assistant. The framework's
+     * `AUDIOFOCUS_LOSS*` code translates to a human-readable cause via
+     * the constructor argument.
+     */
+    data class FocusLost(val cause: String) : WaitReason {
+        override val message: String get() = "Paused for $cause"
+        override val progressFraction: Float? get() = null
+        override val isRecoverable: Boolean get() = true
+        override val isUserActionable: Boolean get() = true
+    }
+
+    /**
+     * Output route changed (headphones plugged/unplugged, Bluetooth
+     * connect/disconnect). The framework typically auto-pauses on a
+     * disconnect; on connect the user often expects a re-play.
+     */
+    data object AudioRouteChange : WaitReason {
+        override val message: String get() = "Audio output changed"
+        override val progressFraction: Float? get() = null
+        override val isRecoverable: Boolean get() = true
+        override val isUserActionable: Boolean get() = true
+    }
+
+    /** Device volume is at 0 or the music stream is system-muted. */
+    data object DeviceMuted : WaitReason {
+        override val message: String get() = "Device is muted"
+        override val progressFraction: Float? get() = null
+        override val isRecoverable: Boolean get() = false
+        override val isUserActionable: Boolean get() = true
+    }
+
+    /** A voice model download failed (404, network, OOM). */
+    data class VoiceDownloadFailed(val voiceName: String) : WaitReason {
+        override val message: String get() = "Couldn't download $voiceName"
+        override val progressFraction: Float? get() = null
+        override val isRecoverable: Boolean get() = true
+        override val isUserActionable: Boolean get() = true
+    }
+
+    /**
+     * Catch-all. The engine claims it's playing, but no PCM has reached
+     * the speakers for [secondsSilent] seconds. We don't know why; the
+     * UI surfaces this so the user is never left wondering — "EVERY
+     * time, beautifully". After ~10 s of this state, the user can tap
+     * the retry chip to kick the pipeline.
+     */
+    data class AudioOutputStuck(val secondsSilent: Int) : WaitReason {
+        override val message: String
+            get() = if (secondsSilent < 4) "Listening for the first words"
+            else "No audio for $secondsSilent s — preparing to recover"
+        override val progressFraction: Float? get() = null
+        override val isRecoverable: Boolean get() = secondsSilent >= 4
+        override val isUserActionable: Boolean get() = secondsSilent >= 4
+    }
+}

--- a/core-playback/src/test/kotlin/in/jphe/storyvox/playback/diagnostics/AudioOutputMonitorTest.kt
+++ b/core-playback/src/test/kotlin/in/jphe/storyvox/playback/diagnostics/AudioOutputMonitorTest.kt
@@ -1,0 +1,199 @@
+package `in`.jphe.storyvox.playback.diagnostics
+
+import android.content.Context
+import android.media.AudioManager
+import `in`.jphe.storyvox.playback.AudioFocusController
+import `in`.jphe.storyvox.playback.EngineState
+import `in`.jphe.storyvox.playback.PlaybackController
+import `in`.jphe.storyvox.playback.PlaybackState
+import javax.inject.Provider
+import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.SharedFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asSharedFlow
+import kotlinx.coroutines.flow.asStateFlow
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.RuntimeEnvironment
+import org.robolectric.annotation.Config
+
+/**
+ * "Why are we waiting?" diagnostic — pin the core diagnose() decision
+ * tree. The full lifecycle (tick loop, audio-route callbacks) is hard
+ * to exercise without an instrumented test; the diagnose() function is
+ * pure-ish (reads volatile flags, AudioManager state) and covers the
+ * decision matrix the architecture brief specs.
+ */
+@RunWith(RobolectricTestRunner::class)
+@Config(sdk = [33])
+class AudioOutputMonitorTest {
+
+    private fun monitor(focus: AudioFocusController? = null, audible: Boolean = true): AudioOutputMonitor {
+        val ctx = RuntimeEnvironment.getApplication()
+        if (audible) {
+            // Robolectric's STREAM_MUSIC defaults to volume 0, which trips
+            // the DeviceMuted branch ahead of the case-under-test. Raise it.
+            val am = ctx.getSystemService(Context.AUDIO_SERVICE) as AudioManager
+            val max = am.getStreamMaxVolume(AudioManager.STREAM_MUSIC)
+            am.setStreamVolume(AudioManager.STREAM_MUSIC, max / 2, 0)
+        }
+        val af = focus ?: AudioFocusController(ctx)
+        val controller = StubController()
+        return AudioOutputMonitor(
+            context = ctx,
+            controllerProvider = Provider { controller },
+            audioFocus = af,
+        )
+    }
+
+    @Test
+    fun `diagnose returns null for engine Idle`() {
+        val m = monitor()
+        val r = m.diagnose(
+            state = PlaybackState(),
+            engine = EngineState.Idle,
+            positionMs = 0L,
+        )
+        assertNull("Idle is handled by other UI surfaces", r)
+    }
+
+    @Test
+    fun `diagnose returns null for engine Paused`() {
+        val m = monitor()
+        val r = m.diagnose(
+            state = PlaybackState(currentChapterId = "c1"),
+            engine = EngineState.Paused,
+            positionMs = 1000L,
+        )
+        assertNull(r)
+    }
+
+    @Test
+    fun `diagnose returns WarmingVoice when engine is Warming`() {
+        val af = AudioFocusController(RuntimeEnvironment.getApplication())
+        af.acquire()
+        val m = monitor(af)
+        val r = m.diagnose(
+            state = PlaybackState(voiceId = "kokoro-en-US-brian", currentChapterId = "c1"),
+            engine = EngineState.Warming("Warming Brian"),
+            positionMs = 0L,
+        )
+        assertTrue("Warming should surface WarmingVoice — got $r", r is WaitReason.WarmingVoice)
+    }
+
+    @Test
+    fun `diagnose returns BufferingNextSentence on mid-chapter buffer`() {
+        val af = AudioFocusController(RuntimeEnvironment.getApplication())
+        af.acquire()
+        val m = monitor(af)
+        val r = m.diagnose(
+            state = PlaybackState(
+                currentChapterId = "c1",
+                chapterTitle = "Chapter 1",
+                voiceId = "v1",
+            ),
+            engine = EngineState.Buffering,
+            positionMs = 5000L,
+        )
+        assertTrue(
+            "Mid-chapter buffering should be BufferingNextSentence — got $r",
+            r is WaitReason.BufferingNextSentence,
+        )
+    }
+
+    @Test
+    fun `diagnose returns LoadingChapter when buffering with no chapter title`() {
+        val af = AudioFocusController(RuntimeEnvironment.getApplication())
+        af.acquire()
+        val m = monitor(af)
+        val r = m.diagnose(
+            state = PlaybackState(currentChapterId = null, chapterTitle = null),
+            engine = EngineState.Buffering,
+            positionMs = 0L,
+        )
+        assertTrue(
+            "Pre-chapter buffering should be LoadingChapter — got $r",
+            r is WaitReason.LoadingChapter,
+        )
+    }
+
+    @Test
+    fun `diagnose returns DeviceMuted when STREAM_MUSIC volume is zero`() {
+        val af = AudioFocusController(RuntimeEnvironment.getApplication())
+        af.acquire()
+        val m = monitor(af, audible = false) // leave volume at 0
+        val r = m.diagnose(
+            state = PlaybackState(currentChapterId = "c1", chapterTitle = "x"),
+            engine = EngineState.Playing,
+            positionMs = 0L,
+        )
+        assertEquals(WaitReason.DeviceMuted, r)
+    }
+
+    @Test
+    fun `guessFocusCause defaults to another app when audio mode is normal`() {
+        val m = monitor()
+        val cause = m.guessFocusCause()
+        assertEquals("another app", cause)
+    }
+
+    @Test
+    fun `WaitReason AudioOutputStuck escalates user-actionable past threshold`() {
+        val short = WaitReason.AudioOutputStuck(secondsSilent = 1)
+        val long = WaitReason.AudioOutputStuck(secondsSilent = 6)
+        assertTrue("under 4s should not be actionable", !short.isRecoverable)
+        assertTrue("over 4s should be actionable", long.isRecoverable)
+    }
+
+    /**
+     * Minimal PlaybackController stub for the test — every flow is a
+     * trivial constant. The diagnose() test path doesn't touch any
+     * mutator so we don't need to record calls.
+     */
+    private class StubController : PlaybackController {
+        override val state: StateFlow<PlaybackState> = MutableStateFlow(PlaybackState()).asStateFlow()
+        override val events: SharedFlow<`in`.jphe.storyvox.playback.PlaybackUiEvent> =
+            MutableSharedFlow<`in`.jphe.storyvox.playback.PlaybackUiEvent>().asSharedFlow()
+        override val engineState: StateFlow<EngineState> =
+            MutableStateFlow<EngineState>(EngineState.Idle).asStateFlow()
+        override val playbackPositionMs: StateFlow<Long> = MutableStateFlow(0L).asStateFlow()
+        override val chapterDurationMs: StateFlow<Long> = MutableStateFlow(0L).asStateFlow()
+        override val recapPlayback: StateFlow<`in`.jphe.storyvox.playback.tts.RecapPlaybackState> =
+            MutableStateFlow(`in`.jphe.storyvox.playback.tts.RecapPlaybackState.Idle).asStateFlow()
+        override val waitReason: StateFlow<WaitReason?> =
+            MutableStateFlow<WaitReason?>(null).asStateFlow()
+
+        override suspend fun play(fictionId: String, chapterId: String, charOffset: Int) = Unit
+        override fun pause() = Unit
+        override fun resume() = Unit
+        override fun togglePlayPause() = Unit
+        override fun seekTo(charOffset: Int) = Unit
+        override fun seekToPositionMs(positionMs: Long) = Unit
+        override fun skipForward30s() = Unit
+        override fun skipBack30s() = Unit
+        override fun prewarmEngine() = Unit
+        override fun nextSentence() = Unit
+        override fun previousSentence() = Unit
+        override suspend fun nextChapter() = Unit
+        override suspend fun previousChapter() = Unit
+        override suspend fun jumpToChapter(chapterId: String) = Unit
+        override fun setSpeed(speed: Float) = Unit
+        override fun setPitch(pitch: Float) = Unit
+        override fun setPunctuationPauseMultiplier(multiplier: Float) = Unit
+        override fun startSleepTimer(mode: `in`.jphe.storyvox.playback.SleepTimerMode) = Unit
+        override fun cancelSleepTimer() = Unit
+        override fun toggleSleepTimer() = Unit
+        override fun setShakeToExtendEnabled(enabled: Boolean) = Unit
+        override suspend fun speakText(text: String) = Unit
+        override fun stopSpeaking() = Unit
+        override fun bufferTelemetry() = `in`.jphe.storyvox.playback.BufferTelemetry()
+        override suspend fun bookmarkHere() = Unit
+        override suspend fun clearBookmark() = Unit
+        override suspend fun jumpToBookmark() = false
+    }
+}

--- a/feature/src/main/kotlin/in/jphe/storyvox/feature/api/UiContracts.kt
+++ b/feature/src/main/kotlin/in/jphe/storyvox/feature/api/UiContracts.kt
@@ -501,6 +501,20 @@ interface PlaybackControllerUi {
      */
     val events: Flow<`in`.jphe.storyvox.playback.PlaybackUiEvent>
         get() = kotlinx.coroutines.flow.emptyFlow()
+
+    /**
+     * "Why are we waiting?" diagnostic. Forwarded straight from
+     * [in.jphe.storyvox.playback.PlaybackController.waitReason]. Null when
+     * audio is genuinely flowing; non-null with a typed
+     * [in.jphe.storyvox.playback.diagnostics.WaitReason] otherwise. The
+     * reader UI subscribes through this flow to render the brass
+     * `WhyAreWeWaitingPanel` above the cover.
+     *
+     * Default emits null forever so test fakes that don't care about
+     * the diagnostic stay slim.
+     */
+    val waitReason: Flow<`in`.jphe.storyvox.playback.diagnostics.WaitReason?>
+        get() = kotlinx.coroutines.flow.flowOf(null)
     fun play()
     fun pause()
     fun seekTo(ms: Long)

--- a/feature/src/main/kotlin/in/jphe/storyvox/feature/reader/AudiobookView.kt
+++ b/feature/src/main/kotlin/in/jphe/storyvox/feature/reader/AudiobookView.kt
@@ -177,6 +177,15 @@ fun AudiobookView(
     /** Issue #418 — toggle Sonic high-quality flag. Persisted via
      *  SettingsRepositoryUi; engine reads at next chapter render. */
     onSetPitchHighQuality: (Boolean) -> Unit = {},
+    /**
+     * "Why are we waiting?" — typed diagnostic explaining why no audio
+     * is reaching the speakers right now. Null when playback is happily
+     * flowing (or the engine is idle/paused/errored — those have their
+     * own UI surfaces). Default null so older callsites (tests,
+     * previews) keep compiling. Drives the brass
+     * [WhyAreWeWaitingPanel] above the cover.
+     */
+    waitReason: `in`.jphe.storyvox.playback.diagnostics.WaitReason? = null,
     modifier: Modifier = Modifier,
 ) {
     val spacing = LocalSpacing.current
@@ -364,6 +373,20 @@ fun AudiobookView(
                     }
                 }
             }
+            // "Why are we waiting?" — magical diagnostic panel. Lives
+            // between the top app bar and the cover so it doesn't fight
+            // the transport row (chip-ui-fixer owns lines 580-640) and
+            // the user can see WHY playback isn't producing sound the
+            // moment it stops. AnimatedVisibility inside the panel
+            // handles slide-in / slide-out so we don't need to gate the
+            // call site itself — passing `waitReason = null` collapses
+            // the panel to zero height.
+            WhyAreWeWaitingPanel(
+                reason = waitReason,
+                modifier = Modifier.fillMaxWidth(),
+                onRetry = onPlayPause,
+                onOpenSettings = onOpenSettings,
+            )
             // While the chapter body + voice model are still loading we don't
             // have a cover URL or chapter title yet — show the brass arcane
             // sigil placeholder instead of a "?" thumb. As soon as state

--- a/feature/src/main/kotlin/in/jphe/storyvox/feature/reader/HybridReaderScreen.kt
+++ b/feature/src/main/kotlin/in/jphe/storyvox/feature/reader/HybridReaderScreen.kt
@@ -217,6 +217,11 @@ fun HybridReaderScreen(
                 pitchInterpolationHighQuality = state.pitchInterpolationHighQuality,
                 onSetPunctuationPause = viewModel::setPunctuationPauseMultiplier,
                 onSetPitchHighQuality = viewModel::setPitchInterpolationHighQuality,
+                // "Why are we waiting?" — pipe AudioOutputMonitor's
+                // diagnostic through the view so the brass panel above
+                // the cover surfaces a typed reason whenever no audio
+                // is reaching the speakers.
+                waitReason = state.waitReason,
             )
         },
         readerContent = {

--- a/feature/src/main/kotlin/in/jphe/storyvox/feature/reader/ReaderViewModel.kt
+++ b/feature/src/main/kotlin/in/jphe/storyvox/feature/reader/ReaderViewModel.kt
@@ -58,6 +58,15 @@ data class ReaderUiState(
      *  on slow hardware can flip it off without diving into Settings.
      *  Default true matches the Settings default. */
     val pitchInterpolationHighQuality: Boolean = true,
+    /**
+     * "Why are we waiting?" — non-null whenever audio is NOT reaching
+     * the speakers (warming, buffering, focus lost, device muted, route
+     * change, stuck). The reader UI renders the brass diagnostic panel
+     * above the cover based on this value. Sourced from
+     * [PlaybackControllerUi.waitReason] which forwards
+     * AudioOutputMonitor's flow.
+     */
+    val waitReason: `in`.jphe.storyvox.playback.diagnostics.WaitReason? = null,
 )
 
 /** Issue #278 — the player loading screen used to be a silent eternity:
@@ -272,7 +281,22 @@ class ReaderViewModel @Inject constructor(
         // SettingsRepositoryUi flow updates and the next emission flows
         // straight back through this `combine`.
         settings.settings,
-    ) { state, text, pane, phase, settingsSnapshot ->
+        // "Why are we waiting?" — pipe the AudioOutputMonitor flow
+        // through ReaderUiState so AudiobookView can render the brass
+        // diagnostic panel without taking another flow subscription.
+        playback.waitReason,
+    ) { values ->
+        @Suppress("UNCHECKED_CAST")
+        val state = values[0] as UiPlaybackState
+        @Suppress("UNCHECKED_CAST")
+        val text = values[1] as String
+        @Suppress("UNCHECKED_CAST")
+        val pane = values[2] as ReaderView
+        @Suppress("UNCHECKED_CAST")
+        val phase = values[3] as LoadingPhase
+        val settingsSnapshot = values[4] as `in`.jphe.storyvox.feature.api.UiSettings
+        @Suppress("UNCHECKED_CAST")
+        val waitReason = values[5] as? `in`.jphe.storyvox.playback.diagnostics.WaitReason
         ReaderUiState(
             playback = state,
             chapterText = text,
@@ -280,6 +304,7 @@ class ReaderViewModel @Inject constructor(
             loadingPhase = phase,
             punctuationPauseMultiplier = settingsSnapshot.punctuationPauseMultiplier,
             pitchInterpolationHighQuality = settingsSnapshot.pitchInterpolationHighQuality,
+            waitReason = waitReason,
         )
     }.stateIn(viewModelScope, SharingStarted.WhileSubscribed(5_000), ReaderUiState())
 

--- a/feature/src/main/kotlin/in/jphe/storyvox/feature/reader/WhyAreWeWaitingPanel.kt
+++ b/feature/src/main/kotlin/in/jphe/storyvox/feature/reader/WhyAreWeWaitingPanel.kt
@@ -1,0 +1,284 @@
+package `in`.jphe.storyvox.feature.reader
+
+import androidx.compose.animation.AnimatedVisibility
+import androidx.compose.animation.core.RepeatMode
+import androidx.compose.animation.core.animateFloat
+import androidx.compose.animation.core.infiniteRepeatable
+import androidx.compose.animation.core.tween
+import androidx.compose.animation.expandVertically
+import androidx.compose.animation.fadeIn
+import androidx.compose.animation.fadeOut
+import androidx.compose.animation.shrinkVertically
+import androidx.compose.foundation.background
+import androidx.compose.foundation.border
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.LinearProgressIndicator
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.ProgressIndicatorDefaults
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.alpha
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.compositeOver
+import androidx.compose.ui.semantics.contentDescription
+import androidx.compose.ui.semantics.liveRegion
+import androidx.compose.ui.semantics.LiveRegionMode
+import androidx.compose.ui.semantics.semantics
+import androidx.compose.ui.text.font.FontFamily
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import `in`.jphe.storyvox.playback.diagnostics.WaitReason
+import `in`.jphe.storyvox.ui.theme.LocalMotion
+import `in`.jphe.storyvox.ui.theme.LocalReducedMotion
+import `in`.jphe.storyvox.ui.theme.LocalSpacing
+
+/**
+ * "Why are we waiting?" — the user-facing magical panel that surfaces a
+ * typed [WaitReason] whenever no audio is reaching the speakers. Lives
+ * above the cover in [AudiobookView]; renders in Library Nocturne brass
+ * with a slow-pulsing sigil, the reason headline, an optional thin
+ * progress bar, a secondary explanatory line, and (for recoverable
+ * reasons) a brass-bordered Retry chip.
+ *
+ * The panel is bound by [AnimatedVisibility] to `reason != null`, so it
+ * slides into view when audio stops and slides out when playback
+ * resumes — never popping the rest of the player UI.
+ *
+ * Accessibility: the whole panel is a polite live region; TalkBack
+ * announces a new reason as it arrives. Each variant carries its own
+ * `contentDescription` because the secondary line + retry chip add
+ * context the headline alone can't convey.
+ */
+@Composable
+fun WhyAreWeWaitingPanel(
+    reason: WaitReason?,
+    modifier: Modifier = Modifier,
+    onRetry: () -> Unit = {},
+    onOpenSettings: () -> Unit = {},
+) {
+    val spacing = LocalSpacing.current
+    val motion = LocalMotion.current
+    val reducedMotion = LocalReducedMotion.current
+
+    AnimatedVisibility(
+        visible = reason != null,
+        enter = fadeIn(tween(motion.standardDurationMs, easing = motion.standardEasing)) +
+            expandVertically(tween(motion.standardDurationMs, easing = motion.standardEasing)),
+        exit = fadeOut(tween(motion.standardDurationMs, easing = motion.standardEasing)) +
+            shrinkVertically(tween(motion.standardDurationMs, easing = motion.standardEasing)),
+        modifier = modifier,
+    ) {
+        // Snapshot the reason so the composable body doesn't recompose
+        // back to null mid-exit-animation; AnimatedVisibility keeps the
+        // last non-null reason on screen during exit.
+        val r = reason ?: return@AnimatedVisibility
+
+        val brass = MaterialTheme.colorScheme.primary
+        // 5 % brass washed onto the surface background — visible against
+        // the Library Nocturne dark surface without competing with the
+        // cover for attention.
+        val panelBg = brass.copy(alpha = 0.08f)
+            .compositeOver(MaterialTheme.colorScheme.surface)
+        val borderColor = brass.copy(alpha = 0.30f)
+
+        Column(
+            modifier = Modifier
+                .fillMaxWidth()
+                .clip(RoundedCornerShape(5.dp))
+                .background(panelBg)
+                .border(width = 1.dp, color = borderColor, shape = RoundedCornerShape(5.dp))
+                .padding(horizontal = spacing.md, vertical = spacing.sm)
+                .semantics {
+                    liveRegion = LiveRegionMode.Polite
+                    contentDescription = "${r.message}. ${secondaryLineFor(r)}"
+                },
+            verticalArrangement = Arrangement.spacedBy(spacing.xs),
+        ) {
+            // Headline row — pulsing brass sigil + EB Garamond headline.
+            Row(
+                verticalAlignment = Alignment.CenterVertically,
+                horizontalArrangement = Arrangement.spacedBy(spacing.sm),
+            ) {
+                PulsingBrassSigil(
+                    color = brass,
+                    reducedMotion = reducedMotion,
+                )
+                Text(
+                    text = r.message,
+                    color = brass,
+                    fontFamily = FontFamily.Serif, // EB Garamond proxy — Library Nocturne maps Serif → EB Garamond
+                    fontWeight = FontWeight.Medium,
+                    fontSize = 18.sp,
+                    modifier = Modifier.weight(1f),
+                )
+            }
+
+            // Optional thin progress bar. 2 dp tall at 70 % opacity per
+            // spec; only shown when the reason carries a known fraction.
+            r.progressFraction?.let { frac ->
+                LinearProgressIndicator(
+                    progress = { frac.coerceIn(0f, 1f) },
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .height(2.dp)
+                        .alpha(0.70f),
+                    color = brass,
+                    trackColor = brass.copy(alpha = 0.15f),
+                    strokeCap = ProgressIndicatorDefaults.LinearStrokeCap,
+                    gapSize = 0.dp,
+                    drawStopIndicator = {},
+                )
+            }
+
+            // Secondary line — small Inter (proxy: SansSerif) 12 sp at
+            // brass-50, explains *what's happening* in one sentence.
+            Text(
+                text = secondaryLineFor(r),
+                color = brass.copy(alpha = 0.65f),
+                fontFamily = FontFamily.SansSerif,
+                fontSize = 12.sp,
+                modifier = Modifier.fillMaxWidth(),
+            )
+
+            // Optional action chip — brass-bordered, right-aligned. Only
+            // rendered when the reason is user-actionable.
+            if (r.isUserActionable) {
+                Row(
+                    modifier = Modifier.fillMaxWidth(),
+                    horizontalArrangement = Arrangement.End,
+                ) {
+                    val (label, action) = chipLabelAndActionFor(r, onRetry, onOpenSettings)
+                    BrassActionChip(
+                        label = label,
+                        onClick = action,
+                        borderColor = borderColor,
+                        textColor = brass,
+                    )
+                }
+            }
+        }
+    }
+}
+
+/**
+ * Pulsing brass sigil — a 12 dp dot that fades 0.5 → 1.0 → 0.5 alpha on a
+ * 1.5 s period. Honors reduced motion: when on, the sigil holds at the
+ * mid-alpha so the visual still reads as "we're watching for output"
+ * without animation.
+ */
+@Composable
+private fun PulsingBrassSigil(
+    color: Color,
+    reducedMotion: Boolean,
+) {
+    val alpha = if (reducedMotion) 0.75f else {
+        val transition = androidx.compose.animation.core
+            .rememberInfiniteTransition(label = "why-waiting-sigil")
+        val a by transition.animateFloat(
+            initialValue = 0.5f,
+            targetValue = 1.0f,
+            animationSpec = infiniteRepeatable(
+                animation = tween(durationMillis = 1500, easing = androidx.compose.animation.core.LinearEasing),
+                repeatMode = RepeatMode.Reverse,
+            ),
+            label = "sigil-alpha",
+        )
+        a
+    }
+    Box(
+        modifier = Modifier
+            .size(12.dp)
+            .alpha(alpha)
+            .clip(RoundedCornerShape(6.dp))
+            .background(color),
+    )
+}
+
+/**
+ * Brass-bordered action chip used for the panel's optional retry /
+ * settings affordance. Keeps the visual lighter than a Material Button
+ * (which would compete with the play control downstream).
+ */
+@Composable
+private fun BrassActionChip(
+    label: String,
+    onClick: () -> Unit,
+    borderColor: Color,
+    textColor: Color,
+) {
+    Box(
+        modifier = Modifier
+            .clip(RoundedCornerShape(50))
+            .border(width = 1.dp, color = borderColor, shape = RoundedCornerShape(50))
+            .clickable(onClick = onClick)
+            .padding(horizontal = 12.dp, vertical = 4.dp)
+            .semantics { contentDescription = label },
+    ) {
+        Text(
+            text = label,
+            color = textColor,
+            fontFamily = FontFamily.SansSerif,
+            fontWeight = FontWeight.Medium,
+            fontSize = 12.sp,
+        )
+    }
+}
+
+/**
+ * Per-variant secondary line copy. Each variant gets one sentence that
+ * explains *what* storyvox is waiting on, in plain language. EB Garamond
+ * headline + Inter explanation = library card aesthetic.
+ */
+internal fun secondaryLineFor(reason: WaitReason): String = when (reason) {
+    is WaitReason.WarmingVoice ->
+        "Voice models load once per chapter session."
+    is WaitReason.LoadingChapter ->
+        "Fetching the chapter text from its source."
+    is WaitReason.BufferingNextSentence ->
+        "The pipeline is rendering the next sentence's audio."
+    is WaitReason.NetworkSlow ->
+        "The chapter source is responding slowly."
+    is WaitReason.FocusLost ->
+        "Audio focus returns when the other audio ends."
+    WaitReason.AudioRouteChange ->
+        "Adjusting for the new output device."
+    WaitReason.DeviceMuted ->
+        "Raise the media volume to hear playback."
+    is WaitReason.VoiceDownloadFailed ->
+        "Voice download didn't complete. Check your connection."
+    is WaitReason.AudioOutputStuck ->
+        "If this persists, tap retry to nudge the pipeline."
+}
+
+/**
+ * Per-variant label + action for the optional retry chip. Pairs with
+ * [WaitReason.isUserActionable] — only the variants where actionable is
+ * true reach this function.
+ */
+internal fun chipLabelAndActionFor(
+    reason: WaitReason,
+    onRetry: () -> Unit,
+    onOpenSettings: () -> Unit,
+): Pair<String, () -> Unit> = when (reason) {
+    WaitReason.DeviceMuted -> "Open settings" to onOpenSettings
+    is WaitReason.AudioOutputStuck -> "Retry" to onRetry
+    is WaitReason.VoiceDownloadFailed -> "Retry" to onRetry
+    is WaitReason.NetworkSlow -> "Retry" to onRetry
+    is WaitReason.FocusLost -> "Resume" to onRetry
+    WaitReason.AudioRouteChange -> "Resume" to onRetry
+    else -> "Retry" to onRetry
+}


### PR DESCRIPTION
## Summary
- **AudioOutputMonitor** (new Singleton in `:core-playback`) ticks at 200 ms while the player is alive, reads the truthful AudioTrack head-position via `PlaybackController.playbackPositionMs`, and cross-references `AudioFocusController` state + `AudioManager` volume/mute + `AudioDeviceCallback` route events to emit a typed `WaitReason` flow.
- **WaitReason** (new sealed interface): WarmingVoice / LoadingChapter / BufferingNextSentence / NetworkSlow / FocusLost / AudioRouteChange / DeviceMuted / VoiceDownloadFailed / AudioOutputStuck (the EVERY-time catch-all).
- **WhyAreWeWaitingPanel** (new Composable in `:feature/.../reader/`): Library Nocturne brass surface above the cover — pulsing brass sigil at 1.5 s period, EB Garamond 18sp headline, optional 2dp progress bar, 12sp secondary line, brass-bordered retry chip. `AnimatedVisibility` slides in/out on null transitions.
- Lifecycle bound to `StoryvoxPlaybackService.onCreate` / `onDestroy`; idempotent re-anchoring.

## Architecture
```
StoryvoxPlaybackService.onCreate()
   └─ audioOutputMonitor.start()
         │
         └─ 200ms tick → PlaybackController.playbackPositionMs
                       → AudioFocusController.isHeld()
                       → AudioManager (volume, mute, mode)
                       → AudioDeviceCallback (route changes)
                       → diagnose() → WaitReason | null

PlaybackController.waitReason  ──┐
PlaybackControllerUi.waitReason  ┼─→  ReaderUiState.waitReason
ReaderUiState.waitReason         ──┘    └─→  AudiobookView(waitReason = ...)
                                                └─→  WhyAreWeWaitingPanel
```

Cycle-break: monitor depends on `Provider<PlaybackController>`; controller depends on `dagger.Lazy<AudioOutputMonitor>`. Both providers resolve lazily so the Singleton graph builds cleanly.

## Test plan
- [x] `./gradlew :app:assembleRelease` green (5m 56s)
- [x] `./gradlew :core-playback:testDebugUnitTest :feature:testDebugUnitTest :app:testDebugUnitTest` green (256+ tests pass)
- [x] 7 new diagnose() tests in `AudioOutputMonitorTest` cover Idle/Paused/Warming/Buffering(mid+pre-chapter)/DeviceMuted/AudioOutputStuck-escalation
- [x] Installed debug build on R5CRB0W66MK (Z Flip 3) — logcat shows `AudioOutputMonitor: monitor started` + `audio route added — count=7` at service onCreate
- [x] Installed debug build on R83W80CAFZB (Tab A7 Lite) — logcat shows `AudioOutputMonitor: monitor started` + `audio route added — count=4` at service onCreate
- [x] DeviceMuted signal verified via `input keyevent KEYCODE_VOLUME_MUTE` → `dumpsys audio` confirms STREAM_MUSIC mute state which `diagnose()` reads
- [ ] End-to-end visual verification on real chapter playback (panel rendering during warmup / buffer / focus loss)

🤖 Generated with [Claude Code](https://claude.com/claude-code)