### PR TITLE
fix(voice): auto-dismiss picker when System TTS seed succeeds — closes #682 (partial)

### DIFF
--- a/core-playback/src/main/kotlin/in/jphe/storyvox/playback/voice/VoiceManager.kt
+++ b/core-playback/src/main/kotlin/in/jphe/storyvox/playback/voice/VoiceManager.kt
@@ -589,11 +589,32 @@ class VoiceManager @Inject constructor(
             // value is now present, bail without overwriting.
             if (!p[VoiceKeys.ACTIVE_ID].isNullOrBlank()) return@edit
             p[VoiceKeys.ACTIVE_ID] = firstEntry.id
-            // Don't auto-dismiss the picker — even though we picked a
-            // voice for the user, we still want to show the Voice
-            // Picker Gate on first launch so they can pick something
-            // else if they prefer. The gate's dismiss is gated by the
-            // user's explicit choice, not by our seed.
+            // Issue #682 — auto-dismiss the gate.
+            //
+            // The previous design left the gate armed even after a
+            // successful System TTS seed so "the user still gets to
+            // choose". On-device verify with R5CRB0W66MK (v0.5.70)
+            // proved that's the wrong call: the user walks "Get
+            // started → Pick a voice (Skip) → What would you like
+            // to hear? → Browse TechEmpower" and the picker
+            // RE-APPEARS with download-only Piper voices, defeating
+            // the entire #676 zero-download unlock. The 5-year-old /
+            // sight-impaired goal personas hit the SAME download
+            // barrier #676 was supposed to eliminate.
+            //
+            // When we successfully seeded a System TTS voice (i.e.
+            // the OS has at least one), the user has a working
+            // voice — first listen needs zero downloads. They can
+            // still swap voices via Settings → Voice library; the
+            // sticky-dismissed flag stops the gate from re-prompting.
+            //
+            // We only flip the flag when the seed actually wrote an
+            // active voice; if the OS has no TTS engines (verified
+            // on Samsung Tab A7 Lite with 0 voices), the early
+            // `if (roster.isEmpty()) return` above prevents us from
+            // reaching this edit block, so the gate stays armed and
+            // the user gets the download-first flow as before.
+            p[VoiceKeys.PICKER_DISMISSED] = true
         }
     }
 

--- a/feature/src/main/kotlin/in/jphe/storyvox/feature/onboarding/VoicePickerOnboarding.kt
+++ b/feature/src/main/kotlin/in/jphe/storyvox/feature/onboarding/VoicePickerOnboarding.kt
@@ -83,6 +83,17 @@ fun VoicePickerOnboarding(
     // re-emissions trigger the auto-advance only when the value
     // changes from the initial null state.
     val initialActive = remember { activeVoice }
+    // Issue #682 — if the user already has an active voice when this
+    // step composes (the #676 System TTS seed populated it before
+    // onboarding began), skip the picker entirely. The user can
+    // change voices via Settings → Voice library. Pre-fix the
+    // download-only Piper picker rendered anyway, re-blocking the
+    // exact zero-download path #676 was supposed to enable.
+    androidx.compose.runtime.LaunchedEffect(Unit) {
+        if (initialActive != null) {
+            onContinue()
+        }
+    }
     androidx.compose.runtime.LaunchedEffect(activeVoice, downloadingId) {
         // Auto-advance when a download successfully completes:
         //   - activeVoice transitions from initial (typically null)


### PR DESCRIPTION
## Summary
v1.0 polish for the #676 zero-download unlock. JP's on-device verify on R5CRB0W66MK caught that the picker re-appeared after the user tapped Skip on the onboarding picker, defeating the entire goal. Two-layer fix:

1. **`VoiceManager.seedSystemTtsDefaultIfUnset()`** now flips `PICKER_DISMISSED = true` when it writes an active System TTS voice. The agent's original design ("don't auto-dismiss, the user still gets to choose") was the wrong call — auto-dismissal IS the desired behavior for the goal-hook personas (sight-impaired, 5-year-old, casual user). Settings → Voice library is the path for explicit voice changes.

2. **`VoicePickerOnboarding`** adds a `LaunchedEffect(Unit)` that checks `initialActive` on first composition: if a voice is already set (seed beat us to it), call `onContinue()` immediately and skip the picker step.

## Partial
Known async race: if `seedSystemTtsDefaultIfUnset` hasn't completed by the time the picker composes (TextToSpeech.onInit takes 100-500ms), `initialActive` captures null and the LaunchedEffect's "already-seeded" guard misses. Filed follow-up. **Two fallbacks still work:**
- The picker's Skip button is a manual escape
- The dismissed flag prevents the gate from re-blocking later when user navigates to other surfaces

## Verification
- Phone R5CRB0W66MK (Google TTS, 22 voices): seed enumerates, fallbacks work, Skip still escapes
- Tablet R83W80CAFZB (no TTS engines, 0 voices): early-return in `seedSystemTtsDefaultIfUnset` preserves the original download-first flow (no regression)
- `:core-playback:testDebugUnitTest` green
- `:app:assembleDebug` green

## Test plan
- [ ] CI green
- [ ] Phone fresh-install verify: Welcome → tap Get started → either picker auto-skips OR Skip button is a one-tap escape
- [ ] Voice library swap still works post-dismissed (user can pick a Piper voice later)

🤖 Generated with [Claude Code](https://claude.com/claude-code)