### PR TITLE
fix(sync): UUID v3 entity IDs for InstantDB

### DIFF
--- a/core-sync/src/main/kotlin/in/jphe/storyvox/sync/SyncIds.kt
+++ b/core-sync/src/main/kotlin/in/jphe/storyvox/sync/SyncIds.kt
@@ -1,0 +1,8 @@
+package `in`.jphe.storyvox.sync
+
+import java.util.UUID
+
+object SyncIds {
+    fun rowUuid(domain: String, userId: String): String =
+        UUID.nameUUIDFromBytes("$domain:$userId".toByteArray()).toString()
+}

--- a/core-sync/src/main/kotlin/in/jphe/storyvox/sync/client/HttpInstantBackend.kt
+++ b/core-sync/src/main/kotlin/in/jphe/storyvox/sync/client/HttpInstantBackend.kt
@@ -62,9 +62,12 @@ import kotlinx.serialization.json.put
  *
  *   Body:
  *     {
- *       "query": { "<entity>": { "$": { "where": { "id": "<id>" } } } },
+ *       "query": { "<entity>": { "$": { "where": { "id": "<uuid>" } } } },
  *       "inference?": false
  *     }
+ *
+ *   `<uuid>` is a deterministic UUID v3 derived from `"$domain:$userId"`
+ *   via [SyncIds.rowUuid]. InstantDB requires entity IDs to be UUIDs.
  *
  *   Response (200): `{ "<entity>": [ { "id": "...", "payload": "...",
  *                                       "updatedAt": <long> }, ... ] }`

--- a/core-sync/src/main/kotlin/in/jphe/storyvox/sync/domain/BookmarksSyncer.kt
+++ b/core-sync/src/main/kotlin/in/jphe/storyvox/sync/domain/BookmarksSyncer.kt
@@ -3,6 +3,7 @@ package `in`.jphe.storyvox.sync.domain
 import android.content.SharedPreferences
 import androidx.core.content.edit
 import `in`.jphe.storyvox.data.db.dao.ChapterDao
+import `in`.jphe.storyvox.sync.SyncIds
 import `in`.jphe.storyvox.sync.client.InstantBackend
 import `in`.jphe.storyvox.sync.client.SignedInUser
 import `in`.jphe.storyvox.sync.coordinator.SyncOutcome
@@ -119,7 +120,7 @@ class BookmarksSyncer @Inject constructor(
     private fun readLastSyncStamp(): Long = prefs.getLong(LAST_SYNC_KEY, 0L)
     private fun writeLastSyncStamp(at: Long) { prefs.edit { putLong(LAST_SYNC_KEY, at) } }
 
-    private fun rowId(user: SignedInUser) = "$DOMAIN:${user.userId}"
+    private fun rowId(user: SignedInUser) = SyncIds.rowUuid(DOMAIN, user.userId)
 
     companion object {
         const val DOMAIN: String = "bookmarks"

--- a/core-sync/src/main/kotlin/in/jphe/storyvox/sync/domain/PlaybackPositionSyncer.kt
+++ b/core-sync/src/main/kotlin/in/jphe/storyvox/sync/domain/PlaybackPositionSyncer.kt
@@ -2,6 +2,7 @@ package `in`.jphe.storyvox.sync.domain
 
 import `in`.jphe.storyvox.data.db.dao.PlaybackDao
 import `in`.jphe.storyvox.data.db.entity.PlaybackPosition
+import `in`.jphe.storyvox.sync.SyncIds
 import `in`.jphe.storyvox.sync.client.InstantBackend
 import `in`.jphe.storyvox.sync.client.SignedInUser
 import `in`.jphe.storyvox.sync.coordinator.SyncOutcome
@@ -146,7 +147,7 @@ class PlaybackPositionSyncer @Inject constructor(
         updatedAt = updatedAt,
     )
 
-    private fun rowId(user: SignedInUser) = "${DOMAIN}:${user.userId}"
+    private fun rowId(user: SignedInUser) = SyncIds.rowUuid(DOMAIN, user.userId)
 
     companion object {
         const val DOMAIN: String = "positions"

--- a/core-sync/src/main/kotlin/in/jphe/storyvox/sync/domain/Remotes.kt
+++ b/core-sync/src/main/kotlin/in/jphe/storyvox/sync/domain/Remotes.kt
@@ -1,5 +1,6 @@
 package `in`.jphe.storyvox.sync.domain
 
+import `in`.jphe.storyvox.sync.SyncIds
 import `in`.jphe.storyvox.sync.client.InstantBackend
 import `in`.jphe.storyvox.sync.client.SignedInUser
 import `in`.jphe.storyvox.sync.coordinator.Stamped
@@ -84,7 +85,7 @@ class BackendSetRemote(
         )
     }
 
-    private fun rowId(user: SignedInUser) = "$domain:${user.userId}"
+    private fun rowId(user: SignedInUser) = SyncIds.rowUuid(domain, user.userId)
 
     private companion object { const val ENTITY = "sets" }
 }
@@ -113,7 +114,7 @@ class BackendBlobRemote(
             updatedAt = payload.updatedAt,
         )
 
-    private fun rowId(user: SignedInUser) = "$domain:${user.userId}"
+    private fun rowId(user: SignedInUser) = SyncIds.rowUuid(domain, user.userId)
 
     private companion object { const val ENTITY = "blobs" }
 }

