### PR TITLE
fix(sync): wire Browse-carousel favorites into sync allowlist

### DIFF
--- a/app/src/main/kotlin/in/jphe/storyvox/data/SettingsRepositoryUiImpl.kt
+++ b/app/src/main/kotlin/in/jphe/storyvox/data/SettingsRepositoryUiImpl.kt
@@ -2074,16 +2074,28 @@ class SettingsRepositoryUiImpl(
      * other (DataStore serializes the edit block, so reading inside
      * is safe). Unknown ids round-trip into the set without
      * validation — same posture as [setSourcePluginEnabled].
+     *
+     * Idempotent: a no-op favorite (re-add of an already-favorited id,
+     * or remove of one that's not present) skips the JSON write.
+     * [stampSyncedWrite] still fires unconditionally so a deliberate
+     * "touch" by the user after a sync conflict still pushes their
+     * intent forward. The key is in [SYNC_ALLOWLIST] + [SYNC_KEY_TYPES]
+     * so favorites ride the next InstantDB sync round to the user's
+     * other devices — cross-device intent ("AO3 is my main source") is
+     * the kind of preference users want mirrored everywhere.
      */
     override suspend fun setSourceFavorite(id: String, favorite: Boolean) {
         store.edit { prefs ->
             val current = `in`.jphe.storyvox.data.source.plugin.decodeSourceFavoritesJson(
                 prefs[Keys.SOURCE_FAVORITES_JSON],
             ).toMutableSet()
-            if (favorite) current.add(id) else current.remove(id)
-            prefs[Keys.SOURCE_FAVORITES_JSON] =
-                `in`.jphe.storyvox.data.source.plugin.encodeSourceFavoritesJson(current)
+            val changed = if (favorite) current.add(id) else current.remove(id)
+            if (changed) {
+                prefs[Keys.SOURCE_FAVORITES_JSON] =
+                    `in`.jphe.storyvox.data.source.plugin.encodeSourceFavoritesJson(current)
+            }
         }
+        stampSyncedWrite()
     }
 
     /**
@@ -2783,6 +2795,10 @@ class SettingsRepositoryUiImpl(
             "pref_source_plos_enabled",
             "pref_source_discord_enabled",
             "pref_source_plugins_enabled_v1",
+            // v0.5.76 — Browse-carousel favorites. Same family as the
+            // enabled-plugins map: cross-device intent ("AO3 is my main
+            // source") rides the sync.
+            "pref_source_favorites_v1",
             // Sleep timer.
             "pref_sleep_shake_to_extend_enabled",
             // Azure fallback.
@@ -2851,6 +2867,7 @@ class SettingsRepositoryUiImpl(
             "pref_ai_bedrock_region" to SyncedType.STRING,
             "pref_ai_bedrock_model" to SyncedType.STRING,
             "pref_source_plugins_enabled_v1" to SyncedType.STRING,
+            "pref_source_favorites_v1" to SyncedType.STRING,
             "pref_azure_fallback_voice_id" to SyncedType.STRING,
             // Float keys.
             "pref_default_speed" to SyncedType.FLOAT,

--- a/app/src/test/kotlin/in/jphe/storyvox/data/SettingsRepositorySyncSnapshotTest.kt
+++ b/app/src/test/kotlin/in/jphe/storyvox/data/SettingsRepositorySyncSnapshotTest.kt
@@ -231,6 +231,25 @@ class SettingsRepositorySyncSnapshotTest {
         assertEquals(first, second)
     }
 
+    @Test fun `source favorites key IS in SYNC_ALLOWLIST (same family as plugins-enabled)`() {
+        // v0.5.76 — Browse-carousel favorites. The user's set of
+        // starred sources is cross-device intent ("AO3 is my main
+        // source"), the same kind of preference that drives
+        // pref_source_plugins_enabled_v1 into the allowlist. If a
+        // future refactor accidentally drops it, the favorites star
+        // becomes per-device — easy to miss on dogfood, painful to
+        // notice on a sign-in to a new device.
+        assertTrue(
+            "pref_source_favorites_v1 must sync — cross-device intent",
+            "pref_source_favorites_v1" in SettingsRepositoryUiImpl.SYNC_ALLOWLIST,
+        )
+        assertEquals(
+            "pref_source_favorites_v1 is JSON-encoded, must use STRING codec",
+            SettingsRepositoryUiImpl.SyncedType.STRING,
+            SettingsRepositoryUiImpl.SYNC_KEY_TYPES["pref_source_favorites_v1"],
+        )
+    }
+
     @Test fun `pronunciation dict key is NOT in SYNC_ALLOWLIST (handled by its own syncer)`() {
         assertFalse(
             "pronunciation dict must NOT be in the settings allowlist — it has its own syncer",


### PR DESCRIPTION
## Summary

Post-merge follow-up to PR #751 addressing Gemini's review feedback. The favorites Set landed in v0.5.76 without sync integration — starring a source on one device never reached the user's other devices.

## What's fixed

- `setSourceFavorite` now has an idempotent guard (skip the JSON write if the set didn't actually change) and unconditionally calls `stampSyncedWrite()` so the next InstantDB sync round picks up the new state.
- `pref_source_favorites_v1` added to `SYNC_ALLOWLIST` + `SYNC_KEY_TYPES` (STRING shape — JSON-encoded set, same codec dispatch as the plugins-enabled map).
- `SettingsRepositorySyncSnapshotTest` gains a positive assertion that the key is in both tables with the STRING codec, so a future refactor can't silently drop it.

## Why

Cross-device intent ("AO3 is my main source") is the kind of preference users want mirrored everywhere they've signed in — same family as `pref_source_plugins_enabled_v1`, which has been synced since v0.5.31. Without this fix, a user who stars Royal Road on their tablet would still see the unstarred default order on their phone after sign-in.

## Test plan

- [x] `:app:testDebugUnitTest` — `SettingsRepositorySyncSnapshotTest` (lockstep invariant + new positive assertion) green
- [x] `:app:testDebugUnitTest` — `SettingsRepositoryFavoriteSourcesTest` (existing round-trip tests) still green
- [ ] On-device: star a source on tablet, sign in on phone, verify the star transfers (manual, post-merge)

## Notes

Defers the BrowseViewModel re-sort perf nit from Gemini's review to a separate follow-up — N is small (number of source plugins, not search results) so the cost per keystroke is negligible.

🤖 Generated with [Claude Code](https://claude.com/claude-code)