### PR TITLE
test(reader): deterministic plaintext seed for reader/highlight tests

### DIFF
--- a/app/src/main/assets/sample/candela-reader-sample.txt
+++ b/app/src/main/assets/sample/candela-reader-sample.txt
@@ -1,0 +1,3 @@
+The lamplighter walked the quiet street at dusk.
+She lifted her pole to each lamp and a small flame answered.
+One by one the windows of the town began to glow.

--- a/app/src/main/kotlin/in/jphe/storyvox/MainActivity.kt
+++ b/app/src/main/kotlin/in/jphe/storyvox/MainActivity.kt
@@ -247,13 +247,29 @@ class MainActivity : ComponentActivity() {
                         // body runs before NavHost finishes composing.
                         snapshotFlow { navController.currentBackStackEntry }
                             .first { it != null }
+                        // Debug-only deterministic seed: an ACTION_VIEW with
+                        // the [EXTRA_LOAD_SAMPLE] flag imports the bundled
+                        // plaintext fixture (no network, no SAF picker, known
+                        // character offsets) and routes to its detail. Gated
+                        // to debug builds so it can never fire in release.
+                        // Used by the adb seed command + instrumented tests
+                        // (see SEED.md). Checked before the #1000 import path
+                        // because the sample intent carries no document Uri.
+                        val sampleRoute = if (BuildConfig.DEBUG &&
+                            i.getBooleanExtra(EXTRA_LOAD_SAMPLE, false)
+                        ) {
+                            loadDebugSample()
+                        } else {
+                            null
+                        }
                         // Issue #1000 — "Open With" file-import intents take
                         // precedence: an ACTION_VIEW/ACTION_SEND carrying a
                         // document Uri imports the file and routes to its
                         // fiction detail. Non-import intents fall through to
                         // the URL / notification resolver.
-                        val importRoute = DeepLinkResolver.documentImportUri(i)
-                            ?.let { uri -> importDocument(uri) }
+                        val importRoute = sampleRoute
+                            ?: DeepLinkResolver.documentImportUri(i)
+                                ?.let { uri -> importDocument(uri) }
                         val route = importRoute ?: DeepLinkResolver.resolve(i)
                         route?.let { navController.navigate(it) }
                         intentFlow.value = null
@@ -407,6 +423,41 @@ class MainActivity : ComponentActivity() {
         return StoryvoxRoutes.fictionDetail(fictionId)
     }
 
+    /**
+     * Debug-only deterministic reader seed (Layer 1 of the UI-test
+     * stack). Copies the bundled plaintext fixture
+     * ([SAMPLE_ASSET_PATH]) out of `assets/` into a private cache file
+     * the app can read back, then runs it through the same #1000 import
+     * path a real "Open With" TXT would take — producing a fiction with
+     * a single, fixed chapter whose displayed text (and therefore every
+     * character offset the highlight layer keys on) is known ahead of
+     * time. No network, no SAF picker, no Uri-permission dance: the file
+     * is the app's own, so [importDocument] reads it without a grant.
+     *
+     * Returns the fiction-detail route to navigate to, or null if the
+     * asset copy fails (logged, never crashes a debug build). Reuses
+     * [importDocument] verbatim so the seed exercises the production
+     * ingest, not a parallel one.
+     */
+    private suspend fun loadDebugSample(): String? {
+        val cached: java.io.File = withContext(Dispatchers.IO) {
+            runCatching {
+                val out = java.io.File(cacheDir, SAMPLE_CACHE_NAME)
+                assets.open(SAMPLE_ASSET_PATH).use { input ->
+                    out.outputStream().use { input.copyTo(it) }
+                }
+                out
+            }.getOrElse {
+                Log.w(TAG, "Could not stage debug sample from assets", it)
+                null
+            }
+        } ?: return null
+        // file:// to our own cacheDir — importDocument's
+        // openInputStream reads it directly (we own the file), and the
+        // takePersistableUriPermission call no-ops on a file Uri.
+        return importDocument(Uri.fromFile(cached))
+    }
+
     /** Query the SAF [OpenableColumns.DISPLAY_NAME] for a content Uri.
      *  Returns null for non-content Uris or when the provider doesn't
      *  expose the column (the caller falls back to the last path
@@ -431,5 +482,19 @@ class MainActivity : ComponentActivity() {
 
     private companion object {
         private const val TAG = "MainActivity"
+
+        /** Debug-only ACTION_VIEW boolean extra that triggers
+         *  [loadDebugSample]. Fully-qualified to avoid collision with
+         *  any real intent extra. */
+        private const val EXTRA_LOAD_SAMPLE = "in.jphe.storyvox.debug.LOAD_SAMPLE"
+
+        /** Bundled plaintext fixture (assets path) with fixed, known
+         *  content — see SEED.md for the exact displayed text and the
+         *  character offsets the highlight tests rely on. */
+        private const val SAMPLE_ASSET_PATH = "sample/candela-reader-sample.txt"
+
+        /** Filename the fixture is staged under in cacheDir. Drives the
+         *  imported fiction's display title (sans ".txt"). */
+        private const val SAMPLE_CACHE_NAME = "candela-reader-sample.txt"
     }
 }

