### PR TITLE
docs: refresh stale counts after v1.1.5

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -16,14 +16,16 @@ CI runs on self-hosted runner (katana). Tags trigger release APK build + GitHub 
 ## Module layout
 
 - **app** — nav graph (`StoryvoxNavHost`), DI wiring (`AppBindings`), `SettingsRepositoryUiImpl`
-- **feature** — all UI: `browse/`, `reader/`, `library/`, `settings/`, `chat/`, `fiction/`, `voicelibrary/`, `onboarding/`, `follows/`, `techempower/`, `sync/`, `auth/`, `sessions/`, `debug/`, `milestone/`, `engine/`, plus shared `api/`, `components/`, `di/`
+- **feature** — all UI: `browse/`, `reader/`, `ocr/`, `library/`, `settings/`, `chat/`, `fiction/`, `voicelibrary/`, `onboarding/`, `follows/`, `techempower/`, `sync/`, `auth/`, `sessions/`, `debug/`, `milestone/`, `engine/`, plus shared `api/`, `components/`, `di/`
 - **core-data** — `FictionSource` interface, `SearchQuery`, `FilterDimension`/`FilterState`, Room DB, models
 - **core-playback** — TTS engine (`EnginePlayer`), voice catalog, audio focus
 - **core-llm** — AI chat, summaries
 - **core-sync** — InstantDB cloud sync
 - **core-ui** — shared theme, spacing, composables
 - **core-plugin-ksp** — `@SourcePlugin` annotation processor → Hilt `@IntoSet` factories
-- **source-*** — 24 source modules, each implements `FictionSource`
+- **wear** — Wear OS companion app (Library Nocturne on the watch)
+- **baselineprofile** — Macrobenchmark module that generates the R8 baseline profile
+- **source-*** — 28 source modules; 25 implement `FictionSource`. The other 3 reuse the module pattern without it: `source-azure` (Azure HD cloud-voice backend), `source-epub-writer` and `source-audiobook-writer` (export writers)
 
 ## Key patterns
 
@@ -37,11 +39,11 @@ CI runs on self-hosted runner (katana). Tags trigger release APK build + GitHub 
 
 ## Large files (read with offset/limit)
 
-- `EnginePlayer.kt` — 5100 lines
-- `SettingsScreen.kt` — 4100 lines (legacy long-scroll, being replaced by hub)
-- `SettingsRepositoryUiImpl.kt` — 3100 lines
-- `AudiobookView.kt` — 2300 lines
-- `UiContracts.kt` — 2300 lines
+- `EnginePlayer.kt` — ~5500 lines
+- `SettingsScreen.kt` — ~4100 lines (legacy long-scroll, being replaced by hub)
+- `SettingsRepositoryUiImpl.kt` — ~3600 lines
+- `AudiobookView.kt` — ~2550 lines
+- `UiContracts.kt` — ~2550 lines
 
 ## Versioning
 

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -5,7 +5,7 @@ A short-form list of shipped + in-flight + planned work. Detailed designs live u
 [`docs/compose-gotchas.md`](compose-gotchas.md) for known scope-shadowing
 and stability traps before searching the internet for confusing errors.
 
-Last refreshed for **v0.7.3** (AGP 9 migration + deprecation cleanup). Prior major refresh was v0.5.51.
+Last refreshed for **v1.1.5** (AGP 9 migration + deprecation cleanup). Prior major refresh was v0.5.51.
 
 ---
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,12 +1,12 @@
 ---
 layout: default
 title: Architecture
-description: Candela's thirty-four Gradle modules, plugin-seam fiction sources via @SourcePlugin + KSP, in-process TTS engine, optional cloud TTS backend, and cross-device InstantDB sync.
+description: Candela's thirty-eight Gradle modules, plugin-seam fiction sources via @SourcePlugin + KSP, in-process TTS engine, optional cloud TTS backend, and cross-device InstantDB sync.
 ---
 
 # Architecture
 
