### PR TITLE
fix(playback): honor sleep-timer pause across chapter advance

### DIFF
--- a/core-playback/src/main/kotlin/in/jphe/storyvox/playback/tts/EnginePlayer.kt
+++ b/core-playback/src/main/kotlin/in/jphe/storyvox/playback/tts/EnginePlayer.kt
@@ -103,6 +103,25 @@ import kotlinx.coroutines.withContext
  * trying to keep state coherent across a `pause()` call.
  */
 /**
+ * Issue #728 — pure decision rule for whether [EnginePlayer.advanceChapter]
+ * should kick off playback after the next chapter's body lands.
+ *
+ * Called with the [PlaybackState] sampled **after** the chapter-body wait
+ * completes. If a pause (sleep timer fade-and-pause, audio focus loss,
+ * manual user pause tap) fired during the wait, [PlaybackState.isPlaying]
+ * is already false and we must honor it — the caller forwards the result
+ * as [EnginePlayer.loadAndPlay]'s `autoPlay` argument so the chapter
+ * loads paused instead of force-starting playback.
+ *
+ * Extracted as a top-level function so the race semantics can be
+ * exercised in a pure unit test (EnginePlayerAutoPlayDecisionTest) without
+ * standing up the full EnginePlayer + Hilt + sherpa-onnx graph (same
+ * constraint that gates PlaybackControllerSkipSeekTest).
+ */
+internal fun shouldAutoPlayAfterAdvance(stateAfterWait: PlaybackState): Boolean =
+    stateAfterWait.isPlaying
+
+/**
  * Issue #189 — playback state for the one-shot recap-aloud TTS pipeline.
  * Distinct from [PlaybackState] because the recap is a transient utterance
  * with its own AudioTrack; conflating the two would force every chapter
@@ -1164,7 +1183,12 @@ class EnginePlayer @AssistedInject constructor(
 
     // ----- Storyvox-internal API -----
 
-    suspend fun loadAndPlay(fictionId: String, chapterId: String, charOffset: Int) {
+    suspend fun loadAndPlay(
+        fictionId: String,
+        chapterId: String,
+        charOffset: Int,
+        autoPlay: Boolean = true,
+    ) {
         // PR-6 (#185) — fallback toast dedupe is per-chapter; reset
         // here so the next chapter's first Azure failure can re-fire
         // the toast. Cheap (one volatile write) so we don't gate it
@@ -1290,7 +1314,15 @@ class EnginePlayer @AssistedInject constructor(
                 currentFictionId = fictionId,
                 currentChapterId = chapterId,
                 charOffset = charOffset,
-                isPlaying = true,
+                // Issue #728 — respect a pause that landed during the
+                // chapter-body wait. Pre-fix this was hardcoded to `true`,
+                // which silently undid `pauseTts()` calls fired by the
+                // sleep timer (or audio-focus loss, or a user tap) between
+                // `handleChapterDone()` and the next chapter's body landing.
+                // The natural-end auto-advance still defaults `autoPlay=true`;
+                // only [advanceChapter]'s post-wait snapshot threads `false`
+                // through here when [shouldAutoPlayAfterAdvance] says so.
+                isPlaying = autoPlay,
                 // Issue #524 — clear the chapter-advance buffering flag
                 // we set in advanceChapter while waiting for the next
                 // chapter's body. The new pipeline takes over and the
@@ -1373,7 +1405,15 @@ class EnginePlayer @AssistedInject constructor(
             // are still warm in the singleton + secondaries lists.
             voiceReloadPending = false
             _observableState.update { it.copy(voiceId = active.id, error = null) }
-            startPlaybackPipeline()
+            // Issue #728 — when the caller wants the chapter loaded
+            // paused (sleep timer or other pause fired during the
+            // chapter-body wait), surface the new chapter id and stop
+            // here. The earlier [stopPlaybackPipeline] call has already
+            // killed any prior audio; not starting the new pipeline
+            // means the user stays in silence until [resume] is called.
+            if (autoPlay) {
+                startPlaybackPipeline()
+            }
             invalidateState()
             return
         }
@@ -1791,7 +1831,14 @@ class EnginePlayer @AssistedInject constructor(
                         "(${it.javaClass.simpleName}: ${it.message}) — continuing",
                 )
             }
-        startPlaybackPipeline()
+        // Issue #728 — only spin the producer/consumer pair when the
+        // caller wants audio. The state update above already set
+        // `isPlaying = autoPlay`; skipping startPlaybackPipeline here
+        // when `autoPlay = false` is what actually keeps the device
+        // silent on a sleep-timer-during-chapter-advance race.
+        if (autoPlay) {
+            startPlaybackPipeline()
+        }
         invalidateState()
     }
 
@@ -3426,11 +3473,20 @@ class EnginePlayer @AssistedInject constructor(
             invalidateState()
             return
         }
+        // Issue #728 — snapshot the pause-truthful flag AFTER the body
+        // wait completes and BEFORE calling loadAndPlay. If anything
+        // flipped `isPlaying` to false during the wait — sleep timer
+        // expiry, audio-focus loss from a phone call, manual user
+        // pause — [shouldAutoPlayAfterAdvance] returns false and the
+        // next chapter loads paused. Pre-fix loadAndPlay unconditionally
+        // wrote `isPlaying = true` here, undoing the pause seconds after
+        // it fired and waking the user back up.
+        val autoPlayNext = shouldAutoPlayAfterAdvance(_observableState.value)
         android.util.Log.i(
             "EnginePlayer",
-            "advanceChapter: body ready for $nextId, calling loadAndPlay",
+            "advanceChapter: body ready for $nextId, calling loadAndPlay autoPlay=$autoPlayNext",
         )
-        loadAndPlay(fiction, nextId, charOffset = 0)
+        loadAndPlay(fiction, nextId, charOffset = 0, autoPlay = autoPlayNext)
         // Issue #287 / #563 (stuck-state-fixer) — persist the new
         // chapter's id immediately so the Library "Continue listening"
         // join sees the freshly-loaded chapter on its next emission.

--- a/core-playback/src/test/kotlin/in/jphe/storyvox/playback/tts/EnginePlayerAutoPlayDecisionTest.kt
+++ b/core-playback/src/test/kotlin/in/jphe/storyvox/playback/tts/EnginePlayerAutoPlayDecisionTest.kt
@@ -1,0 +1,134 @@
+package `in`.jphe.storyvox.playback.tts
+
+import `in`.jphe.storyvox.playback.PlaybackError
+import `in`.jphe.storyvox.playback.PlaybackState
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * Issue #728 — pure-function unit test for [shouldAutoPlayAfterAdvance],
+ * the decision rule that prevents a sleep-timer pause (or any other
+ * mid-wait pause) from being silently stomped when the next chapter's
+ * body lands and `EnginePlayer.advanceChapter` calls `loadAndPlay`.
+ *
+ * Pre-fix: `loadAndPlay` unconditionally wrote `isPlaying = true` and
+ * called `startPlaybackPipeline()`, regardless of whether the user's
+ * intent had changed during the chapter-body wait. The user-visible
+ * symptom was waking up to the next chapter playing at full volume.
+ *
+ * Post-fix: `advanceChapter` snapshots `_observableState.value` after
+ * the wait completes and feeds the result of this helper into
+ * `loadAndPlay(..., autoPlay = ...)`. The helper's contract: return
+ * `state.isPlaying` — if anything paused us during the wait the value
+ * is already false, and the chapter loads paused.
+ *
+ * The test deliberately stays at the pure-function layer; the full
+ * EnginePlayer construction needs a Hilt graph + sherpa-onnx AARs (see
+ * the kdoc on PlaybackControllerSkipSeekTest for the same constraint).
+ */
+class EnginePlayerAutoPlayDecisionTest {
+
+    @Test
+    fun `auto-play when state shows isPlaying=true after the body wait`() {
+        // Natural-end auto-advance: handleChapterDone fires, advanceChapter
+        // sets isBuffering=true (NOT touching isPlaying), waits for body,
+        // nothing pauses us during the wait. The post-wait snapshot keeps
+        // isPlaying=true and the next chapter resumes playing.
+        val state = PlaybackState(
+            currentFictionId = "f",
+            currentChapterId = "c1",
+            isPlaying = true,
+            isBuffering = true,
+        )
+        assertTrue(
+            "advanceChapter should auto-play when no pause landed during the body wait",
+            shouldAutoPlayAfterAdvance(state),
+        )
+    }
+
+    @Test
+    fun `do NOT auto-play when sleep timer flipped isPlaying=false during the body wait`() {
+        // The #728 race: chapter ended, advanceChapter parked in
+        // observeChapter().first(). SleepTimer.fadeAndPause invoked
+        // PauseAction → controller.pause() → pauseTts → _observableState
+        // got `isPlaying = false`. Now the body finally lands; the
+        // post-wait snapshot is the state below. Pre-fix, loadAndPlay
+        // stomped it back to true. The decision rule returns false so
+        // the new chapter loads paused — user stays asleep.
+        val state = PlaybackState(
+            currentFictionId = "f",
+            currentChapterId = "c1",
+            isPlaying = false,
+            isBuffering = true,
+        )
+        assertFalse(
+            "advanceChapter must NOT auto-play when a pause landed during the body wait (#728)",
+            shouldAutoPlayAfterAdvance(state),
+        )
+    }
+
+    @Test
+    fun `do NOT auto-play when audio focus loss flipped isPlaying=false during the body wait`() {
+        // #560 cousin of the #728 race. AudioFocusController's
+        // onFocusLost callback routes through the same pause() path
+        // (PlaybackController.pause → pauseTts → isPlaying=false). A
+        // phone call ringing during chapter-advance must not be
+        // overridden by the chapter-load completion. Same shape, same
+        // decision rule, no special case needed — that's the value of
+        // funnelling through one isPlaying flag.
+        val state = PlaybackState(
+            currentFictionId = "f",
+            currentChapterId = "c1",
+            isPlaying = false,
+            isBuffering = true,
+            error = null,
+        )
+        assertFalse(
+            "advanceChapter must respect a pause caused by audio-focus loss too (#560 / #728)",
+            shouldAutoPlayAfterAdvance(state),
+        )
+    }
+
+    @Test
+    fun `do NOT auto-play when a manual user pause landed during the body wait`() {
+        // User taps Pause on the play screen the moment the chapter
+        // finishes naturally. The tap routes to controller.pause →
+        // pauseTts → isPlaying=false. By the time the body lands, the
+        // user has intentionally requested silence. Honor it.
+        val state = PlaybackState(
+            currentFictionId = "f",
+            currentChapterId = "c1",
+            isPlaying = false,
+            isBuffering = true,
+        )
+        assertFalse(
+            "advanceChapter must respect an explicit user pause that landed during the body wait",
+            shouldAutoPlayAfterAdvance(state),
+        )
+    }
+
+    @Test
+    fun `decision is a pure read of isPlaying — other fields are not consulted`() {
+        // Defensive: if a future refactor adds new state fields, this
+        // test pins the decision to a single field. The helper deliberately
+        // does NOT inspect isBuffering / error / sleepTimerRemainingMs /
+        // sentence range — the truthful "did anyone pause us during the
+        // wait" signal lives entirely in isPlaying, written by pauseTts.
+        val playingHasError = PlaybackState(
+            isPlaying = true,
+            isBuffering = true,
+            error = PlaybackError.ChapterFetchFailed("stale error from prior chapter"),
+            sleepTimerRemainingMs = 30_000L,
+        )
+        assertTrue(shouldAutoPlayAfterAdvance(playingHasError))
+
+        val pausedNoError = PlaybackState(
+            isPlaying = false,
+            isBuffering = false,
+            error = null,
+            sleepTimerRemainingMs = null,
+        )
+        assertFalse(shouldAutoPlayAfterAdvance(pausedNoError))
+    }
+}


