### PR TITLE
feat(sync): sync settings + passphrase in Account screen

### DIFF
--- a/app/src/main/kotlin/in/jphe/storyvox/data/PassphraseStore.kt
+++ b/app/src/main/kotlin/in/jphe/storyvox/data/PassphraseStore.kt
@@ -1,0 +1,42 @@
+package `in`.jphe.storyvox.data
+
+import android.content.SharedPreferences
+import `in`.jphe.storyvox.sync.domain.PassphraseManager
+import javax.inject.Inject
+import javax.inject.Singleton
+
+/**
+ * EncryptedSharedPreferences-backed passphrase store for secrets sync.
+ *
+ * The passphrase is stored under [PREF_KEY] in the `storyvox.secrets`
+ * bag (AES-GCM at rest via Android KeyStore). This key deliberately
+ * falls outside [SecretsSyncer.SECRET_KEY_PREFIXES] and
+ * [SecretsSyncer.SECRET_KEY_NAMES] — the passphrase itself must NOT
+ * be synced to InstantDB (that would be circular: the passphrase
+ * encrypts the bag that would contain the passphrase).
+ */
+@Singleton
+class PassphraseStore @Inject constructor(
+    private val secrets: SharedPreferences,
+) : PassphraseManager {
+
+    override fun get(): CharArray? {
+        val stored = secrets.getString(PREF_KEY, null)
+        return if (stored.isNullOrEmpty()) null else stored.toCharArray()
+    }
+
+    override fun set(passphrase: CharArray) {
+        secrets.edit().putString(PREF_KEY, String(passphrase)).apply()
+    }
+
+    override fun clear() {
+        secrets.edit().remove(PREF_KEY).apply()
+    }
+
+    override fun isSet(): Boolean =
+        !secrets.getString(PREF_KEY, null).isNullOrEmpty()
+
+    companion object {
+        internal const val PREF_KEY = "sync.passphrase"
+    }
+}

--- a/app/src/main/kotlin/in/jphe/storyvox/di/AppBindings.kt
+++ b/app/src/main/kotlin/in/jphe/storyvox/di/AppBindings.kt
@@ -50,6 +50,7 @@ import `in`.jphe.storyvox.playback.tts.RecapPlaybackState
 import `in`.jphe.storyvox.playback.SPEED_BASELINE_CHARS_PER_SECOND
 import `in`.jphe.storyvox.playback.SleepTimerMode
 import `in`.jphe.storyvox.playback.StoryvoxPlaybackService
