### PR TITLE
ci(docs-sync): write release content directly to the wiki (no PR, no PAT)

### DIFF
--- a/.github/workflows/release-docs-sync.yml
+++ b/.github/workflows/release-docs-sync.yml
@@ -21,6 +21,7 @@ concurrency:
 
 permissions:
   contents: write
+  pull-requests: write   # create the docs-sync PR via the REST API
 
 jobs:
   sync:
@@ -149,7 +150,18 @@ jobs:
           NAME: ${{ github.event.repository.name }}
         continue-on-error: true
         run: |
-          gh repo edit "$REPO" --homepage "https://$OWNER.github.io/$NAME"
+          # Use the REST API via curl rather than `gh` — the self-hosted runner
+          # pool is mixed (katana has gh, familiar does NOT), so any `gh`
+          # invocation 127s when the job lands on a runner without it. curl is
+          # present on every runner. jq builds the JSON body so the homepage
+          # value is safely escaped.
+          HOMEPAGE="https://$OWNER.github.io/$NAME"
+          curl -fsS -X PATCH \
+            -H "Authorization: Bearer $GH_TOKEN" \
+            -H "Accept: application/vnd.github+json" \
+            -H "X-GitHub-Api-Version: 2022-11-28" \
+            "https://api.github.com/repos/$REPO" \
+            -d "$(jq -nc --arg h "$HOMEPAGE" '{homepage: $h}')"
 
       - name: Update wiki Home current-version line
         env:
@@ -195,15 +207,20 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           TAG: ${{ steps.tag.outputs.tag }}
+          REPO: ${{ github.repository }}
         run: |
-          # Branch-protection on main blocks the bot from pushing
-          # directly (refs/heads/main is PR-required + CODEOWNERS-
-          # gated). So instead of `git push origin main`, push to a
-          # short-lived `docs-sync/<tag>` branch and open a PR that
-          # CODEOWNERS auto-approves on merge.
+          # Branch-protection on main blocks a direct push (refs/heads/main is
+          # PR-required + needs the "Build APK" check + 1 review). So we push the
+          # docs diff to a short-lived `docs-sync/<tag>` branch and open a PR
+          # against main; a maintainer (or the release admin-merge step) lands it.
           #
-          # `[skip ci]` in the merge commit prevents the Android build
-          # from re-firing on what's a docs-only change.
+          # IMPORTANT — why curl, not `gh`: the self-hosted runner pool is mixed.
+          # katana has the GitHub CLI; familiar does NOT. When this job lands on
+          # familiar every `gh` call 127s ("gh: command not found"), which is
+          # exactly what silently broke docs-sync on every release after v0.5.98.
+          # curl + jq are present on both runners, so the REST API is runner-
+          # agnostic. (The old code also used `gh pr merge --auto`, but repo
+          # auto-merge is disabled, so that path never worked even on katana.)
           git config user.email "github-actions[bot]@users.noreply.github.com"
           git config user.name  "github-actions[bot]"
           git add README.md docs/index.md docs/version.json docs/_layouts/default.html
@@ -215,26 +232,36 @@ jobs:
           git checkout -b "$BRANCH"
           git commit -m "chore(release): docs sync for ${TAG}"
           git push -u origin "$BRANCH"
