### PR TITLE
chore: point in-code repo URLs at techempower-org/candela

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -194,7 +194,7 @@ android {
         buildConfigField(
             "String",
             "SIGIL_REPO",
-            "\"https://github.com/techempower-org/storyvox\"",
+            "\"https://github.com/techempower-org/candela\"",
         )
     }
 

--- a/source-arxiv/src/main/kotlin/in/jphe/storyvox/source/arxiv/net/ArxivApi.kt
+++ b/source-arxiv/src/main/kotlin/in/jphe/storyvox/source/arxiv/net/ArxivApi.kt
@@ -196,7 +196,7 @@ internal class ArxivApi @Inject constructor(
         /** arXiv requests an identifying User-Agent on automated traffic
          *  (see https://info.arxiv.org/help/robots.html). */
         const val USER_AGENT: String =
-            "storyvox-arxiv/1.0 (https://github.com/techempower-org/storyvox; jp@jphein.com)"
+            "storyvox-arxiv/1.0 (https://github.com/techempower-org/candela; jp@jphein.com)"
     }
 }
 

--- a/source-discord/src/main/kotlin/in/jphe/storyvox/source/discord/config/DiscordDefaults.kt
+++ b/source-discord/src/main/kotlin/in/jphe/storyvox/source/discord/config/DiscordDefaults.kt
@@ -47,7 +47,7 @@ object DiscordDefaults {
      *  identify storyvox and the version so Discord's abuse team can
      *  reach out before banning a misbehaving bot. */
     const val USER_AGENT: String =
-        "Storyvox-Discord/1.0 (+https://github.com/techempower-org/storyvox)"
+        "Storyvox-Discord/1.0 (+https://github.com/techempower-org/candela)"
 
     /**
      * Issue #517 — Discord channel id for the TechEmpower peer-support

--- a/source-discord/src/test/kotlin/in/jphe/storyvox/source/discord/DiscordModelsTest.kt
+++ b/source-discord/src/test/kotlin/in/jphe/storyvox/source/discord/DiscordModelsTest.kt
@@ -229,7 +229,7 @@ class DiscordModelsTest {
                   {
                     "title": "Storyvox — narratable Discord",
                     "description": "16 backends, sideload-only audiobook reader",
-                    "url": "https://github.com/techempower-org/storyvox"
+                    "url": "https://github.com/techempower-org/candela"
                   }
                 ],
                 "tts": false,

--- a/source-github/src/main/kotlin/in/jphe/storyvox/source/github/registry/Registry.kt
+++ b/source-github/src/main/kotlin/in/jphe/storyvox/source/github/registry/Registry.kt
@@ -119,7 +119,7 @@ internal open class Registry @Inject constructor(
         const val REGISTRY_URL: String =
             "https://raw.githubusercontent.com/techempower-org/storyvox-registry/main/registry.json"
         const val USER_AGENT: String =
-            "storyvox/0.5 (+https://github.com/techempower-org/storyvox)"
+            "storyvox/0.5 (+https://github.com/techempower-org/candela)"
     }
 }
 

--- a/source-hackernews/src/main/kotlin/in/jphe/storyvox/source/hackernews/net/HackerNewsApi.kt
+++ b/source-hackernews/src/main/kotlin/in/jphe/storyvox/source/hackernews/net/HackerNewsApi.kt
@@ -189,7 +189,7 @@ internal open class HackerNewsApi @Inject constructor(
 
         /** Polite identifier — gives any future rate-limit hits a contact
          *  point. Matches the pattern used by `:source-gutenberg`. */
-        const val USER_AGENT = "storyvox-hackernews/1.0 (+https://github.com/techempower-org/storyvox)"
+        const val USER_AGENT = "storyvox-hackernews/1.0 (+https://github.com/techempower-org/candela)"
 
         /** Browse landing fetches the first 50 of ~500 top-story ids
          *  per #379's spec. Defined here so the source and tests share

--- a/source-matrix/src/main/kotlin/in/jphe/storyvox/source/matrix/config/MatrixDefaults.kt
+++ b/source-matrix/src/main/kotlin/in/jphe/storyvox/source/matrix/config/MatrixDefaults.kt
@@ -58,5 +58,5 @@ object MatrixDefaults {
      *  homeservers are commonly self-hosted on small hardware; a
      *  clear UA keeps storyvox from looking like an anonymous scrape. */
     const val USER_AGENT: String =
-        "Storyvox-Matrix/1.0 (+https://github.com/techempower-org/storyvox)"
+        "Storyvox-Matrix/1.0 (+https://github.com/techempower-org/candela)"
 }

