### PR TITLE
fix(sync): persist PronunciationDictSyncer write stamp — closes #778

### DIFF
--- a/app/src/main/kotlin/in/jphe/storyvox/data/SettingsRepositoryUiImpl.kt
+++ b/app/src/main/kotlin/in/jphe/storyvox/data/SettingsRepositoryUiImpl.kt
@@ -707,6 +707,19 @@ private object Keys {
      *  (`ignoreUnknownKeys = true; encodeDefaults = true`). */
     val PRONUNCIATION_DICT = stringPreferencesKey("pref_pronunciation_dict_v1")
 
+    /** Issue #778 — epoch-ms stamp of the last local edit to
+     *  [PRONUNCIATION_DICT]. Persisted alongside the dict in the main
+     *  `storyvox_settings` DataStore so the `PronunciationDictSyncer`'s
+     *  LWW push survives cold starts. Before this key existed, the
+     *  syncer kept an in-memory `var lastLocalWriteAt: Long = 0L` that
+     *  reset to 0 on every process restart — `readLocal` then stamped
+     *  the dict with `System.currentTimeMillis()` and a stale local
+     *  dict won blanket against newer remotes. Excluded from
+     *  [SYNC_ALLOWLIST] for the same reason
+     *  `instantdb.settings_synced_at` is excluded — syncing the stamp
+     *  itself would loop. */
+    val PRONUNCIATION_DICT_WRITE_AT = longPreferencesKey("instantdb.pronunciation_dict_write_at")
+
     // ── Calliope (v0.5.00) milestone celebration ──────────────────
     /** One-time gate for the brass "thank-you" dialog. Flips to true
      *  after the user taps Continue (or taps outside the card). Pre-
@@ -2433,6 +2446,7 @@ class SettingsRepositoryUiImpl(
             val current = decodePronunciationDictJson(prefs[Keys.PRONUNCIATION_DICT])
             val next = current.copy(entries = current.entries + entry)
             prefs[Keys.PRONUNCIATION_DICT] = encodePronunciationDictJson(next)
+            prefs[Keys.PRONUNCIATION_DICT_WRITE_AT] = System.currentTimeMillis()
         }
     }
 
@@ -2442,6 +2456,7 @@ class SettingsRepositoryUiImpl(
             if (index !in current.entries.indices) return@edit
             val newList = current.entries.toMutableList().apply { this[index] = entry }
             prefs[Keys.PRONUNCIATION_DICT] = encodePronunciationDictJson(current.copy(entries = newList))
+            prefs[Keys.PRONUNCIATION_DICT_WRITE_AT] = System.currentTimeMillis()
         }
     }
 
@@ -2451,11 +2466,32 @@ class SettingsRepositoryUiImpl(
             if (index !in current.entries.indices) return@edit
             val newList = current.entries.toMutableList().apply { removeAt(index) }
             prefs[Keys.PRONUNCIATION_DICT] = encodePronunciationDictJson(current.copy(entries = newList))
+            prefs[Keys.PRONUNCIATION_DICT_WRITE_AT] = System.currentTimeMillis()
         }
     }
 
     override suspend fun replaceAll(dict: PronunciationDict) {
-        store.edit { it[Keys.PRONUNCIATION_DICT] = encodePronunciationDictJson(dict) }
+        store.edit {
+            it[Keys.PRONUNCIATION_DICT] = encodePronunciationDictJson(dict)
+            it[Keys.PRONUNCIATION_DICT_WRITE_AT] = System.currentTimeMillis()
+        }
+    }
+
+    /**
+     * Issue #778 — persisted across cold starts so the
+     * [PronunciationDictSyncer]'s LWW push carries the dict's true last
+     * edit time rather than `System.currentTimeMillis()` on every
+     * restart (which would let a stale local dict beat a newer remote).
+     * Stored in the main `storyvox_settings` DataStore alongside the
+     * dict payload itself — same lifecycle, atomic with the edit that
+     * advances it. Mirrors the [SYNC_LAST_WRITE_KEY] pattern used by
+     * the Tier-1 [SettingsSyncer].
+     */
+    override suspend fun lastDictWriteAt(): Long =
+        store.data.first()[Keys.PRONUNCIATION_DICT_WRITE_AT] ?: 0L
+
+    override suspend fun stampDictWrite(at: Long) {
+        store.edit { it[Keys.PRONUNCIATION_DICT_WRITE_AT] = at }
     }
 
     // ── LlmConfigProvider — bridge to :core-llm ────────────────────

--- a/core-data/src/main/kotlin/in/jphe/storyvox/data/repository/pronunciation/PronunciationDictRepository.kt
+++ b/core-data/src/main/kotlin/in/jphe/storyvox/data/repository/pronunciation/PronunciationDictRepository.kt
@@ -44,4 +44,35 @@ interface PronunciationDictRepository {
     /** Bulk replace — used by tests, future import/export, and the
      *  reset path. */
     suspend fun replaceAll(dict: PronunciationDict)
+
+    /**
+     * Epoch-ms timestamp of the last local edit to the dictionary.
+     * Used as the `updatedAt` for [PronunciationDictSyncer]'s LWW blob
+     * push — without persisting this across cold starts, a stale local
+     * dict gets re-stamped "now" on every process restart and wins
+     * blanket against newer remotes, silently overwriting cross-device
+     * edits (issue #778).
+     *
+     * Returns 0L when the user has never edited the dictionary on this
+     * device (fresh install). The syncer's `readLocal` treats 0L as
+     * "fall back to `System.currentTimeMillis()`" — the same shape used
+     * by [`SettingsSnapshotSource.lastLocalWriteAt`].
+     *
+     * Named with a `dict` suffix to avoid colliding with the identically-
+     * shaped methods on [`SettingsSnapshotSource`] that the same `:app`
+     * impl also implements — Kotlin can't disambiguate two interface
+     * methods with the same JVM signature on one class.
+     */
+    suspend fun lastDictWriteAt(): Long
+
+    /**
+     * Stamp a fresh local write at [at]. Mutators in this contract
+     * ([add], [update], [delete], [replaceAll]) must call this on every
+     * successful edit so the next sync push carries a strictly-increasing
+     * `updatedAt`. Also called by [PronunciationDictSyncer.writeLocal]
+     * on a remote-pull so the local stamp adopts the merged blob's
+     * `updatedAt` (otherwise a pull → push round-trip would advance the
+     * stamp past the remote and break LWW ordering).
+     */
+    suspend fun stampDictWrite(at: Long = System.currentTimeMillis())
 }

--- a/core-sync/build.gradle.kts
+++ b/core-sync/build.gradle.kts
@@ -67,6 +67,20 @@ android {
             java.srcDirs("src/test/kotlin")
         }
     }