-          # Open the PR. If one already exists for the same branch
-          # (e.g. a retry of the same workflow), gh create will fail —
-          # fall through to the merge step in that case.
-          gh pr create \
-            --title "chore(release): docs sync for $TAG" \
-            --body "Auto-generated docs sync for tag $TAG. Updates README headline, docs/index.md headline + release link, docs/version.json + meta tag (realm-sigil bind)." \
-            --base main \
-            --head "$BRANCH" \
-            --label "ci,docs" 2>&1 || true
-          # Auto-merge once the required "Build APK" check passes
-          # (renamed from "Build debug APK" in #529 follow-up; branch
-          # protection updated to match — see android.yml header note).
-          # --admin would bypass the check but requires user-level admin
-          # rights the GITHUB_TOKEN doesn't have. --auto queues the
-          # merge for when the protection rules are satisfied: the
-          # Android workflow fires on every PR (no path filter today),
-          # so the docs-only PR rides through it and merges in ~3 min.
-          # Future optimization: add paths-ignore: docs/** to android.yml
-          # to skip the rebuild on pure docs PRs.
-          gh pr merge "$BRANCH" \
-            --repo "${GITHUB_REPOSITORY}" \
-            --squash --auto --delete-branch \
-            --subject "chore(release): docs sync for $TAG [skip ci]"
+
+          API="https://api.github.com/repos/$REPO"
+          AUTH=(-H "Authorization: Bearer $GH_TOKEN"
+                -H "Accept: application/vnd.github+json"
+                -H "X-GitHub-Api-Version: 2022-11-28")
+
+          # Idempotent: if a PR for this head branch already exists (workflow
+          # retry / re-dispatch of the same tag), don't try to open another.
+          EXISTING=$(curl -fsS "${AUTH[@]}" \
+            "$API/pulls?head=${REPO%%/*}:$BRANCH&state=open" | jq 'length')
+          if [ "${EXISTING:-0}" -gt 0 ]; then
+            echo "PR for $BRANCH already open; nothing to do."
+            exit 0
+          fi
+
+          BODY="Auto-generated docs sync for tag $TAG. Updates README headline, docs/index.md headline + release link, docs/version.json + meta tag (realm-sigil bind)."
+          # jq -n builds the JSON body so $TAG / $BODY are safely escaped.
+          PR_JSON=$(jq -nc \
+            --arg title "chore(release): docs sync for $TAG" \
+            --arg body  "$BODY" \
+            --arg head  "$BRANCH" \
+            --arg base  "main" \
+            '{title: $title, body: $body, head: $head, base: $base}')
+          PR_NUM=$(curl -fsS -X POST "${AUTH[@]}" "$API/pulls" -d "$PR_JSON" | jq -r '.number')
+          if [ -z "$PR_NUM" ] || [ "$PR_NUM" = "null" ]; then
+            echo "::error::Failed to open docs-sync PR for $TAG."
+            exit 1
+          fi
+          echo "Opened docs-sync PR #$PR_NUM for $TAG."
+          # Best-effort labels (don't fail the job if the labels don't exist).
+          curl -fsS -X POST "${AUTH[@]}" "$API/issues/$PR_NUM/labels" \
+            -d "$(jq -nc '{labels: ["ci","docs"]}')" >/dev/null || true
+          echo "PR #$PR_NUM awaits the required Build APK check + review, then merge."

--- a/.github/workflows/release-docs-sync.yml
+++ b/.github/workflows/release-docs-sync.yml
@@ -1,10 +1,23 @@
 name: Release docs sync
 
-# Fires on every tag push (vX.Y.Z) and regenerates everything that should
-# follow the release version: realm-sigil version.json + meta tag, README
-# headline callout, docs/index.md "What just shipped" headline, wiki Home
-# current-version line, and the repo About homepage URL. Commits the result
-# back to main with [skip ci] so we don't re-trigger the Android build.
+# Fires on every tag push (vX.Y.Z) and writes the release-current content
+# DIRECTLY to the GitHub wiki — fully automatic, no PR, no PAT, no human gate.
+#
+# Design (2026-06-07): the wiki must self-update on every release with zero
+# manual steps. The .wiki repo is NOT branch-protected, so a plain `git push`
+# with the built-in GITHUB_TOKEN lands immediately — no pull_request, no
+# CODEOWNERS review, no auto-merge. This workflow OWNS the release-current
+# sections of wiki Home.md (the version line, the "Latest release" line, and
+# the "What's new in vX.Y.Z" section), regenerated from CHANGELOG.md each tag.
+#
+# The repo's own docs/index.md + README headline are deliberately NOT touched
+# here — those ride the normal human-reviewed PR flow into main. This workflow
+# is wiki-only.
+#
+# Page ownership (anti-clobber): this workflow owns Home.md ONLY. The companion
+# wiki-sync.yml owns Architecture/Accessibility/Cloud-sync/Compose-gotchas/
+# Roadmap/Changelog/Modules and deliberately never touches Home.md — so the two
+# never collide. The release section here is fenced by AUTO-GENERATED markers.
 
 on:
   push:
@@ -20,19 +33,19 @@ concurrency:
   cancel-in-progress: false
 
 permissions:
-  contents: write
-  pull-requests: write   # create the docs-sync PR via the REST API
+  contents: write   # push release content directly to the .wiki repo (no PR, no PAT)
 
 jobs:
   sync:
     # Self-hosted runner (see android.yml header note for context on
-    # the 2026-05-12 cap-hit migration). This workflow only commits
-    # docs back, so a hosted runner would also work after the
-    # 2026-06-01 reset — but self-hosted is free.
+    # the 2026-05-12 cap-hit migration). This job only reads the repo and
+    # pushes the .wiki repo, so a hosted runner would also work — but
+    # self-hosted is free. Runner-agnostic: no `gh` dependency (only git +
+    # python3 + curl), so it can't 127 on the gh-less familiar runner.
     runs-on: [self-hosted, linux]
     timeout-minutes: 10
     steps:
-      - name: Checkout main (full history for commit-back)
+      - name: Checkout main (for CHANGELOG.md + the render script)
         uses: actions/checkout@v5
         with:
           ref: main
