### PR TITLE
fix(nav): route "Open AI settings" CTAs to dedicated AI subscreen

### DIFF
--- a/app/src/main/kotlin/in/jphe/storyvox/navigation/StoryvoxNavHost.kt
+++ b/app/src/main/kotlin/in/jphe/storyvox/navigation/StoryvoxNavHost.kt
@@ -591,7 +591,7 @@ private fun StoryvoxNavHostContent(
             ) {
                 HybridReaderScreen(
                     onPickVoice = { navController.navigate(StoryvoxRoutes.VOICE_LIBRARY) },
-                    onOpenAiSettings = { navController.navigate(StoryvoxRoutes.SETTINGS) },
+                    onOpenAiSettings = { navController.navigate(StoryvoxRoutes.SETTINGS_AI) },
                     onOpenSettings = { navController.navigate(StoryvoxRoutes.SETTINGS_HUB) },
                     onOpenChat = { fId, prefill -> navController.navigate(StoryvoxRoutes.chat(fId, prefill)) },
                     // ResumeEmptyPrompt's "Browse the realms" CTA — only
@@ -775,7 +775,7 @@ private fun StoryvoxNavHostContent(
             ) {
                 HybridReaderScreen(
                     onPickVoice = { navController.navigate(StoryvoxRoutes.VOICE_LIBRARY) },
-                    onOpenAiSettings = { navController.navigate(StoryvoxRoutes.SETTINGS) },
+                    onOpenAiSettings = { navController.navigate(StoryvoxRoutes.SETTINGS_AI) },
                     onOpenSettings = { navController.navigate(StoryvoxRoutes.SETTINGS_HUB) },
                     onOpenChat = { fId, prefill -> navController.navigate(StoryvoxRoutes.chat(fId, prefill)) },
                     // Issue #437 — Back arrow on deep-linked reader /
@@ -805,7 +805,7 @@ private fun StoryvoxNavHostContent(
             ) {
                 HybridReaderScreen(
                     onPickVoice = { navController.navigate(StoryvoxRoutes.VOICE_LIBRARY) },
-                    onOpenAiSettings = { navController.navigate(StoryvoxRoutes.SETTINGS) },
+                    onOpenAiSettings = { navController.navigate(StoryvoxRoutes.SETTINGS_AI) },
                     onOpenSettings = { navController.navigate(StoryvoxRoutes.SETTINGS_HUB) },
                     onOpenChat = { fId, prefill -> navController.navigate(StoryvoxRoutes.chat(fId, prefill)) },
                     // Issue #437 — Back arrow on deep-linked reader /
@@ -845,19 +845,19 @@ private fun StoryvoxNavHostContent(
             ) {
                 ChatScreen(
                     onBack = { navController.popBackStack() },
-                    onOpenAiSettings = { navController.navigate(StoryvoxRoutes.SETTINGS) },
+                    onOpenAiSettings = { navController.navigate(StoryvoxRoutes.SETTINGS_AI) },
                     onOpenVoiceLibrary = { navController.navigate(StoryvoxRoutes.VOICE_LIBRARY) },
                 )
             }
 
             // Issue #440 — Settings hub. New gear-icon destination as of
             // v0.5.38. The hub presents an ordered list of section cards;
-            // each row routes either to a dedicated subscreen (Voice
-            // library, Plugins, AI sessions, Pronunciation, Debug) or to
-            // [SETTINGS] (the legacy long-scroll page) for sections that
-            // haven't been broken out yet. Uses homeEnter/Exit (same as
-            // SETTINGS) so the hub feels like a peer of the bottom-tab
-            // surfaces, not a deep stack push.
+            // every named section routes to its own dedicated subscreen.
+            // Only the explicit "All settings" escape-hatch row routes to
+            // [SETTINGS] (the legacy long-scroll page); the per-section
+            // fallback that earlier hub revisions used is gone. Uses
+            // homeEnter/Exit (same as SETTINGS) so the hub feels like a
+            // peer of the bottom-tab surfaces, not a deep stack push.
             composable(
                 StoryvoxRoutes.SETTINGS_HUB,
                 enterTransition = homeEnter,

--- a/app/src/test/kotlin/in/jphe/storyvox/navigation/SettingsSubscreenRoutesTest.kt
+++ b/app/src/test/kotlin/in/jphe/storyvox/navigation/SettingsSubscreenRoutesTest.kt
@@ -1,7 +1,9 @@
 package `in`.jphe.storyvox.navigation
 
+import java.io.File
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertTrue
+import org.junit.Assert.fail
 import org.junit.Test
 
 /**
@@ -83,5 +85,60 @@ class SettingsSubscreenRoutesTest {
     @Test
     fun `SETTINGS_HUB stays the gear-icon destination`() {
         assertEquals("settings/hub", StoryvoxRoutes.SETTINGS_HUB)
+    }
+
+    /**
+     * Pins that every NavHost call site wiring `onOpenAiSettings`
+     * routes to [StoryvoxRoutes.SETTINGS_AI], not the legacy
+     * [StoryvoxRoutes.SETTINGS] long-scroll page. Earlier revisions
+     * dumped users into the 3,600-line legacy page when they tapped
+     * "Open AI settings" from contexts like the recap modal, the
+     * chat empty state, or the chat error banner — pages where the
+     * user is specifically reaching for AI configuration. Routing
+     * them through the dedicated AI subscreen is the whole point of
+     * the hub follow-up to #440.
+     *
+     * Scans the NavHost source file textually because Compose-UI-test
+     * infrastructure to introspect actual navigation wiring isn't on
+     * the JVM unit-test path. A `git grep` regression net is cheaper
+     * than nothing.
+     */
+    @Test
+    fun `every onOpenAiSettings call site routes to the dedicated AI subscreen`() {
+        val navHost = locateNavHostSource()
+        val src = navHost.readText()
+        val callSiteRegex = Regex(
+            """onOpenAiSettings\s*=\s*\{\s*navController\.navigate\(StoryvoxRoutes\.([A-Z_]+)\)""",
+        )
+        val matches = callSiteRegex.findAll(src).map { it.groupValues[1] }.toList()
+        assertTrue(
+            "Expected at least one onOpenAiSettings = { navController.navigate(...) } " +
+                "call site in StoryvoxNavHost.kt — did the file move?",
+            matches.isNotEmpty(),
+        )
+        val nonAiTargets = matches.filter { it != "SETTINGS_AI" }
+        assertTrue(
+            "onOpenAiSettings must land on SETTINGS_AI, not the legacy long-scroll page. " +
+                "Offending targets: $nonAiTargets",
+            nonAiTargets.isEmpty(),
+        )
+    }
+
+    private fun locateNavHostSource(): File {
+        val candidates = listOf(
+            // Default working directory when tests run from :app.
+            File("src/main/kotlin/in/jphe/storyvox/navigation/StoryvoxNavHost.kt"),
+            // Gradle sometimes runs with the repo root as CWD.
+            File("app/src/main/kotlin/in/jphe/storyvox/navigation/StoryvoxNavHost.kt"),
+        )
+        val found = candidates.firstOrNull { it.exists() }
+        if (found == null) {
+            fail(
+                "StoryvoxNavHost.kt not found at expected paths " +
+                    "(cwd=${File(".").absolutePath}); update locateNavHostSource()",
+            )
+            error("unreachable") // fail() throws AssertionError; satisfies non-null return
+        }
+        return found
     }
 }


### PR DESCRIPTION
## Audit findings

Team-lead asked me to audit Settings Hub routing for cards that fell back to the legacy long-scroll page. The memory entry that flagged this dated to v0.5.38; by current main (v0.5.71) the hub itself has been fully wired — **every one of the 16 named hub cards routes to its own dedicated subscreen**. The legacy `SettingsScreen` is reached only via the explicit "All settings" escape-hatch row.

The real routing gap was outside the hub: **4 NavHost call sites for `onOpenAiSettings` pointed at the legacy `SETTINGS` route** when a perfectly good `SETTINGS_AI` subscreen has existed since the #440 / #467 follow-up.

## Affected call sites

| Source | Trigger | Was | Now |
|---|---|---|---|
| `HybridReaderScreen` (PLAYING route, NavHost:594) | Recap modal "open settings" when no AI provider | `SETTINGS` | `SETTINGS_AI` |
| `HybridReaderScreen` (READER route, NavHost:778) | Same | `SETTINGS` | `SETTINGS_AI` |
| `HybridReaderScreen` (AUDIOBOOK route, NavHost:808) | Same | `SETTINGS` | `SETTINGS_AI` |
| `ChatScreen` (CHAT route, NavHost:848) | Chat empty-state "open settings", chat error-banner "open settings" | `SETTINGS` | `SETTINGS_AI` |

Each of these is a moment where the user has **specifically** reached for AI configuration — they tapped "open AI settings" from a context where the AI failed or isn't configured. Dropping them onto a 3,600-line legacy page that opens on Voice & Playback was exactly the bad UX #440 was created to kill.

## Out of scope (separate issues recommended)

- `onOpenAzureSettings` in `PluginManagerScreen` (NavHost:939) still routes to legacy `SETTINGS` because no dedicated Azure subscreen exists yet. The kdoc at the call site already calls this out as a future-state target. Would warrant its own issue for a Cloud Voices / Azure BYOK subscreen.
- `SettingsSubscreenContractTest` does not pin `AdvancedSettingsScreen` even though it pins the other 8 subscreens — small contract-test gap worth a follow-up but not blocking.

## Regression test

`SettingsSubscreenRoutesTest.every onOpenAiSettings call site routes to the dedicated AI subscreen` scans `StoryvoxNavHost.kt` source textually and asserts every `onOpenAiSettings = { navController.navigate(...) }` lands on `SETTINGS_AI`. Verified the test fails when one site is reverted to `SETTINGS`, then restored.

## Verification

- `./gradlew :app:testDebugUnitTest --tests "in.jphe.storyvox.navigation.*"` — green
- `./gradlew :feature:testDebugUnitTest --tests "*Settings*"` — green
- `./gradlew :app:compileDebugKotlin` — clean
- Negative-case check: reverted one site, ran the new test, confirmed it fails with `AssertionError`, then restored.

## Test plan

- [ ] Open a fiction with no AI provider configured, trigger Recap → "Open settings" → confirms it lands on the AI subscreen (not the long-scroll page)
- [ ] Open Chat with no provider → tap empty-state "Open settings" → lands on AI subscreen
- [ ] Trigger an AI error in Chat (bad key) → error banner "Open settings" → lands on AI subscreen

## Co-author

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>