### PR TITLE
fix: storage-low, retry-cap, detail Retry — closes #788 #808 #806

### DIFF
--- a/app/src/main/kotlin/in/jphe/storyvox/di/AppBindings.kt
+++ b/app/src/main/kotlin/in/jphe/storyvox/di/AppBindings.kt
@@ -570,6 +570,18 @@ private class RealFictionRepositoryUi(
         runCatching { repo.refreshRemoteFollows() }
     }
 
+    override suspend fun retryDetail(id: String) {
+        // Issue #806 — Retry button on the FictionDetail error states.
+        // Mirror the first-subscription refresh that [fictionById] runs:
+        // call refreshDetail and update the per-id error state. The
+        // value flow is already a Room observer on the same row, so a
+        // successful refresh will surface automatically.
+        when (val result = repo.refreshDetail(id)) {
+            is FictionResult.Success -> errorState(id).value = null
+            is FictionResult.Failure -> errorState(id).value = result.message
+        }
+    }
+
     override suspend fun addByUrl(
         url: String,
         preferredSourceId: String?,

--- a/core-data/src/main/kotlin/in/jphe/storyvox/data/repository/ChapterDownloadScheduler.kt
+++ b/core-data/src/main/kotlin/in/jphe/storyvox/data/repository/ChapterDownloadScheduler.kt
@@ -41,6 +41,7 @@ class WorkManagerChapterDownloadScheduler @Inject constructor(
         val constraints = Constraints.Builder()
             .setRequiredNetworkType(if (requireUnmetered) NetworkType.UNMETERED else NetworkType.CONNECTED)
             .setRequiresBatteryNotLow(true)
+            .setRequiresStorageNotLow(true)
             .build()
 
         val input = Data.Builder()

--- a/core-data/src/main/kotlin/in/jphe/storyvox/data/work/ChapterDownloadWorker.kt
+++ b/core-data/src/main/kotlin/in/jphe/storyvox/data/work/ChapterDownloadWorker.kt
@@ -70,6 +70,19 @@ class ChapterDownloadWorker @AssistedInject constructor(
         val chapterId = inputData.getString(KEY_CHAPTER_ID) ?: return Result.failure(
             Data.Builder().putString(KEY_RESULT, RESULT_BAD_INPUT).build(),
         )
+        // Issue #808 — cap retries so zombie URLs (chapter pulled, source
+        // permanently rate-limiting us, etc.) eventually terminate instead
+        // of looping forever on exponential backoff. The reaper handles
+        // the DOWNLOADING-state side; this handles the worker side.
+        if (runAttemptCount > MAX_RUN_ATTEMPTS) {
+            chapterDao.setDownloadState(
+                chapterId,
+                ChapterDownloadState.FAILED,
+                System.currentTimeMillis(),
+                "retry-exhausted",
+            )
+            return Result.failure(output(RESULT_RETRY_EXHAUSTED))
+        }
         val now = System.currentTimeMillis()
         val source = sourceFor(fictionDao.get(fictionId)?.sourceId)
 
@@ -202,6 +215,10 @@ class ChapterDownloadWorker @AssistedInject constructor(
         const val RESULT_NOT_FOUND = "404"
         const val RESULT_AUTH = "auth"
         const val RESULT_BAD_INPUT = "bad-input"
+        const val RESULT_RETRY_EXHAUSTED = "retry-exhausted"
+
+        /** Issue #808 — terminate after this many WorkManager retry attempts. */
+        const val MAX_RUN_ATTEMPTS: Int = 5
 
         /**
          * Issue #705 — DOWNLOADING rows older than this are flipped back

--- a/feature/src/main/kotlin/in/jphe/storyvox/feature/api/UiContracts.kt
+++ b/feature/src/main/kotlin/in/jphe/storyvox/feature/api/UiContracts.kt
@@ -177,6 +177,16 @@ interface FictionRepositoryUi {
     suspend fun refreshFollows()
 
     /**
+     * Issue #806 — re-trigger the same refresh that [fictionById]'s
+     * first-subscription kick-off runs, so screens can wire a Retry
+     * affordance after a network/Cloudflare error. Updates the
+     * [fictionLoadError] state in place; the value [fictionById] Flow
+     * emits whatever cached row exists (if any). Best-effort: returns
+     * without throwing on failure.
+     */
+    suspend fun retryDetail(id: String) {}
+
+    /**
      * Resolve a pasted URL (or short form) to a fiction, persist it, and
      * fetch detail. Implementation routes through `UrlResolver` + the
      * multi-source map. Returns enough information for the sheet to

--- a/feature/src/main/kotlin/in/jphe/storyvox/feature/fiction/FictionDetailScreen.kt
+++ b/feature/src/main/kotlin/in/jphe/storyvox/feature/fiction/FictionDetailScreen.kt
@@ -349,17 +349,15 @@ fun FictionDetailScreen(
     ) { scaffoldPadding ->
     Box(modifier = Modifier.fillMaxSize().padding(scaffoldPadding)) {
         if (fiction == null && state.error != null) {
-            // First-load failure with no cached fiction. Issue #169 —
-            // this path used to be a dead-end (no Back, no Retry, only
-            // OS back). Now wires onBack so the user always has a way
-            // out without leaning on the OS gesture. Still no Retry —
-            // the underlying refreshDetail re-fires when the user
-            // re-enters the screen via Back + re-tap, so a Retry CTA
-            // here would just blink the same error.
+            // First-load failure with no cached fiction. Issue #169 wired
+            // onBack so the user always has a way out without leaning on
+            // the OS gesture. Issue #806 added the Retry CTA — re-fires
+            // the same refreshDetail the screen ran on first subscription
+            // (was a dead-end requiring Back + re-tap).
             ErrorBlock(
                 title = "Couldn't load this fiction",
                 message = friendlyErrorMessage(state.error),
-                onRetry = null,
+                onRetry = viewModel::retryRefresh,
                 onBack = onBack,
                 placement = ErrorPlacement.FullScreen,
             )
@@ -384,7 +382,7 @@ fun FictionDetailScreen(
                         ErrorBlock(
                             title = "Couldn't refresh",
                             message = friendlyErrorMessage(state.error),
-                            onRetry = null,
+                            onRetry = viewModel::retryRefresh,
                             placement = ErrorPlacement.Banner,
                         )
                     }
@@ -455,7 +453,7 @@ fun FictionDetailScreen(
                         ErrorBlock(
                             title = "Couldn't refresh",
                             message = friendlyErrorMessage(state.error),
-                            onRetry = null,
+                            onRetry = viewModel::retryRefresh,
                             placement = ErrorPlacement.Banner,
                         )
                     }

--- a/feature/src/main/kotlin/in/jphe/storyvox/feature/fiction/FictionDetailViewModel.kt
+++ b/feature/src/main/kotlin/in/jphe/storyvox/feature/fiction/FictionDetailViewModel.kt
@@ -268,6 +268,17 @@ class FictionDetailViewModel @Inject constructor(
     }
 
     /**
+     * Issue #806 — re-fire the same first-subscription refresh that
+     * loads this fiction's detail. Wired to the Retry button on the
+     * full-screen "Couldn't load this fiction" error and the inline
+     * "Couldn't refresh" banner. Failures update the load-error flow
+     * the screen is already observing; success clears it.
+     */
+    fun retryRefresh() {
+        viewModelScope.launch { repo.retryDetail(fictionId) }
+    }
+
+    /**
      * Issue #211 — push a follow/unfollow to Royal Road's account
      * (distinct from [toggleFollow], which is local library Add/Remove).
      *


### PR DESCRIPTION
## Summary

Three small independent fixes bundled into one PR. They share no review surface so triage is fast.

### #788 — Chapter downloads require storage-not-low
`ChapterDownloadScheduler.kt` now adds `.setRequiresStorageNotLow(true)` next to the existing battery-not-low constraint. WorkManager will defer chapter downloads when device storage is low, preventing ENOSPC partway through a `queueAllMissing` batch on tablets with <500MB free.

### #808 — Cap retries to terminate zombie downloads
`ChapterDownloadWorker.doWork()` early-returns `Result.failure(RESULT_RETRY_EXHAUSTED)` once `runAttemptCount > MAX_RUN_ATTEMPTS` (5). Also flips the chapter row to `FAILED("retry-exhausted")` so the user (and the issue #705 reaper) can see what happened. Zombie URLs no longer loop forever on exponential backoff.

### #806 — Wire onRetry at three FictionDetailScreen ErrorBlock sites
- New `FictionRepositoryUi.retryDetail(id)` mirrors the same `repo.refreshDetail` kick-off that `fictionById`'s first-subscription flow runs, and updates the per-id error state the screen already observes. Default no-op on the interface so test fakes don't break.
- New `FictionDetailViewModel.retryRefresh()` launches it on `viewModelScope`.
- All three `ErrorBlock` call sites (full-screen no-cache, wide-layout banner, phone-layout banner) now pass `onRetry = viewModel::retryRefresh` instead of `null`. Users get a working Retry button instead of a dead-end.

## Test plan

- [x] `./gradlew :core-data:compileDebugKotlin :feature:compileDebugKotlin` — clean
- [x] `./gradlew :feature:testDebugUnitTest` — passing
- [ ] Manual: open a fiction with airplane mode on → Retry button visible, tapping it re-fires the load
- [ ] Manual: storage-low → queue a chapter → confirm WorkManager defers it

🤖 Generated with [Claude Code](https://claude.com/claude-code)