### PR TITLE
feat(notion): split into TechEmpower + PAT source plugins

### DIFF
--- a/app/src/main/kotlin/in/jphe/storyvox/data/SettingsRepositoryUiImpl.kt
+++ b/app/src/main/kotlin/in/jphe/storyvox/data/SettingsRepositoryUiImpl.kt
@@ -346,6 +346,12 @@ internal object LegacySourceKeys {
             Spec(booleanPreferencesKey("pref_source_radio_enabled"), defaultValue = true),
         `in`.jphe.storyvox.data.source.SourceIds.KVMR to
             Spec(booleanPreferencesKey("pref_source_kvmr_enabled"), defaultValue = true),
+        `in`.jphe.storyvox.data.source.SourceIds.NOTION_TECHEMPOWER to
+            Spec(booleanPreferencesKey("pref_source_notion_techempower_enabled"), defaultValue = true),
+        `in`.jphe.storyvox.data.source.SourceIds.NOTION_PAT to
+            Spec(booleanPreferencesKey("pref_source_notion_pat_enabled"), defaultValue = false),
+        // Legacy alias — one migration cycle so persisted enabled-state
+        // for the old "notion" source survives.
         `in`.jphe.storyvox.data.source.SourceIds.NOTION to
             Spec(booleanPreferencesKey("pref_source_notion_enabled"), defaultValue = true),
         `in`.jphe.storyvox.data.source.SourceIds.HACKERNEWS to

--- a/app/src/test/kotlin/in/jphe/storyvox/data/SettingsRepositorySourcePluginsTest.kt
+++ b/app/src/test/kotlin/in/jphe/storyvox/data/SettingsRepositorySourcePluginsTest.kt
@@ -101,12 +101,15 @@ class SettingsRepositorySourcePluginsTest {
             // migration alias and stays in the round-trip set so the
             // dual-key persistence shape is exercised.
             SourceIds.RADIO, SourceIds.KVMR,
-            SourceIds.NOTION, SourceIds.HACKERNEWS, SourceIds.ARXIV,
+            // Issue #770 — split NOTION into TECHEMPOWER + PAT.
+            // Legacy NOTION alias is kept for one migration cycle.
+            SourceIds.NOTION_TECHEMPOWER, SourceIds.NOTION_PAT, SourceIds.NOTION,
+            SourceIds.HACKERNEWS, SourceIds.ARXIV,
             SourceIds.PLOS, SourceIds.DISCORD,
             // #462 — Telegram backend.
             SourceIds.TELEGRAM,
         )
-        assertEquals(19, allIds.size)
+        assertEquals(21, allIds.size)
 
         // Toggle each off then on, in order — verify both states
         // land in the persisted map.
@@ -200,7 +203,9 @@ class SettingsRepositorySourcePluginsTest {
             SourceIds.RSS, SourceIds.EPUB, SourceIds.OUTLINE,
             SourceIds.GUTENBERG, SourceIds.AO3, SourceIds.STANDARD_EBOOKS,
             SourceIds.WIKIPEDIA, SourceIds.WIKISOURCE,
-            SourceIds.RADIO, SourceIds.KVMR, SourceIds.NOTION,
+            SourceIds.RADIO, SourceIds.KVMR,
+            // Issue #770 — split NOTION into TECHEMPOWER + PAT.
+            SourceIds.NOTION_TECHEMPOWER, SourceIds.NOTION,
             SourceIds.HACKERNEWS, SourceIds.ARXIV, SourceIds.PLOS,
             SourceIds.DISCORD,
             // #462 — Telegram backend defaults ON for fresh-install
@@ -217,6 +222,12 @@ class SettingsRepositorySourcePluginsTest {
                 snapshot[id],
             )
         }
+        // NOTION_PAT defaults OFF — private workspace requires token setup.
+        assertEquals(
+            "Fresh install should disable NOTION_PAT by default",
+            false,
+            snapshot[SourceIds.NOTION_PAT],
+        )
     }
 
     @Test
@@ -247,14 +258,14 @@ class SettingsRepositorySourcePluginsTest {
 
     @Test
     fun `independent toggles do not affect each other`() = runTest {
-        repo.setSourcePluginEnabled(SourceIds.NOTION, enabled = false)
+        repo.setSourcePluginEnabled(SourceIds.NOTION_PAT, enabled = false)
         repo.setSourcePluginEnabled(SourceIds.WIKIPEDIA, enabled = true)
         val snapshot = repo.settings.first().sourcePluginsEnabled
 
-        assertEquals(false, snapshot[SourceIds.NOTION])
+        assertEquals(false, snapshot[SourceIds.NOTION_PAT])
         assertEquals(true, snapshot[SourceIds.WIKIPEDIA])
         // No cross-contamination — these are two independent keys.
-        assertTrue(snapshot.containsKey(SourceIds.NOTION))
+        assertTrue(snapshot.containsKey(SourceIds.NOTION_PAT))
         assertTrue(snapshot.containsKey(SourceIds.WIKIPEDIA))
     }
 }

