### PR TITLE
feat(wear): CMD_SEEK so the circular scrubber can scrub (#1031)

### DIFF
--- a/core-playback/src/main/kotlin/in/jphe/storyvox/playback/wear/PhoneWearBridge.kt
+++ b/core-playback/src/main/kotlin/in/jphe/storyvox/playback/wear/PhoneWearBridge.kt
@@ -77,6 +77,10 @@ class PhoneWearBridge @Inject constructor(
                 CMD_PREV_CH -> controller.previousChapter()
                 CMD_SLEEP_15 -> controller.startSleepTimer(SleepTimerMode.Duration(15))
                 CMD_SLEEP_OFF -> controller.cancelSleepTimer()
+                // Issue #1031 — the circular scrubber sends a target position
+                // (ms) in the message payload. A malformed/absent payload
+                // decodes to null and is ignored (no blind seek-to-zero).
+                CMD_SEEK -> SeekPayload.decode(event.data)?.let { controller.seekToPositionMs(it) }
             }
         }
     }
@@ -92,5 +96,12 @@ class PhoneWearBridge @Inject constructor(
         const val CMD_PREV_CH = "/playback/cmd/prevCh"
         const val CMD_SLEEP_15 = "/playback/cmd/sleep15"
         const val CMD_SLEEP_OFF = "/playback/cmd/sleepOff"
+
+        /**
+         * Issue #1031 — scrub from the wrist. Unlike the payload-less
+         * transport commands above, this message carries an 8-byte
+         * [SeekPayload] (absolute target position in ms).
+         */
+        const val CMD_SEEK = "/playback/cmd/seek"
     }
 }

--- a/core-playback/src/main/kotlin/in/jphe/storyvox/playback/wear/SeekPayload.kt
+++ b/core-playback/src/main/kotlin/in/jphe/storyvox/playback/wear/SeekPayload.kt
@@ -1,0 +1,49 @@
+package `in`.jphe.storyvox.playback.wear
+
+import java.nio.ByteBuffer
+
+/**
+ * Issue #1031 — wire format for the wear↔phone `CMD_SEEK` message.
+ *
+ * Shared by both bridges so the encode (watch, [in.jphe.storyvox.wear.playback.WearPlaybackBridge])
+ * and decode (phone, [PhoneWearBridge]) sides can never drift apart. The
+ * payload is an absolute position in **milliseconds on the media-time axis** —
+ * the same currency the seekbar-tap path already speaks via
+ * [in.jphe.storyvox.playback.PlaybackController.seekToPositionMs]. The watch
+ * owns the fraction→ms conversion (it has `durationEstimateMs` in its synced
+ * [in.jphe.storyvox.playback.PlaybackState]); the phone just seeks.
+ *
+ * Encoding is a fixed 8-byte big-endian Long. The fixed width doubles as a
+ * validation check: anything that isn't exactly 8 bytes (including the `null`
+ * MessageClient delivers for the payload-less CMD_* messages) decodes to
+ * `null`, which the phone bridge ignores rather than crashes on.
+ */
+object SeekPayload {
+
+    private const val SIZE_BYTES = 8
+
+    /** Pack [positionMs] into an 8-byte big-endian payload. */
+    fun encode(positionMs: Long): ByteArray =
+        ByteBuffer.allocate(SIZE_BYTES).putLong(positionMs).array()
+
+    /**
+     * Decode an 8-byte big-endian payload back to a position in ms, or `null`
+     * if the payload is absent or malformed (wrong length).
+     */
+    fun decode(payload: ByteArray?): Long? {
+        if (payload == null || payload.size != SIZE_BYTES) return null
+        return ByteBuffer.wrap(payload).long
+    }
+
+    /**
+     * Convert a 0..1 ring [fraction] to an absolute position in ms against the
+     * chapter's [durationMs]. Fractions are clamped; an unknown duration
+     * (`<= 0`, before the first state sync) targets position 0 rather than
+     * dividing by a zero rail.
+     */
+    fun fromFraction(fraction: Float, durationMs: Long): Long {
+        if (durationMs <= 0L) return 0L
+        val clamped = fraction.coerceIn(0f, 1f)
+        return (clamped * durationMs).toLong()
+    }
+}

