### PR TITLE
fix(follows): report new-chapter delta, not the whole NOT_DOWNLOADED backlog

### DIFF
--- a/core-data/src/main/kotlin/in/jphe/storyvox/data/work/NewChapterPollWorker.kt
+++ b/core-data/src/main/kotlin/in/jphe/storyvox/data/work/NewChapterPollWorker.kt
@@ -59,8 +59,12 @@ class NewChapterPollWorker @AssistedInject constructor(
 ) : CoroutineWorker(appContext, params) {
 
     override suspend fun doWork(): Result {
-        var newChapters = 0
         var skippedByRevisionCheck = 0
+        // Sum of genuinely-new chapters across all fictions this poll —
+        // the delta since the previous poll, NOT the cumulative
+        // NOT_DOWNLOADED backlog. This is the count the user is told
+        // about, and what KEY_NEW_CHAPTERS reports.
+        var newChapterDelta = 0
 
         // Issue #907 — poll every fiction the user follows on the source
         // (followedRemotely) as well as the in-library subscribe/eager set.
@@ -96,6 +100,17 @@ class NewChapterPollWorker @AssistedInject constructor(
                 // The full refreshDetail path is the safe default.
             }
 
+            // Snapshot the chapter ids we already hold BEFORE the refresh
+            // mutates the chapter table. The genuine "new since last poll"
+            // delta is the set of chapters that appear after the refresh
+            // but were not here before — NOT the full NOT_DOWNLOADED
+            // backlog. A followed/SUBSCRIBE fiction never downloads its
+            // chapters, so `missingForFiction` (downloadState =
+            // NOT_DOWNLOADED) is the entire un-played history; using its
+            // size as the "new" count made every poll re-announce "65 new
+            // chapters" instead of the one chapter that actually landed.
+            val priorChapterIds = chapterDao.chapterIdsForFiction(fiction.id).toSet()
+
             when (val result = fictionRepository.refreshDetail(fiction.id)) {
                 is FictionResult.Success -> {
                     // After a successful refresh, persist whatever new
@@ -118,27 +133,36 @@ class NewChapterPollWorker @AssistedInject constructor(
 
                     val missing = chapterDao.missingForFiction(fiction.id)
                     if (missing.isEmpty()) continue
-                    newChapters += missing.size
 
-                    // Issue #383 — emit a cross-source Inbox event for
-                    // the user. Gate via the per-source toggle so a
-                    // user who flipped Royal Road's inbox toggle off
-                    // still gets the library updated (and the chapters
-                    // queued in EAGER mode) but doesn't see a row in
-                    // the Inbox feed. Coalescing across consecutive
-                    // polls happens inside InboxRepository.record —
-                    // we always pass the current total, and the repo
-                    // updates the existing unread row in place so the
-                    // feed doesn't flood.
-                    if (inboxGate.isEnabled(fiction.sourceId)) {
-                        val deepLinkChapterId = missing.first().id
-                        val plural = if (missing.size == 1) "chapter" else "chapters"
+                    // Compute what (if anything) to announce. `missing`
+                    // (the whole NOT_DOWNLOADED backlog) still drives EAGER
+                    // auto-download below — but the user-facing count,
+                    // plural label and deep-link target all come from the
+                    // delta computed here. See [newChapterAnnouncement].
+                    val announcement = newChapterAnnouncement(
+                        missingChapterIds = missing.map { it.id },
+                        priorChapterIds = priorChapterIds,
+                    )
+                    newChapterDelta += announcement.newCount
+
+                    // Issue #383 / #907 — emit the cross-source Inbox event
+                    // and the Android system notification. Gate via the
+                    // per-source toggle so a user who flipped Royal Road's
+                    // inbox toggle off still gets the library updated (and
+                    // chapters queued in EAGER mode) but sees no feed row or
+                    // notification. Both reflect the delta since the
+                    // previous poll, not the cumulative NOT_DOWNLOADED
+                    // backlog, and are skipped on the first poll baseline.
+                    val deepLinkChapterId = announcement.deepLinkChapterId
+                    if (announcement.shouldNotify && deepLinkChapterId != null &&
+                        inboxGate.isEnabled(fiction.sourceId)
+                    ) {
                         runCatching {
                             inboxRepository.record(
                                 sourceId = fiction.sourceId,
                                 fictionId = fiction.id,
                                 chapterId = deepLinkChapterId,
-                                title = "${missing.size} new $plural in ${fiction.title}",
+                                title = "${announcement.newCount} new ${announcement.pluralLabel} in ${fiction.title}",
                                 body = null,
                                 deepLinkUri = "storyvox://reader/${fiction.id}/$deepLinkChapterId",
                             )
@@ -149,17 +173,15 @@ class NewChapterPollWorker @AssistedInject constructor(
                             Log.w(TAG, "inbox record failed for ${fiction.id}", e)
                         }
 
-                        // Issue #907 — fire the Android system notification
-                        // alongside the Inbox row. Same gate, same deep-link
-                        // target as the feed entry. Best-effort: a notifier
-                        // failure (denied POST_NOTIFICATIONS, OEM throttle)
-                        // must not fail the poll or skip the persisted rows.
+                        // Best-effort: a notifier failure (denied
+                        // POST_NOTIFICATIONS, OEM throttle) must not fail the
+                        // poll or skip the persisted rows.
                         runCatching {
                             newChapterNotifier.notifyNewChapters(
                                 fictionId = fiction.id,
                                 firstNewChapterId = deepLinkChapterId,
                                 fictionTitle = fiction.title,
-                                newCount = missing.size,
+                                newCount = announcement.newCount,
                             )
                         }.onFailure { e ->
                             Log.w(TAG, "new-chapter notify failed for ${fiction.id}", e)
@@ -198,7 +220,7 @@ class NewChapterPollWorker @AssistedInject constructor(
 
         return Result.success(
             Data.Builder()
-                .putInt(KEY_NEW_CHAPTERS, newChapters)
+                .putInt(KEY_NEW_CHAPTERS, newChapterDelta)
                 .putInt(KEY_SKIPPED_BY_REVISION, skippedByRevisionCheck)
                 .build(),
         )
@@ -207,6 +229,15 @@ class NewChapterPollWorker @AssistedInject constructor(
     companion object {
         const val TAG = "poll:new-chapters"
         const val UNIQUE_NAME = "poll:new-chapters"
+
+        /**
+         * Count of genuinely-new chapters detected this poll — the delta
+         * across all polled fictions since the previous poll, NOT the
+         * cumulative NOT_DOWNLOADED backlog. A followed/SUBSCRIBE fiction
+         * never downloads its chapters, so the backlog is the whole
+         * unplayed history; reporting its size made the notification say
+         * "65 new chapters" when one chapter had actually landed.
+         */
         const val KEY_NEW_CHAPTERS = "newChapterCount"
 
         /**
@@ -217,4 +248,59 @@ class NewChapterPollWorker @AssistedInject constructor(
          */
         const val KEY_SKIPPED_BY_REVISION = "skippedByRevision"
     }
+}
+
+/**
+ * What [NewChapterPollWorker] should tell the user about one fiction after a
+ * poll: how many chapters are genuinely new since the previous poll, the
+ * pluralised label, and which chapter a tap should open.
+ *
+ * @param newCount chapters new since the previous poll (the delta).
+ * @param pluralLabel "chapter" when [newCount] is 1, else "chapters".
+ * @param deepLinkChapterId the earliest new chapter to deep-link into, or
+ *   null when there is nothing to announce.
+ * @param shouldNotify true only when there is a real delta worth surfacing —
+ *   false on the first-poll baseline and when no chapter is actually new.
+ */
+data class NewChapterAnnouncement(
+    val newCount: Int,
+    val pluralLabel: String,
+    val deepLinkChapterId: String?,
+    val shouldNotify: Boolean,
+)
+
+/**
+ * Decide what to announce for a fiction from the current un-downloaded
+ * backlog and the chapter ids we held before this poll's refresh.
+ *
+ * The bug this fixes (Royal Road "65 new chapters"): the worker used the
+ * size of [missingChapterIds] — every `downloadState = NOT_DOWNLOADED`
+ * chapter — as the "new" count. A followed/SUBSCRIBE fiction never downloads
+ * its chapters, so that set is the entire unplayed history, and each poll
+ * re-announced the whole backlog. The genuine delta is the missing chapters
+ * whose ids weren't already present before the refresh.
+ *
+ * First-poll baseline: an empty [priorChapterIds] means this is the first
+ * time we've hydrated this fiction's chapters (e.g. a brand-new follow whose
+ * row was added by `followsList` with no chapters yet). Everything looks new
+ * but none of it is news to the user — they just followed it. We return the
+ * delta count for telemetry but set [NewChapterAnnouncement.shouldNotify] to
+ * false so the backlog isn't announced as new.
+ *
+ * Order is preserved from [missingChapterIds] (callers pass it sorted by
+ * chapter index), so the deep-link target is the earliest new chapter.
+ */
+fun newChapterAnnouncement(
+    missingChapterIds: List<String>,
+    priorChapterIds: Set<String>,
+): NewChapterAnnouncement {
+    val newlyAdded = missingChapterIds.filter { it !in priorChapterIds }
+    val isFirstPoll = priorChapterIds.isEmpty()
+    val shouldNotify = newlyAdded.isNotEmpty() && !isFirstPoll
+    return NewChapterAnnouncement(
+        newCount = newlyAdded.size,
+        pluralLabel = if (newlyAdded.size == 1) "chapter" else "chapters",
+        deepLinkChapterId = newlyAdded.firstOrNull(),
+        shouldNotify = shouldNotify,
+    )
 }

--- a/core-data/src/test/kotlin/in/jphe/storyvox/data/work/NewChapterAnnouncementTest.kt
+++ b/core-data/src/test/kotlin/in/jphe/storyvox/data/work/NewChapterAnnouncementTest.kt
@@ -1,0 +1,92 @@
+package `in`.jphe.storyvox.data.work
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * Regression coverage for the Royal Road "65 new chapters" bug.
+ *
+ * [NewChapterPollWorker] used to report the size of the whole
+ * `NOT_DOWNLOADED` backlog as the "new chapters" count. A followed /
+ * SUBSCRIBE fiction never downloads its chapters, so that set is the
+ * fiction's entire unplayed history — every poll re-announced "65 new
+ * chapters" when one chapter had actually landed. [newChapterAnnouncement]
+ * reports the delta since the previous poll instead.
+ */
+class NewChapterAnnouncementTest {
+
+    @Test
+    fun `one new chapter on top of a 64-chapter backlog announces 1, not 65`() {
+        // 64 chapters already known (never downloaded — all NOT_DOWNLOADED),
+        // the source just published chapter 65. The whole backlog of 65 is
+        // "missing"; only the last id is genuinely new.
+        val prior = (1..64).map { "rr:42:$it" }.toSet()
+        val missing = (1..65).map { "rr:42:$it" }
+
+        val a = newChapterAnnouncement(missingChapterIds = missing, priorChapterIds = prior)
+
+        assertEquals(1, a.newCount)
+        assertEquals("chapter", a.pluralLabel)
+        assertEquals("rr:42:65", a.deepLinkChapterId)
+        assertTrue(a.shouldNotify)
+    }
+
+    @Test
+    fun `multiple new chapters announce the delta and pluralise`() {
+        val prior = (1..64).map { "rr:42:$it" }.toSet()
+        val missing = (1..67).map { "rr:42:$it" } // 3 new: 65, 66, 67
+
+        val a = newChapterAnnouncement(missingChapterIds = missing, priorChapterIds = prior)
+
+        assertEquals(3, a.newCount)
+        assertEquals("chapters", a.pluralLabel)
+        // Earliest new chapter is the deep-link target.
+        assertEquals("rr:42:65", a.deepLinkChapterId)
+        assertTrue(a.shouldNotify)
+    }
+
+    @Test
+    fun `first poll baseline does not announce the whole backlog as new`() {
+        // Brand-new follow: followsList added the fiction row, this is the
+        // first poll that hydrated its chapters. Everything looks new but
+        // none of it is news to the user.
+        val prior = emptySet<String>()
+        val missing = (1..65).map { "rr:42:$it" }
+
+        val a = newChapterAnnouncement(missingChapterIds = missing, priorChapterIds = prior)
+
+        assertFalse(a.shouldNotify)
+    }
+
+    @Test
+    fun `no genuinely new chapters does not notify`() {
+        // Poll found the same un-downloaded backlog as before — nothing new.
+        val ids = (1..10).map { "rr:42:$it" }
+
+        val a = newChapterAnnouncement(missingChapterIds = ids, priorChapterIds = ids.toSet())
+
+        assertEquals(0, a.newCount)
+        assertFalse(a.shouldNotify)
+        assertNull(a.deepLinkChapterId)
+    }
+
+    @Test
+    fun `single new chapter from no prior backlog (second poll) announces 1`() {
+        // EAGER/SUBSCRIBE fiction whose backlog was already fully present
+        // (downloaded or otherwise no longer NOT_DOWNLOADED), so `missing`
+        // holds only the freshly-landed chapter. prior was non-empty, so
+        // this is not the first-poll baseline.
+        val prior = (1..64).map { "rr:42:$it" }.toSet()
+        val missing = listOf("rr:42:65")
+
+        val a = newChapterAnnouncement(missingChapterIds = missing, priorChapterIds = prior)
+
+        assertEquals(1, a.newCount)
+        assertEquals("chapter", a.pluralLabel)
+        assertEquals("rr:42:65", a.deepLinkChapterId)
+        assertTrue(a.shouldNotify)
+    }
+}


### PR DESCRIPTION
## Bug

Royal Road new-chapter notifications said **"65 new chapters"** (the cumulative total of all chapters) instead of the actual count of chapters new since the last check — normally **1**.

## Root cause

`NewChapterPollWorker` computed the "new chapters" count as `chapterDao.missingForFiction(fiction.id).size`, where `missingForFiction` is:

```sql
SELECT * FROM chapter WHERE fictionId = :fictionId AND downloadState = 'NOT_DOWNLOADED'
```

A followed / `SUBSCRIBE` fiction (and a source-only follow with no download mode) **never downloads** its chapters — the worker explicitly leaves them `NOT_DOWNLOADED` (`NewChapterPollWorker` SUBSCRIBE branch). So that set is the fiction's *entire unplayed history*, and every poll re-announced the whole backlog as "new" — in both the Inbox feed row and the Android system notification.

`FictionRepository.upsertDetail` preserves `downloadState` per-PK across refreshes, so the backlog never shrinks for subscribe-mode fictions; the count just grows.

## Fix (minimal, no DB migration)

- Snapshot the chapter ids held **before** `refreshDetail` mutates the chapter table.
- The genuine delta = `missing` chapters whose ids were **not** in that prior snapshot.
- The user-facing count, plural label, and deep-link target now come from that delta. `missing` still drives EAGER auto-download (correctly downloads the whole un-downloaded backlog).
- **First-poll baseline guard**: an empty prior snapshot means this is the first time we've hydrated this fiction's chapters (e.g. a brand-new follow whose row was added by `followsList` with no chapters yet). Everything looks new but isn't news to the user — record silently, don't announce the backlog.
- Pluralisation kept via the existing "1 new chapter" / "N new chapters" idiom.

The decision is extracted into a pure `newChapterAnnouncement(missingChapterIds, priorChapterIds)` so it's unit-testable without Room/WorkManager.

## Tests

`NewChapterAnnouncementTest` (5 cases, all green):
- 64 prior + 1 new of 65 missing → `newCount = 1`, `"chapter"`, deep-links the new chapter, `shouldNotify = true`
- 3 new → `newCount = 3`, `"chapters"`, deep-links the earliest new chapter
- first poll (empty prior, 65 missing) → `shouldNotify = false` (no spurious "65 new")
- nothing new (prior == missing) → `newCount = 0`, no notify, null deep-link
- single new with non-empty prior (second poll) → `newCount = 1`

`./gradlew :core-data:testDebugUnitTest` — BUILD SUCCESSFUL.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * New chapter notifications now accurately report only newly added chapters instead of re-announcing the entire backlog
  * Fixed first-poll baseline to prevent pre-existing chapters from being announced as new updates
  * Improved notification accuracy with proper chapter counts, pluralization, and deep-link targeting

<!-- end of auto-generated comment: release notes by coderabbit.ai -->