### PR TITLE
feat(onboarding): add step indicator across onboarding screens

### DIFF
--- a/feature/src/main/kotlin/in/jphe/storyvox/feature/onboarding/OnboardingHost.kt
+++ b/feature/src/main/kotlin/in/jphe/storyvox/feature/onboarding/OnboardingHost.kt
@@ -109,56 +109,65 @@ fun OnboardingHost(
                     transitionSpec = { fadeIn() togetherWith fadeOut() },
                     label = "onboarding-step",
                 ) { current ->
-                    when (current) {
-                        OnboardingStep.Welcome -> WelcomeScreen(
-                            onGetStarted = { step = OnboardingStep.VoicePick },
-                            onSkip = {
-                                viewModel.markCompleted()
-                            },
-                        )
-                        OnboardingStep.VoicePick -> VoicePickerOnboarding(
-                            onContinue = { step = OnboardingStep.FirstFiction },
-                            onSkip = { step = OnboardingStep.FirstFiction },
-                            onMoreVoices = {
-                                viewModel.markCompleted()
-                                onOpenVoiceLibrary()
-                            },
-                        )
-                        OnboardingStep.FirstFiction -> FirstFictionPicker(
-                            // Issues #644 + #647 (v1.0) — bypass the
-                            // TechEmpower Home hub AND the Guides
-                            // fiction-detail stop. The viewmodel
-                            // resolves the first chapter of the
-                            // `notion:guides` fiction, queues it on
-                            // the playback controller with
-                            // `autoPlay=true`, then [onOpenGuidesAndPlay]
-                            // navigates the user to the Playing
-                            // surface so they land on the transport
-                            // UI as the chapter warms. Net: two taps
-                            // (the hub stop + the Guides-cover stop)
-                            // disappear from the first-launch flow.
-                            //
-                            // Fallback path: if chapter resolution
-                            // fails (network down, source unreachable,
-                            // anonymous Notion 404), the viewmodel
-                            // invokes [onOpenTechEmpower] instead so
-                            // the user lands on the hub with the same
-                            // four-card affordance they would have
-                            // seen pre-fix — never a dead end.
-                            onBrowseTechEmpower = {
-                                viewModel.openGuidesAndAutoPlay(
-                                    onPlaying = onOpenGuidesAndPlay,
-                                    onFallbackToHub = onOpenTechEmpower,
-                                )
-                            },
-                            onAddFromWebsite = { clip ->
-                                viewModel.markCompleted()
-                                onAddFromWebsite(clip)
-                            },
-                            onSkip = {
-                                viewModel.markCompleted()
-                            },
-                        )
+                    // Issue #787 — wrap each screen in the shared
+                    // scaffold so the dot row + "Step X of 3" indicator
+                    // is rendered once at the host level, not
+                    // duplicated into each screen. The scaffold layers
+                    // the indicator over the screen's own scroll
+                    // content; each screen's existing padding keeps the
+                    // headline clear of the indicator row.
+                    OnboardingScaffold(stepIndex = current.ordinal) {
+                        when (current) {
+                            OnboardingStep.Welcome -> WelcomeScreen(
+                                onGetStarted = { step = OnboardingStep.VoicePick },
+                                onSkip = {
+                                    viewModel.markCompleted()
+                                },
+                            )
+                            OnboardingStep.VoicePick -> VoicePickerOnboarding(
+                                onContinue = { step = OnboardingStep.FirstFiction },
+                                onSkip = { step = OnboardingStep.FirstFiction },
+                                onMoreVoices = {
+                                    viewModel.markCompleted()
+                                    onOpenVoiceLibrary()
+                                },
+                            )
+                            OnboardingStep.FirstFiction -> FirstFictionPicker(
+                                // Issues #644 + #647 (v1.0) — bypass the
+                                // TechEmpower Home hub AND the Guides
+                                // fiction-detail stop. The viewmodel
+                                // resolves the first chapter of the
+                                // `notion:guides` fiction, queues it on
+                                // the playback controller with
+                                // `autoPlay=true`, then [onOpenGuidesAndPlay]
+                                // navigates the user to the Playing
+                                // surface so they land on the transport
+                                // UI as the chapter warms. Net: two taps
+                                // (the hub stop + the Guides-cover stop)
+                                // disappear from the first-launch flow.
+                                //
+                                // Fallback path: if chapter resolution
+                                // fails (network down, source unreachable,
+                                // anonymous Notion 404), the viewmodel
+                                // invokes [onOpenTechEmpower] instead so
+                                // the user lands on the hub with the same
+                                // four-card affordance they would have
+                                // seen pre-fix — never a dead end.
+                                onBrowseTechEmpower = {
+                                    viewModel.openGuidesAndAutoPlay(
+                                        onPlaying = onOpenGuidesAndPlay,
+                                        onFallbackToHub = onOpenTechEmpower,
+                                    )
+                                },
+                                onAddFromWebsite = { clip ->
+                                    viewModel.markCompleted()
+                                    onAddFromWebsite(clip)
+                                },
+                                onSkip = {
+                                    viewModel.markCompleted()
+                                },
+                            )
+                        }
                     }
                 }
             }

