### PR TITLE
feat(app): make-your-own-audiobook — export chaptered M4B (#1003)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ Entries before v0.5.12 are reconstructed from the git log — see
 
 ## [Unreleased]
 
+### Added
+- **#1003** **Make your own audiobook** — turn your own text into a saved, shareable audiobook, entirely offline. A new "Make your own audiobook" entry on the Library **+** menu takes pasted/typed text → auto-chapterizes it → narrates it with a downloaded neural voice → exports a **chaptered `.m4b`** (chapter markers + title/author/cover metadata) you can play in Candela and share via the Android share sheet / Save-As (SAF). The same export is available from any library book via Fiction detail → **Export as audiobook…**. The render runs in a background WorkManager job with a progress notification. New `:source-audiobook-writer` module holds the (unit-tested) chapterizer, Nero `chpl` chapter atom + iTunes metadata box builders, and the in-place `moov`/`udta` injector; `:core-playback` adds the AAC `MediaMuxer` encoder, the synthesizer, and the export use case + worker.
+
 ## [1.0.3] -- 2026-05-29
 
 **Rebrand to Candela.** The app is now **Candela** — Latin for *candle*, and the SI unit of luminous intensity. It's a clean public identity for the Google Play debut, away from the crowded "storyvox" name (already live on Play as a different app, and owned by two commercial text-to-audiobook products in our exact category). *Storyvox* lives on as the engine underneath — the package namespace, deep-link scheme, and on-device data layout are all unchanged, so this is purely an identity change with no data migration.

--- a/core-data/src/main/kotlin/in/jphe/storyvox/data/source/SourceIds.kt
+++ b/core-data/src/main/kotlin/in/jphe/storyvox/data/source/SourceIds.kt
@@ -250,6 +250,17 @@ object SourceIds {
     const val READABILITY: String = "readability"
 
     /**
+     * Issue #1003 — "Make your own audiobook." Text the user pastes / types /
+     * imports in the Create-audiobook flow becomes a local fiction under this
+     * source id (`myaudiobook:<uuid>`). Purely device-local, user-authored
+     * content: there is no remote backend to re-fetch from, so these rows are
+     * never polled for new chapters and are not rebuildable on another device
+     * (the text lived only in the paste). The export pipeline narrates the
+     * chapters into a shareable `.m4b`.
+     */
+    const val MY_AUDIOBOOK: String = "myaudiobook"
+
+    /**
      * Issue #989 — the sources whose fiction `id` is an opaque,
      * non-reversible hash of the source URL, so the id alone is NOT
      * enough to rebuild the fiction on a device that never saw the

--- a/core-playback/build.gradle.kts
+++ b/core-playback/build.gradle.kts
@@ -57,6 +57,11 @@ dependencies {
     // generateAudioPCM dispatch table. Pure-JVM module, no AAR; brings
     // OkHttp + the SSML builder + the engine handle adapter.
     implementation(project(":source-azure"))
+    // Issue #1003 — pure chapterizer + M4B chapter/metadata box math for the
+    // "Make your own audiobook" export. The Android encode + mux + the
+    // ExportFictionToAudiobookUseCase live here (we already carry the VoxSherpa
+    // engines + WorkManager); this leaf module supplies the testable pieces.
+    implementation(project(":source-audiobook-writer"))
 
     implementation(libs.androidx.core.ktx)
     implementation(libs.kotlinx.coroutines.android)

--- a/core-playback/src/main/kotlin/in/jphe/storyvox/playback/audiobook/AacM4bEncoder.kt
+++ b/core-playback/src/main/kotlin/in/jphe/storyvox/playback/audiobook/AacM4bEncoder.kt
@@ -1,0 +1,206 @@
+package `in`.jphe.storyvox.playback.audiobook
+
+import android.media.MediaCodec
+import android.media.MediaCodecInfo
+import android.media.MediaFormat
+import android.media.MediaMuxer
+import android.util.Log
+import `in`.jphe.storyvox.source.audiobook.writer.ChapterMarker
+import `in`.jphe.storyvox.source.audiobook.writer.Mp4ChapterMarkers
+import `in`.jphe.storyvox.source.audiobook.writer.Mp4MetadataInjector
+import java.io.File
+import java.io.RandomAccessFile
+import java.nio.ByteBuffer
+
+/**
+ * Encodes a sequence of per-chapter PCM buffers into a single chaptered
+ * `.m4b` audiobook (issue #1003).
+ *
+ * Pipeline:
+ *  1. **AAC encode + mux** — one [MediaCodec] AAC-LC encoder feeds one
+ *     [MediaMuxer] (MPEG-4 container). All chapters share one continuous audio
+ *     track; we record each chapter's byte length so we can compute its
+ *     duration for the chapter markers. PCM is 16-bit mono at [sampleRate].
+ *  2. **Chapter + metadata injection** — once the muxer has written the file
+ *     (with its `moov` atom trailing `mdat`), [Mp4MetadataInjector] appends a
+ *     `udta` box carrying the Nero `chpl` chapter list and iTunes title /
+ *     author / cover tags, then grows the `moov` size in place. See that
+ *     class for why this is safe without rewriting sample-chunk offsets.
+ *
+ * The encode loop is a textbook MediaCodec sync-mode drain: queue input
+ * buffers from the PCM, dequeue output buffers, write encoded samples to the
+ * muxer, signal end-of-stream, drain the tail. No threads — synthesis already
+ * happened; this is CPU-bound transcode the WorkManager job runs off the main
+ * thread.
+ */
+class AacM4bEncoder {
+
+    /** One chapter's already-synthesized audio. */
+    data class ChapterAudio(val title: String, val pcm: ByteArray) {
+        override fun equals(other: Any?): Boolean {
+            if (this === other) return true
+            if (other !is ChapterAudio) return false
+            return title == other.title && pcm.contentEquals(other.pcm)
+        }
+        override fun hashCode(): Int = 31 * title.hashCode() + pcm.contentHashCode()
+    }
+
+    /**
+     * Encode [chapters] to [outFile] as a chaptered M4B. [sampleRate] is the
+     * PCM sample rate; [title]/[author]/[cover] become container metadata.
+     *
+     * Returns the chapter markers actually written (with their computed start
+     * offsets) for logging / UI. Throws on encoder configuration failure.
+     */
+    fun encode(
+        chapters: List<ChapterAudio>,
+        sampleRate: Int,
+        title: String,
+        author: String,
+        cover: ByteArray?,
+        outFile: File,
+    ): List<ChapterMarker> {
+        require(chapters.isNotEmpty()) { "no chapters to encode" }
+
+        val format = MediaFormat.createAudioFormat(MIME_AAC, sampleRate, CHANNELS).apply {
+            setInteger(MediaFormat.KEY_AAC_PROFILE, MediaCodecInfo.CodecProfileLevel.AACObjectLC)
+            setInteger(MediaFormat.KEY_BIT_RATE, BIT_RATE)
+            setInteger(MediaFormat.KEY_MAX_INPUT_SIZE, MAX_INPUT_SIZE)
+        }
+
+        val codec = MediaCodec.createEncoderByType(MIME_AAC)
+        codec.configure(format, null, null, MediaCodec.CONFIGURE_FLAG_ENCODE)
+        codec.start()
+
+        val muxer = MediaMuxer(outFile.absolutePath, MediaMuxer.OutputFormat.MUXER_OUTPUT_MPEG_4)
+        var trackIndex = -1
+        var muxerStarted = false
+
+        // Per-chapter durations, derived from the PCM byte length so chapter
+        // boundaries are exact regardless of encoder framing.
+        val durationsMs = chapters.map { pcmDurationMs(it.pcm.size, sampleRate) }
+        val titles = chapters.map { it.title }
+
+        val bufferInfo = MediaCodec.BufferInfo()
+        try {
+            // Concatenate the chapter PCM into one stream; the chapter
+            // boundaries are tracked purely by byte length above.
+            val pcmStream = ConcatPcm(chapters.map { it.pcm })
+            var presentationUs = 0L
+            var sawInputEos = false
+            var sawOutputEos = false
+
+            while (!sawOutputEos) {
+                if (!sawInputEos) {
+                    val inIndex = codec.dequeueInputBuffer(TIMEOUT_US)
+                    if (inIndex >= 0) {
+                        val inBuf = codec.getInputBuffer(inIndex)!!
+                        inBuf.clear()
+                        val chunk = pcmStream.read(inBuf.remaining())
+                        if (chunk == null) {
+                            codec.queueInputBuffer(
+                                inIndex, 0, 0, presentationUs,
+                                MediaCodec.BUFFER_FLAG_END_OF_STREAM,
+                            )
+                            sawInputEos = true
+                        } else {
+                            inBuf.put(chunk)
+                            codec.queueInputBuffer(inIndex, 0, chunk.size, presentationUs, 0)
+                            // Advance the presentation clock by this chunk's duration.
+                            presentationUs += pcmDurationUs(chunk.size, sampleRate)
+                        }
+                    }
+                }
+
+                // Drain available output. The encoder emits exactly one
+                // INFO_OUTPUT_FORMAT_CHANGED (-2) before the first real sample
+                // — that's when we learn the output format (incl. the AAC
+                // ESDS) and can addTrack + start the muxer. All status codes
+                // are negative, so they fall out of the `>= 0` loop and are
+                // handled explicitly below.
+                var outIndex = codec.dequeueOutputBuffer(bufferInfo, TIMEOUT_US)
+                while (outIndex >= 0) {
+                    val outBuf = codec.getOutputBuffer(outIndex)!!
+                    if (bufferInfo.flags and MediaCodec.BUFFER_FLAG_CODEC_CONFIG != 0) {
+                        // Codec config (ESDS) — already captured by addTrack
+                        // from outputFormat; don't write it as a sample.
+                        bufferInfo.size = 0
+                    }
+                    if (bufferInfo.size > 0 && muxerStarted) {
+                        outBuf.position(bufferInfo.offset)
+                        outBuf.limit(bufferInfo.offset + bufferInfo.size)
+                        muxer.writeSampleData(trackIndex, outBuf, bufferInfo)
+                    }
+                    codec.releaseOutputBuffer(outIndex, false)
+                    if (bufferInfo.flags and MediaCodec.BUFFER_FLAG_END_OF_STREAM != 0) {
+                        sawOutputEos = true
+                        break
+                    }
+                    outIndex = codec.dequeueOutputBuffer(bufferInfo, TIMEOUT_US)
+                }
+                if (outIndex == MediaCodec.INFO_OUTPUT_FORMAT_CHANGED) {
+                    check(!muxerStarted) { "format changed twice" }
+                    trackIndex = muxer.addTrack(codec.outputFormat)
+                    muxer.start()
+                    muxerStarted = true
+                }
+            }
+        } finally {
+            runCatching { codec.stop() }
+            runCatching { codec.release() }
+            runCatching { muxer.stop() }
+            runCatching { muxer.release() }
+        }
+
+        // Inject chapter markers + metadata into the finished file.
+        val markers = Mp4ChapterMarkers.markers(titles, durationsMs)
+        runCatching {
+            RandomAccessFile(outFile, "rw").use { raf ->
+                val injected = Mp4MetadataInjector.inject(raf, markers, title, author, cover)
+                if (!injected) {
+                    Log.w(LOG_TAG, "chapter/metadata injection skipped (moov layout)")
+                }
+            }
+        }.onFailure { Log.w(LOG_TAG, "metadata injection failed", it) }
+
+        return markers
+    }
+
+    /** Sequential reader over a list of PCM buffers, exposing them as one
+     *  continuous byte stream the encoder pulls input chunks from. */
+    private class ConcatPcm(private val buffers: List<ByteArray>) {
+        private var bufIdx = 0
+        private var pos = 0
+
+        /** Read up to [max] bytes; null when fully drained. */
+        fun read(max: Int): ByteArray? {
+            // Skip exhausted/empty buffers.
+            while (bufIdx < buffers.size && pos >= buffers[bufIdx].size) {
+                bufIdx++
+                pos = 0
+            }
+            if (bufIdx >= buffers.size) return null
+            val cur = buffers[bufIdx]
+            val n = minOf(max, cur.size - pos)
+            val out = cur.copyOfRange(pos, pos + n)
+            pos += n
+            return out
+        }
+    }
+
+    private fun pcmDurationMs(byteLen: Int, sampleRate: Int): Long =
+        byteLen.toLong() * 1000L / (sampleRate.toLong() * BYTES_PER_SAMPLE)
+
+    private fun pcmDurationUs(byteLen: Int, sampleRate: Int): Long =
+        byteLen.toLong() * 1_000_000L / (sampleRate.toLong() * BYTES_PER_SAMPLE)
+
+    companion object {
+        private const val LOG_TAG = "AacM4bEncoder"
+        private const val MIME_AAC = MediaFormat.MIMETYPE_AUDIO_AAC
+        private const val CHANNELS = 1 // mono — engines synthesize mono PCM
+        private const val BYTES_PER_SAMPLE = 2 // 16-bit
+        private const val BIT_RATE = 64_000 // 64 kbps mono AAC — speech-grade
+        private const val MAX_INPUT_SIZE = 16 * 1024
+        private const val TIMEOUT_US = 10_000L
+    }
+}

--- a/core-playback/src/main/kotlin/in/jphe/storyvox/playback/audiobook/AudiobookExportJob.kt
+++ b/core-playback/src/main/kotlin/in/jphe/storyvox/playback/audiobook/AudiobookExportJob.kt
@@ -76,7 +76,11 @@ class AudiobookExportJob @AssistedInject constructor(
             // Not retryable — the voice choice is wrong, retrying won't fix it.
             Log.w(LOG_TAG, "audiobook-export UNSUPPORTED-VOICE fictionId=$fictionId", uns)
             Result.failure(errorData(uns.message ?: "Unsupported voice"))
-        } catch (t: Throwable) {
+        } catch (@Suppress("TooGenericExceptionCaught") t: Throwable) {
+            // Top of the worker's execution tree: any escape marks the work
+            // crashed. The native VoxSherpa layer can raise Error subtypes
+            // (UnsatisfiedLinkError, OOM) a narrow catch would miss, so we
+            // convert *everything* into a Failed status the UI can show.
             Log.w(LOG_TAG, "audiobook-export FAIL fictionId=$fictionId", t)
             if (isStopped) Result.failure() else Result.failure(errorData(t.message ?: "Export failed"))
         }

--- a/core-playback/src/main/kotlin/in/jphe/storyvox/playback/audiobook/AudiobookExportJob.kt
+++ b/core-playback/src/main/kotlin/in/jphe/storyvox/playback/audiobook/AudiobookExportJob.kt
@@ -1,0 +1,136 @@
+package `in`.jphe.storyvox.playback.audiobook
+
+import android.app.Notification
+import android.app.NotificationChannel
+import android.app.NotificationManager
+import android.content.Context
+import android.os.Build
+import android.util.Log
+import androidx.core.app.NotificationCompat
+import androidx.hilt.work.HiltWorker
+import androidx.work.CoroutineWorker
+import androidx.work.Data
+import androidx.work.ForegroundInfo
+import androidx.work.WorkerParameters
+import dagger.assisted.Assisted
+import dagger.assisted.AssistedInject
+
+/**
+ * Background WorkManager job that renders + encodes a fiction into a chaptered
+ * `.m4b` (issue #1003). Mirrors `ChapterRenderJob`'s foreground-service shape
+ * but produces a *shareable file* rather than a playback cache entry.
+ *
+ * Progress: publishes a 0..1 fraction via [setProgress] so the launching UI
+ * (Library / Fiction detail) can render a determinate bar, and updates the
+ * foreground notification text. On success, the output [Data] carries the
+ * absolute path + FileProvider-able filename + chapter count so the observer
+ * can fire the share / Save-As sheet.
+ *
+ * Resumability: a render that's interrupted (process death, user cancel)
+ * simply re-runs from the start on retry — synthesis is deterministic and the
+ * partial cache-dir file is overwritten. We don't checkpoint mid-encode; the
+ * common case (a pasted article, a handful of chapters) completes in seconds
+ * to a couple of minutes.
+ */
+@HiltWorker
+class AudiobookExportJob @AssistedInject constructor(
+    @Assisted private val appContext: Context,
+    @Assisted params: WorkerParameters,
+    private val exportUseCase: ExportFictionToAudiobookUseCase,
+) : CoroutineWorker(appContext, params) {
+
+    override suspend fun doWork(): Result {
+        val fictionId = inputData.getString(KEY_FICTION_ID) ?: return Result.failure()
+        val title = inputData.getString(KEY_TITLE).orEmpty()
+        // Optional voice override id — null means "use the active voice".
+        val voiceId = inputData.getString(KEY_VOICE_ID)
+
+        Log.i(LOG_TAG, "audiobook-export START fictionId=$fictionId voiceId=$voiceId")
+        runCatching { setForeground(foregroundInfo(title, progress = 0f)) }
+
+        return try {
+            val voice = voiceId?.let { exportUseCase.resolveVoice(it) }
+            val result = exportUseCase.export(
+                fictionId = fictionId,
+                voiceOverride = voice,
+            ) { fraction ->
+                setProgressAsync(Data.Builder().putFloat(KEY_PROGRESS, fraction).build())
+                runCatching { /* best-effort notif refresh */
+                    setForegroundAsync(foregroundInfo(title, fraction))
+                }
+            }
+            Log.i(
+                LOG_TAG,
+                "audiobook-export SUCCESS fictionId=$fictionId chapters=${result.chapterCount} " +
+                    "file=${result.file.name}",
+            )
+            Result.success(
+                Data.Builder()
+                    .putString(KEY_OUT_PATH, result.file.absolutePath)
+                    .putString(KEY_OUT_FILENAME, result.suggestedFileName)
+                    .putInt(KEY_OUT_CHAPTERS, result.chapterCount)
+                    .putStringArray(KEY_OUT_WARNINGS, result.warnings.toTypedArray())
+                    .build(),
+            )
+        } catch (uns: AudiobookSynthesizer.UnsupportedVoiceException) {
+            // Not retryable — the voice choice is wrong, retrying won't fix it.
+            Log.w(LOG_TAG, "audiobook-export UNSUPPORTED-VOICE fictionId=$fictionId", uns)
+            Result.failure(errorData(uns.message ?: "Unsupported voice"))
+        } catch (t: Throwable) {
+            Log.w(LOG_TAG, "audiobook-export FAIL fictionId=$fictionId", t)
+            if (isStopped) Result.failure() else Result.failure(errorData(t.message ?: "Export failed"))
+        }
+    }
+
+    private fun errorData(message: String): Data =
+        Data.Builder().putString(KEY_OUT_ERROR, message).build()
+
+    private fun foregroundInfo(title: String, progress: Float): ForegroundInfo {
+        val nm = appContext.getSystemService(NotificationManager::class.java)
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O && nm != null) {
+            val ch = NotificationChannel(
+                CHANNEL_ID,
+                CHANNEL_NAME,
+                NotificationManager.IMPORTANCE_LOW,
+            ).apply { description = "Audiobook export" }
+            nm.createNotificationChannel(ch)
+        }
+        val pct = (progress.coerceIn(0f, 1f) * 100).toInt()
+        val notif: Notification = NotificationCompat.Builder(appContext, CHANNEL_ID)
+            .setContentTitle("Creating audiobook")
+            .setContentText(title.ifBlank { "Rendering chapters…" })
+            .setSmallIcon(android.R.drawable.stat_sys_download)
+            .setOngoing(true)
+            .setProgress(100, pct, progress <= 0f)
+            .setPriority(NotificationCompat.PRIORITY_LOW)
+            .build()
+        return if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.UPSIDE_DOWN_CAKE) {
+            ForegroundInfo(
+                NOTIFICATION_ID,
+                notif,
+                android.content.pm.ServiceInfo.FOREGROUND_SERVICE_TYPE_DATA_SYNC,
+            )
+        } else {
+            ForegroundInfo(NOTIFICATION_ID, notif)
+        }
+    }
+
+    companion object {
+        private const val LOG_TAG = "AudiobookExportJob"
+        const val KEY_FICTION_ID = "fictionId"
+        const val KEY_TITLE = "title"
+        const val KEY_VOICE_ID = "voiceId"
+
+        const val KEY_PROGRESS = "progress"
+
+        const val KEY_OUT_PATH = "outPath"
+        const val KEY_OUT_FILENAME = "outFilename"
+        const val KEY_OUT_CHAPTERS = "outChapters"
+        const val KEY_OUT_WARNINGS = "outWarnings"
+        const val KEY_OUT_ERROR = "outError"
+
+        private const val CHANNEL_ID = "audiobook-export-channel"
+        private const val CHANNEL_NAME = "Audiobook export"
+        private const val NOTIFICATION_ID = 5043
+    }
+}