--- a/source-notion/src/main/kotlin/in/jphe/storyvox/source/notion/config/NotionDefaults.kt
+++ b/source-notion/src/main/kotlin/in/jphe/storyvox/source/notion/config/NotionDefaults.kt
@@ -94,7 +94,7 @@ object NotionDefaults {
      * tooling can route concerns somewhere useful.
      */
     const val USER_AGENT: String =
-        "storyvox-notion/1.0 (+https://github.com/techempower-org/storyvox)"
+        "storyvox-notion/1.0 (+https://github.com/techempower-org/candela)"
 
     /**
      * Issue #393 / v0.5.26 — four-fiction layout for TechEmpower in

--- a/source-radio/src/main/kotlin/in/jphe/storyvox/source/radio/RadioSource.kt
+++ b/source-radio/src/main/kotlin/in/jphe/storyvox/source/radio/RadioSource.kt
@@ -413,7 +413,7 @@ internal class RadioSource @Inject constructor(
         const val LEGACY_KVMR_CHAPTER_ID: String = "kvmr:live:0"
 
         const val USER_AGENT: String =
-            "storyvox-radio/0.5.32 (+https://github.com/techempower-org/storyvox)"
+            "storyvox-radio/0.5.32 (+https://github.com/techempower-org/candela)"
 
         /**
          * Sentinel prefixes used by [applyFilters] to smuggle the

--- a/source-radio/src/main/kotlin/in/jphe/storyvox/source/radio/net/RadioBrowserApi.kt
+++ b/source-radio/src/main/kotlin/in/jphe/storyvox/source/radio/net/RadioBrowserApi.kt
@@ -216,7 +216,7 @@ internal class RadioBrowserApi @Inject constructor(
         const val BASE_URL: String = "https://de1.api.radio-browser.info"
 
         const val USER_AGENT: String =
-            "storyvox-radio/0.5.32 (+https://github.com/techempower-org/storyvox)"
+            "storyvox-radio/0.5.32 (+https://github.com/techempower-org/candela)"
     }
 }
 

--- a/source-radio/src/test/kotlin/in/jphe/storyvox/source/radio/RadioSourceTest.kt
+++ b/source-radio/src/test/kotlin/in/jphe/storyvox/source/radio/RadioSourceTest.kt
@@ -251,6 +251,6 @@ class RadioSourceTest {
 
     @Test fun `user-agent identifies storyvox-radio`() {
         assertTrue(RadioSource.USER_AGENT.contains("storyvox-radio"))
-        assertTrue(RadioSource.USER_AGENT.contains("github.com/techempower-org/storyvox"))
+        assertTrue(RadioSource.USER_AGENT.contains("github.com/techempower-org/candela"))
     }
 }

--- a/source-readability/src/main/kotlin/in/jphe/storyvox/source/readability/net/ReadabilityFetcher.kt
+++ b/source-readability/src/main/kotlin/in/jphe/storyvox/source/readability/net/ReadabilityFetcher.kt
@@ -79,6 +79,6 @@ class ReadabilityFetcher @Inject constructor(
         // Polite UA — identifies us as a personal audiobook reader so a
         // server admin who notices the traffic can see what it's for.
         // Same convention as the RSS / Wikipedia / Outline backends.
-        const val USER_AGENT = "storyvox-readability/1.0 (+https://github.com/techempower-org/storyvox)"
+        const val USER_AGENT = "storyvox-readability/1.0 (+https://github.com/techempower-org/candela)"
     }
 }

--- a/source-slack/src/main/kotlin/in/jphe/storyvox/source/slack/config/SlackDefaults.kt
+++ b/source-slack/src/main/kotlin/in/jphe/storyvox/source/slack/config/SlackDefaults.kt
@@ -27,7 +27,7 @@ object SlackDefaults {
      *  identifying ourselves makes abuse-team contact easier if a
      *  bot misbehaves. Mirrors the Discord / Telegram UA pattern. */
     const val USER_AGENT: String =
-        "Storyvox-Slack/1.0 (+https://github.com/techempower-org/storyvox)"
+        "Storyvox-Slack/1.0 (+https://github.com/techempower-org/candela)"
 
     /** `conversations.list` page size. Slack caps this at 1000 but
      *  recommends staying ≤200 for performance + rate-limit

--- a/source-telegram/src/main/kotlin/in/jphe/storyvox/source/telegram/config/TelegramDefaults.kt
+++ b/source-telegram/src/main/kotlin/in/jphe/storyvox/source/telegram/config/TelegramDefaults.kt
@@ -24,7 +24,7 @@ object TelegramDefaults {
      *  but identifying ourselves makes abuse-team contact easier
      *  if a bot misbehaves. Mirrors the Discord UA pattern. */
     const val USER_AGENT: String =
-        "Storyvox-Telegram/1.0 (+https://github.com/techempower-org/storyvox)"
+        "Storyvox-Telegram/1.0 (+https://github.com/techempower-org/candela)"
 
     /** Max messages per `getUpdates` poll. The API caps at 100;
      *  we pull the full window so a single poll reflects every


### PR DESCRIPTION
## What

The repo was renamed `techempower-org/storyvox` → `techempower-org/candela`. GitHub's rename redirect keeps the old links alive, but the in-code references were still stale. This updates the **bare repo URL** everywhere it appears in code (`app core-* source-*`).

Closes part of the post-rebrand cleanup (team task #46).

## Changes (14 files)

- **`SIGIL_REPO`** (`app/build.gradle.kts`) — feeds `Sigil.commitUrl` (`"$repo/commit/$hash"`), so the in-app "view source commit" link now targets the live repo directly instead of leaning on the GitHub rename redirect. This is the one change with user-facing runtime impact.
- **Per-source User-Agent contact URLs** — arxiv, discord, github, hackernews, matrix, notion, radio (×2), readability, slack, telegram.
- **Two lockstep test assertions** — `RadioSourceTest` UA assertion + `DiscordModelsTest` embed fixture.

## Preserved intentionally (out of scope)

- package namespace `in.jphe.storyvox`
- `storyvox://` deep-link scheme
- the `storyvox-registry` raw URL in `source-github/Registry.kt` (separate rename decision — team task #47)
- `storyvox-*` User-Agent **product tokens** — only the repo-URL portion of each UA changed; the tokens may be server-allowlisted, so leaving them stable avoids any chance of a 403
- historical docs

The transform was anchored on `github.com/techempower-org/storyvox` followed by a non-hyphen char, so `storyvox-registry` is provably untouched (verified: the only remaining `techempower-org/storyvox` matches in code are the 3 `storyvox-registry` references).

## Verification

- `:source-radio:testDebugUnitTest` + `:source-discord:testDebugUnitTest` — **pass** with updated assertions
- Other 8 touched modules — `compileDebugKotlin` **clean**
- Build APK gate runs in CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chore**
  * Updated repository references in build configuration and HTTP user-agent identifiers across multiple data source modules for consistency.
  * Applied to all platform integrations to maintain accurate project metadata throughout the application.
  * Changes affect the metadata reported when the application communicates with external services.

* **Tests**
  * Updated test fixtures and assertions to validate the updated repository references.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->