### PR TITLE
fix(source-wikisource): natural-sort subpages so multi-chapter works play in order (#1060)

### DIFF
--- a/source-wikisource/src/main/kotlin/in/jphe/storyvox/source/wikisource/net/WikisourceApi.kt
+++ b/source-wikisource/src/main/kotlin/in/jphe/storyvox/source/wikisource/net/WikisourceApi.kt
@@ -122,11 +122,17 @@ internal class WikisourceApi @Inject constructor(
      * work at `War_and_Peace` with chapters at `War_and_Peace/Book_One`,
      * `War_and_Peace/Book_Two`, etc.
      *
-     * Returns the subpage titles in the order MediaWiki returns them
-     * (alphabetical by title, which happens to be reading order for
-     * well-named works that pad with leading zeros or use Book_One /
-     * Book_Two text). Single-page works return an empty list and the
-     * caller falls back to heading-based splitting on the parent page.
+     * MediaWiki `list=allpages` returns titles in **codepoint
+     * (lexicographic) order**, which is NOT reading order for the
+     * dominant en.wikisource convention of bare chapter numbers
+     * (`/Chapter_1`, `/Chapter_10`, `/Chapter_2`) — lexicographic puts
+     * `Chapter_10` before `Chapter_2`. We apply [naturalSubpageOrder]
+     * here so both callers — index assignment in
+     * `WikisourceSource.fictionDetail` and the index→title re-derivation
+     * in `chapterFromSubpage` — consume the same numerically-sorted list
+     * and can never disagree (issue #1060). Single-page works return an
+     * empty list and the caller falls back to heading-based splitting on
+     * the parent page.
      *
      * `apprefix` parameter expects the prefix relative to the
      * namespace; we pass the underscored title followed by `/`.
@@ -143,7 +149,7 @@ internal class WikisourceApi @Inject constructor(
         return getJson<WikisourceAllPagesResponse>(url).let { res ->
             when (res) {
                 is FictionResult.Success ->
-                    FictionResult.Success(res.value.query?.allpages.orEmpty().map { it.title })
+                    FictionResult.Success(naturalSubpageOrder(res.value.query?.allpages.orEmpty().map { it.title }))
                 is FictionResult.Failure -> res
             }
         }
@@ -244,6 +250,58 @@ internal class WikisourceApi @Inject constructor(
         const val USER_AGENT: String =
             "storyvox-wikisource/1.0 (https://github.com/jphein/storyvox; jp@jphein.com)"
     }
+}
+
+// ─── chapter ordering ──────────────────────────────────────────────────
+
+/**
+ * Natural (numeric-aware) order for Wikisource subpage titles (#1060).
+ *
+ * MediaWiki `list=allpages` hands back codepoint order, which sequences
+ * bare-numbered chapters wrong: `Chapter_1, Chapter_10, Chapter_11,
+ * Chapter_2, …`. For works that zero-pad (`Chapter_01`) the lexicographic
+ * order happens to be correct, but the dominant en.wikisource convention
+ * is the bare form, so ≥10-chapter books play out of reading order.
+ *
+ * We sort on each subpage's **leaf name** (the segment after the last
+ * `/`) so a parent title that itself ends in a number (e.g. `Henry_V`)
+ * doesn't leak into the per-chapter ordinal. The sort key is:
+ *
+ *  1. numbered leaves first (those with a trailing integer run), ordered
+ *     by that integer — this is the chapter ordinal;
+ *  2. then prose-named leaves (no trailing number — `Preface`,
+ *     `Appendix`), ordered lexicographically and grouped after the
+ *     numbered ones so a stray `/Preface` can't land mid-book.
+ *
+ * The trailing-number rule targets the ordinal precisely: leaves are
+ * shaped `Chapter_10`, `Part_2`, `Scene_12`, where the discriminating
+ * integer is always at the end. The sort is **stable**, so equal keys
+ * (and already-correct zero-padded works) keep their incoming order.
+ *
+ * Roman numerals and spelled-out numbers (`Chapter_XII`, `Book_One`)
+ * fall into the prose-named bucket and sort lexicographically — a known
+ * follow-up, called out in the issue, not regressed by this change.
+ */
+internal fun naturalSubpageOrder(titles: List<String>): List<String> {
+    val trailingNumber = Regex("""(\d+)\s*$""")
+    return titles.sortedWith(
+        compareBy(
+            // Stable partition: numbered leaves (key 0) before prose (key 1).
+            { title ->
+                val leaf = title.substringAfterLast('/')
+                if (trailingNumber.containsMatchIn(leaf)) 0 else 1
+            },
+            // Numbered leaves order by the trailing integer; prose leaves
+            // share Long.MAX_VALUE here and fall through to the tiebreak.
+            { title ->
+                val leaf = title.substringAfterLast('/')
+                trailingNumber.find(leaf)?.groupValues?.get(1)?.toLongOrNull() ?: Long.MAX_VALUE
+            },
+            // Lexicographic tiebreak — orders the prose bucket and keeps
+            // the whole sort deterministic for duplicate numeric keys.
+            { it },
+        ),
+    )
 }
 
 // ─── wire types ───────────────────────────────────────────────────────

--- a/source-wikisource/src/test/kotlin/in/jphe/storyvox/source/wikisource/WikisourceSourceTest.kt
+++ b/source-wikisource/src/test/kotlin/in/jphe/storyvox/source/wikisource/WikisourceSourceTest.kt
@@ -13,6 +13,7 @@ import `in`.jphe.storyvox.source.wikisource.net.WikisourceAllPagesResponse
 import `in`.jphe.storyvox.source.wikisource.net.WikisourceCategoryMember
 import `in`.jphe.storyvox.source.wikisource.net.WikisourceCategoryQuery
 import `in`.jphe.storyvox.source.wikisource.net.WikisourceCategoryQueryResponse
+import `in`.jphe.storyvox.source.wikisource.net.naturalSubpageOrder
 import kotlinx.serialization.json.Json
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
@@ -94,9 +95,9 @@ class WikisourceSourceTest {
         // War_and_Peace is the canonical multi-volume example called
         // out in the issue. The wire shape is
         // `query.allpages: [{pageid, ns, title}]` with the prefix-
-        // matched parent included in every title. We rely on
-        // alphabetical ordering by MediaWiki for chapter-order
-        // approximation; verify the parse preserves that order.
+        // matched parent included in every title. Verify the parse
+        // extracts the titles cleanly; chapter ordering is applied
+        // separately by `naturalSubpageOrder` (see #1060).
         val payload = """
             {
               "batchcomplete": "",
@@ -126,6 +127,106 @@ class WikisourceSourceTest {
         assertEquals(
             "Book Two",
             subpageDisplayName(parentTitle = "War_and_Peace", subpageTitle = titles[1].replace(' ', '_')),
+        )
+    }
+
+    // ─── 2b. Natural (numeric-aware) chapter ordering (#1060) ─────────
+
+    @Test
+    fun `naturalSubpageOrder sorts bare-number chapters numerically not lexically`() {
+        // MediaWiki list=allpages returns codepoint order, which puts
+        // Chapter_10/11/12 before Chapter_2 for non-zero-padded works
+        // (the dominant en.wikisource convention). Feed the input in the
+        // alphabetical order the API would deliver and assert the output
+        // is reading order: 1, 2, 3, 10, 11.
+        val alphabetical = listOf(
+            "War_and_Peace/Chapter_1",
+            "War_and_Peace/Chapter_10",
+            "War_and_Peace/Chapter_11",
+            "War_and_Peace/Chapter_2",
+            "War_and_Peace/Chapter_3",
+        )
+        val ordered = naturalSubpageOrder(alphabetical)
+        assertEquals(
+            listOf(
+                "War_and_Peace/Chapter_1",
+                "War_and_Peace/Chapter_2",
+                "War_and_Peace/Chapter_3",
+                "War_and_Peace/Chapter_10",
+                "War_and_Peace/Chapter_11",
+            ),
+            ordered,
+        )
+    }
+
+    @Test
+    fun `naturalSubpageOrder is stable for already-correct zero-padded works`() {
+        // Zero-padded works alphabetize correctly by luck. The sort must
+        // not perturb them — same numeric key order is preserved.
+        val padded = listOf(
+            "Book/Chapter_01",
+            "Book/Chapter_02",
+            "Book/Chapter_03",
+        )
+        assertEquals(padded, naturalSubpageOrder(padded))
+    }
+
+    @Test
+    fun `naturalSubpageOrder extracts the trailing number not a leading one`() {
+        // The chapter ordinal lives at the END of the leaf name. A leaf
+        // like "2nd_Part_3" must sort by 3 (the trailing run), and a
+        // title with no trailing digit must not be misread off an
+        // internal number.
+        val titles = listOf(
+            "Work/Section_3",
+            "Work/Section_1",
+            "Work/Section_2",
+        )
+        assertEquals(
+            listOf("Work/Section_1", "Work/Section_2", "Work/Section_3"),
+            naturalSubpageOrder(titles),
+        )
+    }
+
+    @Test
+    fun `naturalSubpageOrder keeps prose-named subpages lexicographic and after numbered ones`() {
+        // Prose-named subpages (no trailing number) fall back to
+        // lexicographic order and group together. Mixed with numbered
+        // chapters, the numbered ones lead (they carry an explicit
+        // ordinal) and prose pages follow in stable alpha order — so a
+        // "/Preface" doesn't jump into the middle of "/Chapter_N".
+        val mixed = listOf(
+            "Work/Chapter_10",
+            "Work/Preface",
+            "Work/Chapter_2",
+            "Work/Appendix",
+        )
+        assertEquals(
+            listOf(
+                "Work/Chapter_2",
+                "Work/Chapter_10",
+                "Work/Appendix",
+                "Work/Preface",
+            ),
+            naturalSubpageOrder(mixed),
+        )
+    }
+
+    @Test
+    fun `naturalSubpageOrder sorts on the leaf name not the shared parent prefix`() {
+        // The parent prefix is identical across every subpage, so the
+        // numeric key must come from the trailing leaf segment. A naive
+        // sort over the whole title would still work here, but a work
+        // whose PARENT title ends in a number (e.g. "Henry_V") must not
+        // leak that into the per-chapter ordinal.
+        val titles = listOf(
+            "Henry_V/Scene_1",
+            "Henry_V/Scene_12",
+            "Henry_V/Scene_2",
+        )
+        assertEquals(
+            listOf("Henry_V/Scene_1", "Henry_V/Scene_2", "Henry_V/Scene_12"),
+            naturalSubpageOrder(titles),
         )
     }
 


### PR DESCRIPTION
Fixes #1060.

## Problem
A Wikisource work split across `/Chapter_N` subpages plays chapters in **lexicographic order, not reading order**, whenever the chapter numbers aren't zero-padded. For `War_and_Peace/Chapter_1 … /Chapter_12` the listener hears `Chapter 1 → 10 → 11 → 12 → 2 → 3 → …`. Bare numbers are the dominant en.wikisource convention, so most full-length books past 9 chapters are unlistenable in sequence.

## Root cause (confirmed)
`WikisourceApi.subpages()` enumerates via MediaWiki `list=allpages&apprefix=Parent/`, which returns titles in **codepoint order**, untouched. `WikisourceSource.fictionDetail` then assigns `index = idx` straight over that order, and `chapterFromSubpage` re-derives the subpage by indexing back into the *same* unsorted list — so playback is internally **consistent with the wrong order**, which is why the misorder is silent (every chapter renders fine; they're just sequenced wrong).

## Fix
Apply a numeric-aware sort **once inside `WikisourceApi.subpages()`** (`naturalSubpageOrder`) so both callers — index assignment and the index→title re-derivation — consume the same corrected order from a single source of truth and can never drift apart.

Sort key, computed on each subpage's **leaf name** (segment after the last `/`, so a parent title ending in a number like `Henry_V` can't leak into the ordinal):
1. numbered leaves first, ordered by the **trailing** integer run (the chapter ordinal — `Chapter_10`, `Part_2`, `Scene_12`);
2. then prose-named leaves (no trailing number — `Preface`, `Appendix`), lexicographic, grouped after the numbered chapters so a stray `/Preface` can't land mid-book.

Stable sort → already-correct zero-padded works (`/Chapter_01`) are untouched. Roman-numeral / spelled-out forms (`Chapter_XII`, `Book_One`) fall into the prose bucket and sort lexicographically — a known follow-up the issue calls out, not regressed here.

## Distinct from
This is the discovery/ordering path. No overlap with the chapter-split or HTML-scrub paths.

## Tests
- 5 new `naturalSubpageOrder` cases: the `Chapter_1/2/10/11` regression (input fed in allpages-alphabetical order, asserts reading order out), zero-pad stability, trailing-number extraction, prose-named fallback ordering, and leaf-vs-parent-prefix.
- Corrected the stale kdoc on the existing allpages-parse test that pinned alphabetical order as "intended" (issue called this out at `WikisourceSourceTest.kt:93`).
- `:source-wikisource:testDebugUnitTest` → `WikisourceSourceTest` **tests=31, failures=0, errors=0** (26 prior + 5 new). BUILD SUCCESSFUL.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Subpages now sort numerically by their leaf name instead of lexicographically, with numbered chapters appearing before prose-named subpages.

* **Tests**
  * Added comprehensive unit tests for the new natural subpage ordering behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->