### PR TITLE
fix(sync): harden response parsing + charset specification (#936, #937)

### DIFF
--- a/core-sync/src/main/kotlin/in/jphe/storyvox/sync/client/HttpInstantBackend.kt
+++ b/core-sync/src/main/kotlin/in/jphe/storyvox/sync/client/HttpInstantBackend.kt
@@ -11,7 +11,7 @@ import kotlinx.serialization.json.contentOrNull
 import kotlinx.serialization.json.jsonArray
 import kotlinx.serialization.json.jsonObject
 import kotlinx.serialization.json.jsonPrimitive
-import kotlinx.serialization.json.long
+import kotlinx.serialization.json.longOrNull
 import kotlinx.serialization.json.put
 
 /**
@@ -145,7 +145,12 @@ class HttpInstantBackend(
             ?.let { runCatching { it.jsonObject }.getOrNull() }
             ?: return@runCatching null
         val payload = row["payload"]?.let { it as? JsonPrimitive }?.contentOrNull
-        val updatedAt = row["updatedAt"]?.let { it as? JsonPrimitive }?.long
+        // `longOrNull` (not `.long`) — a proxy error page or a malformed
+        // server response can land here with `updatedAt` as a non-numeric
+        // string or JsonNull. `.long` throws in that case and crashes the
+        // sync round; treating it as "row not usable yet" lets the next
+        // round retry against a recovered server. See issue #936.
+        val updatedAt = row["updatedAt"]?.let { it as? JsonPrimitive }?.longOrNull
         if (payload != null && updatedAt != null) RowSnapshot(payload, updatedAt) else null
     }
 

--- a/core-sync/src/main/kotlin/in/jphe/storyvox/sync/domain/SecretsSyncer.kt
+++ b/core-sync/src/main/kotlin/in/jphe/storyvox/sync/domain/SecretsSyncer.kt
@@ -215,7 +215,7 @@ class SecretsSyncer @Inject constructor(
      *  same key. SHA-256 → first 16 bytes. */
     private fun deterministicSaltFor(user: SignedInUser): ByteArray {
         val digest = java.security.MessageDigest.getInstance("SHA-256")
-        return digest.digest(("storyvox-secrets:${user.userId}").toByteArray()).copyOf(16)
+        return digest.digest(("storyvox-secrets:${user.userId}").toByteArray(Charsets.UTF_8)).copyOf(16)
     }
 
     private fun rowId(user: SignedInUser) = SyncIds.rowUuid(DOMAIN, user.userId)

--- a/core-sync/src/test/kotlin/in/jphe/storyvox/sync/HttpInstantBackendTest.kt
+++ b/core-sync/src/test/kotlin/in/jphe/storyvox/sync/HttpInstantBackendTest.kt
@@ -121,6 +121,25 @@ class HttpInstantBackendTest {
         )
     }
 
+    @Test fun `fetch is robust against non-numeric updatedAt (issue 936)`() = runTest {
+        // Proxy error pages, partial responses, or schema drift can deliver
+        // `updatedAt` as a non-numeric string (or null). The old `.long`
+        // accessor threw NumberFormatException and crashed the sync round.
+        // The fix uses `.longOrNull` so a junk value gracefully degrades to
+        // "row not usable yet" — the next round will retry.
+        val transport = FakeTransport(mapOf(
+            "/admin/query" to TransportResult(
+                200,
+                """{"blobs":[{"id":"0e9a6111-40d8-3ef1-9fd1-fadfe3240618","payload":"hello","updatedAt":"<html>error</html>"}]}""",
+            ),
+        ))
+        val backend = HttpInstantBackend("test-app", transport)
+
+        val res = backend.fetch(user, entity = "blobs", id = "0e9a6111-40d8-3ef1-9fd1-fadfe3240618")
+        assertTrue("non-numeric updatedAt yields success-with-null, not crash", res.isSuccess)
+        assertNull(res.getOrThrow())
+    }
+
     @Test fun `fetch is robust against the historical EAV bug (issue 691)`() = runTest {
         // The pre-fix code crashed on this shape because it tried to do
         // `.jsonObject.get(entity)` against a JsonArray. The new HTTP path


### PR DESCRIPTION
Closes #936, closes #937.

## #936 — `HttpInstantBackend` JsonPrimitive.long crashes on non-numeric response

`HttpInstantBackend.fetch()` called `.long` on the `updatedAt` JsonPrimitive at `HttpInstantBackend.kt:148`. That accessor throws on `JsonNull` or a non-numeric string — exactly what an upstream proxy error page, a partial response, or schema drift can deliver. The thrown exception killed the entire sync round inside `runCatching`.

Switched to `.longOrNull`. The surrounding code already returned `null` when either `payload` or `updatedAt` was missing, so a junk `updatedAt` now degrades to "row not usable yet" and the next sync round retries against a recovered server.

Added a regression test (`fetch is robust against non-numeric updatedAt (issue 936)`) that feeds `"updatedAt":"<html>error</html>"` and asserts `res.isSuccess && getOrThrow() == null`.

## #937 — `SyncIds.toByteArray` not guaranteed UTF-8

`SyncIds.rowUuid()` already uses `encodeToByteArray()` (Kotlin stdlib contract is UTF-8) after the commit that fixed the original audit finding (707c28bb, the UUID-v3 entity-IDs PR). The audit-adjacent callsite still on the platform default was `SecretsSyncer.deterministicSaltFor()` at `SecretsSyncer.kt:218` — used to derive the per-user salt fed into PBKDF2.

Now `("storyvox-secrets:${user.userId}").toByteArray(Charsets.UTF_8)`. The salt is identical across all Android JVM configurations regardless of platform default charset.

Audit confirms these are the only two un-charset-specified `toByteArray()` callsites in `core-sync/src/main`:
- `grep -rn '\.toByteArray()' core-sync/src/main` → only `SecretsSyncer.kt:218` (fixed here)
- All other byte conversions in core-sync use `encodeToByteArray()` (UTF-8 by Kotlin contract) or pass an explicit charset.

## Verification

- `./gradlew :core-sync:compileDebugKotlin` — passes
- `./gradlew :core-sync:testDebugUnitTest` — passes (new test included)