### PR TITLE
fix(sync): push settings domain on every preference write (debounced) — closes #977

### DIFF
--- a/app/src/main/kotlin/in/jphe/storyvox/data/SettingsRepositoryUiImpl.kt
+++ b/app/src/main/kotlin/in/jphe/storyvox/data/SettingsRepositoryUiImpl.kt
@@ -12,6 +12,7 @@ import androidx.datastore.preferences.core.longPreferencesKey
 import androidx.datastore.preferences.core.stringPreferencesKey
 import androidx.datastore.preferences.preferencesDataStore
 import dagger.hilt.android.qualifiers.ApplicationContext
+import `in`.jphe.storyvox.sync.coordinator.SyncCoordinator
 import `in`.jphe.storyvox.data.auth.SessionHydrator
 import `in`.jphe.storyvox.data.repository.AuthRepository
 import `in`.jphe.storyvox.data.repository.playback.AzureFallbackConfig
@@ -84,6 +85,7 @@ import `in`.jphe.storyvox.sigil.Sigil
 import `in`.jphe.storyvox.source.mempalace.net.PalaceDaemonApi
 import `in`.jphe.storyvox.source.mempalace.net.PalaceDaemonResult
 import kotlinx.coroutines.flow.combine
+import kotlinx.coroutines.launch
 import javax.inject.Inject
 import javax.inject.Singleton
 import kotlinx.coroutines.flow.Flow
@@ -997,6 +999,25 @@ class SettingsRepositoryUiImpl(
      *  quota, combined into the [settings] flow so the Settings UI's
      *  "Currently used: 1.4 GB / 2 GB" row stays live. */
     private val cacheStats: CacheStatsRepository,
+    /** Issue #977 — push-on-write seam. The action [scheduleSettingsPush]
+     *  fires after the debounce so every synced preference change reaches
+     *  InstantDB without a cold-start/manual sync (and can't be clobbered
+     *  by a pull that precedes the next push).
+     *
+     *  Production wires this to `SyncCoordinator.requestPush("settings")`
+     *  via the [@Inject] constructor below. Defaults to a no-op so the
+     *  test seam's direct primary constructor (named args ending at
+     *  [cacheStats]) keeps compiling — and so sync-agnostic repo tests
+     *  don't drag in a coordinator. Tests for the push path pass a
+     *  recording lambda instead of a real [SyncCoordinator] (which is
+     *  final and would need the whole InstantDB client/session/prefs
+     *  stack). */
+    private val pushSettings: () -> Unit = {},
+    /** Issue #977 — dispatcher backing the debounce scope. Defaults to
+     *  [Dispatchers.Default] in production; tests pass a `TestDispatcher`
+     *  so the 1.5s debounce resolves in virtual time. */
+    private val pushDispatcher: kotlinx.coroutines.CoroutineDispatcher =
+        kotlinx.coroutines.Dispatchers.Default,
 ) : SettingsRepositoryUi,
     PlaybackBufferConfig,
     PlaybackModeConfig,
