### PR TITLE
fix(wiki): drop poisonous language filter, wire srsort on wikipedia + wikisource

### DIFF
--- a/source-wikipedia/src/main/kotlin/in/jphe/storyvox/source/wikipedia/WikipediaSource.kt
+++ b/source-wikipedia/src/main/kotlin/in/jphe/storyvox/source/wikipedia/WikipediaSource.kt
@@ -92,24 +92,45 @@ internal class WikipediaSource @Inject constructor(
         )
     }
 
+    /**
+     * Issue #809 — the prior `language` Select dimension stuffed
+     * `language:<code>` into the search term, which became literal
+     * search text (MediaWiki has no `language:` keyword). Wikipedia's
+     * per-language host is set via [WikipediaConfig] (Settings →
+     * Wikipedia language), not the Browse filter, so the dimension was
+     * always going to be cosmetic. Replaced with a real sort dimension
+     * since the MediaWiki full-text search API supports `srsort`
+     * (relevance, newest, oldest).
+     */
     override fun filterDimensions(): List<FilterDimension> = listOf(
-        FilterDimension.Select(
-            key = "language",
-            label = "Language",
-            options = listOf("en", "es", "fr", "de", "it", "ja", "zh", "ru", "pt", "ar"),
+        FilterDimension.Sort(
+            options = listOf(
+                FilterDimension.SortOption("relevance", "Most relevant"),
+                FilterDimension.SortOption("newest", "Newest"),
+                FilterDimension.SortOption("oldest", "Oldest"),
+            ),
         ),
     )
 
+    /**
+     * Translate the Sort filter into [SearchQuery.orderBy]. The
+     * [search] method reads orderBy below to pick `opensearch` (cheap
+     * title-completion, no sort) vs `fullTextSearch` (slower, `srsort`-
+     * aware). Term is left untouched — pre-fix this was the bug.
+     */
     override fun applyFilters(base: SearchQuery, state: FilterState): SearchQuery {
-        // Language is silently stored on the SearchQuery term so it
-        // survives the round-trip; host switching is a follow-up.
-        var q = base
-        state.stringVal("language")?.takeIf { it.isNotBlank() }?.let { lang ->
-            val composed = if (q.term.isBlank()) "language:$lang"
-                else "${q.term} language:$lang"
-            q = q.copy(term = composed)
+        val sort = state.stringVal("sort") ?: return base
+        return when (sort) {
+            "newest" -> base.copy(
+                orderBy = `in`.jphe.storyvox.data.source.model.SearchOrder.LAST_UPDATE,
+                direction = `in`.jphe.storyvox.data.source.model.SortDirection.DESC,
+            )
+            "oldest" -> base.copy(
+                orderBy = `in`.jphe.storyvox.data.source.model.SearchOrder.LAST_UPDATE,
+                direction = `in`.jphe.storyvox.data.source.model.SortDirection.ASC,
+            )
+            else -> base // relevance is the default
         }
-        return q
     }
 
     // ─── browse ────────────────────────────────────────────────────────
@@ -158,9 +179,23 @@ internal class WikipediaSource @Inject constructor(
     override suspend fun search(query: SearchQuery): FictionResult<ListPage<FictionSummary>> {
         val term = query.term.trim()
         if (term.isEmpty()) return popular(1)
-        return api.openSearch(term).map { hits ->
-            val items = hits.map { it.toSummary() }
-            ListPage(items = items, page = 1, hasNext = false)
+        // Use cheap title-completion for the default RELEVANCE sort —
+        // openSearch matches against article titles, which is what the
+        // user typically wants. For LAST_UPDATE switch to the full-text
+        // search endpoint which is the only one that supports `srsort`.
+        val needsSrsort = query.orderBy == `in`.jphe.storyvox.data.source.model.SearchOrder.LAST_UPDATE
+        return if (needsSrsort) {
+            val sort = when (query.direction) {
+                `in`.jphe.storyvox.data.source.model.SortDirection.ASC -> "last_edit_asc"
+                `in`.jphe.storyvox.data.source.model.SortDirection.DESC -> "last_edit_desc"
+            }
+            api.fullTextSearch(term, sort = sort).map { hits ->
+                ListPage(items = hits.map { it.toSummary() }, page = 1, hasNext = false)
+            }
+        } else {
+            api.openSearch(term).map { hits ->
+                ListPage(items = hits.map { it.toSummary() }, page = 1, hasNext = false)
+            }
         }
     }
 

--- a/source-wikipedia/src/main/kotlin/in/jphe/storyvox/source/wikipedia/net/WikipediaApi.kt
+++ b/source-wikipedia/src/main/kotlin/in/jphe/storyvox/source/wikipedia/net/WikipediaApi.kt
@@ -93,6 +93,56 @@ internal class WikipediaApi @Inject constructor(
         }
     }
 
+    // ─── full-text search (sortable) ──────────────────────────────────
+
+    /**
+     * MediaWiki `list=search` (full-text) — supports the [srsort]
+     * parameter (`relevance`, `last_edit_desc`, `last_edit_asc`,
+     * `create_timestamp_desc`, etc.) that `opensearch` does not.
+     *
+     * Used by the source when the user picked a non-relevance sort
+     * via the Browse filter sheet (#809). `opensearch` is cheaper for
+     * the relevance default — it returns the same article titles as
+     * full-text search but with title-completion shape — so we keep
+     * it as the no-filter fast path.
+     *
+     * Restricted to mainspace (`srnamespace=0`) so user/talk pages
+     * don't pollute the result list.
+     */
+    suspend fun fullTextSearch(
+        term: String,
+        sort: String = "relevance",
+        limit: Int = 20,
+    ): FictionResult<List<WikipediaSearchHit>> {
+        val q = term.trim()
+        if (q.isEmpty()) return FictionResult.Success(emptyList())
+        val state = config.state.first()
+        val url = state.baseUrl +
+            "/w/api.php?action=query" +
+            "&list=search" +
+            "&srsearch=" + URLEncoder.encode(q, "UTF-8") +
+            "&srnamespace=0" +
+            "&srlimit=$limit" +
+            "&srsort=$sort" +
+            "&format=json"
+        return getJson<WikipediaSearchQueryResponse>(url).let { res ->
+            when (res) {
+                is FictionResult.Success ->
+                    FictionResult.Success(
+                        res.value.query?.search.orEmpty().map { hit ->
+                            WikipediaSearchHit(
+                                title = hit.title,
+                                // strip MediaWiki's <span class="searchmatch"> highlighting
+                                description = hit.snippet.replace(Regex("<[^>]+>"), "").trim(),
+                                url = "",
+                            )
+                        },
+                    )
+                is FictionResult.Failure -> res
+            }
+        }
+    }
+
     // ─── featured / popular ───────────────────────────────────────────
 
     /**
@@ -281,4 +331,20 @@ internal data class WikipediaSummary(
     val extract: String? = null,
     val thumbnail: WikipediaThumbnail? = null,
     val titles: WikipediaFeaturedTitles? = null,
+)
+
+@Serializable
+internal data class WikipediaSearchQueryResponse(
+    val query: WikipediaSearchQuery? = null,
+)
+
+@Serializable
+internal data class WikipediaSearchQuery(
+    val search: List<WikipediaFullTextHit> = emptyList(),
+)
+
+@Serializable
+internal data class WikipediaFullTextHit(
+    val title: String,
+    val snippet: String = "",
 )

--- a/source-wikisource/src/main/kotlin/in/jphe/storyvox/source/wikisource/WikisourceSource.kt
+++ b/source-wikisource/src/main/kotlin/in/jphe/storyvox/source/wikisource/WikisourceSource.kt
@@ -94,22 +94,44 @@ internal class WikisourceSource @Inject constructor(
         )
     }
 
+    /**
+     * Issue #809 — the prior `language` Select dimension stuffed
+     * `language:<code>` into the search term, which became literal
+     * search text (MediaWiki has no `language:` keyword). Wikisource
+     * has no app-side language-switching infra anyway — it's hard-coded
+     * to en.wikisource.org via [WikisourceApi.BASE_URL]. Replaced with
+     * a real sort dimension since MediaWiki full-text search supports
+     * `srsort` (relevance, newest, oldest).
+     */
     override fun filterDimensions(): List<FilterDimension> = listOf(
-        FilterDimension.Select(
-            key = "language",
-            label = "Language",
-            options = listOf("en", "es", "fr", "de", "it", "pt"),
+        FilterDimension.Sort(
+            options = listOf(
+                FilterDimension.SortOption("relevance", "Most relevant"),
+                FilterDimension.SortOption("newest", "Newest"),
+                FilterDimension.SortOption("oldest", "Oldest"),
+            ),
         ),
     )
 
+    /**
+     * Translate the Sort filter into [SearchQuery.orderBy] / [direction].
+     * The [search] method reads them below to thread `srsort` through
+     * to the MediaWiki search API. Term is left untouched — pre-fix
+     * this was the bug.
+     */
     override fun applyFilters(base: SearchQuery, state: FilterState): SearchQuery {
-        var q = base
-        state.stringVal("language")?.takeIf { it.isNotBlank() }?.let { lang ->
-            val composed = if (q.term.isBlank()) "language:$lang"
-                else "${q.term} language:$lang"
-            q = q.copy(term = composed)
+        val sort = state.stringVal("sort") ?: return base
+        return when (sort) {
+            "newest" -> base.copy(
+                orderBy = `in`.jphe.storyvox.data.source.model.SearchOrder.LAST_UPDATE,
+                direction = `in`.jphe.storyvox.data.source.model.SortDirection.DESC,
+            )
+            "oldest" -> base.copy(
+                orderBy = `in`.jphe.storyvox.data.source.model.SearchOrder.LAST_UPDATE,
+                direction = `in`.jphe.storyvox.data.source.model.SortDirection.ASC,
+            )
+            else -> base // relevance is the default
         }
-        return q
     }
 
     // ─── browse ────────────────────────────────────────────────────────
@@ -153,7 +175,20 @@ internal class WikisourceSource @Inject constructor(
     override suspend fun search(query: SearchQuery): FictionResult<ListPage<FictionSummary>> {
         val term = query.term.trim()
         if (term.isEmpty()) return popular(1)
-        return when (val r = api.search(term)) {
+        // Translate orderBy → MediaWiki srsort value. Only LAST_UPDATE
+        // varies the default (relevance) — every other SearchOrder
+        // collapses back to relevance because Wikisource search has no
+        // FOLLOWERS / VIEWS / RATING concept.
+        val sort = when (query.orderBy) {
+            `in`.jphe.storyvox.data.source.model.SearchOrder.LAST_UPDATE ->
+                if (query.direction == `in`.jphe.storyvox.data.source.model.SortDirection.ASC) {
+                    "last_edit_asc"
+                } else {
+                    "last_edit_desc"
+                }
+            else -> "relevance"
+        }
+        return when (val r = api.search(term, sort = sort)) {
             is FictionResult.Success ->
                 FictionResult.Success(
                     ListPage(

--- a/source-wikisource/src/main/kotlin/in/jphe/storyvox/source/wikisource/net/WikisourceApi.kt
+++ b/source-wikisource/src/main/kotlin/in/jphe/storyvox/source/wikisource/net/WikisourceApi.kt
@@ -90,7 +90,11 @@ internal class WikisourceApi @Inject constructor(
      * with image references). Restricting to ns0 gives us the parent
      * work pages users actually want to listen to.
      */
-    suspend fun search(term: String, limit: Int = 20): FictionResult<List<WikisourceSearchHit>> {
+    suspend fun search(
+        term: String,
+        sort: String = "relevance",
+        limit: Int = 20,
+    ): FictionResult<List<WikisourceSearchHit>> {
         val q = term.trim()
         if (q.isEmpty()) return FictionResult.Success(emptyList())
         val url = BASE_URL +
@@ -99,6 +103,7 @@ internal class WikisourceApi @Inject constructor(
             "&srsearch=" + URLEncoder.encode(q, "UTF-8") +
             "&srnamespace=0" +
             "&srlimit=$limit" +
+            "&srsort=$sort" +
             "&format=json"
         return getJson<WikisourceSearchQueryResponse>(url).let { res ->
             when (res) {


### PR DESCRIPTION
## Summary

Both `source-wikipedia` and `source-wikisource` declared a `language` Select filter whose `applyFilters` stuffed `language:<code>` into the `SearchQuery.term`. MediaWiki has no `language:` keyword — the prefix became literal search text, silently degrading every result page.

- Wikipedia's per-language host is controlled by `WikipediaConfig` (Settings → Wikipedia language), not the Browse filter.
- Wikisource has no app-side language switching at all (`BASE_URL` is hard-coded to `en.wikisource.org`).

So the Select dimension was always going to be cosmetic — making it active was the bug.

Replaced with a real **Sort** dimension since MediaWiki full-text search supports `srsort`:

| Option | Wikipedia | Wikisource |
|--------|-----------|------------|
| Most relevant (default) | `opensearch` (cheap title-completion) | `srsort=relevance` |
| Newest | `srsort=last_edit_desc` | `srsort=last_edit_desc` |
| Oldest | `srsort=last_edit_asc` | `srsort=last_edit_asc` |

`WikipediaApi` gains a `fullTextSearch(term, sort)` method that hits `action=query&list=search&srsort=...`. `WikipediaSource.search` routes `LAST_UPDATE` to it and keeps the cheaper `opensearch` for the relevance default. `WikisourceApi.search` gains an optional `sort` parameter (default `"relevance"`).

`applyFilters` in both sources no longer touches `q.term` — that was the poisoning bug.

## Test plan

- [x] `./gradlew :source-wikipedia:compileDebugKotlin :source-wikisource:compileDebugKotlin` — clean
- [x] `./gradlew :source-wikipedia:testDebugUnitTest :source-wikisource:testDebugUnitTest` — passing
- [ ] Manual: Browse → Wikipedia → search "linux" → no `language:` text in the box
- [ ] Manual: Browse → Wikipedia → filter sheet shows "Sort by" with three options (was "Language" with 10)

Closes #809, #810.

🤖 Generated with [Claude Code](https://claude.com/claude-code)