### PR TITLE
fix(ao3): wire rating, completion, sort, category, warnings into search

### DIFF
--- a/source-ao3/src/main/kotlin/in/jphe/storyvox/source/ao3/Ao3Source.kt
+++ b/source-ao3/src/main/kotlin/in/jphe/storyvox/source/ao3/Ao3Source.kt
@@ -183,12 +183,37 @@ internal class Ao3Source @Inject constructor(
             )
         }
         state.stringVal("category")?.takeIf { it.isNotBlank() }?.let { cat ->
-            q = q.copy(tags = q.tags + cat.lowercase())
+            // Category passes through as a fandom name — AO3's
+            // `work_search[fandom_names]` matches against the canonical
+            // fandom tag, so the display label (e.g. "Harry Potter")
+            // works directly. Carried in [SearchQuery.tags] so the
+            // existing field plumbing covers it; [search] picks it
+            // out below.
+            q = q.copy(tags = q.tags + cat)
+        }
+        state.stringVal("rating")?.takeIf { it.isNotBlank() }?.let { label ->
+            // Rating is single-select (General/Teen/Mature/Explicit);
+            // round-trip through FictionStatus is wrong — there's no
+            // shared "Rating" field on SearchQuery, so we re-use
+            // [SearchQuery.tags] with a "rating:" prefix. The [search]
+            // adapter peels these back out and maps them to AO3's
+            // numeric `rating_ids[]`.
+            q = q.copy(tags = q.tags + "rating:$label")
+        }
+        state.stringVal("completion")?.takeIf { it.isNotBlank() }?.let { label ->
+            val status = when (label) {
+                "Complete" -> FictionStatus.COMPLETED
+                "In Progress" -> FictionStatus.ONGOING
+                else -> null
+            }
+            if (status != null) {
+                q = q.copy(statuses = q.statuses + status)
+            }
         }
         state.stringSetVal("warnings")?.let { w ->
             q = q.copy(
-                tags = q.tags + w.included.map { it.lowercase() },
-                excludeTags = q.excludeTags + w.excluded.map { it.lowercase() },
+                tags = q.tags + w.included,
+                excludeTags = q.excludeTags + w.excluded,
             )
         }
         return q