### PR DESCRIPTION
Closes #728.

## Root cause

`EnginePlayer.loadAndPlay` unconditionally wrote `isPlaying = true` and started the audio pipeline, regardless of whether anything had paused us while `advanceChapter` was parked in `observeChapter(nextId).first()`. On a slow Notion source the body wait routinely takes seconds, and a sleep-timer fade-and-pause landing in that window would be silently stomped when the body finally arrived.

User wakes to the next chapter playing at full volume — exact opposite of what a sleep timer is supposed to do.

## Fix

Add an `autoPlay: Boolean = true` parameter to `loadAndPlay` that gates both the `isPlaying` state write and the `startPlaybackPipeline()` call. `advanceChapter` snapshots `_observableState.value.isPlaying` **after** the body wait completes and forwards it as `autoPlay`:

- If a pause (sleep timer / audio focus loss / manual tap) landed during the wait → `isPlaying` is already false → chapter loads paused.
- If nothing paused us → `isPlaying` is still true → natural-end auto-advance continues playing into the next chapter as before.

When `autoPlay = false`, the chapter is fully loaded into state (title, cover, sentences) but no AudioTrack or producer is constructed. The next `resume()` takes the existing slow-path branch (no live track + sentences populated) and spins the pipeline up on demand. No new state machinery, no infinite-loop risk.

