### PR TITLE
fix(browse): Royal Road search affordance on signed-out CTA — closes #744

### DIFF
--- a/feature/src/main/kotlin/in/jphe/storyvox/feature/browse/BrowseScreen.kt
+++ b/feature/src/main/kotlin/in/jphe/storyvox/feature/browse/BrowseScreen.kt
@@ -367,7 +367,10 @@ fun BrowseScreen(
             // it), so the CTA is suppressed when the user is on Search.
             state.sourceId == SourceIds.ROYAL_ROAD &&
                 !state.royalRoadSignedIn &&
-                state.tab != BrowseTab.Search -> RoyalRoadSignedOutCta(onOpenRoyalRoadSignIn)
+                state.tab != BrowseTab.Search -> RoyalRoadSignedOutCta(
+                    onOpenSignIn = onOpenRoyalRoadSignIn,
+                    onSearchAnonymously = { viewModel.selectTab(BrowseTab.Search) },
+                )
             state.isLoading && state.items.isEmpty() -> SkeletonGrid()
             state.tab == BrowseTab.Search && state.query.isBlank() && !state.isFilterActive ->
                 SearchHint(state.sourceId, state.visibleSources)
@@ -1041,7 +1044,10 @@ private fun ActiveWingChip(
  * knows (not anonymous discovery of the catalog).
  */
 @Composable
-private fun RoyalRoadSignedOutCta(onOpenSignIn: () -> Unit) {
+private fun RoyalRoadSignedOutCta(
+    onOpenSignIn: () -> Unit,
+    onSearchAnonymously: () -> Unit,
+) {
     val spacing = LocalSpacing.current
     Column(
         modifier = Modifier.fillMaxSize().padding(spacing.lg),
@@ -1072,6 +1078,12 @@ private fun RoyalRoadSignedOutCta(onOpenSignIn: () -> Unit) {
             label = "Sign in to Royal Road",
             onClick = onOpenSignIn,
             variant = BrassButtonVariant.Primary,
+        )
+        Spacer(Modifier.height(spacing.xs))
+        BrassButton(
+            label = "Search without signing in",
+            onClick = onSearchAnonymously,
+            variant = BrassButtonVariant.Text,
         )
     }
 }


### PR DESCRIPTION
## Summary
- Adds a "Search without signing in" text button below the primary "Sign in to Royal Road" CTA on the signed-out state
- Tapping it switches to `BrowseTab.Search`, which the `when` guard already exempts from the CTA overlay — the search UI naturally replaces the sign-in prompt
- The anonymous search path was always functional (#241 spec) but had no visible affordance on narrow devices where the Search tab scrolled off the right edge of the tab strip

## Test plan
- [ ] On R5CRB0W66MK (narrow Flip3): tap Royal Road while signed out, verify "Search without signing in" button appears below the sign-in CTA
- [ ] Tap "Search without signing in" → Search tab activates, search field visible
- [ ] Tap "Sign in to Royal Road" → WebView auth flow still works
- [ ] On R83W80CAFZB (tablet, wider): same behavior, both buttons visible

🤖 Generated with [Claude Code](https://claude.com/claude-code)