### PR TITLE
ci(wiki): auto-sync wiki pages from canonical repo docs

### DIFF
--- a/.github/workflows/wiki-sync.yml
+++ b/.github/workflows/wiki-sync.yml
@@ -1,0 +1,89 @@
+name: Wiki content sync
+
+# Keeps the GitHub wiki (<repo>.wiki) current from the canonical repo docs.
+#
+# Source of truth is the repo, NOT the wiki. On every push to main that touches
+# docs/, CHANGELOG.md, or settings.gradle.kts, this regenerates the wiki pages
+# it OWNS and pushes them to the .wiki repo. It is idempotent (re-running with no
+# source change produces no commit) and never clobbers hand-authored wiki pages.
+#
+# Two-layer guard against clobbering manual edits:
+#   1. Explicit allowlist (PAGE_MAP below) — only listed pages are ever written.
+#      Hand-authored pages (Home, Getting-started, Fiction-sources, AI-chat,
+#      Voices, Voice-catalog, Settings-reference, Building-from-source,
+#      Troubleshooting) are not in the map and are never touched or deleted.
+#   2. Ownership marker — each generated page starts with an AUTO-GENERATED
+#      comment. Before overwriting an EXISTING page the sync checks for that
+#      marker: present => we own it, overwrite; absent => a human owns it, SKIP
+#      with a warning (takeover is opt-in, never silent). Pages are never deleted.
+#
+# The release-version line in wiki Home.md is owned by release-docs-sync.yml;
+# this workflow deliberately does not touch Home.md.
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'docs/**'
+      - 'CHANGELOG.md'
+      - 'settings.gradle.kts'
+      - '.github/workflows/wiki-sync.yml'
+  workflow_dispatch:
+    inputs:
+      force_takeover:
+        description: 'Overwrite hand-authored wiki pages that lack the AUTO-GENERATED marker (default false).'
+        type: boolean
+        default: false
+
+concurrency:
+  group: wiki-sync-${{ github.ref }}
+  cancel-in-progress: false
+
+permissions:
+  contents: write
+
+jobs:
+  sync:
+    runs-on: [self-hosted, linux]
+    timeout-minutes: 10
+    steps:
+      - name: Checkout repo (canonical source)
+        uses: actions/checkout@v5
+        with:
+          ref: main
+          fetch-depth: 1
+
+      - name: Sync docs -> wiki
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
+          OWNER: ${{ github.repository_owner }}
+          NAME: ${{ github.event.repository.name }}
+          FORCE_TAKEOVER: ${{ inputs.force_takeover }}
+          SRC_SHA: ${{ github.sha }}
+        run: |
+          set -euo pipefail
+
+          WIKI_DIR="$RUNNER_TEMP/wiki"
+          rm -rf "$WIKI_DIR"
+          if ! git clone "https://x-access-token:${GH_TOKEN}@github.com/${REPO}.wiki.git" "$WIKI_DIR" 2>/dev/null; then
+            echo "::warning::Wiki not initialized or not accessible — nothing to sync."
+            echo "Create the first wiki page in the GitHub UI to initialize the .wiki repo, then re-run."
+            exit 0
+          fi
+
+          REPO="$REPO" OWNER="$OWNER" NAME="$NAME" WIKI_DIR="$WIKI_DIR" \
+          FORCE_TAKEOVER="${FORCE_TAKEOVER:-false}" SRC_SHA="$SRC_SHA" \
+          python3 "$GITHUB_WORKSPACE/scripts/wiki/sync_wiki.py"
+
+          cd "$WIKI_DIR"
+          if git diff --quiet && git diff --cached --quiet; then
+            echo "Wiki already in sync — no commit."
+            exit 0
+          fi
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git config user.name  "github-actions[bot]"
+          # The Python step stages only managed pages; commit whatever it staged.
+          git commit -m "docs(wiki): sync from main @ ${SRC_SHA:0:7}"
+          git push
+          echo "Wiki synced and pushed."

