### PR TITLE
refactor(core-ui): i18n friendlyErrorMessage strings

### DIFF
--- a/core-ui/src/main/kotlin/in/jphe/storyvox/ui/component/FriendlyError.kt
+++ b/core-ui/src/main/kotlin/in/jphe/storyvox/ui/component/FriendlyError.kt
@@ -1,26 +1,50 @@
 package `in`.jphe.storyvox.ui.component
 
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.res.stringResource
+import `in`.jphe.storyvox.ui.R
+
 /**
- * Maps a raw exception string to user-facing copy that doesn't leak the
- * shape of the underlying network stack.
+ * Categorized friendly-error kinds. Each kind maps 1:1 to a
+ * `friendly_error_*` string resource; `Raw` carries the original
+ * message through when no known pattern matches.
  *
- * Pre-#171: error states across FictionDetail, Browse, and source-mempalace
- * surfaced strings like `HTTP 0: Network timeout: timeout` and
+ * Issue #789 — split out from `friendlyErrorMessage` so the pattern
+ * matching can be unit-tested without a Compose harness while the
+ * user-facing copy lives in `strings.xml` for i18n.
+ */
+enum class FriendlyErrorKind {
+    Generic,
+    NetworkLost,
+    CloudflareChallenge,
+    RateLimited,
+    ServerError,
+    AuthFailed,
+    NotConfigured,
+    UnexpectedResponse,
+    Raw,
+}
+
+/**
+ * Pure-Kotlin categorizer. Returns the matched [FriendlyErrorKind] and
+ * — when the kind is [FriendlyErrorKind.Raw] — the original message
+ * that should be surfaced as-is. For all other kinds the second
+ * element of the pair is `null`; the caller resolves a string resource.
+ *
+ * Pre-#171 / pre-#789 history: error states across FictionDetail,
+ * Browse, and source-mempalace surfaced strings like
+ * `HTTP 0: Network timeout: timeout` and
  * `java.io.IOException: Palace host not configured` directly to the
  * user. The technical strings are useful for bug reports but read as
  * scary nonsense to a reader who just wanted to listen to a chapter.
  *
- * Call sites should pass the raw message through this function before
- * setting it on [ErrorBlock]. The mapping is intentionally lenient —
- * we'd rather show one generic "the realm is unreachable" than ten
- * specific copies that drift apart over time. Capture the technical
- * detail in logcat for bug reports; keep the user-facing copy short
- * and recoverable-sounding.
- *
- * Returns the raw message unchanged when no known pattern matches.
+ * The mapping is intentionally lenient — we'd rather show one generic
+ * "the realm is unreachable" than ten specific copies that drift
+ * apart over time. Capture the technical detail in logcat for bug
+ * reports; keep the user-facing copy short and recoverable-sounding.
  */
