### PR TITLE
fix(gutenberg): drop empty-text spine entries so playback starts on real prose — closes #733

### DIFF
--- a/source-gutenberg/src/main/kotlin/in/jphe/storyvox/source/gutenberg/GutenbergSource.kt
+++ b/source-gutenberg/src/main/kotlin/in/jphe/storyvox/source/gutenberg/GutenbergSource.kt
@@ -204,8 +204,13 @@ internal class GutenbergSource @Inject constructor(
             }
         val idx = chapterIndexFrom(chapterId)
             ?: return FictionResult.NotFound("Malformed chapter id: $chapterId")
-        val ch = parsed.chapters.getOrNull(idx)
-            ?: return FictionResult.NotFound("Chapter $idx out of range (have ${parsed.chapters.size})")
+        // Issue #733 — chapterIdFor() encodes the original spine index
+        // in the chapter id (e.g. `gutenberg:84::1`), but the filtered
+        // list (see [withoutEmptySpineItems]) may have gaps after the
+        // cover SVG / image-only spine entries are dropped. Look up by
+        // matching the EpubChapter.index, NOT by list position.
+        val ch = parsed.chapters.firstOrNull { it.index == idx }
+            ?: return FictionResult.NotFound("Chapter $idx not in spine (filtered or out of range)")
         val info = ChapterInfo(
             id = chapterId,
             sourceChapterId = ch.id,
@@ -259,7 +264,7 @@ internal class GutenbergSource @Inject constructor(
             onDisk.writeBytes(bytes)
         }
         val parsed = try {
-            withContext(Dispatchers.IO) { EpubParser.parseFromBytes(bytes) }
+            withContext(Dispatchers.IO) { EpubParser.parseFromBytes(bytes).withoutEmptySpineItems() }
         } catch (e: EpubParseException) {
             return FictionResult.NetworkError("Could not parse Gutenberg EPUB: ${e.message}", e)
         }
@@ -275,7 +280,7 @@ internal class GutenbergSource @Inject constructor(
         }
         val bytes = withContext(Dispatchers.IO) { onDisk.readBytes() }
         val parsed = try {
-            withContext(Dispatchers.IO) { EpubParser.parseFromBytes(bytes) }
+            withContext(Dispatchers.IO) { EpubParser.parseFromBytes(bytes).withoutEmptySpineItems() }
         } catch (e: EpubParseException) {
             return FictionResult.NetworkError("Cached Gutenberg EPUB unparseable: ${e.message}", e)
         }
@@ -345,6 +350,31 @@ private fun GutendexBook.toSummary(): FictionSummary =
         tags = subjects,
         status = FictionStatus.COMPLETED,
     )
