### PR TITLE
feat(reader): magical cover loading prompts + auto-scroll toggle (#945, #946)

### DIFF
--- a/app/src/main/kotlin/in/jphe/storyvox/data/SettingsRepositoryUiImpl.kt
+++ b/app/src/main/kotlin/in/jphe/storyvox/data/SettingsRepositoryUiImpl.kt
@@ -784,6 +784,15 @@ private object Keys {
      */
     val ONBOARDING_COMPLETED_V1 = booleanPreferencesKey("pref_onboarding_completed_v1")
 
+    /**
+     * Issue #946 — reader auto-scroll on/off toggle. Default `true`
+     * (read-along auto-follow is the long-standing behavior); the
+     * brass IconButton in the reader controls overlay flips this.
+     * Versioned `_v1` per the convention used by PLAYBACK_BUFFER_CHUNKS
+     * / WARMUP_WAIT so future renames can land alongside a fresh key.
+     */
+    val READER_AUTO_SCROLL_ENABLED = booleanPreferencesKey("pref_reader_auto_scroll_enabled_v1")
+
     // ── Accessibility scaffold (Phase 1, v0.5.42) ──────────────────
     // Persists the user's explicit intent for the assistive-service
     // tunables surfaced by the new Settings → Accessibility subscreen.
@@ -2675,6 +2684,14 @@ class SettingsRepositoryUiImpl(
      *  for a true "first-launch dress rehearsal". */
     override suspend fun resetOnboardingV1() {
         store.edit { it[Keys.ONBOARDING_COMPLETED_V1] = false }
+    }
+
+    // ── Reader auto-scroll toggle (#946) ───────────────────────────
+    override val readerAutoScrollEnabled: Flow<Boolean> =
+        store.data.map { it[Keys.READER_AUTO_SCROLL_ENABLED] ?: true }
+
+    override suspend fun setReaderAutoScrollEnabled(enabled: Boolean) {
+        store.edit { it[Keys.READER_AUTO_SCROLL_ENABLED] = enabled }
     }
 
     // ── InstantDB settings sync (this PR) ──────────────────────────

--- a/feature/src/main/kotlin/in/jphe/storyvox/feature/api/UiContracts.kt
+++ b/feature/src/main/kotlin/in/jphe/storyvox/feature/api/UiContracts.kt
@@ -2203,6 +2203,29 @@ interface SettingsRepositoryUi {
      *  flow) can re-experience the welcome screens without clearing
      *  app data. */
     suspend fun resetOnboardingV1() {}
+
+    // ── Reader auto-scroll toggle (#946) ───────────────────────────
+    /**
+     * Issue #946 — magical toggle for the reader's
+     * "scroll-to-current-sentence" auto-follow behavior. When true
+     * (default), the reading view smoothly scrolls each highlighted
+     * sentence into the 40% viewport band as the engine advances.
+     * When false, the chapter body stays put — the user scrolls
+     * manually at their own pace while audio continues.
+     *
+     * Default emits `true` here so test fakes get the production
+     * behavior without opting in; the real DataStore impl overrides
+     * with the persisted value (also defaulting `true` on first
+     * launch — feature is on by default to preserve the read-along
+     * UX that's been there since v0.1).
+     */
+    val readerAutoScrollEnabled: Flow<Boolean>
+        get() = kotlinx.coroutines.flow.flowOf(true)
+
+    /** Persist the reader auto-scroll toggle (#946). Wired to the
+     *  brass IconButton in the reader controls overlay. Default no-op
+     *  for fakes; the DataStore impl persists. */
+    suspend fun setReaderAutoScrollEnabled(enabled: Boolean) {}
 }
 
 /**

--- a/feature/src/main/kotlin/in/jphe/storyvox/feature/reader/AudiobookView.kt
+++ b/feature/src/main/kotlin/in/jphe/storyvox/feature/reader/AudiobookView.kt
@@ -84,6 +84,8 @@ import kotlinx.coroutines.delay
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.alpha
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.compositeOver
 import androidx.compose.ui.graphics.graphicsLayer
@@ -400,32 +402,26 @@ fun AudiobookView(
                     }
                 }
             }
-            // "Why are we waiting?" — magical diagnostic panel. Lives
-            // between the top app bar and the cover so it doesn't fight
-            // the transport row (chip-ui-fixer owns lines 580-640) and
-            // the user can see WHY playback isn't producing sound the
-            // moment it stops. AnimatedVisibility inside the panel
-            // handles slide-in / slide-out so we don't need to gate the
-            // call site itself — passing `waitReason = null` collapses
-            // the panel to zero height.
-            WhyAreWeWaitingPanel(
-                reason = waitReason,
-                modifier = Modifier.fillMaxWidth(),
-                onRetry = onPlayPause,
-                onOpenSettings = onOpenSettings,
-            )
-            // Issue #805 — typed playback error banner. Surfaces above the
-            // cover when the engine is in an error state, with a subtype-
-            // specific icon, message, and recovery action. Dismissible via
-            // the X button; auto-clears when the engine leaves error state.
-            if (playbackError != null) {
-                PlaybackErrorBanner(
-                    error = playbackError,
-                    onRetry = onRetryPlayback,
-                    onDismiss = onDismissPlaybackError,
-                    modifier = Modifier.fillMaxWidth(),
-                )
-            }
+            // Issue #945 — "make the book cover even more magical by
+            // displaying all the loading prompts inside it." Pre-fix
+            // the [WhyAreWeWaitingPanel], the [PlaybackErrorBanner], and
+            // the "Still working…" slow-hint each rendered as their
+            // own full-width band above (or below) the cover, pushing
+            // the cover down the screen by 60-120 dp every time any of
+            // them appeared and crowding the focal element. The cover
+            // already carries the visual loading vocabulary (Ken-Burns
+            // scale, orbiting brass sigil ring, candle-ember overlay) —
+            // the missing piece was the textual diagnostic.
+            //
+            // The fix wraps the cover (or its skeleton-tile equivalent)
+            // in an outer Box and overlays the three loading prompts
+            // at the cover's bottom edge inside a brass-scrim gradient
+            // panel sized to match the 220 dp cover width. The cover's
+            // dimensions don't change; the prompts now appear *on*
+            // the cover rather than around it, reading as "the cover
+            // itself is telling you what's happening." When no prompts
+            // are active the overlay collapses to zero and the cover
+            // renders undecorated.
             // While the chapter body + voice model are still loading we don't
             // have a cover URL or chapter title yet — show the brass arcane
             // sigil placeholder instead of a "?" thumb. As soon as state
@@ -452,6 +448,18 @@ fun AudiobookView(
             // when Catch-up Pause is off, so the consumer drains through
             // the silence without surfacing a spinner.
             val showSpinner = warmingUp || state.isBuffering
+            // Issue #945 — outer Box hosting cover + bottom-aligned
+            // loading-prompts overlay. Sized to the cover (220×330) so
+            // the overlay can clip to the cover's bounds via
+            // `Modifier.matchParentSize()`. The spinner ring (240×350)
+            // still draws over the top by living inside the inner Box
+            // — we deliberately do NOT size the outer Box to the
+            // spinner, otherwise the prompts overlay would float
+            // outside the cover's silhouette.
+            Box(
+                modifier = Modifier.size(width = 220.dp, height = 330.dp),
+                contentAlignment = Alignment.Center,
+            ) {
             if (coverLoading) {
                 MagicSkeletonTile(
                     modifier = Modifier.size(width = 220.dp, height = 330.dp),
@@ -597,6 +605,87 @@ fun AudiobookView(
                     }
                 }
             }
+            // Issue #945 — in-cover loading-prompts overlay. Sits at the
+            // bottom of the cover (matchParentSize against the 220×330
+            // outer Box), clipped to the cover's rounded-corner shape so
+            // the scrim follows the cover silhouette. Three stacked
+            // prompts:
+            //   1. [PlaybackErrorBanner] (#805) — typed engine error
+            //      with subtype-specific icon + recovery action.
+            //   2. [WhyAreWeWaitingPanel] (#646) — typed audio-output
+            //      diagnostic with optional retry chip.
+            //   3. "Still working…" slow-hint (#278) — soft 10 s wall
+            //      copy before the 30 s timeout flip.
+            //
+            // Each prompt handles its own enter/exit AnimatedVisibility
+            // so the overlay grows/shrinks with content. The vertical
+            // gradient scrim (transparent → 70 % surface) only renders
+            // when at least one prompt is visible, otherwise the cover
+            // shows undecorated. The Column is bottom-aligned via the
+            // outer Box's contentAlignment so prompts grow upward from
+            // the cover's lower edge — preserving the cover artwork's
+            // top two thirds as the focal area.
+            val hasAnyPrompt = waitReason != null ||
+                playbackError != null ||
+                loadingPhase == LoadingPhase.Slow
+            androidx.compose.animation.AnimatedVisibility(
+                visible = hasAnyPrompt,
+                enter = fadeIn(tween(motion.standardDurationMs, easing = motion.standardEasing)),
+                exit = fadeOut(tween(motion.standardDurationMs, easing = motion.standardEasing)),
+                modifier = Modifier
+                    .matchParentSize()
+                    .clip(MaterialTheme.shapes.large),
+            ) {
+                // Bottom-aligned column carrying the three prompts. The
+                // gradient scrim sits BEHIND the column via the Box's
+                // background so the text stays legible over any cover
+                // artwork. 0.0 alpha at the top, 0.92 at the bottom —
+                // strong enough for white text on a bright cover, soft
+                // enough to keep the cover identifiable through it.
+                Box(
+                    modifier = Modifier
+                        .matchParentSize()
+                        .background(
+                            Brush.verticalGradient(
+                                0f to Color.Transparent,
+                                0.45f to MaterialTheme.colorScheme.surface.copy(alpha = 0.0f),
+                                0.65f to MaterialTheme.colorScheme.surface.copy(alpha = 0.55f),
+                                1f to MaterialTheme.colorScheme.surface.copy(alpha = 0.92f),
+                            ),
+                        ),
+                    contentAlignment = Alignment.BottomCenter,
+                ) {
+                    Column(
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .padding(horizontal = spacing.sm, vertical = spacing.sm),
+                        verticalArrangement = Arrangement.spacedBy(spacing.xs),
+                    ) {
+                        if (playbackError != null) {
+                            PlaybackErrorBanner(
+                                error = playbackError,
+                                onRetry = onRetryPlayback,
+                                onDismiss = onDismissPlaybackError,
+                                modifier = Modifier.fillMaxWidth(),
+                            )
+                        }
+                        WhyAreWeWaitingPanel(
+                            reason = waitReason,
+                            modifier = Modifier.fillMaxWidth(),
+                            onRetry = onPlayPause,
+                            onOpenSettings = onOpenSettings,
+                        )
+                        if (loadingPhase == LoadingPhase.Slow) {
+                            Text(
+                                "Still working… slow voice or network. Hang tight.",
+                                style = MaterialTheme.typography.bodySmall,
+                                color = MaterialTheme.colorScheme.onSurface,
+                            )
+                        }
+                    }
+                }
+            }
+            } // end #945 outer cover Box
             // v1.0 polish (2026-05-16) — when the fiction title hasn't
             // resolved yet ("Conjuring your chapter…"), apply the
             // existing skeleton shimmer alpha so the placeholder text
@@ -654,19 +743,12 @@ fun AudiobookView(
                 style = MaterialTheme.typography.bodyMedium,
                 color = if (showSpinner) MaterialTheme.colorScheme.primary else MaterialTheme.colorScheme.onSurfaceVariant,
             )
-            // Issue #278 — soft slow hint: after the loading state has been
-            // stuck for 10s the user should know we're still trying. The
-            // hint appears under the existing "Loading voice + chapter text"
-            // / chapter-title subtitle and disappears as soon as state
-            // arrives. At 30s we flip to the full error block above and
-            // this hint never renders.
-            if (loadingPhase == LoadingPhase.Slow) {
-                Text(
-                    "Still working… slow voice or network. Hang tight.",
-                    style = MaterialTheme.typography.bodySmall,
-                    color = MaterialTheme.colorScheme.onSurfaceVariant,
-                )
-            }
+            // Issue #278 / #945 — soft slow hint moved into the
+            // in-cover loading-prompts overlay above. The 10 s wall
+            // copy ("Still working…") now renders inside the cover
+            // alongside the other diagnostic prompts; this position
+            // intentionally holds a Spacer to preserve the vertical
+            // rhythm between the subtitle row and the transport bar.
             Spacer(Modifier.height(spacing.xs))
             // Issue #448 — for live audio chapters (Radio plugin's
             // streams via Media3) the position/duration counters stay

--- a/feature/src/main/kotlin/in/jphe/storyvox/feature/reader/HybridReaderScreen.kt
+++ b/feature/src/main/kotlin/in/jphe/storyvox/feature/reader/HybridReaderScreen.kt
@@ -83,6 +83,7 @@ fun HybridReaderScreen(
     val recapPlayback by viewModel.recapPlayback.collectAsStateWithLifecycle()
     val resumeEntry by viewModel.resumeEntry.collectAsStateWithLifecycle()
     val chapters by viewModel.chapters.collectAsStateWithLifecycle()
+    val autoScrollEnabled by viewModel.autoScrollEnabled.collectAsStateWithLifecycle()
     val playback = state.playback
 
     // Calliope (v0.5.00) — first-natural-chapter-completion confetti.
@@ -328,6 +329,12 @@ fun HybridReaderScreen(
                     // can edit before sending or send as-is.
                     playbackState.fictionId?.let { onOpenChat(it, question) }
                 },
+                // Issue #946 — magical reader auto-scroll toggle.
+                // StateFlow sourced from SettingsRepositoryUi so the
+                // flip persists across sessions; setter is mirrored
+                // shape to the other reader prefs (#418 / #193).
+                autoScrollEnabled = autoScrollEnabled,
+                onToggleAutoScroll = viewModel::setAutoScrollEnabled,
             )
         },
     )

--- a/feature/src/main/kotlin/in/jphe/storyvox/feature/reader/ReaderView.kt
+++ b/feature/src/main/kotlin/in/jphe/storyvox/feature/reader/ReaderView.kt
@@ -1,6 +1,8 @@
 package `in`.jphe.storyvox.feature.reader
 
 import androidx.compose.animation.AnimatedVisibility
+import androidx.compose.animation.core.animateFloatAsState
+import androidx.compose.animation.core.tween
 import androidx.compose.animation.fadeIn
 import androidx.compose.animation.fadeOut
 import androidx.compose.animation.slideInVertically
@@ -21,6 +23,7 @@ import androidx.compose.material.icons.filled.Pause
 import androidx.compose.material.icons.filled.PlayArrow
 import androidx.compose.material.icons.filled.VerticalAlignCenter
 import androidx.compose.material.icons.outlined.AutoAwesome
+import androidx.compose.material.icons.outlined.AutoStories
 import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.FilledIconButton
 import androidx.compose.material3.Icon
@@ -43,10 +46,13 @@ import androidx.compose.runtime.setValue
 import androidx.compose.runtime.snapshotFlow
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.alpha
 import androidx.compose.ui.layout.onGloballyPositioned
 import androidx.compose.ui.layout.onSizeChanged
 import androidx.compose.ui.layout.positionInParent
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.semantics.contentDescription
+import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.text.TextLayoutResult
 import androidx.compose.ui.unit.dp
 import `in`.jphe.storyvox.feature.R
@@ -78,6 +84,20 @@ fun ReaderTextView(
      *  to `navController.navigate(StoryvoxRoutes.chat(fId, prefill = q))`.
      *  No-op default keeps preview/test callsites working unchanged. */
     onAskAiAbout: (String) -> Unit = {},
+    /**
+     * Issue #946 — magical auto-scroll toggle. When true, the chapter
+     * body smoothly follows the engine's current sentence (the
+     * long-standing read-along behavior). When false, the auto-scroll
+     * LaunchedEffect short-circuits — the user owns the wheel.
+     * Defaulted to true so older callsites (tests, previews) keep the
+     * original behavior without opting in.
+     */
+    autoScrollEnabled: Boolean = true,
+    /** Issue #946 — flip the auto-scroll toggle. Wired by
+     *  [HybridReaderScreen] to [ReaderViewModel.setAutoScrollEnabled],
+     *  which persists via [SettingsRepositoryUi]. No-op default for
+     *  preview/test callsites. */
+    onToggleAutoScroll: (Boolean) -> Unit = {},
     modifier: Modifier = Modifier,
 ) {
     val spacing = LocalSpacing.current
@@ -110,7 +130,14 @@ fun ReaderTextView(
     // Auto-scroll target: when sentence range or layout changes, settle the highlighted
     // line at 40% from the top of the viewport — unless we're inside the manual-scroll
     // grace window, in which case the user has the wheel.
-    LaunchedEffect(state.sentenceStart, state.sentenceEnd, textLayout, viewportHeightPx, bodyTopPx, chapterText) {
+    //
+    // Issue #946 — the [autoScrollEnabled] toggle wraps this effect's key set: when the
+    // user flips the brass IconButton off, the LaunchedEffect re-keys to a no-op branch
+    // and never schedules another animateScrollTo. Flipping back on re-keys and resumes
+    // following the next sentence boundary (no jump — only the next emit triggers a
+    // scroll, so the user's manual position is preserved until then).
+    LaunchedEffect(autoScrollEnabled, state.sentenceStart, state.sentenceEnd, textLayout, viewportHeightPx, bodyTopPx, chapterText) {
+        if (!autoScrollEnabled) return@LaunchedEffect
         val layout = textLayout ?: return@LaunchedEffect
         if (chapterText.isEmpty()) return@LaunchedEffect
         if (viewportHeightPx <= 0f) return@LaunchedEffect
@@ -196,6 +223,69 @@ fun ReaderTextView(
             }
         }
 
+        // Issue #946 — magical auto-scroll on/off toggle. Sits above the
+        // recenter FAB (#919) so the two end-aligned controls form a
+        // vertical brass cluster: top = mode (auto-follow vs manual),
+        // bottom = one-shot recenter. Always visible so the user can
+        // discover the toggle without first scrolling away; the icon's
+        // brass-vs-onSurfaceVariant tint communicates state at a glance.
+        //
+        // The contained icon is `Outlined.AutoStories` (the same
+        // open-book glyph the Library tab uses) tinted brass when
+        // auto-scroll is on and dimmed-onSurfaceVariant when off. A
+        // small `Outlined.AutoAwesome` sparkle overlays the top-right
+        // when ON, conveying "magic active" — its alpha cross-fades
+        // on toggle so the flip reads as evocative without competing
+        // with the chapter body's reading focus.
+        val sparkleAlpha by animateFloatAsState(
+            targetValue = if (autoScrollEnabled) 0.85f else 0f,
+            animationSpec = tween(durationMillis = 280),
+            label = "autoscroll-sparkle-alpha",
+        )
+        SmallFloatingActionButton(
+            onClick = { onToggleAutoScroll(!autoScrollEnabled) },
+            modifier = Modifier
+                .align(Alignment.BottomEnd)
+                .padding(end = spacing.md, bottom = 168.dp)
+                .semantics {
+                    contentDescription = if (autoScrollEnabled) {
+                        "Auto-scroll on. Tap to turn off."
+                    } else {
+                        "Auto-scroll off. Tap to turn on."
+                    }
+                },
+            containerColor = if (autoScrollEnabled) {
+                MaterialTheme.colorScheme.primary
+            } else {
+                MaterialTheme.colorScheme.surfaceContainerHigh
+            },
+            contentColor = if (autoScrollEnabled) {
+                MaterialTheme.colorScheme.onPrimary
+            } else {
+                MaterialTheme.colorScheme.onSurfaceVariant
+            },
+        ) {
+            Box(contentAlignment = Alignment.Center) {
+                Icon(
+                    imageVector = Icons.Outlined.AutoStories,
+                    contentDescription = null,
+                )
+                // Sparkle overlay — only visible when auto-scroll is
+                // armed. Sits in the upper-right of the FAB so it
+                // reads as "this book is following you, magically."
+                if (sparkleAlpha > 0.01f) {
+                    Icon(
+                        imageVector = Icons.Outlined.AutoAwesome,
+                        contentDescription = null,
+                        tint = MaterialTheme.colorScheme.onPrimary,
+                        modifier = Modifier
+                            .size(12.dp)
+                            .align(Alignment.TopEnd)
+                            .alpha(sparkleAlpha),
+                    )
+                }
+            }
+        }
         // Issue #919 — floating "scroll to current sentence" button.
         // Positioned above the bottom transport bar (bottom = 104dp to
         // clear the bar + spacing), end-aligned. Uses Material 3

--- a/feature/src/main/kotlin/in/jphe/storyvox/feature/reader/ReaderViewModel.kt
+++ b/feature/src/main/kotlin/in/jphe/storyvox/feature/reader/ReaderViewModel.kt
@@ -445,6 +445,17 @@ class ReaderViewModel @Inject constructor(
         }
         .stateIn(viewModelScope, SharingStarted.WhileSubscribed(5_000), emptyList())
 
+    /**
+     * Issue #946 — magical reader auto-scroll toggle. Default true so
+     * existing users keep their read-along behavior; flipping to false
+     * frees the chapter body for manual scrolling while audio continues.
+     * Backed by [SettingsRepositoryUi.readerAutoScrollEnabled] so the
+     * preference rides across sessions and across the InstantDB sync
+     * allowlist if/when wired through.
+     */
+    val autoScrollEnabled: StateFlow<Boolean> = settings.readerAutoScrollEnabled
+        .stateIn(viewModelScope, SharingStarted.WhileSubscribed(5_000), true)
+
     /** Issue #278 — user-initiated retry from the timed-out error block.
      *  Re-invokes the playback `play()` path; the underlying controller
      *  will re-fetch the chapter / re-prime the voice. We also reset the
@@ -569,6 +580,17 @@ class ReaderViewModel @Inject constructor(
      */
     fun setPitchInterpolationHighQuality(enabled: Boolean) {
         viewModelScope.launch { settings.setPitchInterpolationHighQuality(enabled) }
+    }
+
+    /**
+     * Issue #946 — persist the reader auto-scroll toggle. Mirrored
+     * shape to the other setting setters: fire-and-forget into the
+     * viewModelScope, the StateFlow above re-emits, the
+     * [ReaderTextView] observes and re-gates its scroll
+     * LaunchedEffect.
+     */
+    fun setAutoScrollEnabled(enabled: Boolean) {
+        viewModelScope.launch { settings.setReaderAutoScrollEnabled(enabled) }
     }
 
     // Issue #121 — in-chapter bookmark fan-out. ReaderViewModel stays


### PR DESCRIPTION
## Summary

Two reader-surface UI features filed by JP, implemented in one PR (both touch the reader composables and share visual idiom).

### #945 — loading prompts inside the cover

Moves the three loading-state surfaces (`WhyAreWeWaitingPanel`, `PlaybackErrorBanner`, "Still working…" slow hint) out of their above-and-below-the-cover bands and **into a brass-scrim overlay anchored to the cover's bottom edge**.

The cover already carried the loading vocabulary visually — Ken-Burns scale (#623), orbiting sigil ring, candle-ember overlay — but the textual diagnostics lived in their own full-width bands that pushed the cover down the screen by 60-120 dp every time any of them appeared. Now they read as *the cover itself telling you what's happening*.

- Vertical gradient scrim (transparent → 92% surface) keeps text legible over any cover artwork without obscuring the upper two-thirds.
- `AnimatedVisibility` on the overlay so it fades in/out cleanly; collapses to zero when no prompt is active and the cover renders undecorated.
- Overlay clipped to the cover's rounded-corner shape via `MaterialTheme.shapes.large` so the scrim follows the silhouette.
- Spinner ring (240×350 dp) still extends slightly beyond the 220×330 cover — overlay is sized to the cover only, so prompts stay within the cover's bounds.

### #946 — magical auto-scroll toggle

Persistent on/off toggle for the reader's read-along auto-scroll behavior. Previously the only way to suppress auto-follow was the 5 s manual-scroll grace window — there was no way to say "I just want to read at my own pace."

- `SettingsRepositoryUi.readerAutoScrollEnabled: Flow<Boolean>` + `setReaderAutoScrollEnabled(enabled: Boolean)` persisted via `pref_reader_auto_scroll_enabled_v1` (default `true` so existing users see no change).
- `ReaderViewModel.autoScrollEnabled: StateFlow<Boolean>` + `setAutoScrollEnabled(enabled: Boolean)` mirror the existing reader-pref setters (e.g. `#418` pause multiplier).
- `ReaderTextView.autoScrollEnabled` gates the auto-scroll `LaunchedEffect` — when `false`, the effect short-circuits and the user owns the wheel. Flipping back on re-engages from the next sentence-emit; no jump, the manual position is preserved.
- New `SmallFloatingActionButton` above the existing `#919` recenter FAB (bottom = 168 dp). `Outlined.AutoStories` glyph (matches the Library tab's open-book idiom) with an `Outlined.AutoAwesome` sparkle that cross-fades alpha 0.85 ↔ 0 on toggle. Tinted brass when armed, dimmed surface when off. TalkBack label flips: "Auto-scroll on. Tap to turn off." / "Auto-scroll off. Tap to turn on."

## Test plan

- [x] `./gradlew :feature:compileDebugKotlin` clean
- [x] `./gradlew :app:compileDebugKotlin` clean
- [x] `./gradlew :feature:testDebugUnitTest` passes
- [x] `./gradlew :app:testDebugUnitTest` passes
- [ ] Install on R83W80CAFZB tablet — verify cover overlay during slow-voice cold start (Piper-high), verify auto-scroll toggle persists across app restart
- [ ] R5CRB0W66MK phone — verify scrim legibility on dark cover artwork, verify toggle FAB doesn't overlap the bottom transport row
- [ ] TalkBack — auto-scroll toggle announces state change on tap

## Notes

- No removed/renamed prefs; the toggle is additive.
- `WhyAreWeWaitingPanel` and `PlaybackErrorBanner` composables themselves are unchanged — only their call-site placement moved.
- Test fakes (each test file inlines its own `FakeSettingsRepo`) get the production defaults via the new interface methods' default implementations; no fake updates needed.