### PR TITLE
feat(ui): magical loading animations — replace weird arc, expand sigil polish across surfaces

### DIFF
--- a/core-ui/src/main/kotlin/in/jphe/storyvox/ui/component/BrassEmberOverlay.kt
+++ b/core-ui/src/main/kotlin/in/jphe/storyvox/ui/component/BrassEmberOverlay.kt
@@ -1,0 +1,158 @@
+package `in`.jphe.storyvox.ui.component
+
+import androidx.compose.animation.core.LinearEasing
+import androidx.compose.animation.core.animateFloat
+import androidx.compose.animation.core.infiniteRepeatable
+import androidx.compose.animation.core.rememberInfiniteTransition
+import androidx.compose.animation.core.tween
+import androidx.compose.foundation.Canvas
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.dp
+import `in`.jphe.storyvox.ui.theme.LocalAnimationSpeedScale
+import `in`.jphe.storyvox.ui.theme.LocalReducedMotion
+import `in`.jphe.storyvox.ui.theme.scaleDurationMs
+import kotlin.math.sin
+import kotlin.random.Random
+
+/**
+ * Library Nocturne "candle ember" overlay — a thin layer of slowly-
+ * drifting brass dots that rise out of the bottom of [modifier]'s bounds
+ * with a slight horizontal sway. Read as warm sparks from a lit candle,
+ * the realm's ambient motif. Designed to layer over a static or near-
+ * static element (typically the player cover during the warming window)
+ * to add "alive, working" affordance without competing with the focal
+ * artwork.
+ *
+ * Each ember:
+ *  - Starts at a random x within the bottom 15 % of the canvas.
+ *  - Rises along a `phase 0..1` axis, where 0 = bottom and 1 = top.
+ *  - Sways horizontally with a per-ember sine offset so they don't all
+ *    march in lockstep.
+ *  - Fades in over the first 15 % of its lifetime, holds at alpha, then
+ *    fades out over the last 25 % — so embers ghost into existence and
+ *    snuff out before the top edge of the cover.
+ *  - Has a per-ember radius drawn from `radiusDp.toPx() * 0.6..1.0`.
+ *
+ * The whole thing is one [Canvas] driven by a single infinite-transition
+ * `phase` cycle — cheap to render, and ember positions are derived from
+ * a `remember`d seeded [Random] so the constellation is stable across
+ * recompositions (no flicker-jitter when an ancestor recomposes).
+ *
+ * Honors:
+ *  - [LocalReducedMotion]: when on, the overlay draws a single static
+ *    "lit ember" at the cover's bottom-center (resting position) — a
+ *    deliberate "candle is lit" still rather than a blank canvas. The
+ *    overlay isn't load-bearing for any signal, so a calm static form
+ *    is appropriate.
+ *  - [LocalAnimationSpeedScale] (#589): the ember rise period scales by
+ *    the user's animation-speed pref. Off (scale == 0f) freezes the
+ *    same way as reduced motion.
+ *
+ * @param modifier sizing modifier — typically the same size as the
+ *   underlying cover image (`Modifier.matchParentSize()` inside a [Box]
+ *   is the common call site).
+ * @param emberCount how many embers to draw. Default 6 — calm,
+ *   atmospheric, not snowy.
+ * @param baseColor the brass tint; defaults to brass primary.
+ * @param radiusDp the maximum ember radius (per-ember radius is drawn
+ *   from `radiusDp * 0.6..1.0` of this value).
+ * @param riseDurationMs how long a single ember takes to traverse the
+ *   bounds (bottom → top). Default 5600 ms — slow and deliberate to
+ *   match the Library Nocturne motion vocabulary.
+ */
+@Composable
+fun BrassEmberOverlay(
+    modifier: Modifier = Modifier,
+    emberCount: Int = 6,
+    baseColor: Color = MaterialTheme.colorScheme.primary,
+    radiusDp: Dp = 3.dp,
+    riseDurationMs: Int = 5600,
+) {
+    val reducedMotion = LocalReducedMotion.current
+    val speedScale = LocalAnimationSpeedScale.current
+    val frozen = reducedMotion || speedScale <= 0f
+
+    // Per-ember constants. Seeded so the constellation is stable. We
+    // deliberately don't hoist this into a stable `data class` — the
+    // arrays are local to the composable's lifetime and remembered
+    // across recompositions.
+    val random = remember { Random(0xBEEF) }
+    val xOffsets = remember { FloatArray(emberCount) { random.nextFloat() } }
+    val phaseOffsets = remember { FloatArray(emberCount) { random.nextFloat() } }
+    val swayFreqs = remember { FloatArray(emberCount) { 0.6f + random.nextFloat() * 0.8f } }
+    val swayAmps = remember { FloatArray(emberCount) { 0.04f + random.nextFloat() * 0.05f } }
+    val radiusScales = remember { FloatArray(emberCount) { 0.6f + random.nextFloat() * 0.4f } }
+
+    val phase: Float = if (frozen) 0.10f else {
+        val scaled = scaleDurationMs(riseDurationMs, speedScale).coerceAtLeast(1)
+        val transition = rememberInfiniteTransition(label = "brass-ember-overlay")
+        val p by transition.animateFloat(
+            initialValue = 0f,
+            targetValue = 1f,
+            animationSpec = infiniteRepeatable(
+                animation = tween(durationMillis = scaled, easing = LinearEasing),
+            ),
+            label = "ember-phase",
+        )
+        p
+    }
+
+    Canvas(modifier = modifier) {
+        val w = size.width
+        val h = size.height
+        val maxR = radiusDp.toPx()
+        if (frozen) {
+            // Static "candle is lit" pose — one slightly-larger ember
+            // resting near the bottom-center, at full opacity. Mirrors
+            // MagicSpinner's 135° resting pose: visible, deliberate,
+            // doesn't read as a stuck spinner.
+            drawCircle(
+                color = baseColor.copy(alpha = 0.55f),
+                radius = maxR,
+                center = Offset(w * 0.5f, h * 0.92f),
+            )
+            return@Canvas
+        }
+        for (i in 0 until emberCount) {
+            // Wrap each ember's progress so they're spread across the
+            // cycle (not all rising in unison).
+            val emberPhase = ((phase + phaseOffsets[i]) % 1f)
+            // Per-ember alpha curve:
+            //   0.00..0.15 — fade in (alpha 0 → 0.85)
+            //   0.15..0.75 — hold (alpha 0.85)
+            //   0.75..1.00 — fade out (alpha 0.85 → 0)
+            val alpha = when {
+                emberPhase < 0.15f -> (emberPhase / 0.15f) * 0.85f
+                emberPhase < 0.75f -> 0.85f
+                else -> ((1f - emberPhase) / 0.25f).coerceIn(0f, 1f) * 0.85f
+            }
+            if (alpha <= 0.01f) continue
+
+            // x = base offset + sine sway. The sine argument uses
+            // emberPhase (which is bounded 0..1) so each ember has its
+            // own smooth horizontal wobble.
+            val swayRad = (emberPhase * 2.0 * Math.PI * swayFreqs[i]).toFloat()
+            val x = (xOffsets[i] + swayAmps[i] * sin(swayRad.toDouble()).toFloat())
+                .coerceIn(0.05f, 0.95f) * w
+            // y = rise from 92% (just below bottom edge) → -2% (just
+            // above top edge). The "off-screen" margins on either end
+            // let the fade-in / fade-out happen below / above the
+            // visible region, so embers don't pop into existence at
+            // the cover edge.
+            val y = (0.92f - emberPhase * 0.94f) * h
+
+            drawCircle(
+                color = baseColor.copy(alpha = alpha),
+                radius = maxR * radiusScales[i],
+                center = Offset(x, y),
+            )
+        }
+    }
+}

