### PR TITLE
fix(sync): library-sync payload — sourceId regression (#988) + rebuild-essential URL (#989)

### DIFF
--- a/core-data/schemas/in.jphe.storyvox.data.db.StoryvoxDatabase/13.json
+++ b/core-data/schemas/in.jphe.storyvox.data.db.StoryvoxDatabase/13.json
@@ -1,0 +1,985 @@
+{
+  "formatVersion": 1,
+  "database": {
+    "version": 13,
+    "identityHash": "a991f572acc0eaedfdd8a8828d5a33f4",
+    "entities": [
+      {
+        "tableName": "fiction",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `sourceId` TEXT NOT NULL, `title` TEXT NOT NULL, `author` TEXT NOT NULL, `authorId` TEXT, `coverUrl` TEXT, `description` TEXT, `genres` TEXT NOT NULL, `tags` TEXT NOT NULL, `status` TEXT NOT NULL, `chapterCount` INTEGER NOT NULL, `wordCount` INTEGER, `rating` REAL, `views` INTEGER, `followers` INTEGER, `lastUpdatedAt` INTEGER, `firstSeenAt` INTEGER NOT NULL, `metadataFetchedAt` INTEGER NOT NULL, `inLibrary` INTEGER NOT NULL, `addedToLibraryAt` INTEGER, `followedRemotely` INTEGER NOT NULL, `downloadMode` TEXT, `pinnedVoiceId` TEXT, `pinnedVoiceLocale` TEXT, `notesEverSeen` INTEGER NOT NULL, `sourceUrl` TEXT, `lastSeenRevision` TEXT, `metadataBackfillFailedAt` INTEGER, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "sourceId",
+            "columnName": "sourceId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "title",
+            "columnName": "title",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "author",
+            "columnName": "author",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "authorId",
+            "columnName": "authorId",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "coverUrl",
+            "columnName": "coverUrl",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "description",
+            "columnName": "description",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "genres",
+            "columnName": "genres",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "tags",
+            "columnName": "tags",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "status",
+            "columnName": "status",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "chapterCount",
+            "columnName": "chapterCount",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "wordCount",
+            "columnName": "wordCount",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "rating",
+            "columnName": "rating",
+            "affinity": "REAL"
+          },
+          {
+            "fieldPath": "views",
+            "columnName": "views",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "followers",
+            "columnName": "followers",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "lastUpdatedAt",
+            "columnName": "lastUpdatedAt",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "firstSeenAt",
+            "columnName": "firstSeenAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "metadataFetchedAt",
+            "columnName": "metadataFetchedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "inLibrary",
+            "columnName": "inLibrary",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "addedToLibraryAt",
+            "columnName": "addedToLibraryAt",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "followedRemotely",
+            "columnName": "followedRemotely",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "downloadMode",
+            "columnName": "downloadMode",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "pinnedVoiceId",
+            "columnName": "pinnedVoiceId",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "pinnedVoiceLocale",
+            "columnName": "pinnedVoiceLocale",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "notesEverSeen",
+            "columnName": "notesEverSeen",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "sourceUrl",
+            "columnName": "sourceUrl",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "lastSeenRevision",
+            "columnName": "lastSeenRevision",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "metadataBackfillFailedAt",
+            "columnName": "metadataBackfillFailedAt",
+            "affinity": "INTEGER"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_fiction_inLibrary",
+            "unique": false,
+            "columnNames": [
+              "inLibrary"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_fiction_inLibrary` ON `${TABLE_NAME}` (`inLibrary`)"
+          },
+          {
+            "name": "index_fiction_followedRemotely",
+            "unique": false,
+            "columnNames": [
+              "followedRemotely"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_fiction_followedRemotely` ON `${TABLE_NAME}` (`followedRemotely`)"
+          },
+          {
+            "name": "index_fiction_sourceId_lastUpdatedAt",
+            "unique": false,
+            "columnNames": [
+              "sourceId",
+              "lastUpdatedAt"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_fiction_sourceId_lastUpdatedAt` ON `${TABLE_NAME}` (`sourceId`, `lastUpdatedAt`)"
+          },
+          {
+            "name": "index_fiction_inLibrary_addedToLibraryAt",
+            "unique": false,
+            "columnNames": [
+              "inLibrary",
+              "addedToLibraryAt"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_fiction_inLibrary_addedToLibraryAt` ON `${TABLE_NAME}` (`inLibrary`, `addedToLibraryAt`)"
+          },
+          {
+            "name": "index_fiction_followedRemotely_lastUpdatedAt",
+            "unique": false,
+            "columnNames": [
+              "followedRemotely",
+              "lastUpdatedAt"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_fiction_followedRemotely_lastUpdatedAt` ON `${TABLE_NAME}` (`followedRemotely`, `lastUpdatedAt`)"
+          }
+        ]
+      },
+      {
+        "tableName": "chapter",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `fictionId` TEXT NOT NULL, `sourceChapterId` TEXT NOT NULL, `index` INTEGER NOT NULL, `title` TEXT NOT NULL, `publishedAt` INTEGER, `wordCount` INTEGER, `htmlBody` TEXT, `plainBody` TEXT, `bodyFetchedAt` INTEGER, `bodyChecksum` TEXT, `downloadState` TEXT NOT NULL, `lastDownloadAttemptAt` INTEGER, `lastDownloadError` TEXT, `notesAuthor` TEXT, `notesAuthorPosition` TEXT, `userMarkedRead` INTEGER NOT NULL, `firstReadAt` INTEGER, `bookmarkCharOffset` INTEGER, `audioUrl` TEXT, PRIMARY KEY(`id`), FOREIGN KEY(`fictionId`) REFERENCES `fiction`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "fictionId",
+            "columnName": "fictionId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "sourceChapterId",
+            "columnName": "sourceChapterId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "index",
+            "columnName": "index",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "title",
+            "columnName": "title",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "publishedAt",
+            "columnName": "publishedAt",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "wordCount",
+            "columnName": "wordCount",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "htmlBody",
+            "columnName": "htmlBody",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "plainBody",
+            "columnName": "plainBody",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "bodyFetchedAt",
+            "columnName": "bodyFetchedAt",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "bodyChecksum",
+            "columnName": "bodyChecksum",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "downloadState",
+            "columnName": "downloadState",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastDownloadAttemptAt",
+            "columnName": "lastDownloadAttemptAt",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "lastDownloadError",
+            "columnName": "lastDownloadError",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "notesAuthor",
+            "columnName": "notesAuthor",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "notesAuthorPosition",
+            "columnName": "notesAuthorPosition",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "userMarkedRead",
+            "columnName": "userMarkedRead",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "firstReadAt",
+            "columnName": "firstReadAt",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "bookmarkCharOffset",
+            "columnName": "bookmarkCharOffset",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "audioUrl",
+            "columnName": "audioUrl",
+            "affinity": "TEXT"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_chapter_fictionId",
+            "unique": false,
+            "columnNames": [
+              "fictionId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_chapter_fictionId` ON `${TABLE_NAME}` (`fictionId`)"
+          },
+          {
+            "name": "index_chapter_fictionId_index",
+            "unique": true,
+            "columnNames": [
+              "fictionId",
+              "index"
+            ],
+            "orders": [],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_chapter_fictionId_index` ON `${TABLE_NAME}` (`fictionId`, `index`)"
+          },
+          {
+            "name": "index_chapter_downloadState",
+            "unique": false,
+            "columnNames": [
+              "downloadState"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_chapter_downloadState` ON `${TABLE_NAME}` (`downloadState`)"
+          },
+          {
+            "name": "index_chapter_fictionId_userMarkedRead",
+            "unique": false,
+            "columnNames": [
+              "fictionId",
+              "userMarkedRead"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_chapter_fictionId_userMarkedRead` ON `${TABLE_NAME}` (`fictionId`, `userMarkedRead`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "fiction",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "fictionId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "playback_position",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`fictionId` TEXT NOT NULL, `chapterId` TEXT NOT NULL, `charOffset` INTEGER NOT NULL, `paragraphIndex` INTEGER NOT NULL, `playbackSpeed` REAL NOT NULL, `durationEstimateMs` INTEGER NOT NULL, `updatedAt` INTEGER NOT NULL, PRIMARY KEY(`fictionId`, `chapterId`), FOREIGN KEY(`fictionId`) REFERENCES `fiction`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE , FOREIGN KEY(`chapterId`) REFERENCES `chapter`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "fictionId",
+            "columnName": "fictionId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "chapterId",
+            "columnName": "chapterId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "charOffset",
+            "columnName": "charOffset",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "paragraphIndex",
+            "columnName": "paragraphIndex",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "playbackSpeed",
+            "columnName": "playbackSpeed",
+            "affinity": "REAL",
+            "notNull": true
+          },
+          {
+            "fieldPath": "durationEstimateMs",
+            "columnName": "durationEstimateMs",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "updatedAt",
+            "columnName": "updatedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "fictionId",
+            "chapterId"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_playback_position_chapterId",
+            "unique": false,
+            "columnNames": [
+              "chapterId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_playback_position_chapterId` ON `${TABLE_NAME}` (`chapterId`)"
+          },
+          {
+            "name": "index_playback_position_updatedAt",
+            "unique": false,
+            "columnNames": [
+              "updatedAt"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_playback_position_updatedAt` ON `${TABLE_NAME}` (`updatedAt`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "fiction",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "fictionId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          },
+          {
+            "table": "chapter",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "chapterId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "auth_cookie",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`sourceId` TEXT NOT NULL, `userDisplayName` TEXT, `userId` TEXT, `capturedAt` INTEGER NOT NULL, `expiresAt` INTEGER, `lastVerifiedAt` INTEGER NOT NULL, PRIMARY KEY(`sourceId`))",
+        "fields": [
+          {
+            "fieldPath": "sourceId",
+            "columnName": "sourceId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "userDisplayName",
+            "columnName": "userDisplayName",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "userId",
+            "columnName": "userId",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "capturedAt",
+            "columnName": "capturedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "expiresAt",
+            "columnName": "expiresAt",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "lastVerifiedAt",
+            "columnName": "lastVerifiedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "sourceId"
+          ]
+        }
+      },
+      {
+        "tableName": "llm_session",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `name` TEXT NOT NULL, `provider` TEXT NOT NULL, `model` TEXT NOT NULL, `systemPrompt` TEXT, `createdAt` INTEGER NOT NULL, `lastUsedAt` INTEGER NOT NULL, `featureKind` TEXT, `anchorFictionId` TEXT, `anchorChapterId` TEXT, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "provider",
+            "columnName": "provider",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "model",
+            "columnName": "model",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "systemPrompt",
+            "columnName": "systemPrompt",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "createdAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastUsedAt",
+            "columnName": "lastUsedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "featureKind",
+            "columnName": "featureKind",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "anchorFictionId",
+            "columnName": "anchorFictionId",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "anchorChapterId",
+            "columnName": "anchorChapterId",
+            "affinity": "TEXT"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "llm_message",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `sessionId` TEXT NOT NULL, `role` TEXT NOT NULL, `content` TEXT NOT NULL, `createdAt` INTEGER NOT NULL, FOREIGN KEY(`sessionId`) REFERENCES `llm_session`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "sessionId",
+            "columnName": "sessionId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "role",
+            "columnName": "role",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "content",
+            "columnName": "content",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "createdAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_llm_message_sessionId",
+            "unique": false,
+            "columnNames": [
+              "sessionId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_llm_message_sessionId` ON `${TABLE_NAME}` (`sessionId`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "llm_session",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "sessionId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "fiction_shelf",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`fictionId` TEXT NOT NULL, `shelf` TEXT NOT NULL, `addedAt` INTEGER NOT NULL, PRIMARY KEY(`fictionId`, `shelf`), FOREIGN KEY(`fictionId`) REFERENCES `fiction`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "fictionId",
+            "columnName": "fictionId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "shelf",
+            "columnName": "shelf",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "addedAt",
+            "columnName": "addedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "fictionId",
+            "shelf"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_fiction_shelf_shelf",
+            "unique": false,
+            "columnNames": [
+              "shelf"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_fiction_shelf_shelf` ON `${TABLE_NAME}` (`shelf`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "fiction",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "fictionId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "chapter_history",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`fictionId` TEXT NOT NULL, `chapterId` TEXT NOT NULL, `openedAt` INTEGER NOT NULL, `completed` INTEGER NOT NULL, `fractionRead` REAL, PRIMARY KEY(`fictionId`, `chapterId`), FOREIGN KEY(`fictionId`) REFERENCES `fiction`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE , FOREIGN KEY(`chapterId`) REFERENCES `chapter`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "fictionId",
+            "columnName": "fictionId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "chapterId",
+            "columnName": "chapterId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "openedAt",
+            "columnName": "openedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "completed",
+            "columnName": "completed",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "fractionRead",
+            "columnName": "fractionRead",
+            "affinity": "REAL"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "fictionId",
+            "chapterId"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_chapter_history_openedAt",
+            "unique": false,
+            "columnNames": [
+              "openedAt"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_chapter_history_openedAt` ON `${TABLE_NAME}` (`openedAt`)"
+          },
+          {
+            "name": "index_chapter_history_chapterId",
+            "unique": false,
+            "columnNames": [
+              "chapterId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_chapter_history_chapterId` ON `${TABLE_NAME}` (`chapterId`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "fiction",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "fictionId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          },
+          {
+            "table": "chapter",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "chapterId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "inbox_event",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `sourceId` TEXT NOT NULL, `fictionId` TEXT, `chapterId` TEXT, `title` TEXT NOT NULL, `body` TEXT, `ts` INTEGER NOT NULL, `isRead` INTEGER NOT NULL, `deepLinkUri` TEXT)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "sourceId",
+            "columnName": "sourceId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "fictionId",
+            "columnName": "fictionId",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "chapterId",
+            "columnName": "chapterId",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "title",
+            "columnName": "title",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "body",
+            "columnName": "body",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "ts",
+            "columnName": "ts",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "isRead",
+            "columnName": "isRead",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "deepLinkUri",
+            "columnName": "deepLinkUri",
+            "affinity": "TEXT"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_inbox_event_ts",
+            "unique": false,
+            "columnNames": [
+              "ts"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_inbox_event_ts` ON `${TABLE_NAME}` (`ts`)"
+          },
+          {
+            "name": "index_inbox_event_isRead",
+            "unique": false,
+            "columnNames": [
+              "isRead"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_inbox_event_isRead` ON `${TABLE_NAME}` (`isRead`)"
+          },
+          {
+            "name": "index_inbox_event_sourceId_fictionId",
+            "unique": false,
+            "columnNames": [
+              "sourceId",
+              "fictionId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_inbox_event_sourceId_fictionId` ON `${TABLE_NAME}` (`sourceId`, `fictionId`)"
+          }
+        ]
+      },
+      {
+        "tableName": "fiction_memory_entry",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`fictionId` TEXT NOT NULL, `entityType` TEXT NOT NULL, `name` TEXT NOT NULL, `summary` TEXT NOT NULL, `firstSeenChapterIndex` INTEGER, `lastUpdated` INTEGER NOT NULL, `userEdited` INTEGER NOT NULL, PRIMARY KEY(`fictionId`, `name`))",
+        "fields": [
+          {
+            "fieldPath": "fictionId",
+            "columnName": "fictionId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "entityType",
+            "columnName": "entityType",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "summary",
+            "columnName": "summary",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "firstSeenChapterIndex",
+            "columnName": "firstSeenChapterIndex",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "lastUpdated",
+            "columnName": "lastUpdated",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "userEdited",
+            "columnName": "userEdited",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "fictionId",
+            "name"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_fiction_memory_entry_name",
+            "unique": false,
+            "columnNames": [
+              "name"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_fiction_memory_entry_name` ON `${TABLE_NAME}` (`name`)"
+          },
+          {
+            "name": "index_fiction_memory_entry_fictionId",
+            "unique": false,
+            "columnNames": [
+              "fictionId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_fiction_memory_entry_fictionId` ON `${TABLE_NAME}` (`fictionId`)"
+          }
+        ]
+      }
+    ],
+    "setupQueries": [
+      "CREATE TABLE IF NOT EXISTS room_master_table (id INTEGER PRIMARY KEY,identity_hash TEXT)",
+      "INSERT OR REPLACE INTO room_master_table (id,identity_hash) VALUES(42, 'a991f572acc0eaedfdd8a8828d5a33f4')"
+    ]
+  }
+}

--- a/core-data/src/main/kotlin/in/jphe/storyvox/data/db/StoryvoxDatabase.kt
+++ b/core-data/src/main/kotlin/in/jphe/storyvox/data/db/StoryvoxDatabase.kt
@@ -58,7 +58,12 @@ import `in`.jphe.storyvox.data.db.entity.PlaybackPosition
     // so synced placeholder rows that a source can't hydrate surface a
     // distinct "Couldn't load" state instead of an eternal "Loading…".
     // Purely additive nullable column.
-    version = 12,
+    //
+    // v13 (#989 rebuild-essential URL) — adds `fiction.sourceUrl`, the
+    // original source URL for hash-id sources (Readability/RSS/EPUB
+    // direct-download) so a synced placeholder can be rebuilt on a
+    // second device. Purely additive nullable column.
+    version = 13,
     exportSchema = true,
 )
 @TypeConverters(Converters::class)

--- a/core-data/src/main/kotlin/in/jphe/storyvox/data/db/dao/FictionDao.kt
+++ b/core-data/src/main/kotlin/in/jphe/storyvox/data/db/dao/FictionDao.kt
@@ -104,6 +104,25 @@ interface FictionDao {
     suspend fun setSourceId(id: String, sourceId: String)
 
     /**
+     * Issue #989 — read the persisted rebuild URL for a hash-id source
+     * (Readability/RSS/EPUB direct-download). Null for the many sources
+     * whose id is self-describing. Used both by `ReadabilitySource` as a
+     * durable fallback behind its in-memory URL cache and by
+     * `LibrarySyncer` to populate the synced library payload.
+     */
+    @Query("SELECT sourceUrl FROM fiction WHERE id = :id")
+    suspend fun getSourceUrl(id: String): String?
+
+    /**
+     * Issue #989 — persist the rebuild URL. Only overwrites a NULL: once
+     * a row has a remembered URL we never clobber it (the originating
+     * paste is authoritative; a synced placeholder that arrives later
+     * with the same URL is a no-op, and we never want to null it out).
+     */
+    @Query("UPDATE fiction SET sourceUrl = :url WHERE id = :id AND sourceUrl IS NULL")
+    suspend fun setSourceUrlIfAbsent(id: String, url: String)
+
+    /**
      * Issue #981 — placeholder rows the [MetadataBackfillWorker] should
      * hydrate. A placeholder is a library / source-follow row that was
      * inserted by `LibrarySyncer`/`FollowsSyncer.localAdd` with

--- a/core-data/src/main/kotlin/in/jphe/storyvox/data/db/entity/Fiction.kt
+++ b/core-data/src/main/kotlin/in/jphe/storyvox/data/db/entity/Fiction.kt
@@ -47,6 +47,34 @@ data class Fiction(
     val pinnedVoiceLocale: String? = null,
     val notesEverSeen: Boolean = false,
     /**
+     * Issue #989 — the original source URL needed to *rebuild* this
+     * fiction on a device that never saw the original paste.
+     *
+     * Most sources don't need this: their `id` already encodes
+     * everything required to re-fetch (`gutenberg:84`, `ao3:123`,
+     * numeric Royal Road, `wikipedia:Foo`, …), so the
+     * `MetadataBackfillWorker` can hydrate a placeholder from the id
+     * alone. But three backends hash the source URL into an opaque,
+     * non-reversible id:
+     *  - **Readability** (`readability:<sha256-16>`) — the catch-all
+     *    paste-anything article extractor;
+     *  - **RSS** (`rss:<sha256-16>`) — feed URL hashed;
+     *  - **EPUB direct download** (`epub:url:<sha256-16>`).
+     * For those, the URL is the *only* thing that can rebuild the
+     * fiction, and historically it lived purely in an in-memory cache
+     * on the originating device (see `ReadabilitySource.persistedUrlFor`)
+     * — so a synced placeholder on a second device had an id but no URL
+     * and could never hydrate (issue #989; the #981 worker logged "has
+     * no remembered URL").
+     *
+     * Persisting the URL here gives it a durable home that (a) survives
+     * process death / cache-clear on the originating device and (b) is
+     * readable by `LibrarySyncer` so it can ride across devices in the
+     * synced library payload. Null for the many sources whose id is
+     * self-describing.
+     */
+    val sourceUrl: String? = null,
+    /**
      * Source-side revision token captured the last time we successfully
      * polled this fiction. For GitHub it's the head commit SHA on the
      * default branch; for sources that don't expose a cheap revision

--- a/core-data/src/main/kotlin/in/jphe/storyvox/data/db/migration/Migrations.kt
+++ b/core-data/src/main/kotlin/in/jphe/storyvox/data/db/migration/Migrations.kt
@@ -394,6 +394,18 @@ val MIGRATION_11_12: Migration = object : Migration(11, 12) {
     }
 }
 
+/**
+ * Issue #989 — add `fiction.sourceUrl`, the rebuild-essential original
+ * URL for sources whose id is an opaque hash of the URL (Readability,
+ * RSS, EPUB direct-download). Nullable: the column stays NULL for the
+ * many sources whose id already encodes everything needed to re-fetch.
+ */
+val MIGRATION_12_13: Migration = object : Migration(12, 13) {
+    override fun migrate(db: SupportSQLiteDatabase) {
+        db.execSQL("ALTER TABLE `fiction` ADD COLUMN `sourceUrl` TEXT")
+    }
+}
+
 val ALL_MIGRATIONS: Array<Migration> = arrayOf(
     MIGRATION_1_2,
     MIGRATION_2_3,
@@ -406,4 +418,5 @@ val ALL_MIGRATIONS: Array<Migration> = arrayOf(
     MIGRATION_9_10,
     MIGRATION_10_11,
     MIGRATION_11_12,
+    MIGRATION_12_13,
 )

--- a/core-data/src/main/kotlin/in/jphe/storyvox/data/di/DataModule.kt
+++ b/core-data/src/main/kotlin/in/jphe/storyvox/data/di/DataModule.kt
@@ -310,4 +310,12 @@ abstract class RepositoryBindings {
     abstract fun bindMetadataBackfillScheduler(
         impl: WorkManagerMetadataBackfillScheduler,
     ): MetadataBackfillScheduler
+
+    // Issue #989 — durable source-URL lookup for hash-id sources
+    // (Readability/RSS/EPUB-direct). DAO-backed; consumed by the leaf
+    // source modules so a synced fiction can be rebuilt from its URL.
+    @Binds @Singleton
+    abstract fun bindRememberedUrlStore(
+        impl: `in`.jphe.storyvox.data.source.DaoRememberedUrlStore,
+    ): `in`.jphe.storyvox.data.source.RememberedUrlStore
 }

--- a/core-data/src/main/kotlin/in/jphe/storyvox/data/repository/FictionRepository.kt
+++ b/core-data/src/main/kotlin/in/jphe/storyvox/data/repository/FictionRepository.kt
@@ -444,8 +444,19 @@ class FictionRepositoryImpl @Inject constructor(
                     author = "",
                     firstSeenAt = now,
                     metadataFetchedAt = now,
+                    // Issue #989 — remember the original URL for the
+                    // hash-id sources (Readability/RSS/EPUB-direct) whose
+                    // id can't be reversed to a URL. This is the durable
+                    // home that survives process death / cache-clear and
+                    // rides across devices via LibrarySyncer.
+                    sourceUrl = if (SourceIds.idNeedsSourceUrlToRebuild(picked.sourceId)) url else null,
                 ),
             )
+        } else if (SourceIds.idNeedsSourceUrlToRebuild(picked.sourceId)) {
+            // Row already exists (re-paste of the same URL, or a synced
+            // placeholder we're now hydrating): back-fill the URL if we
+            // never captured it. setSourceUrlIfAbsent never clobbers.
+            fictionDao.setSourceUrlIfAbsent(picked.fictionId, url)
         }
 
         when (val r = src.fictionDetail(picked.fictionId)) {

--- a/core-data/src/main/kotlin/in/jphe/storyvox/data/source/RememberedUrlStore.kt
+++ b/core-data/src/main/kotlin/in/jphe/storyvox/data/source/RememberedUrlStore.kt
@@ -1,0 +1,46 @@
+package `in`.jphe.storyvox.data.source
+
+import `in`.jphe.storyvox.data.db.dao.FictionDao
+import javax.inject.Inject
+import javax.inject.Singleton
+
+/**
+ * Issue #989 — durable lookup of the original source URL for a fiction
+ * whose `id` is an opaque hash of that URL (Readability/RSS/EPUB-direct).
+ *
+ * # Why this exists
+ *
+ * These sources can't reverse their id back to a URL, so rebuilding the
+ * fiction needs the URL stored somewhere. Historically the Readability
+ * source kept it in a process-lifetime in-memory map, which is lost on
+ * process death and never existed on a second device — so a synced
+ * placeholder could never hydrate (issue #989: "has no remembered URL").
+ *
+ * The URL now lives on `Fiction.sourceUrl` (persisted at paste time by
+ * `FictionRepository.addByUrl`, and stamped onto a synced placeholder by
+ * `LibrarySyncer`). This thin interface exposes that column to the leaf
+ * source modules without making them depend on the full `FictionDao`
+ * surface or the `:app`/repository layer — same decoupling rationale as
+ * the other `:core-data` store interfaces (e.g. `FollowedTagsStore`).
+ *
+ * The interface lives in `:core-data` (which the source modules already
+ * depend on) and the implementation is a trivial DAO wrapper, also in
+ * `:core-data`, bound in `RepositoryBindings`.
+ */
+interface RememberedUrlStore {
+    /**
+     * The persisted source URL for [fictionId], or null if none was ever
+     * remembered (the common case for self-describing-id sources, or a
+     * pre-#989 row that predates the column).
+     */
+    suspend fun rememberedUrl(fictionId: String): String?
+}
+
+/** [RememberedUrlStore] backed by the `fiction.sourceUrl` column. */
+@Singleton
+class DaoRememberedUrlStore @Inject constructor(
+    private val fictionDao: FictionDao,
+) : RememberedUrlStore {
+    override suspend fun rememberedUrl(fictionId: String): String? =
+        fictionDao.getSourceUrl(fictionId)
+}

--- a/core-data/src/main/kotlin/in/jphe/storyvox/data/source/SourceIds.kt
+++ b/core-data/src/main/kotlin/in/jphe/storyvox/data/source/SourceIds.kt
@@ -248,4 +248,29 @@ object SourceIds {
      *  source never wins when a specialized backend also claims the URL
      *  — it's a safety net, not a competitor. */
     const val READABILITY: String = "readability"
+
+    /**
+     * Issue #989 — the sources whose fiction `id` is an opaque,
+     * non-reversible hash of the source URL, so the id alone is NOT
+     * enough to rebuild the fiction on a device that never saw the
+     * paste. For these, the original URL must be persisted
+     * (`Fiction.sourceUrl`) and carried in the synced library payload so
+     * a second device can hydrate the placeholder.
+     *
+     * Audit (the "id alone isn't enough to rebuild" gap):
+     *  - [READABILITY] — `readability:<sha256-16>` of the article URL;
+     *  - [RSS] — `rss:<sha256-16>` of the feed URL;
+     *  - [EPUB] *direct-download* variant — `epub:url:<sha256-16>` of an
+     *    `.epub` URL. (SAF-imported EPUBs use a `content://` tree-uri id
+     *    that is device-local and not rebuildable on another device even
+     *    with the URI, so they are deliberately NOT in this set — their
+     *    file simply doesn't exist on a second device.)
+     *
+     * Every other source encodes a source-native id or URL-path in its
+     * fiction id (`gutenberg:84`, `ao3:123`, numeric Royal Road,
+     * `wikipedia:Foo`, `discord:guild/channel`, …) and rebuilds from the
+     * id alone via `MetadataBackfillWorker` → `refreshDetail`.
+     */
+    fun idNeedsSourceUrlToRebuild(sourceId: String): Boolean =
+        sourceId == READABILITY || sourceId == RSS || sourceId == EPUB
 }

--- a/core-data/src/test/kotlin/in/jphe/storyvox/data/db/StoryvoxDatabaseMigrationTest.kt
+++ b/core-data/src/test/kotlin/in/jphe/storyvox/data/db/StoryvoxDatabaseMigrationTest.kt
@@ -15,6 +15,7 @@ import `in`.jphe.storyvox.data.db.migration.MIGRATION_8_9
 import `in`.jphe.storyvox.data.db.migration.MIGRATION_9_10
 import `in`.jphe.storyvox.data.db.migration.MIGRATION_10_11
 import `in`.jphe.storyvox.data.db.migration.MIGRATION_11_12
+import `in`.jphe.storyvox.data.db.migration.MIGRATION_12_13
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNotNull
 import org.junit.Assert.assertTrue
@@ -146,12 +147,16 @@ class StoryvoxDatabaseMigrationTest {
         // so the latest-version Room.databaseBuilder opens without a
         // missing-migration failure.
         helper.runMigrationsAndValidate(dbName, 12, true, MIGRATION_11_12).close()
+        // #989 — v13 adds fiction.sourceUrl. Chain through so the
+        // latest-version Room.databaseBuilder opens cleanly.
+        helper.runMigrationsAndValidate(dbName, 13, true, MIGRATION_12_13).close()
 
         val ctx = org.robolectric.RuntimeEnvironment.getApplication() as android.content.Context
         val db = Room.databaseBuilder(ctx, StoryvoxDatabase::class.java, dbName)
             .addMigrations(
                 MIGRATION_4_5, MIGRATION_5_6, MIGRATION_6_7, MIGRATION_7_8,
                 MIGRATION_8_9, MIGRATION_9_10, MIGRATION_10_11, MIGRATION_11_12,
+                MIGRATION_12_13,
             )
             .build()
 
@@ -312,12 +317,15 @@ class StoryvoxDatabaseMigrationTest {
         helper.runMigrationsAndValidate(dbName, 11, true, MIGRATION_10_11).close()
         // #981 — chain through v12 (fiction.metadataBackfillFailedAt).
         helper.runMigrationsAndValidate(dbName, 12, true, MIGRATION_11_12).close()
+        // #989 — chain through v13 (fiction.sourceUrl).
+        helper.runMigrationsAndValidate(dbName, 13, true, MIGRATION_12_13).close()
 
         val ctx = org.robolectric.RuntimeEnvironment.getApplication() as android.content.Context
         val db = Room.databaseBuilder(ctx, StoryvoxDatabase::class.java, dbName)
             .addMigrations(
                 MIGRATION_4_5, MIGRATION_5_6, MIGRATION_6_7, MIGRATION_7_8,
                 MIGRATION_8_9, MIGRATION_9_10, MIGRATION_10_11, MIGRATION_11_12,
+                MIGRATION_12_13,
             )
             .build()
 
@@ -931,6 +939,89 @@ class StoryvoxDatabaseMigrationTest {
             assertEquals("gutenberg:84", c.getString(0))
             assertTrue(
                 "metadataBackfillFailedAt must default to NULL for existing rows",
+                c.isNull(1),
+            )
+        }
+
+        db.close()
+    }
+
+    /**
+     * Issue #989 — v13 adds the nullable `fiction.sourceUrl` column so a
+     * hash-id fiction (Readability/RSS/EPUB direct-download) can be
+     * rebuilt on a device that never saw the paste. Purely additive;
+     * existing rows get NULL (no remembered URL — the common case for
+     * self-describing-id sources).
+     *
+     * Same shape as the v11→v12 test: seed a v12 row, run 12→13, verify
+     * the column exists, is nullable, and defaults to NULL on the
+     * pre-existing row.
+     */
+    @Test fun `migrate v12 to v13 adds fiction sourceUrl column`() {
+        val dbName = "source-url-migration-test.db"
+
+        helper.createDatabase(dbName, 4).close()
+        helper.runMigrationsAndValidate(dbName, 5, true, MIGRATION_4_5).close()
+        helper.runMigrationsAndValidate(dbName, 6, true, MIGRATION_5_6).close()
+        helper.runMigrationsAndValidate(dbName, 7, true, MIGRATION_6_7).close()
+        helper.runMigrationsAndValidate(dbName, 8, true, MIGRATION_7_8).close()
+        helper.runMigrationsAndValidate(dbName, 9, true, MIGRATION_8_9).close()
+        helper.runMigrationsAndValidate(dbName, 10, true, MIGRATION_9_10).close()
+        helper.runMigrationsAndValidate(dbName, 11, true, MIGRATION_10_11).close()
+        helper.runMigrationsAndValidate(dbName, 12, true, MIGRATION_11_12).use { db ->
+            // Seed a Readability fiction at v12 so the existing row
+            // exercises the NULL-default behaviour after the column lands.
+            db.execSQL(
+                """
+                INSERT INTO fiction(
+                    id, sourceId, title, author, genres, tags, status,
+                    chapterCount, firstSeenAt, metadataFetchedAt,
+                    inLibrary, followedRemotely, notesEverSeen
+                ) VALUES (
+                    'readability:1a2b3c4d5e6f7a8b', 'readability', 'Loading…', '',
+                    '[]', '[]', 'COMPLETED', 1, 0, 0, 1, 0, 0
+                )
+                """.trimIndent(),
+            )
+        }
+
+        val db = helper.runMigrationsAndValidate(
+            dbName,
+            13,
+            /* validateDroppedTables = */ true,
+            MIGRATION_12_13,
+        )
+
+        db.query("PRAGMA table_info('fiction')").use { c ->
+            var sawColumn = false
+            while (c.moveToNext()) {
+                val name = c.getString(c.getColumnIndexOrThrow("name"))
+                if (name == "sourceUrl") {
+                    sawColumn = true
+                    val type = c.getString(c.getColumnIndexOrThrow("type"))
+                    assertEquals("TEXT", type)
+                    val notnull = c.getInt(c.getColumnIndexOrThrow("notnull"))
+                    assertEquals(
+                        "sourceUrl must be nullable (NULL = no remembered URL)",
+                        0,
+                        notnull,
+                    )
+                }
+            }
+            assertTrue(
+                "fiction.sourceUrl column must exist post-migration",
+                sawColumn,
+            )
+        }
+
+        // Pre-existing v12 row must round-trip with a NULL sourceUrl.
+        db.query(
+            "SELECT id, sourceUrl FROM fiction WHERE id = 'readability:1a2b3c4d5e6f7a8b'",
+        ).use { c ->
+            assertTrue("seeded v12 fiction row must survive the migration", c.moveToFirst())
+            assertEquals("readability:1a2b3c4d5e6f7a8b", c.getString(0))
+            assertTrue(
+                "sourceUrl must default to NULL for existing rows",
                 c.isNull(1),
             )
         }

--- a/core-data/src/test/kotlin/in/jphe/storyvox/data/repository/FictionRepositoryImplTest.kt
+++ b/core-data/src/test/kotlin/in/jphe/storyvox/data/repository/FictionRepositoryImplTest.kt
@@ -192,6 +192,18 @@ class FictionRepositoryImplTest {
             publish(id)
         }
 
+        override suspend fun getSourceUrl(id: String): String? = rows[id]?.sourceUrl
+
+        override suspend fun setSourceUrlIfAbsent(id: String, url: String) {
+            callLog += "setSourceUrlIfAbsent($id, $url)"
+            val r = rows[id] ?: return
+            // Mirror the real DAO's `WHERE sourceUrl IS NULL` — never clobber.
+            if (r.sourceUrl == null) {
+                rows[id] = r.copy(sourceUrl = url)
+                publish(id)
+            }
+        }
+
         override suspend fun markBackfillFailed(id: String, now: Long) {
             callLog += "markBackfillFailed($id, $now)"
             val r = rows[id] ?: return

--- a/core-data/src/test/kotlin/in/jphe/storyvox/data/source/FictionSourceIdResolverTest.kt
+++ b/core-data/src/test/kotlin/in/jphe/storyvox/data/source/FictionSourceIdResolverTest.kt
@@ -64,4 +64,21 @@ class FictionSourceIdResolverTest {
         assertEquals("gutenberg", FictionSourceIdResolver.resolveByShape("gutenberg:84"))
         assertEquals("somafm-groove-salad", FictionSourceIdResolver.resolveByShape("somafm-groove-salad:live"))
     }
+
+    @Test fun `issue 988 - placeholder-creation stamps royalroad not the whole number`() {
+        // Regression for #988: LibrarySyncer/FollowsSyncer.localAdd stamp
+        // a fresh placeholder's sourceId via resolveByShape (the sync
+        // layer has no bound-source registry). The pre-fix code used
+        // `id.substringBefore(':')`, which on a colon-less Royal Road id
+        // returned the WHOLE number ("146000") — an unbindable sourceId
+        // that left the row stuck on "Loading…" forever. These are the
+        // exact ids Aria's #981 worker logged repairing on JP's device.
+        for (rrId in listOf("146000", "156215", "8894")) {
+            assertEquals(
+                "bare numeric RR id must resolve to royalroad at placeholder creation",
+                "royalroad",
+                FictionSourceIdResolver.resolveByShape(rrId),
+            )
+        }
+    }
 }

--- a/core-data/src/test/kotlin/in/jphe/storyvox/data/source/SourceIdsRebuildAuditTest.kt
+++ b/core-data/src/test/kotlin/in/jphe/storyvox/data/source/SourceIdsRebuildAuditTest.kt
@@ -1,0 +1,42 @@
+package `in`.jphe.storyvox.data.source
+
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * Issue #989 — pins the audit of which sources have an id that ISN'T
+ * enough to rebuild the fiction without the original URL. Only the
+ * hash-id sources (Readability/RSS/EPUB) qualify; every self-describing
+ * id source must NOT, or we'd bloat the synced payload (and persist
+ * URLs) for fictions that don't need them.
+ */
+class SourceIdsRebuildAuditTest {
+
+    @Test fun `hash-id sources need the source URL to rebuild`() {
+        assertTrue(SourceIds.idNeedsSourceUrlToRebuild(SourceIds.READABILITY))
+        assertTrue(SourceIds.idNeedsSourceUrlToRebuild(SourceIds.RSS))
+        assertTrue(SourceIds.idNeedsSourceUrlToRebuild(SourceIds.EPUB))
+    }
+
+    @Test fun `self-describing-id sources do not need a source URL`() {
+        // A representative spread of the "id encodes everything to
+        // re-fetch" sources — these rebuild from the id alone via
+        // refreshDetail, so carrying a URL would be dead weight.
+        val selfDescribing = listOf(
+            SourceIds.ROYAL_ROAD, SourceIds.GUTENBERG, SourceIds.AO3,
+            SourceIds.WIKIPEDIA, SourceIds.WIKISOURCE, SourceIds.GITHUB,
+            SourceIds.OUTLINE, SourceIds.NOTION_TECHEMPOWER, SourceIds.NOTION_PAT,
+            SourceIds.ARXIV, SourceIds.PLOS, SourceIds.HACKERNEWS,
+            SourceIds.DISCORD, SourceIds.MATRIX, SourceIds.TELEGRAM,
+            SourceIds.SLACK, SourceIds.PALACE, SourceIds.RADIO,
+            SourceIds.STANDARD_EBOOKS, SourceIds.MEMPALACE,
+        )
+        for (id in selfDescribing) {
+            assertFalse(
+                "$id encodes a re-fetchable id and must not require a source URL",
+                SourceIds.idNeedsSourceUrlToRebuild(id),
+            )
+        }
+    }
+}

--- a/core-sync/src/main/kotlin/in/jphe/storyvox/sync/domain/LibrarySyncer.kt
+++ b/core-sync/src/main/kotlin/in/jphe/storyvox/sync/domain/LibrarySyncer.kt
@@ -117,6 +117,20 @@ class LibrarySyncer @Inject constructor(
             playbackDao.delete(id)
         },
         remote = BackendSetRemote(domain = DOMAIN, backend = backend),
+        // Issue #989 — carry the rebuild URL for hash-id sources
+        // (Readability/RSS/EPUB-direct) so a synced library member can be
+        // reconstructed on a device that never saw the paste. Only those
+        // sources persist a `sourceUrl`; everything else returns null and
+        // is naturally absent from the payload.
+        localMemberData = { ids ->
+            ids.mapNotNull { id -> fictionDao.getSourceUrl(id)?.let { id to it } }.toMap()
+        },
+        persistMemberData = { id, url ->
+            // Stamp the URL onto the placeholder row SetSyncer just
+            // created. setSourceUrlIfAbsent never clobbers a URL this
+            // device already captured first-hand.
+            fictionDao.setSourceUrlIfAbsent(id, url)
+        },
     )
 
     companion object {

--- a/core-sync/src/main/kotlin/in/jphe/storyvox/sync/domain/Remotes.kt
+++ b/core-sync/src/main/kotlin/in/jphe/storyvox/sync/domain/Remotes.kt
@@ -41,6 +41,17 @@ class BackendSetRemote(
         val members: List<String> = emptyList(),
         val tombstones: List<String> = emptyList(),
         val tombstoneStamps: Map<String, Long> = emptyMap(),
+        /**
+         * Issue #989 — per-member rebuild data (fictionId → source URL)
+         * for hash-id sources (Readability/RSS/EPUB-direct) whose id
+         * can't be reversed to a URL. Additive + defaulted empty for
+         * round-trip back-compat: a pre-#989 client ignores the unknown
+         * key (Json.ignoreUnknownKeys), and this client reading a
+         * pre-#989 payload simply sees no member URLs. Only the handful
+         * of hash-id members appear here, so the map is tiny even for a
+         * large library.
+         */
+        val memberData: Map<String, String> = emptyMap(),
         val updatedAt: Long = 0L,
     )
 
@@ -61,11 +72,17 @@ class BackendSetRemote(
             SetSyncer.RemoteSet(
                 members = payload.members.toSet(),
                 tombstones = tombs,
+                memberData = payload.memberData,
             )
         }
     }
 
-    override suspend fun push(user: SignedInUser, members: Set<String>, tombstones: Map<String, Long>): Result<Unit> {
+    override suspend fun push(
+        user: SignedInUser,
+        members: Set<String>,
+        tombstones: Map<String, Long>,
+        memberData: Map<String, String>,
+    ): Result<Unit> {
         val now = System.currentTimeMillis()
         val payload = Payload(
             members = members.toList().sorted(),
@@ -73,6 +90,7 @@ class BackendSetRemote(
             // that hasn't been updated yet.
             tombstones = tombstones.keys.sorted(),
             tombstoneStamps = tombstones,
+            memberData = memberData,
             updatedAt = now,
         )
         val body = json.encodeToString(Payload.serializer(), payload)

--- a/core-sync/src/main/kotlin/in/jphe/storyvox/sync/domain/SetSyncer.kt
+++ b/core-sync/src/main/kotlin/in/jphe/storyvox/sync/domain/SetSyncer.kt
@@ -28,6 +28,20 @@ class SetSyncer(
     private val localAdd: suspend (String) -> Unit,
     private val localRemove: suspend (String) -> Unit,
     private val remote: SetRemote,
+    /**
+     * Issue #989 — per-member rebuild data (id → source URL) that some
+     * sources need to reconstruct a fiction on a device that never saw
+     * the original paste (Readability/RSS/EPUB-direct, whose id is an
+     * opaque hash of the URL). Defaults make this a no-op for set
+     * domains that have no per-member aux data (Follows, voices):
+     *  - [localMemberData] returns the URLs this device knows for the
+     *    given member ids (only the hash-id sources contribute);
+     *  - [persistMemberData] is called for each merged member with a
+     *    known URL so the pull side can store it durably before the
+     *    back-fill worker tries to hydrate the placeholder.
+     */
+    private val localMemberData: suspend (Set<String>) -> Map<String, String> = { emptyMap() },
+    private val persistMemberData: suspend (String, String) -> Unit = { _, _ -> },
 ) : Syncer {
 
     /** Abstraction over InstantDB calls so tests don't need a live
@@ -38,13 +52,27 @@ class SetSyncer(
      *  with the long being the epoch-ms stamp the tombstone was
      *  recorded — load-bearing for [ConflictPolicies.unionWithTombstoneStamps]
      *  to apply a freshness window so a re-add of a previously-
-     *  tombstoned id can win. */
+     *  tombstoned id can win.
+     *
+     *  Issue #989: [memberData] (id → source URL) rides alongside the
+     *  member set so hash-id fictions can be rebuilt cross-device. The
+     *  wire field is additive and defaulted empty, so old clients
+     *  ignore it and a new client reading an old payload sees no URLs. */
     interface SetRemote {
         suspend fun fetch(user: SignedInUser): Result<RemoteSet>
-        suspend fun push(user: SignedInUser, members: Set<String>, tombstones: Map<String, Long>): Result<Unit>
+        suspend fun push(
+            user: SignedInUser,
+            members: Set<String>,
+            tombstones: Map<String, Long>,
+            memberData: Map<String, String>,
+        ): Result<Unit>
     }
 
-    data class RemoteSet(val members: Set<String>, val tombstones: Map<String, Long>)
+    data class RemoteSet(
+        val members: Set<String>,
+        val tombstones: Map<String, Long>,
+        val memberData: Map<String, String> = emptyMap(),
+    )
 
     override suspend fun push(user: SignedInUser): SyncOutcome = pushImpl(user)
 
@@ -85,6 +113,17 @@ class SetSyncer(
         )
         android.util.Log.d(tag, "merged: ${mergedMembers.size} members (${combinedTombs.size} combined tombstones)")
 
+        // Issue #989 — combine the per-member rebuild URLs from both
+        // sides. Local wins on conflict: this device's persisted URL is
+        // first-hand (it captured the paste) and we don't want a stale
+        // remote value to shadow it. Remote-only URLs fill in members we
+        // received from another device.
+        val localData = runCatching { localMemberData(local) }
+            .getOrElse { return SyncOutcome.Transient("local member data: ${it.message}") }
+        val mergedData = (remoteSet.memberData + localData)
+            .filterKeys { it in mergedMembers }
+        android.util.Log.d(tag, "memberData: ${localData.size} local, ${remoteSet.memberData.size} remote, ${mergedData.size} merged")
+
         // Reconcile local — apply remote-only adds, drop remote tombs.
         val toAddLocally = mergedMembers - local
         val toRemoveLocally = (local - mergedMembers)
@@ -92,6 +131,15 @@ class SetSyncer(
         for ((i, id) in toAddLocally.withIndex()) {
             runCatching { localAdd(id) }
                 .getOrElse { return SyncOutcome.Transient("localAdd($id): ${it.message}") }
+            // Persist the rebuild URL onto the row localAdd just created
+            // so the back-fill worker (or a detail-open) can hydrate a
+            // hash-id fiction this device has never seen. After localAdd
+            // so the placeholder row exists for the UPDATE to land on.
+            // No-op default for aux-less domains.
+            mergedData[id]?.let { url ->
+                runCatching { persistMemberData(id, url) }
+                    .getOrElse { return SyncOutcome.Transient("persistMemberData($id): ${it.message}") }
+            }
             if ((i + 1) % 10 == 0) android.util.Log.d(tag, "localAdd progress: ${i+1}/${toAddLocally.size}")
         }
         for ((i, id) in toRemoveLocally.withIndex()) {
@@ -106,7 +154,7 @@ class SetSyncer(
         // round) so other devices see the same horizon we just
         // computed against.
         android.util.Log.d(tag, "pushing ${mergedMembers.size} members to remote")
-        val push = remote.push(user, mergedMembers, combinedTombs)
+        val push = remote.push(user, mergedMembers, combinedTombs, mergedData)
         if (push.isFailure) {
             return SyncOutcome.Transient("remote push: ${push.exceptionOrNull()?.message}")
         }

--- a/core-sync/src/test/kotlin/in/jphe/storyvox/sync/BookmarksSyncerTest.kt
+++ b/core-sync/src/test/kotlin/in/jphe/storyvox/sync/BookmarksSyncerTest.kt
@@ -176,6 +176,7 @@ class BookmarksSyncerTest {
             audioUrl: String?,
         ) = error("not used")
         override suspend fun setRead(id: String, read: Boolean, now: Long) = error("not used")
+        override suspend fun markFollowedCaughtUp(now: Long): Int = error("not used")
         override suspend fun trimDownloadedBodies(fictionId: String, keepLast: Int) = error("not used")
         override suspend fun cacheUsage(): `in`.jphe.storyvox.data.db.dao.ChapterCacheUsageRow =
             error("not used")

--- a/core-sync/src/test/kotlin/in/jphe/storyvox/sync/PlaybackPositionSyncerTest.kt
+++ b/core-sync/src/test/kotlin/in/jphe/storyvox/sync/PlaybackPositionSyncerTest.kt
@@ -198,6 +198,8 @@ class PlaybackPositionSyncerTest {
         override suspend fun setPinnedVoice(id: String, voiceId: String?, locale: String?) = error("not used")
         override suspend fun touchMetadata(id: String, now: Long) = error("not used")
         override suspend fun setSourceId(id: String, sourceId: String) = error("not used")
+        override suspend fun getSourceUrl(id: String): String? = error("not used")
+        override suspend fun setSourceUrlIfAbsent(id: String, url: String) = error("not used")
         override suspend fun placeholdersToBackfill(cutoff: Long): List<Fiction> = error("not used")
         override suspend fun placeholderCount(): Int = error("not used")
         override suspend fun markBackfillFailed(id: String, now: Long) = error("not used")
@@ -254,6 +256,7 @@ class PlaybackPositionSyncerTest {
             audioUrl: String?,
         ) = error("not used")
         override suspend fun setRead(id: String, read: Boolean, now: Long) = error("not used")
+        override suspend fun markFollowedCaughtUp(now: Long): Int = error("not used")
         override suspend fun trimDownloadedBodies(fictionId: String, keepLast: Int) = error("not used")
         override suspend fun cacheUsage(): ChapterCacheUsageRow = error("not used")
         override suspend fun chapterIdsForFiction(fictionId: String): List<String> = emptyList()

--- a/core-sync/src/test/kotlin/in/jphe/storyvox/sync/SetSyncerMemberDataTest.kt
+++ b/core-sync/src/test/kotlin/in/jphe/storyvox/sync/SetSyncerMemberDataTest.kt
@@ -1,0 +1,191 @@
+package `in`.jphe.storyvox.sync
+
+import `in`.jphe.storyvox.sync.SyncIds
+import `in`.jphe.storyvox.sync.client.FakeInstantBackend
+import `in`.jphe.storyvox.sync.client.SignedInUser
+import `in`.jphe.storyvox.sync.coordinator.SyncOutcome
+import `in`.jphe.storyvox.sync.coordinator.TombstonesAccess
+import `in`.jphe.storyvox.sync.domain.BackendSetRemote
+import `in`.jphe.storyvox.sync.domain.SetSyncer
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * Issue #989 — the per-member rebuild data (id → source URL) that rides
+ * alongside the library set so a hash-id fiction (Readability/RSS/EPUB
+ * direct-download) can be reconstructed on a device that never saw the
+ * original paste.
+ *
+ * These tests pin three things:
+ *  1. round-trip: a URL pushed by device A reaches device B's
+ *     `persistMemberData` callback (the seam `LibrarySyncer` uses to
+ *     stamp `Fiction.sourceUrl`);
+ *  2. local-wins merge: a device that captured the paste first-hand
+ *     doesn't get its URL shadowed by a (possibly stale) remote value;
+ *  3. wire back-compat both directions — a pre-#989 payload (no
+ *     `memberData` key) decodes to no URLs, and the field only carries
+ *     the handful of members that actually have a URL.
+ */
+class SetSyncerMemberDataTest {
+
+    private val USER = SignedInUser(userId = "u-1", email = null, refreshToken = "rt-1")
+
+    /** Same in-memory tombstone substitute as [SetSyncerTest]. */
+    private class InMemoryTombstones : TombstonesAccess {
+        private val byDomain = mutableMapOf<String, MutableMap<String, Long>>()
+        override fun observe(domain: String): Flow<Set<String>> =
+            flowOf(byDomain[domain]?.keys?.toSet() ?: emptySet())
+        override suspend fun snapshot(domain: String): Set<String> =
+            byDomain[domain]?.keys?.toSet() ?: emptySet()
+        override suspend fun snapshotWithStamps(domain: String): Map<String, Long> =
+            byDomain[domain]?.toMap() ?: emptyMap()
+        override suspend fun add(domain: String, id: String) {
+            byDomain.getOrPut(domain) { mutableMapOf() }[id] = System.currentTimeMillis()
+        }
+        override suspend fun addAll(domain: String, ids: Collection<String>) {
+            val now = System.currentTimeMillis()
+            val bucket = byDomain.getOrPut(domain) { mutableMapOf() }
+            for (id in ids) bucket[id] = now
+        }
+        override suspend fun forget(domain: String, id: String) { byDomain[domain]?.remove(id) }
+        override suspend fun clear(domain: String) { byDomain.remove(domain) }
+    }
+
+    private val readabilityId = "readability:1a2b3c4d5e6f7a8b"
+    private val readabilityUrl = "https://example.com/some-long-article"
+
+    @Test fun `member URL pushed by device A is delivered to device B on pull`() = runTest {
+        val backend = FakeInstantBackend()
+
+        // Device A: has a Readability fiction in its library and knows
+        // the original URL (it captured the paste).
+        val deviceA = mutableSetOf(readabilityId, "gutenberg:84")
+        val deviceAUrls = mapOf(readabilityId to readabilityUrl)
+        SetSyncer(
+            name = "library",
+            tombstones = InMemoryTombstones(),
+            localSnapshot = { deviceA.toSet() },
+            localAdd = { deviceA.add(it) },
+            localRemove = { deviceA.remove(it) },
+            remote = BackendSetRemote("library", backend),
+            localMemberData = { ids -> deviceAUrls.filterKeys { it in ids } },
+        ).push(USER)
+
+        // Device B: empty library. It should pull both members AND
+        // receive the Readability URL through persistMemberData.
+        val deviceB = mutableSetOf<String>()
+        val deviceBUrls = mutableMapOf<String, String>()
+        val outcome = SetSyncer(
+            name = "library",
+            tombstones = InMemoryTombstones(),
+            localSnapshot = { deviceB.toSet() },
+            localAdd = { deviceB.add(it) },
+            localRemove = { deviceB.remove(it) },
+            remote = BackendSetRemote("library", backend),
+            persistMemberData = { id, url -> deviceBUrls[id] = url },
+        ).pull(USER)
+
+        assertTrue(outcome is SyncOutcome.Ok)
+        assertEquals(setOf(readabilityId, "gutenberg:84"), deviceB)
+        // Only the hash-id member carries a URL; the self-describing
+        // gutenberg id does not.
+        assertEquals(mapOf(readabilityId to readabilityUrl), deviceBUrls)
+    }
+
+    @Test fun `persistMemberData fires only for newly-added members`() = runTest {
+        val backend = FakeInstantBackend()
+
+        // Seed remote with the member + URL.
+        val deviceA = mutableSetOf(readabilityId)
+        SetSyncer(
+            "library", InMemoryTombstones(),
+            { deviceA.toSet() }, { deviceA.add(it) }, { deviceA.remove(it) },
+            BackendSetRemote("library", backend),
+            localMemberData = { mapOf(readabilityId to readabilityUrl) },
+        ).push(USER)
+
+        // Device B ALREADY has the member locally (e.g. it captured the
+        // paste itself). A pull must NOT re-persist the URL — the member
+        // isn't in the toAddLocally diff.
+        val deviceB = mutableSetOf(readabilityId)
+        val persisted = mutableListOf<Pair<String, String>>()
+        SetSyncer(
+            "library", InMemoryTombstones(),
+            { deviceB.toSet() }, { deviceB.add(it) }, { deviceB.remove(it) },
+            BackendSetRemote("library", backend),
+            persistMemberData = { id, url -> persisted.add(id to url) },
+        ).pull(USER)
+
+        assertTrue("no localAdd → no persistMemberData", persisted.isEmpty())
+    }
+
+    @Test fun `local URL wins over remote URL on conflict`() = runTest {
+        val backend = FakeInstantBackend()
+
+        // Remote already holds a STALE url for the member.
+        SetSyncer(
+            "library", InMemoryTombstones(),
+            { setOf(readabilityId) }, { }, { },
+            BackendSetRemote("library", backend),
+            localMemberData = { mapOf(readabilityId to "https://example.com/STALE") },
+        ).push(USER)
+
+        // Device C has the member locally with the CORRECT url and also
+        // has it in its set already (so no add), but pushes its own data.
+        // localData wins the merge → the correct URL is written back.
+        SetSyncer(
+            "library", InMemoryTombstones(),
+            { setOf(readabilityId) }, { }, { },
+            BackendSetRemote("library", backend),
+            localMemberData = { mapOf(readabilityId to readabilityUrl) },
+        ).push(USER)
+
+        // Read what's now on the wire — the local (correct) URL must have
+        // won the merge and been written back.
+        val finalDeviceUrls = mutableMapOf<String, String>()
+        val freshDevice = mutableSetOf<String>()
+        SetSyncer(
+            "library", InMemoryTombstones(),
+            { freshDevice.toSet() }, { freshDevice.add(it) }, { freshDevice.remove(it) },
+            BackendSetRemote("library", backend),
+            persistMemberData = { id, url -> finalDeviceUrls[id] = url },
+        ).pull(USER)
+
+        assertEquals(readabilityUrl, finalDeviceUrls[readabilityId])
+    }
+
+    @Test fun `reading a pre-989 payload without memberData yields no URLs`() = runTest {
+        val backend = FakeInstantBackend()
+        // Hand-seed a legacy payload: members + tombstoneStamps, NO
+        // memberData key. ignoreUnknownKeys is irrelevant here — the
+        // point is the field is ABSENT and must default to empty.
+        val rowId = SyncIds.rowUuid("library", USER.userId)
+        val legacyPayload = """
+            {"members":["$readabilityId","gutenberg:84"],
+             "tombstones":[],
+             "tombstoneStamps":{},
+             "updatedAt":1700000000000}
+        """.trimIndent()
+        backend.upsert(USER, entity = "sets", id = rowId, payload = legacyPayload, updatedAt = 1700000000000L)
+
+        val device = mutableSetOf<String>()
+        val urls = mutableMapOf<String, String>()
+        val outcome = SetSyncer(
+            "library", InMemoryTombstones(),
+            { device.toSet() }, { device.add(it) }, { device.remove(it) },
+            BackendSetRemote("library", backend),
+            persistMemberData = { id, url -> urls[id] = url },
+        ).pull(USER)
+
+        assertTrue(outcome is SyncOutcome.Ok)
+        // Members still pull through (back-compat), but no URLs exist.
+        assertEquals(setOf(readabilityId, "gutenberg:84"), device)
+        assertTrue("legacy payload has no member URLs", urls.isEmpty())
+        assertNull(urls[readabilityId])
+    }
+}

--- a/source-readability/src/main/kotlin/in/jphe/storyvox/source/readability/ReadabilitySource.kt
+++ b/source-readability/src/main/kotlin/in/jphe/storyvox/source/readability/ReadabilitySource.kt
@@ -72,6 +72,12 @@ import javax.inject.Singleton
 internal class ReadabilitySource @Inject constructor(
     private val fetcher: ReadabilityFetcher,
     private val extractor: ReadabilityExtractor,
+    // Issue #989 — durable URL lookup (the persisted `Fiction.sourceUrl`)
+    // so a fiction synced from another device (or surviving a process
+    // restart / cache-clear) can still be rebuilt. The in-memory
+    // [urlCache] remains the hot-path fast lane for the same-session
+    // paste-then-fetch flow; this is the cold fallback.
+    private val rememberedUrls: `in`.jphe.storyvox.data.source.RememberedUrlStore,
 ) : FictionSource, UrlMatcher {
 
     override val id: String = SourceIds.READABILITY
@@ -206,24 +212,26 @@ internal class ReadabilitySource @Inject constructor(
     }
 
     /**
-     * Look up the URL we stamped into `Fiction.sourceChapterId` when
-     * the user pasted this URL. The repository's `addByUrl` path
-     * pre-writes a stub row whose `id` is the readability fictionId
-     * and whose detail will be filled in here; we remember the URL
-     * by encoding it in the deterministic fictionId hash and
-     * persisting the original URL in [urlCache].
+     * Resolve the original URL for [fictionId] so detail/chapter can be
+     * re-extracted (the id is a non-reversible hash of the URL).
      *
-     * v1 keeps a tiny in-memory cache populated from `matchUrl` calls.
-     * That's enough for the paste-then-fetch happy path (the user pasted
-     * the URL in this session, so the cache is hot). A cold-app reopen
-     * with a previously-added Readability fiction needs a DB-side
-     * lookup; that path is wired through `Fiction.description` (which
-     * the repository persists per the kdoc on [fictionIdFor]) — but
-     * v1 punts on the proper persistence in favour of "remember the
-     * URL in-process, surface a clear NotFound when missing". Issue
-     * follow-up will move this into a small Room-backed map.
+     * Two tiers:
+     *  1. [urlCache] — the in-memory fast lane, populated by `matchUrl`
+     *     during the same-session paste-then-fetch happy path.
+     *  2. [rememberedUrls] — the durable `Fiction.sourceUrl` column
+     *     (issue #989). Survives process death and, crucially, is filled
+     *     in by `LibrarySyncer` for a fiction added on another device —
+     *     so a synced placeholder hydrates instead of dead-ending on
+     *     "has no remembered URL". A hit warms the in-memory cache so
+     *     subsequent same-session lookups skip the DAO.
+     *
+     * Returns null only when neither tier knows the URL (a genuinely
+     * un-rebuildable row — e.g. a pre-#989 placeholder added before the
+     * column existed); callers surface a clear NotFound in that case.
      */
-    private fun persistedUrlFor(fictionId: String): String? = urlCache[fictionId]
+    private suspend fun persistedUrlFor(fictionId: String): String? =
+        urlCache[fictionId]
+            ?: rememberedUrls.rememberedUrl(fictionId)?.also { urlCache[fictionId] = it }
 
     private fun fictionIdFor(url: String): String {
         val hash = MessageDigest.getInstance("SHA-256")


### PR DESCRIPTION
Two related fixes in the library-sync payload path.

## #988 — wrong sourceId for colon-less ids (already fixed; regression test added)

The #988 fix already landed with the #981 back-fill PR (#987): both `LibrarySyncer.localAdd` and `FollowsSyncer.localAdd` now stamp a fresh placeholder's `sourceId` via `FictionSourceIdResolver.resolveByShape`, which returns `"royalroad"` for colon-less Royal Road ids instead of the old `id.substringBefore(':')` that returned the whole number (`"146000"`). The one resolver is shared between the syncers and the back-fill worker — no duplicated logic.

This PR adds an explicit regression test pinning the exact stuck ids from Aria's #981 worker log (`146000`, `156215`, `8894`) → `royalroad` at placeholder-creation time.

## #989 — sync the rebuild-essential source URL

A Readability fiction (`readability:<sha256-of-url>`) needs the original URL to rebuild its metadata, but that URL lived only in an in-memory cache on the originating device. On a second device the synced placeholder had an id but no URL and could never hydrate ("has no remembered URL").

**Audit — which sources have an id that isn't enough to rebuild:**
- **Need the source URL** (id is an opaque hash of the URL): **Readability**, **RSS**, **EPUB direct-download** (`epub:url:<hash>`).
- **Self-describing** (rebuild from id alone via `refreshDetail`): everything else (royalroad, gutenberg, ao3, wikipedia, github, outline, notion-*, arxiv, plos, discord, matrix, telegram, slack, palace, radio, hackernews, standardebooks, wikisource, mempalace).
- **Out of scope** — SAF-imported local EPUBs: the file doesn't exist on a second device, so no field can rebuild them (the #981 worker already fails these gracefully).

**Changes:**
- Add nullable `fiction.sourceUrl` (Room v12→v13, additive). Durable home for the rebuild URL — also fixes Readability's in-memory-cache fragility.
- `FictionRepository.addByUrl` persists the URL for hash-id sources at paste time (`setSourceUrlIfAbsent` never clobbers).
- `SourceIds.idNeedsSourceUrlToRebuild` — single source of truth for the audit, shared by repository + syncer.
- Extend the `sets` payload with an optional `memberData` map (id → URL). **Back-compat both directions**: pre-#989 clients ignore the unknown key; this client reading an old payload sees no URLs. The member `Set` stays the union key — set/tombstone logic untouched.
- `SetSyncer` threads per-member data through fetch/merge/push with a **local-wins** merge; `persistMemberData` fires after `localAdd` so the placeholder row exists for the UPDATE.
- `LibrarySyncer` reads URLs from `FictionDao` on push, stamps them onto synced placeholders on pull.
- `RememberedUrlStore` (core-data interface + DAO-backed impl) exposes the persisted URL to `:source-readability`, which consults it as a durable fallback behind its in-memory cache.

## Verification
- `./gradlew :core-data:compileDebugKotlin :core-sync:compileDebugKotlin` green; `:app:assembleDebug` green (Hilt graph resolves `RememberedUrlStore` → `ReadabilitySource`).
- `:core-data:testDebugUnitTest` + `:core-sync:testDebugUnitTest` green. New tests: payload round-trip with `memberData`, pre-#989 back-compat decode, local-wins merge, persist-only-on-add, source-URL audit, Room v12→v13 migration (column exists, nullable, NULL on existing rows).

🤖 Generated with [Claude Code](https://claude.com/claude-code)