### PR TITLE
feat(browse): long-press favorites + hide from carousel

### DIFF
--- a/app/src/main/kotlin/in/jphe/storyvox/data/SettingsRepositoryUiImpl.kt
+++ b/app/src/main/kotlin/in/jphe/storyvox/data/SettingsRepositoryUiImpl.kt
@@ -622,6 +622,18 @@ private object Keys {
      */
     val VOICE_FAMILIES_ENABLED_JSON = stringPreferencesKey("pref_voice_families_enabled_v1")
 
+    /**
+     * v0.5.76 — JSON-encoded `Set<String>` of source plugin ids that
+     * the user has "starred" from the Browse carousel long-press
+     * sheet. Twin of [SOURCE_PLUGINS_ENABLED_JSON], but stores a Set
+     * (favorites have no per-source default — empty set is correct
+     * for every fresh install). Codec lives in
+     * [`in.jphe.storyvox.data.source.plugin.encodeSourceFavoritesJson`].
+     * `_v1` suffix lets us rev to a richer shape later (e.g. ordered
+     * list, per-source position) without a destructive migration.
+     */
+    val SOURCE_FAVORITES_JSON = stringPreferencesKey("pref_source_favorites_v1")
+
     // ── Sleep timer shake-to-extend (issue #150) ───────────────────
     val SLEEP_SHAKE_TO_EXTEND_ENABLED = booleanPreferencesKey("pref_sleep_shake_to_extend_enabled")
 
@@ -1149,6 +1161,12 @@ class SettingsRepositoryUiImpl(
             // when its id is absent, so no migration shim is needed.
             voiceFamiliesEnabled = `in`.jphe.storyvox.data.source.plugin.decodeVoiceFamiliesEnabledJson(
                 prefs[Keys.VOICE_FAMILIES_ENABLED_JSON],
+            ),
+            // v0.5.76 — Browse carousel "starred" sources. Empty on
+            // fresh install; no migration since there's no legacy
+            // shape to seed from.
+            favoriteSourceIds = `in`.jphe.storyvox.data.source.plugin.decodeSourceFavoritesJson(
+                prefs[Keys.SOURCE_FAVORITES_JSON],
             ),
             notionDatabaseId = notion.databaseId,
             notionTokenConfigured = notion.apiToken.isNotBlank(),
@@ -2046,6 +2064,25 @@ class SettingsRepositoryUiImpl(
             current[id] = enabled
             prefs[Keys.SOURCE_PLUGINS_ENABLED_JSON] =
                 `in`.jphe.storyvox.data.source.plugin.encodeSourcePluginsEnabledJson(current)
+        }
+    }
+
+    /**
+     * v0.5.76 — toggle a source plugin's "favorite" star. Read-modify-
+     * write the persisted Set so concurrent toggles for *different*
+     * ids in flight at the same DataStore tick don't clobber each
+     * other (DataStore serializes the edit block, so reading inside
+     * is safe). Unknown ids round-trip into the set without
+     * validation — same posture as [setSourcePluginEnabled].
+     */
+    override suspend fun setSourceFavorite(id: String, favorite: Boolean) {
+        store.edit { prefs ->
+            val current = `in`.jphe.storyvox.data.source.plugin.decodeSourceFavoritesJson(
+                prefs[Keys.SOURCE_FAVORITES_JSON],
+            ).toMutableSet()
+            if (favorite) current.add(id) else current.remove(id)
+            prefs[Keys.SOURCE_FAVORITES_JSON] =
+                `in`.jphe.storyvox.data.source.plugin.encodeSourceFavoritesJson(current)
         }
     }
 

--- a/app/src/test/kotlin/in/jphe/storyvox/data/SettingsRepositoryFavoriteSourcesTest.kt
+++ b/app/src/test/kotlin/in/jphe/storyvox/data/SettingsRepositoryFavoriteSourcesTest.kt
@@ -1,0 +1,159 @@
+package `in`.jphe.storyvox.data
+
+import androidx.datastore.core.DataStore
+import androidx.datastore.preferences.core.PreferenceDataStoreFactory
+import androidx.datastore.preferences.core.Preferences
+import `in`.jphe.storyvox.data.source.SourceIds
+import java.io.File
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlinx.coroutines.test.runTest
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import org.junit.rules.TemporaryFolder
+
+/**
+ * v0.5.76 — real-DataStore tests for [SettingsRepositoryUiImpl.setSourceFavorite].
+ *
+ * Verifies the round-trip from `setSourceFavorite(id, true|false)` to the
+ * persisted `UiSettings.favoriteSourceIds` Set. Mirrors the
+ * [SettingsRepositorySourcePluginsTest] setup so the two stay in
+ * lockstep — favorites use the same DataStore + JSON codec posture as
+ * the enabled map, just with a Set shape.
+ */
+@OptIn(ExperimentalCoroutinesApi::class)
+class SettingsRepositoryFavoriteSourcesTest {
+
+    @get:Rule
+    val tempFolder = TemporaryFolder()
+
+    private lateinit var scope: CoroutineScope
+    private lateinit var store: DataStore<Preferences>
+    private lateinit var repo: SettingsRepositoryUiImpl
+
+    @Before
+    fun setUp() {
+        scope = CoroutineScope(SupervisorJob() + UnconfinedTestDispatcher())
+        val file = File(tempFolder.newFolder(), "storyvox_settings.preferences_pb")
+        store = PreferenceDataStoreFactory.create(
+            scope = scope,
+            produceFile = { file },
+        )
+        val pcmBundle = makeFakeCacheBundle(tempFolder.newFolder("pcm_bundle"), scope)
+        repo = SettingsRepositoryUiImpl(
+            store = store,
+            auth = FakeAuth(),
+            hydrator = FakeHydrator(),
+            palaceConfig = makeFakePalaceConfig(tempFolder.newFolder("palace_ds"), scope),
+            palaceApi = makeFakePalaceApi(),
+            llmCreds = `in`.jphe.storyvox.llm.LlmCredentialsStore.forTesting(),
+            githubAuth = FakeGitHubAuth(),
+            teamsAuth = fakeTeamsAuth(),
+            rssConfig = makeFakeRssConfig(tempFolder.newFolder("rss_ds"), scope),
+            epubConfig = makeFakeEpubConfig(tempFolder.newFolder("epub_ds"), scope),
+            outlineConfig = makeFakeOutlineConfig(tempFolder.newFolder("outline_ds"), scope),
+            wikipediaConfig = makeFakeWikipediaConfig(tempFolder.newFolder("wiki_ds"), scope),
+            notionConfig = makeFakeNotionConfig(tempFolder.newFolder("notion_ds"), scope),
+            discordConfig = makeFakeDiscordConfig(tempFolder.newFolder("discord_ds"), scope),
+            discordGuildDirectory = makeFakeDiscordGuildDirectory(),
+            telegramConfig = makeFakeTelegramConfig(tempFolder.newFolder("telegram_ds"), scope),
+            telegramChannelDirectory = makeFakeTelegramChannelDirectory(),
+            suggestedFeedsRegistry = SuggestedFeedsRegistry(),
+            azureCreds = makeFakeAzureCredentials(),
+            azureClient = makeFakeAzureClient(),
+            azureRoster = makeFakeAzureRoster(),
+            googleTokenSource = `in`.jphe.storyvox.llm.auth.GoogleOAuthTokenSource(okhttp3.OkHttpClient()),
+            pcmCache = pcmBundle.pcmCache,
+            pcmCacheConfig = pcmBundle.pcmCacheConfig,
+            cacheStats = pcmBundle.cacheStats,
+        )
+    }
+
+    @After
+    fun tearDown() {
+        scope.cancel()
+    }
+
+    @Test
+    fun `fresh install starts with empty favoriteSourceIds`() = runTest {
+        val snapshot = repo.settings.first()
+        assertTrue(
+            "Expected empty favorites on fresh install, got ${snapshot.favoriteSourceIds}",
+            snapshot.favoriteSourceIds.isEmpty(),
+        )
+    }
+
+    @Test
+    fun `setSourceFavorite adds the id to the set`() = runTest {
+        repo.setSourceFavorite(SourceIds.ROYAL_ROAD, favorite = true)
+
+        val snapshot = repo.settings.first()
+        assertTrue(SourceIds.ROYAL_ROAD in snapshot.favoriteSourceIds)
+    }
+
+    @Test
+    fun `setSourceFavorite false removes the id from the set`() = runTest {
+        repo.setSourceFavorite(SourceIds.ROYAL_ROAD, favorite = true)
+        repo.setSourceFavorite(SourceIds.AO3, favorite = true)
+        repo.setSourceFavorite(SourceIds.ROYAL_ROAD, favorite = false)
+
+        val snapshot = repo.settings.first()
+        assertFalse(SourceIds.ROYAL_ROAD in snapshot.favoriteSourceIds)
+        assertTrue(
+            "AO3 should remain favorited after RR was un-favorited",
+            SourceIds.AO3 in snapshot.favoriteSourceIds,
+        )
+    }
+
+    @Test
+    fun `setSourceFavorite is idempotent for repeated true calls`() = runTest {
+        repo.setSourceFavorite(SourceIds.GUTENBERG, favorite = true)
+        repo.setSourceFavorite(SourceIds.GUTENBERG, favorite = true)
+        repo.setSourceFavorite(SourceIds.GUTENBERG, favorite = true)
+
+        val snapshot = repo.settings.first()
+        assertEquals(setOf(SourceIds.GUTENBERG), snapshot.favoriteSourceIds)
+    }
+
+    @Test
+    fun `setSourceFavorite accepts unknown ids (forward-compat)`() = runTest {
+        // Same posture as setSourcePluginEnabled — an out-of-tree id
+        // round-trips into the Set without validation. Plugins that
+        // pre-populate their favorited state before their annotation
+        // lands shouldn't lose the bit on a startup race.
+        repo.setSourceFavorite("future-backend", favorite = true)
+
+        val snapshot = repo.settings.first()
+        assertTrue("future-backend" in snapshot.favoriteSourceIds)
+    }
+
+    @Test
+    fun `multiple favorites coexist`() = runTest {
+        repo.setSourceFavorite(SourceIds.ROYAL_ROAD, favorite = true)
+        repo.setSourceFavorite(SourceIds.AO3, favorite = true)
+        repo.setSourceFavorite(SourceIds.GUTENBERG, favorite = true)
+
+        val snapshot = repo.settings.first()
+        assertEquals(
+            setOf(SourceIds.ROYAL_ROAD, SourceIds.AO3, SourceIds.GUTENBERG),
+            snapshot.favoriteSourceIds,
+        )
+    }
+
+    @Test
+    fun `un-favoriting an id that was never favorited is a no-op`() = runTest {
+        repo.setSourceFavorite(SourceIds.WIKIPEDIA, favorite = false)
+
+        val snapshot = repo.settings.first()
+        assertTrue(snapshot.favoriteSourceIds.isEmpty())
+    }
+}

--- a/app/src/test/kotlin/in/jphe/storyvox/di/RealPlaybackControllerUiTest.kt
+++ b/app/src/test/kotlin/in/jphe/storyvox/di/RealPlaybackControllerUiTest.kt
@@ -315,6 +315,7 @@ class RealPlaybackControllerUiTest {
         override suspend fun probeTelegramBot(): String? = null
         override suspend fun fetchTelegramChannels(): List<Pair<String, String>> = emptyList()
         override suspend fun setSourcePluginEnabled(id: String, enabled: Boolean) = Unit
+        override suspend fun setSourceFavorite(id: String, favorite: Boolean) = Unit
         override suspend fun setVoiceFamilyEnabled(id: String, enabled: Boolean) = Unit
         override suspend fun setNotionDatabaseId(id: String) = Unit
         override suspend fun setNotionApiToken(token: String?) = Unit

--- a/core-data/src/main/kotlin/in/jphe/storyvox/data/source/plugin/SourceFavoritesCodec.kt
+++ b/core-data/src/main/kotlin/in/jphe/storyvox/data/source/plugin/SourceFavoritesCodec.kt
@@ -1,0 +1,43 @@
+package `in`.jphe.storyvox.data.source.plugin
+
+import kotlinx.serialization.builtins.SetSerializer
+import kotlinx.serialization.builtins.serializer
+import kotlinx.serialization.json.Json
+
+/**
+ * v0.5.76 — JSON codec for the `Set<pluginId>` of "favorited" source
+ * plugins persisted under the `pref_source_favorites_v1` DataStore key.
+ *
+ * Twin of [SourcePluginsEnabledCodec] but stores a Set (not a Map), since
+ * favorites have no per-source default — empty set is the only sensible
+ * fresh-install state. Promoting a source to a favorite is a strictly
+ * user-driven act from the Browse carousel long-press sheet.
+ *
+ * `ignoreUnknownKeys` doesn't apply (Set has no keys), and we don't need
+ * `encodeDefaults` because the Set serializer always emits its members.
+ * A corrupted blob falls back to empty — same posture as the enabled
+ * codec, where a parse failure means "lose the user's favorites" rather
+ * than "crash startup".
+ */
+private val SourceFavoritesJson = Json {
+    ignoreUnknownKeys = true
+}
+
+private val SetSerializer = SetSerializer(String.serializer())
+
+/** Serialize [favorites] to a JSON array for DataStore storage. */
+fun encodeSourceFavoritesJson(favorites: Set<String>): String =
+    SourceFavoritesJson.encodeToString(SetSerializer, favorites)
+
+/**
+ * Parse a JSON blob produced by [encodeSourceFavoritesJson]. Returns
+ * an empty set for null / blank / parse-failed input — corruption
+ * shouldn't crash startup. A user with a corrupted favorites blob
+ * sees an unstarred carousel and can re-star.
+ */
+fun decodeSourceFavoritesJson(blob: String?): Set<String> {
+    if (blob.isNullOrBlank()) return emptySet()
+    return runCatching {
+        SourceFavoritesJson.decodeFromString(SetSerializer, blob)
+    }.getOrDefault(emptySet())
+}

--- a/core-data/src/test/kotlin/in/jphe/storyvox/data/source/plugin/SourceFavoritesCodecTest.kt
+++ b/core-data/src/test/kotlin/in/jphe/storyvox/data/source/plugin/SourceFavoritesCodecTest.kt
@@ -1,0 +1,55 @@
+package `in`.jphe.storyvox.data.source.plugin
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * v0.5.76 — codec round-trip tests for the JSON set persisted under
+ * `pref_source_favorites_v1`.
+ *
+ * Mirrors [SourcePluginsEnabledCodecTest]'s failure-mode contract:
+ * - Null / blank / unparseable input returns an empty set (no throw).
+ * - Encode → decode round-trips intact regardless of insertion order.
+ * - Empty set encodes to a well-formed JSON array, not an empty string.
+ */
+class SourceFavoritesCodecTest {
+
+    @Test fun `null input decodes to empty set`() {
+        assertEquals(emptySet<String>(), decodeSourceFavoritesJson(null))
+    }
+
+    @Test fun `blank input decodes to empty set`() {
+        assertEquals(emptySet<String>(), decodeSourceFavoritesJson(""))
+        assertEquals(emptySet<String>(), decodeSourceFavoritesJson("   "))
+    }
+
+    @Test fun `unparseable input decodes to empty set without throwing`() {
+        assertEquals(emptySet<String>(), decodeSourceFavoritesJson("not json"))
+        assertEquals(emptySet<String>(), decodeSourceFavoritesJson("{garbage"))
+    }
+
+    @Test fun `round-trip preserves members`() {
+        val original = setOf("royalroad", "ao3", "gutenberg")
+
+        val encoded = encodeSourceFavoritesJson(original)
+        val decoded = decodeSourceFavoritesJson(encoded)
+
+        assertEquals(original, decoded)
+    }
+
+    @Test fun `empty set round-trips`() {
+        val encoded = encodeSourceFavoritesJson(emptySet())
+        val decoded = decodeSourceFavoritesJson(encoded)
+        assertEquals(emptySet<String>(), decoded)
+    }
+
+    @Test fun `empty set encodes to a non-blank JSON array`() {
+        // Important — encoding must not produce "" or null. The DataStore
+        // round-trip writes whatever this returns; if it's blank, the
+        // decoder's null/blank guard kicks in next read and we'd lose
+        // an *intentionally empty* favorites set on every save.
+        val encoded = encodeSourceFavoritesJson(emptySet())
+        assertTrue("expected non-blank encoding, got '$encoded'", encoded.isNotBlank())
+    }
+}

--- a/feature/src/main/kotlin/in/jphe/storyvox/feature/api/UiContracts.kt
+++ b/feature/src/main/kotlin/in/jphe/storyvox/feature/api/UiContracts.kt
@@ -1068,6 +1068,20 @@ data class UiSettings(
      */
     val sourcePluginsEnabled: Map<String, Boolean> = emptyMap(),
     /**
+     * v0.5.76 — set of stable plugin ids the user has "starred" from
+     * the Browse carousel's long-press sheet. Favorited sources are
+     * pinned to the front of the carousel in registry order, ahead of
+     * non-favorites. The set is purely a UI ordering hint; it does not
+     * affect [sourcePluginsEnabled] (a source can be favorited but
+     * disabled, in which case it's still hidden until re-enabled).
+     *
+     * Storage: JSON-encoded `Set<String>` under
+     * `pref_source_favorites_v1` (see
+     * [`in.jphe.storyvox.data.source.plugin.encodeSourceFavoritesJson`]).
+     * No migration is needed — the natural default is empty.
+     */
+    val favoriteSourceIds: Set<String> = emptySet(),
+    /**
      * Plugin-seam Phase 4 (#501) — per-voice-family on/off keyed by
      * stable family id (`voice_piper`, `voice_kokoro`, `voice_kitten`,
      * `voice_azure`). Twin of [sourcePluginsEnabled] for the Plugin
@@ -2027,6 +2041,16 @@ interface SettingsRepositoryUi {
      * collapsed into this one entry point.
      */
     suspend fun setSourcePluginEnabled(id: String, enabled: Boolean)
+
+    /**
+     * v0.5.76 — toggle a source plugin's "favorite" star by stable id.
+     * Favorited ids are added to [UiSettings.favoriteSourceIds];
+     * unfavorited ids are removed. The Browse carousel projection
+     * re-sorts so favorites land at the front of the row in registry
+     * order. Favoriting a disabled source is allowed (the star will
+     * apply once the source is re-enabled).
+     */
+    suspend fun setSourceFavorite(id: String, favorite: Boolean)
 
     /**
      * Plugin-seam Phase 4 (#501) — toggle a voice family by its stable

--- a/feature/src/main/kotlin/in/jphe/storyvox/feature/browse/BrowseScreen.kt
+++ b/feature/src/main/kotlin/in/jphe/storyvox/feature/browse/BrowseScreen.kt
@@ -187,6 +187,10 @@ fun BrowseScreen(
             selectedId = state.sourceId,
             onSelect = viewModel::selectSource,
             visibleSources = state.visibleSources,
+            // v0.5.76 — long-press → bottom sheet → favorite/hide.
+            favoriteSourceIds = state.favoriteSourceIds,
+            onToggleFavorite = viewModel::toggleFavorite,
+            onHideSource = { viewModel.setSourceEnabled(it, enabled = false) },
             modifier = Modifier.fillMaxWidth(),
         )
 

--- a/feature/src/main/kotlin/in/jphe/storyvox/feature/browse/BrowseSourceCarousel.kt
+++ b/feature/src/main/kotlin/in/jphe/storyvox/feature/browse/BrowseSourceCarousel.kt
@@ -9,10 +9,12 @@ import androidx.compose.animation.core.tween
 import androidx.compose.foundation.BorderStroke
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
+import androidx.compose.foundation.combinedClickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
@@ -24,6 +26,7 @@ import androidx.compose.foundation.lazy.LazyListState
 import androidx.compose.foundation.lazy.LazyRow
 import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.lazy.rememberLazyListState
+import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.AutoStories
@@ -43,22 +46,33 @@ import androidx.compose.material.icons.filled.Radio
 import androidx.compose.material.icons.filled.RssFeed
 import androidx.compose.material.icons.filled.Science
 import androidx.compose.material.icons.filled.Send
+import androidx.compose.material.icons.filled.Star
+import androidx.compose.material.icons.filled.StarBorder
 import androidx.compose.material.icons.filled.Tag
+import androidx.compose.material.icons.filled.VisibilityOff
 import androidx.compose.material.icons.filled.Workspaces
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.ModalBottomSheet
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
+import androidx.compose.material3.rememberModalBottomSheetState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.semantics.Role
 import androidx.compose.ui.semantics.selected
 import androidx.compose.ui.semantics.semantics
@@ -68,6 +82,7 @@ import androidx.compose.ui.unit.dp
 import `in`.jphe.storyvox.data.source.SourceIds
 import `in`.jphe.storyvox.data.source.plugin.SourcePluginDescriptor
 import `in`.jphe.storyvox.ui.theme.LocalSpacing
+import kotlinx.coroutines.launch
 
 /**
  * v0.5.72 — magical hero source carousel for the first-class Browse tab.
@@ -93,12 +108,27 @@ import `in`.jphe.storyvox.ui.theme.LocalSpacing
  * The carousel auto-scrolls the selected card into view whenever
  * [selectedId] changes, so deep-links / sub-tab returns always land with
  * the active source visible.
+ *
+ * ## v0.5.76 — long-press favorites + hide
+ *
+ * Long-press any card to surface a [SourceContextSheet] with two actions:
+ * - **Star** the source so it pins to the front of the row (in registry
+ *   order within favorites). Tap the star row again to unstar.
+ * - **Hide** the source from the carousel. Settings → Plugins re-enables
+ *   it; the sheet's footer copy names that path so the user always has a
+ *   way back.
+ *
+ * Favorited cards render a small filled star in the top-right corner,
+ * persistent across selected/unselected states, in `primary` color.
  */
 @Composable
 internal fun BrowseSourceCarousel(
     selectedId: String,
     onSelect: (String) -> Unit,
     visibleSources: List<SourcePluginDescriptor>,
+    favoriteSourceIds: Set<String> = emptySet(),
+    onToggleFavorite: (String) -> Unit = {},
+    onHideSource: (String) -> Unit = {},
     modifier: Modifier = Modifier,
 ) {
     val spacing = LocalSpacing.current
@@ -117,6 +147,12 @@ internal fun BrowseSourceCarousel(
         }
     }
 
+    // v0.5.76 — long-press target. Null when the sheet is dismissed.
+    // Held at the carousel level (rather than per-card) so dismiss flow
+    // and the sheet share one state surface and the sheet only mounts
+    // once at a time.
+    var contextSheetFor by remember { mutableStateOf<SourcePluginDescriptor?>(null) }
+
     LazyRow(
         state = listState,
         modifier = modifier
@@ -129,17 +165,38 @@ internal fun BrowseSourceCarousel(
             BrowseSourceCard(
                 descriptor = descriptor,
                 isSelected = descriptor.id == selectedId,
+                isFavorite = descriptor.id in favoriteSourceIds,
                 onClick = { onSelect(descriptor.id) },
+                onLongClick = { contextSheetFor = descriptor },
             )
         }
     }
+
+    contextSheetFor?.let { descriptor ->
+        SourceContextSheet(
+            descriptor = descriptor,
+            isFavorite = descriptor.id in favoriteSourceIds,
+            onToggleFavorite = {
+                onToggleFavorite(descriptor.id)
+                contextSheetFor = null
+            },
+            onHide = {
+                onHideSource(descriptor.id)
+                contextSheetFor = null
+            },
+            onDismiss = { contextSheetFor = null },
+        )
+    }
 }
 
+@OptIn(androidx.compose.foundation.ExperimentalFoundationApi::class)
 @Composable
 private fun BrowseSourceCard(
     descriptor: SourcePluginDescriptor,
     isSelected: Boolean,
+    isFavorite: Boolean,
     onClick: () -> Unit,
+    onLongClick: () -> Unit,
 ) {
     // Hoist into a local so the `Modifier.semantics { selected = ... }`
     // lambda below isn't confused by Compose's `selected` property name —
@@ -202,7 +259,17 @@ private fun BrowseSourceCard(
             // hint intact even on the selected cell — same rationale as
             // BottomTabBar #645.
             .semantics { this.selected = selected }
-            .clickable(role = Role.Button, onClickLabel = label, onClick = onClick),
+            // v0.5.76 — combinedClickable adds long-press without losing
+            // the click semantics or role. The onLongClickLabel is read by
+            // TalkBack on long-press hint announce ("Double-tap and hold
+            // for options").
+            .combinedClickable(
+                role = Role.Button,
+                onClickLabel = label,
+                onLongClickLabel = "Source options",
+                onClick = onClick,
+                onLongClick = onLongClick,
+            ),
         shape = RoundedCornerShape(14.dp),
         color = Color.Transparent,
         border = BorderStroke(if (selected) 2.dp else 1.dp, borderAlpha),
@@ -242,9 +309,212 @@ private fun BrowseSourceCard(
                     overflow = TextOverflow.Ellipsis,
                 )
             }
+
+            // v0.5.76 — favorite star overlay. Top-right corner, primary
+            // color, soft container behind it so it reads on both gradient
+            // states (selected primaryContainer + unselected surface). The
+            // overlay is decorative — the card's selected-state semantics
+            // already include the source name; TalkBack doesn't need to
+            // announce "starred" separately for every favorite card. The
+            // long-press sheet is where star state is read and changed.
+            if (isFavorite) {
+                Box(
+                    modifier = Modifier
+                        .align(Alignment.TopEnd)
+                        .padding(2.dp)
+                        .size(18.dp)
+                        .clip(CircleShape)
+                        .background(
+                            MaterialTheme.colorScheme.surface.copy(alpha = 0.85f),
+                        ),
+                    contentAlignment = Alignment.Center,
+                ) {
+                    Icon(
+                        imageVector = Icons.Filled.Star,
+                        contentDescription = null,
+                        tint = primary,
+                        modifier = Modifier.size(12.dp),
+                    )
+                }
+            }
         }
     }
 }
