### PR TITLE
fix(sources): add coerceInputValues to all JSON source configs

### DIFF
--- a/source-discord/src/main/kotlin/in/jphe/storyvox/source/discord/net/DiscordApi.kt
+++ b/source-discord/src/main/kotlin/in/jphe/storyvox/source/discord/net/DiscordApi.kt
@@ -52,7 +52,7 @@ internal class DiscordApi @Inject constructor(
     private val client: OkHttpClient,
     private val config: DiscordConfig,
 ) {
-    private val json = Json { ignoreUnknownKeys = true; isLenient = true }
+    private val json = Json { ignoreUnknownKeys = true; isLenient = true; coerceInputValues = true }
 
     /**
      * List guilds the bot has been invited to. Drives the Settings

--- a/source-github/src/main/kotlin/in/jphe/storyvox/source/github/auth/DeviceFlowApi.kt
+++ b/source-github/src/main/kotlin/in/jphe/storyvox/source/github/auth/DeviceFlowApi.kt
@@ -213,6 +213,7 @@ open class DeviceFlowApi @Inject constructor(
         private val JSON: Json = Json {
             ignoreUnknownKeys = true
             explicitNulls = false
+            coerceInputValues = true
         }
     }
 }

--- a/source-github/src/main/kotlin/in/jphe/storyvox/source/github/auth/GitHubProfileService.kt
+++ b/source-github/src/main/kotlin/in/jphe/storyvox/source/github/auth/GitHubProfileService.kt
@@ -85,6 +85,7 @@ open class GitHubProfileService @Inject constructor(
         val JSON: Json = Json {
             ignoreUnknownKeys = true
             explicitNulls = false
+            coerceInputValues = true
         }
     }
 }

--- a/source-gutenberg/src/main/kotlin/in/jphe/storyvox/source/gutenberg/net/GutendexApi.kt
+++ b/source-gutenberg/src/main/kotlin/in/jphe/storyvox/source/gutenberg/net/GutendexApi.kt
@@ -31,7 +31,7 @@ import javax.inject.Singleton
 internal class GutendexApi @Inject constructor(
     private val client: OkHttpClient,
 ) {
-    private val json = Json { ignoreUnknownKeys = true; isLenient = true }
+    private val json = Json { ignoreUnknownKeys = true; isLenient = true; coerceInputValues = true }
 
     /**
      * `GET /books?page=N&sort=popular` — default Gutendex sort is by

--- a/source-hackernews/src/main/kotlin/in/jphe/storyvox/source/hackernews/net/HackerNewsApi.kt
+++ b/source-hackernews/src/main/kotlin/in/jphe/storyvox/source/hackernews/net/HackerNewsApi.kt
@@ -41,7 +41,7 @@ import javax.inject.Singleton
 internal open class HackerNewsApi @Inject constructor(
     private val client: OkHttpClient,
 ) {
-    private val json = Json { ignoreUnknownKeys = true; isLenient = true }
+    private val json = Json { ignoreUnknownKeys = true; isLenient = true; coerceInputValues = true }
 
     /**
      * `GET /v0/topstories.json` — array of ids, highest-ranked first.

--- a/source-matrix/src/main/kotlin/in/jphe/storyvox/source/matrix/net/MatrixApi.kt
+++ b/source-matrix/src/main/kotlin/in/jphe/storyvox/source/matrix/net/MatrixApi.kt
@@ -68,7 +68,7 @@ internal class MatrixApi @Inject constructor(
     private val client: OkHttpClient,
     private val config: MatrixConfig,
 ) {
-    private val json = Json { ignoreUnknownKeys = true; isLenient = true }
+    private val json = Json { ignoreUnknownKeys = true; isLenient = true; coerceInputValues = true }
 
     /**
      * Verify the access token and resolve `@user:homeserver`.

--- a/source-mempalace/src/main/kotlin/in/jphe/storyvox/source/mempalace/net/PalaceDaemonApi.kt
+++ b/source-mempalace/src/main/kotlin/in/jphe/storyvox/source/mempalace/net/PalaceDaemonApi.kt
@@ -291,6 +291,7 @@ open class PalaceDaemonApi @Inject constructor(
         internal val JSON = Json {
             ignoreUnknownKeys = true
             isLenient = true
+            coerceInputValues = true
         }
         private val JSON_MEDIA_TYPE = "application/json".toMediaType()
         /** Case-insensitive match for `http://` or `https://` at start of

--- a/source-notion/src/main/kotlin/in/jphe/storyvox/source/notion/net/NotionApi.kt
+++ b/source-notion/src/main/kotlin/in/jphe/storyvox/source/notion/net/NotionApi.kt
@@ -46,7 +46,7 @@ internal class NotionApi @Inject constructor(
     private val client: OkHttpClient,
     private val config: NotionConfig,
 ) {
-    private val json = Json { ignoreUnknownKeys = true; isLenient = true }
+    private val json = Json { ignoreUnknownKeys = true; isLenient = true; coerceInputValues = true }
     private val mediaTypeJson = "application/json".toMediaType()
 
     /**

--- a/source-notion/src/main/kotlin/in/jphe/storyvox/source/notion/net/NotionUnofficialApi.kt
+++ b/source-notion/src/main/kotlin/in/jphe/storyvox/source/notion/net/NotionUnofficialApi.kt
@@ -72,7 +72,7 @@ internal class NotionUnofficialApi @Inject constructor(
     private val client: OkHttpClient,
     private val config: NotionConfig,
 ) {
-    private val json = Json { ignoreUnknownKeys = true; isLenient = true }
+    private val json = Json { ignoreUnknownKeys = true; isLenient = true; coerceInputValues = true }
     private val mediaTypeJson = "application/json".toMediaType()
 
     /**

--- a/source-outline/src/main/kotlin/in/jphe/storyvox/source/outline/net/OutlineApi.kt
+++ b/source-outline/src/main/kotlin/in/jphe/storyvox/source/outline/net/OutlineApi.kt
@@ -34,7 +34,7 @@ internal class OutlineApi @Inject constructor(
     private val client: OkHttpClient,
     private val config: OutlineConfig,
 ) {
-    private val json = Json { ignoreUnknownKeys = true; isLenient = true }
+    private val json = Json { ignoreUnknownKeys = true; isLenient = true; coerceInputValues = true }
 
     suspend fun collections(): FictionResult<List<OutlineCollection>> =
         post<CollectionsResponse>("/api/collections.list", body = """{"limit":100}""")

--- a/source-plos/src/main/kotlin/in/jphe/storyvox/source/plos/net/PlosApi.kt
+++ b/source-plos/src/main/kotlin/in/jphe/storyvox/source/plos/net/PlosApi.kt
@@ -41,7 +41,7 @@ import kotlin.time.Duration.Companion.seconds
 internal class PlosApi @Inject constructor(
     private val client: OkHttpClient,
 ) {
-    private val json = Json { ignoreUnknownKeys = true; isLenient = true }
+    private val json = Json { ignoreUnknownKeys = true; isLenient = true; coerceInputValues = true }
 
     // ─── search (Solr) ─────────────────────────────────────────────────
 

--- a/source-radio/src/main/kotlin/in/jphe/storyvox/source/radio/net/RadioBrowserApi.kt
+++ b/source-radio/src/main/kotlin/in/jphe/storyvox/source/radio/net/RadioBrowserApi.kt
@@ -64,7 +64,7 @@ import kotlin.time.Duration.Companion.seconds
 internal class RadioBrowserApi @Inject constructor(
     private val client: OkHttpClient,
 ) {
-    private val json = Json { ignoreUnknownKeys = true; isLenient = true }
+    private val json = Json { ignoreUnknownKeys = true; isLenient = true; coerceInputValues = true }
 
     /**
      * Search stations by name (case-insensitive fuzzy match server-side).

--- a/source-royalroad/src/main/kotlin/in/jphe/storyvox/source/royalroad/parser/FictionDetailParser.kt
+++ b/source-royalroad/src/main/kotlin/in/jphe/storyvox/source/royalroad/parser/FictionDetailParser.kt
@@ -29,7 +29,7 @@ import org.jsoup.nodes.Document
  */
 internal object FictionDetailParser {
 
-    private val json = Json { ignoreUnknownKeys = true; isLenient = true }
+    private val json = Json { ignoreUnknownKeys = true; isLenient = true; coerceInputValues = true }
 
     fun parse(html: String, fictionId: String): FictionDetail {
         val doc = Jsoup.parse(html, RoyalRoadIds.BASE_URL)

--- a/source-slack/src/main/kotlin/in/jphe/storyvox/source/slack/net/SlackApi.kt
+++ b/source-slack/src/main/kotlin/in/jphe/storyvox/source/slack/net/SlackApi.kt
@@ -66,7 +66,7 @@ internal class SlackApi @Inject constructor(
     private val client: OkHttpClient,
     private val config: SlackConfig,
 ) {
-    private val json = Json { ignoreUnknownKeys = true; isLenient = true }
+    private val json = Json { ignoreUnknownKeys = true; isLenient = true; coerceInputValues = true }
 
     /**
      * Verify the bot token + return workspace metadata. Drives the

--- a/source-telegram/src/main/kotlin/in/jphe/storyvox/source/telegram/net/TelegramApi.kt
+++ b/source-telegram/src/main/kotlin/in/jphe/storyvox/source/telegram/net/TelegramApi.kt
@@ -66,7 +66,7 @@ internal class TelegramApi @Inject constructor(
     private val client: OkHttpClient,
     private val config: TelegramConfig,
 ) {
-    private val json = Json { ignoreUnknownKeys = true; isLenient = true }
+    private val json = Json { ignoreUnknownKeys = true; isLenient = true; coerceInputValues = true }
 
     /**
      * Verify the bot token + return the bot identity. Drives the

--- a/source-wikipedia/src/main/kotlin/in/jphe/storyvox/source/wikipedia/net/WikipediaApi.kt
+++ b/source-wikipedia/src/main/kotlin/in/jphe/storyvox/source/wikipedia/net/WikipediaApi.kt
@@ -48,7 +48,7 @@ internal class WikipediaApi @Inject constructor(
     private val client: OkHttpClient,
     private val config: WikipediaConfig,
 ) {
-    private val json = Json { ignoreUnknownKeys = true; isLenient = true }
+    private val json = Json { ignoreUnknownKeys = true; isLenient = true; coerceInputValues = true }
 
     // ─── opensearch ────────────────────────────────────────────────────
 

--- a/source-wikisource/src/main/kotlin/in/jphe/storyvox/source/wikisource/net/WikisourceApi.kt
+++ b/source-wikisource/src/main/kotlin/in/jphe/storyvox/source/wikisource/net/WikisourceApi.kt
@@ -40,7 +40,7 @@ import kotlin.time.Duration.Companion.seconds
 internal class WikisourceApi @Inject constructor(
     private val client: OkHttpClient,
 ) {
-    private val json = Json { ignoreUnknownKeys = true; isLenient = true }
+    private val json = Json { ignoreUnknownKeys = true; isLenient = true; coerceInputValues = true }
 
     // ─── browse landing ────────────────────────────────────────────────
 


### PR DESCRIPTION
## Summary
- Closes #800
- Only `source-github`'s `GitHubJson` config carried `coerceInputValues = true`; every other source would throw `SerializationException` when an API returned `null` for a non-nullable field with a default — surfacing as a generic "unexpected response" failure
- Adds `coerceInputValues = true` to **17 production `Json` configs** across: discord, github (auth: `DeviceFlowApi` + `GitHubProfileService`), gutenberg, hackernews, matrix, mempalace, notion (`Api` + `UnofficialApi`), outline, plos, radio, royalroad, slack, telegram, wikipedia, wikisource
- One-liner per file for the single-line builders; one added line for the multi-line builders (`PalaceDaemonApi`, GitHub `auth` services)

## Why this matters
Per the issue: APIs routinely return `null` for optional fields with default values (Notion pages with no title, Slack messages from deleted channels with null reactions, etc.). Today these silently fall through to `FictionResult.Failure(SerializationException)` instead of using the default. This change makes parsing tolerant on every source.

## Test plan
- [x] `./gradlew compileDebugKotlin` clean (only pre-existing Compose `ArrowBack` deprecation warnings)
- [x] `./gradlew :source-discord:testDebugUnitTest :source-gutenberg:testDebugUnitTest :source-hackernews:testDebugUnitTest :source-matrix:testDebugUnitTest :source-notion:testDebugUnitTest :source-outline:testDebugUnitTest :source-plos:testDebugUnitTest :source-slack:testDebugUnitTest :source-telegram:testDebugUnitTest :source-wikipedia:testDebugUnitTest :source-wikisource:testDebugUnitTest :source-radio:testDebugUnitTest :source-royalroad:testDebugUnitTest :source-mempalace:testDebugUnitTest :source-github:testDebugUnitTest` — all green
- [ ] CI green

## Notes for reviewers
The issue's proposed approach (PR 1) was to extract a shared `SourceJson` helper in `core-data` first. This PR takes the simpler mechanical path the team-lead requested: add the flag in-place to each existing `Json { }` block. Follow-ups (shared helper extraction + CI lint to enforce the flag on new sources) remain trackable on #800.

🤖 Generated with [Claude Code](https://claude.com/claude-code)