### PR TITLE
feat(reader): magical player→library nav from playing tab (#955)

### DIFF
--- a/app/src/main/kotlin/in/jphe/storyvox/navigation/StoryvoxNavHost.kt
+++ b/app/src/main/kotlin/in/jphe/storyvox/navigation/StoryvoxNavHost.kt
@@ -685,6 +685,14 @@ private fun StoryvoxNavHostContent(
                             }
                         }
                     },
+                    // Issue #955 — brass MenuBook on the player top-bar
+                    // jumps into the currently-playing fiction's detail
+                    // page (cover + full chapter list). Routes via the
+                    // normal nav push so the back stack restores the
+                    // player on Back.
+                    onOpenLibrary = { fId ->
+                        navController.navigate(StoryvoxRoutes.fictionDetail(fId))
+                    },
                 )
             }
             composable(
@@ -856,6 +864,10 @@ private fun StoryvoxNavHostContent(
                             }
                         }
                     },
+                    // Issue #955 — see PLAYING-route comment.
+                    onOpenLibrary = { fId ->
+                        navController.navigate(StoryvoxRoutes.fictionDetail(fId))
+                    },
                 )
             }
 
@@ -898,6 +910,10 @@ private fun StoryvoxNavHostContent(
                                 launchSingleTop = true
                             }
                         }
+                    },
+                    // Issue #955 — see PLAYING-route comment.
+                    onOpenLibrary = { fId ->
+                        navController.navigate(StoryvoxRoutes.fictionDetail(fId))
                     },
                 )
             }

--- a/feature/src/main/kotlin/in/jphe/storyvox/feature/reader/AudiobookView.kt
+++ b/feature/src/main/kotlin/in/jphe/storyvox/feature/reader/AudiobookView.kt
@@ -36,6 +36,7 @@ import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.material3.ripple
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material.icons.automirrored.filled.MenuBook
 import androidx.compose.material.icons.automirrored.outlined.FormatListBulleted
 import androidx.compose.material.icons.filled.Forward30
 import androidx.compose.material.icons.filled.Replay
