### PR TITLE
fix(onboarding): hoist OnboardingScaffold outside AnimatedContent (#933)

### DIFF
--- a/feature/src/main/kotlin/in/jphe/storyvox/feature/onboarding/OnboardingHost.kt
+++ b/feature/src/main/kotlin/in/jphe/storyvox/feature/onboarding/OnboardingHost.kt
@@ -104,19 +104,28 @@ fun OnboardingHost(
                         onClick = {},
                     ),
             ) {
-                AnimatedContent(
-                    targetState = step,
-                    transitionSpec = { fadeIn() togetherWith fadeOut() },
-                    label = "onboarding-step",
-                ) { current ->
-                    // Issue #787 — wrap each screen in the shared
-                    // scaffold so the dot row + "Step X of 3" indicator
-                    // is rendered once at the host level, not
-                    // duplicated into each screen. The scaffold layers
-                    // the indicator over the screen's own scroll
-                    // content; each screen's existing padding keeps the
-                    // headline clear of the indicator row.
-                    OnboardingScaffold(stepIndex = current.ordinal) {
+                // Issue #787 — the shared scaffold (dot row +
+                // "Step X of 3" indicator) is hoisted OUTSIDE the
+                // AnimatedContent so the indicator and any future
+                // chrome stay mounted across step transitions; only
+                // the per-step page body cross-fades. Issue #933
+                // moved this hoist after a Gemini review on PR #836
+                // pointed out that the prior nesting tore down and
+                // recreated the scaffold on every step change, which
+                // (a) replayed the indicator's `liveRegion` TalkBack
+                // announcement mid-transition and (b) wasted a frame
+                // re-laying out the dot row on each fade.
+                //
+                // `stepIndex = step.ordinal` reads from the host's
+                // own state (not AnimatedContent's `current`), so the
+                // indicator updates the instant the user taps a CTA
+                // rather than waiting for the cross-fade to complete.
+                OnboardingScaffold(stepIndex = step.ordinal) {
+                    AnimatedContent(
+                        targetState = step,
+                        transitionSpec = { fadeIn() togetherWith fadeOut() },
+                        label = "onboarding-step",
+                    ) { current ->
                         when (current) {
                             OnboardingStep.Welcome -> WelcomeScreen(
                                 onGetStarted = { step = OnboardingStep.VoicePick },


### PR DESCRIPTION
## Summary

Fixes #933. Per a Gemini review on PR #836, `OnboardingScaffold` was nested inside the `AnimatedContent` block in `OnboardingHost.kt`, so the entire scaffold (dot indicator + "Step X of 3" label) was torn down and recreated on every step transition. That:

- replayed the indicator's `liveRegion` TalkBack announcement mid-fade
- wasted a frame re-laying out the chrome on every transition

## Fix

Hoist `OnboardingScaffold` one level up: `AnimatedContent` now lives **inside** the scaffold's content lambda, so only the per-step page body cross-fades while the indicator stays mounted across transitions.

`stepIndex` reads from `step` (host state) rather than `current` (the AnimatedContent target), so the dots advance the instant the user taps a CTA rather than waiting for the cross-fade to complete.

## Test plan

- [x] `./gradlew :feature:compileDebugKotlin` — green
- [ ] manual: step through Welcome → VoicePick → FirstFiction; indicator stays put, only page body fades
- [ ] TalkBack: announces "Step 2 of 3" / "Step 3 of 3" once per state change, not per-frame

🤖 Generated with [Claude Code](https://claude.com/claude-code)