### PR TITLE
fix(playback): watchdog mirrors in-flight advance direction — closes #726

### DIFF
--- a/core-playback/src/main/kotlin/in/jphe/storyvox/playback/PlaybackController.kt
+++ b/core-playback/src/main/kotlin/in/jphe/storyvox/playback/PlaybackController.kt
@@ -510,10 +510,24 @@ class DefaultPlaybackController @Inject constructor(
                         nowState.currentChapterId == armedFor &&
                         nowState.error == null
                     ) {
+                        // Issue #726 — mirror the in-flight direction
+                        // instead of hardcoding +1. Pre-fix a slow
+                        // Previous-chapter tap (advanceChapter(-1)
+                        // parked on the body-wait flow.first()) was
+                        // recovered with advanceChapter(+1), turning
+                        // Previous into a forward two-skip. The pure
+                        // resolver on the companion handles the latch
+                        // semantics (mirror when set, fall back to +1
+                        // for the original #553 case where the engine
+                        // is stuck without an active advance call).
+                        val watchdogDir = watchdogRecoveryDirection(
+                            p.inFlightAdvanceDirection,
+                        )
                         android.util.Log.w(
                             "PlaybackController",
-                            "#553 watchdog: isBuffering stuck on $armedFor for " +
-                                "${BUFFERING_STUCK_WATCHDOG_MS}ms; firing fallback advance via nextChapter()",
+                            "#553/#726 watchdog: isBuffering stuck on $armedFor for " +
+                                "${BUFFERING_STUCK_WATCHDOG_MS}ms; firing fallback advance " +
+                                "direction=$watchdogDir (in-flight=${p.inFlightAdvanceDirection})",
                         )
                         // #553 follow-up — Media3's Player object is
                         // thread-confined to the application's Main
@@ -526,7 +540,7 @@ class DefaultPlaybackController @Inject constructor(
                         // uses via ReaderViewModel.viewModelScope.
                         runCatching {
                             kotlinx.coroutines.withContext(Dispatchers.Main) {
-                                p.advanceChapter(direction = 1)
+                                p.advanceChapter(direction = watchdogDir)
                             }
                         }.onFailure { t ->
                             // Issue #567 (stuck-state-fixer) — filter
@@ -882,6 +896,32 @@ class DefaultPlaybackController @Inject constructor(
          *  and fire the fallback advance — same recovery path the
          *  manual skip-next button uses. */
         internal const val BUFFERING_STUCK_WATCHDOG_END_OF_CHAPTER_MS = 12_000L
+
+        /**
+         * Issue #726 — pure-function resolver for the watchdog's
+         * recovery direction. Mirrors the in-flight advance direction
+         * when one is set (non-zero), falls back to +1 otherwise.
+         *
+         * The +1 fallback covers the original #553 case where the
+         * engine is stuck on isBuffering without any active
+         * `advanceChapter` call out (e.g. natural end-of-chapter never
+         * fired END_PILL through the consumer). The user was listening
+         * forward, so the natural recovery is forward.
+         *
+         * When the latch IS set (because the user tapped Previous or
+         * Next and the body-wait is parked), this returns whichever
+         * direction the user originally tapped — preserving the
+         * "Previous never moves forward" invariant.
+         *
+         * Inputs are normalized to {-1, 0, +1} so callers can pass the
+         * raw [EnginePlayer.inFlightAdvanceDirection] field without
+         * worrying about stale values from earlier API revisions.
+         */
+        fun watchdogRecoveryDirection(inFlightDirection: Int): Int = when {
+            inFlightDirection > 0 -> 1
+            inFlightDirection < 0 -> -1
+            else -> 1
+        }
 
         /**
          * #531 / #550 — pure-function exports of the seek math so JVM unit

--- a/core-playback/src/main/kotlin/in/jphe/storyvox/playback/tts/EnginePlayer.kt
+++ b/core-playback/src/main/kotlin/in/jphe/storyvox/playback/tts/EnginePlayer.kt
@@ -517,6 +517,29 @@ class EnginePlayer @AssistedInject constructor(
         azureFallbackVoiceId = voiceId
     }
 
+    /**
+     * Issue #726 — direction of the currently in-flight [advanceChapter]
+     * suspension, or 0 when no advance is in flight. Set on entry to
+     * `advanceChapter`, cleared in a try/finally on exit.
+     *
+     * Read by [PlaybackController]'s buffering-stuck watchdog so the
+     * recovery advance moves in the same direction as the user's
+     * original tap. Pre-fix the watchdog hardcoded `direction = 1`,
+     * which turned a slow Previous-chapter tap into a forward two-skip
+     * (Previous targets N-1, watchdog fires Next at +1.5 s targeting
+     * N+1, body-wait then lands on whichever finishes first — never
+     * deterministic, never what the user asked for).
+     *
+     * Volatile because the writer is the coroutine running
+     * `advanceChapter` (on Main when called from the controller
+     * watchdog or from a user tap routed through ReaderViewModel) and
+     * the reader is the watchdog's `launch` block on the
+     * controller's Default-dispatcher scope.
+     */
+    @Volatile
+    var inFlightAdvanceDirection: Int = 0
+        private set
+
     private fun observeBufferConfig() {
         scope.launch {
             // Rebuild the pipeline whenever the buffer-chunks slider
@@ -3317,6 +3340,17 @@ class EnginePlayer @AssistedInject constructor(
     }
 
     suspend fun advanceChapter(direction: Int) {
+        // Issue #726 — record the direction of the in-flight advance so
+        // PlaybackController's buffering-stuck watchdog can mirror it
+        // instead of hardcoding +1. Normalize to -1 / +1 so a Previous
+        // tap (direction=-1) doesn't accidentally read back as 0 from a
+        // caller that passed direction=0. The clear happens in finally
+        // so an exception or coroutine cancellation also resets the
+        // latch — leaving it set would make the next watchdog fire
+        // mirror a stale direction.
+        val normalizedDir = if (direction >= 0) 1 else -1
+        inFlightAdvanceDirection = normalizedDir
+        try {
         val current = _observableState.value.currentChapterId ?: run {
             android.util.Log.w(
                 "EnginePlayer",
@@ -3460,6 +3494,16 @@ class EnginePlayer @AssistedInject constructor(
             "EnginePlayer",
             "advanceChapter: complete, now playing $nextId",
         )
+        } finally {
+            // Issue #726 — clear the in-flight latch on every exit
+            // path (success, early return on missing fiction/chapter
+            // ids, end-of-book, body-wait timeout, exception,
+            // cooperative cancellation from the watchdog). Leaving it
+            // set after exit would make a subsequent watchdog fire
+            // mirror a stale direction — exactly the kind of loose
+            // state machine that produced #726 in the first place.
+            inFlightAdvanceDirection = 0
+        }
     }
 
     private suspend fun handleChapterDone() {

--- a/core-playback/src/test/kotlin/in/jphe/storyvox/playback/WatchdogDirectionTest.kt
+++ b/core-playback/src/test/kotlin/in/jphe/storyvox/playback/WatchdogDirectionTest.kt
@@ -1,0 +1,73 @@
+package `in`.jphe.storyvox.playback
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+/**
+ * Issue #726 — buffering-stuck watchdog must mirror the user's
+ * in-flight advance direction, not hardcode +1.
+ *
+ * Pre-fix the watchdog at [DefaultPlaybackController]:529 always
+ * called `p.advanceChapter(direction = 1)` on a 1.5 s stuck-buffering
+ * latch. When the user tapped Previous on a slow chapter, that
+ * recovery skipped them forward by two chapters instead of landing
+ * on the previous chapter once its body arrived — a non-deterministic
+ * race violating the most basic media-player invariant ("Previous
+ * never moves forward").
+ *
+ * The fix tracks `inFlightAdvanceDirection` on the EnginePlayer (set
+ * on entry to advanceChapter, cleared in finally) and routes the
+ * watchdog recovery through [DefaultPlaybackController.Companion.watchdogRecoveryDirection].
+ * The full controller construction needs a Hilt graph + an
+ * EnginePlayer with sherpa-onnx native AARs — same constraint as
+ * [PlaybackControllerSkipSeekTest] — so the contract is tested via
+ * the pure-function export.
+ */
+class WatchdogDirectionTest {
+
+    @Test
+    fun `mirrors positive in-flight direction`() {
+        // User tapped Next (advanceChapter(+1) parked on body wait).
+        // Watchdog fires at 1.5 s — must mirror forward so the
+        // recovery lands on the same target the user originally
+        // requested.
+        assertEquals(1, DefaultPlaybackController.watchdogRecoveryDirection(1))
+    }
+
+    @Test
+    fun `mirrors negative in-flight direction — the #726 case`() {
+        // User tapped Previous (advanceChapter(-1) parked on body
+        // wait while the previous chapter downloads). Pre-fix this
+        // returned +1, turning Previous into a forward two-skip.
+        // Post-fix it stays -1, preserving the "Previous never moves
+        // forward" invariant.
+        assertEquals(-1, DefaultPlaybackController.watchdogRecoveryDirection(-1))
+    }
+
+    @Test
+    fun `falls back to plus one when no advance is in flight — original #553 case`() {
+        // Engine stuck on isBuffering with no active advanceChapter
+        // call (e.g. natural end-of-chapter never fired END_PILL
+        // through the consumer on a Notion source — the original
+        // #553 root cause). User was listening forward, so +1 is the
+        // natural recovery direction.
+        assertEquals(1, DefaultPlaybackController.watchdogRecoveryDirection(0))
+    }
+
+    @Test
+    fun `normalizes stale positive values to plus one`() {
+        // Defensive — earlier latch revisions could in principle
+        // leak a non-{-1,0,+1} value into the field (e.g. if an
+        // older `advanceChapter(direction = 5)` caller landed). The
+        // resolver normalizes positive to +1 and negative to -1 so
+        // the watchdog never passes an out-of-range value back into
+        // `advanceChapter` (which already uses `if (direction >= 0)`
+        // internally, but normalizing here keeps the contract tight).
+        assertEquals(1, DefaultPlaybackController.watchdogRecoveryDirection(5))
+    }
+
+    @Test
+    fun `normalizes stale negative values to minus one`() {
+        assertEquals(-1, DefaultPlaybackController.watchdogRecoveryDirection(-7))
+    }
+}


### PR DESCRIPTION
## Summary

Issue **#726** — buffering-stuck watchdog flips Previous-chapter taps into a forward two-skip.

The recovery path at `PlaybackController.kt:529` hardcoded `p.advanceChapter(direction = 1)`. When the user tapped **Previous** on a slow chapter, `advanceChapter(-1)` parked on the body-wait flow; at 1.5 s the watchdog fired forward and the listener ended up two chapters past where they started instead of one chapter back. A user pressing **Back** and being skipped **Forward** violates the most basic media-player invariant.

## Fix

- **`EnginePlayer.kt`** — add `@Volatile var inFlightAdvanceDirection: Int = 0` with `private set`. Set on entry to `advanceChapter` (normalized to {-1, +1}), cleared in a `finally` block so every exit path (success, end-of-book, body-wait timeout, exception, cooperative cancellation from the watchdog) resets the latch.
- **`PlaybackController.kt`** — replace hardcoded `direction = 1` with `watchdogRecoveryDirection(p.inFlightAdvanceDirection)`, a pure-function resolver on the companion. Mirrors the in-flight direction when set; falls back to +1 when zero. The +1 fallback preserves the original #553 recovery (engine stuck on `isBuffering` with no active advance call — e.g. natural end-of-chapter that never fired `END_PILL` through the consumer on a Notion source).

## Test plan

- `WatchdogDirectionTest` pins the resolver via the companion export (same pattern as `PlaybackControllerSkipSeekTest` — the full controller needs Hilt + sherpa-onnx native AARs).
  - Mirrors `+1` in-flight → `+1`.
  - Mirrors `-1` in-flight → `-1` (the #726 case).
  - Falls back to `+1` when no advance is in flight (original #553 case).
  - Normalizes stale out-of-range positive/negative values.
- `./gradlew :core-playback:testDebugUnitTest` — full module suite green.

## Verification on-device

This is a low-frequency race (requires a slow Previous-chapter tap where the previous body isn't already cached). The fix preserves all existing #553/#640 watchdog behaviour — only the hardcoded +1 → mirror replacement is in the hot path. Manual repro per the issue (Library jump to chapter 5 where 4 was never downloaded, tap Previous mid-playback) will land on chapter 4 instead of 6 once CI builds the APK.

Closes #726.
Related: #553 #640 #285 #567 #563