### PR TITLE
chore(deps): compileSdk 37 + Hilt/Dagger 2.60

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -172,7 +172,7 @@ val hasPlayPublisherCredentials: Boolean = playPublisherCredentialsPath != null 
 
 android {
     namespace = "in.jphe.storyvox"
-    compileSdk = 36
+    compileSdk = 37
 
     defaultConfig {
         applicationId = "org.techempower.candela"

--- a/baselineprofile/build.gradle.kts
+++ b/baselineprofile/build.gradle.kts
@@ -55,7 +55,7 @@ plugins {
 
 android {
     namespace = "in.jphe.storyvox.baselineprofile"
-    compileSdk = 36
+    compileSdk = 37
 
     compileOptions {
         sourceCompatibility = JavaVersion.VERSION_17

--- a/core-data/build.gradle.kts
+++ b/core-data/build.gradle.kts
@@ -8,7 +8,7 @@ plugins {
 
 android {
     namespace = "in.jphe.storyvox.data"
-    compileSdk = 36
+    compileSdk = 37
 
     defaultConfig {
         minSdk = 26

--- a/core-llm/build.gradle.kts
+++ b/core-llm/build.gradle.kts
@@ -8,7 +8,7 @@ plugins {
 
 android {
     namespace = "in.jphe.storyvox.llm"
-    compileSdk = 36
+    compileSdk = 37
 
     defaultConfig {
         minSdk = 26

--- a/core-playback/build.gradle.kts
+++ b/core-playback/build.gradle.kts
@@ -9,7 +9,7 @@ plugins {
 
 android {
     namespace = "in.jphe.storyvox.playback"
-    compileSdk = 36
+    compileSdk = 37
 
     defaultConfig {
         minSdk = 26

--- a/core-sync/build.gradle.kts
+++ b/core-sync/build.gradle.kts
@@ -28,7 +28,7 @@ val instantAppId: String = run {
 
 android {
     namespace = "in.jphe.storyvox.sync"
-    compileSdk = 36
+    compileSdk = 37
 
     defaultConfig {
         minSdk = 26

--- a/core-ui/build.gradle.kts
+++ b/core-ui/build.gradle.kts
@@ -6,7 +6,7 @@ plugins {
 
 android {
     namespace = "in.jphe.storyvox.ui"
-    compileSdk = 36
+    compileSdk = 37
 
     defaultConfig {
         minSdk = 26

--- a/feature/build.gradle.kts
+++ b/feature/build.gradle.kts
@@ -8,7 +8,7 @@ plugins {
 
 android {
     namespace = "in.jphe.storyvox.feature"
-    compileSdk = 36
+    compileSdk = 37
 
     defaultConfig {
         minSdk = 26

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -24,7 +24,7 @@ compose-bom = "2026.06.00"
 compose-material-icons = "1.7.8"
 
 # Hilt + Hilt-Work
-hilt = "2.59.2"
+hilt = "2.60"
 hilt-navigation-compose = "1.3.0"
 hilt-work = "1.3.0"
 

--- a/source-ao3/build.gradle.kts
+++ b/source-ao3/build.gradle.kts
@@ -13,7 +13,7 @@ plugins {
 
 android {
     namespace = "in.jphe.storyvox.source.ao3"
-    compileSdk = 36
+    compileSdk = 37
 
     defaultConfig {
         minSdk = 26

--- a/source-arxiv/build.gradle.kts
+++ b/source-arxiv/build.gradle.kts
@@ -7,7 +7,7 @@ plugins {
 
 android {
     namespace = "in.jphe.storyvox.source.arxiv"
-    compileSdk = 36
+    compileSdk = 37
 
     defaultConfig {
         minSdk = 26

--- a/source-audiobook-writer/build.gradle.kts
+++ b/source-audiobook-writer/build.gradle.kts
@@ -21,7 +21,7 @@ plugins {
 // the math unit-tested.
 android {
     namespace = "in.jphe.storyvox.source.audiobook.writer"
-    compileSdk = 36
+    compileSdk = 37
 
     defaultConfig {
         minSdk = 26

--- a/source-azure/build.gradle.kts
+++ b/source-azure/build.gradle.kts
@@ -7,7 +7,7 @@ plugins {
 
 android {
     namespace = "in.jphe.storyvox.source.azure"
-    compileSdk = 36
+    compileSdk = 37
 
     defaultConfig {
         minSdk = 26

--- a/source-discord/build.gradle.kts
+++ b/source-discord/build.gradle.kts
@@ -8,7 +8,7 @@ plugins {
 
 android {
     namespace = "in.jphe.storyvox.source.discord"
-    compileSdk = 36
+    compileSdk = 37
 
     defaultConfig {
         minSdk = 26

--- a/source-epub-writer/build.gradle.kts
+++ b/source-epub-writer/build.gradle.kts
@@ -16,7 +16,7 @@ plugins {
 // is pure Kotlin + java.util.zip.
 android {
     namespace = "in.jphe.storyvox.source.epub.writer"
-    compileSdk = 36
+    compileSdk = 37
 
     defaultConfig {
         minSdk = 26

--- a/source-epub/build.gradle.kts
+++ b/source-epub/build.gradle.kts
@@ -7,7 +7,7 @@ plugins {
 
 android {
     namespace = "in.jphe.storyvox.source.epub"
-    compileSdk = 36
+    compileSdk = 37
 
     defaultConfig {
         minSdk = 26

--- a/source-github/build.gradle.kts
+++ b/source-github/build.gradle.kts
@@ -8,7 +8,7 @@ plugins {
 
 android {
     namespace = "in.jphe.storyvox.source.github"
-    compileSdk = 36
+    compileSdk = 37
 
     defaultConfig {
         minSdk = 26

--- a/source-gutenberg/build.gradle.kts
+++ b/source-gutenberg/build.gradle.kts
@@ -8,7 +8,7 @@ plugins {
 
 android {
     namespace = "in.jphe.storyvox.source.gutenberg"
-    compileSdk = 36
+    compileSdk = 37
 
     defaultConfig {
         minSdk = 26

--- a/source-hackernews/build.gradle.kts
+++ b/source-hackernews/build.gradle.kts
@@ -8,7 +8,7 @@ plugins {
 
 android {
     namespace = "in.jphe.storyvox.source.hackernews"
-    compileSdk = 36
+    compileSdk = 37
 
     defaultConfig {
         minSdk = 26

--- a/source-librivox/build.gradle.kts
+++ b/source-librivox/build.gradle.kts
@@ -8,7 +8,7 @@ plugins {
 
 android {
     namespace = "in.jphe.storyvox.source.librivox"
-    compileSdk = 36
+    compileSdk = 37
 
     defaultConfig {
         minSdk = 26

--- a/source-matrix/build.gradle.kts
+++ b/source-matrix/build.gradle.kts
@@ -8,7 +8,7 @@ plugins {
 
 android {
     namespace = "in.jphe.storyvox.source.matrix"
-    compileSdk = 36
+    compileSdk = 37
 
     defaultConfig {
         minSdk = 26

--- a/source-mempalace/build.gradle.kts
+++ b/source-mempalace/build.gradle.kts
@@ -8,7 +8,7 @@ plugins {
 
 android {
     namespace = "in.jphe.storyvox.source.mempalace"
-    compileSdk = 36
+    compileSdk = 37
 
     defaultConfig {
         minSdk = 26

--- a/source-notion/build.gradle.kts
+++ b/source-notion/build.gradle.kts
@@ -8,7 +8,7 @@ plugins {
 
 android {
     namespace = "in.jphe.storyvox.source.notion"
-    compileSdk = 36
+    compileSdk = 37
 
     defaultConfig {
         minSdk = 26

--- a/source-ocr/build.gradle.kts
+++ b/source-ocr/build.gradle.kts
@@ -7,7 +7,7 @@ plugins {
 
 android {
     namespace = "in.jphe.storyvox.source.ocr"
-    compileSdk = 36
+    compileSdk = 37
 
     defaultConfig {
         minSdk = 26

--- a/source-outline/build.gradle.kts
+++ b/source-outline/build.gradle.kts
@@ -8,7 +8,7 @@ plugins {
 
 android {
     namespace = "in.jphe.storyvox.source.outline"
-    compileSdk = 36
+    compileSdk = 37
 
     defaultConfig {
         minSdk = 26

--- a/source-palace/build.gradle.kts
+++ b/source-palace/build.gradle.kts
@@ -7,7 +7,7 @@ plugins {
 
 android {
     namespace = "in.jphe.storyvox.source.palace"
-    compileSdk = 36
+    compileSdk = 37
 
     defaultConfig {
         minSdk = 26

--- a/source-pdf/build.gradle.kts
+++ b/source-pdf/build.gradle.kts
@@ -7,7 +7,7 @@ plugins {
 
 android {
     namespace = "in.jphe.storyvox.source.pdf"
-    compileSdk = 36
+    compileSdk = 37
 
     defaultConfig {
         minSdk = 26

--- a/source-plos/build.gradle.kts
+++ b/source-plos/build.gradle.kts
@@ -8,7 +8,7 @@ plugins {
 
 android {
     namespace = "in.jphe.storyvox.source.plos"
-    compileSdk = 36
+    compileSdk = 37
 
     defaultConfig {
         minSdk = 26

--- a/source-radio/build.gradle.kts
+++ b/source-radio/build.gradle.kts
@@ -8,7 +8,7 @@ plugins {
 
 android {
     namespace = "in.jphe.storyvox.source.radio"
-    compileSdk = 36
+    compileSdk = 37
 
     defaultConfig {
         minSdk = 26

--- a/source-readability/build.gradle.kts
+++ b/source-readability/build.gradle.kts
@@ -7,7 +7,7 @@ plugins {
 
 android {
     namespace = "in.jphe.storyvox.source.readability"
-    compileSdk = 36
+    compileSdk = 37
 
     defaultConfig {
         minSdk = 26

--- a/source-royalroad/build.gradle.kts
+++ b/source-royalroad/build.gradle.kts
@@ -8,7 +8,7 @@ plugins {
 
 android {
     namespace = "in.jphe.storyvox.source.royalroad"
-    compileSdk = 36
+    compileSdk = 37
 
     defaultConfig {
         minSdk = 26

--- a/source-rss/build.gradle.kts
+++ b/source-rss/build.gradle.kts
@@ -7,7 +7,7 @@ plugins {
 
 android {
     namespace = "in.jphe.storyvox.source.rss"
-    compileSdk = 36
+    compileSdk = 37
 
     defaultConfig {
         minSdk = 26

--- a/source-slack/build.gradle.kts
+++ b/source-slack/build.gradle.kts
@@ -8,7 +8,7 @@ plugins {
 
 android {
     namespace = "in.jphe.storyvox.source.slack"
-    compileSdk = 36
+    compileSdk = 37
 
     defaultConfig {
         minSdk = 26

--- a/source-standard-ebooks/build.gradle.kts
+++ b/source-standard-ebooks/build.gradle.kts
@@ -7,7 +7,7 @@ plugins {
 
 android {
     namespace = "in.jphe.storyvox.source.standardebooks"
-    compileSdk = 36
+    compileSdk = 37
 
     defaultConfig {
         minSdk = 26

--- a/source-telegram/build.gradle.kts
+++ b/source-telegram/build.gradle.kts
@@ -8,7 +8,7 @@ plugins {
 
 android {
     namespace = "in.jphe.storyvox.source.telegram"
-    compileSdk = 36
+    compileSdk = 37
 
     defaultConfig {
         minSdk = 26

--- a/source-wikipedia/build.gradle.kts
+++ b/source-wikipedia/build.gradle.kts
@@ -8,7 +8,7 @@ plugins {
 
 android {
     namespace = "in.jphe.storyvox.source.wikipedia"
-    compileSdk = 36
+    compileSdk = 37
 
     defaultConfig {
         minSdk = 26

--- a/source-wikisource/build.gradle.kts
+++ b/source-wikisource/build.gradle.kts
@@ -8,7 +8,7 @@ plugins {
 
 android {
     namespace = "in.jphe.storyvox.source.wikisource"
-    compileSdk = 36
+    compileSdk = 37
 
     defaultConfig {
         minSdk = 26

--- a/wear/build.gradle.kts
+++ b/wear/build.gradle.kts
@@ -9,7 +9,7 @@ plugins {
 
 android {
     namespace = "in.jphe.storyvox.wear"
-    compileSdk = 36
+    compileSdk = 37
 
     defaultConfig {
         applicationId = "in.jphe.storyvox.wear"


### PR DESCRIPTION
## Summary
- Bump `compileSdk` 36 → 37 across all 37 modules (Android 17 / API 37)
- Bump Hilt/Dagger 2.59.2 → 2.60 (adds Kotlin 2.4 metadata support, released today)

Unblocks the 4 dependabot PRs currently failing CI:
- #1106 lifecycle 2.10.0→2.11.0 (needs compileSdk 37)
- #1101 core-ktx 1.18.0→1.19.0 (needs compileSdk 37)
- #1100 kotlin-ecosystem 2.3.21→2.4.0 (needs Hilt with Kotlin 2.4 metadata)
- #1103 coil 3.4.0→3.5.0 (ships Kotlin 2.4 classes)

## Test plan
- [x] `:feature:compileDebugKotlin` passes locally (3m21s, clean)

Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Updated the app to compile with a newer Android platform level across the main app and many modules, supporting newer system APIs and better platform alignment.
- **Chores**
  - Refreshed a shared dependency version used by the project.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->