### PR TITLE
chore(site): GitHub Pages → candela.techempower.org

### DIFF
--- a/docs/CNAME
+++ b/docs/CNAME
@@ -1,1 +1,1 @@
-storyvox.techempower.org
+candela.techempower.org

--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -1,6 +1,6 @@
 title: Candela
 description: A neural-voice audiobook player for any text you have. Seventeen fiction backends, three in-process neural voice families, optional Azure HD cloud voices. Brass-on-warm-dark Library Nocturne aesthetic. Free, GPL-3.0, no telemetry, no per-character billing.
-url: https://storyvox.techempower.org
+url: https://candela.techempower.org
 baseurl: ""
 
 # Default social-share card (override per-page via front-matter image:)


### PR DESCRIPTION
DNS is live (CNAME, grey-cloud). Flips the canonical Pages domain; storyvox.techempower.org 301s to candela.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated documentation site domain from storyvox.techempower.org to candela.techempower.org.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->