+import javax.inject.Named
 import javax.inject.Singleton
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -374,6 +375,23 @@ object AppBindings {
     // No additional binding needed — `SecretsSyncer` picks them up via
     // the extended `SECRET_KEY_PREFIXES` (`notion.`) and
     // `SECRET_KEY_NAMES` (Discord's flat-named token).
+
+    /**
+     * Real passphrase provider — replaces the no-op default that
+     * was in `:core-sync`'s SyncModule. [PassphraseStore] reads from
+     * EncryptedSharedPreferences under `sync.passphrase`.
+     */
+    @Provides
+    @Singleton
+    @Named(`in`.jphe.storyvox.sync.domain.SecretsSyncer.PASSPHRASE_PROVIDER)
+    fun providePassphraseProvider(
+        impl: `in`.jphe.storyvox.data.PassphraseStore,
+    ): `in`.jphe.storyvox.sync.domain.PassphraseProvider = impl
+
+    @Provides @Singleton
+    fun providePassphraseManager(
+        impl: `in`.jphe.storyvox.data.PassphraseStore,
+    ): `in`.jphe.storyvox.sync.domain.PassphraseManager = impl
 
     /**
      * Issue #203 — narrow [GitHubScopePreferences] surface for the

--- a/core-sync/src/main/kotlin/in/jphe/storyvox/sync/coordinator/SyncCoordinator.kt
+++ b/core-sync/src/main/kotlin/in/jphe/storyvox/sync/coordinator/SyncCoordinator.kt
@@ -90,6 +90,15 @@ class SyncCoordinator @Inject constructor(
         }
     }
 
+    /** Manual sync trigger from Settings → Account. Pull then push. */
+    fun syncNow() {
+        val user = session.current() ?: return
+        scope.launch {
+            pullAll(user)
+            requestPushAll()
+        }
+    }
+
     /** Request a push for every domain. Used by the post-sign-in
      *  migration step. */
     fun requestPushAll() {

--- a/core-sync/src/main/kotlin/in/jphe/storyvox/sync/di/SyncModule.kt
+++ b/core-sync/src/main/kotlin/in/jphe/storyvox/sync/di/SyncModule.kt
@@ -22,12 +22,12 @@ import `in`.jphe.storyvox.sync.coordinator.TombstoneStore
 import `in`.jphe.storyvox.sync.domain.BookmarksSyncer
 import `in`.jphe.storyvox.sync.domain.FollowsSyncer
 import `in`.jphe.storyvox.sync.domain.LibrarySyncer
-import `in`.jphe.storyvox.sync.domain.PassphraseProvider
+
 import `in`.jphe.storyvox.sync.domain.PlaybackPositionSyncer
 import `in`.jphe.storyvox.sync.domain.PronunciationDictSyncer
 import `in`.jphe.storyvox.sync.domain.SecretsSyncer
 import `in`.jphe.storyvox.sync.domain.SettingsSyncer
-import javax.inject.Named
+
 import javax.inject.Singleton
 
 /**
@@ -130,18 +130,6 @@ object SyncModule {
     @Provides @IntoSet
     fun provideSettingsSyncer(impl: SettingsSyncer): Syncer = impl
 
-    /**
-     * Default passphrase provider — returns null, i.e. "secrets sync is
-     * a no-op." The real provider lives in `:app` once the Settings →
-     * Account passphrase entry is wired; until then this lets the DI
-     * graph resolve and the rest of the syncers run while
-     * [SecretsSyncer.reconcile] returns `Permanent("set a passphrase")`
-     * straight away.
-     */
-    @Provides
-    @Singleton
-    @Named(SecretsSyncer.PASSPHRASE_PROVIDER)
-    fun provideDefaultPassphraseProvider(): PassphraseProvider = PassphraseProvider { null }
 }
 
 // [SettingsSnapshotSource] and [SecretsSnapshotSource] bindings live

--- a/core-sync/src/main/kotlin/in/jphe/storyvox/sync/domain/SecretsSyncer.kt
+++ b/core-sync/src/main/kotlin/in/jphe/storyvox/sync/domain/SecretsSyncer.kt
@@ -35,6 +35,17 @@ fun interface PassphraseProvider {
 }
 
 /**
+ * Write-side extension of [PassphraseProvider] — used by the settings UI
+ * to let the user set, clear, and check the passphrase. The syncer only
+ * needs [PassphraseProvider.get]; this interface is for the Account screen.
+ */
+interface PassphraseManager : PassphraseProvider {
+    fun set(passphrase: CharArray)
+    fun clear()
+    fun isSet(): Boolean
+}
+
+/**
  * Syncs the user's encrypted secrets — API keys (Claude, OpenAI, etc.),
  * Royal Road session cookies, GitHub PAT, Outline tokens, Notion
  * integration token, Discord bot token.

--- a/feature/src/main/kotlin/in/jphe/storyvox/feature/settings/AccountSettingsScreen.kt
+++ b/feature/src/main/kotlin/in/jphe/storyvox/feature/settings/AccountSettingsScreen.kt
@@ -1,15 +1,29 @@
 package `in`.jphe.storyvox.feature.settings
 
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.input.PasswordVisualTransformation
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import `in`.jphe.storyvox.feature.api.UiGitHubAuthState
 import `in`.jphe.storyvox.feature.settings.components.StatusPill
 import `in`.jphe.storyvox.feature.settings.components.StatusTone
+import `in`.jphe.storyvox.feature.sync.DomainStatusRow
 import `in`.jphe.storyvox.ui.component.BrassButton
 import `in`.jphe.storyvox.ui.component.BrassButtonVariant
 import `in`.jphe.storyvox.ui.theme.LocalSpacing
@@ -17,15 +31,11 @@ import `in`.jphe.storyvox.ui.theme.LocalSpacing
 /**
  * Settings → Account subscreen (follow-up to #440 / #467).
  *
- * Sign-in surfaces for fiction sources that need an account:
- *  - Royal Road (WebView cookie auth — #91).
- *  - GitHub (Device Flow OAuth + scope toggle — #91 / #203).
- *
- * The Notion / Discord / Outline token-paste rows still live under
- * the "Library & Sync" sources section because they're per-plugin
- * config, not per-account sign-ins. Anthropic Teams OAuth lives
- * under AI because it's an AI-provider auth, not a fiction-source
- * sign-in. The legacy long-scroll page preserves the same split.
+ * Three sections:
+ *  1. **Cloud Sync** — sync status, domain grid, passphrase entry,
+ *     and a "Sync now" button. Visible only when signed in.
+ *  2. **Royal Road** — WebView cookie auth (#91).
+ *  3. **GitHub** — Device Flow OAuth + scope toggle (#91 / #203).
  */
 @Composable
 fun AccountSettingsScreen(
@@ -34,8 +44,10 @@ fun AccountSettingsScreen(
     onOpenGitHubSignIn: () -> Unit,
     onOpenGitHubRevoke: () -> Unit,
     viewModel: SettingsViewModel = hiltViewModel(),
+    syncViewModel: AccountSyncViewModel = hiltViewModel(),
 ) {
     val state by viewModel.uiState.collectAsStateWithLifecycle()
+    val syncState by syncViewModel.state.collectAsStateWithLifecycle()
     val spacing = LocalSpacing.current
 
     SettingsSubscreenScaffold(title = "Account", onBack = onBack) { padding ->
@@ -44,6 +56,81 @@ fun AccountSettingsScreen(
             return@SettingsSubscreenScaffold
         }
         SettingsSubscreenBody(padding) {
+            // ── Cloud Sync ──────────────────────────────────────────
+            if (syncState.signedInUser != null) {
+                SettingsGroupCard {
+                    StatusPill(
+                        text = if (syncState.anySyncing) "Cloud Sync · syncing" else "Cloud Sync · connected",
+                        tone = StatusTone.Connected,
+                    )
+                    SettingsRow(
+                        title = "Signed in as",
+                        subtitle = syncState.signedInUser?.email ?: "(no email)",
+                    )
+
+                    if (syncState.domainStatuses.isNotEmpty()) {
+                        Text(
+                            "Domain status",
+                            style = MaterialTheme.typography.labelMedium,
+                            color = MaterialTheme.colorScheme.onSurfaceVariant,
+                            modifier = Modifier.padding(top = spacing.xs),
+                        )
+                        syncState.domainStatuses.entries
+                            .sortedBy { it.key }
+                            .forEach { (domain, status) ->
+                                DomainStatusRow(domain = domain, status = status)
+                            }
+                    }
+
+                    Spacer(Modifier.height(spacing.xs))
+                    BrassButton(
+                        label = if (syncState.anySyncing) "Syncing…" else "Sync now",
+                        onClick = syncViewModel::syncNow,
+                        variant = BrassButtonVariant.Secondary,
+                        modifier = Modifier.fillMaxWidth(),
+                        enabled = !syncState.anySyncing,
+                    )
+                }
+
+                // ── Secrets Passphrase ──────────────────────────────
+                SettingsGroupCard {
+                    StatusPill(
+                        text = if (syncState.passphraseSet) "Secrets sync · enabled" else "Secrets sync · not configured",
+                        tone = if (syncState.passphraseSet) StatusTone.Connected else StatusTone.Neutral,
+                    )
+                    Text(
+                        "Encrypt API keys and tokens with a passphrase before syncing them to the cloud. " +
+                            "The same passphrase is needed on every device.",
+                        style = MaterialTheme.typography.bodySmall,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    )
+                    PassphraseEntry(
+                        isSet = syncState.passphraseSet,
+                        onSet = syncViewModel::setPassphrase,
+                        onClear = syncViewModel::clearPassphrase,
+                    )
+                }
+            } else {
+                SettingsGroupCard {
+                    StatusPill(
+                        text = "Cloud Sync · not signed in",
+                        tone = StatusTone.Neutral,
+                    )
+                    SettingsRow(
+                        title = "Cloud Sync",
+                        subtitle = "Sign in to sync library, follows, positions, and secrets across devices.",
+                        trailing = {
+                            BrassButton(
+                                label = "Sign in",
+                                onClick = onOpenSignIn,
+                                variant = BrassButtonVariant.Primary,
+                            )
+                        },
+                    )
+                }
+            }
+
+            // ── Fiction Source Accounts ──────────────────────────────
             SettingsGroupCard {
                 StatusPill(
                     text = if (s.isSignedIn) "Royal Road · signed in" else "Royal Road · not signed in",
@@ -61,9 +148,6 @@ fun AccountSettingsScreen(
                             )
                         },
                     )
-                    // Issue #178 — two-way tag-sync row. Only
-                    // surfaces when signed in to RR because the
-                    // affordance is meaningless without a session.
                     RoyalRoadTagSyncRow()
                 } else {
                     SettingsRow(
@@ -103,5 +187,56 @@ fun AccountSettingsScreen(
                 )
             }
         }
+    }
+}
+
+@Composable
+private fun PassphraseEntry(
+    isSet: Boolean,
+    onSet: (CharArray) -> Unit,
+    onClear: () -> Unit,
+) {
+    val spacing = LocalSpacing.current
+    var input by remember { mutableStateOf("") }
+
+    if (isSet) {
+        Row(
+            modifier = Modifier.fillMaxWidth(),
+            horizontalArrangement = Arrangement.SpaceBetween,
+            verticalAlignment = Alignment.CenterVertically,
+        ) {
+            Text(
+                "Passphrase is set",
+                style = MaterialTheme.typography.bodyMedium,
+                color = MaterialTheme.colorScheme.onSurface,
+            )
+            BrassButton(
+                label = "Clear",
+                onClick = onClear,
+                variant = BrassButtonVariant.Secondary,
+            )
+        }
+    } else {
+        OutlinedTextField(
+            value = input,
+            onValueChange = { input = it },
+            label = { Text("Sync passphrase") },
+            placeholder = { Text("Enter a passphrase for secrets sync") },
+            visualTransformation = PasswordVisualTransformation(),
+            singleLine = true,
+            modifier = Modifier.fillMaxWidth(),
+        )
+        BrassButton(
+            label = "Set passphrase",
+            onClick = {
+                if (input.isNotBlank()) {
+                    onSet(input.toCharArray())
+                    input = ""
+                }
+            },
+            variant = BrassButtonVariant.Primary,
+            modifier = Modifier.fillMaxWidth().padding(top = spacing.xs),
+            enabled = input.isNotBlank(),
+        )
     }
 }

--- a/feature/src/main/kotlin/in/jphe/storyvox/feature/settings/AccountSyncViewModel.kt
+++ b/feature/src/main/kotlin/in/jphe/storyvox/feature/settings/AccountSyncViewModel.kt
@@ -1,0 +1,69 @@
+package `in`.jphe.storyvox.feature.settings
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import dagger.hilt.android.lifecycle.HiltViewModel
+import `in`.jphe.storyvox.sync.client.InstantSession
+import `in`.jphe.storyvox.sync.client.SignedInUser
+import `in`.jphe.storyvox.sync.coordinator.SyncCoordinator
+import `in`.jphe.storyvox.sync.coordinator.SyncStatus
+import `in`.jphe.storyvox.sync.domain.PassphraseManager
+import javax.inject.Inject
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.SharingStarted
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.combine
+import kotlinx.coroutines.flow.stateIn
+import kotlinx.coroutines.flow.update
+
+data class AccountSyncState(
+    val signedInUser: SignedInUser? = null,
+    val domainStatuses: Map<String, SyncStatus> = emptyMap(),
+    val passphraseSet: Boolean = false,
+    val anySyncing: Boolean = false,
+)
+
+@HiltViewModel
+class AccountSyncViewModel @Inject constructor(
+    private val session: InstantSession,
+    private val coordinator: SyncCoordinator,
+    private val passphraseManager: PassphraseManager,
+) : ViewModel() {
+
+    private val passphraseTick = MutableStateFlow(0)
+
+    val state: StateFlow<AccountSyncState> = combine(
+        session.signedIn,
+        coordinator.status,
+        passphraseTick,
+    ) { user, statuses, _ ->
+        AccountSyncState(
+            signedInUser = user,
+            domainStatuses = statuses,
+            passphraseSet = passphraseManager.isSet(),
+            anySyncing = statuses.values.any { it is SyncStatus.Running },
+        )
+    }.stateIn(
+        viewModelScope,
+        SharingStarted.WhileSubscribed(5_000),
+        AccountSyncState(
+            signedInUser = session.current(),
+            passphraseSet = passphraseManager.isSet(),
+        ),
+    )
+
+    fun setPassphrase(value: CharArray) {
+        passphraseManager.set(value)
+        value.fill(' ')
+        passphraseTick.update { it + 1 }
+    }
+
+    fun clearPassphrase() {
+        passphraseManager.clear()
+        passphraseTick.update { it + 1 }
+    }
+
+    fun syncNow() {
+        coordinator.syncNow()
+    }
+}

--- a/feature/src/main/kotlin/in/jphe/storyvox/feature/sync/SyncStatusComposables.kt
+++ b/feature/src/main/kotlin/in/jphe/storyvox/feature/sync/SyncStatusComposables.kt
@@ -1,0 +1,90 @@
+package `in`.jphe.storyvox.feature.sync
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.CheckCircle
+import androidx.compose.material.icons.filled.Error
+import androidx.compose.material.icons.filled.HelpOutline
+import androidx.compose.material.icons.filled.Sync
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.unit.dp
+import `in`.jphe.storyvox.sync.coordinator.SyncStatus
+import `in`.jphe.storyvox.ui.theme.LocalSpacing
+
+@Composable
+internal fun DomainStatusRow(domain: String, status: SyncStatus) {
+    val spacing = LocalSpacing.current
+    Row(
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(vertical = spacing.xs / 2),
+        verticalAlignment = Alignment.CenterVertically,
+        horizontalArrangement = Arrangement.spacedBy(spacing.xs),
+    ) {
+        DomainStatusIcon(status = status)
+        Column(modifier = Modifier.fillMaxWidth()) {
+            Text(
+                text = domain.replaceFirstChar { it.uppercase() },
+                style = MaterialTheme.typography.bodyMedium,
+                color = MaterialTheme.colorScheme.onSurface,
+            )
+            Text(
+                text = describeSyncStatus(status),
+                style = MaterialTheme.typography.bodySmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
+        }
+    }
+}
+
+@Composable
+internal fun DomainStatusIcon(status: SyncStatus) {
+    val tint: Color
+    val icon = when (status) {
+        SyncStatus.Idle -> {
+            tint = MaterialTheme.colorScheme.onSurfaceVariant
+            Icons.Filled.HelpOutline
+        }
+        SyncStatus.Running -> {
+            tint = MaterialTheme.colorScheme.primary
+            Icons.Filled.Sync
+        }
+        is SyncStatus.OkAt -> {
+            tint = MaterialTheme.colorScheme.primary
+            Icons.Filled.CheckCircle
+        }
+        is SyncStatus.Transient -> {
+            tint = MaterialTheme.colorScheme.tertiary
+            Icons.Filled.Error
+        }
+        is SyncStatus.Permanent -> {
+            tint = MaterialTheme.colorScheme.error
+            Icons.Filled.Error
+        }
+    }
+    Icon(
+        imageVector = icon,
+        contentDescription = null,
+        tint = tint,
+        modifier = Modifier.size(18.dp),
+    )
+}
+
+internal fun describeSyncStatus(status: SyncStatus): String = when (status) {
+    SyncStatus.Idle -> "Idle"
+    SyncStatus.Running -> "Syncing…"
+    is SyncStatus.OkAt -> "Synced (${status.records} record${if (status.records == 1) "" else "s"})"
+    is SyncStatus.Transient -> "Retrying: ${status.message}"
+    is SyncStatus.Permanent -> "Stopped: ${status.message}"
+}

--- a/feature/src/main/kotlin/in/jphe/storyvox/feature/sync/SyncStatusSheet.kt
+++ b/feature/src/main/kotlin/in/jphe/storyvox/feature/sync/SyncStatusSheet.kt
@@ -10,8 +10,7 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.CheckCircle
-import androidx.compose.material.icons.filled.Error
-import androidx.compose.material.icons.filled.HelpOutline
+
 import androidx.compose.material.icons.filled.Sync
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Icon
@@ -23,7 +22,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.graphics.Color
+
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
@@ -206,71 +205,5 @@ private fun SignedInBody(
     )
 }
 
-@Composable
-private fun DomainStatusRow(domain: String, status: SyncStatus) {
-    val spacing = LocalSpacing.current
-    Row(
-        modifier = Modifier
-            .fillMaxWidth()
-            .padding(vertical = spacing.xs / 2),
-        verticalAlignment = Alignment.CenterVertically,
-        horizontalArrangement = Arrangement.spacedBy(spacing.xs),
-    ) {
-        DomainStatusIcon(status = status)
-        Column(modifier = Modifier.fillMaxWidth()) {
-            Text(
-                text = domain.replaceFirstChar { it.uppercase() },
-                style = MaterialTheme.typography.bodyMedium,
-                color = MaterialTheme.colorScheme.onSurface,
-            )
-            Text(
-                text = describe(status),
-                style = MaterialTheme.typography.bodySmall,
-                color = MaterialTheme.colorScheme.onSurfaceVariant,
-            )
-        }
-    }
-}
-
-@Composable
-private fun DomainStatusIcon(status: SyncStatus) {
-    val tint: Color
-    val icon = when (status) {
-        SyncStatus.Idle -> {
-            tint = MaterialTheme.colorScheme.onSurfaceVariant
-            Icons.Filled.HelpOutline
-        }
-        SyncStatus.Running -> {
-            tint = MaterialTheme.colorScheme.primary
-            Icons.Filled.Sync
-        }
-        is SyncStatus.OkAt -> {
-            tint = MaterialTheme.colorScheme.primary
-            Icons.Filled.CheckCircle
-        }
-        is SyncStatus.Transient -> {
-            tint = MaterialTheme.colorScheme.tertiary
-            Icons.Filled.Error
-        }
-        is SyncStatus.Permanent -> {
-            tint = MaterialTheme.colorScheme.error
-            Icons.Filled.Error
-        }
-    }
-    Icon(
-        imageVector = icon,
-        contentDescription = null,
-        tint = tint,
-        modifier = Modifier.size(18.dp),
-    )
-}
-
-/** Human-readable one-liner for a [SyncStatus]. Extracted so the row
- *  composable stays under 30 lines and the copy lives in one spot. */
-private fun describe(status: SyncStatus): String = when (status) {
-    SyncStatus.Idle -> "Idle"
-    SyncStatus.Running -> "Syncing…"
-    is SyncStatus.OkAt -> "Synced (${status.records} record${if (status.records == 1) "" else "s"})"
-    is SyncStatus.Transient -> "Retrying: ${status.message}"
-    is SyncStatus.Permanent -> "Stopped: ${status.message}"
-}
+// DomainStatusRow, DomainStatusIcon, describeSyncStatus are in
+// SyncStatusComposables.kt (shared with AccountSettingsScreen).


### PR DESCRIPTION
## Summary
- Adds **Cloud Sync** section to Settings → Account: signed-in status, per-domain sync grid, "Sync now" button
- Adds **Secrets Passphrase** section: enter/clear the passphrase used to encrypt API keys before syncing to InstantDB
- Creates `PassphraseStore` backed by EncryptedSharedPreferences, wired via Hilt in `:app`
- Removes the default no-op `PassphraseProvider` from `SyncModule` — secrets sync now works when the user sets a passphrase

## Test plan
- [ ] Build + install on device
- [ ] Open Settings → Account — verify Cloud Sync section shows domain status when signed in
- [ ] Enter a passphrase and tap "Set passphrase" — verify "Secrets sync · enabled" pill appears
- [ ] Tap "Sync now" — verify domains transition through Running → OkAt
- [ ] Clear passphrase — verify pill returns to "not configured"
- [ ] Sign out of sync — verify "not signed in" CTA replaces the Cloud Sync section
- [ ] `./gradlew :core-sync:testDebugUnitTest` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)