### PR TITLE
fix: Readability empty-state + end-of-book overlay + Wikipedia HTML entities — closes #673 #677 #672

### DIFF
--- a/feature/src/main/kotlin/in/jphe/storyvox/feature/browse/BrowseScreen.kt
+++ b/feature/src/main/kotlin/in/jphe/storyvox/feature/browse/BrowseScreen.kt
@@ -374,6 +374,17 @@ fun BrowseScreen(
                 !state.isLoading &&
                 state.error == null ->
                 LocalEmptyState(viewModel = viewModel)
+            // Issue #673 — Readability backend is the always-on last-resort
+            // URL matcher; it has no listings of its own. Pre-fix, the chip's
+            // body rendered as silent-empty: no spinner, no message, no CTA.
+            // Surface an informative panel that explains the source's purpose
+            // and points the user at the "Add fiction by URL" FAB.
+            state.sourceId == SourceIds.READABILITY &&
+                state.tab != BrowseTab.Search &&
+                state.items.isEmpty() &&
+                !state.isLoading &&
+                state.error == null ->
+                ReadabilityHintState()
             // First-load failure with no cached items: full-screen error.
             // Retry triggers viewModel.loadMore() which the paginator
             // resolves to the same page that failed.
@@ -849,6 +860,47 @@ private fun RssEmptyState(onAdd: () -> Unit) {
                 label = "Add a feed",
                 onClick = onAdd,
                 variant = BrassButtonVariant.Primary,
+            )
+        }
+    }
+}
+
+/**
+ * Issue #673 — informative empty state for the Readability backend.
+ * Readability is the always-on last-resort URL matcher: any HTTP(S)
+ * URL that none of the 17 specialized backends claim falls through to
+ * here, where Readability4J's Mozilla-Readability port extracts the
+ * article body. It has no Browse listings of its own — popular()
+ * intentionally returns emptyPage().
+ */
+@Composable
+private fun ReadabilityHintState() {
+    val spacing = LocalSpacing.current
+    Box(modifier = Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
+        Column(
+            horizontalAlignment = Alignment.CenterHorizontally,
+            verticalArrangement = Arrangement.spacedBy(spacing.sm),
+            modifier = Modifier.padding(horizontal = spacing.xl),
+        ) {
+            Icon(
+                imageVector = Icons.Filled.Add,
+                contentDescription = null,
+                tint = MaterialTheme.colorScheme.primary,
+                modifier = Modifier.size(48.dp),
+            )
+            Text(
+                "Paste any web article",
+                style = MaterialTheme.typography.titleMedium,
+                color = MaterialTheme.colorScheme.onSurface,
+                textAlign = TextAlign.Center,
+            )
+            Text(
+                "The reader extracts the text from blog posts, news, " +
+                    "and any web page that doesn't match a specialized " +
+                    "backend. Tap the + button below to paste a URL.",
+                style = MaterialTheme.typography.bodySmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                textAlign = TextAlign.Center,
             )
         }
     }

--- a/feature/src/main/kotlin/in/jphe/storyvox/feature/reader/HybridReaderScreen.kt
+++ b/feature/src/main/kotlin/in/jphe/storyvox/feature/reader/HybridReaderScreen.kt
@@ -358,6 +358,25 @@ fun HybridReaderScreen(
             },
         )
     }
+
+    // Issue #677 — end-of-book overlay. Engine emits BookFinished
+    // when the last chapter's last sentence drains and no successor
+    // exists. Pre-fix the screen rendered nothing — scrubber sat
+    // stuck with no surface explaining the book is over.
+    if (state.bookFinished) {
+        BookFinishedOverlay(
+            fictionTitle = state.playback?.fictionTitle,
+            onBackToLibrary = {
+                viewModel.acknowledgeBookFinished()
+                onBack()
+            },
+            onBrowseMore = {
+                viewModel.acknowledgeBookFinished()
+                onBrowse()
+            },
+            onDismiss = { viewModel.acknowledgeBookFinished() },
+        )
+    }
     }
 }
 
@@ -473,4 +492,49 @@ private fun ExplicitArgsLoadingPrompt(
             }
         }
     }
