### PR TITLE
perf(sync): batch PlaybackPositionSyncer into one DAO call — closes #777

### DIFF
--- a/core-data/src/main/kotlin/in/jphe/storyvox/data/db/dao/PlaybackDao.kt
+++ b/core-data/src/main/kotlin/in/jphe/storyvox/data/db/dao/PlaybackDao.kt
@@ -23,6 +23,20 @@ interface PlaybackDao {
     suspend fun delete(fictionId: String)
 
     /**
+     * Slim "all positions" projection used by [PlaybackPositionSyncer] to build
+     * its sync payload in one Room round-trip. Returns only the fields the wire
+     * `Entry` needs; skips bigger columns that aren't part of the sync record.
+     */
+    @Query(
+        """
+        SELECT fictionId, chapterId, charOffset, paragraphIndex,
+               playbackSpeed, durationEstimateMs, updatedAt
+          FROM playback_position
+        """,
+    )
+    suspend fun allPositionsSnapshot(): List<PlaybackPositionSnapshotRow>
+
+    /**
      * Denormalized "recently played" feed for the Auto/Wear menu — flattens
      * fiction title + cover + chapter title into one row so the playback
      * layer doesn't need follow-up queries while building Auto's browse tree.
@@ -129,4 +143,15 @@ data class RecentPlaybackRow(
     val bookTitle: String,
     val chapterTitle: String,
     val coverUrl: String?,
+)
+
+/** Slim projection of [PlaybackPosition] for sync snapshots. */
+data class PlaybackPositionSnapshotRow(
+    val fictionId: String,
+    val chapterId: String,
+    val charOffset: Int,
+    val paragraphIndex: Int,
+    val playbackSpeed: Float,
+    val durationEstimateMs: Long,
+    val updatedAt: Long,
 )

--- a/core-data/src/test/kotlin/in/jphe/storyvox/data/db/dao/PlaybackDaoTest.kt
+++ b/core-data/src/test/kotlin/in/jphe/storyvox/data/db/dao/PlaybackDaoTest.kt
@@ -194,6 +194,42 @@ class PlaybackDaoTest {
     }
 
     @Test
+    fun allPositionsSnapshot_returnsEveryRow_withSyncFields() = runTest {
+        fictionDao.upsert(fiction("f1"))
+        fictionDao.upsert(fiction("f2"))
+        chapterDao.upsert(chapter("c1", "f1"))
+        chapterDao.upsert(chapter("c2", "f2"))
+        dao.upsert(
+            PlaybackPosition(
+                fictionId = "f1",
+                chapterId = "c1",
+                charOffset = 42,
+                paragraphIndex = 3,
+                playbackSpeed = 1.25f,
+                durationEstimateMs = 9_999L,
+                updatedAt = 100L,
+            ),
+        )
+        dao.upsert(PlaybackPosition("f2", "c2", updatedAt = 200L))
+
+        val rows = dao.allPositionsSnapshot().associateBy { it.fictionId }
+        assertEquals(2, rows.size)
+        val r1 = rows.getValue("f1")
+        assertEquals("c1", r1.chapterId)
+        assertEquals(42, r1.charOffset)
+        assertEquals(3, r1.paragraphIndex)
+        assertEquals(1.25f, r1.playbackSpeed, 0.0001f)
+        assertEquals(9_999L, r1.durationEstimateMs)
+        assertEquals(100L, r1.updatedAt)
+        assertEquals("f2", rows.getValue("f2").fictionId)
+    }
+
+    @Test
+    fun allPositionsSnapshot_emptyDb_returnsEmptyList() = runTest {
+        assertEquals(emptyList<PlaybackPositionSnapshotRow>(), dao.allPositionsSnapshot())
+    }
+
+    @Test
     fun upsertThenDelete_isIdempotent() = runTest {
         fictionDao.upsert(fiction("f1"))
         chapterDao.upsert(chapter("c1", "f1"))

--- a/core-sync/src/main/kotlin/in/jphe/storyvox/sync/domain/PlaybackPositionSyncer.kt
+++ b/core-sync/src/main/kotlin/in/jphe/storyvox/sync/domain/PlaybackPositionSyncer.kt
@@ -58,16 +58,6 @@ class PlaybackPositionSyncer @Inject constructor(
     override suspend fun pull(user: SignedInUser): SyncOutcome = reconcile(user)
 
     private suspend fun reconcile(user: SignedInUser): SyncOutcome {
-        // Read local. We don't have an "all positions" DAO method yet —
-        // synthesize from the library. The library + follows are the only
-        // contexts a position is meaningful in (a position outside the
-        // library means the user once played a book they didn't add;
-        // we still sync it because losing it on uninstall is what this
-        // whole effort is fixing).
-        // For v1 we use a workaround: walk the library's fictions and
-        // ask the dao per id. This is O(library-size) round-trips on
-        // pull. Acceptable for v1; revisit when we have a hundreds-of-
-        // fictions library on a tablet.
         val localPositions = localSnapshot()
 
         val remote = backend.fetch(user, ENTITY, rowId(user)).getOrElse {
@@ -129,28 +119,25 @@ class PlaybackPositionSyncer @Inject constructor(
         return SyncOutcome.Ok(writes)
     }
 
-    /** Pull every fiction's position into a map. v1 uses no batch DAO
-     *  call; relies on the per-id `playbackDao.get`. */
+    /**
+     * Pull every fiction's position into a map. One Room round-trip via the
+     * slim [PlaybackDao.allPositionsSnapshot] projection — no per-id follow-up
+     * `get()` calls. See issue #777.
+     */
     private suspend fun localSnapshot(): Map<String, Entry> {
-        // The DAO doesn't have an `all()`; use a SQL probe via the recent feed
-        // capped to a high limit. v1 leaves the absence of a proper `all()` as
-        // a documented limitation — see docs/sync.md.
-        val rows = playbackDao.recent(limit = 10_000)
+        val rows = playbackDao.allPositionsSnapshot()
         if (rows.isEmpty()) return emptyMap()
-        val byId = mutableMapOf<String, Entry>()
-        for (r in rows) {
-            val pos = playbackDao.get(r.fictionId) ?: continue
-            byId[pos.fictionId] = Entry(
-                fictionId = pos.fictionId,
-                chapterId = pos.chapterId,
-                charOffset = pos.charOffset,
-                paragraphIndex = pos.paragraphIndex,
-                playbackSpeed = pos.playbackSpeed,
-                durationEstimateMs = pos.durationEstimateMs,
-                updatedAt = pos.updatedAt,
+        return rows.associate { r ->
+            r.fictionId to Entry(
+                fictionId = r.fictionId,
+                chapterId = r.chapterId,
+                charOffset = r.charOffset,
+                paragraphIndex = r.paragraphIndex,
+                playbackSpeed = r.playbackSpeed,
+                durationEstimateMs = r.durationEstimateMs,
+                updatedAt = r.updatedAt,
             )
         }
-        return byId
     }
 
     private fun Entry.toEntity(): PlaybackPosition = PlaybackPosition(


### PR DESCRIPTION
## Summary
- `PlaybackPositionSyncer.localSnapshot()` was doing O(library-size) Room round-trips: `recent(10_000)` to enumerate rows, then `playbackDao.get(fictionId)` per row to re-read the same table. Issue #777 has the evidence and proposal.
- Adds `PlaybackDao.allPositionsSnapshot()` — a slim projection returning only the seven columns the wire `Entry` needs (`fictionId`, `chapterId`, `charOffset`, `paragraphIndex`, `playbackSpeed`, `durationEstimateMs`, `updatedAt`). Syncer maps directly from the row — one round-trip, no per-id follow-up.
- Removes the pre-existing kdoc and inline TODO comments that documented the workaround as a v1 limitation.

## Why
- Cold-start cost scales with library size — on a 200-fiction library that's 200 SQL trips per sync round, and `SyncCoordinator.initialize()` + every `requestPush("positions")` from the playback layer multiplies the cost.
- The slim projection skips the bigger columns that `playback_position` doesn't actually carry, but more importantly avoids the second `SELECT *` per row.

## Test plan
- [x] `./gradlew :core-data:compileDebugKotlin :core-sync:compileDebugKotlin` — clean
- [ ] `./gradlew :core-data:testDebugUnitTest` — **blocked by pre-existing compile failure unrelated to this PR**: `FakeChapterDao` in `BookmarksSyncerTest`, `ChapterRepositoryImplTest`, and `FictionRepositoryImplTest` doesn't override the `exists()` method that landed in 7b89fe88 (#823 / FK guard fix). Same failure reproduces on `main` with my changes reverted. Should be cleaned up in a separate PR.
- [x] New tests added in `PlaybackDaoTest`: `allPositionsSnapshot_returnsEveryRow_withSyncFields` (verifies projection round-trips all sync columns intact) and `allPositionsSnapshot_emptyDb_returnsEmptyList`.

Closes #777

🤖 Generated with [Claude Code](https://claude.com/claude-code)