### PR TITLE
feat(radio): expose country, language, tag filter chips via Radio Browser facets

### DIFF
--- a/source-radio/src/main/kotlin/in/jphe/storyvox/source/radio/RadioSource.kt
+++ b/source-radio/src/main/kotlin/in/jphe/storyvox/source/radio/RadioSource.kt
@@ -2,6 +2,8 @@ package `in`.jphe.storyvox.source.radio
 
 import `in`.jphe.storyvox.data.source.FictionSource
 import `in`.jphe.storyvox.data.source.SourceIds
+import `in`.jphe.storyvox.data.source.filter.FilterDimension
+import `in`.jphe.storyvox.data.source.filter.FilterState
 import `in`.jphe.storyvox.data.source.plugin.SourceCategory
 import `in`.jphe.storyvox.data.source.plugin.SourcePlugin
 import `in`.jphe.storyvox.data.source.model.ChapterContent
@@ -101,6 +103,59 @@ internal class RadioSource @Inject constructor(
         )
     }
 
+    // ─── filters ──────────────────────────────────────────────────────
+
+    /**
+     * Issue #795 — surface Radio Browser's facet axes (country,
+     * language, tags) as Browse → Radio filter chips. Radio Browser's
+     * `/json/stations/search` accepts all three simultaneously with AND
+     * semantics, so a user can ask for e.g. "all French jazz stations"
+     * and the network call narrows server-side.
+     *
+     * Free-text inputs rather than a select picker because Radio
+     * Browser's facet taxonomies are enormous and free-form (country
+     * strings include phrases like "The United States Of America",
+     * tags are user-added). Bake an autocomplete picker as a v2.
+     */
+    override fun filterDimensions(): List<FilterDimension> = listOf(
+        FilterDimension.Text(
+            key = "country",
+            label = "Country",
+            placeholder = "e.g. France, Germany, United States",
+        ),
+        FilterDimension.Text(
+            key = "language",
+            label = "Language",
+            placeholder = "e.g. english, french, spanish",
+        ),
+        FilterDimension.Text(
+            key = "tags",
+            label = "Tag",
+            placeholder = "e.g. jazz, classical, news",
+        ),
+    )
+
+    /**
+     * Stash filter state in [SearchQuery] using sentinel prefixes in
+     * `tags`. The universal SearchQuery has no dedicated country /
+     * language / station-tag slots, so [search] picks the values back
+     * out by prefix. Mirrors the same pattern the AO3 / Gutenberg
+     * sources use for their per-source axes.
+     */
+    override fun applyFilters(base: SearchQuery, state: FilterState): SearchQuery {
+        var q = base
+        state.stringVal("country")?.takeIf { it.isNotBlank() }?.let { c ->
+            q = q.copy(tags = q.tags + "$COUNTRY_PREFIX$c")
+        }
+        state.stringVal("language")?.takeIf { it.isNotBlank() }?.let { l ->
+            q = q.copy(tags = q.tags + "$LANGUAGE_PREFIX$l")
+        }
+        state.stringVal("tags")?.takeIf { it.isNotBlank() }?.let { t ->
+            q = q.copy(tags = q.tags + "$TAG_PREFIX$t")
+        }
+        return q
+    }
+
     // ─── browse ────────────────────────────────────────────────────────
 
     override suspend fun popular(page: Int): FictionResult<ListPage<FictionSummary>> {
@@ -141,7 +196,23 @@ internal class RadioSource @Inject constructor(
 
     override suspend fun search(query: SearchQuery): FictionResult<ListPage<FictionSummary>> {
         val term = query.term.trim()
-        if (term.isEmpty()) {
+        // Peel filter state back out of [SearchQuery]. [applyFilters]
+        // stashes country / language / tag under sentinel prefixes in
+        // tags.
+        val countryFilter = query.tags
+            .firstOrNull { it.startsWith(COUNTRY_PREFIX) }
+            ?.removePrefix(COUNTRY_PREFIX)
+        val languageFilter = query.tags
+            .firstOrNull { it.startsWith(LANGUAGE_PREFIX) }
+            ?.removePrefix(LANGUAGE_PREFIX)
+        val tagFilter = query.tags
+            .firstOrNull { it.startsWith(TAG_PREFIX) }
+            ?.removePrefix(TAG_PREFIX)
+        val hasFilters = !countryFilter.isNullOrBlank() ||
+            !languageFilter.isNullOrBlank() ||
+            !tagFilter.isNullOrBlank()
+
+        if (term.isEmpty() && !hasFilters) {
             // Match the popular() shape for empty-query so the Search
             // tab feels populated rather than blank-on-arrival.
             return popular(page = 1)
@@ -150,19 +221,50 @@ internal class RadioSource @Inject constructor(
         // (zero network, instant) — this is what kept the old
         // :source-kvmr "search for kvmr" surface fast. Anything beyond
         // the local matches comes from the Radio Browser API call.
+        // With filters active, narrow the local match using the same
+        // axes the remote call applies so the merged list stays
+        // coherent (don't show a US curated station when the filter
+        // says "country = France").
         val lowered = term.lowercase()
         val localMatches = (RadioStations.curated + config.snapshot())
+            .asSequence()
             .filter { station ->
-                station.displayName.lowercase().contains(lowered) ||
+                term.isEmpty() ||
+                    station.displayName.lowercase().contains(lowered) ||
                     station.tags.any { it.lowercase().contains(lowered) } ||
                     station.country.lowercase().contains(lowered)
             }
+            .filter { station ->
+                countryFilter.isNullOrBlank() ||
+                    station.country.contains(countryFilter, ignoreCase = true)
+            }
+            .filter { station ->
+                languageFilter.isNullOrBlank() ||
+                    station.language.contains(languageFilter, ignoreCase = true)
+            }
+            .filter { station ->
+                tagFilter.isNullOrBlank() ||
+                    station.tags.any { it.contains(tagFilter, ignoreCase = true) }
+            }
             .map { it.toSummary() }
+            .toList()
 
-        // Hit Radio Browser for the long-tail. Failures here don't sink
-        // the whole search — local matches still come back even if the
-        // network call fails.
-        val remoteMatches = when (val result = api.byName(term)) {
+        // Hit Radio Browser for the long-tail. Use the multi-facet
+        // `/search` endpoint when any filter is active, otherwise the
+        // original `byname` endpoint (preserves the legacy URL shape
+        // for term-only searches). Failures don't sink the whole
+        // result — local matches still come back even if the network
+        // call fails.
+        val remoteMatches = when (val result = if (hasFilters) {
+            api.search(
+                name = term.ifBlank { null },
+                country = countryFilter,
+                language = languageFilter,
+                tag = tagFilter,
+            )
+        } else {
+            api.byName(term)
+        }) {
             is FictionResult.Success -> result.value.map { it.toSummary() }
             is FictionResult.Failure -> emptyList()
         }
@@ -312,5 +414,16 @@ internal class RadioSource @Inject constructor(
 
         const val USER_AGENT: String =
             "storyvox-radio/0.5.32 (+https://github.com/techempower-org/storyvox)"
+
+        /**
+         * Sentinel prefixes used by [applyFilters] to smuggle the
+         * country / language / tag filters through [SearchQuery.tags].
+         * The universal SearchQuery has no per-source slots for these
+         * Radio Browser facet axes; [search] picks the values back out
+         * by prefix and routes them to the multi-facet API call.
+         */
+        internal const val COUNTRY_PREFIX = "country:"
+        internal const val LANGUAGE_PREFIX = "language:"
+        internal const val TAG_PREFIX = "tag:"
     }
 }

--- a/source-radio/src/main/kotlin/in/jphe/storyvox/source/radio/net/RadioBrowserApi.kt
+++ b/source-radio/src/main/kotlin/in/jphe/storyvox/source/radio/net/RadioBrowserApi.kt
@@ -107,6 +107,54 @@ internal class RadioBrowserApi @Inject constructor(
             }
     }
 
+    /**
+     * Multi-facet search against `/json/stations/search`. Any of
+     * [name], [country], [language], [tag] may be blank/null; the
+     * server applies AND semantics across the non-blank params. This
+     * is the surface that powers the Browse → Radio filter chips
+     * (country / language / tags) declared in [RadioSource.filterDimensions].
+     *
+     * Same HTTPS-only / lastcheckok / ssl_error filtering as [byName]
+     * via the shared [RadioBrowserStation.toRadioStation] mapper.
+     */
+    suspend fun search(
+        name: String? = null,
+        country: String? = null,
+        language: String? = null,
+        tag: String? = null,
+        limit: Int = 50,
+    ): FictionResult<List<RadioStation>> {
+        val url = "$BASE_URL/json/stations/search"
+            .toHttpUrl().newBuilder()
+            .apply {
+                name?.trim()?.takeIf { it.isNotBlank() }?.let {
+                    addQueryParameter("name", it)
+                }
+                country?.trim()?.takeIf { it.isNotBlank() }?.let {
+                    addQueryParameter("country", it)
+                }
+                language?.trim()?.takeIf { it.isNotBlank() }?.let {
+                    addQueryParameter("language", it)
+                }
+                tag?.trim()?.takeIf { it.isNotBlank() }?.let {
+                    addQueryParameter("tag", it)
+                }
+                addQueryParameter("hidebroken", "true")
+                addQueryParameter("limit", limit.coerceIn(1, 100).toString())
+            }
+            .build()
+            .toString()
+        return getJson<List<RadioBrowserStation>>(url)
+            .let { result ->
+                when (result) {
+                    is FictionResult.Success -> FictionResult.Success(
+                        result.value.mapNotNull { it.toRadioStation() },
+                    )
+                    is FictionResult.Failure -> result
+                }
+            }
+    }
+
     // ─── transport ────────────────────────────────────────────────────
 
     private inline fun <reified T> getJson(url: String): FictionResult<T> =

--- a/source-radio/src/test/kotlin/in/jphe/storyvox/source/radio/RadioFiltersTest.kt
+++ b/source-radio/src/test/kotlin/in/jphe/storyvox/source/radio/RadioFiltersTest.kt
@@ -1,0 +1,205 @@
+package `in`.jphe.storyvox.source.radio
+
+import `in`.jphe.storyvox.data.source.filter.FilterDimension
+import `in`.jphe.storyvox.data.source.filter.FilterState
+import `in`.jphe.storyvox.data.source.filter.FilterValue
+import `in`.jphe.storyvox.data.source.model.FictionResult
+import `in`.jphe.storyvox.data.source.model.SearchQuery
+import `in`.jphe.storyvox.source.radio.config.RadioConfig
+import `in`.jphe.storyvox.source.radio.net.RadioBrowserApi
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.test.runTest
+import okhttp3.OkHttpClient
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Assert.assertFalse
+import org.junit.Test
+
+/**
+ * Issue #795 — `:source-radio` filterDimensions + the multi-facet
+ * search path through Radio Browser.
+ *
+ * Covers:
+ *  - [RadioSource.filterDimensions] declares country / language / tag
+ *    as free-text inputs (Radio Browser's facet taxonomies are
+ *    enormous + free-form, no select picker).
+ *  - [RadioSource.applyFilters] stashes filter values under sentinel
+ *    prefixes in `SearchQuery.tags` so the universal query model can
+ *    carry them through to [RadioSource.search].
+ *  - The peeled filter values narrow the *local* match list (curated
+ *    + starred) by country / language / tag — the remote network call
+ *    is exercised at integration time, not here.
+ *
+ * Network calls are bypassed by injecting a no-op
+ * [RadioBrowserApi] (the production class with an empty OkHttpClient —
+ * any call would fail-fast and the source's catch-all maps that to
+ * `emptyList()`, so local matches remain the only observed output).
+ */
+class RadioFiltersTest {
+
+    private val noopApi = RadioBrowserApi(OkHttpClient())
+
+    private fun fakeConfig(starred: List<RadioStation> = emptyList()) = object : RadioConfig {
+        private val state = MutableStateFlow(starred)
+        override val starredStations: Flow<List<RadioStation>> = state.asStateFlow()
+        override suspend fun snapshot(): List<RadioStation> = state.value
+        override suspend fun star(station: RadioStation) { state.value = state.value + station }
+        override suspend fun unstar(stationId: String) {
+            state.value = state.value.filterNot { it.id == stationId }
+        }
+        override suspend fun isStarred(stationId: String): Boolean =
+            state.value.any { it.id == stationId }
+    }
+
+    private fun source(config: RadioConfig = fakeConfig()): RadioSource =
+        RadioSource(noopApi, config)
+
+    // ─── filterDimensions ─────────────────────────────────────────────
+
+    @Test fun `filterDimensions exposes country language and tag as text inputs`() {
+        val dims = source().filterDimensions()
+        assertEquals(3, dims.size)
+        val keys = dims.map { it.key }.toSet()
+        assertEquals(setOf("country", "language", "tags"), keys)
+        // All three are free-form text — Radio Browser's facet
+        // taxonomies are too large for a select picker.
+        assertTrue(dims.all { it is FilterDimension.Text })
+    }
+
+    // ─── applyFilters ──────────────────────────────────────────────────
+
+    @Test fun `applyFilters stashes country under sentinel prefix`() {
+        val q = source().applyFilters(
+            base = SearchQuery(),
+            state = FilterState(
+                values = mapOf("country" to FilterValue.StringVal("France")),
+            ),
+        )
+        assertTrue(
+            "country must land in tags with the country: prefix",
+            q.tags.contains("${RadioSource.COUNTRY_PREFIX}France"),
+        )
+    }
+
+    @Test fun `applyFilters stashes language under sentinel prefix`() {
+        val q = source().applyFilters(
+            base = SearchQuery(),
+            state = FilterState(
+                values = mapOf("language" to FilterValue.StringVal("french")),
+            ),
+        )
+        assertTrue(q.tags.contains("${RadioSource.LANGUAGE_PREFIX}french"))
+    }
+
+    @Test fun `applyFilters stashes tag under sentinel prefix`() {
+        val q = source().applyFilters(
+            base = SearchQuery(),
+            state = FilterState(
+                values = mapOf("tags" to FilterValue.StringVal("jazz")),
+            ),
+        )
+        assertTrue(q.tags.contains("${RadioSource.TAG_PREFIX}jazz"))
+    }
+
+    @Test fun `applyFilters stacks all three axes onto SearchQuery tags`() {
+        val q = source().applyFilters(
+            base = SearchQuery(),
+            state = FilterState(
+                values = mapOf(
+                    "country" to FilterValue.StringVal("Germany"),
+                    "language" to FilterValue.StringVal("german"),
+                    "tags" to FilterValue.StringVal("classical"),
+                ),
+            ),
+        )
+        assertTrue(q.tags.contains("${RadioSource.COUNTRY_PREFIX}Germany"))
+        assertTrue(q.tags.contains("${RadioSource.LANGUAGE_PREFIX}german"))
+        assertTrue(q.tags.contains("${RadioSource.TAG_PREFIX}classical"))
+    }
+
+    @Test fun `applyFilters drops blank inputs`() {
+        val q = source().applyFilters(
+            base = SearchQuery(),
+            state = FilterState(
+                values = mapOf(
+                    "country" to FilterValue.StringVal("   "),
+                    "language" to FilterValue.StringVal(""),
+                ),
+            ),
+        )
+        assertTrue("blank filters must not pollute tags", q.tags.isEmpty())
+    }
+
+    // ─── search filter behavior ───────────────────────────────────────
+
+    @Test fun `search with US country filter matches curated US stations`() = runTest {
+        val q = SearchQuery(
+            term = "",
+            tags = setOf("${RadioSource.COUNTRY_PREFIX}United States"),
+        )
+        val result = source().search(q) as FictionResult.Success
+        // All curated stations are US — filter is permissive.
+        assertTrue(
+            "US country filter should keep curated stations",
+            result.value.items.any { it.id == "kvmr:live" },
+        )
+    }
+
+    @Test fun `search with non-matching country drops every curated station`() = runTest {
+        val q = SearchQuery(
+            term = "",
+            tags = setOf("${RadioSource.COUNTRY_PREFIX}France"),
+        )
+        val result = source().search(q) as FictionResult.Success
+        // No curated station is in France, so the local list is empty.
+        // The remote call fails (noop api with no network) so the
+        // combined list is also empty — this is the negative path.
+        assertFalse(
+            "French filter must not surface KVMR",
+            result.value.items.any { it.id == "kvmr:live" },
+        )
+    }
+
+    @Test fun `search with tag filter narrows to matching curated stations`() = runTest {
+        val q = SearchQuery(
+            term = "",
+            tags = setOf("${RadioSource.TAG_PREFIX}ambient"),
+        )
+        val result = source().search(q) as FictionResult.Success
+        // SomaFM Groove Salad has the ambient tag.
+        assertTrue(
+            "ambient tag filter should surface SomaFM Groove Salad",
+            result.value.items.any { it.id == "somafm-groove-salad:live" },
+        )
+        // KVMR is community radio — no "ambient" tag — should drop.
+        assertFalse(
+            "ambient tag filter should drop KVMR (no ambient tag)",
+            result.value.items.any { it.id == "kvmr:live" },
+        )
+    }
+
+    @Test fun `search term plus tag filter is AND-composed locally`() = runTest {
+        // Term "KVMR" matches the KVMR station name locally; adding an
+        // "ambient" tag filter narrows out KVMR (no ambient tag).
+        val q = SearchQuery(
+            term = "KVMR",
+            tags = setOf("${RadioSource.TAG_PREFIX}ambient"),
+        )
+        val result = source().search(q) as FictionResult.Success
+        assertFalse(
+            "KVMR-the-station does not have an ambient tag — both filters AND",
+            result.value.items.any { it.id == "kvmr:live" },
+        )
+    }
+
+    @Test fun `search empty term and no filters mirrors popular`() = runTest {
+        // Existing contract preserved — empty everything still surfaces
+        // the popular roster so the Search tab isn't blank-on-arrival.
+        val src = source()
+        val popular = (src.popular() as FictionResult.Success).value.items
+        val searched = (src.search(SearchQuery(term = "")) as FictionResult.Success).value.items
+        assertEquals(popular.map { it.id }, searched.map { it.id })
+    }
+}


### PR DESCRIPTION
Closes #795.

## Summary

Radio Browser exposes country / language / tag facets on the wire but `:source-radio` declared no `filterDimensions()`, so the Browse → Radio sheet had no filter chips. Users hunting for "all French jazz stations" were limited to free-text search against the station name field alone.

- `RadioSource.filterDimensions()` now returns three free-text axes (country, language, tag). Free-form rather than Select because Radio Browser's facet taxonomies are user-curated and enormous (country values include "The United States Of America"; tags are thousands of free-form labels).
- `RadioSource.applyFilters()` stashes the values under sentinel prefixes in `SearchQuery.tags`.
- `RadioSource.search()` peels the filter values back out, narrows the local match list (curated + starred) by country / language / tag (AND-composed with the term), and hits the new multi-facet `RadioBrowserApi.search()` against `/json/stations/search` when any filter is active. Falls back to the legacy `byname` endpoint for term-only searches.
- `RadioBrowserApi.search(name, country, language, tag)` builds the multi-param URL and shares the HTTPS-only / `lastcheckok` / `ssl_error` mapper with `byName`. Blank params drop out of the URL.

## Test plan

- [x] `./gradlew :source-radio:compileDebugKotlin` — green
- [x] `./gradlew :source-radio:testDebugUnitTest` — 11 new tests in `RadioFiltersTest` pass; existing `RadioSourceTest` (24 tests) + `RadioBrowserApiTest` unchanged
- [ ] Manual: Browse → Radio → Search, enter "Country=France", confirm KVMR + SomaFM drop and remote French stations appear

Test coverage: filterDimensions shape, applyFilters stashing for each axis, blank-input dropping, stacked all-three composition, local-match narrowing by country (positive + negative), narrowing by tag, term-plus-tag AND composition, and the empty-everything → popular fallback contract.

🤖 Generated with [Claude Code](https://claude.com/claude-code)