### PR TITLE
feat(reader): in-text search — find-in-chapter + jump-to-match (#998)

### DIFF
--- a/core-ui/src/main/kotlin/in/jphe/storyvox/ui/component/SentenceHighlight.kt
+++ b/core-ui/src/main/kotlin/in/jphe/storyvox/ui/component/SentenceHighlight.kt
@@ -38,6 +38,13 @@ import `in`.jphe.storyvox.ui.theme.LocalReducedMotion
  *                        does NOT fire `onTapWord`, so a deliberate long-press never accidentally seeks playback.
  * @param onLayout optional — emits the text layout each time it changes; reader uses it to auto-scroll
  *                the highlighted sentence into view.
+ * @param searchMatches optional (#998) — UTF-16 char ranges of in-text search hits, painted with a
+ *                translucent brass background fill. Independent of the spoken-sentence underline: the
+ *                underline tracks what's being *read*; these tint what was *found*. Empty (the default)
+ *                keeps every existing callsite — AudiobookView, previews, tests — a no-op.
+ * @param activeMatchIndex optional (#998) — index into [searchMatches] of the hit the next/prev chevrons
+ *                last landed on; it gets a stronger fill so the reader sees which match is focused. `-1`
+ *                (default) means no active match — every hit paints with the dimmer fill.
  */
 @Composable
 fun SentenceHighlight(
@@ -48,6 +55,8 @@ fun SentenceHighlight(
     onTapWord: ((Int) -> Unit)? = null,
     onLongPressWord: ((String) -> Unit)? = null,
     onLayout: ((TextLayoutResult) -> Unit)? = null,
+    searchMatches: List<IntRange> = emptyList(),
+    activeMatchIndex: Int = -1,
 ) {
     // #993 — when a reading theme is active, the chapter text uses the
     // theme's foreground and the sentence underline uses its accent; otherwise
@@ -70,25 +79,53 @@ fun SentenceHighlight(
     // switch) and overlay the highlight span via the public AnnotatedString
     // constructor's `spanStyles` list. That constructor takes the SpanStyle
     // ranges by reference; no character copying happens on a sentence change.
+    // #998 — translucent brass background fills for in-text search hits.
+    // The active hit (the one the chevrons landed on) gets a stronger
+    // alpha so it stands out from the other matches. These are *background*
+    // spans, orthogonal to the spoken-sentence *underline* drawn below.
+    val matchFill = brass.copy(alpha = 0.25f)
+    val activeMatchFill = brass.copy(alpha = 0.5f)
+
     val baseAnnotated: AnnotatedString = remember(text) { AnnotatedString(text) }
-    val annotated: AnnotatedString = remember(baseAnnotated, highlightStart, highlightEnd, onSurface) {
+    val annotated: AnnotatedString = remember(
+        baseAnnotated, highlightStart, highlightEnd, onSurface,
+        searchMatches, activeMatchIndex, matchFill, activeMatchFill,
+    ) {
+        val spans = ArrayList<AnnotatedString.Range<SpanStyle>>(searchMatches.size + 1)
+
+        // Sentence-being-read span (bold, on-surface). Unchanged from before.
         if (highlightEnd > highlightStart &&
             highlightStart in 0..text.length &&
             highlightEnd in highlightStart..text.length
         ) {
-            AnnotatedString(
-                text = text,
-                spanStyles = listOf(
-                    AnnotatedString.Range(
-                        item = SpanStyle(color = onSurface, fontWeight = FontWeight.Medium),
-                        start = highlightStart,
-                        end = highlightEnd,
-                    ),
+            spans.add(
+                AnnotatedString.Range(
+                    item = SpanStyle(color = onSurface, fontWeight = FontWeight.Medium),
+                    start = highlightStart,
+                    end = highlightEnd,
                 ),
             )
-        } else {
-            baseAnnotated
         }
+
+        // Search-hit background fills. AnnotatedString end offset is
+        // exclusive; our IntRange is end-inclusive, so end = last + 1.
+        searchMatches.forEachIndexed { i, range ->
+            val start = range.first.coerceIn(0, text.length)
+            val end = (range.last + 1).coerceIn(start, text.length)
+            if (end > start) {
+                spans.add(
+                    AnnotatedString.Range(
+                        item = SpanStyle(
+                            background = if (i == activeMatchIndex) activeMatchFill else matchFill,
+                        ),
+                        start = start,
+                        end = end,
+                    ),
+                )
+            }
+        }
+
+        if (spans.isEmpty()) baseAnnotated else AnnotatedString(text = text, spanStyles = spans)
     }
 
     val reducedMotion = LocalReducedMotion.current

--- a/feature/src/main/kotlin/in/jphe/storyvox/feature/reader/ReaderTextSearch.kt
+++ b/feature/src/main/kotlin/in/jphe/storyvox/feature/reader/ReaderTextSearch.kt
@@ -1,0 +1,52 @@
+package `in`.jphe.storyvox.feature.reader
+
+/**
+ * Issue #998 — find-in-text within the loaded chapter. Pure, Compose-free
+ * so the match-finding core is unit-testable without rendering the reader
+ * (mirrors #794's `filterChaptersByQuery`).
+ *
+ * Scans [text] for every non-overlapping, case-insensitive occurrence of
+ * [query] and returns their UTF-16 char ranges in document order. The
+ * ranges are end-inclusive (`start..end`) so a caller can feed
+ * `range.first` straight to `TextLayoutResult.getLineForOffset(...)` for a
+ * jump-to-match scroll, or pass the range to the search-highlight overlay.
+ *
+ * A blank / empty query (or empty text) returns an empty list — there's
+ * nothing to highlight or count. The query is trimmed first so a stray
+ * paste space doesn't zero out results, matching #794.
+ *
+ * Non-overlapping: after a hit at index `i` of a `len`-char needle, the
+ * scan resumes at `i + len`, so "aa" in "aaaa" yields 0..1 and 2..3, not
+ * a third spurious 1..2. This is the right contract for highlighting —
+ * overlapping spans would double-paint the same glyphs.
+ */
+internal fun findMatches(text: String, query: String): List<IntRange> {
+    val needle = query.trim()
+    if (needle.isEmpty() || text.isEmpty()) return emptyList()
+
+    val matches = mutableListOf<IntRange>()
+    var from = 0
+    while (from <= text.length - needle.length) {
+        val hit = text.indexOf(needle, startIndex = from, ignoreCase = true)
+        if (hit < 0) break
+        matches.add(hit..(hit + needle.length - 1))
+        from = hit + needle.length
+    }
+    return matches
+}
+
+/**
+ * Issue #998 — advance to the next match, wrapping from the last hit back
+ * to the first. Total over [count] == 0 (returns 0) so the next/prev
+ * chevrons can call it unconditionally even before any query is entered.
+ */
+internal fun nextMatchIndex(current: Int, count: Int): Int =
+    if (count <= 0) 0 else (current + 1) % count
+
+/**
+ * Issue #998 — retreat to the previous match, wrapping from the first hit
+ * back to the last. `+ count` before the modulo keeps the result
+ * non-negative when [current] is 0.
+ */
+internal fun prevMatchIndex(current: Int, count: Int): Int =
+    if (count <= 0) 0 else (current - 1 + count) % count

--- a/feature/src/main/kotlin/in/jphe/storyvox/feature/reader/ReaderView.kt
+++ b/feature/src/main/kotlin/in/jphe/storyvox/feature/reader/ReaderView.kt
@@ -20,18 +20,26 @@ import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.widthIn
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
+import androidx.compose.foundation.text.KeyboardActions
+import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Close
 import androidx.compose.material.icons.filled.Pause
 import androidx.compose.material.icons.filled.PlayArrow
 import androidx.compose.material.icons.filled.VerticalAlignCenter
 import androidx.compose.material.icons.outlined.AutoAwesome
 import androidx.compose.material.icons.outlined.AutoStories
 import androidx.compose.material.icons.outlined.CenterFocusStrong
+import androidx.compose.material.icons.outlined.ExpandLess
+import androidx.compose.material.icons.outlined.ExpandMore
+import androidx.compose.material.icons.outlined.Search
 import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.FilledIconButton
 import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
 import androidx.compose.material3.IconButtonDefaults
 import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.SmallFloatingActionButton
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
@@ -42,6 +50,7 @@ import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.derivedStateOf
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableFloatStateOf
+import androidx.compose.runtime.mutableIntStateOf
 import androidx.compose.runtime.mutableLongStateOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
@@ -52,13 +61,17 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.draw.alpha
+import androidx.compose.ui.focus.FocusRequester
+import androidx.compose.ui.focus.focusRequester
 import androidx.compose.ui.layout.onGloballyPositioned
 import androidx.compose.ui.layout.onSizeChanged
 import androidx.compose.ui.layout.positionInParent
+import androidx.compose.ui.platform.LocalSoftwareKeyboardController
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.semantics.contentDescription
 import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.text.TextLayoutResult
+import androidx.compose.ui.text.input.ImeAction
 import androidx.compose.ui.unit.dp
 import `in`.jphe.storyvox.feature.R
 import `in`.jphe.storyvox.feature.api.UiPlaybackState
@@ -273,6 +286,49 @@ fun ReaderTextView(
         label = "focus-title-alpha",
     )
 
+    // Issue #998 — in-text search. All state is local to the reader pane:
+    // the query, whether the search bar is open, and which match the
+    // chevrons last landed on. Matches are derived purely from the
+    // already-in-memory chapterText via [findMatches] (no ViewModel
+    // round-trip), so the whole affordance is scoped to this composable
+    // and the other reader-cluster features rebase cleanly over it.
+    var searchOpen by remember { mutableStateOf(false) }
+    var searchQuery by remember { mutableStateOf("") }
+    var activeMatchIndex by remember { mutableIntStateOf(0) }
+    val matches by remember(chapterText, searchQuery) {
+        derivedStateOf { findMatches(chapterText, searchQuery) }
+    }
+    // Keep the active index in range as the query (and thus match count)
+    // changes — a narrowing query can shrink the list out from under us.
+    LaunchedEffect(matches.size) {
+        if (activeMatchIndex >= matches.size) activeMatchIndex = 0
+    }
+    val searchFocus = remember { FocusRequester() }
+    val keyboard = LocalSoftwareKeyboardController.current
+    val searchHint = stringResource(R.string.reader_search)
+
+    // Jump-to-match: when the active match changes (chevrons, or the first
+    // hit of a fresh query), scroll it to the 40%-from-top reading line —
+    // reusing the exact #919 recenter math — and seek TTS playback to the
+    // match's char offset, so the issue's "search a word and move the
+    // playhead there" accessibility workflow lands in one tap.
+    LaunchedEffect(activeMatchIndex, matches) {
+        val match = matches.getOrNull(activeMatchIndex) ?: return@LaunchedEffect
+        val layout = textLayout ?: return@LaunchedEffect
+        if (chapterText.isEmpty()) return@LaunchedEffect
+        if (viewportHeightPx <= 0f) return@LaunchedEffect
+        // Suppress auto-scroll fighting us while we reposition.
+        lastManualScrollAt = System.currentTimeMillis()
+        val safeStart = match.first.coerceIn(0, (chapterText.length - 1).coerceAtLeast(0))
+        val line = layout.getLineForOffset(safeStart)
+        val lineTopWithinText = layout.getLineTop(line)
+        val targetY = (bodyTopPx + lineTopWithinText - viewportHeightPx * HIGHLIGHT_VIEWPORT_FRACTION)
+            .roundToInt()
+            .coerceIn(0, scroll.maxValue.coerceAtLeast(0))
+        scroll.animateScrollTo(targetY)
+        onSeekToChar(match.first)
+    }
+
     // #993 — provide the reading-theme colours to the chapter renderer below.
     // When active we paint the theme background on the reader surface and tint
     // the chapter title to the theme foreground; SentenceHighlight reads
@@ -328,12 +384,49 @@ fun ReaderTextView(
                         onTapWord = onSeekToChar,
                         onLongPressWord = { word -> lookupWord = word },
                         onLayout = { layout -> textLayout = layout },
+                        // #998 — paint in-text search hits; the active one
+                        // (chevron target) gets the stronger fill.
+                        searchMatches = matches,
+                        activeMatchIndex = activeMatchIndex,
                     )
                 }
             }
         }
 
-        // Issue #997 — Focused Reading toggle. Top of the brass cluster
+        // Issue #998 — find-in-text FAB. Tops the brass cluster (search →
+        // focus → auto-scroll → recenter, reading down at 296/232/168/104).
+        // Toggling it opens the search bar overlay and focuses the field;
+        // toggling off closes the bar and clears the query so the match
+        // highlights vanish. Only shown when there's chapter text to search.
+        if (chapterText.isNotEmpty()) {
+            SmallFloatingActionButton(
+                onClick = {
+                    searchOpen = !searchOpen
+                    if (!searchOpen) {
+                        searchQuery = ""
+                        activeMatchIndex = 0
+                    }
+                },
+                modifier = Modifier
+                    .align(Alignment.BottomEnd)
+                    .padding(end = spacing.md, bottom = 296.dp)
+                    .semantics { contentDescription = searchHint },
+                containerColor = if (searchOpen) {
+                    MaterialTheme.colorScheme.primary
+                } else {
+                    MaterialTheme.colorScheme.surfaceContainerHigh
+                },
+                contentColor = if (searchOpen) {
+                    MaterialTheme.colorScheme.onPrimary
+                } else {
+                    MaterialTheme.colorScheme.onSurfaceVariant
+                },
+            ) {
+                Icon(imageVector = Icons.Outlined.Search, contentDescription = null)
+            }
+        }
+
+        // Issue #997 — Focused Reading toggle. Sits below the search FAB
         // (above the auto-scroll toggle) and ALWAYS visible — even in
         // focus mode — so it's the one persistent control the user can
         // use to leave the distraction-reduced view. Filled-brass when
@@ -587,8 +680,133 @@ fun ReaderTextView(
                 },
             )
         }
+
+        // Issue #998 — find-in-text bar. Slides down from the top as a
+        // floating overlay (it doesn't reflow the immersive body or break
+        // the swipe shell) when the search FAB is toggled on. Holds the
+        // query field, a live "n / total" match counter, prev/next
+        // chevrons, and a close button. Focus + keyboard are claimed on
+        // open so the user can type immediately.
+        LaunchedEffect(searchOpen) {
+            if (searchOpen) {
+                searchFocus.requestFocus()
+                keyboard?.show()
+            }
+        }
+        AnimatedVisibility(
+            visible = searchOpen,
+            modifier = Modifier.align(Alignment.TopCenter).fillMaxWidth(),
+            enter = fadeIn() + slideInVertically { -it },
+            exit = fadeOut() + slideOutVertically { -it },
+        ) {
+            ReaderSearchBar(
+                query = searchQuery,
+                onQueryChange = { searchQuery = it; activeMatchIndex = 0 },
+                matchCount = matches.size,
+                activeMatchIndex = activeMatchIndex,
+                onPrev = { activeMatchIndex = prevMatchIndex(activeMatchIndex, matches.size) },
+                onNext = { activeMatchIndex = nextMatchIndex(activeMatchIndex, matches.size) },
+                onClose = {
+                    searchOpen = false
+                    searchQuery = ""
+                    activeMatchIndex = 0
+                    keyboard?.hide()
+                },
+                focusRequester = searchFocus,
+            )
+        }
     }
     } // CompositionLocalProvider(LocalReaderColors) — #993
+}
+
+/**
+ * Issue #998 — the reader's find-in-text bar. A brass [Surface] holding
+ * the query field, a live match counter, prev/next chevrons, and a close
+ * button. Pure presentational: all state is hoisted to [ReaderTextView],
+ * which owns the query, the derived match list, and the active index.
+ *
+ * The IME "Search" action and the next chevron both advance to the next
+ * match, so a one-handed user can press Enter to walk hits without
+ * reaching for the chevron.
+ */
+@Composable
+private fun ReaderSearchBar(
+    query: String,
+    onQueryChange: (String) -> Unit,
+    matchCount: Int,
+    activeMatchIndex: Int,
+    onPrev: () -> Unit,
+    onNext: () -> Unit,
+    onClose: () -> Unit,
+    focusRequester: FocusRequester,
+) {
+    val spacing = LocalSpacing.current
+    val hasMatches = matchCount > 0
+    val counterText = when {
+        query.isBlank() -> ""
+        !hasMatches -> stringResource(R.string.reader_search_no_matches)
+        else -> stringResource(R.string.reader_search_count, activeMatchIndex + 1, matchCount)
+    }
+    val counterDescription = if (hasMatches) {
+        stringResource(R.string.reader_search_count_description, activeMatchIndex + 1, matchCount)
+    } else {
+        counterText
+    }
+    Surface(
+        color = MaterialTheme.colorScheme.surfaceContainerHigh,
+        shadowElevation = 4.dp,
+    ) {
+        Row(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(horizontal = spacing.sm, vertical = spacing.xs),
+            verticalAlignment = Alignment.CenterVertically,
+        ) {
+            OutlinedTextField(
+                value = query,
+                onValueChange = onQueryChange,
+                label = { Text(stringResource(R.string.reader_search_field_label)) },
+                singleLine = true,
+                leadingIcon = {
+                    Icon(Icons.Outlined.Search, contentDescription = null)
+                },
+                keyboardOptions = KeyboardOptions(imeAction = ImeAction.Search),
+                keyboardActions = KeyboardActions(onSearch = { onNext() }),
+                modifier = Modifier
+                    .weight(1f)
+                    .focusRequester(focusRequester),
+            )
+            if (counterText.isNotEmpty()) {
+                Text(
+                    text = counterText,
+                    style = MaterialTheme.typography.labelMedium,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    maxLines = 1,
+                    modifier = Modifier
+                        .padding(horizontal = spacing.xs)
+                        .semantics { contentDescription = counterDescription },
+                )
+            }
+            IconButton(onClick = onPrev, enabled = hasMatches) {
+                Icon(
+                    Icons.Outlined.ExpandLess,
+                    contentDescription = stringResource(R.string.reader_search_prev),
+                )
+            }
+            IconButton(onClick = onNext, enabled = hasMatches) {
+                Icon(
+                    Icons.Outlined.ExpandMore,
+                    contentDescription = stringResource(R.string.reader_search_next),
+                )
+            }
+            IconButton(onClick = onClose) {
+                Icon(
+                    Icons.Filled.Close,
+                    contentDescription = stringResource(R.string.reader_search_close),
+                )
+            }
+        }
+    }
 }
 
 @Composable

--- a/feature/src/main/res/values/strings.xml
+++ b/feature/src/main/res/values/strings.xml
@@ -167,6 +167,18 @@
     <string name="reader_open_reader">Open reader</string>
     <string name="reader_dock_card_description">Now playing: %1$s. %2$s. Tap to open reader.</string>
 
+    <!-- Reader / in-text search (#998) -->
+    <string name="reader_search">Search this chapter</string>
+    <string name="reader_search_field_label">Find in chapter</string>
+    <string name="reader_search_close">Close search</string>
+    <string name="reader_search_prev">Previous match</string>
+    <string name="reader_search_next">Next match</string>
+    <!-- e.g. "3 / 12" — current match out of total -->
+    <string name="reader_search_count">%1$d / %2$d</string>
+    <string name="reader_search_no_matches">No matches</string>
+    <!-- TalkBack summary of the result counter -->
+    <string name="reader_search_count_description">Match %1$d of %2$d</string>
+
     <!-- Reader / ResumePrompt -->
     <string name="reader_from_the_start">From the start</string>
     <string name="reader_start_listening">▶  Start listening</string>

--- a/feature/src/test/kotlin/in/jphe/storyvox/feature/reader/ReaderTextSearchTest.kt
+++ b/feature/src/test/kotlin/in/jphe/storyvox/feature/reader/ReaderTextSearchTest.kt
@@ -1,0 +1,116 @@
+package `in`.jphe.storyvox.feature.reader
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * Issue #998 — in-text search. Pins the pure match-finding surface that
+ * the reader's find-in-text affordance builds on, so the "search War &
+ * Peace and jump to a hit" workflow can't silently regress on a reader
+ * refactor.
+ *
+ * [findMatches] is deliberately pure (no Compose / Android deps) so the
+ * core search logic is unit-testable without rendering [ReaderTextView]
+ * or standing up Robolectric — same split the codebase already uses for
+ * #794's `filterChaptersByQuery`.
+ */
+class ReaderTextSearchTest {
+
+    @Test
+    fun `blank query yields no matches`() {
+        assertTrue(findMatches("The quick brown fox", "").isEmpty())
+        assertTrue(findMatches("The quick brown fox", "   ").isEmpty())
+    }
+
+    @Test
+    fun `query with no occurrence yields no matches`() {
+        assertTrue(findMatches("The quick brown fox", "zebra").isEmpty())
+    }
+
+    @Test
+    fun `single match returns one range at the right offset`() {
+        // "brown" starts at index 10.
+        assertEquals(listOf(10..14), findMatches("The quick brown fox", "brown"))
+    }
+
+    @Test
+    fun `multiple matches are returned in document order`() {
+        val text = "fox fox fox"
+        // "fox" at 0, 4, 8 — each length 3 → end-inclusive index +2.
+        assertEquals(listOf(0..2, 4..6, 8..10), findMatches(text, "fox"))
+    }
+
+    @Test
+    fun `matching is case insensitive`() {
+        val text = "The The THE the"
+        // Every "the" matches regardless of case; positions 0,4,8,12.
+        assertEquals(listOf(0..2, 4..6, 8..10, 12..14), findMatches(text, "the"))
+    }
+
+    @Test
+    fun `overlapping matches do not double-count — advance past each hit`() {
+        // "aa" in "aaaa": non-overlapping scan finds 0..1 and 2..3, NOT
+        // 1..2. indexOf advancing by match length is the contract.
+        assertEquals(listOf(0..1, 2..3), findMatches("aaaa", "aa"))
+    }
+
+    @Test
+    fun `query is trimmed before matching`() {
+        // A stray trailing space from a paste shouldn't zero out results,
+        // matching #794's filterChaptersByQuery behaviour.
+        assertEquals(listOf(10..14), findMatches("The quick brown fox", "  brown  "))
+    }
+
+    @Test
+    fun `unicode query matches by code unit offset`() {
+        // Accented + CJK content: the returned offsets are UTF-16 char
+        // indices (what TextLayoutResult.getLineForOffset consumes), so a
+        // multi-byte glyph still yields a usable single-char-unit range.
+        val text = "café 第1章 café"
+        // All BMP chars (é = U+00E9, 第/章 each one UTF-16 unit), so char
+        // index == code-unit index. first "café" at 0..3; the run
+        // "café"(4) + " "(1) + "第1章"(3) + " "(1) = 9, so the second at 9..12.
+        assertEquals(listOf(0..3, 9..12), findMatches(text, "café"))
+    }
+
+    @Test
+    fun `empty text yields no matches`() {
+        assertTrue(findMatches("", "anything").isEmpty())
+    }
+
+    @Test
+    fun `whole-text match returns a single full-span range`() {
+        assertEquals(listOf(0..2), findMatches("abc", "abc"))
+    }
+
+    // --- nextMatchIndex / prevMatchIndex (wraparound cycling) ---------------
+
+    @Test
+    fun `next advances and wraps from last to first`() {
+        assertEquals(1, nextMatchIndex(current = 0, count = 3))
+        assertEquals(2, nextMatchIndex(current = 1, count = 3))
+        assertEquals(0, nextMatchIndex(current = 2, count = 3))
+    }
+
+    @Test
+    fun `prev retreats and wraps from first to last`() {
+        assertEquals(2, prevMatchIndex(current = 0, count = 3))
+        assertEquals(0, prevMatchIndex(current = 1, count = 3))
+        assertEquals(1, prevMatchIndex(current = 2, count = 3))
+    }
+
+    @Test
+    fun `cycling with no matches stays at zero`() {
+        // count == 0 must not divide-by-zero; the affordance is hidden
+        // anyway, but the helper has to be total.
+        assertEquals(0, nextMatchIndex(current = 0, count = 0))
+        assertEquals(0, prevMatchIndex(current = 0, count = 0))
+    }
+
+    @Test
+    fun `single match cycles to itself`() {
+        assertEquals(0, nextMatchIndex(current = 0, count = 1))
+        assertEquals(0, prevMatchIndex(current = 0, count = 1))
+    }
+}


### PR DESCRIPTION
Closes #998.

## What
Adds find-in-text to the reader pane: a magnifier FAB (top of the brass cluster) opens a search bar that slides in from the top, with a live `n / total` match counter, prev/next chevrons (wraparound), and a close button. Matches are highlighted with a translucent brass background fill; the active hit (the one the chevrons landed on) gets a stronger fill.

Jumping to a match **scrolls** the hit to the 40%-from-top reading line (reusing the existing #919 recenter math) **and seeks TTS playback** to the match's char offset — so the accessibility workflow the issue calls out (a low-vision reader searches a word and moves the playhead there) lands in one tap.

## Design
- `findMatches` / `nextMatchIndex` / `prevMatchIndex` are **pure, Compose-free** (mirrors #794's `filterChaptersByQuery`) and live in `ReaderTextSearch.kt`. **14 unit tests** cover case-insensitivity, non-overlapping scan, query trim, unicode/CJK UTF-16 offsets, wraparound cycling, and empty/blank/no-match edges — no Robolectric needed.
- All search state is **local to `ReaderTextView`** (no `ReaderViewModel` / `HybridReaderScreen` changes), keeping the change scoped to the reader so the rest of the reader-feature cluster (#992/#993/#997/#994/#1001) rebases cleanly over it.
- The `SentenceHighlight` param (`searchMatches: List<IntRange> = emptyList()`, `activeMatchIndex: Int = -1`) is **purely additive** — `AudiobookView` and every existing callsite stay no-ops. The search-match *background fill* is orthogonal to the spoken-sentence *underline*.

## Scope
Current chapter only (its `plainBody` is already in memory for highlighting — search is cheap `indexOf` over it). **Cross-chapter** search via a Room FTS index over `chapter.plainBody` is a feasible follow-up, as the issue notes; deliberately out of scope to keep this the clean reader-cluster base.

## Verification
- `:feature:testDebugUnitTest` green (14 new tests + existing reader tests).
- `:app:assembleDebug` builds.
- Installed on R83W80CAFZB — clean launch, no crash; reader renders with the default (empty-match) path.
- The interactive flow (type → highlight → chevron jump → seek) reuses the proven #919 scroll path and #794 search-bar idiom; the match/cycling logic is exhaustively unit-tested. Worth a quick visual QA pass on a long chapter.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Implemented find-in-text search in the reader with inline highlighting of all matches and prominent display of the current selection.
  * Added navigation controls (previous/next) to move between search results with a live match counter.
  * Search is case-insensitive and accessible via a floating action button.

* **Tests**
  * Added comprehensive test coverage for search matching and navigation logic.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->