### PR TITLE
fix(library): blank source title no longer freezes synced placeholder on "Loading…" (#1023)

### DIFF
--- a/core-data/src/main/kotlin/in/jphe/storyvox/data/db/entity/Fiction.kt
+++ b/core-data/src/main/kotlin/in/jphe/storyvox/data/db/entity/Fiction.kt
@@ -103,7 +103,24 @@ data class Fiction(
      * null at the same time via [FictionDao.clearBackfillFailure].
      */
     val metadataBackfillFailedAt: Long? = null,
-)
+) {
+    companion object {
+        /**
+         * Issue #981 / #1023 — the sentinel `title` a synced placeholder
+         * row carries until `MetadataBackfillWorker` hydrates it. Written
+         * by `LibrarySyncer`/`FollowsSyncer.localAdd` alongside
+         * `metadataFetchedAt = 0`; the library UI renders the localized
+         * "Loading…" caption for placeholder rows rather than this raw
+         * string.
+         *
+         * It is a single source of truth on purpose: `FictionDetail.toEntity`
+         * must recognize this exact string to avoid mistaking the sentinel
+         * for a genuinely-good cached title (#1023). If you change the value
+         * here, the syncers and the title-preservation guard move together.
+         */
+        const val PLACEHOLDER_TITLE: String = "Loading…"
+    }
+}
 
 /** Per-book download policy override. Null = inherit global setting. */
 enum class DownloadMode { LAZY, EAGER, SUBSCRIBE }

