### PR TITLE
docs(a11y): unstale AccessibilitySettingsScreen kdoc — prefs are wired (#1018)

### DIFF
--- a/feature/src/main/kotlin/in/jphe/storyvox/feature/settings/AccessibilitySettingsScreen.kt
+++ b/feature/src/main/kotlin/in/jphe/storyvox/feature/settings/AccessibilitySettingsScreen.kt
@@ -36,14 +36,14 @@ import `in`.jphe.storyvox.feature.api.SpeakChapterMode
 import `in`.jphe.storyvox.ui.theme.LocalSpacing
 
 /**
- * Settings → Accessibility subscreen (Phase 1 scaffold).
+ * Settings → Accessibility subscreen.
  *
- * Phase 1 surfaces the user's explicit intent for the assistive-
- * service-shaped tunables. No behavior is wired today — every toggle
- * here writes to DataStore and the live state-bridge in
- * [AccessibilityStateBridge] reports what Android is doing right now,
- * but neither feeds back into the rest of the app yet. Phase 2 agents
- * consume these prefs + the bridge to:
+ * Surfaces the user's explicit intent for the assistive-service-shaped
+ * tunables — and each is now WIRED: every toggle writes to DataStore,
+ * and the values are consumed across the app (via MainActivity's
+ * CompositionLocal providers, the A11y DI modules, and the themes). The
+ * live state-bridge in [AccessibilityStateBridge] reports what Android
+ * is doing right now (e.g. whether TalkBack is active). The wired effects:
  *
  *  - swap Library Nocturne for a higher-contrast variant
  *    ([UiSettings.a11yHighContrast]),
@@ -60,13 +60,7 @@ import `in`.jphe.storyvox.ui.theme.LocalSpacing
  *  - override system reading direction
  *    ([UiSettings.a11yReadingDirection]).
  *
- * Each Phase 2 agent will detect a Phase 1 placeholder by the
- * "TODO — Phase 2" inline kdoc on the relevant callback wiring and
- * replace it with the real handler. The Phase 2 placeholders are
- * deliberately load-bearing here — they document the contract for the
- * agent that lands the behavior.
- *
- * Row order matches the spec in the spawning conversation:
+ * Row order:
  *  1. High contrast theme
  *  2. Reduced motion
  *  3. Larger touch targets


### PR DESCRIPTION
Closes #1018.

The screen kdoc still said *"Phase 1 scaffold … No behavior is wired today"*, but all 8 a11y tunables are now consumed across the app:
- high-contrast / larger-touch-targets / font-scale-override / reading-direction → MainActivity CompositionLocal providers
- screen-reader inter-sentence pause → A11y DI module
- reduced-motion → LibraryNocturneTheme (+ the motion locals)
- speak-chapter-mode → A11yLocals

Rewrites the class kdoc to present-tense (the wired effects) and drops the stale Phase-2-placeholder paragraph. **Comment-only — no behavior change.**

Note: the per-row inline `// … Phase 2 …` breadcrumbs lower in the file are likewise historical; left for a follow-up to avoid ballooning a doc fix (the issue is specifically the class kdoc).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Accessibility settings toggles now properly persist and apply across the app.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->