### PR TITLE
feat: OCR scan-to-read — camera → text → audio (#995)

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -543,6 +543,12 @@ dependencies {
     implementation(project(":source-rss"))
     implementation(project(":source-epub"))
     implementation(project(":source-epub-writer"))
+    // Issue #995 — OCR scan-to-read. The app hosts the ML Kit
+    // recognizer impl (MlKitOcrTextRecognizer) + the DataStore-backed
+    // OcrConfig / OcrDocumentStore; the source module + the :core-data
+    // OcrTextRecognizer seam carry the Android-free contracts.
+    implementation(project(":source-ocr"))
+    implementation(libs.mlkit.text.recognition)
     implementation(project(":source-outline"))
     implementation(project(":source-gutenberg"))
     implementation(project(":source-ao3"))

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -18,6 +18,21 @@
     <uses-permission android:name="android.permission.POST_NOTIFICATIONS" />
     <uses-permission android:name="android.permission.RECEIVE_BOOT_COMPLETED" />
 
+    <!-- Issue #995 — OCR scan-to-read. CAMERA is requested at runtime
+         with a plain-language rationale before the system prompt; a
+         denied camera never dead-ends the feature (the gallery-pick
+         path needs no permission). The camera feature is OPTIONAL so a
+         WiFi-only tablet without a rear camera still installs and uses
+         the gallery path — same required="false" posture as telephony
+         above. -->
+    <uses-permission android:name="android.permission.CAMERA" />
+    <uses-feature
+        android:name="android.hardware.camera.any"
+        android:required="false" />
+    <uses-feature
+        android:name="android.hardware.camera.autofocus"
+        android:required="false" />
+
     <!-- Issue #546 / #775 — telephony is OPTIONAL. The TechEmpower
          "Call 211" card (and the matching top-app-bar phone icon)
          dials only on devices with telephony hardware (phones, not

--- a/app/src/main/kotlin/in/jphe/storyvox/data/OcrConfigImpl.kt
+++ b/app/src/main/kotlin/in/jphe/storyvox/data/OcrConfigImpl.kt
@@ -1,0 +1,170 @@
+package `in`.jphe.storyvox.data
+
+import android.content.Context
+import androidx.datastore.core.DataStore
+import androidx.datastore.preferences.core.Preferences
+import androidx.datastore.preferences.core.edit
+import androidx.datastore.preferences.core.stringPreferencesKey
+import androidx.datastore.preferences.preferencesDataStore
+import dagger.hilt.android.qualifiers.ApplicationContext
+import `in`.jphe.storyvox.source.ocr.config.OcrConfig
+import `in`.jphe.storyvox.source.ocr.config.OcrDocument
+import `in`.jphe.storyvox.source.ocr.config.OcrDocumentStore
+import `in`.jphe.storyvox.source.ocr.config.OcrPage
+import `in`.jphe.storyvox.source.ocr.config.fictionIdForOcrCapture
+import java.util.UUID
+import javax.inject.Inject
+import javax.inject.Singleton
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.distinctUntilChanged
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.flow.map
+import kotlinx.serialization.SerializationException
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.builtins.ListSerializer
+import kotlinx.serialization.json.Json
+
+private val Context.ocrDataStore: DataStore<Preferences> by preferencesDataStore(
+    name = "storyvox_ocr_documents",
+)
+
+private object OcrKeys {
+    /**
+     * JSON-encoded `List<OcrDocumentDto>` of the user's scanned
+     * documents. Single key because the set is small (a user scans a
+     * handful of letters / pages), and a scanned document is the
+     * canonical content — there's no upstream file to re-read, so the
+     * recognized text lives here. Same JSON-blob shape as
+     * [RadioConfigImpl]'s starred-stations store.
+     */
+    val DOCUMENTS = stringPreferencesKey("pref_ocr_documents")
+}
+
+/**
+ * Issue #995 — production [OcrConfig] (read) + [OcrDocumentStore]
+ * (write) backed by a dedicated DataStore (`storyvox_ocr_documents`).
+ *
+ * The OCR source persists its own content because a camera capture is
+ * transient — unlike `:source-epub` (re-reads SAF bytes) or
+ * `:source-rss` (re-fetches the feed), the recognized text IS the
+ * artifact. Documents are stored newest-first.
+ *
+ * Forward-compat: `ignoreUnknownKeys = true` tolerates a future schema
+ * extension (per-page source-image thumbnail, OCR confidence, etc.); a
+ * corrupt blob drops back to an empty list rather than failing the
+ * source load.
+ */
+@Singleton
+class OcrConfigImpl internal constructor(
+    private val store: DataStore<Preferences>,
+    private val now: () -> Long,
+    private val nonce: () -> String,
+) : OcrConfig, OcrDocumentStore {
+
+    @Inject constructor(@ApplicationContext context: Context) : this(
+        store = context.ocrDataStore,
+        now = { System.currentTimeMillis() },
+        nonce = { UUID.randomUUID().toString().take(8) },
+    )
+
+    private val json = Json { ignoreUnknownKeys = true; encodeDefaults = true }
+
+    override val documents: Flow<List<OcrDocument>> = store.data
+        .map { prefs -> decode(prefs[OcrKeys.DOCUMENTS]) }
+        .distinctUntilChanged()
+
+    override suspend fun documents(): List<OcrDocument> =
+        decode(store.data.first()[OcrKeys.DOCUMENTS])
+
+    override suspend fun document(fictionId: String): OcrDocument? =
+        documents().firstOrNull { it.fictionId == fictionId }
+
+    override suspend fun save(title: String, pages: List<OcrPage>): String {
+        val createdAt = now()
+        val fictionId = fictionIdForOcrCapture(createdAt, nonce())
+        val doc = OcrDocument(
+            fictionId = fictionId,
+            title = title,
+            createdAt = createdAt,
+            pages = pages,
+        )
+        store.edit { prefs ->
+            val current = decode(prefs[OcrKeys.DOCUMENTS])
+            // Newest first.
+            prefs[OcrKeys.DOCUMENTS] = encode(listOf(doc) + current)
+        }
+        return fictionId
+    }
+
+    override suspend fun delete(fictionId: String) {
+        store.edit { prefs ->
+            val current = decode(prefs[OcrKeys.DOCUMENTS])
+            prefs[OcrKeys.DOCUMENTS] = encode(current.filterNot { it.fictionId == fictionId })
+        }
+    }
+
+    // ─── (de)serialization ──────────────────────────────────────────────
+
+    private fun decode(blob: String?): List<OcrDocument> {
+        if (blob.isNullOrBlank()) return emptyList()
+        return try {
+            json.decodeFromString(ListSerializer(OcrDocumentDto.serializer()), blob)
+                .map { it.toModel() }
+        } catch (_: SerializationException) {
+            emptyList()
+        }
+    }
+
+    private fun encode(docs: List<OcrDocument>): String =
+        json.encodeToString(
+            ListSerializer(OcrDocumentDto.serializer()),
+            docs.map { OcrDocumentDto.fromModel(it) },
+        )
+
+    companion object {
+        /** Test factory — deterministic clock + nonce so persistence
+         *  round-trips are assertable without Robolectric. */
+        internal fun forTesting(
+            store: DataStore<Preferences>,
+            now: () -> Long = { 0L },
+            nonce: () -> String = { "test" },
+        ): OcrConfigImpl = OcrConfigImpl(store, now, nonce)
+    }
+}
+
+@Serializable
+private data class OcrDocumentDto(
+    val fictionId: String,
+    val title: String,
+    val createdAt: Long,
+    val pages: List<OcrPageDto>,
+) {
+    fun toModel() = OcrDocument(
+        fictionId = fictionId,
+        title = title,
+        createdAt = createdAt,
+        pages = pages.map { it.toModel() },
+    )
+
+    companion object {
+        fun fromModel(d: OcrDocument) = OcrDocumentDto(
+            fictionId = d.fictionId,
+            title = d.title,
+            createdAt = d.createdAt,
+            pages = d.pages.map { OcrPageDto.fromModel(it) },
+        )
+    }
+}
+
+@Serializable
+private data class OcrPageDto(
+    val index: Int,
+    val title: String,
+    val text: String,
+) {
+    fun toModel() = OcrPage(index = index, title = title, text = text)
+
+    companion object {
+        fun fromModel(p: OcrPage) = OcrPageDto(index = p.index, title = p.title, text = p.text)
+    }
+}

--- a/app/src/main/kotlin/in/jphe/storyvox/data/ocr/MlKitOcrTextRecognizer.kt
+++ b/app/src/main/kotlin/in/jphe/storyvox/data/ocr/MlKitOcrTextRecognizer.kt
@@ -1,0 +1,67 @@
+package `in`.jphe.storyvox.data.ocr
+
+import android.graphics.BitmapFactory
+import com.google.mlkit.vision.common.InputImage
+import com.google.mlkit.vision.text.TextRecognition
+import com.google.mlkit.vision.text.latin.TextRecognizerOptions
+import javax.inject.Inject
+import javax.inject.Singleton
+import kotlin.coroutines.resume
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.suspendCancellableCoroutine
+import kotlinx.coroutines.withContext
+
+/**
+ * Issue #995 — production [OcrTextRecognizer] backed by Google ML Kit's
+ * bundled Latin-script Text Recognition v2 model.
+ *
+ * Bundled (not Play-Services-downloaded) so the first scan works
+ * offline with no model fetch — the right posture for an accessibility
+ * tool used in low-connectivity settings. Runs entirely on-device:
+ * nothing about the user's scanned letter / medicine label / form
+ * leaves the phone.
+ *
+ * The ML Kit `Text` result preserves reading-order line breaks; we keep
+ * those in [OcrRecognition.text] and map each `Text.TextBlock` to an
+ * [OcrBlock] so the `:source-ocr` parser can reflow on paragraph
+ * boundaries. This is the same recognizer #996's scanned-PDF importer
+ * reuses (it renders each PDF page to a bitmap → bytes → here).
+ */
+@Singleton
+class MlKitOcrTextRecognizer @Inject constructor() : OcrTextRecognizer {
+
+    // The default-options Latin recognizer is process-wide reusable.
+    private val client by lazy {
+        TextRecognition.getClient(TextRecognizerOptions.DEFAULT_OPTIONS)
+    }
+
+    override suspend fun recognize(image: OcrImage): OcrResult {
+        val inputImage = withContext(Dispatchers.Default) {
+            val bitmap = BitmapFactory.decodeByteArray(image.bytes, 0, image.bytes.size)
+                ?: return@withContext null
+            InputImage.fromBitmap(bitmap, normalizeRotation(image.rotationDegrees))
+        } ?: return OcrResult.Failure("Couldn't read that image.")
+
+        return suspendCancellableCoroutine { cont ->
+            client.process(inputImage)
+                .addOnSuccessListener { visionText ->
+                    val blocks = visionText.textBlocks.map { block ->
+                        OcrBlock(text = block.text)
+                    }
+                    cont.resume(OcrResult.Success(OcrRecognition(text = visionText.text, blocks = blocks)))
+                }
+                .addOnFailureListener { e ->
+                    cont.resume(OcrResult.Failure("Text recognition failed.", e))
+                }
+        }
+    }
+
+    /** ML Kit's InputImage accepts only 0/90/180/270. Snap anything
+     *  else to the nearest right angle. */
+    private fun normalizeRotation(degrees: Int): Int = when (((degrees % 360) + 360) % 360) {
+        in 45 until 135 -> 90
+        in 135 until 225 -> 180
+        in 225 until 315 -> 270
+        else -> 0
+    }
+}

--- a/app/src/main/kotlin/in/jphe/storyvox/di/AppBindings.kt
+++ b/app/src/main/kotlin/in/jphe/storyvox/di/AppBindings.kt
@@ -191,6 +191,24 @@ object AppBindings {
     @Provides @Singleton
     fun provideEpubConfig(impl: `in`.jphe.storyvox.data.EpubConfigImpl): `in`.jphe.storyvox.source.epub.config.EpubConfig = impl
 
+    /** Issue #995 — bridges the source-ocr [OcrConfig] read interface
+     *  to the concrete app-side DataStore-backed impl. The same impl
+     *  also serves the [OcrDocumentStore] write side (see
+     *  [provideOcrDocumentStore]) — one DataStore, two facets. */
+    @Provides @Singleton
+    fun provideOcrConfig(impl: `in`.jphe.storyvox.data.OcrConfigImpl): `in`.jphe.storyvox.source.ocr.config.OcrConfig = impl
+
+    /** Issue #995 — write side of the OCR store, consumed by the
+     *  capture flow's ViewModel to persist a finished scan. */
+    @Provides @Singleton
+    fun provideOcrDocumentStore(impl: `in`.jphe.storyvox.data.OcrConfigImpl): `in`.jphe.storyvox.source.ocr.config.OcrDocumentStore = impl
+
+    /** Issue #995 — bridges the :core-data [OcrTextRecognizer] seam to
+     *  the bundled, offline ML Kit Latin recognizer. Shared by the
+     *  camera/gallery capture flow (#995) and #996's scanned-PDF import. */
+    @Provides @Singleton
+    fun provideOcrTextRecognizer(impl: `in`.jphe.storyvox.data.ocr.MlKitOcrTextRecognizer): `in`.jphe.storyvox.data.ocr.OcrTextRecognizer = impl
+
     /** Bridges source-outline OutlineConfig (#245) to the app-side
      *  DataStore + EncryptedSharedPreferences impl. */
     @Provides @Singleton

--- a/app/src/main/kotlin/in/jphe/storyvox/navigation/StoryvoxNavHost.kt
+++ b/app/src/main/kotlin/in/jphe/storyvox/navigation/StoryvoxNavHost.kt
@@ -72,6 +72,10 @@ object StoryvoxRoutes {
     const val LIBRARY = "library"
     const val FOLLOWS = "follows"
     const val BROWSE = "browse"
+    /** Issue #995 — OCR scan-to-read capture surface. Reached from the
+     *  Library add-flow ("Scan a page"); CameraX / gallery capture →
+     *  on-device ML Kit OCR → a fiction the reader narrates. */
+    const val OCR_CAPTURE = "ocr/capture"
     const val FICTION_DETAIL = "fiction/{fictionId}"
     const val READER = "reader/{fictionId}/{chapterId}"
     const val AUDIOBOOK = "audiobook/{fictionId}/{chapterId}"
@@ -722,6 +726,9 @@ private fun StoryvoxNavHostContent(
                     sharedUrl = sharedUrl,
                     onOpenFiction = { id -> navController.navigate(StoryvoxRoutes.fictionDetail(id)) },
                     onOpenReader = { f, c -> navController.navigate(StoryvoxRoutes.reader(f, c)) },
+                    // Issue #995 — "Scan a page" add-flow entry routes to
+                    // the OCR capture surface.
+                    onScanPage = { navController.navigate(StoryvoxRoutes.OCR_CAPTURE) },
                     // v0.5.72 — Browse is a first-class bottom-nav tab
                     // now; the standalone Browse route owns RR + AO3
                     // sign-in deep-links. Follows is still embedded
@@ -783,6 +790,27 @@ private fun StoryvoxNavHostContent(
                 FollowsScreen(
                     onOpenFiction = { id -> navController.navigate(StoryvoxRoutes.fictionDetail(id)) },
                     onOpenSignIn = { navController.navigate(StoryvoxRoutes.authWebView(SourceIds.ROYAL_ROAD)) },
+                )
+            }
+            composable(
+                // Issue #995 — OCR scan-to-read capture surface.
+                StoryvoxRoutes.OCR_CAPTURE,
+                enterTransition = pushEnter,
+                exitTransition = pushExit,
+                popEnterTransition = popEnter,
+                popExitTransition = popExit,
+            ) {
+                `in`.jphe.storyvox.feature.ocr.OcrCaptureScreen(
+                    onNavigateBack = { navController.popBackStack() },
+                    onScanComplete = { fictionId ->
+                        // Land on the new scanned document's detail page —
+                        // the standard landing for any freshly-added
+                        // fiction — and drop the capture screen from the
+                        // back stack so Back returns to the Library.
+                        navController.navigate(StoryvoxRoutes.fictionDetail(fictionId)) {
+                            popUpTo(StoryvoxRoutes.OCR_CAPTURE) { inclusive = true }
+                        }
+                    },
                 )
             }
             composable(

--- a/app/src/test/kotlin/in/jphe/storyvox/data/OcrConfigImplTest.kt
+++ b/app/src/test/kotlin/in/jphe/storyvox/data/OcrConfigImplTest.kt
@@ -1,0 +1,91 @@
+package `in`.jphe.storyvox.data
+
+import androidx.datastore.preferences.core.PreferenceDataStoreFactory
+import `in`.jphe.storyvox.source.ocr.config.OcrPage
+import java.io.File
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Rule
+import org.junit.Test
+import org.junit.rules.TemporaryFolder
+
+/**
+ * Issue #995 — OcrConfigImpl persistence round-trip over a temp-file
+ * DataStore (no Robolectric — same temp-file PreferenceDataStoreFactory
+ * pattern the SettingsRepository tests use). Verifies a scanned
+ * document survives encode→decode, ordering is newest-first, and a
+ * delete removes only the targeted document.
+ */
+class OcrConfigImplTest {
+
+    @get:Rule val tmp = TemporaryFolder()
+
+    private fun newConfig(now: () -> Long, nonce: () -> String): OcrConfigImpl {
+        val file = File(tmp.newFolder(), "ocr.preferences_pb")
+        val store = PreferenceDataStoreFactory.create { file }
+        return OcrConfigImpl.forTesting(store = store, now = now, nonce = nonce)
+    }
+
+    @Test
+    fun `saved document round-trips with its pages`() = runTest {
+        var clock = 100L
+        val config = newConfig(now = { clock }, nonce = { "n" })
+
+        val id = config.save(
+            title = "My letter",
+            pages = listOf(
+                OcrPage(0, "Page 1", "Dear friend, hello."),
+                OcrPage(1, "Page 2", "Yours, me."),
+            ),
+        )
+
+        val loaded = config.document(id)
+        assertTrue(loaded != null)
+        assertEquals("My letter", loaded!!.title)
+        assertEquals(2, loaded.pages.size)
+        assertEquals("Dear friend, hello.", loaded.pages[0].text)
+        assertEquals("Yours, me.", loaded.pages[1].text)
+        assertTrue(id.startsWith("ocr:"))
+    }
+
+    @Test
+    fun `documents are listed newest-first`() = runTest {
+        var clock = 0L
+        val config = newConfig(now = { clock }, nonce = { clock.toString() })
+
+        clock = 1L
+        val first = config.save("First", listOf(OcrPage(0, "P", "a")))
+        clock = 2L
+        val second = config.save("Second", listOf(OcrPage(0, "P", "b")))
+
+        val docs = config.documents()
+        assertEquals(listOf(second, first), docs.map { it.fictionId })
+        assertEquals("Second", docs[0].title)
+    }
+
+    @Test
+    fun `delete removes only the targeted document`() = runTest {
+        var clock = 0L
+        val config = newConfig(now = { clock }, nonce = { clock.toString() })
+        clock = 1L
+        val keep = config.save("Keep", listOf(OcrPage(0, "P", "x")))
+        clock = 2L
+        val drop = config.save("Drop", listOf(OcrPage(0, "P", "y")))
+
+        config.delete(drop)
+
+        val docs = config.documents()
+        assertEquals(1, docs.size)
+        assertEquals(keep, docs[0].fictionId)
+        assertNull(config.document(drop))
+    }
+
+    @Test
+    fun `empty store lists no documents`() = runTest {
+        val config = newConfig(now = { 0L }, nonce = { "x" })
+        assertTrue(config.documents().isEmpty())
+        assertNull(config.document("ocr:anything"))
+    }
+}

--- a/app/src/test/kotlin/in/jphe/storyvox/data/OcrConfigImplTest.kt
+++ b/app/src/test/kotlin/in/jphe/storyvox/data/OcrConfigImplTest.kt
@@ -41,9 +41,8 @@ class OcrConfigImplTest {
             ),
         )
 
-        val loaded = config.document(id)
-        assertTrue(loaded != null)
-        assertEquals("My letter", loaded!!.title)
+        val loaded = requireNotNull(config.document(id)) { "document should round-trip" }
+        assertEquals("My letter", loaded.title)
         assertEquals(2, loaded.pages.size)
         assertEquals("Dear friend, hello.", loaded.pages[0].text)
         assertEquals("Yours, me.", loaded.pages[1].text)

--- a/core-data/src/main/kotlin/in/jphe/storyvox/data/ocr/OcrTextRecognizer.kt
+++ b/core-data/src/main/kotlin/in/jphe/storyvox/data/ocr/OcrTextRecognizer.kt
@@ -1,0 +1,121 @@
+package `in`.jphe.storyvox.data.ocr
+
+/**
+ * Issue #995 — on-device OCR (optical character recognition) seam.
+ *
+ * Turns an image of printed text into recognized text. The production
+ * implementation (`MlKitOcrTextRecognizer` in `:app`) wraps Google ML
+ * Kit's bundled, offline Latin-script Text Recognition v2 model — no
+ * network, privacy-preserving, works in low-connectivity settings.
+ * That matters for the accessibility audience this feature serves
+ * (blind / low-vision / dyslexic users turning a printed letter,
+ * textbook, form, or medicine label into audio).
+ *
+ * ## Why this lives in :core-data
+ *
+ * Both `:source-ocr` (camera / gallery capture → fiction, #995) and
+ * `:source-pdf` (scanned-PDF import, #996) need OCR. Putting the
+ * interface here — alongside [`in`.jphe.storyvox.data.source.FictionSource]
+ * and [`in`.jphe.storyvox.data.source.WebViewFetcher] — lets both leaf
+ * source modules depend on the seam without depending on each other
+ * (the leaf-source architecture forbids source↔source deps). The PDF
+ * importer renders each page to a bitmap, hands the bytes here, and
+ * reuses the exact same recognizer the camera flow uses.
+ *
+ * ## Android-types-free by design
+ *
+ * The interface deals in [OcrImage] (raw encoded bytes + rotation) so
+ * the seam carries no `android.graphics.Bitmap` / `InputImage`
+ * dependency. That keeps `:core-data` and `:source-ocr` unit-testable
+ * without Robolectric — tests inject a fake recognizer that returns
+ * canned [OcrRecognition]s (same posture as the EPUB `EpubFileReader`
+ * fake in `:app`). The ML Kit impl decodes the bytes to an
+ * `InputImage` on its side.
+ */
+interface OcrTextRecognizer {
+
+    /**
+     * Recognize text in [image].
+     *
+     * Implementations run entirely on-device and should be safe to call
+     * from a background dispatcher. Recognition of a blank / textless
+     * image is NOT an error — it returns an [OcrRecognition] with empty
+     * [OcrRecognition.text] and no [OcrRecognition.blocks]. Genuine
+     * failures (model load failure, undecodable bytes) surface as
+     * [OcrResult.Failure] so callers can show a recoverable error
+     * rather than crashing.
+     */
+    suspend fun recognize(image: OcrImage): OcrResult
+}
+
+/**
+ * One image to OCR. [bytes] are the encoded image (JPEG or PNG — what
+ * CameraX `ImageCapture` writes, or what a gallery `content://` Uri
+ * yields). [rotationDegrees] is the EXIF / sensor rotation (0, 90, 180,
+ * 270); ML Kit needs it to read sideways captures correctly. Callers
+ * that have already rotated the bytes upright pass 0.
+ */
+data class OcrImage(
+    val bytes: ByteArray,
+    val rotationDegrees: Int = 0,
+) {
+    // Value-based equals/hashCode so test assertions and de-dup work on
+    // the byte content rather than array identity.
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (other !is OcrImage) return false
+        return rotationDegrees == other.rotationDegrees && bytes.contentEquals(other.bytes)
+    }
+
+    override fun hashCode(): Int = 31 * bytes.contentHashCode() + rotationDegrees
+}
+
+/** Result of one [OcrTextRecognizer.recognize] call. */
+sealed interface OcrResult {
+
+    /**
+     * Recognition completed. [recognition] may be empty (a blank page);
+     * that is a successful recognition of "no text", not a failure.
+     */
+    data class Success(val recognition: OcrRecognition) : OcrResult
+
+    /**
+     * Recognition could not run — model unavailable, image undecodable,
+     * etc. [message] is user-facing; [cause] carries the original
+     * throwable for logging.
+     */
+    data class Failure(val message: String, val cause: Throwable? = null) : OcrResult
+}
+
+/**
+ * Recognized text from one image.
+ *
+ * [text] is the full recognized text with ML Kit's reading-order line
+ * breaks preserved — good enough to narrate directly. [blocks] are the
+ * recognizer's paragraph-level clusters (ML Kit `Text.TextBlock`s),
+ * each a contiguous run of text with an optional confidence. The
+ * `:source-ocr` parser uses blocks to decide paragraph boundaries when
+ * assembling a chapter; #996's PDF importer can map one block-cluster
+ * per page region.
+ */
+data class OcrRecognition(
+    val text: String,
+    val blocks: List<OcrBlock> = emptyList(),
+) {
+    /** True when the recognizer found no usable text (blank page). */
+    val isEmpty: Boolean get() = text.isBlank() && blocks.all { it.text.isBlank() }
+
+    companion object {
+        val EMPTY = OcrRecognition(text = "", blocks = emptyList())
+    }
+}
+
+/**
+ * One recognized paragraph cluster. [confidence] is 0..1 when the
+ * recognizer reports it (ML Kit does not always populate per-block
+ * confidence; null means "unknown", not "zero").
+ */
+data class OcrBlock(
+    val text: String,
+    val confidence: Float? = null,
+)

--- a/core-data/src/main/kotlin/in/jphe/storyvox/data/source/SourceIds.kt
+++ b/core-data/src/main/kotlin/in/jphe/storyvox/data/source/SourceIds.kt
@@ -30,6 +30,12 @@ object SourceIds {
      *  source enumerates .epub files there as fictions. Zero-network,
      *  user-owned-content backend. */
     const val EPUB: String = "epub"
+    /** OCR scan-to-read (#995) — user captures printed text with the
+     *  camera (or picks an image) and on-device ML Kit OCR turns it
+     *  into a fiction (one capture session = one fiction; each captured
+     *  page = one chapter). Zero-network, user-owned-content backend.
+     *  The assistive-tech bridge from the printed world to audio. */
+    const val OCR: String = "ocr"
     /** Outline (#245) — self-hosted wiki. User configures host +
      *  API token; collections become fictions, documents become
      *  chapters. Zero third-party ToS surface. */

--- a/feature/build.gradle.kts
+++ b/feature/build.gradle.kts
@@ -83,6 +83,14 @@ dependencies {
     // one place (the source module that owns the URL composition rule).
     implementation(project(":source-rss"))
 
+    // Issue #995 — OCR scan-to-read. The capture screen consumes the
+    // OcrDocumentStore / OcrPage types + OcrTextParser to turn a ML Kit
+    // recognition into a persisted document; the recognizer itself
+    // comes from :core-data (the OcrTextRecognizer seam). CameraX drives
+    // the capture surface (camera-view's PreviewView + CameraController).
+    implementation(project(":source-ocr"))
+    implementation(libs.bundles.camerax)
+
     implementation(libs.androidx.core.ktx)
     implementation(libs.bundles.lifecycle)
     implementation(libs.bundles.coroutines)

--- a/feature/src/main/kotlin/in/jphe/storyvox/feature/library/LibraryScreen.kt
+++ b/feature/src/main/kotlin/in/jphe/storyvox/feature/library/LibraryScreen.kt
@@ -21,6 +21,7 @@ import androidx.compose.foundation.lazy.grid.itemsIndexed
 import androidx.compose.foundation.lazy.items
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Add
+import androidx.compose.material.icons.filled.DocumentScanner
 import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.Badge
 import androidx.compose.material3.BadgedBox
@@ -127,6 +128,12 @@ fun LibraryScreen(
      * preview surfaces that don't exercise the hero still compile.
      */
     onOpenTechEmpower: () -> Unit = {},
+    /**
+     * Issue #995 — "Scan a page" add-flow entry. Routes to the OCR
+     * capture surface ([StoryvoxRoutes.OCR_CAPTURE]). Default no-op so
+     * test / preview surfaces that don't exercise it still compile.
+     */
+    onScanPage: () -> Unit = {},
     viewModel: LibraryViewModel = hiltViewModel(),
 ) {
     val state by viewModel.uiState.collectAsStateWithLifecycle()
@@ -235,35 +242,54 @@ fun LibraryScreen(
             )
         },
         floatingActionButton = {
-            // Issue #1003 — the + now offers two ways in: add a fiction by
+            // Issue #995 + #1003 — stacked add affordances. The smaller
+            // "Scan a page" FAB sits above the primary add FAB: scan-to-read
+            // is the highest-leverage accessibility entry, so it gets a
+            // visible top-level affordance rather than living only in a sheet.
+            // The primary FAB keeps #1003's DropdownMenu — add a fiction by
             // URL (the original flow) or make your own audiobook from pasted
-            // text. A compact DropdownMenu keeps the single, familiar FAB.
-            androidx.compose.foundation.layout.Box {
-                FloatingActionButton(
-                    onClick = { addMenuOpen = true },
-                    containerColor = MaterialTheme.colorScheme.primary,
-                    contentColor = MaterialTheme.colorScheme.onPrimary,
+            // text — so all three entry points coexist on the single corner.
+            Column(
+                horizontalAlignment = androidx.compose.ui.Alignment.End,
+                verticalArrangement = Arrangement.spacedBy(LocalSpacing.current.sm),
+            ) {
+                androidx.compose.material3.SmallFloatingActionButton(
+                    onClick = onScanPage,
+                    containerColor = MaterialTheme.colorScheme.secondaryContainer,
+                    contentColor = MaterialTheme.colorScheme.onSecondaryContainer,
                 ) {
-                    Icon(Icons.Filled.Add, contentDescription = "Add to library")
+                    Icon(
+                        Icons.Filled.DocumentScanner,
+                        contentDescription = stringResource(R.string.library_scan_page_cd),
+                    )
                 }
-                androidx.compose.material3.DropdownMenu(
-                    expanded = addMenuOpen,
-                    onDismissRequest = { addMenuOpen = false },
-                ) {
-                    androidx.compose.material3.DropdownMenuItem(
-                        text = { Text("Add by URL") },
-                        onClick = {
-                            addMenuOpen = false
-                            viewModel.showAddByUrl()
-                        },
-                    )
-                    androidx.compose.material3.DropdownMenuItem(
-                        text = { Text("Make your own audiobook") },
-                        onClick = {
-                            addMenuOpen = false
-                            createAudiobookOpen = true
-                        },
-                    )
+                androidx.compose.foundation.layout.Box {
+                    FloatingActionButton(
+                        onClick = { addMenuOpen = true },
+                        containerColor = MaterialTheme.colorScheme.primary,
+                        contentColor = MaterialTheme.colorScheme.onPrimary,
+                    ) {
+                        Icon(Icons.Filled.Add, contentDescription = "Add to library")
+                    }
+                    androidx.compose.material3.DropdownMenu(
+                        expanded = addMenuOpen,
+                        onDismissRequest = { addMenuOpen = false },
+                    ) {
+                        androidx.compose.material3.DropdownMenuItem(
+                            text = { Text("Add by URL") },
+                            onClick = {
+                                addMenuOpen = false
+                                viewModel.showAddByUrl()
+                            },
+                        )
+                        androidx.compose.material3.DropdownMenuItem(
+                            text = { Text("Make your own audiobook") },
+                            onClick = {
+                                addMenuOpen = false
+                                createAudiobookOpen = true
+                            },
+                        )
+                    }
                 }
             }
         },

--- a/feature/src/main/kotlin/in/jphe/storyvox/feature/library/LibraryScreen.kt
+++ b/feature/src/main/kotlin/in/jphe/storyvox/feature/library/LibraryScreen.kt
@@ -263,7 +263,7 @@ fun LibraryScreen(
                         contentDescription = stringResource(R.string.library_scan_page_cd),
                     )
                 }
-                androidx.compose.foundation.layout.Box {
+                Box {
                     FloatingActionButton(
                         onClick = { addMenuOpen = true },
                         containerColor = MaterialTheme.colorScheme.primary,

--- a/feature/src/main/kotlin/in/jphe/storyvox/feature/ocr/OcrCaptureScreen.kt
+++ b/feature/src/main/kotlin/in/jphe/storyvox/feature/ocr/OcrCaptureScreen.kt
@@ -1,0 +1,440 @@
+package `in`.jphe.storyvox.feature.ocr
+
+import android.Manifest
+import android.content.Context
+import android.content.pm.PackageManager
+import android.net.Uri
+import androidx.activity.compose.rememberLauncherForActivityResult
+import androidx.activity.result.contract.ActivityResultContracts
+import androidx.camera.core.ImageCapture
+import androidx.camera.core.ImageCaptureException
+import androidx.camera.view.CameraController
+import androidx.camera.view.LifecycleCameraController
+import androidx.camera.view.PreviewView
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.aspectRatio
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material.icons.filled.Delete
+import androidx.compose.material.icons.filled.PhotoLibrary
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.material3.TopAppBar
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.DisposableEffect
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
+import androidx.lifecycle.compose.LocalLifecycleOwner
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.semantics.contentDescription
+import androidx.compose.ui.semantics.semantics
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.viewinterop.AndroidView
+import androidx.core.content.ContextCompat
+import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import `in`.jphe.storyvox.feature.R
+import `in`.jphe.storyvox.ui.component.BrassButton
+import `in`.jphe.storyvox.ui.component.BrassButtonVariant
+import `in`.jphe.storyvox.ui.theme.LocalSpacing
+import java.io.ByteArrayOutputStream
+
+/**
+ * Issue #995 — OCR scan-to-read capture screen.
+ *
+ * Two capture paths, both first-class for accessibility:
+ *  1. **Camera** — CameraX live preview + a capture button. Requires
+ *     CAMERA permission; shows a plain-language rationale before the
+ *     prompt and a graceful "use the gallery instead" fallback if the
+ *     user declines (so a denied camera never dead-ends the feature).
+ *  2. **Gallery** — `ActivityResultContracts.GetContent` for images,
+ *     no permission needed. This is the path a screen-reader user who
+ *     can't aim a camera, or anyone with an existing photo of a page,
+ *     takes — never gate the feature behind the camera.
+ *
+ * Captured/picked images are decoded to JPEG bytes and handed to
+ * [OcrCaptureViewModel.onImageCaptured], which runs on-device ML Kit
+ * OCR and accumulates pages. The user names the document and saves;
+ * [onScanComplete] navigates into the new fiction.
+ */
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun OcrCaptureScreen(
+    onNavigateBack: () -> Unit,
+    onScanComplete: (fictionId: String) -> Unit,
+    viewModel: OcrCaptureViewModel = hiltViewModel(),
+) {
+    val state by viewModel.state.collectAsStateWithLifecycle()
+    val context = LocalContext.current
+    val spacing = LocalSpacing.current
+
+    // One-shot navigation when a document is saved.
+    LaunchedEffect(state.savedFictionId) {
+        state.savedFictionId?.let { id ->
+            onScanComplete(id)
+            viewModel.onNavigatedToSaved()
+        }
+    }
+
+    var hasCameraPermission by remember {
+        mutableStateOf(
+            ContextCompat.checkSelfPermission(context, Manifest.permission.CAMERA) ==
+                PackageManager.PERMISSION_GRANTED,
+        )
+    }
+    // True once the user has declined the prompt at least once — drives
+    // the "camera unavailable, use the gallery" rationale instead of
+    // re-nagging.
+    var cameraDenied by remember { mutableStateOf(false) }
+
+    val cameraPermissionLauncher = rememberLauncherForActivityResult(
+        contract = ActivityResultContracts.RequestPermission(),
+    ) { granted ->
+        hasCameraPermission = granted
+        cameraDenied = !granted
+    }
+
+    // Gallery pick — no permission needed (the system photo picker
+    // returns a one-shot read grant for the chosen image).
+    val galleryLauncher = rememberLauncherForActivityResult(
+        contract = ActivityResultContracts.GetContent(),
+    ) { uri: Uri? ->
+        uri?.let {
+            val bytes = readImageBytes(context, it)
+            if (bytes != null) viewModel.onImageCaptured(bytes)
+        }
+    }
+
+    Scaffold(
+        topBar = {
+            TopAppBar(
+                title = { Text(stringResource(R.string.ocr_capture_title)) },
+                navigationIcon = {
+                    IconButton(onClick = onNavigateBack) {
+                        Icon(
+                            Icons.AutoMirrored.Filled.ArrowBack,
+                            contentDescription = stringResource(R.string.ocr_capture_back_cd),
+                        )
+                    }
+                },
+            )
+        },
+    ) { innerPadding ->
+        Column(
+            modifier = Modifier
+                .fillMaxSize()
+                .padding(innerPadding)
+                .padding(horizontal = spacing.md)
+                .verticalScroll(rememberScrollState()),
+            verticalArrangement = Arrangement.spacedBy(spacing.md),
+        ) {
+            Text(
+                stringResource(R.string.ocr_capture_intro),
+                style = MaterialTheme.typography.bodyMedium,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
+
+            // ── Camera surface or its fallback ─────────────────────────
+            when {
+                hasCameraPermission -> {
+                    CameraCaptureBox(
+                        enabled = !state.isRecognizing && !state.isSaving,
+                        onCaptured = { bytes, rotation ->
+                            viewModel.onImageCaptured(bytes, rotation)
+                        },
+                    )
+                }
+
+                cameraDenied -> {
+                    // Denied: don't re-nag. Explain and lean on gallery.
+                    InfoCard(text = stringResource(R.string.ocr_camera_denied))
+                }
+
+                else -> {
+                    // First run / not yet asked: rationale + grant button.
+                    InfoCard(text = stringResource(R.string.ocr_camera_rationale))
+                    BrassButton(
+                        label = stringResource(R.string.ocr_enable_camera),
+                        onClick = { cameraPermissionLauncher.launch(Manifest.permission.CAMERA) },
+                        variant = BrassButtonVariant.Primary,
+                        modifier = Modifier.fillMaxWidth(),
+                    )
+                }
+            }
+
+            // ── Gallery alternative — always available ─────────────────
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                horizontalArrangement = Arrangement.spacedBy(spacing.sm),
+                verticalAlignment = Alignment.CenterVertically,
+            ) {
+                BrassButton(
+                    label = stringResource(R.string.ocr_pick_from_gallery),
+                    onClick = { galleryLauncher.launch("image/*") },
+                    variant = BrassButtonVariant.Secondary,
+                    enabled = !state.isRecognizing && !state.isSaving,
+                    modifier = Modifier.weight(1f),
+                )
+                Icon(
+                    Icons.Filled.PhotoLibrary,
+                    contentDescription = null,
+                    tint = MaterialTheme.colorScheme.onSurfaceVariant,
+                )
+            }
+
+            if (state.isRecognizing) {
+                Text(
+                    stringResource(R.string.ocr_recognizing),
+                    style = MaterialTheme.typography.bodyMedium,
+                )
+            }
+
+            state.error?.let { err ->
+                Surface(
+                    color = MaterialTheme.colorScheme.errorContainer,
+                    shape = RoundedCornerShape(12.dp),
+                    modifier = Modifier.fillMaxWidth(),
+                ) {
+                    Text(
+                        err,
+                        style = MaterialTheme.typography.bodyMedium,
+                        color = MaterialTheme.colorScheme.onErrorContainer,
+                        modifier = Modifier.padding(spacing.md),
+                    )
+                }
+            }
+
+            // ── Captured pages + title + save ──────────────────────────
+            if (state.pages.isNotEmpty()) {
+                OutlinedTextField(
+                    value = state.title,
+                    onValueChange = viewModel::onTitleChanged,
+                    label = { Text(stringResource(R.string.ocr_document_title_label)) },
+                    singleLine = true,
+                    enabled = !state.isSaving,
+                    modifier = Modifier.fillMaxWidth(),
+                )
+
+                Text(
+                    stringResource(
+                        R.string.ocr_pages_summary,
+                        state.pages.size,
+                        state.totalWords,
+                    ),
+                    style = MaterialTheme.typography.labelLarge,
+                )
+
+                CapturedPagesList(
+                    pages = state.pages,
+                    onRemove = viewModel::removePage,
+                    enabled = !state.isSaving,
+                )
+
+                BrassButton(
+                    label = stringResource(R.string.ocr_save_and_read),
+                    onClick = viewModel::save,
+                    variant = BrassButtonVariant.Primary,
+                    enabled = state.canSave,
+                    loading = state.isSaving,
+                    modifier = Modifier.fillMaxWidth(),
+                )
+            }
+        }
+    }
+}
+
+/**
+ * CameraX live preview wrapped in a Compose [AndroidView], with a
+ * capture button overlaid at the bottom. Uses [LifecycleCameraController]
+ * so the camera binds to the composition's lifecycle automatically.
+ */
+@Composable
+private fun CameraCaptureBox(
+    enabled: Boolean,
+    onCaptured: (bytes: ByteArray, rotationDegrees: Int) -> Unit,
+) {
+    val context = LocalContext.current
+    val lifecycleOwner = LocalLifecycleOwner.current
+    val spacing = LocalSpacing.current
+    val captureCd = stringResource(R.string.ocr_capture_button_cd)
+
+    val controller = remember {
+        LifecycleCameraController(context).apply {
+            setEnabledUseCases(CameraController.IMAGE_CAPTURE)
+        }
+    }
+
+    DisposableEffect(lifecycleOwner) {
+        controller.bindToLifecycle(lifecycleOwner)
+        onDispose { controller.unbind() }
+    }
+
+    Box(
+        modifier = Modifier
+            .fillMaxWidth()
+            .aspectRatio(3f / 4f),
+        contentAlignment = Alignment.BottomCenter,
+    ) {
+        AndroidView(
+            modifier = Modifier.fillMaxSize(),
+            factory = { ctx ->
+                PreviewView(ctx).apply {
+                    this.controller = controller
+                    scaleType = PreviewView.ScaleType.FILL_CENTER
+                }
+            },
+        )
+        BrassButton(
+            label = stringResource(R.string.ocr_capture_button),
+            onClick = {
+                takePicture(context, controller, onCaptured)
+            },
+            variant = BrassButtonVariant.Primary,
+            enabled = enabled,
+            modifier = Modifier
+                .padding(bottom = spacing.md)
+                .semantics { contentDescription = captureCd },
+        )
+    }
+}
+
+@Composable
+private fun CapturedPagesList(
+    pages: List<OcrCapturedPage>,
+    onRemove: (Int) -> Unit,
+    enabled: Boolean,
+) {
+    val spacing = LocalSpacing.current
+    // The page count is small (a handful of scanned pages); a plain
+    // Column inside the scrolling parent would be simpler, but each row
+    // carries a delete affordance and a text preview, so a height-capped
+    // LazyColumn keeps a 20-page scan from blowing past the screen.
+    LazyColumn(
+        modifier = Modifier.fillMaxWidth(),
+        verticalArrangement = Arrangement.spacedBy(spacing.xs),
+        userScrollEnabled = false,
+    ) {
+        items(items = pages, key = { it.index }) { page ->
+            Surface(
+                color = MaterialTheme.colorScheme.surfaceVariant,
+                shape = RoundedCornerShape(12.dp),
+                modifier = Modifier.fillMaxWidth(),
+            ) {
+                Row(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .padding(horizontal = spacing.md, vertical = spacing.sm),
+                    verticalAlignment = Alignment.CenterVertically,
+                ) {
+                    Column(modifier = Modifier.weight(1f)) {
+                        Text(page.title, style = MaterialTheme.typography.titleSmall)
+                        Text(
+                            page.text.take(120),
+                            style = MaterialTheme.typography.bodySmall,
+                            color = MaterialTheme.colorScheme.onSurfaceVariant,
+                            maxLines = 2,
+                        )
+                    }
+                    IconButton(onClick = { onRemove(page.index) }, enabled = enabled) {
+                        Icon(
+                            Icons.Filled.Delete,
+                            contentDescription = stringResource(
+                                R.string.ocr_remove_page_cd,
+                                page.title,
+                            ),
+                        )
+                    }
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun InfoCard(text: String) {
+    val spacing = LocalSpacing.current
+    Surface(
+        color = MaterialTheme.colorScheme.surfaceVariant,
+        shape = RoundedCornerShape(12.dp),
+        modifier = Modifier.fillMaxWidth(),
+    ) {
+        Text(
+            text,
+            style = MaterialTheme.typography.bodyMedium,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+            modifier = Modifier.padding(spacing.md),
+        )
+    }
+}
+
+/**
+ * Capture a still through CameraX [ImageCapture] in-memory, convert the
+ * frame to JPEG bytes, and hand them upward with the sensor rotation so
+ * ML Kit reads sideways shots correctly.
+ */
+private fun takePicture(
+    context: Context,
+    controller: LifecycleCameraController,
+    onCaptured: (bytes: ByteArray, rotationDegrees: Int) -> Unit,
+) {
+    val executor = ContextCompat.getMainExecutor(context)
+    controller.takePicture(
+        executor,
+        object : ImageCapture.OnImageCapturedCallback() {
+            override fun onCaptureSuccess(image: androidx.camera.core.ImageProxy) {
+                val rotation = image.imageInfo.rotationDegrees
+                val bytes = image.toJpegBytes()
+                image.close()
+                if (bytes != null) onCaptured(bytes, rotation)
+            }
+
+            override fun onError(exception: ImageCaptureException) {
+                // Capture failed (rare — device camera busy). Swallow;
+                // the user simply taps capture again. The empty-bytes
+                // path never fires onCaptured, so no blank page is added.
+            }
+        },
+    )
+}
+
+/** Decode an [ImageProxy] to JPEG bytes. CameraX delivers JPEG buffers
+ *  for IMAGE_CAPTURE by default, so we read plane 0 straight through. */
+private fun androidx.camera.core.ImageProxy.toJpegBytes(): ByteArray? {
+    val buffer = planes.firstOrNull()?.buffer ?: return null
+    val bytes = ByteArray(buffer.remaining())
+    buffer.get(bytes)
+    return bytes
+}
+
+/** Read a gallery-picked image's bytes through the ContentResolver. */
+private fun readImageBytes(context: Context, uri: Uri): ByteArray? =
+    runCatching {
+        context.contentResolver.openInputStream(uri)?.use { input ->
+            val out = ByteArrayOutputStream()
+            input.copyTo(out)
+            out.toByteArray()
+        }
+    }.getOrNull()

--- a/feature/src/main/kotlin/in/jphe/storyvox/feature/ocr/OcrCaptureViewModel.kt
+++ b/feature/src/main/kotlin/in/jphe/storyvox/feature/ocr/OcrCaptureViewModel.kt
@@ -1,0 +1,163 @@
+package `in`.jphe.storyvox.feature.ocr
+
+import androidx.compose.runtime.Immutable
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import dagger.hilt.android.lifecycle.HiltViewModel
+import `in`.jphe.storyvox.data.ocr.OcrImage
+import `in`.jphe.storyvox.data.ocr.OcrResult
+import `in`.jphe.storyvox.data.ocr.OcrTextRecognizer
+import `in`.jphe.storyvox.source.ocr.config.OcrDocumentStore
+import `in`.jphe.storyvox.source.ocr.config.OcrPage
+import `in`.jphe.storyvox.source.ocr.parse.OcrTextParser
+import javax.inject.Inject
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.launch
+
+/**
+ * Issue #995 — drives the OCR scan-to-read capture flow.
+ *
+ * The screen hands raw image bytes (from a CameraX capture or a gallery
+ * pick) to [onImageCaptured]; this VM runs them through the on-device
+ * [OcrTextRecognizer] seam, reflows the recognized text via
+ * [OcrTextParser], and accumulates each scan as a page. When the user
+ * finishes, [save] persists an `OcrDocument` through [OcrDocumentStore]
+ * and emits the new fictionId so the screen can navigate into the
+ * reader / start playback.
+ *
+ * All Android / ML Kit specifics stay behind the [OcrTextRecognizer]
+ * and [OcrDocumentStore] interfaces, so this VM is plain JVM logic and
+ * unit-testable with fakes (no Robolectric).
+ */
+@HiltViewModel
+class OcrCaptureViewModel @Inject constructor(
+    private val recognizer: OcrTextRecognizer,
+    private val store: OcrDocumentStore,
+) : ViewModel() {
+
+    private val _state = MutableStateFlow(OcrCaptureUiState())
+    val state: StateFlow<OcrCaptureUiState> = _state.asStateFlow()
+
+    /**
+     * Recognize text in a freshly captured / picked image and append it
+     * as a page. [rotationDegrees] is the EXIF / sensor rotation so ML
+     * Kit reads sideways captures upright.
+     */
+    fun onImageCaptured(bytes: ByteArray, rotationDegrees: Int = 0) {
+        if (_state.value.isRecognizing) return
+        _state.update { it.copy(isRecognizing = true, error = null) }
+        viewModelScope.launch {
+            when (val result = recognizer.recognize(OcrImage(bytes, rotationDegrees))) {
+                is OcrResult.Failure -> _state.update {
+                    it.copy(isRecognizing = false, error = result.message)
+                }
+
+                is OcrResult.Success -> {
+                    val recognition = result.recognition
+                    if (recognition.isEmpty) {
+                        _state.update {
+                            it.copy(
+                                isRecognizing = false,
+                                error = "No text found on that page. Hold steady and try again.",
+                            )
+                        }
+                        return@launch
+                    }
+                    val body = OcrTextParser.renderPage(recognition)
+                    _state.update { prev ->
+                        val nextIndex = prev.pages.size
+                        val newPage = OcrCapturedPage(
+                            index = nextIndex,
+                            title = "Page ${nextIndex + 1}",
+                            text = body.plainBody,
+                            wordCount = OcrTextParser.wordCount(body.plainBody),
+                        )
+                        // Seed the document title from the first page's
+                        // first line if the user hasn't typed one.
+                        val seededTitle = prev.title.ifBlank {
+                            OcrTextParser.suggestTitle(recognition, fallback = "")
+                        }
+                        prev.copy(
+                            isRecognizing = false,
+                            error = null,
+                            title = seededTitle,
+                            pages = prev.pages + newPage,
+                        )
+                    }
+                }
+            }
+        }
+    }
+
+    /** Update the user-editable document title. */
+    fun onTitleChanged(title: String) {
+        _state.update { it.copy(title = title) }
+    }
+
+    /** Drop a captured page (the user re-scans or discards a bad shot). */
+    fun removePage(index: Int) {
+        _state.update { prev ->
+            val remaining = prev.pages
+                .filterNot { it.index == index }
+                .mapIndexed { i, p -> p.copy(index = i, title = "Page ${i + 1}") }
+            prev.copy(pages = remaining)
+        }
+    }
+
+    /** Clear a surfaced error once the user has acknowledged it. */
+    fun clearError() {
+        _state.update { it.copy(error = null) }
+    }
+
+    /**
+     * Persist the accumulated pages as one document and emit its
+     * fictionId via [OcrCaptureUiState.savedFictionId]. No-op when there
+     * are no pages.
+     */
+    fun save() {
+        val snapshot = _state.value
+        if (snapshot.pages.isEmpty() || snapshot.isSaving) return
+        _state.update { it.copy(isSaving = true, error = null) }
+        viewModelScope.launch {
+            val title = snapshot.title.ifBlank { "Scanned document" }.trim()
+            val pages = snapshot.pages.map { OcrPage(index = it.index, title = it.title, text = it.text) }
+            val fictionId = store.save(title = title, pages = pages)
+            _state.update { it.copy(isSaving = false, savedFictionId = fictionId) }
+        }
+    }
+
+    /** Consume the navigation signal so it fires exactly once. */
+    fun onNavigatedToSaved() {
+        _state.update { it.copy(savedFictionId = null) }
+    }
+}
+
+/** UI state for the OCR capture screen. */
+@Immutable
+data class OcrCaptureUiState(
+    val title: String = "",
+    val pages: List<OcrCapturedPage> = emptyList(),
+    val isRecognizing: Boolean = false,
+    val isSaving: Boolean = false,
+    /** User-facing recoverable error (OCR failed, blank page). */
+    val error: String? = null,
+    /** Non-null exactly once after a successful [OcrCaptureViewModel.save];
+     *  the screen navigates into the new fiction then calls
+     *  [OcrCaptureViewModel.onNavigatedToSaved]. */
+    val savedFictionId: String? = null,
+) {
+    val canSave: Boolean get() = pages.isNotEmpty() && !isSaving && !isRecognizing
+    val totalWords: Int get() = pages.sumOf { it.wordCount }
+}
+
+/** One captured + recognized page held in the capture session. */
+@Immutable
+data class OcrCapturedPage(
+    val index: Int,
+    val title: String,
+    val text: String,
+    val wordCount: Int,
+)

--- a/feature/src/main/res/values/strings.xml
+++ b/feature/src/main/res/values/strings.xml
@@ -832,4 +832,21 @@
     <string name="settings_github_revoke_subtitle">Sign-out clears the local token; use this to revoke Candela\'s authorization on GitHub\'s side too.</string>
     <string name="settings_github_expired_subtitle">Session expired — sign in again to recover.</string>
 
+    <!-- Issue #995 — OCR scan-to-read -->
+    <string name="ocr_capture_title">Scan to read</string>
+    <string name="ocr_capture_back_cd">Back</string>
+    <string name="ocr_capture_intro">Point your camera at a printed page, or pick a photo, and Candela reads it aloud. Scan several pages to make one document.</string>
+    <string name="ocr_camera_rationale">To scan printed text, Candela needs camera access. Nothing leaves your device — text recognition runs entirely offline.</string>
+    <string name="ocr_camera_denied">Camera access is off. You can still scan by picking a photo from your gallery below, or turn the camera on in system Settings.</string>
+    <string name="ocr_enable_camera">Enable camera</string>
+    <string name="ocr_pick_from_gallery">Pick a photo</string>
+    <string name="ocr_capture_button">Capture page</string>
+    <string name="ocr_capture_button_cd">Capture this page for text recognition</string>
+    <string name="ocr_recognizing">Reading text…</string>
+    <string name="ocr_document_title_label">Document title</string>
+    <string name="ocr_pages_summary">%1$d page(s) · %2$d words</string>
+    <string name="ocr_remove_page_cd">Remove %1$s</string>
+    <string name="ocr_save_and_read">Save and read</string>
+    <string name="library_scan_page_cd">Scan a printed page to read aloud</string>
+
 </resources>

--- a/feature/src/test/kotlin/in/jphe/storyvox/feature/ocr/OcrCaptureViewModelTest.kt
+++ b/feature/src/test/kotlin/in/jphe/storyvox/feature/ocr/OcrCaptureViewModelTest.kt
@@ -1,0 +1,194 @@
+package `in`.jphe.storyvox.feature.ocr
+
+import `in`.jphe.storyvox.data.ocr.OcrBlock
+import `in`.jphe.storyvox.data.ocr.OcrImage
+import `in`.jphe.storyvox.data.ocr.OcrRecognition
+import `in`.jphe.storyvox.data.ocr.OcrResult
+import `in`.jphe.storyvox.data.ocr.OcrTextRecognizer
+import `in`.jphe.storyvox.source.ocr.config.OcrDocumentStore
+import `in`.jphe.storyvox.source.ocr.config.OcrPage
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.test.setMain
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+
+/**
+ * Issue #995 — OcrCaptureViewModel logic over fakes (no ML Kit, no
+ * DataStore, no Robolectric). Verifies the capture-accumulate-save flow
+ * and the recoverable error / blank-page paths.
+ */
+@OptIn(ExperimentalCoroutinesApi::class)
+class OcrCaptureViewModelTest {
+
+    private val dispatcher = StandardTestDispatcher()
+
+    @Before fun setUp() = Dispatchers.setMain(dispatcher)
+
+    @After fun tearDown() = Dispatchers.resetMain()
+
+    private class FakeRecognizer(var next: OcrResult) : OcrTextRecognizer {
+        var calls = 0
+        val seen = mutableListOf<OcrImage>()
+        override suspend fun recognize(image: OcrImage): OcrResult {
+            calls++
+            seen += image
+            return next
+        }
+    }
+
+    private class FakeStore : OcrDocumentStore {
+        var savedTitle: String? = null
+        var savedPages: List<OcrPage> = emptyList()
+        override suspend fun save(title: String, pages: List<OcrPage>): String {
+            savedTitle = title
+            savedPages = pages
+            return "ocr:saved"
+        }
+        override suspend fun delete(fictionId: String) {}
+    }
+
+    private fun success(text: String, vararg blocks: String) = OcrResult.Success(
+        OcrRecognition(text = text, blocks = blocks.map { OcrBlock(it) }),
+    )
+
+    @Test
+    fun `captured image appends a page and seeds the title`() = runTest(dispatcher) {
+        val rec = FakeRecognizer(success("The Manifesto\nWe hold these truths"))
+        val vm = OcrCaptureViewModel(rec, FakeStore())
+
+        vm.onImageCaptured(byteArrayOf(1, 2, 3), rotationDegrees = 90)
+        dispatcher.scheduler.advanceUntilIdle()
+
+        val state = vm.state.value
+        assertEquals(1, state.pages.size)
+        assertEquals("The Manifesto We hold these truths", state.pages[0].text)
+        assertEquals("The Manifesto", state.title) // seeded from first line
+        assertFalse(state.isRecognizing)
+        assertEquals(90, rec.seen[0].rotationDegrees)
+    }
+
+    @Test
+    fun `second capture appends a second page without overwriting the title`() = runTest(dispatcher) {
+        val rec = FakeRecognizer(success("Page one"))
+        val vm = OcrCaptureViewModel(rec, FakeStore())
+
+        vm.onImageCaptured(byteArrayOf(1))
+        dispatcher.scheduler.advanceUntilIdle()
+        vm.onTitleChanged("My letter")
+        rec.next = success("Page two")
+        vm.onImageCaptured(byteArrayOf(2))
+        dispatcher.scheduler.advanceUntilIdle()
+
+        val state = vm.state.value
+        assertEquals(2, state.pages.size)
+        assertEquals("My letter", state.title) // user title not clobbered
+        assertEquals(listOf(0, 1), state.pages.map { it.index })
+    }
+
+    @Test
+    fun `blank recognition surfaces a recoverable error and adds no page`() = runTest(dispatcher) {
+        val rec = FakeRecognizer(success("   "))
+        val vm = OcrCaptureViewModel(rec, FakeStore())
+
+        vm.onImageCaptured(byteArrayOf(1))
+        dispatcher.scheduler.advanceUntilIdle()
+
+        val state = vm.state.value
+        assertTrue(state.pages.isEmpty())
+        assertTrue(state.error != null)
+        assertFalse(state.isRecognizing)
+    }
+
+    @Test
+    fun `recognizer failure surfaces its message`() = runTest(dispatcher) {
+        val rec = FakeRecognizer(OcrResult.Failure("model unavailable"))
+        val vm = OcrCaptureViewModel(rec, FakeStore())
+
+        vm.onImageCaptured(byteArrayOf(1))
+        dispatcher.scheduler.advanceUntilIdle()
+
+        assertEquals("model unavailable", vm.state.value.error)
+        assertTrue(vm.state.value.pages.isEmpty())
+    }
+
+    @Test
+    fun `removePage reindexes remaining pages`() = runTest(dispatcher) {
+        val rec = FakeRecognizer(success("a"))
+        val vm = OcrCaptureViewModel(rec, FakeStore())
+        repeat(3) { i ->
+            rec.next = success("page $i")
+            vm.onImageCaptured(byteArrayOf(i.toByte()))
+            dispatcher.scheduler.advanceUntilIdle()
+        }
+
+        vm.removePage(1)
+
+        val pages = vm.state.value.pages
+        assertEquals(2, pages.size)
+        assertEquals(listOf(0, 1), pages.map { it.index })
+        assertEquals(listOf("page 0", "page 2"), pages.map { it.text })
+    }
+
+    @Test
+    fun `save persists pages and emits savedFictionId`() = runTest(dispatcher) {
+        val rec = FakeRecognizer(success("Hello world"))
+        val store = FakeStore()
+        val vm = OcrCaptureViewModel(rec, store)
+
+        vm.onImageCaptured(byteArrayOf(1))
+        dispatcher.scheduler.advanceUntilIdle()
+        vm.onTitleChanged("Greetings")
+        vm.save()
+        dispatcher.scheduler.advanceUntilIdle()
+
+        assertEquals("Greetings", store.savedTitle)
+        assertEquals(1, store.savedPages.size)
+        assertEquals("Hello world", store.savedPages[0].text)
+        assertEquals("ocr:saved", vm.state.value.savedFictionId)
+
+        // One-shot navigation signal clears.
+        vm.onNavigatedToSaved()
+        assertNull(vm.state.value.savedFictionId)
+    }
+
+    @Test
+    fun `save is a no-op with no pages`() = runTest(dispatcher) {
+        val store = FakeStore()
+        val vm = OcrCaptureViewModel(FakeRecognizer(success("x")), store)
+
+        vm.save()
+        dispatcher.scheduler.advanceUntilIdle()
+
+        assertNull(store.savedTitle)
+        assertNull(vm.state.value.savedFictionId)
+    }
+
+    @Test
+    fun `blank title falls back to default on save`() = runTest(dispatcher) {
+        val rec = FakeRecognizer(
+            // No usable first line for the title seed (whitespace then
+            // text is fine, but here the recognized text has no leading
+            // line — force the fallback by clearing the seeded title).
+            success("body only"),
+        )
+        val store = FakeStore()
+        val vm = OcrCaptureViewModel(rec, store)
+
+        vm.onImageCaptured(byteArrayOf(1))
+        dispatcher.scheduler.advanceUntilIdle()
+        vm.onTitleChanged("   ") // user blanks it
+        vm.save()
+        dispatcher.scheduler.advanceUntilIdle()
+
+        assertEquals("Scanned document", store.savedTitle)
+    }
+}

--- a/feature/src/test/kotlin/in/jphe/storyvox/feature/ocr/OcrCaptureViewModelTest.kt
+++ b/feature/src/test/kotlin/in/jphe/storyvox/feature/ocr/OcrCaptureViewModelTest.kt
@@ -53,7 +53,7 @@ class OcrCaptureViewModelTest {
             savedPages = pages
             return "ocr:saved"
         }
-        override suspend fun delete(fictionId: String) {}
+        override suspend fun delete(fictionId: String) = Unit // unused in these tests
     }
 
     private fun success(text: String, vararg blocks: String) = OcrResult.Success(

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -91,6 +91,14 @@ desugar = "2.1.5"
 # Storage Access Framework helpers (#235 EPUB import)
 documentfile = "1.1.0"
 
+# OCR / scan-to-read (#995). ML Kit Text Recognition v2 ships a bundled,
+# offline Latin-script model (no Play Services download, no network) —
+# the right posture for an accessibility tool used in low-connectivity
+# settings. CameraX drives the capture surface; the gallery-pick
+# alternative needs no extra dep (ActivityResultContracts.GetContent).
+mlkit-text-recognition = "16.0.1"
+camerax = "1.4.2"
+
 [libraries]
 # AndroidX core
 androidx-core-ktx = { module = "androidx.core:core-ktx", version.ref = "core-ktx" }
@@ -102,6 +110,15 @@ androidx-lifecycle-runtime-compose = { module = "androidx.lifecycle:lifecycle-ru
 androidx-startup = { module = "androidx.startup:startup-runtime", version.ref = "startup" }
 androidx-security-crypto = { module = "androidx.security:security-crypto", version.ref = "security-crypto" }
 androidx-documentfile = { module = "androidx.documentfile:documentfile", version.ref = "documentfile" }
+
+# OCR / scan-to-read (#995). Bundled offline text recognizer + CameraX
+# capture stack. ML Kit lib is consumed by :app (the MlKitOcrTextRecognizer
+# impl); CameraX libs by :feature (the OcrCaptureScreen).
+mlkit-text-recognition = { module = "com.google.mlkit:text-recognition", version.ref = "mlkit-text-recognition" }
+androidx-camera-core = { module = "androidx.camera:camera-core", version.ref = "camerax" }
+androidx-camera-camera2 = { module = "androidx.camera:camera-camera2", version.ref = "camerax" }
+androidx-camera-lifecycle = { module = "androidx.camera:camera-lifecycle", version.ref = "camerax" }
+androidx-camera-view = { module = "androidx.camera:camera-view", version.ref = "camerax" }
 
 # Navigation
 androidx-navigation-compose = { module = "androidx.navigation:navigation-compose", version.ref = "navigation-compose" }
@@ -257,4 +274,12 @@ wear-compose = [
     "androidx-wear-compose-material",
     "androidx-wear-compose-foundation",
     "androidx-wear-compose-navigation",
+]
+# CameraX capture stack for the OCR scan surface (#995). camera-view
+# gives the PreviewView + CameraController; camera2 is the backend.
+camerax = [
+    "androidx-camera-core",
+    "androidx-camera-camera2",
+    "androidx-camera-lifecycle",
+    "androidx-camera-view",
 ]

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -52,6 +52,12 @@ include(":source-epub-writer")
 // Issue #1003 — pure-JVM chapterizer + M4B chapter-marker math for the
 // "Make your own audiobook" export. Android encode/mux lives in :core-playback.
 include(":source-audiobook-writer")
+// Issue #995 — OCR scan-to-read. Camera / gallery capture → on-device
+// ML Kit Text Recognition (offline, bundled model) → a fiction the
+// EnginePlayer narrates. The assistive-tech bridge from the printed
+// world to accessible audio. Shares the :core-data OcrTextRecognizer
+// seam so #996's scanned-PDF import reuses the same recognizer.
+include(":source-ocr")
 include(":source-outline")
 include(":source-gutenberg")
 include(":source-ao3")

--- a/source-ocr/build.gradle.kts
+++ b/source-ocr/build.gradle.kts
@@ -1,0 +1,43 @@
+plugins {
+    alias(libs.plugins.android.library)
+    alias(libs.plugins.kotlin.android)
+    alias(libs.plugins.ksp)
+    alias(libs.plugins.hilt)
+}
+
+android {
+    namespace = "in.jphe.storyvox.source.ocr"
+    compileSdk = 36
+
+    defaultConfig {
+        minSdk = 26
+    }
+
+    compileOptions {
+        sourceCompatibility = JavaVersion.VERSION_17
+        targetCompatibility = JavaVersion.VERSION_17
+    }
+
+}
+
+kotlin {
+    compilerOptions {
+        jvmTarget.set(org.jetbrains.kotlin.gradle.dsl.JvmTarget.JVM_17)
+    }
+}
+
+dependencies {
+    implementation(project(":core-data"))
+    implementation(libs.kotlinx.coroutines.android)
+
+    implementation(libs.hilt.android)
+    ksp(libs.hilt.compiler)
+
+    // Issue #995 — emits the @SourcePlugin → @IntoSet
+    // SourcePluginDescriptor Hilt module for OcrSource (Phase 2 of the
+    // plugin seam, #384). Legacy @IntoMap binding lives in di/OcrModule.kt.
+    ksp(project(":core-plugin-ksp"))
+
+    testImplementation(libs.junit)
+    testImplementation(libs.kotlinx.coroutines.test)
+}

--- a/source-ocr/src/main/AndroidManifest.xml
+++ b/source-ocr/src/main/AndroidManifest.xml
@@ -1,0 +1,2 @@
+<?xml version="1.0" encoding="utf-8"?>
+<manifest xmlns:android="http://schemas.android.com/apk/res/android" />

--- a/source-ocr/src/main/kotlin/in/jphe/storyvox/source/ocr/OcrSource.kt
+++ b/source-ocr/src/main/kotlin/in/jphe/storyvox/source/ocr/OcrSource.kt
@@ -174,7 +174,7 @@ private fun OcrDocument.toSummary(): FictionSummary = FictionSummary(
     sourceId = SourceIds.OCR,
     title = title,
     author = "",
-    description = pages.firstOrNull()?.text?.take(160) ?: "",
+    description = pages.firstOrNull()?.text?.take(160).orEmpty(),
     status = FictionStatus.COMPLETED, // a scan is a static capture
     chapterCount = pages.size,
 )

--- a/source-ocr/src/main/kotlin/in/jphe/storyvox/source/ocr/OcrSource.kt
+++ b/source-ocr/src/main/kotlin/in/jphe/storyvox/source/ocr/OcrSource.kt
@@ -1,0 +1,185 @@
+package `in`.jphe.storyvox.source.ocr
+
+import `in`.jphe.storyvox.data.source.FictionSource
+import `in`.jphe.storyvox.data.source.SourceIds
+import `in`.jphe.storyvox.data.source.model.ChapterContent
+import `in`.jphe.storyvox.data.source.model.ChapterInfo
+import `in`.jphe.storyvox.data.source.model.FictionDetail
+import `in`.jphe.storyvox.data.source.model.FictionResult
+import `in`.jphe.storyvox.data.source.model.FictionStatus
+import `in`.jphe.storyvox.data.source.model.FictionSummary
+import `in`.jphe.storyvox.data.source.model.ListPage
+import `in`.jphe.storyvox.data.source.model.SearchQuery
+import `in`.jphe.storyvox.data.source.plugin.SourceCategory
+import `in`.jphe.storyvox.data.source.plugin.SourcePlugin
+import `in`.jphe.storyvox.source.ocr.config.OcrConfig
+import `in`.jphe.storyvox.source.ocr.config.OcrDocument
+import `in`.jphe.storyvox.source.ocr.parse.OcrTextParser
+import javax.inject.Inject
+import javax.inject.Singleton
+
+/**
+ * Issue #995 — scan-to-read backend.
+ *
+ * The user points the camera at printed text (or picks a photo), the
+ * capture flow runs on-device ML Kit OCR via the
+ * [`in`.jphe.storyvox.data.ocr.OcrTextRecognizer] seam, and the
+ * recognized text is persisted as an [OcrDocument]. This source
+ * surfaces those documents as fictions so the normal `EnginePlayer`
+ * neural-voice pipeline narrates them with every reader feature
+ * (highlight, auto-scroll, pronunciation dict).
+ *
+ * One capture session = one fiction; each captured page = one chapter.
+ * Pure user-content backend: zero network, zero ToS surface — the user
+ * owns the page they scanned; storyvox just reads it aloud. This is the
+ * assistive-tech bridge from the printed world to accessible audio.
+ *
+ * The capture / OCR / persistence work happens in `:feature` (the
+ * `OcrCaptureScreen`) + `:app` (the ML Kit recognizer & DataStore
+ * store). This source is read-only over what that flow persisted —
+ * same split as `:source-epub` (SAF plumbing in `:app`, source reads
+ * the indexed list).
+ */
+@SourcePlugin(
+    id = SourceIds.OCR,
+    displayName = "Scanned text",
+    // Fresh-install discoverability: chip on by default. The backend
+    // lists nothing until the user scans something, but the chip is the
+    // affordance that teaches new users the scan-to-read surface exists
+    // — and it's the highest-leverage accessibility feature, so it
+    // should not be buried behind a toggle.
+    defaultEnabled = true,
+    category = SourceCategory.Text,
+    supportsFollow = false,
+    supportsSearch = true,
+    description = "Scan printed text with your camera · on-device OCR · zero-network",
+    sourceUrl = "",
+)
+@Singleton
+internal class OcrSource @Inject constructor(
+    private val config: OcrConfig,
+) : FictionSource {
+
+    override val id: String = SourceIds.OCR
+    override val displayName: String = "Scanned text"
+
+    // ─── browse ────────────────────────────────────────────────────────
+
+    override suspend fun popular(page: Int): FictionResult<ListPage<FictionSummary>> =
+        listDocuments()
+
+    override suspend fun latestUpdates(page: Int): FictionResult<ListPage<FictionSummary>> =
+        listDocuments()
+
+    override suspend fun byGenre(
+        genre: String,
+        page: Int,
+    ): FictionResult<ListPage<FictionSummary>> =
+        // Scanned documents carry no genre metadata. Surfacing nothing
+        // is more honest than fabricating buckets.
+        FictionResult.Success(ListPage(items = emptyList(), page = 1, hasNext = false))
+
+    override suspend fun genres(): FictionResult<List<String>> =
+        FictionResult.Success(emptyList())
+
+    override suspend fun search(query: SearchQuery): FictionResult<ListPage<FictionSummary>> {
+        val term = query.term.trim().lowercase()
+        if (term.isEmpty()) return listDocuments()
+        val matched = config.documents()
+            .filter { doc ->
+                doc.title.lowercase().contains(term) ||
+                    doc.pages.any { it.text.lowercase().contains(term) }
+            }
+            .map { it.toSummary() }
+        return FictionResult.Success(ListPage(items = matched, page = 1, hasNext = false))
+    }
+
+    private suspend fun listDocuments(): FictionResult<ListPage<FictionSummary>> {
+        val all = config.documents().map { it.toSummary() }
+        return FictionResult.Success(ListPage(items = all, page = 1, hasNext = false))
+    }
+
+    // ─── detail ────────────────────────────────────────────────────────
+
+    override suspend fun fictionDetail(fictionId: String): FictionResult<FictionDetail> {
+        val doc = config.document(fictionId)
+            ?: return FictionResult.NotFound("Scanned document not found: $fictionId")
+
+        val chapters = doc.pages.map { page ->
+            ChapterInfo(
+                id = chapterIdFor(fictionId, page.index),
+                sourceChapterId = page.index.toString(),
+                index = page.index,
+                title = page.title,
+                wordCount = OcrTextParser.wordCount(page.text),
+            )
+        }
+        return FictionResult.Success(
+            FictionDetail(summary = doc.toSummary(), chapters = chapters),
+        )
+    }
+
+    override suspend fun chapter(
+        fictionId: String,
+        chapterId: String,
+    ): FictionResult<ChapterContent> {
+        val doc = config.document(fictionId)
+            ?: return FictionResult.NotFound("Scanned document not found: $fictionId")
+
+        val page = doc.pages.firstOrNull { chapterIdFor(fictionId, it.index) == chapterId }
+            ?: return FictionResult.NotFound("Page not in document: $chapterId")
+
+        val info = ChapterInfo(
+            id = chapterId,
+            sourceChapterId = page.index.toString(),
+            index = page.index,
+            title = page.title,
+            wordCount = OcrTextParser.wordCount(page.text),
+        )
+        // The stored text is already reflowed plaintext (the capture
+        // flow ran it through OcrTextParser before persisting). Wrap
+        // each paragraph in <p> for the reader view.
+        val html = page.text
+            .split("\n\n")
+            .filter { it.isNotBlank() }
+            .joinToString("\n") { "<p>${escapeHtml(it.trim())}</p>" }
+        return FictionResult.Success(
+            ChapterContent(
+                info = info,
+                htmlBody = html,
+                plainBody = page.text,
+            ),
+        )
+    }
+
+    // ─── auth-gated ─────────────────────────────────────────────────────
+
+    override suspend fun followsList(page: Int): FictionResult<ListPage<FictionSummary>> =
+        // No upstream "follows" for local scans. Returning the document
+        // list matches the user mental model: "the things I scanned."
+        listDocuments()
+
+    override suspend fun setFollowed(
+        fictionId: String,
+        followed: Boolean,
+    ): FictionResult<Unit> = FictionResult.Success(Unit)
+}
+
+/** Compose a stable chapter id from the fictionId + the page index. */
+private fun chapterIdFor(fictionId: String, pageIndex: Int): String =
+    "$fictionId::p$pageIndex"
+
+private fun OcrDocument.toSummary(): FictionSummary = FictionSummary(
+    id = fictionId,
+    sourceId = SourceIds.OCR,
+    title = title,
+    author = "",
+    description = pages.firstOrNull()?.text?.take(160) ?: "",
+    status = FictionStatus.COMPLETED, // a scan is a static capture
+    chapterCount = pages.size,
+)
+
+private fun escapeHtml(s: String): String =
+    s.replace("&", "&amp;")
+        .replace("<", "&lt;")
+        .replace(">", "&gt;")

--- a/source-ocr/src/main/kotlin/in/jphe/storyvox/source/ocr/config/OcrConfig.kt
+++ b/source-ocr/src/main/kotlin/in/jphe/storyvox/source/ocr/config/OcrConfig.kt
@@ -1,0 +1,87 @@
+package `in`.jphe.storyvox.source.ocr.config
+
+import kotlinx.coroutines.flow.Flow
+
+/**
+ * Issue #995 — abstraction over the OCR-source's persistent store of
+ * scanned documents. The implementation lives in `:app` (DataStore +
+ * JSON) so this source module stays free of Android Preferences
+ * plumbing; this interface is what the source consumes.
+ *
+ * ## Why the OCR source stores its own content
+ *
+ * Unlike `:source-epub` (re-reads bytes from a SAF file) or
+ * `:source-rss` (re-fetches the feed URL), an OCR capture is
+ * transient — the camera frame is gone the moment the user leaves the
+ * capture screen. The recognized *text* is the canonical artifact, so
+ * the OCR source persists it directly. Each [OcrDocument] is one
+ * capture session = one fiction; each [OcrPage] in it = one chapter.
+ *
+ * The recognized text persists as plain `String`s rather than any
+ * Android type, so this interface (and the source) stay testable
+ * without Robolectric — same posture as `EpubConfig`.
+ */
+interface OcrConfig {
+    /** Hot stream of the user's scanned documents, newest first. */
+    val documents: Flow<List<OcrDocument>>
+
+    /** Synchronous snapshot for code paths that can't suspend. */
+    suspend fun documents(): List<OcrDocument>
+
+    /** One document by its [OcrDocument.fictionId], or null if absent. */
+    suspend fun document(fictionId: String): OcrDocument?
+}
+
+/**
+ * One scanned document = one fiction. [fictionId] is stable across
+ * re-launches (minted at capture time from [createdAt] + a nonce).
+ * [pages] are the captured pages in capture order; each becomes a
+ * chapter.
+ */
+data class OcrDocument(
+    val fictionId: String,
+    val title: String,
+    val createdAt: Long,
+    val pages: List<OcrPage>,
+)
+
+/**
+ * One captured page within a document = one chapter. [text] is the
+ * recognized text (already normalized by the capture flow's parser);
+ * [index] is the 0-based page order.
+ */
+data class OcrPage(
+    val index: Int,
+    val title: String,
+    val text: String,
+)
+
+/** Issue #995 — derive a stable, collision-resistant fictionId for a
+ *  new OCR capture. We can't hash content (the user may scan the same
+ *  page twice on purpose), so we key on creation time + a short nonce.
+ *  Caller supplies the nonce so this stays pure / testable. */
+fun fictionIdForOcrCapture(createdAt: Long, nonce: String): String {
+    val canonical = "$createdAt:$nonce"
+    val hash = canonical.hashCode().toUInt().toString(16).padStart(8, '0')
+    return "${`in`.jphe.storyvox.data.source.SourceIds.OCR}:$hash"
+}
+
+/**
+ * Issue #995 — write-side companion to [OcrConfig]. The `:feature`
+ * capture flow (`OcrCaptureScreen` / its ViewModel) calls this to
+ * persist a finished scan; the `:app` DataStore impl owns the JSON
+ * serialization. Kept separate from [OcrConfig] (read side) so the
+ * read path stays a clean, no-mutation consumer — same split spirit as
+ * `EpubConfigImpl` keeping its mutators off the `EpubConfig` interface.
+ */
+interface OcrDocumentStore {
+    /**
+     * Persist a freshly-captured document and return its assigned
+     * [OcrDocument.fictionId]. [title] is the user-confirmed (or
+     * OCR-suggested) title; [pages] are the captured pages in order.
+     */
+    suspend fun save(title: String, pages: List<OcrPage>): String
+
+    /** Delete a scanned document by [fictionId]. No-op if absent. */
+    suspend fun delete(fictionId: String)
+}

--- a/source-ocr/src/main/kotlin/in/jphe/storyvox/source/ocr/di/OcrModule.kt
+++ b/source-ocr/src/main/kotlin/in/jphe/storyvox/source/ocr/di/OcrModule.kt
@@ -23,11 +23,11 @@ import javax.inject.Singleton
  */
 @Module
 @InstallIn(SingletonComponent::class)
-internal abstract class OcrBindings {
+internal interface OcrBindings {
 
     @Binds
     @Singleton
     @IntoMap
     @StringKey(SourceIds.OCR)
-    abstract fun bindFictionSource(impl: OcrSource): FictionSource
+    fun bindFictionSource(impl: OcrSource): FictionSource
 }

--- a/source-ocr/src/main/kotlin/in/jphe/storyvox/source/ocr/di/OcrModule.kt
+++ b/source-ocr/src/main/kotlin/in/jphe/storyvox/source/ocr/di/OcrModule.kt
@@ -1,0 +1,33 @@
+package `in`.jphe.storyvox.source.ocr.di
+
+import dagger.Binds
+import dagger.Module
+import dagger.hilt.InstallIn
+import dagger.hilt.components.SingletonComponent
+import dagger.multibindings.IntoMap
+import dagger.multibindings.StringKey
+import `in`.jphe.storyvox.data.source.FictionSource
+import `in`.jphe.storyvox.data.source.SourceIds
+import `in`.jphe.storyvox.source.ocr.OcrSource
+import javax.inject.Singleton
+
+/**
+ * Issue #995 — contributes [OcrSource] into the multi-source
+ * `Map<String, FictionSource>` (#235). With this binding active, the
+ * segmented source picker in Browse gets a "Scanned text" entry, and
+ * any persisted fiction with sourceId="ocr" routes through this source.
+ *
+ * Kept alongside the `@SourcePlugin`-generated descriptor binding while
+ * the plugin seam (#384) completes its Phase-3 legacy-binding removal —
+ * same coexistence posture as `:source-epub`.
+ */
+@Module
+@InstallIn(SingletonComponent::class)
+internal abstract class OcrBindings {
+
+    @Binds
+    @Singleton
+    @IntoMap
+    @StringKey(SourceIds.OCR)
+    abstract fun bindFictionSource(impl: OcrSource): FictionSource
+}

--- a/source-ocr/src/main/kotlin/in/jphe/storyvox/source/ocr/parse/OcrTextParser.kt
+++ b/source-ocr/src/main/kotlin/in/jphe/storyvox/source/ocr/parse/OcrTextParser.kt
@@ -1,0 +1,152 @@
+package `in`.jphe.storyvox.source.ocr.parse
+
+import `in`.jphe.storyvox.data.ocr.OcrBlock
+import `in`.jphe.storyvox.data.ocr.OcrRecognition
+
+/**
+ * Issue #995 — pure text-shaping for OCR output.
+ *
+ * ML Kit returns text with hard line breaks at every recognized line
+ * (it OCRs line-by-line, so a single printed paragraph that wraps
+ * across four physical lines comes back as four `\n`-separated lines).
+ * Feeding that straight to TTS produces a stilted, pause-after-every-
+ * line cadence. This object reflows the recognized lines back into
+ * paragraphs and emits clean HTML + plaintext bodies that match the
+ * shape every other [`in`.jphe.storyvox.data.source.FictionSource]
+ * hands back ([htmlBody] for the reader, [plainBody] for TTS).
+ *
+ * Kept Android-types-free and side-effect-free so it unit-tests
+ * without Robolectric — the camera / ML Kit boundary is mocked at the
+ * [OcrRecognition] seam, and everything downstream of that is pure
+ * here.
+ *
+ * ## Reflow heuristic
+ *
+ * - Prefer the recognizer's [OcrRecognition.blocks] (ML Kit's
+ *   paragraph clusters) when present: one block → one paragraph.
+ * - Within a block (or when only flat [OcrRecognition.text] is
+ *   available), join wrapped lines: a line that does NOT end in
+ *   sentence-final punctuation is assumed to continue on the next
+ *   line, so the break becomes a space. A blank line is a hard
+ *   paragraph break.
+ * - De-hyphenate words split across a line break ("encyclo-\npedia" →
+ *   "encyclopedia"), the single most common OCR-of-print artifact.
+ */
+object OcrTextParser {
+
+    /** Sentence-final characters that mark a line as a real line end
+     *  rather than a soft wrap. Includes the common closing quotes /
+     *  brackets that can trail terminal punctuation. */
+    private const val SENTENCE_FINAL = ".!?…\"')]}»”’"
+
+    /**
+     * Build the reader/TTS body for one captured page from its
+     * [recognition]. Returns reflowed paragraphs joined by blank lines
+     * in [plainBody] and wrapped in `<p>` tags in [htmlBody].
+     */
+    fun renderPage(recognition: OcrRecognition): OcrPageBody {
+        val paragraphs = paragraphsFrom(recognition)
+        val plain = paragraphs.joinToString("\n\n")
+        val html = paragraphs.joinToString("\n") { "<p>${escapeHtml(it)}</p>" }
+        return OcrPageBody(htmlBody = html, plainBody = plain)
+    }
+
+    /**
+     * Reflow a [recognition] into a list of paragraph strings. Public
+     * so the document-title heuristic can peek at the first paragraph.
+     */
+    fun paragraphsFrom(recognition: OcrRecognition): List<String> {
+        val blocks = recognition.blocks.filter { it.text.isNotBlank() }
+        return if (blocks.isNotEmpty()) {
+            blocks.map { reflowLines(it.text) }.filter { it.isNotBlank() }
+        } else {
+            // No block structure — split the flat text on blank lines
+            // into paragraph candidates, then reflow each.
+            recognition.text
+                .split(Regex("\\n[ \\t]*\\n"))
+                .map { reflowLines(it) }
+                .filter { it.isNotBlank() }
+        }
+    }
+
+    /**
+     * Suggest a fiction title from the recognized text: the first
+     * non-blank line, trimmed and length-capped. Falls back to
+     * [fallback] when the page has no usable text (a blank scan).
+     */
+    fun suggestTitle(recognition: OcrRecognition, fallback: String): String {
+        val firstLine = recognition.text
+            .lineSequence()
+            .map { it.trim() }
+            .firstOrNull { it.isNotBlank() }
+            ?: recognition.blocks.firstOrNull { it.text.isNotBlank() }
+                ?.text?.lineSequence()?.map { it.trim() }?.firstOrNull { it.isNotBlank() }
+        val candidate = firstLine?.takeIf { it.isNotBlank() } ?: return fallback
+        return candidate.take(MAX_TITLE_LEN).trim()
+    }
+
+    /**
+     * Join wrapped lines within a single paragraph candidate. A line
+     * NOT ending in sentence-final punctuation is treated as a soft
+     * wrap (joined with a space); a trailing hyphen is treated as a
+     * word split (joined with no space, hyphen dropped).
+     */
+    private fun reflowLines(raw: String): String {
+        val lines = raw.split('\n').map { it.trim() }.filter { it.isNotEmpty() }
+        if (lines.isEmpty()) return ""
+        val sb = StringBuilder()
+        for ((i, line) in lines.withIndex()) {
+            if (i == 0) {
+                sb.append(line)
+                continue
+            }
+            val prev = sb.toString()
+            when {
+                // Word split across the break: "encyclo-" + "pedia".
+                // Only de-hyphenate when the char before the hyphen is a
+                // letter, so we don't eat a real trailing dash / range.
+                prev.length >= 2 && prev.last() == '-' && prev[prev.length - 2].isLetter() -> {
+                    sb.setLength(sb.length - 1) // drop the hyphen
+                    sb.append(line)
+                }
+                else -> {
+                    sb.append(' ').append(line)
+                }
+            }
+        }
+        // Collapse any runs of whitespace the joins introduced.
+        return sb.toString().replace(Regex("[ \\t]+"), " ").trim()
+    }
+
+    private fun escapeHtml(s: String): String =
+        s.replace("&", "&amp;")
+            .replace("<", "&lt;")
+            .replace(">", "&gt;")
+
+    /** Naive word count for the chapter-length hint in the picker. */
+    fun wordCount(plain: String): Int {
+        val t = plain.trim()
+        if (t.isEmpty()) return 0
+        return t.split(Regex("\\s+")).size
+    }
+
+    private const val MAX_TITLE_LEN = 80
+
+    /** Exposed for tests / callers that want the sentence-final set. */
+    @Suppress("unused")
+    internal fun isSentenceFinal(line: String): Boolean {
+        val last = line.trimEnd().lastOrNull() ?: return false
+        return SENTENCE_FINAL.contains(last)
+    }
+}
+
+/** Reader (HTML) + TTS (plaintext) bodies for one OCR'd page. */
+data class OcrPageBody(
+    val htmlBody: String,
+    val plainBody: String,
+)
+
+/** Convenience: build an [OcrBlock] list with no confidence — used by
+ *  callers that only have flat text but want to drive the block path. */
+fun flatBlocks(vararg paragraphs: String): List<OcrBlock> =
+    paragraphs.map { OcrBlock(text = it) }

--- a/source-ocr/src/test/kotlin/in/jphe/storyvox/source/ocr/OcrSourceTest.kt
+++ b/source-ocr/src/test/kotlin/in/jphe/storyvox/source/ocr/OcrSourceTest.kt
@@ -44,9 +44,11 @@ class OcrSourceTest {
 
     @Test
     fun `popular lists every scanned document as a fiction`() = runTest {
+        val letterTitle = "Letter"
+        val recipeTitle = "Recipe"
         val source = OcrSource(FakeConfig(listOf(
-            doc("ocr:1", "Letter", "Dear sir"),
-            doc("ocr:2", "Recipe", "Mix flour"),
+            doc("ocr:1", letterTitle, "Dear sir"),
+            doc("ocr:2", recipeTitle, "Mix flour"),
         )))
 
         val res = source.popular()
@@ -55,7 +57,7 @@ class OcrSourceTest {
         val items = (res as FictionResult.Success).value.items
         assertEquals(2, items.size)
         assertEquals(SourceIds.OCR, items[0].sourceId)
-        assertEquals(setOf("Letter", "Recipe"), items.map { it.title }.toSet())
+        assertEquals(setOf(letterTitle, recipeTitle), items.map { it.title }.toSet())
     }
 
     @Test

--- a/source-ocr/src/test/kotlin/in/jphe/storyvox/source/ocr/OcrSourceTest.kt
+++ b/source-ocr/src/test/kotlin/in/jphe/storyvox/source/ocr/OcrSourceTest.kt
@@ -1,0 +1,144 @@
+package `in`.jphe.storyvox.source.ocr
+
+import `in`.jphe.storyvox.data.source.SourceIds
+import `in`.jphe.storyvox.data.source.model.FictionResult
+import `in`.jphe.storyvox.data.source.model.SearchQuery
+import `in`.jphe.storyvox.source.ocr.config.OcrConfig
+import `in`.jphe.storyvox.source.ocr.config.OcrDocument
+import `in`.jphe.storyvox.source.ocr.config.OcrPage
+import `in`.jphe.storyvox.source.ocr.config.fictionIdForOcrCapture
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * Issue #995 — OcrSource read-path contract over a fake [OcrConfig].
+ *
+ * No Robolectric, no ML Kit, no DataStore — the fake stands in for the
+ * `:app`-side store so the source's mapping (document→fiction,
+ * page→chapter, search) is verified in pure JVM. Same fake-source
+ * posture the project uses in PluginManagerLogicTest.
+ */
+class OcrSourceTest {
+
+    private fun doc(
+        id: String,
+        title: String,
+        vararg pageTexts: String,
+    ) = OcrDocument(
+        fictionId = id,
+        title = title,
+        createdAt = 1_000L,
+        pages = pageTexts.mapIndexed { i, t -> OcrPage(index = i, title = "Page ${i + 1}", text = t) },
+    )
+
+    private class FakeConfig(private val docs: List<OcrDocument>) : OcrConfig {
+        override val documents: Flow<List<OcrDocument>> = flowOf(docs)
+        override suspend fun documents(): List<OcrDocument> = docs
+        override suspend fun document(fictionId: String): OcrDocument? =
+            docs.firstOrNull { it.fictionId == fictionId }
+    }
+
+    @Test
+    fun `popular lists every scanned document as a fiction`() = runTest {
+        val source = OcrSource(FakeConfig(listOf(
+            doc("ocr:1", "Letter", "Dear sir"),
+            doc("ocr:2", "Recipe", "Mix flour"),
+        )))
+
+        val res = source.popular()
+
+        assertTrue(res is FictionResult.Success)
+        val items = (res as FictionResult.Success).value.items
+        assertEquals(2, items.size)
+        assertEquals(SourceIds.OCR, items[0].sourceId)
+        assertEquals(setOf("Letter", "Recipe"), items.map { it.title }.toSet())
+    }
+
+    @Test
+    fun `fictionDetail maps each page to a chapter`() = runTest {
+        val source = OcrSource(FakeConfig(listOf(
+            doc("ocr:1", "Doc", "page one text", "page two text", "page three"),
+        )))
+
+        val res = source.fictionDetail("ocr:1")
+
+        assertTrue(res is FictionResult.Success)
+        val detail = (res as FictionResult.Success).value
+        assertEquals(3, detail.chapters.size)
+        assertEquals(listOf(0, 1, 2), detail.chapters.map { it.index })
+        assertEquals(3, detail.summary.chapterCount)
+    }
+
+    @Test
+    fun `fictionDetail returns NotFound for unknown id`() = runTest {
+        val source = OcrSource(FakeConfig(emptyList()))
+
+        val res = source.fictionDetail("ocr:nope")
+
+        assertTrue(res is FictionResult.NotFound)
+    }
+
+    @Test
+    fun `chapter returns the stored page text as plain body`() = runTest {
+        val source = OcrSource(FakeConfig(listOf(
+            doc("ocr:1", "Doc", "first page body", "second page body"),
+        )))
+
+        val detail = (source.fictionDetail("ocr:1") as FictionResult.Success).value
+        val secondChapterId = detail.chapters[1].id
+
+        val res = source.chapter("ocr:1", secondChapterId)
+
+        assertTrue(res is FictionResult.Success)
+        val content = (res as FictionResult.Success).value
+        assertEquals("second page body", content.plainBody)
+        assertTrue(content.htmlBody.contains("<p>second page body</p>"))
+    }
+
+    @Test
+    fun `chapter returns NotFound for unknown chapter`() = runTest {
+        val source = OcrSource(FakeConfig(listOf(doc("ocr:1", "Doc", "only page"))))
+
+        val res = source.chapter("ocr:1", "ocr:1::p99")
+
+        assertTrue(res is FictionResult.NotFound)
+    }
+
+    @Test
+    fun `search matches on title and on page text`() = runTest {
+        val source = OcrSource(FakeConfig(listOf(
+            doc("ocr:1", "Grocery list", "milk eggs bread"),
+            doc("ocr:2", "Poem", "the road less travelled"),
+        )))
+
+        val byTitle = (source.search(SearchQuery(term = "grocery")) as FictionResult.Success).value.items
+        assertEquals(listOf("ocr:1"), byTitle.map { it.id })
+
+        val byBody = (source.search(SearchQuery(term = "travelled")) as FictionResult.Success).value.items
+        assertEquals(listOf("ocr:2"), byBody.map { it.id })
+    }
+
+    @Test
+    fun `empty search term lists all documents`() = runTest {
+        val source = OcrSource(FakeConfig(listOf(doc("ocr:1", "A", "x"), doc("ocr:2", "B", "y"))))
+
+        val res = (source.search(SearchQuery(term = "  ")) as FictionResult.Success).value.items
+
+        assertEquals(2, res.size)
+    }
+
+    @Test
+    fun `fictionIdForOcrCapture is stable for the same inputs and prefixed`() {
+        val a = fictionIdForOcrCapture(1234L, "n1")
+        val b = fictionIdForOcrCapture(1234L, "n1")
+        val c = fictionIdForOcrCapture(1234L, "n2")
+
+        assertEquals(a, b)
+        assertTrue(a != c)
+        assertTrue(a.startsWith("${SourceIds.OCR}:"))
+    }
+}

--- a/source-ocr/src/test/kotlin/in/jphe/storyvox/source/ocr/OcrTextParserTest.kt
+++ b/source-ocr/src/test/kotlin/in/jphe/storyvox/source/ocr/OcrTextParserTest.kt
@@ -1,0 +1,163 @@
+package `in`.jphe.storyvox.source.ocr
+
+import `in`.jphe.storyvox.data.ocr.OcrBlock
+import `in`.jphe.storyvox.data.ocr.OcrRecognition
+import `in`.jphe.storyvox.source.ocr.parse.OcrTextParser
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * Issue #995 — pins the OCR text-shaping contract.
+ *
+ * ML Kit OCRs line-by-line, so a printed paragraph that wraps across
+ * several physical lines comes back as several `\n`-separated lines.
+ * Narrating that verbatim pauses after every line. [OcrTextParser]
+ * reflows wrapped lines back into paragraphs, de-hyphenates split
+ * words, and emits clean HTML + plaintext bodies. These tests fix that
+ * behavior so a refactor can't silently regress the cadence — which is
+ * the whole point of the accessibility feature.
+ */
+class OcrTextParserTest {
+
+    @Test
+    fun `wrapped lines within a paragraph are joined with spaces`() {
+        // A single printed sentence wrapped across three OCR lines.
+        val rec = OcrRecognition(
+            text = "The quick brown fox\njumps over the\nlazy dog.",
+        )
+
+        val body = OcrTextParser.renderPage(rec)
+
+        assertEquals("The quick brown fox jumps over the lazy dog.", body.plainBody)
+        assertFalse("no hard breaks inside a paragraph", body.plainBody.contains("\n"))
+    }
+
+    @Test
+    fun `blank line is a hard paragraph break`() {
+        val rec = OcrRecognition(
+            text = "First paragraph wraps\nacross two lines.\n\nSecond paragraph here.",
+        )
+
+        val paras = OcrTextParser.paragraphsFrom(rec)
+
+        assertEquals(2, paras.size)
+        assertEquals("First paragraph wraps across two lines.", paras[0])
+        assertEquals("Second paragraph here.", paras[1])
+    }
+
+    @Test
+    fun `hyphenated word split across a line break is rejoined`() {
+        // The single most common OCR-of-print artifact.
+        val rec = OcrRecognition(text = "the encyclo-\npedia of birds")
+
+        val body = OcrTextParser.renderPage(rec)
+
+        assertTrue(
+            "expected de-hyphenated 'encyclopedia', got: ${body.plainBody}",
+            body.plainBody.contains("encyclopedia of birds"),
+        )
+        assertFalse(body.plainBody.contains("encyclo-"))
+    }
+
+    @Test
+    fun `a real trailing dash on a non-letter is not eaten`() {
+        // "1939-" then "1945" is a date range, not a word split — the
+        // char before the hyphen is a digit, so we keep the space-join
+        // path rather than gluing.
+        val rec = OcrRecognition(text = "the war 1939-\n1945 ended")
+
+        val body = OcrTextParser.renderPage(rec)
+
+        // We must not silently glue "1939-1945" into the previous word's
+        // de-hyphenation rule (that rule only fires on letters). Either
+        // outcome keeps both numbers; assert both survive.
+        assertTrue(body.plainBody.contains("1939"))
+        assertTrue(body.plainBody.contains("1945"))
+    }
+
+    @Test
+    fun `ML Kit blocks become separate paragraphs`() {
+        val rec = OcrRecognition(
+            text = "ignored when blocks present",
+            blocks = listOf(
+                OcrBlock("Dear Sir,\nI am writing to you"),
+                OcrBlock("Yours faithfully,\nA. Person"),
+            ),
+        )
+
+        val paras = OcrTextParser.paragraphsFrom(rec)
+
+        assertEquals(2, paras.size)
+        assertEquals("Dear Sir, I am writing to you", paras[0])
+        assertEquals("Yours faithfully, A. Person", paras[1])
+    }
+
+    @Test
+    fun `html body wraps each paragraph in p tags and escapes`() {
+        val rec = OcrRecognition(
+            text = "Tom & Jerry\n\n5 < 10 is true",
+        )
+
+        val body = OcrTextParser.renderPage(rec)
+
+        assertEquals(
+            "<p>Tom &amp; Jerry</p>\n<p>5 &lt; 10 is true</p>",
+            body.htmlBody,
+        )
+    }
+
+    @Test
+    fun `blank scan yields empty bodies`() {
+        val rec = OcrRecognition(text = "   \n  \n")
+
+        val body = OcrTextParser.renderPage(rec)
+
+        assertEquals("", body.plainBody)
+        assertEquals("", body.htmlBody)
+        assertTrue(rec.isEmpty)
+    }
+
+    @Test
+    fun `suggestTitle returns first non-blank line trimmed`() {
+        val rec = OcrRecognition(text = "\n   The Great Gatsby   \nby F. Scott Fitzgerald")
+
+        assertEquals("The Great Gatsby", OcrTextParser.suggestTitle(rec, "Scan"))
+    }
+
+    @Test
+    fun `suggestTitle falls back when no text`() {
+        assertEquals(
+            "Scanned page",
+            OcrTextParser.suggestTitle(OcrRecognition.EMPTY, "Scanned page"),
+        )
+    }
+
+    @Test
+    fun `suggestTitle uses block text when flat text is blank`() {
+        val rec = OcrRecognition(
+            text = "",
+            blocks = listOf(OcrBlock("Chapter One\nIt was a dark night")),
+        )
+
+        assertEquals("Chapter One", OcrTextParser.suggestTitle(rec, "Scan"))
+    }
+
+    @Test
+    fun `wordCount counts whitespace-separated tokens`() {
+        assertEquals(0, OcrTextParser.wordCount("   "))
+        assertEquals(1, OcrTextParser.wordCount("hello"))
+        assertEquals(4, OcrTextParser.wordCount("the lazy brown fox"))
+    }
+
+    @Test
+    fun `multiple internal spaces collapse after reflow`() {
+        val rec = OcrRecognition(text = "word1    word2\nword3")
+
+        val body = OcrTextParser.renderPage(rec)
+
+        assertEquals("word1 word2 word3", body.plainBody)
+        assertFalse(body.plainBody.contains("  "))
+    }
+}


### PR DESCRIPTION
## What

Adds an on-device **OCR scan-to-read** flow: point the camera at a printed page (or pick a photo from the gallery), recognize the text offline, and have Candela narrate it through the normal neural-voice pipeline. The assistive-tech bridge from the printed world to accessible audio — for blind / low-vision / dyslexic users, and anyone facing a printed letter, textbook, medicine label, or form.

Closes #995.

## How it fits

Mirrors the `source-epub` leaf-source split (Android plumbing in `:app`, contracts in the source module, zero-network user-content backend):

- **`:core-data`** — new `OcrTextRecognizer` seam (`OcrImage` → `OcrResult` / `OcrRecognition` / `OcrBlock`), deliberately Android-types-free so **#996's scanned-PDF import reuses the exact same recognizer** (render PDF page → bytes → `recognize()`). New `SourceIds.OCR`.
- **`:source-ocr`** (new module) — `OcrSource` (`FictionSource`, `@SourcePlugin`, default-on) surfaces scanned documents as fictions: one capture session = one fiction, each captured page = one chapter. `OcrConfig` / `OcrDocumentStore` contracts. `OcrTextParser` reflows ML Kit's line-by-line output back into paragraphs and de-hyphenates words split across line breaks, so TTS cadence isn't stilted.
- **`:app`** — `MlKitOcrTextRecognizer` (ML Kit Text Recognition v2, **bundled + offline** Latin model — no network, privacy-preserving), `OcrConfigImpl` (DataStore + JSON, read+write), Hilt bindings, `CAMERA` permission (declared `required="false"` so camera-less tablets still install and use the gallery path).
- **`:feature`** — `OcrCaptureScreen`: CameraX live preview + capture, a **first-class gallery-pick alternative** for accessibility, and a plain-language `CAMERA`-permission rationale that never dead-ends the feature when declined. `OcrCaptureViewModel` runs OCR, accumulates pages, persists. "Scan a page" FAB on Library + `OCR_CAPTURE` nav route.

The recognized text plays through the normal `EnginePlayer` with every reader feature (highlight, auto-scroll, pronunciation dict).

## Tests

32 JVM unit tests, no Robolectric — the ML Kit / camera boundary is mocked at the `OcrTextRecognizer` seam:

- `OcrTextParserTest` (12) — paragraph reflow, de-hyphenation, title suggestion, word count, HTML escaping, blank-scan handling
- `OcrSourceTest` (8) — document→fiction / page→chapter mapping, search over title + body, NotFound paths, stable fictionId
- `OcrCaptureViewModelTest` (8) — capture→accumulate→save flow, title seeding, blank-page + recognizer-failure error paths, page re-index on remove
- `OcrConfigImplTest` (4) — DataStore round-trip, newest-first ordering, targeted delete

`:app:compileDebugKotlin` + `:feature:testDebugUnitTest` + `:app:testDebugUnitTest` all green locally.

## Reuse seam for #996

`OcrTextRecognizer` is bound in `AppBindings` as `provideOcrTextRecognizer(MlKitOcrTextRecognizer)`. Scanned-PDF import (#996) injects it directly from `:core-data` (no dep on `:source-ocr`) — render each text-layer-less page to a bitmap → JPEG bytes → `OcrImage` → `recognize()`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * OCR "scan-to-read" flow: camera capture or gallery import, multi-page scanning, edit/save scanned documents, automatic title suggestion and word count, and navigation from capture to saved fiction
  * Library adds a "Scan a page" action; camera is optional with a gallery fallback
  * Scanned documents exposed as a new "Scanned text" source in browsing/search

* **Tests**
  * Unit tests for OCR parsing, recognition/view-model flows, persistence, and source mappings
<!-- end of auto-generated comment: release notes by coderabbit.ai -->