--- a/core-playback/src/main/kotlin/in/jphe/storyvox/playback/audiobook/AudiobookExportScheduler.kt
+++ b/core-playback/src/main/kotlin/in/jphe/storyvox/playback/audiobook/AudiobookExportScheduler.kt
@@ -1,0 +1,113 @@
+package `in`.jphe.storyvox.playback.audiobook
+
+import android.content.Context
+import androidx.work.Constraints
+import androidx.work.Data
+import androidx.work.ExistingWorkPolicy
+import androidx.work.OneTimeWorkRequestBuilder
+import androidx.work.WorkInfo
+import androidx.work.WorkManager
+import dagger.hilt.android.qualifiers.ApplicationContext
+import javax.inject.Inject
+import javax.inject.Singleton
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.map
+
+/**
+ * UI-facing status of an in-flight or finished audiobook export. Surfaced by
+ * [AudiobookExportScheduler.statusFor] so the launching screen can show a
+ * determinate progress bar and then the Share / Save-As sheet (issue #1003).
+ */
+sealed interface AudiobookExportStatus {
+    data object Idle : AudiobookExportStatus
+    data class Running(val progress: Float) : AudiobookExportStatus
+    data class Succeeded(
+        val filePath: String,
+        val fileName: String,
+        val chapterCount: Int,
+        val warnings: List<String>,
+    ) : AudiobookExportStatus
+    data class Failed(val message: String) : AudiobookExportStatus
+}
+
+/**
+ * Enqueues [AudiobookExportJob] and projects its WorkManager state into
+ * [AudiobookExportStatus]. Keeps `androidx.work` imports out of the feature
+ * layer, mirroring `PcmRenderScheduler`.
+ *
+ * Unique-name policy: one export per fiction in flight (`KEEP`), so a
+ * double-tap doesn't kick off two encodes.
+ */
+@Singleton
+class AudiobookExportScheduler @Inject constructor(
+    @ApplicationContext private val context: Context,
+) {
+    private val workManager: WorkManager get() = WorkManager.getInstance(context)
+
+    /**
+     * Enqueue an export of [fictionId] using [voiceId] (null = active voice).
+     * Returns the unique work name, which the caller passes to [statusFor].
+     */
+    fun enqueue(fictionId: String, title: String, voiceId: String?): String {
+        val constraints = Constraints.Builder()
+            .setRequiresStorageNotLow(true)
+            .build()
+        val input = Data.Builder()
+            .putString(AudiobookExportJob.KEY_FICTION_ID, fictionId)
+            .putString(AudiobookExportJob.KEY_TITLE, title)
+            .apply { if (voiceId != null) putString(AudiobookExportJob.KEY_VOICE_ID, voiceId) }
+            .build()
+        val request = OneTimeWorkRequestBuilder<AudiobookExportJob>()
+            .setConstraints(constraints)
+            .setInputData(input)
+            .addTag(TAG)
+            .build()
+        val name = uniqueName(fictionId)
+        workManager.enqueueUniqueWork(name, ExistingWorkPolicy.KEEP, request)
+        return name
+    }
+
+    /** Observe the export's lifecycle for [uniqueName]. */
+    fun statusFor(uniqueName: String): Flow<AudiobookExportStatus> =
+        workManager.getWorkInfosForUniqueWorkFlow(uniqueName).map { infos ->
+            val info = infos.lastOrNull() ?: return@map AudiobookExportStatus.Idle
+            when (info.state) {
+                WorkInfo.State.ENQUEUED,
+                WorkInfo.State.BLOCKED,
+                -> AudiobookExportStatus.Running(0f)
+                WorkInfo.State.RUNNING ->
+                    AudiobookExportStatus.Running(info.progress.getFloat(AudiobookExportJob.KEY_PROGRESS, 0f))
+                WorkInfo.State.SUCCEEDED -> {
+                    val out = info.outputData
+                    val path = out.getString(AudiobookExportJob.KEY_OUT_PATH)
+                    if (path == null) {
+                        AudiobookExportStatus.Failed("Export finished without a file")
+                    } else {
+                        AudiobookExportStatus.Succeeded(
+                            filePath = path,
+                            fileName = out.getString(AudiobookExportJob.KEY_OUT_FILENAME).orEmpty(),
+                            chapterCount = out.getInt(AudiobookExportJob.KEY_OUT_CHAPTERS, 0),
+                            warnings = out.getStringArray(AudiobookExportJob.KEY_OUT_WARNINGS)
+                                ?.toList().orEmpty(),
+                        )
+                    }
+                }
+                WorkInfo.State.FAILED ->
+                    AudiobookExportStatus.Failed(
+                        info.outputData.getString(AudiobookExportJob.KEY_OUT_ERROR)
+                            ?: "Couldn't create the audiobook",
+                    )
+                WorkInfo.State.CANCELLED -> AudiobookExportStatus.Idle
+            }
+        }
+
+    /** Cancel an in-flight export. */
+    fun cancel(fictionId: String) {
+        workManager.cancelUniqueWork(uniqueName(fictionId))
+    }
+
+    companion object {
+        const val TAG = "audiobook-export"
+        fun uniqueName(fictionId: String): String = "audiobook-export-$fictionId"
+    }
+}

--- a/core-playback/src/main/kotlin/in/jphe/storyvox/playback/audiobook/AudiobookSynthesizer.kt
+++ b/core-playback/src/main/kotlin/in/jphe/storyvox/playback/audiobook/AudiobookSynthesizer.kt
@@ -1,0 +1,172 @@
+package `in`.jphe.storyvox.playback.audiobook
+
+import android.content.Context
+import com.CodeBySonu.VoxSherpa.KittenEngine
+import com.CodeBySonu.VoxSherpa.KokoroEngine
+import com.CodeBySonu.VoxSherpa.VoiceEngine
+import dagger.hilt.android.qualifiers.ApplicationContext
+import `in`.jphe.storyvox.playback.cache.EngineMutex
+import `in`.jphe.storyvox.playback.tts.SentenceChunker
+import `in`.jphe.storyvox.playback.tts.detectLocale
+import `in`.jphe.storyvox.playback.voice.EngineType
+import `in`.jphe.storyvox.playback.voice.UiVoiceInfo
+import `in`.jphe.storyvox.playback.voice.VoiceManager
+import java.io.ByteArrayOutputStream
+import java.io.File
+import javax.inject.Inject
+import javax.inject.Singleton
+import kotlinx.coroutines.sync.withLock
+
+/**
+ * Renders a chapter's text to one continuous block of 16-bit-mono PCM using
+ * the in-process VoxSherpa engines (issue #1003 — "Make your own audiobook").
+ *
+ * This is the export counterpart to
+ * [`in`.jphe.storyvox.playback.cache.ChapterRenderJob], which renders into the
+ * per-sentence PCM *cache*. The export wants the whole chapter as a single PCM
+ * buffer to feed the AAC encoder, so we synthesize sentence-by-sentence (the
+ * engines work best on sentence-sized inputs) and concatenate, inserting short
+ * trailing silence between sentences so the narration doesn't run together.
+ *
+ * Engine concurrency mirrors the cache renderer: [EngineMutex.mutex] is held
+ * around `loadModel` and every `generateAudioPCM` so a foreground playback or
+ * a background cache render can't interleave model state with ours.
+ *
+ * Only the local engines (Piper / Kokoro / Kitten) are supported — the export
+ * flow defaults to a local voice and is offline-first per the issue. Azure
+ * (cloud, BYOK, rate-limited) and System TTS (framework binder on the OS
+ * process) are rejected with a typed error so the caller can surface a clear
+ * "pick a local voice" message rather than producing a silent file.
+ */
+@Singleton
+class AudiobookSynthesizer @Inject constructor(
+    @ApplicationContext private val appContext: Context,
+    private val voiceManager: VoiceManager,
+    private val engineMutex: EngineMutex,
+    private val chunker: SentenceChunker,
+) {
+
+    /** Raised when the chosen voice can't be rendered offline by this path. */
+    class UnsupportedVoiceException(message: String) : IllegalStateException(message)
+
+    /** Raised when the engine model couldn't be loaded. */
+    class EngineLoadException(message: String) : IllegalStateException(message)
+
+    /** PCM sample rate (Hz) the active voice's engine reports. The encoder
+     *  needs this to configure the AAC format; it's stable for a loaded
+     *  model so we resolve it once after [loadVoice]. */
+    fun sampleRateFor(voice: UiVoiceInfo): Int =
+        when (voice.engineType) {
+            is EngineType.Kokoro -> KokoroEngine.getInstance().sampleRate
+            is EngineType.Kitten -> KittenEngine.getInstance().sampleRate
+            else -> VoiceEngine.getInstance().sampleRate
+        }.takeIf { it > 0 } ?: DEFAULT_SAMPLE_RATE_HZ
+
+    /**
+     * Load [voice]'s model. Idempotent if the same model is already loaded
+     * (the engine no-ops a redundant load). Must be called before
+     * [renderChapter]. Holds [EngineMutex.mutex].
+     *
+     * @throws UnsupportedVoiceException for Azure / System TTS voices.
+     * @throws EngineLoadException when the native load fails.
+     */
+    suspend fun loadVoice(voice: UiVoiceInfo) {
+        when (voice.engineType) {
+            is EngineType.Azure -> throw UnsupportedVoiceException(
+                "Azure voices need a network round-trip and can't be used for " +
+                    "offline audiobook export — pick a downloaded voice.",
+            )
+            is EngineType.SystemTts -> throw UnsupportedVoiceException(
+                "System (device) voices can't be exported to a file — pick a " +
+                    "downloaded Piper, Kokoro or Kitten voice.",
+            )
+            else -> Unit
+        }
+        val result = engineMutex.mutex.withLock { loadModel(voice) }
+        if (result != "Success") throw EngineLoadException("Voice failed to load: $result")
+    }
+
+    /**
+     * Render [text] to a single PCM buffer (16-bit mono LE at the engine's
+     * sample rate). Returns an empty array for blank text. [onProgress] is
+     * invoked with a 0..1 fraction as sentences complete so a long chapter
+     * can update a progress notification.
+     */
+    suspend fun renderChapter(
+        voice: UiVoiceInfo,
+        text: String,
+        onProgress: (Float) -> Unit = {},
+    ): ByteArray {
+        if (text.isBlank()) return ByteArray(0)
+        val sentences = chunker.chunk(text, detectLocale(text))
+        if (sentences.isEmpty()) return ByteArray(0)
+
+        val sampleRate = sampleRateFor(voice)
+        val silence = silenceBytes(SENTENCE_GAP_MS, sampleRate)
+        val out = ByteArrayOutputStream()
+        for ((i, sentence) in sentences.withIndex()) {
+            val pcm = engineMutex.mutex.withLock { generateAudioPCM(voice, sentence.text) }
+            if (pcm != null && pcm.isNotEmpty()) {
+                out.write(pcm)
+                out.write(silence)
+            }
+            onProgress((i + 1).toFloat() / sentences.size)
+        }
+        return out.toByteArray()
+    }
+
+    // ── engine bridging (mirrors ChapterRenderJob) ──────────────────────────
+
+    private fun loadModel(voice: UiVoiceInfo): String =
+        when (val type = voice.engineType) {
+            is EngineType.Piper -> {
+                val voiceDir = voiceManager.voiceDirFor(voice.id)
+                val onnx = File(voiceDir, "model.onnx").absolutePath
+                val tokens = File(voiceDir, "tokens.txt").absolutePath
+                VoiceEngine.getInstance().loadModel(appContext, onnx, tokens)
+                    ?: "Error: load returned null"
+            }
+            is EngineType.Kokoro -> {
+                val sharedDir = voiceManager.kokoroSharedDir()
+                val onnx = File(sharedDir, "model.onnx").absolutePath
+                val tokens = File(sharedDir, "tokens.txt").absolutePath
+                val voicesBin = File(sharedDir, "voices.bin").absolutePath
+                KokoroEngine.getInstance().setActiveSpeakerId(type.speakerId)
+                KokoroEngine.getInstance().loadModel(appContext, onnx, tokens, voicesBin)
+                    ?: "Error: load returned null"
+            }
+            is EngineType.Kitten -> {
+                val sharedDir = voiceManager.kittenSharedDir()
+                val onnx = File(sharedDir, "model.onnx").absolutePath
+                val tokens = File(sharedDir, "tokens.txt").absolutePath
+                val voicesBin = File(sharedDir, "voices.bin").absolutePath
+                KittenEngine.getInstance().setActiveSpeakerId(type.speakerId)
+                KittenEngine.getInstance().loadModel(appContext, onnx, tokens, voicesBin)
+                    ?: "Error: load returned null"
+            }
+            // Guarded in loadVoice; defensive typed errors keep the when exhaustive.
+            is EngineType.Azure -> "Error: Azure not supported for export"
+            is EngineType.SystemTts -> "Error: System TTS not supported for export"
+        }
+
+    private fun generateAudioPCM(voice: UiVoiceInfo, text: String): ByteArray? =
+        when (voice.engineType) {
+            is EngineType.Kokoro -> KokoroEngine.getInstance().generateAudioPCM(text, 1.0f, 1.0f)
+            is EngineType.Kitten -> KittenEngine.getInstance().generateAudioPCM(text, 1.0f, 1.0f)
+            is EngineType.Azure, is EngineType.SystemTts -> null
+            else -> VoiceEngine.getInstance().generateAudioPCM(text, 1.0f, 1.0f)
+        }
+
+    /** A block of silence: 16-bit mono zero samples for [ms] milliseconds. */
+    private fun silenceBytes(ms: Int, sampleRate: Int): ByteArray {
+        val samples = (sampleRate.toLong() * ms / 1000L).toInt()
+        return ByteArray(samples * BYTES_PER_SAMPLE) // zeroed
+    }
+
+    companion object {
+        private const val DEFAULT_SAMPLE_RATE_HZ = 22_050
+        private const val BYTES_PER_SAMPLE = 2 // 16-bit mono
+        /** Inter-sentence gap so narration doesn't run together. */
+        private const val SENTENCE_GAP_MS = 280
+    }
+}