@@ -232,10 +257,65 @@ internal class Ao3Source @Inject constructor(
 
     override suspend fun search(query: SearchQuery): FictionResult<ListPage<FictionSummary>> {
         val term = query.term.trim()
-        if (term.isEmpty()) {
+        // Peel filter state back out of [SearchQuery]. [applyFilters]
+        // stuffs the rating into `tags` with a "rating:" prefix because
+        // SearchQuery has no rating field; everything else maps to a
+        // real SearchQuery slot. Empty filters drop out of the URL via
+        // [Ao3Api.searchPath]'s skip-on-empty contract.
+        val ratings = query.tags
+            .asSequence()
+            .filter { it.startsWith(RATING_PREFIX) }
+            .mapNotNull { ratingIdFor(it.removePrefix(RATING_PREFIX)) }
+            .toSet()
+        val warningIds = query.tags
+            .asSequence()
+            .mapNotNull { warningIdFor(it) }
+            .toSet()
+        // AO3's `excluded_tag_names` is a free-form comma-joined list —
+        // any tag name (warnings, fandoms, freeforms) goes through this
+        // single param. Forward everything in [SearchQuery.excludeTags]
+        // verbatim; the AO3 backend matches against its tag taxonomy.
+        val excludedTagNames = query.excludeTags.toSet()
+        // Category lives in `tags` as the raw fandom display name —
+        // anything that isn't a rating: prefix or a known warning is
+        // treated as a fandom hint. AO3's search accepts a single
+        // fandom_names value, so collapse to the first match.
+        val fandom = query.tags
+            .firstOrNull {
+                !it.startsWith(RATING_PREFIX) && warningIdFor(it) == null
+            }
+        val complete = when {
+            FictionStatus.COMPLETED in query.statuses &&
+                FictionStatus.ONGOING !in query.statuses -> true
+            FictionStatus.ONGOING in query.statuses &&
+                FictionStatus.COMPLETED !in query.statuses -> false
+            else -> null
+        }
+        val sortColumn = when (query.orderBy) {
+            SearchOrder.POPULARITY -> "kudos_count"
+            SearchOrder.LAST_UPDATE -> "revised_at"
+            else -> null
+        }
+        // No-term + no-filter calls return empty rather than firing a
+        // server query — matches the old behavior. A filter without a
+        // term IS allowed: AO3's search accepts a query=empty body
+        // when other filters narrow the result set.
+        val hasAnyFilter = ratings.isNotEmpty() || warningIds.isNotEmpty() ||
+            excludedTagNames.isNotEmpty() || fandom != null ||
+            complete != null || sortColumn != null
+        if (term.isEmpty() && !hasAnyFilter) {
             return FictionResult.Success(ListPage(items = emptyList(), page = 1, hasNext = false))
         }
-        return api.searchWorks(query = term, page = query.page ?: 1)
+        return api.searchWorks(
+            query = term,
+            page = query.page.coerceAtLeast(1),
+            ratingIds = ratings,
+            complete = complete,
+            fandom = fandom,
+            warningIds = warningIds,
+            excludedTagNames = excludedTagNames,
+            sortColumn = sortColumn,
+        )
     }
 
     /**
@@ -535,6 +615,43 @@ internal class Ao3Source @Inject constructor(
          * user pick their own default.
          */
         const val DEFAULT_TAG_ID: Long = 414093L
+
+        /**
+         * Sentinel prefix used by [applyFilters] to smuggle the
+         * single-select rating label through [SearchQuery.tags]. AO3's
+         * search expects numeric `rating_ids[]`; the universal
+         * SearchQuery has no dedicated rating slot, so we stash the
+         * label here and the [search] adapter translates back to ids.
+         */
+        internal const val RATING_PREFIX = "rating:"
+
+        /**
+         * AO3 rating label → numeric `rating_ids[]` value used by the
+         * `/works/search` form. Resolved from the form's HTML option
+         * values — these ids are part of AO3's data schema and don't
+         * change.
+         */
+        internal fun ratingIdFor(label: String): Int? = when (label) {
+            "General" -> 10
+            "Teen" -> 11
+            "Mature" -> 12
+            "Explicit" -> 13
+            else -> null
+        }
+
+        /**
+         * AO3 archive-warning label → numeric `archive_warning_ids[]`
+         * value used by the `/works/search` form. Only the four labels
+         * surfaced by [filterDimensions] are mapped; anything else
+         * returns null and is treated as a regular tag.
+         */
+        internal fun warningIdFor(label: String): Int? = when (label) {
+            "Graphic Depictions Of Violence" -> 17
+            "Major Character Death" -> 18
+            "Underage" -> 19
+            "Rape/Non-Con" -> 20
+            else -> null
+        }
     }
 }
 