@@ -1044,6 +1065,13 @@ class SettingsRepositoryUiImpl(
         pcmCache: PcmCache,
         pcmCacheConfig: PcmCacheConfig,
         cacheStats: CacheStatsRepository,
+        // Issue #977 — ⚠️ [dagger.Lazy] is load-bearing: the DI graph has
+        // a cycle — SyncCoordinator → Set<Syncer> → SettingsSyncer →
+        // SettingsSnapshotSource (this class) → SyncCoordinator. Lazy
+        // defers instantiation past construction so Hilt builds clean.
+        // `get()` is only called from the debounced push, never at
+        // construction.
+        coordinator: dagger.Lazy<SyncCoordinator>,
     ) : this(
         context.settingsDataStore, auth, hydrator,
         palaceConfig, palaceApi, llmCreds, githubAuth, teamsAuth, rssConfig, epubConfig,
@@ -1053,6 +1081,7 @@ class SettingsRepositoryUiImpl(
         azureCreds, azureClient, azureRoster,
         googleTokenSource,
         pcmCache, pcmCacheConfig, cacheStats,
+        pushSettings = { coordinator.get().requestPush(SETTINGS_PUSH_DOMAIN) },
     )
 
     /**
@@ -1072,6 +1101,26 @@ class SettingsRepositoryUiImpl(
     private val patienceScope = kotlinx.coroutines.CoroutineScope(
         kotlinx.coroutines.SupervisorJob() + kotlinx.coroutines.Dispatchers.Default,
     )
+
+    /** Issue #977 — app-lifetime scope + single coalescing job for the
+     *  debounced settings push. Every synced write cancels the in-flight
+     *  job and relaunches it, so a burst of edits (e.g. dragging the
+     *  source-order list) collapses into ONE push after the user pauses. */
+    private val pushScope = kotlinx.coroutines.CoroutineScope(
+        kotlinx.coroutines.SupervisorJob() + pushDispatcher,
+    )
+    @Volatile private var pushJob: kotlinx.coroutines.Job? = null
+
+    /** Schedule (or reschedule) the debounced settings-domain push.
+     *  Called from [stampSyncedWrite]. [SyncCoordinator.requestPush]
+     *  no-ops when signed out, so this is safe to fire unconditionally. */
+    private fun scheduleSettingsPush() {
+        pushJob?.cancel()
+        pushJob = pushScope.launch {
+            kotlinx.coroutines.delay(SETTINGS_PUSH_DEBOUNCE_MS)
+            pushSettings()
+        }
+    }
 
     /** Issue #377 + #233 + #403 + #462 — non-prefs source configs
      *  bundled into a single combine so the outer combine stays
@@ -2828,10 +2877,16 @@ class SettingsRepositoryUiImpl(
     /** Convenience used by every setter on this class so writes to a
      *  synced key automatically advance the sync timestamp. Settings UI
      *  that calls one of the existing `set*` mutators will get its
-     *  change uploaded on the next sync round without any additional
-     *  wiring. */
+     *  change uploaded without any additional wiring.
+     *
+     *  Issue #977 — this is the single chokepoint that triggers a
+     *  debounced push of the "settings" domain, so a preference change
+     *  reaches InstantDB right away instead of waiting for a cold-start
+     *  or manual "Sync now" (a window in which an intervening pull could
+     *  clobber the un-pushed local change). */
     private suspend fun stampSyncedWrite() {
         stampLocalWrite(System.currentTimeMillis())
+        scheduleSettingsPush()
     }
 
     companion object {
@@ -2839,6 +2894,16 @@ class SettingsRepositoryUiImpl(
          *  [SYNC_ALLOWLIST] (we never sync the sync timestamp itself
          *  — that'd be a loop). */
         private val SYNC_LAST_WRITE_KEY = longPreferencesKey("instantdb.settings_synced_at")
+
+        /** Issue #977 — domain name for the push-on-write seam. Must match
+         *  `SettingsSyncer.DOMAIN`; [SyncCoordinator.requestPush] no-ops if
+         *  no syncer registers under this name. */
+        internal const val SETTINGS_PUSH_DOMAIN: String = "settings"
+
+        /** Issue #977 — debounce window. A burst of synced writes (drag to
+         *  reorder sources, rapid toggle flips) coalesces into ONE push
+         *  this long after the last write. */
+        internal const val SETTINGS_PUSH_DEBOUNCE_MS: Long = 1_500L
 
         /**
          * Names of every DataStore key in the main `storyvox_settings`

--- a/app/src/test/kotlin/in/jphe/storyvox/data/SettingsRepositoryPushOnWriteTest.kt
+++ b/app/src/test/kotlin/in/jphe/storyvox/data/SettingsRepositoryPushOnWriteTest.kt
@@ -1,0 +1,156 @@
+package `in`.jphe.storyvox.data
+
+import androidx.datastore.core.DataStore
+import androidx.datastore.preferences.core.PreferenceDataStoreFactory
+import androidx.datastore.preferences.core.Preferences
+import `in`.jphe.storyvox.sync.domain.SettingsSyncer
+import java.io.File
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.TestDispatcher
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlinx.coroutines.test.advanceTimeBy
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.runTest
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import org.junit.rules.TemporaryFolder
+
+/**
+ * Issue #977 — push-on-every-write regression guard.
+ *
+ * Before this fix, synced preference setters ended at [stampSyncedWrite],
+ * which only bumped a local timestamp; nothing in the app ever called
+ * [SyncCoordinator.requestPush] for the "settings" domain except sign-in
+ * and the manual "Sync now." So a preference change never reached
+ * InstantDB until a cold start, and a cold-start pull could clobber the
+ * un-pushed local change.
+ *
+ * These tests lock in that ANY synced write now schedules a debounced
+ * push of the "settings" domain, and that a burst of writes coalesces
+ * into ONE push (so dragging the source-order list doesn't spam the
+ * backend).
+ *
+ * The push action is exercised through the [SettingsRepositoryUiImpl]
+ * `pushSettings` seam (a recording lambda here) instead of a real
+ * [SyncCoordinator], which is final and would drag in the whole
+ * InstantDB client/session/prefs stack. The debounce runs on a
+ * [StandardTestDispatcher] sharing the test scheduler, so the 1.5s
+ * window resolves in virtual time.
+ */
+@OptIn(ExperimentalCoroutinesApi::class)
+class SettingsRepositoryPushOnWriteTest {
+
+    @get:Rule
+    val tempFolder = TemporaryFolder()
+
+    private lateinit var scope: CoroutineScope
+    private lateinit var store: DataStore<Preferences>
+
+    /** Records each push the repo fires after the debounce. */
+    private var pushCount = 0
+
+    @Before
+    fun setUp() {
+        // Store IO runs eagerly on an Unconfined test dispatcher (mirrors
+        // the other SettingsRepository tests); only the debounce uses the
+        // runTest scheduler so virtual time controls the 1.5s window.
+        scope = CoroutineScope(SupervisorJob() + UnconfinedTestDispatcher())
+        val file = File(tempFolder.newFolder(), "storyvox_settings.preferences_pb")
+        store = PreferenceDataStoreFactory.create(
+            scope = scope,
+            produceFile = { file },
+        )
+    }
+
+    @After
+    fun tearDown() {
+        scope.cancel()
+    }
+
+    /** Build the repo wired to a recording push action + a test-driven
+     *  debounce dispatcher so virtual time controls the 1.5s window. */
+    private fun makeRepo(dispatcher: TestDispatcher): SettingsRepositoryUiImpl {
+        val pcmBundle = makeFakeCacheBundle(tempFolder.newFolder("pcm_bundle"), scope)
+        return SettingsRepositoryUiImpl(
+            store = store,
+            auth = FakeAuth(),
+            hydrator = FakeHydrator(),
+            palaceConfig = makeFakePalaceConfig(tempFolder.newFolder("palace_ds"), scope),
+            palaceApi = makeFakePalaceApi(),
+            llmCreds = `in`.jphe.storyvox.llm.LlmCredentialsStore.forTesting(),
+            githubAuth = FakeGitHubAuth(),
+            teamsAuth = fakeTeamsAuth(),
+            rssConfig = makeFakeRssConfig(tempFolder.newFolder("rss_ds"), scope),
+            epubConfig = makeFakeEpubConfig(tempFolder.newFolder("epub_ds"), scope),
+            outlineConfig = makeFakeOutlineConfig(tempFolder.newFolder("outline_ds"), scope),
+            wikipediaConfig = makeFakeWikipediaConfig(tempFolder.newFolder("wiki_ds"), scope),
+            notionConfig = makeFakeNotionConfig(tempFolder.newFolder("notion_ds"), scope),
+            discordConfig = makeFakeDiscordConfig(tempFolder.newFolder("discord_ds"), scope),
+            discordGuildDirectory = makeFakeDiscordGuildDirectory(),
+            telegramConfig = makeFakeTelegramConfig(tempFolder.newFolder("telegram_ds"), scope),
+            telegramChannelDirectory = makeFakeTelegramChannelDirectory(),
+            suggestedFeedsRegistry = SuggestedFeedsRegistry(),
+            azureCreds = makeFakeAzureCredentials(),
+            azureClient = makeFakeAzureClient(),
+            azureRoster = makeFakeAzureRoster(),
+            googleTokenSource =
+                `in`.jphe.storyvox.llm.auth.GoogleOAuthTokenSource(okhttp3.OkHttpClient()),
+            pcmCache = pcmBundle.pcmCache,
+            pcmCacheConfig = pcmBundle.pcmCacheConfig,
+            cacheStats = pcmBundle.cacheStats,
+            pushSettings = { pushCount++ },
+            pushDispatcher = dispatcher,
+        )
+    }
+
+    @Test
+    fun `synced write schedules a debounced settings push`() = runTest {
+        val repo = makeRepo(StandardTestDispatcher(testScheduler))
+
+        repo.setSourceDisplayOrder(listOf("ao3", "royalroad"))
+        // The push is debounced — nothing fires synchronously with the write.
+        assertEquals("push must NOT fire before the debounce window", 0, pushCount)
+
+        // Let the 1.5s debounce elapse in virtual time.
+        advanceUntilIdle()
+        assertEquals("exactly one push after the debounce", 1, pushCount)
+    }
+
+    @Test
+    fun `a burst of synced writes coalesces into a single push`() = runTest {
+        val repo = makeRepo(StandardTestDispatcher(testScheduler))
+
+        // Simulate dragging the source-order list: several rapid writes,
+        // each well within the debounce window of the last.
+        repo.setSourceDisplayOrder(listOf("ao3"))
+        advanceTimeBy(200)
+        repo.setSourceDisplayOrder(listOf("ao3", "royalroad"))
+        advanceTimeBy(200)
+        repo.setSourceFavorite("ao3", favorite = true)
+        advanceTimeBy(200)
+        repo.setSourceDisplayOrder(listOf("royalroad", "ao3"))
+
+        // Still inside the window after the last write — no push yet.
+        assertEquals("burst must not push mid-stream", 0, pushCount)
+
+        advanceUntilIdle()
+        assertEquals("burst collapses into ONE push", 1, pushCount)
+    }
+
+    @Test
+    fun `push domain matches the SettingsSyncer domain`() {
+        // Guards against the two strings drifting — requestPush(domain)
+        // silently no-ops if no syncer registers under that name.
+        assertEquals(
+            SettingsSyncer.DOMAIN,
+            SettingsRepositoryUiImpl.SETTINGS_PUSH_DOMAIN,
+        )
+    }
+}


### PR DESCRIPTION
## Issue #977 — preference changes never auto-pushed to InstantDB

Synced preference setters in `SettingsRepositoryUiImpl` (setSourceFavorite, setSourceDisplayOrder, setSourcePluginEnabled, theme, speed, all of them) end at `stampSyncedWrite()`, which only bumped a local timestamp. **Nothing in the app ever called `SyncCoordinator.requestPush` for the "settings" domain** except sign-in (`requestPushAll`) and the manual "Sync now" (`syncNow`).

Consequences:
- A preference change never reached InstantDB until a cold start or a manual sync.
- A cold-start pull could land **before** the deferred push and clobber the un-pushed local change.

JP's directive: *"sync should fire on ANY preference change, for saving."*

## Fix

Make `stampSyncedWrite()` — the single chokepoint every synced setter already routes through — schedule a **debounced (1.5s) push of the "settings" domain**. A burst of edits (dragging the source-order list, rapid toggles) coalesces into ONE push after the user pauses.

- **DI cycle:** SyncCoordinator → `Set<Syncer>` → SettingsSyncer → SettingsSnapshotSource (this class) → SyncCoordinator. Broken with `dagger.Lazy<SyncCoordinator>` on the `@Inject` constructor — `Lazy` defers instantiation past construction so Hilt builds clean. `get()` is only touched from the debounced push, never at construction.
- **Signed out:** `requestPush` no-ops (`session.current() ?: return`), so firing unconditionally is safe.
- **Domain name** is `"settings"`, matching `SettingsSyncer.DOMAIN` — guarded by a test so the two can't drift (`requestPush` silently no-ops on an unknown domain).
- **Minimal diff:** only the settings push-on-write seam. `core-sync` untouched. The push action + debounce dispatcher are defaulted seams on the primary constructor (no-op / `Dispatchers.Default`) so the existing named-arg test seam keeps compiling and stays sync-agnostic.

## Verification

- `./gradlew :app:compileDebugKotlin` — green, **Hilt builds clean (no dependency cycle)**.
- `./gradlew :app:testDebugUnitTest` — 183 tests pass, including new `SettingsRepositoryPushOnWriteTest`:
  - synced write → exactly one push after the debounce
  - burst of 4 rapid writes coalesces into a single push
  - `SETTINGS_PUSH_DOMAIN == SettingsSyncer.DOMAIN` drift guard
- `./gradlew :app:assembleDebug` — APK built, installed on R5CR80DJ7TR for on-device behavior check (signed-in: change a setting → auto-push within ~1.5s, no manual sync).

## Follow-up (out of scope)

Other sync domains (library, follows, bookmarks, positions, secrets, pronunciation) appear to share the same gap — no repository calls `requestPush` on write; pushes only happen on sign-in + manual sync. #977 was scoped to settings; a push-on-write sweep across all domains is worth a separate issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)