### PR TITLE
fix(gutenberg): wire filter state through to Gutendex API params

### DIFF
--- a/source-gutenberg/src/main/kotlin/in/jphe/storyvox/source/gutenberg/GutenbergSource.kt
+++ b/source-gutenberg/src/main/kotlin/in/jphe/storyvox/source/gutenberg/GutenbergSource.kt
@@ -152,16 +152,29 @@ internal class GutenbergSource @Inject constructor(
             )
         }
         state.stringVal("author")?.takeIf { it.isNotBlank() }?.let { author ->
+            // Gutendex's `search` matches title + authors, so appending
+            // the author to the term is the right shape — author-only
+            // searches work because the term collapses to just the
+            // name. (Previously this was the only filter wired through;
+            // keep that contract.)
             val composed = if (q.term.isBlank()) author else "${q.term} $author"
             q = q.copy(term = composed)
         }
         state.stringVal("category")?.takeIf { it.isNotBlank() }?.let { cat ->
-            q = q.copy(genres = q.genres + cat)
+            // Category → Gutendex `topic` (matches subjects + bookshelves).
+            // Stash on `tags` so [search] can pull it back out; the
+            // universal SearchQuery has no dedicated topic slot, and
+            // `genres` was previously dropped on the floor because
+            // [search] only forwarded `term` to the API.
+            q = q.copy(tags = q.tags + cat)
         }
         state.stringVal("language")?.takeIf { it.isNotBlank() }?.let { lang ->
-            val composed = if (q.term.isBlank()) "language:$lang"
-                else "${q.term} language:$lang"
-            q = q.copy(term = composed)
+            // Previously this prepended `language:<code>` to `term`,
+            // which Gutendex's `search` doesn't understand — the literal
+            // string "language:en" poisoned every match. Stash with a
+            // `lang:` prefix in tags so [search] can map it to Gutendex's
+            // real `languages` param.
+            q = q.copy(tags = q.tags + "$LANG_PREFIX$lang")
         }
         return q
     }
