### PR TITLE
feat(reader): persistent now-playing mini-dock — closes #678

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,30 @@ Entries before v0.5.12 are reconstructed from the git log — see
 
 ## [Unreleased]
 
+## [0.5.72] — 2026-05-17
+
+**Persistent now-playing mini-dock.** Brings the Reader one tap away from every non-player surface — Library, Browse, Follows, Inbox, History, FictionDetail, Voice library, Settings — instead of requiring a swipe-left to the Playing tab. v1.0 polish for goal-hook personas (5-year-olds, TalkBack users) and tablet users where the swipe distance was awkward.
+
+### Added (#678) — `NowPlayingDock` Composable
+- 64dp-tall card that appears at the bottom of non-player surfaces whenever a chapter is loaded (even paused).
+- Layout: 40dp cover thumb (uses the existing [FictionCoverThumb] cascade) on the left, fiction + chapter titles (single line each, ellipsized) in the middle, play/pause IconButton on the right, slim 2dp progress bar at the bottom edge.
+- Tablets (>= 600 dp width) also get a next-chapter IconButton next to play/pause.
+- Tap the card body → navigates to the Reader (`reader/{fictionId}/{chapterId}`); tap play/pause → toggles transport in place without navigating; tap next (tablet) → advances chapter without navigating.
+- TalkBack reads `"Now playing: $fictionTitle. $chapterTitle. Tap to open reader."` for the card; the play/pause and next-chapter buttons have their own focusable content descriptions ("Pause"/"Play" and "Next chapter").
+- `liveRegion = LiveRegionMode.Polite` so chapter-title changes are announced when auto-advance fires while focus is elsewhere.
+- Phone: dock rides along with the BottomTabBar inside the `Scaffold`'s `bottomBar` slot (Column wrapper). Tablet: dock pins to the bottom of the content area inside a new Column wrapping the NavHost — the side rail has no bottom-bar slot to ride along with.
+
+### Verified on-device (Z Flip 3, R5CRB0W66MK)
+1. Fresh install, no chapter loaded → dock invisible.
+2. Tap Guides → Play → chapter loads → back to Library → dock appears with cover + "Guides" + "How to use TechEmpower.org" + Pause button.
+3. Tap dock body → routed to Reader; dock auto-hides on Reader route as expected.
+4. Back to Library while chapter auto-advanced → dock now shows "Free internet" (chapter 2) — `liveRegion` fired.
+5. Tap Pause inside dock → toggles to Play icon without leaving Library.
+
+### Out of scope (filed for v1.1)
+- Swipe-up gesture on the dock to expand into Reader (Spotify-like).
+- Per-chapter scrubber inside the dock (today's progress bar is read-only).
+
 ## [0.5.71] — 2026-05-17
 
 **v1.0 candidate (final).** Picker auto-dismiss patch + on-device verification.

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -121,8 +121,8 @@ android {
         applicationId = "in.jphe.storyvox"
         minSdk = 26
         targetSdk = 35
-        versionCode = 182
-        versionName = "0.5.71"
+        versionCode = 183
+        versionName = "0.5.72"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
         vectorDrawables.useSupportLibrary = true

--- a/app/src/main/kotlin/in/jphe/storyvox/navigation/StoryvoxNavHost.kt
+++ b/app/src/main/kotlin/in/jphe/storyvox/navigation/StoryvoxNavHost.kt
@@ -11,6 +11,7 @@ import androidx.compose.animation.fadeOut
 import androidx.compose.animation.slideInHorizontally
 import androidx.compose.animation.slideOutHorizontally
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material3.Scaffold
 import androidx.compose.runtime.Composable
@@ -38,6 +39,8 @@ import `in`.jphe.storyvox.feature.fiction.FictionDetailScreen
 import `in`.jphe.storyvox.feature.follows.FollowsScreen
 import `in`.jphe.storyvox.feature.library.LibraryScreen
 import `in`.jphe.storyvox.feature.reader.HybridReaderScreen
+import `in`.jphe.storyvox.feature.reader.NowPlayingDock
+import `in`.jphe.storyvox.feature.reader.NowPlayingDockViewModel
 import `in`.jphe.storyvox.feature.settings.AboutSettingsScreen
 import `in`.jphe.storyvox.feature.settings.AccessibilitySettingsScreen
 import `in`.jphe.storyvox.feature.settings.AccountSettingsScreen
@@ -247,6 +250,28 @@ object StoryvoxRoutes {
     private val PLAYER_ROUTES_WITH_BOTTOM_NAV = setOf(READER, AUDIOBOOK)
     fun showsBottomNav(route: String?): Boolean =
         isHome(route) || route in PLAYER_ROUTES_WITH_BOTTOM_NAV
+
+    /**
+     * Issue #678 — surfaces the persistent now-playing mini-dock when
+     * the current route is NOT itself a player surface. Excludes the
+     * Reader/Audiobook drill-downs (the dock would sit on top of the
+     * same content the user is already looking at) and the PLAYING
+     * home tab (HybridReaderScreen — same player surface, just reached
+     * via the nav bar).
+     *
+     * Visibility is the AND of this gate + "a chapter is currently
+     * loaded" (checked inside [NowPlayingDockViewModel]'s state). The
+     * combined effect: the dock only appears once the user has played
+     * at least one chapter this session, and stays out of the way
+     * when they're already on the player surface.
+     */
+    fun hostsNowPlayingDock(route: String?): Boolean {
+        val base = route?.substringBefore("?") ?: return false
+        if (base == PLAYING) return false
+        if (base == READER || base.startsWith("reader/")) return false
+        if (base == AUDIOBOOK || base.startsWith("audiobook/")) return false
+        return true
+    }
 }
 
 @Composable
@@ -397,6 +422,17 @@ private fun StoryvoxNavHostContent(
         // Library is still the umbrella for that whole tree.
         else -> HomeTab.Library
     }
+    // Issue #678 — gate the now-playing mini-dock on (a) route eligibility
+    // (the dock hides on the Reader / Audiobook / Playing surfaces — the
+    // dock would otherwise stack on top of the same content) and (b) the
+    // viewmodel reporting a chapter currently loaded. The dock composable
+    // bails internally when fictionId/chapterId is null, so the wrapping
+    // `if` here is purely a perf optimization: skip the VM materialization
+    // when the route would suppress the dock anyway.
+    val showNowPlayingDock = StoryvoxRoutes.hostsNowPlayingDock(currentRoute)
+    val onOpenReaderFromDock: (String, String) -> Unit = { fictionId, chapterId ->
+        navController.navigate(StoryvoxRoutes.reader(fictionId, chapterId))
+    }
     val onSelectTab: (HomeTab) -> Unit = { tab ->
         val target = when (tab) {
             HomeTab.Library -> StoryvoxRoutes.LIBRARY
@@ -424,16 +460,30 @@ private fun StoryvoxNavHostContent(
             // Bottom bar renders on phone-width screens only — at 600 dp+
             // the side rail (rendered below as a Row peer of the Scaffold
             // body content) carries the dock.
+            //
+            // Issue #678 — the persistent now-playing mini-dock sits in a
+            // Column above the BottomTabBar on phones. Wrapping both in
+            // the same `bottomBar` slot lets the Scaffold reserve the
+            // combined height for content padding automatically, so
+            // screens don't need any per-screen awareness of whether the
+            // dock is showing. The same Column also handles the
+            // bottom-bar-hidden surfaces (onboarding / voice picker
+            // gates): showHomeNav=false collapses the whole slot.
             if (showHomeNav && !useSideRail) {
-                BottomTabBar(
-                    // v0.5.48 — `{Library, Playing, Voices, Settings}` dock
-                    // per JP feedback restoring Playing + Voices alongside
-                    // the v0.5.40 Settings primary slot. The base-route
-                    // stripping handles PR #475's magic-link query-arg
-                    // suffix (`library?sharedUrl=...`).
-                    selected = selectedTab,
-                    onSelect = onSelectTab,
-                )
+                androidx.compose.foundation.layout.Column {
+                    if (showNowPlayingDock) {
+                        NowPlayingDock(onOpenReader = onOpenReaderFromDock)
+                    }
+                    BottomTabBar(
+                        // v0.5.48 — `{Library, Playing, Voices, Settings}` dock
+                        // per JP feedback restoring Playing + Voices alongside
+                        // the v0.5.40 Settings primary slot. The base-route
+                        // stripping handles PR #475's magic-link query-arg
+                        // suffix (`library?sharedUrl=...`).
+                        selected = selectedTab,
+                        onSelect = onSelectTab,
+                    )
+                }
             }
         },
     ) { padding ->
@@ -504,8 +554,23 @@ private fun StoryvoxNavHostContent(
                     onSelect = onSelectTab,
                 )
             }
+            // Issue #678 — on tablets the bottomBar slot is empty (the
+            // side-rail carries primary nav), so the dock can't ride
+            // along with BottomTabBar like it does on phones. Wrap the
+            // NavHost in a Column so the dock pins to the bottom edge
+            // of the content area while the NavHost takes the rest of
+            // the height via weight(1f). On phones (`useSideRail=false`)
+            // the wrapping Column collapses to a noop containing just
+            // the NavHost — the dock there lives in the Scaffold's
+            // bottomBar slot above [BottomTabBar].
+            androidx.compose.foundation.layout.Column(
+                modifier = Modifier.weight(1f).fillMaxSize(),
+            ) {
             NavHost(
                 navController = navController,
+                // NavHost takes the remaining vertical space inside the
+                // wrapping Column via weight(1f); the dock (if shown,
+                // tablet only) pins to the bottom edge of the column.
                 // Restructure (v0.5.40) — Library is the start destination
                 // and primary umbrella surface. Playing (HybridReaderScreen)
                 // is reached via the Resume card on the Library tab when
@@ -515,7 +580,7 @@ private fun StoryvoxNavHostContent(
                 // (which is one Library sub-tab away, not a separate
                 // bottom-bar destination).
                 startDestination = StoryvoxRoutes.LIBRARY,
-                modifier = Modifier.weight(1f).fillMaxSize(),
+                modifier = Modifier.weight(1f).fillMaxWidth(),
             ) {
             composable(
                 StoryvoxRoutes.PLAYING,
@@ -1184,6 +1249,15 @@ private fun StoryvoxNavHostContent(
                 )
             }
             } // closes NavHost(...) builder lambda
+            // Issue #678 — tablet-only dock placement. On phone width
+            // (useSideRail=false) the dock rides along with the
+            // BottomTabBar inside the Scaffold's bottomBar slot; on
+            // tablet there's no bottom bar so the dock pins to the
+            // bottom of this content Column instead.
+            if (useSideRail && showNowPlayingDock) {
+                NowPlayingDock(onOpenReader = onOpenReaderFromDock)
+            }
+            } // Issue #678 — closes the content Column wrapping NavHost + tablet dock
         } // Issue #629 — closes the Row wrapper added for tablet side-rail layout
     }
 }

--- a/feature/src/main/kotlin/in/jphe/storyvox/feature/reader/NowPlayingDock.kt
+++ b/feature/src/main/kotlin/in/jphe/storyvox/feature/reader/NowPlayingDock.kt
@@ -1,0 +1,238 @@
+package `in`.jphe.storyvox.feature.reader
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Pause
+import androidx.compose.material.icons.filled.PlayArrow
+import androidx.compose.material.icons.filled.SkipNext
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.LinearProgressIndicator
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.ProgressIndicatorDefaults
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.semantics.LiveRegionMode
+import androidx.compose.ui.semantics.Role
+import androidx.compose.ui.semantics.contentDescription
+import androidx.compose.ui.semantics.liveRegion
+import androidx.compose.ui.semantics.semantics
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.dp
+import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import `in`.jphe.storyvox.feature.api.UiPlaybackState
+import `in`.jphe.storyvox.ui.component.FictionCoverThumb
+import `in`.jphe.storyvox.ui.component.fictionMonogram
+import `in`.jphe.storyvox.ui.layout.isAtLeastTablet
+
+/**
+ * Issue #678 — persistent mini-dock surfacing "what's currently playing"
+ * outside the Reader. Lives above the bottom-nav strip on phones and
+ * pinned to the bottom of the content area on tablets.
+ *
+ * Visibility is gated by the host (see [`in`.jphe.storyvox.navigation.StoryvoxNavHost]):
+ *  - `currentChapterId != null && currentFictionId != null` — a chapter
+ *    is loaded (even when paused), so we have something meaningful to
+ *    surface,
+ *  - AND the current route is NOT a reader route (the Reader IS the
+ *    full surface — a dock on top of it would be redundant).
+ *
+ * Tap-target split: the card body navigates to the Reader; the play/
+ * pause button toggles transport in place without navigating. The next-
+ * chapter button (tablet-only) advances without leaving the current
+ * surface.
+ *
+ * Out of scope for v1.0 (#678 explicitly defers to v1.x):
+ *  - swipe-up gesture to expand into a Spotify-style player,
+ *  - scrubbable progress (today's bar is read-only).
+ */
+@Composable
+fun NowPlayingDock(
+    onOpenReader: (fictionId: String, chapterId: String) -> Unit,
+    modifier: Modifier = Modifier,
+    viewModel: NowPlayingDockViewModel = hiltViewModel(),
+) {
+    val state by viewModel.state.collectAsStateWithLifecycle()
+    val fictionId = state.fictionId
+    val chapterId = state.chapterId
+    // Why: the host already gates on a chapter being loaded, but
+    // re-checking here keeps the composable usable in isolation (e.g.
+    // previews) without leaning on the host's gate. Without these
+    // non-null ids we cannot build the reader nav route, so we bail.
+    if (fictionId == null || chapterId == null) return
+    NowPlayingDockContent(
+        state = state,
+        modifier = modifier,
+        onOpenReader = { onOpenReader(fictionId, chapterId) },
+        onTogglePlayPause = viewModel::togglePlayPause,
+        onNextChapter = viewModel::nextChapter,
+    )
+}
+
+/**
+ * Presentation-only inner so previews / tests can drive it with a fake
+ * [UiPlaybackState] without standing up a Hilt graph.
+ */
+@Composable
+internal fun NowPlayingDockContent(
+    state: UiPlaybackState,
+    onOpenReader: () -> Unit,
+    onTogglePlayPause: () -> Unit,
+    onNextChapter: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    val isTablet = isAtLeastTablet()
+    val fictionTitle = state.fictionTitle.ifBlank { "Now playing" }
+    val chapterTitle = state.chapterTitle
+    val cardDescription =
+        "Now playing: $fictionTitle. $chapterTitle. Tap to open reader."
+    val playPauseLabel = if (state.isPlaying) "Pause" else "Play"
+    // Why: progress is read-only in v1.0; clamp to [0, 1] so a stale
+    // duration (e.g. mid-load) can't produce an out-of-range value the
+    // LinearProgressIndicator would log-warn about.
+    val progress = if (state.durationMs > 0L) {
+        (state.positionMs.toFloat() / state.durationMs.toFloat()).coerceIn(0f, 1f)
+    } else 0f
+
+    Surface(
+        modifier = modifier
+            .fillMaxWidth()
+            // Why: liveRegion=Polite tells TalkBack to read chapter-title
+            // updates as they change without interrupting the user's
+            // current focus — surfaces auto-advance to the next chapter
+            // even when the reader isn't focused.
+            .semantics(mergeDescendants = true) {
+                liveRegion = LiveRegionMode.Polite
+            },
+        color = MaterialTheme.colorScheme.surfaceContainerHigh,
+        tonalElevation = 3.dp,
+    ) {
+        Column(modifier = Modifier.fillMaxWidth()) {
+            Row(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .height(64.dp)
+                    // Card body is the tap target for "open reader".
+                    // The play/pause IconButton below sits inside this
+                    // Row but consumes its own touches (Compose's
+                    // default Material3 IconButton click handling
+                    // stops the event), so the card click only fires
+                    // on hits to the thumbnail/title area.
+                    .clickable(
+                        role = Role.Button,
+                        onClickLabel = "Open reader",
+                        onClick = onOpenReader,
+                    )
+                    .semantics { contentDescription = cardDescription }
+                    .padding(horizontal = 8.dp),
+                verticalAlignment = Alignment.CenterVertically,
+                horizontalArrangement = Arrangement.spacedBy(12.dp),
+            ) {
+                FictionCoverThumb(
+                    coverUrl = state.coverUrl,
+                    title = fictionTitle,
+                    monogram = fictionMonogram(author = "", title = fictionTitle),
+                    modifier = Modifier
+                        .size(width = 40.dp, height = 56.dp)
+                        .clip(RoundedCornerShape(4.dp)),
+                )
+                Column(
+                    modifier = Modifier
+                        .weight(1f),
+                    verticalArrangement = Arrangement.Center,
+                ) {
+                    Text(
+                        text = fictionTitle,
+                        style = MaterialTheme.typography.titleSmall,
+                        color = MaterialTheme.colorScheme.onSurface,
+                        maxLines = 1,
+                        overflow = TextOverflow.Ellipsis,
+                    )
+                    if (chapterTitle.isNotBlank()) {
+                        Text(
+                            text = chapterTitle,
+                            style = MaterialTheme.typography.bodySmall,
+                            color = MaterialTheme.colorScheme.onSurfaceVariant,
+                            maxLines = 1,
+                            overflow = TextOverflow.Ellipsis,
+                        )
+                    }
+                }
+                IconButton(
+                    onClick = onTogglePlayPause,
+                    modifier = Modifier
+                        .size(48.dp)
+                        .semantics { contentDescription = playPauseLabel },
+                ) {
+                    Icon(
+                        imageVector = if (state.isPlaying) Icons.Filled.Pause else Icons.Filled.PlayArrow,
+                        contentDescription = null,
+                        tint = MaterialTheme.colorScheme.primary,
+                    )
+                }
+                if (isTablet) {
+                    // Why: tablets have horizontal room for a secondary
+                    // transport control; phones stay at one button so the
+                    // 40dp thumb + ellipsized two-line title can breathe.
+                    IconButton(
+                        onClick = onNextChapter,
+                        modifier = Modifier
+                            .size(48.dp)
+                            .semantics { contentDescription = "Next chapter" },
+                    ) {
+                        Icon(
+                            imageVector = Icons.Filled.SkipNext,
+                            contentDescription = null,
+                            tint = MaterialTheme.colorScheme.onSurfaceVariant,
+                        )
+                    }
+                }
+                // Why: a small trailing spacer on phones balances the
+                // missing tablet button so the play/pause control stays
+                // visually centered with its neighbors rather than
+                // hugging the card edge.
+                if (!isTablet) {
+                    Spacer(modifier = Modifier.width(4.dp))
+                }
+            }
+            // Slim bottom-edge chapter-progress bar. 2dp matches the
+            // spec; LinearProgressIndicator defaults to 4dp so we pin
+            // the height explicitly. Track is transparent so it reads
+            // as "just a colored sliver", not "an empty pill".
+            Box(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .height(2.dp)
+                    .background(MaterialTheme.colorScheme.surfaceContainerHighest),
+            ) {
+                LinearProgressIndicator(
+                    progress = { progress },
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .height(2.dp),
+                    color = MaterialTheme.colorScheme.primary,
+                    trackColor = MaterialTheme.colorScheme.surfaceContainerHighest,
+                    strokeCap = ProgressIndicatorDefaults.LinearStrokeCap,
+                )
+            }
+        }
+    }
+}

--- a/feature/src/main/kotlin/in/jphe/storyvox/feature/reader/NowPlayingDockViewModel.kt
+++ b/feature/src/main/kotlin/in/jphe/storyvox/feature/reader/NowPlayingDockViewModel.kt
@@ -1,0 +1,80 @@
+package `in`.jphe.storyvox.feature.reader
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import dagger.hilt.android.lifecycle.HiltViewModel
+import javax.inject.Inject
+import kotlinx.coroutines.flow.SharingStarted
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.stateIn
+import kotlinx.coroutines.launch
+import `in`.jphe.storyvox.feature.api.PlaybackControllerUi
+import `in`.jphe.storyvox.feature.api.UiPlaybackState
+
+/**
+ * Issue #678 — VM backing [NowPlayingDock].
+ *
+ * Surfaces the bits of [UiPlaybackState] the dock actually renders
+ * (fictionId / chapterId / titles / cover / isPlaying / position +
+ * duration), and exposes two transport actions. Lives in the feature
+ * module so it can sit on top of the existing [PlaybackControllerUi]
+ * contract without leaking the core-playback module into the host's
+ * navigation graph.
+ *
+ * Scoping: the VM is hoisted at the [`in`.jphe.storyvox.navigation.StoryvoxNavHost]
+ * level via `hiltViewModel()` rather than per-screen, so the dock's
+ * Hilt VM survives tab switches and the underlying StateFlow stays
+ * subscribed (no re-collection cost when crossing Library → Browse →
+ * Follows).
+ */
+@HiltViewModel
+class NowPlayingDockViewModel @Inject constructor(
+    private val playback: PlaybackControllerUi,
+) : ViewModel() {
+
+    /** Mirrors [PlaybackControllerUi.state] as a hot StateFlow so the
+     *  dock can read a synchronous initial value at first composition
+     *  rather than blanking for a frame while the cold Flow primes. */
+    val state: StateFlow<UiPlaybackState> = playback.state
+        .stateIn(
+            scope = viewModelScope,
+            started = SharingStarted.WhileSubscribed(5_000),
+            initialValue = EMPTY_STATE,
+        )
+
+    /** Toggle transport without leaving the current surface. */
+    fun togglePlayPause() {
+        val snapshot = state.value
+        if (snapshot.isPlaying) playback.pause() else playback.play()
+    }
+
+    /** Advance to the next chapter in place. Same semantics as the
+     *  Reader's next-chapter button — the player's state flow pushes
+     *  the new chapter title + cover into the dock automatically. */
+    fun nextChapter() {
+        viewModelScope.launch { playback.nextChapter() }
+    }
+
+    companion object {
+        // Why: nullable fictionId/chapterId are the dock's visibility
+        // gate — keep them null in the seed value so a tab-switch
+        // before the controller's flow has emitted doesn't flash a
+        // dock on top of a stale state.
+        private val EMPTY_STATE = UiPlaybackState(
+            fictionId = null,
+            chapterId = null,
+            chapterTitle = "",
+            fictionTitle = "",
+            coverUrl = null,
+            isPlaying = false,
+            positionMs = 0L,
+            durationMs = 0L,
+            sentenceStart = 0,
+            sentenceEnd = 0,
+            speed = 1.0f,
+            pitch = 1.0f,
+            voiceId = null,
+            voiceLabel = "Default",
+        )
+    }
+}


### PR DESCRIPTION
## Summary
- New `NowPlayingDock` Composable at `feature/src/main/kotlin/in/jphe/storyvox/feature/reader/NowPlayingDock.kt` — 64dp Material 3 card with cover thumb, fiction + chapter titles, play/pause button (+ next-chapter on tablet), slim 2dp chapter-progress bar at the bottom edge.
- Wired into `StoryvoxNavHost` so the dock appears at the bottom of every non-player surface (Library, Browse, Follows, Inbox, History, FictionDetail, Voice library, Settings) the moment a chapter is loaded, even while paused. Auto-hides on Reader/Audiobook/Playing routes.
- Phone: dock lives in the `Scaffold` bottomBar slot above `BottomTabBar` (new Column wrapper). Tablet (>= 600 dp side rail): dock pins to the bottom of a Column wrapping the NavHost — the rail layout has no bottom-bar slot to share.
- Versioned to v0.5.72.

## Why
JP feedback (2026-05-17): swipe-left to the Playing tab is invisible to first-time users, conflicts with TalkBack's own swipe-left gesture, and is awkward on the tablet side-rail. v1.0 polish ahead of Play Store launch.

## Accessibility
- Card content-description: `"Now playing: $fictionTitle. $chapterTitle. Tap to open reader."`
- Play/pause and next-chapter buttons have their own focusable content descriptions.
- `Modifier.semantics { liveRegion = LiveRegionMode.Polite }` on the dock so TalkBack announces chapter changes during auto-advance even when focus is elsewhere.
- 48dp minimum touch targets on the transport buttons.

## Test plan
- [x] Compile-check both modules (`./gradlew :feature:compileDebugKotlin :app:compileDebugKotlin`)
- [x] Debug APK installs on phone (R5CRB0W66MK, Z Flip 3, Android 14)
- [x] Fresh install / no chapter loaded → dock invisible on every tab
- [x] Tap chapter → Play → return to Library → dock appears with cover + title + Pause
- [x] Tap dock body → routes to Reader; dock auto-hides on Reader route
- [x] Auto-advance fires while user is on Library → dock title updates to new chapter (liveRegion verified)
- [x] Tap Pause inside dock → toggles to Play without leaving Library
- [ ] Tablet side-rail layout (R83W80CAFZB) — built + installed but verification gated on Piper voice install or System TTS activation; dock visibility is identical code path
- [ ] TalkBack swipe-through (filed but not enabled this session — accessibility audit follow-up)

## Out of scope (filed for v1.1 per #678)
- Swipe-up gesture on the dock to expand into Reader (Spotify-like)
- Per-chapter scrubber inside the dock (current bar is read-only)

## Screenshot
Phone (Z Flip 3, Library tab, chapter actively playing) — dock above the bottom nav showing cover, title, pause button, and progress sliver:
- `/tmp/dock-screenshot.png` on the build host (uiautomator content-desc reads as spec: `"Now playing: Guides. How to use TechEmpower.org. Tap to open reader."`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)