### PR TITLE
fix(test): restore :app unit-test compile — thread pdfConfig into SettingsRepository fixtures

### DIFF
--- a/app/src/test/kotlin/in/jphe/storyvox/data/SettingsRepositoryBufferTest.kt
+++ b/app/src/test/kotlin/in/jphe/storyvox/data/SettingsRepositoryBufferTest.kt
@@ -64,6 +64,7 @@ class SettingsRepositoryBufferTest {
             teamsAuth = fakeTeamsAuth(),
             rssConfig = makeFakeRssConfig(tempFolder.newFolder("rss_ds"), scope),
             epubConfig = makeFakeEpubConfig(tempFolder.newFolder("epub_ds"), scope),
+            pdfConfig = makeFakePdfConfig(tempFolder.newFolder("pdf_ds"), scope),
             outlineConfig = makeFakeOutlineConfig(tempFolder.newFolder("outline_ds"), scope),
             wikipediaConfig = makeFakeWikipediaConfig(tempFolder.newFolder("wiki_ds"), scope),
             notionConfig = makeFakeNotionConfig(tempFolder.newFolder("notion_ds"), scope),

--- a/app/src/test/kotlin/in/jphe/storyvox/data/SettingsRepositoryCoverStyleTest.kt
+++ b/app/src/test/kotlin/in/jphe/storyvox/data/SettingsRepositoryCoverStyleTest.kt
@@ -71,6 +71,7 @@ class SettingsRepositoryCoverStyleTest {
             teamsAuth = fakeTeamsAuth(),
             rssConfig = makeFakeRssConfig(tempFolder.newFolder("rss_ds"), scope),
             epubConfig = makeFakeEpubConfig(tempFolder.newFolder("epub_ds"), scope),
+            pdfConfig = makeFakePdfConfig(tempFolder.newFolder("pdf_ds"), scope),
             outlineConfig = makeFakeOutlineConfig(tempFolder.newFolder("outline_ds"), scope),
             wikipediaConfig = makeFakeWikipediaConfig(tempFolder.newFolder("wiki_ds"), scope),
             notionConfig = makeFakeNotionConfig(tempFolder.newFolder("notion_ds"), scope),

--- a/app/src/test/kotlin/in/jphe/storyvox/data/SettingsRepositoryFavoriteSourcesTest.kt
+++ b/app/src/test/kotlin/in/jphe/storyvox/data/SettingsRepositoryFavoriteSourcesTest.kt
@@ -60,6 +60,7 @@ class SettingsRepositoryFavoriteSourcesTest {
             teamsAuth = fakeTeamsAuth(),
             rssConfig = makeFakeRssConfig(tempFolder.newFolder("rss_ds"), scope),
             epubConfig = makeFakeEpubConfig(tempFolder.newFolder("epub_ds"), scope),
+            pdfConfig = makeFakePdfConfig(tempFolder.newFolder("pdf_ds"), scope),
             outlineConfig = makeFakeOutlineConfig(tempFolder.newFolder("outline_ds"), scope),
             wikipediaConfig = makeFakeWikipediaConfig(tempFolder.newFolder("wiki_ds"), scope),
             notionConfig = makeFakeNotionConfig(tempFolder.newFolder("notion_ds"), scope),

--- a/app/src/test/kotlin/in/jphe/storyvox/data/SettingsRepositoryFieldStampsTest.kt
+++ b/app/src/test/kotlin/in/jphe/storyvox/data/SettingsRepositoryFieldStampsTest.kt
@@ -75,6 +75,7 @@ class SettingsRepositoryFieldStampsTest {
             teamsAuth = fakeTeamsAuth(),
             rssConfig = makeFakeRssConfig(tempFolder.newFolder("rss_ds"), scope),
             epubConfig = makeFakeEpubConfig(tempFolder.newFolder("epub_ds"), scope),
+            pdfConfig = makeFakePdfConfig(tempFolder.newFolder("pdf_ds"), scope),
             outlineConfig = makeFakeOutlineConfig(tempFolder.newFolder("outline_ds"), scope),
             wikipediaConfig = makeFakeWikipediaConfig(tempFolder.newFolder("wiki_ds"), scope),
             notionConfig = makeFakeNotionConfig(tempFolder.newFolder("notion_ds"), scope),

--- a/app/src/test/kotlin/in/jphe/storyvox/data/SettingsRepositoryGitHubScopeTest.kt
+++ b/app/src/test/kotlin/in/jphe/storyvox/data/SettingsRepositoryGitHubScopeTest.kt
@@ -57,6 +57,7 @@ class SettingsRepositoryGitHubScopeTest {
             teamsAuth = fakeTeamsAuth(),
             rssConfig = makeFakeRssConfig(tempFolder.newFolder("rss_ds"), scope),
             epubConfig = makeFakeEpubConfig(tempFolder.newFolder("epub_ds"), scope),
+            pdfConfig = makeFakePdfConfig(tempFolder.newFolder("pdf_ds"), scope),
             outlineConfig = makeFakeOutlineConfig(tempFolder.newFolder("outline_ds"), scope),
             wikipediaConfig = makeFakeWikipediaConfig(tempFolder.newFolder("wiki_ds"), scope),
             notionConfig = makeFakeNotionConfig(tempFolder.newFolder("notion_ds"), scope),

--- a/app/src/test/kotlin/in/jphe/storyvox/data/SettingsRepositoryModesTest.kt
+++ b/app/src/test/kotlin/in/jphe/storyvox/data/SettingsRepositoryModesTest.kt
@@ -60,6 +60,7 @@ class SettingsRepositoryModesTest {
             teamsAuth = fakeTeamsAuth(),
             rssConfig = makeFakeRssConfig(tempFolder.newFolder("rss_ds"), scope),
             epubConfig = makeFakeEpubConfig(tempFolder.newFolder("epub_ds"), scope),
+            pdfConfig = makeFakePdfConfig(tempFolder.newFolder("pdf_ds"), scope),
             outlineConfig = makeFakeOutlineConfig(tempFolder.newFolder("outline_ds"), scope),
             wikipediaConfig = makeFakeWikipediaConfig(tempFolder.newFolder("wiki_ds"), scope),
             notionConfig = makeFakeNotionConfig(tempFolder.newFolder("notion_ds"), scope),

--- a/app/src/test/kotlin/in/jphe/storyvox/data/SettingsRepositoryPitchTest.kt
+++ b/app/src/test/kotlin/in/jphe/storyvox/data/SettingsRepositoryPitchTest.kt
@@ -67,6 +67,7 @@ class SettingsRepositoryPitchTest {
             teamsAuth = fakeTeamsAuth(),
             rssConfig = makeFakeRssConfig(tempFolder.newFolder("rss_ds"), scope),
             epubConfig = makeFakeEpubConfig(tempFolder.newFolder("epub_ds"), scope),
+            pdfConfig = makeFakePdfConfig(tempFolder.newFolder("pdf_ds"), scope),
             outlineConfig = makeFakeOutlineConfig(tempFolder.newFolder("outline_ds"), scope),
             wikipediaConfig = makeFakeWikipediaConfig(tempFolder.newFolder("wiki_ds"), scope),
             notionConfig = makeFakeNotionConfig(tempFolder.newFolder("notion_ds"), scope),

--- a/app/src/test/kotlin/in/jphe/storyvox/data/SettingsRepositoryPronunciationDictTest.kt
+++ b/app/src/test/kotlin/in/jphe/storyvox/data/SettingsRepositoryPronunciationDictTest.kt
@@ -65,6 +65,7 @@ class SettingsRepositoryPronunciationDictTest {
             teamsAuth = fakeTeamsAuth(),
             rssConfig = makeFakeRssConfig(tempFolder.newFolder("rss_ds"), scope),
             epubConfig = makeFakeEpubConfig(tempFolder.newFolder("epub_ds"), scope),
+            pdfConfig = makeFakePdfConfig(tempFolder.newFolder("pdf_ds"), scope),
             outlineConfig = makeFakeOutlineConfig(tempFolder.newFolder("outline_ds"), scope),
             wikipediaConfig = makeFakeWikipediaConfig(tempFolder.newFolder("wiki_ds"), scope),
             notionConfig = makeFakeNotionConfig(tempFolder.newFolder("notion_ds"), scope),

--- a/app/src/test/kotlin/in/jphe/storyvox/data/SettingsRepositoryPunctuationPauseTest.kt
+++ b/app/src/test/kotlin/in/jphe/storyvox/data/SettingsRepositoryPunctuationPauseTest.kt
@@ -72,6 +72,7 @@ class SettingsRepositoryPunctuationPauseTest {
             teamsAuth = fakeTeamsAuth(),
             rssConfig = makeFakeRssConfig(tempFolder.newFolder("rss_ds"), scope),
             epubConfig = makeFakeEpubConfig(tempFolder.newFolder("epub_ds"), scope),
+            pdfConfig = makeFakePdfConfig(tempFolder.newFolder("pdf_ds"), scope),
             outlineConfig = makeFakeOutlineConfig(tempFolder.newFolder("outline_ds"), scope),
             wikipediaConfig = makeFakeWikipediaConfig(tempFolder.newFolder("wiki_ds"), scope),
             notionConfig = makeFakeNotionConfig(tempFolder.newFolder("notion_ds"), scope),

--- a/app/src/test/kotlin/in/jphe/storyvox/data/SettingsRepositoryPushOnWriteTest.kt
+++ b/app/src/test/kotlin/in/jphe/storyvox/data/SettingsRepositoryPushOnWriteTest.kt
@@ -89,6 +89,7 @@ class SettingsRepositoryPushOnWriteTest {
             teamsAuth = fakeTeamsAuth(),
             rssConfig = makeFakeRssConfig(tempFolder.newFolder("rss_ds"), scope),
             epubConfig = makeFakeEpubConfig(tempFolder.newFolder("epub_ds"), scope),
+            pdfConfig = makeFakePdfConfig(tempFolder.newFolder("pdf_ds"), scope),
             outlineConfig = makeFakeOutlineConfig(tempFolder.newFolder("outline_ds"), scope),
             wikipediaConfig = makeFakeWikipediaConfig(tempFolder.newFolder("wiki_ds"), scope),
             notionConfig = makeFakeNotionConfig(tempFolder.newFolder("notion_ds"), scope),

--- a/app/src/test/kotlin/in/jphe/storyvox/data/SettingsRepositorySourcePluginsTest.kt
+++ b/app/src/test/kotlin/in/jphe/storyvox/data/SettingsRepositorySourcePluginsTest.kt
@@ -66,6 +66,7 @@ class SettingsRepositorySourcePluginsTest {
             teamsAuth = fakeTeamsAuth(),
             rssConfig = makeFakeRssConfig(tempFolder.newFolder("rss_ds"), scope),
             epubConfig = makeFakeEpubConfig(tempFolder.newFolder("epub_ds"), scope),
+            pdfConfig = makeFakePdfConfig(tempFolder.newFolder("pdf_ds"), scope),
             outlineConfig = makeFakeOutlineConfig(tempFolder.newFolder("outline_ds"), scope),
             wikipediaConfig = makeFakeWikipediaConfig(tempFolder.newFolder("wiki_ds"), scope),
             notionConfig = makeFakeNotionConfig(tempFolder.newFolder("notion_ds"), scope),

--- a/app/src/test/kotlin/in/jphe/storyvox/data/SettingsRepositoryStampRaceTest.kt
+++ b/app/src/test/kotlin/in/jphe/storyvox/data/SettingsRepositoryStampRaceTest.kt
@@ -140,6 +140,7 @@ class SettingsRepositoryStampRaceTest {
             teamsAuth = fakeTeamsAuth(),
             rssConfig = makeFakeRssConfig(tempFolder.newFolder("rss_ds"), scope),
             epubConfig = makeFakeEpubConfig(tempFolder.newFolder("epub_ds"), scope),
+            pdfConfig = makeFakePdfConfig(tempFolder.newFolder("pdf_ds"), scope),
             outlineConfig = makeFakeOutlineConfig(tempFolder.newFolder("outline_ds"), scope),
             wikipediaConfig = makeFakeWikipediaConfig(tempFolder.newFolder("wiki_ds"), scope),
             notionConfig = makeFakeNotionConfig(tempFolder.newFolder("notion_ds"), scope),

--- a/app/src/test/kotlin/in/jphe/storyvox/data/SettingsRepositorySweeperPrefsTest.kt
+++ b/app/src/test/kotlin/in/jphe/storyvox/data/SettingsRepositorySweeperPrefsTest.kt
@@ -64,6 +64,7 @@ class SettingsRepositorySweeperPrefsTest {
             teamsAuth = fakeTeamsAuth(),
             rssConfig = makeFakeRssConfig(tempFolder.newFolder("rss_ds"), scope),
             epubConfig = makeFakeEpubConfig(tempFolder.newFolder("epub_ds"), scope),
+            pdfConfig = makeFakePdfConfig(tempFolder.newFolder("pdf_ds"), scope),
             outlineConfig = makeFakeOutlineConfig(tempFolder.newFolder("outline_ds"), scope),
             wikipediaConfig = makeFakeWikipediaConfig(tempFolder.newFolder("wiki_ds"), scope),
             notionConfig = makeFakeNotionConfig(tempFolder.newFolder("notion_ds"), scope),

--- a/app/src/test/kotlin/in/jphe/storyvox/data/SettingsRepositorySyncSnapshotTest.kt
+++ b/app/src/test/kotlin/in/jphe/storyvox/data/SettingsRepositorySyncSnapshotTest.kt
@@ -72,6 +72,7 @@ class SettingsRepositorySyncSnapshotTest {
             teamsAuth = fakeTeamsAuth(),
             rssConfig = makeFakeRssConfig(tempFolder.newFolder("rss_ds"), scope),
             epubConfig = makeFakeEpubConfig(tempFolder.newFolder("epub_ds"), scope),
+            pdfConfig = makeFakePdfConfig(tempFolder.newFolder("pdf_ds"), scope),
             outlineConfig = makeFakeOutlineConfig(tempFolder.newFolder("outline_ds"), scope),
             wikipediaConfig = makeFakeWikipediaConfig(tempFolder.newFolder("wiki_ds"), scope),
             notionConfig = makeFakeNotionConfig(tempFolder.newFolder("notion_ds"), scope),

--- a/app/src/test/kotlin/in/jphe/storyvox/data/SettingsRepositoryTestSupport.kt
+++ b/app/src/test/kotlin/in/jphe/storyvox/data/SettingsRepositoryTestSupport.kt
@@ -132,6 +132,22 @@ internal fun makeFakeEpubConfig(
     return EpubConfigImpl.forTesting(epubStore)
 }
 
+/** Real [PdfConfigImpl] over a temp DataStore (#996). Mirrors
+ *  [makeFakeEpubConfig] — the settings tests don't exercise SAF or PDF
+ *  enumeration, just need the dependency to satisfy the constructor.
+ *  [PdfConfigImpl.forTesting] supplies a no-op enumerator, so no SAF
+ *  context is touched. */
+internal fun makeFakePdfConfig(
+    dir: File,
+    scope: CoroutineScope,
+): PdfConfigImpl {
+    val pdfStore = PreferenceDataStoreFactory.create(
+        scope = scope,
+        produceFile = { File(dir, "storyvox_pdf.preferences_pb") },
+    )
+    return PdfConfigImpl.forTesting(pdfStore)
+}
+
 /** Real [OutlineConfigImpl] over a temp DataStore + fake secrets
  *  (#245). Settings tests don't exercise Outline state — the
  *  signature requires the dep, this satisfies it. */

--- a/app/src/test/kotlin/in/jphe/storyvox/data/SettingsRepositoryVoiceLexiconLangTest.kt
+++ b/app/src/test/kotlin/in/jphe/storyvox/data/SettingsRepositoryVoiceLexiconLangTest.kt
@@ -79,6 +79,7 @@ class SettingsRepositoryVoiceLexiconLangTest {
             teamsAuth = fakeTeamsAuth(),
             rssConfig = makeFakeRssConfig(tempFolder.newFolder("rss_ds"), scope),
             epubConfig = makeFakeEpubConfig(tempFolder.newFolder("epub_ds"), scope),
+            pdfConfig = makeFakePdfConfig(tempFolder.newFolder("pdf_ds"), scope),
             outlineConfig = makeFakeOutlineConfig(tempFolder.newFolder("outline_ds"), scope),
             wikipediaConfig = makeFakeWikipediaConfig(tempFolder.newFolder("wiki_ds"), scope),
             notionConfig = makeFakeNotionConfig(tempFolder.newFolder("notion_ds"), scope),

--- a/app/src/test/kotlin/in/jphe/storyvox/data/SettingsRepositoryVoiceSteadyTest.kt
+++ b/app/src/test/kotlin/in/jphe/storyvox/data/SettingsRepositoryVoiceSteadyTest.kt
@@ -63,6 +63,7 @@ class SettingsRepositoryVoiceSteadyTest {
             teamsAuth = fakeTeamsAuth(),
             rssConfig = makeFakeRssConfig(tempFolder.newFolder("rss_ds"), scope),
             epubConfig = makeFakeEpubConfig(tempFolder.newFolder("epub_ds"), scope),
+            pdfConfig = makeFakePdfConfig(tempFolder.newFolder("pdf_ds"), scope),
             outlineConfig = makeFakeOutlineConfig(tempFolder.newFolder("outline_ds"), scope),
             wikipediaConfig = makeFakeWikipediaConfig(tempFolder.newFolder("wiki_ds"), scope),
             notionConfig = makeFakeNotionConfig(tempFolder.newFolder("notion_ds"), scope),


### PR DESCRIPTION
## Problem

The `:app` unit-test source set has not compiled since #996 (PDF import). That PR added a **required** `pdfConfig: PdfConfigImpl` parameter to both `SettingsRepositoryUiImpl` constructors (slotted between `epubConfig` and `outlineConfig`) but never updated the test fixtures.

Result: **48 compile errors** — "No value passed for parameter 'pdfConfig'" — across **16** `SettingsRepository*Test.kt` files, each of which constructs the repo directly via the primary (test-seam) constructor with named args.

The required CI gate (`:app:assembleRelease`) **skips the test source set**, so #996 merged green — but `:app:testDebugUnitTest` could not compile, meaning **zero `:app` unit-test coverage** until now.

## Fix (test-only)

Matches the existing source-config test seam rather than adding a production default:

- `pdfConfig` is a required injected collaborator, exactly like its siblings (`rssConfig`, `epubConfig`, `outlineConfig`, `wikipediaConfig`, `notionConfig`, `discordConfig`, `telegramConfig`) — **none** of which carry defaults. A default on `pdfConfig` alone would be an anomaly and could silently mask real production-wiring gaps. The `#996` author simply forgot to extend the established `makeFake*Config` seam.
- **Add** `makeFakePdfConfig(dir, scope)` to `SettingsRepositoryTestSupport.kt` — mirrors `makeFakeEpubConfig`; uses `PdfConfigImpl.forTesting(store)` (no-op enumerator) over a real temp DataStore.
- **Thread** `pdfConfig = makeFakePdfConfig(...)` into all 16 fixtures, in constructor order (`epub → pdf → outline`).

No production code touched — the diff is confined to `app/src/test/`.

## Verification

- `:app:compileDebugUnitTestKotlin` → **BUILD SUCCESSFUL** (0 `pdfConfig` errors)
- `:app:testDebugUnitTest` → **BUILD SUCCESSFUL** — **202 tests, 0 failures, 0 errors, 0 skipped** (106 across the 16 previously-broken `SettingsRepository*` classes)
- (sanity) `:core-sync:compileDebugUnitTestKotlin` → BUILD SUCCESSFUL — the previously-known duplicate-override breakage is no longer present on this main.

Refs #996.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Enhanced test infrastructure to support PDF configuration persistence across settings repository tests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->