### PR TITLE
fix(core-data): DELETE-then-INSERT chapter upsert — closes #652

### DIFF
--- a/core-data/src/main/kotlin/in/jphe/storyvox/data/db/dao/ChapterDao.kt
+++ b/core-data/src/main/kotlin/in/jphe/storyvox/data/db/dao/ChapterDao.kt
@@ -1,6 +1,8 @@
 package `in`.jphe.storyvox.data.db.dao
 
 import androidx.room.Dao
+import androidx.room.Insert
+import androidx.room.OnConflictStrategy
 import androidx.room.Query
 import androidx.room.Transaction
 import androidx.room.Upsert
@@ -150,18 +152,15 @@ interface ChapterDao {
     /**
      * Issue #349 (RSS reorder crash) — bump every chapter row for
      * [fictionId] currently in the "live" index range into a reserved
-     * parking range above [PARK_OFFSET]. Used right before an upsertAll
-     * batch so the incoming positive-indexed rows can land without
-     * tripping the (fictionId, index) UNIQUE constraint mid-batch.
+     * parking range above [PARK_OFFSET]. Used historically by
+     * [upsertChaptersForFiction] before its rewrite for #652; retained
+     * as a standalone DAO method because nothing else exercises it
+     * directly and removing it would churn the test surface, but the
+     * preferred path now is the DELETE-then-INSERT in
+     * [upsertChaptersForFiction].
      *
-     * The `index >= 0 AND index < PARK_OFFSET` guard means previously-
-     * parked rows from older refreshes stay where they are — no runaway
-     * offset accumulation across many refreshes. Rows whose PK comes
-     * back in the new feed get UPSERTed back to a positive index by
-     * the followup [upsertAll]; rows that have dropped off the feed
-     * stay parked, preserving their bodies/download state for later
-     * playback even though they no longer show in the current feed
-     * snapshot.
+     * The `index >= 0 AND index < PARK_OFFSET` guard prevents runaway
+     * offset accumulation across repeated calls.
      */
     @Query(
         """
@@ -175,22 +174,103 @@ interface ChapterDao {
     suspend fun parkChapterIndexesFor(fictionId: String)
 
     /**
-     * Atomic two-phase chapter sync: park existing rows above the
-     * live range, then upsert the fresh batch at positive indexes
-     * 0..N. Wrapping in @Transaction is what makes this work —
-     * Room defers invalidation-tracker emissions until commit, so
-     * observers never see the "all parked, nothing visible" mid-state.
+     * Issue #652 — delete every chapter row for [fictionId] in a single
+     * statement. Paired with [insertAll] inside [upsertChaptersForFiction]
+     * to fully replace the chapter list atomically.
      *
-     * Use this instead of [upsertAll] from any sync path where the
-     * incoming chapter list may reorder existing rows (RSS feeds,
-     * any future "feed-window" backend). The Royal Road append-only
-     * case works fine with either path; the cost is one extra UPDATE
-     * per fiction-refresh.
+     * `ForeignKey.CASCADE` from chapter→fiction means dropping the
+     * parent deletes children, but the chapter list refresh path is
+     * "replace children, keep parent" — so we delete chapters by
+     * fictionId directly and leave the parent fiction row alone.
+     */
+    @Query("DELETE FROM chapter WHERE fictionId = :fictionId")
+    suspend fun deleteByFictionId(fictionId: String)
+
+    @Insert(onConflict = OnConflictStrategy.REPLACE)
+    suspend fun insertAll(chapters: List<Chapter>)
+
+    /**
+     * Atomic chapter-list replacement: delete all existing rows for
+     * [fictionId], then insert the fresh batch.
+     *
+     * # History
+     *
+     * The first cut of this method (PR #349, RSS reorder crash) used a
+     * two-phase park-then-upsert: bump existing rows above PARK_OFFSET
+     * so the incoming positive indexes could land without tripping the
+     * `(fictionId, index)` UNIQUE constraint mid-batch, then upsertAll
+     * the fresh list. The intent was to preserve dropped rows' bodies
+     * and download state at parked indexes — "feed slides, body lives".
+     *
+     * # Why DELETE-then-INSERT now (issue #652)
+     *
+     * On tablet R83W80CAFZB upgrading from v0.5.64 → v0.5.65+ the
+     * parking path crashed with `SQLiteConstraintException: UNIQUE
+     * constraint failed: chapter.fictionId, chapter.index` on opening
+     * the TechEmpower Guides FictionDetail. Sequence of events:
+     *
+     *  1. v0.5.64 wrote 8 Guides chapters at indexes 0–7. The chapter
+     *     at index 4 was "EBT spending" with PK
+     *     `notion:<fid>::16f7018ad935...`.
+     *  2. PR #648 (v0.5.65) removed "EBT spending" because its
+     *     upstream Notion page started returning a 400. The new chapter
+     *     list has 7 rows.
+     *  3. First open after upgrade: parkChapterIndexesFor bumps all 8
+     *     existing rows from 0–7 to 100000–100007. upsertAll writes 7
+     *     new rows at 0–6, matching the 7 surviving PKs back to the
+     *     live range. "EBT spending" stays parked at 100004.
+     *  4. **Second open**: parkChapterIndexesFor only acts on rows in
+     *     `[0, 100000)` so it tries to bump the 7 live rows 0–6 to
+     *     100000–100006. The bump from index=4 to index=100004
+     *     collides with the still-parked "EBT spending" at 100004.
+     *     UNIQUE index fires; the FictionDetail screen crashes.
+     *
+     * Any time a chapter is permanently removed from a source's feed
+     * (Notion page deleted, RSS entry expired, AO3 chapter pulled,
+     * etc.) the parked row sticks around forever and the next refresh
+     * has a roulette-wheel chance of colliding when the live indexes
+     * cross the parked indexes' offsets.
+     *
+     * # Tradeoff
+     *
+     * The original parking design tried to preserve dropped chapters'
+     * downloaded bodies for "later playback" — the idea being that if
+     * a chapter falls off the feed window in a paginated source, the
+     * user can still play what was already downloaded. In practice:
+     *
+     *  - The repository layer ([FictionRepositoryImpl.upsertDetail])
+     *    already preserves bodies, download state, read state, etc.
+     *    BY PK before this DAO call: it reads each incoming chapter's
+     *    previous row and copies the body forward. So for any chapter
+     *    that's in BOTH the old and new feed (the common case) body
+     *    preservation happens above this layer regardless.
+     *  - The only case the parking design protected was: chapter X
+     *    was in feed yesterday, downloaded, then dropped from the
+     *    feed today. With DELETE-then-INSERT, X's body is now lost.
+     *
+     * Per the v0.5.66 product decision: chapter lists are fully
+     * replaced on every refresh; dropped rows do not survive. If a
+     * future source needs window-style preservation, add a per-source
+     * flag and branch in the repository layer rather than burdening
+     * every refresh with the parking gymnastics.
+     *
+     * # If you find this firing
+     *
+     * The next likely failure mode is an unrelated FK from another
+     * table pointing at chapter.id (e.g. playback position, history,
+     * bookmark sync). Today the schema has:
+     *  - `playback_position` PK = chapter id (not an FK; orphan rows
+     *    are tolerated, they just won't resolve)
+     *  - `chapter_history` joins by id on read, no FK
+     *  - InstantDB sync layer reads chapter rows directly
+     * so DELETE here is safe. If you add a new table with a real FK
+     * onto chapter.id, decide whether dropped chapters should cascade
+     * or whether the DAO needs a soft-delete column.
      */
     @Transaction
     suspend fun upsertChaptersForFiction(fictionId: String, chapters: List<Chapter>) {
-        parkChapterIndexesFor(fictionId)
-        upsertAll(chapters)
+        deleteByFictionId(fictionId)
+        insertAll(chapters)
     }
 
     @Query(

--- a/core-data/src/main/kotlin/in/jphe/storyvox/data/repository/FictionRepository.kt
+++ b/core-data/src/main/kotlin/in/jphe/storyvox/data/repository/FictionRepository.kt
@@ -503,14 +503,19 @@ class FictionRepositoryImpl @Inject constructor(
                 firstReadAt = previous.firstReadAt,
             )
         }
-        // Issue #349 — RSS feeds (and any future window-style backend)
-        // reorder rows across refreshes. Plain upsertAll trips the
-        // (fictionId, index) UNIQUE constraint mid-batch because Room's
-        // @Upsert is per-row and the constraint check is immediate.
-        // upsertChaptersForFiction parks existing rows above the live
-        // range first, then upserts atomically inside a transaction.
-        // Costs one extra UPDATE per refresh; Royal Road's append-only
-        // case is unaffected by the parking pass.
+        // Issues #349 / #652 — RSS feeds (and any future window-style
+        // backend) reorder rows across refreshes. Plain upsertAll trips
+        // the (fictionId, index) UNIQUE constraint mid-batch because
+        // Room's @Upsert is per-row and the constraint check is
+        // immediate. The original fix (parked-then-upsert) preserved
+        // orphan rows above PARK_OFFSET, but that buried a UNIQUE
+        // collision time-bomb when a chapter was permanently removed
+        // from a source (Notion EBT spending, v0.5.65 → #652 crash on
+        // tablet). upsertChaptersForFiction is now a transactional
+        // DELETE-then-INSERT — every refresh fully replaces the
+        // chapter list. Body / download state / read state for
+        // chapters that survive across refreshes are preserved here
+        // in [merged] via the per-PK lookup above.
         chapterDao.upsertChaptersForFiction(detail.summary.id, merged)
     }
 }

--- a/core-data/src/test/kotlin/in/jphe/storyvox/data/db/dao/ChapterDaoTest.kt
+++ b/core-data/src/test/kotlin/in/jphe/storyvox/data/db/dao/ChapterDaoTest.kt
@@ -210,29 +210,94 @@ class ChapterDaoTest {
     }
 
     @Test
-    fun upsertChaptersForFiction_droppedRowsSurviveAtParkedIndexes() = runTest {
+    fun upsertChaptersForFiction_droppedRowsAreDeleted() = runTest {
+        // Issue #652 — semantics flipped from #349's "park dropped
+        // rows above PARK_OFFSET" to "DELETE every chapter row for
+        // the fiction, then INSERT the fresh batch." See the kdoc on
+        // [ChapterDao.upsertChaptersForFiction] for the full history
+        // — short version: orphan parked rows accumulated a UNIQUE
+        // collision time-bomb that fired on tablet R83W80CAFZB when
+        // Notion's "EBT spending" page was removed in v0.5.65.
+        // Body preservation for chapters that survive across
+        // refreshes now happens in the repository layer (per-PK
+        // merge in [FictionRepositoryImpl.upsertDetail]) — the DAO
+        // does a clean wipe-and-replace.
         fictionDao.upsert(fiction)
         dao.upsertAll(
             listOf(
-                chapter("c1", index = 0, plainBody = "preserve me"),
+                chapter("c1", index = 0, plainBody = "do not preserve me"),
                 chapter("c2", index = 1),
             ),
         )
 
-        // Only c2 is in the new feed; c1 drops off but its body must
-        // survive (per the parking-range design: dropped rows stay
-        // parked above PARK_OFFSET = 100000 so their downloaded bodies
-        // are still available for later playback).
+        // Only c2 is in the new feed; c1 drops off and MUST disappear.
         dao.upsertChaptersForFiction("f1", listOf(chapter("c2", index = 0, title = "Now first")))
 
-        // c1 still exists with its body preserved, parked above 100000.
-        val parked = dao.get("c1")
-        assertNotNull("dropped chapter must survive parked", parked)
-        assertEquals("preserve me", parked!!.plainBody)
-        assertTrue("parked row index must be >= 100000, was ${parked.index}", parked.index >= 100000)
-
-        // c2 is at its new positive index.
+        assertNull("dropped chapter must be deleted, not parked", dao.get("c1"))
+        assertEquals("Now first", dao.get("c2")!!.title)
         assertEquals(0, dao.get("c2")!!.index)
+    }
+
+    @Test
+    fun upsertChaptersForFiction_handlesRepeatedRefreshAfterChapterRemoval_issue652() = runTest {
+        // Direct regression for issue #652 — the tablet repro.
+        //
+        // Setup: a fiction whose chapter list shrank. Before v0.5.65
+        // the Notion Guides fiction had 8 chapters at indexes 0..7.
+        // PR #648 dropped "EBT spending" (formerly index 4); v0.5.65+
+        // refreshes write 7 chapters at indexes 0..6 with the same
+        // stable PKs for the survivors. The crash was: open
+        // FictionDetail twice in a row → UNIQUE constraint violation
+        // on (fictionId, index) at index 4.
+        //
+        // The DELETE-then-INSERT path must succeed on N consecutive
+        // calls regardless of how the index map shifts.
+        fictionDao.upsert(fiction)
+        // Pre-#648 state: 8 chapters, the 5th of which is "EBT spending"
+        // (chapter pageId == "ebt"). Bodies populated so we can confirm
+        // both that survivors' bodies are restored through the repo
+        // merge path (out of scope here) AND that the orphan body is
+        // really gone (in scope here).
+        dao.upsertAll(
+            (0..7).map { idx ->
+                chapter(
+                    id = "f1::p$idx",
+                    index = idx,
+                    title = "ch$idx",
+                    plainBody = "body-$idx",
+                )
+            },
+        )
+
+        // New feed: 7 chapters; index 4 in the old DB was p4 ("EBT
+        // spending"), index 4 in the new feed is p5 ("Findhelp"). The
+        // PK shifts at the boundary.
+        val newFeed = listOf(
+            chapter("f1::p0", index = 0, title = "How to use"),
+            chapter("f1::p1", index = 1, title = "Free internet"),
+            chapter("f1::p2", index = 2, title = "EV incentives"),
+            chapter("f1::p3", index = 3, title = "EBT balance"),
+            chapter("f1::p5", index = 4, title = "Findhelp"),
+            chapter("f1::p6", index = 5, title = "Password manager"),
+            chapter("f1::p7", index = 6, title = "Free cell service"),
+        )
+
+        // First refresh after upgrade: must not throw.
+        dao.upsertChaptersForFiction("f1", newFeed)
+        // p4 (EBT spending) is gone.
+        assertNull("dropped chapter must be deleted", dao.get("f1::p4"))
+        // Survivors are at the new indexes.
+        assertEquals(4, dao.get("f1::p5")!!.index)
+
+        // Second refresh: this is the call that crashed on tablet.
+        // With DELETE-then-INSERT it must remain a no-throw.
+        dao.upsertChaptersForFiction("f1", newFeed)
+        assertNull(dao.get("f1::p4"))
+        assertEquals(7, dao.observeChapterInfosByFiction("f1").first().size)
+
+        // Third refresh, same feed — still fine.
+        dao.upsertChaptersForFiction("f1", newFeed)
+        assertEquals(7, dao.observeChapterInfosByFiction("f1").first().size)
     }
 
     @Test

--- a/core-data/src/test/kotlin/in/jphe/storyvox/data/repository/ChapterRepositoryImplTest.kt
+++ b/core-data/src/test/kotlin/in/jphe/storyvox/data/repository/ChapterRepositoryImplTest.kt
@@ -118,6 +118,23 @@ class ChapterRepositoryImplTest {
             chapters.forEach { rows[it.id] = it; publishRow(it.id) }
         }
 
+        // Issue #652 — DELETE-then-INSERT chapter sync. Model the wipe
+        // so any test that drives [upsertChaptersForFiction] sees the
+        // same row-removal semantics the real DAO ships.
+        override suspend fun deleteByFictionId(fictionId: String) {
+            callLog += "deleteByFictionId($fictionId)"
+            val ids = rows.values.filter { it.fictionId == fictionId }.map { it.id }
+            ids.forEach { id ->
+                rows.remove(id)
+                publishRow(id)
+            }
+        }
+
+        override suspend fun insertAll(chapters: List<Chapter>) {
+            callLog += "insertAll(${chapters.map { it.id }})"
+            chapters.forEach { rows[it.id] = it; publishRow(it.id) }
+        }
+
         override suspend fun setDownloadState(
             id: String,
             state: ChapterDownloadState,

--- a/core-data/src/test/kotlin/in/jphe/storyvox/data/repository/FictionRepositoryImplTest.kt
+++ b/core-data/src/test/kotlin/in/jphe/storyvox/data/repository/FictionRepositoryImplTest.kt
@@ -306,6 +306,21 @@ class FictionRepositoryImplTest {
             chapters.forEach { rows[it.id] = it }
             chapters.map { it.fictionId }.toSet().forEach(::publishInfo)
         }
+
+        // Issue #652 — DELETE-then-INSERT chapter sync; record both
+        // for parity with the parking call-log breadcrumb above.
+        override suspend fun deleteByFictionId(fictionId: String) {
+            callLog += "deleteByFictionId($fictionId)"
+            val gone = rows.values.filter { it.fictionId == fictionId }.map { it.id }
+            gone.forEach { rows.remove(it) }
+            publishInfo(fictionId)
+        }
+
+        override suspend fun insertAll(chapters: List<Chapter>) {
+            callLog += "insertAll(${chapters.map { it.id }})"
+            chapters.forEach { rows[it.id] = it }
+            chapters.map { it.fictionId }.toSet().forEach(::publishInfo)
+        }
     }
 
     // -- Fake source -------------------------------------------------------------
@@ -560,16 +575,18 @@ class FictionRepositoryImplTest {
         assertEquals("chapter 0", merged.title)
     }
 
-    @Test fun `refreshDetail parks existing chapter indexes before upsert (issue #349)`() = runTest {
-        // Issue #349 regression — RSS feeds reorder. Without the parking
-        // pass, the fresh upsert would trip the (fictionId, index)
-        // UNIQUE constraint when a *different* chapter PK shows up at
-        // an existing chapter's index. We can't test the real SQL
-        // constraint with the fake DAO, but we CAN verify the
-        // ChapterRepository hits the parking path (parkChapterIndexesFor
-        // → upsertAll) instead of a bare upsertAll. The constraint
-        // crash is then handled by Room atomically inside the
-        // @Transaction wrapper.
+    @Test fun `refreshDetail deletes existing chapters before insert (issues #349, #652)`() = runTest {
+        // Issues #349 / #652 — RSS feeds reorder; a chapter permanently
+        // dropped from a feed used to leave an orphan parked row that
+        // eventually collided with a live row on its next refresh
+        // (tablet R83W80CAFZB Notion Guides v0.5.65 crash, issue #652).
+        // The fix is DELETE-then-INSERT inside @Transaction: every
+        // refresh fully replaces the per-fiction chapter list, so
+        // orphan rows can never accumulate to trigger the UNIQUE
+        // constraint. Verify the repository hits that path instead of
+        // a bare upsertAll — the body merge happens in [upsertDetail]
+        // before this DAO call, so dropped-then-readded chapters keep
+        // their body via the per-PK lookup, not via the DAO.
         val src = FakeSource(SourceIds.ROYAL_ROAD).apply {
             detailResult = FictionResult.Success(detail("99", chapterCount = 1))
         }
@@ -581,10 +598,10 @@ class FictionRepositoryImplTest {
 
         r.refreshDetail("99")
 
-        assertTrue(
-            "parkChapterIndexesFor must run before the upsert batch",
-            chapterDao.callLog.any { it == "parkChapterIndexesFor(99)" },
-        )
+        val deleteIdx = chapterDao.callLog.indexOfFirst { it == "deleteByFictionId(99)" }
+        val insertIdx = chapterDao.callLog.indexOfFirst { it.startsWith("insertAll(") }
+        assertTrue("deleteByFictionId must run", deleteIdx >= 0)
+        assertTrue("insertAll must run after delete", insertIdx > deleteIdx)
     }
 
     // -- refreshRemoteFollows ---------------------------------------------------

--- a/core-sync/src/test/kotlin/in/jphe/storyvox/sync/BookmarksSyncerTest.kt
+++ b/core-sync/src/test/kotlin/in/jphe/storyvox/sync/BookmarksSyncerTest.kt
@@ -165,6 +165,8 @@ class BookmarksSyncerTest {
         override suspend fun upsert(chapter: Chapter) = error("not used")
         override suspend fun upsertAll(chapters: List<Chapter>) = error("not used")
         override suspend fun parkChapterIndexesFor(fictionId: String) = error("not used")
+        override suspend fun deleteByFictionId(fictionId: String) = error("not used")
+        override suspend fun insertAll(chapters: List<Chapter>) = error("not used")
         override suspend fun setDownloadState(id: String, state: ChapterDownloadState, now: Long, error: String?) = error("not used")
         override suspend fun setBody(
             id: String, html: String, plain: String, checksum: String,

--- a/source-epub-writer/src/test/kotlin/in/jphe/storyvox/source/epub/writer/NoopDaos.kt
+++ b/source-epub-writer/src/test/kotlin/in/jphe/storyvox/source/epub/writer/NoopDaos.kt
@@ -62,6 +62,8 @@ internal class NoopChapterDao : ChapterDao {
     override suspend fun upsert(chapter: Chapter) = Unit
     override suspend fun upsertAll(chapters: List<Chapter>) = Unit
     override suspend fun parkChapterIndexesFor(fictionId: String) = Unit
+    override suspend fun deleteByFictionId(fictionId: String) = Unit
+    override suspend fun insertAll(chapters: List<Chapter>) = Unit
     override suspend fun setDownloadState(id: String, state: ChapterDownloadState, now: Long, error: String?) = Unit
     override suspend fun setBody(
         id: String,


### PR DESCRIPTION
## Summary
- Replaces `ChapterDao.upsertChaptersForFiction` two-phase park-then-upsert (#349) with a transactional **DELETE-by-fictionId then INSERT**. Fixes the v1.0 blocker on tablet R83W80CAFZB where opening the Guides FictionDetail crashed with `SQLiteConstraintException: UNIQUE constraint failed: chapter.fictionId, chapter.index`.
- Root cause: PR #648 (v0.5.65) removed "EBT spending" from the curated Guides chapter list. The original parking path left the dropped row at index `100004` forever. On the next refresh, `parkChapterIndexesFor` tried to bump the live row at `index=4` to `index=100004` and tripped the UNIQUE index. Any time a source permanently removes a chapter, the parked orphan time-bombs a future refresh.
- Body / download state / read state are still preserved across refreshes — that merge already happens in `FictionRepositoryImpl.upsertDetail` BY PK before the DAO call, so the wipe is safe for chapters that exist in both old and new feeds. Chapters dropped from a feed (the case the parking path tried to protect) no longer have their bodies preserved — see kdoc on `upsertChaptersForFiction` for the tradeoff rationale.

## Changes
- `core-data/.../ChapterDao.kt` — add `deleteByFictionId` + `insertAll` primitives; rewrite the `@Transaction` `upsertChaptersForFiction` to use them. Long kdoc walks through the #652 sequence-of-events and the tradeoff with #349. `parkChapterIndexesFor` retained as a standalone DAO method (no behavior change there) so tests touching it directly keep working.
- `core-data/.../FictionRepository.kt` — update the explanatory comment above the chapter-upsert call.
- `core-data/.../ChapterDaoTest.kt` — add direct #652 regression (open the shrunk list three times, confirm no crash + correct chapter count). Update the #349-era "dropped rows survive parked" test to assert the new "dropped rows are deleted" semantics.
- `core-data/.../FictionRepositoryImplTest.kt`, `ChapterRepositoryImplTest.kt`, `core-sync/.../BookmarksSyncerTest.kt`, `source-epub-writer/.../NoopDaos.kt` — every `ChapterDao` fake/noop overrides the two new primitives.

## Test plan
- [x] `./gradlew :core-data:testDebugUnitTest` — green (existing and new tests pass).
- [x] `./gradlew :app:testDebugUnitTest` — green.
- [x] `./gradlew :app:assembleRelease` — green (R8 + signing both clean).
- [x] **Tablet verification on R83W80CAFZB without `pm clear`** (preserving the buggy v0.5.65 DB state that caused #652): Library → TechEmpower hero → Browse Resources → tap Guides. Opens cleanly, header shows "7 ch", no `SQLiteConstraintException` in logcat. Repeated three consecutive opens to exercise the exact "second open crashes" repro from the bug report. All three opens render the FictionDetail without crashing.

Closes #652

🤖 Generated with [Claude Code](https://claude.com/claude-code)