### PR TITLE
fix: Gutenberg fictionId validation + Room downgrade survival — closes #718, #721

### DIFF
--- a/core-data/src/main/kotlin/in/jphe/storyvox/data/di/DataModule.kt
+++ b/core-data/src/main/kotlin/in/jphe/storyvox/data/di/DataModule.kt
@@ -66,6 +66,28 @@ object DataModule {
     fun provideDb(@ApplicationContext ctx: Context): StoryvoxDatabase =
         Room.databaseBuilder(ctx, StoryvoxDatabase::class.java, StoryvoxDatabase.NAME)
             .addMigrations(*ALL_MIGRATIONS)
+            // Issue #721 — survive APK downgrade (newer install → older
+            // install) by wiping the DB instead of crashing. ALL_MIGRATIONS
+            // covers v1→v9 forward only; Room doesn't auto-derive
+            // downgrade paths and would throw `IllegalStateException`
+            // ("A migration from N to M was required but not found")
+            // at the first call to provideDb on downgrade — silent
+            // hard-crash at app startup with no recovery short of
+            // uninstall (which wipes the user's library entirely).
+            //
+            // The trade-off — wipe the local Room DB on strict
+            // downgrade — is the right policy here: library content
+            // rehydrates from the source backends (Royal Road, Gutenberg,
+            // etc.) on next sync, and EncryptedSharedPreferences (cookies,
+            // sync state) is untouched. Same-version opens and forward
+            // migrations are unaffected.
+            //
+            // Real-world downgrade scenarios this protects:
+            //   1. Sideload testing on R83W80CAFZB / R5CRB0W66MK
+            //      (`adb install -d v0.5.70.apk` over a v0.5.71 install).
+            //   2. Play Store user-initiated rollback.
+            //   3. Internal-track / beta channel rollback.
+            .fallbackToDestructiveMigrationOnDowngrade()
             // Issue #570 — F2FS_IOC_SET_PIN_FILE SELinux denial silencer.
             // Samsung's One UI 4+ (F2FS filesystem) audits SQLite's WAL
             // file-pinning ioctl as `untrusted_app` cannot perform

--- a/source-gutenberg/src/main/kotlin/in/jphe/storyvox/source/gutenberg/GutenbergSource.kt
+++ b/source-gutenberg/src/main/kotlin/in/jphe/storyvox/source/gutenberg/GutenbergSource.kt
@@ -233,6 +233,7 @@ internal class GutenbergSource @Inject constructor(
     ): FictionResult<EpubBook> {
         parsedCache[fictionId]?.let { return FictionResult.Success(it) }
         val onDisk = epubFileFor(fictionId)
+            ?: return FictionResult.NotFound("Invalid Gutenberg id: $fictionId")
         if (onDisk.exists() && onDisk.length() > 0L) {
             return reparseFromDisk(fictionId)
         }
@@ -257,6 +258,7 @@ internal class GutenbergSource @Inject constructor(
 
     private suspend fun reparseFromDisk(fictionId: String): FictionResult<EpubBook> {
         val onDisk = epubFileFor(fictionId)
+            ?: return FictionResult.NotFound("Invalid Gutenberg id: $fictionId")
         if (!onDisk.exists()) {
             return FictionResult.NotFound("No cached EPUB for $fictionId")
         }
@@ -270,8 +272,15 @@ internal class GutenbergSource @Inject constructor(
         return FictionResult.Success(parsed)
     }
 
-    private fun epubFileFor(fictionId: String): File {
-        val id = parseGutenbergId(fictionId) ?: 0
+    // Issue #718 — refuse to construct a cache path for an unparseable
+    // id. Previously this fell back to `0.epub`, collapsing every
+    // malformed fictionId (`gutenberg:abc`, `gutenberg:`, deep-link
+    // typos like `gutenberg:1342x`) onto the same on-disk file. First
+    // write poisoned the cache; later reads returned the corrupt bytes
+    // and surfaced an unparseable-EPUB error pointing at the disk
+    // cache rather than the bad id. Callers short-circuit with NotFound.
+    private fun epubFileFor(fictionId: String): File? {
+        val id = parseGutenbergId(fictionId) ?: return null
         return File(cacheDir, "$id.epub")
     }
 }
@@ -282,8 +291,11 @@ internal val GUTENBERG_URL_PATTERN: Regex = Regex(
     RegexOption.IGNORE_CASE,
 )
 
-/** `gutenberg:1342` → `1342`; returns null on malformed input. */
-private fun parseGutenbergId(fictionId: String): Int? =
+/** `gutenberg:1342` → `1342`; returns null on malformed input.
+ *  Issue #718 — null must propagate up through `epubFileFor`; the
+ *  prior `?: 0` fallback collapsed every malformed id onto a single
+ *  on-disk file. Internal for test visibility. */
+internal fun parseGutenbergId(fictionId: String): Int? =
     fictionId.substringAfter("gutenberg:", missingDelimiterValue = "")
         .takeIf { it.isNotEmpty() }
         ?.toIntOrNull()

--- a/source-gutenberg/src/test/kotlin/in/jphe/storyvox/source/gutenberg/ParseGutenbergIdTest.kt
+++ b/source-gutenberg/src/test/kotlin/in/jphe/storyvox/source/gutenberg/ParseGutenbergIdTest.kt
@@ -1,0 +1,65 @@
+package `in`.jphe.storyvox.source.gutenberg
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Test
+
+/**
+ * Issue #718 — guard `parseGutenbergId` against silently routing
+ * malformed fictionIds to the `0.epub` cache file.
+ *
+ * Pre-fix, `epubFileFor` used `parseGutenbergId(fictionId) ?: 0`,
+ * which meant every unparseable id (`gutenberg:abc`, empty string,
+ * deep-link typo `gutenberg:1342x`, no-prefix `1342`) shared a single
+ * on-disk path. The first write poisoned the cache; later reads
+ * surfaced a confusing "unparseable EPUB" error rather than an
+ * invalid-id error.
+ *
+ * Post-fix, `parseGutenbergId` is the sole authority on what counts as
+ * a valid fictionId. `null` propagates up to `NotFound("Invalid
+ * Gutenberg id: ...")` rather than collapsing onto a sentinel.
+ */
+class ParseGutenbergIdTest {
+
+    @Test
+    fun `well-formed gutenberg id parses to int`() {
+        assertEquals(1342, parseGutenbergId("gutenberg:1342"))
+        assertEquals(0, parseGutenbergId("gutenberg:0"))
+        assertEquals(70000, parseGutenbergId("gutenberg:70000"))
+    }
+
+    @Test
+    fun `gutenberg id with trailing non-digits returns null`() {
+        // Deep-link typo path from the issue. Pre-fix this hit `?: 0`
+        // and collided with a real `gutenberg:0` cache entry.
+        assertNull(parseGutenbergId("gutenberg:1342x"))
+        assertNull(parseGutenbergId("gutenberg:1342abc"))
+    }
+
+    @Test
+    fun `gutenberg id with no number after prefix returns null`() {
+        // `gutenberg:` with nothing after — empty tail.
+        assertNull(parseGutenbergId("gutenberg:"))
+    }
+
+    @Test
+    fun `id without gutenberg prefix returns null`() {
+        // `substringAfter("gutenberg:", missingDelimiterValue = "")`
+        // returns "" when the prefix is missing, which then trips the
+        // isNotEmpty filter.
+        assertNull(parseGutenbergId("1342"))
+        assertNull(parseGutenbergId("royalroad:1342"))
+    }
+
+    @Test
+    fun `empty string returns null`() {
+        assertNull(parseGutenbergId(""))
+    }
+
+    @Test
+    fun `non-numeric tail returns null`() {
+        // Pure garbage. Pre-fix this also hit `?: 0`.
+        assertNull(parseGutenbergId("gutenberg:abc"))
+        assertNull(parseGutenbergId("gutenberg:not-a-number"))
+    }
+}


### PR DESCRIPTION
Two small Argus-flagged correctness fixes — one per commit.

## #718 — source-gutenberg: malformed fictionId silently falls back to id=0

`GutenbergSource.epubFileFor(fictionId)` resolved unparseable fictionIds to `0` via `?: 0`, so every malformed id (`gutenberg:abc`, empty string, deep-link typo `gutenberg:1342x`) shared `cacheDir/gutenberg/0.epub`. First write poisoned the cache; later reads surfaced a confusing "Cached Gutenberg EPUB unparseable" error pointing at the disk cache rather than the bad id.

**Fix** (`8bfcc053`):
- `epubFileFor` now returns `File?` and returns null on unparseable ids.
- `ensureParsed` and `reparseFromDisk` short-circuit with `FictionResult.NotFound("Invalid Gutenberg id: $fictionId")`.
- `parseGutenbergId` lifted to `internal` for test visibility.
- New `ParseGutenbergIdTest` pins the rejected-input contract (6 cases: well-formed, trailing non-digits, empty tail, missing prefix, empty string, non-numeric tail).

## #721 — core-data: APK downgrade hard-crashes at startup

`Room.databaseBuilder(...)` was missing `fallbackToDestructiveMigrationOnDowngrade()`. `ALL_MIGRATIONS` covers v1→v9 forward only; Room doesn't auto-derive downgrade paths, so any newer→older install crashed with `IllegalStateException("A migration from N to M was required but not found")` at the first call to `provideDb` — silent hard-crash at app startup, no recovery short of uninstall (which wipes the user's library).

**Fix** (`4e6afd70`):
- Add `.fallbackToDestructiveMigrationOnDowngrade()` to the builder.
- On a strict downgrade, the Room DB is wiped; library content rehydrates from the source backends (Royal Road, Gutenberg, etc.) on next sync. `EncryptedSharedPreferences` (cookies, sync state) is untouched. Same-version opens and forward migrations are unaffected.

Survives:
1. Sideload testing on R83W80CAFZB / R5CRB0W66MK (`adb install -d v0.5.x.apk` over a newer build).
2. Play Store user-initiated rollback.
3. Internal-track / beta channel rollback.

## Verification

- `:source-gutenberg:testDebugUnitTest` — BUILD SUCCESSFUL (StripTagsTest + new ParseGutenbergIdTest all green).
- `:core-data:testDebugUnitTest` — BUILD SUCCESSFUL.
- `:app:compileDebugKotlin` — BUILD SUCCESSFUL (only pre-existing deprecation warnings unrelated to this PR).
- #721 verification path is on-device per the issue's repro steps (install v0.5.71 → `adb install -d v0.5.70.apk` → confirm app opens with fresh DB instead of crashing).

## Test plan
- [ ] CI on katana self-hosted runner reports green.
- [ ] On-device manual verification of #721 downgrade scenario when next sideload-test pass runs.

Closes #718.
Closes #721.