### PR TITLE
fix(a11y): merge semantics for settings rows and chat affordances (#491)

### DIFF
--- a/feature/src/main/kotlin/in/jphe/storyvox/feature/chat/ChatScreen.kt
+++ b/feature/src/main/kotlin/in/jphe/storyvox/feature/chat/ChatScreen.kt
@@ -58,6 +58,8 @@ import androidx.compose.ui.draw.alpha
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.semantics.Role
+import androidx.compose.ui.semantics.contentDescription
+import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
@@ -343,6 +345,9 @@ private fun ReadAloudButton(
     }
     androidx.compose.material3.TextButton(
         onClick = onClick,
+        modifier = Modifier.semantics(mergeDescendants = true) {
+            contentDescription = label
+        },
         contentPadding = androidx.compose.foundation.layout.PaddingValues(
             horizontal = 8.dp, vertical = 0.dp,
         ),
@@ -456,6 +461,9 @@ private fun ToolCallCard(event: ToolCallEvent) {
     Row(
         modifier = Modifier
             .fillMaxWidth()
+            .semantics(mergeDescendants = true) {
+                contentDescription = statusText
+            }
             .border(BorderStroke(1.dp, borderColor), RoundedCornerShape(8.dp))
             .background(
                 MaterialTheme.colorScheme.surfaceVariant.copy(alpha = 0.4f),

--- a/feature/src/main/kotlin/in/jphe/storyvox/feature/settings/SettingsComposables.kt
+++ b/feature/src/main/kotlin/in/jphe/storyvox/feature/settings/SettingsComposables.kt
@@ -41,6 +41,8 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.semantics.Role
+import androidx.compose.ui.semantics.contentDescription
+import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
@@ -170,6 +172,9 @@ fun SettingsRow(
         .fillMaxWidth()
         .heightIn(min = minRowHeight)
         .let { m -> if (onClick != null) m.clickable(role = Role.Button, onClick = onClick) else m }
+        .semantics(mergeDescendants = true) {
+            contentDescription = listOfNotNull(title, subtitle).joinToString(", ")
+        }
         .padding(horizontal = spacing.md, vertical = spacing.sm)
 
     Row(


### PR DESCRIPTION
## Summary
- **SettingsRow**: `mergeDescendants + contentDescription` merges title/subtitle into a single TalkBack announcement instead of fragmented descendants
- **ReadAloudButton**: merged semantics with the action label so TalkBack announces "Play" or "Stop" instead of encountering an unlabeled icon
- **ToolCallCard**: merged semantics with the status text for a coherent tool-call announcement

Supersedes #491 (fork PR couldn't run CI). Same intent, applied to current codebase.

Closes #491

## Test plan
- [x] `:feature:compileDebugKotlin` passes
- [ ] TalkBack swipe-through on Settings and Chat screens

🤖 Generated with [Claude Code](https://claude.com/claude-code)