--- a/core-sync/src/main/kotlin/in/jphe/storyvox/sync/domain/SecretsSyncer.kt
+++ b/core-sync/src/main/kotlin/in/jphe/storyvox/sync/domain/SecretsSyncer.kt
@@ -2,6 +2,7 @@ package `in`.jphe.storyvox.sync.domain
 
 import android.content.SharedPreferences
 import androidx.core.content.edit
+import `in`.jphe.storyvox.sync.SyncIds
 import `in`.jphe.storyvox.sync.client.InstantBackend
 import `in`.jphe.storyvox.sync.client.SignedInUser
 import `in`.jphe.storyvox.sync.coordinator.Stamped
@@ -206,7 +207,7 @@ class SecretsSyncer @Inject constructor(
         return digest.digest(("storyvox-secrets:${user.userId}").toByteArray()).copyOf(16)
     }
 
-    private fun rowId(user: SignedInUser) = "$DOMAIN:${user.userId}"
+    private fun rowId(user: SignedInUser) = SyncIds.rowUuid(DOMAIN, user.userId)
 
     companion object {
         const val DOMAIN: String = "secrets"

--- a/core-sync/src/test/kotlin/in/jphe/storyvox/sync/HttpInstantBackendTest.kt
+++ b/core-sync/src/test/kotlin/in/jphe/storyvox/sync/HttpInstantBackendTest.kt
@@ -48,7 +48,7 @@ class HttpInstantBackendTest {
         ))
         val backend = HttpInstantBackend("test-app", transport)
 
-        val res = backend.fetch(user, entity = "blobs", id = "settings:u-1")
+        val res = backend.fetch(user, entity = "blobs", id = "0e9a6111-40d8-3ef1-9fd1-fadfe3240618")
 
         assertTrue(res.isSuccess)
         assertNull(res.getOrThrow())
@@ -60,9 +60,9 @@ class HttpInstantBackendTest {
         assertEquals("application/json", call.headers["content-type"])
         assertEquals("test-app", call.headers["app-id"])
         assertEquals("rt-1", call.headers["as-token"])
-        // Body shape: { query: { blobs: { $: { where: { id: "settings:u-1" } } } }, inference?: false }
+        // Body shape: { query: { blobs: { $: { where: { id: "0e9a6111-40d8-3ef1-9fd1-fadfe3240618" } } } }, inference?: false }
         assertTrue("body has query envelope", call.body.contains("\"query\""))
-        assertTrue("body filters by id", call.body.contains("\"id\":\"settings:u-1\""))
+        assertTrue("body filters by id", call.body.contains("\"id\":\"0e9a6111-40d8-3ef1-9fd1-fadfe3240618\""))
         assertTrue("body has inference? flag", call.body.contains("\"inference?\":false"))
     }
 
