### PR TITLE
fix(auth): update canGoBack in doUpdateVisitedHistory to avoid stale BackHandler (#934)

### DIFF
--- a/source-ao3/src/main/kotlin/in/jphe/storyvox/source/ao3/auth/Ao3AuthWebView.kt
+++ b/source-ao3/src/main/kotlin/in/jphe/storyvox/source/ao3/auth/Ao3AuthWebView.kt
@@ -91,6 +91,7 @@ fun Ao3AuthWebView(
                     // it pre- or post-redirect.
                     override fun onPageStarted(view: WebView?, url: String?, favicon: Bitmap?) {
                         super.onPageStarted(view, url, favicon)
+                        canGoBack = view?.canGoBack() == true
                         tryCapture(url)
                     }
 
@@ -98,6 +99,19 @@ fun Ao3AuthWebView(
                         super.onPageFinished(view, url)
                         canGoBack = view?.canGoBack() == true
                         tryCapture(url)
+                    }
+
+                    // #934 — `onPageFinished` doesn't fire for JS-driven
+                    // navigation (history.pushState / replaceState, hash
+                    // changes, in-page redirects). Without this override,
+                    // `canGoBack` goes stale between full-page loads and
+                    // BackHandler's `enabled` lambda evaluates against
+                    // out-of-date state. `doUpdateVisitedHistory` is the
+                    // canonical WebView hook that fires for every history
+                    // mutation, JS-initiated or otherwise.
+                    override fun doUpdateVisitedHistory(view: WebView?, url: String?, isReload: Boolean) {
+                        super.doUpdateVisitedHistory(view, url, isReload)
+                        canGoBack = view?.canGoBack() == true
                     }
 
                     private fun tryCapture(currentUrl: String?) {

--- a/source-royalroad/src/main/kotlin/in/jphe/storyvox/source/royalroad/auth/RoyalRoadAuthWebView.kt
+++ b/source-royalroad/src/main/kotlin/in/jphe/storyvox/source/royalroad/auth/RoyalRoadAuthWebView.kt
@@ -81,6 +81,7 @@ fun RoyalRoadAuthWebView(
                     // cookie in tight redirect chains.
                     override fun onPageStarted(view: WebView?, url: String?, favicon: Bitmap?) {
                         super.onPageStarted(view, url, favicon)
+                        canGoBack = view?.canGoBack() == true
                         tryCapture()
                     }
 
@@ -88,6 +89,19 @@ fun RoyalRoadAuthWebView(
                         super.onPageFinished(view, url)
                         canGoBack = view?.canGoBack() == true
                         tryCapture()
+                    }
+
+                    // #934 — `onPageFinished` doesn't fire for JS-driven
+                    // navigation (history.pushState / replaceState, hash
+                    // changes, in-page redirects). Without this override,
+                    // `canGoBack` goes stale between full-page loads and
+                    // BackHandler's `enabled` lambda evaluates against
+                    // out-of-date state. `doUpdateVisitedHistory` is the
+                    // canonical WebView hook that fires for every history
+                    // mutation, JS-initiated or otherwise.
+                    override fun doUpdateVisitedHistory(view: WebView?, url: String?, isReload: Boolean) {
+                        super.doUpdateVisitedHistory(view, url, isReload)
+                        canGoBack = view?.canGoBack() == true
                     }
 
                     private fun tryCapture() {


### PR DESCRIPTION
## Summary

Closes #934.

`canGoBack` in `Ao3AuthWebView` and `RoyalRoadAuthWebView` was a `mutableStateOf` that only updated in `onPageFinished` and after `goBack()`. `onPageFinished` does not fire for JavaScript-driven navigation (`history.pushState` / `replaceState`, hash changes, in-page redirects), so the state went stale and `BackHandler`'s `enabled` lambda evaluated against out-of-date history — exiting the WebView when history was still walkable, or trying to `goBack()` when not.

## Fix

Override `doUpdateVisitedHistory(view, url, isReload)` in both WebViewClients. It fires for every history mutation (JS-initiated or otherwise), so `canGoBack` tracks the real navigation state. Also refresh `canGoBack` from `onPageStarted` for symmetry with the post-redirect race the existing `tryCapture` hooks were already catching.

Applied identically to `Ao3AuthWebView.kt` and `RoyalRoadAuthWebView.kt` to keep the two auth WebViews in lockstep (they share near-identical structure).

## Test plan

- [x] `./gradlew :source-ao3:compileDebugKotlin :source-royalroad:compileDebugKotlin` — BUILD SUCCESSFUL
- [ ] Manual: open AO3 / RoyalRoad login WebView, navigate forward via in-page JS link, press system Back — confirm history walks one step instead of dismissing the WebView