### PR TITLE
feat(browse): pull-to-refresh on Browse grid — closes #776

### DIFF
--- a/feature/src/main/kotlin/in/jphe/storyvox/feature/browse/BrowseScreen.kt
+++ b/feature/src/main/kotlin/in/jphe/storyvox/feature/browse/BrowseScreen.kt
@@ -39,6 +39,7 @@ import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.pulltorefresh.PullToRefreshBox
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.SecondaryScrollableTabRow
 import androidx.compose.material3.Tab
@@ -139,6 +140,11 @@ fun BrowseScreen(
     viewModel: BrowseViewModel = hiltViewModel(),
 ) {
     val state by viewModel.uiState.collectAsStateWithLifecycle()
+    // #776 — pull-to-refresh state lives off the ViewModel so the
+    // M3 spinner overlay's `isRefreshing` flag survives recomposition
+    // and matches the paginator refresh lifecycle (cleared in the
+    // finally block of refresh()).
+    val isRefreshing by viewModel.isRefreshing.collectAsStateWithLifecycle()
     val spacing = LocalSpacing.current
     var showFilterSheet by remember { mutableStateOf(false) }
     /** Issue #247 — RSS feed management moved out of Settings into a
@@ -460,6 +466,20 @@ fun BrowseScreen(
                             if (!s.isAppending && !s.isLoading) viewModel.loadMore()
                         }
                 }
+                // #776 — wrap the grid in PullToRefreshBox so the user
+                // can swipe-down to re-fetch the current paginator. The
+                // M3 spinner overlays on top of the existing items
+                // (rather than replacing them with a skeleton grid like
+                // the first-page fetch path does at line ~372), so the
+                // user keeps their visual context through the refresh.
+                // viewModel.refresh() resets the paginator + immediately
+                // calls loadNext(); isRefreshing flips false when that
+                // returns (success OR failure).
+                PullToRefreshBox(
+                    isRefreshing = isRefreshing,
+                    onRefresh = viewModel::refresh,
+                    modifier = Modifier.fillMaxSize(),
+                ) {
                 LazyVerticalGrid(
                     state = gridState,
                     columns = GridCells.Adaptive(minSize = 140.dp),
@@ -575,6 +595,7 @@ fun BrowseScreen(
                         }
                     }
                 }
+                }  // #776 PullToRefreshBox
             }
         }
     }

--- a/feature/src/main/kotlin/in/jphe/storyvox/feature/browse/BrowseViewModel.kt
+++ b/feature/src/main/kotlin/in/jphe/storyvox/feature/browse/BrowseViewModel.kt
@@ -571,6 +571,35 @@ class BrowseViewModel @Inject constructor(
         viewModelScope.launch { paginator.value?.loadNext() }
     }
 
+    // #776 — pull-to-refresh state. Distinct from the paginator's own
+    // [BrowseUiState.isLoading] flag (which drives the skeleton grid on
+    // first page fetch) — `isRefreshing` overlays the M3 spinner on top
+    // of the existing items so the user keeps seeing what they had while
+    // a fresh page-1 fetch lands underneath. Cleared when `loadNext`
+    // returns regardless of success/failure, so a network blip during
+    // refresh still drops the indicator and surfaces the cached items
+    // banner via [BrowseUiState.error] like any other refresh failure.
+    private val _isRefreshing = MutableStateFlow(false)
+    val isRefreshing: StateFlow<Boolean> = _isRefreshing.asStateFlow()
+
+    /** #776 — pull-to-refresh entry point. Resets the current paginator
+     *  to page 1 then immediately re-fetches; the existing
+     *  source-tuple-change `LaunchedEffect` would only fire on tab/query
+     *  changes, so refresh has to push `loadNext()` itself. No-op when
+     *  no paginator is active (e.g. Search tab with empty query). */
+    fun refresh() {
+        val p = paginator.value ?: return
+        viewModelScope.launch {
+            _isRefreshing.value = true
+            try {
+                p.refresh()
+                p.loadNext()
+            } finally {
+                _isRefreshing.value = false
+            }
+        }
+    }
+
     // ─── Local EPUB folder picker (#669) ─────────────────────────────────
     //
     // Browse → Local chip empty-state CTA writes the picked SAF tree URI


### PR DESCRIPTION
## Summary

Wraps the Browse `LazyVerticalGrid` in Material3 `PullToRefreshBox` and wires it to the paginator's already-defined `refresh()` + `loadNext()`. The `BrowsePaginator` interface (`UiContracts.kt:336`) already had `suspend fun refresh()` with the kdoc note _\"Wired up for future pull-to-refresh; not used in v1 of the feature.\"_ — this PR is the v1 hookup.

**Changes:**

- `BrowseViewModel.kt` — adds `isRefreshing: StateFlow<Boolean>` and `fun refresh()` that calls `paginator.refresh()` then `paginator.loadNext()`, clearing `isRefreshing` in `finally` so a network blip still drops the indicator.
- `BrowseScreen.kt` — collects `viewModel.isRefreshing`, wraps the `LazyVerticalGrid` (in the listing `else ->` branch of the gating `when`) with `PullToRefreshBox`. No structural changes to the grid contents themselves.

## UX note

The M3 spinner overlays on top of existing items rather than swapping in a `SkeletonGrid` (which is what `state.isLoading` triggers at line ~372 for the first-page fetch). The user keeps their visual context through the refresh; on failure they see the existing _\"Couldn't refresh\"_ banner — same path as a tail-error.

## Scope

Affects only the listing branch of the gating `when` — sign-in CTAs (RR/AO3), the skeleton grid, search hint, empty state branches, and the full-screen error path are unchanged.

## Test plan

- [x] `./gradlew :feature:compileDebugKotlin` — BUILD SUCCESSFUL
- [x] `./gradlew :feature:testDebugUnitTest` — BUILD SUCCESSFUL
- [ ] Manual on R83W80CAFZB: Browse → Popular tab → swipe down → spinner appears, items refresh, spinner clears
- [ ] Manual: refresh during airplane mode → spinner appears then clears, \"Couldn't refresh\" banner surfaces
- [ ] Manual: tab/source switch mid-refresh → no stuck indicator
- [ ] Manual: pull on Search tab with empty query → no-op (paginator is null)

🤖 Generated with [Claude Code](https://claude.com/claude-code)