@@ -62,14 +75,16 @@ jobs:
           echo "version=${TAG#v}"  >> "$GITHUB_OUTPUT"
           echo "Syncing docs for tag: $TAG"
 
-      - name: Verify tag points at main HEAD before binding sigil
+      - name: Verify tag points at main HEAD before reading the changelog
         env:
           TAG: ${{ steps.tag.outputs.tag }}
         run: |
-          # realm-sigil's build.sh reads HASH from `git rev-parse HEAD`.
-          # We've checked out main; if the tag doesn't point at main's tip
-          # (e.g. someone pushed to main between tag creation and this run),
-          # the sigil hash would bind to the wrong commit. Refuse to proceed.
+          # We render the wiki from CHANGELOG.md as it exists on main's tip
+          # (checked out above). If the tag we're syncing doesn't point at main's
+          # current HEAD — e.g. someone pushed to main between tag creation and
+          # this run — main's CHANGELOG may not yet contain (or may have moved
+          # past) this tag's section, so we'd publish the wrong release notes.
+          # Refuse rather than guess.
           # Dereference via ^{commit} so annotated tags compare correctly —
           # `git rev-parse refs/tags/$TAG` returns the tag OBJECT's SHA for
           # annotated tags, NOT the commit they point at, which false-fires
@@ -80,67 +95,11 @@ jobs:
           MAIN_SHA=$(git rev-parse --verify HEAD)
           if [ "$TAG_SHA" != "$MAIN_SHA" ]; then
             echo "::error::Tag $TAG ($TAG_SHA) does not point at main HEAD ($MAIN_SHA)."
-            echo "::error::Refusing to sync — the realm-sigil hash would bind to the wrong commit."
+            echo "::error::Refusing to sync — main's CHANGELOG may not match this tag's release notes."
             echo "::error::Fast-forward main to the tag (or re-tag main's current tip) and retry."
             exit 1
           fi
           echo "Tag and main agree on $TAG_SHA — proceeding."
-
-      - name: Clone realm-sigil
-        run: git clone --depth=1 https://github.com/jphein/sigil.realm.watch "$RUNNER_TEMP/realm-sigil"
-
-      - name: Regenerate docs/version.json + meta tag
-        working-directory: docs
-        env:
-          REPO: ${{ github.repository }}
-        run: |
-          "$RUNNER_TEMP/realm-sigil/static/build.sh" \
-            --name storyvox \
-            --description "Neural-voice audiobook player for any text you have — offline TTS, optional Azure HD cloud voices, Library Nocturne aesthetic" \
-            --realm fantasy \
-            --repo "https://github.com/$REPO" \
-            --dir . \
-            --html _layouts/default.html
-
-      - name: Bump README headline callout
-        env:
-          TAG: ${{ steps.tag.outputs.tag }}
-        run: |
-          python3 - <<'PY'
-          import os, re, pathlib
-          tag = os.environ['TAG']
-          p = pathlib.Path('README.md')
-          s = p.read_text()
-          s2, n = re.subn(r'^> \*\*v\d+\.\d+\.\d+\*\* —',
-                          f'> **{tag}** —', s, count=1, flags=re.M)
-          if n:
-              p.write_text(s2)
-              print(f'README.md: bumped headline to {tag}')
-          else:
-              print('README.md: no headline pattern matched; skipping')
-          PY
-
-      - name: Bump docs/index.md "What just shipped" callout + release link
-        env:
-          TAG: ${{ steps.tag.outputs.tag }}
-        run: |
-          python3 - <<'PY'
-          import os, re, pathlib
-          tag = os.environ['TAG']
-          p = pathlib.Path('docs/index.md')
-          s = p.read_text()
-          # First <strong>vX.Y.Z</strong> = "What just shipped" headline
-          s2, n1 = re.subn(r'<strong>v\d+\.\d+\.\d+</strong>',
-                            f'<strong>{tag}</strong>', s, count=1)
-          # First release-notes link nearest to that headline
-          s2, n2 = re.subn(r'releases/tag/v\d+\.\d+\.\d+',
-                            f'releases/tag/{tag}', s2, count=1)
-          if n1 or n2:
-              p.write_text(s2)
-              print(f'docs/index.md: headline={n1} link={n2} -> {tag}')
-          else:
-              print('docs/index.md: no patterns matched; skipping')
-          PY
 
       - name: Update repo About homepage
         env:
@@ -163,105 +122,44 @@ jobs:
             "https://api.github.com/repos/$REPO" \
             -d "$(jq -nc --arg h "$HOMEPAGE" '{homepage: $h}')"
 
-      - name: Update wiki Home current-version line
+      - name: Write release content to wiki Home (direct push, no PR)
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           TAG: ${{ steps.tag.outputs.tag }}
           REPO: ${{ github.repository }}
