### PR TITLE
feat: magical v1.1 milestone + hidden candle egg + book-streak light-motes (+ candela release-APK naming)

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -92,7 +92,7 @@ jobs:
         # Only runs on tag builds — for PR / main pushes we just
         # verify the build compiles and stop. The local-build path
         # in `app/build.gradle.kts` (applicationVariants.all) already
-        # renames `app-release.apk` -> `storyvox-v<versionName>.apk`
+        # renames `app-release.apk` -> `candela-v<versionName>.apk`
         # at AGP-output time. We still re-cp here using the tag name
         # so the published asset uses the GIT TAG (which may diverge
         # from versionName in pathological cases — historical sanity
@@ -104,11 +104,11 @@ jobs:
           OUT_DIR=app/build/outputs/apk/release
           # Prefer the AGP-renamed file; fall back to app-release.apk
           # if the variant rename ever stops firing.
-          SRC=$(ls "$OUT_DIR"/storyvox-v*.apk 2>/dev/null | head -1)
+          SRC=$(ls "$OUT_DIR"/candela-v*.apk 2>/dev/null | head -1)
           if [ -z "$SRC" ]; then
             SRC="$OUT_DIR/app-release.apk"
           fi
-          DST="$OUT_DIR/storyvox-${TAG}.apk"
+          DST="$OUT_DIR/candela-${TAG}.apk"
           # `cp file file` errors with exit 1 — happens when AGP's
           # applicationVariants rename already produced the
           # tag-named file. Skip the copy in that case.
@@ -136,4 +136,4 @@ jobs:
             Release APK build for `${{ github.ref_name }}`.
 
             > Signed with the project's checked-in keystore (stable since v0.4.15). Sideload-only distribution today.
-          files: app/build/outputs/apk/release/storyvox-${{ github.ref_name }}.apk
+          files: app/build/outputs/apk/release/candela-${{ github.ref_name }}.apk

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -476,7 +476,7 @@ androidComponents {
             val suffix = if (variant.name == "benchmark") "-benchmark" else ""
             variant.outputs.forEach { output ->
                 output.outputFileName.set(
-                    "storyvox-v${android.defaultConfig.versionName}$suffix.apk"
+                    "candela-v${android.defaultConfig.versionName}$suffix.apk"
                 )
             }
         }

--- a/app/src/main/kotlin/in/jphe/storyvox/data/SettingsRepositoryUiImpl.kt
+++ b/app/src/main/kotlin/in/jphe/storyvox/data/SettingsRepositoryUiImpl.kt
@@ -756,6 +756,25 @@ private object Keys {
      *  dialog. */
     val V0500_CONFETTI_SHOWN = booleanPreferencesKey("pref_v0500_confetti_shown")
 
+    // ── v1.1.0 "read it your way" milestone (Luna) ─────────────────
+    /** One-time gate for the v1.1 "ignite" milestone dialog. Same
+     *  posture as [V0500_MILESTONE_SEEN] but its own key — per
+     *  Milestone.kt's kdoc, each milestone gets independent keys so a
+     *  user who dismissed the 0.5.00 card still sees the 1.1 one. */
+    val V110_MILESTONE_SEEN = booleanPreferencesKey("pref_v110_milestone_seen")
+    /** One-time gate for the v1.1 chapter-complete LightMotes burst.
+     *  Independent from [V110_MILESTONE_SEEN] for the same reason the
+     *  v0.5.00 pair is split. */
+    val V110_CONFETTI_SHOWN = booleanPreferencesKey("pref_v110_confetti_shown")
+
+    /** Lifetime count of books the user has finished, device-local.
+     *  Drives the streak-tier celebrations (1/5/10/25 "books lit").
+     *  Not synced — a "books *you* have finished on this device" feel
+     *  is intentionally per-device, and syncing would double-fire the
+     *  celebration across devices. Monotonic; only ever incremented on
+     *  a natural end-of-book. */
+    val BOOKS_COMPLETED_COUNT = intPreferencesKey("pref_books_completed_count")
+
     /** Issue #517 — gate for the TechEmpower Home onboarding state.
      *  Flips to true the first time the user opens the dedicated
      *  TechEmpower Home screen (via the brass-edged Library hero
@@ -2848,6 +2867,11 @@ class SettingsRepositoryUiImpl(
                 qualifies = `in`.jphe.storyvox.sigil.Milestone.isV0500OrLater,
                 dialogSeen = prefs[Keys.V0500_MILESTONE_SEEN] ?: false,
                 confettiShown = prefs[Keys.V0500_CONFETTI_SHOWN] ?: false,
+                // v1.1.0 "read it your way" milestone (Luna).
+                v110Qualifies = `in`.jphe.storyvox.sigil.Milestone.isV110OrLater,
+                v110DialogSeen = prefs[Keys.V110_MILESTONE_SEEN] ?: false,
+                v110ConfettiShown = prefs[Keys.V110_CONFETTI_SHOWN] ?: false,
+                booksCompleted = prefs[Keys.BOOKS_COMPLETED_COUNT] ?: 0,
             )
         }
 
@@ -2857,6 +2881,35 @@ class SettingsRepositoryUiImpl(
 
     override suspend fun markMilestoneConfettiShown() {
         store.edit { it[Keys.V0500_CONFETTI_SHOWN] = true }
+    }
+
+    // ── v1.1.0 "read it your way" milestone (Luna) ─────────────────
+    override suspend fun markV110MilestoneDialogSeen() {
+        store.edit { it[Keys.V110_MILESTONE_SEEN] = true }
+    }
+
+    override suspend fun markV110ConfettiShown() {
+        store.edit { it[Keys.V110_CONFETTI_SHOWN] = true }
+    }
+
+    /**
+     * Single serialized read-modify-write: increment the completed-book
+     * counter and, in the same `edit` transaction, decide whether the
+     * increment crossed a streak tier. DataStore's `edit` runs its
+     * block under the store's own mutex, so two concurrent
+     * end-of-book signals are serialized — neither double-counts nor
+     * sees a stale `previous`. We capture the crossed tier in a holder
+     * because `edit` returns the new Preferences, not our derived value.
+     */
+    override suspend fun recordBookCompletedAndMilestone(): Int? {
+        var crossed: Int? = null
+        store.edit { prefs ->
+            val previous = prefs[Keys.BOOKS_COMPLETED_COUNT] ?: 0
+            val next = previous + 1
+            prefs[Keys.BOOKS_COMPLETED_COUNT] = next
+            crossed = `in`.jphe.storyvox.ui.component.bookStreakMilestoneCrossed(previous, next)
+        }
+        return crossed
     }
 
     // ── Issue #383 — Inbox per-source mute toggles ─────────────────

--- a/app/src/main/kotlin/in/jphe/storyvox/navigation/StoryvoxNavHost.kt
+++ b/app/src/main/kotlin/in/jphe/storyvox/navigation/StoryvoxNavHost.kt
@@ -395,6 +395,15 @@ private fun MilestoneDialogHost(
             onDismiss = viewModel::dismiss,
         )
     }
+    // v1.1.0 "read it your way" ignite milestone (Luna). Independent
+    // gate from the v0.5.00 card; the two never co-fire (disjoint
+    // version windows) but each has its own seen-flag.
+    val showV110 by viewModel.showV110Dialog.collectAsStateWithLifecycle()
+    if (showV110) {
+        `in`.jphe.storyvox.ui.component.V110MilestoneDialog(
+            onDismiss = viewModel::dismissV110,
+        )
+    }
 }
 
 @Composable

--- a/app/src/main/kotlin/in/jphe/storyvox/sigil/Milestone.kt
+++ b/app/src/main/kotlin/in/jphe/storyvox/sigil/Milestone.kt
@@ -60,6 +60,48 @@ object Milestone {
             compareTriple(triple, V0500_WINDOW_END) <= 0
     }
 
+    // ── v1.1.0 "read it your way" milestone (Luna) ─────────────────
+    /**
+     * Second milestone gate — the "read it your way / bring your own"
+     * release. v1.1.0 landed a wave of reader work (paragraph nav,
+     * per-word highlight, dyslexia typography, reading themes, focused
+     * reading, in-text search) plus a fleet of new import sources.
+     *
+     * Per the [V0500] kdoc above, this is a *separate* helper with its
+     * own DataStore keys (`pref_v110_milestone_seen` /
+     * `pref_v110_confetti_shown`) and hand-tuned copy — we never reuse
+     * the v0.5.00 gate across versions.
+     *
+     * Window is **[1.1.0, 1.2.0)** — closed-open. 1.2.0 itself is OUT:
+     * a fresh install on 1.2.x never lived through the 1.1 crossing,
+     * so the "Candela 1.1 — read it your way" dialog would read as a
+     * dead placeholder (the same reasoning #439 applied to the v0.5.00
+     * window). Same fail-closed parse: any unparseable input → false.
+     */
+    private val V110 = Triple(1, 1, 0)
+
+    /** First version that no longer qualifies (exclusive upper bound). */
+    private val V110_WINDOW_END_EXCLUSIVE = Triple(1, 2, 0)
+
+    /** True when the current build's [BuildConfig.VERSION_NAME] falls
+     *  inside the v1.1.0 celebration window. Process-lifetime constant. */
+    val isV110OrLater: Boolean by lazy {
+        qualifiesV110(BuildConfig.VERSION_NAME)
+    }
+
+    /** Visible for testing — parse + compare without touching
+     *  BuildConfig. Returns false on any parse failure OR outside the
+     *  half-open [1.1.0, 1.2.0) window. */
+    internal fun qualifiesV110(versionName: String): Boolean {
+        val parts = versionName.split('.', '-', '+')
+        val major = parts.getOrNull(0)?.toIntOrNull() ?: return false
+        val minor = parts.getOrNull(1)?.toIntOrNull() ?: 0
+        val patch = parts.getOrNull(2)?.toIntOrNull() ?: 0
+        val triple = Triple(major, minor, patch)
+        return compareTriple(triple, V110) >= 0 &&
+            compareTriple(triple, V110_WINDOW_END_EXCLUSIVE) < 0
+    }
+
     private fun compareTriple(a: Triple<Int, Int, Int>, b: Triple<Int, Int, Int>): Int {
         if (a.first != b.first) return a.first.compareTo(b.first)
         if (a.second != b.second) return a.second.compareTo(b.second)

--- a/app/src/test/kotlin/in/jphe/storyvox/sigil/MilestoneTest.kt
+++ b/app/src/test/kotlin/in/jphe/storyvox/sigil/MilestoneTest.kt
@@ -64,4 +64,63 @@ class MilestoneTest {
         assertTrue(Milestone.qualifies("0.5.0+abcdef"))
         assertFalse(Milestone.qualifies("0.4.97-rc1"))
     }
+
+    // ── v1.1.0 "read it your way" milestone (Luna) ─────────────────
+    // A second, independent celebration window. Per Milestone.kt's
+    // kdoc, each milestone gets its own helper + its own DataStore
+    // keys; the copy is hand-tuned per release. Window: [1.1.0, 1.2.0)
+    // so the celebration retires once 1.2.x ships (fresh installers
+    // past the window never lived through the crossing).
+
+    @Test fun `qualifiesV110 returns true for exact v1_1_0`() {
+        assertTrue(Milestone.qualifiesV110("1.1.0"))
+    }
+
+    @Test fun `qualifiesV110 returns true for patch inside the window`() {
+        assertTrue(Milestone.qualifiesV110("1.1.1"))
+        assertTrue(Milestone.qualifiesV110("1.1.9"))
+        assertTrue(Milestone.qualifiesV110("1.1.99"))
+    }
+
+    @Test fun `qualifiesV110 returns false at and past the window end`() {
+        // Window end is the 1.2.0 boundary — 1.2.0 itself is OUT (a
+        // fresh 1.2 install didn't cross 1.1) and everything above.
+        assertFalse(Milestone.qualifiesV110("1.2.0"))
+        assertFalse(Milestone.qualifiesV110("1.2.5"))
+        assertFalse(Milestone.qualifiesV110("1.3.0"))
+        assertFalse(Milestone.qualifiesV110("2.0.0"))
+    }
+
+    @Test fun `qualifiesV110 returns false for builds below v1_1_0`() {
+        assertFalse(Milestone.qualifiesV110("1.0.0"))
+        assertFalse(Milestone.qualifiesV110("1.0.3"))
+        assertFalse(Milestone.qualifiesV110("0.5.0"))
+        assertFalse(Milestone.qualifiesV110("0.9.99"))
+    }
+
+    @Test fun `qualifiesV110 does not collide with the v0_5_00 window`() {
+        // The two windows are disjoint: nothing in the 0.5 window
+        // qualifies for V110, and nothing in the V110 window qualifies
+        // for 0.5.00.
+        assertFalse(Milestone.qualifiesV110("0.5.0"))
+        assertFalse(Milestone.qualifies("1.1.0"))
+    }
+
+    @Test fun `qualifiesV110 tolerates two-part version names`() {
+        assertTrue(Milestone.qualifiesV110("1.1"))
+        assertFalse(Milestone.qualifiesV110("1.0"))
+        assertFalse(Milestone.qualifiesV110("1.2"))
+    }
+
+    @Test fun `qualifiesV110 fails closed on garbage input`() {
+        assertFalse(Milestone.qualifiesV110(""))
+        assertFalse(Milestone.qualifiesV110("dev"))
+        assertFalse(Milestone.qualifiesV110("foo.bar.baz"))
+    }
+
+    @Test fun `qualifiesV110 strips pre-release suffixes`() {
+        assertTrue(Milestone.qualifiesV110("1.1.0-rc1"))
+        assertTrue(Milestone.qualifiesV110("1.1.0+abcdef"))
+        assertFalse(Milestone.qualifiesV110("1.0.3-rc1"))
+    }
 }