@@ -156,6 +157,16 @@ fun AudiobookView(
      *  Default no-op for previews / tests; production callsites pass a
      *  real `navController.popBackStack()`. */
     onBack: () -> Unit = {},
+    /** Issue #955 — "magical way to get to the library page from the
+     *  playing page." The bottom-of-player mini chapter pulldown doesn't
+     *  scale to long fictions, and there's no first-class affordance to
+     *  jump from playback into the fiction's full chapter list. This
+     *  callback opens the per-fiction detail surface (cover + chapters)
+     *  for whatever's currently loaded. HybridReaderScreen guards
+     *  against null fictionId before invoking. Default no-op for
+     *  previews / tests; production callsites pass
+     *  `navController.navigate(StoryvoxRoutes.fictionDetail(fId))`. */
+    onOpenLibrary: () -> Unit = {},
     /** Issue #278 — loading-phase from the ReaderViewModel. Drives the
      *  soft "Still working…" hint at 10s and the hard timeout/retry
      *  error block at 30s. Defaults to NotLoading so previews / tests
@@ -325,14 +336,40 @@ fun AudiobookView(
                 // arrow: the a11y label matches the icon's perceived
                 // shape and there's a fast escape from the player
                 // without reaching for the system Back button.
-                IconButton(
-                    onClick = onBack,
+                //
+                // Issue #955 — paired with a brass MenuBook to the
+                // right of Back. JP's complaint: the mini chapter
+                // pulldown at the bottom doesn't scale, and there's
+                // no first-class way to land on the fiction's full
+                // chapter list from the player. MenuBook (the
+                // open-book glyph) lives at the leading edge alongside
+                // Back because both are "leave this surface" verbs —
+                // Back returns to wherever you came from, MenuBook
+                // takes you into the fiction's library page. Trailing
+                // edge stays reserved for the playback-modifying
+                // affordances (voice quick sheet, overflow sheet).
+                Row(
                     modifier = Modifier.align(Alignment.CenterStart),
+                    verticalAlignment = Alignment.CenterVertically,
                 ) {
-                    Icon(
-                        Icons.AutoMirrored.Filled.ArrowBack,
-                        contentDescription = "Back",
-                    )
+                    IconButton(onClick = onBack) {
+                        Icon(
+                            Icons.AutoMirrored.Filled.ArrowBack,
+                            contentDescription = "Back",
+                        )
+                    }
+                    IconButton(
+                        onClick = onOpenLibrary,
+                        modifier = Modifier.semantics {
+                            contentDescription = "Open chapter list"
+                        },
+                    ) {
+                        Icon(
+                            imageVector = Icons.AutoMirrored.Filled.MenuBook,
+                            contentDescription = null,
+                            tint = MaterialTheme.colorScheme.primary,
+                        )
+                    }
                 }
                 Column(
                     modifier = Modifier
@@ -340,11 +377,13 @@ fun AudiobookView(
                         // Issue #418 — bumped from 56 dp to 104 dp on the
                         // trailing side because the top bar now carries
                         // TWO trailing affordances (brass voice icon +
-                        // ⋮ overflow). Leading side stays at 56 dp for
-                        // the Settings gear. Asymmetric padding via
-                        // start/end keeps the title visually centered
-                        // across both sides' negative space.
-                        .padding(start = 56.dp, end = 104.dp),
+                        // ⋮ overflow). Issue #955 — leading side also
+                        // goes to 104 dp now that Back is paired with
+                        // the brass MenuBook (Open chapter list) for
+                        // the player → fiction-detail jump. Asymmetric
+                        // padding via start/end keeps the title visually
+                        // centered across both sides' negative space.
+                        .padding(start = 104.dp, end = 104.dp),
                     horizontalAlignment = Alignment.CenterHorizontally,
                 ) {
                     Text(

--- a/feature/src/main/kotlin/in/jphe/storyvox/feature/reader/HybridReaderScreen.kt
+++ b/feature/src/main/kotlin/in/jphe/storyvox/feature/reader/HybridReaderScreen.kt
@@ -76,6 +76,13 @@ fun HybridReaderScreen(
      *  the back stack is empty (deep-link / cold-launch into the
      *  player). Default no-op for previews. */
     onBack: () -> Unit = {},
+    /** Issue #955 — open the currently-playing fiction's detail page
+     *  (cover + full chapter list). Receives the fictionId; this screen
+     *  pulls it from the live playback state and guards the call so the
+     *  AudiobookView never has to know about routing. Default no-op for
+     *  previews / tests; production callsites pass
+     *  `navController.navigate(StoryvoxRoutes.fictionDetail(fId))`. */
+    onOpenLibrary: (fictionId: String) -> Unit = {},
     viewModel: ReaderViewModel = hiltViewModel(),
 ) {
     val state by viewModel.uiState.collectAsStateWithLifecycle()
@@ -282,6 +289,15 @@ fun HybridReaderScreen(
                 },
                 onOpenSettings = onOpenSettings,
                 onBack = onBack,
+                // Issue #955 — guard against the brief blank-ids window
+                // (cold-load before the controller has filled in
+                // fictionId). The AudiobookView default is a no-op, so a
+                // tap during that window is harmless; we just skip the
+                // navigation so a malformed fictionDetail route isn't
+                // pushed onto the back stack.
+                onOpenLibrary = {
+                    playbackState.fictionId?.let { onOpenLibrary(it) }
+                },
                 // Issue #278 — surface loading-phase + retry path. The
                 // view decides what to render based on phase (regular /
                 // slow-hint at 10s / full error block at 30s).

--- a/feature/src/main/kotlin/in/jphe/storyvox/feature/reader/ReaderView.kt
+++ b/feature/src/main/kotlin/in/jphe/storyvox/feature/reader/ReaderView.kt
@@ -24,7 +24,6 @@ import androidx.compose.material.icons.filled.PlayArrow
 import androidx.compose.material.icons.filled.VerticalAlignCenter
 import androidx.compose.material.icons.outlined.AutoAwesome
 import androidx.compose.material.icons.outlined.AutoStories
-import androidx.compose.material.icons.outlined.WhereToVote
 import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.FilledIconButton
 import androidx.compose.material3.Icon
@@ -190,41 +189,6 @@ fun ReaderTextView(
     }
     val showScrollFab = sentenceOutOfView && state.isPlaying
 
-    // Issue #954 — "skip playback to where the reader has scrolled to."
-    // The reverse of #919's recenter. Derives the topmost line currently
-    // inside the viewport (with the same 80px margin as #919's
-    // out-of-view test so the two gates agree on what "visible" means)
-    // and returns its first character offset. Null when layout/text
-    // aren't ready, so the FAB stays hidden during chapter cold-load.
-    val firstVisibleCharOffset by remember {
-        derivedStateOf {
-            val layout = textLayout ?: return@derivedStateOf null
-            if (chapterText.isEmpty()) return@derivedStateOf null
-            if (viewportHeightPx <= 0f) return@derivedStateOf null
-            val margin = 80f
-            val viewportTopInBody = scroll.value.toFloat() - bodyTopPx + margin
-            if (viewportTopInBody < 0f) return@derivedStateOf 0
-            val lineCount = layout.lineCount
-            if (lineCount <= 0) return@derivedStateOf null
-            // Find the first line whose bottom is at or below the
-            // viewport top — that's the first line the user can
-            // actually read.
-            for (line in 0 until lineCount) {
-                if (layout.getLineBottom(line) > viewportTopInBody) {
-                    return@derivedStateOf layout.getLineStart(line)
-                }
-            }
-            layout.getLineStart(lineCount - 1)
-        }
-    }
-    // Show the "skip playback to here" FAB only when (a) the active
-    // sentence isn't already visible (otherwise the button would
-    // re-seek to a position you're already at — confusing) and (b) we
-    // have a valid first-visible offset to seek to. Independent of
-    // `state.isPlaying` — the user might be paused and want to start
-    // playing FROM the scroll position, which is exactly this verb.
-    val showSeekToReaderFab = sentenceOutOfView && firstVisibleCharOffset != null
-
     Box(modifier = modifier.fillMaxSize().onSizeChanged { viewportHeightPx = it.height.toFloat() }) {
         Column(
             modifier = Modifier
@@ -256,51 +220,6 @@ fun ReaderTextView(
                         onLayout = { layout -> textLayout = layout },
                     )
                 }
-            }
-        }
-
-        // Issue #954 — "skip playback to where the reader has scrolled
-        // to." The TOP of the three-FAB brass cluster. Reverse direction
-        // of the #919 recenter below: that FAB pulls the reader to the
-        // playback's position; this one sends the playback to the
-        // reader's position. Same visual vocabulary (SmallFAB, primary
-        // tint) so the cluster reads as a related set of sync verbs.
-        //
-        // Visibility mirrors the #919 recenter's `sentenceOutOfView`
-        // gate — there's nothing to sync when the active sentence is
-        // already on screen — but DROPS the `state.isPlaying` half of
-        // the gate because the verb makes sense paused too (the user
-        // wants playback to start *from this point*).
-        //
-        // Tap computes the first visible character offset from the
-        // current scroll position + textLayout, then forwards it to
-        // [onSeekToChar] — the same callback tap-on-word already uses.
-        // No new VM method required; ReaderViewModel.seekToChar handles
-        // both word-taps and this FAB-tap identically.
-        AnimatedVisibility(
-            visible = showSeekToReaderFab,
-            modifier = Modifier
-                .align(Alignment.BottomEnd)
-                .padding(end = spacing.md, bottom = 232.dp),
-            enter = fadeIn() + slideInVertically { it / 2 },
-            exit = fadeOut() + slideOutVertically { it / 2 },
-        ) {
-            SmallFloatingActionButton(
-                onClick = {
-                    firstVisibleCharOffset?.let { offset ->
-                        onSeekToChar(offset.coerceIn(0, chapterText.length))
-                    }
-                },
-                modifier = Modifier.semantics {
-                    contentDescription = "Skip playback to where you're reading"
-                },
-                containerColor = MaterialTheme.colorScheme.primary,
-                contentColor = MaterialTheme.colorScheme.onPrimary,
-            ) {
-                Icon(
-                    imageVector = Icons.Outlined.WhereToVote,
-                    contentDescription = null,
-                )
             }
         }
 

