### PR TITLE
perf(playback): getTimestamp-based position extrapolation for tighter A/V sync (#974)

### DIFF
--- a/core-playback/src/main/kotlin/in/jphe/storyvox/playback/tts/EnginePlayer.kt
+++ b/core-playback/src/main/kotlin/in/jphe/storyvox/playback/tts/EnginePlayer.kt
@@ -4,6 +4,7 @@ import android.content.Context
 import android.media.AudioAttributes as PlatformAudioAttributes
 import android.media.AudioFormat as AndroidAudioFormat
 import android.media.AudioManager
+import android.media.AudioTimestamp
 import android.media.AudioTrack
 import android.os.Looper
 import android.os.Process as AndroidProcess
@@ -1344,7 +1345,44 @@ class EnginePlayer @AssistedInject constructor(
         // `track.play()` and `playbackHeadPosition` is meaningful.
         val firstSentenceEmitted = state.currentSentenceRange != null
         if (track != null && sr > 0 && pipelineRunning.get() && firstSentenceEmitted) {
-            val headFrames = runCatching { track.playbackHeadPosition.toLong() }.getOrDefault(0L)
+            // Issue #974 — prefer AudioTrack.getTimestamp over
+            // getPlaybackHeadPosition. getTimestamp's (framePosition,
+            // nanoTime) pair is anchored to when those frames crossed
+            // the DAC — i.e. what the listener actually heard — which on
+            // Samsung deep-mixer paths trails the userspace
+            // playbackHeadPosition counter by 30-80 ms. We extrapolate
+            // that anchor forward to "frames played by now" via the pure
+            // [extrapolateFrames] helper (unit-tested in
+            // PositionExtrapolationTest).
+            //
+            // Readiness gate: getTimestamp returns false (and/or a
+            // degenerate (0,0) pair) for the first 2-3 buffer cycles
+            // after play(). The outer firstSentenceEmitted gate covers
+            // most of that, but we also require ok && framePosition > 0
+            // before trusting the anchor; otherwise we fall through to
+            // the legacy playbackHeadPosition read so behavior on
+            // devices that don't support getTimestamp — or on the brief
+            // post-play() / post-flush window — is byte-identical to the
+            // pre-#974 path. The monotonic clamp below still guards
+            // against the 1-2 ms negative drifts the issue notes.
+            val tsFrames = runCatching {
+                val ts = AudioTimestamp()
+                if (track.getTimestamp(ts) && ts.framePosition > 0L) {
+                    extrapolateFrames(
+                        anchorFrames = ts.framePosition,
+                        anchorNanos = ts.nanoTime,
+                        nowNanos = System.nanoTime(),
+                        sampleRate = sr,
+                    )
+                } else {
+                    null // not ready / unsupported — use the legacy read
+                }
+            }.getOrNull()
+            // Fall back to the legacy playbackHeadPosition read whenever
+            // getTimestamp isn't usable (not ready, unsupported, or threw)
+            // so this branch never returns worse than the pre-#974 value.
+            val headFrames = tsFrames
+                ?: runCatching { track.playbackHeadPosition.toLong() }.getOrDefault(0L)
             // Wall-clock-ms-of-PCM-played, then scaled up by the speed
             // the PCM was synthesized at to get media-time-ms.
             val wallClockMs = (headFrames * 1000L) / sr.coerceAtLeast(1)
@@ -2831,7 +2869,20 @@ class EnginePlayer @AssistedInject constructor(
                     // launch when the index actually changes.
                     if (!resumedFromPause && chunk.sentenceIndex != currentSentenceIndex) {
                         currentSentenceIndex = chunk.sentenceIndex
-                        scope.launch {
+                        // Issue #974 (Part B) — dispatch the sentence-range
+                        // emit with Dispatchers.Main.immediate. The highlight
+                        // the user sees is driven by this currentSentenceRange
+                        // update; under heavy Compose recomposition the default
+                        // Main dispatcher can back up by tens of ms, delaying
+                        // the highlight a beat behind the audio. .immediate runs
+                        // the update synchronously when we're already on Main
+                        // (and gives the URGENT_AUDIO-thread case a priority
+                        // bump), shaving that queue wait. Same pattern as the
+                        // #573 emit at the chapter-done path below. The
+                        // _observableState.update remains a single atomic
+                        // whole-PlaybackState snapshot — we only change the
+                        // dispatcher, not the atomicity.
+                        scope.launch(Dispatchers.Main.immediate) {
                             _observableState.update {
                                 it.copy(
                                     currentSentenceRange = chunk.range,

--- a/core-playback/src/main/kotlin/in/jphe/storyvox/playback/tts/PositionExtrapolation.kt
+++ b/core-playback/src/main/kotlin/in/jphe/storyvox/playback/tts/PositionExtrapolation.kt
@@ -1,0 +1,45 @@
+package `in`.jphe.storyvox.playback.tts
+
+/**
+ * Issue #974 (Part A) — pure DAC-anchor extrapolation used by
+ * [EnginePlayer.currentPositionMs].
+ *
+ * `AudioTrack.getTimestamp(AudioTimestamp)` returns a
+ * `(framePosition, nanoTime)` pair anchored to the instant those frames
+ * crossed the DAC — i.e. the frame the *listener* heard at `nanoTime`,
+ * which on Samsung deep-mixer paths trails [AudioTrack.getPlaybackHeadPosition]
+ * (the userspace ring-buffer counter) by 30–80 ms. Between position
+ * polls we extrapolate that anchor forward to "frames the DAC has played
+ * by `nowNanos`":
+ *
+ *   anchorFrames + (nowNanos - anchorNanos) * sampleRate / 1_000_000_000
+ *
+ * Kept as a free function so the arithmetic is unit-testable without an
+ * Android `AudioTrack` (the framework call that fills the struct stays
+ * on the device path). [EnginePlayer.currentPositionMs] feeds the result
+ * through its existing speed-invariant axis and monotonic clamp
+ * unchanged.
+ *
+ * Defensive clamps (see #974 care points):
+ *  - A negative elapsed delta (a stale anchor whose `nanoTime` reads
+ *    slightly ahead of our `System.nanoTime`, possible on rapid calls)
+ *    clamps to zero so the helper never rewinds below the anchor.
+ *  - A non-positive [sampleRate] (uninitialized pipeline, corrupt read)
+ *    returns the anchor unscaled rather than dividing by zero.
+ *
+ * The multiply is done in [Long] after splitting nanos to avoid
+ * overflow: `deltaNanos` is small (one poll cadence, ~5e7 ns) and
+ * `sampleRate` is ~2.4e4, so `deltaNanos * sampleRate` (~1.2e12) fits
+ * comfortably in a Long before the 1e9 divide.
+ */
+internal fun extrapolateFrames(
+    anchorFrames: Long,
+    anchorNanos: Long,
+    nowNanos: Long,
+    sampleRate: Int,
+): Long {
+    if (sampleRate <= 0) return anchorFrames
+    val deltaNanos = (nowNanos - anchorNanos).coerceAtLeast(0L)
+    val extraFrames = deltaNanos * sampleRate / 1_000_000_000L
+    return anchorFrames + extraFrames
+}

--- a/core-playback/src/test/kotlin/in/jphe/storyvox/playback/tts/PositionExtrapolationTest.kt
+++ b/core-playback/src/test/kotlin/in/jphe/storyvox/playback/tts/PositionExtrapolationTest.kt
@@ -1,0 +1,98 @@
+package `in`.jphe.storyvox.playback.tts
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+/**
+ * Issue #974 (Part A) — unit coverage for the pure `getTimestamp`
+ * extrapolation math used by [EnginePlayer.currentPositionMs].
+ *
+ * `AudioTrack.getTimestamp` hands back a `(framePosition, nanoTime)`
+ * pair anchored to the moment those frames crossed the DAC. Between
+ * 50 ms position polls we extrapolate forward to "frames played
+ * through the DAC right now" by adding the wall-clock elapsed since
+ * the anchor, scaled to frames:
+ *
+ *   extrapolated = anchorFrames + (nowNanos - anchorNanos) * sampleRate / 1e9
+ *
+ * These tests pin that arithmetic — and the defensive clamps the issue
+ * calls out — without an Android `AudioTrack`. The framework call that
+ * fills the timestamp struct stays on the (untested) device path; only
+ * the math lives here, mirroring how the rest of the playback suite
+ * tests derived position values rather than the framework.
+ */
+class PositionExtrapolationTest {
+
+    private val SR = 24_000 // sherpa-onnx default; representative
+
+    @Test
+    fun `zero elapsed returns the anchor frame exactly`() {
+        // now == anchor: no time has passed, so the playhead is exactly
+        // where the DAC anchor says it is.
+        val frames = extrapolateFrames(
+            anchorFrames = 48_000L,
+            anchorNanos = 1_000_000_000L,
+            nowNanos = 1_000_000_000L,
+            sampleRate = SR,
+        )
+        assertEquals(48_000L, frames)
+    }
+
+    @Test
+    fun `one second elapsed advances by exactly one sampleRate of frames`() {
+        // 1.0 s after the anchor, the DAC has drained sampleRate more
+        // frames. 48000 + 24000 = 72000.
+        val frames = extrapolateFrames(
+            anchorFrames = 48_000L,
+            anchorNanos = 1_000_000_000L,
+            nowNanos = 2_000_000_000L, // +1.0 s
+            sampleRate = SR,
+        )
+        assertEquals(72_000L, frames)
+    }
+
+    @Test
+    fun `fifty ms elapsed advances by the poll-cadence worth of frames`() {
+        // The post-#970 poll cadence is 50 ms. At 24 kHz that's
+        // 0.050 * 24000 = 1200 frames of forward extrapolation — the
+        // gap this fix exists to close.
+        val frames = extrapolateFrames(
+            anchorFrames = 0L,
+            anchorNanos = 0L,
+            nowNanos = 50_000_000L, // 50 ms in nanos
+            sampleRate = SR,
+        )
+        assertEquals(1_200L, frames)
+    }
+
+    @Test
+    fun `a stale anchor in the future never rewinds the playhead`() {
+        // getTimestamp can hand back an anchor whose nanoTime is
+        // slightly AHEAD of our System.nanoTime read when called
+        // rapidly (different clock reads). A negative delta must clamp
+        // to zero rather than subtract frames — the monotonic latch in
+        // currentPositionMs is the outer guard, but we don't want this
+        // helper feeding it a value below the anchor either.
+        val frames = extrapolateFrames(
+            anchorFrames = 48_000L,
+            anchorNanos = 2_000_000_000L,
+            nowNanos = 1_999_000_000L, // 1 ms BEFORE the anchor
+            sampleRate = SR,
+        )
+        assertEquals(48_000L, frames)
+    }
+
+    @Test
+    fun `non-positive sampleRate returns the anchor unscaled`() {
+        // Defensive: a 0 / negative sampleRate (uninitialized pipeline,
+        // corrupt read) must not divide-by-zero or produce garbage —
+        // fall back to the anchor frame count.
+        val frames = extrapolateFrames(
+            anchorFrames = 12_345L,
+            anchorNanos = 0L,
+            nowNanos = 1_000_000_000L,
+            sampleRate = 0,
+        )
+        assertEquals(12_345L, frames)
+    }
+}


### PR DESCRIPTION
Refs #974. Follow-up to #970 (poll-cadence tightening).

## What

Closes the remaining two contributors to the "display catches up a beat after the speaker" lag the #970 investigation identified.

### Part A — `getTimestamp` extrapolation in `currentPositionMs()`

`AudioTrack.getPlaybackHeadPosition()` counts the userspace ring buffer; on Samsung deep-mixer paths it trails what the listener actually *hears* by 30–80 ms. `getTimestamp(AudioTimestamp)` returns a `(framePosition, nanoTime)` pair anchored to when frames cross the **DAC**. Between 50 ms polls we extrapolate that anchor forward to "frames played by now":

```
anchorFrames + (now - anchorNanos) * sampleRate / 1e9
```

The math lives in a new pure helper, `extrapolateFrames()`. The result feeds the **existing** speed-invariant axis (`pipelineStartSpeed` scaling) and the **existing** monotonic clamp completely unchanged — only the source of the frame count moved.

**Readiness + fallback (the reason this isn't a one-liner):** `getTimestamp` returns `false` / a degenerate `(0,0)` pair for the first 2–3 buffer cycles after `play()`. We require `ok && framePosition > 0` before trusting the anchor; otherwise — including if `getTimestamp` throws — we fall back to the legacy `playbackHeadPosition` read, so behavior on unsupported devices and the brief post-`play()` / post-flush window is **byte-identical** to the pre-#974 path.

Invariants verified untouched: #536 monotonic latch, #554 pause-pin, #555 speed-invariant axis (the 1:21→1:02 speed-chip jump), #566 warming-up gate.

### Part B — sentence-emit dispatch

The `currentSentenceRange` emit that drives the highlight now uses `scope.launch(Dispatchers.Main.immediate)` (same pattern as the #573 chapter-done emit) so a backed-up Main under heavy Compose recomposition doesn't delay the highlight behind the audio. The `_observableState.update` stays a single atomic whole-`PlaybackState` snapshot — only the dispatcher changed (issue's recommended option 1; option 2's per-field split was explicitly rejected for breaking the atomic-snapshot guarantee).

## Tests

`PositionExtrapolationTest` (new, 5 cases) pins the pure arithmetic without an Android `AudioTrack`: anchor identity at zero elapsed, +1 s = +sampleRate frames, +50 ms = poll-cadence frames, stale-anchor-in-the-future no-rewind clamp, and non-positive-sampleRate divide-by-zero guard. The framework `getTimestamp` call stays on the device path — matching how the rest of the playback suite tests *derived* position rather than the framework. TDD: watched it fail (unresolved `extrapolateFrames`) → pass.

- `:core-playback:testDebugUnitTest` → **330 green, 0 failures** (incl. the #553/#554/#555 `PlaybackSmoothnessFollowupTest` and the #568/#566 `PolishBundle*` guards).
- `:app:assembleDebug` green.

## On-device acceptance (manual, for the ship pass)

The 30–80 ms gain is device-dependent. The issue's acceptance asks for a manual A/V-sync smoke on R83W80CAFZB vs the post-#970 baseline (target: perceived <50 ms lag) and a `getTimestamp`-cost check on the Tab A7 Lite (Helio P22T) at the 50 ms cadence. Not reproducible in JVM tests — flagged here for the on-device step.

## Collision note

⚠️ Touches the same EnginePlayer timing path as **#994 (per-word highlight, @Reverie)** — specifically `currentPositionMs()` (~L1347) and the sentence-emit site (~L2864). Coordinated directly with Reverie; their branch was at base when this was written. **Please sequence the merge** with #994 to avoid a hot-path clobber. A tighter `currentPositionMs` is a net help for per-word granularity, so building #994 on top of this should be additive.

## Files

- `core-playback/.../tts/PositionExtrapolation.kt` — new pure `extrapolateFrames()` helper.
- `core-playback/.../tts/EnginePlayer.kt` — Part A read-swap + Part B dispatcher.
- `core-playback/.../tts/PositionExtrapolationTest.kt` — new unit tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved playback position tracking accuracy for better audio-text synchronization
  * Reduced text highlighting lag during playback for improved responsiveness

* **Tests**
  * Added unit tests to validate playback position calculation accuracy

<!-- end of auto-generated comment: release notes by coderabbit.ai -->