### PR TITLE
fix(sync): SyncCoordinator.publish uses atomic CAS update

### DIFF
--- a/core-sync/src/main/kotlin/in/jphe/storyvox/sync/coordinator/SyncCoordinator.kt
+++ b/core-sync/src/main/kotlin/in/jphe/storyvox/sync/coordinator/SyncCoordinator.kt
@@ -12,6 +12,7 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
@@ -121,7 +122,10 @@ class SyncCoordinator @Inject constructor(
     }
 
     private fun publish(domain: String, status: SyncStatus) {
-        _status.value = _status.value + (domain to status)
+        // Atomic CAS-based read-modify-write so concurrent syncers
+        // running on different domains can't lose each other's updates.
+        // See #704 for the lost-update repro.
+        _status.update { it + (domain to status) }
     }
 }
 


### PR DESCRIPTION
Closes #704.

## Summary

Replaces a non-atomic read-modify-write on `_status` with the CAS-based `StateFlow.update {}` so concurrent syncers can't lose each other's status updates.

## The race

`SyncCoordinator.publish()`:

```kotlin
private fun publish(domain: String, status: SyncStatus) {
    _status.value = _status.value + (domain to status)
}
```

Three separate operations: read `_status.value`, compute `old + entry`, write back. Two concurrent syncers (different domains under their own per-domain mutexes — push-all explicitly fans out across domains) can each read the same `_status` snapshot, both append their own update, and one overwrites the other.

1. Domain A reads `{A=Idle, B=Idle}`
2. Domain B reads `{A=Idle, B=Idle}` (same snapshot)
3. Domain A writes `{A=Running, B=Idle}`
4. Domain B writes `{A=Idle, B=Running}` — **A's Running is lost**

`requestPushAll()` launches one coroutine per syncer, so this is reachable on the post-sign-in migration path. UI subscribers see Domain A go directly Idle → Ok (skipping Running), or stuck at Idle while Domain B reports activity.

## The fix

```kotlin
import kotlinx.coroutines.flow.update

private fun publish(domain: String, status: SyncStatus) {
    _status.update { it + (domain to status) }
}
```

`StateFlow.update {}` is a CAS loop internally — read latest, transform, `compareAndSet`, retry if a concurrent writer beat us. The transform `it + (domain to status)` is a pure map operation so re-invocation is safe.

## Files

- `core-sync/src/main/kotlin/in/jphe/storyvox/sync/coordinator/SyncCoordinator.kt` — added `update` import, swapped the publish body, comment pointing at #704

## Verification

- `./gradlew :core-sync:compileDebugKotlin` — clean
- `./gradlew :core-sync:testDebugUnitTest` — BUILD SUCCESSFUL

## Test plan

- [ ] Sign in fresh, trigger post-sign-in migration (requestPushAll), watch `SyncStatusSheet` — every domain should transition Idle → Running → terminal without "skips"
- [ ] No regression in single-domain push path (requestPush for one domain)
- [ ] No regression in pullAll on app start

## Related

#691 (InstantDB sync still doesn't work) — hazel is debugging that. This race could plausibly contribute to UI status inconsistencies they're seeing, but is a real concurrency bug in its own right regardless of whether #691 turns out to share a root cause.

🤖 Generated with [Claude Code](https://claude.com/claude-code)