--- a/core-playback/src/main/kotlin/in/jphe/storyvox/playback/audiobook/AudiobookSynthesizer.kt
+++ b/core-playback/src/main/kotlin/in/jphe/storyvox/playback/audiobook/AudiobookSynthesizer.kt
@@ -121,28 +121,28 @@ class AudiobookSynthesizer @Inject constructor(
         when (val type = voice.engineType) {
             is EngineType.Piper -> {
                 val voiceDir = voiceManager.voiceDirFor(voice.id)
-                val onnx = File(voiceDir, "model.onnx").absolutePath
-                val tokens = File(voiceDir, "tokens.txt").absolutePath
+                val onnx = File(voiceDir, MODEL_FILE).absolutePath
+                val tokens = File(voiceDir, TOKENS_FILE).absolutePath
                 VoiceEngine.getInstance().loadModel(appContext, onnx, tokens)
-                    ?: "Error: load returned null"
+                    ?: ERR_LOAD_NULL
             }
             is EngineType.Kokoro -> {
                 val sharedDir = voiceManager.kokoroSharedDir()
-                val onnx = File(sharedDir, "model.onnx").absolutePath
-                val tokens = File(sharedDir, "tokens.txt").absolutePath
-                val voicesBin = File(sharedDir, "voices.bin").absolutePath
+                val onnx = File(sharedDir, MODEL_FILE).absolutePath
+                val tokens = File(sharedDir, TOKENS_FILE).absolutePath
+                val voicesBin = File(sharedDir, VOICES_BIN_FILE).absolutePath
                 KokoroEngine.getInstance().setActiveSpeakerId(type.speakerId)
                 KokoroEngine.getInstance().loadModel(appContext, onnx, tokens, voicesBin)
-                    ?: "Error: load returned null"
+                    ?: ERR_LOAD_NULL
             }
             is EngineType.Kitten -> {
                 val sharedDir = voiceManager.kittenSharedDir()
-                val onnx = File(sharedDir, "model.onnx").absolutePath
-                val tokens = File(sharedDir, "tokens.txt").absolutePath
-                val voicesBin = File(sharedDir, "voices.bin").absolutePath
+                val onnx = File(sharedDir, MODEL_FILE).absolutePath
+                val tokens = File(sharedDir, TOKENS_FILE).absolutePath
+                val voicesBin = File(sharedDir, VOICES_BIN_FILE).absolutePath
                 KittenEngine.getInstance().setActiveSpeakerId(type.speakerId)
                 KittenEngine.getInstance().loadModel(appContext, onnx, tokens, voicesBin)
-                    ?: "Error: load returned null"
+                    ?: ERR_LOAD_NULL
             }
             // Guarded in loadVoice; defensive typed errors keep the when exhaustive.
             is EngineType.Azure -> "Error: Azure not supported for export"
@@ -168,5 +168,12 @@ class AudiobookSynthesizer @Inject constructor(
         private const val BYTES_PER_SAMPLE = 2 // 16-bit mono
         /** Inter-sentence gap so narration doesn't run together. */
         private const val SENTENCE_GAP_MS = 280
+
+        // On-disk voice-bundle artifact names — a filesystem contract shared with
+        // the voice downloader and ChapterRenderJob across all three engines.
+        private const val MODEL_FILE = "model.onnx"
+        private const val TOKENS_FILE = "tokens.txt"
+        private const val VOICES_BIN_FILE = "voices.bin"
+        private const val ERR_LOAD_NULL = "Error: load returned null"
     }
 }

--- a/core-playback/src/main/kotlin/in/jphe/storyvox/playback/audiobook/CreateAudiobookFromTextUseCase.kt
+++ b/core-playback/src/main/kotlin/in/jphe/storyvox/playback/audiobook/CreateAudiobookFromTextUseCase.kt
@@ -1,0 +1,88 @@
+package `in`.jphe.storyvox.playback.audiobook
+
+import `in`.jphe.storyvox.data.db.dao.ChapterDao
+import `in`.jphe.storyvox.data.db.dao.FictionDao
+import `in`.jphe.storyvox.data.db.entity.Chapter
+import `in`.jphe.storyvox.data.db.entity.ChapterDownloadState
+import `in`.jphe.storyvox.data.db.entity.Fiction
+import `in`.jphe.storyvox.data.source.SourceIds
+import `in`.jphe.storyvox.data.source.model.FictionStatus
+import `in`.jphe.storyvox.source.audiobook.writer.Chapterizer
+import java.util.UUID
+import javax.inject.Inject
+import javax.inject.Singleton
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+
+/**
+ * Turns a blob of pasted / typed / imported text into a local fiction with
+ * chapters, ready to play in Candela and to export as an audiobook (issue
+ * #1003 — "Make your own audiobook").
+ *
+ * The text is auto-chapterized by [Chapterizer]; each resulting section
+ * becomes a `DOWNLOADED` chapter with its `plainBody` set, so it's immediately
+ * narratable (the export reads `plainBody`) and readable without any network
+ * round-trip. The fiction is added to the library so the user can find it
+ * again. The synthetic source id is [SourceIds.MY_AUDIOBOOK].
+ */
+@Singleton
+class CreateAudiobookFromTextUseCase @Inject constructor(
+    private val fictionDao: FictionDao,
+    private val chapterDao: ChapterDao,
+) {
+
+    /**
+     * Create the fiction and return its id. [text] is the raw content;
+     * [title] / [author] are the user-supplied metadata (title defaults to a
+     * generic label when blank).
+     *
+     * @throws IllegalArgumentException when [text] is blank.
+     */
+    suspend fun create(
+        text: String,
+        title: String,
+        author: String,
+    ): String = withContext(Dispatchers.IO) {
+        require(text.isNotBlank()) { "Can't create an audiobook from empty text" }
+
+        val cleanTitle = title.trim().ifBlank { "My Audiobook" }
+        val cleanAuthor = author.trim().ifBlank { "Me" }
+        val fictionId = "${SourceIds.MY_AUDIOBOOK}:${UUID.randomUUID()}"
+        val now = System.currentTimeMillis()
+
+        val sections = Chapterizer.chapterize(text, cleanTitle)
+            .ifEmpty { return@withContext fictionId } // blank guarded above; defensive
+
+        val fiction = Fiction(
+            id = fictionId,
+            sourceId = SourceIds.MY_AUDIOBOOK,
+            title = cleanTitle,
+            author = cleanAuthor,
+            status = FictionStatus.COMPLETED,
+            chapterCount = sections.size,
+            firstSeenAt = now,
+            metadataFetchedAt = now,
+            inLibrary = true,
+            addedToLibraryAt = now,
+        )
+        fictionDao.upsert(fiction)
+
+        val chapters = sections.mapIndexed { index, section ->
+            Chapter(
+                // Chapter PK convention is "$fictionId:$index" (see Chapter.kt).
+                id = "$fictionId:$index",
+                fictionId = fictionId,
+                sourceChapterId = index.toString(),
+                index = index,
+                title = section.title,
+                plainBody = section.text,
+                wordCount = section.text.split(Regex("\\s+")).count { it.isNotBlank() },
+                bodyFetchedAt = now,
+                downloadState = ChapterDownloadState.DOWNLOADED,
+            )
+        }
+        chapterDao.upsertAll(chapters)
+
+        fictionId
+    }
+}

--- a/core-playback/src/main/kotlin/in/jphe/storyvox/playback/audiobook/ExportFictionToAudiobookUseCase.kt
+++ b/core-playback/src/main/kotlin/in/jphe/storyvox/playback/audiobook/ExportFictionToAudiobookUseCase.kt
@@ -1,0 +1,190 @@
+package `in`.jphe.storyvox.playback.audiobook
+
+import android.content.Context
+import android.net.Uri
+import androidx.core.content.FileProvider
+import dagger.hilt.android.qualifiers.ApplicationContext
+import `in`.jphe.storyvox.data.db.dao.ChapterDao
+import `in`.jphe.storyvox.data.db.dao.FictionDao
+import `in`.jphe.storyvox.playback.voice.UiVoiceInfo
+import `in`.jphe.storyvox.playback.voice.VoiceManager
+import `in`.jphe.storyvox.source.audiobook.writer.AudiobookFileName
+import java.io.File
+import java.text.SimpleDateFormat
+import java.util.Date
+import java.util.Locale
+import javax.inject.Inject
+import javax.inject.Singleton
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.withContext
+import okhttp3.OkHttpClient
+import okhttp3.Request
+
+/**
+ * Result of [ExportFictionToAudiobookUseCase] — mirrors the EPUB writer's
+ * `EpubExportResult`. Carries the finished `.m4b` plus a FileProvider URI for
+ * the share / SAF-save flow and any non-fatal [warnings].
+ */
+data class AudiobookExportResult(
+    val file: File,
+    /** content:// URI granted via FileProvider — pass to ACTION_SEND /
+     *  ACTION_CREATE_DOCUMENT. */
+    val uri: Uri,
+    val suggestedFileName: String,
+    val chapterCount: Int,
+    val warnings: List<String> = emptyList(),
+)
+
+/**
+ * Renders a stored fiction to a chaptered `.m4b` audiobook in
+ * `cacheDir/exports/` for sharing or SAF Save-As (issue #1003).
+ *
+ * The "missing piece" the issue calls out: storyvox synthesizes + caches PCM
+ * for *playback* but never wrote a portable file. This use case closes that —
+ * it mirrors `ExportFictionToEpubUseCase` (load DB rows → build → write to the
+ * shared exports dir → FileProvider URI), substituting the audio pipeline
+ * ([AudiobookSynthesizer] → [AacM4bEncoder]) for the EPUB ZIP writer.
+ *
+ * Threading: all on `Dispatchers.IO` — synthesis is CPU-bound and the encode
+ * is blocking. The caller is the WorkManager [AudiobookExportJob], which sets
+ * itself foreground for the (potentially many-minute) render.
+ */
+@Singleton
+class ExportFictionToAudiobookUseCase @Inject constructor(
+    @ApplicationContext private val appContext: Context,
+    private val fictionDao: FictionDao,
+    private val chapterDao: ChapterDao,
+    private val voiceManager: VoiceManager,
+    private val synthesizer: AudiobookSynthesizer,
+) {
+    private val encoder = AacM4bEncoder()
+
+    private val coverClient: OkHttpClient by lazy {
+        OkHttpClient.Builder()
+            .connectTimeout(java.time.Duration.ofSeconds(5))
+            .readTimeout(java.time.Duration.ofSeconds(10))
+            .build()
+    }
+
+    /**
+     * Build the audiobook for [fictionId] using [voiceOverride] (or the
+     * active voice when null). [onProgress] reports an overall 0..1 fraction
+     * across all chapters so the worker can update its notification.
+     *
+     * @throws IllegalStateException when there's no fiction row, no chapters
+     *  with text, or no usable voice.
+     * @throws AudiobookSynthesizer.UnsupportedVoiceException for Azure /
+     *  System TTS voices.
+     */
+    suspend fun export(
+        fictionId: String,
+        voiceOverride: UiVoiceInfo? = null,
+        onProgress: (Float) -> Unit = {},
+    ): AudiobookExportResult = withContext(Dispatchers.IO) {
+        val fiction = fictionDao.get(fictionId)
+            ?: error("No Fiction row for id=$fictionId")
+
+        val voice = voiceOverride
+            ?: voiceManager.activeVoice.first()
+            ?: error("No active voice — pick a voice before exporting an audiobook.")
+
+        val allChapters = chapterDao.allChapters(fictionId)
+        // Only chapters with narratable text. Skip audio-stream chapters
+        // (they're pre-recorded URLs, not TTS) and empty placeholders.
+        val renderable = allChapters
+            .filter { it.audioUrl == null && !it.plainBody.isNullOrBlank() }
+            .sortedBy { it.index }
+        if (renderable.isEmpty()) {
+            error("No downloaded chapter text to narrate for fiction $fictionId")
+        }
+
+        val warnings = mutableListOf<String>()
+        val skipped = allChapters.size - renderable.size
+        if (skipped > 0) {
+            warnings += "$skipped chapter${if (skipped == 1) "" else "s"} skipped " +
+                "(not downloaded or audio-only)"
+        }
+
+        // Load the model once up front (throws for unsupported voices).
+        synthesizer.loadVoice(voice)
+        val sampleRate = synthesizer.sampleRateFor(voice)
+
+        // Render each chapter to PCM, reporting cumulative progress.
+        val chapterAudio = ArrayList<AacM4bEncoder.ChapterAudio>(renderable.size)
+        renderable.forEachIndexed { i, chapter ->
+            val pcm = synthesizer.renderChapter(
+                voice = voice,
+                text = chapter.plainBody.orEmpty(),
+            ) { withinChapter ->
+                val overall = (i + withinChapter) / renderable.size
+                onProgress(overall)
+            }
+            if (pcm.isNotEmpty()) {
+                chapterAudio += AacM4bEncoder.ChapterAudio(
+                    title = chapter.title.ifBlank { "Chapter ${chapter.index + 1}" },
+                    pcm = pcm,
+                )
+            }
+        }
+        if (chapterAudio.isEmpty()) {
+            error("Synthesis produced no audio for fiction $fictionId")
+        }
+
+        val cover = fiction.coverUrl?.let { url ->
+            runCatching { fetchCover(url) }.getOrElse {
+                warnings += "Cover couldn't be downloaded (${it.javaClass.simpleName})"
+                null
+            }
+        }
+
+        val outDir = File(appContext.cacheDir, "exports").apply { mkdirs() }
+        val stamp = SimpleDateFormat("yyyyMMdd-HHmm", Locale.US).format(Date())
+        val fileName = AudiobookFileName.forTitle(
+            fiction.title.ifBlank { fiction.id }, stamp,
+        )
+        val outFile = File(outDir, fileName)
+
+        encoder.encode(
+            chapters = chapterAudio,
+            sampleRate = sampleRate,
+            title = fiction.title.ifBlank { "Untitled" },
+            author = fiction.author.ifBlank { "Unknown" },
+            cover = cover,
+            outFile = outFile,
+        )
+        onProgress(1f)
+
+        val uri = FileProvider.getUriForFile(
+            appContext,
+            "${appContext.packageName}.fileprovider",
+            outFile,
+        )
+
+        AudiobookExportResult(
+            file = outFile,
+            uri = uri,
+            suggestedFileName = fileName,
+            chapterCount = chapterAudio.size,
+            warnings = warnings,
+        )
+    }
+
+    /**
+     * Resolve a voice id to its [UiVoiceInfo] from the installed roster, or
+     * null if it's not currently installed. Used by [AudiobookExportJob] to
+     * turn the persisted "render with this voice" id (the user's pick in the
+     * Create-audiobook flow) into the voice the synthesizer loads. Falls back
+     * to the active voice at the call site when this returns null.
+     */
+    suspend fun resolveVoice(voiceId: String): UiVoiceInfo? =
+        voiceManager.installedVoices.first().firstOrNull { it.id == voiceId }
+
+    private fun fetchCover(url: String): ByteArray? {
+        val req = Request.Builder().url(url).build()
+        coverClient.newCall(req).execute().use { resp ->
+            if (!resp.isSuccessful) return null
+            return resp.body?.bytes()
+        }
+    }
+}

--- a/feature/src/main/kotlin/in/jphe/storyvox/feature/fiction/FictionDetailScreen.kt
+++ b/feature/src/main/kotlin/in/jphe/storyvox/feature/fiction/FictionDetailScreen.kt
@@ -130,6 +130,10 @@ fun FictionDetailScreen(
     // change without re-firing the export.
     var pendingExport by remember { mutableStateOf<EpubExportResult?>(null) }
 
+    // Issue #1003 — audiobook (.m4b) export status. Drives a progress chip
+    // while rendering and the Share / Save-As sheet when done.
+    val audiobookStatus by viewModel.audiobookExportStatus.collectAsStateWithLifecycle()
+
     // SAF "Save…" picker. Wired up as a launcher up-front so the user
     // can also kick it off from the sheet without us having to remember
     // whether we already initialized it. The contract delivers the
@@ -152,6 +156,22 @@ fun FictionDetailScreen(
                 pendingExport = source.copy(
                     warnings = source.warnings + "Save failed: ${t.message ?: t.javaClass.simpleName}",
                 )
+            }
+        }
+    }
+
+    // Issue #1003 — SAF "Save…" launcher for the finished .m4b audiobook.
+    // The path of the rendered file comes from the export status.
+    val audiobookDone = audiobookStatus as? `in`.jphe.storyvox.playback.audiobook.AudiobookExportStatus.Succeeded
+    val saveAudiobookLauncher = rememberLauncherForActivityResult(
+        contract = ActivityResultContracts.CreateDocument("audio/mp4"),
+    ) { destination ->
+        val done = audiobookDone
+        if (destination != null && done != null) {
+            runCatching {
+                context.contentResolver.openOutputStream(destination)?.use { out ->
+                    java.io.File(done.filePath).inputStream().use { it.copyTo(out) }
+                }
             }
         }
     }
