### PR TITLE
fix(playback): validate PCM cache integrity to stop silent chapter skips (#1128)

### DIFF
--- a/core-playback/src/main/kotlin/in/jphe/storyvox/playback/cache/PcmAppender.kt
+++ b/core-playback/src/main/kotlin/in/jphe/storyvox/playback/cache/PcmAppender.kt
@@ -149,6 +149,24 @@ class PcmAppender internal constructor(
     @Throws(IOException::class)
     fun complete() {
         check(!closed) { "appender already closed (complete/abandon)" }
+
+        // Issue #1128 — refuse to finalize a degenerate (zero-sentence)
+        // entry. A render whose every sentence produced empty/declined PCM
+        // (transient engine failure, model decline, all-punctuation text)
+        // would otherwise land a "complete" idx.json with sentenceCount=0 /
+        // totalBytes=0. [PcmCache.isComplete] then returns true forever, the
+        // cache-hit branch opens it, and [CacheFileSource.nextChunk] reports
+        // an instant natural-end with zero audio — the chapter is SILENTLY
+        // SKIPPED on every play, and the user's only recourse was the manual
+        // "Clear cache" button (the #1128 report). Discard instead: the next
+        // play is a clean cache MISS and re-renders, giving the engine
+        // another chance rather than poisoning the cache. [CacheFileSource]
+        // also rejects any such entry already on disk (read-side belt).
+        if (sentences.isEmpty()) {
+            abandon()
+            return
+        }
+
         closed = true
         runCatching { pcmStream.close() }
 

--- a/core-playback/src/main/kotlin/in/jphe/storyvox/playback/tts/EnginePlayer.kt
+++ b/core-playback/src/main/kotlin/in/jphe/storyvox/playback/tts/EnginePlayer.kt
@@ -2610,12 +2610,24 @@ class EnginePlayer @AssistedInject constructor(
                             "fromSentence=$currentSentenceIndex base=${key.fileBaseName().take(12)}",
                     )
                 }.onFailure { t ->
+                    // #1128 — the entry is "complete" (isComplete passed) but
+                    // failed CacheFileSource's integrity gate: empty/degenerate
+                    // index, truncated/missing .pcm, or unreadable idx.json.
+                    // Just falling back to streaming would leave the poisoned
+                    // entry on disk — isComplete stays true, so it keeps losing
+                    // the cache-hit race on EVERY future play and the chapter
+                    // stays silently skipped until a manual "Clear cache" (the
+                    // #1128 bug). Delete it: this play's streaming tee re-renders
+                    // a clean entry and future plays hit fresh bytes. delete() is
+                    // idempotent + swallows per-file errors; onFailure is inline
+                    // so the suspend call rides this withContext(IO) scope.
                     android.util.Log.w(
                         "EnginePlayer",
                         "pcm-cache hit-open FAILED chapter=${key.chapterId} " +
-                            "base=${key.fileBaseName().take(12)} — falling back to streaming",
+                            "base=${key.fileBaseName().take(12)} — invalidating + re-rendering",
                         t,
                     )
+                    pcmCache.delete(key)
                 }.getOrNull()
             }
         }

