### PR TITLE
fix(settings): route Azure CTA to Cloud Voices subscreen + pin remaining routes

### DIFF
--- a/app/src/main/kotlin/in/jphe/storyvox/navigation/StoryvoxNavHost.kt
+++ b/app/src/main/kotlin/in/jphe/storyvox/navigation/StoryvoxNavHost.kt
@@ -47,6 +47,7 @@ import `in`.jphe.storyvox.feature.settings.AccountSettingsScreen
 import `in`.jphe.storyvox.feature.settings.AdvancedSettingsScreen
 import `in`.jphe.storyvox.feature.settings.AppearanceSettingsScreen
 import `in`.jphe.storyvox.feature.settings.AiSettingsScreen
+import `in`.jphe.storyvox.feature.settings.CloudVoicesSettingsScreen
 import `in`.jphe.storyvox.feature.settings.MemoryPalaceSettingsScreen
 import `in`.jphe.storyvox.feature.settings.PerformanceSettingsScreen
 import `in`.jphe.storyvox.feature.settings.ReadingSettingsScreen
@@ -123,6 +124,13 @@ object StoryvoxRoutes {
     /** Settings → Advanced (v1 settings-bundle-7). Power-user knobs:
      *  Android Auto bucket size (#598) and future integration tunables. */
     const val SETTINGS_ADVANCED = "settings/advanced"
+    /** Settings → Cloud Voices (#712, follow-up to #404 + #702). Dedicated
+     *  destination for the Azure Speech BYOK key + region + test-connection
+     *  flow that previously dumped the user onto the 3,600-line legacy
+     *  [SETTINGS] long-scroll page when they tapped "configure" on the
+     *  Azure plugin row. Hosts the same [AzureSection] composable as the
+     *  legacy page, so the two surfaces stay byte-identical. */
+    const val SETTINGS_CLOUD_VOICES = "settings/cloud-voices"
     /** Settings → Account. Royal Road sign-in, GitHub OAuth + scope. */
     const val SETTINGS_ACCOUNT = "settings/account"
     /** Settings → Memory Palace. Daemon host, API key, test probe. */
@@ -930,13 +938,14 @@ private fun StoryvoxNavHostContent(
                 `in`.jphe.storyvox.feature.settings.plugins.PluginManagerScreen(
                     onNavigateBack = { navController.popBackStack() },
                     // #501 — Voice bundles section deep-links into the
-                    // Voice Library for per-family voice management and
-                    // into the long-scroll Settings for Azure BYOK key
-                    // entry. The long-scroll page anchors the Azure
-                    // card; a future dedicated Settings → Cloud Voices
-                    // subscreen would replace this target.
+                    // Voice Library for per-family voice management.
+                    // Issue #712 (follow-up to #702) — the "configure
+                    // Azure" CTA on the Azure plugin row now lands on
+                    // the dedicated [SETTINGS_CLOUD_VOICES] subscreen
+                    // instead of dumping the user onto the legacy
+                    // long-scroll page.
                     onOpenVoiceLibrary = { navController.navigate(StoryvoxRoutes.VOICE_LIBRARY) },
-                    onOpenAzureSettings = { navController.navigate(StoryvoxRoutes.SETTINGS) },
+                    onOpenAzureSettings = { navController.navigate(StoryvoxRoutes.SETTINGS_CLOUD_VOICES) },
                 )
             }
             composable(
@@ -1067,6 +1076,24 @@ private fun StoryvoxNavHostContent(
                 popExitTransition = popExit,
             ) {
                 AdvancedSettingsScreen(
+                    onBack = { navController.popBackStack() },
+                )
+            }
+            // Issue #712 (follow-up to #404 + #702) — Cloud Voices
+            // subscreen. Azure BYOK key + region + test-connection +
+            // offline-fallback toggle, hosted in the same [AzureSection]
+            // composable the legacy long-scroll page uses, so the two
+            // surfaces stay byte-identical. Reached from the Plugin
+            // Manager's Azure row "configure" CTA; previously that tap
+            // dumped users onto the legacy page (#712).
+            composable(
+                StoryvoxRoutes.SETTINGS_CLOUD_VOICES,
+                enterTransition = pushEnter,
+                exitTransition = pushExit,
+                popEnterTransition = popEnter,
+                popExitTransition = popExit,
+            ) {
+                CloudVoicesSettingsScreen(
                     onBack = { navController.popBackStack() },
                 )
             }

--- a/app/src/test/kotlin/in/jphe/storyvox/navigation/SettingsSubscreenRoutesTest.kt
+++ b/app/src/test/kotlin/in/jphe/storyvox/navigation/SettingsSubscreenRoutesTest.kt
@@ -7,8 +7,9 @@ import org.junit.Assert.fail
 import org.junit.Test
 
 /**
- * Follow-up to #440 / #467 — pins the seven new subscreen route
- * constants and the rules they collectively follow:
+ * Follow-up to #440 / #467 — pins the new subscreen route constants
+ * added when the hub was wired up and the rules they collectively
+ * follow:
  *
  *  - Every settings subscreen route starts with `settings/`. The
  *    NavHost routing them is prefix-agnostic, but the prefix is a
@@ -20,6 +21,11 @@ import org.junit.Test
  *  - The legacy [StoryvoxRoutes.SETTINGS] page is preserved as an
  *    "All settings" escape hatch and stays reachable. The hub's
  *    "All settings" row routes there explicitly.
+ *
+ * Issue #713 — list grew from seven to eleven as later subscreens
+ * landed (Accessibility v0.5.42, Appearance v0.5.59, Advanced v1
+ * settings-bundle-7, Cloud Voices #712). The route constants existed
+ * but weren't pinned, leaving renames / alias-collisions undetected.
  */
 class SettingsSubscreenRoutesTest {
 
@@ -31,11 +37,17 @@ class SettingsSubscreenRoutesTest {
         StoryvoxRoutes.SETTINGS_ACCOUNT,
         StoryvoxRoutes.SETTINGS_MEMORY_PALACE,
         StoryvoxRoutes.SETTINGS_ABOUT,
+        // Issue #713 — added below after the original seven.
+        StoryvoxRoutes.SETTINGS_ACCESSIBILITY,
+        StoryvoxRoutes.SETTINGS_APPEARANCE,
+        StoryvoxRoutes.SETTINGS_ADVANCED,
+        // Issue #712 — Cloud Voices subscreen for Azure BYOK config.
+        StoryvoxRoutes.SETTINGS_CLOUD_VOICES,
     )
 
     @Test
-    fun `seven new subscreen routes are declared`() {
-        assertEquals(7, newRoutes.size)
+    fun `all hub-follow-up subscreen routes are declared`() {
+        assertEquals(11, newRoutes.size)
     }
 
     @Test
@@ -121,6 +133,35 @@ class SettingsSubscreenRoutesTest {
             "onOpenAiSettings must land on SETTINGS_AI, not the legacy long-scroll page. " +
                 "Offending targets: $nonAiTargets",
             nonAiTargets.isEmpty(),
+        )
+    }
+
+    /**
+     * Issue #712 follow-up — same regression net as the
+     * `onOpenAiSettings` pin above, but for the PluginManager's Azure
+     * BYOK "configure" CTA. Before #712, the lone NavHost call site
+     * for `onOpenAzureSettings` routed to the legacy long-scroll page;
+     * the fix routes it to the dedicated [SETTINGS_CLOUD_VOICES]
+     * subscreen.
+     */
+    @Test
+    fun `every onOpenAzureSettings call site routes to the dedicated Cloud Voices subscreen`() {
+        val navHost = locateNavHostSource()
+        val src = navHost.readText()
+        val callSiteRegex = Regex(
+            """onOpenAzureSettings\s*=\s*\{\s*navController\.navigate\(StoryvoxRoutes\.([A-Z_]+)\)""",
+        )
+        val matches = callSiteRegex.findAll(src).map { it.groupValues[1] }.toList()
+        assertTrue(
+            "Expected at least one onOpenAzureSettings = { navController.navigate(...) } " +
+                "call site in StoryvoxNavHost.kt — did the file move?",
+            matches.isNotEmpty(),
+        )
+        val nonCloudVoicesTargets = matches.filter { it != "SETTINGS_CLOUD_VOICES" }
+        assertTrue(
+            "onOpenAzureSettings must land on SETTINGS_CLOUD_VOICES, not the legacy long-scroll page. " +
+                "Offending targets: $nonCloudVoicesTargets",
+            nonCloudVoicesTargets.isEmpty(),
         )
     }
 

--- a/feature/src/main/kotlin/in/jphe/storyvox/feature/settings/CloudVoicesSettingsScreen.kt
+++ b/feature/src/main/kotlin/in/jphe/storyvox/feature/settings/CloudVoicesSettingsScreen.kt
@@ -1,0 +1,64 @@
+package `in`.jphe.storyvox.feature.settings
+
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.padding
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Modifier
+import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import `in`.jphe.storyvox.ui.theme.LocalSpacing
+
+/**
+ * Settings → Cloud Voices subscreen (#712, follow-up to #440 / #467 /
+ * #702).
+ *
+ * Hosts the Azure BYOK key / region / test-connection trio plus the
+ * offline-fallback toggle inside the shared [AzureSection] composable.
+ * Reached from the PluginManagerScreen's Azure plugin row "configure"
+ * CTA — before this screen existed, that tap dumped the user onto the
+ * 3,600-line legacy [SettingsScreen] long-scroll page, mirroring the
+ * #704 bug pattern that #702 fixed for `onOpenAiSettings`.
+ *
+ * Same lean-screen pattern as [MemoryPalaceSettingsScreen]: shared
+ * Hilt-injected [SettingsViewModel], the section composable itself
+ * lives in [SettingsScreen.kt] and is reused verbatim so the legacy
+ * long-scroll page and this focused subscreen stay byte-identical.
+ *
+ * Phase 3 / Plugin manager (#404) wired the Azure plugin row's
+ * configure action to `onOpenAzureSettings`; this screen is its
+ * destination.
+ */
+@Composable
+fun CloudVoicesSettingsScreen(
+    onBack: () -> Unit,
+    viewModel: SettingsViewModel = hiltViewModel(),
+) {
+    val state by viewModel.uiState.collectAsStateWithLifecycle()
+    val spacing = LocalSpacing.current
+
+    SettingsSubscreenScaffold(title = "Cloud voices", onBack = onBack) { padding ->
+        val s = state.settings ?: run {
+            SettingsSkeleton(modifier = Modifier.fillMaxSize().padding(padding).padding(spacing.md))
+            return@SettingsSubscreenScaffold
+        }
+        SettingsSubscreenBody(padding) {
+            SettingsGroupCard {
+                AzureSection(
+                    azure = s.azure,
+                    probe = state.azureProbe,
+                    probing = state.azureProbing,
+                    onSetKey = viewModel::setAzureKey,
+                    onSetRegion = viewModel::setAzureRegion,
+                    onClear = viewModel::clearAzureCredentials,
+                    onTest = viewModel::testAzureConnection,
+                    fallbackEnabled = s.azureFallbackEnabled,
+                    fallbackVoiceId = s.azureFallbackVoiceId,
+                    installedVoices = state.voices,
+                    onSetFallbackEnabled = viewModel::setAzureFallbackEnabled,
+                    onSetFallbackVoice = viewModel::setAzureFallbackVoiceId,
+                )
+            }
+        }
+    }
+}

--- a/feature/src/main/kotlin/in/jphe/storyvox/feature/settings/SettingsScreen.kt
+++ b/feature/src/main/kotlin/in/jphe/storyvox/feature/settings/SettingsScreen.kt
@@ -1045,7 +1045,7 @@ internal fun MemoryPalaceSection(
  */
 @OptIn(ExperimentalLayoutApi::class)
 @Composable
-private fun AzureSection(
+internal fun AzureSection(
     azure: UiAzureConfig,
     probe: AzureProbeResult?,
     probing: Boolean,


### PR DESCRIPTION
Closes #712, #713.

Two related settings-navigation fixes, kept in one PR because #713's regression net covers #712's fix shape.

## #712 — Azure BYOK CTA falls through to legacy page

`PluginManagerScreen` Azure-row "configure" CTA previously routed to `StoryvoxRoutes.SETTINGS`, dumping users onto the 3,600-line legacy long-scroll page. Same fall-through pattern #702 fixed for `onOpenAiSettings`; PR #702's audit explicitly flagged this as out of scope because no dedicated Azure subscreen existed.

This PR builds it, mirroring the lean-screen pattern from `MemoryPalaceSettingsScreen` / `AccountSettingsScreen`:

- New `CloudVoicesSettingsScreen` composable hosts the existing `AzureSection` (key + region + test-connection + offline fallback) so the focused subscreen and the legacy page stay byte-identical.
- `AzureSection` visibility relaxed from `private` to `internal` so the new screen can reuse it (`MemoryPalaceSection` is `internal` for the same reason).
- New route constant `StoryvoxRoutes.SETTINGS_CLOUD_VOICES = "settings/cloud-voices"`.
- NavHost composable registered with push enter/exit (drill-down from the Plugin Manager).
- Call site at `StoryvoxNavHost.kt:948` rewritten to navigate to the new route. Stale "future-state target" kdoc paragraph replaced with a #712 fix-shipped note.

## #713 — SettingsSubscreenRoutesTest missing routes

The contract test pinned only the original seven hub follow-up routes. Four more landed after but were never added: `SETTINGS_ACCESSIBILITY` (v0.5.42), `SETTINGS_APPEARANCE` (v0.5.59), `SETTINGS_ADVANCED` (v1 settings-bundle-7), and `SETTINGS_CLOUD_VOICES` (this PR).

- `newRoutes` grows from 7 to 11. New entries grouped with their issue tags.
- `seven new subscreen routes are declared` renamed to `all hub-follow-up subscreen routes are declared`, bumped to expect 11.
- Adds an `onOpenAzureSettings` regression pin mirroring the existing `onOpenAiSettings` pin from #702. Scans NavHost source textually and asserts every call site lands on `SETTINGS_CLOUD_VOICES`.
- Prefix / uniqueness / non-collision tests pick up the new entries automatically because they iterate over `newRoutes`.

## Verification

- `./gradlew :feature:compileDebugKotlin :app:compileDebugKotlin` — clean (one pre-existing `Divider` deprecation warning, unrelated).
- `./gradlew :app:testDebugUnitTest --tests "in.jphe.storyvox.navigation.SettingsSubscreenRoutesTest"` — 8/8 green.
- Negative-case check: reverted the `onOpenAzureSettings` fix, the new test fails with `Offending targets: [SETTINGS]`, restored the fix.

## Test plan

- [ ] Open Settings hub → Plugins → tap configure on the Azure family row → confirms it lands on the Cloud Voices subscreen with the key / region / test-connection / offline-fallback fields visible (not the long-scroll legacy page).
- [ ] Back arrow from Cloud Voices returns to the Plugin Manager card list.
- [ ] Verify the "All settings" escape hatch on the hub still works and shows the Azure section in its original location on the legacy page (the section composable is shared, so any change to one surface reflects in both).