--- a/scripts/wiki/sync_wiki.py
+++ b/scripts/wiki/sync_wiki.py
@@ -1,0 +1,298 @@
+#!/usr/bin/env python3
+"""Sync canonical repo docs into the GitHub wiki working tree.
+
+Source of truth is the repo (docs/, CHANGELOG.md, settings.gradle.kts), never the
+wiki. This script regenerates only the wiki pages it OWNS and stages them; the
+calling workflow (.github/workflows/wiki-sync.yml) commits and pushes.
+
+Two-layer guard against clobbering hand-authored wiki pages:
+
+  1. PAGE_MAP allowlist — only pages listed here are ever written. Pages not in
+     the map (Home, Getting-started, Fiction-sources, AI-chat, Voices,
+     Voice-catalog, Settings-reference, Building-from-source, Troubleshooting)
+     are never read, written, or deleted.
+
+  2. Ownership marker (MARKER_RE) — each generated page starts with an
+     AUTO-GENERATED comment. Before overwriting an EXISTING page the script
+     checks for that marker: present => we own it, overwrite; absent => a human
+     owns it, SKIP with a warning. Takeover of a hand-authored page is opt-in
+     via FORCE_TAKEOVER=true (workflow_dispatch input), never silent.
+
+Pages are never deleted: removing a source doc leaves the wiki page in place
+(logged, not removed).
+
+The script is deterministic, so re-running with unchanged sources stages no
+changes and the workflow makes no commit (idempotent).
+
+Environment:
+  WIKI_DIR         path to the cloned .wiki working tree (required)
+  REPO             owner/name slug, e.g. techempower-org/candela (required)
+  OWNER            repository owner, for Pages URLs (required)
+  NAME             repository name, for Pages URLs (required)
+  SRC_SHA          source commit SHA, recorded in the provenance line (optional)
+  FORCE_TAKEOVER   "true" to overwrite marker-less existing pages (optional)
+  GITHUB_WORKSPACE repo checkout root (provided by Actions; falls back to cwd)
+"""
+
+from __future__ import annotations
+
+import os
+import re
+import subprocess
+import sys
+from pathlib import Path
+
+# ---------------------------------------------------------------------------
+# Allowlist: canonical source (relative to repo root) -> wiki page filename.
+# A source of None means the page is generated (see GENERATORS below).
+# ---------------------------------------------------------------------------
+PAGE_MAP: dict[str, str] = {
+    "docs/architecture.md": "Architecture.md",
+    "docs/accessibility.md": "Accessibility.md",
+    "docs/sync.md": "Cloud-sync.md",
+    "docs/compose-gotchas.md": "Compose-gotchas.md",
+    "docs/ROADMAP.md": "Roadmap.md",
+    "CHANGELOG.md": "Changelog.md",
+}
+
+# Wiki pages produced from repo state rather than a single source file.
+# name -> (generator key, human-readable source label)
+GENERATED_PAGES: dict[str, str] = {
+    "Modules.md": "settings.gradle.kts",
+}
+
+# Maps a source doc's intra-repo link target (basename) to the wiki page slug
+# it should point at. Built from PAGE_MAP plus the docs-site landing pages that
+# have no wiki equivalent (those are left pointing at the published site).
+def _wiki_slug(page_filename: str) -> str:
+    """`Architecture.md` -> `Architecture` (GitHub wiki link slug)."""
+    return page_filename[:-3] if page_filename.endswith(".md") else page_filename
+
+
+# Basename of a synced source doc -> wiki slug it should resolve to.
+INTRA_DOC_LINKS: dict[str, str] = {
+    Path(src).name: _wiki_slug(dst) for src, dst in PAGE_MAP.items()
+}
+
+MARKER_PREFIX = "<!-- AUTO-GENERATED FROM"
+MARKER_RE = re.compile(r"^<!-- AUTO-GENERATED FROM .* -->\s*$", re.M)
+
+FRONT_MATTER_RE = re.compile(r"\A---\n.*?\n---\n", re.S)
+
+# Root-relative asset/link like `](/screenshots/x.png)` or `](/voices/)`.
+ROOT_REL_LINK_RE = re.compile(r"\]\((/[^)]+)\)")
+# Intra-doc markdown link like `](architecture.md)` or `](architecture.md#anchor)`.
+INTRA_DOC_LINK_RE = re.compile(r"\]\((?!https?://|/|#)([^)#]+\.md)(#[^)]*)?\)")
+
+
+def repo_root() -> Path:
+    ws = os.environ.get("GITHUB_WORKSPACE")
+    return Path(ws) if ws else Path.cwd()
+
+
+def pages_base_url() -> str:
+    owner = os.environ["OWNER"]
+    name = os.environ["NAME"]
+    return f"https://{owner}.github.io/{name}"
+
+
+def marker(source_label: str) -> str:
+    return (
+        f"<!-- AUTO-GENERATED FROM {source_label} BY "
+        f".github/workflows/wiki-sync.yml — DO NOT EDIT HERE. "
+        f"Edit the source in the repo and push to main. -->"
+    )
+
+
+def provenance(source_label: str) -> str:
+    sha = os.environ.get("SRC_SHA", "")
+    short = sha[:7] if sha else "main"
+    return (
+        f"_Synced from [`{source_label}`]"
+        f"(https://github.com/{os.environ['REPO']}/blob/main/{source_label}) "
+        f"@ `{short}`. Edit there, not here._"
+    )
+
+
+def strip_front_matter(text: str) -> str:
+    return FRONT_MATTER_RE.sub("", text, count=1)
+
+
+def rewrite_links(text: str) -> str:
+    base = pages_base_url()
+
+    def _intra(m: re.Match) -> str:
+        target = m.group(1)
+        anchor = m.group(2) or ""
+        name = Path(target).name
+        slug = INTRA_DOC_LINKS.get(name)
+        if slug:
+            # GitHub wiki links don't carry .md; anchors pass through.
+            return f"]({slug}{anchor})"
+        # Unknown sibling doc — point at the published docs site so it resolves.
+        return f"]({base}/{target}{anchor})"
+
+    text = INTRA_DOC_LINK_RE.sub(_intra, text)
+    # Root-relative -> absolute Pages URL (images, /voices/, etc.).
+    text = ROOT_REL_LINK_RE.sub(lambda m: f"]({base}{m.group(1)})", text)
+    return text
+
+
+def render_doc(source_label: str, raw: str) -> str:
+    body = strip_front_matter(raw)
+    body = rewrite_links(body)
+    return f"{marker(source_label)}\n{provenance(source_label)}\n\n{body.lstrip()}"
+
+
+def parse_modules(settings_text: str) -> list[str]:
+    mods = re.findall(r'include\(\s*"(:[^"]+)"\s*\)', settings_text)
+    # Deterministic order for idempotency.
+    return sorted(set(mods))
+
+
+def render_modules_page(source_label: str, mods: list[str]) -> str:
+    groups: dict[str, list[str]] = {
+        "Application": [],
+        "Feature": [],
+        "Core": [],
+        "Fiction sources": [],
+        "Build / tooling": [],
+        "Other": [],
+    }
+    for m in mods:
+        name = m.lstrip(":")
+        if name in ("app",):
+            groups["Application"].append(m)
+        elif name in ("feature", "wear"):
+            groups["Feature"].append(m)
+        elif name.startswith("core-"):
+            groups["Core"].append(m)
+        elif name.startswith("source-"):
+            groups["Fiction sources"].append(m)
+        elif name in ("baselineprofile", "core-plugin-ksp"):
+            groups["Build / tooling"].append(m)
+        else:
+            groups["Other"].append(m)
+    # core-plugin-ksp is core-prefixed but a build tool; move it explicitly.
+    if ":core-plugin-ksp" in groups["Core"]:
+        groups["Core"].remove(":core-plugin-ksp")
+        groups["Build / tooling"].append(":core-plugin-ksp")
+        groups["Build / tooling"].sort()
+
+    lines = [
+        marker(source_label),
+        provenance(source_label),
+        "",
+        "# Modules",
+        "",
+        f"Candela is a multi-module Gradle project — **{len(mods)} modules** "
+        f"as declared in [`settings.gradle.kts`]"
+        f"(https://github.com/{os.environ['REPO']}/blob/main/settings.gradle.kts). "
+        "This page is generated; the source file is canonical. See "
+        "[Architecture](Architecture) for the dependency graph and module roles.",
+        "",
+    ]
+    for group, members in groups.items():
+        if not members:
+            continue
+        lines.append(f"## {group}")
+        lines.append("")
+        lines.append("| Module |")
+        lines.append("|--------|")
+        for m in members:
+            lines.append(f"| `{m}` |")
+        lines.append("")
+    return "\n".join(lines).rstrip() + "\n"
+
+
+def should_write(dest: Path, force: bool) -> tuple[bool, str]:
+    """Return (write?, reason). Honors the ownership-marker guard."""
+    if not dest.exists():
+        return True, "new page"
+    existing = dest.read_text(encoding="utf-8")
+    if MARKER_RE.search(existing):
+        return True, "owned (marker present)"
+    if force:
+        return True, "FORCE_TAKEOVER override"
+    return False, "hand-authored (no marker) — skipping, not clobbering"
+
+
+def write_if_changed(dest: Path, content: str) -> bool:
+    """Write only if bytes differ. Return True if the file changed on disk."""
+    if dest.exists() and dest.read_text(encoding="utf-8") == content:
+        return False
+    dest.write_text(content, encoding="utf-8")
+    return True
+
+
+def main() -> int:
+    wiki_dir = Path(os.environ["WIKI_DIR"])
+    root = repo_root()
+    force = os.environ.get("FORCE_TAKEOVER", "false").lower() == "true"
+
+    changed: list[str] = []
+    skipped: list[str] = []
+
+    # 1. File-backed pages.
+    for src_rel, page in PAGE_MAP.items():
+        src = root / src_rel
+        if not src.exists():
+            print(f"::warning::source missing, skipping: {src_rel}")
+            continue
+        dest = wiki_dir / page
+        ok, reason = should_write(dest, force)
+        if not ok:
+            print(f"::warning::{page}: {reason} (source {src_rel})")
+            skipped.append(page)
+            continue
+        content = render_doc(src_rel, src.read_text(encoding="utf-8"))
+        if write_if_changed(dest, content):
+            changed.append(page)
+            print(f"{page}: written ({reason}) from {src_rel}")
+        else:
+            print(f"{page}: unchanged")
+
+    # 2. Generated pages.
+    for page, source_label in GENERATED_PAGES.items():
+        dest = wiki_dir / page
+        ok, reason = should_write(dest, force)
+        if not ok:
+            print(f"::warning::{page}: {reason}")
+            skipped.append(page)
+            continue
+        if source_label == "settings.gradle.kts":
+            settings = (root / "settings.gradle.kts").read_text(encoding="utf-8")
+            content = render_modules_page(source_label, parse_modules(settings))
+        else:
+            print(f"::warning::no generator for {page}; skipping")
+            continue
+        if write_if_changed(dest, content):
+            changed.append(page)
+            print(f"{page}: written ({reason}) — generated from {source_label}")
+        else:
+            print(f"{page}: unchanged")
+
+    # 3. Stage ONLY managed pages (never `git add -A`). Use a subprocess arg
+    #    list (not a shell string) so page names can never be a shell-injection
+    #    sink — they are hardcoded constants here, but the arg-list form keeps it
+    #    safe regardless of how PAGE_MAP evolves.
+    managed = list(PAGE_MAP.values()) + list(GENERATED_PAGES.keys())
+    if changed:
+        result = subprocess.run(
+            ["git", "add", "--", *managed],
+            cwd=wiki_dir,
+        )
+        if result.returncode != 0:
+            print("::error::git add failed")
+            return 1
+
+    print(f"\nSummary: {len(changed)} written, {len(skipped)} skipped (hand-authored).")
+    if changed:
+        print("  written: " + ", ".join(changed))
+    if skipped:
+        print("  skipped: " + ", ".join(skipped))
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/wiki/sync_wiki.py
+++ b/scripts/wiki/sync_wiki.py
@@ -145,7 +145,19 @@ def render_doc(source_label: str, raw: str) -> str:
 
 
 def parse_modules(settings_text: str) -> list[str]:
