### PR TITLE
chore: ignore orphan source-kvmr/ — closes #696

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -51,6 +51,14 @@ storyvox-upload.keystore
 .superpowers/
 scratch/
 
+# Issue #417 — :source-kvmr was renamed to :source-radio. Older
+# checkouts of the repo still write build artifacts into
+# source-kvmr/build/ when their settings.gradle.kts still includes
+# `:source-kvmr`; ignoring the entire directory keeps those orphan
+# trees from creeping into commits via `git add .` or IDE plugins.
+# See issue #696.
+source-kvmr/
+
 # Misc
 *.bak
 *.swp


### PR DESCRIPTION
## Root cause

`:source-kvmr` was generalized to `:source-radio` in #417 and removed from `settings.gradle.kts`. But older checkouts (and IDE re-syncs against pre-#417 branches) still write Gradle outputs into `source-kvmr/build/`. The directory has no `src/` or `build.gradle.kts` — it's pure orphan garbage — but it pollutes `find`/`grep` results and confuses contributors.

The contents are already covered by the global `build/` gitignore rule, so nothing got accidentally committed — the only fix needed is making the orphan tree's status explicit and providing an obvious anchor for future contributors who hit it.

## What this PR does

Adds `source-kvmr/` to `.gitignore` with a comment cross-referencing #417, so:
- `git add .` (if anyone uses it) can never sweep the orphan tree in
- IDE re-syncs that recreate the directory don't show it as untracked
- A future grep for "source-kvmr" in `.gitignore` immediately surfaces the rename context

## What this PR deliberately does NOT do

**Does not remove `SourceIds.KVMR`** — Argus's issue body suggested verifying whether it's still needed. I confirmed it's load-bearing in 15+ call sites:
- `RadioModule.kt:98` — `@StringKey(SourceIds.KVMR)` Hilt multibinding (persistence alias for v0.5.20..0.5.31 library rows with `sourceId = "kvmr"`)
- `BrowseViewModel.kt:708` — browse-tab routing
- `BrowseSourceUi.kt:56` — "Radio" display label for legacy persisted rows
- `SettingsRepositoryUiImpl.kt:347` — settings JSON map seeder
- `KvmrEnabledToRadioEnabledMigrationTest.kt` — the migration test that proves legacy preference rows still flip Radio on
- `RadioSourceTest.kt:66` — asserts the alias value

The KDoc in `core-data/.../SourceIds.kt:88-97` explicitly says "A follow-up release can drop this once one full release cycle has elapsed; until then the alias is load-bearing for library-shelf / playback-position survival." That's a deliberate future cleanup, not part of #696.

**Does not `git rm source-kvmr/`** — there's nothing tracked under `source-kvmr/`. The 8MB `source-kvmr/build/` tree existed only in the local working copy; I deleted it outside the commit.

## Test plan

- [x] `.gitignore` diff renders cleanly on GitHub
- [x] No source code changed → no test runs needed (CHANGELOG entry is borderline — a 5-line gitignore comment doesn't really merit one; happy to add one if reviewers prefer)
- [ ] Next time someone clones an older branch with `:source-kvmr` in settings, the orphan tree stays out of `git status`

Closes #696.

🤖 Generated with [Claude Code](https://claude.com/claude-code)