### PR TITLE
feat(playback): per-chapter playback position — (fictionId,chapterId) PK + v11 migration (#965)

### DIFF
--- a/core-data/schemas/in.jphe.storyvox.data.db.StoryvoxDatabase/11.json
+++ b/core-data/schemas/in.jphe.storyvox.data.db.StoryvoxDatabase/11.json
@@ -1,0 +1,975 @@
+{
+  "formatVersion": 1,
+  "database": {
+    "version": 11,
+    "identityHash": "da10e2cb27f64f4de299785a7ef4a5e1",
+    "entities": [
+      {
+        "tableName": "fiction",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `sourceId` TEXT NOT NULL, `title` TEXT NOT NULL, `author` TEXT NOT NULL, `authorId` TEXT, `coverUrl` TEXT, `description` TEXT, `genres` TEXT NOT NULL, `tags` TEXT NOT NULL, `status` TEXT NOT NULL, `chapterCount` INTEGER NOT NULL, `wordCount` INTEGER, `rating` REAL, `views` INTEGER, `followers` INTEGER, `lastUpdatedAt` INTEGER, `firstSeenAt` INTEGER NOT NULL, `metadataFetchedAt` INTEGER NOT NULL, `inLibrary` INTEGER NOT NULL, `addedToLibraryAt` INTEGER, `followedRemotely` INTEGER NOT NULL, `downloadMode` TEXT, `pinnedVoiceId` TEXT, `pinnedVoiceLocale` TEXT, `notesEverSeen` INTEGER NOT NULL, `lastSeenRevision` TEXT, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "sourceId",
+            "columnName": "sourceId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "title",
+            "columnName": "title",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "author",
+            "columnName": "author",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "authorId",
+            "columnName": "authorId",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "coverUrl",
+            "columnName": "coverUrl",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "description",
+            "columnName": "description",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "genres",
+            "columnName": "genres",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "tags",
+            "columnName": "tags",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "status",
+            "columnName": "status",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "chapterCount",
+            "columnName": "chapterCount",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "wordCount",
+            "columnName": "wordCount",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "rating",
+            "columnName": "rating",
+            "affinity": "REAL"
+          },
+          {
+            "fieldPath": "views",
+            "columnName": "views",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "followers",
+            "columnName": "followers",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "lastUpdatedAt",
+            "columnName": "lastUpdatedAt",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "firstSeenAt",
+            "columnName": "firstSeenAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "metadataFetchedAt",
+            "columnName": "metadataFetchedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "inLibrary",
+            "columnName": "inLibrary",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "addedToLibraryAt",
+            "columnName": "addedToLibraryAt",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "followedRemotely",
+            "columnName": "followedRemotely",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "downloadMode",
+            "columnName": "downloadMode",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "pinnedVoiceId",
+            "columnName": "pinnedVoiceId",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "pinnedVoiceLocale",
+            "columnName": "pinnedVoiceLocale",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "notesEverSeen",
+            "columnName": "notesEverSeen",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastSeenRevision",
+            "columnName": "lastSeenRevision",
+            "affinity": "TEXT"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_fiction_inLibrary",
+            "unique": false,
+            "columnNames": [
+              "inLibrary"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_fiction_inLibrary` ON `${TABLE_NAME}` (`inLibrary`)"
+          },
+          {
+            "name": "index_fiction_followedRemotely",
+            "unique": false,
+            "columnNames": [
+              "followedRemotely"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_fiction_followedRemotely` ON `${TABLE_NAME}` (`followedRemotely`)"
+          },
+          {
+            "name": "index_fiction_sourceId_lastUpdatedAt",
+            "unique": false,
+            "columnNames": [
+              "sourceId",
+              "lastUpdatedAt"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_fiction_sourceId_lastUpdatedAt` ON `${TABLE_NAME}` (`sourceId`, `lastUpdatedAt`)"
+          },
+          {
+            "name": "index_fiction_inLibrary_addedToLibraryAt",
+            "unique": false,
+            "columnNames": [
+              "inLibrary",
+              "addedToLibraryAt"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_fiction_inLibrary_addedToLibraryAt` ON `${TABLE_NAME}` (`inLibrary`, `addedToLibraryAt`)"
+          },
+          {
+            "name": "index_fiction_followedRemotely_lastUpdatedAt",
+            "unique": false,
+            "columnNames": [
+              "followedRemotely",
+              "lastUpdatedAt"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_fiction_followedRemotely_lastUpdatedAt` ON `${TABLE_NAME}` (`followedRemotely`, `lastUpdatedAt`)"
+          }
+        ]
+      },
+      {
+        "tableName": "chapter",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `fictionId` TEXT NOT NULL, `sourceChapterId` TEXT NOT NULL, `index` INTEGER NOT NULL, `title` TEXT NOT NULL, `publishedAt` INTEGER, `wordCount` INTEGER, `htmlBody` TEXT, `plainBody` TEXT, `bodyFetchedAt` INTEGER, `bodyChecksum` TEXT, `downloadState` TEXT NOT NULL, `lastDownloadAttemptAt` INTEGER, `lastDownloadError` TEXT, `notesAuthor` TEXT, `notesAuthorPosition` TEXT, `userMarkedRead` INTEGER NOT NULL, `firstReadAt` INTEGER, `bookmarkCharOffset` INTEGER, `audioUrl` TEXT, PRIMARY KEY(`id`), FOREIGN KEY(`fictionId`) REFERENCES `fiction`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "fictionId",
+            "columnName": "fictionId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "sourceChapterId",
+            "columnName": "sourceChapterId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "index",
+            "columnName": "index",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "title",
+            "columnName": "title",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "publishedAt",
+            "columnName": "publishedAt",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "wordCount",
+            "columnName": "wordCount",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "htmlBody",
+            "columnName": "htmlBody",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "plainBody",
+            "columnName": "plainBody",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "bodyFetchedAt",
+            "columnName": "bodyFetchedAt",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "bodyChecksum",
+            "columnName": "bodyChecksum",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "downloadState",
+            "columnName": "downloadState",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastDownloadAttemptAt",
+            "columnName": "lastDownloadAttemptAt",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "lastDownloadError",
+            "columnName": "lastDownloadError",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "notesAuthor",
+            "columnName": "notesAuthor",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "notesAuthorPosition",
+            "columnName": "notesAuthorPosition",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "userMarkedRead",
+            "columnName": "userMarkedRead",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "firstReadAt",
+            "columnName": "firstReadAt",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "bookmarkCharOffset",
+            "columnName": "bookmarkCharOffset",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "audioUrl",
+            "columnName": "audioUrl",
+            "affinity": "TEXT"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_chapter_fictionId",
+            "unique": false,
+            "columnNames": [
+              "fictionId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_chapter_fictionId` ON `${TABLE_NAME}` (`fictionId`)"
+          },
+          {
+            "name": "index_chapter_fictionId_index",
+            "unique": true,
+            "columnNames": [
+              "fictionId",
+              "index"
+            ],
+            "orders": [],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_chapter_fictionId_index` ON `${TABLE_NAME}` (`fictionId`, `index`)"
+          },
+          {
+            "name": "index_chapter_downloadState",
+            "unique": false,
+            "columnNames": [
+              "downloadState"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_chapter_downloadState` ON `${TABLE_NAME}` (`downloadState`)"
+          },
+          {
+            "name": "index_chapter_fictionId_userMarkedRead",
+            "unique": false,
+            "columnNames": [
+              "fictionId",
+              "userMarkedRead"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_chapter_fictionId_userMarkedRead` ON `${TABLE_NAME}` (`fictionId`, `userMarkedRead`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "fiction",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "fictionId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "playback_position",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`fictionId` TEXT NOT NULL, `chapterId` TEXT NOT NULL, `charOffset` INTEGER NOT NULL, `paragraphIndex` INTEGER NOT NULL, `playbackSpeed` REAL NOT NULL, `durationEstimateMs` INTEGER NOT NULL, `updatedAt` INTEGER NOT NULL, PRIMARY KEY(`fictionId`, `chapterId`), FOREIGN KEY(`fictionId`) REFERENCES `fiction`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE , FOREIGN KEY(`chapterId`) REFERENCES `chapter`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "fictionId",
+            "columnName": "fictionId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "chapterId",
+            "columnName": "chapterId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "charOffset",
+            "columnName": "charOffset",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "paragraphIndex",
+            "columnName": "paragraphIndex",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "playbackSpeed",
+            "columnName": "playbackSpeed",
+            "affinity": "REAL",
+            "notNull": true
+          },
+          {
+            "fieldPath": "durationEstimateMs",
+            "columnName": "durationEstimateMs",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "updatedAt",
+            "columnName": "updatedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "fictionId",
+            "chapterId"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_playback_position_chapterId",
+            "unique": false,
+            "columnNames": [
+              "chapterId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_playback_position_chapterId` ON `${TABLE_NAME}` (`chapterId`)"
+          },
+          {
+            "name": "index_playback_position_updatedAt",
+            "unique": false,
+            "columnNames": [
+              "updatedAt"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_playback_position_updatedAt` ON `${TABLE_NAME}` (`updatedAt`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "fiction",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "fictionId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          },
+          {
+            "table": "chapter",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "chapterId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "auth_cookie",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`sourceId` TEXT NOT NULL, `userDisplayName` TEXT, `userId` TEXT, `capturedAt` INTEGER NOT NULL, `expiresAt` INTEGER, `lastVerifiedAt` INTEGER NOT NULL, PRIMARY KEY(`sourceId`))",
+        "fields": [
+          {
+            "fieldPath": "sourceId",
+            "columnName": "sourceId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "userDisplayName",
+            "columnName": "userDisplayName",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "userId",
+            "columnName": "userId",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "capturedAt",
+            "columnName": "capturedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "expiresAt",
+            "columnName": "expiresAt",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "lastVerifiedAt",
+            "columnName": "lastVerifiedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "sourceId"
+          ]
+        }
+      },
+      {
+        "tableName": "llm_session",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `name` TEXT NOT NULL, `provider` TEXT NOT NULL, `model` TEXT NOT NULL, `systemPrompt` TEXT, `createdAt` INTEGER NOT NULL, `lastUsedAt` INTEGER NOT NULL, `featureKind` TEXT, `anchorFictionId` TEXT, `anchorChapterId` TEXT, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "provider",
+            "columnName": "provider",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "model",
+            "columnName": "model",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "systemPrompt",
+            "columnName": "systemPrompt",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "createdAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastUsedAt",
+            "columnName": "lastUsedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "featureKind",
+            "columnName": "featureKind",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "anchorFictionId",
+            "columnName": "anchorFictionId",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "anchorChapterId",
+            "columnName": "anchorChapterId",
+            "affinity": "TEXT"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "llm_message",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `sessionId` TEXT NOT NULL, `role` TEXT NOT NULL, `content` TEXT NOT NULL, `createdAt` INTEGER NOT NULL, FOREIGN KEY(`sessionId`) REFERENCES `llm_session`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "sessionId",
+            "columnName": "sessionId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "role",
+            "columnName": "role",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "content",
+            "columnName": "content",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "createdAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_llm_message_sessionId",
+            "unique": false,
+            "columnNames": [
+              "sessionId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_llm_message_sessionId` ON `${TABLE_NAME}` (`sessionId`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "llm_session",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "sessionId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "fiction_shelf",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`fictionId` TEXT NOT NULL, `shelf` TEXT NOT NULL, `addedAt` INTEGER NOT NULL, PRIMARY KEY(`fictionId`, `shelf`), FOREIGN KEY(`fictionId`) REFERENCES `fiction`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "fictionId",
+            "columnName": "fictionId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "shelf",
+            "columnName": "shelf",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "addedAt",
+            "columnName": "addedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "fictionId",
+            "shelf"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_fiction_shelf_shelf",
+            "unique": false,
+            "columnNames": [
+              "shelf"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_fiction_shelf_shelf` ON `${TABLE_NAME}` (`shelf`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "fiction",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "fictionId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "chapter_history",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`fictionId` TEXT NOT NULL, `chapterId` TEXT NOT NULL, `openedAt` INTEGER NOT NULL, `completed` INTEGER NOT NULL, `fractionRead` REAL, PRIMARY KEY(`fictionId`, `chapterId`), FOREIGN KEY(`fictionId`) REFERENCES `fiction`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE , FOREIGN KEY(`chapterId`) REFERENCES `chapter`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "fictionId",
+            "columnName": "fictionId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "chapterId",
+            "columnName": "chapterId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "openedAt",
+            "columnName": "openedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "completed",
+            "columnName": "completed",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "fractionRead",
+            "columnName": "fractionRead",
+            "affinity": "REAL"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "fictionId",
+            "chapterId"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_chapter_history_openedAt",
+            "unique": false,
+            "columnNames": [
+              "openedAt"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_chapter_history_openedAt` ON `${TABLE_NAME}` (`openedAt`)"
+          },
+          {
+            "name": "index_chapter_history_chapterId",
+            "unique": false,
+            "columnNames": [
+              "chapterId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_chapter_history_chapterId` ON `${TABLE_NAME}` (`chapterId`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "fiction",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "fictionId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          },
+          {
+            "table": "chapter",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "chapterId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "inbox_event",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `sourceId` TEXT NOT NULL, `fictionId` TEXT, `chapterId` TEXT, `title` TEXT NOT NULL, `body` TEXT, `ts` INTEGER NOT NULL, `isRead` INTEGER NOT NULL, `deepLinkUri` TEXT)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "sourceId",
+            "columnName": "sourceId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "fictionId",
+            "columnName": "fictionId",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "chapterId",
+            "columnName": "chapterId",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "title",
+            "columnName": "title",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "body",
+            "columnName": "body",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "ts",
+            "columnName": "ts",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "isRead",
+            "columnName": "isRead",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "deepLinkUri",
+            "columnName": "deepLinkUri",
+            "affinity": "TEXT"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_inbox_event_ts",
+            "unique": false,
+            "columnNames": [
+              "ts"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_inbox_event_ts` ON `${TABLE_NAME}` (`ts`)"
+          },
+          {
+            "name": "index_inbox_event_isRead",
+            "unique": false,
+            "columnNames": [
+              "isRead"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_inbox_event_isRead` ON `${TABLE_NAME}` (`isRead`)"
+          },
+          {
+            "name": "index_inbox_event_sourceId_fictionId",
+            "unique": false,
+            "columnNames": [
+              "sourceId",
+              "fictionId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_inbox_event_sourceId_fictionId` ON `${TABLE_NAME}` (`sourceId`, `fictionId`)"
+          }
+        ]
+      },
+      {
+        "tableName": "fiction_memory_entry",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`fictionId` TEXT NOT NULL, `entityType` TEXT NOT NULL, `name` TEXT NOT NULL, `summary` TEXT NOT NULL, `firstSeenChapterIndex` INTEGER, `lastUpdated` INTEGER NOT NULL, `userEdited` INTEGER NOT NULL, PRIMARY KEY(`fictionId`, `name`))",
+        "fields": [
+          {
+            "fieldPath": "fictionId",
+            "columnName": "fictionId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "entityType",
+            "columnName": "entityType",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "summary",
+            "columnName": "summary",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "firstSeenChapterIndex",
+            "columnName": "firstSeenChapterIndex",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "lastUpdated",
+            "columnName": "lastUpdated",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "userEdited",
+            "columnName": "userEdited",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "fictionId",
+            "name"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_fiction_memory_entry_name",
+            "unique": false,
+            "columnNames": [
+              "name"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_fiction_memory_entry_name` ON `${TABLE_NAME}` (`name`)"
+          },
+          {
+            "name": "index_fiction_memory_entry_fictionId",
+            "unique": false,
+            "columnNames": [
+              "fictionId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_fiction_memory_entry_fictionId` ON `${TABLE_NAME}` (`fictionId`)"
+          }
+        ]
+      }
+    ],
+    "setupQueries": [
+      "CREATE TABLE IF NOT EXISTS room_master_table (id INTEGER PRIMARY KEY,identity_hash TEXT)",
+      "INSERT OR REPLACE INTO room_master_table (id,identity_hash) VALUES(42, 'da10e2cb27f64f4de299785a7ef4a5e1')"
+    ]
+  }
+}

--- a/core-data/src/main/kotlin/in/jphe/storyvox/data/db/StoryvoxDatabase.kt
+++ b/core-data/src/main/kotlin/in/jphe/storyvox/data/db/StoryvoxDatabase.kt
@@ -50,7 +50,10 @@ import `in`.jphe.storyvox.data.db.entity.PlaybackPosition
         // a book you no longer have."
         FictionMemoryEntry::class,
     ],
-    version = 10,
+    // v11 (#965 per-chapter playback position) — PlaybackPosition PK changes
+    // from `fictionId` to composite `(fictionId, chapterId)` so each chapter
+    // remembers its own offset. Table-rebuild migration, zero data loss.
+    version = 11,
     exportSchema = true,
 )
 @TypeConverters(Converters::class)

--- a/core-data/src/main/kotlin/in/jphe/storyvox/data/db/dao/PlaybackDao.kt
+++ b/core-data/src/main/kotlin/in/jphe/storyvox/data/db/dao/PlaybackDao.kt
@@ -9,16 +9,50 @@ import kotlinx.coroutines.flow.Flow
 @Dao
 interface PlaybackDao {
 
-    @Query("SELECT * FROM playback_position WHERE fictionId = :fictionId")
+    /**
+     * Issue #965 — most-recently-played row for a fiction. Under the
+     * composite `(fictionId, chapterId)` PK there can be several rows per
+     * fiction (one per chapter the user touched); "the fiction's position"
+     * is the chapter played most recently, so observers take the top row by
+     * `updatedAt DESC`. Never returns a stale future-chapter offset.
+     */
+    @Query(
+        "SELECT * FROM playback_position WHERE fictionId = :fictionId " +
+            "ORDER BY updatedAt DESC LIMIT 1",
+    )
     fun observe(fictionId: String): Flow<PlaybackPosition?>
 
-    /** One-shot lookup used by the playback layer's `load(fictionId)`. */
-    @Query("SELECT * FROM playback_position WHERE fictionId = :fictionId")
+    /**
+     * One-shot most-recent lookup used by the playback layer's
+     * `load(fictionId)` resume path. Same `ORDER BY updatedAt DESC LIMIT 1`
+     * semantics as [observe].
+     */
+    @Query(
+        "SELECT * FROM playback_position WHERE fictionId = :fictionId " +
+            "ORDER BY updatedAt DESC LIMIT 1",
+    )
     suspend fun get(fictionId: String): PlaybackPosition?
+
+    /**
+     * Exact-row lookup for one chapter. Used by the repository's
+     * field-preserving `save()` so it reads back the SAME chapter's
+     * `paragraphIndex` / `playbackSpeed` rather than whatever chapter
+     * happened to be played last.
+     */
+    @Query(
+        "SELECT * FROM playback_position " +
+            "WHERE fictionId = :fictionId AND chapterId = :chapterId",
+    )
+    suspend fun get(fictionId: String, chapterId: String): PlaybackPosition?
 
     @Upsert
     suspend fun upsert(position: PlaybackPosition)
 
+    /**
+     * Clears every saved chapter position for a fiction — the "forget this
+     * book's progress entirely" operation. Issue #965: now deletes all
+     * per-chapter rows for the fiction, not the single former per-fiction row.
+     */
     @Query("DELETE FROM playback_position WHERE fictionId = :fictionId")
     suspend fun delete(fictionId: String)
 
@@ -40,6 +74,13 @@ interface PlaybackDao {
      * Denormalized "recently played" feed for the Auto/Wear menu — flattens
      * fiction title + cover + chapter title into one row so the playback
      * layer doesn't need follow-up queries while building Auto's browse tree.
+     *
+     * Issue #965: with the composite PK there are now several rows per
+     * fiction. The Auto rail lists *books*, not chapters, so we collapse to
+     * one row per fiction — the most-recently-played chapter. The inner
+     * query picks each fiction's MAX(updatedAt) row id, then the outer join
+     * pulls only those rows. `ORDER BY updatedAt DESC LIMIT :limit` then
+     * gives the N most-recent distinct fictions.
      */
     @Query(
         """
@@ -51,6 +92,10 @@ interface PlaybackDao {
           FROM playback_position p
           JOIN fiction f ON f.id = p.fictionId
           JOIN chapter c ON c.id = p.chapterId
+         WHERE p.updatedAt = (
+               SELECT MAX(p2.updatedAt) FROM playback_position p2
+                WHERE p2.fictionId = p.fictionId
+         )
          ORDER BY p.updatedAt DESC
          LIMIT :limit
         """,
@@ -64,8 +109,16 @@ interface PlaybackDao {
      * fiction rows the Continue-listening tile needs. Emits on any
      * playback-position upsert / delete; the Library ViewModel
      * collapses it into a `Map<String, Long>` for the sort step.
+     *
+     * Issue #965 — under the composite PK there are multiple rows per
+     * fiction (one per chapter). `GROUP BY fictionId` + `MAX(updatedAt)`
+     * collapses them back to one "last played" timestamp per fiction so
+     * the Library sort still gets exactly one value per book.
      */
-    @Query("SELECT fictionId, updatedAt FROM playback_position")
+    @Query(
+        "SELECT fictionId, MAX(updatedAt) AS updatedAt " +
+            "FROM playback_position GROUP BY fictionId",
+    )
     fun observeLastPlayedTimes(): Flow<List<LastPlayedRow>>
 
     /**

--- a/core-data/src/main/kotlin/in/jphe/storyvox/data/db/entity/PlaybackPosition.kt
+++ b/core-data/src/main/kotlin/in/jphe/storyvox/data/db/entity/PlaybackPosition.kt
@@ -3,15 +3,22 @@ package `in`.jphe.storyvox.data.db.entity
 import androidx.room.Entity
 import androidx.room.ForeignKey
 import androidx.room.Index
-import androidx.room.PrimaryKey
 
 /**
- * "Where I was" — one row per fiction, holds latest position. Bookmarks /
- * history are deferred (YAGNI v1). Cascade-deletes when the parent fiction
- * leaves the library.
+ * "Where I was" — one row per (fiction, chapter), holds the latest position
+ * for each chapter independently. Issue #965: the PK was `fictionId` alone
+ * (one row per fiction), which let a stale future-chapter offset linger in
+ * the row when the user backed up to an earlier chapter — any reader of the
+ * row in that window (Library Resume tile, Auto/Wear browse, Recap) could
+ * resume at the stale offset ("skips forward"). With the composite
+ * `(fictionId, chapterId)` PK each chapter remembers its own offset, and
+ * "resume the fiction" means "resume its most-recently-played chapter"
+ * (`ORDER BY updatedAt DESC`), which is never stale. Cascade-deletes when
+ * either the parent fiction or the parent chapter leaves the library.
  */
 @Entity(
     tableName = "playback_position",
+    primaryKeys = ["fictionId", "chapterId"],
     foreignKeys = [
         ForeignKey(
             entity = Fiction::class,
@@ -27,12 +34,15 @@ import androidx.room.PrimaryKey
         ),
     ],
     indices = [
+        // chapterId index backs the chapter FK cascade planner. fictionId is
+        // the leading column of the composite PK so its own lookups
+        // (observe/get/delete-by-fiction) are already index-served.
         Index(value = ["chapterId"]),
         Index(value = ["updatedAt"]),
     ],
 )
 data class PlaybackPosition(
-    @PrimaryKey val fictionId: String,
+    val fictionId: String,
     val chapterId: String,
     val charOffset: Int = 0,
     val paragraphIndex: Int = 0,

--- a/core-data/src/main/kotlin/in/jphe/storyvox/data/db/migration/Migrations.kt
+++ b/core-data/src/main/kotlin/in/jphe/storyvox/data/db/migration/Migrations.kt
@@ -301,6 +301,79 @@ val MIGRATION_9_10: Migration = object : Migration(9, 10) {
     }
 }
 
+/**
+ * v11 — issue #965: per-chapter playback position. Changes the
+ * `playback_position` primary key from `fictionId` alone to the composite
+ * `(fictionId, chapterId)` so each chapter remembers its own offset. A
+ * stale future-chapter offset can no longer linger in "the fiction's row"
+ * after the user backs up to an earlier chapter ("skips forward").
+ *
+ * SQLite can't ALTER a primary key in place, so this is the standard Room
+ * table-rebuild: create `playback_position_new` with the composite PK and
+ * the IDENTICAL column set / FKs, copy every row across, drop the old
+ * table, rename the new one into place, then recreate both indexes.
+ *
+ * DATA PRESERVATION — the crux of this issue. Every existing v10 row
+ * already carries its `chapterId` as a regular NOT-NULL column; only the PK
+ * definition changes. `INSERT ... SELECT *` copies all seven columns
+ * verbatim, so each old per-fiction row maps 1:1 to a `(fictionId,
+ * chapterId)` row with its stored offset/paragraph/speed/duration/timestamp
+ * intact. No row is dropped, merged, or transformed. The composite PK only
+ * *permits* additional rows going forward; it doesn't disturb the ones
+ * already there (no two v10 rows can collide, since they had distinct
+ * fictionIds to begin with).
+ *
+ * The DDL below is byte-for-byte the v10 `playback_position` createSql with
+ * `PRIMARY KEY(fictionId)` swapped for `PRIMARY KEY(fictionId, chapterId)`,
+ * so Room's post-migration identity-hash validation against `11.json`
+ * passes. Both FKs (fiction + chapter, ON DELETE CASCADE) and both indexes
+ * (chapterId, updatedAt) are recreated exactly as the entity declares them.
+ */
+val MIGRATION_10_11: Migration = object : Migration(10, 11) {
+    override fun migrate(db: SupportSQLiteDatabase) {
+        db.execSQL(
+            """
+            CREATE TABLE IF NOT EXISTS `playback_position_new` (
+                `fictionId` TEXT NOT NULL,
+                `chapterId` TEXT NOT NULL,
+                `charOffset` INTEGER NOT NULL,
+                `paragraphIndex` INTEGER NOT NULL,
+                `playbackSpeed` REAL NOT NULL,
+                `durationEstimateMs` INTEGER NOT NULL,
+                `updatedAt` INTEGER NOT NULL,
+                PRIMARY KEY(`fictionId`, `chapterId`),
+                FOREIGN KEY(`fictionId`) REFERENCES `fiction`(`id`)
+                  ON UPDATE NO ACTION ON DELETE CASCADE,
+                FOREIGN KEY(`chapterId`) REFERENCES `chapter`(`id`)
+                  ON UPDATE NO ACTION ON DELETE CASCADE
+            )
+            """.trimIndent(),
+        )
+        db.execSQL(
+            """
+            INSERT INTO `playback_position_new` (
+                `fictionId`, `chapterId`, `charOffset`, `paragraphIndex`,
+                `playbackSpeed`, `durationEstimateMs`, `updatedAt`
+            )
+            SELECT
+                `fictionId`, `chapterId`, `charOffset`, `paragraphIndex`,
+                `playbackSpeed`, `durationEstimateMs`, `updatedAt`
+            FROM `playback_position`
+            """.trimIndent(),
+        )
+        db.execSQL("DROP TABLE `playback_position`")
+        db.execSQL("ALTER TABLE `playback_position_new` RENAME TO `playback_position`")
+        db.execSQL(
+            "CREATE INDEX IF NOT EXISTS `index_playback_position_chapterId` " +
+                "ON `playback_position` (`chapterId`)",
+        )
+        db.execSQL(
+            "CREATE INDEX IF NOT EXISTS `index_playback_position_updatedAt` " +
+                "ON `playback_position` (`updatedAt`)",
+        )
+    }
+}
+
 val ALL_MIGRATIONS: Array<Migration> = arrayOf(
     MIGRATION_1_2,
     MIGRATION_2_3,
@@ -311,4 +384,5 @@ val ALL_MIGRATIONS: Array<Migration> = arrayOf(
     MIGRATION_7_8,
     MIGRATION_8_9,
     MIGRATION_9_10,
+    MIGRATION_10_11,
 )

--- a/core-data/src/main/kotlin/in/jphe/storyvox/data/repository/PlaybackPositionRepository.kt
+++ b/core-data/src/main/kotlin/in/jphe/storyvox/data/repository/PlaybackPositionRepository.kt
@@ -15,6 +15,11 @@ import javax.inject.Singleton
 
 interface PlaybackPositionRepository {
 
+    /**
+     * Observe the fiction's resume point — its most-recently-played
+     * chapter's row (issue #965). Multiple chapters of one fiction now have
+     * independent rows; this surfaces the freshest one.
+     */
     fun observePosition(fictionId: String): Flow<PlaybackPosition?>
 
     /**
@@ -40,6 +45,10 @@ interface PlaybackPositionRepository {
         playbackSpeed: Float,
     )
 
+    /**
+     * Forget every saved chapter position for a fiction (issue #965 — clears
+     * all per-chapter rows, not just the former single per-fiction row).
+     */
     suspend fun clearPosition(fictionId: String)
 
     // ─── playback-layer accessors ─────────────────────────────────────────
@@ -47,8 +56,10 @@ interface PlaybackPositionRepository {
     /**
      * Persist a resume point — playback-layer flavor. Updates `charOffset` and
      * `durationEstimateMs`; leaves `paragraphIndex` and `playbackSpeed`
-     * untouched (the reader UI owns those). If no row exists yet, defaults
-     * are written for the untouched fields.
+     * untouched (the reader UI owns those). If no row exists yet for this
+     * (fiction, chapter), defaults are written for the untouched fields.
+     * Issue #965: the preserve-read is now scoped to the exact chapter, so
+     * saving chapter N never inherits chapter N+1's paragraphIndex/speed.
      */
     suspend fun save(
         fictionId: String,
@@ -57,7 +68,11 @@ interface PlaybackPositionRepository {
         durationEstimateMs: Long,
     )
 
-    /** Load the resume point for a given fiction, or null if none. */
+    /**
+     * Load the resume point for a given fiction — its most-recently-played
+     * chapter's row (issue #965), or null if none. Picks the freshest
+     * chapter so resume never lands on a stale future-chapter offset.
+     */
     suspend fun load(fictionId: String): SavedPosition?
 
     /** Most-recently-played list, denormalized for the Auto/Wear menu. */
@@ -118,7 +133,7 @@ class PlaybackPositionRepositoryImpl @Inject constructor(
         charOffset: Int,
         durationEstimateMs: Long,
     ) {
-        val existing = dao.get(fictionId)
+        val existing = dao.get(fictionId, chapterId)
         dao.upsert(
             PlaybackPosition(
                 fictionId = fictionId,

--- a/core-data/src/test/kotlin/in/jphe/storyvox/data/db/StoryvoxDatabaseMigrationTest.kt
+++ b/core-data/src/test/kotlin/in/jphe/storyvox/data/db/StoryvoxDatabaseMigrationTest.kt
@@ -13,6 +13,7 @@ import `in`.jphe.storyvox.data.db.migration.MIGRATION_6_7
 import `in`.jphe.storyvox.data.db.migration.MIGRATION_7_8
 import `in`.jphe.storyvox.data.db.migration.MIGRATION_8_9
 import `in`.jphe.storyvox.data.db.migration.MIGRATION_9_10
+import `in`.jphe.storyvox.data.db.migration.MIGRATION_10_11
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNotNull
 import org.junit.Assert.assertTrue
@@ -136,12 +137,16 @@ class StoryvoxDatabaseMigrationTest {
         // latest version) can open the file without a missing-migration
         // failure.
         helper.runMigrationsAndValidate(dbName, 10, true, MIGRATION_9_10).close()
+        // #965 — v11 rebuilds playback_position with the composite PK.
+        // Chain through so the latest-version Room.databaseBuilder opens
+        // cleanly.
+        helper.runMigrationsAndValidate(dbName, 11, true, MIGRATION_10_11).close()
 
         val ctx = org.robolectric.RuntimeEnvironment.getApplication() as android.content.Context
         val db = Room.databaseBuilder(ctx, StoryvoxDatabase::class.java, dbName)
             .addMigrations(
                 MIGRATION_4_5, MIGRATION_5_6, MIGRATION_6_7, MIGRATION_7_8,
-                MIGRATION_8_9, MIGRATION_9_10,
+                MIGRATION_8_9, MIGRATION_9_10, MIGRATION_10_11,
             )
             .build()
 
@@ -298,12 +303,14 @@ class StoryvoxDatabaseMigrationTest {
         helper.runMigrationsAndValidate(dbName, 9, true, MIGRATION_8_9).close()
         // #890/#889/#884 — chain through v10 (missing query indexes).
         helper.runMigrationsAndValidate(dbName, 10, true, MIGRATION_9_10).close()
+        // #965 — chain through v11 (playback_position composite PK).
+        helper.runMigrationsAndValidate(dbName, 11, true, MIGRATION_10_11).close()
 
         val ctx = org.robolectric.RuntimeEnvironment.getApplication() as android.content.Context
         val db = Room.databaseBuilder(ctx, StoryvoxDatabase::class.java, dbName)
             .addMigrations(
                 MIGRATION_4_5, MIGRATION_5_6, MIGRATION_6_7, MIGRATION_7_8,
-                MIGRATION_8_9, MIGRATION_9_10,
+                MIGRATION_8_9, MIGRATION_9_10, MIGRATION_10_11,
             )
             .build()
 
@@ -433,6 +440,168 @@ class StoryvoxDatabaseMigrationTest {
             "index_inbox_event_sourceId_fictionId must exist (Inbox lookup)",
             indexesOn("inbox_event").any { it == "index_inbox_event_sourceId_fictionId" },
         )
+
+        db.close()
+    }
+
+    /**
+     * Issue #965 — v11 changes the `playback_position` primary key from
+     * `fictionId` alone to the composite `(fictionId, chapterId)` so each
+     * chapter remembers its own offset. This is the DATA-PRESERVATION guard
+     * for the issue: a botched migration would lose every user's "where I
+     * was" anchor, so the test seeds a populated v10 `playback_position`
+     * table and asserts every row + every offset survives the rebuild
+     * byte-for-byte.
+     *
+     * The migration is a table rebuild (SQLite can't ALTER a PK in place):
+     * CREATE _new with the composite PK + identical columns/FKs, INSERT
+     * SELECT *, DROP old, RENAME. `runMigrationsAndValidate(..., 11, true,
+     * MIGRATION_10_11)` also triggers Room's identity-hash check against
+     * `11.json`, so a missing index / wrong FK / wrong PK fails here too.
+     *
+     * Seeds TWO fictions with ONE position each (the only shape a v10 DB can
+     * hold — fictionId was the PK), then proves both survive. A post-migration
+     * insert of a SECOND chapter row for an existing fiction confirms the new
+     * composite PK actually permits per-chapter rows (it would have hit a
+     * UNIQUE violation under the old single-column PK).
+     */
+    @Test fun `migrate v10 to v11 preserves all playback positions and enables per-chapter rows`() {
+        val dbName = "playback-position-pk-migration-test.db"
+
+        helper.createDatabase(dbName, 4).close()
+        helper.runMigrationsAndValidate(dbName, 5, true, MIGRATION_4_5).close()
+        helper.runMigrationsAndValidate(dbName, 6, true, MIGRATION_5_6).close()
+        helper.runMigrationsAndValidate(dbName, 7, true, MIGRATION_6_7).close()
+        helper.runMigrationsAndValidate(dbName, 8, true, MIGRATION_7_8).close()
+        helper.runMigrationsAndValidate(dbName, 9, true, MIGRATION_8_9).close()
+        helper.runMigrationsAndValidate(dbName, 10, true, MIGRATION_9_10).use { db ->
+            // Parent rows first (FK: playback_position → fiction + chapter).
+            db.execSQL(
+                """
+                INSERT INTO fiction(
+                    id, sourceId, title, author, genres, tags, status,
+                    chapterCount, firstSeenAt, metadataFetchedAt,
+                    inLibrary, followedRemotely, notesEverSeen
+                ) VALUES
+                    ('rr:1', 'royalroad', 'Mother of Learning', 'nobody103',
+                     '[]', '[]', 'ONGOING', 2, 0, 0, 1, 0, 0),
+                    ('rr:2', 'royalroad', 'The Wandering Inn', 'pirateaba',
+                     '[]', '[]', 'ONGOING', 1, 0, 0, 1, 0, 0)
+                """.trimIndent(),
+            )
+            db.execSQL(
+                """
+                INSERT INTO chapter(
+                    id, fictionId, sourceChapterId, `index`, title,
+                    downloadState, userMarkedRead
+                ) VALUES
+                    ('rr:1:0', 'rr:1', '0', 0, 'Good Morning Brother',
+                     'NOT_DOWNLOADED', 0),
+                    ('rr:1:1', 'rr:1', '1', 1, 'A Bad Night',
+                     'NOT_DOWNLOADED', 0),
+                    ('rr:2:0', 'rr:2', '0', 0, 'Chapter 1.00',
+                     'NOT_DOWNLOADED', 0)
+                """.trimIndent(),
+            )
+            // v10 shape: one position row per fiction (fictionId is the PK).
+            db.execSQL(
+                """
+                INSERT INTO playback_position(
+                    fictionId, chapterId, charOffset, paragraphIndex,
+                    playbackSpeed, durationEstimateMs, updatedAt
+                ) VALUES
+                    ('rr:1', 'rr:1:0', 4321, 7, 1.5, 600000, 1000),
+                    ('rr:2', 'rr:2:0', 99,   0, 1.0, 120000, 2000)
+                """.trimIndent(),
+            )
+        }
+
+        val db = helper.runMigrationsAndValidate(
+            dbName,
+            11,
+            /* validateDroppedTables = */ true,
+            MIGRATION_10_11,
+        )
+
+        // Composite PK present, both indexes recreated.
+        db.query("PRAGMA table_info('playback_position')").use { c ->
+            val pkCols = mutableListOf<String>()
+            while (c.moveToNext()) {
+                val name = c.getString(c.getColumnIndexOrThrow("name"))
+                val pk = c.getInt(c.getColumnIndexOrThrow("pk"))
+                if (pk > 0) pkCols += "$pk:$name"
+            }
+            // pk index 1 = fictionId, 2 = chapterId (declaration order).
+            assertEquals(
+                "composite PK must be (fictionId, chapterId)",
+                listOf("1:fictionId", "2:chapterId"),
+                pkCols.sorted(),
+            )
+        }
+        db.query(
+            "SELECT name FROM sqlite_master WHERE type='index' " +
+                "AND tbl_name='playback_position'",
+        ).use { c ->
+            val indexes = buildList { while (c.moveToNext()) add(c.getString(0)) }
+            assertTrue(
+                "index_playback_position_chapterId must survive the rebuild",
+                indexes.any { it == "index_playback_position_chapterId" },
+            )
+            assertTrue(
+                "index_playback_position_updatedAt must survive the rebuild",
+                indexes.any { it == "index_playback_position_updatedAt" },
+            )
+        }
+
+        // EVERY seeded row + offset must survive verbatim.
+        db.query(
+            "SELECT fictionId, chapterId, charOffset, paragraphIndex, " +
+                "playbackSpeed, durationEstimateMs, updatedAt " +
+                "FROM playback_position ORDER BY fictionId",
+        ).use { c ->
+            assertTrue("row rr:1 must survive", c.moveToFirst())
+            assertEquals("rr:1", c.getString(0))
+            assertEquals("rr:1:0", c.getString(1))
+            assertEquals(4321, c.getInt(2))
+            assertEquals(7, c.getInt(3))
+            assertEquals(1.5f, c.getFloat(4), 0.0001f)
+            assertEquals(600000L, c.getLong(5))
+            assertEquals(1000L, c.getLong(6))
+
+            assertTrue("row rr:2 must survive", c.moveToNext())
+            assertEquals("rr:2", c.getString(0))
+            assertEquals("rr:2:0", c.getString(1))
+            assertEquals(99, c.getInt(2))
+            assertEquals(0, c.getInt(3))
+            assertEquals(1.0f, c.getFloat(4), 0.0001f)
+            assertEquals(120000L, c.getLong(5))
+            assertEquals(2000L, c.getLong(6))
+
+            assertTrue("exactly the two seeded rows survive", !c.moveToNext())
+        }
+
+        // The whole point of #965: a second chapter of an existing fiction
+        // can now hold its own independent position row. Under the old
+        // single-column PK this insert would throw a UNIQUE constraint
+        // violation on fictionId.
+        db.execSQL(
+            """
+            INSERT INTO playback_position(
+                fictionId, chapterId, charOffset, paragraphIndex,
+                playbackSpeed, durationEstimateMs, updatedAt
+            ) VALUES ('rr:1', 'rr:1:1', 12, 0, 1.0, 300000, 3000)
+            """.trimIndent(),
+        )
+        db.query(
+            "SELECT COUNT(*) FROM playback_position WHERE fictionId = 'rr:1'",
+        ).use { c ->
+            assertTrue(c.moveToFirst())
+            assertEquals(
+                "fiction rr:1 now holds two independent per-chapter rows",
+                2,
+                c.getInt(0),
+            )
+        }
 
         db.close()
     }

--- a/core-data/src/test/kotlin/in/jphe/storyvox/data/db/dao/PlaybackDaoTest.kt
+++ b/core-data/src/test/kotlin/in/jphe/storyvox/data/db/dao/PlaybackDaoTest.kt
@@ -241,4 +241,146 @@ class PlaybackDaoTest {
         // Second delete is a no-op, must not throw.
         dao.delete("f1")
     }
+
+    // ─── Issue #965: per-chapter (fictionId, chapterId) PK semantics ──────
+
+    @Test
+    fun multipleChaptersOfOneFiction_coexistAsIndependentRows() = runTest {
+        // Under the old fictionId-only PK the second upsert would REPLACE the
+        // first. With the composite PK both rows must survive.
+        fictionDao.upsert(fiction("f1"))
+        chapterDao.upsert(chapter("c1", "f1", index = 0))
+        chapterDao.upsert(chapter("c2", "f1", index = 1))
+        dao.upsert(PlaybackPosition("f1", "c1", charOffset = 100, updatedAt = 10L))
+        dao.upsert(PlaybackPosition("f1", "c2", charOffset = 200, updatedAt = 20L))
+
+        val rows = dao.allPositionsSnapshot()
+            .filter { it.fictionId == "f1" }
+            .associateBy { it.chapterId }
+        assertEquals(2, rows.size)
+        assertEquals(100, rows.getValue("c1").charOffset)
+        assertEquals(200, rows.getValue("c2").charOffset)
+    }
+
+    @Test
+    fun getByFiction_returnsMostRecentlyPlayedChapter() = runTest {
+        // load(fictionId) / observe(fictionId) must surface the freshest
+        // chapter, never a stale earlier one — the core #965 fix.
+        fictionDao.upsert(fiction("f1"))
+        chapterDao.upsert(chapter("c1", "f1", index = 0))
+        chapterDao.upsert(chapter("c2", "f1", index = 1))
+        dao.upsert(PlaybackPosition("f1", "c1", charOffset = 100, updatedAt = 10L))
+        dao.upsert(PlaybackPosition("f1", "c2", charOffset = 200, updatedAt = 20L))
+
+        val latest = dao.get("f1")
+        assertNotNull(latest)
+        assertEquals("c2", latest!!.chapterId)
+        assertEquals(200, latest.charOffset)
+
+        // Observing the fiction yields the same freshest row.
+        val observed = dao.observe("f1").first()
+        assertEquals("c2", observed!!.chapterId)
+
+        // Backing up to an earlier chapter (newer timestamp on c1) flips the
+        // resume target back to c1 — the "skips forward" guard.
+        dao.upsert(PlaybackPosition("f1", "c1", charOffset = 50, updatedAt = 30L))
+        assertEquals("c1", dao.get("f1")!!.chapterId)
+        assertEquals(50, dao.get("f1")!!.charOffset)
+    }
+
+    @Test
+    fun getByFictionAndChapter_returnsExactChapterRow() = runTest {
+        fictionDao.upsert(fiction("f1"))
+        chapterDao.upsert(chapter("c1", "f1", index = 0))
+        chapterDao.upsert(chapter("c2", "f1", index = 1))
+        dao.upsert(
+            PlaybackPosition(
+                "f1", "c1", charOffset = 11, paragraphIndex = 3,
+                playbackSpeed = 1.25f, updatedAt = 99L,
+            ),
+        )
+        dao.upsert(PlaybackPosition("f1", "c2", charOffset = 22, updatedAt = 100L))
+
+        // Exact-row lookup ignores recency — returns the asked-for chapter,
+        // so the repository's save() preserves the SAME chapter's fields.
+        val c1 = dao.get("f1", "c1")
+        assertNotNull(c1)
+        assertEquals(11, c1!!.charOffset)
+        assertEquals(3, c1.paragraphIndex)
+        assertEquals(1.25f, c1.playbackSpeed, 0.0001f)
+
+        assertNull("non-existent chapter row is null", dao.get("f1", "nope"))
+    }
+
+    @Test
+    fun observeLastPlayedTimes_collapsesToMaxPerFiction() = runTest {
+        // With multiple chapter rows per fiction the Library sort must still
+        // see exactly one (fictionId, lastPlayedAt) — the MAX(updatedAt).
+        fictionDao.upsert(fiction("f1"))
+        fictionDao.upsert(fiction("f2"))
+        chapterDao.upsert(chapter("c1", "f1", index = 0))
+        chapterDao.upsert(chapter("c2", "f1", index = 1))
+        chapterDao.upsert(chapter("c3", "f2", index = 0))
+        dao.upsert(PlaybackPosition("f1", "c1", updatedAt = 10L))
+        dao.upsert(PlaybackPosition("f1", "c2", updatedAt = 40L))
+        dao.upsert(PlaybackPosition("f2", "c3", updatedAt = 25L))
+
+        val map = dao.observeLastPlayedTimes().first().associate { it.fictionId to it.updatedAt }
+        assertEquals(2, map.size)
+        assertEquals("f1 collapses to its newest chapter timestamp", 40L, map.getValue("f1"))
+        assertEquals(25L, map.getValue("f2"))
+    }
+
+    @Test
+    fun recent_collapsesToOneRowPerFiction_mostRecentChapter() = runTest {
+        // The Auto rail lists books, not chapters: each fiction appears once,
+        // at its most-recently-played chapter.
+        fictionDao.upsert(fiction("f1", title = "A"))
+        fictionDao.upsert(fiction("f2", title = "B"))
+        chapterDao.upsert(chapter("c1", "f1", index = 0, title = "A-ch0"))
+        chapterDao.upsert(chapter("c2", "f1", index = 1, title = "A-ch1"))
+        chapterDao.upsert(chapter("c3", "f2", index = 0, title = "B-ch0"))
+        dao.upsert(PlaybackPosition("f1", "c1", updatedAt = 10L))
+        dao.upsert(PlaybackPosition("f1", "c2", updatedAt = 50L))
+        dao.upsert(PlaybackPosition("f2", "c3", updatedAt = 30L))
+
+        val rows = dao.recent(limit = 10)
+        assertEquals("one row per fiction", listOf("f1", "f2"), rows.map { it.fictionId })
+        // f1's row is its newest chapter (c2 @50), not c1 @10.
+        assertEquals("c2", rows.first { it.fictionId == "f1" }.chapterId)
+        assertEquals("A-ch1", rows.first { it.fictionId == "f1" }.chapterTitle)
+    }
+
+    @Test
+    fun observeMostRecentContinueListening_picksFreshestChapterAcrossAllFictions() = runTest {
+        // The single Continue tile resumes the freshest chapter overall, even
+        // when one fiction has several chapter rows.
+        fictionDao.upsert(fiction("f1", title = "A"))
+        fictionDao.upsert(fiction("f2", title = "B"))
+        chapterDao.upsert(chapter("c1", "f1", index = 0))
+        chapterDao.upsert(chapter("c2", "f1", index = 1))
+        chapterDao.upsert(chapter("c3", "f2", index = 0))
+        dao.upsert(PlaybackPosition("f1", "c1", updatedAt = 100L))
+        dao.upsert(PlaybackPosition("f1", "c2", updatedAt = 300L))
+        dao.upsert(PlaybackPosition("f2", "c3", updatedAt = 200L))
+
+        val row = dao.observeMostRecentContinueListening().first()
+        assertNotNull(row)
+        assertEquals("f1", row!!.f_id)
+        assertEquals("c2", row.c_id)
+    }
+
+    @Test
+    fun deleteByFiction_clearsEveryChapterRow() = runTest {
+        fictionDao.upsert(fiction("f1"))
+        chapterDao.upsert(chapter("c1", "f1", index = 0))
+        chapterDao.upsert(chapter("c2", "f1", index = 1))
+        dao.upsert(PlaybackPosition("f1", "c1", updatedAt = 10L))
+        dao.upsert(PlaybackPosition("f1", "c2", updatedAt = 20L))
+
+        dao.delete("f1")
+
+        assertNull(dao.get("f1"))
+        assertEquals(emptyList<PlaybackPositionSnapshotRow>(), dao.allPositionsSnapshot())
+    }
 }

--- a/core-sync/src/main/kotlin/in/jphe/storyvox/sync/domain/PlaybackPositionSyncer.kt
+++ b/core-sync/src/main/kotlin/in/jphe/storyvox/sync/domain/PlaybackPositionSyncer.kt
@@ -16,17 +16,36 @@ import kotlinx.serialization.json.Json
  * Syncs the user's "where I was" position across devices, with the
  * "server keeps the maximum across devices" rule from JP's brief.
  *
- * Wire format is a single JSON blob per user: a map of fictionId →
- * position + chapter + speed + timestamps. One row, one transact —
- * keeps wire traffic low and the conflict rule trivial. The whole map
- * is rewritten on each sync; conflict resolution applies per-fiction
- * using [PlaybackPositionConflict.merge].
+ * Wire format is a single JSON blob per user: a list of position entries
+ * (position + chapter + speed + timestamps). One row, one transact — keeps
+ * wire traffic low and the conflict rule trivial. The whole list is
+ * rewritten on each sync; conflict resolution applies per entry, max-stamp
+ * wins.
  *
- * Why not per-fiction-row: per-row would scale better at very large
- * libraries but introduces many more transacts per sync round and a
- * lot more bookkeeping. For storyvox's typical user (dozens, maybe
- * low hundreds, of fictions in library) the blob approach is fine and
- * keeps the data layer thin.
+ * ## Wire-format versioning (issue #965)
+ *
+ * The entry key changed from `fictionId` (one entry per fiction) to the
+ * composite `(fictionId, chapterId)` (one entry per chapter), matching the
+ * new per-chapter PK. The on-wire [Entry] shape is UNCHANGED — it always
+ * carried both `fictionId` and `chapterId`; only how we *key* the merge map
+ * changed. [Payload.version] is bumped to [WIRE_VERSION] = 2 for diagnostics.
+ *
+ * BACK-COMPAT (the critical bit): a legacy v1 blob pushed by a device still
+ * on the old build (phone / Android Auto / Wear not yet upgraded) is a list
+ * of entries each keyed-by-fiction — i.e. at most one entry per fiction, but
+ * every one still has a valid `chapterId`. Re-keying that list by
+ * `(fictionId, chapterId)` is lossless: each legacy entry lands on its own
+ * composite key and is merged normally. Nothing is dropped. Conversely a v1
+ * reader receiving our v2 blob (multiple chapters per fiction) keeps only
+ * the last entry it sees per fiction via its `associateBy { fictionId }` —
+ * it loses the extra chapters but keeps a valid, recent position, so an
+ * un-upgraded device degrades gracefully rather than corrupting. The
+ * back-compat window stays open until all of a user's devices are on v11+.
+ *
+ * Why not per-entry-row: per-row would scale better at very large libraries
+ * but introduces many more transacts per sync round and a lot more
+ * bookkeeping. For storyvox's typical user (dozens, maybe low hundreds, of
+ * fictions) the blob approach is fine and keeps the data layer thin.
  */
 @Singleton
 class PlaybackPositionSyncer @Inject constructor(
@@ -51,8 +70,24 @@ class PlaybackPositionSyncer @Inject constructor(
         val updatedAt: Long,
     )
 
+    /**
+     * [version] defaults to 1 so a legacy blob (which omits the field
+     * entirely) decodes as v1 without `coerceInputValues` having to guess.
+     * We always *write* [WIRE_VERSION]. The version is advisory — the reader
+     * re-keys entries by `(fictionId, chapterId)` regardless, so a v1 blob is
+     * read losslessly (see class kdoc). Kept for diagnostics + any future
+     * format change that genuinely can't be back-read.
+     */
     @Serializable
-    data class Payload(val entries: List<Entry>)
+    data class Payload(
+        val entries: List<Entry>,
+        val version: Int = 1,
+    )
+
+    /** Composite merge key — mirrors the v11 `(fictionId, chapterId)` PK. */
+    private data class PosKey(val fictionId: String, val chapterId: String)
+
+    private val Entry.key: PosKey get() = PosKey(fictionId, chapterId)
 
     override suspend fun push(user: SignedInUser): SyncOutcome = reconcile(user)
     override suspend fun pull(user: SignedInUser): SyncOutcome = reconcile(user)
@@ -66,12 +101,18 @@ class PlaybackPositionSyncer @Inject constructor(
         val remotePayload = remote?.payload?.let {
             runCatching { json.decodeFromString(Payload.serializer(), it) }.getOrNull()
         }
-        val remoteByFiction = remotePayload?.entries?.associateBy { it.fictionId } ?: emptyMap()
+        // Re-key remote entries by the composite (fictionId, chapterId).
+        // Lossless for both formats: a legacy v1 blob has at most one entry
+        // per fiction (each with a valid chapterId), so each lands on its
+        // own composite key; a v2 blob already has per-chapter entries.
+        // associateBy keeps the last entry on a key collision, which can't
+        // happen within a well-formed blob (composite keys are unique).
+        val remoteByKey = remotePayload?.entries?.associateBy { it.key } ?: emptyMap()
 
-        // Merge with the max-stamped policy.
-        val mergedByFiction = (localPositions.keys + remoteByFiction.keys).associateWith { id ->
-            val l = localPositions[id]
-            val r = remoteByFiction[id]
+        // Merge with the max-stamped policy, per (fiction, chapter).
+        val mergedByKey = (localPositions.keys + remoteByKey.keys).associateWith { key ->
+            val l = localPositions[key]
+            val r = remoteByKey[key]
             when {
                 l == null -> r!!
                 r == null -> l
@@ -88,13 +129,13 @@ class PlaybackPositionSyncer @Inject constructor(
         // once library sync has created the parent rows.
         var writes = 0
         var skipped = 0
-        for ((id, merged) in mergedByFiction) {
-            val local = localPositions[id]
+        for ((key, merged) in mergedByKey) {
+            val local = localPositions[key]
             if (local == null || merged.updatedAt > local.updatedAt) {
                 val fictionExists = fictionDao.get(merged.fictionId) != null
                 val chapterExists = chapterDao.exists(merged.chapterId)
                 if (!fictionExists || !chapterExists) {
-                    android.util.Log.d(TAG, "skipping position for ${merged.fictionId}: fiction=$fictionExists chapter=$chapterExists")
+                    android.util.Log.d(TAG, "skipping position for ${merged.fictionId}/${merged.chapterId}: fiction=$fictionExists chapter=$chapterExists")
                     skipped++
                     continue
                 }
@@ -104,8 +145,14 @@ class PlaybackPositionSyncer @Inject constructor(
         }
         if (skipped > 0) android.util.Log.i(TAG, "skipped $skipped positions (missing parent rows)")
 
-        // Push the merged payload back.
-        val pushPayload = Payload(entries = mergedByFiction.values.sortedBy { it.fictionId })
+        // Push the merged payload back at the current wire version. Sort by
+        // (fictionId, chapterId) so the blob is deterministic across devices.
+        val pushPayload = Payload(
+            entries = mergedByKey.values.sortedWith(
+                compareBy({ it.fictionId }, { it.chapterId }),
+            ),
+            version = WIRE_VERSION,
+        )
         // Nothing to upload (fresh install, no local or remote positions).
         // Pushing here would stamp the remote row with System.currentTimeMillis(),
         // an updatedAt that corresponds to no real entry and ratchets upward on
@@ -126,15 +173,17 @@ class PlaybackPositionSyncer @Inject constructor(
     }
 
     /**
-     * Pull every fiction's position into a map. One Room round-trip via the
-     * slim [PlaybackDao.allPositionsSnapshot] projection — no per-id follow-up
-     * `get()` calls. See issue #777.
+     * Pull every saved position into a map keyed by `(fictionId, chapterId)`.
+     * One Room round-trip via the slim [PlaybackDao.allPositionsSnapshot]
+     * projection — no per-id follow-up `get()` calls. See issue #777. Under
+     * the v11 PK there are now multiple rows per fiction; each is its own
+     * map entry (issue #965).
      */
-    private suspend fun localSnapshot(): Map<String, Entry> {
+    private suspend fun localSnapshot(): Map<PosKey, Entry> {
         val rows = playbackDao.allPositionsSnapshot()
         if (rows.isEmpty()) return emptyMap()
         return rows.associate { r ->
-            r.fictionId to Entry(
+            PosKey(r.fictionId, r.chapterId) to Entry(
                 fictionId = r.fictionId,
                 chapterId = r.chapterId,
                 charOffset = r.charOffset,
@@ -162,5 +211,14 @@ class PlaybackPositionSyncer @Inject constructor(
         const val DOMAIN: String = "positions"
         private const val ENTITY = "positions"
         private const val TAG = "PositionSyncer"
+
+        /**
+         * Wire-format version written into [Payload.version]. v1 keyed
+         * entries by fictionId (one per fiction); v2 (#965) keys by
+         * `(fictionId, chapterId)`. The reader re-keys regardless, so v1
+         * blobs are still read losslessly — see the class kdoc back-compat
+         * note. Bump only when a future change can't be back-read.
+         */
+        private const val WIRE_VERSION = 2
     }
 }

--- a/core-sync/src/test/kotlin/in/jphe/storyvox/sync/PlaybackPositionSyncerTest.kt
+++ b/core-sync/src/test/kotlin/in/jphe/storyvox/sync/PlaybackPositionSyncerTest.kt
@@ -1,0 +1,257 @@
+package `in`.jphe.storyvox.sync
+
+import `in`.jphe.storyvox.data.db.dao.ChapterDao
+import `in`.jphe.storyvox.data.db.dao.ChapterCacheUsageRow
+import `in`.jphe.storyvox.data.db.dao.ChapterDownloadStateRow
+import `in`.jphe.storyvox.data.db.dao.ChapterInfoRow
+import `in`.jphe.storyvox.data.db.dao.ContinueListeningRow
+import `in`.jphe.storyvox.data.db.dao.FictionDao
+import `in`.jphe.storyvox.data.db.dao.LastPlayedRow
+import `in`.jphe.storyvox.data.db.dao.PlaybackChapterRow
+import `in`.jphe.storyvox.data.db.dao.PlaybackDao
+import `in`.jphe.storyvox.data.db.dao.PlaybackPositionSnapshotRow
+import `in`.jphe.storyvox.data.db.dao.RecentPlaybackRow
+import `in`.jphe.storyvox.data.db.dao.UnreadChapterRow
+import `in`.jphe.storyvox.data.db.entity.Chapter
+import `in`.jphe.storyvox.data.db.entity.ChapterDownloadState
+import `in`.jphe.storyvox.data.db.entity.Fiction
+import `in`.jphe.storyvox.data.db.entity.DownloadMode
+import `in`.jphe.storyvox.data.db.entity.PlaybackPosition
+import `in`.jphe.storyvox.sync.client.FakeInstantBackend
+import `in`.jphe.storyvox.sync.client.SignedInUser
+import `in`.jphe.storyvox.sync.coordinator.SyncOutcome
+import `in`.jphe.storyvox.sync.domain.PlaybackPositionSyncer
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * Issue #965 — wire-format back-compat for the per-chapter position sync.
+ *
+ * The entry key moved from `fictionId` (one entry per fiction, the legacy
+ * v1 blob) to the composite `(fictionId, chapterId)` (v2). The critical
+ * invariant: a legacy v1 blob pushed by a device still on the old build
+ * (phone / Android Auto / Wear not yet upgraded) must still be read
+ * losslessly — every legacy entry already carries a valid `chapterId`, so
+ * re-keying by the composite drops nothing. These tests pin that, plus the
+ * v2 multi-chapter round-trip and the max-stamp merge per chapter.
+ */
+class PlaybackPositionSyncerTest {
+
+    private val USER = SignedInUser(userId = "u-1", email = null, refreshToken = "rt-1")
+    private val ENTITY = "positions"
+
+    private fun syncer(
+        backend: FakeInstantBackend,
+        local: MutableList<PlaybackPosition>,
+        knownFictions: Set<String> = setOf("f1", "f2"),
+        knownChapters: Set<String> = setOf("f1:c0", "f1:c1", "f2:c0"),
+    ) = PlaybackPositionSyncer(
+        playbackDao = FakePlaybackDao(local),
+        backend = backend,
+        fictionDao = FakeFictionDao(knownFictions),
+        chapterDao = FakeChapterDao(knownChapters),
+    )
+
+    @Test fun `legacy v1 blob (no version field, keyed by fiction) reads losslessly`() = runTest {
+        val backend = FakeInstantBackend()
+        // A v1 blob as written by an old build: no `version` field, one
+        // entry per fiction. Each still has a valid chapterId.
+        val legacy = """
+            {"entries":[
+              {"fictionId":"f1","chapterId":"f1:c0","charOffset":500,"paragraphIndex":2,"playbackSpeed":1.5,"durationEstimateMs":600000,"updatedAt":1000},
+              {"fictionId":"f2","chapterId":"f2:c0","charOffset":10,"paragraphIndex":0,"playbackSpeed":1.0,"durationEstimateMs":120000,"updatedAt":2000}
+            ]}
+        """.trimIndent()
+        backend.upsert(USER, ENTITY, SyncIds.rowUuid("positions", USER.userId), legacy, 2000L)
+
+        val local = mutableListOf<PlaybackPosition>()
+        val result = syncer(backend, local).pull(USER)
+
+        assertTrue("pull succeeds: $result", result is SyncOutcome.Ok)
+        // Both legacy entries landed in local — nothing dropped.
+        val byChapter = local.associateBy { it.chapterId }
+        assertEquals(2, byChapter.size)
+        assertEquals(500, byChapter.getValue("f1:c0").charOffset)
+        assertEquals(2, byChapter.getValue("f1:c0").paragraphIndex)
+        assertEquals(1.5f, byChapter.getValue("f1:c0").playbackSpeed, 0.0001f)
+        assertEquals(10, byChapter.getValue("f2:c0").charOffset)
+    }
+
+    @Test fun `v2 round-trips multiple chapters of one fiction`() = runTest {
+        val backend = FakeInstantBackend()
+        // Local has two chapters of f1 + one of f2 — only possible under v11.
+        val local = mutableListOf(
+            PlaybackPosition("f1", "f1:c0", charOffset = 100, updatedAt = 10L),
+            PlaybackPosition("f1", "f1:c1", charOffset = 200, updatedAt = 20L),
+            PlaybackPosition("f2", "f2:c0", charOffset = 300, updatedAt = 30L),
+        )
+        val pushResult = syncer(backend, local).push(USER)
+        assertTrue("push succeeds: $pushResult", pushResult is SyncOutcome.Ok)
+
+        // The pushed blob must carry all three per-chapter entries at v2.
+        val pushed = backend.fetch(USER, ENTITY, SyncIds.rowUuid("positions", USER.userId))
+            .getOrNull()
+        assertNotNull(pushed)
+        assertTrue("blob is v2", pushed!!.payload.contains("\"version\":2"))
+        assertTrue(pushed.payload.contains("\"f1:c0\""))
+        assertTrue(pushed.payload.contains("\"f1:c1\""))
+        assertTrue(pushed.payload.contains("\"f2:c0\""))
+
+        // A fresh device pulling that blob into an empty DB recovers all three.
+        val fresh = mutableListOf<PlaybackPosition>()
+        val pull = syncer(backend, fresh).pull(USER)
+        assertTrue(pull is SyncOutcome.Ok)
+        assertEquals(3, fresh.size)
+        assertEquals(
+            setOf("f1:c0", "f1:c1", "f2:c0"),
+            fresh.map { it.chapterId }.toSet(),
+        )
+    }
+
+    @Test fun `max-stamp merge is per chapter, not per fiction`() = runTest {
+        val backend = FakeInstantBackend()
+        // Remote already holds f1:c0 @ updatedAt=100 with offset 999.
+        val remote = """
+            {"version":2,"entries":[
+              {"fictionId":"f1","chapterId":"f1:c0","charOffset":999,"paragraphIndex":0,"playbackSpeed":1.0,"durationEstimateMs":0,"updatedAt":100}
+            ]}
+        """.trimIndent()
+        backend.upsert(USER, ENTITY, SyncIds.rowUuid("positions", USER.userId), remote, 100L)
+
+        // Local has a NEWER f1:c0 (should win) and a separate f1:c1 the
+        // remote never saw (should be added, not clobbered by the per-fiction
+        // collapse the old code did).
+        val local = mutableListOf(
+            PlaybackPosition("f1", "f1:c0", charOffset = 555, updatedAt = 200L),
+            PlaybackPosition("f1", "f1:c1", charOffset = 42, updatedAt = 150L),
+        )
+        val result = syncer(backend, local).pull(USER)
+        assertTrue(result is SyncOutcome.Ok)
+
+        val byChapter = local.associateBy { it.chapterId }
+        // c0: local newer (200 > 100) → keeps local offset 555.
+        assertEquals(555, byChapter.getValue("f1:c0").charOffset)
+        // c1: remote never had it → survives.
+        assertEquals(42, byChapter.getValue("f1:c1").charOffset)
+    }
+
+    // ─── minimal fakes ───────────────────────────────────────────────────
+
+    /** In-memory PlaybackDao — only the sync-touched methods are live. */
+    private class FakePlaybackDao(
+        private val rows: MutableList<PlaybackPosition>,
+    ) : PlaybackDao {
+        override suspend fun allPositionsSnapshot(): List<PlaybackPositionSnapshotRow> =
+            rows.map {
+                PlaybackPositionSnapshotRow(
+                    fictionId = it.fictionId,
+                    chapterId = it.chapterId,
+                    charOffset = it.charOffset,
+                    paragraphIndex = it.paragraphIndex,
+                    playbackSpeed = it.playbackSpeed,
+                    durationEstimateMs = it.durationEstimateMs,
+                    updatedAt = it.updatedAt,
+                )
+            }
+
+        override suspend fun upsert(position: PlaybackPosition) {
+            rows.removeAll {
+                it.fictionId == position.fictionId && it.chapterId == position.chapterId
+            }
+            rows.add(position)
+        }
+
+        override fun observe(fictionId: String): Flow<PlaybackPosition?> = flowOf(null)
+        override suspend fun get(fictionId: String): PlaybackPosition? = error("not used")
+        override suspend fun get(fictionId: String, chapterId: String): PlaybackPosition? =
+            error("not used")
+        override suspend fun delete(fictionId: String) = error("not used")
+        override suspend fun recent(limit: Int): List<RecentPlaybackRow> = error("not used")
+        override fun observeLastPlayedTimes(): Flow<List<LastPlayedRow>> = flowOf(emptyList())
+        override fun observeMostRecentContinueListening(): Flow<ContinueListeningRow?> = flowOf(null)
+    }
+
+    /** FictionDao stub — only `get` (existence check) is used by the syncer. */
+    private class FakeFictionDao(private val known: Set<String>) : FictionDao {
+        override suspend fun get(id: String): Fiction? =
+            if (id in known) STUB.copy(id = id) else null
+
+        override fun observe(id: String): Flow<Fiction?> = flowOf(null)
+        override suspend fun getMany(ids: List<String>): List<Fiction> = error("not used")
+        override fun observeLibrary(): Flow<List<Fiction>> = flowOf(emptyList())
+        override suspend fun librarySnapshot(): List<Fiction> = error("not used")
+        override fun observeFollowsRemote(): Flow<List<Fiction>> = flowOf(emptyList())
+        override suspend fun followsSnapshot(): List<Fiction> = error("not used")
+        override suspend fun pollableForNewChapters(): List<Fiction> = error("not used")
+        override suspend fun insertIfNew(fiction: Fiction): Long = error("not used")
+        override suspend fun upsert(fiction: Fiction) = error("not used")
+        override suspend fun upsertMany(fictions: List<Fiction>) = error("not used")
+        override suspend fun update(fiction: Fiction) = error("not used")
+        override suspend fun setInLibrary(id: String, inLibrary: Boolean, now: Long) = error("not used")
+        override suspend fun setFollowedRemote(id: String, followed: Boolean) = error("not used")
+        override suspend fun setDownloadMode(id: String, mode: DownloadMode?) = error("not used")
+        override suspend fun setPinnedVoice(id: String, voiceId: String?, locale: String?) = error("not used")
+        override suspend fun touchMetadata(id: String, now: Long) = error("not used")
+        override suspend fun getLastSeenRevision(id: String): String? = error("not used")
+        override suspend fun setLastSeenRevision(id: String, revision: String?) = error("not used")
+        override suspend fun deleteIfTransient(id: String): Int = error("not used")
+
+        private companion object {
+            val STUB = Fiction(
+                id = "stub",
+                sourceId = "royalroad",
+                title = "Stub",
+                author = "nobody",
+                coverUrl = null,
+                description = null,
+                tags = emptyList(),
+                firstSeenAt = 0L,
+                metadataFetchedAt = 0L,
+                inLibrary = true,
+            )
+        }
+    }
+
+    /** ChapterDao stub — only `exists` is used by the syncer. */
+    private class FakeChapterDao(private val known: Set<String>) : ChapterDao {
+        override suspend fun exists(id: String): Boolean = id in known
+
+        override suspend fun allChapters(fictionId: String): List<Chapter> = emptyList()
+        override fun observeChapterInfosByFiction(fictionId: String): Flow<List<ChapterInfoRow>> = flowOf(emptyList())
+        override fun observe(id: String): Flow<Chapter?> = flowOf(null)
+        override suspend fun get(id: String): Chapter? = null
+        override fun observeDownloadStates(fictionId: String): Flow<List<ChapterDownloadStateRow>> = flowOf(emptyList())
+        override fun observePlayedChapterIds(fictionId: String): Flow<List<String>> = flowOf(emptyList())
+        override suspend fun missingForFiction(fictionId: String): List<Chapter> = emptyList()
+        override suspend fun maxIndex(fictionId: String): Int? = null
+        override suspend fun nextChapterId(currentId: String): String? = null
+        override suspend fun previousChapterId(currentId: String): String? = null
+        override suspend fun playbackChapter(id: String): PlaybackChapterRow? = null
+        override suspend fun unreadChapters(limit: Int): List<UnreadChapterRow> = emptyList()
+        override suspend fun allBookmarks() = emptyList<`in`.jphe.storyvox.data.db.dao.BookmarkRow>()
+        override suspend fun setBookmark(id: String, charOffset: Int?) = error("not used")
+        override suspend fun getBookmark(id: String): Int? = null
+        override suspend fun upsert(chapter: Chapter) = error("not used")
+        override suspend fun upsertAll(chapters: List<Chapter>) = error("not used")
+        override suspend fun parkChapterIndexesFor(fictionId: String) = error("not used")
+        override suspend fun deleteByFictionId(fictionId: String) = error("not used")
+        override suspend fun insertAll(chapters: List<Chapter>) = error("not used")
+        override suspend fun setDownloadState(id: String, state: ChapterDownloadState, now: Long, error: String?) = error("not used")
+        override suspend fun reapStuckDownloads(now: Long, cutoff: Long): Int = error("not used")
+        override suspend fun setBody(
+            id: String, html: String, plain: String, checksum: String,
+            notesAuthor: String?, notesAuthorPosition: String?, now: Long,
+            audioUrl: String?,
+        ) = error("not used")
+        override suspend fun setRead(id: String, read: Boolean, now: Long) = error("not used")
+        override suspend fun trimDownloadedBodies(fictionId: String, keepLast: Int) = error("not used")
+        override suspend fun cacheUsage(): ChapterCacheUsageRow = error("not used")
+        override suspend fun chapterIdsForFiction(fictionId: String): List<String> = emptyList()
+        override suspend fun deleteByIds(ids: List<String>) = error("not used")
+    }
+}


### PR DESCRIPTION
Closes #965. Long-term fix for the "skips forward" symptom Nyx traced in #956: changes the \`PlaybackPosition\` primary key from \`fictionId\` alone to the composite \`(fictionId, chapterId)\` so each chapter remembers its own offset. A stale future-chapter offset can no longer linger in "the fiction's row" after the user backs up to an earlier chapter.

## Migration (v10 → v11) — zero data loss

SQLite can't ALTER a PK in place, so this is the standard Room table rebuild: \`CREATE playback_position_new\` with the composite PK and the **identical** column set / FKs, \`INSERT ... SELECT *\`, \`DROP\` old, \`RENAME\`, recreate both indexes.

Every existing v10 row already carries its \`chapterId\` as a regular NOT-NULL column; only the PK definition changes. So each old per-fiction row maps **1:1** to a \`(fictionId, chapterId)\` row with its offset/paragraph/speed/duration/timestamp intact — no row dropped, merged, or transformed. The DDL is byte-for-byte the v10 \`createSql\` with the PK swapped, so Room's identity-hash validation against \`11.json\` passes.

**Verified on a real populated DB.** The tablet had a debuggable v0.7.4 install at \`user_version=10\` with a live row (\`notion:guides\`, charOffset 1316). Built the debug APK, installed \`-r\` (no uninstall, same debug signature → real DB preserved), launched:
- \`user_version\` 10 → 11, composite PK + \`sqlite_autoindex\` + both declared indexes present.
- The live row survived **identically** (1316 / 0 / 1.0 / 271520 / 1780073480889).
- No crash, no identity-hash mismatch.
- Continue-listening tile rendered the right chapter; tapping Resume produced \`startListening fiction=notion:guides chapter=…7519… offset=1316\` → \`EnginePlayer loadAndPlay … fromIndex=25\`. Resume lands on the correct chapter at the correct offset.

## DAO / repository

- \`get\`/\`observe(fictionId)\` now return the most-recently-played chapter (\`ORDER BY updatedAt DESC LIMIT 1\`) — resume never lands on a stale row.
- New \`get(fictionId, chapterId)\` exact lookup so \`save()\` preserves the **same** chapter's \`paragraphIndex\`/\`playbackSpeed\`.
- \`observeLastPlayedTimes\` → \`GROUP BY fictionId\` + \`MAX(updatedAt)\` so the Library sort still gets one timestamp per fiction.
- \`recent()\` (Auto/Wear rail) collapses to one row per fiction (its newest chapter). \`delete(fictionId)\` clears all of a fiction's rows.

## Sync back-compat (PlaybackPositionSyncer)

The wire \`Entry\` shape is **unchanged** (it always carried both ids); only the merge keying moved from \`fictionId\` to \`(fictionId, chapterId)\`. \`Payload.version\` bumped to 2 for diagnostics.

- A **legacy v1 blob** (no \`version\` field, one entry per fiction) is read **losslessly** — each legacy entry has a valid \`chapterId\`, so re-keying by the composite drops nothing.
- An un-upgraded device receiving a v2 blob degrades gracefully (keeps a valid recent position per fiction via its \`associateBy { fictionId }\`).
- The back-compat window stays open until all of a user's devices are v11+.

## Tests

- **Migration test** (\`StoryvoxDatabaseMigrationTest\`): seeds a populated v10 table, asserts every row + offset survives the rebuild byte-for-byte, then proves a 2nd chapter of one fiction can now coexist (would've been a UNIQUE violation under the old PK). 11 tests, 0 fail.
- **PlaybackDaoTest**: +7 multi-row tests (16 total). Chapters coexist; \`get(fictionId)\`=most-recent; \`get(fictionId,chapterId)\`=exact; \`observeLastPlayedTimes\` MAX-per-fiction; \`recent()\` one-row-per-fiction; Continue picks freshest; \`delete\` clears all.
- **PlaybackPositionSyncerTest** (new): legacy-v1 lossless read, v2 multi-chapter round-trip, per-chapter max-stamp merge. 3 tests, 0 fail.

🤖 Generated with [Claude Code](https://claude.com/claude-code)