--- a/core-playback/src/test/kotlin/in/jphe/storyvox/playback/wear/SeekPayloadTest.kt
+++ b/core-playback/src/test/kotlin/in/jphe/storyvox/playback/wear/SeekPayloadTest.kt
@@ -1,0 +1,66 @@
+package `in`.jphe.storyvox.playback.wear
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Test
+
+/**
+ * Issue #1031 — the watch's circular scrubber sends a CMD_SEEK message with a
+ * target position payload; the phone decodes it. [SeekPayload] is the shared
+ * wire format so the encode (watch) and decode (phone) sides can never drift.
+ *
+ * The payload is an absolute position in milliseconds on the media-time axis
+ * (mirrors the seekbar-tap path which already thinks in ms — see
+ * [in.jphe.storyvox.playback.PlaybackController.seekToPositionMs]).
+ */
+class SeekPayloadTest {
+
+    @Test fun `round-trips a positive position`() {
+        val bytes = SeekPayload.encode(123_456L)
+        assertEquals(123_456L, SeekPayload.decode(bytes))
+    }
+
+    @Test fun `round-trips zero`() {
+        assertEquals(0L, SeekPayload.decode(SeekPayload.encode(0L)))
+    }
+
+    @Test fun `round-trips a large position past Int range`() {
+        // ~25 days in ms — comfortably past Int.MAX_VALUE, proving the wire
+        // format carries a full 64-bit Long, not a truncated Int.
+        val big = 2_200_000_000L
+        assertEquals(big, SeekPayload.decode(SeekPayload.encode(big)))
+    }
+
+    @Test fun `encodes to exactly 8 bytes (big-endian Long)`() {
+        assertEquals(8, SeekPayload.encode(1L).size)
+    }
+
+    @Test fun `decode returns null for null payload`() {
+        // MessageClient delivers null when a message carries no data (every
+        // existing CMD_* sends null). A stray null on the seek path must not
+        // crash the phone bridge — it's simply ignored.
+        assertNull(SeekPayload.decode(null))
+    }
+
+    @Test fun `decode returns null for wrong-length payload`() {
+        assertNull(SeekPayload.decode(byteArrayOf(1, 2, 3)))
+        assertNull(SeekPayload.decode(ByteArray(0)))
+    }
+
+    @Test fun `fromFraction maps mid-ring to half the duration`() {
+        // The ring reports a 0..1 fraction; the watch converts to ms using the
+        // synced durationEstimateMs before sending.
+        assertEquals(300_000L, SeekPayload.fromFraction(0.5f, durationMs = 600_000L))
+    }
+
+    @Test fun `fromFraction clamps out-of-range fractions`() {
+        assertEquals(0L, SeekPayload.fromFraction(-0.2f, durationMs = 600_000L))
+        assertEquals(600_000L, SeekPayload.fromFraction(1.4f, durationMs = 600_000L))
+    }
+
+    @Test fun `fromFraction is zero when duration unknown`() {
+        // Before the first state sync the watch has durationEstimateMs == 0;
+        // a scrub then targets position 0 rather than dividing by zero.
+        assertEquals(0L, SeekPayload.fromFraction(0.5f, durationMs = 0L))
+    }
+}

--- a/wear/src/main/kotlin/in/jphe/storyvox/wear/components/CircularScrubber.kt
+++ b/wear/src/main/kotlin/in/jphe/storyvox/wear/components/CircularScrubber.kt
@@ -1,5 +1,6 @@
 package `in`.jphe.storyvox.wear.components
 
+import androidx.compose.foundation.gestures.detectTapGestures
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.padding
@@ -8,11 +9,14 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import androidx.wear.compose.material.CircularProgressIndicator
 import `in`.jphe.storyvox.wear.theme.BrassPrimary
 import `in`.jphe.storyvox.wear.theme.BrassRingTrack
