### PR TITLE
feat(reader): text highlights + notes with Markdown/TXT export (#999 phase 1)

### DIFF
--- a/core-data/schemas/in.jphe.storyvox.data.db.StoryvoxDatabase/14.json
+++ b/core-data/schemas/in.jphe.storyvox.data.db.StoryvoxDatabase/14.json
@@ -1,0 +1,1100 @@
+{
+  "formatVersion": 1,
+  "database": {
+    "version": 14,
+    "identityHash": "9acb1a313dfe0567f12001ea7f15a926",
+    "entities": [
+      {
+        "tableName": "fiction",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `sourceId` TEXT NOT NULL, `title` TEXT NOT NULL, `author` TEXT NOT NULL, `authorId` TEXT, `coverUrl` TEXT, `description` TEXT, `genres` TEXT NOT NULL, `tags` TEXT NOT NULL, `status` TEXT NOT NULL, `chapterCount` INTEGER NOT NULL, `wordCount` INTEGER, `rating` REAL, `views` INTEGER, `followers` INTEGER, `lastUpdatedAt` INTEGER, `firstSeenAt` INTEGER NOT NULL, `metadataFetchedAt` INTEGER NOT NULL, `inLibrary` INTEGER NOT NULL, `addedToLibraryAt` INTEGER, `followedRemotely` INTEGER NOT NULL, `downloadMode` TEXT, `pinnedVoiceId` TEXT, `pinnedVoiceLocale` TEXT, `notesEverSeen` INTEGER NOT NULL, `sourceUrl` TEXT, `lastSeenRevision` TEXT, `metadataBackfillFailedAt` INTEGER, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "sourceId",
+            "columnName": "sourceId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "title",
+            "columnName": "title",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "author",
+            "columnName": "author",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "authorId",
+            "columnName": "authorId",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "coverUrl",
+            "columnName": "coverUrl",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "description",
+            "columnName": "description",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "genres",
+            "columnName": "genres",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "tags",
+            "columnName": "tags",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "status",
+            "columnName": "status",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "chapterCount",
+            "columnName": "chapterCount",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "wordCount",
+            "columnName": "wordCount",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "rating",
+            "columnName": "rating",
+            "affinity": "REAL"
+          },
+          {
+            "fieldPath": "views",
+            "columnName": "views",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "followers",
+            "columnName": "followers",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "lastUpdatedAt",
+            "columnName": "lastUpdatedAt",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "firstSeenAt",
+            "columnName": "firstSeenAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "metadataFetchedAt",
+            "columnName": "metadataFetchedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "inLibrary",
+            "columnName": "inLibrary",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "addedToLibraryAt",
+            "columnName": "addedToLibraryAt",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "followedRemotely",
+            "columnName": "followedRemotely",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "downloadMode",
+            "columnName": "downloadMode",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "pinnedVoiceId",
+            "columnName": "pinnedVoiceId",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "pinnedVoiceLocale",
+            "columnName": "pinnedVoiceLocale",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "notesEverSeen",
+            "columnName": "notesEverSeen",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "sourceUrl",
+            "columnName": "sourceUrl",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "lastSeenRevision",
+            "columnName": "lastSeenRevision",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "metadataBackfillFailedAt",
+            "columnName": "metadataBackfillFailedAt",
+            "affinity": "INTEGER"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_fiction_inLibrary",
+            "unique": false,
+            "columnNames": [
+              "inLibrary"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_fiction_inLibrary` ON `${TABLE_NAME}` (`inLibrary`)"
+          },
+          {
+            "name": "index_fiction_followedRemotely",
+            "unique": false,
+            "columnNames": [
+              "followedRemotely"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_fiction_followedRemotely` ON `${TABLE_NAME}` (`followedRemotely`)"
+          },
+          {
+            "name": "index_fiction_sourceId_lastUpdatedAt",
+            "unique": false,
+            "columnNames": [
+              "sourceId",
+              "lastUpdatedAt"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_fiction_sourceId_lastUpdatedAt` ON `${TABLE_NAME}` (`sourceId`, `lastUpdatedAt`)"
+          },
+          {
+            "name": "index_fiction_inLibrary_addedToLibraryAt",
+            "unique": false,
+            "columnNames": [
+              "inLibrary",
+              "addedToLibraryAt"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_fiction_inLibrary_addedToLibraryAt` ON `${TABLE_NAME}` (`inLibrary`, `addedToLibraryAt`)"
+          },
+          {
+            "name": "index_fiction_followedRemotely_lastUpdatedAt",
+            "unique": false,
+            "columnNames": [
+              "followedRemotely",
+              "lastUpdatedAt"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_fiction_followedRemotely_lastUpdatedAt` ON `${TABLE_NAME}` (`followedRemotely`, `lastUpdatedAt`)"
+          }
+        ]
+      },
+      {
+        "tableName": "chapter",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `fictionId` TEXT NOT NULL, `sourceChapterId` TEXT NOT NULL, `index` INTEGER NOT NULL, `title` TEXT NOT NULL, `publishedAt` INTEGER, `wordCount` INTEGER, `htmlBody` TEXT, `plainBody` TEXT, `bodyFetchedAt` INTEGER, `bodyChecksum` TEXT, `downloadState` TEXT NOT NULL, `lastDownloadAttemptAt` INTEGER, `lastDownloadError` TEXT, `notesAuthor` TEXT, `notesAuthorPosition` TEXT, `userMarkedRead` INTEGER NOT NULL, `firstReadAt` INTEGER, `bookmarkCharOffset` INTEGER, `audioUrl` TEXT, PRIMARY KEY(`id`), FOREIGN KEY(`fictionId`) REFERENCES `fiction`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "fictionId",
+            "columnName": "fictionId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "sourceChapterId",
+            "columnName": "sourceChapterId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "index",
+            "columnName": "index",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "title",
+            "columnName": "title",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "publishedAt",
+            "columnName": "publishedAt",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "wordCount",
+            "columnName": "wordCount",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "htmlBody",
+            "columnName": "htmlBody",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "plainBody",
+            "columnName": "plainBody",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "bodyFetchedAt",
+            "columnName": "bodyFetchedAt",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "bodyChecksum",
+            "columnName": "bodyChecksum",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "downloadState",
+            "columnName": "downloadState",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastDownloadAttemptAt",
+            "columnName": "lastDownloadAttemptAt",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "lastDownloadError",
+            "columnName": "lastDownloadError",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "notesAuthor",
+            "columnName": "notesAuthor",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "notesAuthorPosition",
+            "columnName": "notesAuthorPosition",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "userMarkedRead",
+            "columnName": "userMarkedRead",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "firstReadAt",
+            "columnName": "firstReadAt",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "bookmarkCharOffset",
+            "columnName": "bookmarkCharOffset",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "audioUrl",
+            "columnName": "audioUrl",
+            "affinity": "TEXT"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_chapter_fictionId",
+            "unique": false,
+            "columnNames": [
+              "fictionId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_chapter_fictionId` ON `${TABLE_NAME}` (`fictionId`)"
+          },
+          {
+            "name": "index_chapter_fictionId_index",
+            "unique": true,
+            "columnNames": [
+              "fictionId",
+              "index"
+            ],
+            "orders": [],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_chapter_fictionId_index` ON `${TABLE_NAME}` (`fictionId`, `index`)"
+          },
+          {
+            "name": "index_chapter_downloadState",
+            "unique": false,
+            "columnNames": [
+              "downloadState"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_chapter_downloadState` ON `${TABLE_NAME}` (`downloadState`)"
+          },
+          {
+            "name": "index_chapter_fictionId_userMarkedRead",
+            "unique": false,
+            "columnNames": [
+              "fictionId",
+              "userMarkedRead"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_chapter_fictionId_userMarkedRead` ON `${TABLE_NAME}` (`fictionId`, `userMarkedRead`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "fiction",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "fictionId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "playback_position",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`fictionId` TEXT NOT NULL, `chapterId` TEXT NOT NULL, `charOffset` INTEGER NOT NULL, `paragraphIndex` INTEGER NOT NULL, `playbackSpeed` REAL NOT NULL, `durationEstimateMs` INTEGER NOT NULL, `updatedAt` INTEGER NOT NULL, PRIMARY KEY(`fictionId`, `chapterId`), FOREIGN KEY(`fictionId`) REFERENCES `fiction`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE , FOREIGN KEY(`chapterId`) REFERENCES `chapter`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "fictionId",
+            "columnName": "fictionId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "chapterId",
+            "columnName": "chapterId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "charOffset",
+            "columnName": "charOffset",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "paragraphIndex",
+            "columnName": "paragraphIndex",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "playbackSpeed",
+            "columnName": "playbackSpeed",
+            "affinity": "REAL",
+            "notNull": true
+          },
+          {
+            "fieldPath": "durationEstimateMs",
+            "columnName": "durationEstimateMs",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "updatedAt",
+            "columnName": "updatedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "fictionId",
+            "chapterId"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_playback_position_chapterId",
+            "unique": false,
+            "columnNames": [
+              "chapterId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_playback_position_chapterId` ON `${TABLE_NAME}` (`chapterId`)"
+          },
+          {
+            "name": "index_playback_position_updatedAt",
+            "unique": false,
+            "columnNames": [
+              "updatedAt"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_playback_position_updatedAt` ON `${TABLE_NAME}` (`updatedAt`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "fiction",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "fictionId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          },
+          {
+            "table": "chapter",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "chapterId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "auth_cookie",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`sourceId` TEXT NOT NULL, `userDisplayName` TEXT, `userId` TEXT, `capturedAt` INTEGER NOT NULL, `expiresAt` INTEGER, `lastVerifiedAt` INTEGER NOT NULL, PRIMARY KEY(`sourceId`))",
+        "fields": [
+          {
+            "fieldPath": "sourceId",
+            "columnName": "sourceId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "userDisplayName",
+            "columnName": "userDisplayName",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "userId",
+            "columnName": "userId",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "capturedAt",
+            "columnName": "capturedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "expiresAt",
+            "columnName": "expiresAt",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "lastVerifiedAt",
+            "columnName": "lastVerifiedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "sourceId"
+          ]
+        }
+      },
+      {
+        "tableName": "llm_session",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `name` TEXT NOT NULL, `provider` TEXT NOT NULL, `model` TEXT NOT NULL, `systemPrompt` TEXT, `createdAt` INTEGER NOT NULL, `lastUsedAt` INTEGER NOT NULL, `featureKind` TEXT, `anchorFictionId` TEXT, `anchorChapterId` TEXT, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "provider",
+            "columnName": "provider",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "model",
+            "columnName": "model",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "systemPrompt",
+            "columnName": "systemPrompt",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "createdAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastUsedAt",
+            "columnName": "lastUsedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "featureKind",
+            "columnName": "featureKind",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "anchorFictionId",
+            "columnName": "anchorFictionId",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "anchorChapterId",
+            "columnName": "anchorChapterId",
+            "affinity": "TEXT"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "llm_message",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `sessionId` TEXT NOT NULL, `role` TEXT NOT NULL, `content` TEXT NOT NULL, `createdAt` INTEGER NOT NULL, FOREIGN KEY(`sessionId`) REFERENCES `llm_session`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "sessionId",
+            "columnName": "sessionId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "role",
+            "columnName": "role",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "content",
+            "columnName": "content",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "createdAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_llm_message_sessionId",
+            "unique": false,
+            "columnNames": [
+              "sessionId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_llm_message_sessionId` ON `${TABLE_NAME}` (`sessionId`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "llm_session",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "sessionId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "fiction_shelf",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`fictionId` TEXT NOT NULL, `shelf` TEXT NOT NULL, `addedAt` INTEGER NOT NULL, PRIMARY KEY(`fictionId`, `shelf`), FOREIGN KEY(`fictionId`) REFERENCES `fiction`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "fictionId",
+            "columnName": "fictionId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "shelf",
+            "columnName": "shelf",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "addedAt",
+            "columnName": "addedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "fictionId",
+            "shelf"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_fiction_shelf_shelf",
+            "unique": false,
+            "columnNames": [
+              "shelf"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_fiction_shelf_shelf` ON `${TABLE_NAME}` (`shelf`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "fiction",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "fictionId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "chapter_history",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`fictionId` TEXT NOT NULL, `chapterId` TEXT NOT NULL, `openedAt` INTEGER NOT NULL, `completed` INTEGER NOT NULL, `fractionRead` REAL, PRIMARY KEY(`fictionId`, `chapterId`), FOREIGN KEY(`fictionId`) REFERENCES `fiction`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE , FOREIGN KEY(`chapterId`) REFERENCES `chapter`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "fictionId",
+            "columnName": "fictionId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "chapterId",
+            "columnName": "chapterId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "openedAt",
+            "columnName": "openedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "completed",
+            "columnName": "completed",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "fractionRead",
+            "columnName": "fractionRead",
+            "affinity": "REAL"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "fictionId",
+            "chapterId"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_chapter_history_openedAt",
+            "unique": false,
+            "columnNames": [
+              "openedAt"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_chapter_history_openedAt` ON `${TABLE_NAME}` (`openedAt`)"
+          },
+          {
+            "name": "index_chapter_history_chapterId",
+            "unique": false,
+            "columnNames": [
+              "chapterId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_chapter_history_chapterId` ON `${TABLE_NAME}` (`chapterId`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "fiction",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "fictionId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          },
+          {
+            "table": "chapter",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "chapterId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "inbox_event",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `sourceId` TEXT NOT NULL, `fictionId` TEXT, `chapterId` TEXT, `title` TEXT NOT NULL, `body` TEXT, `ts` INTEGER NOT NULL, `isRead` INTEGER NOT NULL, `deepLinkUri` TEXT)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "sourceId",
+            "columnName": "sourceId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "fictionId",
+            "columnName": "fictionId",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "chapterId",
+            "columnName": "chapterId",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "title",
+            "columnName": "title",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "body",
+            "columnName": "body",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "ts",
+            "columnName": "ts",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "isRead",
+            "columnName": "isRead",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "deepLinkUri",
+            "columnName": "deepLinkUri",
+            "affinity": "TEXT"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_inbox_event_ts",
+            "unique": false,
+            "columnNames": [
+              "ts"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_inbox_event_ts` ON `${TABLE_NAME}` (`ts`)"
+          },
+          {
+            "name": "index_inbox_event_isRead",
+            "unique": false,
+            "columnNames": [
+              "isRead"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_inbox_event_isRead` ON `${TABLE_NAME}` (`isRead`)"
+          },
+          {
+            "name": "index_inbox_event_sourceId_fictionId",
+            "unique": false,
+            "columnNames": [
+              "sourceId",
+              "fictionId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_inbox_event_sourceId_fictionId` ON `${TABLE_NAME}` (`sourceId`, `fictionId`)"
+          }
+        ]
+      },
+      {
+        "tableName": "fiction_memory_entry",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`fictionId` TEXT NOT NULL, `entityType` TEXT NOT NULL, `name` TEXT NOT NULL, `summary` TEXT NOT NULL, `firstSeenChapterIndex` INTEGER, `lastUpdated` INTEGER NOT NULL, `userEdited` INTEGER NOT NULL, PRIMARY KEY(`fictionId`, `name`))",
+        "fields": [
+          {
+            "fieldPath": "fictionId",
+            "columnName": "fictionId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "entityType",
+            "columnName": "entityType",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "summary",
+            "columnName": "summary",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "firstSeenChapterIndex",
+            "columnName": "firstSeenChapterIndex",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "lastUpdated",
+            "columnName": "lastUpdated",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "userEdited",
+            "columnName": "userEdited",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "fictionId",
+            "name"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_fiction_memory_entry_name",
+            "unique": false,
+            "columnNames": [
+              "name"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_fiction_memory_entry_name` ON `${TABLE_NAME}` (`name`)"
+          },
+          {
+            "name": "index_fiction_memory_entry_fictionId",
+            "unique": false,
+            "columnNames": [
+              "fictionId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_fiction_memory_entry_fictionId` ON `${TABLE_NAME}` (`fictionId`)"
+          }
+        ]
+      },
+      {
+        "tableName": "annotation",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `fictionId` TEXT NOT NULL, `chapterId` TEXT NOT NULL, `startOffset` INTEGER NOT NULL, `endOffset` INTEGER NOT NULL, `color` TEXT NOT NULL, `note` TEXT, `quotedText` TEXT NOT NULL, `createdAt` INTEGER NOT NULL, `updatedAt` INTEGER NOT NULL, PRIMARY KEY(`id`), FOREIGN KEY(`fictionId`) REFERENCES `fiction`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE , FOREIGN KEY(`chapterId`) REFERENCES `chapter`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "fictionId",
+            "columnName": "fictionId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "chapterId",
+            "columnName": "chapterId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "startOffset",
+            "columnName": "startOffset",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "endOffset",
+            "columnName": "endOffset",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "color",
+            "columnName": "color",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "note",
+            "columnName": "note",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "quotedText",
+            "columnName": "quotedText",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "createdAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "updatedAt",
+            "columnName": "updatedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_annotation_fictionId",
+            "unique": false,
+            "columnNames": [
+              "fictionId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_annotation_fictionId` ON `${TABLE_NAME}` (`fictionId`)"
+          },
+          {
+            "name": "index_annotation_chapterId",
+            "unique": false,
+            "columnNames": [
+              "chapterId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_annotation_chapterId` ON `${TABLE_NAME}` (`chapterId`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "fiction",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "fictionId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          },
+          {
+            "table": "chapter",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "chapterId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      }
+    ],
+    "setupQueries": [
+      "CREATE TABLE IF NOT EXISTS room_master_table (id INTEGER PRIMARY KEY,identity_hash TEXT)",
+      "INSERT OR REPLACE INTO room_master_table (id,identity_hash) VALUES(42, '9acb1a313dfe0567f12001ea7f15a926')"
+    ]
+  }
+}

--- a/core-data/src/main/kotlin/in/jphe/storyvox/data/annotation/AnnotationExportFormatter.kt
+++ b/core-data/src/main/kotlin/in/jphe/storyvox/data/annotation/AnnotationExportFormatter.kt
@@ -1,0 +1,91 @@
+package `in`.jphe.storyvox.data.annotation
+
+import `in`.jphe.storyvox.data.db.entity.Annotation
+
+/**
+ * Issue #999 — pure formatter that renders a fiction's highlights + notes as
+ * Markdown or plain text for the share-sheet export. No Android / Context /
+ * IO dependency: the caller resolves the fiction title and groups the
+ * annotations by chapter (with chapter titles), then this object turns that
+ * already-resolved shape into a string. Keeping it pure makes the export
+ * format unit-testable without standing up Room or a FileProvider, and keeps
+ * the surface (FictionDetail VM) free of formatting logic.
+ *
+ * The input is pre-grouped and pre-ordered by the caller (the DAO already
+ * returns annotations in chapter-index then start-offset order), so this
+ * formatter does no sorting — it just walks the groups in the order given.
+ */
+object AnnotationExportFormatter {
+
+    /** One chapter's worth of annotations, in the order they should render. */
+    data class ChapterGroup(
+        val chapterTitle: String,
+        val annotations: List<Annotation>,
+    )
+
+    enum class Format { MARKDOWN, PLAIN }
+
+    /**
+     * Render [groups] for a fiction titled [fictionTitle]. Empty groups (a
+     * chapter with no annotations) are skipped; an entirely empty export
+     * yields a header + a "no highlights" line so the shared file is never
+     * confusingly blank.
+     */
+    fun format(
+        fictionTitle: String,
+        groups: List<ChapterGroup>,
+        format: Format,
+    ): String = when (format) {
+        Format.MARKDOWN -> markdown(fictionTitle, groups)
+        Format.PLAIN -> plain(fictionTitle, groups)
+    }
+
+    private fun markdown(fictionTitle: String, groups: List<ChapterGroup>): String {
+        val nonEmpty = groups.filter { it.annotations.isNotEmpty() }
+        val sb = StringBuilder()
+        sb.append("# ").append(fictionTitle).append("\n\n")
+        sb.append("_Highlights & notes").append("_\n\n")
+        if (nonEmpty.isEmpty()) {
+            sb.append("No highlights yet.\n")
+            return sb.toString()
+        }
+        for (group in nonEmpty) {
+            sb.append("## ").append(group.chapterTitle).append("\n\n")
+            for (a in group.annotations) {
+                // Block-quote the highlighted text; collapse internal newlines
+                // so a multi-line selection stays one quote block.
+                val quote = a.quotedText.replace("\n", " ").trim()
+                sb.append("> ").append(quote).append("\n")
+                if (!a.note.isNullOrBlank()) {
+                    sb.append("\n").append(a.note.trim()).append("\n")
+                }
+                sb.append("\n")
+            }
+        }
+        return sb.toString()
+    }
+
+    private fun plain(fictionTitle: String, groups: List<ChapterGroup>): String {
+        val nonEmpty = groups.filter { it.annotations.isNotEmpty() }
+        val sb = StringBuilder()
+        sb.append(fictionTitle).append("\n")
+        sb.append("Highlights & notes").append("\n\n")
+        if (nonEmpty.isEmpty()) {
+            sb.append("No highlights yet.\n")
+            return sb.toString()
+        }
+        for (group in nonEmpty) {
+            sb.append(group.chapterTitle).append("\n")
+            sb.append("-".repeat(group.chapterTitle.length.coerceAtLeast(1))).append("\n\n")
+            for (a in group.annotations) {
+                val quote = a.quotedText.replace("\n", " ").trim()
+                sb.append("“").append(quote).append("”").append("\n")
+                if (!a.note.isNullOrBlank()) {
+                    sb.append("  Note: ").append(a.note.trim()).append("\n")
+                }
+                sb.append("\n")
+            }
+        }
+        return sb.toString()
+    }
+}

--- a/core-data/src/main/kotlin/in/jphe/storyvox/data/annotation/ExportAnnotationsUseCase.kt
+++ b/core-data/src/main/kotlin/in/jphe/storyvox/data/annotation/ExportAnnotationsUseCase.kt
@@ -1,0 +1,163 @@
+package `in`.jphe.storyvox.data.annotation
+
+import android.content.Context
+import android.net.Uri
+import androidx.core.content.FileProvider
+import `in`.jphe.storyvox.data.annotation.AnnotationExportFormatter.ChapterGroup
+import `in`.jphe.storyvox.data.annotation.AnnotationExportFormatter.Format
+import `in`.jphe.storyvox.data.db.dao.AnnotationDao
+import `in`.jphe.storyvox.data.db.dao.ChapterDao
+import `in`.jphe.storyvox.data.db.dao.FictionDao
+import `in`.jphe.storyvox.data.db.entity.Annotation
+import `in`.jphe.storyvox.data.db.entity.Chapter
+import java.io.File
+import java.text.SimpleDateFormat
+import java.util.Date
+import java.util.Locale
+import javax.inject.Inject
+import javax.inject.Singleton
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+
+/**
+ * Issue #999 — result of [ExportAnnotationsUseCase]. Mirrors
+ * [in.jphe.storyvox.source.epub.writer.EpubExportResult] so the FictionDetail
+ * share-sheet plumbing (ACTION_SEND + SAF CreateDocument) transfers with no new
+ * UI concepts. The one divergence: [mimeType] is per-format (annotations export
+ * as `text/markdown` or `text/plain`) where EPUB is always `application/epub+zip`.
+ */
+data class AnnotationExportResult(
+    val file: File,
+    /** content:// URI granted via FileProvider — pass to ACTION_SEND / SAF. */
+    val uri: Uri,
+    /** Suggested user-facing filename for the SAF "Save…" path. */
+    val suggestedFileName: String,
+    /** `text/markdown` or `text/plain`, matching the chosen [Format]. */
+    val mimeType: String,
+    /** True when this fiction had no annotations — the file is still valid
+     *  (header + "No highlights yet.") but the UI can choose to warn first. */
+    val isEmpty: Boolean,
+)
+
+/**
+ * Builds a Markdown / plain-text export of a fiction's highlights + notes and
+ * stages it in `context.cacheDir/exports/` for the share-sheet or SAF Save-As.
+ *
+ * This is the seam between the flat DAO rows and the pure
+ * [AnnotationExportFormatter]: [buildGroups] turns the per-fiction annotation
+ * list (already chapter-index ordered by the DAO) plus the chapter titles into
+ * the formatter's [ChapterGroup] shape, then [export] writes the formatted
+ * string to disk and hands back a FileProvider URI.
+ *
+ * Threading: the file write + DB reads run on `Dispatchers.IO`. The caller
+ * (FictionDetail ViewModel) launches into `viewModelScope`. Mirrors the
+ * threading + FileProvider staging in `ExportFictionToEpubUseCase` (#117).
+ */
+@Singleton
+class ExportAnnotationsUseCase @Inject constructor(
+    private val annotationDao: AnnotationDao,
+    private val chapterDao: ChapterDao,
+    private val fictionDao: FictionDao,
+) {
+
+    /**
+     * Build the export file. Throws [IllegalStateException] when there's no
+     * Fiction row for [fictionId] — a bug at the call site, since the detail
+     * screen only offers export for fictions it's already rendering.
+     */
+    suspend fun export(
+        context: Context,
+        fictionId: String,
+        format: Format,
+    ): AnnotationExportResult = withContext(Dispatchers.IO) {
+        val fiction = fictionDao.get(fictionId)
+            ?: error("No Fiction row for id=$fictionId — was export shown for an unknown fiction?")
+
+        val annotations = annotationDao.annotationsForFiction(fictionId)
+        val chapters = chapterDao.allChapters(fictionId)
+        val groups = groupAnnotationsByChapter(annotations, chapters)
+
+        val title = fiction.title.ifBlank { "Untitled" }
+        val text = AnnotationExportFormatter.format(title, groups, format)
+
+        val outDir = File(context.cacheDir, "exports").apply { mkdirs() }
+        val fileName = buildFileName(fiction.title.ifBlank { fiction.id }, format)
+        val file = File(outDir, fileName)
+        file.writeText(text)
+
+        val uri = FileProvider.getUriForFile(
+            context,
+            // Authority matches the <provider> in app/AndroidManifest.xml —
+            // the same one #117's EPUB export uses. Keep in sync with manifest.
+            "${context.packageName}.fileprovider",
+            file,
+        )
+
+        AnnotationExportResult(
+            file = file,
+            uri = uri,
+            suggestedFileName = fileName,
+            mimeType = format.mimeType(),
+            isEmpty = annotations.isEmpty(),
+        )
+    }
+
+    /**
+     * Suggested name for the cache file + the SAF picker default. Slugified
+     * title + timestamp keeps repeated exports distinguishable; extension
+     * tracks the chosen [Format]. Mirrors the EPUB exporter's `buildFileName`.
+     */
+    private fun buildFileName(title: String, format: Format): String {
+        val slug = title.lowercase(Locale.US)
+            .replace(Regex("[^a-z0-9]+"), "-")
+            .trim('-')
+            .take(60)
+            .ifBlank { "fiction" }
+        val stamp = SimpleDateFormat("yyyyMMdd-HHmm", Locale.US).format(Date())
+        return "$slug-highlights-$stamp.${format.extension()}"
+    }
+}
+
+/**
+ * Pure grouping function — the testable core of the export. Given the flat
+ * per-fiction annotation list and the chapter rows, produce the formatter's
+ * [ChapterGroup] list in chapter reading order. No Android / Context / Room
+ * dependency, so it's covered by a plain JVM unit test (we have no Robolectric).
+ *
+ * [annotations] arrives already ordered by chapter index then start offset
+ * (the DAO's JOIN-ed `annotationsForFiction` query). We re-sort the resulting
+ * groups by the chapter's [Chapter.index] anyway, so the export stays in
+ * reading order even if the input order ever changes. An annotation whose
+ * chapter row is missing (purged while the highlight awaits a sync reconcile)
+ * sorts last rather than being dropped — losing a user's highlight silently is
+ * worse than an out-of-place one. A blank chapter title falls back to
+ * "Chapter N", matching the EPUB exporter's `title.ifBlank { "Chapter ${index + 1}" }`.
+ */
+internal fun groupAnnotationsByChapter(
+    annotations: List<Annotation>,
+    chapters: List<Chapter>,
+): List<ChapterGroup> {
+    if (annotations.isEmpty()) return emptyList()
+    val chapterById = chapters.associateBy { it.id }
+    return annotations.groupBy { it.chapterId }.entries
+        .sortedBy { (chapterId, _) -> chapterById[chapterId]?.index ?: Int.MAX_VALUE }
+        .map { (chapterId, anns) ->
+            val ch = chapterById[chapterId]
+            val title = ch?.title?.ifBlank { null }
+                ?: ch?.let { "Chapter ${it.index + 1}" }
+                ?: "Chapter"
+            ChapterGroup(chapterTitle = title, annotations = anns)
+        }
+}
+
+/** File extension for a chosen export [Format]. */
+internal fun Format.extension(): String = when (this) {
+    Format.MARKDOWN -> "md"
+    Format.PLAIN -> "txt"
+}
+
+/** MIME type for a chosen export [Format] (drives the share-sheet `type`). */
+internal fun Format.mimeType(): String = when (this) {
+    Format.MARKDOWN -> "text/markdown"
+    Format.PLAIN -> "text/plain"
+}

--- a/core-data/src/main/kotlin/in/jphe/storyvox/data/db/StoryvoxDatabase.kt
+++ b/core-data/src/main/kotlin/in/jphe/storyvox/data/db/StoryvoxDatabase.kt
@@ -4,6 +4,7 @@ import androidx.room.Database
 import androidx.room.RoomDatabase
 import androidx.room.TypeConverters
 import `in`.jphe.storyvox.data.db.converter.Converters
+import `in`.jphe.storyvox.data.db.dao.AnnotationDao
 import `in`.jphe.storyvox.data.db.dao.AuthDao
 import `in`.jphe.storyvox.data.db.dao.ChapterDao
 import `in`.jphe.storyvox.data.db.dao.ChapterHistoryDao
@@ -14,6 +15,7 @@ import `in`.jphe.storyvox.data.db.dao.InboxEventDao
 import `in`.jphe.storyvox.data.db.dao.LlmMessageDao
 import `in`.jphe.storyvox.data.db.dao.LlmSessionDao
 import `in`.jphe.storyvox.data.db.dao.PlaybackDao
+import `in`.jphe.storyvox.data.db.entity.Annotation
 import `in`.jphe.storyvox.data.db.entity.AuthCookie
 import `in`.jphe.storyvox.data.db.entity.Chapter
 import `in`.jphe.storyvox.data.db.entity.ChapterHistory
@@ -49,6 +51,11 @@ import `in`.jphe.storyvox.data.db.entity.PlaybackPosition
         // cross-fiction lookup still surfaces "you read this name in
         // a book you no longer have."
         FictionMemoryEntry::class,
+        // v14 (#999 highlights + notes) — text-range annotations beyond the
+        // single per-chapter bookmark. FK CASCADE to fiction + chapter so a
+        // removed book drops its highlights. Char-offset range into the
+        // chapter body (same coordinate as the bookmark + sentence-highlight).
+        Annotation::class,
     ],
     // v11 (#965 per-chapter playback position) — PlaybackPosition PK changes
     // from `fictionId` to composite `(fictionId, chapterId)` so each chapter
@@ -63,7 +70,11 @@ import `in`.jphe.storyvox.data.db.entity.PlaybackPosition
     // original source URL for hash-id sources (Readability/RSS/EPUB
     // direct-download) so a synced placeholder can be rebuilt on a
     // second device. Purely additive nullable column.
-    version = 13,
+    //
+    // v14 (#999 highlights + notes) — new `annotation` table for text-range
+    // highlights with optional notes. Purely additive table; no existing
+    // table or row is touched.
+    version = 14,
     exportSchema = true,
 )
 @TypeConverters(Converters::class)
@@ -78,6 +89,7 @@ abstract class StoryvoxDatabase : RoomDatabase() {
     abstract fun fictionShelfDao(): FictionShelfDao
     abstract fun inboxEventDao(): InboxEventDao
     abstract fun fictionMemoryDao(): FictionMemoryDao
+    abstract fun annotationDao(): AnnotationDao
 
     companion object {
         const val NAME: String = "storyvox.db"

--- a/core-data/src/main/kotlin/in/jphe/storyvox/data/db/dao/AnnotationDao.kt
+++ b/core-data/src/main/kotlin/in/jphe/storyvox/data/db/dao/AnnotationDao.kt
@@ -1,0 +1,82 @@
+package `in`.jphe.storyvox.data.db.dao
+
+import androidx.room.Dao
+import androidx.room.Insert
+import androidx.room.OnConflictStrategy
+import androidx.room.Query
+import `in`.jphe.storyvox.data.db.entity.Annotation
+import kotlinx.coroutines.flow.Flow
+
+/**
+ * Read/write surface for the `annotation` table (issue #999) — text
+ * highlights + optional notes, beyond the single per-chapter bookmark.
+ *
+ * Patterned on [FictionShelfDao]: idempotent upsert via
+ * [OnConflictStrategy.REPLACE] (re-saving the same annotation id is a no-op
+ * refresh, not a crash), plus targeted deletes. The reader observes one
+ * chapter's spans ([observeForChapter]); the FictionDetail list observes the
+ * whole fiction ([observeForFiction]); the syncer reads everything
+ * ([allAnnotations]) and probes existence ([exists]) for its FK-guard.
+ */
+@Dao
+interface AnnotationDao {
+
+    // ── Observers ────────────────────────────────────────────────────────
+
+    /**
+     * Every annotation for a fiction, ordered for the grouped list:
+     * chapter-by-chapter (by the chapter's reading order via the join),
+     * then by start offset, then newest-edit as a tiebreak.
+     */
+    @Query(
+        """
+        SELECT a.* FROM annotation a
+        INNER JOIN chapter c ON c.id = a.chapterId
+        WHERE a.fictionId = :fictionId
+        ORDER BY c.`index` ASC, a.startOffset ASC, a.updatedAt DESC
+        """,
+    )
+    fun observeForFiction(fictionId: String): Flow<List<Annotation>>
+
+    /** This chapter's annotations, start-offset order — the reader overlay. */
+    @Query(
+        "SELECT * FROM annotation WHERE chapterId = :chapterId ORDER BY startOffset ASC",
+    )
+    fun observeForChapter(chapterId: String): Flow<List<Annotation>>
+
+    /** Whole-table snapshot for the syncer's reconcile pass. */
+    @Query("SELECT * FROM annotation")
+    suspend fun allAnnotations(): List<Annotation>
+
+    /** One-shot per-fiction read for non-flow paths (export builder). */
+    @Query(
+        """
+        SELECT a.* FROM annotation a
+        INNER JOIN chapter c ON c.id = a.chapterId
+        WHERE a.fictionId = :fictionId
+        ORDER BY c.`index` ASC, a.startOffset ASC, a.updatedAt DESC
+        """,
+    )
+    suspend fun annotationsForFiction(fictionId: String): List<Annotation>
+
+    /** Sync FK-guard: is this annotation row already present locally? */
+    @Query("SELECT EXISTS(SELECT 1 FROM annotation WHERE id = :id)")
+    suspend fun exists(id: String): Boolean
+
+    // ── Mutators ─────────────────────────────────────────────────────────
+
+    /**
+     * Insert is REPLACE so re-saving an annotation by id (an edit to its
+     * note, or a sync apply of a newer copy) overwrites the row rather than
+     * throwing. UI / sync are both idempotent on id.
+     */
+    @Insert(onConflict = OnConflictStrategy.REPLACE)
+    suspend fun upsert(annotation: Annotation)
+
+    @Query("DELETE FROM annotation WHERE id = :id")
+    suspend fun deleteById(id: String)
+
+    /** Drop every annotation for a fiction — e.g. on library removal. */
+    @Query("DELETE FROM annotation WHERE fictionId = :fictionId")
+    suspend fun clearForFiction(fictionId: String)
+}

--- a/core-data/src/main/kotlin/in/jphe/storyvox/data/db/entity/Annotation.kt
+++ b/core-data/src/main/kotlin/in/jphe/storyvox/data/db/entity/Annotation.kt
@@ -1,0 +1,97 @@
+package `in`.jphe.storyvox.data.db.entity
+
+import androidx.room.Entity
+import androidx.room.ForeignKey
+import androidx.room.Index
+import androidx.room.PrimaryKey
+
+/**
+ * Issue #999 — a text highlight (optionally with a note) inside a chapter.
+ *
+ * Goes beyond the single per-chapter bookmark ([Chapter.bookmarkCharOffset],
+ * #121): a fiction can hold many annotations, each spanning a character range
+ * of the chapter body, optionally carrying a freeform [note].
+ *
+ * ## Range model
+ * `[startOffset, endOffset)` are character offsets into the chapter's body
+ * text — the *same* coordinate the existing bookmark ([Chapter.bookmarkCharOffset]
+ * → `plainBody`) and the reader's sentence-highlight use. No new coordinate
+ * concept is introduced: the reader already maps offsets ↔ `TextLayoutResult`.
+ *
+ * Offsets are best-effort for scroll-to / overlay rendering. A chapter
+ * re-fetch can shift the body (different whitespace, a fixed typo), so the
+ * offsets may no longer line up. [quotedText] is the durable record — it is
+ * denormalized into the row so the annotation list and the export survive a
+ * body that no longer matches, and so the overlay can be skipped (rather than
+ * drawn at the wrong place) when the range falls outside the current body.
+ *
+ * ## Identity
+ * [id] is a client-generated UUID (see `SyncIds`), NOT a derived key. A stable
+ * id is what lets [AnnotationsSyncer] (#999, mirroring `BookmarksSyncer`)
+ * address one annotation across devices and express an explicit delete
+ * tombstone for it without a derived-key collision when two devices highlight
+ * overlapping ranges.
+ *
+ * ## Cascade
+ * Both FKs are `ON DELETE CASCADE`: purging a fiction (or a chapter) drops its
+ * annotations, so removing a book can't leave orphaned highlight rows that
+ * would surface as ghost entries in the per-fiction list. Mirrors the cascade
+ * reasoning in [FictionShelf] and [Chapter].
+ */
+@Entity(
+    tableName = "annotation",
+    foreignKeys = [
+        ForeignKey(
+            entity = Fiction::class,
+            parentColumns = ["id"],
+            childColumns = ["fictionId"],
+            onDelete = ForeignKey.CASCADE,
+        ),
+        ForeignKey(
+            entity = Chapter::class,
+            parentColumns = ["id"],
+            childColumns = ["chapterId"],
+            onDelete = ForeignKey.CASCADE,
+        ),
+    ],
+    indices = [
+        // Per-fiction list surface (FictionDetail highlights/notes view).
+        Index(value = ["fictionId"]),
+        // Per-chapter overlay query (reader renders this chapter's spans) and
+        // the FK-cascade planner for the chapter foreign key.
+        Index(value = ["chapterId"]),
+    ],
+)
+data class Annotation(
+    /** Client-generated UUID — the stable cross-device sync key. */
+    @PrimaryKey val id: String,
+    val fictionId: String,
+    val chapterId: String,
+    /** Inclusive start char offset into the chapter body. */
+    val startOffset: Int,
+    /** Exclusive end char offset into the chapter body. */
+    val endOffset: Int,
+    /**
+     * Highlight color, persisted as a palette enum *name* string (not an
+     * ordinal) so a new swatch can be appended without a schema migration —
+     * the same string-not-ordinal pattern as [FictionShelf.shelf].
+     */
+    val color: String,
+    /** Optional freeform note. Null = a highlight with no attached note. */
+    val note: String? = null,
+    /**
+     * Denormalized snapshot of the highlighted text at creation time. The
+     * durable record of *what* was highlighted, independent of whether
+     * [startOffset]/[endOffset] still line up after a body re-fetch.
+     */
+    val quotedText: String,
+    /** Wall-clock millis the annotation was created. */
+    val createdAt: Long,
+    /**
+     * Wall-clock millis of the last edit (note change). Equal to
+     * [createdAt] on first write. Drives last-writer-wins in
+     * [AnnotationsSyncer] and orders the per-fiction list within a chapter
+     * group as a tiebreak after [startOffset].
+     */
+    val updatedAt: Long,
+)

--- a/core-data/src/main/kotlin/in/jphe/storyvox/data/db/migration/Migrations.kt
+++ b/core-data/src/main/kotlin/in/jphe/storyvox/data/db/migration/Migrations.kt
@@ -406,6 +406,55 @@ val MIGRATION_12_13: Migration = object : Migration(12, 13) {
     }
 }
 
+/**
+ * Issue #999 — v14 creates the `annotation` table for text-range highlights
+ * with optional notes (beyond the single per-chapter bookmark, #121).
+ *
+ * Purely additive: no existing table or row is touched. The table carries two
+ * `ON DELETE CASCADE` foreign keys (fiction + chapter), so removing a book
+ * drops its highlights rather than orphaning them. Two indexes:
+ * `index_annotation_fictionId` (per-fiction list) and
+ * `index_annotation_chapterId` (reader per-chapter overlay + the chapter
+ * FK-cascade planner).
+ *
+ * The CREATE TABLE / CREATE INDEX SQL is hand-written to match what Room
+ * generates from the [Annotation] `@Entity`; `runMigrationsAndValidate`
+ * against `14.json` fails with an identity-hash mismatch if they ever drift.
+ */
+val MIGRATION_13_14: Migration = object : Migration(13, 14) {
+    override fun migrate(db: SupportSQLiteDatabase) {
+        db.execSQL(
+            """
+            CREATE TABLE IF NOT EXISTS `annotation` (
+                `id` TEXT NOT NULL,
+                `fictionId` TEXT NOT NULL,
+                `chapterId` TEXT NOT NULL,
+                `startOffset` INTEGER NOT NULL,
+                `endOffset` INTEGER NOT NULL,
+                `color` TEXT NOT NULL,
+                `note` TEXT,
+                `quotedText` TEXT NOT NULL,
+                `createdAt` INTEGER NOT NULL,
+                `updatedAt` INTEGER NOT NULL,
+                PRIMARY KEY(`id`),
+                FOREIGN KEY(`fictionId`) REFERENCES `fiction`(`id`)
+                  ON UPDATE NO ACTION ON DELETE CASCADE,
+                FOREIGN KEY(`chapterId`) REFERENCES `chapter`(`id`)
+                  ON UPDATE NO ACTION ON DELETE CASCADE
+            )
+            """.trimIndent(),
+        )
+        db.execSQL(
+            "CREATE INDEX IF NOT EXISTS `index_annotation_fictionId` " +
+                "ON `annotation` (`fictionId`)",
+        )
+        db.execSQL(
+            "CREATE INDEX IF NOT EXISTS `index_annotation_chapterId` " +
+                "ON `annotation` (`chapterId`)",
+        )
+    }
+}
+
 val ALL_MIGRATIONS: Array<Migration> = arrayOf(
     MIGRATION_1_2,
     MIGRATION_2_3,
@@ -419,4 +468,5 @@ val ALL_MIGRATIONS: Array<Migration> = arrayOf(
     MIGRATION_10_11,
     MIGRATION_11_12,
     MIGRATION_12_13,
+    MIGRATION_13_14,
 )

--- a/core-data/src/main/kotlin/in/jphe/storyvox/data/di/DataModule.kt
+++ b/core-data/src/main/kotlin/in/jphe/storyvox/data/di/DataModule.kt
@@ -17,6 +17,7 @@ import `in`.jphe.storyvox.data.db.StoryvoxDatabase
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.SupervisorJob
+import `in`.jphe.storyvox.data.db.dao.AnnotationDao
 import `in`.jphe.storyvox.data.db.dao.AuthDao
 import `in`.jphe.storyvox.data.db.dao.ChapterDao
 import `in`.jphe.storyvox.data.db.dao.ChapterHistoryDao
@@ -29,6 +30,8 @@ import `in`.jphe.storyvox.data.db.dao.LlmSessionDao
 import `in`.jphe.storyvox.data.db.dao.PlaybackDao
 import `in`.jphe.storyvox.data.db.migration.ALL_MIGRATIONS
 import `in`.jphe.storyvox.data.repository.AuthRepository
+import `in`.jphe.storyvox.data.repository.AnnotationRepository
+import `in`.jphe.storyvox.data.repository.AnnotationRepositoryImpl
 import `in`.jphe.storyvox.data.repository.AuthRepositoryImpl
 import `in`.jphe.storyvox.data.repository.ChapterDownloadScheduler
 import `in`.jphe.storyvox.data.repository.ChapterRepository
@@ -119,6 +122,9 @@ object DataModule {
     @Provides fun fictionShelfDao(db: StoryvoxDatabase): FictionShelfDao = db.fictionShelfDao()
     @Provides fun inboxEventDao(db: StoryvoxDatabase): InboxEventDao = db.inboxEventDao()
     @Provides fun fictionMemoryDao(db: StoryvoxDatabase): FictionMemoryDao = db.fictionMemoryDao()
+    // Issue #999 — highlights + notes. Consumed by AnnotationsSyncer,
+    // ExportAnnotationsUseCase, and AnnotationRepository.
+    @Provides fun annotationDao(db: StoryvoxDatabase): AnnotationDao = db.annotationDao()
 
     /**
      * Long-lived [CoroutineScope] for singleton repositories that need to fire
@@ -300,6 +306,11 @@ abstract class RepositoryBindings {
     abstract fun bindFictionMemoryRepository(
         impl: FictionMemoryRepositoryImpl,
     ): FictionMemoryRepository
+
+    @Binds @Singleton
+    abstract fun bindAnnotationRepository(
+        impl: AnnotationRepositoryImpl,
+    ): AnnotationRepository
 
     @Binds @Singleton
     abstract fun bindChapterDownloadScheduler(

--- a/core-data/src/main/kotlin/in/jphe/storyvox/data/repository/AnnotationRepository.kt
+++ b/core-data/src/main/kotlin/in/jphe/storyvox/data/repository/AnnotationRepository.kt
@@ -1,0 +1,42 @@
+package `in`.jphe.storyvox.data.repository
+
+import `in`.jphe.storyvox.data.db.dao.AnnotationDao
+import `in`.jphe.storyvox.data.db.entity.Annotation
+import javax.inject.Inject
+import javax.inject.Singleton
+import kotlinx.coroutines.flow.Flow
+
+/**
+ * Issue #999 — read/delete surface for a fiction's highlights + notes,
+ * backing the FictionDetail "Highlights & notes" list. Mirrors
+ * [FictionMemoryRepository]: a thin domain seam over [AnnotationDao] so the
+ * feature module observes/deletes annotations without importing Room DAOs
+ * directly (the convention every feature ViewModel here follows).
+ *
+ * Writes (create/edit an annotation from the reader select-drag overlay) land
+ * in #999's phase-2 fast-follow; this v1 surface is read + delete only, which
+ * is all the FictionDetail list needs. The export path goes through
+ * [in.jphe.storyvox.data.annotation.ExportAnnotationsUseCase], not this repo.
+ */
+interface AnnotationRepository {
+
+    /** Live feed of every annotation for [fictionId], chapter-index then
+     *  start-offset ordered (the DAO's JOIN-ed query) — the list surface. */
+    fun observeForFiction(fictionId: String): Flow<List<Annotation>>
+
+    /** Delete a single annotation by its UUID — the list's per-row delete. */
+    suspend fun delete(id: String)
+}
+
+@Singleton
+class AnnotationRepositoryImpl @Inject constructor(
+    private val dao: AnnotationDao,
+) : AnnotationRepository {
+
+    override fun observeForFiction(fictionId: String): Flow<List<Annotation>> =
+        dao.observeForFiction(fictionId)
+
+    override suspend fun delete(id: String) {
+        dao.deleteById(id)
+    }
+}

--- a/core-data/src/test/kotlin/in/jphe/storyvox/data/annotation/AnnotationExportFormatterTest.kt
+++ b/core-data/src/test/kotlin/in/jphe/storyvox/data/annotation/AnnotationExportFormatterTest.kt
@@ -1,0 +1,91 @@
+package `in`.jphe.storyvox.data.annotation
+
+import `in`.jphe.storyvox.data.annotation.AnnotationExportFormatter.ChapterGroup
+import `in`.jphe.storyvox.data.annotation.AnnotationExportFormatter.Format
+import `in`.jphe.storyvox.data.db.entity.Annotation
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * #999 — pure-function coverage for the highlights/notes export formatter.
+ * No Room, no Context: just shape-in → string-out.
+ */
+class AnnotationExportFormatterTest {
+
+    private fun a(quoted: String, note: String? = null) = Annotation(
+        id = "x", fictionId = "f", chapterId = "c",
+        startOffset = 0, endOffset = quoted.length, color = "YELLOW",
+        note = note, quotedText = quoted, createdAt = 0L, updatedAt = 0L,
+    )
+
+    @Test fun `markdown includes title, chapter headers, quotes and notes`() {
+        val out = AnnotationExportFormatter.format(
+            fictionTitle = "Mother of Learning",
+            groups = listOf(
+                ChapterGroup("Chapter 1", listOf(a("a passage", "my note"), a("another bit"))),
+                ChapterGroup("Chapter 2", listOf(a("deep thought", "important"))),
+            ),
+            format = Format.MARKDOWN,
+        )
+        assertTrue(out.startsWith("# Mother of Learning"))
+        assertTrue("chapter 1 header", out.contains("## Chapter 1"))
+        assertTrue("chapter 2 header", out.contains("## Chapter 2"))
+        assertTrue("quoted passage as blockquote", out.contains("> a passage"))
+        assertTrue("note rendered", out.contains("my note"))
+        assertTrue("note-less highlight still shows quote", out.contains("> another bit"))
+        assertTrue("second chapter note", out.contains("important"))
+    }
+
+    @Test fun `plain text uses quotes and Note prefix`() {
+        val out = AnnotationExportFormatter.format(
+            fictionTitle = "MoL",
+            groups = listOf(ChapterGroup("Ch1", listOf(a("hello world", "remember")))),
+            format = Format.PLAIN,
+        )
+        assertTrue(out.startsWith("MoL"))
+        assertTrue("plain has no markdown header", !out.contains("# MoL"))
+        assertTrue("quoted with curly quotes", out.contains("“hello world”"))
+        assertTrue("note prefixed", out.contains("Note: remember"))
+    }
+
+    @Test fun `empty groups yield a friendly no-highlights line, not a blank file`() {
+        val md = AnnotationExportFormatter.format("Empty Book", emptyList(), Format.MARKDOWN)
+        assertTrue(md.contains("No highlights yet."))
+        val txt = AnnotationExportFormatter.format("Empty Book", emptyList(), Format.PLAIN)
+        assertTrue(txt.contains("No highlights yet."))
+    }
+
+    @Test fun `chapters with zero annotations are skipped`() {
+        val out = AnnotationExportFormatter.format(
+            fictionTitle = "Book",
+            groups = listOf(
+                ChapterGroup("Has none", emptyList()),
+                ChapterGroup("Has one", listOf(a("kept"))),
+            ),
+            format = Format.MARKDOWN,
+        )
+        assertFalse("empty chapter header must be omitted", out.contains("Has none"))
+        assertTrue("non-empty chapter header present", out.contains("## Has one"))
+    }
+
+    @Test fun `multiline quoted text is collapsed to a single line`() {
+        val out = AnnotationExportFormatter.format(
+            fictionTitle = "Book",
+            groups = listOf(ChapterGroup("Ch", listOf(a("line one\nline two")))),
+            format = Format.MARKDOWN,
+        )
+        assertTrue("newline collapsed inside the quote", out.contains("> line one line two"))
+        assertFalse("no stray mid-quote newline", out.contains("> line one\nline two"))
+    }
+
+    @Test fun `blank note is treated as no note`() {
+        val out = AnnotationExportFormatter.format(
+            fictionTitle = "Book",
+            groups = listOf(ChapterGroup("Ch", listOf(a("quote", note = "   ")))),
+            format = Format.PLAIN,
+        )
+        assertEquals("blank note must not render a Note line", false, out.contains("Note:"))
+    }
+}

--- a/core-data/src/test/kotlin/in/jphe/storyvox/data/annotation/ExportAnnotationsUseCaseTest.kt
+++ b/core-data/src/test/kotlin/in/jphe/storyvox/data/annotation/ExportAnnotationsUseCaseTest.kt
@@ -1,0 +1,90 @@
+package `in`.jphe.storyvox.data.annotation
+
+import `in`.jphe.storyvox.data.annotation.AnnotationExportFormatter.Format
+import `in`.jphe.storyvox.data.db.entity.Annotation
+import `in`.jphe.storyvox.data.db.entity.Chapter
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * #999 — pure coverage for the grouping seam + Format helpers behind
+ * [ExportAnnotationsUseCase]. The Context-bound `export()` path (FileProvider,
+ * cacheDir write) is exercised on-device, not here; this tests the testable
+ * core: flat DAO rows → chapter-ordered [AnnotationExportFormatter.ChapterGroup]s.
+ */
+class ExportAnnotationsUseCaseTest {
+
+    private fun chapter(id: String, index: Int, title: String = "Chapter $index") = Chapter(
+        id = id, fictionId = "f", sourceChapterId = id, index = index, title = title,
+    )
+
+    private fun annotation(id: String, chapterId: String, quoted: String, note: String? = null) =
+        Annotation(
+            id = id, fictionId = "f", chapterId = chapterId,
+            startOffset = 0, endOffset = quoted.length, color = "YELLOW",
+            note = note, quotedText = quoted, createdAt = 0L, updatedAt = 0L,
+        )
+
+    @Test fun `groups by chapter and orders by chapter index`() {
+        // Chapters out of index order in the input list; annotations reference
+        // both. Grouping must emit the chapter-1 group before chapter-2.
+        val chapters = listOf(chapter("c2", 1), chapter("c1", 0))
+        val annotations = listOf(
+            annotation("a1", "c1", "first chapter quote"),
+            annotation("a2", "c2", "second chapter quote"),
+        )
+        val groups = groupAnnotationsByChapter(annotations, chapters)
+        assertEquals(2, groups.size)
+        assertEquals("Chapter 0", groups[0].chapterTitle)
+        assertEquals("Chapter 1", groups[1].chapterTitle)
+        assertEquals("first chapter quote", groups[0].annotations.single().quotedText)
+    }
+
+    @Test fun `multiple annotations in one chapter stay in one group`() {
+        val chapters = listOf(chapter("c1", 0))
+        val annotations = listOf(
+            annotation("a1", "c1", "alpha"),
+            annotation("a2", "c1", "beta"),
+        )
+        val groups = groupAnnotationsByChapter(annotations, chapters)
+        assertEquals(1, groups.size)
+        assertEquals(listOf("alpha", "beta"), groups[0].annotations.map { it.quotedText })
+    }
+
+    @Test fun `empty annotation list yields no groups`() {
+        val groups = groupAnnotationsByChapter(emptyList(), listOf(chapter("c1", 0)))
+        assertTrue(groups.isEmpty())
+    }
+
+    @Test fun `blank chapter title falls back to Chapter N+1`() {
+        val chapters = listOf(chapter("c1", 4, title = ""))
+        val annotations = listOf(annotation("a1", "c1", "quote"))
+        val groups = groupAnnotationsByChapter(annotations, chapters)
+        // index 4 → human-facing "Chapter 5"
+        assertEquals("Chapter 5", groups.single().chapterTitle)
+    }
+
+    @Test fun `annotation for an unknown chapter still exports, sorted last`() {
+        // A chapter row may be missing (e.g. purged) while the annotation
+        // survives until the next sync reconcile. Don't drop it — sort it
+        // last (Int.MAX_VALUE index) so the highlight isn't silently lost.
+        val chapters = listOf(chapter("c1", 0))
+        val annotations = listOf(
+            annotation("a1", "c1", "known"),
+            annotation("a2", "ghost", "orphaned"),
+        )
+        val groups = groupAnnotationsByChapter(annotations, chapters)
+        assertEquals(2, groups.size)
+        assertEquals("known", groups[0].annotations.single().quotedText)
+        assertEquals("orphaned", groups[1].annotations.single().quotedText)
+        assertEquals("Chapter", groups[1].chapterTitle)
+    }
+
+    @Test fun `format extension and mime track the chosen format`() {
+        assertEquals("md", Format.MARKDOWN.extension())
+        assertEquals("txt", Format.PLAIN.extension())
+        assertEquals("text/markdown", Format.MARKDOWN.mimeType())
+        assertEquals("text/plain", Format.PLAIN.mimeType())
+    }
+}

--- a/core-data/src/test/kotlin/in/jphe/storyvox/data/db/StoryvoxDatabaseMigrationTest.kt
+++ b/core-data/src/test/kotlin/in/jphe/storyvox/data/db/StoryvoxDatabaseMigrationTest.kt
@@ -16,6 +16,7 @@ import `in`.jphe.storyvox.data.db.migration.MIGRATION_9_10
 import `in`.jphe.storyvox.data.db.migration.MIGRATION_10_11
 import `in`.jphe.storyvox.data.db.migration.MIGRATION_11_12
 import `in`.jphe.storyvox.data.db.migration.MIGRATION_12_13
+import `in`.jphe.storyvox.data.db.migration.MIGRATION_13_14
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNotNull
 import org.junit.Assert.assertTrue
@@ -150,13 +151,16 @@ class StoryvoxDatabaseMigrationTest {
         // #989 — v13 adds fiction.sourceUrl. Chain through so the
         // latest-version Room.databaseBuilder opens cleanly.
         helper.runMigrationsAndValidate(dbName, 13, true, MIGRATION_12_13).close()
+        // #999 — v14 adds the annotation table. Chain through so the
+        // latest-version Room.databaseBuilder opens cleanly.
+        helper.runMigrationsAndValidate(dbName, 14, true, MIGRATION_13_14).close()
 
         val ctx = org.robolectric.RuntimeEnvironment.getApplication() as android.content.Context
         val db = Room.databaseBuilder(ctx, StoryvoxDatabase::class.java, dbName)
             .addMigrations(
                 MIGRATION_4_5, MIGRATION_5_6, MIGRATION_6_7, MIGRATION_7_8,
                 MIGRATION_8_9, MIGRATION_9_10, MIGRATION_10_11, MIGRATION_11_12,
-                MIGRATION_12_13,
+                MIGRATION_12_13, MIGRATION_13_14,
             )
             .build()
 
@@ -319,13 +323,15 @@ class StoryvoxDatabaseMigrationTest {
         helper.runMigrationsAndValidate(dbName, 12, true, MIGRATION_11_12).close()
         // #989 — chain through v13 (fiction.sourceUrl).
         helper.runMigrationsAndValidate(dbName, 13, true, MIGRATION_12_13).close()
+        // #999 — chain through v14 (annotation table).
+        helper.runMigrationsAndValidate(dbName, 14, true, MIGRATION_13_14).close()
 
         val ctx = org.robolectric.RuntimeEnvironment.getApplication() as android.content.Context
         val db = Room.databaseBuilder(ctx, StoryvoxDatabase::class.java, dbName)
             .addMigrations(
                 MIGRATION_4_5, MIGRATION_5_6, MIGRATION_6_7, MIGRATION_7_8,
                 MIGRATION_8_9, MIGRATION_9_10, MIGRATION_10_11, MIGRATION_11_12,
-                MIGRATION_12_13,
+                MIGRATION_12_13, MIGRATION_13_14,
             )
             .build()
 
@@ -1027,5 +1033,178 @@ class StoryvoxDatabaseMigrationTest {
         }
 
         db.close()
+    }
+
+    /**
+     * Issue #999 — v14 creates the `annotation` table for text-range
+     * highlights with optional notes (beyond the single per-chapter
+     * bookmark, #121). Purely additive: existing tables are untouched. Two
+     * indexes (`fictionId` for the per-fiction list, `chapterId` for the
+     * reader overlay + FK-cascade planner) must exist post-migration.
+     *
+     * `runMigrationsAndValidate(..., 14, true, MIGRATION_13_14)` also
+     * triggers Room's identity-hash check against `14.json`, so a malformed
+     * CREATE TABLE, a wrong column type, a missing FK action, or a dropped
+     * index fails here too.
+     */
+    @Test fun `migrate v13 to v14 creates annotation table`() {
+        val dbName = "annotation-migration-test.db"
+
+        helper.createDatabase(dbName, 4).close()
+        helper.runMigrationsAndValidate(dbName, 5, true, MIGRATION_4_5).close()
+        helper.runMigrationsAndValidate(dbName, 6, true, MIGRATION_5_6).close()
+        helper.runMigrationsAndValidate(dbName, 7, true, MIGRATION_6_7).close()
+        helper.runMigrationsAndValidate(dbName, 8, true, MIGRATION_7_8).close()
+        helper.runMigrationsAndValidate(dbName, 9, true, MIGRATION_8_9).close()
+        helper.runMigrationsAndValidate(dbName, 10, true, MIGRATION_9_10).close()
+        helper.runMigrationsAndValidate(dbName, 11, true, MIGRATION_10_11).close()
+        helper.runMigrationsAndValidate(dbName, 12, true, MIGRATION_11_12).close()
+        helper.runMigrationsAndValidate(dbName, 13, true, MIGRATION_12_13).close()
+
+        val db = helper.runMigrationsAndValidate(
+            dbName,
+            14,
+            /* validateDroppedTables = */ true,
+            MIGRATION_13_14,
+        )
+
+        db.query(
+            "SELECT name FROM sqlite_master WHERE type='table' AND name='annotation'",
+        ).use { c ->
+            assertTrue("annotation table must exist post-migration", c.moveToFirst())
+        }
+
+        db.query(
+            "SELECT name FROM sqlite_master WHERE type='index' AND tbl_name='annotation'",
+        ).use { c ->
+            val indexes = mutableListOf<String>()
+            while (c.moveToNext()) indexes += c.getString(0)
+            assertTrue(
+                "index_annotation_fictionId must exist (per-fiction list)",
+                indexes.any { it == "index_annotation_fictionId" },
+            )
+            assertTrue(
+                "index_annotation_chapterId must exist (reader overlay + FK planner)",
+                indexes.any { it == "index_annotation_chapterId" },
+            )
+        }
+
+        // note must be the only nullable column; offsets/timestamps NOT NULL.
+        db.query("PRAGMA table_info('annotation')").use { c ->
+            val nullableByName = mutableMapOf<String, Boolean>()
+            while (c.moveToNext()) {
+                val name = c.getString(c.getColumnIndexOrThrow("name"))
+                val notnull = c.getInt(c.getColumnIndexOrThrow("notnull"))
+                nullableByName[name] = (notnull == 0)
+            }
+            assertEquals("note must be nullable", true, nullableByName["note"])
+            assertEquals("startOffset must be NOT NULL", false, nullableByName["startOffset"])
+            assertEquals("quotedText must be NOT NULL", false, nullableByName["quotedText"])
+        }
+
+        db.close()
+    }
+
+    /**
+     * Issue #999 — smoke test that the migrated v14 db can write + read an
+     * annotation row through the raw SQL surface. Catches a schema/entity
+     * mismatch the identity-hash check alone wouldn't (e.g. a column rename
+     * that happens to keep the hash stable). Seeds the parent fiction +
+     * chapter first (FK: annotation → fiction + chapter).
+     */
+    @Test fun `migrated v14 db round-trips an annotation row`() {
+        val dbName = "annotation-roundtrip-test.db"
+        helper.createDatabase(dbName, 4).close()
+        helper.runMigrationsAndValidate(dbName, 5, true, MIGRATION_4_5).close()
+        helper.runMigrationsAndValidate(dbName, 6, true, MIGRATION_5_6).close()
+        helper.runMigrationsAndValidate(dbName, 7, true, MIGRATION_6_7).close()
+        helper.runMigrationsAndValidate(dbName, 8, true, MIGRATION_7_8).close()
+        helper.runMigrationsAndValidate(dbName, 9, true, MIGRATION_8_9).close()
+        helper.runMigrationsAndValidate(dbName, 10, true, MIGRATION_9_10).close()
+        helper.runMigrationsAndValidate(dbName, 11, true, MIGRATION_10_11).close()
+        helper.runMigrationsAndValidate(dbName, 12, true, MIGRATION_11_12).close()
+        helper.runMigrationsAndValidate(dbName, 13, true, MIGRATION_12_13).close()
+        helper.runMigrationsAndValidate(dbName, 14, true, MIGRATION_13_14).close()
+
+        val ctx = org.robolectric.RuntimeEnvironment.getApplication() as android.content.Context
+        val db = Room.databaseBuilder(ctx, StoryvoxDatabase::class.java, dbName)
+            .addMigrations(
+                MIGRATION_4_5, MIGRATION_5_6, MIGRATION_6_7, MIGRATION_7_8,
+                MIGRATION_8_9, MIGRATION_9_10, MIGRATION_10_11, MIGRATION_11_12,
+                MIGRATION_12_13, MIGRATION_13_14,
+            )
+            .build()
+
+        try {
+            db.openHelper.writableDatabase.execSQL(
+                """
+                INSERT INTO fiction(
+                    id, sourceId, title, author, genres, tags, status,
+                    chapterCount, firstSeenAt, metadataFetchedAt,
+                    inLibrary, followedRemotely, notesEverSeen
+                ) VALUES (
+                    'rr:42', 'royalroad', 'Mother of Learning', 'nobody103',
+                    '[]', '[]', 'ONGOING', 1, 0, 0, 1, 0, 0
+                )
+                """.trimIndent(),
+            )
+            db.openHelper.writableDatabase.execSQL(
+                """
+                INSERT INTO chapter(
+                    id, fictionId, sourceChapterId, `index`, title,
+                    downloadState, userMarkedRead
+                ) VALUES (
+                    'rr:42:0', 'rr:42', '0', 0, 'Good Morning Brother',
+                    'NOT_DOWNLOADED', 0
+                )
+                """.trimIndent(),
+            )
+            // One highlight WITH a note, one WITHOUT (null note column).
+            db.openHelper.writableDatabase.execSQL(
+                "INSERT INTO annotation(id, fictionId, chapterId, startOffset, endOffset, " +
+                    "color, note, quotedText, createdAt, updatedAt) VALUES " +
+                    "('ann-1', 'rr:42', 'rr:42:0', 10, 25, 'YELLOW', 'remember this', " +
+                    "'a good morning', 1000, 1000)",
+            )
+            db.openHelper.writableDatabase.execSQL(
+                "INSERT INTO annotation(id, fictionId, chapterId, startOffset, endOffset, " +
+                    "color, note, quotedText, createdAt, updatedAt) VALUES " +
+                    "('ann-2', 'rr:42', 'rr:42:0', 40, 50, 'GREEN', NULL, " +
+                    "'plain highlight', 2000, 2000)",
+            )
+
+            db.openHelper.readableDatabase.query(
+                "SELECT id, startOffset, endOffset, color, note, quotedText, updatedAt " +
+                    "FROM annotation ORDER BY startOffset",
+            ).use { c ->
+                assertTrue(c.moveToFirst())
+                assertEquals("ann-1", c.getString(0))
+                assertEquals(10, c.getInt(1))
+                assertEquals(25, c.getInt(2))
+                assertEquals("YELLOW", c.getString(3))
+                assertEquals("remember this", c.getString(4))
+                assertEquals("a good morning", c.getString(5))
+                assertEquals(1000L, c.getLong(6))
+
+                assertTrue(c.moveToNext())
+                assertEquals("ann-2", c.getString(0))
+                assertEquals("GREEN", c.getString(3))
+                assertTrue("ann-2 note must be NULL", c.isNull(4))
+
+                assertTrue("exactly two annotation rows", !c.moveToNext())
+            }
+
+            // CASCADE: deleting the fiction drops its annotations.
+            db.openHelper.writableDatabase.execSQL("PRAGMA foreign_keys = ON")
+            db.openHelper.writableDatabase.execSQL("DELETE FROM fiction WHERE id = 'rr:42'")
+            db.openHelper.readableDatabase.query("SELECT COUNT(*) FROM annotation").use { c ->
+                assertTrue(c.moveToFirst())
+                assertEquals("annotations cascade-deleted with the fiction", 0, c.getInt(0))
+            }
+        } finally {
+            db.close()
+        }
+
+        assertNotNull("smoke sentinel — fail-fast if the try block was no-op'd", helper)
     }
 }

--- a/core-data/src/test/kotlin/in/jphe/storyvox/data/db/dao/AnnotationDaoTest.kt
+++ b/core-data/src/test/kotlin/in/jphe/storyvox/data/db/dao/AnnotationDaoTest.kt
@@ -1,0 +1,174 @@
+package `in`.jphe.storyvox.data.db.dao
+
+import android.content.Context
+import androidx.room.Room
+import androidx.test.core.app.ApplicationProvider
+import `in`.jphe.storyvox.data.db.StoryvoxDatabase
+import `in`.jphe.storyvox.data.db.entity.Annotation
+import `in`.jphe.storyvox.data.db.entity.Chapter
+import `in`.jphe.storyvox.data.db.entity.Fiction
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.test.runTest
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+
+/**
+ * Roundtrip exercise of [AnnotationDao] (issue #999) against an in-memory
+ * Room database. Covers the operations the reader overlay, the per-fiction
+ * list, the export builder, and [AnnotationsSyncer] rely on:
+ *
+ *  - upsert → observeForChapter / observeForFiction return it
+ *  - upsert same id → REPLACE (edit a note in place, not a duplicate row)
+ *  - observeForFiction ordering: chapter index, then start offset
+ *  - exists() probe (the syncer FK-guard)
+ *  - deleteById / clearForFiction
+ *  - CASCADE delete of the fiction drops its annotations
+ */
+@RunWith(RobolectricTestRunner::class)
+@Config(manifest = Config.NONE)
+class AnnotationDaoTest {
+
+    private lateinit var db: StoryvoxDatabase
+    private lateinit var dao: AnnotationDao
+    private lateinit var fictionDao: FictionDao
+    private lateinit var chapterDao: ChapterDao
+
+    private val fiction = Fiction(
+        id = "f1",
+        sourceId = "royalroad",
+        title = "Sky Pride",
+        author = "Anonymous",
+        firstSeenAt = 0L,
+        metadataFetchedAt = 0L,
+        inLibrary = true,
+    )
+
+    // Two chapters so the per-fiction ordering (chapter index asc) is exercised.
+    private val ch0 = Chapter(
+        id = "f1:0", fictionId = "f1", sourceChapterId = "0", index = 0, title = "One",
+    )
+    private val ch1 = Chapter(
+        id = "f1:1", fictionId = "f1", sourceChapterId = "1", index = 1, title = "Two",
+    )
+
+    private fun ann(
+        id: String,
+        chapterId: String,
+        start: Int,
+        end: Int,
+        color: String = "YELLOW",
+        note: String? = null,
+        quoted: String = "snippet",
+        at: Long = 1000L,
+    ) = Annotation(
+        id = id, fictionId = "f1", chapterId = chapterId,
+        startOffset = start, endOffset = end, color = color,
+        note = note, quotedText = quoted, createdAt = at, updatedAt = at,
+    )
+
+    @Before
+    fun setUp() = runTest {
+        val ctx = ApplicationProvider.getApplicationContext<Context>()
+        db = Room.inMemoryDatabaseBuilder(ctx, StoryvoxDatabase::class.java)
+            .allowMainThreadQueries()
+            .build()
+        dao = db.annotationDao()
+        fictionDao = db.fictionDao()
+        chapterDao = db.chapterDao()
+        fictionDao.upsert(fiction)
+        chapterDao.upsert(ch0)
+        chapterDao.upsert(ch1)
+    }
+
+    @After
+    fun tearDown() {
+        db.close()
+    }
+
+    @Test
+    fun upsert_thenObserveForChapter_returnsIt() = runTest {
+        dao.upsert(ann("a1", "f1:0", 10, 20, note = "hi"))
+
+        val rows = dao.observeForChapter("f1:0").first()
+        assertEquals(1, rows.size)
+        assertEquals("a1", rows[0].id)
+        assertEquals("hi", rows[0].note)
+    }
+
+    @Test
+    fun upsertSameId_replacesInPlace() = runTest {
+        dao.upsert(ann("a1", "f1:0", 10, 20, note = null, at = 1000L))
+        // Edit: add a note, bump updatedAt — REPLACE, not a second row.
+        dao.upsert(ann("a1", "f1:0", 10, 20, note = "added later", at = 2000L))
+
+        val rows = dao.observeForChapter("f1:0").first()
+        assertEquals("exactly one row after re-upsert", 1, rows.size)
+        assertEquals("added later", rows[0].note)
+        assertEquals(2000L, rows[0].updatedAt)
+    }
+
+    @Test
+    fun observeForFiction_ordersByChapterIndexThenStartOffset() = runTest {
+        // Insert out of order across both chapters.
+        dao.upsert(ann("b", "f1:1", 5, 9))      // chapter index 1
+        dao.upsert(ann("a2", "f1:0", 40, 50))   // chapter index 0, later offset
+        dao.upsert(ann("a1", "f1:0", 10, 20))   // chapter index 0, earlier offset
+
+        val ids = dao.observeForFiction("f1").first().map { it.id }
+        assertEquals(listOf("a1", "a2", "b"), ids)
+    }
+
+    @Test
+    fun exists_reflectsPresence() = runTest {
+        assertFalse(dao.exists("nope"))
+        dao.upsert(ann("a1", "f1:0", 10, 20))
+        assertTrue(dao.exists("a1"))
+    }
+
+    @Test
+    fun deleteById_removesOnlyThatRow() = runTest {
+        dao.upsert(ann("a1", "f1:0", 10, 20))
+        dao.upsert(ann("a2", "f1:0", 40, 50))
+
+        dao.deleteById("a1")
+
+        val ids = dao.observeForFiction("f1").first().map { it.id }
+        assertEquals(listOf("a2"), ids)
+    }
+
+    @Test
+    fun clearForFiction_dropsAll() = runTest {
+        dao.upsert(ann("a1", "f1:0", 10, 20))
+        dao.upsert(ann("b", "f1:1", 5, 9))
+
+        dao.clearForFiction("f1")
+        assertTrue(dao.annotationsForFiction("f1").isEmpty())
+    }
+
+    @Test
+    fun deletingFiction_cascadesAnnotations() = runTest {
+        dao.upsert(ann("a1", "f1:0", 10, 20))
+        dao.upsert(ann("b", "f1:1", 5, 9))
+
+        // Transient fiction is eligible for deleteIfTransient; CASCADE drops
+        // its annotations (and chapters). Flip library/follow off first.
+        fictionDao.setInLibrary("f1", false, now = 0L)
+        val deleted = fictionDao.deleteIfTransient("f1")
+        assertEquals(1, deleted)
+        assertTrue(dao.annotationsForFiction("f1").isEmpty())
+    }
+
+    @Test
+    fun nullNote_roundTrips() = runTest {
+        dao.upsert(ann("a1", "f1:0", 10, 20, note = null))
+        assertNull(dao.observeForChapter("f1:0").first().single().note)
+    }
+}

--- a/core-sync/src/main/kotlin/in/jphe/storyvox/sync/di/SyncModule.kt
+++ b/core-sync/src/main/kotlin/in/jphe/storyvox/sync/di/SyncModule.kt
@@ -17,8 +17,12 @@ import `in`.jphe.storyvox.sync.client.InstantClient
 import `in`.jphe.storyvox.sync.client.InstantHttpTransport
 import `in`.jphe.storyvox.sync.client.InstantSession
 import `in`.jphe.storyvox.sync.client.OkHttpInstantTransport
+import `in`.jphe.storyvox.data.db.dao.AnnotationDao
+import `in`.jphe.storyvox.data.db.dao.ChapterDao
+import `in`.jphe.storyvox.data.db.dao.FictionDao
 import `in`.jphe.storyvox.sync.coordinator.Syncer
 import `in`.jphe.storyvox.sync.coordinator.TombstoneStore
+import `in`.jphe.storyvox.sync.domain.AnnotationsSyncer
 import `in`.jphe.storyvox.sync.domain.BookmarksSyncer
 import `in`.jphe.storyvox.sync.domain.FollowsSyncer
 import `in`.jphe.storyvox.sync.domain.LibrarySyncer
@@ -114,6 +118,27 @@ object SyncModule {
 
     @Provides @IntoSet
     fun provideBookmarksSyncer(impl: BookmarksSyncer): Syncer = impl
+
+    /** Issue #999 — text highlights + notes. One blob/user, LWW, the same
+     *  #1029 absence-is-not-deletion + local-only-union contract as
+     *  BookmarksSyncer. The FK-parent existence probes are supplied as
+     *  lambdas (fiction via [FictionDao.get], chapter via [ChapterDao.exists])
+     *  so the syncer can FK-guard an incoming annotation whose chapter/fiction
+     *  row hasn't synced locally yet, without depending on the whole DAOs. */
+    @Provides @IntoSet
+    fun provideAnnotationsSyncer(
+        annotationDao: AnnotationDao,
+        backend: InstantBackend,
+        prefs: SharedPreferences,
+        chapterDao: ChapterDao,
+        fictionDao: FictionDao,
+    ): Syncer = AnnotationsSyncer(
+        annotationDao = annotationDao,
+        backend = backend,
+        prefs = prefs,
+        chapterExists = { id -> chapterDao.exists(id) },
+        fictionExists = { id -> fictionDao.get(id) != null },
+    )
 
     /** Issue #360 finding 1 (argus) — SecretsSyncer is now in the
      *  multibound set so its push/pull actually fires from the

--- a/core-sync/src/main/kotlin/in/jphe/storyvox/sync/domain/AnnotationsSyncer.kt
+++ b/core-sync/src/main/kotlin/in/jphe/storyvox/sync/domain/AnnotationsSyncer.kt
@@ -1,0 +1,191 @@
+package `in`.jphe.storyvox.sync.domain
+
+import android.content.SharedPreferences
+import androidx.core.content.edit
+import `in`.jphe.storyvox.data.db.dao.AnnotationDao
+import `in`.jphe.storyvox.data.db.entity.Annotation
+import `in`.jphe.storyvox.sync.SyncIds
+import `in`.jphe.storyvox.sync.client.InstantBackend
+import `in`.jphe.storyvox.sync.client.SignedInUser
+import `in`.jphe.storyvox.sync.coordinator.SyncOutcome
+import `in`.jphe.storyvox.sync.coordinator.Syncer
+import javax.inject.Inject
+import javax.inject.Singleton
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.json.Json
+
+/**
+ * Syncs text highlights + notes (#999). One blob per user with a map of
+ * annotation id → [Dto] (or null), exactly mirroring [BookmarksSyncer].
+ *
+ * Wire format: `{ annotations: { <id>: Dto | null }, updatedAt: Long }`.
+ * LWW on the whole map, keyed by the persisted last-sync stamp (NOT a
+ * process-local var — see the #360 lesson in [BookmarksSyncer]). Per-row
+ * merge is not done in v1: like bookmarks, two devices rarely edit the
+ * *same* highlight simultaneously, and the UUID id keeps independent adds
+ * on two devices from colliding.
+ *
+ * Deletion contract (the #1029 lesson, applied verbatim): a map entry of
+ * `id -> null` is an explicit delete tombstone and clears the local row.
+ * *Absence* of an id from a winning remote map means "no change", NOT
+ * "delete" — a local-only add (made on this device, not yet pushed) is
+ * absent from a winning remote, so it is preserved locally and unioned
+ * into the push payload rather than destroyed.
+ *
+ * FK guard (the [BookmarksSyncer] / PlaybackPositionSyncer pattern): an
+ * incoming annotation can arrive before its chapter/fiction row is
+ * hydrated locally. `annotationDao.upsert` would violate the FK; we keep
+ * such an entry on the wire (so a later round writes it once the parent
+ * rows arrive) but skip the local write this round. Because the FK is on
+ * fiction+chapter, the guard checks those parents — not the annotation's
+ * own id (which is exactly what we're trying to insert).
+ */
+@Singleton
+class AnnotationsSyncer @Inject constructor(
+    private val annotationDao: AnnotationDao,
+    private val backend: InstantBackend,
+    private val prefs: SharedPreferences,
+    // FK-parent existence probes. Kept as small lambdas so the syncer
+    // doesn't take a hard dependency on the whole Fiction/Chapter DAOs;
+    // wired in SyncModule. Default to "present" so a test can omit them.
+    private val chapterExists: suspend (String) -> Boolean = { true },
+    private val fictionExists: suspend (String) -> Boolean = { true },
+) : Syncer {
+
+    override val name: String get() = DOMAIN
+
+    private val json = Json { ignoreUnknownKeys = true; encodeDefaults = true; coerceInputValues = true }
+
+    /** Wire representation of one annotation. Mirrors [Annotation] minus
+     *  the redundant id (it's the map key) and fictionId/chapterId which
+     *  ARE carried so a second device can write the row + FK-guard it. */
+    @Serializable
+    data class Dto(
+        val fictionId: String,
+        val chapterId: String,
+        val startOffset: Int,
+        val endOffset: Int,
+        val color: String,
+        val note: String? = null,
+        val quotedText: String,
+        val createdAt: Long,
+        val updatedAt: Long,
+    )
+
+    @Serializable
+    data class Payload(
+        val annotations: Map<String, Dto?>,
+        val updatedAt: Long,
+    )
+
+    override suspend fun push(user: SignedInUser): SyncOutcome = reconcile(user)
+    override suspend fun pull(user: SignedInUser): SyncOutcome = reconcile(user)
+
+    private suspend fun reconcile(user: SignedInUser): SyncOutcome {
+        val localRows = annotationDao.allAnnotations()
+        val localMap: Map<String, Dto> = localRows.associate { it.id to it.toDto() }
+
+        val remoteSnap = backend.fetch(user, ENTITY, rowId(user)).getOrElse {
+            return SyncOutcome.Transient("remote fetch: ${it.message}")
+        }
+        val remotePayload = remoteSnap?.payload?.let {
+            runCatching { json.decodeFromString(Payload.serializer(), it) }.getOrNull()
+        }
+        val remoteMap: Map<String, Dto?> = remotePayload?.annotations.orEmpty()
+
+        // LWW winner for the shared keys. Same rule as BookmarksSyncer: if
+        // remote is a perfect mirror of local (and as-fresh as the row), no
+        // one wins; otherwise remote wins iff it's strictly newer than our
+        // last sync stamp.
+        val remoteWins = when {
+            remotePayload == null -> false
+            remotePayload.updatedAt > (remoteSnap.updatedAt - 1L) &&
+                remoteMap == localMap -> false
+            else -> remotePayload.updatedAt > readLastSyncStamp()
+        }
+
+        // Build [merged] honoring the #1029 contract:
+        //  - start from the LWW winner for keys both sides know,
+        //  - union in every local-only row (present locally, no remote entry
+        //    at all) so an unsynced add survives + propagates,
+        //  - a remote *explicit* null is the only delete signal and stays
+        //    null in [merged] so the apply loop clears it and the push
+        //    doesn't resurrect it.
+        val merged = LinkedHashMap<String, Dto?>()
+        merged.putAll(if (remoteWins) remoteMap else localMap)
+        if (remoteWins) {
+            for ((id, dto) in localMap) {
+                if (!remoteMap.containsKey(id)) merged[id] = dto
+            }
+        }
+
+        // Apply [merged] to local. An explicit null deletes; a present Dto
+        // upserts iff it diverges from local. FK guard: skip-but-retain when
+        // the parent fiction/chapter row isn't local yet.
+        var writes = 0
+        var skipped = 0
+        for ((id, dto) in merged) {
+            if (dto == null) {
+                if (localMap.containsKey(id)) {
+                    annotationDao.deleteById(id)
+                    writes++
+                }
+                continue
+            }
+            if (localMap[id] == dto) continue // already in desired state
+            if (!fictionExists(dto.fictionId) || !chapterExists(dto.chapterId)) {
+                skipped++
+                continue
+            }
+            annotationDao.upsert(dto.toEntity(id))
+            writes++
+        }
+        if (skipped > 0) {
+            android.util.Log.i(TAG, "skipped $skipped annotations (missing parent rows); retained on wire")
+        }
+
+        val now = System.currentTimeMillis()
+        val push = backend.upsert(
+            user = user,
+            entity = ENTITY,
+            id = rowId(user),
+            payload = json.encodeToString(
+                Payload.serializer(),
+                Payload(annotations = merged, updatedAt = now),
+            ),
+            updatedAt = now,
+        )
+        writeLastSyncStamp(now)
+        return if (push.isSuccess) SyncOutcome.Ok(writes)
+        else SyncOutcome.Transient("remote push: ${push.exceptionOrNull()?.message}")
+    }
+
+    private fun Annotation.toDto() = Dto(
+        fictionId = fictionId, chapterId = chapterId,
+        startOffset = startOffset, endOffset = endOffset,
+        color = color, note = note, quotedText = quotedText,
+        createdAt = createdAt, updatedAt = updatedAt,
+    )
+
+    private fun Dto.toEntity(id: String) = Annotation(
+        id = id, fictionId = fictionId, chapterId = chapterId,
+        startOffset = startOffset, endOffset = endOffset,
+        color = color, note = note, quotedText = quotedText,
+        createdAt = createdAt, updatedAt = updatedAt,
+    )
+
+    // Persisted last-sync stamp — see the #360 lesson in BookmarksSyncer:
+    // a process-local @Volatile var resets to 0L on cold start and makes
+    // any non-empty remote blanket-win, clobbering unpushed local adds.
+    private fun readLastSyncStamp(): Long = prefs.getLong(LAST_SYNC_KEY, 0L)
+    private fun writeLastSyncStamp(at: Long) { prefs.edit { putLong(LAST_SYNC_KEY, at) } }
+
+    private fun rowId(user: SignedInUser) = SyncIds.rowUuid(DOMAIN, user.userId)
+
+    companion object {
+        const val DOMAIN: String = "annotations"
+        private const val ENTITY = "blobs"
+        private const val LAST_SYNC_KEY = "instantdb.annotations_synced_at"
+        private const val TAG = "AnnotationsSyncer"
+    }
+}

--- a/core-sync/src/test/kotlin/in/jphe/storyvox/sync/AnnotationsSyncerTest.kt
+++ b/core-sync/src/test/kotlin/in/jphe/storyvox/sync/AnnotationsSyncerTest.kt
@@ -1,0 +1,224 @@
+package `in`.jphe.storyvox.sync
+
+import android.content.SharedPreferences
+import `in`.jphe.storyvox.data.db.dao.AnnotationDao
+import `in`.jphe.storyvox.data.db.entity.Annotation
+import `in`.jphe.storyvox.sync.client.FakeInstantBackend
+import `in`.jphe.storyvox.sync.client.SignedInUser
+import `in`.jphe.storyvox.sync.coordinator.SyncOutcome
+import `in`.jphe.storyvox.sync.domain.AnnotationsSyncer
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.test.runTest
+import kotlinx.serialization.json.Json
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * #999 — AnnotationsSyncer mirrors BookmarksSyncer, so its tests mirror
+ * BookmarksSyncerTest: the #360 persisted-stamp cold-restart guard, the
+ * #1029 local-only-survives-a-winning-remote contract, the explicit-null
+ * delete signal, and stamp advancement on a no-op round. Plus the
+ * annotation-specific FK skip-retain (parent fiction/chapter not local yet).
+ */
+class AnnotationsSyncerTest {
+
+    private val USER = SignedInUser(userId = "u-1", email = null, refreshToken = "rt-1")
+    private val json = Json { ignoreUnknownKeys = true }
+
+    private fun ann(
+        id: String,
+        chapterId: String = "f1:0",
+        fictionId: String = "f1",
+        start: Int = 0,
+        end: Int = 5,
+        note: String? = null,
+        at: Long = 1000L,
+    ) = Annotation(
+        id = id, fictionId = fictionId, chapterId = chapterId,
+        startOffset = start, endOffset = end, color = "YELLOW",
+        note = note, quotedText = "snip", createdAt = at, updatedAt = at,
+    )
+
+    private fun syncer(
+        dao: FakeAnnotationDao,
+        backend: FakeInstantBackend,
+        prefs: SharedPreferences,
+        parentsPresent: Boolean = true,
+    ) = AnnotationsSyncer(
+        annotationDao = dao,
+        backend = backend,
+        prefs = prefs,
+        chapterExists = { parentsPresent },
+        fictionExists = { parentsPresent },
+    )
+
+    @Test fun `cold restart between sync passes does not clobber the local annotation`() = runTest {
+        val backend = FakeInstantBackend()
+        val prefs = FakePrefs()
+
+        val dao1 = FakeAnnotationDao(mutableMapOf("a1" to ann("a1")))
+        val r1 = syncer(dao1, backend, prefs).push(USER)
+        assertTrue("first push succeeds: $r1", r1 is SyncOutcome.Ok)
+        val stamp1 = prefs.getLong("instantdb.annotations_synced_at", -1L)
+        assertTrue("last-sync stamp must persist", stamp1 > 0L)
+
+        // Cold restart: new syncer instance, SAME prefs bag, plus a local-only
+        // add a2. Must not clobber.
+        val dao2 = FakeAnnotationDao(mutableMapOf("a1" to ann("a1"), "a2" to ann("a2", start = 10, end = 15)))
+        val r2 = syncer(dao2, backend, prefs).push(USER)
+        assertTrue("post-restart push succeeds: $r2", r2 is SyncOutcome.Ok)
+        assertTrue("a1 survives", dao2.rows.containsKey("a1"))
+        assertTrue("local-only a2 survives", dao2.rows.containsKey("a2"))
+        assertTrue(prefs.getLong("instantdb.annotations_synced_at", 0L) >= stamp1)
+    }
+
+    @Test fun `local-only annotation survives a winning remote that never had it`() = runTest {
+        val backend = FakeInstantBackend()
+
+        // Device B pushes {a1}.
+        val daoB = FakeAnnotationDao(mutableMapOf("a1" to ann("a1")))
+        syncer(daoB, backend, FakePrefs()).push(USER)
+
+        // Device A: fresh stamp (0L), local-only a2 the remote never saw.
+        val daoA = FakeAnnotationDao(mutableMapOf("a1" to ann("a1"), "a2" to ann("a2", start = 10, end = 15)))
+        val rA = syncer(daoA, backend, FakePrefs()).pull(USER)
+        assertTrue("device A sync succeeds: $rA", rA is SyncOutcome.Ok)
+
+        assertTrue("a1 unchanged", daoA.rows.containsKey("a1"))
+        assertTrue("local-only a2 must NOT be deleted on mere absence", daoA.rows.containsKey("a2"))
+
+        // a2 rode out on the push payload.
+        val snap = backend.fetch(USER, "blobs", SyncIds.rowUuid("annotations", USER.userId)).getOrNull()
+        requireNotNull(snap) { "remote blob must exist after a push" }
+        val pushed = json.decodeFromString(AnnotationsSyncer.Payload.serializer(), snap.payload).annotations
+        assertTrue("a1 retained on the wire", pushed["a1"] != null)
+        assertTrue("local-only a2 must be unioned into the push payload", pushed["a2"] != null)
+    }
+
+    @Test fun `explicit remote null still clears the local annotation`() = runTest {
+        val backend = FakeInstantBackend()
+
+        // Seed remote with an explicit-null tombstone for a2, newer than A's stamp.
+        val now = System.currentTimeMillis()
+        backend.upsert(
+            user = USER,
+            entity = "blobs",
+            id = SyncIds.rowUuid("annotations", USER.userId),
+            payload = """{"annotations":{"a1":{"fictionId":"f1","chapterId":"f1:0","startOffset":0,"endOffset":5,"color":"YELLOW","note":null,"quotedText":"snip","createdAt":1000,"updatedAt":1000},"a2":null},"updatedAt":$now}""",
+            updatedAt = now,
+        )
+
+        val daoA = FakeAnnotationDao(mutableMapOf("a1" to ann("a1"), "a2" to ann("a2", start = 10, end = 15)))
+        assertTrue(syncer(daoA, backend, FakePrefs()).pull(USER) is SyncOutcome.Ok)
+
+        assertTrue("a1 unchanged", daoA.rows.containsKey("a1"))
+        assertNull("a2 must be cleared by the explicit remote null", daoA.rows["a2"])
+    }
+
+    @Test fun `incoming annotation with missing parent rows is skipped but retained on wire`() = runTest {
+        val backend = FakeInstantBackend()
+
+        // Remote has a1; device A's parents are NOT yet hydrated locally.
+        val now = System.currentTimeMillis()
+        backend.upsert(
+            user = USER,
+            entity = "blobs",
+            id = SyncIds.rowUuid("annotations", USER.userId),
+            payload = """{"annotations":{"a1":{"fictionId":"f1","chapterId":"f1:0","startOffset":0,"endOffset":5,"color":"YELLOW","note":null,"quotedText":"snip","createdAt":1000,"updatedAt":1000}},"updatedAt":$now}""",
+            updatedAt = now,
+        )
+
+        val daoA = FakeAnnotationDao(mutableMapOf())
+        val rA = syncer(daoA, backend, FakePrefs(), parentsPresent = false).pull(USER)
+        assertTrue(rA is SyncOutcome.Ok)
+
+        // Not written locally (FK guard), but retained on the wire for a later round.
+        assertTrue("a1 must NOT be written when parents are missing", daoA.rows.isEmpty())
+        val snap = backend.fetch(USER, "blobs", SyncIds.rowUuid("annotations", USER.userId)).getOrNull()!!
+        val pushed = json.decodeFromString(AnnotationsSyncer.Payload.serializer(), snap.payload).annotations
+        assertTrue("a1 retained on the wire for a later round", pushed["a1"] != null)
+    }
+
+    @Test fun `edited note applies on a winning remote`() = runTest {
+        val backend = FakeInstantBackend()
+
+        // Device B pushes a1 with a note, newer stamp.
+        val daoB = FakeAnnotationDao(mutableMapOf("a1" to ann("a1", note = "edited", at = 5000L)))
+        syncer(daoB, backend, FakePrefs()).push(USER)
+
+        // Device A has the old (note-less) a1, fresh stamp → remote wins, note applies.
+        val daoA = FakeAnnotationDao(mutableMapOf("a1" to ann("a1", note = null, at = 1000L)))
+        assertTrue(syncer(daoA, backend, FakePrefs()).pull(USER) is SyncOutcome.Ok)
+        assertEquals("edited", daoA.rows["a1"]?.note)
+    }
+
+    @Test fun `stamp advances even on a no-op round`() = runTest {
+        val backend = FakeInstantBackend()
+        val prefs = FakePrefs()
+        val dao = FakeAnnotationDao(mutableMapOf("a1" to ann("a1")))
+        val s = syncer(dao, backend, prefs)
+        s.push(USER)
+        val stamp1 = prefs.getLong("instantdb.annotations_synced_at", 0L)
+        assertTrue(stamp1 > 0L)
+        Thread.sleep(2L)
+        s.push(USER)
+        assertTrue(prefs.getLong("instantdb.annotations_synced_at", 0L) >= stamp1)
+    }
+
+    /** Pure-JVM SharedPreferences substitute — identical to the one in
+     *  BookmarksSyncerTest; duplicated for the same reason (same test source
+     *  set, no shared test-only module). */
+    private class FakePrefs : SharedPreferences {
+        private val store = mutableMapOf<String, Any?>()
+        override fun getAll(): MutableMap<String, *> = store.toMutableMap()
+        override fun getString(key: String, defValue: String?): String? = (store[key] as? String) ?: defValue
+        override fun getStringSet(key: String, defValues: MutableSet<String>?): MutableSet<String>? =
+            @Suppress("UNCHECKED_CAST") (store[key] as? MutableSet<String>) ?: defValues
+        override fun getInt(key: String, defValue: Int): Int = (store[key] as? Int) ?: defValue
+        override fun getLong(key: String, defValue: Long): Long = (store[key] as? Long) ?: defValue
+        override fun getFloat(key: String, defValue: Float): Float = (store[key] as? Float) ?: defValue
+        override fun getBoolean(key: String, defValue: Boolean): Boolean = (store[key] as? Boolean) ?: defValue
+        override fun contains(key: String): Boolean = store.containsKey(key)
+        override fun edit(): SharedPreferences.Editor = FakeEditor()
+        override fun registerOnSharedPreferenceChangeListener(l: SharedPreferences.OnSharedPreferenceChangeListener?) {}
+        override fun unregisterOnSharedPreferenceChangeListener(l: SharedPreferences.OnSharedPreferenceChangeListener?) {}
+        private inner class FakeEditor : SharedPreferences.Editor {
+            private val pending = mutableMapOf<String, Any?>()
+            private var clearAll = false
+            override fun putString(key: String, value: String?) = apply { pending[key] = value }
+            override fun putStringSet(key: String, values: MutableSet<String>?) = apply { pending[key] = values }
+            override fun putInt(key: String, value: Int) = apply { pending[key] = value }
+            override fun putLong(key: String, value: Long) = apply { pending[key] = value }
+            override fun putFloat(key: String, value: Float) = apply { pending[key] = value }
+            override fun putBoolean(key: String, value: Boolean) = apply { pending[key] = value }
+            override fun remove(key: String) = apply { pending[key] = REMOVE_SENTINEL }
+            override fun clear() = apply { clearAll = true }
+            override fun commit(): Boolean { apply(); return true }
+            override fun apply() {
+                if (clearAll) store.clear()
+                for ((k, v) in pending) if (v === REMOVE_SENTINEL) store.remove(k) else store[k] = v
+            }
+        }
+        private companion object { val REMOVE_SENTINEL = Any() }
+    }
+
+    /** Minimal in-memory AnnotationDao — only the methods AnnotationsSyncer
+     *  touches are implemented; everything else throws if accidentally hit. */
+    private class FakeAnnotationDao(
+        val rows: MutableMap<String, Annotation>,
+    ) : AnnotationDao {
+        override suspend fun allAnnotations(): List<Annotation> = rows.values.toList()
+        override suspend fun upsert(annotation: Annotation) { rows[annotation.id] = annotation }
+        override suspend fun deleteById(id: String) { rows.remove(id) }
+        override suspend fun exists(id: String): Boolean = rows.containsKey(id)
+
+        // ---- not used by AnnotationsSyncer ----
+        override fun observeForFiction(fictionId: String): Flow<List<Annotation>> = flowOf(emptyList())
+        override fun observeForChapter(chapterId: String): Flow<List<Annotation>> = flowOf(emptyList())
+        override suspend fun annotationsForFiction(fictionId: String): List<Annotation> = error("not used")
+        override suspend fun clearForFiction(fictionId: String) = error("not used")
+    }
+}

--- a/docs/superpowers/specs/2026-06-05-999-highlights-notes-design.md
+++ b/docs/superpowers/specs/2026-06-05-999-highlights-notes-design.md
@@ -1,0 +1,112 @@
+# #999 — Text highlights + notes (annotation) with export
+
+**Status:** design (awaiting team-lead scope ruling)
+**Issue:** techempower-org/candela#999 (extends #121 per-chapter bookmark)
+**Branch:** `feat/999-highlights-notes` / worktree `echo-999`
+
+## Problem
+
+storyvox today has only a single per-chapter bookmark (`Chapter.bookmarkCharOffset`,
+#121). No text-range highlights, no notes, no multi-bookmark. The issue (VDR
+competitive feature) wants: highlight a passage, attach an optional note, see a
+per-fiction list of highlights/notes, and export them (Markdown/TXT via the
+existing share-sheet FileProvider). Sync mirrors `BookmarksSyncer`.
+
+## Range model (the one real design decision)
+
+The reader already operates on `chapterText: String` with char offsets:
+`Chapter.bookmarkCharOffset`, `state.sentenceStart/sentenceEnd`, and
+`TextLayoutResult` in `ReaderView.kt`. An annotation's range is therefore
+**`[startOffset, endOffset)` as character offsets into the same chapterText** —
+no new coordinate concept. This is consistent with the existing bookmark and
+sentence-highlight, and it is what the reader's `TextLayoutResult` already maps
+to/from. Stored text snippet (`quotedText`) is denormalized into the row so the
+export and the list survive a chapter re-fetch that shifts offsets (offsets are
+best-effort for scroll-to; the quoted text is the durable record).
+
+## Architecture (well-bounded units)
+
+### 1. core-data: `Annotation` entity + `AnnotationDao` (new table, v14)
+- `@Entity(tableName = "annotation")`, FK `fictionId → fiction(id)` ON DELETE CASCADE,
+  FK `chapterId → chapter(id)` ON DELETE CASCADE.
+- Columns: `id` TEXT PK (client-generated UUID — stable sync key, mirrors
+  `SyncIds` usage), `fictionId` TEXT, `chapterId` TEXT, `startOffset` INTEGER,
+  `endOffset` INTEGER, `color` TEXT (palette enum-name string, same
+  string-not-ordinal pattern as `FictionShelf.shelf`), `note` TEXT nullable
+  (null = highlight with no note), `quotedText` TEXT (denormalized snippet),
+  `createdAt` INTEGER, `updatedAt` INTEGER (for LWW sync + edit).
+- Indices: `index_annotation_fictionId` (per-fiction list), `index_annotation_chapterId`
+  (FK cascade planner + reader-per-chapter overlay query).
+- DAO patterned on `FictionShelfDao`: `observeForFiction(fictionId): Flow<List<Annotation>>`,
+  `observeForChapter(chapterId): Flow<List<Annotation>>`, `allAnnotations()` (sync),
+  `upsert(@Insert REPLACE)`, `deleteById(id)`, `exists(id)`, `clearForFiction(fictionId)`.
+
+### 2. core-data: `MIGRATION_13_14` + DB bump to v14
+- `CREATE TABLE IF NOT EXISTS annotation(...)` matching the entity byte-for-byte
+  (so `runMigrationsAndValidate` identity hash passes) + the two `CREATE INDEX`.
+- Register in `ALL_MIGRATIONS`, add `Annotation::class` + `annotationDao()` to
+  `StoryvoxDatabase`, bump `version = 14`, regenerate `14.json` schema (KSP).
+
+### 3. core-data test: migration coverage
+- `migrate v13 to v14 creates annotation table` — table + both indexes exist.
+- `migrated v14 db round-trips an annotation row` — insert+read through the
+  migrated DB (catches entity/schema mismatch the hash check wouldn't).
+- Update the two existing "open at latest" tests' chain-through to add the
+  `runMigrationsAndValidate(dbName, 14, true, MIGRATION_13_14)` step + the v14
+  migration in their `Room.databaseBuilder().addMigrations(...)`.
+
+### 4. core-sync: `AnnotationsSyncer` (mirrors `BookmarksSyncer`)
+- One blob per user (`ENTITY="blobs"`, `rowId=SyncIds.rowUuid("annotations", userId)`),
+  LWW on the whole map keyed by persisted `instantdb.annotations_synced_at`.
+- Map is `id → AnnotationDto?` (null = explicit delete tombstone). Replicates the
+  #1029/#360 contract exactly: **absence ≠ deletion**; only an explicit null clears
+  a local row; local-only adds are unioned into the push so an unsynced add is
+  never clobbered. FK guard: skip-but-retain-on-wire when the chapter/fiction row
+  isn't hydrated locally yet (mirrors BookmarksSyncer's `chapterDao.exists`).
+- Register in `SyncModule` `@IntoSet`.
+
+### 5. feature/reader: select-text → highlight + note
+- ReaderView already has `TextLayoutResult` + long-press word handling
+  (`SentenceHighlight`/AI lookup). Add a selection-range action: on a selected
+  range, show a small action bar → pick highlight color (+ optional note dialog).
+  Maps the selected `TextRange` (composeoffsets) → char offsets into chapterText.
+- Render existing annotations for the open chapter as a background span overlay
+  in the AnnotatedString (color from the palette), layered under the
+  sentence-playback highlight.
+
+### 6. feature: per-fiction highlights/notes list + export
+- A surface listing this fiction's annotations (grouped by chapter, ordered by
+  startOffset), tap-to-jump-to-reader. Entry point on FictionDetail (where the
+  EPUB export already lives).
+- Export: build a Markdown/TXT file in `cacheDir/exports/` (the existing
+  FileProvider scope), emit a one-shot UI event → share-sheet, EXACTLY mirroring
+  `exportToEpub` + `EpubExported` event in FictionDetailViewModel/Screen.
+
+## Error handling
+- Offsets out of range after a chapter re-fetch: clamp/skip the overlay span,
+  still show the row in the list via `quotedText` (durable). No crash.
+- Sync FK-not-yet-hydrated: retain on wire, apply on a later round (BookmarksSyncer pattern).
+- Export with zero annotations: disabled/short-circuited, friendly message.
+
+## Testing
+- core-data: the migration tests above (Robolectric + MigrationTestHelper).
+- core-data: AnnotationDao round-trip (existing in-memory Room DAO test pattern).
+- core-sync: `AnnotationsSyncerTest` mirroring `BookmarksSyncerTest` — LWW,
+  local-only preservation (#1029), explicit-null delete, FK-skip-retain.
+- feature: offset-mapping pure function unit test (TextRange ↔ char offset),
+  export-formatter pure function unit test (annotations → Markdown/TXT string).
+
+## Scope forks for team-lead (need a ruling before build)
+1. **Multi-bookmark promotion** — the issue lists "promote bookmarks from
+   one-per-chapter to multiple labeled bookmarks while here." That's a *separate*
+   schema/sync change (touches the chapter bookmark column + BookmarksSyncer wire
+   format) and is a known data-migration risk. RECOMMEND: **out of this PR**
+   (its own issue/PR), keep #999 to annotations only. Confirm.
+2. **Highlight range = char offset into chapterText** (above). Confirm OK vs any
+   paragraph-index model #1001 is introducing (rebase-coordinate with that work).
+3. **List/export surface = FictionDetail** (reuses #117 export plumbing) vs a
+   Library surface. RECOMMEND FictionDetail.
+4. **Phase split** — issue suggests Phase 1 (highlights no notes) / Phase 2
+   (notes+export). RECOMMEND: ship annotations *with* notes + export in one PR
+   (the note column + export are cheap once the table exists); skip multi-bookmark.
+   Confirm single-PR scope is acceptable.

--- a/feature/src/main/kotlin/in/jphe/storyvox/feature/fiction/FictionDetailScreen.kt
+++ b/feature/src/main/kotlin/in/jphe/storyvox/feature/fiction/FictionDetailScreen.kt
@@ -69,6 +69,7 @@ import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import `in`.jphe.storyvox.data.annotation.AnnotationExportFormatter
 import `in`.jphe.storyvox.feature.R
 import `in`.jphe.storyvox.feature.api.UiChapter
 import `in`.jphe.storyvox.feature.api.UiFiction
@@ -130,6 +131,13 @@ fun FictionDetailScreen(
     // change without re-firing the export.
     var pendingExport by remember { mutableStateOf<EpubExportResult?>(null) }
 
+    // Issue #999 — pending highlights/notes export, held the same way as the
+    // EPUB export so its Share / Save sheet survives config change without
+    // re-firing the write.
+    var pendingAnnotationExport by remember {
+        mutableStateOf<`in`.jphe.storyvox.data.annotation.AnnotationExportResult?>(null)
+    }
+
     // Issue #1003 — audiobook (.m4b) export status. Drives a progress chip
     // while rendering and the Share / Save-As sheet when done.
     val audiobookStatus by viewModel.audiobookExportStatus.collectAsStateWithLifecycle()
@@ -176,12 +184,34 @@ fun FictionDetailScreen(
         }
     }
 
+    // Issue #999 — SAF "Save…" launcher for the highlights/notes export. The
+    // contract type is "*/*" because the file is .md OR .txt depending on the
+    // user's pick; the suggested name carries the right extension. Copies the
+    // cached export file into the user's chosen target.
+    val saveAnnotationLauncher = rememberLauncherForActivityResult(
+        contract = ActivityResultContracts.CreateDocument("*/*"),
+    ) { destination ->
+        val source = pendingAnnotationExport
+        if (destination != null && source != null) {
+            runCatching {
+                context.contentResolver.openOutputStream(destination)?.use { out ->
+                    source.file.inputStream().use { it.copyTo(out) }
+                }
+            }
+        }
+        pendingAnnotationExport = null
+    }
+
     LaunchedEffect(viewModel) {
         viewModel.events.collect { event ->
             when (event) {
                 is FictionDetailUiEvent.OpenReader -> onOpenReader(event.fictionId, event.chapterId)
                 is FictionDetailUiEvent.EpubExported -> pendingExport = event.result
                 is FictionDetailUiEvent.EpubExportFailed ->
+                    snackbarHostState.showSnackbar(event.message)
+                // Issue #999 — highlights/notes export finished / failed.
+                is FictionDetailUiEvent.AnnotationsExported -> pendingAnnotationExport = event.result
+                is FictionDetailUiEvent.AnnotationsExportFailed ->
                     snackbarHostState.showSnackbar(event.message)
                 FictionDetailUiEvent.OpenRoyalRoadSignIn -> onOpenRoyalRoadSignIn()
                 is FictionDetailUiEvent.FollowFailed ->
@@ -445,6 +475,14 @@ fun FictionDetailScreen(
                         onDelete = viewModel::deleteNotebookEntry,
                         onAdd = viewModel::addNotebookEntry,
                     )
+                    // Issue #999 — Highlights & notes list + export, in the
+                    // wide-layout left column. Hides itself when empty.
+                    HighlightsSection(
+                        groups = state.annotationGroups,
+                        isExporting = state.isExportingAnnotations,
+                        onDelete = viewModel::deleteAnnotation,
+                        onExport = { format -> viewModel.exportAnnotations(context, format) },
+                    )
                 }
                 // Issue #794 — chapter search + jump-to-#. Renders only
                 // when the list crosses CHAPTER_SEARCH_THRESHOLD; for
@@ -639,6 +677,17 @@ fun FictionDetailScreen(
                         onAdd = viewModel::addNotebookEntry,
                     )
                 }
+                // Issue #999 — Highlights & notes list + export in the narrow
+                // (phone) layout. Single LazyColumn item so it scrolls with
+                // the chapter list; hides itself when empty.
+                item {
+                    HighlightsSection(
+                        groups = state.annotationGroups,
+                        isExporting = state.isExportingAnnotations,
+                        onDelete = viewModel::deleteAnnotation,
+                        onExport = { format -> viewModel.exportAnnotations(context, format) },
+                    )
+                }
                 if (narrowShowSearch) {
                     item(key = "chapter-search") {
                         ChapterSearchBar(
@@ -723,6 +772,35 @@ fun FictionDetailScreen(
                 pendingExport = null
             },
             onDismiss = { pendingExport = null },
+        )
+    }
+
+    // Issue #999 — highlights/notes Share / Save-as sheet. Renders after the
+    // export use case posts AnnotationsExported. Same two-route plumbing as the
+    // EPUB sheet (ACTION_SEND primary, SAF Save… secondary) over the
+    // FileProvider-backed Uri; the share type tracks the chosen format.
+    pendingAnnotationExport?.let { exported ->
+        AnnotationExportSheet(
+            export = exported,
+            onShare = {
+                val send = Intent(Intent.ACTION_SEND).apply {
+                    type = exported.mimeType
+                    putExtra(Intent.EXTRA_STREAM, exported.uri)
+                    putExtra(Intent.EXTRA_TITLE, exported.suggestedFileName)
+                    addFlags(Intent.FLAG_GRANT_READ_URI_PERMISSION)
+                }
+                context.startActivity(
+                    Intent.createChooser(send, "Share highlights").also {
+                        it.addFlags(Intent.FLAG_GRANT_READ_URI_PERMISSION)
+                    },
+                )
+                pendingAnnotationExport = null
+            },
+            onSaveAs = {
+                // launcher's result callback clears pendingAnnotationExport.
+                saveAnnotationLauncher.launch(exported.suggestedFileName)
+            },
+            onDismiss = { pendingAnnotationExport = null },
         )
     }
 
@@ -1514,3 +1592,168 @@ private fun UiChapter.toCardState(currentId: String?) = ChapterCardState(
     // window instead of flickering bogus state.
     cacheState = cacheState,
 )
+
+/**
+ * Issue #999 — per-fiction "Highlights & notes" list with export. Renders the
+ * annotations grouped by chapter (chapter header + each quote, with its note
+ * and color label below), a per-row delete, and a Markdown / Plain-text export
+ * row that fires the share-sheet via the ViewModel.
+ *
+ * Hides itself entirely when there are no annotations (early return), the same
+ * empty-state behaviour as [NotebookSection] — a first-launch user shouldn't
+ * see an empty highlights card pointing at a workflow they haven't started
+ * (highlights are created from the reader, #999 phase 2).
+ */
+@Composable
+private fun HighlightsSection(
+    groups: List<AnnotationGroup>,
+    isExporting: Boolean,
+    onDelete: (String) -> Unit,
+    onExport: (AnnotationExportFormatter.Format) -> Unit,
+) {
+    if (groups.isEmpty()) return
+    val spacing = LocalSpacing.current
+    Column(
+        modifier = Modifier.fillMaxWidth().padding(horizontal = spacing.md, vertical = spacing.sm),
+        verticalArrangement = Arrangement.spacedBy(spacing.xs),
+    ) {
+        Row(
+            modifier = Modifier.fillMaxWidth(),
+            verticalAlignment = Alignment.CenterVertically,
+            horizontalArrangement = Arrangement.SpaceBetween,
+        ) {
+            Text(
+                stringResource(R.string.fiction_highlights_title),
+                style = MaterialTheme.typography.titleMedium,
+            )
+            if (isExporting) {
+                Text(
+                    stringResource(R.string.fiction_highlights_exporting),
+                    style = MaterialTheme.typography.labelSmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                )
+            }
+        }
+        groups.forEach { group ->
+            Text(
+                group.chapterTitle,
+                style = MaterialTheme.typography.labelLarge,
+                color = MaterialTheme.colorScheme.primary,
+                modifier = Modifier.padding(top = spacing.xs),
+            )
+            group.annotations.forEach { ann ->
+                Row(
+                    modifier = Modifier.fillMaxWidth(),
+                    verticalAlignment = Alignment.Top,
+                ) {
+                    Column(modifier = Modifier.weight(1f)) {
+                        Text(
+                            // Collapse internal newlines so a multi-line
+                            // selection reads as one quote in the list row.
+                            "“${ann.quotedText.replace("\n", " ").trim()}”",
+                            style = MaterialTheme.typography.bodyMedium,
+                        )
+                        val note = ann.note
+                        if (!note.isNullOrBlank()) {
+                            Text(
+                                note.trim(),
+                                style = MaterialTheme.typography.bodySmall,
+                                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                            )
+                        }
+                        Text(
+                            ann.color.lowercase(),
+                            style = MaterialTheme.typography.labelSmall,
+                            color = MaterialTheme.colorScheme.onSurfaceVariant,
+                        )
+                    }
+                    BrassButton(
+                        label = stringResource(R.string.fiction_highlights_remove),
+                        onClick = { onDelete(ann.id) },
+                        variant = BrassButtonVariant.Text,
+                    )
+                }
+            }
+        }
+        Spacer(Modifier.height(spacing.xxs))
+        Row(
+            modifier = Modifier.fillMaxWidth(),
+            horizontalArrangement = Arrangement.spacedBy(spacing.sm),
+        ) {
+            BrassButton(
+                label = stringResource(R.string.fiction_highlights_export_markdown),
+                onClick = { onExport(AnnotationExportFormatter.Format.MARKDOWN) },
+                variant = BrassButtonVariant.Secondary,
+                modifier = Modifier.weight(1f),
+            )
+            BrassButton(
+                label = stringResource(R.string.fiction_highlights_export_text),
+                onClick = { onExport(AnnotationExportFormatter.Format.PLAIN) },
+                variant = BrassButtonVariant.Secondary,
+                modifier = Modifier.weight(1f),
+            )
+        }
+    }
+}
+
+/**
+ * Issue #999 — modal bottom sheet after a highlights/notes export completes.
+ * Offers Share (primary, ACTION_SEND chooser) and Save… (secondary, SAF
+ * CreateDocument). Mirrors [ExportSheet] (#117); the only divergence is the
+ * empty-export hint, since a fiction with no annotations still exports a
+ * placeholder file.
+ */
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+private fun AnnotationExportSheet(
+    export: `in`.jphe.storyvox.data.annotation.AnnotationExportResult,
+    onShare: () -> Unit,
+    onSaveAs: () -> Unit,
+    onDismiss: () -> Unit,
+) {
+    val spacing = LocalSpacing.current
+    val sheetState = rememberModalBottomSheetState()
+    ModalBottomSheet(onDismissRequest = onDismiss, sheetState = sheetState) {
+        Column(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(horizontal = spacing.lg, vertical = spacing.md),
+            verticalArrangement = Arrangement.spacedBy(spacing.sm),
+        ) {
+            Text(
+                text = stringResource(R.string.fiction_highlights_export_ready),
+                style = MaterialTheme.typography.titleMedium,
+            )
+            Text(
+                text = export.suggestedFileName,
+                style = MaterialTheme.typography.bodySmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
+            if (export.isEmpty) {
+                Text(
+                    text = stringResource(R.string.fiction_highlights_export_empty),
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                )
+            }
+            Spacer(Modifier.height(spacing.xs))
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                horizontalArrangement = Arrangement.spacedBy(spacing.sm),
+            ) {
+                BrassButton(
+                    label = "Save…",
+                    onClick = onSaveAs,
+                    variant = BrassButtonVariant.Secondary,
+                    modifier = Modifier.weight(1f),
+                )
+                BrassButton(
+                    label = "Share",
+                    onClick = onShare,
+                    variant = BrassButtonVariant.Primary,
+                    modifier = Modifier.weight(1f),
+                )
+            }
+        }
+    }
+}

--- a/feature/src/main/kotlin/in/jphe/storyvox/feature/fiction/FictionDetailViewModel.kt
+++ b/feature/src/main/kotlin/in/jphe/storyvox/feature/fiction/FictionDetailViewModel.kt
@@ -6,7 +6,12 @@ import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import dagger.hilt.android.lifecycle.HiltViewModel
+import `in`.jphe.storyvox.data.annotation.AnnotationExportFormatter
+import `in`.jphe.storyvox.data.annotation.AnnotationExportResult
+import `in`.jphe.storyvox.data.annotation.ExportAnnotationsUseCase
+import `in`.jphe.storyvox.data.db.entity.Annotation
 import `in`.jphe.storyvox.data.db.entity.FictionMemoryEntry
+import `in`.jphe.storyvox.data.repository.AnnotationRepository
 import `in`.jphe.storyvox.data.repository.FictionMemoryRepository
 import `in`.jphe.storyvox.data.repository.pronunciation.PronunciationDictRepository
 import `in`.jphe.storyvox.feature.api.DownloadMode
@@ -64,6 +69,27 @@ data class FictionDetailUiState(
      *  book has no recorded entities yet — the UI hides the section
      *  rather than rendering an empty card. */
     val notebookEntries: List<FictionMemoryEntry> = emptyList(),
+    /** Issue #999 — highlights + notes for this fiction, grouped by chapter
+     *  in reading order for the "Highlights & notes" list. Empty list when
+     *  the book has no annotations yet — the UI hides the section (like the
+     *  Notebook) rather than rendering an empty card. */
+    val annotationGroups: List<AnnotationGroup> = emptyList(),
+    /** Issue #999 — true while [ExportAnnotationsUseCase] writes the
+     *  Markdown/TXT file. Surfaces a building chip, like [isExportingEpub]. */
+    val isExportingAnnotations: Boolean = false,
+)
+
+/**
+ * Issue #999 — one chapter's worth of annotations for the FictionDetail list.
+ * UI-facing projection: [chapterTitle] is resolved from the chapter row (so
+ * the list shows real titles, not ids), [annotations] are the raw rows in the
+ * DAO's start-offset order. Distinct from the export formatter's internal
+ * `ChapterGroup` so the UI layer doesn't depend on the formatter's shape.
+ */
+@Immutable
+data class AnnotationGroup(
+    val chapterTitle: String,
+    val annotations: List<Annotation>,
 )
 
 sealed interface FictionDetailUiEvent {
@@ -87,6 +113,17 @@ sealed interface FictionDetailUiEvent {
      *  (network, CSRF token miss, 500). Surfaced as a toast so the
      *  user knows the tap didn't take. */
     data class FollowFailed(val message: String) : FictionDetailUiEvent
+
+    /**
+     * Issue #999 — fired when a highlights/notes export finishes. The screen
+     * collects this and surfaces the Share / Save-As sheet, mirroring #117's
+     * [EpubExported]. One-shot via the event channel so the share action
+     * doesn't re-fire on configuration change.
+     */
+    data class AnnotationsExported(val result: AnnotationExportResult) : FictionDetailUiEvent
+
+    /** Issue #999 — non-fatal export failure (disk write error). Toasted. */
+    data class AnnotationsExportFailed(val message: String) : FictionDetailUiEvent
 }
 
 @HiltViewModel
@@ -116,6 +153,12 @@ class FictionDetailViewModel @Inject constructor(
     /** Issue #1003 — enqueues + observes the "export this fiction as an
      *  audiobook" render. Mirrors the EPUB export's home on this screen. */
     private val audiobookExportScheduler: AudiobookExportScheduler,
+    /** Issue #999 — read/delete surface for this fiction's highlights +
+     *  notes (the "Highlights & notes" list). */
+    private val annotationRepo: AnnotationRepository,
+    /** Issue #999 — builds the Markdown/TXT export file + FileProvider URI
+     *  for the share-sheet. Injected like [exportEpub] (#117). */
+    private val exportAnnotations: ExportAnnotationsUseCase,
     savedState: SavedStateHandle,
 ) : ViewModel() {
 
@@ -139,6 +182,11 @@ class FictionDetailViewModel @Inject constructor(
      *  through the combine below. Held outside the combine so the suspend
      *  call site can flip it cleanly around the use-case invocation. */
     private val isExporting = MutableStateFlow(false)
+
+    /** Issue #999 — highlights-export-in-flight flag. Exposed via
+     *  [FictionDetailUiState.isExportingAnnotations]; held outside the combine
+     *  so [exportAnnotations] can flip it around the use-case invocation. */
+    private val isExportingAnnotationsFlow = MutableStateFlow(false)
 
     /** Issue #1003 — unique work name of an in-flight audiobook export for
      *  this fiction (null until the user taps "Export as audiobook"). */
@@ -233,11 +281,25 @@ class FictionDetailViewModel @Inject constructor(
                 )
             }
         }
+        // Issue #999 — highlights/notes feed, grouped by chapter for the list.
+        // Combined with the chapter list (for titles + reading order) and the
+        // export-in-flight flag. Re-grouping on every annotation change is
+        // cheap (a groupBy over a handful of rows). Emits a Pair so the outer
+        // combine stays within the 5-arg ceiling.
+        val annotationsFlow: kotlinx.coroutines.flow.Flow<Pair<List<AnnotationGroup>, Boolean>> =
+            combine(
+                annotationRepo.observeForFiction(fictionId),
+                repo.chaptersFor(fictionId),
+                isExportingAnnotationsFlow,
+            ) { annotations, chapters, exporting ->
+                groupAnnotations(annotations, chapters) to exporting
+            }
         combine(
             base,
             memoryRepo.entitiesForFiction(fictionId),
             cacheStates,
-        ) { state, notebook, cacheStateMap ->
+            annotationsFlow,
+        ) { state, notebook, cacheStateMap, (annotationGroups, exportingAnnotations) ->
             // PR-H — fold the cache-state map onto each UiChapter. If
             // the inspector hasn't produced a value for a chapter
             // (empty map on missing voice, or new chapter not yet in
@@ -251,8 +313,38 @@ class FictionDetailViewModel @Inject constructor(
                     if (ch.cacheState == cs) ch else ch.copy(cacheState = cs)
                 }
             }
-            state.copy(chapters = chaptersWithCache, notebookEntries = notebook)
+            state.copy(
+                chapters = chaptersWithCache,
+                notebookEntries = notebook,
+                annotationGroups = annotationGroups,
+                isExportingAnnotations = exportingAnnotations,
+            )
         }.stateIn(viewModelScope, SharingStarted.WhileSubscribed(5_000), FictionDetailUiState())
+    }
+
+    /**
+     * Issue #999 — group a flat annotation list (chapter-index ordered by the
+     * DAO) into per-chapter [AnnotationGroup]s with resolved titles. Mirrors
+     * the export use case's `groupAnnotationsByChapter`, but keyed off the
+     * already-loaded [UiChapter] list (the VM has it via [repo.chaptersFor])
+     * rather than re-reading the DB. A blank/unknown chapter falls back to a
+     * "Chapter N" label so a highlight never renders title-less or vanishes.
+     */
+    private fun groupAnnotations(
+        annotations: List<Annotation>,
+        chapters: List<UiChapter>,
+    ): List<AnnotationGroup> {
+        if (annotations.isEmpty()) return emptyList()
+        val chapterById = chapters.associateBy { it.id }
+        return annotations.groupBy { it.chapterId }.entries
+            .sortedBy { (chapterId, _) -> chapterById[chapterId]?.number ?: Int.MAX_VALUE }
+            .map { (chapterId, anns) ->
+                val ch = chapterById[chapterId]
+                val title = ch?.title?.ifBlank { null }
+                    ?: ch?.let { "Chapter ${it.number}" }
+                    ?: "Chapter"
+                AnnotationGroup(chapterTitle = title, annotations = anns)
+            }
     }
 
     /** Issue #760 — synopsis-aloud TTS state. Reuses the recap-aloud
@@ -395,6 +487,44 @@ class FictionDetailViewModel @Inject constructor(
                 isExporting.value = false
             }
         }
+    }
+
+    /**
+     * Issue #999 — build a Markdown / plain-text file of this fiction's
+     * highlights + notes in the cache dir and emit
+     * [FictionDetailUiEvent.AnnotationsExported] so the screen fires the
+     * share-sheet / SAF flow. Mirrors [exportToEpub] (#117): takes [context]
+     * for `cacheDir` + `FileProvider`, idempotent against a double-tap while a
+     * previous export is in flight.
+     *
+     * Exports even when there are no annotations (the file carries a friendly
+     * "No highlights yet." line); the screen can choose to gate the menu item
+     * on a non-empty list, but the use case itself never refuses.
+     */
+    fun exportAnnotations(context: Context, format: AnnotationExportFormatter.Format) {
+        if (isExportingAnnotationsFlow.value) return
+        viewModelScope.launch {
+            isExportingAnnotationsFlow.value = true
+            try {
+                val result = exportAnnotations.export(context, fictionId, format)
+                _events.send(FictionDetailUiEvent.AnnotationsExported(result))
+            } catch (t: Throwable) {
+                _events.send(
+                    FictionDetailUiEvent.AnnotationsExportFailed(
+                        "Couldn't export highlights: ${t.message ?: t.javaClass.simpleName}",
+                    ),
+                )
+            } finally {
+                isExportingAnnotationsFlow.value = false
+            }
+        }
+    }
+
+    /** Issue #999 — delete one annotation by its UUID. The "Highlights &
+     *  notes" list's per-row delete routes here; the list updates via the
+     *  observed flow. */
+    fun deleteAnnotation(id: String) {
+        viewModelScope.launch { annotationRepo.delete(id) }
     }
 
     /**

--- a/feature/src/main/res/values/strings.xml
+++ b/feature/src/main/res/values/strings.xml
@@ -304,6 +304,14 @@
     <!-- Issue #1003 — turn this fiction into a chaptered .m4b audiobook. -->
     <string name="fiction_export_audiobook">Export as audiobook…</string>
     <string name="fiction_clear_cache">Clear fiction cache…</string>
+    <!-- Issue #999 — highlights + notes list + export. -->
+    <string name="fiction_highlights_title">Highlights &amp; notes</string>
+    <string name="fiction_highlights_exporting">Exporting…</string>
+    <string name="fiction_highlights_remove">Remove</string>
+    <string name="fiction_highlights_export_markdown">Export Markdown</string>
+    <string name="fiction_highlights_export_text">Export text</string>
+    <string name="fiction_highlights_export_ready">Your highlights are ready</string>
+    <string name="fiction_highlights_export_empty">No highlights yet — the file is a placeholder.</string>
     <string name="fiction_chapter_count">%1$d ch</string>
     <string name="fiction_separator">·</string>
     <string name="fiction_name_label">Name</string>


### PR DESCRIPTION
Closes the headline of #999: **highlight passages, attach notes, sync them across devices, and export them** — beyond storyvox's single per-chapter bookmark (#121).

Per the scope ruling, this is **phase 1: data + sync + FictionDetail list + export**. It touches **core-data / core-sync / FictionDetail only — never ReaderView**, so it merges clean independent of the reader cluster (#993/#997/#998/#1001/#994). In-reader select-drag highlight *creation* is split into the fast-follow **#1079**.

## What's here

**Schema (additive, v13 → v14)**
- New \`annotation\` table: \`(id UUID PK, fictionId, chapterId, [startOffset,endOffset), color, note?, quotedText, createdAt, updatedAt)\`, FK→fiction/chapter \`ON DELETE CASCADE\`, indexed on fictionId + chapterId.
- \`MIGRATION_13_14\` + KSP-exported \`14.json\` + \`runMigrationsAndValidate\` migration tests (follows the v11/v12/v13 pattern) + round-trip + CASCADE coverage.
- Char-offset \`[start, end)\` range model — the same coordinate the bookmark + sentence-highlight already use, no new concept. \`quotedText\` denormalized as the durable record when offsets drift.

**Sync**
- \`AnnotationsSyncer\` (InstantDB, one blob/user, LWW) mirroring \`BookmarksSyncer\` — including the #1029 contract: absence ≠ deletion, only explicit null tombstone clears, local-only adds unioned into push, FK-parent skip-retain guard.

**Export**
- Pure \`AnnotationExportFormatter\` (Markdown / plain text) + \`ExportAnnotationsUseCase\` that groups by chapter and stages a file in \`cacheDir/exports/\` behind the existing #117 FileProvider authority.

**UI (FictionDetail)**
- "Highlights & notes" list grouped by chapter, per-row delete, hides when empty (like the #217 Notebook).
- Share / Save… sheet over the same SAF plumbing the EPUB export uses; share type tracks Markdown vs text.

## DI fix worth flagging
\`AnnotationDao\` was consumed by \`AnnotationsSyncer\` (already merged-in on this branch) but **never bound in any Hilt module** — per-module compiles passed while the full \`:app\` graph would have failed \`hiltJavaCompileDebug\` with a missing binding. This PR adds the \`DataModule\` provider, so \`:app:assembleDebug\` now resolves.

## Verification
- \`:app:assembleDebug\` BUILD SUCCESSFUL (Hilt graph resolves end-to-end).
- Tests green: AnnotationExportFormatterTest (6), ExportAnnotationsUseCaseTest (6), AnnotationDaoTest (8), StoryvoxDatabaseMigrationTest (v13→v14 + round-trip + CASCADE), AnnotationsSyncerTest (6), FictionDetail* (26, no regressions).

## Follow-up
- **#1079** — in-reader select-text highlight overlay (#999 phase 2), lands after the reader cluster settles.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Users can now highlight text in stories and add optional notes to each highlight.
  * Highlights are organized by chapter for easy reference.
  * Export annotations as Markdown or plain text files.
  * Share highlights via the share sheet.
  * Delete individual annotations.

* **Documentation**
  * Added design specification for the highlights & notes feature.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->