-    mods = re.findall(r'include\(\s*"(:[^"]+)"\s*\)', settings_text)
+    # Line-by-line so commented-out includes don't leak into the wiki, and
+    # accept either quote style. settings.gradle.kts uses double quotes, but a
+    # disabled module is often left as `// include(":foo")` during refactors —
+    # publishing that as a live module would be wrong.
+    mods: list[str] = []
+    include_re = re.compile(r"""include\(\s*['"](:[^'"]+)['"]\s*\)""")
+    for line in settings_text.splitlines():
+        stripped = line.strip()
+        if stripped.startswith(("//", "/*", "*")):
+            continue
+        match = include_re.search(stripped)
+        if match:
+            mods.append(match.group(1))
     # Deterministic order for idempotency.
     return sorted(set(mods))
 
@@ -165,19 +177,16 @@ def render_modules_page(source_label: str, mods: list[str]) -> str:
             groups["Application"].append(m)
         elif name in ("feature", "wear"):
             groups["Feature"].append(m)
+        # Build tools must be matched before the generic core-/source- prefixes:
+        # core-plugin-ksp is core-prefixed but is build tooling, not a core lib.
+        elif name in ("baselineprofile", "core-plugin-ksp"):
+            groups["Build / tooling"].append(m)
         elif name.startswith("core-"):
             groups["Core"].append(m)
         elif name.startswith("source-"):
             groups["Fiction sources"].append(m)
