### PR TITLE
feat(settings): add developer logging toggle

### DIFF
--- a/app/src/main/kotlin/in/jphe/storyvox/StoryvoxApp.kt
+++ b/app/src/main/kotlin/in/jphe/storyvox/StoryvoxApp.kt
@@ -10,6 +10,7 @@ import `in`.jphe.storyvox.BuildConfig
 import `in`.jphe.storyvox.data.PrerenderModeWatcher
 import `in`.jphe.storyvox.data.auth.SessionHydrator
 import `in`.jphe.storyvox.data.db.StoryvoxDatabase
+import `in`.jphe.storyvox.data.log.DebugLog
 import `in`.jphe.storyvox.data.repository.AuthRepository
 import `in`.jphe.storyvox.data.repository.FictionRepository
 import `in`.jphe.storyvox.data.repository.PlaybackPositionRepository
@@ -23,7 +24,9 @@ import javax.inject.Inject
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.launch
 import java.util.concurrent.atomic.AtomicBoolean
 
@@ -158,6 +161,17 @@ class StoryvoxApp : Application(), Configuration.Provider {
             workScheduler.get().ensurePeriodicWorkScheduled()
         }
         rehydrateRoyalRoadCookies()
+        // Issue #823 — propagate the persisted "verbose logging" toggle
+        // into DebugLog so the playback / download pipeline starts
+        // emitting Info-level breadcrumbs on next event. distinctUntilChanged
+        // keeps the AtomicBoolean writes quiet when the flow re-emits
+        // the same value (DataStore replay-on-subscribe behaviour).
+        initScope.launch {
+            settingsRepo.get().settings
+                .map { it.debugLogging }
+                .distinctUntilChanged()
+                .collect { DebugLog.setEnabled(it) }
+        }
         // Voice-engine seed calls intentionally NOT invoked here — see
         // [seedVoiceEngineFromSettings] kdoc. MainActivity drives the
         // post-first-frame hand-off so the .so dlopen lands well after

