### PR TITLE
feat(reader): add haptic feedback on transport controls and bookmark

### DIFF
--- a/feature/src/main/kotlin/in/jphe/storyvox/feature/reader/AudiobookView.kt
+++ b/feature/src/main/kotlin/in/jphe/storyvox/feature/reader/AudiobookView.kt
@@ -87,6 +87,8 @@ import androidx.compose.ui.draw.alpha
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.compositeOver
 import androidx.compose.ui.graphics.graphicsLayer
+import androidx.compose.ui.hapticfeedback.HapticFeedbackType
+import androidx.compose.ui.platform.LocalHapticFeedback
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
 import `in`.jphe.storyvox.feature.R
@@ -205,6 +207,7 @@ fun AudiobookView(
     val spacing = LocalSpacing.current
     val motion = LocalMotion.current
     val reducedMotion = LocalReducedMotion.current
+    val haptic = LocalHapticFeedback.current
     // Spinner enter/exit transitions for the warmup state. Honors
     // LocalReducedMotion: when true, visibility flips instantly (reduce
     // motion = absent motion, not shorter motion — same pattern as
@@ -518,6 +521,7 @@ fun AudiobookView(
                                     // the wrong icon for ~16-100 ms.
                                     feedbackShowsPause = state.isPlaying
                                     coverFeedbackAtMs = System.currentTimeMillis()
+                                    haptic.performHapticFeedback(HapticFeedbackType.TextHandleMove)
                                     onPlayPause()
                                 },
                             ),
