### PR TITLE
fix(source-notion): recurse into nested blocks — toggles/columns/sub-lists narrate (#1036)

### DIFF
--- a/source-notion/src/main/kotlin/in/jphe/storyvox/source/notion/NotionHelpers.kt
+++ b/source-notion/src/main/kotlin/in/jphe/storyvox/source/notion/NotionHelpers.kt
@@ -278,11 +278,11 @@ internal fun NotionBlock.toHtml(): String = when (type) {
     }
     "bulleted_list_item" -> {
         val text = htmlEscape(extractRichText(bulletedListItem) ?: "")
-        if (text.isBlank()) "" else "<li>$text</li>"
+        if (text.isBlank()) "" else nestListItem(text)
     }
     "numbered_list_item" -> {
         val text = htmlEscape(extractRichText(numberedListItem) ?: "")
-        if (text.isBlank()) "" else "<li>$text</li>"
+        if (text.isBlank()) "" else nestListItem(text)
     }
     "quote" -> {
         val text = htmlEscape(extractRichText(quote) ?: "")
@@ -305,7 +305,25 @@ internal fun NotionBlock.toHtml(): String = when (type) {
         val text = htmlEscape(extractRichText(toDo) ?: "")
         if (text.isBlank()) "" else "<p>$text</p>"
     }
+    // Issue #1036 — layout containers carry no text of their own; their
+    // children were spliced into the flat list by flattenNested and
+    // render on their own. Emitting nothing for the container keeps the
+    // reader free of empty wrappers.
+    "column_list", "column", "synced_block" -> ""
     else -> ""
+}
+
+/**
+ * Issue #1036 — wrap a nested list item so the reader shows its nesting.
+ * Top-level items (depth 0) render as a bare `<li>` exactly as before;
+ * each level of nesting wraps in one more `<ul>` so a sub-bullet reads
+ * as indented under its parent. The TTS path ignores tags, so this is
+ * purely visual — narration completeness comes from the block being in
+ * the flat list at all, which it now is.
+ */
+private fun NotionBlock.nestListItem(escapedText: String): String {
+    val li = "<li>$escapedText</li>"
+    return if (depth <= 0) li else "<ul>".repeat(depth) + li + "</ul>".repeat(depth)
 }
 
 /** Plain-text projection of a block for TTS. Strips all markup; only
@@ -322,6 +340,9 @@ internal fun NotionBlock.toPlainText(): String = when (type) {
     "divider" -> ""
     "toggle" -> extractRichText(toggle) ?: ""
     "to_do" -> extractRichText(toDo) ?: ""
+    // Issue #1036 — transparent containers narrate nothing; their child
+    // blocks carry the text and narrate on their own.
+    "column_list", "column", "synced_block" -> ""
     else -> ""
 }
 

--- a/source-notion/src/main/kotlin/in/jphe/storyvox/source/notion/net/NotionApi.kt
+++ b/source-notion/src/main/kotlin/in/jphe/storyvox/source/notion/net/NotionApi.kt
@@ -96,25 +96,66 @@ internal class NotionApi @Inject constructor(
     }
 
     /**
-     * Fetch a page's block children, transparently following
-     * `has_more / next_cursor` pagination so the caller gets the full
-     * block list as one flat array. Notion caps `page_size` at 100;
-     * pages with thousands of blocks (long-form articles) compose into
-     * 10-20 round-trips. Acceptable for chapter rendering — the alternative
-     * (streaming chapter assembly) adds complexity Browse doesn't need.
+     * Fetch a page's blocks as one flat array in document order, fully
+     * resolving nested blocks (issue #1036). Notion's API is a *tree*:
+     * each block with `has_children: true` (toggles, columns, synced
+     * blocks, nested lists) hides its body behind a separate
+     * `GET /v1/blocks/{block_id}/children` call. We fetch the top level,
+     * then [flattenNested] descends depth-first, splicing each block's
+     * children immediately after it and stamping their [NotionBlock.depth]
+     * so the renderer can indent nested lists.
+     *
+     * Within a level, `has_more / next_cursor` pagination is followed
+     * transparently (Notion caps `page_size` at 100). Two guards keep the
+     * request budget sane on pathological pages: a depth cap
+     * ([MAX_NEST_DEPTH]) and a total child-fetch ceiling
+     * ([MAX_CHILD_REQUESTS]) — deeply/widely nested pages otherwise
+     * multiply round-trips (one extra call per `has_children` block).
+     *
+     * A child fetch that fails is treated as "no children" rather than
+     * failing the whole page: a transient error on one toggle shouldn't
+     * blank an otherwise-readable article. Only a failure fetching the
+     * top level aborts.
      */
     suspend fun pageBlocks(pageId: String): FictionResult<List<NotionBlock>> {
         val state = config.current()
         requireConfigured<List<NotionBlock>>(state)?.let { return it }
+        val top = when (val r = fetchChildren(pageId, state)) {
+            is FictionResult.Success -> r.value
+            is FictionResult.Failure -> return r
+        }
+        val flat = flattenNested(
+            roots = top,
+            maxDepth = MAX_NEST_DEPTH,
+            maxRequests = MAX_CHILD_REQUESTS,
+            fetchChildren = { childId ->
+                when (val r = fetchChildren(childId, state)) {
+                    is FictionResult.Success -> r.value
+                    // Swallow a single child-level failure: descend no
+                    // further under this block, keep the rest of the page.
+                    is FictionResult.Failure -> emptyList()
+                }
+            },
+        )
+        return FictionResult.Success(flat)
+    }
+
+    /**
+     * Fetch one block's direct children, following sibling pagination
+     * (`has_more / next_cursor`) so the returned list is the complete set
+     * of immediate children. The `repeat(50)` cap guards against a
+     * paginated cycle (50 × 100 = 5,000 siblings — past anything sane).
+     */
+    private suspend fun fetchChildren(
+        blockId: String,
+        state: NotionConfigState,
+    ): FictionResult<List<NotionBlock>> {
         val accumulated = mutableListOf<NotionBlock>()
         var cursor: String? = null
-        // Safety cap — if Notion ever returns a paginated cycle we don't
-        // want an infinite loop. 50 pages × 100 blocks = 5,000 blocks per
-        // chapter; well past anything a sane Notion page contains.
         repeat(50) {
             val url = buildString {
                 append(state.baseUrl)
-                append("/v1/blocks/").append(pageId).append("/children")
+                append("/v1/blocks/").append(blockId).append("/children")
                 append("?page_size=100")
                 if (cursor != null) append("&start_cursor=").append(cursor)
             }
@@ -250,6 +291,66 @@ internal class NotionApi @Inject constructor(
         }
         return null
     }
+
+    private companion object {
+        /** Issue #1036 — how deep to follow `has_children`. 5 covers
+         *  real Notion content (toggle → column → list → sub-list); past
+         *  that we stop descending to bound the request fan-out. */
+        const val MAX_NEST_DEPTH = 5
+
+        /** Total `blocks/{id}/children` calls for nested blocks, on top
+         *  of the top-level fetch. Each `has_children` block costs one
+         *  call; this ceiling caps the rate-limit exposure on a
+         *  pathologically nested page. 200 covers heavily-structured
+         *  pages without risking a request storm. */
+        const val MAX_CHILD_REQUESTS = 200
+    }
+}
+
+/**
+ * Issue #1036 — flatten a Notion block *tree* into the flat,
+ * document-order list the rest of the pipeline (`splitOnHeading1`,
+ * chapter assembly, `toHtml`/`toPlainText`) consumes.
+ *
+ * Notion only returns one level per `GET /v1/blocks/{id}/children`;
+ * a block with `has_children: true` hides its body behind another
+ * call. This walks [roots] depth-first: each block is emitted, then —
+ * if it declares children and we're under [maxDepth] / [maxRequests] —
+ * its children (via [fetchChildren]) are spliced in immediately after,
+ * stamped with `depth + 1`, and recursed into. The result preserves
+ * reading order (parent, then its subtree, then the next sibling).
+ *
+ * Pulled out as a top-level function (not a method) so the recursion
+ * logic is unit-testable with an in-memory [fetchChildren] and no HTTP.
+ *
+ * @param maxDepth deepest level to descend (roots are depth 0).
+ * @param maxRequests ceiling on child-fetch calls; once hit, remaining
+ *  `has_children` blocks are emitted without their children rather than
+ *  exceeding the budget.
+ */
+internal suspend fun flattenNested(
+    roots: List<NotionBlock>,
+    maxDepth: Int = 5,
+    maxRequests: Int = 200,
+    fetchChildren: suspend (blockId: String) -> List<NotionBlock>,
+): List<NotionBlock> {
+    val out = mutableListOf<NotionBlock>()
+    var requests = 0
+
+    suspend fun walk(blocks: List<NotionBlock>, depth: Int) {
+        for (block in blocks) {
+            out.add(block.copy(depth = depth))
+            if (!block.hasChildren) continue
+            if (depth >= maxDepth) continue
+            if (requests >= maxRequests) continue
+            requests++
+            val children = fetchChildren(block.id)
+            if (children.isNotEmpty()) walk(children, depth + 1)
+        }
+    }
+
+    walk(roots, 0)
+    return out.toList()
 }
 
 /**

--- a/source-notion/src/main/kotlin/in/jphe/storyvox/source/notion/net/NotionModels.kt
+++ b/source-notion/src/main/kotlin/in/jphe/storyvox/source/notion/net/NotionModels.kt
@@ -2,6 +2,7 @@ package `in`.jphe.storyvox.source.notion.net
 
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
+import kotlinx.serialization.Transient
 import kotlinx.serialization.json.JsonElement
 
 /**
@@ -116,6 +117,13 @@ internal data class NotionBlock(
     val divider: JsonElement? = null,
     val toggle: JsonElement? = null,
     @SerialName("to_do") val toDo: JsonElement? = null,
+    /** Issue #1036 — nesting level in the flattened document order.
+     *  Top-level blocks are depth 0; children spliced in by
+     *  [flattenNested] carry their parent's depth + 1. Not part of the
+     *  wire shape (Notion's API is a tree, not a flat depth-tagged list),
+     *  so it's [Transient] — set during fetch-time flattening and read by
+     *  the renderer to indent nested list items. */
+    @Transient val depth: Int = 0,
 )
 
 /**

--- a/source-notion/src/test/kotlin/in/jphe/storyvox/source/notion/NotionNestedBlocksTest.kt
+++ b/source-notion/src/test/kotlin/in/jphe/storyvox/source/notion/NotionNestedBlocksTest.kt
@@ -1,0 +1,172 @@
+package `in`.jphe.storyvox.source.notion
+
+import `in`.jphe.storyvox.source.notion.net.NotionBlock
+import `in`.jphe.storyvox.source.notion.net.flattenNested
+import kotlinx.coroutines.test.runTest
+import kotlinx.serialization.json.Json
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * Issue #1036 — nested Notion blocks (toggles, columns, synced blocks,
+ * nested lists) were silently dropped because `pageBlocks` never
+ * recursed on `has_children` and the renderer dropped container types.
+ *
+ * These tests exercise the two pure pieces of the fix without HTTP:
+ *  - [flattenNested]: depth-first flatten of a block tree into the flat
+ *    document-order list the rest of the pipeline consumes, stamping
+ *    each block's nesting [NotionBlock.depth], honouring a depth cap and
+ *    a total-request budget.
+ *  - rendering of container blocks (column_list/column/synced_block) and
+ *    depth-indented list items in [NotionBlock.toHtml]/[toPlainText].
+ *
+ * The fetch loop in `NotionApi.pageBlocks` wires a real
+ * `GET /v1/blocks/{id}/children` fetcher into [flattenNested]; here we
+ * pass an in-memory fetcher so the recursion logic is testable in pure
+ * JVM with no network.
+ */
+class NotionNestedBlocksTest {
+
+    private val json = Json { ignoreUnknownKeys = true; isLenient = true }
+
+    // ─── flattenNested: depth-first splice ────────────────────────────
+
+    @Test
+    fun `flattenNested splices children depth-first right after their parent`() = runTest {
+        // toggle "Parent" -> [child "A", child "B"], then sibling "After".
+        val parent = container("toggle", "p1", hasChildren = true)
+        val after = paragraph("After", "p2")
+        val children = mapOf(
+            "p1" to listOf(paragraph("A", "a1"), paragraph("B", "b1")),
+        )
+        val flat = flattenNested(
+            roots = listOf(parent, after),
+            fetchChildren = { id -> children[id].orEmpty() },
+        )
+        // Document order: parent, A, B, After.
+        assertEquals(listOf("p1", "a1", "b1", "p2"), flat.map { it.id })
+        // Parent + sibling at depth 0; spliced children at depth 1.
+        assertEquals(listOf(0, 1, 1, 0), flat.map { it.depth })
+    }
+
+    @Test
+    fun `flattenNested recurses through multiple levels`() = runTest {
+        // L0 has child L1, which has child L2.
+        val l0 = container("toggle", "l0", hasChildren = true)
+        val children = mapOf(
+            "l0" to listOf(container("toggle", "l1", hasChildren = true)),
+            "l1" to listOf(paragraph("deep", "l2")),
+        )
+        val flat = flattenNested(listOf(l0)) { id -> children[id].orEmpty() }
+        assertEquals(listOf("l0", "l1", "l2"), flat.map { it.id })
+        assertEquals(listOf(0, 1, 2), flat.map { it.depth })
+    }
+
+    @Test
+    fun `flattenNested does not fetch children for blocks without has_children`() = runTest {
+        val leaf = paragraph("leaf", "x")
+        var fetches = 0
+        val flat = flattenNested(listOf(leaf)) { fetches++; emptyList() }
+        assertEquals(listOf("x"), flat.map { it.id })
+        assertEquals(0, fetches) // hasChildren=false → never asks the API
+    }
+
+    @Test
+    fun `flattenNested honours the depth cap`() = runTest {
+        // A chain deeper than the cap: each level claims a child.
+        val root = container("toggle", "d0", hasChildren = true)
+        val children = HashMap<String, List<NotionBlock>>()
+        for (i in 0 until 10) {
+            children["d$i"] = listOf(container("toggle", "d${i + 1}", hasChildren = true))
+        }
+        val flat = flattenNested(
+            roots = listOf(root),
+            maxDepth = 3,
+            fetchChildren = { id -> children[id].orEmpty() },
+        )
+        // Cap at 3 means we descend to depth 3 and stop (don't fetch d4's kids).
+        val maxSeen = flat.maxOf { it.depth }
+        assertTrue("expected to stop at depth <= 3, saw $maxSeen", maxSeen <= 3)
+    }
+
+    @Test
+    fun `flattenNested honours the total-request budget`() = runTest {
+        // Wide tree: 1 root with 100 has_children siblings; tiny budget.
+        val roots = (0 until 100).map { container("toggle", "n$it", hasChildren = true) }
+        val children = roots.associate { it.id to listOf(paragraph("k", "k${it.id}")) }
+        var fetches = 0
+        flattenNested(
+            roots = roots,
+            maxRequests = 5,
+            fetchChildren = { id -> fetches++; children[id].orEmpty() },
+        )
+        assertTrue("expected <= 5 child fetches, made $fetches", fetches <= 5)
+    }
+
+    // ─── rendering: containers + nested list indentation ──────────────
+
+    @Test
+    fun `column_list and column render as transparent containers`() {
+        // They carry no text of their own — children render on their own.
+        assertEquals("", NotionBlock(id = "cl", type = "column_list").toHtml())
+        assertEquals("", NotionBlock(id = "c", type = "column").toHtml())
+        assertEquals("", NotionBlock(id = "sb", type = "synced_block").toHtml())
+        assertEquals("", NotionBlock(id = "cl", type = "column_list").toPlainText())
+        assertEquals("", NotionBlock(id = "c", type = "column").toPlainText())
+        assertEquals("", NotionBlock(id = "sb", type = "synced_block").toPlainText())
+    }
+
+    @Test
+    fun `nested bulleted list item indents its html by depth`() {
+        val nested = bullet("Sub-point", "b1").copy(depth = 1)
+        // Depth-1 list item gets wrapped so the reader shows nesting.
+        assertEquals(
+            "<ul><li>Sub-point</li></ul>",
+            nested.toHtml(),
+        )
+        // Plain text (TTS) is unaffected by indentation — text is what matters.
+        assertEquals("Sub-point", nested.toPlainText())
+    }
+
+    @Test
+    fun `top-level list item is not extra-indented`() {
+        val top = bullet("Point", "b0") // depth 0
+        assertEquals("<li>Point</li>", top.toHtml())
+    }
+
+    @Test
+    fun `toggle body children are present in the flat list and narrate`() = runTest {
+        // Real-world repro: a toggle whose body is the only content.
+        val toggle = container("toggle", "t0", hasChildren = true).let {
+            it.copy(toggle = json.parseToJsonElement("""{"rich_text":[{"plain_text":"Summary"}]}"""))
+        }
+        val children = mapOf("t0" to listOf(paragraph("Hidden body text.", "p1")))
+        val flat = flattenNested(listOf(toggle)) { id -> children[id].orEmpty() }
+        val narration = flat.joinToString(" ") { it.toPlainText() }.trim()
+        assertTrue(
+            "toggle body must appear in narration, got: '$narration'",
+            narration.contains("Hidden body text."),
+        )
+    }
+
+    // ─── helpers ──────────────────────────────────────────────────────
+
+    private fun paragraph(text: String, id: String) = NotionBlock(
+        id = id,
+        type = "paragraph",
+        paragraph = json.parseToJsonElement("""{"rich_text":[{"plain_text":"$text"}]}"""),
+    )
+
+    private fun bullet(text: String, id: String) = NotionBlock(
+        id = id,
+        type = "bulleted_list_item",
+        bulletedListItem = json.parseToJsonElement("""{"rich_text":[{"plain_text":"$text"}]}"""),
+    )
+
+    private fun container(type: String, id: String, hasChildren: Boolean) = NotionBlock(
+        id = id,
+        type = type,
+        hasChildren = hasChildren,
+    )
+}