--- a/app/src/main/kotlin/in/jphe/storyvox/data/SettingsRepositoryUiImpl.kt
+++ b/app/src/main/kotlin/in/jphe/storyvox/data/SettingsRepositoryUiImpl.kt
@@ -658,6 +658,12 @@ private object Keys {
      *  /debug screen is reachable regardless of this toggle. */
     val SHOW_DEBUG_OVERLAY = booleanPreferencesKey("pref_show_debug_overlay")
 
+    /** Issue #823 — verbose-logging master switch. Default false;
+     *  flips DebugLog.isEnabled() so the playback / download pipeline
+     *  starts emitting Info-level breadcrumbs. Per-device (NOT synced)
+     *  — only useful on the device JP is currently diagnosing. */
+    val DEBUG_LOGGING_ENABLED = booleanPreferencesKey("pref_debug_logging_enabled")
+
     // ── Azure offline-fallback (issue #185, PR-6) ──────────────────
     val AZURE_FALLBACK_ENABLED = booleanPreferencesKey("pref_azure_fallback_enabled")
     val AZURE_FALLBACK_VOICE_ID = stringPreferencesKey("pref_azure_fallback_voice_id")
@@ -1209,6 +1215,7 @@ class SettingsRepositoryUiImpl(
             notionRootPageId = notion.rootPageId,
             sleepShakeToExtendEnabled = prefs[Keys.SLEEP_SHAKE_TO_EXTEND_ENABLED] ?: true,
             showDebugOverlay = prefs[Keys.SHOW_DEBUG_OVERLAY] ?: false,
+            debugLogging = prefs[Keys.DEBUG_LOGGING_ENABLED] ?: false,
             azure = run {
                 // #182 — read the encrypted snapshot imperatively each
                 // emission. The azureTick flow above guarantees a fresh
@@ -2187,6 +2194,10 @@ class SettingsRepositoryUiImpl(
 
     override suspend fun setShowDebugOverlay(enabled: Boolean) {
         store.edit { it[Keys.SHOW_DEBUG_OVERLAY] = enabled }
+    }
+
+    override suspend fun setDebugLogging(enabled: Boolean) {
+        store.edit { it[Keys.DEBUG_LOGGING_ENABLED] = enabled }
     }
 
     // ── Accessibility scaffold (Phase 1, v0.5.42) ──────────────────

--- a/core-data/src/main/kotlin/in/jphe/storyvox/data/log/DebugLog.kt
+++ b/core-data/src/main/kotlin/in/jphe/storyvox/data/log/DebugLog.kt
@@ -1,0 +1,74 @@
+package `in`.jphe.storyvox.data.log
+
+import android.util.Log
+import java.util.concurrent.atomic.AtomicBoolean
+
+/**
+ * Issue #823 — process-wide verbose-logging toggle.
+ *
+ * Default-off lightweight tracer for the playback + chapter-download
+ * pipeline. Errors and critical events keep going through `Log.e` /
+ * `Log.w` unconditionally; this helper only gates the Info-level
+ * "what step just happened" breadcrumbs that the issue lists as the
+ * subsystems worth tracing when something goes wrong on device:
+ *
+ *  - **ChapterDownloadScheduler** — schedule / complete / fail with
+ *    chapter ids
+ *  - **ChapterDownloadWorker** — doWork entry, result, retry reason
+ *  - **EnginePlayer** — loadAndPlay, advanceChapter, voice load,
+ *    pipeline start/stop
+ *  - **PlaybackController** — play / pause / seek with position info
+ *
+ * Why an [AtomicBoolean] rather than reading the flow on every call:
+ * playback log call sites can fire many times per second
+ * (EnginePlayer's sentence loop, the audio queue, etc.) — going
+ * through a coroutine-collected `StateFlow` per-call would add latency
+ * to the hot path even when logging is off. `AtomicBoolean.get()` is a
+ * single volatile read.
+ *
+ * Wiring: [StoryvoxApp][in.jphe.storyvox.StoryvoxApp] collects the
+ * `debugLogging` flag from
+ * [SettingsRepositoryUi][in.jphe.storyvox.feature.api.SettingsRepositoryUi]
+ * and calls [setEnabled] on every emission. The Settings → Developer
+ * "Verbose logging" toggle is the user-facing surface.
+ *
+ * When disabled, call sites short-circuit before any string
+ * formatting — pass eagerly-built messages only at sites where the
+ * string is already cheap, and use the lambda overloads ([i], [d])
+ * everywhere else.
+ */
+object DebugLog {
+
+    private val enabled = AtomicBoolean(false)
+
+    /** Read the current toggle state. Cheap (single volatile read). */
+    fun isEnabled(): Boolean = enabled.get()
+
+    /**
+     * Settings collector calls this on every emission of
+     * `UiSettings.debugLogging`. Idempotent — re-setting the same
+     * value is a no-op at the [AtomicBoolean] level.
+     */
+    fun setEnabled(value: Boolean) {
+        enabled.set(value)
+    }
+
+    /**
+     * Info-level breadcrumb. The [message] lambda is only invoked
+     * when verbose logging is on, so callers pay nothing for string
+     * construction on the disabled path.
+     */
+    inline fun i(tag: String, message: () -> String) {
+        if (isEnabled()) Log.i(tag, message())
+    }
+
+    /**
+     * Debug-level breadcrumb. Same gating contract as [i]; use for
+     * the noisiest trace points (per-sentence, per-buffer) so they
+     * stay off `logcat` even when a developer flips the toggle for a
+     * narrower trace via [i] only.
+     */
+    inline fun d(tag: String, message: () -> String) {
+        if (isEnabled()) Log.d(tag, message())
+    }
+}

--- a/core-data/src/main/kotlin/in/jphe/storyvox/data/repository/ChapterDownloadScheduler.kt
+++ b/core-data/src/main/kotlin/in/jphe/storyvox/data/repository/ChapterDownloadScheduler.kt
@@ -9,6 +9,7 @@ import androidx.work.NetworkType
 import androidx.work.OneTimeWorkRequestBuilder
 import androidx.work.WorkManager
 import dagger.hilt.android.qualifiers.ApplicationContext
+import `in`.jphe.storyvox.data.log.DebugLog
 import `in`.jphe.storyvox.data.work.ChapterDownloadWorker
 import java.time.Duration
 import javax.inject.Inject
@@ -56,6 +57,9 @@ class WorkManagerChapterDownloadScheduler @Inject constructor(
             .build()
 
         android.util.Log.i("ChapterDownload", "schedule: chapter=$chapterId fiction=$fictionId unmetered=$requireUnmetered")
+        DebugLog.i("ChapterDownloadScheduler") {
+            "enqueueUniqueWork chapter=$chapterId fiction=$fictionId policy=REPLACE"
+        }
         workManager.enqueueUniqueWork(
             ChapterDownloadWorker.uniqueName(chapterId),
             ExistingWorkPolicy.REPLACE,

--- a/core-data/src/main/kotlin/in/jphe/storyvox/data/work/ChapterDownloadWorker.kt
+++ b/core-data/src/main/kotlin/in/jphe/storyvox/data/work/ChapterDownloadWorker.kt
@@ -10,6 +10,7 @@ import dagger.assisted.AssistedInject
 import `in`.jphe.storyvox.data.db.dao.ChapterDao
 import `in`.jphe.storyvox.data.db.dao.FictionDao
 import `in`.jphe.storyvox.data.db.entity.ChapterDownloadState
+import `in`.jphe.storyvox.data.log.DebugLog
 import `in`.jphe.storyvox.data.repository.AuthRepository
 import `in`.jphe.storyvox.data.source.FictionSource
 import `in`.jphe.storyvox.data.source.WebViewFetcher
@@ -70,6 +71,7 @@ class ChapterDownloadWorker @AssistedInject constructor(
         val chapterId = inputData.getString(KEY_CHAPTER_ID) ?: return Result.failure(
             Data.Builder().putString(KEY_RESULT, RESULT_BAD_INPUT).build(),
         )
+        DebugLog.i(TAG_LOG) { "doWork enter chapter=$chapterId fiction=$fictionId attempt=$runAttemptCount" }
         // Issue #808 — cap retries so zombie URLs (chapter pulled, source
         // permanently rate-limiting us, etc.) eventually terminate instead
         // of looping forever on exponential backoff. The reaper handles
@@ -110,6 +112,7 @@ class ChapterDownloadWorker @AssistedInject constructor(
                         now = System.currentTimeMillis(),
                         audioUrl = content.audioUrl,
                     )
+                    DebugLog.i(TAG_LOG) { "doWork ok chapter=$chapterId bytes=${content.htmlBody.length}" }
                     Result.success(output(RESULT_OK))
                 }
 
@@ -204,6 +207,9 @@ class ChapterDownloadWorker @AssistedInject constructor(
 
     companion object {
         const val TAG = "download:chapter"
+
+        /** Issue #823 — logcat tag for [DebugLog] breadcrumbs. */
+        const val TAG_LOG = "ChapterDownloadWorker"
 
         const val KEY_FICTION_ID = "fictionId"
         const val KEY_CHAPTER_ID = "chapterId"

--- a/core-playback/src/main/kotlin/in/jphe/storyvox/playback/PlaybackController.kt
+++ b/core-playback/src/main/kotlin/in/jphe/storyvox/playback/PlaybackController.kt
@@ -1,5 +1,6 @@
 package `in`.jphe.storyvox.playback
 
+import `in`.jphe.storyvox.data.log.DebugLog
 import `in`.jphe.storyvox.playback.diagnostics.AudioOutputMonitor
 import `in`.jphe.storyvox.playback.diagnostics.WaitReason
 import `in`.jphe.storyvox.playback.tts.EnginePlayer
@@ -631,6 +632,7 @@ class DefaultPlaybackController @Inject constructor(
     }
 
     override suspend fun play(fictionId: String, chapterId: String, charOffset: Int) {
+        DebugLog.i("PlaybackController") { "play fiction=$fictionId chapter=$chapterId charOffset=$charOffset" }
         // #90 — record the play intent BEFORE loadAndPlay (which can take
         // 30+s to return on a cold engine load). If the user kills the
         // app mid-load we want resume-on-reopen to autoplay.
@@ -648,6 +650,7 @@ class DefaultPlaybackController @Inject constructor(
     }
 
     override fun pause() {
+        DebugLog.i("PlaybackController") { "pause" }
         // #90 — explicit pause is a user intent. Persist so the next
         // Library Resume CTA respects it (load chapter, stay paused).
         scope.launch { runCatching { resumePolicy.setLastWasPlaying(false) } }
@@ -660,6 +663,7 @@ class DefaultPlaybackController @Inject constructor(
     }
 
     override fun resume() {
+        DebugLog.i("PlaybackController") { "resume" }
         scope.launch { runCatching { resumePolicy.setLastWasPlaying(true) } }
         player?.resume()
     }
@@ -668,7 +672,10 @@ class DefaultPlaybackController @Inject constructor(
         if (state.value.isPlaying) pause() else resume()
     }
 
-    override fun seekTo(charOffset: Int) { player?.seekToCharOffset(charOffset) }
+    override fun seekTo(charOffset: Int) {
+        DebugLog.i("PlaybackController") { "seekTo charOffset=$charOffset" }
+        player?.seekToCharOffset(charOffset)
+    }
 
     override fun seekToPositionMs(positionMs: Long) {
         // #531 / #555 — UI gives us a ms position on the scrubber rail

--- a/core-playback/src/main/kotlin/in/jphe/storyvox/playback/tts/EnginePlayer.kt
+++ b/core-playback/src/main/kotlin/in/jphe/storyvox/playback/tts/EnginePlayer.kt
@@ -23,6 +23,7 @@ import com.google.common.util.concurrent.ListenableFuture
 import dagger.assisted.Assisted
 import dagger.assisted.AssistedFactory
 import dagger.assisted.AssistedInject
+import `in`.jphe.storyvox.data.log.DebugLog
 import `in`.jphe.storyvox.data.repository.ChapterRepository
 import `in`.jphe.storyvox.data.repository.HistoryRepository
 import `in`.jphe.storyvox.data.repository.PlaybackPositionRepository
@@ -1212,6 +1213,7 @@ class EnginePlayer @AssistedInject constructor(
         charOffset: Int,
         autoPlay: Boolean = true,
     ) {
+        DebugLog.i("EnginePlayer") { "loadAndPlay fiction=$fictionId chapter=$chapterId charOffset=$charOffset autoPlay=$autoPlay" }
         // PR-6 (#185) — fallback toast dedupe is per-chapter; reset
         // here so the next chapter's first Azure failure can re-fire
         // the toast. Cheap (one volatile write) so we don't gate it
@@ -3387,6 +3389,7 @@ class EnginePlayer @AssistedInject constructor(
     }
 
     suspend fun advanceChapter(direction: Int) {
+        DebugLog.i("EnginePlayer") { "advanceChapter direction=$direction" }
         // Issue #726 — record the direction of the in-flight advance so
         // PlaybackController's buffering-stuck watchdog can mirror it
         // instead of hardcoding +1. Normalize to -1 / +1 so a Previous

--- a/feature/src/main/kotlin/in/jphe/storyvox/feature/api/UiContracts.kt
+++ b/feature/src/main/kotlin/in/jphe/storyvox/feature/api/UiContracts.kt
@@ -1082,6 +1082,19 @@ data class UiSettings(
      */
     val showDebugOverlay: Boolean = false,
     /**
+     * Issue #823 — verbose-logging master switch. Default `false`.
+     * When `true`, the playback + chapter-download subsystems
+     * (PlaybackController, EnginePlayer, ChapterDownloadScheduler,
+     * ChapterDownloadWorker) emit Info-level breadcrumbs through
+     * [DebugLog][in.jphe.storyvox.data.log.DebugLog] for on-device
+     * diagnostics via `adb logcat`. Errors and critical events log
+     * regardless of this flag.
+     *
+     * Per-device pref (NOT synced) — only relevant to whichever
+     * device the user is currently diagnosing.
+     */
+    val debugLogging: Boolean = false,
+    /**
      * Issue #383 — per-source Inbox notification toggles. When false,
      * the corresponding backend's update emitter skips writing events
      * to the cross-source Inbox feed (and skips the optional system
@@ -2023,6 +2036,18 @@ interface SettingsRepositoryUi {
      * that *do* care about the overlay's persistence can override.
      */
     suspend fun setShowDebugOverlay(enabled: Boolean) {
+        // default no-op for test fakes; SettingsRepositoryUiImpl overrides.
+    }
+
+    /**
+     * Issue #823 — toggle the verbose-logging master switch
+     * ([UiSettings.debugLogging]). Default impl is a no-op so existing
+     * test fakes don't need to be touched; the real DataStore impl
+     * persists the value and [StoryvoxApp][in.jphe.storyvox.StoryvoxApp]
+     * propagates emissions to
+     * [DebugLog][in.jphe.storyvox.data.log.DebugLog].
+     */
+    suspend fun setDebugLogging(enabled: Boolean) {
         // default no-op for test fakes; SettingsRepositoryUiImpl overrides.
     }
 

--- a/feature/src/main/kotlin/in/jphe/storyvox/feature/debug/DebugScreen.kt
+++ b/feature/src/main/kotlin/in/jphe/storyvox/feature/debug/DebugScreen.kt
@@ -101,6 +101,7 @@ fun DebugScreen(
 ) {
     val snapshot by viewModel.snapshot.collectAsStateWithLifecycle()
     val overlayEnabled by viewModel.overlayEnabled.collectAsStateWithLifecycle()
+    val debugLoggingEnabled by viewModel.debugLoggingEnabled.collectAsStateWithLifecycle()
     val context = LocalContext.current
     val scope = rememberCoroutineScope()
     var copyFlashAt by remember { mutableStateOf(0L) }
@@ -108,9 +109,11 @@ fun DebugScreen(
     DebugScreenContent(
         snapshot = snapshot,
         overlayEnabled = overlayEnabled,
+        debugLoggingEnabled = debugLoggingEnabled,
         copyFlashAt = copyFlashAt,
         onBack = onBack,
         onToggleOverlay = viewModel::setOverlayEnabled,
+        onToggleDebugLogging = viewModel::setDebugLoggingEnabled,
         onCopy = {
             scope.launch {
                 val snap = viewModel.captureForExport()
@@ -126,9 +129,11 @@ fun DebugScreen(
 internal fun DebugScreenContent(
     snapshot: DebugSnapshot,
     overlayEnabled: Boolean,
+    debugLoggingEnabled: Boolean,
     copyFlashAt: Long,
     onBack: () -> Unit,
     onToggleOverlay: (Boolean) -> Unit,
+    onToggleDebugLogging: (Boolean) -> Unit,
     onCopy: () -> Unit,
 ) {
     val spacing = LocalSpacing.current
@@ -188,6 +193,15 @@ internal fun DebugScreenContent(
             OverlayToggleCard(
                 enabled = overlayEnabled,
                 onToggle = onToggleOverlay,
+            )
+
+            // Issue #823 — verbose-logging master switch. Flips
+            // DebugLog.isEnabled() so PlaybackController / EnginePlayer /
+            // ChapterDownloadScheduler / ChapterDownloadWorker emit
+            // Info-level breadcrumbs to logcat for on-device diagnostics.
+            VerboseLoggingToggleCard(
+                enabled = debugLoggingEnabled,
+                onToggle = onToggleDebugLogging,
             )
 
             DebugSection(title = "Pipeline") {
@@ -419,6 +433,63 @@ private fun OverlayToggleCard(enabled: Boolean, onToggle: (Boolean) -> Unit) {
     }
 }
 
+/**
+ * Issue #823 — sibling of [OverlayToggleCard] for the verbose-logging
+ * master switch. When on, the playback + chapter-download subsystems
+ * (PlaybackController, EnginePlayer, ChapterDownloadScheduler,
+ * ChapterDownloadWorker) emit Info-level breadcrumbs through
+ * [DebugLog][in.jphe.storyvox.data.log.DebugLog] for on-device
+ * diagnostics via `adb logcat`. Errors keep going to logcat regardless.
+ */
+@Composable
+private fun VerboseLoggingToggleCard(enabled: Boolean, onToggle: (Boolean) -> Unit) {
+    val brassColors = SwitchDefaults.colors(
+        checkedThumbColor = MaterialTheme.colorScheme.primary,
+        checkedTrackColor = MaterialTheme.colorScheme.primaryContainer,
+        checkedBorderColor = MaterialTheme.colorScheme.primary,
+        uncheckedThumbColor = MaterialTheme.colorScheme.outline,
+    )
+    Card(
+        modifier = Modifier.fillMaxWidth(),
+        colors = CardDefaults.cardColors(
+            containerColor = MaterialTheme.colorScheme.surfaceContainerHigh,
+        ),
+        shape = MaterialTheme.shapes.large,
+    ) {
+        // a11y (#478): toggleable Row so TalkBack announces a single
+        // Role.Switch node with the label.
+        Row(
+            modifier = Modifier
+                .fillMaxWidth()
+                .toggleable(
+                    value = enabled,
+                    role = Role.Switch,
+                    onValueChange = onToggle,
+                )
+                .padding(horizontal = 16.dp, vertical = 12.dp),
+            verticalAlignment = Alignment.CenterVertically,
+            horizontalArrangement = Arrangement.spacedBy(12.dp),
+        ) {
+            Column(modifier = Modifier.weight(1f)) {
+                Text(
+                    text = "Verbose logging",
+                    style = MaterialTheme.typography.bodyLarge,
+                )
+                Text(
+                    text = "Emit Info-level breadcrumbs from playback + chapter-download to logcat. Errors log regardless.",
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                )
+            }
+            Switch(
+                checked = enabled,
+                onCheckedChange = null,
+                colors = brassColors,
+            )
+        }
+    }
+}
+
 @Composable
 private fun DebugSection(
     title: String,
@@ -585,9 +656,11 @@ private fun PreviewDebugScreenIdle() = LibraryNocturneTheme(darkTheme = true) {
             snapshotAtMs = System.currentTimeMillis(),
         ),
         overlayEnabled = false,
+        debugLoggingEnabled = false,
         copyFlashAt = 0L,
         onBack = {},
         onToggleOverlay = {},
+        onToggleDebugLogging = {},
         onCopy = {},
     )
 }
@@ -630,9 +703,11 @@ private fun PreviewDebugScreenPlaying() = LibraryNocturneTheme(darkTheme = true)
             snapshotAtMs = System.currentTimeMillis(),
         ),
         overlayEnabled = true,
+        debugLoggingEnabled = true,
         copyFlashAt = 0L,
         onBack = {},
         onToggleOverlay = {},
+        onToggleDebugLogging = {},
         onCopy = {},
     )
 }

--- a/feature/src/main/kotlin/in/jphe/storyvox/feature/debug/DebugViewModel.kt
+++ b/feature/src/main/kotlin/in/jphe/storyvox/feature/debug/DebugViewModel.kt
@@ -52,6 +52,21 @@ class DebugViewModel @Inject constructor(
         settings.setShowDebugOverlay(enabled)
     }
 
+    /**
+     * Issue #823 — verbose-logging master switch. Reads from the
+     * settings flow; [StoryvoxApp][in.jphe.storyvox.StoryvoxApp]
+     * propagates the same value into
+     * [DebugLog][in.jphe.storyvox.data.log.DebugLog] on every change.
+     */
+    val debugLoggingEnabled: StateFlow<Boolean> = settings.settings
+        .map { it.debugLogging }
+        .stateIn(viewModelScope, SharingStarted.WhileSubscribed(5_000), false)
+
+    /** Writes through to DataStore. */
+    fun setDebugLoggingEnabled(enabled: Boolean) = viewModelScope.launch {
+        settings.setDebugLogging(enabled)
+    }
+
     /** Suspending one-shot capture for clipboard export — invoked by the
      *  Debug screen's "Copy snapshot" button. The screen wraps this in
      *  a coroutine so the suspend is invisible. */


### PR DESCRIPTION
## Summary
- New `DebugLog` object in core-data with `AtomicBoolean`-gated inline `i()`/`d()` lambdas (zero cost when disabled)
- Toggle in Debug screen (Settings → Developer → Debug) with brass-switch pattern
- Persisted via `SettingsRepositoryUiImpl` (per-device, NOT synced)
- `StoryvoxApp.onCreate` collects flag and writes to `DebugLog.setEnabled()`
- Representative breadcrumbs at key entry points: PlaybackController, EnginePlayer, ChapterDownloadScheduler, ChapterDownloadWorker

Closes #823

## Test plan
- [ ] Settings → Developer → Debug → verify "Verbose logging" toggle appears
- [ ] Enable toggle → play a chapter → check logcat for `[storyvox]` tagged entries
- [ ] Disable toggle → verify no debug log output
- [ ] Kill + relaunch → verify toggle state persists

🤖 Generated with [Claude Code](https://claude.com/claude-code)