+import kotlin.math.atan2
 
 /**
  * Circular brass scrubber for round Wear faces.
@@ -22,16 +26,20 @@ import `in`.jphe.storyvox.wear.theme.BrassRingTrack
  * brass reads at a glance from the wrist; ring track is the warm-dark outline
  * variant so the unfilled portion still has presence.
  *
- * The touch-to-scrub overlay isn't implemented in v1 — wiring scrub commands
- * back through `WearPlaybackBridge` needs a `CMD_SEEK` path on the bridge that
- * doesn't exist yet. Filed as a follow-up; for now the ring is read-only.
- * Touching the ring is reserved (no-op) so we don't accidentally swallow a
- * swipe-to-dismiss gesture before the seek protocol lands.
+ * Touch-to-scrub (#1031): when [onScrub] is supplied, tapping a point on the
+ * ring seeks there. We use **tap** rather than drag on purpose — a drag
+ * detector would compete with Wear's edge swipe-to-dismiss system gesture
+ * (the hazard the original v1 kdoc warned about). A tap is a discrete down-up
+ * with no drag, so the dismiss swipe still passes through untouched. The tap
+ * point's clockwise angle from 12-o'clock (where the progress arc starts,
+ * `startAngle = 270f`) maps to a 0f..1f fraction. When [onScrub] is null the
+ * ring stays display-only, exactly as before.
  *
  * @param progress 0f..1f scrub position, typically from
  *   [in.jphe.storyvox.playback.scrubProgress].
  * @param indeterminate when true (buffering), animates a sweep around the ring
  *   instead of a frozen progress arc — matches the phone's buffering spinner.
+ * @param onScrub invoked with the tapped 0f..1f fraction; null = read-only.
  */
 @Composable
 fun CircularScrubber(
@@ -39,9 +47,19 @@ fun CircularScrubber(
     modifier: Modifier = Modifier,
     indeterminate: Boolean = false,
     strokeWidth: Dp = 6.dp,
+    onScrub: ((fraction: Float) -> Unit)? = null,
     content: @Composable () -> Unit,
 ) {
-    Box(modifier = modifier, contentAlignment = Alignment.Center) {
+    val scrubModifier = if (onScrub != null) {
+        Modifier.pointerInput(Unit) {
+            detectTapGestures { offset ->
+                onScrub(tapFraction(offset, size.width.toFloat(), size.height.toFloat()))
+            }
+        }
+    } else {
+        Modifier
+    }
+    Box(modifier = modifier.then(scrubModifier), contentAlignment = Alignment.Center) {
         if (indeterminate) {
             CircularProgressIndicator(
                 modifier = Modifier.fillMaxSize(),
@@ -71,4 +89,23 @@ fun CircularScrubber(
             content()
         }
     }
+}
+
+/**
+ * Issue #1031 — map a tap at [offset] inside a [width]×[height] box to a
+ * 0f..1f ring fraction. 0f is 12-o'clock (where the progress arc starts,
+ * `startAngle = 270f`); the fraction grows clockwise. Pure geometry, no
+ * Compose state, so it's unit-testable on the JVM.
+ *
+ * `atan2(dx, -dy)` is the clockwise angle from the upward vertical: dx points
+ * right, -dy points up, so a point directly above center → 0, directly right →
+ * +π/2, etc. We fold negative angles into 0..2π then normalize by 2π.
+ */
+internal fun tapFraction(offset: Offset, width: Float, height: Float): Float {
+    val dx = offset.x - width / 2f
+    val dy = offset.y - height / 2f
+    val twoPi = (2.0 * Math.PI).toFloat()
+    var angle = atan2(dx, -dy) // clockwise from 12-o'clock, range (-π, π]
+    if (angle < 0f) angle += twoPi
+    return (angle / twoPi).coerceIn(0f, 1f)
 }

--- a/wear/src/main/kotlin/in/jphe/storyvox/wear/playback/WearPlaybackBridge.kt
+++ b/wear/src/main/kotlin/in/jphe/storyvox/wear/playback/WearPlaybackBridge.kt
@@ -8,6 +8,7 @@ import com.google.android.gms.wearable.DataMapItem
 import com.google.android.gms.wearable.Wearable
 import `in`.jphe.storyvox.playback.PlaybackState
 import `in`.jphe.storyvox.playback.wear.PhoneWearBridge
+import `in`.jphe.storyvox.playback.wear.SeekPayload
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.SupervisorJob
@@ -95,12 +96,32 @@ class WearPlaybackBridge(private val context: Context) : DataClient.OnDataChange
     }
 
     /**
-     * Send a transport command, returning the outcome and updating [connected]
-     * from what we learned. A successful send is the strongest evidence a node
-     * is reachable; a disconnected/failed send flips [connected] to `false` so
-     * the UI greys the controls immediately.
+     * Send a payload-less transport command (play/pause/skip/...), returning the
+     * outcome and updating [connected] from what we learned.
      */
-    suspend fun send(path: String): SendResult {
+    suspend fun send(path: String): SendResult = dispatch(path, null)
+
+    /**
+     * Issue #1031 — scrub from the wrist. Converts the 0..1 ring [fraction] to
+     * an absolute position in ms against [durationMs] (the synced
+     * `durationEstimateMs`) and sends it as a [SeekPayload] on
+     * [PhoneWearBridge.CMD_SEEK]. Unknown-duration handling lives in
+     * [SeekPayload.fromFraction] (targets 0), so this never divides by a zero
+     * rail. Shares [dispatch] with [send] so a scrub-while-disconnected updates
+     * [connected] and surfaces the same "Phone not connected" hint.
+     */
+    suspend fun sendSeek(fraction: Float, durationMs: Long): SendResult {
+        val positionMs = SeekPayload.fromFraction(fraction, durationMs)
+        return dispatch(PhoneWearBridge.CMD_SEEK, SeekPayload.encode(positionMs))
+    }
+
+    /**
+     * Single send path shared by every command. A successful send is the
+     * strongest evidence a node is reachable; a disconnected/failed send flips
+     * [connected] to `false` so the UI greys the controls immediately. The only
+     * difference between a transport tap and a seek is the [payload].
+     */
+    private suspend fun dispatch(path: String, payload: ByteArray?): SendResult {
         val nodes = runCatching { connectedPhoneNodes() }.getOrNull()
         val target = nodes?.let { NodeSelection.preferredTarget(it) }
         if (target == null) {
@@ -108,7 +129,7 @@ class WearPlaybackBridge(private val context: Context) : DataClient.OnDataChange
             return SendResult.Disconnected
         }
         return runCatching {
-            messageClient.sendMessage(target.id, path, null).await()
+            messageClient.sendMessage(target.id, path, payload).await()
             _connected.value = true
             SendResult.Sent
         }.getOrElse {

--- a/wear/src/main/kotlin/in/jphe/storyvox/wear/screens/NowPlayingScreen.kt
+++ b/wear/src/main/kotlin/in/jphe/storyvox/wear/screens/NowPlayingScreen.kt
@@ -88,6 +88,8 @@ fun NowPlayingScreen(bridge: WearPlaybackBridge) {
         },
         onSkipBack = { scope.launch { bridge.send(PhoneWearBridge.CMD_SKIP_BACK) } },
         onSkipForward = { scope.launch { bridge.send(PhoneWearBridge.CMD_SKIP_FWD) } },
+        // #1031 — tap the ring to scrub; duration comes from the synced state.
+        onScrub = { fraction -> scope.launch { bridge.sendSeek(fraction, state.durationEstimateMs) } },
     )
 }
 
@@ -102,6 +104,7 @@ internal fun NowPlayingContent(
     onPlayPause: () -> Unit,
     onSkipBack: () -> Unit,
     onSkipForward: () -> Unit,
+    onScrub: ((fraction: Float) -> Unit)? = null,
 ) {
     val configuration = LocalConfiguration.current
     val isRound = configuration.isScreenRound
@@ -125,6 +128,7 @@ internal fun NowPlayingContent(
                     onPlayPause = onPlayPause,
                     onSkipBack = onSkipBack,
                     onSkipForward = onSkipForward,
+                    onScrub = onScrub,
                 )
             } else {
                 SquareNowPlaying(
@@ -148,6 +152,7 @@ private fun RoundNowPlaying(
     onPlayPause: () -> Unit,
     onSkipBack: () -> Unit,
     onSkipForward: () -> Unit,
+    onScrub: ((fraction: Float) -> Unit)? = null,
 ) {
     Column(
         modifier = Modifier
@@ -159,6 +164,7 @@ private fun RoundNowPlaying(
         CircularScrubber(
             progress = progress,
             indeterminate = state.isBuffering,
+            onScrub = onScrub,
             modifier = Modifier
                 .size(116.dp)
                 .aspectRatio(1f),

--- a/wear/src/test/kotlin/in/jphe/storyvox/wear/components/CircularScrubberTest.kt
+++ b/wear/src/test/kotlin/in/jphe/storyvox/wear/components/CircularScrubberTest.kt
@@ -1,0 +1,51 @@
+package `in`.jphe.storyvox.wear.components
+
+import androidx.compose.ui.geometry.Offset
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+/**
+ * Issue #1031 — geometry behind tap-to-scrub on the circular ring.
+ *
+ * [tapFraction] maps a tap inside the ring box to a 0f..1f fraction, with 0f at
+ * 12-o'clock (where the progress arc starts, `startAngle = 270f`) and growing
+ * clockwise. `Offset` is a pure value class, so these run on the JVM without
+ * Robolectric — same seam pattern as [in.jphe.storyvox.wear.playback.NodeSelectionTest].
+ *
+ * Box is 200×200, so center is (100, 100).
+ */
+class CircularScrubberTest {
+
+    private val size = 200f
+    private val tol = 0.001f
+
+    @Test fun `tap at 12 o'clock (top) is fraction 0`() {
+        assertEquals(0f, tapFraction(Offset(100f, 0f), size, size), tol)
+    }
+
+    @Test fun `tap at 3 o'clock (right) is a quarter`() {
+        assertEquals(0.25f, tapFraction(Offset(200f, 100f), size, size), tol)
+    }
+
+    @Test fun `tap at 6 o'clock (bottom) is a half`() {
+        assertEquals(0.5f, tapFraction(Offset(100f, 200f), size, size), tol)
+    }
+
+    @Test fun `tap at 9 o'clock (left) is three quarters`() {
+        assertEquals(0.75f, tapFraction(Offset(0f, 100f), size, size), tol)
+    }
+
+    @Test fun `fraction grows clockwise — 1 30 position is between top and right`() {
+        // A point up-and-to-the-right (between 12 and 3 o'clock) must land
+        // strictly between 0 and 0.25, proving the sweep direction is clockwise.
+        val f = tapFraction(Offset(150f, 50f), size, size)
+        assertEquals(0.125f, f, tol)
+    }
+
+    @Test fun `result is always within 0 to 1`() {
+        // Even a tap at the exact center (degenerate, zero radius) stays in range
+        // rather than producing NaN/out-of-bounds.
+        val f = tapFraction(Offset(100f, 100f), size, size)
+        assertEquals(true, f in 0f..1f)
+    }
+}


### PR DESCRIPTION
## What

The Wear circular brass scrubber was **display-only** — the seek protocol was never built (the original v1 `CircularScrubber` kdoc filed it as a follow-up that was never actually filed). This wires a `CMD_SEEK` path through the wear↔phone bridge so a tap on the ring jumps playback to that position.

## How

- **`SeekPayload` (core-playback)** — shared 8-byte big-endian `Long` codec. Lives in `:core-playback` (which `:wear` depends on) so the watch *encode* and phone *decode* sides reference one source of truth and can never drift. `fromFraction(fraction, durationMs)` converts a 0..1 ring fraction → absolute ms (clamped; unknown duration → 0, never a divide-by-zero rail).
- **`PhoneWearBridge`** — new `CMD_SEEK` path decodes `event.data` via `SeekPayload` and calls `controller.seekToPositionMs(...)` — the same proven currency the seekbar-tap path already uses. A `null`/malformed payload decodes to `null` and is ignored (no blind seek-to-zero), matching how the existing payload-less `CMD_*` messages behave.
- **`WearPlaybackBridge.sendSeek(fraction, durationMs)`** — encodes + sends the payload. Shares a unified private `dispatch(path, payload)` with `send(path)`, so a scrub-while-disconnected updates the `connected` state and surfaces the same "Phone not connected" hint introduced in #1030 (this PR is rebased on top of #1052).
- **`CircularScrubber`** — optional `onScrub` overlay using `detectTapGestures` (**tap, not drag**) so Wear's edge swipe-to-dismiss system gesture still passes through untouched — the exact hazard the original kdoc warned about. `tapFraction` maps the tap's clockwise angle from 12-o'clock (where the arc starts, `startAngle = 270f`) to a fraction. When `onScrub` is null the ring stays read-only.
- **`NowPlayingScreen`** — wires the round ring's `onScrub` to `sendSeek` using the synced `durationEstimateMs`.

## Tests

- `SeekPayloadTest` — **9 tests**: encode/decode round-trip (incl. zero, past-Int range), 8-byte width, null/wrong-length → null, fraction→ms (mid/clamp/unknown-duration). (The acceptance criterion's required round-trip test.)
- `CircularScrubberTest` — **6 tests**: tap geometry at all four cardinal directions + clockwise-growth + in-range guard.
- `NodeSelectionTest` (pre-existing, #1030) still green — confirms the shared `dispatch` refactor didn't regress connectivity.

Closes #1031

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added tap-to-scrub functionality to the watch's circular progress ring—users can now tap anywhere on the ring to seek to that position during playback.
  * Implemented seek messaging between watch and phone devices with secure payload encoding/decoding.

* **Tests**
  * Added tests for seek payload encoding/decoding behavior.
  * Added tests for circular scrubber tap gesture mapping.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->