### PR TITLE
fix(source-discord): nullable message author so one author-less message can't brick the channel (#1064)

### DIFF
--- a/source-discord/src/main/kotlin/in/jphe/storyvox/source/discord/DiscordSource.kt
+++ b/source-discord/src/main/kotlin/in/jphe/storyvox/source/discord/DiscordSource.kt
@@ -246,7 +246,7 @@ internal class DiscordSource @Inject constructor(
                     id = discordFictionId(head.id),
                     sourceId = SourceIds.DISCORD,
                     title = head.contentPreview(),
-                    author = head.author.displayName(),
+                    author = head.author?.displayName() ?: "Unknown",
                     description = head.content.ifBlank { null },
                     status = FictionStatus.ONGOING,
                 )
@@ -555,7 +555,7 @@ internal fun coalesceMessages(
         groups.add(
             DiscordMessageGroup(
                 headId = head.id,
-                authorName = head.author.displayName(),
+                authorName = head.author?.displayName() ?: "Unknown",
                 messages = currentMessages.toList(),
                 headTimestampMillis = parseDiscordTimestamp(head.timestamp),
             ),
@@ -567,7 +567,13 @@ internal fun coalesceMessages(
 
     for (m in chronological) {
         val ts = parseDiscordTimestamp(m.timestamp)
-        val sameAuthor = currentAuthor == m.author.id
+        // A null author id never merges — same instinct as an unparseable
+        // timestamp (#1064): treat "unknown" as a group boundary rather
+        // than collapsing distinct author-less messages together. These
+        // are system/webhook noise the `type == 0` filter drops upstream
+        // anyway, but defending here keeps coalescing correct if one slips.
+        val messageAuthorId = m.author?.id
+        val sameAuthor = messageAuthorId != null && currentAuthor == messageAuthorId
         val withinWindow = windowMs > 0 && ts != null && currentLastTs != null &&
             (ts - currentLastTs!!) <= windowMs
         if (sameAuthor && withinWindow) {
@@ -576,7 +582,7 @@ internal fun coalesceMessages(
         } else {
             flush()
             currentMessages.add(m)
-            currentAuthor = m.author.id
+            currentAuthor = messageAuthorId
             currentLastTs = ts
         }
     }

--- a/source-discord/src/main/kotlin/in/jphe/storyvox/source/discord/net/DiscordModels.kt
+++ b/source-discord/src/main/kotlin/in/jphe/storyvox/source/discord/net/DiscordModels.kt
@@ -81,8 +81,19 @@ internal data class DiscordMessage(
     /** Plain-text message content. May be empty for attachment-only
      *  or embed-only messages. */
     val content: String = "",
-    /** Message author. Coalesce check compares author ids. */
-    val author: DiscordUser,
+    /** Message author. Coalesce check compares author ids.
+     *
+     *  Nullable + defaulted (#1064): webhook / system / integration
+     *  message shapes can arrive with `author` explicitly null or the
+     *  key omitted entirely. Discord's `coerceInputValues` does NOT
+     *  rescue a non-nullable field, so a single author-less element in
+     *  a page would throw and fail the WHOLE `List<DiscordMessage>`
+     *  decode — bricking the entire channel rather than one message.
+     *  Author-less messages are system/webhook noise the `type == 0`
+     *  filter drops downstream; consumers fall back via
+     *  `author?.displayName() ?: "Unknown"`. Matches Slack's
+     *  `user: SlackUser? = null` defense. */
+    val author: DiscordUser? = null,
     /** Attachments uploaded with the message. Filenames + URLs are
      *  surfaced in the chapter body so TTS can mention them. */
     val attachments: List<DiscordAttachment> = emptyList(),

--- a/source-discord/src/test/kotlin/in/jphe/storyvox/source/discord/DiscordCoalesceTest.kt
+++ b/source-discord/src/test/kotlin/in/jphe/storyvox/source/discord/DiscordCoalesceTest.kt
@@ -96,10 +96,10 @@ class DiscordCoalesceTest {
         val groups = coalesceMessages(messages, coalesceMinutes = 30)
 
         assertEquals(4, groups.size)
-        assertEquals("alice", groups[0].messages.first().author.id)
-        assertEquals("bob", groups[1].messages.first().author.id)
-        assertEquals("alice", groups[2].messages.first().author.id)
-        assertEquals("bob", groups[3].messages.first().author.id)
+        assertEquals("alice", groups[0].messages.first().author!!.id)
+        assertEquals("bob", groups[1].messages.first().author!!.id)
+        assertEquals("alice", groups[2].messages.first().author!!.id)
+        assertEquals("bob", groups[3].messages.first().author!!.id)
     }
 
     @Test

--- a/source-discord/src/test/kotlin/in/jphe/storyvox/source/discord/DiscordModelsTest.kt
+++ b/source-discord/src/test/kotlin/in/jphe/storyvox/source/discord/DiscordModelsTest.kt
@@ -22,6 +22,12 @@ class DiscordModelsTest {
 
     private val json = Json { ignoreUnknownKeys = true; isLenient = true }
 
+    // Mirror DiscordApi.kt:55 exactly — the production decoder also sets
+    // coerceInputValues. The #1064 regression hinges on the fact that
+    // coerceInputValues does NOT rescue a null/missing NON-nullable field,
+    // so the null-author tests below must run under the real config.
+    private val apiJson = Json { ignoreUnknownKeys = true; isLenient = true; coerceInputValues = true }
+
     @Test
     fun `parses users me guilds response`() {
         // Real response shape from Discord's docs for
@@ -190,11 +196,11 @@ class DiscordModelsTest {
         val firstHead = response.messages[0][0]
         assertEquals("1200000000000000001", firstHead.id)
         assertEquals("Has anyone seen the dragon chapter?", firstHead.content)
-        assertEquals("alice", firstHead.author.username)
-        assertEquals("Alice", firstHead.author.globalName)
+        assertEquals("alice", firstHead.author!!.username)
+        assertEquals("Alice", firstHead.author!!.globalName)
         // Bob in the second message has no global_name; parsing must
         // accept null without falling over.
-        assertNull(response.messages[0][1].author.globalName)
+        assertNull(response.messages[0][1].author!!.globalName)
         // Second match has an attachment — verify the nested shape.
         val secondHead = response.messages[1][0]
         assertEquals(1, secondHead.attachments.size)
@@ -247,7 +253,7 @@ class DiscordModelsTest {
         assertEquals(1, messages.size)
         val m = messages[0]
         assertEquals("Check out this link", m.content)
-        assertEquals("Charlie", m.author.globalName)
+        assertEquals("Charlie", m.author!!.globalName)
         assertEquals(1, m.embeds.size)
         assertEquals("Storyvox — narratable Discord", m.embeds[0].title)
         assertTrue(
@@ -256,7 +262,88 @@ class DiscordModelsTest {
         )
         // The author's display-name helper falls back through the
         // global_name → username chain.
-        assertEquals("Charlie", m.author.displayName())
+        assertEquals("Charlie", m.author!!.displayName())
         assertNotNull(parseDiscordTimestamp(m.timestamp))
+    }
+
+    // ─── #1064 — author-less messages must not brick the page ─────────
+
+    @Test
+    fun `a message with author null does not fail the whole page decode`() {
+        // A webhook / system / integration message can arrive with
+        // author explicitly null. Before #1064, author was a required
+        // non-null field, so kotlinx.serialization threw on this element
+        // and the ENTIRE List<DiscordMessage> decode failed — the whole
+        // channel surfaced as NetworkError. The real-shaped author-less
+        // message sits BETWEEN two normal ones to prove the page survives
+        // and the good neighbours still decode.
+        val body = """
+            [
+              {
+                "id": "1500000000000000001",
+                "timestamp": "2026-05-13T20:00:00.000000+00:00",
+                "content": "normal message before",
+                "author": { "id": "111", "username": "alice", "global_name": "Alice" },
+                "attachments": [],
+                "embeds": [],
+                "type": 0
+              },
+              {
+                "id": "1500000000000000002",
+                "timestamp": "2026-05-13T20:01:00.000000+00:00",
+                "content": "webhook post with no author",
+                "author": null,
+                "attachments": [],
+                "embeds": [],
+                "type": 0
+              },
+              {
+                "id": "1500000000000000003",
+                "timestamp": "2026-05-13T20:02:00.000000+00:00",
+                "content": "normal message after",
+                "author": { "id": "222", "username": "bob", "global_name": "Bob" },
+                "attachments": [],
+                "embeds": [],
+                "type": 0
+              }
+            ]
+        """.trimIndent()
+
+        val messages = apiJson.decodeFromString<List<DiscordMessage>>(body)
+
+        assertEquals(3, messages.size)
+        assertEquals("Alice", messages[0].author?.displayName())
+        // The anomalous element decodes with a null author rather than
+        // throwing — this is the core #1064 regression guard.
+        assertNull(messages[1].author)
+        assertEquals("normal message after", messages[2].content)
+        assertEquals("Bob", messages[2].author?.displayName())
+    }
+
+    @Test
+    fun `a message with author field entirely absent decodes with null author`() {
+        // Some system-message shapes omit `author` outright rather than
+        // sending null. A missing required field threw MissingFieldException
+        // before #1064; with author defaulted to null it now decodes.
+        val body = """
+            [
+              {
+                "id": "1600000000000000001",
+                "timestamp": "2026-05-13T21:00:00.000000+00:00",
+                "content": "system event with no author key",
+                "attachments": [],
+                "embeds": [],
+                "type": 6
+              }
+            ]
+        """.trimIndent()
+
+        val messages = apiJson.decodeFromString<List<DiscordMessage>>(body)
+
+        assertEquals(1, messages.size)
+        assertNull(messages[0].author)
+        // The display-name fallback yields the synthetic label for a
+        // null author, matching the DiscordUser.displayName() terminal.
+        assertEquals("Unknown", messages[0].author?.displayName() ?: "Unknown")
     }
 }


### PR DESCRIPTION
Fixes #1064.

## Problem
`DiscordMessage.author: DiscordUser` was declared **non-nullable with no default**, while `DiscordApi.listMessages` decodes a whole page as `decodeFromString<List<DiscordMessage>>(...)`. If **any** message in the page lacks an `author` (or has `author: null`) — common for some webhook / system / integration message shapes — kotlinx.serialization throws and the **entire page** surfaces as `FictionResult.NetworkError`. The channel becomes unreadable, not just the one anomalous message. The `type == 0` filter that would skip these runs *after* decode, too late.

`coerceInputValues = true` (DiscordApi.kt:55) does **not** save this: it coerces an explicit `null` to the default only when the property is nullable or has a default. `author` was neither, so null *or* a missing key threw `MissingFieldException` / `SerializationException`.

## Fix
`author: DiscordUser? = null`, consistent with how Slack (`user: SlackUser? = null`) and Telegram already defend nested objects. Consumers fall back null-safely:
- search result + coalesce group title → `author?.displayName() ?: "Unknown"`
- coalesce same-author grouping key → a **null author id never merges** (treated as a group boundary, the same instinct already used for unparseable timestamps), so distinct author-less messages don't collapse together.

Author-less messages stay system/webhook noise that the `type == 0` filter drops downstream — the key win is the page no longer fails to decode, so the channel opens.

## Tests
- 2 new `DiscordModelsTest` regression cases under a decoder that **mirrors the production config including `coerceInputValues`**:
  - an explicit `"author": null` element wedged **between two normal messages** — asserts the page decodes (3 elements), the anomaly has `author == null`, and the good neighbours still parse;
  - a message with the `author` key **absent entirely** — asserts it decodes with null author and the `?: "Unknown"` fallback holds.
- Existing assertions on known-present fixture authors switched to `!!` (documents the test's own precondition).
- **RED confirmed first**: both new tests threw `MissingFieldException` / decode failure against the old non-nullable model before the fix.
- `:source-discord:testDebugUnitTest` → **16 tests, 0 failures** (DiscordModelsTest 6, DiscordCoalesceTest 6, DiscordTechEmpowerSeedTest 4). BUILD SUCCESSFUL.

Found during the messaging-source scout (sibling to #1061).

🤖 Generated with [Claude Code](https://claude.com/claude-code)