### PR TITLE
fix: wave 6 — 2 nav/UI bugs + 4 perf fixes + locale detection

### DIFF
--- a/app/src/main/kotlin/in/jphe/storyvox/navigation/StoryvoxNavHost.kt
+++ b/app/src/main/kotlin/in/jphe/storyvox/navigation/StoryvoxNavHost.kt
@@ -19,6 +19,7 @@ import androidx.compose.runtime.getValue
 import androidx.compose.ui.Modifier
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.navigation.NavBackStackEntry
+import androidx.navigation.NavGraph.Companion.findStartDestination
 import androidx.navigation.NavHostController
 import androidx.navigation.NavType
 import androidx.navigation.compose.NavHost
@@ -455,7 +456,16 @@ private fun StoryvoxNavHostContent(
             HomeTab.Voices -> StoryvoxRoutes.VOICE_LIBRARY
             HomeTab.Settings -> StoryvoxRoutes.SETTINGS_HUB
         }
-        if (target != currentRoute) {
+        // Issue #918 — strip query-parameter suffixes before comparing.
+        // The Library route is registered as "library?sharedUrl={...}"
+        // so `destination.route` includes the query template. Without
+        // stripping, tapping Library while on Library would re-navigate
+        // (target "library" != currentRoute "library?sharedUrl={...}").
+        // More critically, the mismatch caused `popUpTo` with the bare
+        // route string to silently fail on drill-down stacks (Library →
+        // FictionDetail → Reader), making bottom-nav tabs unresponsive.
+        val baseRoute = currentRoute?.substringBefore("?")
+        if (target != baseRoute) {
             // Pop everything above the start destination so tab
             // switches don't accumulate, then push the target.
             // `launchSingleTop` collapses repeated taps on the active
@@ -469,6 +479,16 @@ private fun StoryvoxNavHostContent(
             // the standard Compose bottom-nav pattern from the Now in
             // Android reference app and the official navigation docs.
             //
+            // Issue #918 — use `findStartDestination().id` instead of
+            // the bare route string for `popUpTo`. The Library composable
+            // is registered with an optional query parameter
+            // ("library?sharedUrl={sharedUrl}") so the destination's
+            // route pattern differs from the `StoryvoxRoutes.LIBRARY`
+            // constant ("library"). Using the destination ID bypasses
+            // route-string matching entirely and reliably finds the
+            // start destination in the back stack — the same pattern the
+            // Now in Android reference app uses.
+            //
             // Library is the start destination and always lives at the
             // bottom of the back stack — its NavBackStackEntry (and
             // ViewModel / composable state) persist naturally. Using
@@ -478,7 +498,7 @@ private fun StoryvoxNavHostContent(
             // of the Library grid. Disable restoreState for Library;
             // other tabs restore normally.
             navController.navigate(target) {
-                popUpTo(StoryvoxRoutes.LIBRARY) {
+                popUpTo(navController.graph.findStartDestination().id) {
                     saveState = true
                 }
                 launchSingleTop = true
@@ -642,8 +662,10 @@ private fun StoryvoxNavHostContent(
                         // sub-tab. We open BROWSE directly here so the
                         // CTA's verb still matches its destination
                         // exactly.
+                        // Issue #918 — use findStartDestination().id for
+                        // popUpTo (see onSelectTab comment for rationale).
                         navController.navigate(StoryvoxRoutes.BROWSE) {
-                            popUpTo(StoryvoxRoutes.LIBRARY) {
+                            popUpTo(navController.graph.findStartDestination().id) {
                                 saveState = true
                             }
                             launchSingleTop = true
@@ -658,7 +680,7 @@ private fun StoryvoxNavHostContent(
                     onBack = {
                         if (!navController.popBackStack()) {
                             navController.navigate(StoryvoxRoutes.LIBRARY) {
-                                popUpTo(StoryvoxRoutes.LIBRARY) { inclusive = true }
+                                popUpTo(navController.graph.findStartDestination().id) { inclusive = true }
                                 launchSingleTop = true
                             }
                         }
@@ -812,9 +834,11 @@ private fun StoryvoxNavHostContent(
                     // no-op `{}` made both buttons dead — the user finished
                     // a book via FictionDetail → Reader and had no path to
                     // Browse without OS-backing out first.
+                    // Issue #918 — use findStartDestination().id for
+                    // popUpTo (see onSelectTab comment for rationale).
                     onBrowse = {
                         navController.navigate(StoryvoxRoutes.BROWSE) {
-                            popUpTo(StoryvoxRoutes.LIBRARY) {
+                            popUpTo(navController.graph.findStartDestination().id) {
                                 saveState = true
                             }
                             launchSingleTop = true
@@ -827,7 +851,7 @@ private fun StoryvoxNavHostContent(
                     onBack = {
                         if (!navController.popBackStack()) {
                             navController.navigate(StoryvoxRoutes.LIBRARY) {
-                                popUpTo(StoryvoxRoutes.LIBRARY) { inclusive = true }
+                                popUpTo(navController.graph.findStartDestination().id) { inclusive = true }
                                 launchSingleTop = true
                             }
                         }
@@ -853,9 +877,11 @@ private fun StoryvoxNavHostContent(
                     onOpenChat = { fId, prefill -> navController.navigate(StoryvoxRoutes.chat(fId, prefill)) },
                     // Issue #677 follow-up — same onBrowse wiring as the
                     // READER route above. See the comment there.
+                    // Issue #918 — use findStartDestination().id for
+                    // popUpTo (see onSelectTab comment for rationale).
                     onBrowse = {
                         navController.navigate(StoryvoxRoutes.BROWSE) {
-                            popUpTo(StoryvoxRoutes.LIBRARY) {
+                            popUpTo(navController.graph.findStartDestination().id) {
                                 saveState = true
                             }
                             launchSingleTop = true
@@ -868,7 +894,7 @@ private fun StoryvoxNavHostContent(
                     onBack = {
                         if (!navController.popBackStack()) {
                             navController.navigate(StoryvoxRoutes.LIBRARY) {
-                                popUpTo(StoryvoxRoutes.LIBRARY) { inclusive = true }
+                                popUpTo(navController.graph.findStartDestination().id) { inclusive = true }
                                 launchSingleTop = true
                             }
                         }
@@ -1295,8 +1321,10 @@ private fun StoryvoxNavHostContent(
                         // so users land on TechEmpower's four-fiction
                         // tile set (Guides / Resources / About /
                         // Donate) immediately.
+                        // Issue #918 — use findStartDestination().id for
+                        // popUpTo (see onSelectTab comment for rationale).
                         navController.navigate(StoryvoxRoutes.BROWSE) {
-                            popUpTo(StoryvoxRoutes.LIBRARY) {
+                            popUpTo(navController.graph.findStartDestination().id) {
                                 saveState = true
                             }
                             launchSingleTop = true

--- a/core-data/src/main/kotlin/in/jphe/storyvox/data/db/dao/FictionDao.kt
+++ b/core-data/src/main/kotlin/in/jphe/storyvox/data/db/dao/FictionDao.kt
@@ -45,6 +45,9 @@ interface FictionDao {
     @Upsert
     suspend fun upsert(fiction: Fiction)
 
+    @Upsert
+    suspend fun upsertMany(fictions: List<Fiction>)
+
     @Update
     suspend fun update(fiction: Fiction)
 
@@ -84,9 +87,18 @@ interface FictionDao {
     suspend fun upsertAllPreservingUserState(fictions: List<Fiction>) {
         // Listing pages don't know about library/follow state — preserve the
         // user-owned columns so a browse-page upsert never silently un-libraries.
-        for (incoming in fictions) {
-            val existing = get(incoming.id)
-            val merged = if (existing == null) incoming else incoming.copy(
+        //
+        // Batch-fetch existing rows instead of O(N) individual get() calls.
+        // SQLite has a 999-variable limit for IN clauses, so chunk if needed.
+        val existingMap: Map<String, Fiction> = fictions
+            .map { it.id }
+            .chunked(900)
+            .flatMap { chunk -> getMany(chunk) }
+            .associateBy { it.id }
+
+        val merged = fictions.map { incoming ->
+            val existing = existingMap[incoming.id]
+            if (existing == null) incoming else incoming.copy(
                 inLibrary = existing.inLibrary,
                 addedToLibraryAt = existing.addedToLibraryAt,
                 followedRemotely = existing.followedRemotely,
@@ -100,8 +112,8 @@ interface FictionDao {
                 // upsert doesn't reset the cheap-poll state.
                 lastSeenRevision = existing.lastSeenRevision,
             )
-            upsert(merged)
         }
+        upsertMany(merged)
     }
 
     @Query("DELETE FROM fiction WHERE id = :id AND inLibrary = 0 AND followedRemotely = 0")

--- a/core-data/src/test/kotlin/in/jphe/storyvox/data/repository/FictionRepositoryImplTest.kt
+++ b/core-data/src/test/kotlin/in/jphe/storyvox/data/repository/FictionRepositoryImplTest.kt
@@ -119,6 +119,14 @@ class FictionRepositoryImplTest {
             publish(fiction.id)
         }
 
+        override suspend fun upsertMany(fictions: List<Fiction>) {
+            for (f in fictions) {
+                callLog += "upsertMany(${f.id})"
+                rows[f.id] = f
+                publish(f.id)
+            }
+        }
+
         override suspend fun update(fiction: Fiction) {
             rows[fiction.id] = fiction
             publish(fiction.id)

--- a/core-playback/src/main/kotlin/in/jphe/storyvox/playback/cache/ChapterRenderJob.kt
+++ b/core-playback/src/main/kotlin/in/jphe/storyvox/playback/cache/ChapterRenderJob.kt
@@ -21,6 +21,7 @@ import `in`.jphe.storyvox.data.repository.pronunciation.PronunciationDict
 import `in`.jphe.storyvox.playback.EngineSampleRateCache
 import `in`.jphe.storyvox.playback.tts.CHUNKER_VERSION
 import `in`.jphe.storyvox.playback.tts.SentenceChunker
+import `in`.jphe.storyvox.playback.tts.detectLocale
 import `in`.jphe.storyvox.playback.tts.source.trailingPauseMs
 import `in`.jphe.storyvox.playback.voice.EngineType
 import `in`.jphe.storyvox.playback.voice.UiVoiceInfo
@@ -201,7 +202,7 @@ class ChapterRenderJob @AssistedInject constructor(
         EngineSampleRateCache.refreshFromEngine()
 
         // 9. Generate sentences + write to cache.
-        val sentences = chunker.chunk(chapter.text)
+        val sentences = chunker.chunk(chapter.text, detectLocale(chapter.text))
         val sampleRate = sampleRateFor(voice)
         val appender = pcmCache.appender(cacheKey, sampleRate = sampleRate)
         try {

--- a/core-playback/src/main/kotlin/in/jphe/storyvox/playback/tts/EnginePlayer.kt
+++ b/core-playback/src/main/kotlin/in/jphe/storyvox/playback/tts/EnginePlayer.kt
@@ -4187,19 +4187,14 @@ class EnginePlayer @AssistedInject constructor(
     }
 
     fun releaseEngine() {
-        // #790 — releaseEngine is invoked from StoryvoxPlaybackService.onDestroy
-        // on the main thread. persistPosition does a Room @Upsert; a naked
-        // runBlocking here either janks the main thread or trips Android's
-        // StrictMode disk-IO-on-main detector. Launch the write fire-and-
-        // forget on the scope (already Dispatchers.Main + the suspend body
-        // hops to IO inside Room), then park the main thread for at most
-        // 500ms waiting for it. If the join times out the write keeps
-        // running until scope.cancel() below drops it — the worst case is
-        // a missed position checkpoint, not a lost user gesture.
-        val persistJob = scope.launch { persistPosition() }
-        kotlinx.coroutines.runBlocking {
-            kotlinx.coroutines.withTimeoutOrNull(500L) { persistJob.join() }
-        }
+        // #873 — releaseEngine is invoked from StoryvoxPlaybackService.onDestroy
+        // on the main thread. persistPosition does a Room @Upsert whose suspend
+        // body hops to IO inside the DAO. Fire-and-forget: the scope stays alive
+        // until scope.cancel() below, which gives the IO dispatcher time to flush
+        // the write. Worst case the cancel races the upsert and a position
+        // checkpoint is lost — acceptable, since the previous checkpoint from the
+        // periodic save is at most a few seconds stale.
+        scope.launch { persistPosition() }
         stopRecapPipeline()
         stopPlaybackPipeline()
         stopAudioStreamPlayer()

--- a/core-playback/src/main/kotlin/in/jphe/storyvox/playback/tts/EnginePlayer.kt
+++ b/core-playback/src/main/kotlin/in/jphe/storyvox/playback/tts/EnginePlayer.kt
@@ -2495,13 +2495,14 @@ class EnginePlayer @AssistedInject constructor(
                         // window — once true, always true for the
                         // source's lifetime.
                         naturalEnd = source.producedAllSentences
-                        android.util.Log.i(
-                            "EnginePlayer",
+                        // #867 — was always-on Log.i; string formatting
+                        // on URGENT_AUDIO is unnecessary in release.
+                        DebugLog.i("EnginePlayer") {
                             "end-of-pcm: naturalEnd=$naturalEnd " +
                                 "producedAll=${source.producedAllSentences} " +
                                 "pipelineRunning=${pipelineRunning.get()} " +
-                                "userPaused=${userPaused.get()}",
-                        )
+                                "userPaused=${userPaused.get()}"
+                        }
                         break
                     }
                     val chunk = chunkOrNull
@@ -2512,9 +2513,19 @@ class EnginePlayer @AssistedInject constructor(
                     // which is the whole reason we left coroutines.
                     // #883 — skip on a pause-resume: the listener is still
                     // inside this same sentence, the range is already live.
-                    if (!resumedFromPause) {
+                    //
+                    // #865 — gate on sentence-index change. Pre-fix this
+                    // launched a new coroutine on EVERY chunk, even when
+                    // successive chunks belong to the same sentence (same
+                    // range, same charOffset). Each launch allocates a
+                    // coroutine object + dispatches to Main — unnecessary
+                    // work on the URGENT_AUDIO thread. Move the volatile
+                    // write of currentSentenceIndex to this thread (single
+                    // writer, volatile read elsewhere is safe) and only
+                    // launch when the index actually changes.
+                    if (!resumedFromPause && chunk.sentenceIndex != currentSentenceIndex) {
+                        currentSentenceIndex = chunk.sentenceIndex
                         scope.launch {
-                            currentSentenceIndex = chunk.sentenceIndex
                             _observableState.update {
                                 it.copy(
                                     currentSentenceRange = chunk.range,
@@ -2574,16 +2585,16 @@ class EnginePlayer @AssistedInject constructor(
                                     break
                                 }
                             }
-                            runCatching {
-                                android.util.Log.i(
-                                    "EnginePlayer",
-                                    "#862 prebuffer-gate: depth=${source.producerQueueDepth()} " +
-                                        "target=$target producedAll=${source.producedAllSentences} " +
-                                        "elapsedMs=${
-                                            (System.nanoTime() - (deadlineNanos -
-                                                PREBUFFER_TIMEOUT_MS * 1_000_000L)) / 1_000_000L
-                                        }",
-                                )
+                            // #867 — was always-on Log.i; string formatting
+                            // (nanoTime arithmetic + interpolation) is free
+                            // when verbose logging is off.
+                            DebugLog.i("EnginePlayer") {
+                                "#862 prebuffer-gate: depth=${source.producerQueueDepth()} " +
+                                    "target=$target producedAll=${source.producedAllSentences} " +
+                                    "elapsedMs=${
+                                        (System.nanoTime() - (deadlineNanos -
+                                            PREBUFFER_TIMEOUT_MS * 1_000_000L)) / 1_000_000L
+                                    }"
                             }
                         }
 
@@ -2837,13 +2848,14 @@ class EnginePlayer @AssistedInject constructor(
                         source.producerQueueDepth() <= 1
                     ) {
                         naturalEnd = true
-                        android.util.Log.i(
-                            "EnginePlayer",
+                        // #867 — was always-on Log.i on the URGENT_AUDIO
+                        // thread; gated behind DebugLog for release builds.
+                        DebugLog.i("EnginePlayer") {
                             "end-of-pcm (post-write fast path): naturalEnd=true " +
                                 "producedAll=true queueDepth=${source.producerQueueDepth()} " +
                                 "pipelineRunning=${pipelineRunning.get()} — " +
-                                "skipping the END_PILL round-trip (#573 gapless)",
-                        )
+                                "skipping the END_PILL round-trip (#573 gapless)"
+                        }
                         break
                     }
                 }
@@ -2882,12 +2894,12 @@ class EnginePlayer @AssistedInject constructor(
                 // chapter N+1's audio starts ≤300 ms later — Spotify-
                 // style gapless on cached Notion sources.
                 if (naturalEnd) {
-                    android.util.Log.i(
-                        "EnginePlayer",
+                    // #867 — was always-on Log.i on URGENT_AUDIO thread.
+                    DebugLog.i("EnginePlayer") {
                         "post-finally: naturalEnd=true producedAll=${source.producedAllSentences} " +
                             "pipelineRunning=${pipelineRunning.get()} — dispatching handleChapterDone " +
-                            "and draining HW buffer (#573 gapless)",
-                    )
+                            "and draining HW buffer (#573 gapless)"
+                    }
                     // PR-D (#86) — finalize the cache on natural end so
                     // the index sidecar lands and the cache is complete
                     // for next play. Must happen BEFORE the chapter-done
@@ -2983,11 +2995,11 @@ class EnginePlayer @AssistedInject constructor(
                     // idempotent.
                     runCatching { track.pause() }
                     runCatching { track.release() }
-                    android.util.Log.i(
-                        "EnginePlayer",
+                    // #867 — was always-on Log.i.
+                    DebugLog.i("EnginePlayer") {
                         "post-finally: HW buffer drained, AudioTrack released " +
-                            "(target=$targetFrames frames, naturalEnd path, no flush #877)",
-                    )
+                            "(target=$targetFrames frames, naturalEnd path, no flush #877)"
+                    }
                     return@Thread
                 }
                 // Non-natural-end path (user pause, voice swap, seek,
@@ -3010,12 +3022,12 @@ class EnginePlayer @AssistedInject constructor(
                         _observableState.update { it.copy(isBuffering = false) }
                     }
                 }
-                android.util.Log.i(
-                    "EnginePlayer",
+                // #867 — was always-on Log.i.
+                DebugLog.i("EnginePlayer") {
                     "post-finally: naturalEnd=false producedAll=${source.producedAllSentences} " +
                         "pipelineRunning=${pipelineRunning.get()} — non-natural exit " +
-                        "(pause/swap/seek), AudioTrack released",
-                )
+                        "(pause/swap/seek), AudioTrack released"
+                }
             }
         }, "storyvox-audio-out").apply {
             isDaemon = true

--- a/core-playback/src/main/kotlin/in/jphe/storyvox/playback/tts/EnginePlayer.kt
+++ b/core-playback/src/main/kotlin/in/jphe/storyvox/playback/tts/EnginePlayer.kt
@@ -1338,7 +1338,7 @@ class EnginePlayer @AssistedInject constructor(
         // brass spinner immediately. Sherpa-onnx Kokoro init can take 30+s
         // on modest hardware; without this the screen sits blank that long.
         val text = chapter.text
-        sentences = chunker.chunk(text)
+        sentences = chunker.chunk(text, detectLocale(text))
         // Issue #442 — Gutenberg-derived plain text can be "stripTags(htmlBody)"-
         // empty for spine entries that are pure-HTML wrappers (front-matter,
         // PG header pages, image-only inserts). When that happens the
@@ -4526,7 +4526,7 @@ class EnginePlayer @AssistedInject constructor(
         if (text.isBlank()) return
         stopRecapPipeline()
         if (!ensureVoiceLoaded()) return
-        val recapSentences = chunker.chunk(text)
+        val recapSentences = chunker.chunk(text, detectLocale(text))
         if (recapSentences.isEmpty()) return
         startRecapPipeline(recapSentences)
     }

--- a/core-playback/src/main/kotlin/in/jphe/storyvox/playback/tts/SentenceChunker.kt
+++ b/core-playback/src/main/kotlin/in/jphe/storyvox/playback/tts/SentenceChunker.kt
@@ -6,6 +6,54 @@ import javax.inject.Inject
 import javax.inject.Singleton
 
 /**
+ * Samples up to [SCRIPT_SAMPLE_LIMIT] non-whitespace characters from [text]
+ * and returns a [Locale] whose [BreakIterator] rules match the dominant
+ * Unicode script. Falls back to [fallback] (default [Locale.getDefault])
+ * when the text is Latin, Common, or too short to classify.
+ *
+ * The mapping covers scripts where ICU's sentence-break rules differ
+ * materially from the Latin/Common defaults:
+ *  - CJK (Han / Hiragana / Katakana → [Locale.JAPANESE], Hangul → [Locale.KOREAN])
+ *  - Thai (no inter-word spaces; BreakIterator needs Thai locale)
+ *  - Arabic / Hebrew (RTL + different punctuation conventions)
+ *
+ * Issue #899 — sentence boundaries were always computed with the device
+ * locale, producing wrong splits for non-Latin chapter text.
+ */
+internal fun detectLocale(text: String, fallback: Locale = Locale.getDefault()): Locale {
+    val counts = mutableMapOf<Character.UnicodeScript, Int>()
+    var sampled = 0
+    for (ch in text) {
+        if (ch.isWhitespace()) continue
+        val script = Character.UnicodeScript.of(ch.code)
+        // COMMON covers digits, punctuation, emoji — skip.
+        if (script == Character.UnicodeScript.COMMON ||
+            script == Character.UnicodeScript.INHERITED
+        ) continue
+        counts[script] = (counts[script] ?: 0) + 1
+        if (++sampled >= SCRIPT_SAMPLE_LIMIT) break
+    }
+    val dominant = counts.maxByOrNull { it.value }?.key ?: return fallback
+    return SCRIPT_LOCALE_MAP[dominant] ?: fallback
+}
+
+/** Max non-whitespace characters to sample for script detection. */
+private const val SCRIPT_SAMPLE_LIMIT: Int = 200
+
+/** Maps a dominant Unicode script to the most appropriate [Locale] for
+ *  [BreakIterator.getSentenceInstance]. Only scripts where ICU's break
+ *  rules diverge from the Latin default need entries here. */
+private val SCRIPT_LOCALE_MAP: Map<Character.UnicodeScript, Locale> = mapOf(
+    Character.UnicodeScript.HAN to Locale.CHINESE,
+    Character.UnicodeScript.HIRAGANA to Locale.JAPANESE,
+    Character.UnicodeScript.KATAKANA to Locale.JAPANESE,
+    Character.UnicodeScript.HANGUL to Locale.KOREAN,
+    Character.UnicodeScript.THAI to Locale("th"),
+    Character.UnicodeScript.ARABIC to Locale("ar"),
+    Character.UnicodeScript.HEBREW to Locale("he"),
+)
+
+/**
  * Bumped when [SentenceChunker.chunk] changes its boundary semantics in a way
  * that would shift `(startChar, endChar)` for the same input. Included in
  * [`in`.jphe.storyvox.playback.cache.PcmCacheKey] so a chunker change
@@ -28,8 +76,12 @@ import javax.inject.Singleton
  *    length for the last sentence) instead of stopping at the trimmed text
  *    length, so sentence ranges partition the chapter contiguously. This
  *    moves endChar for any sentence followed by inter-sentence whitespace.
+ *  - v4 (#899): call sites now pass a text-detected locale instead of
+ *    Locale.getDefault(). For non-Latin text (CJK, Thai, Arabic, Hebrew)
+ *    the BreakIterator uses locale-appropriate rules, shifting boundaries.
+ *    Bump invalidates pre-cached PCM that was chunked under the wrong locale.
  */
-const val CHUNKER_VERSION: Int = 3
+const val CHUNKER_VERSION: Int = 4
 
 data class Sentence(
     val index: Int,

--- a/core-playback/src/main/kotlin/in/jphe/storyvox/playback/tts/source/EngineStreamingSource.kt
+++ b/core-playback/src/main/kotlin/in/jphe/storyvox/playback/tts/source/EngineStreamingSource.kt
@@ -526,8 +526,22 @@ class EngineStreamingSource(
         try {
             var next = fromIndex
             while (next < sentences.size && running.get()) {
+                // #901 — simplified predicate. Pre-fix was
+                //   `signal.first { it != signal.value || completed.containsKey(next) }`
+                // The `it != signal.value` branch is a dead comparison:
+                // StateFlow.first {} receives the current value on
+                // subscribe, at which point `it == signal.value`, so the
+                // predicate only passes via the second disjunct anyway.
+                // On subsequent emissions `it` IS the new value and
+                // `signal.value` has already been CAS'd to the same
+                // value, so the comparison is racy and can wake
+                // spuriously (the sequencer re-enters the inner while,
+                // finds the map still empty, and re-subscribes — wasted
+                // work on the producer dispatcher). Dropping the dead
+                // branch means the sequencer only wakes when the target
+                // sentence is actually ready.
                 while (running.get() && !completed.containsKey(next)) {
-                    signal.first { it != signal.value || completed.containsKey(next) }
+                    signal.first { completed.containsKey(next) }
                 }
                 if (!running.get()) break
                 val chunk = completed.remove(next) ?: continue

--- a/core-playback/src/test/kotlin/in/jphe/storyvox/playback/tts/SentenceChunkerTest.kt
+++ b/core-playback/src/test/kotlin/in/jphe/storyvox/playback/tts/SentenceChunkerTest.kt
@@ -115,4 +115,63 @@ class SentenceChunkerTest {
         // which should still parse if numeric.
         assertEquals(3, chunker.parseSentenceIndex("s3"))
     }
+
+    // ── detectLocale tests ──────────────────────────────────────────────
+
+    @Test fun `detectLocale returns fallback for empty text`() {
+        assertEquals(Locale.FRENCH, detectLocale("", Locale.FRENCH))
+    }
+
+    @Test fun `detectLocale returns fallback for whitespace-only text`() {
+        assertEquals(Locale.GERMAN, detectLocale("   \n\t  ", Locale.GERMAN))
+    }
+
+    @Test fun `detectLocale returns fallback for Latin text`() {
+        val fallback = Locale.US
+        assertEquals(fallback, detectLocale("Hello world. This is English.", fallback))
+    }
+
+    @Test fun `detectLocale returns Japanese for hiragana-heavy text`() {
+        assertEquals(Locale.JAPANESE, detectLocale("これは日本語のテストです。次の文も日本語です。"))
+    }
+
+    @Test fun `detectLocale returns Japanese for katakana-heavy text`() {
+        assertEquals(Locale.JAPANESE, detectLocale("カタカナのテキストです。テストケースです。"))
+    }
+
+    @Test fun `detectLocale returns Chinese for Han-only text`() {
+        assertEquals(Locale.CHINESE, detectLocale("这是中文测试。下一句也是中文。"))
+    }
+
+    @Test fun `detectLocale returns Korean for Hangul text`() {
+        assertEquals(Locale.KOREAN, detectLocale("이것은 한국어 테스트입니다. 다음 문장도 한국어입니다."))
+    }
+
+    @Test fun `detectLocale returns Thai for Thai text`() {
+        assertEquals(Locale("th"), detectLocale("นี่คือการทดสอบภาษาไทย ประโยคถัดไปก็เป็นภาษาไทย"))
+    }
+
+    @Test fun `detectLocale returns Arabic for Arabic text`() {
+        assertEquals(Locale("ar"), detectLocale("هذا اختبار باللغة العربية. الجملة التالية أيضاً بالعربية."))
+    }
+
+    @Test fun `detectLocale returns Hebrew for Hebrew text`() {
+        assertEquals(Locale("he"), detectLocale("זהו מבחן בעברית. המשפט הבא גם בעברית."))
+    }
+
+    @Test fun `detectLocale ignores punctuation and digits in classification`() {
+        // Digits and punctuation are COMMON script — only actual CJK carries weight.
+        assertEquals(Locale.JAPANESE, detectLocale("123 これはテスト!!! 456 もう一つ。"))
+    }
+
+    @Test fun `chunk uses detected locale for Japanese text`() {
+        // Japanese sentence endings use '。' — BreakIterator with Japanese
+        // locale should split on them correctly.
+        val text = "最初の文。二番目の文。三番目の文。"
+        val out = chunker.chunk(text, detectLocale(text))
+        assertEquals(3, out.size)
+        assertEquals("最初の文。", out[0].text)
+        assertEquals("二番目の文。", out[1].text)
+        assertEquals("三番目の文。", out[2].text)
+    }
 }

--- a/feature/src/main/kotlin/in/jphe/storyvox/feature/library/LibraryScreen.kt
+++ b/feature/src/main/kotlin/in/jphe/storyvox/feature/library/LibraryScreen.kt
@@ -351,7 +351,7 @@ fun LibraryScreen(
                             state = state,
                             dedupedFictions = dedupedFictions,
                             onResume = viewModel::resume,
-                            onTapFiction = viewModel::resumeOrOpenFiction,
+                            onTapFiction = viewModel::openFiction,
                             onLongPress = viewModel::openManageShelves,
                             onOpenTechEmpower = onOpenTechEmpower,
                         )
@@ -739,10 +739,11 @@ private fun LibraryGridBody(
     dedupedFictions: List<FictionSummary>,
     onResume: () -> Unit,
     /**
-     * Issue #827 — tap on a grid item. The ViewModel routes the tap
-     * to resume-playback when a saved position exists and to
-     * fiction-detail when it doesn't, so this single callback covers
-     * both "continue listening" and "open a new book" paths.
+     * Issue #908 — tap on a grid item always opens fiction-detail
+     * (chapter list, metadata, description). The NowPlayingDock
+     * already provides reader access for the currently-playing book;
+     * routing taps to the reader was a shortcut that skipped the
+     * detail page (see #827 revert rationale).
      */
     onTapFiction: (String) -> Unit,
     onLongPress: (FictionSummary) -> Unit,
@@ -835,10 +836,10 @@ private fun LibraryGridBody(
                     author = fiction.author,
                     sourceFamily = coverSourceFamilyFor(fiction.sourceId),
                     // Long-press → manage-shelves bottom sheet (#116).
-                    // Tap → resume-or-open (#827): when the fiction has
-                    // a saved playback position, tap resumes playback
-                    // like the ResumeCard hero; otherwise it falls
-                    // back to opening fiction detail.
+                    // Tap → fiction detail (#908): always opens the
+                    // detail page (chapter list, metadata). The #827
+                    // resume-or-open shortcut was reverted because it
+                    // skipped the detail page unexpectedly.
                     modifier = Modifier
                         .fillMaxWidth()
                         .combinedClickable(

--- a/source-github/src/main/kotlin/in/jphe/storyvox/source/github/auth/GitHubAuthRepository.kt
+++ b/source-github/src/main/kotlin/in/jphe/storyvox/source/github/auth/GitHubAuthRepository.kt
@@ -2,12 +2,10 @@ package `in`.jphe.storyvox.source.github.auth
 
 import android.content.SharedPreferences
 import androidx.core.content.edit
-import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
-import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 import javax.inject.Inject
 import javax.inject.Singleton
@@ -124,15 +122,12 @@ internal class GitHubAuthRepositoryImpl @Inject constructor(
         // stays intact so the next captureSession() restores cleanly. The
         // in-memory state flips so the interceptor stops attaching the
         // dead token to subsequent requests.
+        //
+        // #871 — MutableStateFlow.value= is thread-safe and notifies
+        // subscribers immediately; the previous CoroutineScope(IO).launch
+        // was redundant and leaked an unscoped coroutine.
         if (state.value is GitHubSession.Expired) return
         state.value = GitHubSession.Expired
-        // Best-effort fan-out so background machinery (Settings, etc.)
-        // doesn't keep showing "signed in" when the token's actually dead.
-        // Doesn't await: the StateFlow update above is the source of truth.
-        CoroutineScope(Dispatchers.IO).launch {
-            // No-op other than yielding to ensure subscribers wake up.
-            state.value = GitHubSession.Expired
-        }
     }
 
     companion object {


### PR DESCRIPTION
## Summary
- **#918** fix(nav): bottom-nav Browse tab unresponsive when on Reader via Library drill-down — `popUpTo` route mismatch with query-param pattern
- **#908** fix(library): book-cover tap routes to Fiction Detail instead of Reader — callback swap from `resumeOrOpenFiction` to `openFiction`
- **#882** perf(data): batch FictionDao.upsertAllPreservingUserState — O(N) get() → single getMany() with chunked(900)
- **#873** perf(playback): remove runBlocking from releaseEngine position persist — fire-and-forget instead of 500ms Main block
- **#871** fix(auth): remove ephemeral CoroutineScope leak in markExpired — direct StateFlow assignment
- **#899** fix(tts): detect chapter script for BreakIterator locale — Unicode script sampling for CJK/Thai/Arabic/Hebrew + 12 new tests
- **#865** perf(playback): gate per-chunk coroutine launch on sentence-index change
- **#867** perf(playback): migrate consumer-thread logging to DebugLog (zero-cost in release)
- **#901** fix(playback): remove dead branch in parallel-producer sequencer predicate

## Test plan
- [ ] CI build passes
- [ ] Library book tap → Fiction Detail (not Reader)
- [ ] Browse tab responsive after Library → Reader drill-down
- [ ] Playback still works after releaseEngine change
- [ ] CJK text gets correct sentence boundaries
- [ ] No double-voice regression

🤖 Generated with [Claude Code](https://claude.com/claude-code)