Existing callers (`PlaybackController.play`, voice-swap-mid-play at line 677, voice-reload-on-resume at line 3227) keep the default `autoPlay = true` and are unaffected.

The decision is extracted as a top-level pure function `shouldAutoPlayAfterAdvance(PlaybackState): Boolean` — same testing pattern `PlaybackControllerSkipSeekTest` uses for seek math, since the full `EnginePlayer` construction needs a Hilt graph + sherpa-onnx AARs.

## Test plan

- [x] `EnginePlayerAutoPlayDecisionTest` — 5 cases:
  - auto-play when nothing paused during the wait (natural-end auto-advance)
  - do NOT auto-play when sleep timer flipped isPlaying=false (the #728 scenario)
  - do NOT auto-play on audio-focus loss during wait (#560 cousin)
  - do NOT auto-play on manual user pause during wait
  - decision is a pure read of `isPlaying` — other fields not consulted
- [x] Full `:core-playback:testDebugUnitTest` suite still green
- [x] `:app:compileDebugKotlin` clean (no downstream call-site breakage from the new defaulted parameter)
- [ ] Device verification on R83W80CAFZB: set 1-minute Duration timer, start a Notion-backed RSS book near chapter-end with slow network, confirm chapter stops playing when timer expires even if it fires mid-advance.

## Related

- #560 — audio-focus-loss has the same shape (pause-during-async-advance). This fix covers it too, since both routes funnel through `pauseTts → isPlaying = false`.
- #558 — slow Notion API at chapter boundaries is what makes the race window observable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)