### PR TITLE
fix(follows): make 'Mark all caught up' actually persist read-status (#982)

### DIFF
--- a/app/src/main/kotlin/in/jphe/storyvox/di/AppBindings.kt
+++ b/app/src/main/kotlin/in/jphe/storyvox/di/AppBindings.kt
@@ -567,9 +567,12 @@ private class RealFictionRepositoryUi(
                 `in`.jphe.storyvox.feature.api.SetFollowedRemoteResult.Error(r.message)
         }
 
-    override suspend fun markAllCaughtUp() {
-        // No-op for v1 — chapter-level "read" tracking lands when the reader is wired.
-    }
+    override suspend fun markAllCaughtUp(): Int =
+        // Issue #982 — was a "No-op for v1" stub that still let the VM emit a
+        // success event, so the UI claimed a save that never touched Room. Now
+        // delegates to the repository, which flips every followed fiction's
+        // unread chapters to read in one statement and returns the count.
+        repo.markAllCaughtUp()
 
     override suspend fun refreshFollows() {
         // Best-effort — failures are silent. AuthRequired returns when unauthed,

--- a/core-data/src/main/kotlin/in/jphe/storyvox/data/db/dao/ChapterDao.kt
+++ b/core-data/src/main/kotlin/in/jphe/storyvox/data/db/dao/ChapterDao.kt
@@ -388,6 +388,32 @@ interface ChapterDao {
     )
     suspend fun setRead(id: String, read: Boolean, now: Long)
 
+    /**
+     * Issue #982 — "Mark all caught up" on the Follows screen. Flips every
+     * unread chapter (`userMarkedRead = 0`) belonging to a *followed* fiction
+     * (`fiction.followedRemotely = 1`) to read in one statement, stamping
+     * `firstReadAt` the same way [setRead] does for rows that hadn't been
+     * read before.
+     *
+     * Scoped to `followedRemotely` because that's exactly the set the Follows
+     * tab renders (see [FictionDao.observeFollowsRemote] and
+     * `FollowsRepositoryImpl.unreadChapters`, which join on the same two
+     * columns). The `userMarkedRead = 0` guard keeps `firstReadAt` from being
+     * re-stamped on already-read rows and makes the returned count meaningful:
+     * it's the number of chapters this action actually transitioned, which the
+     * caller uses to avoid claiming a save when nothing changed.
+     */
+    @Query(
+        """
+        UPDATE chapter
+           SET userMarkedRead = 1,
+               firstReadAt = CASE WHEN firstReadAt IS NULL THEN :now ELSE firstReadAt END
+         WHERE userMarkedRead = 0
+           AND fictionId IN (SELECT id FROM fiction WHERE followedRemotely = 1)
+        """,
+    )
+    suspend fun markFollowedCaughtUp(now: Long): Int
+
     @Query(
         """
         UPDATE chapter SET htmlBody = NULL, plainBody = NULL,

--- a/core-data/src/main/kotlin/in/jphe/storyvox/data/repository/FictionRepository.kt
+++ b/core-data/src/main/kotlin/in/jphe/storyvox/data/repository/FictionRepository.kt
@@ -111,6 +111,16 @@ interface FictionRepository {
     suspend fun setFollowedRemote(id: String, followed: Boolean): FictionResult<Unit>
 
     /**
+     * Issue #982 — "Mark all caught up" on the Follows tab. Marks every unread
+     * chapter of every followed fiction (`followedRemotely = 1`) as read in a
+     * single statement, persisting to the same `chapter.userMarkedRead` column
+     * playback and the chat tools write. Returns the number of chapters this
+     * transitioned, so the caller can avoid signalling a save when there was
+     * nothing unread to catch up on.
+     */
+    suspend fun markAllCaughtUp(): Int
+
+    /**
      * Resolve a pasted URL (or short form like `owner/repo`) to a fiction,
      * persist a stub row, and refresh its detail. Returns the resolved
      * `fictionId` on success so the UI can navigate to the detail screen.
@@ -380,6 +390,10 @@ class FictionRepositoryImpl @Inject constructor(
                 is FictionResult.Failure -> r
             }
         }
+
+    override suspend fun markAllCaughtUp(): Int = withContext(Dispatchers.IO) {
+        chapterDao.markFollowedCaughtUp(System.currentTimeMillis())
+    }
 
     override suspend fun addByUrl(
         url: String,

--- a/core-data/src/test/kotlin/in/jphe/storyvox/data/db/dao/ChapterDaoTest.kt
+++ b/core-data/src/test/kotlin/in/jphe/storyvox/data/db/dao/ChapterDaoTest.kt
@@ -444,6 +444,54 @@ class ChapterDaoTest {
         assertEquals(100L, dao.get("c1")!!.firstReadAt)
     }
 
+    // ----- markFollowedCaughtUp (#982) ------------------------------------------
+
+    @Test
+    fun markFollowedCaughtUp_marksOnlyFollowedUnreadChapters_andStampsFirstRead() = runTest {
+        // f1 is followed; f2 is in-library-only (not followed). The action must
+        // flip f1's unread chapters and leave f2 alone — that's the exact set
+        // the Follows tab renders (followedRemotely = 1).
+        val followed = fiction.copy(id = "f1", followedRemotely = true)
+        val notFollowed = fiction.copy(id = "f2", followedRemotely = false)
+        fictionDao.upsert(followed)
+        fictionDao.upsert(notFollowed)
+        dao.upsertAll(
+            listOf(
+                // f1: one unread, one already read with an existing firstReadAt.
+                chapter("a1", index = 0, fictionId = "f1", userMarkedRead = false),
+                chapter("a2", index = 1, fictionId = "f1", userMarkedRead = true),
+                // f2 (not followed): unread, must stay unread.
+                chapter("b1", index = 0, fictionId = "f2", userMarkedRead = false),
+            ),
+        )
+        // Stamp f1's already-read chapter so we can prove it isn't re-stamped.
+        dao.setRead("a2", read = true, now = 50L)
+
+        val flipped = dao.markFollowedCaughtUp(now = 100L)
+
+        // Only the single genuinely-unread followed chapter transitioned.
+        assertEquals(1, flipped)
+        assertTrue(dao.get("a1")!!.userMarkedRead)
+        assertEquals(100L, dao.get("a1")!!.firstReadAt)
+        // Already-read followed chapter keeps its original firstReadAt.
+        assertTrue(dao.get("a2")!!.userMarkedRead)
+        assertEquals(50L, dao.get("a2")!!.firstReadAt)
+        // Non-followed fiction is untouched.
+        assertEquals(false, dao.get("b1")!!.userMarkedRead)
+        assertNull(dao.get("b1")!!.firstReadAt)
+    }
+
+    @Test
+    fun markFollowedCaughtUp_noUnreadFollowed_returnsZero() = runTest {
+        // Already-caught-up followed fiction: nothing to transition, so the
+        // count is 0 and the caller can avoid claiming a fresh save.
+        val followed = fiction.copy(id = "f1", followedRemotely = true)
+        fictionDao.upsert(followed)
+        dao.upsert(chapter("a1", index = 0, fictionId = "f1", userMarkedRead = true))
+
+        assertEquals(0, dao.markFollowedCaughtUp(now = 100L))
+    }
+
     // ----- trimDownloadedBodies -------------------------------------------------
 
     @Test

--- a/core-data/src/test/kotlin/in/jphe/storyvox/data/repository/ChapterRepositoryImplTest.kt
+++ b/core-data/src/test/kotlin/in/jphe/storyvox/data/repository/ChapterRepositoryImplTest.kt
@@ -216,6 +216,8 @@ class ChapterRepositoryImplTest {
             publishRow(id)
         }
 
+        override suspend fun markFollowedCaughtUp(now: Long): Int = 0
+
         override suspend fun cacheUsage(): `in`.jphe.storyvox.data.db.dao.ChapterCacheUsageRow {
             val cached = rows.values.filter { !it.plainBody.isNullOrEmpty() }
             return `in`.jphe.storyvox.data.db.dao.ChapterCacheUsageRow(

--- a/core-data/src/test/kotlin/in/jphe/storyvox/data/repository/FictionRepositoryImplTest.kt
+++ b/core-data/src/test/kotlin/in/jphe/storyvox/data/repository/FictionRepositoryImplTest.kt
@@ -276,6 +276,7 @@ class FictionRepositoryImplTest {
         override suspend fun playbackChapter(id: String): PlaybackChapterRow? = null
         override suspend fun unreadChapters(limit: Int): List<UnreadChapterRow> = emptyList()
         override suspend fun setRead(id: String, read: Boolean, now: Long) {}
+        override suspend fun markFollowedCaughtUp(now: Long): Int = 0
         override suspend fun trimDownloadedBodies(fictionId: String, keepLast: Int) {}
         override suspend fun cacheUsage(): `in`.jphe.storyvox.data.db.dao.ChapterCacheUsageRow =
             `in`.jphe.storyvox.data.db.dao.ChapterCacheUsageRow(count = 0, bytes = 0L)

--- a/feature/src/main/kotlin/in/jphe/storyvox/feature/api/UiContracts.kt
+++ b/feature/src/main/kotlin/in/jphe/storyvox/feature/api/UiContracts.kt
@@ -168,7 +168,15 @@ interface FictionRepositoryUi {
      * library Add/Remove.
      */
     suspend fun setFollowedRemote(fictionId: String, followed: Boolean): SetFollowedRemoteResult
-    suspend fun markAllCaughtUp()
+    /**
+     * Issue #982 — Follows tab "Mark all caught up". Marks every unread
+     * chapter of every followed fiction as read and persists it (the same
+     * `userMarkedRead` column playback writes). Returns how many chapters
+     * were transitioned so the screen only signals success when a write
+     * actually happened — the previous v1 no-op claimed success while
+     * writing nothing.
+     */
+    suspend fun markAllCaughtUp(): Int
     /**
      * Best-effort refresh of the user's source-side follows list. No-op if
      * the user isn't signed in. Caller doesn't await the result — the local

--- a/feature/src/main/kotlin/in/jphe/storyvox/feature/follows/FollowsViewModel.kt
+++ b/feature/src/main/kotlin/in/jphe/storyvox/feature/follows/FollowsViewModel.kt
@@ -72,6 +72,13 @@ class FollowsViewModel @Inject constructor(
 
     fun markAllCaughtUp() {
         viewModelScope.launch {
+            // Issue #982 — markAllCaughtUp now actually persists the read-status
+            // flip and returns the number of chapters it transitioned. The
+            // CaughtUp event still fires unconditionally: pressing the button
+            // when you're already caught up (count == 0) is a no-op write but a
+            // legitimately "caught up" state, so the confirmation is honest. The
+            // bug it fixed was claiming success while writing *nothing* — that's
+            // gone now that the repository write runs first.
             repo.markAllCaughtUp()
             _events.send(FollowsUiEvent.CaughtUp)
         }

--- a/feature/src/test/kotlin/in/jphe/storyvox/feature/chat/ChatViewModelTest.kt
+++ b/feature/src/test/kotlin/in/jphe/storyvox/feature/chat/ChatViewModelTest.kt
@@ -617,7 +617,7 @@ private class FakeFictionRepo(
         followed: Boolean,
     ): `in`.jphe.storyvox.feature.api.SetFollowedRemoteResult =
         `in`.jphe.storyvox.feature.api.SetFollowedRemoteResult.Success
-    override suspend fun markAllCaughtUp() = Unit
+    override suspend fun markAllCaughtUp() = 0
     override suspend fun refreshFollows() = Unit
     override suspend fun addByUrl(url: String, preferredSourceId: String?): UiAddByUrlResult = UiAddByUrlResult.UnrecognizedUrl
     override fun previewUrl(url: String) = emptyList<`in`.jphe.storyvox.feature.api.UiRouteCandidate>()
@@ -646,7 +646,7 @@ private class FakeFictionRepoMulti(
         followed: Boolean,
     ): `in`.jphe.storyvox.feature.api.SetFollowedRemoteResult =
         `in`.jphe.storyvox.feature.api.SetFollowedRemoteResult.Success
-    override suspend fun markAllCaughtUp() = Unit
+    override suspend fun markAllCaughtUp() = 0
     override suspend fun refreshFollows() = Unit
     override suspend fun addByUrl(url: String, preferredSourceId: String?): UiAddByUrlResult = UiAddByUrlResult.UnrecognizedUrl
     override fun previewUrl(url: String) = emptyList<`in`.jphe.storyvox.feature.api.UiRouteCandidate>()

--- a/feature/src/test/kotlin/in/jphe/storyvox/feature/chat/tools/ChatToolHandlersTest.kt
+++ b/feature/src/test/kotlin/in/jphe/storyvox/feature/chat/tools/ChatToolHandlersTest.kt
@@ -228,7 +228,7 @@ private class FakeFictionRepoT : FictionRepositoryUi {
     override suspend fun follow(fictionId: String, follow: Boolean) = Unit
     override suspend fun setFollowedRemote(fictionId: String, followed: Boolean): SetFollowedRemoteResult =
         SetFollowedRemoteResult.Success
-    override suspend fun markAllCaughtUp() = Unit
+    override suspend fun markAllCaughtUp() = 0
     override suspend fun refreshFollows() = Unit
     override suspend fun addByUrl(url: String, preferredSourceId: String?): UiAddByUrlResult = UiAddByUrlResult.UnrecognizedUrl
     override fun previewUrl(url: String) = emptyList<`in`.jphe.storyvox.feature.api.UiRouteCandidate>()


### PR DESCRIPTION
## Problem
The Follows tab's **Mark all caught up** button reported success while writing nothing. `AppBindings.markAllCaughtUp()` was an empty `// No-op for v1` stub, but `FollowsViewModel.markAllCaughtUp()` still emitted `FollowsUiEvent.CaughtUp` right after — the UI showed a confirmation, Room was untouched, and the followed-series unread state was unchanged. (Mirage persistence audit, the one collection action in the #977 cluster that didn't persist.)

## Fix
Wired the action end to end so it genuinely marks the unread chapters of every followed fiction as read:

- **`ChapterDao.markFollowedCaughtUp(now)`** — a single `UPDATE` flipping every unread chapter (`userMarkedRead = 0`) belonging to a followed fiction (`fiction.followedRemotely = 1`) to read, stamping `firstReadAt` the same way `setRead` does. Returns the count of rows actually transitioned. Scoped to `followedRemotely` because that's exactly the set the Follows tab renders (same columns `FollowsRepositoryImpl.unreadChapters` joins on).
- **`FictionRepository.markAllCaughtUp()`** — delegates to the DAO on `Dispatchers.IO`, returns the count.
- **`AppBindings` / `UiContracts.markAllCaughtUp()`** — now return that `Int` instead of `Unit`; the repository write runs **before** `CaughtUp` fires, so the confirmation is honest. `CaughtUp` still fires unconditionally (pressing the button when already caught up is a legitimately caught-up state) — the bug it fixed was claiming success while writing nothing.

Writes go to the same `chapter.userMarkedRead` column playback and the chat tools already use, so the action survives app restart and the unread feeds (`unreadChapters`, Auto's "Continue subscribed series" rail) reflect it immediately.

## Tests
`ChapterDaoTest` (Robolectric + in-memory Room), both passing:
- `markFollowedCaughtUp_marksOnlyFollowedUnreadChapters_andStampsFirstRead` — marks only followed fictions' unread chapters, leaves a non-followed fiction untouched, stamps `firstReadAt` on newly-read rows, and does **not** re-stamp an already-read chapter's `firstReadAt`. Returns count `1`.
- `markFollowedCaughtUp_noUnreadFollowed_returnsZero` — already-caught-up followed fiction returns `0`.

Verified: `:app:compileDebugKotlin :feature:compileDebugKotlin :core-data:compileDebugKotlin` and `:core-data:testDebugUnitTest` (ChapterDaoTest, FictionRepositoryImplTest, ChapterRepositoryImplTest) + affected `:feature` chat tests all green.

Closes #982.

🤖 Generated with [Claude Code](https://claude.com/claude-code)