--- a/feature/src/main/kotlin/in/jphe/storyvox/feature/onboarding/OnboardingScaffold.kt
+++ b/feature/src/main/kotlin/in/jphe/storyvox/feature/onboarding/OnboardingScaffold.kt
@@ -1,0 +1,108 @@
+package `in`.jphe.storyvox.feature.onboarding
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.semantics.contentDescription
+import androidx.compose.ui.semantics.liveRegion
+import androidx.compose.ui.semantics.LiveRegionMode
+import androidx.compose.ui.semantics.semantics
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.unit.dp
+import `in`.jphe.storyvox.feature.R
+import `in`.jphe.storyvox.ui.theme.LocalSpacing
+
+/**
+ * Issue #787 — shared scaffold wrapping each of the three onboarding
+ * screens with a step indicator that tells the user where they are in
+ * the forward-only flow (Welcome → VoicePick → FirstFiction).
+ *
+ * Visual: a row of three dots at the top of the page (filled brass =
+ * visited or current, outlined = upcoming) plus a small "Step X of 3"
+ * text label below the dots. The dots alone are not screen-reader
+ * accessible — TalkBack needs the explicit count — so we surface both.
+ *
+ * The indicator is informational only: dots are NOT clickable. Per
+ * `OnboardingHost.kt`'s state-machine doc, the welcome flow is
+ * forward-only by design; tappable dots would invite a non-existent
+ * Back affordance.
+ *
+ * The whole indicator row is wrapped in a [contentDescription] +
+ * [liveRegion] so TalkBack announces the step change ("Step 2 of 3")
+ * once when the AnimatedContent transition lands on a new screen,
+ * rather than re-reading the dot count on every focus pass.
+ */
+@Composable
+internal fun OnboardingScaffold(
+    stepIndex: Int,
+    totalSteps: Int = 3,
+    content: @Composable () -> Unit,
+) {
+    val spacing = LocalSpacing.current
+    val stepLabel = stringResource(
+        R.string.onboarding_step_n_of_m,
+        stepIndex + 1,
+        totalSteps,
+    )
+    Box(modifier = Modifier.fillMaxSize()) {
+        content()
+        // Indicator overlay sits above the screen's own padded content
+        // so each screen keeps its existing vertical rhythm (the page
+        // headlines already center themselves in the viewport). The
+        // overlay uses its own top padding rather than competing for
+        // a slot inside each screen's Column.
+        Column(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(top = spacing.md)
+                .semantics(mergeDescendants = true) {
+                    contentDescription = stepLabel
+                    liveRegion = LiveRegionMode.Polite
+                },
+            horizontalAlignment = Alignment.CenterHorizontally,
+        ) {
+            Row(
+                horizontalArrangement = Arrangement.spacedBy(spacing.xs),
+                verticalAlignment = Alignment.CenterVertically,
+            ) {
+                repeat(totalSteps) { i ->
+                    StepDot(filled = i <= stepIndex)
+                }
+            }
+            Spacer(Modifier.height(spacing.xxs))
+            Text(
+                text = stepLabel,
+                style = MaterialTheme.typography.labelSmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                textAlign = TextAlign.Center,
+            )
+        }
+    }
+}
+
+@Composable
+private fun StepDot(filled: Boolean) {
+    val brass = MaterialTheme.colorScheme.primary
+    Box(
+        modifier = Modifier
+            .size(8.dp)
+            .clip(CircleShape)
+            .background(if (filled) brass else brass.copy(alpha = 0.25f)),
+    )
+}

--- a/feature/src/main/res/values/strings.xml
+++ b/feature/src/main/res/values/strings.xml
@@ -371,6 +371,9 @@
     <string name="craigslist_subscribe">Subscribe</string>
     <string name="craigslist_subscribed_confirmation">Subscribed: %1$s. See it under Browse → RSS.</string>
 
+    <!-- Onboarding · step indicator (#787) — rendered above every onboarding screen via OnboardingScaffold. -->
+    <string name="onboarding_step_n_of_m">Step %1$d of %2$d</string>
+
     <!-- Onboarding · WelcomeScreen -->
     <string name="onboarding_welcome_headline">Stories, read aloud.</string>
     <string name="onboarding_welcome_body">storyvox reads books, guides, and articles to you with calming voices. Free, forever, no ads.</string>


### PR DESCRIPTION
## Summary
- Adds brass dot indicators + "Step X of 3" label across all three onboarding screens (Welcome, Voice Picker, First Fiction)
- New `OnboardingScaffold` composable wraps each step with consistent indicator placement
- Accessible: `semantics(mergeDescendants=true)` with `liveRegion = Polite` for TalkBack

Closes #787

## Test plan
- [ ] Fresh install → walk through all 3 onboarding screens → verify step indicator shows and advances
- [ ] Verify TalkBack announces "Step X of 3" on each transition
- [ ] Verify dots show filled for current/visited, dimmed for upcoming

🤖 Generated with [Claude Code](https://claude.com/claude-code)