### PR TITLE
fix(playback): reset incoming chapter position on auto-advance (#1127)

### DIFF
--- a/core-data/src/main/kotlin/in/jphe/storyvox/data/repository/PlaybackPositionRepository.kt
+++ b/core-data/src/main/kotlin/in/jphe/storyvox/data/repository/PlaybackPositionRepository.kt
@@ -69,6 +69,25 @@ interface PlaybackPositionRepository {
     )
 
     /**
+     * Issue #1127 — reset one chapter's resume point back to its head.
+     *
+     * Auto-advance is a *fresh* listen: finishing chapter N means chapter
+     * N+1 starts at the beginning, even if the user partially listened to
+     * N+1 earlier and a stale `charOffset` still sits in its
+     * `playback_position` row. This upserts `charOffset = 0` /
+     * `paragraphIndex = 0` for the exact `(fictionId, chapterId)` row and
+     * bumps `updatedAt`, so the chapter becomes the freshest resume target
+     * pointing at its head — every external surface (Library "Continue
+     * listening", Auto/Wear browse, sync snapshot) then reads position 0,
+     * never the stale middle-of-chapter offset. The per-chapter
+     * [playbackSpeed] / [durationEstimateMs] are preserved (the listen is
+     * fresh, but the user's speed for this chapter and its cached duration
+     * estimate are not). Distinct from [clearPosition], which forgets the
+     * WHOLE fiction's progress; this scopes to one chapter and keeps a row.
+     */
+    suspend fun resetToChapterStart(fictionId: String, chapterId: String)
+
+    /**
      * Load the resume point for a given fiction — its most-recently-played
      * chapter's row (issue #965), or null if none. Picks the freshest
      * chapter so resume never lands on a stale future-chapter offset.
@@ -142,6 +161,27 @@ class PlaybackPositionRepositoryImpl @Inject constructor(
                 paragraphIndex = existing?.paragraphIndex ?: 0,
                 playbackSpeed = existing?.playbackSpeed ?: 1.0f,
                 durationEstimateMs = durationEstimateMs,
+                updatedAt = System.currentTimeMillis(),
+            ),
+        )
+    }
+
+    override suspend fun resetToChapterStart(fictionId: String, chapterId: String) {
+        // Read-then-upsert so the speed the user picked for THIS chapter and
+        // its cached duration estimate survive the reset; only the resume
+        // cursor (charOffset + paragraphIndex) snaps to the head. The upsert
+        // replaces the row in place under the composite `(fictionId,
+        // chapterId)` PK (#965) — no duplicate row — and the bumped
+        // `updatedAt` makes it the freshest resume target for `load`/`observe`.
+        val existing = dao.get(fictionId, chapterId)
+        dao.upsert(
+            PlaybackPosition(
+                fictionId = fictionId,
+                chapterId = chapterId,
+                charOffset = 0,
+                paragraphIndex = 0,
+                playbackSpeed = existing?.playbackSpeed ?: 1.0f,
+                durationEstimateMs = existing?.durationEstimateMs ?: 0L,
                 updatedAt = System.currentTimeMillis(),
             ),
         )

--- a/core-data/src/test/kotlin/in/jphe/storyvox/data/db/dao/PlaybackDaoTest.kt
+++ b/core-data/src/test/kotlin/in/jphe/storyvox/data/db/dao/PlaybackDaoTest.kt
@@ -7,6 +7,7 @@ import `in`.jphe.storyvox.data.db.StoryvoxDatabase
 import `in`.jphe.storyvox.data.db.entity.Chapter
 import `in`.jphe.storyvox.data.db.entity.Fiction
 import `in`.jphe.storyvox.data.db.entity.PlaybackPosition
+import `in`.jphe.storyvox.data.repository.PlaybackPositionRepositoryImpl
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.test.runTest
 import org.junit.After
@@ -36,7 +37,13 @@ import org.robolectric.annotation.Config
  * Also covers recent() + the cascade delete from chapter / fiction.
  */
 @RunWith(RobolectricTestRunner::class)
-@Config(manifest = Config.NONE)
+// Pin Robolectric's emulated SDK to 36 (its current ceiling — Robolectric
+// 4.16.1 supports API ≤36). The module compiles against compileSdk=37 with no
+// explicit targetSdk, so the test manifest defaults to targetSdkVersion=37 and
+// the runner otherwise fails to initialize ("targetSdkVersion=37 >
+// maxSdkVersion=36"). Tracked module-wide as #1132; pinned here so this class's
+// tests (incl. the #1127 regression below) run regardless of merge order.
+@Config(manifest = Config.NONE, sdk = [36])
 class PlaybackDaoTest {
 
     private lateinit var db: StoryvoxDatabase
@@ -310,6 +317,52 @@ class PlaybackDaoTest {
         assertEquals(1.25f, c1.playbackSpeed, 0.0001f)
 
         assertNull("non-existent chapter row is null", dao.get("f1", "nope"))
+    }
+
+    @Test
+    fun resetToChapterStart_snapsChapterToHead_andBecomesFreshestResume() = runTest {
+        // Issue #1127 reproduced at the persistence layer. The user partially
+        // heard ch3 (charOffset=500), backed up to ch2 and listened it to the
+        // end (a fresher updatedAt), so before auto-advancing INTO ch3 its row
+        // still carries the stale mid-chapter offset. resetToChapterStart must
+        // snap ch3 to its head so the next listen — and any surface reading the
+        // resume point mid-transition — starts at 0, never the stale offset.
+        val repo = PlaybackPositionRepositoryImpl(dao)
+        fictionDao.upsert(fiction("f1"))
+        chapterDao.upsert(chapter("c2", "f1", index = 1))
+        chapterDao.upsert(chapter("c3", "f1", index = 2))
+        dao.upsert(
+            PlaybackPosition(
+                "f1", "c3", charOffset = 500, paragraphIndex = 7,
+                playbackSpeed = 1.5f, durationEstimateMs = 90_000L, updatedAt = 100L,
+            ),
+        )
+        dao.upsert(PlaybackPosition("f1", "c2", charOffset = 8_000, updatedAt = 200L))
+
+        repo.resetToChapterStart("f1", "c3")
+
+        // ch3's exact row snaps to the head: cursor zeroed, row REPLACED in
+        // place (no stale 500, no duplicate under the composite PK), and the
+        // per-chapter speed + duration estimate preserved.
+        val c3 = dao.get("f1", "c3")
+        assertNotNull(c3)
+        assertEquals(0, c3!!.charOffset)
+        assertEquals(0, c3.paragraphIndex)
+        assertEquals(1.5f, c3.playbackSpeed, 0.0001f)
+        assertEquals(90_000L, c3.durationEstimateMs)
+
+        // Exactly two rows survive — the reset replaced ch3 rather than adding.
+        assertEquals(2, dao.allPositionsSnapshot().count { it.fictionId == "f1" })
+
+        // The bumped updatedAt makes ch3@0 the freshest resume target, so
+        // load()/observe() surface the head — the #1127 symptom is gone.
+        val resume = dao.get("f1")
+        assertNotNull(resume)
+        assertEquals("c3", resume!!.chapterId)
+        assertEquals(0, resume.charOffset)
+
+        // The sibling chapter the user actually finished is left untouched.
+        assertEquals(8_000, dao.get("f1", "c2")!!.charOffset)
     }
 
     @Test

--- a/core-playback/src/main/kotlin/in/jphe/storyvox/playback/tts/EnginePlayer.kt
+++ b/core-playback/src/main/kotlin/in/jphe/storyvox/playback/tts/EnginePlayer.kt
@@ -4185,6 +4185,31 @@ class EnginePlayer @AssistedInject constructor(
             }
             return@withLock
         }
+        // Issue #1127 — a FORWARD advance is a fresh listen of the incoming
+        // chapter: reaching the end of chapter N (auto-advance) or tapping
+        // Next means chapter N+1 must begin at its head, even if the user
+        // partially listened to N+1 earlier and a stale resume offset still
+        // sits in its playback_position row. The `loadAndPlay(charOffset=0)`
+        // below already drives the AUDIO from the head, but its persist of
+        // that 0 only lands AFTER the body-wait (up to
+        // CHAPTER_BODY_WAIT_TIMEOUT_MS). Reset the incoming chapter's row
+        // up-front so (a) the timeout/error path can't strand the stale
+        // offset, and (b) every external surface that reads the resume point
+        // DURING the transition — Library "Continue listening", Auto/Wear
+        // browse, the sync snapshot — sees the head, never the stale
+        // middle-of-chapter offset (the #1127 symptom). Forward only: a
+        // Previous tap / skip-back-into-prev owns its own offset semantics.
+        if (direction >= 0) {
+            runCatching { positionRepo.resetToChapterStart(fiction, nextId) }
+                .onFailure {
+                    android.util.Log.w(
+                        "EnginePlayer",
+                        "advanceChapter: resetToChapterStart($nextId) failed " +
+                            "(${it.javaClass.simpleName}: ${it.message}) — continuing; " +
+                            "loadAndPlay still loads at charOffset=0",
+                    )
+                }
+        }
         // Issue #524 — surface a Buffering state while we wait for the
         // next chapter's body to land in the DB. Pre-fix the engine sat
         // on isPlaying=true with no audio output during this wait, which

--- a/core-playback/src/test/kotlin/in/jphe/storyvox/playback/cache/PrerenderTriggersTest.kt
+++ b/core-playback/src/test/kotlin/in/jphe/storyvox/playback/cache/PrerenderTriggersTest.kt
@@ -174,6 +174,7 @@ class PrerenderTriggersTest {
             charOffset: Int,
             durationEstimateMs: Long,
         ) = Unit
+        override suspend fun resetToChapterStart(fictionId: String, chapterId: String) = Unit
         override suspend fun load(fictionId: String): SavedPosition? = positions[fictionId]
         override suspend fun recent(limit: Int): List<RecentItem> = emptyList()
     }