@@ -70,12 +70,12 @@ class HttpInstantBackendTest {
         val transport = FakeTransport(mapOf(
             "/admin/query" to TransportResult(
                 200,
-                """{"blobs":[{"id":"settings:u-1","payload":"hello","updatedAt":12345}]}""",
+                """{"blobs":[{"id":"0e9a6111-40d8-3ef1-9fd1-fadfe3240618","payload":"hello","updatedAt":12345}]}""",
             ),
         ))
         val backend = HttpInstantBackend("test-app", transport)
 
-        val res = backend.fetch(user, entity = "blobs", id = "settings:u-1")
+        val res = backend.fetch(user, entity = "blobs", id = "0e9a6111-40d8-3ef1-9fd1-fadfe3240618")
         val row = res.getOrThrow()
         assertNotNull(row)
         assertEquals("hello", row!!.payload)
@@ -144,7 +144,7 @@ class HttpInstantBackendTest {
         val res = backend.upsert(
             user,
             entity = "blobs",
-            id = "settings:u-1",
+            id = "0e9a6111-40d8-3ef1-9fd1-fadfe3240618",
             payload = "encoded-blob",
             updatedAt = 99L,
         )
@@ -153,13 +153,13 @@ class HttpInstantBackendTest {
         val call = transport.calls.single()
         assertTrue(call.url.endsWith("/admin/transact?app_id=test-app"))
         assertEquals("rt-1", call.headers["as-token"])
-        // Body: { steps: [["update","blobs","settings:u-1",{payload,updatedAt}]], "throw-on-missing-attrs?": false }
+        // Body: { steps: [["update","blobs","0e9a6111-40d8-3ef1-9fd1-fadfe3240618",{payload,updatedAt}]], "throw-on-missing-attrs?": false }
         // — the key is `steps`, NOT `tx-steps`, per the admin SDK.
         assertTrue("body has steps envelope", call.body.contains("\"steps\""))
         assertFalse("body must NOT use tx-steps", call.body.contains("\"tx-steps\""))
         assertTrue("body includes update verb", call.body.contains("\"update\""))
         assertTrue("body includes entity", call.body.contains("\"blobs\""))
-        assertTrue("body includes id", call.body.contains("\"settings:u-1\""))
+        assertTrue("body includes id", call.body.contains("\"0e9a6111-40d8-3ef1-9fd1-fadfe3240618\""))
         assertTrue("body includes payload", call.body.contains("\"payload\":\"encoded-blob\""))
         assertTrue("body includes updatedAt", call.body.contains("\"updatedAt\":99"))
     }

--- a/core-sync/src/test/kotlin/in/jphe/storyvox/sync/LwwBlobSyncerTest.kt
+++ b/core-sync/src/test/kotlin/in/jphe/storyvox/sync/LwwBlobSyncerTest.kt
@@ -1,5 +1,6 @@
 package `in`.jphe.storyvox.sync
 
+import `in`.jphe.storyvox.sync.SyncIds
 import `in`.jphe.storyvox.sync.client.FakeInstantBackend
 import `in`.jphe.storyvox.sync.client.SignedInUser
 import `in`.jphe.storyvox.sync.coordinator.Stamped
@@ -52,7 +53,7 @@ class LwwBlobSyncerTest {
     @Test fun `newer remote overrides local on pull`() = runTest {
         val backend = FakeInstantBackend()
         // Pre-seed remote.
-        backend.upsert(USER, "blobs", "pronunciation:u-1", payload = "fresh", updatedAt = 2000L)
+        backend.upsert(USER, "blobs", SyncIds.rowUuid("pronunciation", USER.userId), payload = "fresh", updatedAt = 2000L)
 
         val local = LocalCell().apply { value = Stamped("stale", 1000L) }
         val syncer = LwwBlobSyncer(
@@ -68,7 +69,7 @@ class LwwBlobSyncerTest {
 
     @Test fun `older remote does not override newer local`() = runTest {
         val backend = FakeInstantBackend()
-        backend.upsert(USER, "blobs", "pronunciation:u-1", payload = "stale", updatedAt = 1000L)
+        backend.upsert(USER, "blobs", SyncIds.rowUuid("pronunciation", USER.userId), payload = "stale", updatedAt = 1000L)
         val local = LocalCell().apply { value = Stamped("fresh", 2000L) }
         val syncer = LwwBlobSyncer(
             name = "pronunciation",
@@ -80,7 +81,7 @@ class LwwBlobSyncerTest {
         // Local should still be "fresh".
         assertEquals("fresh", local.value!!.value)
         // And remote should be updated to match local.
-        val onRemote = backend.fetch(USER, "blobs", "pronunciation:u-1").getOrNull()!!
+        val onRemote = backend.fetch(USER, "blobs", SyncIds.rowUuid("pronunciation", USER.userId)).getOrNull()!!
         assertEquals("fresh", onRemote.payload)
     }
 }

--- a/core-sync/src/test/kotlin/in/jphe/storyvox/sync/SettingsSyncerTest.kt
+++ b/core-sync/src/test/kotlin/in/jphe/storyvox/sync/SettingsSyncerTest.kt
@@ -1,6 +1,7 @@
 package `in`.jphe.storyvox.sync
 
 import `in`.jphe.storyvox.data.repository.sync.SettingsSnapshotSource
+import `in`.jphe.storyvox.sync.SyncIds
 import `in`.jphe.storyvox.sync.client.FakeInstantBackend
 import `in`.jphe.storyvox.sync.client.RowSnapshot
 import `in`.jphe.storyvox.sync.client.SignedInUser
@@ -60,7 +61,7 @@ class SettingsSyncerTest {
         val outcome = syncer.push(USER)
         assertTrue("push must succeed: $outcome", outcome is SyncOutcome.Ok)
 
-        val row = backend.fetch(USER, "blobs", "settings:${USER.userId}").getOrNull()
+        val row = backend.fetch(USER, "blobs", SyncIds.rowUuid("settings", USER.userId)).getOrNull()
         assertNotNull("remote row must exist after push", row)
         // Payload contains both keys, JSON-encoded.
         assertTrue(row!!.payload.contains("\"settings.pref_theme_override\""))
@@ -125,7 +126,7 @@ class SettingsSyncerTest {
         // Local must still be DARK.
         assertEquals("DARK", sourceB.store["settings.pref_theme_override"])
         // And the remote must now reflect the newer local.
-        val row = backend.fetch(USER, "blobs", "settings:${USER.userId}").getOrNull()!!
+        val row = backend.fetch(USER, "blobs", SyncIds.rowUuid("settings", USER.userId)).getOrNull()!!
         assertTrue("remote should now hold DARK", row.payload.contains("\"DARK\""))
         assertEquals(5_000L, row.updatedAt)
     }
@@ -137,7 +138,7 @@ class SettingsSyncerTest {
         val outcome = syncer.push(USER)
         assertTrue("no-op push should be Ok: $outcome", outcome is SyncOutcome.Ok)
         // Nothing on the remote.
-        assertNull(backend.fetch(USER, "blobs", "settings:${USER.userId}").getOrNull())
+        assertNull(backend.fetch(USER, "blobs", SyncIds.rowUuid("settings", USER.userId)).getOrNull())
     }
 
     @Test fun `tombstone propagates — local clears a key, remote sees the clear`() = runTest {
@@ -160,7 +161,7 @@ class SettingsSyncerTest {
         source.stamp = 2_000L
         SettingsSyncer(source, backend).push(USER)
 
-        val row = backend.fetch(USER, "blobs", "settings:${USER.userId}").getOrNull()!!
+        val row = backend.fetch(USER, "blobs", SyncIds.rowUuid("settings", USER.userId)).getOrNull()!!
         assertTrue("remote should retain the theme", row.payload.contains("\"DARK\""))
         assertTrue(
             "remote should NOT carry the cleared default-speed",
@@ -201,7 +202,7 @@ class SettingsSyncerTest {
         ).also { it.stamp = 500L }
         SettingsSyncer(sourceB, backend).push(USER)
 
-        val row = backend.fetch(USER, "blobs", "settings:${USER.userId}").getOrNull()
+        val row = backend.fetch(USER, "blobs", SyncIds.rowUuid("settings", USER.userId)).getOrNull()
         assertNotNull(row)
         assertTrue(row!!.payload.contains("\"DARK\""))
     }
@@ -244,7 +245,7 @@ class SettingsSyncerTest {
         // Local must still hold LOCAL_VAL (tie went to local).
         assertEquals("LOCAL_VAL", sourceB.store["settings.pref_theme_override"])
         // Remote is now updated to local (same updatedAt — LwwBlobSyncer pushes back).
-        val row = backend.fetch(USER, "blobs", "settings:${USER.userId}").getOrNull()!!
+        val row = backend.fetch(USER, "blobs", SyncIds.rowUuid("settings", USER.userId)).getOrNull()!!
         assertTrue(row.payload.contains("\"LOCAL_VAL\""))
     }
 
@@ -254,7 +255,7 @@ class SettingsSyncerTest {
         backend.upsert(
             USER,
             entity = "blobs",
-            id = "settings:${USER.userId}",
+            id = SyncIds.rowUuid("settings", USER.userId),
             payload = """{"settings.pref_theme_override":"DARK","settings.pref_future_v999_unknown":"hello"}""",
             updatedAt = 5_000L,
         )
@@ -282,11 +283,11 @@ class SettingsSyncerTest {
             ),
         ).also { it.stamp = 1_000L }
         SettingsSyncer(source, backend).push(USER)
-        val first = backend.fetch(USER, "blobs", "settings:${USER.userId}").getOrNull()!!.payload
+        val first = backend.fetch(USER, "blobs", SyncIds.rowUuid("settings", USER.userId)).getOrNull()!!.payload
 
         // Re-push with the same source — payload should be byte-identical.
         SettingsSyncer(source, backend).push(USER)
-        val second = backend.fetch(USER, "blobs", "settings:${USER.userId}").getOrNull()!!.payload
+        val second = backend.fetch(USER, "blobs", SyncIds.rowUuid("settings", USER.userId)).getOrNull()!!.payload
 
         assertEquals("repeated push of identical source must produce byte-identical payload", first, second)
     }
@@ -300,9 +301,9 @@ class SettingsSyncerTest {
             FakeSource(mapOf("settings.pref_theme_override" to "LIGHT")).also { it.stamp = 1L },
             backend,
         ).push(USER)
-        // The row id is `<domain>:<userId>` per the BackendBlobRemote
-        // contract — direct-fetch by that id should return the row.
-        assertNotNull(backend.fetch(USER, "blobs", "settings:${USER.userId}").getOrNull())
+        // The row id is a UUID v3 derived from `domain:userId` per
+        // SyncIds.rowUuid — direct-fetch by that id should return the row.
+        assertNotNull(backend.fetch(USER, "blobs", SyncIds.rowUuid("settings", USER.userId)).getOrNull())
     }
 
     @Test fun `per-backend keys round-trip alongside main settings`() = runTest {
@@ -336,7 +337,7 @@ class SettingsSyncerTest {
         val source = FakeSource(mapOf("settings.pref_theme_override" to "DARK"))
         source.stamp = 42L
         SettingsSyncer(source, backend).push(USER)
-        val row = backend.fetch(USER, "blobs", "settings:${USER.userId}").getOrNull()!!
+        val row = backend.fetch(USER, "blobs", SyncIds.rowUuid("settings", USER.userId)).getOrNull()!!
         assertEquals(42L, row.updatedAt)
     }
 }

--- a/core-sync/src/test/kotlin/in/jphe/storyvox/sync/WireContractTest.kt
+++ b/core-sync/src/test/kotlin/in/jphe/storyvox/sync/WireContractTest.kt
@@ -104,7 +104,7 @@ class WireContractTest {
         val transport = CapturingTransport(loadFixture("query-response-blobs-miss.json"))
         val backend = HttpInstantBackend("test-app", transport)
 
-        backend.fetch(user, entity = "blobs", id = "settings:u-1")
+        backend.fetch(user, entity = "blobs", id = "0e9a6111-40d8-3ef1-9fd1-fadfe3240618")
 
         val actual = json.parseToJsonElement(transport.lastBody!!).jsonObject
         val expected = loadJson("query-request-blobs.json").jsonObject
@@ -134,7 +134,7 @@ class WireContractTest {
         val actualQuery = actual["query"]!!.jsonObject
         val expectedQuery = expected["query"]!!.jsonObject
         assertEquals(expectedQuery.keys, actualQuery.keys)
-        assertEquals("settings:u-1",
+        assertEquals("0e9a6111-40d8-3ef1-9fd1-fadfe3240618",
             actualQuery["blobs"]!!.jsonObject["\$"]!!.jsonObject["where"]!!
                 .jsonObject["id"]!!.jsonPrimitive.contentOrNull,
         )
@@ -168,7 +168,7 @@ class WireContractTest {
         val transport = CapturingTransport(loadFixture("query-response-blobs-hit.json"))
         val backend = HttpInstantBackend("test-app", transport)
 
-        val res = backend.fetch(user, entity = "blobs", id = "settings:u-1")
+        val res = backend.fetch(user, entity = "blobs", id = "0e9a6111-40d8-3ef1-9fd1-fadfe3240618")
         val row = res.getOrThrow()
         assertNotNull("hit fixture must deserialize to a row", row)
 
@@ -191,7 +191,7 @@ class WireContractTest {
         val transport = CapturingTransport(loadFixture("query-response-blobs-miss.json"))
         val backend = HttpInstantBackend("test-app", transport)
 
-        val res = backend.fetch(user, entity = "blobs", id = "settings:u-1")
+        val res = backend.fetch(user, entity = "blobs", id = "0e9a6111-40d8-3ef1-9fd1-fadfe3240618")
         assertTrue("empty array is a hit-with-no-row, not an error", res.isSuccess)
         assertNull("missing row maps to null", res.getOrThrow())
     }
@@ -203,7 +203,7 @@ class WireContractTest {
         val transport = CapturingTransport(loadFixture("query-response-blobs-no-entity-key.json"))
         val backend = HttpInstantBackend("test-app", transport)
 
-        val res = backend.fetch(user, entity = "blobs", id = "settings:u-1")
+        val res = backend.fetch(user, entity = "blobs", id = "0e9a6111-40d8-3ef1-9fd1-fadfe3240618")
         assertTrue(res.isSuccess)
         assertNull(res.getOrThrow())
     }
@@ -233,7 +233,7 @@ class WireContractTest {
         backend.upsert(
             user,
             entity = "blobs",
-            id = "settings:u-1",
+            id = "0e9a6111-40d8-3ef1-9fd1-fadfe3240618",
             payload = "{\"theme\":\"dark\"}",
             updatedAt = 1716393600000L,
         )
@@ -266,7 +266,7 @@ class WireContractTest {
         assertEquals("step must be a 4-tuple", 4, step.size)
         assertEquals("update", step[0].jsonPrimitive.contentOrNull)
         assertEquals("blobs", step[1].jsonPrimitive.contentOrNull)
-        assertEquals("settings:u-1", step[2].jsonPrimitive.contentOrNull)
+        assertEquals("0e9a6111-40d8-3ef1-9fd1-fadfe3240618", step[2].jsonPrimitive.contentOrNull)
         val patch = step[3].jsonObject
         assertEquals("{\"theme\":\"dark\"}", patch["payload"]!!.jsonPrimitive.contentOrNull)
         assertEquals(1716393600000L, patch["updatedAt"]!!.jsonPrimitive.long)

--- a/core-sync/src/test/resources/instant-wire/query-request-blobs.json
+++ b/core-sync/src/test/resources/instant-wire/query-request-blobs.json
@@ -3,7 +3,7 @@
     "blobs": {
       "$": {
         "where": {
-          "id": "settings:u-1"
+          "id": "0e9a6111-40d8-3ef1-9fd1-fadfe3240618"
         }
       }
     }

--- a/core-sync/src/test/resources/instant-wire/query-response-blobs-hit.json
+++ b/core-sync/src/test/resources/instant-wire/query-response-blobs-hit.json
@@ -1,7 +1,7 @@
 {
   "blobs": [
     {
-      "id": "settings:u-1",
+      "id": "0e9a6111-40d8-3ef1-9fd1-fadfe3240618",
       "payload": "{\"theme\":\"dark\",\"voice\":\"en-US-AvaNeural\"}",
       "updatedAt": 1716393600000
     }

--- a/core-sync/src/test/resources/instant-wire/transact-request-update.json
+++ b/core-sync/src/test/resources/instant-wire/transact-request-update.json
@@ -3,7 +3,7 @@
     [
       "update",
       "blobs",
-      "settings:u-1",
+      "0e9a6111-40d8-3ef1-9fd1-fadfe3240618",
       {
         "payload": "{\"theme\":\"dark\"}",
         "updatedAt": 1716393600000


### PR DESCRIPTION
## Summary

- **Root cause**: InstantDB requires entity IDs to be valid UUIDs, but all syncers built IDs as colon-delimited strings (`"library:userId"`, `"settings:userId"`), causing "validation failed for steps invalid entity id" on every push
- **Fix**: Add `SyncIds.rowUuid()` utility using `UUID.nameUUIDFromBytes()` (UUID v3, deterministic) — same user+domain always maps to the same UUID across devices
- **Scope**: All 5 `rowId()` call sites across 4 syncer files, plus wire-format test fixtures updated to use realistic UUIDs

Closes the sync failure reported in SyncStatusSheet showing `Transient`/`Permanent` errors for all domains.

## Test plan

- [x] `./gradlew :core-sync:testDebugUnitTest` — all 84 tests pass
- [ ] CI green
- [ ] Install on tablet, open SyncStatusSheet, verify domains show `OkAt`
- [ ] Check logcat for sync activity

🤖 Generated with [Claude Code](https://claude.com/claude-code)