### PR TITLE
feat: wave 7 — 6 features (reader FAB, voices polish, error UI, thermal, power save, library search)

### DIFF
--- a/app/src/main/kotlin/in/jphe/storyvox/di/AppBindings.kt
+++ b/app/src/main/kotlin/in/jphe/storyvox/di/AppBindings.kt
@@ -946,6 +946,12 @@ internal class RealPlaybackControllerUi(
      *  add a stale duplication seam. */
     override val events: Flow<PlaybackUiEvent> = controller.events
 
+    /** Issue #805 — forward the typed engine state to the feature layer
+     *  so the reader can show distinct error banners (auth / network /
+     *  throttle / generic) rather than collapsing everything to a string. */
+    override val engineState: Flow<`in`.jphe.storyvox.playback.EngineState> =
+        controller.engineState
+
     /** "Why are we waiting?" — forward the AudioOutputMonitor's
      *  diagnostic flow through the UI contract. The monitor lives in
      *  core-playback as a Singleton; this adapter doesn't transform the

--- a/core-playback/src/main/kotlin/in/jphe/storyvox/playback/PowerSaveMonitor.kt
+++ b/core-playback/src/main/kotlin/in/jphe/storyvox/playback/PowerSaveMonitor.kt
@@ -1,0 +1,75 @@
+package `in`.jphe.storyvox.playback
+
+import android.content.BroadcastReceiver
+import android.content.Context
+import android.content.Intent
+import android.content.IntentFilter
+import android.os.PowerManager
+import android.util.Log
+import dagger.hilt.android.qualifiers.ApplicationContext
+import javax.inject.Inject
+import javax.inject.Singleton
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+
+/**
+ * Issue #801 — monitors Android's battery-saver / power-save mode and
+ * exposes the current state as a [StateFlow]. Consumers in the playback
+ * layer use this to:
+ *
+ *  - **Pause pre-rendering** ([PrerenderTriggers]) — background chapter
+ *    renders are CPU-heavy (~30%+ on Helio P22T per chapter) and should
+ *    not run when the OS is explicitly trying to conserve battery.
+ *  - **Lower producer thread priority** ([EngineStreamingSource]) — the
+ *    producer drives TTS synthesis and normally runs at URGENT_AUDIO so
+ *    the consumer's AudioTrack never underruns. In power-save mode the
+ *    producer drops to THREAD_PRIORITY_BACKGROUND; the consumer KEEPS
+ *    URGENT_AUDIO because audio glitches are worse than battery drain.
+ *
+ * Lifecycle: `@Singleton` scope — constructed once by Hilt, lives for
+ * the process. The [BroadcastReceiver] is registered in the constructor
+ * with the application context, so it survives Activity recreation.
+ *
+ * Initial state is seeded from [PowerManager.isPowerSaveMode] so the
+ * flow has a correct value before the first broadcast arrives.
+ */
+@Singleton
+class PowerSaveMonitor @Inject constructor(
+    @ApplicationContext private val context: Context,
+) {
+    private val _isPowerSaveMode = MutableStateFlow(queryPowerSaveMode())
+
+    /**
+     * `true` when the device is in battery-saver / power-save mode.
+     * Updates within milliseconds of the OS broadcast.
+     */
+    val isPowerSaveMode: StateFlow<Boolean> = _isPowerSaveMode.asStateFlow()
+
+    init {
+        val filter = IntentFilter(PowerManager.ACTION_POWER_SAVE_MODE_CHANGED)
+        context.registerReceiver(
+            object : BroadcastReceiver() {
+                override fun onReceive(ctx: Context, intent: Intent) {
+                    val newState = queryPowerSaveMode()
+                    _isPowerSaveMode.value = newState
+                    Log.i(
+                        LOG_TAG,
+                        "power-save mode changed: $newState",
+                    )
+                }
+            },
+            filter,
+        )
+        Log.i(LOG_TAG, "initialized — isPowerSaveMode=${_isPowerSaveMode.value}")
+    }
+
+    private fun queryPowerSaveMode(): Boolean {
+        val pm = context.getSystemService(Context.POWER_SERVICE) as? PowerManager
+        return pm?.isPowerSaveMode ?: false
+    }
+
+    companion object {
+        private const val LOG_TAG = "PowerSaveMonitor"
+    }
+}

--- a/core-playback/src/main/kotlin/in/jphe/storyvox/playback/ThermalMonitor.kt
+++ b/core-playback/src/main/kotlin/in/jphe/storyvox/playback/ThermalMonitor.kt
@@ -1,0 +1,112 @@
+package `in`.jphe.storyvox.playback
+
+import android.content.Context
+import android.os.Build
+import android.os.PowerManager
+import android.util.Log
+import dagger.hilt.android.qualifiers.ApplicationContext
+import `in`.jphe.storyvox.data.log.DebugLog
+import javax.inject.Inject
+import javax.inject.Singleton
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+
+/**
+ * Issue #803 — observes the device's thermal status via
+ * [PowerManager.addThermalStatusListener] (API 29+) and exposes it as a
+ * [StateFlow] that playback components can collect.
+ *
+ * On API < 29 the flow stays at [PowerManager.THERMAL_STATUS_NONE] (0)
+ * permanently — callers treat 0 as "no thermal pressure, use defaults."
+ *
+ * ## Thermal status values (from PowerManager):
+ *  - 0 = THERMAL_STATUS_NONE — no throttling
+ *  - 1 = THERMAL_STATUS_LIGHT — light throttling, no user-visible impact
+ *  - 2 = THERMAL_STATUS_MODERATE — moderate throttling, noticeable
+ *  - 3 = THERMAL_STATUS_SEVERE — severe, device is hot
+ *  - 4 = THERMAL_STATUS_CRITICAL — platform may shut down
+ *  - 5 = THERMAL_STATUS_EMERGENCY — key components shutting down
+ *  - 6 = THERMAL_STATUS_SHUTDOWN — shutdown imminent
+ *
+ * ## Consumer contract:
+ *  - [EnginePlayer][in.jphe.storyvox.playback.tts.EnginePlayer] collects
+ *    [thermalStatus] and caps parallel-synth concurrency when the value
+ *    reaches MODERATE (2) or above. The user's saved setting is NOT
+ *    modified — only the runtime effective value is overridden for the
+ *    duration of the thermal event. When the status drops back below
+ *    MODERATE, the user's configured concurrency is restored on the
+ *    next pipeline rebuild.
+ *
+ * Lifecycle: `@Singleton` — the listener is registered once per process
+ * and never removed. PowerManager holds a weak reference internally, so
+ * no leak concern.
+ */
+@Singleton
+class ThermalMonitor @Inject constructor(
+    @ApplicationContext context: Context,
+) {
+    private val _thermalStatus = MutableStateFlow(THERMAL_STATUS_NONE)
+
+    /**
+     * Current thermal status. 0 = no thermal pressure (or API < 29).
+     * Mirrors the [PowerManager] THERMAL_STATUS_* constants.
+     */
+    val thermalStatus: StateFlow<Int> = _thermalStatus.asStateFlow()
+
+    init {
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
+            val pm = context.getSystemService(Context.POWER_SERVICE) as? PowerManager
+            if (pm != null) {
+                try {
+                    pm.addThermalStatusListener { status ->
+                        val prev = _thermalStatus.value
+                        _thermalStatus.value = status
+                        Log.w(
+                            TAG,
+                            "#803 thermal status changed: $prev -> $status " +
+                                "(${thermalLabel(status)})",
+                        )
+                        DebugLog.i(TAG) {
+                            "#803 thermal status $prev -> $status (${thermalLabel(status)})"
+                        }
+                    }
+                    DebugLog.i(TAG) { "#803 thermal listener registered (API ${Build.VERSION.SDK_INT})" }
+                } catch (e: Exception) {
+                    // Some OEM ROMs throw on addThermalStatusListener
+                    // (seen on MIUI 14 / Xiaomi Redmi Note 12). Degrade
+                    // gracefully — flow stays at 0, no thermal throttling.
+                    Log.w(TAG, "#803 failed to register thermal listener", e)
+                }
+            }
+        } else {
+            DebugLog.i(TAG) { "#803 API ${Build.VERSION.SDK_INT} < 29, thermal monitoring disabled" }
+        }
+    }
+
+    companion object {
+        private const val TAG = "ThermalMonitor"
+
+        /** Mirror of [PowerManager.THERMAL_STATUS_NONE] for use without
+         *  a Q+ API-level guard. */
+        const val THERMAL_STATUS_NONE = 0
+
+        /** Moderate thermal pressure — parallel synth should drop to
+         *  serial mode (1 instance). */
+        const val THERMAL_STATUS_MODERATE = 2
+
+        /** Severe thermal pressure — serial mode + reduced queue depth. */
+        const val THERMAL_STATUS_SEVERE = 3
+
+        private fun thermalLabel(status: Int): String = when (status) {
+            0 -> "NONE"
+            1 -> "LIGHT"
+            2 -> "MODERATE"
+            3 -> "SEVERE"
+            4 -> "CRITICAL"
+            5 -> "EMERGENCY"
+            6 -> "SHUTDOWN"
+            else -> "UNKNOWN($status)"
+        }
+    }
+}

--- a/core-playback/src/main/kotlin/in/jphe/storyvox/playback/cache/PrerenderTriggers.kt
+++ b/core-playback/src/main/kotlin/in/jphe/storyvox/playback/cache/PrerenderTriggers.kt
@@ -6,6 +6,7 @@ import `in`.jphe.storyvox.data.repository.FictionLibraryListener
 import `in`.jphe.storyvox.data.repository.PlaybackPositionRepository
 import `in`.jphe.storyvox.data.repository.playback.PlaybackModeConfig
 import `in`.jphe.storyvox.data.repository.playback.PrerenderChapterCountConfig
+import `in`.jphe.storyvox.playback.PowerSaveMonitor
 import javax.inject.Inject
 import javax.inject.Singleton
 import kotlinx.coroutines.flow.first
