### PR TITLE
refactor(techempower): remove 988/911 emergency help UI, keep 211

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -18,18 +18,19 @@
     <uses-permission android:name="android.permission.POST_NOTIFICATIONS" />
     <uses-permission android:name="android.permission.RECEIVE_BOOT_COMPLETED" />
 
-    <!-- Issue #546 — telephony is OPTIONAL. The TechEmpower Emergency
-         Help card surfaces 988 / 211 / 911 dial affordances that only
-         work on devices with telephony hardware (phones, not WiFi-only
-         tablets). Marking `required="false"` keeps storyvox eligible
-         for install on tablets in the Play Store; the in-app
+    <!-- Issue #546 / #775 — telephony is OPTIONAL. The TechEmpower
+         "Call 211" card (and the matching top-app-bar phone icon)
+         dials only on devices with telephony hardware (phones, not
+         WiFi-only tablets). Marking `required="false"` keeps storyvox
+         eligible for install on tablets in the Play Store; the in-app
          [dialOrSurfaceFallback] helper probes
          PackageManager.FEATURE_TELEPHONY at runtime and surfaces a
          "this device can't make calls" dialog with copy-to-clipboard
          + web-fallback when telephony is absent (rather than letting
          ACTION_DIAL route the user to the AOSP contact picker — the
-         documented default fallback, and the wrong UX for a crisis
-         surface). -->
+         documented default fallback, and the wrong UX for the
+         help-line surface). 988 / 911 affordances were removed in
+         #775; 211 is the surviving dial path. -->
     <uses-feature
         android:name="android.hardware.telephony"
         android:required="false" />

--- a/core-data/src/main/kotlin/in/jphe/storyvox/data/TechEmpowerLinks.kt
+++ b/core-data/src/main/kotlin/in/jphe/storyvox/data/TechEmpowerLinks.kt
@@ -107,40 +107,15 @@ object TechEmpowerLinks {
      * assistance, utility assistance, mental health referrals.
      * Available in most of the US + Canada; the OS dialer handles
      * region availability gracefully (dials normally if local).
+     *
+     * Issue #775 — 988 (Suicide & Crisis Lifeline) and 911 (emergency
+     * dispatch) affordances were removed for the current app stage;
+     * they can be reinstated when the user base is large enough that
+     * a proper crisis-UX review with intervention experts is
+     * warranted. 211 stays because it's the everyday social-services
+     * line and aligns with TechEmpower's mission.
      */
     const val PRIMARY_HELP_NUMBER: String = "211"
