### PR TITLE
feat(reader): color overlays + custom reading themes (#993)

### DIFF
--- a/app/src/main/kotlin/in/jphe/storyvox/data/SettingsRepositoryUiImpl.kt
+++ b/app/src/main/kotlin/in/jphe/storyvox/data/SettingsRepositoryUiImpl.kt
@@ -69,6 +69,7 @@ import `in`.jphe.storyvox.source.azure.AzureVoiceRoster
 import `in`.jphe.storyvox.feature.api.CacheQuotaOptions
 import `in`.jphe.storyvox.feature.api.UiSettings
 import `in`.jphe.storyvox.feature.api.UiSigil
+import `in`.jphe.storyvox.ui.theme.ReaderTheme
 import `in`.jphe.storyvox.playback.cache.CacheStatsRepository
 import `in`.jphe.storyvox.playback.cache.PcmCache
 import `in`.jphe.storyvox.playback.cache.PcmCacheConfig
@@ -827,6 +828,15 @@ private object Keys {
      *  fall back to [ReadingDirection.FollowSystem] on read. */
     val A11Y_READING_DIRECTION = stringPreferencesKey("pref_a11y_reading_direction")
 
+    /** Issue #993 — reading-theme (color overlay) for the reader surface.
+     *  Stored as the [ReaderTheme] enum's name; unknown values fall back to
+     *  [ReaderTheme.Default] on read. Custom fg/bg are ARGB ints (0 = unset).
+     *  Device-local (NOT synced) — same per-device rationale as the reader
+     *  typography prefs (#992). */
+    val READER_THEME = stringPreferencesKey("pref_reader_theme")
+    val READER_CUSTOM_FG_ARGB = intPreferencesKey("pref_reader_custom_fg_argb")
+    val READER_CUSTOM_BG_ARGB = intPreferencesKey("pref_reader_custom_bg_argb")
+
     /**
      * Accessibility scaffold Phase 2 (#488, v0.5.43) — one-shot
      * dismissal flag for the TalkBack-install nudge surfaced in the
@@ -1486,6 +1496,15 @@ class SettingsRepositoryUiImpl(
             autoItemsPerCategory = snapAutoItemsPerCategory(
                 prefs[Keys.AUTO_ITEMS_PER_CATEGORY] ?: 6,
             ),
+            // Issue #993 — reading-theme. Unknown enum strings fall back to
+            // Default; custom fg/bg are raw ARGB ints (0 = unset). The
+            // UiSettings.readerColors accessor resolves these into the
+            // ReaderColors triple consumed by the reader.
+            readerTheme = prefs[Keys.READER_THEME]
+                ?.let { runCatching { ReaderTheme.valueOf(it) }.getOrNull() }
+                ?: ReaderTheme.Default,
+            readerCustomFgArgb = prefs[Keys.READER_CUSTOM_FG_ARGB] ?: 0,
+            readerCustomBgArgb = prefs[Keys.READER_CUSTOM_BG_ARGB] ?: 0,
         )
     }
 
@@ -2451,6 +2470,26 @@ class SettingsRepositoryUiImpl(
             it[Keys.AUTO_ITEMS_PER_CATEGORY] = snapAutoItemsPerCategory(count)
         }
         stampSyncedWrite()
+    }
+
+    // ── Reading theme / color overlay (issue #993) ─────────────────
+    // DEVICE-LOCAL — reading themes are a per-device reading-comfort choice
+    // (sepia on a phone, dark on a tablet), so these setters are deliberately
+    // NOT in SYNC_ALLOWLIST and do NOT call stampSyncedWrite(). Same rationale
+    // and idiom as the #992 reader-typography prefs.
+    override suspend fun setReaderTheme(theme: ReaderTheme) {
+        store.edit { it[Keys.READER_THEME] = theme.name }
+    }
+
+    override suspend fun setReaderCustomColors(fgArgb: Int, bgArgb: Int) {
+        // Selecting a custom pair implies the Custom theme, so flip the theme
+        // enum in the same edit — otherwise the colours would persist but the
+        // reader would keep showing whatever preset was active.
+        store.edit {
+            it[Keys.READER_CUSTOM_FG_ARGB] = fgArgb
+            it[Keys.READER_CUSTOM_BG_ARGB] = bgArgb
+            it[Keys.READER_THEME] = ReaderTheme.Custom.name
+        }
     }
 
     // ── Azure Speech Services BYOK (#182, PR-3) ────────────────────

--- a/core-ui/src/main/kotlin/in/jphe/storyvox/ui/component/SentenceHighlight.kt
+++ b/core-ui/src/main/kotlin/in/jphe/storyvox/ui/component/SentenceHighlight.kt
@@ -23,6 +23,7 @@ import androidx.compose.ui.text.TextLayoutResult
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import `in`.jphe.storyvox.ui.theme.LocalMotion
+import `in`.jphe.storyvox.ui.theme.LocalReaderColors
 import `in`.jphe.storyvox.ui.theme.LocalReducedMotion
 
 /**
@@ -48,8 +49,12 @@ fun SentenceHighlight(
     onLongPressWord: ((String) -> Unit)? = null,
     onLayout: ((TextLayoutResult) -> Unit)? = null,
 ) {
-    val brass = MaterialTheme.colorScheme.primary
-    val onSurface = MaterialTheme.colorScheme.onSurface
+    // #993 — when a reading theme is active, the chapter text uses the
+    // theme's foreground and the sentence underline uses its accent; otherwise
+    // we fall back to MaterialTheme so the default reader is pixel-identical.
+    val readerColors = LocalReaderColors.current.resolved
+    val brass = readerColors?.accent ?: MaterialTheme.colorScheme.primary
+    val onSurface = readerColors?.foreground ?: MaterialTheme.colorScheme.onSurface
     val motion = LocalMotion.current
 
     var layout by remember { mutableStateOf<TextLayoutResult?>(null) }

--- a/core-ui/src/main/kotlin/in/jphe/storyvox/ui/theme/ReaderColors.kt
+++ b/core-ui/src/main/kotlin/in/jphe/storyvox/ui/theme/ReaderColors.kt
@@ -1,0 +1,162 @@
+package `in`.jphe.storyvox.ui.theme
+
+import androidx.compose.runtime.Immutable
+import androidx.compose.runtime.staticCompositionLocalOf
+import androidx.compose.ui.graphics.Color
+
+/**
+ * Reading-theme choice for the chapter-reading surface (#993).
+ *
+ * Separate from the *app* theme: a user may want sepia paper for reading while
+ * keeping the brand dark chrome everywhere else. Stored as a stable enum (not a
+ * [Color] triple) so it persists as a plain string. [Default] means "use the
+ * app theme" — the reader renders exactly as it does today.
+ */
+enum class ReaderTheme {
+    /** Inherit the app theme — no reader-specific tint. */
+    Default,
+
+    /** Warm light paper (the app's existing paper-cream light surface). */
+    Light,
+
+    /** Warm dark (the app's existing Library Nocturne dark surface). */
+    Dark,
+
+    /** Classic sepia — dark-brown ink on aged-paper cream. */
+    Sepia,
+
+    /** Soft cream — near-black ink on a gentle off-white, lower glare than pure white. */
+    Cream,
+
+    /** Maximal-legibility: pure black ink on pure white (AAA). */
+    HighContrastBlackOnWhite,
+
+    /** Maximal-legibility inverse: pure white ink on pure black (AAA), low light. */
+    HighContrastWhiteOnBlack,
+
+    /** User-chosen foreground/background pair (the Irlen-style custom overlay). */
+    Custom,
+}
+
+/**
+ * Resolved reading-surface colour triple.
+ *
+ * - [foreground] — chapter body text + chapter title.
+ * - [background] — the reader surface behind the text.
+ * - [accent] — the sentence-highlight underline (kept legible against [background]).
+ */
+@Immutable
+data class ReaderColorTriple(
+    val foreground: Color,
+    val background: Color,
+    val accent: Color,
+)
+
+/**
+ * Reading-surface colours for the current reader, consumed via [LocalReaderColors]
+ * and provided from the app layer (which owns the persisted setting) — the same
+ * dependency-inversion seam used by [LocalReaderTypography] / [LocalSpacing].
+ *
+ * When [active] is false (the default), [resolved] is null and the reader renders
+ * with `MaterialTheme` colours exactly as it does today. The renderer only applies
+ * a tint when [active] — so existing readers see no change until they opt in (#993).
+ */
+@Immutable
+data class ReaderColors(
+    val active: Boolean = false,
+    val resolved: ReaderColorTriple? = null,
+) {
+    companion object {
+        // ── Preset triples ──────────────────────────────────────────────
+        // Each preset's fg/bg clears at least AA-large (3:1); the two
+        // high-contrast presets clear AAA (7:1). Accents are chosen to stay
+        // ≥3:1 on their own background so the sentence underline never
+        // vanishes. (Verified by ReaderColorsTest.)
+
+        private val LIGHT = ReaderColorTriple(
+            foreground = SurfaceTokens.OnSurfaceLight,   // #1A1614
+            background = SurfaceTokens.SurfaceLight,      // #F4EDE2 paper-cream
+            accent = BrassRamp.Brass600,                  // #5A431F — brass on cream
+        )
+        private val DARK = ReaderColorTriple(
+            foreground = SurfaceTokens.OnSurfaceDark,    // #E8DFD1
+            background = SurfaceTokens.SurfaceDark,        // #0E0C12
+            accent = BrassRamp.Brass400,                  // #C9A774 — brass on dark
+        )
+        private val SEPIA = ReaderColorTriple(
+            foreground = Color(0xFF4A3A28),               // dark-brown ink
+            background = Color(0xFFF4ECD8),               // aged-paper cream
+            accent = Color(0xFF7A4A1F),                   // deeper sepia-brown accent
+        )
+        private val CREAM = ReaderColorTriple(
+            foreground = Color(0xFF2A2620),               // near-black warm ink
+            background = Color(0xFFFBF6EC),               // soft off-white
+            accent = BrassRamp.Brass600,                  // #5A431F
+        )
+        private val HC_BLACK_ON_WHITE = ReaderColorTriple(
+            foreground = Color(0xFF000000),
+            background = Color(0xFFFFFFFF),
+            accent = Color(0xFF5A3E10),                   // dark brass — AAA on white
+        )
+        private val HC_WHITE_ON_BLACK = ReaderColorTriple(
+            foreground = Color(0xFFFFFFFF),
+            background = Color(0xFF000000),
+            accent = HighContrastTokens.BrassHc500,       // #FFC14A — bright brass on black
+        )
+
+        /** Build [ReaderColors] for a preset. [ReaderTheme.Default] → inactive. */
+        fun forTheme(theme: ReaderTheme): ReaderColors = when (theme) {
+            ReaderTheme.Default -> ReaderColors()
+            ReaderTheme.Light -> ReaderColors(active = true, resolved = LIGHT)
+            ReaderTheme.Dark -> ReaderColors(active = true, resolved = DARK)
+            ReaderTheme.Sepia -> ReaderColors(active = true, resolved = SEPIA)
+            ReaderTheme.Cream -> ReaderColors(active = true, resolved = CREAM)
+            ReaderTheme.HighContrastBlackOnWhite ->
+                ReaderColors(active = true, resolved = HC_BLACK_ON_WHITE)
+            ReaderTheme.HighContrastWhiteOnBlack ->
+                ReaderColors(active = true, resolved = HC_WHITE_ON_BLACK)
+            // Custom needs the user's colours — callers must use [custom] /
+            // [resolve]; a bare Custom with no colours degrades to inactive.
+            ReaderTheme.Custom -> ReaderColors()
+        }
+
+        /**
+         * Build [ReaderColors] for a user-chosen foreground/background pair.
+         * The accent is derived from the foreground so it always tracks the
+         * user's ink colour (and therefore stays legible against their bg).
+         */
+        fun custom(foreground: Color, background: Color): ReaderColors =
+            ReaderColors(
+                active = true,
+                resolved = ReaderColorTriple(
+                    foreground = foreground,
+                    background = background,
+                    accent = foreground,
+                ),
+            )
+
+        /**
+         * Settings-layer entry point: turn the persisted `(theme, customFgArgb,
+         * customBgArgb)` triple into [ReaderColors]. Custom colours persist as
+         * ARGB ints (`Color.toArgb()`); `0` means "unset", in which case Custom
+         * degrades to inactive rather than rendering a transparent surface.
+         */
+        fun resolve(theme: ReaderTheme, customFgArgb: Int, customBgArgb: Int): ReaderColors =
+            if (theme == ReaderTheme.Custom) {
+                if (customFgArgb == 0 || customBgArgb == 0) {
+                    ReaderColors()
+                } else {
+                    custom(Color(customFgArgb), Color(customBgArgb))
+                }
+            } else {
+                forTheme(theme)
+            }
+    }
+}
+
+/**
+ * Reading-surface colours for the current reader. Defaults to *inactive* (the
+ * reader uses `MaterialTheme` colours); the app layer overrides it via
+ * `CompositionLocalProvider` around the reader when a theme is selected.
+ */
+val LocalReaderColors = staticCompositionLocalOf { ReaderColors() }

--- a/core-ui/src/main/kotlin/in/jphe/storyvox/ui/theme/WcagContrast.kt
+++ b/core-ui/src/main/kotlin/in/jphe/storyvox/ui/theme/WcagContrast.kt
@@ -1,0 +1,74 @@
+package `in`.jphe.storyvox.ui.theme
+
+import androidx.compose.ui.graphics.Color
+import kotlin.math.pow
+
+/** WCAG conformance rating for a foreground/background pair (normal-size body text). */
+enum class WcagRating {
+    /** < 3:1 — fails even large-text AA. */
+    FAIL,
+
+    /** ≥ 3:1 but < 4.5:1 — passes AA for large text only. */
+    AA_LARGE,
+
+    /** ≥ 4.5:1 but < 7:1 — passes AA for normal body text. */
+    AA,
+
+    /** ≥ 7:1 — passes AAA for normal body text. */
+    AAA,
+}
+
+/**
+ * WCAG 2.x relative-luminance contrast ratio.
+ *
+ * Used by the #993 custom reading-theme picker to validate (and warn on) a
+ * user-chosen foreground/background pair before they apply it. We *warn* but
+ * never hard-block: a deliberate low-contrast choice is the user's call (an
+ * a11y tool that overrides the user isn't accessible), and the presets are
+ * always one tap away. The math is pure JVM so it unit-tests without
+ * Robolectric.
+ *
+ * Formula (WCAG 2.1, "relative luminance" + "contrast ratio"):
+ *   - linearize each sRGB channel c in [0,1]: c ≤ 0.03928 ? c/12.92 : ((c+0.055)/1.055)^2.4
+ *   - L = 0.2126·R + 0.7152·G + 0.0722·B
+ *   - ratio = (Llighter + 0.05) / (Ldarker + 0.05), in [1, 21]
+ */
+object WcagContrast {
+
+    private fun linearize(channel: Float): Double {
+        val c = channel.toDouble()
+        return if (c <= 0.03928) c / 12.92 else ((c + 0.055) / 1.055).pow(2.4)
+    }
+
+    /** WCAG relative luminance of [color], ignoring alpha (text is composited opaque). */
+    fun relativeLuminance(color: Color): Double =
+        0.2126 * linearize(color.red) +
+            0.7152 * linearize(color.green) +
+            0.0722 * linearize(color.blue)
+
+    /** Contrast ratio between two colors, in `[1.0, 21.0]`. Symmetric in its arguments. */
+    fun ratio(a: Color, b: Color): Double {
+        val la = relativeLuminance(a)
+        val lb = relativeLuminance(b)
+        val lighter = maxOf(la, lb)
+        val darker = minOf(la, lb)
+        return (lighter + 0.05) / (darker + 0.05)
+    }
+
+    /** AA for normal body text: ≥ 4.5:1. */
+    fun passesAaNormal(fg: Color, bg: Color): Boolean = ratio(fg, bg) >= 4.5
+
+    /** AA for large text (≥18pt, or ≥14pt bold): ≥ 3:1. */
+    fun passesAaLarge(fg: Color, bg: Color): Boolean = ratio(fg, bg) >= 3.0
+
+    /** Classify a foreground/background pair against the WCAG body-text thresholds. */
+    fun rating(fg: Color, bg: Color): WcagRating {
+        val r = ratio(fg, bg)
+        return when {
+            r >= 7.0 -> WcagRating.AAA
+            r >= 4.5 -> WcagRating.AA
+            r >= 3.0 -> WcagRating.AA_LARGE
+            else -> WcagRating.FAIL
+        }
+    }
+}

--- a/core-ui/src/test/kotlin/in/jphe/storyvox/ui/theme/ReaderColorsTest.kt
+++ b/core-ui/src/test/kotlin/in/jphe/storyvox/ui/theme/ReaderColorsTest.kt
@@ -1,0 +1,117 @@
+package `in`.jphe.storyvox.ui.theme
+
+import androidx.compose.ui.graphics.Color
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * Pure-JVM tests for the #993 reading-theme seam. Compose [Color] is pure
+ * JVM, so presets, the custom builder, and the "inactive default" no-op can
+ * all be asserted without Robolectric (same approach as ReaderTypographyTest).
+ */
+class ReaderColorsTest {
+
+    @Test
+    fun `default reader colors are inactive — renderer falls back to MaterialTheme`() {
+        // The CompositionLocal default MUST be inactive so existing readers
+        // render exactly as today until they opt into a theme (#993).
+        assertFalse(ReaderColors().active)
+        assertNull(ReaderColors().resolved)
+    }
+
+    @Test
+    fun `every non-Default preset resolves to a concrete colour triple`() {
+        ReaderTheme.entries
+            .filter { it != ReaderTheme.Default && it != ReaderTheme.Custom }
+            .forEach { theme ->
+                val colors = ReaderColors.forTheme(theme)
+                assertTrue("$theme should be active", colors.active)
+                assertNotNull("$theme should resolve", colors.resolved)
+            }
+    }
+
+    @Test
+    fun `Default theme is inactive`() {
+        assertFalse(ReaderColors.forTheme(ReaderTheme.Default).active)
+    }
+
+    @Test
+    fun `every preset clears AA-large for body text (3 to 1 floor)`() {
+        // Presets are curated; none may ship below the large-text AA floor.
+        ReaderTheme.entries
+            .filter { it != ReaderTheme.Default && it != ReaderTheme.Custom }
+            .forEach { theme ->
+                val c = ReaderColors.forTheme(theme).resolved!!
+                val ratio = WcagContrast.ratio(c.foreground, c.background)
+                assertTrue(
+                    "$theme contrast ${"%.2f".format(ratio)} below 3:1",
+                    ratio >= 3.0,
+                )
+            }
+    }
+
+    @Test
+    fun `high-contrast presets clear AAA (7 to 1)`() {
+        listOf(
+            ReaderTheme.HighContrastBlackOnWhite,
+            ReaderTheme.HighContrastWhiteOnBlack,
+        ).forEach { theme ->
+            val c = ReaderColors.forTheme(theme).resolved!!
+            assertEquals(WcagRating.AAA, WcagContrast.rating(c.foreground, c.background))
+        }
+    }
+
+    @Test
+    fun `custom builder uses the supplied fg and bg`() {
+        val fg = Color(0xFF102030)
+        val bg = Color(0xFFFAFAFA)
+        val c = ReaderColors.custom(fg, bg).resolved!!
+        assertEquals(fg, c.foreground)
+        assertEquals(bg, c.background)
+    }
+
+    @Test
+    fun `custom theme is active`() {
+        assertTrue(ReaderColors.custom(Color(0xFF000000), Color(0xFFFFFFFF)).active)
+    }
+
+    @Test
+    fun `accent is legible against its own background (at least AA-large)`() {
+        // The sentence underline + chapter title use the accent; it must not
+        // vanish into the themed background.
+        ReaderTheme.entries
+            .filter { it != ReaderTheme.Default && it != ReaderTheme.Custom }
+            .forEach { theme ->
+                val c = ReaderColors.forTheme(theme).resolved!!
+                assertTrue(
+                    "$theme accent invisible on its background",
+                    WcagContrast.ratio(c.accent, c.background) >= 3.0,
+                )
+            }
+    }
+
+    @Test
+    fun `resolve picks preset triple for a preset and custom triple for Custom`() {
+        // The settings-layer entry point: (theme, customFgArgb, customBgArgb) → ReaderColors.
+        // Custom colours persist as ARGB ints (Color.toArgb); 0 = unset.
+        val sepia = ReaderColors.resolve(ReaderTheme.Sepia, customFgArgb = 0, customBgArgb = 0)
+        assertEquals(ReaderColors.forTheme(ReaderTheme.Sepia).resolved, sepia.resolved)
+
+        val customFg = 0xFF112233.toInt()
+        val customBg = 0xFFEEDDCC.toInt()
+        val custom = ReaderColors.resolve(ReaderTheme.Custom, customFg, customBg).resolved!!
+        assertEquals(Color(0xFF112233), custom.foreground)
+        assertEquals(Color(0xFFEEDDCC), custom.background)
+    }
+
+    @Test
+    fun `Custom with unset colours falls back to inactive`() {
+        // A user who selected Custom but never picked colours shouldn't get a
+        // transparent/black surface — degrade to the app theme (inactive).
+        assertFalse(ReaderColors.resolve(ReaderTheme.Custom, customFgArgb = 0, customBgArgb = 0).active)
+    }
+}

--- a/core-ui/src/test/kotlin/in/jphe/storyvox/ui/theme/WcagContrastTest.kt
+++ b/core-ui/src/test/kotlin/in/jphe/storyvox/ui/theme/WcagContrastTest.kt
@@ -1,0 +1,73 @@
+package `in`.jphe.storyvox.ui.theme
+
+import androidx.compose.ui.graphics.Color
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * Pure-JVM tests for the WCAG 2.x relative-luminance contrast ratio.
+ *
+ * Compose [Color] and the math are pure JVM — no Robolectric needed (same
+ * approach as ReaderTypographyTest). Reference ratios are the canonical
+ * WCAG values: black-on-white = 21:1 exactly, white-on-white = 1:1.
+ */
+class WcagContrastTest {
+
+    private val white = Color(0xFFFFFFFF)
+    private val black = Color(0xFF000000)
+
+    @Test
+    fun `black on white is the maximum 21 to 1`() {
+        assertEquals(21.0, WcagContrast.ratio(black, white), 0.05)
+    }
+
+    @Test
+    fun `white on white is the minimum 1 to 1`() {
+        assertEquals(1.0, WcagContrast.ratio(white, white), 0.001)
+    }
+
+    @Test
+    fun `ratio is symmetric — order of args does not matter`() {
+        val a = Color(0xFF333333)
+        val b = Color(0xFFCCCCCC)
+        assertEquals(WcagContrast.ratio(a, b), WcagContrast.ratio(b, a), 0.0001)
+    }
+
+    @Test
+    fun `mid grey on white — known reference around 5_3 to 1`() {
+        // #767676 on white is the canonical "just passes AA" grey: ~4.54:1.
+        val grey = Color(0xFF767676)
+        assertEquals(4.54, WcagContrast.ratio(grey, white), 0.1)
+    }
+
+    @Test
+    fun `sepia ink on cream paper clears AA for body text`() {
+        // Sepia preset: dark-brown ink on warm cream.
+        val ink = Color(0xFF4A3A28)
+        val paper = Color(0xFFF4ECD8)
+        assertTrue(WcagContrast.ratio(ink, paper) >= 4.5)
+    }
+
+    @Test
+    fun `passesAaNormal threshold is 4_5 to 1`() {
+        // A pair at exactly ~4.5 passes; a clearly-lower pair fails.
+        assertTrue(WcagContrast.passesAaNormal(black, white))
+        assertFalse(WcagContrast.passesAaNormal(Color(0xFFAAAAAA), white)) // ~2.0:1
+    }
+
+    @Test
+    fun `passesAaLarge is the laxer 3 to 1 threshold`() {
+        // A pair between 3 and 4.5 fails normal but passes large.
+        val grey = Color(0xFF949494) // ~3.0:1 on white
+        assertFalse(WcagContrast.passesAaNormal(grey, white))
+        assertTrue(WcagContrast.passesAaLarge(grey, white))
+    }
+
+    @Test
+    fun `rating classifies the canonical pairs`() {
+        assertEquals(WcagRating.AAA, WcagContrast.rating(black, white))      // 21:1
+        assertEquals(WcagRating.FAIL, WcagContrast.rating(white, white))     // 1:1
+    }
+}

--- a/feature/src/main/kotlin/in/jphe/storyvox/feature/api/UiContracts.kt
+++ b/feature/src/main/kotlin/in/jphe/storyvox/feature/api/UiContracts.kt
@@ -1,6 +1,8 @@
 package `in`.jphe.storyvox.feature.api
 
 import `in`.jphe.storyvox.playback.cache.ChapterCacheState
+import `in`.jphe.storyvox.ui.theme.ReaderColors
+import `in`.jphe.storyvox.ui.theme.ReaderTheme
 import kotlinx.coroutines.flow.Flow
 
 /**
@@ -1324,7 +1326,31 @@ data class UiSettings(
      * Per-device pref (NOT synced) — Auto pairing is device-bound.
      */
     val autoItemsPerCategory: Int = 6,
+    /**
+     * Issue #993 — reading-theme (color overlay) for the chapter-reading
+     * surface only, not app chrome. [ReaderTheme.Default] inherits the app
+     * theme (the reader renders exactly as today). Presets cover sepia /
+     * cream / high-contrast pairs; [ReaderTheme.Custom] uses
+     * [readerCustomFgArgb] / [readerCustomBgArgb].
+     *
+     * Per-device pref (NOT synced) — like reader typography (#992) and the
+     * other reader-comfort knobs, a user may want sepia on a phone and dark
+     * on a tablet; syncing would push one device's choice onto the other.
+     */
+    val readerTheme: ReaderTheme = ReaderTheme.Default,
+    /** Custom-theme foreground, as an ARGB int (`Color.toArgb`). 0 = unset. */
+    val readerCustomFgArgb: Int = 0,
+    /** Custom-theme background, as an ARGB int (`Color.toArgb`). 0 = unset. */
+    val readerCustomBgArgb: Int = 0,
 ) {
+    /**
+     * Resolved reading-surface colours for the reader (#993). Inactive when
+     * [readerTheme] is [ReaderTheme.Default] (or Custom with unset colours),
+     * in which case the reader uses `MaterialTheme` colours unchanged.
+     */
+    val readerColors: ReaderColors
+        get() = ReaderColors.resolve(readerTheme, readerCustomFgArgb, readerCustomBgArgb)
+
     /** Speed value the engine should run at right now — the active
      *  voice's override if set, otherwise the global default (#195). */
     val effectiveSpeed: Float
@@ -1747,6 +1773,17 @@ interface SettingsRepositoryUi {
      * [4, 6, 8, 12] on write. Default impl is a no-op.
      */
     suspend fun setAutoItemsPerCategory(count: Int) = Unit
+    /**
+     * Issue #993 — set the reading-theme (color overlay) for the reader
+     * surface. Device-local (NOT synced). Default impl is a no-op.
+     */
+    suspend fun setReaderTheme(theme: ReaderTheme) = Unit
+    /**
+     * Issue #993 — set the custom reading-theme foreground/background pair,
+     * as ARGB ints (`Color.toArgb`). Selecting a custom pair also implies
+     * [ReaderTheme.Custom]. Device-local (NOT synced). Default impl no-op.
+     */
+    suspend fun setReaderCustomColors(fgArgb: Int, bgArgb: Int) = Unit
     suspend fun setDefaultSpeed(speed: Float)
     suspend fun setDefaultPitch(pitch: Float)
     suspend fun setDefaultVoice(voiceId: String?)

--- a/feature/src/main/kotlin/in/jphe/storyvox/feature/reader/HybridReaderScreen.kt
+++ b/feature/src/main/kotlin/in/jphe/storyvox/feature/reader/HybridReaderScreen.kt
@@ -92,6 +92,7 @@ fun HybridReaderScreen(
     val chapters by viewModel.chapters.collectAsStateWithLifecycle()
     val autoScrollEnabled by viewModel.autoScrollEnabled.collectAsStateWithLifecycle()
     val focusModeEnabled by viewModel.focusModeEnabled.collectAsStateWithLifecycle()
+    val readerColors by viewModel.readerColors.collectAsStateWithLifecycle()
     val playback = state.playback
 
     // Calliope (v0.5.00) — first-natural-chapter-completion confetti.
@@ -360,6 +361,8 @@ fun HybridReaderScreen(
                 // collapses the bottom chrome when on.
                 focusModeEnabled = focusModeEnabled,
                 onToggleFocusMode = viewModel::setFocusModeEnabled,
+                // Issue #993 — reading-theme colour overlay for the surface.
+                readerColors = readerColors,
             )
         },
     )

--- a/feature/src/main/kotlin/in/jphe/storyvox/feature/reader/ReaderView.kt
+++ b/feature/src/main/kotlin/in/jphe/storyvox/feature/reader/ReaderView.kt
@@ -7,6 +7,7 @@ import androidx.compose.animation.fadeIn
 import androidx.compose.animation.fadeOut
 import androidx.compose.animation.slideInVertically
 import androidx.compose.animation.slideOutVertically
+import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
@@ -36,6 +37,7 @@ import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.derivedStateOf
 import androidx.compose.runtime.getValue
@@ -48,6 +50,7 @@ import androidx.compose.runtime.setValue
 import androidx.compose.runtime.snapshotFlow
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.draw.alpha
 import androidx.compose.ui.layout.onGloballyPositioned
 import androidx.compose.ui.layout.onSizeChanged
@@ -60,7 +63,9 @@ import androidx.compose.ui.unit.dp
 import `in`.jphe.storyvox.feature.R
 import `in`.jphe.storyvox.feature.api.UiPlaybackState
 import `in`.jphe.storyvox.ui.component.SentenceHighlight
+import `in`.jphe.storyvox.ui.theme.LocalReaderColors
 import `in`.jphe.storyvox.ui.theme.LocalSpacing
+import `in`.jphe.storyvox.ui.theme.ReaderColors
 import kotlin.math.roundToInt
 import kotlinx.coroutines.launch
 
@@ -155,6 +160,11 @@ fun ReaderTextView(
      *  [HybridReaderScreen] to [ReaderViewModel.setFocusModeEnabled].
      *  No-op default for preview/test callsites. */
     onToggleFocusMode: (Boolean) -> Unit = {},
+    /** Issue #993 — reading-theme colours for the chapter surface. Default
+     *  is inactive (the reader uses the app theme); when a theme is active
+     *  the body background + text + sentence underline are re-tinted. No-op
+     *  default keeps preview/test/audiobook callsites unchanged. */
+    readerColors: ReaderColors = ReaderColors(),
     modifier: Modifier = Modifier,
 ) {
     val spacing = LocalSpacing.current
@@ -263,7 +273,15 @@ fun ReaderTextView(
         label = "focus-title-alpha",
     )
 
-    Box(modifier = modifier.fillMaxSize().onSizeChanged { viewportHeightPx = it.height.toFloat() }) {
+    // #993 — provide the reading-theme colours to the chapter renderer below.
+    // When active we paint the theme background on the reader surface and tint
+    // the chapter title to the theme foreground; SentenceHighlight reads
+    // LocalReaderColors for the body text + underline. Inactive = no change.
+    val readerSurface = readerColors.resolved
+    val surfaceModifier =
+        if (readerSurface != null) modifier.background(readerSurface.background) else modifier
+    CompositionLocalProvider(LocalReaderColors provides readerColors) {
+    Box(modifier = surfaceModifier.fillMaxSize().onSizeChanged { viewportHeightPx = it.height.toFloat() }) {
         Column(
             modifier = Modifier
                 .fillMaxSize()
@@ -282,6 +300,11 @@ fun ReaderTextView(
             Text(
                 state.chapterTitle,
                 style = MaterialTheme.typography.headlineSmall,
+                // #993 — tint the title to the theme foreground when a reading
+                // theme is active; Color.Unspecified falls back to the app theme.
+                color = readerSurface?.foreground ?: Color.Unspecified,
+                // #997 — focus mode narrows the column (contentWidthModifier)
+                // and fades the title back (titleAlpha).
                 modifier = contentWidthModifier
                     .fillMaxWidth()
                     .padding(bottom = spacing.md)
@@ -565,6 +588,7 @@ fun ReaderTextView(
             )
         }
     }
+    } // CompositionLocalProvider(LocalReaderColors) — #993
 }
 
 @Composable

--- a/feature/src/main/kotlin/in/jphe/storyvox/feature/reader/ReaderViewModel.kt
+++ b/feature/src/main/kotlin/in/jphe/storyvox/feature/reader/ReaderViewModel.kt
@@ -15,6 +15,7 @@ import `in`.jphe.storyvox.feature.api.UiChapter
 import `in`.jphe.storyvox.feature.api.UiPlaybackState
 import `in`.jphe.storyvox.feature.api.UiRecapPlaybackState
 import `in`.jphe.storyvox.feature.api.UiSleepTimerMode
+import `in`.jphe.storyvox.ui.theme.ReaderColors
 import `in`.jphe.storyvox.playback.PlaybackUiEvent
 import `in`.jphe.storyvox.llm.LlmError
 import `in`.jphe.storyvox.llm.feature.ChapterRecap
@@ -466,6 +467,16 @@ class ReaderViewModel @Inject constructor(
      */
     val focusModeEnabled: StateFlow<Boolean> = settings.readerFocusModeEnabled
         .stateIn(viewModelScope, SharingStarted.WhileSubscribed(5_000), false)
+
+    /**
+     * Issue #993 — resolved reading-theme colours for the reader surface.
+     * Default [ReaderColors] is inactive, so the reader renders with the app
+     * theme until the user opts into a reading theme. Device-local pref.
+     */
+    val readerColors: StateFlow<ReaderColors> = settings.settings
+        .map { it.readerColors }
+        .distinctUntilChanged()
+        .stateIn(viewModelScope, SharingStarted.WhileSubscribed(5_000), ReaderColors())
 
     /** Issue #278 — user-initiated retry from the timed-out error block.
      *  Re-invokes the playback `play()` path; the underlying controller

--- a/feature/src/main/kotlin/in/jphe/storyvox/feature/settings/ReadingSettingsScreen.kt
+++ b/feature/src/main/kotlin/in/jphe/storyvox/feature/settings/ReadingSettingsScreen.kt
@@ -1,27 +1,55 @@
 package `in`.jphe.storyvox.feature.settings
 
+import androidx.compose.foundation.background
+import androidx.compose.foundation.border
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Slider
+import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.toArgb
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.semantics.contentDescription
+import androidx.compose.ui.semantics.semantics
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
 import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import `in`.jphe.storyvox.feature.R
 import `in`.jphe.storyvox.feature.api.ThemeOverride
 import `in`.jphe.storyvox.ui.theme.LocalSpacing
+import `in`.jphe.storyvox.ui.theme.ReaderColors
+import `in`.jphe.storyvox.ui.theme.ReaderTheme
+import `in`.jphe.storyvox.ui.theme.WcagContrast
+import `in`.jphe.storyvox.ui.theme.WcagRating
 
 /**
  * Settings → Reading subscreen (follow-up to #440 / #467).
  *
  * Visual reading knobs:
- *  - Theme override (System / Dark / Light, shipped in v0.5.32 #427).
+ *  - App theme override (System / Dark / Light, shipped in v0.5.32 #427).
  *  - Shake-to-extend sleep timer (#150).
+ *  - Reading-color theme + custom overlay (#993) — tints the reading page
+ *    only, leaving app chrome alone. Device-local pref.
  *
- * The legacy long-scroll [SettingsScreen] still renders the same two
- * rows under the "Reading" section heading; this subscreen is the
- * curated single-purpose surface reached from the hub.
+ * The legacy long-scroll [SettingsScreen] still renders the first two rows
+ * under the "Reading" section heading; this subscreen is the curated
+ * single-purpose surface reached from the hub.
  */
 @Composable
 fun ReadingSettingsScreen(
@@ -53,6 +81,260 @@ fun ReadingSettingsScreen(
                     onCheckedChange = viewModel::setSleepShakeToExtendEnabled,
                 )
             }
+
+            // #993 — reading-color theme (page overlay), separate from the
+            // app theme above.
+            SettingsSectionHeader(label = stringResource(R.string.settings_reading_overlay_group_title))
+            SettingsGroupCard {
+                ReadingThemeBlock(
+                    selectedTheme = s.readerTheme,
+                    customFgArgb = s.readerCustomFgArgb,
+                    customBgArgb = s.readerCustomBgArgb,
+                    onSelectTheme = viewModel::setReaderTheme,
+                    onCustomColors = viewModel::setReaderCustomColors,
+                )
+            }
         }
+    }
+}
+
+/** Maps a [ReaderTheme] to its display-name string resource. */
+@Composable
+private fun ReaderTheme.label(): String = stringResource(
+    when (this) {
+        ReaderTheme.Default -> R.string.settings_reading_overlay_theme_default
+        ReaderTheme.Light -> R.string.settings_reading_overlay_theme_light
+        ReaderTheme.Dark -> R.string.settings_reading_overlay_theme_dark
+        ReaderTheme.Sepia -> R.string.settings_reading_overlay_theme_sepia
+        ReaderTheme.Cream -> R.string.settings_reading_overlay_theme_cream
+        ReaderTheme.HighContrastBlackOnWhite -> R.string.settings_reading_overlay_theme_hc_bw
+        ReaderTheme.HighContrastWhiteOnBlack -> R.string.settings_reading_overlay_theme_hc_wb
+        ReaderTheme.Custom -> R.string.settings_reading_overlay_theme_custom
+    },
+)
+
+/**
+ * Reading-theme picker: a wrapping grid of preview chips (each rendered in its
+ * own colours so the user *sees* sepia / cream / etc.) plus, when Custom is
+ * selected, an RGB fg/bg picker with a live WCAG contrast readout.
+ */
+@Composable
+private fun ReadingThemeBlock(
+    selectedTheme: ReaderTheme,
+    customFgArgb: Int,
+    customBgArgb: Int,
+    onSelectTheme: (ReaderTheme) -> Unit,
+    onCustomColors: (fgArgb: Int, bgArgb: Int) -> Unit,
+) {
+    val spacing = LocalSpacing.current
+    Column(
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(horizontal = spacing.md, vertical = spacing.sm),
+        verticalArrangement = Arrangement.spacedBy(spacing.sm),
+    ) {
+        Text(
+            text = stringResource(R.string.settings_reading_overlay_title),
+            style = MaterialTheme.typography.bodyLarge,
+        )
+        Text(
+            text = stringResource(R.string.settings_reading_overlay_subtitle),
+            style = MaterialTheme.typography.bodySmall,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+        )
+
+        // Preset chips, two rows of four. Each chip previews its own theme.
+        ReaderTheme.entries.toList().chunked(4).forEach { rowThemes ->
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                horizontalArrangement = Arrangement.spacedBy(spacing.sm),
+            ) {
+                rowThemes.forEach { theme ->
+                    ThemeChip(
+                        theme = theme,
+                        selected = theme == selectedTheme,
+                        customFgArgb = customFgArgb,
+                        customBgArgb = customBgArgb,
+                        onClick = { onSelectTheme(theme) },
+                        modifier = Modifier.width(76.dp),
+                    )
+                }
+            }
+        }
+
+        if (selectedTheme == ReaderTheme.Custom) {
+            CustomColorPicker(
+                fgArgb = customFgArgb.takeIf { it != 0 } ?: Color(0xFF1A1614).toArgb(),
+                bgArgb = customBgArgb.takeIf { it != 0 } ?: Color(0xFFF4ECD8).toArgb(),
+                onChange = onCustomColors,
+            )
+        }
+    }
+}
+
+/** A single selectable preview chip rendered in its theme's own colours. */
+@Composable
+private fun ThemeChip(
+    theme: ReaderTheme,
+    selected: Boolean,
+    customFgArgb: Int,
+    customBgArgb: Int,
+    onClick: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    val resolved = ReaderColors.resolve(theme, customFgArgb, customBgArgb).resolved
+    // Default (and unset-Custom) have no triple — preview with the app surface.
+    val bg = resolved?.background ?: MaterialTheme.colorScheme.surface
+    val fg = resolved?.foreground ?: MaterialTheme.colorScheme.onSurface
+    val label = theme.label()
+    val cd = stringResource(R.string.settings_reading_overlay_cd, label)
+    val borderColor =
+        if (selected) MaterialTheme.colorScheme.primary else MaterialTheme.colorScheme.outlineVariant
+    val borderWidth = if (selected) 2.dp else 1.dp
+
+    Column(
+        modifier = modifier
+            .clip(RoundedCornerShape(10.dp))
+            .border(borderWidth, borderColor, RoundedCornerShape(10.dp))
+            .background(bg)
+            .clickable(onClick = onClick)
+            .semantics { contentDescription = cd }
+            .padding(vertical = 10.dp, horizontal = 6.dp),
+        horizontalAlignment = Alignment.CenterHorizontally,
+        verticalArrangement = Arrangement.spacedBy(4.dp),
+    ) {
+        // "Aa" specimen in the theme's foreground, then the label.
+        Text(
+            text = "Aa",
+            color = fg,
+            style = MaterialTheme.typography.titleMedium,
+            fontWeight = FontWeight.SemiBold,
+        )
+        Text(
+            text = label,
+            color = fg,
+            style = MaterialTheme.typography.labelSmall,
+        )
+    }
+}
+
+/**
+ * RGB fg/bg picker with a live preview line and a WCAG contrast readout.
+ * Deliberately dependency-free (sliders, not a colour wheel) — delivers the
+ * accessibility-validated custom pair the issue asks for without a new dep.
+ * We warn on low contrast but never block: a deliberate choice is the user's.
+ */
+@Composable
+private fun CustomColorPicker(
+    fgArgb: Int,
+    bgArgb: Int,
+    onChange: (fgArgb: Int, bgArgb: Int) -> Unit,
+) {
+    val spacing = LocalSpacing.current
+    val fg = Color(fgArgb)
+    val bg = Color(bgArgb)
+
+    Column(verticalArrangement = Arrangement.spacedBy(spacing.sm)) {
+        Text(
+            text = stringResource(R.string.settings_reading_custom_title),
+            style = MaterialTheme.typography.bodyLarge,
+        )
+
+        // Live preview of the current pair.
+        Box(
+            modifier = Modifier
+                .fillMaxWidth()
+                .clip(RoundedCornerShape(10.dp))
+                .background(bg)
+                .padding(spacing.md),
+        ) {
+            Text(
+                text = stringResource(R.string.settings_reading_overlay_preview),
+                color = fg,
+                style = MaterialTheme.typography.bodyLarge,
+            )
+        }
+
+        // WCAG readout + rating — warn-only.
+        val ratio = WcagContrast.ratio(fg, bg)
+        val ratingRes = when (WcagContrast.rating(fg, bg)) {
+            WcagRating.AAA -> R.string.settings_reading_contrast_aaa
+            WcagRating.AA -> R.string.settings_reading_contrast_aa
+            WcagRating.AA_LARGE -> R.string.settings_reading_contrast_aa_large
+            WcagRating.FAIL -> R.string.settings_reading_contrast_fail
+        }
+        val isLow = WcagContrast.rating(fg, bg) == WcagRating.FAIL
+        Text(
+            text = stringResource(
+                R.string.settings_reading_contrast_readout,
+                ratio,
+                stringResource(ratingRes),
+            ),
+            style = MaterialTheme.typography.bodySmall,
+            color = if (isLow) MaterialTheme.colorScheme.error else MaterialTheme.colorScheme.onSurfaceVariant,
+        )
+
+        RgbSliders(
+            label = stringResource(R.string.settings_reading_custom_fg),
+            color = fg,
+            onColor = { onChange(it.toArgb(), bgArgb) },
+        )
+        RgbSliders(
+            label = stringResource(R.string.settings_reading_custom_bg),
+            color = bg,
+            onColor = { onChange(fgArgb, it.toArgb()) },
+        )
+    }
+}
+
+/** Three R/G/B sliders for one opaque colour. */
+@Composable
+private fun RgbSliders(
+    label: String,
+    color: Color,
+    onColor: (Color) -> Unit,
+) {
+    Column {
+        Row(verticalAlignment = Alignment.CenterVertically) {
+            Box(
+                modifier = Modifier
+                    .size(16.dp)
+                    .clip(RoundedCornerShape(4.dp))
+                    .background(color),
+            )
+            Text(
+                text = label,
+                style = MaterialTheme.typography.labelLarge,
+                modifier = Modifier.padding(start = 8.dp),
+            )
+        }
+        ChannelSlider(stringResource(R.string.settings_reading_custom_red), color.red) {
+            onColor(color.copy(red = it))
+        }
+        ChannelSlider(stringResource(R.string.settings_reading_custom_green), color.green) {
+            onColor(color.copy(green = it))
+        }
+        ChannelSlider(stringResource(R.string.settings_reading_custom_blue), color.blue) {
+            onColor(color.copy(blue = it))
+        }
+    }
+}
+
+@Composable
+private fun ChannelSlider(name: String, value: Float, onValue: (Float) -> Unit) {
+    Row(verticalAlignment = Alignment.CenterVertically) {
+        Text(
+            text = name.take(1),
+            style = MaterialTheme.typography.labelSmall,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+            modifier = Modifier
+                .width(16.dp)
+                .semantics { contentDescription = name },
+        )
+        Slider(
+            value = value,
+            onValueChange = onValue,
+            modifier = Modifier.fillMaxWidth(),
+        )
     }
 }

--- a/feature/src/main/kotlin/in/jphe/storyvox/feature/settings/SettingsViewModel.kt
+++ b/feature/src/main/kotlin/in/jphe/storyvox/feature/settings/SettingsViewModel.kt
@@ -14,6 +14,7 @@ import `in`.jphe.storyvox.feature.api.PalaceProbeResult
 import `in`.jphe.storyvox.feature.api.ReadingDirection
 import `in`.jphe.storyvox.feature.api.SettingsRepositoryUi
 import `in`.jphe.storyvox.feature.api.SpeakChapterMode
+import `in`.jphe.storyvox.ui.theme.ReaderTheme
 import `in`.jphe.storyvox.feature.api.ThemeOverride
 import `in`.jphe.storyvox.feature.api.UiLlmProvider
 import `in`.jphe.storyvox.feature.api.UiSettings
@@ -552,6 +553,14 @@ class SettingsViewModel @Inject constructor(
     /** Issue #598 — Android Auto bucket size. */
     fun setAutoItemsPerCategory(count: Int) =
         viewModelScope.launch { repo.setAutoItemsPerCategory(count) }
+
+    /** Issue #993 — reading-theme (color overlay) for the reader surface. */
+    fun setReaderTheme(theme: ReaderTheme) =
+        viewModelScope.launch { repo.setReaderTheme(theme) }
+
+    /** Issue #993 — custom reading-theme fg/bg as ARGB ints; implies Custom. */
+    fun setReaderCustomColors(fgArgb: Int, bgArgb: Int) =
+        viewModelScope.launch { repo.setReaderCustomColors(fgArgb, bgArgb) }
 }
 
 /** Map the feature-layer enum to the :core-llm enum. The two are

--- a/feature/src/main/res/values/strings.xml
+++ b/feature/src/main/res/values/strings.xml
@@ -551,6 +551,35 @@
     <string name="settings_reading_shake_extend_title">Shake to extend sleep timer</string>
     <string name="settings_reading_shake_extend_subtitle">Shake during the fade-out to add 15 more minutes.</string>
 
+    <!-- Settings · Reading-theme color overlay (#993) -->
+    <string name="settings_reading_overlay_group_title">Reading colors</string>
+    <string name="settings_reading_overlay_title">Color theme</string>
+    <string name="settings_reading_overlay_subtitle">Tint the reading page only — sepia, cream, or high-contrast. Doesn\'t change the rest of the app.</string>
+    <string name="settings_reading_overlay_theme_default">Default</string>
+    <string name="settings_reading_overlay_theme_light">Light</string>
+    <string name="settings_reading_overlay_theme_dark">Dark</string>
+    <string name="settings_reading_overlay_theme_sepia">Sepia</string>
+    <string name="settings_reading_overlay_theme_cream">Cream</string>
+    <string name="settings_reading_overlay_theme_hc_bw">Black on white</string>
+    <string name="settings_reading_overlay_theme_hc_wb">White on black</string>
+    <string name="settings_reading_overlay_theme_custom">Custom</string>
+    <string name="settings_reading_overlay_preview">The quick brown fox jumps over the lazy dog.</string>
+    <!-- Custom picker -->
+    <string name="settings_reading_custom_title">Custom colors</string>
+    <string name="settings_reading_custom_fg">Text</string>
+    <string name="settings_reading_custom_bg">Background</string>
+    <string name="settings_reading_custom_red">Red</string>
+    <string name="settings_reading_custom_green">Green</string>
+    <string name="settings_reading_custom_blue">Blue</string>
+    <!-- WCAG readout: %1$.1f = contrast ratio, %2$s = rating label -->
+    <string name="settings_reading_contrast_readout">Contrast %1$.1f:1 · %2$s</string>
+    <string name="settings_reading_contrast_aaa">AAA — excellent</string>
+    <string name="settings_reading_contrast_aa">AA — good</string>
+    <string name="settings_reading_contrast_aa_large">AA large text only</string>
+    <string name="settings_reading_contrast_fail">Low contrast — hard to read</string>
+    <!-- contentDescription for the per-preset swatch chip; %1$s = theme name -->
+    <string name="settings_reading_overlay_cd">Reading color theme: %1$s</string>
+
     <!-- Settings · Cloud voices subscreen -->
     <string name="settings_cloud_voices_title">Cloud voices</string>
 


### PR DESCRIPTION
Closes #993.

Reading-color themes (Irlen-style overlay) for the **reading surface only**, separate from the app theme — companion to #992 (dyslexia typography), built on the same CompositionLocal seam + device-local-pref pattern.

## What's new
- **`ReaderColors` seam** (core-ui): `ReaderTheme` enum — Default / Light / Dark / Sepia / Cream / two high-contrast pairs / Custom — with curated preset triples (foreground / background / accent) and a custom fg/bg builder. `LocalReaderColors` defaults to **inactive**, so existing readers render exactly as today until they opt in.
- **`WcagContrast`** (core-ui): pure-JVM WCAG 2.x relative-luminance contrast ratio + AA/AAA rating, used to validate (warn, never block) the custom picker.
- **Device-local prefs** (`SettingsRepositoryUiImpl`): `pref_reader_theme` / `_custom_fg_argb` / `_custom_bg_argb`. **NOT** in `SYNC_ALLOWLIST` and no `stampSyncedWrite` — per the #993 ruling, reading themes are a per-device comfort choice (sepia on a phone, dark on a tablet). Unknown enum → Default on read.
- **Applied at the reading surface**: `SentenceHighlight` re-tints body text + highlighted span (theme foreground) and the sentence underline (theme accent); `ReaderTextView` paints the theme background and tints the chapter title; `HybridReaderScreen` threads `ReaderViewModel.readerColors`. Default is pixel-identical to today.
- **Settings UI**: a "Reading colors" group with preview chips (each rendered in its own theme colours, "Aa" specimen) + a Custom RGB fg/bg picker with a live preview line and a live WCAG contrast readout/rating. Chips + channel labels carry TalkBack semantics.

## Tests
- `WcagContrastTest` (8) — canonical ratios (black-on-white 21:1, white-on-white 1:1), symmetry, AA/AA-large thresholds, rating classification.
- `ReaderColorsTest` (10) — inactive default no-op, every preset resolves + clears AA-large (3:1), high-contrast pairs clear AAA (7:1), accent legible on its own bg, custom/ARGB resolve + unset-Custom degrades to inactive.
- `:app:assembleDebug` BUILD SUCCESSFUL; 18/18 unit tests pass.

## Merge sequencing
Touches the shared reader surface (`SentenceHighlight.kt`, `ReaderView.kt`, `HybridReaderScreen.kt`, `UiContracts.kt`) — same files as #992 / #997 / #998 / #1001. Changes are additive (new param with no-op default, new CompositionLocal). Clean `git merge-tree` against current main; will rebase-sequence at merge per the lead's ordering.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Customizable reading overlay themes: Default, Light, Dark, Sepia, Cream, two High-Contrast presets, and Custom.
  * Custom color picker with RGB sliders, live preview and WCAG contrast readout/warnings.
  * Reading theme applied across reader UI (including sentence highlighting) and exposed to reader view.

* **Behavior**
  * Reading-theme choices persist locally on device (device-only, not synced).

* **Tests**
  * Added comprehensive theme and WCAG contrast validation tests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->