### PR TITLE
fix(sources): wire filter dimensions through to search APIs across 10 sources

### DIFF
--- a/source-arxiv/src/main/kotlin/in/jphe/storyvox/source/arxiv/ArxivSource.kt
+++ b/source-arxiv/src/main/kotlin/in/jphe/storyvox/source/arxiv/ArxivSource.kt
@@ -116,8 +116,17 @@ internal class ArxivSource @Inject constructor(
         state.stringVal("category")?.takeIf { it.isNotBlank() }?.let { cat ->
             q = q.copy(genres = q.genres + cat)
         }
-        state.stringVal("dateRange")?.takeIf { it != "any" }?.let {
-            q = q.copy(orderBy = SearchOrder.LAST_UPDATE)
+        // arXiv's API only supports two sort orders (submittedDate,
+        // lastUpdatedDate); a "this last 30 days" filter realistically
+        // maps onto "sort by lastUpdatedDate descending" — there's no
+        // server-side date-range param. We persist the preset in tags
+        // so [search] can both flip the sort and (in future) filter
+        // client-side once results come back.
+        state.stringVal("dateRange")?.takeIf { it != "any" && it.isNotBlank() }?.let { preset ->
+            q = q.copy(
+                orderBy = SearchOrder.LAST_UPDATE,
+                tags = q.tags + "dateRange:$preset",
+            )
         }
         return q
     }
@@ -170,12 +179,24 @@ internal class ArxivSource @Inject constructor(
 
     override suspend fun search(query: SearchQuery): FictionResult<ListPage<FictionSummary>> {
         val term = query.term.trim()
-        if (term.isEmpty()) return popular(1)
+        val category = query.genres.firstOrNull()?.takeIf { it.isNotBlank() }
+        val sortBy = when (query.orderBy) {
+            SearchOrder.LAST_UPDATE -> "lastUpdatedDate"
+            SearchOrder.RELEVANCE -> "relevance"
+            else -> "submittedDate"
+        }
+        // Empty term AND no facets → fall back to the popular landing.
+        if (term.isEmpty() && category == null && query.orderBy == SearchOrder.RELEVANCE) {
+            return popular(query.page.coerceAtLeast(1))
+        }
         val pageIdx = (query.page - 1).coerceAtLeast(0)
         val start = pageIdx * ArxivApi.DEFAULT_PAGE_SIZE
-        return api.search(term = term, start = start).map { feed ->
-            feed.toListPage(query.page)
-        }
+        return api.search(
+            term = term,
+            start = start,
+            category = category,
+            sortBy = sortBy,
+        ).map { feed -> feed.toListPage(query.page) }
     }
 
     // ─── detail ────────────────────────────────────────────────────────

--- a/source-arxiv/src/main/kotlin/in/jphe/storyvox/source/arxiv/net/ArxivApi.kt
+++ b/source-arxiv/src/main/kotlin/in/jphe/storyvox/source/arxiv/net/ArxivApi.kt
@@ -58,18 +58,22 @@ internal class ArxivApi @Inject constructor(
 
     /**
      * Free-form search. Builds an `all:<term>` query — `all` matches the
-     * paper's title, abstract, authors, and comments. We keep the
-     * sort-order at submittedDate desc so the user sees the most recent
-     * matches first; arXiv's relevance-sort isn't exposed via the
-     * public API (only `submittedDate`, `lastUpdatedDate`, and
-     * `relevance` with the latter known to be flaky).
+     * paper's title, abstract, authors, and comments. Optionally
+     * narrows by [category] (`cat:<code>`) and overrides the default
+     * `submittedDate desc` sort via [sortBy].
+     *
+     * arXiv only documents three sortBy values — `submittedDate`,
+     * `lastUpdatedDate`, and `relevance` — anything else is silently
+     * ignored by the API and falls back to `submittedDate`.
      */
     suspend fun search(
         term: String,
         start: Int = 0,
         maxResults: Int = DEFAULT_PAGE_SIZE,
+        category: String? = null,
+        sortBy: String = "submittedDate",
     ): FictionResult<ArxivAtomFeed> {
-        val url = composeSearchUrl(term, start, maxResults)
+        val url = composeSearchUrl(term, start, maxResults, category, sortBy)
         return getAtom(url)
     }
 
@@ -221,18 +225,35 @@ internal fun composeRecentUrl(
 /**
  * Compose the URL for a free-form `all:<term>` search call. Pure
  * function for test pinning — see [ArxivApiUrlTest].
+ *
+ * When [category] is non-blank we AND it into the query as
+ * `all:<term>+AND+cat:<code>`, mirroring the arXiv query-language
+ * shape documented at https://info.arxiv.org/help/api/user-manual.html.
+ * A blank term + non-blank category becomes a pure `cat:` query (the
+ * filter-only browse case).
  */
 internal fun composeSearchUrl(
     term: String,
     start: Int = 0,
     maxResults: Int = ArxivApi.DEFAULT_PAGE_SIZE,
+    category: String? = null,
+    sortBy: String = "submittedDate",
 ): String {
-    // `all:` matches title + abstract + authors + comments. Trim before
-    // URL-encoding so a stray newline / leading space doesn't break the
-    // query syntax on arXiv's side.
-    val q = "all:" + URLEncoder.encode(term.trim(), "UTF-8")
+    val trimmedTerm = term.trim()
+    val cat = category?.trim()?.takeIf { it.isNotBlank() }
+    // Build search_query: `all:term`, `cat:code`, or both joined by AND.
+    val parts = buildList {
+        if (trimmedTerm.isNotEmpty()) add("all:" + URLEncoder.encode(trimmedTerm, "UTF-8"))
+        if (cat != null) add("cat:" + URLEncoder.encode(cat, "UTF-8"))
+    }
+    val searchQuery = parts.joinToString("+AND+").ifEmpty {
+        // arXiv's query API requires *something* in search_query; fall
+        // back to the default browse category so a bare facet-less,
+        // term-less call still returns rows.
+        "cat:" + URLEncoder.encode(ArxivApi.DEFAULT_CATEGORY, "UTF-8")
+    }
     return ArxivApi.QUERY_BASE +
-        "?search_query=" + q +
-        "&sortBy=submittedDate&sortOrder=descending" +
+        "?search_query=" + searchQuery +
+        "&sortBy=$sortBy&sortOrder=descending" +
         "&start=$start&max_results=$maxResults"
 }

--- a/source-gutenberg/src/main/kotlin/in/jphe/storyvox/source/gutenberg/GutenbergSource.kt
+++ b/source-gutenberg/src/main/kotlin/in/jphe/storyvox/source/gutenberg/GutenbergSource.kt
@@ -151,17 +151,29 @@ internal class GutenbergSource @Inject constructor(
                 },
             )
         }
+        // Author is a free-text filter; Gutendex's `search=` matches
+        // against both title and author, so the safe way to apply it is
+        // by appending to the search term. (Gutendex has no dedicated
+        // `author=` param — its API is title+author OR'd into a single
+        // search field.)
         state.stringVal("author")?.takeIf { it.isNotBlank() }?.let { author ->
             val composed = if (q.term.isBlank()) author else "${q.term} $author"
             q = q.copy(term = composed)
         }
+        // Category lands in [SearchQuery.genres] as a display-cased
+        // label; [GutenbergSource.search] passes the first non-empty
+        // genre through as Gutendex `topic=` (fuzzy match against the
+        // subjects + bookshelves taxonomy).
         state.stringVal("category")?.takeIf { it.isNotBlank() }?.let { cat ->
             q = q.copy(genres = q.genres + cat)
         }
+        // Language is a real Gutendex facet (`languages=<iso-code>`);
+        // [GutenbergSource.search] reads it back off [SearchQuery.tags]
+        // with a `lang:` sentinel so it doesn't collide with future
+        // tag-based filters. Pre-fix this stuffed `language:en` into
+        // the search term and broke every query.
         state.stringVal("language")?.takeIf { it.isNotBlank() }?.let { lang ->
-            val composed = if (q.term.isBlank()) "language:$lang"
-                else "${q.term} language:$lang"
-            q = q.copy(term = composed)
+            q = q.copy(tags = q.tags + "lang:$lang")
         }
         return q
     }
@@ -189,10 +201,27 @@ internal class GutenbergSource @Inject constructor(
 
     override suspend fun search(query: SearchQuery): FictionResult<ListPage<FictionSummary>> {
         val term = query.term.trim()
-        if (term.isEmpty()) {
+        val page = (query.page ?: 1).coerceAtLeast(1)
+        // Pull out the language sentinel set by applyFilters (see kdoc
+        // above) — we strip it from the tag list before deciding what
+        // to send to Gutendex as the topic facet.
+        val language = query.tags
+            .firstOrNull { it.startsWith("lang:") }
+            ?.removePrefix("lang:")
+            ?.takeIf { it.isNotBlank() }
+        val topic = query.genres.firstOrNull()?.takeIf { it.isNotBlank() }
+        val sort = query.orderBy.toGutendexSort()
+        val anyFacetActive = !language.isNullOrBlank() || topic != null || sort != null
+        if (term.isEmpty() && !anyFacetActive) {
             return FictionResult.Success(ListPage(items = emptyList(), page = 1, hasNext = false))
         }
-        return api.search(term, query.page ?: 1).map { it.toListPage(query.page ?: 1) }
+        return api.browse(
+            term = term,
+            page = page,
+            topic = topic,
+            language = language,
+            sort = sort,
+        ).map { it.toListPage(page) }
     }
 
     override suspend fun genres(): FictionResult<List<String>> =
@@ -357,6 +386,17 @@ internal class GutenbergSource @Inject constructor(
         val id = parseGutenbergId(fictionId) ?: return null
         return File(cacheDir, "$id.epub")
     }
+}
+
+/** Map storyvox [SearchOrder] to the Gutendex `sort` param. Gutendex
+ *  supports `popular` (download_count desc), `ascending`, and
+ *  `descending` (by id; ~recently-added). Anything else returns null
+ *  so we omit the param and Gutendex falls back to its default
+ *  relevance ranking when a search term is present. */
+private fun SearchOrder.toGutendexSort(): String? = when (this) {
+    SearchOrder.POPULARITY -> "popular"
+    SearchOrder.LAST_UPDATE, SearchOrder.RELEASE_DATE -> "descending"
+    else -> null
 }
 
 /** Issue #472 — Gutenberg URL pattern for the magic-link resolver. */

--- a/source-gutenberg/src/main/kotlin/in/jphe/storyvox/source/gutenberg/net/GutendexApi.kt
+++ b/source-gutenberg/src/main/kotlin/in/jphe/storyvox/source/gutenberg/net/GutendexApi.kt
@@ -52,14 +52,44 @@ internal class GutendexApi @Inject constructor(
         get("/books?sort=descending&page=$page")
 
     /**
-     * `GET /books?search=...` — Gutendex matches against title +
-     * authors. The query is URL-encoded so search terms with spaces
-     * land verbatim.
+     * Compose a Gutendex query that pairs `search=` with the catalog
+     * facets the filter sheet exposes — `topic=` (matches both subjects
+     * and bookshelves, fuzzy), `languages=` (two-letter codes), and
+     * `sort=` (popular | ascending | descending). Empty term + active
+     * facets is a legitimate shape (filter-only browse), so we omit the
+     * `search=` param when [term] is blank rather than sending `search=`.
+     *
+     * All params are URL-encoded; unknown sort values fall through to
+     * Gutendex's default ranking.
      */
-    suspend fun search(term: String, page: Int): FictionResult<GutendexListPage> {
-        val encoded = java.net.URLEncoder.encode(term, Charsets.UTF_8)
-        return get("/books?search=$encoded&page=$page")
+    suspend fun browse(
+        term: String,
+        page: Int,
+        topic: String? = null,
+        language: String? = null,
+        sort: String? = null,
+    ): FictionResult<GutendexListPage> {
+        val params = buildList {
+            if (term.isNotBlank()) {
+                add("search" to term.trim())
+            }
+            if (!topic.isNullOrBlank()) add("topic" to topic.trim())
+            if (!language.isNullOrBlank()) add("languages" to language.trim())
+            if (!sort.isNullOrBlank()) add("sort" to sort)
+            add("page" to page.toString())
+        }
+        val qs = params.joinToString("&") { (k, v) ->
+            k + "=" + java.net.URLEncoder.encode(v, Charsets.UTF_8)
+        }
+        return get("/books?$qs")
     }
+
+    /**
+     * Legacy term-only search retained for callers that haven't migrated
+     * to [browse]. Identical to `browse(term, page)` with no facets.
+     */
+    suspend fun search(term: String, page: Int): FictionResult<GutendexListPage> =
+        browse(term = term, page = page)
 
     /**
      * `GET /books/{id}` — single-row detail. Returns the same shape

--- a/source-hackernews/src/main/kotlin/in/jphe/storyvox/source/hackernews/HackerNewsSource.kt
+++ b/source-hackernews/src/main/kotlin/in/jphe/storyvox/source/hackernews/HackerNewsSource.kt
@@ -132,9 +132,21 @@ internal class HackerNewsSource @Inject constructor(
                 },
             )
         }
+        // Category is an Algolia `tags=` value (story | ask_hn | show_hn
+        // | front_page) — we stash it on q.tags with a `tag:` sentinel
+        // so [search] can pull it back out without colliding with future
+        // free-tag filters. Pre-fix this stuffed the category into
+        // q.term, which Algolia searched for as literal text and
+        // broke every category-filtered query.
         state.stringVal("category")?.takeIf { it.isNotBlank() }?.let { cat ->
-            val composed = if (q.term.isBlank()) cat else "${q.term} $cat"
-            q = q.copy(term = composed)
+            q = q.copy(tags = q.tags + "tag:$cat")
+        }
+        // minScore lands as a NumberRange whose `min` is the floor; we
+        // persist it on minRating (the closest existing slot on the
+        // SearchQuery — HN doesn't carry a 0..5 star rating, so the
+        // field is free for re-purposing here).
+        state.rangeVal("minScore")?.min?.takeIf { it > 0f }?.let { floor ->
+            q = q.copy(minRating = floor)
         }
         return q
     }
@@ -198,11 +210,30 @@ internal class HackerNewsSource @Inject constructor(
      */
     override suspend fun search(query: SearchQuery): FictionResult<ListPage<FictionSummary>> {
         val term = query.term.trim()
-        if (term.isEmpty()) {
+        val page = query.page.coerceAtLeast(1)
+        val tag = query.tags
+            .firstOrNull { it.startsWith("tag:") }
+            ?.removePrefix("tag:")
+            ?.takeIf { it.isNotBlank() }
+            ?: "story"
+        val endpoint = when (query.orderBy) {
+            SearchOrder.LAST_UPDATE -> "search_by_date"
+            else -> "search"
+        }
+        val minPoints = query.minRating?.toInt()?.takeIf { it > 0 }
+        val anyFacetActive = tag != "story" || endpoint != "search" || minPoints != null
+        if (term.isEmpty() && !anyFacetActive) {
             return FictionResult.Success(ListPage(items = emptyList(), page = 1, hasNext = false))
         }
-        val page = query.page.coerceAtLeast(1)
-        val resp = when (val r = api.searchAlgolia(term, page)) {
+        val resp = when (
+            val r = api.searchAlgolia(
+                query = term,
+                page = page,
+                tag = tag,
+                endpoint = endpoint,
+                minPoints = minPoints,
+            )
+        ) {
             is FictionResult.Success -> r.value
             is FictionResult.Failure -> return r
         }

--- a/source-hackernews/src/main/kotlin/in/jphe/storyvox/source/hackernews/net/HackerNewsApi.kt
+++ b/source-hackernews/src/main/kotlin/in/jphe/storyvox/source/hackernews/net/HackerNewsApi.kt
@@ -103,15 +103,37 @@ internal open class HackerNewsApi @Inject constructor(
     /**
      * `GET https://hn.algolia.com/api/v1/search?query=...&tags=story` —
      * Algolia-indexed full-text search over HN stories. We restrict to
-     * `tags=story` so the result set matches the Browse catalog (no
-     * comments / polls). Algolia pages with `page=N` zero-indexed; we
-     * surface storyvox's 1-indexed page param translated.
+     * `tags=<tag>` so the result set matches the Browse catalog (no
+     * comments / polls by default); callers can override [tag] with
+     * `ask_hn` / `show_hn` / `front_page` to narrow.
+     *
+     * [endpoint] picks between `/search` (relevance-ranked, the default)
+     * and `/search_by_date` (created_at_i desc). Algolia exposes both as
+     * separate paths — switching them is the canonical way to ask for
+     * "newest" vs "best match" on the same query shape.
+     *
+     * [minPoints] adds Algolia's `numericFilters=points>=N` so the
+     * minimum-score dimension actually clips the result set; the
+     * filter param is omitted when [minPoints] is null or zero so the
+     * URL stays clean on the no-filter path.
+     *
+     * Algolia pages with `page=N` zero-indexed; we translate from
+     * storyvox's 1-indexed page param.
      */
-    suspend fun searchAlgolia(query: String, page: Int = 1): FictionResult<AlgoliaSearchResponse> =
+    suspend fun searchAlgolia(
+        query: String,
+        page: Int = 1,
+        tag: String = "story",
+        endpoint: String = "search",
+        minPoints: Int? = null,
+    ): FictionResult<AlgoliaSearchResponse> =
         withContext(Dispatchers.IO) {
             val q = java.net.URLEncoder.encode(query, Charsets.UTF_8)
             val zeroIdx = (page - 1).coerceAtLeast(0)
-            val url = "$ALGOLIA_BASE/search?query=$q&tags=story&page=$zeroIdx"
+            val numericFilters = minPoints?.takeIf { it > 0 }?.let {
+                "&numericFilters=" + java.net.URLEncoder.encode("points>=$it", Charsets.UTF_8)
+            }.orEmpty()
+            val url = "$ALGOLIA_BASE/$endpoint?query=$q&tags=$tag&page=$zeroIdx$numericFilters"
             try {
                 val req = Request.Builder()
                     .url(url)

--- a/source-notion/src/main/kotlin/in/jphe/storyvox/source/notion/AnonymousNotionDelegate.kt
+++ b/source-notion/src/main/kotlin/in/jphe/storyvox/source/notion/AnonymousNotionDelegate.kt
@@ -164,10 +164,18 @@ internal class AnonymousNotionDelegate @Inject constructor(
      * do an in-memory filter over the tiles we already built. Keeps the
      * source consistent with the FictionSource contract (returns
      * ListPage even on empty match).
+     *
+     * [order] sorts the filtered set in memory:
+     *   - [SearchOrder.TITLE] → alphabetical
+     *   - any other → preserves the tile order from [popular]
+     * (The anonymous surface has no per-tile last-update timestamp to
+     * sort against, so LAST_UPDATE is a no-op rather than a wrong sort.)
      */
     suspend fun search(
         state: NotionConfigState,
         term: String,
+        order: `in`.jphe.storyvox.data.source.model.SearchOrder =
+            `in`.jphe.storyvox.data.source.model.SearchOrder.RELEVANCE,
     ): FictionResult<ListPage<FictionSummary>> {
         val popularResult = popular(state, page = 1)
         val all = when (popularResult) {
@@ -179,8 +187,13 @@ internal class AnonymousNotionDelegate @Inject constructor(
             it.title.lowercase().contains(termLc) ||
                 it.description?.lowercase()?.contains(termLc) == true
         }
+        val ordered = when (order) {
+            `in`.jphe.storyvox.data.source.model.SearchOrder.TITLE ->
+                matches.sortedBy { it.title.lowercase() }
+            else -> matches
+        }
         return FictionResult.Success(
-            ListPage(items = matches, page = 1, hasNext = false),
+            ListPage(items = ordered, page = 1, hasNext = false),
         )
     }
 

--- a/source-notion/src/main/kotlin/in/jphe/storyvox/source/notion/NotionPATSource.kt
+++ b/source-notion/src/main/kotlin/in/jphe/storyvox/source/notion/NotionPATSource.kt
@@ -118,7 +118,15 @@ internal class NotionPATSource @Inject constructor(
                         summary.title.lowercase().contains(term) ||
                         summary.description?.lowercase()?.contains(term) == true
                 }
-            ListPage(items = items, page = 1, hasNext = false)
+            // Notion's PAT page summary doesn't carry a last_edited_time
+            // to this layer, so LAST_UPDATE falls through to the
+            // database's natural order (Notion's own sort) — TITLE
+            // alphabetizes in memory.
+            val ordered = when (query.orderBy) {
+                SearchOrder.TITLE -> items.sortedBy { it.title.lowercase() }
+                else -> items
+            }
+            ListPage(items = ordered, page = 1, hasNext = false)
         }
     }
 

--- a/source-notion/src/main/kotlin/in/jphe/storyvox/source/notion/NotionTechEmpowerSource.kt
+++ b/source-notion/src/main/kotlin/in/jphe/storyvox/source/notion/NotionTechEmpowerSource.kt
@@ -104,7 +104,7 @@ internal class NotionTechEmpowerSource @Inject constructor(
 
     override suspend fun search(query: SearchQuery): FictionResult<ListPage<FictionSummary>> {
         val state = config.current()
-        return anonymous.search(state, query.term)
+        return anonymous.search(state, query.term, query.orderBy)
     }
 
     // ─── detail ────────────────────────────────────────────────────────

--- a/source-outline/src/main/kotlin/in/jphe/storyvox/source/outline/OutlineSource.kt
+++ b/source-outline/src/main/kotlin/in/jphe/storyvox/source/outline/OutlineSource.kt
@@ -127,12 +127,25 @@ internal class OutlineSource @Inject constructor(
 
     override suspend fun search(query: SearchQuery): FictionResult<ListPage<FictionSummary>> {
         val term = query.term.trim().lowercase()
-        if (term.isEmpty()) return popular(1)
         return api.collections().map { cols ->
-            val filtered = cols
-                .filter { it.name.lowercase().contains(term) }
-                .map { it.toSummary() }
-            ListPage(items = filtered, page = 1, hasNext = false)
+            val filtered = if (term.isEmpty()) {
+                cols.map { it.toSummary() }
+            } else {
+                cols.filter { it.name.lowercase().contains(term) }
+                    .map { it.toSummary() }
+            }
+            val sorted = when (query.orderBy) {
+                SearchOrder.TITLE -> filtered.sortedBy { it.title.lowercase() }
+                SearchOrder.LAST_UPDATE ->
+                    // The OutlineCollection API doesn't expose updatedAt
+                    // to this layer (CollectionDto strips it before the
+                    // summary mapper), so the closest stable proxy is
+                    // collection id descending — newest collections in
+                    // Outline get higher monotonic ids.
+                    filtered.sortedByDescending { it.id }
+                else -> filtered
+            }
+            ListPage(items = sorted, page = 1, hasNext = false)
         }
     }
 

--- a/source-plos/src/main/kotlin/in/jphe/storyvox/source/plos/PlosSource.kt
+++ b/source-plos/src/main/kotlin/in/jphe/storyvox/source/plos/PlosSource.kt
@@ -172,10 +172,27 @@ internal class PlosSource @Inject constructor(
 
     override suspend fun search(query: SearchQuery): FictionResult<ListPage<FictionSummary>> {
         val term = query.term.trim()
-        if (term.isEmpty()) return popular(1)
         val rows = ROWS_PER_PAGE
         val start = (query.page - 1).coerceAtLeast(0) * rows
-        return api.searchQuery(term = term, start = start, rows = rows).map { resp ->
+        val subject = query.genres.firstOrNull()?.takeIf { it.isNotBlank() }
+        val sort = when (query.orderBy) {
+            SearchOrder.LAST_UPDATE, SearchOrder.RELEASE_DATE -> "publication_date desc"
+            SearchOrder.POPULARITY -> "counter_total_all desc"
+            else -> null // Solr default ranking (relevance for non-empty q)
+        }
+        // Empty term AND no facets → fall back to the popular landing
+        // (PLOS ONE recents). Once any filter is active, route through
+        // searchQuery so the sort + subject params reach Solr.
+        if (term.isEmpty() && subject == null && sort == null) {
+            return popular(query.page.coerceAtLeast(1))
+        }
+        return api.searchQuery(
+            term = term,
+            start = start,
+            rows = rows,
+            sort = sort,
+            subjectFilter = subject,
+        ).map { resp ->
             val items = resp.response.docs.mapNotNull { it.toSummary() }
             ListPage(
                 items = items,

--- a/source-plos/src/main/kotlin/in/jphe/storyvox/source/plos/net/PlosApi.kt
+++ b/source-plos/src/main/kotlin/in/jphe/storyvox/source/plos/net/PlosApi.kt
@@ -92,20 +92,37 @@ internal class PlosApi @Inject constructor(
      * Free-form search. Term is passed through to Solr's `q` parameter
      * untouched (so Boolean operators like `AND` / `OR` and field-
      * scoped queries like `title:climate` work as documented in the
-     * PLOS Search API spec). Results sort by relevance — caller's
-     * `start`/`rows` paginate.
+     * PLOS Search API spec). Results sort by relevance unless [sort]
+     * overrides; [subjectFilter] adds a `fq=subject:"<name>"` to narrow
+     * to a single PLOS subject taxonomy bucket. Caller's `start`/`rows`
+     * paginate.
      */
     suspend fun searchQuery(
         term: String,
         start: Int = 0,
         rows: Int = 50,
+        sort: String? = null,
+        subjectFilter: String? = null,
     ): FictionResult<PlosSearchResponse> {
-        val url = "$BASE_SEARCH" +
-            "?q=" + URLEncoder.encode(term, "UTF-8") +
-            "&start=$start" +
-            "&rows=$rows" +
-            "&fl=" + URLEncoder.encode(DEFAULT_FIELDS, "UTF-8") +
-            "&wt=json"
+        val params = buildList {
+            // Empty term + subject-only is a legitimate filter-only
+            // browse; Solr accepts `q=*:*` as the "match anything"
+            // primary clause.
+            val q = term.ifBlank { "*:*" }
+            add("q" to q)
+            add("fq" to "doc_type:full")
+            if (!subjectFilter.isNullOrBlank()) {
+                add("fq" to "subject:\"$subjectFilter\"")
+            }
+            if (!sort.isNullOrBlank()) add("sort" to sort)
+            add("start" to start.toString())
+            add("rows" to rows.toString())
+            add("fl" to DEFAULT_FIELDS)
+            add("wt" to "json")
+        }
+        val url = "$BASE_SEARCH?" + params.joinToString("&") { (k, v) ->
+            URLEncoder.encode(k, "UTF-8") + "=" + URLEncoder.encode(v, "UTF-8")
+        }
         return getJson<PlosSearchResponse>(url)
     }
 

--- a/source-radio/src/main/kotlin/in/jphe/storyvox/source/radio/RadioSource.kt
+++ b/source-radio/src/main/kotlin/in/jphe/storyvox/source/radio/RadioSource.kt
@@ -2,6 +2,8 @@ package `in`.jphe.storyvox.source.radio
 
 import `in`.jphe.storyvox.data.source.FictionSource
 import `in`.jphe.storyvox.data.source.SourceIds
+import `in`.jphe.storyvox.data.source.filter.FilterDimension
+import `in`.jphe.storyvox.data.source.filter.FilterState
 import `in`.jphe.storyvox.data.source.plugin.SourceCategory
 import `in`.jphe.storyvox.data.source.plugin.SourcePlugin
 import `in`.jphe.storyvox.data.source.model.ChapterContent
@@ -101,6 +103,63 @@ internal class RadioSource @Inject constructor(
         )
     }
 
+    // ─── filters ───────────────────────────────────────────────────────
+
+    /**
+     * Issue #795 — Radio Browser's `/json/stations/search` endpoint
+     * supports country, language, and tag facets that the v1 source
+     * was discarding. The filter sheet now surfaces them as free-text
+     * Text dimensions (the directory's value space is too large to
+     * enumerate as Select chips — JP's "german jazz" search is one
+     * combination among thousands of country×language×tag triples).
+     */
+    override fun filterDimensions(): List<FilterDimension> = listOf(
+        FilterDimension.Text(
+            key = "country",
+            label = "Country",
+            placeholder = "e.g. The United States Of America",
+        ),
+        FilterDimension.Text(
+            key = "countryCode",
+            label = "Country code",
+            placeholder = "e.g. US, DE, GB",
+        ),
+        FilterDimension.Text(
+            key = "language",
+            label = "Language",
+            placeholder = "e.g. english, spanish",
+        ),
+        FilterDimension.Text(
+            key = "tag",
+            label = "Tag",
+            placeholder = "e.g. jazz, classical, news",
+        ),
+    )
+
+    /**
+     * Persists Radio Browser facets onto the SearchQuery via sentinel
+     * tags (`country:`, `countryCode:`, `language:`, `tag:`) so [search]
+     * can pull them back out without growing new SearchQuery fields.
+     * The sentinels are namespaced to this source's tag space; they
+     * never leak past [RadioSource.search].
+     */
+    override fun applyFilters(base: SearchQuery, state: FilterState): SearchQuery {
+        var q = base
+        state.stringVal("country")?.takeIf { it.isNotBlank() }?.let {
+            q = q.copy(tags = q.tags + "country:${it.trim()}")
+        }
+        state.stringVal("countryCode")?.takeIf { it.isNotBlank() }?.let {
+            q = q.copy(tags = q.tags + "countryCode:${it.trim()}")
+        }
+        state.stringVal("language")?.takeIf { it.isNotBlank() }?.let {
+            q = q.copy(tags = q.tags + "language:${it.trim()}")
+        }
+        state.stringVal("tag")?.takeIf { it.isNotBlank() }?.let {
+            q = q.copy(tags = q.tags + "tag:${it.trim()}")
+        }
+        return q
+    }
+
     // ─── browse ────────────────────────────────────────────────────────
 
     override suspend fun popular(page: Int): FictionResult<ListPage<FictionSummary>> {
@@ -141,28 +200,56 @@ internal class RadioSource @Inject constructor(
 
     override suspend fun search(query: SearchQuery): FictionResult<ListPage<FictionSummary>> {
         val term = query.term.trim()
-        if (term.isEmpty()) {
+        // Pull the Radio Browser facets back off the tag sentinels
+        // [applyFilters] writes.
+        val country = query.tags.firstOrNull { it.startsWith("country:") }
+            ?.removePrefix("country:")?.takeIf { it.isNotBlank() }
+        val countryCode = query.tags.firstOrNull { it.startsWith("countryCode:") }
+            ?.removePrefix("countryCode:")?.takeIf { it.isNotBlank() }
+        val language = query.tags.firstOrNull { it.startsWith("language:") }
+            ?.removePrefix("language:")?.takeIf { it.isNotBlank() }
+        val tag = query.tags.firstOrNull { it.startsWith("tag:") }
+            ?.removePrefix("tag:")?.takeIf { it.isNotBlank() }
+        val anyFacet = country != null || countryCode != null ||
+            language != null || tag != null
+
+        if (term.isEmpty() && !anyFacet) {
             // Match the popular() shape for empty-query so the Search
             // tab feels populated rather than blank-on-arrival.
             return popular(page = 1)
         }
+
         // Local match against the curated set + starred imports first
         // (zero network, instant) — this is what kept the old
         // :source-kvmr "search for kvmr" surface fast. Anything beyond
         // the local matches comes from the Radio Browser API call.
+        // Local search only applies a name term — country/language/tag
+        // facets always route to the remote API for proper coverage.
         val lowered = term.lowercase()
-        val localMatches = (RadioStations.curated + config.snapshot())
-            .filter { station ->
-                station.displayName.lowercase().contains(lowered) ||
-                    station.tags.any { it.lowercase().contains(lowered) } ||
-                    station.country.lowercase().contains(lowered)
-            }
-            .map { it.toSummary() }
+        val localMatches = if (term.isNotEmpty()) {
+            (RadioStations.curated + config.snapshot())
+                .filter { station ->
+                    station.displayName.lowercase().contains(lowered) ||
+                        station.tags.any { it.lowercase().contains(lowered) } ||
+                        station.country.lowercase().contains(lowered)
+                }
+                .map { it.toSummary() }
+        } else {
+            emptyList()
+        }
 
         // Hit Radio Browser for the long-tail. Failures here don't sink
         // the whole search — local matches still come back even if the
         // network call fails.
-        val remoteMatches = when (val result = api.byName(term)) {
+        val remoteMatches = when (
+            val result = api.search(
+                name = term.takeIf { it.isNotEmpty() },
+                country = country,
+                countryCode = countryCode,
+                language = language,
+                tag = tag,
+            )
+        ) {
             is FictionResult.Success -> result.value.map { it.toSummary() }
             is FictionResult.Failure -> emptyList()
         }

--- a/source-radio/src/main/kotlin/in/jphe/storyvox/source/radio/net/RadioBrowserApi.kt
+++ b/source-radio/src/main/kotlin/in/jphe/storyvox/source/radio/net/RadioBrowserApi.kt
@@ -82,21 +82,59 @@ internal class RadioBrowserApi @Inject constructor(
     suspend fun byName(
         query: String,
         limit: Int = 50,
+    ): FictionResult<List<RadioStation>> =
+        search(name = query.takeIf { it.isNotBlank() }, limit = limit)
+
+    /**
+     * Multi-facet search using Radio Browser's `/json/stations/search`
+     * endpoint. Every facet is optional; when none are provided we
+     * return an empty list rather than the full ~30k catalog (the
+     * caller — [RadioSource.search] — keeps the curated/starred fast
+     * path for the no-facet case).
+     *
+     * Facets we expose:
+     *  - [name] — fuzzy substring match on the station name
+     *  - [country] — exact match against Radio Browser's country field
+     *    (e.g. "The United States Of America"); use [countryCode]
+     *    instead for ISO-3166 short codes
+     *  - [countryCode] — two-letter ISO code (e.g. "us", "gb", "de")
+     *  - [language] — fuzzy match (e.g. "english", "spanish")
+     *  - [tag] — single-tag fuzzy match (Radio Browser also accepts
+     *    `tagList=t1,t2` for AND semantics; v1 stays single-tag)
+     *
+     * Radio Browser's search endpoint applies all params as AND, so a
+     * country+language combination narrows correctly.
+     */
+    suspend fun search(
+        name: String? = null,
+        country: String? = null,
+        countryCode: String? = null,
+        language: String? = null,
+        tag: String? = null,
+        limit: Int = 50,
     ): FictionResult<List<RadioStation>> {
-        val trimmed = query.trim()
-        if (trimmed.isEmpty()) {
-            return FictionResult.Success(emptyList())
-        }
-        val url = "$BASE_URL/json/stations/byname/$trimmed"
+        // Refuse to fan out the full catalog — Radio Browser's
+        // /search endpoint returns ALL stations when called with no
+        // filters and we'd flood the UI list.
+        val hasAnyFacet = !name.isNullOrBlank() || !country.isNullOrBlank() ||
+            !countryCode.isNullOrBlank() || !language.isNullOrBlank() ||
+            !tag.isNullOrBlank()
+        if (!hasAnyFacet) return FictionResult.Success(emptyList())
+        val builder = "$BASE_URL/json/stations/search"
             .toHttpUrl().newBuilder()
             // `hidebroken=true` filters out stations Radio Browser's
             // own uptime checker has marked as broken — saves the user
             // from tapping "Play" on a dead URL.
             .addQueryParameter("hidebroken", "true")
             .addQueryParameter("limit", limit.coerceIn(1, 100).toString())
-            .build()
-            .toString()
-        return getJson<List<RadioBrowserStation>>(url)
+        if (!name.isNullOrBlank()) builder.addQueryParameter("name", name.trim())
+        if (!country.isNullOrBlank()) builder.addQueryParameter("country", country.trim())
+        if (!countryCode.isNullOrBlank()) {
+            builder.addQueryParameter("countrycode", countryCode.trim().uppercase())
+        }
+        if (!language.isNullOrBlank()) builder.addQueryParameter("language", language.trim())
+        if (!tag.isNullOrBlank()) builder.addQueryParameter("tag", tag.trim())
+        return getJson<List<RadioBrowserStation>>(builder.build().toString())
             .let { result ->
                 when (result) {
                     is FictionResult.Success -> FictionResult.Success(

--- a/source-rss/src/main/kotlin/in/jphe/storyvox/source/rss/RssSource.kt
+++ b/source-rss/src/main/kotlin/in/jphe/storyvox/source/rss/RssSource.kt
@@ -121,14 +121,18 @@ internal class RssSource @Inject constructor(
     }
 
     override fun filterDimensions(): List<FilterDimension> = listOf(
+        // Subscription summaries don't carry publish timestamps (we
+        // skip the network storm of fetching every feed on Browse
+        // open), so the only sort with a meaningful effect is Title.
+        // Default/Newest both fall through to natural subscription
+        // order; keep them as options for parity with other sources'
+        // Sort dimensions.
         FilterDimension.Sort(
             options = listOf(
                 FilterDimension.SortOption("relevance", "Default"),
-                FilterDimension.SortOption("last_update", "Newest"),
                 FilterDimension.SortOption("title", "Title"),
             ),
         ),
-        FilterDimension.DateRange(),
     )
 
     override fun applyFilters(base: SearchQuery, state: FilterState): SearchQuery {
@@ -136,7 +140,6 @@ internal class RssSource @Inject constructor(
         state.stringVal("sort")?.let { sortId ->
             q = q.copy(
                 orderBy = when (sortId) {
-                    "last_update" -> SearchOrder.LAST_UPDATE
                     "title" -> SearchOrder.TITLE
                     else -> SearchOrder.RELEVANCE
                 },
@@ -166,10 +169,20 @@ internal class RssSource @Inject constructor(
 
     override suspend fun search(query: SearchQuery): FictionResult<ListPage<FictionSummary>> {
         val term = query.term.trim().lowercase()
-        if (term.isEmpty()) return listSubscriptions(sortByMostRecent = true)
         val all = subscriptionSummaries()
-        val filtered = all.filter { it.title.lowercase().contains(term) }
-        return FictionResult.Success(ListPage(items = filtered, page = 1, hasNext = false))
+        val matched = if (term.isEmpty()) all else all.filter {
+            it.title.lowercase().contains(term)
+        }
+        // Sort dimension is the only one with a meaningful effect at
+        // this layer — we don't fan-out to fetch publish dates for the
+        // landing summaries (see [listSubscriptions]), so LAST_UPDATE
+        // falls through to natural subscription order. TITLE
+        // alphabetizes in memory.
+        val ordered = when (query.orderBy) {
+            SearchOrder.TITLE -> matched.sortedBy { it.title.lowercase() }
+            else -> matched
+        }
+        return FictionResult.Success(ListPage(items = ordered, page = 1, hasNext = false))
     }
 
     private suspend fun listSubscriptions(

--- a/source-standard-ebooks/src/main/kotlin/in/jphe/storyvox/source/standardebooks/StandardEbooksSource.kt
+++ b/source-standard-ebooks/src/main/kotlin/in/jphe/storyvox/source/standardebooks/StandardEbooksSource.kt
@@ -154,11 +154,29 @@ internal class StandardEbooksSource @Inject constructor(
 
     override suspend fun search(query: SearchQuery): FictionResult<ListPage<FictionSummary>> {
         val term = query.term.trim()
-        if (term.isEmpty()) {
-            return FictionResult.Success(ListPage(items = emptyList(), page = 1, hasNext = false))
-        }
         val page = query.page ?: 1
-        return api.search(term, page).map { it.toListPage(page) }
+        val sort = query.orderBy.toSeSortKey()
+        // The category dimension lands in [SearchQuery.tags] as a
+        // display-cased label (e.g. "Science Fiction"); SE wants its
+        // slug form ("science-fiction"). First non-empty tag wins —
+        // SE's listing endpoint only honors a single `tags[]` value at
+        // a time.
+        val tag = query.tags.firstOrNull()
+            ?.takeIf { it.isNotBlank() }
+            ?.toSeTagSlug()
+        if (term.isEmpty()) {
+            // Filter sheet may activate without a term ("Sort by Title");
+            // the Filtered route still flows through search() here, so
+            // serve a bare listing rather than empty when a sort or tag
+            // is active.
+            return if (sort == "default" && tag == null) {
+                FictionResult.Success(ListPage(items = emptyList(), page = 1, hasNext = false))
+            } else {
+                api.listing(page = page, sort = sort, tag = tag).map { it.toListPage(page) }
+            }
+        }
+        return api.search(term = term, page = page, sort = sort, tag = tag)
+            .map { it.toListPage(page) }
     }
 
     override suspend fun genres(): FictionResult<List<String>> =
@@ -428,6 +446,18 @@ private fun SeBookEntry.toSummary(): FictionSummary =
  *  SE's lowercase-hyphenated subject slug. Keeps the surface stable
  *  even as SE adds new subjects: unknown labels fall through to a
  *  reasonable slugification (`lowercase + spaces→hyphens`). */
+/** Map storyvox [SearchOrder] to the sort keys SE's listing endpoint
+ *  accepts (`default` = release date desc, plus `popularity` / `author-name`
+ *  / `title`). Unmapped orderings fall back to `default` so the listing
+ *  always renders. */
+private fun SearchOrder.toSeSortKey(): String = when (this) {
+    SearchOrder.POPULARITY -> "popularity"
+    SearchOrder.LAST_UPDATE, SearchOrder.RELEASE_DATE -> "default"
+    SearchOrder.TITLE -> "title"
+    SearchOrder.AUTHOR -> "author-name"
+    else -> "default"
+}
+
 private fun String.toSeTagSlug(): String = when (lowercase()) {
     "fiction" -> "fiction"
     "adventure" -> "adventure"

--- a/source-standard-ebooks/src/main/kotlin/in/jphe/storyvox/source/standardebooks/net/StandardEbooksApi.kt
+++ b/source-standard-ebooks/src/main/kotlin/in/jphe/storyvox/source/standardebooks/net/StandardEbooksApi.kt
@@ -62,9 +62,28 @@ internal open class StandardEbooksApi @Inject constructor(
     suspend fun latestUpdates(page: Int): FictionResult<SeListPage> =
         getListing(page = page, sort = "default")
 
-    /** Free-form search hits the same listing endpoint with `?query=`. */
-    suspend fun search(term: String, page: Int): FictionResult<SeListPage> =
-        getListing(page = page, sort = "default", query = term)
+    /** Free-form search hits the same listing endpoint with `?query=`.
+     *  [sort] mirrors SE's own sort keys (`default`, `popularity`,
+     *  `release-date`, `author-name`, `title`). [tag] is the SE subject
+     *  slug (fiction, adventure, …) and gets passed as `tags[]=<slug>`
+     *  when present so an active category filter narrows the search. */
+    suspend fun search(
+        term: String,
+        page: Int,
+        sort: String = "default",
+        tag: String? = null,
+    ): FictionResult<SeListPage> =
+        getListing(page = page, sort = sort, query = term, tag = tag)
+
+    /** Bare listing for the Filtered-but-no-term browse case. Mirrors
+     *  [popular]/[latestUpdates] but lets callers compose sort+tag from
+     *  filter state without a query string. */
+    suspend fun listing(
+        page: Int,
+        sort: String = "default",
+        tag: String? = null,
+    ): FictionResult<SeListPage> =
+        getListing(page = page, sort = sort, tag = tag)
 
     /**
      * Subject-filtered listing. SE's `tags[]=` query param matches its

--- a/source-wikipedia/src/main/kotlin/in/jphe/storyvox/source/wikipedia/WikipediaSource.kt
+++ b/source-wikipedia/src/main/kotlin/in/jphe/storyvox/source/wikipedia/WikipediaSource.kt
@@ -2,8 +2,6 @@ package `in`.jphe.storyvox.source.wikipedia
 
 import `in`.jphe.storyvox.data.source.FictionSource
 import `in`.jphe.storyvox.data.source.SourceIds
-import `in`.jphe.storyvox.data.source.filter.FilterDimension
-import `in`.jphe.storyvox.data.source.filter.FilterState
 import `in`.jphe.storyvox.data.source.plugin.SourceCategory
 import `in`.jphe.storyvox.data.source.plugin.SourcePlugin
 import `in`.jphe.storyvox.data.source.model.ChapterContent
@@ -92,25 +90,14 @@ internal class WikipediaSource @Inject constructor(
         )
     }
 
-    override fun filterDimensions(): List<FilterDimension> = listOf(
-        FilterDimension.Select(
-            key = "language",
-            label = "Language",
-            options = listOf("en", "es", "fr", "de", "it", "ja", "zh", "ru", "pt", "ar"),
-        ),
-    )
-
-    override fun applyFilters(base: SearchQuery, state: FilterState): SearchQuery {
-        // Language is silently stored on the SearchQuery term so it
-        // survives the round-trip; host switching is a follow-up.
-        var q = base
-        state.stringVal("language")?.takeIf { it.isNotBlank() }?.let { lang ->
-            val composed = if (q.term.isBlank()) "language:$lang"
-                else "${q.term} language:$lang"
-            q = q.copy(term = composed)
-        }
-        return q
-    }
+    // Wikipedia exposes no per-search filter dimensions today. The
+    // article language is a settings-level choice persisted through
+    // [WikipediaConfig] (DataStore); a one-shot Browse filter would
+    // need a config-write side-effect we don't surface from here.
+    // Pre-fix this declared a "language" Select whose applyFilters
+    // appended `language:<code>` to SearchQuery.term — opensearch then
+    // searched for that string literally, breaking every faceted
+    // query. Removed entirely until a proper language-picker UI lands.
 
     // ─── browse ────────────────────────────────────────────────────────
 

--- a/source-wikisource/src/main/kotlin/in/jphe/storyvox/source/wikisource/WikisourceSource.kt
+++ b/source-wikisource/src/main/kotlin/in/jphe/storyvox/source/wikisource/WikisourceSource.kt
@@ -13,6 +13,7 @@ import `in`.jphe.storyvox.data.source.model.FictionResult
 import `in`.jphe.storyvox.data.source.model.FictionStatus
 import `in`.jphe.storyvox.data.source.model.FictionSummary
 import `in`.jphe.storyvox.data.source.model.ListPage
+import `in`.jphe.storyvox.data.source.model.SearchOrder
 import `in`.jphe.storyvox.data.source.model.SearchQuery
 import `in`.jphe.storyvox.source.wikisource.net.WikisourceApi
 import `in`.jphe.storyvox.source.wikisource.net.WikisourceCategoryMember
@@ -95,19 +96,29 @@ internal class WikisourceSource @Inject constructor(
     }
 
     override fun filterDimensions(): List<FilterDimension> = listOf(
-        FilterDimension.Select(
-            key = "language",
-            label = "Language",
-            options = listOf("en", "es", "fr", "de", "it", "pt"),
+        // MediaWiki's `srsort` is the only per-search facet that's
+        // wired in v1. Pre-fix this declared a "language" Select that
+        // poisoned the search term with `language:<code>` — Wikisource
+        // is pinned to en.wikisource.org by [WikisourceApi.BASE_URL]
+        // anyway, so the filter never had infra behind it. Dropped
+        // entirely until a per-language host config lands.
+        FilterDimension.Sort(
+            options = listOf(
+                FilterDimension.SortOption("relevance", "Default"),
+                FilterDimension.SortOption("last_update", "Recently edited"),
+            ),
         ),
     )
 
     override fun applyFilters(base: SearchQuery, state: FilterState): SearchQuery {
         var q = base
-        state.stringVal("language")?.takeIf { it.isNotBlank() }?.let { lang ->
-            val composed = if (q.term.isBlank()) "language:$lang"
-                else "${q.term} language:$lang"
-            q = q.copy(term = composed)
+        state.stringVal("sort")?.let { sortId ->
+            q = q.copy(
+                orderBy = when (sortId) {
+                    "last_update" -> SearchOrder.LAST_UPDATE
+                    else -> SearchOrder.RELEVANCE
+                },
+            )
         }
         return q
     }
@@ -153,7 +164,11 @@ internal class WikisourceSource @Inject constructor(
     override suspend fun search(query: SearchQuery): FictionResult<ListPage<FictionSummary>> {
         val term = query.term.trim()
         if (term.isEmpty()) return popular(1)
-        return when (val r = api.search(term)) {
+        val sort = when (query.orderBy) {
+            SearchOrder.LAST_UPDATE -> "last_edit_desc"
+            else -> "relevance"
+        }
+        return when (val r = api.search(term, sort = sort)) {
             is FictionResult.Success ->
                 FictionResult.Success(
                     ListPage(

--- a/source-wikisource/src/main/kotlin/in/jphe/storyvox/source/wikisource/net/WikisourceApi.kt
+++ b/source-wikisource/src/main/kotlin/in/jphe/storyvox/source/wikisource/net/WikisourceApi.kt
@@ -90,15 +90,25 @@ internal class WikisourceApi @Inject constructor(
      * with image references). Restricting to ns0 gives us the parent
      * work pages users actually want to listen to.
      */
-    suspend fun search(term: String, limit: Int = 20): FictionResult<List<WikisourceSearchHit>> {
+    suspend fun search(
+        term: String,
+        limit: Int = 20,
+        sort: String = "relevance",
+    ): FictionResult<List<WikisourceSearchHit>> {
         val q = term.trim()
         if (q.isEmpty()) return FictionResult.Success(emptyList())
+        // MediaWiki's `srsort` accepts a small set of stable values:
+        // relevance (default), last_edit_desc, last_edit_asc,
+        // create_timestamp_desc, create_timestamp_asc. Unknown values
+        // are silently ignored server-side, so a typo here just falls
+        // back to relevance rather than 4xx-ing the request.
         val url = BASE_URL +
             "/w/api.php?action=query" +
             "&list=search" +
             "&srsearch=" + URLEncoder.encode(q, "UTF-8") +
             "&srnamespace=0" +
             "&srlimit=$limit" +
+            "&srsort=" + URLEncoder.encode(sort, "UTF-8") +
             "&format=json"
         return getJson<WikisourceSearchQueryResponse>(url).let { res ->
             when (res) {


### PR DESCRIPTION
## Summary

Audit + fix for every browse-source whose `filterDimensions()` declared filters that `applyFilters()` / `search()` then dropped on the floor. Pattern across the codebase: dimensions composed `q.copy(orderBy = …)` or `q.copy(tags = q.tags + …)` but `search()` only forwarded `query.term` to the API, so the dimensions were UI-only.

**Sources fixed (10):**

- **standard-ebooks** — sort + category → SE listing endpoint `sort=` + `tags[]=`
- **gutenberg** — language + category + sort → Gutendex `languages=` + `topic=` + `sort=` (was poisoning the search term with `language:en` literals)
- **arxiv** — category + sort → arXiv query `cat:` AND'd into search_query + `sortBy=lastUpdatedDate`
- **plos** — orderBy + category → Solr `sort=` + `fq=subject:`
- **hackernews** — category + sort + minScore → Algolia `tags=`, `/search_by_date` endpoint, `numericFilters=points>=N` (was poisoning the search term with category labels)
- **outline** — sort → in-memory ordering of collection list
- **notion (both PAT + TechEmpower)** — sort → in-memory ordering
- **rss** — sort → in-memory Title ordering; dropped dead Newest sort + DateRange dimensions (no backing timestamps)
- **wikipedia + wikisource** — removed broken Language Select that stuffed `language:en` into search term; wikisource gets a real Sort dimension wired to MediaWiki `srsort=last_edit_desc`
- **source-radio (#795)** — added country, countryCode, language, tag filter dimensions wired to Radio Browser's `/json/stations/search` endpoint (was declaring no filterDimensions despite the wire shape exposing them)

Common pattern fixed: previously `applyFilters` stuffed filter values into `SearchQuery.term` as `"language:en"`-style sentinels, then `search()` forwarded those to the upstream API as literal search text — so the filter actively broke search rather than narrowing it. The fix routes facets through the dedicated SearchQuery fields (`tags`, `genres`, `orderBy`, `minRating`) and namespaced tag sentinels.

Sources reviewed and confirmed already correct: **royalroad** (canonical reference), **github** (qualifier-laden term composition is correct), **discord** (no filterDimensions, search OK), **matrix** + **mempalace** + **palace** (no filterDimensions; search intentionally empty per v1 spec).

AO3 fix is in task #1 / a sibling PR (#lyra) — not touched here.

## Test plan

- [x] `./gradlew testDebugUnitTest` passes
- [x] `./gradlew :app:compileDebugKotlin` passes
- [x] Per-module compile + tests for every touched source-* module

🤖 Generated with [Claude Code](https://claude.com/claude-code)