### PR TITLE
fix: FlowRow brass-words on sign-in card + byline maxLines on FictionDetail — closes #655 #657

### DIFF
--- a/feature/src/main/kotlin/in/jphe/storyvox/feature/fiction/FictionDetailScreen.kt
+++ b/feature/src/main/kotlin/in/jphe/storyvox/feature/fiction/FictionDetailScreen.kt
@@ -6,6 +6,8 @@ import androidx.activity.result.contract.ActivityResultContracts
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.ExperimentalLayoutApi
+import androidx.compose.foundation.layout.FlowRow
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
@@ -56,6 +58,7 @@ import androidx.compose.ui.semantics.contentDescription
 import androidx.compose.ui.semantics.liveRegion
 import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.text.input.ImeAction
+import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
@@ -649,6 +652,7 @@ private fun ExportSheet(
     }
 }
 
+@OptIn(ExperimentalLayoutApi::class)
 @Composable
 private fun Hero(fiction: UiFiction) {
     val spacing = LocalSpacing.current
@@ -675,17 +679,45 @@ private fun Hero(fiction: UiFiction) {
             // ambiguous string like a repo-name-shaped label). Adding
             // "by" anchors the byline role unambiguously, matching the
             // pattern used on Library Resume cards and Browse listing.
+            //
+            // Issue #657 — on Tab A7 Lite portrait (800px) with a 120dp
+            // cover thumbnail eating the left half of the hero, a long
+            // author name like "by TechEmpower" wrapped to two lines
+            // (113×76px). That pushed the metadata row down, and the
+            // last metadata pill ("Ongoing") was clipped or dropped by
+            // the parent Row. Cap the byline at one line with ellipsis
+            // — readers care more about seeing the status badge than
+            // seeing the full author name (which is also visible above
+            // the fold elsewhere in the surface).
             if (fiction.author.isNotBlank()) {
                 Text(
                     "by ${fiction.author}",
                     style = MaterialTheme.typography.bodyMedium,
                     color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    maxLines = 1,
+                    overflow = TextOverflow.Ellipsis,
                 )
             }
             Spacer(Modifier.height(spacing.xxs))
-            Row(verticalAlignment = Alignment.CenterVertically, horizontalArrangement = Arrangement.spacedBy(spacing.xxs)) {
-                Icon(Icons.Filled.Star, contentDescription = null, tint = MaterialTheme.colorScheme.primary, modifier = Modifier.size(16.dp))
-                Text("%.1f".format(fiction.rating), style = MaterialTheme.typography.labelMedium)
+            // Issue #657 — FlowRow (rather than Row) so the metadata
+            // pills wrap onto a second line when the narrow column
+            // can't fit `rating · chapters · status` on one line.
+            // Plain Row clipped the trailing "Ongoing" pill silently
+            // on Tab A7 Lite portrait; FlowRow keeps every pill
+            // visible at every width, and on wider devices the
+            // single-line layout is unchanged because no wrap is
+            // triggered.
+            FlowRow(
+                horizontalArrangement = Arrangement.spacedBy(spacing.xxs),
+                verticalArrangement = Arrangement.spacedBy(spacing.xxs),
+            ) {
+                Row(
+                    verticalAlignment = Alignment.CenterVertically,
+                    horizontalArrangement = Arrangement.spacedBy(spacing.xxs),
+                ) {
+                    Icon(Icons.Filled.Star, contentDescription = null, tint = MaterialTheme.colorScheme.primary, modifier = Modifier.size(16.dp))
+                    Text("%.1f".format(fiction.rating), style = MaterialTheme.typography.labelMedium)
+                }
                 Text("·", style = MaterialTheme.typography.labelMedium, color = MaterialTheme.colorScheme.onSurfaceVariant)
                 Text("${fiction.chapterCount} ch", style = MaterialTheme.typography.labelMedium, color = MaterialTheme.colorScheme.onSurfaceVariant)
                 Text("·", style = MaterialTheme.typography.labelMedium, color = MaterialTheme.colorScheme.onSurfaceVariant)

--- a/feature/src/main/kotlin/in/jphe/storyvox/feature/sync/PassphraseVisualizer.kt
+++ b/feature/src/main/kotlin/in/jphe/storyvox/feature/sync/PassphraseVisualizer.kt
@@ -4,7 +4,8 @@ import androidx.compose.animation.core.LinearOutSlowInEasing
 import androidx.compose.animation.core.animateFloatAsState
 import androidx.compose.animation.core.tween
 import androidx.compose.foundation.layout.Arrangement
-import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.ExperimentalLayoutApi
+import androidx.compose.foundation.layout.FlowRow
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
@@ -51,16 +52,29 @@ import kotlinx.coroutines.delay
  *
  * Why a custom row-of-Text rather than a single AnnotatedString with
  * span-level alpha: AnnotatedString's span alpha lerps are global per
- * draw frame, but we want per-word independent timing curves. A Row
- * of N Text widgets, each with its own animateFloatAsState, gives us
- * that with no draw-layer math. The trade-off is one Text per word
- * (cheap at this surface — passphrases cap at ~6 words).
+ * draw frame, but we want per-word independent timing curves. A
+ * FlowRow of N Text widgets, each with its own animateFloatAsState,
+ * gives us that with no draw-layer math. The trade-off is one Text
+ * per word (cheap at this surface — passphrases cap at ~6 words).
  *
- * Accessibility: the Row is a single semantics node by default —
- * TalkBack reads the words in order without animation cues. Callers
- * needing to skip the animation entirely should pass `staggerMs = 0`
- * and `revealMs = 0` so the visualizer mounts at full opacity.
+ * Why FlowRow rather than Row (issue #655): on tablet portrait
+ * (Tab A7 Lite, 800px wide) the 4-word demo list "candlelight ·
+ * brass · vellum · starlight" overflows the SyncOnboardingCard's
+ * inner padded width. Row clips horizontally and the last word
+ * (longest tail) collapses into a 21×304px vertical letter-stack
+ * because the Text widget gets a constraint of 1-column width but
+ * unbounded height. FlowRow wraps gracefully onto a second line
+ * when the words can't fit, preserving readability at every screen
+ * size without forcing a smaller font on the wider phones/tablets
+ * that *can* fit the row on a single line.
+ *
+ * Accessibility: the FlowRow is a single semantics node by default
+ * — TalkBack reads the words in order without animation cues.
+ * Callers needing to skip the animation entirely should pass
+ * `staggerMs = 0` and `revealMs = 0` so the visualizer mounts at
+ * full opacity.
  */
+@OptIn(ExperimentalLayoutApi::class)
 @Composable
 fun PassphraseVisualizer(
     words: List<String>,
@@ -68,9 +82,10 @@ fun PassphraseVisualizer(
     staggerMs: Int = 240,
     revealMs: Int = 360,
 ) {
-    Row(
+    FlowRow(
         modifier = modifier,
         horizontalArrangement = Arrangement.spacedBy(8.dp),
+        verticalArrangement = Arrangement.spacedBy(4.dp),
     ) {
         words.forEachIndexed { index, word ->
             WordReveal(


### PR DESCRIPTION
## Summary

Two same-shape portrait-squish fixes on Tab A7 Lite (800×1340), bundled because they share the same root cause (Row clipping on narrow widths) and the same remedy (FlowRow + tightened text overflow rules).

### #655 — SyncOnboardingCard brass-words

- `PassphraseVisualizer` `Row` → `FlowRow` (+ `verticalArrangement = spacedBy(4.dp)`) so `candlelight · brass · vellum · starlight` wraps gracefully when the SyncOnboardingCard inner width can't fit all four on one line.
- Per-word reveal animation preserved — each `WordReveal` still owns its `animateFloatAsState`.

### #657 — FictionDetail header on TechEmpower's "Guides"

- Byline `Text` (`"by ${fiction.author}"`) gets `maxLines = 1` + `overflow = TextOverflow.Ellipsis`. Reader value: keep the metadata pills visible rather than a perfectly-wrapped author name.
- Metadata `Row` (`★ 0.0 · 7 ch · Ongoing`) → `FlowRow` so the trailing pill wraps onto row 2 instead of being clipped/dropped. Star icon + rating stay grouped in an inner `Row` so the wrap point can't separate "0.0" from its star.

## Device-verified bounds (R83W80CAFZB, portrait 800×1340)

### Sign-in card brass-words (#655)

| word | bounds | size | row |
|------|--------|------|-----|
| candlelight | `[251,686][381,724]` | 130×38 | 1 |
| brass       | `[392,686][457,724]` |  65×38 | 1 |
| vellum      | `[468,686][548,724]` |  80×38 | 1 |
| starlight   | `[251,735][349,773]` |  98×38 | 2 (wrapped) |

`starlight` went from **21×304** (broken vertical letter-stack) to **98×38** (horizontal, wrapped).

### FictionDetail header (#657)

| element | bounds | size | note |
|---------|--------|------|------|
| by TechEmpower | `[202,213][315,235]` | 113×22 | was 113×76 (2-line wrap) |
| 0.0            | `[228,251][253,270]` |  25×19 | row 1 of FlowRow |
| 7 ch           | `[269,250][302,269]` |  33×19 | row 1 |
| Ongoing        | `[213,276][276,295]` |  63×19 | row 2 — **was missing from dump entirely** |

## Test plan

- [x] `./gradlew :feature:testDebugUnitTest :app:testDebugUnitTest` — green
- [x] `./gradlew :app:assembleRelease` — green
- [x] R83W80CAFZB cold launch → onboarding flow → sign-in card → all 4 brass words horizontal (#655)
- [x] R83W80CAFZB Library → TechEmpower hero → Browse Resources → Guides → FictionDetail header shows `by TechEmpower` on one line + all three metadata pills visible (#657)
- [ ] Visual confirmation on wider devices (phones, landscape): single-line layouts should be unchanged — FlowRow only wraps when the inner Row would have overflowed.

## Files

- `feature/src/main/kotlin/in/jphe/storyvox/feature/sync/PassphraseVisualizer.kt`
- `feature/src/main/kotlin/in/jphe/storyvox/feature/fiction/FictionDetailScreen.kt`

Closes #655
Closes #657

🤖 Generated with [Claude Code](https://claude.com/claude-code)