### PR TITLE
fix(sync): retry transient sync failures with bounded backoff

### DIFF
--- a/core-sync/src/main/kotlin/in/jphe/storyvox/sync/coordinator/SyncCoordinator.kt
+++ b/core-sync/src/main/kotlin/in/jphe/storyvox/sync/coordinator/SyncCoordinator.kt
@@ -9,6 +9,7 @@ import javax.inject.Singleton
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
@@ -135,27 +136,48 @@ class SyncCoordinator @Inject constructor(
         }
     }
 
-    /** Wrapper that publishes status transitions for the UI. */
+    /**
+     * Wrapper that publishes status transitions for the UI.
+     *
+     * Issue #779 — `SyncOutcome.Transient` documents that the coordinator
+     * retries on transient failures (see [SyncOutcome.Transient] kdoc and
+     * [Syncer.push] kdoc that promises idempotency under coordinator
+     * retry). Before this change the block was called exactly once and a
+     * Transient outcome was published verbatim, so a cold-start `pullAll`
+     * on a flaky network left every domain stuck until the user manually
+     * hit "Sync now."
+     *
+     * Retry policy: bounded in-coroutine retry with exponential backoff
+     * — up to [RETRY_BACKOFFS_MS]`.size + 1` attempts (1 initial + N
+     * retries), with the per-attempt sleep coming from
+     * [RETRY_BACKOFFS_MS]. We only retry on `Transient` (or thrown
+     * exception, which we map to `Transient`); `Permanent` and `Ok`
+     * short-circuit immediately. The whole loop runs inside the
+     * per-domain mutex (same as before), so per-domain serialisation is
+     * preserved — concurrent local writes on the same domain queue
+     * behind the retry, which is exactly the idempotency contract the
+     * syncer kdoc already requires.
+     *
+     * This handles the "device woke up on a flaky connection" case; the
+     * "device was offline for an hour" case is left for a future
+     * WorkManager-backed scheduler (option 2 in #779).
+     */
     private suspend fun runWithStatus(syncer: Syncer, block: suspend (Syncer) -> SyncOutcome) {
         publish(syncer.name, SyncStatus.Running)
         val t0 = System.currentTimeMillis()
-        val outcome = runCatching { block(syncer) }
-            .getOrElse { e ->
-                android.util.Log.e(TAG, "runWithStatus: ${syncer.name} threw", e)
-                SyncOutcome.Transient(e.message ?: e::class.simpleName ?: "error")
-            }
+        val result = runWithRetry(syncer.name, RETRY_BACKOFFS_MS) { block(syncer) }
         val elapsed = System.currentTimeMillis() - t0
-        val status = when (outcome) {
+        val status = when (val outcome = result.outcome) {
             is SyncOutcome.Ok -> {
-                android.util.Log.i(TAG, "${syncer.name}: OK (${outcome.recordsAffected} records, ${elapsed}ms)")
+                android.util.Log.i(TAG, "${syncer.name}: OK (${outcome.recordsAffected} records, ${elapsed}ms, attempts=${result.attempts})")
                 SyncStatus.OkAt(System.currentTimeMillis(), outcome.recordsAffected)
             }
             is SyncOutcome.Transient -> {
-                android.util.Log.w(TAG, "${syncer.name}: TRANSIENT — ${outcome.message} (${elapsed}ms)")
+                android.util.Log.w(TAG, "${syncer.name}: TRANSIENT — ${outcome.message} (${elapsed}ms, attempts=${result.attempts})")
                 SyncStatus.Transient(outcome.message)
             }
             is SyncOutcome.Permanent -> {
-                android.util.Log.e(TAG, "${syncer.name}: PERMANENT — ${outcome.message} (${elapsed}ms)")
+                android.util.Log.e(TAG, "${syncer.name}: PERMANENT — ${outcome.message} (${elapsed}ms, attempts=${result.attempts})")
                 SyncStatus.Permanent(outcome.message)
             }
         }
@@ -165,6 +187,14 @@ class SyncCoordinator @Inject constructor(
     private companion object {
         private const val TAG = "SyncCoordinator"
         private val FK_ROOT_DOMAINS = setOf("library", "follows")
+
+        /**
+         * Retry backoff schedule (ms) for [SyncOutcome.Transient] failures.
+         * Length = max retries. Total worst-case wall time = sum of entries
+         * (~13s) plus per-attempt work. Picked to ride out a typical DNS
+         * blip / TLS handshake retry without making cold-start feel hung.
+         */
+        private val RETRY_BACKOFFS_MS = longArrayOf(1_000L, 3_000L, 9_000L)
     }
 
     private fun publish(domain: String, status: SyncStatus) {
@@ -183,3 +213,50 @@ sealed interface SyncStatus {
     data class Transient(val message: String) : SyncStatus
     data class Permanent(val message: String) : SyncStatus
 }
+
+/** Return value of [runWithRetry]: the final [SyncOutcome] plus how many
+ *  total attempts (1 initial + N retries) were actually executed. */
+internal data class RetryResult(val outcome: SyncOutcome, val attempts: Int)
+
+/**
+ * Bounded-retry wrapper for a single syncer call. Issue #779.
+ *
+ * - One initial attempt, then up to `backoffsMs.size` retries.
+ * - Retries fire only on [SyncOutcome.Transient] or thrown exceptions
+ *   (mapped to Transient with the exception message).
+ * - [SyncOutcome.Ok] and [SyncOutcome.Permanent] short-circuit the loop.
+ * - Between attempts, `delay(backoffsMs[i])` is called — under
+ *   `kotlinx.coroutines.test.runTest` virtual time this auto-advances,
+ *   so tests don't wait real seconds.
+ *
+ * Top-level + `internal` rather than a method on [SyncCoordinator] so the
+ * loop is unit-testable without needing to stand up the coordinator's
+ * Hilt-injected deps (InstantClient, InstantSession, SharedPreferences).
+ * The [name] parameter is just for log breadcrumbs.
+ */
+internal suspend fun runWithRetry(
+    name: String,
+    backoffsMs: LongArray,
+    block: suspend () -> SyncOutcome,
+): RetryResult {
+    var outcome: SyncOutcome = runAttempt(name, block)
+    var attempts = 1
+    while (outcome is SyncOutcome.Transient && attempts <= backoffsMs.size) {
+        val backoff = backoffsMs[attempts - 1]
+        android.util.Log.w(
+            "SyncCoordinator",
+            "$name: transient (\"${outcome.message}\"), retry $attempts/${backoffsMs.size} in ${backoff}ms",
+        )
+        delay(backoff)
+        outcome = runAttempt(name, block)
+        attempts++
+    }
+    return RetryResult(outcome, attempts)
+}
+
+private suspend fun runAttempt(name: String, block: suspend () -> SyncOutcome): SyncOutcome =
+    runCatching { block() }
+        .getOrElse { e ->
+            android.util.Log.e("SyncCoordinator", "runAttempt: $name threw", e)
+            SyncOutcome.Transient(e.message ?: e::class.simpleName ?: "error")
+        }

--- a/core-sync/src/test/kotlin/in/jphe/storyvox/sync/SyncCoordinatorRetryTest.kt
+++ b/core-sync/src/test/kotlin/in/jphe/storyvox/sync/SyncCoordinatorRetryTest.kt
@@ -1,0 +1,138 @@
+package `in`.jphe.storyvox.sync
+
+import `in`.jphe.storyvox.sync.coordinator.SyncOutcome
+import `in`.jphe.storyvox.sync.coordinator.runWithRetry
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * Issue #779 — `SyncOutcome.Transient` documents retry, but the
+ * coordinator previously ran each syncer call exactly once. These tests
+ * lock in the retry-with-bounded-backoff behaviour added to
+ * `SyncCoordinator.runWithRetry`:
+ *
+ *  - `Ok` on first try → no retry.
+ *  - `Permanent` on first try → no retry (per kdoc).
+ *  - `Transient` → retried up to `backoffs.size` times, then surfaced.
+ *  - `Transient` → `Ok` on a later attempt → final outcome is `Ok`.
+ *  - Thrown exception → mapped to `Transient` and also retried.
+ *
+ * `runTest` gives us virtual time so the 1s/3s/9s prod delays cost zero
+ * wall-clock seconds in the test JVM.
+ */
+class SyncCoordinatorRetryTest {
+
+    private val BACKOFFS = longArrayOf(1_000L, 3_000L, 9_000L)
+
+    @Test
+    fun `Ok on first attempt — no retry`() = runTest {
+        var calls = 0
+        val result = runWithRetry("library", BACKOFFS) {
+            calls++
+            SyncOutcome.Ok(recordsAffected = 7)
+        }
+        assertEquals(1, calls)
+        assertEquals(1, result.attempts)
+        val outcome = result.outcome
+        assertTrue(outcome is SyncOutcome.Ok)
+        assertEquals(7, (outcome as SyncOutcome.Ok).recordsAffected)
+    }
+
+    @Test
+    fun `Permanent on first attempt — no retry`() = runTest {
+        var calls = 0
+        val result = runWithRetry("library", BACKOFFS) {
+            calls++
+            SyncOutcome.Permanent("bad credentials")
+        }
+        assertEquals(1, calls)
+        assertEquals(1, result.attempts)
+        val outcome = result.outcome
+        assertTrue(outcome is SyncOutcome.Permanent)
+        assertEquals("bad credentials", (outcome as SyncOutcome.Permanent).message)
+    }
+
+    @Test
+    fun `Transient every time — retries up to bound then surfaces Transient`() = runTest {
+        var calls = 0
+        val result = runWithRetry("library", BACKOFFS) {
+            calls++
+            SyncOutcome.Transient("dns timeout")
+        }
+        // 1 initial + 3 retries = 4 total attempts.
+        assertEquals(4, calls)
+        assertEquals(4, result.attempts)
+        val outcome = result.outcome
+        assertTrue(outcome is SyncOutcome.Transient)
+        assertEquals("dns timeout", (outcome as SyncOutcome.Transient).message)
+    }
+
+    @Test
+    fun `Transient then Ok — stops retrying, returns Ok`() = runTest {
+        var calls = 0
+        val result = runWithRetry("library", BACKOFFS) {
+            calls++
+            if (calls < 3) SyncOutcome.Transient("flaky") else SyncOutcome.Ok(2)
+        }
+        assertEquals(3, calls)
+        assertEquals(3, result.attempts)
+        val outcome = result.outcome
+        assertTrue(outcome is SyncOutcome.Ok)
+        assertEquals(2, (outcome as SyncOutcome.Ok).recordsAffected)
+    }
+
+    @Test
+    fun `Transient then Permanent — stops retrying, returns Permanent`() = runTest {
+        var calls = 0
+        val result = runWithRetry("library", BACKOFFS) {
+            calls++
+            if (calls == 1) SyncOutcome.Transient("blip") else SyncOutcome.Permanent("schema mismatch")
+        }
+        // First attempt Transient → retry. Second attempt Permanent → stop.
+        assertEquals(2, calls)
+        assertEquals(2, result.attempts)
+        val outcome = result.outcome
+        assertTrue(outcome is SyncOutcome.Permanent)
+        assertEquals("schema mismatch", (outcome as SyncOutcome.Permanent).message)
+    }
+
+    @Test
+    fun `Thrown exception is mapped to Transient and retried`() = runTest {
+        var calls = 0
+        val result = runWithRetry("library", BACKOFFS) {
+            calls++
+            if (calls < 2) throw java.io.IOException("connection reset")
+            SyncOutcome.Ok(0)
+        }
+        assertEquals(2, calls)
+        assertEquals(2, result.attempts)
+        assertTrue(result.outcome is SyncOutcome.Ok)
+    }
+
+    @Test
+    fun `Thrown exception every time — surfaces Transient with exception message`() = runTest {
+        var calls = 0
+        val result = runWithRetry("library", BACKOFFS) {
+            calls++
+            throw java.io.IOException("offline")
+        }
+        assertEquals(4, calls)
+        val outcome = result.outcome
+        assertTrue(outcome is SyncOutcome.Transient)
+        assertEquals("offline", (outcome as SyncOutcome.Transient).message)
+    }
+
+    @Test
+    fun `Empty backoff array — no retries even on Transient`() = runTest {
+        var calls = 0
+        val result = runWithRetry("library", longArrayOf()) {
+            calls++
+            SyncOutcome.Transient("never gets a second chance")
+        }
+        assertEquals(1, calls)
+        assertEquals(1, result.attempts)
+        assertTrue(result.outcome is SyncOutcome.Transient)
+    }
+}


### PR DESCRIPTION
## Summary
- `SyncOutcome.Transient` now actually retried (was documented but never implemented)
- Bounded: 1 initial + 3 retries with [1s, 3s, 9s] backoff (~13s worst-case)
- `Permanent` and `Ok` short-circuit; thrown exceptions mapped to `Transient`
- Extracted `runWithRetry` for testability; 8 JVM tests covering all branches

Closes #779

## Test plan
- [ ] `./gradlew :core-sync:testDebugUnitTest` — all 13 test classes green
- [ ] Simulate flaky network during sync → verify retry before failure

🤖 Generated with [Claude Code](https://claude.com/claude-code)