### PR TITLE
fix(app): join upgrade handler before starting prerender watcher (#931)

### DIFF
--- a/app/src/main/kotlin/in/jphe/storyvox/StoryvoxApp.kt
+++ b/app/src/main/kotlin/in/jphe/storyvox/StoryvoxApp.kt
@@ -179,7 +179,15 @@ class StoryvoxApp : Application(), Configuration.Provider {
         // first cache read is downstream of user interaction (tap a
         // chapter) so a short DataStore read + File.delete sweep here
         // is always done well before the cache is needed.
-        initScope.launch {
+        //
+        // Issue #931 — capture this Job so [prerenderModeWatcher] can
+        // join() before it starts. If an upgrade is detected,
+        // [runIfUpgraded] wipes the PCM cache root, which races with
+        // any writer that has already opened a file under it. The
+        // watcher is the only init-time writer that touches the cache,
+        // so serializing watcher-start → upgrade-handler-finish is
+        // sufficient; everything else on initScope stays concurrent.
+        val upgradeHandlerJob = initScope.launch {
             versionUpgradeHandler.get().runIfUpgraded()
         }
         initScope.launch {
@@ -221,7 +229,17 @@ class StoryvoxApp : Application(), Configuration.Provider {
         // materialised off the cold-launch critical path; start()
         // launches its own long-running collector inside the watcher's
         // singleton scope.
+        //
+        // Issue #931 — join the upgrade-handler Job first. The watcher
+        // writes pre-rendered PCM into the same cache root that
+        // [VersionUpgradeHandler.runIfUpgraded] wipes on a versionCode
+        // change; without the join the two race and the watcher's
+        // freshly-written files can be deleted (or its writes can hit
+        // an I/O exception mid-sweep). Joining serializes only that
+        // one ordering — the watcher still runs on IO and the rest of
+        // init stays concurrent.
         initScope.launch {
+            upgradeHandlerJob.join()
             prerenderModeWatcher.get().start()
         }
         // Issue #159 — start the widget state observer once the Hilt


### PR DESCRIPTION
Fixes #931. Surfaced by Gemini on PR #895.

## Race

`StoryvoxApp.onCreate` launched both jobs on `initScope` (Dispatchers.IO) concurrently:

- `versionUpgradeHandler.get().runIfUpgraded()` — on a versionCode change, calls `pcmCache.clearAll()` (recursive `File.delete()` over the PCM cache root).
- `prerenderModeWatcher.get().start()` — Mode C flow collector that writes pre-rendered PCM into the same cache root.

If both ran on the cold-launch path during an upgrade, the watcher's freshly written files could be deleted by the wipe, or the wipe could hit an `IOException` while the watcher held a file open. Subtle because it only fires on the first launch after a version change.

## Fix

Capture the upgrade-handler launch as a `Job`, then `join()` it from the watcher launch before calling `start()`. Everything else on `initScope` stays concurrent — only the watcher's `start()` waits for the cache wipe (if any) to finish.

KDoc on both launches now spells out the ordering dependency so a future refactor doesn't silently re-introduce the race.

## Verification

- `./gradlew :app:compileDebugKotlin` — clean.
- Diff is a single file, 19 insertions / 1 deletion.

## Test plan

- [ ] CI green
- [ ] Install on R83W80CAFZB after release — confirm clean launch when bumping versionCode triggers the upgrade path