-        continue-on-error: true
+          # CHANGELOG.md from the checked-out main is the source of the
+          # release tagline + bullets; the workspace was checked out at the top.
+          CHANGELOG: ${{ github.workspace }}/CHANGELOG.md
         run: |
+          # The .wiki repo is NOT branch-protected, so a plain `git push` with
+          # the built-in GITHUB_TOKEN lands the wiki update immediately — no PR,
+          # no PAT, no review gate. This is the whole point: the wiki self-updates
+          # on every release with zero human steps. NOT continue-on-error — if the
+          # wiki fails to update, the release docs are stale and we want to know.
+          set -uo pipefail
           WIKI_DIR="$RUNNER_TEMP/wiki"
-          if ! git clone "https://x-access-token:${GH_TOKEN}@github.com/${REPO}.wiki.git" "$WIKI_DIR" 2>/dev/null; then
-            echo "Wiki not initialized or no access; skipping wiki update."
-            exit 0
-          fi
-          cd "$WIKI_DIR"
-          [ -f Home.md ] || { echo "No Home.md; skipping."; exit 0; }
-          python3 - <<'PY'
-          import os, re, pathlib
-          tag = os.environ['TAG']
-          p = pathlib.Path('Home.md')
-          s = p.read_text()
-          marker = re.compile(r'^_Current version: v\d+\.\d+\.\d+_\s*$', re.M)
-          line = f'_Current version: {tag}_'
-          if marker.search(s):
-              s2 = marker.sub(line, s)
-          else:
-              # Insert after first H1 if present
-              s2 = re.sub(r'(\A#[^\n]+\n)', lambda m: m.group(1) + '\n' + line + '\n', s, count=1)
-          if s2 != s:
-              p.write_text(s2)
-              print(f'Home.md: set version to {tag}')
-          else:
-              print('Home.md: already current')
-          PY
-          if ! git diff --quiet; then
-            git config user.email "github-actions[bot]@users.noreply.github.com"
-            git config user.name  "github-actions[bot]"
-            git add Home.md
-            git commit -m "docs(wiki): bump current version to ${TAG}"
-            git push
-          fi
-
-      - name: Open docs-sync PR
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          TAG: ${{ steps.tag.outputs.tag }}
-          REPO: ${{ github.repository }}
-        run: |
-          # Branch-protection on main blocks a direct push (refs/heads/main is
-          # PR-required + needs the "Build APK" check + 1 review). So we push the
-          # docs diff to a short-lived `docs-sync/<tag>` branch and open a PR
-          # against main; a maintainer (or the release admin-merge step) lands it.
-          #
-          # IMPORTANT — why curl, not `gh`: the self-hosted runner pool is mixed.
-          # katana has the GitHub CLI; familiar does NOT. When this job lands on
-          # familiar every `gh` call 127s ("gh: command not found"), which is
-          # exactly what silently broke docs-sync on every release after v0.5.98.
-          # curl + jq are present on both runners, so the REST API is runner-
-          # agnostic. (The old code also used `gh pr merge --auto`, but repo
-          # auto-merge is disabled, so that path never worked even on katana.)
-          git config user.email "github-actions[bot]@users.noreply.github.com"
-          git config user.name  "github-actions[bot]"
-          git add README.md docs/index.md docs/version.json docs/_layouts/default.html
-          if git diff --staged --quiet; then
-            echo "No docs changes to commit."
-            exit 0
-          fi
-          BRANCH="docs-sync/${TAG}"
-          git checkout -b "$BRANCH"
-          git commit -m "chore(release): docs sync for ${TAG}"
-          git push -u origin "$BRANCH"
-
-          API="https://api.github.com/repos/$REPO"
-          AUTH=(-H "Authorization: Bearer $GH_TOKEN"
-                -H "Accept: application/vnd.github+json"
-                -H "X-GitHub-Api-Version: 2022-11-28")
-
-          # Idempotent: if a PR for this head branch already exists (workflow
-          # retry / re-dispatch of the same tag), don't try to open another.
-          EXISTING=$(curl -fsS "${AUTH[@]}" \
-            "$API/pulls?head=${REPO%%/*}:$BRANCH&state=open" | jq 'length')
-          if [ "${EXISTING:-0}" -gt 0 ]; then
-            echo "PR for $BRANCH already open; nothing to do."
-            exit 0
-          fi
-
-          BODY="Auto-generated docs sync for tag $TAG. Updates README headline, docs/index.md headline + release link, docs/version.json + meta tag (realm-sigil bind)."
-          # jq -n builds the JSON body so $TAG / $BODY are safely escaped.
-          PR_JSON=$(jq -nc \
-            --arg title "chore(release): docs sync for $TAG" \
-            --arg body  "$BODY" \
-            --arg head  "$BRANCH" \
-            --arg base  "main" \
-            '{title: $title, body: $body, head: $head, base: $base}')
-          PR_NUM=$(curl -fsS -X POST "${AUTH[@]}" "$API/pulls" -d "$PR_JSON" | jq -r '.number')
-          if [ -z "$PR_NUM" ] || [ "$PR_NUM" = "null" ]; then
-            echo "::error::Failed to open docs-sync PR for $TAG."
+          rm -rf "$WIKI_DIR"
+          if ! git clone "https://x-access-token:${GH_TOKEN}@github.com/${REPO}.wiki.git" "$WIKI_DIR"; then
+            echo "::error::Could not clone the wiki repo. Initialize the wiki (create any page in the UI) and re-run."
             exit 1
           fi
