### PR TITLE
fix(browse): wire AddByUrlSheet multi-match chooser — closes #700

### DIFF
--- a/feature/src/main/kotlin/in/jphe/storyvox/feature/library/AddByUrlSheet.kt
+++ b/feature/src/main/kotlin/in/jphe/storyvox/feature/library/AddByUrlSheet.kt
@@ -2,17 +2,23 @@ package `in`.jphe.storyvox.feature.library
 
 import android.content.ClipboardManager
 import android.content.Context
+import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.heightIn
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.ModalBottomSheet
 import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.SheetState
+import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.material3.rememberModalBottomSheetState
 import androidx.compose.runtime.Composable
@@ -23,9 +29,15 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.semantics.Role
+import androidx.compose.ui.semantics.contentDescription
+import androidx.compose.ui.semantics.role
+import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.text.input.ImeAction
 import androidx.compose.ui.text.input.KeyboardCapitalization
 import androidx.compose.ui.text.input.KeyboardType
+import androidx.compose.ui.unit.dp
+import `in`.jphe.storyvox.feature.api.UiRouteCandidate
 import `in`.jphe.storyvox.ui.component.BrassButton
 import `in`.jphe.storyvox.ui.component.BrassButtonVariant
 import `in`.jphe.storyvox.ui.theme.LocalSpacing
@@ -39,6 +51,12 @@ import `in`.jphe.storyvox.ui.theme.LocalSpacing
  * clipboard (single-tap fill from a copied URL), Add button submits.
  * The error string from the viewmodel surfaces inline below the field
  * so the user can correct without losing what they typed.
