### PR TITLE
fix(standardebooks): correct EPUB container.xml parsing — closes #735

### DIFF
--- a/source-standard-ebooks/build.gradle.kts
+++ b/source-standard-ebooks/build.gradle.kts
@@ -46,4 +46,7 @@ dependencies {
 
     testImplementation(libs.junit)
     testImplementation(libs.kotlinx.coroutines.test)
+    // #735 — MockWebServer for the EPUB-download interstitial regression
+    // test. Same version :source-github and :source-azure already pin.
+    testImplementation("com.squareup.okhttp3:mockwebserver:4.12.0")
 }

--- a/source-standard-ebooks/src/main/kotlin/in/jphe/storyvox/source/standardebooks/StandardEbooksSource.kt
+++ b/source-standard-ebooks/src/main/kotlin/in/jphe/storyvox/source/standardebooks/StandardEbooksSource.kt
@@ -239,8 +239,15 @@ internal class StandardEbooksSource @Inject constructor(
     ): FictionResult<EpubBook> {
         parsedCache[fictionId]?.let { return FictionResult.Success(it) }
         val onDisk = epubFileFor(authorSlug, bookSlug)
-        if (onDisk.exists() && onDisk.length() > 0L) {
+        if (onDisk.exists() && isLikelyZip(onDisk)) {
             return reparseFromDisk(fictionId)
+        }
+        // Issue #735 — releases v0.5.71 and earlier persisted SE's HTML
+        // interstitial page to this path (the bug). If a non-zip file is
+        // sitting here from a prior install, delete it before re-fetching
+        // so the user doesn't stay stuck on a cached error.
+        if (onDisk.exists()) {
+            withContext(Dispatchers.IO) { onDisk.delete() }
         }
         val bytes = when (val r = api.downloadEpub(authorSlug, bookSlug)) {
             is FictionResult.Success -> r.value
@@ -266,6 +273,17 @@ internal class StandardEbooksSource @Inject constructor(
         if (!onDisk.exists()) {
             return FictionResult.NotFound("No cached EPUB for $fictionId")
         }
+        // Issue #735 — a v0.5.71-era poisoned cache file (HTML
+        // interstitial) gets here on cold start. Delete and surface a
+        // distinct error so the next user action (re-add / refresh)
+        // re-downloads cleanly.
+        if (!isLikelyZip(onDisk)) {
+            withContext(Dispatchers.IO) { onDisk.delete() }
+            return FictionResult.NetworkError(
+                "Cached EPUB was invalid — please retry to re-download.",
+                java.io.IOException("non-zip cached EPUB"),
+            )
+        }
         val bytes = withContext(Dispatchers.IO) { onDisk.readBytes() }
         val parsed = try {
             withContext(Dispatchers.IO) { EpubParser.parseFromBytes(bytes) }
@@ -277,6 +295,24 @@ internal class StandardEbooksSource @Inject constructor(
         }
         parsedCache[fictionId] = parsed
         return FictionResult.Success(parsed)
+    }
+
+    /** Cheap content check — every EPUB starts with the four-byte zip
+     *  local-file-header signature `PK\x03\x04`. A file too small to
+     *  contain that signature, or with anything else in those positions,
+     *  is treated as a poisoned cache entry (see #735). */
+    private fun isLikelyZip(file: File): Boolean = try {
+        if (file.length() < 4) false else file.inputStream().use { input ->
+            val header = ByteArray(4)
+            val read = input.read(header)
+            read == 4 &&
+                header[0] == 'P'.code.toByte() &&
+                header[1] == 'K'.code.toByte() &&
+                header[2] == 0x03.toByte() &&
+                header[3] == 0x04.toByte()
+        }
+    } catch (_: Throwable) {
+        false
     }
 
     private fun epubFileFor(authorSlug: String, bookSlug: String): File =

--- a/source-standard-ebooks/src/main/kotlin/in/jphe/storyvox/source/standardebooks/net/StandardEbooksApi.kt
+++ b/source-standard-ebooks/src/main/kotlin/in/jphe/storyvox/source/standardebooks/net/StandardEbooksApi.kt
@@ -46,9 +46,13 @@ import javax.inject.Singleton
  * so any rate-limit hits can be routed to a real maintainer.
  */
 @Singleton
-internal class StandardEbooksApi @Inject constructor(
+internal open class StandardEbooksApi @Inject constructor(
     private val client: OkHttpClient,
 ) {
+
+    /** Base URL — `open` so JVM unit tests can point this at a
+     *  MockWebServer without restructuring the call sites. */
+    internal open val baseUrl: String = BASE_URL
 
     /** Popular = SE-side "Popularity (most → least)" sort. */
     suspend fun popular(page: Int): FictionResult<SeListPage> =
@@ -80,20 +84,30 @@ internal class StandardEbooksApi @Inject constructor(
      */
     suspend fun bookPage(authorSlug: String, bookSlug: String): FictionResult<String> =
         withContext(Dispatchers.IO) {
-            val url = "$BASE_URL/ebooks/$authorSlug/$bookSlug"
+            val url = "$baseUrl/ebooks/$authorSlug/$bookSlug"
             fetchString(url)
         }
 
     /**
      * Binary EPUB download — the "Recommended compatible epub" build,
      * which is the variant SE markets as "All devices and apps except
-     * Kindles and Kobos" (i.e., the plain EPUB 3 file). URL pattern is
-     * documented and stable.
+     * Kindles and Kobos" (i.e., the plain EPUB 3 file).
+     *
+     * Issue #735 — SE serves an HTML interstitial ("Your Download Has
+     * Started!") page at the bare `.../<author>_<book>.epub` URL that
+     * relies on a `<meta http-equiv="refresh">` to deliver the actual
+     * binary. The interstitial is ~8KB of XHTML and parses as
+     * "container.xml missing" downstream. Appending `?source=download`
+     * (the query SE's own download buttons emit) bypasses the
+     * interstitial and returns the EPUB binary directly. We also
+     * sanity-check the local "PK" zip signature so any future regression
+     * surfaces as an immediate, actionable error rather than confusing
+     * the EPUB parser.
      */
     suspend fun downloadEpub(authorSlug: String, bookSlug: String): FictionResult<ByteArray> =
         withContext(Dispatchers.IO) {
-            val url = "$BASE_URL/ebooks/$authorSlug/$bookSlug/downloads/" +
-                "${authorSlug}_${bookSlug}.epub"
+            val url = "$baseUrl/ebooks/$authorSlug/$bookSlug/downloads/" +
+                "${authorSlug}_${bookSlug}.epub?source=download"
             try {
                 val req = Request.Builder()
                     .url(url)
@@ -114,6 +128,13 @@ internal class StandardEbooksApi @Inject constructor(
                                     "empty EPUB body",
                                     IOException("empty body"),
                                 )
+                            if (!looksLikeZip(bytes)) {
+                                return@withContext FictionResult.NetworkError(
+                                    "Standard Ebooks returned non-EPUB content at $url" +
+                                        " (got ${bytes.size}B, no PK header)",
+                                    IOException("non-EPUB response"),
+                                )
+                            }
                             FictionResult.Success(bytes)
                         }
                     }
@@ -122,6 +143,16 @@ internal class StandardEbooksApi @Inject constructor(
                 FictionResult.NetworkError(e.message ?: "EPUB download failed", e)
             }
         }
+
+    /** All zip files (and therefore all EPUBs) start with the four
+     *  bytes `PK\x03\x04`. Lets us distinguish a real EPUB from SE's
+     *  HTML interstitial without parsing the response. */
+    private fun looksLikeZip(bytes: ByteArray): Boolean =
+        bytes.size >= 4 &&
+            bytes[0] == 'P'.code.toByte() &&
+            bytes[1] == 'K'.code.toByte() &&
+            bytes[2] == 0x03.toByte() &&
+            bytes[3] == 0x04.toByte()
 
     /**
      * One catalog page. Composes the query string then parses the
@@ -150,7 +181,7 @@ internal class StandardEbooksApi @Inject constructor(
             val ev = java.net.URLEncoder.encode(v, Charsets.UTF_8)
             "$ek=$ev"
         }
-        val url = "$BASE_URL/ebooks?$params"
+        val url = "$baseUrl/ebooks?$params"
         when (val r = fetchString(url)) {
             is FictionResult.Success -> {
                 val parsed = SeHtmlParser.parseListPage(r.value)

--- a/source-standard-ebooks/src/test/kotlin/in/jphe/storyvox/source/standardebooks/StandardEbooksApiTest.kt
+++ b/source-standard-ebooks/src/test/kotlin/in/jphe/storyvox/source/standardebooks/StandardEbooksApiTest.kt
@@ -1,0 +1,134 @@
+package `in`.jphe.storyvox.source.standardebooks
+
+import `in`.jphe.storyvox.data.source.model.FictionResult
+import `in`.jphe.storyvox.source.standardebooks.net.StandardEbooksApi
+import kotlinx.coroutines.test.runTest
+import okhttp3.OkHttpClient
+import okhttp3.mockwebserver.MockResponse
+import okhttp3.mockwebserver.MockWebServer
+import okio.Buffer
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+import java.util.concurrent.TimeUnit
+
+/**
+ * Issue #735 — pins the EPUB-download wire behavior for [StandardEbooksApi].
+ *
+ * Standard Ebooks serves an HTML interstitial ("Your Download Has
+ * Started!") at the bare `<author>_<book>.epub` URL and relies on a
+ * `<meta http-equiv="refresh">` to deliver the actual binary EPUB at
+ * the same path with `?source=download` appended. v0.5.71 and earlier
+ * hit the bare URL and persisted the 8KB interstitial as if it were
+ * the EPUB, which downstream failed with "META-INF/container.xml
+ * missing or has no rootfile".
+ *
+ * These tests assert:
+ *  1. The download request carries `?source=download`.
+ *  2. A valid EPUB binary (PK\x03\x04 signature) is returned as Success.
+ *  3. SE's HTML interstitial response is rejected as NetworkError —
+ *     not silently propagated to the EPUB parser.
+ */
+class StandardEbooksApiTest {
+
+    private lateinit var server: MockWebServer
+    private lateinit var http: OkHttpClient
+
+    @Before
+    fun setUp() {
+        server = MockWebServer()
+        server.start()
+        http = OkHttpClient.Builder()
+            .readTimeout(2, TimeUnit.SECONDS)
+            .build()
+    }
+
+    @After
+    fun tearDown() {
+        server.shutdown()
+    }
+
+    /** [StandardEbooksApi] pointed at the local MockWebServer. */
+    private fun apiPointingAtServer(): StandardEbooksApi =
+        object : StandardEbooksApi(http) {
+            override val baseUrl: String = server.url("/").toString().trimEnd('/')
+        }
+
+    @Test
+    fun `downloadEpub appends source-download query to bypass interstitial`() = runTest {
+        // Even though the response body is fake, we only care about
+        // the request URL the client emits.
+        server.enqueue(
+            MockResponse()
+                .setHeader("Content-Type", "application/epub+zip")
+                .setBody(Buffer().write(pkZipPrefix())),
+        )
+
+        apiPointingAtServer().downloadEpub("jane-austen", "pride-and-prejudice")
+
+        val recorded = server.takeRequest()
+        val expectedPath = "/ebooks/jane-austen/pride-and-prejudice/downloads/" +
+            "jane-austen_pride-and-prejudice.epub?source=download"
+        assertEquals(expectedPath, recorded.path)
+    }
+
+    @Test
+    fun `downloadEpub returns Success when body starts with PK zip signature`() = runTest {
+        server.enqueue(
+            MockResponse()
+                .setHeader("Content-Type", "application/epub+zip")
+                .setBody(Buffer().write(pkZipPrefix())),
+        )
+
+        val result = apiPointingAtServer().downloadEpub("a", "b")
+
+        assertTrue(
+            "expected Success, got $result",
+            result is FictionResult.Success,
+        )
+        val bytes = (result as FictionResult.Success).value
+        assertEquals(0x50.toByte(), bytes[0]) // 'P'
+        assertEquals(0x4B.toByte(), bytes[1]) // 'K'
+    }
+
+    @Test
+    fun `downloadEpub rejects HTML interstitial as NetworkError`() = runTest {
+        // Trimmed but representative of the "Your Download Has Started!"
+        // XHTML page SE returns at the bare URL. No PK header.
+        server.enqueue(
+            MockResponse()
+                .setHeader("Content-Type", "application/xhtml+xml; charset=utf-8")
+                .setBody(
+                    """<?xml version="1.0" encoding="utf-8"?>
+                    <!DOCTYPE html>
+                    <html xmlns="http://www.w3.org/1999/xhtml" lang="en-US">
+                    <head><title>Your Download Has Started!</title>
+                    <meta http-equiv="refresh"
+                      content="0; url=/ebooks/a/b/downloads/a_b.epub?source=download" />
+                    </head><body></body></html>
+                    """.trimIndent(),
+                ),
+        )
+
+        val result = apiPointingAtServer().downloadEpub("a", "b")
+
+        assertTrue(
+            "expected NetworkError, got $result",
+            result is FictionResult.NetworkError,
+        )
+        val message = (result as FictionResult.NetworkError).message
+        assertNotNull(message)
+        assertTrue(
+            "error message should hint at the non-EPUB content: $message",
+            message!!.contains("non-EPUB", ignoreCase = true) ||
+                message.contains("PK", ignoreCase = true),
+        )
+    }
+
+    /** Local-file-header signature for any zip (and therefore EPUB). */
+    private fun pkZipPrefix(): ByteArray =
+        byteArrayOf(0x50, 0x4B, 0x03, 0x04, 0x00, 0x00, 0x00, 0x00)
+}


### PR DESCRIPTION
## Summary

Standard Ebooks's `/downloads/<author>_<book>.epub` URL serves an ~8 KB XHTML interstitial ("Your Download Has Started!") that relies on a `<meta http-equiv=\"refresh\">` to fetch the real EPUB binary. v0.5.71 and earlier persisted that HTML page as if it were the EPUB, so the parser failed downstream with `META-INF/container.xml missing or has no rootfile` and every Standard Ebooks fiction opened with 0 chapters.

This PR:

- Appends `?source=download` to the EPUB URL — the same query SE's own download buttons emit — so SE returns the binary directly without the interstitial step.
- Validates the response body starts with the `PK\x03\x04` zip signature and rejects anything else as `NetworkError` instead of poisoning the on-disk cache with HTML.
- On read, detects non-zip cached files left over from the v0.5.71-era bug and deletes them so the next attempt re-downloads cleanly instead of replaying the same parse failure forever.

Plus the existing `BASE_URL` companion constant is exposed as an `open val baseUrl` so MockWebServer-backed tests can point the client at a local server — same pattern `:source-github`'s `DeviceFlowApi` uses.

## Test plan

- [x] `./gradlew :source-standard-ebooks:testDebugUnitTest` — 3 new tests in `StandardEbooksApiTest` pin: query string contains `?source=download`, PK-prefix → Success, HTML interstitial → NetworkError. All pass.
- [x] `./gradlew :source-standard-ebooks:assembleDebug` — module builds clean.
- [ ] Manual on R83W80CAFZB: Browse → Standard Ebooks → tap *Pride and Prejudice* → detail card shows chapter list (not the parse-error banner).

🤖 Generated with [Claude Code](https://claude.com/claude-code)