### PR TITLE
test(wear): WearPlaybackBridge state-decode + version-skew resilience (#1032)

### DIFF
--- a/wear/src/main/kotlin/in/jphe/storyvox/wear/playback/WearPlaybackBridge.kt
+++ b/wear/src/main/kotlin/in/jphe/storyvox/wear/playback/WearPlaybackBridge.kt
@@ -1,6 +1,7 @@
 package `in`.jphe.storyvox.wear.playback
 
 import android.content.Context
+import android.util.Log
 import com.google.android.gms.wearable.DataClient
 import com.google.android.gms.wearable.DataEventBuffer
 import com.google.android.gms.wearable.DataItem
@@ -38,7 +39,6 @@ class WearPlaybackBridge(private val context: Context) : DataClient.OnDataChange
     private val dataClient by lazy { Wearable.getDataClient(context) }
     private val messageClient by lazy { Wearable.getMessageClient(context) }
     private val nodeClient by lazy { Wearable.getNodeClient(context) }
-    private val json = Json { ignoreUnknownKeys = true }
 
     private val _state = MutableStateFlow(PlaybackState())
     val state: StateFlow<PlaybackState> = _state.asStateFlow()
@@ -90,8 +90,13 @@ class WearPlaybackBridge(private val context: Context) : DataClient.OnDataChange
 
     private fun consume(item: DataItem) {
         val map = DataMapItem.fromDataItem(item).dataMap
-        val raw = map.getString("state") ?: return
-        runCatching { _state.value = json.decodeFromString<PlaybackState>(raw) }
+        _state.value = decodeState(map.getString("state"), _state.value) { t ->
+            // #1032 — was a bare runCatching that silently dropped the payload.
+            // A dropped state on the watch shows as stale playback info, so make
+            // it greppable when it happens (malformed blob, or version skew where
+            // the phone shipped a PlaybackError subtype this build can't decode).
+            Log.w(TAG, "wear: dropping undecodable PlaybackState payload", t)
+        }
     }
 
     /**
@@ -119,4 +124,39 @@ class WearPlaybackBridge(private val context: Context) : DataClient.OnDataChange
 
     private suspend fun connectedPhoneNodes(): List<PhoneNode> =
         nodeClient.connectedNodes.await().map { PhoneNode(id = it.id, isNearby = it.isNearby) }
+
+    companion object {
+        private const val TAG = "WearPlaybackBridge"
+
+        /**
+         * Decode a phone-published [PlaybackState] JSON blob, falling back to the
+         * last-good [current] state on any failure (#1032).
+         *
+         * Pure and instance-free so the decode contract can be unit-tested without
+         * GMS `DataItem`/`DataClient` (the seam pattern, mirroring [NodeSelection]).
+         * Returns [current] unchanged when:
+         *  - [raw] is null (no "state" key on the DataItem), or
+         *  - the JSON is malformed / truncated, or
+         *  - it carries an unknown sealed-[PlaybackError] discriminator (version
+         *    skew: the phone shipped an error subtype this watch build predates) —
+         *    kotlinx.serialization throws on the unknown type even with
+         *    `ignoreUnknownKeys`, so we must catch rather than crash the watch.
+         *
+         * [onError] is invoked with the decode failure so the caller can log it
+         * (the previous `consume()` swallowed failures silently).
+         */
+        internal inline fun decodeState(
+            raw: String?,
+            current: PlaybackState,
+            onError: (Throwable) -> Unit = {},
+        ): PlaybackState {
+            if (raw == null) return current
+            return runCatching { DECODE_JSON.decodeFromString<PlaybackState>(raw) }
+                .getOrElse { onError(it); current }
+        }
+
+        /** Matches [in.jphe.storyvox.playback.wear.PhoneWearBridge]'s encoder config. */
+        @PublishedApi
+        internal val DECODE_JSON = Json { ignoreUnknownKeys = true }
+    }
 }

