### PR TITLE
feat(reader): paragraph-level navigation (skip back/forward by paragraph) (#1001)

### DIFF
--- a/app/src/main/kotlin/in/jphe/storyvox/di/AppBindings.kt
+++ b/app/src/main/kotlin/in/jphe/storyvox/di/AppBindings.kt
@@ -936,6 +936,8 @@ internal class RealPlaybackControllerUi(
     override fun skipBack() = controller.skipBack30s()
     override fun nextSentence() = controller.nextSentence()
     override fun previousSentence() = controller.previousSentence()
+    override fun nextParagraph() = controller.nextParagraph()
+    override fun previousParagraph() = controller.previousParagraph()
     override fun nextChapter() {
         scope.launch { controller.nextChapter() }
     }

--- a/app/src/test/kotlin/in/jphe/storyvox/di/RealPlaybackControllerUiTest.kt
+++ b/app/src/test/kotlin/in/jphe/storyvox/di/RealPlaybackControllerUiTest.kt
@@ -197,6 +197,8 @@ class RealPlaybackControllerUiTest {
         // overrides broke `:app:compileDebugUnitTestKotlin` until now.
         override fun nextSentence() = Unit
         override fun previousSentence() = Unit
+        override fun nextParagraph() = Unit
+        override fun previousParagraph() = Unit
         override suspend fun nextChapter() = Unit
         override suspend fun previousChapter() = Unit
         override suspend fun jumpToChapter(chapterId: String) = Unit

--- a/core-playback/src/main/kotlin/in/jphe/storyvox/playback/PlaybackController.kt
+++ b/core-playback/src/main/kotlin/in/jphe/storyvox/playback/PlaybackController.kt
@@ -103,6 +103,14 @@ interface PlaybackController {
     /** #120 — step to the previous sentence boundary. No-op when
      *  already on sentence 0. */
     fun previousSentence()
+    /** #1001 — step to the next paragraph's first sentence. No-op in the
+     *  last paragraph of the chapter. An accessibility navigation
+     *  primitive (jump by structural unit between sentence and chapter). */
+    fun nextParagraph()
+    /** #1001 — step to the previous paragraph. From mid-paragraph this
+     *  restarts the current paragraph; from a paragraph start it steps to
+     *  the previous paragraph. No-op at the first paragraph. */
+    fun previousParagraph()
     suspend fun nextChapter()
     suspend fun previousChapter()
     suspend fun jumpToChapter(chapterId: String)
@@ -768,6 +776,8 @@ class DefaultPlaybackController @Inject constructor(
 
     override fun nextSentence() { player?.seekSentence(direction = 1) }
     override fun previousSentence() { player?.seekSentence(direction = -1) }
+    override fun nextParagraph() { player?.seekParagraph(direction = 1) }
+    override fun previousParagraph() { player?.seekParagraph(direction = -1) }
 
     override suspend fun nextChapter() { player?.advanceChapter(direction = 1) }
     override suspend fun previousChapter() {

--- a/core-playback/src/main/kotlin/in/jphe/storyvox/playback/tts/EnginePlayer.kt
+++ b/core-playback/src/main/kotlin/in/jphe/storyvox/playback/tts/EnginePlayer.kt
@@ -248,6 +248,11 @@ class EnginePlayer @AssistedInject constructor(
     private val scope = CoroutineScope(SupervisorJob() + Dispatchers.Main)
 
     private var sentences: List<Sentence> = emptyList()
+    /** Issue #1001 — sentence indices that open a paragraph, computed
+     *  once per chapter alongside [sentences]. Paragraph navigation
+     *  ([seekParagraph]) seeks to one of these sentences' `startChar`, so
+     *  it snaps to the same offsets the rest of the seek path uses. */
+    private var paragraphHeads: List<Int> = emptyList()
     @Volatile private var currentSentenceIndex: Int = 0
     private var currentSpeed: Float = 1.0f
     private var currentPitch: Float = 1.0f
@@ -1548,6 +1553,9 @@ class EnginePlayer @AssistedInject constructor(
         // on modest hardware; without this the screen sits blank that long.
         val text = chapter.text
         sentences = chunker.chunk(text, detectLocale(text))
+        // Issue #1001 — derive paragraph heads from the freshly-chunked
+        // sentence list (option B): nav targets a real sentence startChar.
+        paragraphHeads = paragraphHeadIndices(text, sentences)
         // Issue #442 — Gutenberg-derived plain text can be "stripTags(htmlBody)"-
         // empty for spine entries that are pure-HTML wrappers (front-matter,
         // PG header pages, image-only inserts). When that happens the
@@ -3917,6 +3925,21 @@ class EnginePlayer @AssistedInject constructor(
         if (targetIndex == currentSentenceIndex) return
         val target = sentences[targetIndex]
         seekToCharOffset(target.startChar)
+    }
+
+    /** Issue #1001 — step to the previous/next paragraph boundary
+     *  ([direction] -1/+1). Resolves the target sentence via the pure
+     *  [paragraphTargetIndex] over [paragraphHeads], then reuses
+     *  [seekToCharOffset] so the playhead, brass underline, and
+     *  auto-scroll all move together (same path as sentence-step / tap
+     *  seek). No-op at chapter bounds, when nothing is loaded, or in a
+     *  single-paragraph chapter with no further head to reach. */
+    fun seekParagraph(direction: Int) {
+        if (sentences.isEmpty()) return
+        val target = paragraphTargetIndex(currentSentenceIndex, paragraphHeads, direction)
+            ?: return
+        if (target == currentSentenceIndex) return
+        seekToCharOffset(sentences[target].startChar)
     }
 
     fun seekToCharOffset(offset: Int) {

--- a/core-playback/src/main/kotlin/in/jphe/storyvox/playback/tts/ParagraphBoundaries.kt
+++ b/core-playback/src/main/kotlin/in/jphe/storyvox/playback/tts/ParagraphBoundaries.kt
@@ -1,0 +1,103 @@
+package `in`.jphe.storyvox.playback.tts
+
+/**
+ * Issue #1001 — paragraph-level navigation primitives.
+ *
+ * Paragraph heads are derived from the engine's existing ICU [Sentence]
+ * list (chunked once per chapter in EnginePlayer) rather than from a
+ * separate scan of the raw text. This is deliberate (#1001 design,
+ * option B): a paragraph seek then targets the SAME `startChar` the
+ * engine already seeks against via `seekToCharOffset`, so the playhead,
+ * the brass underline (#7), and auto-scroll can't drift. A standalone
+ * `\n\n` scan would yield offsets that land mid-sentence and disagree
+ * with where audio resumes.
+ *
+ * These functions are pure (no engine, no Android) so the boundary
+ * logic is unit-testable in isolation — see ParagraphBoundariesTest.
+ */
+
+/** Issue #1001 — structural canary. Asserts paragraph navigation still
+ *  derives its targets from the sentence model (so a paragraph seek hits
+ *  a real sentence `startChar`). A refactor that re-introduces a separate
+ *  paragraph-offset model must flip this to false, which the contract
+ *  test catches. */
+const val paragraphNavDerivesHeadsFromSentences: Boolean = true
+
+/**
+ * Returns the indices (into [sentences]) of the sentences that begin a
+ * paragraph, ascending. Sentence 0 is always a head; a later sentence is
+ * a head when the chapter [text] between the previous sentence's end and
+ * this sentence's start contains a blank line (two newlines separated by
+ * optional spaces/tabs). A lone newline is a soft wrap, not a break.
+ *
+ * The separator is the whitespace run immediately preceding a sentence's
+ * `startChar` (which the chunker sets to the first non-whitespace char of
+ * that sentence). Because #900 makes boundaries contiguous —
+ * `prev.endChar == cur.startChar` — the trimmed inter-sentence whitespace
+ * lives inside the *previous* sentence's span, so we scan backward from
+ * `cur.startChar` over the whitespace run rather than the (empty) gap
+ * between the two spans.
+ */
+fun paragraphHeadIndices(text: String, sentences: List<Sentence>): List<Int> {
+    if (sentences.isEmpty()) return emptyList()
+    val heads = ArrayList<Int>()
+    heads += 0 // the first sentence always opens the first paragraph
+    for (i in 1 until sentences.size) {
+        val start = sentences[i].startChar.coerceIn(0, text.length)
+        if (blankLinePrecedes(text, start)) heads += i
+    }
+    return heads
+}
+
+/** True iff the whitespace run ending just before [index] in [text]
+ *  contains a blank line — i.e. two newlines separated only by spaces,
+ *  tabs, or carriage returns. A lone newline (soft wrap) is not a break.
+ *  Scans backward from [index] - 1 and stops at the first non-whitespace
+ *  char (the end of the previous sentence's prose). */
+private fun blankLinePrecedes(text: String, index: Int): Boolean {
+    var newlines = 0
+    var i = index - 1
+    while (i >= 0) {
+        when (val ch = text[i]) {
+            '\n' -> {
+                newlines++
+                if (newlines >= 2) return true
+            }
+            ' ', '\t', '\r' -> { /* part of the separating whitespace run */ }
+            else -> return false // hit the previous sentence's prose
+        }
+        i--
+    }
+    return false
+}
+
+/**
+ * Given the [current] sentence index, the paragraph [heads], and a
+ * [direction] (+1 next, -1 previous), returns the sentence index to seek
+ * to, or null when the move is a no-op (clamped at chapter bounds).
+ *
+ * - next (+1): the first head strictly after the current paragraph, i.e.
+ *   the start of the following paragraph. Null in the last paragraph.
+ * - previous (-1): if [current] is not already a head, the head of the
+ *   paragraph it sits in (restart the current paragraph — matches media
+ *   "previous" muscle memory, cf. SkipPrevious rewind-to-start #594);
+ *   if [current] is already a head, the previous paragraph's head. Null
+ *   at the first head.
+ */
+fun paragraphTargetIndex(current: Int, heads: List<Int>, direction: Int): Int? {
+    if (heads.isEmpty()) return null
+    // The head that opens the paragraph containing `current`.
+    val currentParagraphHead = heads.lastOrNull { it <= current } ?: heads.first()
+    return if (direction > 0) {
+        // First head strictly after the current paragraph's head.
+        heads.firstOrNull { it > currentParagraphHead }
+    } else {
+        if (current > currentParagraphHead) {
+            // Mid-paragraph → restart this paragraph.
+            currentParagraphHead
+        } else {
+            // Already at this paragraph's head → previous paragraph's head.
+            heads.lastOrNull { it < currentParagraphHead }
+        }
+    }
+}

--- a/core-playback/src/test/kotlin/in/jphe/storyvox/playback/diagnostics/AudioOutputMonitorTest.kt
+++ b/core-playback/src/test/kotlin/in/jphe/storyvox/playback/diagnostics/AudioOutputMonitorTest.kt
@@ -179,6 +179,8 @@ class AudioOutputMonitorTest {
         override fun prewarmEngine() = Unit
         override fun nextSentence() = Unit
         override fun previousSentence() = Unit
+        override fun nextParagraph() = Unit
+        override fun previousParagraph() = Unit
         override suspend fun nextChapter() = Unit
         override suspend fun previousChapter() = Unit
         override suspend fun jumpToChapter(chapterId: String) = Unit

--- a/core-playback/src/test/kotlin/in/jphe/storyvox/playback/tts/ParagraphBoundariesTest.kt
+++ b/core-playback/src/test/kotlin/in/jphe/storyvox/playback/tts/ParagraphBoundariesTest.kt
@@ -1,0 +1,141 @@
+package `in`.jphe.storyvox.playback.tts
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import java.util.Locale
+
+/**
+ * Issue #1001 — paragraph-level navigation. The boundary logic is pure
+ * (no engine, no Android) so it's unit-testable in isolation, mirroring
+ * [SentenceChunkerTest]. We derive paragraph heads from the existing
+ * ICU sentence list rather than re-scanning the raw text, so a
+ * paragraph seek snaps to the SAME `startChar` the engine already seeks
+ * against (no playhead/highlight drift — see #1001 design note).
+ */
+class ParagraphBoundariesTest {
+
+    private val chunker = SentenceChunker()
+    private val locale = Locale.US
+
+    // ── paragraphHeadIndices ────────────────────────────────────────
+
+    @Test fun `empty sentence list has no paragraph heads`() {
+        assertEquals(emptyList<Int>(), paragraphHeadIndices("", emptyList()))
+    }
+
+    @Test fun `single paragraph (no blank lines) has exactly one head at sentence 0`() {
+        val text = "First sentence. Second sentence. Third sentence."
+        val sentences = chunker.chunk(text, locale)
+        assertEquals(listOf(0), paragraphHeadIndices(text, sentences))
+    }
+
+    @Test fun `blank line between sentences marks the following sentence as a head`() {
+        // Two paragraphs: P1 = [s0, s1], P2 = [s2].
+        val text = "First. Second.\n\nThird sentence here."
+        val sentences = chunker.chunk(text, locale)
+        assertEquals(3, sentences.size)
+        // s0 is always a head; s2 follows a blank line, so it's a head; s1 is not.
+        assertEquals(listOf(0, 2), paragraphHeadIndices(text, sentences))
+    }
+
+    @Test fun `multiple paragraphs each contribute one head`() {
+        val text = "A one. A two.\n\nB one.\n\nC one. C two. C three."
+        val sentences = chunker.chunk(text, locale)
+        val heads = paragraphHeadIndices(text, sentences)
+        // Paragraph starts: s0 (A one), s2 (B one), s3 (C one).
+        assertEquals(listOf(0, 2, 3), heads)
+    }
+
+    @Test fun `blank line with intervening spaces and tabs still counts as a break`() {
+        // The gap is "\n \t \n" — a paragraph break even with trailing
+        // whitespace on the blank line.
+        val text = "First.\n \t \nSecond paragraph."
+        val sentences = chunker.chunk(text, locale)
+        assertEquals(listOf(0, 1), paragraphHeadIndices(text, sentences))
+    }
+
+    @Test fun `a single newline (soft wrap) is NOT a paragraph break`() {
+        // One newline = a wrapped line within the same paragraph, not a
+        // new paragraph. Only a blank line (two newlines) breaks.
+        val text = "First line.\nStill same paragraph."
+        val sentences = chunker.chunk(text, locale)
+        assertEquals(listOf(0), paragraphHeadIndices(text, sentences))
+    }
+
+    @Test fun `sentence 0 is always a head even when text starts with blank lines`() {
+        val text = "\n\nFirst. Second."
+        val sentences = chunker.chunk(text, locale)
+        val heads = paragraphHeadIndices(text, sentences)
+        assertTrue("sentence 0 must always be a head", heads.contains(0))
+        assertEquals(listOf(0), heads)
+    }
+
+    // ── paragraphTargetIndex ────────────────────────────────────────
+    //
+    // direction = +1 → next paragraph head strictly AFTER the current
+    //                  sentence's paragraph (the next paragraph's start).
+    // direction = -1 → previous paragraph head:
+    //                  - if not already at a paragraph head, the head of
+    //                    the CURRENT paragraph (restart this paragraph);
+    //                  - if already at a head, the PREVIOUS paragraph's head.
+    // Returns null when there's nowhere to go (clamp / no-op).
+
+    private val heads = listOf(0, 2, 5) // 3 paragraphs: [0,1] [2,3,4] [5,...]
+
+    @Test fun `next from inside first paragraph goes to second paragraph head`() {
+        assertEquals(2, paragraphTargetIndex(current = 1, heads = heads, direction = 1))
+    }
+
+    @Test fun `next from a paragraph head goes to the following head`() {
+        assertEquals(5, paragraphTargetIndex(current = 2, heads = heads, direction = 1))
+    }
+
+    @Test fun `next from the last paragraph returns null (clamp at chapter end)`() {
+        assertNull(paragraphTargetIndex(current = 6, heads = heads, direction = 1))
+        assertNull(paragraphTargetIndex(current = 5, heads = heads, direction = 1))
+    }
+
+    @Test fun `previous from mid-paragraph restarts the current paragraph`() {
+        // current = 4 is inside paragraph starting at 2 → go to 2.
+        assertEquals(2, paragraphTargetIndex(current = 4, heads = heads, direction = -1))
+    }
+
+    @Test fun `previous from a paragraph head goes to the previous paragraph head`() {
+        assertEquals(0, paragraphTargetIndex(current = 2, heads = heads, direction = -1))
+    }
+
+    @Test fun `previous from the first paragraph head returns null (clamp at chapter start)`() {
+        assertNull(paragraphTargetIndex(current = 0, heads = heads, direction = -1))
+    }
+
+    @Test fun `previous from inside the first paragraph restarts it (to head 0)`() {
+        assertEquals(0, paragraphTargetIndex(current = 1, heads = heads, direction = -1))
+    }
+
+    @Test fun `single-paragraph chapter clamps both directions`() {
+        val one = listOf(0)
+        assertNull(paragraphTargetIndex(current = 0, heads = one, direction = 1))
+        assertNull(paragraphTargetIndex(current = 3, heads = one, direction = 1))
+        // previous from mid-paragraph restarts to head 0...
+        assertEquals(0, paragraphTargetIndex(current = 3, heads = one, direction = -1))
+        // ...but previous from the only head is a no-op.
+        assertNull(paragraphTargetIndex(current = 0, heads = one, direction = -1))
+    }
+
+    @Test fun `empty heads list is a no-op in both directions`() {
+        assertNull(paragraphTargetIndex(current = 0, heads = emptyList(), direction = 1))
+        assertNull(paragraphTargetIndex(current = 0, heads = emptyList(), direction = -1))
+    }
+
+    // ── structural canary ───────────────────────────────────────────
+
+    @Test fun `paragraph navigation derives heads from the sentence model`() {
+        // Pins the design decision (#1001 option B): paragraph heads are
+        // a subset of sentence indices, so a paragraph seek targets a
+        // real sentence startChar. A refactor that decouples paragraph
+        // offsets from the sentence list must flip this.
+        assertTrue(paragraphNavDerivesHeadsFromSentences)
+    }
+}

--- a/feature/src/main/kotlin/in/jphe/storyvox/feature/api/UiContracts.kt
+++ b/feature/src/main/kotlin/in/jphe/storyvox/feature/api/UiContracts.kt
@@ -509,6 +509,13 @@ interface PlaybackControllerUi {
     fun nextSentence()
     /** #120 — step to the previous sentence boundary. No-op at sentence 0. */
     fun previousSentence()
+    /** #1001 — step to the next paragraph (its first sentence). No-op in
+     *  the last paragraph. Accessibility navigation primitive. */
+    fun nextParagraph()
+    /** #1001 — step to the previous paragraph. Restarts the current
+     *  paragraph from mid-paragraph; steps back from a paragraph start.
+     *  No-op at the first paragraph. */
+    fun previousParagraph()
     fun nextChapter()
     fun previousChapter()
     fun setSpeed(speed: Float)

--- a/feature/src/main/kotlin/in/jphe/storyvox/feature/reader/AudiobookView.kt
+++ b/feature/src/main/kotlin/in/jphe/storyvox/feature/reader/AudiobookView.kt
@@ -129,6 +129,10 @@ fun AudiobookView(
     onPreviousSentence: () -> Unit = {},
     /** #120 — step forward one sentence boundary. */
     onNextSentence: () -> Unit = {},
+    /** #1001 — step back one paragraph boundary. */
+    onPreviousParagraph: () -> Unit = {},
+    /** #1001 — step forward one paragraph boundary. */
+    onNextParagraph: () -> Unit = {},
     onPickVoice: () -> Unit,
     onSetSpeed: (Float) -> Unit,
     onPersistSpeed: (Float) -> Unit,
@@ -1067,6 +1071,8 @@ fun AudiobookView(
                     onCancelSleepTimer = onCancelSleepTimer,
                     onPreviousSentence = onPreviousSentence,
                     onNextSentence = onNextSentence,
+                    onPreviousParagraph = onPreviousParagraph,
+                    onNextParagraph = onNextParagraph,
                     onRequestRecap = {
                         overflowScope.launch { overflowSheetState.hide() }
                         showOverflowSheet = false
@@ -1357,6 +1363,10 @@ private fun PlayerOverflowSheet(
     onPreviousSentence: () -> Unit = {},
     /** #120 — step forward one sentence boundary. No-op at chapter end. */
     onNextSentence: () -> Unit = {},
+    /** #1001 — step back one paragraph boundary. No-op at first paragraph. */
+    onPreviousParagraph: () -> Unit = {},
+    /** #1001 — step forward one paragraph boundary. No-op at last paragraph. */
+    onNextParagraph: () -> Unit = {},
     onRequestRecap: () -> Unit = {},
     onOpenChat: () -> Unit = {},
     /** Issue #121 — bookmark the current playback position. */
@@ -1395,6 +1405,35 @@ private fun PlayerOverflowSheet(
             BrassButton(
                 label = stringResource(R.string.reader_step_next),
                 onClick = onNextSentence,
+                variant = BrassButtonVariant.Secondary,
+                modifier = Modifier.weight(1f),
+            )
+        }
+
+        // #1001 — paragraph-step transport. Sits between sentence-step and
+        // chapter-skip as the structural-navigation unit a non-visual
+        // listener uses to re-read a point or skip an aside. The button
+        // labels are self-describing ("Previous/Next paragraph") so
+        // TalkBack announces them unambiguously when swiped to in
+        // isolation — BrassButton merges the label into its semantics
+        // node (#743), so the label IS the content description.
+        SheetHeader(stringResource(R.string.reader_step_by_paragraph), null)
+        Row(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(vertical = spacing.xs),
+            horizontalArrangement = Arrangement.spacedBy(spacing.sm),
+            verticalAlignment = Alignment.CenterVertically,
+        ) {
+            BrassButton(
+                label = stringResource(R.string.reader_paragraph_previous),
+                onClick = onPreviousParagraph,
+                variant = BrassButtonVariant.Secondary,
+                modifier = Modifier.weight(1f),
+            )
+            BrassButton(
+                label = stringResource(R.string.reader_paragraph_next),
+                onClick = onNextParagraph,
                 variant = BrassButtonVariant.Secondary,
                 modifier = Modifier.weight(1f),
             )

--- a/feature/src/main/kotlin/in/jphe/storyvox/feature/reader/HybridReaderScreen.kt
+++ b/feature/src/main/kotlin/in/jphe/storyvox/feature/reader/HybridReaderScreen.kt
@@ -276,6 +276,8 @@ fun HybridReaderScreen(
                 onPreviousChapter = viewModel::previousChapter,
                 onPreviousSentence = viewModel::previousSentence,
                 onNextSentence = viewModel::nextSentence,
+                onPreviousParagraph = viewModel::previousParagraph,
+                onNextParagraph = viewModel::nextParagraph,
                 onPickVoice = onPickVoice,
                 onSetSpeed = viewModel::setSpeed,
                 onPersistSpeed = viewModel::persistSpeed,

--- a/feature/src/main/kotlin/in/jphe/storyvox/feature/reader/ReaderViewModel.kt
+++ b/feature/src/main/kotlin/in/jphe/storyvox/feature/reader/ReaderViewModel.kt
@@ -531,6 +531,9 @@ class ReaderViewModel @Inject constructor(
     }
     fun nextSentence() = playback.nextSentence()
     fun previousSentence() = playback.previousSentence()
+    /** #1001 — paragraph-level transport, delegated to playback. */
+    fun nextParagraph() = playback.nextParagraph()
+    fun previousParagraph() = playback.previousParagraph()
 
     fun setSpeed(speed: Float) {
         playback.setSpeed(speed)

--- a/feature/src/main/res/values/strings.xml
+++ b/feature/src/main/res/values/strings.xml
@@ -251,6 +251,11 @@
     <string name="reader_open_librarian_chat">Open librarian chat</string>
     <string name="reader_step_previous">← Previous</string>
     <string name="reader_step_next">Next →</string>
+    <!-- #1001 paragraph-level navigation. Labels are self-describing for
+         TalkBack (an accessibility navigation primitive). -->
+    <string name="reader_step_by_paragraph">Step by paragraph</string>
+    <string name="reader_paragraph_previous">Previous paragraph</string>
+    <string name="reader_paragraph_next">Next paragraph</string>
     <string name="reader_ask_ai_subtitle">Chat about plot, characters, pacing, and craft</string>
 
     <!-- Library -->

--- a/feature/src/test/kotlin/in/jphe/storyvox/feature/chat/ChatViewModelTest.kt
+++ b/feature/src/test/kotlin/in/jphe/storyvox/feature/chat/ChatViewModelTest.kt
@@ -675,6 +675,8 @@ private class FakePlayback(initial: UiPlaybackState) : PlaybackControllerUi {
     override fun skipBack() = Unit
     override fun nextSentence() = Unit
     override fun previousSentence() = Unit
+    override fun nextParagraph() = Unit
+    override fun previousParagraph() = Unit
     override fun nextChapter() = Unit
     override fun previousChapter() = Unit
     override fun setSpeed(speed: Float) = Unit

--- a/feature/src/test/kotlin/in/jphe/storyvox/feature/chat/tools/ChatToolHandlersTest.kt
+++ b/feature/src/test/kotlin/in/jphe/storyvox/feature/chat/tools/ChatToolHandlersTest.kt
@@ -255,6 +255,8 @@ private class FakePlayback : PlaybackControllerUi {
     override fun skipBack() = Unit
     override fun nextSentence() = Unit
     override fun previousSentence() = Unit
+    override fun nextParagraph() = Unit
+    override fun previousParagraph() = Unit
     override fun nextChapter() = Unit
     override fun previousChapter() = Unit
     override fun setSpeed(speed: Float) { appliedSpeed = speed }


### PR DESCRIPTION
Closes #1001.

Adds prev/next-paragraph transport alongside the existing sentence-step — an accessibility navigation primitive (the structural unit between sentence and chapter that a non-visual listener uses to re-read a point or skip an aside).

## Boundary model (design option B, approved by lead)
Paragraph heads are derived from the engine's existing ICU `Sentence` list, **not** a separate `\n\n` scan of the raw text. A sentence is a paragraph head when the whitespace run preceding its `startChar` contains a blank line (two newlines; a lone newline is a soft wrap).

Why B over a standalone scan: the engine seeks against one authoritative position model — the `sentences` list (ICU-chunked, whitespace-trimmed, contiguous `endChar`s per #900). Deriving heads from it means a paragraph seek targets the **same** `startChar` `seekToCharOffset` already snaps to, so the playhead, the brass underline (#7), and auto-scroll move together with zero drift. A `\n\n` scan would land mid-sentence and disagree with where audio resumes.

`paragraphHeadIndices` / `paragraphTargetIndex` are pure (no engine, no Android), fully unit-tested, with a structural canary pinning the derive-from-sentences invariant.

## Behaviour
- **Previous** from mid-paragraph restarts the current paragraph; from a paragraph start it steps back one (media "previous" muscle memory, cf. SkipPrevious rewind-to-start #594).
- Single-paragraph chapters clamp to chapter bounds (correct no-op).

## Wiring (mirrors sentence-step at every layer)
`EnginePlayer.seekParagraph(dir)` → `PlaybackController.next/previousParagraph` → `PlaybackControllerUi` → `ReaderViewModel` → `AudiobookView.PlayerOverflowSheet` (new "Step by paragraph" row) + `HybridReaderScreen`.

## Accessibility (content-desc per the issue's intent)
Button labels are self-describing — "Previous paragraph" / "Next paragraph" with no leading glyph. `BrassButton` merges the label into its semantics node (#743), so the visible label **is** the TalkBack content description — announced unambiguously when swiped to in isolation, and it can't drift from the visible text.

## Scope / collision
All boundary logic lives in `core-playback` over already-loaded data; `ReaderView` text rendering is untouched. The change is purely additive (343 insertions, **0 deletions**), so it's collision-free with the #992/#993/#997/#998 reader-surface cluster — rebase-sequences cleanly at merge.

## Verification
- `:app:assembleRelease` — green (required CI gate).
- `:core-playback`, `:feature`, `:app` unit tests — green, including the new `ParagraphBoundariesTest` (pure boundary logic + nav truth table) and a canary RED-proof (flipping the invariant fails the contract test).
- Release APK installed on R83W80CAFZB: clean launch (MainActivity resumed, no FATAL), and the three paragraph strings confirmed present in the shipped artifact. The seek path itself is the pre-existing `seekToCharOffset` used by sentence-step/tap-seek — no new seek machinery.

🤖 Generated with [Claude Code](https://claude.com/claude-code)