### PR TITLE
fix: Gemini Code Assist review sweep — 10 fixes across 15 PRs

### DIFF
--- a/app/src/main/kotlin/in/jphe/storyvox/data/PassphraseStore.kt
+++ b/app/src/main/kotlin/in/jphe/storyvox/data/PassphraseStore.kt
@@ -33,8 +33,7 @@ class PassphraseStore @Inject constructor(
         secrets.edit().remove(PREF_KEY).apply()
     }
 
-    override fun isSet(): Boolean =
-        !secrets.getString(PREF_KEY, null).isNullOrEmpty()
+    override fun isSet(): Boolean = secrets.contains(PREF_KEY)
 
     companion object {
         internal const val PREF_KEY = "sync.passphrase"

--- a/core-data/src/main/kotlin/in/jphe/storyvox/data/repository/FictionRepository.kt
+++ b/core-data/src/main/kotlin/in/jphe/storyvox/data/repository/FictionRepository.kt
@@ -296,7 +296,7 @@ class FictionRepositoryImpl @Inject constructor(
         val source = sourceFor(SourceIds.ROYAL_ROAD)
         val allIncoming = mutableListOf<FictionSummary>()
         var page = 1
-        while (true) {
+        while (page <= MAX_FOLLOWS_PAGES) {
             when (val result = source.followsList(page = page)) {
                 is FictionResult.Success -> {
                     allIncoming.addAll(result.value.items)
@@ -483,6 +483,7 @@ class FictionRepositoryImpl @Inject constructor(
     private companion object {
         const val CHOOSER_THRESHOLD: Float = 0.5f
         const val DOMINANT_GAP: Float = 0.2f
+        const val MAX_FOLLOWS_PAGES: Int = 200
     }
 
     // ─── helpers ──────────────────────────────────────────────────────────

--- a/core-playback/src/main/kotlin/in/jphe/storyvox/playback/PlaybackController.kt
+++ b/core-playback/src/main/kotlin/in/jphe/storyvox/playback/PlaybackController.kt
@@ -526,7 +526,7 @@ class DefaultPlaybackController @Inject constructor(
                         android.util.Log.w(
                             "PlaybackController",
                             "#553/#726 watchdog: isBuffering stuck on $armedFor for " +
-                                "${BUFFERING_STUCK_WATCHDOG_MS}ms; firing fallback advance " +
+                                "${threshold}ms; firing fallback advance " +
                                 "direction=$watchdogDir (in-flight=${p.inFlightAdvanceDirection})",
                         )
                         // #553 follow-up — Media3's Player object is

--- a/core-playback/src/main/kotlin/in/jphe/storyvox/playback/tts/SystemTtsEngine.kt
+++ b/core-playback/src/main/kotlin/in/jphe/storyvox/playback/tts/SystemTtsEngine.kt
@@ -227,10 +227,13 @@ class SystemTtsEngine(
         // well outside the healthy band and matches the buffering
         // watchdog window in PlaybackController so upstream's
         // AudioOutputStuck recovery kicks in at the same horizon.
-        val ok = withTimeoutOrNull(SYNTH_TIMEOUT_MS) { deferred.await() }
+        val ok = try {
+            withTimeoutOrNull(SYNTH_TIMEOUT_MS) { deferred.await() }
+        } finally {
+            pending.remove(utteranceId)
+        }
         if (ok == null) {
             Log.w(TAG, "synth timed out after ${SYNTH_TIMEOUT_MS}ms text.len=${text.length}")
-            pending.remove(utteranceId)
             runCatching { outFile.delete() }
             return@withContext null
         }

--- a/core-sync/src/main/kotlin/in/jphe/storyvox/sync/SyncIds.kt
+++ b/core-sync/src/main/kotlin/in/jphe/storyvox/sync/SyncIds.kt
@@ -4,5 +4,5 @@ import java.util.UUID
 
 object SyncIds {
     fun rowUuid(domain: String, userId: String): String =
-        UUID.nameUUIDFromBytes("$domain:$userId".toByteArray()).toString()
+        UUID.nameUUIDFromBytes("$domain:$userId".encodeToByteArray()).toString()
 }

--- a/feature/src/main/kotlin/in/jphe/storyvox/feature/browse/DynamicFilterSheet.kt
+++ b/feature/src/main/kotlin/in/jphe/storyvox/feature/browse/DynamicFilterSheet.kt
@@ -194,13 +194,14 @@ private fun TagSetSection(
     }
 
     if (dim.options.isNotEmpty()) {
-        val selected = dim.options.filter { it in included || it in excluded }
-        val unselected = dim.options.filter { it !in included && it !in excluded }
-        val filtered = if (searchable && query.isNotBlank()) {
+        val filtered = remember(dim.options, included, excluded, query) {
+            val (selected, unselected) = dim.options.partition { it in included || it in excluded }
             val q = query.trim()
-            selected + unselected.filter { it.contains(q, ignoreCase = true) }
-        } else {
-            selected + unselected
+            if (searchable && q.isNotEmpty()) {
+                selected + unselected.filter { it.contains(q, ignoreCase = true) }
+            } else {
+                selected + unselected
+            }
         }
 
         FlowRow(
@@ -245,6 +246,10 @@ private fun TagSetChip(
                 isIncluded && allowExclude -> {
                     newIncluded = included - tag
                     newExcluded = excluded + tag
+                }
+                isIncluded -> {
+                    newIncluded = included - tag
+                    newExcluded = excluded
                 }
                 isExcluded -> {
                     newIncluded = included
@@ -396,7 +401,7 @@ private fun TextSection(
         value = value,
         onValueChange = { text ->
             if (text.isBlank()) onChange(state.without(dim.key))
-            else onChange(state.with(dim.key, FilterValue.StringVal(text.trim())))
+            else onChange(state.with(dim.key, FilterValue.StringVal(text)))
         },
         placeholder = if (dim.placeholder.isNotEmpty()) {
             { Text(dim.placeholder, style = MaterialTheme.typography.bodyMedium) }

--- a/feature/src/main/kotlin/in/jphe/storyvox/feature/settings/AccountSettingsScreen.kt
+++ b/feature/src/main/kotlin/in/jphe/storyvox/feature/settings/AccountSettingsScreen.kt
@@ -17,6 +17,9 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.foundation.text.KeyboardOptions
+import androidx.compose.ui.text.input.ImeAction
+import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.text.input.PasswordVisualTransformation
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
@@ -223,6 +226,11 @@ private fun PassphraseEntry(
             label = { Text("Sync passphrase") },
             placeholder = { Text("Enter a passphrase for secrets sync") },
             visualTransformation = PasswordVisualTransformation(),
+            keyboardOptions = KeyboardOptions(
+                keyboardType = KeyboardType.Password,
+                autoCorrectEnabled = false,
+                imeAction = ImeAction.Done,
+            ),
             singleLine = true,
             modifier = Modifier.fillMaxWidth(),
         )

--- a/source-ao3/src/main/kotlin/in/jphe/storyvox/source/ao3/auth/Ao3AuthWebView.kt
+++ b/source-ao3/src/main/kotlin/in/jphe/storyvox/source/ao3/auth/Ao3AuthWebView.kt
@@ -57,8 +57,9 @@ fun Ao3AuthWebView(
     // why `canGoBack()` is read inside the BackHandler `enabled`
     // lambda rather than snapshotted into Compose state.
     var webView: WebView? by remember { mutableStateOf(null) }
+    var canGoBack by remember { mutableStateOf(false) }
 
-    BackHandler(enabled = webView?.canGoBack() == true) {
+    BackHandler(enabled = canGoBack) {
         webView?.goBack()
     }
 
@@ -94,6 +95,7 @@ fun Ao3AuthWebView(
 
                     override fun onPageFinished(view: WebView?, url: String?) {
                         super.onPageFinished(view, url)
+                        canGoBack = view?.canGoBack() == true
                         tryCapture(url)
                     }
 

--- a/source-ao3/src/main/kotlin/in/jphe/storyvox/source/ao3/auth/Ao3AuthWebView.kt
+++ b/source-ao3/src/main/kotlin/in/jphe/storyvox/source/ao3/auth/Ao3AuthWebView.kt
@@ -61,6 +61,7 @@ fun Ao3AuthWebView(
 
     BackHandler(enabled = canGoBack) {
         webView?.goBack()
+        canGoBack = webView?.canGoBack() == true
     }
 
     AndroidView(

--- a/source-ao3/src/main/kotlin/in/jphe/storyvox/source/ao3/net/Ao3Api.kt
+++ b/source-ao3/src/main/kotlin/in/jphe/storyvox/source/ao3/net/Ao3Api.kt
@@ -343,7 +343,7 @@ internal class Ao3Api @Inject constructor(
          * in unit tests.
          */
         internal fun searchPath(query: String, page: Int = 1): String {
-            val encoded = java.net.URLEncoder.encode(query, Charsets.UTF_8)
+            val encoded = java.net.URLEncoder.encode(query, "UTF-8")
             return if (page <= 1) {
                 "/works/search?work_search%5Bquery%5D=$encoded"
             } else {

--- a/source-royalroad/src/main/kotlin/in/jphe/storyvox/source/royalroad/auth/RoyalRoadAuthWebView.kt
+++ b/source-royalroad/src/main/kotlin/in/jphe/storyvox/source/royalroad/auth/RoyalRoadAuthWebView.kt
@@ -45,8 +45,9 @@ fun RoyalRoadAuthWebView(
     // which is the behavior we want. A null guard covers the brief
     // moment before AndroidView's factory has run.
     var webView: WebView? by remember { mutableStateOf(null) }
+    var canGoBack by remember { mutableStateOf(false) }
 
-    BackHandler(enabled = webView?.canGoBack() == true) {
+    BackHandler(enabled = canGoBack) {
         webView?.goBack()
     }
 
@@ -84,6 +85,7 @@ fun RoyalRoadAuthWebView(
 
                     override fun onPageFinished(view: WebView?, url: String?) {
                         super.onPageFinished(view, url)
+                        canGoBack = view?.canGoBack() == true
                         tryCapture()
                     }
 

--- a/source-royalroad/src/main/kotlin/in/jphe/storyvox/source/royalroad/auth/RoyalRoadAuthWebView.kt
+++ b/source-royalroad/src/main/kotlin/in/jphe/storyvox/source/royalroad/auth/RoyalRoadAuthWebView.kt
@@ -49,6 +49,7 @@ fun RoyalRoadAuthWebView(
 
     BackHandler(enabled = canGoBack) {
         webView?.goBack()
+        canGoBack = webView?.canGoBack() == true
     }
 
     AndroidView(


### PR DESCRIPTION
## Summary
- Audited all Gemini Code Assist review comments across PRs #723–#768 (15 PRs with findings)
- Fixed 5 HIGH-priority bugs (real crashes/incorrect behavior) and 5 MEDIUM hardening items
- 10 files changed across 7 modules

## HIGH fixes (bugs)
- **DynamicFilterSheet**: tag unselect got stuck when `allowExclude=false` — missing cycle branch
- **Ao3Api**: `URLEncoder.encode(String, Charset)` crashes on API < 33 — use `(String, String)` overload
- **DynamicFilterSheet TextSection**: `trim()` on keystroke erased trailing spaces while typing
- **Ao3/RoyalRoad AuthWebView**: `BackHandler(enabled = webView?.canGoBack())` never re-evaluated — imperative `canGoBack()` doesn't trigger Compose recomposition; added `var canGoBack by mutableStateOf`
- **SystemTtsEngine**: `pending` map leaked utteranceId on coroutine cancellation — wrapped `withTimeoutOrNull` in `try-finally`

## MEDIUM fixes (hardening)
- **PassphraseStore.isSet()**: `contains(key)` avoids EncryptedSharedPreferences decryption overhead
- **AccountSettingsScreen passphrase**: `KeyboardType.Password` + `autoCorrectEnabled=false` + `ImeAction.Done`
- **SyncIds**: `encodeToByteArray()` for explicit UTF-8 (vs platform-default `toByteArray()`)
- **PlaybackController watchdog log**: used `threshold` variable instead of hardcoded constant name
- **FictionRepository**: safety cap (200 pages) on unbounded `while(true)` follows pagination

## Triaged as non-issues
- `advanceChapter` race (finally block correctly always resets to 0)
- `parseGutenbergId` substringAfter (functionally equivalent to startsWith+removePrefix with the missingDelimiterValue guard)
- `GitHubSource.scanUserBooksRepos` (already handles rate-limit via `probeForBookManifest` null → break)
- `setSourceFavorite` stampSyncedWrite (unconditional stamp is by design per kdoc)

## Test plan
- [x] `./gradlew :app:compileDebugKotlin :feature:compileDebugKotlin :core-data:compileDebugKotlin :core-playback:compileDebugKotlin :core-sync:compileDebugKotlin :source-ao3:compileDebugKotlin :source-royalroad:compileDebugKotlin` — clean
- [x] `./gradlew :core-sync:testDebugUnitTest :core-data:testDebugUnitTest :source-ao3:testDebugUnitTest :feature:testDebugUnitTest` — all pass
- [ ] Install on tablet + phone, verify browse filters, auth WebView back navigation, TTS playback

🤖 Generated with [Claude Code](https://claude.com/claude-code)