### PR TITLE
fix(a11y): isolate first-launch overlays from TalkBack background traversal (#1026)

### DIFF
--- a/feature/src/main/kotlin/in/jphe/storyvox/feature/components/OverlayA11y.kt
+++ b/feature/src/main/kotlin/in/jphe/storyvox/feature/components/OverlayA11y.kt
@@ -1,0 +1,83 @@
+package `in`.jphe.storyvox.feature.components
+
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.semantics.invisibleToUser
+import androidx.compose.ui.semantics.isTraversalGroup
+import androidx.compose.ui.semantics.semantics
+import androidx.compose.ui.semantics.traversalIndex
+
+/**
+ * Issue #1026 — accessibility isolation for full-screen first-launch
+ * overlays ([OnboardingHost], [VoicePickerGate]).
+ *
+ * Both overlays render the real app content (the Library `NavHost`)
+ * underneath themselves *unconditionally* — the embedded NavHost must be
+ * composed so a CTA's `navController.navigate(...)` resolves in the same
+ * frame the overlay dismisses. They guard against stray taps with a
+ * transparent `clickable` "tap-swallow" shield, but that only intercepts
+ * **pointer** input — it does nothing to TalkBack's semantic traversal.
+ *
+ * On the dev tablet (R83W80CAFZB, Samsung SM-T227U, TalkBack 17.0) the
+ * opaque full-screen background already happens to occlude the Library
+ * subtree out of the accessibility tree, so focus does not escape there.
+ * But that is a *coincidental* side-effect of draw/occlusion order, not a
+ * contract Compose guarantees across Android / TalkBack versions. These
+ * helpers make the isolation **explicit** so a screen-reader user on first
+ * launch can never swipe past the active overlay into the (visually
+ * hidden) Library list / bottom nav rendered behind it.
+ *
+ * Apply [overlayBackground] to the underlying `content()` wrapper and
+ * [overlayForeground] to the overlay's own root, gating both on whether an
+ * overlay is currently showing.
+ */
+
+/**
+ * Wraps the background `content()` so it is removed from the accessibility
+ * traversal while [overlayShowing]. When an overlay is up the whole subtree
+ * is marked [invisibleToUser] — TalkBack / Switch Access skip it entirely;
+ * when no overlay is up this is a no-op and `content()` behaves normally.
+ *
+ * `invisibleToUser` (rather than `clearAndSetSemantics {}`) is deliberate:
+ * it hides the subtree from accessibility services without disturbing the
+ * pointer-input or layout semantics the live NavHost still needs while it
+ * sits composed beneath the overlay.
+ */
+fun Modifier.overlayBackground(overlayShowing: Boolean): Modifier =
+    if (overlayShowing) {
+        this.semantics { invisibleToUser() }
+    } else {
+        this
+    }
+
+/**
+ * Marks the overlay's own root as a self-contained traversal group placed
+ * ahead of anything else on screen, so TalkBack's linear (swipe) navigation
+ * stays within the overlay's controls. Pairs with [overlayBackground] — the
+ * background is hidden, the foreground is grouped — so focus is bounded on
+ * both ends regardless of draw order.
+ */
+fun Modifier.overlayForeground(): Modifier =
+    this.semantics {
+        isTraversalGroup = true
+        // Negative index sorts the overlay group before the (now hidden)
+        // background in the merged traversal order; belt-and-suspenders
+        // with overlayBackground's invisibleToUser.
+        traversalIndex = -1f
+    }
+
+/**
+ * Structural canary for issue #1026 — both first-launch overlays MUST
+ * isolate the background NavHost from TalkBack traversal while they are up.
+ * The bug did not reproduce on the dev tablet (the opaque background
+ * occluded the subtree *coincidentally*), so there is nothing a runtime
+ * assertion can observe regress on this device — and the `feature` unit
+ * source set has no Robolectric / ComposeTestRule to drive a live
+ * traversal anyway. This boolean pins the contract the same way
+ * [`in`.jphe.storyvox.feature.fiction.notebookAddNoteUsesExplicitFocus]
+ * does for the Notebook focus plumbing: flip it to false only after
+ * proving on a real device with TalkBack that the overlays still isolate
+ * background focus without [overlayBackground] / [overlayForeground].
+ *
+ * Pinned by `OverlayA11yContractTest`.
+ */
+const val onboardingOverlaysIsolateBackgroundFromTalkBack: Boolean = true

--- a/feature/src/main/kotlin/in/jphe/storyvox/feature/engine/VoicePickerGate.kt
+++ b/feature/src/main/kotlin/in/jphe/storyvox/feature/engine/VoicePickerGate.kt
@@ -44,6 +44,8 @@ import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.launch
 import `in`.jphe.storyvox.data.source.SystemTtsVoiceProvider
 import `in`.jphe.storyvox.feature.R
+import `in`.jphe.storyvox.feature.components.overlayBackground
+import `in`.jphe.storyvox.feature.components.overlayForeground
 import `in`.jphe.storyvox.playback.voice.UiVoiceInfo
 import `in`.jphe.storyvox.playback.voice.VoiceCatalog
 import `in`.jphe.storyvox.playback.voice.VoiceManager
@@ -82,9 +84,17 @@ fun VoicePickerGate(
     // dismisses the gate AND calls navController.navigate in the same frame —
     // if content weren't already in the composition, the destination route
     // wouldn't exist on the NavController yet and navigate() would crash.
+    val gateShowing = !bypassed && activeVoice == null
     Box(modifier = Modifier.fillMaxSize()) {
-        content()
-        if (!bypassed && activeVoice == null) {
+        // #1026 — hide the live NavHost beneath from TalkBack while the gate
+        // is up, so a screen-reader user can't swipe past the picker into the
+        // (visually hidden) Library list / bottom nav. content() stays
+        // composed (navigate() races the gate's dismiss); we isolate it
+        // semantically rather than tearing it down.
+        Box(modifier = Modifier.fillMaxSize().overlayBackground(gateShowing)) {
+            content()
+        }
+        if (gateShowing) {
             // Swallow taps in the gate's empty regions so they don't fall
             // through to the LibraryScreen rendered underneath. We use a
             // ripple-less clickable rather than pointerInput because the
@@ -94,13 +104,24 @@ fun VoicePickerGate(
             // a11y (#481, #482): this clickable is a *tap-swallow* — a
             // transparent shield that prevents underlying content from
             // receiving taps while the voice picker overlays it. It
-            // doesn't need (and shouldn't have) a Role; TalkBack should
-            // walk through it to the VoicePickerScreen below. Marked
-            // explicitly so a future Role-sweep doesn't add one.
+            // doesn't need (and shouldn't have) a Role. Marked explicitly
+            // so a future Role-sweep doesn't add one.
+            //
+            // #1026 follow-up: the shield only blocks POINTER input — it
+            // never bounded TalkBack traversal. The background NavHost is
+            // now marked invisibleToUser via overlayBackground() above, and
+            // this overlay is a traversal group (overlayForeground below),
+            // so screen-reader focus is isolated to the picker explicitly
+            // rather than relying on the opaque background occluding the
+            // subtree (which only happens to work on some TalkBack versions).
             Box(
                 modifier = Modifier
                     .fillMaxSize()
                     .background(MaterialTheme.colorScheme.background)
+                    // #1026 — scope the gate as a self-contained traversal
+                    // group ahead of the background so TalkBack swipe-
+                    // navigation stays within the picker's controls.
+                    .overlayForeground()
                     .clickable(
                         interactionSource = swallow,
                         indication = null,

--- a/feature/src/main/kotlin/in/jphe/storyvox/feature/onboarding/OnboardingHost.kt
+++ b/feature/src/main/kotlin/in/jphe/storyvox/feature/onboarding/OnboardingHost.kt
@@ -34,6 +34,8 @@ import kotlinx.coroutines.withTimeoutOrNull
 import `in`.jphe.storyvox.feature.api.FictionRepositoryUi
 import `in`.jphe.storyvox.feature.api.PlaybackControllerUi
 import `in`.jphe.storyvox.feature.api.SettingsRepositoryUi
+import `in`.jphe.storyvox.feature.components.overlayBackground
+import `in`.jphe.storyvox.feature.components.overlayForeground
 
 /**
  * Issue #599 (v1.0 blocker) — the three-screen first-launch welcome
@@ -84,7 +86,15 @@ fun OnboardingHost(
 ) {
     val show by viewModel.shouldShow.collectAsStateWithLifecycle()
     Box(modifier = Modifier.fillMaxSize()) {
-        content()
+        // #1026 — hide the live NavHost beneath from TalkBack while the
+        // welcome overlay is up, so a screen-reader user can't swipe past
+        // the overlay into the (visually hidden) Library list / bottom nav.
+        // The content() must stay composed (route resolution races the
+        // overlay's dismiss), so we isolate it semantically rather than
+        // tearing it down.
+        Box(modifier = Modifier.fillMaxSize().overlayBackground(show)) {
+            content()
+        }
         if (show) {
             // Forward-only three-step state machine. rememberSaveable
             // so a configuration change (rotation) doesn't snap the
@@ -95,6 +105,10 @@ fun OnboardingHost(
                 modifier = Modifier
                     .fillMaxSize()
                     .background(MaterialTheme.colorScheme.background)
+                    // #1026 — scope the overlay as a self-contained
+                    // traversal group ahead of the background so TalkBack
+                    // swipe-navigation stays within the welcome controls.
+                    .overlayForeground()
                     // Tap-swallow shield (same pattern as
                     // VoicePickerGate) — prevents underlying Library
                     // taps from leaking through the welcome overlay.

--- a/feature/src/test/kotlin/in/jphe/storyvox/feature/components/OverlayA11yContractTest.kt
+++ b/feature/src/test/kotlin/in/jphe/storyvox/feature/components/OverlayA11yContractTest.kt
@@ -1,0 +1,87 @@
+package `in`.jphe.storyvox.feature.components
+
+import androidx.compose.ui.Modifier
+import org.junit.Assert.assertNotEquals
+import org.junit.Assert.assertSame
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * Issue #1026 — regression guard for first-launch overlay TalkBack
+ * isolation ([`in`.jphe.storyvox.feature.onboarding.OnboardingHost] and
+ * [`in`.jphe.storyvox.feature.engine.VoicePickerGate]).
+ *
+ * Both overlays keep the Library `NavHost` composed underneath themselves
+ * (route resolution races the overlay's dismiss) and guard against stray
+ * taps with a transparent tap-swallow shield. That shield blocks *pointer*
+ * input only — it never bounded TalkBack's semantic traversal, so a
+ * screen-reader user could in principle swipe past the overlay into the
+ * visually hidden Library. On the dev tablet (R83W80CAFZB, TalkBack 17.0)
+ * the opaque background happened to occlude the subtree out of the a11y
+ * tree, so it did not reproduce — but that is a draw-order coincidence,
+ * not a contract. [overlayBackground] + [overlayForeground] make the
+ * isolation explicit and version-independent.
+ *
+ * The `feature` unit source set has no Robolectric / ComposeTestRule (see
+ * [`in`.jphe.storyvox.feature.fiction.NotebookFocusContractTest]), so we
+ * pin the contract via:
+ *  (a) the structural marker [onboardingOverlaysIsolateBackgroundFromTalkBack],
+ *      and
+ *  (b) the no-op-when-inactive / mutates-when-active shape of
+ *      [overlayBackground], which guarantees the live NavHost is untouched
+ *      when no overlay is up and isolated when one is.
+ */
+class OverlayA11yContractTest {
+
+    @Test
+    fun `overlay background isolation is a no-op when no overlay is showing`() {
+        // While no overlay is up, content() must behave exactly as before
+        // — no stray semantics on the live NavHost wrapper. The helper
+        // returns the receiver unchanged.
+        val base = Modifier
+        assertSame(
+            "overlayBackground(false) must return the modifier unchanged so the live NavHost keeps its normal semantics",
+            base,
+            base.overlayBackground(overlayShowing = false),
+        )
+    }
+
+    @Test
+    fun `overlay background isolation adds semantics when an overlay is showing`() {
+        // When an overlay is up, the background wrapper must carry the
+        // invisibleToUser semantics (a different Modifier chain than the
+        // bare receiver). We can't read the SemanticsConfiguration without
+        // a ComposeTestRule, but the chain must have grown.
+        val base = Modifier
+        val isolated = base.overlayBackground(overlayShowing = true)
+        assertNotEquals(
+            "overlayBackground(true) must add semantics to hide the background from TalkBack",
+            base,
+            isolated,
+        )
+    }
+
+    @Test
+    fun `overlay foreground always adds traversal-group semantics`() {
+        // The overlay root must always be scoped as a traversal group; it
+        // is only ever applied while the overlay is on screen.
+        val base = Modifier
+        assertNotEquals(
+            "overlayForeground() must add traversal-group semantics to the overlay root",
+            base,
+            base.overlayForeground(),
+        )
+    }
+
+    @Test
+    fun `onboarding overlays isolate background from TalkBack per issue #1026`() {
+        // Structural canary. Both OnboardingHost and VoicePickerGate must
+        // keep applying overlayBackground()/overlayForeground(). Flip to
+        // false only after a real-device TalkBack pass proves the overlays
+        // still bound screen-reader focus without these helpers.
+        assertTrue(
+            "OnboardingHost + VoicePickerGate must isolate the background NavHost from TalkBack (issue #1026)",
+            onboardingOverlaysIsolateBackgroundFromTalkBack,
+        )
+    }
+}


### PR DESCRIPTION
Closes #1026.

## Problem

`OnboardingHost` and `VoicePickerGate` both render the Library `NavHost` underneath themselves **unconditionally** (route resolution races the overlay's dismiss, so `content()` must stay composed) and guard stray taps with a transparent `clickable` tap-swallow shield. That shield blocks **pointer** input only — it never bounded TalkBack's semantic traversal. So in principle a screen-reader user on first launch could swipe-right past the overlay's controls into the visually hidden Library list / bottom nav.

## Verification (the `needs-verification` part)

Confirmed on the dev tablet **R83W80CAFZB** (Samsung SM-T227U, TalkBack 17.0, candela v1.0.3):

Method: clear app data → cold launch → enable TalkBack → drive swipe-right traversal + dump the accessibility node tree at each step.

**Result: the bug did NOT reproduce on this device.** With the Welcome overlay showing, the accessibility tree contained only the 6 overlay nodes; 8 TalkBack next-element swipes never surfaced any Library/fiction/nav node. The opaque full-screen `background()` Box causes Compose's accessibility integration to occlude the Library subtree out of the tree.

**But that is a draw-order coincidence, not a contract** — exactly the caveat the issue raises ("may already coincidentally win focus order on *some* Android/TalkBack versions"). Rather than close as already-correct and leave the correctness resting on an occlusion side-effect, I hardened it so the isolation is explicit and version-independent (the acceptance criteria's "if reproduced" path, applied defensively).

## Fix

Shared helper `feature/components/OverlayA11y.kt`, applied to **both** overlays:

- `Modifier.overlayBackground(showing)` — marks the background `content()` `invisibleToUser()` while an overlay is up; a **no-op (receiver unchanged)** when none is, so normal post-onboarding TalkBack use is untouched.
- `Modifier.overlayForeground()` — scopes the overlay root as an `isTraversalGroup` placed ahead of the background.

`content()` stays composed (navigation still works); only its accessibility exposure is gated.

## Re-verification on the fixed release build (on-device)

Installed the fixed `:app:assembleRelease` APK on R83W80CAFZB, cleared data, walked the full first-run flow and dumped the a11y tree at each overlay:

| Surface | Labelled a11y nodes | Library/nav leaked? |
|---|---|---|
| Welcome (Step 1/3) | 6 (overlay only) | none |
| In-onboarding voice picker (Step 2/3) | 14 (overlay only) | none |
| VoicePickerGate ("Continue without audio") | 15 (overlay only) | none |
| **All overlays dismissed** | **32 — full Library** incl. Playing/Library/Browse/Voices/Settings bottom nav | n/a (correctly visible) |

The last row is the key control: isolation **lifts** when no overlay is up, so the live NavHost behaves normally once onboarding completes. The intended in-overlay traversal (overlay controls reachable, shield doesn't trap) still works.

## Tests / gate

- `OverlayA11yContractTest` (new): structural canary `onboardingOverlaysIsolateBackgroundFromTalkBack` + asserts `overlayBackground(false)` is a no-op and `overlayBackground(true)`/`overlayForeground()` mutate the modifier chain. Mirrors `NotebookFocusContractTest` (feature unit set has no Robolectric/ComposeTestRule).
- `:feature:compileDebugKotlin` + `:feature:testDebugUnitTest --tests OverlayA11yContractTest` — green.
- `:app:assembleRelease` — green (required gate).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced accessibility for screen reader users by isolating overlay controls from background content, ensuring proper focus navigation within modals and popups.

* **Tests**
  * Added automated tests to verify accessibility behavior for screen reader traversal within overlay components.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->