+}
+
+/**
+ * Issue #677 — end-of-book modal. Renders when the engine has
+ * emitted BookFinished and the user hasn't acknowledged yet.
+ * Material 3 AlertDialog — TalkBack-friendly (focus-claiming surface,
+ * headline reads immediately), matches the recap modal pattern.
+ */
+@Composable
+private fun BookFinishedOverlay(
+    fictionTitle: String?,
+    onBackToLibrary: () -> Unit,
+    onBrowseMore: () -> Unit,
+    onDismiss: () -> Unit,
+) {
+    androidx.compose.material3.AlertDialog(
+        onDismissRequest = onDismiss,
+        title = {
+            Text(
+                text = if (fictionTitle.isNullOrBlank()) {
+                    "You finished this book."
+                } else {
+                    "You finished “${'$'}fictionTitle”"
+                },
+                style = MaterialTheme.typography.titleLarge,
+            )
+        },
+        text = {
+            Text(
+                text = "Beautiful work. The story is over — for now. " +
+                    "Where would you like to go next?",
+                style = MaterialTheme.typography.bodyMedium,
+            )
+        },
+        confirmButton = {
+            androidx.compose.material3.TextButton(onClick = onBrowseMore) {
+                Text("Browse the realms")
+            }
+        },
+        dismissButton = {
+            androidx.compose.material3.TextButton(onClick = onBackToLibrary) {
+                Text("Back to Library")
+            }
+        },
+    )
 }