### PR DESCRIPTION
Closes #1127.

## Summary

Auto-advancing into chapter N+1 must start at the chapter head even when the
user partially listened to N+1 earlier and a stale resume offset still sits in
its `playback_position` row. This resets the incoming chapter's saved position
to the head up-front, on every forward advance.

## Investigation finding (important)

I traced the full auto-advance path — `handleChapterDone → advanceChapter →
loadAndPlay` — across `EnginePlayer`, `PlaybackController`, `AppBindings`, the
reader/library view-models, `AudiobookView`, the Room layer, and `core-sync`.

**The engine already drives the next chapter's _audio_ from `charOffset = 0`**
(`advanceChapter` has always called `loadAndPlay(..., charOffset = 0)`), and
`EnginePlayer` never _reads_ the saved position — it only writes it. So the
audio playhead was not the leak.

The residual gap is on the **persistence / transition side**: `loadAndPlay`
only persists that `0` _after_ its chapter-body wait (up to
`CHAPTER_BODY_WAIT_TIMEOUT_MS` ≈ 60 s). During that window the incoming
chapter's row still carries its stale offset, and the timeout/error path can
strand it entirely. Any surface that reads the resume point mid-transition —
Library "Continue listening", Auto/Wear browse, the sync snapshot — observes
the stale middle-of-chapter offset. That is the reported symptom's most
defensible mechanism on current `main`.

