### PR TITLE
chore(release): docs sync for v0.5.98 [skip ci]

### DIFF
--- a/docs/_layouts/default.html
+++ b/docs/_layouts/default.html
@@ -21,7 +21,7 @@
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
   <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=EB+Garamond:ital,wght@0,400;0,500;0,600;1,400&family=Inter:wght@400;500;600;700&display=swap" />
   <link rel="stylesheet" href="{{ '/assets/css/style.css' | relative_url }}" />
-  <meta name="realm-version" content='{"name": "storyvox", "description": "Neural-voice audiobook player for any text you have \u2014 offline TTS, optional Azure HD cloud voices, Library Nocturne aesthetic", "version": "Runic Throne \u00b7 f824efe", "hash": "f824efe", "branch": "main", "dirty": false, "built": "2026-05-22T22:37:13Z", "realm": "fantasy", "repo": "https://github.com/techempower-org/storyvox", "commit_url": "https://github.com/techempower-org/storyvox/commit/f824efe"}'>
+  <meta name="realm-version" content='{"name": "storyvox", "description": "Neural-voice audiobook player for any text you have \u2014 offline TTS, optional Azure HD cloud voices, Library Nocturne aesthetic", "version": "Radiant Aegis \u00b7 61549a71", "hash": "61549a71", "branch": "main", "dirty": false, "built": "2026-05-26T03:49:38Z", "realm": "fantasy", "repo": "https://github.com/techempower-org/storyvox", "commit_url": "https://github.com/techempower-org/storyvox/commit/61549a71"}'>
 </head>
 <body>
   <header class="site-header">

--- a/docs/index.md
+++ b/docs/index.md
@@ -401,7 +401,7 @@ image: /screenshots/03-reader.png
     (#462), Palace Project (#502), Slack (#454), Matrix (#457); home-screen widget with
     Continue Listening + Play/Pause; <strong>beautiful Notion covers</strong> with body-image
     fallback and brass-edged synthetic tiles; AO3 auth PR1 landed.
-    <a href="https://github.com/techempower-org/storyvox/releases/tag/v0.5.75">Full release notes →</a>
+    <a href="https://github.com/techempower-org/storyvox/releases/tag/v0.5.98">Full release notes →</a>
   </p>
   <p>
     <strong>Earlier in v0.5:</strong> <strong>twenty-one fiction backends</strong> behind a

--- a/docs/version.json
+++ b/docs/version.json
@@ -1,12 +1,12 @@
 {
   "name": "storyvox",
   "description": "Neural-voice audiobook player for any text you have \u2014 offline TTS, optional Azure HD cloud voices, Library Nocturne aesthetic",
-  "version": "Runic Throne \u00b7 f824efe",
-  "hash": "f824efe",
+  "version": "Radiant Aegis \u00b7 61549a71",
+  "hash": "61549a71",
   "branch": "main",
   "dirty": false,
-  "built": "2026-05-22T22:37:13Z",
+  "built": "2026-05-26T03:49:38Z",
   "realm": "fantasy",
   "repo": "https://github.com/techempower-org/storyvox",
-  "commit_url": "https://github.com/techempower-org/storyvox/commit/f824efe"
+  "commit_url": "https://github.com/techempower-org/storyvox/commit/61549a71"
 }


### PR DESCRIPTION
Auto-generated docs sync for v0.5.98. Label missing caused CI failure — created ci label and re-ran manually.