### PR TITLE
fix(playback): per-key write lease stops PCM-cache corruption race (#1034)

### DIFF
--- a/core-playback/src/main/kotlin/in/jphe/storyvox/playback/cache/ChapterRenderJob.kt
+++ b/core-playback/src/main/kotlin/in/jphe/storyvox/playback/cache/ChapterRenderJob.kt
@@ -168,12 +168,6 @@ class ChapterRenderJob @AssistedInject constructor(
             return Result.success()
         }
 
-        // 6. Wipe stale partial — same abandon-and-restart policy as
-        // the foreground streaming-tee path (PR-D).
-        if (pcmCache.metaFileFor(cacheKey).exists()) {
-            pcmCache.delete(cacheKey)
-        }
-
         // 7. setForeground for long renders — render can run 30+ min on
         // Piper-high on the Tab A7 Lite. runCatching guards against
         // foreground-service start failures on locked devices /
@@ -202,24 +196,52 @@ class ChapterRenderJob @AssistedInject constructor(
         EngineSampleRateCache.refreshFromEngine()
 
         // 9. Generate sentences + write to cache.
+        // Issue #1034 — acquire the single-writer lease for this key as a
+        // WORKER. If the foreground streaming-tee already owns this exact
+        // key (the user is actively playing this chapter at 1.0×/1.0× with
+        // the empty dict), [openLease] refuses (null) and we skip: the
+        // foreground is rendering it, and racing it would corrupt the
+        // shared `.pcm`. The lease also subsumes the old stale-partial
+        // delete (delete + appender-open happen atomically under the
+        // cache's key guard, so a delete never races a concurrent open).
         val sentences = chunker.chunk(chapter.text, detectLocale(chapter.text))
         val sampleRate = sampleRateFor(voice)
-        val appender = pcmCache.appender(cacheKey, sampleRate = sampleRate)
+        val lease = pcmCache.openLease(
+            cacheKey,
+            sampleRate = sampleRate,
+            owner = PcmCache.LeaseOwner.WORKER,
+        )
+        if (lease == null) {
+            Log.i(
+                LOG_TAG,
+                "pcm-cache PRERENDER-SKIP-FOREGROUND-OWNS chapterId=$chapterId " +
+                    "base=${cacheKey.fileBaseName().take(12)}",
+            )
+            return Result.success()
+        }
         try {
             for (s in sentences) {
                 if (isStopped) {
-                    appender.abandon()
+                    lease.abandon()
                     Log.i(LOG_TAG, "pcm-cache PRERENDER-CANCELLED chapterId=$chapterId")
                     return Result.failure()
+                }
+                // #1034 — the foreground may have evicted us mid-render
+                // (user started playing this chapter). The lease's writes
+                // are already inert in that case, but bail promptly so we
+                // don't burn synth cycles producing PCM nobody will store.
+                if (!lease.isActive) {
+                    Log.i(LOG_TAG, "pcm-cache PRERENDER-PREEMPTED chapterId=$chapterId")
+                    return Result.success()
                 }
                 val pcm = engineMutex.mutex.withLock {
                     if (isStopped) return@withLock null
                     generateAudioPCM(voice, s.text)
                 } ?: continue
                 val pauseMs = trailingPauseMs(s.text)
-                runCatching { appender.appendSentence(s, pcm, pauseMs) }
+                runCatching { lease.appendSentence(s, pcm, pauseMs) }
                     .onFailure {
-                        appender.abandon()
+                        lease.abandon()
                         Log.w(LOG_TAG, "pcm-cache PRERENDER-FAIL chapterId=$chapterId", it)
                         return Result.retry()
                     }
@@ -229,9 +251,9 @@ class ChapterRenderJob @AssistedInject constructor(
             // Issue #581 — `complete()` (was `finalize()`) avoids the
             // Object.finalize() shadow that produced uncaught
             // IllegalStateExceptions on the FinalizerDaemon thread.
-            runCatching { appender.complete() }
+            runCatching { lease.complete() }
                 .onFailure {
-                    appender.abandon()
+                    lease.abandon()
                     Log.w(LOG_TAG, "pcm-cache PRERENDER-FAIL chapterId=$chapterId complete", it)
                     return Result.retry()
                 }
@@ -245,7 +267,7 @@ class ChapterRenderJob @AssistedInject constructor(
             )
             return Result.success()
         } catch (t: Throwable) {
-            appender.abandon()
+            lease.abandon()
             Log.w(LOG_TAG, "pcm-cache PRERENDER-FAIL chapterId=$chapterId threw", t)
             return if (isStopped) Result.failure() else Result.retry()
         }

--- a/core-playback/src/main/kotlin/in/jphe/storyvox/playback/cache/PcmCache.kt
+++ b/core-playback/src/main/kotlin/in/jphe/storyvox/playback/cache/PcmCache.kt
@@ -2,6 +2,7 @@ package `in`.jphe.storyvox.playback.cache
 
 import android.content.Context
 import dagger.hilt.android.qualifiers.ApplicationContext
+import `in`.jphe.storyvox.playback.tts.Sentence
 import java.io.File
 import javax.inject.Inject
 import javax.inject.Singleton
@@ -23,15 +24,27 @@ import kotlinx.coroutines.withContext
  * Concurrency:
  *  - Reads ([isComplete], [pcmFileFor], [indexFileFor], [totalSizeBytes]) are
  *    safe to call from any thread.
- *  - Writes ([appender], [evictTo], [delete]) are also thread-safe
- *    individually, but at most one [PcmAppender] should be open per
- *    key at a time. PR-D enforces that mutual exclusion at the
- *    streaming-source / render-job boundary; PR-C trusts the caller.
+ *  - Writes ([evictTo], [delete]) are also thread-safe individually.
+ *  - **At most one writer per key.** Issue #1034: the cross-boundary
+ *    mutual exclusion the original kdoc promised ("PR-D enforces that
+ *    mutual exclusion at the streaming-source / render-job boundary")
+ *    was never actually implemented — the background [ChapterRenderJob]
+ *    and the foreground streaming-tee could open two [PcmAppender]s on
+ *    the SAME key and interleave append-mode writes (or one's [delete]
+ *    could unlink files under the other's open stream), finalizing a
+ *    corrupt entry. It is now enforced HERE: [openLease] hands out a
+ *    single-owner [PcmAppenderLease] per [PcmCacheKey.fileBaseName].
+ *    A second open for a live key is arbitrated — the FOREGROUND wins
+ *    over a background WORKER, a WORKER is refused while the FOREGROUND
+ *    owns the key (see [LeaseOwner]). The stale-partial delete + appender
+ *    open happen together under the short [keyGuard] mutex, so a delete
+ *    never races an open. The lock is NOT held across [appendSentence]
+ *    or synthesis, so it can't deadlock with [EngineMutex] (which is
+ *    taken per-sentence inside the producer loop).
  *
- * No integration in this PR — `EnginePlayer` doesn't reference this
- * class. PR-D wires the [appender] into `EngineStreamingSource`'s
- * producer loop; PR-E adds a `CacheFileSource` that reads via
- * [pcmFileFor] + [indexFileFor].
+ * The raw [appender] entry point remains for tests and the M4B export
+ * path that owns its key exclusively; callers that share keys across the
+ * worker/foreground boundary MUST go through [openLease].
  */
 @Singleton
 class PcmCache(
@@ -41,6 +54,29 @@ class PcmCache(
     init {
         rootDir.mkdirs()
     }
+
+    /**
+     * Issue #1034 — guards [liveLeases] and the brief "delete stale +
+     * open appender" / "evict + register" critical sections in [openLease]
+     * and [releaseLease].
+     *
+     * A plain JVM monitor, NOT a coroutine [kotlinx.coroutines.sync.Mutex],
+     * on purpose: every critical section is short, non-suspending file work
+     * (a few `File.delete` syscalls + a `FileOutputStream` open), so a
+     * monitor is correct and — crucially — lets both the suspend caller
+     * ([ChapterRenderJob.doWork]) and the NON-suspend caller
+     * ([`in`.jphe.storyvox.playback.tts.source.EngineStreamingSource.finalizeCache],
+     * which runs on the consumer thread) drive a lease uniformly without
+     * rippling `suspend` through the `PcmSource` interface. The lock is
+     * NEVER held across [PcmAppender.appendSentence] or engine synthesis, so
+     * it cannot deadlock with [EngineMutex] (taken per-sentence inside the
+     * producer loop, after the lease is already open).
+     */
+    private val keyGuard = Any()
+
+    /** basename ([PcmCacheKey.fileBaseName]) -> the live lease currently
+     *  authorized to write that key. Guarded by [keyGuard]. */
+    private val liveLeases = mutableMapOf<String, PcmAppenderLease>()
 
     /** Hilt entry point — anchors the cache root at
      *  `${context.cacheDir}/pcm-cache/`. The primary constructor takes a
@@ -88,6 +124,95 @@ class PcmCache(
         speedHundredths = key.speedHundredths,
         pitchHundredths = key.pitchHundredths,
     )
+
+    /**
+     * Who is asking for a write lease on a key. Drives [openLease]'s
+     * arbitration when two callers contend for the same key (issue #1034).
+     */
+    enum class LeaseOwner {
+        /** Live playback's streaming-tee. Always wins — playback must
+         *  never be blocked behind, or corrupted by, a background render. */
+        FOREGROUND,
+
+        /** Background [ChapterRenderJob] pre-render. Yields to the
+         *  foreground; refused while the foreground holds the key. */
+        WORKER,
+    }
+
+    /**
+     * Acquire the single writer lease for [key] (issue #1034).
+     *
+     * Atomically (under [keyGuard]): resolves contention with any
+     * already-live lease, wipes a stale partial if we're starting fresh,
+     * opens the [PcmAppender], and registers the new owner. Returns the
+     * [PcmAppenderLease] to write through, or `null` if this caller is
+     * not allowed to write the key right now.
+     *
+     * Arbitration:
+     *  - Key free → granted to either owner.
+     *  - Held by [LeaseOwner.WORKER], requested by [LeaseOwner.FOREGROUND]
+     *    → the worker is **evicted** (its lease goes inactive and its
+     *    open stream is closed + partial wiped) and the foreground is
+     *    granted. Foreground always wins.
+     *  - Held by [LeaseOwner.FOREGROUND], requested by [LeaseOwner.WORKER]
+     *    → **refused** (`null`). The worker should skip — the foreground
+     *    is already producing this exact key.
+     *  - Held by the same owner type → refused (`null`). Defensive: the
+     *    WorkManager `KEEP` policy and the single foreground pipeline make
+     *    this unreachable in practice, but refusing keeps the invariant
+     *    "one live writer per key" total.
+     *
+     * The stale-partial delete only runs when we open fresh (not when we
+     * evict a worker mid-stream — there the evicted appender's [abandon]
+     * already removes the partial). [keyGuard] is released before the
+     * caller writes a single sentence, so synthesis + [EngineMutex] never
+     * nest under it.
+     */
+    fun openLease(
+        key: PcmCacheKey,
+        sampleRate: Int,
+        owner: LeaseOwner,
+    ): PcmAppenderLease? = synchronized(keyGuard) {
+        val basename = key.fileBaseName()
+        val existing = liveLeases[basename]
+        if (existing != null) {
+            // Foreground wins over a worker; everything else is refused.
+            if (!(owner == LeaseOwner.FOREGROUND && existing.owner == LeaseOwner.WORKER)) {
+                return@synchronized null
+            }
+            // Evict the worker: deactivate the lease + close its stream and
+            // wipe its partial so it can't leave half-written bytes behind.
+            existing.deactivateAndAbandon()
+            liveLeases.remove(basename)
+        }
+
+        // Fresh open: same abandon-and-restart policy as before — a leftover
+        // partial (meta present, idx absent) is wiped before opening so the
+        // appender starts at byte 0 rather than resuming onto stale bytes.
+        if (metaFileFor(key).exists() && !isComplete(key)) {
+            runCatching { pcmFileFor(key).delete() }
+            runCatching { metaFileFor(key).delete() }
+            runCatching { File(rootDir, "$basename$INDEX_SUFFIX$TMP_SUFFIX").delete() }
+        }
+
+        val lease = PcmAppenderLease(
+            owner = owner,
+            basename = basename,
+            appender = appender(key, sampleRate),
+            cache = this,
+        )
+        liveLeases[basename] = lease
+        lease
+    }
+
+    /** Release [lease] from [liveLeases] if it's still the registered owner
+     *  of its key. Called by the lease itself on complete/abandon. A lease
+     *  that was already evicted (replaced in the map) is a no-op here. */
+    internal fun releaseLease(lease: PcmAppenderLease) = synchronized(keyGuard) {
+        if (liveLeases[lease.basename] === lease) {
+            liveLeases.remove(lease.basename)
+        }
+    }
 
     /** Touch the pcm file's mtime — call on every successful play of
      *  a cached chapter so LRU eviction prefers genuinely-cold entries. */
@@ -218,5 +343,70 @@ class PcmCache(
         const val INDEX_SUFFIX = ".idx.json"
         const val META_SUFFIX = ".meta.json"
         const val TMP_SUFFIX = ".tmp"
+    }
+}
+
+/**
+ * Single-owner write lease over one [PcmCacheKey]'s cache entry (issue
+ * #1034). Obtained from [PcmCache.openLease]; wraps the underlying
+ * [PcmAppender] and gates every mutation on still owning the key.
+ *
+ * The whole point: a lease that has been **evicted** (the foreground took
+ * the key from a worker) flips [isActive] to `false`, so the loser's
+ * remaining [appendSentence] / [complete] calls become no-ops instead of
+ * corrupting the winner's entry. The loser never has to learn it lost —
+ * it just stops being able to touch the file.
+ *
+ * Not itself thread-safe per instance (mirrors [PcmAppender]): one owner
+ * holds the only reference and writes sentences in order. The cross-owner
+ * safety lives in [PcmCache.openLease]'s [PcmCache.keyGuard] arbitration,
+ * not here.
+ */
+class PcmAppenderLease internal constructor(
+    val owner: PcmCache.LeaseOwner,
+    internal val basename: String,
+    private val appender: PcmAppender,
+    private val cache: PcmCache,
+) {
+    @Volatile
+    private var active: Boolean = true
+
+    /** True while this lease still owns its key. Flips to `false` once the
+     *  lease is completed, abandoned, or evicted by a higher-priority owner. */
+    val isActive: Boolean get() = active
+
+    /** Append one sentence's PCM — no-op if the lease is no longer active
+     *  (evicted/closed). @see [PcmAppender.appendSentence]. */
+    fun appendSentence(sentence: Sentence, pcm: ByteArray, trailingSilenceMs: Int) {
+        if (!active) return
+        appender.appendSentence(sentence, pcm, trailingSilenceMs)
+    }
+
+    /** Finalize the entry + release the key. No-op (releases nothing it
+     *  doesn't own) if already inactive. @see [PcmAppender.complete]. */
+    fun complete() {
+        if (!active) return
+        active = false
+        appender.complete()
+        cache.releaseLease(this)
+    }
+
+    /** Discard the partial entry + release the key. Idempotent.
+     *  @see [PcmAppender.abandon]. */
+    fun abandon() {
+        if (!active) return
+        active = false
+        appender.abandon()
+        cache.releaseLease(this)
+    }
+
+    /** Internal eviction path used by [PcmCache.openLease] when a
+     *  higher-priority owner takes the key. Closes the underlying stream
+     *  and wipes the partial so no half-written bytes survive, but does
+     *  NOT call back into [PcmCache.releaseLease] — the caller already
+     *  holds [PcmCache.keyGuard] and is swapping the map entry itself. */
+    internal fun deactivateAndAbandon() {
+        active = false
+        appender.abandon()
     }
 }

--- a/core-playback/src/main/kotlin/in/jphe/storyvox/playback/tts/EnginePlayer.kt
+++ b/core-playback/src/main/kotlin/in/jphe/storyvox/playback/tts/EnginePlayer.kt
@@ -47,7 +47,7 @@ import `in`.jphe.storyvox.playback.SleepTimer
 import `in`.jphe.storyvox.playback.ThermalMonitor
 import `in`.jphe.storyvox.playback.TtsVolumeRamp
 import `in`.jphe.storyvox.playback.cache.EngineMutex
-import `in`.jphe.storyvox.playback.cache.PcmAppender
+import `in`.jphe.storyvox.playback.cache.PcmAppenderLease
 import `in`.jphe.storyvox.playback.cache.PcmCache
 import `in`.jphe.storyvox.playback.cache.PcmCacheKey
 import `in`.jphe.storyvox.playback.cache.PcmIndex
@@ -2545,22 +2545,30 @@ class EnginePlayer @AssistedInject constructor(
             // Cache miss (or hit-open failed) — streaming source +
             // tee appender path (PR-D). If a partial entry exists
             // from a prior killed render (meta.json on disk,
-            // idx.json absent), wipe it first; PR-D's resume policy
-            // is "abandon, restart".
+            // idx.json absent), it's wiped on lease-open; PR-D's
+            // resume policy is "abandon, restart".
             //
             // #866 — withContext(IO), not runBlocking: startPlaybackPipeline
-            // is now suspend, so the cache delete + appender open run on
+            // is now suspend, so the cache lease open runs on
             // Dispatchers.IO without parking Main. Pre-#866 this was a
             // runBlocking on Main and a slow flash filesystem could push
             // the delete+open to 50+ ms, dropping Compose frames on every
             // speed/seek/voice-swap rebuild.
-            val appender: PcmAppender? = cacheKey?.let { key ->
+            //
+            // #1034 — open the FOREGROUND single-writer lease (not a bare
+            // appender). This evicts any background ChapterRenderJob that
+            // was rendering the same key and blocks a worker that starts
+            // later, so the worker and this tee can never interleave
+            // append-mode writes / delete-under-open on the shared `.pcm`.
+            // The stale-partial wipe is now atomic with the open inside
+            // openLease (under the cache's key guard).
+            val appender: PcmAppenderLease? = cacheKey?.let { key ->
                 withContext(Dispatchers.IO) {
-                    if (pcmCache.metaFileFor(key).exists() && !pcmCache.isComplete(key)) {
-                        // Stale partial — wipe before opening fresh.
-                        pcmCache.delete(key)
-                    }
-                    pcmCache.appender(key, sampleRate = sampleRate)
+                    pcmCache.openLease(
+                        key,
+                        sampleRate = sampleRate,
+                        owner = PcmCache.LeaseOwner.FOREGROUND,
+                    )
                 }
             }
             cacheKey?.let { key ->
@@ -2578,7 +2586,7 @@ class EnginePlayer @AssistedInject constructor(
                 speed = currentSpeed,
                 pitch = currentPitch,
                 engineMutex = engineMutex,
-                cacheAppender = appender,
+                cacheLease = appender,
                 punctuationPauseMultiplier = currentPunctuationPauseMultiplier,
                 // #486 / #488 — TalkBack inter-sentence pad. Snapshot
                 // at pipeline-construction time; mid-listen slider

--- a/core-playback/src/main/kotlin/in/jphe/storyvox/playback/tts/source/EngineStreamingSource.kt
+++ b/core-playback/src/main/kotlin/in/jphe/storyvox/playback/tts/source/EngineStreamingSource.kt
@@ -3,6 +3,7 @@ package `in`.jphe.storyvox.playback.tts.source
 import android.os.Process as AndroidProcess
 import `in`.jphe.storyvox.playback.SentenceRange
 import `in`.jphe.storyvox.playback.cache.PcmAppender
+import `in`.jphe.storyvox.playback.cache.PcmAppenderLease
 import `in`.jphe.storyvox.playback.tts.Sentence
 import java.util.concurrent.Executors
 import java.util.concurrent.LinkedBlockingQueue
@@ -77,14 +78,23 @@ class EngineStreamingSource(
     /**
      * PR-D (#86) — optional write-through to the on-disk PCM cache. When
      * non-null, every sentence the producer generates is mirrored into
-     * this appender via [PcmAppender.appendSentence]. On [close] (which
+     * this lease via [PcmAppenderLease.appendSentence]. On [close] (which
      * fires on user pause + pipeline teardown, voice swap, and
-     * seek-induced restart) the appender is [PcmAppender.abandon]'d so
+     * seek-induced restart) the lease is [PcmAppenderLease.abandon]'d so
      * the partial files don't lie around looking like a complete cache.
      * On natural end-of-chapter (the consumer thread reaches the
      * END_PILL), the consumer calls [finalizeCache] which writes the
      * index sidecar and marks the cache complete for PR-E's
      * `CacheFileSource` to pick up on next play.
+     *
+     * Issue #1034 — this is a [PcmAppenderLease], not a bare
+     * [PcmAppender]: it is the FOREGROUND single-writer lease for the
+     * cache key, obtained from [`in`.jphe.storyvox.playback.cache.PcmCache.openLease].
+     * If a background [`in`.jphe.storyvox.playback.cache.ChapterRenderJob]
+     * was already rendering this key, opening the foreground lease evicted
+     * it; if the worker started afterward it is refused. Either way every
+     * tee write here goes through the lease, which no-ops if (defensively)
+     * the lease were ever evicted out from under the foreground.
      *
      * Null in tests that don't care about the cache, and in pre-cache
      * environments where the feature flag is off (PR-F gates).
@@ -95,7 +105,7 @@ class EngineStreamingSource(
      * Reassigning a constructor `val` parameter is a compile error in
      * Kotlin, hence the shadow.
      */
-    cacheAppender: PcmAppender? = null,
+    cacheLease: PcmAppenderLease? = null,
     private val punctuationPauseMultiplier: Float = 1f,
     /**
      * Accessibility scaffold Phase 2 (#486 / #488, v0.5.43) — extra
@@ -255,13 +265,13 @@ class EngineStreamingSource(
     private val headroomLock = Any()
 
     /**
-     * PR-D (#86) — mutable shadow of the constructor's `cacheAppender`
+     * PR-D (#86) — mutable shadow of the constructor's `cacheLease`
      * param so [seekToCharOffset] and [close] can null it out after
      * abandon. Volatile because the producer reads it on the dedicated
      * producer thread while [seekToCharOffset] / [close] runs on the
      * caller's thread.
      */
-    @Volatile private var cacheAppender: PcmAppender? = cacheAppender
+    @Volatile private var cacheAppender: PcmAppenderLease? = cacheLease
 
     private val _bufferHeadroomMs = MutableStateFlow(0L)
 

--- a/core-playback/src/test/kotlin/in/jphe/storyvox/playback/cache/PcmCacheLeaseTest.kt
+++ b/core-playback/src/test/kotlin/in/jphe/storyvox/playback/cache/PcmCacheLeaseTest.kt
@@ -1,0 +1,126 @@
+package `in`.jphe.storyvox.playback.cache
+
+import android.app.Application
+import `in`.jphe.storyvox.playback.tts.Sentence
+import kotlinx.coroutines.runBlocking
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.RuntimeEnvironment
+import org.robolectric.annotation.Config
+
+/**
+ * Issue #1034 — the cross-boundary mutual exclusion that [PcmCache]'s
+ * kdoc promised ("at most one PcmAppender open per key ... PR-D enforces
+ * that mutual exclusion at the streaming-source / render-job boundary")
+ * was never implemented. The background [ChapterRenderJob] and the
+ * foreground streaming-tee could open two appenders on the SAME cache key
+ * and interleave append-mode writes / delete files under each other's open
+ * stream, finalizing a corrupt entry.
+ *
+ * These tests pin the lease-based single-owner arbitration that closes the
+ * race: a key has at most one live writer; the foreground wins over a
+ * background worker; and a writer that lost the key (evicted, or refused at
+ * open time) cannot clobber the winner's entry.
+ */
+@RunWith(RobolectricTestRunner::class)
+@Config(application = Application::class)
+class PcmCacheLeaseTest {
+
+    private lateinit var context: Application
+    private lateinit var cache: PcmCache
+    private lateinit var config: PcmCacheConfig
+
+    @Before
+    fun setUp() {
+        context = RuntimeEnvironment.getApplication()
+        config = PcmCacheConfig(context)
+        cache = PcmCache(context, config)
+        cache.rootDirectory().listFiles()?.forEach { it.delete() }
+    }
+
+    @After
+    fun tearDown() {
+        cache.rootDirectory().listFiles()?.forEach { it.delete() }
+    }
+
+    private val key = PcmCacheKey("ch1", "cori", 100, 100, 1, 0)
+
+    private fun sentence() = Sentence(0, 0, 10, "Sentence.")
+
+    @Test
+    fun `worker is refused while the foreground holds the key`() = runBlocking {
+        val fg = cache.openLease(key, sampleRate = 22050, owner = PcmCache.LeaseOwner.FOREGROUND)
+        assertNotNull("foreground must acquire a free key", fg)
+
+        val worker = cache.openLease(key, sampleRate = 22050, owner = PcmCache.LeaseOwner.WORKER)
+        assertNull("worker must be refused while foreground owns the key", worker)
+
+        fg!!.abandon()
+    }
+
+    @Test
+    fun `foreground evicts a worker that already holds the key`() = runBlocking {
+        val worker = cache.openLease(key, sampleRate = 22050, owner = PcmCache.LeaseOwner.WORKER)
+        assertNotNull("worker acquires a free key", worker)
+
+        val fg = cache.openLease(key, sampleRate = 22050, owner = PcmCache.LeaseOwner.FOREGROUND)
+        assertNotNull("foreground must win the key from a worker", fg)
+
+        // The evicted worker lease is no longer active — its lifecycle calls
+        // must be inert so it can't corrupt the foreground entry.
+        assertFalse("worker lease must report inactive after eviction", worker!!.isActive)
+
+        fg!!.abandon()
+    }
+
+    @Test
+    fun `an evicted worker cannot clobber the foreground entry`() = runBlocking {
+        // Worker opens first and writes one sentence.
+        val worker = cache.openLease(key, sampleRate = 22050, owner = PcmCache.LeaseOwner.WORKER)!!
+        worker.appendSentence(sentence(), ByteArray(100) { 0x11 }, trailingSilenceMs = 0)
+
+        // Foreground takes over the key (foreground-wins) and renders the
+        // real entry to completion.
+        val fg = cache.openLease(key, sampleRate = 22050, owner = PcmCache.LeaseOwner.FOREGROUND)!!
+        fg.appendSentence(sentence(), ByteArray(200) { 0x22 }, trailingSilenceMs = 0)
+
+        // The evicted worker keeps trying to write + finalize (it doesn't
+        // know it lost). These must be no-ops, NOT writes to the shared file.
+        worker.appendSentence(sentence(), ByteArray(100) { 0x11 }, trailingSilenceMs = 0)
+        worker.complete()
+
+        // Foreground finalizes the genuine entry.
+        fg.complete()
+
+        assertTrue("foreground entry must be complete", cache.isComplete(key))
+        // The pcm must contain ONLY the foreground's bytes (200), never the
+        // worker's interleaved/garbage writes.
+        assertEquals(
+            "pcm must hold exactly the foreground's bytes, no worker interleave",
+            200L,
+            cache.pcmFileFor(key).length(),
+        )
+    }
+
+    @Test
+    fun `releasing the key lets the next owner acquire it`() = runBlocking {
+        val first = cache.openLease(key, sampleRate = 22050, owner = PcmCache.LeaseOwner.FOREGROUND)!!
+        first.appendSentence(sentence(), ByteArray(50), trailingSilenceMs = 0)
+        first.complete()
+
+        // After complete() the key is released — a worker may now re-acquire
+        // (e.g. to re-render after the entry was later deleted).
+        cache.delete(key)
+        val second = cache.openLease(key, sampleRate = 22050, owner = PcmCache.LeaseOwner.WORKER)
+        assertNotNull("a released key must be re-acquirable", second)
+        second!!.abandon()
+    }
+}

--- a/core-playback/src/test/kotlin/in/jphe/storyvox/playback/tts/source/EngineStreamingSourceCacheTeeTest.kt
+++ b/core-playback/src/test/kotlin/in/jphe/storyvox/playback/tts/source/EngineStreamingSourceCacheTeeTest.kt
@@ -78,7 +78,7 @@ class EngineStreamingSourceCacheTeeTest {
 
     @Test
     fun `tee writes one cache entry per sentence then finalize completes the cache`() = runBlocking {
-        val appender = cache.appender(key, sampleRate = 22050)
+        val appender = cache.openLease(key, sampleRate = 22050, owner = PcmCache.LeaseOwner.FOREGROUND)!!
         val source = EngineStreamingSource(
             sentences = sentences,
             startSentenceIndex = 0,
@@ -86,7 +86,7 @@ class EngineStreamingSourceCacheTeeTest {
             speed = 1f,
             pitch = 1f,
             engineMutex = Mutex(),
-            cacheAppender = appender,
+            cacheLease = appender,
         )
 
         // Drain the source — pull every sentence + the END_PILL. This
@@ -117,7 +117,7 @@ class EngineStreamingSourceCacheTeeTest {
 
     @Test
     fun `close abandons the in-progress cache (no index lands)`() = runBlocking {
-        val appender = cache.appender(key, sampleRate = 22050)
+        val appender = cache.openLease(key, sampleRate = 22050, owner = PcmCache.LeaseOwner.FOREGROUND)!!
         val source = EngineStreamingSource(
             sentences = sentences,
             startSentenceIndex = 0,
@@ -125,7 +125,7 @@ class EngineStreamingSourceCacheTeeTest {
             speed = 1f,
             pitch = 1f,
             engineMutex = Mutex(),
-            cacheAppender = appender,
+            cacheLease = appender,
         )
 
         // Pull two of three sentences so at least one tee fired.
@@ -143,7 +143,7 @@ class EngineStreamingSourceCacheTeeTest {
 
     @Test
     fun `seek abandons cache progress`() = runBlocking {
-        val appender = cache.appender(key, sampleRate = 22050)
+        val appender = cache.openLease(key, sampleRate = 22050, owner = PcmCache.LeaseOwner.FOREGROUND)!!
         val source = EngineStreamingSource(
             sentences = sentences,
             startSentenceIndex = 0,
@@ -151,7 +151,7 @@ class EngineStreamingSourceCacheTeeTest {
             speed = 1f,
             pitch = 1f,
             engineMutex = Mutex(),
-            cacheAppender = appender,
+            cacheLease = appender,
         )
         source.nextChunk()                // pull one sentence to ensure
                                           // a tee write hit disk before
@@ -176,7 +176,7 @@ class EngineStreamingSourceCacheTeeTest {
             speed = 1f,
             pitch = 1f,
             engineMutex = Mutex(),
-            cacheAppender = null,        // pre-PR-D behavior
+            cacheLease = null,        // pre-PR-D behavior
         )
         // Drain all three sentences.
         repeat(3) { source.nextChunk() }
@@ -190,7 +190,7 @@ class EngineStreamingSourceCacheTeeTest {
 
     @Test
     fun `finalize is idempotent — second call after finalize is a no-op`() = runBlocking {
-        val appender = cache.appender(key, sampleRate = 22050)
+        val appender = cache.openLease(key, sampleRate = 22050, owner = PcmCache.LeaseOwner.FOREGROUND)!!
         val source = EngineStreamingSource(
             sentences = sentences,
             startSentenceIndex = 0,
@@ -198,7 +198,7 @@ class EngineStreamingSourceCacheTeeTest {
             speed = 1f,
             pitch = 1f,
             engineMutex = Mutex(),
-            cacheAppender = appender,
+            cacheLease = appender,
         )
         // Drain.
         while (source.nextChunk() != null) Unit


### PR DESCRIPTION
## Problem (#1034 — data corruption)

The background `ChapterRenderJob` (WorkManager pre-render) and the foreground streaming-tee could open two `PcmAppender`s on the **same** cache key and:
- interleave append-mode writes on the same `.pcm` (in-memory byte index no longer matches disk), or
- one path's `delete()` unlinks files under the other's *open* `FileOutputStream`.

Either way a corrupt entry gets finalized (`.idx.json` written over garbled PCM). Next play reads `isComplete == true`, opens a `CacheFileSource` over bad offsets, and emits wrong/garbled audio for that chapter.

## Root cause (confirmed by reading source)

`PcmCache`'s own kdoc promised _"at most one `PcmAppender` open per key at a time. PR-D enforces that mutual exclusion at the streaming-source / render-job boundary"_ — **but that exclusion was never implemented; the class had no lock field at all.** The only guards present:
- `engineMutex` — serializes `generateAudioPCM` synth only, NOT `delete`/`appender`/`appendSentence`.
- WorkManager `ExistingWorkPolicy.KEEP` — worker-vs-worker dedup only, nothing about worker-vs-foreground.

The foreground key (`EnginePlayer.kt:2485`) and worker key (`ChapterRenderJob.kt:152`) are byte-identical for the common case (default 1.0×/1.0×, empty pronunciation dict). `fullPrerender = true` schedules even the currently-playing chapter, the cleanest reproducer.

## Fix — single-writer lease in the `@Singleton` PcmCache

- `PcmCache.openLease(key, sampleRate, owner)` hands out one `PcmAppenderLease` per `fileBaseName()`, arbitrated under a short JVM monitor (`keyGuard`). The stale-partial wipe + appender open happen **atomically** under that lock, so a `delete` never races an open.
- **Foreground wins**: a `FOREGROUND` open *evicts* a `WORKER` that holds the key (worker lease goes inactive, its stream is closed + partial wiped); a `WORKER` is *refused* (`null`) while the `FOREGROUND` owns the key. Playback is never blocked behind or corrupted by a background render.
- The lock is **never** held across `appendSentence` or engine synthesis → cannot deadlock with `engineMutex` (taken per-sentence inside the producer loop). A plain monitor (not a coroutine `Mutex`) lets both the suspend worker path and the non-suspend consumer-thread `finalizeCache` drive a lease without rippling `suspend` through `PcmSource`.
- An evicted/refused writer's `appendSentence`/`complete` become inert no-ops via the lease's `isActive` flag, so a loser can never clobber the winner's entry.

### Callers
- `ChapterRenderJob` → `WORKER` lease: skips with `Result.success()` if the foreground owns the key, bails promptly if evicted mid-render.
- `EnginePlayer` streaming-tee → `FOREGROUND` lease.
- `EngineStreamingSource` holds the lease instead of a bare appender (terminal `complete`/`abandon`/`appendSentence` unchanged in shape).
- The raw `appender()` entry point stays for tests and the exclusive-key M4B export path.

### Note on the issue's suggested direction
The issue sketched "hold the keyed mutex around the whole lifecycle (delete + open + all appendSentence + complete)." Holding one lock across the whole foreground lifecycle would mean holding it for the entire (~30-min) chapter playback — blocking the worker past its WorkManager window and risking a lock-ordering deadlock with `engineMutex`. This implements the **same invariant** ("one live writer per key; delete never under an open appender") via ownership + foreground-wins arbitration instead of a long-held lock.

## Tests — red→green verified

New `PcmCacheLeaseTest` (Robolectric, temp cacheDir):
- worker refused while foreground holds the key
- foreground evicts a worker that already holds the key
- an evicted worker cannot clobber the foreground entry (`.pcm` holds exactly the foreground's bytes, no interleave)
- a released key is re-acquirable

**Verified:** with the arbitration disabled, the two contract tests fail; with it, all 4 pass. The existing `EngineStreamingSourceCacheTeeTest` (5) and `PcmCacheTest` (10) stay green; full `:core-playback:testDebugUnitTest` is all-green; `:app:compileDebugKotlin` compiles.

Closes #1034