### PR TITLE
fix(reader): interpolate fiction title in end-of-fiction dialog

### DIFF
--- a/feature/src/main/kotlin/in/jphe/storyvox/feature/reader/HybridReaderScreen.kt
+++ b/feature/src/main/kotlin/in/jphe/storyvox/feature/reader/HybridReaderScreen.kt
@@ -514,7 +514,7 @@ private fun BookFinishedOverlay(
                 text = if (fictionTitle.isNullOrBlank()) {
                     "You finished this book."
                 } else {
-                    "You finished “${'$'}fictionTitle”"
+                    "You finished “$fictionTitle”"
                 },
                 style = MaterialTheme.typography.titleLarge,
             )


### PR DESCRIPTION
Closes #738.

## Summary
The end-of-fiction `BookFinishedOverlay` was rendering the literal string `$fictionTitle` instead of interpolating the actual title. Reported as:

> You finished "$fictionTitle"

Root cause: the string template used Kotlin's `${'$'}` escape sequence, which compiles to a literal `$` character — so the variable was never substituted at all. It's a single-character fix: drop the escape and let normal Kotlin string interpolation do its job.

`feature/src/main/kotlin/in/jphe/storyvox/feature/reader/HybridReaderScreen.kt:517`

```diff
-                    "You finished “${'$'}fictionTitle”"
+                    "You finished “$fictionTitle”"
```

The `fictionTitle.isNullOrBlank()` branch already exists, so a missing/blank title still falls back to `"You finished this book."`

## Test plan
- [x] `./gradlew assembleDebug` — BUILD SUCCESSFUL
- [ ] Manual verify on R5CRB0W66MK (the reporting device): play an arXiv paper to natural end → dialog title shows the actual paper title