### PR TITLE
fix(reader): don't paint the prior book on an explicit drill-down (#638)

### DIFF
--- a/feature/src/main/kotlin/in/jphe/storyvox/feature/reader/HybridReaderScreen.kt
+++ b/feature/src/main/kotlin/in/jphe/storyvox/feature/reader/HybridReaderScreen.kt
@@ -172,67 +172,40 @@ fun HybridReaderScreen(
     //      fall back on (otherwise AudiobookView's friendlier
     //      Retry/Pick-voice error block handles the dead-end case).
     //
-    // We compute the cases below in two steps so Kotlin's smart-cast
-    // on `playback != null` stays usable for the rest of the screen.
-    val showPromptForNullPlayback = playback == null
-    val showPromptForBlankIds = playback != null &&
-        playback.fictionId == null &&
-        playback.chapterId == null
-    val showPromptForTimedOutWithEntry =
-        playback != null && timedOut && resumeEntry != null
-    // Issue #638 (v1.0 blocker) — when the Reader was navigated to
-    // with explicit /reader/{fictionId}/{chapterId} args (drill-down
-    // from FictionDetail's Play button), the playback flow has not
-    // yet emitted by the time the composable first runs. Pre-fix the
-    // screen would fall through to ResumeEmptyPrompt and render the
-    // "Your library awaits / Browse the realms →" CTA — making it
-    // look exactly like the Library tab's empty state and convincing
-    // JP (and any user) that the Play tap had bounced them back to
-    // Library. Suppress the prompt branch entirely while the
-    // controller is still warming up on an explicit-args entry —
-    // the regular spinner inside AudiobookView (LoadingPhase.Loading)
-    // owns the loading affordance from here, just as it does for
-    // every other chapter-load path. The Playing tab (/playing, no
-    // args) still falls through to the prompt as before, which is
-    // the desired empty-state behaviour for that surface.
-    // Issue #638 — the explicit-args loading window covers BOTH the
-    // pre-emission case (showPromptForNullPlayback) AND the
-    // post-emission-but-blank-ids case (showPromptForBlankIds, where
-    // PlaybackController has emitted its default state with fictionId
-    // = null / chapterId = null but the controller's play() call
-    // hasn't reached the engine yet). The full sequence on a cold
-    // Play tap from FictionDetail:
-    //   t=0   :  user taps Play → listen(c) → startListening()
-    //   t=0+  :  screen navigates to /reader; ReaderVM constructs;
-    //            playback flow has not emitted → playback = null;
-    //            showPromptForNullPlayback = true
-    //   t=43ms:  playback flow emits default UiPlaybackState
-    //            (fictionId = null, chapterId = null); the null case
-    //            flips false BUT showPromptForBlankIds flips true,
-    //            and pre-fix that re-routed straight back to
-    //            ResumeEmptyPrompt — a 43ms flash of "Your library
-    //            awaits" was the bug. Including blank-ids here keeps
-    //            the explicit-args loading surface up through the
-    //            whole controller cold-start window, until the
-    //            controller fills in ids on the first chapter-load
-    //            tick. The TimedOut sub-branch within
-    //            [ExplicitArgsLoadingPrompt] surfaces a Retry/Back
-    //            block on a 30s wall — same affordance shape as the
-    //            in-AudiobookView TimedOut path, but rendered here
-    //            because we never reach AudiobookView with no ids.
-    val isExplicitArgsLoading = viewModel.hasExplicitChapterArgs &&
-        (showPromptForNullPlayback || showPromptForBlankIds)
-    if (isExplicitArgsLoading) {
-        // Brass loading-card surface while the controller warms up.
-        // Pre-fix this branch fell through to ResumeEmptyPrompt and
-        // rendered the "Your library awaits / Browse the realms →"
-        // CTA — visually indistinguishable from the Library empty
-        // state, and exactly what the bug report mistook for "the
-        // bottom-dock intercepted my Play tap." The real fix is here:
-        // show a typed loading state for the explicit-args path so
-        // the user sees "your chapter is loading," not "you have no
-        // library." Once the playback flow flips non-null the screen
-        // re-composes through the normal AudiobookView branch below.
+    // Issue #638 (v1.0 blocker) + TechEmpower wrong-book regression
+    // (v1.1.1) — the reader renders the GLOBAL PlaybackController state,
+    // not its own nav args. [readerContentMode] is the single gate that
+    // decides which top-level surface to show; see its kdoc for the full
+    // case table. The load-bearing cases:
+    //
+    //  - Explicit drill-down (/reader/{f}/{c}) while the controller is
+    //    still warming up (null/blank ids) OR — the v1.1.1 fix — while it
+    //    still holds a DIFFERENT (surviving prior) fiction than the one
+    //    requested → ExplicitLoading (brass loading card for the requested
+    //    fiction). Pre-fix the #638 gate only covered the blank-ids
+    //    warm-up window, so a process that survived from a prior session
+    //    painted the prior book through the explicit route until the cold
+    //    Resources body finally loaded (or permanently, on a 30s timeout).
+    //  - Playing tab (no args) with no loaded chapter → the magical Resume
+    //    prompt, or the "Browse the realms" empty prompt with no entry.
+    //  - Otherwise → render the player (AudiobookView) below.
+    val contentMode = readerContentMode(
+        hasExplicitChapterArgs = viewModel.hasExplicitChapterArgs,
+        argFictionId = viewModel.argFictionId,
+        hasPlayback = playback != null,
+        playbackFictionId = playback?.fictionId,
+        playbackChapterId = playback?.chapterId,
+        hasResumeEntry = resumeEntry != null,
+        timedOut = timedOut,
+    )
+    if (contentMode == ReaderContentMode.ExplicitLoading) {
+        // Brass loading-card surface while the controller warms up or
+        // catches up to the requested fiction. Pre-#638 this branch fell
+        // through to ResumeEmptyPrompt ("Your library awaits"); pre-v1.1.1
+        // a surviving prior fiction fell through to AudiobookView painting
+        // the WRONG book. Both are now held here until the controller
+        // reports the requested fiction, at which point the screen
+        // re-composes through the AudiobookView branch below.
         Box(modifier = Modifier.fillMaxSize()) {
             ExplicitArgsLoadingPrompt(
                 loadingPhase = state.loadingPhase,
@@ -245,12 +218,12 @@ fun HybridReaderScreen(
         }
         return
     }
-    if (showPromptForNullPlayback || showPromptForBlankIds ||
-        showPromptForTimedOutWithEntry
+    if (contentMode == ReaderContentMode.ResumePrompt ||
+        contentMode == ReaderContentMode.ResumeEmpty
     ) {
         Box(modifier = Modifier.fillMaxSize()) {
             val entry = resumeEntry
-            if (entry != null) {
+            if (contentMode == ReaderContentMode.ResumePrompt && entry != null) {
                 ResumePrompt(
                     entry = entry,
                     onResume = { viewModel.resume(fromStart = false) },

--- a/feature/src/main/kotlin/in/jphe/storyvox/feature/reader/ReaderContentMode.kt
+++ b/feature/src/main/kotlin/in/jphe/storyvox/feature/reader/ReaderContentMode.kt
@@ -1,0 +1,104 @@
+package `in`.jphe.storyvox.feature.reader
+
+/**
+ * Which top-level surface [HybridReaderScreen] should render. Extracted
+ * from the screen's inline branch logic so the decision is unit-testable
+ * (the screen consumes the enum and renders the matching composable).
+ */
+enum class ReaderContentMode {
+    /**
+     * The brass loading card for an explicit drill-down
+     * (`/reader/{fictionId}/{chapterId}`) whose chapter hasn't surfaced in
+     * the global PlaybackController yet. Owns the loading affordance so the
+     * screen never falls back to the global resume prompt — or, post-fix,
+     * to a PRIOR book — while the requested chapter is still loading.
+     */
+    ExplicitLoading,
+
+    /** Magical Resume prompt for the most-recent continue-listening entry. */
+    ResumePrompt,
+
+    /** "Your library awaits / Browse the realms" empty prompt. */
+    ResumeEmpty,
+
+    /** Render the player (AudiobookView) for the controller's loaded chapter. */
+    Content,
+}
+
+/**
+ * Decide the reader's top-level surface from the nav args + the GLOBAL
+ * PlaybackController state. [HybridReaderScreen] renders the controller's
+ * state, not its own nav args, so this function is the single gate that
+ * keeps the explicit drill-down route from painting the wrong content.
+ *
+ * Issue #638 (v1.0) added the [ExplicitLoading] gate to stop the explicit
+ * route from flashing the empty resume prompt during the cold-start
+ * warm-up window (controller ids still BLANK).
+ *
+ * TechEmpower wrong-book regression (v1.1.1) — that gate was too narrow.
+ * It only held while the controller's ids were blank. When the app
+ * process survives from a prior session, the controller still holds the
+ * PRIOR book's (non-blank) ids, so on a fresh explicit open of a
+ * different fiction (e.g. Resources) the gate fell through to [Content]
+ * and the screen painted the prior book until the requested chapter
+ * finally loaded — or permanently, if the cold body-fetch timed out. The
+ * fix: also hold [ExplicitLoading] while the controller is pointed at a
+ * DIFFERENT fiction than the one the explicit route requested
+ * ([argFictionId]). Once the controller catches up to [argFictionId] the
+ * gate releases and the player renders.
+ *
+ * @param hasExplicitChapterArgs true on the `/reader/{f}/{c}` and
+ *   `/audiobook/{f}/{c}` routes (both args present); false on the bare
+ *   `/playing` tab.
+ * @param argFictionId the fictionId from the explicit nav args, or null on
+ *   the bare `/playing` route.
+ * @param hasPlayback whether the controller's UI state has emitted (the
+ *   reader's `state.playback != null`).
+ * @param playbackFictionId the controller's currently-loaded fictionId.
+ * @param playbackChapterId the controller's currently-loaded chapterId.
+ * @param hasResumeEntry whether a most-recent continue-listening entry
+ *   exists (picks [ResumePrompt] vs [ResumeEmpty]).
+ * @param timedOut whether the load timer hit [LoadingPhase.TimedOut].
+ */
+internal fun readerContentMode(
+    hasExplicitChapterArgs: Boolean,
+    argFictionId: String?,
+    hasPlayback: Boolean,
+    playbackFictionId: String?,
+    playbackChapterId: String?,
+    hasResumeEntry: Boolean,
+    timedOut: Boolean,
+): ReaderContentMode {
+    // The controller has no real chapter to render yet — three cases:
+    //  (a) playback flow hasn't emitted (cold start, app-killed)
+    //  (b) it emitted a default state with both ids null
+    //  (c) the load timed out and we have a resume entry to fall back on
+    val showPromptForNullPlayback = !hasPlayback
+    val showPromptForBlankIds = hasPlayback &&
+        playbackFictionId == null &&
+        playbackChapterId == null
+    val showPromptForTimedOutWithEntry = hasPlayback && timedOut && hasResumeEntry
+
+    // Issue #638 + wrong-book fix — suppress the prompt branch on an
+    // explicit-args entry while the controller is still warming up OR is
+    // pointed at a DIFFERENT fiction than the one requested. The latter
+    // clause is the regression fix: a surviving prior book must not paint
+    // through the explicit route. Once the controller's fictionId matches
+    // the requested argFictionId, this is false and the player renders.
+    val explicitArgsPointAtDifferentFiction = hasExplicitChapterArgs &&
+        argFictionId != null &&
+        playbackFictionId != argFictionId
+    val isExplicitArgsLoading = hasExplicitChapterArgs &&
+        (showPromptForNullPlayback || showPromptForBlankIds || explicitArgsPointAtDifferentFiction)
+    if (isExplicitArgsLoading) {
+        return ReaderContentMode.ExplicitLoading
+    }
+
+    if (showPromptForNullPlayback || showPromptForBlankIds ||
+        showPromptForTimedOutWithEntry
+    ) {
+        return if (hasResumeEntry) ReaderContentMode.ResumePrompt else ReaderContentMode.ResumeEmpty
+    }
+
+    return ReaderContentMode.Content
+}

--- a/feature/src/main/kotlin/in/jphe/storyvox/feature/reader/ReaderViewModel.kt
+++ b/feature/src/main/kotlin/in/jphe/storyvox/feature/reader/ReaderViewModel.kt
@@ -213,6 +213,19 @@ class ReaderViewModel @Inject constructor(
         !f.isNullOrBlank() && !c.isNullOrBlank()
     }
 
+    /**
+     * TechEmpower wrong-book regression (v1.1.1) — the fictionId from the
+     * explicit `/reader/{fictionId}/{chapterId}` nav args, or null on the
+     * bare `/playing` route. [HybridReaderScreen] compares this to the
+     * GLOBAL PlaybackController's current fictionId: when they differ, the
+     * controller is still showing a PRIOR (surviving) book and the screen
+     * must hold the loading card for the requested fiction rather than
+     * paint the prior book. See [readerContentMode]. Blank on the Playing
+     * tab, which intentionally renders the controller's current chapter /
+     * the resume prompt.
+     */
+    val argFictionId: String? = savedState.get<String>("fictionId")?.takeIf { it.isNotBlank() }
+
     private val _activePane = MutableStateFlow(ReaderView.Audiobook)
     private val _recap = MutableStateFlow<RecapUiState>(RecapUiState.Hidden)
 

--- a/feature/src/test/kotlin/in/jphe/storyvox/feature/reader/ReaderContentModeTest.kt
+++ b/feature/src/test/kotlin/in/jphe/storyvox/feature/reader/ReaderContentModeTest.kt
@@ -1,0 +1,210 @@
+package `in`.jphe.storyvox.feature.reader
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+/**
+ * TechEmpower wrong-book regression (v1.1.1) — when the user opens the
+ * Resources fiction's detail page and taps Play, the reader briefly (or
+ * permanently, on a 30s body-fetch timeout) shows a DIFFERENT,
+ * previously-played book.
+ *
+ * Root cause: [HybridReaderScreen] renders the GLOBAL PlaybackController
+ * state, not its own nav args. The #638 loading gate
+ * ([readerContentMode] → [ReaderContentMode.ExplicitLoading]) only held
+ * while the controller's ids were BLANK (cold-start warm-up window). If
+ * the app process survived from a prior session, the controller still
+ * holds the prior book's (non-blank) ids, so the gate fell through to
+ * [ReaderContentMode.Content] and the reader painted the prior book —
+ * even though the user navigated to /reader/{resources}/{ch} with
+ * explicit args. The cold body-fetch (first-ever Resources open, 30s
+ * Notion fetch) makes the window long enough to be the reported bug; a
+ * warm fetch resolves before the user notices.
+ *
+ * These tests pin [readerContentMode] (the pure decision the screen
+ * calls) so the gate can't regress. The load-bearing case is
+ * [explicit args for a different fiction than the controller currently
+ * holds must show the loading card, not the prior book].
+ */
+class ReaderContentModeTest {
+
+    @Test
+    fun `explicit args while controller holds a DIFFERENT fiction shows loading, never the prior book`() {
+        // The exact regression: user navigated to /reader/{resources}/{ch}
+        // (hasExplicitChapterArgs = true, argFictionId = resources) but the
+        // controller still holds a prior book B (non-blank ids) because the
+        // process survived. The reader must show the explicit-args loading
+        // card for Resources, NOT fall through to Content (which paints B).
+        val mode = readerContentMode(
+            hasExplicitChapterArgs = true,
+            argFictionId = "notion:resources",
+            hasPlayback = true,
+            playbackFictionId = "lucidx:bookB",
+            playbackChapterId = "lucidx:bookB::ch1",
+            hasResumeEntry = true,
+            timedOut = false,
+        )
+        assertEquals(ReaderContentMode.ExplicitLoading, mode)
+    }
+
+    @Test
+    fun `cold Play on fiction A whose chapters are unresolved never surfaces resume for prior book B`() {
+        // The lead's exact COLD-timing case: the user taps Play on Resources
+        // (A) whose chapter list/body has NOT resolved yet — the controller
+        // either hasn't emitted, or still carries the prior most-recent book
+        // B. A most-recent continue-listening entry for B EXISTS
+        // (hasResumeEntry = true), so the *only* thing standing between the
+        // user and ResumePrompt(B) is that the explicit-args gate must stay
+        // CLOSED (return ExplicitLoading) for A. We assert both unresolved
+        // shapes resolve to A's loading card, never B's resume prompt.
+
+        // Shape 1: controller hasn't emitted yet (truly cold, app-killed).
+        val coldNoEmit = readerContentMode(
+            hasExplicitChapterArgs = true,
+            argFictionId = "notion:resources",
+            hasPlayback = false,
+            playbackFictionId = null,
+            playbackChapterId = null,
+            hasResumeEntry = true, // B is the most-recent — must NOT surface
+            timedOut = false,
+        )
+        assertEquals(ReaderContentMode.ExplicitLoading, coldNoEmit)
+
+        // Shape 2: controller survived holding prior book B; A still resolving.
+        val coldHoldsPriorB = readerContentMode(
+            hasExplicitChapterArgs = true,
+            argFictionId = "notion:resources",
+            hasPlayback = true,
+            playbackFictionId = "lucidx:bookB",
+            playbackChapterId = "lucidx:bookB::ch1",
+            hasResumeEntry = true, // B is the most-recent — must NOT surface
+            timedOut = false,
+        )
+        assertEquals(ReaderContentMode.ExplicitLoading, coldHoldsPriorB)
+    }
+
+    @Test
+    fun `explicit args while controller holds the SAME fiction renders content`() {
+        // Once the controller catches up to the requested fiction, the
+        // loading gate releases and the reader renders the player normally.
+        val mode = readerContentMode(
+            hasExplicitChapterArgs = true,
+            argFictionId = "notion:resources",
+            hasPlayback = true,
+            playbackFictionId = "notion:resources",
+            playbackChapterId = "notion:resources::abc",
+            hasResumeEntry = true,
+            timedOut = false,
+        )
+        assertEquals(ReaderContentMode.Content, mode)
+    }
+
+    @Test
+    fun `explicit args with null playback shows loading (cold start, pre-emission)`() {
+        // #638 original case: playback flow hasn't emitted yet.
+        val mode = readerContentMode(
+            hasExplicitChapterArgs = true,
+            argFictionId = "notion:resources",
+            hasPlayback = false,
+            playbackFictionId = null,
+            playbackChapterId = null,
+            hasResumeEntry = true,
+            timedOut = false,
+        )
+        assertEquals(ReaderContentMode.ExplicitLoading, mode)
+    }
+
+    @Test
+    fun `explicit args with blank controller ids shows loading (#638 post-emission window)`() {
+        // #638 follow-up: controller emitted its default state with both
+        // ids null but hasn't reached the engine yet.
+        val mode = readerContentMode(
+            hasExplicitChapterArgs = true,
+            argFictionId = "notion:resources",
+            hasPlayback = true,
+            playbackFictionId = null,
+            playbackChapterId = null,
+            hasResumeEntry = true,
+            timedOut = false,
+        )
+        assertEquals(ReaderContentMode.ExplicitLoading, mode)
+    }
+
+    @Test
+    fun `Playing tab (no explicit args) with empty controller shows the resume prompt`() {
+        // The Playing tab has no nav args → hasExplicitChapterArgs = false.
+        // With a most-recent entry it shows the magical Resume prompt.
+        val mode = readerContentMode(
+            hasExplicitChapterArgs = false,
+            argFictionId = null,
+            hasPlayback = false,
+            playbackFictionId = null,
+            playbackChapterId = null,
+            hasResumeEntry = true,
+            timedOut = false,
+        )
+        assertEquals(ReaderContentMode.ResumePrompt, mode)
+    }
+
+    @Test
+    fun `Playing tab with empty controller and no resume entry shows the empty prompt`() {
+        val mode = readerContentMode(
+            hasExplicitChapterArgs = false,
+            argFictionId = null,
+            hasPlayback = false,
+            playbackFictionId = null,
+            playbackChapterId = null,
+            hasResumeEntry = false,
+            timedOut = false,
+        )
+        assertEquals(ReaderContentMode.ResumeEmpty, mode)
+    }
+
+    @Test
+    fun `Playing tab with a loaded chapter renders content`() {
+        val mode = readerContentMode(
+            hasExplicitChapterArgs = false,
+            argFictionId = null,
+            hasPlayback = true,
+            playbackFictionId = "notion:resources",
+            playbackChapterId = "notion:resources::abc",
+            hasResumeEntry = true,
+            timedOut = false,
+        )
+        assertEquals(ReaderContentMode.Content, mode)
+    }
+
+    @Test
+    fun `timed-out with a resume entry falls back to the resume prompt`() {
+        // Lyra's TimedOut escape hatch: a stalled load with a resume entry
+        // surfaces the Resume prompt instead of a dead-end error block.
+        val mode = readerContentMode(
+            hasExplicitChapterArgs = false,
+            argFictionId = null,
+            hasPlayback = true,
+            playbackFictionId = "notion:resources",
+            playbackChapterId = "notion:resources::abc",
+            hasResumeEntry = true,
+            timedOut = true,
+        )
+        assertEquals(ReaderContentMode.ResumePrompt, mode)
+    }
+
+    @Test
+    fun `explicit-args loading wins over a timed-out resume entry`() {
+        // On the explicit drill-down route a stall surfaces the typed
+        // ExplicitArgsLoadingPrompt (with its own Retry/Back), NOT the
+        // global resume prompt — so we never bounce the user into a
+        // different book on a slow Resources fetch.
+        val mode = readerContentMode(
+            hasExplicitChapterArgs = true,
+            argFictionId = "notion:resources",
+            hasPlayback = true,
+            playbackFictionId = "lucidx:bookB",
+            playbackChapterId = "lucidx:bookB::ch1",
+            hasResumeEntry = true,
+            timedOut = true,
+        )
+        assertEquals(ReaderContentMode.ExplicitLoading, mode)
+    }
+}


### PR DESCRIPTION
## Symptom

TechEmpower **wrong-book regression (v1.1.1)**. As reported: **"Browse → Resources tile → Play reads a different book."** Opening the Resources fiction's detail page (Browse → TechEmpower 4-tile → Resources tile — the detail page itself is correct) and tapping **Play** briefly — or permanently, on a 30s Notion body-fetch timeout — showed a **different, previously-played book** in the reader. Audio-wrong only (the detail page was always correct). Reproduced intermittently: a cold first-ever Resources open hit it; an already-warmed device did not.

**Precondition** (why it's intermittent): the app process **survived from a prior session with a prior book loaded** (backgrounded, not force-killed), AND the tapped fiction's body is a **cold fetch** (first-ever Resources open, ~30s from Notion).

## Root cause

`HybridReaderScreen` renders the **GLOBAL `PlaybackController` state**, not its own nav args. The #638 loading gate (`isExplicitArgsLoading`) only held while the controller's ids were **BLANK** (the cold-start warm-up window). When the app **process survives** from a prior session, the controller still holds the **prior book's (non-blank) ids**, so on a fresh explicit open of a *different* fiction the gate fell through to `Content` and the reader painted the prior book until the requested chapter finally loaded — or **permanently**, if the cold body-fetch timed out at 30s.

The window's duration equals the cold-body-fetch time: a never-fetched Resources chapter takes ~30s from Notion, so the prior book stays on screen that whole time; a warm fetch resolves in a few seconds, before the user notices — which is exactly why it reproduced only intermittently. (Confirmed on-device: a clean force-killed cold start, where the controller is empty, shows the correct book — pinning the precondition to "backgrounded with a prior book.")

## Fix

Extract the screen's inline surface-selection logic into a pure, unit-testable `readerContentMode(...)` and **widen the explicit-args loading gate** to also hold `ExplicitLoading` while the controller points at a **different fiction** than the one the explicit route requested (`argFictionId`). Once the controller catches up to `argFictionId`, the gate releases and the player renders normally.

- Keys on **fiction only** → same-fiction chapter switches still render `Content` (no false loading card).
- On the **30s timeout** the explicit route shows `ExplicitArgsLoadingPrompt`'s "Couldn't start this chapter" + Retry/Back — an error scoped to the **requested** fiction, never the prior book.
- Bare `/playing` tab behavior unchanged (Resume / empty prompt).

4 files, all in `feature/`. No `PlaybackController` interface change. The source-level controller hardening (a synchronous buffering transition before the async body-wait) is deliberately deferred to a follow-up so this regression ship stays tight and low-risk.

## Tests

`ReaderContentModeTest` (10 tests) pins the decision:
- **RED without the new clause** — 3 load-bearing cases fail: explicit args for a different fiction than the controller holds; cold Play on a fiction whose chapters are unresolved while a prior-book resume entry exists; and explicit-args loading winning over a timed-out resume entry.
- **GREEN with it** — all 10 pass; the 7 behavior-preserving cases pass throughout.

Verified: `:app:compileDebugKotlin` green; `:feature` `reader.*` + `fiction.*` suites green.

> **CI note:** `Build APK` (the required check) is green — the app compiles. `:feature:testDebugUnitTest` **execution** depends on Ember's parallel PR `fix/feature-test-fakes-pdffolder` landing first: `main` currently fails to compile that test source set because 3 stale `SettingsViewModel*Test` fakes are missing #996's PDF-folder members — a **pre-existing breakage unrelated to this change**. This PR's tests were verified in isolation. **Merge order: Ember's fakes-fix → this PR (rebased on the new main).**

Closes the v1.1.1 wrong-book regression. Refs #638.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
