### PR TITLE
feat(app): 'Open With' file association for EPUB/PDF/TXT (#1000)

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -84,6 +84,71 @@
                 <category android:name="android.intent.category.DEFAULT" />
                 <data android:mimeType="text/plain" />
             </intent-filter>
+
+            <!--
+                Issue #1000 — "Open With" file association. Advertise
+                Candela as a handler for EPUB and plaintext documents so
+                a long-press → "Open with" (file manager) or an email
+                attachment → "Open" lands the file straight into the app
+                (the fastest "read this for me" path for a low-vision /
+                low-literacy user). MainActivity.importDocument ingests
+                the Uri (SAF), persists read permission, and reuses the
+                :source-epub import path to create the fiction.
+
+                Why so many <data> rows: file managers / mail clients are
+                inconsistent about the mime they attach. We register the
+                canonical mime AND the filename extension (pathPattern on
+                a host-less content/file Uri) so a .epub that arrives as
+                application/octet-stream (or no mime) is still claimed.
+                DocumentImportClassifier does the final mime-then-
+                extension bucketing on our side.
+
+                PDF (application/pdf) is intentionally NOT advertised yet
+                — it's gated on #996 (PDF text extraction). When #996
+                lands: flip DocumentImportClassifier.PDF_ENABLED and add
+                a <data android:mimeType="application/pdf"/> row + a
+                ".pdf" pathPattern here. Advertising the filter before
+                the extractor exists would put Candela in the chooser for
+                a type it can't open — the dead-end this issue calls out.
+            -->
+            <!-- ACTION_VIEW: file-manager "Open with Candela" by mime. -->
+            <intent-filter android:label="@string/open_with_label">
+                <action android:name="android.intent.action.VIEW" />
+                <category android:name="android.intent.category.DEFAULT" />
+                <category android:name="android.intent.category.BROWSABLE" />
+                <data android:scheme="content" />
+                <data android:scheme="file" />
+                <data android:mimeType="application/epub+zip" />
+                <data android:mimeType="text/plain" />
+            </intent-filter>
+            <!-- ACTION_VIEW: claim by .epub/.txt extension when the mime
+                 is generic (octet-stream) or absent. host="*" + a
+                 mimeType is required for pathPattern matching on
+                 content/file Uris; we use a broad */* mime and let
+                 DocumentImportClassifier reject anything whose extension
+                 isn't one we handle. The doubled patterns cover
+                 names with a second dot (e.g. "book.v2.epub"). -->
+            <intent-filter android:label="@string/open_with_label">
+                <action android:name="android.intent.action.VIEW" />
+                <category android:name="android.intent.category.DEFAULT" />
+                <category android:name="android.intent.category.BROWSABLE" />
+                <data android:scheme="content" />
+                <data android:scheme="file" />
+                <data android:host="*" />
+                <data android:mimeType="*/*" />
+                <data android:pathPattern=".*\\.epub" />
+                <data android:pathPattern=".*\\.txt" />
+                <data android:pathPattern=".*\\..*\\.epub" />
+                <data android:pathPattern=".*\\..*\\.txt" />
+            </intent-filter>
+            <!-- ACTION_SEND: "Share → Candela" for an EPUB attachment.
+                 (text/plain file-shares ride the #472 filter above —
+                 documentImportUri picks EXTRA_STREAM before EXTRA_TEXT.) -->
+            <intent-filter android:label="@string/open_with_label">
+                <action android:name="android.intent.action.SEND" />
+                <category android:name="android.intent.category.DEFAULT" />
+                <data android:mimeType="application/epub+zip" />
+            </intent-filter>
         </activity>
 
         <!-- Disable default WorkManager init so Hilt's Configuration.Provider takes over. -->

--- a/app/src/main/kotlin/in/jphe/storyvox/MainActivity.kt
+++ b/app/src/main/kotlin/in/jphe/storyvox/MainActivity.kt
@@ -2,9 +2,13 @@ package `in`.jphe.storyvox
 
 import android.Manifest
 import android.content.Intent
+import android.database.Cursor
 import android.content.pm.PackageManager
+import android.net.Uri
 import android.os.Build
 import android.os.Bundle
+import android.provider.OpenableColumns
+import android.util.Log
 import android.view.Choreographer
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.rememberLauncherForActivityResult
@@ -47,13 +51,20 @@ import `in`.jphe.storyvox.ui.a11y.LocalIsTalkBackActive
 import `in`.jphe.storyvox.ui.component.CoverStyleLocal
 import `in`.jphe.storyvox.ui.component.LocalCoverStyle
 import `in`.jphe.storyvox.ui.theme.LibraryNocturneTheme
+import `in`.jphe.storyvox.data.EpubConfigImpl
 import `in`.jphe.storyvox.navigation.DeepLinkResolver
+import `in`.jphe.storyvox.navigation.DocumentImportClassifier
+import `in`.jphe.storyvox.navigation.ImportKind
 import `in`.jphe.storyvox.navigation.StoryvoxNavHost
+import `in`.jphe.storyvox.navigation.StoryvoxRoutes
+import `in`.jphe.storyvox.source.epub.config.EpubEntryKind
 import javax.inject.Inject
+import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.emitAll
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.flow
+import kotlinx.coroutines.withContext
 
 @AndroidEntryPoint
 class MainActivity : ComponentActivity() {
@@ -104,6 +115,17 @@ class MainActivity : ComponentActivity() {
      * than blocking pre-setContent main-thread work.
      */
     @Inject lateinit var accessibilityStateBridge: Lazy<AccessibilityStateBridge>
+
+    /**
+     * Issue #1000 — "Open With" file import. The EPUB config impl is
+     * the registry the import path writes into (a single inbound EPUB /
+     * TXT file becomes a standalone fiction, reusing the `:source-epub`
+     * read path). Wrapped in [Lazy] for the same cold-launch reason as
+     * the other injects (#409): the DataStore-backed graph isn't
+     * materialised during activity injection, only when an import
+     * intent actually arrives.
+     */
+    @Inject lateinit var epubConfig: Lazy<EpubConfigImpl>
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
@@ -225,9 +247,15 @@ class MainActivity : ComponentActivity() {
                         // body runs before NavHost finishes composing.
                         snapshotFlow { navController.currentBackStackEntry }
                             .first { it != null }
-                        DeepLinkResolver.resolve(i)?.let { route ->
-                            navController.navigate(route)
-                        }
+                        // Issue #1000 — "Open With" file-import intents take
+                        // precedence: an ACTION_VIEW/ACTION_SEND carrying a
+                        // document Uri imports the file and routes to its
+                        // fiction detail. Non-import intents fall through to
+                        // the URL / notification resolver.
+                        val importRoute = DeepLinkResolver.documentImportUri(i)
+                            ?.let { uri -> importDocument(uri) }
+                        val route = importRoute ?: DeepLinkResolver.resolve(i)
+                        route?.let { navController.navigate(it) }
                         intentFlow.value = null
                     }
                 }
@@ -324,5 +352,84 @@ class MainActivity : ComponentActivity() {
         super.onNewIntent(intent)
         setIntent(intent)
         intentFlow.value = intent
+    }
+
+    /**
+     * Issue #1000 — ingest a document Uri received via "Open With"
+     * (ACTION_VIEW) or "Share → Candela" (ACTION_SEND with EXTRA_STREAM)
+     * and return the fiction-detail route to navigate to, or null if
+     * the document type isn't one we can open.
+     *
+     * Steps:
+     *  1. Resolve the mime type (intent type → ContentResolver type) and
+     *     a human filename (OpenableColumns.DISPLAY_NAME → last path
+     *     segment) for the Uri.
+     *  2. [DocumentImportClassifier.classify] buckets it (Epub / Text /
+     *     Pdf / Unsupported). Unsupported (incl. PDF until #996 lands)
+     *     → return null; the resolver fall-through then declines too.
+     *  3. [takePersistableUriPermission] so re-opens from Library
+     *     survive a relaunch — content Uris from SAF / file managers
+     *     carry FLAG_GRANT_READ_URI_PERMISSION; persisting it converts
+     *     the one-shot grant into a durable one.
+     *  4. Register with the EPUB config and return its fictionId route.
+     */
+    private suspend fun importDocument(uri: Uri): String? {
+        val mime = intent?.type ?: contentResolver.getType(uri)
+        val displayName = queryDisplayName(uri) ?: uri.lastPathSegment.orEmpty()
+        val kind = DocumentImportClassifier.classify(mime, displayName)
+        val entryKind = when (kind) {
+            ImportKind.Epub -> EpubEntryKind.Epub
+            ImportKind.Text -> EpubEntryKind.Text
+            // PDF lands here once #996 flips DocumentImportClassifier
+            // .PDF_ENABLED and wires its extractor into the import store;
+            // until then classify() never returns Pdf, so this is the
+            // single hook to extend (don't import as EPUB — the parser
+            // would reject the bytes).
+            ImportKind.Pdf -> return null
+            ImportKind.Unsupported -> return null
+        }
+        // Persist read access so Library re-opens work after relaunch.
+        // Best-effort: some providers grant only a one-shot read (no
+        // persistable flag) — the import still works for this session,
+        // and a failed persist shouldn't abort the open.
+        runCatching {
+            contentResolver.takePersistableUriPermission(
+                uri,
+                Intent.FLAG_GRANT_READ_URI_PERMISSION,
+            )
+        }.onFailure { Log.w(TAG, "Could not persist URI permission for $uri", it) }
+
+        val fictionId = epubConfig.get().importFile(
+            uriString = uri.toString(),
+            displayName = displayName,
+            kind = entryKind,
+        )
+        return StoryvoxRoutes.fictionDetail(fictionId)
+    }
+
+    /** Query the SAF [OpenableColumns.DISPLAY_NAME] for a content Uri.
+     *  Returns null for non-content Uris or when the provider doesn't
+     *  expose the column (the caller falls back to the last path
+     *  segment). Off the main thread — ContentResolver.query touches a
+     *  binder. */
+    private suspend fun queryDisplayName(uri: Uri): String? =
+        withContext(Dispatchers.IO) {
+            if (uri.scheme != "content") return@withContext null
+            runCatching {
+                contentResolver.query(
+                    uri,
+                    arrayOf(OpenableColumns.DISPLAY_NAME),
+                    null,
+                    null,
+                    null,
+                )?.use { cursor: Cursor ->
+                    val idx = cursor.getColumnIndex(OpenableColumns.DISPLAY_NAME)
+                    if (idx >= 0 && cursor.moveToFirst()) cursor.getString(idx) else null
+                }
+            }.getOrNull()?.takeIf { it.isNotBlank() }
+        }
+
+    private companion object {
+        private const val TAG = "MainActivity"
     }
 }

--- a/app/src/main/kotlin/in/jphe/storyvox/data/EpubConfigImpl.kt
+++ b/app/src/main/kotlin/in/jphe/storyvox/data/EpubConfigImpl.kt
@@ -6,16 +6,19 @@ import androidx.datastore.core.DataStore
 import androidx.datastore.preferences.core.Preferences
 import androidx.datastore.preferences.core.edit
 import androidx.datastore.preferences.core.stringPreferencesKey
+import androidx.datastore.preferences.core.stringSetPreferencesKey
 import androidx.datastore.preferences.preferencesDataStore
 import androidx.documentfile.provider.DocumentFile
 import dagger.hilt.android.qualifiers.ApplicationContext
 import `in`.jphe.storyvox.source.epub.config.EpubConfig
+import `in`.jphe.storyvox.source.epub.config.EpubEntryKind
 import `in`.jphe.storyvox.source.epub.config.EpubFileEntry
 import `in`.jphe.storyvox.source.epub.config.fictionIdForEpubUri
 import javax.inject.Inject
 import javax.inject.Singleton
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.map
@@ -30,6 +33,60 @@ private object EpubKeys {
      *  = no folder configured (Browse → Local Books shows empty
      *  state with a CTA back to Settings). */
     val FOLDER_URI = stringPreferencesKey("pref_epub_folder_uri")
+
+    /** Issue #1000 — single files imported via "Open With" (vs the
+     *  folder picker). Each member is one encoded entry record
+     *  (`kind|displayName|uriString` — see [encodeImported] /
+     *  [decodeImported]). A `Set<String>` preference dedups by exact
+     *  record, but we also key the indexed list on fictionId so re-
+     *  opening the same document doesn't create a duplicate fiction. */
+    val IMPORTED_FILES = stringSetPreferencesKey("pref_epub_imported_files")
+}
+
+/** Issue #1000 — encoded `Set<String>` record for one imported file.
+ *  Pipe-delimited; the uriString is last so it can legally contain the
+ *  delimiter (we `substringAfter` the second pipe). */
+private fun encodeImported(entry: EpubFileEntry): String =
+    "${entry.kind.name}|${entry.displayName.replace('|', '_')}|${entry.uriString}"
+
+private fun decodeImported(record: String): EpubFileEntry? {
+    val firstPipe = record.indexOf('|')
+    if (firstPipe < 0) return null
+    val secondPipe = record.indexOf('|', firstPipe + 1)
+    if (secondPipe < 0) return null
+    val kindStr = record.substring(0, firstPipe)
+    val displayName = record.substring(firstPipe + 1, secondPipe)
+    val uriString = record.substring(secondPipe + 1)
+    if (uriString.isBlank()) return null
+    val kind = runCatching { EpubEntryKind.valueOf(kindStr) }.getOrNull() ?: return null
+    return EpubFileEntry(
+        fictionId = fictionIdForEpubUri(uriString),
+        uriString = uriString,
+        displayName = displayName,
+        kind = kind,
+    )
+}
+
+/** Decode the persisted import-record set into entries, sorted by
+ *  display name. Malformed records are dropped silently (forward-
+ *  compat / corruption resilience). */
+private fun decodeImportedSet(records: Set<String>?): List<EpubFileEntry> =
+    records.orEmpty()
+        .mapNotNull { decodeImported(it) }
+        .sortedBy { it.displayName.lowercase() }
+
+/** Issue #1000 — merge folder-enumerated EPUBs with single-file
+ *  imports. Folder entries win on fictionId collision (the folder is
+ *  the canonical surface); imports for files not in the folder are
+ *  appended. Stable order: folder books first, then imports, each
+ *  alphabetised by its own producer. */
+private fun mergeBooks(
+    folder: List<EpubFileEntry>,
+    imported: List<EpubFileEntry>,
+): List<EpubFileEntry> {
+    if (imported.isEmpty()) return folder
+    val folderIds = folder.mapTo(HashSet()) { it.fictionId }
+    return folder + imported.filter { it.fictionId !in folderIds }
 }
 
 /**
@@ -102,13 +159,25 @@ class EpubConfigImpl internal constructor(
     override suspend fun snapshot(): String? =
         store.data.first()[EpubKeys.FOLDER_URI]?.takeIf { it.isNotBlank() }
 
-    override val books: Flow<List<EpubFileEntry>> = folderUriString.map { uri ->
-        if (uri == null) emptyList() else withContext(Dispatchers.IO) { reader.enumerate(uri) }
-    }.distinctUntilChanged()
+    /** Issue #1000 — single files imported via "Open With", decoded
+     *  from the [EpubKeys.IMPORTED_FILES] preference set. Independent of
+     *  the folder picker; merged into [books] below. */
+    private val importedFiles: Flow<List<EpubFileEntry>> = store.data
+        .map { prefs -> decodeImportedSet(prefs[EpubKeys.IMPORTED_FILES]) }
+        .distinctUntilChanged()
+
+    override val books: Flow<List<EpubFileEntry>> =
+        combine(folderUriString, importedFiles) { uri, imported ->
+            val folder = if (uri == null) emptyList()
+            else withContext(Dispatchers.IO) { reader.enumerate(uri) }
+            mergeBooks(folder, imported)
+        }.distinctUntilChanged()
 
     override suspend fun books(): List<EpubFileEntry> {
-        val uri = snapshot() ?: return emptyList()
-        return withContext(Dispatchers.IO) { reader.enumerate(uri) }
+        val folder = snapshot()?.let { withContext(Dispatchers.IO) { reader.enumerate(it) } }
+            ?: emptyList()
+        val imported = decodeImportedSet(store.data.first()[EpubKeys.IMPORTED_FILES])
+        return mergeBooks(folder, imported)
     }
 
     override suspend fun readBookBytes(uriString: String): ByteArray? =
@@ -131,6 +200,44 @@ class EpubConfigImpl internal constructor(
 
     suspend fun clearFolder() {
         store.edit { prefs -> prefs.remove(EpubKeys.FOLDER_URI) }
+    }
+
+    /**
+     * Issue #1000 — register a single document received via "Open With"
+     * (ACTION_VIEW / ACTION_SEND) as a standalone fiction, independent
+     * of the folder picker. The caller (MainActivity's import path) is
+     * expected to have already taken persistable read permission on the
+     * Uri via [android.content.ContentResolver.takePersistableUriPermission]
+     * so the grant survives the next launch (re-opens from Library
+     * work). Returns the stable fictionId the resolver navigates to.
+     *
+     * Idempotent on the Uri: the persisted record set is keyed by the
+     * exact encoded record, and the indexed list dedups by fictionId
+     * ([fictionIdForEpubUri] is a stable hash of the Uri), so opening
+     * the same file twice doesn't create a second fiction.
+     */
+    suspend fun importFile(
+        uriString: String,
+        displayName: String,
+        kind: EpubEntryKind,
+    ): String {
+        val entry = EpubFileEntry(
+            fictionId = fictionIdForEpubUri(uriString),
+            uriString = uriString.trim(),
+            displayName = displayName.ifBlank { uriString.substringAfterLast('/') },
+            kind = kind,
+        )
+        store.edit { prefs ->
+            val existing = prefs[EpubKeys.IMPORTED_FILES].orEmpty()
+            // Drop any prior record for the same fictionId (e.g. the
+            // display name changed) before adding the fresh one.
+            val pruned = existing.filterTo(mutableSetOf()) { rec ->
+                decodeImported(rec)?.fictionId != entry.fictionId
+            }
+            pruned.add(encodeImported(entry))
+            prefs[EpubKeys.IMPORTED_FILES] = pruned
+        }
+        return entry.fictionId
     }
 
     companion object {

--- a/app/src/main/kotlin/in/jphe/storyvox/navigation/DocumentImport.kt
+++ b/app/src/main/kotlin/in/jphe/storyvox/navigation/DocumentImport.kt
@@ -1,0 +1,107 @@
+package `in`.jphe.storyvox.navigation
+
+/**
+ * Issue #1000 — "Open With" file association. The kind of document an
+ * inbound `ACTION_VIEW` / `ACTION_SEND` intent is carrying, decided
+ * purely from its mime type and (as a fallback) its filename
+ * extension. This is the seam the unit tests exercise: no Android
+ * `Uri`, `Intent`, or `ContentResolver` — just the (mime, name) pair
+ * the activity reads off the intent.
+ */
+enum class ImportKind {
+    /** `application/epub+zip` (or a `.epub` filename). Routed through
+     *  the existing `:source-epub` import path. */
+    Epub,
+
+    /** `text/plain` (or any `text/...` subtype, or a `.txt` / `.text` /
+     *  `.md` filename). Imported as a single-chapter book via the same
+     *  EPUB-backed import store (the EPUB source synthesises a one-
+     *  chapter book from the plaintext body). */
+    Text,
+
+    /** `application/pdf` (or a `.pdf` filename). Gated on #996 (Somnia's
+     *  PDF text-extraction path). Until that lands the resolver maps PDF
+     *  to [Unsupported]; the manifest intent-filter + this branch are
+     *  the hook #996 wires its extractor into — see
+     *  [DocumentImportClassifier.PDF_ENABLED]. */
+    Pdf,
+
+    /** Anything we don't advertise an intent-filter for, or a payload
+     *  whose mime + extension we can't confidently bucket. The resolver
+     *  declines (returns null) rather than guessing. */
+    Unsupported,
+}
+
+/**
+ * Issue #1000 — pure mapping from an inbound document's mime type and
+ * filename to an [ImportKind]. Kept Android-free so it unit-tests
+ * without Robolectric (CLAUDE.md: JUnit 4, no Robolectric).
+ *
+ * File managers and email clients are wildly inconsistent about the
+ * mime they attach to a share/open-with intent: a `.epub` may arrive
+ * as `application/epub+zip`, `application/octet-stream`, or no mime at
+ * all. We therefore try the mime first and fall back to the filename
+ * extension — matching either is enough to claim the document.
+ */
+object DocumentImportClassifier {
+
+    /**
+     * #996 hook — flip to `true` once Somnia's PDF text-extraction path
+     * (`:source-pdf`) is merged and wired into the import store. While
+     * `false`, PDFs classify as [ImportKind.Unsupported] so the resolver
+     * declines them (the manifest still advertises the filter, behind
+     * the same gate, so we don't appear in the chooser for a type we
+     * can't yet open). Keeping the branch live + tested means #996 is a
+     * one-line flip + a store wire, not a re-derivation.
+     */
+    const val PDF_ENABLED: Boolean = false
+
+    private val EPUB_MIMES = setOf(
+        "application/epub+zip",
+        "application/x-epub+zip",
+        "application/epub",
+    )
+    private val PDF_MIMES = setOf(
+        "application/pdf",
+        "application/x-pdf",
+    )
+
+    /**
+     * Classify a document by its [mimeType] (as reported on the intent's
+     * `type` or resolved from the content Uri) and its [fileName] (the
+     * Uri's last path segment or the DocumentFile display name). Either
+     * may be null/blank — a file manager that supplies neither yields
+     * [ImportKind.Unsupported].
+     */
+    fun classify(mimeType: String?, fileName: String?): ImportKind {
+        val mime = mimeType?.trim()?.lowercase()?.substringBefore(';')?.takeIf { it.isNotEmpty() }
+        val ext = fileName?.trim()?.lowercase()
+            ?.substringBefore('?')?.substringBefore('#')
+            ?.substringAfterLast('.', missingDelimiterValue = "")
+            ?.takeIf { it.isNotEmpty() }
+
+        // Mime is the strongest signal when it's specific.
+        when {
+            mime in EPUB_MIMES -> return ImportKind.Epub
+            mime in PDF_MIMES -> return pdfOrUnsupported()
+            mime == "text/plain" -> return ImportKind.Text
+        }
+
+        // Generic / wildcard mimes (octet-stream, text/*, or absent) —
+        // fall back to the filename extension.
+        when (ext) {
+            "epub" -> return ImportKind.Epub
+            "pdf" -> return pdfOrUnsupported()
+            "txt", "text", "md", "markdown" -> return ImportKind.Text
+        }
+
+        // A bare `text/*` (e.g. text/markdown) with no useful extension
+        // is still plaintext we can read aloud.
+        if (mime != null && mime.startsWith("text/")) return ImportKind.Text
+
+        return ImportKind.Unsupported
+    }
+
+    private fun pdfOrUnsupported(): ImportKind =
+        if (PDF_ENABLED) ImportKind.Pdf else ImportKind.Unsupported
+}

--- a/app/src/main/kotlin/in/jphe/storyvox/navigation/StoryvoxNavHost.kt
+++ b/app/src/main/kotlin/in/jphe/storyvox/navigation/StoryvoxNavHost.kt
@@ -2,6 +2,7 @@ package `in`.jphe.storyvox.navigation
 
 import android.content.Intent
 import android.net.Uri
+import androidx.core.content.IntentCompat
 import androidx.compose.animation.AnimatedContentTransitionScope
 import androidx.compose.animation.EnterTransition
 import androidx.compose.animation.ExitTransition
@@ -1394,6 +1395,45 @@ object DeepLinkResolver {
      *  screen pulls this off the nav arguments on first composition
      *  and pre-fills the sheet via `viewModel.openAddByUrlPrefilled`. */
     const val ARG_SHARED_URL = "sharedUrl"
+
+    /**
+     * Issue #1000 — extract the document Uri an "Open With" intent is
+     * carrying, or null if this intent isn't a file-import. Pure
+     * inspection (no ContentResolver, no permission grant); the
+     * side-effecting import — mime/name resolution,
+     * [takePersistableUriPermission], registering with the EPUB config,
+     * and the final navigate — lives in `MainActivity`, which has the
+     * injected deps. We return the Uri here only to keep the
+     * "what kind of intent is this?" decision in one place.
+     *
+     * Two shapes reach us:
+     *  - `ACTION_VIEW` with a `content://` (or `file://`) data Uri — the
+     *    file-manager "Open with Candela" path.
+     *  - `ACTION_SEND` carrying `EXTRA_STREAM` — the share-sheet
+     *    "Share → Candela" path for a file (the text/URL `EXTRA_TEXT`
+     *    share is #472, handled in [resolve]).
+     */
+    fun documentImportUri(intent: Intent): Uri? {
+        when (intent.action) {
+            Intent.ACTION_VIEW -> {
+                val data = intent.data ?: return null
+                if (data.scheme == "content" || data.scheme == "file") return data
+                return null
+            }
+            Intent.ACTION_SEND -> {
+                // IntentCompat handles the API-33 getParcelableExtra
+                // type-safe overload split without a deprecation warning.
+                val stream = IntentCompat.getParcelableExtra(
+                    intent,
+                    Intent.EXTRA_STREAM,
+                    Uri::class.java,
+                ) ?: return null
+                if (stream.scheme == "content" || stream.scheme == "file") return stream
+                return null
+            }
+            else -> return null
+        }
+    }
 
     fun resolve(intent: Intent): String? {
         // Notification tap → reader for the currently-playing chapter.

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1,4 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <string name="app_name">Candela</string>
+    <!-- Issue #1000 — chooser label shown for Candela in the Android
+         "Open with" / share sheet for EPUB & text documents. -->
+    <string name="open_with_label">Listen with Candela</string>
 </resources>

--- a/app/src/test/kotlin/in/jphe/storyvox/navigation/DocumentImportClassifierTest.kt
+++ b/app/src/test/kotlin/in/jphe/storyvox/navigation/DocumentImportClassifierTest.kt
@@ -1,0 +1,103 @@
+package `in`.jphe.storyvox.navigation
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+/**
+ * Issue #1000 — the (mime, filename) → [ImportKind] mapping is the
+ * load-bearing decision in the "Open With" path: it decides whether an
+ * inbound document is opened as an EPUB, read as plaintext, deferred to
+ * the PDF path (#996), or declined. Pure (no Android types), so it runs
+ * as a plain JUnit test — no Robolectric.
+ */
+class DocumentImportClassifierTest {
+
+    // ── EPUB ────────────────────────────────────────────────────────
+
+    @Test
+    fun epubMime_classifiesEpub() {
+        assertEquals(ImportKind.Epub, classify("application/epub+zip", "book.epub"))
+        assertEquals(ImportKind.Epub, classify("application/x-epub+zip", "book"))
+        assertEquals(ImportKind.Epub, classify("APPLICATION/EPUB+ZIP", "book.epub"))
+    }
+
+    @Test
+    fun epubExtension_withGenericMime_classifiesEpub() {
+        // The common file-manager case: octet-stream + a .epub name.
+        assertEquals(ImportKind.Epub, classify("application/octet-stream", "novel.epub"))
+        assertEquals(ImportKind.Epub, classify(null, "novel.EPUB"))
+    }
+
+    @Test
+    fun epubExtension_withSecondDot_classifiesEpub() {
+        assertEquals(ImportKind.Epub, classify(null, "book.v2.epub"))
+    }
+
+    // ── Text ────────────────────────────────────────────────────────
+
+    @Test
+    fun textPlainMime_classifiesText() {
+        assertEquals(ImportKind.Text, classify("text/plain", "notes.txt"))
+        assertEquals(ImportKind.Text, classify("text/plain; charset=utf-8", "notes.txt"))
+    }
+
+    @Test
+    fun textExtensions_withGenericMime_classifyText() {
+        assertEquals(ImportKind.Text, classify("application/octet-stream", "letter.txt"))
+        assertEquals(ImportKind.Text, classify(null, "letter.text"))
+        assertEquals(ImportKind.Text, classify(null, "README.md"))
+        assertEquals(ImportKind.Text, classify(null, "README.markdown"))
+    }
+
+    @Test
+    fun textWildcardMime_classifiesText() {
+        // text/markdown with no useful extension is still readable prose.
+        assertEquals(ImportKind.Text, classify("text/markdown", "doc"))
+    }
+
+    // ── PDF (gated on #996) ──────────────────────────────────────────
+
+    @Test
+    fun pdf_isUnsupportedWhileGated() {
+        // PDF_ENABLED is false until #996 lands — until then PDFs must
+        // NOT be opened (the EPUB parser would choke on the bytes).
+        assertEquals(false, DocumentImportClassifier.PDF_ENABLED)
+        assertEquals(ImportKind.Unsupported, classify("application/pdf", "report.pdf"))
+        assertEquals(ImportKind.Unsupported, classify(null, "report.pdf"))
+        assertEquals(ImportKind.Unsupported, classify("application/x-pdf", "report"))
+    }
+
+    // ── Unsupported / edge ───────────────────────────────────────────
+
+    @Test
+    fun unknownTypes_areUnsupported() {
+        assertEquals(ImportKind.Unsupported, classify("image/png", "photo.png"))
+        assertEquals(ImportKind.Unsupported, classify("application/zip", "archive.zip"))
+        assertEquals(ImportKind.Unsupported, classify(null, "data.bin"))
+    }
+
+    @Test
+    fun nothingToGoOn_isUnsupported() {
+        assertEquals(ImportKind.Unsupported, classify(null, null))
+        assertEquals(ImportKind.Unsupported, classify("", ""))
+        assertEquals(ImportKind.Unsupported, classify("   ", "   "))
+    }
+
+    @Test
+    fun mimeTakesPrecedenceOverMisleadingExtension() {
+        // A real EPUB mime wins even if the name lacks/contradicts it.
+        assertEquals(ImportKind.Epub, classify("application/epub+zip", "mystery.dat"))
+        // text/plain mime wins over a .epub-looking name.
+        assertEquals(ImportKind.Text, classify("text/plain", "weird.epub.txt"))
+    }
+
+    @Test
+    fun extensionWithQueryOrFragment_isStripped() {
+        // last-path-segment Uris sometimes still carry ?/# tails.
+        assertEquals(ImportKind.Epub, classify(null, "book.epub?token=abc"))
+        assertEquals(ImportKind.Text, classify(null, "notes.txt#section"))
+    }
+
+    private fun classify(mime: String?, name: String?): ImportKind =
+        DocumentImportClassifier.classify(mime, name)
+}

--- a/source-epub/src/main/kotlin/in/jphe/storyvox/source/epub/EpubSource.kt
+++ b/source-epub/src/main/kotlin/in/jphe/storyvox/source/epub/EpubSource.kt
@@ -13,8 +13,10 @@ import `in`.jphe.storyvox.data.source.model.FictionSummary
 import `in`.jphe.storyvox.data.source.model.ListPage
 import `in`.jphe.storyvox.data.source.model.SearchQuery
 import `in`.jphe.storyvox.source.epub.config.EpubConfig
+import `in`.jphe.storyvox.source.epub.config.EpubEntryKind
 import `in`.jphe.storyvox.source.epub.config.EpubFileEntry
 import `in`.jphe.storyvox.source.epub.parse.EpubBook
+import `in`.jphe.storyvox.source.epub.parse.EpubChapter
 import `in`.jphe.storyvox.source.epub.parse.EpubParseException
 import `in`.jphe.storyvox.source.epub.parse.EpubParser
 import javax.inject.Inject
@@ -196,12 +198,47 @@ internal class EpubSource @Inject constructor(
 
     private suspend fun parseBook(entry: EpubFileEntry): EpubBook? {
         val bytes = config.readBookBytes(entry.uriString) ?: return null
-        return try {
-            EpubParser.parseFromBytes(bytes)
-        } catch (_: EpubParseException) {
-            null
+        return when (entry.kind) {
+            EpubEntryKind.Epub -> try {
+                EpubParser.parseFromBytes(bytes)
+            } catch (_: EpubParseException) {
+                null
+            }
+            // Issue #1000 — a plaintext file imported via "Open With".
+            // No zip/OPF/spine; synthesise a single-chapter book from
+            // the UTF-8 body so the rest of the source (chapter list,
+            // chapter content, word count) flows through unchanged.
+            EpubEntryKind.Text -> textBook(entry, bytes)
         }
     }
+}
+
+/** Issue #1000 — wrap a plaintext file's bytes into a one-chapter
+ *  [EpubBook]. The body is HTML-escaped and dropped into a `<pre>`
+ *  block so the downstream HTML→plaintext stripper (which the engine
+ *  feeds from) round-trips it without mangling angle brackets or
+ *  collapsing the prose. Title is the filename sans extension. */
+private fun textBook(entry: EpubFileEntry, bytes: ByteArray): EpubBook {
+    val text = bytes.toString(Charsets.UTF_8)
+    val title = entry.displayName
+        .substringBeforeLast('.', missingDelimiterValue = entry.displayName)
+        .ifBlank { entry.displayName }
+    val escaped = text
+        .replace("&", "&amp;")
+        .replace("<", "&lt;")
+        .replace(">", "&gt;")
+    return EpubBook(
+        title = title,
+        author = "",
+        chapters = listOf(
+            EpubChapter(
+                id = "txt-0",
+                title = title,
+                index = 0,
+                htmlBody = "<pre>$escaped</pre>",
+            ),
+        ),
+    )
 }
 
 /** Compose a stable chapter id from the fictionId + the per-EPUB
@@ -212,7 +249,9 @@ private fun chapterIdFor(fictionId: String, idref: String): String =
 private fun EpubFileEntry.toSummary(): FictionSummary = FictionSummary(
     id = fictionId,
     sourceId = SourceIds.EPUB,
-    title = displayName.removeSuffix(".epub"),
+    // #1000 — strip the real extension (.epub/.txt/…) rather than only
+    // ".epub", so imported plaintext files show a clean browse title.
+    title = displayName.substringBeforeLast('.', missingDelimiterValue = displayName),
     author = "",
     description = displayName,
     status = FictionStatus.COMPLETED,

--- a/source-epub/src/main/kotlin/in/jphe/storyvox/source/epub/config/EpubConfig.kt
+++ b/source-epub/src/main/kotlin/in/jphe/storyvox/source/epub/config/EpubConfig.kt
@@ -41,6 +41,23 @@ interface EpubConfig {
 }
 
 /**
+ * Issue #1000 — what kind of document an indexed entry is, so the
+ * source knows how to turn its bytes into a book. Folder-enumerated
+ * entries are always [Epub]; the "Open With" import path (#1000) can
+ * also register a [Text] file, which the source wraps into a single-
+ * chapter book rather than running through the EPUB zip parser.
+ */
+enum class EpubEntryKind {
+    /** A real `.epub` — parse the zip/OPF/spine. */
+    Epub,
+
+    /** A plaintext file — synthesise a one-chapter book from the UTF-8
+     *  body (the reader/engine pipeline downstream is HTML-tolerant, so
+     *  the body is wrapped in a `<pre>` block). */
+    Text,
+}
+
+/**
  * One indexed EPUB file. The fictionId is a stable hash of the URI
  * string — same file at the same SAF path resolves to the same id
  * across re-launches. Display name comes from DocumentFile.getName()
@@ -51,6 +68,10 @@ data class EpubFileEntry(
     val fictionId: String,
     val uriString: String,
     val displayName: String,
+    /** Issue #1000 — how to read this entry's bytes into a book.
+     *  Defaults to [EpubEntryKind.Epub] so existing folder-enumeration
+     *  call sites (and any persisted state) keep their behaviour. */
+    val kind: EpubEntryKind = EpubEntryKind.Epub,
 )
 
 /** Issue #235 — derive the persistent fictionId from a SAF URI.


### PR DESCRIPTION
## What

Advertise Candela in the Android **"Open with"** / share sheet for **EPUB** and **plaintext** documents, so a low-vision or low-literacy user who receives a file can long-press → *Open with Candela* (or share an attachment to it) and hear it — no in-app navigation. The fastest "read this for me" path, and how most documents actually reach an accessibility reader (VDR parity, per Theia's analysis in #1000).

## How

- **AndroidManifest** (`MainActivity`):
  - `ACTION_VIEW` for `content://` / `file://` Uris by mime (`application/epub+zip`, `text/plain`) **and** by `.epub`/`.txt` filename extension (`pathPattern`), to catch the very common file-manager case of `application/octet-stream` or no mime at all.
  - `ACTION_SEND` for `application/epub+zip`. A shared `.txt` file rides the existing **#472** `text/plain` SEND filter — `documentImportUri` picks `EXTRA_STREAM` before `EXTRA_TEXT`, so a *file* share imports and a *URL* share still hits the #472 Magic-add path. One filter, both behaviours.
- **`DocumentImportClassifier`** — pure `(mime, filename) → ImportKind` mapping (Epub / Text / Pdf / Unsupported), mime-first with an extension fallback. Android-free, so it **unit-tests without Robolectric**.
- **`DeepLinkResolver.documentImportUri`** — pure detection of the inbound document Uri on `ACTION_VIEW` / `ACTION_SEND` (`EXTRA_STREAM` via `IntentCompat`, no deprecation).
- **`MainActivity.importDocument`** — resolves the mime + display name, classifies, calls `takePersistableUriPermission` (so re-opens from Library survive a relaunch), registers the file, and navigates to its fiction detail.
- **Reuses the `:source-epub` import path** — `EpubConfigImpl` gains a single-file import store merged into `books()`; `EpubSource` synthesises a one-chapter book from an imported plaintext file. `EpubFileEntry` gains a `kind` (defaults to `Epub`, so folder enumeration and any persisted state are unchanged).

## PDF — gated on #996 (deliberate)

PDF is **intentionally not advertised** yet: a chooser entry for a type we can't open is the exact dead-end #1000 warns against. The hook is left clean and tested:

1. Flip `DocumentImportClassifier.PDF_ENABLED` to `true`.
2. Add the `application/pdf` `<data>` rows + a `.pdf` `pathPattern` (the manifest comment marks exactly where).
3. Replace the `ImportKind.Pdf -> return null` branch in `importDocument()` with a call into `:source-pdf`.

No re-derivation — coordinated with Somnia on #996.

## Tests

`DocumentImportClassifierTest` — EPUB/Text by mime & by extension, second-dot filenames, mime-over-extension precedence, the PDF gate, `?`/`#` tail stripping, and the nothing-to-go-on case. `:source-epub` and `:app` data suites green.

```
./gradlew :source-epub:compileDebugKotlin   # BUILD SUCCESSFUL
./gradlew :app:compileDebugKotlin           # BUILD SUCCESSFUL
./gradlew :app:testDebugUnitTest --tests "in.jphe.storyvox.navigation.*"  # green
./gradlew :source-epub:testDebugUnitTest    # green
```

Closes #1000

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added "Listen with Candela" option in system apps and share sheets to open EPUB files and plaintext documents
  * Added support for displaying plaintext text files as readable books within the app
  * Improved document import management to persist imported files alongside folder-based libraries

* **Tests**
  * Added comprehensive tests for document type classification

<!-- end of auto-generated comment: release notes by coderabbit.ai -->