+
+/**
+ * v0.5.76 — long-press context sheet for a source card.
+ *
+ * Renders as a [ModalBottomSheet] anchored to the bottom of the screen,
+ * with a compact header (icon + display name + tagline) and two action
+ * rows: toggle favorite, hide-from-Browse. A footer line names the
+ * Settings → Plugins re-enable path so disabling the source never
+ * feels like a one-way door.
+ *
+ * Two rows is intentionally narrow scope. Future actions (per-source
+ * sign-in, "open in WebView", reorder) belong here too, but only after
+ * the data layer can express them; piling rows in pre-emptively would
+ * just make the favorite/hide affordance harder to find.
+ */
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+private fun SourceContextSheet(
+    descriptor: SourcePluginDescriptor,
+    isFavorite: Boolean,
+    onToggleFavorite: () -> Unit,
+    onHide: () -> Unit,
+    onDismiss: () -> Unit,
+) {
+    val spacing = LocalSpacing.current
+    val scope = rememberCoroutineScope()
+    val sheetState = rememberModalBottomSheetState(skipPartiallyExpanded = true)
+
+    val label = BrowseSourceUi.chipLabel(descriptor.id, descriptor.displayName)
+    val tagline = sourceTagline(descriptor.id)
+    val glyph = sourceGlyph(descriptor.id)
+
+    fun dismissThen(action: () -> Unit) {
+        // Animate-then-act so the user perceives the sheet acknowledging
+        // their tap before the underlying state shifts. Mirrors the
+        // Material 3 sample for action-then-dismiss flows.
+        scope.launch {
+            sheetState.hide()
+        }.invokeOnCompletion {
+            action()
+        }
+    }
+
+    ModalBottomSheet(
+        onDismissRequest = onDismiss,
+        sheetState = sheetState,
+        modifier = Modifier.testTag("source-context-sheet"),
+    ) {
+        Column(modifier = Modifier.padding(horizontal = spacing.md, vertical = spacing.sm)) {
+            // Header — icon + name + tagline. Smaller than the carousel
+            // card, but visually identical so the user reads "this sheet
+            // is acting on THIS source".
+            Row(
+                modifier = Modifier.fillMaxWidth().padding(bottom = spacing.sm),
+                verticalAlignment = Alignment.CenterVertically,
+                horizontalArrangement = Arrangement.spacedBy(spacing.sm),
+            ) {
+                Icon(
+                    imageVector = glyph,
+                    contentDescription = null,
+                    tint = MaterialTheme.colorScheme.primary,
+                    modifier = Modifier.size(28.dp),
+                )
+                Column(modifier = Modifier.weight(1f)) {
+                    Text(
+                        text = label,
+                        style = MaterialTheme.typography.titleMedium,
+                        fontWeight = FontWeight.SemiBold,
+                        maxLines = 1,
+                        overflow = TextOverflow.Ellipsis,
+                    )
+                    if (tagline.isNotBlank()) {
+                        Text(
+                            text = tagline,
+                            style = MaterialTheme.typography.bodySmall,
+                            color = MaterialTheme.colorScheme.onSurfaceVariant,
+                            maxLines = 1,
+                            overflow = TextOverflow.Ellipsis,
+                        )
+                    }
+                }
+            }
+            HorizontalDivider()
+
+            // Star / unstar row.
+            SheetActionRow(
+                icon = if (isFavorite) Icons.Filled.Star else Icons.Filled.StarBorder,
+                iconTint = if (isFavorite) MaterialTheme.colorScheme.primary
+                else MaterialTheme.colorScheme.onSurface,
+                title = if (isFavorite) "Remove from favorites" else "Add to favorites",
+                subtitle = if (isFavorite) {
+                    "Will keep its place in the list"
+                } else {
+                    "Pins to the front of the carousel"
+                },
+                titleColor = MaterialTheme.colorScheme.onSurface,
+                testTag = "source-context-sheet-favorite",
+                onClick = { dismissThen(onToggleFavorite) },
+            )
+
+            // Hide row.
+            SheetActionRow(
+                icon = Icons.Filled.VisibilityOff,
+                iconTint = MaterialTheme.colorScheme.error,
+                title = "Hide from Browse",
+                subtitle = "Re-enable from Settings -> Plugins",
+                titleColor = MaterialTheme.colorScheme.error,
+                testTag = "source-context-sheet-hide",
+                onClick = { dismissThen(onHide) },
+            )
+
+            Spacer(modifier = Modifier.height(spacing.sm))
+        }
+    }
+}
+
+@Composable
+private fun SheetActionRow(
+    icon: ImageVector,
+    iconTint: Color,
+    title: String,
+    subtitle: String,
+    titleColor: Color,
+    testTag: String,
+    onClick: () -> Unit,
+) {
+    val spacing = LocalSpacing.current
+    Row(
+        modifier = Modifier
+            .fillMaxWidth()
+            .testTag(testTag)
+            .semantics(mergeDescendants = true) { }
+            .clip(RoundedCornerShape(8.dp))
+            // Clickable AFTER clip so the ripple stays inside the
+            // rounded corners; mergeDescendants gives TalkBack one
+            // composite announcement per row.
+            .androidxClickable(
+                onClickLabel = title,
+                onClick = onClick,
+            )
+            .padding(horizontal = spacing.xs, vertical = spacing.sm),
+        verticalAlignment = Alignment.CenterVertically,
+        horizontalArrangement = Arrangement.spacedBy(spacing.md),
+    ) {
+        Icon(
+            imageVector = icon,
+            contentDescription = null,
+            tint = iconTint,
+            modifier = Modifier.size(24.dp),
+        )
+        Column(modifier = Modifier.weight(1f)) {
+            Text(
+                text = title,
+                style = MaterialTheme.typography.bodyLarge,
+                color = titleColor,
+            )
+            Text(
+                text = subtitle,
+                style = MaterialTheme.typography.bodySmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
+        }
+    }
+}
+
+/** Tiny helper so the sheet row Modifier chain reads top-to-bottom.
+ *  Wraps Modifier.clickable so the sheet rows stay readable without a
+ *  block-level `.clickable { ... }` mid-chain. */
+private fun Modifier.androidxClickable(onClickLabel: String, onClick: () -> Unit): Modifier =
+    this.clickable(
+        enabled = true,
+        onClickLabel = onClickLabel,
+        role = Role.Button,
+        onClick = onClick,
+    )
 
 /**
  * Short, plain-English tagline rendered under the source name in the

--- a/feature/src/main/kotlin/in/jphe/storyvox/feature/browse/BrowseViewModel.kt
+++ b/feature/src/main/kotlin/in/jphe/storyvox/feature/browse/BrowseViewModel.kt
@@ -95,8 +95,20 @@ data class BrowseUiState(
     val enabledSourceIds: Set<String> = emptySet(),
     /** Ordered list of plugin descriptors visible to the picker (the
      *  enabled subset, in registry display order). Surfaced here so the
-     *  chip strip can render without re-injecting the registry. */
+     *  chip strip can render without re-injecting the registry.
+     *
+     *  v0.5.76 — favorites are pinned to the front of this list in
+     *  registry order, non-favorites follow in registry order. The
+     *  carousel renders this list directly so the visual order matches
+     *  the data-layer order without any extra sort in the UI. */
     val visibleSources: List<SourcePluginDescriptor> = emptyList(),
+    /** v0.5.76 — ids the user has "starred" from the Browse carousel
+     *  long-press sheet. Subset of [enabledSourceIds] in practice
+     *  (favoriting a disabled source is allowed but the star only
+     *  visibly applies when the source becomes visible again). The
+     *  carousel renders a star overlay on cards whose id is in this
+     *  set. */
+    val favoriteSourceIds: Set<String> = emptySet(),
     /** Issue #443 — true when the Notion source is in anonymous-public
      *  mode (no integration token configured). The Notion listing then
      *  surfaces TechEmpower's public content as a zero-setup demo; the
@@ -129,6 +141,7 @@ private data class ControlsView(
     val ao3SignedIn: Boolean,
     val enabledSourceIds: Set<String>,
     val visibleSources: List<SourcePluginDescriptor>,
+    val favoriteSourceIds: Set<String>,
 )
 
 /**
@@ -281,6 +294,15 @@ class BrowseViewModel @Inject constructor(
                 registry.descriptors.filter { it.defaultEnabled }.map { it.id }.toSet(),
             )
 
+    /** v0.5.76 — the user's "starred" sources, surfaced to the carousel
+     *  as the membership signal for the corner star overlay AND as the
+     *  re-ordering input for `visibleSources` below. */
+    private val favoriteSourceIds: StateFlow<Set<String>> =
+        settings.settings
+            .map { it.favoriteSourceIds }
+            .distinctUntilChanged()
+            .stateIn(viewModelScope, SharingStarted.WhileSubscribed(5_000), emptySet())
+
     private val paginator: StateFlow<BrowsePaginator?> = run {
         val baseTuple = combine(
             _sourceId,
@@ -365,12 +387,31 @@ class BrowseViewModel @Inject constructor(
         // #693 — fold palace + generic filter into one stream to stay
         // inside the 4-arg combine overload.
         val sourceFilters = combine(_palaceFilter, _genericFilter) { pf, gf -> pf to gf }
+        // v0.5.76 — fold favorites into the enabled-set stream so the
+        // top-level controls combine() stays at 4 args. The pair carries
+        // both into the final reducer, where visibleSources is sorted
+        // favorites-first within registry order.
+        val enabledAndFavorites = combine(enabledSourceIds, favoriteSourceIds) { e, f -> e to f }
         combine(
             baseTuple,
             sourceFilters,
             authSnapshot,
-            enabledSourceIds,
-        ) { tup, filters, auth, enabled ->
+            enabledAndFavorites,
+        ) { tup, filters, auth, ef ->
+            val (enabled, favorites) = ef
+            // Sort: favorites first (registry order), then non-favorites
+            // (registry order). Using partitionedBy on registry.descriptors
+            // — which is already in display order — keeps two passes
+            // O(n) and stable.
+            val visible = run {
+                val faves = mutableListOf<SourcePluginDescriptor>()
+                val rest = mutableListOf<SourcePluginDescriptor>()
+                for (d in registry.descriptors) {
+                    if (d.id !in enabled) continue
+                    if (d.id in favorites) faves.add(d) else rest.add(d)
+                }
+                faves + rest
+            }
             ControlsView(
                 sourceId = tup.sourceId,
                 tab = tup.tab,
@@ -384,7 +425,8 @@ class BrowseViewModel @Inject constructor(
                 royalRoadSignedIn = auth.royalRoadSignedIn,
                 ao3SignedIn = auth.ao3SignedIn,
                 enabledSourceIds = enabled,
-                visibleSources = registry.descriptors.filter { it.id in enabled },
+                visibleSources = visible,
+                favoriteSourceIds = favorites,
             )
         }
     }
@@ -415,6 +457,7 @@ class BrowseViewModel @Inject constructor(
                     ao3SignedIn = c.ao3SignedIn,
                     enabledSourceIds = c.enabledSourceIds,
                     visibleSources = c.visibleSources,
+                    favoriteSourceIds = c.favoriteSourceIds,
                     notionAnonymousActive = notionAnon,
                 )
             }
@@ -452,6 +495,7 @@ class BrowseViewModel @Inject constructor(
                     ao3SignedIn = c.ao3SignedIn,
                     enabledSourceIds = c.enabledSourceIds,
                     visibleSources = c.visibleSources,
+                    favoriteSourceIds = c.favoriteSourceIds,
                     notionAnonymousActive = notionAnon,
                 )
             }
@@ -524,6 +568,38 @@ class BrowseViewModel @Inject constructor(
                 .getOrDefault(emptyList())
             if (wings.isEmpty()) palaceWingsLoaded = false
             _palaceWings.value = wings
+        }
+    }
+
+    /**
+     * v0.5.76 — toggle a source plugin's favorite star from the Browse
+     * carousel long-press sheet. The persisted set is updated through
+     * the settings repo; the next [BrowseUiState] emission re-sorts
+     * [BrowseUiState.visibleSources] so the just-starred card slides to
+     * the front of the row.
+     *
+     * Note: favoriting a *disabled* source is allowed and persists, but
+     * the card stays hidden in the carousel until the source is
+     * re-enabled. This is intentional — the long-press sheet can star
+     * a card before disabling it, and re-enabling later restores both
+     * the visibility and the star without a second tap.
+     */
+    fun toggleFavorite(id: String) {
+        val currentFavorite = id in (uiState.value.favoriteSourceIds)
+        viewModelScope.launch {
+            settings.setSourceFavorite(id, favorite = !currentFavorite)
+        }
+    }
+
+    /**
+     * v0.5.76 — enable/disable a source plugin from the Browse carousel
+     * long-press sheet. Twin entry point to the Plugin Manager
+     * Settings row — same persistence layer, just reachable from the
+     * gesture that surfaced the question.
+     */
+    fun setSourceEnabled(id: String, enabled: Boolean) {
+        viewModelScope.launch {
+            settings.setSourcePluginEnabled(id, enabled)
         }
     }
 

--- a/feature/src/test/kotlin/in/jphe/storyvox/feature/chat/ChatViewModelTest.kt
+++ b/feature/src/test/kotlin/in/jphe/storyvox/feature/chat/ChatViewModelTest.kt
@@ -785,6 +785,7 @@ private class FakeSettingsRepo(
         override suspend fun probeTelegramBot(): String? = null
         override suspend fun fetchTelegramChannels(): List<Pair<String, String>> = emptyList()
         override suspend fun setSourcePluginEnabled(id: String, enabled: Boolean) = Unit
+        override suspend fun setSourceFavorite(id: String, favorite: Boolean) = Unit
         override suspend fun setVoiceFamilyEnabled(id: String, enabled: Boolean) = Unit
         override suspend fun setNotionDatabaseId(id: String) = Unit
         override suspend fun setNotionApiToken(token: String?) = Unit

--- a/feature/src/test/kotlin/in/jphe/storyvox/feature/chat/tools/ChatToolHandlersTest.kt
+++ b/feature/src/test/kotlin/in/jphe/storyvox/feature/chat/tools/ChatToolHandlersTest.kt
@@ -349,6 +349,7 @@ private class FakeSettings : SettingsRepositoryUi {
     override suspend fun signOutGitHub() = Unit
     override suspend fun setGitHubPrivateReposEnabled(enabled: Boolean) = Unit
     override suspend fun setSourcePluginEnabled(id: String, enabled: Boolean) = Unit
+    override suspend fun setSourceFavorite(id: String, favorite: Boolean) = Unit
     override suspend fun setVoiceFamilyEnabled(id: String, enabled: Boolean) = Unit
     override suspend fun setOutlineHost(host: String) = Unit
     override suspend fun setOutlineApiKey(apiKey: String) = Unit

--- a/feature/src/test/kotlin/in/jphe/storyvox/feature/settings/SettingsViewModelBufferTest.kt
+++ b/feature/src/test/kotlin/in/jphe/storyvox/feature/settings/SettingsViewModelBufferTest.kt
@@ -211,6 +211,7 @@ class SettingsViewModelBufferTest {
         override suspend fun probeTelegramBot(): String? = null
         override suspend fun fetchTelegramChannels(): List<Pair<String, String>> = emptyList()
         override suspend fun setSourcePluginEnabled(id: String, enabled: Boolean) = Unit
+        override suspend fun setSourceFavorite(id: String, favorite: Boolean) = Unit
         override suspend fun setVoiceFamilyEnabled(id: String, enabled: Boolean) = Unit
         override suspend fun setNotionDatabaseId(id: String) = Unit
         override suspend fun setNotionApiToken(token: String?) = Unit

--- a/feature/src/test/kotlin/in/jphe/storyvox/feature/settings/SettingsViewModelModesTest.kt
+++ b/feature/src/test/kotlin/in/jphe/storyvox/feature/settings/SettingsViewModelModesTest.kt
@@ -286,6 +286,7 @@ class SettingsViewModelModesTest {
         override suspend fun probeTelegramBot(): String? = null
         override suspend fun fetchTelegramChannels(): List<Pair<String, String>> = emptyList()
         override suspend fun setSourcePluginEnabled(id: String, enabled: Boolean) = Unit
+        override suspend fun setSourceFavorite(id: String, favorite: Boolean) = Unit
         override suspend fun setVoiceFamilyEnabled(id: String, enabled: Boolean) = Unit
         override suspend fun setNotionDatabaseId(id: String) = Unit
         override suspend fun setNotionApiToken(token: String?) = Unit

--- a/feature/src/test/kotlin/in/jphe/storyvox/feature/settings/SettingsViewModelPunctuationPauseTest.kt
+++ b/feature/src/test/kotlin/in/jphe/storyvox/feature/settings/SettingsViewModelPunctuationPauseTest.kt
@@ -224,6 +224,7 @@ class SettingsViewModelPunctuationPauseTest {
         override suspend fun probeTelegramBot(): String? = null
         override suspend fun fetchTelegramChannels(): List<Pair<String, String>> = emptyList()
         override suspend fun setSourcePluginEnabled(id: String, enabled: Boolean) = Unit
+        override suspend fun setSourceFavorite(id: String, favorite: Boolean) = Unit
         override suspend fun setVoiceFamilyEnabled(id: String, enabled: Boolean) = Unit
         override suspend fun setNotionDatabaseId(id: String) = Unit
         override suspend fun setNotionApiToken(token: String?) = Unit


### PR DESCRIPTION
## Summary
- Long-press any source card in the Browse carousel to surface a context sheet with **favorite** and **hide** actions
- Favorited sources pin to the front of the carousel (registry order within favorites, then non-favorites)
- Starred cards render a small star overlay in the top-right corner
- Hidden sources disable from Browse; re-enable from Settings → Plugins
- Favorites persist via DataStore as JSON `Set<String>` under `pref_source_favorites_v1`

## Changes
- **`SourceFavoritesCodec`** — encode/decode for the favorites JSON set
- **`UiContracts.kt`** — `UiSettings.favoriteSourceIds` + `SettingsRepositoryUi.setSourceFavorite()`
- **`SettingsRepositoryUiImpl`** — read-modify-write persistence via DataStore
- **`BrowseViewModel`** — `toggleFavorite()` + `setSourceEnabled()` + favorites-first sort in `visibleSources`
- **`BrowseSourceCarousel`** — `SourceContextSheet` composable, star overlay, `combinedClickable` long-press
- **`BrowseScreen`** — wires three new callbacks to the carousel
- **Tests** — `SourceFavoritesCodecTest` (codec round-trip), `SettingsRepositoryFavoriteSourcesTest` (DataStore persistence), 5 fake stubs updated

## Test plan
- [ ] Long-press a source card → context sheet appears with source name, tagline, star/hide rows
- [ ] Tap "Add to favorites" → sheet dismisses, card gets star overlay, slides to front of carousel
- [ ] Tap "Remove from favorites" → star removed, card returns to registry position
- [ ] Tap "Hide from Browse" → card disappears from carousel; re-enable in Settings → Plugins
- [ ] Kill + relaunch app → favorites persist across sessions
- [ ] All unit tests pass (`./gradlew testDebugUnitTest`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)