### PR TITLE
fix(browse): filter Search tab when descriptor declares supportsSearch=false

### DIFF
--- a/feature/src/main/kotlin/in/jphe/storyvox/feature/browse/BrowseScreen.kt
+++ b/feature/src/main/kotlin/in/jphe/storyvox/feature/browse/BrowseScreen.kt
@@ -191,11 +191,27 @@ fun BrowseScreen(
             modifier = Modifier.fillMaxWidth(),
         )
 
-        val supportedTabs = remember(state.sourceId, state.githubSignedIn, state.ao3SignedIn) {
+        // Issue #695 — read the active source's `supportsSearch`
+        // annotation off its descriptor so the Search tab disappears for
+        // sources that declared `supportsSearch = false`
+        // (Slack, Telegram). Sources missing from `visibleSources` (an
+        // unenabled-id race) default to `true` so we don't accidentally
+        // strip Search while the picker is still loading.
+        val supportsSearch = state.visibleSources
+            .firstOrNull { it.id == state.sourceId }
+            ?.supportsSearch
+            ?: true
+        val supportedTabs = remember(
+            state.sourceId,
+            state.githubSignedIn,
+            state.ao3SignedIn,
+            supportsSearch,
+        ) {
             BrowseSourceUi.supportedTabs(
                 state.sourceId,
                 githubSignedIn = state.githubSignedIn,
                 ao3SignedIn = state.ao3SignedIn,
+                supportsSearch = supportsSearch,
             )
         }
         Row(

--- a/feature/src/main/kotlin/in/jphe/storyvox/feature/browse/BrowseSourceUi.kt
+++ b/feature/src/main/kotlin/in/jphe/storyvox/feature/browse/BrowseSourceUi.kt
@@ -67,11 +67,33 @@ internal object BrowseSourceUi {
      * (`Ao3MySubscriptions` / `Ao3MarkedForLater`, #426 PR2).
      * Unknown ids fall through to a reasonable default of
      * Popular + Search.
+     *
+     * Issue #695 — when [supportsSearch] is `false`, the
+     * [BrowseTab.Search] tab is stripped out of whichever branch
+     * matched. Sources that declare `supportsSearch = false` on their
+     * `@SourcePlugin` annotation (Slack, Telegram) used to hit the
+     * `else` fallthrough below and surface a Search tab that did
+     * nothing — typing a query returned `empty ListPage` and the user
+     * concluded the source was broken. Filtering here is the
+     * single-source-of-truth fix; the per-source branches stay as
+     * "ideal default tab set" and the descriptor's annotation wins
+     * when it disagrees. Defaulting to `true` keeps every existing
+     * caller and test path unchanged.
      */
     fun supportedTabs(
         id: String,
         githubSignedIn: Boolean = false,
         ao3SignedIn: Boolean = false,
+        supportsSearch: Boolean = true,
+    ): List<BrowseTab> {
+        val tabs = supportedTabsRaw(id, githubSignedIn, ao3SignedIn)
+        return if (supportsSearch) tabs else tabs.filterNot { it == BrowseTab.Search }
+    }
+
+    private fun supportedTabsRaw(
+        id: String,
+        githubSignedIn: Boolean,
+        ao3SignedIn: Boolean,
     ): List<BrowseTab> = when (id) {
         SourceIds.ROYAL_ROAD -> listOf(
             BrowseTab.Popular,

--- a/feature/src/main/kotlin/in/jphe/storyvox/feature/browse/BrowseViewModel.kt
+++ b/feature/src/main/kotlin/in/jphe/storyvox/feature/browse/BrowseViewModel.kt
@@ -437,10 +437,18 @@ class BrowseViewModel @Inject constructor(
     fun selectSource(id: String) {
         if (_sourceId.value == id) return
         _sourceId.value = id
+        // Issue #695 — descriptor-driven supportsSearch so Slack /
+        // Telegram (which declare `supportsSearch = false`) don't end up
+        // with an active Search tab after the user picks them. Missing
+        // descriptor (out-of-tree id) defaults to true to preserve the
+        // old fallthrough behavior.
+        val supportsSearch = registry.descriptors.firstOrNull { it.id == id }
+            ?.supportsSearch ?: true
         val supported = BrowseSourceUi.supportedTabs(
             id,
             githubSignedIn = githubSignedIn.value,
             ao3SignedIn = ao3SignedIn.value,
+            supportsSearch = supportsSearch,
         )
         if (_tab.value !in supported) {
             _tab.value = BrowseTab.Popular

--- a/feature/src/test/kotlin/in/jphe/storyvox/feature/browse/BrowseSourceUiTest.kt
+++ b/feature/src/test/kotlin/in/jphe/storyvox/feature/browse/BrowseSourceUiTest.kt
@@ -39,6 +39,10 @@ class BrowseSourceUiTest {
             SourceIds.DISCORD to "Discord",
         )
 
+        // 18 = 11 catalog backends + Radio/Kvmr alias + Notion + HN +
+        // arXiv + PLOS + Discord. Slack and Telegram intentionally fall
+        // through to the registry's displayName (chip strip uses the
+        // same string as the Settings → Plugins label).
         assertEquals(18, expected.size)
         for ((id, label) in expected) {
             assertEquals(
@@ -73,6 +77,55 @@ class BrowseSourceUiTest {
         assertTrue(BrowseTab.Gists in authed)
     }
 
+    /**
+     * Issue #695 — sources that declare `supportsSearch = false` on
+     * their `@SourcePlugin` annotation (Slack, Telegram) used to fall
+     * through to the default `Popular + Search` branch and surface a
+     * Search tab that did nothing. The new `supportsSearch` parameter
+     * strips Search from whatever branch matched.
+     */
+    @Test fun `supportedTabs strips Search when descriptor declares supportsSearch false`() {
+        val withSearch = BrowseSourceUi.supportedTabs(SourceIds.SLACK, supportsSearch = true)
+        val withoutSearch = BrowseSourceUi.supportedTabs(SourceIds.SLACK, supportsSearch = false)
+        assertTrue(
+            "Slack with supportsSearch=true should keep Search (legacy default)",
+            BrowseTab.Search in withSearch,
+        )
+        assertFalse(
+            "Slack with supportsSearch=false must not surface a Search tab",
+            BrowseTab.Search in withoutSearch,
+        )
+        // Popular still present — only the Search tab is filtered.
+        assertTrue(BrowseTab.Popular in withoutSearch)
+    }
+
+    /**
+     * Issue #695 — defense-in-depth: even sources whose explicit branch
+     * lists `Search` should honor the descriptor flag. Verifies the
+     * filter runs after the per-source branch, not only on the `else`
+     * fallthrough.
+     */
+    @Test fun `supportedTabs strips Search even from sources with an explicit branch`() {
+        // Wikipedia has an explicit `Popular + Search` branch.
+        val filtered = BrowseSourceUi.supportedTabs(SourceIds.WIKIPEDIA, supportsSearch = false)
+        assertFalse(
+            "Wikipedia branch lists Search explicitly; descriptor flag must still win",
+            BrowseTab.Search in filtered,
+        )
+        assertTrue(BrowseTab.Popular in filtered)
+    }
+
+    /**
+     * Issue #695 — the `supportsSearch` parameter defaults to `true`,
+     * matching the pre-fix behavior for every caller that doesn't yet
+     * thread the descriptor flag through.
+     */
+    @Test fun `supportedTabs default supportsSearch preserves legacy behavior`() {
+        val withDefault = BrowseSourceUi.supportedTabs(SourceIds.WIKIPEDIA)
+        val withExplicitTrue = BrowseSourceUi.supportedTabs(SourceIds.WIKIPEDIA, supportsSearch = true)
+        assertEquals(withDefault, withExplicitTrue)
+    }
+
     @Test fun `filterShape RoyalRoad GitHub MemPalace get sheet, others get None`() {
         assertEquals(FilterShape.RoyalRoad, BrowseSourceUi.filterShape(SourceIds.ROYAL_ROAD))
         assertEquals(FilterShape.GitHub, BrowseSourceUi.filterShape(SourceIds.GITHUB))
@@ -86,7 +139,13 @@ class BrowseSourceUiTest {
     }
 
     @Test fun `searchHint returns sensible copy for every in-tree source`() {
-        for (id in IN_TREE_IDS) {
+        // Issue #695 — sources that declare `supportsSearch = false`
+        // (Slack, Telegram) never reach the Search tab's empty state,
+        // so a dedicated `searchHint` entry is unreachable copy. The
+        // generic "Search <displayName>" fallback is fine for them.
+        // Every other in-tree source must override.
+        val noSearchSources = setOf(SourceIds.SLACK, SourceIds.TELEGRAM)
+        for (id in IN_TREE_IDS - noSearchSources) {
             val hint = BrowseSourceUi.searchHint(id, displayName = "FallbackName")
             assertTrue(
                 "Expected non-empty searchHint for $id (got: '$hint')",
@@ -106,9 +165,11 @@ class BrowseSourceUiTest {
     }
 
     private companion object {
-        /** All 17 in-tree backends. Adding a row here when a new
-         *  backend lands is the explicit "did we add the UI hint?"
-         *  audit step. */
+        /** All in-tree backends. Adding a row here when a new backend
+         *  lands is the explicit "did we add the UI hint?" audit step.
+         *  Slack and Telegram were missing pre-#695 — adding them here
+         *  surfaces any future drop-through-to-default bug for
+         *  supportsSearch=false sources via the existing smoke loops. */
         val IN_TREE_IDS = setOf(
             SourceIds.ROYAL_ROAD, SourceIds.GITHUB, SourceIds.MEMPALACE,
             SourceIds.RSS, SourceIds.EPUB, SourceIds.OUTLINE,
@@ -119,6 +180,10 @@ class BrowseSourceUiTest {
             SourceIds.RADIO, SourceIds.KVMR,
             SourceIds.NOTION, SourceIds.HACKERNEWS, SourceIds.ARXIV,
             SourceIds.PLOS, SourceIds.DISCORD,
+            // Issue #695 — Slack/Telegram declare supportsSearch=false;
+            // the smoke loops verify their tab list still includes
+            // Popular and isn't accidentally empty.
+            SourceIds.SLACK, SourceIds.TELEGRAM,
         )
     }
 }


### PR DESCRIPTION
Closes #695.

## Problem

`BrowseSourceUi.supportedTabs` fell through to a default `listOf(Popular, Search)` for sources without an explicit `when` branch. `SourceIds.SLACK` and `SourceIds.TELEGRAM` declare `supportsSearch = false` on their `@SourcePlugin` annotation and return empty `ListPage` from `search()` — but the Browse chip strip still showed a Search tab. Typing a query rendered the empty state, which read as a broken source. Argus called the same UX bug class as #673 (Readability).

## Fix

`supportedTabs` gains a `supportsSearch: Boolean = true` parameter and filters `BrowseTab.Search` out of the returned list when the flag is `false`. Filtering runs after the per-source `when` branch, so even explicit branches that include `Search` honor the descriptor's annotation (defense-in-depth).

Callers:
- `BrowseViewModel.selectSource` reads `supportsSearch` off the live `SourcePluginRegistry`, defaulting to `true` for out-of-tree ids the registry doesn't know about.
- `BrowseScreen` reads it off `state.visibleSources` so the chip-strip recomposition reflects the active descriptor.

The default `true` value is backwards-compatible — every existing test path and every caller that doesn't yet thread the descriptor flag continues to work unchanged.

## Tests

| Test | Verifies |
|---|---|
| `supportedTabs strips Search when descriptor declares supportsSearch false` | Slack with `false` → no Search; with `true` (legacy default) → keeps Search |
| `supportedTabs strips Search even from sources with an explicit branch` | Wikipedia's `Popular + Search` branch still loses Search when descriptor says no |
| `supportedTabs default supportsSearch preserves legacy behavior` | Default param value matches explicit `true` |
| `IN_TREE_IDS` gains Slack + Telegram | Pre-#695 their absence is why the bug went undetected — existing smoke loops now cover them |
| `searchHint returns sensible copy for every in-tree source` | Skips Slack/Telegram (their Search tab is never reached, so the hint is unreachable copy — the generic fallback is fine) |

**Negative-case verification**: temporarily reverted the `tabs.filterNot { it == BrowseTab.Search }` to `return tabs`, confirmed the new test fails with `AssertionError`, restored.

## Verification

- `./gradlew :feature:testDebugUnitTest --tests "in.jphe.storyvox.feature.browse.*"` — green
- `./gradlew :app:compileDebugKotlin` — clean

## Test plan

- [ ] Open Browse, switch to Slack → confirm Search tab is gone (just Popular)
- [ ] Switch to Telegram → same
- [ ] Switch to Royal Road / AO3 / GitHub → Search tab still present
- [ ] Switch from Slack → AO3 while on a tab Slack supported (e.g., user was on Popular) → no tab-index regression

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>