-        elif name in ("baselineprofile", "core-plugin-ksp"):
-            groups["Build / tooling"].append(m)
         else:
             groups["Other"].append(m)
-    # core-plugin-ksp is core-prefixed but a build tool; move it explicitly.
-    if ":core-plugin-ksp" in groups["Core"]:
-        groups["Core"].remove(":core-plugin-ksp")
-        groups["Build / tooling"].append(":core-plugin-ksp")
-        groups["Build / tooling"].sort()
 
     lines = [
         marker(source_label),
@@ -226,6 +235,17 @@ def write_if_changed(dest: Path, content: str) -> bool:
 
 
 def main() -> int:
+    # Validate required env upfront so a missing var fails with a clear message
+    # instead of a mid-run KeyError traceback that's painful to diagnose in CI.
+    required = ["WIKI_DIR", "REPO", "OWNER", "NAME"]
+    missing = [v for v in required if not os.environ.get(v)]
+    if missing:
+        print(
+            f"::error::missing required env var(s): {', '.join(missing)}",
+            file=sys.stderr,
+        )
+        return 1
+
     wiki_dir = Path(os.environ["WIKI_DIR"])
     root = repo_root()
     force = os.environ.get("FORCE_TAKEOVER", "false").lower() == "true"

--- a/scripts/wiki/test_sync_wiki.py
+++ b/scripts/wiki/test_sync_wiki.py
@@ -1,0 +1,160 @@
+#!/usr/bin/env python3
+"""Tests for sync_wiki.py — run with: python3 scripts/wiki/test_sync_wiki.py
+
+Pure-stdlib (no pytest dependency) so it runs anywhere python3 is present,
+matching the repo convention of not adding test frameworks unprompted.
+"""
+
+import os
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+# Env that the module reads at import/call time.
+os.environ.setdefault("REPO", "techempower-org/candela")
+os.environ.setdefault("OWNER", "techempower-org")
+os.environ.setdefault("NAME", "candela")
+os.environ.setdefault("SRC_SHA", "abcdef1234567890")
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+import sync_wiki as sw  # noqa: E402
+
+
+class StripFrontMatter(unittest.TestCase):
+    def test_strips_leading_jekyll_block(self):
+        raw = "---\nlayout: default\ntitle: X\n---\n# Heading\n\nBody\n"
+        self.assertEqual(sw.strip_front_matter(raw), "# Heading\n\nBody\n")
+
+    def test_no_front_matter_passthrough(self):
+        raw = "# Heading\n\nBody\n"
+        self.assertEqual(sw.strip_front_matter(raw), raw)
+
+    def test_only_strips_first_block(self):
+        raw = "---\na: 1\n---\nbody\n---\nfooter rule\n---\n"
+        out = sw.strip_front_matter(raw)
+        self.assertTrue(out.startswith("body\n"))
+        self.assertIn("footer rule", out)
+
+
+class RewriteLinks(unittest.TestCase):
+    def test_intra_doc_known_target_to_wiki_slug(self):
+        # compose-gotchas.md is in PAGE_MAP -> Compose-gotchas
+        out = sw.rewrite_links("see [gotchas](compose-gotchas.md) here")
+        self.assertIn("[gotchas](Compose-gotchas)", out)
+
+    def test_intra_doc_with_anchor_preserved(self):
+        out = sw.rewrite_links("[a](architecture.md#data-flow)")
+        self.assertIn("[a](Architecture#data-flow)", out)
+
+    def test_intra_doc_unknown_target_to_pages_site(self):
+        out = sw.rewrite_links("[x](some-other-doc.md)")
+        self.assertIn(
+            "[x](https://techempower-org.github.io/candela/some-other-doc.md)", out
+        )
+
+    def test_root_relative_to_pages(self):
+        out = sw.rewrite_links("![s](/screenshots/03-reader.png)")
+        self.assertIn(
+            "![s](https://techempower-org.github.io/candela/screenshots/03-reader.png)",
+            out,
+        )
+
+    def test_absolute_links_untouched(self):
+        raw = "[ext](https://example.com/x.md)"
+        self.assertEqual(sw.rewrite_links(raw), raw)
+
+
+class RenderDoc(unittest.TestCase):
+    def test_marker_and_provenance_prepended(self):
+        out = sw.render_doc("docs/architecture.md", "---\ntitle: A\n---\n# Arch\n")
+        self.assertTrue(out.startswith(sw.MARKER_PREFIX))
+        self.assertIn("docs/architecture.md", out)
+        self.assertIn("abcdef1", out)  # short sha
+        self.assertIn("# Arch", out)
+
+    def test_idempotent_render(self):
+        raw = "---\ntitle: A\n---\n# Arch\n\nbody\n"
+        self.assertEqual(
+            sw.render_doc("docs/architecture.md", raw),
+            sw.render_doc("docs/architecture.md", raw),
+        )
+
+
+class ParseModules(unittest.TestCase):
+    SETTINGS = (
+        'rootProject.name = "x"\n'
+        'include(":app")\n'
+        'include(":source-rss")\n'
+        'include( ":core-data" )\n'
+        'include(":app")\n'  # duplicate
+    )
+
+    def test_dedup_and_sorted(self):
+        self.assertEqual(
+            sw.parse_modules(self.SETTINGS),
+            [":app", ":core-data", ":source-rss"],
+        )
+
+
+class RenderModulesPage(unittest.TestCase):
+    def test_groups_and_count(self):
+        mods = [":app", ":core-data", ":core-plugin-ksp", ":source-rss", ":wear", ":baselineprofile"]
+        page = sw.render_modules_page("settings.gradle.kts", mods)
+        self.assertTrue(page.startswith(sw.MARKER_PREFIX))
+        self.assertIn("**6 modules**", page)
+        self.assertIn("## Application", page)
+        self.assertIn("## Fiction sources", page)
+        self.assertIn("`:source-rss`", page)
+        # core-plugin-ksp is reclassified as build tooling, not core
+        bt = page.split("## Build / tooling")[1]
+        self.assertIn(":core-plugin-ksp", bt)
+
+
+class ShouldWrite(unittest.TestCase):
+    def test_new_page_writes(self):
+        with tempfile.TemporaryDirectory() as d:
+            dest = Path(d) / "New.md"
+            ok, _ = sw.should_write(dest, force=False)
+            self.assertTrue(ok)
+
+    def test_marked_page_overwrites(self):
+        with tempfile.TemporaryDirectory() as d:
+            dest = Path(d) / "Owned.md"
+            dest.write_text(sw.marker("docs/x.md") + "\nstuff\n")
+            ok, _ = sw.should_write(dest, force=False)
+            self.assertTrue(ok)
+
+    def test_handauthored_page_skipped(self):
+        with tempfile.TemporaryDirectory() as d:
+            dest = Path(d) / "Human.md"
+            dest.write_text("# Hand written\n\nNo marker here.\n")
+            ok, reason = sw.should_write(dest, force=False)
+            self.assertFalse(ok)
+            self.assertIn("hand-authored", reason)
+
+    def test_handauthored_page_force_overrides(self):
+        with tempfile.TemporaryDirectory() as d:
+            dest = Path(d) / "Human.md"
+            dest.write_text("# Hand written\n")
+            ok, reason = sw.should_write(dest, force=True)
+            self.assertTrue(ok)
+            self.assertIn("FORCE", reason)
+
+
+class WriteIfChanged(unittest.TestCase):
+    def test_no_change_returns_false(self):
+        with tempfile.TemporaryDirectory() as d:
+            dest = Path(d) / "P.md"
+            dest.write_text("same\n")
+            self.assertFalse(sw.write_if_changed(dest, "same\n"))
+
+    def test_change_returns_true(self):
+        with tempfile.TemporaryDirectory() as d:
+            dest = Path(d) / "P.md"
+            dest.write_text("old\n")
+            self.assertTrue(sw.write_if_changed(dest, "new\n"))
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/scripts/wiki/test_sync_wiki.py
+++ b/scripts/wiki/test_sync_wiki.py
@@ -96,6 +96,26 @@ class ParseModules(unittest.TestCase):
             [":app", ":core-data", ":source-rss"],
         )
 