-
-    /**
-     * Secondary helpline surfaced via long-press on the phone icon —
-     * the **988 Suicide & Crisis Lifeline**. We deliberately put 988
-     * on the long-press path rather than the primary tap so a user
-     * who needs the social-services line (the much-more-common case)
-     * doesn't have to scroll past a crisis-line option to reach it.
-     *
-     * Also surfaced as the *top* button on the TechEmpower Home
-     * Emergency Help card (issue #516) — the card is the discoverable
-     * companion to the hidden long-press affordance.
-     */
-    const val CRISIS_HELP_NUMBER: String = "988"
-
-    /**
-     * Issue #516 — **911 emergency dispatch**, surfaced ONLY on the
-     * TechEmpower Home Emergency Help card. Intentionally NOT on the
-     * top-app-bar phone icon: a stray tap on a top-bar shortcut that
-     * dials emergency services is the wrong UX (accidental misdials
-     * waste dispatch capacity). On the card surface, the user has
-     * already chosen "I'm looking at emergency numbers" — context-
-     * aware enough that a tap-to-dial affordance is appropriate.
-     *
-     * `ACTION_DIAL` (not `ACTION_CALL`) keeps storyvox out of the
-     * permission-requiring path; the user lands in the system dialer
-     * with `911` pre-filled and has to hit the green button to
-     * actually place the call.
-     *
-     * V1 is US-only. CA/UK/AU have different emergency numbers
-     * (999/000/etc.) — localisation is a v2 issue (see #516).
-     */
-    const val EMERGENCY_DISPATCH_NUMBER: String = "911"
 
     /**
      * Building a `tel:` URI for [Intent.ACTION_DIAL]. Returns a String

--- a/feature/src/main/kotlin/in/jphe/storyvox/feature/library/LibraryScreen.kt
+++ b/feature/src/main/kotlin/in/jphe/storyvox/feature/library/LibraryScreen.kt
@@ -181,12 +181,12 @@ fun LibraryScreen(
                     // grouped action icons without bumping the row past
                     // Flip3 width.
                     //
-                    // Issue #517 — TechEmpower help icons (phone +
-                    // Discord) — leftmost so the cross-cutting "I
-                    // need help" affordances read before the
-                    // engine-specific cloud-icon.
-                    // Phone is tap = 211, long-press = 988; Discord
-                    // opens the peer-support invite URL. See
+                    // Issue #517 / #775 — TechEmpower help icons
+                    // (phone for 211, forum for Discord) — leftmost so
+                    // the cross-cutting "I need help" affordances read
+                    // before the engine-specific cloud-icon. Phone is
+                    // a direct tap to 211; Discord opens the
+                    // peer-support invite URL. See
                     // [TechEmpowerHelpIcons] for the design rationale.
                     TechEmpowerHelpIcons()
                     Spacer(Modifier.width(spacing.xs))

--- a/feature/src/main/kotlin/in/jphe/storyvox/feature/techempower/TechEmpowerHelpIcons.kt
+++ b/feature/src/main/kotlin/in/jphe/storyvox/feature/techempower/TechEmpowerHelpIcons.kt
@@ -7,7 +7,6 @@ import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Forum
-import androidx.compose.material.icons.filled.MonitorHeart
 import androidx.compose.material.icons.filled.Phone
 import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
@@ -23,24 +22,17 @@ import androidx.compose.ui.semantics.Role
 import androidx.compose.ui.unit.dp
 
 /**
- * Issue #517 + #608 — brass-tinted help icons (988 + 211 + Discord)
- * surfaced in the top-app-bar on Library and TechEmpower Home. Three
- * single-tap affordances for "I need help right now". JP's design call
- * locks 988 (Suicide & Crisis Lifeline), 211 (social services), and
- * Discord (peer-support) as the always-on entry points.
+ * Issue #517 + #608 — brass-tinted help icons (211 + Discord) surfaced
+ * in the top-app-bar on Library and TechEmpower Home. Two single-tap
+ * affordances for "I need help right now": 211 (social services) and
+ * Discord (peer-support).
  *
- * Why three separate icons and not "tap = 211, long-press = 988":
- * Issue #608 — TalkBack users cannot reliably trigger the long-press
- * gesture (Android's "double-tap and hold" is non-obvious and
- * error-prone), so a sight-impaired user in crisis previously had no
- * one-shot path to 988 from the top-app-bar. Splitting 988 into its
- * own tappable icon — with an explicit `contentDescription` —
- * gives every user (sighted + screen-reader) the same single-gesture
- * affordance. Long-press is gone entirely; the Emergency Help card on
- * Library home exposes the same numbers for users who prefer that
- * surface.
+ * Issue #775 — the 988 (Suicide & Crisis Lifeline) icon that used to
+ * lead this row was removed for the current app stage; it can be
+ * reinstated when the user base is large enough to warrant a proper
+ * crisis-UX review with intervention experts.
  *
- * Why a shared composable: the icon trio appears identically on both
+ * Why a shared composable: the icon pair appears identically on both
  * surfaces (Library + TechEmpower Home), and centralising the layout
  * + intent wiring means a behavioural change is a one-file edit
  * instead of keeping two copies in sync.
@@ -57,60 +49,16 @@ import androidx.compose.ui.unit.dp
  *
  * v0.5.51 — first pass alongside the TechEmpower brand integration.
  * v0.5.61 — split 988 into its own icon (#608, TalkBack safety).
+ * Issue #775 — 988 icon removed.
  */
 @Composable
 fun TechEmpowerHelpIcons() {
     val context = LocalContext.current
 
-    // Issue #546 — fallback dialog state for any helpline tapped on a
-    // device without telephony. Shared across all three direct-dial
-    // entry points (988 icon, 211 icon — and any future additions)
-    // because they all route through [dialOrSurfaceFallback]. The
-    // Discord icon is non-telephony so it bypasses this state.
+    // Issue #546 — fallback dialog state for the 211 helpline tap on a
+    // device without telephony. The Discord icon is non-telephony so
+    // it bypasses this state.
     var noTelephonyTarget by remember { mutableStateOf<EmergencyTarget?>(null) }
-
-    // ─── Call 988 — Suicide & Crisis Lifeline ────────────────────────
-    // Issue #608 — TalkBack-safe direct tap. Previously this number
-    // was hidden behind a long-press on the 211 icon, which TalkBack
-    // users could not reliably trigger. Now it is its own 48dp icon
-    // with an explicit content description so screen-reader users
-    // hear "Call 988, Suicide and Crisis Lifeline" on swipe and can
-    // reach it with a single double-tap.
-    //
-    // MonitorHeart is the closest M3 stock glyph to a "crisis /
-    // health-line" affordance — a heart with a pulse waveform reads
-    // as medical-urgency in a way the plain Phone icon does not.
-    // Tinted brass like every other top-bar action so the colour
-    // pairs with the brass-on-warm-dark palette.
-    Box(
-        modifier = Modifier
-            .size(48.dp)
-            .clickable(
-                role = Role.Button,
-                onClick = {
-                    dialOrSurfaceFallback(
-                        context = context,
-                        target = EmergencyTarget.Crisis988,
-                        onNoTelephony = { noTelephonyTarget = it },
-                    )
-                },
-            ),
-        contentAlignment = Alignment.Center,
-    ) {
-        Icon(
-            imageVector = Icons.Filled.MonitorHeart,
-            contentDescription = "Call 988, Suicide and Crisis Lifeline.",
-            tint = MaterialTheme.colorScheme.primary,
-            modifier = Modifier.size(24.dp),
-        )
-    }
-
-    // Issue #533 — 8dp gap between icons. The 48dp Boxes pack flush
-    // together otherwise, making mis-taps trivial on the Flip3
-    // (1080dp narrow). The Spacer keeps each icon at its full 48dp
-    // tap target while giving the user enough visual + finger
-    // separation to choose one deliberately.
-    Spacer(Modifier.width(8.dp))
 
     // ─── Call 211 — local help / social services ─────────────────────
     // Single tap. tel: URI goes through ACTION_DIAL so the user lands

--- a/feature/src/main/kotlin/in/jphe/storyvox/feature/techempower/TechEmpowerHomeScreen.kt
+++ b/feature/src/main/kotlin/in/jphe/storyvox/feature/techempower/TechEmpowerHomeScreen.kt
@@ -26,7 +26,6 @@ import androidx.compose.material.icons.automirrored.filled.ArrowBack
 import androidx.compose.material.icons.filled.Forum
 import androidx.compose.material.icons.filled.Info
 import androidx.compose.material.icons.filled.Phone
-import androidx.compose.material.icons.filled.Warning
 import androidx.compose.material3.CenterAlignedTopAppBar
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Icon
@@ -61,16 +60,14 @@ import `in`.jphe.storyvox.ui.theme.LocalSpacing
  *
  * Structure (top to bottom):
  *  - Brass-on-warm-dark top-app-bar with back arrow + help icons
- *    (phone for 211 / 988, forum for Discord) on the right.
+ *    (phone for 211, forum for Discord) on the right.
  *  - Hero: TechEmpower sun-disk logo + mission tagline.
- *  - Brass-edged card grid (5 cards):
+ *  - Brass-edged card grid:
  *      1. Browse Resources → opens Browse (Notion's anonymous-mode
  *         four-fiction layout is the default tile set today).
  *      2. Peer Support Discord → ACTION_VIEW Discord invite URL.
  *      3. Call 211 → ACTION_DIAL tel:211 (United Way social services).
- *      4. Emergency Help → 3-button card (988 / 211 / 911) — see
- *         issue #516 and [TechEmpowerEmergencyCard].
- *      5. About TechEmpower → drill-down to [TechEmpowerAboutScreen].
+ *      4. About TechEmpower → drill-down to [TechEmpowerAboutScreen].
  *  - Featured guides strip: horizontal row of the 8 hand-curated
  *    TechEmpower guide chapters (read directly off the anonymous
  *    Notion delegate's curated list — keeps this screen plumbing-
@@ -87,6 +84,8 @@ import `in`.jphe.storyvox.ui.theme.LocalSpacing
  *
  * v0.5.51 — first pass.
  * v0.5.52 — added Emergency Help card (issue #516).
+ * Issue #775 — Emergency Help card (988 / 911) removed; 211 affordance
+ * stays as a regular grid card.
  */
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
@@ -101,8 +100,7 @@ fun TechEmpowerHomeScreen(
 
     // Issue #546 — when telephony is absent (WiFi-only tablets), pop a
     // fallback dialog instead of routing the user into the contact
-    // picker. Hoisted to the screen scope so all dial entry points
-    // (Call 211 card + each EmergencyDialButton) can drive it.
+    // picker.
     var noTelephonyTarget by remember { mutableStateOf<EmergencyTarget?>(null) }
 
     Scaffold(
@@ -167,7 +165,7 @@ fun TechEmpowerHomeScreen(
             // the device can't dial. Without this guard, WiFi-only
             // tablets like the Tab A7 Lite route ACTION_DIAL to the
             // system Contacts picker — exactly the wrong UX when the
-            // user explicitly wants to reach 211 / 988 / 911.
+            // user explicitly wants to reach 211.
             item {
                 TechEmpowerCard(
                     title = "Call 211",
@@ -182,17 +180,12 @@ fun TechEmpowerHomeScreen(
                     },
                 )
             }
-            // ─── Emergency Help (issue #516) ──────────────────────
-            // Full-width because the card stacks three brass-edged
-            // sub-buttons vertically; squeezing it into a 160dp grid
-            // cell would push the third number off-screen. Spanning
-            // the full row width keeps the 988 / 211 / 911 trio
-            // visible without scrolling on the Flip3 cover.
-            item(span = { GridItemSpan(maxLineSpan) }) {
-                TechEmpowerEmergencyCard(
-                    onNoTelephony = { noTelephonyTarget = it },
-                )
-            }
+            // Issue #775 — the Emergency Help card (988 / 911) that
+            // sat between Call 211 and About TechEmpower was removed
+            // for the current app stage. 211 stays as a regular grid
+            // card above; the crisis affordances can be reinstated as
+            // a new card here once the UX review with intervention
+            // experts lands.
             item {
                 TechEmpowerCard(
                     title = "About TechEmpower",
@@ -337,196 +330,18 @@ private fun TechEmpowerCard(
     }
 }
 
-/**
- * Issue #516 — Emergency Help card. Brass-edged outer container with
- * three brass-edged sub-buttons (988 / 211 / 911), each dialling its
- * respective number via `ACTION_DIAL` so the user lands in the system
- * dialer with the number pre-filled but NOT auto-placed.
- *
- * Why a card with three buttons instead of three separate top-level
- * cards: the trio reads as one cognitive unit ("emergency numbers")
- * and bundling them under one heading lets the user scan all three
- * affordances together. Three separate cards would be visually
- * indistinguishable from the regular brass-edged action cards and
- * lose the "this is the emergency section" signal.
- *
- * Visual ranking is 988 → 211 → 911 (per issue #516 spec, not numeric
- * order): 988 is the most likely first-touch for someone in immediate
- * distress, 211 is everyday social services, 911 is true life-or-
- * limb. 911 last keeps it discoverable without inviting a stray tap
- * — accidental 911 misdials waste dispatch capacity.
- *
- * The outer card has no click handler; only the sub-buttons dial.
- * Tapping the card's title row or the gap between sub-buttons does
- * nothing — by design. The user has to land their tap on a specific
- * number, and the brass edge around each sub-button telegraphs that.
- *
- * V1 ships US-only. The number constants live in [TechEmpowerLinks];
- * localising for CA/UK/AU is a v2 follow-up (see issue #516 + the
- * [TechEmpowerLinks.EMERGENCY_DISPATCH_NUMBER] kdoc).
- */
-@Composable
-private fun TechEmpowerEmergencyCard(
-    onNoTelephony: (EmergencyTarget) -> Unit,
-) {
-    val spacing = LocalSpacing.current
-    val brass = MaterialTheme.colorScheme.primary
-    val substrate = MaterialTheme.colorScheme.surfaceContainerHigh
-    Column(
-        modifier = Modifier
-            .fillMaxWidth()
-            .clip(MaterialTheme.shapes.large)
-            .background(substrate)
-            .border(
-                width = 1.5.dp,
-                color = brass.copy(alpha = 0.55f),
-                shape = MaterialTheme.shapes.large,
-            )
-            .padding(spacing.md),
-        verticalArrangement = Arrangement.spacedBy(spacing.sm),
-    ) {
-        // Header row: warning icon + title. Warning glyph anchors the
-        // "this is the emergency section" semantic — brass-tinted to
-        // match the card edge, no red-on-red panic colouring (the
-        // Library Nocturne palette doesn't have a panic-red, and the
-        // dialer itself surfaces the call confirmation, so we don't
-        // need to scream the affordance).
-        Row(
-            verticalAlignment = Alignment.CenterVertically,
-            horizontalArrangement = Arrangement.spacedBy(spacing.sm),
-        ) {
-            Icon(
-                imageVector = Icons.Filled.Warning,
-                contentDescription = null,
-                tint = brass,
-                modifier = Modifier.size(28.dp),
-            )
-            Text(
-                text = "Emergency Help",
-                style = MaterialTheme.typography.titleMedium,
-                color = brass,
-                fontWeight = FontWeight.SemiBold,
-            )
-        }
-        Text(
-            text = "Three US helplines. Each opens the dialer with the number pre-filled — tap the green button to actually place the call.",
-            style = MaterialTheme.typography.bodySmall,
-            color = MaterialTheme.colorScheme.onSurfaceVariant,
-        )
-        // ─── 988 — Suicide & Crisis Lifeline (top of the list) ────
-        EmergencyDialButton(
-            target = EmergencyTarget.Crisis988,
-            onNoTelephony = onNoTelephony,
-        )
-        // ─── 211 — United Way social services ─────────────────────
-        EmergencyDialButton(
-            target = EmergencyTarget.Help211,
-            onNoTelephony = onNoTelephony,
-        )
-        // ─── 911 — Emergency dispatch (last on purpose) ───────────
-        EmergencyDialButton(
-            target = EmergencyTarget.Dispatch911,
-            onNoTelephony = onNoTelephony,
-        )
-    }
-}
-
-/**
- * Issue #516 — single brass-edged dial button inside
- * [TechEmpowerEmergencyCard]. The number renders large-and-brass on
- * the left (the affordance — it's what the user is looking for and
- * what they'll tap), with label + body stacked to the right.
- *
- * Tap fires `ACTION_DIAL` (not `ACTION_CALL`) — `ACTION_DIAL` works
- * without the `CALL_PHONE` runtime permission and lands the user in
- * the system dialer with the number pre-filled but NOT auto-placed.
- * The user has to hit the green button to actually place the call;
- * this is the right UX for "emergency menu" affordances where a
- * stray tap shouldn't dispatch police.
- *
- * `runCatching` swallows `ActivityNotFoundException` — a device
- * without a dialer activity (rare, but tablets without telephony)
- * just no-ops the button. We don't show a toast because (a) the
- * other two buttons might still work, and (b) the user can always
- * find the number written on the card and dial manually from
- * another device.
- *
- * `Role.Button` plus a content description on the icon-less row
- * gives TalkBack users "988, Suicide and Crisis Lifeline, button" —
- * matching the visual reading order top-to-bottom.
- */
-@Composable
-private fun EmergencyDialButton(
-    target: EmergencyTarget,
-    onNoTelephony: (EmergencyTarget) -> Unit,
-) {
-    val spacing = LocalSpacing.current
-    val context = LocalContext.current
-    val brass = MaterialTheme.colorScheme.primary
-    Row(
-        modifier = Modifier
-            .fillMaxWidth()
-            .clip(MaterialTheme.shapes.medium)
-            .background(MaterialTheme.colorScheme.surfaceContainerHighest)
-            .border(
-                width = 1.dp,
-                color = brass.copy(alpha = 0.45f),
-                shape = MaterialTheme.shapes.medium,
-            )
-            .clickable(
-                role = Role.Button,
-                onClick = {
-                    dialOrSurfaceFallback(
-                        context = context,
-                        target = target,
-                        onNoTelephony = onNoTelephony,
-                    )
-                },
-            )
-            .padding(horizontal = spacing.md, vertical = spacing.sm),
-        verticalAlignment = Alignment.CenterVertically,
-        horizontalArrangement = Arrangement.spacedBy(spacing.md),
-    ) {
-        // The number itself is the primary visual + the tap target's
-        // raison d'être — render it large-and-brass so it reads at a
-        // glance from arm's length. SemiBold (not Bold) because the
-        // Library Nocturne typography ramp tops out at SemiBold for
-        // body-adjacent surfaces; bumping to Bold would clash with the
-        // titleMedium "Emergency Help" header above.
-        Text(
-            text = target.number,
-            style = MaterialTheme.typography.headlineSmall,
-            color = brass,
-            fontWeight = FontWeight.SemiBold,
-            modifier = Modifier.width(56.dp),
-            textAlign = TextAlign.Start,
-        )
-        Column(
-            modifier = Modifier.fillMaxWidth(),
-            verticalArrangement = Arrangement.spacedBy(spacing.xxs),
-        ) {
-            Text(
-                text = target.label,
-                style = MaterialTheme.typography.titleSmall,
-                color = brass,
-                fontWeight = FontWeight.SemiBold,
-            )
-            Text(
-                text = target.body,
-                style = MaterialTheme.typography.bodySmall,
-                color = MaterialTheme.colorScheme.onSurfaceVariant,
-                maxLines = 2,
-            )
-        }
-    }
-}
-
 // [EmergencyTarget], [dialOrSurfaceFallback], and the no-telephony
 // fallback dialog live in [TechEmpowerIntents.kt] because they're
-// shared between the Emergency Help card here AND the top-app-bar
-// phone icon in [TechEmpowerHelpIcons]. Keeping them in one place
-// means a behavioural change (e.g., add a new helpline, swap a
-// fallback URL) is a one-file edit.
+// shared between the "Call 211" card here AND the top-app-bar phone
+// icon in [TechEmpowerHelpIcons]. Keeping them in one place means a
+// behavioural change (e.g., add a new helpline, swap a fallback URL)
+// is a one-file edit.
+//
+// Issue #775 — the Emergency Help card composable + its
+// EmergencyDialButton helper lived here until v0.5.87; both were
+// removed alongside the 988 / 911 affordances. The grid card list in
+// [TechEmpowerHomeScreen] now stops at "Call 211" + "About
+// TechEmpower".
 
 /**
  * Horizontal strip of the eight hand-curated TechEmpower guides. The

--- a/feature/src/main/kotlin/in/jphe/storyvox/feature/techempower/TechEmpowerIntents.kt
+++ b/feature/src/main/kotlin/in/jphe/storyvox/feature/techempower/TechEmpowerIntents.kt
@@ -77,21 +77,23 @@ internal fun launchDiscord(context: Context) {
 }
 
 /**
- * Issue #546 — single source of truth for the three Emergency Help
- * helplines + the everyday "Call 211" card. Each target bundles the
- * dial number with the label/body shown in the in-card chip and the
- * web fallback URL surfaced when telephony is unavailable.
+ * Issue #546 — single source of truth for the helpline surfaces. Each
+ * target bundles the dial number with the label/body shown in the
+ * in-card chip and the web fallback URL surfaced when telephony is
+ * unavailable.
  *
  * The web fallback is what saves the user on a WiFi-only tablet: a
  * `tel:` URI on a device without telephony routes to the AOSP contact
- * picker by default — which is exactly the wrong landing for someone
- * in a crisis. With a web URL in hand we can offer "open in your
- * browser" as a real alternative to dialling.
+ * picker by default — which is exactly the wrong landing. With a web
+ * URL in hand we can offer "open in your browser" as a real
+ * alternative to dialling.
  *
- * 911 has no real web counterpart (you cannot place an emergency
- * dispatch through a webpage), so the web fallback is the FCC's
- * informational page on text-to-911 — the closest the public web gets
- * to "here is how you reach 911 without a regular voice call".
+ * Issue #775 — Crisis988 + Dispatch911 entries were removed alongside
+ * the rest of the 988/911 UI. Help211 is the only surviving target;
+ * the enum stays as an enum (single-entry) so the shared
+ * [dialOrSurfaceFallback] + [NoTelephonyFallbackDialog] plumbing is
+ * unchanged and the crisis affordances can be reinstated as new
+ * entries when the UX review lands.
  */
 internal enum class EmergencyTarget(
     val number: String,
@@ -99,15 +101,6 @@ internal enum class EmergencyTarget(
     val body: String,
     val webFallback: String,
 ) {
-    Crisis988(
-        number = TechEmpowerLinks.CRISIS_HELP_NUMBER,
-        label = "Suicide & Crisis Lifeline",
-        body = "National 24/7 mental health crisis support.",
-        // 988lifeline.org has a Chat option that works WITHOUT
-        // telephony — the user can reach a counsellor right now from
-        // a WiFi-only device. This is the killer fallback for #546.
-        webFallback = "https://988lifeline.org/chat/",
-    ),
     Help211(
         number = TechEmpowerLinks.PRIMARY_HELP_NUMBER,
         label = "United Way social services",
@@ -115,15 +108,6 @@ internal enum class EmergencyTarget(
         // 211.org has a "search by ZIP" tool plus a chat option — both
         // work without telephony.
         webFallback = "https://www.211.org/",
-    ),
-    Dispatch911(
-        number = TechEmpowerLinks.EMERGENCY_DISPATCH_NUMBER,
-        label = "Emergency dispatch",
-        body = "Life-threatening situations — police, fire, ambulance.",
-        // 911 has no real WiFi-only equivalent — point the user at the
-        // FCC's text-to-911 guidance, which is the official US
-        // resource for "I can't make a voice call right now".
-        webFallback = "https://www.fcc.gov/consumers/guides/what-you-need-know-about-text-911",
     ),
 }
 
@@ -140,12 +124,6 @@ internal enum class EmergencyTarget(
  * ACTION_DIAL intent reliably falls through to a contact picker in
  * that state. The check is fast (constant-time lookup against the
  * system features table) and has no permission requirements.
- *
- * 911 is handled identically — even though "emergency call routing on
- * WiFi-only devices" is a real concept in some regions, in practice
- * Android tablets without telephony cannot place 911 calls. The
- * fallback dialog still surfaces the number for a user to dial from
- * another device or via the FCC text-to-911 path.
  */
 internal fun dialOrSurfaceFallback(
     context: Context,
@@ -176,11 +154,11 @@ internal fun dialOrSurfaceFallback(
 /**
  * Issue #546 — fallback dialog shown when a user taps a helpline on a
  * device without telephony. Surfaces the number prominently, offers
- * copy-to-clipboard (so they can dial from another device), and a
+ * copy-to-clipboard (so they can dial from another device), and an
  * "Open in browser" affordance pointing at the helpline's web
- * counterpart (988 chat, 211 search, FCC text-to-911 guidance).
+ * counterpart (211 search).
  *
- * Why an AlertDialog instead of a bottom sheet: a crisis surface
+ * Why an AlertDialog instead of a bottom sheet: a help-line surface
  * needs a modal, focus-stealing affordance with a single primary
  * action. Bottom sheets dismiss on outside-tap and stack with the
  * scaffold; AlertDialog is the right semantic for "we owe you an
@@ -220,9 +198,8 @@ internal fun NoTelephonyFallbackDialog(
                     text = "${target.label} — call ${target.number} from a phone, or use the web option below.",
                     style = MaterialTheme.typography.bodyMedium,
                 )
-                // The number itself, large-and-brass — matches the
-                // EmergencyDialButton visual ranking so the user
-                // anchors on it as the actionable atom.
+                // The number itself, large-and-brass — anchors the
+                // user on the actionable atom of the dialog.
                 Text(
                     text = target.number,
                     style = MaterialTheme.typography.displaySmall,

--- a/feature/src/test/kotlin/in/jphe/storyvox/feature/techempower/EmergencyHelpCardContractTest.kt
+++ b/feature/src/test/kotlin/in/jphe/storyvox/feature/techempower/EmergencyHelpCardContractTest.kt
@@ -7,46 +7,11 @@ import org.junit.Assert.assertTrue
 import org.junit.Test
 
 /**
- * Issue #516 — pins the contract of the Emergency Help card on
- * TechEmpower Home. The card itself is a private composable inside
- * [TechEmpowerHomeScreen], so this test exercises the *data contract*
- * the card depends on rather than rendering the composable:
- *
- *  1. The three US helpline numbers (988 / 211 / 911) exist on
- *     [TechEmpowerLinks] with the exact string values the dialer
- *     expects. A typo here (e.g. "9-1-1" or "988 ") would silently
- *     break the `ACTION_DIAL` intent — the dialer parses `tel:` URIs
- *     strictly.
- *  2. [TechEmpowerLinks.telUri] produces the canonical `tel:<n>`
- *     shape — no whitespace, no `tel://` (Android dialer treats
- *     `tel://211` as a non-resolvable URI on some OEM dialers).
- *  3. The three numbers are *distinct*. Bundling them into one card
- *     only works if each constant points to a different line; a copy-
- *     paste regression that sets 911 = "988" would silently route
- *     emergency taps to the crisis line.
- *  4. The card composable [TechEmpowerHomeScreen] still exists with
- *     the same public signature — Compose synthesises the function
- *     as `TechEmpowerHomeScreenKt`, and a reflection load catches
- *     accidental renames.
- *
- * Why pin via data + reflection instead of a Compose UI test:
- * `:feature` ships JVM unit tests only (no androidx.compose.ui.test
- * dependency yet — see [SettingsSubscreenContractTest] for the same
- * rationale). Once that infra lands, this test can grow assertions
- * that click each of the three sub-buttons and verify the dispatched
- * intent's action + data. Until then, the data-shape contract is the
- * cheapest regression net for the high-value "wrong number dialled
- * in an emergency" failure mode.
+ * Issue #516 / #775 — pins the data contract for the TechEmpower
+ * helpline affordances. After #775 removed the 988 and 911 surfaces,
+ * only the 211 (United Way social services) constant survives.
  */
 class EmergencyHelpCardContractTest {
-
-    @Test
-    fun `crisis helpline constant is 988`() {
-        // Exact string match — `tel:988` is the URI the dialer
-        // resolves. Any whitespace, punctuation, or alternate
-        // formatting (e.g. "9-8-8") would break the intent.
-        assertEquals("988", TechEmpowerLinks.CRISIS_HELP_NUMBER)
-    }
 
     @Test
     fun `primary helpline constant is 211`() {
@@ -54,81 +19,31 @@ class EmergencyHelpCardContractTest {
     }
 
     @Test
-    fun `emergency dispatch constant is 911`() {
-        // Issue #516 introduced this constant. Pin its exact value
-        // so a refactor that touches TechEmpowerLinks can't silently
-        // drop or mis-spell the 911 surface.
-        assertEquals("911", TechEmpowerLinks.EMERGENCY_DISPATCH_NUMBER)
-    }
-
-    @Test
-    fun `telUri produces canonical tel scheme for every emergency number`() {
-        // The dialer parses `tel:<digits>` strictly. `tel://211`
-        // (with two slashes) is treated as a non-resolvable URI on
-        // some OEM dialers — Samsung's stock dialer was the failure
-        // mode JP hit during v0.5.51 development.
-        assertEquals(
-            "tel:988",
-            TechEmpowerLinks.telUri(TechEmpowerLinks.CRISIS_HELP_NUMBER),
-        )
+    fun `telUri produces canonical tel scheme for 211`() {
         assertEquals(
             "tel:211",
             TechEmpowerLinks.telUri(TechEmpowerLinks.PRIMARY_HELP_NUMBER),
         )
-        assertEquals(
-            "tel:911",
-            TechEmpowerLinks.telUri(TechEmpowerLinks.EMERGENCY_DISPATCH_NUMBER),
-        )
     }
 
     @Test
-    fun `three emergency numbers are distinct`() {
-        // A copy-paste regression that sets two of the constants to
-        // the same value would silently route taps to the wrong line.
-        // Especially dangerous for 911 — an emergency tap going to
-        // 988 (or vice-versa) is a user-facing failure mode that no
-        // CI signal would catch downstream.
-        val numbers = setOf(
-            TechEmpowerLinks.CRISIS_HELP_NUMBER,
-            TechEmpowerLinks.PRIMARY_HELP_NUMBER,
-            TechEmpowerLinks.EMERGENCY_DISPATCH_NUMBER,
+    fun `primary helpline constant is non-empty digit string`() {
+        val n = TechEmpowerLinks.PRIMARY_HELP_NUMBER
+        assertTrue("Helpline number must be non-blank: '$n'", n.isNotBlank())
+        assertTrue(
+            "Helpline number must be digits-only: '$n'",
+            n.all { it.isDigit() },
         )
-        assertEquals(3, numbers.size)
     }
 
     @Test
     fun `TechEmpowerHomeScreen composable still exists`() {
-        // Compose-emitted top-level functions land on a synthetic
-        // class named `<FileName>Kt`. Asserting the class loads is
-        // the cheapest smoke test for "the surface still exists" —
-        // a rename or accidental deletion turns into ClassNotFound.
         val cls = runCatching {
             Class.forName("in.jphe.storyvox.feature.techempower.TechEmpowerHomeScreenKt")
         }.getOrNull()
         assertNotNull(
-            "TechEmpowerHomeScreen composable missing — the Emergency Help card lives inside it.",
+            "TechEmpowerHomeScreen composable missing.",
             cls,
         )
-    }
-
-    @Test
-    fun `all three emergency-number constants are non-empty digit strings`() {
-        // Defensive: the dialer happily opens with an empty `tel:`
-        // URI but the user lands in an empty dial pad, which reads
-        // as "the app is broken." Pin that each constant is non-blank
-        // and digits-only (the only shape that round-trips cleanly
-        // through `tel:` on every Android dialer JP has tested).
-        val constants = listOf(
-            TechEmpowerLinks.CRISIS_HELP_NUMBER,
-            TechEmpowerLinks.PRIMARY_HELP_NUMBER,
-            TechEmpowerLinks.EMERGENCY_DISPATCH_NUMBER,
-        )
-        for (n in constants) {
-            assertTrue("Emergency number must be non-blank: '$n'", n.isNotBlank())
-            assertTrue(
-                "Emergency number must be digits-only: '$n'",
-                n.all { it.isDigit() },
-            )
-        }
     }
 }


### PR DESCRIPTION
## Summary
- Remove 988 (Suicide & Crisis Lifeline) icon from top-app-bar help icons row
- Remove Emergency Help card (988/211/911) from TechEmpower Home screen
- Remove `CRISIS_HELP_NUMBER` and `EMERGENCY_DISPATCH_NUMBER` constants from `TechEmpowerLinks`
- Remove `Crisis988` and `Dispatch911` enum entries from `EmergencyTarget`
- Update test suite to cover only the surviving 211 contract
- 211 social-services dial affordance stays intact everywhere

Closes #775

## Test plan
- [ ] Compile clean: `./gradlew :feature:compileDebugKotlin :core-data:compileDebugKotlin`
- [ ] Tests pass: `./gradlew :feature:testDebugUnitTest`
- [ ] TechEmpower Home shows Call 211 card but no Emergency Help card
- [ ] Top-app-bar help icons: phone (211) + Discord — no MonitorHeart (988) icon
- [ ] Tapping 211 on phone opens dialer with 211 pre-filled
- [ ] Tapping 211 on WiFi-only tablet shows fallback dialog

🤖 Generated with [Claude Code](https://claude.com/claude-code)