### PR TITLE
feat(browse): text filter dimension + AO3 search

### DIFF
--- a/core-data/src/main/kotlin/in/jphe/storyvox/data/source/filter/FilterDimension.kt
+++ b/core-data/src/main/kotlin/in/jphe/storyvox/data/source/filter/FilterDimension.kt
@@ -49,6 +49,12 @@ sealed interface FilterDimension {
         val default: Boolean = false,
     ) : FilterDimension
 
+    data class Text(
+        override val key: String,
+        override val label: String,
+        val placeholder: String = "",
+    ) : FilterDimension
+
     companion object {
         val DEFAULT_DATE_PRESETS = listOf(
             DatePreset("any", "Any time"),

--- a/feature/src/main/kotlin/in/jphe/storyvox/feature/browse/DynamicFilterSheet.kt
+++ b/feature/src/main/kotlin/in/jphe/storyvox/feature/browse/DynamicFilterSheet.kt
@@ -17,6 +17,7 @@ import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.ModalBottomSheet
 import androidx.compose.material3.OutlinedButton
+import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.RangeSlider
 import androidx.compose.material3.Switch
 import androidx.compose.material3.Text
@@ -74,6 +75,7 @@ fun DynamicFilterSheet(
                     is FilterDimension.NumberRange -> NumberRangeSection(dim, local) { local = it }
                     is FilterDimension.DateRange -> DateRangeSection(dim, local) { local = it }
                     is FilterDimension.Toggle -> ToggleSection(dim, local) { local = it }
+                    is FilterDimension.Text -> TextSection(dim, local) { local = it }
                 }
                 HorizontalDivider()
             }
@@ -330,6 +332,28 @@ private fun ToggleSection(
             },
         )
     }
+}
+
+@Composable
+private fun TextSection(
+    dim: FilterDimension.Text,
+    state: FilterState,
+    onChange: (FilterState) -> Unit,
+) {
+    val value = state.stringVal(dim.key).orEmpty()
+    SectionLabel(dim.label)
+    OutlinedTextField(
+        value = value,
+        onValueChange = { text ->
+            if (text.isBlank()) onChange(state.without(dim.key))
+            else onChange(state.with(dim.key, FilterValue.StringVal(text.trim())))
+        },
+        placeholder = if (dim.placeholder.isNotEmpty()) {
+            { Text(dim.placeholder, style = MaterialTheme.typography.bodyMedium) }
+        } else null,
+        singleLine = true,
+        modifier = Modifier.fillMaxWidth(),
+    )
 }
 
 @Composable

