### PR TITLE
fix(core-playback): route secondary-engine sample-rate reads through cache — closes #582

### DIFF
--- a/core-playback/src/main/kotlin/in/jphe/storyvox/playback/tts/EnginePlayer.kt
+++ b/core-playback/src/main/kotlin/in/jphe/storyvox/playback/tts/EnginePlayer.kt
@@ -1784,8 +1784,19 @@ class EnginePlayer @AssistedInject constructor(
         val secondaryHandles: List<EngineStreamingSource.VoiceEngineHandle> = when (engineType) {
             EngineType.Piper -> secondaryPiperEngines.map { eng ->
                 object : EngineStreamingSource.VoiceEngineHandle {
+                    // Issue #582 — route secondary-engine sample-rate
+                    // reads through the volatile cache too. Each
+                    // secondary is a separate VoiceEngine instance with
+                    // its own intrinsic monitor, so a per-secondary
+                    // loadModel that's still in flight when this main-
+                    // thread construction runs would contend on THAT
+                    // instance the same way the singleton did. All
+                    // Piper engines share one model file and therefore
+                    // one sample rate within a process, so the
+                    // engine-type-scoped cache is the correct answer.
                     override val sampleRate: Int =
-                        eng.sampleRate.takeIf { it > 0 } ?: DEFAULT_SAMPLE_RATE
+                        EngineSampleRateCache.piperRate()
+                            .takeIf { it > 0 } ?: DEFAULT_SAMPLE_RATE
                     override fun generateAudioPCM(
                         text: String, speed: Float, pitch: Float,
                     ): ByteArray? {
@@ -1798,8 +1809,11 @@ class EnginePlayer @AssistedInject constructor(
             }
             is EngineType.Kokoro -> secondaryKokoroEngines.map { eng ->
                 object : EngineStreamingSource.VoiceEngineHandle {
+                    // Issue #582 — see Piper branch above. Kokoro is
+                    // architecturally 24 kHz across every speaker.
                     override val sampleRate: Int =
-                        eng.sampleRate.takeIf { it > 0 } ?: DEFAULT_SAMPLE_RATE
+                        EngineSampleRateCache.kokoroRate()
+                            .takeIf { it > 0 } ?: DEFAULT_SAMPLE_RATE
                     override fun generateAudioPCM(
                         text: String, speed: Float, pitch: Float,
                     ): ByteArray? {
@@ -1816,8 +1830,11 @@ class EnginePlayer @AssistedInject constructor(
             // signature.
             is EngineType.Kitten -> secondaryKittenEngines.map { eng ->
                 object : EngineStreamingSource.VoiceEngineHandle {
+                    // Issue #582 — see Piper branch above. Kitten is
+                    // architecturally 24 kHz across every speaker.
                     override val sampleRate: Int =
-                        eng.sampleRate.takeIf { it > 0 } ?: DEFAULT_SAMPLE_RATE
+                        EngineSampleRateCache.kittenRate()
+                            .takeIf { it > 0 } ?: DEFAULT_SAMPLE_RATE
                     override fun generateAudioPCM(
                         text: String, speed: Float, pitch: Float,
                     ): ByteArray? {


### PR DESCRIPTION
## Summary
Closes the last remaining lock-contention vector on the VoxSherpa sample-rate path. The singleton was already routed through `EngineSampleRateCache.{piper,kokoro,kitten}Rate()` in #582's earlier fix, but the **secondary** engine handles (parallel-synth instances) at `EnginePlayer.kt:1788/1802/1820` were still doing direct `eng.sampleRate` reads.

Each secondary is a separate `VoiceEngine`/`KokoroEngine`/`KittenEngine` instance with its own intrinsic monitor — if a secondary's `loadModel` is still in flight when `startPlaybackPipeline` runs on the main thread (speed-chip cycling pattern from the original `adb shell monkey` repro), the read contends on THAT instance the same way the singleton contended for 2.054s on the Z Flip 3.

## Fix
All Piper engines in a process share one model file and therefore one sample rate, so the engine-type-scoped `EngineSampleRateCache` is the correct answer — using `EngineSampleRateCache.piperRate()` for both primary AND secondary handles is consistent + lock-free.

## Verification
- `./gradlew :core-playback:testDebugUnitTest` — green
- `./gradlew :app:assembleRelease` — green (3m 32s)
- The Z Flip 3 stress repro (rapid speed-chip cycling + monkey 5000) can re-test on v0.5.69 to confirm no `Long monitor contention` warnings.

## Test plan
- [x] Unit tests pass
- [x] R8-minified release build passes
- [ ] CI green
- [ ] Z Flip 3 re-stress on v0.5.69 (post-merge) confirms zero `Long monitor contention` lines under the monkey workload

🤖 Generated with [Claude Code](https://claude.com/claude-code)