### PR TITLE
fix(source): pin Slack/Telegram/Matrix doRequest to Dispatchers.IO (#1061)

### DIFF
--- a/source-matrix/src/main/kotlin/in/jphe/storyvox/source/matrix/net/MatrixApi.kt
+++ b/source-matrix/src/main/kotlin/in/jphe/storyvox/source/matrix/net/MatrixApi.kt
@@ -4,6 +4,8 @@ import `in`.jphe.storyvox.data.source.model.FictionResult
 import `in`.jphe.storyvox.source.matrix.config.MatrixConfig
 import `in`.jphe.storyvox.source.matrix.config.MatrixConfigState
 import `in`.jphe.storyvox.source.matrix.config.MatrixDefaults
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
 import kotlinx.serialization.json.Json
 import okhttp3.HttpUrl.Companion.toHttpUrl
 import okhttp3.OkHttpClient
@@ -181,7 +183,7 @@ internal class MatrixApi @Inject constructor(
 
     // ─── transport ────────────────────────────────────────────────────
 
-    private inline fun <reified T> getJson(url: String, state: MatrixConfigState): FictionResult<T> =
+    private suspend inline fun <reified T> getJson(url: String, state: MatrixConfigState): FictionResult<T> =
         when (val raw = doRequest(url, state)) {
             is FictionResult.Success -> try {
                 FictionResult.Success(json.decodeFromString<T>(raw.value))
@@ -196,12 +198,19 @@ internal class MatrixApi @Inject constructor(
      * failure mapping. Token + base URL come from [state] (a fresh
      * snapshot per call) so a Settings change applies on the next
      * request without process restart.
+     *
+     * Issue #585 — wrapped in [withContext]`(Dispatchers.IO)`, mirroring
+     * `DiscordApi.doRequest`: the suspend caller's dispatcher (often
+     * `Dispatchers.Main.immediate` via a Compose ViewModel scope) is
+     * inherited without an explicit pin, and the underlying OkHttp
+     * `execute()` blocks on DNS / TCP / TLS — fatal
+     * `NetworkOnMainThreadException`.
      */
-    private fun doRequest(
+    private suspend fun doRequest(
         url: String,
         state: MatrixConfigState,
-    ): FictionResult<String> {
-        return try {
+    ): FictionResult<String> = withContext(Dispatchers.IO) {
+        try {
             val request = Request.Builder()
                 .url(url)
                 // Standard Bearer-token scheme per the Matrix spec.

--- a/source-slack/src/main/kotlin/in/jphe/storyvox/source/slack/net/SlackApi.kt
+++ b/source-slack/src/main/kotlin/in/jphe/storyvox/source/slack/net/SlackApi.kt
@@ -4,6 +4,8 @@ import `in`.jphe.storyvox.data.source.model.FictionResult
 import `in`.jphe.storyvox.source.slack.config.SlackConfig
 import `in`.jphe.storyvox.source.slack.config.SlackConfigState
 import `in`.jphe.storyvox.source.slack.config.SlackDefaults
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
 import kotlinx.serialization.json.Json
 import okhttp3.HttpUrl.Companion.toHttpUrl
 import okhttp3.OkHttpClient
@@ -149,7 +151,7 @@ internal class SlackApi @Inject constructor(
 
     // ─── transport ────────────────────────────────────────────────────
 
-    private inline fun <reified T> getJson(url: String, state: SlackConfigState): FictionResult<T> =
+    private suspend inline fun <reified T> getJson(url: String, state: SlackConfigState): FictionResult<T> =
         when (val raw = doRequest(url, state)) {
             is FictionResult.Success -> try {
                 val parsed = json.decodeFromString<T>(raw.value)
@@ -205,12 +207,19 @@ internal class SlackApi @Inject constructor(
      * Single GET with Slack's required headers + structured failure
      * mapping. Token comes from [state] (a fresh snapshot per call)
      * so a Settings change applies on the next request.
+     *
+     * Issue #585 — wrapped in [withContext]`(Dispatchers.IO)`, mirroring
+     * `DiscordApi.doRequest`: the suspend caller's dispatcher (often
+     * `Dispatchers.Main.immediate` via a Compose ViewModel scope) is
+     * inherited without an explicit pin, and the underlying OkHttp
+     * `execute()` blocks on DNS / TCP / TLS — fatal
+     * `NetworkOnMainThreadException`.
      */
-    private fun doRequest(
+    private suspend fun doRequest(
         url: String,
         state: SlackConfigState,
-    ): FictionResult<String> {
-        return try {
+    ): FictionResult<String> = withContext(Dispatchers.IO) {
+        try {
             val request = Request.Builder()
                 .url(url)
                 // `Bearer <token>` is Slack's documented modern auth

--- a/source-telegram/src/main/kotlin/in/jphe/storyvox/source/telegram/net/TelegramApi.kt
+++ b/source-telegram/src/main/kotlin/in/jphe/storyvox/source/telegram/net/TelegramApi.kt
@@ -4,6 +4,8 @@ import `in`.jphe.storyvox.data.source.model.FictionResult
 import `in`.jphe.storyvox.source.telegram.config.TelegramConfig
 import `in`.jphe.storyvox.source.telegram.config.TelegramConfigState
 import `in`.jphe.storyvox.source.telegram.config.TelegramDefaults
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
 import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.JsonElement
 import okhttp3.OkHttpClient
@@ -123,7 +125,7 @@ internal class TelegramApi @Inject constructor(
 
     // ─── transport ────────────────────────────────────────────────────
 
-    private inline fun <reified T> getJson(url: String, state: TelegramConfigState): FictionResult<T> =
+    private suspend inline fun <reified T> getJson(url: String, state: TelegramConfigState): FictionResult<T> =
         when (val raw = doRequest(url, state)) {
             is FictionResult.Success -> try {
                 // Unwrap the {ok, result} envelope.
@@ -173,12 +175,19 @@ internal class TelegramApi @Inject constructor(
      * Single GET with Telegram's required headers + structured
      * failure mapping. Token is in the URL path (per Bot API
      * convention) so no Authorization header.
+     *
+     * Issue #585 — wrapped in [withContext]`(Dispatchers.IO)`, mirroring
+     * `DiscordApi.doRequest`: the suspend caller's dispatcher (often
+     * `Dispatchers.Main.immediate` via a Compose ViewModel scope) is
+     * inherited without an explicit pin, and the underlying OkHttp
+     * `execute()` blocks on DNS / TCP / TLS — fatal
+     * `NetworkOnMainThreadException`.
      */
-    private fun doRequest(
+    private suspend fun doRequest(
         url: String,
         @Suppress("UNUSED_PARAMETER") state: TelegramConfigState,
-    ): FictionResult<String> {
-        return try {
+    ): FictionResult<String> = withContext(Dispatchers.IO) {
+        try {
             val request = Request.Builder()
                 .url(url)
                 .header("Accept", "application/json")


### PR DESCRIPTION
## Summary

`SlackApi`, `TelegramApi`, and `MatrixApi` `doRequest` ran OkHttp's **blocking** `client.newCall(request).execute()` on whatever dispatcher the suspend caller provided. From a Compose ViewModel scope (`Dispatchers.Main.immediate`), this throws **`NetworkOnMainThreadException`** and crashes Browse/Detail for those sources.

This is the **exact bug Issue #585 already fixed for `DiscordApi`** (and `ArxivApi.getRaw`) — the IO-pin was never propagated to the three sibling clients written from the same template. Confirmation: `grep -rn "Dispatchers\|withContext\|flowOn"` returned **NONE** in `src/main` of all three modules.

Fixes #1061.

## Fix (mirrors #585 exactly)

For each of the three clients:
- Make `doRequest` `suspend` and wrap its body in `withContext(Dispatchers.IO)`.
- Make the `getJson` that calls it `suspend inline` (same as `DiscordApi.getJson`).
- Add the `#585` kdoc paragraph explaining the dispatcher-inheritance trap.

All public methods (`authTest`/`listConversations`/`listMessages`/`userInfo`, `getMe`/`getUpdates`/`getChat`, `whoami`/`listJoinedRooms`/`getRoomName`/`getRoomTopic`/`listMessages`/`getDisplayName`) already funnel through `getJson` from `suspend` context, so **no call sites change**. Error-mapping and JSON-parsing behavior is untouched.

Telegram keeps `@Suppress("UNUSED_PARAMETER") state` — its token is in the URL path, so the param stays genuinely unused (removing the suppression would be an unrelated change).

## Verification

This is a **runtime-only** bug: `NetworkOnMainThreadException` is thrown by Android's main `Looper` guard, which doesn't exist on the JVM test runtime — so a JVM unit test cannot reproduce it (the same reason #585 shipped without one). The honest gates are:

- `./gradlew :source-slack:compileDebugKotlin :source-telegram:compileDebugKotlin :source-matrix:compileDebugKotlin` → **BUILD SUCCESSFUL**
- `./gradlew :source-slack:testDebugUnitTest :source-telegram:testDebugUnitTest :source-matrix:testDebugUnitTest` → **all green** (existing error-mapping/parsing suites preserved)
- **Build APK** is the real gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)