### PR TITLE
fix: phone can't load Notion chapter — closes #640

### DIFF
--- a/core-playback/src/main/kotlin/in/jphe/storyvox/playback/PlaybackController.kt
+++ b/core-playback/src/main/kotlin/in/jphe/storyvox/playback/PlaybackController.kt
@@ -437,16 +437,70 @@ class DefaultPlaybackController @Inject constructor(
      */
     private suspend fun runBufferingWatchdog(p: EnginePlayer) {
         var watchdogJob: kotlinx.coroutines.Job? = null
+        // Issue #640 — two-tier watchdog. Distinguishes intra-chapter
+        // underrun pauses (false-positive) from genuinely stuck states
+        // (legitimate fire) by the presence of `currentSentenceRange`,
+        // and runs each on its own threshold.
+        //
+        // Before this disambiguation, the consumer's catch-up-pause branch
+        // ([EnginePlayer] line ~2161, the
+        // `bufferHeadroomMs < BUFFER_UNDERRUN_THRESHOLD_MS` path) set
+        // `isBuffering = true` mid-chapter without clearing
+        // `currentSentenceRange`. On Piper-low / Z Flip 3 (sub-realtime
+        // synth), that underrun pause held for >1.5 s as the producer
+        // caught up — the watchdog fired in the middle of chapter 1,
+        // called `advanceChapter(1)`, which interrupted the still-running
+        // consumer mid-write, and stranded chapter 2's pipeline
+        // half-constructed. The user saw "Reconnecting — please wait"
+        // (AudioOutputStuck) with audio focus held but no PCM moving.
+        //
+        // The two legitimate "buffering" states are now disambiguated by
+        // `currentSentenceRange`:
+        //
+        //   - **Chapter-transition buffering** (`currentSentenceRange == null`):
+        //     set by handleChapterDone / advanceChapter / loadAndPlay
+        //     before the new pipeline emits its first sentence. This IS
+        //     the case the watchdog is designed for — natural-end advance
+        //     failed to land, fire a fallback advance. Fast threshold
+        //     (`BUFFERING_STUCK_WATCHDOG_MS` = 1.5 s, original behaviour)
+        //     so the gap between chapters stays imperceptible.
+        //
+        //   - **Intra-chapter underrun / end-of-chapter without natural-end**
+        //     (`currentSentenceRange != null`): consumer is parked on the
+        //     bufferHeadroom flow with the last-played sentence range
+        //     still in state. On healthy CPU the producer catches up
+        //     within a few hundred ms; on Piper-low / slow CPU it can
+        //     hold for several seconds; in the worst case (the natural-
+        //     end branch silently failing to fire on Notion sources)
+        //     it holds forever. Slow threshold
+        //     (`BUFFERING_STUCK_WATCHDOG_END_OF_CHAPTER_MS` = 12 s) gives
+        //     legitimate underruns ample time to resolve naturally, then
+        //     kicks the same fallback advance for the truly-stuck case.
+        //
+        // Triple is `(transitionBuffering, endOfChapterBuffering, chapterId)`.
+        // distinctUntilChanged emits on any transition; the collect
+        // cancels the prior watchdog and arms a new one with the right
+        // threshold for whichever state we landed in.
         p.observableState
-            .map { (it.isBuffering && it.currentChapterId != null) to it.currentChapterId }
+            .map {
+                val buffering = it.isBuffering && it.currentChapterId != null
+                val transition = buffering && it.currentSentenceRange == null
+                val endOfChapter = buffering && it.currentSentenceRange != null
+                Triple(transition, endOfChapter, it.currentChapterId)
+            }
             .distinctUntilChanged()
-            .collect { (buffering, chapterId) ->
+            .collect { (transition, endOfChapter, chapterId) ->
                 watchdogJob?.cancel()
                 watchdogJob = null
-                if (!buffering || chapterId == null) return@collect
+                if ((!transition && !endOfChapter) || chapterId == null) return@collect
                 val armedFor = chapterId
+                val threshold = if (transition) {
+                    BUFFERING_STUCK_WATCHDOG_MS
+                } else {
+                    BUFFERING_STUCK_WATCHDOG_END_OF_CHAPTER_MS
+                }
                 watchdogJob = scope.launch {
-                    kotlinx.coroutines.delay(BUFFERING_STUCK_WATCHDOG_MS)
+                    kotlinx.coroutines.delay(threshold)
                     val nowState = p.observableState.value
                     // Only fire if we're STILL buffering AND still on
                     // the same chapter id (i.e. nothing else has
@@ -797,22 +851,37 @@ class DefaultPlaybackController @Inject constructor(
          *  [skipConfig.rewindToStartThresholdSec] Flow. */
         internal const val REWIND_TO_START_THRESHOLD_SEC = 3f
 
-        /** Issue #553 — buffering-stuck watchdog threshold. If
-         *  `isBuffering=true` holds on the same chapter id for this long
-         *  without a state transition (advance, error, user pause), fire
-         *  a fallback `advanceChapter(1)` to recover. Started at 8 s
-         *  (cautious), lowered to 1.5 s once on-device testing confirmed
-         *  the engine-side primary advance silently fails to fire at
-         *  natural chapter end on Notion sources — the watchdog is the
-         *  *only* working advance path on that backend, and 8 s is far
-         *  too noticeable as the gap between chapters (target:
-         *  Spotify/Apple Music-grade, essentially imperceptible). If
-         *  the next chapter body isn't downloaded by the time the
-         *  watchdog fires, advanceChapter itself still has a 30 s
-         *  internal timeout, so a false-positive is harmless — the
-         *  fallback advance just waits on the same future the engine-
-         *  side advance would have waited on. */
+        /** Issue #553 — buffering-stuck watchdog threshold for the
+         *  **chapter-transition** path (sentence range cleared, new
+         *  pipeline hasn't emitted yet). Kept fast (1.5 s) so the gap
+         *  between chapters stays imperceptible — Spotify/Apple
+         *  Music-grade pacing. Issue #640 added a structural gate on
+         *  `currentSentenceRange == null` (see [runBufferingWatchdog])
+         *  so the false-positive case (intra-chapter underrun) routes
+         *  to [BUFFERING_STUCK_WATCHDOG_END_OF_CHAPTER_MS] instead. */
         internal const val BUFFERING_STUCK_WATCHDOG_MS = 1_500L
+
+        /** Issue #640 — buffering-stuck watchdog threshold for the
+         *  **intra-chapter / end-of-chapter** path (sentence range still
+         *  set). Longer (12 s) because legitimate underrun pauses on
+         *  slow CPUs (Piper-low / Z Flip 3) can hold for several
+         *  seconds before the producer catches up, and firing a
+         *  chapter advance mid-chapter is catastrophic — interrupts
+         *  the still-running consumer, strands the new chapter's
+         *  pipeline half-constructed, and leaves the user on
+         *  "Reconnecting — please wait" with audio focus held but no
+         *  PCM moving.
+         *
+         *  This path also covers the worst-case scenario where the
+         *  consumer's natural-end branch silently fails to fire (the
+         *  original #553 root cause): the producer has emitted every
+         *  sentence but END_PILL never surfaced through `nextChunk()`
+         *  on Notion sources for reasons that still resist
+         *  reproduction in unit tests. After 12 s of stuck-with-
+         *  sentence-range we conclude the chapter is genuinely over
+         *  and fire the fallback advance — same recovery path the
+         *  manual skip-next button uses. */
+        internal const val BUFFERING_STUCK_WATCHDOG_END_OF_CHAPTER_MS = 12_000L
 
         /**
          * #531 / #550 — pure-function exports of the seek math so JVM unit

--- a/core-playback/src/test/kotlin/in/jphe/storyvox/playback/PlaybackSmoothnessFollowupTest.kt
+++ b/core-playback/src/test/kotlin/in/jphe/storyvox/playback/PlaybackSmoothnessFollowupTest.kt
@@ -100,36 +100,71 @@ class PlaybackSmoothnessFollowupTest {
 
     // ─── #553: buffering-stuck watchdog ──────────────────────────────
 
-    @Test
-    fun `watchdog fires once when isBuffering stays stuck on same chapter`() = runTest {
-        val state = MutableStateFlow(
-            PlaybackState(currentChapterId = "ch1", isPlaying = true, isBuffering = true),
-        )
-        var firedFor: String? = null
-        val job = launch {
-            // Inline replica of the watchdog (slimmer than collecting
-            // the full controller's flow chain).
-            var watchdog: kotlinx.coroutines.Job? = null
-            state
-                .map { (it.isBuffering && it.currentChapterId != null) to it.currentChapterId }
-                .distinctUntilChanged()
-                .collect { (buffering, chapterId) ->
-                    watchdog?.cancel()
-                    if (!buffering || chapterId == null) return@collect
-                    val armedFor = chapterId
-                    watchdog = launch {
-                        delay(DefaultPlaybackController.BUFFERING_STUCK_WATCHDOG_MS)
-                        val s = state.value
-                        if (
-                            s.isBuffering &&
-                            s.currentChapterId == armedFor &&
-                            s.error == null
-                        ) {
-                            firedFor = armedFor
-                        }
+    /**
+     * Inline replica of [DefaultPlaybackController.runBufferingWatchdog],
+     * trimmed to what the JVM tests need (no controller-scope, no
+     * EnginePlayer dispatch). Mirrors the production two-tier gate
+     * exactly — `currentSentenceRange == null` selects the fast
+     * 1.5 s chapter-transition threshold; sentence range set selects
+     * the slow 12 s intra-chapter / end-of-chapter threshold so we
+     * don't fire mid-chapter on a Piper-low underrun pause (the #640
+     * v1.0 blocker symptom).
+     *
+     * Returns a launched Job that records the armed chapter id into
+     * [onFire] when the watchdog actually triggers; cancel the job in
+     * tests' tearDown to avoid leaking a runTest coroutine.
+     */
+    private fun kotlinx.coroutines.CoroutineScope.runInlineWatchdog(
+        state: MutableStateFlow<PlaybackState>,
+        onFire: (String) -> Unit,
+    ) = launch {
+        var watchdog: kotlinx.coroutines.Job? = null
+        state
+            .map {
+                val buffering = it.isBuffering && it.currentChapterId != null
+                val transition = buffering && it.currentSentenceRange == null
+                val endOfChapter = buffering && it.currentSentenceRange != null
+                Triple(transition, endOfChapter, it.currentChapterId)
+            }
+            .distinctUntilChanged()
+            .collect { (transition, endOfChapter, chapterId) ->
+                watchdog?.cancel()
+                if ((!transition && !endOfChapter) || chapterId == null) return@collect
+                val armedFor = chapterId
+                val threshold = if (transition) {
+                    DefaultPlaybackController.BUFFERING_STUCK_WATCHDOG_MS
+                } else {
+                    DefaultPlaybackController.BUFFERING_STUCK_WATCHDOG_END_OF_CHAPTER_MS
+                }
+                watchdog = launch {
+                    delay(threshold)
+                    val s = state.value
+                    if (
+                        s.isBuffering &&
+                        s.currentChapterId == armedFor &&
+                        s.error == null
+                    ) {
+                        onFire(armedFor)
                     }
                 }
-        }
+            }
+    }
+
+    @Test
+    fun `watchdog fires once when isBuffering stays stuck on same chapter`() = runTest {
+        // Chapter-transition buffering: sentence range null because the
+        // new pipeline hasn't emitted its first sentence yet. This is
+        // the case the watchdog exists to recover.
+        val state = MutableStateFlow(
+            PlaybackState(
+                currentChapterId = "ch1",
+                isPlaying = true,
+                isBuffering = true,
+                currentSentenceRange = null,
+            ),
+        )
+        var firedFor: String? = null
+        val job = runInlineWatchdog(state) { firedFor = it }
         // Less than the threshold — watchdog should not have fired yet.
         advanceTimeBy(DefaultPlaybackController.BUFFERING_STUCK_WATCHDOG_MS / 2)
         assertNull("watchdog fired prematurely", firedFor)
@@ -142,42 +177,22 @@ class PlaybackSmoothnessFollowupTest {
     @Test
     fun `watchdog cancels when chapter changes before threshold`() = runTest {
         val state = MutableStateFlow(
-            PlaybackState(currentChapterId = "ch1", isPlaying = true, isBuffering = true),
+            PlaybackState(
+                currentChapterId = "ch1",
+                isPlaying = true,
+                isBuffering = true,
+                currentSentenceRange = null,
+            ),
         )
         var firedFor: String? = null
-        val job = launch {
-            var watchdog: kotlinx.coroutines.Job? = null
-            state
-                .map { (it.isBuffering && it.currentChapterId != null) to it.currentChapterId }
-                .distinctUntilChanged()
-                .collect { (buffering, chapterId) ->
-                    watchdog?.cancel()
-                    if (!buffering || chapterId == null) return@collect
-                    val armedFor = chapterId
-                    watchdog = launch {
-                        delay(DefaultPlaybackController.BUFFERING_STUCK_WATCHDOG_MS)
-                        val s = state.value
-                        if (
-                            s.isBuffering &&
-                            s.currentChapterId == armedFor &&
-                            s.error == null
-                        ) {
-                            firedFor = armedFor
-                        }
-                    }
-                }
-        }
-        // Chapter advances naturally before the watchdog threshold.
-        // v0.5.57 (#557) — watchdog dropped from 8 s → 1.5 s, so the
-        // "advance well before threshold" probe has to be sub-threshold.
-        // Pre-fix this advanced 2 s which now overshoots the 1.5 s
-        // watchdog, fires it, and trips the assertNull on the test below.
+        val job = runInlineWatchdog(state) { firedFor = it }
+        // Chapter advances naturally well before the watchdog threshold.
         advanceTimeBy(500L)
         state.value = state.value.copy(
             currentChapterId = "ch2",
             isBuffering = false,
         )
-        // Now well past the original threshold.
+        // Now well past the threshold.
         advanceTimeBy(DefaultPlaybackController.BUFFERING_STUCK_WATCHDOG_MS + 1_000L)
         assertNull("watchdog should have cancelled on chapter change", firedFor)
         job.cancel()
@@ -186,35 +201,15 @@ class PlaybackSmoothnessFollowupTest {
     @Test
     fun `watchdog cancels when isBuffering clears before threshold`() = runTest {
         val state = MutableStateFlow(
-            PlaybackState(currentChapterId = "ch1", isPlaying = true, isBuffering = true),
+            PlaybackState(
+                currentChapterId = "ch1",
+                isPlaying = true,
+                isBuffering = true,
+                currentSentenceRange = null,
+            ),
         )
         var firedFor: String? = null
-        val job = launch {
-            var watchdog: kotlinx.coroutines.Job? = null
-            state
-                .map { (it.isBuffering && it.currentChapterId != null) to it.currentChapterId }
-                .distinctUntilChanged()
-                .collect { (buffering, chapterId) ->
-                    watchdog?.cancel()
-                    if (!buffering || chapterId == null) return@collect
-                    val armedFor = chapterId
-                    watchdog = launch {
-                        delay(DefaultPlaybackController.BUFFERING_STUCK_WATCHDOG_MS)
-                        val s = state.value
-                        if (
-                            s.isBuffering &&
-                            s.currentChapterId == armedFor &&
-                            s.error == null
-                        ) {
-                            firedFor = armedFor
-                        }
-                    }
-                }
-        }
-        // v0.5.57 (#557) — watchdog dropped from 8 s → 1.5 s, so the
-        // "advance well before threshold" probe has to be sub-threshold.
-        // Pre-fix this advanced 2 s which now overshoots the 1.5 s
-        // watchdog, fires it, and trips the assertNull on the test below.
+        val job = runInlineWatchdog(state) { firedFor = it }
         advanceTimeBy(500L)
         // Buffering clears (e.g., chapter body landed, audio started).
         state.value = state.value.copy(isBuffering = false)
@@ -226,35 +221,15 @@ class PlaybackSmoothnessFollowupTest {
     @Test
     fun `watchdog does not fire when error surfaces before threshold`() = runTest {
         val state = MutableStateFlow(
-            PlaybackState(currentChapterId = "ch1", isPlaying = true, isBuffering = true),
+            PlaybackState(
+                currentChapterId = "ch1",
+                isPlaying = true,
+                isBuffering = true,
+                currentSentenceRange = null,
+            ),
         )
         var firedFor: String? = null
-        val job = launch {
-            var watchdog: kotlinx.coroutines.Job? = null
-            state
-                .map { (it.isBuffering && it.currentChapterId != null) to it.currentChapterId }
-                .distinctUntilChanged()
-                .collect { (buffering, chapterId) ->
-                    watchdog?.cancel()
-                    if (!buffering || chapterId == null) return@collect
-                    val armedFor = chapterId
-                    watchdog = launch {
-                        delay(DefaultPlaybackController.BUFFERING_STUCK_WATCHDOG_MS)
-                        val s = state.value
-                        if (
-                            s.isBuffering &&
-                            s.currentChapterId == armedFor &&
-                            s.error == null
-                        ) {
-                            firedFor = armedFor
-                        }
-                    }
-                }
-        }
-        // v0.5.57 (#557) — watchdog dropped from 8 s → 1.5 s, so the
-        // "advance well before threshold" probe has to be sub-threshold.
-        // Pre-fix this advanced 2 s which now overshoots the 1.5 s
-        // watchdog, fires it, and trips the assertNull on the test below.
+        val job = runInlineWatchdog(state) { firedFor = it }
         advanceTimeBy(500L)
         // Error surfaces — engine already gave up; watchdog should NOT
         // double-fire an advance.
@@ -264,6 +239,89 @@ class PlaybackSmoothnessFollowupTest {
         advanceTimeBy(DefaultPlaybackController.BUFFERING_STUCK_WATCHDOG_MS + 1_000L)
         assertNull(
             "watchdog should defer to the typed error path",
+            firedFor,
+        )
+        job.cancel()
+    }
+
+    @Test
+    fun `watchdog defers past fast threshold when sentence range is set (issue #640)`() = runTest {
+        // #640 v1.0 blocker — on Piper-low / Z Flip 3 the consumer's
+        // catch-up-pause branch flips isBuffering=true mid-chapter when
+        // bufferHeadroomMs drops below the underrun threshold.
+        // `currentSentenceRange` stays non-null because the consumer is
+        // still inside a chapter — that's the structural marker that
+        // separates this case from chapter-transition buffering.
+        //
+        // Pre-fix the watchdog ignored currentSentenceRange, fired
+        // after the 1.5 s threshold, called advanceChapter(1) MID
+        // CHAPTER, interrupted the still-running consumer, and
+        // stranded the new pipeline. Symptom: phone shows "Reconnecting
+        // — please wait" with audio focus held but no PCM moving.
+        //
+        // Post-fix the watchdog routes sentence-range-set buffering
+        // to the slower 12 s threshold instead, giving legitimate
+        // underrun pauses ample time to resolve naturally.
+        val state = MutableStateFlow(
+            PlaybackState(
+                currentChapterId = "ch1",
+                isPlaying = true,
+                isBuffering = true,
+                // Non-null sentence range == we're still inside a
+                // chapter, this is an intra-chapter underrun, NOT a
+                // chapter-transition stuck state.
+                currentSentenceRange = SentenceRange(
+                    startCharInChapter = 100,
+                    endCharInChapter = 200,
+                    sentenceIndex = 3,
+                ),
+            ),
+        )
+        var firedFor: String? = null
+        val job = runInlineWatchdog(state) { firedFor = it }
+        // Past the FAST (chapter-transition) threshold — watchdog must
+        // NOT fire yet, because firing would interrupt the running
+        // consumer mid-chapter.
+        advanceTimeBy(DefaultPlaybackController.BUFFERING_STUCK_WATCHDOG_MS + 2_000L)
+        assertNull(
+            "watchdog must NOT fire at the fast threshold while a " +
+                "sentence is still being played — that's an intra-chapter " +
+                "underrun, not a stuck chapter transition",
+            firedFor,
+        )
+        job.cancel()
+    }
+
+    @Test
+    fun `watchdog eventually fires on truly stuck end-of-chapter (issue #640 recovery)`() = runTest {
+        // Companion to the #640 deferral test above — once we cross
+        // the slow [BUFFERING_STUCK_WATCHDOG_END_OF_CHAPTER_MS]
+        // threshold (12 s) with sentence range still set, the
+        // watchdog DOES fire so the user isn't left forever on a
+        // chapter that has silently failed to advance through the
+        // natural-end path (the original #553 symptom that survived
+        // on Notion sources).
+        val state = MutableStateFlow(
+            PlaybackState(
+                currentChapterId = "ch1",
+                isPlaying = true,
+                isBuffering = true,
+                currentSentenceRange = SentenceRange(
+                    startCharInChapter = 100,
+                    endCharInChapter = 200,
+                    sentenceIndex = 3,
+                ),
+            ),
+        )
+        var firedFor: String? = null
+        val job = runInlineWatchdog(state) { firedFor = it }
+        // Past the slow threshold — watchdog SHOULD fire as the
+        // recovery path for a genuinely stuck consumer.
+        advanceTimeBy(DefaultPlaybackController.BUFFERING_STUCK_WATCHDOG_END_OF_CHAPTER_MS + 1_000L)
+        assertEquals(
+            "watchdog should fire on the slow threshold to recover " +
+                "from a stuck end-of-chapter that never reached natural-end",
+            "ch1",
             firedFor,
         )
         job.cancel()


### PR DESCRIPTION
## Summary
- v1.0 blocker — on R5CRB0W66MK (Z Flip 3), the #553 buffering-stuck watchdog fired mid-chapter (1.5 s threshold) when Piper-low's sub-realtime synth drove the consumer's catch-up-pause branch into `isBuffering=true`. The watchdog called `advanceChapter(1)` while chapter 1 was still playing, interrupted the running consumer, and stranded chapter 2's pipeline half-constructed. User saw "Reconnecting — please wait" with audio focus held but no PCM moving.
- Fix: gate the watchdog on `currentSentenceRange` to disambiguate chapter-transition buffering (fast 1.5 s threshold, sentence range null) from intra-chapter / end-of-chapter buffering (slow 12 s threshold, sentence range still set). Intra-chapter underruns get time to resolve naturally; truly stuck end-of-chapter states still recover after 12 s.
- Tablet wasn't affected because faster CPU → producer keeps up → underrun never holds past 1.5 s. The misfire was phone-only, matching the issue's "Tablet does NOT exhibit this" observation.

## Root cause (from on-device debug variant logcat)
1. `advanceChapter dir=1 from=chapter1` fired at 17:29:50.812 — but chapter 1 position was ~56s of 78s, well before natural end.
2. Preceding line: `PlaybackController: #553 watchdog: isBuffering stuck on chapter1 for 1500ms; firing fallback advance via nextChapter()`.
3. Tracing back: consumer's `bufferHeadroomMs < BUFFER_UNDERRUN_THRESHOLD_MS` branch ([`EnginePlayer.kt` line ~2161](https://github.com/techempower-org/storyvox/blob/main/core-playback/src/main/kotlin/in/jphe/storyvox/playback/tts/EnginePlayer.kt#L2161)) set `isBuffering = true` without clearing `currentSentenceRange`. Producer eventually caught up but watchdog already won the race.
4. The interrupted consumer left chapter 2's pipeline half-built; `AudioOutputMonitor` flagged it as `AudioOutputStuck → "Reconnecting — please wait"`.

## Why the two thresholds
- **Fast (1.5 s, sentence range null)** — legitimate chapter-transition buffering set by `handleChapterDone` / `advanceChapter` / `loadAndPlay` before the new pipeline emits its first sentence. Spotify/Apple-Music-grade chapter gap.
- **Slow (12 s, sentence range set)** — legitimate intra-chapter underrun pause + worst-case recovery path for the original #553 symptom (natural-end branch silently failing to fire on Notion sources). Long enough that Piper-low underruns resolve naturally; short enough that a truly-stuck chapter doesn't hang forever.

## Test plan
- [x] `:core-playback:testDebugUnitTest` — 10 tests pass, including two new #640 tests:
  - `watchdog defers past fast threshold when sentence range is set (issue #640)` — verifies false-positive is gated out
  - `watchdog eventually fires on truly stuck end-of-chapter (issue #640 recovery)` — verifies the 12 s recovery still works
- [x] `:app:assembleRelease` — clean (release variant with R8 minification on)
- [x] `:feature:testDebugUnitTest` `:app:testDebugUnitTest` — all green
- [x] On-device verification (R5CRB0W66MK / Z Flip 3, release variant): cold launch → onboarding → TechEmpower hero → Browse Resources → Guides → tap Play.
  - Chapter 1 "How to use TechEmpower.org" plays to 1:18 with audio focus held (`dumpsys audio` shows storyvox on focus stack, USAGE_MEDIA).
  - Mid-chapter manual skip-next transitions to chapter 2 "Free internet" (4:15) within 317 ms — engine logs show `advanceChapter` → body wait → `loadAndPlay` → `#569 skipLoadModel` → `pcm-cache MISS` → `advanceChapter: complete, now playing`.
  - No `#553 watchdog: isBuffering stuck` misfire in the logcat.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)