--- a/core-ui/src/main/kotlin/in/jphe/storyvox/ui/component/MagicSpinner.kt
+++ b/core-ui/src/main/kotlin/in/jphe/storyvox/ui/component/MagicSpinner.kt
@@ -20,15 +20,21 @@ import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.rotate
+import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.PathEffect
 import androidx.compose.ui.graphics.StrokeCap
 import androidx.compose.ui.graphics.drawscope.Stroke
+import androidx.compose.ui.graphics.drawscope.rotate
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
+import `in`.jphe.storyvox.ui.theme.LocalAnimationSpeedScale
 import `in`.jphe.storyvox.ui.theme.LocalReducedMotion
 import `in`.jphe.storyvox.ui.theme.LocalSpacing
+import `in`.jphe.storyvox.ui.theme.scaleDurationMs
+import kotlin.math.cos
+import kotlin.math.sin
 
 /**
  * Brass arcane sigil ring — single rotating dashed circle in the realm
@@ -38,6 +44,11 @@ import `in`.jphe.storyvox.ui.theme.LocalSpacing
  * Visually quieter than [MagicSkeletonTile] (which adds a six-pointed
  * star + pulsing alpha), so it composes cleanly as an overlay behind a
  * play button or as a small inline indicator.
+ *
+ * Honors [LocalReducedMotion] (freezes at 135°) and
+ * [LocalAnimationSpeedScale] (#589 — the user's animation-speed master
+ * multiplier scales the rotation period so the sigil ring rotates at
+ * the same rate as every other transition in the app).
  *
  * @param strokeWidth thickness of the ring; defaults to 2.dp.
  * @param dashLengthFraction fraction of the circumference used by the
@@ -64,15 +75,22 @@ fun MagicSpinner(
     // existence and the accompanying "Loading…" text (callers always
     // pair it with status copy).
     val reducedMotion = LocalReducedMotion.current
+    // #589 — scale the rotation period by the user's animation-speed
+    // pref. We use scaleDurationMs directly (not tweenScaled) because
+    // infiniteRepeatable's tween needs a stable spec, and we want
+    // scale == 0f to fall through to the reducedMotion branch (which
+    // already freezes the rotation). Off is "no motion", same shape.
+    val speedScale = LocalAnimationSpeedScale.current
+    val scaledDurationMs = scaleDurationMs(durationMs, speedScale).coerceAtLeast(1)
     val transition = rememberInfiniteTransition(label = "magic-spinner")
-    val angle: Float = if (reducedMotion) {
+    val angle: Float = if (reducedMotion || speedScale <= 0f) {
         135f
     } else {
         val animated by transition.animateFloat(
             initialValue = 0f,
             targetValue = 360f,
             animationSpec = infiniteRepeatable(
-                animation = tween(durationMs, easing = LinearEasing),
+                animation = tween(scaledDurationMs, easing = LinearEasing),
                 repeatMode = RepeatMode.Restart,
             ),
             label = "rotation",
@@ -127,4 +145,183 @@ fun MagicLoadingStatus(
             textAlign = TextAlign.Center,
         )
     }
+}
+
+/**
+ * Library Nocturne replacement for Material's `CircularProgressIndicator`
+ * — a layered brass sigil: an outer dashed ring rotating clockwise + an
+ * inner six-pointed star rotating counter-clockwise + a faint static
+ * outer guide ring. Same visual family as [MagicSkeletonTile] but sized
+ * for use as an inline progress affordance (24–64 dp typical) instead of
+ * a full cover-slot placeholder.
+ *
+ * Replaces the Material `CircularProgressIndicator`'s sweeping arc (the
+ * "weird arc spinning around" — JP's audit, 2026-05-16, v0.5.65) with
+ * something that reads as deliberate magic instead of a generic OS
+ * spinner. The arc was a thin material-default sweep that visually felt
+ * out of place against the rest of Library Nocturne's slow brass-on-warm-
+ * dark motion vocabulary.
+ *
+ * Honors [LocalReducedMotion] (both rings freeze at a deliberate resting
+ * pose — outer 0°, inner 30° — matching [MagicSkeletonTile]'s static-mode
+ * pose so the static-glyph reads as one consistent realm sigil across
+ * the loading surfaces).
+ *
+ * Honors [LocalAnimationSpeedScale] (#589) — both rotation periods are
+ * scaled by the user's animation-speed pref, so cranking the slider to
+ * Slow / Fast scales the loading indicator at the same factor as page
+ * transitions.
+ *
+ * Sized to be a drop-in for `CircularProgressIndicator(modifier =
+ * Modifier.size(N.dp))` — pass the same modifier you would to the
+ * Material widget. The glyph fills the Canvas, so the visual diameter
+ * is the modifier's size minus the stroke width.
+ *
+ * @param modifier sizing modifier — pass `Modifier.size(48.dp)` etc.
+ * @param color stroke color; defaults to brass primary.
+ * @param outerPeriodMs rotation period of the outer dashed ring;
+ *   default 5000 ms (slow, deliberate; ~12 RPM).
+ * @param innerPeriodMs rotation period of the inner six-pointed star;
+ *   default 8000 ms in the *opposite* direction so the parallax reads
+ *   as two independent layers, not one rigid sigil.
+ */
+@Composable
+fun MagicCircularProgress(
+    modifier: Modifier = Modifier,
+    color: Color = MaterialTheme.colorScheme.primary,
+    outerPeriodMs: Int = 5000,
+    innerPeriodMs: Int = 8000,
+) {
+    val reducedMotion = LocalReducedMotion.current
+    val speedScale = LocalAnimationSpeedScale.current
+    val frozen = reducedMotion || speedScale <= 0f
+    val transition = rememberInfiniteTransition(label = "magic-circular-progress")
+
+    val outerRotation: Float = if (frozen) 0f else {
+        val v by transition.animateFloat(
+            initialValue = 0f,
+            targetValue = 360f,
+            animationSpec = infiniteRepeatable(
+                animation = tween(
+                    durationMillis = scaleDurationMs(outerPeriodMs, speedScale)
+                        .coerceAtLeast(1),
+                    easing = LinearEasing,
+                ),
+            ),
+            label = "outer",
+        )
+        v
+    }
+    val innerRotation: Float = if (frozen) 30f else {
+        val v by transition.animateFloat(
+            initialValue = 0f,
+            targetValue = -360f,
+            animationSpec = infiniteRepeatable(
+                animation = tween(
+                    durationMillis = scaleDurationMs(innerPeriodMs, speedScale)
+                        .coerceAtLeast(1),
+                    easing = LinearEasing,
+                ),
+            ),
+            label = "inner",
+        )
+        v
+    }
+    val pulse: Float = if (frozen) 1.0f else {
+        val v by transition.animateFloat(
+            initialValue = 0.65f,
+            targetValue = 1.0f,
+            animationSpec = infiniteRepeatable(
+                animation = tween(
+                    durationMillis = scaleDurationMs(1800, speedScale)
+                        .coerceAtLeast(1),
+                    easing = LinearEasing,
+                ),
+                repeatMode = RepeatMode.Reverse,
+            ),
+            label = "pulse",
+        )
+        v
+    }
+
+    val brass = color
+    val brassDim = brass.copy(alpha = 0.45f)
+    val brassFaint = brass.copy(alpha = 0.18f)
+
+    Canvas(modifier = modifier) {
+        val center = Offset(size.width / 2f, size.height / 2f)
+        val radius = size.minDimension / 2f
+        val ringStroke = (radius * 0.10f).coerceAtLeast(1.5f)
+        val starStroke = (radius * 0.12f).coerceAtLeast(2.0f)
+
+        // Faint static outer guide ring — gives the rotating layers a
+        // bounded substrate to read against.
+        drawCircle(
+            color = brassFaint,
+            radius = radius * 0.95f,
+            center = center,
+            style = Stroke(width = ringStroke * 0.6f),
+        )
+
+        // Outer rotating dashed ring
+        rotate(outerRotation, pivot = center) {
+            drawCircle(
+                color = brassDim.copy(alpha = brassDim.alpha * pulse),
+                radius = radius * 0.78f,
+                center = center,
+                style = Stroke(
+                    width = ringStroke * 0.85f,
+                    pathEffect = PathEffect.dashPathEffect(
+                        floatArrayOf(radius * 0.20f, radius * 0.10f),
+                        phase = 0f,
+                    ),
+                ),
+            )
+        }
+
+        // Inner six-pointed star — two overlaid triangles, brass at full
+        // pulse opacity for visual punch.
+        rotate(innerRotation, pivot = center) {
+            val starRadius = radius * 0.50f
+            drawCircularStarTriangle(center, starRadius, 0f, brass.copy(alpha = pulse), starStroke)
+            drawCircularStarTriangle(center, starRadius, 60f, brass.copy(alpha = pulse * 0.85f), starStroke)
+        }
+
+        // Lit center "candle" — the focal dot.
+        drawCircle(
+            color = brass.copy(alpha = pulse),
+            radius = radius * 0.08f,
+            center = center,
+        )
+    }
+}
+
+/**
+ * Helper: draws an equilateral triangle inscribed in [radius] around
+ * [center], rotated by [degreesOffset]. Mirrors [drawTriangle] in
+ * SkeletonShimmer.kt — kept package-private here so the call site
+ * compiles without forcing SkeletonShimmer's helper to be visible to
+ * external modules.
+ */
+private fun androidx.compose.ui.graphics.drawscope.DrawScope.drawCircularStarTriangle(
+    center: Offset,
+    radius: Float,
+    degreesOffset: Float,
+    color: Color,
+    strokeWidth: Float,
+) {
+    val path = androidx.compose.ui.graphics.Path()
+    for (i in 0..2) {
+        val angleDeg = -90f + degreesOffset + i * 120f
+        val rad = Math.toRadians(angleDeg.toDouble())
+        val x = center.x + radius * cos(rad).toFloat()
+        val y = center.y + radius * sin(rad).toFloat()
+        if (i == 0) path.moveTo(x, y) else path.lineTo(x, y)
+    }
+    path.close()
+    drawPath(
+        path = path,
+        color = color,
+        style = Stroke(width = strokeWidth, cap = StrokeCap.Round),
+    )
 }

