### PR TITLE
feat(onboarding,a11y): v1.0 final polish — closes #644 #645 #646 #647

### DIFF
--- a/app/src/main/kotlin/in/jphe/storyvox/di/AppBindings.kt
+++ b/app/src/main/kotlin/in/jphe/storyvox/di/AppBindings.kt
@@ -529,6 +529,24 @@ private class RealFictionRepositoryUi(
     override fun previewUrl(url: String): List<`in`.jphe.storyvox.feature.api.UiRouteCandidate> =
         repo.previewUrl(url).map { it.toUi() }
 
+    /**
+     * Issues #644 + #647 (v1.0) — passthrough to [FictionRepository.browsePopular]
+     * for the onboarding's "Browse TechEmpower's free guides" CTA. Calling
+     * `browsePopular(page = 1, sourceId)` runs the source's `popular()`
+     * round-trip and pipes the result through `cacheListing`, which is
+     * what upserts the per-fiction rows into the `fictionDao` so that a
+     * subsequent `refreshDetail(notion:guides)` routes to the right source
+     * instead of the legacy `ROYAL_ROAD` fallback. Returns true iff the
+     * source returned a Success with at least one item.
+     */
+    override suspend fun seedPopularForSource(sourceId: String): Boolean =
+        runCatching {
+            when (val result = repo.browsePopular(page = 1, sourceId = sourceId)) {
+                is FictionResult.Success -> result.value.items.isNotEmpty()
+                is FictionResult.Failure -> false
+            }
+        }.getOrDefault(false)
+
     private fun `in`.jphe.storyvox.data.source.RouteMatch.toUi():
         `in`.jphe.storyvox.feature.api.UiRouteCandidate =
         `in`.jphe.storyvox.feature.api.UiRouteCandidate(

--- a/app/src/main/kotlin/in/jphe/storyvox/navigation/StoryvoxNavHost.kt
+++ b/app/src/main/kotlin/in/jphe/storyvox/navigation/StoryvoxNavHost.kt
@@ -262,8 +262,30 @@ fun StoryvoxNavHost(
     // shield doesn't trap welcome-screen taps. The welcome's own
     // shield handles its swallow.
     OnboardingHost(
+        // Issues #644 + #647 (v1.0) — `onOpenTechEmpower` stays
+        // wired to the hub destination so the viewmodel's fallback
+        // path (chapter resolution failed) still lands on a working
+        // surface. The happy path runs through [onOpenGuidesAndPlay]
+        // below, which skips the hub AND the FictionDetail cover
+        // stop in favor of dropping the user directly onto the
+        // Playing transport surface with chapter 1 of the Guides
+        // queued + auto-playing. The pre-fix two-step (hub →
+        // Browse Resources → Guides → Play) collapses to a single
+        // tap on the "Browse TechEmpower's free guides" card.
         onOpenTechEmpower = {
             navController.navigate(StoryvoxRoutes.TECHEMPOWER_HOME)
+        },
+        onOpenGuidesAndPlay = {
+            // Route to PLAYING and pop the welcome's underlying
+            // Library entry so OS-Back from the player surfaces
+            // the Library (the cold-launch destination) — not a
+            // ghost entry for the welcome screen the user already
+            // dismissed. launchSingleTop collapses a stray double-
+            // tap into a single navigation.
+            navController.navigate(StoryvoxRoutes.PLAYING) {
+                popUpTo(StoryvoxRoutes.LIBRARY)
+                launchSingleTop = true
+            }
         },
         onAddFromWebsite = { clipboardUrl ->
             // Route to Library with the magic-add sheet pre-opened.

--- a/core-ui/src/main/kotlin/in/jphe/storyvox/ui/component/BottomTabBar.kt
+++ b/core-ui/src/main/kotlin/in/jphe/storyvox/ui/component/BottomTabBar.kt
@@ -234,10 +234,21 @@ private fun TabCell(
     val interactionSource = remember { MutableInteractionSource() }
     val indication = LocalIndication.current
     Column(
-        // a11y (#485): expose this cell as a tab to TalkBack with
-        // `Role.Tab` + a `selected` flag. Without these, TalkBack
-        // announces "double tap to activate" with no indication of
-        // which tab is current; the indicator pill is visual-only.
+        // a11y (#485, #645): expose this cell to TalkBack with a
+        // `selected` flag for state announcement, but use `Role.Button`
+        // (NOT `Role.Tab`) on the clickable. The combination of
+        // `Role.Tab` + `selected=true` triggers a TalkBack behavior
+        // where the cell is read as "already on" and loses its
+        // "double-tap to activate" hint — observed on Reader / Voices /
+        // Settings where Library is marked `selected=true` (the route-
+        // collapse mapping in StoryvoxNavHost lights Library for any
+        // route under its umbrella). Switching to `Role.Button` keeps
+        // the selected-state announcement ("Library, selected, button")
+        // AND restores the activation hint so a TalkBack user can
+        // always tap to return to the Library home, even from within a
+        // deep-link drill-down. The indicator pill remains a purely
+        // visual cue.
+        //
         // `.semantics { selected = isSelected }` must come BEFORE the
         // clickable so the role on clickable doesn't override it.
         modifier = modifier
@@ -245,7 +256,7 @@ private fun TabCell(
             .clickable(
                 interactionSource = interactionSource,
                 indication = indication,
-                role = Role.Tab,
+                role = Role.Button,
                 onClickLabel = tab.label,
                 onClick = onClick,
             ),
@@ -305,12 +316,17 @@ private val ICON_TARGET_WIDTH = 64.dp
 private const val SLIDE_DURATION_MS = 280
 
 /**
- * Structural canary for issue #485 — TabCell must expose `Role.Tab`
- * + a `selected` semantics property so TalkBack announces the
- * currently-active tab. Flipped to `false` only after a future refactor
- * proves on a real device with TalkBack that an alternative shape
- * carries the same announcement.
+ * Structural canary for issues #485 + #645 — TabCell must expose a
+ * `selected` semantics property so TalkBack announces the currently-
+ * active tab. Issue #645 (v1.0) changed the clickable's role from
+ * `Role.Tab` to `Role.Button` because `Role.Tab` + `selected=true`
+ * caused TalkBack to suppress the "double-tap to activate" hint on
+ * the selected cell — fatal for the Reader / Voices / Settings
+ * surfaces where Library lights as selected (via the route-collapse
+ * mapping in StoryvoxNavHost) and the user needs to tap it to return
+ * home. With `Role.Button` + `selected`, TalkBack announces "Library,
+ * selected, button" AND still offers the activation hint.
  *
  * Pinned by `BottomTabBarSemanticsTest`.
  */
-internal const val bottomTabBarUsesRoleTabAndSelected: Boolean = true
+internal const val bottomTabBarUsesRoleButtonPlusSelected: Boolean = true

--- a/core-ui/src/test/kotlin/in/jphe/storyvox/ui/component/BottomTabBarSemanticsTest.kt
+++ b/core-ui/src/test/kotlin/in/jphe/storyvox/ui/component/BottomTabBarSemanticsTest.kt
@@ -62,13 +62,19 @@ class BottomTabBarSemanticsTest {
     }
 
     @Test
-    fun `BottomTabBar uses Role-Tab plus selected semantics per issue #485`() {
-        // Structural canary. Flipped to false only after a future
-        // refactor proves on a real device that a different shape
-        // carries the same TalkBack announcement.
+    fun `BottomTabBar uses Role-Button plus selected semantics per issue #645`() {
+        // Structural canary. Issue #645 (v1.0) changed Role.Tab →
+        // Role.Button because Role.Tab + selected=true caused TalkBack
+        // to suppress the "double-tap to activate" hint on the selected
+        // cell — a focus dead-end for users on Reader / Voices /
+        // Settings trying to return to Library via the dock. With
+        // Role.Button + selected the cell still announces its selected
+        // state but stays activatable. Flipped to false only after a
+        // future refactor proves on a real device that a different
+        // shape carries the same announcement + activation.
         assertTrue(
-            "BottomTabBar.TabCell must expose Role.Tab + selected semantics (issue #485)",
-            bottomTabBarUsesRoleTabAndSelected,
+            "BottomTabBar.TabCell must expose Role.Button + selected semantics (issues #485, #645)",
+            bottomTabBarUsesRoleButtonPlusSelected,
         )
     }
 }

--- a/feature/src/main/kotlin/in/jphe/storyvox/feature/api/UiContracts.kt
+++ b/feature/src/main/kotlin/in/jphe/storyvox/feature/api/UiContracts.kt
@@ -193,6 +193,27 @@ interface FictionRepositoryUi {
      * state and waits.
      */
     fun previewUrl(url: String): List<UiRouteCandidate>
+
+    /**
+     * Issues #644 + #647 (v1.0) — seed the local Fiction DB with the
+     * first-page "popular" tiles for [sourceId]. Used by the welcome
+     * flow's "Browse TechEmpower's free guides" CTA to ensure the
+     * Notion fiction rows (notably `notion:guides`) exist in the
+     * Fiction DAO before [fictionById] / [chaptersFor] attempt to
+     * refresh detail — without this seeding pass, [refreshDetail]
+     * falls back to the wrong source on first launch because the
+     * row's `sourceId` column is unknown.
+     *
+     * The default no-op is a Kotlin interface defaulting trick used
+     * elsewhere in the contract (see `markAllCaughtUp`'s comment in
+     * the impl) so test stand-ins don't have to bother stubbing.
+     *
+     * Returns true iff at least one row was upserted; false on
+     * network failure / source not bound / cancellation. Callers
+     * treat false as "fall back to a path that doesn't depend on
+     * the seeded rows".
+     */
+    suspend fun seedPopularForSource(sourceId: String): Boolean = false
 }
 
 interface BrowseRepositoryUi {

--- a/feature/src/main/kotlin/in/jphe/storyvox/feature/onboarding/OnboardingHost.kt
+++ b/feature/src/main/kotlin/in/jphe/storyvox/feature/onboarding/OnboardingHost.kt
@@ -25,9 +25,14 @@ import dagger.hilt.android.lifecycle.HiltViewModel
 import javax.inject.Inject
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.flow.firstOrNull
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.withTimeoutOrNull
+import `in`.jphe.storyvox.feature.api.FictionRepositoryUi
+import `in`.jphe.storyvox.feature.api.PlaybackControllerUi
 import `in`.jphe.storyvox.feature.api.SettingsRepositoryUi
 
 /**
@@ -62,6 +67,18 @@ fun OnboardingHost(
     onOpenTechEmpower: () -> Unit,
     onAddFromWebsite: (clipboardUrl: String?) -> Unit,
     onOpenVoiceLibrary: () -> Unit,
+    /**
+     * Issues #644 + #647 (v1.0) — invoked after the viewmodel has
+     * resolved the first chapter of the TechEmpower Guides fiction
+     * and queued it on the playback controller with `autoPlay=true`.
+     * Routes the user to the PLAYING surface so they land on the
+     * transport UI as audio starts. Distinct from [onOpenTechEmpower]
+     * (the hub-landing legacy route) so a future variant of the
+     * onboarding can keep the hub-stop path without touching this
+     * one. Default no-op so a caller that doesn't set it falls back
+     * to the legacy hub-routed CTA.
+     */
+    onOpenGuidesAndPlay: () -> Unit = onOpenTechEmpower,
     viewModel: OnboardingHostViewModel = hiltViewModel(),
     content: @Composable () -> Unit,
 ) {
@@ -108,9 +125,31 @@ fun OnboardingHost(
                             },
                         )
                         OnboardingStep.FirstFiction -> FirstFictionPicker(
+                            // Issues #644 + #647 (v1.0) — bypass the
+                            // TechEmpower Home hub AND the Guides
+                            // fiction-detail stop. The viewmodel
+                            // resolves the first chapter of the
+                            // `notion:guides` fiction, queues it on
+                            // the playback controller with
+                            // `autoPlay=true`, then [onOpenGuidesAndPlay]
+                            // navigates the user to the Playing
+                            // surface so they land on the transport
+                            // UI as the chapter warms. Net: two taps
+                            // (the hub stop + the Guides-cover stop)
+                            // disappear from the first-launch flow.
+                            //
+                            // Fallback path: if chapter resolution
+                            // fails (network down, source unreachable,
+                            // anonymous Notion 404), the viewmodel
+                            // invokes [onOpenTechEmpower] instead so
+                            // the user lands on the hub with the same
+                            // four-card affordance they would have
+                            // seen pre-fix — never a dead end.
                             onBrowseTechEmpower = {
-                                viewModel.markCompleted()
-                                onOpenTechEmpower()
+                                viewModel.openGuidesAndAutoPlay(
+                                    onPlaying = onOpenGuidesAndPlay,
+                                    onFallbackToHub = onOpenTechEmpower,
+                                )
                             },
                             onAddFromWebsite = { clip ->
                                 viewModel.markCompleted()
@@ -133,6 +172,24 @@ internal enum class OnboardingStep { Welcome, VoicePick, FirstFiction }
 @HiltViewModel
 class OnboardingHostViewModel @Inject constructor(
     private val settings: SettingsRepositoryUi,
+    /**
+     * Issues #644 + #647 (v1.0) — used by [openGuidesAndAutoPlay] to
+     * resolve the first chapter of the TechEmpower Guides fiction
+     * (`notion:guides`). The first emission of [chaptersFor] is the
+     * source of truth; we take its head element. Anonymous-mode
+     * Notion fetches return a non-empty list within ~1 s of the
+     * source's first-subscription refresh, so a single
+     * [Flow.first] is safe here as a one-shot resolve.
+     */
+    private val fictionRepo: FictionRepositoryUi,
+    /**
+     * Issues #644 + #647 — used by [openGuidesAndAutoPlay] to queue
+     * the resolved chapter with `autoPlay=true`. The controller
+     * handles voice warming + chapter download internally; the
+     * onboarding host just kicks off the load and routes to the
+     * Playing surface so the user lands on a live transport UI.
+     */
+    private val playback: PlaybackControllerUi,
 ) : ViewModel() {
 
     /** True iff the welcome flow should be on screen right now. Maps
@@ -153,5 +210,154 @@ class OnboardingHostViewModel @Inject constructor(
      *  from the composition. */
     fun markCompleted() {
         viewModelScope.launch { settings.markOnboardingCompletedV1() }
+    }
+
+    /**
+     * Issues #644 + #647 (v1.0) — the "Browse TechEmpower's free
+     * guides" CTA's payload. Resolves the first chapter of the
+     * Guides fiction (`notion:guides`, served by the anonymous-mode
+     * Notion source), queues it on [playback] with `autoPlay=true`,
+     * marks onboarding complete, and routes the user to the Playing
+     * surface via [onPlaying]. If the chapter list comes back empty
+     * (network failure, source unreachable, anonymous 404), we fall
+     * back to [onFallbackToHub] so the user still lands on the
+     * TechEmpower Home hub instead of a dead screen — the legacy
+     * pre-fix behavior was hub-first anyway, so the fallback is
+     * strictly a worst-case parity guarantee.
+     *
+     * Why the fallback is null-or-empty (not the more general
+     * try/catch): [FictionRepositoryUi.chaptersFor] is documented to
+     * emit a non-null List on every observation; the failure modes
+     * surface as empty lists (network refresh failed before any
+     * cache landed) rather than exceptions. The flow's
+     * first-subscription refresh runs as a side effect, so the head
+     * element is whatever the cache + refresh produced together.
+     *
+     * The viewmodel calls [markCompleted] BEFORE the playback queue
+     * so the onboarding host self-removes from the composition
+     * immediately; if the user backgrounds the app mid-warm we don't
+     * want them seeing the welcome again on next launch just because
+     * playback hadn't started yet.
+     */
+    fun openGuidesAndAutoPlay(
+        onPlaying: () -> Unit,
+        onFallbackToHub: () -> Unit,
+    ) {
+        viewModelScope.launch {
+            // Mark completed up-front. The DataStore write is
+            // fire-and-forget; we don't await it because the
+            // onboarding host's [shouldShow] flow will pick up the
+            // change on its next emission, and the user is about to
+            // either hit Playing (chapter resolved) or the hub
+            // (fallback) — neither needs the welcome flow back.
+            settings.markOnboardingCompletedV1()
+            // Resolve the first chapter of the Guides fiction in
+            // three steps:
+            //
+            //  1. Seed the local Fiction DAO with the Notion
+            //     anonymous-mode source's "popular" tiles. This is
+            //     what writes the `notion:guides` row into the DB
+            //     with the correct `sourceId="notion"`. Without it,
+            //     [FictionRepository.refreshDetail] falls back to
+            //     `SourceIds.ROYAL_ROAD` for an unknown row and the
+            //     refresh silently fails — chapters never land. This
+            //     mirrors the implicit pre-seeding the Browse tab's
+            //     Notion plugin does when the user opens it via
+            //     TechEmpower Home → Browse Resources in the legacy
+            //     8-tap flow.
+            //
+            //  2. Drive the refresh side-effect via [fictionById]'s
+            //     first emission. We don't care about the emitted
+            //     UiFiction value; the important thing is that
+            //     `refreshDetail("notion:guides")` has completed by
+            //     the time this returns.
+            //
+            //  3. Wait for [chaptersFor] to emit a non-empty list and
+            //     take the first chapter. The observeFiction flow
+            //     emits as soon as the Room row lands from the
+            //     refresh; chaptersFor combines it with the
+            //     observePlayedChapterIds flow.
+            //
+            // All three steps share a single [withTimeoutOrNull]
+            // budget so a flaky network or a slow Notion endpoint
+            // can't hang the onboarding flow indefinitely. On
+            // timeout we fall back to the TechEmpower Home hub so
+            // the user has a working surface to land on.
+            val firstChapter = withTimeoutOrNull(GUIDES_RESOLVE_TIMEOUT_MS) {
+                runCatching {
+                    // Step 1: seed Notion tiles into the local DB.
+                    // We intentionally ignore the boolean return —
+                    // step 2 will still fail-fast if seeding didn't
+                    // populate the row, and we'd rather fall through
+                    // to the hub than swallow a network failure
+                    // here.
+                    fictionRepo.seedPopularForSource(NOTION_SOURCE_ID)
+                    // Step 2: drive the per-fiction refresh.
+                    fictionRepo.fictionById(GUIDES_FICTION_ID).firstOrNull()
+                    // Step 3: wait for the chapter list to land.
+                    fictionRepo.chaptersFor(GUIDES_FICTION_ID)
+                        .first { it.isNotEmpty() }
+                        .first()
+                }.getOrNull()
+            }
+            if (firstChapter == null) {
+                // Fallback: source didn't surface a chapter list in
+                // time. Land the user on the TechEmpower Home hub
+                // (the legacy CTA target) so they have an obvious
+                // path forward — Browse Resources → Guides — instead
+                // of dead-ending on the Playing surface with no
+                // chapter queued.
+                onFallbackToHub()
+                return@launch
+            }
+            // Queue the chapter and route. `autoPlay=true` lets the
+            // playback controller start audio as soon as the voice
+            // is warm and the chapter body lands.
+            playback.startListening(
+                fictionId = GUIDES_FICTION_ID,
+                chapterId = firstChapter.id,
+                charOffset = 0,
+                autoPlay = true,
+            )
+            onPlaying()
+        }
+    }
+
+    internal companion object {
+        /**
+         * The Notion anonymous-mode source's `notion:guides` fiction
+         * — the TechEmpower curated guides PageList. Inline here (and
+         * mirrored in TechEmpowerHomeScreen's chip strip) so the
+         * onboarding doesn't take a runtime dependency on the
+         * source-notion module just to know one identifier.
+         */
+        const val GUIDES_FICTION_ID: String = "notion:guides"
+
+        /**
+         * Source id for the anonymous-mode Notion delegate that
+         * serves the `notion:guides` fiction. Inline here (mirrors
+         * `SourceIds.NOTION` in :core-data) so the onboarding doesn't
+         * take a module dependency on `:core-data` just for one
+         * string constant. If `SourceIds.NOTION` ever moves to a
+         * different string, a one-grep audit catches this site.
+         */
+        const val NOTION_SOURCE_ID: String = "notion"
+
+        /**
+         * Upper bound on how long [openGuidesAndAutoPlay] waits for
+         * the anonymous-Notion seed + refresh to land a chapter
+         * list. Once exceeded we fall back to the TechEmpower Home
+         * hub rather than spinning a quiet welcome screen for the
+         * user.
+         *
+         * 8000 ms is a generous budget for a cold-launch Notion
+         * round-trip on a hotel-wifi connection (seeding + refresh
+         * each typically clear in <1.5 s on a normal home network,
+         * but the welcome flow runs on whatever wifi the user has
+         * at the moment of first launch). On timeout the user
+         * still gets a working surface via the hub fallback, so a
+         * conservative budget doesn't lock anyone out.
+         */
+        const val GUIDES_RESOLVE_TIMEOUT_MS: Long = 8_000L
     }
 }

--- a/feature/src/main/kotlin/in/jphe/storyvox/feature/reader/WhyAreWeWaitingPanel.kt
+++ b/feature/src/main/kotlin/in/jphe/storyvox/feature/reader/WhyAreWeWaitingPanel.kt
@@ -116,7 +116,31 @@ fun WhyAreWeWaitingPanel(
         // the diagnostic genuinely settled. Identical-content
         // transitions (the same WaitReason re-emitted) never bump the
         // state, so they never trigger a polite-region announcement.
-        val intended = "${r.message}. ${secondaryLineFor(r)}"
+        //
+        // Issue #646 (v1.0 polish, 2026-05-16) — AudioRouteChange (and
+        // any other reason with both a headline + secondary line) was
+        // still triple-announcing on TalkBack:
+        //   1. The parent's merged contentDesc reads
+        //      "Audio output changed.. Switching to the new speaker…"
+        //      (note the DOUBLE period — `r.message` already ends in
+        //      "." so the legacy `"${r.message}. …"` concat appended
+        //      another).
+        //   2. AND each child Text (headline, secondary line) was
+        //      announced as its own node because the parent's
+        //      `Modifier.semantics { … }` didn't merge descendants —
+        //      it only set the live-region + contentDesc. Children
+        //      stayed visible to TalkBack as separate semantic nodes.
+        //
+        // Two-part fix:
+        //   - Switch to `Modifier.semantics(mergeDescendants = true) { … }`
+        //     so the children fold into one node and TalkBack reads
+        //     the announced string ONCE per state change.
+        //   - Use `joinHeadlineAndBody` to glue headline + secondary
+        //     line without a double period, regardless of whether
+        //     either side already ends in punctuation. The result is
+        //     "Audio output changed. Switching to the new speaker…"
+        //     — one clean sentence pair, one TalkBack utterance.
+        val intended = joinHeadlineAndBody(r.message, secondaryLineFor(r))
         var announced by remember { mutableStateOf(intended) }
         LaunchedEffect(intended) {
             // Coalesce window. Rapid Warming ⇄ Buffering oscillations
@@ -138,7 +162,15 @@ fun WhyAreWeWaitingPanel(
                 .background(panelBg)
                 .border(width = 1.dp, color = borderColor, shape = RoundedCornerShape(5.dp))
                 .padding(horizontal = spacing.md, vertical = spacing.sm)
-                .semantics {
+                // mergeDescendants=true folds the headline Text +
+                // secondary Text + retry chip into a single semantic
+                // node so TalkBack announces the panel ONCE per state
+                // change, not once per child. See issue #646 comment
+                // above. The retry chip retains its own `Role.Button`
+                // semantic (set on its inner clickable) so it stays
+                // independently focusable when TalkBack enters
+                // explore-by-touch on the panel.
+                .semantics(mergeDescendants = true) {
                     liveRegion = LiveRegionMode.Polite
                     contentDescription = announced
                 },
@@ -272,6 +304,38 @@ private fun BrassActionChip(
             fontSize = 12.sp,
         )
     }
+}
+
+/**
+ * Issue #646 — glue a headline + secondary body together for the
+ * panel's TalkBack contentDescription without ever producing a double
+ * period. The legacy `"$headline. $body"` concat happily produced
+ * "Audio output changed.. Switching…" when [headline] already ended
+ * in punctuation. We strip a single trailing sentence-terminator from
+ * [headline] before re-appending exactly one period + a space; if
+ * [body] is blank we skip the join entirely so a one-liner reason
+ * doesn't leave a dangling separator.
+ *
+ * Kept package-internal so the unit test can pin the no-double-period
+ * invariant for every WaitReason headline. The function intentionally
+ * stays lossless on non-terminator punctuation ("Hang tight…",
+ * "Loading the chapter") — only periods get the dedupe pass since
+ * those are what the original message literals end in.
+ */
+internal fun joinHeadlineAndBody(headline: String, body: String): String {
+    val trimmedBody = body.trim()
+    val trimmedHead = headline.trimEnd()
+    if (trimmedBody.isEmpty()) return trimmedHead
+    // Strip exactly one trailing period from the headline so the
+    // join site contributes a single ". " separator. Other terminators
+    // (`…`, `!`, `?`) are left intact — they're already sentence ends
+    // and pair fine with a space + body.
+    val headWithoutTrailingPeriod = if (trimmedHead.endsWith(".")) {
+        trimmedHead.dropLast(1).trimEnd()
+    } else {
+        trimmedHead
+    }
+    return "$headWithoutTrailingPeriod. $trimmedBody"
 }
 
 /**

--- a/feature/src/test/kotlin/in/jphe/storyvox/feature/reader/WhyAreWeWaitingPanelAnnounceTest.kt
+++ b/feature/src/test/kotlin/in/jphe/storyvox/feature/reader/WhyAreWeWaitingPanelAnnounceTest.kt
@@ -1,0 +1,88 @@
+package `in`.jphe.storyvox.feature.reader
+
+import `in`.jphe.storyvox.playback.diagnostics.WaitReason
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Test
+
+/**
+ * Issue #646 (v1.0 polish) — TalkBack must announce a Wait-reason
+ * panel ONCE per state change with a single clean utterance, no
+ * double period. Pre-fix the legacy concat produced
+ * "Audio output changed.. Switching to the new speaker…" because the
+ * `r.message` headlines already ended in "." and the join site
+ * appended another. [joinHeadlineAndBody] strips a single trailing
+ * period from the headline before the join, so every reason now
+ * announces with exactly one terminator between the two clauses.
+ *
+ * This test sweeps the full [WaitReason] tree (every data-object +
+ * representative data-class payload) and asserts:
+ *   - the joined string never contains a `..` substring,
+ *   - the joined string is non-empty,
+ *   - the joined string starts with the (period-trimmed) headline and
+ *     ends with the (un-trimmed) body trimmed of whitespace — i.e.,
+ *     no silent payload loss from the dedup pass.
+ *
+ * Lives in the feature test source set because [joinHeadlineAndBody]
+ * is `internal` to the reader package — same kind of structural canary
+ * test as [BottomTabBarSemanticsTest] pinning the dock semantics.
+ */
+class WhyAreWeWaitingPanelAnnounceTest {
+
+    private val allReasons: List<WaitReason> = listOf(
+        WaitReason.WarmingVoice(voiceName = "Brian", progress = 0.5f),
+        WaitReason.LoadingChapter(chapterTitle = "Chapter 1"),
+        WaitReason.BufferingNextSentence(queueDepth = 2),
+        WaitReason.NetworkSlow(secondsWaiting = 5),
+        WaitReason.FocusLost(cause = "phone call"),
+        WaitReason.AudioRouteChange,
+        WaitReason.DeviceMuted,
+        WaitReason.VoiceDownloadFailed(voiceName = "Brian"),
+        WaitReason.AudioOutputStuck(secondsSilent = 6),
+        WaitReason.AudioOutputStuck(secondsSilent = 2),
+    )
+
+    @Test
+    fun `joined announcement never contains a double period`() {
+        allReasons.forEach { reason ->
+            val joined = joinHeadlineAndBody(reason.message, secondaryLineFor(reason))
+            assertFalse(
+                "WaitReason ${reason::class.simpleName} announced as \"$joined\" — contains a double period",
+                joined.contains(".."),
+            )
+        }
+    }
+
+    @Test
+    fun `AudioRouteChange announces with a single period between headline and body`() {
+        // The bellwether case from issue #646. Pre-fix the panel
+        // re-announced "Audio output changed.. Switching to the new
+        // speaker or headphones." three times. Post-fix it's the
+        // tidy one-utterance sentence pair below.
+        val joined = joinHeadlineAndBody(
+            WaitReason.AudioRouteChange.message,
+            secondaryLineFor(WaitReason.AudioRouteChange),
+        )
+        assertEquals(
+            "Audio output changed. Switching to the new speaker or headphones.",
+            joined,
+        )
+    }
+
+    @Test
+    fun `empty body falls back to bare headline — no dangling separator`() {
+        assertEquals("Audio output changed.", joinHeadlineAndBody("Audio output changed.", ""))
+        assertEquals("Hang tight", joinHeadlineAndBody("Hang tight", "   "))
+    }
+
+    @Test
+    fun `headline without a trailing period still gets exactly one period before body`() {
+        // Future-proofing: if a maintainer rewrites a WaitReason
+        // headline to drop the trailing "." the join site must still
+        // produce a single ". " separator, not zero.
+        assertEquals(
+            "Loading the chapter. Getting the chapter ready to read aloud.",
+            joinHeadlineAndBody("Loading the chapter", "Getting the chapter ready to read aloud."),
+        )
+    }
+}


### PR DESCRIPTION
## Summary
v1.0 yellow-light → green-light fixes from persona verification on v0.5.64. Four issues closed in one bundle.

### #647 + #644 — Cold-launch tap budget: 8 → 5 (device-verified on R5CRB0W66MK)
- "Browse TechEmpower's free guides" now resolves chapter 1 of `notion:guides` and queues it on the playback controller with `autoPlay=true`, then navigates to the Playing surface.
- New `OnboardingHostViewModel.openGuidesAndAutoPlay()` does the work in three steps: seed Notion tiles → drive `fictionById` refresh → wait for `chaptersFor` to emit, all under an 8 s timeout budget.
- Fallback path: on network failure / timeout, lands on the TechEmpower Home hub (the legacy CTA destination) so the user never dead-ends.
- Tap sequence verified post-fix: Allow notif → Get started → Pick voice → Skip sync → Browse TechEmpower → **chapter 1 audio at 0:24 of 1:18**.

### #645 — Bottom-dock Library tab clickable=false on Reader / Voices / Settings
- `BottomTabBar.TabCell` clickable role changed from `Role.Tab` to `Role.Button` while keeping `selected = isSelected`. `Role.Tab + selected=true` caused TalkBack to suppress the "double-tap to activate" hint on the selected cell (dead-ending users trying to return to Library from a drill-down where the route-collapse maps everything to Library = selected).
- `Role.Button + selected` keeps the selected-state announcement and restores activation.
- Updated `BottomTabBarSemanticsTest` canary constant: `bottomTabBarUsesRoleButtonPlusSelected`.
- Device-verified: Player → Library and Voices → Library navigation via dock both work.

### #646 — AudioRouteChange TalkBack triple-announce + double-period
- Switched `WhyAreWeWaitingPanel` to `Modifier.semantics(mergeDescendants = true)` so TalkBack reads the panel as one node per state change instead of merged parent + each child Text.
- New `joinHeadlineAndBody()` strips a single trailing period from the headline before re-appending one — kills the "Audio output changed.. Switching…" double-period the legacy `\$headline. \$body` concat produced.
- New `WhyAreWeWaitingPanelAnnounceTest` sweeps every `WaitReason` variant to pin the no-double-period invariant.

## New UI contract surface
- Added `FictionRepositoryUi.seedPopularForSource(sourceId)` with a default no-op so test stubs don't break. Used by the onboarding's auto-play CTA to pre-seed Notion tiles into the local Fiction DAO before `refreshDetail` runs — without this, `refreshDetail` falls back to `ROYAL_ROAD` for an unknown row's source.

## CI gate
- `:app:assembleRelease` ✓
- `:feature:testDebugUnitTest` ✓
- `:core-ui:testDebugUnitTest` ✓
- `:app:testDebugUnitTest` ✓

## Test plan
- [x] Cold-launch tap count ≤ 5 on R5CRB0W66MK
- [x] Audio playing post-fix (timer advances from 0:06 → 0:24 in 18 s)
- [x] Player → Library navigation via bottom dock works
- [x] Voices → Library navigation via bottom dock works
- [x] Unit tests pin Role.Button + selected (BottomTabBarSemanticsTest)
- [x] Unit tests pin no-double-period announce for every WaitReason (WhyAreWeWaitingPanelAnnounceTest)
- [ ] On-device Bluetooth AudioRouteChange single-announce check — pinned via unit test; physical Bluetooth disconnect not exercised in agent verification

🤖 Generated with [Claude Code](https://claude.com/claude-code)