+ *
+ * Issue #700 — when the resolver returns multiple chooser-eligible
+ * candidates, the sheet swaps to a picker row listing each backend so
+ * the user disambiguates. The picker re-submits via [onChooseSource]
+ * with the user's pick; [onCancelChoose] returns to the editable
+ * input.
  */
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
@@ -46,6 +64,8 @@ fun AddByUrlSheet(
     state: AddByUrlSheetState,
     onSubmit: (String) -> Unit,
     onDismiss: () -> Unit,
+    onChooseSource: (String) -> Unit = {},
+    onCancelChoose: () -> Unit = {},
 ) {
     if (state === AddByUrlSheetState.Hidden) return
 
@@ -56,6 +76,7 @@ fun AddByUrlSheet(
 
     val error: String? = (state as? AddByUrlSheetState.Open)?.error
     val isSubmitting = state === AddByUrlSheetState.Submitting
+    val chooser = state as? AddByUrlSheetState.ChooseSource
 
     ModalBottomSheet(
         onDismissRequest = { if (!isSubmitting) onDismiss() },
@@ -68,82 +89,182 @@ fun AddByUrlSheet(
                 .padding(bottom = spacing.xl),
             verticalArrangement = Arrangement.spacedBy(spacing.sm),
         ) {
+            if (chooser != null) {
+                ChooseSourceBody(
+                    url = chooser.url,
+                    candidates = chooser.candidates,
+                    onPick = onChooseSource,
+                    onCancel = onCancelChoose,
+                )
+            } else {
+                Text(
+                    "Add by URL",
+                    style = MaterialTheme.typography.titleLarge,
+                    modifier = Modifier.padding(top = spacing.sm),
+                )
+                // Issue #446 — copy used to read "Paste a Royal Road
+                // fiction or chapter URL", which implied RR was the only
+                // accepted source. Generalised once #472 added the
+                // magic-link catch-alls; #700 wires the multi-match
+                // chooser on top of that plumbing.
+                Text(
+                    "Paste a fiction URL — we'll auto-detect the source.",
+                    style = MaterialTheme.typography.bodyMedium,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                )
+                Text(
+                    "Supported: Royal Road · AO3 · GitHub · Gutenberg · arXiv · " +
+                        "RSS · Wikipedia · direct EPUB",
+                    style = MaterialTheme.typography.labelSmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                )
+
+                OutlinedTextField(
+                    value = input,
+                    onValueChange = { input = it },
+                    label = { Text("URL") },
+                    placeholder = { Text("https://…") },
+                    isError = error != null,
+                    singleLine = true,
+                    enabled = !isSubmitting,
+                    keyboardOptions = KeyboardOptions(
+                        keyboardType = KeyboardType.Uri,
+                        imeAction = ImeAction.Done,
+                        capitalization = KeyboardCapitalization.None,
+                        autoCorrectEnabled = false,
+                    ),
+                    modifier = Modifier.fillMaxWidth(),
+                )
+
+                if (error != null) {
+                    Text(
+                        error,
+                        style = MaterialTheme.typography.bodySmall,
+                        color = MaterialTheme.colorScheme.error,
+                    )
+                }
+
+                Row(
+                    modifier = Modifier.fillMaxWidth(),
+                    horizontalArrangement = Arrangement.spacedBy(spacing.sm),
+                    verticalAlignment = Alignment.CenterVertically,
+                ) {
+                    BrassButton(
+                        label = "Paste",
+                        onClick = {
+                            readClipboardText(context)?.let { clip ->
+                                if (clip.isNotBlank()) input = clip
+                            }
+                        },
+                        variant = BrassButtonVariant.Secondary,
+                        enabled = !isSubmitting,
+                    )
+                    BrassButton(
+                        label = if (isSubmitting) "Adding…" else "Add",
+                        onClick = { onSubmit(input.trim()) },
+                        variant = BrassButtonVariant.Primary,
+                        enabled = !isSubmitting && input.isNotBlank(),
+                        loading = isSubmitting,
+                    )
+                }
+            }
+        }
+    }
+}
+
+/**
+ * Issue #700 — picker body shown when [AddByUrlSheetState.ChooseSource]
+ * is the active state. Lists each candidate as a tappable row
+ * (label + sourceId chip), with a Cancel button that returns the user
+ * to the editable input. The list is intentionally a plain
+ * [LazyColumn] capped at a sensible height so a pathological 10+
+ * candidate resolution still scrolls inside the sheet instead of
+ * exploding past the screen.
+ */
+@Composable
+private fun ChooseSourceBody(
+    url: String,
+    candidates: List<UiRouteCandidate>,
+    onPick: (String) -> Unit,
+    onCancel: () -> Unit,
+) {
+    val spacing = LocalSpacing.current
+    Text(
+        "Where do you want to add this from?",
+        style = MaterialTheme.typography.titleLarge,
+        modifier = Modifier.padding(top = spacing.sm),
+    )
+    Text(
+        "Several sources can handle this URL. Pick the one that fits best.",
+        style = MaterialTheme.typography.bodyMedium,
+        color = MaterialTheme.colorScheme.onSurfaceVariant,
+    )
+    Text(
+        url,
+        style = MaterialTheme.typography.labelSmall,
+        color = MaterialTheme.colorScheme.onSurfaceVariant,
+        maxLines = 2,
+    )
+
+    LazyColumn(
+        modifier = Modifier
+            .fillMaxWidth()
+            .heightIn(max = 320.dp),
+        verticalArrangement = Arrangement.spacedBy(spacing.xs),
+    ) {
+        items(
+            items = candidates,
+            key = { it.sourceId + "/" + it.fictionId },
+        ) { candidate ->
+            CandidateRow(candidate = candidate, onPick = onPick)
+        }
+    }
+
+    Row(
+        modifier = Modifier.fillMaxWidth().padding(top = spacing.sm),
+        horizontalArrangement = Arrangement.spacedBy(spacing.sm),
+    ) {
+        BrassButton(
+            label = "Back",
+            onClick = onCancel,
+            variant = BrassButtonVariant.Secondary,
+        )
+    }
+}
+
+@Composable
+private fun CandidateRow(
+    candidate: UiRouteCandidate,
+    onPick: (String) -> Unit,
+) {
+    val spacing = LocalSpacing.current
+    Surface(
+        shape = RoundedCornerShape(12.dp),
+        color = MaterialTheme.colorScheme.surfaceVariant,
+        modifier = Modifier
+            .fillMaxWidth()
+            .clickable { onPick(candidate.sourceId) }
+            .semantics {
+                role = Role.Button
+                contentDescription = "Add from ${candidate.label}"
+            },
+    ) {
+        Column(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(horizontal = spacing.md, vertical = spacing.sm),
+            verticalArrangement = Arrangement.spacedBy(spacing.xs),
+        ) {
             Text(
-                "Add by URL",
-                style = MaterialTheme.typography.titleLarge,
-                modifier = Modifier.padding(top = spacing.sm),
-            )
-            // Issue #446 — copy used to read "Paste a Royal Road
-            // fiction or chapter URL", which implied RR was the only
-            // accepted source. The URL router resolves Royal Road +
-            // GitHub today and the parallel magic-link work (#472)
-            // adds AO3 / Gutenberg / arXiv / RSS / Wikipedia / Plos /
-            // Wikisource / Standard Ebooks / a Readability catch-all.
-            // Generalize the hint so any pasted URL feels welcome; the
-            // detection-failure message handles the unrecognised case.
-            // TODO(#472): the magic-link agent owns the multi-match
-            // chooser UI that will replace this single-string entry
-            // point; once that lands, this sheet either gets replaced
-            // wholesale or grows a candidate-preview row.
-            Text(
-                "Paste a fiction URL — we'll auto-detect the source.",
-                style = MaterialTheme.typography.bodyMedium,
+                candidate.label,
+                style = MaterialTheme.typography.titleMedium,
                 color = MaterialTheme.colorScheme.onSurfaceVariant,
             )
             Text(
-                "Supported: Royal Road · AO3 · GitHub · Gutenberg · arXiv · " +
-                    "RSS · Wikipedia · direct EPUB",
+                candidate.sourceId,
                 style = MaterialTheme.typography.labelSmall,
                 color = MaterialTheme.colorScheme.onSurfaceVariant,
             )
-
-            OutlinedTextField(
-                value = input,
-                onValueChange = { input = it },
-                label = { Text("URL") },
-                placeholder = { Text("https://…") },
-                isError = error != null,
-                singleLine = true,
-                enabled = !isSubmitting,
-                keyboardOptions = KeyboardOptions(
-                    keyboardType = KeyboardType.Uri,
-                    imeAction = ImeAction.Done,
-                    capitalization = KeyboardCapitalization.None,
-                    autoCorrectEnabled = false,
-                ),
-                modifier = Modifier.fillMaxWidth(),
-            )
-
-            if (error != null) {
-                Text(
-                    error,
-                    style = MaterialTheme.typography.bodySmall,
-                    color = MaterialTheme.colorScheme.error,
-                )
-            }
-
-            Row(
-                modifier = Modifier.fillMaxWidth(),
-                horizontalArrangement = Arrangement.spacedBy(spacing.sm),
-                verticalAlignment = Alignment.CenterVertically,
-            ) {
-                BrassButton(
-                    label = "Paste",
-                    onClick = {
-                        readClipboardText(context)?.let { clip ->
-                            if (clip.isNotBlank()) input = clip
-                        }
-                    },
-                    variant = BrassButtonVariant.Secondary,
-                    enabled = !isSubmitting,
-                )
-                BrassButton(
-                    label = if (isSubmitting) "Adding…" else "Add",
-                    onClick = { onSubmit(input.trim()) },
-                    variant = BrassButtonVariant.Primary,
-                    enabled = !isSubmitting && input.isNotBlank(),
-                )
-            }
         }
     }
 }

--- a/feature/src/main/kotlin/in/jphe/storyvox/feature/library/LibraryScreen.kt
+++ b/feature/src/main/kotlin/in/jphe/storyvox/feature/library/LibraryScreen.kt
@@ -399,6 +399,8 @@ fun LibraryScreen(
         state = addByUrlState,
         onSubmit = viewModel::submitAddByUrl,
         onDismiss = viewModel::dismissAddByUrl,
+        onChooseSource = viewModel::chooseSource,
+        onCancelChoose = viewModel::cancelChooseSource,
     )
 
     ManageShelvesSheet(

--- a/feature/src/main/kotlin/in/jphe/storyvox/feature/library/LibraryViewModel.kt
+++ b/feature/src/main/kotlin/in/jphe/storyvox/feature/library/LibraryViewModel.kt
@@ -19,6 +19,7 @@ import `in`.jphe.storyvox.feature.api.DownloadMode
 import `in`.jphe.storyvox.feature.api.FictionRepositoryUi
 import `in`.jphe.storyvox.feature.api.PlaybackControllerUi
 import `in`.jphe.storyvox.feature.api.UiAddByUrlResult
+import `in`.jphe.storyvox.feature.api.UiRouteCandidate
 import javax.inject.Inject
 import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -167,6 +168,19 @@ sealed interface AddByUrlSheetState {
 
     /** Submission in flight (network call to the source). */
     data object Submitting : AddByUrlSheetState
+
+    /**
+     * Issue #700 — magic-link resolver returned several
+     * chooser-eligible candidates for the pasted [url]. Sheet shows a
+     * picker so the user selects which backend to route to; tapping a
+     * row re-submits via [LibraryViewModel.chooseSource] with the
+     * picked sourceId. Cancel (back / dismiss) returns the sheet to
+     * [Open] with the original input so the user can edit and retry.
+     */
+    data class ChooseSource(
+        val url: String,
+        val candidates: List<UiRouteCandidate>,
+    ) : AddByUrlSheetState
 }
 
 @HiltViewModel
@@ -392,6 +406,32 @@ class LibraryViewModel @Inject constructor(
         _addByUrlState.value = AddByUrlSheetState.Hidden
     }
 
+    /**
+     * Issue #700 — user picked a backend from the multi-match chooser.
+     * Re-submits the original URL with [sourceId] as the preferred
+     * source so [FictionRepository.addByUrl] bypasses the resolver and
+     * routes straight to that backend. A no-op if the sheet isn't in
+     * [AddByUrlSheetState.ChooseSource] (defensive — the picker can
+     * only fire while that state is live, but recompositions during
+     * dismissal can race).
+     */
+    fun chooseSource(sourceId: String) {
+        val current = _addByUrlState.value as? AddByUrlSheetState.ChooseSource ?: return
+        submitAddByUrl(current.url, preferredSourceId = sourceId)
+    }
+
+    /**
+     * Issue #700 — back-out of the chooser without picking. Returns the
+     * sheet to the editable [AddByUrlSheetState.Open] state so the user
+     * can amend the URL and resubmit; a no-op when the sheet isn't
+     * showing the chooser.
+     */
+    fun cancelChooseSource() {
+        if (_addByUrlState.value is AddByUrlSheetState.ChooseSource) {
+            _addByUrlState.value = AddByUrlSheetState.Open()
+        }
+    }
+
     fun submitAddByUrl(url: String, preferredSourceId: String? = null) {
         if (_addByUrlState.value === AddByUrlSheetState.Submitting) return
         // Issue #584 — reject non-http(s) schemes before hitting the
@@ -432,18 +472,23 @@ class LibraryViewModel @Inject constructor(
                     )
                 }
                 is UiAddByUrlResult.MultipleMatches -> {
-                    // Issue #472 — v1 picks the top candidate
-                    // automatically. The chooser-modal UX is wired in
-                    // LibraryViewModel.Chooser state (see follow-up
-                    // PR) so the user can override; v1's resolver
-                    // already disambiguates most paste scenarios via
-                    // the dominance threshold in FictionRepositoryImpl.
-                    val top = result.candidates.firstOrNull()
-                    if (top != null) {
-                        submitAddByUrl(trimmed, preferredSourceId = top.sourceId)
-                    } else {
+                    // Issue #700 — surface the chooser UI rather than
+                    // silently auto-picking. The resolver already
+                    // dominance-collapses obvious wins
+                    // (FictionRepositoryImpl.maybeMultipleMatchesOr);
+                    // anything that reaches here is genuinely
+                    // ambiguous and the user gets to decide. An empty
+                    // candidate list shouldn't normally arrive — the
+                    // repository only emits MultipleMatches when there
+                    // are ≥2 — but we still degrade gracefully.
+                    if (result.candidates.isEmpty()) {
                         _addByUrlState.value = AddByUrlSheetState.Open(
                             error = "Could not pick a backend for that URL.",
+                        )
+                    } else {
+                        _addByUrlState.value = AddByUrlSheetState.ChooseSource(
+                            url = trimmed,
+                            candidates = result.candidates,
                         )
                     }
                 }

--- a/feature/src/test/kotlin/in/jphe/storyvox/feature/library/AddByUrlSheetStateTest.kt
+++ b/feature/src/test/kotlin/in/jphe/storyvox/feature/library/AddByUrlSheetStateTest.kt
@@ -1,0 +1,81 @@
+package `in`.jphe.storyvox.feature.library
+
+import `in`.jphe.storyvox.feature.api.UiRouteCandidate
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotEquals
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * Issue #700 — pin the shape of [AddByUrlSheetState] so the magic-link
+ * multi-match flow (pre-fix the chooser was a stub kdoc TODO) keeps
+ * carrying the URL and the candidate list together. The renderer in
+ * [AddByUrlSheet] keys off this state and re-submits via
+ * [LibraryViewModel.chooseSource]; both sides depend on the data
+ * surviving the [AddByUrlSheetState.Submitting] → ChooseSource
+ * transition.
+ *
+ * State-only test on purpose — full
+ * [LibraryViewModel.submitAddByUrl] coverage would require building 8
+ * fakes (Fiction/Shelf/History/Inbox/Position repos + PlaybackUi +
+ * ResumePolicy + FictionRepositoryUi). The state shape is the contract
+ * the chooser UX depends on.
+ */
+class AddByUrlSheetStateTest {
+
+    @Test
+    fun `Hidden is a singleton`() {
+        assertTrue(AddByUrlSheetState.Hidden === AddByUrlSheetState.Hidden)
+    }
+
+    @Test
+    fun `Open carries an optional error`() {
+        val fresh = AddByUrlSheetState.Open()
+        assertNull(fresh.error)
+
+        val failed = AddByUrlSheetState.Open(error = "bad URL")
+        assertEquals("bad URL", failed.error)
+    }
+
+    @Test
+    fun `ChooseSource carries url and candidates`() {
+        val candidates = listOf(
+            UiRouteCandidate(
+                sourceId = "github",
+                fictionId = "github:owner/repo",
+                confidence = 1.0f,
+                label = "GitHub repo",
+            ),
+            UiRouteCandidate(
+                sourceId = "readability",
+                fictionId = "readability:abc123",
+                confidence = 0.1f,
+                label = "Web article (readability)",
+            ),
+        )
+        val state = AddByUrlSheetState.ChooseSource(
+            url = "https://github.com/owner/repo",
+            candidates = candidates,
+        )
+
+        assertEquals("https://github.com/owner/repo", state.url)
+        assertEquals(2, state.candidates.size)
+        assertEquals("github", state.candidates.first().sourceId)
+    }
+
+    @Test
+    fun `ChooseSource is not the same as Open or Submitting`() {
+        // Pre-#700 the multi-match branch fell through to Submitting
+        // (auto-resubmit with top candidate). The chooser branch must
+        // be a distinct state so the renderer can switch UI bodies
+        // without leaning on an out-of-band flag.
+        val choosing: AddByUrlSheetState = AddByUrlSheetState.ChooseSource(
+            url = "x",
+            candidates = emptyList(),
+        )
+        assertNotEquals(AddByUrlSheetState.Submitting as Any, choosing as Any)
+        assertNotEquals(AddByUrlSheetState.Open() as Any, choosing as Any)
+        assertNotEquals(AddByUrlSheetState.Hidden as Any, choosing as Any)
+    }
+}


### PR DESCRIPTION
## Summary

Pre-fix, the `LibraryViewModel.MultipleMatches` branch silently auto-picked the top-confidence candidate from the magic-link resolver — contradicting the kdoc in `AddByUrlSheet.kt:84` that promised a chooser UX. When a pasted URL was claimed by two or more backends (e.g. a `github.com` URL that the Readability catch-all also matches), the user got no choice. Closes #700.

The fix wires the chooser as a third sheet state, `AddByUrlSheetState.ChooseSource(url, candidates)`. When `addByUrl(url)` returns `MultipleMatches`, the ViewModel now publishes the chooser state instead of auto-resubmitting. The sheet swaps into a picker body listing each candidate with its `label` + `sourceId`; tapping a row calls `viewModel.chooseSource(sourceId)`, which re-submits via `submitAddByUrl(url, preferredSourceId = sourceId)` so the repository bypasses the resolver and routes straight to the user's pick. A Back button returns the sheet to the editable `Open` state without losing the URL.

The resolver still collapses dominance-eligible wins inside `FictionRepositoryImpl.maybeMultipleMatchesOr`, so the chooser only fires on genuinely ambiguous URLs.

### Files touched

- `feature/src/main/kotlin/in/jphe/storyvox/feature/library/LibraryViewModel.kt` — new `ChooseSource` state, `chooseSource(sourceId)` and `cancelChooseSource()` methods, `MultipleMatches` branch rewritten.
- `feature/src/main/kotlin/in/jphe/storyvox/feature/library/AddByUrlSheet.kt` — picker body + candidate row, `onChooseSource` / `onCancelChoose` callbacks (defaulted so other call sites need no change).
- `feature/src/main/kotlin/in/jphe/storyvox/feature/library/LibraryScreen.kt` — wires the new callbacks through to the ViewModel.
- `feature/src/test/kotlin/in/jphe/storyvox/feature/library/AddByUrlSheetStateTest.kt` — pins the `ChooseSource` state shape (state-only test; full VM coverage would need 8 fakes for unrelated repos).

## Test plan

- [x] `./gradlew :feature:testDebugUnitTest` — all feature tests pass (including the new `AddByUrlSheetStateTest`).
- [x] `./gradlew :app:compileDebugKotlin` — app module still compiles.
- [ ] Manual on R83W80CAFZB: paste an ambiguous URL (e.g. `https://github.com/jphein/storyvox`) into the Library Add-by-URL sheet, verify chooser appears with multiple backend rows, tap one, verify the picked backend's detail screen opens.
- [ ] Manual: tap Back from the chooser, verify the sheet returns to the editable URL input with no error.