### PR TITLE
feat(browse): realm-vocabulary end-of-list footer — closes #782

### DIFF
--- a/feature/src/main/kotlin/in/jphe/storyvox/feature/browse/BrowseScreen.kt
+++ b/feature/src/main/kotlin/in/jphe/storyvox/feature/browse/BrowseScreen.kt
@@ -33,6 +33,7 @@ import androidx.compose.material3.Card
 import androidx.compose.material3.CardDefaults
 import androidx.compose.material3.CenterAlignedTopAppBar
 import androidx.compose.material3.FloatingActionButton
+import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
@@ -546,13 +547,31 @@ fun BrowseScreen(
                         }
                     } else if (!state.hasMore && state.items.isNotEmpty()) {
                         item(span = { GridItemSpan(maxLineSpan) }) {
-                            Text(
-                                "End of list",
-                                style = MaterialTheme.typography.bodySmall,
-                                color = MaterialTheme.colorScheme.onSurfaceVariant,
-                                modifier = Modifier.fillMaxWidth().padding(spacing.lg),
-                                textAlign = TextAlign.Center,
-                            )
+                            // Issue #782 — realm-vocabulary footer. Was a bare
+                            // M3-default "End of list" Text; the rest of Browse
+                            // already speaks the realm (MagicSpinner, brass
+                            // error blocks), so the last line should too.
+                            // Thin outline-variant divider anchors the footer
+                            // as a deliberate landmark rather than a stray label.
+                            Column(
+                                modifier = Modifier
+                                    .fillMaxWidth()
+                                    .padding(vertical = spacing.lg),
+                                horizontalAlignment = Alignment.CenterHorizontally,
+                            ) {
+                                HorizontalDivider(
+                                    modifier = Modifier
+                                        .fillMaxWidth(0.4f)
+                                        .padding(bottom = spacing.md),
+                                    color = MaterialTheme.colorScheme.outlineVariant,
+                                )
+                                Text(
+                                    text = stringResource(R.string.browse_end_of_list),
+                                    style = MaterialTheme.typography.bodySmall,
+                                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                                    textAlign = TextAlign.Center,
+                                )
+                            }
                         }
                     }
                 }

--- a/feature/src/main/res/values/strings.xml
+++ b/feature/src/main/res/values/strings.xml
@@ -8,6 +8,8 @@
     <string name="browse_notion_connect_cta">Have a Notion workspace? Connect it →</string>
     <string name="browse_ao3_signin_cta">Sign in to AO3</string>
     <string name="browse_mempalace_wing_chip">Wing: %1$s</string>
+    <!-- Issue #782 — realm-vocabulary footer when the Browse grid runs out of pages. -->
+    <string name="browse_end_of_list">You\'ve reached the edge of the realm.</string>
     <string name="filter_tag_search_hint">Search tags…</string>
 
     <!-- Source carousel actions -->


### PR DESCRIPTION
## Summary
- Replaces the bare M3-default `Text("End of list")` at the bottom of the Browse grid with an i18n'd, realm-themed footer
- Adds `browse_end_of_list` string: "You've reached the edge of the realm." — matches the existing realm voice (`reader_browse_realms`, brass UI vocabulary)
- Adds a thin `outlineVariant` `HorizontalDivider` above the copy so the footer reads as a deliberate landmark rather than a stray label
- Scope intentionally limited to Browse; Library / Follows / Voice Library can adopt the same pattern as follow-ups (the issue body calls this out as a v0 deferral)

## Why
Browse is otherwise fully styled in the realm vocabulary (MagicSpinner, FictionCardSkeleton, brass-tinted error blocks). The "End of list" footer was the lone holdout. Smallest possible delight + the cheapest way to remove the regression risk that originally closed #727 (no hardcoded user-facing literals).

## Files
- `feature/src/main/kotlin/in/jphe/storyvox/feature/browse/BrowseScreen.kt` (+21/-7)
- `feature/src/main/res/values/strings.xml` (+2)

Single-import addition (`HorizontalDivider`); no other surface affected.

## Test plan
- [x] `./gradlew :feature:compileDebugKotlin` — passes (only pre-existing deprecation warnings)
- [ ] Visual check on the Browse grid once a source returns `hasMore = false` (e.g., a small RSS feed, or scroll to the bottom of any source)
- [ ] Verify divider color picks up dark + light Nocturne themes

🤖 Generated with [Claude Code](https://claude.com/claude-code)