+
+/**
+ * Issue #733 — drop spine entries whose visible text content is empty
+ * after [stripTags]. Project Gutenberg's EPUB3 builds always front-load
+ * the spine with a `coverpage-wrapper` page that contains only an SVG
+ * `<image>` referencing the cover JPEG — no text. The catalog row's
+ * `<dc:title>` doesn't tell the reader this; the user sees "Chapter 1"
+ * in the chapter list, taps Play, the download succeeds but writes an
+ * empty `plainBody`, and `getChapter()` returns null because the
+ * text-required guard fires. Result: PRERENDER-SKIP-NOTEXT in the
+ * background worker forever; foreground play surfaces the
+ * `ChapterFetchFailed` error band on chapter ::0.
+ *
+ * Filtering here (vs. in [EpubParser]) keeps the parser source-agnostic
+ * — sideloaded EPUBs (`:source-epub`) may want to surface cover-only
+ * spine entries verbatim for a fully-faithful reading experience — but
+ * PG's marquee-source flow needs the first audible chapter to be the
+ * first chapter with actual prose. The remaining chapters keep their
+ * original [EpubChapter.index] so the encoded chapter id
+ * (`gutenberg:N::SPINE_INDEX`) is stable across the filter; gaps in
+ * the index sequence are fine because [chapter] looks up by
+ * `firstOrNull { it.index == idx }` rather than list position.
+ */
+internal fun EpubBook.withoutEmptySpineItems(): EpubBook =
+    copy(chapters = chapters.filter { it.htmlBody.stripTags().isNotEmpty() })
 
 /** Cheap HTML→plaintext for the chapter body the engine receives.
  *  The downstream pipeline normalizes further; this just gets the

--- a/source-gutenberg/src/test/kotlin/in/jphe/storyvox/source/gutenberg/EmptySpineFilterTest.kt
+++ b/source-gutenberg/src/test/kotlin/in/jphe/storyvox/source/gutenberg/EmptySpineFilterTest.kt
@@ -1,0 +1,160 @@
+package `in`.jphe.storyvox.source.gutenberg
+
+import `in`.jphe.storyvox.source.epub.parse.EpubBook
+import `in`.jphe.storyvox.source.epub.parse.EpubChapter
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNotNull
+import org.junit.Test
+
+/**
+ * Issue #733 — playback fails on real Gutenberg books because the
+ * first spine entry is the `coverpage-wrapper` HTML containing only an
+ * SVG `<image>` reference to the cover JPEG. Its [stripTags] yields an
+ * empty string, so the chapter row's `plainBody` lands empty in the
+ * DB. The render worker logs `PRERENDER-SKIP-NOTEXT`; the foreground
+ * `loadAndPlay` path returns null from `chapterRepo.getChapter()` and
+ * surfaces `ChapterFetchFailed`.
+ *
+ * [withoutEmptySpineItems] drops those entries so the chapter list
+ * starts at the first spine item with audible text. The remaining
+ * chapters keep their original [EpubChapter.index] so the
+ * `gutenberg:N::SPINE_INDEX` chapter id encoding is stable across the
+ * filter; downstream lookups in [GutenbergSource.chapter] match by
+ * `it.index == idx` (not list position), so gaps in the index sequence
+ * are safe.
+ */
+class EmptySpineFilterTest {
+
+    @Test
+    fun `drops cover SVG entry whose stripTags is empty`() {
+        // Real-shape coverpage-wrapper from a PG EPUB3 build — body
+        // contains only an SVG <image>; no visible text.
+        val coverHtml = """
+            <!DOCTYPE html><html><head><title>"Cover"</title></head>
+            <body class="x-ebookmaker-coverpage">
+              <div class="x-ebookmaker-cover">
+                <svg viewBox="0 0 1824 2726"><image xlink:href="cover.jpg"/></svg>
+              </div>
+            </body></html>
+        """.trimIndent()
+
+        val pgHeaderHtml = """
+            <html><head><title>Frankenstein</title></head>
+            <body><div class="pgheader"><h2>The Project Gutenberg eBook of Frankenstein</h2>
+            <p>This eBook is for the use of anyone anywhere in the United States.</p></div></body></html>
+        """.trimIndent()
+
+        val realChapterHtml = """
+            <html><head><title>Frankenstein</title></head>
+            <body><h2>Letter 1</h2><p>To Mrs. Saville, England.</p>
+            <p>You will rejoice to hear that no disaster has accompanied the commencement.</p></body></html>
+        """.trimIndent()
+
+        val book = EpubBook(
+            title = "Frankenstein",
+            author = "Mary Wollstonecraft Shelley",
+            chapters = listOf(
+                EpubChapter(id = "coverpage-wrapper", title = "Chapter 1", index = 0, htmlBody = coverHtml),
+                EpubChapter(id = "pg-header", title = "Chapter 2", index = 1, htmlBody = pgHeaderHtml),
+                EpubChapter(id = "item4", title = "Chapter 3", index = 2, htmlBody = realChapterHtml),
+            ),
+        )
+
+        val filtered = book.withoutEmptySpineItems()
+
+        // Cover is dropped.
+        assertEquals(2, filtered.chapters.size)
+        assertFalse(
+            "Cover SVG entry should be filtered out",
+            filtered.chapters.any { it.id == "coverpage-wrapper" },
+        )
+
+        // pg-header and the real chapter survive, with their original
+        // spine indexes intact — chapter ids stay stable.
+        assertEquals(1, filtered.chapters[0].index)
+        assertEquals("pg-header", filtered.chapters[0].id)
+        assertEquals(2, filtered.chapters[1].index)
+        assertEquals("item4", filtered.chapters[1].id)
+    }
+
+    @Test
+    fun `preserves index gaps so chapter id encoding stays stable`() {
+        // Mixed-shape spine: a cover, then real content, then an
+        // image-only mid-book inset, then more real content. The mid-
+        // book inset is rare in PG but easy to reproduce on Standard
+        // Ebooks-derived builds.
+        val empty = """<html><body><div><img src="x.jpg"/></div></body></html>""".trimIndent()
+        val real = """<html><body><p>The text.</p></body></html>""".trimIndent()
+        val book = EpubBook(
+            title = "T",
+            author = "A",
+            chapters = listOf(
+                EpubChapter("c0", "C0", 0, empty),
+                EpubChapter("c1", "C1", 1, real),
+                EpubChapter("c2", "C2", 2, empty),
+                EpubChapter("c3", "C3", 3, real),
+            ),
+        )
+
+        val filtered = book.withoutEmptySpineItems()
+
+        // Indexes 1 and 3 survive with a gap at 2 — that's load-bearing.
+        // chapterIdFor(fictionId, ch.index) builds the chapter id from
+        // EpubChapter.index, and GutenbergSource.chapter() looks up via
+        // firstOrNull { it.index == idx } rather than list position, so
+        // the gap doesn't break navigation.
+        assertEquals(2, filtered.chapters.size)
+        assertEquals(1, filtered.chapters[0].index)
+        assertEquals(3, filtered.chapters[1].index)
+        assertNotNull(filtered.chapters.firstOrNull { it.index == 1 })
+        assertNotNull(filtered.chapters.firstOrNull { it.index == 3 })
+    }
+
+    @Test
+    fun `book with no empty entries is returned unchanged`() {
+        val real = """<html><body><p>Text.</p></body></html>""".trimIndent()
+        val book = EpubBook(
+            title = "T",
+            author = "A",
+            chapters = listOf(
+                EpubChapter("c0", "C0", 0, real),
+                EpubChapter("c1", "C1", 1, real),
+            ),
+        )
+
+        val filtered = book.withoutEmptySpineItems()
+
+        assertEquals(2, filtered.chapters.size)
+        assertEquals(0, filtered.chapters[0].index)
+        assertEquals(1, filtered.chapters[1].index)
+    }
+
+    @Test
+    fun `style-only spine entry is dropped because stripTags removes style contents`() {
+        // The #442 fix removes the contents of <style> blocks. A spine
+        // entry that contains only `<head>` + `<body><style>…</style></body>`
+        // (rare but seen on a couple of pre-2010 Gutenberg builds where
+        // the converter dropped a full stylesheet into the body) yields
+        // an empty stripTags — and would silently break playback the
+        // same way the cover SVG does.
+        val styleOnly = """
+            <html><head><title>x</title></head>
+            <body><style>body { color: black; }</style></body></html>
+        """.trimIndent()
+        val real = """<html><body><p>Letter 1. To Mrs. Saville.</p></body></html>""".trimIndent()
+        val book = EpubBook(
+            title = "T",
+            author = "A",
+            chapters = listOf(
+                EpubChapter("c0", "C0", 0, styleOnly),
+                EpubChapter("c1", "C1", 1, real),
+            ),
+        )
+
+        val filtered = book.withoutEmptySpineItems()
+
+        assertEquals(1, filtered.chapters.size)
+        assertEquals(1, filtered.chapters[0].index)
+    }
+}


