### PR TITLE
perf(playback): mechanical cleanup — closes #930 #932 #953

### DIFF
--- a/core-playback/src/main/kotlin/in/jphe/storyvox/playback/tts/EnginePlayer.kt
+++ b/core-playback/src/main/kotlin/in/jphe/storyvox/playback/tts/EnginePlayer.kt
@@ -2133,6 +2133,14 @@ class EnginePlayer @AssistedInject constructor(
         // path and re-renders at the engine's current rate. Either
         // way, the AudioTrack sample rate, the cached PCM bytes,
         // and `silenceBytesFor` all agree.
+        // Issue #930 — the on-disk index read + JSON deserialization runs
+        // synchronously on whatever dispatcher called startPlaybackPipeline.
+        // The outer call sites are `scope.launch { startPlaybackPipeline() }`
+        // (scope is Dispatchers.Main), so on slow flash storage — e.g.
+        // Helio P22T tablet, where the read+parse measured ~30-80 ms — this
+        // block janks the UI thread and can trip StrictMode. Hop to IO for
+        // the read; the rest of pipeline construction stays on Main because
+        // it touches AudioTrack / Compose state which are main-thread-bound.
         val cachedIndexSampleRate: Int? = run {
             val chapId = _observableState.value.currentChapterId
             val voiceId = loadedVoiceId
@@ -2145,13 +2153,15 @@ class EnginePlayer @AssistedInject constructor(
                 chunkerVersion = CHUNKER_VERSION,
                 pronunciationDictHash = cachedPronunciationDict.contentHash,
             )
-            if (!pcmCache.isComplete(probeKey)) return@run null
-            val onDiskRate = runCatching {
-                pcmCacheJson.decodeFromString(
-                    PcmIndex.serializer(),
-                    pcmCache.indexFileFor(probeKey).readText(),
-                ).sampleRate
-            }.getOrNull() ?: return@run null
+            val onDiskRate = kotlinx.coroutines.withContext(Dispatchers.IO) {
+                if (!pcmCache.isComplete(probeKey)) return@withContext null
+                runCatching {
+                    pcmCacheJson.decodeFromString(
+                        PcmIndex.serializer(),
+                        pcmCache.indexFileFor(probeKey).readText(),
+                    ).sampleRate
+                }.getOrNull()
+            } ?: return@run null
             if (onDiskRate != engineSampleRate) {
                 android.util.Log.w(
                     "EnginePlayer",
@@ -2159,7 +2169,7 @@ class EnginePlayer @AssistedInject constructor(
                         "on-disk=$onDiskRate base=${probeKey.fileBaseName().take(12)}; " +
                         "invalidating cache entry and re-rendering",
                 )
-                runBlocking { pcmCache.delete(probeKey) }
+                pcmCache.delete(probeKey)
                 return@run null
             }
             onDiskRate
@@ -2719,8 +2729,18 @@ class EnginePlayer @AssistedInject constructor(
                         // exits promptly (50 ms polling matches the
                         // userPaused park above).
                         if (source.producerQueueCapacity() > 0) {
+                            // Issue #932 — capture startTimeNanos directly
+                            // rather than reconstructing it from
+                            // (deadlineNanos - PREBUFFER_TIMEOUT_MS *
+                            // 1_000_000L) in the elapsedMs log below. The
+                            // reconstruction was algebraically correct but
+                            // a future tweak to either side (timeout
+                            // constant, deadline computation) silently
+                            // diverges the two without a compile-time
+                            // failure.
+                            val startTimeNanos = System.nanoTime()
                             val deadlineNanos =
-                                System.nanoTime() + PREBUFFER_TIMEOUT_MS * 1_000_000L
+                                startTimeNanos + PREBUFFER_TIMEOUT_MS * 1_000_000L
                             val target = PREBUFFER_TARGET_CHUNKS - 1
                             while (pipelineRunning.get() &&
                                 !userPaused.get() &&
@@ -2741,8 +2761,7 @@ class EnginePlayer @AssistedInject constructor(
                                 "#862 prebuffer-gate: depth=${source.producerQueueDepth()} " +
                                     "target=$target producedAll=${source.producedAllSentences} " +
                                     "elapsedMs=${
-                                        (System.nanoTime() - (deadlineNanos -
-                                            PREBUFFER_TIMEOUT_MS * 1_000_000L)) / 1_000_000L
+                                        (System.nanoTime() - startTimeNanos) / 1_000_000L
                                     }"
                             }
                         }
@@ -3791,10 +3810,20 @@ class EnginePlayer @AssistedInject constructor(
         // Issue #929 — stamp a fresh token so an overlapping
         // `advanceChapter` (e.g. user double-tap, or watchdog firing
         // mid-body-wait) doesn't let our `finally` clear a latch the
-        // newer invocation owns. Order matters: bump token BEFORE
-        // writing direction so a concurrent reader either sees the new
-        // (token, direction) pair or the old one — never a torn
-        // (newToken, oldDirection).
+        // newer invocation owns. The token serves only as
+        // invocation-ownership proof for the matching `finally` block:
+        // no external reader inspects the (token, direction) pair as a
+        // tuple, so the brief window between the two writes (where a
+        // reader could observe `newToken` with `oldDirection`) is
+        // harmless. What we DO guarantee, and the watchdog relies on,
+        // is that the `finally` only clears `inFlightAdvanceDirection`
+        // when the current `inFlightAdvanceToken` still equals our
+        // captured `myToken` — so a later overlapping `advanceChapter`
+        // call (which has bumped the token past ours) is protected
+        // from our cleanup. Issue #953 — tightens the earlier KDoc
+        // claim that the two writes were torn-free as a tuple; they
+        // aren't, but the invariant the code needs is the finally-time
+        // token comparison, not pair-atomicity at write time.
         val myToken = advanceInvocationCounter.incrementAndGet()
         inFlightAdvanceToken = myToken
         inFlightAdvanceDirection = normalizedDir


### PR DESCRIPTION
## Summary

Three independent low-risk cleanups in `EnginePlayer.kt` from Gemini review feedback, batched. No behavioral change.

- **#930** — `pcmCache.indexFileFor(probeKey).readText()` + JSON deserialization at line ~2152 measured 30-80 ms on Helio P22T flash. The outer `startPlaybackPipeline` runs on `Dispatchers.Main` (the call sites are `scope.launch { ... }` and `scope = Main`), so the synchronous file read janks the UI thread and can trip StrictMode. Wrap the read + `isComplete` check in `withContext(Dispatchers.IO)`. The post-read mismatch branch already uses a suspend `pcmCache.delete(probeKey)` (internally `withContext(IO)`), so the leftover `runBlocking` wrapper was redundant — removed.
- **#932** — `elapsedMs` in the prebuffer-gate log reconstructed start time from `deadlineNanos - PREBUFFER_TIMEOUT_MS * 1_000_000L`. Algebraically correct but a future tweak to either side silently diverges the two without compile-time failure. Capture `startTimeNanos = System.nanoTime()` directly.
- **#953** — tighten KDoc on the `inFlightAdvanceToken` ordering comment. The prior wording claimed concurrent readers would never see a torn `(newToken, oldDirection)` pair — they CAN, between the two writes; the implementation is still correct because no external reader inspects the pair as a tuple, and the finally-time `inFlightAdvanceToken == myToken` comparison is the actual load-bearing invariant. Reworded to say so. Pure docs.

Separate from PR #966 (#944/#956 concurrency fix) so the high-risk behavioral PR can iterate after JP's device smoke-test without blocking these trivial cleanups.

## Test plan

- [x] `./gradlew :core-playback:compileDebugKotlin` — clean
- [x] `./gradlew :core-playback:testDebugUnitTest` — green
- [ ] No device repro required for any of the three — #930 is a dispatcher hop with the same observable result, #932 is an arithmetic rewrite of a debug log line, #953 is comment-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)