### PR TITLE
test(app): instrumented Compose UI test infra + launch smoke (#1088)

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -430,6 +430,11 @@ android {
         getByName("testRelease") {
             java.srcDirs("src/testRelease/kotlin")
         }
+        // #1088 — instrumented (on-device) test source set. Same `kotlin/`
+        // convention as main/test above; default is `java/`.
+        getByName("androidTest") {
+            java.srcDirs("src/androidTest/kotlin")
+        }
     }
 
     testOptions {
@@ -665,6 +670,22 @@ dependencies {
     testImplementation(libs.robolectric)
     androidTestImplementation(libs.androidx.junit)
     androidTestImplementation(libs.androidx.espresso.core)
+
+    // #1088 — Layer 3 instrumented Compose UI test infra. The Compose BOM
+    // must be on the androidTest classpath too so ui-test-junit4 resolves to
+    // the same Compose version the app is built against (the main-classpath
+    // platform() above doesn't propagate to androidTest). ui-test-manifest is
+    // a debugImplementation: it adds the stub ComponentActivity the test rule
+    // launches into and never ships in the release APK.
+    androidTestImplementation(platform(libs.androidx.compose.bom))
+    androidTestImplementation(libs.androidx.compose.ui.test.junit4)
+    debugImplementation(libs.androidx.compose.ui.test.manifest)
+    // GrantPermissionRule (androidx.test:rules) — MainActivity requests
+    // POST_NOTIFICATIONS at launch; on an ungranted device the system
+    // permission dialog steals focus and pauses MainActivity, so the
+    // Compose registry sees zero resumed roots ("No compose hierarchies
+    // found"). Pre-granting the permission keeps the activity resumed.
+    androidTestImplementation(libs.androidx.test.rules)
 
     // Issue #409 — ProfileInstaller compiles the bundled
     // `baseline-prof.txt` at first-run on devices that don't go through

--- a/app/src/androidTest/kotlin/in/jphe/storyvox/LaunchSmokeTest.kt
+++ b/app/src/androidTest/kotlin/in/jphe/storyvox/LaunchSmokeTest.kt
@@ -1,0 +1,88 @@
+package `in`.jphe.storyvox
+
+import android.Manifest
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.junit4.createAndroidComposeRule
+import androidx.compose.ui.test.onAllNodesWithText
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import androidx.test.rule.GrantPermissionRule
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+
+/**
+ * Layer 3 proof-of-life — the first instrumented (on-device) Compose UI
+ * test in the project (#1088). It exists to prove the androidTest stack is
+ * wired correctly end to end: the Compose BOM resolves on the androidTest
+ * classpath, ui-test-junit4 + ui-test-manifest are present, the
+ * AndroidJUnitRunner instantiates the real `@HiltAndroidApp` [StoryvoxApp]
+ * (so the Hilt graph is the production graph — no test harness needed for a
+ * launch-only smoke), and [MainActivity] reaches first frame without
+ * crashing.
+ *
+ * Two device-launch obstacles had to be cleared for the activity to reach
+ * the resumed state the Compose test registry reads (both verified by
+ * inspecting `dumpsys window` / `dumpsys activity` while the test polled):
+ *
+ *  1. MainActivity is `launchMode="singleTask"` in production. ActivityScenario
+ *     (which backs [createAndroidComposeRule]) can't instrument a singleTask
+ *     activity — the system reparents it into its own task, so the test
+ *     owner sees no composition. Fixed by a debug-variant manifest overlay
+ *     (`app/src/debug/AndroidManifest.xml`) that flips launchMode to
+ *     `standard`; the shipped `release` variant keeps singleTask.
+ *
+ *  2. MainActivity requests POST_NOTIFICATIONS at launch. On an ungranted
+ *     device the system permission dialog (GrantPermissionsActivity) takes
+ *     focus and PAUSES MainActivity, so the registry reports zero resumed
+ *     roots ("No compose hierarchies found"). [grantNotifications] pre-grants
+ *     the permission so no dialog appears and the activity stays resumed.
+ *
+ * Assertion target: the visible string "Library". It's the bottom-nav tab
+ * label — a hardcoded enum constant in `core-ui`'s `BottomTabBar.HomeTab`
+ * (not a string resource), so it's the most stable visible text on the
+ * post-onboarding home surface. The shared test tablet (R83W80CAFZB) has
+ * onboarding already completed, so the bottom bar is the cold-launch
+ * landing surface.
+ *
+ * Assertion shape: the word "Library" renders in several places on the
+ * cold-launch Library surface (the bottom-nav tab, the in-screen
+ * Library/Reading tab, the screen title) — observed as 2-3 matching nodes,
+ * some clickable. For a launch proof-of-life that's fine: we assert that at
+ * least one "Library" node renders AND is displayed, rather than
+ * over-specifying which one. `onNodeWithText`/`hasClickAction` both threw
+ * "expected at most 1 node" against the real surface.
+ *
+ * TODO(#1088 follow-up): assert a single, semantically-meaningful node via a
+ * testTag once Lyra's Layer-0 PR lands testTags on the core navigable
+ * surface — text matching is brittle to copy changes and locale, and can't
+ * disambiguate the duplicate "Library" labels; a stable tag fixes both.
+ */
+@RunWith(AndroidJUnit4::class)
+class LaunchSmokeTest {
+
+    // Pre-grant POST_NOTIFICATIONS so the system permission dialog never
+    // pops at launch (see class kdoc, obstacle #2). On API < 33 the
+    // permission doesn't exist and GrantPermissionRule is a no-op.
+    @get:Rule(order = 0)
+    val grantNotifications: GrantPermissionRule =
+        GrantPermissionRule.grant(Manifest.permission.POST_NOTIFICATIONS)
+
+    @get:Rule(order = 1)
+    val composeRule = createAndroidComposeRule<MainActivity>()
+
+    @Test
+    fun launches_andShowsLibraryTab() {
+        // Compose may still be settling first frame / running the cold-launch
+        // animations when the rule hands control back. Wait for the nav bar
+        // to render rather than asserting eagerly — the bottom bar mounts
+        // after the VoicePickerGate resolves.
+        composeRule.waitUntil(timeoutMillis = 15_000) {
+            composeRule.onAllNodesWithText("Library").fetchSemanticsNodes().isNotEmpty()
+        }
+
+        // Proof-of-life: at least one "Library" node rendered and is on
+        // screen. Assert the first match is displayed (see kdoc on why we
+        // don't over-specify which "Library" node before testTags land).
+        composeRule.onAllNodesWithText("Library")[0].assertIsDisplayed()
+    }
+}

--- a/app/src/debug/AndroidManifest.xml
+++ b/app/src/debug/AndroidManifest.xml
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  Debug-variant manifest overlay (#1088 — Layer 3 instrumented test infra).
+
+  Production MainActivity declares android:launchMode="singleTask" (so a
+  notification tap / deep link routes through the existing task rather than
+  stacking a duplicate). That launch mode breaks AndroidX Test's
+  ActivityScenario — which backs createAndroidComposeRule<MainActivity>():
+  the system reparents a singleTask activity into a fresh task (observed as
+  t808, separate from the instrumentation task), so the ComposeTestRule's
+  TestOwner sees an empty composition and waitUntil times out ("No compose
+  hierarchies found").
+
+  The androidTest manifest can't fix this — it merges into the *test* APK
+  (org.techempower.candela.test), not the target app APK the test
+  instruments. The target is the *debug* APK, so the override belongs here.
+
+  tools:replace="android:launchMode" tells the manifest merger to override
+  (not conflict on) the value from the main manifest. This overlay applies to
+  the DEBUG variant only. The shipped artifact is the `release` variant (see
+  app/build.gradle.kts buildTypes — post-#529 release is the shipped build),
+  so production launch behavior is untouched: a sideloaded/Play release APK
+  still gets singleTask.
+-->
+<manifest xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools">
+
+    <application>
+        <activity
+            android:name="in.jphe.storyvox.MainActivity"
+            android:launchMode="standard"
+            tools:replace="android:launchMode" />
+    </application>
+</manifest>

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -74,6 +74,12 @@ junit = "4.13.2"
 androidx-junit = "1.3.0"
 espresso = "3.7.0"
 robolectric = "4.16.1"
+# Compose UI test (#1088 — Layer 3 instrumented test infra). ui-test-junit4
+# brings createAndroidComposeRule + the onNode*/assert* matchers; ui-test-
+# manifest injects the empty Activity the test rule needs at runtime (it's a
+# debugImplementation so it never ships in release). Both versions track the
+# Compose BOM (compose-bom above) — declared without version.ref so the BOM
+# pins them, matching how the other androidx.compose.* libraries resolve.
 
 # Baseline Profile / Macrobenchmark (#409 — cold-launch hot-path AOT).
 # benchmark provides BaselineProfileRule + MacrobenchmarkRule; the
@@ -205,6 +211,11 @@ junit = { module = "junit:junit", version.ref = "junit" }
 androidx-junit = { module = "androidx.test.ext:junit", version.ref = "androidx-junit" }
 androidx-espresso-core = { module = "androidx.test.espresso:espresso-core", version.ref = "espresso" }
 robolectric = { module = "org.robolectric:robolectric", version.ref = "robolectric" }
+# Compose UI test (#1088) — BOM-pinned, so no version here (see compose-bom).
+# ui-test-junit4 is androidTestImplementation; ui-test-manifest is
+# debugImplementation (it adds the stub Activity the rule launches into).
+androidx-compose-ui-test-junit4 = { module = "androidx.compose.ui:ui-test-junit4" }
+androidx-compose-ui-test-manifest = { module = "androidx.compose.ui:ui-test-manifest" }
 
 # Baseline Profile generator + StartupBenchmark dependencies (#409).
 # androidx.benchmark.macro.junit4.{BaselineProfileRule,MacrobenchmarkRule}


### PR DESCRIPTION
## Layer 3 — instrumented (on-device) Compose test infra

Stands up the androidTest Compose UI test stack and proves it end to end with one launch smoke test. This is the infra + proof-of-life; the #1079 selection-gesture test comes later (after #1088 merges).

### What's here
- **Deps** (BOM-pinned in `libs.versions.toml`): `androidx.compose.ui:ui-test-junit4` (`androidTestImplementation`), `ui-test-manifest` (`debugImplementation`), `androidx.test:rules` (for `GrantPermissionRule`). The Compose BOM is added to the androidTest classpath so `ui-test` resolves to the same Compose version the app is built against (`1.11.2`).
- **Source set**: `app/src/androidTest/kotlin` registered (matches the `kotlin/` convention used by `main`/`test`).
- **`LaunchSmokeTest`**: `createAndroidComposeRule<MainActivity>()` launches the app against the **real** `@HiltAndroidApp` graph (no Hilt test harness needed for a launch-only smoke) and asserts the `"Library"` bottom-nav label renders.

### Two device-launch obstacles cleared (both diagnosed via `dumpsys`)
1. **`launchMode="singleTask"`** — `ActivityScenario` (backing `createAndroidComposeRule`) can't instrument a singleTask activity; the system reparents it into its own task, so the test owner sees no composition (`No compose hierarchies found`). Fixed with a **debug-variant manifest overlay** (`app/src/debug/AndroidManifest.xml`, `tools:replace` → `launchMode=standard`). The shipped `release` variant keeps `singleTask` — **production launch behavior is untouched**.
2. **`POST_NOTIFICATIONS` request at launch** — on an ungranted device the system permission dialog (`GrantPermissionsActivity`) steals focus and **pauses** MainActivity, so the registry reports zero resumed roots. `GrantPermissionRule` pre-grants it (proven by revoking the permission on-device before a passing run).

### Verification
`./gradlew :app:connectedDebugAndroidTest` on **R83W80CAFZB** (Galaxy Tab A7 Lite, Android 14):

```
in.jphe.storyvox.LaunchSmokeTest > launches_andShowsLibraryTab  PASSED
1 test, 0 failures, 0 errors, 0 skipped — 12.5s
100% successful
```

`:app:testDebugUnitTest` still green; `:app:compileDebugAndroidTestKotlin` green.

### Follow-up
`testTag`-based matching is left as a TODO for when Lyra's Layer-0 PR lands testTags on the core navigable surface — text matching can't disambiguate the duplicate `"Library"` labels and is brittle to copy/locale changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added automated UI testing infrastructure to verify the app launches successfully and core navigation functions correctly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->