+    def test_commented_out_includes_ignored(self):
+        text = (
+            'include(":app")\n'
+            '// include(":source-disabled")\n'
+            '  //include(":also-disabled")\n'
+            '/* include(":block-disabled") */\n'
+            'include(":core-data")\n'
+        )
+        self.assertEqual(
+            sw.parse_modules(text),
+            [":app", ":core-data"],
+        )
+
+    def test_single_quoted_include_accepted(self):
+        text = "include(':source-rss')\ninclude(\":app\")\n"
+        self.assertEqual(
+            sw.parse_modules(text),
+            [":app", ":source-rss"],
+        )
+
 
 class RenderModulesPage(unittest.TestCase):
     def test_groups_and_count(self):


### PR DESCRIPTION
## What

Adds a GitHub Action that keeps the [candela.wiki](https://github.com/techempower-org/candela/wiki) current from the repo automatically. **`docs/` is the source of truth** — edit docs, push to main, the wiki follows.

- `.github/workflows/wiki-sync.yml` — fires on push to `main` touching `docs/**`, `CHANGELOG.md`, or `settings.gradle.kts` (plus `workflow_dispatch`). Clones `.wiki` via `GITHUB_TOKEN`, regenerates the pages it owns, commits + pushes.
- `scripts/wiki/sync_wiki.py` — the sync engine (pure stdlib, testable).
- `scripts/wiki/test_sync_wiki.py` — 18 unit tests.

## Pages it syncs

| canonical source | wiki page |
|---|---|
| `docs/architecture.md` | Architecture |
| `docs/accessibility.md` | Accessibility |
| `docs/sync.md` | Cloud-sync |
| `docs/compose-gotchas.md` | Compose-gotchas |
| `docs/ROADMAP.md` | Roadmap |
| `CHANGELOG.md` | Changelog |
| _generated_ from `settings.gradle.kts` | Modules |

Jekyll front-matter stripped; intra-doc links remapped to wiki slugs; root-relative asset links rewritten to the Pages site. Repo owner/name derived from `github.repository` at runtime (no hardcoded URLs).

## Safety — never blanket-overwrites the wiki

Two independent guards so hand-authored wiki pages stay untouched:

1. **Allowlist** — only mapped pages are ever written. The nine hand-authored pages (Home, Getting-started, Fiction-sources, AI-chat, Voices, Voice-catalog, Settings-reference, Building-from-source, Troubleshooting) are never read, written, or deleted.
2. **Ownership marker** — every generated page starts with an `AUTO-GENERATED … DO NOT EDIT HERE` comment. An existing page is overwritten **only if it carries that marker**; a marker-less page is **skipped with a warning** (takeover is opt-in via the `force_takeover` dispatch input, never silent). Pages are never deleted.

**Idempotent**: deterministic transform + write-if-changed → a re-run with no source change stages nothing and makes no commit.

Deliberately does **not** touch `Home.md` — its `_Current version:_` line is owned by the existing `release-docs-sync.yml` (found and not duplicated).

## Validation

- 18 unit tests pass (front-matter strip, link rewrite, module parse/group, marker guard, idempotency).
- End-to-end against a live clone of `candela.wiki`: first run **skipped** the hand-authored `Architecture.md` and created 6 pages; second run was a clean **no-op**; `force_takeover` overwrote as expected.
- Workflow YAML validates; all `${{ }}` inputs flow through `env:` (no injection sinks); git invoked via subprocess arg-list (no shell string).

## Follow-up decision (not blocking this PR)

The wiki's hand-authored `Architecture.md` (from the rebrand) lacks the marker, so the sync will skip it until someone deletes the manual page or runs `force_takeover`. Canonical `docs/architecture.md` is richer; recommend taking it over once this lands.

Related: also reconciled the duplicate `_Current version:_` line on the wiki `Home.md` (pushed directly to the wiki — wikis have no PR).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Wiki pages now auto-sync from repository docs on pushes to main, with a manual "force takeover" trigger.
  * Sync preserves hand-authored pages (won’t overwrite unless forced), never deletes pages, rewrites links for wiki/pages, and generates a Modules summary page.
* **Tests**
  * Added unit tests covering front-matter stripping, link rewriting, module parsing, write/overwrite rules, and idempotent output.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->