### PR TITLE
fix(playback): tighten position poll 100ms→50ms to reduce A/V lag (#970)

### DIFF
--- a/core-playback/src/main/kotlin/in/jphe/storyvox/playback/PlaybackController.kt
+++ b/core-playback/src/main/kotlin/in/jphe/storyvox/playback/PlaybackController.kt
@@ -371,14 +371,24 @@ class DefaultPlaybackController @Inject constructor(
                 }
             }
         }
-        // #539 — poll the engine for the truthful audio position. Polls
-        // every 100 ms while a chapter is loaded; lower than that and the
-        // scrubber jitters from the AudioTrack frame-counter granularity
-        // (sherpa-onnx is 24 kHz, so 1 ms = 24 frames; the poll cadence
-        // dominates jitter, not the counter). Idle when no chapter
-        // loaded — we skip emissions equal to the last value so a paused
-        // chapter doesn't burn CPU. Bound to the controller's scope so
-        // it dies with bindPlayer/unbindPlayer pairs.
+        // #539 / #970 — poll the engine for the truthful audio position.
+        // Polls every 50 ms while a chapter is loaded. The original
+        // cadence (#539) was 100 ms with the rationale that lower polls
+        // would let AudioTrack frame-counter granularity dominate the
+        // scrubber's jitter (sherpa-onnx is 24 kHz, so 1 ms = 24
+        // frames; the poll cadence dominates jitter, not the counter).
+        // That reasoning is still correct — 50 ms is well above any
+        // frame-quantum floor for our sample rates — but the 100 ms
+        // cadence cost an average sampling lag of 50 ms (up to 100 ms
+        // worst-case) on the position display vs. audible output.
+        // Issue #970 surfaced that the visual position / sentence
+        // highlight catches up "a beat later" than the speaker; the
+        // poll cadence is the largest cleanly-fixable contributor.
+        // Halving the interval halves the sampling lag with negligible
+        // CPU cost (one currentPositionMs JNI read per 50 ms while
+        // playing; idle paths still skip equal-value emissions so a
+        // paused chapter doesn't burn CPU). Bound to the controller's
+        // scope so it dies with bindPlayer/unbindPlayer pairs.
         scope.launch {
             while (true) {
                 val live = player ?: break
@@ -386,7 +396,7 @@ class DefaultPlaybackController @Inject constructor(
                 if (pos != _playbackPositionMs.value) {
                     _playbackPositionMs.value = pos
                 }
-                kotlinx.coroutines.delay(100L)
+                kotlinx.coroutines.delay(50L)
             }
         }
         // Calliope (v0.5.00) — bridge the player's internal uiEvents


### PR DESCRIPTION
Closes #970 (the actionable portion). Follow-up #974 captures the deferred deeper work.

## Summary

`PlaybackController` polls `EnginePlayer.currentPositionMs()` to feed the scrubber thumb, position counter, and sentence-highlight binding. The original cadence (#539) was 100 ms with the rationale that lower polls would let AudioTrack frame-counter granularity dominate the scrubber's jitter.

That rationale is still correct — 50 ms is well above any frame-quantum floor for our sample rates — but the 100 ms cadence cost an average sampling lag of 50 ms (up to 100 ms worst-case) on the position display vs. audible output. Halving the interval halves the sampling lag.

## Investigation

Three independent contributors stack to produce the "display catches up a beat after the speaker" lag identified in #970:

1. **Poll cadence (this PR)** — 100 ms → 50 ms. Largest cleanly-fixable contributor. Avg sampling lag halved.
2. **`getPlaybackHeadPosition()` reporting on Samsung** — deferred to #974. `getTimestamp(AudioTimestamp)` would tighten this 30–80 ms but touches the hot position formula locked down through #536/#539/#554/#555/#566. Not worth pre-1.0.
3. **Sentence-range emit dispatch through Main** — deferred to #974. Touches the URGENT_AUDIO decoupling that #865 deliberately added. Not worth pre-1.0.

Full analysis in #974.

## Cost

Negligible. One `currentPositionMs` JNI read per 50 ms while playing instead of per 100 ms. Idle paths still skip equal-value emissions, so a paused chapter doesn't burn CPU.

## Verification

- `./gradlew :core-playback:compileDebugKotlin` — green.
- `./gradlew :core-playback:testDebugUnitTest` — green.
- No tests pinned the 100 ms value (grep'd; the 100s elsewhere in playback tests are unrelated fixtures).

## Test plan

- [ ] Install on R83W80CAFZB.
- [ ] Play a chapter and confirm the scrubber / position counter / sentence highlight track audible output more tightly than before.
- [ ] Verify no scrubber jitter (the original concern from #539 — 50 ms is still well above the AudioTrack frame-counter quantum at 24 kHz).
- [ ] Pause + resume, seek, speed-change — no regression on existing position-related fixes (#536, #554, #555, #566).

🤖 Generated with [Claude Code](https://claude.com/claude-code)