### PR TITLE
fix: Notion pagination + remove stale Discord TODO — #698 #699

### DIFF
--- a/source-discord/src/main/kotlin/in/jphe/storyvox/source/discord/DiscordSource.kt
+++ b/source-discord/src/main/kotlin/in/jphe/storyvox/source/discord/DiscordSource.kt
@@ -132,14 +132,12 @@ internal class DiscordSource @Inject constructor(
         // fictionDetail() / chapter() paths — those are channel-id
         // scoped too, so no extra plumbing is required.
         //
-        // TODO(#517 surface): TechEmpower Home's "Featured guides"
-        // strip in `feature/.../techempower/TechEmpowerHomeScreen.kt`
-        // is hard-coded to Notion-only guide titles today; a follow-up
-        // PR should either add a "Peer-support" strip there or
-        // refactor the strip into a cross-source TechEmpower-featured
-        // iterator that picks up this Discord seed automatically. Not
-        // touched here because sibling agent #516 (Emergency Help
-        // card) is editing the same screen.
+        // The Peer-Support channel is also reachable from
+        // TechEmpowerHomeScreen via the dedicated Discord card (the
+        // paired phone+forum row near the top of the screen). The
+        // Notion-served "Featured guides" strip there stays
+        // Notion-only by design — it advertises the `notion:guides`
+        // PageList fiction specifically, not a cross-source category.
         val pinnedItems: List<FictionSummary> = state.pinnedChannelIds.map { channelId ->
             FictionSummary(
                 id = discordFictionId(channelId),

--- a/source-notion/src/main/kotlin/in/jphe/storyvox/source/notion/net/NotionUnofficialApi.kt
+++ b/source-notion/src/main/kotlin/in/jphe/storyvox/source/notion/net/NotionUnofficialApi.kt
@@ -36,10 +36,12 @@ import kotlin.time.Duration.Companion.seconds
  *  - **POST `/queryCollection`** — list rows of a database. Body wraps
  *    `{collection:{id}, collectionView:{id}, source, loader:{reducer...}}`.
  *    The reducer query is the same shape react-notion-x sends, with
- *    `collection_group_results` capped at 100. Larger collections are
- *    expected to page; for TechEmpower the Resources collection has
- *    ~80 rows so one call covers it. We do not yet stream — first 100
- *    rows is the visible Browse-page surface; pagination is a TODO.
+ *    `collection_group_results` whose `limit` controls the per-call cap.
+ *    The unofficial endpoint reports the full row count under
+ *    `result.reducerResults.collection_group_results.total`; when
+ *    `total > limit` we re-issue the call with `limit = total` (capped
+ *    at [MAX_COLLECTION_ROWS]) so large databases aren't silently
+ *    truncated. Issue #698.
  *
  *  - **POST `/syncRecordValuesMain`** — fetch a specific block by id
  *    (used to resolve a child page when its block payload isn't yet
@@ -102,20 +104,42 @@ internal class NotionUnofficialApi @Inject constructor(
     /**
      * Query a database (collection) for rows. The loader shape is a
      * verbatim port of the body react-notion-x sends — type:"reducer"
-     * with a single `collection_group_results` reducer at limit=100.
-     * We do not surface filters/sort yet; storyvox's Browse paginator
-     * doesn't drive them. TechEmpower's Resources collection currently
-     * has ~80 rows so a single non-paginated call covers everything.
+     * with a single `collection_group_results` reducer.
+     *
+     * Pagination (#698): the unofficial endpoint reports the full row
+     * count under `result.reducerResults.collection_group_results.total`
+     * but caps a single response at the loader's `limit`. We issue the
+     * first call at the caller's [limit]; if the server says there are
+     * more rows than we received, we re-issue with `limit = total`
+     * (capped at [MAX_COLLECTION_ROWS]) so [collectRows] sees the whole
+     * recordMap. One refetch covers any realistic Notion collection;
+     * larger-than-cap collections are truncated to [MAX_COLLECTION_ROWS]
+     * deterministically rather than silently at 100.
      */
     suspend fun queryCollection(
         collectionId: String,
         collectionViewId: String,
         limit: Int = 100,
     ): FictionResult<NotionQueryCollectionResponse> {
+        val first = queryCollectionPage(collectionId, collectionViewId, limit)
+        if (first !is FictionResult.Success) return first
+        val total = first.value.rowsTotal() ?: return first
+        val returned = first.value.rowsReturned()
+        if (total <= returned) return first
+        val widened = total.coerceAtMost(MAX_COLLECTION_ROWS)
+        if (widened <= returned) return first
+        return queryCollectionPage(collectionId, collectionViewId, widened)
+    }
+
+    private suspend fun queryCollectionPage(
+        collectionId: String,
+        collectionViewId: String,
+        limit: Int,
+    ): FictionResult<NotionQueryCollectionResponse> {
         val state = config.current()
         val collId = hyphenatePageId(collectionId)
         val viewId = hyphenatePageId(collectionViewId)
-        val safeLimit = limit.coerceIn(1, 999)
+        val safeLimit = limit.coerceIn(1, MAX_COLLECTION_ROWS)
         val body = buildString {
             append('{')
             append("\"collection\":{\"id\":\"").append(collId).append("\"},")
@@ -288,6 +312,16 @@ internal class NotionUnofficialApi @Inject constructor(
     }
 
     companion object {
+        /**
+         * Upper bound on rows we'll request in a single queryCollection
+         * call when widening for pagination (#698). A collection larger
+         * than this gets truncated deterministically rather than
+         * silently at the default 100. Sized for the largest realistic
+         * Notion database the unofficial endpoint will return without
+         * 5xx-ing; can be raised if a user reports truncation.
+         */
+        internal const val MAX_COLLECTION_ROWS: Int = 5000
+
         /**
          * Notion's unofficial API requires page ids in the hyphenated
          * UUID form (8-4-4-4-12). We accept compact 32-hex or

--- a/source-notion/src/main/kotlin/in/jphe/storyvox/source/notion/net/NotionUnofficialModels.kt
+++ b/source-notion/src/main/kotlin/in/jphe/storyvox/source/notion/net/NotionUnofficialModels.kt
@@ -92,6 +92,14 @@ internal data class NotionChunkResponse(
  * Response shape for `queryCollection`. We pull the row block ids out
  * of `result.reducerResults.collection_group_results.blockIds` and
  * resolve them in `recordMap.block`.
+ *
+ * The `result.reducerResults.collection_group_results.total` field
+ * reports the **full** row count in the collection regardless of the
+ * per-call `limit` cap — we use it to drive pagination
+ * ([rowsTotal]/[rowsReturned] helpers), since the unofficial API
+ * doesn't expose a `has_more`/`next_cursor` token on this endpoint
+ * (it caps a single call's payload and expects callers to widen
+ * `limit` or re-issue).
  */
 @Serializable
 internal data class NotionQueryCollectionResponse(
@@ -99,6 +107,39 @@ internal data class NotionQueryCollectionResponse(
     val recordMap: NotionRecordMap = NotionRecordMap(),
     val allBlockIds: List<String> = emptyList(),
 )
+
+/**
+ * Read the **total** row count the server reports for this collection
+ * out of `result.reducerResults.collection_group_results.total`.
+ * Returns null when the field is missing or non-numeric (older
+ * response shapes, or a reducer envelope we don't recognise).
+ */
+internal fun NotionQueryCollectionResponse.rowsTotal(): Int? {
+    val res = result as? JsonObject ?: return null
+    val reducers = res["reducerResults"] as? JsonObject ?: return null
+    val group = reducers["collection_group_results"] as? JsonObject ?: return null
+    val total = group["total"] as? kotlinx.serialization.json.JsonPrimitive ?: return null
+    return total.content.toIntOrNull()
+}
+
+/**
+ * How many row block ids the server actually returned in
+ * `result.reducerResults.collection_group_results.blockIds`. Counts
+ * only string primitives in the array; non-string entries are skipped
+ * defensively. Returns 0 when the field is missing.
+ */
+internal fun NotionQueryCollectionResponse.rowsReturned(): Int {
+    val res = result as? JsonObject ?: return 0
+    val reducers = res["reducerResults"] as? JsonObject ?: return 0
+    val group = reducers["collection_group_results"] as? JsonObject ?: return 0
+    val ids = group["blockIds"] as? JsonArray ?: return 0
+    var n = 0
+    for (e in ids) {
+        val p = e as? kotlinx.serialization.json.JsonPrimitive ?: continue
+        if (p.isString) n++
+    }
+    return n
+}
 
 /** `getPublicPageData` response. We use [publicAccessRole] /
  *  [requireLogin] as the "is this readable anonymously" probe. */

--- a/source-notion/src/test/kotlin/in/jphe/storyvox/source/notion/NotionUnofficialModelsTest.kt
+++ b/source-notion/src/test/kotlin/in/jphe/storyvox/source/notion/NotionUnofficialModelsTest.kt
@@ -5,9 +5,12 @@ import `in`.jphe.storyvox.source.notion.net.NotionQueryCollectionResponse
 import `in`.jphe.storyvox.source.notion.net.NotionRecordMap
 import `in`.jphe.storyvox.source.notion.net.NotionUnofficialError
 import `in`.jphe.storyvox.source.notion.net.contentIds
+import `in`.jphe.storyvox.source.notion.net.rowsReturned
+import `in`.jphe.storyvox.source.notion.net.rowsTotal
 import kotlinx.serialization.json.Json
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNull
 import org.junit.Assert.assertTrue
 import org.junit.Test
 
@@ -105,6 +108,51 @@ class NotionUnofficialModelsTest {
         val first = parsed.recordMap.findBlock("309a4ee6-9520-817a-aa23-ebc00eebbe32")
         assertNotNull(first)
         assertEquals("GitHub Student Developer Pack", readTitle(first!!))
+    }
+
+    @Test
+    fun `rowsTotal and rowsReturned expose pagination signal from reducer envelope`() {
+        // Issue #698 — server reports `total` separately from the
+        // capped `blockIds` array. The pagination loop in
+        // NotionUnofficialApi.queryCollection keys off both.
+        val raw = """
+        {
+          "result":{
+            "type":"reducer",
+            "reducerResults":{
+              "collection_group_results":{
+                "type":"results",
+                "total":237,
+                "blockIds":["id-a","id-b","id-c"]
+              }
+            },
+            "sizeHint":3
+          },
+          "recordMap":{"__version__":3,"block":{},"collection":{}}
+        }
+        """.trimIndent()
+        val parsed = json.decodeFromString<NotionQueryCollectionResponse>(raw)
+        assertEquals(237, parsed.rowsTotal())
+        assertEquals(3, parsed.rowsReturned())
+    }
+
+    @Test
+    fun `rowsTotal returns null when reducer envelope is missing or malformed`() {
+        // Older / unexpected response shapes — must not throw.
+        val noResult = json.decodeFromString<NotionQueryCollectionResponse>(
+            """{"recordMap":{"__version__":3,"block":{},"collection":{}}}""",
+        )
+        assertNull(noResult.rowsTotal())
+        assertEquals(0, noResult.rowsReturned())
+
+        val resultNoTotal = json.decodeFromString<NotionQueryCollectionResponse>(
+            """
+            {"result":{"reducerResults":{"collection_group_results":{"blockIds":[]}}},
+             "recordMap":{"__version__":3,"block":{},"collection":{}}}
+            """.trimIndent(),
+        )
+        assertNull(resultNoTotal.rowsTotal())
+        assertEquals(0, resultNoTotal.rowsReturned())
     }
 
     @Test


### PR DESCRIPTION
## Summary

Two surgical source-module fixes from the storyvox-dreamteam Argus scout pass.

### Closes #698 — source-notion: queryCollection 100-row cap

The unofficial `/api/v3/queryCollection` endpoint silently truncated large Notion databases at the loader's default `limit=100`. No error, no UX signal — rows just vanished from Browse.

The endpoint exposes the **full** row count under `result.reducerResults.collection_group_results.total` but provides no `has_more`/`next_cursor` token (this is a single-shot reducer call, not a streamed cursor). The fix:

1. Split the single-shot fetch into a private `queryCollectionPage()`.
2. After the first call, read `total` and the actual returned-blockIds count via two new helpers (`rowsTotal()` / `rowsReturned()`) on `NotionQueryCollectionResponse`.
3. If `total > rowsReturned`, re-issue with `limit = total` (capped at `MAX_COLLECTION_ROWS = 5000`) so the returned `recordMap.block` contains every row. `collectRows()` reads the full map without changes.

A larger-than-5000 collection still truncates, but **deterministically and documented**, not silently at 100. Cap can be raised if a user reports truncation.

### Closes #699 — source-discord: stale TODO #517

`DiscordSource.kt:135` had a `TODO(#517 surface)` describing a "Peer-Support strip" follow-up for `TechEmpowerHomeScreen`'s Featured guides surface. Issue #517 closed 2026-05-15 after that follow-up was deliberately not picked up: the Featured guides strip is Notion-only **by design** (it advertises the `notion:guides` PageList fiction specifically), and the Peer-Support channel is already reachable from the dedicated Discord card on the same screen.

Replaced the TODO block with a paragraph documenting **why** the strip stays Notion-scoped so a future reader doesn't propose the same cross-source refactor.

## Test plan

- [x] `./gradlew :source-notion:testDebugUnitTest` passes (new helpers covered with two cases: populated + malformed envelope)
- [x] `./gradlew :source-discord:compileDebugKotlin :source-discord:testDebugUnitTest` passes
- [ ] CI green on PR
- [ ] (No user-facing UX change without a >100-row Notion DB; existing TechEmpower Resources collection (~80 rows) hits the same one-call path)

🤖 Generated with [Claude Code](https://claude.com/claude-code)