### PR TITLE
feat(ui): polish main nav tab title areas

### DIFF
--- a/core-ui/src/main/kotlin/in/jphe/storyvox/ui/component/MagicTitleBar.kt
+++ b/core-ui/src/main/kotlin/in/jphe/storyvox/ui/component/MagicTitleBar.kt
@@ -1,0 +1,81 @@
+package `in`.jphe.storyvox.ui.component
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.size
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.outlined.AutoAwesome
+import androidx.compose.material3.CenterAlignedTopAppBar
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import `in`.jphe.storyvox.ui.theme.LibraryNocturneTheme
+import `in`.jphe.storyvox.ui.theme.LocalSpacing
+
+/**
+ * Issue #830 — the shared title bar for every primary-nav surface
+ * (Library / Browse / Follows / Voice Library / Settings Hub).
+ *
+ * Before this composable existed each tab built its own bar inline,
+ * which drifted: three used [CenterAlignedTopAppBar] with `titleMedium`,
+ * two used a left-aligned [androidx.compose.material3.TopAppBar] with
+ * `titleLarge`, and Follows overrode the container color to `surface`.
+ * The visible result was five subtly different headers across one app.
+ *
+ * [MagicTitleBar] picks the most polished pattern (center-aligned,
+ * `titleMedium`, default container) and adds a small brass-tinted
+ * sparkle glyph next to the title. The glyph is the same
+ * [Icons.Outlined.AutoAwesome] used by the Settings hub heading, so it
+ * reads as one design family. Slots for [navigationIcon] and [actions]
+ * mirror the underlying [CenterAlignedTopAppBar] API.
+ */
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun MagicTitleBar(
+    title: String,
+    modifier: Modifier = Modifier,
+    navigationIcon: @Composable () -> Unit = {},
+    actions: @Composable () -> Unit = {},
+) {
+    val spacing = LocalSpacing.current
+    CenterAlignedTopAppBar(
+        modifier = modifier,
+        title = {
+            Row(
+                verticalAlignment = Alignment.CenterVertically,
+                horizontalArrangement = Arrangement.spacedBy(spacing.xs),
+            ) {
+                Icon(
+                    imageVector = Icons.Outlined.AutoAwesome,
+                    contentDescription = null,
+                    tint = MaterialTheme.colorScheme.primary,
+                    modifier = Modifier.size(16.dp),
+                )
+                Text(
+                    text = title,
+                    style = MaterialTheme.typography.titleMedium,
+                )
+            }
+        },
+        navigationIcon = navigationIcon,
+        actions = { actions() },
+    )
+}
+
+@Preview(name = "MagicTitleBar — dark", widthDp = 360)
+@Composable
+private fun PreviewMagicTitleBarDark() = LibraryNocturneTheme(darkTheme = true) {
+    MagicTitleBar(title = "Library")
+}
+
+@Preview(name = "MagicTitleBar — light", widthDp = 360)
+@Composable
+private fun PreviewMagicTitleBarLight() = LibraryNocturneTheme(darkTheme = false) {
+    MagicTitleBar(title = "Voice library")
+}

--- a/feature/src/main/kotlin/in/jphe/storyvox/feature/browse/BrowseScreen.kt
+++ b/feature/src/main/kotlin/in/jphe/storyvox/feature/browse/BrowseScreen.kt
@@ -31,7 +31,6 @@ import androidx.compose.material3.Badge
 import androidx.compose.material3.BadgedBox
 import androidx.compose.material3.Card
 import androidx.compose.material3.CardDefaults
-import androidx.compose.material3.CenterAlignedTopAppBar
 import androidx.compose.material3.FloatingActionButton
 import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Icon
@@ -78,6 +77,7 @@ import `in`.jphe.storyvox.ui.component.FictionCoverThumb
 import `in`.jphe.storyvox.ui.component.fictionMonogram
 import `in`.jphe.storyvox.ui.component.MagicSkeletonTile
 import `in`.jphe.storyvox.ui.component.MagicSpinner