-Candela is **thirty-four Gradle modules** (up from 13 at v0.4.x; 29 at v0.5.38). The split keeps fiction sources, playback, UI, theming, sync, and the LLM provider matrix independently testable, and makes adding a new fiction source (or swapping the TTS backend) a localized change. Since v0.5.27 each fiction source is annotated with `@SourcePlugin`; the `:core-plugin-ksp` KSP processor emits a Hilt `@IntoSet` factory per annotated class, so `SourcePluginRegistry` discovers backends at startup. Adding a new backend is ~4 touchpoints today.
+Candela is **thirty-eight Gradle modules** (up from 13 at v0.4.x; 29 at v0.5.38). The split keeps fiction sources, playback, UI, theming, sync, and the LLM provider matrix independently testable, and makes adding a new fiction source (or swapping the TTS backend) a localized change. Since v0.5.27 each fiction source is annotated with `@SourcePlugin`; the `:core-plugin-ksp` KSP processor emits a Hilt `@IntoSet` factory per annotated class, so `SourcePluginRegistry` discovers backends at startup. Adding a new backend is ~4 touchpoints today.
 
 ```
 ┌─────────────────────────────────────────────┐

--- a/docs/index.md
+++ b/docs/index.md
@@ -139,7 +139,7 @@ image: /screenshots/03-reader.png
 </section>
 
 <section class="sources">
-  <h2>Twenty-one fiction backends, side by side</h2>
+  <h2>Twenty-five fiction backends, side by side</h2>
   <p class="muted">
     A plugin-seam architecture means each backend is ~4 touchpoints. Adding a new one auto-surfaces
     in <strong>Settings → Plugins</strong>. Each has its own on/off toggle.

--- a/docs/play-store-listing.md
+++ b/docs/play-store-listing.md
@@ -44,7 +44,7 @@ Three drafts, ranked. JP picks final:
 Three drafts, ranked:
 
 1. **`Free books, tech guides, and accessible help — read aloud by TechEmpower.`** (74 ch) ✅ recommended — concrete benefit, mentions TechEmpower, no jargon.
-2. `Neural-voice audiobook player. 21 sources. Free, ad-free, on-device.` (68 ch) — leads with the audiobook angle.
+2. `Neural-voice audiobook player. 25 sources. Free, ad-free, on-device.` (68 ch) — leads with the audiobook angle.
 3. `Listen to anything text — tech guides, fiction, wiki, RSS — all on-device.` (74 ch) — leans into "anything text" but loses the TechEmpower hook.
 
 ### Full description (4000 char max)
@@ -61,7 +61,7 @@ through a high-quality neural text-to-speech engine that runs entirely on
 your device. No subscription. No ads. No tracking.
 
 Under the hood, Candela is a serious audiobook player for any text you
-have access to — twenty-one fiction and reference backends are wired in,
+have access to — twenty-five fiction and reference backends are wired in,
 side by side. Browse Royal Road, Archive of Our Own, Standard Ebooks,
 Project Gutenberg, Wikipedia, Hacker News, arXiv, PLOS, and more. Open
 EPUB files from your device's storage. Connect your Notion workspace,
@@ -92,7 +92,7 @@ section. Twelve accessibility audit findings closed in version 0.5.43;
 work continues.
 
 FEATURES
-• 21 fiction & reference backends — opt in to the ones you want
+• 25 fiction & reference backends — opt in to the ones you want
 • 3 on-device neural voice families (Piper, Kokoro, KittenTTS)
 • Optional Bring-Your-Own-Key cloud voices (Microsoft Azure)
 • Reader view with synced sentence highlighting


### PR DESCRIPTION
## Summary

Post-v1.1.5 documentation freshness audit. Fixes stale counts across `CLAUDE.md` and the `docs/` sources that feed both the GitHub Pages site and the wiki (`wiki-sync.yml` PAGE_MAP).

## What changed

| File | Fix |
|------|-----|
| `CLAUDE.md` | Source modules **24 → 28** (25 implement `FictionSource`; `source-azure` + the two `-writer` modules don't). Added `wear` + `baselineprofile` to the module layout, added missing `feature/ocr/` subdir, refreshed large-file line counts (`EnginePlayer` 5100→~5500, `SettingsRepositoryUiImpl` 3100→~3600, `AudiobookView`/`UiContracts` 2300→~2550). |
| `docs/architecture.md` | **thirty-four → thirty-eight** Gradle modules (frontmatter + body). |
| `docs/index.md` | Fiction-backends section header **21 → 25** — it was inconsistent with the page's own frontmatter and hero, which already said twenty-five. |
| `docs/ROADMAP.md` | "Last refreshed for **v0.7.3**" → **v1.1.5** (the AGP 9 migration it cites shipped in v1.1.5; there is no v0.7.x in the version lineage). |
| `docs/play-store-listing.md` | **21 → 25** fiction & reference backends (3 refs: tagline, description, feature bullet). |

Canonical numbers verified from source: `settings.gradle.kts` declares **38** modules; **28** `source-*` modules exist, **25** implement `FictionSource` (matches README's "twenty-five fiction backends").

## Verified correct — no change needed

- **CHANGELOG v1.1.5** — complete and accurate against all 16 merged PRs (`git log v1.1.4..v1.1.5`).
- **docs/version.json** — intentionally version-less by design (static Pages microsite; the embedded `note` explains it). Live version resolves via the releases URL.
- **release-docs-sync** for v1.1.5 — succeeded; wiki Home shows v1.1.5 + correct What's-new. (v1.1.4's run failed at the "CHANGELOG can supply release notes" guard because the changelog entry landed *after* the tag — self-healed by v1.1.5's run.)
- **README.md** — current; already reflects 25 backends and v1.1.5-era features.
- ROADMAP's two other "twenty-one" refs are intentional historical snapshots ("the v0.5 line landed…", "17 → 21 … (v0.5.51)") and were left as-is.

## Follow-up

The **wiki Home.md intro** counts ("twenty-one fiction backends", "Thirty-four modules") are hand-authored in the `.wiki` repo and owned by neither sync workflow, so they re-stale every release. That structural gap can't be fixed from this repo's PR — tracked in **#1146**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
