### PR TITLE
chore(i18n): extract hardcoded user-facing strings to resources (#943)

### DIFF
--- a/core-ui/src/main/res/values/strings.xml
+++ b/core-ui/src/main/res/values/strings.xml
@@ -5,7 +5,8 @@
          the user actually reads. -->
     <string name="friendly_error_generic">Something went wrong. Try again in a moment.</string>
     <string name="friendly_error_network_lost">Connection lost. Check your network and try again.</string>
-    <string name="friendly_error_cloudflare_challenge">Royal Road asked us to wait. Try again in a moment.</string>
+    <!-- Issue #943 — generic across any Cloudflare-protected source, not just Royal Road. -->
+    <string name="friendly_error_cloudflare_challenge">The source asked us to wait. Try again in a moment.</string>
     <string name="friendly_error_rate_limited">We\'re sending requests too fast — slow down and try again.</string>
     <string name="friendly_error_server_error">The realm is having trouble. Try again in a moment.</string>
     <string name="friendly_error_auth_failed">We couldn\'t sign in. Re-paste your credentials in Settings.</string>

--- a/feature/src/main/kotlin/in/jphe/storyvox/feature/library/AddByUrlSheet.kt
+++ b/feature/src/main/kotlin/in/jphe/storyvox/feature/library/AddByUrlSheet.kt
@@ -100,7 +100,7 @@ fun AddByUrlSheet(
                 )
             } else {
                 Text(
-                    "Add by URL",
+                    stringResource(R.string.library_add_by_url_title),
                     style = MaterialTheme.typography.titleLarge,
                     modifier = Modifier.padding(top = spacing.sm),
                 )
@@ -110,13 +110,12 @@ fun AddByUrlSheet(
                 // magic-link catch-alls; #700 wires the multi-match
                 // chooser on top of that plumbing.
                 Text(
-                    "Paste a fiction URL — we'll auto-detect the source.",
+                    stringResource(R.string.library_add_by_url_subtitle),
                     style = MaterialTheme.typography.bodyMedium,
                     color = MaterialTheme.colorScheme.onSurfaceVariant,
                 )
                 Text(
-                    "Supported: Royal Road · AO3 · GitHub · Gutenberg · arXiv · " +
-                        "RSS · Wikipedia · direct EPUB",
+                    stringResource(R.string.library_add_by_url_supported),
                     style = MaterialTheme.typography.labelSmall,
                     color = MaterialTheme.colorScheme.onSurfaceVariant,
                 )
@@ -152,7 +151,7 @@ fun AddByUrlSheet(
                     verticalAlignment = Alignment.CenterVertically,
                 ) {
                     BrassButton(
-                        label = "Paste",
+                        label = stringResource(R.string.library_add_by_url_paste),
                         onClick = {
                             readClipboardText(context)?.let { clip ->
                                 if (clip.isNotBlank()) input = clip
@@ -162,7 +161,10 @@ fun AddByUrlSheet(
                         enabled = !isSubmitting,
                     )
                     BrassButton(
-                        label = if (isSubmitting) "Adding…" else "Add",
+                        label = stringResource(
+                            if (isSubmitting) R.string.library_add_by_url_adding
+                            else R.string.library_add_by_url_add,
+                        ),
                         onClick = { onSubmit(input.trim()) },
                         variant = BrassButtonVariant.Primary,
                         enabled = !isSubmitting && input.isNotBlank(),
@@ -192,12 +194,12 @@ private fun ChooseSourceBody(
 ) {
     val spacing = LocalSpacing.current
     Text(
-        "Where do you want to add this from?",
+        stringResource(R.string.library_add_by_url_chooser_title),
         style = MaterialTheme.typography.titleLarge,
         modifier = Modifier.padding(top = spacing.sm),
     )
     Text(
-        "Several sources can handle this URL. Pick the one that fits best.",
+        stringResource(R.string.library_add_by_url_chooser_subtitle),
         style = MaterialTheme.typography.bodyMedium,
         color = MaterialTheme.colorScheme.onSurfaceVariant,
     )
@@ -227,7 +229,7 @@ private fun ChooseSourceBody(
         horizontalArrangement = Arrangement.spacedBy(spacing.sm),
     ) {
         BrassButton(
-            label = "Back",
+            label = stringResource(R.string.library_add_by_url_chooser_back),
             onClick = onCancel,
             variant = BrassButtonVariant.Secondary,
         )
@@ -240,6 +242,7 @@ private fun CandidateRow(
     onPick: (String) -> Unit,
 ) {
     val spacing = LocalSpacing.current
+    val candidateCd = stringResource(R.string.library_add_by_url_candidate_cd, candidate.label)
     Surface(
         shape = RoundedCornerShape(12.dp),
         color = MaterialTheme.colorScheme.surfaceVariant,
@@ -248,7 +251,7 @@ private fun CandidateRow(
             .clickable { onPick(candidate.sourceId) }
             .semantics {
                 role = Role.Button
-                contentDescription = "Add from ${candidate.label}"
+                contentDescription = candidateCd
             },
     ) {
         Column(

--- a/feature/src/main/kotlin/in/jphe/storyvox/feature/library/ManageShelvesSheet.kt
+++ b/feature/src/main/kotlin/in/jphe/storyvox/feature/library/ManageShelvesSheet.kt
@@ -17,8 +17,10 @@ import androidx.compose.material3.rememberModalBottomSheetState
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.semantics.Role
 import `in`.jphe.storyvox.data.db.entity.Shelf
+import `in`.jphe.storyvox.feature.R
 import `in`.jphe.storyvox.ui.theme.LocalSpacing
 
 /**
@@ -63,7 +65,7 @@ fun ManageShelvesSheet(
             verticalArrangement = Arrangement.spacedBy(spacing.sm),
         ) {
             Text(
-                text = "Manage shelves",
+                text = stringResource(R.string.manage_shelves_title),
                 style = MaterialTheme.typography.titleMedium,
                 color = MaterialTheme.colorScheme.primary,
             )
@@ -121,7 +123,7 @@ fun ManageShelvesSheet(
                 verticalAlignment = Alignment.CenterVertically,
             ) {
                 Text(
-                    text = "Remove from library",
+                    text = stringResource(R.string.manage_shelves_remove_from_library),
                     style = MaterialTheme.typography.bodyLarge,
                     color = MaterialTheme.colorScheme.error,
                 )

--- a/feature/src/main/kotlin/in/jphe/storyvox/feature/sync/SyncStatusComposables.kt
+++ b/feature/src/main/kotlin/in/jphe/storyvox/feature/sync/SyncStatusComposables.kt
@@ -19,7 +19,10 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
+import `in`.jphe.storyvox.feature.R
 import `in`.jphe.storyvox.sync.coordinator.SyncStatus
 import `in`.jphe.storyvox.ui.theme.LocalSpacing
 
@@ -82,10 +85,18 @@ internal fun DomainStatusIcon(status: SyncStatus) {
     )
 }
 
-internal fun describeSyncStatus(status: SyncStatus): String = when (status) {
-    SyncStatus.Idle -> "Idle"
-    SyncStatus.Running -> "Syncing…"
-    is SyncStatus.OkAt -> "Synced (${status.records} record${if (status.records == 1) "" else "s"})"
-    is SyncStatus.Transient -> "Retrying: ${status.message}"
-    is SyncStatus.Permanent -> "Stopped: ${status.message}"
+@Composable
+internal fun describeSyncStatus(status: SyncStatus): String {
+    val context = LocalContext.current
+    return when (status) {
+        SyncStatus.Idle -> stringResource(R.string.sync_status_idle)
+        SyncStatus.Running -> stringResource(R.string.sync_status_running)
+        is SyncStatus.OkAt -> context.resources.getQuantityString(
+            R.plurals.sync_status_synced_records,
+            status.records,
+            status.records,
+        )
+        is SyncStatus.Transient -> stringResource(R.string.sync_status_transient, status.message)
+        is SyncStatus.Permanent -> stringResource(R.string.sync_status_permanent, status.message)
+    }
 }

--- a/feature/src/main/res/values/plurals.xml
+++ b/feature/src/main/res/values/plurals.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <!-- Issue #943 — replaces manual `record${if (n == 1) "" else "s"}` in SyncStatusComposables.describeSyncStatus. -->
+    <plurals name="sync_status_synced_records">
+        <item quantity="one">Synced (%d record)</item>
+        <item quantity="other">Synced (%d records)</item>
+    </plurals>
+</resources>

--- a/feature/src/main/res/values/strings.xml
+++ b/feature/src/main/res/values/strings.xml
@@ -781,6 +781,41 @@
     <string name="settings_section_about_label">About</string>
     <string name="settings_section_about_descriptor">Build identity for bug reports.</string>
 
+    <!-- ════════════════════════════════════════════════════════════ -->
+    <!-- Issue #943 — i18n hardcoded user-facing strings              -->
+    <!-- ════════════════════════════════════════════════════════════ -->
+
+    <!-- AddByUrlSheet -->
+    <string name="library_add_by_url_title">Add by URL</string>
+    <string name="library_add_by_url_subtitle">Paste a fiction URL — we\'ll auto-detect the source.</string>
+    <string name="library_add_by_url_supported">Supported: Royal Road · AO3 · GitHub · Gutenberg · arXiv · RSS · Wikipedia · direct EPUB</string>
+    <string name="library_add_by_url_paste">Paste</string>
+    <string name="library_add_by_url_add">Add</string>
+    <string name="library_add_by_url_adding">Adding…</string>
+    <string name="library_add_by_url_chooser_title">Where do you want to add this from?</string>
+    <string name="library_add_by_url_chooser_subtitle">Several sources can handle this URL. Pick the one that fits best.</string>
+    <string name="library_add_by_url_chooser_back">Back</string>
+    <string name="library_add_by_url_candidate_cd">Add from %1$s</string>
+
+    <!-- ManageShelvesSheet -->
+    <string name="manage_shelves_title">Manage shelves</string>
+    <string name="manage_shelves_remove_from_library">Remove from library</string>
+
+    <!-- NOTE: Source-side filter labels (Wikipedia/Wikisource "Most relevant"/
+         "Newest"/"Oldest", Wikisource "Form"/"Author"/"Include proofread") are
+         strings returned from FictionSource.filterDimensions() in :source-*
+         modules with no res/ dirs. Moving those requires changing the
+         FilterDimension data classes in :core-data to carry @StringRes IDs (or
+         deferring resolution to the rendering layer in DynamicFilterSheet),
+         a contract change touching all 24 source modules. Tracked as a
+         follow-up to #943 — out of scope for this PR. -->
+
+    <!-- Sync status pluralization (replaces inline manual plural in describeSyncStatus) -->
+    <string name="sync_status_idle">Idle</string>
+    <string name="sync_status_running">Syncing…</string>
+    <string name="sync_status_transient">Retrying: %1$s</string>
+    <string name="sync_status_permanent">Stopped: %1$s</string>
+
     <!-- Settings · GitHub sign-in row -->
     <string name="settings_github_title">GitHub</string>
     <string name="settings_github_anon_subtitle">Sign in lifts the 60 req/hr anon cap to 5,000 req/hr and unlocks repository READMEs as fictions. read:user + public_repo only.</string>


### PR DESCRIPTION
Closes part of #943.

## Summary

Tier-1 sweep of the issue-cited locations:

- **AddByUrlSheet** (`feature/library/AddByUrlSheet.kt`) — title, subtitle, supported-sources line, Paste/Add/Adding buttons, chooser title/subtitle/Back, candidate `contentDescription` → `R.string.library_add_by_url_*`.
- **ManageShelvesSheet** (`feature/library/ManageShelvesSheet.kt`) — "Manage shelves", "Remove from library" → `R.string.manage_shelves_*`.
- **SyncStatusComposables.describeSyncStatus** — converted to `@Composable`, swapped inline manual pluralization (`record\${if (n == 1) "" else "s"}`) for a proper `<plurals>` resource in new `feature/src/main/res/values/plurals.xml`.
- **`core-ui` Cloudflare error string** — `friendly_error_cloudflare_challenge` was hardcoded to "Royal Road asked us to wait" but the FriendlyError mapping fires for any Cloudflare-protected source. Rewritten to "The source asked us to wait. Try again in a moment."

## Deliberately out of scope (deferred)

The audit found ~300+ user-facing literal sites across 30+ files. Triaged into tiers:

- **Source-module filter labels** (`WikipediaSource`/`WikisourceSource` "Most relevant"/"Newest"/"Oldest", Wikisource "Form"/"Author"/"Include proofread"). These are returned from `FictionSource.filterDimensions()` as raw strings, and the `:source-*` modules have no `res/` dirs. Extracting cleanly requires a `FilterDimension` contract change in `:core-data` to carry `@StringRes` IDs (or move label resolution into `DynamicFilterSheet`), touching all 24 source modules. Worth doing in its own PR.
- **`SettingsScreen.kt` legacy long-scroll** (~125 sites). Most duplicate strings already added to `feature/strings.xml` by #799's "Settings · legacy" section — almost pure `stringResource()`-swap work, but it's a 4053-line file and outside the issue's "non-exhaustive 15+" framing. Better as a dedicated follow-up.
- **High-traffic surfaces** (`BrowseScreen`, `FictionDetailScreen`, `VoiceLibraryScreen`, `PluginManagerScreen`, `AudiobookView`, auth screens) — ~150+ literal sites. Defer to per-screen follow-ups so each PR has a tight regression surface.

The `SettingsHubScreen.kt:151,186` references in the issue body are actually a unit-test fixture (`SettingsHubSections` data class for asserting row order); the rendered hub rows are already fully `stringResource()`d.

## Test plan

- [x] `./gradlew :feature:compileDebugKotlin` — clean (pre-existing deprecation warnings only)
- [x] `./gradlew :app:compileDebugKotlin` — clean
- [x] `./gradlew :feature:testDebugUnitTest` — passing
- [x] `./gradlew :core-ui:testDebugUnitTest` — passing
- [ ] Manual check on R83W80CAFZB: open Library → long-press a card to confirm "Manage shelves" + "Remove from library" still read correctly; open Add-by-URL sheet to confirm title/Paste/Add render; trigger a sync to confirm the new "Synced (1 record)" / "Synced (5 records)" plural variants format correctly.