### PR TITLE
fix(nav): Library tab no longer restores Reader drill-down

### DIFF
--- a/app/src/main/kotlin/in/jphe/storyvox/navigation/StoryvoxNavHost.kt
+++ b/app/src/main/kotlin/in/jphe/storyvox/navigation/StoryvoxNavHost.kt
@@ -468,12 +468,21 @@ private fun StoryvoxNavHostContent(
             // is popped, and restores it when the user returns. This is
             // the standard Compose bottom-nav pattern from the Now in
             // Android reference app and the official navigation docs.
+            //
+            // Library is the start destination and always lives at the
+            // bottom of the back stack — its NavBackStackEntry (and
+            // ViewModel / composable state) persist naturally. Using
+            // restoreState for Library would push saved drill-down
+            // routes (Reader, AudiobookView) back on top, so tapping
+            // "Library" after playing would land on the Reader instead
+            // of the Library grid. Disable restoreState for Library;
+            // other tabs restore normally.
             navController.navigate(target) {
                 popUpTo(StoryvoxRoutes.LIBRARY) {
                     saveState = true
                 }
                 launchSingleTop = true
-                restoreState = true
+                restoreState = target != StoryvoxRoutes.LIBRARY
             }
         }
     }


### PR DESCRIPTION
## Summary
- Tapping Library in the bottom bar/side rail while audio was playing navigated to the Reader instead of the Library grid
- Root cause: `restoreState = true` on tab switches restored saved drill-down routes (Reader/Audiobook) when returning to the Library tab
- Fix: disable `restoreState` for Library only — Library is the start destination and its state persists naturally via its `NavBackStackEntry`; other tabs still restore normally

## Test plan
- [ ] Start playback from Library → navigate to Browse → tap Library → should show Library grid (not Reader)
- [ ] Switch Browse → Settings → Browse → verify scroll position preserved (restoreState still works for non-Library tabs)
- [ ] Library sub-tabs (Library/Follows/Inbox/History) persist across tab switches

🤖 Generated with [Claude Code](https://claude.com/claude-code)