### PR TITLE
feat(i18n): extract feature/ hardcoded strings to resources — closes #727

### DIFF
--- a/feature/src/main/kotlin/in/jphe/storyvox/feature/browse/BrowseCraigslistTemplateCard.kt
+++ b/feature/src/main/kotlin/in/jphe/storyvox/feature/browse/BrowseCraigslistTemplateCard.kt
@@ -22,8 +22,10 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.semantics.Role
 import androidx.compose.ui.unit.dp
+import `in`.jphe.storyvox.feature.R
 import `in`.jphe.storyvox.source.rss.templates.CraigslistCategory
 import `in`.jphe.storyvox.source.rss.templates.CraigslistRegion
 import `in`.jphe.storyvox.source.rss.templates.CraigslistTemplates
@@ -77,16 +79,16 @@ internal fun BrowseCraigslistTemplateCard(
             .fillMaxWidth()
             .clickable(
                 role = Role.Button,
-                onClickLabel = if (expanded) "Collapse Craigslist template" else "Expand Craigslist template",
+                onClickLabel = if (expanded) stringResource(R.string.craigslist_collapse) else stringResource(R.string.craigslist_expand),
             ) { expanded = !expanded }
             .padding(vertical = 4.dp),
         verticalAlignment = Alignment.CenterVertically,
     ) {
         Text(
             text = if (expanded) {
-                "▾  Local marketplace · Craigslist"
+                stringResource(R.string.craigslist_header_expanded)
             } else {
-                "▸  Local marketplace · Craigslist"
+                stringResource(R.string.craigslist_header_collapsed)
             },
             style = MaterialTheme.typography.labelMedium,
             color = MaterialTheme.colorScheme.primary,
@@ -95,7 +97,7 @@ internal fun BrowseCraigslistTemplateCard(
     }
     if (!expanded) {
         Text(
-            text = "Tap to subscribe to a Craigslist regional feed by region + category.",
+            text = stringResource(R.string.craigslist_collapsed_hint),
             style = MaterialTheme.typography.bodySmall,
             color = MaterialTheme.colorScheme.onSurfaceVariant,
         )
@@ -107,7 +109,7 @@ internal fun BrowseCraigslistTemplateCard(
         verticalArrangement = Arrangement.spacedBy(spacing.xs),
     ) {
         Text(
-            text = "1. Pick a region",
+            text = stringResource(R.string.craigslist_step_region),
             style = MaterialTheme.typography.labelSmall,
             color = MaterialTheme.colorScheme.onSurfaceVariant,
             modifier = Modifier.padding(top = spacing.xs),
@@ -137,7 +139,7 @@ internal fun BrowseCraigslistTemplateCard(
         }
 
         Text(
-            text = "2. Pick a category",
+            text = stringResource(R.string.craigslist_step_category),
             style = MaterialTheme.typography.labelSmall,
             color = MaterialTheme.colorScheme.onSurfaceVariant,
             modifier = Modifier.padding(top = spacing.sm),
@@ -196,7 +198,7 @@ internal fun BrowseCraigslistTemplateCard(
             }
         } else {
             Text(
-                text = "Pick a region and a category to preview the feed URL.",
+                text = stringResource(R.string.craigslist_pick_preview_hint),
                 style = MaterialTheme.typography.bodySmall,
                 color = MaterialTheme.colorScheme.onSurfaceVariant,
                 modifier = Modifier.padding(top = spacing.sm),
@@ -210,7 +212,7 @@ internal fun BrowseCraigslistTemplateCard(
             horizontalArrangement = Arrangement.End,
         ) {
             BrassButton(
-                label = if (alreadySubscribed) "Already subscribed" else "Subscribe",
+                label = if (alreadySubscribed) stringResource(R.string.craigslist_already_subscribed) else stringResource(R.string.craigslist_subscribe),
                 onClick = {
                     if (composedUrl != null && !alreadySubscribed) {
                         onSubscribe(composedUrl)
@@ -229,7 +231,7 @@ internal fun BrowseCraigslistTemplateCard(
 
         lastSubscribedTitle?.let { title ->
             Text(
-                text = "Subscribed: $title. See it under Browse → RSS.",
+                text = stringResource(R.string.craigslist_subscribed_confirmation, title),
                 style = MaterialTheme.typography.bodySmall,
                 color = MaterialTheme.colorScheme.primary,
                 modifier = Modifier.padding(top = spacing.xs),

--- a/feature/src/main/kotlin/in/jphe/storyvox/feature/browse/BrowseFilterSheet.kt
+++ b/feature/src/main/kotlin/in/jphe/storyvox/feature/browse/BrowseFilterSheet.kt
@@ -33,11 +33,13 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.semantics.contentDescription
 import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.semantics.stateDescription
 import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.foundation.text.KeyboardOptions
+import `in`.jphe.storyvox.feature.R
 import `in`.jphe.storyvox.feature.api.BrowseFilter
 import `in`.jphe.storyvox.feature.api.UiContentWarning
 import `in`.jphe.storyvox.feature.api.UiFictionStatus
@@ -85,7 +87,7 @@ fun BrowseFilterSheet(
                 verticalArrangement = Arrangement.spacedBy(spacing.md),
             ) {
             Text(
-                "Filter Royal Road",
+                stringResource(R.string.royalroad_filter_title),
                 style = MaterialTheme.typography.titleLarge,
                 modifier = Modifier.padding(top = spacing.sm),
             )
@@ -101,7 +103,7 @@ fun BrowseFilterSheet(
             HorizontalDivider()
 
             // Status
-            SectionLabel("Status")
+            SectionLabel(stringResource(R.string.filter_status_section))
             FlowRow(
                 horizontalArrangement = Arrangement.spacedBy(spacing.xs),
                 verticalArrangement = Arrangement.spacedBy(spacing.xs),
@@ -115,20 +117,20 @@ fun BrowseFilterSheet(
                                 statuses = if (selected) local.statuses - status else local.statuses + status,
                             )
                         },
-                        label = { Text(status.label) },
+                        label = { Text(stringResource(status.labelRes)) },
                         colors = brassFilterChipColors(),
                     )
                 }
             }
 
             // Type
-            SectionLabel("Type")
+            SectionLabel(stringResource(R.string.filter_type_section))
             FlowRow(horizontalArrangement = Arrangement.spacedBy(spacing.xs)) {
                 UiFictionType.entries.forEach { type ->
                     FilterChip(
                         selected = local.type == type,
                         onClick = { local = local.copy(type = type) },
-                        label = { Text(type.label) },
+                        label = { Text(stringResource(type.labelRes)) },
                         colors = brassFilterChipColors(),
                     )
                 }
@@ -137,14 +139,14 @@ fun BrowseFilterSheet(
             HorizontalDivider()
 
             // Tags include
-            SectionLabel("Include tags")
+            SectionLabel(stringResource(R.string.filter_include_tags_section))
             TagSelector(
                 selected = local.tagsInclude,
                 onChanged = { local = local.copy(tagsInclude = it) },
             )
 
             // Tags exclude
-            SectionLabel("Exclude tags")
+            SectionLabel(stringResource(R.string.filter_exclude_tags_section))
             TagSelector(
                 selected = local.tagsExclude,
                 onChanged = { local = local.copy(tagsExclude = it) },
@@ -153,7 +155,7 @@ fun BrowseFilterSheet(
             HorizontalDivider()
 
             // Length (pages)
-            SectionLabel("Length (pages): ${local.pagesLabel()}")
+            SectionLabel(stringResource(R.string.filter_length_pages_section, local.pagesLabel()))
             val pagesRange = (local.minPages?.toFloat() ?: 0f)..(local.maxPages?.toFloat() ?: PAGES_MAX)
             RangeSlider(
                 value = pagesRange,
@@ -175,7 +177,7 @@ fun BrowseFilterSheet(
             )
 
             // Rating
-            SectionLabel("Rating: ${local.ratingLabel()}")
+            SectionLabel(stringResource(R.string.filter_rating_section, local.ratingLabel()))
             val ratingRange = (local.minRating ?: 0f)..(local.maxRating ?: 5f)
             RangeSlider(
                 value = ratingRange,
@@ -197,7 +199,7 @@ fun BrowseFilterSheet(
             HorizontalDivider()
 
             // Content warnings
-            SectionLabel("Content warnings — exclude")
+            SectionLabel(stringResource(R.string.filter_content_warnings_exclude_section))
             FlowRow(
                 horizontalArrangement = Arrangement.spacedBy(spacing.xs),
                 verticalArrangement = Arrangement.spacedBy(spacing.xs),
@@ -213,7 +215,7 @@ fun BrowseFilterSheet(
                                 warningsRequire = local.warningsRequire - warning,
                             )
                         },
-                        label = { Text(warning.label) },
+                        label = { Text(stringResource(warning.labelRes)) },
                         colors = brassFilterChipColors(),
                     )
                 }
@@ -241,11 +243,11 @@ fun BrowseFilterSheet(
                     OutlinedButton(
                         onClick = onReset,
                         modifier = Modifier.weight(1f),
-                    ) { Text("Reset") }
+                    ) { Text(stringResource(R.string.filter_reset)) }
                     Button(
                         onClick = { onApply(local) },
                         modifier = Modifier.weight(2f),
-                    ) { Text("Apply") }
+                    ) { Text(stringResource(R.string.filter_apply)) }
                 }
             }
         }
@@ -270,7 +272,7 @@ private fun SortRow(
     onDirection: (UiSortDirection) -> Unit,
 ) {
     val spacing = LocalSpacing.current
-    SectionLabel("Sort by")
+    SectionLabel(stringResource(R.string.filter_sort_by_section))
     Row(
         modifier = Modifier.fillMaxWidth(),
         horizontalArrangement = Arrangement.spacedBy(spacing.sm),
@@ -283,7 +285,7 @@ private fun SortRow(
             modifier = Modifier.weight(2f),
         ) {
             OutlinedTextField(
-                value = orderBy.label,
+                value = stringResource(orderBy.labelRes),
                 onValueChange = {},
                 readOnly = true,
                 trailingIcon = { ExposedDropdownMenuDefaults.TrailingIcon(expanded = expanded) },
@@ -297,7 +299,7 @@ private fun SortRow(
             ) {
                 UiSearchOrder.entries.forEach { order ->
                     DropdownMenuItem(
-                        text = { Text(order.label) },
+                        text = { Text(stringResource(order.labelRes)) },
                         onClick = {
                             onOrderBy(order)
                             expanded = false
@@ -311,7 +313,7 @@ private fun SortRow(
             onClick = {
                 onDirection(if (direction == UiSortDirection.Desc) UiSortDirection.Asc else UiSortDirection.Desc)
             },
-            label = { Text(if (direction == UiSortDirection.Desc) "Desc" else "Asc") },
+            label = { Text(stringResource(if (direction == UiSortDirection.Desc) R.string.filter_sort_direction_desc else R.string.filter_sort_direction_asc)) },
             colors = brassFilterChipColors(),
         )
     }
@@ -332,7 +334,7 @@ private fun TagSelector(
     OutlinedTextField(
         value = query,
         onValueChange = { query = it },
-        label = { Text("Filter tags") },
+        label = { Text(stringResource(R.string.filter_tags_label)) },
         modifier = Modifier.fillMaxWidth(),
         singleLine = true,
         keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Text),
@@ -393,41 +395,41 @@ private fun BrowseFilter.ratingLabel(): String {
     return "$lo – $hi"
 }
 
-private val UiFictionStatus.label: String
+internal val UiFictionStatus.labelRes: Int
     get() = when (this) {
-        UiFictionStatus.Ongoing -> "Ongoing"
-        UiFictionStatus.Completed -> "Completed"
-        UiFictionStatus.Hiatus -> "Hiatus"
-        UiFictionStatus.Stub -> "Stub"
-        UiFictionStatus.Dropped -> "Dropped"
+        UiFictionStatus.Ongoing -> R.string.fiction_status_ongoing
+        UiFictionStatus.Completed -> R.string.fiction_status_completed
+        UiFictionStatus.Hiatus -> R.string.fiction_status_hiatus
+        UiFictionStatus.Stub -> R.string.fiction_status_stub
+        UiFictionStatus.Dropped -> R.string.fiction_status_dropped
     }
 
-private val UiFictionType.label: String
+internal val UiFictionType.labelRes: Int
     get() = when (this) {
-        UiFictionType.All -> "All"
-        UiFictionType.Original -> "Original"
-        UiFictionType.FanFiction -> "Fan Fiction"
+        UiFictionType.All -> R.string.fiction_type_all
+        UiFictionType.Original -> R.string.fiction_type_original
+        UiFictionType.FanFiction -> R.string.fiction_type_fanfiction
     }
 
-private val UiContentWarning.label: String
+internal val UiContentWarning.labelRes: Int
     get() = when (this) {
-        UiContentWarning.Profanity -> "Profanity"
-        UiContentWarning.SexualContent -> "Sexual"
-        UiContentWarning.GraphicViolence -> "Violence"
-        UiContentWarning.SensitiveContent -> "Sensitive"
-        UiContentWarning.AiAssisted -> "AI-assisted"
-        UiContentWarning.AiGenerated -> "AI-generated"
+        UiContentWarning.Profanity -> R.string.content_warning_profanity
+        UiContentWarning.SexualContent -> R.string.content_warning_sexual
+        UiContentWarning.GraphicViolence -> R.string.content_warning_violence
+        UiContentWarning.SensitiveContent -> R.string.content_warning_sensitive
+        UiContentWarning.AiAssisted -> R.string.content_warning_ai_assisted
+        UiContentWarning.AiGenerated -> R.string.content_warning_ai_generated
     }
 
-private val UiSearchOrder.label: String
+internal val UiSearchOrder.labelRes: Int
     get() = when (this) {
-        UiSearchOrder.Relevance -> "Relevance"
-        UiSearchOrder.Popularity -> "Popularity"
-        UiSearchOrder.Rating -> "Average rating"
-        UiSearchOrder.LastUpdate -> "Last update"
-        UiSearchOrder.ReleaseDate -> "Release date"
-        UiSearchOrder.Followers -> "Followers"
-        UiSearchOrder.Length -> "Length"
-        UiSearchOrder.Views -> "Views"
-        UiSearchOrder.Title -> "Title"
+        UiSearchOrder.Relevance -> R.string.search_order_relevance
+        UiSearchOrder.Popularity -> R.string.search_order_popularity
+        UiSearchOrder.Rating -> R.string.search_order_rating
+        UiSearchOrder.LastUpdate -> R.string.search_order_last_update
+        UiSearchOrder.ReleaseDate -> R.string.search_order_release_date
+        UiSearchOrder.Followers -> R.string.search_order_followers
+        UiSearchOrder.Length -> R.string.search_order_length
+        UiSearchOrder.Views -> R.string.search_order_views
+        UiSearchOrder.Title -> R.string.search_order_title
     }

--- a/feature/src/main/kotlin/in/jphe/storyvox/feature/browse/BrowseRssManageSheet.kt
+++ b/feature/src/main/kotlin/in/jphe/storyvox/feature/browse/BrowseRssManageSheet.kt
@@ -29,6 +29,7 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalFocusManager
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.semantics.Role
 import androidx.compose.ui.text.input.ImeAction
 import androidx.compose.ui.text.input.KeyboardCapitalization
@@ -36,6 +37,7 @@ import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import `in`.jphe.storyvox.feature.R
 import `in`.jphe.storyvox.feature.api.SuggestedFeed
 import `in`.jphe.storyvox.feature.api.SuggestedFeedKind
 import `in`.jphe.storyvox.ui.component.BrassButton
@@ -116,12 +118,12 @@ internal fun BrowseRssManageSheet(
             verticalArrangement = Arrangement.spacedBy(spacing.sm),
         ) {
             Text(
-                "Manage RSS feeds",
+                stringResource(R.string.rss_manage_title),
                 style = MaterialTheme.typography.titleLarge,
                 modifier = Modifier.padding(top = spacing.sm),
             )
             Text(
-                "Subscribe to any feed that publishes RSS or Atom. Storyvox treats each feed as one fiction; each item is a chapter.",
+                stringResource(R.string.rss_manage_description),
                 style = MaterialTheme.typography.bodyMedium,
                 color = MaterialTheme.colorScheme.onSurfaceVariant,
             )
@@ -133,8 +135,8 @@ internal fun BrowseRssManageSheet(
             OutlinedTextField(
                 value = draftUrl,
                 onValueChange = { draftUrl = it },
-                label = { Text("Feed URL") },
-                placeholder = { Text("https://example.com/feed.xml") },
+                label = { Text(stringResource(R.string.rss_feed_url_label)) },
+                placeholder = { Text(stringResource(R.string.rss_feed_url_placeholder)) },
                 singleLine = true,
                 keyboardOptions = KeyboardOptions(
                     keyboardType = KeyboardType.Uri,
@@ -150,7 +152,7 @@ internal fun BrowseRssManageSheet(
                 horizontalArrangement = Arrangement.End,
             ) {
                 BrassButton(
-                    label = "Add",
+                    label = stringResource(R.string.rss_add),
                     onClick = { submitDraft() },
                     variant = BrassButtonVariant.Primary,
                     enabled = draftUrl.isNotBlank(),
@@ -161,13 +163,13 @@ internal fun BrowseRssManageSheet(
 
             // ── Subscribed feeds ─────────────────────────────────────
             Text(
-                text = if (subs.isEmpty()) "No subscriptions yet" else "Your feeds (${subs.size})",
+                text = if (subs.isEmpty()) stringResource(R.string.rss_no_subscriptions) else stringResource(R.string.rss_your_feeds_count, subs.size),
                 style = MaterialTheme.typography.labelMedium,
                 color = MaterialTheme.colorScheme.onSurfaceVariant,
             )
             if (subs.isEmpty()) {
                 Text(
-                    "Paste a feed URL above to subscribe, or pick from the suggested list below.",
+                    stringResource(R.string.rss_empty_hint),
                     style = MaterialTheme.typography.bodySmall,
                     color = MaterialTheme.colorScheme.onSurfaceVariant,
                 )
@@ -185,7 +187,7 @@ internal fun BrowseRssManageSheet(
                             overflow = TextOverflow.Ellipsis,
                         )
                         TextButton(onClick = { viewModel.removeRssFeedByUrl(url) }) {
-                            Text("Remove")
+                            Text(stringResource(R.string.rss_remove))
                         }
                     }
                 }
@@ -217,13 +219,13 @@ internal fun BrowseRssManageSheet(
                     .fillMaxWidth()
                     .clickable(
                         role = Role.Button,
-                        onClickLabel = if (suggestionsExpanded) "Collapse suggested feeds" else "Expand suggested feeds",
+                        onClickLabel = if (suggestionsExpanded) stringResource(R.string.rss_suggested_collapse) else stringResource(R.string.rss_suggested_expand),
                     ) { suggestionsExpanded = !suggestionsExpanded }
                     .padding(vertical = 4.dp),
                 verticalAlignment = Alignment.CenterVertically,
             ) {
                 Text(
-                    text = if (suggestionsExpanded) "▾  Suggested feeds" else "▸  Suggested feeds",
+                    text = if (suggestionsExpanded) stringResource(R.string.rss_suggested_expanded_header) else stringResource(R.string.rss_suggested_collapsed_header),
                     style = MaterialTheme.typography.labelMedium,
                     color = MaterialTheme.colorScheme.primary,
                     modifier = Modifier.weight(1f),
@@ -231,7 +233,7 @@ internal fun BrowseRssManageSheet(
             }
             if (!suggestionsExpanded) {
                 Text(
-                    text = "Tap to browse curated feeds (Buddhist & dharma, more coming).",
+                    text = stringResource(R.string.rss_suggested_collapsed_hint),
                     style = MaterialTheme.typography.bodySmall,
                     color = MaterialTheme.colorScheme.onSurfaceVariant,
                 )
@@ -276,26 +278,24 @@ private fun SuggestedFeedsList(
                             color = MaterialTheme.colorScheme.onSurfaceVariant,
                         )
                         Text(
-                            text = when (feed.kind) {
-                                SuggestedFeedKind.Text ->
-                                    "Text articles — narrate well"
-                                SuggestedFeedKind.AudioPodcast ->
-                                    "Audio podcast — storyvox narrates show notes only"
-                            },
+                            text = stringResource(when (feed.kind) {
+                                SuggestedFeedKind.Text -> R.string.rss_kind_text
+                                SuggestedFeedKind.AudioPodcast -> R.string.rss_kind_audio_podcast
+                            }),
                             style = MaterialTheme.typography.labelSmall,
                             color = MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.7f),
                         )
                     }
                     if (alreadyAdded) {
                         Text(
-                            text = "Added",
+                            text = stringResource(R.string.rss_already_added),
                             style = MaterialTheme.typography.labelSmall,
                             color = MaterialTheme.colorScheme.primary,
                             modifier = Modifier.padding(start = spacing.sm, end = spacing.sm),
                         )
                     } else {
                         BrassButton(
-                            label = "Add",
+                            label = stringResource(R.string.rss_add),
                             onClick = { onAdd(feed.url) },
                             variant = BrassButtonVariant.Text,
                             modifier = Modifier.padding(start = spacing.sm),

--- a/feature/src/main/kotlin/in/jphe/storyvox/feature/browse/BrowseScreen.kt
+++ b/feature/src/main/kotlin/in/jphe/storyvox/feature/browse/BrowseScreen.kt
@@ -57,11 +57,13 @@ import kotlinx.coroutines.flow.filter
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.semantics.Role
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import `in`.jphe.storyvox.data.source.SourceIds
+import `in`.jphe.storyvox.feature.R
 import `in`.jphe.storyvox.data.source.plugin.SourcePluginDescriptor
 import `in`.jphe.storyvox.feature.api.BrowseFilter
 import `in`.jphe.storyvox.ui.component.BrassButton
@@ -99,7 +101,7 @@ private fun BrowseScaffoldOrFrame(
         Scaffold(
             topBar = {
                 CenterAlignedTopAppBar(
-                    title = { Text("Browse", style = MaterialTheme.typography.titleMedium) },
+                    title = { Text(stringResource(R.string.browse_title), style = MaterialTheme.typography.titleMedium) },
                     actions = {
                         IconButton(onClick = onOpenSettings) {
                             Icon(Icons.Outlined.Settings, contentDescription = "Settings")
@@ -327,7 +329,7 @@ fun BrowseScreen(
             OutlinedTextField(
                 value = state.query,
                 onValueChange = viewModel::setQuery,
-                label = { Text("Search $sourceLabel") },
+                label = { Text(stringResource(R.string.browse_search_hint, sourceLabel)) },
                 modifier = Modifier.fillMaxWidth().padding(spacing.md),
                 singleLine = true,
             )
@@ -752,7 +754,7 @@ private fun NotionDemoBanner(onOpenSettings: () -> Unit) {
             androidx.compose.material3.TextButton(
                 onClick = onOpenSettings,
                 modifier = Modifier.padding(top = spacing.xs),
-            ) { Text("Have a Notion workspace? Connect it →") }
+            ) { Text(stringResource(R.string.browse_notion_connect_cta)) }
         }
     }
 }
@@ -792,7 +794,7 @@ private fun Ao3SignInBanner(onOpenSignIn: () -> Unit) {
             androidx.compose.material3.TextButton(
                 onClick = onOpenSignIn,
                 modifier = Modifier.padding(top = spacing.xs),
-            ) { Text("Sign in to AO3") }
+            ) { Text(stringResource(R.string.browse_ao3_signin_cta)) }
         }
     }
 }
@@ -1017,7 +1019,7 @@ private fun ActiveWingChip(
 ) {
     AssistChip(
         onClick = onClear,
-        label = { Text("Wing: ${prettifyWing(wing)}") },
+        label = { Text(stringResource(R.string.browse_mempalace_wing_chip, prettifyWing(wing))) },
         trailingIcon = {
             Icon(
                 Icons.Filled.Close,

--- a/feature/src/main/kotlin/in/jphe/storyvox/feature/browse/BrowseSourceCarousel.kt
+++ b/feature/src/main/kotlin/in/jphe/storyvox/feature/browse/BrowseSourceCarousel.kt
@@ -73,6 +73,7 @@ import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.semantics.Role
 import androidx.compose.ui.semantics.selected
 import androidx.compose.ui.semantics.semantics
@@ -81,6 +82,7 @@ import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import `in`.jphe.storyvox.data.source.SourceIds
 import `in`.jphe.storyvox.data.source.plugin.SourcePluginDescriptor
+import `in`.jphe.storyvox.feature.R
 import `in`.jphe.storyvox.ui.theme.LocalSpacing
 import kotlinx.coroutines.launch
 
@@ -266,7 +268,7 @@ private fun BrowseSourceCard(
             .combinedClickable(
                 role = Role.Button,
                 onClickLabel = label,
-                onLongClickLabel = "Source options",
+                onLongClickLabel = stringResource(R.string.source_options),
                 onClick = onClick,
                 onLongClick = onLongClick,
             ),
@@ -429,11 +431,11 @@ private fun SourceContextSheet(
                 icon = if (isFavorite) Icons.Filled.Star else Icons.Filled.StarBorder,
                 iconTint = if (isFavorite) MaterialTheme.colorScheme.primary
                 else MaterialTheme.colorScheme.onSurface,
-                title = if (isFavorite) "Remove from favorites" else "Add to favorites",
+                title = if (isFavorite) stringResource(R.string.source_remove_from_favorites) else stringResource(R.string.source_add_to_favorites),
                 subtitle = if (isFavorite) {
-                    "Will keep its place in the list"
+                    stringResource(R.string.source_favorite_subtitle_remove)
                 } else {
-                    "Pins to the front of the carousel"
+                    stringResource(R.string.source_favorite_subtitle_add)
                 },
                 titleColor = MaterialTheme.colorScheme.onSurface,
                 testTag = "source-context-sheet-favorite",
@@ -444,8 +446,8 @@ private fun SourceContextSheet(
             SheetActionRow(
                 icon = Icons.Filled.VisibilityOff,
                 iconTint = MaterialTheme.colorScheme.error,
-                title = "Hide from Browse",
-                subtitle = "Re-enable from Settings -> Plugins",
+                title = stringResource(R.string.source_hide_title),
+                subtitle = stringResource(R.string.source_hide_subtitle),
                 titleColor = MaterialTheme.colorScheme.error,
                 testTag = "source-context-sheet-hide",
                 onClick = { dismissThen(onHide) },
@@ -523,30 +525,34 @@ private fun Modifier.androidxClickable(onClickLabel: String, onClick: () -> Unit
  * descriptor's category text or stay blank — the carousel doesn't crash
  * if a source has no row here, it just hides the tagline line.
  */
-private fun sourceTagline(id: String): String = when (id) {
-    SourceIds.ROYAL_ROAD -> "Web serials"
-    SourceIds.AO3 -> "Fanfiction archive"
-    SourceIds.GUTENBERG -> "Classic books"
-    SourceIds.STANDARD_EBOOKS -> "Polished classics"
-    SourceIds.WIKIPEDIA -> "Encyclopedia"
-    SourceIds.WIKISOURCE -> "Historic texts"
-    SourceIds.GITHUB -> "Repo READMEs"
-    SourceIds.RSS -> "Your feeds"
-    SourceIds.EPUB -> "Your EPUBs"
-    SourceIds.OUTLINE -> "Your wiki"
-    SourceIds.MEMPALACE -> "Your palace"
-    SourceIds.RADIO, SourceIds.KVMR -> "Live radio"
-    SourceIds.NOTION -> "Your Notion"
-    SourceIds.HACKERNEWS -> "Tech news"
-    SourceIds.ARXIV -> "Research papers"
-    SourceIds.PLOS -> "Open science"
-    SourceIds.DISCORD -> "Server channels"
-    SourceIds.MATRIX -> "Matrix rooms"
-    SourceIds.TELEGRAM -> "Channel posts"
-    SourceIds.SLACK -> "Workspace threads"
-    SourceIds.PALACE -> "Library borrows"
-    SourceIds.READABILITY -> "Paste any link"
-    else -> ""
+@Composable
+private fun sourceTagline(id: String): String {
+    val res = when (id) {
+        SourceIds.ROYAL_ROAD -> R.string.source_tagline_royal_road
+        SourceIds.AO3 -> R.string.source_tagline_ao3
+        SourceIds.GUTENBERG -> R.string.source_tagline_gutenberg
+        SourceIds.STANDARD_EBOOKS -> R.string.source_tagline_standard_ebooks
+        SourceIds.WIKIPEDIA -> R.string.source_tagline_wikipedia
+        SourceIds.WIKISOURCE -> R.string.source_tagline_wikisource
+        SourceIds.GITHUB -> R.string.source_tagline_github
+        SourceIds.RSS -> R.string.source_tagline_rss
+        SourceIds.EPUB -> R.string.source_tagline_epub
+        SourceIds.OUTLINE -> R.string.source_tagline_outline
+        SourceIds.MEMPALACE -> R.string.source_tagline_mempalace
+        SourceIds.RADIO, SourceIds.KVMR -> R.string.source_tagline_radio
+        SourceIds.NOTION -> R.string.source_tagline_notion
+        SourceIds.HACKERNEWS -> R.string.source_tagline_hackernews
+        SourceIds.ARXIV -> R.string.source_tagline_arxiv
+        SourceIds.PLOS -> R.string.source_tagline_plos
+        SourceIds.DISCORD -> R.string.source_tagline_discord
+        SourceIds.MATRIX -> R.string.source_tagline_matrix
+        SourceIds.TELEGRAM -> R.string.source_tagline_telegram
+        SourceIds.SLACK -> R.string.source_tagline_slack
+        SourceIds.PALACE -> R.string.source_tagline_palace
+        SourceIds.READABILITY -> R.string.source_tagline_readability
+        else -> return ""
+    }
+    return stringResource(res)
 }
 
 /**

--- a/feature/src/main/kotlin/in/jphe/storyvox/feature/browse/GenericBrowseFilterSheet.kt
+++ b/feature/src/main/kotlin/in/jphe/storyvox/feature/browse/GenericBrowseFilterSheet.kt
@@ -30,6 +30,8 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import `in`.jphe.storyvox.feature.R
 import `in`.jphe.storyvox.feature.api.GenericBrowseFilter
 import `in`.jphe.storyvox.feature.api.GenericDateRange
 import `in`.jphe.storyvox.feature.api.GenericFilterCapabilities
@@ -79,13 +81,13 @@ fun GenericBrowseFilterSheet(
             verticalArrangement = Arrangement.spacedBy(spacing.md),
         ) {
             Text(
-                "Filter $sourceLabel",
+                stringResource(R.string.generic_filter_title, sourceLabel),
                 style = MaterialTheme.typography.titleLarge,
                 modifier = Modifier.padding(top = spacing.sm),
             )
 
             if (capabilities.supportsSortOrder) {
-                SectionLabel("Sort by")
+                SectionLabel(stringResource(R.string.filter_sort_by_section))
                 SortDropdown(
                     available = capabilities.availableSortOrders,
                     value = local.sortOrder,
@@ -95,14 +97,14 @@ fun GenericBrowseFilterSheet(
             }
 
             if (capabilities.supportsCategory) {
-                SectionLabel("Category")
+                SectionLabel(stringResource(R.string.filter_category_section))
                 if (capabilities.availableCategories.isNotEmpty()) {
                     FlowRow(
                         horizontalArrangement = Arrangement.spacedBy(spacing.xs),
                         verticalArrangement = Arrangement.spacedBy(spacing.xs),
                     ) {
                         ChipOption(
-                            label = "Any",
+                            label = stringResource(R.string.generic_filter_chip_any),
                             selected = local.category == null,
                             onClick = { local = local.copy(category = null) },
                         )
@@ -124,7 +126,7 @@ fun GenericBrowseFilterSheet(
                         onValueChange = { v ->
                             local = local.copy(category = v.trim().takeIf { it.isNotEmpty() })
                         },
-                        placeholder = { Text("e.g. fantasy, biology") },
+                        placeholder = { Text(stringResource(R.string.filter_tags_placeholder)) },
                         singleLine = true,
                         modifier = Modifier.fillMaxWidth(),
                     )
@@ -133,14 +135,14 @@ fun GenericBrowseFilterSheet(
             }
 
             if (capabilities.supportsLanguage) {
-                SectionLabel("Language")
+                SectionLabel(stringResource(R.string.filter_language_section))
                 if (capabilities.availableLanguages.isNotEmpty()) {
                     FlowRow(
                         horizontalArrangement = Arrangement.spacedBy(spacing.xs),
                         verticalArrangement = Arrangement.spacedBy(spacing.xs),
                     ) {
                         ChipOption(
-                            label = "Any",
+                            label = stringResource(R.string.generic_filter_chip_any),
                             selected = local.language == null,
                             onClick = { local = local.copy(language = null) },
                         )
@@ -162,7 +164,7 @@ fun GenericBrowseFilterSheet(
                         onValueChange = { v ->
                             local = local.copy(language = v.trim().takeIf { it.isNotEmpty() })
                         },
-                        placeholder = { Text("ISO code (e.g. en, fr, ja)") },
+                        placeholder = { Text(stringResource(R.string.filter_language_iso_placeholder)) },
                         singleLine = true,
                         modifier = Modifier.fillMaxWidth(),
                     )
@@ -171,14 +173,14 @@ fun GenericBrowseFilterSheet(
             }
 
             if (capabilities.supportsDateRange) {
-                SectionLabel("Recent")
+                SectionLabel(stringResource(R.string.filter_recent_section))
                 FlowRow(
                     horizontalArrangement = Arrangement.spacedBy(spacing.xs),
                     verticalArrangement = Arrangement.spacedBy(spacing.xs),
                 ) {
                     GenericDateRange.entries.forEach { range ->
                         ChipOption(
-                            label = range.uiLabel(),
+                            label = stringResource(range.uiLabelRes()),
                             selected = local.dateRange == range,
                             onClick = { local = local.copy(dateRange = range) },
                         )
@@ -194,11 +196,11 @@ fun GenericBrowseFilterSheet(
                 OutlinedButton(
                     onClick = onReset,
                     modifier = Modifier.weight(1f),
-                ) { Text("Reset") }
+                ) { Text(stringResource(R.string.filter_reset)) }
                 Button(
                     onClick = { onApply(local) },
                     modifier = Modifier.weight(2f),
-                ) { Text("Apply") }
+                ) { Text(stringResource(R.string.filter_apply)) }
             }
         }
     }
@@ -240,7 +242,7 @@ private fun SortDropdown(
         onExpandedChange = { expanded = it },
     ) {
         OutlinedTextField(
-            value = value.uiLabel(),
+            value = stringResource(value.uiLabelRes()),
             onValueChange = {},
             readOnly = true,
             trailingIcon = { ExposedDropdownMenuDefaults.TrailingIcon(expanded = expanded) },
@@ -254,7 +256,7 @@ private fun SortDropdown(
         ) {
             available.forEach { option ->
                 DropdownMenuItem(
-                    text = { Text(option.uiLabel()) },
+                    text = { Text(stringResource(option.uiLabelRes())) },
                     onClick = {
                         onChange(option)
                         expanded = false
@@ -265,19 +267,19 @@ private fun SortDropdown(
     }
 }
 
-private fun GenericSortOrder.uiLabel(): String = when (this) {
-    GenericSortOrder.Default -> "Default"
-    GenericSortOrder.Newest -> "Newest"
-    GenericSortOrder.Popular -> "Popular"
-    GenericSortOrder.Title -> "Title (A-Z)"
+private fun GenericSortOrder.uiLabelRes(): Int = when (this) {
+    GenericSortOrder.Default -> R.string.generic_sort_default
+    GenericSortOrder.Newest -> R.string.generic_sort_newest
+    GenericSortOrder.Popular -> R.string.generic_sort_popular
+    GenericSortOrder.Title -> R.string.generic_sort_title
 }
 
-private fun GenericDateRange.uiLabel(): String = when (this) {
-    GenericDateRange.Any -> "Any time"
-    GenericDateRange.Last7Days -> "Last 7 days"
-    GenericDateRange.Last30Days -> "Last 30 days"
-    GenericDateRange.Last90Days -> "Last 90 days"
-    GenericDateRange.LastYear -> "Last year"
+private fun GenericDateRange.uiLabelRes(): Int = when (this) {
+    GenericDateRange.Any -> R.string.generic_range_any
+    GenericDateRange.Last7Days -> R.string.generic_range_last_7_days
+    GenericDateRange.Last30Days -> R.string.generic_range_last_30_days
+    GenericDateRange.Last90Days -> R.string.generic_range_last_90_days
+    GenericDateRange.LastYear -> R.string.generic_range_last_year
 }
 
 /** True when [filter] has any non-default knob set. Drives the

--- a/feature/src/main/kotlin/in/jphe/storyvox/feature/browse/GitHubFilterSheet.kt
+++ b/feature/src/main/kotlin/in/jphe/storyvox/feature/browse/GitHubFilterSheet.kt
@@ -27,6 +27,8 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import `in`.jphe.storyvox.feature.R
 import `in`.jphe.storyvox.feature.api.GitHubArchivedStatus
 import `in`.jphe.storyvox.feature.api.GitHubPushedSince
 import `in`.jphe.storyvox.feature.api.GitHubSearchFilter
@@ -73,7 +75,7 @@ fun GitHubFilterSheet(
             verticalArrangement = Arrangement.spacedBy(spacing.md),
         ) {
             Text(
-                "Filter GitHub",
+                stringResource(R.string.github_filter_title),
                 style = MaterialTheme.typography.titleLarge,
                 modifier = Modifier.padding(top = spacing.sm),
             )
@@ -82,7 +84,7 @@ fun GitHubFilterSheet(
             // Above 500 is uncommon for fiction repos and would mask
             // smaller-but-relevant repos. User who wants exact control
             // can supply a precise GitHub URL via the add-by-URL sheet.
-            SectionLabel("Minimum stars: ${local.minStars ?: 0}")
+            SectionLabel(stringResource(R.string.github_min_stars_section, local.minStars ?: 0))
             Slider(
                 value = (local.minStars ?: 0).toFloat(),
                 onValueChange = { v ->
@@ -98,20 +100,20 @@ fun GitHubFilterSheet(
             // Language — free-text ISO-639-1 (en, fr, ja, ...). GitHub
             // accepts the human label too ("English") but the code is
             // less ambiguous. Empty = no language qualifier.
-            SectionLabel("Language (ISO code, e.g. en, ja)")
+            SectionLabel(stringResource(R.string.github_language_section))
             OutlinedTextField(
                 value = local.language.orEmpty(),
                 onValueChange = { v ->
                     local = local.copy(language = v.trim().takeIf { it.isNotEmpty() })
                 },
-                placeholder = { Text("e.g. en") },
+                placeholder = { Text(stringResource(R.string.filter_language_short_placeholder)) },
                 singleLine = true,
                 modifier = Modifier.fillMaxWidth(),
             )
 
             HorizontalDivider()
 
-            SectionLabel("Last pushed")
+            SectionLabel(stringResource(R.string.github_pushed_section))
             PushedSinceDropdown(
                 value = local.pushedSince,
                 onChange = { local = local.copy(pushedSince = it) },
@@ -124,7 +126,7 @@ fun GitHubFilterSheet(
             // `topic:X` qualifier; multiple AND together. We avoid a
             // chip-based picker for v1 because GitHub has no public
             // topic-suggestion API — users type what they know.
-            SectionLabel("Topic tags (comma-separated, e.g. litrpg, fantasy)")
+            SectionLabel(stringResource(R.string.github_topics_section))
             var tagsDraft by remember(local.tags) { mutableStateOf(local.tags.joinToString(", ")) }
             OutlinedTextField(
                 value = tagsDraft,
@@ -134,7 +136,7 @@ fun GitHubFilterSheet(
                         tags = v.split(',').map { it.trim().lowercase() }.filter { it.isNotEmpty() }.toSet(),
                     )
                 },
-                placeholder = { Text("e.g. litrpg, fantasy") },
+                placeholder = { Text(stringResource(R.string.filter_tags_short_placeholder)) },
                 singleLine = true,
                 modifier = Modifier.fillMaxWidth(),
             )
@@ -144,15 +146,15 @@ fun GitHubFilterSheet(
             // Archive status (#205). Default `Any` returns both kinds;
             // ActiveOnly is the most common power-user filter (skip
             // deprecated forks); ArchivedOnly is for retro-archeology.
-            SectionLabel("Repository state")
+            SectionLabel(stringResource(R.string.github_repo_state_section))
             Row(horizontalArrangement = Arrangement.spacedBy(spacing.xs)) {
-                ArchivedChip("Any", local.archivedStatus == GitHubArchivedStatus.Any) {
+                ArchivedChip(stringResource(R.string.github_repo_state_any), local.archivedStatus == GitHubArchivedStatus.Any) {
                     local = local.copy(archivedStatus = GitHubArchivedStatus.Any)
                 }
-                ArchivedChip("Active only", local.archivedStatus == GitHubArchivedStatus.ActiveOnly) {
+                ArchivedChip(stringResource(R.string.github_repo_state_active), local.archivedStatus == GitHubArchivedStatus.ActiveOnly) {
                     local = local.copy(archivedStatus = GitHubArchivedStatus.ActiveOnly)
                 }
-                ArchivedChip("Archived only", local.archivedStatus == GitHubArchivedStatus.ArchivedOnly) {
+                ArchivedChip(stringResource(R.string.github_repo_state_archived), local.archivedStatus == GitHubArchivedStatus.ArchivedOnly) {
                     local = local.copy(archivedStatus = GitHubArchivedStatus.ArchivedOnly)
                 }
             }
@@ -163,15 +165,15 @@ fun GitHubFilterSheet(
             // silently empties the grid.
             if (showVisibilityChips) {
                 HorizontalDivider()
-                SectionLabel("Visibility")
+                SectionLabel(stringResource(R.string.github_visibility_section))
                 Row(horizontalArrangement = Arrangement.spacedBy(spacing.xs)) {
-                    ArchivedChip("Both", local.visibility == GitHubVisibilityFilter.Both) {
+                    ArchivedChip(stringResource(R.string.github_visibility_both), local.visibility == GitHubVisibilityFilter.Both) {
                         local = local.copy(visibility = GitHubVisibilityFilter.Both)
                     }
-                    ArchivedChip("Public", local.visibility == GitHubVisibilityFilter.PublicOnly) {
+                    ArchivedChip(stringResource(R.string.github_visibility_public), local.visibility == GitHubVisibilityFilter.PublicOnly) {
                         local = local.copy(visibility = GitHubVisibilityFilter.PublicOnly)
                     }
-                    ArchivedChip("Private", local.visibility == GitHubVisibilityFilter.PrivateOnly) {
+                    ArchivedChip(stringResource(R.string.github_visibility_private), local.visibility == GitHubVisibilityFilter.PrivateOnly) {
                         local = local.copy(visibility = GitHubVisibilityFilter.PrivateOnly)
                     }
                 }
@@ -179,7 +181,7 @@ fun GitHubFilterSheet(
 
             HorizontalDivider()
 
-            SectionLabel("Sort by")
+            SectionLabel(stringResource(R.string.filter_sort_by_section))
             SortDropdown(
                 value = local.sort,
                 onChange = { local = local.copy(sort = it) },
@@ -193,11 +195,11 @@ fun GitHubFilterSheet(
                 OutlinedButton(
                     onClick = onReset,
                     modifier = Modifier.weight(1f),
-                ) { Text("Reset") }
+                ) { Text(stringResource(R.string.filter_reset)) }
                 Button(
                     onClick = { onApply(local) },
                     modifier = Modifier.weight(2f),
-                ) { Text("Apply") }
+                ) { Text(stringResource(R.string.filter_apply)) }
             }
         }
     }
@@ -233,7 +235,7 @@ private fun PushedSinceDropdown(
         onExpandedChange = { expanded = it },
     ) {
         OutlinedTextField(
-            value = value.label,
+            value = stringResource(value.labelRes),
             onValueChange = {},
             readOnly = true,
             trailingIcon = { ExposedDropdownMenuDefaults.TrailingIcon(expanded = expanded) },
@@ -247,7 +249,7 @@ private fun PushedSinceDropdown(
         ) {
             GitHubPushedSince.entries.forEach { option ->
                 DropdownMenuItem(
-                    text = { Text(option.label) },
+                    text = { Text(stringResource(option.labelRes)) },
                     onClick = {
                         onChange(option)
                         expanded = false
@@ -270,7 +272,7 @@ private fun SortDropdown(
         onExpandedChange = { expanded = it },
     ) {
         OutlinedTextField(
-            value = value.label,
+            value = stringResource(value.labelRes),
             onValueChange = {},
             readOnly = true,
             trailingIcon = { ExposedDropdownMenuDefaults.TrailingIcon(expanded = expanded) },
@@ -284,7 +286,7 @@ private fun SortDropdown(
         ) {
             GitHubSort.entries.forEach { option ->
                 DropdownMenuItem(
-                    text = { Text(option.label) },
+                    text = { Text(stringResource(option.labelRes)) },
                     onClick = {
                         onChange(option)
                         expanded = false
@@ -298,18 +300,18 @@ private fun SortDropdown(
 private const val STARS_MAX = 500f
 private const val STARS_STEPS = 49 // every 10 stars in 0..500
 
-private val GitHubPushedSince.label: String
+private val GitHubPushedSince.labelRes: Int
     get() = when (this) {
-        GitHubPushedSince.Any -> "Any time"
-        GitHubPushedSince.Last7Days -> "Last 7 days"
-        GitHubPushedSince.Last30Days -> "Last 30 days"
-        GitHubPushedSince.Last90Days -> "Last 90 days"
-        GitHubPushedSince.LastYear -> "Last year"
+        GitHubPushedSince.Any -> R.string.github_pushed_any
+        GitHubPushedSince.Last7Days -> R.string.github_pushed_last_7_days
+        GitHubPushedSince.Last30Days -> R.string.github_pushed_last_30_days
+        GitHubPushedSince.Last90Days -> R.string.github_pushed_last_90_days
+        GitHubPushedSince.LastYear -> R.string.github_pushed_last_year
     }
 
-private val GitHubSort.label: String
+private val GitHubSort.labelRes: Int
     get() = when (this) {
-        GitHubSort.BestMatch -> "Best match"
-        GitHubSort.Stars -> "Stars"
-        GitHubSort.Updated -> "Recently updated"
+        GitHubSort.BestMatch -> R.string.github_sort_best_match
+        GitHubSort.Stars -> R.string.github_sort_stars
+        GitHubSort.Updated -> R.string.github_sort_updated
     }

--- a/feature/src/main/kotlin/in/jphe/storyvox/feature/browse/MemPalaceFilterSheet.kt
+++ b/feature/src/main/kotlin/in/jphe/storyvox/feature/browse/MemPalaceFilterSheet.kt
@@ -22,6 +22,8 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import `in`.jphe.storyvox.feature.R
 import `in`.jphe.storyvox.feature.api.MemPalaceFilter
 import `in`.jphe.storyvox.ui.component.BrassButton
 import `in`.jphe.storyvox.ui.component.BrassButtonVariant
@@ -63,14 +65,14 @@ fun MemPalaceFilterSheet(
             verticalArrangement = Arrangement.spacedBy(spacing.md),
         ) {
             Text(
-                "Filter by wing",
+                stringResource(R.string.mempalace_filter_title),
                 style = MaterialTheme.typography.titleLarge,
                 modifier = Modifier.padding(top = spacing.sm),
             )
 
             if (wings.isEmpty()) {
                 Text(
-                    "No wings reachable. Confirm your palace daemon is configured under Settings → Memory Palace.",
+                    stringResource(R.string.mempalace_no_wings),
                     style = MaterialTheme.typography.bodyMedium,
                     color = MaterialTheme.colorScheme.onSurfaceVariant,
                 )
@@ -82,7 +84,7 @@ fun MemPalaceFilterSheet(
                 verticalArrangement = Arrangement.spacedBy(spacing.xs),
             ) {
                 WingChip(
-                    label = "All",
+                    label = stringResource(R.string.mempalace_chip_all),
                     selected = local.wing == null,
                     onClick = { local = local.copy(wing = null) },
                 )
@@ -102,11 +104,11 @@ fun MemPalaceFilterSheet(
                 OutlinedButton(
                     onClick = onReset,
                     modifier = Modifier.weight(1f),
-                ) { Text("Reset") }
+                ) { Text(stringResource(R.string.filter_reset)) }
                 Button(
                     onClick = { onApply(local) },
                     modifier = Modifier.weight(2f),
-                ) { Text("Apply") }
+                ) { Text(stringResource(R.string.filter_apply)) }
             }
         }
     }

--- a/feature/src/main/kotlin/in/jphe/storyvox/feature/chat/ChatScreen.kt
+++ b/feature/src/main/kotlin/in/jphe/storyvox/feature/chat/ChatScreen.kt
@@ -56,11 +56,13 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.alpha
 import androidx.compose.ui.draw.clip
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.semantics.Role
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import `in`.jphe.storyvox.feature.R
 import `in`.jphe.storyvox.llm.tools.ToolCallEvent
 import `in`.jphe.storyvox.llm.tools.ToolResult
 import kotlinx.coroutines.launch
@@ -748,7 +750,7 @@ private fun ChatInput(
                 value = text,
                 onValueChange = { text = it },
                 enabled = enabled,
-                placeholder = { Text("Ask a question…") },
+                placeholder = { Text(stringResource(R.string.chat_ask_question_placeholder)) },
                 modifier = Modifier.weight(1f),
                 singleLine = false,
                 maxLines = 4,

--- a/feature/src/main/kotlin/in/jphe/storyvox/feature/debug/DebugScreen.kt
+++ b/feature/src/main/kotlin/in/jphe/storyvox/feature/debug/DebugScreen.kt
@@ -47,6 +47,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.semantics.Role
 import androidx.compose.ui.text.font.FontFamily
 import androidx.compose.ui.text.font.FontWeight
@@ -55,6 +56,7 @@ import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import `in`.jphe.storyvox.feature.R
 import `in`.jphe.storyvox.feature.api.DebugEvent
 import `in`.jphe.storyvox.feature.api.DebugEventKind
 import `in`.jphe.storyvox.feature.api.DebugSnapshot
@@ -146,7 +148,7 @@ internal fun DebugScreenContent(
                             tint = MaterialTheme.colorScheme.primary,
                             modifier = Modifier.size(20.dp),
                         )
-                        Text("Debug")
+                        Text(stringResource(R.string.debug_title))
                     }
                 },
                 navigationIcon = {

--- a/feature/src/main/kotlin/in/jphe/storyvox/feature/engine/VoicePickerGate.kt
+++ b/feature/src/main/kotlin/in/jphe/storyvox/feature/engine/VoicePickerGate.kt
@@ -24,6 +24,7 @@ import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.semantics.Role
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
@@ -42,6 +43,7 @@ import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.launch
 import `in`.jphe.storyvox.data.source.SystemTtsVoiceProvider
+import `in`.jphe.storyvox.feature.R
 import `in`.jphe.storyvox.playback.voice.UiVoiceInfo
 import `in`.jphe.storyvox.playback.voice.VoiceCatalog
 import `in`.jphe.storyvox.playback.voice.VoiceManager
@@ -398,7 +400,7 @@ private fun DownloadProgressBlock(
     val spacing = LocalSpacing.current
     when (progress) {
         DownloadProgress.Resolving -> {
-            Text("Resolving…", style = MaterialTheme.typography.bodySmall)
+            Text(stringResource(R.string.engine_voice_resolving), style = MaterialTheme.typography.bodySmall)
             Spacer(Modifier.height(spacing.xs))
             // Indeterminate brass comet — the manifest fetch is brief but
             // network-flaky enough that callers sit on this state for 1-3s.

--- a/feature/src/main/kotlin/in/jphe/storyvox/feature/fiction/FictionDetailScreen.kt
+++ b/feature/src/main/kotlin/in/jphe/storyvox/feature/fiction/FictionDetailScreen.kt
@@ -53,6 +53,7 @@ import androidx.compose.ui.focus.FocusRequester
 import androidx.compose.ui.focus.focusRequester
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalFocusManager
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.semantics.LiveRegionMode
 import androidx.compose.ui.semantics.contentDescription
 import androidx.compose.ui.semantics.liveRegion
@@ -62,6 +63,7 @@ import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import `in`.jphe.storyvox.feature.R
 import `in`.jphe.storyvox.feature.api.UiChapter
 import `in`.jphe.storyvox.feature.api.UiFiction
 import `in`.jphe.storyvox.source.epub.writer.EpubExportResult
@@ -162,21 +164,16 @@ fun FictionDetailScreen(
     // configuration change without surviving as a half-rendered modal.
     var showClearCacheConfirm by remember { mutableStateOf(false) }
     if (showClearCacheConfirm) {
-        val titleForDialog = state.fiction?.title ?: "this fiction"
+        val titleForDialog = state.fiction?.title ?: stringResource(R.string.fiction_default_title)
         AlertDialog(
             onDismissRequest = { showClearCacheConfirm = false },
-            title = { Text("Clear cached audio for $titleForDialog?") },
+            title = { Text(stringResource(R.string.fiction_clear_cache_title, titleForDialog)) },
             text = {
-                Text(
-                    "Removes the PCM cache for every chapter of this fiction " +
-                        "across every voice variant. Replays will re-render " +
-                        "once. The fiction stays in your library; your read " +
-                        "progress and library state are not affected.",
-                )
+                Text(stringResource(R.string.fiction_clear_cache_body))
             },
             confirmButton = {
                 BrassButton(
-                    label = "Clear",
+                    label = stringResource(R.string.fiction_clear),
                     onClick = {
                         showClearCacheConfirm = false
                         viewModel.clearFictionCache()
@@ -190,7 +187,7 @@ fun FictionDetailScreen(
             },
             dismissButton = {
                 BrassButton(
-                    label = "Cancel",
+                    label = stringResource(R.string.fiction_cancel),
                     onClick = { showClearCacheConfirm = false },
                     variant = BrassButtonVariant.Secondary,
                 )
@@ -198,19 +195,16 @@ fun FictionDetailScreen(
         )
     }
     if (showRemoveConfirm) {
-        val titleForDialog = state.fiction?.title ?: "this fiction"
+        val titleForDialog = state.fiction?.title ?: stringResource(R.string.fiction_default_title)
         AlertDialog(
             onDismissRequest = { showRemoveConfirm = false },
-            title = { Text("Remove $titleForDialog from your library?") },
+            title = { Text(stringResource(R.string.fiction_remove_title, titleForDialog)) },
             text = {
-                Text(
-                    "Your read progress will be lost. You can re-add it from " +
-                        "Browse anytime, but the position you've reached won't be restored.",
-                )
+                Text(stringResource(R.string.fiction_remove_body))
             },
             confirmButton = {
                 BrassButton(
-                    label = "Remove",
+                    label = stringResource(R.string.fiction_remove),
                     onClick = {
                         showRemoveConfirm = false
                         viewModel.toggleFollow(false)
@@ -220,7 +214,7 @@ fun FictionDetailScreen(
             },
             dismissButton = {
                 BrassButton(
-                    label = "Cancel",
+                    label = stringResource(R.string.fiction_cancel),
                     onClick = { showRemoveConfirm = false },
                     variant = BrassButtonVariant.Secondary,
                 )
@@ -303,7 +297,7 @@ fun FictionDetailScreen(
                                 MagicCircularProgress(
                                     modifier = Modifier.size(16.dp),
                                 )
-                                Text("Building .epub…", style = MaterialTheme.typography.labelSmall)
+                                Text(stringResource(R.string.fiction_building_epub), style = MaterialTheme.typography.labelSmall)
                             }
                         } else {
                             IconButton(onClick = { menuOpen = true }) {
@@ -314,7 +308,7 @@ fun FictionDetailScreen(
                                 onDismissRequest = { menuOpen = false },
                             ) {
                                 DropdownMenuItem(
-                                    text = { Text("Export as EPUB…") },
+                                    text = { Text(stringResource(R.string.fiction_export_epub)) },
                                     onClick = {
                                         menuOpen = false
                                         viewModel.exportToEpub(context)
@@ -335,7 +329,7 @@ fun FictionDetailScreen(
                                 // user opens the menu on a cold launch,
                                 // so the gate would flicker.
                                 DropdownMenuItem(
-                                    text = { Text("Clear fiction cache…") },
+                                    text = { Text(stringResource(R.string.fiction_clear_cache)) },
                                     onClick = {
                                         menuOpen = false
                                         showClearCacheConfirm = true
@@ -718,9 +712,9 @@ private fun Hero(fiction: UiFiction) {
                     Icon(Icons.Filled.Star, contentDescription = null, tint = MaterialTheme.colorScheme.primary, modifier = Modifier.size(16.dp))
                     Text("%.1f".format(fiction.rating), style = MaterialTheme.typography.labelMedium)
                 }
-                Text("·", style = MaterialTheme.typography.labelMedium, color = MaterialTheme.colorScheme.onSurfaceVariant)
-                Text("${fiction.chapterCount} ch", style = MaterialTheme.typography.labelMedium, color = MaterialTheme.colorScheme.onSurfaceVariant)
-                Text("·", style = MaterialTheme.typography.labelMedium, color = MaterialTheme.colorScheme.onSurfaceVariant)
+                Text(stringResource(R.string.fiction_separator), style = MaterialTheme.typography.labelMedium, color = MaterialTheme.colorScheme.onSurfaceVariant)
+                Text(stringResource(R.string.fiction_chapter_count, fiction.chapterCount), style = MaterialTheme.typography.labelMedium, color = MaterialTheme.colorScheme.onSurfaceVariant)
+                Text(stringResource(R.string.fiction_separator), style = MaterialTheme.typography.labelMedium, color = MaterialTheme.colorScheme.onSurfaceVariant)
                 Text(if (fiction.isOngoing) "Ongoing" else "Completed", style = MaterialTheme.typography.labelMedium, color = MaterialTheme.colorScheme.primary)
             }
         }
@@ -879,7 +873,7 @@ private fun NotebookSection(
                 androidx.compose.material3.OutlinedTextField(
                     value = draftName,
                     onValueChange = { draftName = it },
-                    label = { Text("Name") },
+                    label = { Text(stringResource(R.string.fiction_name_label)) },
                     singleLine = true,
                     keyboardOptions = KeyboardOptions(imeAction = ImeAction.Next),
                     keyboardActions = KeyboardActions(
@@ -892,7 +886,7 @@ private fun NotebookSection(
                 androidx.compose.material3.OutlinedTextField(
                     value = draftSummary,
                     onValueChange = { draftSummary = it },
-                    label = { Text("One-line description") },
+                    label = { Text(stringResource(R.string.fiction_one_line_description)) },
                     keyboardOptions = KeyboardOptions(imeAction = ImeAction.Done),
                     keyboardActions = KeyboardActions(
                         onDone = { focusManager.clearFocus() },

--- a/feature/src/main/kotlin/in/jphe/storyvox/feature/follows/FollowsScreen.kt
+++ b/feature/src/main/kotlin/in/jphe/storyvox/feature/follows/FollowsScreen.kt
@@ -29,11 +29,13 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.semantics.Role
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import `in`.jphe.storyvox.feature.R
 import `in`.jphe.storyvox.feature.api.UiFollow
 import `in`.jphe.storyvox.ui.component.BrassButton
 import `in`.jphe.storyvox.ui.component.BrassButtonVariant
@@ -101,7 +103,7 @@ fun FollowsScreen(
             // Row so it remains reachable.
             if (!embedded) {
                 TopAppBar(
-                    title = { Text("Follows", style = MaterialTheme.typography.titleLarge) },
+                    title = { Text(stringResource(R.string.follows_title), style = MaterialTheme.typography.titleLarge) },
                     actions = {
                         if (state.isSignedIn && state.follows.isNotEmpty()) {
                             BrassButton(

--- a/feature/src/main/kotlin/in/jphe/storyvox/feature/library/AddByUrlSheet.kt
+++ b/feature/src/main/kotlin/in/jphe/storyvox/feature/library/AddByUrlSheet.kt
@@ -29,6 +29,7 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.semantics.Role
 import androidx.compose.ui.semantics.contentDescription
 import androidx.compose.ui.semantics.role
@@ -37,6 +38,7 @@ import androidx.compose.ui.text.input.ImeAction
 import androidx.compose.ui.text.input.KeyboardCapitalization
 import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.unit.dp
+import `in`.jphe.storyvox.feature.R
 import `in`.jphe.storyvox.feature.api.UiRouteCandidate
 import `in`.jphe.storyvox.ui.component.BrassButton
 import `in`.jphe.storyvox.ui.component.BrassButtonVariant
@@ -122,8 +124,8 @@ fun AddByUrlSheet(
                 OutlinedTextField(
                     value = input,
                     onValueChange = { input = it },
-                    label = { Text("URL") },
-                    placeholder = { Text("https://…") },
+                    label = { Text(stringResource(R.string.library_add_by_url_label)) },
+                    placeholder = { Text(stringResource(R.string.library_add_by_url_placeholder)) },
                     isError = error != null,
                     singleLine = true,
                     enabled = !isSubmitting,

--- a/feature/src/main/kotlin/in/jphe/storyvox/feature/library/LibraryScreen.kt
+++ b/feature/src/main/kotlin/in/jphe/storyvox/feature/library/LibraryScreen.kt
@@ -42,6 +42,7 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.semantics.Role
 import androidx.compose.ui.semantics.role
 import androidx.compose.ui.semantics.selected
@@ -51,6 +52,7 @@ import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import `in`.jphe.storyvox.data.TechEmpowerLinks
 import `in`.jphe.storyvox.data.db.entity.InboxEvent
+import `in`.jphe.storyvox.feature.R
 import `in`.jphe.storyvox.data.db.entity.Shelf
 import `in`.jphe.storyvox.data.repository.ContinueListeningEntry
 import `in`.jphe.storyvox.data.repository.HistoryEntry
@@ -172,7 +174,7 @@ fun LibraryScreen(
         // exists in LibraryViewModel yet.
         topBar = {
             CenterAlignedTopAppBar(
-                title = { Text("Library", style = MaterialTheme.typography.titleMedium) },
+                title = { Text(stringResource(R.string.library_title), style = MaterialTheme.typography.titleMedium) },
                 actions = {
                     // Issue #533 — top-bar action icons used to pack
                     // flush together at 0dp gap on the Flip3 (1080dp
@@ -507,7 +509,7 @@ private fun ResumeCard(entry: ContinueListeningEntry, onResume: () -> Unit) {
                 modifier = Modifier.size(width = 68.dp, height = 100.dp),
             )
             Column(modifier = Modifier.weight(1f)) {
-                Text("Resume", style = MaterialTheme.typography.labelMedium, color = MaterialTheme.colorScheme.primary)
+                Text(stringResource(R.string.library_resume), style = MaterialTheme.typography.labelMedium, color = MaterialTheme.colorScheme.primary)
                 Text(entry.fiction.title, style = MaterialTheme.typography.titleMedium, maxLines = 1)
                 // #265 — when chapter.title is blank (RSS feeds where only
                 // the index was parsed, first-cold-launch state), the old
@@ -1020,7 +1022,7 @@ private fun InboxList(
                 horizontalArrangement = Arrangement.End,
             ) {
                 TextButton(onClick = onMarkAllRead) {
-                    Text("Mark all read", style = MaterialTheme.typography.labelLarge)
+                    Text(stringResource(R.string.library_mark_all_read), style = MaterialTheme.typography.labelLarge)
                 }
             }
         }

--- a/feature/src/main/kotlin/in/jphe/storyvox/feature/library/ShelfChipRow.kt
+++ b/feature/src/main/kotlin/in/jphe/storyvox/feature/library/ShelfChipRow.kt
@@ -13,7 +13,9 @@ import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
 import `in`.jphe.storyvox.data.db.entity.Shelf
+import `in`.jphe.storyvox.feature.R
 import `in`.jphe.storyvox.ui.theme.LocalSpacing
 
 /**
@@ -45,7 +47,7 @@ fun ShelfChipRow(
         FilterChip(
             selected = selected is ShelfFilter.All,
             onClick = { onSelect(ShelfFilter.All) },
-            label = { Text("All") },
+            label = { Text(stringResource(R.string.library_shelf_all)) },
             colors = brassFilterChipColors(),
         )
         Shelf.ALL.forEach { shelf ->

--- a/feature/src/main/kotlin/in/jphe/storyvox/feature/reader/AudiobookView.kt
+++ b/feature/src/main/kotlin/in/jphe/storyvox/feature/reader/AudiobookView.kt
@@ -87,7 +87,9 @@ import androidx.compose.ui.draw.alpha
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.compositeOver
 import androidx.compose.ui.graphics.graphicsLayer
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
+import `in`.jphe.storyvox.feature.R
 import `in`.jphe.storyvox.feature.api.UiPlaybackState
 import `in`.jphe.storyvox.feature.api.UiSleepTimerMode
 import `in`.jphe.storyvox.ui.component.BrassButton
@@ -229,13 +231,12 @@ fun AudiobookView(
     // state flow takes over and we route back to the normal player UI.
     if (loadingPhase == LoadingPhase.TimedOut) {
         ErrorBlock(
-            title = "Couldn't load this chapter",
-            message = "The voice or chapter text is taking longer than expected. " +
-                "Try again, or pick a different voice — some take a moment to warm up.",
+            title = stringResource(R.string.reader_couldnt_load_chapter),
+            message = stringResource(R.string.reader_couldnt_load_message),
             onRetry = onRetryLoading,
-            retryLabel = "Try again",
+            retryLabel = stringResource(R.string.reader_try_again),
             onBack = onPickVoice,
-            backLabel = "Pick a different voice",
+            backLabel = stringResource(R.string.reader_pick_different_voice),
             placement = ErrorPlacement.FullScreen,
             modifier = modifier,
         )
@@ -372,8 +373,8 @@ fun AudiobookView(
                                 interactionSource = voiceInteraction,
                                 indication = ripple(bounded = false, radius = 24.dp),
                                 role = androidx.compose.ui.semantics.Role.Button,
-                                onClickLabel = "Voice settings",
-                                onLongClickLabel = "Open Voice Library",
+                                onClickLabel = stringResource(R.string.reader_voice_settings),
+                                onLongClickLabel = stringResource(R.string.reader_open_voice_library),
                                 onClick = { showVoiceSheet = true },
                                 onLongClick = onPickVoice,
                             ),
@@ -505,7 +506,7 @@ fun AudiobookView(
                             }
                             .clickable(
                                 role = androidx.compose.ui.semantics.Role.Button,
-                                onClickLabel = if (state.isPlaying) "Pause" else "Play",
+                                onClickLabel = if (state.isPlaying) stringResource(R.string.reader_pause) else stringResource(R.string.reader_play),
                                 onClick = {
                                     // Capture the icon BEFORE firing the
                                     // toggle: tapping a playing chapter
@@ -975,7 +976,7 @@ private fun ChapterListSheet(
             .padding(bottom = spacing.lg),
     ) {
         Text(
-            text = "Chapters",
+            text = stringResource(R.string.reader_chapters),
             style = MaterialTheme.typography.titleMedium,
             color = MaterialTheme.colorScheme.primary,
             modifier = Modifier.padding(vertical = spacing.sm),
@@ -1160,7 +1161,7 @@ private fun SleepTimerCountdownChip(remainingMs: Long, onCancel: () -> Unit) {
     AssistChip(
         onClick = onCancel,
         label = {
-            Text("Sleeping in ${"%d:%02d".format(mins, secs)}", style = MaterialTheme.typography.labelMedium)
+            Text(stringResource(R.string.reader_sleep_sleeping_in, mins, secs), style = MaterialTheme.typography.labelMedium)
         },
         leadingIcon = {
             Icon(Icons.Outlined.Bedtime, contentDescription = null)
@@ -1216,7 +1217,7 @@ private fun PlayerOverflowSheet(
         // these sit in the options sheet for users who want
         // sentence-precision rewind/fast-forward (re-listen the line
         // you just heard, or skip a sentence you didn't want).
-        SheetHeader("Step by sentence", null)
+        SheetHeader(stringResource(R.string.reader_sleep_step_by_sentence), null)
         Row(
             modifier = Modifier
                 .fillMaxWidth()
@@ -1225,20 +1226,20 @@ private fun PlayerOverflowSheet(
             verticalAlignment = Alignment.CenterVertically,
         ) {
             BrassButton(
-                label = "← Previous",
+                label = stringResource(R.string.reader_step_previous),
                 onClick = onPreviousSentence,
                 variant = BrassButtonVariant.Secondary,
                 modifier = Modifier.weight(1f),
             )
             BrassButton(
-                label = "Next →",
+                label = stringResource(R.string.reader_step_next),
                 onClick = onNextSentence,
                 variant = BrassButtonVariant.Secondary,
                 modifier = Modifier.weight(1f),
             )
         }
 
-        SheetHeader("Sleep timer", null)
+        SheetHeader(stringResource(R.string.reader_sleep_timer), null)
         SleepTimerChips(
             activeRemainingMs = state.sleepTimerRemainingMs,
             onStart = onStartSleepTimer,
@@ -1249,14 +1250,14 @@ private fun PlayerOverflowSheet(
         // drops a marker at the current playback position; "Jump to
         // bookmark" seeks to it. Both fire-and-forget; the controller
         // no-ops gracefully when nothing is loaded / no bookmark exists.
-        SheetHeader("Bookmark", null)
+        SheetHeader(stringResource(R.string.reader_bookmark_header), null)
         // a11y (#481): Role.Button for the action rows in the
         // bookmark / smart-feature sheet — TalkBack reads the title
         // text via merge, plus the Button role + onClickLabel verb.
         Row(
             modifier = Modifier
                 .fillMaxWidth()
-                .clickable(role = Role.Button, onClickLabel = "Bookmark here", onClick = onBookmarkHere)
+                .clickable(role = Role.Button, onClickLabel = stringResource(R.string.reader_bookmark_here), onClick = onBookmarkHere)
                 .padding(vertical = spacing.xs),
             verticalAlignment = Alignment.CenterVertically,
             horizontalArrangement = Arrangement.spacedBy(spacing.sm),
@@ -1267,9 +1268,9 @@ private fun PlayerOverflowSheet(
                 tint = MaterialTheme.colorScheme.primary,
             )
             Column(modifier = Modifier.weight(1f)) {
-                Text("Bookmark here", style = MaterialTheme.typography.bodyMedium)
+                Text(stringResource(R.string.reader_bookmark_here), style = MaterialTheme.typography.bodyMedium)
                 Text(
-                    "Drop a marker at the current position",
+                    stringResource(R.string.reader_bookmark_here_subtitle),
                     style = MaterialTheme.typography.bodySmall,
                     color = MaterialTheme.colorScheme.onSurfaceVariant,
                 )
@@ -1278,7 +1279,7 @@ private fun PlayerOverflowSheet(
         Row(
             modifier = Modifier
                 .fillMaxWidth()
-                .clickable(role = Role.Button, onClickLabel = "Jump to bookmark", onClick = onJumpToBookmark)
+                .clickable(role = Role.Button, onClickLabel = stringResource(R.string.reader_jump_to_bookmark), onClick = onJumpToBookmark)
                 .padding(vertical = spacing.xs),
             verticalAlignment = Alignment.CenterVertically,
             horizontalArrangement = Arrangement.spacedBy(spacing.sm),
@@ -1289,9 +1290,9 @@ private fun PlayerOverflowSheet(
                 tint = MaterialTheme.colorScheme.primary,
             )
             Column(modifier = Modifier.weight(1f)) {
-                Text("Jump to bookmark", style = MaterialTheme.typography.bodyMedium)
+                Text(stringResource(R.string.reader_jump_to_bookmark), style = MaterialTheme.typography.bodyMedium)
                 Text(
-                    "Resume from the marker you set",
+                    stringResource(R.string.reader_jump_to_bookmark_subtitle),
                     style = MaterialTheme.typography.bodySmall,
                     color = MaterialTheme.colorScheme.onSurfaceVariant,
                 )
@@ -1306,11 +1307,11 @@ private fun PlayerOverflowSheet(
         // than two-tap behind the ⋮.
 
         // ── Chapter Recap (issue #81) — opens the librarian modal ──
-        SheetHeader("Smart features", null)
+        SheetHeader(stringResource(R.string.reader_smart_features), null)
         Row(
             modifier = Modifier
                 .fillMaxWidth()
-                .clickable(role = Role.Button, onClickLabel = "Recap so far", onClick = onRequestRecap)
+                .clickable(role = Role.Button, onClickLabel = stringResource(R.string.reader_recap_so_far), onClick = onRequestRecap)
                 .padding(vertical = spacing.xs),
             verticalAlignment = Alignment.CenterVertically,
             horizontalArrangement = Arrangement.spacedBy(spacing.sm),
@@ -1321,9 +1322,9 @@ private fun PlayerOverflowSheet(
                 tint = MaterialTheme.colorScheme.primary,
             )
             Column(modifier = Modifier.weight(1f)) {
-                Text("Recap so far", style = MaterialTheme.typography.bodyMedium)
+                Text(stringResource(R.string.reader_recap_so_far), style = MaterialTheme.typography.bodyMedium)
                 Text(
-                    "Ask the librarian to summarize the last few chapters",
+                    stringResource(R.string.reader_recap_subtitle),
                     style = MaterialTheme.typography.bodySmall,
                     color = MaterialTheme.colorScheme.onSurfaceVariant,
                 )
@@ -1339,7 +1340,7 @@ private fun PlayerOverflowSheet(
         Row(
             modifier = Modifier
                 .fillMaxWidth()
-                .clickable(role = Role.Button, onClickLabel = "Open librarian chat", onClick = onOpenChat)
+                .clickable(role = Role.Button, onClickLabel = stringResource(R.string.reader_open_librarian_chat), onClick = onOpenChat)
                 .padding(vertical = spacing.xs),
             verticalAlignment = Alignment.CenterVertically,
             horizontalArrangement = Arrangement.spacedBy(spacing.sm),
@@ -1350,9 +1351,9 @@ private fun PlayerOverflowSheet(
                 tint = MaterialTheme.colorScheme.primary,
             )
             Column(modifier = Modifier.weight(1f)) {
-                Text("Ask the AI", style = MaterialTheme.typography.bodyMedium)
+                Text(stringResource(R.string.reader_ask_the_ai), style = MaterialTheme.typography.bodyMedium)
                 Text(
-                    "Chat about plot, characters, pacing, and craft",
+                    stringResource(R.string.reader_ask_ai_subtitle),
                     style = MaterialTheme.typography.bodySmall,
                     color = MaterialTheme.colorScheme.onSurfaceVariant,
                 )
@@ -1400,21 +1401,21 @@ private fun SleepTimerChips(
         FilterChip(
             selected = !isActive,
             onClick = { onCancel() },
-            label = { Text("Off") },
+            label = { Text(stringResource(R.string.reader_sleep_off)) },
             colors = brassFilterChipColors(),
         )
         listOf(15, 30, 45, 60).forEach { minutes ->
             FilterChip(
                 selected = false,
                 onClick = { onStart(UiSleepTimerMode.Duration(minutes)) },
-                label = { Text("${minutes}m") },
+                label = { Text(stringResource(R.string.reader_sleep_minutes, minutes)) },
                 colors = brassFilterChipColors(),
             )
         }
         FilterChip(
             selected = false,
             onClick = { onStart(UiSleepTimerMode.EndOfChapter) },
-            label = { Text("End") },
+            label = { Text(stringResource(R.string.reader_sleep_end)) },
             colors = brassFilterChipColors(),
         )
     }
@@ -2011,21 +2012,21 @@ internal fun PlayerQuickChips(
                 FilterChip(
                     selected = !sleepActive,
                     onClick = { onCancelSleepTimer() },
-                    label = { Text("Off") },
+                    label = { Text(stringResource(R.string.reader_sleep_off)) },
                     colors = brassFilterChipColors(),
                 )
                 SLEEP_TIMER_PRESETS_MIN.forEach { minutes ->
                     FilterChip(
                         selected = false,
                         onClick = { onStartSleepTimer(UiSleepTimerMode.Duration(minutes)) },
-                        label = { Text("${minutes}m") },
+                        label = { Text(stringResource(R.string.reader_sleep_minutes, minutes)) },
                         colors = brassFilterChipColors(),
                     )
                 }
                 FilterChip(
                     selected = false,
                     onClick = { onStartSleepTimer(UiSleepTimerMode.EndOfChapter) },
-                    label = { Text("End") },
+                    label = { Text(stringResource(R.string.reader_sleep_end)) },
                     colors = brassFilterChipColors(),
                 )
             }

--- a/feature/src/main/kotlin/in/jphe/storyvox/feature/reader/HybridReaderScreen.kt
+++ b/feature/src/main/kotlin/in/jphe/storyvox/feature/reader/HybridReaderScreen.kt
@@ -19,10 +19,12 @@ import androidx.compose.runtime.setValue
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import `in`.jphe.storyvox.feature.R
 import `in`.jphe.storyvox.feature.debug.DebugOverlay
 import `in`.jphe.storyvox.feature.debug.DebugViewModel
 import `in`.jphe.storyvox.ui.component.BrassButton
@@ -428,8 +430,7 @@ private fun ExplicitArgsLoadingPrompt(
                 )
                 Spacer(Modifier.height(spacing.xs))
                 Text(
-                    text = "The voice engine is taking longer than expected. " +
-                        "Try again, or back out to the chapter list.",
+                    text = stringResource(R.string.reader_voice_engine_slow_body),
                     style = MaterialTheme.typography.bodyMedium,
                     color = MaterialTheme.colorScheme.onSurfaceVariant,
                     textAlign = TextAlign.Center,
@@ -437,12 +438,12 @@ private fun ExplicitArgsLoadingPrompt(
                 Spacer(Modifier.height(spacing.lg))
                 Row(horizontalArrangement = Arrangement.spacedBy(spacing.sm)) {
                     BrassButton(
-                        label = "Back",
+                        label = stringResource(R.string.reader_back),
                         onClick = onBack,
                         variant = BrassButtonVariant.Secondary,
                     )
                     BrassButton(
-                        label = "Retry",
+                        label = stringResource(R.string.reader_retry),
                         onClick = onRetry,
                         variant = BrassButtonVariant.Primary,
                     )
@@ -462,14 +463,13 @@ private fun ExplicitArgsLoadingPrompt(
                 )
                 Spacer(Modifier.height(spacing.md))
                 Text(
-                    text = "Still loading…",
+                    text = stringResource(R.string.reader_still_loading),
                     style = MaterialTheme.typography.titleSmall,
                     color = MaterialTheme.colorScheme.primary,
                 )
                 Spacer(Modifier.height(spacing.xs))
                 Text(
-                    text = "Cold-start of a slow voice or large chapter " +
-                        "can take a moment.",
+                    text = stringResource(R.string.reader_still_loading_subtitle),
                     style = MaterialTheme.typography.bodySmall,
                     color = MaterialTheme.colorScheme.onSurfaceVariant,
                     textAlign = TextAlign.Center,
@@ -488,7 +488,7 @@ private fun ExplicitArgsLoadingPrompt(
                 )
                 Spacer(Modifier.height(spacing.md))
                 Text(
-                    text = "Loading chapter…",
+                    text = stringResource(R.string.reader_loading_chapter),
                     style = MaterialTheme.typography.titleSmall,
                     color = MaterialTheme.colorScheme.primary,
                 )
@@ -515,28 +515,27 @@ private fun BookFinishedOverlay(
         title = {
             Text(
                 text = if (fictionTitle.isNullOrBlank()) {
-                    "You finished this book."
+                    stringResource(R.string.reader_book_finished_no_title)
                 } else {
-                    "You finished “$fictionTitle”"
+                    stringResource(R.string.reader_book_finished_with_title, fictionTitle)
                 },
                 style = MaterialTheme.typography.titleLarge,
             )
         },
         text = {
             Text(
-                text = "Beautiful work. The story is over — for now. " +
-                    "Where would you like to go next?",
+                text = stringResource(R.string.reader_book_finished_body),
                 style = MaterialTheme.typography.bodyMedium,
             )
         },
         confirmButton = {
             androidx.compose.material3.TextButton(onClick = onBrowseMore) {
-                Text("Browse the realms")
+                Text(stringResource(R.string.reader_browse_realms))
             }
         },
         dismissButton = {
             androidx.compose.material3.TextButton(onClick = onBackToLibrary) {
-                Text("Back to Library")
+                Text(stringResource(R.string.reader_back_to_library))
             }
         },
     )

--- a/feature/src/main/kotlin/in/jphe/storyvox/feature/reader/NowPlayingDock.kt
+++ b/feature/src/main/kotlin/in/jphe/storyvox/feature/reader/NowPlayingDock.kt
@@ -29,6 +29,7 @@ import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.semantics.LiveRegionMode
 import androidx.compose.ui.semantics.Role
 import androidx.compose.ui.semantics.contentDescription
@@ -38,6 +39,7 @@ import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import `in`.jphe.storyvox.feature.R
 import `in`.jphe.storyvox.feature.api.UiPlaybackState
 import `in`.jphe.storyvox.ui.component.FictionCoverThumb
 import `in`.jphe.storyvox.ui.component.fictionMonogram
@@ -100,11 +102,10 @@ internal fun NowPlayingDockContent(
     modifier: Modifier = Modifier,
 ) {
     val isTablet = isAtLeastTablet()
-    val fictionTitle = state.fictionTitle.ifBlank { "Now playing" }
+    val fictionTitle = state.fictionTitle.ifBlank { stringResource(R.string.reader_now_playing) }
     val chapterTitle = state.chapterTitle
-    val cardDescription =
-        "Now playing: $fictionTitle. $chapterTitle. Tap to open reader."
-    val playPauseLabel = if (state.isPlaying) "Pause" else "Play"
+    val cardDescription = stringResource(R.string.reader_dock_card_description, fictionTitle, chapterTitle)
+    val playPauseLabel = if (state.isPlaying) stringResource(R.string.reader_pause) else stringResource(R.string.reader_play)
     // Why: progress is read-only in v1.0; clamp to [0, 1] so a stale
     // duration (e.g. mid-load) can't produce an out-of-range value the
     // LinearProgressIndicator would log-warn about.
@@ -138,7 +139,7 @@ internal fun NowPlayingDockContent(
                     // on hits to the thumbnail/title area.
                     .clickable(
                         role = Role.Button,
-                        onClickLabel = "Open reader",
+                        onClickLabel = stringResource(R.string.reader_open_reader),
                         onClick = onOpenReader,
                     )
                     .semantics { contentDescription = cardDescription }

--- a/feature/src/main/kotlin/in/jphe/storyvox/feature/reader/ReaderView.kt
+++ b/feature/src/main/kotlin/in/jphe/storyvox/feature/reader/ReaderView.kt
@@ -37,8 +37,10 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.layout.onGloballyPositioned
 import androidx.compose.ui.layout.onSizeChanged
 import androidx.compose.ui.layout.positionInParent
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.TextLayoutResult
 import androidx.compose.ui.unit.dp
+import `in`.jphe.storyvox.feature.R
 import `in`.jphe.storyvox.feature.api.UiPlaybackState
 import `in`.jphe.storyvox.ui.component.SentenceHighlight
 import `in`.jphe.storyvox.ui.theme.LocalSpacing
@@ -209,14 +211,13 @@ fun ReaderTextView(
                 },
                 title = {
                     Text(
-                        text = "Ask AI: who is \"$word\"?",
+                        text = stringResource(R.string.reader_ask_ai_title, word),
                         style = MaterialTheme.typography.titleMedium,
                     )
                 },
                 text = {
                     Text(
-                        text = "The librarian-companion will answer based on what you've " +
-                            "read so far — no spoilers from later chapters.",
+                        text = stringResource(R.string.reader_ask_ai_body),
                         style = MaterialTheme.typography.bodyMedium,
                         color = MaterialTheme.colorScheme.onSurfaceVariant,
                     )
@@ -229,12 +230,12 @@ fun ReaderTextView(
                             onAskAiAbout(q)
                         },
                     ) {
-                        Text("Ask AI")
+                        Text(stringResource(R.string.reader_ask_ai))
                     }
                 },
                 dismissButton = {
                     TextButton(onClick = { lookupWord = null }) {
-                        Text("Cancel")
+                        Text(stringResource(R.string.reader_cancel))
                     }
                 },
             )

--- a/feature/src/main/kotlin/in/jphe/storyvox/feature/reader/RecapModal.kt
+++ b/feature/src/main/kotlin/in/jphe/storyvox/feature/reader/RecapModal.kt
@@ -33,11 +33,13 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.alpha
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.semantics.Role
 import androidx.compose.ui.semantics.role
 import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
+import `in`.jphe.storyvox.feature.R
 import `in`.jphe.storyvox.feature.api.UiRecapPlaybackState
 import `in`.jphe.storyvox.ui.component.BrassButton
 import `in`.jphe.storyvox.ui.component.BrassButtonVariant
@@ -101,12 +103,12 @@ fun RecapModal(
             // feature itself.
             Column {
                 Text(
-                    text = "Recap so far",
+                    text = stringResource(R.string.reader_recap_so_far),
                     style = MaterialTheme.typography.titleMedium,
                     color = MaterialTheme.colorScheme.primary,
                 )
                 Text(
-                    text = subtitleFor(state),
+                    text = stringResource(subtitleResFor(state)),
                     style = MaterialTheme.typography.bodySmall,
                     color = MaterialTheme.colorScheme.onSurfaceVariant,
                 )
@@ -141,14 +143,14 @@ fun RecapModal(
                     is RecapUiState.Loading,
                     is RecapUiState.Streaming -> {
                         BrassButton(
-                            label = "Cancel",
+                            label = stringResource(R.string.reader_cancel),
                             onClick = onCancel,
                             variant = BrassButtonVariant.Secondary,
                         )
                     }
                     is RecapUiState.Done -> {
                         BrassButton(
-                            label = "Close",
+                            label = stringResource(R.string.reader_close),
                             onClick = onCancel,
                             variant = BrassButtonVariant.Secondary,
                         )
@@ -162,12 +164,12 @@ fun RecapModal(
                             RecapUiState.ErrorKind.NotConfigured,
                             RecapUiState.ErrorKind.AuthFailed -> {
                                 BrassButton(
-                                    label = "Open Settings",
+                                    label = stringResource(R.string.reader_open_settings),
                                     onClick = onOpenSettings,
                                     variant = BrassButtonVariant.Primary,
                                 )
                                 BrassButton(
-                                    label = "Close",
+                                    label = stringResource(R.string.reader_close),
                                     onClick = onCancel,
                                     variant = BrassButtonVariant.Secondary,
                                 )
@@ -175,12 +177,12 @@ fun RecapModal(
                             RecapUiState.ErrorKind.Transport,
                             RecapUiState.ErrorKind.ProviderError -> {
                                 BrassButton(
-                                    label = "Try again",
+                                    label = stringResource(R.string.reader_try_again),
                                     onClick = onRetry,
                                     variant = BrassButtonVariant.Primary,
                                 )
                                 BrassButton(
-                                    label = "Close",
+                                    label = stringResource(R.string.reader_close),
                                     onClick = onCancel,
                                     variant = BrassButtonVariant.Secondary,
                                 )
@@ -208,9 +210,9 @@ private fun ReadAloudIconButton(
     val isSpeaking = playbackState == UiRecapPlaybackState.Speaking
     val brass = MaterialTheme.colorScheme.primary
     val (icon, label) = if (isSpeaking) {
-        Icons.Filled.Pause to "Pause read aloud"
+        Icons.Filled.Pause to stringResource(R.string.reader_pause_read_aloud)
     } else {
-        Icons.Filled.PlayArrow to "Read aloud"
+        Icons.Filled.PlayArrow to stringResource(R.string.reader_read_aloud)
     }
     IconButton(
         onClick = onClick,
@@ -239,7 +241,7 @@ private fun LoadingBody() {
     ) {
         MagicSpinner()
         Text(
-            text = "  Asking the librarian…",
+            text = stringResource(R.string.reader_recap_asking_librarian),
             style = MaterialTheme.typography.bodyMedium,
             color = MaterialTheme.colorScheme.onSurfaceVariant,
         )
@@ -301,12 +303,12 @@ private fun StreamingBody(text: String) {
  * Internal so [`PunctuationPauseTickPlacementTest`-style] unit testing
  * could cover the mapping if it grows beyond five branches.
  */
-internal fun subtitleFor(state: RecapUiState): String = when (state) {
+internal fun subtitleResFor(state: RecapUiState): Int = when (state) {
     is RecapUiState.Loading,
-    is RecapUiState.Streaming -> "Asking the librarian about the last few chapters."
-    is RecapUiState.Done -> "Here's what happened in the last few chapters."
-    is RecapUiState.Error -> "Quick chapter summaries from your AI provider."
-    RecapUiState.Hidden -> ""  // unreachable — modal returns early when Hidden
+    is RecapUiState.Streaming -> R.string.reader_recap_subtitle_in_flight
+    is RecapUiState.Done -> R.string.reader_recap_subtitle_done
+    is RecapUiState.Error -> R.string.reader_recap_subtitle_error
+    RecapUiState.Hidden -> R.string.empty_string  // unreachable — modal returns early when Hidden
 }
 
 @Composable

--- a/feature/src/main/kotlin/in/jphe/storyvox/feature/reader/ResumePrompt.kt
+++ b/feature/src/main/kotlin/in/jphe/storyvox/feature/reader/ResumePrompt.kt
@@ -31,9 +31,11 @@ import androidx.compose.ui.draw.alpha
 import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import `in`.jphe.storyvox.data.repository.ContinueListeningEntry
+import `in`.jphe.storyvox.feature.R
 import `in`.jphe.storyvox.ui.component.BrassButton
 import `in`.jphe.storyvox.ui.component.BrassButtonVariant
 import `in`.jphe.storyvox.ui.component.FictionCoverThumb
@@ -201,7 +203,7 @@ fun ResumePrompt(
                 // sweep is preserved (it's the moment of magic
                 // storyvox is named for).
                 BrassButton(
-                    label = "▶  Start listening",
+                    label = stringResource(R.string.reader_start_listening),
                     onClick = onResume,
                     variant = BrassButtonVariant.Primary,
                     modifier = Modifier.fillMaxWidth(),
@@ -211,7 +213,7 @@ fun ResumePrompt(
             Spacer(Modifier.height(spacing.sm))
 
             BrassButton(
-                label = "From the start",
+                label = stringResource(R.string.reader_from_the_start),
                 onClick = onFromStart,
                 variant = BrassButtonVariant.Text,
             )
@@ -479,21 +481,21 @@ fun ResumeEmptyPrompt(
         )
         Spacer(Modifier.height(spacing.lg))
         Text(
-            text = "Your library awaits",
+            text = stringResource(R.string.reader_empty_library_title),
             style = MaterialTheme.typography.titleMedium,
             color = MaterialTheme.colorScheme.primary,
             textAlign = TextAlign.Center,
         )
         Spacer(Modifier.height(spacing.xs))
         Text(
-            text = "Pick up an audiobook to listen and storyvox remembers your place.",
+            text = stringResource(R.string.reader_empty_library_body),
             style = MaterialTheme.typography.bodyMedium,
             color = MaterialTheme.colorScheme.onSurfaceVariant,
             textAlign = TextAlign.Center,
         )
         Spacer(Modifier.height(spacing.lg))
         BrassButton(
-            label = "Browse the realms →",
+            label = stringResource(R.string.reader_browse_realms_arrow),
             onClick = onBrowse,
             variant = BrassButtonVariant.Primary,
         )

--- a/feature/src/main/kotlin/in/jphe/storyvox/feature/reader/VoiceQuickSheet.kt
+++ b/feature/src/main/kotlin/in/jphe/storyvox/feature/reader/VoiceQuickSheet.kt
@@ -37,10 +37,12 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.semantics.Role
 import androidx.compose.ui.semantics.contentDescription
 import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.semantics.stateDescription
+import `in`.jphe.storyvox.feature.R
 import `in`.jphe.storyvox.feature.api.UiPlaybackState
 import `in`.jphe.storyvox.ui.component.humanizeVoiceLabel
 import `in`.jphe.storyvox.ui.theme.LocalReducedMotion
@@ -113,7 +115,7 @@ internal fun VoiceQuickSheetContent(
         // below. The chip presets are the *fast path* — one tap and
         // the value is committed immediately. The slider stays
         // available for fine-tuning between presets.
-        QuickSheetHeader("Speed", "${"%.2f".format(state.speed)}×")
+        QuickSheetHeader(stringResource(R.string.reader_voice_speed_header), "${"%.2f".format(state.speed)}×")
         QuickSheetPresetChipRow(
             presets = SPEED_PRESETS,
             isSelected = { preset -> isSpeedPresetSelected(state.speed, preset) },
@@ -149,7 +151,7 @@ internal fun VoiceQuickSheetContent(
         // has no equivalent on a live stream the player can't re-encode.
         // Hiding rather than disabling keeps the sheet visually clean.
         if (!state.isLiveAudioChapter) {
-            QuickSheetHeader("Pitch", "${"%.2f".format(state.pitch)}×")
+            QuickSheetHeader(stringResource(R.string.reader_voice_pitch_header), "${"%.2f".format(state.pitch)}×")
             QuickSheetPresetChipRow(
                 presets = PITCH_PRESETS,
                 isSelected = { preset -> isPitchPresetSelected(state.pitch, preset) },
@@ -182,12 +184,13 @@ internal fun VoiceQuickSheetContent(
         // Tap-to-open-full-picker. The whole row is the touch target
         // (matches the established Player Options sheet pattern; the
         // previous IconButton-only target was undersized at 36 dp).
-        QuickSheetHeader("Voice", null)
+        QuickSheetHeader(stringResource(R.string.reader_voice_header), null)
         // a11y (#481): Role.Button + label for the voice-picker row.
+        val pickVoiceLabel = stringResource(R.string.reader_pick_voice)
         Row(
             modifier = Modifier
                 .fillMaxWidth()
-                .clickable(role = Role.Button, onClickLabel = "Pick voice", onClick = onPickVoice)
+                .clickable(role = Role.Button, onClickLabel = pickVoiceLabel, onClick = onPickVoice)
                 .padding(vertical = spacing.xs),
             verticalAlignment = Alignment.CenterVertically,
             horizontalArrangement = Arrangement.spacedBy(spacing.sm),
@@ -203,11 +206,11 @@ internal fun VoiceQuickSheetContent(
                 // the raw `azure:en-US-BrianNeural` token. Falls back
                 // to "Pick a voice" via `ifBlank` when no voice is set.
                 Text(
-                    humanizeVoiceLabel(state.voiceLabel).ifBlank { "Pick a voice" },
+                    humanizeVoiceLabel(state.voiceLabel).ifBlank { stringResource(R.string.reader_pick_a_voice) },
                     style = MaterialTheme.typography.bodyMedium,
                 )
                 Text(
-                    "Tap to change",
+                    stringResource(R.string.reader_voice_tap_to_change),
                     style = MaterialTheme.typography.bodySmall,
                     color = MaterialTheme.colorScheme.onSurfaceVariant,
                 )
@@ -225,7 +228,7 @@ internal fun VoiceQuickSheetContent(
         // "Custom…" for users who want extra-slow narrator cadence.
         // 0× = rapid listening; 1× = audiobook-tuned default;
         // 2-3× = slow, a11y / language-learning cadence.
-        QuickSheetHeader("Sentence silence", "${"%.2f".format(punctuationPauseMultiplier)}×")
+        QuickSheetHeader(stringResource(R.string.reader_voice_sentence_silence_header), "${"%.2f".format(punctuationPauseMultiplier)}×")
         QuickSheetPresetChipRow(
             presets = PUNCTUATION_PAUSE_PRESETS,
             isSelected = { preset ->
@@ -263,11 +266,11 @@ internal fun VoiceQuickSheetContent(
         // so the listener isn't surprised the current chapter doesn't
         // change tone mid-stream.
         QuickSheetSwitchRow(
-            title = "High-quality pitch",
+            title = stringResource(R.string.reader_voice_high_quality_title),
             subtitle = if (pitchInterpolationHighQuality) {
-                "Smoother pitch-shifted audio. Applies on next chapter."
+                stringResource(R.string.reader_voice_high_quality_on)
             } else {
-                "Faster pitch shifting. Grittier at non-neutral pitch."
+                stringResource(R.string.reader_voice_high_quality_off)
             },
             checked = pitchInterpolationHighQuality,
             onCheckedChange = onSetPitchHighQuality,
@@ -285,7 +288,7 @@ internal fun VoiceQuickSheetContent(
                 .fillMaxWidth()
                 .clickable(
                     role = Role.Button,
-                    onClickLabel = if (advancedOpen) "Collapse advanced" else "Expand advanced",
+                    onClickLabel = if (advancedOpen) stringResource(R.string.reader_voice_collapse_advanced) else stringResource(R.string.reader_voice_expand_advanced),
                 ) { advancedOpen = !advancedOpen }
                 .padding(vertical = spacing.xs),
             verticalAlignment = Alignment.CenterVertically,
@@ -297,14 +300,14 @@ internal fun VoiceQuickSheetContent(
                 tint = MaterialTheme.colorScheme.primary,
             )
             Text(
-                "Advanced",
+                stringResource(R.string.reader_voice_advanced),
                 style = MaterialTheme.typography.titleSmall,
                 color = MaterialTheme.colorScheme.primary,
                 modifier = Modifier.weight(1f),
             )
             Icon(
                 imageVector = if (advancedOpen) Icons.Outlined.ExpandLess else Icons.Outlined.ExpandMore,
-                contentDescription = if (advancedOpen) "Collapse advanced" else "Expand advanced",
+                contentDescription = if (advancedOpen) stringResource(R.string.reader_voice_collapse_advanced) else stringResource(R.string.reader_voice_expand_advanced),
                 tint = MaterialTheme.colorScheme.onSurfaceVariant,
             )
         }
@@ -323,7 +326,7 @@ internal fun VoiceQuickSheetContent(
                         .fillMaxWidth()
                         .clickable(
                             role = Role.Button,
-                            onClickLabel = "Open per-voice lexicon and Kokoro language",
+                            onClickLabel = stringResource(R.string.reader_voice_advanced_open_label),
                             onClick = onOpenAdvancedVoice,
                         )
                         .padding(vertical = spacing.xs),
@@ -332,11 +335,11 @@ internal fun VoiceQuickSheetContent(
                 ) {
                     Column(modifier = Modifier.weight(1f)) {
                         Text(
-                            "Per-voice lexicon + Kokoro language",
+                            stringResource(R.string.reader_voice_per_voice_lexicon),
                             style = MaterialTheme.typography.bodyMedium,
                         )
                         Text(
-                            "Open Voice Library for per-voice pronunciation rules and phonemizer overrides.",
+                            stringResource(R.string.reader_voice_per_voice_lexicon_subtitle),
                             style = MaterialTheme.typography.bodySmall,
                             color = MaterialTheme.colorScheme.onSurfaceVariant,
                         )
@@ -423,7 +426,7 @@ private fun QuickSheetPresetChipRow(
         FilterChip(
             selected = customExpanded,
             onClick = onToggleCustom,
-            label = { Text(if (customExpanded) "Custom" else "Custom…") },
+            label = { Text(if (customExpanded) stringResource(R.string.reader_voice_custom) else stringResource(R.string.reader_voice_custom_more)) },
             colors = brassFilterChipColors(),
             modifier = Modifier.semantics {
                 contentDescription = if (customExpanded) {

--- a/feature/src/main/kotlin/in/jphe/storyvox/feature/sessions/SessionsScreen.kt
+++ b/feature/src/main/kotlin/in/jphe/storyvox/feature/sessions/SessionsScreen.kt
@@ -32,10 +32,12 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontStyle
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import `in`.jphe.storyvox.feature.R
 import `in`.jphe.storyvox.ui.theme.LocalSpacing
 import java.text.DateFormat
 import java.util.Date
@@ -64,7 +66,7 @@ fun SessionsScreen(
         topBar = {
             TopAppBar(
                 title = {
-                    Text("Sessions", style = MaterialTheme.typography.titleMedium)
+                    Text(stringResource(R.string.sessions_title), style = MaterialTheme.typography.titleMedium)
                 },
                 navigationIcon = {
                     IconButton(onClick = onBack) {
@@ -111,7 +113,7 @@ fun SessionsScreen(
     pendingDelete?.let { row ->
         AlertDialog(
             onDismissRequest = { pendingDelete = null },
-            title = { Text("Delete this session?") },
+            title = { Text(stringResource(R.string.sessions_delete_dialog_title)) },
             text = {
                 Text(
                     "Removes the chat history and all messages. Cannot be undone.",
@@ -122,10 +124,10 @@ fun SessionsScreen(
                 TextButton(onClick = {
                     viewModel.deleteSession(row.session.id)
                     pendingDelete = null
-                }) { Text("Delete") }
+                }) { Text(stringResource(R.string.sessions_delete)) }
             },
             dismissButton = {
-                TextButton(onClick = { pendingDelete = null }) { Text("Cancel") }
+                TextButton(onClick = { pendingDelete = null }) { Text(stringResource(R.string.sessions_cancel)) }
             },
         )
     }
@@ -185,7 +187,7 @@ private fun SessionCard(
                 horizontalArrangement = Arrangement.End,
             ) {
                 if (onOpen != null) {
-                    TextButton(onClick = onOpen) { Text("Open") }
+                    TextButton(onClick = onOpen) { Text(stringResource(R.string.sessions_open)) }
                 }
                 TextButton(onClick = onDelete) {
                     Icon(
@@ -193,7 +195,7 @@ private fun SessionCard(
                         contentDescription = null,
                         modifier = Modifier.padding(end = 4.dp),
                     )
-                    Text("Delete")
+                    Text(stringResource(R.string.sessions_delete))
                 }
             }
         }

--- a/feature/src/main/kotlin/in/jphe/storyvox/feature/sync/SyncAuthScreen.kt
+++ b/feature/src/main/kotlin/in/jphe/storyvox/feature/sync/SyncAuthScreen.kt
@@ -23,6 +23,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.semantics.LiveRegionMode
 import androidx.compose.ui.semantics.contentDescription
 import androidx.compose.ui.semantics.liveRegion
@@ -33,6 +34,7 @@ import androidx.compose.ui.unit.dp
 import androidx.compose.foundation.text.KeyboardOptions
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import `in`.jphe.storyvox.feature.R
 import `in`.jphe.storyvox.ui.component.MagicCircularProgress
 
 /**
@@ -60,7 +62,7 @@ fun SyncAuthScreen(
     Scaffold(
         modifier = modifier,
         topBar = {
-            TopAppBar(title = { Text("Sync") })
+            TopAppBar(title = { Text(stringResource(R.string.sync_title)) })
         },
     ) { padding ->
         Column(
@@ -132,7 +134,7 @@ private fun SignedOutForm(
     OutlinedTextField(
         value = email,
         onValueChange = onEmailChange,
-        label = { Text("Email") },
+        label = { Text(stringResource(R.string.sync_email_label)) },
         singleLine = true,
         keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Email),
         modifier = Modifier.fillMaxWidth(),
@@ -144,7 +146,7 @@ private fun SignedOutForm(
         onClick = onSubmit,
         modifier = Modifier.fillMaxWidth(),
         colors = ButtonDefaults.buttonColors(),
-    ) { Text("Send code") }
+    ) { Text(stringResource(R.string.sync_send_code)) }
 }
 
 @Composable
@@ -165,7 +167,7 @@ private fun CodePromptForm(
     OutlinedTextField(
         value = code,
         onValueChange = onCodeChange,
-        label = { Text("6-digit code") },
+        label = { Text(stringResource(R.string.sync_code_label)) },
         singleLine = true,
         keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.NumberPassword),
         modifier = Modifier.fillMaxWidth(),
@@ -176,12 +178,12 @@ private fun CodePromptForm(
     Button(
         onClick = onSubmit,
         modifier = Modifier.fillMaxWidth(),
-    ) { Text("Verify") }
+    ) { Text(stringResource(R.string.sync_verify)) }
     Spacer(Modifier.height(8.dp))
     OutlinedButton(
         onClick = onReset,
         modifier = Modifier.fillMaxWidth(),
-    ) { Text("Use a different email") }
+    ) { Text(stringResource(R.string.sync_different_email)) }
 }
 
 @Composable
@@ -236,10 +238,10 @@ private fun SignedInPanel(
     Button(
         onClick = onClose,
         modifier = Modifier.fillMaxWidth(),
-    ) { Text("Done") }
+    ) { Text(stringResource(R.string.sync_done)) }
     Spacer(Modifier.height(8.dp))
     OutlinedButton(
         onClick = onSignOut,
         modifier = Modifier.fillMaxWidth(),
-    ) { Text("Sign out") }
+    ) { Text(stringResource(R.string.sync_sign_out)) }
 }

--- a/feature/src/main/kotlin/in/jphe/storyvox/feature/techempower/TechEmpowerIntents.kt
+++ b/feature/src/main/kotlin/in/jphe/storyvox/feature/techempower/TechEmpowerIntents.kt
@@ -26,10 +26,12 @@ import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import `in`.jphe.storyvox.data.TechEmpowerLinks
+import `in`.jphe.storyvox.feature.R
 import `in`.jphe.storyvox.ui.theme.LocalSpacing
 
 /**
@@ -257,7 +259,7 @@ internal fun NoTelephonyFallbackDialog(
                             modifier = Modifier.size(18.dp),
                         )
                         Spacer(Modifier.width(spacing.xs))
-                        Text("Copy")
+                        Text(stringResource(R.string.techempower_copy))
                     }
                     TextButton(
                         modifier = Modifier.weight(1f),
@@ -278,13 +280,13 @@ internal fun NoTelephonyFallbackDialog(
                             modifier = Modifier.size(18.dp),
                         )
                         Spacer(Modifier.width(spacing.xs))
-                        Text("Open web")
+                        Text(stringResource(R.string.techempower_open_web))
                     }
                 }
             }
         },
         confirmButton = {
-            TextButton(onClick = onDismiss) { Text("Close") }
+            TextButton(onClick = onDismiss) { Text(stringResource(R.string.techempower_close)) }
         },
     )
 }

--- a/feature/src/main/kotlin/in/jphe/storyvox/feature/voicelibrary/VoiceLibraryScreen.kt
+++ b/feature/src/main/kotlin/in/jphe/storyvox/feature/voicelibrary/VoiceLibraryScreen.kt
@@ -54,6 +54,7 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.semantics.Role
 import androidx.compose.ui.semantics.clearAndSetSemantics
 import androidx.compose.ui.semantics.contentDescription
@@ -65,6 +66,7 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import `in`.jphe.storyvox.feature.R
 import `in`.jphe.storyvox.playback.voice.EngineKey
 import `in`.jphe.storyvox.playback.voice.EngineType
 import `in`.jphe.storyvox.playback.voice.QualityLevel
@@ -103,7 +105,7 @@ fun VoiceLibraryScreen(
     Scaffold(
         topBar = {
             TopAppBar(
-                title = { Text("Voice library") },
+                title = { Text(stringResource(R.string.voicelibrary_title)) },
                 // Voice Library was promoted to a first-class home tab
                 // (issue #264 follow-up), so it no longer has a back
                 // arrow — peer of Library/Browse/Follows/Playing. The
@@ -183,7 +185,7 @@ fun VoiceLibraryScreen(
             OutlinedTextField(
                 value = rawQuery,
                 onValueChange = { viewModel.setQuery(it) },
-                placeholder = { Text("Search voices") },
+                placeholder = { Text(stringResource(R.string.voicelibrary_search_placeholder)) },
                 singleLine = true,
                 leadingIcon = {
                     Icon(Icons.Outlined.Search, contentDescription = null)
@@ -274,7 +276,7 @@ fun VoiceLibraryScreen(
                     onClick = {
                         selectedGenders = selectedGenders.toggleMember(VoiceGender.Female)
                     },
-                    label = { Text("♀ Female") },
+                    label = { Text(stringResource(R.string.voicelibrary_female)) },
                     colors = brassFilterChipColors(),
                 )
                 FilterChip(
@@ -282,7 +284,7 @@ fun VoiceLibraryScreen(
                     onClick = {
                         selectedGenders = selectedGenders.toggleMember(VoiceGender.Male)
                     },
-                    label = { Text("♂ Male") },
+                    label = { Text(stringResource(R.string.voicelibrary_male)) },
                     colors = brassFilterChipColors(),
                 )
                 FilterChip(
@@ -290,7 +292,7 @@ fun VoiceLibraryScreen(
                     onClick = {
                         selectedGenders = selectedGenders.toggleMember(VoiceGender.Unknown)
                     },
-                    label = { Text("Neutral") },
+                    label = { Text(stringResource(R.string.voicelibrary_neutral)) },
                     colors = brassFilterChipColors(),
                 )
                 listOf(
@@ -309,7 +311,7 @@ fun VoiceLibraryScreen(
                 FilterChip(
                     selected = multilingualOnly,
                     onClick = { multilingualOnly = !multilingualOnly },
-                    label = { Text("Multilingual") },
+                    label = { Text(stringResource(R.string.voicelibrary_multilingual)) },
                     colors = brassFilterChipColors(),
                 )
             }
@@ -1211,7 +1213,7 @@ private fun DeleteConfirmDialog(
 ) {
     AlertDialog(
         onDismissRequest = onDismiss,
-        title = { Text("Delete ${voice.displayName}?") },
+        title = { Text(stringResource(R.string.voicelibrary_delete_title, voice.displayName)) },
         text = {
             Text(
                 "Frees ${formatBytes(voice.sizeBytes)}. You can re-download anytime from this screen.",
@@ -1556,7 +1558,7 @@ private fun PhonemizerLangDropdown(
         FilterChip(
             selected = selected.isEmpty(),
             onClick = { onSelected(null) },
-            label = { Text("Default", style = MaterialTheme.typography.labelMedium) },
+            label = { Text(stringResource(R.string.voicelibrary_default), style = MaterialTheme.typography.labelMedium) },
             colors = brassFilterChipColors(),
         )
         for (code in `in`.jphe.storyvox.playback.KOKORO_PHONEMIZER_LANGS) {

--- a/feature/src/main/res/values/strings.xml
+++ b/feature/src/main/res/values/strings.xml
@@ -1,0 +1,195 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <!-- Browse -->
+    <string name="browse_title">Browse</string>
+    <string name="browse_search_hint">Search %1$s</string>
+    <string name="browse_notion_connect_cta">Have a Notion workspace? Connect it →</string>
+    <string name="browse_ao3_signin_cta">Sign in to AO3</string>
+    <string name="browse_mempalace_wing_chip">Wing: %1$s</string>
+
+    <!-- Source carousel actions -->
+    <string name="source_options">Source options</string>
+    <string name="source_remove_from_favorites">Remove from favorites</string>
+    <string name="source_add_to_favorites">Add to favorites</string>
+    <string name="source_favorite_subtitle_remove">Will keep its place in the list</string>
+    <string name="source_favorite_subtitle_add">Pins to the front of the carousel</string>
+    <string name="source_hide_title">Hide from Browse</string>
+    <string name="source_hide_subtitle">Re-enable from Settings -&gt; Plugins</string>
+
+    <!-- Source taglines -->
+    <string name="source_tagline_royal_road">Web serials</string>
+    <string name="source_tagline_ao3">Fanfiction archive</string>
+    <string name="source_tagline_gutenberg">Classic books</string>
+    <string name="source_tagline_standard_ebooks">Polished classics</string>
+    <string name="source_tagline_wikipedia">Encyclopedia</string>
+    <string name="source_tagline_wikisource">Historic texts</string>
+    <string name="source_tagline_github">Repo READMEs</string>
+    <string name="source_tagline_rss">Your feeds</string>
+    <string name="source_tagline_epub">Your EPUBs</string>
+    <string name="source_tagline_outline">Your wiki</string>
+    <string name="source_tagline_mempalace">Your palace</string>
+    <string name="source_tagline_radio">Live radio</string>
+    <string name="source_tagline_notion">Your Notion</string>
+    <string name="source_tagline_hackernews">Tech news</string>
+    <string name="source_tagline_arxiv">Research papers</string>
+    <string name="source_tagline_plos">Open science</string>
+    <string name="source_tagline_discord">Server channels</string>
+    <string name="source_tagline_matrix">Matrix rooms</string>
+    <string name="source_tagline_telegram">Channel posts</string>
+    <string name="source_tagline_slack">Workspace threads</string>
+    <string name="source_tagline_palace">Library borrows</string>
+    <string name="source_tagline_readability">Paste any link</string>
+
+    <!-- Per-source search hints (#271) -->
+    <string name="search_hint_royal_road">Find fictions across Royal Road</string>
+    <string name="search_hint_github">Search indexed GitHub repositories</string>
+    <string name="search_hint_mempalace">Search your MemPalace knowledge base</string>
+    <string name="search_hint_rss">Search your subscribed feeds</string>
+    <string name="search_hint_epub">Search your local EPUB library</string>
+    <string name="search_hint_outline">Search your Outline notes</string>
+    <string name="search_hint_gutenberg">Search Project Gutenberg\'s 70,000+ public-domain books</string>
+    <string name="search_hint_ao3">Search AO3 by tag, fandom, or character</string>
+    <string name="search_hint_standard_ebooks">Search Standard Ebooks\' hand-curated public-domain classics</string>
+    <string name="search_hint_wikipedia">Search Wikipedia — narrate any article</string>
+    <string name="search_hint_wikisource">Search Wikisource — transcribed public-domain texts</string>
+    <string name="search_hint_radio">Search Radio Browser — community, public, and college stations worldwide</string>
+    <string name="search_hint_kvmr">Tune in to KVMR — live community radio from Nevada City</string>
+    <string name="search_hint_notion">Search your configured Notion database</string>
+    <string name="search_hint_hackernews">Search Hacker News stories (Algolia-backed full-text)</string>
+    <string name="search_hint_arxiv">Search arXiv — open-access academic papers</string>
+    <string name="search_hint_plos">Search PLOS — open-access peer-reviewed science</string>
+    <string name="search_hint_discord">Search messages in your selected Discord server</string>
+    <string name="search_hint_generic">Search %1$s</string>
+
+    <!-- Filter sheets (shared) -->
+    <string name="filter_reset">Reset</string>
+    <string name="filter_apply">Apply</string>
+    <string name="filter_tags_label">Filter tags</string>
+    <string name="filter_sort_by_section">Sort by</string>
+    <string name="filter_category_section">Category</string>
+    <string name="filter_language_section">Language</string>
+    <string name="filter_recent_section">Recent</string>
+    <string name="filter_status_section">Status</string>
+    <string name="filter_include_tags_section">Include tags</string>
+    <string name="filter_exclude_tags_section">Exclude tags</string>
+    <string name="filter_tags_placeholder">e.g. fantasy, biology</string>
+    <string name="filter_language_iso_placeholder">ISO code (e.g. en, fr, ja)</string>
+    <string name="filter_language_short_placeholder">e.g. en</string>
+    <string name="filter_tags_short_placeholder">e.g. litrpg, fantasy</string>
+
+    <!-- BrowseFilterSheet (Royal Road) -->
+    <string name="royalroad_filter_title">Filter Royal Road</string>
+    <string name="filter_type_section">Type</string>
+    <string name="filter_length_pages_section">Length (pages): %1$s</string>
+    <string name="filter_rating_section">Rating: %1$s</string>
+    <string name="filter_content_warnings_exclude_section">Content warnings — exclude</string>
+    <string name="filter_sort_direction_desc">Desc</string>
+    <string name="filter_sort_direction_asc">Asc</string>
+
+    <!-- Fiction status labels -->
+    <string name="fiction_status_ongoing">Ongoing</string>
+    <string name="fiction_status_completed">Completed</string>
+    <string name="fiction_status_hiatus">Hiatus</string>
+    <string name="fiction_status_stub">Stub</string>
+    <string name="fiction_status_dropped">Dropped</string>
+
+    <!-- Fiction type labels -->
+    <string name="fiction_type_all">All</string>
+    <string name="fiction_type_original">Original</string>
+    <string name="fiction_type_fanfiction">Fan Fiction</string>
+
+    <!-- Content warning labels -->
+    <string name="content_warning_profanity">Profanity</string>
+    <string name="content_warning_sexual">Sexual</string>
+    <string name="content_warning_violence">Violence</string>
+    <string name="content_warning_sensitive">Sensitive</string>
+    <string name="content_warning_ai_assisted">AI-assisted</string>
+    <string name="content_warning_ai_generated">AI-generated</string>
+
+    <!-- Search order labels -->
+    <string name="search_order_relevance">Relevance</string>
+    <string name="search_order_popularity">Popularity</string>
+    <string name="search_order_rating">Average rating</string>
+    <string name="search_order_last_update">Last update</string>
+    <string name="search_order_release_date">Release date</string>
+    <string name="search_order_followers">Followers</string>
+    <string name="search_order_length">Length</string>
+    <string name="search_order_views">Views</string>
+    <string name="search_order_title">Title</string>
+
+    <!-- Generic sort/range labels -->
+    <string name="generic_sort_default">Default</string>
+    <string name="generic_sort_newest">Newest</string>
+    <string name="generic_sort_popular">Popular</string>
+    <string name="generic_sort_title">Title (A-Z)</string>
+    <string name="generic_range_any">Any time</string>
+    <string name="generic_range_last_7_days">Last 7 days</string>
+    <string name="generic_range_last_30_days">Last 30 days</string>
+    <string name="generic_range_last_90_days">Last 90 days</string>
+    <string name="generic_range_last_year">Last year</string>
+
+    <!-- Generic filter sheet -->
+    <string name="generic_filter_title">Filter %1$s</string>
+    <string name="generic_filter_chip_any">Any</string>
+
+    <!-- MemPalace filter sheet -->
+    <string name="mempalace_filter_title">Filter by wing</string>
+    <string name="mempalace_no_wings">No wings reachable. Confirm your palace daemon is configured under Settings → Memory Palace.</string>
+    <string name="mempalace_chip_all">All</string>
+
+    <!-- GitHub filter sheet -->
+    <string name="github_filter_title">Filter GitHub</string>
+    <string name="github_min_stars_section">Minimum stars: %1$d</string>
+    <string name="github_language_section">Language (ISO code, e.g. en, ja)</string>
+    <string name="github_pushed_section">Last pushed</string>
+    <string name="github_topics_section">Topic tags (comma-separated, e.g. litrpg, fantasy)</string>
+    <string name="github_repo_state_section">Repository state</string>
+    <string name="github_repo_state_any">Any</string>
+    <string name="github_repo_state_active">Active only</string>
+    <string name="github_repo_state_archived">Archived only</string>
+    <string name="github_visibility_section">Visibility</string>
+    <string name="github_visibility_both">Both</string>
+    <string name="github_visibility_public">Public</string>
+    <string name="github_visibility_private">Private</string>
+    <string name="github_sort_best_match">Best match</string>
+    <string name="github_sort_stars">Stars</string>
+    <string name="github_sort_updated">Recently updated</string>
+    <string name="github_pushed_any">Any time</string>
+    <string name="github_pushed_last_7_days">Last 7 days</string>
+    <string name="github_pushed_last_30_days">Last 30 days</string>
+    <string name="github_pushed_last_90_days">Last 90 days</string>
+    <string name="github_pushed_last_year">Last year</string>
+
+    <!-- RSS manage sheet -->
+    <string name="rss_manage_title">Manage RSS feeds</string>
+    <string name="rss_manage_description">Subscribe to any feed that publishes RSS or Atom. Storyvox treats each feed as one fiction; each item is a chapter.</string>
+    <string name="rss_feed_url_label">Feed URL</string>
+    <string name="rss_feed_url_placeholder">https://example.com/feed.xml</string>
+    <string name="rss_add">Add</string>
+    <string name="rss_remove">Remove</string>
+    <string name="rss_no_subscriptions">No subscriptions yet</string>
+    <string name="rss_your_feeds_count">Your feeds (%1$d)</string>
+    <string name="rss_empty_hint">Paste a feed URL above to subscribe, or pick from the suggested list below.</string>
+    <string name="rss_suggested_collapse">Collapse suggested feeds</string>
+    <string name="rss_suggested_expand">Expand suggested feeds</string>
+    <string name="rss_suggested_expanded_header">▾  Suggested feeds</string>
+    <string name="rss_suggested_collapsed_header">▸  Suggested feeds</string>
+    <string name="rss_suggested_collapsed_hint">Tap to browse curated feeds (Buddhist &amp; dharma, more coming).</string>
+    <string name="rss_kind_text">Text articles — narrate well</string>
+    <string name="rss_kind_audio_podcast">Audio podcast — storyvox narrates show notes only</string>
+    <string name="rss_already_added">Added</string>
+
+    <!-- Craigslist template card -->
+    <string name="craigslist_expand">Expand Craigslist template</string>
+    <string name="craigslist_collapse">Collapse Craigslist template</string>
+    <string name="craigslist_header_expanded">▾  Local marketplace · Craigslist</string>
+    <string name="craigslist_header_collapsed">▸  Local marketplace · Craigslist</string>
+    <string name="craigslist_collapsed_hint">Tap to subscribe to a Craigslist regional feed by region + category.</string>
+    <string name="craigslist_step_region">1. Pick a region</string>
+    <string name="craigslist_step_category">2. Pick a category</string>
+    <string name="craigslist_pick_preview_hint">Pick a region and a category to preview the feed URL.</string>
+    <string name="craigslist_already_subscribed">Already subscribed</string>
+    <string name="craigslist_subscribe">Subscribe</string>
+    <string name="craigslist_subscribed_confirmation">Subscribed: %1$s. See it under Browse → RSS.</string>
+
+</resources>

--- a/feature/src/main/res/values/strings.xml
+++ b/feature/src/main/res/values/strings.xml
@@ -1,5 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
+    <!-- Shared utility -->
+    <string name="empty_string"></string>
     <!-- Browse -->
     <string name="browse_title">Browse</string>
     <string name="browse_search_hint">Search %1$s</string>
@@ -131,6 +133,109 @@
     <!-- Generic filter sheet -->
     <string name="generic_filter_title">Filter %1$s</string>
     <string name="generic_filter_chip_any">Any</string>
+
+    <!-- Reader / ReaderView -->
+    <string name="reader_ask_ai_title">Ask AI: who is \"%1$s\"?</string>
+    <string name="reader_ask_ai_body">The librarian-companion will answer based on what you\'ve read so far — no spoilers from later chapters.</string>
+    <string name="reader_ask_ai">Ask AI</string>
+    <string name="reader_cancel">Cancel</string>
+
+    <!-- Reader / HybridReaderScreen -->
+    <string name="reader_empty_library_title">Your library awaits</string>
+    <string name="reader_browse_realms">Browse the realms</string>
+    <string name="reader_back_to_library">Back to Library</string>
+    <string name="reader_back">Back</string>
+    <string name="reader_retry">Retry</string>
+    <string name="reader_voice_engine_slow_body">The voice engine is taking longer than expected. Try again, or back out to the chapter list.</string>
+    <string name="reader_still_loading">Still loading…</string>
+    <string name="reader_still_loading_subtitle">Cold-start of a slow voice or large chapter can take a moment.</string>
+    <string name="reader_loading_chapter">Loading chapter…</string>
+    <string name="reader_book_finished_no_title">You finished this book.</string>
+    <string name="reader_book_finished_with_title">You finished “%1$s”</string>
+    <string name="reader_book_finished_body">Beautiful work. The story is over — for now. Where would you like to go next?</string>
+
+    <!-- Reader / NowPlayingDock -->
+    <string name="reader_now_playing">Now playing</string>
+    <string name="reader_pause">Pause</string>
+    <string name="reader_play">Play</string>
+    <string name="reader_open_reader">Open reader</string>
+    <string name="reader_dock_card_description">Now playing: %1$s. %2$s. Tap to open reader.</string>
+
+    <!-- Reader / ResumePrompt -->
+    <string name="reader_from_the_start">From the start</string>
+    <string name="reader_start_listening">▶  Start listening</string>
+    <string name="reader_empty_library_body">Pick up an audiobook to listen and storyvox remembers your place.</string>
+    <string name="reader_browse_realms_arrow">Browse the realms →</string>
+
+    <!-- Reader / RecapModal -->
+    <string name="reader_recap_so_far">Recap so far</string>
+    <string name="reader_close">Close</string>
+    <string name="reader_open_settings">Open Settings</string>
+    <string name="reader_try_again">Try again</string>
+    <string name="reader_pause_read_aloud">Pause read aloud</string>
+    <string name="reader_read_aloud">Read aloud</string>
+    <string name="reader_recap_asking_librarian">  Asking the librarian…</string>
+    <string name="reader_recap_subtitle_in_flight">Asking the librarian about the last few chapters.</string>
+    <string name="reader_recap_subtitle_done">Here\'s what happened in the last few chapters.</string>
+    <string name="reader_recap_subtitle_error">Quick chapter summaries from your AI provider.</string>
+
+    <!-- Reader / VoiceQuickSheet -->
+    <string name="reader_voice_header">Voice</string>
+    <string name="reader_pick_voice">Pick voice</string>
+    <string name="reader_pick_a_voice">Pick a voice</string>
+    <string name="reader_voice_tap_to_change">Tap to change</string>
+    <string name="reader_voice_collapse_advanced">Collapse advanced</string>
+    <string name="reader_voice_expand_advanced">Expand advanced</string>
+    <string name="reader_voice_advanced">Advanced</string>
+    <string name="reader_voice_custom">Custom</string>
+    <string name="reader_voice_custom_more">Custom…</string>
+    <string name="reader_voice_hide_custom_slider">Hide custom slider</string>
+    <string name="reader_voice_show_custom_slider">Show custom slider</string>
+    <string name="reader_voice_speed_header">Speed</string>
+    <string name="reader_voice_pitch_header">Pitch</string>
+    <string name="reader_voice_sentence_silence_header">Sentence silence</string>
+    <string name="reader_voice_speech_speed_cd">Speech speed</string>
+    <string name="reader_voice_pitch_cd">Pitch</string>
+    <string name="reader_voice_inter_sentence_pause_cd">Inter-sentence pause</string>
+    <string name="reader_voice_playback_speed_cd">Playback speed %1$s</string>
+    <string name="reader_voice_pitch_value_cd">Pitch %1$s</string>
+    <string name="reader_voice_sentence_silence_value_cd">Sentence silence %1$s</string>
+    <string name="reader_voice_high_quality_title">High-quality pitch</string>
+    <string name="reader_voice_high_quality_on">Smoother pitch-shifted audio. Applies on next chapter.</string>
+    <string name="reader_voice_high_quality_off">Faster pitch shifting. Grittier at non-neutral pitch.</string>
+    <string name="reader_voice_advanced_open_label">Open per-voice lexicon and Kokoro language</string>
+    <string name="reader_voice_per_voice_lexicon">Per-voice lexicon + Kokoro language</string>
+    <string name="reader_voice_per_voice_lexicon_subtitle">Open Voice Library for per-voice pronunciation rules and phonemizer overrides.</string>
+
+    <!-- Reader / WhyAreWeWaitingPanel -->
+    <string name="reader_wait_open_settings">Open settings</string>
+    <string name="reader_wait_resume">Resume</string>
+
+    <!-- Reader / AudiobookView -->
+    <string name="reader_voice_settings">Voice settings</string>
+    <string name="reader_open_voice_library">Open Voice Library</string>
+    <string name="reader_pick_different_voice">Pick a different voice</string>
+    <string name="reader_chapters">Chapters</string>
+    <string name="reader_couldnt_load_chapter">Couldn\'t load this chapter</string>
+    <string name="reader_couldnt_load_message">The voice or chapter text is taking longer than expected. Try again, or pick a different voice — some take a moment to warm up.</string>
+    <string name="reader_sleep_step_by_sentence">Step by sentence</string>
+    <string name="reader_sleep_timer">Sleep timer</string>
+    <string name="reader_sleep_off">Off</string>
+    <string name="reader_sleep_minutes">%1$dm</string>
+    <string name="reader_sleep_end">End</string>
+    <string name="reader_sleep_sleeping_in">Sleeping in %1$d:%2$02d</string>
+    <string name="reader_bookmark_header">Bookmark</string>
+    <string name="reader_bookmark_here">Bookmark here</string>
+    <string name="reader_bookmark_here_subtitle">Drop a marker at the current position</string>
+    <string name="reader_jump_to_bookmark">Jump to bookmark</string>
+    <string name="reader_jump_to_bookmark_subtitle">Resume from the marker you set</string>
+    <string name="reader_smart_features">Smart features</string>
+    <string name="reader_recap_subtitle">Ask the librarian to summarize the last few chapters</string>
+    <string name="reader_ask_the_ai">Ask the AI</string>
+    <string name="reader_open_librarian_chat">Open librarian chat</string>
+    <string name="reader_step_previous">← Previous</string>
+    <string name="reader_step_next">Next →</string>
+    <string name="reader_ask_ai_subtitle">Chat about plot, characters, pacing, and craft</string>
 
     <!-- MemPalace filter sheet -->
     <string name="mempalace_filter_title">Filter by wing</string>

--- a/feature/src/main/res/values/strings.xml
+++ b/feature/src/main/res/values/strings.xml
@@ -289,6 +289,23 @@
     <string name="voicelibrary_delete_title">Delete %1$s?</string>
     <string name="voicelibrary_default">Default</string>
 
+    <!-- Engine / Voice picker gate -->
+    <string name="engine_voice_resolving">Resolving…</string>
+
+    <!-- Debug -->
+    <string name="debug_title">Debug</string>
+
+    <!-- Follows -->
+    <string name="follows_title">Follows</string>
+
+    <!-- Chat -->
+    <string name="chat_ask_question_placeholder">Ask a question…</string>
+
+    <!-- TechEmpower intents -->
+    <string name="techempower_copy">Copy</string>
+    <string name="techempower_open_web">Open web</string>
+    <string name="techempower_close">Close</string>
+
     <!-- MemPalace filter sheet -->
     <string name="mempalace_filter_title">Filter by wing</string>
     <string name="mempalace_no_wings">No wings reachable. Confirm your palace daemon is configured under Settings → Memory Palace.</string>

--- a/feature/src/main/res/values/strings.xml
+++ b/feature/src/main/res/values/strings.xml
@@ -237,6 +237,58 @@
     <string name="reader_step_next">Next →</string>
     <string name="reader_ask_ai_subtitle">Chat about plot, characters, pacing, and craft</string>
 
+    <!-- Library -->
+    <string name="library_title">Library</string>
+    <string name="library_resume">Resume</string>
+    <string name="library_mark_all_read">Mark all read</string>
+    <string name="library_shelf_all">All</string>
+    <string name="library_add_by_url_label">URL</string>
+    <string name="library_add_by_url_placeholder">https://…</string>
+
+    <!-- Sessions -->
+    <string name="sessions_title">Sessions</string>
+    <string name="sessions_delete_dialog_title">Delete this session?</string>
+    <string name="sessions_delete">Delete</string>
+    <string name="sessions_cancel">Cancel</string>
+    <string name="sessions_open">Open</string>
+
+    <!-- Sync -->
+    <string name="sync_title">Sync</string>
+    <string name="sync_email_label">Email</string>
+    <string name="sync_send_code">Send code</string>
+    <string name="sync_code_label">6-digit code</string>
+    <string name="sync_verify">Verify</string>
+    <string name="sync_different_email">Use a different email</string>
+    <string name="sync_done">Done</string>
+    <string name="sync_sign_out">Sign out</string>
+
+    <!-- Fiction detail -->
+    <string name="fiction_clear_cache_title">Clear cached audio for %1$s?</string>
+    <string name="fiction_clear_cache_body">Removes the PCM cache for every chapter of this fiction across every voice variant. Replays will re-render once. The fiction stays in your library; your read progress and library state are not affected.</string>
+    <string name="fiction_clear">Clear</string>
+    <string name="fiction_cancel">Cancel</string>
+    <string name="fiction_remove">Remove</string>
+    <string name="fiction_default_title">this fiction</string>
+    <string name="fiction_remove_title">Remove %1$s from your library?</string>
+    <string name="fiction_remove_body">Your read progress will be lost. You can re-add it from Browse anytime, but the position you\'ve reached won\'t be restored.</string>
+    <string name="fiction_building_epub">Building .epub…</string>
+    <string name="fiction_export_epub">Export as EPUB…</string>
+    <string name="fiction_clear_cache">Clear fiction cache…</string>
+    <string name="fiction_chapter_count">%1$d ch</string>
+    <string name="fiction_separator">·</string>
+    <string name="fiction_name_label">Name</string>
+    <string name="fiction_one_line_description">One-line description</string>
+
+    <!-- Voice library -->
+    <string name="voicelibrary_title">Voice library</string>
+    <string name="voicelibrary_search_placeholder">Search voices</string>
+    <string name="voicelibrary_female">♀ Female</string>
+    <string name="voicelibrary_male">♂ Male</string>
+    <string name="voicelibrary_neutral">Neutral</string>
+    <string name="voicelibrary_multilingual">Multilingual</string>
+    <string name="voicelibrary_delete_title">Delete %1$s?</string>
+    <string name="voicelibrary_default">Default</string>
+
     <!-- MemPalace filter sheet -->
     <string name="mempalace_filter_title">Filter by wing</string>
     <string name="mempalace_no_wings">No wings reachable. Confirm your palace daemon is configured under Settings → Memory Palace.</string>


### PR DESCRIPTION
## Summary

First sweep of #727 — moves user-facing string literals in the `feature/` module out of Kotlin source and into `feature/src/main/res/values/strings.xml`, replacing them with `stringResource()` calls.

- Creates `feature/src/main/res/values/strings.xml` with 200+ resource entries grouped by area
- Extracts visible `Text(\"...\")`, `label = { Text(...) }`, `placeholder = { Text(...) }`, `onClickLabel = \"...\"`, `BrassButton(label = \"...\")`, and similar literals across browse/, reader/, library/, sessions/, sync/, fiction/, voicelibrary/, engine/, debug/, follows/, chat/, techempower/
- Refactors enum extension `.label: String` properties in BrowseFilterSheet and GitHubFilterSheet to `.labelRes: Int` so non-composable code paths still resolve the right resource (`stringResource()` runs at call sites)
- Refactors `RecapModal.subtitleFor()` → `subtitleResFor()` returning `@StringRes Int` for the same reason
- Refactors `sourceTagline()` in BrowseSourceCarousel to be `@Composable`, returning `stringResource()` lookups

## Out of scope (each needs its own PR — documented in `scratch/i18n-agent.md`)

Some extractions can't be mechanical and were intentionally deferred:

- **`BrowseSourceUi.chipLabel`** — proper-noun brand names (\"Royal Road\", \"AO3\", \"GitHub\"). Wouldn't be translated and `BrowseSourceUiTest` asserts them by value.
- **`BrowseSourceUi.searchHint`** — non-composable utility with test coverage (\"FallbackName\" fallthrough assertion). Needs parallel Int API + test rewrite.
- **`BrowseSourceUi.genericCapabilities.availableCategories`** — \"Adventure\", \"Fantasy\", \"cs.AI\", \"story\" etc. are *both* displayed labels *and* backend query parameters; translating them would break Gutenberg/arXiv/HN search.
- **`WhyAreWeWaitingPanel.secondaryLineFor` / `chipLabelAndActionFor`** — `WhyAreWeWaitingPanelAnnounceTest` asserts exact string content (8 cases).
- **`Modifier.semantics { contentDescription = \"X\" }` and `stateDescription`** — semantics receivers aren't `@Composable`, so `stringResource()` needs the string captured in a val above. Mechanical but tedious — kept for an a11y-focused follow-up.
- **`contentDescriptionFor = { preset -> ... }` lambdas in `QuickSheetPresetChipRow`** — same scope issue.
- **Voice-engine humanizers** in `AudiobookView.kt` lines 1463-1594 (`humanizeVoiceLabel`, engine-id displays, language-code lookups) — non-composable, called from many sites. ~80 strings; deserves a focused PR.
- **`settings/` directory** — `SettingsScreen.kt` alone is 3936 lines with ~200 strings. Per `feedback_settings_hub_unfinished.md` the hub itself is still in flux; ships better after the hub refactor lands.

## Test plan

- [x] `./gradlew :feature:compileDebugKotlin` — green
- [x] `./gradlew :feature:testDebugUnitTest` — green (all existing feature unit tests pass)
- [x] `./gradlew assembleDebug` — green (full APK builds)
- [ ] Visual / TalkBack smoke on R83W80CAFZB once installed (verify no missing-resource crashes, dialogs/labels render the expected English)
- [ ] Copilot + CI review

Closes #727

🤖 Generated with [Claude Code](https://claude.com/claude-code)