### PR TITLE
fix(copy): Voice library subtitle + Outline empty-state — closes #670 #671

### DIFF
--- a/feature/src/main/kotlin/in/jphe/storyvox/feature/settings/SettingsScreen.kt
+++ b/feature/src/main/kotlin/in/jphe/storyvox/feature/settings/SettingsScreen.kt
@@ -155,7 +155,11 @@ fun SettingsScreen(
         SettingsGroupCard {
             SettingsLinkRow(
                 title = "Voice library",
-                subtitle = "Pick a voice and hear samples.",
+                // Issue #670 — until per-voice sample-play exists, the
+                // subtitle should not promise "hear samples". The
+                // current row only Activates the voice; preview-without-
+                // activation is filed as a v1.x enhancement.
+                subtitle = "Browse and switch between available voices.",
                 onClick = onOpenVoiceLibrary,
             )
             // #195 — sliders read+write the *effective* value (the

--- a/source-outline/src/main/kotlin/in/jphe/storyvox/source/outline/net/OutlineApi.kt
+++ b/source-outline/src/main/kotlin/in/jphe/storyvox/source/outline/net/OutlineApi.kt
@@ -73,7 +73,15 @@ internal class OutlineApi @Inject constructor(
         body: String,
     ): FictionResult<T> {
         val state = config.state.first()
-        if (!state.isConfigured) return FictionResult.AuthRequired("Outline host or API key not set")
+        // Issue #671 — friendly empty-state copy. Palace's panel reads
+        // "Set up your Memory Palace host in Settings → Memory Palace
+        // to browse your private fictions." which is much clearer than
+        // the bare "Outline host or API key not set". Mirror the same
+        // shape: name the source, point at the exact Settings path, say
+        // what the user gets after configuring.
+        if (!state.isConfigured) return FictionResult.AuthRequired(
+            "Set up your Outline host and API key in Settings → Outline to browse your team docs.",
+        )
         val url = state.baseUrl + path
         return withContext(Dispatchers.IO) {
             try {


### PR DESCRIPTION
## Summary
Two tiny copy fixes from the tablet find-issues agent.

- **#670** — Voice library card subtitle promised "Pick a voice and hear samples" but no preview UI exists. Tapping a row Activates the voice; there's no per-row play button. Subtitle rewritten to: *"Browse and switch between available voices."* Per-voice sample-play remains a v1.x enhancement; this fix stops the screen from lying.
- **#671** — Outline empty state read "Outline host or API key not set" — terse vs Palace's helpful *"Set up your Memory Palace host in Settings → Memory Palace to browse your private fictions."* Outline's panel now mirrors that pattern: *"Set up your Outline host and API key in Settings → Outline to browse your team docs."*

## Verification
- `./gradlew :feature:compileDebugKotlin :source-outline:compileDebugKotlin` — green
- Visual on the next install: Settings hub Voice library row reads the new copy; Browse → Wiki shows the friendlier panel

## Test plan
- [x] Both subprojects compile
- [ ] CI green
- [ ] On-device: Settings → Voice library subtitle reads "Browse and switch between available voices"
- [ ] On-device: Browse → Wiki shows the friendly setup-path empty state

🤖 Generated with [Claude Code](https://claude.com/claude-code)