### PR TITLE
chore(#77): final URL sweep — storyvox.techempower.org → candela

### DIFF
--- a/docs/play-store-listing.md
+++ b/docs/play-store-listing.md
@@ -106,7 +106,7 @@ FEATURES
 • Free, GPL-3.0, ad-free, no tracking
 
 Candela is built by TechEmpower, a 501(c)(3) nonprofit. The source is
-open at github.com/techempower-org/storyvox. Privacy policy:
+open at github.com/techempower-org/candela. Privacy policy:
 candela.techempower.org/privacy/
 ```
 

--- a/docs/play-store-listing.md
+++ b/docs/play-store-listing.md
@@ -107,7 +107,7 @@ FEATURES
 
 Candela is built by TechEmpower, a 501(c)(3) nonprofit. The source is
 open at github.com/techempower-org/storyvox. Privacy policy:
-storyvox.techempower.org/privacy/
+candela.techempower.org/privacy/
 ```
 
 ---
@@ -259,7 +259,7 @@ library state, encrypted in transit, deletable by the user.
 
 ## Privacy policy URL
 
-`https://storyvox.techempower.org/privacy/`
+`https://candela.techempower.org/privacy/`
 
 The policy lives at `docs/privacy-policy.md`; Jekyll renders it at
 `/privacy/` via the `permalink: /privacy/` front-matter directive. Verify
@@ -271,7 +271,7 @@ the URL resolves before Play submission.
 
 - **Email:** _DRAFT — JP to fill in_ (`claude2@techempower.org` or
   `jp@jphein.com`)
-- **Website:** `https://storyvox.techempower.org`
+- **Website:** `https://candela.techempower.org`
 - **Phone:** Play Console requires a phone number on the developer profile,
   not on the listing. JP's call which number to use (TechEmpower's main, or
   a personal number).
@@ -326,7 +326,7 @@ incrementally post-launch without re-submitting.
 
 Things to wire into the Candela UI as part of v1.0:
 
-- **Settings → About** → "Privacy Policy" link → `https://storyvox.techempower.org/privacy/`
+- **Settings → About** → "Privacy Policy" link → `https://candela.techempower.org/privacy/`
 - **Settings → About** → "Open Source Licenses" (already present, verify it lists every dep)
 - **Settings → About** → "Rate Candela" → `market://details?id=org.techempower.candela`
 - **Settings → About** → "What's New" — pull from the latest release notes

--- a/docs/play-store-policy-check.md
+++ b/docs/play-store-policy-check.md
@@ -292,7 +292,7 @@ are scoped to real workloads.
 - [ ] Release keystore generated (see `release-keystore.md`)
 - [ ] AAB built with the release keystore, verified with `apksigner verify --print-certs`
 - [ ] Play App Signing enrolled (upload key cert exported & uploaded)
-- [ ] Privacy policy live at `https://storyvox.techempower.org/privacy/`
+- [ ] Privacy policy live at `https://candela.techempower.org/privacy/`
 - [ ] Listing copy finalized (`play-store-listing.md`)
 - [ ] Graphics produced (icon, feature graphic, 4–8 phone, 4–8 tablet)
 - [ ] Data Safety form completed per section 4 above
@@ -302,7 +302,7 @@ are scoped to real workloads.
 - [ ] Emergency Help disclaimer added ("US/Canada numbers; use your local
       emergency number elsewhere") — section 3
 - [ ] Settings → About → Privacy Policy link added (links to
-      `storyvox.techempower.org/privacy/`)
+      `candela.techempower.org/privacy/`)
 - [ ] Settings → About → Report objectionable content (mailto) added —
       section 1
 - [ ] Settings → About → Open Source Licenses verified complete

--- a/feature/src/main/kotlin/in/jphe/storyvox/feature/settings/AccessibilitySettingsScreen.kt
+++ b/feature/src/main/kotlin/in/jphe/storyvox/feature/settings/AccessibilitySettingsScreen.kt
@@ -273,12 +273,12 @@ fun AccessibilitySettingsScreen(
                 // the verified false positives from the static sweep,
                 // and the partnership-outreach plan. Lives at
                 // /docs/accessibility.md in the repo, hosted at the
-                // GitHub Pages site (storyvox.techempower.org).
+                // GitHub Pages site (candela.techempower.org).
                 SettingsLinkRow(
                     title = stringResource(R.string.settings_accessibility_learn_more_title),
                     subtitle = stringResource(R.string.settings_accessibility_learn_more_subtitle),
                     onClick = {
-                        uriHandler.openUri("https://storyvox.techempower.org/accessibility")
+                        uriHandler.openUri("https://candela.techempower.org/accessibility")
                     },
                 )
             }

