### PR TITLE
chore(build): migrate to AGP 9 new DSL with built-in Kotlin

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -2,7 +2,6 @@ import java.util.Properties
 
 plugins {
     alias(libs.plugins.android.application)
-    alias(libs.plugins.kotlin.android)
     alias(libs.plugins.kotlin.compose)
     alias(libs.plugins.ksp)
     alias(libs.plugins.hilt)

--- a/baselineprofile/build.gradle.kts
+++ b/baselineprofile/build.gradle.kts
@@ -49,7 +49,6 @@ plugins {
     // `android-test`; the version-less form picks up the same AGP
     // already resolved.
     id("com.android.test")
-    alias(libs.plugins.kotlin.android)
     alias(libs.plugins.androidx.baselineprofile)
 }
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -10,7 +10,6 @@ plugins {
     // Issue #409 — `androidx.baselineprofile` Gradle plugin. Applied
     // to both :app (consumer side) and :baselineprofile (producer side).
     alias(libs.plugins.androidx.baselineprofile) apply false
-    alias(libs.plugins.kotlin.android) apply false
     alias(libs.plugins.kotlin.jvm) apply false
     alias(libs.plugins.kotlin.compose) apply false
     alias(libs.plugins.ksp) apply false

--- a/core-data/build.gradle.kts
+++ b/core-data/build.gradle.kts
@@ -1,6 +1,5 @@
 plugins {
     alias(libs.plugins.android.library)
-    alias(libs.plugins.kotlin.android)
     alias(libs.plugins.kotlin.serialization)
     alias(libs.plugins.ksp)
     alias(libs.plugins.hilt)

--- a/core-llm/build.gradle.kts
+++ b/core-llm/build.gradle.kts
@@ -1,6 +1,5 @@
 plugins {
     alias(libs.plugins.android.library)
-    alias(libs.plugins.kotlin.android)
     alias(libs.plugins.ksp)
     alias(libs.plugins.hilt)
     alias(libs.plugins.kotlin.serialization)

--- a/core-playback/build.gradle.kts
+++ b/core-playback/build.gradle.kts
@@ -1,6 +1,5 @@
 plugins {
     alias(libs.plugins.android.library)
-    alias(libs.plugins.kotlin.android)
     alias(libs.plugins.kotlin.compose)
     alias(libs.plugins.hilt)
     alias(libs.plugins.ksp)

--- a/core-sync/build.gradle.kts
+++ b/core-sync/build.gradle.kts
@@ -2,7 +2,6 @@ import java.util.Properties
 
 plugins {
     alias(libs.plugins.android.library)
-    alias(libs.plugins.kotlin.android)
     alias(libs.plugins.kotlin.serialization)
     alias(libs.plugins.ksp)
     alias(libs.plugins.hilt)

--- a/core-ui/build.gradle.kts
+++ b/core-ui/build.gradle.kts
@@ -1,6 +1,5 @@
 plugins {
     alias(libs.plugins.android.library)
-    alias(libs.plugins.kotlin.android)
     alias(libs.plugins.kotlin.compose)
 }
 

--- a/feature/build.gradle.kts
+++ b/feature/build.gradle.kts
@@ -1,6 +1,5 @@
 plugins {
     alias(libs.plugins.android.library)
-    alias(libs.plugins.kotlin.android)
     alias(libs.plugins.kotlin.compose)
     alias(libs.plugins.ksp)
     alias(libs.plugins.hilt)

--- a/gradle.properties
+++ b/gradle.properties
@@ -7,8 +7,7 @@ org.gradle.configureondemand=false
 android.useAndroidX=true
 android.nonTransitiveRClass=true
 android.nonFinalResIds=true
-android.builtInKotlin=false
-android.newDsl=false
+android.builtInKotlin=true
 
 kotlin.code.style=official
 kotlin.incremental=true

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -92,9 +92,9 @@ robolectric = "4.16.1"
 # handle Android 14's new "Waiting for app processes to flush
 # profiles..." prefix line. 1.3.x throws IllegalStateException on
 # that output on the Tab A7 Lite (Android 14, June 2025 patch).
-benchmark = "1.4.1"
+benchmark = "1.5.0-alpha06"
 uiautomator = "2.3.0"
-baselineprofile-gradle = "1.4.1"
+baselineprofile-gradle = "1.5.0-alpha06"
 
 # Desugaring
 desugar = "2.1.5"
@@ -250,7 +250,6 @@ android-test = { id = "com.android.test", version.ref = "agp" }
 # bundles the compiled profile into the consumer's APK. Applied to
 # BOTH :app (consumer) and :baselineprofile (producer).
 androidx-baselineprofile = { id = "androidx.baselineprofile", version.ref = "baselineprofile-gradle" }
-kotlin-android = { id = "org.jetbrains.kotlin.android", version.ref = "kotlin" }
 # Pure-JVM Kotlin plugin — used by :core-plugin-ksp (KSP SymbolProcessor
 # lives on the compiler's JVM classpath, not the Android runtime).
 kotlin-jvm = { id = "org.jetbrains.kotlin.jvm", version.ref = "kotlin" }

--- a/source-ao3/build.gradle.kts
+++ b/source-ao3/build.gradle.kts
@@ -1,10 +1,5 @@
 plugins {
     alias(libs.plugins.android.library)
-    alias(libs.plugins.kotlin.android)
-    // PR2 of #426 — AO3 WebView sign-in lives in this module (mirrors
-    // :source-royalroad). Compose is needed for the [Ao3AuthWebView]
-    // composable; without the plugin we can't expose the @Composable
-    // entry point to :app's [AuthWebViewScreen].
     alias(libs.plugins.kotlin.compose)
     alias(libs.plugins.ksp)
     alias(libs.plugins.hilt)

--- a/source-arxiv/build.gradle.kts
+++ b/source-arxiv/build.gradle.kts
@@ -1,6 +1,5 @@
 plugins {
     alias(libs.plugins.android.library)
-    alias(libs.plugins.kotlin.android)
     alias(libs.plugins.ksp)
     alias(libs.plugins.hilt)
 }

--- a/source-audiobook-writer/build.gradle.kts
+++ b/source-audiobook-writer/build.gradle.kts
@@ -1,6 +1,5 @@
 plugins {
     alias(libs.plugins.android.library)
-    alias(libs.plugins.kotlin.android)
 }
 
 // Issue #1003 — "Make your own audiobook" M4B export.

--- a/source-azure/build.gradle.kts
+++ b/source-azure/build.gradle.kts
@@ -1,6 +1,5 @@
 plugins {
     alias(libs.plugins.android.library)
-    alias(libs.plugins.kotlin.android)
     alias(libs.plugins.ksp)
     alias(libs.plugins.hilt)
 }

--- a/source-discord/build.gradle.kts
+++ b/source-discord/build.gradle.kts
@@ -1,6 +1,5 @@
 plugins {
     alias(libs.plugins.android.library)
-    alias(libs.plugins.kotlin.android)
     alias(libs.plugins.ksp)
     alias(libs.plugins.hilt)
     alias(libs.plugins.kotlin.serialization)

--- a/source-epub-writer/build.gradle.kts
+++ b/source-epub-writer/build.gradle.kts
@@ -1,6 +1,5 @@
 plugins {
     alias(libs.plugins.android.library)
-    alias(libs.plugins.kotlin.android)
     alias(libs.plugins.ksp)
     alias(libs.plugins.hilt)
 }

--- a/source-epub/build.gradle.kts
+++ b/source-epub/build.gradle.kts
@@ -1,6 +1,5 @@
 plugins {
     alias(libs.plugins.android.library)
-    alias(libs.plugins.kotlin.android)
     alias(libs.plugins.ksp)
     alias(libs.plugins.hilt)
 }

--- a/source-github/build.gradle.kts
+++ b/source-github/build.gradle.kts
@@ -1,6 +1,5 @@
 plugins {
     alias(libs.plugins.android.library)
-    alias(libs.plugins.kotlin.android)
     alias(libs.plugins.ksp)
     alias(libs.plugins.hilt)
     alias(libs.plugins.kotlin.serialization)

--- a/source-gutenberg/build.gradle.kts
+++ b/source-gutenberg/build.gradle.kts
@@ -1,6 +1,5 @@
 plugins {
     alias(libs.plugins.android.library)
-    alias(libs.plugins.kotlin.android)
     alias(libs.plugins.ksp)
     alias(libs.plugins.hilt)
     alias(libs.plugins.kotlin.serialization)

--- a/source-hackernews/build.gradle.kts
+++ b/source-hackernews/build.gradle.kts
@@ -1,6 +1,5 @@
 plugins {
     alias(libs.plugins.android.library)
-    alias(libs.plugins.kotlin.android)
     alias(libs.plugins.kotlin.serialization)
     alias(libs.plugins.ksp)
     alias(libs.plugins.hilt)

--- a/source-librivox/build.gradle.kts
+++ b/source-librivox/build.gradle.kts
@@ -1,6 +1,5 @@
 plugins {
     alias(libs.plugins.android.library)
-    alias(libs.plugins.kotlin.android)
     alias(libs.plugins.ksp)
     alias(libs.plugins.hilt)
     alias(libs.plugins.kotlin.serialization)

--- a/source-matrix/build.gradle.kts
+++ b/source-matrix/build.gradle.kts
@@ -1,6 +1,5 @@
 plugins {
     alias(libs.plugins.android.library)
-    alias(libs.plugins.kotlin.android)
     alias(libs.plugins.ksp)
     alias(libs.plugins.hilt)
     alias(libs.plugins.kotlin.serialization)

--- a/source-mempalace/build.gradle.kts
+++ b/source-mempalace/build.gradle.kts
@@ -1,6 +1,5 @@
 plugins {
     alias(libs.plugins.android.library)
-    alias(libs.plugins.kotlin.android)
     alias(libs.plugins.ksp)
     alias(libs.plugins.hilt)
     alias(libs.plugins.kotlin.serialization)

--- a/source-notion/build.gradle.kts
+++ b/source-notion/build.gradle.kts
@@ -1,6 +1,5 @@
 plugins {
     alias(libs.plugins.android.library)
-    alias(libs.plugins.kotlin.android)
     alias(libs.plugins.ksp)
     alias(libs.plugins.hilt)
     alias(libs.plugins.kotlin.serialization)

--- a/source-ocr/build.gradle.kts
+++ b/source-ocr/build.gradle.kts
@@ -1,6 +1,5 @@
 plugins {
     alias(libs.plugins.android.library)
-    alias(libs.plugins.kotlin.android)
     alias(libs.plugins.ksp)
     alias(libs.plugins.hilt)
 }

--- a/source-outline/build.gradle.kts
+++ b/source-outline/build.gradle.kts
@@ -1,6 +1,5 @@
 plugins {
     alias(libs.plugins.android.library)
-    alias(libs.plugins.kotlin.android)
     alias(libs.plugins.ksp)
     alias(libs.plugins.hilt)
     alias(libs.plugins.kotlin.serialization)

--- a/source-palace/build.gradle.kts
+++ b/source-palace/build.gradle.kts
@@ -1,6 +1,5 @@
 plugins {
     alias(libs.plugins.android.library)
-    alias(libs.plugins.kotlin.android)
     alias(libs.plugins.ksp)
     alias(libs.plugins.hilt)
 }

--- a/source-pdf/build.gradle.kts
+++ b/source-pdf/build.gradle.kts
@@ -1,6 +1,5 @@
 plugins {
     alias(libs.plugins.android.library)
-    alias(libs.plugins.kotlin.android)
     alias(libs.plugins.ksp)
     alias(libs.plugins.hilt)
 }

--- a/source-plos/build.gradle.kts
+++ b/source-plos/build.gradle.kts
@@ -1,6 +1,5 @@
 plugins {
     alias(libs.plugins.android.library)
-    alias(libs.plugins.kotlin.android)
     alias(libs.plugins.ksp)
     alias(libs.plugins.hilt)
     alias(libs.plugins.kotlin.serialization)

--- a/source-radio/build.gradle.kts
+++ b/source-radio/build.gradle.kts
@@ -1,6 +1,5 @@
 plugins {
     alias(libs.plugins.android.library)
-    alias(libs.plugins.kotlin.android)
     alias(libs.plugins.ksp)
     alias(libs.plugins.hilt)
     alias(libs.plugins.kotlin.serialization)

--- a/source-readability/build.gradle.kts
+++ b/source-readability/build.gradle.kts
@@ -1,6 +1,5 @@
 plugins {
     alias(libs.plugins.android.library)
-    alias(libs.plugins.kotlin.android)
     alias(libs.plugins.ksp)
     alias(libs.plugins.hilt)
 }

--- a/source-royalroad/build.gradle.kts
+++ b/source-royalroad/build.gradle.kts
@@ -1,6 +1,5 @@
 plugins {
     alias(libs.plugins.android.library)
-    alias(libs.plugins.kotlin.android)
     alias(libs.plugins.kotlin.compose)
     alias(libs.plugins.ksp)
     alias(libs.plugins.hilt)

--- a/source-rss/build.gradle.kts
+++ b/source-rss/build.gradle.kts
@@ -1,6 +1,5 @@
 plugins {
     alias(libs.plugins.android.library)
-    alias(libs.plugins.kotlin.android)
     alias(libs.plugins.ksp)
     alias(libs.plugins.hilt)
 }

--- a/source-slack/build.gradle.kts
+++ b/source-slack/build.gradle.kts
@@ -1,6 +1,5 @@
 plugins {
     alias(libs.plugins.android.library)
-    alias(libs.plugins.kotlin.android)
     alias(libs.plugins.ksp)
     alias(libs.plugins.hilt)
     alias(libs.plugins.kotlin.serialization)

--- a/source-standard-ebooks/build.gradle.kts
+++ b/source-standard-ebooks/build.gradle.kts
@@ -1,6 +1,5 @@
 plugins {
     alias(libs.plugins.android.library)
-    alias(libs.plugins.kotlin.android)
     alias(libs.plugins.ksp)
     alias(libs.plugins.hilt)
 }

--- a/source-telegram/build.gradle.kts
+++ b/source-telegram/build.gradle.kts
@@ -1,6 +1,5 @@
 plugins {
     alias(libs.plugins.android.library)
-    alias(libs.plugins.kotlin.android)
     alias(libs.plugins.ksp)
     alias(libs.plugins.hilt)
     alias(libs.plugins.kotlin.serialization)

--- a/source-wikipedia/build.gradle.kts
+++ b/source-wikipedia/build.gradle.kts
@@ -1,6 +1,5 @@
 plugins {
     alias(libs.plugins.android.library)
-    alias(libs.plugins.kotlin.android)
     alias(libs.plugins.ksp)
     alias(libs.plugins.hilt)
     alias(libs.plugins.kotlin.serialization)

--- a/source-wikisource/build.gradle.kts
+++ b/source-wikisource/build.gradle.kts
@@ -1,6 +1,5 @@
 plugins {
     alias(libs.plugins.android.library)
-    alias(libs.plugins.kotlin.android)
     alias(libs.plugins.ksp)
     alias(libs.plugins.hilt)
     alias(libs.plugins.kotlin.serialization)

--- a/wear/build.gradle.kts
+++ b/wear/build.gradle.kts
@@ -1,6 +1,5 @@
 plugins {
     alias(libs.plugins.android.application)
-    alias(libs.plugins.kotlin.android)
     alias(libs.plugins.kotlin.compose)
     alias(libs.plugins.ksp)
     alias(libs.plugins.hilt)


### PR DESCRIPTION
## Summary
- Removes `android.newDsl=false` and sets `android.builtInKotlin=true` in `gradle.properties`, enabling AGP 9's native Kotlin compilation
- Removes the now-unnecessary `org.jetbrains.kotlin.android` plugin from all 37 Android modules (AGP handles Kotlin natively in this mode)
- Retains `org.jetbrains.kotlin.plugin.compose` for the 7 Compose-enabled modules (still required separately)
- Retains `org.jetbrains.kotlin.jvm` for `:core-plugin-ksp` (pure-JVM module, not managed by AGP)
- Bumps `androidx.benchmark` and `baselineprofile-gradle` from 1.4.1 to 1.5.0-alpha06 for AGP 9 new-DSL compatibility
- Removes the unused `kotlin-android` plugin alias from the version catalog

## Test plan
- [x] `./gradlew :app:assembleDebug` builds clean (verified in worktree)
- [x] `./gradlew testDebugUnitTest` — 292/299 pass; 7 failures are pre-existing Robolectric SDK-37 incompatibilities (also fail on main)
- [ ] CI green

Closes #923

🤖 Generated with [Claude Code](https://claude.com/claude-code)