### PR TITLE
perf(sync): field-level settings merge (per-key updatedAt) to stop cross-device clobber (#978)

### DIFF
--- a/app/src/main/kotlin/in/jphe/storyvox/data/SettingsRepositoryUiImpl.kt
+++ b/app/src/main/kotlin/in/jphe/storyvox/data/SettingsRepositoryUiImpl.kt
@@ -3,6 +3,8 @@ package `in`.jphe.storyvox.data
 import android.content.Context
 import androidx.datastore.core.DataMigration
 import androidx.datastore.core.DataStore
+import kotlinx.serialization.builtins.MapSerializer
+import kotlinx.serialization.builtins.serializer
 import androidx.datastore.preferences.core.Preferences
 import androidx.datastore.preferences.core.booleanPreferencesKey
 import androidx.datastore.preferences.core.edit
@@ -2806,6 +2808,47 @@ class SettingsRepositoryUiImpl(
     }
 
     override suspend fun apply(snapshot: Map<String, String>) {
+        applyValues(snapshot)
+        // After applying, mark this as a fresh local write so the
+        // next sync round push carries the merged-blob timestamp.
+        // (Flat path — no incoming per-key stamps; treat the whole
+        // applied set as "written now" for diff purposes.)
+        stampSyncedWrite()
+    }
+
+    /**
+     * #978 — field-level apply. Writes the values exactly like [apply],
+     * then records the **incoming** per-key stamps (the timestamps the
+     * merge already chose) into the local stamp store instead of
+     * stamping everything `now`. This keeps the local per-key clock in
+     * lockstep with the value the merge selected, so a key the remote
+     * won doesn't get re-stamped fresher than its true edit time (which
+     * would make it spuriously win the next merge).
+     */
+    override suspend fun applyStamped(snapshot: Map<String, String>, stamps: Map<String, Long>) {
+        applyValues(snapshot)
+        // Persist the incoming stamps for the applied keys, and rebase
+        // the diff baseline to the values we just wrote so the next
+        // LOCAL edit diffs against the merged state (not a stale one).
+        val existingStamps = readFieldStamps().toMutableMap()
+        val baseline = readSnapshotBaseline().toMutableMap()
+        for ((key, value) in snapshot) {
+            stamps[key]?.let { existingStamps[key] = it }
+            baseline[key] = value
+        }
+        writeFieldStamps(existingStamps)
+        writeSnapshotBaseline(baseline)
+        // Advance the legacy global stamp to the newest applied field
+        // (still the v1 row updatedAt + the per-key fallback). Do NOT
+        // call stampSyncedWrite — that would re-stamp everything `now`
+        // and schedule a redundant push of state we just received.
+        stamps.values.maxOrNull()?.let { stampLocalWrite(it) }
+    }
+
+    /** Shared value-application body for [apply] / [applyStamped].
+     *  Per-key tolerant: a remote that omits a key leaves the local
+     *  value alone. */
+    private suspend fun applyValues(snapshot: Map<String, String>) {
         // 1. Main settings DataStore.
         val mainSlice = snapshot.filterKeys { it.startsWith("settings.") }
             .mapKeys { (k, _) -> k.removePrefix("settings.") }
@@ -2829,9 +2872,6 @@ class SettingsRepositoryUiImpl(
         snapshot["outline.pref_outline_host"]?.let { outlineConfig.setHost(it) }
         snapshot["wikipedia.pref_wikipedia_language_code"]?.let { wikipediaConfig.setLanguageCode(it) }
         snapshot["palace.pref_palace_host"]?.let { palaceConfig.setHost(it) }
-        // After applying, mark this as a fresh local write so the
-        // next sync round push carries the merged-blob timestamp.
-        stampSyncedWrite()
     }
 
     /**
@@ -2874,6 +2914,18 @@ class SettingsRepositoryUiImpl(
         store.edit { it[SYNC_LAST_WRITE_KEY] = at }
     }
 
+    /**
+     * #978 — per-key `updatedAt` for the synced settings. The map is
+     * persisted as a stringified JSON `Map<String,Long>` in the main
+     * store under the non-synced [SYNC_FIELD_STAMPS_KEY], maintained
+     * by the diff in [stampSyncedWrite] (local edits) and by
+     * [applyStamped] (remote merges). A key absent here has never been
+     * individually stamped on this device; the syncer falls back to
+     * [lastLocalWriteAt] for it — which reproduces the pre-#978
+     * blob-level behavior for untouched keys after an upgrade.
+     */
+    override suspend fun fieldStamps(): Map<String, Long> = readFieldStamps()
+
     /** Convenience used by every setter on this class so writes to a
      *  synced key automatically advance the sync timestamp. Settings UI
      *  that calls one of the existing `set*` mutators will get its
@@ -2883,10 +2935,59 @@ class SettingsRepositoryUiImpl(
      *  debounced push of the "settings" domain, so a preference change
      *  reaches InstantDB right away instead of waiting for a cold-start
      *  or manual "Sync now" (a window in which an intervening pull could
-     *  clobber the un-pushed local change). */
+     *  clobber the un-pushed local change).
+     *
+     *  Issue #978 — diff-based per-key stamping. Because this is the
+     *  single funnel for every synced local write, we can derive
+     *  per-key timestamps WITHOUT touching the ~70 `set*` mutators:
+     *  snapshot the current allowlisted map, diff it against the
+     *  persisted baseline, and bump `updatedAt = now` only for keys
+     *  whose value actually changed (or are new). Keys removed from
+     *  the snapshot drop their stamp. The baseline is then rebased to
+     *  the current snapshot so the next edit diffs against it. Two keys
+     *  changed inside one debounce window share a `now` stamp — fine,
+     *  they're genuinely concurrent local edits. */
     private suspend fun stampSyncedWrite() {
-        stampLocalWrite(System.currentTimeMillis())
+        val now = System.currentTimeMillis()
+        stampLocalWrite(now)
+        runCatching { reconcileFieldStamps(now) }
         scheduleSettingsPush()
+    }
+
+    /** Recompute the per-key stamp map from a fresh snapshot vs the
+     *  persisted baseline, bumping changed/new keys to [now]. */
+    private suspend fun reconcileFieldStamps(now: Long) {
+        val current = snapshot()
+        val baseline = readSnapshotBaseline()
+        val stamps = readFieldStamps().toMutableMap()
+        // Bump changed / new keys.
+        for ((key, value) in current) {
+            if (baseline[key] != value) stamps[key] = now
+        }
+        // Forget stamps for keys no longer present.
+        stamps.keys.retainAll(current.keys)
+        writeFieldStamps(stamps)
+        writeSnapshotBaseline(current)
+    }
+
+    private suspend fun readFieldStamps(): Map<String, Long> {
+        val raw = store.data.first()[SYNC_FIELD_STAMPS_KEY] ?: return emptyMap()
+        return runCatching { syncJson.decodeFromString(STAMP_MAP_SERIALIZER, raw) }.getOrDefault(emptyMap())
+    }
+
+    private suspend fun writeFieldStamps(stamps: Map<String, Long>) {
+        val encoded = syncJson.encodeToString(STAMP_MAP_SERIALIZER, stamps)
+        store.edit { it[SYNC_FIELD_STAMPS_KEY] = encoded }
+    }
+
+    private suspend fun readSnapshotBaseline(): Map<String, String> {
+        val raw = store.data.first()[SYNC_SNAPSHOT_BASELINE_KEY] ?: return emptyMap()
+        return runCatching { syncJson.decodeFromString(STRING_MAP_SERIALIZER, raw) }.getOrDefault(emptyMap())
+    }
+
+    private suspend fun writeSnapshotBaseline(snapshot: Map<String, String>) {
+        val encoded = syncJson.encodeToString(STRING_MAP_SERIALIZER, snapshot)
+        store.edit { it[SYNC_SNAPSHOT_BASELINE_KEY] = encoded }
     }
 
     companion object {
@@ -2894,6 +2995,32 @@ class SettingsRepositoryUiImpl(
          *  [SYNC_ALLOWLIST] (we never sync the sync timestamp itself
          *  — that'd be a loop). */
         private val SYNC_LAST_WRITE_KEY = longPreferencesKey("instantdb.settings_synced_at")
+
+        /** Issue #978 — per-key `updatedAt` map (stringified JSON
+         *  `Map<String,Long>`) for field-level merge. Same non-synced
+         *  `instantdb.*` convention as [SYNC_LAST_WRITE_KEY] /
+         *  `instantdb.pronunciation_dict_write_at` — excluded from
+         *  [SYNC_ALLOWLIST] so we never sync the sync clock itself. */
+        private val SYNC_FIELD_STAMPS_KEY =
+            stringPreferencesKey("instantdb.settings_field_stamps_v1")
+
+        /** Issue #978 — the last snapshot the per-key stamping diffed
+         *  against (stringified JSON `Map<String,String>`). Lets
+         *  [reconcileFieldStamps] bump only the keys that actually
+         *  changed since the previous synced write, without touching
+         *  any `set*` mutator. Non-synced `instantdb.*` key. */
+        private val SYNC_SNAPSHOT_BASELINE_KEY =
+            stringPreferencesKey("instantdb.settings_snapshot_baseline_v1")
+
+        /** JSON + serializers for the #978 per-key stamp / baseline
+         *  maps. Lenient on read so a corrupt sidecar degrades to
+         *  "empty" (every key falls back to the global stamp) rather
+         *  than crashing. */
+        private val syncJson = kotlinx.serialization.json.Json {
+            ignoreUnknownKeys = true; encodeDefaults = true; coerceInputValues = true
+        }
+        private val STAMP_MAP_SERIALIZER = MapSerializer(String.serializer(), Long.serializer())
+        private val STRING_MAP_SERIALIZER = MapSerializer(String.serializer(), String.serializer())
 
         /** Issue #977 — domain name for the push-on-write seam. Must match
          *  `SettingsSyncer.DOMAIN`; [SyncCoordinator.requestPush] no-ops if

--- a/app/src/test/kotlin/in/jphe/storyvox/data/SettingsRepositoryFieldStampsTest.kt
+++ b/app/src/test/kotlin/in/jphe/storyvox/data/SettingsRepositoryFieldStampsTest.kt
@@ -1,0 +1,177 @@
+package `in`.jphe.storyvox.data
+
+import androidx.datastore.core.DataStore
+import androidx.datastore.preferences.core.PreferenceDataStoreFactory
+import androidx.datastore.preferences.core.Preferences
+import java.io.File
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.TestDispatcher
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.runTest
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import org.junit.rules.TemporaryFolder
+
+/**
+ * Issue #978 — diff-based per-key stamping in [SettingsRepositoryUiImpl].
+ *
+ * The field-level merge in `:core-sync`'s `SettingsSyncer` relies on the
+ * snapshot source surfacing a correct per-key `updatedAt` via
+ * [SettingsRepositoryUiImpl.fieldStamps]. That stamp map is derived
+ * WITHOUT touching any `set*` mutator — at the single
+ * `stampSyncedWrite` chokepoint we diff the current snapshot against a
+ * persisted baseline and bump only the keys that changed. These tests
+ * prove that diff:
+ *  - editing one key stamps ONLY that key (not the whole allowlist),
+ *  - a later edit to a different key advances only its own stamp,
+ *  - [SettingsRepositoryUiImpl.applyStamped] records the INCOMING merge
+ *    stamps rather than re-stamping everything `now`.
+ *
+ * Wiring mirrors [SettingsRepositoryPushOnWriteTest] — a real
+ * PreferenceDataStore over a temp file, a recording push lambda, and a
+ * test dispatcher so the debounce resolves in virtual time.
+ */
+@OptIn(ExperimentalCoroutinesApi::class)
+class SettingsRepositoryFieldStampsTest {
+
+    @get:Rule
+    val tempFolder = TemporaryFolder()
+
+    private lateinit var scope: CoroutineScope
+    private lateinit var store: DataStore<Preferences>
+
+    @Before
+    fun setUp() {
+        scope = CoroutineScope(SupervisorJob() + UnconfinedTestDispatcher())
+        val file = File(tempFolder.newFolder(), "storyvox_settings.preferences_pb")
+        store = PreferenceDataStoreFactory.create(scope = scope, produceFile = { file })
+    }
+
+    @After
+    fun tearDown() {
+        scope.cancel()
+    }
+
+    private fun makeRepo(dispatcher: TestDispatcher): SettingsRepositoryUiImpl {
+        val pcmBundle = makeFakeCacheBundle(tempFolder.newFolder("pcm_bundle"), scope)
+        return SettingsRepositoryUiImpl(
+            store = store,
+            auth = FakeAuth(),
+            hydrator = FakeHydrator(),
+            palaceConfig = makeFakePalaceConfig(tempFolder.newFolder("palace_ds"), scope),
+            palaceApi = makeFakePalaceApi(),
+            llmCreds = `in`.jphe.storyvox.llm.LlmCredentialsStore.forTesting(),
+            githubAuth = FakeGitHubAuth(),
+            teamsAuth = fakeTeamsAuth(),
+            rssConfig = makeFakeRssConfig(tempFolder.newFolder("rss_ds"), scope),
+            epubConfig = makeFakeEpubConfig(tempFolder.newFolder("epub_ds"), scope),
+            outlineConfig = makeFakeOutlineConfig(tempFolder.newFolder("outline_ds"), scope),
+            wikipediaConfig = makeFakeWikipediaConfig(tempFolder.newFolder("wiki_ds"), scope),
+            notionConfig = makeFakeNotionConfig(tempFolder.newFolder("notion_ds"), scope),
+            discordConfig = makeFakeDiscordConfig(tempFolder.newFolder("discord_ds"), scope),
+            discordGuildDirectory = makeFakeDiscordGuildDirectory(),
+            telegramConfig = makeFakeTelegramConfig(tempFolder.newFolder("telegram_ds"), scope),
+            telegramChannelDirectory = makeFakeTelegramChannelDirectory(),
+            suggestedFeedsRegistry = SuggestedFeedsRegistry(),
+            azureCreds = makeFakeAzureCredentials(),
+            azureClient = makeFakeAzureClient(),
+            azureRoster = makeFakeAzureRoster(),
+            googleTokenSource =
+                `in`.jphe.storyvox.llm.auth.GoogleOAuthTokenSource(okhttp3.OkHttpClient()),
+            pcmCache = pcmBundle.pcmCache,
+            pcmCacheConfig = pcmBundle.pcmCacheConfig,
+            cacheStats = pcmBundle.cacheStats,
+            pushSettings = { },
+            pushDispatcher = dispatcher,
+        )
+    }
+
+    @Test
+    fun `editing one key stamps only that key`() = runTest {
+        val repo = makeRepo(StandardTestDispatcher(testScheduler))
+
+        // Use a setter that funnels through stampSyncedWrite (the
+        // source-order/favorites cluster — same as the #977 push test).
+        repo.setSourceDisplayOrder(listOf("ao3", "royalroad"))
+        advanceUntilIdle()
+
+        val stamps = repo.fieldStamps()
+        assertTrue(
+            "display-order key must be stamped after editing it",
+            stamps.containsKey("settings.pref_source_display_order_v1"),
+        )
+        // Diff-based: an UNTOUCHED key gets no per-key stamp (it falls
+        // back to the global stamp in the syncer). The favorites key,
+        // never written, must be absent.
+        assertNull(
+            "an unwritten key must NOT be stamped",
+            stamps["settings.pref_source_favorites_v1"],
+        )
+    }
+
+    @Test
+    fun `a later edit advances only its own key's stamp`() = runTest {
+        val repo = makeRepo(StandardTestDispatcher(testScheduler))
+
+        repo.setSourceDisplayOrder(listOf("ao3"))
+        advanceUntilIdle()
+        val orderStamp = repo.fieldStamps()["settings.pref_source_display_order_v1"]!!
+
+        // A distinct second edit to a DIFFERENT key.
+        repo.setSourceFavorite("ao3", favorite = true)
+        advanceUntilIdle()
+        val after = repo.fieldStamps()
+
+        assertEquals(
+            "the display-order stamp must be unchanged by a later favorites edit",
+            orderStamp,
+            after["settings.pref_source_display_order_v1"],
+        )
+        assertTrue(
+            "the favorites key must now be stamped",
+            after.containsKey("settings.pref_source_favorites_v1"),
+        )
+    }
+
+    @Test
+    fun `applyStamped records the incoming merge stamps, not now`() = runTest {
+        val repo = makeRepo(StandardTestDispatcher(testScheduler))
+
+        // Simulate a remote merge landing two keys with fixed, OLD stamps.
+        repo.applyStamped(
+            snapshot = mapOf(
+                "settings.pref_theme_override" to "LIGHT",
+                "settings.pref_default_speed" to "0.9",
+            ),
+            stamps = mapOf(
+                "settings.pref_theme_override" to 4_000L,
+                "settings.pref_default_speed" to 5_000L,
+            ),
+        )
+        advanceUntilIdle()
+
+        val stamps = repo.fieldStamps()
+        assertEquals(
+            "applyStamped must persist the incoming theme stamp verbatim",
+            4_000L,
+            stamps["settings.pref_theme_override"],
+        )
+        assertEquals(
+            "applyStamped must persist the incoming speed stamp verbatim",
+            5_000L,
+            stamps["settings.pref_default_speed"],
+        )
+        // The global lastLocalWriteAt advances to the newest applied field.
+        assertEquals(5_000L, repo.lastLocalWriteAt())
+    }
+}

--- a/core-data/src/main/kotlin/in/jphe/storyvox/data/repository/sync/SettingsSnapshotSource.kt
+++ b/core-data/src/main/kotlin/in/jphe/storyvox/data/repository/sync/SettingsSnapshotSource.kt
@@ -110,4 +110,46 @@ interface SettingsSnapshotSource {
      * carries an `updatedAt` later than the previous one.
      */
     suspend fun stampLocalWrite(at: Long = System.currentTimeMillis())
+
+    // ── Field-level sync (#978) ────────────────────────────────────
+    /**
+     * Per-key `updatedAt` (epoch-ms) for the keys returned by
+     * [snapshot] — the field-level-merge fix for #978.
+     *
+     * The whole-blob model carried ONE [lastLocalWriteAt] for every
+     * synced key, so a sync conflict resolved at blob granularity and
+     * dropped concurrent cross-device edits to *different* keys. This
+     * method surfaces a stamp per key so the syncer can merge
+     * key-by-key (newest-per-key wins) instead of blob-by-blob.
+     *
+     * Contract:
+     *  - The returned map's keys MUST be a subset of [snapshot]'s keys
+     *    (a stamp for a key not in the snapshot is meaningless).
+     *  - A key present in [snapshot] but ABSENT here means "this build
+     *    has no per-key stamp for it" — the syncer falls back to
+     *    [lastLocalWriteAt] for that key. This is what makes the
+     *    first run after upgrade (no per-key stamps yet) behave
+     *    exactly like the old blob-level model.
+     *
+     * Default: empty map → every key falls back to [lastLocalWriteAt],
+     * reproducing the pre-#978 behavior. Only the `:app` impl overrides
+     * this; in-memory test/fake sources inherit the default and keep
+     * working unchanged.
+     */
+    suspend fun fieldStamps(): Map<String, Long> = emptyMap()
+
+    /**
+     * Apply a snapshot received from a remote device **with** the
+     * per-key `updatedAt` that the merge selected for each key, so the
+     * local per-key stamp store stays in lockstep with the values.
+     *
+     * Same tolerance rules as [apply] for the values. [stamps] keys
+     * SHOULD line up with [snapshot] keys; any stamp for a key the
+     * impl can't apply is simply ignored.
+     *
+     * Default: ignore [stamps] and delegate to [apply], so an impl
+     * that doesn't track per-key stamps (every fake/test source) keeps
+     * working. The `:app` impl overrides to persist the stamps.
+     */
+    suspend fun applyStamped(snapshot: Map<String, String>, stamps: Map<String, Long>) = apply(snapshot)
 }

--- a/core-sync/src/main/kotlin/in/jphe/storyvox/sync/coordinator/ConflictPolicies.kt
+++ b/core-sync/src/main/kotlin/in/jphe/storyvox/sync/coordinator/ConflictPolicies.kt
@@ -123,6 +123,52 @@ object ConflictPolicies {
             else -> remote
         }
     }
+
+    /**
+     * Field-level LWW for a map of independently-stamped values — the
+     * settings-domain fix for #978.
+     *
+     * The whole-blob [lastWriteWins] above picks ONE side's entire blob
+     * by a single `updatedAt`, discarding every key on the loser. That
+     * silently drops cross-device concurrent edits: device A reorders
+     * its sources, device B flips a theme, B's blob wins on timestamp,
+     * A's reorder is gone. This merge instead resolves **each key
+     * independently**:
+     *
+     *  - **Union of keys** — a key present on only one side survives
+     *    (the other side simply has "no opinion" about it; settings has
+     *    no delete semantic — a cleared pref is an *omitted* key, not a
+     *    tombstone, per `SettingsSnapshotSource.apply`'s kdoc). This
+     *    union is the actual fix: A's local-only edit and B's local-only
+     *    edit both land.
+     *  - **Per-key newest-wins** — for a key on both sides, the higher
+     *    `updatedAt` wins.
+     *  - **Tie → local** — mirrors [lastWriteWins]'s "ties go to local"
+     *    rule, applied per key instead of per blob (same anti-churn
+     *    intent: don't rewrite a value that didn't meaningfully change).
+     *
+     * Order note: `merge(a, b)` and `merge(b, a)` agree on every key
+     * except exact-`updatedAt`-tie keys, where each call keeps its own
+     * `local`. That's the intended "don't churn the local store"
+     * behavior, not a correctness bug — tied values are equal-priority
+     * by definition.
+     */
+    fun <T> mergeStampedMap(
+        local: Map<String, Stamped<T>>,
+        remote: Map<String, Stamped<T>>,
+    ): Map<String, Stamped<T>> {
+        if (remote.isEmpty()) return local
+        if (local.isEmpty()) return remote
+        val out = LinkedHashMap<String, Stamped<T>>(local.size + remote.size)
+        out.putAll(local)
+        for ((key, r) in remote) {
+            val l = out[key]
+            // Remote-only key, or remote strictly newer → take remote.
+            // Local-only key, or tie → keep local (already in `out`).
+            if (l == null || r.updatedAt > l.updatedAt) out[key] = r
+        }
+        return out
+    }
 }
 
 /**

--- a/core-sync/src/main/kotlin/in/jphe/storyvox/sync/domain/SettingsSyncer.kt
+++ b/core-sync/src/main/kotlin/in/jphe/storyvox/sync/domain/SettingsSyncer.kt
@@ -1,8 +1,11 @@
 package `in`.jphe.storyvox.sync.domain
 
 import `in`.jphe.storyvox.data.repository.sync.SettingsSnapshotSource
+import `in`.jphe.storyvox.sync.SyncIds
 import `in`.jphe.storyvox.sync.client.InstantBackend
+import `in`.jphe.storyvox.sync.client.RowSnapshot
 import `in`.jphe.storyvox.sync.client.SignedInUser
+import `in`.jphe.storyvox.sync.coordinator.ConflictPolicies
 import `in`.jphe.storyvox.sync.coordinator.Stamped
 import `in`.jphe.storyvox.sync.coordinator.SyncOutcome
 import `in`.jphe.storyvox.sync.coordinator.Syncer
@@ -24,17 +27,50 @@ import kotlinx.serialization.json.Json
  * [SettingsSnapshotSource]'s kdoc for the full allowlist and the
  * design justification for splitting Tier 1 from Tier 2.
  *
- * Wire shape: a single JSON `Map<String, String>` blob, LWW on
- * `updatedAt`. Same shape and policy as `PronunciationDictSyncer` —
- * the trade-off is documented there: editing setting X on device A
- * and setting Y on device B simultaneously will lose one of the two
- * changes on next sync. The brief explicitly accepts that for
- * "settings are user intent, not collaborative data."
+ * ## Field-level merge (#978)
  *
- * Concurrency: relies on [LwwBlobSyncer]'s reconcile-then-write
- * shape — one fetch + one upsert per sync round, no per-key
- * fan-out. The [SyncCoordinator] serialises push/pull per domain
- * via a mutex, so there's no internal race.
+ * Settings used to ride [LwwBlobSyncer]: one JSON `Map<String,String>`
+ * blob with a single `updatedAt`, resolved last-write-wins **at the
+ * blob level**. That dropped concurrent cross-device edits — device A
+ * reorders its sources, device B flips a theme, B's blob wins on
+ * timestamp, A's reorder is gone. This syncer now reconciles
+ * **per-key**: each setting carries its own `updatedAt` and the merge
+ * is a union with newest-per-key-wins (see
+ * [ConflictPolicies.mergeStampedMap]). Two devices editing two
+ * different keys both survive.
+ *
+ * ### Wire format (v2) and back-compat
+ *
+ * The remote row is still `blobs` / id `settings:<userId>`, still a
+ * single `payload` string + a row `updatedAt`. Only the payload's
+ * shape changed, and it stays readable by a pre-#978 (v1) client:
+ *
+ *  - **Top level is the flat `{key: value}` map** — exactly the v1
+ *    shape. An old client deserializing `Map<String,String>` reads
+ *    every real preference unchanged.
+ *  - Plus two reserved string entries an old client ignores as
+ *    unknown keys: `"_v": "2"` (format version) and
+ *    `"_field_stamps": "<json {key: updatedAt}>"` — the per-key
+ *    stamps, **stringified** so every top-level value is a String and
+ *    the old `Map<String,String>` decoder can't choke on an object
+ *    value. (Same JSON-in-a-string trick the pronunciation dict uses.)
+ *
+ * Reading directions, neither loses data:
+ *  - **v2 reads a v1 row** (no `_field_stamps`): synthesize every
+ *    key's stamp from the row's `updatedAt` — that long *was* the only
+ *    timestamp those keys ever had — then merge per-key. Reproduces v1
+ *    semantics exactly.
+ *  - **old (v1) client reads a v2 row**: reads the top-level flat
+ *    values, ignores `_v` / `_field_stamps`. It keeps doing blob-LWW
+ *    until it upgrades. The fleet degrades to v1 behavior, never
+ *    corrupts.
+ *
+ * No migration job: the first push from a #978 device rewrites that
+ * user's row to v2 in place (lazy, per-user).
+ *
+ * Concurrency: the [SyncCoordinator] serialises push/pull per domain
+ * via a mutex, so the fetch→merge→upsert round here has no internal
+ * race.
  */
 @Singleton
 class SettingsSyncer @Inject constructor(
@@ -43,43 +79,166 @@ class SettingsSyncer @Inject constructor(
 ) : Syncer {
 
     private val json = Json { ignoreUnknownKeys = true; encodeDefaults = true; coerceInputValues = true }
-
-    private val delegate by lazy {
-        LwwBlobSyncer(
-            name = DOMAIN,
-            localRead = ::readLocal,
-            localWrite = ::writeLocal,
-            remote = BackendBlobRemote(domain = DOMAIN, backend = backend),
-        )
-    }
+    private val mapSerializer = MapSerializer(String.serializer(), String.serializer())
+    private val stampSerializer = MapSerializer(String.serializer(), Long.serializer())
 
     override val name: String get() = DOMAIN
 
-    override suspend fun push(user: SignedInUser): SyncOutcome = delegate.push(user)
-    override suspend fun pull(user: SignedInUser): SyncOutcome = delegate.pull(user)
+    override suspend fun push(user: SignedInUser): SyncOutcome = reconcile(user)
+    override suspend fun pull(user: SignedInUser): SyncOutcome = reconcile(user)
 
-    private suspend fun readLocal(): Stamped<String>? {
+    /**
+     * Fetch the remote row, merge per-key against the local snapshot,
+     * write the merged result back to whichever side is stale. Push
+     * and pull are the same operation — both end with the two sides
+     * field-level-reconciled. (Same shape as [LwwBlobSyncer.reconcile],
+     * but the conflict step is [ConflictPolicies.mergeStampedMap]
+     * instead of whole-blob LWW.)
+     */
+    private suspend fun reconcile(user: SignedInUser): SyncOutcome {
+        val tag = "SettingsSyncer"
+        val local = runCatching { readLocalStamped() }
+            .getOrElse { return SyncOutcome.Transient("local read: ${it.message}") }
+        val remoteRow = backend.fetch(user, ENTITY, rowId(user)).getOrElse {
+            return SyncOutcome.Transient("remote fetch: ${it.message}")
+        }
+        val remote = remoteRow?.let { decodeStamped(it) }
+        android.util.Log.d(
+            tag,
+            "local=${local?.size ?: "null"}keys remote=${remote?.size ?: "null"}keys",
+        )
+
+        when {
+            local.isNullOrEmpty() && remote.isNullOrEmpty() -> {
+                android.util.Log.d(tag, "both empty, nothing to sync")
+                return SyncOutcome.Ok(0)
+            }
+            local.isNullOrEmpty() -> {
+                // Fresh device — adopt the remote wholesale.
+                android.util.Log.i(tag, "local empty, applying remote (${remote!!.size} keys)")
+                runCatching { writeLocalStamped(remote) }
+                    .onFailure { return SyncOutcome.Transient("localWrite: ${it.message}") }
+                return SyncOutcome.Ok(remote.size)
+            }
+            remote.isNullOrEmpty() -> {
+                // Remote empty — upload local as source of truth.
+                android.util.Log.i(tag, "remote empty, pushing local (${local.size} keys)")
+                val push = backend.upsert(user, ENTITY, rowId(user), encodeStamped(local), rowStamp(local))
+                if (push.isFailure) return SyncOutcome.Transient("remote push: ${push.exceptionOrNull()?.message}")
+                return SyncOutcome.Ok(local.size)
+            }
+        }
+
+        val merged = ConflictPolicies.mergeStampedMap(local, remote)
+        android.util.Log.d(tag, "merged=${merged.size}keys")
+
+        if (merged != local) {
+            android.util.Log.d(tag, "writing merged to local")
+            runCatching { writeLocalStamped(merged) }
+                .onFailure { return SyncOutcome.Transient("localWrite: ${it.message}") }
+        }
+        if (merged != remote) {
+            android.util.Log.d(tag, "pushing merged to remote")
+            val push = backend.upsert(user, ENTITY, rowId(user), encodeStamped(merged), rowStamp(merged))
+            if (push.isFailure) return SyncOutcome.Transient("remote push: ${push.exceptionOrNull()?.message}")
+        }
+        return SyncOutcome.Ok(merged.size)
+    }
+
+    // ── Local IO ──────────────────────────────────────────────────
+
+    /**
+     * Read the local snapshot as a per-key stamped map. Each value's
+     * stamp comes from [SettingsSnapshotSource.fieldStamps]; a key the
+     * impl has no per-key stamp for (e.g. first run after upgrade,
+     * before any per-key write) falls back to the global
+     * [SettingsSnapshotSource.lastLocalWriteAt] — reproducing the
+     * pre-#978 blob-level behavior for keys that haven't been touched
+     * since the upgrade. Returns null when there are no synced keys.
+     */
+    private suspend fun readLocalStamped(): Map<String, Stamped<String>>? {
         val snap = source.snapshot()
         if (snap.isEmpty()) return null
-        val stamp = source.lastLocalWriteAt().takeIf { it > 0L }
-            ?: System.currentTimeMillis()
-        val payload = json.encodeToString(
-            MapSerializer(String.serializer(), String.serializer()),
-            snap,
-        )
-        return Stamped(value = payload, updatedAt = stamp)
+        val perKey = runCatching { source.fieldStamps() }.getOrDefault(emptyMap())
+        val fallback = source.lastLocalWriteAt().takeIf { it > 0L } ?: System.currentTimeMillis()
+        return snap.mapValues { (key, value) ->
+            Stamped(value, perKey[key] ?: fallback)
+        }
     }
 
-    private suspend fun writeLocal(stamped: Stamped<String>) {
-        val map = runCatching {
-            json.decodeFromString(
-                MapSerializer(String.serializer(), String.serializer()),
-                stamped.value,
-            )
-        }.getOrNull() ?: return
-        source.apply(map)
-        source.stampLocalWrite(stamped.updatedAt)
+    private suspend fun writeLocalStamped(merged: Map<String, Stamped<String>>) {
+        val values = merged.mapValues { it.value.value }
+        val stamps = merged.mapValues { it.value.updatedAt }
+        source.applyStamped(values, stamps)
+        // Keep the legacy global stamp advanced to the newest field —
+        // it's still the v1 row updatedAt and the fallback for any key
+        // the impl can't stamp per-key.
+        rowStampOrNull(merged)?.let { source.stampLocalWrite(it) }
     }
+
+    // ── Wire encode / decode (v2 payload, v1-compatible) ──────────
+
+    /**
+     * Encode the merged map as the v2 payload: flat `{key: value}` at
+     * the top level (v1-readable) plus `_v` and a stringified
+     * `_field_stamps` sidecar. Deterministic key order (sorted) so a
+     * byte-identical input yields a byte-identical payload — no no-op
+     * push thrash.
+     */
+    private fun encodeStamped(merged: Map<String, Stamped<String>>): String {
+        val flat = sortedMapOf<String, String>()
+        val stamps = sortedMapOf<String, Long>()
+        for ((key, sv) in merged) {
+            flat[key] = sv.value
+            stamps[key] = sv.updatedAt
+        }
+        val out = LinkedHashMap<String, String>(flat.size + 2)
+        out.putAll(flat)
+        out[KEY_VERSION] = WIRE_VERSION.toString()
+        out[KEY_FIELD_STAMPS] = json.encodeToString(stampSerializer, stamps)
+        return json.encodeToString(mapSerializer, out)
+    }
+
+    /**
+     * Decode a remote row into a per-key stamped map. Handles both
+     * shapes:
+     *  - **v2**: strip the reserved `_v` / `_field_stamps` entries, use
+     *    the parsed sidecar for per-key stamps (a key missing from the
+     *    sidecar falls back to the row's `updatedAt`).
+     *  - **v1** (no `_field_stamps`): every key inherits the row's
+     *    `updatedAt` — the only timestamp a v1 row ever had.
+     *
+     * Returns null on an unparseable payload (treated as "no remote"
+     * by reconcile — we never let a corrupt row clobber local).
+     */
+    private fun decodeStamped(row: RowSnapshot): Map<String, Stamped<String>>? {
+        val raw = runCatching { json.decodeFromString(mapSerializer, row.payload) }.getOrNull()
+            ?: return null
+        val stampsJson = raw[KEY_FIELD_STAMPS]
+        val perKey: Map<String, Long> = if (stampsJson != null) {
+            runCatching { json.decodeFromString(stampSerializer, stampsJson) }.getOrDefault(emptyMap())
+        } else {
+            emptyMap()
+        }
+        val out = LinkedHashMap<String, Stamped<String>>(raw.size)
+        for ((key, value) in raw) {
+            if (key == KEY_VERSION || key == KEY_FIELD_STAMPS) continue
+            out[key] = Stamped(value, perKey[key] ?: row.updatedAt)
+        }
+        return out
+    }
+
+    /** The row-level `updatedAt` to stamp an upsert with — the newest
+     *  per-key stamp (so the v1 fallback an old reader sees is the most
+     *  recent edit). Defaults to `now` for an empty map (never happens
+     *  on the push paths, which guard non-empty first). */
+    private fun rowStamp(merged: Map<String, Stamped<String>>): Long =
+        rowStampOrNull(merged) ?: System.currentTimeMillis()
+
+    private fun rowStampOrNull(merged: Map<String, Stamped<String>>): Long? =
+        merged.values.maxOfOrNull { it.updatedAt }
+
+    private fun rowId(user: SignedInUser) = SyncIds.rowUuid(DOMAIN, user.userId)
 
     companion object {
         /**
@@ -89,5 +248,20 @@ class SettingsSyncer @Inject constructor(
          * — a rename would orphan existing rows.
          */
         const val DOMAIN: String = "settings"
+
+        /** Remote entity. Shared with the other blob-shaped domains. */
+        private const val ENTITY: String = "blobs"
+
+        /** v2 = field-level (#978). v1 rows have no version marker and
+         *  decode as flat blob-LWW. */
+        private const val WIRE_VERSION: Int = 2
+
+        /** Reserved payload keys. Underscore-prefixed so they can't
+         *  collide with a real synced key (every synced key is
+         *  namespaced `settings.` / `notion.` / `discord.` / etc., none
+         *  start with `_`). An old v1 reader sees these as unknown
+         *  String entries and ignores them. */
+        private const val KEY_VERSION: String = "_v"
+        private const val KEY_FIELD_STAMPS: String = "_field_stamps"
     }
 }

--- a/core-sync/src/test/kotlin/in/jphe/storyvox/sync/BookmarksSyncerTest.kt
+++ b/core-sync/src/test/kotlin/in/jphe/storyvox/sync/BookmarksSyncerTest.kt
@@ -163,6 +163,9 @@ class BookmarksSyncerTest {
         override suspend fun previousChapterId(currentId: String): String? = null
         override suspend fun playbackChapter(id: String): PlaybackChapterRow? = null
         override suspend fun unreadChapters(limit: Int): List<UnreadChapterRow> = emptyList()
+        // #982 — not exercised by BookmarksSyncer; stub to satisfy the
+        // ChapterDao contract (added to the interface after this fake).
+        override suspend fun markFollowedCaughtUp(now: Long): Int = error("not used")
         override suspend fun upsert(chapter: Chapter) = error("not used")
         override suspend fun upsertAll(chapters: List<Chapter>) = error("not used")
         override suspend fun parkChapterIndexesFor(fictionId: String) = error("not used")

--- a/core-sync/src/test/kotlin/in/jphe/storyvox/sync/ConflictPoliciesTest.kt
+++ b/core-sync/src/test/kotlin/in/jphe/storyvox/sync/ConflictPoliciesTest.kt
@@ -101,4 +101,56 @@ class ConflictPoliciesTest {
         val remote = Stamped(value = 5, updatedAt = 100L)
         assertTrue(local === ConflictPolicies.maxScalarStamped(local, remote))
     }
+
+    // ── mergeStampedMap (#978 field-level merge) ───────────────────
+
+    @Test fun `mergeStampedMap unions disjoint keys — both survive`() {
+        val local = mapOf("theme" to Stamped("dark", 1L))
+        val remote = mapOf("speed" to Stamped("1.5", 1L))
+        val merged = ConflictPolicies.mergeStampedMap(local, remote)
+        assertEquals(2, merged.size)
+        assertEquals("dark", merged["theme"]!!.value)
+        assertEquals("1.5", merged["speed"]!!.value)
+    }
+
+    @Test fun `mergeStampedMap newest-per-key wins independently`() {
+        val local = mapOf(
+            "theme" to Stamped("light", 2_000L), // older
+            "speed" to Stamped("3.0", 9_000L),   // newer
+        )
+        val remote = mapOf(
+            "theme" to Stamped("dark", 5_000L),  // newer → wins
+            "speed" to Stamped("1.0", 1_000L),   // older
+        )
+        val merged = ConflictPolicies.mergeStampedMap(local, remote)
+        assertEquals("dark", merged["theme"]!!.value)
+        assertEquals("3.0", merged["speed"]!!.value)
+    }
+
+    @Test fun `mergeStampedMap tie on a key prefers local value`() {
+        val local = mapOf("k" to Stamped("LOCAL", 100L))
+        val remote = mapOf("k" to Stamped("REMOTE", 100L))
+        val merged = ConflictPolicies.mergeStampedMap(local, remote)
+        assertEquals("LOCAL", merged["k"]!!.value)
+    }
+
+    @Test fun `mergeStampedMap empty remote returns local unchanged`() {
+        val local = mapOf("k" to Stamped("v", 1L))
+        assertEquals(local, ConflictPolicies.mergeStampedMap(local, emptyMap()))
+    }
+
+    @Test fun `mergeStampedMap empty local returns remote unchanged`() {
+        val remote = mapOf("k" to Stamped("v", 1L))
+        assertEquals(remote, ConflictPolicies.mergeStampedMap(emptyMap(), remote))
+    }
+
+    @Test fun `mergeStampedMap keeps each side's local-only keys plus newest shared`() {
+        val local = mapOf("a" to Stamped("la", 5L), "shared" to Stamped("ls", 5L))
+        val remote = mapOf("b" to Stamped("rb", 5L), "shared" to Stamped("rs", 9L))
+        val merged = ConflictPolicies.mergeStampedMap(local, remote)
+        assertEquals("la", merged["a"]!!.value)
+        assertEquals("rb", merged["b"]!!.value)
+        assertEquals("rs", merged["shared"]!!.value) // remote newer (9 > 5)
+        assertEquals(9L, merged["shared"]!!.updatedAt)
+    }
 }

--- a/core-sync/src/test/kotlin/in/jphe/storyvox/sync/PlaybackPositionSyncerTest.kt
+++ b/core-sync/src/test/kotlin/in/jphe/storyvox/sync/PlaybackPositionSyncerTest.kt
@@ -238,6 +238,9 @@ class PlaybackPositionSyncerTest {
         override suspend fun previousChapterId(currentId: String): String? = null
         override suspend fun playbackChapter(id: String): PlaybackChapterRow? = null
         override suspend fun unreadChapters(limit: Int): List<UnreadChapterRow> = emptyList()
+        // #982 — not exercised by PlaybackPositionSyncer; stub to
+        // satisfy the ChapterDao contract (added after this fake).
+        override suspend fun markFollowedCaughtUp(now: Long): Int = error("not used")
         override suspend fun allBookmarks() = emptyList<`in`.jphe.storyvox.data.db.dao.BookmarkRow>()
         override suspend fun setBookmark(id: String, charOffset: Int?) = error("not used")
         override suspend fun getBookmark(id: String): Int? = null

--- a/core-sync/src/test/kotlin/in/jphe/storyvox/sync/SettingsSyncerTest.kt
+++ b/core-sync/src/test/kotlin/in/jphe/storyvox/sync/SettingsSyncerTest.kt
@@ -8,7 +8,11 @@ import `in`.jphe.storyvox.sync.client.SignedInUser
 import `in`.jphe.storyvox.sync.coordinator.SyncOutcome
 import `in`.jphe.storyvox.sync.domain.SettingsSyncer
 import kotlinx.coroutines.test.runTest
+import kotlinx.serialization.builtins.MapSerializer
+import kotlinx.serialization.builtins.serializer
+import kotlinx.serialization.json.Json
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
 import org.junit.Assert.assertNotNull
 import org.junit.Assert.assertNull
 import org.junit.Assert.assertTrue
@@ -36,6 +40,11 @@ class SettingsSyncerTest {
     private class FakeSource(initial: Map<String, String> = emptyMap()) : SettingsSnapshotSource {
         val store: MutableMap<String, String> = initial.toMutableMap()
         var stamp: Long = 0L
+        /** Per-key stamps (#978). Empty by default → every key falls
+         *  back to [stamp], reproducing the pre-#978 single-stamp
+         *  behavior. Tests that exercise field-level merge populate
+         *  this to give two keys independent timestamps. */
+        val keyStamps: MutableMap<String, Long> = mutableMapOf()
 
         override suspend fun snapshot(): Map<String, String> = store.toMap()
 
@@ -46,6 +55,20 @@ class SettingsSyncerTest {
         override suspend fun lastLocalWriteAt(): Long = stamp
 
         override suspend fun stampLocalWrite(at: Long) { stamp = at }
+
+        override suspend fun fieldStamps(): Map<String, Long> = keyStamps.toMap()
+
+        override suspend fun applyStamped(snapshot: Map<String, String>, stamps: Map<String, Long>) {
+            for ((k, v) in snapshot) store[k] = v
+            for ((k, t) in stamps) keyStamps[k] = t
+        }
+
+        /** Convenience for tests: set a key + its per-key stamp. */
+        fun put(key: String, value: String, at: Long) {
+            store[key] = value
+            keyStamps[key] = at
+            if (at > stamp) stamp = at
+        }
     }
 
     @Test fun `local write gets pushed to remote on first sync`() = runTest {
@@ -141,12 +164,16 @@ class SettingsSyncerTest {
         assertNull(backend.fetch(USER, "blobs", SyncIds.rowUuid("settings", USER.userId)).getOrNull())
     }
 
-    @Test fun `tombstone propagates — local clears a key, remote sees the clear`() = runTest {
-        // Settings sync uses LWW on the whole blob; "clearing a key
-        // locally" is encoded as "the next local snapshot omits the
-        // key." Pushing the smaller snapshot replaces the remote blob
-        // entirely (no per-key tombstones — that's the v1 model
-        // documented in design-decisions.md).
+    @Test fun `field-level merge — omitting a key on push does NOT delete it remotely (#978 union)`() = runTest {
+        // BEHAVIOR CHANGE (#978): settings sync moved from whole-blob
+        // LWW to per-key UNION merge. Settings has no delete semantic
+        // — an omitted key means "no opinion," not "tombstone" (see
+        // SettingsSnapshotSource.apply kdoc). So pushing a smaller
+        // snapshot no longer wipes the omitted key from the remote;
+        // the union preserves it. This is intentional and is the flip
+        // side of the cross-device-clobber fix: device A omitting a
+        // key it doesn't know about must not erase device B's value
+        // for it.
         val backend = FakeInstantBackend()
         val source = FakeSource(
             initial = mapOf(
@@ -156,7 +183,7 @@ class SettingsSyncerTest {
         ).also { it.stamp = 1_000L }
         SettingsSyncer(source, backend).push(USER)
 
-        // User clears the speed override.
+        // A later snapshot omits the speed key.
         source.store.remove("settings.pref_default_speed")
         source.stamp = 2_000L
         SettingsSyncer(source, backend).push(USER)
@@ -164,8 +191,8 @@ class SettingsSyncerTest {
         val row = backend.fetch(USER, "blobs", SyncIds.rowUuid("settings", USER.userId)).getOrNull()!!
         assertTrue("remote should retain the theme", row.payload.contains("\"DARK\""))
         assertTrue(
-            "remote should NOT carry the cleared default-speed",
-            !row.payload.contains("\"settings.pref_default_speed\""),
+            "remote should STILL carry the omitted default-speed (union, no delete semantic)",
+            row.payload.contains("\"settings.pref_default_speed\""),
         )
     }
 
@@ -339,5 +366,174 @@ class SettingsSyncerTest {
         SettingsSyncer(source, backend).push(USER)
         val row = backend.fetch(USER, "blobs", SyncIds.rowUuid("settings", USER.userId)).getOrNull()!!
         assertEquals(42L, row.updatedAt)
+    }
+
+    // ── #978 field-level merge ─────────────────────────────────────
+
+    @Test fun `field-level merge — A edits X, B edits Y concurrently, BOTH survive`() = runTest {
+        // THE bug #978 fixes. Device A edits the theme; device B edits
+        // the default speed; neither knows about the other's edit.
+        // Under whole-blob LWW one would clobber the other. Under
+        // per-key merge both land.
+        val backend = FakeInstantBackend()
+
+        // Device A: had theme=LIGHT + speed=1.0 at t=1000, then edits
+        // theme→DARK at t=3000 (only the theme key bumps).
+        val deviceA = FakeSource()
+        deviceA.put("settings.pref_theme_override", "LIGHT", 1_000L)
+        deviceA.put("settings.pref_default_speed", "1.0", 1_000L)
+        deviceA.put("settings.pref_theme_override", "DARK", 3_000L) // A's edit
+        SettingsSyncer(deviceA, backend).push(USER) // A uploads first
+
+        // Device B: same starting state, edits speed→2.0 at t=2000
+        // (only the speed key bumps), still thinks theme=LIGHT.
+        val deviceB = FakeSource()
+        deviceB.put("settings.pref_theme_override", "LIGHT", 1_000L)
+        deviceB.put("settings.pref_default_speed", "1.0", 1_000L)
+        deviceB.put("settings.pref_default_speed", "2.0", 2_000L) // B's edit
+        SettingsSyncer(deviceB, backend).push(USER) // B syncs against A's row
+
+        // After B's merge: theme=DARK (A's t=3000 beats B's t=1000) and
+        // speed=2.0 (B's t=2000 beats A's t=1000). BOTH edits survived.
+        assertEquals("A's theme edit survives on B", "DARK", deviceB.store["settings.pref_theme_override"])
+        assertEquals("B's speed edit survives on B", "2.0", deviceB.store["settings.pref_default_speed"])
+
+        // And the remote reflects both, so a third device pulls both.
+        val deviceC = FakeSource()
+        SettingsSyncer(deviceC, backend).pull(USER)
+        assertEquals("DARK", deviceC.store["settings.pref_theme_override"])
+        assertEquals("2.0", deviceC.store["settings.pref_default_speed"])
+    }
+
+    @Test fun `field-level merge — newest-per-key wins independently`() = runTest {
+        val backend = FakeInstantBackend()
+        // Remote: theme edited late (t=5000), speed edited early (t=1000).
+        val a = FakeSource()
+        a.put("settings.pref_theme_override", "DARK", 5_000L)
+        a.put("settings.pref_default_speed", "1.0", 1_000L)
+        SettingsSyncer(a, backend).push(USER)
+
+        // Local: theme edited early (t=2000 < 5000 → loses), speed
+        // edited late (t=9000 > 1000 → wins).
+        val b = FakeSource()
+        b.put("settings.pref_theme_override", "LIGHT", 2_000L)
+        b.put("settings.pref_default_speed", "3.0", 9_000L)
+        SettingsSyncer(b, backend).pull(USER)
+
+        assertEquals("remote's newer theme wins", "DARK", b.store["settings.pref_theme_override"])
+        assertEquals("local's newer speed wins", "3.0", b.store["settings.pref_default_speed"])
+    }
+
+    @Test fun `field-level merge — equal per-key timestamp ties to local`() = runTest {
+        // Mirrors the whole-blob "tie → local" rule, applied per key.
+        val backend = FakeInstantBackend()
+        val a = FakeSource()
+        a.put("settings.pref_theme_override", "REMOTE_VAL", 777L)
+        SettingsSyncer(a, backend).push(USER)
+
+        val b = FakeSource()
+        b.put("settings.pref_theme_override", "LOCAL_VAL", 777L) // exact tie
+        SettingsSyncer(b, backend).pull(USER)
+
+        assertEquals("tie keeps local", "LOCAL_VAL", b.store["settings.pref_theme_override"])
+    }
+
+    @Test fun `v1 to v2 — a flat (v1) remote row synthesizes per-key stamps from the row updatedAt`() = runTest {
+        // A pre-#978 device wrote a flat blob with a single row
+        // updatedAt and NO _field_stamps sidecar. A #978 device must
+        // read it, synthesize every key's stamp = row.updatedAt, and
+        // merge correctly (no data loss, no crash).
+        val backend = FakeInstantBackend()
+        val rowId = SyncIds.rowUuid("settings", USER.userId)
+        // Hand-craft a v1 flat payload (exactly what old code wrote).
+        backend.upsert(
+            USER,
+            entity = "blobs",
+            id = rowId,
+            payload = """{"settings.pref_theme_override":"DARK","settings.pref_default_speed":"1.5"}""",
+            updatedAt = 8_000L,
+        )
+
+        // Local device has a NEWER edit to one key (t=9000) and an
+        // OLDER value for another (no per-key stamp → falls back to
+        // global stamp 500, which loses to the v1 row's 8000).
+        val local = FakeSource()
+        local.put("settings.pref_theme_override", "LIGHT", 9_000L) // newer than 8000 → wins
+        local.store["settings.pref_default_speed"] = "2.0"          // no per-key stamp
+        local.stamp = 500L                                          // fallback < 8000 → loses
+        SettingsSyncer(local, backend).pull(USER)
+
+        assertEquals("local's newer theme wins over v1 row", "LIGHT", local.store["settings.pref_theme_override"])
+        assertEquals("v1 row's speed (8000) beats local fallback (500)", "1.5", local.store["settings.pref_default_speed"])
+    }
+
+    @Test fun `HARD GATE — a v1 client can decode a v2 payload without throwing and reads every real key`() = runTest {
+        // This is the back-compat gate Sandman flagged: JP's other
+        // devices run v1.0.1 (pre-#978) and will read v2 payloads this
+        // build writes. A v1 client deserializes the payload with
+        // MapSerializer(String, String). If a v2 payload had an
+        // OBJECT-typed value (e.g. a nested {value,updatedAt}) that
+        // decode would throw and sync would BREAK for the old device.
+        // The stringified _field_stamps sidecar keeps every top-level
+        // value a String, so the old decoder reads every real
+        // preference and silently ignores _v / _field_stamps.
+        val backend = FakeInstantBackend()
+        val rowId = SyncIds.rowUuid("settings", USER.userId)
+
+        // Produce a REAL v2 payload by pushing through the new syncer.
+        val producer = FakeSource()
+        producer.put("settings.pref_theme_override", "DARK", 1_000L)
+        producer.put("settings.pref_default_speed", "1.25", 2_000L)
+        producer.put("notion.pref_notion_database_id", "db-9999", 3_000L)
+        SettingsSyncer(producer, backend).push(USER)
+        val v2payload = backend.fetch(USER, "blobs", rowId).getOrNull()!!.payload
+
+        // Sanity: it really is v2 (carries the sidecar markers).
+        assertTrue("payload must be v2", v2payload.contains("\"_v\""))
+        assertTrue("payload must carry _field_stamps", v2payload.contains("\"_field_stamps\""))
+
+        // Decode it EXACTLY as a v1 client would: flat Map<String,String>.
+        val v1Json = Json { ignoreUnknownKeys = true; coerceInputValues = true }
+        val flat: Map<String, String> = v1Json.decodeFromString(
+            MapSerializer(String.serializer(), String.serializer()),
+            v2payload,
+        ) // <-- must not throw
+
+        // Every real preference is present and correct for the old reader.
+        assertEquals("DARK", flat["settings.pref_theme_override"])
+        assertEquals("1.25", flat["settings.pref_default_speed"])
+        assertEquals("db-9999", flat["notion.pref_notion_database_id"])
+        // The reserved sidecar keys are visible to the old reader as
+        // opaque strings, never as objects (which would have thrown).
+        // They don't collide with any real key (all real keys are
+        // namespaced, none start with `_`).
+        assertEquals("2", flat["_v"])
+        assertTrue("_field_stamps is an opaque string to the v1 reader", flat["_field_stamps"]!!.contains("updatedAt").not())
+        assertFalse("no real preference key starts with _", flat.keys.filter { it.startsWith("_") }.any { it != "_v" && it != "_field_stamps" })
+    }
+
+    @Test fun `round-trip — v2 producer to v2 consumer preserves per-key stamps`() = runTest {
+        // A v2 consumer reading a v2 row must recover the SAME per-key
+        // stamps the producer wrote, so a subsequent merge resolves
+        // correctly. We verify indirectly: after C pulls, C re-pushes
+        // and the row is byte-identical (stamps round-tripped).
+        val backend = FakeInstantBackend()
+        val rowId = SyncIds.rowUuid("settings", USER.userId)
+        val producer = FakeSource()
+        producer.put("settings.pref_theme_override", "DARK", 1_111L)
+        producer.put("settings.pref_default_speed", "1.25", 2_222L)
+        SettingsSyncer(producer, backend).push(USER)
+        val first = backend.fetch(USER, "blobs", rowId).getOrNull()!!.payload
+
+        val consumer = FakeSource()
+        SettingsSyncer(consumer, backend).pull(USER)
+        // Consumer recorded the producer's per-key stamps via applyStamped.
+        assertEquals(1_111L, consumer.keyStamps["settings.pref_theme_override"])
+        assertEquals(2_222L, consumer.keyStamps["settings.pref_default_speed"])
+
+        // Re-push from the consumer — identical state → identical bytes.
+        SettingsSyncer(consumer, backend).push(USER)
+        val second = backend.fetch(USER, "blobs", rowId).getOrNull()!!.payload
+        assertEquals("v2 round-trip must be byte-stable", first, second)
     }
 }


### PR DESCRIPTION
## What

Moves settings sync from **whole-blob last-write-wins** to **field-level merge** (per-key `updatedAt`). Closes #978.

Previously all ~70 synced preferences shared ONE `updatedAt`, so a change to any setting on device B could overwrite ALL of device A's concurrent edits when B's blob won on timestamp. Now each key carries its own `updatedAt` and conflicts resolve key-by-key (union + newest-per-key wins): two devices editing two different keys both survive.

## Design (approved Option A — uniform per-key, diff-based stamping)

- **`ConflictPolicies.mergeStampedMap`** — pure per-key union merge, tie→local (mirrors the whole-blob "tie to local" rule per key). Unit-tested in isolation.
- **`SettingsSyncer`** reconciles per-key directly; `LwwBlobSyncer` is left untouched (still serves the pronunciation-dict / secrets blob domains).
- **Per-key stamps derived diff-based** at the existing #977 `stampSyncedWrite` chokepoint (current snapshot vs persisted baseline) — **zero changes to the ~70 `set*` mutators**. Two new non-synced local keys: `instantdb.settings_field_stamps_v1` + `instantdb.settings_snapshot_baseline_v1`.
- **`SettingsSnapshotSource`** gains `fieldStamps()` / `applyStamped()` as **default methods** so other impls and test fakes keep compiling unchanged.

## Wire format v2 — back-compat both directions, no migration job

- Top-level **flat `{key: value}`** (v1-readable) + a **stringified `_field_stamps`** sidecar + `_v` marker. Stringified so a v1 client's `Map<String,String>` decoder can't choke on an object value.
- **v2 reads a v1 row**: synthesize each key's stamp from the row `updatedAt` — exactly the semantics that row had.
- **old v1 client reads a v2 row**: reads the flat values, ignores `_v`/`_field_stamps`. The fleet degrades to blob-LWW, never loses data. First v2 push upgrades the row in place, per-user, lazily.

> ⚠️ This back-compat is not theoretical: JP's other devices run **v1.0.1 (pre-#978)** and will read v2 payloads this build writes.

## Behavior change

Omitting a key on push no longer deletes it remotely (union, **no tombstone** — settings has no delete semantic; a cleared pref is an omitted key meaning "no opinion"). This is the intended flip side of the clobber fix. The one existing test that asserted the old delete-on-omit behavior was updated to assert the union behavior, with a comment explaining the #978 change.

## Tests

- **HARD GATE** (`HARD GATE — a v1 client can decode a v2 payload without throwing and reads every real key`): decodes a real v2 payload with the **old** `MapSerializer<String,String>` and asserts no throw + every real key present. This is the back-compat gate; it is green.
- Field-level-merge proof: A edits X, B edits Y concurrently → both survive.
- v1→v2 stamp synthesis, tie-to-local-per-key, v2 round-trip stamp preservation.
- 6 `mergeStampedMap` pure unit tests.
- 3 `:app` diff-stamping tests (per-key stamp bumps only the changed key; `applyStamped` records incoming stamps verbatim).
- Also unblocked a **pre-existing** `:core-sync` test compile break: #982's `ChapterDao.markFollowedCaughtUp` was missing from two test fakes (`BookmarksSyncerTest`, `PlaybackPositionSyncerTest`) — stubbed `= error("not used")` to match the convention.

## Verification

```
:core-sync:compileDebugKotlin            ✓
:core-sync:testDebugUnitTest             ✓ (SettingsSyncerTest 21, ConflictPoliciesTest 17, 0 failures)
:app:compileDebugKotlin                  ✓
:app SettingsRepository* tests           ✓ (incl. 3 new field-stamp tests)
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)