--- a/wear/src/test/kotlin/in/jphe/storyvox/wear/playback/WearStateDecodeTest.kt
+++ b/wear/src/test/kotlin/in/jphe/storyvox/wear/playback/WearStateDecodeTest.kt
@@ -1,0 +1,126 @@
+package `in`.jphe.storyvox.wear.playback
+
+import `in`.jphe.storyvox.playback.PlaybackError
+import `in`.jphe.storyvox.playback.PlaybackState
+import kotlinx.serialization.encodeToString
+import kotlinx.serialization.json.Json
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertSame
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * Pure tests for [WearPlaybackBridge.decodeState] — the watch-side decode of the
+ * `/playback/state` JSON the phone publishes (#1032).
+ *
+ * Extracted out of `consume()` as a pure function so the decode contract can be
+ * exercised without standing up GMS `DataItem`/`DataClient` (the seam pattern,
+ * mirroring [NodeSelection] for #1030 and DocumentImportClassifier for #1000).
+ *
+ * The phone side ([in.jphe.storyvox.playback.wear.PhoneWearBridge.publishState])
+ * encodes with `Json { ignoreUnknownKeys = true }` and NO `encodeDefaults`, so a
+ * default-valued field is simply omitted; [phoneJson] mirrors that exactly so the
+ * round-trip tests assert the real wire shape, not an idealised one.
+ */
+class WearStateDecodeTest {
+
+    /** Same config as both bridges — defaults omitted, unknown keys tolerated. */
+    private val phoneJson = Json { ignoreUnknownKeys = true }
+
+    @Test
+    fun `round-trips a published state through encode then decode`() {
+        val published = PlaybackState(
+            currentFictionId = "fic-1",
+            currentChapterId = "ch-3",
+            charOffset = 512,
+            durationEstimateMs = 90_000L,
+            isPlaying = true,
+            bookTitle = "The Title",
+            chapterTitle = "Chapter 3",
+        )
+        val raw = phoneJson.encodeToString(published)
+
+        val decoded = WearPlaybackBridge.decodeState(raw, PlaybackState())
+
+        // data-class equality covers every field, so any future field that the
+        // phone encodes but the watch fails to reconstruct trips this.
+        assertEquals(published, decoded)
+    }
+
+    @Test
+    fun `round-trips a sealed PlaybackError subtype`() {
+        val published = PlaybackState(error = PlaybackError.AzureThrottled("F0 quota exhausted"))
+        val raw = phoneJson.encodeToString(published)
+
+        val decoded = WearPlaybackBridge.decodeState(raw, PlaybackState())
+
+        assertEquals(PlaybackError.AzureThrottled("F0 quota exhausted"), decoded.error)
+    }
+
+    @Test
+    fun `malformed JSON leaves the last-good state intact`() {
+        val lastGood = PlaybackState(currentChapterId = "ch-good", charOffset = 99, isPlaying = true)
+
+        val decoded = WearPlaybackBridge.decodeState("{not valid json", lastGood)
+
+        // Identity, not just equality — a bad payload must not even allocate a
+        // replacement; the watch keeps showing exactly what it last had.
+        assertSame(lastGood, decoded)
+    }
+
+    @Test
+    fun `unknown sealed-error discriminator from a newer phone keeps last-good`() {
+        // Version skew: the phone shipped a PlaybackError subtype this (older)
+        // watch build can't resolve. kotlinx.serialization throws on the unknown
+        // polymorphic discriminator even with ignoreUnknownKeys — the decode must
+        // be caught so the watch doesn't crash and doesn't blank the UI.
+        val raw = """{"error":{"type":"in.jphe.storyvox.playback.PlaybackError.FutureV2Error","code":7}}"""
+        val lastGood = PlaybackState(isPlaying = true, charOffset = 42)
+
+        val decoded = WearPlaybackBridge.decodeState(raw, lastGood)
+
+        assertSame(lastGood, decoded)
+    }
+
+    @Test
+    fun `null payload returns current unchanged`() {
+        val current = PlaybackState(currentChapterId = "ch-x")
+        assertSame(current, WearPlaybackBridge.decodeState(null, current))
+    }
+
+    @Test
+    fun `decode failure invokes the onError hook`() {
+        // #1032 — consume() previously swallowed decode failures in a bare
+        // runCatching. The onError seam is what lets WearPlaybackBridge log the
+        // dropped payload (and lets this test prove the failure was observed,
+        // without Robolectric for android.util.Log).
+        var seen: Throwable? = null
+
+        WearPlaybackBridge.decodeState("{bad", PlaybackState()) { seen = it }
+
+        assertNotNull("expected onError to fire on malformed payload", seen)
+    }
+
+    @Test
+    fun `successful decode does not invoke the onError hook`() {
+        val raw = phoneJson.encodeToString(PlaybackState(charOffset = 7))
+        var fired = false
+
+        WearPlaybackBridge.decodeState(raw, PlaybackState()) { fired = true }
+
+        assertTrue("onError must not fire on a clean decode", !fired)
+    }
+
+    @Test
+    fun `extra unknown keys from a newer phone are ignored`() {
+        // Forward-compat: a newer phone adds a field the watch's PlaybackState
+        // doesn't know. ignoreUnknownKeys lets the known fields through.
+        val raw = """{"currentChapterId":"ch-1","charOffset":5,"futureField":true}"""
+
+        val decoded = WearPlaybackBridge.decodeState(raw, PlaybackState())
+
+        assertEquals("ch-1", decoded.currentChapterId)
+        assertEquals(5, decoded.charOffset)
+    }
+}


### PR DESCRIPTION
Closes #1032.

The `:wear` module had **zero tests**. #1030 (#1052) added the node-selection half (`NodeSelection` + `NodeSelectionTest`); this PR covers the other half — the phone→watch `PlaybackState` decode path in `consume()`.

## What changed
- **Extracted a pure, instance-free `decodeState(raw, current, onError = {})`** from `consume()` so the decode contract is unit-testable without standing up GMS `DataItem`/`DataClient` (the seam pattern, mirroring `NodeSelection` for #1030 and `DocumentImportClassifier` for #1000).
- **Fixed a latent silent-drop gap #1030 left in place:** `consume()` previously swallowed decode failures in a bare `runCatching`, so a malformed blob — or a **version-skew payload** (the phone ships a `PlaybackError` sealed subtype this watch build predates → kotlinx.serialization throws on the unknown polymorphic discriminator *even with* `ignoreUnknownKeys`) — was dropped silently and surfaced only as stale playback info on the watch. The failure is now `Log.w`'d so it's greppable; the watch keeps its last-good state instead of crashing or blanking.
- Removed the now-dead instance `json` field; `consume()` routes through the companion `DECODE_JSON` (same `Json { ignoreUnknownKeys = true }` config the phone's `PhoneWearBridge` encodes with).

## Tests — `WearStateDecodeTest` (8, JUnit4, no Robolectric)
- round-trip a published state (encode↔decode, full data-class equality)
- round-trip a sealed `PlaybackError` subtype (`AzureThrottled`)
- malformed JSON → last-good state preserved (`assertSame`, no realloc)
- **unknown sealed-error discriminator (newer phone) → no crash, last-good** (the version-skew case)
- null payload → current unchanged
- decode failure fires `onError`; clean decode does not
- unknown extra keys (newer phone) ignored (forward-compat)

No node-selection tests — covered by #1030. `send()`/command path untouched (Aurora's #1031 `CMD_SEEK` lands on top).

## Stacking note for the reviewer/merger
This branch is **based on `fix/1030-wear-transport` (#1052)**, not directly on `main` (per the agreed merge order #1030 → #1032 → #1031, to inherit the `:wear` test source set without duplicating it). Until #1052 merges, this PR's diff will show #1030's commit too. **After #1052 lands on main**, I'll `git fetch origin main && git rebase origin/main` so this PR shows only the decode commit, then ping for merge.

## Verification
- `:wear:testDebugUnitTest` green — `WearStateDecodeTest` 8/8, `NodeSelectionTest` 5/5, 0 skipped/failed/errored.
- `:wear:compileDebugKotlin` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added phone connectivity indicator on the watch display
  * Transport controls now disable when phone is disconnected
  * New "Phone not connected" message appears during disconnection

* **Improvements**
  * Connectivity status automatically refreshes when returning to the playback screen
  * Enhanced visual feedback for disabled transport controls

* **Tests**
  * Added comprehensive test coverage for connectivity and state handling

<!-- end of auto-generated comment: release notes by coderabbit.ai -->