### PR TITLE
fix(inbox): accumulate new-chapter count across coalesced polls

### DIFF
--- a/core-data/schemas/in.jphe.storyvox.data.db.StoryvoxDatabase/15.json
+++ b/core-data/schemas/in.jphe.storyvox.data.db.StoryvoxDatabase/15.json
@@ -1,0 +1,1106 @@
+{
+  "formatVersion": 1,
+  "database": {
+    "version": 15,
+    "identityHash": "7d8297870f92b9751fad505603bce1b5",
+    "entities": [
+      {
+        "tableName": "fiction",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `sourceId` TEXT NOT NULL, `title` TEXT NOT NULL, `author` TEXT NOT NULL, `authorId` TEXT, `coverUrl` TEXT, `description` TEXT, `genres` TEXT NOT NULL, `tags` TEXT NOT NULL, `status` TEXT NOT NULL, `chapterCount` INTEGER NOT NULL, `wordCount` INTEGER, `rating` REAL, `views` INTEGER, `followers` INTEGER, `lastUpdatedAt` INTEGER, `firstSeenAt` INTEGER NOT NULL, `metadataFetchedAt` INTEGER NOT NULL, `inLibrary` INTEGER NOT NULL, `addedToLibraryAt` INTEGER, `followedRemotely` INTEGER NOT NULL, `downloadMode` TEXT, `pinnedVoiceId` TEXT, `pinnedVoiceLocale` TEXT, `notesEverSeen` INTEGER NOT NULL, `sourceUrl` TEXT, `lastSeenRevision` TEXT, `metadataBackfillFailedAt` INTEGER, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "sourceId",
+            "columnName": "sourceId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "title",
+            "columnName": "title",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "author",
+            "columnName": "author",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "authorId",
+            "columnName": "authorId",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "coverUrl",
+            "columnName": "coverUrl",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "description",
+            "columnName": "description",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "genres",
+            "columnName": "genres",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "tags",
+            "columnName": "tags",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "status",
+            "columnName": "status",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "chapterCount",
+            "columnName": "chapterCount",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "wordCount",
+            "columnName": "wordCount",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "rating",
+            "columnName": "rating",
+            "affinity": "REAL"
+          },
+          {
+            "fieldPath": "views",
+            "columnName": "views",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "followers",
+            "columnName": "followers",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "lastUpdatedAt",
+            "columnName": "lastUpdatedAt",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "firstSeenAt",
+            "columnName": "firstSeenAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "metadataFetchedAt",
+            "columnName": "metadataFetchedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "inLibrary",
+            "columnName": "inLibrary",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "addedToLibraryAt",
+            "columnName": "addedToLibraryAt",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "followedRemotely",
+            "columnName": "followedRemotely",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "downloadMode",
+            "columnName": "downloadMode",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "pinnedVoiceId",
+            "columnName": "pinnedVoiceId",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "pinnedVoiceLocale",
+            "columnName": "pinnedVoiceLocale",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "notesEverSeen",
+            "columnName": "notesEverSeen",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "sourceUrl",
+            "columnName": "sourceUrl",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "lastSeenRevision",
+            "columnName": "lastSeenRevision",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "metadataBackfillFailedAt",
+            "columnName": "metadataBackfillFailedAt",
+            "affinity": "INTEGER"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_fiction_inLibrary",
+            "unique": false,
+            "columnNames": [
+              "inLibrary"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_fiction_inLibrary` ON `${TABLE_NAME}` (`inLibrary`)"
+          },
+          {
+            "name": "index_fiction_followedRemotely",
+            "unique": false,
+            "columnNames": [
+              "followedRemotely"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_fiction_followedRemotely` ON `${TABLE_NAME}` (`followedRemotely`)"
+          },
+          {
+            "name": "index_fiction_sourceId_lastUpdatedAt",
+            "unique": false,
+            "columnNames": [
+              "sourceId",
+              "lastUpdatedAt"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_fiction_sourceId_lastUpdatedAt` ON `${TABLE_NAME}` (`sourceId`, `lastUpdatedAt`)"
+          },
+          {
+            "name": "index_fiction_inLibrary_addedToLibraryAt",
+            "unique": false,
+            "columnNames": [
+              "inLibrary",
+              "addedToLibraryAt"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_fiction_inLibrary_addedToLibraryAt` ON `${TABLE_NAME}` (`inLibrary`, `addedToLibraryAt`)"
+          },
+          {
+            "name": "index_fiction_followedRemotely_lastUpdatedAt",
+            "unique": false,
+            "columnNames": [
+              "followedRemotely",
+              "lastUpdatedAt"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_fiction_followedRemotely_lastUpdatedAt` ON `${TABLE_NAME}` (`followedRemotely`, `lastUpdatedAt`)"
+          }
+        ]
+      },
+      {
+        "tableName": "chapter",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `fictionId` TEXT NOT NULL, `sourceChapterId` TEXT NOT NULL, `index` INTEGER NOT NULL, `title` TEXT NOT NULL, `publishedAt` INTEGER, `wordCount` INTEGER, `htmlBody` TEXT, `plainBody` TEXT, `bodyFetchedAt` INTEGER, `bodyChecksum` TEXT, `downloadState` TEXT NOT NULL, `lastDownloadAttemptAt` INTEGER, `lastDownloadError` TEXT, `notesAuthor` TEXT, `notesAuthorPosition` TEXT, `userMarkedRead` INTEGER NOT NULL, `firstReadAt` INTEGER, `bookmarkCharOffset` INTEGER, `audioUrl` TEXT, PRIMARY KEY(`id`), FOREIGN KEY(`fictionId`) REFERENCES `fiction`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "fictionId",
+            "columnName": "fictionId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "sourceChapterId",
+            "columnName": "sourceChapterId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "index",
+            "columnName": "index",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "title",
+            "columnName": "title",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "publishedAt",
+            "columnName": "publishedAt",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "wordCount",
+            "columnName": "wordCount",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "htmlBody",
+            "columnName": "htmlBody",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "plainBody",
+            "columnName": "plainBody",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "bodyFetchedAt",
+            "columnName": "bodyFetchedAt",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "bodyChecksum",
+            "columnName": "bodyChecksum",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "downloadState",
+            "columnName": "downloadState",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastDownloadAttemptAt",
+            "columnName": "lastDownloadAttemptAt",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "lastDownloadError",
+            "columnName": "lastDownloadError",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "notesAuthor",
+            "columnName": "notesAuthor",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "notesAuthorPosition",
+            "columnName": "notesAuthorPosition",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "userMarkedRead",
+            "columnName": "userMarkedRead",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "firstReadAt",
+            "columnName": "firstReadAt",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "bookmarkCharOffset",
+            "columnName": "bookmarkCharOffset",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "audioUrl",
+            "columnName": "audioUrl",
+            "affinity": "TEXT"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_chapter_fictionId",
+            "unique": false,
+            "columnNames": [
+              "fictionId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_chapter_fictionId` ON `${TABLE_NAME}` (`fictionId`)"
+          },
+          {
+            "name": "index_chapter_fictionId_index",
+            "unique": true,
+            "columnNames": [
+              "fictionId",
+              "index"
+            ],
+            "orders": [],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_chapter_fictionId_index` ON `${TABLE_NAME}` (`fictionId`, `index`)"
+          },
+          {
+            "name": "index_chapter_downloadState",
+            "unique": false,
+            "columnNames": [
+              "downloadState"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_chapter_downloadState` ON `${TABLE_NAME}` (`downloadState`)"
+          },
+          {
+            "name": "index_chapter_fictionId_userMarkedRead",
+            "unique": false,
+            "columnNames": [
+              "fictionId",
+              "userMarkedRead"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_chapter_fictionId_userMarkedRead` ON `${TABLE_NAME}` (`fictionId`, `userMarkedRead`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "fiction",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "fictionId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "playback_position",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`fictionId` TEXT NOT NULL, `chapterId` TEXT NOT NULL, `charOffset` INTEGER NOT NULL, `paragraphIndex` INTEGER NOT NULL, `playbackSpeed` REAL NOT NULL, `durationEstimateMs` INTEGER NOT NULL, `updatedAt` INTEGER NOT NULL, PRIMARY KEY(`fictionId`, `chapterId`), FOREIGN KEY(`fictionId`) REFERENCES `fiction`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE , FOREIGN KEY(`chapterId`) REFERENCES `chapter`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "fictionId",
+            "columnName": "fictionId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "chapterId",
+            "columnName": "chapterId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "charOffset",
+            "columnName": "charOffset",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "paragraphIndex",
+            "columnName": "paragraphIndex",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "playbackSpeed",
+            "columnName": "playbackSpeed",
+            "affinity": "REAL",
+            "notNull": true
+          },
+          {
+            "fieldPath": "durationEstimateMs",
+            "columnName": "durationEstimateMs",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "updatedAt",
+            "columnName": "updatedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "fictionId",
+            "chapterId"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_playback_position_chapterId",
+            "unique": false,
+            "columnNames": [
+              "chapterId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_playback_position_chapterId` ON `${TABLE_NAME}` (`chapterId`)"
+          },
+          {
+            "name": "index_playback_position_updatedAt",
+            "unique": false,
+            "columnNames": [
+              "updatedAt"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_playback_position_updatedAt` ON `${TABLE_NAME}` (`updatedAt`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "fiction",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "fictionId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          },
+          {
+            "table": "chapter",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "chapterId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "auth_cookie",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`sourceId` TEXT NOT NULL, `userDisplayName` TEXT, `userId` TEXT, `capturedAt` INTEGER NOT NULL, `expiresAt` INTEGER, `lastVerifiedAt` INTEGER NOT NULL, PRIMARY KEY(`sourceId`))",
+        "fields": [
+          {
+            "fieldPath": "sourceId",
+            "columnName": "sourceId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "userDisplayName",
+            "columnName": "userDisplayName",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "userId",
+            "columnName": "userId",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "capturedAt",
+            "columnName": "capturedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "expiresAt",
+            "columnName": "expiresAt",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "lastVerifiedAt",
+            "columnName": "lastVerifiedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "sourceId"
+          ]
+        }
+      },
+      {
+        "tableName": "llm_session",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `name` TEXT NOT NULL, `provider` TEXT NOT NULL, `model` TEXT NOT NULL, `systemPrompt` TEXT, `createdAt` INTEGER NOT NULL, `lastUsedAt` INTEGER NOT NULL, `featureKind` TEXT, `anchorFictionId` TEXT, `anchorChapterId` TEXT, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "provider",
+            "columnName": "provider",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "model",
+            "columnName": "model",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "systemPrompt",
+            "columnName": "systemPrompt",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "createdAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastUsedAt",
+            "columnName": "lastUsedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "featureKind",
+            "columnName": "featureKind",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "anchorFictionId",
+            "columnName": "anchorFictionId",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "anchorChapterId",
+            "columnName": "anchorChapterId",
+            "affinity": "TEXT"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "llm_message",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `sessionId` TEXT NOT NULL, `role` TEXT NOT NULL, `content` TEXT NOT NULL, `createdAt` INTEGER NOT NULL, FOREIGN KEY(`sessionId`) REFERENCES `llm_session`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "sessionId",
+            "columnName": "sessionId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "role",
+            "columnName": "role",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "content",
+            "columnName": "content",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "createdAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_llm_message_sessionId",
+            "unique": false,
+            "columnNames": [
+              "sessionId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_llm_message_sessionId` ON `${TABLE_NAME}` (`sessionId`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "llm_session",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "sessionId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "fiction_shelf",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`fictionId` TEXT NOT NULL, `shelf` TEXT NOT NULL, `addedAt` INTEGER NOT NULL, PRIMARY KEY(`fictionId`, `shelf`), FOREIGN KEY(`fictionId`) REFERENCES `fiction`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "fictionId",
+            "columnName": "fictionId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "shelf",
+            "columnName": "shelf",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "addedAt",
+            "columnName": "addedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "fictionId",
+            "shelf"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_fiction_shelf_shelf",
+            "unique": false,
+            "columnNames": [
+              "shelf"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_fiction_shelf_shelf` ON `${TABLE_NAME}` (`shelf`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "fiction",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "fictionId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "chapter_history",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`fictionId` TEXT NOT NULL, `chapterId` TEXT NOT NULL, `openedAt` INTEGER NOT NULL, `completed` INTEGER NOT NULL, `fractionRead` REAL, PRIMARY KEY(`fictionId`, `chapterId`), FOREIGN KEY(`fictionId`) REFERENCES `fiction`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE , FOREIGN KEY(`chapterId`) REFERENCES `chapter`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "fictionId",
+            "columnName": "fictionId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "chapterId",
+            "columnName": "chapterId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "openedAt",
+            "columnName": "openedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "completed",
+            "columnName": "completed",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "fractionRead",
+            "columnName": "fractionRead",
+            "affinity": "REAL"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "fictionId",
+            "chapterId"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_chapter_history_openedAt",
+            "unique": false,
+            "columnNames": [
+              "openedAt"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_chapter_history_openedAt` ON `${TABLE_NAME}` (`openedAt`)"
+          },
+          {
+            "name": "index_chapter_history_chapterId",
+            "unique": false,
+            "columnNames": [
+              "chapterId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_chapter_history_chapterId` ON `${TABLE_NAME}` (`chapterId`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "fiction",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "fictionId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          },
+          {
+            "table": "chapter",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "chapterId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "inbox_event",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `sourceId` TEXT NOT NULL, `fictionId` TEXT, `chapterId` TEXT, `title` TEXT NOT NULL, `body` TEXT, `ts` INTEGER NOT NULL, `isRead` INTEGER NOT NULL, `newChapterCount` INTEGER NOT NULL, `deepLinkUri` TEXT)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "sourceId",
+            "columnName": "sourceId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "fictionId",
+            "columnName": "fictionId",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "chapterId",
+            "columnName": "chapterId",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "title",
+            "columnName": "title",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "body",
+            "columnName": "body",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "ts",
+            "columnName": "ts",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "isRead",
+            "columnName": "isRead",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "newChapterCount",
+            "columnName": "newChapterCount",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "deepLinkUri",
+            "columnName": "deepLinkUri",
+            "affinity": "TEXT"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_inbox_event_ts",
+            "unique": false,
+            "columnNames": [
+              "ts"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_inbox_event_ts` ON `${TABLE_NAME}` (`ts`)"
+          },
+          {
+            "name": "index_inbox_event_isRead",
+            "unique": false,
+            "columnNames": [
+              "isRead"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_inbox_event_isRead` ON `${TABLE_NAME}` (`isRead`)"
+          },
+          {
+            "name": "index_inbox_event_sourceId_fictionId",
+            "unique": false,
+            "columnNames": [
+              "sourceId",
+              "fictionId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_inbox_event_sourceId_fictionId` ON `${TABLE_NAME}` (`sourceId`, `fictionId`)"
+          }
+        ]
+      },
+      {
+        "tableName": "fiction_memory_entry",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`fictionId` TEXT NOT NULL, `entityType` TEXT NOT NULL, `name` TEXT NOT NULL, `summary` TEXT NOT NULL, `firstSeenChapterIndex` INTEGER, `lastUpdated` INTEGER NOT NULL, `userEdited` INTEGER NOT NULL, PRIMARY KEY(`fictionId`, `name`))",
+        "fields": [
+          {
+            "fieldPath": "fictionId",
+            "columnName": "fictionId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "entityType",
+            "columnName": "entityType",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "summary",
+            "columnName": "summary",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "firstSeenChapterIndex",
+            "columnName": "firstSeenChapterIndex",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "lastUpdated",
+            "columnName": "lastUpdated",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "userEdited",
+            "columnName": "userEdited",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "fictionId",
+            "name"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_fiction_memory_entry_name",
+            "unique": false,
+            "columnNames": [
+              "name"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_fiction_memory_entry_name` ON `${TABLE_NAME}` (`name`)"
+          },
+          {
+            "name": "index_fiction_memory_entry_fictionId",
+            "unique": false,
+            "columnNames": [
+              "fictionId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_fiction_memory_entry_fictionId` ON `${TABLE_NAME}` (`fictionId`)"
+          }
+        ]
+      },
+      {
+        "tableName": "annotation",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `fictionId` TEXT NOT NULL, `chapterId` TEXT NOT NULL, `startOffset` INTEGER NOT NULL, `endOffset` INTEGER NOT NULL, `color` TEXT NOT NULL, `note` TEXT, `quotedText` TEXT NOT NULL, `createdAt` INTEGER NOT NULL, `updatedAt` INTEGER NOT NULL, PRIMARY KEY(`id`), FOREIGN KEY(`fictionId`) REFERENCES `fiction`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE , FOREIGN KEY(`chapterId`) REFERENCES `chapter`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "fictionId",
+            "columnName": "fictionId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "chapterId",
+            "columnName": "chapterId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "startOffset",
+            "columnName": "startOffset",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "endOffset",
+            "columnName": "endOffset",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "color",
+            "columnName": "color",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "note",
+            "columnName": "note",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "quotedText",
+            "columnName": "quotedText",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "createdAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "updatedAt",
+            "columnName": "updatedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_annotation_fictionId",
+            "unique": false,
+            "columnNames": [
+              "fictionId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_annotation_fictionId` ON `${TABLE_NAME}` (`fictionId`)"
+          },
+          {
+            "name": "index_annotation_chapterId",
+            "unique": false,
+            "columnNames": [
+              "chapterId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_annotation_chapterId` ON `${TABLE_NAME}` (`chapterId`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "fiction",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "fictionId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          },
+          {
+            "table": "chapter",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "chapterId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      }
+    ],
+    "setupQueries": [
+      "CREATE TABLE IF NOT EXISTS room_master_table (id INTEGER PRIMARY KEY,identity_hash TEXT)",
+      "INSERT OR REPLACE INTO room_master_table (id,identity_hash) VALUES(42, '7d8297870f92b9751fad505603bce1b5')"
+    ]
+  }
+}

--- a/core-data/src/main/kotlin/in/jphe/storyvox/data/db/StoryvoxDatabase.kt
+++ b/core-data/src/main/kotlin/in/jphe/storyvox/data/db/StoryvoxDatabase.kt
@@ -74,7 +74,11 @@ import `in`.jphe.storyvox.data.db.entity.PlaybackPosition
     // v14 (#999 highlights + notes) — new `annotation` table for text-range
     // highlights with optional notes. Purely additive table; no existing
     // table or row is touched.
-    version = 14,
+    //
+    // v15 (#1083 inbox unread-count) — adds `inbox_event.newChapterCount`
+    // so coalesced polls accumulate chapter deltas instead of overwriting.
+    // Purely additive NOT NULL DEFAULT 0 column.
+    version = 15,
     exportSchema = true,
 )
 @TypeConverters(Converters::class)

--- a/core-data/src/main/kotlin/in/jphe/storyvox/data/db/dao/InboxEventDao.kt
+++ b/core-data/src/main/kotlin/in/jphe/storyvox/data/db/dao/InboxEventDao.kt
@@ -75,23 +75,34 @@ interface InboxEventDao {
     )
     suspend fun latestUnreadForFiction(sourceId: String, fictionId: String): InboxEvent?
 
-    /** Update an existing event in place (used by coalescing). */
+    /**
+     * Coalesce a new poll's delta into an existing unread row. The
+     * [additionalCount] is *added* to the stored `newChapterCount` so
+     * consecutive polls accumulate ("2 new chapters" + "1 new chapter"
+     * = 3, not 1). The [title] is rewritten by the caller to reflect
+     * the new total.
+     *
+     * Issue #1083: the previous version overwrote the title with the
+     * single-poll delta, losing the prior count.
+     */
     @Query(
         """
         UPDATE inbox_event
            SET title = :title,
                body = :body,
                ts = :ts,
-               deepLinkUri = :deepLinkUri
+               deepLinkUri = :deepLinkUri,
+               newChapterCount = newChapterCount + :additionalCount
          WHERE id = :id
         """,
     )
-    suspend fun updateInPlace(
+    suspend fun coalesceInPlace(
         id: Long,
         title: String,
         body: String?,
         ts: Long,
         deepLinkUri: String?,
+        additionalCount: Int,
     )
 
     /** Diagnostic / test helper — full table delete. */

--- a/core-data/src/main/kotlin/in/jphe/storyvox/data/db/entity/InboxEvent.kt
+++ b/core-data/src/main/kotlin/in/jphe/storyvox/data/db/entity/InboxEvent.kt
@@ -63,6 +63,18 @@ data class InboxEvent(
     /** True once the user has tapped the row (or markAllRead fired). */
     val isRead: Boolean = false,
     /**
+     * Accumulated new-chapter count across coalesced polls. When the
+     * new-chapter poller fires every N hours and the user hasn't opened
+     * the Inbox, each poll's delta is *added* to this column rather than
+     * overwriting the title with a count derived from a single poll.
+     * Issue #1083: without this, the second poll's "1 new chapter"
+     * overwrites the first poll's "2 new chapters", under-counting.
+     *
+     * Zero for legacy rows (pre-migration default) and for non-chapter
+     * events that don't carry a count.
+     */
+    val newChapterCount: Int = 0,
+    /**
      * Tap-target. Storyvox-internal deep-link URI string —
      * `storyvox://reader/<fictionId>/<chapterId>` for chapter events,
      * `storyvox://fiction/<fictionId>` for source-wide events. The UI

--- a/core-data/src/main/kotlin/in/jphe/storyvox/data/db/migration/Migrations.kt
+++ b/core-data/src/main/kotlin/in/jphe/storyvox/data/db/migration/Migrations.kt
@@ -455,6 +455,30 @@ val MIGRATION_13_14: Migration = object : Migration(13, 14) {
     }
 }
 
+/**
+ * v15 — issue #1083: inbox unread-count under-counts when multiple
+ * new-chapter polls coalesce before the user reads the Inbox.
+ *
+ * Adds `inbox_event.newChapterCount` (INTEGER NOT NULL DEFAULT 0). The
+ * repository's coalesce-on-insert now *accumulates* the poll delta into
+ * this column and rewrites the title from the total, instead of blindly
+ * overwriting with the single-poll string. Existing rows get 0 (no
+ * accumulated count — the display title is already baked in and still
+ * readable).
+ *
+ * Purely additive — no existing data touched, no row rewritten. SQLite
+ * `ALTER TABLE ADD COLUMN` with a NOT NULL default is metadata-only on
+ * SQLite >= 3.22 (Android 9+); older devices still get the constant-
+ * time path because the default is a literal.
+ */
+val MIGRATION_14_15: Migration = object : Migration(14, 15) {
+    override fun migrate(db: SupportSQLiteDatabase) {
+        db.execSQL(
+            "ALTER TABLE `inbox_event` ADD COLUMN `newChapterCount` INTEGER NOT NULL DEFAULT 0",
+        )
+    }
+}
+
 val ALL_MIGRATIONS: Array<Migration> = arrayOf(
     MIGRATION_1_2,
     MIGRATION_2_3,
@@ -469,4 +493,5 @@ val ALL_MIGRATIONS: Array<Migration> = arrayOf(
     MIGRATION_11_12,
     MIGRATION_12_13,
     MIGRATION_13_14,
+    MIGRATION_14_15,
 )

--- a/core-data/src/main/kotlin/in/jphe/storyvox/data/repository/InboxRepository.kt
+++ b/core-data/src/main/kotlin/in/jphe/storyvox/data/repository/InboxRepository.kt
@@ -36,14 +36,23 @@ interface InboxRepository {
 
     /**
      * Insert an event with coalescing. If an existing unread event
-     * matches `(sourceId, fictionId)`, its title/body/ts are updated
-     * in place — used by the new-chapter poller to roll "1 new chapter"
-     * + "2 new chapters" into "3 new chapters" across consecutive
-     * polls without flooding the feed.
+     * matches `(sourceId, fictionId)`, the [newChapterCount] delta is
+     * *accumulated* into the row's stored count and the title is
+     * rewritten to reflect the total — used by the new-chapter poller
+     * to roll "1 new chapter" + "2 new chapters" into "3 new chapters"
+     * across consecutive polls without flooding the feed.
      *
      * When [fictionId] is null (source-wide events like "KVMR live
      * now") we always insert a new row — there's nothing to coalesce
      * against. Same when no unread row exists for the fiction.
+     *
+     * [newChapterCount] is the delta from this poll (default 0 for
+     * non-chapter events). On coalesce the stored count grows by this
+     * amount; the [title] is ignored and rebuilt from the new total +
+     * [fictionTitle]. On fresh insert the count seeds the row.
+     *
+     * Issue #1083: without numeric accumulation, the second poll's
+     * title overwrote the first poll's, under-counting.
      */
     suspend fun record(
         sourceId: String,
@@ -53,6 +62,8 @@ interface InboxRepository {
         body: String?,
         ts: Long = System.currentTimeMillis(),
         deepLinkUri: String?,
+        newChapterCount: Int = 0,
+        fictionTitle: String? = null,
     ): Long
 
     /** Mark a single event read — fired on row tap. */
@@ -82,22 +93,37 @@ class InboxRepositoryImpl @Inject constructor(
         body: String?,
         ts: Long,
         deepLinkUri: String?,
+        newChapterCount: Int,
+        fictionTitle: String?,
     ): Long {
         // Coalesce when we have a fictionId to look up against. The
         // common case: the new-chapter poller fires every N hours and
         // the user hasn't opened the Inbox yet — instead of stacking
-        // "1 new chapter" then "2 new chapters" rows, update the
-        // existing unread row so the feed shows one entry with the
-        // latest count.
+        // "1 new chapter" then "2 new chapters" rows, accumulate the
+        // count and rewrite the title to reflect the total.
+        //
+        // Issue #1083: the previous version blindly overwrote the title
+        // with the single-poll delta, so poll 2's "1 new chapter"
+        // clobbered poll 1's "2 new chapters". Now the stored
+        // newChapterCount is the source of truth and the title is
+        // derived from it.
         if (fictionId != null) {
             val existing = dao.latestUnreadForFiction(sourceId, fictionId)
             if (existing != null) {
-                dao.updateInPlace(
+                val totalCount = existing.newChapterCount + newChapterCount
+                val plural = if (totalCount == 1) "chapter" else "chapters"
+                val coalescedTitle = if (fictionTitle != null && totalCount > 0) {
+                    "$totalCount new $plural in $fictionTitle"
+                } else {
+                    title
+                }
+                dao.coalesceInPlace(
                     id = existing.id,
-                    title = title,
+                    title = coalescedTitle,
                     body = body,
                     ts = ts,
                     deepLinkUri = deepLinkUri,
+                    additionalCount = newChapterCount,
                 )
                 return existing.id
             }
@@ -112,6 +138,7 @@ class InboxRepositoryImpl @Inject constructor(
                 ts = ts,
                 isRead = false,
                 deepLinkUri = deepLinkUri,
+                newChapterCount = newChapterCount,
             ),
         )
     }

--- a/core-data/src/main/kotlin/in/jphe/storyvox/data/work/NewChapterPollWorker.kt
+++ b/core-data/src/main/kotlin/in/jphe/storyvox/data/work/NewChapterPollWorker.kt
@@ -165,6 +165,8 @@ class NewChapterPollWorker @AssistedInject constructor(
                                 title = "${announcement.newCount} new ${announcement.pluralLabel} in ${fiction.title}",
                                 body = null,
                                 deepLinkUri = "storyvox://reader/${fiction.id}/$deepLinkChapterId",
+                                newChapterCount = announcement.newCount,
+                                fictionTitle = fiction.title,
                             )
                         }.onFailure { e ->
                             // Inbox write is best-effort; a Room

--- a/core-data/src/test/kotlin/in/jphe/storyvox/data/db/StoryvoxDatabaseMigrationTest.kt
+++ b/core-data/src/test/kotlin/in/jphe/storyvox/data/db/StoryvoxDatabaseMigrationTest.kt
@@ -17,6 +17,7 @@ import `in`.jphe.storyvox.data.db.migration.MIGRATION_10_11
 import `in`.jphe.storyvox.data.db.migration.MIGRATION_11_12
 import `in`.jphe.storyvox.data.db.migration.MIGRATION_12_13
 import `in`.jphe.storyvox.data.db.migration.MIGRATION_13_14
+import `in`.jphe.storyvox.data.db.migration.MIGRATION_14_15
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNotNull
 import org.junit.Assert.assertTrue
@@ -154,13 +155,15 @@ class StoryvoxDatabaseMigrationTest {
         // #999 — v14 adds the annotation table. Chain through so the
         // latest-version Room.databaseBuilder opens cleanly.
         helper.runMigrationsAndValidate(dbName, 14, true, MIGRATION_13_14).close()
+        // #1083 — v15 adds inbox_event.newChapterCount. Chain through.
+        helper.runMigrationsAndValidate(dbName, 15, true, MIGRATION_14_15).close()
 
         val ctx = org.robolectric.RuntimeEnvironment.getApplication() as android.content.Context
         val db = Room.databaseBuilder(ctx, StoryvoxDatabase::class.java, dbName)
             .addMigrations(
                 MIGRATION_4_5, MIGRATION_5_6, MIGRATION_6_7, MIGRATION_7_8,
                 MIGRATION_8_9, MIGRATION_9_10, MIGRATION_10_11, MIGRATION_11_12,
-                MIGRATION_12_13, MIGRATION_13_14,
+                MIGRATION_12_13, MIGRATION_13_14, MIGRATION_14_15,
             )
             .build()
 
@@ -325,24 +328,26 @@ class StoryvoxDatabaseMigrationTest {
         helper.runMigrationsAndValidate(dbName, 13, true, MIGRATION_12_13).close()
         // #999 — chain through v14 (annotation table).
         helper.runMigrationsAndValidate(dbName, 14, true, MIGRATION_13_14).close()
+        // #1083 — chain through v15 (inbox_event.newChapterCount).
+        helper.runMigrationsAndValidate(dbName, 15, true, MIGRATION_14_15).close()
 
         val ctx = org.robolectric.RuntimeEnvironment.getApplication() as android.content.Context
         val db = Room.databaseBuilder(ctx, StoryvoxDatabase::class.java, dbName)
             .addMigrations(
                 MIGRATION_4_5, MIGRATION_5_6, MIGRATION_6_7, MIGRATION_7_8,
                 MIGRATION_8_9, MIGRATION_9_10, MIGRATION_10_11, MIGRATION_11_12,
-                MIGRATION_12_13, MIGRATION_13_14,
+                MIGRATION_12_13, MIGRATION_13_14, MIGRATION_14_15,
             )
             .build()
 
         try {
             db.openHelper.writableDatabase.execSQL(
-                "INSERT INTO inbox_event(sourceId, fictionId, chapterId, title, body, ts, isRead, deepLinkUri) " +
-                    "VALUES ('royalroad', 'rr:42', 'rr:42:7', '3 new chapters', null, 1234, 0, 'storyvox://reader/rr:42/rr:42:7')",
+                "INSERT INTO inbox_event(sourceId, fictionId, chapterId, title, body, ts, isRead, deepLinkUri, newChapterCount) " +
+                    "VALUES ('royalroad', 'rr:42', 'rr:42:7', '3 new chapters', null, 1234, 0, 'storyvox://reader/rr:42/rr:42:7', 3)",
             )
 
             db.openHelper.readableDatabase.query(
-                "SELECT sourceId, fictionId, chapterId, title, ts, isRead, deepLinkUri " +
+                "SELECT sourceId, fictionId, chapterId, title, ts, isRead, deepLinkUri, newChapterCount " +
                     "FROM inbox_event",
             ).use { c ->
                 assertTrue(c.moveToFirst())
@@ -353,6 +358,7 @@ class StoryvoxDatabaseMigrationTest {
                 assertEquals(1234L, c.getLong(4))
                 assertEquals(0, c.getInt(5))
                 assertEquals("storyvox://reader/rr:42/rr:42:7", c.getString(6))
+                assertEquals(3, c.getInt(7))
             }
         } finally {
             db.close()
@@ -1125,13 +1131,15 @@ class StoryvoxDatabaseMigrationTest {
         helper.runMigrationsAndValidate(dbName, 12, true, MIGRATION_11_12).close()
         helper.runMigrationsAndValidate(dbName, 13, true, MIGRATION_12_13).close()
         helper.runMigrationsAndValidate(dbName, 14, true, MIGRATION_13_14).close()
+        // #1083 — chain through v15 (inbox_event.newChapterCount).
+        helper.runMigrationsAndValidate(dbName, 15, true, MIGRATION_14_15).close()
 
         val ctx = org.robolectric.RuntimeEnvironment.getApplication() as android.content.Context
         val db = Room.databaseBuilder(ctx, StoryvoxDatabase::class.java, dbName)
             .addMigrations(
                 MIGRATION_4_5, MIGRATION_5_6, MIGRATION_6_7, MIGRATION_7_8,
                 MIGRATION_8_9, MIGRATION_9_10, MIGRATION_10_11, MIGRATION_11_12,
-                MIGRATION_12_13, MIGRATION_13_14,
+                MIGRATION_12_13, MIGRATION_13_14, MIGRATION_14_15,
             )
             .build()
 
@@ -1206,5 +1214,95 @@ class StoryvoxDatabaseMigrationTest {
         }
 
         assertNotNull("smoke sentinel — fail-fast if the try block was no-op'd", helper)
+    }
+
+    /**
+     * Issue #1083 — v15 adds `inbox_event.newChapterCount` (INTEGER NOT NULL
+     * DEFAULT 0) so coalesced polls accumulate chapter deltas instead of
+     * overwriting. Purely additive; existing rows get 0.
+     *
+     * Seeds a v14 inbox_event row, runs 14->15, and asserts the column
+     * exists, is NOT NULL, defaults to 0 on the pre-existing row, and
+     * that a fresh insert with an explicit count round-trips.
+     */
+    @Test fun `migrate v14 to v15 adds inbox_event newChapterCount column`() {
+        val dbName = "inbox-new-chapter-count-migration-test.db"
+
+        helper.createDatabase(dbName, 4).close()
+        helper.runMigrationsAndValidate(dbName, 5, true, MIGRATION_4_5).close()
+        helper.runMigrationsAndValidate(dbName, 6, true, MIGRATION_5_6).close()
+        helper.runMigrationsAndValidate(dbName, 7, true, MIGRATION_6_7).close()
+        helper.runMigrationsAndValidate(dbName, 8, true, MIGRATION_7_8).close()
+        helper.runMigrationsAndValidate(dbName, 9, true, MIGRATION_8_9).close()
+        helper.runMigrationsAndValidate(dbName, 10, true, MIGRATION_9_10).close()
+        helper.runMigrationsAndValidate(dbName, 11, true, MIGRATION_10_11).close()
+        helper.runMigrationsAndValidate(dbName, 12, true, MIGRATION_11_12).close()
+        helper.runMigrationsAndValidate(dbName, 13, true, MIGRATION_12_13).close()
+        helper.runMigrationsAndValidate(dbName, 14, true, MIGRATION_13_14).use { db ->
+            // Seed a v14 inbox_event row so we can verify the default.
+            db.execSQL(
+                "INSERT INTO inbox_event(sourceId, fictionId, chapterId, title, body, ts, isRead, deepLinkUri) " +
+                    "VALUES ('royalroad', 'rr:42', 'rr:42:7', '2 new chapters', null, 1234, 0, " +
+                    "'storyvox://reader/rr:42/rr:42:7')",
+            )
+        }
+
+        val db = helper.runMigrationsAndValidate(
+            dbName,
+            15,
+            /* validateDroppedTables = */ true,
+            MIGRATION_14_15,
+        )
+
+        // Column exists with the right type and NOT NULL constraint.
+        db.query("PRAGMA table_info('inbox_event')").use { c ->
+            var sawColumn = false
+            while (c.moveToNext()) {
+                val name = c.getString(c.getColumnIndexOrThrow("name"))
+                if (name == "newChapterCount") {
+                    sawColumn = true
+                    val type = c.getString(c.getColumnIndexOrThrow("type"))
+                    assertEquals("INTEGER", type)
+                    val notnull = c.getInt(c.getColumnIndexOrThrow("notnull"))
+                    assertEquals(
+                        "newChapterCount must be NOT NULL",
+                        1,
+                        notnull,
+                    )
+                }
+            }
+            assertTrue(
+                "inbox_event.newChapterCount column must exist post-migration",
+                sawColumn,
+            )
+        }
+
+        // Pre-existing v14 row defaults to 0.
+        db.query(
+            "SELECT title, newChapterCount FROM inbox_event WHERE fictionId = 'rr:42'",
+        ).use { c ->
+            assertTrue("seeded v14 inbox_event row must survive", c.moveToFirst())
+            assertEquals("2 new chapters", c.getString(0))
+            assertEquals(
+                "newChapterCount must default to 0 for existing rows",
+                0,
+                c.getInt(1),
+            )
+        }
+
+        // A fresh insert with an explicit count round-trips.
+        db.execSQL(
+            "INSERT INTO inbox_event(sourceId, fictionId, chapterId, title, body, ts, isRead, deepLinkUri, newChapterCount) " +
+                "VALUES ('ao3', 'ao3:99', 'ao3:99:1', '5 new chapters', null, 5678, 0, " +
+                "'storyvox://reader/ao3:99/ao3:99:1', 5)",
+        )
+        db.query(
+            "SELECT newChapterCount FROM inbox_event WHERE fictionId = 'ao3:99'",
+        ).use { c ->
+            assertTrue(c.moveToFirst())
+            assertEquals(5, c.getInt(0))
+        }
+
+        db.close()
     }
 }

--- a/core-data/src/test/kotlin/in/jphe/storyvox/data/repository/InboxRepositoryImplTest.kt
+++ b/core-data/src/test/kotlin/in/jphe/storyvox/data/repository/InboxRepositoryImplTest.kt
@@ -73,12 +73,13 @@ class InboxRepositoryImplTest {
             .filter { it.sourceId == sourceId && it.fictionId == fictionId && !it.isRead }
             .maxByOrNull { it.ts }
 
-        override suspend fun updateInPlace(
+        override suspend fun coalesceInPlace(
             id: Long,
             title: String,
             body: String?,
             ts: Long,
             deepLinkUri: String?,
+            additionalCount: Int,
         ) {
             rows[id]?.let {
                 rows[id] = it.copy(
@@ -86,6 +87,7 @@ class InboxRepositoryImplTest {
                     body = body,
                     ts = ts,
                     deepLinkUri = deepLinkUri,
+                    newChapterCount = it.newChapterCount + additionalCount,
                 )
             }
             rebuild()
@@ -130,17 +132,22 @@ class InboxRepositoryImplTest {
             body = null,
             ts = 1_000L,
             deepLinkUri = "storyvox://reader/rr:42/rr:42:7",
+            newChapterCount = 1,
+            fictionTitle = "Mother of Learning",
         )
-        // Second poll detects more chapters — should update the
-        // existing row in place, not stack a new one.
+        // Second poll detects 2 more chapters — should accumulate into
+        // the existing row (total 3), not stack a new one and not
+        // overwrite the count with 2. Issue #1083.
         repo.record(
             sourceId = "royalroad",
             fictionId = "rr:42",
             chapterId = "rr:42:9",
-            title = "3 new chapters in Mother of Learning",
+            title = "2 new chapters in Mother of Learning",
             body = null,
             ts = 2_000L,
             deepLinkUri = "storyvox://reader/rr:42/rr:42:9",
+            newChapterCount = 2,
+            fictionTitle = "Mother of Learning",
         )
 
         val all = repo.observeAll().first()
@@ -150,7 +157,12 @@ class InboxRepositoryImplTest {
             all.size,
         )
         val row = all.first()
-        assertEquals("3 new chapters in Mother of Learning", row.title)
+        assertEquals(
+            "title reflects accumulated count (1 + 2 = 3), not single-poll delta",
+            "3 new chapters in Mother of Learning",
+            row.title,
+        )
+        assertEquals(3, row.newChapterCount)
         assertEquals(2_000L, row.ts)
         assertEquals("storyvox://reader/rr:42/rr:42:9", row.deepLinkUri)
     }
@@ -220,6 +232,62 @@ class InboxRepositoryImplTest {
             2,
             all.size,
         )
+    }
+
+    /**
+     * Issue #1083 regression — the exact scenario from the bug report:
+     * three polls coalesce before read. Poll 1 finds 2, poll 2 finds 1,
+     * poll 3 finds 3. The title must say "6 new chapters", not "3".
+     */
+    @Test fun `record accumulates counts across three coalesced polls (issue 1083)`() = runTest {
+        val dao = FakeInboxEventDao()
+        val repo = InboxRepositoryImpl(dao)
+
+        // Poll 1: 2 new chapters
+        repo.record(
+            sourceId = "royalroad",
+            fictionId = "rr:42",
+            chapterId = "rr:42:65",
+            title = "2 new chapters in The Wandering Inn",
+            body = null,
+            ts = 1_000L,
+            deepLinkUri = "storyvox://reader/rr:42/rr:42:65",
+            newChapterCount = 2,
+            fictionTitle = "The Wandering Inn",
+        )
+        // Poll 2: 1 new chapter
+        repo.record(
+            sourceId = "royalroad",
+            fictionId = "rr:42",
+            chapterId = "rr:42:67",
+            title = "1 new chapter in The Wandering Inn",
+            body = null,
+            ts = 2_000L,
+            deepLinkUri = "storyvox://reader/rr:42/rr:42:67",
+            newChapterCount = 1,
+            fictionTitle = "The Wandering Inn",
+        )
+        // Poll 3: 3 new chapters
+        repo.record(
+            sourceId = "royalroad",
+            fictionId = "rr:42",
+            chapterId = "rr:42:70",
+            title = "3 new chapters in The Wandering Inn",
+            body = null,
+            ts = 3_000L,
+            deepLinkUri = "storyvox://reader/rr:42/rr:42:70",
+            newChapterCount = 3,
+            fictionTitle = "The Wandering Inn",
+        )
+
+        val all = repo.observeAll().first()
+        assertEquals("still one coalesced row", 1, all.size)
+        val row = all.first()
+        assertEquals(6, row.newChapterCount)
+        assertEquals("6 new chapters in The Wandering Inn", row.title)
+        // Deep link points to the most recent poll's chapter
+        assertEquals("storyvox://reader/rr:42/rr:42:70", row.deepLinkUri)
+        assertEquals(3_000L, row.ts)
     }
 
     @Test fun `markAllRead clears the unread count`() = runTest {


### PR DESCRIPTION
## Summary

Fixes #1083 -- inbox unread-count under-counts when multiple new-chapter polls coalesce before the user reads the inbox.

- Adds `newChapterCount` column to `inbox_event` (Room migration v14->v15, `INTEGER NOT NULL DEFAULT 0`)
- Replaces `updateInPlace` with `coalesceInPlace` in the DAO, which *adds* the poll delta to the stored count instead of ignoring it
- `InboxRepository.record()` now accepts `newChapterCount` and `fictionTitle`; on coalesce it rebuilds the title from the accumulated total
- `NewChapterPollWorker` passes both new params to the repository

**Before:** Poll 1 records "2 new chapters", poll 2 overwrites with "1 new chapter" -- count goes down.
**After:** Poll 1 seeds count=2, poll 2 accumulates to count=3, title reads "3 new chapters".

## Test plan

- [x] `InboxRepositoryImplTest` -- existing coalesce test updated to verify accumulated counts
- [x] New regression test: three polls coalescing (2+1+3=6) verifies accumulated count and title
- [x] Migration test: v14->v15 column exists, NOT NULL, defaults to 0 on existing rows, explicit count round-trips
- [x] Migration chain-through: all round-trip tests updated to chain through v15
- [x] `./gradlew :core-data:compileDebugKotlin` -- passes
- [x] `./gradlew :app:compileDebugKotlin` -- passes (Hilt whole-graph resolution)
- [x] `./gradlew :core-data:testDebugUnitTest` -- all non-Robolectric tests pass (Robolectric failures are pre-existing SDK-level config issue)

Generated with [Claude Code](https://claude.com/claude-code)