@@ -84,6 +85,15 @@ class PrerenderTriggers @Inject constructor(
      * current pref at trigger time.
      */
     private val prerenderCountConfig: PrerenderChapterCountConfig,
+    /**
+     * Issue #801 — power-save gate. When the device is in battery-saver
+     * mode, all prerender scheduling is suppressed. Background chapter
+     * renders are CPU-heavy (~30%+ on Helio P22T per chapter) and the
+     * OS is explicitly trying to conserve battery. The triggers resume
+     * normal behavior the moment power-save mode is turned off — the
+     * next chapter-complete / library-add / Mode C flip re-evaluates.
+     */
+    private val powerSaveMonitor: PowerSaveMonitor,
 ) : FictionLibraryListener {
 
     /**
@@ -118,6 +128,14 @@ class PrerenderTriggers @Inject constructor(
      *  - Mode C (full pre-render) → render everything (no slice).
      */
     override suspend fun onLibraryAdded(fictionId: String) {
+        // Issue #801 — skip prerender scheduling in power-save mode.
+        if (powerSaveMonitor.isPowerSaveMode.value) {
+            Log.i(
+                LOG_TAG,
+                "pcm-cache TRIGGER-LIBRARY-ADD fictionId=$fictionId SKIPPED (power save mode)",
+            )
+            return
+        }
         val chapters = chapterRepo.observeChapters(fictionId).first()
             .sortedBy { it.index }
         if (chapters.isEmpty()) {
@@ -262,6 +280,15 @@ class PrerenderTriggers @Inject constructor(
      * the trigger doesn't carry it and we don't want to assume.
      */
     suspend fun onChapterCompleted(currentChapterId: String) {
+        // Issue #801 — skip prerender scheduling in power-save mode.
+        if (powerSaveMonitor.isPowerSaveMode.value) {
+            Log.i(
+                LOG_TAG,
+                "pcm-cache TRIGGER-CHAPTER-DONE chapterId=$currentChapterId " +
+                    "SKIPPED (power save mode)",
+            )
+            return
+        }
         val nextId = chapterRepo.getNextChapterId(currentChapterId)
         if (nextId == null) {
             Log.i(
@@ -301,6 +328,14 @@ class PrerenderTriggers @Inject constructor(
      * here, the scheduler dedupes.
      */
     suspend fun onFullPrerenderEnabled(fictionIds: Iterable<String>) {
+        // Issue #801 — skip prerender scheduling in power-save mode.
+        if (powerSaveMonitor.isPowerSaveMode.value) {
+            Log.i(
+                LOG_TAG,
+                "pcm-cache TRIGGER-FULL-PRERENDER SKIPPED (power save mode)",
+            )
+            return
+        }
         for (fictionId in fictionIds) {
             val chapters = chapterRepo.observeChapters(fictionId).first()
                 .sortedBy { it.index }

--- a/core-playback/src/main/kotlin/in/jphe/storyvox/playback/tts/EnginePlayer.kt
+++ b/core-playback/src/main/kotlin/in/jphe/storyvox/playback/tts/EnginePlayer.kt
@@ -44,6 +44,7 @@ import `in`.jphe.storyvox.playback.PlaybackUiEvent
 import `in`.jphe.storyvox.playback.SPEED_BASELINE_CHARS_PER_SECOND
 import `in`.jphe.storyvox.playback.SentenceRange
 import `in`.jphe.storyvox.playback.SleepTimer
+import `in`.jphe.storyvox.playback.ThermalMonitor
 import `in`.jphe.storyvox.playback.TtsVolumeRamp
 import `in`.jphe.storyvox.playback.cache.EngineMutex
 import `in`.jphe.storyvox.playback.cache.PcmAppender
@@ -203,6 +204,13 @@ class EnginePlayer @AssistedInject constructor(
      *  so chapter transitions reuse the same focus request rather than
      *  thrashing the stack. */
     private val audioFocus: `in`.jphe.storyvox.playback.AudioFocusController,
+    /** Issue #803 — thermal status monitor. When the device overheats
+     *  (THERMAL_STATUS_MODERATE+), the effective parallel-synth
+     *  concurrency is temporarily capped to reduce CPU load. The user's
+     *  saved setting is NOT modified — only the runtime value used at
+     *  pipeline-construction time is overridden. Full concurrency is
+     *  restored when the thermal status drops back below MODERATE. */
+    private val thermalMonitor: ThermalMonitor,
 ) : SimpleBasePlayer(Looper.getMainLooper()) {
 
     @AssistedFactory
@@ -276,6 +284,17 @@ class EnginePlayer @AssistedInject constructor(
      *  suspending, the consumer is sync. Defaults to 1 (serial). */
     @Volatile
     private var cachedParallelSynthInstances: Int = 1
+
+    /** Issue #803 — snapshot of [ThermalMonitor.thermalStatus] for
+     *  synchronous reads at pipeline-construction time. When >= 2
+     *  (THERMAL_STATUS_MODERATE), [startPlaybackPipeline] caps the
+     *  effective parallel-synth concurrency to 1 (serial). When >= 3
+     *  (THERMAL_STATUS_SEVERE), queue depth is also halved. The user's
+     *  saved [cachedParallelSynthInstances] is unchanged — only the
+     *  runtime value fed to [EngineStreamingSource] is overridden.
+     *  Updated by [observeThermalStatus]; defaults to 0 (no pressure). */
+    @Volatile
+    private var cachedThermalStatus: Int = ThermalMonitor.THERMAL_STATUS_NONE
 
     /** Tier 3 (#88) — list of secondary VoiceEngine / KokoroEngine
      *  instances for parallel synth. Sized at (instances-1) so the
@@ -401,6 +420,7 @@ class EnginePlayer @AssistedInject constructor(
         observeAzureErrors()
         observeAzureFallbackConfig()
         observeA11yPacing()
+        observeThermalStatus()
     }
 
     /**
@@ -414,6 +434,51 @@ class EnginePlayer @AssistedInject constructor(
         scope.launch {
             a11yPacingConfig.extraSilenceMs.collect { ms ->
                 cachedA11yExtraSilenceMs = ms.coerceIn(0, 1500)
+            }
+        }
+    }
+
+    /**
+     * Issue #803 — collect [ThermalMonitor.thermalStatus] and cache
+     * it as a volatile for the synchronous pipeline-construction path.
+     * When the status rises to MODERATE (2) or above, the next pipeline
+     * rebuild caps the effective parallel-synth concurrency to 1 (serial
+     * mode). If playback is already running, we trigger a pipeline
+     * rebuild so the cap takes effect immediately rather than waiting
+     * for the next chapter/seek/voice-swap.
+     *
+     * When the status drops back below MODERATE, the same rebuild
+     * restores the user's configured concurrency from
+     * [cachedParallelSynthInstances].
+     */
+    private fun observeThermalStatus() {
+        scope.launch {
+            thermalMonitor.thermalStatus.collect { status ->
+                val prev = cachedThermalStatus
+                cachedThermalStatus = status
+                if (prev == status) return@collect
+                DebugLog.i("EnginePlayer") {
+                    "#803 thermal status update: $prev -> $status" +
+                        if (status >= ThermalMonitor.THERMAL_STATUS_MODERATE) {
+                            " — capping parallel synth to serial mode"
+                        } else if (prev >= ThermalMonitor.THERMAL_STATUS_MODERATE) {
+                            " — restoring user-configured concurrency"
+                        } else {
+                            ""
+                        }
+                }
+                // Only trigger a pipeline rebuild if the thermal status
+                // crosses the MODERATE boundary while playing. Rebuilds
+                // within the same thermal zone (e.g. SEVERE -> CRITICAL)
+                // are unnecessary — the cap is already at serial.
+                val crossedThreshold =
+                    (prev < ThermalMonitor.THERMAL_STATUS_MODERATE &&
+                        status >= ThermalMonitor.THERMAL_STATUS_MODERATE) ||
+                    (prev >= ThermalMonitor.THERMAL_STATUS_MODERATE &&
+                        status < ThermalMonitor.THERMAL_STATUS_MODERATE)
+                if (crossedThreshold && _observableState.value.isPlaying) {
+                    startPlaybackPipeline()
+                }
             }
         }
     }
@@ -2068,7 +2133,23 @@ class EnginePlayer @AssistedInject constructor(
         // the slider's 3000-chunk max — JP set the slider to 3000 to
         // probe the gap and got 1500 in practice. Lifted to 3000 so
         // the configured value reaches the queue verbatim.
-        val queueCapacity = cachedBufferChunks.coerceIn(2, 3000)
+        // Issue #803 — snapshot the thermal status for this pipeline.
+        val thermalStatus = cachedThermalStatus
+        val queueCapacity = run {
+            val base = cachedBufferChunks.coerceIn(2, 3000)
+            if (thermalStatus >= ThermalMonitor.THERMAL_STATUS_SEVERE) {
+                // Severe thermal pressure: halve queue depth to reduce
+                // memory + CPU headroom. Floor at 2 so the pipeline
+                // doesn't starve.
+                val capped = (base / 2).coerceAtLeast(2)
+                DebugLog.i("EnginePlayer") {
+                    "#803 thermal SEVERE+: queue depth $base -> $capped"
+                }
+                capped
+            } else {
+                base
+            }
+        }
         // Issue #135: snapshot the dict at construction time. The
         // capture is by-value (the dict is an immutable data class) so
         // a mid-chapter edit doesn't mutate the active pipeline's
@@ -2190,6 +2271,33 @@ class EnginePlayer @AssistedInject constructor(
             }
             else -> emptyList()
         }
+        // Issue #803 — thermal throttle: when the device is at
+        // THERMAL_STATUS_MODERATE or above, drop all secondaries so
+        // the pipeline runs in serial mode (single engine). The
+        // secondary engine instances stay alive in memory (they're
+        // expensive to construct) — we just don't hand them to the
+        // streaming source for this pipeline lifetime. When the
+        // thermal status drops below MODERATE, [observeThermalStatus]
+        // triggers a pipeline rebuild that passes the full set of
+        // secondaries again, restoring the user's configured
+        // concurrency without re-loading models.
+        val effectiveSecondaryHandles = if (
+            thermalStatus >= ThermalMonitor.THERMAL_STATUS_MODERATE &&
+            secondaryHandles.isNotEmpty()
+        ) {
+            DebugLog.i("EnginePlayer") {
+                "#803 thermal MODERATE+: dropping ${secondaryHandles.size} secondary " +
+                    "engine(s) — serial mode until thermal clears"
+            }
+            android.util.Log.i(
+                "EnginePlayer",
+                "#803 thermal throttle active (status=$thermalStatus): " +
+                    "parallel synth ${secondaryHandles.size + 1} -> 1 instance(s)",
+            )
+            emptyList()
+        } else {
+            secondaryHandles
+        }
         // PR-D (#86) — build the cache key for this (chapter, voice,
         // speed, pitch, dict) tuple. All five pieces of identity must
         // be known; if any is null we skip the cache write entirely
@@ -2308,7 +2416,7 @@ class EnginePlayer @AssistedInject constructor(
                 extraA11ySilenceMs = cachedA11yExtraSilenceMs,
                 queueCapacity = queueCapacity,
                 pronunciationDictApply = pronunciationDict::apply,
-                secondaryEngines = secondaryHandles,
+                secondaryEngines = effectiveSecondaryHandles,
             )
         }
         pcmSource = source

--- a/core-playback/src/main/kotlin/in/jphe/storyvox/playback/tts/EnginePlayer.kt
+++ b/core-playback/src/main/kotlin/in/jphe/storyvox/playback/tts/EnginePlayer.kt
@@ -211,6 +211,11 @@ class EnginePlayer @AssistedInject constructor(
      *  pipeline-construction time is overridden. Full concurrency is
      *  restored when the thermal status drops back below MODERATE. */
     private val thermalMonitor: ThermalMonitor,
+    /** Issue #801 — power-save monitor. Snapshot at pipeline-construction
+     *  time to lower producer thread priority and skip prerender triggers
+     *  when the device is in battery-saver mode. The consumer thread keeps
+     *  URGENT_AUDIO — audio glitches are worse than battery drain. */
+    private val powerSaveMonitor: `in`.jphe.storyvox.playback.PowerSaveMonitor,
 ) : SimpleBasePlayer(Looper.getMainLooper()) {
 
     @AssistedFactory
@@ -233,6 +238,16 @@ class EnginePlayer @AssistedInject constructor(
      *  [setPunctuationPauseMultiplier] rebuilds the pipeline if playing,
      *  so the new value takes effect on the next sentence boundary). */
     private var currentPunctuationPauseMultiplier: Float = 1f
+
+    /**
+     * Issue #801 — the thread priority the producer-side VoiceEngineHandle
+     * wrappers should use. In power-save mode the producer drops to
+     * THREAD_PRIORITY_BACKGROUND; normally it stays at URGENT_AUDIO for
+     * minimum inter-sentence jitter. Snapshotted per pipeline build.
+     */
+    private fun producerPriority(): Int =
+        if (powerSaveMonitor.isPowerSaveMode.value) AndroidProcess.THREAD_PRIORITY_BACKGROUND
+        else AndroidProcess.THREAD_PRIORITY_URGENT_AUDIO
 
     /** Engine type for the currently-loaded voice. Set in [loadAndPlay]
      *  after a successful model load; read by the producer in
@@ -2188,9 +2203,8 @@ class EnginePlayer @AssistedInject constructor(
                     override fun generateAudioPCM(
                         text: String, speed: Float, pitch: Float,
                     ): ByteArray? {
-                        AndroidProcess.setThreadPriority(
-                            AndroidProcess.THREAD_PRIORITY_URGENT_AUDIO,
-                        )
+                        // Issue #801 — respect power-save mode.
+                        AndroidProcess.setThreadPriority(producerPriority())
                         return eng.generateAudioPCM(text, speed, pitch)
                     }
                 }
@@ -2205,9 +2219,8 @@ class EnginePlayer @AssistedInject constructor(
                     override fun generateAudioPCM(
                         text: String, speed: Float, pitch: Float,
                     ): ByteArray? {
-                        AndroidProcess.setThreadPriority(
-                            AndroidProcess.THREAD_PRIORITY_URGENT_AUDIO,
-                        )
+                        // Issue #801 — respect power-save mode.
+                        AndroidProcess.setThreadPriority(producerPriority())
                         return eng.generateAudioPCM(text, speed, pitch)
                     }
                 }
@@ -2226,9 +2239,8 @@ class EnginePlayer @AssistedInject constructor(
                     override fun generateAudioPCM(
                         text: String, speed: Float, pitch: Float,
                     ): ByteArray? {
-                        AndroidProcess.setThreadPriority(
-                            AndroidProcess.THREAD_PRIORITY_URGENT_AUDIO,
-                        )
+                        // Issue #801 — respect power-save mode.
+                        AndroidProcess.setThreadPriority(producerPriority())
                         return eng.generateAudioPCM(text, speed, pitch)
                     }
                 }
@@ -2250,9 +2262,8 @@ class EnginePlayer @AssistedInject constructor(
                         override fun generateAudioPCM(
                             text: String, speed: Float, pitch: Float,
                         ): ByteArray? {
-                            AndroidProcess.setThreadPriority(
-                                AndroidProcess.THREAD_PRIORITY_URGENT_AUDIO,
-                            )
+                            // Issue #801 — respect power-save mode.
+                            AndroidProcess.setThreadPriority(producerPriority())
                             return azureVoiceEngine.synthesize(text, voiceName, speed, pitch)
                         }
                     }
@@ -2417,6 +2428,7 @@ class EnginePlayer @AssistedInject constructor(
                 queueCapacity = queueCapacity,
                 pronunciationDictApply = pronunciationDict::apply,
                 secondaryEngines = effectiveSecondaryHandles,
+                powerSaveMode = powerSaveMonitor.isPowerSaveMode.value,
             )
         }
         pcmSource = source
@@ -3165,7 +3177,8 @@ class EnginePlayer @AssistedInject constructor(
                 }.takeIf { it > 0 } ?: DEFAULT_SAMPLE_RATE
 
                 override fun generateAudioPCM(text: String, speed: Float, pitch: Float): ByteArray? {
-                    AndroidProcess.setThreadPriority(AndroidProcess.THREAD_PRIORITY_URGENT_AUDIO)
+                    // Issue #801 — respect power-save mode on the producer thread.
+                    AndroidProcess.setThreadPriority(producerPriority())
                     return when (engineType) {
                         is EngineType.Kokoro -> KokoroEngine.getInstance()
                             .generateAudioPCM(text, speed, pitch)
@@ -3205,7 +3218,8 @@ class EnginePlayer @AssistedInject constructor(
             override fun generateAudioPCM(
                 text: String, speed: Float, pitch: Float,
             ): ByteArray? {
-                AndroidProcess.setThreadPriority(AndroidProcess.THREAD_PRIORITY_URGENT_AUDIO)
+                // Issue #801 — respect power-save mode on the producer thread.
+                AndroidProcess.setThreadPriority(producerPriority())
                 val engine = systemTtsEngine ?: return null
                 return engine.generateAudioPCMBlocking(text, speed, pitch)
             }
@@ -3219,7 +3233,8 @@ class EnginePlayer @AssistedInject constructor(
                 .takeIf { it > 0 } ?: DEFAULT_SAMPLE_RATE
 
             override fun generateAudioPCM(text: String, speed: Float, pitch: Float): ByteArray? {
-                AndroidProcess.setThreadPriority(AndroidProcess.THREAD_PRIORITY_URGENT_AUDIO)
+                // Issue #801 — respect power-save mode on the producer thread.
+                AndroidProcess.setThreadPriority(producerPriority())
                 return azureVoiceEngine.synthesize(text, engineType.voiceName, speed, pitch)
             }
         }
@@ -4866,6 +4881,9 @@ class EnginePlayer @AssistedInject constructor(
             // benefits from the same inter-sentence breathing room).
             extraA11ySilenceMs = cachedA11yExtraSilenceMs,
             queueCapacity = cachedBufferChunks.coerceIn(2, 3000),
+            // Issue #801 — recap producer also lowers priority in
+            // power-save mode.
+            powerSaveMode = powerSaveMonitor.isPowerSaveMode.value,
             pronunciationDictApply = cachedPronunciationDict::apply,
         )
         recapPcmSource = source

--- a/core-playback/src/main/kotlin/in/jphe/storyvox/playback/tts/source/EngineStreamingSource.kt
+++ b/core-playback/src/main/kotlin/in/jphe/storyvox/playback/tts/source/EngineStreamingSource.kt
@@ -135,6 +135,21 @@ class EngineStreamingSource(
      * the same monotonic stream of sentence indices either way.
      */
     private val secondaryEngines: List<VoiceEngineHandle> = emptyList(),
+    /**
+     * Issue #801 — when `true`, the producer thread(s) run at
+     * [AndroidProcess.THREAD_PRIORITY_BACKGROUND] instead of
+     * [AndroidProcess.THREAD_PRIORITY_URGENT_AUDIO]. The consumer
+     * thread is NOT affected — it keeps URGENT_AUDIO because audio
+     * glitches (underruns) are worse than battery drain. The net
+     * effect is that TTS synthesis yields more readily to other
+     * processes, reducing CPU contention while the OS is explicitly
+     * trying to conserve battery.
+     *
+     * Snapshot at construction time from [PowerSaveMonitor.isPowerSaveMode];
+     * a mid-pipeline power-save toggle takes effect on next pipeline
+     * rebuild (matches the other live-config knobs like speed/pitch).
+     */
+    private val powerSaveMode: Boolean = false,
 ) : PcmSource {
 
     /** SAM-style handle so tests can fake the engine without pulling the
@@ -144,6 +159,16 @@ class EngineStreamingSource(
         val sampleRate: Int
         fun generateAudioPCM(text: String, speed: Float, pitch: Float): ByteArray?
     }
+
+    /**
+     * Issue #801 — thread priority for the producer side. In power-save
+     * mode the producer drops to BACKGROUND so TTS synthesis yields to
+     * other processes; normally it stays at URGENT_AUDIO for minimum
+     * inter-sentence jitter.
+     */
+    private val producerThreadPriority: Int =
+        if (powerSaveMode) AndroidProcess.THREAD_PRIORITY_BACKGROUND
+        else AndroidProcess.THREAD_PRIORITY_URGENT_AUDIO
 
     override val sampleRate: Int = engine.sampleRate
 
@@ -624,10 +649,12 @@ class EngineStreamingSource(
         // pool guarantees this thread is dedicated; calls into the
         // engine don't suspend (they're synchronized JNI calls), so
         // the priority sticks for the worker's lifetime.
+        //
+        // Issue #801 — in power-save mode, use BACKGROUND priority
+        // instead of URGENT_AUDIO so parallel workers yield to other
+        // processes while the OS is conserving battery.
         runCatching {
-            AndroidProcess.setThreadPriority(
-                AndroidProcess.THREAD_PRIORITY_URGENT_AUDIO,
-            )
+            AndroidProcess.setThreadPriority(producerThreadPriority)
         }
         try {
             for (i in jobChan) {
@@ -669,10 +696,12 @@ class EngineStreamingSource(
         // single-threaded; coroutine suspends resume on the same OS
         // thread so the priority survives the engineMutex.withLock
         // and queue.put suspension points.
+        //
+        // Issue #801 — in power-save mode, use BACKGROUND priority
+        // instead of URGENT_AUDIO so TTS synthesis yields to other
+        // processes while the OS is conserving battery.
         runCatching {
-            AndroidProcess.setThreadPriority(
-                AndroidProcess.THREAD_PRIORITY_URGENT_AUDIO,
-            )
+            AndroidProcess.setThreadPriority(producerThreadPriority)
         }
         try {
             for (i in fromIndex until sentences.size) {

--- a/core-playback/src/test/kotlin/in/jphe/storyvox/playback/cache/PrerenderTriggersTest.kt
+++ b/core-playback/src/test/kotlin/in/jphe/storyvox/playback/cache/PrerenderTriggersTest.kt
@@ -13,6 +13,7 @@ import `in`.jphe.storyvox.data.repository.playback.RecentItem
 import `in`.jphe.storyvox.data.repository.playback.SavedPosition
 import `in`.jphe.storyvox.data.source.model.ChapterContent
 import `in`.jphe.storyvox.data.source.model.ChapterInfo
+import `in`.jphe.storyvox.playback.PowerSaveMonitor
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.asStateFlow
@@ -23,6 +24,7 @@ import org.junit.Assert.assertTrue
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.robolectric.RobolectricTestRunner
+import org.robolectric.RuntimeEnvironment
 import org.robolectric.annotation.Config
 
 /**
@@ -176,6 +178,13 @@ class PrerenderTriggersTest {
         override suspend fun recent(limit: Int): List<RecentItem> = emptyList()
     }
 
+    /** Issue #801 — power-save monitor routed through Robolectric's
+     *  application context. Default state is OFF so existing tests
+     *  preserve their pre-#801 behavior. */
+    private val powerSaveMonitor: PowerSaveMonitor by lazy {
+        PowerSaveMonitor(RuntimeEnvironment.getApplication())
+    }
+
     private fun chapter(num: Int, fictionPrefix: String) = ChapterInfo(
         id = "$fictionPrefix-c$num",
         sourceChapterId = "src-$num",
@@ -189,7 +198,7 @@ class PrerenderTriggersTest {
         // Issue #558 — DEFAULT_PRERENDER_CHAPTERS is 5 (up from 3); fiction
         // has 7 chapters so the slice is non-trivial.
         val repo = FakeChapterRepo(mapOf("f1" to (1..7).map { chapter(it, "f1") }))
-        val triggers = PrerenderTriggers(scheduler, repo, FakeModeConfig(full = false), FakePositionRepo(), FakePrerenderCount())
+        val triggers = PrerenderTriggers(scheduler, repo, FakeModeConfig(full = false), FakePositionRepo(), FakePrerenderCount(), powerSaveMonitor)
 
         triggers.onLibraryAdded("f1")
 
@@ -208,7 +217,7 @@ class PrerenderTriggersTest {
     fun `onLibraryAdded enqueues all chapters when fullPrerender on`() = runBlocking {
         val scheduler = RecordingScheduler()
         val repo = FakeChapterRepo(mapOf("f1" to (1..5).map { chapter(it, "f1") }))
-        val triggers = PrerenderTriggers(scheduler, repo, FakeModeConfig(full = true), FakePositionRepo(), FakePrerenderCount())
+        val triggers = PrerenderTriggers(scheduler, repo, FakeModeConfig(full = true), FakePositionRepo(), FakePrerenderCount(), powerSaveMonitor)
 
         triggers.onLibraryAdded("f1")
 
@@ -225,7 +234,7 @@ class PrerenderTriggersTest {
         // Fiction with only 2 chapters; default limit is 3 but we shouldn't
         // try to schedule beyond what exists.
         val repo = FakeChapterRepo(mapOf("f1" to (1..2).map { chapter(it, "f1") }))
-        val triggers = PrerenderTriggers(scheduler, repo, FakeModeConfig(full = false), FakePositionRepo(), FakePrerenderCount())
+        val triggers = PrerenderTriggers(scheduler, repo, FakeModeConfig(full = false), FakePositionRepo(), FakePrerenderCount(), powerSaveMonitor)
 
         triggers.onLibraryAdded("f1")
 
@@ -236,7 +245,7 @@ class PrerenderTriggersTest {
     fun `onLibraryAdded with empty chapter list is a no-op`() = runBlocking {
         val scheduler = RecordingScheduler()
         val repo = FakeChapterRepo(emptyMap())
-        val triggers = PrerenderTriggers(scheduler, repo, FakeModeConfig(full = false), FakePositionRepo(), FakePrerenderCount())
+        val triggers = PrerenderTriggers(scheduler, repo, FakeModeConfig(full = false), FakePositionRepo(), FakePrerenderCount(), powerSaveMonitor)
 
         triggers.onLibraryAdded("f1")
 
@@ -252,6 +261,7 @@ class PrerenderTriggersTest {
             FakeModeConfig(),
             FakePositionRepo(),
             FakePrerenderCount(),
+            powerSaveMonitor,
         )
 
         triggers.onLibraryRemoved("f1")
@@ -277,7 +287,7 @@ class PrerenderTriggersTest {
                     coverUrl = null,
                 ) else null
         }
-        val triggers = PrerenderTriggers(scheduler, repo, FakeModeConfig(), FakePositionRepo(), FakePrerenderCount())
+        val triggers = PrerenderTriggers(scheduler, repo, FakeModeConfig(), FakePositionRepo(), FakePrerenderCount(), powerSaveMonitor)
 
         // Just-completed = c1 → next = c2 → next-next = c3 → schedule c3.
         triggers.onChapterCompleted("f1-c1")
@@ -291,7 +301,7 @@ class PrerenderTriggersTest {
         val scheduler = RecordingScheduler()
         // f1 has 3 chapters; completing c2 → next is c3 → next-next is null.
         val repo = FakeChapterRepo(mapOf("f1" to (1..3).map { chapter(it, "f1") }))
-        val triggers = PrerenderTriggers(scheduler, repo, FakeModeConfig(), FakePositionRepo(), FakePrerenderCount())
+        val triggers = PrerenderTriggers(scheduler, repo, FakeModeConfig(), FakePositionRepo(), FakePrerenderCount(), powerSaveMonitor)
 
         triggers.onChapterCompleted("f1-c2")
 
@@ -302,7 +312,7 @@ class PrerenderTriggersTest {
     fun `onChapterCompleted at last chapter is a no-op`() = runBlocking {
         val scheduler = RecordingScheduler()
         val repo = FakeChapterRepo(mapOf("f1" to (1..3).map { chapter(it, "f1") }))
-        val triggers = PrerenderTriggers(scheduler, repo, FakeModeConfig(), FakePositionRepo(), FakePrerenderCount())
+        val triggers = PrerenderTriggers(scheduler, repo, FakeModeConfig(), FakePositionRepo(), FakePrerenderCount(), powerSaveMonitor)
 
         triggers.onChapterCompleted("f1-c3")
 
@@ -318,7 +328,7 @@ class PrerenderTriggersTest {
                 "f2" to (1..4).map { chapter(it, "f2") },
             ),
         )
-        val triggers = PrerenderTriggers(scheduler, repo, FakeModeConfig(), FakePositionRepo(), FakePrerenderCount())
+        val triggers = PrerenderTriggers(scheduler, repo, FakeModeConfig(), FakePositionRepo(), FakePrerenderCount(), powerSaveMonitor)
 
         triggers.onFullPrerenderEnabled(listOf("f1", "f2"))
 
@@ -350,7 +360,7 @@ class PrerenderTriggersTest {
                 ),
             ),
         )
-        val triggers = PrerenderTriggers(scheduler, repo, FakeModeConfig(full = false), positions, FakePrerenderCount())
+        val triggers = PrerenderTriggers(scheduler, repo, FakeModeConfig(full = false), positions, FakePrerenderCount(), powerSaveMonitor)
 
         triggers.onLibraryAdded("f1")
 
@@ -367,7 +377,7 @@ class PrerenderTriggersTest {
         val repo = FakeChapterRepo(mapOf("f1" to (1..10).map { chapter(it, "f1") }))
         // First-time add, no prior position. Should match the legacy
         // pre-#557 behavior — pre-render from the start.
-        val triggers = PrerenderTriggers(scheduler, repo, FakeModeConfig(full = false), FakePositionRepo(), FakePrerenderCount())
+        val triggers = PrerenderTriggers(scheduler, repo, FakeModeConfig(full = false), FakePositionRepo(), FakePrerenderCount(), powerSaveMonitor)
 
         triggers.onLibraryAdded("f1")
 
@@ -392,7 +402,7 @@ class PrerenderTriggersTest {
                 ),
             ),
         )
-        val triggers = PrerenderTriggers(scheduler, repo, FakeModeConfig(full = false), positions, FakePrerenderCount())
+        val triggers = PrerenderTriggers(scheduler, repo, FakeModeConfig(full = false), positions, FakePrerenderCount(), powerSaveMonitor)
 
         triggers.onLibraryAdded("f1")
 
@@ -422,7 +432,7 @@ class PrerenderTriggersTest {
                 ),
             ),
         )
-        val triggers = PrerenderTriggers(scheduler, repo, FakeModeConfig(full = false), positions, FakePrerenderCount())
+        val triggers = PrerenderTriggers(scheduler, repo, FakeModeConfig(full = false), positions, FakePrerenderCount(), powerSaveMonitor)
 
         triggers.onLibraryAdded("f1")
 
@@ -438,7 +448,7 @@ class PrerenderTriggersTest {
     fun `onChapterOpened queues body downloads for next BODY_PREFETCH_LOOKAHEAD chapters`() = runBlocking {
         val scheduler = RecordingScheduler()
         val repo = FakeChapterRepo(mapOf("f1" to (1..10).map { chapter(it, "f1") }))
-        val triggers = PrerenderTriggers(scheduler, repo, FakeModeConfig(full = false), FakePositionRepo(), FakePrerenderCount())
+        val triggers = PrerenderTriggers(scheduler, repo, FakeModeConfig(full = false), FakePositionRepo(), FakePrerenderCount(), powerSaveMonitor)
 
         // User just opened chapter 4 — prefetch should pull chapters 5, 6, 7.
         triggers.onChapterOpened("f1", "f1-c4")
@@ -467,7 +477,7 @@ class PrerenderTriggersTest {
         // 5-chapter fiction; user just opened chapter 3 → only c4, c5
         // exist downstream, so the prefetch should cap at 2.
         val repo = FakeChapterRepo(mapOf("f1" to (1..5).map { chapter(it, "f1") }))
-        val triggers = PrerenderTriggers(scheduler, repo, FakeModeConfig(full = false), FakePositionRepo(), FakePrerenderCount())
+        val triggers = PrerenderTriggers(scheduler, repo, FakeModeConfig(full = false), FakePositionRepo(), FakePrerenderCount(), powerSaveMonitor)
 
         triggers.onChapterOpened("f1", "f1-c3")
 
@@ -481,7 +491,7 @@ class PrerenderTriggersTest {
     fun `onChapterOpened at last chapter is a no-op`() = runBlocking {
         val scheduler = RecordingScheduler()
         val repo = FakeChapterRepo(mapOf("f1" to (1..3).map { chapter(it, "f1") }))
-        val triggers = PrerenderTriggers(scheduler, repo, FakeModeConfig(full = false), FakePositionRepo(), FakePrerenderCount())
+        val triggers = PrerenderTriggers(scheduler, repo, FakeModeConfig(full = false), FakePositionRepo(), FakePrerenderCount(), powerSaveMonitor)
 
         triggers.onChapterOpened("f1", "f1-c3")
 
@@ -502,7 +512,7 @@ class PrerenderTriggersTest {
         val repo = object : FakeChapterRepo(mapOf("f1" to (1..6).map { chapter(it, "f1") })) {
             override suspend fun getChapter(id: String): PlaybackChapter? = null
         }
-        val triggers = PrerenderTriggers(scheduler, repo, FakeModeConfig(full = false), FakePositionRepo(), FakePrerenderCount())
+        val triggers = PrerenderTriggers(scheduler, repo, FakeModeConfig(full = false), FakePositionRepo(), FakePrerenderCount(), powerSaveMonitor)
 
         triggers.onChapterOpened("f1", "f1-c1")
 
@@ -530,7 +540,7 @@ class PrerenderTriggersTest {
                     ),
                 ),
             )
-            val triggers = PrerenderTriggers(scheduler, repo, FakeModeConfig(full = true), positions, FakePrerenderCount())
+            val triggers = PrerenderTriggers(scheduler, repo, FakeModeConfig(full = true), positions, FakePrerenderCount(), powerSaveMonitor)
 
             triggers.onLibraryAdded("f1")
 
@@ -540,4 +550,83 @@ class PrerenderTriggersTest {
                 scheduler.scheduled.map { it.second },
             )
         }
+
+    // ─── Issue #801 — power-save mode suppression ───────────────────
+
+    @Test
+    fun `onLibraryAdded skips scheduling when power save mode is on`() = runBlocking {
+        val scheduler = RecordingScheduler()
+        val repo = FakeChapterRepo(mapOf("f1" to (1..7).map { chapter(it, "f1") }))
+        // Set power-save mode ON via Robolectric's PowerManager shadow.
+        val context = RuntimeEnvironment.getApplication()
+        val pm = context.getSystemService(android.content.Context.POWER_SERVICE)
+            as android.os.PowerManager
+        org.robolectric.Shadows.shadowOf(pm).setIsPowerSaveMode(true)
+        val psm = PowerSaveMonitor(context)
+        val triggers = PrerenderTriggers(
+            scheduler, repo, FakeModeConfig(full = false),
+            FakePositionRepo(), FakePrerenderCount(), psm,
+        )
+
+        triggers.onLibraryAdded("f1")
+
+        assertTrue(
+            "no renders scheduled when power save mode is on",
+            scheduler.scheduled.isEmpty(),
+        )
+    }
+
+    @Test
+    fun `onChapterCompleted skips scheduling when power save mode is on`() = runBlocking {
+        val scheduler = RecordingScheduler()
+        val repo = object : FakeChapterRepo(
+            mapOf("f1" to (1..5).map { chapter(it, "f1") }),
+        ) {
+            override suspend fun getChapter(id: String): PlaybackChapter? =
+                if (id == "f1-c3") PlaybackChapter(
+                    id = "f1-c3", fictionId = "f1", text = "body",
+                    title = "Chapter 3", bookTitle = "F1", coverUrl = null,
+                ) else null
+        }
+        val context = RuntimeEnvironment.getApplication()
+        val pm = context.getSystemService(android.content.Context.POWER_SERVICE)
+            as android.os.PowerManager
+        org.robolectric.Shadows.shadowOf(pm).setIsPowerSaveMode(true)
+        val psm = PowerSaveMonitor(context)
+        val triggers = PrerenderTriggers(
+            scheduler, repo, FakeModeConfig(),
+            FakePositionRepo(), FakePrerenderCount(), psm,
+        )
+
+        triggers.onChapterCompleted("f1-c1")
+
+        assertTrue(
+            "no renders scheduled when power save mode is on",
+            scheduler.scheduled.isEmpty(),
+        )
+    }
+
+    @Test
+    fun `onFullPrerenderEnabled skips scheduling when power save mode is on`() = runBlocking {
+        val scheduler = RecordingScheduler()
+        val repo = FakeChapterRepo(
+            mapOf("f1" to (1..3).map { chapter(it, "f1") }),
+        )
+        val context = RuntimeEnvironment.getApplication()
+        val pm = context.getSystemService(android.content.Context.POWER_SERVICE)
+            as android.os.PowerManager
+        org.robolectric.Shadows.shadowOf(pm).setIsPowerSaveMode(true)
+        val psm = PowerSaveMonitor(context)
+        val triggers = PrerenderTriggers(
+            scheduler, repo, FakeModeConfig(),
+            FakePositionRepo(), FakePrerenderCount(), psm,
+        )
+
+        triggers.onFullPrerenderEnabled(listOf("f1"))
+
+        assertTrue(
+            "no renders scheduled when power save mode is on",
+            scheduler.scheduled.isEmpty(),
+        )
+    }
 }

--- a/feature/src/main/kotlin/in/jphe/storyvox/feature/api/UiContracts.kt
+++ b/feature/src/main/kotlin/in/jphe/storyvox/feature/api/UiContracts.kt
@@ -447,6 +447,18 @@ interface PlaybackControllerUi {
         get() = kotlinx.coroutines.flow.emptyFlow()
 
     /**
+     * Issue #805 — typed engine state for error surfacing. The reader UI
+     * subscribes to this to show distinct error banners for auth failures,
+     * network errors, throttling, etc. — replacing the generic "something
+     * went wrong" treatment with actionable recovery actions.
+     *
+     * Default emits [EngineState.Idle] forever so test fakes that don't
+     * care about error surfaces stay slim.
+     */
+    val engineState: Flow<`in`.jphe.storyvox.playback.EngineState>
+        get() = kotlinx.coroutines.flow.flowOf(`in`.jphe.storyvox.playback.EngineState.Idle)
+
+    /**
      * "Why are we waiting?" diagnostic. Forwarded straight from
      * [in.jphe.storyvox.playback.PlaybackController.waitReason]. Null when
      * audio is genuinely flowing; non-null with a typed

--- a/feature/src/main/kotlin/in/jphe/storyvox/feature/library/LibraryScreen.kt
+++ b/feature/src/main/kotlin/in/jphe/storyvox/feature/library/LibraryScreen.kt
@@ -70,6 +70,14 @@ import `in`.jphe.storyvox.ui.component.MagicTitleBar
 import `in`.jphe.storyvox.ui.component.cascadeReveal
 import `in`.jphe.storyvox.ui.theme.LocalSpacing
 import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.text.KeyboardActions
+import androidx.compose.foundation.text.KeyboardOptions
+import androidx.compose.material.icons.filled.Clear
+import androidx.compose.material.icons.filled.Search
+import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.OutlinedTextFieldDefaults
+import androidx.compose.ui.platform.LocalFocusManager
+import androidx.compose.ui.text.input.ImeAction
 import androidx.compose.ui.text.style.TextAlign
 
 @OptIn(ExperimentalMaterial3Api::class, ExperimentalFoundationApi::class)
@@ -311,6 +319,18 @@ fun LibraryScreen(
 
             when (state.tab) {
                 LibraryTab.Library -> Column(modifier = Modifier.fillMaxSize().padding(top = spacing.md)) {
+                    // Issue #785 — search bar above the chip/sort row. Filters
+                    // the library grid by title or author as the user types
+                    // (debounced at 300ms in the ViewModel). Works in
+                    // combination with the shelf chip filter.
+                    LibrarySearchBar(
+                        query = state.searchQuery,
+                        onQueryChange = viewModel::onSearchQueryChange,
+                        onClear = viewModel::clearSearch,
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .padding(horizontal = spacing.md),
+                    )
                     // #116 — chip strip above the grid (and above the
                     // Resume card) so it's always reachable regardless of
                     // scroll. #438 collapsed the old `Reading` tab into a
@@ -604,6 +624,102 @@ private fun ResumeCard(entry: ContinueListeningEntry, onResume: () -> Unit) {
     }
 }
 
+/**
+ * Issue #785 — search bar for the Library tab. A compact
+ * [OutlinedTextField] with a leading search icon and a trailing clear
+ * button (visible only when the query is non-empty). Single-line,
+ * IME action "search" dismisses the keyboard without losing focus so
+ * the user can type, glance at results, and keep typing. Material 3
+ * surface-container tones + brass primary for the focused border so
+ * it slots into Library Nocturne's colour palette.
+ */
+@Composable
+private fun LibrarySearchBar(
+    query: String,
+    onQueryChange: (String) -> Unit,
+    onClear: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    val focusManager = LocalFocusManager.current
+    OutlinedTextField(
+        value = query,
+        onValueChange = onQueryChange,
+        modifier = modifier,
+        placeholder = {
+            Text(
+                stringResource(R.string.library_search_placeholder),
+                style = MaterialTheme.typography.bodyMedium,
+            )
+        },
+        leadingIcon = {
+            Icon(
+                imageVector = Icons.Filled.Search,
+                contentDescription = null,
+                tint = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
+        },
+        trailingIcon = if (query.isNotEmpty()) {
+            {
+                androidx.compose.material3.IconButton(onClick = onClear) {
+                    Icon(
+                        imageVector = Icons.Filled.Clear,
+                        contentDescription = stringResource(R.string.library_search_clear_cd),
+                        tint = MaterialTheme.colorScheme.onSurfaceVariant,
+                    )
+                }
+            }
+        } else null,
+        singleLine = true,
+        keyboardOptions = KeyboardOptions(imeAction = ImeAction.Search),
+        keyboardActions = KeyboardActions(onSearch = { focusManager.clearFocus() }),
+        shape = MaterialTheme.shapes.large,
+        colors = OutlinedTextFieldDefaults.colors(
+            focusedBorderColor = MaterialTheme.colorScheme.primary,
+            unfocusedBorderColor = MaterialTheme.colorScheme.outlineVariant,
+            focusedContainerColor = MaterialTheme.colorScheme.surfaceContainerHigh,
+            unfocusedContainerColor = MaterialTheme.colorScheme.surfaceContainerHigh,
+        ),
+        textStyle = MaterialTheme.typography.bodyMedium,
+    )
+}
+
+/**
+ * Issue #785 — empty state shown when a search query matches no
+ * fictions. Same brass-realm rhythm as [EmptyLibrary] and [EmptyShelf]
+ * but worded for the search-miss case so the user knows the library
+ * is not empty — just that nothing matched.
+ */
+@Composable
+private fun EmptySearchResults() {
+    val spacing = LocalSpacing.current
+    Column(
+        modifier = Modifier.fillMaxSize().padding(spacing.lg),
+        horizontalAlignment = Alignment.CenterHorizontally,
+        verticalArrangement = Arrangement.Center,
+    ) {
+        Icon(
+            imageVector = Icons.Filled.Search,
+            contentDescription = null,
+            modifier = Modifier.size(64.dp),
+            tint = MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.38f),
+        )
+        Spacer(Modifier.height(spacing.lg))
+        Text(
+            stringResource(R.string.library_search_no_results_title),
+            style = MaterialTheme.typography.titleMedium,
+            color = MaterialTheme.colorScheme.primary,
+            textAlign = TextAlign.Center,
+        )
+        Spacer(Modifier.height(spacing.xs))
+        Text(
+            stringResource(R.string.library_search_no_results_body),
+            style = MaterialTheme.typography.bodyMedium,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+            textAlign = TextAlign.Center,
+        )
+    }
+}
+
 @Composable
 private fun EmptyLibrary() {
     val spacing = LocalSpacing.current
@@ -751,6 +867,14 @@ private fun LibraryGridBody(
 ) {
     val spacing = LocalSpacing.current
     val isEmpty = !state.isLoading && dedupedFictions.isEmpty() && state.resume == null
+    // Issue #785 — distinguish "search found nothing" from "library is
+    // actually empty". When a search query is active and the list is
+    // empty, show a search-specific empty state rather than the library-
+    // wide or shelf-specific ones.
+    if (!state.isLoading && dedupedFictions.isEmpty() && state.searchQuery.isNotBlank()) {
+        EmptySearchResults()
+        return
+    }
     if (isEmpty) {
         when (val f = state.filter) {
             ShelfFilter.All -> {

--- a/feature/src/main/kotlin/in/jphe/storyvox/feature/library/LibraryViewModel.kt
+++ b/feature/src/main/kotlin/in/jphe/storyvox/feature/library/LibraryViewModel.kt
@@ -21,12 +21,14 @@ import `in`.jphe.storyvox.feature.api.PlaybackControllerUi
 import `in`.jphe.storyvox.feature.api.UiAddByUrlResult
 import `in`.jphe.storyvox.feature.api.UiRouteCandidate
 import javax.inject.Inject
+import kotlinx.coroutines.FlowPreview
 import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.combine
+import kotlinx.coroutines.flow.debounce
 import kotlinx.coroutines.flow.flatMapLatest
 import kotlinx.coroutines.flow.receiveAsFlow
 import kotlinx.coroutines.flow.stateIn
@@ -128,6 +130,8 @@ data class LibraryUiState(
     val filter: ShelfFilter = ShelfFilter.All,
     /** Issue #793 — current Library "All" shelf sort mode. */
     val sortMode: LibrarySortMode = LibrarySortMode.DEFAULT,
+    /** Issue #785 — current search query text (empty = no search active). */
+    val searchQuery: String = "",
     val isLoading: Boolean = true,
 )
 
@@ -187,7 +191,7 @@ sealed interface AddByUrlSheetState {
 }
 
 @HiltViewModel
-@OptIn(kotlinx.coroutines.ExperimentalCoroutinesApi::class)
+@OptIn(kotlinx.coroutines.ExperimentalCoroutinesApi::class, FlowPreview::class)
 class LibraryViewModel @Inject constructor(
     fictionRepo: FictionRepository,
     private val positionRepo: PlaybackPositionRepository,
@@ -222,6 +226,22 @@ class LibraryViewModel @Inject constructor(
 
     private val _manageShelves = MutableStateFlow<ManageShelvesSheetState>(ManageShelvesSheetState.Hidden)
     val manageShelvesState: StateFlow<ManageShelvesSheetState> = _manageShelves.asStateFlow()
+
+    /**
+     * Issue #785 — raw search query text from the search bar. Debounced
+     * to [_debouncedSearch] at 300ms so rapid keystrokes don't trigger
+     * a refilter on every character.
+     */
+    private val _searchQuery = MutableStateFlow("")
+
+    /**
+     * Issue #785 — debounced search query. 300ms is long enough to
+     * swallow burst-typing but short enough that the list feels
+     * responsive once the user pauses. The initial empty-string value
+     * emits immediately (no delay for the no-search cold start).
+     */
+    private val _debouncedSearch = _searchQuery.debounce(300L)
+        .stateIn(viewModelScope, SharingStarted.WhileSubscribed(5_000), "")
 
     /**
      * The fiction list flow swaps between the full library and a
@@ -284,16 +304,20 @@ class LibraryViewModel @Inject constructor(
         positionRepo.observeMostRecentContinueListening(),
         historyRepo.observeAll(),
         tabSnapshot,
-    ) { library, resume, history, snap ->
+        _debouncedSearch,
+    ) { library, resume, history, snap, query ->
+        val sorted = sortLibrary(library, snap.sortMode)
+        val filtered = filterBySearch(sorted, query)
         LibraryUiState(
             resume = resume,
-            fictions = sortLibrary(library, snap.sortMode),
+            fictions = filtered,
             history = history,
             inbox = snap.inboxEvents,
             inboxUnreadCount = snap.inboxUnreadCount,
             tab = snap.tab,
             filter = snap.filter,
             sortMode = snap.sortMode,
+            searchQuery = query,
             isLoading = false,
         )
     }.stateIn(viewModelScope, SharingStarted.WhileSubscribed(5_000), LibraryUiState())
@@ -365,6 +389,18 @@ class LibraryViewModel @Inject constructor(
     /** Dropdown menu pick — persisted via [LibrarySortStore]. */
     fun selectSortMode(mode: LibrarySortMode) {
         viewModelScope.launch { sortStore.set(mode) }
+    }
+
+    // ─── search (#785) ─────────────────────────────────────────────────────
+
+    /** Issue #785 — update the search query as the user types. */
+    fun onSearchQueryChange(query: String) {
+        _searchQuery.value = query
+    }
+
+    /** Issue #785 — clear the search bar. */
+    fun clearSearch() {
+        _searchQuery.value = ""
     }
 
     // ─── manage-shelves bottom sheet (#116) ───────────────────────────────
@@ -652,6 +688,26 @@ internal fun sortLibrary(
             .thenBy { it.title.lowercase() }
             .thenBy { it.id },
     )
+}
+
+/**
+ * Issue #785 — client-side search filter. Case-insensitive substring
+ * match against fiction title and author. Returns the full list when
+ * the query is blank so an empty search bar shows everything.
+ *
+ * Exposed `internal` so unit tests can exercise the matching without
+ * spinning up the full ViewModel graph.
+ */
+internal fun filterBySearch(
+    fictions: List<FictionSummary>,
+    query: String,
+): List<FictionSummary> {
+    if (query.isBlank()) return fictions
+    val terms = query.trim().lowercase()
+    return fictions.filter { fiction ->
+        fiction.title.lowercase().contains(terms) ||
+            fiction.author.lowercase().contains(terms)
+    }
 }
 
 internal fun isLikelyAddByUrl(raw: String): Boolean {

--- a/feature/src/main/kotlin/in/jphe/storyvox/feature/reader/AudiobookView.kt
+++ b/feature/src/main/kotlin/in/jphe/storyvox/feature/reader/AudiobookView.kt
@@ -202,6 +202,16 @@ fun AudiobookView(
     waitReason: `in`.jphe.storyvox.playback.diagnostics.WaitReason? = null,
     chapters: List<`in`.jphe.storyvox.feature.api.UiChapter> = emptyList(),
     onPlayChapter: (chapterId: String) -> Unit = {},
+    /**
+     * Issue #805 — typed playback error from [EngineState.Error]. Non-null
+     * when the engine is in an error state; surfaces a dismissible banner
+     * with error-type-specific icon, message, and recovery action.
+     */
+    playbackError: `in`.jphe.storyvox.playback.EngineState.Error? = null,
+    /** Issue #805 — retry the failed playback (calls play() on the controller). */
+    onRetryPlayback: () -> Unit = {},
+    /** Issue #805 — dismiss the error banner without retrying. */
+    onDismissPlaybackError: () -> Unit = {},
     modifier: Modifier = Modifier,
 ) {
     val spacing = LocalSpacing.current
@@ -404,6 +414,18 @@ fun AudiobookView(
                 onRetry = onPlayPause,
                 onOpenSettings = onOpenSettings,
             )
+            // Issue #805 — typed playback error banner. Surfaces above the
+            // cover when the engine is in an error state, with a subtype-
+            // specific icon, message, and recovery action. Dismissible via
+            // the X button; auto-clears when the engine leaves error state.
+            if (playbackError != null) {
+                PlaybackErrorBanner(
+                    error = playbackError,
+                    onRetry = onRetryPlayback,
+                    onDismiss = onDismissPlaybackError,
+                    modifier = Modifier.fillMaxWidth(),
+                )
+            }
             // While the chapter body + voice model are still loading we don't
             // have a cover URL or chapter title yet — show the brass arcane
             // sigil placeholder instead of a "?" thumb. As soon as state

--- a/feature/src/main/kotlin/in/jphe/storyvox/feature/reader/HybridReaderScreen.kt
+++ b/feature/src/main/kotlin/in/jphe/storyvox/feature/reader/HybridReaderScreen.kt
@@ -308,6 +308,11 @@ fun HybridReaderScreen(
                 waitReason = state.waitReason,
                 chapters = chapters,
                 onPlayChapter = viewModel::playChapter,
+                // Issue #805 — typed playback error banner with
+                // subtype-specific icon + message + recovery action.
+                playbackError = state.playbackError,
+                onRetryPlayback = viewModel::retryLoading,
+                onDismissPlaybackError = viewModel::dismissPlaybackError,
             )
         },
         readerContent = {

--- a/feature/src/main/kotlin/in/jphe/storyvox/feature/reader/PlaybackErrorBanner.kt
+++ b/feature/src/main/kotlin/in/jphe/storyvox/feature/reader/PlaybackErrorBanner.kt
@@ -1,0 +1,272 @@
+package `in`.jphe.storyvox.feature.reader
+
+import androidx.compose.animation.AnimatedVisibility
+import androidx.compose.animation.expandVertically
+import androidx.compose.animation.shrinkVertically
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Close
+import androidx.compose.material.icons.outlined.CloudOff
+import androidx.compose.material.icons.outlined.ErrorOutline
+import androidx.compose.material.icons.outlined.Lock
+import androidx.compose.material.icons.outlined.Schedule
+import androidx.compose.material.icons.outlined.WifiOff
+import androidx.compose.material3.Card
+import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.semantics.LiveRegionMode
+import androidx.compose.ui.semantics.liveRegion
+import androidx.compose.ui.semantics.semantics
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import `in`.jphe.storyvox.feature.R
+import `in`.jphe.storyvox.playback.EngineState
+import `in`.jphe.storyvox.ui.component.BrassButton
+import `in`.jphe.storyvox.ui.component.BrassButtonVariant
+import `in`.jphe.storyvox.ui.theme.LibraryNocturneTheme
+import `in`.jphe.storyvox.ui.theme.LocalSpacing
+
+/**
+ * Issue #805 — typed playback-error banner. Displays above the player
+ * controls when [EngineState.Error] is active, with an icon, message,
+ * and recovery action tailored to the error subtype.
+ *
+ * The banner is dismissible (X button) and auto-clears when the engine
+ * leaves the error state (e.g. after a successful retry). The error
+ * message from [EngineState.Error.message] is already render-ready
+ * (produced by PlaybackController.errorMessage) and includes subtype-
+ * specific copy:
+ *  - Auth failure (Azure key rejected) -> lock icon, no retry
+ *  - Network unavailable -> wifi-off icon, retry
+ *  - Throttled (429) -> schedule icon, retry
+ *  - Server error (5xx) -> cloud-off icon, retry
+ *  - Engine unavailable -> error icon, no retry (install needed)
+ *  - TTS speak failed -> error icon, retry
+ *  - Chapter fetch failed -> error icon, retry
+ *
+ * The [onRetry] callback fires playback.play() which clears the engine
+ * error and re-attempts. The [onDismiss] callback records the dismissed
+ * message so the ViewModel suppresses re-display of the same error.
+ */
+@Composable
+fun PlaybackErrorBanner(
+    error: EngineState.Error,
+    onRetry: () -> Unit,
+    onDismiss: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    val spacing = LocalSpacing.current
+    val classification = classifyError(error.message)
+
+    AnimatedVisibility(
+        visible = true,
+        enter = expandVertically(),
+        exit = shrinkVertically(),
+    ) {
+        Card(
+            modifier = modifier
+                .fillMaxWidth()
+                .padding(horizontal = spacing.md, vertical = spacing.xs)
+                .semantics { liveRegion = LiveRegionMode.Polite },
+            colors = CardDefaults.cardColors(
+                containerColor = MaterialTheme.colorScheme.errorContainer,
+                contentColor = MaterialTheme.colorScheme.onErrorContainer,
+            ),
+            shape = MaterialTheme.shapes.medium,
+        ) {
+            Row(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(start = spacing.md, top = spacing.sm, bottom = spacing.sm, end = spacing.xs),
+                verticalAlignment = Alignment.CenterVertically,
+            ) {
+                Icon(
+                    imageVector = classification.icon,
+                    contentDescription = null,
+                    modifier = Modifier.size(24.dp),
+                    tint = MaterialTheme.colorScheme.error,
+                )
+                Spacer(Modifier.width(spacing.sm))
+                Column(
+                    modifier = Modifier.weight(1f),
+                    verticalArrangement = Arrangement.spacedBy(2.dp),
+                ) {
+                    Text(
+                        text = classification.title,
+                        style = MaterialTheme.typography.titleSmall,
+                        maxLines = 1,
+                        overflow = TextOverflow.Ellipsis,
+                    )
+                    Text(
+                        text = error.message,
+                        style = MaterialTheme.typography.bodySmall,
+                        color = MaterialTheme.colorScheme.onErrorContainer.copy(alpha = 0.85f),
+                        maxLines = 2,
+                        overflow = TextOverflow.Ellipsis,
+                    )
+                }
+                if (error.retryable) {
+                    BrassButton(
+                        label = stringResource(R.string.reader_error_retry),
+                        onClick = onRetry,
+                        variant = BrassButtonVariant.Text,
+                    )
+                }
+                IconButton(
+                    onClick = onDismiss,
+                    modifier = Modifier.size(36.dp),
+                ) {
+                    Icon(
+                        imageVector = Icons.Filled.Close,
+                        contentDescription = stringResource(R.string.reader_error_dismiss),
+                        modifier = Modifier.size(18.dp),
+                    )
+                }
+            }
+        }
+    }
+}
+
+// ---- Error classification ----
+
+/**
+ * Local classification of the render-ready error message back into UX
+ * categories. We pattern-match on the message strings produced by
+ * PlaybackController.errorMessage() rather than leaking PlaybackError
+ * subtypes into the feature layer. The strings are stable (we own them)
+ * and the fallback is always the generic treatment.
+ */
+private data class ErrorClassification(
+    val icon: ImageVector,
+    val title: String,
+)
+
+@Composable
+private fun classifyError(message: String): ErrorClassification {
+    val lower = message.lowercase()
+    return when {
+        // Azure auth — "Azure subscription key was rejected"
+        lower.contains("subscription key") || lower.contains("key was rejected") ->
+            ErrorClassification(
+                icon = Icons.Outlined.Lock,
+                title = stringResource(R.string.reader_error_title_auth),
+            )
+        // Network unavailable — Azure or general network errors
+        lower.contains("network") || lower.contains("connection") ||
+        lower.contains("dns") || lower.contains("timeout") ->
+            ErrorClassification(
+                icon = Icons.Outlined.WifiOff,
+                title = stringResource(R.string.reader_error_title_network),
+            )
+        // Throttled — "quota", "rate", "too many"
+        lower.contains("quota") || lower.contains("throttl") ||
+        lower.contains("rate limit") || lower.contains("too many") ->
+            ErrorClassification(
+                icon = Icons.Outlined.Schedule,
+                title = stringResource(R.string.reader_error_title_throttled),
+            )
+        // Azure server error / outage
+        lower.contains("server") || lower.contains("azure") ||
+        lower.contains("outage") || lower.contains("5xx") ->
+            ErrorClassification(
+                icon = Icons.Outlined.CloudOff,
+                title = stringResource(R.string.reader_error_title_server),
+            )
+        // Voice engine not installed
+        lower.contains("engine") || lower.contains("installed") ->
+            ErrorClassification(
+                icon = Icons.Outlined.ErrorOutline,
+                title = stringResource(R.string.reader_error_title_engine),
+            )
+        // Generic fallback
+        else -> ErrorClassification(
+            icon = Icons.Outlined.ErrorOutline,
+            title = stringResource(R.string.reader_error_title_generic),
+        )
+    }
+}
+
+// region Previews
+
+@Preview(name = "Auth error (dark)", widthDp = 360)
+@Composable
+private fun PreviewAuthDark() = LibraryNocturneTheme(darkTheme = true) {
+    PlaybackErrorBanner(
+        error = EngineState.Error(
+            "Azure subscription key was rejected. Paste a fresh key in Settings → Cloud voices.",
+            retryable = false,
+        ),
+        onRetry = {},
+        onDismiss = {},
+    )
+}
+
+@Preview(name = "Network error (dark)", widthDp = 360)
+@Composable
+private fun PreviewNetworkDark() = LibraryNocturneTheme(darkTheme = true) {
+    PlaybackErrorBanner(
+        error = EngineState.Error(
+            "Network required for cloud voices.",
+            retryable = true,
+        ),
+        onRetry = {},
+        onDismiss = {},
+    )
+}
+
+@Preview(name = "Throttled (light)", widthDp = 360)
+@Composable
+private fun PreviewThrottledLight() = LibraryNocturneTheme(darkTheme = false) {
+    PlaybackErrorBanner(
+        error = EngineState.Error(
+            "Azure quota exceeded. Switch to a local voice or wait for monthly reset.",
+            retryable = true,
+        ),
+        onRetry = {},
+        onDismiss = {},
+    )
+}
+
+@Preview(name = "Server error (dark)", widthDp = 360)
+@Composable
+private fun PreviewServerDark() = LibraryNocturneTheme(darkTheme = true) {
+    PlaybackErrorBanner(
+        error = EngineState.Error(
+            "Azure server error (503). Try again in a moment.",
+            retryable = true,
+        ),
+        onRetry = {},
+        onDismiss = {},
+    )
+}
+
+@Preview(name = "Generic error (dark)", widthDp = 360)
+@Composable
+private fun PreviewGenericDark() = LibraryNocturneTheme(darkTheme = true) {
+    PlaybackErrorBanner(
+        error = EngineState.Error(
+            "Voice failed mid-utterance (code 3). Tap to retry.",
+            retryable = true,
+        ),
+        onRetry = {},
+        onDismiss = {},
+    )
+}
+
+// endregion

--- a/feature/src/main/kotlin/in/jphe/storyvox/feature/reader/ReaderView.kt
+++ b/feature/src/main/kotlin/in/jphe/storyvox/feature/reader/ReaderView.kt
@@ -1,5 +1,10 @@
 package `in`.jphe.storyvox.feature.reader
 
+import androidx.compose.animation.AnimatedVisibility
+import androidx.compose.animation.fadeIn
+import androidx.compose.animation.fadeOut
+import androidx.compose.animation.slideInVertically
+import androidx.compose.animation.slideOutVertically
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
@@ -14,22 +19,26 @@ import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Pause
 import androidx.compose.material.icons.filled.PlayArrow
+import androidx.compose.material.icons.filled.VerticalAlignCenter
 import androidx.compose.material.icons.outlined.AutoAwesome
 import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.FilledIconButton
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButtonDefaults
 import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.SmallFloatingActionButton
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.derivedStateOf
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableFloatStateOf
 import androidx.compose.runtime.mutableLongStateOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.setValue
 import androidx.compose.runtime.snapshotFlow
 import androidx.compose.ui.Alignment
@@ -45,6 +54,7 @@ import `in`.jphe.storyvox.feature.api.UiPlaybackState
 import `in`.jphe.storyvox.ui.component.SentenceHighlight
 import `in`.jphe.storyvox.ui.theme.LocalSpacing
 import kotlin.math.roundToInt
+import kotlinx.coroutines.launch
 
 /**
  * Manual-scroll grace window. While the user is dragging or for this many millis after,
@@ -120,6 +130,38 @@ fun ReaderTextView(
         scroll.animateScrollTo(targetY)
     }
 
+    // Issue #919 — "scroll to current sentence" FAB. Derived state tracks
+    // whether the brass-underlined sentence is visible in the viewport.
+    // When the user scrolls away (sentence not visible AND playback active),
+    // a small FAB appears; tapping it resets the manual-scroll grace and
+    // smooth-scrolls to the active sentence. Auto-hides when the sentence
+    // is already in view. The 80px margin gives a comfortable buffer so the
+    // FAB doesn't flicker when the sentence is right at the edge.
+    val scope = rememberCoroutineScope()
+    val sentenceOutOfView by remember {
+        derivedStateOf {
+            val layout = textLayout ?: return@derivedStateOf false
+            val start = state.sentenceStart
+            val end = state.sentenceEnd
+            if (end <= start) return@derivedStateOf false
+            if (chapterText.isEmpty()) return@derivedStateOf false
+            if (start !in 0..chapterText.length) return@derivedStateOf false
+            if (viewportHeightPx <= 0f) return@derivedStateOf false
+
+            val safeStart = start.coerceIn(0, (chapterText.length - 1).coerceAtLeast(0))
+            val line = layout.getLineForOffset(safeStart)
+            val lineTop = bodyTopPx + layout.getLineTop(line)
+            val lineBottom = bodyTopPx + layout.getLineBottom(line)
+            val scrollY = scroll.value.toFloat()
+            // Sentence is "out of view" when its top line is above the viewport
+            // (scrolled past) or below it (not scrolled to yet). An 80px margin
+            // avoids flicker when the sentence is at the edge.
+            val margin = 80f
+            lineBottom < scrollY + margin || lineTop > scrollY + viewportHeightPx - margin
+        }
+    }
+    val showScrollFab = sentenceOutOfView && state.isPlaying
+
     Box(modifier = modifier.fillMaxSize().onSizeChanged { viewportHeightPx = it.height.toFloat() }) {
         Column(
             modifier = Modifier
@@ -151,6 +193,49 @@ fun ReaderTextView(
                         onLayout = { layout -> textLayout = layout },
                     )
                 }
+            }
+        }
+
+        // Issue #919 — floating "scroll to current sentence" button.
+        // Positioned above the bottom transport bar (bottom = 104dp to
+        // clear the bar + spacing), end-aligned. Uses Material 3
+        // SmallFloatingActionButton with the app's primary/onPrimary
+        // colors. Enter = fade + slide up; exit = fade + slide down —
+        // deliberate and warm, matching the Library Nocturne motion.
+        AnimatedVisibility(
+            visible = showScrollFab,
+            modifier = Modifier
+                .align(Alignment.BottomEnd)
+                .padding(end = spacing.md, bottom = 104.dp),
+            enter = fadeIn() + slideInVertically { it / 2 },
+            exit = fadeOut() + slideOutVertically { it / 2 },
+        ) {
+            SmallFloatingActionButton(
+                onClick = {
+                    // Reset grace so auto-scroll doesn't fight the user.
+                    lastManualScrollAt = 0L
+                    val layout = textLayout ?: return@SmallFloatingActionButton
+                    if (chapterText.isEmpty()) return@SmallFloatingActionButton
+                    val start = state.sentenceStart
+                    val end = state.sentenceEnd
+                    if (end <= start) return@SmallFloatingActionButton
+                    if (start !in 0..chapterText.length) return@SmallFloatingActionButton
+
+                    val safeStart = start.coerceIn(0, (chapterText.length - 1).coerceAtLeast(0))
+                    val line = layout.getLineForOffset(safeStart)
+                    val lineTopWithinText = layout.getLineTop(line)
+                    val targetY = (bodyTopPx + lineTopWithinText - viewportHeightPx * HIGHLIGHT_VIEWPORT_FRACTION)
+                        .roundToInt()
+                        .coerceIn(0, scroll.maxValue.coerceAtLeast(0))
+                    scope.launch { scroll.animateScrollTo(targetY) }
+                },
+                containerColor = MaterialTheme.colorScheme.primary,
+                contentColor = MaterialTheme.colorScheme.onPrimary,
+            ) {
+                Icon(
+                    imageVector = Icons.Filled.VerticalAlignCenter,
+                    contentDescription = "Scroll to current sentence",
+                )
             }
         }
 

--- a/feature/src/main/kotlin/in/jphe/storyvox/feature/reader/ReaderViewModel.kt
+++ b/feature/src/main/kotlin/in/jphe/storyvox/feature/reader/ReaderViewModel.kt
@@ -83,6 +83,13 @@ data class ReaderUiState(
      * "Restart from beginning" doesn't immediately re-trip the modal.
      */
     val bookFinished: Boolean = false,
+    /**
+     * Issue #805 — typed playback error from [EngineState.Error]. Non-null
+     * when the engine is in an error state; the reader surfaces a
+     * dismissible banner with an error-type-specific message and
+     * recovery action (retry, sign-in, etc.). Null when no error.
+     */
+    val playbackError: `in`.jphe.storyvox.playback.EngineState.Error? = null,
 )
 
 /** Issue #278 — the player loading screen used to be a silent eternity:
@@ -273,6 +280,13 @@ class ReaderViewModel @Inject constructor(
     private val _confettiTrigger = Channel<Unit>(capacity = Channel.CONFLATED)
     val confettiTrigger: Flow<Unit> = _confettiTrigger.receiveAsFlow()
 
+    /** Issue #805 — user-dismissed error message. When the user dismisses
+     *  the playback error banner, we record the error message here. The
+     *  combine below suppresses the banner when the current error message
+     *  matches the dismissed one. A new/different error re-arms the banner
+     *  automatically (different message = cleared latch). */
+    private val _dismissedErrorMessage = MutableStateFlow<String?>(null)
+
     /** Issue #677 — end-of-book latch backing the
      *  [ReaderUiState.bookFinished] projection. Engine-driven set in the
      *  [PlaybackUiEvent.BookFinished] arm of the player-events collector;
@@ -340,6 +354,14 @@ class ReaderViewModel @Inject constructor(
         _bookFinished.value = false
     }
 
+    /** Issue #805 — user swiped away / tapped X on the playback error
+     *  banner. Records the dismissed message so the combine suppresses
+     *  the same error. A new/different error re-arms the banner. */
+    fun dismissPlaybackError() {
+        val current = uiState.value.playbackError
+        _dismissedErrorMessage.value = current?.message
+    }
+
     val uiState: StateFlow<ReaderUiState> = combine(
         playback.state,
         playback.chapterText,
@@ -361,6 +383,15 @@ class ReaderViewModel @Inject constructor(
         // Issue #677 — end-of-book latch; HybridReaderScreen mounts the
         // BookFinishedOverlay when this flips true.
         _bookFinished,
+        // Issue #805 — typed engine state for error surfacing. The reader
+        // projects EngineState.Error onto ReaderUiState.playbackError so
+        // AudiobookView can render a typed error banner with specific
+        // messages and recovery actions per error subtype.
+        playback.engineState,
+        // Issue #805 — dismiss latch for the error banner. When the user
+        // swipes away the banner, we record the message; same message =
+        // suppressed; new/different message = re-armed.
+        _dismissedErrorMessage,
     ) { values ->
         @Suppress("UNCHECKED_CAST")
         val state = values[0] as UiPlaybackState
@@ -374,6 +405,9 @@ class ReaderViewModel @Inject constructor(
         @Suppress("UNCHECKED_CAST")
         val waitReason = values[5] as? `in`.jphe.storyvox.playback.diagnostics.WaitReason
         val bookFinished = values[6] as Boolean
+        val engineState = values[7] as `in`.jphe.storyvox.playback.EngineState
+        val dismissedMsg = values[8] as? String
+        val error = engineState as? `in`.jphe.storyvox.playback.EngineState.Error
         ReaderUiState(
             playback = state,
             chapterText = text,
@@ -383,6 +417,9 @@ class ReaderViewModel @Inject constructor(
             pitchInterpolationHighQuality = settingsSnapshot.pitchInterpolationHighQuality,
             waitReason = waitReason,
             bookFinished = bookFinished,
+            // Suppress the banner when the user already dismissed this
+            // exact error message; a new/different error re-arms it.
+            playbackError = if (error != null && error.message != dismissedMsg) error else null,
         )
     }.stateIn(viewModelScope, SharingStarted.WhileSubscribed(5_000), ReaderUiState())
 

--- a/feature/src/main/kotlin/in/jphe/storyvox/feature/voicelibrary/VoiceLibraryScreen.kt
+++ b/feature/src/main/kotlin/in/jphe/storyvox/feature/voicelibrary/VoiceLibraryScreen.kt
@@ -15,6 +15,7 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.LazyRow
 import androidx.compose.foundation.lazy.items
@@ -24,9 +25,15 @@ import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Star
 import androidx.compose.material.icons.outlined.Check
+import androidx.compose.material.icons.outlined.Cloud
 import androidx.compose.material.icons.outlined.ExpandLess
 import androidx.compose.material.icons.outlined.ExpandMore
+import androidx.compose.material.icons.outlined.Mic
+import androidx.compose.material.icons.outlined.MusicNote
+import androidx.compose.material.icons.outlined.Pets
+import androidx.compose.material.icons.outlined.RecordVoiceOver
 import androidx.compose.material.icons.outlined.Settings
+import androidx.compose.material.icons.outlined.SmartToy
 import androidx.compose.material.icons.outlined.StarBorder
 import androidx.compose.foundation.horizontalScroll
 import androidx.compose.foundation.layout.PaddingValues as ComposePaddingValues
@@ -36,6 +43,7 @@ import androidx.compose.material.icons.outlined.Search
 import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.FilterChip
 import androidx.compose.material3.FilterChipDefaults
+import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
@@ -53,6 +61,11 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
+import androidx.compose.ui.draw.drawBehind
+import androidx.compose.ui.geometry.CornerRadius
+import androidx.compose.ui.graphics.Brush
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.semantics.Role
 import androidx.compose.ui.semantics.clearAndSetSemantics
@@ -62,7 +75,9 @@ import androidx.compose.ui.semantics.role
 import androidx.compose.ui.semantics.selected
 import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import `in`.jphe.storyvox.feature.R
@@ -302,12 +317,24 @@ fun VoiceLibraryScreen(
             }
 
             if (filteredIsEmpty) {
-                Box(
+                // #912 — polished filter-empty state with a decorative
+                // icon and softer copy. The centered layout with a muted
+                // search icon reads as "nothing found" without feeling
+                // like an error.
+                Column(
                     modifier = Modifier
                         .fillMaxSize()
-                        .padding(spacing.md),
-                    contentAlignment = Alignment.Center,
+                        .padding(spacing.lg),
+                    horizontalAlignment = Alignment.CenterHorizontally,
+                    verticalArrangement = Arrangement.Center,
                 ) {
+                    Icon(
+                        imageVector = Icons.Outlined.RecordVoiceOver,
+                        contentDescription = null,
+                        tint = MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.35f),
+                        modifier = Modifier.size(56.dp),
+                    )
+                    Spacer(modifier = Modifier.height(spacing.md))
                     // Empty-state text reflects whichever filter
                     // dimension the user is actually engaging — query
                     // text wins when present (it's the more specific
@@ -316,16 +343,24 @@ fun VoiceLibraryScreen(
                     // chips being active.
                     val emptyLabel = when {
                         rawQuery.trim().isNotEmpty() ->
-                            "No voices match \"${rawQuery.trim()}\"."
+                            "No voices match \"${rawQuery.trim()}\""
                         selectedLanguage != null ->
-                            "No voices match \"$selectedLanguage\"."
+                            "No voices match \"$selectedLanguage\""
                         else ->
-                            "No voices match the current filters."
+                            "No voices match the current filters"
                     }
                     Text(
                         emptyLabel,
-                        style = MaterialTheme.typography.bodyMedium,
+                        style = MaterialTheme.typography.titleSmall,
                         color = MaterialTheme.colorScheme.onSurfaceVariant,
+                        textAlign = TextAlign.Center,
+                    )
+                    Spacer(modifier = Modifier.height(spacing.xs))
+                    Text(
+                        "Try adjusting your search or filters.",
+                        style = MaterialTheme.typography.bodySmall,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.7f),
+                        textAlign = TextAlign.Center,
                     )
                 }
                 return@Column
@@ -402,12 +437,22 @@ fun VoiceLibraryScreen(
             item { SectionHeader("Installed", count = installedTotal) }
             if (installedTotal == 0) {
                 item {
-                    Text(
-                        "No voices installed yet. Pick one below to get started.",
-                        style = MaterialTheme.typography.bodyMedium,
-                        color = MaterialTheme.colorScheme.onSurfaceVariant,
-                        modifier = Modifier.padding(vertical = spacing.sm),
-                    )
+                    // #912 — friendlier empty-installed nudge with a
+                    // subtle container background so it reads as a
+                    // callout rather than orphaned body text.
+                    Box(
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .clip(RoundedCornerShape(8.dp))
+                            .background(MaterialTheme.colorScheme.surfaceContainerLow)
+                            .padding(spacing.sm),
+                    ) {
+                        Text(
+                            "No voices installed yet — pick one below to get started.",
+                            style = MaterialTheme.typography.bodyMedium,
+                            color = MaterialTheme.colorScheme.onSurfaceVariant,
+                        )
+                    }
                 }
             } else {
                 installedByEngine.forEach { (engine, tiers) ->
@@ -574,42 +619,71 @@ fun VoiceLibraryScreen(
  *  and the remaining 52 then activate instantly. Inference is heavier
  *  than Piper, so on modest hardware a small inter-sentence pause is
  *  expected. Heading off both UX surprises upfront. */
+/** #912 — polished Kokoro bundle note with a leading icon and more
+ *  structured layout. The brass border-left accent visually ties it to
+ *  the engine sub-header above while the icon + structured text makes
+ *  the two key points (shared bundle + inference cost) scannable. */
 @Composable
 private fun KokoroBundleNote() {
     val spacing = LocalSpacing.current
-    val outline = MaterialTheme.colorScheme.outlineVariant
-    Box(
+    val brass = MaterialTheme.colorScheme.primary
+    Row(
         modifier = Modifier
             .fillMaxWidth()
             .clip(RoundedCornerShape(8.dp))
             .background(MaterialTheme.colorScheme.surfaceContainerLow)
-            .border(1.dp, outline.copy(alpha = 0.5f), RoundedCornerShape(8.dp))
-            .padding(spacing.sm),
+            .drawBehind {
+                // Brass accent line on the leading edge.
+                drawRoundRect(
+                    color = brass.copy(alpha = 0.6f),
+                    size = androidx.compose.ui.geometry.Size(
+                        width = 3.dp.toPx(),
+                        height = size.height,
+                    ),
+                    cornerRadius = CornerRadius(2.dp.toPx()),
+                )
+            }
+            .padding(start = spacing.sm + 3.dp, end = spacing.sm, top = spacing.sm, bottom = spacing.sm),
+        horizontalArrangement = Arrangement.spacedBy(spacing.sm),
     ) {
-        Column(verticalArrangement = Arrangement.spacedBy(2.dp)) {
+        Icon(
+            imageVector = Icons.Outlined.SmartToy,
+            contentDescription = null,
+            tint = brass.copy(alpha = 0.7f),
+            modifier = Modifier
+                .size(20.dp)
+                .padding(top = 2.dp),
+        )
+        Column(verticalArrangement = Arrangement.spacedBy(spacing.xxs)) {
             Text(
-                "🌐 Kokoro voices share one bundle",
+                "Kokoro voices share one bundle",
                 style = MaterialTheme.typography.labelLarge,
-                color = MaterialTheme.colorScheme.primary,
+                color = brass,
                 fontWeight = FontWeight.SemiBold,
             )
             Text(
-                "All 53 Kokoro speakers (English, Spanish, French, Hindi, Italian, Japanese, Portuguese, Chinese) share one ~380 MB bundle (model + speakers + tokens). The first Kokoro voice you pick downloads it; every Kokoro voice after that activates instantly.",
+                "All 53 Kokoro speakers share a single ~380 MB bundle. The first voice you pick downloads it; every voice after that activates instantly.",
                 style = MaterialTheme.typography.bodySmall,
                 color = MaterialTheme.colorScheme.onSurfaceVariant,
             )
             Text(
-                "Kokoro inference is heavier than Piper — on modest hardware you may notice a small pause between sentences while the next chunk renders.",
+                "Kokoro inference is heavier than Piper — on modest hardware expect a brief pause between sentences.",
                 style = MaterialTheme.typography.bodySmall,
-                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                color = MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.8f),
             )
         }
     }
 }
 
+/** #912 — polished section header with a brass divider line and count
+ *  badge. The visual read order is: brass accent line → section label →
+ *  count badge. The line extends from the label's trailing edge to the
+ *  screen edge, creating a ruled-notebook aesthetic that fits the
+ *  literary/realm theme. */
 @Composable
 private fun SectionHeader(label: String, count: Int, dim: Boolean = false) {
     val color = if (dim) MaterialTheme.colorScheme.onSurfaceVariant else MaterialTheme.colorScheme.primary
+    val spacing = LocalSpacing.current
     // Issue #651 — TalkBack pre-fix focused this row but read nothing
     // (empty default contentDescription). Wrap the Row in a semantics
     // block that announces the section name + count as one phrase, and
@@ -618,30 +692,66 @@ private fun SectionHeader(label: String, count: Int, dim: Boolean = false) {
     // by Compose's default semantics, so we use [clearAndSetSemantics]
     // to consolidate them into a single TalkBack announcement instead
     // of three separate ones ("AVAILABLE", " · ", "204").
-    Row(
-        verticalAlignment = Alignment.CenterVertically,
-        modifier = Modifier.clearAndSetSemantics {
-            contentDescription = "$label section, $count voices"
-            role = Role.Image // Compose Material lacks Role.Header;
-            // Image is the closest neutral role that lets TalkBack
-            // read the contentDescription without claiming "Button"
-            // (no tap target) or "Tab" (not a tab). Custom roles
-            // require a CustomAccessibilityAction — overkill for a
-            // static header.
-        },
+    Column(
+        modifier = Modifier
+            .fillMaxWidth()
+            .clearAndSetSemantics {
+                contentDescription = "$label section, $count voices"
+                role = Role.Image // Compose Material lacks Role.Header;
+                // Image is the closest neutral role that lets TalkBack
+                // read the contentDescription without claiming "Button"
+                // (no tap target) or "Tab" (not a tab). Custom roles
+                // require a CustomAccessibilityAction — overkill for a
+                // static header.
+            },
     ) {
-        Text(
-            label.uppercase(),
-            style = MaterialTheme.typography.labelLarge,
-            color = color,
-            fontWeight = FontWeight.SemiBold,
-        )
-        Text(
-            "  ·  $count",
-            style = MaterialTheme.typography.labelMedium,
-            color = color.copy(alpha = 0.7f),
-        )
+        Row(
+            verticalAlignment = Alignment.CenterVertically,
+            modifier = Modifier.fillMaxWidth(),
+        ) {
+            Text(
+                label.uppercase(),
+                style = MaterialTheme.typography.titleSmall,
+                color = color,
+                fontWeight = FontWeight.Bold,
+                letterSpacing = 1.2.sp,
+            )
+            Spacer(modifier = Modifier.width(spacing.sm))
+            // Count badge — brass pill with the voice count.
+            Box(
+                modifier = Modifier
+                    .clip(RoundedCornerShape(50))
+                    .background(color.copy(alpha = 0.12f))
+                    .padding(horizontal = spacing.xs, vertical = 2.dp),
+                contentAlignment = Alignment.Center,
+            ) {
+                Text(
+                    "$count",
+                    style = MaterialTheme.typography.labelSmall,
+                    color = color,
+                    fontWeight = FontWeight.SemiBold,
+                )
+            }
+            Spacer(modifier = Modifier.width(spacing.sm))
+            // Ruled line extending to the trailing edge.
+            HorizontalDivider(
+                modifier = Modifier.weight(1f),
+                thickness = 1.dp,
+                color = color.copy(alpha = 0.25f),
+            )
+        }
     }
+}
+
+/** #912 — Engine icon for the sub-header. Each engine gets a distinctive
+ *  Material icon so the user can instantly identify the voice backend at
+ *  a glance — no need to parse the text label. */
+private fun engineIcon(engine: VoiceEngine): ImageVector = when (engine) {
+    VoiceEngine.SystemTts -> Icons.Outlined.RecordVoiceOver
+    VoiceEngine.Piper -> Icons.Outlined.MusicNote
+    VoiceEngine.Kokoro -> Icons.Outlined.Mic
+    VoiceEngine.Kitten -> Icons.Outlined.Pets
+    VoiceEngine.Azure -> Icons.Outlined.Cloud
 }
 
 /** Engine label + count rendered under a [SectionHeader] (Piper /
@@ -654,7 +764,10 @@ private fun SectionHeader(label: String, count: Int, dim: Boolean = false) {
  *  the trailing chevron flips between [Icons.Outlined.ExpandMore]
  *  (collapsed) and [Icons.Outlined.ExpandLess] (expanded). The
  *  chevron lives at the row's end via a `Spacer(weight = 1f)` so
- *  the label/count stay left-aligned even on wide screens. */
+ *  the label/count stay left-aligned even on wide screens.
+ *
+ *  #912 — added a leading engine icon + subtle container background so
+ *  engine sections read as distinct visual blocks. */
 @Composable
 private fun EngineSubHeader(
     engine: VoiceEngine,
@@ -668,6 +781,7 @@ private fun EngineSubHeader(
     } else {
         MaterialTheme.colorScheme.primary
     }
+    val spacing = LocalSpacing.current
     val label = when (engine) {
         // #676 — System TTS sub-header. "System TTS" is the
         // shortest accurate label — the family card subtitle
@@ -687,6 +801,12 @@ private fun EngineSubHeader(
         // emoji to know what's cloud vs local.
         VoiceEngine.Azure -> "Azure (Cloud)"
     }
+    val reducedMotion = LocalReducedMotion.current
+    val chevronRotation by animateFloatAsState(
+        targetValue = if (isCollapsed) 0f else 180f,
+        animationSpec = tween(durationMillis = if (reducedMotion) 0 else 200),
+        label = "engine-chevron-$label",
+    )
     // a11y (#481): engine sub-header expand/collapse — Role.Button with
     // an explicit click label so TalkBack reads "Expand <label>" /
     // "Collapse <label>" rather than the generic "double tap".
@@ -694,13 +814,22 @@ private fun EngineSubHeader(
         verticalAlignment = Alignment.CenterVertically,
         modifier = Modifier
             .fillMaxWidth()
+            .clip(RoundedCornerShape(8.dp))
+            .background(baseColor.copy(alpha = 0.06f))
             .clickable(
                 role = Role.Button,
                 onClickLabel = if (isCollapsed) "Expand $label" else "Collapse $label",
                 onClick = onToggle,
             )
-            .padding(top = 6.dp, bottom = 2.dp),
+            .padding(horizontal = spacing.sm, vertical = spacing.xs),
     ) {
+        Icon(
+            imageVector = engineIcon(engine),
+            contentDescription = null,
+            tint = baseColor.copy(alpha = 0.85f),
+            modifier = Modifier.size(18.dp),
+        )
+        Spacer(modifier = Modifier.width(spacing.xs))
         Text(
             label,
             style = MaterialTheme.typography.labelLarge,
@@ -714,17 +843,21 @@ private fun EngineSubHeader(
         )
         Spacer(modifier = Modifier.weight(1f))
         Icon(
-            imageVector = if (isCollapsed) Icons.Outlined.ExpandMore else Icons.Outlined.ExpandLess,
+            imageVector = Icons.Outlined.ExpandMore,
             contentDescription = if (isCollapsed) "Expand $label" else "Collapse $label",
             tint = baseColor.copy(alpha = 0.7f),
-            modifier = Modifier.size(20.dp),
+            modifier = Modifier
+                .size(20.dp)
+                .rotate(chevronRotation),
         )
     }
 }
 
-/** Tier label + count rendered under an [EngineSubHeader] (Studio /
- *  High / Medium / Low). Visually quieter than the engine sub-header so
- *  the Section → Engine grouping reads first; the tier label is a
+/** #912 — Tier label + count rendered under an [EngineSubHeader]
+ *  (Studio / High / Medium / Low). Each tier gets a small colored dot
+ *  that encodes quality at a glance — brass-gold for Studio, a calmer
+ *  tint for the lower tiers. Visually quieter than the engine sub-header
+ *  so the Section → Engine grouping reads first; the tier label is a
  *  refinement, not a peer. */
 @Composable
 private fun TierSubHeader(tier: QualityLevel, count: Int, dim: Boolean = false) {
@@ -733,18 +866,21 @@ private fun TierSubHeader(tier: QualityLevel, count: Int, dim: Boolean = false) 
     } else {
         MaterialTheme.colorScheme.onSurface
     }
-    val (label, accent) = tierDisplay(tier)
+    val spacing = LocalSpacing.current
+    val (label, _) = tierDisplay(tier)
+    val dotColor = tierDotColor(tier)
     Row(
         verticalAlignment = Alignment.CenterVertically,
-        modifier = Modifier.padding(top = 4.dp, bottom = 2.dp),
+        modifier = Modifier.padding(top = spacing.xs, bottom = 2.dp, start = spacing.xs),
     ) {
-        if (accent.isNotEmpty()) {
-            Text(
-                accent,
-                style = MaterialTheme.typography.labelMedium,
-            )
-            Spacer(modifier = Modifier.size(4.dp))
-        }
+        // Quality dot — small colored circle indicating the tier.
+        Box(
+            modifier = Modifier
+                .size(8.dp)
+                .clip(CircleShape)
+                .background(dotColor),
+        )
+        Spacer(modifier = Modifier.width(spacing.xs))
         Text(
             label,
             style = MaterialTheme.typography.labelMedium,
@@ -767,6 +903,17 @@ private fun tierDisplay(tier: QualityLevel): Pair<String, String> = when (tier) 
     QualityLevel.High -> "High" to ""
     QualityLevel.Medium -> "Medium" to ""
     QualityLevel.Low -> "Low" to ""
+}
+
+/** #912 — color for the quality-tier dot. Uses theme-relative colors so
+ *  both dark and light modes produce correct contrast. Studio gets the
+ *  primary brass; lower tiers dim progressively. */
+@Composable
+private fun tierDotColor(tier: QualityLevel): Color = when (tier) {
+    QualityLevel.Studio -> MaterialTheme.colorScheme.primary
+    QualityLevel.High -> MaterialTheme.colorScheme.primary.copy(alpha = 0.7f)
+    QualityLevel.Medium -> MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.6f)
+    QualityLevel.Low -> MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.4f)
 }
 
 @Composable
@@ -839,15 +986,39 @@ private fun VoiceRow(
         if (isActive) append(", currently active")
         if (isAvailable) append(", not yet downloaded")
     }
+    // #912 — active voice gets a subtle gradient border glow to stand
+    // out as the "current narrator". The gradient runs from primary at
+    // the top-start to a complementary brass-muted tone at the bottom-
+    // end, creating a warm metallic frame effect.
+    val activeBorderBrush = Brush.linearGradient(
+        colors = listOf(
+            brass.copy(alpha = 0.9f),
+            brass.copy(alpha = 0.4f),
+        ),
+    )
     Box(
         modifier = modifier
             .fillMaxWidth()
             .clip(RoundedCornerShape(12.dp))
             .background(containerColor)
-            .border(
-                width = if (isActive) 1.5.dp else 1.dp,
-                color = borderColor,
-                shape = RoundedCornerShape(12.dp),
+            .then(
+                if (isActive) {
+                    Modifier.drawBehind {
+                        drawRoundRect(
+                            brush = activeBorderBrush,
+                            cornerRadius = CornerRadius(12.dp.toPx()),
+                            style = androidx.compose.ui.graphics.drawscope.Stroke(
+                                width = 2.dp.toPx(),
+                            ),
+                        )
+                    }
+                } else {
+                    Modifier.border(
+                        width = 1.dp,
+                        color = borderColor,
+                        shape = RoundedCornerShape(12.dp),
+                    )
+                },
             )
             .combinedClickable(
                 onClick = onTap,
@@ -866,6 +1037,14 @@ private fun VoiceRow(
                 verticalAlignment = Alignment.CenterVertically,
                 horizontalArrangement = Arrangement.spacedBy(spacing.sm),
             ) {
+                // #912 — Voice avatar: a circular initial badge that
+                // gives each voice a distinctive visual identity. The
+                // background tint is derived from the engine type so
+                // the user can scan by engine color at a glance.
+                VoiceAvatar(
+                    voice = voice,
+                    isActive = isActive,
+                )
                 FavoriteToggle(
                     isFavorite = isFavorite,
                     onToggle = onToggleFavorite,
@@ -1127,29 +1306,90 @@ private fun FavoriteToggle(
     }
 }
 
+/** #912 — Voice avatar: a circular badge showing the voice's initial
+ *  letter on a tinted background. The tint is engine-derived so the
+ *  user can identify voice backends by color at a glance — warm brass
+ *  for Piper, a cooler purple for Kokoro, etc. The active voice gets
+ *  a brass border ring. */
+@Composable
+private fun VoiceAvatar(
+    voice: UiVoiceInfo,
+    isActive: Boolean,
+) {
+    val brass = MaterialTheme.colorScheme.primary
+    val avatarBg = engineAvatarColor(voice.engineType)
+    val initial = voice.displayName.firstOrNull()?.uppercaseChar() ?: '?'
+    Box(
+        modifier = Modifier
+            .size(36.dp)
+            .clip(CircleShape)
+            .background(avatarBg)
+            .then(
+                if (isActive) {
+                    Modifier.border(2.dp, brass, CircleShape)
+                } else {
+                    Modifier
+                },
+            ),
+        contentAlignment = Alignment.Center,
+    ) {
+        Text(
+            text = initial.toString(),
+            style = MaterialTheme.typography.titleSmall,
+            fontWeight = FontWeight.Bold,
+            color = Color.White,
+        )
+    }
+}
+
+/** #912 — Engine-derived avatar background color. Each engine type gets
+ *  a distinctive hue so the user can scan the list by engine at a
+ *  glance. Uses semi-transparent overlays on the theme's primary and
+ *  tertiary colors so both dark and light themes produce pleasant
+ *  contrast. */
+@Composable
+private fun engineAvatarColor(engineType: EngineType): Color = when (engineType) {
+    is EngineType.Piper -> MaterialTheme.colorScheme.primary.copy(alpha = 0.75f)
+    is EngineType.Kokoro -> MaterialTheme.colorScheme.tertiary.copy(alpha = 0.75f)
+    is EngineType.Kitten -> MaterialTheme.colorScheme.secondary.copy(alpha = 0.75f)
+    is EngineType.Azure -> MaterialTheme.colorScheme.primaryContainer.copy(alpha = 0.85f)
+    is EngineType.SystemTts -> MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.5f)
+}
+
+/** #912 — polished active chip with a gradient brass fill instead of
+ *  the flat alpha overlay. The gradient gives the chip a warm metallic
+ *  feel that matches the realm's brass vocabulary. */
 @Composable
 private fun ActiveChip() {
     val brass = MaterialTheme.colorScheme.primary
+    val onBrass = MaterialTheme.colorScheme.onPrimary
     Row(
         modifier = Modifier
             .clip(RoundedCornerShape(50))
-            .background(brass.copy(alpha = 0.18f))
-            .border(width = 1.dp, color = brass, shape = RoundedCornerShape(50))
-            .padding(horizontal = 8.dp, vertical = 2.dp),
+            .background(
+                Brush.horizontalGradient(
+                    colors = listOf(
+                        brass.copy(alpha = 0.85f),
+                        brass.copy(alpha = 0.65f),
+                    ),
+                ),
+            )
+            .padding(horizontal = 10.dp, vertical = 3.dp),
         verticalAlignment = Alignment.CenterVertically,
         horizontalArrangement = Arrangement.spacedBy(4.dp),
     ) {
         Icon(
             imageVector = Icons.Outlined.Check,
             contentDescription = null,
-            tint = brass,
+            tint = onBrass,
             modifier = Modifier.size(12.dp),
         )
         Text(
             "ACTIVE",
             style = MaterialTheme.typography.labelSmall,
-            color = brass,
-            fontWeight = FontWeight.SemiBold,
+            color = onBrass,
+            fontWeight = FontWeight.Bold,
+            letterSpacing = 0.5.sp,
         )
     }
 }
@@ -1222,6 +1462,9 @@ private fun DeleteConfirmDialog(
     )
 }
 
+/** #912 — enhanced loading state with a more literary/magical flavor
+ *  that fits the storyvox realm theme. The skeleton tile stays as the
+ *  visual anchor; the copy leans into the fantasy vocabulary. */
 @Composable
 private fun EmptyState(modifier: Modifier = Modifier) {
     val spacing = LocalSpacing.current
@@ -1239,15 +1482,17 @@ private fun EmptyState(modifier: Modifier = Modifier) {
         )
         Spacer(modifier = Modifier.height(spacing.lg))
         Text(
-            "Voices loading…",
+            "Summoning voices…",
             style = MaterialTheme.typography.titleMedium,
             color = MaterialTheme.colorScheme.primary,
+            fontWeight = FontWeight.SemiBold,
         )
         Spacer(modifier = Modifier.height(spacing.xs))
         Text(
-            "Catalog is being summoned. This shouldn't take more than a moment.",
+            "The voice catalog is being summoned from the archives. This will only take a moment.",
             style = MaterialTheme.typography.bodyMedium,
             color = MaterialTheme.colorScheme.onSurfaceVariant,
+            textAlign = TextAlign.Center,
         )
     }
 }

--- a/feature/src/main/res/values/strings.xml
+++ b/feature/src/main/res/values/strings.xml
@@ -247,6 +247,11 @@
     <string name="library_shelf_all">All</string>
     <string name="library_add_by_url_label">URL</string>
     <string name="library_add_by_url_placeholder">https://…</string>
+    <!-- Issue #785 — Library search bar. -->
+    <string name="library_search_placeholder">Search by title or author</string>
+    <string name="library_search_clear_cd">Clear search</string>
+    <string name="library_search_no_results_title">No matches</string>
+    <string name="library_search_no_results_body">Try a different search term or clear the search to see your full library.</string>
     <!-- Issue #793 — Library sort dropdown. -->
     <string name="library_sort_chip_cd">Sort library</string>
     <string name="library_sort_title">Title</string>

--- a/feature/src/main/res/values/strings.xml
+++ b/feature/src/main/res/values/strings.xml
@@ -221,6 +221,16 @@
     <string name="reader_chapters">Chapters</string>
     <string name="reader_couldnt_load_chapter">Couldn\'t load this chapter</string>
     <string name="reader_couldnt_load_message">The voice or chapter text is taking longer than expected. Try again, or pick a different voice — some take a moment to warm up.</string>
+
+    <!-- Issue #805 — typed playback error banner -->
+    <string name="reader_error_retry">Retry</string>
+    <string name="reader_error_dismiss">Dismiss error</string>
+    <string name="reader_error_title_auth">Sign in required</string>
+    <string name="reader_error_title_network">No connection</string>
+    <string name="reader_error_title_throttled">Too many requests</string>
+    <string name="reader_error_title_server">Server issue</string>
+    <string name="reader_error_title_engine">Voice not available</string>
+    <string name="reader_error_title_generic">Something went wrong</string>
     <string name="reader_sleep_step_by_sentence">Step by sentence</string>
     <string name="reader_sleep_timer">Sleep timer</string>
     <string name="reader_sleep_off">Off</string>


### PR DESCRIPTION
## Summary
- **#919** feat(reader): floating scroll-to-current-sentence FAB with smooth animation
- **#912** feat(ui): Voice Library polish — engine avatars, brass gradients, section headers, empty states
- **#785** feat(library): search bar with debounced filtering (title + author, combines with filter chips)
- **#803** feat(playback): thermal throttle — auto-reduce parallel-synth on THERMAL_STATUS_MODERATE+
- **#801** feat(playback): power save mode — pause prerender, lower producer thread priority
- **#805** feat(reader): typed PlaybackError banners — auth/network/throttle/engine with retry + dismiss

## Test plan
- [ ] CI build passes
- [ ] Reader FAB appears when scrolled away from current sentence, scrolls back on tap
- [ ] Voices page has engine avatars, brass active indicator, section headers
- [ ] Library search filters by title/author, works with chips
- [ ] Playback works normally (thermal/power-save features activate only under system conditions)
- [ ] Error banner shows when playback fails (simulate by toggling airplane mode mid-play)

🤖 Generated with [Claude Code](https://claude.com/claude-code)