### PR TITLE
feat(reader): per-word read-along highlight (#994)

### DIFF
--- a/app/src/main/kotlin/in/jphe/storyvox/data/SettingsRepositoryUiImpl.kt
+++ b/app/src/main/kotlin/in/jphe/storyvox/data/SettingsRepositoryUiImpl.kt
@@ -67,6 +67,7 @@ import `in`.jphe.storyvox.source.azure.AzureRegion
 import `in`.jphe.storyvox.source.azure.AzureSpeechClient
 import `in`.jphe.storyvox.source.azure.AzureVoiceRoster
 import `in`.jphe.storyvox.feature.api.CacheQuotaOptions
+import `in`.jphe.storyvox.feature.api.HighlightMode
 import `in`.jphe.storyvox.feature.api.UiSettings
 import `in`.jphe.storyvox.feature.api.UiSigil
 import `in`.jphe.storyvox.ui.theme.ReaderTheme
@@ -846,6 +847,15 @@ private object Keys {
     val READER_CUSTOM_FG_ARGB = intPreferencesKey("pref_reader_custom_fg_argb")
     val READER_CUSTOM_BG_ARGB = intPreferencesKey("pref_reader_custom_bg_argb")
 
+    /** Issue #994 — reading-highlight mode. Stored as the [HighlightMode]
+     *  enum's name; unknown values fall back to [HighlightMode.Sentence] on
+     *  read. Custom word-highlight colour is an ARGB int (0 = unset → use the
+     *  reading-theme accent). Device-local (NOT synced) — same per-device
+     *  reading-comfort rationale as the reading theme (#993) / typography
+     *  (#992). */
+    val HIGHLIGHT_MODE = stringPreferencesKey("pref_highlight_mode")
+    val WORD_HIGHLIGHT_ARGB = intPreferencesKey("pref_word_highlight_argb")
+
     // ── Reader-surface typography (issue #992) ──────────────────────
     /** Reader font family — stored as the [ReaderFontFamily] enum's name.
      *  Unknown values fall back to [ReaderFontFamily.Default] on read. Synced. */
@@ -1530,6 +1540,14 @@ class SettingsRepositoryUiImpl(
                 ?: ReaderTheme.Default,
             readerCustomFgArgb = prefs[Keys.READER_CUSTOM_FG_ARGB] ?: 0,
             readerCustomBgArgb = prefs[Keys.READER_CUSTOM_BG_ARGB] ?: 0,
+            // Issue #994 — reading-highlight mode + custom word colour.
+            // Unknown enum strings fall back to Sentence (today's behaviour);
+            // wordHighlightArgb is a raw ARGB int (0 = unset → reading-theme
+            // accent, resolved view-side).
+            highlightMode = prefs[Keys.HIGHLIGHT_MODE]
+                ?.let { runCatching { HighlightMode.valueOf(it) }.getOrNull() }
+                ?: HighlightMode.Sentence,
+            wordHighlightArgb = prefs[Keys.WORD_HIGHLIGHT_ARGB] ?: 0,
             // Issue #992 — reader-surface typography. Unknown enum strings
             // fall back to Default; numeric fields are clamped by
             // ReaderTypography.clamped() via UiSettings.readerTypography so we
@@ -2579,6 +2597,19 @@ class SettingsRepositoryUiImpl(
             it[Keys.READER_CUSTOM_BG_ARGB] = bgArgb
             it[Keys.READER_THEME] = ReaderTheme.Custom.name
         }
+    }
+
+    // ── Reading-highlight mode / per-word colour (issue #994) ──────
+    // DEVICE-LOCAL — like the reading theme (#993) and reader typography
+    // (#992), the highlight mode + custom word colour are per-device
+    // reading-comfort choices, so these are deliberately NOT in
+    // SYNC_ALLOWLIST and do NOT call stampSyncedWrite().
+    override suspend fun setHighlightMode(mode: HighlightMode) {
+        store.edit { it[Keys.HIGHLIGHT_MODE] = mode.name }
+    }
+
+    override suspend fun setWordHighlightColor(argb: Int) {
+        store.edit { it[Keys.WORD_HIGHLIGHT_ARGB] = argb }
     }
 
     // ── Azure Speech Services BYOK (#182, PR-3) ────────────────────

--- a/core-ui/src/main/kotlin/in/jphe/storyvox/ui/component/SentenceHighlight.kt
+++ b/core-ui/src/main/kotlin/in/jphe/storyvox/ui/component/SentenceHighlight.kt
@@ -46,6 +46,15 @@ import `in`.jphe.storyvox.ui.theme.LocalReducedMotion
  * @param activeMatchIndex optional (#998) — index into [searchMatches] of the hit the next/prev chevrons
  *                last landed on; it gets a stronger fill so the reader sees which match is focused. `-1`
  *                (default) means no active match — every hit paints with the dimmer fill.
+ * @param wordStart optional (#994) — UTF-16 char index of the word currently being spoken, for the
+ *                per-word "karaoke" fill. `-1` (default) = no word fill, so every existing callsite
+ *                renders pixel-identically. Drawn as a translucent draw-layer rect *behind* the
+ *                spoken-sentence underline, so the underline stays visible over the wash.
+ * @param wordEnd optional (#994) — exclusive UTF-16 end of the karaoke word. The fill paints only when
+ *                `wordEnd > wordStart && wordStart >= 0`.
+ * @param wordFill optional (#994) — colour for the per-word fill. Default null lets it derive from the
+ *                active reading-theme accent (or MaterialTheme.primary when inactive); a non-null value
+ *                is the user's custom highlight colour (issue #994 "customizable highlight color").
  */
 @Composable
 fun SentenceHighlight(
@@ -58,6 +67,9 @@ fun SentenceHighlight(
     onLayout: ((TextLayoutResult) -> Unit)? = null,
     searchMatches: List<IntRange> = emptyList(),
     activeMatchIndex: Int = -1,
+    wordStart: Int = -1,
+    wordEnd: Int = -1,
+    wordFill: androidx.compose.ui.graphics.Color? = null,
 ) {
     // #993 — when a reading theme is active, the chapter text uses the
     // theme's foreground and the sentence underline uses its accent; otherwise
@@ -66,6 +78,13 @@ fun SentenceHighlight(
     val brass = readerColors?.accent ?: MaterialTheme.colorScheme.primary
     val onSurface = readerColors?.foreground ?: MaterialTheme.colorScheme.onSurface
     val motion = LocalMotion.current
+
+    // #994 — per-word karaoke fill colour. A user-set custom colour wins;
+    // otherwise we derive from the same accent the sentence underline uses
+    // (brass), so out of the box the word fill harmonises with the active
+    // reading theme (#993). 0.25 alpha = a soft wash the dark text reads
+    // through. Distinct draw layer from #998's search-hit *span* fills.
+    val wordFillColor = (wordFill ?: brass).copy(alpha = 0.25f)
 
     var layout by remember { mutableStateOf<TextLayoutResult?>(null) }
 
@@ -232,6 +251,39 @@ fun SentenceHighlight(
             )
             .drawBehind {
                 val l = layout ?: return@drawBehind
+
+                // #994 — per-word karaoke fill, drawn FIRST so the spoken-
+                // sentence underline (below) sits on top of the wash. Full
+                // line-height rect behind the current word, segmented per
+                // visible line exactly like the underline. No `animated`
+                // fade: the word fill should track the voice crisply, not
+                // breathe. Paints only for a valid word range — `-1`
+                // defaults make this a no-op for every non-karaoke callsite.
+                if (wordEnd > wordStart && wordStart >= 0) {
+                    val wStart = wordStart.coerceIn(0, text.length)
+                    val wEnd = wordEnd.coerceIn(wStart, text.length)
+                    if (wEnd > wStart) {
+                        val wFirst = l.getLineForOffset(wStart)
+                        val wLast = l.getLineForOffset(wEnd.coerceAtLeast(wStart + 1) - 1)
+                        for (line in wFirst..wLast) {
+                            val lineStart = l.getLineStart(line)
+                            val lineEnd = l.getLineEnd(line, visibleEnd = true)
+                            val segStart = maxOf(wStart, lineStart)
+                            val segEnd = minOf(wEnd, lineEnd)
+                            if (segEnd <= segStart) continue
+                            val xStart = l.getHorizontalPosition(segStart, usePrimaryDirection = true)
+                            val xEnd = l.getHorizontalPosition(segEnd, usePrimaryDirection = true)
+                            val top = l.getLineTop(line)
+                            val bottom = l.getLineBottom(line)
+                            drawRect(
+                                color = wordFillColor,
+                                topLeft = Offset(xStart, top),
+                                size = Size(xEnd - xStart, bottom - top),
+                            )
+                        }
+                    }
+                }
+
                 if (drawEnd <= drawStart) return@drawBehind
                 val safeStart = drawStart.coerceIn(0, text.length)
                 val safeEnd = drawEnd.coerceIn(safeStart, text.length)

--- a/core-ui/src/main/kotlin/in/jphe/storyvox/ui/component/WordHighlightMapper.kt
+++ b/core-ui/src/main/kotlin/in/jphe/storyvox/ui/component/WordHighlightMapper.kt
@@ -69,3 +69,26 @@ fun currentWordRange(
     }
     return words.last()
 }
+
+/**
+ * Issue #994 — fraction (0..1) of the way through the current sentence,
+ * for feeding [currentWordRange]'s `sentenceProgress`.
+ *
+ * The reader accumulates [elapsedMs] of (speed-scaled) playback time since
+ * the engine published the current sentence and divides by the sentence's
+ * [durationMs] estimate. Kept pure so the composable's per-frame
+ * [withFrameNanos] loop stays a thin call site and the timing math is
+ * unit-tested under plain JUnit.
+ *
+ * @param elapsedMs playback time elapsed within the current sentence; may
+ *        briefly go negative across a clock-reset race (clamped to 0).
+ * @param durationMs the sentence's duration estimate. When <= 0 (not yet
+ *        estimated, or a zero-length sentence) we return 1f — "treat as
+ *        done", highlighting the last word — rather than dividing by zero;
+ *        this self-corrects on the next sentence boundary.
+ * @return progress in [0f, 1f].
+ */
+fun sentenceProgress(elapsedMs: Long, durationMs: Long): Float {
+    if (durationMs <= 0L) return 1f
+    return (elapsedMs.toFloat() / durationMs.toFloat()).coerceIn(0f, 1f)
+}

--- a/core-ui/src/main/kotlin/in/jphe/storyvox/ui/component/WordHighlightMapper.kt
+++ b/core-ui/src/main/kotlin/in/jphe/storyvox/ui/component/WordHighlightMapper.kt
@@ -1,0 +1,71 @@
+package `in`.jphe.storyvox.ui.component
+
+/**
+ * Issue #994 — per-word "karaoke" highlight.
+ *
+ * Maps the audio playhead's progress through the current sentence
+ * ([sentenceProgress], 0..1) to the char range of the word being spoken,
+ * so the reader can draw a background highlight that follows the voice.
+ *
+ * This is the *proportional* model the issue blesses — no true phoneme
+ * timing. Each word's share of the sentence's spoken time is weighted by
+ * its character length (longer words take longer to say), which matches
+ * how most Android TTS "karaoke" implementations approximate word timing.
+ * The error self-corrects every sentence boundary, when the engine's real
+ * sentence range advances and the progress clock resets.
+ *
+ * Pure function (no Compose / Android types) so it unit-tests under plain
+ * JUnit and the composable stays a dumb renderer: [SentenceHighlight]
+ * resolves the returned [IntRange] to pixels via its [TextLayoutResult].
+ *
+ * @param text full chapter text
+ * @param sentenceStart UTF-16 char index where the current sentence begins
+ * @param sentenceEnd UTF-16 char index where the current sentence ends (exclusive)
+ * @param sentenceProgress 0..1 fraction of the way through the sentence;
+ *        clamped, so callers needn't guard against overshoot/undershoot.
+ * @return the current word's char range (inclusive `first`..`last`) in the
+ *         same absolute coordinate space as [text], or null when the
+ *         sentence window holds no word (empty / whitespace-only).
+ */
+fun currentWordRange(
+    text: String,
+    sentenceStart: Int,
+    sentenceEnd: Int,
+    sentenceProgress: Float,
+): IntRange? {
+    val start = sentenceStart.coerceIn(0, text.length)
+    val end = sentenceEnd.coerceIn(start, text.length)
+    if (end <= start) return null
+
+    // Tokenize into words = maximal non-whitespace runs, keeping each
+    // word's absolute inclusive char range (first..last) in the chapter
+    // text. `wordStart until i` yields an IntRange whose `.last` is the
+    // last non-whitespace char (i is the exclusive scan position).
+    val words = ArrayList<IntRange>()
+    var i = start
+    while (i < end) {
+        while (i < end && text[i].isWhitespace()) i++
+        if (i >= end) break
+        val wordStart = i
+        while (i < end && !text[i].isWhitespace()) i++
+        words.add(wordStart until i)
+    }
+    if (words.isEmpty()) return null
+
+    // Each word's weight = its char length = (last - first + 1).
+    val totalWeight = words.sumOf { it.last - it.first + 1 }.toFloat()
+    val progress = sentenceProgress.coerceIn(0f, 1f)
+
+    // Walk cumulative length-weighted bands; the current word is the one
+    // whose [cumStart, cumEnd) fraction band contains `progress`. The last
+    // word owns progress == 1.0 (the `< bandEnd` test would otherwise miss
+    // the exact endpoint), so we fall through to it.
+    var cum = 0f
+    for (w in words) {
+        val weight = (w.last - w.first + 1).toFloat()
+        val bandEnd = (cum + weight) / totalWeight
+        if (progress < bandEnd) return w
+        cum += weight
+    }
+    return words.last()
+}

--- a/core-ui/src/test/kotlin/in/jphe/storyvox/ui/component/SentenceProgressTest.kt
+++ b/core-ui/src/test/kotlin/in/jphe/storyvox/ui/component/SentenceProgressTest.kt
@@ -1,0 +1,59 @@
+package `in`.jphe.storyvox.ui.component
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+/**
+ * Issue #994 — the per-word "karaoke" highlight needs a 0..1 progress
+ * fraction through the current sentence to feed [currentWordRange]. The
+ * reader drives a per-frame clock ([withFrameNanos]) that accumulates the
+ * elapsed wall-clock time since the engine published the current sentence,
+ * scaled by playback speed, and divides by the sentence's duration
+ * estimate. That division is the pure math pinned here so the composable's
+ * frame loop stays a thin call site.
+ *
+ * Edge cases that matter during live playback:
+ *  - a not-yet-estimated or zero-length sentence ([durationMs] <= 0) must
+ *    never divide-by-zero; it returns 1f ("treat as done" → highlight the
+ *    last word), which self-corrects on the next sentence boundary;
+ *  - overshoot (the clock ran past the estimate before the engine advanced
+ *    the sentence) and undershoot (negative elapsed from a clock reset
+ *    race) are clamped to [0, 1].
+ */
+class SentenceProgressTest {
+
+    @Test
+    fun `zero elapsed is start of sentence`() {
+        assertEquals(0.0f, sentenceProgress(elapsedMs = 0L, durationMs = 1000L), 1e-6f)
+    }
+
+    @Test
+    fun `half elapsed is halfway through`() {
+        assertEquals(0.5f, sentenceProgress(elapsedMs = 500L, durationMs = 1000L), 1e-6f)
+    }
+
+    @Test
+    fun `full elapsed is end of sentence`() {
+        assertEquals(1.0f, sentenceProgress(elapsedMs = 1000L, durationMs = 1000L), 1e-6f)
+    }
+
+    @Test
+    fun `overshoot past the estimate clamps to 1`() {
+        assertEquals(1.0f, sentenceProgress(elapsedMs = 1500L, durationMs = 1000L), 1e-6f)
+    }
+
+    @Test
+    fun `negative elapsed from a clock-reset race clamps to 0`() {
+        assertEquals(0.0f, sentenceProgress(elapsedMs = -200L, durationMs = 1000L), 1e-6f)
+    }
+
+    @Test
+    fun `zero duration estimate returns 1 instead of dividing by zero`() {
+        assertEquals(1.0f, sentenceProgress(elapsedMs = 0L, durationMs = 0L), 1e-6f)
+    }
+
+    @Test
+    fun `negative duration estimate returns 1 instead of going negative`() {
+        assertEquals(1.0f, sentenceProgress(elapsedMs = 100L, durationMs = -50L), 1e-6f)
+    }
+}

--- a/core-ui/src/test/kotlin/in/jphe/storyvox/ui/component/WordHighlightMapperTest.kt
+++ b/core-ui/src/test/kotlin/in/jphe/storyvox/ui/component/WordHighlightMapperTest.kt
@@ -1,0 +1,105 @@
+package `in`.jphe.storyvox.ui.component
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Test
+
+/**
+ * Issue #994 — per-word "karaoke" highlight. The reader maps the audio
+ * playhead's progress through the current sentence (0..1) to the word
+ * being spoken, so a background highlight can follow the voice word by
+ * word.
+ *
+ * The mapping is the *proportional* model the issue blesses (no true
+ * phoneme timing): each word's spoken-time share is weighted by its
+ * character length, since longer words take longer to say. These tests
+ * pin the pure char-range math; the composable resolves the returned
+ * range to pixels via its TextLayoutResult.
+ *
+ * All char offsets are absolute within the chapter text — the mapper is
+ * handed the sentence's [sentenceStart, sentenceEnd) window and returns
+ * a sub-range in the same coordinate space (or null when there's no
+ * word to highlight).
+ */
+class WordHighlightMapperTest {
+
+    // "The quick brown fox" — four words, lengths 3/5/5/3, total weight 16.
+    // Cumulative fractional boundaries (start-of-word):
+    //   The   [0/16 .. 3/16)   = 0.0000 .. 0.1875
+    //   quick [3/16 .. 8/16)   = 0.1875 .. 0.5000
+    //   brown [8/16 .. 13/16)  = 0.5000 .. 0.8125
+    //   fox   [13/16 .. 16/16) = 0.8125 .. 1.0000
+    private val text = "The quick brown fox"
+
+    @Test
+    fun `progress at sentence start highlights the first word`() {
+        val range = currentWordRange(text, sentenceStart = 0, sentenceEnd = text.length, sentenceProgress = 0.0f)
+        assertEquals(0, range!!.first)   // "The"
+        assertEquals(3, range.last + 1)
+    }
+
+    @Test
+    fun `progress in the second band highlights the second word`() {
+        val range = currentWordRange(text, 0, text.length, sentenceProgress = 0.30f)
+        assertEquals("quick", text.substring(range!!.first, range.last + 1))
+    }
+
+    @Test
+    fun `progress in the third band highlights the third word`() {
+        val range = currentWordRange(text, 0, text.length, sentenceProgress = 0.60f)
+        assertEquals("brown", text.substring(range!!.first, range.last + 1))
+    }
+
+    @Test
+    fun `progress at the end highlights the last word, never overruns`() {
+        val range = currentWordRange(text, 0, text.length, sentenceProgress = 1.0f)
+        assertEquals("fox", text.substring(range!!.first, range.last + 1))
+    }
+
+    @Test
+    fun `progress is clamped — values past 1 stay on the last word`() {
+        val range = currentWordRange(text, 0, text.length, sentenceProgress = 1.9f)
+        assertEquals("fox", text.substring(range!!.first, range.last + 1))
+    }
+
+    @Test
+    fun `progress is clamped — negative values stay on the first word`() {
+        val range = currentWordRange(text, 0, text.length, sentenceProgress = -0.5f)
+        assertEquals("The", text.substring(range!!.first, range.last + 1))
+    }
+
+    @Test
+    fun `returns absolute offsets when the sentence starts mid-chapter`() {
+        // Sentence "brown fox" begins at char 10 of the chapter text.
+        val rangeFirst = currentWordRange(text, sentenceStart = 10, sentenceEnd = text.length, sentenceProgress = 0.0f)
+        assertEquals("brown", text.substring(rangeFirst!!.first, rangeFirst.last + 1))
+        assertEquals(10, rangeFirst.first) // absolute, not 0
+
+        val rangeLast = currentWordRange(text, sentenceStart = 10, sentenceEnd = text.length, sentenceProgress = 1.0f)
+        assertEquals("fox", text.substring(rangeLast!!.first, rangeLast.last + 1))
+    }
+
+    @Test
+    fun `multiple spaces and punctuation do not produce empty words`() {
+        // Leading/trailing whitespace + double space + trailing period.
+        val s = "  Hi,  world. "
+        val atStart = currentWordRange(s, 0, s.length, sentenceProgress = 0.0f)
+        assertEquals("Hi,", s.substring(atStart!!.first, atStart.last + 1))
+        val atEnd = currentWordRange(s, 0, s.length, sentenceProgress = 1.0f)
+        assertEquals("world.", s.substring(atEnd!!.first, atEnd.last + 1))
+    }
+
+    @Test
+    fun `empty or blank sentence yields no word`() {
+        assertNull(currentWordRange("", 0, 0, 0.5f))
+        assertNull(currentWordRange("     ", 0, 5, 0.5f))
+    }
+
+    @Test
+    fun `single word sentence highlights that word for all progress`() {
+        val s = "Hello"
+        assertEquals("Hello", s.substring(currentWordRange(s, 0, s.length, 0.0f)!!.let { it.first..it.last }))
+        assertEquals("Hello", s.substring(currentWordRange(s, 0, s.length, 0.5f)!!.let { it.first..it.last }))
+        assertEquals("Hello", s.substring(currentWordRange(s, 0, s.length, 1.0f)!!.let { it.first..it.last }))
+    }
+}

--- a/feature/src/main/kotlin/in/jphe/storyvox/feature/api/UiContracts.kt
+++ b/feature/src/main/kotlin/in/jphe/storyvox/feature/api/UiContracts.kt
@@ -1366,6 +1366,22 @@ data class UiSettings(
     val readerLetterSpacingEm: Float = 0.0111f,
     /** Inter-paragraph spacing multiplier in the reader; clamped 0.5..3.0. 1.0 = legacy. */
     val readerParagraphSpacingMultiplier: Float = 1f,
+    /**
+     * Issue #994 — reading-highlight mode. [HighlightMode.Sentence] (default)
+     * is today's brass-underline-only behaviour; [HighlightMode.Word] /
+     * [HighlightMode.Both] add the per-word karaoke fill. Per-device pref
+     * (NOT synced) — a reading-comfort choice, same rationale as the reading
+     * theme (#993) and reader typography (#992).
+     */
+    val highlightMode: HighlightMode = HighlightMode.Sentence,
+    /**
+     * Custom per-word highlight colour, as an ARGB int (`Color.toArgb`).
+     * `0` (default, unset) means derive from the active reading-theme accent
+     * (#993) — so out of the box the word fill harmonises with the theme.
+     * A non-zero value is the user's chosen colour (issue #994
+     * "customizable highlight color"). Per-device pref (NOT synced).
+     */
+    val wordHighlightArgb: Int = 0,
 ) {
     /**
      * Resolved reading-surface colours for the reader (#993). Inactive when
@@ -1668,6 +1684,21 @@ enum class SpeakChapterMode { Both, NumbersOnly, TitlesOnly }
 enum class ReadingDirection { FollowSystem, ForceLtr, ForceRtl }
 
 /**
+ * Issue #994 — how the reader highlights the text being narrated.
+ *
+ * - [Sentence] (default) reproduces today's behaviour: a brass underline
+ *   glides under the spoken sentence.
+ * - [Word] adds the per-word "karaoke" fill that follows the voice word by
+ *   word (no underline).
+ * - [Both] shows the sentence underline AND the per-word fill together.
+ * - [Off] disables reading highlights entirely.
+ *
+ * Default [Sentence] keeps existing users on the exact behaviour they have
+ * now until they opt into word-level highlighting.
+ */
+enum class HighlightMode { Off, Sentence, Word, Both }
+
+/**
  * Book-cover fallback style — what [`FictionCoverThumb`] renders when
  * the remote cover URL is missing, expired, or fails to load. Real
  * covers are always shown when they load successfully; this enum only
@@ -1820,6 +1851,17 @@ interface SettingsRepositoryUi {
      * [ReaderTheme.Custom]. Device-local (NOT synced). Default impl no-op.
      */
     suspend fun setReaderCustomColors(fgArgb: Int, bgArgb: Int) = Unit
+    /**
+     * Issue #994 — set the reading-highlight mode (sentence / word / both /
+     * off). Device-local (NOT synced). Default impl is a no-op.
+     */
+    suspend fun setHighlightMode(mode: HighlightMode) = Unit
+    /**
+     * Issue #994 — set the custom per-word highlight colour, as an ARGB int
+     * (`Color.toArgb`). `0` clears the override (fall back to the reading-
+     * theme accent). Device-local (NOT synced). Default impl is a no-op.
+     */
+    suspend fun setWordHighlightColor(argb: Int) = Unit
     /**
      * Issue #992 — reader-surface typography setters. Each clamps into the safe
      * range from [ReaderTypography] on write. Default impls are no-ops so tests

--- a/feature/src/main/kotlin/in/jphe/storyvox/feature/reader/HybridReaderScreen.kt
+++ b/feature/src/main/kotlin/in/jphe/storyvox/feature/reader/HybridReaderScreen.kt
@@ -94,6 +94,8 @@ fun HybridReaderScreen(
     val focusModeEnabled by viewModel.focusModeEnabled.collectAsStateWithLifecycle()
     val readerColors by viewModel.readerColors.collectAsStateWithLifecycle()
     val readerTypography by viewModel.readerTypography.collectAsStateWithLifecycle()
+    val highlightMode by viewModel.highlightMode.collectAsStateWithLifecycle()
+    val wordHighlightArgb by viewModel.wordHighlightArgb.collectAsStateWithLifecycle()
     val playback = state.playback
 
     // Calliope (v0.5.00) — first-natural-chapter-completion confetti.
@@ -366,6 +368,9 @@ fun HybridReaderScreen(
                 readerColors = readerColors,
                 // Issue #992 — reader-surface typography from settings.
                 readerTypography = readerTypography,
+                // Issue #994 — per-word karaoke highlight mode + custom colour.
+                highlightMode = highlightMode,
+                wordHighlightArgb = wordHighlightArgb,
             )
         },
     )

--- a/feature/src/main/kotlin/in/jphe/storyvox/feature/reader/ReaderView.kt
+++ b/feature/src/main/kotlin/in/jphe/storyvox/feature/reader/ReaderView.kt
@@ -74,8 +74,12 @@ import androidx.compose.ui.text.TextLayoutResult
 import androidx.compose.ui.text.input.ImeAction
 import androidx.compose.ui.unit.dp
 import `in`.jphe.storyvox.feature.R
+import `in`.jphe.storyvox.feature.api.HighlightMode
 import `in`.jphe.storyvox.feature.api.UiPlaybackState
+import androidx.compose.runtime.withFrameNanos
 import `in`.jphe.storyvox.ui.component.SentenceHighlight
+import `in`.jphe.storyvox.ui.component.currentWordRange
+import `in`.jphe.storyvox.ui.component.sentenceProgress
 import `in`.jphe.storyvox.ui.theme.LocalReaderColors
 import `in`.jphe.storyvox.ui.theme.LocalReaderTypography
 import `in`.jphe.storyvox.ui.theme.LocalSpacing
@@ -185,6 +189,14 @@ fun ReaderTextView(
      *  Default reproduces the legacy reader style, so preview/test callsites
      *  render unchanged. */
     readerTypography: ReaderTypography = ReaderTypography(),
+    /** Issue #994 — reading-highlight mode. [HighlightMode.Word] /
+     *  [HighlightMode.Both] drive the per-word karaoke fill; the default
+     *  [HighlightMode.Sentence] keeps the legacy underline-only behaviour, so
+     *  preview/test callsites are unchanged. */
+    highlightMode: HighlightMode = HighlightMode.Sentence,
+    /** Issue #994 — custom per-word highlight colour (ARGB int). 0 (default)
+     *  derives from the reading-theme accent. */
+    wordHighlightArgb: Int = 0,
     modifier: Modifier = Modifier,
 ) {
     val spacing = LocalSpacing.current
@@ -390,10 +402,60 @@ fun ReaderTextView(
                         bodyTopPx = coords.positionInParent().y
                     },
                 ) {
+                    // #994 — per-word karaoke clock. Word/Both modes drive a
+                    // proportional highlight (the issue-blessed model: no true
+                    // phoneme timing). We anchor wall-clock at each sentence
+                    // boundary and estimate the sentence's spoken duration from
+                    // its character count at the current speed (~16 chars/s at
+                    // 1.0x). currentWordRange maps that progress to a word; the
+                    // error self-corrects every boundary when the engine
+                    // advances the sentence range. Sentence/Off modes leave
+                    // wordStart/wordEnd at -1 → SentenceHighlight no-ops the fill.
+                    val wordHighlightActive =
+                        (highlightMode == HighlightMode.Word || highlightMode == HighlightMode.Both) &&
+                            state.isPlaying
+                    var sentenceElapsedMs by remember { mutableLongStateOf(0L) }
+                    LaunchedEffect(
+                        wordHighlightActive,
+                        state.sentenceStart,
+                        state.sentenceEnd,
+                    ) {
+                        sentenceElapsedMs = 0L
+                        if (!wordHighlightActive) return@LaunchedEffect
+                        val anchorNanos = withFrameNanos { it }
+                        while (true) {
+                            val nowNanos = withFrameNanos { it }
+                            sentenceElapsedMs = (nowNanos - anchorNanos) / 1_000_000L
+                        }
+                    }
+                    // Estimate spoken duration from char count. ~16 chars/s at
+                    // 1.0x; faster speed → shorter estimate. Floor of 1 char so
+                    // a degenerate range never yields 0ms (handled anyway by
+                    // sentenceProgress's durationMs<=0 guard).
+                    val sentenceChars = (state.sentenceEnd - state.sentenceStart).coerceAtLeast(1)
+                    val speed = state.speed.coerceAtLeast(0.1f)
+                    val estDurationMs = (sentenceChars * 1000L / (16f * speed)).toLong()
+                    val wordRange = if (wordHighlightActive) {
+                        currentWordRange(
+                            text = chapterText,
+                            sentenceStart = state.sentenceStart,
+                            sentenceEnd = state.sentenceEnd,
+                            sentenceProgress = sentenceProgress(sentenceElapsedMs, estDurationMs),
+                        )
+                    } else {
+                        null
+                    }
+                    // #994 — Word-only mode hides the sentence underline (the
+                    // word fill IS the indicator); Both keeps both. Off/Sentence
+                    // keep today's underline.
+                    val underlineSuppressed = highlightMode == HighlightMode.Word ||
+                        highlightMode == HighlightMode.Off
+                    val customWordFill =
+                        if (wordHighlightArgb != 0) Color(wordHighlightArgb) else null
                     SentenceHighlight(
                         text = chapterText,
-                        highlightStart = state.sentenceStart,
-                        highlightEnd = state.sentenceEnd,
+                        highlightStart = if (underlineSuppressed) 0 else state.sentenceStart,
+                        highlightEnd = if (underlineSuppressed) 0 else state.sentenceEnd,
                         onTapWord = onSeekToChar,
                         onLongPressWord = { word -> lookupWord = word },
                         onLayout = { layout -> textLayout = layout },
@@ -401,6 +463,10 @@ fun ReaderTextView(
                         // (chevron target) gets the stronger fill.
                         searchMatches = matches,
                         activeMatchIndex = activeMatchIndex,
+                        // #994 — per-word karaoke fill.
+                        wordStart = wordRange?.first ?: -1,
+                        wordEnd = wordRange?.let { it.last + 1 } ?: -1,
+                        wordFill = customWordFill,
                     )
                 } // Box
                 } // CompositionLocalProvider(LocalReaderTypography) — #992

--- a/feature/src/main/kotlin/in/jphe/storyvox/feature/reader/ReaderViewModel.kt
+++ b/feature/src/main/kotlin/in/jphe/storyvox/feature/reader/ReaderViewModel.kt
@@ -9,6 +9,7 @@ import `in`.jphe.storyvox.data.repository.ContinueListeningEntry
 import `in`.jphe.storyvox.data.repository.PlaybackPositionRepository
 import `in`.jphe.storyvox.data.repository.playback.PlaybackResumePolicyConfig
 import `in`.jphe.storyvox.feature.api.FictionRepositoryUi
+import `in`.jphe.storyvox.feature.api.HighlightMode
 import `in`.jphe.storyvox.feature.api.PlaybackControllerUi
 import `in`.jphe.storyvox.feature.api.SettingsRepositoryUi
 import `in`.jphe.storyvox.ui.theme.ReaderTypography
@@ -489,6 +490,26 @@ class ReaderViewModel @Inject constructor(
         .map { it.readerTypography }
         .distinctUntilChanged()
         .stateIn(viewModelScope, SharingStarted.WhileSubscribed(5_000), ReaderTypography())
+
+    /**
+     * Issue #994 — reading-highlight mode. [ReaderTextView] observes this to
+     * drive the per-word karaoke fill (Word / Both) vs the legacy sentence
+     * underline (Sentence) or no highlight (Off). Device-local pref; default
+     * [HighlightMode.Sentence] keeps today's behaviour.
+     */
+    val highlightMode: StateFlow<HighlightMode> = settings.settings
+        .map { it.highlightMode }
+        .distinctUntilChanged()
+        .stateIn(viewModelScope, SharingStarted.WhileSubscribed(5_000), HighlightMode.Sentence)
+
+    /**
+     * Issue #994 — custom per-word highlight colour (ARGB int; 0 = unset →
+     * derive from the reading-theme accent). Device-local pref.
+     */
+    val wordHighlightArgb: StateFlow<Int> = settings.settings
+        .map { it.wordHighlightArgb }
+        .distinctUntilChanged()
+        .stateIn(viewModelScope, SharingStarted.WhileSubscribed(5_000), 0)
 
     /** Issue #278 — user-initiated retry from the timed-out error block.
      *  Re-invokes the playback `play()` path; the underlying controller

--- a/feature/src/main/kotlin/in/jphe/storyvox/feature/settings/ReadingSettingsScreen.kt
+++ b/feature/src/main/kotlin/in/jphe/storyvox/feature/settings/ReadingSettingsScreen.kt
@@ -33,6 +33,7 @@ import androidx.compose.ui.unit.dp
 import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import `in`.jphe.storyvox.feature.R
+import `in`.jphe.storyvox.feature.api.HighlightMode
 import `in`.jphe.storyvox.feature.api.ThemeOverride
 import `in`.jphe.storyvox.ui.theme.LocalReaderTypography
 import `in`.jphe.storyvox.ui.theme.LocalSpacing
@@ -117,8 +118,104 @@ fun ReadingSettingsScreen(
                     onParagraphSpacing = viewModel::setReaderParagraphSpacing,
                 )
             }
+
+            // #994 — read-along highlight: sentence underline / per-word
+            // karaoke fill / both / off, plus an optional custom word colour.
+            SettingsSectionHeader(label = stringResource(R.string.settings_highlight_group_title))
+            SettingsGroupCard {
+                HighlightGroup(
+                    mode = s.highlightMode,
+                    wordHighlightArgb = s.wordHighlightArgb,
+                    accentArgb = s.readerColors.resolved?.accent?.toArgb() ?: 0,
+                    onSetMode = viewModel::setHighlightMode,
+                    onSetWordColor = viewModel::setWordHighlightColor,
+                )
+            }
         }
     }
+}
+
+/**
+ * Issue #994 — read-along highlight controls: a segmented mode picker
+ * (Off / Sentence / Word / Both) and, when a per-word mode is active, an
+ * optional custom highlight colour. The colour defaults to the reading-theme
+ * accent (#993) — "Use theme colour" clears the override (stores 0); picking
+ * a colour stores the ARGB so the karaoke fill uses it.
+ */
+@Composable
+private fun HighlightGroup(
+    mode: HighlightMode,
+    wordHighlightArgb: Int,
+    accentArgb: Int,
+    onSetMode: (HighlightMode) -> Unit,
+    onSetWordColor: (Int) -> Unit,
+) {
+    val spacing = LocalSpacing.current
+    Column(verticalArrangement = Arrangement.spacedBy(spacing.sm)) {
+        SettingsSegmentedBlock(
+            title = stringResource(R.string.settings_highlight_mode_title),
+            subtitle = stringResource(R.string.settings_highlight_mode_subtitle),
+            options = HighlightMode.entries.map { it.label() },
+            selectedIndex = HighlightMode.entries.indexOf(mode).coerceAtLeast(0),
+            onSelected = { idx -> onSetMode(HighlightMode.entries[idx]) },
+        )
+
+        // Word colour only matters when a per-word fill is showing.
+        if (mode == HighlightMode.Word || mode == HighlightMode.Both) {
+            // Effective swatch: the custom colour if set, else the theme accent.
+            val effectiveArgb = if (wordHighlightArgb != 0) wordHighlightArgb else accentArgb
+            Text(
+                text = stringResource(R.string.settings_highlight_color_title),
+                style = MaterialTheme.typography.bodyLarge,
+                modifier = Modifier.padding(horizontal = spacing.md),
+            )
+            Row(
+                modifier = Modifier.padding(horizontal = spacing.md),
+                horizontalArrangement = Arrangement.spacedBy(spacing.sm),
+                verticalAlignment = Alignment.CenterVertically,
+            ) {
+                Box(
+                    modifier = Modifier
+                        .size(28.dp)
+                        .clip(RoundedCornerShape(6.dp))
+                        .background(Color(effectiveArgb).copy(alpha = 1f)),
+                )
+                Text(
+                    text = if (wordHighlightArgb != 0) {
+                        stringResource(R.string.settings_highlight_color_custom)
+                    } else {
+                        stringResource(R.string.settings_highlight_color_theme)
+                    },
+                    style = MaterialTheme.typography.bodyMedium,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                )
+            }
+            RgbSliders(
+                label = stringResource(R.string.settings_highlight_color_title),
+                color = Color(effectiveArgb),
+                onColor = { onSetWordColor(it.toArgb()) },
+            )
+            if (wordHighlightArgb != 0) {
+                Text(
+                    text = stringResource(R.string.settings_highlight_color_reset),
+                    style = MaterialTheme.typography.labelLarge,
+                    color = MaterialTheme.colorScheme.primary,
+                    modifier = Modifier
+                        .padding(horizontal = spacing.md)
+                        .clickable { onSetWordColor(0) },
+                )
+            }
+        }
+    }
+}
+
+/** Display label for a [HighlightMode] segment. */
+@Composable
+private fun HighlightMode.label(): String = when (this) {
+    HighlightMode.Off -> stringResource(R.string.settings_highlight_mode_off)
+    HighlightMode.Sentence -> stringResource(R.string.settings_highlight_mode_sentence)
+    HighlightMode.Word -> stringResource(R.string.settings_highlight_mode_word)
+    HighlightMode.Both -> stringResource(R.string.settings_highlight_mode_both)
 }
 
 /** Maps a [ReaderTheme] to its display-name string resource. */

--- a/feature/src/main/kotlin/in/jphe/storyvox/feature/settings/SettingsViewModel.kt
+++ b/feature/src/main/kotlin/in/jphe/storyvox/feature/settings/SettingsViewModel.kt
@@ -12,6 +12,7 @@ import `in`.jphe.storyvox.feature.api.UiParticleIntensity
 import `in`.jphe.storyvox.feature.api.UiSkeletonStyle
 import `in`.jphe.storyvox.feature.api.PalaceProbeResult
 import `in`.jphe.storyvox.feature.api.ReadingDirection
+import `in`.jphe.storyvox.feature.api.HighlightMode
 import `in`.jphe.storyvox.feature.api.SettingsRepositoryUi
 import `in`.jphe.storyvox.feature.api.SpeakChapterMode
 import `in`.jphe.storyvox.ui.theme.ReaderTheme
@@ -578,6 +579,15 @@ class SettingsViewModel @Inject constructor(
     /** Issue #993 — custom reading-theme fg/bg as ARGB ints; implies Custom. */
     fun setReaderCustomColors(fgArgb: Int, bgArgb: Int) =
         viewModelScope.launch { repo.setReaderCustomColors(fgArgb, bgArgb) }
+
+    /** Issue #994 — reading-highlight mode (sentence / word / both / off). */
+    fun setHighlightMode(mode: HighlightMode) =
+        viewModelScope.launch { repo.setHighlightMode(mode) }
+
+    /** Issue #994 — custom per-word highlight colour (ARGB int; 0 clears
+     *  the override → fall back to the reading-theme accent). */
+    fun setWordHighlightColor(argb: Int) =
+        viewModelScope.launch { repo.setWordHighlightColor(argb) }
 }
 
 /** Map the feature-layer enum to the :core-llm enum. The two are

--- a/feature/src/main/res/values/strings.xml
+++ b/feature/src/main/res/values/strings.xml
@@ -616,6 +616,19 @@
     <string name="settings_reading_preview_text">The quick brown fox jumps over the lazy dog. Reading should feel comfortable.</string>
     <string name="settings_reading_reset">Reset to defaults</string>
 
+    <!-- Settings · Read-along highlight (#994) -->
+    <string name="settings_highlight_group_title">Read-along highlight</string>
+    <string name="settings_highlight_mode_title">Highlight style</string>
+    <string name="settings_highlight_mode_subtitle">How the reader marks the words being narrated.</string>
+    <string name="settings_highlight_mode_off">Off</string>
+    <string name="settings_highlight_mode_sentence">Sentence</string>
+    <string name="settings_highlight_mode_word">Word</string>
+    <string name="settings_highlight_mode_both">Both</string>
+    <string name="settings_highlight_color_title">Word highlight color</string>
+    <string name="settings_highlight_color_theme">Using the reading theme color</string>
+    <string name="settings_highlight_color_custom">Custom color</string>
+    <string name="settings_highlight_color_reset">Use theme color</string>
+
     <!-- Settings · Cloud voices subscreen -->
     <string name="settings_cloud_voices_title">Cloud voices</string>
 


### PR DESCRIPTION
Closes #994.

Flagship reader feature: a per-word "karaoke" highlight that tracks the spoken word as the TTS reads, plus a customizable highlight colour.

## Design — option B (accent default + optional override)

`HighlightMode { Off, Sentence, Word, Both }` — default **Sentence** (preserves current behaviour). `Word`/`Both` enable the per-word fill; `Word` suppresses the sentence underline, `Both` keeps it. Optional `wordHighlightArgb` (0 = unset → falls back to `LocalReaderColors.accent` from #993). Both prefs are **device-local** (not synced — matches #992/#993 reader-comfort prefs).

## How it works (no EnginePlayer changes)

UI-side proportional model:
- `currentWordRange(text, sentenceStart, sentenceEnd, progress)` — char-length-weighted word mapping (core-ui, pure, tested).
- `sentenceProgress(elapsedMs, durationMs)` — clamps 0..1 (pure, tested).
- A `withFrameNanos` clock in `ReaderView` anchors per-sentence and estimates spoken duration from char-count × speed (~16 chars/s @ 1.0×). Self-corrects at every sentence boundary, so drift never accumulates.

The word-fill is drawn in the existing `drawBehind` layer (a `drawRect` keyed off `TextLayoutResult`), **not** an `AnnotatedString` span — this avoids rebuilding the annotated string 60×/sec on long chapters. Orthogonal to #998 search-hit spans.

## Sits on the reader cluster

Rebased onto main after #992/#993/#997/#998/#1001/#1038. Consumes #993 `LocalReaderColors.accent` for the default fill; reuses #993 `CustomColorPicker` pattern for the colour UI. Respects the #992/#993 nested `LocalReaderColors`/`LocalReaderTypography` provider boundaries.

## Tests

- `WordHighlightMapperTest` (10) — word-range mapping across progress values, boundaries, empty/single-word.
- `SentenceProgressTest` (7) — zero/half/full/overshoot/negative elapsed + zero/negative duration clamping.

`:app:assembleDebug` green (confirms Compose brace balance on the rebased tree). 17/17 unit tests pass.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added customizable read-along highlighting with four modes: Off, Sentence-level, Per-word (karaoke), or Both
  * Per-word highlights update in real-time during audio playback for a karaoke-style experience
  * New "Highlight" settings section allows users to select their preferred highlight mode and custom highlight color
  * Option to reset custom colors back to theme defaults

<!-- end of auto-generated comment: release notes by coderabbit.ai -->