--- a/feature/src/main/kotlin/in/jphe/storyvox/feature/reader/ReaderView.kt
+++ b/feature/src/main/kotlin/in/jphe/storyvox/feature/reader/ReaderView.kt
@@ -24,6 +24,7 @@ import androidx.compose.material.icons.filled.PlayArrow
 import androidx.compose.material.icons.filled.VerticalAlignCenter
 import androidx.compose.material.icons.outlined.AutoAwesome
 import androidx.compose.material.icons.outlined.AutoStories
+import androidx.compose.material.icons.outlined.WhereToVote
 import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.FilledIconButton
 import androidx.compose.material3.Icon
@@ -189,6 +190,41 @@ fun ReaderTextView(
     }
     val showScrollFab = sentenceOutOfView && state.isPlaying
 
+    // Issue #954 — "skip playback to where the reader has scrolled to."
+    // The reverse of #919's recenter. Derives the topmost line currently
+    // inside the viewport (with the same 80px margin as #919's
+    // out-of-view test so the two gates agree on what "visible" means)
+    // and returns its first character offset. Null when layout/text
+    // aren't ready, so the FAB stays hidden during chapter cold-load.
+    val firstVisibleCharOffset by remember {
+        derivedStateOf {
+            val layout = textLayout ?: return@derivedStateOf null
+            if (chapterText.isEmpty()) return@derivedStateOf null
+            if (viewportHeightPx <= 0f) return@derivedStateOf null
+            val margin = 80f
+            val viewportTopInBody = scroll.value.toFloat() - bodyTopPx + margin
+            if (viewportTopInBody < 0f) return@derivedStateOf 0
+            val lineCount = layout.lineCount
+            if (lineCount <= 0) return@derivedStateOf null
+            // Find the first line whose bottom is at or below the
+            // viewport top — that's the first line the user can
+            // actually read.
+            for (line in 0 until lineCount) {
+                if (layout.getLineBottom(line) > viewportTopInBody) {
+                    return@derivedStateOf layout.getLineStart(line)
+                }
+            }
+            layout.getLineStart(lineCount - 1)
+        }
+    }
+    // Show the "skip playback to here" FAB only when (a) the active
+    // sentence isn't already visible (otherwise the button would
+    // re-seek to a position you're already at — confusing) and (b) we
+    // have a valid first-visible offset to seek to. Independent of
+    // `state.isPlaying` — the user might be paused and want to start
+    // playing FROM the scroll position, which is exactly this verb.
+    val showSeekToReaderFab = sentenceOutOfView && firstVisibleCharOffset != null
+
     Box(modifier = modifier.fillMaxSize().onSizeChanged { viewportHeightPx = it.height.toFloat() }) {
         Column(
             modifier = Modifier
@@ -220,6 +256,51 @@ fun ReaderTextView(
                         onLayout = { layout -> textLayout = layout },
                     )
                 }
+            }
+        }
+
+        // Issue #954 — "skip playback to where the reader has scrolled
+        // to." The TOP of the three-FAB brass cluster. Reverse direction
+        // of the #919 recenter below: that FAB pulls the reader to the
+        // playback's position; this one sends the playback to the
+        // reader's position. Same visual vocabulary (SmallFAB, primary
+        // tint) so the cluster reads as a related set of sync verbs.
+        //
+        // Visibility mirrors the #919 recenter's `sentenceOutOfView`
+        // gate — there's nothing to sync when the active sentence is
+        // already on screen — but DROPS the `state.isPlaying` half of
+        // the gate because the verb makes sense paused too (the user
+        // wants playback to start *from this point*).
+        //
+        // Tap computes the first visible character offset from the
+        // current scroll position + textLayout, then forwards it to
+        // [onSeekToChar] — the same callback tap-on-word already uses.
+        // No new VM method required; ReaderViewModel.seekToChar handles
+        // both word-taps and this FAB-tap identically.
+        AnimatedVisibility(
+            visible = showSeekToReaderFab,
+            modifier = Modifier
+                .align(Alignment.BottomEnd)
+                .padding(end = spacing.md, bottom = 232.dp),
+            enter = fadeIn() + slideInVertically { it / 2 },
+            exit = fadeOut() + slideOutVertically { it / 2 },
+        ) {
+            SmallFloatingActionButton(
+                onClick = {
+                    firstVisibleCharOffset?.let { offset ->
+                        onSeekToChar(offset.coerceIn(0, chapterText.length))
+                    }
+                },
+                modifier = Modifier.semantics {
+                    contentDescription = "Skip playback to where you're reading"
+                },
+                containerColor = MaterialTheme.colorScheme.primary,
+                contentColor = MaterialTheme.colorScheme.onPrimary,
+            ) {
+                Icon(
+                    imageVector = Icons.Outlined.WhereToVote,
+                    contentDescription = null,
+                )
             }
         }
 


