### PR TITLE
fix(core-playback): chapter 2 produces audio after auto-advance — closes #642

### DIFF
--- a/core-playback/src/main/kotlin/in/jphe/storyvox/playback/tts/EnginePlayer.kt
+++ b/core-playback/src/main/kotlin/in/jphe/storyvox/playback/tts/EnginePlayer.kt
@@ -2155,9 +2155,36 @@ class EnginePlayer @AssistedInject constructor(
                     // consumer drains through underruns without pausing:
                     // listener may hear dead air, but never sees the
                     // "Buffering…" UI. EngineStreamingSource is untouched.
+                    //
+                    // Issue #642 — also bail out of the underrun pause when
+                    // the producer has already emitted every sentence
+                    // (END_PILL is in the queue). Pre-fix the gate fired
+                    // even on the chapter's LAST real chunk: producer
+                    // signalled `producedAllSentences=true` then pushed
+                    // END_PILL (queue depth = 1, audio depth = 0), the
+                    // consumer dequeued the last chunk, then the underrun
+                    // check saw headroom == 0 and pausing-then-parked on
+                    // [bufferHeadroomMs.first]. The Flow re-emits only when
+                    // the producer puts a new chunk; with the producer
+                    // already done, no more emissions ever land, and the
+                    // park inside [bufferHeadroomMs.first] is stuck until
+                    // the OUTER stopPlaybackPipeline interrupts the
+                    // consumer thread — which on auto-advance only fires
+                    // when the watchdog finally trips at the 12 s
+                    // end-of-chapter threshold. Net symptom: chapter N's
+                    // last sentence is never written to AudioTrack, the
+                    // listener never hears it, and chapter N+1's pipeline
+                    // doesn't start until the watchdog kicks. Reproduced
+                    // on R5CRB0W66MK Z Flip 3 in v0.5.63, captured in the
+                    // #642 logcat. Adding `!producedAllSentences` to the
+                    // gate keeps every legitimate intra-chapter underrun
+                    // pause intact (producedAll flips true ONLY at the
+                    // very end of the producer) while skipping the
+                    // doomed park on the final chunk.
                     if (cachedCatchupPause &&
                         !source.isStreaming &&
                         !paused &&
+                        !source.producedAllSentences &&
                         source.bufferHeadroomMs.value < BUFFER_UNDERRUN_THRESHOLD_MS) {
                         runCatching { track.pause() }
                         paused = true
@@ -2177,12 +2204,35 @@ class EnginePlayer @AssistedInject constructor(
                     // the headroom flow until the producer queues enough
                     // audio to cross the resume threshold, then resume
                     // the track and proceed with the write.
+                    //
+                    // Issue #642 — extra exit predicate: also resume when
+                    // the producer has flipped [producedAllSentences]
+                    // true. The [bufferHeadroomMs] flow re-evaluates the
+                    // predicate ONLY on a new emission, and the producer
+                    // doesn't emit again after END_PILL (END_PILL contains
+                    // 0 PCM bytes and goes through queue.put, not the
+                    // headroom flow). Without this extra predicate the
+                    // park sat forever even when the producer was done —
+                    // see the long comment on the underrun gate above
+                    // for the full repro trace. The new gate is
+                    // belt-and-suspenders: the underrun gate's
+                    // !producedAllSentences clause now blocks entry to
+                    // this branch on the last chunk, so in practice we
+                    // never reach the pause-park with the producer
+                    // already done. The defensive predicate guards the
+                    // race where producedAllSentences flips true AFTER
+                    // we entered the park (paused=true via a legitimate
+                    // mid-chapter underrun, producer races to finish
+                    // before listener catches back up). To make
+                    // `first { }` re-evaluate when the flag flips, we
+                    // call out to a helper that combines the headroom
+                    // flow with a producedAllSentences poll bridge —
+                    // simpler than wiring a SharedFlow on the source
+                    // and keeps the surface area for #642 minimal.
                     if (paused) {
                         try {
                             runBlocking {
-                                source.bufferHeadroomMs.first {
-                                    it >= BUFFER_RESUME_THRESHOLD_MS || !pipelineRunning.get()
-                                }
+                                waitForResumeOrTerminalState(source)
                             }
                         } catch (_: Throwable) {
                             // Interrupted by stopPlaybackPipeline (interrupt +
@@ -2569,6 +2619,75 @@ class EnginePlayer @AssistedInject constructor(
                 )
             }
         }
+
+    /**
+     * Issue #642 — wait for the consumer's underrun pause to resolve.
+     *
+     * Three exit conditions, any of which clears the park:
+     *   1. `bufferHeadroomMs >= BUFFER_RESUME_THRESHOLD_MS`: the producer
+     *      caught back up; resume the AudioTrack and keep writing.
+     *   2. `!pipelineRunning`: the outer pipeline is being torn down
+     *      (stopPlaybackPipeline). Skip the resume; the next iteration
+     *      of the consumer's outer while will see pipelineRunning=false
+     *      and exit cleanly.
+     *   3. `source.producedAllSentences`: the producer has emitted the
+     *      LAST sentence and pushed END_PILL. No further headroom
+     *      emissions will ever arrive (the producer's only headroom
+     *      writes are inside its per-sentence loop). Without this exit,
+     *      `bufferHeadroomMs.first { ... }` would park forever waiting
+     *      for an emission that never comes — exactly the #642 stall
+     *      reproduced on R5CRB0W66MK.
+     *
+     * Implementation: race the headroom flow against a poll loop on
+     * [PcmSource.producedAllSentences]. The flow is the fast path
+     * (every legitimate intra-chapter underrun resolves through an
+     * emission); the poll is the safety net that fires when the
+     * producer finishes during the park window. 50 ms poll cadence
+     * matches the user-pause park grain elsewhere in the consumer —
+     * imperceptible latency for the listener, cheap to run.
+     *
+     * Why not a SharedFlow on the source: keeps the surface area of
+     * the #642 fix minimal. A SharedFlow would be cleaner long-term;
+     * we can fold this into [EngineStreamingSource]'s public API in a
+     * follow-up if more callsites need to observe the terminal
+     * transition. For now the polling helper is private to
+     * [EnginePlayer] and used by exactly one consumer-thread branch.
+     */
+    private suspend fun waitForResumeOrTerminalState(source: PcmSource) {
+        kotlinx.coroutines.coroutineScope {
+            val headroomJob = launch {
+                runCatching {
+                    source.bufferHeadroomMs.first {
+                        it >= BUFFER_RESUME_THRESHOLD_MS || !pipelineRunning.get()
+                    }
+                }
+            }
+            val terminalPollJob = launch {
+                // Poll producedAllSentences + pipelineRunning at the
+                // same cadence as the user-pause park (Thread.sleep(50)
+                // in the outer consumer loop). 50 ms is below the
+                // perceived-gap threshold for resumed audio playback
+                // and well under the AudioTrack ring buffer drain
+                // time (~130 ms minBuffer on Samsung devices), so any
+                // race the predicate observes resolves before the
+                // listener notices.
+                while (
+                    pipelineRunning.get() &&
+                    !source.producedAllSentences &&
+                    source.bufferHeadroomMs.value < BUFFER_RESUME_THRESHOLD_MS
+                ) {
+                    kotlinx.coroutines.delay(50L)
+                }
+            }
+            // Whichever job completes first wakes the park; cancel the
+            // other so we don't leak a launched coroutine after the
+            // consumer thread proceeds.
+            kotlinx.coroutines.selects.select<Unit> {
+                headroomJob.onJoin { terminalPollJob.cancel() }
+                terminalPollJob.onJoin { headroomJob.cancel() }
+            }
+        }
+    }
 
     private fun stopPlaybackPipeline() {
         // Shutdown handshake:

--- a/core-playback/src/test/kotlin/in/jphe/storyvox/playback/tts/source/EngineStreamingSourceProducedAllRaceTest.kt
+++ b/core-playback/src/test/kotlin/in/jphe/storyvox/playback/tts/source/EngineStreamingSourceProducedAllRaceTest.kt
@@ -1,0 +1,146 @@
+package `in`.jphe.storyvox.playback.tts.source
+
+import `in`.jphe.storyvox.playback.tts.Sentence
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.withTimeoutOrNull
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * Issue #642 — auto-advance stall on chapter end.
+ *
+ * The on-device reproduction (R5CRB0W66MK Z Flip 3, v0.5.63) showed the
+ * consumer thread parked in `bufferHeadroomMs.first { ... }` after
+ * dequeuing the LAST real chunk of a chapter. The producer had already
+ * pushed END_PILL by then and would never emit again, so the consumer
+ * waited forever for headroom to recover.
+ *
+ * The fix has two parts in [`in`.jphe.storyvox.playback.tts.EnginePlayer]:
+ *
+ *   1. The underrun pause gate now also checks
+ *      `!source.producedAllSentences` — when the producer signals
+ *      end-of-list, the consumer skips the pause and proceeds to drain
+ *      the END_PILL.
+ *
+ *   2. The pause-park's wait helper races the headroom flow against a
+ *      50 ms poll on `source.producedAllSentences`, so a producer that
+ *      finishes WHILE the consumer is parked still wakes the park.
+ *
+ * Both rely on the contract that `producedAllSentences` is set true
+ * BEFORE the END_PILL is pushed to the queue, and stays sticky-true
+ * thereafter. This test pins that timing — without it the EnginePlayer
+ * fix is correct but fragile (a producer change could break the
+ * ordering and the on-device stall would silently regress).
+ */
+class EngineStreamingSourceProducedAllRaceTest {
+
+    @Test
+    fun `producedAllSentences flips true before END_PILL is dequeued`() = runBlocking {
+        // Two sentences — enough to verify ordering. We pull the second
+        // (last) chunk and immediately observe the flag, BEFORE pulling
+        // the END_PILL. The producer must have set the flag in the same
+        // critical section as its loop-exit; if the test sees false here
+        // the on-device fix's underrun-gate `!producedAllSentences`
+        // would race against the consumer's last-chunk dequeue and the
+        // #642 stall would reappear.
+        val sentences = listOf(
+            Sentence(0, 0, 10, "First sentence."),
+            Sentence(1, 11, 30, "Last sentence."),
+        )
+        val src = EngineStreamingSource(
+            sentences = sentences,
+            startSentenceIndex = 0,
+            engine = ProducedAllRaceFakeVoiceEngine(22050) { ByteArray(100) },
+            speed = 1f,
+            pitch = 1f,
+            engineMutex = Mutex(),
+        )
+
+        // Drain real chunks. After the SECOND nextChunk() returns the
+        // last sentence, the producer has exited its for-loop, set
+        // producedAll=true, and pushed END_PILL. The ordering invariant
+        // is exactly the one EnginePlayer's underrun gate relies on.
+        val first = src.nextChunk()
+        assertTrue("First nextChunk must return a real chunk", first != null)
+        val last = src.nextChunk()
+        assertTrue("Last real nextChunk must return a chunk", last != null)
+
+        // Give the producer thread a moment to set producedAll AND push
+        // END_PILL (both happen in the same critical section in the
+        // producer's for-loop exit path, but the JIT can reorder
+        // observation across threads). The polling shape mirrors the
+        // EnginePlayer fix's 50 ms cadence.
+        val observedTrue = withTimeoutOrNull(2_000L) {
+            while (!src.producedAllSentences) delay(20L)
+            true
+        }
+        assertEquals(
+            "producedAllSentences must flip true within 2 s of dequeuing the last real chunk; " +
+                "if this assertion fails, EnginePlayer's #642 underrun gate races against the " +
+                "consumer's last-chunk dequeue and the chapter-end stall reproduces on device",
+            true,
+            observedTrue,
+        )
+
+        // And confirm END_PILL is what the next dequeue gives us.
+        val end = src.nextChunk()
+        assertEquals("After the END_PILL is consumed nextChunk returns null", null, end)
+
+        src.close()
+    }
+
+    @Test
+    fun `producedAllSentences observable during consumer underrun pause window`() = runBlocking {
+        // Simulates the on-device window: producer finishes, consumer is
+        // mid-write on the chunk it just dequeued, ABOUT to enter the
+        // underrun pause check. The check reads producedAllSentences
+        // synchronously — this test pins that the read is correct
+        // (true, since producer is done) and the underrun gate's
+        // `!producedAllSentences` clause short-circuits the pause.
+        val sentences = listOf(Sentence(0, 0, 10, "Solo sentence."))
+        val src = EngineStreamingSource(
+            sentences = sentences,
+            startSentenceIndex = 0,
+            engine = ProducedAllRaceFakeVoiceEngine(22050) { ByteArray(50) },
+            speed = 1f,
+            pitch = 1f,
+            engineMutex = Mutex(),
+        )
+
+        val chunk = src.nextChunk()
+        assertTrue("Must get the one real chunk", chunk != null)
+
+        // Wait for producer to push END_PILL and flip the flag.
+        val flagged = withTimeoutOrNull(2_000L) {
+            while (!src.producedAllSentences) delay(10L)
+            true
+        }
+        assertEquals(true, flagged)
+
+        // At this exact moment the EnginePlayer consumer-thread underrun
+        // gate `!source.producedAllSentences` evaluates to false → skip
+        // the pause. The bug pre-fix had no such gate; the consumer
+        // paused the AudioTrack and parked on bufferHeadroomMs.first
+        // forever. Asserting on the flag at this moment is the
+        // unit-test stand-in for the on-device assertion "chapter 2's
+        // audio reaches the speakers within 3 s of auto-advance".
+        assertTrue(
+            "Producer must have completed by the time the consumer reaches the underrun check",
+            src.producedAllSentences,
+        )
+
+        src.close()
+    }
+}
+
+/** Test-only engine handle. Identity behaviour. Distinct copy from the
+ *  Gapless test class's helper so a refactor to one doesn't leak. */
+private class ProducedAllRaceFakeVoiceEngine(
+    override val sampleRate: Int,
+    val pcmFor: (String) -> ByteArray,
+) : EngineStreamingSource.VoiceEngineHandle {
+    override fun generateAudioPCM(text: String, speed: Float, pitch: Float): ByteArray? = pcmFor(text)
+}


### PR DESCRIPTION
## v1.0 BLOCKER — auto-advance silence on chapter 2

Reproduced on R5CRB0W66MK (Z Flip 3) with v0.5.63 release.

### Root cause (with the log line that revealed it)

After chapter 1's producer pushes END_PILL, the consumer dequeues the LAST real chunk and the underrun-pause gate fires because `bufferHeadroomMs == 0` (END_PILL has 0 PCM bytes). Consumer calls `track.pause()` then parks on:

```kotlin
runBlocking {
    source.bufferHeadroomMs.first { it >= RESUME || !pipelineRunning.get() }
}
```

The `first { }` predicate observes `bufferHeadroomMs` Flow emissions. With the producer already done, the flow never emits again. The `!pipelineRunning.get()` clause inside the predicate is never re-evaluated. Consumer is stuck until external interrupt 12 s later when the end-of-chapter watchdog finally fires.

Confirmed by the symptom logcat at 18:19:15.734:
```
I/EngineStreamingSource: serial producer: natural end (all 54 sentences emitted), pushing END_PILL
```
Followed by **12 seconds of no logs** until:
```
W/PlaybackController: #553 watchdog: isBuffering stuck on ch1 for 1500ms — but timing matches BUFFERING_STUCK_WATCHDOG_END_OF_CHAPTER_MS = 12000ms (endOfChapter mode)
```

The chapter-2 `loadAndPlay` then logs `sentences=36` and goes silent — its `stopPlaybackPipeline` interrupts the stuck consumer chain but the new pipeline never produces.

### Fix

`core-playback/EnginePlayer.kt` consumer-thread changes:

1. **Underrun-pause gate** now ANDs `!source.producedAllSentences` — skip the pause entirely on the last chunk so the post-write fast-path runs and dispatches `handleChapterDone` naturally.

2. **New `waitForResumeOrTerminalState`** helper races `bufferHeadroomMs.first { … }` against a 50 ms poll on `producedAllSentences`, so a producer that completes WHILE the consumer is in a legitimate mid-chapter underrun park still wakes the park.

Plus `EngineStreamingSourceProducedAllRaceTest` pinning the contract that `producedAllSentences` flips true within ~2 s of dequeuing the last real chunk — so a future producer change can't silently break the gate.

### On-device verification (R5CRB0W66MK release variant)

Reproduced JP's exact flow: cold launch → onboarding skip → Browse → Guides → tap Play at 2× speed.

Two consecutive natural-end advances both clean:

```
18:37:28.347 end-of-pcm (post-write fast path): naturalEnd=true producedAll=true queueDepth=1 — #573 gapless
18:37:28.353 handleChapterDone: starting natural-end housekeeping
18:37:28.835 pcm-cache MISS chapter=...:Free internet fromSentence=0 base=f8b0e23687b4
… (ch2 plays through at 2×) …
18:39:58.567 end-of-pcm (post-write fast path): naturalEnd=true producedAll=true queueDepth=1 — #573 gapless
18:39:58.898 pcm-cache MISS chapter=...:EV incentives fromSentence=0 base=e2a87290ae51
```

- ch1→ch2 gap: 488 ms producer-to-producer
- ch2→ch3 gap: 331 ms producer-to-producer
- `dumpsys audio` shows `AudioTrack u/pid:10312/4691 state:started attr:USAGE_MEDIA/CONTENT_TYPE_MUSIC` during ch2 + ch3
- No "Reconnecting — please wait." panel
- WhyAreWeWaitingPanel stays hidden

Tablet R83W80CAFZB regression-clear: Cori medium, ch1→ch2 fast-path fires at 18:41:57.635, ch2 producer at 18:41:58.374 (739 ms gap), UI advances cleanly to "Free internet" at 0:40.

### CI gate

`./gradlew :app:assembleRelease :core-playback:testDebugUnitTest :feature:testDebugUnitTest :app:testDebugUnitTest` — BUILD SUCCESSFUL in 3m 5s.

## Test plan

- [x] CI gate passes locally (assembleRelease + 3 testDebugUnitTest paths)
- [x] R5CRB0W66MK release variant: chapter 1 plays at 2× to natural end
- [x] R5CRB0W66MK: chapter 2 audio reaches speakers within ~3 s of auto-advance
- [x] R5CRB0W66MK: chapter 2 → chapter 3 advance also clean (no regression on subsequent transitions)
- [x] R5CRB0W66MK: WhyAreWeWaitingPanel stays hidden during transition
- [x] R5CRB0W66MK: `dumpsys audio` shows AudioTrack state=started for chapter 2
- [x] R83W80CAFZB tablet: ch1 → ch2 advance still works (was working pre-fix, must not regress)

🤖 Generated with [Claude Code](https://claude.com/claude-code)