### PR TITLE
fix(source-plos): swap retired `journal_key` filter + drop section-fragments — closes #664

### DIFF
--- a/source-plos/src/main/kotlin/in/jphe/storyvox/source/plos/net/PlosApi.kt
+++ b/source-plos/src/main/kotlin/in/jphe/storyvox/source/plos/net/PlosApi.kt
@@ -64,14 +64,22 @@ internal class PlosApi @Inject constructor(
         val url = "$BASE_SEARCH" +
             "?q=" + URLEncoder.encode("*:*", "UTF-8") +
             // Issue #664 — PLOS retired the `journal_key` field; queries
-            // against it return numFound=0 now. The user-facing journal
-            // name `"PLOS ONE"` (quoted to keep the space inside one
-            // term) is the current Solr-side filter that still resolves
-            // to ~2.8M docs. Curl-confirmed against
-            //   https://api.plos.org/search?q=*:*&fq=journal:"PLOS ONE"
-            // — if/when PLOS publishes a stable replacement key, swap
-            // here and update PlosApiTest's URL fixture.
+            // against it return numFound=0 now. Two fq's together:
+            //  1. `journal:"PLOS ONE"` pins PLOS ONE (case-insensitive
+            //     — Solr matches "PLoS ONE" as well; we keep the
+            //     all-caps form in the query for human readability).
+            //  2. `doc_type:full` drops the per-section fragment docs
+            //     (`/title`, `/abstract`, `/body`, `/references`) that
+            //     would otherwise surface as separate "fictions" in
+            //     Browse — each real article is indexed N+1 times in
+            //     PLOS's Solr (one full, one per section). Without this
+            //     filter Browse → PLOS shows the parent article AND its
+            //     5+ sub-docs as duplicate cards with cryptic DOI-path
+            //     titles. ~3.4M total → ~330k full-article docs.
+            // Curl-confirmed at
+            //   https://api.plos.org/search?q=*:*&fq=journal:"PLOS ONE"&fq=doc_type:full
             "&fq=" + URLEncoder.encode("journal:\"PLOS ONE\"", "UTF-8") +
+            "&fq=" + URLEncoder.encode("doc_type:full", "UTF-8") +
             "&sort=" + URLEncoder.encode("publication_date desc", "UTF-8") +
             "&start=$start" +
             "&rows=$rows" +

--- a/source-plos/src/main/kotlin/in/jphe/storyvox/source/plos/net/PlosApi.kt
+++ b/source-plos/src/main/kotlin/in/jphe/storyvox/source/plos/net/PlosApi.kt
@@ -49,9 +49,13 @@ internal class PlosApi @Inject constructor(
      * Recent articles in PLOS ONE — the Browse → Popular landing.
      * PLOS doesn't expose a "top stories" feed; sorting PLOS ONE
      * (their biggest journal by volume) by publication date desc
-     * gives a stable + fresh listing. `journal_key:PLOSONE` is the
-     * Solr-side filter for PLOS ONE specifically; the
-     * Solr-internal id is the all-caps form, not the URL slug.
+     * gives a stable + fresh listing.
+     *
+     * Filter shape (post-#664): `fq=journal:"PLOS ONE"`. The legacy
+     * `journal_key:PLOSONE` field is no longer indexed — Solr returns
+     * `numFound=0` for it, surfacing as a silent empty Browse tab. The
+     * `journal` field carries the human-readable name and remains the
+     * stable filter today.
      */
     suspend fun searchRecent(
         start: Int = 0,
@@ -59,7 +63,15 @@ internal class PlosApi @Inject constructor(
     ): FictionResult<PlosSearchResponse> {
         val url = "$BASE_SEARCH" +
             "?q=" + URLEncoder.encode("*:*", "UTF-8") +
-            "&fq=" + URLEncoder.encode("journal_key:PLOSONE", "UTF-8") +
+            // Issue #664 — PLOS retired the `journal_key` field; queries
+            // against it return numFound=0 now. The user-facing journal
+            // name `"PLOS ONE"` (quoted to keep the space inside one
+            // term) is the current Solr-side filter that still resolves
+            // to ~2.8M docs. Curl-confirmed against
+            //   https://api.plos.org/search?q=*:*&fq=journal:"PLOS ONE"
+            // — if/when PLOS publishes a stable replacement key, swap
+            // here and update PlosApiTest's URL fixture.
+            "&fq=" + URLEncoder.encode("journal:\"PLOS ONE\"", "UTF-8") +
             "&sort=" + URLEncoder.encode("publication_date desc", "UTF-8") +
             "&start=$start" +
             "&rows=$rows" +


### PR DESCRIPTION
## Summary
- v1.0 blocker. **PLOS Browse showed a completely empty body** — no spinner, no error, no content — on tablet (R83W80CAFZB, v0.5.67-release). Confirmed silent network success: API returns `numFound: 0`.
- Root cause: PLOS retired the `journal_key` field at some point post-2024. `fq=journal_key:PLOSONE` matches zero docs.
- Two-part fix:
  1. **`journal:"PLOS ONE"`** (the human-readable name, case-insensitive in Solr) replaces the retired `journal_key` filter → ~2.8M PLOS ONE docs.
  2. **`doc_type:full`** drops per-section sub-docs (`/title`, `/abstract`, `/body`, `/references` — Solr indexes each article N+1 times) → ~330k full articles only. Without this, cards rendered cryptic `10.1371/journal.pone.XXXX/...` titles next to the parent article.

## Verification
On tablet, post-fix release APK installed and Browse → PLOS now shows six distinct articles with proper titles + authors:
- *Enhanced nitrogen removal via simultaneous nitrification...* — Shufeng Chen et al.
- *Nutritional status and associated factors among...* — Birtukan Kebede Moti et al.
- *'We need to be supported so that we are...* — Carley Citron et al.
- *An exploratory study on cortical hemodynamics...* — Yanping Feng et al.
- *PufCB-Auth: A lightweight continuous...* — Chongchao Zhang et al.
- *Lived experience of cognitive-communication...* — Nicholas Behn et al.

## Test plan
- [x] `./gradlew :source-plos:testDebugUnitTest` — green
- [x] `./gradlew :app:assembleRelease` — green
- [x] Tablet Browse → PLOS → six real articles render with bylines
- [ ] CI green on `Build APK`

🤖 Generated with [Claude Code](https://claude.com/claude-code)