-fun friendlyErrorMessage(raw: String?): String {
-    val s = raw ?: return "Something went wrong. Try again in a moment."
+fun categorizeFriendlyError(raw: String?): Pair<FriendlyErrorKind, String?> {
+    val s = raw ?: return FriendlyErrorKind.Generic to null
     val lower = s.lowercase()
     return when {
         // Network timeouts / offline / DNS — by far the most common.
@@ -31,43 +55,68 @@ fun friendlyErrorMessage(raw: String?): String {
         lower.contains("unknownhostexception") ||
         lower.contains("connection refused") ||
         lower.contains("failed to connect") ->
-            "Connection lost. Check your network and try again."
+            FriendlyErrorKind.NetworkLost to null
 
         // Cloudflare or similar bot-challenge — we couldn't transparently
         // solve a challenge. User can retry; sometimes resolves on its own.
         lower.contains("cloudflare") ||
         lower.contains("challenge") ->
-            "Royal Road asked us to wait. Try again in a moment."
+            FriendlyErrorKind.CloudflareChallenge to null
 
         // Rate-limited (our own gate or the server's 429).
         lower.contains("rate limited") ||
         lower.contains("too many requests") ||
         lower.contains("retry after") ->
-            "We're sending requests too fast — slow down and try again."
+            FriendlyErrorKind.RateLimited to null
 
         // Server errors. Don't blame the user.
         s.contains("HTTP 5") || lower.contains("server error") ->
-            "The realm is having trouble. Try again in a moment."
+            FriendlyErrorKind.ServerError to null
 
         // Auth — but only for fetch contexts (playback has its own typed
         // PlaybackError.AzureAuthFailed path).
         s.contains("HTTP 401") || s.contains("HTTP 403") ||
         lower.contains("authentication") ->
-            "We couldn't sign in. Re-paste your credentials in Settings."
+            FriendlyErrorKind.AuthFailed to null
 
         // Specific config gaps surfaced as IOException — Memory Palace
         // is the canonical example (PalaceDaemonApi throws on empty host).
         lower.contains("host not configured") ||
         lower.contains("not configured") ->
-            "This source isn't set up yet. Open Settings to configure it."
+            FriendlyErrorKind.NotConfigured to null
 
         // Other 4xx — usually means something the user can't fix.
         s.contains("HTTP 4") ->
-            "The realm returned an unexpected response. Try again later."
+            FriendlyErrorKind.UnexpectedResponse to null
 
         // Fall back to the raw string. Either the source layer already
         // produced user-friendly copy, or we don't have a mapping yet.
         // Better to show something specific than to swallow detail.
-        else -> s
+        else -> FriendlyErrorKind.Raw to s
+    }
+}
+
+/**
+ * Maps a raw exception string to user-facing copy that doesn't leak
+ * the shape of the underlying network stack. Call sites should pass
+ * the raw message through this composable before setting it on
+ * [ErrorBlock].
+ *
+ * Returns the raw message unchanged when no known pattern matches
+ * (`FriendlyErrorKind.Raw`).
+ */
+@Composable
+fun friendlyErrorMessage(raw: String?): String {
+    val (kind, fallback) = categorizeFriendlyError(raw)
+    return when (kind) {
+        FriendlyErrorKind.Generic -> stringResource(R.string.friendly_error_generic)
+        FriendlyErrorKind.NetworkLost -> stringResource(R.string.friendly_error_network_lost)
+        FriendlyErrorKind.CloudflareChallenge -> stringResource(R.string.friendly_error_cloudflare_challenge)
+        FriendlyErrorKind.RateLimited -> stringResource(R.string.friendly_error_rate_limited)
+        FriendlyErrorKind.ServerError -> stringResource(R.string.friendly_error_server_error)
+        FriendlyErrorKind.AuthFailed -> stringResource(R.string.friendly_error_auth_failed)
+        FriendlyErrorKind.NotConfigured -> stringResource(R.string.friendly_error_not_configured)
+        FriendlyErrorKind.UnexpectedResponse -> stringResource(R.string.friendly_error_unexpected_response)
+        FriendlyErrorKind.Raw -> fallback ?: stringResource(R.string.friendly_error_generic)
     }
 }

--- a/core-ui/src/main/res/values/strings.xml
+++ b/core-ui/src/main/res/values/strings.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <!-- Issue #789 — friendlyErrorMessage user-facing copy. The mapping
+         logic lives in FriendlyError.kt; these are the localizable copies
+         the user actually reads. -->
+    <string name="friendly_error_generic">Something went wrong. Try again in a moment.</string>
+    <string name="friendly_error_network_lost">Connection lost. Check your network and try again.</string>
+    <string name="friendly_error_cloudflare_challenge">Royal Road asked us to wait. Try again in a moment.</string>
+    <string name="friendly_error_rate_limited">We\'re sending requests too fast — slow down and try again.</string>
+    <string name="friendly_error_server_error">The realm is having trouble. Try again in a moment.</string>
+    <string name="friendly_error_auth_failed">We couldn\'t sign in. Re-paste your credentials in Settings.</string>
+    <string name="friendly_error_not_configured">This source isn\'t set up yet. Open Settings to configure it.</string>
+    <string name="friendly_error_unexpected_response">The realm returned an unexpected response. Try again later.</string>
+</resources>

--- a/core-ui/src/test/kotlin/in/jphe/storyvox/ui/component/FriendlyErrorCategorizationTest.kt
+++ b/core-ui/src/test/kotlin/in/jphe/storyvox/ui/component/FriendlyErrorCategorizationTest.kt
@@ -1,0 +1,159 @@
+package `in`.jphe.storyvox.ui.component
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Test
+
+/**
+ * Issue #789 — coverage for `categorizeFriendlyError`, the pure-Kotlin
+ * half of the FriendlyError split. The Composable wrapper just maps
+ * each [FriendlyErrorKind] to a string resource; the matching logic
+ * is what can drift without notice, so this is where the regression
+ * fence lives.
+ */
+class FriendlyErrorCategorizationTest {
+
+    @Test
+    fun `null raw maps to Generic with no fallback`() {
+        val (kind, fallback) = categorizeFriendlyError(null)
+        assertEquals(FriendlyErrorKind.Generic, kind)
+        assertNull(fallback)
+    }
+
+    @Test
+    fun `HTTP 0 timeout maps to NetworkLost`() {
+        assertEquals(
+            FriendlyErrorKind.NetworkLost,
+            categorizeFriendlyError("HTTP 0: Network timeout: timeout").first
+        )
+    }
+
+    @Test
+    fun `unknown host maps to NetworkLost`() {
+        assertEquals(
+            FriendlyErrorKind.NetworkLost,
+            categorizeFriendlyError("java.net.UnknownHostException: royalroad.com").first
+        )
+    }
+
+    @Test
+    fun `socket timeout maps to NetworkLost`() {
+        assertEquals(
+            FriendlyErrorKind.NetworkLost,
+            categorizeFriendlyError("java.net.SocketTimeoutException").first
+        )
+    }
+
+    @Test
+    fun `connection refused maps to NetworkLost`() {
+        assertEquals(
+            FriendlyErrorKind.NetworkLost,
+            categorizeFriendlyError("Failed to connect to host: Connection refused").first
+        )
+    }
+
+    @Test
+    fun `cloudflare challenge maps to CloudflareChallenge`() {
+        assertEquals(
+            FriendlyErrorKind.CloudflareChallenge,
+            categorizeFriendlyError("Cloudflare challenge could not be solved").first
+        )
+        assertEquals(
+            FriendlyErrorKind.CloudflareChallenge,
+            categorizeFriendlyError("got a JS challenge page").first
+        )
+    }
+
+    @Test
+    fun `rate limited maps to RateLimited`() {
+        assertEquals(
+            FriendlyErrorKind.RateLimited,
+            categorizeFriendlyError("HTTP 429: Too Many Requests").first
+        )
+        assertEquals(
+            FriendlyErrorKind.RateLimited,
+            categorizeFriendlyError("rate limited by gate").first
+        )
+        assertEquals(
+            FriendlyErrorKind.RateLimited,
+            categorizeFriendlyError("Retry after 30s").first
+        )
+    }
+
+    @Test
+    fun `5xx maps to ServerError`() {
+        assertEquals(
+            FriendlyErrorKind.ServerError,
+            categorizeFriendlyError("HTTP 500: Internal Server Error").first
+        )
+        assertEquals(
+            FriendlyErrorKind.ServerError,
+            categorizeFriendlyError("HTTP 503").first
+        )
+    }
+
+    @Test
+    fun `401 and 403 map to AuthFailed`() {
+        assertEquals(
+            FriendlyErrorKind.AuthFailed,
+            categorizeFriendlyError("HTTP 401: Unauthorized").first
+        )
+        assertEquals(
+            FriendlyErrorKind.AuthFailed,
+            categorizeFriendlyError("HTTP 403: Forbidden").first
+        )
+    }
+
+    @Test
+    fun `not configured maps to NotConfigured`() {
+        assertEquals(
+            FriendlyErrorKind.NotConfigured,
+            categorizeFriendlyError("Palace host not configured").first
+        )
+        assertEquals(
+            FriendlyErrorKind.NotConfigured,
+            categorizeFriendlyError("Source is not configured yet").first
+        )
+    }
+
+    @Test
+    fun `other 4xx maps to UnexpectedResponse`() {
+        assertEquals(
+            FriendlyErrorKind.UnexpectedResponse,
+            categorizeFriendlyError("HTTP 418: I'm a teapot").first
+        )
+        assertEquals(
+            FriendlyErrorKind.UnexpectedResponse,
+            categorizeFriendlyError("HTTP 422: Unprocessable Entity").first
+        )
+    }
+
+    @Test
+    fun `unmatched maps to Raw with the original message as fallback`() {
+        val (kind, fallback) = categorizeFriendlyError("The chapter list is empty.")
+        assertEquals(FriendlyErrorKind.Raw, kind)
+        assertEquals("The chapter list is empty.", fallback)
+    }
+
+    @Test
+    fun `match order — 401 beats generic 4xx`() {
+        // The fence here: 401 must hit AuthFailed before "HTTP 4" fires
+        // UnexpectedResponse. If someone reorders the when branches and
+        // breaks this, the user sees "unexpected response" for a
+        // re-paste-credentials situation, which is confusing copy.
+        assertEquals(
+            FriendlyErrorKind.AuthFailed,
+            categorizeFriendlyError("HTTP 401: Unauthorized").first
+        )
+    }
+
+    @Test
+    fun `match order — 429 beats generic 4xx`() {
+        // Same fence for rate-limited: "too many requests" must win
+        // over the generic HTTP 4 branch.
+        assertEquals(
+            FriendlyErrorKind.RateLimited,
+            categorizeFriendlyError("HTTP 429: Too Many Requests").first
+        )
+    }
+}


### PR DESCRIPTION
## Summary
- Splits `friendlyErrorMessage` into pure-Kotlin `categorizeFriendlyError()` (returns `FriendlyErrorKind`) + `@Composable friendlyErrorMessage()` (resolves to `stringResource`)
- Adds 7 `friendly_error_*` string resources in core-ui's first `strings.xml`
- 14 JVM unit tests covering all match arms + order-fence regressions (401 beats generic 4xx, 429 beats generic 4xx)

Closes #789

## Test plan
- [ ] Trigger network error in Browse → verify error message renders correctly
- [ ] Trigger auth error (expired token) → verify "auth failed" message
- [ ] `./gradlew :core-ui:testDebugUnitTest` — all 14 new tests green

🤖 Generated with [Claude Code](https://claude.com/claude-code)