--- a/source-librivox/src/main/kotlin/in/jphe/storyvox/source/librivox/LibriVoxSource.kt
+++ b/source-librivox/src/main/kotlin/in/jphe/storyvox/source/librivox/LibriVoxSource.kt
@@ -364,7 +364,7 @@ internal class LibriVoxSource @Inject constructor(
         internal fun bookIdFromFictionId(fictionId: String): String = fictionId.trim()
 
         const val USER_AGENT: String =
-            "storyvox-librivox/1.0 (+https://github.com/techempower-org/storyvox)"
+            "storyvox-librivox/1.0 (+https://github.com/techempower-org/candela)"
 
         /**
          * Sentinel prefixes used by [applyFilters] to smuggle the

--- a/source-librivox/src/main/kotlin/in/jphe/storyvox/source/librivox/net/LibriVoxApi.kt
+++ b/source-librivox/src/main/kotlin/in/jphe/storyvox/source/librivox/net/LibriVoxApi.kt
@@ -221,7 +221,7 @@ internal class LibriVoxApi @Inject constructor(
         const val PAGE_SIZE: Int = 50
 
         const val USER_AGENT: String =
-            "storyvox-librivox/1.0 (+https://github.com/techempower-org/storyvox)"
+            "storyvox-librivox/1.0 (+https://github.com/techempower-org/candela)"
     }
 }
 

--- a/source-librivox/src/test/kotlin/in/jphe/storyvox/source/librivox/LibriVoxSourceTest.kt
+++ b/source-librivox/src/test/kotlin/in/jphe/storyvox/source/librivox/LibriVoxSourceTest.kt
@@ -134,6 +134,6 @@ class LibriVoxSourceTest {
 
     @Test fun `user-agent identifies storyvox-librivox`() {
         assertTrue(LibriVoxSource.USER_AGENT.contains("storyvox-librivox"))
-        assertTrue(LibriVoxSource.USER_AGENT.contains("github.com/techempower-org/storyvox"))
+        assertTrue(LibriVoxSource.USER_AGENT.contains("github.com/techempower-org/candela"))
     }
 }


### PR DESCRIPTION
## What

The last sweep of `storyvox.techempower.org` / `techempower-org/storyvox` references → candela, so the Play privacy URL resolves as candela before ship (#77, before-ship blocker).

## Changes

**A. In-app (user-facing)**
- `AccessibilitySettingsScreen.kt` — the "Learn more" link (+ its comment) now opens `https://candela.techempower.org/accessibility`. This was the only `openUri`/website/privacy link still on the old host (the rest of the app — `app/build.gradle.kts` repo + applicationId — already point at candela).

**B. Play Store docs**
- `docs/play-store-listing.md` — privacy URL ×3 (lines 110, 262, 329) + Website (274) → `candela.techempower.org`.
- `docs/play-store-policy-check.md` — privacy URL ×2 (295, 305) → `candela.techempower.org`.

**C. Code stragglers**
- `source-librivox` LibriVox User-Agent repo URL in `LibriVoxApi.kt` + `LibriVoxSource.kt` → `github.com/techempower-org/candela`, plus the `LibriVoxSourceTest` assertion that checks it. (All three are live — the UA for the LibriVox source — not historical.)

## Left intentionally

- `CHANGELOG.md` historical entries (per scope).
- `storyvox://` deep-link scheme (unchanged app identity).
- The `storyvox-librivox/1.0` product token in the UA (app identity, not a repo URL — only the repo URL portion changed).

## Verify

- `:feature` compiles (BUILD SUCCESSFUL).
- `source-librivox` unit tests green — **22** (LibriVoxSourceTest 15, LibriVoxApiTest 7, 0 failures), including the updated UA assertion.
- Post-sweep grep confirms **zero** `storyvox.techempower.org` (outside CHANGELOG) and **zero** `techempower-org/storyvox` in `app`/`core-*`/`source-*`/`feature`.

> Note for reviewer: `docs/play-store-listing.md:108` still reads "open at github.com/techempower-org/storyvox" in the listing body copy — a stale repo URL outside the enumerated scope (B was the privacy/Website URLs). Flagged to team-lead separately; easy to fold in if wanted.

Refs #77

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated privacy policy and accessibility documentation links to point to the new documentation domain.

* **Chores**
  * Updated internal repository references to reflect domain migration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->