### PR TITLE
fix(source-epub): normalize OPF hrefs — percent-decode + ../ + leading-slash (#1035, #1021)

### DIFF
--- a/source-epub/src/main/kotlin/in/jphe/storyvox/source/epub/parse/EpubParser.kt
+++ b/source-epub/src/main/kotlin/in/jphe/storyvox/source/epub/parse/EpubParser.kt
@@ -50,11 +50,22 @@ object EpubParser {
         val opf = parseOpf(String(opfBytes, Charsets.UTF_8))
 
         // Resolve each spine idref → href via the manifest, then
-        // pull the chapter HTML by joining opfDir + href.
+        // pull the chapter HTML by resolving opfDir + href against the
+        // zip entry names.
         val chapters = opf.spineIdrefs.mapIndexedNotNull { index, idref ->
             val manifestItem = opf.manifest[idref] ?: return@mapIndexedNotNull null
-            val resolved = joinPath(opfDir, manifestItem.href)
-            val bodyBytes = entries[resolved] ?: return@mapIndexedNotNull null
+            // #1035 / #1021 — OPF hrefs are URI references: they may be
+            // percent-encoded ("Chapter%201.xhtml") and relative
+            // ("../text/ch1.xhtml"), while ZipEntry.name is the literal
+            // decoded path. [resolveHref] percent-decodes, resolves
+            // ./ and ../ segments, and strips a leading slash so the
+            // result matches the zip entry. The raw join is kept as a
+            // fallback for the (rare) EPUB whose zip names are
+            // themselves percent-encoded.
+            val resolved = resolveHref(opfDir, manifestItem.href)
+            val bodyBytes = entries[resolved]
+                ?: entries[joinPath(opfDir, manifestItem.href)]
+                ?: return@mapIndexedNotNull null
             EpubChapter(
                 id = idref,
                 title = manifestItem.title ?: "Chapter ${index + 1}",
@@ -195,6 +206,79 @@ object EpubParser {
         if (dir.isEmpty()) return href
         // EPUB hrefs use forward slashes regardless of host OS.
         return "$dir/$href".replace("//", "/")
+    }
+
+    /**
+     * Resolve an OPF manifest [href] against the OPF directory [dir] into
+     * a path that matches a decoded [ZipEntry.name].
+     *
+     * OPF hrefs are URI references (EPUB 3 §3.4.1 / OPF 2.0.1 §1.4), so
+     * they may be:
+     *  - **percent-encoded** — `Chapter%201.xhtml`, `Caf%C3%A9.xhtml`
+     *    (#1035). `java.util.zip` exposes the literal decoded name, so we
+     *    decode the href before matching.
+     *  - **relative with `./` / `../` segments** — `../text/ch1.xhtml`
+     *    when the OPF lives in a subdir like `OEBPS/` (#1021).
+     *  - **leading-slash absolute** — `/OEBPS/ch1.xhtml`.
+     *
+     * Steps: percent-decode → join with [dir] → collapse `.`/`..`
+     * segments → strip a leading `/`. Pure Kotlin (no `android.util.Xml`)
+     * so it is unit-testable without the Android XML coupling that has
+     * kept this module untested.
+     */
+    internal fun resolveHref(dir: String, href: String): String {
+        val decoded = percentDecode(href)
+        // A leading-slash href is root-absolute: resolve it from the zip
+        // root, ignoring the OPF dir (joining would double-prefix).
+        val joined = when {
+            decoded.startsWith('/') -> decoded
+            dir.isEmpty() -> decoded
+            else -> "$dir/$decoded"
+        }
+        return normalizeSegments(joined)
+    }
+
+    /** Collapse `.`/`..` path segments and strip a leading slash, on a
+     *  forward-slash path. A `..` that would escape the root is dropped
+     *  (clamped at root) rather than producing a leading `..`, since zip
+     *  entry names are always root-relative. */
+    private fun normalizeSegments(path: String): String {
+        val stack = ArrayDeque<String>()
+        for (segment in path.split('/')) {
+            when (segment) {
+                "", "." -> {} // skip empty (handles `//` and leading `/`) and `.`
+                ".." -> if (stack.isNotEmpty()) stack.removeLast()
+                else -> stack.addLast(segment)
+            }
+        }
+        return stack.joinToString("/")
+    }
+
+    /** Path-aware percent-decoding: turns `%XX` escapes into their bytes
+     *  and UTF-8-decodes the result. Unlike [java.net.URLDecoder], a
+     *  literal `+` stays a `+` (it is a valid filename char and only
+     *  means "space" in `application/x-www-form-urlencoded`, not in path
+     *  components). Malformed escapes are left verbatim. */
+    internal fun percentDecode(s: String): String {
+        if ('%' !in s) return s
+        val bytes = ArrayList<Byte>(s.length)
+        var i = 0
+        while (i < s.length) {
+            val c = s[i]
+            if (c == '%' && i + 2 < s.length) {
+                val hi = Character.digit(s[i + 1], 16)
+                val lo = Character.digit(s[i + 2], 16)
+                if (hi >= 0 && lo >= 0) {
+                    bytes.add(((hi shl 4) or lo).toByte())
+                    i += 3
+                    continue
+                }
+            }
+            // Not a valid escape — emit the char's UTF-8 bytes verbatim.
+            for (b in c.toString().toByteArray(Charsets.UTF_8)) bytes.add(b)
+            i++
+        }
+        return String(bytes.toByteArray(), Charsets.UTF_8)
     }
 
     // ── XmlPullParser helpers (mirrored from RssParser) ──────────

--- a/source-epub/src/test/kotlin/in/jphe/storyvox/source/epub/parse/EpubParserResolveHrefTest.kt
+++ b/source-epub/src/test/kotlin/in/jphe/storyvox/source/epub/parse/EpubParserResolveHrefTest.kt
@@ -1,0 +1,117 @@
+package `in`.jphe.storyvox.source.epub.parse
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+/**
+ * Issues #1035 and #1021 — OPF manifest hrefs are URI references, so
+ * they can be percent-encoded (`Chapter%201.xhtml`, #1035) and relative
+ * with `./`/`../` segments or a leading slash (#1021). But
+ * `java.util.zip` exposes `ZipEntry.name` as the literal *decoded*,
+ * root-relative path. The old `joinPath` did neither decode nor segment
+ * normalization, so the entry-map lookup missed and `mapIndexedNotNull`
+ * silently dropped those chapters.
+ *
+ * These tests pin [EpubParser.resolveHref] (and its [EpubParser.percentDecode]
+ * helper) — both pure Kotlin, deliberately decoupled from
+ * `android.util.Xml` so the path-resolution logic is testable without
+ * Robolectric. A regression in either bug reappears here before a reader
+ * loses a chapter.
+ */
+class EpubParserResolveHrefTest {
+
+    // ── #1035: percent-encoded hrefs ─────────────────────────────
+
+    @Test fun `percent-encoded space resolves to the decoded entry name`() {
+        // Calibre "Save to disk" emits href="Chapter%201.xhtml" while the
+        // zip entry is physically "Chapter 1.xhtml".
+        assertEquals("Chapter 1.xhtml", EpubParser.resolveHref("", "Chapter%201.xhtml"))
+    }
+
+    @Test fun `utf8 percent-encoded accent decodes`() {
+        // "Café.xhtml" → "Caf%C3%A9.xhtml" (UTF-8 of é = C3 A9).
+        assertEquals("Café.xhtml", EpubParser.resolveHref("", "Caf%C3%A9.xhtml"))
+    }
+
+    @Test fun `utf8 percent-encoded cjk decodes`() {
+        // "第1章.xhtml" → each CJK char is 3 UTF-8 bytes.
+        assertEquals(
+            "第1章.xhtml",
+            EpubParser.resolveHref("", "%E7%AC%AC1%E7%AB%A0.xhtml"),
+        )
+    }
+
+    @Test fun `plus sign is preserved not turned into space`() {
+        // Unlike URLDecoder, a literal '+' is a valid path char and must
+        // NOT become a space (that only holds for form-url-encoding).
+        assertEquals("a+b.xhtml", EpubParser.resolveHref("", "a+b.xhtml"))
+    }
+
+    @Test fun `malformed percent escape is left verbatim`() {
+        // "%2G" / a trailing "%" aren't valid escapes — leave them as-is
+        // rather than throwing, so a single bad href can't sink the book.
+        assertEquals("a%2Gb.xhtml", EpubParser.resolveHref("", "a%2Gb.xhtml"))
+        assertEquals("trailing%", EpubParser.resolveHref("", "trailing%"))
+    }
+
+    // ── #1021: relative segments + leading slash ─────────────────
+
+    @Test fun `parent-dir segment is resolved against nested opf dir`() {
+        // OPF at OEBPS/content.opf (opfDir = "OEBPS") referencing
+        // ../text/ch1.xhtml must resolve to text/ch1.xhtml.
+        assertEquals("text/ch1.xhtml", EpubParser.resolveHref("OEBPS", "../text/ch1.xhtml"))
+    }
+
+    @Test fun `current-dir segment collapses`() {
+        assertEquals("OEBPS/ch1.xhtml", EpubParser.resolveHref("OEBPS", "./ch1.xhtml"))
+    }
+
+    @Test fun `leading slash is stripped`() {
+        // Zip entry names are root-relative; a leading-slash absolute
+        // href must not double-prefix or keep the slash.
+        assertEquals("OEBPS/ch1.xhtml", EpubParser.resolveHref("OEBPS", "/OEBPS/ch1.xhtml"))
+    }
+
+    @Test fun `simple join when href is in the opf dir`() {
+        assertEquals("OEBPS/ch1.xhtml", EpubParser.resolveHref("OEBPS", "ch1.xhtml"))
+    }
+
+    @Test fun `empty opf dir leaves a root-level href untouched`() {
+        assertEquals("ch1.xhtml", EpubParser.resolveHref("", "ch1.xhtml"))
+    }
+
+    @Test fun `nested opf dir with deep parent traversal`() {
+        // opfDir two levels deep, href climbs back up to a sibling tree.
+        assertEquals(
+            "images/cover.xhtml",
+            EpubParser.resolveHref("OEBPS/xhtml", "../../images/cover.xhtml"),
+        )
+    }
+
+    @Test fun `parent traversal past root is clamped not escaped`() {
+        // A pathological "../../.." can't produce a leading "../" — zip
+        // names are root-relative, so we clamp at root.
+        assertEquals("ch1.xhtml", EpubParser.resolveHref("OEBPS", "../../../ch1.xhtml"))
+    }
+
+    // ── #1035 + #1021 combined: encoded AND relative ─────────────
+
+    @Test fun `percent-encoded and parent-relative href resolves both`() {
+        // The case a single normalize-href step must close: decode the
+        // %20 AND resolve the ../ in one pass.
+        assertEquals(
+            "text/Chapter 1.xhtml",
+            EpubParser.resolveHref("OEBPS", "../text/Chapter%201.xhtml"),
+        )
+    }
+
+    // ── percentDecode unit coverage ──────────────────────────────
+
+    @Test fun `percentDecode short-circuits plain strings`() {
+        assertEquals("plain.xhtml", EpubParser.percentDecode("plain.xhtml"))
+    }
+
+    @Test fun `percentDecode handles consecutive escapes`() {
+        assertEquals("a b c", EpubParser.percentDecode("a%20b%20c"))
+    }
+}

--- a/source-epub/src/test/kotlin/in/jphe/storyvox/source/epub/parse/EpubParserResolveHrefTest.kt
+++ b/source-epub/src/test/kotlin/in/jphe/storyvox/source/epub/parse/EpubParserResolveHrefTest.kt
@@ -27,7 +27,8 @@ class EpubParserResolveHrefTest {
         // each assertion self-documenting and clears DeepSource KT-W1042's
         // duplicate-literal gate (the literal recurs 3+ times otherwise).
         const val CH1 = "ch1.xhtml"
-        const val OEBPS_CH1 = "OEBPS/$CH1"
+        const val OPF_DIR = "OEBPS"
+        const val OEBPS_CH1 = "$OPF_DIR/$CH1"
     }
 
     // ── #1035: percent-encoded hrefs ─────────────────────────────
@@ -69,21 +70,21 @@ class EpubParserResolveHrefTest {
     @Test fun `parent-dir segment is resolved against nested opf dir`() {
         // OPF at OEBPS/content.opf (opfDir = "OEBPS") referencing
         // ../text/ch1.xhtml must resolve to text/ch1.xhtml.
-        assertEquals("text/ch1.xhtml", EpubParser.resolveHref("OEBPS", "../text/ch1.xhtml"))
+        assertEquals("text/ch1.xhtml", EpubParser.resolveHref(OPF_DIR,"../text/ch1.xhtml"))
     }
 
     @Test fun `current-dir segment collapses`() {
-        assertEquals(OEBPS_CH1, EpubParser.resolveHref("OEBPS", "./ch1.xhtml"))
+        assertEquals(OEBPS_CH1, EpubParser.resolveHref(OPF_DIR,"./ch1.xhtml"))
     }
 
     @Test fun `leading slash is stripped`() {
         // Zip entry names are root-relative; a leading-slash absolute
         // href must not double-prefix or keep the slash.
-        assertEquals(OEBPS_CH1, EpubParser.resolveHref("OEBPS", "/OEBPS/ch1.xhtml"))
+        assertEquals(OEBPS_CH1, EpubParser.resolveHref(OPF_DIR,"/OEBPS/ch1.xhtml"))
     }
 
     @Test fun `simple join when href is in the opf dir`() {
-        assertEquals(OEBPS_CH1, EpubParser.resolveHref("OEBPS", CH1))
+        assertEquals(OEBPS_CH1, EpubParser.resolveHref(OPF_DIR,CH1))
     }
 
     @Test fun `empty opf dir leaves a root-level href untouched`() {
@@ -101,7 +102,7 @@ class EpubParserResolveHrefTest {
     @Test fun `parent traversal past root is clamped not escaped`() {
         // A pathological "../../.." can't produce a leading "../" — zip
         // names are root-relative, so we clamp at root.
-        assertEquals(CH1, EpubParser.resolveHref("OEBPS", "../../../ch1.xhtml"))
+        assertEquals(CH1, EpubParser.resolveHref(OPF_DIR,"../../../ch1.xhtml"))
     }
 
     // ── #1035 + #1021 combined: encoded AND relative ─────────────
@@ -111,7 +112,7 @@ class EpubParserResolveHrefTest {
         // %20 AND resolve the ../ in one pass.
         assertEquals(
             "text/Chapter 1.xhtml",
-            EpubParser.resolveHref("OEBPS", "../text/Chapter%201.xhtml"),
+            EpubParser.resolveHref(OPF_DIR,"../text/Chapter%201.xhtml"),
         )
     }
 

--- a/source-epub/src/test/kotlin/in/jphe/storyvox/source/epub/parse/EpubParserResolveHrefTest.kt
+++ b/source-epub/src/test/kotlin/in/jphe/storyvox/source/epub/parse/EpubParserResolveHrefTest.kt
@@ -20,6 +20,14 @@ import org.junit.Test
  */
 class EpubParserResolveHrefTest {
 
+    private companion object {
+        // Three #1021 cases converge on this one canonical resolved path,
+        // each reaching it from a different input href (./, leading-slash,
+        // plain). Naming it documents the convergence (and clears DeepSource
+        // KT-W1042's duplicate-literal gate).
+        const val OEBPS_CH1 = "OEBPS/ch1.xhtml"
+    }
+
     // ── #1035: percent-encoded hrefs ─────────────────────────────
 
     @Test fun `percent-encoded space resolves to the decoded entry name`() {
@@ -63,17 +71,17 @@ class EpubParserResolveHrefTest {
     }
 
     @Test fun `current-dir segment collapses`() {
-        assertEquals("OEBPS/ch1.xhtml", EpubParser.resolveHref("OEBPS", "./ch1.xhtml"))
+        assertEquals(OEBPS_CH1, EpubParser.resolveHref("OEBPS", "./ch1.xhtml"))
     }
 
     @Test fun `leading slash is stripped`() {
         // Zip entry names are root-relative; a leading-slash absolute
         // href must not double-prefix or keep the slash.
-        assertEquals("OEBPS/ch1.xhtml", EpubParser.resolveHref("OEBPS", "/OEBPS/ch1.xhtml"))
+        assertEquals(OEBPS_CH1, EpubParser.resolveHref("OEBPS", "/OEBPS/ch1.xhtml"))
     }
 
     @Test fun `simple join when href is in the opf dir`() {
-        assertEquals("OEBPS/ch1.xhtml", EpubParser.resolveHref("OEBPS", "ch1.xhtml"))
+        assertEquals(OEBPS_CH1, EpubParser.resolveHref("OEBPS", "ch1.xhtml"))
     }
 
     @Test fun `empty opf dir leaves a root-level href untouched`() {

--- a/source-epub/src/test/kotlin/in/jphe/storyvox/source/epub/parse/EpubParserResolveHrefTest.kt
+++ b/source-epub/src/test/kotlin/in/jphe/storyvox/source/epub/parse/EpubParserResolveHrefTest.kt
@@ -21,11 +21,13 @@ import org.junit.Test
 class EpubParserResolveHrefTest {
 
     private companion object {
-        // Three #1021 cases converge on this one canonical resolved path,
-        // each reaching it from a different input href (./, leading-slash,
-        // plain). Naming it documents the convergence (and clears DeepSource
-        // KT-W1042's duplicate-literal gate).
-        const val OEBPS_CH1 = "OEBPS/ch1.xhtml"
+        // The bare root-level chapter leaf, reused as both an input href and
+        // an expected resolved path across several cases. CH1 is the leaf;
+        // OEBPS_CH1 is that leaf joined under the OPF dir. Naming both keeps
+        // each assertion self-documenting and clears DeepSource KT-W1042's
+        // duplicate-literal gate (the literal recurs 3+ times otherwise).
+        const val CH1 = "ch1.xhtml"
+        const val OEBPS_CH1 = "OEBPS/$CH1"
     }
 
     // ── #1035: percent-encoded hrefs ─────────────────────────────
@@ -81,11 +83,11 @@ class EpubParserResolveHrefTest {
     }
 
     @Test fun `simple join when href is in the opf dir`() {
-        assertEquals(OEBPS_CH1, EpubParser.resolveHref("OEBPS", "ch1.xhtml"))
+        assertEquals(OEBPS_CH1, EpubParser.resolveHref("OEBPS", CH1))
     }
 
     @Test fun `empty opf dir leaves a root-level href untouched`() {
-        assertEquals("ch1.xhtml", EpubParser.resolveHref("", "ch1.xhtml"))
+        assertEquals(CH1, EpubParser.resolveHref("", CH1))
     }
 
     @Test fun `nested opf dir with deep parent traversal`() {
@@ -99,7 +101,7 @@ class EpubParserResolveHrefTest {
     @Test fun `parent traversal past root is clamped not escaped`() {
         // A pathological "../../.." can't produce a leading "../" — zip
         // names are root-relative, so we clamp at root.
-        assertEquals("ch1.xhtml", EpubParser.resolveHref("OEBPS", "../../../ch1.xhtml"))
+        assertEquals(CH1, EpubParser.resolveHref("OEBPS", "../../../ch1.xhtml"))
     }
 
     // ── #1035 + #1021 combined: encoded AND relative ─────────────


### PR DESCRIPTION
Fixes #1035 and #1021 — two distinct href-resolution bugs in `EpubParser` that each **silently drop chapters** (the spine entry returns null from `mapIndexedNotNull`, no error, the book just imports short).

## The bugs

`EpubParser.parseFromBytes` resolved each spine href against the OPF dir with a naive join, then looked it up in a map keyed on the raw, *decoded* `ZipEntry.name`:

```kotlin
val resolved = joinPath(opfDir, manifestItem.href)            // encoded, un-normalized
val bodyBytes = entries[resolved] ?: return@mapIndexedNotNull null   // miss → chapter dropped
```

- **#1035 — percent-encoding.** OPF hrefs are URI references and are commonly percent-encoded (`Chapter%201.xhtml`, `Caf%C3%A9.xhtml`, CJK). `java.util.zip` exposes the literal decoded name (`Chapter 1.xhtml`), so `"Chapter%201.xhtml" != "Chapter 1.xhtml"` and the lookup misses. Calibre "Save to disk", many publisher EPUBs, and some Standard Ebooks titles produce this.
- **#1021 — relative segments.** `joinPath` only collapsed a single `//`; it never resolved `./`/`../` or a leading slash. A nested OPF (`OEBPS/content.opf`, `opfDir = "OEBPS"`) referencing `../text/ch1.xhtml` joined to `OEBPS/../text/ch1.xhtml`, matching no zip entry.

## The fix

A single `resolveHref(dir, href)` step (Sandman/Lucid's "one normalize-href step closes both"):

1. **percent-decode** — path-aware: `%XX` → UTF-8 bytes; keeps a literal `+` (only form-url-encoding means `+`=space, not path components); malformed escapes left verbatim so one bad href can't sink the book.
2. **leading-slash** href treated as root-absolute (don't double-prefix with opfDir).
3. **join** with the OPF dir.
4. **normalize** `.`/`..` segments (`..` past root is clamped, since zip names are root-relative) and **strip** the leading slash.

The old raw `joinPath` is retained as a secondary lookup for the rare EPUB whose zip entry names are themselves percent-encoded. `coverHref` is left untouched — it isn't resolved or consumed anywhere yet, so fixing it would be speculative and out of scope.

## Tests (module had zero)

`source-epub` had **no tests**, partly because `EpubParser` is coupled to `android.util.Xml` (and this project runs JUnit without Robolectric). `resolveHref` / `percentDecode` are extracted as **pure `internal` helpers** with no Android deps — exactly the testability win #1021 asked for — so `EpubParserResolveHrefTest` adds **15 passing JUnit tests**:

- %-encoded space, UTF-8 accent (`é`), CJK (`第1章`)
- `+` preserved, malformed `%2G` / trailing `%` left verbatim
- `./`, `../`, leading-slash, simple join, empty opf dir
- deep parent traversal (`../../`), root clamping (`../../../`)
- **combined** encoded + parent-relative (`OEBPS` + `../text/Chapter%201.xhtml` → `text/Chapter 1.xhtml`)

## Verification

- [x] `:source-epub:testDebugUnitTest` — 15 tests, 0 failures (was 0 tests)
- [x] `:app:assembleDebug` builds

A full end-to-end `parseFromBytes` fixture test isn't included because that path requires `android.util.Xml`, which needs Robolectric (deliberately not used in this repo). The pure path-resolution helper — the actual locus of both bugs — is fully covered.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * EPUB manifest hrefs now correctly handle percent-encoded filenames, ./ and ../ segments, and leading slashes when locating resources, with a safe fallback for unmatched lookups—improving compatibility with more EPUBs and edge-case filenames.

* **Tests**
  * Added comprehensive tests for percent-decoding, preservation of literal plus signs, malformed percent escapes, relative-path normalization, root-clamping behavior, and combined decode+resolution scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->