+import `in`.jphe.storyvox.ui.component.MagicTitleBar
 import `in`.jphe.storyvox.ui.theme.LocalSpacing
 
 /**
@@ -99,9 +99,8 @@ private fun BrowseScaffoldOrFrame(
     } else {
         Scaffold(
             topBar = {
-                CenterAlignedTopAppBar(
-                    title = { Text(stringResource(R.string.browse_title), style = MaterialTheme.typography.titleMedium) },
-                )
+                // #830 — shared title bar across all primary-nav surfaces.
+                MagicTitleBar(title = stringResource(R.string.browse_title))
             },
         ) { scaffoldPadding ->
             Box(modifier = Modifier.fillMaxSize().padding(scaffoldPadding)) {

--- a/feature/src/main/kotlin/in/jphe/storyvox/feature/follows/FollowsScreen.kt
+++ b/feature/src/main/kotlin/in/jphe/storyvox/feature/follows/FollowsScreen.kt
@@ -19,8 +19,6 @@ import androidx.compose.material3.Card
 import androidx.compose.material3.CardDefaults
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
-import androidx.compose.material3.TopAppBar
-import androidx.compose.material3.TopAppBarDefaults
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
@@ -39,6 +37,7 @@ import `in`.jphe.storyvox.ui.component.coverSourceFamilyFor
 import `in`.jphe.storyvox.ui.component.FictionCoverThumb
 import `in`.jphe.storyvox.ui.component.fictionMonogram
 import `in`.jphe.storyvox.ui.component.MagicSkeletonTile
+import `in`.jphe.storyvox.ui.component.MagicTitleBar
 import `in`.jphe.storyvox.ui.component.SkeletonBlock
 import `in`.jphe.storyvox.ui.layout.isAtLeastTablet
 import `in`.jphe.storyvox.ui.theme.LocalSpacing
@@ -97,8 +96,9 @@ fun FollowsScreen(
             // surfaces inline below as a TextButton in an aligned-end
             // Row so it remains reachable.
             if (!embedded) {
-                TopAppBar(
-                    title = { Text(stringResource(R.string.follows_title), style = MaterialTheme.typography.titleLarge) },
+                // #830 — shared title bar across all primary-nav surfaces.
+                MagicTitleBar(
+                    title = stringResource(R.string.follows_title),
                     actions = {
                         if (state.isSignedIn && state.follows.isNotEmpty()) {
                             BrassButton(
@@ -108,10 +108,6 @@ fun FollowsScreen(
                             )
                         }
                     },
-                    colors = TopAppBarDefaults.topAppBarColors(
-                        containerColor = MaterialTheme.colorScheme.surface,
-                        titleContentColor = MaterialTheme.colorScheme.onSurface,
-                    ),
                 )
             } else if (state.isSignedIn && state.follows.isNotEmpty()) {
                 // Embedded fallback for the "Mark all caught up"

--- a/feature/src/main/kotlin/in/jphe/storyvox/feature/library/LibraryScreen.kt
+++ b/feature/src/main/kotlin/in/jphe/storyvox/feature/library/LibraryScreen.kt
@@ -25,7 +25,6 @@ import androidx.compose.material3.Badge
 import androidx.compose.material3.BadgedBox
 import androidx.compose.material3.Card
 import androidx.compose.material3.CardDefaults
-import androidx.compose.material3.CenterAlignedTopAppBar
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.FloatingActionButton
 import androidx.compose.material3.Icon
@@ -66,6 +65,7 @@ import `in`.jphe.storyvox.ui.component.coverSourceFamilyFor
 import `in`.jphe.storyvox.ui.component.FictionCoverThumb
 import `in`.jphe.storyvox.ui.component.fictionMonogram
 import `in`.jphe.storyvox.ui.component.MagicSkeletonTile
+import `in`.jphe.storyvox.ui.component.MagicTitleBar
 import `in`.jphe.storyvox.ui.component.cascadeReveal
 import `in`.jphe.storyvox.ui.theme.LocalSpacing
 import androidx.compose.foundation.layout.Spacer
@@ -163,15 +163,13 @@ fun LibraryScreen(
     Scaffold(
         // Issue #255 — Library used to fade straight from the system status
         // bar into a Resume card with no header — no 'Library' title, no
-        // identity. CenterAlignedTopAppBar gives the screen a hard
-        // identifier (matches Material 3 standard for home tabs) and a
-        // place to surface search/sort/filter actions later. For now the
-        // bar is bare title-only; the issue's deeper ask (search +
-        // sort/filter affordances) needs its own follow-up since neither
-        // exists in LibraryViewModel yet.
+        // identity. The shared [MagicTitleBar] (#830) renders a
+        // center-aligned title with a brass sparkle glyph; same widget
+        // is used on every other primary-nav surface so the headers all
+        // belong to one design family.
         topBar = {
-            CenterAlignedTopAppBar(
-                title = { Text(stringResource(R.string.library_title), style = MaterialTheme.typography.titleMedium) },
+            MagicTitleBar(
+                title = stringResource(R.string.library_title),
                 actions = {
                     // Issue #533 — top-bar action icons used to pack
                     // flush together at 0dp gap on the Flip3 (1080dp

--- a/feature/src/main/kotlin/in/jphe/storyvox/feature/settings/SettingsHubScreen.kt
+++ b/feature/src/main/kotlin/in/jphe/storyvox/feature/settings/SettingsHubScreen.kt
@@ -26,7 +26,6 @@ import androidx.compose.material.icons.outlined.Info
 import androidx.compose.material.icons.outlined.RecordVoiceOver
 import androidx.compose.material.icons.outlined.Search
 import androidx.compose.material.icons.outlined.Speed
-import androidx.compose.material3.CenterAlignedTopAppBar
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
@@ -44,6 +43,7 @@ import androidx.compose.runtime.staticCompositionLocalOf
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.vector.ImageVector
 import `in`.jphe.storyvox.feature.settings.components.SectionHeading
+import `in`.jphe.storyvox.ui.component.MagicTitleBar
 import `in`.jphe.storyvox.ui.theme.LocalSpacing
 
 /**
@@ -146,8 +146,9 @@ fun SettingsHubScreen(
     var query by remember { mutableStateOf("") }
     Scaffold(
         topBar = {
-            CenterAlignedTopAppBar(
-                title = { Text("Settings", style = MaterialTheme.typography.titleMedium) },
+            // #830 — shared title bar across all primary-nav surfaces.
+            MagicTitleBar(
+                title = "Settings",
                 navigationIcon = {
                     IconButton(onClick = onNavigateBack) {
                         Icon(

--- a/feature/src/main/kotlin/in/jphe/storyvox/feature/voicelibrary/VoiceLibraryScreen.kt
+++ b/feature/src/main/kotlin/in/jphe/storyvox/feature/voicelibrary/VoiceLibraryScreen.kt
@@ -44,7 +44,6 @@ import androidx.compose.material3.Scaffold
 import androidx.compose.material3.SnackbarHost
 import androidx.compose.material3.SnackbarHostState
 import androidx.compose.material3.Text
-import androidx.compose.material3.TopAppBar
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
@@ -80,6 +79,7 @@ import `in`.jphe.storyvox.ui.component.BrassButton
 import `in`.jphe.storyvox.ui.component.BrassButtonVariant
 import `in`.jphe.storyvox.ui.component.BrassProgressBar
 import `in`.jphe.storyvox.ui.component.MagicSkeletonTile
+import `in`.jphe.storyvox.ui.component.MagicTitleBar
 import `in`.jphe.storyvox.ui.component.cascadeReveal
 import `in`.jphe.storyvox.ui.theme.LocalReducedMotion
 import androidx.compose.animation.core.animateFloatAsState
@@ -103,9 +103,8 @@ fun VoiceLibraryScreen(
 
     Scaffold(
         topBar = {
-            TopAppBar(
-                title = { Text(stringResource(R.string.voicelibrary_title)) },
-            )
+            // #830 — shared title bar across all primary-nav surfaces.
+            MagicTitleBar(title = stringResource(R.string.voicelibrary_title))
         },
         snackbarHost = { SnackbarHost(snackbar) },
     ) { padding ->


### PR DESCRIPTION
## Summary
- New shared `MagicTitleBar` composable in core-ui wrapping CenterAlignedTopAppBar with consistent titleMedium + brass sparkle glyph
- Route all 5 primary nav tabs through MagicTitleBar (Library, Browse, Follows, Voice Library, Settings Hub)
- Previously: 3 different TopAppBar styles across tabs (center-aligned vs left-aligned, titleMedium vs titleLarge, varying container colors)

Closes #830

## Test plan
- [ ] All 5 tabs show consistent centered title with sparkle glyph
- [ ] Navigation icons and action buttons still work on each tab
- [ ] Dark and light themes render correctly
- [ ] `:core-ui:compileDebugKotlin` green
- [ ] `:feature:compileDebugKotlin` green

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>