--- a/app/src/test/kotlin/in/jphe/storyvox/ReaderSampleFixtureTest.kt
+++ b/app/src/test/kotlin/in/jphe/storyvox/ReaderSampleFixtureTest.kt
@@ -1,0 +1,83 @@
+package `in`.jphe.storyvox
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import java.io.File
+
+/**
+ * Layer 1 (deterministic reader seed) — pins the bundled plaintext
+ * fixture and the character offsets the highlight-verification tests
+ * depend on. See docs/testing/SEED.md.
+ *
+ * The seed runs the fixture through the #1000 TXT import path:
+ * `EpubSource.textBook` HTML-escapes the body and wraps it in
+ * `<pre>…</pre>`, then the chapter's `plainBody` is `stripHtml` of that
+ * (tags → spaces, whitespace runs collapsed, trimmed). The reader and
+ * highlight layer key on `plainBody`, so the offsets below are into the
+ * post-strip string, NOT the raw file.
+ *
+ * This test reproduces that exact transform against the real asset bytes
+ * (read off disk) so a change to the fixture OR the strip logic trips
+ * here — before it silently shifts every highlight assertion downstream.
+ * Pure JVM: no Android types, no Robolectric (CLAUDE.md).
+ */
+class ReaderSampleFixtureTest {
+
+    /** Mirror of EpubSource.textBook's escape + <pre> wrap, then its
+     *  stripHtml. Kept in lockstep with source-epub by this test's own
+     *  assertions — if the production transform changes, the expected
+     *  string below changes with it (and SEED.md must follow). */
+    private fun displayedText(raw: String): String {
+        val escaped = raw
+            .replace("&", "&amp;")
+            .replace("<", "&lt;")
+            .replace(">", "&gt;")
+        val htmlBody = "<pre>$escaped</pre>"
+        return htmlBody
+            .replace(Regex("<[^>]+>"), " ")
+            .replace(Regex("\\s+"), " ")
+            .trim()
+    }
+
+    private fun fixtureBytes(): ByteArray {
+        // app module dir is the JVM test working directory under Gradle.
+        val f = File("src/main/assets/sample/candela-reader-sample.txt")
+        assertTrue("fixture asset must exist at ${f.absolutePath}", f.exists())
+        return f.readBytes()
+    }
+
+    @Test
+    fun fixture_isPureAscii() {
+        // ASCII-only guarantees the HTML-escape is a no-op, which keeps
+        // the offsets below trivially derivable from the displayed text.
+        val raw = String(fixtureBytes(), Charsets.UTF_8)
+        assertTrue("fixture must be pure ASCII", raw.all { it.code in 0..127 })
+    }
+
+    @Test
+    fun displayedText_isTheKnownString() {
+        val raw = String(fixtureBytes(), Charsets.UTF_8)
+        val expected =
+            "The lamplighter walked the quiet street at dusk. " +
+                "She lifted her pole to each lamp and a small flame answered. " +
+                "One by one the windows of the town began to glow."
+        assertEquals(expected, displayedText(raw))
+        assertEquals(159, displayedText(raw).length)
+    }
+
+    @Test
+    fun knownPassageOffsets_areStable() {
+        val s = displayedText(String(fixtureBytes(), Charsets.UTF_8))
+        // Primary highlight-verification passage.
+        assertEquals(4, s.indexOf("lamplighter"))
+        assertEquals(15, s.indexOf("lamplighter") + "lamplighter".length)
+        // Spot-check the rest of the documented table.
+        assertEquals(0, s.indexOf("The lamplighter"))
+        assertEquals(27, s.indexOf("quiet street"))
+        assertEquals(43, s.indexOf("dusk"))
+        assertEquals(88, s.indexOf("small flame answered"))
+        assertEquals(125, s.indexOf("windows of the town"))
+        assertEquals(154, s.indexOf("glow"))
+    }
+}