--- a/core-ui/src/main/kotlin/in/jphe/storyvox/ui/component/SkeletonShimmer.kt
+++ b/core-ui/src/main/kotlin/in/jphe/storyvox/ui/component/SkeletonShimmer.kt
@@ -32,7 +32,9 @@ import androidx.compose.ui.graphics.drawscope.rotate
 import androidx.compose.ui.graphics.drawscope.scale
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
+import `in`.jphe.storyvox.ui.theme.LocalAnimationSpeedScale
 import `in`.jphe.storyvox.ui.theme.LocalReducedMotion
+import `in`.jphe.storyvox.ui.theme.scaleDurationMs
 import kotlin.math.cos
 import kotlin.math.sin
 
@@ -49,12 +51,20 @@ fun shimmerAlpha(): Float {
     // decorative bit a vestibular-sensitive user wants out of their
     // peripheral vision.
     if (LocalReducedMotion.current) return 0.6f
+    // #589 — animation-speed pref also collapses to static at Off
+    // (scale == 0f). Same shape as ReducedMotion: the slider's "Off"
+    // tier is a stronger statement than per-component motion.
+    val speedScale = LocalAnimationSpeedScale.current
+    if (speedScale <= 0f) return 0.6f
     val transition = rememberInfiniteTransition(label = "skeleton-shimmer")
     val alpha by transition.animateFloat(
         initialValue = 0.35f,
         targetValue = 0.85f,
         animationSpec = infiniteRepeatable(
-            animation = tween(durationMillis = 1200, easing = LinearEasing),
+            animation = tween(
+                durationMillis = scaleDurationMs(1200, speedScale).coerceAtLeast(1),
+                easing = LinearEasing,
+            ),
             repeatMode = RepeatMode.Reverse,
         ),
         label = "skeleton-alpha",
@@ -102,36 +112,50 @@ fun MagicSkeletonTile(
     // at a deliberate resting pose (outer 0°, inner 30°, full pulse).
     // The brass glyph still reads as a placeholder; the rotating
     // parallax goes away.
+    // #589 — same shape for animation-speed Off (scale == 0f): the
+    // slider's strongest tier collapses to static, matching reduced
+    // motion. Non-zero scales multiply each rotation period.
     val reducedMotion = LocalReducedMotion.current
+    val speedScale = LocalAnimationSpeedScale.current
+    val frozen = reducedMotion || speedScale <= 0f
     val transition = rememberInfiniteTransition(label = "skeleton-sigil")
-    val outerRotation: Float = if (reducedMotion) 0f else {
+    val outerRotation: Float = if (frozen) 0f else {
         val v by transition.animateFloat(
             initialValue = 0f,
             targetValue = 360f,
             animationSpec = infiniteRepeatable(
-                animation = tween(durationMillis = 12_000, easing = LinearEasing),
+                animation = tween(
+                    durationMillis = scaleDurationMs(12_000, speedScale).coerceAtLeast(1),
+                    easing = LinearEasing,
+                ),
             ),
             label = "outer",
         )
         v
     }
-    val innerRotation: Float = if (reducedMotion) 30f else {
+    val innerRotation: Float = if (frozen) 30f else {
         val v by transition.animateFloat(
             initialValue = 0f,
             targetValue = -360f,
             animationSpec = infiniteRepeatable(
-                animation = tween(durationMillis = 18_000, easing = LinearEasing),
+                animation = tween(
+                    durationMillis = scaleDurationMs(18_000, speedScale).coerceAtLeast(1),
+                    easing = LinearEasing,
+                ),
             ),
             label = "inner",
         )
         v
     }
-    val pulse: Float = if (reducedMotion) 1.0f else {
+    val pulse: Float = if (frozen) 1.0f else {
         val v by transition.animateFloat(
             initialValue = 0.55f,
             targetValue = 1.0f,
             animationSpec = infiniteRepeatable(
-                animation = tween(durationMillis = 1800, easing = LinearEasing),
+                animation = tween(
+                    durationMillis = scaleDurationMs(1800, speedScale).coerceAtLeast(1),
+                    easing = LinearEasing,
+                ),
                 repeatMode = RepeatMode.Reverse,
             ),
             label = "pulse",

--- a/feature/src/main/kotlin/in/jphe/storyvox/feature/fiction/FictionDetailScreen.kt
+++ b/feature/src/main/kotlin/in/jphe/storyvox/feature/fiction/FictionDetailScreen.kt
@@ -25,7 +25,6 @@ import androidx.compose.material.icons.automirrored.filled.ArrowBack
 import androidx.compose.material.icons.filled.MoreVert
 import androidx.compose.material.icons.filled.Star
 import androidx.compose.material3.AlertDialog
-import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.DropdownMenu
 import androidx.compose.material3.DropdownMenuItem
 import androidx.compose.material3.ExperimentalMaterial3Api
@@ -67,6 +66,7 @@ import `in`.jphe.storyvox.ui.component.BrassButton
 import `in`.jphe.storyvox.ui.component.BrassButtonVariant
 import `in`.jphe.storyvox.ui.component.ChapterCard
 import `in`.jphe.storyvox.ui.component.ChapterCardState
+import `in`.jphe.storyvox.ui.component.MagicCircularProgress
 import `in`.jphe.storyvox.ui.component.coverSourceFamilyFor
 import `in`.jphe.storyvox.ui.component.ErrorBlock
 import `in`.jphe.storyvox.ui.component.ErrorPlacement
@@ -287,9 +287,18 @@ fun FictionDetailScreen(
                                 verticalAlignment = Alignment.CenterVertically,
                                 horizontalArrangement = Arrangement.spacedBy(6.dp),
                             ) {
-                                CircularProgressIndicator(
+                                // v1.0 polish (2026-05-16) — swap the
+                                // Material CircularProgressIndicator for
+                                // MagicCircularProgress so the .epub
+                                // export progress reads as the same
+                                // brass-sigil family used everywhere
+                                // else in the app. Tiny size (16 dp) so
+                                // the inner star + outer dashed ring
+                                // collapses to a recognizable brass dot
+                                // with a slow ring sweep — still distinct
+                                // from a static glyph, still ours.
+                                MagicCircularProgress(
                                     modifier = Modifier.size(16.dp),
-                                    strokeWidth = 2.dp,
                                 )
                                 Text("Building .epub…", style = MaterialTheme.typography.labelSmall)
                             }

--- a/feature/src/main/kotlin/in/jphe/storyvox/feature/reader/AudiobookView.kt
+++ b/feature/src/main/kotlin/in/jphe/storyvox/feature/reader/AudiobookView.kt
@@ -86,6 +86,7 @@ import `in`.jphe.storyvox.feature.api.UiPlaybackState
 import `in`.jphe.storyvox.feature.api.UiSleepTimerMode
 import `in`.jphe.storyvox.ui.component.BrassButton
 import `in`.jphe.storyvox.ui.component.BrassButtonVariant
+import `in`.jphe.storyvox.ui.component.BrassEmberOverlay
 import `in`.jphe.storyvox.ui.component.BrassProgressTrack
 import `in`.jphe.storyvox.ui.component.BrassVoiceIcon
 import `in`.jphe.storyvox.ui.component.ErrorBlock
@@ -532,12 +533,53 @@ fun AudiobookView(
                     ) {
                         MagicSpinner(modifier = Modifier.size(width = 240.dp, height = 350.dp))
                     }
+                    // v1.0 polish (2026-05-16) — layer brass candle-ember
+                    // particles over the cover during warming. The Ken-
+                    // Burns scale on the cover + the orbiting sigil ring
+                    // are both *single-element* motion signals; adding
+                    // the ember drift gives the warming window a third
+                    // layer (slow scale × medium ring × fast drift) so
+                    // it reads as ambient magic gathering around the
+                    // chapter — not just one element trying to do all
+                    // the work of saying "we're working". 6 embers, 3 dp
+                    // max radius, 5.6 s rise period — calm + atmospheric.
+                    // Honors LocalReducedMotion (collapses to a single
+                    // resting candle-glow ember at the cover bottom)
+                    // and LocalAnimationSpeedScale (#589). Hidden when
+                    // not warming so playback stays undecorated.
+                    androidx.compose.animation.AnimatedVisibility(
+                        visible = showSpinner,
+                        enter = spinnerEnter,
+                        exit = spinnerExit,
+                    ) {
+                        BrassEmberOverlay(
+                            modifier = Modifier.size(width = 220.dp, height = 330.dp),
+                            emberCount = 6,
+                            radiusDp = 3.dp,
+                            riseDurationMs = 5600,
+                        )
+                    }
                 }
             }
+            // v1.0 polish (2026-05-16) — when the fiction title hasn't
+            // resolved yet ("Conjuring your chapter…"), apply the
+            // existing skeleton shimmer alpha so the placeholder text
+            // breathes between 0.35..0.85 alpha at the same 1.2 s
+            // cadence as every other skeleton on screen. Reads as a
+            // magical incantation forming itself, not as plain
+            // placeholder text waiting for a network hit. Honors
+            // LocalReducedMotion + LocalAnimationSpeedScale (both
+            // collapse the shimmer to a static mid-alpha via
+            // shimmerAlpha() — see SkeletonShimmer.kt).
+            val titleBlank = state.fictionTitle.isBlank()
+            val titleShimmerAlpha = if (titleBlank) {
+                `in`.jphe.storyvox.ui.component.shimmerAlpha()
+            } else 1f
             Text(
-                if (state.fictionTitle.isBlank()) "Conjuring your chapter…" else state.fictionTitle,
+                if (titleBlank) "Conjuring your chapter…" else state.fictionTitle,
                 style = MaterialTheme.typography.titleLarge,
-                color = if (state.fictionTitle.isBlank()) MaterialTheme.colorScheme.primary else MaterialTheme.colorScheme.onSurface,
+                color = if (titleBlank) MaterialTheme.colorScheme.primary else MaterialTheme.colorScheme.onSurface,
+                modifier = Modifier.alpha(titleShimmerAlpha),
             )
             Text(
                 // Issue #166 — when we have a chapter title, KEEP it visible

--- a/feature/src/main/kotlin/in/jphe/storyvox/feature/reader/HybridReaderScreen.kt
+++ b/feature/src/main/kotlin/in/jphe/storyvox/feature/reader/HybridReaderScreen.kt
@@ -9,7 +9,6 @@ import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
-import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
@@ -29,6 +28,7 @@ import `in`.jphe.storyvox.feature.debug.DebugViewModel
 import `in`.jphe.storyvox.ui.component.BrassButton
 import `in`.jphe.storyvox.ui.component.BrassButtonVariant
 import `in`.jphe.storyvox.ui.component.HybridReaderShell
+import `in`.jphe.storyvox.ui.component.MagicCircularProgress
 import `in`.jphe.storyvox.ui.component.MilestoneConfetti
 import `in`.jphe.storyvox.ui.theme.LocalSpacing
 
@@ -427,9 +427,16 @@ private fun ExplicitArgsLoadingPrompt(
                 }
             }
             LoadingPhase.Slow -> {
-                CircularProgressIndicator(
-                    modifier = Modifier.size(48.dp),
-                    strokeWidth = 3.dp,
+                // v1.0 polish (2026-05-16) — JP audit flagged the
+                // Material CircularProgressIndicator's sweeping arc
+                // as "weird" against the rest of the Library Nocturne
+                // motion vocabulary. Swap to MagicCircularProgress: a
+                // layered brass sigil (outer dashed ring + inner six-
+                // pointed star) that matches MagicSkeletonTile's
+                // geometry so the loading + skeleton surfaces read as
+                // one realm-language.
+                MagicCircularProgress(
+                    modifier = Modifier.size(56.dp),
                 )
                 Spacer(Modifier.height(spacing.md))
                 Text(
@@ -447,9 +454,15 @@ private fun ExplicitArgsLoadingPrompt(
                 )
             }
             else -> {
-                CircularProgressIndicator(
-                    modifier = Modifier.size(48.dp),
-                    strokeWidth = 3.dp,
+                // v1.0 polish — same swap as the Slow branch. See
+                // comment above. ExplicitArgsLoadingPrompt is the
+                // surface JP sees the moment he taps a chapter from
+                // FictionDetail and the controller hasn't emitted yet
+                // (~200-2000 ms typical), so this is one of the most
+                // load-bearing animations in the app for "is this
+                // working?" confidence.
+                MagicCircularProgress(
+                    modifier = Modifier.size(56.dp),
                 )
                 Spacer(Modifier.height(spacing.md))
                 Text(

--- a/feature/src/main/kotlin/in/jphe/storyvox/feature/reader/WhyAreWeWaitingPanel.kt
+++ b/feature/src/main/kotlin/in/jphe/storyvox/feature/reader/WhyAreWeWaitingPanel.kt
@@ -47,6 +47,7 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import `in`.jphe.storyvox.playback.diagnostics.WaitReason
+import `in`.jphe.storyvox.ui.component.MagicSpinner
 import `in`.jphe.storyvox.ui.theme.LocalMotion
 import `in`.jphe.storyvox.ui.theme.LocalReducedMotion
 import `in`.jphe.storyvox.ui.theme.LocalSpacing
@@ -243,21 +244,31 @@ fun WhyAreWeWaitingPanel(
 }
 
 /**
- * Pulsing brass sigil — a 12 dp dot that fades 0.5 → 1.0 → 0.5 alpha on a
- * 1.5 s period. Honors reduced motion: when on, the sigil holds at the
- * mid-alpha so the visual still reads as "we're watching for output"
- * without animation.
+ * Pulsing brass sigil — a 14 dp rotating brass dashed ring (MagicSpinner
+ * with the standard 2-second period) overlaid with a subtle alpha pulse.
+ * Used at the panel headline so "we're waiting on output" reads as the
+ * same brass-sigil-family as every other Library Nocturne loading
+ * surface (skeleton tiles, MagicCircularProgress, cover-warm spinner)
+ * instead of a generic alpha-pulse dot. Pre-v1.0-polish (2026-05-16)
+ * this was a 12 dp circle that faded between two alphas — visually
+ * indistinguishable from a status LED, lost the realm-language of the
+ * surrounding UI.
+ *
+ * Honors reduced motion: when on, the spinner freezes at MagicSpinner's
+ * 135° resting pose AND the alpha pulse collapses to a steady mid-
+ * value (0.75), so the sigil holds as a static brass glyph rather than
+ * disappearing.
  */
 @Composable
 private fun PulsingBrassSigil(
     color: Color,
     reducedMotion: Boolean,
 ) {
-    val alpha = if (reducedMotion) 0.75f else {
+    val alpha = if (reducedMotion) 0.85f else {
         val transition = androidx.compose.animation.core
             .rememberInfiniteTransition(label = "why-waiting-sigil")
         val a by transition.animateFloat(
-            initialValue = 0.5f,
+            initialValue = 0.65f,
             targetValue = 1.0f,
             animationSpec = infiniteRepeatable(
                 animation = tween(durationMillis = 1500, easing = androidx.compose.animation.core.LinearEasing),
@@ -269,11 +280,17 @@ private fun PulsingBrassSigil(
     }
     Box(
         modifier = Modifier
-            .size(12.dp)
-            .alpha(alpha)
-            .clip(RoundedCornerShape(6.dp))
-            .background(color),
-    )
+            .size(14.dp)
+            .alpha(alpha),
+    ) {
+        MagicSpinner(
+            modifier = Modifier.size(14.dp),
+            color = color,
+            strokeWidth = 1.5.dp,
+            durationMs = 2400,
+            dashLengthFraction = 0.22f,
+        )
+    }
 }
 
 /**

--- a/feature/src/main/kotlin/in/jphe/storyvox/feature/sync/SyncAuthScreen.kt
+++ b/feature/src/main/kotlin/in/jphe/storyvox/feature/sync/SyncAuthScreen.kt
@@ -12,7 +12,6 @@ import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.CloudSync
 import androidx.compose.material3.Button
 import androidx.compose.material3.ButtonDefaults
-import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.OutlinedButton
@@ -34,6 +33,7 @@ import androidx.compose.ui.unit.dp
 import androidx.compose.foundation.text.KeyboardOptions
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import `in`.jphe.storyvox.ui.component.MagicCircularProgress
 
 /**
  * Brass-themed sign-in screen for the InstantDB sync layer.
@@ -190,12 +190,22 @@ private fun InProgress(label: String) {
     // announces "Loading, <label>" instead of staying silent during a
     // multi-second OAuth handshake. Marked as a live region so the
     // announcement is re-spoken when the label flips between states.
-    CircularProgressIndicator(
+    // v1.0 polish (2026-05-16) — JP audit flagged the Material
+    // CircularProgressIndicator as the "weird arc spinning around"
+    // visible across the app's loading surfaces. Swap to
+    // MagicCircularProgress so OAuth handoff (sign-in → e-mail magic
+    // link → token exchange) shows the same brass sigil family as
+    // every other Library Nocturne loading state. The semantics live
+    // region stays identical so TalkBack's "Loading, <label>"
+    // announcement is preserved.
+    MagicCircularProgress(
         color = MaterialTheme.colorScheme.primary,
-        modifier = Modifier.semantics {
-            contentDescription = "Loading: $label"
-            liveRegion = LiveRegionMode.Polite
-        },
+        modifier = Modifier
+            .size(48.dp)
+            .semantics {
+                contentDescription = "Loading: $label"
+                liveRegion = LiveRegionMode.Polite
+            },
     )
     Spacer(Modifier.height(12.dp))
     Text(


### PR DESCRIPTION
## Summary

v1.0 polish — JP audit (2026-05-16) flagged Material 3's `CircularProgressIndicator` as the "weird arc spinning around" against the rest of the Library Nocturne motion vocabulary. Three sites used it; all three swapped to a new `MagicCircularProgress` — a layered brass arcane sigil (outer dashed ring + inner six-pointed star + faint static outer guide ring + center dot). Matches `MagicSkeletonTile`'s geometry so loading + cover-skeleton surfaces read as one realm language.

### Surfaces touched

- **`HybridReaderScreen.ExplicitArgsLoadingPrompt`** (Slow + default branches) — the surface JP sees the moment he taps a chapter from FictionDetail and the controller hasn't emitted yet. **The "weird arc."**
- **`SyncAuthScreen.InProgress`** — OAuth handoff loading
- **`FictionDetailScreen`** — Building .epub progress chip
- **`AudiobookView`** — new `BrassEmberOverlay` (6 brass candle-ember particles drifting upward with sine sway, fade in / hold / fade out) layered over the cover during warming, alongside the existing MagicSpinner orbit
- **`WhyAreWeWaitingPanel.PulsingBrassSigil`** — was a 12 dp alpha-pulse dot, now a 14 dp `MagicSpinner` brass ring with overlaid alpha-breath. Same sigil family as everywhere else.
- **`AudiobookView`** "Conjuring your chapter…" placeholder title — now breathes via `shimmerAlpha()` while title is empty (incantation-forming feel)

### New shared primitives in `:core-ui`

- `MagicCircularProgress` — drop-in for `CircularProgressIndicator`
- `BrassEmberOverlay` — candle-ember particle layer

### Reduced motion + animation-speed honored

All animations branch through `LocalReducedMotion` OR `LocalAnimationSpeedScale.current <= 0f` (Off tier from #589) to a deliberate static brass-sigil resting pose. Updates extend the existing pattern to **`MagicSpinner`** and **`MagicSkeletonTile`** + **`shimmerAlpha()`** which previously only honored ReducedMotion — they now also collapse at animation-speed Off.

### Pure-Compose

Every new animation uses `animateFloat` / `rememberInfiniteTransition` / `Modifier.graphicsLayer` / `Canvas`. No new dependencies, no raster sprite sheets.

## Test plan

- [x] `./gradlew :app:assembleRelease :core-ui:testDebugUnitTest :feature:testDebugUnitTest :app:testDebugUnitTest` — green
- [x] Installed v0.5.65 release APK on R83W80CAFZB (Tab A7 Lite)
- [x] Library → Browse → TechEmpower Guides → Chapter 5 (uncached) — confirmed `WhyAreWeWaitingPanel` renders with new sigil; content-desc reads "Loading the next bit of audio. Just a moment — the next bit is almost ready."
- [x] `AnimationSpeedScaleTest` still passes — covers the `scaleDurationMs` math gating each frozen-state branch
- [ ] Visual sanity once merged: cold launch → onboarding → voice download → chapter open → all surfaces consistent

🤖 Generated with [Claude Code](https://claude.com/claude-code)