### PR TITLE
fix(browse): add Local (EPUB) empty state with folder-picker CTA — closes #669

### DIFF
--- a/feature/src/main/kotlin/in/jphe/storyvox/feature/browse/BrowseScreen.kt
+++ b/feature/src/main/kotlin/in/jphe/storyvox/feature/browse/BrowseScreen.kt
@@ -361,6 +361,19 @@ fun BrowseScreen(
                 !state.isLoading &&
                 state.error == null ->
                 RssEmptyState(onAdd = { showRssManageSheet = true })
+            // Issue #669 — Local backend empty state. Without this branch
+            // tapping the Local chip on a fresh install rendered a
+            // completely blank content area: no spinner, no message,
+            // no CTA. Indistinguishable from a backend hang. Surface
+            // an explicit empty state with copy + a primary CTA that
+            // launches the SAF folder picker directly so the user can
+            // start importing without first navigating to Settings.
+            state.sourceId == SourceIds.EPUB &&
+                state.tab != BrowseTab.Search &&
+                state.items.isEmpty() &&
+                !state.isLoading &&
+                state.error == null ->
+                LocalEmptyState(viewModel = viewModel)
             // First-load failure with no cached items: full-screen error.
             // Retry triggers viewModel.loadMore() which the paginator
             // resolves to the same page that failed.
@@ -733,6 +746,76 @@ private fun Ao3SignInBanner(onOpenSignIn: () -> Unit) {
  * one-line explanation of how the source works + a primary "Add a
  * feed" CTA that opens the same `BrowseRssManageSheet` the FAB does.
  */
+/**
+ * Issue #669 — empty state for the Local (EPUB) backend.
+ *
+ * Pre-fix Browse → Local rendered a completely blank content area with
+ * no spinner, no message, no CTA. Every other "not yet configured"
+ * backend (Palace, Wiki, Discord) had a clear `realm is unreachable`
+ * panel + setup path; Local did not.
+ *
+ * The CTA below launches the same SAF `OpenDocumentTree` picker
+ * Settings → EPUB folder uses, then persists the URI via
+ * `BrowseViewModel.setEpubFolderUri`. The repository's `epubFolderUri`
+ * flow propagates the change so the EPUB source re-enumerates the
+ * folder and the empty state flips into the normal grid on next
+ * paginator tick.
+ *
+ * The folder-permission `takePersistableUriPermission` call mirrors the
+ * Settings row's logic (SettingsScreen.EpubFolderPickerRow) so the
+ * grant outlives the current process.
+ */
+@Composable
+private fun LocalEmptyState(viewModel: BrowseViewModel) {
+    val spacing = LocalSpacing.current
+    val context = androidx.compose.ui.platform.LocalContext.current
+    val launcher = androidx.activity.compose.rememberLauncherForActivityResult(
+        contract = androidx.activity.result.contract.ActivityResultContracts.OpenDocumentTree(),
+    ) { uri ->
+        if (uri != null) {
+            val flags = android.content.Intent.FLAG_GRANT_READ_URI_PERMISSION
+            runCatching {
+                context.contentResolver.takePersistableUriPermission(uri, flags)
+            }
+            viewModel.setEpubFolderUri(uri.toString())
+        }
+    }
+    Box(modifier = Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
+        Column(
+            horizontalAlignment = Alignment.CenterHorizontally,
+            verticalArrangement = Arrangement.spacedBy(spacing.sm),
+            modifier = Modifier.padding(horizontal = spacing.xl),
+        ) {
+            Icon(
+                imageVector = Icons.Filled.Add,
+                contentDescription = null,
+                tint = MaterialTheme.colorScheme.primary,
+                modifier = Modifier.size(48.dp),
+            )
+            Text(
+                "Listen to your own EPUBs",
+                style = MaterialTheme.typography.titleMedium,
+                color = MaterialTheme.colorScheme.onSurface,
+                textAlign = TextAlign.Center,
+            )
+            Text(
+                "Pick a folder on your device — every .epub inside becomes " +
+                    "a fiction storyvox can read to you. Zero network, " +
+                    "your files stay on your device.",
+                style = MaterialTheme.typography.bodySmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                textAlign = TextAlign.Center,
+            )
+            Spacer(Modifier.height(spacing.md))
+            BrassButton(
+                label = "Choose folder",
+                onClick = { launcher.launch(null) },
+                variant = BrassButtonVariant.Primary,
+            )
+        }
+    }
+}
+
 @Composable
 private fun RssEmptyState(onAdd: () -> Unit) {
     val spacing = LocalSpacing.current

--- a/feature/src/main/kotlin/in/jphe/storyvox/feature/browse/BrowseViewModel.kt
+++ b/feature/src/main/kotlin/in/jphe/storyvox/feature/browse/BrowseViewModel.kt
@@ -492,6 +492,21 @@ class BrowseViewModel @Inject constructor(
         viewModelScope.launch { paginator.value?.loadNext() }
     }
 
+    // ─── Local EPUB folder picker (#669) ─────────────────────────────────
+    //
+    // Browse → Local chip empty-state CTA writes the picked SAF tree URI
+    // straight through here so the user can start importing local books
+    // without navigating to Settings → EPUB folder. The corresponding
+    // Settings row continues to exist for "I want to change my folder
+    // later" — this entry point is for first-run discoverability.
+    val epubFolderUri: StateFlow<String?> =
+        settings.epubFolderUri
+            .stateIn(viewModelScope, SharingStarted.WhileSubscribed(5_000), null)
+
+    fun setEpubFolderUri(uri: String) = viewModelScope.launch {
+        settings.setEpubFolderUri(uri)
+    }
+
     // ─── RSS feed management (#247) ─────────────────────────────────────
 
     val rssSubscriptions: StateFlow<List<String>> =


### PR DESCRIPTION
## Summary
v1.0-blocker caught by tablet find-issues agent. Tapping **Browse → Local** rendered a completely blank content area — no spinner, no message, no CTA. The exact silent-empty pattern that bit arXiv (#663) and PLOS (#664), but on the *Local* backend where the right answer is "tap to pick a folder," not "fix the network call."

Every other "not yet configured" backend (Palace, Wiki, Discord) had a clear `realm is unreachable` panel + setup path. Local did not.

## Fix
Mirrors the Issue #458 RSS empty state shape:
- Explicit headline + body copy
- Primary `Choose folder` CTA that launches the SAF `OpenDocumentTree` picker directly from Browse (no Settings round-trip for the first run)
- Persistable URI grant via `takePersistableUriPermission` so the grant survives process death (mirrors `SettingsScreen.EpubFolderPickerRow`)
- New `BrowseViewModel.setEpubFolderUri()` writes through `SettingsRepositoryUi` → DataStore; the existing `epubFolderUri` flow propagates the change so the EPUB source re-enumerates on the next paginator tick

## Verification
- `./gradlew :feature:compileDebugKotlin` — green (33s)
- v0.5.69 had ZERO empty-state for Local (verified by tablet agent)
- After this fix, expect: tap Local on fresh install → headline + folder-picker CTA → tap → SAF picker → folder picked → grid renders with EPUBs

## Test plan
- [x] Compose subtree compiles
- [ ] CI green
- [ ] On-device verify: tablet R83W80CAFZB, fresh install → Browse → Local → CTA appears → tap → SAF picker → pick a folder containing `.epub` → list populates

🤖 Generated with [Claude Code](https://claude.com/claude-code)