-          echo "Opened docs-sync PR #$PR_NUM for $TAG."
-          # Best-effort labels (don't fail the job if the labels don't exist).
-          curl -fsS -X POST "${AUTH[@]}" "$API/issues/$PR_NUM/labels" \
-            -d "$(jq -nc '{labels: ["ci","docs"]}')" >/dev/null || true
-          echo "PR #$PR_NUM awaits the required Build APK check + review, then merge."
+          [ -f "$WIKI_DIR/Home.md" ] || { echo "::error::Wiki has no Home.md to update."; exit 1; }
+
+          # Regenerate the release-current regions of Home.md from CHANGELOG.md.
+          # This workflow OWNS three regions, all on Home.md (which wiki-sync.yml
+          # never touches): the version line, the "Latest release" line, and the
+          # AUTO-GENERATED-fenced "What's new" section.
+          REPO="$REPO" TAG="$TAG" CHANGELOG="$CHANGELOG" \
+          python3 "$GITHUB_WORKSPACE/scripts/wiki/render_release_home.py" "$WIKI_DIR/Home.md"
+
+          cd "$WIKI_DIR" || { echo "::error::cannot cd into wiki clone"; exit 1; }
+          if git diff --quiet; then
+            echo "Home.md already current for ${TAG} — no commit."
+            exit 0
+          fi
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git config user.name  "github-actions[bot]"
+          git add Home.md
+          git commit -m "docs(wiki): release content for ${TAG}"
+          git push
+          echo "Wiki Home.md updated to ${TAG} and pushed."