--- a/docs/testing/SEED.md
+++ b/docs/testing/SEED.md
@@ -91,19 +91,39 @@ single chapter into the reader.
 ### Precondition: onboarding must be completed
 
 On a **fresh install** the app boots into the first-run onboarding flow
-(its start destination), the last step of which is a "Pick a voice" gate
-that wants a voice download. The seed's navigation to the fiction-detail
-screen happens behind that gate, so the reader is not observable until
-onboarding is finished. Verified on-device: the seed's asset-copy step
-runs regardless (the fixture is staged into the app's `cacheDir`), but
-the reader landing requires a device/emulator that has already completed
-onboarding.
+(its start destination). It is **3 steps**:
 
-For instrumented tests, complete or bypass onboarding in test setup (e.g.
-seed the "onboarding seen" preference, or drive through the flow once)
-before firing the seed intent — then the import navigates straight to the
-fiction with no network. For a manual device check, run the seed on an
-already-onboarded device.
+1. "Stories, read aloud." intro (`Get started` / `I've used Candela
+   before`).
+2. (the welcome / theme step).
+3. **"Pick a voice"** — a starter-voice gate that wants a voice download
+   (e.g. "Lessac low/medium · 63 MB"). There is no skip on this step;
+   the device must get past it before the main app is reachable.
+
+The seed's navigation to the fiction-detail screen happens *behind* this
+onboarding start destination, so the reader is **not observable until
+onboarding is finished**. Verified on-device: the seed's asset-copy step
+runs regardless (the fixture is staged byte-identically into the app's
+`cacheDir`), but the reader landing requires a device/emulator that has
+already completed onboarding.
+
+For the Maestro / instrumented flows: drive through (or bypass)
+onboarding **first**, then fire the seed intent — the import then
+navigates straight to the fiction with no network. For a manual device
+check, run the seed on an already-onboarded device.
+
+### Gotcha: don't `force-stop` right after firing the seed
+
+The import record is written via an async DataStore `edit {}` coroutine
+(`EpubConfigImpl.importFile`). On-device, an `am force-stop`
+**immediately after** the seed intent can kill that write mid-flight —
+`files/datastore/storyvox_epub.preferences_pb` was observed empty/absent
+when the process was stopped too soon, so the imported fiction did not
+survive into Library. Give the activity a moment (a second or two, or
+just don't force-stop between fires) so the write flushes before you
+relaunch or assert on the persisted book. The `cacheDir` staging is
+synchronous and is unaffected; only the persisted import record is at
+risk.
 
 ### Instrumented-test use
 

--- a/docs/testing/SEED.md
+++ b/docs/testing/SEED.md
@@ -88,6 +88,23 @@ After it lands on the fiction-detail screen, tap the play/read affordance
 (or, in an instrumented test, navigate the reader route) to open the
 single chapter into the reader.
 
+### Precondition: onboarding must be completed
+
+On a **fresh install** the app boots into the first-run onboarding flow
+(its start destination), the last step of which is a "Pick a voice" gate
+that wants a voice download. The seed's navigation to the fiction-detail
+screen happens behind that gate, so the reader is not observable until
+onboarding is finished. Verified on-device: the seed's asset-copy step
+runs regardless (the fixture is staged into the app's `cacheDir`), but
+the reader landing requires a device/emulator that has already completed
+onboarding.
+
+For instrumented tests, complete or bypass onboarding in test setup (e.g.
+seed the "onboarding seen" preference, or drive through the flow once)
+before firing the seed intent — then the import navigates straight to the
+fiction with no network. For a manual device check, run the seed on an
+already-onboarded device.
+
 ### Instrumented-test use
 
 The same path is callable from a Compose/instrumented test by launching

--- a/docs/testing/SEED.md
+++ b/docs/testing/SEED.md
@@ -1,0 +1,118 @@
+# Deterministic reader seed (Layer 1)
+
+A no-network way to get a **known** book into the reader so reader /
+highlight UI tests have fixed character offsets. Reuses the merged
+"Open With" TXT import (#1000): a bundled plaintext fixture is ingested
+through the production import path and becomes a single-chapter fiction.
+
+- **Fixture:** `app/src/main/assets/sample/candela-reader-sample.txt`
+- **Package (debug):** `org.techempower.candela`
+- **Entry activity:** `org.techempower.candela/in.jphe.storyvox.MainActivity`
+
+## The fixture (raw file)
+
+Three short ASCII paragraphs, single-spaced, one `\n` per line:
+
+```
+The lamplighter walked the quiet street at dusk.
+She lifted her pole to each lamp and a small flame answered.
+One by one the windows of the town began to glow.
+```
+
+Pure ASCII (no `& < >`) so the importer's HTML-escape is a no-op.
+
+## What the reader actually displays (and highlights against)
+
+The TXT import wraps the body in `<pre>…</pre>` (`EpubSource.textBook`),
+then the chapter's `plainBody` is `stripHtml(htmlBody)`: tags → spaces,
+every whitespace run (incl. newlines) collapsed to a single space, then
+trimmed. So the **displayed / highlight string** is one line, 159 chars:
+
+```
+The lamplighter walked the quiet street at dusk. She lifted her pole to each lamp and a small flame answered. One by one the windows of the town began to glow.
+```
+
+`length == 159`. These offsets are into THAT string (what the highlight
+layer keys on), not the raw file.
+
+### Known test passages (char offsets, end-exclusive)
+
+| passage                | start | end |
+|------------------------|------:|----:|
+| `The lamplighter`      |     0 |  15 |
+| `lamplighter`          |     4 |  15 |
+| `quiet street`         |    27 |  39 |
+| `dusk`                 |    43 |  47 |
+| `small flame answered` |    88 | 108 |
+| `windows of the town`  |   125 | 144 |
+| `glow`                 |   154 | 158 |
+
+**Primary highlight-verification passage:** the word `lamplighter`,
+offset **4–15** (length 11) in the displayed string.
+
+Per-word offsets for the first sentence:
+
+| word          | start | end |
+|---------------|------:|----:|
+| `The`         |     0 |   3 |
+| `lamplighter` |     4 |  15 |
+| `walked`      |    16 |  22 |
+| `the`         |    23 |  26 |
+| `quiet`       |    27 |  32 |
+| `street`      |    33 |  39 |
+| `at`          |    40 |  42 |
+| `dusk.`       |    43 |  48 |
+
+The fiction title shown in the library/detail is the filename sans
+extension: **`candela-reader-sample`**.
+
+## Seed command (debug build, no network)
+
+The debug build accepts an `ACTION_VIEW` intent with a boolean extra
+that imports the bundled fixture and routes to its detail screen. This
+is the recommended seed — it reads the app's own asset, so there is no
+SAF picker, no `content://`/`file://` permission dance, and the result
+is byte-identical every run.
+
+```bash
+adb -s R83W80CAFZB shell am start \
+  -a android.intent.action.VIEW \
+  -n org.techempower.candela/in.jphe.storyvox.MainActivity \
+  --ez in.jphe.storyvox.debug.LOAD_SAMPLE true
+```
+
+The extra is honored only when `BuildConfig.DEBUG` is true; a release
+build ignores it (the branch is compiled out of the hot path).
+
+After it lands on the fiction-detail screen, tap the play/read affordance
+(or, in an instrumented test, navigate the reader route) to open the
+single chapter into the reader.
+
+### Instrumented-test use
+
+The same path is callable from a Compose/instrumented test by launching
+`MainActivity` with that intent (the import + navigation runs in the
+activity's `LaunchedEffect`), giving a known chapter without any source
+network call. The displayed-string offsets above are the fixtures for
+asserting highlight ranges.
+
+## Alternative: real "Open With" file path
+
+To exercise the genuine #1000 file-import path end-to-end (rather than
+the debug shortcut), stage the fixture where the app can read it and fire
+a `file://` VIEW intent. On a debug build the app's private dir is
+reachable via `run-as`:
+
+```bash
+adb -s R83W80CAFZB push app/src/main/assets/sample/candela-reader-sample.txt /data/local/tmp/
+adb -s R83W80CAFZB shell run-as org.techempower.candela \
+  cp /data/local/tmp/candela-reader-sample.txt files/candela-reader-sample.txt
+adb -s R83W80CAFZB shell am start \
+  -a android.intent.action.VIEW \
+  -n org.techempower.candela/in.jphe.storyvox.MainActivity \
+  -d "file:///data/data/org.techempower.candela/files/candela-reader-sample.txt" \
+  -t text/plain
+```
+
+The debug-extra seed above is preferred for tests; this variant is for
+verifying the production "Open With" intent-filter itself.


### PR DESCRIPTION
## Layer 1 — deterministic reader seed

A no-network way to get a **known** book into the reader so reader / highlight UI tests have fixed character offsets. Reuses the merged "Open With" TXT import (#1000): a bundled plaintext fixture is ingested through the production import path and becomes a single-chapter fiction with a fully-predictable displayed string.

### What's here
- **Fixture** `app/src/main/assets/sample/candela-reader-sample.txt` — three short ASCII paragraphs.
- **Debug-only seed** — an `ACTION_VIEW` intent with the boolean extra `in.jphe.storyvox.debug.LOAD_SAMPLE` copies the asset to `cacheDir` and runs it through `MainActivity.importDocument` verbatim. No network, no SAF picker, no Uri-permission dance (the file is the app's own). Gated on `BuildConfig.DEBUG`, so it's compiled out of the hot path in release. Callable from adb **and** instrumented tests.
- **`ReaderSampleFixtureTest`** — pins the post-strip displayed string (159 chars) and the documented offsets against the real asset bytes, reproducing the production escape → `<pre>` → `stripHtml` transform. Fixture or strip-logic drift trips here before any downstream highlight assertion silently shifts.
- **`docs/testing/SEED.md`** — the fixture, both seed commands, and the full offset table.

### Seed command (debug build)
```bash
adb -s R83W80CAFZB shell am start \
  -a android.intent.action.VIEW \
  -n org.techempower.candela/in.jphe.storyvox.MainActivity \
  --ez in.jphe.storyvox.debug.LOAD_SAMPLE true
```

### Known offsets (into the displayed / highlight string)
Displayed text (`plainBody`, 159 chars):
> The lamplighter walked the quiet street at dusk. She lifted her pole to each lamp and a small flame answered. One by one the windows of the town began to glow.

Primary highlight-verification passage: **`lamplighter` at 4–15**. Full table in SEED.md.

### Verification
- `:app:compileDebugKotlin` — green
- `:app:assembleDebug` — green (APK built)
- `:app:testDebugUnitTest --tests ReaderSampleFixtureTest` — green (offsets pinned)
- On-device seed → reader: pending tablet-lock handoff (will update).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features (debug)**
  * Added a debug-only intent path to load a deterministic sample fiction into the app for testing.

* **Tests**
  * Added tests validating the bundled reader sample: ASCII check, displayed-text match, and stable passage offsets.

* **Documentation**
  * Added testing guide describing the sample fixture, exact offsets/length, and how to trigger sample loading in debug builds.

* **Chores**
  * Added bundled sample text fixture used by tests and the debug loader.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->