### PR TITLE
fix(sync): guard settings field-stamp/baseline RMW with a mutex (#1024)

### DIFF
--- a/app/src/main/kotlin/in/jphe/storyvox/data/SettingsRepositoryUiImpl.kt
+++ b/app/src/main/kotlin/in/jphe/storyvox/data/SettingsRepositoryUiImpl.kt
@@ -88,6 +88,8 @@ import `in`.jphe.storyvox.source.mempalace.net.PalaceDaemonApi
 import `in`.jphe.storyvox.source.mempalace.net.PalaceDaemonResult
 import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
 import javax.inject.Inject
 import javax.inject.Singleton
 import kotlinx.coroutines.flow.Flow
@@ -1112,6 +1114,23 @@ class SettingsRepositoryUiImpl(
         kotlinx.coroutines.SupervisorJob() + pushDispatcher,
     )
     @Volatile private var pushJob: kotlinx.coroutines.Job? = null
+
+    /** Issue #1024 — serializes the per-key stamp / snapshot-baseline
+     *  read-modify-write so the two writers of [SYNC_FIELD_STAMPS_KEY] /
+     *  [SYNC_SNAPSHOT_BASELINE_KEY] can't interleave:
+     *  - Path A: a local UI setter → [stampSyncedWrite] → [reconcileFieldStamps],
+     *    running on whatever coroutine the setter was called from.
+     *  - Path B: a sync pull → [applyStamped], running inside the
+     *    [SyncCoordinator] per-domain mutex.
+     *  The coordinator mutex only serializes syncers against each other; it
+     *  does not touch Path A, which calls this repository directly from the
+     *  UI layer. Each individual `store.edit` is atomic, but the compound
+     *  read→read→write→write is not, so without this lock a write from one
+     *  path could land on a stale read from the other — corrupting the
+     *  baseline (#978 cross-device-clobber, just in a narrower window). This
+     *  mutex is fully local and `@Singleton`-scoped, so one instance guards
+     *  every caller. */
+    private val stampMutex = Mutex()
 
     /** Schedule (or reschedule) the debounced settings-domain push.
      *  Called from [stampSyncedWrite]. [SyncCoordinator.requestPush]
@@ -2826,23 +2845,29 @@ class SettingsRepositoryUiImpl(
      * would make it spuriously win the next merge).
      */
     override suspend fun applyStamped(snapshot: Map<String, String>, stamps: Map<String, Long>) {
-        applyValues(snapshot)
-        // Persist the incoming stamps for the applied keys, and rebase
-        // the diff baseline to the values we just wrote so the next
-        // LOCAL edit diffs against the merged state (not a stale one).
-        val existingStamps = readFieldStamps().toMutableMap()
-        val baseline = readSnapshotBaseline().toMutableMap()
-        for ((key, value) in snapshot) {
-            stamps[key]?.let { existingStamps[key] = it }
-            baseline[key] = value
+        stampMutex.withLock {
+            // Issue #1024 — the value-apply + stamp/baseline rebase runs as one
+            // unit under [stampMutex]. applyValues writes the settings values that
+            // reconcileFieldStamps' snapshot() reads, so locking it together with
+            // the stamp/baseline write keeps Path A from snapshotting a half-
+            // applied state or rebasing the baseline off a stale read.
+            applyValues(snapshot)
+            // Persist the incoming stamps for the applied keys, and rebase
+            // the diff baseline to the values we just wrote so the next
+            // LOCAL edit diffs against the merged state (not a stale one).
+            val existingStamps = readFieldStamps().toMutableMap()
+            val baseline = readSnapshotBaseline().toMutableMap()
+            for ((key, value) in snapshot) {
+                stamps[key]?.let { existingStamps[key] = it }
+                baseline[key] = value
+            }
+            writeStampsAndBaseline(existingStamps, baseline)
+            // Advance the legacy global stamp to the newest applied field
+            // (still the v1 row updatedAt + the per-key fallback). Do NOT
+            // call stampSyncedWrite — that would re-stamp everything `now`
+            // and schedule a redundant push of state we just received.
+            stamps.values.maxOrNull()?.let { stampLocalWrite(it) }
         }
-        writeFieldStamps(existingStamps)
-        writeSnapshotBaseline(baseline)
-        // Advance the legacy global stamp to the newest applied field
-        // (still the v1 row updatedAt + the per-key fallback). Do NOT
-        // call stampSyncedWrite — that would re-stamp everything `now`
-        // and schedule a redundant push of state we just received.
-        stamps.values.maxOrNull()?.let { stampLocalWrite(it) }
     }
 
     /** Shared value-application body for [apply] / [applyStamped].
@@ -2955,8 +2980,13 @@ class SettingsRepositoryUiImpl(
     }
 
     /** Recompute the per-key stamp map from a fresh snapshot vs the
-     *  persisted baseline, bumping changed/new keys to [now]. */
-    private suspend fun reconcileFieldStamps(now: Long) {
+     *  persisted baseline, bumping changed/new keys to [now].
+     *
+     *  Issue #1024 — the whole read-modify-write runs under [stampMutex] so
+     *  it can't interleave with [applyStamped] (Path B), and the two writes
+     *  are folded into one [writeStampsAndBaseline] edit so the stamp map and
+     *  its baseline always advance together. */
+    private suspend fun reconcileFieldStamps(now: Long) = stampMutex.withLock {
         val current = snapshot()
         val baseline = readSnapshotBaseline()
         val stamps = readFieldStamps().toMutableMap()
@@ -2966,8 +2996,7 @@ class SettingsRepositoryUiImpl(
         }
         // Forget stamps for keys no longer present.
         stamps.keys.retainAll(current.keys)
-        writeFieldStamps(stamps)
-        writeSnapshotBaseline(current)
+        writeStampsAndBaseline(stamps, current)
     }
 
     private suspend fun readFieldStamps(): Map<String, Long> {
@@ -2975,19 +3004,25 @@ class SettingsRepositoryUiImpl(
         return runCatching { syncJson.decodeFromString(STAMP_MAP_SERIALIZER, raw) }.getOrDefault(emptyMap())
     }
 
-    private suspend fun writeFieldStamps(stamps: Map<String, Long>) {
-        val encoded = syncJson.encodeToString(STAMP_MAP_SERIALIZER, stamps)
-        store.edit { it[SYNC_FIELD_STAMPS_KEY] = encoded }
-    }
-
     private suspend fun readSnapshotBaseline(): Map<String, String> {
         val raw = store.data.first()[SYNC_SNAPSHOT_BASELINE_KEY] ?: return emptyMap()
         return runCatching { syncJson.decodeFromString(STRING_MAP_SERIALIZER, raw) }.getOrDefault(emptyMap())
     }
 
-    private suspend fun writeSnapshotBaseline(snapshot: Map<String, String>) {
-        val encoded = syncJson.encodeToString(STRING_MAP_SERIALIZER, snapshot)
-        store.edit { it[SYNC_SNAPSHOT_BASELINE_KEY] = encoded }
+    /** Issue #1024 — persist the stamp map and its diff baseline in a single
+     *  [DataStore.edit] so they always advance together. Previously these were
+     *  two separate `store.edit` calls; a writer that crashed (or was
+     *  cancelled) between them, or a concurrent reader landing between them,
+     *  could observe stamps that disagree with the baseline. Callers
+     *  ([reconcileFieldStamps] / [applyStamped]) hold [stampMutex] across the
+     *  read-modify-write; this collapses the persist to one atomic step. */
+    private suspend fun writeStampsAndBaseline(stamps: Map<String, Long>, baseline: Map<String, String>) {
+        val encodedStamps = syncJson.encodeToString(STAMP_MAP_SERIALIZER, stamps)
+        val encodedBaseline = syncJson.encodeToString(STRING_MAP_SERIALIZER, baseline)
+        store.edit {
+            it[SYNC_FIELD_STAMPS_KEY] = encodedStamps
+            it[SYNC_SNAPSHOT_BASELINE_KEY] = encodedBaseline
+        }
     }
 
     companion object {

--- a/app/src/test/kotlin/in/jphe/storyvox/data/SettingsRepositoryStampRaceTest.kt
+++ b/app/src/test/kotlin/in/jphe/storyvox/data/SettingsRepositoryStampRaceTest.kt
@@ -1,0 +1,232 @@
+package `in`.jphe.storyvox.data
+
+import androidx.datastore.core.DataStore
+import androidx.datastore.preferences.core.PreferenceDataStoreFactory
+import androidx.datastore.preferences.core.Preferences
+import androidx.datastore.preferences.core.stringPreferencesKey
+import java.io.File
+import java.util.concurrent.Executors
+import java.util.concurrent.atomic.AtomicBoolean
+import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.asCoroutineDispatcher
+import kotlinx.coroutines.async
+import kotlinx.coroutines.awaitAll
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlinx.coroutines.withTimeoutOrNull
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import org.junit.rules.TemporaryFolder
+
+/**
+ * Issue #1024 — concurrency regression guard for the per-key stamp /
+ * snapshot-baseline store in [SettingsRepositoryUiImpl].
+ *
+ * Two paths read-modify-write the same DataStore keys
+ * (`SYNC_FIELD_STAMPS_KEY` / `SYNC_SNAPSHOT_BASELINE_KEY`):
+ *  - **Path A** — a local UI `set*` → `stampSyncedWrite` → `reconcileFieldStamps`,
+ *    on whatever coroutine the setter was invoked from.
+ *  - **Path B** — a sync pull → `applyStamped`, inside the SyncCoordinator
+ *    per-domain mutex (which does NOT cover Path A).
+ *
+ * Each path does read→read→(modify)→write. Before the fix there was no shared
+ * lock, so the two compound sequences could interleave: one path reads, the
+ * other runs its full RMW and commits, then the first path commits on top of
+ * its now-stale read — clobbering the value/stamp the other just adopted (the
+ * cross-device clobber #978 set out to kill).
+ *
+ * Forcing that interleave deterministically: [GatedStampWriteDataStore] parks
+ * the FIRST write that touches the stamps key — by then the parking path has
+ * finished its reads. The test drives a precise order:
+ *
+ *   1. Start Path A (local write) alone. It reads the stamp/baseline store,
+ *      then parks at the stamp-write gate — its reads are now frozen-in-time.
+ *   2. While A is parked, run Path B (`applyStamped`) to FULL completion: it
+ *      reads, adopts the theme value with the old stamp, and commits.
+ *   3. Release A. It commits the stamp/baseline it computed back in step 1 —
+ *      a read taken BEFORE B existed.
+ *
+ * On the unguarded code step 3 clobbers B's just-committed baseline: A's
+ * baseline has no record of theme="DARK", so the NEXT diff (or A's own write)
+ * leaves theme stamped at a value inconsistent with the adopted one — the
+ * assertion catches it. With the [stampMutex] guard, step 2's `applyStamped`
+ * can't start its RMW at all (it blocks on the mutex A holds across its whole
+ * read-modify-write), so the ordering in steps 1-3 is impossible; B only runs
+ * after A commits a consistent baseline → assertion passes.
+ *
+ * Verified to FAIL on the pre-fix code and pass with the guard, by reverting
+ * the fix while keeping the test.
+ */
+@OptIn(ExperimentalCoroutinesApi::class)
+class SettingsRepositoryStampRaceTest {
+
+    @get:Rule
+    val tempFolder = TemporaryFolder()
+
+    private lateinit var scope: CoroutineScope
+    private lateinit var rawStore: DataStore<Preferences>
+
+    @Before
+    fun setUp() {
+        scope = CoroutineScope(SupervisorJob() + UnconfinedTestDispatcher())
+        val file = File(tempFolder.newFolder(), "storyvox_settings.preferences_pb")
+        rawStore = PreferenceDataStoreFactory.create(scope = scope, produceFile = { file })
+    }
+
+    @After
+    fun tearDown() {
+        scope.cancel()
+    }
+
+    /**
+     * Parks the first stamp-touching write OUTSIDE the delegate's write actor
+     * (so the other path's writes still commit during the park). It peeks the
+     * current state, runs the caller's transform on a copy to see whether the
+     * stamps key changes, and if so — and the gate is still armed — signals
+     * [firstStampWriteReached] and awaits [release] before delegating.
+     */
+    private class GatedStampWriteDataStore(
+        private val delegate: DataStore<Preferences>,
+    ) : DataStore<Preferences> {
+        private val stampsKey = stringPreferencesKey("instantdb.settings_field_stamps_v1")
+        val firstStampWriteReached = CompletableDeferred<Unit>()
+        private val releaseGate = CompletableDeferred<Unit>()
+        private val armed = AtomicBoolean(true)
+
+        fun release() {
+            if (!releaseGate.isCompleted) releaseGate.complete(Unit)
+        }
+
+        override val data: Flow<Preferences> get() = delegate.data
+
+        override suspend fun updateData(
+            transform: suspend (Preferences) -> Preferences,
+        ): Preferences {
+            val before = delegate.data.first()
+            val after = transform(before)
+            val touchesStamps = after[stampsKey] != before[stampsKey]
+            if (touchesStamps && armed.compareAndSet(true, false)) {
+                firstStampWriteReached.complete(Unit)
+                releaseGate.await()
+            }
+            // Re-run the caller's transform inside the real update so the
+            // commit is atomic against the live state (the peek above was only
+            // to classify the write; DataStore re-applies transform anyway).
+            return delegate.updateData(transform)
+        }
+    }
+
+    private fun makeRepo(store: DataStore<Preferences>): SettingsRepositoryUiImpl {
+        val pcmBundle = makeFakeCacheBundle(tempFolder.newFolder("pcm_bundle"), scope)
+        return SettingsRepositoryUiImpl(
+            store = store,
+            auth = FakeAuth(),
+            hydrator = FakeHydrator(),
+            palaceConfig = makeFakePalaceConfig(tempFolder.newFolder("palace_ds"), scope),
+            palaceApi = makeFakePalaceApi(),
+            llmCreds = `in`.jphe.storyvox.llm.LlmCredentialsStore.forTesting(),
+            githubAuth = FakeGitHubAuth(),
+            teamsAuth = fakeTeamsAuth(),
+            rssConfig = makeFakeRssConfig(tempFolder.newFolder("rss_ds"), scope),
+            epubConfig = makeFakeEpubConfig(tempFolder.newFolder("epub_ds"), scope),
+            outlineConfig = makeFakeOutlineConfig(tempFolder.newFolder("outline_ds"), scope),
+            wikipediaConfig = makeFakeWikipediaConfig(tempFolder.newFolder("wiki_ds"), scope),
+            notionConfig = makeFakeNotionConfig(tempFolder.newFolder("notion_ds"), scope),
+            discordConfig = makeFakeDiscordConfig(tempFolder.newFolder("discord_ds"), scope),
+            discordGuildDirectory = makeFakeDiscordGuildDirectory(),
+            telegramConfig = makeFakeTelegramConfig(tempFolder.newFolder("telegram_ds"), scope),
+            telegramChannelDirectory = makeFakeTelegramChannelDirectory(),
+            suggestedFeedsRegistry = SuggestedFeedsRegistry(),
+            azureCreds = makeFakeAzureCredentials(),
+            azureClient = makeFakeAzureClient(),
+            azureRoster = makeFakeAzureRoster(),
+            googleTokenSource =
+                `in`.jphe.storyvox.llm.auth.GoogleOAuthTokenSource(okhttp3.OkHttpClient()),
+            pcmCache = pcmBundle.pcmCache,
+            pcmCacheConfig = pcmBundle.pcmCacheConfig,
+            cacheStats = pcmBundle.cacheStats,
+            pushSettings = { },
+            pushDispatcher = StandardTestDispatcher(),
+        )
+    }
+
+    @Test(timeout = 60_000)
+    fun `concurrent local write and applyStamped do not corrupt the adopted stamp`() {
+        val gated = GatedStampWriteDataStore(rawStore)
+        val repo = makeRepo(gated)
+
+        val pool = Executors.newFixedThreadPool(2)
+        val raceDispatcher = pool.asCoroutineDispatcher()
+        try {
+            runBlocking {
+                val themeKey = "settings.pref_theme_override"
+                // The theme key is ONLY ever written by applyStamped, always
+                // with this fixed OLD stamp. A consistent baseline keeps it
+                // here; if a racing Path A diffs theme against a baseline that
+                // doesn't record the adopted value, it re-stamps theme to a
+                // fresh now (>> incomingStamp), which the assertion catches.
+                val incomingStamp = 1_000L
+
+                // Step 1 — Path A (local edit of a DIFFERENT key) starts first
+                // and parks at its stamp-write gate with its reads frozen.
+                val localWrite = async(raceDispatcher) {
+                    repo.setSourceDisplayOrder(listOf("ao3", "royalroad"))
+                }
+                gated.firstStampWriteReached.await()
+
+                // Step 2 — with A parked, kick off Path B (remote merge adopts
+                // theme with the old stamp). DON'T await it here: under the fix
+                // B blocks on the mutex A holds, so awaiting would deadlock.
+                // Instead give it a generous window to run (it completes only
+                // on the UNGUARDED code, where A doesn't hold a lock).
+                val pull = async(raceDispatcher) {
+                    repo.applyStamped(
+                        snapshot = mapOf(themeKey to "DARK"),
+                        stamps = mapOf(themeKey to incomingStamp),
+                    )
+                }
+                delay(500L)
+
+                // Step 3 — release A so it commits the stamp/baseline it read
+                // back in step 1. On unguarded code that clobbers B's adopted
+                // theme baseline; under the guard B never got to run, so A
+                // commits clean and B runs afterwards.
+                gated.release()
+
+                // Both must finish (bounded, so a real deadlock fails loudly
+                // rather than masquerading as a pass).
+                val finished = withTimeoutOrNull(20_000L) {
+                    awaitAll(localWrite, pull)
+                    true
+                }
+                assertEquals("both paths must complete (no deadlock)", true, finished)
+
+                assertEquals(
+                    "the applyStamped-adopted theme key was re-stamped by a racing " +
+                        "local write — the stamp/baseline read-modify-write interleaved " +
+                        "(regression for #1024). Expected the incoming stamp, got a fresh now.",
+                    incomingStamp,
+                    repo.fieldStamps()[themeKey],
+                )
+                assertEquals(
+                    "theme value must remain the remote-adopted one",
+                    "DARK",
+                    repo.snapshot()[themeKey],
+                )
+            }
+        } finally {
+            pool.shutdownNow()
+        }
+    }
+}


### PR DESCRIPTION
Fixes #1024.

## Problem

The per-key stamp (`SYNC_FIELD_STAMPS_KEY`) and diff baseline (`SYNC_SNAPSHOT_BASELINE_KEY`) stores in `SettingsRepositoryUiImpl` are read-modify-written by **two paths with no shared lock**:

- **Path A** — a local UI `set*` → `stampSyncedWrite` → `reconcileFieldStamps`, on whatever coroutine the setter ran from.
- **Path B** — a sync pull → `applyStamped`, inside the `SyncCoordinator` per-domain mutex.

The coordinator mutex only serialises syncers against each other; it does **not** cover Path A, a direct repo call from the UI layer. Each `store.edit` is atomic, but the compound `read→read→write→write` is not — so a write from one path can land on a stale read from the other:

1. **Lost remote edit** — a value the merge just adopted gets re-stamped a fresh `now` and re-pushed, able to clobber an even-newer concurrent edit from a third device (the #978 cross-device clobber, shifted into a narrower window that #977's immediate-push made easier to hit).
2. **Stale baseline** — the diff baseline reflects neither the local nor the just-applied remote value, so the next local edit mis-detects which keys changed (spurious or missed pushes).

## Fix

- A repository-owned `private val stampMutex = Mutex()` wraps the whole read-modify-write in **both** `reconcileFieldStamps` (Path A) and `applyStamped` (Path B). In `applyStamped`, `applyValues` is inside the lock too, since `reconcileFieldStamps`'s `snapshot()` reads the values it writes.
- The two separate `store.edit` writes (`writeFieldStamps` + `writeSnapshotBaseline`) are folded into one atomic `writeStampsAndBaseline` so the stamp map and its baseline always advance together.

Fully local, `@Singleton`-scoped (one mutex guards all callers), **no wire-format impact**. No reentrancy: the two locked entry points never nest.

## Test

`SettingsRepositoryStampRaceTest` — a `GatedStampWriteDataStore` parks Path A's stamp write *after* its reads, lets Path B's full `applyStamped` commit during the park, then releases A to commit its stale read. On the unguarded code A clobbers B's adopted theme baseline and the theme key loses its incoming stamp → assertion fails; with the guard, B blocks on the mutex during the park and only runs after A commits a consistent baseline → passes.

**Verified the test is a real guard**: it FAILS on the pre-fix code (`expected:<1000>` for the adopted stamp) and passes with the fix, confirmed by reverting the fix while keeping the test. A deadlock guard (`withTimeoutOrNull`) keeps a hang from masquerading as a pass.

## Verification

- `:app:assembleDebug` / `:app:compileDebugKotlin` — green
- `:app:testDebugUnitTest --tests "in.jphe.storyvox.data.SettingsRepository*"` — green (incl. existing `SettingsRepositoryFieldStampsTest`)
- `:core-sync:testDebugUnitTest --tests SettingsSyncerTest` — green

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

**Bug Fixes**
- Fixed a data synchronization issue that could cause data loss when local and remote updates occur simultaneously. Enhanced the synchronization protocol to reliably handle concurrent modifications from multiple sources while protecting data integrity.

**Tests**
- Added a regression test to verify that data consistency is preserved when local and remote updates happen concurrently. This ensures the app properly handles simultaneous edits from different sources.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->