+
+    // Issue #778 — `LwwBlobSyncer.reconcile` was instrumented with
+    // `android.util.Log` calls in commit 7b89fe88 (sync FK guard), which
+    // throws `RuntimeException: Method d in android.util.Log not mocked`
+    // under the JVM unit-test runner. Returning default values makes
+    // Log.d a no-op in tests — same shape every other Android module
+    // uses for its unit-test source set. This unblocks both the new
+    // `PronunciationDictSyncerTest` and the pre-existing
+    // `SettingsSyncerTest` that started failing on the same commit.
+    testOptions {
+        unitTests {
+            isReturnDefaultValues = true
+        }
+    }
 }
 
 dependencies {

--- a/core-sync/src/main/kotlin/in/jphe/storyvox/sync/domain/PronunciationDictSyncer.kt
+++ b/core-sync/src/main/kotlin/in/jphe/storyvox/sync/domain/PronunciationDictSyncer.kt
@@ -44,34 +44,36 @@ class PronunciationDictSyncer @Inject constructor(
         )
     }
 
-    /** updatedAt tracking: the repository doesn't carry one today, so we
-     *  derive it from the content hash + last write epoch we remember.
-     *  v1: just stamp every push with `now`. This loses some ordering
-     *  information (a local edit that happened before a remote push
-     *  may still get stamped "later" because we re-push on sync) but
-     *  the conflict outcome is no worse than naive LWW. */
-    private var lastLocalWriteAt: Long = 0L
-
     override val name: String get() = DOMAIN
     override suspend fun push(user: SignedInUser): SyncOutcome = delegate.push(user)
     override suspend fun pull(user: SignedInUser): SyncOutcome = delegate.pull(user)
 
