### PR TITLE
fix(safety): 988 Suicide & Crisis Lifeline must be single-tap for TalkBack — closes #608

### DIFF
--- a/feature/src/main/kotlin/in/jphe/storyvox/feature/techempower/TechEmpowerHelpIcons.kt
+++ b/feature/src/main/kotlin/in/jphe/storyvox/feature/techempower/TechEmpowerHelpIcons.kt
@@ -1,14 +1,13 @@
 package `in`.jphe.storyvox.feature.techempower
 
-import androidx.compose.foundation.ExperimentalFoundationApi
 import androidx.compose.foundation.clickable
-import androidx.compose.foundation.combinedClickable
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Forum
+import androidx.compose.material.icons.filled.MonitorHeart
 import androidx.compose.material.icons.filled.Phone
 import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
@@ -24,68 +23,71 @@ import androidx.compose.ui.semantics.Role
 import androidx.compose.ui.unit.dp
 
 /**
- * Issue #517 — paired brass-tinted help icons (Phone + Discord Forum)
- * surfaced in the top-app-bar on Library and TechEmpower Home. One-tap
- * affordances for "I need help right now" — JP's design call locks
- * Discord + 211 as the primary peer-support + social-services
- * surfaces, with 988 (Suicide & Crisis Lifeline) reachable via
- * long-press on the phone icon.
+ * Issue #517 + #608 — brass-tinted help icons (988 + 211 + Discord)
+ * surfaced in the top-app-bar on Library and TechEmpower Home. Three
+ * single-tap affordances for "I need help right now". JP's design call
+ * locks 988 (Suicide & Crisis Lifeline), 211 (social services), and
+ * Discord (peer-support) as the always-on entry points.
  *
- * Why a shared composable: the icon pair appears identically on both
- * surfaces (Library + TechEmpower Home), and centralising the layout +
- * intent wiring means a behavioural change (e.g., swap the phone
- * long-press target from 988 to 911) is a one-file edit instead of
- * keeping two copies in sync.
+ * Why three separate icons and not "tap = 211, long-press = 988":
+ * Issue #608 — TalkBack users cannot reliably trigger the long-press
+ * gesture (Android's "double-tap and hold" is non-obvious and
+ * error-prone), so a sight-impaired user in crisis previously had no
+ * one-shot path to 988 from the top-app-bar. Splitting 988 into its
+ * own tappable icon — with an explicit `contentDescription` —
+ * gives every user (sighted + screen-reader) the same single-gesture
+ * affordance. Long-press is gone entirely; the Emergency Help card on
+ * Library home exposes the same numbers for users who prefer that
+ * surface.
  *
- * Why a `Box.combinedClickable` instead of `IconButton`: IconButton
- * doesn't expose a long-click slot, so the standard Material 3
- * pattern for "tap + long-press behave differently" is to drop to a
- * Box and apply `Modifier.combinedClickable`. The Box keeps the same
- * 48dp touch-target size IconButton uses by default, and the implicit
- * `LocalIndication` ripple renders identically to IconButton.
+ * Why a shared composable: the icon trio appears identically on both
+ * surfaces (Library + TechEmpower Home), and centralising the layout
+ * + intent wiring means a behavioural change is a one-file edit
+ * instead of keeping two copies in sync.
+ *
+ * Why a `Box.clickable` instead of `IconButton`: IconButton bakes in
+ * a default 48dp ripple ring with its own padding semantics that
+ * shrinks the visual glyph relative to a plain Box; the Boxes here
+ * already provide the same 48dp touch target and align with the
+ * other top-bar action visuals (SyncCloudIcon also uses a Box).
  *
  * Brass tint comes from `MaterialTheme.colorScheme.primary` — same
  * brass-on-warm-dark palette as every other top-app-bar action in the
  * app.
  *
  * v0.5.51 — first pass alongside the TechEmpower brand integration.
+ * v0.5.61 — split 988 into its own icon (#608, TalkBack safety).
  */