--- a/core-ui/src/main/kotlin/in/jphe/storyvox/ui/component/BookStreak.kt
+++ b/core-ui/src/main/kotlin/in/jphe/storyvox/ui/component/BookStreak.kt
@@ -1,0 +1,33 @@
+package `in`.jphe.storyvox.ui.component
+
+/**
+ * Luna (v1.1.0) — book-completion streak celebration tiers.
+ *
+ * Finishing a book ticks a device-local DataStore counter. We light a
+ * [LightMotes] celebration + an "N books lit" badge only at a sparse
+ * set of tiers so the moment stays special — every-book confetti would
+ * cheapen it. The tiers are deliberately front-loaded (1, 5) then
+ * spaced out (10, 25): the first book is worth marking, and the rhythm
+ * widens as the habit forms.
+ *
+ * The "did this increment cross a tier" decision is pure logic so it's
+ * JVM-testable (the counter itself lives behind the repo seam). See
+ * [BookStreakTest].
+ */
+val bookStreakTiers: List<Int> = listOf(1, 5, 10, 25)
+
+/**
+ * Returns the highest streak tier crossed by moving the completed-book
+ * count from [previous] to [new], or null if no tier was crossed.
+ *
+ * The range is half-open `(previous, new]`: a tier counts as "crossed"
+ * when the new count reaches or passes it AND the old count hadn't yet.
+ * When a single delta vaults multiple tiers (e.g. a cross-device sync
+ * backfill), we return only the *highest* tier reached — one
+ * celebration for the top milestone, never a backlog of three. A
+ * no-op or backward delta returns null.
+ */
+fun bookStreakMilestoneCrossed(previous: Int, new: Int): Int? {
+    if (new <= previous) return null
+    return bookStreakTiers.lastOrNull { tier -> tier in (previous + 1)..new }
+}

--- a/core-ui/src/main/kotlin/in/jphe/storyvox/ui/component/BooksLitBadgeOverlay.kt
+++ b/core-ui/src/main/kotlin/in/jphe/storyvox/ui/component/BooksLitBadgeOverlay.kt
@@ -1,0 +1,159 @@
+package `in`.jphe.storyvox.ui.component
+
+import androidx.compose.animation.AnimatedVisibility
+import androidx.compose.animation.fadeIn
+import androidx.compose.animation.fadeOut
+import androidx.compose.animation.scaleIn
+import androidx.compose.foundation.BorderStroke
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.semantics.contentDescription
+import androidx.compose.ui.semantics.liveRegion
+import androidx.compose.ui.semantics.LiveRegionMode
+import androidx.compose.ui.semantics.semantics
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import `in`.jphe.storyvox.ui.theme.BrassRamp
+import `in`.jphe.storyvox.ui.theme.LibraryNocturneTheme
+import `in`.jphe.storyvox.ui.theme.LocalReducedMotion
+import `in`.jphe.storyvox.ui.theme.LocalSpacing
+
+/**
+ * Candela (v1.1.0) — the book-streak celebration overlay: a
+ * [LightMotes] burst with a centered "N books lit" glow-badge that
+ * fades in with the motes and clears when they finish.
+ *
+ * Shown when the user crosses a streak tier (1/5/10/25 finished books).
+ * The badge copy reads "N books lit" — the candle metaphor: each book
+ * finished is another flame kept. [onFinished] fires when the [LightMotes]
+ * burst completes (or immediately under reduced motion), which the host
+ * uses to clear the overlay.
+ *
+ * The badge carries a [LiveRegionMode.Polite] semantics announcement so
+ * TalkBack speaks the milestone even though it's a transient visual.
+ */
+@Composable
+fun BooksLitBadgeOverlay(
+    booksLit: Int,
+    onFinished: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    val spacing = LocalSpacing.current
+    val reducedMotion = LocalReducedMotion.current
+
+    var badgeVisible by remember { mutableStateOf(false) }
+    androidx.compose.runtime.LaunchedEffect(Unit) { badgeVisible = true }
+
+    val label = if (booksLit == 1) "1 book lit" else "$booksLit books lit"
+
+    Box(modifier = modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
+        // The rising motes carry the celebration; onFinished is driven
+        // off the burst so the badge and motes leave together.
+        LightMotes(onFinished = onFinished, modifier = Modifier.fillMaxSize())
+
+        AnimatedVisibility(
+            visible = badgeVisible,
+            enter = if (reducedMotion) fadeIn() else fadeIn() + scaleIn(initialScale = 0.85f),
+            exit = fadeOut(),
+        ) {
+            Surface(
+                shape = MaterialTheme.shapes.large,
+                color = BooksLitSubstrate,
+                tonalElevation = 0.dp,
+                shadowElevation = 10.dp,
+                border = BorderStroke(1.dp, BrassRamp.Brass500.copy(alpha = 0.6f)),
+                modifier = Modifier.semantics {
+                    liveRegion = LiveRegionMode.Polite
+                    contentDescription = "Reading streak: $label"
+                },
+            ) {
+                Column(
+                    modifier = Modifier.padding(horizontal = spacing.lg, vertical = spacing.md),
+                    horizontalAlignment = Alignment.CenterHorizontally,
+                    verticalArrangement = Arrangement.spacedBy(spacing.xxs),
+                ) {
+                    Text(
+                        text = "🕯",
+                        style = MaterialTheme.typography.headlineMedium,
+                    )
+                    Text(
+                        text = label,
+                        style = MaterialTheme.typography.titleLarge,
+                        color = BrassRamp.Brass200,
+                        textAlign = TextAlign.Center,
+                    )
+                    Text(
+                        text = streakTagline(booksLit),
+                        style = MaterialTheme.typography.bodySmall,
+                        color = BrassRamp.Brass100.copy(alpha = 0.7f),
+                        textAlign = TextAlign.Center,
+                    )
+                }
+            }
+        }
+    }
+}
+
+/** Tier-specific tagline under the "N books lit" count. Pure — pinned
+ *  by [BooksLitBadgeTest]. */
+internal fun streakTagline(booksLit: Int): String = when (booksLit) {
+    1 -> "Your first flame."
+    5 -> "Five kept alight."
+    10 -> "Ten and still burning."
+    25 -> "A constellation of finished tales."
+    else -> "Books lit."
+}
+
+private val BooksLitSubstrate = androidx.compose.ui.graphics.Color(0xFF1F1424)
+
+// region Previews
+
+@Preview(name = "Books lit badge — tier 5 (dark)", widthDp = 360, heightDp = 640)
+@Composable
+private fun PreviewBooksLitBadge() = LibraryNocturneTheme(darkTheme = true) {
+    Box(
+        modifier = Modifier
+            .fillMaxSize()
+            .padding(0.dp),
+        contentAlignment = Alignment.Center,
+    ) {
+        Surface(
+            shape = MaterialTheme.shapes.large,
+            color = BooksLitSubstrate,
+            border = BorderStroke(1.dp, BrassRamp.Brass500.copy(alpha = 0.6f)),
+        ) {
+            Column(
+                modifier = Modifier.padding(horizontal = 24.dp, vertical = 16.dp),
+                horizontalAlignment = Alignment.CenterHorizontally,
+            ) {
+                Text("🕯", style = MaterialTheme.typography.headlineMedium)
+                Text(
+                    "5 books lit",
+                    style = MaterialTheme.typography.titleLarge,
+                    color = BrassRamp.Brass200,
+                )
+                Text(
+                    streakTagline(5),
+                    style = MaterialTheme.typography.bodySmall,
+                    color = BrassRamp.Brass100.copy(alpha = 0.7f),
+                )
+            }
+        }
+    }
+}
+
+// endregion

--- a/core-ui/src/main/kotlin/in/jphe/storyvox/ui/component/CandleTapEgg.kt
+++ b/core-ui/src/main/kotlin/in/jphe/storyvox/ui/component/CandleTapEgg.kt
@@ -1,0 +1,131 @@
+package `in`.jphe.storyvox.ui.component
+
+import androidx.compose.animation.AnimatedVisibility
+import androidx.compose.animation.fadeIn
+import androidx.compose.animation.fadeOut
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.interaction.MutableInteractionSource
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.wrapContentSize
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableIntStateOf
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.unit.dp
+import `in`.jphe.storyvox.ui.theme.BrassRamp
+
+/** Number of taps on the sigil glyph that lights the hidden candle. */
+internal const val CANDLE_EGG_TAP_THRESHOLD: Int = 7
+
+/** The whisper revealed when the candle lights — the meaning of the
+ *  name. Pure const so the egg copy is testable + single-sourced. */
+internal const val CANDLE_EGG_WHISPER: String =
+    "Candela — the SI unit of luminous intensity"
+
+/**
+ * Candela (v1.1.0) — the hidden candle easter egg.
+ *
+ * Wraps the sigil glyph ([content], typically a [MagicSkeletonTile]) in
+ * an invisible tap-counter. Tapping it [CANDLE_EGG_TAP_THRESHOLD] times
+ * lights a small [LightMotes] flame-burst over the glyph and whispers
+ * "[CANDLE_EGG_WHISPER]" in a brass tooltip. Self-contained and
+ * discoverable: nothing changes on taps 1–6, so it stays a secret; the
+ * 7th tap rewards the curious. Re-arms after the whisper fades, so it
+ * can be found again.
+ *
+ * Deliberately NOT gated by a one-time DataStore flag — unlike the
+ * milestone celebrations, this is a re-discoverable delight, not a
+ * one-shot announcement.
+ *
+ * The wrapper keeps [MagicSkeletonTile] pure: the tile only draws; this
+ * layer owns the tap behavior. The tap target is the glyph's own
+ * bounds (it sizes to [content]).
+ */
+@Composable
+fun CandleTapEgg(
+    modifier: Modifier = Modifier,
+    content: @Composable () -> Unit,
+) {
+    var taps by remember { mutableIntStateOf(0) }
+    var lit by remember { mutableStateOf(false) }
+    val interaction = remember { MutableInteractionSource() }
+
+    Box(
+        modifier = modifier.wrapContentSize(),
+        contentAlignment = Alignment.Center,
+    ) {
+        Box(
+            modifier = Modifier.clickable(
+                interactionSource = interaction,
+                indication = null, // silent — no ripple gives away the secret
+            ) {
+                if (!lit) {
+                    taps += 1
+                    if (taps >= CANDLE_EGG_TAP_THRESHOLD) {
+                        taps = 0
+                        lit = true
+                    }
+                }
+            },
+        ) {
+            content()
+        }
+
+        // The flame-burst overlay, sized to the glyph bounds, mounted
+        // only while lit. LightMotes drives the rise + bloom; onFinished
+        // clears `lit`, re-arming the egg.
+        if (lit) {
+            LightMotes(
+                onFinished = { lit = false },
+                modifier = Modifier.fillMaxSize(),
+            )
+        }
+
+        // The whisper tooltip — a small brass caption below the glyph,
+        // fading in with the burst and out when it clears.
+        AnimatedVisibility(
+            visible = lit,
+            enter = fadeIn(),
+            exit = fadeOut(),
+            modifier = Modifier
+                .align(Alignment.BottomCenter),
+        ) {
+            Text(
+                text = CANDLE_EGG_WHISPER,
+                style = MaterialTheme.typography.bodySmall,
+                color = BrassRamp.Brass100,
+                textAlign = TextAlign.Center,
+                modifier = Modifier
+                    .background(
+                        color = Color(0xFF1F1424).copy(alpha = 0.92f),
+                        shape = RoundedCornerShape(8.dp),
+                    )
+                    .padding(horizontal = 12.dp, vertical = 6.dp),
+            )
+        }
+
+        // Safety: if a host keeps us composed, ensure a lit egg always
+        // eventually clears even if LightMotes' onFinished is missed
+        // (e.g. reduced motion fires it next-frame; this is a no-op
+        // backstop, not the primary path).
+        if (lit) {
+            LaunchedEffect(Unit) {
+                kotlinx.coroutines.delay(4000)
+                lit = false
+            }
+        }
+    }
+}