--- a/source-ao3/src/main/kotlin/in/jphe/storyvox/source/ao3/net/Ao3Api.kt
+++ b/source-ao3/src/main/kotlin/in/jphe/storyvox/source/ao3/net/Ao3Api.kt
@@ -228,9 +228,35 @@ internal class Ao3Api @Inject constructor(
      * Anonymous — no auth cookie needed. AO3's search is available to
      * logged-out users; the results may exclude Archive-Warning-gated
      * works but that's AO3's standard anonymous behavior.
+     *
+     * Filter params mirror AO3's `/works/search` form:
+     *  - [ratingIds] → `work_search[rating_ids][]` (10/11/12/13)
+     *  - [complete] → `work_search[complete]` ("T"|"F", omit for both)
+     *  - [fandom] → `work_search[fandom_names]`
+     *  - [warningIds] → `work_search[archive_warning_ids][]`
+     *  - [excludedTagNames] → `work_search[excluded_tag_names]` (comma-joined)
+     *  - [sortColumn] → `work_search[sort_column]` ("kudos_count"|"revised_at"|null)
      */
-    suspend fun searchWorks(query: String, page: Int = 1): FictionResult<ListPage<FictionSummary>> {
-        val path = searchPath(query, page)
+    suspend fun searchWorks(
+        query: String,
+        page: Int = 1,
+        ratingIds: Set<Int> = emptySet(),
+        complete: Boolean? = null,
+        fandom: String? = null,
+        warningIds: Set<Int> = emptySet(),
+        excludedTagNames: Set<String> = emptySet(),
+        sortColumn: String? = null,
+    ): FictionResult<ListPage<FictionSummary>> {
+        val path = searchPath(
+            query = query,
+            page = page,
+            ratingIds = ratingIds,
+            complete = complete,
+            fandom = fandom,
+            warningIds = warningIds,
+            excludedTagNames = excludedTagNames,
+            sortColumn = sortColumn,
+        )
         return withContext(Dispatchers.IO) {
             when (val res = requestText(client, path)) {
                 is FictionResult.Success -> {
@@ -338,17 +364,57 @@ internal class Ao3Api @Inject constructor(
          * GitHub Issues are the door.
          */
         /**
-         * `/works/search?work_search[query]=<term>[&page=N]` — AO3's
-         * work search. Exposed package-private for URL-shape pinning
-         * in unit tests.
+         * `/works/search?work_search[...]=...[&page=N]` — AO3's work
+         * search URL builder. Exposed package-private for URL-shape
+         * pinning in unit tests. Params are emitted in a deterministic
+         * order (query → ratings → complete → fandom → warnings →
+         * excluded tags → sort → page) so the test assertions can pin
+         * exact strings without flake.
+         *
+         * Empty / null filter values are skipped — passing no filters
+         * round-trips to the original term-only URL.
          */
-        internal fun searchPath(query: String, page: Int = 1): String {
-            val encoded = java.net.URLEncoder.encode(query, "UTF-8")
-            return if (page <= 1) {
-                "/works/search?work_search%5Bquery%5D=$encoded"
-            } else {
-                "/works/search?work_search%5Bquery%5D=$encoded&page=$page"
+        internal fun searchPath(
+            query: String,
+            page: Int = 1,
+            ratingIds: Set<Int> = emptySet(),
+            complete: Boolean? = null,
+            fandom: String? = null,
+            warningIds: Set<Int> = emptySet(),
+            excludedTagNames: Set<String> = emptySet(),
+            sortColumn: String? = null,
+        ): String {
+            val params = mutableListOf<Pair<String, String>>()
+            params += "work_search[query]" to query
+            // AO3 accepts repeated `rating_ids[]` params for OR semantics;
+            // emit in sorted order so the URL is deterministic.
+            for (id in ratingIds.toSortedSet()) {
+                params += "work_search[rating_ids][]" to id.toString()
             }
+            if (complete != null) {
+                params += "work_search[complete]" to if (complete) "T" else "F"
+            }
+            fandom?.takeIf { it.isNotBlank() }?.let {
+                params += "work_search[fandom_names]" to it
+            }
+            for (id in warningIds.toSortedSet()) {
+                params += "work_search[archive_warning_ids][]" to id.toString()
+            }
+            if (excludedTagNames.isNotEmpty()) {
+                params += "work_search[excluded_tag_names]" to
+                    excludedTagNames.toSortedSet().joinToString(",")
+            }
+            sortColumn?.takeIf { it.isNotBlank() }?.let {
+                params += "work_search[sort_column]" to it
+            }
+            if (page > 1) {
+                params += "page" to page.toString()
+            }
+            val qs = params.joinToString("&") { (k, v) ->
+                java.net.URLEncoder.encode(k, "UTF-8") + "=" +
+                    java.net.URLEncoder.encode(v, "UTF-8")
+            }
+            return "/works/search?$qs"
         }
 
         const val USER_AGENT = "storyvox-ao3/1.0 (+https://github.com/jphein/storyvox)"

--- a/source-ao3/src/test/kotlin/in/jphe/storyvox/source/ao3/Ao3SearchPathTest.kt
+++ b/source-ao3/src/test/kotlin/in/jphe/storyvox/source/ao3/Ao3SearchPathTest.kt
@@ -1,0 +1,229 @@
+package `in`.jphe.storyvox.source.ao3
+
+import `in`.jphe.storyvox.source.ao3.net.Ao3Api
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * Pin the AO3 `/works/search` URL shape across the filter axes
+ * declared in [Ao3Source.filterDimensions] — sort, category (fandom),
+ * rating, completion, archive warnings, and excluded tags. The bug
+ * these tests guard against is the regression where filter state was
+ * silently dropped on the way to the URL builder (rating/completion
+ * declared in the UI but never wired through; warnings/category/sort
+ * present in [Ao3Source.applyFilters] but never read by [Ao3Source.search]).
+ *
+ * Pinning the URL shape directly (rather than asserting against
+ * [Ao3Source.search] end-to-end with a fake API) keeps the test
+ * fast and makes any future URL-encoding tweak surface as a single
+ * loud red line.
+ */
+class Ao3SearchPathTest {
+
+    @Test
+    fun `searchPath term-only matches the legacy shape`() {
+        // No filters → just the query param. The page-1 case stays
+        // page-less in the URL (AO3 accepts page=1 explicitly but the
+        // legacy URL didn't include it and we keep that shape).
+        val path = Ao3Api.searchPath(query = "marvel")
+        assertEquals("/works/search?work_search%5Bquery%5D=marvel", path)
+    }
+
+    @Test
+    fun `searchPath appends page query for paginated requests`() {
+        val path = Ao3Api.searchPath(query = "marvel", page = 3)
+        assertTrue("must carry page=3", path.contains("&page=3"))
+        assertTrue(
+            "page must be last in the param order",
+            path.endsWith("&page=3"),
+        )
+    }
+
+    @Test
+    fun `searchPath encodes spaces and special chars in the query`() {
+        val path = Ao3Api.searchPath(query = "hello world & goodnight")
+        // Spaces → '+' (URLEncoder default), '&' → '%26'.
+        assertTrue("must encode space as '+'", path.contains("hello+world"))
+        assertTrue("must encode literal '&' in the value", path.contains("%26"))
+        // The structural '&' between params is still a literal '&'.
+        // Term-only path has no second param, so this URL has no
+        // structural '&' at all.
+        assertFalse("term-only path must not have an unencoded '&'", path.contains("&"))
+    }
+
+    @Test
+    fun `searchPath emits rating_ids params in sorted order`() {
+        val path = Ao3Api.searchPath(
+            query = "marvel",
+            ratingIds = setOf(13, 10),
+        )
+        // %5B = '[', %5D = ']'. Sorted: 10 then 13.
+        val ratingParam = "work_search%5Brating_ids%5D%5B%5D"
+        val tenIdx = path.indexOf("$ratingParam=10")
+        val thirteenIdx = path.indexOf("$ratingParam=13")
+        assertTrue("rating_ids[]=10 must be present", tenIdx > 0)
+        assertTrue("rating_ids[]=13 must be present", thirteenIdx > 0)
+        assertTrue("10 must precede 13 in the URL", tenIdx < thirteenIdx)
+    }
+
+    @Test
+    fun `searchPath emits complete=T for complete works`() {
+        val path = Ao3Api.searchPath(query = "marvel", complete = true)
+        assertTrue(
+            "must include complete=T",
+            path.contains("work_search%5Bcomplete%5D=T"),
+        )
+    }
+
+    @Test
+    fun `searchPath emits complete=F for in-progress works`() {
+        val path = Ao3Api.searchPath(query = "marvel", complete = false)
+        assertTrue(
+            "must include complete=F",
+            path.contains("work_search%5Bcomplete%5D=F"),
+        )
+    }
+
+    @Test
+    fun `searchPath omits complete when null`() {
+        val path = Ao3Api.searchPath(query = "marvel", complete = null)
+        assertFalse(
+            "must not include complete when null",
+            path.contains("work_search%5Bcomplete%5D"),
+        )
+    }
+
+    @Test
+    fun `searchPath emits fandom_names param`() {
+        val path = Ao3Api.searchPath(
+            query = "",
+            fandom = "Harry Potter",
+        )
+        // 'Harry Potter' encodes as 'Harry+Potter'.
+        assertTrue(
+            "must include fandom_names=Harry+Potter",
+            path.contains("work_search%5Bfandom_names%5D=Harry+Potter"),
+        )
+    }
+
+    @Test
+    fun `searchPath omits blank fandom`() {
+        val path = Ao3Api.searchPath(query = "marvel", fandom = "  ")
+        assertFalse(
+            "blank fandom must be omitted",
+            path.contains("fandom_names"),
+        )
+    }
+
+    @Test
+    fun `searchPath emits archive_warning_ids params in sorted order`() {
+        val path = Ao3Api.searchPath(
+            query = "marvel",
+            warningIds = setOf(20, 17, 18),
+        )
+        val warningParam = "work_search%5Barchive_warning_ids%5D%5B%5D"
+        val seventeenIdx = path.indexOf("$warningParam=17")
+        val eighteenIdx = path.indexOf("$warningParam=18")
+        val twentyIdx = path.indexOf("$warningParam=20")
+        assertTrue("warning 17 must be present", seventeenIdx > 0)
+        assertTrue("warning 18 must be present", eighteenIdx > 0)
+        assertTrue("warning 20 must be present", twentyIdx > 0)
+        assertTrue("17 < 18", seventeenIdx < eighteenIdx)
+        assertTrue("18 < 20", eighteenIdx < twentyIdx)
+    }
+
+    @Test
+    fun `searchPath emits excluded_tag_names as comma-joined list`() {
+        val path = Ao3Api.searchPath(
+            query = "marvel",
+            excludedTagNames = setOf("Underage", "Major Character Death"),
+        )
+        // Sorted alphabetically, comma-joined, then URL-encoded
+        // (comma → %2C, space → +).
+        assertTrue(
+            "must include excluded_tag_names with comma-joined value",
+            path.contains(
+                "work_search%5Bexcluded_tag_names%5D=" +
+                    "Major+Character+Death%2CUnderage",
+            ),
+        )
+    }
+
+    @Test
+    fun `searchPath emits sort_column for popularity`() {
+        val path = Ao3Api.searchPath(query = "marvel", sortColumn = "kudos_count")
+        assertTrue(
+            "must include sort_column=kudos_count",
+            path.contains("work_search%5Bsort_column%5D=kudos_count"),
+        )
+    }
+
+    @Test
+    fun `searchPath emits sort_column for newest`() {
+        val path = Ao3Api.searchPath(query = "marvel", sortColumn = "revised_at")
+        assertTrue(
+            "must include sort_column=revised_at",
+            path.contains("work_search%5Bsort_column%5D=revised_at"),
+        )
+    }
+
+    @Test
+    fun `searchPath stacks every filter axis into a single URL`() {
+        // The integration shape — every dimension declared in
+        // filterDimensions wired in at once. Verifies the order is
+        // deterministic and nothing collides.
+        val path = Ao3Api.searchPath(
+            query = "marvel",
+            page = 2,
+            ratingIds = setOf(11, 12),
+            complete = true,
+            fandom = "Marvel Cinematic Universe",
+            warningIds = setOf(17),
+            excludedTagNames = setOf("Underage"),
+            sortColumn = "kudos_count",
+        )
+        // The expected param order: query, ratings (sorted),
+        // complete, fandom, warnings (sorted), excluded, sort, page.
+        val expected = "/works/search?" +
+            "work_search%5Bquery%5D=marvel" +
+            "&work_search%5Brating_ids%5D%5B%5D=11" +
+            "&work_search%5Brating_ids%5D%5B%5D=12" +
+            "&work_search%5Bcomplete%5D=T" +
+            "&work_search%5Bfandom_names%5D=Marvel+Cinematic+Universe" +
+            "&work_search%5Barchive_warning_ids%5D%5B%5D=17" +
+            "&work_search%5Bexcluded_tag_names%5D=Underage" +
+            "&work_search%5Bsort_column%5D=kudos_count" +
+            "&page=2"
+        assertEquals(expected, path)
+    }
+
+    @Test
+    fun `searchPath drops empty page parameter on page 1`() {
+        // page=1 isn't useful in the URL — AO3 treats path with no
+        // page param as page 1.
+        val path = Ao3Api.searchPath(query = "marvel", page = 1)
+        assertFalse("page=1 must not appear", path.contains("page="))
+    }
+
+    // ─── rating + warning ID mappings ──────────────────────────────────
+
+    @Test
+    fun `ratingIdFor maps AO3 rating labels to AO3 form ids`() {
+        assertEquals(10, Ao3Source.ratingIdFor("General"))
+        assertEquals(11, Ao3Source.ratingIdFor("Teen"))
+        assertEquals(12, Ao3Source.ratingIdFor("Mature"))
+        assertEquals(13, Ao3Source.ratingIdFor("Explicit"))
+        assertEquals(null, Ao3Source.ratingIdFor("Unknown"))
+    }
+
+    @Test
+    fun `warningIdFor maps the four canonical archive warnings`() {
+        assertEquals(17, Ao3Source.warningIdFor("Graphic Depictions Of Violence"))
+        assertEquals(18, Ao3Source.warningIdFor("Major Character Death"))
+        assertEquals(19, Ao3Source.warningIdFor("Underage"))
+        assertEquals(20, Ao3Source.warningIdFor("Rape/Non-Con"))
+        assertEquals(null, Ao3Source.warningIdFor("Something Else"))
+    }
+}


### PR DESCRIPTION
## Summary

AO3 search was effectively term-only — `Ao3Source.search()` passed just `query.term` to the API, and `applyFilters()` never wired the `rating` or `completion` axes declared in `filterDimensions()`. Users picking filters in the Browse sheet saw no effect on the result set.

- Extend `Ao3Api.searchPath()` / `searchWorks()` to accept `rating_ids[]`, `complete`, `fandom_names`, `archive_warning_ids[]`, `excluded_tag_names`, and `sort_column` — the same params AO3's `/works/search` form emits.
- Wire `rating` + `completion` in `Ao3Source.applyFilters()`; rating smuggles through a `rating:` prefix in `SearchQuery.tags` (no rating slot on the universal query model), completion maps to `SearchQuery.statuses`.
- Translate the full `SearchQuery` (filter state, sort, statuses, excluded tags) into AO3 form params in `Ao3Source.search()`. Label → numeric id maps for ratings (10/11/12/13) and the four canonical archive warnings (17/18/19/20) live in the companion object.
- Allow filter-only searches (empty term + at least one active filter) — AO3's `/works/search` accepts this and narrows by the form fields.

## Test plan

- [x] `./gradlew :source-ao3:compileDebugKotlin` — green
- [x] `./gradlew :source-ao3:testDebugUnitTest` — 17 new tests in `Ao3SearchPathTest` pass; existing AO3 suites unchanged
- [ ] Manual: open Browse → AO3 → Search, pick Rating=Mature + Completion=Complete, confirm results respect the filter (live verification deferred to integration / phone check)

URL-shape pinning covers: term-only legacy shape, pagination, encoding of spaces and special chars, sorted multi-value `rating_ids[]`, `complete=T`/`F`/omitted, fandom_names emit + blank skip, sorted multi-value `archive_warning_ids[]`, comma-joined `excluded_tag_names`, both `sort_column` values, the stacked-everything integration shape, page=1 omission, and the rating / warning id mapping helpers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)