@@ -671,10 +675,16 @@ fun AudiobookView(
                 horizontalArrangement = Arrangement.SpaceEvenly,
                 verticalAlignment = Alignment.CenterVertically,
             ) {
-                IconButton(onClick = onPreviousChapter) {
+                IconButton(onClick = {
+                    haptic.performHapticFeedback(HapticFeedbackType.LongPress)
+                    onPreviousChapter()
+                }) {
                     Icon(Icons.Filled.SkipPrevious, contentDescription = "Previous chapter", modifier = Modifier.size(32.dp))
                 }
-                IconButton(onClick = onSkipBack) {
+                IconButton(onClick = {
+                    haptic.performHapticFeedback(HapticFeedbackType.TextHandleMove)
+                    onSkipBack()
+                }) {
                     // Issue #268 — Replay30 / Forward30 show the literal '30'
                     // inside a curved-arrow glyph, so the seek interval is
                     // legible at a glance instead of just an abstract
@@ -736,6 +746,7 @@ fun AudiobookView(
                         state.chapterId != null
                     FilledIconButton(
                         onClick = {
+                            haptic.performHapticFeedback(HapticFeedbackType.TextHandleMove)
                             if (isAtNaturalEndForClick) {
                                 onSeekTo(0L)
                             }
@@ -789,10 +800,16 @@ fun AudiobookView(
                         }
                     }
                 }
-                IconButton(onClick = onSkipForward) {
+                IconButton(onClick = {
+                    haptic.performHapticFeedback(HapticFeedbackType.TextHandleMove)
+                    onSkipForward()
+                }) {
                     Icon(Icons.Filled.Forward30, contentDescription = "Skip forward 30 seconds", modifier = Modifier.size(32.dp))
                 }
-                IconButton(onClick = onNextChapter) {
+                IconButton(onClick = {
+                    haptic.performHapticFeedback(HapticFeedbackType.LongPress)
+                    onNextChapter()
+                }) {
                     Icon(Icons.Filled.SkipNext, contentDescription = "Next chapter", modifier = Modifier.size(32.dp))
                 }
             }
@@ -1205,6 +1222,7 @@ private fun PlayerOverflowSheet(
     onJumpToBookmark: () -> Unit = {},
 ) {
     val spacing = LocalSpacing.current
+    val haptic = LocalHapticFeedback.current
     Column(
         modifier = Modifier
             .fillMaxWidth()
@@ -1257,7 +1275,10 @@ private fun PlayerOverflowSheet(
         Row(
             modifier = Modifier
                 .fillMaxWidth()
-                .clickable(role = Role.Button, onClickLabel = stringResource(R.string.reader_bookmark_here), onClick = onBookmarkHere)
+                .clickable(role = Role.Button, onClickLabel = stringResource(R.string.reader_bookmark_here), onClick = {
+                    haptic.performHapticFeedback(HapticFeedbackType.LongPress)
+                    onBookmarkHere()
+                })
                 .padding(vertical = spacing.xs),
             verticalAlignment = Alignment.CenterVertically,
             horizontalArrangement = Arrangement.spacedBy(spacing.sm),
@@ -1279,7 +1300,10 @@ private fun PlayerOverflowSheet(
         Row(
             modifier = Modifier
                 .fillMaxWidth()
-                .clickable(role = Role.Button, onClickLabel = stringResource(R.string.reader_jump_to_bookmark), onClick = onJumpToBookmark)
+                .clickable(role = Role.Button, onClickLabel = stringResource(R.string.reader_jump_to_bookmark), onClick = {
+                    haptic.performHapticFeedback(HapticFeedbackType.LongPress)
+                    onJumpToBookmark()
+                })
                 .padding(vertical = spacing.xs),
             verticalAlignment = Alignment.CenterVertically,
             horizontalArrangement = Arrangement.spacedBy(spacing.sm),

--- a/feature/src/main/kotlin/in/jphe/storyvox/feature/reader/NowPlayingDock.kt
+++ b/feature/src/main/kotlin/in/jphe/storyvox/feature/reader/NowPlayingDock.kt
@@ -29,6 +29,8 @@ import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
+import androidx.compose.ui.hapticfeedback.HapticFeedbackType
+import androidx.compose.ui.platform.LocalHapticFeedback
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.semantics.LiveRegionMode
 import androidx.compose.ui.semantics.Role
@@ -102,6 +104,7 @@ internal fun NowPlayingDockContent(
     modifier: Modifier = Modifier,
 ) {
     val isTablet = isAtLeastTablet()
+    val haptic = LocalHapticFeedback.current
     val fictionTitle = state.fictionTitle.ifBlank { stringResource(R.string.reader_now_playing) }
     val chapterTitle = state.chapterTitle
     val cardDescription = stringResource(R.string.reader_dock_card_description, fictionTitle, chapterTitle)
@@ -178,7 +181,10 @@ internal fun NowPlayingDockContent(
                     }
                 }
                 IconButton(
-                    onClick = onTogglePlayPause,
+                    onClick = {
+                        haptic.performHapticFeedback(HapticFeedbackType.TextHandleMove)
+                        onTogglePlayPause()
+                    },
                     modifier = Modifier
                         .size(48.dp)
                         .semantics { contentDescription = playPauseLabel },
@@ -194,7 +200,10 @@ internal fun NowPlayingDockContent(
                     // transport control; phones stay at one button so the
                     // 40dp thumb + ellipsized two-line title can breathe.
                     IconButton(
-                        onClick = onNextChapter,
+                        onClick = {
+                            haptic.performHapticFeedback(HapticFeedbackType.LongPress)
+                            onNextChapter()
+                        },
                         modifier = Modifier
                             .size(48.dp)
                             .semantics { contentDescription = "Next chapter" },


### PR DESCRIPTION
## Summary
- Adds haptic feedback via `LocalHapticFeedback` to reader transport controls (play/pause, skip ±30s, chapter skip) and bookmark actions
- `TextHandleMove` for subtle taps (play/pause, ±30s), `LongPress` for committing actions (chapter skip, bookmark)
- Also wired in `NowPlayingDock` play/pause and tablet next-chapter buttons

Closes #780

## Test plan
- [ ] Open reader → tap play/pause → feel subtle haptic
- [ ] Tap skip forward/backward → feel subtle haptic
- [ ] Tap next/previous chapter → feel stronger haptic
- [ ] Open overflow → bookmark here / jump to bookmark → feel haptic
- [ ] Verify NowPlayingDock play/pause also has haptic

🤖 Generated with [Claude Code](https://claude.com/claude-code)