### PR TITLE
fix(playback): defer thermal concurrency cap to stop mid-playback replay (#1126)

### DIFF
--- a/core-playback/src/main/kotlin/in/jphe/storyvox/playback/tts/EnginePlayer.kt
+++ b/core-playback/src/main/kotlin/in/jphe/storyvox/playback/tts/EnginePlayer.kt
@@ -152,6 +152,37 @@ internal fun shouldCheckpointPosition(state: PlaybackState): Boolean =
     state.currentFictionId != null && state.currentChapterId != null
 
 /**
+ * Issue #1126 — did a thermal-status transition cross the MODERATE
+ * boundary in either direction?
+ *
+ * [ThermalMonitor.THERMAL_STATUS_MODERATE] (2) is the threshold at which
+ * [EnginePlayer.startPlaybackPipeline] drops parallel-synth secondaries to
+ * serial mode (#803). Crossing it — up (throttle on) or down (throttle off)
+ * — changes the *effective* concurrency the NEXT pipeline build will use.
+ *
+ * The cap is read fresh from `cachedThermalStatus` at every
+ * `startPlaybackPipeline()`, so it applies automatically on the next natural
+ * pipeline boundary (next chapter / seek / voice-swap / speed change). We do
+ * NOT force a mid-playback rebuild on a crossing: tearing the AudioTrack down
+ * mid-sentence restarts the producer at the current sentence's start, which
+ * the listener hears as a brief pause followed by the current sentence
+ * replaying from the beginning — issue #1126's "pause-then-repeat". Since the
+ * concurrency cap is a producer-side optimisation with no audible component,
+ * deferring it to the next boundary costs nothing audible while removing the
+ * intermittent replay entirely.
+ *
+ * Extracted as a top-level function so the boundary math can be exercised in a
+ * pure unit test (EnginePlayerThermalRebuildTest) without standing up the full
+ * EnginePlayer + Hilt + sherpa-onnx graph — same constraint that gates
+ * [shouldAutoPlayAfterAdvance] / [shouldCheckpointPosition].
+ */
+internal fun crossedThermalModerateBoundary(prev: Int, status: Int): Boolean =
+    (prev < ThermalMonitor.THERMAL_STATUS_MODERATE &&
+        status >= ThermalMonitor.THERMAL_STATUS_MODERATE) ||
+    (prev >= ThermalMonitor.THERMAL_STATUS_MODERATE &&
+        status < ThermalMonitor.THERMAL_STATUS_MODERATE)
+
+/**
  * Issue #189 — playback state for the one-shot recap-aloud TTS pipeline.
  * Distinct from [PlaybackState] because the recap is a transient utterance
  * with its own AudioTrack; conflating the two would force every chapter
@@ -497,17 +528,27 @@ class EnginePlayer @AssistedInject constructor(
     }
 
     /**
-     * Issue #803 — collect [ThermalMonitor.thermalStatus] and cache
-     * it as a volatile for the synchronous pipeline-construction path.
-     * When the status rises to MODERATE (2) or above, the next pipeline
-     * rebuild caps the effective parallel-synth concurrency to 1 (serial
-     * mode). If playback is already running, we trigger a pipeline
-     * rebuild so the cap takes effect immediately rather than waiting
-     * for the next chapter/seek/voice-swap.
+     * Issue #803 / #1126 — collect [ThermalMonitor.thermalStatus] and
+     * cache it as a volatile for the synchronous pipeline-construction
+     * path. When the status is MODERATE (2) or above, the next pipeline
+     * build caps the effective parallel-synth concurrency to 1 (serial
+     * mode); when it drops back below MODERATE the next build restores
+     * the user's configured concurrency from [cachedParallelSynthInstances].
      *
-     * When the status drops back below MODERATE, the same rebuild
-     * restores the user's configured concurrency from
-     * [cachedParallelSynthInstances].
+     * Issue #1126 — the cap is DEFERRED to the next natural pipeline
+     * boundary (next chapter / seek / voice-swap / speed change), which
+     * reads `cachedThermalStatus` fresh at construction time (see
+     * [startPlaybackPipeline]'s `effectiveSecondaryHandles`). We no longer
+     * force an immediate mid-playback rebuild on a thermal crossing: a
+     * rebuild tears the AudioTrack down and restarts the producer at the
+     * current sentence's start, so the listener hears a brief pause then
+     * the current sentence replaying from the beginning — the intermittent
+     * "pause-then-repeat" reported in #1126. The thermal trigger was the
+     * only non-user, intermittent rebuild path (speed/pitch/pause-mult/seek/
+     * voice-swap are all user-initiated and capture the audible position
+     * first). The concurrency cap is a producer-side optimisation with no
+     * audible component, so deferring it costs nothing the listener can hear
+     * while removing the replay entirely. See [crossedThermalModerateBoundary].
      */
     private fun observeThermalStatus() {
         scope.launch {
@@ -515,27 +556,20 @@ class EnginePlayer @AssistedInject constructor(
                 val prev = cachedThermalStatus
                 cachedThermalStatus = status
                 if (prev == status) return@collect
-                DebugLog.i("EnginePlayer") {
-                    "#803 thermal status update: $prev -> $status" +
-                        if (status >= ThermalMonitor.THERMAL_STATUS_MODERATE) {
-                            " — capping parallel synth to serial mode"
-                        } else if (prev >= ThermalMonitor.THERMAL_STATUS_MODERATE) {
-                            " — restoring user-configured concurrency"
-                        } else {
-                            ""
-                        }
-                }
-                // Only trigger a pipeline rebuild if the thermal status
-                // crosses the MODERATE boundary while playing. Rebuilds
-                // within the same thermal zone (e.g. SEVERE -> CRITICAL)
-                // are unnecessary — the cap is already at serial.
-                val crossedThreshold =
-                    (prev < ThermalMonitor.THERMAL_STATUS_MODERATE &&
-                        status >= ThermalMonitor.THERMAL_STATUS_MODERATE) ||
-                    (prev >= ThermalMonitor.THERMAL_STATUS_MODERATE &&
-                        status < ThermalMonitor.THERMAL_STATUS_MODERATE)
-                if (crossedThreshold && _observableState.value.isPlaying) {
-                    startPlaybackPipeline()
+                // #1126 — log the (deferred) concurrency change when we
+                // cross the MODERATE boundary; the new value is picked up
+                // by the next startPlaybackPipeline() with no mid-playback
+                // teardown. Same-zone changes (e.g. SEVERE -> CRITICAL)
+                // don't alter the serial/parallel decision and are silent.
+                if (crossedThermalModerateBoundary(prev, status)) {
+                    DebugLog.i("EnginePlayer") {
+                        "#1126 thermal crossed MODERATE: $prev -> $status — " +
+                            if (status >= ThermalMonitor.THERMAL_STATUS_MODERATE) {
+                                "parallel synth will cap to serial on next pipeline build"
+                            } else {
+                                "user-configured concurrency restored on next pipeline build"
+                            }
+                    }
                 }
             }
         }
@@ -2529,11 +2563,13 @@ class EnginePlayer @AssistedInject constructor(
         // the pipeline runs in serial mode (single engine). The
         // secondary engine instances stay alive in memory (they're
         // expensive to construct) — we just don't hand them to the
-        // streaming source for this pipeline lifetime. When the
-        // thermal status drops below MODERATE, [observeThermalStatus]
-        // triggers a pipeline rebuild that passes the full set of
-        // secondaries again, restoring the user's configured
-        // concurrency without re-loading models.
+        // streaming source for this pipeline lifetime. Issue #1126 —
+        // the cap is applied HERE, at construction time, off the live
+        // `cachedThermalStatus`; [observeThermalStatus] no longer forces
+        // a mid-playback rebuild (that caused an audible pause-then-repeat),
+        // so a thermal change takes effect on the next natural pipeline
+        // boundary (next chapter / seek / voice-swap / speed change),
+        // restoring or capping concurrency without re-loading models.
         val effectiveSecondaryHandles = if (
             thermalStatus >= ThermalMonitor.THERMAL_STATUS_MODERATE &&
             secondaryHandles.isNotEmpty()

--- a/core-playback/src/test/kotlin/in/jphe/storyvox/playback/tts/EnginePlayerThermalRebuildTest.kt
+++ b/core-playback/src/test/kotlin/in/jphe/storyvox/playback/tts/EnginePlayerThermalRebuildTest.kt
@@ -1,0 +1,86 @@
+package `in`.jphe.storyvox.playback.tts
+
+import `in`.jphe.storyvox.playback.ThermalMonitor
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * Issue #1126 — pure-function unit test for [crossedThermalModerateBoundary],
+ * the boundary check that gates whether a thermal-status transition is worth
+ * logging (and, pre-#1126, used to trigger a mid-playback pipeline rebuild).
+ *
+ * The bug: [EnginePlayer.observeThermalStatus] used to call
+ * `startPlaybackPipeline()` immediately whenever the thermal status crossed
+ * the MODERATE boundary while playing. A pipeline rebuild tears the
+ * AudioTrack down and restarts the producer at the current sentence's start,
+ * so the listener heard a brief pause followed by the current sentence
+ * replaying from the beginning. Thermal crossings are the only non-user,
+ * intermittent rebuild trigger (speed/pitch/pause-mult/seek/voice-swap are
+ * all user-initiated), which is why #1126 reproduced as an *occasional*
+ * pause-then-repeat during otherwise-normal playback — and could repeat on
+ * every oscillation across the MODERATE line.
+ *
+ * The fix defers the parallel-synth concurrency cap to the next natural
+ * pipeline boundary (the cap is read fresh from `cachedThermalStatus` at
+ * `startPlaybackPipeline()` construction time, so nothing audible is lost).
+ * This test pins the boundary math the deferral logging depends on.
+ *
+ * Like [EnginePlayerAutoPlayDecisionTest] this deliberately stays at the
+ * pure-function layer; a full EnginePlayer needs a Hilt graph + sherpa-onnx
+ * AARs and a real AudioTrack.
+ *
+ * MODERATE = 2. LIGHT (1) and CRITICAL (4) are not exposed as constants on
+ * [ThermalMonitor], so the raw PowerManager-mirroring ints are used directly.
+ */
+class EnginePlayerThermalRebuildTest {
+
+    private val none = ThermalMonitor.THERMAL_STATUS_NONE       // 0
+    private val light = 1                                       // THERMAL_STATUS_LIGHT
+    private val moderate = ThermalMonitor.THERMAL_STATUS_MODERATE // 2
+    private val severe = ThermalMonitor.THERMAL_STATUS_SEVERE   // 3
+    private val critical = 4                                    // THERMAL_STATUS_CRITICAL
+
+    @Test
+    fun `crossing up into MODERATE is a boundary crossing`() {
+        assertTrue(crossedThermalModerateBoundary(light, moderate))
+        assertTrue(crossedThermalModerateBoundary(none, moderate))
+        assertTrue(crossedThermalModerateBoundary(none, severe))
+        assertTrue(crossedThermalModerateBoundary(light, critical))
+    }
+
+    @Test
+    fun `dropping back below MODERATE is a boundary crossing`() {
+        assertTrue(crossedThermalModerateBoundary(moderate, light))
+        assertTrue(crossedThermalModerateBoundary(severe, none))
+        assertTrue(crossedThermalModerateBoundary(critical, light))
+        assertTrue(crossedThermalModerateBoundary(moderate, none))
+    }
+
+    @Test
+    fun `transitions that stay below MODERATE are NOT crossings`() {
+        // No concurrency change — both sides run the user's full parallel set.
+        assertFalse(crossedThermalModerateBoundary(none, light))
+        assertFalse(crossedThermalModerateBoundary(light, none))
+    }
+
+    @Test
+    fun `transitions that stay at-or-above MODERATE are NOT crossings`() {
+        // Already capped to serial; SEVERE -> CRITICAL etc. change nothing
+        // about the serial/parallel decision, so no log, no (deferred) action.
+        assertFalse(crossedThermalModerateBoundary(moderate, severe))
+        assertFalse(crossedThermalModerateBoundary(severe, critical))
+        assertFalse(crossedThermalModerateBoundary(critical, moderate))
+        assertFalse(crossedThermalModerateBoundary(severe, moderate))
+    }
+
+    @Test
+    fun `MODERATE itself is on the capped side of the boundary`() {
+        // The cap fires at >= MODERATE, so MODERATE counts as "throttled".
+        // Entering it from below crosses; leaving it downward crosses;
+        // staying at-or-above does not.
+        assertTrue(crossedThermalModerateBoundary(light, moderate))   // below -> MODERATE
+        assertTrue(crossedThermalModerateBoundary(moderate, light))   // MODERATE -> below
+        assertFalse(crossedThermalModerateBoundary(moderate, moderate)) // no change
+    }
+}


### PR DESCRIPTION
## Issue #1126 — occasional pause-then-repeat during TTS playback

### Root cause
`EnginePlayer.observeThermalStatus()` forced an **immediate** `startPlaybackPipeline()` rebuild whenever the device thermal status crossed the `THERMAL_STATUS_MODERATE` boundary *while playing*:

```kotlin
if (crossedThreshold && _observableState.value.isPlaying) {
    startPlaybackPipeline()   // <-- mid-playback teardown + rebuild
}
```

A pipeline rebuild tears the `AudioTrack` down (brief silence) and restarts the **producer at the current sentence's start** (`startSentenceIndex = currentSentenceIndex`). For typical long prose sentences the listener is partway through that sentence, so they hear it **replay from the beginning** → the reported *"pauses briefly, then replays a section it already read before continuing forward."*

It's **intermittent** because it only fires when the device temperature crosses the MODERATE line — and can recur on every oscillation across it.

### Why this was the bug (and others weren't)
Thermal crossings are the **only non-user, intermittent** rebuild trigger. Every other rebuild path is user-initiated and already captures the truthful audible position before rebuilding:
- `setSpeed` / `setPitch` / `setPunctuationPauseMultiplier` → `currentPositionMs()` → `speedHandoffCharOffset`
- `seekToCharOffset` / `loadAndPlay` → set `currentSentenceIndex` from a char offset

Ruled out during investigation: producer double-emit (serial + parallel sequencer are both monotonic), PCM cache cursor regression (monotonic, single-threaded), underrun catch-up pause (`track.pause()`/`play()` retains the ring buffer), audio-focus loss (no auto-resume on gain), and the `#974` getTimestamp extrapolation (the position display is monotonically clamped, so it can only overshoot forward — never replay).

### Fix
Defer the thermal concurrency cap to the next **natural** pipeline boundary instead of forcing a mid-playback rebuild. `startPlaybackPipeline()` already reads `cachedThermalStatus` fresh at construction time (`effectiveSecondaryHandles`), so the cap still applies on the next chapter / seek / voice-swap / speed change. The parallel-synth cap is a **producer-side optimisation with no audible component**, so deferring it costs nothing the listener can hear while removing the replay entirely.

- Extracted `crossedThermalModerateBoundary(prev, status)` as a pure helper (mirrors `shouldAutoPlayAfterAdvance` / `shouldCheckpointPosition`).
- Added `EnginePlayerThermalRebuildTest` (5 cases) pinning the boundary math.
- Refreshed the now-stale comment in `startPlaybackPipeline`.

### Verification
- `./gradlew :core-playback:compileDebugKotlin` — clean.
- `EnginePlayerThermalRebuildTest` — 5/5 pass.
- Pre-existing, unrelated failures in the full `core-playback` suite (Robolectric `targetSdk 37 > maxSdk 36` init errors; `VoiceFamilyRegistryTest` "expected 6 but was 7" — stale since the Supertonic scaffold #1114). Diff touches only `EnginePlayer.kt` + the new test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