--- a/feature/src/test/kotlin/in/jphe/storyvox/feature/browse/BrowseViewModelFavoritesOrderingTest.kt
+++ b/feature/src/test/kotlin/in/jphe/storyvox/feature/browse/BrowseViewModelFavoritesOrderingTest.kt
@@ -1,0 +1,105 @@
+package `in`.jphe.storyvox.feature.browse
+
+import `in`.jphe.storyvox.data.source.FictionSource
+import `in`.jphe.storyvox.data.source.model.ChapterContent
+import `in`.jphe.storyvox.data.source.model.FictionDetail
+import `in`.jphe.storyvox.data.source.model.FictionResult
+import `in`.jphe.storyvox.data.source.model.FictionSummary
+import `in`.jphe.storyvox.data.source.model.ListPage
+import `in`.jphe.storyvox.data.source.model.SearchQuery
+import `in`.jphe.storyvox.data.source.plugin.SourceCategory
+import `in`.jphe.storyvox.data.source.plugin.SourcePluginDescriptor
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+/**
+ * v0.5.76 — pins the favorites-first ordering invariant from
+ * [BrowseViewModel]'s `controls` flow: favorites pinned to the
+ * front of the visible-sources list in registry order, non-
+ * favorites follow in registry order. Tested as a pure function
+ * so no Hilt or Compose host is needed.
+ */
+class BrowseViewModelFavoritesOrderingTest {
+
+    private val rr = descriptor("rr", "Royal Road")
+    private val gh = descriptor("github", "GitHub")
+    private val ao3 = descriptor("ao3", "AO3")
+    private val gut = descriptor("gutenberg", "Gutenberg")
+    private val wiki = descriptor("wikipedia", "Wikipedia")
+
+    private val registry = listOf(rr, gh, ao3, gut, wiki)
+
+    @Test fun `no favorites preserves registry order`() {
+        val result = visibleSources(registry, enabled = setOf("rr", "github", "ao3", "gutenberg", "wikipedia"), favorites = emptySet())
+        assertEquals(listOf("rr", "github", "ao3", "gutenberg", "wikipedia"), result.map { it.id })
+    }
+
+    @Test fun `single favorite pins to front`() {
+        val result = visibleSources(registry, enabled = setOf("rr", "github", "ao3", "gutenberg", "wikipedia"), favorites = setOf("ao3"))
+        assertEquals(listOf("ao3", "rr", "github", "gutenberg", "wikipedia"), result.map { it.id })
+    }
+
+    @Test fun `multiple favorites preserve registry order among themselves`() {
+        val result = visibleSources(registry, enabled = setOf("rr", "github", "ao3", "gutenberg", "wikipedia"), favorites = setOf("gutenberg", "github"))
+        assertEquals(listOf("github", "gutenberg", "rr", "ao3", "wikipedia"), result.map { it.id })
+    }
+
+    @Test fun `disabled sources are excluded even if favorited`() {
+        val result = visibleSources(registry, enabled = setOf("rr", "ao3", "wikipedia"), favorites = setOf("github", "ao3"))
+        assertEquals(listOf("ao3", "rr", "wikipedia"), result.map { it.id })
+    }
+
+    @Test fun `all favorited yields full registry order`() {
+        val all = registry.map { it.id }.toSet()
+        val result = visibleSources(registry, enabled = all, favorites = all)
+        assertEquals(listOf("rr", "github", "ao3", "gutenberg", "wikipedia"), result.map { it.id })
+    }
+
+    @Test fun `empty enabled yields empty list`() {
+        val result = visibleSources(registry, enabled = emptySet(), favorites = setOf("rr"))
+        assertEquals(emptyList<String>(), result.map { it.id })
+    }
+
+    /**
+     * Mirrors the partition logic from [BrowseViewModel]'s `controls`
+     * combine block (lines ~364-371). Extracted here so the test
+     * doesn't need the full ViewModel.
+     */
+    private fun visibleSources(
+        descriptors: List<SourcePluginDescriptor>,
+        enabled: Set<String>,
+        favorites: Set<String>,
+    ): List<SourcePluginDescriptor> {
+        val faves = mutableListOf<SourcePluginDescriptor>()
+        val rest = mutableListOf<SourcePluginDescriptor>()
+        for (d in descriptors) {
+            if (d.id !in enabled) continue
+            if (d.id in favorites) faves.add(d) else rest.add(d)
+        }
+        return faves + rest
+    }
+
+    private fun descriptor(id: String, name: String) = SourcePluginDescriptor(
+        id = id,
+        displayName = name,
+        defaultEnabled = false,
+        category = SourceCategory.Text,
+        supportsFollow = false,
+        supportsSearch = false,
+        source = FakeFictionSource(id),
+    )
+
+    private class FakeFictionSource(override val id: String) : FictionSource {
+        override val displayName: String = id
+        override suspend fun popular(page: Int) =
+            FictionResult.Success(ListPage<FictionSummary>(items = emptyList(), page = page, hasNext = false))
+        override suspend fun latestUpdates(page: Int) = popular(page)
+        override suspend fun byGenre(genre: String, page: Int) = popular(page)
+        override suspend fun search(query: SearchQuery) = popular(1)
+        override suspend fun fictionDetail(fictionId: String): FictionResult<FictionDetail> = FictionResult.NotFound("fake")
+        override suspend fun chapter(fictionId: String, chapterId: String): FictionResult<ChapterContent> = FictionResult.NotFound("fake")
+        override suspend fun followsList(page: Int) = popular(page)
+        override suspend fun setFollowed(fictionId: String, followed: Boolean) = FictionResult.Success(Unit)
+        override suspend fun genres() = FictionResult.Success(emptyList<String>())
+    }
+}

--- a/source-ao3/src/main/kotlin/in/jphe/storyvox/source/ao3/Ao3Source.kt
+++ b/source-ao3/src/main/kotlin/in/jphe/storyvox/source/ao3/Ao3Source.kt
@@ -230,16 +230,13 @@ internal class Ao3Source @Inject constructor(
         return feedAsListPage(tagId, page)
     }
 
