### PR TITLE
fix: wave 3 — 6 MEDIUM priority bug fixes (#874 #876 #878 #888 #905 #902)

### DIFF
--- a/core-playback/src/main/kotlin/in/jphe/storyvox/playback/tts/EnginePlayer.kt
+++ b/core-playback/src/main/kotlin/in/jphe/storyvox/playback/tts/EnginePlayer.kt
@@ -4520,13 +4520,24 @@ class EnginePlayer @AssistedInject constructor(
     fun bufferTelemetry(): `in`.jphe.storyvox.playback.BufferTelemetry {
         val src = pcmSource
         val track = audioTrack
-        val audioBufferMs = if (track != null && track.sampleRate > 0) {
-            val head = track.playbackHeadPosition.toLong() and 0xFFFFFFFFL
-            val pendingFrames = (totalFramesWritten - head).coerceAtLeast(0)
-            pendingFrames * 1000L / track.sampleRate
-        } else {
-            0L
-        }
+        // Issue #874 — this runs off the Main thread (Debug overlay's 1Hz
+        // poll) while [stopPlaybackPipeline] can null+release the track on
+        // Main. Both `playbackHeadPosition` and `sampleRate` are JNI reads
+        // against the native handle: a concurrent release makes
+        // `playbackHeadPosition` throw IllegalStateException and leaves
+        // `sampleRate` undefined. Prefer the [pipelineSampleRate] volatile
+        // (never changes for a track's lifetime, the #539 fix) and wrap the
+        // head read in runCatching so a teardown race degrades to 0 rather
+        // than crashing the overlay.
+        val audioBufferMs = track?.let {
+            runCatching {
+                val sr = pipelineSampleRate.takeIf { rate -> rate > 0 }
+                    ?: return@runCatching 0L
+                val head = it.playbackHeadPosition.toLong() and 0xFFFFFFFFL
+                val pendingFrames = (totalFramesWritten - head).coerceAtLeast(0)
+                pendingFrames * 1000L / sr
+            }.getOrDefault(0L)
+        } ?: 0L
         return `in`.jphe.storyvox.playback.BufferTelemetry(
             producerQueueDepth = src?.producerQueueDepth() ?: 0,
             producerQueueCapacity = src?.producerQueueCapacity() ?: 0,

--- a/core-playback/src/main/kotlin/in/jphe/storyvox/playback/tts/EnginePlayer.kt
+++ b/core-playback/src/main/kotlin/in/jphe/storyvox/playback/tts/EnginePlayer.kt
@@ -3035,13 +3035,18 @@ class EnginePlayer @AssistedInject constructor(
     /**
      * #676 — handle for System TTS voices. Mirrors [azureStreamingHandle]
      * in that it adapts an instance-based engine ([SystemTtsEngine]) to
-     * the [EngineStreamingSource.VoiceEngineHandle] contract. The
-     * underlying [SystemTtsEngine.generateAudioPCM] is suspending
-     * (block-awaits the framework's UtteranceProgressListener) so we
-     * wrap with [kotlinx.coroutines.runBlocking] on the producer worker
-     * thread — same shape Piper/Kokoro use for their synchronous JNI
-     * calls. Returns null when the engine isn't loaded yet (the
-     * pipeline's skip-empty-PCM branch handles this).
+     * the [EngineStreamingSource.VoiceEngineHandle] contract.
+     *
+     * #876 — synth runs through [SystemTtsEngine.generateAudioPCMBlocking],
+     * which does `synthesizeToFile` + the completion await synchronously
+     * on **this** producer worker thread. The previous `runBlocking { … }`
+     * wrapper dispatched the suspend body onto a `Dispatchers.IO` pool
+     * thread at DEFAULT priority, so the URGENT_AUDIO priority set just
+     * below leaked nowhere useful and the producer parked idle. The
+     * blocking variant keeps the synth on the URGENT_AUDIO thread —
+     * same shape Piper/Kokoro use for their synchronous JNI calls.
+     * Returns null when the engine isn't loaded yet (the pipeline's
+     * skip-empty-PCM branch handles this).
      */
     private fun systemTtsHandle(
         engineType: EngineType.SystemTts,
@@ -3055,7 +3060,7 @@ class EnginePlayer @AssistedInject constructor(
             ): ByteArray? {
                 AndroidProcess.setThreadPriority(AndroidProcess.THREAD_PRIORITY_URGENT_AUDIO)
                 val engine = systemTtsEngine ?: return null
-                return runBlocking { engine.generateAudioPCM(text, speed, pitch) }
+                return engine.generateAudioPCMBlocking(text, speed, pitch)
             }
         }
 

--- a/core-playback/src/main/kotlin/in/jphe/storyvox/playback/tts/EnginePlayer.kt
+++ b/core-playback/src/main/kotlin/in/jphe/storyvox/playback/tts/EnginePlayer.kt
@@ -3512,6 +3512,13 @@ class EnginePlayer @AssistedInject constructor(
         // gets cleared anyway. Worst case is a redundant track.play()
         // JNI call (~µs); best case (the observed bug) we skip a full
         // AudioTrack rebuild + sherpa-onnx warm-up.
+        // #888 — re-acquire audio focus before the fast path's
+        // audioTrack.play(). If another app grabbed focus while we were
+        // paused, the fast path would unpause a track that's been
+        // ducked/silenced, yielding "PLAYING + no audio". Idempotent: a
+        // no-op if we still hold focus. The slow path acquires its own
+        // focus inside startPlaybackPipeline(), so only the fast path needs this.
+        runCatching { audioFocus.acquire() }
         if (rHaveTrack && rRunning) {
             _observableState.update { it.copy(isPlaying = true, error = null) }
             userPaused.set(false)

--- a/core-playback/src/main/kotlin/in/jphe/storyvox/playback/tts/EnginePlayer.kt
+++ b/core-playback/src/main/kotlin/in/jphe/storyvox/playback/tts/EnginePlayer.kt
@@ -713,7 +713,14 @@ class EnginePlayer @AssistedInject constructor(
                 val s = _observableState.value
                 val fictionId = s.currentFictionId
                 val chapterId = s.currentChapterId
-                if (fictionId == null || chapterId == null) return@collect
+                if (fictionId == null || chapterId == null) {
+                    DebugLog.d("EnginePlayer") {
+                        "observeActiveVoice: voice=$newId but no chapter loaded " +
+                            "(fiction=$fictionId chapter=$chapterId) — swap deferred " +
+                            "to next loadAndPlay, which reads activeVoice itself"
+                    }
+                    return@collect
+                }
                 if (s.isPlaying) {
                     // Live swap. Tear down the current pipeline FIRST so the
                     // old generator can't keep pushing old-voice PCM into
@@ -722,7 +729,27 @@ class EnginePlayer @AssistedInject constructor(
                     // the user hears 5–10 s of stale audio before silence
                     // and finally the new voice.
                     stopPlaybackPipeline()
-                    loadAndPlay(fictionId, chapterId, s.charOffset)
+                    // loadAndPlay can throw (network fetch, OOM on Kokoro model
+                    // load). An uncaught throw here cancels this collect on the
+                    // scope, after which voice swaps are silently ignored until
+                    // the player is recreated. runCatching keeps the collector
+                    // alive so the *next* swap still gets a chance. (#878)
+                    runCatching {
+                        loadAndPlay(fictionId, chapterId, s.charOffset)
+                    }.onFailure { t ->
+                        // Never swallow cancellation — that would let the
+                        // collector keep running after the scope is torn down,
+                        // breaking structured concurrency. Only transient
+                        // load failures should be logged-and-survived.
+                        if (t is kotlin.coroutines.cancellation.CancellationException) throw t
+                        android.util.Log.e(
+                            "EnginePlayer",
+                            "observeActiveVoice: live voice swap to $newId failed " +
+                                "(fiction=$fictionId chapter=$chapterId); collector " +
+                                "kept alive for next swap",
+                            t,
+                        )
+                    }
                 } else {
                     voiceReloadPending = true
                     stopPlaybackPipeline()

--- a/core-playback/src/main/kotlin/in/jphe/storyvox/playback/tts/EnginePlayer.kt
+++ b/core-playback/src/main/kotlin/in/jphe/storyvox/playback/tts/EnginePlayer.kt
@@ -4666,6 +4666,23 @@ class EnginePlayer @AssistedInject constructor(
      *    advance, no position persistence.
      */
     private fun startRecapPipeline(recapSentences: List<Sentence>) {
+        // Issue #905 — claim audio focus BEFORE creating the recap
+        // AudioTrack, mirroring [startPlaybackPipeline]'s #560 fix. The
+        // main pipeline holds focus on a Play, but a cold-start recap
+        // (reader opened, Play never tapped, user taps "Read recap
+        // aloud") has no prior focus — without this the framework can
+        // silently refuse to drain the track and the recap is swallowed.
+        // Idempotent on the singleton focus request, so a recap fired
+        // while the chapter is already playing reuses the held focus.
+        val focusGranted = runCatching { audioFocus.acquire() }.getOrDefault(false)
+        if (!focusGranted) {
+            android.util.Log.w(
+                "EnginePlayer",
+                "#905 startRecapPipeline: audio focus was NOT granted; recap will be silent " +
+                    "until another app yields focus",
+            )
+        }
+
         val engineType = activeEngineType
         // Issue #582 — startRecapPipeline is reachable from main-thread
         // Compose handlers (the "play recap" button in the reader). Use
@@ -4705,7 +4722,14 @@ class EnginePlayer @AssistedInject constructor(
 
         recapConsumerThread = Thread({
             AndroidProcess.setThreadPriority(AndroidProcess.THREAD_PRIORITY_URGENT_AUDIO)
-            var firstSentence = true
+            // Issue #905 — live volume mirror, mirroring the main consumer's
+            // change-detection. Pre-fix the recap consumer hardcoded
+            // setVolume(1f) on the first sentence, ignoring the sleep
+            // timer's volumeRamp: a recap fired while the timer was fading
+            // played at full volume — louder than the chapter audio the
+            // listener was last hearing. Now we read volumeRamp.current per
+            // write and skip the JNI setVolume when the ramp is idle.
+            var lastVol = -1f
             try {
                 runCatching { track.play() }
                 while (recapPipelineRunning.get()) {
@@ -4715,19 +4739,24 @@ class EnginePlayer @AssistedInject constructor(
                         null
                     } ?: break
 
-                    if (firstSentence) {
-                        runCatching { track.setVolume(1f) }
-                        firstSentence = false
-                    }
-
                     var written = 0
                     while (written < chunk.pcm.size && recapPipelineRunning.get()) {
+                        val v = volumeRamp.current
+                        if (v != lastVol) {
+                            runCatching { track.setVolume(v) }
+                            lastVol = v
+                        }
                         val n = track.write(chunk.pcm, written, chunk.pcm.size - written)
                         if (n < 0) break
                         written += n
                     }
                     var remaining = chunk.trailingSilenceBytes
                     while (remaining > 0 && recapPipelineRunning.get()) {
+                        val v = volumeRamp.current
+                        if (v != lastVol) {
+                            runCatching { track.setVolume(v) }
+                            lastVol = v
+                        }
                         val sz = remaining.coerceAtMost(SILENCE_CHUNK.size)
                         val n = track.write(SILENCE_CHUNK, 0, sz)
                         if (n < 0) break

--- a/core-playback/src/main/kotlin/in/jphe/storyvox/playback/tts/SystemTtsEngine.kt
+++ b/core-playback/src/main/kotlin/in/jphe/storyvox/playback/tts/SystemTtsEngine.kt
@@ -289,17 +289,24 @@ class SystemTtsEngine(
         // earlier scattered per-branch deletes missed the truncated-output
         // early returns and leaked header-only WAVs into cacheDir.
         try {
-            // #716 — bound the await so an engine that swallows the
+            // #716/#902 — bound the await so an engine that swallows the
             // utterance (no onDone, no onError — observed on stock Samsung
             // TTS firmware after a mid-synth engine-package crash) can't
-            // park this thread forever. A healthy sentence synthesizes
-            // in <500 ms even on slow phones; SYNTH_TIMEOUT_MS (10 s) is
-            // well outside the healthy band and matches the buffering
-            // watchdog window in PlaybackController so upstream's
-            // AudioOutputStuck recovery kicks in at the same horizon.
+            // park this thread forever. SYNTH_TIMEOUT_MS (30 s) is sized
+            // for the slowest devices we support — Samsung TTS on Helio P22T
+            // tablets takes 8-15 s for ~500-char sentences — so a real
+            // sentence never trips it; only a genuinely stuck engine does.
+            // See the constant's kdoc for why this is decoupled from the
+            // 12 s buffering watchdog in PlaybackController.
+            val synthStart = System.currentTimeMillis()
             val ok = gate.awaitBlocking(SYNTH_TIMEOUT_MS)
             if (ok == null) {
-                Log.w(TAG, "synth timed out after ${SYNTH_TIMEOUT_MS}ms text.len=${text.length}")
+                val elapsed = System.currentTimeMillis() - synthStart
+                Log.w(
+                    TAG,
+                    "synth timed out after ${elapsed}ms (limit ${SYNTH_TIMEOUT_MS}ms) " +
+                        "text.len=${text.length} — sentence skipped",
+                )
                 return null
             }
             if (!ok) {
@@ -424,14 +431,31 @@ class SystemTtsEngine(
         /**
          * Upper bound on how long we'll wait for the
          * `UtteranceProgressListener` to fire `onDone`/`onError` for a
-         * single sentence (#716). A healthy sentence synthesizes in
-         * <500 ms even on slow phones; 10 s matches the buffering
-         * watchdog horizon in `PlaybackController`
-         * (BUFFERING_STUCK_WATCHDOG_END_OF_CHAPTER_MS = 12 s), so a
-         * timeout here lands fractionally before upstream's
-         * AudioOutputStuck recovery — exactly the sequence we want.
+         * single sentence (#716, #902).
+         *
+         * Originally 10 s, chosen to land just before the
+         * `BUFFERING_STUCK_WATCHDOG_END_OF_CHAPTER_MS` (12 s) horizon in
+         * `PlaybackController`. That coupling turned out to be wrong: on
+         * low-spec hardware, System TTS legitimately takes far longer than
+         * the "healthy <500 ms" assumption. Samsung TTS on Helio P22T
+         * tablets needs 8-15 s to synthesize a ~500-char sentence, so a
+         * 10 s cap fired on *real* sentences — the engine then returned
+         * null and the sentence was silently skipped (audible gap +
+         * highlight jump), the exact symptom in #902.
+         *
+         * Now 30 s — matching the chapter-body-wait timeout used elsewhere
+         * — and deliberately *decoupled* from the 12 s buffering watchdog.
+         * This is a hung-engine backstop, not a pacing knob: it should only
+         * fire when an engine has genuinely swallowed the utterance, never
+         * on a slow-but-progressing synth. The buffering watchdog upstream
+         * handles the audio-stall UX on its own shorter horizon; letting
+         * synth run past it is fine because a 12 s stall on a 15 s sentence
+         * is buffering-bound, not a dead engine, and recovering by skipping
+         * the sentence (the old behavior) is worse than waiting it out.
+         * When this 30 s limit *does* trip, the call site logs length +
+         * elapsed time so the skip is visible rather than silent.
          */
-        const val SYNTH_TIMEOUT_MS: Long = 10_000
+        const val SYNTH_TIMEOUT_MS: Long = 30_000
 
         /** Android TTS documented setSpeechRate bounds. */
         private const val MIN_RATE: Float = 0.1f

--- a/core-playback/src/main/kotlin/in/jphe/storyvox/playback/tts/SystemTtsEngine.kt
+++ b/core-playback/src/main/kotlin/in/jphe/storyvox/playback/tts/SystemTtsEngine.kt
@@ -7,12 +7,14 @@ import android.util.Log
 import java.io.File
 import java.util.UUID
 import java.util.concurrent.ConcurrentHashMap
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.TimeUnit
 import kotlin.math.max
 import kotlin.math.min
 import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.runInterruptible
 import kotlinx.coroutines.withContext
-import kotlinx.coroutines.withTimeoutOrNull
 
 /**
  * Issue #676 — adapter from Android's framework `TextToSpeech` to the
@@ -77,8 +79,13 @@ class SystemTtsEngine(
     @Volatile private var cachedSampleRate: Int = 0
 
     /** Per-utterance completion routing — UtteranceProgressListener
-     *  fires once per synthesizeToFile() and we route by utteranceId. */
-    private val pending = ConcurrentHashMap<String, CompletableDeferred<Boolean>>()
+     *  fires once per synthesizeToFile() and we route by utteranceId.
+     *  The gate's [CompletionGate.awaitBlocking] parks the calling thread —
+     *  #876 routes System TTS synth on the URGENT_AUDIO producer thread via
+     *  the blocking path, while the suspend [generateAudioPCM] reaches the
+     *  same await through `runInterruptible` so coroutine callers keep the
+     *  suspend contract. */
+    private val pending = ConcurrentHashMap<String, CompletionGate>()
 
     private val progressListener = object : UtteranceProgressListener() {
         override fun onStart(utteranceId: String?) { /* not used */ }
@@ -181,15 +188,63 @@ class SystemTtsEngine(
      *  - synthesizeToFile returning an error code.
      *  - UtteranceProgressListener firing onError.
      *  - Output file truncated below the WAV header length.
+     *
+     * Suspend variant for coroutine callers — dispatches to
+     * [Dispatchers.IO] so it never blocks the caller's thread. The
+     * EnginePlayer producer path uses [generateAudioPCMBlocking] instead
+     * (#876); this entry point remains for non-producer callers that
+     * want the suspend contract.
      */
     suspend fun generateAudioPCM(
         text: String,
         speed: Float,
         pitch: Float,
     ): ByteArray? = withContext(Dispatchers.IO) {
-        if (text.isBlank()) return@withContext null
-        val instance = tts ?: return@withContext null
-        if (!ready) return@withContext null
+        // runInterruptible so coroutine cancellation interrupts the
+        // gate's blocking await rather than orphaning the synth.
+        runInterruptible { synthesizeBlocking(text, speed, pitch) }
+    }
+
+    /**
+     * #876 — synchronous synth on the **calling thread**, with no
+     * dispatcher hop.
+     *
+     * The EnginePlayer producer worker is pinned at
+     * `THREAD_PRIORITY_URGENT_AUDIO`; the previous `runBlocking { … }`
+     * wrapper around the suspend [generateAudioPCM] dispatched the synth
+     * onto a `Dispatchers.IO` pool thread running at DEFAULT priority,
+     * so System TTS was the only engine whose synth missed URGENT_AUDIO
+     * scheduling (and the producer thread parked uselessly). This variant
+     * runs `synthesizeToFile` + the completion await directly on the
+     * URGENT_AUDIO producer thread.
+     *
+     * Same null-return contract as [generateAudioPCM]. The completion
+     * await is bounded by [SYNTH_TIMEOUT_MS] via a [CountDownLatch] so a
+     * framework engine that swallows the utterance (no onDone/onError)
+     * can't park the producer thread forever.
+     */
+    fun generateAudioPCMBlocking(
+        text: String,
+        speed: Float,
+        pitch: Float,
+    ): ByteArray? = synthesizeBlocking(text, speed, pitch)
+
+    /**
+     * Shared synth core. Runs entirely on the calling thread (the
+     * framework's `synthesizeToFile` is itself async and posts back via
+     * the [progressListener], so this thread only blocks awaiting the
+     * [CompletionGate]). Callers that need an off-thread guarantee wrap
+     * this in their own dispatcher; the producer path (#876) calls it
+     * directly to inherit URGENT_AUDIO priority.
+     */
+    private fun synthesizeBlocking(
+        text: String,
+        speed: Float,
+        pitch: Float,
+    ): ByteArray? {
+        if (text.isBlank()) return null
+        val instance = tts ?: return null
+        if (!ready) return null
 
         // Clamp into Android TTS's documented range. The framework
         // clamps for us in newer versions, but older OEMs occasionally
@@ -202,8 +257,8 @@ class SystemTtsEngine(
         }
 
         val utteranceId = UUID.randomUUID().toString()
-        val deferred = CompletableDeferred<Boolean>()
-        pending[utteranceId] = deferred
+        val gate = CompletionGate()
+        pending[utteranceId] = gate
 
         val outFile = File(context.cacheDir, "$TEMP_WAV_PREFIX$utteranceId$TEMP_WAV_SUFFIX")
         // Defensive cleanup if a previous run with the same UUID
@@ -217,13 +272,13 @@ class SystemTtsEngine(
         }.getOrElse { t ->
             Log.w(TAG, "synthesizeToFile threw: ${t.message}")
             pending.remove(utteranceId)
-            return@withContext null
+            return null
         }
         if (rc != TextToSpeech.SUCCESS) {
             Log.w(TAG, "synthesizeToFile returned non-success rc=$rc text.len=${text.length}")
             pending.remove(utteranceId)
             runCatching { outFile.delete() }
-            return@withContext null
+            return null
         }
 
         // #903 — once synthesizeToFile has accepted the request, the temp
@@ -237,27 +292,27 @@ class SystemTtsEngine(
             // #716 — bound the await so an engine that swallows the
             // utterance (no onDone, no onError — observed on stock Samsung
             // TTS firmware after a mid-synth engine-package crash) can't
-            // park this coroutine forever. A healthy sentence synthesizes
+            // park this thread forever. A healthy sentence synthesizes
             // in <500 ms even on slow phones; SYNTH_TIMEOUT_MS (10 s) is
             // well outside the healthy band and matches the buffering
             // watchdog window in PlaybackController so upstream's
             // AudioOutputStuck recovery kicks in at the same horizon.
-            val ok = withTimeoutOrNull(SYNTH_TIMEOUT_MS) { deferred.await() }
+            val ok = gate.awaitBlocking(SYNTH_TIMEOUT_MS)
             if (ok == null) {
                 Log.w(TAG, "synth timed out after ${SYNTH_TIMEOUT_MS}ms text.len=${text.length}")
-                return@withContext null
+                return null
             }
             if (!ok) {
-                return@withContext null
+                return null
             }
             if (!outFile.exists() || outFile.length() <= WAV_HEADER_BYTES) {
                 Log.w(TAG, "synthesizeToFile produced no audio body file=${outFile.length()}b")
-                return@withContext null
+                return null
             }
             val bytes = outFile.readBytes()
             if (bytes.size <= WAV_HEADER_BYTES) {
                 Log.w(TAG, "synthesizeToFile output too short to contain audio (${bytes.size}b)")
-                return@withContext null
+                return null
             }
             // Cache the sample rate from the WAV header on first successful synth.
             if (cachedSampleRate == 0) {
@@ -269,7 +324,7 @@ class SystemTtsEngine(
             }
             // Strip the 44-byte header — the rest is signed 16-bit little-endian PCM,
             // matching the contract Piper/Kokoro/Kitten/Azure all return.
-            bytes.copyOfRange(WAV_HEADER_BYTES, bytes.size)
+            return bytes.copyOfRange(WAV_HEADER_BYTES, bytes.size)
         } finally {
             pending.remove(utteranceId)
             runCatching { outFile.delete() }
@@ -279,8 +334,8 @@ class SystemTtsEngine(
     /**
      * Tear down the underlying TextToSpeech. Safe to call multiple
      * times; further [generateAudioPCM] calls after shutdown return
-     * null. Any in-flight syntheses get their deferreds completed
-     * `false` so block-awaiting callers wake up promptly.
+     * null. Any in-flight syntheses get their gates completed `false`
+     * so block-awaiting callers wake up promptly.
      */
     fun shutdown() {
         ready = false
@@ -291,11 +346,46 @@ class SystemTtsEngine(
             runCatching { instance.shutdown() }
         }
         // Wake every block-awaiting caller so they don't hang on a
-        // deferred whose listener is now detached.
+        // gate whose listener is now detached.
         val drained = pending.keys.toList()
         for (id in drained) {
             pending.remove(id)?.complete(false)
         }
+    }
+
+    /**
+     * One-shot completion primitive routed by utteranceId. The
+     * [progressListener] fires [complete] exactly once (onDone → true,
+     * onError → false); [awaitBlocking] parks the calling thread on a
+     * [CountDownLatch] until then or the timeout elapses.
+     *
+     * Why a latch and not a `CompletableDeferred`: #876 needs the synth
+     * to run on the URGENT_AUDIO producer thread without a coroutine
+     * dispatcher hop, so the await must be a plain blocking call. A
+     * `CountDownLatch.await(timeout)` is interruptible, so coroutine
+     * callers reach it through [runInterruptible] and cancellation still
+     * propagates.
+     */
+    private class CompletionGate {
+        private val latch = CountDownLatch(1)
+        @Volatile private var result: Boolean = false
+
+        fun complete(value: Boolean) {
+            // CountDownLatch.countDown() past zero is a no-op, so a
+            // duplicate listener event (shouldn't happen — the map
+            // removes on first fire — but be defensive) is harmless.
+            result = value
+            latch.countDown()
+        }
+
+        /**
+         * Block the calling thread until [complete] fires or [timeoutMs]
+         * elapses. Returns the completion value, or null on timeout. A
+         * thread interrupt (coroutine cancellation via runInterruptible)
+         * surfaces as an [InterruptedException] to the caller.
+         */
+        fun awaitBlocking(timeoutMs: Long): Boolean? =
+            if (latch.await(timeoutMs, TimeUnit.MILLISECONDS)) result else null
     }
 
     companion object {


### PR DESCRIPTION
## Summary

Wave 3 of the overnight fix sweep — 6 medium-priority bugs, all in `core-playback`:

- **#874** — `bufferTelemetry` race: wrap released-AudioTrack JNI reads in `runCatching`, use `pipelineSampleRate` volatile instead of `track.sampleRate`
- **#876** — SystemTtsEngine `runBlocking` drops URGENT_AUDIO: replace with `generateAudioPCMBlocking()` using `CountDownLatch`-based `CompletionGate` so synth stays on the producer thread
- **#878** — `observeActiveVoice` silent death: wrap `loadAndPlay` in `runCatching` (re-throws `CancellationException`), add debug log on null-bail path
- **#888** — Fast-resume no audio focus: add `audioFocus.acquire()` before fast-resume `audioTrack?.play()`
- **#905** — Recap pipeline no audio focus: add `audioFocus.acquire()` at top of `startRecapPipeline()`, honor `volumeRamp` instead of hardcoded 1f
- **#902** — 10s synth timeout skips sentences: bump `SYNTH_TIMEOUT_MS` to 30s, log elapsed time + text length on timeout

## Test plan

- [ ] `./gradlew :core-playback:compileDebugKotlin` passes
- [ ] Install on tablet, verify playback works (play, pause, resume, voice swap)
- [ ] Verify recap "Read aloud" works from cold-start (no prior Play tap)
- [ ] Verify debug overlay doesn't crash on chapter transitions

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>