### PR TITLE
fix(feature): repair :feature unit-test compile — #996 PDF-folder fakes

### DIFF
--- a/feature/src/test/kotlin/in/jphe/storyvox/feature/settings/SettingsViewModelBufferTest.kt
+++ b/feature/src/test/kotlin/in/jphe/storyvox/feature/settings/SettingsViewModelBufferTest.kt
@@ -202,6 +202,9 @@ class SettingsViewModelBufferTest {
         override val epubFolderUri: kotlinx.coroutines.flow.Flow<String?> = kotlinx.coroutines.flow.flowOf(null)
         override suspend fun setEpubFolderUri(uri: String) = Unit
         override suspend fun clearEpubFolder() = Unit
+        override val pdfFolderUri: kotlinx.coroutines.flow.Flow<String?> = kotlinx.coroutines.flow.flowOf(null)
+        override suspend fun setPdfFolderUri(uri: String) = Unit
+        override suspend fun clearPdfFolder() = Unit
         override suspend fun setWikipediaLanguageCode(code: String) = Unit
         override suspend fun setDiscordApiToken(token: String?) = Unit
         override suspend fun setDiscordServer(serverId: String, serverName: String) = Unit

--- a/feature/src/test/kotlin/in/jphe/storyvox/feature/settings/SettingsViewModelModesTest.kt
+++ b/feature/src/test/kotlin/in/jphe/storyvox/feature/settings/SettingsViewModelModesTest.kt
@@ -277,6 +277,9 @@ class SettingsViewModelModesTest {
         override val epubFolderUri: kotlinx.coroutines.flow.Flow<String?> = kotlinx.coroutines.flow.flowOf(null)
         override suspend fun setEpubFolderUri(uri: String) = Unit
         override suspend fun clearEpubFolder() = Unit
+        override val pdfFolderUri: kotlinx.coroutines.flow.Flow<String?> = kotlinx.coroutines.flow.flowOf(null)
+        override suspend fun setPdfFolderUri(uri: String) = Unit
+        override suspend fun clearPdfFolder() = Unit
         override suspend fun setWikipediaLanguageCode(code: String) = Unit
         override suspend fun setDiscordApiToken(token: String?) = Unit
         override suspend fun setDiscordServer(serverId: String, serverName: String) = Unit

--- a/feature/src/test/kotlin/in/jphe/storyvox/feature/settings/SettingsViewModelPunctuationPauseTest.kt
+++ b/feature/src/test/kotlin/in/jphe/storyvox/feature/settings/SettingsViewModelPunctuationPauseTest.kt
@@ -215,6 +215,9 @@ class SettingsViewModelPunctuationPauseTest {
         override val epubFolderUri: kotlinx.coroutines.flow.Flow<String?> = kotlinx.coroutines.flow.flowOf(null)
         override suspend fun setEpubFolderUri(uri: String) = Unit
         override suspend fun clearEpubFolder() = Unit
+        override val pdfFolderUri: kotlinx.coroutines.flow.Flow<String?> = kotlinx.coroutines.flow.flowOf(null)
+        override suspend fun setPdfFolderUri(uri: String) = Unit
+        override suspend fun clearPdfFolder() = Unit
         override suspend fun setWikipediaLanguageCode(code: String) = Unit
         override suspend fun setDiscordApiToken(token: String?) = Unit
         override suspend fun setDiscordServer(serverId: String, serverName: String) = Unit


### PR DESCRIPTION
## Problem

`:feature:testDebugUnitTest` does **not compile on `main`** (`a82c2438`). Three `FakeSettingsRepo` implementations never grew the PDF SAF-folder members that #996 added to the `SettingsRepositoryUi` interface (`UiContracts.kt:2158-2161`):

```kotlin
val pdfFolderUri: Flow<String?>
suspend fun setPdfFolderUri(uri: String)
suspend fun clearPdfFolder()
```

A non-abstract class missing interface members is a hard compile error, so the whole `:feature` unit-test source set failed to build.

### Why it reached main

The only **required** CI check, `Build APK`, assembles the **release** variant and never compiles `testDebug` sources. Unit-test compilation is effectively unguarded by required CI — so a `:feature:testDebugUnitTest` breakage sailed through green.

## Fix

Add the three #996 overrides to each affected fake, matching the existing #235 `epubFolder` fake style (`flowOf(null)` + no-op suspend bodies):

- `SettingsViewModelModesTest.kt`
- `SettingsViewModelBufferTest.kt`
- `SettingsViewModelPunctuationPauseTest.kt`

9 insertions, no other changes. Confirmed these are the only `:feature` test fakes implementing the interface that were missing the members (the other interface references — `ChatViewModelTest`, `ChatToolHandlersTest` — already have them; `LexiconPathSafParseTest` only names the type in kdoc).

## Verification

From this worktree (`./gradlew :feature:testDebugUnitTest`):

```
BUILD SUCCESSFUL
427 tests, 0 failures, 0 errors
  SettingsViewModelModesTest        8/8
  SettingsViewModelBufferTest       3/3
  SettingsViewModelPunctuationPauseTest  3/3
```

## Note on overlap

solace's #1088 carries an equivalent fix for these same fakes; team-lead will dedupe during #1088 integration. Landing this standalone unblocks `:feature` unit tests on `main` immediately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Extended test fixtures to support PDF folder persistence features in settings tests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->