--- a/scripts/wiki/render_release_home.py
+++ b/scripts/wiki/render_release_home.py
@@ -1,0 +1,180 @@
+#!/usr/bin/env python3
+"""Render the release-current regions of the wiki Home.md from CHANGELOG.md.
+
+Owned by .github/workflows/release-docs-sync.yml, which direct-pushes the wiki
+on every release tag (no PR, no PAT — the .wiki repo is unprotected). This is
+the ONLY writer of wiki Home.md; the companion wiki-sync.yml deliberately never
+touches Home.md, so the two workflows never collide.
+
+Three regions are regenerated from the tag's CHANGELOG.md section:
+
+  1. The current-version line          `_Current version: vX.Y.Z_`
+  2. The "Latest release" line         `📦 **Latest release:** [vX — Title](url) — tagline`
+  3. The "What's new" section          fenced by AUTO-GENERATED markers and
+                                       rebuilt from the release's bullets.
+
+Everything else in Home.md (the intro, the Pages list, "Recent highlights",
+Quick links) is hand-authored and left untouched — this script only rewrites
+the three regions above and fails loudly if it cannot.
+
+Usage:  REPO=owner/name TAG=v1.1.3 CHANGELOG=/path/to/CHANGELOG.md \\
+            render_release_home.py /path/to/Home.md
+"""
+from __future__ import annotations
+
+import os
+import re
+import sys
+from pathlib import Path
+
+# Fence markers for the auto-owned "What's new" section. Stable across runs so
+# the section is replaced in place rather than appended.
+WN_BEGIN = "<!-- AUTO-GENERATED: release-whats-new BEGIN (release-docs-sync.yml) -->"
+WN_END = "<!-- AUTO-GENERATED: release-whats-new END -->"
+
+
+def parse_changelog_section(changelog: str, version: str) -> tuple[str, list[str]]:
+    """Return (tagline, bullets) for `## [version] -- date` in the changelog.
+
+    `tagline` is the bold lead sentence + its summary (the line after the
+    heading, e.g. "**Mark the page.** In-reader text highlighting.").
+    `bullets` are the top-level `- ` list items across all `###` subsections,
+    in document order, with their multi-line continuations folded to one line.
+    """
+    # Match the heading for this exact version, capture body up to the next
+    # `## [` heading (or EOF). Version may carry a leading 'v'.
+    v = version.lstrip("v")
+    heading_re = re.compile(
+        r"^##\s*\[" + re.escape(v) + r"\][^\n]*\n(?P<body>.*?)(?=^##\s*\[|\Z)",
+        re.M | re.S,
+    )
+    m = heading_re.search(changelog)
+    if not m:
+        raise SystemExit(f"render_release_home: no CHANGELOG section for [{v}]")
+    body = m.group("body").strip("\n")
+
+    # Tagline: the first non-empty line of the body, before any `###` subsection.
+    tagline = ""
+    for line in body.splitlines():
+        stripped = line.strip()
+        if not stripped:
+            continue
+        if stripped.startswith("#"):
+            break
+        tagline = stripped
+        break
+
+    # Bullets: every top-level `- ` item (deeper indented continuations are
+    # folded onto the preceding bullet). Bullets under a `###` subsection whose
+    # heading is flagged "(internal)" are dropped — the flag lives on the
+    # SUBSECTION HEADING (e.g. "### Fixed (internal)"), not on the bullet text,
+    # so we track the active subsection and skip accordingly.
+    bullets: list[str] = []
+    cur: str | None = None
+    skip_subsection = False
+
+    def flush() -> None:
+        nonlocal cur
+        if cur is not None and not skip_subsection:
+            bullets.append(cur)
+        cur = None
+
+    for line in body.splitlines():
+        if line.startswith("#"):                       # a `###` subsection heading
+            flush()
+            skip_subsection = "(internal)" in line.lower()
+        elif re.match(r"^- ", line):
+            flush()
+            cur = line[2:].strip()
+        elif re.match(r"^\s+\S", line) and cur is not None:
+            cur += " " + line.strip()
+        elif line.strip() == "":
+            flush()
+    flush()
+
+    # Also drop any individual bullet that self-flags internal, belt-and-braces.
+    bullets = [b for b in bullets if "(internal)" not in b.lower()]
+    return tagline, bullets
+
+
+def render_whats_new(version: str, tagline: str, bullets: list[str]) -> str:
+    """Build the fenced 'What's new' section body."""
+    lines = [WN_BEGIN, f"## What's new in {version}", ""]
+    if tagline:
+        lines.append(tagline)
+        lines.append("")
+    if bullets:
+        lines.extend(f"- {b}" for b in bullets)
+    else:
+        lines.append("_See the [release notes](RELEASE_URL) for details._")
+    lines.append(WN_END)
+    return "\n".join(lines)
+
+
+def main() -> None:
+    if len(sys.argv) != 2:
+        raise SystemExit("usage: render_release_home.py <Home.md>")
+    home_path = Path(sys.argv[1])
+    tag = os.environ["TAG"]                      # e.g. v1.1.3
+    repo = os.environ["REPO"]                    # owner/name
+    changelog_path = Path(os.environ["CHANGELOG"])
+
+    release_url = f"https://github.com/{repo}/releases/tag/{tag}"
+    changelog = changelog_path.read_text(encoding="utf-8")
+    tagline, bullets = parse_changelog_section(changelog, tag)
+
+    # Title for the "Latest release" line: the bold lead of the tagline, e.g.
+    # "**Mark the page.** ..." -> "Mark the page". Fall back to the tag.
+    title_m = re.match(r"\*\*(?P<t>[^*]+?)\.?\*\*", tagline)
+    release_title = title_m.group("t").strip() if title_m else tag
+    # The descriptive remainder after the bold lead (for the Latest-release line).
+    remainder = tagline[title_m.end():].strip() if title_m else tagline
+
+    s = home_path.read_text(encoding="utf-8")
+    orig = s
+
+    # 1. Current-version line.
+    ver_re = re.compile(r"^_Current version: v\d+\.\d+\.\d+_\s*$", re.M)
+    ver_line = f"_Current version: {tag}_"
+    if ver_re.search(s):
+        s = ver_re.sub(ver_line, s, count=1)
+    else:
+        # Insert just after the first H1.
+        s = re.sub(r"(\A#[^\n]+\n)", lambda m: m.group(1) + "\n" + ver_line + "\n",
+                   s, count=1)
+
+    # 2. Latest-release line.
+    latest_re = re.compile(r"^📦 \*\*Latest release:\*\*.*$", re.M)
+    latest_line = (
+        f"📦 **Latest release:** [{tag} — {release_title}]({release_url})"
+        + (f" — {remainder}" if remainder else "")
+    )
+    if latest_re.search(s):
+        s = latest_re.sub(lambda _m: latest_line, s, count=1)
+    else:
+        raise SystemExit("render_release_home: no '📦 **Latest release:**' line in Home.md")
+
+    # 3. "What's new" section (fenced + idempotent).
+    whats_new = render_whats_new(tag, tagline, bullets).replace("RELEASE_URL", release_url)
+    fenced_re = re.compile(re.escape(WN_BEGIN) + r".*?" + re.escape(WN_END), re.S)
+    if fenced_re.search(s):
+        s = fenced_re.sub(lambda _m: whats_new, s, count=1)
+    else:
+        # First adoption: replace the legacy, unfenced "## What's new in vX"
+        # block (up to the next `## ` heading) with the fenced version.
+        legacy_re = re.compile(r"^## What's new in v\d+\.\d+\.\d+.*?(?=^## )", re.M | re.S)
+        if legacy_re.search(s):
+            s = legacy_re.sub(whats_new + "\n\n", s, count=1)
+        else:
+            raise SystemExit("render_release_home: no '## What's new' section to take over")
+
+    if s != orig:
+        home_path.write_text(s, encoding="utf-8")
+        print(f"render_release_home: Home.md updated to {tag} "
+              f"({len(bullets)} bullet(s)).")
+    else:
+        print(f"render_release_home: Home.md already current for {tag}.")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/wiki/test_render_release_home.py
+++ b/scripts/wiki/test_render_release_home.py
@@ -1,0 +1,166 @@
+#!/usr/bin/env python3
+"""Tests for render_release_home.py — run with:
+    python3 scripts/wiki/test_render_release_home.py
+
+Pure-stdlib (no pytest), matching the sibling test_sync_wiki.py convention.
+"""
+
+import os
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+os.environ.setdefault("REPO", "techempower-org/candela")
+os.environ.setdefault("TAG", "v1.1.3")
+os.environ.setdefault("CHANGELOG", "/dev/null")
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+import render_release_home as rr  # noqa: E402
+
+CHANGELOG = """\
+# Changelog
+
+## [Unreleased]
+
+## [1.1.3] -- 2026-06-07
+
+**Mark the page.** In-reader text highlighting.
+
+### Added
+
+- **In-reader highlights.** Long-press to select text in the reader, pick a
+  color, and attach a note. (#1079 / #1088)
+
+### Tested
+
+- The select->highlight gesture is verified on-device.
+
+### Fixed (internal)
+
+- Some internal-only plumbing that should NOT appear on the wiki.
+
+## [1.1.2] -- 2026-06-06
+
+**Right book, every time.** Older release.
+
+### Fixed
+
+- An older fix that must not bleed into the 1.1.3 section.
+"""
+
+HOME = """\
+# Candela wiki
+
+_Current version: v0.5.51_
+**Candela is TechEmpower's accessible resource app.**
+
+📦 **Latest release:** [v0.5.51 — Luminous Quartz](https://github.com/techempower-org/candela/releases/tag/v0.5.51) — old summary.
+
+---
+
+## Pages
+
+- **[Getting started](Getting-started)**
+
+## What's new in v0.5.51
+
+- Old bullet that should be replaced.
+
+## Recent v0.5 highlights
+
+- A hand-curated highlight we do NOT own.
+
+## Quick links
+
+- [Releases](https://github.com/techempower-org/candela/releases)
+"""
+
+
+def render(home_text: str, tag: str = "v1.1.3", changelog: str = CHANGELOG) -> str:
+    with tempfile.TemporaryDirectory() as d:
+        cl = Path(d) / "CHANGELOG.md"
+        cl.write_text(changelog)
+        home = Path(d) / "Home.md"
+        home.write_text(home_text)
+        os.environ["TAG"] = tag
+        os.environ["CHANGELOG"] = str(cl)
+        sys.argv = ["render_release_home.py", str(home)]
+        rr.main()
+        return home.read_text()
+
+
+class ParseChangelog(unittest.TestCase):
+    def test_tagline_and_bullets(self):
+        tagline, bullets = rr.parse_changelog_section(CHANGELOG, "v1.1.3")
+        self.assertEqual(tagline, "**Mark the page.** In-reader text highlighting.")
+        self.assertEqual(len(bullets), 2)  # Added + Tested; internal dropped
+        self.assertIn("In-reader highlights", bullets[0])
+        self.assertIn("on-device", bullets[1])
+
+    def test_internal_bullets_dropped(self):
+        _, bullets = rr.parse_changelog_section(CHANGELOG, "v1.1.3")
+        self.assertFalse(any("internal" in b.lower() for b in bullets))
+
+    def test_does_not_bleed_into_older_release(self):
+        _, bullets = rr.parse_changelog_section(CHANGELOG, "v1.1.3")
+        self.assertFalse(any("older fix" in b.lower() for b in bullets))
+
+    def test_missing_version_raises(self):
+        with self.assertRaises(SystemExit):
+            rr.parse_changelog_section(CHANGELOG, "v9.9.9")
+
+
+class RenderHome(unittest.TestCase):
+    def test_version_line_updated(self):
+        out = render(HOME)
+        self.assertIn("_Current version: v1.1.3_", out)
+        self.assertNotIn("_Current version: v0.5.51_", out)
+
+    def test_latest_release_line(self):
+        out = render(HOME)
+        self.assertIn(
+            "📦 **Latest release:** [v1.1.3 — Mark the page]"
+            "(https://github.com/techempower-org/candela/releases/tag/v1.1.3)"
+            " — In-reader text highlighting.",
+            out,
+        )
+
+    def test_whats_new_fenced_and_populated(self):
+        out = render(HOME)
+        self.assertIn(rr.WN_BEGIN, out)
+        self.assertIn(rr.WN_END, out)
+        self.assertIn("## What's new in v1.1.3", out)
+        self.assertIn("In-reader highlights", out)
+        self.assertNotIn("Old bullet that should be replaced", out)
+
+    def test_legacy_unowned_section_preserved(self):
+        out = render(HOME)
+        self.assertIn("## Recent v0.5 highlights", out)
+        self.assertIn("A hand-curated highlight we do NOT own", out)
+
+    def test_idempotent(self):
+        once = render(HOME)
+        twice = render(once)
+        self.assertEqual(once, twice)
+
+    def test_next_release_replaces_in_place_no_dupes(self):
+        once = render(HOME)
+        cl2 = CHANGELOG.replace(
+            "## [Unreleased]",
+            "## [Unreleased]\n\n## [1.2.0] -- 2026-07-01\n\n"
+            "**Next one.** A new summary.\n\n### Added\n\n- A 1.2.0 bullet.",
+        )
+        twice = render(once, tag="v1.2.0", changelog=cl2)
+        self.assertEqual(twice.count(rr.WN_BEGIN), 1)
+        self.assertIn("## What's new in v1.2.0", twice)
+        self.assertNotIn("## What's new in v1.1.3", twice)
+
+    def test_missing_latest_release_line_raises(self):
+        broken = HOME.replace("📦 **Latest release:**", "Latest release:")
+        with self.assertRaises(SystemExit):
+            render(broken)
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)


