### PR TITLE
fix(sync): bookmarks syncer no longer deletes local-only bookmarks (#1029)

### DIFF
--- a/core-sync/src/main/kotlin/in/jphe/storyvox/sync/domain/BookmarksSyncer.kt
+++ b/core-sync/src/main/kotlin/in/jphe/storyvox/sync/domain/BookmarksSyncer.kt
@@ -26,6 +26,12 @@ import kotlinx.serialization.json.Json
  * format too so a sync round can clear a bookmark; absence means "no
  * change," null means "explicitly cleared." This avoids needing a
  * tombstone log.
+ *
+ * Local-only adds (#1029): a bookmark added on this device but not yet on
+ * the wire is *absent* from a winning remote map, not explicitly cleared,
+ * so it is preserved locally and unioned into the pushed payload rather
+ * than deleted. Only a remote entry mapped to null clears a local
+ * bookmark; mere absence never does.
  */
 @Singleton
 class BookmarksSyncer @Inject constructor(
@@ -59,21 +65,44 @@ class BookmarksSyncer @Inject constructor(
         }
         val remoteMap = remotePayload?.bookmarks.orEmpty()
 
-        val merged = when {
-            remotePayload == null -> localMap
-            remotePayload.updatedAt > (remoteSnap.updatedAt - 1L) && remoteMap == localMap -> localMap
-            // LWW: pick whichever side is newer. We don't have a local
-            // updatedAt stamp per the chapter row (bookmark write
-            // doesn't bump a timestamp), so the local "stamp" is the
-            // last push attempt for this domain — if remote is strictly
-            // newer than that, take remote.
-            remotePayload.updatedAt > readLastSyncStamp() -> remoteMap
-            else -> localMap
+        // Pick the LWW winner for the *shared* keys. We don't have a
+        // local updatedAt stamp per the chapter row (bookmark write
+        // doesn't bump a timestamp), so the local "stamp" is the last
+        // push attempt for this domain — if remote is strictly newer
+        // than that, take remote.
+        val remoteWins = when {
+            remotePayload == null -> false
+            remotePayload.updatedAt > (remoteSnap.updatedAt - 1L) && remoteMap == localMap -> false
+            else -> remotePayload.updatedAt > readLastSyncStamp()
         }
 
-        // Apply merged to local: write every chapterId in [merged] that
-        // diverges from local, and clear chapters present in remote
-        // with null offset.
+        // Build the merged set honoring the documented wire contract
+        // (#1029): absence means "no change," null means "explicitly
+        // cleared." A local-only bookmark — added on this device and not
+        // yet on the wire — is *absent* from a winning remote map, NOT
+        // explicitly cleared, so it must be preserved (and propagated),
+        // never deleted on mere absence.
+        //
+        // - Start from whichever side wins LWW for the keys both sides
+        //   know about.
+        // - Union in every local-only bookmark (present locally, the
+        //   remote has no entry for that id at all) so an unsynced local
+        //   add survives this round and rides out on the push payload.
+        // - A remote *explicit* null (id -> null in remoteMap) is the
+        //   only delete signal; such ids stay null in [merged] so the
+        //   apply loop clears them locally and the push doesn't resurrect
+        //   them.
+        val merged = LinkedHashMap<String, Int?>()
+        merged.putAll(if (remoteWins) remoteMap else localMap)
+        if (remoteWins) {
+            for ((id, offset) in localMap) {
+                if (!remoteMap.containsKey(id)) merged[id] = offset
+            }
+        }
+
+        // Apply [merged] to local: write every chapterId whose offset
+        // diverges from local (including explicit nulls, which clear the
+        // local bookmark).
         //
         // Guard (#885): `setBookmark` is an UPDATE … WHERE id = :id, a
         // silent no-op when the chapter row doesn't exist locally yet
@@ -86,19 +115,16 @@ class BookmarksSyncer @Inject constructor(
         var writes = 0
         var skipped = 0
         for ((id, offset) in merged) {
+            // localMap only holds non-null offsets (allBookmarks() is
+            // WHERE bookmarkCharOffset IS NOT NULL), so a local-absent id
+            // with a null merged offset compares equal (null == null) and
+            // is correctly skipped as already in the desired state.
             if (localMap[id] != offset) {
                 if (!chapterDao.exists(id)) {
                     skipped++
                     continue
                 }
                 chapterDao.setBookmark(id, offset)
-                writes++
-            }
-        }
-        // Clear local bookmarks that the remote explicitly removed.
-        for ((id, _) in localMap) {
-            if (!merged.containsKey(id)) {
-                chapterDao.setBookmark(id, null)
                 writes++
             }
         }

--- a/core-sync/src/test/kotlin/in/jphe/storyvox/sync/BookmarksSyncerTest.kt
+++ b/core-sync/src/test/kotlin/in/jphe/storyvox/sync/BookmarksSyncerTest.kt
@@ -16,6 +16,7 @@ import `in`.jphe.storyvox.sync.domain.BookmarksSyncer
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.test.runTest
+import kotlinx.serialization.json.Json
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertTrue
 import org.junit.Test
@@ -36,6 +37,7 @@ import org.junit.Test
 class BookmarksSyncerTest {
 
     private val USER = SignedInUser(userId = "u-1", email = null, refreshToken = "rt-1")
+    private val json = Json { ignoreUnknownKeys = true }
 
     @Test fun `cold restart between sync passes does not clobber the local bookmark`() = runTest {
         val backend = FakeInstantBackend()
@@ -75,6 +77,84 @@ class BookmarksSyncerTest {
         // The persisted stamp moved forward.
         val stampAfterRound2 = prefs.getLong("instantdb.bookmarks_synced_at", 0L)
         assertTrue("stamp must advance on subsequent push", stampAfterRound2 >= stampAfterRound1)
+    }
+
+    /**
+     * Issue #1029 (data loss): a bookmark added on device A but not yet
+     * on the wire must NOT be deleted when device A pulls a remote blob
+     * that wins LWW. The remote merely *doesn't know about* the new
+     * bookmark (it's absent), which the documented wire contract defines
+     * as "no change" — only an explicit null clears a bookmark.
+     *
+     * Repro:
+     *  1. Device B pushes {ch1=100} → remote blob, updatedAt = T1.
+     *  2. Device A (fresh stamp = 0L, i.e. hasn't synced since B's push)
+     *     has local {ch1=100, ch2=200}.
+     *  3. A syncs. remote.updatedAt (T1) > A's stamp (0L) → remote wins.
+     *  4. Old code: ch2 ∈ local, ch2 ∉ winning map → setBookmark(ch2,
+     *     null). A's just-added bookmark is destroyed and was never on
+     *     the wire as an explicit null.
+     *
+     * With the fix, ch2 (a local-only add, absent from remote) survives
+     * locally AND is unioned into the pushed payload so it propagates.
+     */
+    @Test fun `local-only bookmark survives a winning remote that never had it`() = runTest {
+        val backend = FakeInstantBackend()
+
+        // Device B: pushes {ch1=100} to the shared remote.
+        val prefsB = FakePrefs()
+        val daoB = FakeChapterDao(bookmarks = mutableMapOf("ch1" to 100))
+        val syncerB = BookmarksSyncer(chapterDao = daoB, backend = backend, prefs = prefsB)
+        assertTrue(syncerB.push(USER) is SyncOutcome.Ok)
+
+        // Device A: fresh prefs (stamp 0L → hasn't synced since B's push),
+        // and a local-only bookmark ch2 that the remote has never seen.
+        val prefsA = FakePrefs()
+        val daoA = FakeChapterDao(bookmarks = mutableMapOf("ch1" to 100, "ch2" to 200))
+        val syncerA = BookmarksSyncer(chapterDao = daoA, backend = backend, prefs = prefsA)
+        val rA = syncerA.pull(USER)
+        assertTrue("device A sync succeeds: $rA", rA is SyncOutcome.Ok)
+
+        // ch2 survives locally — it was never explicitly cleared.
+        assertEquals("ch1 unchanged", 100, daoA.bookmarks["ch1"])
+        assertEquals("local-only ch2 must NOT be deleted on mere absence", 200, daoA.bookmarks["ch2"])
+
+        // ...and it rode out on the pushed payload, so it propagates.
+        val snap = backend.fetch(USER, "blobs", SyncIds.rowUuid("bookmarks", USER.userId)).getOrNull()
+        requireNotNull(snap) { "remote blob must exist after a push" }
+        val pushed = json
+            .decodeFromString(BookmarksSyncer.Payload.serializer(), snap.payload)
+            .bookmarks
+        assertEquals("ch1 retained on the wire", 100, pushed["ch1"])
+        assertEquals("local-only ch2 must be unioned into the push payload", 200, pushed["ch2"])
+    }
+
+    /**
+     * The flip side of #1029: an *explicit* remote null (id -> null) is
+     * the one legitimate delete signal and must still clear the local
+     * bookmark. This guards against an over-correction that would never
+     * delete anything.
+     */
+    @Test fun `explicit remote null still clears the local bookmark`() = runTest {
+        val backend = FakeInstantBackend()
+
+        // Seed the remote directly with an explicit-null clear for ch2,
+        // newer than device A's stamp (0L) so remote wins.
+        backend.upsert(
+            user = USER,
+            entity = "blobs",
+            id = SyncIds.rowUuid("bookmarks", USER.userId),
+            payload = """{"bookmarks":{"ch1":100,"ch2":null},"updatedAt":${System.currentTimeMillis()}}""",
+            updatedAt = System.currentTimeMillis(),
+        )
+
+        val prefsA = FakePrefs()
+        val daoA = FakeChapterDao(bookmarks = mutableMapOf("ch1" to 100, "ch2" to 200))
+        val syncerA = BookmarksSyncer(chapterDao = daoA, backend = backend, prefs = prefsA)
+        assertTrue(syncerA.pull(USER) is SyncOutcome.Ok)
+
+        assertEquals("ch1 unchanged", 100, daoA.bookmarks["ch1"])
+        assertTrue("ch2 must be cleared by the explicit remote null", daoA.bookmarks["ch2"] == null)
     }
 
     @Test fun `stamp is written even on a no-op sync round`() = runTest {
@@ -179,7 +259,6 @@ class BookmarksSyncerTest {
             audioUrl: String?,
         ) = error("not used")
         override suspend fun setRead(id: String, read: Boolean, now: Long) = error("not used")
-        override suspend fun markFollowedCaughtUp(now: Long): Int = error("not used")
         override suspend fun trimDownloadedBodies(fictionId: String, keepLast: Int) = error("not used")
         override suspend fun cacheUsage(): `in`.jphe.storyvox.data.db.dao.ChapterCacheUsageRow =
             error("not used")

--- a/core-sync/src/test/kotlin/in/jphe/storyvox/sync/PlaybackPositionSyncerTest.kt
+++ b/core-sync/src/test/kotlin/in/jphe/storyvox/sync/PlaybackPositionSyncerTest.kt
@@ -259,7 +259,6 @@ class PlaybackPositionSyncerTest {
             audioUrl: String?,
         ) = error("not used")
         override suspend fun setRead(id: String, read: Boolean, now: Long) = error("not used")
-        override suspend fun markFollowedCaughtUp(now: Long): Int = error("not used")
         override suspend fun trimDownloadedBodies(fictionId: String, keepLast: Int) = error("not used")
         override suspend fun cacheUsage(): ChapterCacheUsageRow = error("not used")
         override suspend fun chapterIdsForFiction(fictionId: String): List<String> = emptyList()


### PR DESCRIPTION
Closes #1029.

## The bug (silent data loss)

`BookmarksSyncer`'s local-clear loop deleted any local bookmark **absent from the winning merged map**, treating absence as a delete signal:

```kotlin
for ((id, _) in localMap) {
    if (!merged.containsKey(id)) { chapterDao.setBookmark(id, null); writes++ }
}
```

But `localMap` only holds real bookmarks, and when the remote wins LWW (`merged = remoteMap`), any **local-only** bookmark — one the user just added on this device, not yet pushed — isn't in `merged`, so it gets cleared. That contradicts the class's own documented wire contract:

> absence means "no change," null means "explicitly cleared."

The remote never *cleared* the bookmark; it simply didn't know about it yet.

## The fix

Issue's Option 1, plus a payload union so the entry actually propagates:

- **Only an explicit remote null clears a local bookmark.** The dedicated absence-based clear loop is removed; explicit nulls (`id -> null` in a winning remoteMap) now flow through the normal apply loop (a null offset diverges from a non-null local row → `setBookmark(id, null)`).
- **Local-only adds are preserved and propagated.** A bookmark present locally with no key at all in a winning remoteMap is unioned into `merged`, so it survives this round *and* rides out on the pushed payload to reach other devices.

No schema change. The documented "whole-map LWW loses concurrent same-key edits" v1 limitation is untouched — this PR is strictly about the undocumented absence-vs-null delete bug.

## Tests

`:core-sync:testDebugUnitTest` — 124 passing. Two new regression tests in `BookmarksSyncerTest`:

- `local-only bookmark survives a winning remote that never had it` — the #1029 repro. **Verified it fails on the pre-fix code** with `expected:<200> but was:<null>` (ch2 destroyed), and passes after. Asserts ch2 survives locally **and** appears in the pushed payload.
- `explicit remote null still clears the local bookmark` — the inverse guard, so the fix doesn't over-correct into "never delete."

## Incidental fix (was blocking the build)

The `FakeChapterDao` in both `BookmarksSyncerTest` and `PlaybackPositionSyncerTest` had a **duplicate `markFollowedCaughtUp(now: Long)` override** — a "Conflicting overloads" compile error (surfaced by the Kotlin 2.3 migration) that prevented the entire `:core-sync` test source set from compiling. Removed the stray copies. No production code touched.

## Verification

- [x] `:core-sync:testDebugUnitTest` green (124 tests)
- [x] `:app:assembleDebug` builds (gate: Build APK required)
- [x] New test confirmed red-on-old / green-on-new

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Local bookmarks are now preserved during sync when absent from remote source
  * Only explicit remote deletions remove local bookmarks; mere absence no longer triggers deletion

<!-- end of auto-generated comment: release notes by coderabbit.ai -->