### PR TITLE
a11y(browse): restore TalkBack long-click label on BrowseSourceCarousel (#941)

### DIFF
--- a/feature/src/main/kotlin/in/jphe/storyvox/feature/browse/BrowseSourceCarousel.kt
+++ b/feature/src/main/kotlin/in/jphe/storyvox/feature/browse/BrowseSourceCarousel.kt
@@ -82,6 +82,7 @@ import androidx.compose.ui.platform.LocalHapticFeedback
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.semantics.Role
+import androidx.compose.ui.semantics.onLongClick
 import androidx.compose.ui.semantics.selected
 import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.text.font.FontWeight
@@ -340,7 +341,14 @@ private fun BrowseSourceCard(
             // Role.Button (not Role.Tab) keeps the "double-tap to activate"
             // hint intact even on the selected cell — same rationale as
             // BottomTabBar #645.
-            .semantics { this.selected = selected }
+            // onLongClick label restores the TalkBack announcement that was
+            // dropped when combinedClickable was split into clickable +
+            // pointerInput (#941). The actual long-press handler lives in the
+            // pointerInput below; this just provides the spoken hint.
+            .semantics {
+                this.selected = selected
+                onLongClick(label = "Reorder or open options") { true }
+            }
             // Tap handler — selects the source. Separated from the long-
             // press gesture below so they don't fight over pointer events.
             .clickable(


### PR DESCRIPTION
Fixes #941.

## Problem

`BrowseSourceCarousel.kt` source cards lost their TalkBack long-press hint when a prior refactor split `combinedClickable` into separate `clickable` + `pointerInput` modifiers. The long-press gesture itself still fires (`detectDragGesturesAfterLongPress` in the `pointerInput` block), but the `onLongClickLabel` semantics that drove the spoken announcement went with `combinedClickable`. Users running TalkBack now hear no description of what holding a source card will do.

## Fix

Re-add the long-click semantics on the existing `.semantics { }` block:

```kotlin
.semantics {
    this.selected = selected
    onLongClick(label = "Reorder or open options") { true }
}
```

The carousel-level `onDragEnd` discriminates between long-press-only (opens the context sheet) and long-press + drag (reorder), so the label covers both outcomes. The actual gesture handling stays in the `pointerInput` block untouched — this restores only the accessibility announcement.

## Verified

- `./gradlew :feature:compileDebugKotlin` — BUILD SUCCESSFUL
- Existing `.semantics { this.selected = selected }` preserved (still announces selected state, still uses Role.Button via the `clickable` modifier — same pattern as BottomTabBar #645)
- `pointerInput` drag/reorder logic untouched