### PR TITLE
fix(download): recover from stuck chapter downloads

### DIFF
--- a/app/src/main/kotlin/in/jphe/storyvox/di/AppBindings.kt
+++ b/app/src/main/kotlin/in/jphe/storyvox/di/AppBindings.kt
@@ -988,9 +988,15 @@ internal class RealPlaybackControllerUi(
         scope.launch {
             // Kick off the download (idempotent — WorkManager dedupes by uniqueName).
             // requireUnmetered=false: user just tapped Listen; honour their intent.
+            android.util.Log.i("PlaybackBindings", "startListening: fiction=$fictionId chapter=$chapterId offset=$charOffset autoPlay=$autoPlay")
             chapters.queueChapterDownload(fictionId, chapterId, requireUnmetered = false)
-            // Wait for the first non-null body to land in the DB.
-            chapters.observeChapter(chapterId).filterNotNull().first()
+            val ready = kotlinx.coroutines.withTimeoutOrNull(30_000L) {
+                chapters.observeChapter(chapterId).filterNotNull().first()
+            }
+            if (ready == null) {
+                android.util.Log.e("PlaybackBindings", "startListening: chapter $chapterId body not ready within 30s — aborting")
+                return@launch
+            }
             controller.play(fictionId, chapterId, charOffset = charOffset)
             // #90 smart-resume — when the user explicitly paused the
             // last session, Library's Resume CTA loads the chapter

--- a/core-data/src/main/kotlin/in/jphe/storyvox/data/repository/ChapterDownloadScheduler.kt
+++ b/core-data/src/main/kotlin/in/jphe/storyvox/data/repository/ChapterDownloadScheduler.kt
@@ -55,9 +55,10 @@ class WorkManagerChapterDownloadScheduler @Inject constructor(
             .addTag(ChapterDownloadWorker.TAG)
             .build()
 
+        android.util.Log.i("ChapterDownload", "schedule: chapter=$chapterId fiction=$fictionId unmetered=$requireUnmetered")
         workManager.enqueueUniqueWork(
             ChapterDownloadWorker.uniqueName(chapterId),
-            ExistingWorkPolicy.KEEP,
+            ExistingWorkPolicy.REPLACE,
             request,
         )
     }


### PR DESCRIPTION
## Summary
- Change `ExistingWorkPolicy.KEEP` → `REPLACE` so new download requests replace stuck/failed old ones
- Add 30s timeout to `startListening`'s `observeChapter` wait — no longer hangs forever
- Add diagnostic logging at download schedule + startListening entry points

Fixes the cascade where low battery → blocked WorkManager → KEEP dedupes new requests → infinite hang in startListening.

## Test plan
- [ ] Play a book on low battery (<15%) — chapter loads normally
- [ ] Switch books mid-playback — new book loads within 30s
- [ ] Check logcat for `PlaybackBindings` and `ChapterDownload` tags

🤖 Generated with [Claude Code](https://claude.com/claude-code)