--- a/core-ui/src/main/kotlin/in/jphe/storyvox/ui/component/LightMotes.kt
+++ b/core-ui/src/main/kotlin/in/jphe/storyvox/ui/component/LightMotes.kt
@@ -1,0 +1,335 @@
+package `in`.jphe.storyvox.ui.component
+
+import androidx.compose.animation.core.LinearEasing
+import androidx.compose.animation.core.animateFloat
+import androidx.compose.animation.core.tween
+import androidx.compose.animation.core.updateTransition
+import androidx.compose.foundation.Canvas
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberUpdatedState
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.graphics.Brush
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import `in`.jphe.storyvox.ui.theme.BrassRamp
+import `in`.jphe.storyvox.ui.theme.LibraryNocturneTheme
+import `in`.jphe.storyvox.ui.theme.LocalAnimationSpeedScale
+import `in`.jphe.storyvox.ui.theme.LocalParticleIntensity
+import `in`.jphe.storyvox.ui.theme.LocalReducedMotion
+import `in`.jphe.storyvox.ui.theme.ParticleIntensity
+import `in`.jphe.storyvox.ui.theme.scaleDurationMs
+import kotlin.math.sin
+import kotlin.random.Random
+
+/**
+ * Candela (v1.1.0) — the celebratory **one-shot** sibling of
+ * [BrassEmberOverlay].
+ *
+ * Where [BrassEmberOverlay] is an *infinite* ambient candle-ember
+ * drift (always running, layered over the warming cover), [LightMotes]
+ * is a *finite* burst: a wash of warm amber→gold motes that rise out
+ * of the bottom, bloom with a soft radial glow, sway gently, and fade
+ * to nothing over [LIGHT_MOTES_LIFETIME_MS] — then call [onFinished] exactly once.
+ * It is the shared "luminous language" for every celebration in the
+ * app: the v1.1 milestone ignite, the hidden candle egg, the book-
+ * streak tiers, and the chapter-complete moment (replacing the old
+ * falling [MilestoneConfetti]). One mote engine, used everywhere, so
+ * the whole app celebrates in the same voice.
+ *
+ * Shares [BrassEmberOverlay]'s three preference seams so a celebration
+ * never contradicts the user's own settings:
+ *  - [LocalReducedMotion] — motion off → a single warm static bloom +
+ *    no rising particles (still warm, not blank), and [onFinished]
+ *    fires on the next frame so any one-time gate still closes.
+ *  - [LocalAnimationSpeedScale] (#589) — scales the burst duration;
+ *    scale 0 freezes the same as reduced motion.
+ *  - [LocalParticleIntensity] (#590) — None still runs the burst (a
+ *    celebration with zero motes would just be a flash), but at a
+ *    floor count; Subtle is the default density; Lush doubles it.
+ *
+ * **onFinished reliability** — [onFinished] is captured via
+ * [rememberUpdatedState] and fired from a [LaunchedEffect] whose key is
+ * [Unit], so it runs once per mount. If the host removes [LightMotes]
+ * early (composition leaves before the burst completes), the
+ * LaunchedEffect is cancelled and [onFinished] does NOT fire — so the
+ * **caller** must treat the side-effect (e.g. markV110ConfettiShown,
+ * streak-flag) as the gate, and the caller serializes that through the
+ * repo seam exactly like [MilestoneConfetti]'s host does. This keeps a
+ * dropped celebration from permanently consuming its one-time flag.
+ *
+ * Pure Compose [Canvas] — no third-party particle library.
+ */
+@Composable
+fun LightMotes(
+    onFinished: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    val reducedMotion = LocalReducedMotion.current
+    val speedScale = LocalAnimationSpeedScale.current
+    val intensity = LocalParticleIntensity.current
+    val frozen = reducedMotion || speedScale <= 0f
+
+    // Capture the latest onFinished so a recomposition that swaps the
+    // lambda doesn't fire a stale one. Single-fire via the Unit-keyed
+    // effect below.
+    val finished by rememberUpdatedState(onFinished)
+
+    if (frozen) {
+        // Warm static fallback — a single soft amber bloom at the
+        // bottom-center, so reduced-motion users still get a "light was
+        // lit" beat rather than nothing. Fire onFinished next frame so
+        // the one-time gate closes immediately.
+        LaunchedEffect(Unit) { finished() }
+        Box(modifier = modifier.fillMaxSize()) {
+            Canvas(modifier = Modifier.fillMaxSize()) {
+                drawMoteBloom(
+                    center = Offset(size.width * 0.5f, size.height * 0.72f),
+                    radius = size.minDimension * 0.22f,
+                    alpha = 0.5f,
+                )
+            }
+        }
+        return
+    }
+
+    // Mote count from intensity: floor of 10 even at None (a
+    // celebration needs *some* light), default 18 at Subtle, 36 at
+    // Lush. Distinct from the ambient overlay's calmer 6/12 — a burst
+    // wants more density than a background drift.
+    val moteCount = when (intensity) {
+        ParticleIntensity.None -> 10
+        ParticleIntensity.Subtle -> 18
+        ParticleIntensity.Lush -> 36
+    }
+
+    // Stable seed pinned at first composition so motes don't reshuffle
+    // when an ancestor recomposes mid-burst.
+    val seed = remember { Random.nextLong() }
+    val motes = remember(seed, moteCount) {
+        val r = Random(seed)
+        List(moteCount) { i ->
+            Mote(
+                x0 = r.nextFloat(),
+                swayAmp = 0.03f + r.nextFloat() * 0.05f,
+                swayFreq = 0.5f + r.nextFloat() * 0.9f,
+                radiusDp = 2.0f + r.nextFloat() * 2.5f,
+                phase = r.nextFloat(),
+                rise = 0.85f + r.nextFloat() * 0.25f,
+                // Amber→gold gradient across the trio: deep brass, warm
+                // brass, near-cream gold — the "rising spark" palette.
+                tint = when (i % 3) {
+                    0 -> BrassRamp.Brass400
+                    1 -> BrassRamp.Brass300
+                    else -> BrassRamp.Brass100
+                },
+            )
+        }
+    }
+
+    // One transition 0→1 over the scaled lifetime drives the whole
+    // burst; updateTransition cancels cleanly if the parent removes us.
+    var started by remember { mutableStateOf(false) }
+    LaunchedEffect(Unit) {
+        started = true
+        kotlinx.coroutines.delay(scaleDurationMs(LIGHT_MOTES_LIFETIME_MS, speedScale).toLong().coerceAtLeast(1L))
+        finished()
+    }
+    val transition = updateTransition(targetState = started, label = "lightMotesT")
+    val progress by transition.animateFloat(
+        label = "lightMotesProgress",
+        transitionSpec = {
+            tween(
+                durationMillis = scaleDurationMs(LIGHT_MOTES_LIFETIME_MS, speedScale).coerceAtLeast(1),
+                easing = LinearEasing,
+            )
+        },
+    ) { if (it) 1f else 0f }
+
+    Box(modifier = modifier.fillMaxSize()) {
+        Canvas(modifier = Modifier.fillMaxSize()) {
+            val w = size.width
+            val h = size.height
+            val onePx = 1.dp.toPx()
+
+            // A soft warm bloom at the bottom that swells in the first
+            // third then fades — the "glow" beat under the rising motes.
+            val bloomAlpha = moteBloomAlpha(progress)
+            if (bloomAlpha > 0.01f) {
+                drawMoteBloom(
+                    center = Offset(w * 0.5f, h * 0.78f),
+                    radius = h * 0.34f,
+                    alpha = bloomAlpha,
+                )
+            }
+
+            for (m in motes) {
+                // Each mote is offset in phase so they don't all rise in
+                // lockstep; its own progress is clamped 0..1.
+                val mp = ((progress + m.phase) % 1f)
+                val alpha = moteAlpha(mp)
+                if (alpha <= 0.01f) continue
+                val swayRad = (mp * 2.0 * Math.PI * m.swayFreq).toFloat()
+                val x = (m.x0 + m.swayAmp * sin(swayRad.toDouble()).toFloat())
+                    .coerceIn(0.04f, 0.96f) * w
+                // Rise from just below the bottom edge (1.02) up past the
+                // top (-0.04), so motes drift INTO and OUT of frame
+                // rather than popping at the edges.
+                val y = (1.02f - mp * m.rise * 1.06f) * h
+                val r = m.radiusDp * onePx
+                // Soft mote: a small filled core with a faint halo so it
+                // reads as light, not a hard dot.
+                drawCircle(
+                    color = m.tint.copy(alpha = m.tint.alpha * alpha * 0.30f),
+                    radius = r * 2.2f,
+                    center = Offset(x, y),
+                )
+                drawCircle(
+                    color = m.tint.copy(alpha = m.tint.alpha * alpha),
+                    radius = r,
+                    center = Offset(x, y),
+                )
+            }
+        }
+    }
+}
+
+/** Per-mote model. Fractions are of the canvas (resolution-independent). */
+private data class Mote(
+    val x0: Float,
+    val swayAmp: Float,
+    val swayFreq: Float,
+    val radiusDp: Float,
+    val phase: Float,
+    val rise: Float,
+    val tint: Color,
+)
+
+/** Total burst lifetime before [LightMotes] calls onFinished. */
+internal const val LIGHT_MOTES_LIFETIME_MS: Int = 2800
+
+/**
+ * Structural canary (matches the team's pure-fn-marker pattern): set
+ * when [LightMotes] is the shared celebration engine reused across the
+ * milestone ignite, hidden egg, streak, and chapter-complete surfaces.
+ * A refactor that forks a second particle system must consciously flip
+ * this.
+ */
+internal const val lightMotesIsSharedCelebrationEngine: Boolean = true
+
+/**
+ * Per-mote alpha envelope over its own 0..1 progress:
+ *  - 0.00..0.18 fade in (0 → 0.9)
+ *  - 0.18..0.70 hold (0.9)
+ *  - 0.70..1.00 fade out (0.9 → 0)
+ * Pure so the curve is verifiable without a frame clock.
+ */
+internal fun moteAlpha(progress: Float): Float = when {
+    progress < 0f -> 0f
+    progress < 0.18f -> (progress / 0.18f) * 0.9f
+    progress < 0.70f -> 0.9f
+    progress < 1f -> ((1f - progress) / 0.30f).coerceIn(0f, 1f) * 0.9f
+    else -> 0f
+}
+
+/**
+ * The warm radial bloom's alpha over the whole-burst progress:
+ * swells over the first 0.30, holds briefly, then fades by 0.85 so the
+ * glow leaves a lingering warmth and is gone before the motes finish.
+ * Pure for the same reason as [moteAlpha].
+ */
+internal fun moteBloomAlpha(progress: Float): Float = when {
+    progress < 0f -> 0f
+    progress < 0.30f -> (progress / 0.30f) * 0.45f
+    progress < 0.55f -> 0.45f
+    progress < 0.85f -> (1f - (progress - 0.55f) / 0.30f) * 0.45f
+    else -> 0f
+}
+
+/** Draws a soft amber radial glow centered at [center]. Shared by the
+ *  live burst and the reduced-motion static fallback. */
+private fun androidx.compose.ui.graphics.drawscope.DrawScope.drawMoteBloom(
+    center: Offset,
+    radius: Float,
+    alpha: Float,
+) {
+    drawCircle(
+        brush = Brush.radialGradient(
+            colors = listOf(
+                BrassRamp.Brass300.copy(alpha = alpha),
+                BrassRamp.Brass400.copy(alpha = alpha * 0.5f),
+                Color.Transparent,
+            ),
+            center = center,
+            radius = radius,
+        ),
+        radius = radius,
+        center = center,
+    )
+}
+
+// region Previews
+
+@Preview(name = "LightMotes — mid-burst (dark)", widthDp = 360, heightDp = 640)
+@Composable
+private fun PreviewLightMotesDark() = LibraryNocturneTheme(darkTheme = true) {
+    PreviewMotesFrame(progressPinned = 0.5f)
+}
+
+@Composable
+private fun PreviewMotesFrame(progressPinned: Float) {
+    val r = Random(7L)
+    val motes = List(18) { i ->
+        Mote(
+            x0 = r.nextFloat(),
+            swayAmp = 0.03f + r.nextFloat() * 0.05f,
+            swayFreq = 0.5f + r.nextFloat() * 0.9f,
+            radiusDp = 2.0f + r.nextFloat() * 2.5f,
+            phase = r.nextFloat(),
+            rise = 0.85f + r.nextFloat() * 0.25f,
+            tint = when (i % 3) {
+                0 -> BrassRamp.Brass400
+                1 -> BrassRamp.Brass300
+                else -> BrassRamp.Brass100
+            },
+        )
+    }
+    Box(
+        modifier = Modifier
+            .fillMaxSize()
+            .background(Color(0xFF1F1424)),
+    ) {
+        Canvas(modifier = Modifier.fillMaxSize()) {
+            val w = size.width
+            val h = size.height
+            val onePx = 1.dp.toPx()
+            val bloomAlpha = moteBloomAlpha(progressPinned)
+            if (bloomAlpha > 0.01f) {
+                drawMoteBloom(Offset(w * 0.5f, h * 0.78f), h * 0.34f, bloomAlpha)
+            }
+            for (m in motes) {
+                val mp = ((progressPinned + m.phase) % 1f)
+                val alpha = moteAlpha(mp)
+                if (alpha <= 0.01f) continue
+                val swayRad = (mp * 2.0 * Math.PI * m.swayFreq).toFloat()
+                val x = (m.x0 + m.swayAmp * sin(swayRad.toDouble()).toFloat())
+                    .coerceIn(0.04f, 0.96f) * w
+                val y = (1.02f - mp * m.rise * 1.06f) * h
+                val rad = m.radiusDp * onePx
+                drawCircle(m.tint.copy(alpha = m.tint.alpha * alpha * 0.30f), rad * 2.2f, Offset(x, y))
+                drawCircle(m.tint.copy(alpha = m.tint.alpha * alpha), rad, Offset(x, y))
+            }
+        }
+    }
+}
+
+// endregion

