### PR TITLE
fix(sync): wrong passphrase no longer clobbers the remote secrets blob (#1027)

### DIFF
--- a/core-sync/src/main/kotlin/in/jphe/storyvox/sync/domain/SecretsSyncer.kt
+++ b/core-sync/src/main/kotlin/in/jphe/storyvox/sync/domain/SecretsSyncer.kt
@@ -121,7 +121,26 @@ class SecretsSyncer @Inject constructor(
         val remote = backend.fetch(user, ENTITY, rowId(user)).getOrElse {
             return SyncOutcome.Transient("remote fetch: ${it.message}")
         }
-        val remoteDecoded: Stamped<Map<String, String>>? = remote?.let { decode(it.payload, it.updatedAt, key) }
+
+        // Issue #1027 (data loss): a remote row that EXISTS but cannot be
+        // decrypted/parsed is NOT the same as "no remote row." The old
+        // code collapsed both into `null`, picked local, and then pushed
+        // unconditionally — re-encrypting local secrets under the wrong
+        // key and silently destroying a perfectly good remote blob that a
+        // sibling device (holding the correct passphrase) still needed.
+        //
+        // We now distinguish the two. A present-but-opaque row means the
+        // passphrase doesn't match what the blob was encrypted with (wrong
+        // passphrase typed, or rotated on another device) — or, far more
+        // rarely, a garbled fetch. Either way we MUST NOT push: bail with a
+        // Permanent outcome so the coordinator stops retrying and the UI
+        // can prompt for the right passphrase, and leave both the remote
+        // blob and local prefs untouched.
+        val remoteDecoded: Stamped<Map<String, String>>? = when (val d = remote?.let { decode(it.payload, it.updatedAt, key) }) {
+            null -> null // no remote row at all — safe to originate from local
+            is DecodeResult.Undecryptable -> return SyncOutcome.Permanent(PASSPHRASE_MISMATCH_MESSAGE)
+            is DecodeResult.Decoded -> d.stamped
+        }
         val localStamp = Stamped(local, localUpdatedAt(local))
 
         val merged = when {
@@ -137,7 +156,11 @@ class SecretsSyncer @Inject constructor(
             secrets.edit { putLong(LAST_TOUCH_KEY, merged.updatedAt) }
         }
 
-        // Push merged back.
+        // Push merged back. Reaching here guarantees either there was no
+        // remote row, or the remote row decoded cleanly under this key —
+        // so this push never clobbers an opaque-but-present remote blob
+        // (the #1027 invariant). `merged` was therefore encrypted under the
+        // same key the existing remote uses (or originates a fresh blob).
         val envelope = encode(merged.value, key)
         val pushed = backend.upsert(
             user = user,
@@ -232,16 +255,41 @@ class SecretsSyncer @Inject constructor(
         return UserDerivedKey.envelope(blob)
     }
 
-    private fun decode(envelope: String, updatedAt: Long, key: SecretKey): Stamped<Map<String, String>>? {
-        val parsed = UserDerivedKey.parseEnvelope(envelope) ?: return null
-        val plain = runCatching { UserDerivedKey.decrypt(key, parsed.blob) }.getOrNull() ?: return null
+    /**
+     * Outcome of decoding a remote secrets row that we KNOW exists.
+     *
+     * Issue #1027: the caller must be able to tell "decoded cleanly" from
+     * "row is present but we can't read it" — the latter is the
+     * data-loss-causing case and must never lead to a push. ([reconcile]
+     * handles "no remote row at all" separately, before calling [decode],
+     * via the nullable `remote?.let { … }`.)
+     */
+    private sealed interface DecodeResult {
+        data class Decoded(val stamped: Stamped<Map<String, String>>) : DecodeResult
+
+        /**
+         * The envelope failed to parse, failed to decrypt (AES-GCM tag
+         * mismatch → wrong passphrase), or decrypted to non-JSON. The row
+         * exists on the server and belongs to someone's correct
+         * passphrase — overwriting it would be data loss.
+         */
+        data object Undecryptable : DecodeResult
+    }
+
+    private fun decode(envelope: String, updatedAt: Long, key: SecretKey): DecodeResult {
+        val parsed = UserDerivedKey.parseEnvelope(envelope) ?: return DecodeResult.Undecryptable
+        // AES-GCM authentication failure (wrong key) surfaces as an
+        // AEADBadTagException out of cipher.doFinal; any decrypt throw is
+        // treated as "can't read this row," never as "no row."
+        val plain = runCatching { UserDerivedKey.decrypt(key, parsed.blob) }.getOrNull()
+            ?: return DecodeResult.Undecryptable
         val map = runCatching {
             json.decodeFromString(
                 MapSerializer(String.serializer(), String.serializer()),
                 plain.decodeToString(),
             )
-        }.getOrNull() ?: return null
-        return Stamped(value = map, updatedAt = updatedAt)
+        }.getOrNull() ?: return DecodeResult.Undecryptable
+        return DecodeResult.Decoded(Stamped(value = map, updatedAt = updatedAt))
     }
 
     /** A 16-byte salt derived from the userId. Stable across devices for
@@ -258,6 +306,17 @@ class SecretsSyncer @Inject constructor(
         const val DOMAIN: String = "secrets"
         private const val ENTITY = "blobs"
         private const val LAST_TOUCH_KEY = "instantdb.secrets_synced_at"
+
+        /**
+         * Issue #1027 — user-facing outcome when the remote secrets blob
+         * exists but can't be decrypted with this device's passphrase.
+         * Surfaced via [SyncOutcome.Permanent] so the coordinator stops
+         * retrying and the Account screen can prompt the user to re-enter
+         * the passphrase used on their other device — instead of silently
+         * overwriting the remote blob (the data-loss bug this fixes).
+         */
+        const val PASSPHRASE_MISMATCH_MESSAGE: String =
+            "secrets: passphrase does not match the synced data — re-enter the passphrase used on your other device"
 
         /**
          * Hilt @Named qualifier for the passphrase provider binding.

--- a/core-sync/src/test/kotlin/in/jphe/storyvox/sync/SecretsSyncerTest.kt
+++ b/core-sync/src/test/kotlin/in/jphe/storyvox/sync/SecretsSyncerTest.kt
@@ -228,6 +228,109 @@ class SecretsSyncerTest {
         assertEquals("local-only-key", prefsB.getString("llm.openai_key", null))
     }
 
+    @Test fun `wrong passphrase does NOT overwrite the remote blob and reports passphrase mismatch (regression #1027)`() = runTest {
+        // #1027 (data loss): device B with a wrong/rotated passphrase used
+        // to (a) re-encrypt its OWN local secrets under the wrong key,
+        // (b) overwrite device A's good remote blob with that garbage, and
+        // (c) report SyncOutcome.Ok — destroying cross-device secret sync
+        // silently. The fix makes a present-but-undecryptable remote row a
+        // non-clobbering Permanent outcome.
+        val backend = FakeInstantBackend()
+        val rowId = SyncIds.rowUuid(SecretsSyncer.DOMAIN, USER.userId)
+
+        // Device A encrypts under the CORRECT passphrase and pushes.
+        val prefsA = FakePrefs().apply {
+            edit().putString("llm.openai_key", "sk-correct-A").apply()
+        }
+        SecretsSyncer(
+            secrets = prefsA,
+            backend = backend,
+            passphraseProvider = { PASSPHRASE.copyOf() },
+        ).push(USER)
+        val goodBlob = backend.fetch(USER, "blobs", rowId).getOrNull()
+        assertNotNull("device A must have written the remote blob", goodBlob)
+
+        // Device B has its own local secret and a WRONG passphrase.
+        val prefsB = FakePrefs().apply {
+            edit().putString("llm.openai_key", "local-only-B").apply()
+        }
+        val deviceB = SecretsSyncer(
+            secrets = prefsB,
+            backend = backend,
+            passphraseProvider = { "wrong-passphrase".toCharArray() },
+        )
+        val outcome = deviceB.pull(USER)
+
+        // (1) The outcome is the passphrase-mismatch Permanent — NOT Ok.
+        assertTrue(
+            "undecryptable remote must yield Permanent, got $outcome",
+            outcome is SyncOutcome.Permanent,
+        )
+        assertEquals(
+            SecretsSyncer.PASSPHRASE_MISMATCH_MESSAGE,
+            (outcome as SyncOutcome.Permanent).message,
+        )
+
+        // (2) The remote blob is BYTE-FOR-BYTE the one device A wrote —
+        // device B did not push anything over it.
+        val afterBlob = backend.fetch(USER, "blobs", rowId).getOrNull()
+        assertNotNull(afterBlob)
+        assertEquals(
+            "remote secrets blob must be untouched after a wrong-passphrase sync",
+            goodBlob!!.payload,
+            afterBlob!!.payload,
+        )
+        assertEquals(goodBlob.updatedAt, afterBlob.updatedAt)
+
+        // (3) Device A (correct passphrase) can still decrypt the remote —
+        // i.e. the blob is genuinely still A's, not silently re-keyed.
+        val prefsA2 = FakePrefs()
+        val deviceA2 = SecretsSyncer(
+            secrets = prefsA2,
+            backend = backend,
+            passphraseProvider = { PASSPHRASE.copyOf() },
+        )
+        assertTrue(
+            "a device with the correct passphrase must still pull cleanly",
+            deviceA2.pull(USER) is SyncOutcome.Ok,
+        )
+        assertEquals("sk-correct-A", prefsA2.getString("llm.openai_key", null))
+
+        // (4) Device B's local secret is untouched too (pre-fix invariant
+        // that already held — kept here so a future change can't regress
+        // it while we're guarding the remote).
+        assertEquals("local-only-B", prefsB.getString("llm.openai_key", null))
+    }
+
+    @Test fun `a structurally garbled remote envelope is non-clobbering (regression #1027)`() = runTest {
+        // The issue notes that even a remote row that fails parseEnvelope
+        // (not just decrypt) used to trip the same unconditional overwrite.
+        // A present-but-unparseable row is treated as undecryptable: never
+        // overwrite a row we can't read.
+        val backend = FakeInstantBackend()
+        val rowId = SyncIds.rowUuid(SecretsSyncer.DOMAIN, USER.userId)
+        // Seed the remote with a payload that is NOT a valid v1/v2 envelope.
+        backend.upsert(USER, "blobs", rowId, payload = "not-a-valid-envelope", updatedAt = 123L)
+
+        val prefs = FakePrefs().apply {
+            edit().putString("llm.openai_key", "local-key").apply()
+        }
+        val device = SecretsSyncer(
+            secrets = prefs,
+            backend = backend,
+            passphraseProvider = { PASSPHRASE.copyOf() },
+        )
+        val outcome = device.pull(USER)
+        assertTrue(
+            "garbled remote envelope must yield Permanent, got $outcome",
+            outcome is SyncOutcome.Permanent,
+        )
+        // The garbled row is left exactly as-is — we don't push over it.
+        val after = backend.fetch(USER, "blobs", rowId).getOrNull()
+        assertEquals("not-a-valid-envelope", after?.payload)
+        assertEquals(123L, after?.updatedAt)
+    }
+
     @Test fun `no passphrase configured returns permanent and does not touch local or remote`() = runTest {
         val backend = FakeInstantBackend()
         val prefs = FakePrefs().apply {


### PR DESCRIPTION
## Problem (#1027 — HIGH / data loss)

A wrong or rotated sync passphrase **silently overwrote** the remote
encrypted-secrets blob and reported `SyncOutcome.Ok`, destroying
cross-device secret sync. A user who mistyped their passphrase (or
rotated it on another device) would re-encrypt their local secrets under
the wrong key, push that over the good remote blob, and get a green
"synced" — leaving the sibling device that held the *correct* passphrase
unable to ever recover the originals.

## Root cause

`SecretsSyncer.decode()` returned `null` on **both**:
1. "no remote row exists" (safe — originate from local), and
2. "row exists but can't be decrypted/parsed" (wrong passphrase → AES-GCM
   tag mismatch, unparseable envelope, or non-JSON plaintext).

`reconcile()` collapsed both into "pick local" and then pushed
**unconditionally**, so case (2) clobbered a perfectly good remote blob.

## Fix

`decode()` now returns a sealed `DecodeResult`:
- `DecodeResult.Decoded` → flows through the existing LWW merge unchanged.
- `DecodeResult.Undecryptable` → `reconcile()` returns
  `SyncOutcome.Permanent(PASSPHRASE_MISMATCH_MESSAGE)` **before any push**.

"No remote row at all" stays the safe-to-originate path via the nullable
`remote?.let { … }`. The `Permanent` outcome stops the coordinator from
retrying and lets the Account screen prompt the user to re-enter the
passphrase from their other device. **All #979 LWW behavior is preserved
unchanged** — only present-but-opaque rows change behavior, and only to
stop destroying them.

## Tests (red→green verified)

Two regression tests added to `SecretsSyncerTest`:
- `wrong passphrase does NOT overwrite the remote blob and reports passphrase mismatch (regression #1027)` — asserts the remote blob is **byte-for-byte unchanged** (payload + updatedAt), the outcome is the passphrase-mismatch `Permanent`, a correct-passphrase device can still pull cleanly, and local prefs are untouched.
- `a structurally garbled remote envelope is non-clobbering (regression #1027)` — covers the `parseEnvelope` failure path on the same non-clobbering branch.

**Verified:** with the fix reverted (bug reproduced), exactly these 2 tests fail and the other 6 in the suite still pass; with the fix in place all 8 pass. `:core-sync:compileDebugKotlin` is green.

> Note: `:core-sync:testDebugUnitTest` has a **pre-existing, unrelated** compile error on `main` (duplicate `markFollowedCaughtUp` overrides in `BookmarksSyncerTest.kt` and `PlaybackPositionSyncerTest.kt`) — being fixed separately in #1029 / PR #1043. It does not touch this change's files and does not affect the Build APK gate. My regression tests were verified green by running against a locally-patched (uncommitted) test source set.

Closes #1027