--- a/core-playback/src/main/kotlin/in/jphe/storyvox/playback/tts/source/CacheFileSource.kt
+++ b/core-playback/src/main/kotlin/in/jphe/storyvox/playback/tts/source/CacheFileSource.kt
@@ -218,10 +218,13 @@ class CacheFileSource private constructor(
          * `EnginePlayer.startPlaybackPipeline` calls this when
          * `PcmCache.isComplete(key)` returns true.
          *
-         * @throws IOException if reading the index fails or the pcm
-         *  file is truncated. EnginePlayer catches this and falls
-         *  back to the streaming source — a corrupt cache should
-         *  re-render rather than crash playback.
+         * @throws IOException if the entry fails its integrity gate (#1128):
+         *  unreadable / corrupt index JSON, a degenerate (zero-sentence)
+         *  index, a self-inconsistent manifest, a missing `.pcm`, or a
+         *  `.pcm` shorter than the index requires. EnginePlayer catches
+         *  this, deletes the bad entry, and falls back to the streaming
+         *  source — a corrupt cache re-renders rather than silently
+         *  skipping the chapter or crashing playback.
          */
         @Throws(IOException::class)
         suspend fun open(
@@ -229,17 +232,72 @@ class CacheFileSource private constructor(
             indexFile: File,
             startSentenceIndex: Int = 0,
         ): CacheFileSource = withContext(Dispatchers.IO) {
-            val index = pcmCacheJson.decodeFromString(
-                PcmIndex.serializer(),
-                indexFile.readText(),
-            )
-            // Validate: the .pcm file must be at least totalBytes long.
+            // Issue #1128 — the index sidecar itself can be corrupt
+            // (truncated / half-written JSON from a disk-full finalize or
+            // an OS cache-dir reap mid-write). Decoding it then throws a
+            // [kotlinx.serialization.SerializationException], NOT the
+            // [IOException] this method advertises and EnginePlayer's
+            // fall-back-to-streaming catch keys on — so a corrupt index
+            // would have escaped the cache-recovery path. Surface it as the
+            // documented IOException instead.
+            val index = runCatching {
+                pcmCacheJson.decodeFromString(PcmIndex.serializer(), indexFile.readText())
+            }.getOrElse { t ->
+                throw IOException("PCM cache index unreadable: ${indexFile.name}", t)
+            }
+
+            // Issue #1128 — integrity gate. A "complete" entry (its .idx.json
+            // exists, so [PcmCache.isComplete] is true) can still be unusable
+            // in ways that make the chapter SILENTLY SKIP rather than crash.
+            // Each is rejected here as an IOException → EnginePlayer deletes
+            // the entry and re-renders, instead of serving a broken chapter
+            // forever (the #1128 manual-cache-clear bug):
+            //
+            //  - Degenerate index (zero sentences / non-positive totalBytes):
+            //    written when a render's every sentence produced empty/declined
+            //    PCM. This is the #1128 root cause; also guarded write-side in
+            //    [`in`.jphe.storyvox.playback.cache.PcmAppender.complete]. Served
+            //    as-is it yields an instant natural-end with no audio.
+            //  - Manifest self-inconsistency (sentenceCount != sentences.size):
+            //    a tell that the JSON was truncated mid-array yet still parsed.
+            //  - Missing .pcm: the idx survived an eviction / chapter-sweep that
+            //    failed to unlink its siblings ([PcmCache.delete]/[evictTo] swallow
+            //    per-file errors), leaving idx-without-pcm.
+            //  - Truncated .pcm: shorter than the index's declared totalBytes, or
+            //    an index entry references bytes past EOF (disk-full mid-finalize,
+            //    OS cache-dir reaper between finalize and open). Reading those
+            //    ranges yields zero-length / garbage and drops the sentence.
+            if (index.sentences.isEmpty() || index.totalBytes <= 0L) {
+                throw IOException(
+                    "PCM cache empty/degenerate: sentences=${index.sentences.size} " +
+                        "totalBytes=${index.totalBytes}",
+                )
+            }
+            if (index.sentenceCount != index.sentences.size) {
+                throw IOException(
+                    "PCM cache index inconsistent: sentenceCount=${index.sentenceCount} " +
+                        "!= sentences.size=${index.sentences.size}",
+                )
+            }
+            if (!pcmFile.isFile) {
+                throw IOException("PCM cache file missing: ${pcmFile.name}")
+            }
             // PR-D's appender writes exactly totalBytes; a smaller file
             // means truncation (disk-full mid-finalize, or wiped by
             // the OS cache-dir reaper between finalize and open).
-            if (pcmFile.length() < index.totalBytes) {
+            val pcmLen = pcmFile.length()
+            if (pcmLen < index.totalBytes) {
                 throw IOException(
-                    "PCM cache file truncated: ${pcmFile.length()} < ${index.totalBytes}",
+                    "PCM cache file truncated: $pcmLen < ${index.totalBytes}",
+                )
+            }
+            // No index entry may reference bytes past EOF — a corrupt entry
+            // whose totalBytes looks fine but whose last offset is bogus would
+            // read past the mmap / RandomAccessFile and drop that sentence.
+            val maxExtent = index.sentences.maxOf { it.byteOffset + it.byteLen }
+            if (maxExtent > pcmLen) {
+                throw IOException(
+                    "PCM cache index overruns file: maxExtent=$maxExtent > length=$pcmLen",
                 )
             }
             val raf = RandomAccessFile(pcmFile, "r")

--- a/core-playback/src/test/kotlin/in/jphe/storyvox/playback/cache/PcmAppenderTest.kt
+++ b/core-playback/src/test/kotlin/in/jphe/storyvox/playback/cache/PcmAppenderTest.kt
@@ -112,6 +112,47 @@ class PcmAppenderTest {
     }
 
     @Test
+    fun `complete with no appended sentences discards the entry`() {
+        // Issue #1128 — a render that never appended a sentence (every
+        // sentence produced empty/declined PCM) must NOT finalize a
+        // "complete" but zero-byte entry. Such an entry makes
+        // PcmCache.isComplete return true while CacheFileSource serves zero
+        // audio, so the chapter is silently skipped on every play until the
+        // user clears the cache by hand. complete() discards instead.
+        val app = newAppender()
+        // No appendSentence calls at all.
+        app.complete()
+
+        assertFalse(
+            "complete() with no sentences must not write idx.json (#1128)",
+            File(dir, "abc.idx.json").exists(),
+        )
+        // The degenerate partial (pcm + meta written at construction) is
+        // wiped too, so isComplete is false → next play re-renders.
+        assertFalse(File(dir, "abc.pcm").exists())
+        assertFalse(File(dir, "abc.meta.json").exists())
+    }
+
+    @Test
+    fun `complete after only empty-pcm sentences discards the entry`() {
+        // Issue #1128 — same poison, reached via the appender's empty-PCM
+        // skip path: every sentence the engine returned was empty, so
+        // nothing was recorded in the index. Finalizing would still land a
+        // zero-sentence idx.json. Discard instead.
+        val app = newAppender()
+        app.appendSentence(Sentence(0, 0, 10, "Hi."), ByteArray(0), trailingSilenceMs = 350)
+        app.appendSentence(Sentence(1, 11, 20, "There."), ByteArray(0), trailingSilenceMs = 350)
+        app.complete()
+
+        assertFalse(
+            "all-empty render must not write idx.json (#1128)",
+            File(dir, "abc.idx.json").exists(),
+        )
+        assertFalse(File(dir, "abc.pcm").exists())
+        assertFalse(File(dir, "abc.meta.json").exists())
+    }
+
+    @Test
     fun `finalize after abandon throws`() {
         val app = newAppender()
         app.abandon()

--- a/core-playback/src/test/kotlin/in/jphe/storyvox/playback/tts/source/CacheFileSourceTest.kt
+++ b/core-playback/src/test/kotlin/in/jphe/storyvox/playback/tts/source/CacheFileSourceTest.kt
@@ -4,6 +4,9 @@ import android.app.Application
 import `in`.jphe.storyvox.playback.cache.PcmCache
 import `in`.jphe.storyvox.playback.cache.PcmCacheConfig
 import `in`.jphe.storyvox.playback.cache.PcmCacheKey
+import `in`.jphe.storyvox.playback.cache.PcmIndex
+import `in`.jphe.storyvox.playback.cache.PcmIndexEntry
+import `in`.jphe.storyvox.playback.cache.pcmCacheJson
 import `in`.jphe.storyvox.playback.tts.CHUNKER_VERSION
 import `in`.jphe.storyvox.playback.tts.Sentence
 import kotlinx.coroutines.runBlocking
@@ -39,8 +42,14 @@ import java.io.FileOutputStream
  *    [java.io.IOException] (corrupt cache → re-render, not crash).
  *  - `startSentenceIndex` resumes mid-chapter (post-seek path).
  */
+// sdk=36: core-playback sets compileSdk=37 with no explicit targetSdk, so
+// the test manifest's targetSdkVersion defaults to 37 — past Robolectric
+// 4.16.1's maxSdkVersion=36, which makes the whole class fail to initialize
+// ("targetSdkVersion=37 > maxSdkVersion=36"). Pin the emulated SDK to 36
+// (Robolectric's current ceiling) so these pure-file-IO tests run until the
+// toolchain catches up to 37. The behavior under test is SDK-agnostic.
 @RunWith(RobolectricTestRunner::class)
-@Config(application = Application::class)
+@Config(application = Application::class, sdk = [36])
 class CacheFileSourceTest {
 
     private lateinit var context: Application
@@ -202,6 +211,114 @@ class CacheFileSourceTest {
             )
         }
         assertTrue("CacheFileSource.open should throw on truncated pcm", threw)
+    }
+
+    /** Hand-write an index sidecar + matching pcm file, bypassing
+     *  [PcmAppender] (whose #1128 guard now refuses to produce a
+     *  degenerate entry). Lets these tests forge the exact corrupt
+     *  on-disk shapes a killed/disk-full/reaped render can leave behind. */
+    private fun writeIndex(index: PcmIndex, pcmBytes: ByteArray) {
+        cache.indexFileFor(key)
+            .writeText(pcmCacheJson.encodeToString(PcmIndex.serializer(), index))
+        FileOutputStream(cache.pcmFileFor(key)).use { it.write(pcmBytes) }
+    }
+
+    @Test
+    fun `degenerate zero-sentence index fails to open with IOException`() = runBlocking {
+        // Issue #1128 root cause — a "complete" entry (idx.json present, so
+        // PcmCache.isComplete is true) whose render produced no audio:
+        // sentenceCount=0, totalBytes=0, no pcm bytes. Pre-fix this passed
+        // the only length check (0 < 0 is false) and CacheFileSource served
+        // zero chunks — an instant natural-end that silently skipped the
+        // chapter. open() must now reject it so EnginePlayer re-renders.
+        writeIndex(
+            PcmIndex(sampleRate = 22050, sentenceCount = 0, totalBytes = 0L, sentences = emptyList()),
+            ByteArray(0),
+        )
+        var threw = false
+        try {
+            CacheFileSource.open(pcmFile = cache.pcmFileFor(key), indexFile = cache.indexFileFor(key))
+        } catch (e: java.io.IOException) {
+            threw = true
+            assertTrue(
+                "message should flag degenerate entry, got: ${e.message}",
+                e.message?.contains("degenerate") == true,
+            )
+        }
+        assertTrue("open should reject a zero-sentence index (#1128)", threw)
+    }
+
+    @Test
+    fun `missing pcm file fails to open with IOException`() = runBlocking {
+        // Issue #1128 — the idx.json survived an eviction / chapter sweep
+        // that failed to unlink its .pcm sibling (PcmCache.delete/evictTo
+        // swallow per-file errors). isComplete stays true but the audio is
+        // gone; open() must reject rather than serve an empty file.
+        renderCache()
+        assertTrue("precondition: pcm exists", cache.pcmFileFor(key).delete())
+        var threw = false
+        try {
+            CacheFileSource.open(pcmFile = cache.pcmFileFor(key), indexFile = cache.indexFileFor(key))
+        } catch (e: java.io.IOException) {
+            threw = true
+            assertTrue(
+                "message should flag missing pcm, got: ${e.message}",
+                e.message?.contains("missing") == true,
+            )
+        }
+        assertTrue("open should reject a missing .pcm (#1128)", threw)
+    }
+
+    @Test
+    fun `index entry overrunning the pcm file fails to open`() = runBlocking {
+        // Issue #1128 — a corrupt index whose totalBytes matches the file
+        // length but whose last entry references bytes past EOF. The mmap /
+        // RandomAccessFile read would silently return short/garbage for that
+        // sentence; reject it up front.
+        val pcm = ByteArray(100) { 0x44 }
+        writeIndex(
+            PcmIndex(
+                sampleRate = 22050,
+                sentenceCount = 1,
+                totalBytes = 100L,
+                // byteOffset 60 + byteLen 80 = 140 > 100-byte file.
+                sentences = listOf(PcmIndexEntry(i = 0, start = 0, end = 10, byteOffset = 60L, byteLen = 80, trailingSilenceMs = 0)),
+            ),
+            pcm,
+        )
+        var threw = false
+        try {
+            CacheFileSource.open(pcmFile = cache.pcmFileFor(key), indexFile = cache.indexFileFor(key))
+        } catch (e: java.io.IOException) {
+            threw = true
+            assertTrue(
+                "message should flag overrun, got: ${e.message}",
+                e.message?.contains("overruns") == true,
+            )
+        }
+        assertTrue("open should reject an index that overruns the file (#1128)", threw)
+    }
+
+    @Test
+    fun `unreadable index json fails to open with IOException not SerializationException`() = runBlocking {
+        // Issue #1128 — a truncated / half-written idx.json (disk-full
+        // finalize, OS reap mid-write) decodes to a SerializationException,
+        // which is NOT the IOException EnginePlayer's recovery catch keyed
+        // on pre-fix. open() must surface it as IOException so the entry is
+        // invalidated + re-rendered rather than escaping recovery.
+        cache.indexFileFor(key).writeText("{ this is not valid json")
+        FileOutputStream(cache.pcmFileFor(key)).use { it.write(ByteArray(100)) }
+        var threw = false
+        try {
+            CacheFileSource.open(pcmFile = cache.pcmFileFor(key), indexFile = cache.indexFileFor(key))
+        } catch (e: java.io.IOException) {
+            threw = true
+            assertTrue(
+                "message should flag unreadable index, got: ${e.message}",
+                e.message?.contains("unreadable") == true,
+            )
+        }
+        assertTrue("open should wrap a bad-JSON index as IOException (#1128)", threw)
     }
 
     @Test


### PR DESCRIPTION
## What

Fixes #1128 — corrupted/degenerate PCM cache entries that caused chapters (or parts) to be **silently skipped** during playback, only fixable by manually clearing the cache in Settings.

## Root cause

A chapter whose TTS render produced **no audio** — every sentence empty or declined (transient engine failure, model decline, all-punctuation text) — still called `PcmAppender.complete()`, which wrote a "complete" `.idx.json` with `sentenceCount=0 / totalBytes=0`.

From then on:
1. `PcmCache.isComplete()` returns `true` (it only checks that the `.idx.json` sidecar exists).
2. `CacheFileSource.open()` passed its only validation (`length(0) < totalBytes(0)` is false).
3. `nextChunk()` immediately hit "natural end" and served **zero** audio → chapter silently skipped, forever, until manual cache clear.

Secondary gaps found and closed: a missing `.pcm` with a surviving `.idx.json` (partial eviction/sweep — `delete()`/`evictTo()` swallow per-file errors), a corrupt index JSON leaking a `SerializationException` past EnginePlayer's `IOException`-keyed recovery catch, and no auto-delete of a bad entry (it fell through to streaming but stayed poisoned, losing the cache-hit race on every subsequent play).

## Fix — three layers of defense

| Layer | File | Change |
|-------|------|--------|
| **Write-side prevention** | `PcmAppender.complete()` | Refuse to finalize a zero-sentence render; discard the partial so the next play re-renders cleanly instead of poisoning the cache. |
| **Read-side validation** | `CacheFileSource.open()` | Integrity gate rejecting (as the advertised `IOException`): degenerate/empty index, self-inconsistent manifest (`sentenceCount != sentences.size`), missing `.pcm`, `.pcm` shorter than `totalBytes`, or an index entry that overruns EOF. Index JSON parse wrapped so a corrupt sidecar surfaces as `IOException` rather than `SerializationException`. |
| **Auto-recovery** | `EnginePlayer` cache-hit branch | On hit-open failure, **delete** the bad entry (not just fall through) so it stops losing the cache-hit race on every future play; this play's streaming tee re-renders fresh bytes. Warns to logcat. |

This auto-heals caches that are **already** poisoned on users' devices — no manual "Clear cache" needed.

## On the "magic bytes / header" idea (issue fix-direction 4)

Considered and intentionally **not** done: the `.idx.json` already records `totalBytes`, and the new `maxExtent`/`sentenceCount`/missing-file checks give equivalent truncation detection. Adding a header to the raw `.pcm` would shift every `byteOffset`, invalidate **all** existing caches (forcing every user to re-render everything), and complicate the mmap offset math — a heavy format break for no gain over the length-based checks.

## Tests

- **`PcmAppenderTest`** (plain JUnit, runs everywhere): write-side discard for a no-sentence render and an all-empty-PCM render. ✅ 8/8 pass.
- **`CacheFileSourceTest`**: read-side rejection of a degenerate index, missing `.pcm`, EOF-overrunning entry, and unreadable JSON. ✅ 19/19 pass.

> **Note on the test SDK pin:** `CacheFileSourceTest` is pinned to `@Config(sdk=36)`. `core-playback` sets `compileSdk=37` with no explicit `targetSdk` (landed in #1111), so the test manifest's `targetSdkVersion` defaults to 37 — past Robolectric 4.16.1's `maxSdkVersion=36` — and the whole class fails to initialize (`targetSdkVersion=37 > maxSdkVersion=36`). The pin makes these SDK-agnostic file-IO tests runnable. **The same breakage silently affects every other Robolectric test class in `core-playback`** (e.g. `EngineStreamingSourceCacheTeeTest`, `PcmCacheTest`, `CacheStateInspectorTest`); a module-wide fix (bump Robolectric or pin a `robolectric.properties` SDK) is a separate infra task, out of scope here.

## Verification

`./gradlew :core-playback:compileDebugKotlin` — clean. Affected unit tests green (27/27 across the two touched classes).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
