### PR TITLE
feat(nav): promote Browse to first-class bottom nav tab — magical backend switching

### DIFF
--- a/app/src/main/kotlin/in/jphe/storyvox/navigation/StoryvoxNavHost.kt
+++ b/app/src/main/kotlin/in/jphe/storyvox/navigation/StoryvoxNavHost.kt
@@ -416,16 +416,22 @@ private fun StoryvoxNavHostContent(
     val useSideRail = isAtLeastTablet() && showHomeNav
 
     // Shared nav-target resolution: both the side rail (tablet) and the
-    // bottom bar (phone) drive the same {Library, Playing, Voices,
-    // Settings} dock, so the selected tab + onSelect logic is identical
-    // across both surfaces. Extracting them here keeps the two surfaces
-    // in lockstep — a future tab addition lands in one place.
+    // bottom bar (phone) drive the same {Playing, Library, Browse,
+    // Voices, Settings} dock, so the selected tab + onSelect logic is
+    // identical across both surfaces. Extracting them here keeps the two
+    // surfaces in lockstep — a future tab addition lands in one place.
+    //
+    // v0.5.72 — Browse is first-class. The BROWSE route lights the Browse
+    // pill (not Library), so the user always knows where they are. The
+    // Library sub-tabs (Follows, Inbox, History) still collapse to the
+    // Library pill since those remain under the Library umbrella.
     val selectedTab = when (currentRoute?.substringBefore("?")) {
         StoryvoxRoutes.SETTINGS_HUB,
         StoryvoxRoutes.SETTINGS -> HomeTab.Settings
         StoryvoxRoutes.VOICE_LIBRARY -> HomeTab.Voices
         StoryvoxRoutes.PLAYING -> HomeTab.Playing
-        // Library + Browse + Follows + Inbox + History sub-tabs and
+        StoryvoxRoutes.BROWSE -> HomeTab.Browse
+        // Library + Follows + Inbox + History sub-tabs and
         // Reader / Audiobook drill-downs all light the Library pill —
         // Library is still the umbrella for that whole tree.
         else -> HomeTab.Library
@@ -445,6 +451,7 @@ private fun StoryvoxNavHostContent(
         val target = when (tab) {
             HomeTab.Library -> StoryvoxRoutes.LIBRARY
             HomeTab.Playing -> StoryvoxRoutes.PLAYING
+            HomeTab.Browse -> StoryvoxRoutes.BROWSE
             HomeTab.Voices -> StoryvoxRoutes.VOICE_LIBRARY
             HomeTab.Settings -> StoryvoxRoutes.SETTINGS_HUB
         }
@@ -664,17 +671,11 @@ private fun StoryvoxNavHostContent(
                     onOpenFiction = { id -> navController.navigate(StoryvoxRoutes.fictionDetail(id)) },
                     onOpenReader = { f, c -> navController.navigate(StoryvoxRoutes.reader(f, c)) },
                     onOpenSettings = { navController.navigate(StoryvoxRoutes.SETTINGS_HUB) },
-                    // Restructure (v0.5.40) — Browse + Follows are
-                    // embedded sub-tabs now. Both rely on the host
-                    // (this NavHost) to surface the auth WebView for
-                    // Royal Road sign-in; we route to the same shared
-                    // sign-in surface used by FictionDetail #211 and
-                    // standalone Browse #241.
-                    onOpenRoyalRoadSignIn = { navController.navigate(StoryvoxRoutes.authWebView(SourceIds.ROYAL_ROAD)) },
+                    // v0.5.72 — Browse is a first-class bottom-nav tab
+                    // now; the standalone Browse route owns RR + AO3
+                    // sign-in deep-links. Follows is still embedded
+                    // here, so its sign-in CTA still threads through.
                     onOpenFollowsSignIn = { navController.navigate(StoryvoxRoutes.authWebView(SourceIds.ROYAL_ROAD)) },
-                    // #426 PR2 — AO3 sign-in deep-link from the embedded
-                    // Browse tab's AO3 chip signed-out banner.
-                    onOpenAo3SignIn = { navController.navigate(StoryvoxRoutes.authWebView(SourceIds.AO3)) },
                     // Issue #500 — cloud-icon tap on the Library top
                     // app bar routes to the InstantDB sign-in surface
                     // (the same SyncAuthScreen the onboarding card

--- a/app/src/test/kotlin/in/jphe/storyvox/navigation/NavStructureTest.kt
+++ b/app/src/test/kotlin/in/jphe/storyvox/navigation/NavStructureTest.kt
@@ -8,8 +8,8 @@ import org.junit.Assert.assertTrue
 import org.junit.Test
 
 /**
- * Restructure (v0.5.40 + v0.5.48 partial revert) — bottom-nav + primary-
- * destination contract.
+ * Restructure (v0.5.40 + v0.5.48 partial revert + v0.5.72 Browse
+ * promotion) — bottom-nav + primary-destination contract.
  *
  * v0.5.40 directive: "put settings in the main nav bar, and put follows
  * and browse into the library tab." Collapsed bottom nav to two primary
@@ -18,46 +18,59 @@ import org.junit.Test
  * drill-down.
  *
  * v0.5.48 partial revert (JP feedback 2026-05-15): Playing + Voices
- * restored as primary destinations. Browse + Follows stay as Library
- * sub-tabs (that part of the v0.5.40 restructure stuck). Dock is now
- * `Playing | Library | Voices | Settings`.
+ * restored as primary destinations. Browse + Follows stayed as Library
+ * sub-tabs. Dock was `Playing | Library | Voices | Settings`.
  *
- * v0.5.48 (commit 7f75435) restored Playing + Voices to the dock per
- * JP feedback: `{Library, Playing, Voices, Settings}`. The assertions
- * here track that current layout. The "no Browse / Follows pill"
- * contract is still pinned — those stay under the Library umbrella.
+ * v0.5.72 — Browse promoted to first-class bottom-nav destination
+ * (compass icon, magical hero source carousel inside). Dock is now
+ * `Playing | Library | Browse | Voices | Settings` — five tabs.
+ * Follows stays under the Library umbrella (per-user scope).
  *
- * These tests pin the contract so a future refactor that re-adds a
- * Browse pill to the bottom bar or that removes the Settings
- * destination fails here first. Plain JUnit (no Robolectric): we're
- * only inspecting enum + route-string state, not any Android framework
- * objects.
+ * These tests pin the contract so a future refactor that removes the
+ * Browse pill or changes the dock ordering fails here first. Plain
+ * JUnit (no Robolectric): we're only inspecting enum + route-string
+ * state, not any Android framework objects.
  */
 class NavStructureTest {
 
     @Test
-    fun `bottom nav exposes exactly four primary destinations`() {
-        // v0.5.48 — Library + Playing + Voices + Settings. v0.5.40 had
-        // collapsed to {Library, Settings} but JP feedback restored
-        // Playing + Voices as primary destinations. Going past four
-        // needs a UX review — the sliding indicator pill in
-        // BottomTabBar is centered per-cell and five cells starts
-        // crowding label rendering on the Flip3's compact cover width.
-        assertEquals(4, HomeTab.entries.size)
+    fun `bottom nav exposes exactly five primary destinations`() {
+        // v0.5.72 — Playing + Library + Browse + Voices + Settings.
+        // Browse was promoted from Library sub-tab to a first-class
+        // dock pill. Going past five needs a UX review — the sliding
+        // indicator pill in BottomTabBar is centered per-cell and six
+        // cells starts crowding label rendering on the Flip3's
+        // compact cover width.
+        assertEquals(5, HomeTab.entries.size)
     }
 
     @Test
-    fun `bottom nav primary destinations are Playing Library Voices Settings`() {
+    fun `bottom nav primary destinations are Playing Library Browse Voices Settings`() {
         // Order matters — BottomTabBar uses ordinal to position the
-        // indicator pill. v0.5.50 final order (after a v0.5.48 flip-
-        // flop): Playing leads since it's the most-touched destination
-        // during a listening session. Library remains the cold-launch
-        // landing (NavHost startDestination is independent of dock
-        // ordinal).
+        // indicator pill. v0.5.72 final order: Playing leads
+        // (most-touched during a listening session); Library second
+        // (cold-launch landing — NavHost startDestination is
+        // independent of dock ordinal but adjacency matters for the
+        // "I just opened the app" glance); Browse third (discovery
+        // sits between "your shelves" and "playback ops"); Voices
+        // fourth; Settings always last. Library + Browse adjacency is
+        // intentional — finishing a book and discovering the next is
+        // one swipe.
         val labels = HomeTab.entries.map { it.label }
-        assertEquals(listOf("Playing", "Library", "Voices", "Settings"), labels)
+        assertEquals(listOf("Playing", "Library", "Browse", "Voices", "Settings"), labels)
         assertEquals(HomeTab.Playing, HomeTab.entries.first())
         assertEquals(HomeTab.Settings, HomeTab.entries.last())
+    }
+
+    @Test
+    fun `Browse is now a first-class bottom-nav destination (v0_5_72)`() {
+        // Pinned alongside the order assertion above so a regression
+        // that drops Browse from the dock fails this test by name (not
+        // just the order assertion). Browse was a Library sub-tab in
+        // v0.5.40–v0.5.71; v0.5.72 gave it its own pill with the
+        // compass icon and a magical hero source carousel inside.
+        assertNotNull(HomeTab.entries.firstOrNull { it == HomeTab.Browse })
+        assertEquals("Browse", HomeTab.Browse.label)
     }
 
     @Test

--- a/core-ui/src/main/kotlin/in/jphe/storyvox/ui/component/BottomTabBar.kt
+++ b/core-ui/src/main/kotlin/in/jphe/storyvox/ui/component/BottomTabBar.kt
@@ -21,10 +21,12 @@ import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.windowInsetsPadding
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.AutoStories
+import androidx.compose.material.icons.filled.Explore
 import androidx.compose.material.icons.filled.PlayArrow
 import androidx.compose.material.icons.filled.RecordVoiceOver
 import androidx.compose.material.icons.filled.Settings
 import androidx.compose.material.icons.outlined.AutoStories
+import androidx.compose.material.icons.outlined.Explore
 import androidx.compose.material.icons.outlined.PlayArrow
 import androidx.compose.material.icons.outlined.RecordVoiceOver
 import androidx.compose.material.icons.outlined.Settings
@@ -72,27 +74,33 @@ import androidx.compose.ui.unit.dp
  *
  * **v0.5.48 partial revert** (JP feedback 2026-05-15) — Playing + Voices
  * restored as primary nav destinations alongside Library + Settings.
- * Browse + Follows + Inbox + History stay as Library sub-tabs (the user
- * liked that part of the restructure); the two destinations being added
- * back are the ones the user reaches often enough that the gear-menu
- * detour was friction:
- *  - **Playing** — currently-playing chapter transport. Returns the
- *    Apple-Books pattern of "tap-and-you're-back-in-audio".
- *  - **Voices** — Voice Library, was at Settings → Voices in the
- *    restructure; JP reaches it often enough to deserve the dock.
  *
- * Four tabs now in the dock: `{Library, Playing, Voices, Settings}`.
+ * **v0.5.72 — Browse promoted to first-class** (issues #712/#713 follow-up,
+ * 2026-05-22). Browse was a Library sub-tab in the v0.5.40 restructure but
+ * the discovery surface (multi-backend source switching + content grid)
+ * carried enough first-class behavior — its own ViewModel, sub-tabs of its
+ * own, and the standalone BROWSE deep-link route — that hiding it behind a
+ * Library sub-tab cost a tap on the most common "what should I read next"
+ * flow. The compass icon reads as "go look around" without overloading the
+ * other dock metaphors (Playing = transport, Library = your shelves,
+ * Voices = TTS, Settings = gear).
+ *
+ * Five tabs now in the dock: `{Playing, Library, Browse, Voices, Settings}`.
  */
 // Order matters — entries' ordinal positions the sliding indicator
-// pill left-to-right in the bar. JP final on 2026-05-15 (after one
-// earlier flip-flop): Playing leads the dock since it's the
-// most-touched destination during a listening session. Library stays
-// second + remains the cold-launch landing (NavHost startDestination
-// is independent of dock order).
+// pill left-to-right in the bar. v0.5.72 final order: Playing leads
+// (most-touched during a listening session); Library second (the
+// cold-launch landing — NavHost startDestination is independent of
+// dock order but adjacency matters for the "I just opened the app"
+// glance); Browse third (discovery sits between "your stuff" and
+// "everything else about playback"); Voices fourth; Settings always
+// last. Library + Browse adjacent is intentional — a user finishing
+// a book in Library can swipe one tab to discover the next.
 @Immutable
 enum class HomeTab(val label: String, val filled: ImageVector, val outlined: ImageVector) {
     Playing("Playing", Icons.Filled.PlayArrow, Icons.Outlined.PlayArrow),
     Library("Library", Icons.Filled.AutoStories, Icons.Outlined.AutoStories),
+    Browse("Browse", Icons.Filled.Explore, Icons.Outlined.Explore),
     Voices("Voices", Icons.Filled.RecordVoiceOver, Icons.Outlined.RecordVoiceOver),
     Settings("Settings", Icons.Filled.Settings, Icons.Outlined.Settings),
 }

--- a/feature/src/main/kotlin/in/jphe/storyvox/feature/browse/BrowseScreen.kt
+++ b/feature/src/main/kotlin/in/jphe/storyvox/feature/browse/BrowseScreen.kt
@@ -33,8 +33,6 @@ import androidx.compose.material3.BadgedBox
 import androidx.compose.material3.Card
 import androidx.compose.material3.CardDefaults
 import androidx.compose.material3.CenterAlignedTopAppBar
-import androidx.compose.material3.FilterChip
-import androidx.compose.material3.FilterChipDefaults
 import androidx.compose.material3.FloatingActionButton
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
@@ -178,16 +176,17 @@ fun BrowseScreen(
     ) {
     Box(modifier = Modifier.fillMaxSize()) {
     Column(modifier = Modifier.fillMaxSize().padding(top = spacing.md)) {
-        // Top-level source picker. Switches the multibinding lookup in
-        // FictionRepository between Royal Road and GitHub. Tabs and the
-        // filter sheet rebind to whatever the chosen source supports.
-        BrowseSourcePicker(
+        // v0.5.72 — magical hero source carousel for the first-class
+        // Browse tab. Replaces the v0.5.40 chip strip with brass-edged
+        // source cards showing icon + name + tagline so the picker
+        // reads as a discovery surface, not a search facet. Switching
+        // cards swaps the multibinding lookup in FictionRepository
+        // between sources; tabs and the filter sheet rebind to the new
+        // source's shape.
+        BrowseSourceCarousel(
             selectedId = state.sourceId,
             onSelect = viewModel::selectSource,
             visibleSources = state.visibleSources,
-            // Picker now handles its own horizontal padding via LazyRow's
-            // contentPadding so off-screen chips can pan into view without
-            // an outer padding clipping them at the edges.
             modifier = Modifier.fillMaxWidth(),
         )
 
@@ -996,93 +995,6 @@ private val BrowseTab.label: String
         BrowseTab.Ao3MySubscriptions -> "Subscribed"
         BrowseTab.Ao3MarkedForLater -> "Marked"
     }
-
-/**
- * Horizontally scrollable backend-picker strip pinned above the tab row.
- *
- * Each enabled backend gets its own [FilterChip] at its natural label
- * width inside a [LazyRow]. The previous implementation used Material 3
- * `SingleChoiceSegmentedButtonRow`, which divides the parent's width
- * evenly between every segment — fine for 2-3 backends, but with 11+
- * enabled it forces the label to wrap mid-word inside ~50dp segments
- * and clips the off-screen backends entirely (no horizontal scroll on
- * segmented rows). See #407.
- *
- * Filter chips:
- *  - keep each label on one line (`softWrap = false`, `maxLines = 1`,
- *    overflow = ellipsis for paranoia on very narrow tablets),
- *  - allow the strip to grow as long as needed and pan freely on a
- *    one-finger horizontal swipe (LazyRow handles fling + clipping),
- *  - keep the brass-primary selection treatment so the strip still
- *    reads as part of the realm aesthetic.
- *
- * Plugin-seam Phase 3 (#384) — the picker iterates the
- * `SourcePluginRegistry`-derived `visibleSources` list rather than
- * the (deleted) `BrowseSourceKey.entries`. Adding a new backend is
- * one `@SourcePlugin`-annotated class — no enum entry needed.
- */
-@OptIn(ExperimentalMaterial3Api::class)
-@Composable
-private fun BrowseSourcePicker(
-    selectedId: String,
-    onSelect: (String) -> Unit,
-    visibleSources: List<SourcePluginDescriptor>,
-    modifier: Modifier = Modifier,
-) {
-    val spacing = LocalSpacing.current
-    if (visibleSources.isEmpty()) return
-    LazyRow(
-        modifier = modifier,
-        horizontalArrangement = Arrangement.spacedBy(spacing.sm),
-        contentPadding = PaddingValues(horizontal = spacing.md),
-    ) {
-        items(visibleSources, key = { it.id }) { descriptor ->
-            val label = BrowseSourceUi.chipLabel(descriptor.id, descriptor.displayName)
-            val isSelected = descriptor.id == selectedId
-            // Issue #622 — consistency sweep across the 21 backend chips.
-            // Pre-fix the chips relied on `FilterChipDefaults` for the
-            // unselected state, which on dark surfaces renders an almost-
-            // invisible outline. The result was a strip where the selected
-            // chip popped but the rest faded into the background, making
-            // it hard to count or scan the available sources.
-            //
-            // Fix: every chip carries the SAME shape, SAME border, SAME
-            // label style. Selected = brass primaryContainer fill.
-            // Unselected = transparent fill + brass outline at 35 % alpha
-            // (subtle, matches the WhyAreWeWaitingPanel border tone) +
-            // onSurfaceVariant label. The brass primary border on the
-            // active chip is suppressed (the fill already announces
-            // selection) so the strip reads as a uniform family.
-            FilterChip(
-                selected = isSelected,
-                onClick = { onSelect(descriptor.id) },
-                label = {
-                    Text(
-                        text = label,
-                        style = MaterialTheme.typography.labelLarge,
-                        maxLines = 1,
-                        softWrap = false,
-                        overflow = androidx.compose.ui.text.style.TextOverflow.Ellipsis,
-                    )
-                },
-                colors = FilterChipDefaults.filterChipColors(
-                    containerColor = androidx.compose.ui.graphics.Color.Transparent,
-                    labelColor = MaterialTheme.colorScheme.onSurfaceVariant,
-                    selectedContainerColor = MaterialTheme.colorScheme.primaryContainer,
-                    selectedLabelColor = MaterialTheme.colorScheme.onPrimaryContainer,
-                ),
-                border = FilterChipDefaults.filterChipBorder(
-                    enabled = true,
-                    selected = isSelected,
-                    borderColor = MaterialTheme.colorScheme.primary.copy(alpha = 0.35f),
-                    selectedBorderColor = androidx.compose.ui.graphics.Color.Transparent,
-                    borderWidth = 1.dp,
-                    selectedBorderWidth = 0.dp,
-                ),
-            )
-        }
-    }
-}
 
 /**
  * Hint chip surfaced under the tab row when MemPalace browse is scoped

--- a/feature/src/main/kotlin/in/jphe/storyvox/feature/browse/BrowseSourceCarousel.kt
+++ b/feature/src/main/kotlin/in/jphe/storyvox/feature/browse/BrowseSourceCarousel.kt
@@ -1,0 +1,331 @@
+package `in`.jphe.storyvox.feature.browse
+
+import androidx.compose.animation.animateColorAsState
+import androidx.compose.animation.core.FastOutSlowInEasing
+import androidx.compose.animation.core.Spring
+import androidx.compose.animation.core.animateDpAsState
+import androidx.compose.animation.core.spring
+import androidx.compose.animation.core.tween
+import androidx.compose.foundation.BorderStroke
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.lazy.LazyListState
+import androidx.compose.foundation.lazy.LazyRow
+import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.lazy.rememberLazyListState
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.AutoStories
+import androidx.compose.material.icons.filled.Bolt
+import androidx.compose.material.icons.filled.Cast
+import androidx.compose.material.icons.filled.Chat
+import androidx.compose.material.icons.filled.Description
+import androidx.compose.material.icons.filled.Explore
+import androidx.compose.material.icons.filled.FolderOpen
+import androidx.compose.material.icons.filled.Forum
+import androidx.compose.material.icons.filled.LibraryBooks
+import androidx.compose.material.icons.filled.Link
+import androidx.compose.material.icons.filled.LocalLibrary
+import androidx.compose.material.icons.filled.MenuBook
+import androidx.compose.material.icons.filled.Public
+import androidx.compose.material.icons.filled.Radio
+import androidx.compose.material.icons.filled.RssFeed
+import androidx.compose.material.icons.filled.Science
+import androidx.compose.material.icons.filled.Send
+import androidx.compose.material.icons.filled.Tag
+import androidx.compose.material.icons.filled.Workspaces
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Brush
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.semantics.Role
+import androidx.compose.ui.semantics.selected
+import androidx.compose.ui.semantics.semantics
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.dp
+import `in`.jphe.storyvox.data.source.SourceIds
+import `in`.jphe.storyvox.data.source.plugin.SourcePluginDescriptor
+import `in`.jphe.storyvox.ui.theme.LocalSpacing
+
+/**
+ * v0.5.72 — magical hero source carousel for the first-class Browse tab.
+ *
+ * Replaces the flat `FilterChip` strip that the v0.5.40 restructure shipped.
+ * Each enabled backend gets its own brass-edged hero card with a source-
+ * appropriate icon glyph, a one-line display name, and a one-line tagline.
+ * The selected card grows ~6 dp taller and lights its border in brass
+ * primary, with the unselected cards holding back at a softer outline so
+ * the active source reads at a glance.
+ *
+ * Why a richer carousel instead of the chip strip:
+ *  - Browse is now a top-level destination, so "what sources does this app
+ *    even have?" is a discovery question. The chip strip read as a search
+ *    facet; the carousel reads as "pick your realm".
+ *  - The taglines turn the picker into an informational surface — a fresh-
+ *    install user can scan once and learn that Royal Road = web serials,
+ *    Gutenberg = classics, Wikipedia = encyclopedia, etc., without first
+ *    tapping each chip.
+ *  - The icon + brass selection treatment gives the bar a visual identity
+ *    that pairs with the fantasy-realm aesthetic JP's been pushing.
+ *
+ * The carousel auto-scrolls the selected card into view whenever
+ * [selectedId] changes, so deep-links / sub-tab returns always land with
+ * the active source visible.
+ */
+@Composable
+internal fun BrowseSourceCarousel(
+    selectedId: String,
+    onSelect: (String) -> Unit,
+    visibleSources: List<SourcePluginDescriptor>,
+    modifier: Modifier = Modifier,
+) {
+    val spacing = LocalSpacing.current
+    if (visibleSources.isEmpty()) return
+
+    val listState = rememberLazyListState()
+    val selectedIndex = remember(selectedId, visibleSources) {
+        visibleSources.indexOfFirst { it.id == selectedId }.coerceAtLeast(0)
+    }
+    // Auto-scroll the selected card into view. The viewport stays anchored
+    // on the active source so a user returning from a drill-down or a
+    // deep-link never has to hunt for "which one is selected?".
+    LaunchedEffect(selectedIndex, visibleSources.size) {
+        if (selectedIndex in visibleSources.indices) {
+            listState.animateScrollToItem(selectedIndex)
+        }
+    }
+
+    LazyRow(
+        state = listState,
+        modifier = modifier
+            .fillMaxWidth()
+            .height(CAROUSEL_HEIGHT),
+        horizontalArrangement = Arrangement.spacedBy(spacing.sm),
+        contentPadding = PaddingValues(horizontal = spacing.md, vertical = spacing.xs),
+    ) {
+        items(visibleSources, key = { it.id }) { descriptor ->
+            BrowseSourceCard(
+                descriptor = descriptor,
+                isSelected = descriptor.id == selectedId,
+                onClick = { onSelect(descriptor.id) },
+            )
+        }
+    }
+}
+
+@Composable
+private fun BrowseSourceCard(
+    descriptor: SourcePluginDescriptor,
+    isSelected: Boolean,
+    onClick: () -> Unit,
+) {
+    // Hoist into a local so the `Modifier.semantics { selected = ... }`
+    // lambda below isn't confused by Compose's `selected` property name —
+    // referring to `isSelected` inside the lambda is unambiguous.
+    val selected = isSelected
+    val spacing = LocalSpacing.current
+    val primary = MaterialTheme.colorScheme.primary
+    val onSurfaceVariant = MaterialTheme.colorScheme.onSurfaceVariant
+
+    // Spring-animated lift so the selected card grows into focus instead
+    // of snapping. Same lively curve as the BottomTabBar pill indicator.
+    val cardHeight by animateDpAsState(
+        targetValue = if (selected) CARD_HEIGHT_SELECTED else CARD_HEIGHT_BASE,
+        animationSpec = spring(
+            dampingRatio = Spring.DampingRatioMediumBouncy,
+            stiffness = Spring.StiffnessMediumLow,
+        ),
+        label = "browse-source-card-lift",
+    )
+    val borderAlpha by animateColorAsState(
+        targetValue = if (selected) primary else primary.copy(alpha = 0.20f),
+        animationSpec = tween(280, easing = FastOutSlowInEasing),
+        label = "browse-source-card-border",
+    )
+    val labelColor by animateColorAsState(
+        targetValue = if (selected) MaterialTheme.colorScheme.onPrimaryContainer else onSurfaceVariant,
+        animationSpec = tween(280, easing = FastOutSlowInEasing),
+        label = "browse-source-card-label",
+    )
+
+    val label = BrowseSourceUi.chipLabel(descriptor.id, descriptor.displayName)
+    val tagline = sourceTagline(descriptor.id)
+    val glyph = sourceGlyph(descriptor.id)
+    // Soft brass-tinted gradient on the selected card. Pulls the active
+    // surface out of the row without resorting to a saturated fill that
+    // would clash with the rest of Library Nocturne.
+    val gradient = if (selected) {
+        Brush.verticalGradient(
+            colors = listOf(
+                MaterialTheme.colorScheme.primaryContainer,
+                MaterialTheme.colorScheme.primaryContainer.copy(alpha = 0.55f),
+            ),
+        )
+    } else {
+        Brush.verticalGradient(
+            colors = listOf(
+                MaterialTheme.colorScheme.surfaceContainerHigh,
+                MaterialTheme.colorScheme.surfaceContainer,
+            ),
+        )
+    }
+
+    Surface(
+        modifier = Modifier
+            .width(CARD_WIDTH)
+            .height(cardHeight)
+            // a11y — every source card is a button with selected state so
+            // TalkBack announces "Royal Road, web serials, selected".
+            // Role.Button (not Role.Tab) keeps the "double-tap to activate"
+            // hint intact even on the selected cell — same rationale as
+            // BottomTabBar #645.
+            .semantics { this.selected = selected }
+            .clickable(role = Role.Button, onClickLabel = label, onClick = onClick),
+        shape = RoundedCornerShape(14.dp),
+        color = Color.Transparent,
+        border = BorderStroke(if (selected) 2.dp else 1.dp, borderAlpha),
+    ) {
+        Box(
+            modifier = Modifier
+                .fillMaxSize()
+                .clip(RoundedCornerShape(14.dp))
+                .background(gradient)
+                .padding(horizontal = spacing.sm, vertical = spacing.xs),
+        ) {
+            Column(
+                modifier = Modifier.fillMaxSize(),
+                verticalArrangement = Arrangement.spacedBy(2.dp),
+                horizontalAlignment = Alignment.Start,
+            ) {
+                Icon(
+                    imageVector = glyph,
+                    contentDescription = null,
+                    tint = if (selected) primary else onSurfaceVariant,
+                    modifier = Modifier.size(22.dp),
+                )
+                Spacer(modifier = Modifier.height(2.dp))
+                Text(
+                    text = label,
+                    style = MaterialTheme.typography.labelLarge,
+                    fontWeight = if (selected) FontWeight.SemiBold else FontWeight.Medium,
+                    color = labelColor,
+                    maxLines = 1,
+                    overflow = TextOverflow.Ellipsis,
+                )
+                Text(
+                    text = tagline,
+                    style = MaterialTheme.typography.labelSmall,
+                    color = labelColor.copy(alpha = 0.78f),
+                    maxLines = 2,
+                    overflow = TextOverflow.Ellipsis,
+                )
+            }
+        }
+    }
+}
+
+/**
+ * Short, plain-English tagline rendered under the source name in the
+ * carousel. Kept to ~24 characters so it fits two lines comfortably at
+ * labelSmall on a narrow phone. New backends can fall through to the
+ * descriptor's category text or stay blank — the carousel doesn't crash
+ * if a source has no row here, it just hides the tagline line.
+ */
+private fun sourceTagline(id: String): String = when (id) {
+    SourceIds.ROYAL_ROAD -> "Web serials"
+    SourceIds.AO3 -> "Fanfiction archive"
+    SourceIds.GUTENBERG -> "Classic books"
+    SourceIds.STANDARD_EBOOKS -> "Polished classics"
+    SourceIds.WIKIPEDIA -> "Encyclopedia"
+    SourceIds.WIKISOURCE -> "Historic texts"
+    SourceIds.GITHUB -> "Repo READMEs"
+    SourceIds.RSS -> "Your feeds"
+    SourceIds.EPUB -> "Your EPUBs"
+    SourceIds.OUTLINE -> "Your wiki"
+    SourceIds.MEMPALACE -> "Your palace"
+    SourceIds.RADIO, SourceIds.KVMR -> "Live radio"
+    SourceIds.NOTION -> "Your Notion"
+    SourceIds.HACKERNEWS -> "Tech news"
+    SourceIds.ARXIV -> "Research papers"
+    SourceIds.PLOS -> "Open science"
+    SourceIds.DISCORD -> "Server channels"
+    SourceIds.MATRIX -> "Matrix rooms"
+    SourceIds.TELEGRAM -> "Channel posts"
+    SourceIds.SLACK -> "Workspace threads"
+    SourceIds.PALACE -> "Library borrows"
+    SourceIds.READABILITY -> "Paste any link"
+    else -> ""
+}
+
+/**
+ * Material icon glyph that fits the source's metaphor. Books for book-
+ * shaped sources, antennas for streaming, chat bubbles for chat platforms,
+ * a generic compass for "everything else". The same icon set ships with
+ * material-icons-extended, already on the classpath via the BottomTabBar
+ * compass import.
+ */
+private fun sourceGlyph(id: String): ImageVector = when (id) {
+    SourceIds.ROYAL_ROAD -> Icons.Filled.AutoStories
+    SourceIds.AO3 -> Icons.Filled.LibraryBooks
+    SourceIds.GUTENBERG -> Icons.Filled.MenuBook
+    SourceIds.STANDARD_EBOOKS -> Icons.Filled.MenuBook
+    SourceIds.WIKIPEDIA -> Icons.Filled.Public
+    SourceIds.WIKISOURCE -> Icons.Filled.Description
+    SourceIds.GITHUB -> Icons.Filled.Workspaces
+    SourceIds.RSS -> Icons.Filled.RssFeed
+    SourceIds.EPUB -> Icons.Filled.FolderOpen
+    SourceIds.OUTLINE -> Icons.Filled.Description
+    SourceIds.MEMPALACE -> Icons.Filled.LocalLibrary
+    SourceIds.RADIO, SourceIds.KVMR -> Icons.Filled.Radio
+    SourceIds.NOTION -> Icons.Filled.Description
+    SourceIds.HACKERNEWS -> Icons.Filled.Bolt
+    SourceIds.ARXIV -> Icons.Filled.Science
+    SourceIds.PLOS -> Icons.Filled.Science
+    SourceIds.DISCORD -> Icons.Filled.Chat
+    SourceIds.MATRIX -> Icons.Filled.Tag
+    SourceIds.TELEGRAM -> Icons.Filled.Send
+    SourceIds.SLACK -> Icons.Filled.Forum
+    SourceIds.PALACE -> Icons.Filled.LocalLibrary
+    SourceIds.READABILITY -> Icons.Filled.Link
+    else -> Icons.Filled.Explore
+}
+
+/** Card width — wide enough for "Standard Ebooks" + an icon column at
+ *  labelLarge, narrow enough that ~3 cards peek on a 360 dp phone so the
+ *  user reads it as a horizontal carousel, not a column. */
+private val CARD_WIDTH = 132.dp
+
+/** Resting card height — fits icon + name + 2-line tagline at the chosen
+ *  typography tokens with room to spare. */
+private val CARD_HEIGHT_BASE = 92.dp
+
+/** Selected card grows ~4 dp taller. Subtle enough not to break the row's
+ *  baseline, obvious enough to read as "this one is active" without
+ *  needing the border or color cues alone. */
+private val CARD_HEIGHT_SELECTED = 96.dp
+
+/** Carousel container height. Includes the selected lift + vertical
+ *  padding so the LazyRow doesn't clip the bouncy spring overshoot. */
+private val CAROUSEL_HEIGHT = 108.dp

--- a/feature/src/main/kotlin/in/jphe/storyvox/feature/library/LibraryScreen.kt
+++ b/feature/src/main/kotlin/in/jphe/storyvox/feature/library/LibraryScreen.kt
@@ -93,20 +93,14 @@ fun LibraryScreen(
      */
     onOpenInboxLink: (String) -> Unit = {},
     /**
-     * Restructure (v0.5.40) — embedded BrowseScreen's RR sign-in CTA.
-     * Default no-op for tests / preview surfaces that don't exercise
-     * the Browse sub-tab.
-     */
-    onOpenRoyalRoadSignIn: () -> Unit = {},
-    /**
-     * #426 PR2 — embedded BrowseScreen's AO3 sign-in CTA. Routes to
-     * the same AUTH_WEBVIEW destination as the standalone Browse
-     * screen, parameterized with `SourceIds.AO3`.
-     */
-    onOpenAo3SignIn: () -> Unit = {},
-    /**
      * Restructure (v0.5.40) — embedded FollowsScreen's sign-in CTA
      * (Royal Road WebView for now; #241 shared sign-in surface).
+     *
+     * v0.5.72 — Browse was promoted to a first-class bottom-nav tab,
+     * so the previously-threaded `onOpenRoyalRoadSignIn` and
+     * `onOpenAo3SignIn` callbacks have been dropped here (Browse's
+     * standalone route owns them now). Follows stays embedded under
+     * Library and still routes through here.
      */
     onOpenFollowsSignIn: () -> Unit = {},
     /**
@@ -346,25 +340,6 @@ fun LibraryScreen(
                             onOpenTechEmpower = onOpenTechEmpower,
                         )
                     }
-                }
-
-                // Restructure (v0.5.40) — Browse embedded under Library.
-                // BrowseScreen carries its own ViewModel (Hilt-scoped to
-                // this NavBackStackEntry) so its state survives sub-tab
-                // switches inside Library, same as it survived
-                // top-level tab switches before the restructure.
-                LibraryTab.Browse -> Box(modifier = Modifier.fillMaxSize()) {
-                    BrowseScreen(
-                        onOpenFiction = onOpenFiction,
-                        onOpenRoyalRoadSignIn = onOpenRoyalRoadSignIn,
-                        // #426 PR2 — thread the AO3 sign-in entry point
-                        // through to the embedded BrowseScreen so the
-                        // AO3 chip's signed-out banner lands in the
-                        // right destination.
-                        onOpenAo3SignIn = onOpenAo3SignIn,
-                        onOpenSettings = onOpenSettings,
-                        embedded = true,
-                    )
                 }
 
                 // Restructure (v0.5.40) — Follows embedded under Library.

--- a/feature/src/main/kotlin/in/jphe/storyvox/feature/library/LibraryViewModel.kt
+++ b/feature/src/main/kotlin/in/jphe/storyvox/feature/library/LibraryViewModel.kt
@@ -78,14 +78,15 @@ import kotlinx.coroutines.launch
 enum class LibraryTab(val label: String) {
     Library("Library"),
     /**
-     * Restructure (v0.5.40) — Browse folded under Library. The embedded
-     * BrowseScreen body renders here, source picker and all, sans its
-     * own TopAppBar (the Library TopAppBar serves both).
-     */
-    Browse("Browse"),
-    /**
-     * Restructure (v0.5.40) — Follows folded under Library. Same
-     * pattern as Browse: embedded body, no internal TopAppBar.
+     * Restructure (v0.5.40) — Follows folded under Library. The embedded
+     * FollowsScreen body renders here sans its own TopAppBar (the Library
+     * TopAppBar serves both).
+     *
+     * v0.5.72 note — Browse was previously a Library sub-tab too but was
+     * promoted to a first-class bottom-nav destination in v0.5.72. Follows
+     * stays embedded because it's tightly coupled to "your library" (per-
+     * user, signed-in scope) while Browse is the cross-source discovery
+     * surface that earned its own dock pill.
      */
     Follows("Follows"),
     /**
@@ -283,13 +284,12 @@ class LibraryViewModel @Inject constructor(
      */
     fun selectTab(tab: LibraryTab) {
         _tab.value = tab
-        // Restructure (v0.5.40) — Browse / Follows render their own
-        // embedded surfaces (own ViewModels via hiltViewModel), so the
-        // selectTab handler has nothing source-specific to coerce.
-        // Each branch is a documented no-op for grep symmetry.
+        // Follows renders its own embedded surface (own ViewModel via
+        // hiltViewModel), so the selectTab handler has nothing source-
+        // specific to coerce. Each branch is a documented no-op for
+        // grep symmetry.
         when (tab) {
             LibraryTab.Library -> { /* chip-row filter persists across tab switches */ }
-            LibraryTab.Browse -> { /* BrowseScreen owns its own state */ }
             LibraryTab.Follows -> { /* FollowsScreen owns its own state */ }
             LibraryTab.History -> { /* history feed renders from state.history */ }
             LibraryTab.Inbox -> { /* inbox feed renders from state.inbox */ }

--- a/feature/src/main/kotlin/in/jphe/storyvox/feature/settings/SettingsComposables.kt
+++ b/feature/src/main/kotlin/in/jphe/storyvox/feature/settings/SettingsComposables.kt
@@ -360,7 +360,7 @@ fun SettingsSliderBlock(
 
 /**
  * Three-stop selector built on Material 3's `SingleChoiceSegmentedButtonRow`
- * with the same brass-tinted active treatment as [BrowseSourcePicker].
+ * with the same brass-tinted active treatment as [BrowseSourceCarousel].
  *
  * Earlier revisions used a row of [BrassButton]s where the selected stop
  * was `Primary` (filled brass) and the unselected were `Secondary`

--- a/feature/src/test/kotlin/in/jphe/storyvox/feature/library/LibraryTabCollapseTest.kt
+++ b/feature/src/test/kotlin/in/jphe/storyvox/feature/library/LibraryTabCollapseTest.kt
@@ -10,7 +10,7 @@ import org.junit.Test
 
 /**
  * Issue #438 — regression guard for the four-tab/four-chip overlap, plus
- * v0.5.40 nav-restructure follow-up.
+ * v0.5.40 nav-restructure follow-up and v0.5.72 Browse promotion.
  *
  * v0.5.36 stacked the four-entry `LibraryTab` strip (All / Reading /
  * Inbox / History) directly on top of the four-entry shelf chip row
@@ -20,21 +20,27 @@ import org.junit.Test
  * time.
  *
  * v0.5.40 restructure — JP directive "put follows and browse into the
- * library tab" — grew the tab strip back to five entries, but the
- * #438 invariants still hold: no tab label may collide with a shelf
- * chip label. The new tabs are [LibraryTab.Browse] and
- * [LibraryTab.Follows], neither of which is a shelf name, so the
- * collision contract is preserved.
+ * library tab" — grew the tab strip back to five entries.
+ *
+ * v0.5.72 — Browse promoted to first-class bottom-nav destination (its
+ * own pill with the compass icon). LibraryTab drops Browse so there's
+ * exactly one place named "Browse" in the app. Follows stays embedded
+ * (it's per-user / signed-in scope, tightly coupled to the Library
+ * umbrella). Final shape: `Library / Follows / Inbox / History`.
+ *
+ * The #438 invariants still hold: no tab label may collide with a shelf
+ * chip label.
  */
 class LibraryTabCollapseTest {
 
     @Test
-    fun `LibraryTab has exactly five entries`() {
-        // v0.5.40 restructure — Library / Browse / Follows / Inbox /
-        // History. Five is the new ceiling; growing past five needs a
-        // UX review since SecondaryScrollableTabRow is already required
-        // to fit five labels on Flip3 portrait.
-        assertEquals(5, LibraryTab.entries.size)
+    fun `LibraryTab has exactly four entries`() {
+        // v0.5.72 — Library / Follows / Inbox / History. Browse was
+        // pulled out of the strip when it became a first-class bottom-
+        // nav destination. Four is the new ceiling; growing past four
+        // needs a UX review since SecondaryScrollableTabRow already
+        // packs four labels onto Flip3 portrait.
+        assertEquals(4, LibraryTab.entries.size)
     }
 
     @Test
@@ -75,24 +81,35 @@ class LibraryTabCollapseTest {
     fun `Library is the first tab and is the default landing surface`() {
         // The Library tab hosts the chip row + the user's books; it
         // must be the landing tab so a fresh launch shows the user
-        // what they own, not the Browse / Follows / Inbox feeds.
+        // what they own, not the Follows / Inbox feeds.
         val first = LibraryTab.entries.first()
         assertEquals(LibraryTab.Library, first)
         assertEquals("Library", first.label)
     }
 
     @Test
-    fun `Browse and Follows are folded under Library as sub-tabs`() {
-        // v0.5.40 restructure pin — Browse / Follows are no longer
-        // top-level bottom-bar destinations; they're sub-tabs inside
-        // the Library destination. If anyone reverts to a top-bar
-        // Browse / Follows, this assertion still passes (the enum
-        // entries can coexist), but the bottom-nav assertions in
-        // BottomTabBar HomeTab.entries catch the regression there.
-        assertNotNull(
-            "LibraryTab.Browse missing — v0.5.40 folded Browse under Library.",
-            LibraryTab.entries.firstOrNull { it == LibraryTab.Browse },
+    fun `Browse is NOT a Library sub-tab (v0_5_72 promotion)`() {
+        // v0.5.72 pin — Browse was promoted to a first-class bottom-nav
+        // destination. A regression that re-adds `LibraryTab.Browse`
+        // would re-introduce two destinations both labelled "Browse" —
+        // one in the dock, one inside Library — which is exactly the
+        // confusion the promotion was meant to fix. The standalone
+        // StoryvoxRoutes.BROWSE deep-link route still exists; this
+        // assertion only pins the absence from the in-Library tab strip.
+        val browseByName = LibraryTab.entries.firstOrNull { it.name == "Browse" }
+        assertNull(
+            "LibraryTab.Browse must NOT exist — Browse is a first-class " +
+                "bottom-nav destination as of v0.5.72.",
+            browseByName,
         )
+    }
+
+    @Test
+    fun `Follows stays folded under Library as a sub-tab`() {
+        // v0.5.40 restructure pin — Follows is still embedded inside
+        // Library because it's per-user / signed-in scope (tightly
+        // coupled to "your books"). Browse left this strip in v0.5.72
+        // but Follows belongs here.
         assertNotNull(
             "LibraryTab.Follows missing — v0.5.40 folded Follows under Library.",
             LibraryTab.entries.firstOrNull { it == LibraryTab.Follows },
@@ -110,13 +127,13 @@ class LibraryTabCollapseTest {
 
     @Test
     fun `LibraryTab order matches reading flow`() {
-        // Left-to-right: own-it (Library) → find-it (Browse / Follows)
+        // Left-to-right: own-it (Library) → find-via-author (Follows)
         // → new updates (Inbox) → revisit (History). The order isn't
         // alphabetical or random; it's narratively grouped, and the
         // SecondaryScrollableTabRow indicator pill follows this order.
+        // Browse (the find-everything-else flow) is now in the dock.
         val expectedOrder = listOf(
             LibraryTab.Library,
-            LibraryTab.Browse,
             LibraryTab.Follows,
             LibraryTab.Inbox,
             LibraryTab.History,


### PR DESCRIPTION
## Summary

Browse joins **Playing | Library | Browse | Voices | Settings** as a top-level bottom-nav destination, with a compass icon and a brass-edged hero source carousel that turns backend switching into a discovery surface instead of a search facet.

### Why
Browse was a Library sub-tab in v0.5.40, but the discovery surface (multi-backend source switching + content grid) carried enough first-class behavior — its own ViewModel, sub-tabs of its own, and the standalone BROWSE deep-link route — that hiding it behind a Library sub-tab cost a tap on the most common "what should I read next" flow. Promoting it to its own pill also frees up real estate to make the backend switcher magical instead of a flat chip strip.

### Magical backend switching
The old `FilterChip` strip is replaced with a `BrowseSourceCarousel` of brass-edged hero cards. Each card carries:
- A source-appropriate Material icon glyph (book / antenna / chat bubble per backend family)
- The short display name (Royal Road, AO3, Gutenberg, Wikipedia, RSS, EPUB, …)
- A one-line tagline ("Web serials", "Fanfiction archive", "Encyclopedia", …)
- A brass-gradient fill + thicker primary border when active, with a soft spring lift (~4 dp) and an animated border/label color crossfade
- Auto-scroll-to-selected so deep-links / sub-tab returns always land with the right source visible

Taglines + glyphs cover all 22 `SourceIds` with sensible fallbacks for future backends added to the registry.

### Dock contract
`HomeTab` now has 5 entries (Playing, Library, Browse, Voices, Settings). `LibraryTab` drops to 4 (Library, Follows, Inbox, History) — Follows stays embedded because it's per-user scope, tightly coupled to "your library"; Browse leaves so there's exactly one place named "Browse" in the app.

Tests updated:
- `NavStructureTest` pins 5 tabs + the Playing/Library/Browse/Voices/Settings order + the new `Browse is first-class` regression guard
- `LibraryTabCollapseTest` pins LibraryTab to 4 entries and explicitly forbids re-adding `LibraryTab.Browse`

The standalone `StoryvoxRoutes.BROWSE` deep-link route is unchanged, so the HybridReader empty-state "Browse the realms" CTA and any other back-stack pushers keep working.

### Files touched
- `core-ui/src/main/kotlin/in/jphe/storyvox/ui/component/BottomTabBar.kt` — `HomeTab.Browse` enum entry + `Icons.Filled/Outlined.Explore`
- `feature/src/main/kotlin/in/jphe/storyvox/feature/browse/BrowseSourceCarousel.kt` — new hero carousel (331 lines)
- `feature/src/main/kotlin/in/jphe/storyvox/feature/browse/BrowseScreen.kt` — swap picker → carousel, prune dead `BrowseSourcePicker`
- `feature/src/main/kotlin/in/jphe/storyvox/feature/library/{LibraryScreen,LibraryViewModel}.kt` — drop `LibraryTab.Browse` + the embedded `BrowseScreen` body
- `app/src/main/kotlin/in/jphe/storyvox/navigation/StoryvoxNavHost.kt` — route `HomeTab.Browse` to `StoryvoxRoutes.BROWSE` + map `BROWSE` route to the Browse pill
- Tests: `NavStructureTest`, `LibraryTabCollapseTest`
- Kdoc ref bump in `SettingsComposables.kt` (BrowseSourcePicker → BrowseSourceCarousel)

## Test plan
- [x] `./gradlew :app:compileDebugKotlin` — green
- [x] `./gradlew :app:assembleDebug` — green (APK at `app/build/outputs/apk/debug/app-debug.apk`)
- [x] `./gradlew :app:testDebugUnitTest :feature:testDebugUnitTest :core-ui:testDebugUnitTest` — all green (includes updated `NavStructureTest`, `LibraryTabCollapseTest`, `BottomTabBarSemanticsTest`)
- [ ] Tap Browse in the bottom nav — lands on the standalone Browse screen with the carousel visible
- [ ] Switch between sources by tapping cards — selected card lifts + brass-glows, listing rebinds, content area transitions cleanly
- [ ] Library / Playing / Voices / Settings tabs continue to work; back from Browse pops correctly
- [ ] Tablet side-rail (≥600 dp width) shows the same 5 entries vertically
- [ ] TalkBack reads each source card as "<source name>, selected/not selected, button" with the tagline announced

🤖 Generated with [Claude Code](https://claude.com/claude-code)