-@OptIn(ExperimentalFoundationApi::class)
 @Composable
 fun TechEmpowerHelpIcons() {
     val context = LocalContext.current
 
-    // Issue #546 — fallback dialog state for the top-app-bar phone
-    // icon. Without this, a tap on a WiFi-only tablet routes to the
-    // contact picker. The shared [NoTelephonyDialog]-equivalent path
-    // is owned by [TechEmpowerHomeScreen]; here we use the same
-    // [dialOrSurfaceFallback] helper and surface the dialog locally
-    // so Library users get the same protection.
+    // Issue #546 — fallback dialog state for any helpline tapped on a
+    // device without telephony. Shared across all three direct-dial
+    // entry points (988 icon, 211 icon — and any future additions)
+    // because they all route through [dialOrSurfaceFallback]. The
+    // Discord icon is non-telephony so it bypasses this state.
     var noTelephonyTarget by remember { mutableStateOf<EmergencyTarget?>(null) }
 
-    // ─── Call 211 (primary) / 988 (long-press) ───────────────────────
-    // tel: URIs go through ACTION_DIAL so the user lands in the dialer
-    // with the number pre-filled but NOT auto-dialled — accidental
-    // top-app-bar taps surface as "huh, the dialer opened" rather than
-    // an actual phone call. ACTION_CALL would require CALL_PHONE
-    // permission and is the wrong UX for an in-bar shortcut.
+    // ─── Call 988 — Suicide & Crisis Lifeline ────────────────────────
+    // Issue #608 — TalkBack-safe direct tap. Previously this number
+    // was hidden behind a long-press on the 211 icon, which TalkBack
+    // users could not reliably trigger. Now it is its own 48dp icon
+    // with an explicit content description so screen-reader users
+    // hear "Call 988, Suicide and Crisis Lifeline" on swipe and can
+    // reach it with a single double-tap.
     //
-    // Issue #546 — both tap and long-press route through
-    // [dialOrSurfaceFallback] so devices without telephony land on the
-    // explanatory fallback dialog instead of the AOSP contact picker.
+    // MonitorHeart is the closest M3 stock glyph to a "crisis /
+    // health-line" affordance — a heart with a pulse waveform reads
+    // as medical-urgency in a way the plain Phone icon does not.
+    // Tinted brass like every other top-bar action so the colour
+    // pairs with the brass-on-warm-dark palette.
     Box(
         modifier = Modifier
             .size(48.dp)
-            .combinedClickable(
+            .clickable(
                 role = Role.Button,
                 onClick = {
-                    dialOrSurfaceFallback(
-                        context = context,
-                        target = EmergencyTarget.Help211,
-                        onNoTelephony = { noTelephonyTarget = it },
-                    )
-                },
-                onLongClick = {
                     dialOrSurfaceFallback(
                         context = context,
                         target = EmergencyTarget.Crisis988,
@@ -96,19 +98,55 @@ fun TechEmpowerHelpIcons() {
         contentAlignment = Alignment.Center,
     ) {
         Icon(
-            imageVector = Icons.Filled.Phone,
-            contentDescription =
-                "Call 211 for help. Long-press for the 988 Suicide and Crisis Lifeline.",
+            imageVector = Icons.Filled.MonitorHeart,
+            contentDescription = "Call 988, Suicide and Crisis Lifeline.",
             tint = MaterialTheme.colorScheme.primary,
             modifier = Modifier.size(24.dp),
         )
     }
 
-    // Issue #533 — 8dp gap between the phone and Discord icons. The
-    // two 48dp Boxes used to pack flush together, making mis-taps
-    // trivial on the Flip3 (1080dp narrow). Spacer keeps both icons
-    // at their full 48dp tap targets while giving the user enough
-    // visual + finger separation to choose one deliberately.
+    // Issue #533 — 8dp gap between icons. The 48dp Boxes pack flush
+    // together otherwise, making mis-taps trivial on the Flip3
+    // (1080dp narrow). The Spacer keeps each icon at its full 48dp
+    // tap target while giving the user enough visual + finger
+    // separation to choose one deliberately.
+    Spacer(Modifier.width(8.dp))
+
+    // ─── Call 211 — local help / social services ─────────────────────
+    // Single tap. tel: URI goes through ACTION_DIAL so the user lands
+    // in the dialer with the number pre-filled but NOT auto-dialled
+    // — accidental top-app-bar taps surface as "huh, the dialer
+    // opened" rather than an actual phone call. ACTION_CALL would
+    // require CALL_PHONE permission and is the wrong UX for an in-bar
+    // shortcut.
+    //
+    // Issue #546 — routes through [dialOrSurfaceFallback] so devices
+    // without telephony land on the explanatory fallback dialog
+    // instead of the AOSP contact picker.
+    Box(
+        modifier = Modifier
+            .size(48.dp)
+            .clickable(
+                role = Role.Button,
+                onClick = {
+                    dialOrSurfaceFallback(
+                        context = context,
+                        target = EmergencyTarget.Help211,
+                        onNoTelephony = { noTelephonyTarget = it },
+                    )
+                },
+            ),
+        contentAlignment = Alignment.Center,
+    ) {
+        Icon(
+            imageVector = Icons.Filled.Phone,
+            contentDescription =
+                "Call 211, local help: housing, food, and mental health referrals.",
+            tint = MaterialTheme.colorScheme.primary,
+            modifier = Modifier.size(24.dp),
+        )
+    }
+
     Spacer(Modifier.width(8.dp))
 
     // ─── Open peer-support Discord ───────────────────────────────────


### PR DESCRIPTION
## Summary

- **Closes #608** (v1.0-blocker, accessibility, priority:high).
- The 988 Suicide & Crisis Lifeline was previously reachable only via **long-press** on the top-bar phone icon — a gesture TalkBack users cannot reliably trigger. For a sight-impaired user in crisis, that's a safety-critical accessibility failure.
- Splits the top-bar help affordances into **three single-tap icons** (Option A from the spec):
  1. `MonitorHeart` -> 988 — `contentDescription = "Call 988, Suicide and Crisis Lifeline."`
  2. `Phone` -> 211 — `contentDescription = "Call 211, local help: housing, food, and mental health referrals."`
  3. `Forum` -> Discord (unchanged)
- Removed `combinedClickable` and the misleading "Long-press for the 988…" copy. Both 988 and 211 still route through `dialOrSurfaceFallback` so WiFi-only devices land on the `NoTelephonyFallbackDialog` from #574/#546.

## Why Option A (two icons), not Option B (chooser sheet)

- JP's stated preference (cleaner, faster path) — verified the icon row fits on Flip3 (1080dp narrow). Top-bar now has 5 action icons (988, 211, Discord, Sync, Settings) at 48dp each + 8dp spacers between TechEmpower icons + xs spacers before Sync/Settings. CenterAlignedTopAppBar shrinks the title region as needed.
- `MonitorHeart` is the closest M3 stock glyph to a medical/crisis affordance — a heart with a pulse waveform reads as health-urgency in a way the plain Phone icon does not.

## Files changed

- `feature/src/main/kotlin/in/jphe/storyvox/feature/techempower/TechEmpowerHelpIcons.kt` — single file, +83 / -45.

No callers needed updating — `TechEmpowerHelpIcons()` signature is unchanged, so both `LibraryScreen.kt` and `TechEmpowerHomeScreen.kt` pick it up automatically.

## Test plan

- [x] `./gradlew :app:assembleRelease :feature:testDebugUnitTest :app:testDebugUnitTest` — passes locally (4m 1s, 1386 tasks).
- [x] R83W80CAFZB (WiFi-only tablet, no telephony): 988 icon visible in top app bar at [431,74][495,138]; single tap -> `NoTelephonyFallbackDialog` with title "This device can't make calls" and the body "Suicide & Crisis Lifeline — call 988 from a phone".
- [x] R5CRB0W66MK (phone, real dial): 988 icon visible at [252,212][396,356]; single tap -> Samsung dialer (`com.samsung.android.dialer/.DialtactsActivity`) pre-filled with `988`.
- [x] TalkBack ON (R83W80CAFZB): single tap on 988 icon announces "Call 988, Suicide and Crisis Lifeline." and DOES NOT trigger the dialog (TalkBack consumes the tap as focus). Double-tap activates and fires `NoTelephonyFallbackDialog`. **No long-press required.**
- [x] TalkBack disabled on both devices after audit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)