### PR TITLE
fix(downloads): recover stuck DOWNLOADING chapters — closes #705

### DIFF
--- a/core-data/src/main/kotlin/in/jphe/storyvox/data/db/dao/ChapterDao.kt
+++ b/core-data/src/main/kotlin/in/jphe/storyvox/data/db/dao/ChapterDao.kt
@@ -284,6 +284,39 @@ interface ChapterDao {
     )
     suspend fun setDownloadState(id: String, state: ChapterDownloadState, now: Long, error: String?)
 
+    /**
+     * Issue #705 — DOWNLOADING is a transient state set by
+     * [`ChapterDownloadWorker`][in.jphe.storyvox.data.work.ChapterDownloadWorker]
+     * just before [FictionSource.chapter] runs. Every normal exit (Success,
+     * NotFound, AuthRequired, Cloudflare, RateLimited, NetworkError) writes
+     * a follow-up state — but if the worker is killed mid-flight (Android
+     * low-memory kill, JobScheduler timeout, process crash) or a parser
+     * throws something the worker can't catch (OOM, hard crash), the row
+     * is left at DOWNLOADING with no reaper.
+     *
+     * This query flips DOWNLOADING rows whose `lastDownloadAttemptAt` is
+     * older than `cutoff` back to QUEUED with a `stuck` error tag so the
+     * next scheduler pass picks them up again. Called from the worker
+     * itself at the top of `doWork()` so every fresh download self-heals
+     * stale siblings without needing an app-start hook.
+     *
+     * The 5-minute cutoff (per the issue's recommendation) is comfortably
+     * longer than the slowest real `source.chapter()` call observed in
+     * the wild (RR cold cache + chapter-list page-walk parser is < 30s
+     * on a bad night), so we don't race a still-running download.
+     */
+    @Query(
+        """
+        UPDATE chapter
+           SET downloadState = 'QUEUED',
+               lastDownloadAttemptAt = :now,
+               lastDownloadError = 'stuck'
+         WHERE downloadState = 'DOWNLOADING'
+           AND (lastDownloadAttemptAt IS NULL OR lastDownloadAttemptAt < :cutoff)
+        """,
+    )
+    suspend fun reapStuckDownloads(now: Long, cutoff: Long): Int
+
     @Query(
         """
         UPDATE chapter

--- a/core-data/src/main/kotlin/in/jphe/storyvox/data/work/ChapterDownloadWorker.kt
+++ b/core-data/src/main/kotlin/in/jphe/storyvox/data/work/ChapterDownloadWorker.kt
@@ -15,6 +15,7 @@ import `in`.jphe.storyvox.data.source.FictionSource
 import `in`.jphe.storyvox.data.source.WebViewFetcher
 import `in`.jphe.storyvox.data.source.model.FictionResult
 import java.security.MessageDigest
+import kotlin.coroutines.cancellation.CancellationException
 
 /**
  * Downloads a single chapter body. Run with `OneTimeWorkRequest`; orchestration
@@ -31,6 +32,20 @@ import java.security.MessageDigest
  *    parse via the same source code path, then `Result.success()`. If the
  *    fetcher isn't available, `retry()`.
  *  - [FictionResult.Success] → write body, mark `DOWNLOADED`, `Result.success()`.
+ *
+ * # Stuck-state recovery (issue #705)
+ *
+ * Before setting this chapter to `DOWNLOADING` the worker calls
+ * [ChapterDao.reapStuckDownloads] to flip any sibling rows that have been
+ * stuck at `DOWNLOADING` for longer than [STUCK_CUTOFF_MS] back to
+ * `QUEUED`. The whole `source.chapter()` / `setBody` path is then wrapped
+ * in a `try` that catches any uncaught throwable (parser bugs, OOM,
+ * Room constraint violations) and writes `FAILED` with a `crash` tag so
+ * the row never sits at `DOWNLOADING` forever. [CancellationException]
+ * is rethrown so coroutine cancellation propagates normally — the
+ * reaper on the next worker run will pick the row up because the
+ * `lastDownloadAttemptAt` timestamp from the `setDownloadState`
+ * call already aged out.
  */
 @HiltWorker
 class ChapterDownloadWorker @AssistedInject constructor(
@@ -58,79 +73,111 @@ class ChapterDownloadWorker @AssistedInject constructor(
         val now = System.currentTimeMillis()
         val source = sourceFor(fictionDao.get(fictionId)?.sourceId)
 
+        // Issue #705 — Reap sibling rows stuck in DOWNLOADING from a
+        // crashed/killed previous worker run before we claim a new one.
+        // Cheap (indexed on downloadState) and runs once per scheduled
+        // download, which is the natural cadence — if downloads are
+        // happening at all, the reaper is making progress.
+        chapterDao.reapStuckDownloads(now = now, cutoff = now - STUCK_CUTOFF_MS)
+
         chapterDao.setDownloadState(chapterId, ChapterDownloadState.DOWNLOADING, now, null)
 
-        return when (val result = source.chapter(fictionId, chapterId)) {
-            is FictionResult.Success -> {
-                val content = result.value
-                val checksum = sha256(content.htmlBody)
-                chapterDao.setBody(
-                    id = chapterId,
-                    html = content.htmlBody,
-                    plain = content.plainBody,
-                    checksum = checksum,
-                    notesAuthor = content.notesAuthor,
-                    notesAuthorPosition = content.notesAuthorPosition?.name,
-                    now = System.currentTimeMillis(),
-                    audioUrl = content.audioUrl,
-                )
-                Result.success(output(RESULT_OK))
-            }
-
-            is FictionResult.NotFound -> {
-                chapterDao.setDownloadState(chapterId, ChapterDownloadState.FAILED, now, "404")
-                Result.failure(output(RESULT_NOT_FOUND))
-            }
-
-            is FictionResult.AuthRequired -> {
-                chapterDao.setDownloadState(chapterId, ChapterDownloadState.FAILED, now, "auth")
-                Result.failure(output(RESULT_AUTH))
-            }
-
-            is FictionResult.Cloudflare -> {
-                val fetcher = webView
-                if (fetcher == null) {
-                    chapterDao.setDownloadState(chapterId, ChapterDownloadState.QUEUED, now, "cf-no-fetcher")
-                    return Result.retry()
+        return try {
+            when (val result = source.chapter(fictionId, chapterId)) {
+                is FictionResult.Success -> {
+                    val content = result.value
+                    val checksum = sha256(content.htmlBody)
+                    chapterDao.setBody(
+                        id = chapterId,
+                        html = content.htmlBody,
+                        plain = content.plainBody,
+                        checksum = checksum,
+                        notesAuthor = content.notesAuthor,
+                        notesAuthorPosition = content.notesAuthorPosition?.name,
+                        now = System.currentTimeMillis(),
+                        audioUrl = content.audioUrl,
+                    )
+                    Result.success(output(RESULT_OK))
                 }
-                // The source's `chapter()` already failed at the HTTP layer.
-                // We escalate by fetching the URL via WebView and then asking
-                // the source to re-parse it. To avoid leaking a parse-from-html
-                // method into the FictionSource interface we instead just
-                // retry the original suspend call — Oneiros's RR impl is
-                // expected to consult AuthRepository's cookie + WebViewFetcher
-                // on retry. If still Cloudflare, we give up for this run.
-                when (val retry = source.chapter(fictionId, chapterId)) {
-                    is FictionResult.Success -> {
-                        val checksum = sha256(retry.value.htmlBody)
-                        chapterDao.setBody(
-                            id = chapterId,
-                            html = retry.value.htmlBody,
-                            plain = retry.value.plainBody,
-                            checksum = checksum,
-                            notesAuthor = retry.value.notesAuthor,
-                            notesAuthorPosition = retry.value.notesAuthorPosition?.name,
-                            now = System.currentTimeMillis(),
-                            audioUrl = retry.value.audioUrl,
-                        )
-                        Result.success(output(RESULT_OK))
+
+                is FictionResult.NotFound -> {
+                    chapterDao.setDownloadState(chapterId, ChapterDownloadState.FAILED, now, "404")
+                    Result.failure(output(RESULT_NOT_FOUND))
+                }
+
+                is FictionResult.AuthRequired -> {
+                    chapterDao.setDownloadState(chapterId, ChapterDownloadState.FAILED, now, "auth")
+                    Result.failure(output(RESULT_AUTH))
+                }
+
+                is FictionResult.Cloudflare -> {
+                    val fetcher = webView
+                    if (fetcher == null) {
+                        chapterDao.setDownloadState(chapterId, ChapterDownloadState.QUEUED, now, "cf-no-fetcher")
+                        return Result.retry()
                     }
-                    is FictionResult.Failure -> {
-                        chapterDao.setDownloadState(chapterId, ChapterDownloadState.FAILED, now, "cf")
-                        Result.retry()
+                    // The source's `chapter()` already failed at the HTTP layer.
+                    // We escalate by fetching the URL via WebView and then asking
+                    // the source to re-parse it. To avoid leaking a parse-from-html
+                    // method into the FictionSource interface we instead just
+                    // retry the original suspend call — Oneiros's RR impl is
+                    // expected to consult AuthRepository's cookie + WebViewFetcher
+                    // on retry. If still Cloudflare, we give up for this run.
+                    when (val retry = source.chapter(fictionId, chapterId)) {
+                        is FictionResult.Success -> {
+                            val checksum = sha256(retry.value.htmlBody)
+                            chapterDao.setBody(
+                                id = chapterId,
+                                html = retry.value.htmlBody,
+                                plain = retry.value.plainBody,
+                                checksum = checksum,
+                                notesAuthor = retry.value.notesAuthor,
+                                notesAuthorPosition = retry.value.notesAuthorPosition?.name,
+                                now = System.currentTimeMillis(),
+                                audioUrl = retry.value.audioUrl,
+                            )
+                            Result.success(output(RESULT_OK))
+                        }
+                        is FictionResult.Failure -> {
+                            chapterDao.setDownloadState(chapterId, ChapterDownloadState.FAILED, now, "cf")
+                            Result.retry()
+                        }
                     }
                 }
-            }
 
-            is FictionResult.RateLimited -> {
-                chapterDao.setDownloadState(chapterId, ChapterDownloadState.QUEUED, now, "rate")
-                Result.retry()
-            }
+                is FictionResult.RateLimited -> {
+                    chapterDao.setDownloadState(chapterId, ChapterDownloadState.QUEUED, now, "rate")
+                    Result.retry()
+                }
 
-            is FictionResult.NetworkError -> {
-                chapterDao.setDownloadState(chapterId, ChapterDownloadState.QUEUED, now, "net")
-                Result.retry()
+                is FictionResult.NetworkError -> {
+                    chapterDao.setDownloadState(chapterId, ChapterDownloadState.QUEUED, now, "net")
+                    Result.retry()
+                }
             }
+        } catch (cancel: CancellationException) {
+            // Don't swallow cancellation — the coroutines machinery uses
+            // this to propagate WorkManager's `stop()` (system kills the
+            // worker mid-flight) and structured concurrency. The reaper
+            // at the top of the NEXT doWork() pass will flip this row
+            // back to QUEUED after STUCK_CUTOFF_MS — that's the recovery
+            // path for the cancel-mid-flight case.
+            throw cancel
+        } catch (t: Throwable) {
+            // Issue #705 — any other uncaught throwable (parser bug, OOM
+            // on a giant body, Room constraint violation, IOException
+            // that didn't get mapped to FictionResult.NetworkError) used
+            // to leave the row stuck at DOWNLOADING forever. Flip it to
+            // FAILED with a `crash` tag so the user (and the reaper) can
+            // see something happened, and return retry() so WorkManager's
+            // exponential backoff gets a shot at it.
+            chapterDao.setDownloadState(
+                chapterId,
+                ChapterDownloadState.FAILED,
+                System.currentTimeMillis(),
+                "crash: ${t.javaClass.simpleName}",
+            )
+            Result.retry()
         }
     }
 
@@ -155,6 +202,15 @@ class ChapterDownloadWorker @AssistedInject constructor(
         const val RESULT_NOT_FOUND = "404"
         const val RESULT_AUTH = "auth"
         const val RESULT_BAD_INPUT = "bad-input"
+
+        /**
+         * Issue #705 — DOWNLOADING rows older than this are flipped back
+         * to QUEUED by [ChapterDao.reapStuckDownloads] on the next
+         * worker run. 5 minutes is well above the slowest observed
+         * `source.chapter()` call (RR cold-cache page-walk parsers
+         * land in <30s) so we don't race a still-running download.
+         */
+        const val STUCK_CUTOFF_MS: Long = 5 * 60 * 1000L
 
         fun uniqueName(chapterId: String): String = "download:$chapterId"
     }

--- a/core-data/src/test/kotlin/in/jphe/storyvox/data/db/dao/ChapterDaoTest.kt
+++ b/core-data/src/test/kotlin/in/jphe/storyvox/data/db/dao/ChapterDaoTest.kt
@@ -353,6 +353,84 @@ class ChapterDaoTest {
         assertEquals(1L, row.lastDownloadAttemptAt)
     }
 
+    // ----- reapStuckDownloads (issue #705) -------------------------------------
+
+    @Test
+    fun reapStuckDownloads_flipsAgedDownloadingRowsToQueued() = runTest {
+        fictionDao.upsert(fiction)
+        dao.upsertAll(
+            listOf(
+                chapter("c1", index = 0, downloadState = ChapterDownloadState.DOWNLOADING),
+                chapter("c2", index = 1, downloadState = ChapterDownloadState.DOWNLOADING),
+            ),
+        )
+        // c1 is old (started at t=100), c2 is fresh (started at t=900).
+        dao.setDownloadState("c1", ChapterDownloadState.DOWNLOADING, now = 100L, error = null)
+        dao.setDownloadState("c2", ChapterDownloadState.DOWNLOADING, now = 900L, error = null)
+
+        // Cutoff = 500. c1 (lastAttempt=100 < 500) is stuck; c2 (=900) is fresh.
+        val reaped = dao.reapStuckDownloads(now = 1000L, cutoff = 500L)
+
+        assertEquals(1, reaped)
+        val c1 = dao.get("c1")!!
+        val c2 = dao.get("c2")!!
+        assertEquals(ChapterDownloadState.QUEUED, c1.downloadState)
+        assertEquals("stuck", c1.lastDownloadError)
+        assertEquals(1000L, c1.lastDownloadAttemptAt)
+        // c2 untouched.
+        assertEquals(ChapterDownloadState.DOWNLOADING, c2.downloadState)
+        assertNull(c2.lastDownloadError)
+        assertEquals(900L, c2.lastDownloadAttemptAt)
+    }
+
+    @Test
+    fun reapStuckDownloads_doesNotTouchNonDownloadingRows() = runTest {
+        fictionDao.upsert(fiction)
+        dao.upsertAll(
+            listOf(
+                chapter("c1", index = 0, downloadState = ChapterDownloadState.QUEUED),
+                chapter("c2", index = 1, downloadState = ChapterDownloadState.DOWNLOADED),
+                chapter("c3", index = 2, downloadState = ChapterDownloadState.FAILED),
+                chapter("c4", index = 3, downloadState = ChapterDownloadState.NOT_DOWNLOADED),
+            ),
+        )
+        // Backdate all four with the same ancient timestamp.
+        dao.setDownloadState("c1", ChapterDownloadState.QUEUED, now = 1L, error = null)
+        dao.setDownloadState("c2", ChapterDownloadState.DOWNLOADED, now = 1L, error = null)
+        dao.setDownloadState("c3", ChapterDownloadState.FAILED, now = 1L, error = "old")
+        // c4 left untouched so lastDownloadAttemptAt is NULL.
+
+        val reaped = dao.reapStuckDownloads(now = 5000L, cutoff = 4000L)
+
+        assertEquals(0, reaped)
+        assertEquals(ChapterDownloadState.QUEUED, dao.get("c1")!!.downloadState)
+        assertEquals(ChapterDownloadState.DOWNLOADED, dao.get("c2")!!.downloadState)
+        assertEquals(ChapterDownloadState.FAILED, dao.get("c3")!!.downloadState)
+        assertEquals(ChapterDownloadState.NOT_DOWNLOADED, dao.get("c4")!!.downloadState)
+    }
+
+    @Test
+    fun reapStuckDownloads_reapsRowsWithNullLastAttempt() = runTest {
+        // Belt-and-suspenders: if a chapter is somehow at DOWNLOADING with a
+        // NULL lastDownloadAttemptAt (shouldn't happen with the worker as
+        // written, but possible if the row was hand-edited or restored from
+        // a stale backup), the reaper should still flip it back to QUEUED.
+        fictionDao.upsert(fiction)
+        dao.upsert(
+            chapter("c1", index = 0, downloadState = ChapterDownloadState.DOWNLOADING),
+        )
+        // Don't call setDownloadState → lastDownloadAttemptAt stays NULL.
+        assertNull(dao.get("c1")!!.lastDownloadAttemptAt)
+
+        val reaped = dao.reapStuckDownloads(now = 1000L, cutoff = 500L)
+
+        assertEquals(1, reaped)
+        val row = dao.get("c1")!!
+        assertEquals(ChapterDownloadState.QUEUED, row.downloadState)
+        assertEquals("stuck", row.lastDownloadError)
+        assertEquals(1000L, row.lastDownloadAttemptAt)
+    }
+
     @Test
     fun setRead_setsFirstReadAtOnFirstReadOnly() = runTest {
         fictionDao.upsert(fiction)

--- a/core-data/src/test/kotlin/in/jphe/storyvox/data/repository/ChapterRepositoryImplTest.kt
+++ b/core-data/src/test/kotlin/in/jphe/storyvox/data/repository/ChapterRepositoryImplTest.kt
@@ -151,6 +151,27 @@ class ChapterRepositoryImplTest {
             publishRow(id)
         }
 
+        // Issue #705 — reaper for stuck DOWNLOADING rows. Repository never
+        // calls this directly (the worker does), but the DAO interface
+        // requires an impl. Match the live SQL: flip DOWNLOADING rows
+        // whose lastDownloadAttemptAt is NULL or < cutoff back to QUEUED.
+        override suspend fun reapStuckDownloads(now: Long, cutoff: Long): Int {
+            callLog += "reapStuckDownloads(cutoff=$cutoff)"
+            val stuck = rows.values.filter {
+                it.downloadState == ChapterDownloadState.DOWNLOADING &&
+                    (it.lastDownloadAttemptAt == null || it.lastDownloadAttemptAt < cutoff)
+            }
+            stuck.forEach { r ->
+                rows[r.id] = r.copy(
+                    downloadState = ChapterDownloadState.QUEUED,
+                    lastDownloadAttemptAt = now,
+                    lastDownloadError = "stuck",
+                )
+                publishRow(r.id)
+            }
+            return stuck.size
+        }
+
         override suspend fun setBody(
             id: String,
             html: String,

--- a/core-data/src/test/kotlin/in/jphe/storyvox/data/repository/FictionRepositoryImplTest.kt
+++ b/core-data/src/test/kotlin/in/jphe/storyvox/data/repository/FictionRepositoryImplTest.kt
@@ -284,6 +284,10 @@ class FictionRepositoryImplTest {
             now: Long,
             error: String?,
         ) {}
+
+        // Issue #705 — DAO interface adds a reaper; this test fake
+        // doesn't exercise downloads so a no-op is sufficient.
+        override suspend fun reapStuckDownloads(now: Long, cutoff: Long): Int = 0
         override suspend fun setBody(
             id: String,
             html: String,

--- a/core-sync/src/test/kotlin/in/jphe/storyvox/sync/BookmarksSyncerTest.kt
+++ b/core-sync/src/test/kotlin/in/jphe/storyvox/sync/BookmarksSyncerTest.kt
@@ -168,6 +168,7 @@ class BookmarksSyncerTest {
         override suspend fun deleteByFictionId(fictionId: String) = error("not used")
         override suspend fun insertAll(chapters: List<Chapter>) = error("not used")
         override suspend fun setDownloadState(id: String, state: ChapterDownloadState, now: Long, error: String?) = error("not used")
+        override suspend fun reapStuckDownloads(now: Long, cutoff: Long): Int = error("not used")
         override suspend fun setBody(
             id: String, html: String, plain: String, checksum: String,
             notesAuthor: String?, notesAuthorPosition: String?, now: Long,

--- a/source-epub-writer/src/test/kotlin/in/jphe/storyvox/source/epub/writer/NoopDaos.kt
+++ b/source-epub-writer/src/test/kotlin/in/jphe/storyvox/source/epub/writer/NoopDaos.kt
@@ -65,6 +65,7 @@ internal class NoopChapterDao : ChapterDao {
     override suspend fun deleteByFictionId(fictionId: String) = Unit
     override suspend fun insertAll(chapters: List<Chapter>) = Unit
     override suspend fun setDownloadState(id: String, state: ChapterDownloadState, now: Long, error: String?) = Unit
+    override suspend fun reapStuckDownloads(now: Long, cutoff: Long): Int = 0
     override suspend fun setBody(
         id: String,
         html: String,


### PR DESCRIPTION
## Summary

Closes #705.

- Defensive `try/catch` in `ChapterDownloadWorker.doWork()` — uncaught throwables (parser crashes, OOM, Room constraint violations) flip the row to `FAILED` with a `crash: ClassName` tag and return `Result.retry()` instead of leaving the row stuck at `DOWNLOADING` forever. `CancellationException` is rethrown to preserve coroutines structured concurrency and WorkManager's `stop()` signal.
- Self-healing reaper — new `ChapterDao.reapStuckDownloads(now, cutoff)` query called at the top of every `doWork()` flips `DOWNLOADING` rows older than `STUCK_CUTOFF_MS` (5 min) back to `QUEUED` with a `stuck` tag. Covers the worker-killed-mid-flight case (Android low-memory kill, JobScheduler timeout).

No app-start hook needed — the reaper runs as a side effect of normal download scheduling, so it's idempotent under crash and free when no downloads happen.

## Why both layers

| Failure mode | Caught by |
|---|---|
| Parser throws, worker exits cleanly | try/catch → `FAILED` |
| Process killed mid-`source.chapter()` | next doWork()'s reaper → `QUEUED` |
| WorkManager calls `stop()` mid-flight | `CancellationException` propagates, next reaper rescues |
| RateLimited / NetworkError / Cloudflare | existing `when` branches (unchanged) |

## STUCK_CUTOFF_MS = 5 min

Comfortably above the slowest real `source.chapter()` call (RR cold cache + page-walk parser is < 30s on a bad night), so we never race a still-running download.

## Tests

- `ChapterDaoTest` — four reap scenarios (stuck row → QUEUED, recent row untouched, null timestamp → reaped, non-DOWNLOADING untouched)
- `ChapterRepositoryImplTest` fake DAO mirrors the live SQL semantics
- `FictionRepositoryImplTest`, `BookmarksSyncerTest`, `NoopDaos` — no-op stubs to satisfy the new interface method

Verified locally: `:core-data:compileDebugKotlin`, `:core-data:testDebugUnitTest`, `:core-sync:testDebugUnitTest`, `:source-epub-writer:testDebugUnitTest` all BUILD SUCCESSFUL.

## Test plan

- [ ] Tablet smoke: download a chapter normally → arrives at `DOWNLOADED`
- [ ] Tablet smoke: scheduled download then force-stop app mid-flight, reopen, schedule another → reaper flips the stuck row to `QUEUED` on next worker run
- [ ] Library shows no chapters permanently stuck at "Downloading…" after a crash

🤖 Generated with [Claude Code](https://claude.com/claude-code)