@@ -189,10 +202,39 @@ internal class GutenbergSource @Inject constructor(
 
     override suspend fun search(query: SearchQuery): FictionResult<ListPage<FictionSummary>> {
         val term = query.term.trim()
-        if (term.isEmpty()) {
+        // Peel filter state back out of [SearchQuery]. [applyFilters]
+        // stashes language as `lang:<code>` in tags and category as
+        // its plain display name; everything else maps to a real
+        // SearchQuery slot.
+        val languages = query.tags
+            .asSequence()
+            .filter { it.startsWith(LANG_PREFIX) }
+            .map { it.removePrefix(LANG_PREFIX) }
+            .filter { it.isNotBlank() }
+            .toSet()
+        // Category is whichever tag isn't a lang: prefix. Gutendex's
+        // `topic` is single-valued; pick the first non-language tag.
+        val topic = query.tags.firstOrNull { !it.startsWith(LANG_PREFIX) }
+        val sort = when (query.orderBy) {
+            SearchOrder.POPULARITY -> "popular"
+            // Gutendex's `descending` sorts by id desc, which the
+            // [latestUpdates] surface already documents as the right
+            // proxy for "newest additions".
+            SearchOrder.LAST_UPDATE -> "descending"
+            else -> null
+        }
+        val page = query.page.coerceAtLeast(1)
+        val hasAnyFilter = languages.isNotEmpty() || topic != null || sort != null
+        if (term.isEmpty() && !hasAnyFilter) {
             return FictionResult.Success(ListPage(items = emptyList(), page = 1, hasNext = false))
         }
-        return api.search(term, query.page ?: 1).map { it.toListPage(query.page ?: 1) }
+        return api.books(
+            search = term.ifBlank { null },
+            topic = topic,
+            languages = languages,
+            sort = sort,
+            page = page,
+        ).map { it.toListPage(page) }
     }
 
     override suspend fun genres(): FictionResult<List<String>> =
@@ -356,6 +398,20 @@ internal class GutenbergSource @Inject constructor(
     private fun epubFileFor(fictionId: String): File? {
         val id = parseGutenbergId(fictionId) ?: return null
         return File(cacheDir, "$id.epub")
+    }
+
+    companion object {
+        /**
+         * Sentinel prefix used by [applyFilters] to smuggle the
+         * language code through [SearchQuery.tags]. Gutendex's
+         * `languages` param wants ISO 639-1 codes (en, fr, …);
+         * the universal SearchQuery has no language slot, so we
+         * stash the code here and [search] translates it back.
+         * Previously the language was prepended to [SearchQuery.term]
+         * as `language:en` literal — Gutendex's `search` field doesn't
+         * parse that and every match was poisoned.
+         */
+        internal const val LANG_PREFIX = "lang:"
     }
 }
 

--- a/source-gutenberg/src/main/kotlin/in/jphe/storyvox/source/gutenberg/net/GutendexApi.kt
+++ b/source-gutenberg/src/main/kotlin/in/jphe/storyvox/source/gutenberg/net/GutendexApi.kt
@@ -39,7 +39,7 @@ internal class GutendexApi @Inject constructor(
      * tab. 32 results per page is Gutendex's hardcoded page size.
      */
     suspend fun popular(page: Int): FictionResult<GutendexListPage> =
-        get("/books?sort=popular&page=$page")
+        get(booksPath(sort = "popular", page = page))
 
     /**
      * `GET /books?sort=descending` — sorts by Gutenberg id descending,
@@ -49,17 +49,43 @@ internal class GutendexApi @Inject constructor(
      * "what's been added lately".
      */
     suspend fun latestUpdates(page: Int): FictionResult<GutendexListPage> =
-        get("/books?sort=descending&page=$page")
+        get(booksPath(sort = "descending", page = page))
 
     /**
      * `GET /books?search=...` — Gutendex matches against title +
      * authors. The query is URL-encoded so search terms with spaces
      * land verbatim.
      */
-    suspend fun search(term: String, page: Int): FictionResult<GutendexListPage> {
-        val encoded = java.net.URLEncoder.encode(term, Charsets.UTF_8)
-        return get("/books?search=$encoded&page=$page")
-    }
+    suspend fun search(term: String, page: Int): FictionResult<GutendexListPage> =
+        get(booksPath(search = term, page = page))
+
+    /**
+     * Composite `/books` query — wraps every Gutendex filter axis the
+     * storyvox Browse sheet exposes (search, topic, languages, sort).
+     * `null`/blank/empty params drop out of the URL so the legacy
+     * single-axis call shapes (popular / latestUpdates / term-only
+     * search) round-trip identically.
+     *
+     * Gutendex param reference: https://gutendex.com/
+     *  - `search` matches title + authors (free-form)
+     *  - `topic` matches against subjects + bookshelves (free-form)
+     *  - `languages` comma-joined ISO 639-1 codes (e.g. "en,fr")
+     *  - `sort` is one of popular | ascending | descending
+     */
+    suspend fun books(
+        search: String? = null,
+        topic: String? = null,
+        languages: Set<String> = emptySet(),
+        sort: String? = null,
+        page: Int = 1,
+    ): FictionResult<GutendexListPage> =
+        get(booksPath(
+            search = search,
+            topic = topic,
+            languages = languages,
+            sort = sort,
+            page = page,
+        ))
 
     /**
      * `GET /books/{id}` — single-row detail. Returns the same shape
@@ -163,6 +189,37 @@ internal class GutendexApi @Inject constructor(
          * traffic ever looks misbehaved.
          */
         const val USER_AGENT = "storyvox-gutenberg/1.0 (+https://github.com/jphein/storyvox)"
+
+        /**
+         * Build the `/books` query string with whichever params are
+         * non-null/non-blank. Params emit in a deterministic order
+         * (search → topic → languages → sort → page) so URL-shape
+         * tests can pin exact strings without flake. Exposed
+         * package-private for unit-test pinning.
+         */
+        internal fun booksPath(
+            search: String? = null,
+            topic: String? = null,
+            languages: Set<String> = emptySet(),
+            sort: String? = null,
+            page: Int = 1,
+        ): String {
+            val params = mutableListOf<Pair<String, String>>()
+            search?.takeIf { it.isNotBlank() }?.let { params += "search" to it }
+            topic?.takeIf { it.isNotBlank() }?.let { params += "topic" to it }
+            if (languages.isNotEmpty()) {
+                params += "languages" to languages.toSortedSet().joinToString(",")
+            }
+            sort?.takeIf { it.isNotBlank() }?.let { params += "sort" to it }
+            if (page > 1) {
+                params += "page" to page.toString()
+            }
+            if (params.isEmpty()) return "/books"
+            val qs = params.joinToString("&") { (k, v) ->
+                "$k=" + java.net.URLEncoder.encode(v, Charsets.UTF_8)
+            }
+            return "/books?$qs"
+        }
     }
 }
 

--- a/source-gutenberg/src/test/kotlin/in/jphe/storyvox/source/gutenberg/GutendexBooksPathTest.kt
+++ b/source-gutenberg/src/test/kotlin/in/jphe/storyvox/source/gutenberg/GutendexBooksPathTest.kt
@@ -1,0 +1,137 @@
+package `in`.jphe.storyvox.source.gutenberg
+
+import `in`.jphe.storyvox.source.gutenberg.net.GutendexApi
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * Pin the Gutendex `/books` URL shape across the filter axes declared
+ * in [GutenbergSource.filterDimensions] — sort, topic (category),
+ * languages, and free-form search. Guards two prior bugs:
+ *
+ *  - language filter prepended the literal string `"language:en"` to
+ *    [SearchQuery.term] and let Gutendex's `search` field interpret
+ *    it as part of the title query, which poisoned every result
+ *  - category was written to `SearchQuery.genres` which the search
+ *    adapter dropped on the floor
+ *
+ * URL-pinning rather than fake-API end-to-end keeps the test fast and
+ * makes future encoding tweaks surface as a single loud red line.
+ */
+class GutendexBooksPathTest {
+
+    @Test
+    fun `booksPath with no params returns plain books path`() {
+        assertEquals("/books", GutendexApi.booksPath())
+    }
+
+    @Test
+    fun `booksPath search-only matches legacy shape`() {
+        // Note: legacy was `/books?search=foo&page=1`; we drop the
+        // `&page=1` because Gutendex treats no page param as page 1.
+        // Semantically equivalent.
+        val path = GutendexApi.booksPath(search = "frankenstein")
+        assertEquals("/books?search=frankenstein", path)
+    }
+
+    @Test
+    fun `booksPath emits sort=popular for popular tab`() {
+        assertEquals("/books?sort=popular", GutendexApi.booksPath(sort = "popular"))
+    }
+
+    @Test
+    fun `booksPath emits sort=descending for newest tab`() {
+        assertEquals("/books?sort=descending", GutendexApi.booksPath(sort = "descending"))
+    }
+
+    @Test
+    fun `booksPath skips page=1 but emits higher pages`() {
+        assertFalse(
+            "page=1 must not appear in URL",
+            GutendexApi.booksPath(search = "foo", page = 1).contains("page="),
+        )
+        assertTrue(
+            "page>1 must appear",
+            GutendexApi.booksPath(search = "foo", page = 3).endsWith("&page=3"),
+        )
+    }
+
+    @Test
+    fun `booksPath URL-encodes spaces in search term`() {
+        val path = GutendexApi.booksPath(search = "war and peace")
+        // Default URLEncoder encodes spaces as '+'.
+        assertTrue("must encode space as +", path.contains("search=war+and+peace"))
+    }
+
+    @Test
+    fun `booksPath emits topic for category filter`() {
+        val path = GutendexApi.booksPath(topic = "Science Fiction")
+        assertTrue(
+            "topic=Science+Fiction must be in URL",
+            path.contains("topic=Science+Fiction"),
+        )
+    }
+
+    @Test
+    fun `booksPath skips blank topic`() {
+        val path = GutendexApi.booksPath(search = "x", topic = "  ")
+        assertFalse("blank topic must drop", path.contains("topic="))
+    }
+
+    @Test
+    fun `booksPath joins languages with comma in sorted order`() {
+        val path = GutendexApi.booksPath(languages = setOf("fr", "en", "de"))
+        // Sorted alphabetically, comma-joined; comma URL-encodes to %2C.
+        assertTrue(
+            "languages must be sorted comma-joined",
+            path.contains("languages=de%2Cen%2Cfr"),
+        )
+    }
+
+    @Test
+    fun `booksPath skips empty languages set`() {
+        val path = GutendexApi.booksPath(search = "x", languages = emptySet())
+        assertFalse("empty languages must drop", path.contains("languages="))
+    }
+
+    @Test
+    fun `booksPath stacks every filter axis into a single URL`() {
+        // Integration shape — every dimension wired at once with a
+        // deterministic param order: search → topic → languages →
+        // sort → page.
+        val path = GutendexApi.booksPath(
+            search = "frankenstein",
+            topic = "Horror",
+            languages = setOf("en", "fr"),
+            sort = "popular",
+            page = 2,
+        )
+        val expected = "/books?" +
+            "search=frankenstein" +
+            "&topic=Horror" +
+            "&languages=en%2Cfr" +
+            "&sort=popular" +
+            "&page=2"
+        assertEquals(expected, path)
+    }
+
+    @Test
+    fun `booksPath does not poison search term with language tokens`() {
+        // The original bug: `applyFilters` prepended `language:en` to
+        // [SearchQuery.term]. With the new flow the term is the raw
+        // user query — language travels through its own `languages`
+        // param — so no `language:` literal can survive into the URL.
+        val path = GutendexApi.booksPath(
+            search = "shelley",
+            languages = setOf("en"),
+        )
+        assertFalse(
+            "search term must not carry the literal 'language:' marker",
+            path.contains("language%3A"),
+        )
+        assertTrue("languages param must carry the code", path.contains("languages=en"))
+        assertTrue("search must stay clean", path.contains("search=shelley"))
+    }
+}


### PR DESCRIPTION
## Summary

Gutenberg search was effectively broken:
- `applyFilters` prepended `language:en` to `SearchQuery.term`, poisoning every match because Gutendex's `search` field doesn't parse that literal
- category was written to `SearchQuery.genres` but `search()` only forwarded `term` to the API, dropping every filter axis except author

This fix:
- Adds `GutendexApi.booksPath()` / `books()` accepting `search`, `topic`, `languages`, `sort`, `page` — Gutendex's real param surface. Deterministic emit order; empty/null values skip cleanly.
- Stops poisoning the search term in `applyFilters`. Language is stashed under a `lang:` prefix in `SearchQuery.tags`; category passes through as a plain tag; sort maps to `SearchQuery.orderBy`.
- Translates the full `SearchQuery` into Gutendex form params in `GutenbergSource.search()`. Allows filter-only searches (empty term + active filter, e.g. "all French sci-fi").

## Test plan

- [x] `./gradlew :source-gutenberg:compileDebugKotlin` — green
- [x] `./gradlew :source-gutenberg:testDebugUnitTest` — 12 new tests in `GutendexBooksPathTest` pass; existing Gutenberg suites unchanged
- [ ] Manual: open Browse → Gutenberg → Search, pick Language=French + Category=Science Fiction, confirm results respect both filters

URL-pinning covers: empty params, search-only legacy shape, popular/descending sort emit, page=1 omission, space encoding in search term, single-value topic with blank skip, multi-value `languages` comma-joined and sorted, stacked-everything integration shape, and the regression that a language filter can never re-introduce the literal `language:` token into the URL.

🤖 Generated with [Claude Code](https://claude.com/claude-code)