--- a/core-ui/src/main/kotlin/in/jphe/storyvox/ui/component/V110MilestoneDialog.kt
+++ b/core-ui/src/main/kotlin/in/jphe/storyvox/ui/component/V110MilestoneDialog.kt
@@ -29,10 +29,12 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.alpha
+import androidx.compose.ui.draw.clip
 import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.Path
+import androidx.compose.ui.graphics.RectangleShape
 import androidx.compose.ui.graphics.drawscope.DrawScope
 import androidx.compose.ui.graphics.drawscope.Stroke
 import androidx.compose.ui.text.style.TextAlign
@@ -137,73 +139,91 @@ fun V110MilestoneDialog(
             shadowElevation = 12.dp,
             border = BorderStroke(width = 1.dp, color = BrassRamp.Brass500.copy(alpha = 0.55f)),
         ) {
+            // Outer Box: the content Column stacks the flame band ABOVE the
+            // text (so they never fight for the same rows), and the rising
+            // motes are a separate full-card overlay drifting across both.
             Box {
-                // The candle stage — flame + glow + arc rings, drawn on a
-                // canvas band at the top of the card.
-                Box(
-                    modifier = Modifier
-                        .fillMaxWidth()
-                        .height(180.dp),
-                    contentAlignment = Alignment.Center,
-                ) {
-                    CandleStage(intro = intro, flicker = flicker, frozen = frozen)
-                    // Rising motes layered over the candle stage (live only;
-                    // LightMotes itself draws a static bloom when frozen and
-                    // fires onFinished immediately, which is harmless here —
-                    // the dialog's own gate is the dismiss tap, not the
-                    // burst).
-                    if (!frozen) {
-                        LightMotes(onFinished = {}, modifier = Modifier.fillMaxSize())
+                Column(modifier = Modifier.fillMaxWidth()) {
+                    // The candle stage gets its OWN dedicated vertical band at
+                    // the top of the card — flame + glow + arc rings, with real
+                    // breathing room above it so nothing jams the top edge. The
+                    // text lives strictly below this band. `clip` is the hard
+                    // guarantee that the soft radial glow (and the expanding arc
+                    // rings) can never paint DOWN over the title — the canvas is
+                    // bounded to exactly this band.
+                    Box(
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .padding(top = spacing.lg)
+                            .height(176.dp)
+                            .clip(RectangleShape),
+                        contentAlignment = Alignment.Center,
+                    ) {
+                        CandleStage(intro = intro, flicker = flicker, frozen = frozen)
+                    }
+
+                    Column(
+                        modifier = Modifier
+                            .padding(horizontal = spacing.lg)
+                            .padding(top = spacing.md, bottom = spacing.lg)
+                            .fillMaxWidth(),
+                        horizontalAlignment = Alignment.Start,
+                        verticalArrangement = Arrangement.spacedBy(spacing.sm),
+                    ) {
+                        Text(
+                            text = "Candela 1.1 — read it your way",
+                            style = MaterialTheme.typography.headlineSmall,
+                            color = BrassRamp.Brass300,
+                        )
+                        Text(
+                            text = "Every reader holds the light a little differently.",
+                            style = MaterialTheme.typography.titleMedium,
+                            color = MilestoneCreamV110,
+                            modifier = Modifier.padding(top = spacing.xxs),
+                        )
+                        Text(
+                            text = "Per-word glow, your own typeface, the colors that " +
+                                "rest your eyes, the sources you already love — bring " +
+                                "your own, and read it your way.",
+                            style = MaterialTheme.typography.bodyMedium,
+                            color = MilestoneCreamV110.copy(alpha = 0.88f),
+                        )
+                        Text(
+                            text = "— from one small flame to the next",
+                            style = MaterialTheme.typography.bodySmall,
+                            color = MilestoneCreamV110.copy(alpha = 0.65f),
+                            modifier = Modifier
+                                .fillMaxWidth()
+                                .padding(top = spacing.xs),
+                            textAlign = TextAlign.End,
+                        )
+                        Row(
+                            modifier = Modifier
+                                .fillMaxWidth()
+                                .padding(top = spacing.sm),
+                            horizontalArrangement = Arrangement.End,
+                        ) {
+                            BrassButton(
+                                label = "Continue",
+                                onClick = onDismiss,
+                                variant = BrassButtonVariant.Primary,
+                            )
+                        }
                     }
                 }
 
-                Column(
-                    modifier = Modifier
-                        .padding(horizontal = spacing.lg)
-                        .padding(bottom = spacing.lg)
-                        .fillMaxWidth(),
-                    horizontalAlignment = Alignment.Start,
-                    verticalArrangement = Arrangement.spacedBy(spacing.sm),
-                ) {
-                    Text(
-                        text = "Candela 1.1 — read it your way",
-                        style = MaterialTheme.typography.headlineSmall,
-                        color = BrassRamp.Brass300,
+                // Rising motes drift across the WHOLE card, layered over both
+                // the flame band and the text (live only; LightMotes draws a
+                // static bloom when frozen and fires onFinished immediately,
+                // which is harmless here — the dialog's gate is the dismiss
+                // tap, not the burst). matchParentSize keeps the overlay
+                // exactly the size the content Column measured, so the card
+                // never grows to fit the motes.
+                if (!frozen) {
+                    LightMotes(
+                        onFinished = {},
+                        modifier = Modifier.matchParentSize(),
                     )
-                    Text(
-                        text = "Every reader holds the light a little differently.",
-                        style = MaterialTheme.typography.titleMedium,
-                        color = MilestoneCreamV110,
-                        modifier = Modifier.padding(top = spacing.xxs),
-                    )
-                    Text(
-                        text = "Per-word glow, your own typeface, the colors that " +
-                            "rest your eyes, the sources you already love — bring " +
-                            "your own, and read it your way.",
-                        style = MaterialTheme.typography.bodyMedium,
-                        color = MilestoneCreamV110.copy(alpha = 0.88f),
-                    )
-                    Text(
-                        text = "— from one small flame to the next",
-                        style = MaterialTheme.typography.bodySmall,
-                        color = MilestoneCreamV110.copy(alpha = 0.65f),
-                        modifier = Modifier
-                            .fillMaxWidth()
-                            .padding(top = spacing.xs),
-                        textAlign = TextAlign.End,
-                    )
-                    Row(
-                        modifier = Modifier
-                            .fillMaxWidth()
-                            .padding(top = spacing.sm),
-                        horizontalArrangement = Arrangement.End,
-                    ) {
-                        BrassButton(
-                            label = "Continue",
-                            onClick = onDismiss,
-                            variant = BrassButtonVariant.Primary,
-                        )
-                    }
                 }
             }
         }
@@ -222,13 +242,24 @@ private fun CandleStage(intro: Float, flicker: Float, frozen: Boolean) {
         val w = size.width
         val h = size.height
         val cx = w * 0.5f
-        // Wick / flame base sits a little below the vertical center.
-        val baseY = h * 0.62f
+        // Wick / flame base — lifted to just below the band's vertical
+        // center (was 0.62h, which sank the glow against the band's lower
+        // edge and crowded the title below). The whole candle composition
+        // (flame, glow, rings) hangs off this single anchor so it moves as
+        // one unit, and a smaller glow radius leaves a dark margin before
+        // the band bottom — the breathing room JP asked for.
+        val baseY = h * 0.56f
+        // Single shared center for the radial glow and the arc rings, so
+        // the light blooms from one point and stays vertically balanced
+        // within the band.
+        val glowCenterY = baseY - h * 0.12f
 
         // Beat 2 — radial glow [0.12, 0.50], holds afterward at a calm
-        // resting alpha so the card stays warm.
+        // resting alpha so the card stays warm. Radius trimmed 0.46h→0.40h
+        // so the soft outer falloff lands inside the band with margin.
         val glowProgress = remap(intro, 0.12f, 0.50f)
         val glowAlpha = (0.15f + 0.35f * glowProgress) * (0.85f + 0.15f * flicker)
+        val glowRadius = h * 0.40f
         drawCircle(
             brush = Brush.radialGradient(
                 colors = listOf(
@@ -236,11 +267,11 @@ private fun CandleStage(intro: Float, flicker: Float, frozen: Boolean) {
                     BrassRamp.Brass400.copy(alpha = glowAlpha * 0.45f),
                     Color.Transparent,
                 ),
-                center = Offset(cx, baseY - h * 0.10f),
-                radius = h * 0.46f,
+                center = Offset(cx, glowCenterY),
+                radius = glowRadius,
             ),
-            radius = h * 0.46f,
-            center = Offset(cx, baseY - h * 0.10f),
+            radius = glowRadius,
+            center = Offset(cx, glowCenterY),
         )
 
         // Beat 4 — soundwave arc rings [0.45, 0.95]. Three concentric
@@ -253,12 +284,12 @@ private fun CandleStage(intro: Float, flicker: Float, frozen: Boolean) {
                     // Stagger each ring by 1/3 so they chase outward.
                     val rp = (ringProgress - i * 0.18f).coerceIn(0f, 1f)
                     if (rp <= 0f) continue
-                    val radius = h * (0.10f + rp * 0.34f)
+                    val radius = h * (0.10f + rp * 0.30f)
                     val ringAlpha = (1f - rp) * 0.5f
                     drawCircle(
                         color = BrassRamp.Brass200.copy(alpha = ringAlpha),
                         radius = radius,
-                        center = Offset(cx, baseY - h * 0.08f),
+                        center = Offset(cx, glowCenterY),
                         style = Stroke(width = (h * 0.012f).coerceAtLeast(1.5f)),
                     )
                 }

--- a/core-ui/src/main/kotlin/in/jphe/storyvox/ui/component/V110MilestoneDialog.kt
+++ b/core-ui/src/main/kotlin/in/jphe/storyvox/ui/component/V110MilestoneDialog.kt
@@ -1,0 +1,406 @@
+package `in`.jphe.storyvox.ui.component
+
+import androidx.compose.animation.core.LinearEasing
+import androidx.compose.animation.core.LinearOutSlowInEasing
+import androidx.compose.animation.core.animateFloat
+import androidx.compose.animation.core.infiniteRepeatable
+import androidx.compose.animation.core.rememberInfiniteTransition
+import androidx.compose.animation.core.tween
+import androidx.compose.foundation.BorderStroke
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.widthIn
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableFloatStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.alpha
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.graphics.Brush
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.Path
+import androidx.compose.ui.graphics.drawscope.DrawScope
+import androidx.compose.ui.graphics.drawscope.Stroke
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.window.Dialog
+import androidx.compose.ui.window.DialogProperties
+import `in`.jphe.storyvox.ui.theme.BrassRamp
+import `in`.jphe.storyvox.ui.theme.LibraryNocturneTheme
+import `in`.jphe.storyvox.ui.theme.LocalAnimationSpeedScale
+import `in`.jphe.storyvox.ui.theme.LocalReducedMotion
+import `in`.jphe.storyvox.ui.theme.LocalSpacing
+import `in`.jphe.storyvox.ui.theme.scaleDurationMs
+
+/**
+ * Candela (v1.1.0) — the "ignite" milestone dialog. The centerpiece
+ * easter egg: a candle being lit, not a pep-rally.
+ *
+ * **The ignite sequence** is driven by ONE master progress clock
+ * (0→1 over the intro) with overlapping beat windows, so it reads as a
+ * single continuous ignition rather than five discrete steps (the way
+ * audio crossfades overlap):
+ *  1. **Flame draws in**  [0.00, 0.28] — the flame teardrop scales up
+ *     from a spark at the wick.
+ *  2. **Radial glow blooms** [0.12, 0.50] — a warm amber wash swells
+ *     outward behind the flame (overlaps the flame draw).
+ *  3. **Light-motes rise**  from ~0.30 — [LightMotes] layered over the
+ *     card; warm sparks drift upward.
+ *  4. **Sound-wave arc rings** [0.45, 0.95] — three concentric arcs
+ *     (the BrassVoiceIcon's soundwave, reborn as rings of light) pulse
+ *     outward from the flame.
+ *  5. **Settle to a gentle flicker** — once the intro completes an
+ *     infinite-transition flicker takes over the flame's brightness so
+ *     the candle stays alive while the card rests.
+ *
+ * Honors [LocalReducedMotion] / [LocalAnimationSpeedScale]: when motion
+ * is off the whole sequence collapses to a static lit candle + warm
+ * glow (no rising motes, no pulsing rings) — still warm, never blank.
+ *
+ * Copy is hand-tuned for v1.1 ("Candela 1.1 — read it your way") and
+ * not templated, per the Milestone.kt per-release convention.
+ */
+@Composable
+fun V110MilestoneDialog(
+    onDismiss: () -> Unit,
+) {
+    val spacing = LocalSpacing.current
+    val reducedMotion = LocalReducedMotion.current
+    val speedScale = LocalAnimationSpeedScale.current
+    val frozen = reducedMotion || speedScale <= 0f
+
+    // Master intro progress 0→1. Hand-driven via a frame loop so we can
+    // hold at 1f afterward (vs. an infinite transition that would loop
+    // the ignition). Frozen → pinned at 1f (fully lit, static).
+    var intro by remember { mutableFloatStateOf(if (frozen) 1f else 0f) }
+    LaunchedEffect(frozen) {
+        if (frozen) { intro = 1f; return@LaunchedEffect }
+        val durationMs = scaleDurationMs(IGNITE_INTRO_MS, speedScale).coerceAtLeast(1)
+        val start = withFrameNanosStart()
+        var now = start
+        while (now - start < durationMs * 1_000_000L) {
+            now = awaitFrameNanos()
+            intro = ((now - start).toFloat() / (durationMs * 1_000_000f)).coerceIn(0f, 1f)
+        }
+        intro = 1f
+    }
+
+    // Post-intro flicker — a slow brightness shimmer on the flame so the
+    // candle stays alive. Frozen → steady full brightness.
+    val flicker: Float = if (frozen) 1f else {
+        val t = rememberInfiniteTransition(label = "v110-flicker")
+        val f by t.animateFloat(
+            initialValue = 0.82f,
+            targetValue = 1f,
+            animationSpec = infiniteRepeatable(
+                animation = tween(
+                    durationMillis = scaleDurationMs(2200, speedScale).coerceAtLeast(1),
+                    easing = LinearEasing,
+                ),
+                repeatMode = androidx.compose.animation.core.RepeatMode.Reverse,
+            ),
+            label = "v110-flicker-v",
+        )
+        f
+    }
+
+    Dialog(
+        onDismissRequest = onDismiss,
+        properties = DialogProperties(
+            dismissOnBackPress = true,
+            dismissOnClickOutside = true,
+            usePlatformDefaultWidth = false,
+        ),
+    ) {
+        Surface(
+            modifier = Modifier
+                .widthIn(min = 300.dp, max = 380.dp)
+                .padding(horizontal = spacing.lg),
+            shape = MaterialTheme.shapes.large,
+            color = MilestoneSubstrateV110,
+            tonalElevation = 0.dp,
+            shadowElevation = 12.dp,
+            border = BorderStroke(width = 1.dp, color = BrassRamp.Brass500.copy(alpha = 0.55f)),
+        ) {
+            Box {
+                // The candle stage — flame + glow + arc rings, drawn on a
+                // canvas band at the top of the card.
+                Box(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .height(180.dp),
+                    contentAlignment = Alignment.Center,
+                ) {
+                    CandleStage(intro = intro, flicker = flicker, frozen = frozen)
+                    // Rising motes layered over the candle stage (live only;
+                    // LightMotes itself draws a static bloom when frozen and
+                    // fires onFinished immediately, which is harmless here —
+                    // the dialog's own gate is the dismiss tap, not the
+                    // burst).
+                    if (!frozen) {
+                        LightMotes(onFinished = {}, modifier = Modifier.fillMaxSize())
+                    }
+                }
+
+                Column(
+                    modifier = Modifier
+                        .padding(horizontal = spacing.lg)
+                        .padding(bottom = spacing.lg)
+                        .fillMaxWidth(),
+                    horizontalAlignment = Alignment.Start,
+                    verticalArrangement = Arrangement.spacedBy(spacing.sm),
+                ) {
+                    Text(
+                        text = "Candela 1.1 — read it your way",
+                        style = MaterialTheme.typography.headlineSmall,
+                        color = BrassRamp.Brass300,
+                    )
+                    Text(
+                        text = "Every reader holds the light a little differently.",
+                        style = MaterialTheme.typography.titleMedium,
+                        color = MilestoneCreamV110,
+                        modifier = Modifier.padding(top = spacing.xxs),
+                    )
+                    Text(
+                        text = "Per-word glow, your own typeface, the colors that " +
+                            "rest your eyes, the sources you already love — bring " +
+                            "your own, and read it your way.",
+                        style = MaterialTheme.typography.bodyMedium,
+                        color = MilestoneCreamV110.copy(alpha = 0.88f),
+                    )
+                    Text(
+                        text = "— from one small flame to the next",
+                        style = MaterialTheme.typography.bodySmall,
+                        color = MilestoneCreamV110.copy(alpha = 0.65f),
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .padding(top = spacing.xs),
+                        textAlign = TextAlign.End,
+                    )
+                    Row(
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .padding(top = spacing.sm),
+                        horizontalArrangement = Arrangement.End,
+                    ) {
+                        BrassButton(
+                            label = "Continue",
+                            onClick = onDismiss,
+                            variant = BrassButtonVariant.Primary,
+                        )
+                    }
+                }
+            }
+        }
+    }
+}
+
+/**
+ * The lit-candle canvas: a warm radial bloom, a flame teardrop, and the
+ * pulsing soundwave-arc rings — all derived from the single [intro]
+ * master clock with overlapping windows, plus the post-intro [flicker]
+ * on flame brightness.
+ */
+@Composable
+private fun CandleStage(intro: Float, flicker: Float, frozen: Boolean) {
+    androidx.compose.foundation.Canvas(modifier = Modifier.fillMaxSize()) {
+        val w = size.width
+        val h = size.height
+        val cx = w * 0.5f
+        // Wick / flame base sits a little below the vertical center.
+        val baseY = h * 0.62f
+
+        // Beat 2 — radial glow [0.12, 0.50], holds afterward at a calm
+        // resting alpha so the card stays warm.
+        val glowProgress = remap(intro, 0.12f, 0.50f)
+        val glowAlpha = (0.15f + 0.35f * glowProgress) * (0.85f + 0.15f * flicker)
+        drawCircle(
+            brush = Brush.radialGradient(
+                colors = listOf(
+                    BrassRamp.Brass300.copy(alpha = glowAlpha),
+                    BrassRamp.Brass400.copy(alpha = glowAlpha * 0.45f),
+                    Color.Transparent,
+                ),
+                center = Offset(cx, baseY - h * 0.10f),
+                radius = h * 0.46f,
+            ),
+            radius = h * 0.46f,
+            center = Offset(cx, baseY - h * 0.10f),
+        )
+
+        // Beat 4 — soundwave arc rings [0.45, 0.95]. Three concentric
+        // arcs expanding outward, fading as they grow; the BrassVoiceIcon
+        // soundwave reborn as rings of light. Static (frozen) → skip.
+        if (!frozen) {
+            val ringProgress = remap(intro, 0.45f, 0.95f)
+            if (ringProgress > 0f) {
+                for (i in 0 until 3) {
+                    // Stagger each ring by 1/3 so they chase outward.
+                    val rp = (ringProgress - i * 0.18f).coerceIn(0f, 1f)
+                    if (rp <= 0f) continue
+                    val radius = h * (0.10f + rp * 0.34f)
+                    val ringAlpha = (1f - rp) * 0.5f
+                    drawCircle(
+                        color = BrassRamp.Brass200.copy(alpha = ringAlpha),
+                        radius = radius,
+                        center = Offset(cx, baseY - h * 0.08f),
+                        style = Stroke(width = (h * 0.012f).coerceAtLeast(1.5f)),
+                    )
+                }
+            }
+        }
+
+        // Beat 1 — flame teardrop [0.00, 0.28], scales from a spark.
+        val flameProgress = remap(intro, 0.00f, 0.28f)
+        val flameScale = flameProgress
+        if (flameScale > 0.02f) {
+            val flameH = h * 0.30f * flameScale
+            val flameW = h * 0.13f * flameScale
+            val tipY = baseY - flameH
+            val brightness = 0.65f + 0.35f * flicker
+            // Outer flame (amber).
+            drawFlame(cx, baseY, tipY, flameW, BrassRamp.Brass400.copy(alpha = 0.85f * brightness))
+            // Inner flame (bright cream core), smaller.
+            drawFlame(
+                cx,
+                baseY - flameH * 0.06f,
+                tipY + flameH * 0.30f,
+                flameW * 0.55f,
+                BrassRamp.Brass100.copy(alpha = 0.95f * brightness),
+            )
+        }
+
+        // The wick base — a small warm dot anchoring the flame even at
+        // the very first frame (so the "spark" has somewhere to live).
+        drawCircle(
+            color = BrassRamp.Brass300.copy(alpha = 0.8f),
+            radius = (h * 0.012f).coerceAtLeast(2f),
+            center = Offset(cx, baseY),
+        )
+    }
+}
+
+/** A simple flame teardrop: a quadratic path bulging out then tapering
+ *  to a point at [tipY], centered on [cx]. */
+private fun DrawScope.drawFlame(
+    cx: Float,
+    baseY: Float,
+    tipY: Float,
+    halfWidth: Float,
+    color: Color,
+) {
+    val path = Path().apply {
+        moveTo(cx, baseY)
+        // Right side bulges out then curves to the tip.
+        cubicTo(
+            cx + halfWidth, baseY - (baseY - tipY) * 0.15f,
+            cx + halfWidth * 0.8f, baseY - (baseY - tipY) * 0.65f,
+            cx, tipY,
+        )
+        // Left side mirrors back down to the base.
+        cubicTo(
+            cx - halfWidth * 0.8f, baseY - (baseY - tipY) * 0.65f,
+            cx - halfWidth, baseY - (baseY - tipY) * 0.15f,
+            cx, baseY,
+        )
+        close()
+    }
+    drawPath(path = path, color = color)
+}
+
+/**
+ * Remaps [value] from the window [[start], [end]] onto 0..1, clamped.
+ * The overlapping-window trick that makes the ignite beats crossfade.
+ * Pure — pinned by [V110MilestoneIgniteTest].
+ */
+internal fun remap(value: Float, start: Float, end: Float): Float {
+    if (end <= start) return if (value >= end) 1f else 0f
+    return ((value - start) / (end - start)).coerceIn(0f, 1f)
+}
+
+/** Total ignite-intro duration before the flame settles to a flicker. */
+internal const val IGNITE_INTRO_MS: Int = 2200
+
+/**
+ * Structural canary: the v1.1 dialog's beats are sequenced (overlapping
+ * windows on one master clock), not fired simultaneously. A refactor
+ * that collapses them to a single AnimationSpec must flip this.
+ */
+internal const val v110IgniteBeatsAreSequenced: Boolean = true
+
+/** Deep-purple substrate — same swatch as the v0.5.00 card. */
+private val MilestoneSubstrateV110 = Color(0xFF1F1424)
+
+/** Cream text — Brass100, lifted as a named const for previews. */
+private val MilestoneCreamV110 = BrassRamp.Brass100
+
+// region frame-clock helpers
+
+/** First frame time in nanos (suspends one frame). */
+private suspend fun withFrameNanosStart(): Long = awaitFrameNanos()
+
+/** Suspends until the next frame and returns its time in nanos. */
+private suspend fun awaitFrameNanos(): Long =
+    androidx.compose.runtime.withFrameNanos { it }
+
+// endregion
+
+// region Previews
+
+@Preview(name = "V110 ignite — settled (dark)", widthDp = 420, heightDp = 560)
+@Composable
+private fun PreviewV110Settled() = LibraryNocturneTheme(darkTheme = true) {
+    Box(
+        modifier = Modifier
+            .fillMaxSize()
+            .background(Color.Black.copy(alpha = 0.6f))
+            .padding(24.dp),
+        contentAlignment = Alignment.Center,
+    ) {
+        Surface(
+            modifier = Modifier.widthIn(max = 380.dp),
+            shape = MaterialTheme.shapes.large,
+            color = MilestoneSubstrateV110,
+            border = BorderStroke(1.dp, BrassRamp.Brass500.copy(alpha = 0.55f)),
+        ) {
+            Column {
+                Box(
+                    modifier = Modifier.fillMaxWidth().height(180.dp),
+                    contentAlignment = Alignment.Center,
+                ) {
+                    // Pinned at fully-lit for the static preview frame.
+                    CandleStage(intro = 1f, flicker = 1f, frozen = true)
+                }
+                Column(modifier = Modifier.padding(24.dp).alpha(0.99f)) {
+                    Text(
+                        "Candela 1.1 — read it your way",
+                        style = MaterialTheme.typography.headlineSmall,
+                        color = BrassRamp.Brass300,
+                    )
+                    Text(
+                        "Every reader holds the light a little differently.",
+                        style = MaterialTheme.typography.titleMedium,
+                        color = MilestoneCreamV110,
+                    )
+                }
+            }
+        }
+    }
+}
+
+// endregion

--- a/core-ui/src/test/kotlin/in/jphe/storyvox/ui/component/BookStreakTest.kt
+++ b/core-ui/src/test/kotlin/in/jphe/storyvox/ui/component/BookStreakTest.kt
@@ -1,0 +1,81 @@
+package `in`.jphe.storyvox.ui.component
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Test
+
+/**
+ * Luna (v1.1.0) — book-completion streak milestone delta.
+ *
+ * When the user finishes a book, the completed-book counter ticks up.
+ * [bookStreakMilestoneCrossed] decides whether that single increment
+ * crossed a celebration tier (1, 5, 10, 25 "books lit") and, if so,
+ * which one. It returns the *highest* tier inside the half-open range
+ * `(previous, new]` so a delta that vaults past a tier (e.g. a sync
+ * that jumps the counter) still fires exactly one celebration for the
+ * top tier reached — never a backlog.
+ *
+ * Pure function, no Android: the streak counter itself is persisted in
+ * DataStore (device-local), but the "did we just cross a tier" decision
+ * is logic that has to be testable on the JVM. The repo seam computes
+ * `(oldCount, oldCount + 1)` and renders [LightMotes] + an "N books
+ * lit" badge when this returns non-null.
+ */
+class BookStreakTest {
+
+    @Test fun `crossing exactly the first book fires tier 1`() {
+        assertEquals(1, bookStreakMilestoneCrossed(previous = 0, new = 1))
+    }
+
+    @Test fun `a normal increment between tiers fires nothing`() {
+        assertNull(bookStreakMilestoneCrossed(previous = 1, new = 2))
+        assertNull(bookStreakMilestoneCrossed(previous = 2, new = 3))
+        assertNull(bookStreakMilestoneCrossed(previous = 3, new = 4))
+        assertNull(bookStreakMilestoneCrossed(previous = 5, new = 6))
+        assertNull(bookStreakMilestoneCrossed(previous = 10, new = 11))
+    }
+
+    @Test fun `crossing the fifth book fires tier 5`() {
+        assertEquals(5, bookStreakMilestoneCrossed(previous = 4, new = 5))
+    }
+
+    @Test fun `crossing the tenth book fires tier 10`() {
+        assertEquals(10, bookStreakMilestoneCrossed(previous = 9, new = 10))
+    }
+
+    @Test fun `crossing the twenty-fifth book fires tier 25`() {
+        assertEquals(25, bookStreakMilestoneCrossed(previous = 24, new = 25))
+    }
+
+    @Test fun `past the top tier fires nothing`() {
+        // No tiers above 25; finishing book 26, 30, 100 is quietly
+        // un-celebrated (we don't want every book past 25 to flash).
+        assertNull(bookStreakMilestoneCrossed(previous = 25, new = 26))
+        assertNull(bookStreakMilestoneCrossed(previous = 30, new = 31))
+        assertNull(bookStreakMilestoneCrossed(previous = 99, new = 100))
+    }
+
+    @Test fun `a jump that vaults multiple tiers fires only the top tier`() {
+        // E.g. a device that syncs a higher completed-count from another
+        // device, or a backfill. We fire once, for the highest tier
+        // reached, rather than a confetti backlog of 1+5+10.
+        assertEquals(10, bookStreakMilestoneCrossed(previous = 0, new = 12))
+        assertEquals(25, bookStreakMilestoneCrossed(previous = 4, new = 25))
+        assertEquals(5, bookStreakMilestoneCrossed(previous = 0, new = 5))
+    }
+
+    @Test fun `no-op or backward deltas fire nothing`() {
+        // Defensive: a recompute that doesn't move the counter, or a
+        // decrement (book un-completed / deleted), never celebrates.
+        assertNull(bookStreakMilestoneCrossed(previous = 5, new = 5))
+        assertNull(bookStreakMilestoneCrossed(previous = 10, new = 8))
+        assertNull(bookStreakMilestoneCrossed(previous = 1, new = 0))
+    }
+
+    @Test fun `the tier set is exactly 1-5-10-25`() {
+        // Structural canary: the celebration tiers are a fixed,
+        // deliberately-sparse set. If someone adds/removes a tier they
+        // must update this list (and the copy + the badge).
+        assertEquals(listOf(1, 5, 10, 25), bookStreakTiers)
+    }
+}

--- a/core-ui/src/test/kotlin/in/jphe/storyvox/ui/component/BooksLitBadgeTest.kt
+++ b/core-ui/src/test/kotlin/in/jphe/storyvox/ui/component/BooksLitBadgeTest.kt
@@ -1,0 +1,37 @@
+package `in`.jphe.storyvox.ui.component
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * Candela (v1.1.0) — pins the streak-tier taglines. Each celebration
+ * tier has its own line; anything off-tier falls back to a generic
+ * line (defensive — the host only ever passes a real tier).
+ */
+class BooksLitBadgeTest {
+
+    @Test fun `each tier has its own tagline`() {
+        assertEquals("Your first flame.", streakTagline(1))
+        assertEquals("Five kept alight.", streakTagline(5))
+        assertEquals("Ten and still burning.", streakTagline(10))
+        assertEquals("A constellation of finished tales.", streakTagline(25))
+    }
+
+    @Test fun `off-tier values get a safe generic line`() {
+        assertEquals("Books lit.", streakTagline(2))
+        assertEquals("Books lit.", streakTagline(0))
+        assertEquals("Books lit.", streakTagline(100))
+    }
+
+    @Test fun `every real streak tier has a non-generic tagline`() {
+        // Ties the badge copy to the canonical tier set so adding a tier
+        // without copy is caught here, not on-device.
+        bookStreakTiers.forEach { tier ->
+            assertTrue(
+                "tier $tier is missing its own tagline",
+                streakTagline(tier) != "Books lit.",
+            )
+        }
+    }
+}

--- a/core-ui/src/test/kotlin/in/jphe/storyvox/ui/component/LightMotesTest.kt
+++ b/core-ui/src/test/kotlin/in/jphe/storyvox/ui/component/LightMotesTest.kt
@@ -1,0 +1,95 @@
+package `in`.jphe.storyvox.ui.component
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * Candela (v1.1.0) — pins the pure alpha envelopes that shape the
+ * [LightMotes] burst. The composable itself can't be unit-tested in
+ * this source set (no Robolectric), so the testable contract is the
+ * timing math: a mote fades in, holds, and fades out; the warm bloom
+ * swells early and is gone before the motes finish. Verified
+ * on-device for the visual result.
+ */
+class LightMotesTest {
+
+    private val eps = 1e-4f
+
+    // ── moteAlpha envelope ─────────────────────────────────────────
+
+    @Test fun `mote starts fully transparent`() {
+        assertEquals(0f, moteAlpha(0f), eps)
+    }
+
+    @Test fun `mote fades in over the first fifth`() {
+        // Halfway through the fade-in (0.09 of 0.18) → half of peak 0.9.
+        assertEquals(0.45f, moteAlpha(0.09f), eps)
+    }
+
+    @Test fun `mote holds at peak through the middle`() {
+        assertEquals(0.9f, moteAlpha(0.18f), eps)
+        assertEquals(0.9f, moteAlpha(0.45f), eps)
+        assertEquals(0.9f, moteAlpha(0.69f), eps)
+    }
+
+    @Test fun `mote fades out to nothing by the end`() {
+        // Just inside the end the alpha is small but positive; at/after
+        // 1.0 it is exactly zero.
+        assertTrue(moteAlpha(0.95f) in 0.001f..0.45f)
+        assertEquals(0f, moteAlpha(1f), eps)
+        assertEquals(0f, moteAlpha(1.2f), eps)
+    }
+
+    @Test fun `mote alpha never exceeds peak and never goes negative`() {
+        var p = 0f
+        while (p <= 1.2f) {
+            val a = moteAlpha(p)
+            assertTrue("alpha $a out of range at p=$p", a in 0f..0.9001f)
+            p += 0.01f
+        }
+    }
+
+    // ── moteBloomAlpha envelope ────────────────────────────────────
+
+    @Test fun `bloom swells from zero`() {
+        assertEquals(0f, moteBloomAlpha(0f), eps)
+        // Halfway through the swell (0.15 of 0.30) → half of peak 0.45.
+        assertEquals(0.225f, moteBloomAlpha(0.15f), eps)
+    }
+
+    @Test fun `bloom holds briefly at peak`() {
+        assertEquals(0.45f, moteBloomAlpha(0.30f), eps)
+        assertEquals(0.45f, moteBloomAlpha(0.54f), eps)
+    }
+
+    @Test fun `bloom is gone before the motes finish`() {
+        // By 0.85 the bloom has fully faded; the motes keep rising
+        // afterward, so the glow leaves lingering warmth, not a flash
+        // that outlasts the sparks.
+        assertEquals(0f, moteBloomAlpha(0.85f), eps)
+        assertEquals(0f, moteBloomAlpha(1f), eps)
+    }
+
+    @Test fun `bloom alpha stays in range`() {
+        var p = 0f
+        while (p <= 1.0f) {
+            val a = moteBloomAlpha(p)
+            assertTrue("bloom $a out of range at p=$p", a in 0f..0.4501f)
+            p += 0.01f
+        }
+    }
+
+    // ── shared-engine canary ───────────────────────────────────────
+
+    @Test fun `LightMotes is the shared celebration engine`() {
+        // If a refactor forks a second particle system this must be
+        // consciously flipped — the whole point is ONE luminous
+        // language across milestone / egg / streak / chapter-complete.
+        assertTrue(lightMotesIsSharedCelebrationEngine)
+    }
+
+    @Test fun `burst lifetime is positive and brief`() {
+        assertTrue(LIGHT_MOTES_LIFETIME_MS in 1000..5000)
+    }
+}

--- a/core-ui/src/test/kotlin/in/jphe/storyvox/ui/component/V110MilestoneIgniteTest.kt
+++ b/core-ui/src/test/kotlin/in/jphe/storyvox/ui/component/V110MilestoneIgniteTest.kt
@@ -1,0 +1,61 @@
+package `in`.jphe.storyvox.ui.component
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * Candela (v1.1.0) — pins the [remap] window math that sequences the
+ * ignite dialog's beats and the structural canary asserting the beats
+ * are staggered (not fired at once). The composable's visual result is
+ * verified on-device; this guards the timing contract.
+ */
+class V110MilestoneIgniteTest {
+
+    private val eps = 1e-4f
+
+    @Test fun `remap is zero before the window opens`() {
+        assertEquals(0f, remap(0.0f, 0.12f, 0.50f), eps)
+        assertEquals(0f, remap(0.11f, 0.12f, 0.50f), eps)
+    }
+
+    @Test fun `remap reaches one at and after the window close`() {
+        assertEquals(1f, remap(0.50f, 0.12f, 0.50f), eps)
+        assertEquals(1f, remap(0.90f, 0.12f, 0.50f), eps)
+    }
+
+    @Test fun `remap interpolates linearly inside the window`() {
+        // Midpoint of [0.12, 0.50] is 0.31 → 0.5.
+        assertEquals(0.5f, remap(0.31f, 0.12f, 0.50f), eps)
+        // Quarter point.
+        assertEquals(0.25f, remap(0.215f, 0.12f, 0.50f), eps)
+    }
+
+    @Test fun `remap degenerate window steps at the boundary`() {
+        // start == end: a step function, not a divide-by-zero.
+        assertEquals(0f, remap(0.3f, 0.5f, 0.5f), eps)
+        assertEquals(1f, remap(0.5f, 0.5f, 0.5f), eps)
+        assertEquals(1f, remap(0.7f, 0.5f, 0.5f), eps)
+    }
+
+    @Test fun `the ignite beat windows overlap so the sequence crossfades`() {
+        // The whole point of the staggered design: at a moment in the
+        // early-middle of the intro, MORE than one beat is partially
+        // active — flame still drawing AND glow already blooming. If
+        // these were sequential (non-overlapping) windows, only one
+        // would be in (0,1) at a time.
+        val t = 0.20f
+        val flame = remap(t, 0.00f, 0.28f)   // beat 1
+        val glow = remap(t, 0.12f, 0.50f)    // beat 2
+        assertTrue("flame should be mid-draw at t=$t", flame in 0.01f..0.99f)
+        assertTrue("glow should be mid-bloom at t=$t", glow in 0.01f..0.99f)
+    }
+
+    @Test fun `ignite beats are sequenced canary`() {
+        assertTrue(v110IgniteBeatsAreSequenced)
+    }
+
+    @Test fun `ignite intro duration is positive and brief`() {
+        assertTrue(IGNITE_INTRO_MS in 1000..4000)
+    }
+}

--- a/feature/src/main/kotlin/in/jphe/storyvox/feature/api/UiContracts.kt
+++ b/feature/src/main/kotlin/in/jphe/storyvox/feature/api/UiContracts.kt
@@ -2250,6 +2250,23 @@ interface SettingsRepositoryUi {
      *  the DataStore impl persists. */
     suspend fun markMilestoneConfettiShown() {}
 
+    // ── v1.1.0 "read it your way" milestone (Luna) ─────────────────
+    /** Flip the v1.1 ignite-dialog seen flag. Default no-op for fakes. */
+    suspend fun markV110MilestoneDialogSeen() {}
+
+    /** Flip the v1.1 chapter-complete LightMotes flag. Default no-op. */
+    suspend fun markV110ConfettiShown() {}
+
+    /**
+     * Record that the user finished a book and return the streak tier
+     * (1/5/10/25) just crossed by the increment, or null if none. The
+     * counter increment + tier decision are a single serialized
+     * read-modify-write through this seam so two near-simultaneous
+     * end-of-book signals can't double-count or double-celebrate.
+     * Default returns null (fakes neither persist nor celebrate).
+     */
+    suspend fun recordBookCompletedAndMilestone(): Int? = null
+
     // ── Issue #383 — Inbox per-source mute toggles ─────────────────
     /**
      * Per-source Inbox notification toggles. When OFF, the backend's
@@ -2419,6 +2436,16 @@ data class MilestoneState(
     val qualifies: Boolean = false,
     val dialogSeen: Boolean = false,
     val confettiShown: Boolean = false,
+    // ── v1.1.0 "read it your way" milestone (Luna) ─────────────────
+    /** True when the build is inside the v1.1 celebration window
+     *  ([`in`.jphe.storyvox.sigil.Milestone.isV110OrLater]). */
+    val v110Qualifies: Boolean = false,
+    /** The v1.1 ignite dialog has been seen + dismissed on this install. */
+    val v110DialogSeen: Boolean = false,
+    /** The v1.1 chapter-complete LightMotes burst has fired once. */
+    val v110ConfettiShown: Boolean = false,
+    /** Lifetime device-local count of finished books, for streak tiers. */
+    val booksCompleted: Int = 0,
 )
 
 /** Tier 3 (#88) slider bounds. Min 1 (serial), max 8 (the Snapdragon

--- a/feature/src/main/kotlin/in/jphe/storyvox/feature/library/LibraryScreen.kt
+++ b/feature/src/main/kotlin/in/jphe/storyvox/feature/library/LibraryScreen.kt
@@ -822,11 +822,15 @@ private fun EmptyLibrary() {
         horizontalAlignment = Alignment.CenterHorizontally,
         verticalArrangement = Arrangement.Center,
     ) {
-        MagicSkeletonTile(
-            modifier = Modifier.size(width = 160.dp, height = 220.dp),
-            shape = MaterialTheme.shapes.medium,
-            glyphSize = 80.dp,
-        )
+        // Hidden candle egg (Candela v1.1) — 7 taps on the sigil tile
+        // lights the flame + whispers the meaning of "Candela".
+        `in`.jphe.storyvox.ui.component.CandleTapEgg {
+            MagicSkeletonTile(
+                modifier = Modifier.size(width = 160.dp, height = 220.dp),
+                shape = MaterialTheme.shapes.medium,
+                glyphSize = 80.dp,
+            )
+        }
         Spacer(Modifier.height(spacing.lg))
         Text(
             "Your library is empty",

--- a/feature/src/main/kotlin/in/jphe/storyvox/feature/milestone/MilestoneViewModel.kt
+++ b/feature/src/main/kotlin/in/jphe/storyvox/feature/milestone/MilestoneViewModel.kt
@@ -47,4 +47,22 @@ class MilestoneViewModel @Inject constructor(
     fun dismiss() {
         viewModelScope.launch { settings.markMilestoneDialogSeen() }
     }
+
+    // ── v1.1.0 "read it your way" milestone (Luna) ─────────────────
+    /** True iff the v1.1 "ignite" dialog should be on screen: the
+     *  build is inside the v1.1 window and the user hasn't dismissed it
+     *  on this install. Independent gate from [showDialog] — the two
+     *  milestones never co-fire (disjoint version windows) but carry
+     *  separate seen-flags so a user who dismissed the 0.5.00 card
+     *  still meets the 1.1 one. */
+    val showV110Dialog: StateFlow<Boolean> = settings.milestoneState
+        .map { it.v110Qualifies && !it.v110DialogSeen }
+        .stateIn(viewModelScope, SharingStarted.WhileSubscribed(5_000), false)
+
+    /** Dismiss the v1.1 ignite dialog (Continue or outside-tap).
+     *  Persists the seen-flag; [showV110Dialog] flips false next
+     *  emission and the dialog leaves the composition. */
+    fun dismissV110() {
+        viewModelScope.launch { settings.markV110MilestoneDialogSeen() }
+    }
 }

--- a/feature/src/main/kotlin/in/jphe/storyvox/feature/reader/HybridReaderScreen.kt
+++ b/feature/src/main/kotlin/in/jphe/storyvox/feature/reader/HybridReaderScreen.kt
@@ -31,7 +31,6 @@ import `in`.jphe.storyvox.ui.component.BrassButton
 import `in`.jphe.storyvox.ui.component.BrassButtonVariant
 import `in`.jphe.storyvox.ui.component.HybridReaderShell
 import `in`.jphe.storyvox.ui.component.MagicCircularProgress
-import `in`.jphe.storyvox.ui.component.MilestoneConfetti
 import `in`.jphe.storyvox.ui.theme.LocalSpacing
 
 @Composable
@@ -98,15 +97,27 @@ fun HybridReaderScreen(
     val wordHighlightArgb by viewModel.wordHighlightArgb.collectAsStateWithLifecycle()
     val playback = state.playback
 
-    // Calliope (v0.5.00) — first-natural-chapter-completion confetti.
-    // The VM's confettiTrigger fires Unit once per qualifying event;
-    // we flip a local visible flag that drives the [MilestoneConfetti]
-    // overlay, then close the gate persistently via markConfettiShown
-    // when the overlay tells us it's done.
+    // Chapter-completion celebration. The VM's confettiTrigger fires
+    // Unit once per qualifying event (v0.5.00 OR v1.1 window); we flip a
+    // local visible flag that drives the [LightMotes] overlay (v1.1
+    // upgraded the visual from falling confetti to rising motes), then
+    // close the gate persistently via markConfettiShown when the
+    // overlay tells us it's done.
     var celebrationVisible by remember { mutableStateOf(false) }
     LaunchedEffect(viewModel) {
         viewModel.confettiTrigger.collect {
             celebrationVisible = true
+        }
+    }
+
+    // Candela (v1.1.0) — book-completion streak. Each tier (1/5/10/25)
+    // pulled off the channel shows a LightMotes burst + an "N books
+    // lit" badge. The tier value also picks the badge copy. Conflated
+    // upstream, so we hold the latest tier in local state.
+    var streakTier by remember { mutableStateOf<Int?>(null) }
+    LaunchedEffect(viewModel) {
+        viewModel.bookStreakTrigger.collect { tier ->
+            streakTier = tier
         }
     }
 
@@ -397,18 +408,31 @@ fun HybridReaderScreen(
         DebugOverlay(viewModel = debugVm)
     }
 
-    // Calliope (v0.5.00) — confetti easter-egg, drifts across the
-    // player for ~3.5s then fades. Sits ABOVE the debug overlay so
+    // Chapter-completion celebration — rising LightMotes wash across
+    // the player (~2.8s) then fades. Sits ABOVE the debug overlay so
     // power users still see the celebration; the overlay can wait.
     // markConfettiShown persists the one-time flag so this never
     // reappears for this install. Non-blocking — no pointer
     // interception, just a Canvas drawing on top.
     if (celebrationVisible) {
-        MilestoneConfetti(
+        `in`.jphe.storyvox.ui.component.LightMotes(
             onFinished = {
                 celebrationVisible = false
                 viewModel.markConfettiShown()
             },
+        )
+    }
+
+    // Candela (v1.1.0) — book-streak celebration. A LightMotes burst
+    // plus an "N books lit" glow-badge, shown when the user crosses a
+    // streak tier on finishing a book. The badge lingers with the burst
+    // and clears together when the motes finish. Layered above the
+    // chapter-complete celebration; the two rarely coincide (one fires
+    // on ChapterDone, the other on BookFinished).
+    streakTier?.let { tier ->
+        `in`.jphe.storyvox.ui.component.BooksLitBadgeOverlay(
+            booksLit = tier,
+            onFinished = { streakTier = null },
         )
     }
 

--- a/feature/src/main/kotlin/in/jphe/storyvox/feature/reader/ReaderViewModel.kt
+++ b/feature/src/main/kotlin/in/jphe/storyvox/feature/reader/ReaderViewModel.kt
@@ -283,6 +283,19 @@ class ReaderViewModel @Inject constructor(
     private val _confettiTrigger = Channel<Unit>(capacity = Channel.CONFLATED)
     val confettiTrigger: Flow<Unit> = _confettiTrigger.receiveAsFlow()
 
+    /**
+     * Candela (v1.1.0) — book-completion streak celebration. Carries
+     * the streak tier (1/5/10/25) just crossed when the user finishes a
+     * book; [HybridReaderScreen] renders a [LightMotes] burst + an "N
+     * books lit" badge for each tier pulled off the channel. Conflated
+     * so a missed observer sees the latest signal but never a backlog.
+     * The counter increment + tier decision are serialized in the repo
+     * seam ([recordBookCompletedAndMilestone]) so this fires at most
+     * once per finished book.
+     */
+    private val _bookStreakTrigger = Channel<Int>(capacity = Channel.CONFLATED)
+    val bookStreakTrigger: Flow<Int> = _bookStreakTrigger.receiveAsFlow()
+
     /** Issue #805 — user-dismissed error message. When the user dismisses
      *  the playback error banner, we record the error message here. The
      *  combine below suppresses the banner when the current error message
@@ -324,8 +337,17 @@ class ReaderViewModel @Inject constructor(
             playback.events.collect { ev ->
                 when (ev) {
                     is PlaybackUiEvent.ChapterDone -> {
+                        // Fire the chapter-complete celebration when EITHER
+                        // milestone window is live and its one-time flag is
+                        // still unshown. v1.1 upgraded the visual from the
+                        // old falling confetti to the rising LightMotes; the
+                        // same conflated trigger drives both (the host picks
+                        // the overlay), so the serialization + one-time gate
+                        // are unchanged.
                         val ms = settings.milestoneState.first()
-                        if (ms.qualifies && !ms.confettiShown) {
+                        val v0500 = ms.qualifies && !ms.confettiShown
+                        val v110 = ms.v110Qualifies && !ms.v110ConfettiShown
+                        if (v0500 || v110) {
                             _confettiTrigger.trySend(Unit)
                         }
                     }
@@ -334,6 +356,14 @@ class ReaderViewModel @Inject constructor(
                     // so HybridReaderScreen renders the BookFinishedOverlay.
                     is PlaybackUiEvent.BookFinished -> {
                         _bookFinished.value = true
+                        // Candela (v1.1.0) — a finished book ticks the
+                        // device-local streak counter. The repo seam
+                        // serializes increment + tier decision; if this
+                        // increment crossed a tier (1/5/10/25) emit it for
+                        // the LightMotes + "N books lit" badge.
+                        settings.recordBookCompletedAndMilestone()?.let { tier ->
+                            _bookStreakTrigger.trySend(tier)
+                        }
                     }
                     else -> Unit
                 }
@@ -341,13 +371,18 @@ class ReaderViewModel @Inject constructor(
         }
     }
 
-    /** Calliope — called by [HybridReaderScreen] when the confetti
-     *  overlay fades out, so the one-time flag flips and the
-     *  celebration never replays. The collector branch above also
-     *  reads the flag on every ChapterDone, so this method
-     *  effectively closes the gate. */
+    /** Called by [HybridReaderScreen] when the chapter-complete
+     *  celebration overlay fades out, so the one-time flag flips and it
+     *  never replays. Flips BOTH milestone flags (Calliope v0.5.00 +
+     *  Candela v1.1) — only the live window's flag is read back by the
+     *  ChapterDone gate above, and flipping an already-true flag is a
+     *  harmless idempotent write, so we don't need to know which
+     *  milestone actually fired the burst. */
     fun markConfettiShown() {
-        viewModelScope.launch { settings.markMilestoneConfettiShown() }
+        viewModelScope.launch {
+            settings.markMilestoneConfettiShown()
+            settings.markV110ConfettiShown()
+        }
     }
 
     /** Issue #677 — user dismissed the end-of-book overlay (Back to

--- a/feature/src/main/kotlin/in/jphe/storyvox/feature/settings/AboutSettingsScreen.kt
+++ b/feature/src/main/kotlin/in/jphe/storyvox/feature/settings/AboutSettingsScreen.kt
@@ -51,11 +51,16 @@ fun AboutSettingsScreen(
                         text = stringResource(R.string.settings_about_version, s.sigil.versionName),
                         style = MaterialTheme.typography.bodyLarge,
                     )
-                    Text(
-                        text = s.sigil.name,
-                        style = MaterialTheme.typography.titleMedium,
-                        color = MaterialTheme.colorScheme.primary,
-                    )
+                    // Hidden candle egg (Candela v1.1) — 7 taps on the
+                    // brass sigil name lights the flame + whispers the
+                    // meaning of "Candela".
+                    `in`.jphe.storyvox.ui.component.CandleTapEgg {
+                        Text(
+                            text = s.sigil.name,
+                            style = MaterialTheme.typography.titleMedium,
+                            color = MaterialTheme.colorScheme.primary,
+                        )
+                    }
                     val dirtySuffix = if (s.sigil.dirty) stringResource(R.string.settings_about_dirty) else ""
                     val builtSuffix = stringResource(R.string.settings_about_built, s.sigil.built.take(10))
                     Text(


### PR DESCRIPTION
## Three candlelight easter eggs, one luminous language

Unified by **one reusable `LightMotes` engine** (core-ui) — rising amber→gold motes + soft radial bloom + alpha fade, the celebratory one-shot sibling of the ambient `BrassEmberOverlay`. Shares its `LocalReducedMotion` / `LocalAnimationSpeedScale` (#589) / `LocalParticleIntensity` (#590) seams + brass palette, so a celebration never contradicts the user's own settings.

### 1. V110 "read it your way" ignite dialog (centerpiece)
- Own `qualifiesV110()` / window **[1.1.0, 1.2.0)** in `Milestone.kt` (per-version helper + own DataStore keys, per the kdoc convention — never reuse a gate across versions).
- `MilestoneState.v110*` / `markV110*` **default-no-op seam** (zero test-fake churn), `MilestoneViewModel.showV110Dialog`, mounted in `StoryvoxNavHost`.
- **Staggered ignite** on one master clock with overlapping windows: flame draws in → radial glow blooms → motes rise → soundwave arc-rings pulse → settle to a gentle flicker. Reads as a candle being lit, not five things firing at once.
- Reduce-motion → warm static lit candle + copy, never blank.
- Copy: *"Candela 1.1 — read it your way."*

### 2. Hidden candle egg
- `CandleTapEgg` wraps the sigil glyph (empty-library `MagicSkeletonTile` + About sigil name). **7 silent taps** light a flame-burst and whisper *"Candela — the SI unit of luminous intensity."* Re-discoverable (not one-time gated).

### 3. Book-completion streak
- Device-local counter via `recordBookCompletedAndMilestone()` (serialized read-modify-write through the repo seam). Tiers **1/5/10/25** fire a `LightMotes` burst + an **"N books lit"** glow-badge (TalkBack live-region).
- Chapter-complete celebration **upgraded** from the falling `MilestoneConfetti` to the rising `LightMotes` (same conflated trigger + one-time gate, broadened to either milestone window).

### Bundled
- storyvox→candela release-APK naming rename (`app/build.gradle.kts` + `.github/workflows/android.yml`).

## Tests (TDD, RED→GREEN proven)
- `Milestone.qualifiesV110` window (disjoint from the v0.5.00 window, fail-closed)
- `bookStreakMilestoneCrossed` delta — highest-tier-only, no backlog on vaulting jumps
- `LightMotes` mote + bloom alpha envelopes (red-proofed by breaking the peak)
- `remap` beat-window math + overlapping-beats canary
- streak taglines tied to the canonical tier set
- All `:core-ui` tests green; `Milestone.qualifiesV110` green via `:app`.

## Verification
- `:app:assembleDebug` ✓ (Compose brace/animation correctness)
- `:app:assembleRelease` ✓ (required Build APK gate)
- Installed on **R83W80CAFZB** (`org.techempower.candela` versionCode **228** / versionName **1.1.0**), clean launch (no FATAL). **Ignite dialog + hidden candle egg confirmed on-device** (screenshots in the team thread).

Do **not** merge — the lead drains via the consolidation pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * v1.1 "Candela" milestone with an animated ignition dialog and light-motes celebration
  * Device-local book-completion streaks with tiered celebrations (1, 5, 10, 25) and a book-lit badge overlay
  * Hidden candle tap easter egg added to library and about screens

* **Tests**
  * New unit tests for version gating, streak milestone detection, and animation/envelope behavior

* **Chores**
  * App artifacts and release workflow renamed/updated to "Candela"
<!-- end of auto-generated comment: release notes by coderabbit.ai -->