@@ -331,6 +351,16 @@ fun FictionDetailScreen(
                                     onClick = {
                                         menuOpen = false
                                         viewModel.exportToEpub(context)
+                                    },
+                                )
+                                // Issue #1003 — "Make your own audiobook"
+                                // sibling: render this fiction's chapters into
+                                // a chaptered .m4b with the active voice.
+                                DropdownMenuItem(
+                                    text = { Text(stringResource(R.string.fiction_export_audiobook)) },
+                                    onClick = {
+                                        menuOpen = false
+                                        viewModel.exportToAudiobook()
                                     },
                                 )
                                 // PR-H (#86) — destructive cache wipe for
@@ -694,6 +724,134 @@ fun FictionDetailScreen(
             },
             onDismiss = { pendingExport = null },
         )
+    }
+
+    // Issue #1003 — audiobook export progress + Share/Save-As sheet. Shown
+    // while the .m4b renders and when it's ready; mirrors the EPUB ExportSheet.
+    AudiobookExportSheet(
+        status = audiobookStatus,
+        onShare = { done ->
+            val file = java.io.File(done.filePath)
+            val uri = androidx.core.content.FileProvider.getUriForFile(
+                context, "${context.packageName}.fileprovider", file,
+            )
+            val send = Intent(Intent.ACTION_SEND).apply {
+                type = "audio/mp4"
+                putExtra(Intent.EXTRA_STREAM, uri)
+                putExtra(Intent.EXTRA_TITLE, done.fileName)
+                addFlags(Intent.FLAG_GRANT_READ_URI_PERMISSION)
+            }
+            context.startActivity(
+                Intent.createChooser(send, "Share audiobook").also {
+                    it.addFlags(Intent.FLAG_GRANT_READ_URI_PERMISSION)
+                },
+            )
+            viewModel.clearAudiobookExport()
+        },
+        onSaveAs = { done ->
+            saveAudiobookLauncher.launch(done.fileName)
+            viewModel.clearAudiobookExport()
+        },
+        onDismiss = { viewModel.clearAudiobookExport() },
+    )
+}
+
+/**
+ * Issue #1003 — modal sheet for the "Export as audiobook" flow. Renders a
+ * determinate progress bar while the WorkManager job runs and a Share / Save…
+ * row when the `.m4b` is ready. Hidden while [status] is Idle.
+ */
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+private fun AudiobookExportSheet(
+    status: `in`.jphe.storyvox.playback.audiobook.AudiobookExportStatus,
+    onShare: (`in`.jphe.storyvox.playback.audiobook.AudiobookExportStatus.Succeeded) -> Unit,
+    onSaveAs: (`in`.jphe.storyvox.playback.audiobook.AudiobookExportStatus.Succeeded) -> Unit,
+    onDismiss: () -> Unit,
+) {
+    if (status is `in`.jphe.storyvox.playback.audiobook.AudiobookExportStatus.Idle) return
+    val spacing = LocalSpacing.current
+    val sheetState = rememberModalBottomSheetState()
+    ModalBottomSheet(onDismissRequest = onDismiss, sheetState = sheetState) {
+        Column(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(horizontal = spacing.lg, vertical = spacing.md),
+            verticalArrangement = Arrangement.spacedBy(spacing.sm),
+        ) {
+            when (status) {
+                is `in`.jphe.storyvox.playback.audiobook.AudiobookExportStatus.Running -> {
+                    Text("Creating your audiobook…", style = MaterialTheme.typography.titleMedium)
+                    Text(
+                        "Narrating chapters offline. This keeps going in the background.",
+                        style = MaterialTheme.typography.bodySmall,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    )
+                    if (status.progress <= 0f) {
+                        androidx.compose.material3.LinearProgressIndicator(
+                            modifier = Modifier.fillMaxWidth(),
+                        )
+                    } else {
+                        androidx.compose.material3.LinearProgressIndicator(
+                            progress = { status.progress },
+                            modifier = Modifier.fillMaxWidth(),
+                        )
+                        Text(
+                            "${(status.progress * 100).toInt()}%",
+                            style = MaterialTheme.typography.labelSmall,
+                        )
+                    }
+                }
+                is `in`.jphe.storyvox.playback.audiobook.AudiobookExportStatus.Succeeded -> {
+                    Text("Your audiobook is ready", style = MaterialTheme.typography.titleMedium)
+                    Text(
+                        "${status.fileName} · ${status.chapterCount} " +
+                            "chapter${if (status.chapterCount == 1) "" else "s"}",
+                        style = MaterialTheme.typography.bodySmall,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    )
+                    status.warnings.forEach { w ->
+                        Text(
+                            "• $w",
+                            style = MaterialTheme.typography.bodySmall,
+                            color = MaterialTheme.colorScheme.onSurfaceVariant,
+                        )
+                    }
+                    Row(
+                        modifier = Modifier.fillMaxWidth(),
+                        horizontalArrangement = Arrangement.spacedBy(spacing.sm),
+                    ) {
+                        BrassButton(
+                            label = "Save…",
+                            onClick = { onSaveAs(status) },
+                            variant = BrassButtonVariant.Secondary,
+                            modifier = Modifier.weight(1f),
+                        )
+                        BrassButton(
+                            label = "Share",
+                            onClick = { onShare(status) },
+                            variant = BrassButtonVariant.Primary,
+                            modifier = Modifier.weight(1f),
+                        )
+                    }
+                }
+                is `in`.jphe.storyvox.playback.audiobook.AudiobookExportStatus.Failed -> {
+                    Text("Couldn't create the audiobook", style = MaterialTheme.typography.titleMedium)
+                    Text(
+                        status.message,
+                        style = MaterialTheme.typography.bodySmall,
+                        color = MaterialTheme.colorScheme.error,
+                    )
+                    BrassButton(
+                        label = "Close",
+                        onClick = onDismiss,
+                        variant = BrassButtonVariant.Primary,
+                        modifier = Modifier.fillMaxWidth(),
+                    )
+                }
+                `in`.jphe.storyvox.playback.audiobook.AudiobookExportStatus.Idle -> Unit
+            }
+        }
     }
 }
 

--- a/feature/src/main/kotlin/in/jphe/storyvox/feature/fiction/FictionDetailViewModel.kt
+++ b/feature/src/main/kotlin/in/jphe/storyvox/feature/fiction/FictionDetailViewModel.kt
@@ -17,6 +17,8 @@ import `in`.jphe.storyvox.feature.api.SettingsRepositoryUi
 import `in`.jphe.storyvox.feature.api.UiChapter
 import `in`.jphe.storyvox.feature.api.UiFiction
 import `in`.jphe.storyvox.feature.api.UiRecapPlaybackState
+import `in`.jphe.storyvox.playback.audiobook.AudiobookExportScheduler
+import `in`.jphe.storyvox.playback.audiobook.AudiobookExportStatus
 import `in`.jphe.storyvox.playback.cache.CacheStateInspector
 import `in`.jphe.storyvox.playback.cache.ChapterCacheState
 import `in`.jphe.storyvox.playback.cache.PcmCache
@@ -32,6 +34,7 @@ import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.flow.flatMapLatest
 import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.receiveAsFlow
