### PR TITLE
feat(librivox): surface matching public-domain text in the reader (#1046)

### DIFF
--- a/source-librivox/src/main/kotlin/in/jphe/storyvox/source/librivox/LibriVoxSource.kt
+++ b/source-librivox/src/main/kotlin/in/jphe/storyvox/source/librivox/LibriVoxSource.kt
@@ -14,6 +14,7 @@ import `in`.jphe.storyvox.data.source.model.ListPage
 import `in`.jphe.storyvox.data.source.model.SearchQuery
 import `in`.jphe.storyvox.data.source.plugin.SourceCategory
 import `in`.jphe.storyvox.data.source.plugin.SourcePlugin
+import `in`.jphe.storyvox.source.librivox.net.GutenbergTextApi
 import `in`.jphe.storyvox.source.librivox.net.LibriVoxApi
 import `in`.jphe.storyvox.source.librivox.net.LibriVoxBook
 import `in`.jphe.storyvox.source.librivox.net.LibriVoxSection
@@ -43,6 +44,17 @@ import javax.inject.Singleton
  *   Each chapter's [ChapterContent.audioUrl] is the section's
  *   `listen_url`; text bodies are empty so EnginePlayer takes the
  *   Media3 branch.
+ * - **Open-domain text companion (issue #1046)**. A LibriVox recording
+ *   is a volunteer reading a public-domain text — almost always a
+ *   Project Gutenberg ebook, linked from the book's `url_text_source`.
+ *   When that link resolves to a Gutenberg id ([GutenbergTextApi]),
+ *   [fictionDetail] appends one extra **text** chapter
+ *   ("📖 Read the text (Project Gutenberg)", chapterId
+ *   `"<bookId>:gutenberg-text"`) after the audio sections. It carries
+ *   NO `audioUrl`, so the reader shows the public-domain text and the
+ *   TTS pipeline can narrate it — the open-domain text "alongside" the
+ *   human-narrated audio. The Gutenberg fetch is lazy: only [chapter]
+ *   for that id pays it, never the browse/detail listing.
  *
  * ## Two API shapes (lazy section hydration)
  *
@@ -53,12 +65,15 @@ import javax.inject.Singleton
  * `extended=1` single-book fetch that returns the sections. See
  * [LibriVoxApi] for the endpoint detail.
  *
- * ## Audio-stream backend invariant (issue #373)
+ * ## Audio-stream backend invariant (issue #373 / #1046)
  *
- * Every chapter this source produces has `audioUrl != null` and both
- * text bodies empty — EnginePlayer's audio-vs-TTS branch keys off
- * exactly that shape. Keep these in lockstep with `:core-playback`'s
- * expectations or playback regresses.
+ * Every *audio section* chapter has `audioUrl != null` with empty text
+ * bodies — EnginePlayer's audio-vs-TTS branch keys off `audioUrl` and
+ * routes those through Media3. The lone exception is the optional
+ * Gutenberg text companion above: it deliberately has `audioUrl == null`
+ * and a populated body so it flows through the normal text → TTS / reader
+ * path. Keep the section chapters' `audioUrl` non-null in lockstep with
+ * `:core-playback`'s expectations or audio playback regresses.
  */
 @SourcePlugin(
     id = SourceIds.LIBRIVOX,
@@ -73,6 +88,7 @@ import javax.inject.Singleton
 @Singleton
 internal class LibriVoxSource @Inject constructor(
     private val api: LibriVoxApi,
+    private val gutenberg: GutenbergTextApi,
 ) : FictionSource {
 
     override val id: String = SourceIds.LIBRIVOX
@@ -237,12 +253,24 @@ internal class LibriVoxSource @Inject constructor(
         return when (val result = api.byId(bookId)) {
             is FictionResult.Success -> {
                 val book = result.value
+                val audioChapters = book.sections.mapIndexed { index, section ->
+                    section.toChapterInfo(book.id, index)
+                }
+                // Issue #1046 — append the open-domain text companion
+                // when `url_text_source` resolves to a Project Gutenberg
+                // ebook. Sits after the audio sections; carries no audio
+                // so the reader/TTS path handles it. The id is checked
+                // here (cheap, offline) but the text itself is fetched
+                // lazily in [chapter].
+                val chapters = audioChapters + listOfNotNull(
+                    GutenbergTextApi.parseGutenbergId(book.urlTextSource)?.let {
+                        gutenbergTextChapterInfo(book.id, audioChapters.size)
+                    },
+                )
                 FictionResult.Success(
                     FictionDetail(
                         summary = book.toSummary(),
-                        chapters = book.sections.mapIndexed { index, section ->
-                            section.toChapterInfo(book.id, index)
-                        },
+                        chapters = chapters,
                         wordCount = null,
                         lastUpdatedAt = null,
                     ),
@@ -257,6 +285,13 @@ internal class LibriVoxSource @Inject constructor(
         chapterId: String,
     ): FictionResult<ChapterContent> {
         val bookId = bookIdFromFictionId(fictionId)
+        // Issue #1046 — the open-domain text companion. Resolve the
+        // Gutenberg id from the book's `url_text_source`, then fetch +
+        // clean the plain text. Returned with NO audioUrl so the reader
+        // shows it and the TTS pipeline (not Media3) handles playback.
+        if (chapterId == gutenbergTextChapterIdFor(bookId)) {
+            return fetchGutenbergTextChapter(bookId, chapterId)
+        }
         return when (val result = api.byId(bookId)) {
             is FictionResult.Success -> {
                 val book = result.value
@@ -341,7 +376,84 @@ internal class LibriVoxSource @Inject constructor(
             title = title.ifBlank { "Section ${sectionNumber.ifBlank { (index + 1).toString() }}" },
         )
 
+    /** Issue #1046 — TOC entry for the open-domain text companion. Sits
+     *  at [index] (after the audio sections) so it reads as a trailing
+     *  "and here's the text" affordance rather than displacing section 1. */
+    private fun gutenbergTextChapterInfo(bookId: String, index: Int): ChapterInfo =
+        ChapterInfo(
+            id = gutenbergTextChapterIdFor(bookId),
+            sourceChapterId = "gutenberg-text",
+            index = index,
+            title = "📖 Read the text (Project Gutenberg)",
+        )
+
+    /**
+     * Issue #1046 — resolve the book's Gutenberg id (via the
+     * `extended=1` fetch, which carries `url_text_source`) and download
+     * the cleaned public-domain text. Returned as a pure text chapter
+     * (`audioUrl == null`) so the reader renders it and TTS can narrate
+     * it. [FictionResult.NotFound] when the book's text source isn't a
+     * Gutenberg ebook — defensive; [fictionDetail] only advertises this
+     * chapter when the id resolves, but a direct deep-link could still
+     * request it.
+     */
+    private suspend fun fetchGutenbergTextChapter(
+        bookId: String,
+        chapterId: String,
+    ): FictionResult<ChapterContent> {
+        val book = when (val result = api.byId(bookId)) {
+            is FictionResult.Success -> result.value
+            is FictionResult.Failure -> return result
+        }
+        val gutenbergId = GutenbergTextApi.parseGutenbergId(book.urlTextSource)
+            ?: return FictionResult.NotFound(
+                "LibriVox book $bookId has no Project Gutenberg text source",
+            )
+        return when (val text = gutenberg.fetchPlainText(gutenbergId)) {
+            is FictionResult.Success -> FictionResult.Success(
+                ChapterContent(
+                    info = gutenbergTextChapterInfo(book.id, book.sections.size),
+                    htmlBody = gutenbergHtml(text.value),
+                    plainBody = text.value,
+                    // No audioUrl — this is the text path, not Media3.
+                    audioUrl = null,
+                ),
+            )
+            is FictionResult.Failure -> text
+        }
+    }
+
+    /** Wrap Gutenberg plain text into simple paragraph HTML for the
+     *  `htmlBody` contract (blank lines delimit paragraphs; intra-
+     *  paragraph newlines become `<br/>`). The reader's text pane reads
+     *  `plainBody`, but persistence keeps both. */
+    private fun gutenbergHtml(plain: String): String =
+        plain.split(PARAGRAPH_BREAK)
+            .asSequence()
+            .map { it.trim() }
+            .filter { it.isNotEmpty() }
+            .joinToString(separator = "") { para ->
+                val escaped = para
+                    .replace("&", "&amp;")
+                    .replace("<", "&lt;")
+                    .replace(">", "&gt;")
+                    .replace("\n", "<br/>")
+                "<p>$escaped</p>"
+            }
+
     companion object {
+        /** Blank-line paragraph delimiter in Gutenberg plain text. */
+        private val PARAGRAPH_BREAK: Regex = Regex("\\n\\s*\\n")
+
+        /**
+         * Issue #1046 — chapterId for the open-domain text companion:
+         * `"<bookId>:gutenberg-text"`. Distinct from the section
+         * chapterId shape `"<bookId>:<section_number>"` (section numbers
+         * are numeric), so [chapter] routes the two apart unambiguously.
+         */
+        internal fun gutenbergTextChapterIdFor(bookId: String): String =
+            "$bookId:gutenberg-text"
+
         /**
          * Build the storyvox-scoped chapterId for [section] within
          * [bookId]. Format is `"<bookId>:<section_number>"` — stable

--- a/source-librivox/src/main/kotlin/in/jphe/storyvox/source/librivox/di/LibriVoxModule.kt
+++ b/source-librivox/src/main/kotlin/in/jphe/storyvox/source/librivox/di/LibriVoxModule.kt
@@ -10,6 +10,7 @@ import dagger.multibindings.StringKey
 import `in`.jphe.storyvox.data.source.FictionSource
 import `in`.jphe.storyvox.data.source.SourceIds
 import `in`.jphe.storyvox.source.librivox.LibriVoxSource
+import `in`.jphe.storyvox.source.librivox.net.GutenbergTextApi
 import `in`.jphe.storyvox.source.librivox.net.LibriVoxApi
 import okhttp3.OkHttpClient
 import javax.inject.Qualifier
@@ -53,6 +54,19 @@ internal object LibriVoxHttpModule {
     fun provideLibriVoxApi(
         @LibriVoxHttp client: OkHttpClient,
     ): LibriVoxApi = LibriVoxApi(client)
+
+    /**
+     * Issue #1046 — Project Gutenberg plain-text fetcher for the
+     * open-domain text companion chapter. Reuses the same
+     * redirect-following [LibriVoxHttp] client (the `.txt.utf-8` alias
+     * 302s to the cache host, and the generous read timeout suits a
+     * multi-hundred-KB book download).
+     */
+    @Provides
+    @Singleton
+    fun provideGutenbergTextApi(
+        @LibriVoxHttp client: OkHttpClient,
+    ): GutenbergTextApi = GutenbergTextApi(client)
 }
 
 /**

--- a/source-librivox/src/main/kotlin/in/jphe/storyvox/source/librivox/net/GutenbergTextApi.kt
+++ b/source-librivox/src/main/kotlin/in/jphe/storyvox/source/librivox/net/GutenbergTextApi.kt
@@ -1,0 +1,160 @@
+package `in`.jphe.storyvox.source.librivox.net
+
+import `in`.jphe.storyvox.data.source.model.FictionResult
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+import okhttp3.OkHttpClient
+import okhttp3.Request
+import java.io.IOException
+import javax.inject.Inject
+import javax.inject.Singleton
+
+/**
+ * Issue #1046 — fetch the public-domain *text* that matches a LibriVox
+ * recording from Project Gutenberg.
+ *
+ * Every LibriVox audiobook record carries a `url_text_source`
+ * ([LibriVoxBook.urlTextSource]) — the source text the volunteers read
+ * from, which for the overwhelming majority of the catalog is a Project
+ * Gutenberg ebook page (`https://www.gutenberg.org/ebooks/<id>`). The
+ * LibriVox source already streams the human narration through Media3
+ * (audio-stream backend, issue #373); this client lets it ALSO surface
+ * the underlying public-domain text so the reader's text pane can show
+ * the book "alongside" the audio (and the TTS pipeline can narrate it,
+ * since the text chapter carries no `audioUrl`).
+ *
+ * ## What it does
+ *
+ * 1. [parseGutenbergId] pulls the numeric ebook id out of a
+ *    `url_text_source` when it points at gutenberg.org (the `ebooks`,
+ *    `files`, `etext`, and `cache/epub` URL shapes). Non-Gutenberg
+ *    sources (Wikisource, archive.org text, …) return `null` and the
+ *    LibriVox source simply omits the text chapter rather than guessing.
+ * 2. [fetchPlainText] downloads the UTF-8 plain-text rendering from
+ *    `https://www.gutenberg.org/ebooks/<id>.txt.utf-8` (Gutenberg's
+ *    stable "Plain Text UTF-8" alias, which 302-redirects to the
+ *    `cache/epub/<id>/pg<id>.txt` file — the dedicated LibriVox client
+ *    follows redirects), then [stripGutenbergBoilerplate] trims the
+ *    `*** START/END OF THE PROJECT GUTENBERG EBOOK ***` license wrapper
+ *    so the reader shows the work, not the legal preamble.
+ *
+ * The blocking OkHttp call is wrapped in `withContext(Dispatchers.IO)`
+ * so a call from the main dispatcher can't trip
+ * `NetworkOnMainThreadException` (the recurring `:source-*` footgun).
+ */
+@Singleton
+internal class GutenbergTextApi @Inject constructor(
+    private val client: OkHttpClient,
+) {
+    /**
+     * Download + clean the Gutenberg plain-text for [bookId]. The id is
+     * the numeric Gutenberg ebook id (see [parseGutenbergId]), NOT the
+     * LibriVox book id.
+     */
+    suspend fun fetchPlainText(bookId: String): FictionResult<String> = withContext(Dispatchers.IO) {
+        val url = plainTextUrl(bookId)
+        try {
+            val request = Request.Builder()
+                .url(url)
+                .header("Accept", "text/plain")
+                // gutenberg.org's robot policy asks clients to identify
+                // themselves; reuse the LibriVox user-agent contact.
+                .header("User-Agent", USER_AGENT)
+                .get()
+                .build()
+            client.newCall(request).execute().use { resp ->
+                val body = resp.body?.string().orEmpty()
+                when {
+                    resp.code == 404 ->
+                        FictionResult.NotFound("No Project Gutenberg text for ebook $bookId")
+                    !resp.isSuccessful ->
+                        FictionResult.NetworkError(
+                            "HTTP ${resp.code} from gutenberg.org",
+                            IOException("HTTP ${resp.code}"),
+                        )
+                    body.isBlank() ->
+                        FictionResult.NetworkError(
+                            "Empty Project Gutenberg response for ebook $bookId",
+                            IOException("empty body"),
+                        )
+                    else -> FictionResult.Success(stripGutenbergBoilerplate(body))
+                }
+            }
+        } catch (e: IOException) {
+            FictionResult.NetworkError(e.message ?: "fetch failed", e)
+        }
+    }
+
+    companion object {
+        const val BASE_URL: String = "https://www.gutenberg.org"
+
+        const val USER_AGENT: String =
+            "storyvox-librivox/1.0 (+https://github.com/techempower-org/candela)"
+
+        /**
+         * Gutenberg's stable "Plain Text UTF-8" download alias. 302-
+         * redirects to `cache/epub/<id>/pg<id>.txt`; the LibriVox OkHttp
+         * client follows redirects, so a single URL is enough.
+         */
+        internal fun plainTextUrl(bookId: String): String =
+            "$BASE_URL/ebooks/$bookId.txt.utf-8"
+
+        /**
+         * Extract the numeric Project Gutenberg ebook id from a LibriVox
+         * `url_text_source`, or `null` when the URL isn't a Gutenberg
+         * book (so the caller can skip the text chapter rather than
+         * fetch a bogus id). Handles the catalog's URL shapes:
+         *
+         * - `https://www.gutenberg.org/ebooks/1342`
+         * - `http://www.gutenberg.org/files/1342/1342-h/1342-h.htm`
+         * - `https://www.gutenberg.org/etext/1342` (legacy)
+         * - `https://www.gutenberg.org/cache/epub/1342/pg1342.txt`
+         *
+         * The trailing `(?:[/?#].*)?` tolerates sub-paths / query / hash.
+         */
+        internal fun parseGutenbergId(urlTextSource: String?): String? {
+            val url = urlTextSource?.trim().orEmpty()
+            if (url.isEmpty()) return null
+            return GUTENBERG_ID_PATTERN.find(url)?.groupValues?.getOrNull(1)
+        }
+
+        private val GUTENBERG_ID_PATTERN: Regex = Regex(
+            """^https?://(?:www\.)?gutenberg\.org/""" +
+                """(?:ebooks|etext|files|cache/epub)/(\d+)(?:[/?#.].*)?$""",
+            RegexOption.IGNORE_CASE,
+        )
+
+        /**
+         * Trim Project Gutenberg's license wrapper. PG plain-text files
+         * fence the work between
+         * `*** START OF THE PROJECT GUTENBERG EBOOK <title> ***` and
+         * `*** END OF THE PROJECT GUTENBERG EBOOK <title> ***` (older
+         * files say "THIS" instead of "THE", and spacing/case varies).
+         * Returns the content between the markers; if either marker is
+         * absent (a rare malformed file) the whole trimmed text is kept
+         * so the reader still gets the book rather than nothing.
+         */
+        internal fun stripGutenbergBoilerplate(raw: String): String {
+            val startMatch = START_MARKER.find(raw)
+            val afterStart = if (startMatch != null) {
+                // Skip to the end of the marker's line.
+                val nl = raw.indexOf('\n', startMatch.range.last)
+                if (nl >= 0) raw.substring(nl + 1) else raw.substring(startMatch.range.last + 1)
+            } else {
+                raw
+            }
+            val endMatch = END_MARKER.find(afterStart)
+            val body = if (endMatch != null) afterStart.substring(0, endMatch.range.first) else afterStart
+            return body.trim()
+        }
+
+        private val START_MARKER: Regex = Regex(
+            """\*\*\*\s*START OF (?:THE|THIS) PROJECT GUTENBERG EBOOK.*""",
+            RegexOption.IGNORE_CASE,
+        )
+        private val END_MARKER: Regex = Regex(
+            """\*\*\*\s*END OF (?:THE|THIS) PROJECT GUTENBERG EBOOK.*""",
+            RegexOption.IGNORE_CASE,
+        )
+    }
+}

--- a/source-librivox/src/test/kotlin/in/jphe/storyvox/source/librivox/LibriVoxSourceTest.kt
+++ b/source-librivox/src/test/kotlin/in/jphe/storyvox/source/librivox/LibriVoxSourceTest.kt
@@ -6,12 +6,14 @@ import `in`.jphe.storyvox.data.source.filter.FilterState
 import `in`.jphe.storyvox.data.source.filter.FilterValue
 import `in`.jphe.storyvox.data.source.model.FictionResult
 import `in`.jphe.storyvox.data.source.model.SearchQuery
+import `in`.jphe.storyvox.source.librivox.net.GutenbergTextApi
 import `in`.jphe.storyvox.source.librivox.net.LibriVoxApi
 import `in`.jphe.storyvox.source.librivox.net.LibriVoxSection
 import kotlinx.coroutines.test.runTest
 import okhttp3.OkHttpClient
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNull
 import org.junit.Assert.assertTrue
 import org.junit.Test
 
@@ -36,8 +38,9 @@ import org.junit.Test
 class LibriVoxSourceTest {
 
     private val noopApi = LibriVoxApi(OkHttpClient())
+    private val noopGutenberg = GutenbergTextApi(OkHttpClient())
 
-    private fun source(): LibriVoxSource = LibriVoxSource(noopApi)
+    private fun source(): LibriVoxSource = LibriVoxSource(noopApi, noopGutenberg)
 
     @Test fun `id and displayName use the LIBRIVOX source`() {
         val src = source()
@@ -135,5 +138,85 @@ class LibriVoxSourceTest {
     @Test fun `user-agent identifies storyvox-librivox`() {
         assertTrue(LibriVoxSource.USER_AGENT.contains("storyvox-librivox"))
         assertTrue(LibriVoxSource.USER_AGENT.contains("github.com/techempower-org/candela"))
+    }
+
+    // ─── Issue #1046 — open-domain text companion ──────────────────────
+
+    @Test fun `gutenbergTextChapterIdFor is distinct from the section id shape`() {
+        // Section ids are "<bookId>:<number>"; the text companion is
+        // "<bookId>:gutenberg-text" so chapter() routes them apart.
+        assertEquals("47:gutenberg-text", LibriVoxSource.gutenbergTextChapterIdFor("47"))
+        val sectionId = LibriVoxSource.chapterIdFor(
+            "47",
+            LibriVoxSection(id = "1", sectionNumber = "1", title = "Ch 1"),
+        )
+        assertFalse(
+            "text-companion id must not collide with a section id",
+            sectionId == LibriVoxSource.gutenbergTextChapterIdFor("47"),
+        )
+    }
+
+    @Test fun `parseGutenbergId extracts the ebook id from the catalog URL shapes`() {
+        assertEquals("1342", GutenbergTextApi.parseGutenbergId("https://www.gutenberg.org/ebooks/1342"))
+        assertEquals("1342", GutenbergTextApi.parseGutenbergId("http://gutenberg.org/ebooks/1342"))
+        assertEquals(
+            "1342",
+            GutenbergTextApi.parseGutenbergId("https://www.gutenberg.org/files/1342/1342-h/1342-h.htm"),
+        )
+        assertEquals("11", GutenbergTextApi.parseGutenbergId("http://www.gutenberg.org/etext/11"))
+        assertEquals(
+            "84",
+            GutenbergTextApi.parseGutenbergId("https://www.gutenberg.org/cache/epub/84/pg84.txt"),
+        )
+    }
+
+    @Test fun `parseGutenbergId returns null for non-Gutenberg or blank sources`() {
+        // LibriVox texts aren't always on Gutenberg (Wikisource,
+        // archive.org, …) — those must skip the text chapter, not guess.
+        assertNull(GutenbergTextApi.parseGutenbergId("https://en.wikisource.org/wiki/Frankenstein"))
+        assertNull(GutenbergTextApi.parseGutenbergId("https://archive.org/details/something"))
+        assertNull(GutenbergTextApi.parseGutenbergId("https://www.gutenberg.org/about/"))
+        assertNull(GutenbergTextApi.parseGutenbergId(""))
+        assertNull(GutenbergTextApi.parseGutenbergId(null))
+    }
+
+    @Test fun `plainTextUrl targets the stable UTF-8 plain-text alias`() {
+        assertEquals(
+            "https://www.gutenberg.org/ebooks/1342.txt.utf-8",
+            GutenbergTextApi.plainTextUrl("1342"),
+        )
+    }
+
+    @Test fun `stripGutenbergBoilerplate keeps only the content between the markers`() {
+        val raw = """
+            The Project Gutenberg eBook of Example
+            Some license preamble here.
+
+            *** START OF THE PROJECT GUTENBERG EBOOK EXAMPLE ***
+
+            Chapter One. It was a bright cold day.
+
+            *** END OF THE PROJECT GUTENBERG EBOOK EXAMPLE ***
+
+            Trailing license / donation boilerplate.
+        """.trimIndent()
+        val body = GutenbergTextApi.stripGutenbergBoilerplate(raw)
+        assertTrue("content kept", body.contains("Chapter One. It was a bright cold day."))
+        assertFalse("license preamble dropped", body.contains("license preamble"))
+        assertFalse("trailing boilerplate dropped", body.contains("donation boilerplate"))
+        assertFalse("start marker dropped", body.contains("START OF THE PROJECT"))
+        assertFalse("end marker dropped", body.contains("END OF THE PROJECT"))
+    }
+
+    @Test fun `stripGutenbergBoilerplate tolerates the legacy THIS wording`() {
+        val raw = "junk\n***START OF THIS PROJECT GUTENBERG EBOOK FOO***\nReal text.\n" +
+            "***END OF THIS PROJECT GUTENBERG EBOOK FOO***\nfooter"
+        val body = GutenbergTextApi.stripGutenbergBoilerplate(raw)
+        assertEquals("Real text.", body)
+    }
+
+    @Test fun `stripGutenbergBoilerplate returns the whole text when markers are absent`() {
+        val raw = "A short public-domain snippet with no PG wrapper."
+        assertEquals(raw, GutenbergTextApi.stripGutenbergBoilerplate(raw))
     }
 }


### PR DESCRIPTION
## Summary
Implements the **LibriVox half of #1046** ("voice to text" for the audio backends in the reader). A LibriVox recording is a volunteer reading a **public-domain** book — almost always a Project Gutenberg ebook, linked from the catalog's `url_text_source`. This surfaces that matching public-domain text in the reader so the words can be read alongside the human-narrated audio. Per JP's steer, the Gutenberg text *is* the transcript, so no on-device ASR is needed for LibriVox.

## Scope note (STT framing)
#1046 is **speech-to-text** (transcribe audio → readable text), not TTS.
- **LibriVox** (this PR): the audio reads a public-domain book → use the matching Gutenberg text directly. ✅ shipped here.
- **Radio**: has no pre-existing transcript → genuine on-device ASR (model + live-stream decode + streaming recognition). That's a multi-PR subsystem, filed separately as **#1131**. No radio changes in this PR.

## What's in this PR
- **`GutenbergTextApi`** (new):
  - `parseGutenbergId(url_text_source)` — extracts the ebook id from the catalog's Gutenberg URL shapes (`ebooks` / `files` / `etext` / `cache/epub`); returns `null` for non-Gutenberg sources (Wikisource, archive.org, …) so we never guess.
  - `fetchPlainText(id)` — GETs the stable `https://www.gutenberg.org/ebooks/<id>.txt.utf-8` alias (302s to the cache file; the LibriVox client follows redirects), then strips the `*** START/END OF THE PROJECT GUTENBERG EBOOK ***` license wrapper. Blocking call wrapped in `Dispatchers.IO`.
- **`LibriVoxSource`**: when `url_text_source` resolves to a Gutenberg id, `fictionDetail` appends one **"📖 Read the text (Project Gutenberg)"** chapter after the audio sections. It carries **no `audioUrl`**, so the reader renders it as text (and TTS can narrate it). The Gutenberg fetch is **lazy** — only opening that chapter pays it; browse/detail never download a book's text.
- **DI**: `GutenbergTextApi` provided from the existing `@LibriVoxHttp` OkHttp client (mirrors `provideLibriVoxApi`).

## Why this is safe (no engine / core-model changes)
The "audio chapter that ALSO carries text" data path already exists: `ChapterRepository.getChapter()` checks `audioUrl` **before** the empty-text guard precisely so audio + transcript can coexist (its comment even names "a future audio source that ALSO carries a transcript"). The audio section chapters are unchanged (still `audioUrl`-only → Media3); only the new text chapter is added.

## Testing
- `:source-librivox:testDebugUnitTest` — green. New tests: Gutenberg id parsing (all catalog URL shapes + non-Gutenberg/null), `.txt.utf-8` URL, boilerplate stripping (modern + legacy "THIS" wording + marker-absent), text-chapter id distinctness.
- Full `:app:assembleDebug` — green (validates the Hilt graph / new `@Provides`).
- **Not yet device-verified** this session. Recommended on-device check: open a LibriVox book whose `url_text_source` is a Gutenberg ebook → the new "📖 Read the text" chapter renders the cleaned text in the reader pane.

Radio STT tracked in #1131. (Leaving #1046 open for the team to close or keep as the umbrella.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
