### PR TITLE
fix(wear): surface phone-disconnected state instead of dropping transport taps (#1030)

### DIFF
--- a/wear/build.gradle.kts
+++ b/wear/build.gradle.kts
@@ -107,4 +107,6 @@ dependencies {
     implementation(libs.androidx.lifecycle.runtime.compose)
 
     coreLibraryDesugaring(libs.android.desugar.jdk.libs)
+
+    testImplementation(libs.junit)
 }

--- a/wear/src/main/kotlin/in/jphe/storyvox/wear/components/TransportRow.kt
+++ b/wear/src/main/kotlin/in/jphe/storyvox/wear/components/TransportRow.kt
@@ -31,6 +31,11 @@ import `in`.jphe.storyvox.wear.theme.WarmDarkSurface
  *
  * Skip buttons map to `CMD_SKIP_BACK` / `CMD_SKIP_FWD` (30s seek) rather than
  * chapter nav — same defaults as the phone notification controls.
+ *
+ * When [enabled] is `false` (no phone node reachable, #1030) the buttons are
+ * greyed and non-clickable — Wear's [Button] applies its disabled colours
+ * automatically and TalkBack announces them as disabled — so a tap can't
+ * silently no-op the way it did before.
  */
 @Composable
 fun TransportRow(
@@ -39,6 +44,7 @@ fun TransportRow(
     onSkipBack: () -> Unit,
     onSkipForward: () -> Unit,
     modifier: Modifier = Modifier,
+    enabled: Boolean = true,
 ) {
     Row(
         modifier = modifier.fillMaxWidth(),
@@ -50,18 +56,21 @@ fun TransportRow(
             contentDescription = "Skip back 30 seconds",
             onClick = onSkipBack,
             isPrimary = false,
+            enabled = enabled,
         )
         TransportButton(
             icon = if (isPlaying) Icons.Filled.Pause else Icons.Filled.PlayArrow,
             contentDescription = if (isPlaying) "Pause" else "Play",
             onClick = onPlayPause,
             isPrimary = true,
+            enabled = enabled,
         )
         TransportButton(
             icon = Icons.Filled.SkipNext,
             contentDescription = "Skip forward 30 seconds",
             onClick = onSkipForward,
             isPrimary = false,
+            enabled = enabled,
         )
     }
 }
@@ -72,11 +81,13 @@ private fun TransportButton(
     contentDescription: String,
     onClick: () -> Unit,
     isPrimary: Boolean,
+    enabled: Boolean,
 ) {
     val size = if (isPrimary) 44.dp else 36.dp
     val iconSize = if (isPrimary) 24.dp else 20.dp
     Button(
         onClick = onClick,
+        enabled = enabled,
         modifier = Modifier.size(size),
         colors = if (isPrimary) {
             ButtonDefaults.primaryButtonColors(

--- a/wear/src/main/kotlin/in/jphe/storyvox/wear/playback/NodeSelection.kt
+++ b/wear/src/main/kotlin/in/jphe/storyvox/wear/playback/NodeSelection.kt
@@ -1,0 +1,43 @@
+package `in`.jphe.storyvox.wear.playback
+
+/**
+ * Minimal, GMS-free projection of a connected Wear node.
+ *
+ * [WearPlaybackBridge] maps `com.google.android.gms.wearable.Node` into this
+ * shape so the connectivity / targeting decision in [NodeSelection] can be unit
+ * tested without Robolectric or Play Services on the classpath.
+ */
+data class PhoneNode(val id: String, val isNearby: Boolean)
+
+/**
+ * The pure decision that backs both the watch's connectivity state and which
+ * node a transport command is sent to.
+ *
+ * "Connected" means at least one node is reachable. The preferred target is a
+ * *nearby* node (direct Bluetooth/Wi-Fi) when one exists, otherwise the first
+ * reachable node (cloud relay) — never dropping a command just because no node
+ * is nearby, while still reporting honestly when nothing is reachable at all.
+ */
+object NodeSelection {
+
+    fun isConnected(nodes: List<PhoneNode>): Boolean = nodes.isNotEmpty()
+
+    fun preferredTarget(nodes: List<PhoneNode>): PhoneNode? =
+        nodes.firstOrNull { it.isNearby } ?: nodes.firstOrNull()
+}
+
+/**
+ * Outcome of a transport command send. The UI consults this (and the
+ * connectivity [kotlinx.coroutines.flow.StateFlow]) to decide whether to show a
+ * "Phone not connected" hint instead of pretending the tap worked.
+ */
+enum class SendResult {
+    /** Delivered to a reachable node. */
+    Sent,
+
+    /** No node is reachable — the phone is out of range or Bluetooth is off. */
+    Disconnected,
+
+    /** A node was reachable but the send threw (e.g. it dropped mid-send). */
+    Failed,
+}

--- a/wear/src/main/kotlin/in/jphe/storyvox/wear/playback/WearPlaybackBridge.kt
+++ b/wear/src/main/kotlin/in/jphe/storyvox/wear/playback/WearPlaybackBridge.kt
@@ -24,7 +24,11 @@ import kotlinx.serialization.json.Json
  *
  * - Subscribes to `/playback/state` DataItem updates from the phone, decodes the
  *   JSON-encoded [PlaybackState], and exposes it as a [StateFlow].
- * - Sends transport commands to the phone via [com.google.android.gms.wearable.MessageClient].
+ * - Tracks whether a phone node is reachable via [connected], refreshed on
+ *   [start]/[refreshConnectivity] and updated reactively from every [send].
+ * - Sends transport commands to the phone via [com.google.android.gms.wearable.MessageClient],
+ *   returning a [SendResult] so the caller can surface a "Phone not connected"
+ *   hint instead of silently dropping the tap (#1030).
  *
  * Lifecycle bound to [in.jphe.storyvox.wear.WearApp] / its NowPlaying composable.
  */
@@ -39,6 +43,14 @@ class WearPlaybackBridge(private val context: Context) : DataClient.OnDataChange
     private val _state = MutableStateFlow(PlaybackState())
     val state: StateFlow<PlaybackState> = _state.asStateFlow()
 
+    /**
+     * Whether a phone node is currently reachable. Starts `true` (optimistic, so
+     * controls aren't greyed for the split second before the first node query
+     * resolves) and is corrected by [refreshConnectivity] and every [send].
+     */
+    private val _connected = MutableStateFlow(true)
+    val connected: StateFlow<Boolean> = _connected.asStateFlow()
+
     fun start() {
         dataClient.addListener(this, android.net.Uri.parse("wear://*/playback"), DataClient.FILTER_PREFIX)
         // Hydrate immediately from the latest cached DataItem
@@ -49,11 +61,25 @@ class WearPlaybackBridge(private val context: Context) : DataClient.OnDataChange
                 }
             }
         }
+        refreshConnectivity()
     }
 
     fun stop() {
         dataClient.removeListener(this)
         scope.cancel()
+    }
+
+    /**
+     * Re-query reachable nodes and update [connected]. Call on resume so the UI
+     * reflects a phone that came back into range while the watch screen was off.
+     */
+    fun refreshConnectivity() {
+        scope.launch {
+            val nodes = runCatching { connectedPhoneNodes() }.getOrNull()
+            // A query failure (GMS unavailable) is left as-is rather than forced
+            // to disconnected — the next send is the authoritative signal.
+            if (nodes != null) _connected.value = NodeSelection.isConnected(nodes)
+        }
     }
 
     override fun onDataChanged(events: DataEventBuffer) {
@@ -68,11 +94,29 @@ class WearPlaybackBridge(private val context: Context) : DataClient.OnDataChange
         runCatching { _state.value = json.decodeFromString<PlaybackState>(raw) }
     }
 
-    suspend fun send(path: String) {
-        runCatching {
-            val nodes = nodeClient.connectedNodes.await()
-            val phone = nodes.firstOrNull { it.isNearby } ?: nodes.firstOrNull() ?: return
-            messageClient.sendMessage(phone.id, path, null).await()
+    /**
+     * Send a transport command, returning the outcome and updating [connected]
+     * from what we learned. A successful send is the strongest evidence a node
+     * is reachable; a disconnected/failed send flips [connected] to `false` so
+     * the UI greys the controls immediately.
+     */
+    suspend fun send(path: String): SendResult {
+        val nodes = runCatching { connectedPhoneNodes() }.getOrNull()
+        val target = nodes?.let { NodeSelection.preferredTarget(it) }
+        if (target == null) {
+            _connected.value = false
+            return SendResult.Disconnected
+        }
+        return runCatching {
+            messageClient.sendMessage(target.id, path, null).await()
+            _connected.value = true
+            SendResult.Sent
+        }.getOrElse {
+            _connected.value = false
+            SendResult.Failed
         }
     }
+
+    private suspend fun connectedPhoneNodes(): List<PhoneNode> =
+        nodeClient.connectedNodes.await().map { PhoneNode(id = it.id, isNearby = it.isNearby) }
 }

--- a/wear/src/main/kotlin/in/jphe/storyvox/wear/screens/NowPlayingScreen.kt
+++ b/wear/src/main/kotlin/in/jphe/storyvox/wear/screens/NowPlayingScreen.kt
@@ -20,6 +20,7 @@ import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.tooling.preview.Devices
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
+import androidx.lifecycle.compose.LifecycleResumeEffect
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.wear.compose.material.MaterialTheme
 import androidx.wear.compose.material.Scaffold
@@ -67,10 +68,20 @@ import kotlinx.coroutines.launch
 @Composable
 fun NowPlayingScreen(bridge: WearPlaybackBridge) {
     val state by bridge.state.collectAsStateWithLifecycle()
+    val connected by bridge.connected.collectAsStateWithLifecycle()
     val scope = rememberCoroutineScope()
+
+    // Re-check reachability whenever the watch face comes back to the
+    // foreground, so a phone that returned to range while the screen was off
+    // restores the transport controls without a tap.
+    LifecycleResumeEffect(bridge) {
+        bridge.refreshConnectivity()
+        onPauseOrDispose {}
+    }
 
     NowPlayingContent(
         state = state,
+        connected = connected,
         onPlayPause = {
             val cmd = if (state.isPlaying) PhoneWearBridge.CMD_PAUSE else PhoneWearBridge.CMD_PLAY
             scope.launch { bridge.send(cmd) }
@@ -87,6 +98,7 @@ fun NowPlayingScreen(bridge: WearPlaybackBridge) {
 @Composable
 internal fun NowPlayingContent(
     state: PlaybackState,
+    connected: Boolean,
     onPlayPause: () -> Unit,
     onSkipBack: () -> Unit,
     onSkipForward: () -> Unit,
@@ -109,6 +121,7 @@ internal fun NowPlayingContent(
                 RoundNowPlaying(
                     state = state,
                     progress = progress,
+                    connected = connected,
                     onPlayPause = onPlayPause,
                     onSkipBack = onSkipBack,
                     onSkipForward = onSkipForward,
@@ -117,6 +130,7 @@ internal fun NowPlayingContent(
                 SquareNowPlaying(
                     state = state,
                     progress = progress,
+                    connected = connected,
                     onPlayPause = onPlayPause,
                     onSkipBack = onSkipBack,
                     onSkipForward = onSkipForward,
@@ -130,6 +144,7 @@ internal fun NowPlayingContent(
 private fun RoundNowPlaying(
     state: PlaybackState,
     progress: Float,
+    connected: Boolean,
     onPlayPause: () -> Unit,
     onSkipBack: () -> Unit,
     onSkipForward: () -> Unit,
@@ -158,10 +173,12 @@ private fun RoundNowPlaying(
         ChapterMeta(state = state)
         TransportRow(
             isPlaying = state.isPlaying,
+            enabled = connected,
             onPlayPause = onPlayPause,
             onSkipBack = onSkipBack,
             onSkipForward = onSkipForward,
         )
+        DisconnectedHint(connected = connected)
     }
 }
 
@@ -169,6 +186,7 @@ private fun RoundNowPlaying(
 private fun SquareNowPlaying(
     state: PlaybackState,
     progress: Float,
+    connected: Boolean,
     onPlayPause: () -> Unit,
     onSkipBack: () -> Unit,
     onSkipForward: () -> Unit,
@@ -190,10 +208,12 @@ private fun SquareNowPlaying(
         LinearScrubber(progress = progress, modifier = Modifier.fillMaxWidth())
         TransportRow(
             isPlaying = state.isPlaying,
+            enabled = connected,
             onPlayPause = onPlayPause,
             onSkipBack = onSkipBack,
             onSkipForward = onSkipForward,
         )
+        DisconnectedHint(connected = connected)
     }
 }
 
@@ -225,6 +245,25 @@ private fun ChapterMeta(state: PlaybackState) {
     }
 }
 
+/**
+ * Brief "Phone not connected" note shown beneath the (greyed) transport row
+ * when no phone node is reachable. Reserves no space when connected — it simply
+ * isn't composed — so the layout is unchanged in the common case.
+ */
+@Composable
+private fun DisconnectedHint(connected: Boolean) {
+    if (connected) return
+    Text(
+        text = "Phone not connected",
+        style = MaterialTheme.typography.caption2,
+        color = ParchmentOnMuted,
+        maxLines = 1,
+        overflow = TextOverflow.Ellipsis,
+        textAlign = TextAlign.Center,
+        modifier = Modifier.fillMaxWidth(),
+    )
+}
+
 // region --- Previews ---
 
 private fun samplePlaying() = PlaybackState(
@@ -254,44 +293,41 @@ private fun sampleBuffering() = PlaybackState(
     charOffset = 0,
 )
 
-@Preview(device = WearDevices.LARGE_ROUND, showSystemUi = true, name = "Round · Playing")
 @Composable
-private fun PreviewRoundPlaying() {
+private fun NowPlayingPreview(state: PlaybackState, connected: Boolean = true) {
     WearLibraryNocturneTheme {
-        NowPlayingContent(samplePlaying(), {}, {}, {})
+        NowPlayingContent(
+            state = state,
+            connected = connected,
+            onPlayPause = {},
+            onSkipBack = {},
+            onSkipForward = {},
+        )
     }
 }
+
+@Preview(device = WearDevices.LARGE_ROUND, showSystemUi = true, name = "Round · Playing")
+@Composable
+private fun PreviewRoundPlaying() = NowPlayingPreview(samplePlaying())
 
 @Preview(device = WearDevices.LARGE_ROUND, showSystemUi = true, name = "Round · Paused")
 @Composable
-private fun PreviewRoundPaused() {
-    WearLibraryNocturneTheme {
-        NowPlayingContent(samplePaused(), {}, {}, {})
-    }
-}
+private fun PreviewRoundPaused() = NowPlayingPreview(samplePaused())
 
 @Preview(device = WearDevices.LARGE_ROUND, showSystemUi = true, name = "Round · Buffering")
 @Composable
-private fun PreviewRoundBuffering() {
-    WearLibraryNocturneTheme {
-        NowPlayingContent(sampleBuffering(), {}, {}, {})
-    }
-}
+private fun PreviewRoundBuffering() = NowPlayingPreview(sampleBuffering())
+
+@Preview(device = WearDevices.LARGE_ROUND, showSystemUi = true, name = "Round · Disconnected")
+@Composable
+private fun PreviewRoundDisconnected() = NowPlayingPreview(samplePaused(), connected = false)
 
 @Preview(device = WearDevices.SMALL_ROUND, showSystemUi = true, name = "Small Round")
 @Composable
-private fun PreviewSmallRound() {
-    WearLibraryNocturneTheme {
-        NowPlayingContent(samplePlaying(), {}, {}, {})
-    }
-}
+private fun PreviewSmallRound() = NowPlayingPreview(samplePlaying())
 
 @Preview(device = WearDevices.SQUARE, showSystemUi = true, name = "Square")
 @Composable
-private fun PreviewSquare() {
-    WearLibraryNocturneTheme {
-        NowPlayingContent(samplePlaying(), {}, {}, {})
-    }
-}
+private fun PreviewSquare() = NowPlayingPreview(samplePlaying())
 
 // endregion

--- a/wear/src/test/kotlin/in/jphe/storyvox/wear/playback/NodeSelectionTest.kt
+++ b/wear/src/test/kotlin/in/jphe/storyvox/wear/playback/NodeSelectionTest.kt
@@ -1,0 +1,61 @@
+package `in`.jphe.storyvox.wear.playback
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * Pure tests for the node-selection rule that backs [WearPlaybackBridge]'s
+ * connectivity state and command targeting.
+ *
+ * The GMS `Node` type is mapped to [PhoneNode] before this logic runs, so these
+ * tests need neither Robolectric nor Play Services — they exercise the decision
+ * in isolation (the seam pattern, mirroring DocumentImportClassifier for #1000).
+ */
+class NodeSelectionTest {
+
+    private fun node(id: String, nearby: Boolean) = PhoneNode(id = id, isNearby = nearby)
+
+    @Test
+    fun `no nodes means disconnected and no target`() {
+        val nodes = emptyList<PhoneNode>()
+        assertFalse(NodeSelection.isConnected(nodes))
+        assertNull(NodeSelection.preferredTarget(nodes))
+    }
+
+    @Test
+    fun `any node means connected`() {
+        val nodes = listOf(node("a", nearby = false))
+        assertTrue(NodeSelection.isConnected(nodes))
+    }
+
+    @Test
+    fun `prefers a nearby node over a cloud-only node`() {
+        val nodes = listOf(
+            node("cloud", nearby = false),
+            node("watch-paired", nearby = true),
+        )
+        assertEquals("watch-paired", NodeSelection.preferredTarget(nodes)?.id)
+    }
+
+    @Test
+    fun `falls back to first node when none are nearby`() {
+        val nodes = listOf(
+            node("cloud-1", nearby = false),
+            node("cloud-2", nearby = false),
+        )
+        // No nearby node exists, but the phone is still reachable via the cloud
+        // relay — we target the first and report connected rather than dropping
+        // the command.
+        assertEquals("cloud-1", NodeSelection.preferredTarget(nodes)?.id)
+        assertTrue(NodeSelection.isConnected(nodes))
+    }
+
+    @Test
+    fun `single nearby node is the target`() {
+        val nodes = listOf(node("only", nearby = true))
+        assertEquals("only", NodeSelection.preferredTarget(nodes)?.id)
+    }
+}


### PR DESCRIPTION
Closes #1030.

## Problem

`WearPlaybackBridge.send()` dropped transport commands silently when no phone node was reachable:

```kotlin
val phone = nodes.firstOrNull { it.isNearby } ?: nodes.firstOrNull() ?: return  // no node → silent
// ...all wrapped in runCatching {}                                              // throw → silent
```

There was **no connectivity state anywhere in the watch UI**, so a user with the phone in a bag / out of BT range taps play/pause/skip, the button reacts visually, and nothing happens — no toast, no greyed control, no hint. The watch face looked live but was inert on the exact hands-free surface Wear exists for.

## Fix

- **`WearPlaybackBridge`** exposes `connected: StateFlow<Boolean>`, refreshed on `start()`/`refreshConnectivity()` and corrected reactively from every `send()` — a successful send proves reachability; a disconnected/failed send flips `connected` to `false` immediately. `send()` now returns a `SendResult` (`Sent` / `Disconnected` / `Failed`).
- **`NodeSelection`** (new) holds the pure, GMS-free connectivity + node-targeting decision (`PhoneNode`, `SendResult`), unit-tested without Robolectric — the same testable-seam pattern used for #1000.
- **`NowPlayingScreen`** observes `connected`, re-checks on resume via `LifecycleResumeEffect` (a phone returning to range restores controls automatically), greys the transport row, and shows a **"Phone not connected"** hint.
- **`TransportRow`** gains an `enabled` flag → Wear `Button` disabled colours, non-clickable, and TalkBack announces the controls as disabled.

## Design note — listener vs. resume-refresh

The acceptance criteria suggest "a `CapabilityClient`/`NodeClient` listener, refreshed on resume" (`e.g.`). I went with **resume-refresh + send-path correction** rather than a persistent listener: it's lighter on Wear's aggressive doze and covers the dominant flows — (1) walk out of range with screen off → next wake greys controls; (2) tap while out of range → send returns `Disconnected`, greys instantly; (3) phone returns → next resume restores. The three observable behaviors the issue requires (greyed controls, hint, auto-restore) are all met.

## Acceptance checklist

- [x] `WearPlaybackBridge` exposes connectivity (`connected: StateFlow<Boolean>`)
- [x] `send()` returns a success/failure result the caller can react to
- [x] `NowPlayingScreen` reflects disconnected state (greyed controls + "Phone not connected" note)
- [x] Reconnect restores controls automatically (resume refresh + send correction)
- [x] No phone-side change

## Verification

- `:wear:compileDebugKotlin` — BUILD SUCCESSFUL
- `:wear:testDebugUnitTest --tests NodeSelectionTest` — tests=5, failures=0, errors=0

Also adds `testImplementation(junit)` to `:wear`, establishing the module's first unit-test harness (unblocks #1032).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added visual connection status indicator displaying when the phone is unreachable on the Now Playing screen.
  * Transport controls (play, pause, skip buttons) now automatically disable when phone connection is lost, with clear visual feedback.

* **Improvements**
  * App now refreshes phone connectivity status when returning from background.
  * Enhanced accessibility for disabled controls with improved TalkBack announcements and visual disabled button states.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->