--- a/core-data/src/main/kotlin/in/jphe/storyvox/data/source/SourceIds.kt
+++ b/core-data/src/main/kotlin/in/jphe/storyvox/data/source/SourceIds.kt
@@ -101,8 +101,25 @@ object SourceIds {
      *  Integration Token (PAT). Default database id points at the
      *  techempower.org content database (#390) so a fresh install
      *  surfaces TechEmpower content without configuration once the
-     *  user supplies the integration token. */
+     *  user supplies the integration token.
+     *
+     *  Legacy alias — kept across one migration cycle so persisted
+     *  fictions with `sourceId = "notion"` (pre-split) continue to
+     *  resolve. Routes to [NOTION_TECHEMPOWER] via the Hilt FictionSource
+     *  map binding. */
     const val NOTION: String = "notion"
+
+    /** TechEmpower anonymous Notion reader (#770) — public TechEmpower
+     *  guides, resources, and about pages via the unofficial Notion API.
+     *  Default ON. No token required. Split from the old dual-mode
+     *  [NOTION] source into a dedicated `@SourcePlugin`. */
+    const val NOTION_TECHEMPOWER: String = "notion-techempower"
+
+    /** Private Notion workspace via PAT (#770) — user's own Notion
+     *  databases via an Internal Integration Token. Default OFF.
+     *  Split from the old dual-mode [NOTION] source into a dedicated
+     *  `@SourcePlugin`. */
+    const val NOTION_PAT: String = "notion-pat"
     /** Hacker News (#379) — front-page stories + Ask HN / Show HN +
      *  Algolia-backed search. Each story = one fiction with exactly
      *  one chapter ("listen to one HN thread as an episode"). Free,

--- a/core-data/src/main/kotlin/in/jphe/storyvox/data/source/plugin/SourcePluginRegistry.kt
+++ b/core-data/src/main/kotlin/in/jphe/storyvox/data/source/plugin/SourcePluginRegistry.kt
@@ -52,7 +52,7 @@ class SourcePluginRegistry @Inject constructor(
      *  list order doesn't churn. */
     val all: List<SourcePluginDescriptor> = descriptors
         .sortedWith(
-            compareBy<SourcePluginDescriptor> { if (it.id == SourceIds.NOTION) 0 else 1 }
+            compareBy<SourcePluginDescriptor> { if (it.id == SourceIds.NOTION_TECHEMPOWER) 0 else 1 }
                 .thenBy { it.category.ordinal }
                 .thenBy { it.displayName.lowercase() },
         )

--- a/core-data/src/test/kotlin/in/jphe/storyvox/data/source/plugin/SourcePluginRegistryTest.kt
+++ b/core-data/src/test/kotlin/in/jphe/storyvox/data/source/plugin/SourcePluginRegistryTest.kt
@@ -124,7 +124,11 @@ class SourcePluginRegistryTest {
             // in the FictionSource map binding, not in the descriptor
             // registry.
             SourceIds.RADIO,
-            SourceIds.NOTION,
+            // Issue #770 — split NotionSource into TechEmpower + PAT.
+            // The legacy NOTION id survives as a routing alias in the
+            // FictionSource map binding, not in the descriptor registry.
+            SourceIds.NOTION_TECHEMPOWER,
+            SourceIds.NOTION_PAT,
         )
         val descriptors = expectedIds.map { id ->
             descriptor(
@@ -136,7 +140,7 @@ class SourcePluginRegistryTest {
 
         val registry = SourcePluginRegistry(descriptors.toSet())
 
-        assertEquals(12, registry.all.size)
+        assertEquals(13, registry.all.size)
         // Every expected id resolves via byId — order-independent so
         // the assertion stays robust against future sort changes.
         for (id in expectedIds) {

--- a/feature/src/main/kotlin/in/jphe/storyvox/feature/api/UiContracts.kt
+++ b/feature/src/main/kotlin/in/jphe/storyvox/feature/api/UiContracts.kt
@@ -858,7 +858,7 @@ data class UiSettings(
     val telegramTokenConfigured: Boolean = false,
     /**
      * Plugin-seam Phase 3 (#384) — per-plugin on/off keyed by stable
-     * plugin id ("kvmr", "royalroad", "notion", ...). Single source of
+     * plugin id ("kvmr", "royalroad", "notion-techempower", ...). Single source of
      * truth as of v0.5.31: the deleted Phase 1/2 hand-rolled
      * `sourceXxxEnabled` fields have all collapsed into this map.
      *

--- a/feature/src/main/kotlin/in/jphe/storyvox/feature/browse/BrowseScreen.kt
+++ b/feature/src/main/kotlin/in/jphe/storyvox/feature/browse/BrowseScreen.kt
@@ -329,7 +329,7 @@ fun BrowseScreen(
         // "Notion" → TechEmpower cards and conclude the source is
         // broken / mis-wired. JP design (issue comment): keep the
         // fallback, add a clear demo label + a Settings deep-link.
-        if (state.sourceId == SourceIds.NOTION && state.notionAnonymousActive) {
+        if (state.sourceId == SourceIds.NOTION_TECHEMPOWER && state.notionAnonymousActive) {
             NotionDemoBanner(onOpenSettings = onOpenSettings)
         }
 

--- a/feature/src/main/kotlin/in/jphe/storyvox/feature/browse/BrowseSourceCarousel.kt
+++ b/feature/src/main/kotlin/in/jphe/storyvox/feature/browse/BrowseSourceCarousel.kt
@@ -540,7 +540,8 @@ private fun sourceTagline(id: String): String {
         SourceIds.OUTLINE -> R.string.source_tagline_outline
         SourceIds.MEMPALACE -> R.string.source_tagline_mempalace
         SourceIds.RADIO, SourceIds.KVMR -> R.string.source_tagline_radio
-        SourceIds.NOTION -> R.string.source_tagline_notion
+        SourceIds.NOTION_TECHEMPOWER -> R.string.source_tagline_techempower
+        SourceIds.NOTION_PAT -> R.string.source_tagline_notion
         SourceIds.HACKERNEWS -> R.string.source_tagline_hackernews
         SourceIds.ARXIV -> R.string.source_tagline_arxiv
         SourceIds.PLOS -> R.string.source_tagline_plos
@@ -575,7 +576,8 @@ private fun sourceGlyph(id: String): ImageVector = when (id) {
     SourceIds.OUTLINE -> Icons.Filled.Description
     SourceIds.MEMPALACE -> Icons.Filled.LocalLibrary
     SourceIds.RADIO, SourceIds.KVMR -> Icons.Filled.Radio
-    SourceIds.NOTION -> Icons.Filled.Description
+    SourceIds.NOTION_TECHEMPOWER -> Icons.Filled.Bolt
+    SourceIds.NOTION_PAT -> Icons.Filled.Description
     SourceIds.HACKERNEWS -> Icons.Filled.Bolt
     SourceIds.ARXIV -> Icons.Filled.Science
     SourceIds.PLOS -> Icons.Filled.Science

--- a/feature/src/main/kotlin/in/jphe/storyvox/feature/browse/BrowseSourceUi.kt
+++ b/feature/src/main/kotlin/in/jphe/storyvox/feature/browse/BrowseSourceUi.kt
@@ -52,7 +52,8 @@ internal object BrowseSourceUi {
         // any code path still resolving through it stays consistent.
         SourceIds.RADIO -> "Radio"
         SourceIds.KVMR -> "Radio"
-        SourceIds.NOTION -> "Notion"
+        SourceIds.NOTION_TECHEMPOWER -> "TechEmpower"
+        SourceIds.NOTION_PAT -> "Notion"
         SourceIds.HACKERNEWS -> "Hacker News"
         SourceIds.ARXIV -> "arXiv"
         SourceIds.PLOS -> "PLOS"
@@ -149,7 +150,8 @@ internal object BrowseSourceUi {
         // Search tab anyway.
         SourceIds.RADIO -> listOf(BrowseTab.Popular, BrowseTab.Search)
         SourceIds.KVMR -> listOf(BrowseTab.Popular)
-        SourceIds.NOTION -> listOf(BrowseTab.Popular, BrowseTab.Search)
+        SourceIds.NOTION_TECHEMPOWER -> listOf(BrowseTab.Popular, BrowseTab.Search)
+        SourceIds.NOTION_PAT -> listOf(BrowseTab.Popular, BrowseTab.Search)
         SourceIds.HACKERNEWS -> listOf(BrowseTab.Popular, BrowseTab.Search)
         SourceIds.ARXIV -> listOf(BrowseTab.Popular, BrowseTab.Search)
         SourceIds.PLOS -> listOf(BrowseTab.Popular, BrowseTab.Search)
@@ -173,7 +175,8 @@ internal object BrowseSourceUi {
         // Issue #417 — Radio search drives the Radio Browser API.
         SourceIds.RADIO -> "Search Radio Browser — community, public, and college stations worldwide"
         SourceIds.KVMR -> "Tune in to KVMR — live community radio from Nevada City"
-        SourceIds.NOTION -> "Search your configured Notion database"
+        SourceIds.NOTION_TECHEMPOWER -> "Search TechEmpower guides & resources"
+        SourceIds.NOTION_PAT -> "Search your configured Notion database"
         SourceIds.HACKERNEWS -> "Search Hacker News stories (Algolia-backed full-text)"
         SourceIds.ARXIV -> "Search arXiv — open-access academic papers"
         SourceIds.PLOS -> "Search PLOS — open-access peer-reviewed science"

--- a/feature/src/main/kotlin/in/jphe/storyvox/feature/onboarding/OnboardingHost.kt
+++ b/feature/src/main/kotlin/in/jphe/storyvox/feature/onboarding/OnboardingHost.kt
@@ -257,7 +257,7 @@ class OnboardingHostViewModel @Inject constructor(
             //  1. Seed the local Fiction DAO with the Notion
             //     anonymous-mode source's "popular" tiles. This is
             //     what writes the `notion:guides` row into the DB
-            //     with the correct `sourceId="notion"`. Without it,
+            //     with the correct `sourceId="notion-techempower"`. Without it,
             //     [FictionRepository.refreshDetail] falls back to
             //     `SourceIds.ROYAL_ROAD` for an unknown row and the
             //     refresh silently fails — chapters never land. This
@@ -336,12 +336,13 @@ class OnboardingHostViewModel @Inject constructor(
         /**
          * Source id for the anonymous-mode Notion delegate that
          * serves the `notion:guides` fiction. Inline here (mirrors
-         * `SourceIds.NOTION` in :core-data) so the onboarding doesn't
-         * take a module dependency on `:core-data` just for one
-         * string constant. If `SourceIds.NOTION` ever moves to a
-         * different string, a one-grep audit catches this site.
+         * `SourceIds.NOTION_TECHEMPOWER` in :core-data) so the
+         * onboarding doesn't take a module dependency on `:core-data`
+         * just for one string constant. If `SourceIds.NOTION_TECHEMPOWER`
+         * ever moves to a different string, a one-grep audit catches
+         * this site.
          */
-        const val NOTION_SOURCE_ID: String = "notion"
+        const val NOTION_SOURCE_ID: String = "notion-techempower"
 
         /**
          * Upper bound on how long [openGuidesAndAutoPlay] waits for

--- a/feature/src/main/res/values/strings.xml
+++ b/feature/src/main/res/values/strings.xml
@@ -32,6 +32,7 @@
     <string name="source_tagline_outline">Your wiki</string>
     <string name="source_tagline_mempalace">Your palace</string>
     <string name="source_tagline_radio">Live radio</string>
+    <string name="source_tagline_techempower">Guides &amp; resources</string>
     <string name="source_tagline_notion">Your Notion</string>
     <string name="source_tagline_hackernews">Tech news</string>
     <string name="source_tagline_arxiv">Research papers</string>

--- a/feature/src/test/kotlin/in/jphe/storyvox/feature/browse/BrowseSourceUiTest.kt
+++ b/feature/src/test/kotlin/in/jphe/storyvox/feature/browse/BrowseSourceUiTest.kt
@@ -32,18 +32,21 @@ class BrowseSourceUiTest {
             // migration overlap.
             SourceIds.RADIO to "Radio",
             SourceIds.KVMR to "Radio",
-            SourceIds.NOTION to "Notion",
+            // Issue #770 — split NOTION into TECHEMPOWER + PAT.
+            SourceIds.NOTION_TECHEMPOWER to "TechEmpower",
+            SourceIds.NOTION_PAT to "Notion",
             SourceIds.HACKERNEWS to "Hacker News",
             SourceIds.ARXIV to "arXiv",
             SourceIds.PLOS to "PLOS",
             SourceIds.DISCORD to "Discord",
         )
 
-        // 18 = 11 catalog backends + Radio/Kvmr alias + Notion + HN +
-        // arXiv + PLOS + Discord. Slack and Telegram intentionally fall
-        // through to the registry's displayName (chip strip uses the
-        // same string as the Settings → Plugins label).
-        assertEquals(18, expected.size)
+        // 19 = 11 catalog backends + Radio/Kvmr alias +
+        // Notion TechEmpower + Notion PAT + HN + arXiv + PLOS + Discord.
+        // Slack and Telegram intentionally fall through to the registry's
+        // displayName (chip strip uses the same string as the Settings →
+        // Plugins label).
+        assertEquals(19, expected.size)
         for ((id, label) in expected) {
             assertEquals(
                 "Unexpected chip label for $id",
@@ -166,7 +169,9 @@ class BrowseSourceUiTest {
             // Issue #417 — RADIO is canonical; KVMR alias kept for
             // one cycle to cover persisted-id resolution.
             SourceIds.RADIO, SourceIds.KVMR,
-            SourceIds.NOTION, SourceIds.HACKERNEWS, SourceIds.ARXIV,
+            // Issue #770 — split NOTION into TECHEMPOWER + PAT.
+            SourceIds.NOTION_TECHEMPOWER, SourceIds.NOTION_PAT,
+            SourceIds.HACKERNEWS, SourceIds.ARXIV,
             SourceIds.PLOS, SourceIds.DISCORD,
             // Issue #695 — Slack/Telegram declare supportsSearch=false;
             // the smoke loops verify their tab list still includes

--- a/source-notion/src/main/kotlin/in/jphe/storyvox/source/notion/AnonymousNotionDelegate.kt
+++ b/source-notion/src/main/kotlin/in/jphe/storyvox/source/notion/AnonymousNotionDelegate.kt
@@ -256,7 +256,7 @@ internal class AnonymousNotionDelegate @Inject constructor(
         return fictions.map { fiction ->
             FictionSummary(
                 id = notionFictionId(fiction.id),
-                sourceId = SourceIds.NOTION,
+                sourceId = SourceIds.NOTION_TECHEMPOWER,
                 title = fiction.title,
                 author = "TechEmpower",
                 description = fiction.description,
@@ -325,7 +325,7 @@ internal class AnonymousNotionDelegate @Inject constructor(
         val cover = readCoverUrl(block) ?: readBodyImageUrl(root.recordMap, block)
         return FictionSummary(
             id = notionFictionId(compactRoot),
-            sourceId = SourceIds.NOTION,
+            sourceId = SourceIds.NOTION_TECHEMPOWER,
             title = title,
             author = "Notion",
             description = description,
@@ -353,7 +353,7 @@ internal class AnonymousNotionDelegate @Inject constructor(
         }
         val summary = FictionSummary(
             id = fictionId,
-            sourceId = SourceIds.NOTION,
+            sourceId = SourceIds.NOTION_TECHEMPOWER,
             title = fiction.title,
             author = "TechEmpower",
             description = fiction.description,
@@ -403,7 +403,7 @@ internal class AnonymousNotionDelegate @Inject constructor(
         }
         val summary = FictionSummary(
             id = fictionId,
-            sourceId = SourceIds.NOTION,
+            sourceId = SourceIds.NOTION_TECHEMPOWER,
             title = fiction.title,
             author = "TechEmpower",
             description = fiction.description,
@@ -430,7 +430,7 @@ internal class AnonymousNotionDelegate @Inject constructor(
         )
         val summary = FictionSummary(
             id = fictionId,
-            sourceId = SourceIds.NOTION,
+            sourceId = SourceIds.NOTION_TECHEMPOWER,
             title = fiction.title,
             author = "TechEmpower",
             description = fiction.description,

--- a/source-notion/src/main/kotlin/in/jphe/storyvox/source/notion/NotionHelpers.kt
+++ b/source-notion/src/main/kotlin/in/jphe/storyvox/source/notion/NotionHelpers.kt
@@ -1,24 +1,8 @@
 package `in`.jphe.storyvox.source.notion
 
-import `in`.jphe.storyvox.data.source.FictionSource
 import `in`.jphe.storyvox.data.source.SourceIds
-import `in`.jphe.storyvox.data.source.filter.FilterDimension
-import `in`.jphe.storyvox.data.source.filter.FilterState
-import `in`.jphe.storyvox.data.source.plugin.SourceCategory
-import `in`.jphe.storyvox.data.source.plugin.SourcePlugin
-import `in`.jphe.storyvox.data.source.model.ChapterContent
-import `in`.jphe.storyvox.data.source.model.ChapterInfo
-import `in`.jphe.storyvox.data.source.model.FictionDetail
-import `in`.jphe.storyvox.data.source.model.FictionResult
 import `in`.jphe.storyvox.data.source.model.FictionStatus
 import `in`.jphe.storyvox.data.source.model.FictionSummary
-import `in`.jphe.storyvox.data.source.model.ListPage
-import `in`.jphe.storyvox.data.source.model.SearchOrder
-import `in`.jphe.storyvox.data.source.model.SearchQuery
-import `in`.jphe.storyvox.data.source.model.map
-import `in`.jphe.storyvox.source.notion.config.NotionConfig
-import `in`.jphe.storyvox.source.notion.config.NotionMode
-import `in`.jphe.storyvox.source.notion.net.NotionApi
 import `in`.jphe.storyvox.source.notion.net.NotionBlock
 import `in`.jphe.storyvox.source.notion.net.NotionPage
 import kotlinx.serialization.json.JsonArray
@@ -28,266 +12,6 @@ import kotlinx.serialization.json.contentOrNull
 import kotlinx.serialization.json.jsonArray
 import kotlinx.serialization.json.jsonObject
 import kotlinx.serialization.json.jsonPrimitive
-import javax.inject.Inject
-import javax.inject.Singleton
-
-/**
- * Issue #233 — Notion as a fiction backend. Issue #390 — the bundled
- * default points at the techempower.org content database, so a fresh
- * install opens Browse → Notion and immediately surfaces TechEmpower
- * content as narratable audio.
- *
- * Data model:
- *  - One Notion **database** → the Browse catalog. Configured per-user.
- *  - Each **page** in the database → one [FictionSummary].
- *  - The page's top-level **blocks** split into chapters on every
- *    `heading_1` boundary. The lead (before the first `heading_1`) is
- *    chapter 0 / "Introduction" — same shape as `:source-wikipedia`,
- *    which makes long-form Notion docs behave like an article.
- *  - Sub-headings (`heading_2`, `heading_3`) and other blocks stay
- *    inline within their parent chapter's HTML so the chapter count
- *    stays sensible.
- *
- * Auth: PAT-based. Notion's REST API requires `Authorization: Bearer
- * <integration_token>` on every call — there is no anonymous tier and
- * Notion's "public share" pages don't expose a public REST surface.
- * Users supply an Internal Integration Token from
- * notion.so/my-integrations and share the database with that
- * integration. The token is stored encrypted in app config.
- *
- * Fiction IDs: `notion:<pageId-with-hyphens-stripped>`. Chapter IDs:
- * `notion:<pageId>::section-<index>` where `index` is the 0-based
- * heading-split section (0 = Introduction).
- */
-@SourcePlugin(
-    id = SourceIds.NOTION,
-    displayName = "Notion",
-    defaultEnabled = true,
-    category = SourceCategory.Text,
-    supportsFollow = false,
-    supportsSearch = true,
-    description = "Notion databases or public pages as fictions · anonymous reader by default · PAT for private workspaces",
-    sourceUrl = "https://www.notion.so",
-)
-@Singleton
-internal class NotionSource @Inject constructor(
-    private val api: NotionApi,
-    private val anonymous: AnonymousNotionDelegate,
-    private val config: NotionConfig,
-) : FictionSource, `in`.jphe.storyvox.data.source.UrlMatcher {
-
-    override val id: String = SourceIds.NOTION
-    override val displayName: String = "Notion"
-
-    /** Issue #472 — `*.notion.so/<workspace>/<slug-with-32-hex-id>` or
-     *  bare `notion.so/<32-hex-id>`. The pageId is the trailing 32-char
-     *  hex blob with hyphens stripped. */
-    override fun matchUrl(url: String): `in`.jphe.storyvox.data.source.RouteMatch? {
-        val m = NOTION_URL_PATTERN.matchEntire(url.trim()) ?: return null
-        val pageId = m.groupValues[1].replace("-", "")
-        return `in`.jphe.storyvox.data.source.RouteMatch(
-            sourceId = SourceIds.NOTION,
-            fictionId = "${SourceIds.NOTION}:$pageId",
-            confidence = 0.85f,
-            label = "Notion page",
-        )
-    }
-
-    override fun filterDimensions(): List<FilterDimension> = listOf(
-        FilterDimension.Sort(
-            options = listOf(
-                FilterDimension.SortOption("relevance", "Default"),
-                FilterDimension.SortOption("last_update", "Newest"),
-                FilterDimension.SortOption("title", "Title"),
-            ),
-        ),
-    )
-
-    override fun applyFilters(base: SearchQuery, state: FilterState): SearchQuery {
-        var q = base
-        state.stringVal("sort")?.let { sortId ->
-            q = q.copy(
-                orderBy = when (sortId) {
-                    "last_update" -> SearchOrder.LAST_UPDATE
-                    "title" -> SearchOrder.TITLE
-                    else -> SearchOrder.RELEVANCE
-                },
-            )
-        }
-        return q
-    }
-
-    // ─── browse ────────────────────────────────────────────────────────
-
-    override suspend fun popular(page: Int): FictionResult<ListPage<FictionSummary>> {
-        val state = config.current()
-        if (state.mode == NotionMode.ANONYMOUS_PUBLIC) {
-            return anonymous.popular(state, page)
-        }
-        // Notion paginates via opaque `start_cursor` strings, not integer
-        // page numbers. Our BrowsePaginator drives 1-indexed page numbers;
-        // we collapse "first call" = page 1 = cursor=null. Page 2+ from a
-        // cold start can't actually resolve the right cursor without
-        // having seen page 1's response, so storyvox's paginator always
-        // calls page 1 first and we forward the cursor through the
-        // ListPage.nextCursor seam (which doesn't exist today). For v1
-        // we surface the first 100 results only; pagination follow-up
-        // is a separate ticket.
-        //
-        // Notion's default sort = `last_edited_time` desc, which reads
-        // as "most-recently-updated" — perfect for Popular when the user
-        // is following an active content team's Notion DB.
-        if (page > 1) {
-            return FictionResult.Success(ListPage(items = emptyList(), page = page, hasNext = false))
-        }
-        return api.queryDatabase(cursor = null, pageSize = 100).map { list ->
-            ListPage(
-                items = list.results.mapNotNull { it.toSummary() },
-                page = 1,
-                hasNext = list.hasMore,
-            )
-        }
-    }
-
-    override suspend fun latestUpdates(page: Int): FictionResult<ListPage<FictionSummary>> =
-        // Same shape — Notion's default sort already orders by last
-        // edited time (descending), so "popular" and "new releases"
-        // resolve identically. If we ever want a separate Popular
-        // ordering, we'd post a sort body to /databases/{id}/query;
-        // for v1 the two tabs are intentionally aligned.
-        popular(page)
-
-    override suspend fun byGenre(
-        genre: String,
-        page: Int,
-    ): FictionResult<ListPage<FictionSummary>> =
-        // Notion has no built-in genre faceting. Out of scope for v1;
-        // users can search by keyword instead.
-        FictionResult.Success(ListPage(items = emptyList(), page = 1, hasNext = false))
-
-    override suspend fun genres(): FictionResult<List<String>> =
-        FictionResult.Success(emptyList())
-
-    override suspend fun search(query: SearchQuery): FictionResult<ListPage<FictionSummary>> {
-        val state = config.current()
-        if (state.mode == NotionMode.ANONYMOUS_PUBLIC) {
-            return anonymous.search(state, query.term)
-        }
-        // v1 — client-side filter over the database's first 100 pages.
-        // Notion's /search endpoint exists but searches the user's whole
-        // workspace, not just the configured database; that's the wrong
-        // shape (storyvox is per-database, not per-workspace). A
-        // server-side filter via /databases/{id}/query with a `filter`
-        // body is the follow-up.
-        val term = query.term.trim().lowercase()
-        return api.queryDatabase(cursor = null, pageSize = 100).map { list ->
-            val items = list.results.mapNotNull { it.toSummary() }
-                .filter { summary ->
-                    term.isEmpty() ||
-                        summary.title.lowercase().contains(term) ||
-                        summary.description?.lowercase()?.contains(term) == true
-                }
-            ListPage(items = items, page = 1, hasNext = false)
-        }
-    }
-
-    // ─── detail ────────────────────────────────────────────────────────
-
-    override suspend fun fictionDetail(fictionId: String): FictionResult<FictionDetail> {
-        val state = config.current()
-        if (state.mode == NotionMode.ANONYMOUS_PUBLIC) {
-            return anonymous.fictionDetail(state, fictionId)
-        }
-        val pageId = fictionId.toPageId()
-            ?: return FictionResult.NotFound("Notion fiction id not recognized: $fictionId")
-        // Two-call pattern: page metadata + block children. Same shape
-        // as :source-wikipedia uses for summary + html.
-        val pageResult = api.page(pageId)
-        val page = when (pageResult) {
-            is FictionResult.Success -> pageResult.value
-            is FictionResult.Failure -> return pageResult
-        }
-        val blocksResult = api.pageBlocks(pageId)
-        val blocks = when (blocksResult) {
-            is FictionResult.Success -> blocksResult.value
-            is FictionResult.Failure -> return blocksResult
-        }
-        val sections = splitOnHeading1(blocks)
-        val chapters = sections.mapIndexed { idx, section ->
-            ChapterInfo(
-                id = chapterIdFor(fictionId, idx),
-                sourceChapterId = "section-$idx",
-                index = idx,
-                title = section.title,
-                publishedAt = null,
-            )
-        }
-        val summary = page.toSummary()?.copy(chapterCount = chapters.size)
-            ?: FictionSummary(
-                id = fictionId,
-                sourceId = SourceIds.NOTION,
-                title = "Untitled Notion page",
-                author = "Notion",
-                description = null,
-                status = FictionStatus.ONGOING,
-                chapterCount = chapters.size,
-            )
-        return FictionResult.Success(FictionDetail(summary = summary, chapters = chapters))
-    }
-
-    override suspend fun chapter(
-        fictionId: String,
-        chapterId: String,
-    ): FictionResult<ChapterContent> {
-        val state = config.current()
-        if (state.mode == NotionMode.ANONYMOUS_PUBLIC) {
-            return anonymous.chapter(state, fictionId, chapterId)
-        }
-        val pageId = fictionId.toPageId()
-            ?: return FictionResult.NotFound("Notion fiction id not recognized: $fictionId")
-        val sectionIndex = chapterId.substringAfterLast("::section-", "")
-            .toIntOrNull()
-            ?: return FictionResult.NotFound("Notion chapter id not recognized: $chapterId")
-        return when (val r = api.pageBlocks(pageId)) {
-            is FictionResult.Success -> {
-                val sections = splitOnHeading1(r.value)
-                val section = sections.getOrNull(sectionIndex)
-                    ?: return FictionResult.NotFound(
-                        "Section $sectionIndex not found in Notion page $pageId",
-                    )
-                val info = ChapterInfo(
-                    id = chapterId,
-                    sourceChapterId = "section-$sectionIndex",
-                    index = sectionIndex,
-                    title = section.title,
-                )
-                val html = section.blocks.joinToString("\n") { it.toHtml() }
-                val plain = section.blocks.joinToString("\n\n") { it.toPlainText() }
-                    .trim()
-                FictionResult.Success(
-                    ChapterContent(
-                        info = info,
-                        htmlBody = html,
-                        plainBody = plain,
-                    ),
-                )
-            }
-            is FictionResult.Failure -> r
-        }
-    }
-
-    // ─── auth-gated ─────────────────────────────────────────────────────
-
-    override suspend fun followsList(page: Int): FictionResult<ListPage<FictionSummary>> =
-        // Notion has no follow concept; the database membership IS the
-        // follow list. Browse → Notion serves the same purpose.
-        FictionResult.Success(ListPage(items = emptyList(), page = 1, hasNext = false))
-
-    override suspend fun setFollowed(
-        fictionId: String,
-        followed: Boolean,
-    ): FictionResult<Unit> = FictionResult.Success(Unit)
-}
 
 // ─── helpers ──────────────────────────────────────────────────────────
 
@@ -393,15 +117,19 @@ internal fun splitOnHeading1(blocks: List<NotionBlock>): List<NotionSection> {
  * scan the `properties` map for the first entry whose JSON shape
  * declares `"type": "title"`, then extract the rich-text array under
  * that property's `title` key.
+ *
+ * @param sourceId The [SourceIds] constant to stamp on the returned
+ *  summary — callers pass their own id so the split TechEmpower /
+ *  PAT sources each claim their own fictions.
  */
-internal fun NotionPage.toSummary(): FictionSummary? {
+internal fun NotionPage.toSummary(sourceId: String): FictionSummary? {
     val title = extractTitleProperty(properties) ?: return null
     if (title.isBlank()) return null
     val description = extractDescriptionProperty(properties)
     val coverUrl = cover?.let { it.external?.url?.ifBlank { null } ?: it.file?.url?.ifBlank { null } }
     return FictionSummary(
         id = notionFictionId(id),
-        sourceId = SourceIds.NOTION,
+        sourceId = sourceId,
         title = title,
         author = extractAuthorProperty(properties) ?: "Notion",
         description = description,

--- a/source-notion/src/main/kotlin/in/jphe/storyvox/source/notion/NotionPATSource.kt
+++ b/source-notion/src/main/kotlin/in/jphe/storyvox/source/notion/NotionPATSource.kt
@@ -1,0 +1,210 @@
+package `in`.jphe.storyvox.source.notion
+
+import `in`.jphe.storyvox.data.source.FictionSource
+import `in`.jphe.storyvox.data.source.SourceIds
+import `in`.jphe.storyvox.data.source.filter.FilterDimension
+import `in`.jphe.storyvox.data.source.filter.FilterState
+import `in`.jphe.storyvox.data.source.model.ChapterContent
+import `in`.jphe.storyvox.data.source.model.ChapterInfo
+import `in`.jphe.storyvox.data.source.model.FictionDetail
+import `in`.jphe.storyvox.data.source.model.FictionResult
+import `in`.jphe.storyvox.data.source.model.FictionStatus
+import `in`.jphe.storyvox.data.source.model.FictionSummary
+import `in`.jphe.storyvox.data.source.model.ListPage
+import `in`.jphe.storyvox.data.source.model.SearchOrder
+import `in`.jphe.storyvox.data.source.model.SearchQuery
+import `in`.jphe.storyvox.data.source.model.map
+import `in`.jphe.storyvox.data.source.plugin.SourceCategory
+import `in`.jphe.storyvox.data.source.plugin.SourcePlugin
+import `in`.jphe.storyvox.source.notion.config.NotionConfig
+import `in`.jphe.storyvox.source.notion.config.NotionMode
+import `in`.jphe.storyvox.source.notion.net.NotionApi
+import javax.inject.Inject
+import javax.inject.Singleton
+
+/**
+ * Issue #770 — private Notion workspace reader via PAT, split from the
+ * old dual-mode [NotionSource]. No anonymous-mode code paths at all.
+ *
+ * Users supply an Internal Integration Token from
+ * notion.so/my-integrations and share the database with that
+ * integration. The token is stored encrypted in app config.
+ */
+@SourcePlugin(
+    id = SourceIds.NOTION_PAT,
+    displayName = "Notion",
+    defaultEnabled = false,
+    category = SourceCategory.Text,
+    supportsFollow = false,
+    supportsSearch = true,
+    description = "Private Notion databases via Integration Token",
+    sourceUrl = "https://www.notion.so",
+)
+@Singleton
+internal class NotionPATSource @Inject constructor(
+    private val api: NotionApi,
+    private val config: NotionConfig,
+) : FictionSource {
+
+    override val id: String = SourceIds.NOTION_PAT
+    override val displayName: String = "Notion"
+
+    override fun filterDimensions(): List<FilterDimension> = listOf(
+        FilterDimension.Sort(
+            options = listOf(
+                FilterDimension.SortOption("relevance", "Default"),
+                FilterDimension.SortOption("last_update", "Newest"),
+                FilterDimension.SortOption("title", "Title"),
+            ),
+        ),
+    )
+
+    override fun applyFilters(base: SearchQuery, state: FilterState): SearchQuery {
+        var q = base
+        state.stringVal("sort")?.let { sortId ->
+            q = q.copy(
+                orderBy = when (sortId) {
+                    "last_update" -> SearchOrder.LAST_UPDATE
+                    "title" -> SearchOrder.TITLE
+                    else -> SearchOrder.RELEVANCE
+                },
+            )
+        }
+        return q
+    }
+
+    // ─── browse ────────────────────────────────────────────────────────
+
+    override suspend fun popular(page: Int): FictionResult<ListPage<FictionSummary>> {
+        val state = config.current()
+        if (state.mode != NotionMode.OFFICIAL_PAT || state.apiToken.isBlank()) {
+            // Not configured — no token supplied. Return empty.
+            return FictionResult.Success(ListPage(items = emptyList(), page = page, hasNext = false))
+        }
+        if (page > 1) {
+            return FictionResult.Success(ListPage(items = emptyList(), page = page, hasNext = false))
+        }
+        return api.queryDatabase(cursor = null, pageSize = 100).map { list ->
+            ListPage(
+                items = list.results.mapNotNull { it.toSummary(SourceIds.NOTION_PAT) },
+                page = 1,
+                hasNext = list.hasMore,
+            )
+        }
+    }
+
+    override suspend fun latestUpdates(page: Int): FictionResult<ListPage<FictionSummary>> =
+        popular(page)
+
+    override suspend fun byGenre(
+        genre: String,
+        page: Int,
+    ): FictionResult<ListPage<FictionSummary>> =
+        FictionResult.Success(ListPage(items = emptyList(), page = 1, hasNext = false))
+
+    override suspend fun genres(): FictionResult<List<String>> =
+        FictionResult.Success(emptyList())
+
+    override suspend fun search(query: SearchQuery): FictionResult<ListPage<FictionSummary>> {
+        val state = config.current()
+        if (state.mode != NotionMode.OFFICIAL_PAT || state.apiToken.isBlank()) {
+            return FictionResult.Success(ListPage(items = emptyList(), page = 1, hasNext = false))
+        }
+        val term = query.term.trim().lowercase()
+        return api.queryDatabase(cursor = null, pageSize = 100).map { list ->
+            val items = list.results.mapNotNull { it.toSummary(SourceIds.NOTION_PAT) }
+                .filter { summary ->
+                    term.isEmpty() ||
+                        summary.title.lowercase().contains(term) ||
+                        summary.description?.lowercase()?.contains(term) == true
+                }
+            ListPage(items = items, page = 1, hasNext = false)
+        }
+    }
+
+    // ─── detail ────────────────────────────────────────────────────────
+
+    override suspend fun fictionDetail(fictionId: String): FictionResult<FictionDetail> {
+        val pageId = fictionId.toPageId()
+            ?: return FictionResult.NotFound("Notion fiction id not recognized: $fictionId")
+        // Two-call pattern: page metadata + block children.
+        val pageResult = api.page(pageId)
+        val page = when (pageResult) {
+            is FictionResult.Success -> pageResult.value
+            is FictionResult.Failure -> return pageResult
+        }
+        val blocksResult = api.pageBlocks(pageId)
+        val blocks = when (blocksResult) {
+            is FictionResult.Success -> blocksResult.value
+            is FictionResult.Failure -> return blocksResult
+        }
+        val sections = splitOnHeading1(blocks)
+        val chapters = sections.mapIndexed { idx, section ->
+            ChapterInfo(
+                id = chapterIdFor(fictionId, idx),
+                sourceChapterId = "section-$idx",
+                index = idx,
+                title = section.title,
+                publishedAt = null,
+            )
+        }
+        val summary = page.toSummary(SourceIds.NOTION_PAT)?.copy(chapterCount = chapters.size)
+            ?: FictionSummary(
+                id = fictionId,
+                sourceId = SourceIds.NOTION_PAT,
+                title = "Untitled Notion page",
+                author = "Notion",
+                description = null,
+                status = FictionStatus.ONGOING,
+                chapterCount = chapters.size,
+            )
+        return FictionResult.Success(FictionDetail(summary = summary, chapters = chapters))
+    }
+
+    override suspend fun chapter(
+        fictionId: String,
+        chapterId: String,
+    ): FictionResult<ChapterContent> {
+        val pageId = fictionId.toPageId()
+            ?: return FictionResult.NotFound("Notion fiction id not recognized: $fictionId")
+        val sectionIndex = chapterId.substringAfterLast("::section-", "")
+            .toIntOrNull()
+            ?: return FictionResult.NotFound("Notion chapter id not recognized: $chapterId")
+        return when (val r = api.pageBlocks(pageId)) {
+            is FictionResult.Success -> {
+                val sections = splitOnHeading1(r.value)
+                val section = sections.getOrNull(sectionIndex)
+                    ?: return FictionResult.NotFound(
+                        "Section $sectionIndex not found in Notion page $pageId",
+                    )
+                val info = ChapterInfo(
+                    id = chapterId,
+                    sourceChapterId = "section-$sectionIndex",
+                    index = sectionIndex,
+                    title = section.title,
+                )
+                val html = section.blocks.joinToString("\n") { it.toHtml() }
+                val plain = section.blocks.joinToString("\n\n") { it.toPlainText() }
+                    .trim()
+                FictionResult.Success(
+                    ChapterContent(
+                        info = info,
+                        htmlBody = html,
+                        plainBody = plain,
+                    ),
+                )
+            }
+            is FictionResult.Failure -> r
+        }
+    }
+
+    // ─── auth-gated ─────────────────────────────────────────────────────
+
+    override suspend fun followsList(page: Int): FictionResult<ListPage<FictionSummary>> =
+        FictionResult.Success(ListPage(items = emptyList(), page = 1, hasNext = false))
+
+    override suspend fun setFollowed(
+        fictionId: String,
+        followed: Boolean,
+    ): FictionResult<Unit> = FictionResult.Success(Unit)
+}

--- a/source-notion/src/main/kotlin/in/jphe/storyvox/source/notion/NotionTechEmpowerSource.kt
+++ b/source-notion/src/main/kotlin/in/jphe/storyvox/source/notion/NotionTechEmpowerSource.kt
@@ -51,10 +51,9 @@ internal class NotionTechEmpowerSource @Inject constructor(
      *  hex blob with hyphens stripped. */
     override fun matchUrl(url: String): RouteMatch? {
         val m = NOTION_URL_PATTERN.matchEntire(url.trim()) ?: return null
-        val pageId = m.groupValues[1].replace("-", "")
         return RouteMatch(
             sourceId = SourceIds.NOTION_TECHEMPOWER,
-            fictionId = "${SourceIds.NOTION}:$pageId",
+            fictionId = notionFictionId(m.groupValues[1]),
             confidence = 0.85f,
             label = "Notion page",
         )

--- a/source-notion/src/main/kotlin/in/jphe/storyvox/source/notion/NotionTechEmpowerSource.kt
+++ b/source-notion/src/main/kotlin/in/jphe/storyvox/source/notion/NotionTechEmpowerSource.kt
@@ -1,0 +1,135 @@
+package `in`.jphe.storyvox.source.notion
+
+import `in`.jphe.storyvox.data.source.FictionSource
+import `in`.jphe.storyvox.data.source.RouteMatch
+import `in`.jphe.storyvox.data.source.SourceIds
+import `in`.jphe.storyvox.data.source.UrlMatcher
+import `in`.jphe.storyvox.data.source.filter.FilterDimension
+import `in`.jphe.storyvox.data.source.filter.FilterState
+import `in`.jphe.storyvox.data.source.model.ChapterContent
+import `in`.jphe.storyvox.data.source.model.FictionDetail
+import `in`.jphe.storyvox.data.source.model.FictionResult
+import `in`.jphe.storyvox.data.source.model.FictionSummary
+import `in`.jphe.storyvox.data.source.model.ListPage
+import `in`.jphe.storyvox.data.source.model.SearchOrder
+import `in`.jphe.storyvox.data.source.model.SearchQuery
+import `in`.jphe.storyvox.data.source.plugin.SourceCategory
+import `in`.jphe.storyvox.data.source.plugin.SourcePlugin
+import `in`.jphe.storyvox.source.notion.config.NotionConfig
+import javax.inject.Inject
+import javax.inject.Singleton
+
+/**
+ * Issue #770 — TechEmpower anonymous-mode Notion reader, split from the
+ * old dual-mode [NotionSource]. Delegates entirely to
+ * [AnonymousNotionDelegate] — no PAT-mode code paths at all.
+ *
+ * Surfaces TechEmpower guides, resources, and about pages via the
+ * unofficial Notion API, zero configuration required.
+ */
+@SourcePlugin(
+    id = SourceIds.NOTION_TECHEMPOWER,
+    displayName = "TechEmpower",
+    defaultEnabled = true,
+    category = SourceCategory.Text,
+    supportsFollow = false,
+    supportsSearch = true,
+    description = "TechEmpower guides, resources & about pages",
+    sourceUrl = "https://www.notion.so",
+)
+@Singleton
+internal class NotionTechEmpowerSource @Inject constructor(
+    private val anonymous: AnonymousNotionDelegate,
+    private val config: NotionConfig,
+) : FictionSource, UrlMatcher {
+
+    override val id: String = SourceIds.NOTION_TECHEMPOWER
+    override val displayName: String = "TechEmpower"
+
+    /** Issue #472 — `*.notion.so/<workspace>/<slug-with-32-hex-id>` or
+     *  bare `notion.so/<32-hex-id>`. The pageId is the trailing 32-char
+     *  hex blob with hyphens stripped. */
+    override fun matchUrl(url: String): RouteMatch? {
+        val m = NOTION_URL_PATTERN.matchEntire(url.trim()) ?: return null
+        val pageId = m.groupValues[1].replace("-", "")
+        return RouteMatch(
+            sourceId = SourceIds.NOTION_TECHEMPOWER,
+            fictionId = "${SourceIds.NOTION}:$pageId",
+            confidence = 0.85f,
+            label = "Notion page",
+        )
+    }
+
+    override fun filterDimensions(): List<FilterDimension> = listOf(
+        FilterDimension.Sort(
+            options = listOf(
+                FilterDimension.SortOption("relevance", "Default"),
+                FilterDimension.SortOption("last_update", "Newest"),
+                FilterDimension.SortOption("title", "Title"),
+            ),
+        ),
+    )
+
+    override fun applyFilters(base: SearchQuery, state: FilterState): SearchQuery {
+        var q = base
+        state.stringVal("sort")?.let { sortId ->
+            q = q.copy(
+                orderBy = when (sortId) {
+                    "last_update" -> SearchOrder.LAST_UPDATE
+                    "title" -> SearchOrder.TITLE
+                    else -> SearchOrder.RELEVANCE
+                },
+            )
+        }
+        return q
+    }
+
+    // ─── browse ────────────────────────────────────────────────────────
+
+    override suspend fun popular(page: Int): FictionResult<ListPage<FictionSummary>> {
+        val state = config.current()
+        return anonymous.popular(state, page)
+    }
+
+    override suspend fun latestUpdates(page: Int): FictionResult<ListPage<FictionSummary>> =
+        popular(page)
+
+    override suspend fun byGenre(
+        genre: String,
+        page: Int,
+    ): FictionResult<ListPage<FictionSummary>> =
+        FictionResult.Success(ListPage(items = emptyList(), page = 1, hasNext = false))
+
+    override suspend fun genres(): FictionResult<List<String>> =
+        FictionResult.Success(emptyList())
+
+    override suspend fun search(query: SearchQuery): FictionResult<ListPage<FictionSummary>> {
+        val state = config.current()
+        return anonymous.search(state, query.term)
+    }
+
+    // ─── detail ────────────────────────────────────────────────────────
+
+    override suspend fun fictionDetail(fictionId: String): FictionResult<FictionDetail> {
+        val state = config.current()
+        return anonymous.fictionDetail(state, fictionId)
+    }
+
+    override suspend fun chapter(
+        fictionId: String,
+        chapterId: String,
+    ): FictionResult<ChapterContent> {
+        val state = config.current()
+        return anonymous.chapter(state, fictionId, chapterId)
+    }
+
+    // ─── auth-gated ─────────────────────────────────────────────────────
+
+    override suspend fun followsList(page: Int): FictionResult<ListPage<FictionSummary>> =
+        FictionResult.Success(ListPage(items = emptyList(), page = 1, hasNext = false))
+
+    override suspend fun setFollowed(
+        fictionId: String,
+        followed: Boolean,
+    ): FictionResult<Unit> = FictionResult.Success(Unit)
+}

--- a/source-notion/src/main/kotlin/in/jphe/storyvox/source/notion/di/NotionModule.kt
+++ b/source-notion/src/main/kotlin/in/jphe/storyvox/source/notion/di/NotionModule.kt
@@ -12,7 +12,8 @@ import `in`.jphe.storyvox.data.repository.net.NetworkPatience
 import `in`.jphe.storyvox.data.repository.net.NetworkPatienceConfig
 import `in`.jphe.storyvox.data.source.FictionSource
 import `in`.jphe.storyvox.data.source.SourceIds
-import `in`.jphe.storyvox.source.notion.NotionSource
+import `in`.jphe.storyvox.source.notion.NotionPATSource
+import `in`.jphe.storyvox.source.notion.NotionTechEmpowerSource
 import kotlinx.coroutines.runBlocking
 import okhttp3.OkHttpClient
 import javax.inject.Qualifier
@@ -89,10 +90,11 @@ internal object NotionHttpModule {
 }
 
 /**
- * Issue #233 — contributes [NotionSource] into the multi-source
- * `Map<String, FictionSource>`. Adds a "Notion" entry to the
- * segmented source picker; persisted fictions with sourceId="notion"
- * route through this source.
+ * Issue #770 — contributes [NotionTechEmpowerSource] and
+ * [NotionPATSource] into the multi-source `Map<String, FictionSource>`.
+ * Legacy alias routes `SourceIds.NOTION` to the TechEmpower source
+ * so persisted fictions with `sourceId="notion"` continue to resolve
+ * across one migration cycle.
  */
 @Module
 @InstallIn(SingletonComponent::class)
@@ -101,6 +103,21 @@ internal abstract class NotionBindings {
     @Binds
     @Singleton
     @IntoMap
+    @StringKey(SourceIds.NOTION_TECHEMPOWER)
+    abstract fun bindTechEmpowerSource(impl: NotionTechEmpowerSource): FictionSource
+
+    @Binds
+    @Singleton
+    @IntoMap
+    @StringKey(SourceIds.NOTION_PAT)
+    abstract fun bindPATSource(impl: NotionPATSource): FictionSource
+
+    /** Legacy alias — one migration cycle. Persisted rows with
+     *  `sourceId = "notion"` route to the TechEmpower source so
+     *  library-shelf / playback-position survival is preserved. */
+    @Binds
+    @Singleton
+    @IntoMap
     @StringKey(SourceIds.NOTION)
-    abstract fun bindFictionSource(impl: NotionSource): FictionSource
+    abstract fun bindLegacySource(impl: NotionTechEmpowerSource): FictionSource
 }


### PR DESCRIPTION
## Summary
- Splits the dual-mode `NotionSource` into two independent `@SourcePlugin` classes: `NotionTechEmpowerSource` (`notion-techempower`, default ON) and `NotionPATSource` (`notion-pat`, default OFF)
- TechEmpower source delegates entirely to `AnonymousNotionDelegate` — zero configuration, surfaces guides/resources/about pages via unofficial API
- PAT source handles private workspace access via Integration Token only
- Legacy `sourceId="notion"` alias routes to TechEmpower for one migration cycle
- Helper functions extracted to `NotionHelpers.kt` shared by both sources

## Test plan
- [ ] `./gradlew :source-notion:compileDebugKotlin :feature:compileDebugKotlin :app:compileDebugKotlin :core-data:compileDebugKotlin` compiles clean
- [ ] `./gradlew testDebugUnitTest` — all tests pass
- [ ] Browse shows "TechEmpower" and "Notion" as separate source cards
- [ ] TechEmpower shows 4 tiles (Guides, Resources, About, Donate) without any configuration
- [ ] Notion (PAT) shows empty state when no token configured
- [ ] Settings → Notion config row only appears for PAT source
- [ ] Paste a notion.so URL → routes to TechEmpower source

🤖 Generated with [Claude Code](https://claude.com/claude-code)