### PR DESCRIPTION
## Problem

Notion pages whose content lives inside **nested blocks** — toggle lists, column layouts (`column_list`/`column`), synced blocks, or nested bulleted/numbered lists — rendered and narrated only their **top-level** text. Everything under a block with `has_children: true` was silently dropped (no error, just missing audio + reader text). Toggles and columns are extremely common in real Notion pages, so this hit typical content.

**Root cause** (per #1036): `NotionBlock.hasChildren` was parsed but never read, and `NotionApi.pageBlocks` fetched only the first level of children — never issuing `GET /v1/blocks/{childId}/children`. The renderer mirrored the gap: `toHtml`/`toPlainText` dropped toggle bodies and had no `column_list`/`column`/`synced_block` case.

## Fix

**Fetch — `NotionApi`**
- Split sibling pagination out as `fetchChildren(blockId)`, then add `flattenNested()`: a depth-first walk that, for every `has_children` block, fetches its children and splices them into the flat document-order list immediately after the parent, stamping each with its nesting `depth`.
- Bounded fan-out: `MAX_NEST_DEPTH = 5` + `MAX_CHILD_REQUESTS = 200` (each `has_children` block = one extra round-trip; this caps the rate-limit exposure on pathologically nested pages).
- A child-level fetch failure is swallowed (treated as no children) so a transient error on one toggle can't blank an otherwise-readable page; only a top-level failure aborts.

**Model — `NotionModels`**
- `NotionBlock` gains a `@Transient depth` (off the wire — Notion's API is a tree, not a depth-tagged flat list); set during flattening, read by the renderer.

**Render — `NotionHelpers`**
- `column_list` / `column` / `synced_block` handled as transparent containers (no own text; children render on their own) in both `toHtml` and `toPlainText`.
- Nested list items indented by `depth` in `toHtml` so the reader shows nesting; plain-text (TTS) is unaffected — narration completeness comes from the block being in the flat list, which it now is.

## Tests

New `NotionNestedBlocksTest` (9 tests): depth-first splice + document order, multi-level recursion, no-fetch on leaf blocks, depth cap, request budget, container rendering, depth-indented list items, and the toggle-body-narrates repro. `flattenNested` is a top-level fn so the recursion is testable with an in-memory fetcher (no HTTP).

`./gradlew :source-notion:testDebugUnitTest` → **80 tests, 0 failures** (9 new + 71 existing, incl. the unofficial-API `AnonymousNotionDelegate` path, unaffected).

Closes #1036

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Nested lists now render with proper indentation based on nesting level.
  * Container elements are now transparent in rendered output, improving readability.

* **Bug Fixes**
  * Improved robustness when handling complex nested content from Notion pages.
  * Added safety limits to prevent performance issues with deeply nested structures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->