### PR TITLE
fix(auth): WebView autofill hints for AO3 + Royal Road — closes #688

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -121,7 +121,7 @@ android {
         applicationId = "in.jphe.storyvox"
         minSdk = 26
         targetSdk = 35
-        versionCode = 184
+        versionCode = 185
         versionName = "0.5.73"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"

--- a/source-ao3/src/main/kotlin/in/jphe/storyvox/source/ao3/auth/Ao3AuthWebView.kt
+++ b/source-ao3/src/main/kotlin/in/jphe/storyvox/source/ao3/auth/Ao3AuthWebView.kt
@@ -2,6 +2,7 @@ package `in`.jphe.storyvox.source.ao3.auth
 
 import android.annotation.SuppressLint
 import android.graphics.Bitmap
+import android.view.View
 import android.webkit.CookieManager
 import android.webkit.WebView
 import android.webkit.WebViewClient
@@ -54,6 +55,15 @@ fun Ao3AuthWebView(
                 settings.javaScriptEnabled = true
                 settings.domStorageEnabled = true
                 settings.userAgentString = Ao3Api.USER_AGENT
+                // #688 — keep the autofill framework alive inside our WebView.
+                // Default `importantForAutofill` toggled across API levels; being
+                // explicit ensures Bitwarden / 1Password / Chrome autofill see
+                // the form-field tree on every API >= 26. saveFormData is
+                // separately gated and also flips between OS versions, so set
+                // it directly rather than trust the default.
+                importantForAutofill = View.IMPORTANT_FOR_AUTOFILL_YES
+                @Suppress("DEPRECATION")
+                settings.saveFormData = true
                 CookieManager.getInstance().setAcceptCookie(true)
                 CookieManager.getInstance().setAcceptThirdPartyCookies(this, true)
 

--- a/source-royalroad/src/main/kotlin/in/jphe/storyvox/source/royalroad/auth/RoyalRoadAuthWebView.kt
+++ b/source-royalroad/src/main/kotlin/in/jphe/storyvox/source/royalroad/auth/RoyalRoadAuthWebView.kt
@@ -2,6 +2,7 @@ package `in`.jphe.storyvox.source.royalroad.auth
 
 import android.annotation.SuppressLint
 import android.graphics.Bitmap
+import android.view.View
 import android.webkit.CookieManager
 import android.webkit.WebView
 import android.webkit.WebViewClient
@@ -40,6 +41,18 @@ fun RoyalRoadAuthWebView(
                 settings.javaScriptEnabled = true
                 settings.domStorageEnabled = true
                 settings.userAgentString = RoyalRoadIds.USER_AGENT
+                // #688 — keep the autofill framework alive inside our WebView.
+                // Default `importantForAutofill` toggled across API levels; being
+                // explicit ensures Bitwarden / 1Password / Chrome autofill see
+                // the form-field tree on every API >= 26. saveFormData is
+                // separately gated and also flips between OS versions, so set
+                // it directly rather than trust the default. Royal Road's
+                // login form already carries `autocomplete="email"` +
+                // `autocomplete="current-password"`, so once the WebView opts
+                // in here, password managers latch on with no DOM tweaks.
+                importantForAutofill = View.IMPORTANT_FOR_AUTOFILL_YES
+                @Suppress("DEPRECATION")
+                settings.saveFormData = true
                 CookieManager.getInstance().setAcceptCookie(true)
                 CookieManager.getInstance().setAcceptThirdPartyCookies(this, true)
 


### PR DESCRIPTION
## Why

Closes #688. JP feedback (2026-05-17): Bitwarden / 1Password / Chrome autofill can't surface inside our in-app sign-in WebViews. Custom Tabs migration is impossible for these — they're cookie-capture flows, not OAuth (#668). The fix that works inside WebView: tell Android's autofill framework explicitly that the field tree matters.

## What

Two-file additive settings tweak on the WebView host. No behavior change to cookie capture.

```kotlin
importantForAutofill = View.IMPORTANT_FOR_AUTOFILL_YES
@Suppress("DEPRECATION")
settings.saveFormData = true
```

- `source-ao3/src/main/kotlin/in/jphe/storyvox/source/ao3/auth/Ao3AuthWebView.kt`
- `source-royalroad/src/main/kotlin/in/jphe/storyvox/source/royalroad/auth/RoyalRoadAuthWebView.kt`

Why explicit:
- Default `importantForAutofill` flips across API levels; being explicit ensures the field tree is visible on every API >= 26.
- `saveFormData` is gated separately and also defaults differently between OS versions; set it directly rather than trust the default.

Bumps `versionCode` 184 → 185 (piggybacks on the in-flight v0.5.73 bundle — name stays 0.5.73).

## Upstream form `autocomplete=` check

Curl'd both login pages from desktop (Android UA) to confirm whether the upstream forms hint at field intent:

**Royal Road** (`/account/login`) — well-hinted, autofill will work cleanly:
```html
<input name=\"Email\" id=\"email\" autocomplete=\"email\" type=\"email\" ... />
<input type=\"password\" name=\"Password\" id=\"password\" autocomplete=\"current-password\" ... />
```

**AO3** (`/users/login`, main `#new_user` form) — NO autocomplete attributes:
```html
<input type=\"text\" name=\"user[login]\" id=\"user_login\" />
<input type=\"password\" name=\"user[password]\" id=\"user_password\" />
```

The smaller `#new_user_session_small` form (header) has `autocomplete=\"on\"` on the login input but nothing on the password. Per the #688 spec we do NOT inject DOM tweaks from our side — too fragile, an upstream concern. Will file an issue against [otwarchive](https://github.com/otwcode/otwarchive) separately so AO3's main login form gets `autocomplete=\"username\"` / `autocomplete=\"current-password\"` hints.

Even without upstream hints, Bitwarden / 1Password's heuristic matchers (field-name regex, page-URL match) typically still surface a suggestion. AO3 will just be a slightly worse experience than Royal Road until upstream patches.

## Verification

**Compile** — green:
```
JAVA_HOME=/usr/lib/jvm/java-17-openjdk-amd64 ./gradlew \
  :source-ao3:compileDebugKotlin :source-royalroad:compileDebugKotlin --no-daemon
BUILD SUCCESSFUL in 23s
```

**Debug APK** — built + installed on tablet `R83W80CAFZB` (per CLAUDE.md, tablet only — phone state preserved).

**On-tablet smoke test**:
- Walked through onboarding → Library → Settings → Account → Royal Road \"Sign in\"
- Royal Road WebView loaded the real login page (Email / Password fields visible + tappable, social-sign-in buttons present, ReCaptcha intact)
- Tapped the Email field — `dumpsys autofill` confirmed the system autofill service is alive (`com.google.android.gms/.autofill.service.AutofillService`)
- Back button returned cleanly to the Account screen — WebView dismissed without crash

**WebView still loads + still captures the session cookie**: cookie-capture path is untouched (settings tweak only, no change to `WebViewClient` callbacks, `tryCapture()`, or `CookieManager` calls).

**Couldn't fully verify**: the actual autofill bottom-sheet surfacing with a real password manager (no Bitwarden / 1Password configured on the test tablet). The framework being available + the field-focus event reaching the autofill manager is the part this change controls; the bottom-sheet UI is the password manager's responsibility once the field tree is visible.

AO3 not exercised on-device — the AO3 plugin requires enabling via Settings → Plugins on this fresh install, and the change is mechanically identical to the Royal Road file. Both edits are pure mirror-image, code-reviewed for parity.

## Test plan

- [x] Compile green (both source modules + app)
- [x] Debug APK builds + installs on tablet R83W80CAFZB
- [x] Royal Road sign-in WebView loads + form fields reachable
- [x] Back navigation works (no regression to cookie-capture flow)
- [x] Upstream form `autocomplete` attributes inspected and documented
- [ ] Manual: install on a device with Bitwarden / 1Password configured and confirm the autofill bottom-sheet surfaces on focus

🤖 Generated with [Claude Code](https://claude.com/claude-code)