### PR TITLE
fix(error): meaningful fallback for blank FriendlyError input (#935)

### DIFF
--- a/core-ui/src/main/kotlin/in/jphe/storyvox/ui/component/FriendlyError.kt
+++ b/core-ui/src/main/kotlin/in/jphe/storyvox/ui/component/FriendlyError.kt
@@ -44,7 +44,11 @@ enum class FriendlyErrorKind {
  * reports; keep the user-facing copy short and recoverable-sounding.
  */
 fun categorizeFriendlyError(raw: String?): Pair<FriendlyErrorKind, String?> {
-    val s = raw ?: return FriendlyErrorKind.Generic to null
+    // #935 — blank input (whitespace-only or empty) used to fall through
+    // to the `Raw to s` branch and surface an empty user-facing message.
+    // Treat it the same as null: there's nothing actionable to show, so
+    // route to the generic fallback copy.
+    val s = raw?.takeIf { it.isNotBlank() } ?: return FriendlyErrorKind.Generic to null
     val lower = s.lowercase()
     return when {
         // Network timeouts / offline / DNS — by far the most common.

--- a/core-ui/src/test/kotlin/in/jphe/storyvox/ui/component/FriendlyErrorCategorizationTest.kt
+++ b/core-ui/src/test/kotlin/in/jphe/storyvox/ui/component/FriendlyErrorCategorizationTest.kt
@@ -21,6 +21,24 @@ class FriendlyErrorCategorizationTest {
     }
 
     @Test
+    fun `empty raw maps to Generic with no fallback`() {
+        // #935 — empty string used to land on `Raw to ""`, surfacing an
+        // empty error to the user. Must behave the same as null.
+        val (kind, fallback) = categorizeFriendlyError("")
+        assertEquals(FriendlyErrorKind.Generic, kind)
+        assertNull(fallback)
+    }
+
+    @Test
+    fun `whitespace-only raw maps to Generic with no fallback`() {
+        // #935 — whitespace-only (spaces, tabs, newlines) is the other
+        // shape of "nothing to show" we used to leak through.
+        val (kind, fallback) = categorizeFriendlyError("   \t\n  ")
+        assertEquals(FriendlyErrorKind.Generic, kind)
+        assertNull(fallback)
+    }
+
+    @Test
     fun `HTTP 0 timeout maps to NetworkLost`() {
         assertEquals(
             FriendlyErrorKind.NetworkLost,


### PR DESCRIPTION
Closes #935.

## Problem
`categorizeFriendlyError(raw)` in `core-ui/.../FriendlyError.kt` null-checks but does not blank-check its input. A blank string (empty or whitespace-only) fell through to the `else` branch and returned `FriendlyErrorKind.Raw to s` where `s` was empty/whitespace. The composable `friendlyErrorMessage` then rendered an empty user-facing message because the `fallback ?: stringResource(...)` guard only fires on null.

## Fix
Treat blank input the same as null on line 47:

```kotlin
val s = raw?.takeIf { it.isNotBlank() } ?: return FriendlyErrorKind.Generic to null
```

Blank input now routes to `FriendlyErrorKind.Generic`, which the composable resolves to the existing `friendly_error_generic` string ("Something went wrong. Try again in a moment."). No new strings, no i18n churn.

## Tests
Added two cases to `FriendlyErrorCategorizationTest`:
- `empty raw maps to Generic with no fallback`
- `whitespace-only raw maps to Generic with no fallback`

All 16 categorization tests pass (`./gradlew :core-ui:testDebugUnitTest`). `./gradlew :core-ui:compileDebugKotlin` clean.

## Source
Gemini review on PR #838.