### PR TITLE
fix(source-plos): free-text Search filters to doc_type:full — kills ~6 dup cards/article (#1058)

### DIFF
--- a/source-plos/build.gradle.kts
+++ b/source-plos/build.gradle.kts
@@ -45,4 +45,7 @@ dependencies {
 
     testImplementation(libs.junit)
     testImplementation(libs.kotlinx.coroutines.test)
+    // #1058 — MockWebServer to pin the search request URL (assert the
+    // doc_type:full fq parity between searchRecent and searchQuery).
+    testImplementation("com.squareup.okhttp3:mockwebserver:4.12.0")
 }

--- a/source-plos/src/main/kotlin/in/jphe/storyvox/source/plos/net/PlosApi.kt
+++ b/source-plos/src/main/kotlin/in/jphe/storyvox/source/plos/net/PlosApi.kt
@@ -38,10 +38,15 @@ import kotlin.time.Duration.Companion.seconds
  * specific exceptions.
  */
 @Singleton
-internal class PlosApi @Inject constructor(
+internal open class PlosApi @Inject constructor(
     private val client: OkHttpClient,
 ) {
     private val json = Json { ignoreUnknownKeys = true; isLenient = true; coerceInputValues = true }
+
+    /** Solr search endpoint — `open` so JVM unit tests can point this
+     *  at a MockWebServer without restructuring the call sites (#1058,
+     *  same seam StandardEbooksApi.baseUrl uses). */
+    internal open val baseSearch: String = BASE_SEARCH
 
     // ─── search (Solr) ─────────────────────────────────────────────────
 
@@ -61,7 +66,7 @@ internal class PlosApi @Inject constructor(
         start: Int = 0,
         rows: Int = 50,
     ): FictionResult<PlosSearchResponse> {
-        val url = "$BASE_SEARCH" +
+        val url = baseSearch +
             "?q=" + URLEncoder.encode("*:*", "UTF-8") +
             // Issue #664 — PLOS retired the `journal_key` field; queries
             // against it return numFound=0 now. Two fq's together:
@@ -100,8 +105,18 @@ internal class PlosApi @Inject constructor(
         start: Int = 0,
         rows: Int = 50,
     ): FictionResult<PlosSearchResponse> {
-        val url = "$BASE_SEARCH" +
+        val url = baseSearch +
             "?q=" + URLEncoder.encode(term, "UTF-8") +
+            // Issue #1058 — parity with searchRecent's doc_type:full
+            // filter. PLOS's Solr indexes each article N+1 times (one
+            // full doc + one per section), so without this the free-
+            // text Search tab returned the parent article AND its 5+
+            // section fragments as duplicate cards with cryptic
+            // DOI-path titles (`/title`, `/abstract`, `/body`, ...).
+            // We deliberately do NOT pin a journal here — free-text
+            // search spans all PLOS journals, unlike the PLOS-ONE-only
+            // Popular landing.
+            "&fq=" + URLEncoder.encode("doc_type:full", "UTF-8") +
             "&start=$start" +
             "&rows=$rows" +
             "&fl=" + URLEncoder.encode(DEFAULT_FIELDS, "UTF-8") +
@@ -118,7 +133,7 @@ internal class PlosApi @Inject constructor(
      */
     suspend fun fetchByDoi(doi: String): FictionResult<PlosSearchResponse> {
         val q = "id:\"$doi\""
-        val url = "$BASE_SEARCH" +
+        val url = baseSearch +
             "?q=" + URLEncoder.encode(q, "UTF-8") +
             "&rows=1" +
             "&fl=" + URLEncoder.encode(DEFAULT_FIELDS, "UTF-8") +

--- a/source-plos/src/test/kotlin/in/jphe/storyvox/source/plos/net/PlosApiTest.kt
+++ b/source-plos/src/test/kotlin/in/jphe/storyvox/source/plos/net/PlosApiTest.kt
@@ -1,0 +1,100 @@
+package `in`.jphe.storyvox.source.plos.net
+
+import kotlinx.coroutines.test.runTest
+import okhttp3.OkHttpClient
+import okhttp3.mockwebserver.MockResponse
+import okhttp3.mockwebserver.MockWebServer
+import org.junit.After
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+import java.net.URLDecoder
+import java.util.concurrent.TimeUnit
+
+/**
+ * Issue #1058 — pins the Solr `fq=doc_type:full` filter on the
+ * free-text Search path.
+ *
+ * PLOS's Solr index stores each article N+1 times: one `doc_type:full`
+ * document plus one fragment doc per section (`/title`, `/abstract`,
+ * `/body`, `/references`). [PlosApi.searchRecent] (the Popular tab)
+ * drops the fragments with `&fq=doc_type:full`; before #1058
+ * [PlosApi.searchQuery] (the Search tab) omitted it, so a free-text
+ * query surfaced ~6 duplicate cards per real article.
+ *
+ * These tests assert the emitted request URL — not a parsed response —
+ * because the bug is purely in URL construction. The MockWebServer
+ * hands back an empty result set; we only care which query params the
+ * client sent.
+ */
+class PlosApiTest {
+
+    private lateinit var server: MockWebServer
+    private lateinit var http: OkHttpClient
+
+    @Before
+    fun setUp() {
+        server = MockWebServer()
+        server.start()
+        http = OkHttpClient.Builder()
+            .readTimeout(2, TimeUnit.SECONDS)
+            .build()
+    }
+
+    @After
+    fun tearDown() {
+        server.shutdown()
+    }
+
+    /** [PlosApi] pointed at the local MockWebServer. */
+    private fun apiPointingAtServer(): PlosApi =
+        object : PlosApi(http) {
+            override val baseSearch: String = server.url("/search").toString()
+        }
+
+    /** Empty-but-valid Solr response so [PlosApi] returns Success. */
+    private fun enqueueEmptyResponse() {
+        server.enqueue(
+            MockResponse()
+                .setHeader("Content-Type", "application/json")
+                .setBody("""{"response":{"numFound":0,"start":0,"docs":[]}}"""),
+        )
+    }
+
+    /** Decoded `fq` values from a recorded request's query string. */
+    private fun fqValuesOf(rawQuery: String): List<String> =
+        rawQuery.split('&')
+            .filter { it.startsWith("fq=") }
+            .map { URLDecoder.decode(it.removePrefix("fq="), "UTF-8") }
+
+    @Test
+    fun `searchQuery filters to doc_type full so section fragments are dropped`() = runTest {
+        enqueueEmptyResponse()
+
+        apiPointingAtServer().searchQuery(term = "climate", start = 0, rows = 50)
+
+        val recorded = server.takeRequest()
+        val query = recorded.requestUrl?.query.orEmpty()
+        val fqs = fqValuesOf(query)
+        assertTrue(
+            "free-text search must carry fq=doc_type:full to drop the " +
+                "per-section fragment docs (#1058); fq's were $fqs",
+            fqs.contains("doc_type:full"),
+        )
+    }
+
+    @Test
+    fun `searchRecent still carries doc_type full filter (parity guard)`() = runTest {
+        enqueueEmptyResponse()
+
+        apiPointingAtServer().searchRecent(start = 0, rows = 50)
+
+        val recorded = server.takeRequest()
+        val query = recorded.requestUrl?.query.orEmpty()
+        val fqs = fqValuesOf(query)
+        assertTrue(
+            "Popular path must keep fq=doc_type:full; fq's were $fqs",
+            fqs.contains("doc_type:full"),
+        )
+    }
+}


### PR DESCRIPTION
Closes #1058.

## Problem

Browse → PLOS → **Search** returned roughly **6 cards per real article**: the actual article plus 5 cryptic per-section fragment cards with DOI-path titles (`.../title`, `.../abstract`, `.../body`, `.../references`). The **Popular** tab was already correct.

## Root cause

PLOS's Solr index stores each article N+1 times: one `doc_type:full` document plus one fragment doc per section. `PlosApi.searchRecent` (the Popular path) drops the fragments with `&fq=doc_type:full` — and its kdoc documents exactly why. But the free-text `PlosApi.searchQuery` never got the same filter, so every query returned the full doc AND all its section fragments. Nothing downstream dedups them (`PlosSource.search` maps `docs` straight through).

## Fix

One-line parity change: add the same `&fq=doc_type:full` to `searchQuery` that `searchRecent` already uses. Matches the documented, curl-confirmed Solr contract.

No journal pin is added on this path — free-text search intentionally spans all PLOS journals, unlike the PLOS-ONE-only Popular landing.

## Test

`PlosApiTest` (new) points `PlosApi` at a `MockWebServer` via a new `open baseSearch` seam — mirroring the existing `StandardEbooksApi.baseUrl` pattern — and asserts the emitted **search request URL** carries `fq=doc_type:full`, with a parity guard that `searchRecent` still does too.

TDD verified: the `searchQuery` assertion **fails** with the fix line removed (the seam stays, so it's a real assertion failure, not a compile error) and **passes** with it restored. The `searchRecent` guard passes throughout.

- `:source-plos:testDebugUnitTest` → **13 green** (PlosSourceTest 11 unchanged + PlosApiTest 2 new), 0 failures, 0 errors.

## Files

- `source-plos/.../net/PlosApi.kt` — the `&fq=doc_type:full` parity line in `searchQuery`; `open class` + `open val baseSearch` test seam (all three search callers routed through it).
- `source-plos/.../net/PlosApiTest.kt` — new MockWebServer request-URL tests.
- `source-plos/build.gradle.kts` — `mockwebserver:4.12.0` test dependency (same version other source modules use).

🤖 Generated with [Claude Code](https://claude.com/claude-code)