### PR TITLE
feat(reader): add "Read along" chip to open text reader from player (#1016)

### DIFF
--- a/feature/src/main/kotlin/in/jphe/storyvox/feature/reader/AudiobookView.kt
+++ b/feature/src/main/kotlin/in/jphe/storyvox/feature/reader/AudiobookView.kt
@@ -37,6 +37,7 @@ import androidx.compose.material3.ripple
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
 import androidx.compose.material.icons.automirrored.filled.MenuBook
+import androidx.compose.material.icons.automirrored.outlined.Article
 import androidx.compose.material.icons.automirrored.outlined.FormatListBulleted
 import androidx.compose.material.icons.filled.Forward30
 import androidx.compose.material.icons.filled.Replay
@@ -173,6 +174,17 @@ fun AudiobookView(
      *  previews / tests; production callsites pass
      *  `navController.navigate(StoryvoxRoutes.fictionDetail(fId))`. */
     onOpenLibrary: () -> Unit = {},
+    /** Issue #1016 — "another magical way of accessing the reading mode in
+     *  the play tab besides just swiping to the right." The [HybridReaderShell]
+     *  reaches the text reader by a horizontal swipe (offset 0 → -width); the
+     *  only non-swipe path was the TalkBack-only custom action added in #1025.
+     *  This callback gives sighted users a visible, one-tap affordance — the
+     *  "Read along" chip below the transport — that flips the same pane.
+     *  HybridReaderScreen wires it to `viewModel.setActivePane(ReaderView.Reader)`
+     *  so the tap animates the identical pane settle the swipe does (in-place,
+     *  no nav push — the global playback keeps narrating). Default no-op for
+     *  previews / tests. */
+    onOpenReader: () -> Unit = {},
     /** Issue #278 — loading-phase from the ReaderViewModel. Drives the
      *  soft "Still working…" hint at 10s and the hard timeout/retry
      *  error block at 30s. Defaults to NotLoading so previews / tests
@@ -996,6 +1008,7 @@ fun AudiobookView(
                 onPickVoice = onPickVoice,
                 chapterCount = chapters.size,
                 onOpenChapterList = { showChapterListSheet = true },
+                onOpenReader = onOpenReader,
                 modifier = Modifier
                     .fillMaxWidth()
                     .padding(top = spacing.xs),
@@ -2152,6 +2165,12 @@ internal fun PlayerQuickChips(
     onPickVoice: () -> Unit,
     chapterCount: Int = 0,
     onOpenChapterList: () -> Unit = {},
+    /** Issue #1016 — open the text reader pane for the current chapter.
+     *  Rendered as the brass "Read along" chip pinned at the TOP of the
+     *  block (directly under the transport) so it stays above the fold on
+     *  the narrow Z Flip3 where the lower chip rows can scroll off (#527).
+     *  Wired by [AudiobookView] up to `setActivePane(ReaderView.Reader)`. */
+    onOpenReader: () -> Unit = {},
     modifier: Modifier = Modifier,
 ) {
     val spacing = LocalSpacing.current
@@ -2159,6 +2178,52 @@ internal fun PlayerQuickChips(
         modifier = modifier,
         verticalArrangement = Arrangement.spacedBy(spacing.xs),
     ) {
+        // Issue #1016 — "Read along" entry into the text reader. The
+        // [HybridReaderShell] otherwise only reaches the reader via a
+        // rightward swipe (or the #1025 TalkBack-only custom action), which
+        // the issue calls out as undiscoverable. This labelled brass chip
+        // mirrors the sibling "Chapters" AssistChip below; its trailing
+        // ChevronRight even echoes the swipe-right direction. Pinned first
+        // so it sits directly beneath the play button — the most
+        // discoverable slot — and never scrolls off on a short viewport.
+        Row(
+            modifier = Modifier.fillMaxWidth(),
+            verticalAlignment = Alignment.CenterVertically,
+            horizontalArrangement = Arrangement.spacedBy(spacing.xs),
+        ) {
+            Icon(
+                Icons.AutoMirrored.Outlined.Article,
+                contentDescription = null,
+                tint = MaterialTheme.colorScheme.primary,
+                modifier = Modifier.size(18.dp),
+            )
+            AssistChip(
+                onClick = onOpenReader,
+                label = {
+                    Text(
+                        "Read along",
+                        maxLines = 1,
+                        overflow = androidx.compose.ui.text.style.TextOverflow.Ellipsis,
+                    )
+                },
+                trailingIcon = {
+                    Icon(
+                        Icons.Outlined.ChevronRight,
+                        contentDescription = null,
+                        tint = MaterialTheme.colorScheme.onSurfaceVariant,
+                    )
+                },
+                colors = AssistChipDefaults.assistChipColors(
+                    containerColor = MaterialTheme.colorScheme.surfaceContainerHigh,
+                ),
+                modifier = Modifier
+                    .weight(1f)
+                    .semantics {
+                        contentDescription =
+                            "Read along. Open the text reader for this chapter."
+                    },
+            )
+        }
         // Row 1 — speed presets. Brass icon + presets list. Sleep timer
         // and voice chip go to row 2 so a narrow phone gets a clean
         // two-row layout instead of a 9-chip wrap.

--- a/feature/src/main/kotlin/in/jphe/storyvox/feature/reader/HybridReaderScreen.kt
+++ b/feature/src/main/kotlin/in/jphe/storyvox/feature/reader/HybridReaderScreen.kt
@@ -31,6 +31,7 @@ import `in`.jphe.storyvox.ui.component.BrassButton
 import `in`.jphe.storyvox.ui.component.BrassButtonVariant
 import `in`.jphe.storyvox.ui.component.HybridReaderShell
 import `in`.jphe.storyvox.ui.component.MagicCircularProgress
+import `in`.jphe.storyvox.ui.component.ReaderView
 import `in`.jphe.storyvox.ui.theme.LocalSpacing
 
 @Composable
@@ -291,6 +292,16 @@ fun HybridReaderScreen(
                 onOpenLibrary = {
                     playbackState.fictionId?.let { onOpenLibrary(it) }
                 },
+                // Issue #1016 — the visible "Read along" chip flips the
+                // shell to the reader pane exactly as the rightward swipe
+                // does. setActivePane feeds HybridReaderShell's
+                // `current`/`onViewChange`, so we get the same animated
+                // pane settle, playback keeps narrating, and nothing is
+                // pushed onto the back stack (a /reader route push would
+                // re-enter on the Audiobook pane — _activePane always
+                // starts at Audiobook — so it wouldn't even land on the
+                // text, besides being a jarring full-screen transition).
+                onOpenReader = { viewModel.setActivePane(ReaderView.Reader) },
                 // Issue #278 — surface loading-phase + retry path. The
                 // view decides what to render based on phase (regular /
                 // slow-hint at 10s / full error block at 30s).


### PR DESCRIPTION
## What

Closes #1016 — "make another magical way of accessing the reading mode in the play tab besides just swiping to the right."

Adds a visible **"Read along"** chip to the player (Playing tab), pinned at the top of the quick-chips block directly under the transport controls. Tapping it slides the [`HybridReaderShell`] over to the text-reader pane — the exact same animated pane settle the rightward swipe produces.

## Why

The player only reached the text reader via a rightward swipe on `HybridReaderShell`. That gesture is discoverable only by accident; the sole non-swipe path was the **TalkBack-only** custom action added in #1025, so sighted users had nothing visible to tap. This adds the missing first-class affordance.

## How

- New `onOpenReader` callback on `AudiobookView` → `PlayerQuickChips`, rendered as a brass `AssistChip` (leading `Article` glyph, trailing chevron that echoes the swipe-right direction) mirroring the sibling "Chapters" chip.
- Pinned as the **first** chip row so it stays above the fold even on the narrow Z Flip3, where lower chip rows can scroll off (#527).
- `HybridReaderScreen` wires it to `viewModel.setActivePane(ReaderView.Reader)` — the same `current`/`onViewChange` path the swipe drives. In-place, **playback keeps narrating**, nothing pushed onto the back stack.

### Why a pane switch, not a `/reader` route push
`_activePane` always starts at `ReaderView.Audiobook`, so navigating to `StoryvoxRoutes.reader(...)` would re-enter the screen on the **player** pane (never landing on the text), plus add a jarring full-screen transition. `setActivePane` is the correct mechanism.

The pane switch is wired inside `HybridReaderScreen`, so all three player routes (PLAYING / READER / AUDIOBOOK) get the affordance for free. Both new params are defaulted, so previews and tests are unaffected.

## Accessibility
The chip carries `contentDescription = "Read along. Open the text reader for this chapter."` (matching the established voice/chapters AssistChip semantics pattern). Complements the existing #1025 TalkBack custom action.

## Testing
- `./gradlew :feature:compileDebugKotlin` — ✅ BUILD SUCCESSFUL (no new deprecation warnings; used the AutoMirrored `Article` variant).
- `./gradlew :feature:testDebugUnitTest` — 449/450 pass. The one failure (`VoiceFamilyFilterTest > toggleableIds excludes the placeholder`) is **pre-existing** on the base branch and unrelated to this change (verified via `git stash`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
