### PR TITLE
feat(library): resume playback on library book tap

### DIFF
--- a/feature/src/main/kotlin/in/jphe/storyvox/feature/library/LibraryScreen.kt
+++ b/feature/src/main/kotlin/in/jphe/storyvox/feature/library/LibraryScreen.kt
@@ -326,7 +326,7 @@ fun LibraryScreen(
                             state = state,
                             dedupedFictions = dedupedFictions,
                             onResume = viewModel::resume,
-                            onOpenFiction = viewModel::openFiction,
+                            onTapFiction = viewModel::resumeOrOpenFiction,
                             onLongPress = viewModel::openManageShelves,
                             onOpenTechEmpower = onOpenTechEmpower,
                         )
@@ -681,7 +681,13 @@ private fun LibraryGridBody(
     state: LibraryUiState,
     dedupedFictions: List<FictionSummary>,
     onResume: () -> Unit,
-    onOpenFiction: (String) -> Unit,
+    /**
+     * Issue #827 — tap on a grid item. The ViewModel routes the tap
+     * to resume-playback when a saved position exists and to
+     * fiction-detail when it doesn't, so this single callback covers
+     * both "continue listening" and "open a new book" paths.
+     */
+    onTapFiction: (String) -> Unit,
     onLongPress: (FictionSummary) -> Unit,
     onOpenTechEmpower: () -> Unit,
 ) {
@@ -772,12 +778,14 @@ private fun LibraryGridBody(
                     author = fiction.author,
                     sourceFamily = coverSourceFamilyFor(fiction.sourceId),
                     // Long-press → manage-shelves bottom sheet (#116).
-                    // combinedClickable keeps the tap-to-open path
-                    // identical to before; long-press is additive.
+                    // Tap → resume-or-open (#827): when the fiction has
+                    // a saved playback position, tap resumes playback
+                    // like the ResumeCard hero; otherwise it falls
+                    // back to opening fiction detail.
                     modifier = Modifier
                         .fillMaxWidth()
                         .combinedClickable(
-                            onClick = { onOpenFiction(fiction.id) },
+                            onClick = { onTapFiction(fiction.id) },
                             onLongClick = { onLongPress(fiction) },
                         ),
                 )

--- a/feature/src/main/kotlin/in/jphe/storyvox/feature/library/LibraryViewModel.kt
+++ b/feature/src/main/kotlin/in/jphe/storyvox/feature/library/LibraryViewModel.kt
@@ -188,7 +188,7 @@ sealed interface AddByUrlSheetState {
 @OptIn(kotlinx.coroutines.ExperimentalCoroutinesApi::class)
 class LibraryViewModel @Inject constructor(
     fictionRepo: FictionRepository,
-    positionRepo: PlaybackPositionRepository,
+    private val positionRepo: PlaybackPositionRepository,
     private val shelfRepo: ShelfRepository,
     /** Issue #158 — reading history backing the new "History" sub-tab. */
     historyRepo: HistoryRepository,
@@ -391,6 +391,31 @@ class LibraryViewModel @Inject constructor(
                 autoPlay = autoPlay,
             )
             _events.send(LibraryUiEvent.OpenReader(entry.fiction.id, entry.chapter.id))
+        }
+    }
+
+    /**
+     * Issue #827 — tapping a book in the Library grid resumes playback
+     * when a saved position exists for that fiction; falls back to
+     * opening the fiction detail screen otherwise. Mirrors the
+     * smart-resume logic in [resume]: the resume policy decides
+     * whether audio auto-plays so an explicit pre-pause is respected.
+     */
+    fun resumeOrOpenFiction(fictionId: String) {
+        viewModelScope.launch {
+            val saved = positionRepo.load(fictionId)
+            if (saved == null) {
+                _events.send(LibraryUiEvent.OpenFiction(fictionId))
+                return@launch
+            }
+            val autoPlay = resumePolicy.currentLastWasPlaying()
+            playback.startListening(
+                saved.fictionId,
+                saved.chapterId,
+                saved.charOffset,
+                autoPlay = autoPlay,
+            )
+            _events.send(LibraryUiEvent.OpenReader(saved.fictionId, saved.chapterId))
         }
     }
 


### PR DESCRIPTION
## Summary
- Tapping a book in the Library grid now resumes playback if a saved position exists
- Falls back to opening fiction detail for unstarted books (existing behavior)
- New `resumeOrOpenFiction()` in LibraryViewModel mirrors the ResumeCard's smart-resume policy

Closes #827

## Test plan
- [ ] Tap a book with saved position → resumes playback, opens reader
- [ ] Tap a book with no position → opens fiction detail (unchanged behavior)
- [ ] Long press still opens ManageShelvesSheet (unchanged)
- [ ] ResumeCard hero still works as before
- [ ] `:feature:compileDebugKotlin` green

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>