### PR TITLE
feat(llm): add Claude Opus 4.7 / Sonnet 4.7 to model registries

### DIFF
--- a/core-llm/src/main/kotlin/in/jphe/storyvox/llm/LlmConfig.kt
+++ b/core-llm/src/main/kotlin/in/jphe/storyvox/llm/LlmConfig.kt
@@ -87,6 +87,8 @@ object LlmModels {
         "claude-haiku-4.5",
         "claude-sonnet-4.6",
         "claude-opus-4.6",
+        "claude-sonnet-4.7",
+        "claude-opus-4.7",
     )
     val openAi = listOf(
         "gpt-4o-mini",

--- a/core-llm/src/main/kotlin/in/jphe/storyvox/llm/provider/AnthropicTeamsProvider.kt
+++ b/core-llm/src/main/kotlin/in/jphe/storyvox/llm/provider/AnthropicTeamsProvider.kt
@@ -504,6 +504,8 @@ open class AnthropicTeamsProvider @Inject constructor(
      * → wire-name mapping is identical.
      */
     private fun String.resolveAnthropic(): String = when (this) {
+        "claude-opus-4.7" -> "claude-opus-4-7"
+        "claude-sonnet-4.7" -> "claude-sonnet-4-7"
         "claude-opus-4.6" -> "claude-opus-4-6"
         "claude-sonnet-4.6" -> "claude-sonnet-4-6"
         "claude-haiku-4.5" -> "claude-haiku-4-5-20251001"

--- a/core-llm/src/main/kotlin/in/jphe/storyvox/llm/provider/BedrockProvider.kt
+++ b/core-llm/src/main/kotlin/in/jphe/storyvox/llm/provider/BedrockProvider.kt
@@ -244,6 +244,8 @@ open class BedrockProvider @Inject constructor(
          *  shows. */
         val BEDROCK_MODEL_MAP = mapOf(
             "claude-haiku-4.5" to "us.anthropic.claude-haiku-4-5-20251001-v1:0",
+            "claude-sonnet-4.7" to "us.anthropic.claude-sonnet-4-7",
+            "claude-opus-4.7" to "us.anthropic.claude-opus-4-7",
             "claude-sonnet-4.6" to "us.anthropic.claude-sonnet-4-6",
             "claude-opus-4.6" to "us.anthropic.claude-opus-4-6-v1",
             "claude-sonnet-4.5" to "us.anthropic.claude-sonnet-4-5-20250929-v1:0",
@@ -265,6 +267,8 @@ object BedrockModels {
         "claude-haiku-4.5",
         "claude-sonnet-4.6",
         "claude-opus-4.6",
+        "claude-sonnet-4.7",
+        "claude-opus-4.7",
         "nova-pro",
         "nova-lite",
         "llama4-maverick-17b",

--- a/core-llm/src/main/kotlin/in/jphe/storyvox/llm/provider/ClaudeApiProvider.kt
+++ b/core-llm/src/main/kotlin/in/jphe/storyvox/llm/provider/ClaudeApiProvider.kt
@@ -413,6 +413,8 @@ open class ClaudeApiProvider @Inject constructor(
      * canonicalized.
      */
     private fun String.resolveAnthropic(): String = when (this) {
+        "claude-opus-4.7" -> "claude-opus-4-7"
+        "claude-sonnet-4.7" -> "claude-sonnet-4-7"
         "claude-opus-4.6" -> "claude-opus-4-6"
         "claude-sonnet-4.6" -> "claude-sonnet-4-6"
         "claude-haiku-4.5" -> "claude-haiku-4-5-20251001"

--- a/feature/src/main/kotlin/in/jphe/storyvox/feature/settings/SettingsScreen.kt
+++ b/feature/src/main/kotlin/in/jphe/storyvox/feature/settings/SettingsScreen.kt
@@ -2310,7 +2310,13 @@ private fun ClaudeProviderRows(
         )
         // Model picker as a row of Brass chips. Hardcoded list for v1.
         FlowRow(horizontalArrangement = Arrangement.spacedBy(spacing.xs), verticalArrangement = Arrangement.spacedBy(spacing.xs)) {
-            listOf("claude-haiku-4.5", "claude-sonnet-4.6", "claude-opus-4.6").forEach { m ->
+            listOf(
+                "claude-haiku-4.5",
+                "claude-sonnet-4.6",
+                "claude-opus-4.6",
+                "claude-sonnet-4.7",
+                "claude-opus-4.7",
+            ).forEach { m ->
                 BrassButton(
                     label = m.removePrefix("claude-"),
                     onClick = { onSetClaudeModel(m) },
@@ -2919,6 +2925,7 @@ private fun BedrockProviderRows(
             listOf(
                 "claude-haiku-4.5",
                 "claude-sonnet-4.6",
+                "claude-sonnet-4.7",
                 "nova-lite",
                 "llama4-maverick-17b",
             ).forEach { m ->


### PR DESCRIPTION
Closes #697.

## Summary

Adds Claude Opus 4.7 and Sonnet 4.7 to all three Anthropic-backed providers and the Bedrock translation table. Older models (4.5 / 4.6) stay in all maps for backward compatibility with persisted user prefs — this is purely additive.

## Files touched

- `core-llm/.../LlmConfig.kt` — `LlmModels.claude` list (Settings dropdown source of truth)
- `core-llm/.../provider/ClaudeApiProvider.kt` — canonical → wire ID map
- `core-llm/.../provider/AnthropicTeamsProvider.kt` — same map (Teams shares the Messages API)
- `core-llm/.../provider/BedrockProvider.kt` — `BEDROCK_MODEL_MAP` + `BedrockModels.canonical`
- `feature/.../settings/SettingsScreen.kt` — both `ClaudeProviderRows` and `BedrockProviderRows` chip lists

Note: `SettingsScreen.ClaudeProviderRows` and `BedrockProviderRows` are also rendered by the new `AiSettingsScreen` hub subscreen (via the shared `AiSection` composable), so the chip update covers both the legacy long-scroll path and the new hub flow.

## Wire format

Follows the new-model convention already used for 4.6:

| Canonical | Anthropic API | Bedrock |
|---|---|---|
| `claude-opus-4.7` | `claude-opus-4-7` | `us.anthropic.claude-opus-4-7` |
| `claude-sonnet-4.7` | `claude-sonnet-4-7` | `us.anthropic.claude-sonnet-4-7` |

The dated-suffix form (`-20251001` style) only appears on older models where Anthropic published explicit dated aliases. Reasonable to revise these wire IDs if upstream introduces dated aliases for 4.7 later — `resolveAnthropic` is the one place to change.

## Verification

- `./gradlew :core-llm:compileDebugKotlin` — clean
- `./gradlew :feature:compileDebugKotlin` — clean (pre-existing deprecation warnings unrelated)
- `./gradlew :core-llm:testDebugUnitTest` — BUILD SUCCESSFUL

## Test plan

- [ ] Open Settings → AI → Claude provider, verify 4.7 chips appear and selecting them persists
- [ ] Test connection with a Claude API key on 4.7 model selected — verify request reaches `claude-opus-4-7` / `claude-sonnet-4-7` wire ID
- [ ] Same for Bedrock with proper region and credentials
- [ ] Same for Teams (post-#692 merge — sign in, pick 4.7 model, send a recap)

🤖 Generated with [Claude Code](https://claude.com/claude-code)