### PR TITLE
fix(source-arxiv): switch QUERY_BASE to HTTPS — Browse loads on Android 9+ release

### DIFF
--- a/source-arxiv/src/main/kotlin/in/jphe/storyvox/source/arxiv/di/ArxivModule.kt
+++ b/source-arxiv/src/main/kotlin/in/jphe/storyvox/source/arxiv/di/ArxivModule.kt
@@ -25,8 +25,9 @@ annotation class ArxivHttp
  * with a paragraph-length abstract); connect timeout stays tight because
  * `export.arxiv.org` is CDN-fronted and reliably reachable.
  *
- * arXiv recommends following redirects so the `http://export.arxiv.org`
- * → `https://` upgrade happens transparently.
+ * Follow-redirects stays on as a belt-and-suspenders guard, but the
+ * base URL is now HTTPS directly — Android's network-security-config
+ * blocks cleartext before OkHttp can follow arXiv's HTTP→HTTPS 301.
  */
 @Module
 @InstallIn(SingletonComponent::class)

--- a/source-arxiv/src/main/kotlin/in/jphe/storyvox/source/arxiv/net/ArxivApi.kt
+++ b/source-arxiv/src/main/kotlin/in/jphe/storyvox/source/arxiv/net/ArxivApi.kt
@@ -182,8 +182,13 @@ internal class ArxivApi @Inject constructor(
 
         /** Atom-query endpoint host. arXiv directs automated clients to
          *  `export.arxiv.org` rather than the user-facing `arxiv.org`
-         *  to keep CDN cache pressure off the read path. */
-        const val QUERY_BASE: String = "http://export.arxiv.org/api/query"
+         *  to keep CDN cache pressure off the read path. HTTPS is
+         *  required — Android's default network-security-config blocks
+         *  cleartext to every host except `palace.jphe.in`, so the
+         *  pre-2026-05 `http://` value silently failed at the OS layer
+         *  before OkHttp could even follow arXiv's 301→https redirect.
+         *  Arxiv's HTTPS endpoint returns HTTP/2 200 directly. */
+        const val QUERY_BASE: String = "https://export.arxiv.org/api/query"
 
         /** Per-paper abstract page host. */
         const val ABS_BASE: String = "https://arxiv.org/abs"

--- a/source-arxiv/src/test/kotlin/in/jphe/storyvox/source/arxiv/ArxivApiUrlTest.kt
+++ b/source-arxiv/src/test/kotlin/in/jphe/storyvox/source/arxiv/ArxivApiUrlTest.kt
@@ -24,7 +24,7 @@ class ArxivApiUrlTest {
         // alone since it's an unreserved sub-delim in query strings;
         // arXiv accepts both `cat:` and `cat%3A`.
         assertEquals(
-            "http://export.arxiv.org/api/query" +
+            "https://export.arxiv.org/api/query" +
                 "?search_query=cat:cs.AI" +
                 "&sortBy=submittedDate&sortOrder=descending" +
                 "&start=0&max_results=50",
@@ -48,7 +48,7 @@ class ArxivApiUrlTest {
         // both `+` and `%20`. The `:` in the qualifier prefix stays
         // literal — see [composeRecentUrl] test for the same call out.
         assertEquals(
-            "http://export.arxiv.org/api/query" +
+            "https://export.arxiv.org/api/query" +
                 "?search_query=all:attention+is+all+you+need" +
                 "&sortBy=submittedDate&sortOrder=descending" +
                 "&start=0&max_results=50",


### PR DESCRIPTION
## Summary
- v1.0 blocker. arXiv Browse silently failed with no content + no error on tablet because the Atom-query endpoint was hardcoded `http://export.arxiv.org/api/query`. Android's `network_security_config.xml` only allows cleartext to `palace.jphe.in`, so the OS blocked the request before OkHttp could follow arXiv's HTTP→HTTPS 301 redirect.
- Confirmed by tablet sweep (R83W80CAFZB, v0.5.67-release post-fix): cs.AI papers ("ATLAS", "EntityBench", "Quantitative Video World Model Evaluation", etc.) now render in Browse.
- Switch `QUERY_BASE` const to HTTPS. `followRedirects` + `followSslRedirects` stay on as belt-and-suspenders if arXiv ever inverts the redirect direction. `ArxivApiUrlTest` fixtures pinned to the new shape.

## Test plan
- [x] `./gradlew :source-arxiv:testDebugUnitTest` — green
- [x] Tablet Browse → arXiv chip → real paper titles render
- [ ] CI green on `Build APK`
- [ ] JP confirms phone Browse → arXiv also loads

🤖 Generated with [Claude Code](https://claude.com/claude-code)