### PR TITLE
fix(settings): human-readable Google TTS voice names — closes #740

### DIFF
--- a/app/src/main/kotlin/in/jphe/storyvox/data/SystemTtsVoiceRoster.kt
+++ b/app/src/main/kotlin/in/jphe/storyvox/data/SystemTtsVoiceRoster.kt
@@ -7,6 +7,7 @@ import android.util.Log
 import dagger.hilt.android.qualifiers.ApplicationContext
 import `in`.jphe.storyvox.data.source.SystemTtsVoiceDescriptor
 import `in`.jphe.storyvox.data.source.SystemTtsVoiceProvider
+import java.util.Locale
 import javax.inject.Inject
 import javax.inject.Singleton
 import kotlinx.coroutines.CompletableDeferred
@@ -109,7 +110,7 @@ class SystemTtsVoiceRoster @Inject constructor(
             return emptyList()
         }
 
-        val result = mutableListOf<SystemTtsVoiceDescriptor>()
+        val raw = mutableListOf<RawVoice>()
         // Step 2: bind each engine and enumerate its voices.
         for (engineInfo in engineInfos) {
             val engineName = engineInfo.name
@@ -135,18 +136,17 @@ class SystemTtsVoiceRoster @Inject constructor(
                     val isNotInstalled = TextToSpeech.Engine.KEY_FEATURE_NOT_INSTALLED in features
                     if (isNotInstalled) continue
 
-                    val locale = runCatching { v.locale.toLanguageTag() }
-                        .getOrDefault("und")
-                    result += SystemTtsVoiceDescriptor(
+                    val voiceLocale = runCatching { v.locale }.getOrNull()
+                    val localeTag = runCatching { voiceLocale?.toLanguageTag() }
+                        .getOrNull()
+                        ?.takeIf { it.isNotBlank() } ?: "und"
+                    raw += RawVoice(
                         engineName = engineName,
                         engineLabel = engineLabel,
                         voiceName = v.name,
-                        displayName = humanizeVoiceName(v.name, locale),
-                        locale = locale,
+                        locale = localeTag,
+                        voiceLocale = voiceLocale,
                         isNetworkConnectionRequired = runCatching {
-                            v.isNetworkConnectionRequired
-                        }.getOrDefault(false),
-                        requiresInternetConnection = runCatching {
                             v.isNetworkConnectionRequired
                         }.getOrDefault(false),
                     )
@@ -157,8 +157,21 @@ class SystemTtsVoiceRoster @Inject constructor(
                 runCatching { tts.shutdown() }
             }
         }
-        return result
+        return assignDisplayNames(raw)
     }
+
+    private fun assignDisplayNames(raw: List<RawVoice>): List<SystemTtsVoiceDescriptor> =
+        labelRawVoices(raw)
+
+    /** Intermediate enumeration row before display-name assignment. */
+    internal data class RawVoice(
+        val engineName: String,
+        val engineLabel: String,
+        val voiceName: String,
+        val locale: String,
+        val voiceLocale: Locale?,
+        val isNetworkConnectionRequired: Boolean,
+    )
 
     /**
      * Boot a one-shot framework TextToSpeech bound to [engine] (null
@@ -189,33 +202,6 @@ class SystemTtsVoiceRoster @Inject constructor(
         tts
     }
 
-    /**
-     * Make a voice name picker-readable. The framework exposes a
-     * locale-and-id slug ("en-us-x-iol-network") that's stable enough
-     * to round-trip via [TextToSpeech.setVoice] but unfriendly in the
-     * UI. We strip locale + network suffixes and humanize what
-     * remains; fall back to the raw name if our heuristics can't find
-     * a meaningful root.
-     */
-    private fun humanizeVoiceName(rawName: String, locale: String): String {
-        val parts = rawName.replace('_', '-').split('-').filter { it.isNotBlank() }
-        // Drop a leading locale ("en-us", "en-gb"), drop the variant
-        // marker "x", drop trailing "network"/"local" tags.
-        val filtered = parts.filterIndexed { i, part ->
-            // First two components frequently encode the locale —
-            // drop them when they match the voice's reported locale.
-            val isLocaleHead = i < 2 && locale.contains(part, ignoreCase = true)
-            val isMarker = part.equals("x", ignoreCase = true) ||
-                part.equals("network", ignoreCase = true) ||
-                part.equals("local", ignoreCase = true)
-            !isLocaleHead && !isMarker
-        }
-        val pretty = filtered.joinToString(separator = " ") {
-            it.replaceFirstChar { c -> c.titlecase() }
-        }
-        return pretty.takeIf { it.isNotBlank() } ?: rawName
-    }
-
     /** Sort key — English locales surface first, then alpha rank. */
     private fun englishLocaleRank(locale: String): Int = when {
         locale.equals("en-US", ignoreCase = true) -> 0
@@ -227,7 +213,116 @@ class SystemTtsVoiceRoster @Inject constructor(
         else -> 100
     }
 
-    private companion object {
+    internal companion object {
         const val TAG = "SystemTtsVoiceRoster"
+
+        /**
+         * #740 — second pass over the raw roster that assigns
+         * human-readable display names.
+         *
+         * The framework's `Voice.name` is a slug like
+         * `en-us-x-lob-network` — the `lob` middle segment is an
+         * internal Google code with no published mapping, so surfacing
+         * it ("Lob", "Log", "Lol") looks unfinished in the picker.
+         * Instead, label by locale display name + quality tier, and
+         * disambiguate identical buckets with a numeric suffix in
+         * voice-name order so the labels stay stable across runs.
+         *
+         * Examples for a Samsung tablet's stock Google TTS:
+         *   en-us-x-lob-network → "American English (HD) #1"
+         *   en-us-x-log-network → "American English (HD) #2"
+         *   en-us-x-iol-local   → "American English (offline) #1"
+         *
+         * Stable across enumerations because the bucket sort key is
+         * deterministic. If a future Google TTS update exposes
+         * `Voice` gender/age hints, the labeling pass can grow to
+         * include them without touching the descriptor schema.
+         *
+         * `internal` for unit testing — see [SystemTtsVoiceLabelingTest].
+         */
+        internal fun labelRawVoices(raw: List<RawVoice>): List<SystemTtsVoiceDescriptor> {
+            // Sort each bucket by voiceName so #1/#2 numbering is
+            // stable across enumerations.
+            val sortedRaw = raw.sortedBy { it.voiceName }
+            // Group by (engine, locale, network/local) — the picker's
+            // intuitive bucket.
+            val bucketCounts = sortedRaw
+                .groupingBy { Triple(it.engineName, it.locale, it.isNetworkConnectionRequired) }
+                .eachCount()
+            val bucketIndex = mutableMapOf<Triple<String, String, Boolean>, Int>()
+            return sortedRaw.map { r ->
+                val key = Triple(r.engineName, r.locale, r.isNetworkConnectionRequired)
+                val ordinal = bucketIndex.getOrDefault(key, 0) + 1
+                bucketIndex[key] = ordinal
+                val total = bucketCounts[key] ?: 1
+                val display = friendlyDisplayName(
+                    voiceLocale = r.voiceLocale,
+                    localeTag = r.locale,
+                    voiceName = r.voiceName,
+                    isNetwork = r.isNetworkConnectionRequired,
+                    ordinal = ordinal,
+                    bucketSize = total,
+                )
+                SystemTtsVoiceDescriptor(
+                    engineName = r.engineName,
+                    engineLabel = r.engineLabel,
+                    voiceName = r.voiceName,
+                    displayName = display,
+                    locale = r.locale,
+                    isNetworkConnectionRequired = r.isNetworkConnectionRequired,
+                    requiresInternetConnection = r.isNetworkConnectionRequired,
+                )
+            }
+        }
+
+        /**
+         * Compose the user-facing label for one System TTS voice. Falls
+         * back through `Locale.getDisplayName()`, the raw locale tag,
+         * and finally a stripped form of the voice name so a misshapen
+         * entry still gets *something* readable rather than going
+         * blank.
+         */
+        internal fun friendlyDisplayName(
+            voiceLocale: Locale?,
+            localeTag: String,
+            voiceName: String,
+            isNetwork: Boolean,
+            ordinal: Int,
+            bucketSize: Int,
+        ): String {
+            val baseLocaleName = voiceLocale
+                ?.runCatching { getDisplayName(Locale.getDefault()) }
+                ?.getOrNull()
+                ?.takeIf { it.isNotBlank() }
+                ?: localeTag.takeIf { it.isNotBlank() && it != "und" }
+                ?: stripSlug(voiceName)
+            val qualityTag = if (isNetwork) "HD" else "offline"
+            val suffix = if (bucketSize > 1) " #$ordinal" else ""
+            return "$baseLocaleName ($qualityTag)$suffix"
+        }
+
+        /**
+         * Last-resort fallback when a voice has no resolvable locale.
+         * Strips the locale-shaped head (`en-us`), the `x` marker, and
+         * `network`/`local` tags from a `Voice.name` slug and Title-
+         * cases what remains. Mirrors the pre-#740 behavior; only fires
+         * now when [friendlyDisplayName] has no `Locale` *and* no
+         * locale tag to work with — extraordinarily rare on real
+         * devices.
+         */
+        private fun stripSlug(rawName: String): String {
+            val parts = rawName.replace('_', '-').split('-').filter { it.isNotBlank() }
+            val filtered = parts.filterIndexed { i, part ->
+                val isMaybeLocale = i < 2 && part.length == 2
+                val isMarker = part.equals("x", ignoreCase = true) ||
+                    part.equals("network", ignoreCase = true) ||
+                    part.equals("local", ignoreCase = true)
+                !isMaybeLocale && !isMarker
+            }
+            val pretty = filtered.joinToString(separator = " ") {
+                it.replaceFirstChar { c -> c.titlecase() }
+            }
+            return pretty.takeIf { it.isNotBlank() } ?: rawName
+        }
     }
 }

--- a/app/src/test/kotlin/in/jphe/storyvox/data/SystemTtsVoiceLabelingTest.kt
+++ b/app/src/test/kotlin/in/jphe/storyvox/data/SystemTtsVoiceLabelingTest.kt
@@ -1,0 +1,179 @@
+package `in`.jphe.storyvox.data
+
+import `in`.jphe.storyvox.data.SystemTtsVoiceRoster.Companion.labelRawVoices
+import `in`.jphe.storyvox.data.SystemTtsVoiceRoster.RawVoice
+import java.util.Locale
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * #740 — display-name assignment for System TTS voices.
+ *
+ * Exercises [SystemTtsVoiceRoster.labelRawVoices] without booting the
+ * Android TextToSpeech framework. The framework's `Voice.name` slugs
+ * like `en-us-x-lob-network` previously surfaced as raw codes ("Lob",
+ * "Log", "Lol") in the picker; these tests pin the new behavior: a
+ * locale-derived label, a quality tag, and a stable numeric suffix
+ * when more than one voice shares the bucket.
+ */
+class SystemTtsVoiceLabelingTest {
+
+    private fun raw(
+        voiceName: String,
+        locale: Locale,
+        isNetwork: Boolean,
+        engineName: String = "com.google.android.tts",
+        engineLabel: String = "Google",
+    ) = RawVoice(
+        engineName = engineName,
+        engineLabel = engineLabel,
+        voiceName = voiceName,
+        locale = locale.toLanguageTag(),
+        voiceLocale = locale,
+        isNetworkConnectionRequired = isNetwork,
+    )
+
+    @Test
+    fun `Google en-US network voices get locale label + HD tag + numeric suffix`() {
+        val result = labelRawVoices(
+            listOf(
+                raw("en-us-x-lob-network", Locale.US, isNetwork = true),
+                raw("en-us-x-log-network", Locale.US, isNetwork = true),
+                raw("en-us-x-lol-network", Locale.US, isNetwork = true),
+                raw("en-us-x-lom-network", Locale.US, isNetwork = true),
+            ),
+        )
+        // Same bucket — all get numbered.
+        val names = result.map { it.displayName }
+        assertEquals(4, names.size)
+        // No raw code segments leak through.
+        names.forEach { name ->
+            assertTrue(
+                "Expected human-readable label, got '$name'",
+                !name.equals("Lob", ignoreCase = true) &&
+                    !name.equals("Log", ignoreCase = true) &&
+                    !name.equals("Lol", ignoreCase = true) &&
+                    !name.equals("Lom", ignoreCase = true),
+            )
+        }
+        // All four labels are distinct (numbered).
+        assertEquals(4, names.toSet().size)
+        // Every label carries the (HD) tag.
+        names.forEach { assertTrue("'$it' missing (HD)", it.contains("(HD)")) }
+        // Every label carries the locale display name.
+        val englishName = Locale.US.getDisplayName(Locale.getDefault())
+        names.forEach { assertTrue("'$it' missing '$englishName'", it.contains(englishName)) }
+    }
+
+    @Test
+    fun `single voice in a bucket gets no numeric suffix`() {
+        val result = labelRawVoices(
+            listOf(raw("en-us-x-iol-network", Locale.US, isNetwork = true)),
+        )
+        val name = result.single().displayName
+        assertTrue("'$name' should not carry '#' suffix", !name.contains("#"))
+        assertTrue("'$name' should contain (HD)", name.contains("(HD)"))
+    }
+
+    @Test
+    fun `local quality tier renders as offline tag`() {
+        val result = labelRawVoices(
+            listOf(raw("en-us-x-iol-local", Locale.US, isNetwork = false)),
+        )
+        val name = result.single().displayName
+        assertTrue("'$name' should contain (offline)", name.contains("(offline)"))
+        assertTrue("'$name' should not contain (HD)", !name.contains("(HD)"))
+    }
+
+    @Test
+    fun `network and local voices in same locale get separate buckets`() {
+        // Both buckets have exactly one entry — neither gets a #N
+        // suffix.
+        val result = labelRawVoices(
+            listOf(
+                raw("en-us-x-lob-network", Locale.US, isNetwork = true),
+                raw("en-us-x-lob-local", Locale.US, isNetwork = false),
+            ),
+        )
+        val names = result.map { it.displayName }
+        assertEquals(2, names.toSet().size)
+        assertTrue(names.any { it.contains("(HD)") && !it.contains("#") })
+        assertTrue(names.any { it.contains("(offline)") && !it.contains("#") })
+    }
+
+    @Test
+    fun `different locales never collide`() {
+        val result = labelRawVoices(
+            listOf(
+                raw("en-us-x-lob-network", Locale.US, isNetwork = true),
+                raw("en-gb-x-lob-network", Locale.UK, isNetwork = true),
+            ),
+        )
+        val names = result.map { it.displayName }
+        assertEquals(2, names.toSet().size)
+        // Locale display names differ across en-US and en-GB.
+        val us = Locale.US.getDisplayName(Locale.getDefault())
+        val gb = Locale.UK.getDisplayName(Locale.getDefault())
+        assertNotEquals(us, gb)
+        assertTrue(names.any { it.contains(us) })
+        assertTrue(names.any { it.contains(gb) })
+    }
+
+    @Test
+    fun `numbering is stable across enumeration order`() {
+        // Same set, different input order — labels should match by
+        // voiceName because the labeler sorts internally.
+        val first = labelRawVoices(
+            listOf(
+                raw("en-us-x-lol-network", Locale.US, isNetwork = true),
+                raw("en-us-x-lob-network", Locale.US, isNetwork = true),
+                raw("en-us-x-log-network", Locale.US, isNetwork = true),
+            ),
+        ).associate { it.voiceName to it.displayName }
+        val second = labelRawVoices(
+            listOf(
+                raw("en-us-x-log-network", Locale.US, isNetwork = true),
+                raw("en-us-x-lol-network", Locale.US, isNetwork = true),
+                raw("en-us-x-lob-network", Locale.US, isNetwork = true),
+            ),
+        ).associate { it.voiceName to it.displayName }
+        assertEquals(first, second)
+    }
+
+    @Test
+    fun `empty roster produces empty output`() {
+        assertEquals(emptyList<Any>(), labelRawVoices(emptyList()))
+    }
+
+    @Test
+    fun `descriptor preserves voiceName for round-trip selection`() {
+        // The catalog round-trips voices by their stable `voiceName`
+        // — labeling must not mutate that field.
+        val result = labelRawVoices(
+            listOf(raw("en-us-x-lob-network", Locale.US, isNetwork = true)),
+        )
+        assertEquals("en-us-x-lob-network", result.single().voiceName)
+    }
+
+    @Test
+    fun `Samsung-style language voiceName still gets a locale label`() {
+        // Samsung TTS emits names like 'en-US-language' rather than
+        // the Google '-x-' slug. Both should label sanely.
+        val result = labelRawVoices(
+            listOf(
+                raw(
+                    voiceName = "en-US-language",
+                    locale = Locale.US,
+                    isNetwork = false,
+                    engineName = "com.samsung.SMT",
+                    engineLabel = "Samsung",
+                ),
+            ),
+        )
+        val name = result.single().displayName
+        assertTrue("'$name' should not be a raw slug", !name.contains("-x-"))
+        assertTrue("'$name' should contain English locale", name.contains("English"))
+    }
+}


### PR DESCRIPTION
## Summary
- Google's `Voice.name` slug (`en-us-x-lob-network`) was being stripped to its meaningless middle segment, so the Voice library showed a wall of `lob`/`log`/`lol`/`lom` for every Google TTS voice
- Replace with `Locale.getDisplayName()` + quality tag (`(HD)` for network, `(offline)` for local) + stable numeric suffix when the bucket has multiple voices
- Pre-#740 slug-strip path survives as a last-resort fallback for voices with no resolvable locale

### Examples
- `en-us-x-lob-network` → `English (United States) (HD) #1`
- `en-us-x-log-network` → `English (United States) (HD) #2`
- `en-us-x-iol-local` → `English (United States) (offline)`

Numbering is stable across enumerations because the labeler sorts by `Voice.name` before assigning ordinals.

## Test plan
- [x] `./gradlew :app:assembleDebug` clean
- [x] `./gradlew :app:testDebugUnitTest` — new `SystemTtsVoiceLabelingTest` (9 cases) covers numbered buckets, single-voice no-suffix, network/local separation, cross-locale isolation, stable ordering, and Samsung-style `en-US-language` voice IDs
- [ ] Install on R5CRB0W66MK (reporter's device — Galaxy Z Flip 3), open Settings → Voice library, confirm no `lob`/`log`/`lol`/`lom`
- [ ] Spot-check Reader → "Pick a different voice" surfaces the same labels