-    /** Call this from the dict repository every time we save. */
-    fun stampLocalWrite(at: Long = System.currentTimeMillis()) {
-        lastLocalWriteAt = at
-    }
-
     private suspend fun readLocal(): Stamped<String>? {
         val dict = repo.current()
         if (dict.entries.isEmpty()) return null
-        val stamp = if (lastLocalWriteAt > 0) lastLocalWriteAt else System.currentTimeMillis()
+        // Issue #778 — the per-write stamp is owned by the repository
+        // and persisted across cold starts. Falling back to "now" when
+        // the user has never edited the dict on this device matches
+        // [SettingsSyncer.readLocal]: a 0L stamp would lose blanket to
+        // every non-zero remote, which is correct for true fresh
+        // installs but wrong for upgrades from a build that didn't
+        // record the stamp yet (the dict already exists locally, just
+        // without a recorded write time). The fallback preserves the
+        // pre-#778 behaviour for that one upgrade boundary.
+        val persisted = repo.lastDictWriteAt()
+        val stamp = if (persisted > 0L) persisted else System.currentTimeMillis()
         return Stamped(value = encodePronunciationDictJson(dict), updatedAt = stamp)
     }
 
     private suspend fun writeLocal(stamped: Stamped<String>) {
         val decoded = decodePronunciationDictJson(stamped.value)
         repo.replaceAll(decoded)
-        lastLocalWriteAt = stamped.updatedAt
+        // [replaceAll] above stamps "now" via the repository, which
+        // would advance our local clock past the remote's `updatedAt`
+        // and make us "win" the next push spuriously. Re-stamp with the
+        // merged-blob's updatedAt so a subsequent pull-then-push cycle
+        // is byte-stable — same shape as [SettingsSyncer.writeLocal].
+        repo.stampDictWrite(stamped.updatedAt)
     }
 
     companion object {

--- a/core-sync/src/test/kotlin/in/jphe/storyvox/sync/BookmarksSyncerTest.kt
+++ b/core-sync/src/test/kotlin/in/jphe/storyvox/sync/BookmarksSyncerTest.kt
@@ -148,6 +148,7 @@ class BookmarksSyncerTest {
             if (charOffset == null) bookmarks.remove(id) else bookmarks[id] = charOffset
         }
         override suspend fun getBookmark(id: String): Int? = bookmarks[id]
+        override suspend fun exists(id: String): Boolean = bookmarks.containsKey(id)
 
         // ---- everything below is "not used by BookmarksSyncer" ----
         override suspend fun allChapters(fictionId: String): List<Chapter> = emptyList()

--- a/core-sync/src/test/kotlin/in/jphe/storyvox/sync/PronunciationDictSyncerTest.kt
+++ b/core-sync/src/test/kotlin/in/jphe/storyvox/sync/PronunciationDictSyncerTest.kt
@@ -1,0 +1,231 @@
+package `in`.jphe.storyvox.sync
+
+import `in`.jphe.storyvox.data.repository.pronunciation.MatchType
+import `in`.jphe.storyvox.data.repository.pronunciation.PronunciationDict
+import `in`.jphe.storyvox.data.repository.pronunciation.PronunciationDictRepository
+import `in`.jphe.storyvox.data.repository.pronunciation.PronunciationEntry
+import `in`.jphe.storyvox.sync.client.FakeInstantBackend
+import `in`.jphe.storyvox.sync.client.SignedInUser
+import `in`.jphe.storyvox.sync.coordinator.SyncOutcome
+import `in`.jphe.storyvox.sync.domain.PronunciationDictSyncer
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * Issue #778 regression cover — `PronunciationDictSyncer.lastLocalWriteAt`
+ * used to be an in-memory `var = 0L` that reset on every cold start. The
+ * `readLocal` fallback then stamped the dict with
+ * `System.currentTimeMillis()` and a stale local dict won blanket
+ * against newer remotes in LWW.
+ *
+ * Same shape as [BookmarksSyncerTest] / [SettingsSyncerTest] — a
+ * `FakeInstantBackend` plays the cloud, a `FakeDictRepo` plays the
+ * persisted storage (its `lastDictWriteAt` value survives "cold restart"
+ * because we re-use the same instance across syncer instances).
+ */
+class PronunciationDictSyncerTest {
+
+    private val USER = SignedInUser(userId = "u-dict", email = null, refreshToken = "rt")
+
+    /** In-memory [PronunciationDictRepository] standing in for the
+     *  DataStore-backed `:app` impl. Persistence is just a field on
+     *  this instance — passing the SAME instance to a second syncer
+     *  simulates a cold restart that reloaded from disk. */
+    private class FakeDictRepo(initial: PronunciationDict = PronunciationDict.EMPTY) : PronunciationDictRepository {
+        private var current: PronunciationDict = initial
+        private var writeStamp: Long = 0L
+
+        override val dict: Flow<PronunciationDict> = flowOf(current)
+        override suspend fun current(): PronunciationDict = current
+        override suspend fun add(entry: PronunciationEntry) {
+            current = current.copy(entries = current.entries + entry)
+            writeStamp = System.currentTimeMillis()
+        }
+        override suspend fun update(index: Int, entry: PronunciationEntry) {
+            if (index !in current.entries.indices) return
+            current = current.copy(
+                entries = current.entries.toMutableList().apply { this[index] = entry },
+            )
+            writeStamp = System.currentTimeMillis()
+        }
+        override suspend fun delete(index: Int) {
+            if (index !in current.entries.indices) return
+            current = current.copy(
+                entries = current.entries.toMutableList().apply { removeAt(index) },
+            )
+            writeStamp = System.currentTimeMillis()
+        }
+        override suspend fun replaceAll(dict: PronunciationDict) {
+            current = dict
+            writeStamp = System.currentTimeMillis()
+        }
+        override suspend fun lastDictWriteAt(): Long = writeStamp
+        override suspend fun stampDictWrite(at: Long) { writeStamp = at }
+    }
+
+    private fun entry(pattern: String, replacement: String) =
+        PronunciationEntry(pattern = pattern, replacement = replacement, matchType = MatchType.WORD)
+
+    @Test fun `cold restart preserves the persisted write stamp across syncer instances`() = runTest {
+        // Device A: edits dict at T=1000, pushes.
+        val backend = FakeInstantBackend()
+        val repoA = FakeDictRepo().apply {
+            replaceAll(PronunciationDict(entries = listOf(entry("Astaria", "a"))))
+            // Pin the stamp to a deterministic value — the real impl
+            // stamps `System.currentTimeMillis()` on every mutator,
+            // but for the merge-rule assertion we want a fixed T.
+            stampDictWrite(1_000L)
+        }
+        val syncerA1 = PronunciationDictSyncer(repoA, backend)
+        val r1 = syncerA1.push(USER)
+        assertTrue("first push succeeds: $r1", r1 is SyncOutcome.Ok)
+
+        // Cold restart on device A — a fresh syncer instance, but the
+        // repo (the disk-backed state) survives. The persisted stamp
+        // must still be 1000L, NOT reset to 0L.
+        val syncerA2 = PronunciationDictSyncer(repoA, backend)
+        assertEquals("persisted stamp survives the syncer kill", 1_000L, repoA.lastDictWriteAt())
+
+        // Round 2: A2 pushes again. The remote `updatedAt` must STILL
+        // be 1000L — pre-#778, the cold-restart re-pushed with "now"
+        // (System.currentTimeMillis()), which would have moved it
+        // forward and let A clobber any concurrent edit on device B.
+        val r2 = syncerA2.push(USER)
+        assertTrue("second push succeeds: $r2", r2 is SyncOutcome.Ok)
+        val row = backend.fetch(USER, "blobs", SyncIds.rowUuid("pronunciation", USER.userId)).getOrNull()
+        assertNotNull("remote row must exist after both pushes", row)
+        assertEquals(
+            "remote updatedAt must remain the dict's true edit time, NOT bumped to 'now' by the cold-restart re-push",
+            1_000L,
+            row!!.updatedAt,
+        )
+    }
+
+    @Test fun `newer remote overrides older local on cold-start pull`() = runTest {
+        val backend = FakeInstantBackend()
+        // Device B (newer) pushes first.
+        val repoB = FakeDictRepo().apply {
+            replaceAll(PronunciationDict(entries = listOf(entry("name", "newer"))))
+            stampDictWrite(5_000L)
+        }
+        PronunciationDictSyncer(repoB, backend).push(USER)
+
+        // Device A: had a stale local edit at T=1000, then was killed.
+        // Cold start: persisted stamp = 1000L. Pull should bring in
+        // B's newer dict because 5000 > 1000.
+        val repoA = FakeDictRepo().apply {
+            replaceAll(PronunciationDict(entries = listOf(entry("name", "older"))))
+            stampDictWrite(1_000L)
+        }
+        val outcome = PronunciationDictSyncer(repoA, backend).pull(USER)
+        assertTrue("pull succeeds: $outcome", outcome is SyncOutcome.Ok)
+        assertEquals(
+            "newer remote must win over stale local on pull",
+            "newer",
+            repoA.current().entries.single().replacement,
+        )
+    }
+
+    @Test fun `older remote does not clobber newer local on push`() = runTest {
+        val backend = FakeInstantBackend()
+        // Remote: older.
+        val repoOld = FakeDictRepo().apply {
+            replaceAll(PronunciationDict(entries = listOf(entry("name", "older"))))
+            stampDictWrite(1_000L)
+        }
+        PronunciationDictSyncer(repoOld, backend).push(USER)
+
+        // Local: newer. Push must overwrite the older remote.
+        val repoNew = FakeDictRepo().apply {
+            replaceAll(PronunciationDict(entries = listOf(entry("name", "newer"))))
+            stampDictWrite(5_000L)
+        }
+        val outcome = PronunciationDictSyncer(repoNew, backend).push(USER)
+        assertTrue("push succeeds: $outcome", outcome is SyncOutcome.Ok)
+
+        val row = backend.fetch(USER, "blobs", SyncIds.rowUuid("pronunciation", USER.userId)).getOrNull()!!
+        assertTrue("remote payload should now contain the newer replacement", row.payload.contains("newer"))
+        assertEquals("remote stamp must be the local newer stamp", 5_000L, row.updatedAt)
+    }
+
+    @Test fun `pull writes back the remote stamp so subsequent push is byte-stable`() = runTest {
+        // After a pull, the local stamp adopts the merged blob's
+        // updatedAt. Otherwise the syncer's `replaceAll` would stamp
+        // "now" via the repo's mutator and the next push would spuriously
+        // advance the remote's updatedAt without any real local edit.
+        val backend = FakeInstantBackend()
+        val repoA = FakeDictRepo().apply {
+            replaceAll(PronunciationDict(entries = listOf(entry("k", "v"))))
+            stampDictWrite(7_000L)
+        }
+        PronunciationDictSyncer(repoA, backend).push(USER)
+
+        val repoB = FakeDictRepo()
+        PronunciationDictSyncer(repoB, backend).pull(USER)
+        assertEquals(
+            "after pull, local stamp must equal the merged blob's updatedAt, not 'now'",
+            7_000L,
+            repoB.lastDictWriteAt(),
+        )
+    }
+
+    @Test fun `empty local dict is a no-op push when remote is also empty`() = runTest {
+        val backend = FakeInstantBackend()
+        val repo = FakeDictRepo()  // empty dict, stamp 0
+        val outcome = PronunciationDictSyncer(repo, backend).push(USER)
+        assertTrue("no-op push should still be Ok: $outcome", outcome is SyncOutcome.Ok)
+        val row = backend.fetch(USER, "blobs", SyncIds.rowUuid("pronunciation", USER.userId)).getOrNull()
+        assertEquals(null, row)
+    }
+
+    @Test fun `fresh install with non-zero local stamp pushes with that stamp`() = runTest {
+        // Smoke test for the fallback path — readLocal uses the
+        // persisted stamp when > 0, only falls back to "now" when 0.
+        val backend = FakeInstantBackend()
+        val repo = FakeDictRepo().apply {
+            replaceAll(PronunciationDict(entries = listOf(entry("Astaria", "a"))))
+            stampDictWrite(42L)
+        }
+        PronunciationDictSyncer(repo, backend).push(USER)
+        val row = backend.fetch(USER, "blobs", SyncIds.rowUuid("pronunciation", USER.userId)).getOrNull()!!
+        assertEquals(42L, row.updatedAt)
+    }
+
+    @Test fun `domain identifier remains stable`() = runTest {
+        // Renames orphan rows on the InstantDB side — assert the wire
+        // constant doesn't drift.
+        assertEquals("pronunciation", PronunciationDictSyncer.DOMAIN)
+    }
+
+    @Test fun `repository mutators record a strictly-positive stamp`() = runTest {
+        // The fake mirrors the real impl: `add`/`update`/`delete`/
+        // `replaceAll` must advance `lastDictWriteAt`. Without that
+        // wiring, the syncer would push with `System.currentTimeMillis()`
+        // on the first push after an edit, which breaks LWW ordering on
+        // any device that processed the push later.
+        val repo = FakeDictRepo()
+        assertEquals(0L, repo.lastDictWriteAt())
+        repo.add(entry("a", "x"))
+        assertTrue("add() must advance stamp", repo.lastDictWriteAt() > 0L)
+        val afterAdd = repo.lastDictWriteAt()
+
+        repo.update(0, entry("a", "y"))
+        assertFalse("update() must shift stamp", repo.lastDictWriteAt() == 0L)
+
+        repo.delete(0)
+        assertFalse("delete() must shift stamp", repo.lastDictWriteAt() == 0L)
+
+        repo.replaceAll(PronunciationDict(entries = listOf(entry("z", "zz"))))
+        assertFalse("replaceAll() must shift stamp", repo.lastDictWriteAt() == 0L)
+
+        // Each mutation advances the stamp — at minimum the post-add
+        // stamp is strictly less than the final replaceAll stamp.
+        assertTrue(afterAdd <= repo.lastDictWriteAt())
+    }
+}


### PR DESCRIPTION
## Summary

Fixes #778 — `PronunciationDictSyncer.lastLocalWriteAt` was an in-memory `var` that reset to `0L` on every cold start. `readLocal` then stamped the dict with `System.currentTimeMillis()`, letting a stale local dict beat newer remotes in LWW and silently overwrite cross-device edits.

Compounding bug surfaced by the issue: `stampLocalWrite()` had **zero callers** from `:app` / `:feature`, so the `if (lastLocalWriteAt > 0)` branch was dead even within a single process.

## What changed

**Contract** — `PronunciationDictRepository` grows `lastDictWriteAt()` / `stampDictWrite()`. The `Dict` suffix avoids a JVM-signature collision with the identically-shaped methods on `SettingsSnapshotSource` (the same `:app` impl implements both).

**Persistence** — `SettingsRepositoryUiImpl` stores the stamp in the main `storyvox_settings` DataStore under the `instantdb.*` namespace, written atomically with the dict payload. Every mutator (`add`/`update`/`delete`/`replaceAll`) now stamps `System.currentTimeMillis()`, closing the dead-callers bug.

**Syncer** — mirrors `SettingsSyncer.readLocal`/`writeLocal`:
- `readLocal` reads the persisted stamp; falls back to `now` only when the user has never edited on this device (matches `SettingsSyncer` behaviour).
- `writeLocal` re-stamps with the merged blob's `updatedAt` after `replaceAll` (which would otherwise stamp `now` via the repo mutator and break LWW ordering on the next push).

## Tests

New `PronunciationDictSyncerTest` (8 cases):
- Cold-restart regression — persisted stamp survives a syncer kill; second push carries the dict's true edit time, not `now`.
- LWW both directions (newer remote wins pull; newer local wins push).
- Pull writes back the remote stamp so subsequent push is byte-stable.
- Empty-local + empty-remote is a no-op push.
- Fresh-install with non-zero local stamp uses that stamp.
- Domain identifier is stable (no wire-orphan risk on rename).
- Repository mutators advance the stamp.

## Collateral fixes (needed to compile/run tests on `main` HEAD — both broken by 7b89fe88)

1. `BookmarksSyncerTest.FakeChapterDao` missed the `exists()` override added by 7b89fe88's `ChapterDao` change. One-line stub.
2. `core-sync` test source set enables `testOptions.unitTests.isReturnDefaultValues = true` so the `android.util.Log.d` calls 7b89fe88 added to `LwwBlobSyncer.reconcile` no-op under the JVM runner instead of throwing `RuntimeException: Method d in android.util.Log not mocked`. This was already breaking `SettingsSyncerTest` on `main`.

## Test plan

- [x] `./gradlew :core-sync:compileDebugKotlin :app:compileDebugKotlin` — passes
- [x] `./gradlew :core-sync:testDebugUnitTest` — full suite passes (includes the previously-broken `SettingsSyncerTest` / `BookmarksSyncerTest`)
- [x] `./gradlew :app:testDebugUnitTest --tests "*PronunciationDictTest"` — passes
- [x] `./gradlew :app:testDebugUnitTest --tests "*SyncSnapshotTest"` — passes
- [ ] CI green
- [ ] Manual: edit dict on device A → force-stop → reopen → confirm next sync push retains the device-A stamp rather than re-pushing as `now`

🤖 Generated with [Claude Code](https://claude.com/claude-code)