-    /**
-     * Search is deferred per the issue spec — AO3's `/works/search`
-     * returns an HTML listing only (no Atom or JSON equivalent), and
-     * v1 commits to zero scraping. Return an empty page so the UI
-     * renders the no-results empty state cleanly; a future PR
-     * (tracked in the #381 follow-up list) can either revisit HTML
-     * parsing or layer search over the per-tag feeds.
-     */
-    override suspend fun search(query: SearchQuery): FictionResult<ListPage<FictionSummary>> =
-        FictionResult.Success(ListPage(items = emptyList(), page = 1, hasNext = false))
+    override suspend fun search(query: SearchQuery): FictionResult<ListPage<FictionSummary>> {
+        val term = query.term.trim()
+        if (term.isEmpty()) {
+            return FictionResult.Success(ListPage(items = emptyList(), page = 1, hasNext = false))
+        }
+        return api.searchWorks(query = term, page = query.page ?: 1)
+    }
 
     /**
      * Curated tag list for the Browse genre picker. Three fandoms

--- a/source-ao3/src/main/kotlin/in/jphe/storyvox/source/ao3/net/Ao3Api.kt
+++ b/source-ao3/src/main/kotlin/in/jphe/storyvox/source/ao3/net/Ao3Api.kt
@@ -218,6 +218,36 @@ internal class Ao3Api @Inject constructor(
         }
     }
 
+    /**
+     * `GET /works/search?work_search[query]=<term>&page=<N>` — AO3's
+     * full-text work search. Returns an HTML listing page with the
+     * same `<li class="work blurb">` card shape that subscriptions
+     * and Marked-for-Later use, so the existing [Ao3WorksIndexParser]
+     * handles the body directly.
+     *
+     * Anonymous — no auth cookie needed. AO3's search is available to
+     * logged-out users; the results may exclude Archive-Warning-gated
+     * works but that's AO3's standard anonymous behavior.
+     */
+    suspend fun searchWorks(query: String, page: Int = 1): FictionResult<ListPage<FictionSummary>> {
+        val path = searchPath(query, page)
+        return withContext(Dispatchers.IO) {
+            when (val res = requestText(client, path)) {
+                is FictionResult.Success -> {
+                    try {
+                        FictionResult.Success(Ao3WorksIndexParser.parse(res.value, page))
+                    } catch (e: Exception) {
+                        FictionResult.NetworkError(
+                            "AO3 search results unparseable: ${e.message}",
+                            e,
+                        )
+                    }
+                }
+                is FictionResult.Failure -> res
+            }
+        }
+    }
+
     /** Generic text-body GET against the supplied client. Sync OkHttp
      *  `execute()` wrapped in `withContext(Dispatchers.IO)` for the
      *  same reason as the Gutenberg client — `suspend` alone doesn't
@@ -307,6 +337,20 @@ internal class Ao3Api @Inject constructor(
          * URL up front. If OTW Ops ever wants to reach out, the project's
          * GitHub Issues are the door.
          */
+        /**
+         * `/works/search?work_search[query]=<term>[&page=N]` — AO3's
+         * work search. Exposed package-private for URL-shape pinning
+         * in unit tests.
+         */
+        internal fun searchPath(query: String, page: Int = 1): String {
+            val encoded = java.net.URLEncoder.encode(query, Charsets.UTF_8)
+            return if (page <= 1) {
+                "/works/search?work_search%5Bquery%5D=$encoded"
+            } else {
+                "/works/search?work_search%5Bquery%5D=$encoded&page=$page"
+            }
+        }
+
         const val USER_AGENT = "storyvox-ao3/1.0 (+https://github.com/jphein/storyvox)"
 
         /**

--- a/source-gutenberg/src/main/kotlin/in/jphe/storyvox/source/gutenberg/GutenbergSource.kt
+++ b/source-gutenberg/src/main/kotlin/in/jphe/storyvox/source/gutenberg/GutenbergSource.kt
@@ -119,6 +119,11 @@ internal class GutenbergSource @Inject constructor(
                 FilterDimension.SortOption("last_update", "Newest"),
             ),
         ),
+        FilterDimension.Text(
+            key = "author",
+            label = "Author",
+            placeholder = "e.g. Austen, Dickens, Shelley",
+        ),
         FilterDimension.Select(
             key = "language",
             label = "Language",
@@ -145,6 +150,10 @@ internal class GutenbergSource @Inject constructor(
                     else -> SearchOrder.RELEVANCE
                 },
             )
+        }
+        state.stringVal("author")?.takeIf { it.isNotBlank() }?.let { author ->
+            val composed = if (q.term.isBlank()) author else "${q.term} $author"
+            q = q.copy(term = composed)
         }
         state.stringVal("category")?.takeIf { it.isNotBlank() }?.let { cat ->
             q = q.copy(genres = q.genres + cat)


### PR DESCRIPTION
## Summary
- Adds `FilterDimension.Text` to the sealed hierarchy — renders as an `OutlinedTextField` in `DynamicFilterSheet` with optional placeholder text
- Gutenberg declares an "Author" text dimension that folds the typed name into the Gutendex search term via `applyFilters()`
- AO3 search now works: `Ao3Api.searchWorks()` hits `/works/search?work_search[query]=<term>` and parses results through the existing `Ao3WorksIndexParser` — same `<li class="work blurb">` HTML card shape used by subscriptions and Marked-for-Later

## Test plan
- [x] `:source-ao3:compileDebugKotlin` — clean
- [x] `:source-gutenberg:compileDebugKotlin` — clean
- [x] `:feature:compileDebugKotlin` — clean
- [x] `:source-ao3:testDebugUnitTest` — all pass
- [x] `:source-gutenberg:testDebugUnitTest` — all pass
- [ ] On-device: Gutenberg filter sheet shows Author text field
- [ ] On-device: AO3 search returns results (type a query in Browse → AO3)

🤖 Generated with [Claude Code](https://claude.com/claude-code)