### PR DESCRIPTION
## Summary

Project Gutenberg's EPUB3 builds front-load the spine with a `coverpage-wrapper` page that contains only an SVG `<image>` reference to the cover JPEG — no text. When the user tapped Play on any PG book (`gutenberg:84::0` Frankenstein, `gutenberg:2701::0` Moby Dick), the ChapterDownloadWorker reported SUCCESS but wrote `plainBody=\"\"` for that first chapter; `ChapterRepository.getChapter()`'s text-required guard returned null, and the reader surfaced `ChapterFetchFailed`. Meanwhile the background prerender retried `PRERENDER-SKIP-NOTEXT` forever on every chapter — chapters past the first never got their bodies downloaded either (library-add only schedules PCM renders, not chapter downloads).

This PR:

- Adds `EpubBook.withoutEmptySpineItems()` in `GutenbergSource.kt` that drops spine entries whose `htmlBody.stripTags()` is empty.
- Applies the filter in both `ensureParsed` (first-time download) and `reparseFromDisk` (process-restart cache path) so the parsed cache is consistent.
- Changes `chapter()`'s lookup from `parsed.chapters[idx]` (position-based) to `firstOrNull { it.index == idx }` (id-based) so the encoded `gutenberg:N::SPINE_INDEX` chapter id stays stable across filtered gaps — `chapterIdFor` already uses `ch.index`, so chapter ids like `::1`, `::2`, `::4` (with `::0` and `::3` dropped) navigate correctly.

After the fix, the first audible Gutenberg chapter is the first spine entry with actual text — typically `pg-header` (the PG license boilerplate, which then auto-advances into the real prose) or the first letter/chapter for builds that drop the boilerplate.

Scoped to `:source-gutenberg`. The sister `:source-epub` (sideloaded EPUBs) is intentionally left untouched — local-EPUB users may want to surface cover-only spine entries verbatim for fully-faithful reading. PG's marquee-source flow has the stricter \"playable from chapter 0\" need.

## Test plan

- [x] `./gradlew :source-gutenberg:testDebugUnitTest` — 4 new tests in `EmptySpineFilterTest` pass (cover-SVG drop, index-gap preservation, no-op on already-clean book, style-only entry filtering). Existing `StripTagsTest` + `ParseGutenbergIdTest` still pass.
- [x] `./gradlew :source-gutenberg:assembleDebug` — module builds clean.
- [ ] Manual on R83W80CAFZB: Browse → Gutenberg → tap Frankenstein → tap Play → audio starts on the first real chapter (no \"Chapter not ready\" error band).

🤖 Generated with [Claude Code](https://claude.com/claude-code)