### PR TITLE
fix(library): pad empty-state copy above FAB so text is not clipped — closes #741

### DIFF
--- a/feature/src/main/kotlin/in/jphe/storyvox/feature/library/LibraryScreen.kt
+++ b/feature/src/main/kotlin/in/jphe/storyvox/feature/library/LibraryScreen.kt
@@ -584,6 +584,14 @@ private fun EmptyLibrary() {
     // headline, bodyMedium body. No CTA: Browse is one tap away in the
     // bottom nav and Add-by-URL is on the FAB above. Empty state's job
     // is to acknowledge and invite, not duplicate navigation.
+    //
+    // Issue #741 — on narrow viewports (Flip 3 cover, ~720dp portrait)
+    // the body copy is long enough that its last line wraps under the
+    // floating + FAB at the bottom-right. Inset the body text by FAB
+    // container width (56dp) + gap (16dp) on both sides so the wrapped
+    // line cannot draw into the FAB's column. Symmetric so the centered
+    // text stays visually centered (asymmetric end-only padding would
+    // shift the optical center left).
     Column(
         modifier = Modifier.fillMaxSize().padding(spacing.lg),
         horizontalAlignment = Alignment.CenterHorizontally,
@@ -607,6 +615,7 @@ private fun EmptyLibrary() {
             style = MaterialTheme.typography.bodyMedium,
             color = MaterialTheme.colorScheme.onSurfaceVariant,
             textAlign = TextAlign.Center,
+            modifier = Modifier.padding(horizontal = 72.dp),
         )
     }
 }


### PR DESCRIPTION
Closes #741.

## Summary

On the Library "All" empty state (first launch), the helper copy *"Browse Royal Road or paste a fiction URL with the + button to start collecting."* extended full column width and its wrapped last line drew underneath the floating + FAB on narrow viewports (Z Flip 3 cover, ~720dp portrait). UI-dump bounds in the issue confirmed text container ending at x=864 with the FAB starting at x=864.

## Fix

Add `Modifier.padding(horizontal = 72.dp)` to the body `Text` in `EmptyLibrary` — FAB container width (56dp) + gap (16dp). Symmetric so the centered text stays visually centered; asymmetric end-only padding would shift the optical center left of the column center and look mis-aligned at wider viewports.

Only `EmptyLibrary` is patched. `EmptyShelf` uses the shorter "Long-press a book to add it." copy which the issue confirms does not overlap.

## Files

- `feature/src/main/kotlin/in/jphe/storyvox/feature/library/LibraryScreen.kt` — body Text gains horizontal 72dp inset; added a comment block citing #741 with the rationale (FAB size + gap, symmetric vs asymmetric tradeoff)

## Test plan

- [x] `./gradlew :feature:compileDebugKotlin` — clean compile
- [x] `./gradlew assembleDebug` — BUILD SUCCESSFUL
- [ ] Install on R5CRB0W66MK (Z Flip 3 — repro device) and confirm last line of empty-state copy no longer wraps under the FAB
- [ ] Verify the wider tablet R83W80CAFZB still renders the empty state centered and pleasant (symmetric padding shouldn't hurt at wider widths since text is short relative to inset bounds)