### PR TITLE
fix(ui): browse + library polish (#938, #939, #940)

### DIFF
--- a/feature/src/main/kotlin/in/jphe/storyvox/feature/browse/BrowseViewModel.kt
+++ b/feature/src/main/kotlin/in/jphe/storyvox/feature/browse/BrowseViewModel.kt
@@ -393,7 +393,10 @@ class BrowseViewModel @Inject constructor(
                     // followed by any enabled sources not yet in the list
                     // (newly enabled since the last reorder).
                     val byId = enabledDescriptors.associateBy { it.id }
-                    val ordered = customOrder.mapNotNull { byId[it] }
+                    // #938 — dedupe customOrder before lookup: sync conflicts
+                    // or hand-edited JSON can land duplicate ids in the list,
+                    // which would otherwise render the same source card twice.
+                    val ordered = customOrder.distinct().mapNotNull { byId[it] }
                     val remaining = enabledDescriptors.filter { it.id !in customOrder }
                     ordered + remaining
                 } else {

--- a/feature/src/main/kotlin/in/jphe/storyvox/feature/library/LibraryScreen.kt
+++ b/feature/src/main/kotlin/in/jphe/storyvox/feature/library/LibraryScreen.kt
@@ -155,10 +155,10 @@ fun LibraryScreen(
     // Issue #828 — confirm-before-remove dialog state for the
     // "Remove from library" row on ManageShelvesSheet. Holds the
     // (fictionId, title) the sheet asked to remove; null = no dialog.
-    // Mirrors the FictionDetailScreen #169 pattern (ephemeral state at
-    // the screen level so the dialog dies on configuration change
-    // rather than surviving as a half-rendered modal).
-    var pendingRemoval by androidx.compose.runtime.remember {
+    // #939 — `rememberSaveable` so the dialog survives configuration
+    // changes (rotation, dark-mode flip). A `Pair<String, String>?`
+    // is Saveable via the default Bundle saver.
+    var pendingRemoval by androidx.compose.runtime.saveable.rememberSaveable {
         androidx.compose.runtime.mutableStateOf<Pair<String, String>?>(null)
     }
 

--- a/feature/src/main/kotlin/in/jphe/storyvox/feature/library/ManageShelvesSheet.kt
+++ b/feature/src/main/kotlin/in/jphe/storyvox/feature/library/ManageShelvesSheet.kt
@@ -107,13 +107,17 @@ fun ManageShelvesSheet(
             // colorScheme.error to signal destructiveness; host gates
             // the actual removal behind a confirm dialog.
             HorizontalDivider(modifier = Modifier.padding(vertical = spacing.sm))
+            // #940 — padding before clickable so the padded area is part of
+            // the tap target. The visible row (text + its vertical padding)
+            // should all respond to a tap; otherwise edge-of-row taps miss
+            // and the row falls short of the 48dp tap-target guideline.
             Row(
                 modifier = Modifier
                     .fillMaxWidth()
+                    .padding(vertical = spacing.sm)
                     .clickable(role = Role.Button) {
                         onRemoveRequest(state.fictionId, state.fictionTitle)
-                    }
-                    .padding(vertical = spacing.sm),
+                    },
                 verticalAlignment = Alignment.CenterVertically,
             ) {
                 Text(


### PR DESCRIPTION
Three small UI fixes from Gemini audit on 2026-05-27.

## #938 — browse carousel duplicate sources
`BrowseViewModel.kt:396` — `customOrder.mapNotNull { byId[it] }` would render the same source card twice if `customOrder` contained a duplicate id (sync conflict or hand-edited JSON). Now dedupes `customOrder` before lookup.

## #939 — pendingRemoval dialog lost on rotation
`LibraryScreen.kt:161` — the confirm-before-remove dialog used `remember`, so a rotation while the dialog was open silently dismissed it. Hoisted to `rememberSaveable`; `Pair<String, String>?` rides the default Bundle saver. Comment rewritten to match the new intent (the previous comment described the bug as intentional).

## #940 — ManageShelvesSheet remove-row tap target
`ManageShelvesSheet.kt:110` — `.padding()` was applied *after* `.clickable()`, so edge-of-row taps in the padded margin missed. Padding now sits inside the clickable so the visible row is fully tappable, meeting the 48dp guideline.

## Verification
- `./gradlew :feature:compileDebugKotlin` → BUILD SUCCESSFUL (only pre-existing deprecation warnings)
- `./gradlew :feature:testDebugUnitTest` → BUILD SUCCESSFUL

Closes #938, #939, #940.