### PR TITLE
test(maestro): nav-smoke flow + Maestro flow library (Layer 2)

### DIFF
--- a/.maestro/README.md
+++ b/.maestro/README.md
@@ -1,0 +1,35 @@
+# Candela Maestro flows
+
+Live-app UI flows driven by [Maestro](https://maestro.mobile.dev). Maestro reads
+the Compose **semantics** tree, so it works where uiautomator can't — *provided*
+the app exposes testTags as resource-ids.
+
+## The testTagsAsResourceId bridge — validated 2026-06-06
+Compose testTags are invisible to Maestro/uiautomator unless the app sets
+`Modifier.semantics { testTagsAsResourceId = true }` at the Compose root
+(MainActivity, #1090). With it, every `testTag` surfaces as a resource-id.
+
+**Proven on-device (R83W80CAFZB, v1.1.2):** `maestro hierarchy` returns the whole
+Compose tree as text — onboarding copy + all nav/screen testTags as resource-ids —
+where the pre-bridge uiautomator dump was empty. `nav-smoke` passes 10/10.
+
+## Run (tablet on katana)
+    export PATH="$PATH:$HOME/.maestro/bin"
+    maestro test .maestro/nav-smoke.yaml
+    maestro hierarchy            # perceive primitive — Compose as text
+
+## Flows
+- `nav-smoke.yaml` — bridge validation + nav destinations. **GREEN (10/10).**
+- `open-reader.yaml` — seed the bundled sample (#1089) → open reader. *Pending:* needs a debug build (the LOAD_SAMPLE intent is BuildConfig.DEBUG-gated).
+- `highlight.yaml` — #1079 select→highlight→assert. *Pending* #1088 + highlight-control testTags.
+
+## Fresh-install precondition
+A fresh install runs 3-step onboarding ending in a voice-download gate
+(Lessac, 63 MB) + a skippable sign-in step. Flows assume the app is past
+onboarding. (See docs/testing/SEED.md.)
+
+## Seeding a book (deterministic, no network — #1089, debug build only)
+    adb shell am start -a android.intent.action.VIEW \
+      -n org.techempower.candela/in.jphe.storyvox.MainActivity \
+      --ez in.jphe.storyvox.debug.LOAD_SAMPLE true
+Known passage offsets (e.g. "lamplighter" 4–15) live in docs/testing/SEED.md.

--- a/.maestro/nav-smoke.yaml
+++ b/.maestro/nav-smoke.yaml
@@ -1,0 +1,31 @@
+# Candela — nav smoke. Proves the testTagsAsResourceId bridge (Compose
+# testTags addressable by Maestro `id:`) + that nav navigation works.
+# Tags from core-ui TestTags (#1090).
+#
+# NOTE: final assert uses `library-fab` (always present on Library) not
+# `library-list` — the LazyVerticalGrid carrying `library-list` only
+# renders when the library has content; empty library = absent. (Surfaced
+# by this flow on its first run — exactly what the tooling is for.)
+appId: org.techempower.candela
+name: nav-smoke
+---
+- launchApp:
+    clearState: false
+- assertVisible:
+    id: "nav-library"
+- tapOn:
+    id: "nav-browse"
+- assertVisible:
+    id: "browse-source-list"
+- tapOn:
+    id: "nav-voices"
+- assertVisible:
+    id: "voice-list"
+- tapOn:
+    id: "nav-settings"
+- assertVisible:
+    id: "settings-list"
+- tapOn:
+    id: "nav-library"
+- assertVisible:
+    id: "library-fab"


### PR DESCRIPTION
Layer 2 of the UI-test stack. Adds `.maestro/` with a validated **nav-smoke** flow + README documenting the testTagsAsResourceId bridge.

**Proven on-device (R83W80CAFZB, v1.1.2):**
- `maestro hierarchy` returns the full Compose tree as text (onboarding copy + all nav/screen testTags as resource-ids) — the pre-bridge uiautomator dump was empty.
- `nav-smoke` passes **10/10**: launch → assert nav-library → tap through browse/voices/settings (asserting browse-source-list, voice-list, settings-list) → back to library (library-fab).

Surfaced one real edge: `library-list` (LazyVerticalGrid) only renders with content, so the flow asserts `library-fab` on the empty library.

Follow-ups (stubbed in README): `open-reader` (needs a debug build — #1089 seed intent is DEBUG-gated) and `highlight` (#1079, pending #1088).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added guide for running Maestro UI tests, including setup instructions, testing commands, and catalog of available test flows with their status.

* **Tests**
  * Added navigation smoke test verifying that users can navigate between library, browse, voices, and settings screens with expected content displayed on each screen.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->