### PR TITLE
fix(settings): SettingsHubScreen Voice library subtitle — closes #685

### DIFF
--- a/feature/src/main/kotlin/in/jphe/storyvox/feature/settings/SettingsHubScreen.kt
+++ b/feature/src/main/kotlin/in/jphe/storyvox/feature/settings/SettingsHubScreen.kt
@@ -163,7 +163,7 @@ fun SettingsHubScreen(
                 SettingsHubRow(
                     icon = Icons.Outlined.RecordVoiceOver,
                     title = "Voice library",
-                    subtitle = "Pick a voice and hear samples.",
+                    subtitle = "Browse and switch between available voices.",
                     onClick = onOpenVoiceLibrary,
                 )
                 SettingsHubRow(
@@ -327,7 +327,7 @@ data class SettingsHubSection(val title: String, val subtitle: String)
 
 val SettingsHubSections: List<SettingsHubSection> = listOf(
     SettingsHubSection("Voice & Playback", "Voice, speed, cadence, pitch."),
-    SettingsHubSection("Voice library", "Pick a voice and hear samples."),
+    SettingsHubSection("Voice library", "Browse and switch between available voices."),
     SettingsHubSection("Reading", "Theme, sleep timer."),
     // v0.5.59 (#cover-style-toggle) — Appearance.
     SettingsHubSection("Appearance", "Book cover style."),


### PR DESCRIPTION
## Summary
PR #675 only updated SettingsScreen.kt — SettingsHubScreen.kt still showed the misleading "Pick a voice and hear samples." copy at two sites. Caught during v0.5.72 on-device verify (Z Flip 3 → Settings → Voice library card subtitle still wrong).

## Test plan
- [x] Both occurrences in SettingsHubScreen.kt swapped to "Browse and switch between available voices."
- [ ] CI green
- [ ] On-device: Settings hub Voice library card subtitle reads the new copy

🤖 Generated with [Claude Code](https://claude.com/claude-code)