### PR TITLE
feat(browse): pull-to-refresh on Browse grid — closes #776

### DIFF
--- a/feature/src/main/kotlin/in/jphe/storyvox/feature/browse/BrowseScreen.kt
+++ b/feature/src/main/kotlin/in/jphe/storyvox/feature/browse/BrowseScreen.kt
@@ -39,6 +39,7 @@ import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.pulltorefresh.PullToRefreshBox
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.SecondaryScrollableTabRow
 import androidx.compose.material3.Tab
@@ -460,6 +461,18 @@ fun BrowseScreen(
                             if (!s.isAppending && !s.isLoading) viewModel.loadMore()
                         }
                 }
+                // Issue #776 — pull-to-refresh. Wraps the grid in
+                // PullToRefreshBox; the VM's refresh() resets the paginator
+                // to page 1 and re-fetches. isRefreshing is a separate
+                // StateFlow distinct from state.isLoading (first-load
+                // skeleton) so the spinner only shows on user-initiated
+                // pulls, not initial paint.
+                val isRefreshing by viewModel.isRefreshing.collectAsStateWithLifecycle()
+                PullToRefreshBox(
+                    isRefreshing = isRefreshing,
+                    onRefresh = viewModel::refresh,
+                    modifier = Modifier.fillMaxSize(),
+                ) {
                 LazyVerticalGrid(
                     state = gridState,
                     columns = GridCells.Adaptive(minSize = 140.dp),
@@ -575,6 +588,7 @@ fun BrowseScreen(
                         }
                     }
                 }
+                }  // PullToRefreshBox
             }
         }
     }

--- a/feature/src/main/kotlin/in/jphe/storyvox/feature/browse/BrowseViewModel.kt
+++ b/feature/src/main/kotlin/in/jphe/storyvox/feature/browse/BrowseViewModel.kt
@@ -571,6 +571,31 @@ class BrowseViewModel @Inject constructor(
         viewModelScope.launch { paginator.value?.loadNext() }
     }
 
+    /** Issue #776 — true while a user-initiated pull-to-refresh round-trip
+     *  is in flight. Distinct from [BrowseUiState.isLoading] (first-load
+     *  skeleton) and [BrowseUiState.isAppending] (next-page spinner)
+     *  because the PullToRefreshBox spinner has its own lifetime that
+     *  the screen drives independently. */
+    private val _isRefreshing = MutableStateFlow(false)
+    val isRefreshing: StateFlow<Boolean> = _isRefreshing.asStateFlow()
+
+    /** Issue #776 — pull-to-refresh handler for the Browse grid. Resets
+     *  the current paginator to page 1 and re-fetches. The
+     *  [BrowsePaginator.refresh] call already clears items + error and
+     *  the follow-up [BrowsePaginator.loadNext] emits the fresh page. */
+    fun refresh() {
+        val p = paginator.value ?: return
+        viewModelScope.launch {
+            _isRefreshing.value = true
+            try {
+                p.refresh()
+                p.loadNext()
+            } finally {
+                _isRefreshing.value = false
+            }
+        }
+    }
+
     // ─── Local EPUB folder picker (#669) ─────────────────────────────────
     //
     // Browse → Local chip empty-state CTA writes the picked SAF tree URI


### PR DESCRIPTION
## Summary

Adds Material3 `PullToRefreshBox` around the Browse grid. Pull triggers a new `BrowseViewModel.refresh()` that resets the current paginator to page 1 (`BrowsePaginator.refresh()` — already defined in the interface and noted as wired for "future pull-to-refresh") and re-fetches via `loadNext()`.

A separate `isRefreshing: StateFlow<Boolean>` drives the spinner so it only shows for user-initiated pulls — distinct from `state.isLoading` (first-load skeleton) and `state.isAppending` (next-page spinner below the grid).

The PullToRefreshBox only wraps the populated-grid branch of the screen's state machine. The empty / first-error / Readability-hint branches don't need pull-to-refresh — their CTAs (sign-in, retry, add-by-URL) already cover the user actions that would otherwise warrant a pull.

## Test plan

- [x] `./gradlew :feature:compileDebugKotlin` — clean
- [x] `./gradlew :feature:testDebugUnitTest` — passing
- [ ] Manual: pull down on the Browse grid → spinner appears, items re-fetched
- [ ] Manual: pull while no network → spinner shows briefly, error banner appears in-grid

🤖 Generated with [Claude Code](https://claude.com/claude-code)