### PR TITLE
docs(play-store): audit listing copy + corrected, limit-compliant drafts

### DIFF
--- a/docs/play-store/listing/AUDIT.md
+++ b/docs/play-store/listing/AUDIT.md
@@ -80,7 +80,7 @@ consolidated here so it's in one place for the questionnaire.
 - [ ] **Category: Books & Reference** (brief's recommendation; confirm).
 - [ ] **Contact email** on the listing — brief leaves as DRAFT (`claude2@techempower.org` or `jp@jphein.com`?).
 - [ ] **Developer phone** (Play requires one on the developer profile).
-- [ ] **Privacy policy URL** resolves — brief lists `https://candela.techempower.org/privacy/` (source `docs/privacy-policy.md`); verify it serves before submission.
+- [ ] **Privacy policy URL** — use **`https://candela.techempower.org/privacy-policy/`** (the path that actually resolves). ⚠️ The design brief and `docs/privacy-policy.md`'s `permalink: /privacy/` both point at `/privacy/`, which **404s** (confirmed by Drift): the docs microsite is **static-served**, so Jekyll's per-page `permalink` isn't honored and the page serves at its filename path `/privacy-policy/`. Either fix the deploy so `/privacy/` resolves **or** (recommended) use `/privacy-policy/` in Play Console since it works today. Play **requires** a resolving privacy-policy URL or the submission is rejected, so don't ship the `/privacy/` form.
 
 ## Data Safety + permissions (pointers — already drafted)
 

--- a/docs/play-store/listing/AUDIT.md
+++ b/docs/play-store/listing/AUDIT.md
@@ -1,0 +1,105 @@
+---
+layout: default
+title: Candela · Play Store listing audit + drafts
+description: Audit of existing Play Store listing copy and corrected, limit-compliant drafts.
+---
+
+# Play Store listing — audit + corrected drafts
+
+Audited 2026-06-26 against app **v1.1.5** (versionCode 233, `org.techempower.candela`).
+Drafts in this folder are **publish-ready text** for the gradle-play-publisher
+layout; ranked alternates + rationale live here.
+
+## TL;DR
+
+Listing copy already exists in **three** places, and they disagree:
+
+| Source | State | Problem |
+|---|---|---|
+| `app/src/main/play/listings/en-US/` (live publish path) | **Stale** | Title + full description still say **"storyvox"** (pre-rebrand). Title is **33 chars > 30 limit**. Release notes **519 chars > 500 limit**. gradle-play-publisher **auto-uploads these** on `publishReleaseBundle` → a stale, over-limit listing would ship. |
+| `docs/play-store-listing.md` (design brief, PR #610) | Good base, dated | Candela-branded + great IARC/data-safety detail, but assumes the **old 50-char title limit** (real limit is **30** — every title draft in it is over), and says "21 backends" (now 25). |
+| `README.md` | Current truth | "Candela", **25 backends**, 3 voice families, AI chat, Wear OS, TechEmpower-first. |
+
+**The live publish-path files are a release hazard, not just a doc nit.** They
+should be corrected (de-"storyvox", trimmed to limits) before the next
+`publishReleaseBundle`. This folder holds the corrected copy ready to drop in.
+
+## Corrected drafts in this folder (all within Play limits)
+
+| File | Limit | This draft | Maps to (publish path) |
+|---|---|---|---|
+| `title.txt` | 30 | **19** ✅ | `app/src/main/play/listings/en-US/title.txt` |
+| `short-description.txt` | 80 | **70** ✅ | `…/short-description.txt` |
+| `full-description.txt` | 4000 | **3196** ✅ | `…/full-description.txt` |
+| `release-notes-template.txt` | 500/release | example **421** ✅ | `app/src/main/play/release-notes/en-US/default.txt` |
+
+### Title — `Candela: Read Aloud` (19) ✅ recommended
+Play's title limit is **30 chars** (not 50 — the brief is wrong on this). Brand +
+the core verb; "read aloud" is the discovery keyword for the TTS/audiobook intent.
+Ranked alternates (all ≤30):
+1. `Candela: Read Aloud` (19) ✅
+2. `Candela: books read aloud` (25)
+3. `Candela — listen to anything` (28)
+4. `Candela: free tech help, aloud` (30) — leads with the TechEmpower mission, at the limit.
+
+> The TechEmpower mission can't fit a 30-char title alongside the brand + a
+> function keyword; it carries in the short/full description and the
+> "TechEmpower" developer name shown on the listing. Flagging in case JP wants
+> mission-first (option 4) over discovery-first (option 1).
+
+### Short description — 70/80 ✅
+`Free books, tech guides, and the web — read aloud by on-device voices.`
+Alternates:
+- `Free books, tech guides, and accessible help — read aloud by TechEmpower.` (73) — mission-forward (the brief's pick).
+- `Listen to free books, guides, fiction, and the web — beautiful on-device voices.` (79) — function-forward.
+
+### Full description — 3196/4000 ✅
+Rewritten from the brief's draft: **"storyvox" → "Candela"**, **21 → 25 sources**,
+added LibriVox / Radio / OCR+PDF / per-book AI chat / Wear OS, kept the TechEmpower
+mission framing, accessibility, and offline-first posture. 800 chars of headroom
+for tuning.
+
+## Content rating (IARC questionnaire) — answers + flags
+
+The brief (`docs/play-store-listing.md`) and `RUNBOOK.md` already align on this;
+consolidated here so it's in one place for the questionnaire.
+
+**Recommended outcome: Teen (13+) with a user-generated-content advisory.**
+
+| IARC question | Answer | Why |
+|---|---|---|
+| Violence / sexual content / profanity / drugs / gambling *in the app itself* | No | Default surfaces are TechEmpower's resource library + a neutral library. |
+| Users can access **user-generated / unmoderated** content from third parties | **Yes** | Readability magic-link, Royal Road, AO3, RSS, Discord/Telegram/etc. fetch user-supplied URLs Candela does not moderate → this is what drives the 13+ rating. |
+| Users interact with each other / in-app messaging | **No** | Discord/Slack/Matrix/Telegram backends are **read-only feeds**; you can't post from inside Candela. |
+| Shares user location | No | No location features/permission. |
+| Digital purchases / IAP / real-money | No | Free, no IAP, no ads. |
+| Shares personal info with third parties | No | Optional sync sends *your* email to *your* InstantDB sync, opt-in — not third-party sharing. |
+
+**Open items needing a human decision before submission:**
+- [ ] **Target audience: 13+** (must match the content rating; NOT child-directed → not eligible for Designed for Families).
+- [ ] **Category: Books & Reference** (brief's recommendation; confirm).
+- [ ] **Contact email** on the listing — brief leaves as DRAFT (`claude2@techempower.org` or `jp@jphein.com`?).
+- [ ] **Developer phone** (Play requires one on the developer profile).
+- [ ] **Privacy policy URL** resolves — brief lists `https://candela.techempower.org/privacy/` (source `docs/privacy-policy.md`); verify it serves before submission.
+
+## Data Safety + permissions (pointers — already drafted)
+
+- **Data Safety form**: see `docs/play-store-policy-check.md`. Summary: nothing
+  collected by default; with optional sync, collects email + library state
+  (encrypted in transit, user-deletable, never sold). No ads, no ad IDs.
+- **Sensitive permissions to justify** at the Play Console permissions screen
+  (from `app/src/main/AndroidManifest.xml`):
+  - `CAMERA` → on-device OCR only (scan a page → text); images never leave the device.
+  - `POST_NOTIFICATIONS` + `FOREGROUND_SERVICE_MEDIA_PLAYBACK` / `_DATA_SYNC` → audiobook playback notification + background chapter sync.
+  - `RECEIVE_BOOT_COMPLETED`, `WAKE_LOCK` → resume playback / keep audio alive.
+  - Justification copy lives in `docs/play-store-policy-check.md`.
+
+## Recommended next action
+
+1. Pick final title + short-description variants (or accept the recommended).
+2. Copy these four drafts into `app/src/main/play/…` to replace the stale
+   "storyvox" copy **before the next `publishReleaseBundle`** (per `RUNBOOK.md`,
+   that path auto-uploads). I can apply that move in this PR on your say-so —
+   left out for now since the task was "draft into docs/play-store/listing/".
+3. Answer the 5 open content-rating/contact items above.
+4. Graphics already staged in `docs/play-store/v1.0/` + `app/src/main/play/.../graphics/` — no change needed unless the rebrand changed the icon/wordmark.

--- a/docs/play-store/listing/full-description.txt
+++ b/docs/play-store/listing/full-description.txt
@@ -1,0 +1,28 @@
+Candela is TechEmpower's free, accessible resource app — read aloud.
+
+Browse free tech guides, find local help by dialing 211 or 988, reach a peer-support Discord in one tap, and read or listen to all of it through a high-quality neural text-to-speech engine that runs entirely on your device. No subscription. No ads. No tracking. No account required.
+
+Under the hood, Candela is a serious audiobook player for any text you can reach — twenty-five fiction and reference sources are wired in, side by side. Browse Project Gutenberg, Standard Ebooks, LibriVox public-domain audiobooks, Royal Road, Archive of Our Own, Wikipedia, Wikisource, Hacker News, arXiv, and PLOS. Open EPUB and PDF files from your device, or turn a photo or scan into text with on-device OCR. Connect a Notion workspace, an Outline wiki, a Memory Palace you host yourself, or your Discord, Slack, Matrix, and Telegram channels. Tune in to internet radio with search across 30,000+ stations. Share any web link into Candela and a magic-link reader pulls the readable text and queues it for narration.
+
+Three on-device neural voice families ship: Piper (compact, dozens of languages), Kokoro (multi-speaker, warm narration), and KittenTTS (the lightest tier, built for slower phones). Voices download once, then work fully offline. Bring your own Microsoft Azure key for optional cloud-grade voices — Candela takes no cut, and falls back to a local voice if the network drops. Assign a different narrator to each book, and adjust speed, pitch, and pause length live.
+
+The hybrid reader shows the chapter in EB Garamond on a warm dark theme, highlighting the spoken sentence in brass as the voice glides along. Swipe to a clean cover-and-scrubber audiobook view. Ask the built-in AI assistant about any book (bring your own Anthropic, OpenAI, or Google key). Listen on Android Auto, from the lock screen, or a home-screen widget, with a sleep timer and gapless chapter auto-advance. A Wear OS companion puts playback on your wrist.
+
+Built for accessibility and for slower devices: TalkBack-aware navigation, WCAG AA brass-on-near-black contrast, adjustable font scale, and reduced-motion options throughout.
+
+Optional cloud sync (powered by InstantDB) keeps your library, follows, reading positions, bookmarks, and voice settings across devices — encrypted in transit, never sold. Or stay fully offline; your call.
+
+FEATURES
+• 25 fiction & reference sources — enable only the ones you want
+• 3 on-device neural voice families (Piper, Kokoro, KittenTTS)
+• Optional bring-your-own-key cloud voices (Microsoft Azure)
+• Hybrid reader with synced brass sentence highlighting
+• Per-book AI chat (bring your own key — Anthropic, OpenAI, Google)
+• Android Auto, lock-screen controls, sleep timer, home-screen widget
+• Gapless chapter auto-advance with smart prerendering
+• Optional cross-device sync — or fully offline
+• Wear OS companion
+• Dark and light themes; TalkBack-friendly; WCAG AA contrast
+• Free, GPL-3.0, ad-free, no tracking, no account required
+
+Candela is built by TechEmpower, a 501(c)(3) nonprofit closing the digital divide with free tools, training, and software. Open source at github.com/techempower-org/candela.

--- a/docs/play-store/listing/release-notes-template.txt
+++ b/docs/play-store/listing/release-notes-template.txt
@@ -1,0 +1,36 @@
+PLAY STORE RELEASE NOTES — TEMPLATE
+====================================
+Hard limit: 500 characters per language (Play Console rejects longer).
+Live publish file: app/src/main/play/release-notes/en-US/default.txt
+Keep it user-facing: what changed for the listener, not issue numbers.
+3–5 bullets. Lead with the tagline from CHANGELOG.md.
+
+------------------------------------------------------------
+TEMPLATE (copy into default.txt, fill the placeholders):
+------------------------------------------------------------
+v<MAJOR.MINOR.PATCH> — <short tagline>
+
+• <headline change in plain language>
+• <second user-facing improvement>
+• <third user-facing improvement>
+• Fixes & polish: <one short line>
+
+------------------------------------------------------------
+EXAMPLE — v1.1.5 (this release; 470 chars, within limit):
+------------------------------------------------------------
+v1.1.5 — Voices, gears, and polish
+
+• Upgraded KittenTTS voices (v0.8): clearer, more natural speech with named speakers
+• Voice downloads are now gzip-compressed, so big voice models use less data
+• Inbox unread count now adds up correctly across new-chapter checks
+• Accessibility: clearer TalkBack labels for settings, chat read-aloud, and tool cards
+• Under the hood: build migration (AGP 9) and a dependency refresh
+
+------------------------------------------------------------
+NOTES
+- First production release should say "First public release" + a 4–5 bullet
+  feature summary (see full-description.txt for the feature set), still <=500.
+- Don't include version-internal jargon (module names, PR numbers) — those
+  live in CHANGELOG.md, not the Play listing.
+- Emoji are allowed but keep them sparse; Play flags promo-style copy
+  ("BEST!", "#1", excessive caps).

--- a/docs/play-store/listing/short-description.txt
+++ b/docs/play-store/listing/short-description.txt
@@ -1,0 +1,1 @@
+Free books, tech guides, and the web — read aloud by on-device voices.

--- a/docs/play-store/listing/title.txt
+++ b/docs/play-store/listing/title.txt
@@ -1,0 +1,1 @@
+Candela: Read Aloud


### PR DESCRIPTION
## Summary
Audits Candela's Play Store listing copy and adds corrected, limit-compliant **drafts** under `docs/play-store/listing/`. Docs-only; no code changes.

## Audit finding (the important part)
Listing copy already exists in three places that disagree:
- **`app/src/main/play/listings/en-US/`** (the gradle-play-publisher publish path) is **pre-rebrand and out of spec**: title + full description still say **"storyvox"**, the title is **33 chars (Play limit 30)**, and release notes are **519 chars (limit 500)**. Per `docs/play-store/RUNBOOK.md`, `./gradlew :app:publishReleaseBundle` **auto-uploads these**, so this is a live release hazard, not just a stale doc.
- **`docs/play-store-listing.md`** (design brief) is Candela-branded with solid IARC / data-safety detail, but assumes the **old 50-char title limit** (real = 30, so its title drafts are also over) and "21 backends" (now 25).
- **`README.md`** is current: Candela, 25 backends, 3 voice families, AI chat, Wear OS, TechEmpower-first.

## What's in this PR (drafts only)
New `docs/play-store/listing/`:

| File | Limit | This draft |
|---|---|---|
| `title.txt` — `Candela: Read Aloud` | 30 | **19** ✅ |
| `short-description.txt` | 80 | **70** ✅ |
| `full-description.txt` | 4000 | **3196** ✅ |
| `release-notes-template.txt` (template + accurate v1.1.5 example) | 500 | **421** ✅ |
| `AUDIT.md` | — | findings, ranked alternates, content-rating answers, open items |

Full description rewritten from the brief: storyvox→Candela, 21→25 sources, added LibriVox / Radio / OCR+PDF / per-book AI chat / Wear OS, kept the TechEmpower mission + accessibility + offline-first framing.

## Content rating (flagged per the task)
Recommended: **Teen (13+) with a user-generated-content advisory** — driven by the "users can access unmoderated third-party content" answer (Readability magic-link, Royal Road, AO3, RSS, read-only Discord/Matrix/etc. feeds). Full IARC answer table is in `AUDIT.md`. **5 open items need a human decision**: target audience 13+, category (Books & Reference), contact email, developer phone, privacy-policy URL resolves.

## Deliberately NOT done (flagged for sign-off)
I did **not** overwrite the live `app/src/main/play/` files — the task scoped the drafts to `docs/play-store/listing/`. But those stale "storyvox"/over-limit files should be replaced with these drafts **before the next `publishReleaseBundle`**. Happy to apply that move in a follow-up on your say-so.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
