### PR TITLE
feat(library): add remove-from-library to long press menu

### DIFF
--- a/feature/src/main/kotlin/in/jphe/storyvox/feature/library/LibraryScreen.kt
+++ b/feature/src/main/kotlin/in/jphe/storyvox/feature/library/LibraryScreen.kt
@@ -21,6 +21,7 @@ import androidx.compose.foundation.lazy.grid.itemsIndexed
 import androidx.compose.foundation.lazy.items
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Add
+import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.Badge
 import androidx.compose.material3.BadgedBox
 import androidx.compose.material3.Card
@@ -136,6 +137,16 @@ fun LibraryScreen(
     // open/closed boolean here.
     var syncSheetOpen by androidx.compose.runtime.remember {
         androidx.compose.runtime.mutableStateOf(false)
+    }
+
+    // Issue #828 — confirm-before-remove dialog state for the
+    // "Remove from library" row on ManageShelvesSheet. Holds the
+    // (fictionId, title) the sheet asked to remove; null = no dialog.
+    // Mirrors the FictionDetailScreen #169 pattern (ephemeral state at
+    // the screen level so the dialog dies on configuration change
+    // rather than surviving as a half-rendered modal).
+    var pendingRemoval by androidx.compose.runtime.remember {
+        androidx.compose.runtime.mutableStateOf<Pair<String, String>?>(null)
     }
 
     val dedupedFictions = androidx.compose.runtime.remember(state.fictions) {
@@ -371,8 +382,40 @@ fun LibraryScreen(
     ManageShelvesSheet(
         state = manageShelvesState,
         onToggle = viewModel::toggleShelf,
+        onRemoveRequest = { id, title -> pendingRemoval = id to title },
         onDismiss = viewModel::dismissManageShelves,
     )
+
+    // Issue #828 — destructive removal confirm. Mirrors the #169 dialog
+    // shape on FictionDetailScreen so users see one consistent voice
+    // for "you're about to drop this book." Strings are reused
+    // (fiction_remove_title / fiction_remove_body / fiction_remove /
+    // fiction_cancel) — single source for the warning copy.
+    pendingRemoval?.let { (fictionId, title) ->
+        val resolved = title.ifBlank { stringResource(R.string.fiction_default_title) }
+        AlertDialog(
+            onDismissRequest = { pendingRemoval = null },
+            title = { Text(stringResource(R.string.fiction_remove_title, resolved)) },
+            text = { Text(stringResource(R.string.fiction_remove_body)) },
+            confirmButton = {
+                BrassButton(
+                    label = stringResource(R.string.fiction_remove),
+                    onClick = {
+                        pendingRemoval = null
+                        viewModel.removeFromLibrary(fictionId)
+                    },
+                    variant = BrassButtonVariant.Primary,
+                )
+            },
+            dismissButton = {
+                BrassButton(
+                    label = stringResource(R.string.fiction_cancel),
+                    onClick = { pendingRemoval = null },
+                    variant = BrassButtonVariant.Secondary,
+                )
+            },
+        )
+    }
 
     // Issue #500 — InstantDB sync status sheet. Mounted unconditionally
     // and gated on [syncSheetOpen] to keep the composition stable. The

--- a/feature/src/main/kotlin/in/jphe/storyvox/feature/library/LibraryViewModel.kt
+++ b/feature/src/main/kotlin/in/jphe/storyvox/feature/library/LibraryViewModel.kt
@@ -367,6 +367,25 @@ class LibraryViewModel @Inject constructor(
         }
     }
 
+    /**
+     * Issue #828 — long-press → "Remove from library" affordance on the
+     * manage-shelves sheet. Routes through [FictionRepositoryUi.follow]
+     * with `follow=false`, the same plumbing the #169 FictionDetail
+     * destructive flow uses, so the underlying tear-down (library row,
+     * download cancellation, FictionLibraryListener fan-out) stays
+     * single-sourced. Caller is responsible for confirming first; this
+     * is the un-gated terminal action.
+     *
+     * Dismisses the sheet on completion so the user lands back on the
+     * library grid with the now-absent row.
+     */
+    fun removeFromLibrary(fictionId: String) {
+        viewModelScope.launch {
+            uiRepo.follow(fictionId, follow = false)
+            _manageShelves.value = ManageShelvesSheetState.Hidden
+        }
+    }
+
     // ─── existing surface (unchanged behaviour) ───────────────────────────
 
     fun openFiction(id: String) {

--- a/feature/src/main/kotlin/in/jphe/storyvox/feature/library/ManageShelvesSheet.kt
+++ b/feature/src/main/kotlin/in/jphe/storyvox/feature/library/ManageShelvesSheet.kt
@@ -1,5 +1,6 @@
 package `in`.jphe.storyvox.feature.library
 
+import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
@@ -7,6 +8,7 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.selection.toggleable
 import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.ModalBottomSheet
 import androidx.compose.material3.Switch
@@ -28,12 +30,21 @@ import `in`.jphe.storyvox.ui.theme.LocalSpacing
  * Display labels come from [Shelf.displayName] — the data-layer owns
  * the user-facing strings so every shelf-aware surface shows the same
  * word (chip row, sheet, future "where is this book?" hint).
+ *
+ * Issue #828 — destructive "Remove from library" row at the bottom,
+ * separated from the shelf toggles by a [HorizontalDivider]. Tapping
+ * it does NOT remove inline — it surfaces [onRemoveRequest] so the
+ * host (LibraryScreen) can gate the action behind an AlertDialog. The
+ * read-progress-loss warning mirrors the existing #169 confirm flow
+ * on [FictionDetailScreen]; we share strings + UX so users see one
+ * voice for "you're about to drop this book."
  */
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun ManageShelvesSheet(
     state: ManageShelvesSheetState,
     onToggle: (String, Shelf) -> Unit,
+    onRemoveRequest: (String, String) -> Unit,
     onDismiss: () -> Unit,
 ) {
     if (state !is ManageShelvesSheetState.Open) return
@@ -88,6 +99,28 @@ fun ManageShelvesSheet(
                         onCheckedChange = null,
                     )
                 }
+            }
+
+            // Issue #828 — destructive "Remove from library" action.
+            // Divider sets it apart from the additive shelf toggles so
+            // it doesn't read as just another switch. Tinted with
+            // colorScheme.error to signal destructiveness; host gates
+            // the actual removal behind a confirm dialog.
+            HorizontalDivider(modifier = Modifier.padding(vertical = spacing.sm))
+            Row(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .clickable(role = Role.Button) {
+                        onRemoveRequest(state.fictionId, state.fictionTitle)
+                    }
+                    .padding(vertical = spacing.sm),
+                verticalAlignment = Alignment.CenterVertically,
+            ) {
+                Text(
+                    text = "Remove from library",
+                    style = MaterialTheme.typography.bodyLarge,
+                    color = MaterialTheme.colorScheme.error,
+                )
             }
         }
     }


### PR DESCRIPTION
## Summary
- Add "Remove from library" destructive action to ManageShelvesSheet (long press menu)
- Confirmation dialog before removal, using existing `fiction_remove_*` strings
- Routes through `uiRepo.follow(id, false)` — same plumbing as FictionDetail's remove flow

Closes #828

## Test plan
- [ ] Long press a library book → sheet shows "Remove from library" below shelf toggles
- [ ] Tap remove → confirmation dialog appears
- [ ] Confirm → book removed from library
- [ ] Cancel → no change
- [ ] `:feature:compileDebugKotlin` green

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>