## Fix

- **core-data** — new `PlaybackPositionRepository.resetToChapterStart(fictionId, chapterId)`:
  upserts `charOffset = 0` / `paragraphIndex = 0` for the exact
  `(fictionId, chapterId)` row, **preserving** the user's per-chapter speed and
  cached duration estimate, and bumps `updatedAt` so the chapter becomes the
  freshest resume target pointing at its head. Distinct from `clearPosition`,
  which forgets a whole fiction.
- **core-playback** — `advanceChapter` calls it for **forward** advances
  (`direction >= 0`) before the body-wait, so the reset survives a load
  timeout and is visible to every external reader during the transition.
  Backward (Previous) keeps its existing offset semantics.

## Tests

- `PlaybackDaoTest.resetToChapterStart_snapsChapterToHead_andBecomesFreshestResume`
  reproduces the #1127 sequence against **real in-memory Room** (ch3 partially
  heard → ch2 finished later → reset ch3): asserts ch3 snaps to `0`, the row is
  replaced in place (no dupe under the composite PK), speed/duration preserved,
  ch3 becomes the freshest resume target, and the finished sibling is untouched.
- Updated the `PrerenderTriggersTest` fake repo for the new interface method.
- `:core-playback:compileDebugKotlin` ✅ · `PlaybackDaoTest` 17/17 ✅ ·
  `PrerenderTriggersTest` 21/21 ✅

## Note on the Robolectric SDK pin

`PlaybackDaoTest` gained `@Config(sdk = [36])` because the module compiles
against `compileSdk = 37`, past Robolectric 4.16.1's ceiling (36) — the runner
otherwise fails to initialize the whole class. This is the pre-existing,
module-wide **#1132** (being addressed separately via `robolectric.properties`);
the per-class pin here is scoped to this file so the regression test runs
regardless of merge order, and is compatible with the module-level fix.