--- a/feature/src/main/kotlin/in/jphe/storyvox/feature/reader/ReaderViewModel.kt
+++ b/feature/src/main/kotlin/in/jphe/storyvox/feature/reader/ReaderViewModel.kt
@@ -67,6 +67,18 @@ data class ReaderUiState(
      * AudioOutputMonitor's flow.
      */
     val waitReason: `in`.jphe.storyvox.playback.diagnostics.WaitReason? = null,
+    /**
+     * Issue #677 — end-of-book latch. Set true when the engine emits
+     * [PlaybackUiEvent.BookFinished] (the last chapter ended naturally
+     * with no successor). Drives [HybridReaderScreen]'s
+     * `BookFinishedOverlay` — pre-fix, the screen rendered nothing
+     * after the final sentence drained and the scrubber sat stuck at
+     * the end. Cleared via [ReaderViewModel.acknowledgeBookFinished]
+     * (overlay dismissal / Back to Library / Browse more) or by a
+     * fresh [ReaderViewModel.resume] / `startListening` call so a
+     * "Restart from beginning" doesn't immediately re-trip the modal.
+     */
+    val bookFinished: Boolean = false,
 )
 
 /** Issue #278 — the player loading screen used to be a silent eternity:
@@ -256,6 +268,14 @@ class ReaderViewModel @Inject constructor(
     private val _confettiTrigger = Channel<Unit>(capacity = Channel.CONFLATED)
     val confettiTrigger: Flow<Unit> = _confettiTrigger.receiveAsFlow()
 
+    /** Issue #677 — end-of-book latch backing the
+     *  [ReaderUiState.bookFinished] projection. Engine-driven set in the
+     *  [PlaybackUiEvent.BookFinished] arm of the player-events collector;
+     *  cleared by [acknowledgeBookFinished] when the user dismisses the
+     *  overlay, and by [resume] before starting a fresh listen so a
+     *  "Restart from beginning" doesn't immediately re-trip the modal. */
+    private val _bookFinished = MutableStateFlow(false)
+
     init {
         viewModelScope.launch {
             isLoading.collect { loading ->
@@ -280,10 +300,20 @@ class ReaderViewModel @Inject constructor(
         // double-fire on a quick chapter-complete after reopening.
         viewModelScope.launch {
             playback.events.collect { ev ->
-                if (ev !is PlaybackUiEvent.ChapterDone) return@collect
-                val ms = settings.milestoneState.first()
-                if (ms.qualifies && !ms.confettiShown) {
-                    _confettiTrigger.trySend(Unit)
+                when (ev) {
+                    is PlaybackUiEvent.ChapterDone -> {
+                        val ms = settings.milestoneState.first()
+                        if (ms.qualifies && !ms.confettiShown) {
+                            _confettiTrigger.trySend(Unit)
+                        }
+                    }
+                    // Issue #677 — engine signaled the last chapter ended
+                    // naturally with no successor. Flip the end-of-book latch
+                    // so HybridReaderScreen renders the BookFinishedOverlay.
+                    is PlaybackUiEvent.BookFinished -> {
+                        _bookFinished.value = true
+                    }
+                    else -> Unit
                 }
             }
         }
@@ -296,6 +326,13 @@ class ReaderViewModel @Inject constructor(
      *  effectively closes the gate. */
     fun markConfettiShown() {
         viewModelScope.launch { settings.markMilestoneConfettiShown() }
+    }
+
+    /** Issue #677 — user dismissed the end-of-book overlay (Back to
+     *  Library, Browse more, or backdrop tap). Clear the latch so the
+     *  modal doesn't re-trip the next time the screen recomposes. */
+    fun acknowledgeBookFinished() {
+        _bookFinished.value = false
     }
 
     val uiState: StateFlow<ReaderUiState> = combine(
@@ -316,6 +353,9 @@ class ReaderViewModel @Inject constructor(
         // through ReaderUiState so AudiobookView can render the brass
         // diagnostic panel without taking another flow subscription.
         playback.waitReason,
+        // Issue #677 — end-of-book latch; HybridReaderScreen mounts the
+        // BookFinishedOverlay when this flips true.
+        _bookFinished,
     ) { values ->
         @Suppress("UNCHECKED_CAST")
         val state = values[0] as UiPlaybackState
@@ -328,6 +368,7 @@ class ReaderViewModel @Inject constructor(
         val settingsSnapshot = values[4] as `in`.jphe.storyvox.feature.api.UiSettings
         @Suppress("UNCHECKED_CAST")
         val waitReason = values[5] as? `in`.jphe.storyvox.playback.diagnostics.WaitReason
+        val bookFinished = values[6] as Boolean
         ReaderUiState(
             playback = state,
             chapterText = text,
@@ -336,6 +377,7 @@ class ReaderViewModel @Inject constructor(
             punctuationPauseMultiplier = settingsSnapshot.punctuationPauseMultiplier,
             pitchInterpolationHighQuality = settingsSnapshot.pitchInterpolationHighQuality,
             waitReason = waitReason,
+            bookFinished = bookFinished,
         )
     }.stateIn(viewModelScope, SharingStarted.WhileSubscribed(5_000), ReaderUiState())
 
@@ -390,6 +432,10 @@ class ReaderViewModel @Inject constructor(
     fun resume(fromStart: Boolean = false) {
         val entry = resumeEntry.value ?: return
         _loadingPhase.value = LoadingPhase.Loading
+        // Issue #677 — clear the end-of-book latch on a fresh listen so
+        // the overlay doesn't re-trip when the user taps "Restart from
+        // beginning" after finishing the book.
+        _bookFinished.value = false
         viewModelScope.launch {
             val autoPlay = resumePolicy.currentLastWasPlaying()
             playback.startListening(

--- a/source-wikipedia/src/main/kotlin/in/jphe/storyvox/source/wikipedia/WikipediaSource.kt
+++ b/source-wikipedia/src/main/kotlin/in/jphe/storyvox/source/wikipedia/WikipediaSource.kt
@@ -257,7 +257,7 @@ internal fun String.toArticleTitle(): String? =
 private fun WikipediaSearchHit.toSummary(): FictionSummary = FictionSummary(
     id = wikipediaFictionId(title),
     sourceId = SourceIds.WIKIPEDIA,
-    title = title,
+    title = cleanWikipediaTitle(title),
     author = "Wikipedia",
     description = description.ifBlank { null },
     status = FictionStatus.ONGOING,
@@ -269,7 +269,7 @@ private fun WikipediaFeaturedArticle.toSummary(): FictionSummary? {
     return FictionSummary(
         id = wikipediaFictionId(canonical),
         sourceId = SourceIds.WIKIPEDIA,
-        title = display.replace('_', ' '),
+        title = cleanWikipediaTitle(display.replace('_', ' ')),
         author = "Wikipedia",
         coverUrl = thumbnail?.source,
         description = description ?: extract,
@@ -283,7 +283,7 @@ private fun WikipediaMostReadArticle.toSummary(): FictionSummary? {
     return FictionSummary(
         id = wikipediaFictionId(canonical),
         sourceId = SourceIds.WIKIPEDIA,
-        title = display.replace('_', ' '),
+        title = cleanWikipediaTitle(display.replace('_', ' ')),
         author = "Wikipedia",
         coverUrl = thumbnail?.source,
         description = description ?: extract,
@@ -298,7 +298,7 @@ private fun WikipediaSummary.toSummary(
 ): FictionSummary = FictionSummary(
     id = fictionId,
     sourceId = SourceIds.WIKIPEDIA,
-    title = (titles?.display ?: titles?.normalized ?: this.title).replace('_', ' '),
+    title = cleanWikipediaTitle((titles?.display ?: titles?.normalized ?: this.title).replace('_', ' ')),
     author = "Wikipedia",
     coverUrl = thumbnail?.source,
     description = description ?: extract,
@@ -509,6 +509,30 @@ internal fun scrubWikipediaCruft(html: String): String {
     // missed). Cheap belt-and-braces strip.
     cleaned = cleaned.replace(Regex("""\[\s*edit\s*\]""", RegexOption.IGNORE_CASE), "")
     return cleaned
+}
+
+/**
+ * Issue #672 — clean a Wikipedia title for display. Decodes entities
+ * FIRST, then strips the now-decoded <i>...</i> tags. Order matters:
+ * htmlToPlainText() does tag-strip-then-decode, which leaves
+ * entity-encoded tags visible. Many Wikipedia Popular entries have
+ * italicized titles (films, albums, books) and were rendering as raw
+ * "&lt;i&gt;Iceman&lt;/i&gt; (Drake album)" pre-fix.
+ */
+private fun cleanWikipediaTitle(raw: String): String {
+    var out = raw
+        .replace("&nbsp;", " ")
+        .replace("&amp;", "&")
+        .replace("&lt;", "<")
+        .replace("&gt;", ">")
+        .replace("&quot;", "\"")
+        .replace("&#39;", "'")
+        .replace("&apos;", "'")
+        .replace("&mdash;", "—")
+        .replace("&ndash;", "–")
+        .replace("&hellip;", "…")
+    out = out.replace(Regex("<[^>]+>"), "")
+    return out.trim()
 }
 
 /**


### PR DESCRIPTION
## Summary

Three independent catchall fixes bundled into one PR — single files each, clean compile.

### #673 Readability silent-empty
The Readability backend is the always-on last-resort URL matcher; any HTTP(S) URL no specialized backend claims falls through to its Readability4J extractor. It has no Browse listings of its own (`popular()` intentionally returns `emptyPage()`), so the chip used to render as a totally silent empty surface — no spinner, no copy, no CTA.

- `BrowseScreen.kt`: parallel branch to the existing RSS empty-state, new `ReadabilityHintState` composable that explains what the source is for and points at the "Add fiction by URL" FAB.

### #677 End-of-book UI freeze
Engine emits `PlaybackUiEvent.BookFinished` when the last chapter's last sentence drains and no successor exists. Pre-fix nothing rendered — scrubber sat stuck at the end with no surface explaining the book was over.

- `ReaderViewModel.kt`: new `bookFinished: Boolean` field on `ReaderUiState`, backed by `_bookFinished` MutableStateFlow. Player-events collector becomes a `when` block: ChapterDone keeps the confetti path, BookFinished flips the latch. Added `acknowledgeBookFinished()`. Latch clears at the top of `resume()` so "Restart from beginning" doesn't immediately re-trip the modal. `_bookFinished` added as the 7th flow in the `uiState` combine.
- `HybridReaderScreen.kt`: `BookFinishedOverlay` Material 3 `AlertDialog` (TalkBack-friendly, headline reads immediately) — "Back to Library" / "Browse the realms" actions, dismissable. Mounted right after the celebration confetti block.

### #672 Wikipedia HTML entities in titles
The file already had a `htmlToPlainText()` that did tag-strip-then-decode — fine for body content but wrong for titles, because Wikipedia titles often come back as `&lt;i&gt;Iceman&lt;/i&gt; (Drake album)` and tag-stripping THAT leaves the entity-encoded markup visible.

- `WikipediaSource.kt`: new `cleanWikipediaTitle` that decodes entities first, then strips the now-decoded `<i>...</i>` tags. Wired into all four `toSummary` call sites (`WikipediaSearchHit`, `WikipediaFeaturedArticle`, `WikipediaMostReadArticle`, `WikipediaSummary`).

## Build

```
JAVA_HOME=… ./gradlew :feature:compileDebugKotlin :source-wikipedia:compileDebugKotlin
```
BUILD SUCCESSFUL — both modules compile cleanly with no warnings introduced by this diff.

## Test plan (on-device R83W80CAFZB)

- [ ] Browse → Readability chip → see the new hint panel (Add icon, "Paste any web article" headline, copy mentioning the + FAB)
- [ ] Browse → RSS chip → still shows the existing RSS empty-state (didn't regress sibling branch)
- [ ] Listen through to the final chapter of a short book → BookFinishedOverlay appears with the title, "Back to Library" / "Browse the realms" buttons
- [ ] Tap "Back to Library" → overlay clears, navigates back
- [ ] Trip the overlay, dismiss it via backdrop tap → overlay clears, screen stays on Reader
- [ ] After overlay shown, hit "Restart from beginning" from the resume prompt → overlay doesn't re-trip
- [ ] TalkBack reads the overlay headline immediately when it appears
- [ ] Browse → Wikipedia → Popular → confirm italicized titles like "Iceman (Drake album)" render as plain Unicode (no `&lt;i&gt;`)
- [ ] Browse → Wikipedia → Search "Iceman" → search results show clean titles
- [ ] Open a Wikipedia article whose canonical title contains entities → FictionDetail title renders clean

Closes #673
Closes #677
Closes #672

🤖 Generated with [Claude Code](https://claude.com/claude-code)