@@ -110,6 +113,9 @@ class FictionDetailViewModel @Inject constructor(
     private val voiceManager: VoiceManager,
     private val pronunciationDict: PronunciationDictRepository,
     private val pcmCache: PcmCache,
+    /** Issue #1003 — enqueues + observes the "export this fiction as an
+     *  audiobook" render. Mirrors the EPUB export's home on this screen. */
+    private val audiobookExportScheduler: AudiobookExportScheduler,
     savedState: SavedStateHandle,
 ) : ViewModel() {
 
@@ -133,6 +139,42 @@ class FictionDetailViewModel @Inject constructor(
      *  through the combine below. Held outside the combine so the suspend
      *  call site can flip it cleanly around the use-case invocation. */
     private val isExporting = MutableStateFlow(false)
+
+    /** Issue #1003 — unique work name of an in-flight audiobook export for
+     *  this fiction (null until the user taps "Export as audiobook"). */
+    private val audiobookWorkName = MutableStateFlow<String?>(null)
+
+    /** Issue #1003 — live status of the audiobook export. Idle until the user
+     *  starts one; the screen observes this to show a progress chip and then
+     *  the Share / Save-As sheet. */
+    @OptIn(kotlinx.coroutines.ExperimentalCoroutinesApi::class)
+    val audiobookExportStatus: StateFlow<AudiobookExportStatus> = audiobookWorkName
+        .flatMapLatest { name ->
+            if (name == null) flowOf(AudiobookExportStatus.Idle)
+            else audiobookExportScheduler.statusFor(name)
+        }
+        .stateIn(viewModelScope, SharingStarted.WhileSubscribed(5_000), AudiobookExportStatus.Idle)
+
+    /**
+     * Issue #1003 — enqueue an audiobook (`.m4b`) export of this fiction using
+     * the active voice. Idempotent at the WorkManager layer (one export per
+     * fiction in flight). The screen surfaces progress + the finished file via
+     * [audiobookExportStatus].
+     */
+    fun exportToAudiobook() {
+        val name = audiobookExportScheduler.enqueue(
+            fictionId = fictionId,
+            title = uiState.value.fiction?.title.orEmpty(),
+            voiceId = null,
+        )
+        audiobookWorkName.value = name
+    }
+
+    /** Issue #1003 — clear the audiobook export status after the user
+     *  dismisses the result sheet. */
+    fun clearAudiobookExport() {
+        audiobookWorkName.value = null
+    }
 
     /** PR-H (#86) — cache-state nudge channel. The view-model recomputes
      *  per-chapter cache states whenever (chapters, active voice,

--- a/feature/src/main/kotlin/in/jphe/storyvox/feature/library/CreateAudiobookSheet.kt
+++ b/feature/src/main/kotlin/in/jphe/storyvox/feature/library/CreateAudiobookSheet.kt
@@ -1,0 +1,341 @@
+package `in`.jphe.storyvox.feature.library
+
+import android.content.ClipboardManager
+import android.content.Context
+import android.content.Intent
+import androidx.activity.compose.rememberLauncherForActivityResult
+import androidx.activity.result.contract.ActivityResultContracts
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.heightIn
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.selection.selectable
+import androidx.compose.foundation.lazy.LazyRow
+import androidx.compose.foundation.lazy.items
+import androidx.compose.material3.AssistChip
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.LinearProgressIndicator
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.ModalBottomSheet
+import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.Text
+import androidx.compose.material3.rememberModalBottomSheetState
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.semantics.Role
+import androidx.compose.ui.text.input.ImeAction
+import androidx.compose.ui.text.input.KeyboardCapitalization
+import androidx.compose.ui.unit.dp
+import androidx.core.content.FileProvider
+import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.compose.foundation.text.KeyboardOptions
+import `in`.jphe.storyvox.playback.audiobook.AudiobookExportStatus
+import `in`.jphe.storyvox.ui.component.BrassButton
+import `in`.jphe.storyvox.ui.component.BrassButtonVariant
+import `in`.jphe.storyvox.ui.theme.LocalSpacing
+import java.io.File
+
+/**
+ * "Make your own audiobook" sheet (issue #1003). One screen, three phases:
+ *  1. **Compose** — paste/type text, name the book + author, pick a voice
+ *     (the active/first voice is pre-selected so the user can one-tap through).
+ *  2. **Rendering** — a determinate progress bar driven by the WorkManager
+ *     job's published fraction.
+ *  3. **Done** — Share (ACTION_SEND) / Save… (SAF) the finished `.m4b`.
+ */
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun CreateAudiobookSheet(
+    onDismiss: () -> Unit,
+    viewModel: CreateAudiobookViewModel = hiltViewModel(),
+) {
+    val spacing = LocalSpacing.current
+    val context = LocalContext.current
+    val sheetState = rememberModalBottomSheetState(skipPartiallyExpanded = true)
+
+    val uiState by viewModel.uiState.collectAsState()
+    val voices by viewModel.voices.collectAsState()
+    val status by viewModel.exportStatus.collectAsState()
+
+    var title by remember { mutableStateOf("") }
+    var author by remember { mutableStateOf("") }
+    var text by remember { mutableStateOf("") }
+    var selectedVoiceId by remember { mutableStateOf<String?>(null) }
+
+    // Pre-select a sensible default voice once the roster loads.
+    LaunchedEffect(voices) {
+        if (selectedVoiceId == null) selectedVoiceId = voices.firstOrNull()?.id
+    }
+
+    val saveLauncher = rememberLauncherForActivityResult(
+        contract = ActivityResultContracts.CreateDocument("audio/mp4"),
+    ) { destination ->
+        val done = status as? AudiobookExportStatus.Succeeded
+        if (destination != null && done != null) {
+            runCatching {
+                context.contentResolver.openOutputStream(destination)?.use { out ->
+                    File(done.filePath).inputStream().use { it.copyTo(out) }
+                }
+            }
+        }
+    }
+
+    ModalBottomSheet(onDismissRequest = onDismiss, sheetState = sheetState) {
+        Column(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(horizontal = spacing.lg)
+                .padding(bottom = spacing.xl),
+            verticalArrangement = Arrangement.spacedBy(spacing.sm),
+        ) {
+            when (val s = status) {
+                is AudiobookExportStatus.Succeeded -> DonePhase(
+                    fileName = s.fileName,
+                    chapterCount = s.chapterCount,
+                    warnings = s.warnings,
+                    onShare = { shareAudiobook(context, File(s.filePath), s.fileName) },
+                    onSave = { saveLauncher.launch(s.fileName) },
+                    onDone = { viewModel.reset(); onDismiss() },
+                )
+
+                is AudiobookExportStatus.Running -> RenderingPhase(progress = s.progress)
+
+                is AudiobookExportStatus.Failed -> FailedPhase(
+                    message = s.message,
+                    onRetry = { viewModel.reset() },
+                )
+
+                AudiobookExportStatus.Idle -> ComposePhase(
+                    title = title,
+                    author = author,
+                    text = text,
+                    voices = voices,
+                    selectedVoiceId = selectedVoiceId,
+                    isStarting = uiState.isStarting,
+                    error = uiState.error,
+                    onTitle = { title = it },
+                    onAuthor = { author = it },
+                    onText = { text = it },
+                    onPaste = { readClipboard(context)?.let { c -> if (c.isNotBlank()) text = c } },
+                    onPickVoice = { selectedVoiceId = it },
+                    onCreate = {
+                        viewModel.start(
+                            text = text,
+                            title = title,
+                            author = author,
+                            voiceId = selectedVoiceId,
+                        )
+                    },
+                )
+            }
+        }
+    }
+}
+
+@Composable
+private fun ComposePhase(
+    title: String,
+    author: String,
+    text: String,
+    voices: List<`in`.jphe.storyvox.playback.voice.UiVoiceInfo>,
+    selectedVoiceId: String?,
+    isStarting: Boolean,
+    error: String?,
+    onTitle: (String) -> Unit,
+    onAuthor: (String) -> Unit,
+    onText: (String) -> Unit,
+    onPaste: () -> Unit,
+    onPickVoice: (String) -> Unit,
+    onCreate: () -> Unit,
+) {
+    val spacing = LocalSpacing.current
+    Text("Make your own audiobook", style = MaterialTheme.typography.titleLarge)
+    Text(
+        "Paste or type your text, pick a voice, and Candela narrates it into a " +
+            "chaptered audiobook you can keep and share — all offline, no account.",
+        style = MaterialTheme.typography.bodyMedium,
+        color = MaterialTheme.colorScheme.onSurfaceVariant,
+    )
+
+    OutlinedTextField(
+        value = title,
+        onValueChange = onTitle,
+        label = { Text("Title") },
+        singleLine = true,
+        enabled = !isStarting,
+        keyboardOptions = KeyboardOptions(capitalization = KeyboardCapitalization.Words),
+        modifier = Modifier.fillMaxWidth(),
+    )
+    OutlinedTextField(
+        value = author,
+        onValueChange = onAuthor,
+        label = { Text("Author (optional)") },
+        singleLine = true,
+        enabled = !isStarting,
+        keyboardOptions = KeyboardOptions(capitalization = KeyboardCapitalization.Words),
+        modifier = Modifier.fillMaxWidth(),
+    )
+    OutlinedTextField(
+        value = text,
+        onValueChange = onText,
+        label = { Text("Your text") },
+        placeholder = { Text("Paste a chapter, an article, a story…") },
+        enabled = !isStarting,
+        keyboardOptions = KeyboardOptions(imeAction = ImeAction.Default),
+        modifier = Modifier
+            .fillMaxWidth()
+            .heightIn(min = 120.dp, max = 240.dp),
+    )
+
+    if (voices.isNotEmpty()) {
+        Text("Voice", style = MaterialTheme.typography.labelLarge)
+        LazyRow(horizontalArrangement = Arrangement.spacedBy(spacing.xs)) {
+            items(voices, key = { it.id }) { v ->
+                AssistChip(
+                    onClick = { onPickVoice(v.id) },
+                    label = { Text(v.displayName) },
+                    modifier = Modifier.selectable(
+                        selected = v.id == selectedVoiceId,
+                        role = Role.RadioButton,
+                        onClick = { onPickVoice(v.id) },
+                    ),
+                    colors = if (v.id == selectedVoiceId) {
+                        androidx.compose.material3.AssistChipDefaults.assistChipColors(
+                            containerColor = MaterialTheme.colorScheme.primaryContainer,
+                        )
+                    } else {
+                        androidx.compose.material3.AssistChipDefaults.assistChipColors()
+                    },
+                )
+            }
+        }
+    } else {
+        Text(
+            "Install a voice in the Voices tab to narrate your audiobook.",
+            style = MaterialTheme.typography.bodySmall,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+        )
+    }
+
+    if (error != null) {
+        Text(error, style = MaterialTheme.typography.bodySmall, color = MaterialTheme.colorScheme.error)
+    }
+
+    BrassButton(
+        label = "Create audiobook",
+        onClick = onCreate,
+        variant = BrassButtonVariant.Primary,
+        enabled = text.isNotBlank() && voices.isNotEmpty() && !isStarting,
+        loading = isStarting,
+        modifier = Modifier.fillMaxWidth(),
+    )
+}
+
+@Composable
+private fun RenderingPhase(progress: Float) {
+    val spacing = LocalSpacing.current
+    Text("Creating your audiobook…", style = MaterialTheme.typography.titleMedium)
+    Text(
+        "Narrating chapters offline. You can leave this screen — we'll keep going " +
+            "in the background.",
+        style = MaterialTheme.typography.bodySmall,
+        color = MaterialTheme.colorScheme.onSurfaceVariant,
+    )
+    if (progress <= 0f) {
+        LinearProgressIndicator(modifier = Modifier.fillMaxWidth().padding(top = spacing.sm))
+    } else {
+        LinearProgressIndicator(
+            progress = { progress },
+            modifier = Modifier.fillMaxWidth().padding(top = spacing.sm),
+        )
+        Text("${(progress * 100).toInt()}%", style = MaterialTheme.typography.labelSmall)
+    }
+}
+
+@Composable
+private fun DonePhase(
+    fileName: String,
+    chapterCount: Int,
+    warnings: List<String>,
+    onShare: () -> Unit,
+    onSave: () -> Unit,
+    onDone: () -> Unit,
+) {
+    val spacing = LocalSpacing.current
+    Text("Your audiobook is ready", style = MaterialTheme.typography.titleMedium)
+    Text(
+        "$fileName · $chapterCount chapter${if (chapterCount == 1) "" else "s"}",
+        style = MaterialTheme.typography.bodySmall,
+        color = MaterialTheme.colorScheme.onSurfaceVariant,
+    )
+    warnings.forEach { w ->
+        Text("• $w", style = MaterialTheme.typography.bodySmall, color = MaterialTheme.colorScheme.onSurfaceVariant)
+    }
+    Row(
+        modifier = Modifier.fillMaxWidth().padding(top = spacing.xs),
+        horizontalArrangement = Arrangement.spacedBy(spacing.sm),
+    ) {
+        BrassButton(
+            label = "Save…",
+            onClick = onSave,
+            variant = BrassButtonVariant.Secondary,
+            modifier = Modifier.weight(1f),
+        )
+        BrassButton(
+            label = "Share",
+            onClick = onShare,
+            variant = BrassButtonVariant.Primary,
+            modifier = Modifier.weight(1f),
+        )
+    }
+    BrassButton(
+        label = "Done",
+        onClick = onDone,
+        variant = BrassButtonVariant.Text,
+        modifier = Modifier.fillMaxWidth(),
+    )
+}
+
+@Composable
+private fun FailedPhase(message: String, onRetry: () -> Unit) {
+    Text("Couldn't create the audiobook", style = MaterialTheme.typography.titleMedium)
+    Text(message, style = MaterialTheme.typography.bodySmall, color = MaterialTheme.colorScheme.error)
+    BrassButton(
+        label = "Try again",
+        onClick = onRetry,
+        variant = BrassButtonVariant.Primary,
+        modifier = Modifier.fillMaxWidth(),
+    )
+}
+
+private fun shareAudiobook(context: Context, file: File, fileName: String) {
+    val uri = FileProvider.getUriForFile(context, "${context.packageName}.fileprovider", file)
+    val send = Intent(Intent.ACTION_SEND).apply {
+        type = "audio/mp4"
+        putExtra(Intent.EXTRA_STREAM, uri)
+        putExtra(Intent.EXTRA_TITLE, fileName)
+        addFlags(Intent.FLAG_GRANT_READ_URI_PERMISSION)
+    }
+    context.startActivity(
+        Intent.createChooser(send, "Share audiobook").also {
+            it.addFlags(Intent.FLAG_GRANT_READ_URI_PERMISSION)
+        },
+    )
+}
+
+private fun readClipboard(context: Context): String? {
+    val cm = context.getSystemService(Context.CLIPBOARD_SERVICE) as? ClipboardManager ?: return null
+    val clip = cm.primaryClip ?: return null
+    if (clip.itemCount == 0) return null
+    return clip.getItemAt(0)?.text?.toString()
+}

--- a/feature/src/main/kotlin/in/jphe/storyvox/feature/library/CreateAudiobookSheet.kt
+++ b/feature/src/main/kotlin/in/jphe/storyvox/feature/library/CreateAudiobookSheet.kt
@@ -196,6 +196,17 @@ private fun ComposePhase(
             .fillMaxWidth()
             .heightIn(min = 120.dp, max = 240.dp),
     )
+    Row(
+        modifier = Modifier.fillMaxWidth(),
+        horizontalArrangement = Arrangement.End,
+    ) {
+        BrassButton(
+            label = "Paste from clipboard",
+            onClick = onPaste,
+            variant = BrassButtonVariant.Text,
+            enabled = !isStarting,
+        )
+    }
 
     if (voices.isNotEmpty()) {
         Text("Voice", style = MaterialTheme.typography.labelLarge)

--- a/feature/src/main/kotlin/in/jphe/storyvox/feature/library/CreateAudiobookViewModel.kt
+++ b/feature/src/main/kotlin/in/jphe/storyvox/feature/library/CreateAudiobookViewModel.kt
@@ -94,7 +94,9 @@ class CreateAudiobookViewModel @Inject constructor(
                 )
                 workName.value = name
                 _uiState.value = _uiState.value.copy(isStarting = false)
-            } catch (t: Throwable) {
+            } catch (@Suppress("TooGenericExceptionCaught") t: Throwable) {
+                // A DB write or enqueue failure must surface as an inline error,
+                // never an uncaught coroutine crash of the library screen.
                 _uiState.value = _uiState.value.copy(
                     isStarting = false,
                     error = t.message ?: "Couldn't start the audiobook",

--- a/feature/src/main/kotlin/in/jphe/storyvox/feature/library/CreateAudiobookViewModel.kt
+++ b/feature/src/main/kotlin/in/jphe/storyvox/feature/library/CreateAudiobookViewModel.kt
@@ -1,0 +1,118 @@
+package `in`.jphe.storyvox.feature.library
+
+import androidx.compose.runtime.Immutable
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import dagger.hilt.android.lifecycle.HiltViewModel
+import `in`.jphe.storyvox.playback.audiobook.AudiobookExportScheduler
+import `in`.jphe.storyvox.playback.audiobook.AudiobookExportStatus
+import `in`.jphe.storyvox.playback.audiobook.CreateAudiobookFromTextUseCase
+import `in`.jphe.storyvox.playback.voice.EngineType
+import `in`.jphe.storyvox.playback.voice.UiVoiceInfo
+import `in`.jphe.storyvox.playback.voice.VoiceManager
+import javax.inject.Inject
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.SharingStarted
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.flow.flatMapLatest
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.flow.stateIn
+import kotlinx.coroutines.launch
+
+/**
+ * Drives the "Make your own audiobook" flow (issue #1003): the user pastes /
+ * types text, names the book, picks a voice (a sensible default is
+ * pre-selected so they can one-tap straight through), and we
+ *   1. turn the text into a local fiction with chapters
+ *      ([CreateAudiobookFromTextUseCase]), then
+ *   2. enqueue the background render → encode → `.m4b`
+ *      ([AudiobookExportScheduler]),
+ * surfacing progress and finally the finished file for share / Save-As.
+ */
+@OptIn(kotlinx.coroutines.ExperimentalCoroutinesApi::class)
+@HiltViewModel
+class CreateAudiobookViewModel @Inject constructor(
+    private val createFromText: CreateAudiobookFromTextUseCase,
+    private val exportScheduler: AudiobookExportScheduler,
+    private val voiceManager: VoiceManager,
+) : ViewModel() {
+
+    /** Installed voices the user can narrate with. Azure / System TTS are
+     *  filtered out — the export path is offline-only (see
+     *  AudiobookSynthesizer). */
+    val voices: StateFlow<List<UiVoiceInfo>> = voiceManager.installedVoices
+        .map { list ->
+            list.filter { v ->
+                v.engineType !is EngineType.Azure && v.engineType !is EngineType.SystemTts
+            }
+        }
+        .stateIn(viewModelScope, SharingStarted.WhileSubscribed(5_000), emptyList())
+
+    private val _uiState = MutableStateFlow(CreateAudiobookUiState())
+    val uiState: StateFlow<CreateAudiobookUiState> = _uiState.asStateFlow()
+
+    /** The unique work name of the in-flight export, set on [start]. The
+     *  status flow is keyed off it. */
+    private val workName = MutableStateFlow<String?>(null)
+
+    /** Live export status for the active job (Idle until [start]). */
+    val exportStatus: StateFlow<AudiobookExportStatus> = workName
+        .flatMapLatest { name ->
+            if (name == null) flowOf(AudiobookExportStatus.Idle)
+            else exportScheduler.statusFor(name)
+        }
+        .stateIn(viewModelScope, SharingStarted.WhileSubscribed(5_000), AudiobookExportStatus.Idle)
+
+    /**
+     * Kick off creation + export. [voiceId] null = the active voice. Creates
+     * the local fiction first, then enqueues the render. The screen observes
+     * [exportStatus] for progress + the finished file.
+     */
+    fun start(text: String, title: String, author: String, voiceId: String?) {
+        if (_uiState.value.isStarting) return
+        _uiState.value = _uiState.value.copy(isStarting = true, error = null)
+        viewModelScope.launch {
+            try {
+                // Need at least one usable voice — fail fast with a clear msg
+                // rather than a cryptic worker failure.
+                val chosen = voiceId ?: voiceManager.activeVoice.first()?.id
+                if (chosen == null && voices.first().isEmpty()) {
+                    _uiState.value = _uiState.value.copy(
+                        isStarting = false,
+                        error = "Install a voice first (Voices tab), then create your audiobook.",
+                    )
+                    return@launch
+                }
+                val fictionId = createFromText.create(text = text, title = title, author = author)
+                val name = exportScheduler.enqueue(
+                    fictionId = fictionId,
+                    title = title.ifBlank { "My Audiobook" },
+                    voiceId = voiceId,
+                )
+                workName.value = name
+                _uiState.value = _uiState.value.copy(isStarting = false)
+            } catch (t: Throwable) {
+                _uiState.value = _uiState.value.copy(
+                    isStarting = false,
+                    error = t.message ?: "Couldn't start the audiobook",
+                )
+            }
+        }
+    }
+
+    /** Reset for a fresh creation (after the user dismisses the result). */
+    fun reset() {
+        workName.value = null
+        _uiState.value = CreateAudiobookUiState()
+    }
+}
+
+@Immutable
+data class CreateAudiobookUiState(
+    /** True between the create tap and the work being enqueued. */
+    val isStarting: Boolean = false,
+    val error: String? = null,
+)

--- a/feature/src/main/kotlin/in/jphe/storyvox/feature/library/LibraryScreen.kt
+++ b/feature/src/main/kotlin/in/jphe/storyvox/feature/library/LibraryScreen.kt
@@ -152,6 +152,16 @@ fun LibraryScreen(
         androidx.compose.runtime.mutableStateOf(false)
     }
 
+    // Issue #1003 — "Make your own audiobook." The + FAB opens a small
+    // chooser (Add by URL / Make your own audiobook); these two flags drive
+    // that menu and the create-audiobook sheet respectively.
+    var addMenuOpen by androidx.compose.runtime.remember {
+        androidx.compose.runtime.mutableStateOf(false)
+    }
+    var createAudiobookOpen by androidx.compose.runtime.remember {
+        androidx.compose.runtime.mutableStateOf(false)
+    }
+
     // Issue #828 — confirm-before-remove dialog state for the
     // "Remove from library" row on ManageShelvesSheet. Holds the
     // (fictionId, title) the sheet asked to remove; null = no dialog.
@@ -225,12 +235,36 @@ fun LibraryScreen(
             )
         },
         floatingActionButton = {
-            FloatingActionButton(
-                onClick = viewModel::showAddByUrl,
-                containerColor = MaterialTheme.colorScheme.primary,
-                contentColor = MaterialTheme.colorScheme.onPrimary,
-            ) {
-                Icon(Icons.Filled.Add, contentDescription = "Add fiction by URL")
+            // Issue #1003 — the + now offers two ways in: add a fiction by
+            // URL (the original flow) or make your own audiobook from pasted
+            // text. A compact DropdownMenu keeps the single, familiar FAB.
+            androidx.compose.foundation.layout.Box {
+                FloatingActionButton(
+                    onClick = { addMenuOpen = true },
+                    containerColor = MaterialTheme.colorScheme.primary,
+                    contentColor = MaterialTheme.colorScheme.onPrimary,
+                ) {
+                    Icon(Icons.Filled.Add, contentDescription = "Add to library")
+                }
+                androidx.compose.material3.DropdownMenu(
+                    expanded = addMenuOpen,
+                    onDismissRequest = { addMenuOpen = false },
+                ) {
+                    androidx.compose.material3.DropdownMenuItem(
+                        text = { Text("Add by URL") },
+                        onClick = {
+                            addMenuOpen = false
+                            viewModel.showAddByUrl()
+                        },
+                    )
+                    androidx.compose.material3.DropdownMenuItem(
+                        text = { Text("Make your own audiobook") },
+                        onClick = {
+                            addMenuOpen = false
+                            createAudiobookOpen = true
+                        },
+                    )
+                }
             }
         },
     ) { scaffoldPadding ->
@@ -426,6 +460,13 @@ fun LibraryScreen(
         onChooseSource = viewModel::chooseSource,
         onCancelChoose = viewModel::cancelChooseSource,
     )
+
+    // Issue #1003 — "Make your own audiobook" sheet. Self-contained: its own
+    // ViewModel handles text → local fiction → background render → .m4b →
+    // share/Save-As.
+    if (createAudiobookOpen) {
+        CreateAudiobookSheet(onDismiss = { createAudiobookOpen = false })
+    }
 
     ManageShelvesSheet(
         state = manageShelvesState,

--- a/feature/src/main/res/values/strings.xml
+++ b/feature/src/main/res/values/strings.xml
@@ -301,6 +301,8 @@
     <string name="fiction_remove_body">Your read progress will be lost. You can re-add it from Browse anytime, but the position you\'ve reached won\'t be restored.</string>
     <string name="fiction_building_epub">Building .epub…</string>
     <string name="fiction_export_epub">Export as EPUB…</string>
+    <!-- Issue #1003 — turn this fiction into a chaptered .m4b audiobook. -->
+    <string name="fiction_export_audiobook">Export as audiobook…</string>
     <string name="fiction_clear_cache">Clear fiction cache…</string>
     <string name="fiction_chapter_count">%1$d ch</string>
     <string name="fiction_separator">·</string>

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -49,6 +49,9 @@ include(":source-azure")
 include(":source-rss")
 include(":source-epub")
 include(":source-epub-writer")
+// Issue #1003 — pure-JVM chapterizer + M4B chapter-marker math for the
+// "Make your own audiobook" export. Android encode/mux lives in :core-playback.
+include(":source-audiobook-writer")
 include(":source-outline")
 include(":source-gutenberg")
 include(":source-ao3")

--- a/source-audiobook-writer/build.gradle.kts
+++ b/source-audiobook-writer/build.gradle.kts
@@ -1,0 +1,44 @@
+plugins {
+    alias(libs.plugins.android.library)
+    alias(libs.plugins.kotlin.android)
+}
+
+// Issue #1003 — "Make your own audiobook" M4B export.
+//
+// Distinct from the playback pipeline in :core-playback: this module holds
+// only the *pure*, Android-framework-free pieces of the export so they stay
+// testable in plain JUnit (no Robolectric, no MediaMuxer mocking):
+//   - AudiobookModel  — the book/chapter inputs the encoder consumes
+//   - Chapterizer     — splits a blob of pasted/imported text into chapters
+//   - Mp4ChapterMarkers — turns per-chapter durations into the timecode list
+//     the muxer needs, plus the QuickTime chapter-text track payload bytes
+//
+// The Android-specific encode + mux (MediaCodec AAC -> MediaMuxer .m4b) and the
+// `ExportFictionToAudiobookUseCase` that orchestrates synthesis live in
+// :core-playback, which already carries the VoxSherpa engines, EngineMutex,
+// VoiceManager and WorkManager wiring. core-playback depends on this module;
+// keeping this one a leaf (no project deps) avoids a dependency cycle and keeps
+// the math unit-tested.
+android {
+    namespace = "in.jphe.storyvox.source.audiobook.writer"
+    compileSdk = 36
+
+    defaultConfig {
+        minSdk = 26
+    }
+
+    compileOptions {
+        sourceCompatibility = JavaVersion.VERSION_17
+        targetCompatibility = JavaVersion.VERSION_17
+    }
+}
+
+kotlin {
+    compilerOptions {
+        jvmTarget.set(org.jetbrains.kotlin.gradle.dsl.JvmTarget.JVM_17)
+    }
+}
+
+dependencies {
+    testImplementation(libs.junit)
+}

--- a/source-audiobook-writer/src/main/AndroidManifest.xml
+++ b/source-audiobook-writer/src/main/AndroidManifest.xml
@@ -1,0 +1,2 @@
+<?xml version="1.0" encoding="utf-8"?>
+<manifest />

--- a/source-audiobook-writer/src/main/kotlin/in/jphe/storyvox/source/audiobook/writer/AudiobookFileName.kt
+++ b/source-audiobook-writer/src/main/kotlin/in/jphe/storyvox/source/audiobook/writer/AudiobookFileName.kt
@@ -1,0 +1,23 @@
+package `in`.jphe.storyvox.source.audiobook.writer
+
+import java.util.Locale
+
+/**
+ * Suggested cache filename + SAF picker default for an exported audiobook.
+ * Slugified title keeps multiple exports of the same book distinguishable in
+ * the user's Downloads folder. Mirrors the EPUB writer's `buildFileName`.
+ *
+ * Pure (takes the timestamp as a param) so it's deterministic under test.
+ */
+object AudiobookFileName {
+
+    /** `.m4b` for the chaptered AAC container, `.mp3` for the fallback path. */
+    fun forTitle(title: String, stamp: String, extension: String = "m4b"): String {
+        val slug = title.lowercase(Locale.US)
+            .replace(Regex("[^a-z0-9]+"), "-")
+            .trim('-')
+            .take(60)
+            .ifBlank { "audiobook" }
+        return "$slug-$stamp.$extension"
+    }
+}

--- a/source-audiobook-writer/src/main/kotlin/in/jphe/storyvox/source/audiobook/writer/AudiobookModel.kt
+++ b/source-audiobook-writer/src/main/kotlin/in/jphe/storyvox/source/audiobook/writer/AudiobookModel.kt
@@ -1,0 +1,51 @@
+package `in`.jphe.storyvox.source.audiobook.writer
+
+/**
+ * Inputs the M4B encoder consumes to write one chaptered audiobook. Pure
+ * data; no Room / Android dependency. Built by `ExportFictionToAudiobookUseCase`
+ * (in :core-playback) from DB rows, mirroring `EpubBook` from
+ * :source-epub-writer.
+ *
+ * Issue #1003 — "Make your own audiobook." A finished export carries title +
+ * author + optional cover and a chapter list; the encoder synthesizes each
+ * chapter's PCM, encodes to AAC, muxes into a single `.m4b`, and writes a
+ * QuickTime chapter-text track + iTunes metadata so audiobook players (Smart
+ * AudioBook Player, BookPlayer, Apple Books, etc.) show the chapter list.
+ */
+data class AudiobookBook(
+    val title: String,
+    val author: String,
+    /** Cover image bytes (JPEG/PNG), or null. Embedded as the `covr` atom in
+     *  the iTunes metadata so players show artwork. */
+    val cover: ByteArray? = null,
+    val chapters: List<AudiobookChapter>,
+) {
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (other !is AudiobookBook) return false
+        return title == other.title &&
+            author == other.author &&
+            cover.contentEqualsNullable(other.cover) &&
+            chapters == other.chapters
+    }
+
+    override fun hashCode(): Int {
+        var result = title.hashCode()
+        result = 31 * result + author.hashCode()
+        result = 31 * result + (cover?.contentHashCode() ?: 0)
+        result = 31 * result + chapters.hashCode()
+        return result
+    }
+}
+
+/**
+ * One chapter to narrate. [text] is the plain text fed to TTS; [title] labels
+ * the chapter marker in the output file.
+ */
+data class AudiobookChapter(
+    val title: String,
+    val text: String,
+)
+
+private fun ByteArray?.contentEqualsNullable(other: ByteArray?): Boolean =
+    if (this == null) other == null else other != null && this.contentEquals(other)

--- a/source-audiobook-writer/src/main/kotlin/in/jphe/storyvox/source/audiobook/writer/Chapterizer.kt
+++ b/source-audiobook-writer/src/main/kotlin/in/jphe/storyvox/source/audiobook/writer/Chapterizer.kt
@@ -1,0 +1,159 @@
+package `in`.jphe.storyvox.source.audiobook.writer
+
+/**
+ * Splits a blob of pasted / imported plain text into chapters for the
+ * "Make your own audiobook" flow (issue #1003).
+ *
+ * The split heuristic, in priority order:
+ *  1. **Explicit chapter headings** — lines like `Chapter 1`, `CHAPTER IV`,
+ *     `Chapter One:`, `Part 2`, or a bare `# Markdown heading`. When at least
+ *     two such headings are found, each heading opens a new chapter and the
+ *     heading line becomes that chapter's title.
+ *  2. **Form-feed / horizontal-rule breaks** — a line that's only `---`,
+ *     `***`, `===`, or a literal form-feed (`\f`, common in `.txt` exports
+ *     from PDFs) splits chapters. Titles fall back to "Chapter N".
+ *  3. **Fallback: one chapter.** Short pastes (a single article, a poem)
+ *     become a single chapter titled after the book.
+ *
+ * This is deliberately a pure function over a `String` so it unit-tests
+ * without Android. The UI lets the user edit the result before rendering
+ * (manual-edit affordance per the issue), so the heuristic only needs to be
+ * a sensible *default*, not perfect.
+ */
+object Chapterizer {
+
+    /** A chapter heading: optional markdown hashes, then `Chapter`/`Part`/
+     *  `Section` + a number (arabic or roman) or spelled-out number, with an
+     *  optional `: Subtitle`. Case-insensitive, whole line. */
+    private val HEADING = Regex(
+        pattern = """^\s*#{0,6}\s*(chapter|part|section|book)\s+""" +
+            """([0-9]+|[ivxlcdm]+|one|two|three|four|five|six|seven|eight|nine|ten|""" +
+            """eleven|twelve|thirteen|fourteen|fifteen|sixteen|seventeen|eighteen|""" +
+            """nineteen|twenty)\b.*$""",
+        options = setOf(RegexOption.IGNORE_CASE),
+    )
+
+    /** A bare markdown heading line (`# Title`, `## Title`) used as a chapter
+     *  break when no `Chapter N` headings are present. */
+    private val MD_HEADING = Regex("""^\s*#{1,6}\s+\S.*$""")
+
+    /** A thematic-break line: only rule characters (`---`, `***`, `___`,
+     *  `===`). */
+    private val RULE = Regex("""^\s*([-*_=]\s*){3,}\s*$""")
+
+    /** Canonical rule line a form-feed is rewritten to before splitting. */
+    private const val RULE_LINE = "---"
+
+    /** Form-feed: a page break, common in `.txt` exports of paginated docs. */
+    private const val FORM_FEED = '\u000C'
+
+    /**
+     * Split [fullText] into chapters. [bookTitle] is used as the single
+     * chapter's title in the fallback (no-heading) case. Never returns an
+     * empty list for non-blank input; blank input yields an empty list.
+     */
+    fun chapterize(fullText: String, bookTitle: String): List<AudiobookChapter> {
+        // Normalize newlines, and promote any form-feed page break to a
+        // standalone thematic-break line so the line-oriented splitters below
+        // see it cleanly regardless of the text that surrounds it on the page.
+        val normalized = fullText
+            .replace("\r\n", "\n")
+            .replace("\r", "\n")
+            .replace(FORM_FEED.toString(), "\n$RULE_LINE\n")
+        if (normalized.isBlank()) return emptyList()
+
+        // 1. Try explicit Chapter/Part headings.
+        byHeadings(normalized, HEADING)?.let { return it }
+        // 2. Fall back to markdown headings (must have at least 2 to be a
+        //    structure rather than a single titled article).
+        byHeadings(normalized, MD_HEADING, minHeadings = 2)?.let { return it }
+        // 3. Thematic-break splits.
+        byRules(normalized)?.let { return it }
+        // 4. Single chapter.
+        return listOf(
+            AudiobookChapter(
+                title = bookTitle.ifBlank { "Chapter 1" },
+                text = normalized.trim(),
+            ),
+        )
+    }
+
+    /**
+     * Split where lines match [heading]. Returns null when fewer than
+     * [minHeadings] headings are present (caller falls through to the next
+     * strategy). Any text *before* the first heading becomes an untitled
+     * "Foreword"-style chapter so no content is dropped.
+     */
+    private fun byHeadings(
+        text: String,
+        heading: Regex,
+        minHeadings: Int = 2,
+    ): List<AudiobookChapter>? {
+        val lines = text.split("\n")
+        val headingIdx = lines.indices.filter { heading.matches(lines[it]) }
+        if (headingIdx.size < minHeadings) return null
+
+        val chapters = mutableListOf<AudiobookChapter>()
+
+        // Preamble before the first heading (dedication, intro) — keep it.
+        val firstHeading = headingIdx.first()
+        if (firstHeading > 0) {
+            val pre = lines.subList(0, firstHeading).joinToString("\n").trim()
+            if (pre.isNotBlank()) {
+                chapters += AudiobookChapter(title = "Introduction", text = pre)
+            }
+        }
+
+        for ((n, start) in headingIdx.withIndex()) {
+            val end = headingIdx.getOrNull(n + 1) ?: lines.size
+            val rawTitle = lines[start].trim().removePrefix("#").trim()
+                .trimStart('#').trim()
+                .ifBlank { "Chapter ${n + 1}" }
+            val body = lines.subList(start + 1, end).joinToString("\n").trim()
+            // Skip a heading with no body (two headings back-to-back) but
+            // keep the title carried onto the next non-empty section by
+            // simply emitting the (possibly title-only) chapter — players
+            // tolerate a near-zero-length chapter, and dropping it would
+            // misalign the user's manual edits. We still emit so the count
+            // matches what the user sees.
+            chapters += AudiobookChapter(title = cleanTitle(rawTitle), text = body)
+        }
+        return chapters
+    }
+
+    /** Split on thematic-break lines. Returns null when there are no rule
+     *  lines (so the single-chapter fallback applies). */
+    private fun byRules(text: String): List<AudiobookChapter>? {
+        val lines = text.split("\n")
+        if (lines.none { RULE.matches(it) }) return null
+
+        val chapters = mutableListOf<AudiobookChapter>()
+        val current = StringBuilder()
+        var chapterNo = 1
+        fun flush() {
+            val body = current.toString().trim()
+            if (body.isNotBlank()) {
+                chapters += AudiobookChapter(title = "Chapter $chapterNo", text = body)
+                chapterNo++
+            }
+            current.setLength(0)
+        }
+        for (line in lines) {
+            if (RULE.matches(line)) {
+                flush()
+            } else {
+                current.append(line).append('\n')
+            }
+        }
+        flush()
+        return chapters.ifEmpty { null }
+    }
+
+    /** Trim a heading down to a clean marker label: collapse whitespace and
+     *  cap length so a runaway "heading" (a wrapped paragraph mis-detected as
+     *  a heading) doesn't produce an absurd chapter title. */
+    private fun cleanTitle(raw: String): String {
+        val collapsed = raw.replace(Regex("\\s+"), " ").trim()
+        return if (collapsed.length > 80) collapsed.take(77) + "…" else collapsed
+    }
+}

--- a/source-audiobook-writer/src/main/kotlin/in/jphe/storyvox/source/audiobook/writer/Mp4Boxes.kt
+++ b/source-audiobook-writer/src/main/kotlin/in/jphe/storyvox/source/audiobook/writer/Mp4Boxes.kt
@@ -1,0 +1,164 @@
+package `in`.jphe.storyvox.source.audiobook.writer
+
+import java.io.ByteArrayOutputStream
+
+/**
+ * Minimal MP4 (ISO-BMFF) box builders for the metadata atoms that turn a
+ * MediaMuxer-produced `.m4a`/`.mp4` into a chaptered, tagged audiobook
+ * (issue #1003). Pure byte manipulation — no Android — so the layout is
+ * unit-testable against the well-known formats.
+ *
+ * We write two things into a `udta` box that gets injected into the `moov`
+ * atom by [Mp4MetadataInjector]:
+ *
+ *  - **`chpl`** — the Nero chapter list (`moov.udta.chpl`). The de-facto
+ *    chapter format read by VLC, audiobookshelf, Smart AudioBook Player and
+ *    most Android audiobook apps. 100-nanosecond timestamps, 1-byte count.
+ *  - **`meta`/`ilst`** — iTunes-style metadata: `©nam` (title), `©ART`
+ *    (author), and `covr` (cover art). Read by Apple Books / iTunes / many
+ *    players for the title + artwork.
+ *
+ * Box wire format (ISO-BMFF): `[uint32 size][4-byte type][payload]`, sizes
+ * big-endian and inclusive of the 8-byte header.
+ */
+internal object Mp4Boxes {
+
+    /** Every ISO-BMFF box type is a 4-character (FourCC) code. */
+    private const val FOURCC_LEN = 4
+
+    /** Build a full `udta` box carrying the chapter list and iTunes metadata.
+     *  Either part may be empty (no chapters / no metadata); a fully empty
+     *  result still returns a valid (header-only) udta the injector can skip. */
+    fun udta(
+        markers: List<ChapterMarker>,
+        title: String,
+        author: String,
+        cover: ByteArray?,
+    ): ByteArray {
+        val children = ByteArrayOutputStream()
+        if (markers.isNotEmpty()) children.write(chpl(markers))
+        val meta = meta(title, author, cover)
+        if (meta != null) children.write(meta)
+        return box("udta", children.toByteArray())
+    }
+
+    /**
+     * Nero `chpl` chapter box. Version 1, with the 4-byte reserved field and
+     * a 1-byte chapter count, then per-chapter an 8-byte 100ns start time and
+     * a 1-byte-length-prefixed UTF-8 title.
+     *
+     * Chapter count is an 8-bit field; we clamp at 255 (the Nero ceiling).
+     */
+    fun chpl(markers: List<ChapterMarker>): ByteArray {
+        val count = markers.size.coerceAtMost(255)
+        val payload = ByteArrayOutputStream()
+        // version(1) + flags(3)
+        payload.write(0x01)
+        payload.write(byteArrayOf(0, 0, 0))
+        // reserved(4) — FFmpeg writes a 4-byte reserved field in the v1 box
+        payload.write(byteArrayOf(0, 0, 0, 0))
+        // chapter count (1 byte)
+        payload.write(count and 0xFF)
+        for (i in 0 until count) {
+            val m = markers[i]
+            // start time in 100-nanosecond units
+            val start100ns = m.startMs * 10_000L
+            payload.write(longBE(start100ns))
+            val titleBytes = m.title.toByteArray(Charsets.UTF_8)
+            val tlen = titleBytes.size.coerceAtMost(255)
+            payload.write(tlen and 0xFF)
+            payload.write(titleBytes, 0, tlen)
+        }
+        return box("chpl", payload.toByteArray())
+    }
+
+    /**
+     * iTunes `meta` box: `[fullbox header][hdlr 'mdir'][ilst ...]`. Returns
+     * null when there's nothing to write (no title, author or cover).
+     */
+    fun meta(title: String, author: String, cover: ByteArray?): ByteArray? {
+        val items = ByteArrayOutputStream()
+        if (title.isNotBlank()) items.write(ituneTextItem("©nam", title))
+        if (author.isNotBlank()) items.write(ituneTextItem("©ART", author))
+        if (cover != null && cover.isNotEmpty()) items.write(ituneCoverItem(cover))
+        val ilstPayload = items.toByteArray()
+        if (ilstPayload.isEmpty()) return null
+
+        val metaPayload = ByteArrayOutputStream()
+        // meta is a FullBox: version(1) + flags(3) before its children.
+        metaPayload.write(byteArrayOf(0, 0, 0, 0))
+        metaPayload.write(hdlrMdir())
+        metaPayload.write(box("ilst", ilstPayload))
+        return box("meta", metaPayload.toByteArray())
+    }
+
+    /** `hdlr` declaring the metadata handler type `mdir`/`appl` that iTunes
+     *  metadata readers expect inside a `meta` box. */
+    private fun hdlrMdir(): ByteArray {
+        val p = ByteArrayOutputStream()
+        p.write(byteArrayOf(0, 0, 0, 0)) // version + flags
+        p.write(byteArrayOf(0, 0, 0, 0)) // pre_defined
+        p.write("mdir".toByteArray(Charsets.US_ASCII)) // handler_type
+        p.write("appl".toByteArray(Charsets.US_ASCII)) // reserved[0] = 'appl'
+        p.write(byteArrayOf(0, 0, 0, 0)) // reserved[1]
+        p.write(byteArrayOf(0, 0, 0, 0)) // reserved[2]
+        p.write(0x00) // name (empty, null-terminated)
+        return box("hdlr", p.toByteArray())
+    }
+
+    /** A `©nam`/`©ART`-style text metadata item: an outer box named by the
+     *  4-byte key, containing a `data` box with type-flag 1 (UTF-8 text). */
+    private fun ituneTextItem(key: String, value: String): ByteArray {
+        val data = dataBox(typeFlag = 1, payload = value.toByteArray(Charsets.UTF_8))
+        return box(key, data)
+    }
+
+    /** A `covr` cover-art item: `data` box with the image type flag (13 = JPEG,
+     *  14 = PNG). We sniff the PNG magic; default to JPEG. */
+    private fun ituneCoverItem(cover: ByteArray): ByteArray {
+        val isPng = cover.size >= 8 &&
+            cover[0] == 0x89.toByte() && cover[1] == 'P'.code.toByte() &&
+            cover[2] == 'N'.code.toByte() && cover[3] == 'G'.code.toByte()
+        val typeFlag = if (isPng) 14 else 13
+        return box("covr", dataBox(typeFlag = typeFlag, payload = cover))
+    }
+
+    /** iTunes `data` box: `[uint32 typeFlag][uint32 locale=0][payload]`. */
+    private fun dataBox(typeFlag: Int, payload: ByteArray): ByteArray {
+        val p = ByteArrayOutputStream()
+        p.write(intBE(typeFlag))
+        p.write(intBE(0)) // locale
+        p.write(payload)
+        return box("data", p.toByteArray())
+    }
+
+    /** Wrap [payload] in a box of [type] (4 ASCII chars). */
+    fun box(type: String, payload: ByteArray): ByteArray {
+        require(type.length == FOURCC_LEN) { "box type must be 4 chars: $type" }
+        val size = 8 + payload.size
+        val out = ByteArray(size)
+        writeIntBE(out, 0, size)
+        // Type chars are Latin-1 (©nam uses 0xA9) — encode per-char.
+        for (i in 0 until FOURCC_LEN) out[4 + i] = type[i].code.toByte()
+        System.arraycopy(payload, 0, out, 8, payload.size)
+        return out
+    }
+
+    fun intBE(v: Int): ByteArray = byteArrayOf(
+        ((v ushr 24) and 0xFF).toByte(),
+        ((v ushr 16) and 0xFF).toByte(),
+        ((v ushr 8) and 0xFF).toByte(),
+        (v and 0xFF).toByte(),
+    )
+
+    fun longBE(v: Long): ByteArray = ByteArray(8) { i ->
+        ((v ushr (56 - i * 8)) and 0xFF).toByte()
+    }
+
+    fun writeIntBE(buf: ByteArray, offset: Int, v: Int) {
+        buf[offset] = ((v ushr 24) and 0xFF).toByte()
+        buf[offset + 1] = ((v ushr 16) and 0xFF).toByte()
+        buf[offset + 2] = ((v ushr 8) and 0xFF).toByte()
+        buf[offset + 3] = (v and 0xFF).toByte()
+    }
+}

--- a/source-audiobook-writer/src/main/kotlin/in/jphe/storyvox/source/audiobook/writer/Mp4ChapterMarkers.kt
+++ b/source-audiobook-writer/src/main/kotlin/in/jphe/storyvox/source/audiobook/writer/Mp4ChapterMarkers.kt
@@ -1,0 +1,64 @@
+package `in`.jphe.storyvox.source.audiobook.writer
+
+/**
+ * One chapter marker in the finished M4B: a label + its start offset from the
+ * beginning of the book.
+ */
+data class ChapterMarker(
+    val title: String,
+    val startMs: Long,
+)
+
+/**
+ * Pure timecode math + payload building for M4B chapter markers (issue #1003).
+ *
+ * Kept Android-free so the offset arithmetic and the QuickTime text-sample
+ * encoding are unit-testable without a `MediaMuxer`. The Android encoder
+ * (`AacM4bEncoder` in :core-playback) feeds in each chapter's rendered
+ * duration and uses the returned [ChapterMarker]s + text samples to write a
+ * QuickTime `text`/chapter track that audiobook players read.
+ */
+object Mp4ChapterMarkers {
+
+    /**
+     * Turn per-chapter durations (in the order the chapters were rendered)
+     * into absolute start offsets. The first chapter starts at 0; each
+     * subsequent chapter starts at the running sum of all prior durations.
+     *
+     * [titles] and [durationsMs] must be the same length; mismatched input is
+     * a programming error at the call site (the encoder pairs each rendered
+     * chapter with its title) and throws.
+     */
+    fun markers(titles: List<String>, durationsMs: List<Long>): List<ChapterMarker> {
+        require(titles.size == durationsMs.size) {
+            "titles (${titles.size}) and durationsMs (${durationsMs.size}) must align"
+        }
+        var acc = 0L
+        return titles.mapIndexed { i, title ->
+            val marker = ChapterMarker(title = title, startMs = acc)
+            acc += durationsMs[i].coerceAtLeast(0L)
+            marker
+        }
+    }
+
+    /**
+     * Encode one chapter title as a QuickTime `text` sample payload.
+     *
+     * The QuickTime text-sample wire format is: a big-endian `uint16` length
+     * prefix, then the UTF-8 text bytes. (Optional style/extension atoms may
+     * follow; players that show chapter names only need the length-prefixed
+     * string, which is what we emit.) This is the sample data the muxer writes
+     * into the chapter track for each marker.
+     */
+    fun textSample(title: String): ByteArray {
+        val utf8 = title.toByteArray(Charsets.UTF_8)
+        // Cap at uint16 — chapter titles are short; clamp defensively so the
+        // length prefix can't overflow on a pathological title.
+        val len = utf8.size.coerceAtMost(0xFFFF)
+        val out = ByteArray(2 + len)
+        out[0] = ((len ushr 8) and 0xFF).toByte()
+        out[1] = (len and 0xFF).toByte()
+        System.arraycopy(utf8, 0, out, 2, len)
+        return out
+    }
+}

--- a/source-audiobook-writer/src/main/kotlin/in/jphe/storyvox/source/audiobook/writer/Mp4MetadataInjector.kt
+++ b/source-audiobook-writer/src/main/kotlin/in/jphe/storyvox/source/audiobook/writer/Mp4MetadataInjector.kt
@@ -1,0 +1,111 @@
+package `in`.jphe.storyvox.source.audiobook.writer
+
+import java.io.RandomAccessFile
+
+/**
+ * Injects a `udta` metadata box (chapters + iTunes tags) into the `moov` atom
+ * of an MP4/M4A produced by Android's `MediaMuxer` (issue #1003).
+ *
+ * Why this is safe and cheap: `MediaMuxer` writes the `moov` atom **last**
+ * (after `mdat`). Because `moov` is the final top-level box and `udta` becomes
+ * its final child, we can:
+ *   1. append the `udta` bytes at the current end-of-file (i.e. immediately
+ *      after `moov`'s existing last child), and
+ *   2. grow `moov`'s 4-byte size field by the `udta` length.
+ *
+ * Nothing in `mdat` moves, so the `stco`/`co64` sample-chunk offsets inside
+ * `moov` stay valid — no offset rewriting needed. This is the one ordering
+ * that makes in-place metadata injection trivial; if a future Android release
+ * starts writing faststart (`moov` before `mdat`) files we'd need the full
+ * offset-patching path instead, so [findTopLevelMoov] verifies the layout and
+ * the caller treats a non-trailing `moov` as "skip metadata" rather than
+ * corrupting the file.
+ */
+object Mp4MetadataInjector {
+
+    /** Result of [findTopLevelMoov]: byte offset of the `moov` box header and
+     *  its declared size. */
+    data class MoovBox(val offset: Long, val size: Long)
+
+    /**
+     * Inject chapters + tags into [file] in place. No-op (returns false)
+     * when there's nothing to write or the `moov` isn't the trailing box.
+     * Returns true when metadata was injected.
+     */
+    fun inject(
+        file: RandomAccessFile,
+        markers: List<ChapterMarker>,
+        title: String,
+        author: String,
+        cover: ByteArray?,
+    ): Boolean {
+        val udta = Mp4Boxes.udta(markers, title, author, cover)
+        // udta header alone (8 bytes) with no children means nothing to add.
+        if (udta.size <= 8) return false
+
+        val moov = findTopLevelMoov(file) ?: return false
+
+        // moov must be the last top-level box for the append-and-grow trick.
+        val fileLen = file.length()
+        if (moov.offset + moov.size != fileLen) return false
+        // A 64-bit-size moov (size field == 1) would need largesize handling;
+        // audiobook moovs are far under 4 GiB, so a 32-bit size is expected.
+        if (moov.size > 0xFFFFFFFFL) return false
+
+        // 1. Append udta at EOF (becomes moov's final child).
+        file.seek(fileLen)
+        file.write(udta)
+
+        // 2. Grow moov's 32-bit size field in place.
+        val newMoovSize = moov.size + udta.size
+        require(newMoovSize <= 0xFFFFFFFFL) { "moov would exceed 32-bit size" }
+        file.seek(moov.offset)
+        file.write(Mp4Boxes.intBE(newMoovSize.toInt()))
+        return true
+    }
+
+    /**
+     * Walk the top-level box list and return the trailing `moov` box, or null
+     * if there's no `moov` or it isn't last. Handles the 64-bit `largesize`
+     * extension (size field == 1) and the "rest of file" sentinel (size == 0).
+     */
+    fun findTopLevelMoov(file: RandomAccessFile): MoovBox? {
+        val fileLen = file.length()
+        var pos = 0L
+        var found: MoovBox? = null
+        val header = ByteArray(8)
+        while (pos + 8 <= fileLen) {
+            file.seek(pos)
+            file.readFully(header)
+            val size32 = readUIntBE(header, 0)
+            val type = String(header, 4, 4, Charsets.US_ASCII)
+            val boxSize: Long = when (size32) {
+                1L -> {
+                    // 64-bit largesize follows the type.
+                    val ext = ByteArray(8)
+                    file.readFully(ext)
+                    readULongBE(ext, 0)
+                }
+                0L -> fileLen - pos // extends to EOF
+                else -> size32
+            }
+            if (boxSize <= 0 || pos + boxSize > fileLen) break
+            if (type == "moov") found = MoovBox(offset = pos, size = boxSize)
+            pos += boxSize
+        }
+        // Only return moov if it's the last box (offset + size == EOF).
+        return found?.takeIf { it.offset + it.size == fileLen }
+    }
+
+    private fun readUIntBE(b: ByteArray, o: Int): Long =
+        ((b[o].toLong() and 0xFF) shl 24) or
+            ((b[o + 1].toLong() and 0xFF) shl 16) or
+            ((b[o + 2].toLong() and 0xFF) shl 8) or
+            (b[o + 3].toLong() and 0xFF)
+
+    private fun readULongBE(b: ByteArray, o: Int): Long {
+        var v = 0L
+        for (i in 0 until 8) v = (v shl 8) or (b[o + i].toLong() and 0xFF)
+        return v
+    }
+}

--- a/source-audiobook-writer/src/test/kotlin/in/jphe/storyvox/source/audiobook/writer/AudiobookFileNameTest.kt
+++ b/source-audiobook-writer/src/test/kotlin/in/jphe/storyvox/source/audiobook/writer/AudiobookFileNameTest.kt
@@ -1,0 +1,34 @@
+package `in`.jphe.storyvox.source.audiobook.writer
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class AudiobookFileNameTest {
+
+    @Test
+    fun `slugifies title and appends stamp and extension`() {
+        val name = AudiobookFileName.forTitle("My Great Book!", "20260605-1430")
+        assertEquals("my-great-book-20260605-1430.m4b", name)
+    }
+
+    @Test
+    fun `blank title falls back to audiobook`() {
+        val name = AudiobookFileName.forTitle("   ", "20260605-1430")
+        assertEquals("audiobook-20260605-1430.m4b", name)
+    }
+
+    @Test
+    fun `mp3 fallback extension`() {
+        val name = AudiobookFileName.forTitle("Tale", "20260605-1430", extension = "mp3")
+        assertTrue(name.endsWith(".mp3"))
+    }
+
+    @Test
+    fun `long titles are truncated to a sane slug length`() {
+        val long = "a".repeat(200)
+        val name = AudiobookFileName.forTitle(long, "20260605-1430")
+        // 60-char slug + "-" + stamp + ".m4b"
+        assertTrue(name.startsWith("a".repeat(60) + "-"))
+    }
+}

--- a/source-audiobook-writer/src/test/kotlin/in/jphe/storyvox/source/audiobook/writer/ChapterizerTest.kt
+++ b/source-audiobook-writer/src/test/kotlin/in/jphe/storyvox/source/audiobook/writer/ChapterizerTest.kt
@@ -1,0 +1,148 @@
+package `in`.jphe.storyvox.source.audiobook.writer
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class ChapterizerTest {
+
+    @Test
+    fun `blank input yields no chapters`() {
+        assertTrue(Chapterizer.chapterize("   \n\n  ", "Book").isEmpty())
+    }
+
+    @Test
+    fun `single paragraph becomes one chapter titled after the book`() {
+        val chapters = Chapterizer.chapterize("Just a short article here.", "My Article")
+        assertEquals(1, chapters.size)
+        assertEquals("My Article", chapters[0].title)
+        assertEquals("Just a short article here.", chapters[0].text)
+    }
+
+    @Test
+    fun `explicit Chapter headings split and become titles`() {
+        val text = """
+            Chapter 1
+            The first part.
+
+            Chapter 2
+            The second part.
+
+            Chapter 3
+            The third part.
+        """.trimIndent()
+        val chapters = Chapterizer.chapterize(text, "Novel")
+        assertEquals(3, chapters.size)
+        assertEquals("Chapter 1", chapters[0].title)
+        assertEquals("The first part.", chapters[0].text)
+        assertEquals("Chapter 3", chapters[2].title)
+        assertEquals("The third part.", chapters[2].text)
+    }
+
+    @Test
+    fun `chapter heading with subtitle keeps the whole line as the title`() {
+        val text = """
+            Chapter One: The Beginning
+            Once upon a time.
+
+            Chapter Two: The Middle
+            Things happened.
+        """.trimIndent()
+        val chapters = Chapterizer.chapterize(text, "Tale")
+        assertEquals(2, chapters.size)
+        assertEquals("Chapter One: The Beginning", chapters[0].title)
+        assertEquals("Chapter Two: The Middle", chapters[1].title)
+    }
+
+    @Test
+    fun `preamble before first heading is kept as an Introduction`() {
+        val text = """
+            A dedication to my readers.
+
+            Chapter 1
+            Body one.
+
+            Chapter 2
+            Body two.
+        """.trimIndent()
+        val chapters = Chapterizer.chapterize(text, "Book")
+        assertEquals(3, chapters.size)
+        assertEquals("Introduction", chapters[0].title)
+        assertEquals("A dedication to my readers.", chapters[0].text)
+    }
+
+    @Test
+    fun `roman numeral chapters are detected`() {
+        val text = """
+            Chapter IV
+            Four.
+
+            Chapter V
+            Five.
+        """.trimIndent()
+        val chapters = Chapterizer.chapterize(text, "Book")
+        assertEquals(2, chapters.size)
+        assertEquals("Chapter IV", chapters[0].title)
+    }
+
+    @Test
+    fun `markdown headings split when at least two are present`() {
+        val text = """
+            # Prologue
+            In the beginning.
+
+            # Epilogue
+            And in the end.
+        """.trimIndent()
+        val chapters = Chapterizer.chapterize(text, "Book")
+        assertEquals(2, chapters.size)
+        assertEquals("Prologue", chapters[0].title)
+        assertEquals("Epilogue", chapters[1].title)
+    }
+
+    @Test
+    fun `single markdown heading does not split into a heading-only chapter`() {
+        // Only one '#' heading -> not a multi-chapter structure -> single chapter.
+        val text = "# Title\nThe body of a single titled article."
+        val chapters = Chapterizer.chapterize(text, "Fallback Title")
+        assertEquals(1, chapters.size)
+        assertEquals("Fallback Title", chapters[0].title)
+    }
+
+    @Test
+    fun `horizontal rule breaks split into numbered chapters`() {
+        val text = """
+            First section text.
+
+            ---
+
+            Second section text.
+
+            ***
+
+            Third section text.
+        """.trimIndent()
+        val chapters = Chapterizer.chapterize(text, "Book")
+        assertEquals(3, chapters.size)
+        assertEquals("Chapter 1", chapters[0].title)
+        assertEquals("First section text.", chapters[0].text)
+        assertEquals("Third section text.", chapters[2].text)
+    }
+
+    @Test
+    fun `form feed splits chapters`() {
+        val text = "Page one body.\n\u000CPage two body."
+        val chapters = Chapterizer.chapterize(text, "Book")
+        assertEquals(2, chapters.size)
+        assertEquals("Page one body.", chapters[0].text)
+        assertEquals("Page two body.", chapters[1].text)
+    }
+
+    @Test
+    fun `CRLF line endings are normalized`() {
+        val text = "Chapter 1\r\nBody one.\r\n\r\nChapter 2\r\nBody two."
+        val chapters = Chapterizer.chapterize(text, "Book")
+        assertEquals(2, chapters.size)
+        assertEquals("Body one.", chapters[0].text)
+    }
+}

--- a/source-audiobook-writer/src/test/kotlin/in/jphe/storyvox/source/audiobook/writer/Mp4BoxesTest.kt
+++ b/source-audiobook-writer/src/test/kotlin/in/jphe/storyvox/source/audiobook/writer/Mp4BoxesTest.kt
@@ -1,0 +1,91 @@
+package `in`.jphe.storyvox.source.audiobook.writer
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class Mp4BoxesTest {
+
+    private fun u32(b: ByteArray, o: Int): Long =
+        ((b[o].toLong() and 0xFF) shl 24) or
+            ((b[o + 1].toLong() and 0xFF) shl 16) or
+            ((b[o + 2].toLong() and 0xFF) shl 8) or
+            (b[o + 3].toLong() and 0xFF)
+
+    private fun type(b: ByteArray, o: Int): String = String(b, o, 4, Charsets.US_ASCII)
+
+    @Test
+    fun `box header carries size and fourcc`() {
+        val b = Mp4Boxes.box("test", byteArrayOf(1, 2, 3))
+        assertEquals(11L, u32(b, 0))
+        assertEquals("test", type(b, 4))
+        assertEquals(11, b.size)
+    }
+
+    @Test
+    fun `chpl encodes count and 100ns timestamps`() {
+        val markers = listOf(
+            ChapterMarker("Intro", 0L),
+            ChapterMarker("Two", 1_000L), // 1s -> 10_000_000 in 100ns units
+        )
+        val chpl = Mp4Boxes.chpl(markers)
+        assertEquals("chpl", type(chpl, 4))
+        // payload starts at offset 8: version(1)+flags(3)+reserved(4)+count(1)
+        assertEquals(0x01, chpl[8].toInt()) // version
+        val count = chpl[8 + 1 + 3 + 4].toInt() and 0xFF
+        assertEquals(2, count)
+        // first chapter timestamp (8 bytes) right after the count byte
+        val tsOffset = 8 + 1 + 3 + 4 + 1
+        var ts0 = 0L
+        for (i in 0 until 8) ts0 = (ts0 shl 8) or (chpl[tsOffset + i].toLong() and 0xFF)
+        assertEquals(0L, ts0)
+        // title length + "Intro"
+        val len0 = chpl[tsOffset + 8].toInt() and 0xFF
+        assertEquals("Intro".length, len0)
+    }
+
+    @Test
+    fun `meta returns null when nothing to write`() {
+        assertNull(Mp4Boxes.meta(title = "", author = "", cover = null))
+    }
+
+    @Test
+    fun `meta carries title and author items`() {
+        val meta = Mp4Boxes.meta(title = "My Book", author = "Jane Doe", cover = null)!!
+        assertEquals("meta", type(meta, 4))
+        val asString = String(meta, Charsets.ISO_8859_1)
+        assertTrue("expected ©nam key", asString.contains("nam"))
+        assertTrue("expected ©ART key", asString.contains("ART"))
+        assertTrue(asString.contains("My Book"))
+        assertTrue(asString.contains("Jane Doe"))
+        assertTrue("expected mdir handler", asString.contains("mdir"))
+    }
+
+    @Test
+    fun `cover type flag is JPEG by default and PNG when magic present`() {
+        val jpeg = byteArrayOf(0xFF.toByte(), 0xD8.toByte(), 0xFF.toByte(), 0)
+        val metaJpeg = Mp4Boxes.meta("", "", jpeg)!!
+        // covr -> data box with typeFlag 13 (JPEG)
+        assertTrue(String(metaJpeg, Charsets.ISO_8859_1).contains("covr"))
+
+        val png = byteArrayOf(0x89.toByte(), 'P'.code.toByte(), 'N'.code.toByte(), 'G'.code.toByte(), 0, 0, 0, 0)
+        val metaPng = Mp4Boxes.meta("", "", png)!!
+        assertTrue(String(metaPng, Charsets.ISO_8859_1).contains("covr"))
+    }
+
+    @Test
+    fun `udta nests chpl and meta`() {
+        val udta = Mp4Boxes.udta(
+            markers = listOf(ChapterMarker("A", 0L)),
+            title = "T",
+            author = "Au",
+            cover = null,
+        )
+        assertEquals("udta", type(udta, 4))
+        val s = String(udta, Charsets.ISO_8859_1)
+        assertTrue(s.contains("chpl"))
+        assertTrue(s.contains("meta"))
+        assertEquals(udta.size.toLong(), u32(udta, 0))
+    }
+}

--- a/source-audiobook-writer/src/test/kotlin/in/jphe/storyvox/source/audiobook/writer/Mp4ChapterMarkersTest.kt
+++ b/source-audiobook-writer/src/test/kotlin/in/jphe/storyvox/source/audiobook/writer/Mp4ChapterMarkersTest.kt
@@ -1,0 +1,64 @@
+package `in`.jphe.storyvox.source.audiobook.writer
+
+import org.junit.Assert.assertArrayEquals
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertThrows
+import org.junit.Test
+
+class Mp4ChapterMarkersTest {
+
+    @Test
+    fun `markers accumulate start offsets from durations`() {
+        val markers = Mp4ChapterMarkers.markers(
+            titles = listOf("One", "Two", "Three"),
+            durationsMs = listOf(5_000L, 3_000L, 10_000L),
+        )
+        assertEquals(3, markers.size)
+        assertEquals(0L, markers[0].startMs)
+        assertEquals(5_000L, markers[1].startMs)
+        assertEquals(8_000L, markers[2].startMs)
+        assertEquals("Two", markers[1].title)
+    }
+
+    @Test
+    fun `single chapter starts at zero`() {
+        val markers = Mp4ChapterMarkers.markers(listOf("Only"), listOf(42_000L))
+        assertEquals(1, markers.size)
+        assertEquals(0L, markers[0].startMs)
+    }
+
+    @Test
+    fun `negative durations are clamped so offsets never go backwards`() {
+        val markers = Mp4ChapterMarkers.markers(
+            titles = listOf("A", "B", "C"),
+            durationsMs = listOf(-1_000L, 2_000L, 1_000L),
+        )
+        assertEquals(0L, markers[0].startMs)
+        // -1000 clamped to 0, so B still starts at 0.
+        assertEquals(0L, markers[1].startMs)
+        assertEquals(2_000L, markers[2].startMs)
+    }
+
+    @Test
+    fun `mismatched title and duration counts throw`() {
+        assertThrows(IllegalArgumentException::class.java) {
+            Mp4ChapterMarkers.markers(listOf("A", "B"), listOf(1_000L))
+        }
+    }
+
+    @Test
+    fun `text sample is uint16 length-prefixed UTF-8`() {
+        val sample = Mp4ChapterMarkers.textSample("Hi")
+        // 2-byte big-endian length (2), then 'H','i'.
+        assertArrayEquals(byteArrayOf(0x00, 0x02, 'H'.code.toByte(), 'i'.code.toByte()), sample)
+    }
+
+    @Test
+    fun `text sample counts UTF-8 bytes not chars`() {
+        // "é" is two UTF-8 bytes (0xC3 0xA9).
+        val sample = Mp4ChapterMarkers.textSample("é")
+        assertEquals(0x00, sample[0].toInt())
+        assertEquals(0x02, sample[1].toInt())
+        assertEquals(4, sample.size)
+    }
+}

--- a/source-audiobook-writer/src/test/kotlin/in/jphe/storyvox/source/audiobook/writer/Mp4MetadataInjectorTest.kt
+++ b/source-audiobook-writer/src/test/kotlin/in/jphe/storyvox/source/audiobook/writer/Mp4MetadataInjectorTest.kt
@@ -1,0 +1,101 @@
+package `in`.jphe.storyvox.source.audiobook.writer
+
+import java.io.File
+import java.io.RandomAccessFile
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Rule
+import org.junit.Test
+import org.junit.rules.TemporaryFolder
+
+class Mp4MetadataInjectorTest {
+
+    @Rule
+    @JvmField
+    val tmp = TemporaryFolder()
+
+    /** Build a minimal MP4-shaped file: ftyp, then mdat, then a trailing
+     *  moov (the layout MediaMuxer produces). moov has a single child so the
+     *  box-walk has something to skip. */
+    private fun fakeMp4(moovLast: Boolean = true): File {
+        val ftyp = Mp4Boxes.box("ftyp", "isom".toByteArray())
+        val mdat = Mp4Boxes.box("mdat", ByteArray(64) { it.toByte() })
+        val moovChild = Mp4Boxes.box("mvhd", ByteArray(8))
+        val moov = Mp4Boxes.box("moov", moovChild)
+        val f = tmp.newFile("test.m4a")
+        f.outputStream().use {
+            it.write(ftyp)
+            if (moovLast) {
+                it.write(mdat)
+                it.write(moov)
+            } else {
+                it.write(moov) // faststart: moov before mdat
+                it.write(mdat)
+            }
+        }
+        return f
+    }
+
+    @Test
+    fun `finds trailing moov`() {
+        val f = fakeMp4()
+        RandomAccessFile(f, "r").use { raf ->
+            val moov = Mp4MetadataInjector.findTopLevelMoov(raf)
+            assertTrue(moov != null)
+            assertEquals(raf.length(), moov!!.offset + moov.size)
+        }
+    }
+
+    @Test
+    fun `does not return moov when it is not last`() {
+        val f = fakeMp4(moovLast = false)
+        RandomAccessFile(f, "r").use { raf ->
+            assertTrue(Mp4MetadataInjector.findTopLevelMoov(raf) == null)
+        }
+    }
+
+    @Test
+    fun `inject grows moov and appends udta, file stays well-formed`() {
+        val f = fakeMp4()
+        val originalLen = f.length()
+
+        val markers = listOf(ChapterMarker("One", 0L), ChapterMarker("Two", 5_000L))
+        RandomAccessFile(f, "rw").use { raf ->
+            val moovBefore = Mp4MetadataInjector.findTopLevelMoov(raf)!!
+            val injected = Mp4MetadataInjector.inject(
+                raf, markers, title = "Title", author = "Auth", cover = null,
+            )
+            assertTrue(injected)
+
+            // File grew by exactly the udta size.
+            val udta = Mp4Boxes.udta(markers, "Title", "Auth", null)
+            assertEquals(originalLen + udta.size, raf.length())
+
+            // moov is still the last box and now includes udta.
+            val moovAfter = Mp4MetadataInjector.findTopLevelMoov(raf)!!
+            assertEquals(moovBefore.offset, moovAfter.offset)
+            assertEquals(moovBefore.size + udta.size, moovAfter.size)
+            assertEquals(raf.length(), moovAfter.offset + moovAfter.size)
+        }
+
+        // The trailing bytes are the udta we wrote.
+        val bytes = f.readBytes()
+        val tail = String(bytes, bytes.size - 200.coerceAtMost(bytes.size), 200.coerceAtMost(bytes.size), Charsets.ISO_8859_1)
+        assertTrue(tail.contains("udta"))
+        assertTrue(tail.contains("chpl"))
+    }
+
+    @Test
+    fun `inject is a no-op when there is nothing to write`() {
+        val f = fakeMp4()
+        val originalLen = f.length()
+        RandomAccessFile(f, "rw").use { raf ->
+            val injected = Mp4MetadataInjector.inject(
+                raf, markers = emptyList(), title = "", author = "", cover = null,
+            )
+            assertFalse(injected)
+        }
+        assertEquals(originalLen, f.length())
+    }
+}


### PR DESCRIPTION
## What

Implements **#1003** — *"Make your own audiobook"*: turn your own text into a saved, shareable audiobook, **entirely offline, no account, no billing**.

This adds the one missing piece the issue calls out: Candela already synthesizes + caches PCM for *playback* but never wrote a portable file. Now it does — a chaptered **`.m4b`** with chapter markers + title/author/cover metadata, playable in Candela and shareable via the Android share sheet / Save-As (SAF).

## Two entry points

- **Library → `+` → "Make your own audiobook"** — paste/type text, name it + author, pick a voice (a sensible default is pre-selected so you can one-tap through). Text is auto-chapterized, rendered, and exported.
- **Fiction detail → overflow → "Export as audiobook…"** — turn any library book (Royal Road, Gutenberg, …) into an `.m4b` with the active voice. Mirrors the existing "Export as EPUB…" home.

Both surface a determinate progress sheet and then Share / Save-As.

## How it's built

**`:source-audiobook-writer`** (new, pure-JVM leaf — keeps the tricky bits unit-testable without Robolectric, **31 tests, all green**):
- `Chapterizer` — split text on `Chapter`/`Part` headings, markdown headings, thematic-break rules, or form-feed page breaks.
- `Mp4Boxes` / `Mp4ChapterMarkers` — Nero `chpl` chapter atom + iTunes `meta`/`ilst` (`©nam`/`©ART`/`covr`) box builders, plus chapter-timecode math.
- `Mp4MetadataInjector` — appends a `udta` box into the **trailing** `moov` that `MediaMuxer` writes and grows the `moov` size in place. Because `moov` follows `mdat`, no `stco`/`co64` chunk-offset rewriting is needed — the one ordering that makes in-place injection safe (verified + guarded: a non-trailing `moov` is a no-op, not a corruption).

**`:core-playback`** audiobook pipeline:
- `AudiobookSynthesizer` — renders a chapter to one PCM buffer via the in-process Piper/Kokoro/Kitten engines, serialized on the shared `EngineMutex` (same discipline as `ChapterRenderJob`). Azure / System TTS are rejected with a clear message — export is offline-only.
- `AacM4bEncoder` — MediaCodec AAC-LC → `MediaMuxer` MP4 → inject chapters + metadata.
- `ExportFictionToAudiobookUseCase` — mirrors `ExportFictionToEpubUseCase` (load DB rows → render → encode → FileProvider URI).
- `AudiobookExportJob` (`@HiltWorker`) + `AudiobookExportScheduler` — background render with a progress notification and a `WorkInfo`-backed status `Flow`.
- `CreateAudiobookFromTextUseCase` — pasted text → local fiction (`SourceIds.MY_AUDIOBOOK`) with `DOWNLOADED` chapters.

## Verification

- `:app:assembleDebug` — green (full Hilt DI graph resolves, `@HiltWorker` wired).
- `:source-audiobook-writer:testDebugUnitTest` — 31 tests green (chapterizer, chapter-marker math, MP4 box layout, and a round-trip injector test that asserts `moov` grows and the file stays well-formed).
- `:core-playback` + `:feature` compile clean.

Reuses the existing `${applicationId}.fileprovider` + `exports/` path already wired for EPUB export, so no manifest changes.

Closes #1003

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added "Make your own audiobook" feature to create audiobooks from pasted or typed text with auto-generated chapters using your downloaded voices
  * New "Export as audiobook" option available in fiction details for sharing audiobooks
  * Background processing with real-time progress tracking during audiobook generation
  * Save and share generated audiobooks in standard format

<!-- end of auto-generated comment: release notes by coderabbit.ai -->