### PR DESCRIPTION
## What this does

Makes the **wiki self-update on every release with zero human steps** — no PR-to-main, no PAT, no maintainer-merge gate — which is the behaviour JP asked for.

### Root cause of the breakage
`release-docs-sync` has been red on every tag since v0.5.98. Two compounding causes:
1. It used the `gh` CLI. The self-hosted runner pool is mixed — katana has `gh`, **familiar did not** — so when a job landed on familiar every `gh` call exited 127 (`gh: command not found`). That alone failed every release after v0.5.98.
2. Even on katana the docs PR could never auto-land (repo auto-merge disabled + CODEOWNERS requires a maintainer review).

### The fix — write release content DIRECTLY to the wiki
The `.wiki` repo is **not** branch-protected, so a plain `git push` with the built-in `GITHUB_TOKEN` lands immediately (no PAT, no protected-branch gate, no `gh`). This workflow now OWNS the release-current regions of wiki **Home.md**: the `_Current version:` line, the `Latest release:` line, and an AUTO-GENERATED-fenced **What's new in vX.Y.Z** section — all regenerated from `CHANGELOG.md` on each tag and direct-pushed to the wiki.

### Why this fixes the real staleness
The version line was already current (that one regex worked). What was frozen at **v0.5.51** was the "Latest release" line and the "What's new" section — exactly what this regenerates each release.

### Dropped entirely
The docs-PR-to-main machinery: `gh`/`curl pr create`, the `docs-sync/*` branch, the README + `docs/index.md` edits, realm-sigil `version.json` regen, and `pull-requests: write`. The main-repo `docs/index.md` + README headline stay on the normal human-PR flow per JP — this workflow is wiki-only.

### Rendering + tests
Logic lives in `scripts/wiki/render_release_home.py` with a pure-stdlib unittest (`scripts/wiki/test_render_release_home.py`, **11 tests**, all passing). Idempotent, parses the tag's CHANGELOG section (skipping `(internal)` subsections), replaces the fenced section in place across releases without duplication. Dry-run against the **live** wiki Home.md for v1.1.3 produces the correct output (Latest-release line + What's-new with the 2 real bullets).

### Anti-clobber
This owns **Home.md only**. The companion `wiki-sync.yml` (#1040) owns Architecture/Accessibility/Cloud-sync/Compose-gotchas/Roadmap/Changelog/Modules and never touches Home.md — the two cannot collide.

Generated with Claude Code