### PR DESCRIPTION
## Summary

Closes #955. Adds a first-class affordance for jumping from the player surface (Playing tab / Reader / Audiobook routes) into the currently-playing fiction's detail page, where the full chapter list already lives. JP's request: "still need a magical way to get to the library page from the playing page. The mini chapter pulldown doesn't work that well for everything; need a way to quickly get to the full library chapter list from the play tab."

A brass `Icons.AutoMirrored.Filled.MenuBook` `IconButton` sits on the player top-bar's leading cluster, immediately right of the existing Back arrow. Both are "leave this surface" verbs:
- **Back** returns to wherever you came from
- **MenuBook** takes you into the currently-playing fiction's detail page (cover + full chapter list — already the canonical home of that list in this app)

The trailing cluster on the top-bar stays reserved for playback-modifying affordances (voice quick sheet, overflow). Title's start padding bumps to 104 dp to balance the now-104 dp leading cluster — same symmetry treatment that #418 applied to the trailing edge.

`HybridReaderScreen` guards against the brief cold-load window where `fictionId` is still null (tap during that window is a no-op, no malformed `fictionDetail` route is pushed onto the back stack). `StoryvoxNavHost` wires the callback to `navController.navigate(StoryvoxRoutes.fictionDetail(fId))` for all three `HybridReaderScreen` entry points (PLAYING, READER, AUDIOBOOK).

### Scope note

This branch initially also addressed #954 with a third "skip playback to here" FAB on the reader pane. JP's smoke-test design call: that capability already exists via tap-on-sentence (the existing `onSeekToChar` path), so the new FAB was redundant. The third FAB has been reverted in commit 36bc413e; the reader-pane FAB cluster is back to its prior 2-FAB state (auto-scroll toggle + recenter), unchanged from `main`. #954 is being closed separately as "already covered."

## Test plan
- [x] `./gradlew :feature:compileDebugKotlin :app:compileDebugKotlin` — green
- [x] `./gradlew :feature:testDebugUnitTest` — pass
- [ ] Install debug APK on R83W80CAFZB. On the Playing tab, confirm the new brass `MenuBook` icon sits to the right of the Back arrow on the player top-bar.
- [ ] Tap it; verify navigation lands on the fiction-detail page with the chapter list visible. Back navigates cleanly back to the player.
- [ ] Tap during cold-load (before chapter starts playing) — confirm the no-op guard works (no crash, no malformed route).
- [ ] TalkBack swipe the top-bar — labels read "Back" then "Open chapter list" then the title/subtitle, then the trailing voice/overflow cluster.

🤖 Generated with [Claude Code](https://claude.com/claude-code)