### PR TITLE
fix(playback): periodic position checkpoint + NonCancellable teardown saves (#980)

### DIFF
--- a/core-playback/src/main/kotlin/in/jphe/storyvox/playback/tts/EnginePlayer.kt
+++ b/core-playback/src/main/kotlin/in/jphe/storyvox/playback/tts/EnginePlayer.kt
@@ -130,6 +130,27 @@ internal fun shouldAutoPlayAfterAdvance(stateAfterWait: PlaybackState): Boolean 
     stateAfterWait.isPlaying
 
 /**
+ * Issue #980 — pure guard for whether a position checkpoint has anything to
+ * save. [EnginePlayer.persistPosition] upserts `(fictionId, chapterId,
+ * charOffset)`; both ids must be present or the row is meaningless (Room would
+ * reject a null PK / the resume join has nothing to point at). The periodic
+ * checkpoint loop, the seek save, and the teardown saves all funnel through
+ * persistPosition, so this single predicate decides every save.
+ *
+ * Note the order dependency this encodes for [EnginePlayer.handleStop]: the
+ * checkpoint MUST run before handleStop zeroes charOffset + nulls
+ * currentChapterId, otherwise this guard short-circuits on the null chapter id
+ * and the listener's place is lost on an explicit Stop (#980 GAP-4).
+ *
+ * Extracted as a top-level function so the save-guard contract can be exercised
+ * in a pure unit test (EnginePlayerPositionCheckpointTest) without standing up
+ * the full EnginePlayer + Hilt + sherpa-onnx graph — same constraint that gates
+ * [shouldAutoPlayAfterAdvance] / PlaybackControllerSkipSeekTest.
+ */
+internal fun shouldCheckpointPosition(state: PlaybackState): Boolean =
+    state.currentFictionId != null && state.currentChapterId != null
+
+/**
  * Issue #189 — playback state for the one-shot recap-aloud TTS pipeline.
  * Distinct from [PlaybackState] because the recap is a transient utterance
  * with its own AudioTrack; conflating the two would force every chapter
@@ -929,6 +950,21 @@ class EnginePlayer @AssistedInject constructor(
     // setup so rapid taps don't queue up wasteful builds.
     private val pipelineBuildMutex = Mutex()
     private var pipelineSetupJob: Job? = null
+
+    /**
+     * Issue #980 — periodic position-checkpoint loop. [persistPosition] only
+     * fires on discrete events (loadAndPlay / pause / chapter-done / advance /
+     * release / seek). During a long uninterrupted listen the in-memory
+     * [PlaybackState.charOffset] advances each sentence but is never written to
+     * Room, so an OS-kill that skips `onDestroy → releaseEngine` (memory
+     * pressure, native crash, force-stop) rolls the resume position back to the
+     * last event-driven save — up to a full chapter of progress lost. This job
+     * runs while [pipelineRunning] and upserts the live position every
+     * [POSITION_CHECKPOINT_INTERVAL_MS], bounding worst-case loss to that
+     * window. One cheap upsert per tick; cancel-and-replaced on each pipeline
+     * start (mirrors [pipelineSetupJob]) and cancelled in [stopPlaybackPipeline].
+     */
+    private var positionCheckpointJob: Job? = null
 
     /**
      * Issue #944 / #956 — serialization guard for the *outer* `loadAndPlay`
@@ -2558,6 +2594,23 @@ class EnginePlayer @AssistedInject constructor(
         }
         pcmSource = source
         pipelineRunning.set(true)
+        // Issue #980 — arm the periodic position checkpoint for this pipeline
+        // lifetime. Cancel-and-replace any prior loop (a rebuild from seek /
+        // speed / voice swap reuses the same engine scope) so we never run two
+        // overlapping savers. The loop self-terminates on pipelineRunning=false
+        // and is also cancelled explicitly in stopPlaybackPipeline; this launch
+        // just (re)starts it for the freshly-armed pipeline.
+        positionCheckpointJob?.cancel()
+        positionCheckpointJob = scope.launch {
+            while (pipelineRunning.get()) {
+                delay(POSITION_CHECKPOINT_INTERVAL_MS)
+                // Re-check after the delay: a teardown may have flipped the
+                // flag while we slept, in which case the position was already
+                // (or is about to be) saved by the discrete-event path.
+                if (!pipelineRunning.get()) break
+                runCatching { persistPosition() }
+            }
+        }
         // Issue #540 — every fresh pipeline starts unpaused. Tear-down
         // paths (stopPlaybackPipeline) also clear userPaused so a
         // pipeline rebuild after a hard stop (voice swap, seek, etc.)
@@ -3473,6 +3526,12 @@ class EnginePlayer @AssistedInject constructor(
         // unblock the parked write; pause() is idempotent w.r.t. the
         // consumer's subsequent flush()/release().
         pipelineRunning.set(false)
+        // Issue #980 — stop the periodic checkpoint loop with the pipeline.
+        // The loop polls pipelineRunning and would exit on its own at the next
+        // delay boundary; cancelling here drops it immediately so a rebuild's
+        // fresh launch can't briefly overlap the dying one.
+        positionCheckpointJob?.cancel()
+        positionCheckpointJob = null
         // Issue #540 — also clear the user-pause flag so the consumer's
         // park branch exits promptly. The pipelineRunning=false above
         // already covers the inner break, but the park loop polls
@@ -3879,6 +3938,13 @@ class EnginePlayer @AssistedInject constructor(
             pipelineSetupJob?.cancel()
             pipelineSetupJob = scope.launch { startPlaybackPipeline() }
         }
+        // Issue #980 — persist the new playhead right after a seek. The
+        // periodic checkpoint covers steady-state, but a scrub-then-kill (or a
+        // seek while paused, where the rebuild branch above doesn't run and the
+        // checkpoint loop isn't armed) would otherwise resume at the pre-seek
+        // position. Fire-and-forget on the engine scope; the in-memory
+        // charOffset above is already the source of truth persistPosition reads.
+        scope.launch { runCatching { persistPosition() } }
         invalidateState()
     }
 
@@ -4074,7 +4140,7 @@ class EnginePlayer @AssistedInject constructor(
         // join sees the freshly-loaded chapter on its next emission.
         // Without this the playback_position row stays pointed at the
         // PREVIOUS chapter until the next save tick (e.g. user pauses,
-        // or next sentence boundary triggers a persistPosition), and
+        // or the #980 periodic checkpoint fires ~10 s later), and
         // the Resume card paints the new chapter's title alongside the
         // old chapter's index/number — a confusing mismatch every
         // auto-advance.
@@ -4314,11 +4380,13 @@ class EnginePlayer @AssistedInject constructor(
 
     private suspend fun persistPosition() {
         val s = _observableState.value
-        val fictionId = s.currentFictionId ?: return
-        val chapterId = s.currentChapterId ?: return
+        // Issue #980 — single save-guard for every checkpoint path (periodic
+        // loop, seek, pause, chapter boundary, teardown). See
+        // [shouldCheckpointPosition] for why both ids must be present.
+        if (!shouldCheckpointPosition(s)) return
         positionRepo.save(
-            fictionId = fictionId,
-            chapterId = chapterId,
+            fictionId = s.currentFictionId!!,
+            chapterId = s.currentChapterId!!,
             charOffset = s.charOffset,
             durationEstimateMs = s.durationEstimateMs,
         )
@@ -4503,6 +4571,17 @@ class EnginePlayer @AssistedInject constructor(
         // the floor with no audio and no error surfaced. Mirror the chapter-
         // fetch-failed cleanup path (line ~1233) so post-stop state is the
         // same shape as cold-boot Idle.
+        //
+        // Issue #980 — capture the position BEFORE the update below zeroes
+        // charOffset + nulls currentChapterId. persistPosition reads those two
+        // fields, so it must run first or it would save 0 / early-return on the
+        // now-null chapter id and the listener loses their place on an explicit
+        // Stop. NonCancellable + blocking so the upsert lands before we clear.
+        runBlocking {
+            withContext(kotlinx.coroutines.NonCancellable) {
+                runCatching { persistPosition() }
+            }
+        }
         _observableState.update {
             it.copy(
                 currentChapterId = null,
@@ -4536,14 +4615,24 @@ class EnginePlayer @AssistedInject constructor(
     }
 
     fun releaseEngine() {
-        // #873 — releaseEngine is invoked from StoryvoxPlaybackService.onDestroy
+        // #873 / #980 — releaseEngine runs from StoryvoxPlaybackService.onDestroy
         // on the main thread. persistPosition does a Room @Upsert whose suspend
-        // body hops to IO inside the DAO. Fire-and-forget: the scope stays alive
-        // until scope.cancel() below, which gives the IO dispatcher time to flush
-        // the write. Worst case the cancel races the upsert and a position
-        // checkpoint is lost — acceptable, since the previous checkpoint from the
-        // periodic save is at most a few seconds stale.
-        scope.launch { persistPosition() }
+        // body hops to IO inside the DAO. The pre-#980 `scope.launch { ... }`
+        // queued the save behind the running release body and then `scope.cancel()`
+        // (below) tore the scope down before the launched coroutine ever
+        // dispatched — on a clean swipe-away this final save was the one most
+        // likely to drop. Run it synchronously under NonCancellable so it
+        // completes BEFORE the cancel, mirroring the handleChapterDone /
+        // advanceChapter teardown saves. runBlocking is acceptable here: we're
+        // already on the main thread in a one-shot teardown, the DAO upsert hops
+        // to IO internally, and other teardown steps below (pcmSource.close)
+        // already block the same way. The #980 periodic checkpoint keeps any
+        // residual loss to ~one interval even if this somehow fails.
+        runBlocking {
+            withContext(kotlinx.coroutines.NonCancellable) {
+                runCatching { persistPosition() }
+            }
+        }
         stopRecapPipeline()
         stopPlaybackPipeline()
         stopAudioStreamPlayer()
@@ -5255,6 +5344,15 @@ class EnginePlayer @AssistedInject constructor(
          *  realtime engines and produced audible gaps with all
          *  Performance & Buffering toggles ON at buffer=3000. */
         const val BUFFER_RESUME_THRESHOLD_MS = 10_000L
+
+        /** Issue #980 — interval between periodic position checkpoints during
+         *  continuous playback. Each tick is a single Room upsert of the live
+         *  charOffset (see [positionCheckpointJob]); 10 s caps the progress an
+         *  OS-kill can roll back while keeping write volume trivial (~6/min).
+         *  Steady-state event-driven saves (pause / seek / chapter boundary)
+         *  still fire on top of this — the loop only covers the long
+         *  uninterrupted listen where no discrete event occurs. */
+        const val POSITION_CHECKPOINT_INTERVAL_MS = 10_000L
 
         /** Issue #862 — target total chunks in flight before the first
          *  [android.media.AudioTrack.play] call: 1 in the consumer's hand

--- a/core-playback/src/test/kotlin/in/jphe/storyvox/playback/tts/EnginePlayerPositionCheckpointTest.kt
+++ b/core-playback/src/test/kotlin/in/jphe/storyvox/playback/tts/EnginePlayerPositionCheckpointTest.kt
@@ -1,0 +1,103 @@
+package `in`.jphe.storyvox.playback.tts
+
+import `in`.jphe.storyvox.playback.PlaybackState
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * Issue #980 — pure-function unit test for [shouldCheckpointPosition], the
+ * save-guard that every position-persist path funnels through
+ * (periodic checkpoint loop, post-seek save, pause, chapter boundary, and the
+ * NonCancellable teardown saves in releaseEngine / handleStop).
+ *
+ * The bug fixed in #980 was about WHEN persistPosition fires, not whether the
+ * write commits — but a regression in the guard would silently disable every
+ * one of those saves. This pins the contract: a checkpoint is meaningful iff
+ * BOTH the fiction id and the chapter id are present, because the row's
+ * composite identity needs them and the Library "Continue listening" join has
+ * nothing to point at otherwise.
+ *
+ * Stays at the pure-function layer — full EnginePlayer construction needs a
+ * Hilt graph + sherpa-onnx AARs (same constraint documented on
+ * EnginePlayerAutoPlayDecisionTest / PlaybackControllerSkipSeekTest).
+ */
+class EnginePlayerPositionCheckpointTest {
+
+    @Test
+    fun `checkpoint saves when both fiction and chapter ids are present`() {
+        // Steady-state continuous listen: the periodic loop ticks mid-chapter
+        // with a live fiction + chapter and a non-zero offset. This is the
+        // headline #980 case — an OS-kill after this save resumes here instead
+        // of rolling back to the chapter start.
+        val state = PlaybackState(
+            currentFictionId = "f",
+            currentChapterId = "c1",
+            charOffset = 5_000,
+        )
+        assertTrue(
+            "a fully-identified, mid-chapter state must be persisted",
+            shouldCheckpointPosition(state),
+        )
+    }
+
+    @Test
+    fun `checkpoint saves even at charOffset zero when ids are present`() {
+        // A fresh chapter load (offset 0) is still a real position — the
+        // Resume card should point at chapter start, not the previous chapter.
+        // The guard keys on identity, not progress.
+        val state = PlaybackState(
+            currentFictionId = "f",
+            currentChapterId = "c1",
+            charOffset = 0,
+        )
+        assertTrue(
+            "offset 0 with a live chapter id is a valid, save-worthy position",
+            shouldCheckpointPosition(state),
+        )
+    }
+
+    @Test
+    fun `no checkpoint when chapter id is null`() {
+        // This is the handleStop ordering trap (#980 GAP-4): handleStop zeroes
+        // charOffset and nulls currentChapterId. If a save ran AFTER that
+        // clear, the guard short-circuits here and the listener's place is
+        // lost. The fix persists BEFORE clearing; this test pins the guard
+        // that makes a post-clear save a no-op rather than a 0-offset stomp.
+        val cleared = PlaybackState(
+            currentFictionId = "f",
+            currentChapterId = null,
+            charOffset = 0,
+        )
+        assertFalse(
+            "a null chapter id (post-stop / cold-boot) has nothing to checkpoint",
+            shouldCheckpointPosition(cleared),
+        )
+    }
+
+    @Test
+    fun `no checkpoint when fiction id is null`() {
+        // Idle / cold-boot Idle state. Defensive: a stray checkpoint tick on
+        // an unloaded engine must not write a half-identified row.
+        val idle = PlaybackState(
+            currentFictionId = null,
+            currentChapterId = "c1",
+        )
+        assertFalse(
+            "a null fiction id is not a persistable position",
+            shouldCheckpointPosition(idle),
+        )
+    }
+
+    @Test
+    fun `no checkpoint on the default Idle state`() {
+        // The all-default PlaybackState (engine constructed, nothing loaded).
+        // The periodic loop is never armed in this state, but the teardown
+        // saves can still call persistPosition on a never-played engine; the
+        // guard makes that a clean no-op.
+        assertFalse(
+            "the default Idle state has no fiction/chapter to save",
+            shouldCheckpointPosition(PlaybackState()),
+        )
+    }
+}


### PR DESCRIPTION
## Summary
Closes #980. EnginePlayer's `persistPosition()` only fired on discrete events (loadAndPlay / pause / chapter-done / advance / release). During a long uninterrupted listen the in-memory `charOffset` advanced each sentence but was never written to Room — an OS-kill that skipped `onDestroy → releaseEngine` (memory pressure / native crash / force-stop) rolled the resume position back to the last event-driven save, up to a full chapter of progress lost.

Verdict from Solace's audit stands: **position writes commit durably; the gap was WHEN they fire, not WHETHER.** This PR fixes the timing.

## Changes (mapped to the audit's gaps)
- **GAP-1 (headline) — periodic checkpoint.** New `positionCheckpointJob` loop on the engine scope, armed right after `pipelineRunning.set(true)`, upserting the live position every `POSITION_CHECKPOINT_INTERVAL_MS` (10 s). Cancel-and-replaced per pipeline start (mirrors `pipelineSetupJob`), cancelled in `stopPlaybackPipeline`, and re-checks `pipelineRunning` after the delay. One cheap upsert per tick (~6/min); bounds worst-case OS-kill loss to one interval.
- **GAP-2 — seeks.** `seekToCharOffset()` (which `seekSentence()` delegates to) now does a fire-and-forget `persistPosition()` after moving the playhead, so a scrub-then-kill — or a **seek while paused**, where neither the rebuild branch nor the checkpoint loop is armed — resumes at the new offset.
- **GAP-3 — releaseEngine race.** The final save was `scope.launch { persistPosition() }` immediately before `scope.cancel()`; the launch was queued behind the running body and cancelled before it dispatched. Now `runBlocking { withContext(NonCancellable) { ... } }` **before** the cancel, mirroring the existing `handleChapterDone` / `advanceChapter` teardown saves. Safe on Main: Room's suspend DAO dispatches the query to its own executor, so the `runBlocking` parks on a background completion (same shape as the existing `pcmSource.close` runBlocking in teardown).
- **GAP-4 — handleStop.** Persists (NonCancellable) **before** zeroing `charOffset` + nulling `currentChapterId`, so an explicit Stop keeps the listener's place instead of saving 0 / short-circuiting on the now-null id.
- **Doc fix.** Corrected the false "next sentence boundary triggers a persistPosition" comment (~4077) to reference the new periodic checkpoint.

## GAP-5 (paragraphIndex) — confirmed dead-by-design, untouched
The 4-arg `save()` preserves `existing?.paragraphIndex ?: 0` and never writes a fresh value; the 5-arg `savePosition` (which does take paragraphIndex) has no live playback caller. `charOffset` is the source of truth. Left as-is per the issue.

## Tests
Extracted `shouldCheckpointPosition()` as a pure top-level guard that **every** save path now funnels through, and added `EnginePlayerPositionCheckpointTest` (5 cases) — following the `shouldAutoPlayAfterAdvance` precedent, since full `EnginePlayer` construction needs a Hilt graph + sherpa-onnx AARs. The guard test also pins the `handleStop` ordering trap (a post-clear save must be a no-op, not a 0-offset stomp).

```
./gradlew :core-playback:compileDebugKotlin :core-playback:testDebugUnitTest  # BUILD SUCCESSFUL
EnginePlayerPositionCheckpointTest — tests=5 failures=0 errors=0
```

## Concurrency note
Does not touch the #927/#929 `loadAndPlayMutex` / `advanceChapterMutex` guards — the checkpoint only calls the existing `persistPosition()`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)