### PR TITLE
fix(a11y): wire Larger touch targets at SettingsRow / BrassButton / ChapterCard — closes #690

### DIFF
--- a/core-ui/src/main/kotlin/in/jphe/storyvox/ui/component/BrassButton.kt
+++ b/core-ui/src/main/kotlin/in/jphe/storyvox/ui/component/BrassButton.kt
@@ -2,6 +2,7 @@ package `in`.jphe.storyvox.ui.component
 
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.defaultMinSize
 import androidx.compose.foundation.layout.size
 import androidx.compose.material3.Button
 import androidx.compose.material3.ButtonDefaults
@@ -18,6 +19,7 @@ import androidx.compose.ui.semantics.Role
 import androidx.compose.ui.semantics.role
 import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.unit.dp
+import `in`.jphe.storyvox.ui.a11y.LocalAccessibleTouchTargets
 
 enum class BrassButtonVariant { Primary, Secondary, Text }
 
@@ -40,8 +42,19 @@ fun BrassButton(
     enabled: Boolean = true,
     loading: Boolean = false,
 ) {
+    // #690 Phase 2 — under [LocalAccessibleTouchTargets], grow the
+    // button's minimum height from the M3 default 40dp to 64dp so
+    // motor-impaired / Switch Access users get the wider tap surface
+    // promised by the "Larger touch targets" toggle. Padding stays the
+    // same (visual size scales with label); the minimum just floors it.
+    val enlarged = LocalAccessibleTouchTargets.current
     val padding = PaddingValues(horizontal = 24.dp, vertical = 12.dp)
-    val sem = Modifier.semantics { role = Role.Button }
+    val baseSem = Modifier.semantics { role = Role.Button }
+    val sem = if (enlarged) {
+        baseSem.then(Modifier.defaultMinSize(minHeight = 64.dp))
+    } else {
+        baseSem
+    }
     // Disabled colors stay in the brass family rather than falling through to
     // M3's default `onSurface * 0.12 / 0.38`, which renders as cool grey and
     // breaks the brass aesthetic during reachable disabled flows (e.g.,

--- a/core-ui/src/main/kotlin/in/jphe/storyvox/ui/component/ChapterCard.kt
+++ b/core-ui/src/main/kotlin/in/jphe/storyvox/ui/component/ChapterCard.kt
@@ -5,6 +5,7 @@ import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.heightIn
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.material.icons.Icons
@@ -30,6 +31,7 @@ import androidx.compose.ui.unit.dp
 import `in`.jphe.storyvox.playback.cache.ChapterCacheState
 import `in`.jphe.storyvox.ui.a11y.A11ySpeakChapterMode
 import `in`.jphe.storyvox.ui.a11y.LocalA11ySpeakChapterMode
+import `in`.jphe.storyvox.ui.a11y.LocalAccessibleTouchTargets
 import `in`.jphe.storyvox.ui.theme.LocalSpacing
 
 @Immutable
@@ -120,9 +122,16 @@ fun ChapterCard(
     // clickable still owns the action — `clearAndSetSemantics` doesn't
     // strip merged actions from the SAME modifier chain (only from
     // descendants), so the row stays tappable.
+    // #690 Phase 2 — under [LocalAccessibleTouchTargets], floor the
+    // chapter row to 80dp so motor-impaired / Switch Access users have
+    // a comfortably wide tap surface for chapter selection. The
+    // chapter list is the deepest scrollable list in the reader flow,
+    // so the row growth is load-bearing for those users.
+    val enlarged = LocalAccessibleTouchTargets.current
     Card(
         modifier = modifier
             .fillMaxWidth()
+            .let { m -> if (enlarged) m.heightIn(min = 80.dp) else m }
             .clickable(
                 role = Role.Button,
                 onClickLabel = "Open chapter",

--- a/feature/src/main/kotlin/in/jphe/storyvox/feature/settings/SettingsComposables.kt
+++ b/feature/src/main/kotlin/in/jphe/storyvox/feature/settings/SettingsComposables.kt
@@ -44,6 +44,7 @@ import androidx.compose.ui.semantics.Role
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
+import `in`.jphe.storyvox.ui.a11y.LocalAccessibleTouchTargets
 import `in`.jphe.storyvox.ui.component.BrassButton
 import `in`.jphe.storyvox.ui.component.BrassButtonVariant
 import `in`.jphe.storyvox.ui.theme.LibraryNocturneTheme
@@ -157,9 +158,17 @@ fun SettingsRow(
     onClick: (() -> Unit)? = null,
 ) {
     val spacing = LocalSpacing.current
+    // #690 Phase 2 — widen the 64dp min-height to 80dp under
+    // [LocalAccessibleTouchTargets] (1.25×, matching the
+    // [accessibleSize] 48→64dp ratio used elsewhere). The Settings
+    // surface is the most common tap target in the app outside
+    // playback, and Switch Access / motor-impaired users routinely
+    // re-traverse it, so the row growth is load-bearing.
+    val enlarged = LocalAccessibleTouchTargets.current
+    val minRowHeight = if (enlarged) 80.dp else 64.dp
     val rowModifier = modifier
         .fillMaxWidth()
-        .heightIn(min = 64.dp)
+        .heightIn(min = minRowHeight)
         .let { m -> if (onClick != null) m.clickable(role = Role.Button, onClick = onClick) else m }
         .padding(horizontal = spacing.md, vertical = spacing.sm)
 
@@ -241,9 +250,14 @@ fun SettingsSwitchRow(
         checkedBorderColor = MaterialTheme.colorScheme.primary,
         uncheckedThumbColor = MaterialTheme.colorScheme.outline,
     )
+    // #690 Phase 2 — same widened min-height as [SettingsRow]; switch
+    // rows are the most numerous tap target in the accessibility
+    // subscreen itself, so this matters even more here.
+    val enlarged = LocalAccessibleTouchTargets.current
+    val minRowHeight = if (enlarged) 80.dp else 64.dp
     val rowModifier = modifier
         .fillMaxWidth()
-        .heightIn(min = 64.dp)
+        .heightIn(min = minRowHeight)
         .toggleable(
             value = checked,
             enabled = enabled,


### PR DESCRIPTION
## Summary

Closes #690.

#690 Phase 2 had #486 / #488 land most of the a11y subscreen wiring already (high-contrast palette swap, reduced-motion fold, font-scale override, reading-direction override, screen-reader pause pacing via `A11yPacingConfig`, chapter readout mode via `LocalA11ySpeakChapterMode`). The remaining gap was "Larger touch targets" — `LocalAccessibleTouchTargets` was plumbed at the NavHost root but only consumed in a handful of auth / voice-library files. The four tap surfaces named in the Accessibility subscreen's own kdoc — `SettingsRow`, `SettingsSwitchRow`, `BrassButton`, `ChapterCard` — still rendered at the default heights regardless of the flag, so a user toggling the switch felt nothing.

This PR wires those four:

| Site | Baseline | Enlarged |
|---|---|---|
| `SettingsRow` `heightIn(min=)` | 64dp | 80dp |
| `SettingsSwitchRow` `heightIn(min=)` | 64dp | 80dp |
| `BrassButton` `defaultMinSize(minHeight=)` | M3 default (~40dp) | 64dp |
| `ChapterCard` `heightIn(min=)` | unbounded | 80dp |

The 1.25× ratio mirrors the existing `accessibleSize` 48→64dp ratio used by `LocalAccessibleTouchTargets` elsewhere.

## Audit of the other seven toggles (already wired in earlier PRs)

| # | Setting | Already wired by | Status |
|---|---|---|---|
| 1 | High contrast theme | #486 → `LibraryNocturneTheme(useHighContrast)` | DONE |
| 2 | Reduced motion | #480 / #486 → `LocalReducedMotion` (8+ consumer files) | DONE |
| 3 | Larger touch targets | **this PR** | DONE (now) |
| 4 | Screen-reader pauses | #488 → `A11yPacingConfig` → EnginePlayer | DONE |
| 5 | Speak chapter mode | #486 → `LocalA11ySpeakChapterMode` → ChapterCard | DONE |
| 6 | Font scale override | #486 → `scaledTypography()` | DONE |
| 7 | Reading direction | #486 → `LocalLayoutDirection` at NavHost root | DONE |
| 8 | Learn more link | #487 → `storyvox.techempower.org/accessibility` | DONE |

So #690 is fully closeable with this PR — every toggle on the subscreen now affects behavior.

## Behavior

- No-op for users who haven't toggled the pref AND aren't running Switch Access — the OR-fold in `MainActivity` already gates the `LocalAccessibleTouchTargets` value, so the default path is byte-identical to before.
- Under the toggle (or Switch Access auto-detected), the four named tap surfaces grow uniformly.

## Test plan

- [x] `:feature:testDebugUnitTest` passes
- [x] `:core-ui:testDebugUnitTest` passes
- [x] Full debug compile clean
- [ ] Tablet smoke: toggle "Larger touch targets" ON in Settings → Accessibility, verify the rows below grow visibly (≥16dp taller)
- [ ] Tablet smoke: navigate to a fiction's chapter list, verify chapter rows are taller
- [ ] Tablet smoke: trigger a `BrassButton` flow (e.g. Settings → Reset onboarding), verify the button reads taller

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>