--- a/core-data/src/main/kotlin/in/jphe/storyvox/data/repository/FictionRepository.kt
+++ b/core-data/src/main/kotlin/in/jphe/storyvox/data/repository/FictionRepository.kt
@@ -610,24 +610,36 @@ internal fun FictionSummary.toEntity(now: Long): Fiction = Fiction(
 
 internal fun FictionDetail.toEntity(existing: Fiction?, now: Long): Fiction {
     val base = existing ?: summary.toEntity(now)
+    // Issue #1023 — the "Loading…" placeholder sentinel is NOT a real
+    // cached title; treat it as blank everywhere below so it can neither
+    // win over an incoming title in [preferTitle] nor count as "we have a
+    // good title now". The #279 guard was written for `existing` being a
+    // genuinely-good cached title we don't want to clobber; it never
+    // anticipated `existing` being the placeholder sentinel.
+    val existingTitle = base.title.takeUnless { it == Fiction.PLACEHOLDER_TITLE }.orEmpty()
+    val resolvedTitle = preferTitle(
+        incoming = summary.title,
+        // Issue #279 — never overwrite a previously-good title with a
+        // worse one. The RSS source falls back to the URL host when the
+        // feed parse comes up blank (intermittent gateway timeouts,
+        // momentarily-malformed XML, upstream 5xx, etc.), which produced a
+        // perfectly non-blank but useless string like "lionsroar.com". The
+        // result: pull-to-refresh silently corrupted the Library card from
+        // 'Lion's Roar / Rev. Marvin Harada' to 'lionsroar.com / ?'.
+        existing = existingTitle,
+        sourceFallback = inferUrlHost(summary.description),
+    )
+    // Issue #1023 — only treat this as a completed hydrate (stamp
+    // metadataFetchedAt = now, which drops the row out of
+    // `placeholdersToBackfill`) when we actually resolved a real title. A
+    // *successful* fetch that still yields a blank/sentinel title is a soft
+    // failure: leave `metadataFetchedAt` as-is (0 for a placeholder) so the
+    // back-fill worker's cool-down retry applies, exactly like the
+    // FictionResult.Failure path #981 established — rather than freezing the
+    // sentinel as the permanent title with no spinner, no error, no retry.
+    val hydrated = resolvedTitle.isNotBlank() && resolvedTitle != Fiction.PLACEHOLDER_TITLE
     return base.copy(
-        // Issue #279 — never overwrite a previously-good title / author
-        // with a worse one. The RSS source falls back to the URL host
-        // when the feed parse comes up blank (intermittent gateway
-        // timeouts, momentarily-malformed XML, upstream 5xx, etc.),
-        // which produced a perfectly non-blank but useless string like
-        // "lionsroar.com". The result: pull-to-refresh silently corrupted
-        // the Library card from 'Lion's Roar / Rev. Marvin Harada' to
-        // 'lionsroar.com / ?'.
-        //
-        // Defensive: if we have a non-blank existing title (the user has
-        // seen it before) and the incoming title looks like a degraded
-        // fallback — either blank OR a bare host string that matches the
-        // last cached description / cover URL host — keep the cached
-        // value. Same pattern for author. Sources that genuinely return
-        // a richer title are unaffected: the equality check only fires
-        // when the new title literally is the URL host fallback.
-        title = preferTitle(incoming = summary.title, existing = base.title, sourceFallback = inferUrlHost(summary.description)),
+        title = resolvedTitle,
         author = summary.author.ifBlank { base.author },
         authorId = authorId ?: base.authorId,
         coverUrl = summary.coverUrl ?: base.coverUrl,
@@ -641,7 +653,7 @@ internal fun FictionDetail.toEntity(existing: Fiction?, now: Long): Fiction {
         views = views ?: base.views,
         followers = followers ?: base.followers,
         lastUpdatedAt = lastUpdatedAt ?: base.lastUpdatedAt,
-        metadataFetchedAt = now,
+        metadataFetchedAt = if (hydrated) now else base.metadataFetchedAt,
     )
 }
 

--- a/core-data/src/test/kotlin/in/jphe/storyvox/data/repository/FictionRepositoryImplTest.kt
+++ b/core-data/src/test/kotlin/in/jphe/storyvox/data/repository/FictionRepositoryImplTest.kt
@@ -630,6 +630,71 @@ class FictionRepositoryImplTest {
         assertNull("failure stamp cleared on success", fictionDao.rows["99"]!!.metadataBackfillFailedAt)
     }
 
+    @Test fun `refreshDetail success with blank title leaves placeholder eligible for retry (#1023)`() = runTest {
+        // #1023 — a successful detail fetch that carries a BLANK title must
+        // NOT freeze the placeholder. Before the fix, toEntity kept the
+        // "Loading…" sentinel as the title AND stamped metadataFetchedAt =
+        // now, dropping the row out of placeholdersToBackfill forever — the
+        // card read "Loading…" as its real title with no spinner, no error,
+        // no retry. The row must stay metadataFetchedAt == 0 so the next
+        // back-fill sweep re-fetches it.
+        val src = FakeSource(SourceIds.ROYAL_ROAD).apply {
+            detailResult = FictionResult.Success(
+                FictionDetail(
+                    summary = FictionSummary(
+                        id = "99", sourceId = SourceIds.ROYAL_ROAD, title = "", author = "",
+                    ),
+                    chapters = emptyList(),
+                ),
+            )
+        }
+        val (r, fictionDao, _) = repo(sources = mapOf(SourceIds.ROYAL_ROAD to src))
+        fictionDao.rows["99"] = Fiction(
+            id = "99", sourceId = SourceIds.ROYAL_ROAD, title = "Loading…", author = "",
+            firstSeenAt = 0L, metadataFetchedAt = 0L, inLibrary = true,
+        )
+
+        val result = r.refreshDetail("99")
+
+        assertTrue(result is FictionResult.Success)
+        val row = fictionDao.rows["99"]!!
+        assertEquals(
+            "row still in the back-fill set (metadataFetchedAt unchanged)",
+            0L, row.metadataFetchedAt,
+        )
+        assertTrue(
+            "row still a placeholder (re-derived isPlaceholder)",
+            row.toSummary().isPlaceholder,
+        )
+        // The next sweep will see it: cutoff far in the future so any
+        // failure stamp is past it too.
+        assertTrue(
+            "row reappears in placeholdersToBackfill",
+            fictionDao.placeholdersToBackfill(cutoff = Long.MAX_VALUE).any { it.id == "99" },
+        )
+    }
+
+    @Test fun `refreshDetail success with real title hydrates and stamps as before (#1023 regression-guard)`() = runTest {
+        // The fix must NOT change the happy path: a successful fetch with a
+        // genuine title still stamps metadataFetchedAt and drops the row out
+        // of the placeholder set.
+        val src = FakeSource(SourceIds.ROYAL_ROAD).apply {
+            detailResult = FictionResult.Success(detail("99", chapterCount = 1))
+        }
+        val (r, fictionDao, _) = repo(sources = mapOf(SourceIds.ROYAL_ROAD to src))
+        fictionDao.rows["99"] = Fiction(
+            id = "99", sourceId = SourceIds.ROYAL_ROAD, title = "Loading…", author = "",
+            firstSeenAt = 0L, metadataFetchedAt = 0L, inLibrary = true,
+        )
+
+        r.refreshDetail("99")
+
+        val row = fictionDao.rows["99"]!!
+        assertEquals("real title wins over the sentinel", "title-99", row.title)
+        assertTrue("hydrated row stamps metadataFetchedAt", row.metadataFetchedAt > 0L)
+        assertTrue("no longer a placeholder", !row.toSummary().isPlaceholder)
+    }
+
     @Test fun `refreshDetail failure does NOT touch the DB`() = runTest {
         val src = FakeSource(SourceIds.ROYAL_ROAD).apply {
             detailResult = FictionResult.NotFound()

--- a/core-sync/src/main/kotlin/in/jphe/storyvox/sync/domain/FollowsSyncer.kt
+++ b/core-sync/src/main/kotlin/in/jphe/storyvox/sync/domain/FollowsSyncer.kt
@@ -57,7 +57,9 @@ class FollowsSyncer @Inject constructor(
                         // back-fill worker repairs anything resolveByShape
                         // can't (radio station ids) on its first pass.
                         sourceId = `in`.jphe.storyvox.data.source.FictionSourceIdResolver.resolveByShape(id),
-                        title = "Loading…",
+                        // #1023 — single source of truth for the sentinel
+                        // FictionDetail.toEntity recognizes; see PLACEHOLDER_TITLE.
+                        title = `in`.jphe.storyvox.data.db.entity.Fiction.PLACEHOLDER_TITLE,
                         author = "",
                         firstSeenAt = now,
                         metadataFetchedAt = 0L,

--- a/core-sync/src/main/kotlin/in/jphe/storyvox/sync/domain/LibrarySyncer.kt
+++ b/core-sync/src/main/kotlin/in/jphe/storyvox/sync/domain/LibrarySyncer.kt
@@ -88,7 +88,9 @@ class LibrarySyncer @Inject constructor(
                         // "royalroad" for colon-less ids; the back-fill
                         // worker repairs the rarer radio-station case.
                         sourceId = `in`.jphe.storyvox.data.source.FictionSourceIdResolver.resolveByShape(id),
-                        title = "Loading…",
+                        // #1023 — single source of truth for the sentinel
+                        // FictionDetail.toEntity recognizes; see PLACEHOLDER_TITLE.
+                        title = `in`.jphe.storyvox.data.db.entity.Fiction.PLACEHOLDER_TITLE,
                         author = "",
                         firstSeenAt = now,
                         metadataFetchedAt = 0L,


### PR DESCRIPTION
Closes #1023.

## Symptom
A synced library/follows placeholder whose source returns a **successful** `fictionDetail` with a **blank title** got permanently stamped `metadataFetchedAt = now`, dropped out of `placeholdersToBackfill`, and displayed the literal `"Loading…"` sentinel as its real title — forever. No spinner, no "Couldn't load" state, no retry. This re-opened the eternal-"Loading…" symptom #981 set out to kill, via a *success* path instead of a fetch failure.

## Root cause
`MetadataBackfillWorker.hydrateOne` → `FictionRepository.refreshDetail` → `upsertDetail` → `FictionDetail.toEntity`.

`toEntity` could not distinguish the `"Loading…"` placeholder sentinel from a genuinely-good cached title:
- `preferTitle` (#279 title-degradation guard) returned `existing` when `incoming` was blank — correct when `existing` is a real cached title, **wrong** when it is the placeholder sentinel.
- `toEntity` then stamped `metadataFetchedAt = now` unconditionally, freezing the sentinel and removing the row from the back-fill set.

Net: card permanently reads "Loading…", `isPlaceholder` (`metadataFetchedAt == 0L`) is false, so the UI renders the raw stored string instead of the loading caption, and the worker never retries.

## Fix (`core-data/FictionRepository.toEntity`)
1. Treat the sentinel as blank when feeding `preferTitle`, so a blank incoming title can no longer "win" by preserving `"Loading…"`.
2. Stamp `metadataFetchedAt = now` **only when a real title was resolved**. A success-with-blank/sentinel title is a soft failure: leave `metadataFetchedAt` unchanged (`0` for a placeholder) so the row stays eligible for the back-fill worker's cool-down retry — matching the `FictionResult.Failure` contract #981 established. `isPlaceholder` stays true, so the UI shows the localized loading caption, not the raw string.

Also lifts the duplicated `"Loading…"` magic string into `Fiction.PLACEHOLDER_TITLE` (single source of truth) and points `LibrarySyncer`/`FollowsSyncer.localAdd` at it, so the sentinel the syncers write and the sentinel `toEntity` recognizes can never drift apart.

## Tests
Two new `FictionRepositoryImplTest` cases:
- blank-title success leaves the row in `placeholdersToBackfill` (`metadataFetchedAt == 0`, `isPlaceholder == true`) — fails before the fix, passes after.
- real-title success still hydrates and stamps (`metadataFetchedAt > 0`, `isPlaceholder == false`) — happy-path regression guard.

Verification: full `core-data` (276 tests) + `core-sync` (126 tests) suites green, 0 failures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue where incomplete metadata (displaying "Loading…") was incorrectly marked as fully synced, preventing proper refresh on future operations.
  * Improved consistency in placeholder handling across the sync system.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->