### PR TITLE
fix: dream-team polish — seek, perf, text overflow, follows pagination

### DIFF
--- a/app/src/main/kotlin/in/jphe/storyvox/di/AppBindings.kt
+++ b/app/src/main/kotlin/in/jphe/storyvox/di/AppBindings.kt
@@ -848,12 +848,15 @@ internal class RealPlaybackControllerUi(
     override fun play() = controller.resume()
     override fun pause() = controller.pause()
     override fun seekTo(ms: Long) {
-        // UI thinks in milliseconds; the controller indexes by char offset.
-        // Reverse the same baseline conversion EnginePlayer uses for content position.
-        val s = controller.state.value
-        val charsPerSec = SPEED_BASELINE_CHARS_PER_SECOND * s.speed
-        val charOffset = ((ms / 1000.0) * charsPerSec).toInt().coerceAtLeast(0)
-        controller.seekTo(charOffset)
+        // Issue #555 follow-up — the scrubber rail and duration both live on
+        // the speed-invariant media-time axis (see EnginePlayer.estimateDurationMs
+        // and DefaultPlaybackController.seekToPositionMs). The conversion must
+        // use the baseline rate WITHOUT multiplying by speed, otherwise a seek
+        // at 2x speed jumps twice as far as intended. Pre-fix this method
+        // multiplied by `s.speed`, producing a seek overshoot proportional to
+        // the playback speed — e.g. tapping the 50% mark at 2x landed at the
+        // character offset that corresponds to 100% of the chapter.
+        controller.seekToPositionMs(ms)
     }
     override fun seekToChar(charOffset: Int) {
         controller.seekTo(charOffset.coerceAtLeast(0))

--- a/app/src/main/kotlin/in/jphe/storyvox/di/AppBindings.kt
+++ b/app/src/main/kotlin/in/jphe/storyvox/di/AppBindings.kt
@@ -493,6 +493,9 @@ private class RealFictionRepositoryUi(
     override suspend fun chapterTextById(chapterId: String): String? =
         chapters.getChapter(chapterId)?.text
 
+    override fun observeIsInLibrary(fictionId: String): Flow<Boolean> =
+        repo.observeIsInLibrary(fictionId)
+
     override fun chaptersFor(fictionId: String): Flow<List<UiChapter>> =
         // Issue #282 — the previous mapping hard-coded `isFinished = false`,
         // so the played-indicator on the Fiction detail chapter list never

--- a/app/src/main/kotlin/in/jphe/storyvox/navigation/StoryvoxNavHost.kt
+++ b/app/src/main/kotlin/in/jphe/storyvox/navigation/StoryvoxNavHost.kt
@@ -787,6 +787,19 @@ private fun StoryvoxNavHostContent(
                     onOpenAiSettings = { navController.navigate(StoryvoxRoutes.SETTINGS_AI) },
                     onOpenSettings = { navController.navigate(StoryvoxRoutes.SETTINGS_HUB) },
                     onOpenChat = { fId, prefill -> navController.navigate(StoryvoxRoutes.chat(fId, prefill)) },
+                    // Issue #677 follow-up — BookFinishedOverlay's "Browse
+                    // more" CTA and ResumeEmptyPrompt's "Browse the realms"
+                    // need a working onBrowse on the drill-down reader
+                    // route, not just the PLAYING tab. Pre-fix the default
+                    // no-op `{}` made both buttons dead — the user finished
+                    // a book via FictionDetail → Reader and had no path to
+                    // Browse without OS-backing out first.
+                    onBrowse = {
+                        navController.navigate(StoryvoxRoutes.BROWSE) {
+                            popUpTo(StoryvoxRoutes.LIBRARY)
+                            launchSingleTop = true
+                        }
+                    },
                     // Issue #437 — Back arrow on deep-linked reader /
                     // audiobook destinations. Falls back to LIBRARY if
                     // the back stack was empty (cold-launch deep link).
@@ -817,6 +830,14 @@ private fun StoryvoxNavHostContent(
                     onOpenAiSettings = { navController.navigate(StoryvoxRoutes.SETTINGS_AI) },
                     onOpenSettings = { navController.navigate(StoryvoxRoutes.SETTINGS_HUB) },
                     onOpenChat = { fId, prefill -> navController.navigate(StoryvoxRoutes.chat(fId, prefill)) },
+                    // Issue #677 follow-up — same onBrowse wiring as the
+                    // READER route above. See the comment there.
+                    onBrowse = {
+                        navController.navigate(StoryvoxRoutes.BROWSE) {
+                            popUpTo(StoryvoxRoutes.LIBRARY)
+                            launchSingleTop = true
+                        }
+                    },
                     // Issue #437 — Back arrow on deep-linked reader /
                     // audiobook destinations. Falls back to LIBRARY if
                     // the back stack was empty (cold-launch deep link).

--- a/core-data/src/main/kotlin/in/jphe/storyvox/data/repository/FictionRepository.kt
+++ b/core-data/src/main/kotlin/in/jphe/storyvox/data/repository/FictionRepository.kt
@@ -293,43 +293,44 @@ class FictionRepositoryImpl @Inject constructor(
         // `followsList`. When step 3f wires GitHub PAT auth, this
         // becomes a per-source flow and the kdoc on the interface
         // method should grow a `sourceId` parameter to match.
-        when (val result = sourceFor(SourceIds.ROYAL_ROAD).followsList(page = 1)) {
-            is FictionResult.Success -> {
-                val now = System.currentTimeMillis()
-                val incoming = result.value.items
-                val incomingIds = incoming.map { it.id }.toSet()
-
-                // Upsert each follow, preserving prior fields (the follows
-                // page is row-shape only — author/status/rating come from
-                // detail-page refresh later) and flipping followedRemotely.
-                incoming.forEach { summary ->
-                    val existing = fictionDao.get(summary.id)
-                    val merged = if (existing != null) {
-                        existing.copy(
-                            // Refresh whatever the rows do carry without
-                            // clobbering richer detail-page fields.
-                            title = summary.title.ifBlank { existing.title },
-                            coverUrl = summary.coverUrl ?: existing.coverUrl,
-                            tags = summary.tags.ifEmpty { existing.tags },
-                            followedRemotely = true,
-                        )
-                    } else {
-                        summary.toEntity(now).copy(followedRemotely = true)
-                    }
-                    fictionDao.upsert(merged)
+        val source = sourceFor(SourceIds.ROYAL_ROAD)
+        val allIncoming = mutableListOf<FictionSummary>()
+        var page = 1
+        while (true) {
+            when (val result = source.followsList(page = page)) {
+                is FictionResult.Success -> {
+                    allIncoming.addAll(result.value.items)
+                    if (!result.value.hasNext) break
+                    page++
                 }
-
-                // Clear followedRemotely on rows that aren't in the latest
-                // list (user unfollowed remotely on the website).
-                val previously = fictionDao.followsSnapshot().map { it.id }.toSet()
-                (previously - incomingIds).forEach { gone ->
-                    fictionDao.setFollowedRemote(gone, false)
-                }
-
-                FictionResult.Success(Unit)
+                is FictionResult.Failure -> return@withContext result
             }
-            is FictionResult.Failure -> result
         }
+
+        val now = System.currentTimeMillis()
+        val incomingIds = allIncoming.map { it.id }.toSet()
+
+        allIncoming.forEach { summary ->
+            val existing = fictionDao.get(summary.id)
+            val merged = if (existing != null) {
+                existing.copy(
+                    title = summary.title.ifBlank { existing.title },
+                    coverUrl = summary.coverUrl ?: existing.coverUrl,
+                    tags = summary.tags.ifEmpty { existing.tags },
+                    followedRemotely = true,
+                )
+            } else {
+                summary.toEntity(now).copy(followedRemotely = true)
+            }
+            fictionDao.upsert(merged)
+        }
+
+        val previously = fictionDao.followsSnapshot().map { it.id }.toSet()
+        (previously - incomingIds).forEach { gone ->
+            fictionDao.setFollowedRemote(gone, false)
+        }
+
+        FictionResult.Success(Unit)
     }
 
     override suspend fun addToLibrary(id: String, mode: DownloadMode?) = withContext(Dispatchers.IO) {

--- a/core-data/src/main/kotlin/in/jphe/storyvox/data/repository/FictionRepository.kt
+++ b/core-data/src/main/kotlin/in/jphe/storyvox/data/repository/FictionRepository.kt
@@ -20,6 +20,7 @@ import `in`.jphe.storyvox.data.source.model.SearchQuery
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.combine
+import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.withContext
 import javax.inject.Inject
@@ -34,6 +35,15 @@ interface FictionRepository {
     fun observeLibrary(): Flow<List<FictionSummary>>
     fun observeFollowsRemote(): Flow<List<FictionSummary>>
     fun observeFiction(id: String): Flow<FictionDetail?>
+
+    /**
+     * Targeted boolean stream: true when the fiction row exists in the
+     * user's library. Unlike [observeLibrary] (which emits the entire
+     * list on any library change), this flow is scoped to a single row
+     * and only re-emits when *this* fiction's `inLibrary` column flips.
+     * Used by FictionDetailViewModel to avoid the O(n) full-list scan.
+     */
+    fun observeIsInLibrary(id: String): Flow<Boolean>
 
     /**
      * Browse the popular fictions on [sourceId]. Defaults to
@@ -208,6 +218,11 @@ class FictionRepositoryImpl @Inject constructor(
         fictionDao.observeFollowsRemote().map { rows ->
             rows.map { it.toSummary(supportsFollow = supportsFollowFor(it.sourceId)) }
         }
+
+    override fun observeIsInLibrary(id: String): Flow<Boolean> =
+        fictionDao.observe(id)
+            .map { it?.inLibrary == true }
+            .distinctUntilChanged()
 
     override fun observeFiction(id: String): Flow<FictionDetail?> =
         fictionDao.observe(id).combine(chapterDao.observeChapterInfosByFiction(id)) { fiction, chapters ->

--- a/feature/src/main/kotlin/in/jphe/storyvox/feature/api/UiContracts.kt
+++ b/feature/src/main/kotlin/in/jphe/storyvox/feature/api/UiContracts.kt
@@ -143,6 +143,13 @@ interface FictionRepositoryUi {
     fun fictionLoadError(id: String): Flow<String?>
     fun chaptersFor(fictionId: String): Flow<List<UiChapter>>
     /**
+     * Targeted boolean stream: true when [fictionId] is in the user's
+     * library. Scoped to a single row — unlike [library], this flow
+     * does not re-emit when unrelated fictions change. Used by
+     * FictionDetailViewModel to avoid the O(n) full-list scan.
+     */
+    fun observeIsInLibrary(fictionId: String): Flow<Boolean>
+    /**
      * Issue #212 — fetch the plain-text body of a downloaded chapter
      * for AI grounding. Returns null if the chapter row doesn't exist
      * or its body hasn't been downloaded yet. Suspends because the

--- a/feature/src/main/kotlin/in/jphe/storyvox/feature/browse/BrowseScreen.kt
+++ b/feature/src/main/kotlin/in/jphe/storyvox/feature/browse/BrowseScreen.kt
@@ -481,7 +481,13 @@ fun BrowseScreen(
                         item(span = { GridItemSpan(maxLineSpan) }) {
                             ErrorBlock(
                                 title = "Couldn't refresh",
-                                message = state.error ?: "We couldn't reach Royal Road.",
+                                // Use friendlyErrorMessage for consistency
+                                // with the full-screen error block above.
+                                // The pre-fix fallback "We couldn't reach
+                                // Royal Road." was dead code (the if-guard
+                                // ensures non-null) but also wrong for
+                                // non-RR sources.
+                                message = friendlyErrorMessage(state.error),
                                 onRetry = { viewModel.loadMore() },
                                 placement = ErrorPlacement.Banner,
                             )

--- a/feature/src/main/kotlin/in/jphe/storyvox/feature/fiction/FictionDetailScreen.kt
+++ b/feature/src/main/kotlin/in/jphe/storyvox/feature/fiction/FictionDetailScreen.kt
@@ -666,7 +666,7 @@ private fun Hero(fiction: UiFiction) {
             modifier = Modifier.weight(1f),
             verticalArrangement = Arrangement.spacedBy(spacing.xxs),
         ) {
-            Text(fiction.title, style = MaterialTheme.typography.headlineSmall, maxLines = 3)
+            Text(fiction.title, style = MaterialTheme.typography.headlineSmall, maxLines = 3, overflow = TextOverflow.Ellipsis)
             // Issue #463 — without an explicit "by" prefix, the author
             // line read as a subtitle of the title (especially for
             // GitHub fictions whose book.toml authors[] can carry an

--- a/feature/src/main/kotlin/in/jphe/storyvox/feature/fiction/FictionDetailViewModel.kt
+++ b/feature/src/main/kotlin/in/jphe/storyvox/feature/fiction/FictionDetailViewModel.kt
@@ -157,14 +157,14 @@ class FictionDetailViewModel @Inject constructor(
         val base = combine(
             repo.fictionById(fictionId),
             repo.chaptersFor(fictionId),
-            repo.library,
+            repo.observeIsInLibrary(fictionId),
             repo.fictionLoadError(fictionId),
             isExporting,
-        ) { fiction, chapters, library, error, exporting ->
+        ) { fiction, chapters, inLibrary, error, exporting ->
             FictionDetailUiState(
                 fiction = fiction,
                 chapters = chapters,
-                isInLibrary = library.any { it.id == fictionId },
+                isInLibrary = inLibrary,
                 // Stop showing the spinner once we either have a cached row
                 // OR the refresh has failed — otherwise a Cloudflare/network
                 // error leaves the user on a permanent spinner with no signal.

--- a/feature/src/main/kotlin/in/jphe/storyvox/feature/library/LibraryScreen.kt
+++ b/feature/src/main/kotlin/in/jphe/storyvox/feature/library/LibraryScreen.kt
@@ -510,7 +510,12 @@ private fun ResumeCard(entry: ContinueListeningEntry, onResume: () -> Unit) {
             )
             Column(modifier = Modifier.weight(1f)) {
                 Text(stringResource(R.string.library_resume), style = MaterialTheme.typography.labelMedium, color = MaterialTheme.colorScheme.primary)
-                Text(entry.fiction.title, style = MaterialTheme.typography.titleMedium, maxLines = 1)
+                Text(
+                    entry.fiction.title,
+                    style = MaterialTheme.typography.titleMedium,
+                    maxLines = 1,
+                    overflow = androidx.compose.ui.text.style.TextOverflow.Ellipsis,
+                )
                 // #265 — when chapter.title is blank (RSS feeds where only
                 // the index was parsed, first-cold-launch state), the old
                 // format produced "Ch. 0 · " with a dangling separator
@@ -525,6 +530,7 @@ private fun ResumeCard(entry: ContinueListeningEntry, onResume: () -> Unit) {
                     style = MaterialTheme.typography.bodySmall,
                     color = MaterialTheme.colorScheme.onSurfaceVariant,
                     maxLines = 1,
+                    overflow = androidx.compose.ui.text.style.TextOverflow.Ellipsis,
                 )
                 if (fraction != null) {
                     // BrassProgressBar smooth-animates the fill on resume —
@@ -787,10 +793,15 @@ private fun LibraryGridBody(
                             onLongClick = { onLongPress(fiction) },
                         ),
                 )
+                // Issue #272 parity — BrowseScreen's grid added
+                // TextOverflow.Ellipsis so long titles end with "..."
+                // instead of cutting mid-token. The Library grid was
+                // missed; same fix for both title and author.
                 Text(
                     fiction.title,
                     style = MaterialTheme.typography.titleSmall,
                     maxLines = 2,
+                    overflow = androidx.compose.ui.text.style.TextOverflow.Ellipsis,
                 )
                 if (fiction.author.isNotBlank()) {
                     Text(
@@ -798,6 +809,7 @@ private fun LibraryGridBody(
                         style = MaterialTheme.typography.bodySmall,
                         color = MaterialTheme.colorScheme.onSurfaceVariant,
                         maxLines = 1,
+                        overflow = androidx.compose.ui.text.style.TextOverflow.Ellipsis,
                     )
                 }
             }
@@ -872,6 +884,7 @@ private fun HistoryRow(entry: HistoryEntry, onClick: () -> Unit) {
                     text = entry.fictionTitle ?: "(removed)",
                     style = MaterialTheme.typography.titleSmall,
                     maxLines = 1,
+                    overflow = androidx.compose.ui.text.style.TextOverflow.Ellipsis,
                 )
                 // Match Resume card formatting: "Ch. N · title" with the
                 // dangling-separator guard for blank titles (see #265).
@@ -887,6 +900,7 @@ private fun HistoryRow(entry: HistoryEntry, onClick: () -> Unit) {
                     style = MaterialTheme.typography.bodySmall,
                     color = MaterialTheme.colorScheme.onSurfaceVariant,
                     maxLines = 1,
+                    overflow = androidx.compose.ui.text.style.TextOverflow.Ellipsis,
                 )
                 Text(
                     text = relativeTimeLabel(entry.openedAt),
@@ -1087,6 +1101,7 @@ private fun InboxRow(event: InboxEvent, onClick: () -> Unit) {
                     text = event.title,
                     style = MaterialTheme.typography.titleSmall,
                     maxLines = 2,
+                    overflow = androidx.compose.ui.text.style.TextOverflow.Ellipsis,
                 )
                 event.body?.takeIf { it.isNotBlank() }?.let { body ->
                     Text(
@@ -1094,6 +1109,7 @@ private fun InboxRow(event: InboxEvent, onClick: () -> Unit) {
                         style = MaterialTheme.typography.bodySmall,
                         color = MaterialTheme.colorScheme.onSurfaceVariant,
                         maxLines = 2,
+                        overflow = androidx.compose.ui.text.style.TextOverflow.Ellipsis,
                     )
                 }
                 Row(

--- a/feature/src/test/kotlin/in/jphe/storyvox/feature/chat/ChatViewModelTest.kt
+++ b/feature/src/test/kotlin/in/jphe/storyvox/feature/chat/ChatViewModelTest.kt
@@ -608,6 +608,7 @@ private class FakeFictionRepo(
         flowOf(if (id == fictionId && title != null) uiFictionOf(id, title) else null)
     override fun fictionLoadError(id: String): Flow<String?> = flowOf(null)
     override fun chaptersFor(fictionId: String): Flow<List<UiChapter>> = flowOf(emptyList())
+    override fun observeIsInLibrary(fictionId: String): Flow<Boolean> = flowOf(false)
     override suspend fun chapterTextById(chapterId: String): String? = null
     override suspend fun setDownloadMode(fictionId: String, mode: DownloadMode) = Unit
     override suspend fun follow(fictionId: String, follow: Boolean) = Unit
@@ -636,6 +637,7 @@ private class FakeFictionRepoMulti(
         flowOf(titlesById[id]?.let { uiFictionOf(id, it) })
     override fun fictionLoadError(id: String): Flow<String?> = flowOf(null)
     override fun chaptersFor(fictionId: String): Flow<List<UiChapter>> = flowOf(emptyList())
+    override fun observeIsInLibrary(fictionId: String): Flow<Boolean> = flowOf(false)
     override suspend fun chapterTextById(chapterId: String): String? = null
     override suspend fun setDownloadMode(fictionId: String, mode: DownloadMode) = Unit
     override suspend fun follow(fictionId: String, follow: Boolean) = Unit

--- a/feature/src/test/kotlin/in/jphe/storyvox/feature/chat/tools/ChatToolHandlersTest.kt
+++ b/feature/src/test/kotlin/in/jphe/storyvox/feature/chat/tools/ChatToolHandlersTest.kt
@@ -222,6 +222,7 @@ private class FakeFictionRepoT : FictionRepositoryUi {
     )
     override fun fictionLoadError(id: String): Flow<String?> = flowOf(null)
     override fun chaptersFor(fictionId: String): Flow<List<UiChapter>> = flowOf(emptyList())
+    override fun observeIsInLibrary(fictionId: String): Flow<Boolean> = flowOf(false)
     override suspend fun chapterTextById(chapterId: String): String? = null
     override suspend fun setDownloadMode(fictionId: String, mode: DownloadMode) = Unit
     override suspend fun follow(fictionId: String, follow: Boolean) = Unit

--- a/source-royalroad/src/main/kotlin/in/jphe/storyvox/source/royalroad/RoyalRoadSource.kt
+++ b/source-royalroad/src/main/kotlin/in/jphe/storyvox/source/royalroad/RoyalRoadSource.kt
@@ -244,7 +244,7 @@ class RoyalRoadSource @Inject internal constructor(
         // /account/login?ReturnUrl=/my/follows, which FollowsParser detects
         // and surfaces as AuthRequired.
         when (val outcome = fetcher.fetchHtml("${RoyalRoadIds.BASE_URL}/my/follows" + if (page > 1) "?page=$page" else "")) {
-            is FetchOutcome.Body -> when (val res = FollowsParser.parse(outcome.html, outcome.finalUrl)) {
+            is FetchOutcome.Body -> when (val res = FollowsParser.parse(outcome.html, outcome.finalUrl, page)) {
                 is FollowsParser.FollowsResult.Ok -> FictionResult.Success(res.items)
                 FollowsParser.FollowsResult.NotAuthenticated -> FictionResult.AuthRequired(
                     message = "Sign in to Royal Road to view your follows",

--- a/source-royalroad/src/main/kotlin/in/jphe/storyvox/source/royalroad/parser/FollowsParser.kt
+++ b/source-royalroad/src/main/kotlin/in/jphe/storyvox/source/royalroad/parser/FollowsParser.kt
@@ -27,17 +27,21 @@ internal object FollowsParser {
         data object NotAuthenticated : FollowsResult
     }
 
-    fun parse(html: String, finalUrl: String): FollowsResult {
-        // The follows endpoint resolves to /home when unauthed (302 → /).
+    fun parse(html: String, finalUrl: String, currentPage: Int = 1): FollowsResult {
         if (looksUnauthed(finalUrl, html)) return FollowsResult.NotAuthenticated
 
         val doc = Jsoup.parse(html, RoyalRoadIds.BASE_URL)
         HoneypotFilter.strip(doc)
 
         val items = doc.select("div.fiction-list-item.row").mapNotNull(::parseRow)
-        // The follows page is single-screen for typical users; we don't
-        // paginate. hasNext = false unless RR adds it later.
-        return FollowsResult.Ok(ListPage(items = items, page = 1, hasNext = false))
+        val hasNext = hasNextPage(doc, currentPage)
+        return FollowsResult.Ok(ListPage(items = items, page = currentPage, hasNext = hasNext))
+    }
+
+    private fun hasNextPage(doc: Document, currentPage: Int): Boolean {
+        val pages = doc.select("ul.pagination li a[data-page]")
+            .mapNotNull { it.attr("data-page").toIntOrNull() }
+        return pages.any { it > currentPage }
     }
 
     private fun looksUnauthed(finalUrl: String, html: String): Boolean {


### PR DESCRIPTION
## Summary
- **Scrubber seek fix**: `seekTo(ms)` used speed-dependent conversion, causing overshoot at non-1x speeds. Fixed by delegating to `seekToPositionMs(ms)` which uses the correct speed-invariant axis (issue #555).
- **Dead "Browse more" button**: READER/AUDIOBOOK routes didn't wire `onBrowse`, so BookFinishedOverlay's CTA was a no-op. Fixed by wiring navigation to BROWSE.
- **FictionDetail perf**: Replaced O(n) full-library-list scan (`repo.library.any { it.id == fictionId }`) with targeted `observeIsInLibrary(fictionId)` backed by a single-row DAO query. Only re-emits when this fiction's `inLibrary` actually flips.
- **TextOverflow.Ellipsis parity**: Library grid, ResumeCard, HistoryRow, InboxRow, and FictionDetail Hero were missing ellipsis on truncated text (BrowseScreen had it since #272). Fixed across 9 locations.
- **Browse error banner**: Hardcoded "We couldn't reach Royal Road" fallback replaced with `friendlyErrorMessage()` for source-agnostic error display.
- **P0 follows pagination**: `refreshRemoteFollows()` only fetched page 1 and actively cleared `followedRemotely` on follows beyond page 1 — a data-loss bug. Fixed by looping all pages via `hasNext` before reconciling. Also fixed `FollowsParser` which hardcoded `hasNext=false`.

## Test plan
- [x] `:core-data:compileDebugKotlin` — pass
- [x] `:source-royalroad:compileDebugKotlin` — pass
- [x] `:feature:compileDebugKotlin` — pass
- [x] `:app:compileDebugKotlin` — pass
- [x] `:core-data:testDebugUnitTest` — pass
- [x] `:source-royalroad:testDebugUnitTest` — pass
- [x] `:feature:testDebugUnitTest` — pass
- [ ] Install on R83W80CAFZB + R5CRB0W66MK, verify seek, browse-more, library grid text, follows list

🤖 Generated with [Claude Code](https://claude.com/claude-code)