### PR TITLE
refactor(playback): remove dead #883 pause-mid-write resume state (#1144)

### DIFF
--- a/core-playback/src/main/kotlin/in/jphe/storyvox/playback/tts/EnginePlayer.kt
+++ b/core-playback/src/main/kotlin/in/jphe/storyvox/playback/tts/EnginePlayer.kt
@@ -2810,20 +2810,6 @@ class EnginePlayer @AssistedInject constructor(
             // setVolume JNI call when the ramp is idle, which is the steady
             // state. Seeded in the firstSentence block below.
             var lastVol = -1f
-            // Issue #883 — pause-mid-write resume state. When the user
-            // pauses while we're partway through writing a chunk's PCM (or
-            // its trailing silence), the inner write loops break and we
-            // stash the in-flight chunk here along with how far we got.
-            // After the fast-pause park clears on resume, we re-enter the
-            // write phase for the SAME chunk at the saved offsets instead
-            // of pulling the next chunk from the queue — which would skip
-            // the rest of sentence N and jump to N+1, the audible "player
-            // skips a few seconds on pause" symptom. pausedPcmOffset is a
-            // byte index into chunk.pcm; pausedSilenceWritten is bytes of
-            // trailing silence already accepted by AudioTrack.
-            var pausedChunk: PcmChunk? = null
-            var pausedPcmOffset = 0
-            var pausedSilenceWritten = 0
             try {
                 while (pipelineRunning.get()) {
                     // Issue #540 — fast-pause park. When the user taps
@@ -2878,16 +2864,7 @@ class EnginePlayer @AssistedInject constructor(
                     // but because the consumer thread is the only thing
                     // waiting for the result, runBlocking just parks it
                     // exactly as queue.take() did pre-PR-A.
-                    // Issue #883 — if a prior iteration paused mid-write,
-                    // resume that exact chunk rather than dequeuing the
-                    // next one. resumedFromPause gates the per-chunk setup
-                    // below (sentence-range broadcast, firstSentence
-                    // prebuffer) so we don't re-fire it for a chunk the
-                    // listener was already partway through.
-                    val resumedFromPause = pausedChunk != null
-                    val chunkOrNull = if (resumedFromPause) {
-                        pausedChunk
-                    } else try {
+                    val chunkOrNull = try {
                         runBlocking { source.nextChunk() }
                     } catch (t: Throwable) {
                         // Issue #588 — pre-fix this was a silent
@@ -2946,8 +2923,6 @@ class EnginePlayer @AssistedInject constructor(
                     // and-forget on Main — withContext would force this
                     // thread to coordinate with the coroutine dispatcher,
                     // which is the whole reason we left coroutines.
-                    // #883 — skip on a pause-resume: the listener is still
-                    // inside this same sentence, the range is already live.
                     //
                     // #865 — gate on sentence-index change. Pre-fix this
                     // launched a new coroutine on EVERY chunk, even when
@@ -2958,7 +2933,7 @@ class EnginePlayer @AssistedInject constructor(
                     // write of currentSentenceIndex to this thread (single
                     // writer, volatile read elsewhere is safe) and only
                     // launch when the index actually changes.
-                    if (!resumedFromPause && chunk.sentenceIndex != currentSentenceIndex) {
+                    if (chunk.sentenceIndex != currentSentenceIndex) {
                         currentSentenceIndex = chunk.sentenceIndex
                         // Issue #974 (Part B) — dispatch the sentence-range
                         // emit with Dispatchers.Main.immediate. The highlight
@@ -3205,22 +3180,27 @@ class EnginePlayer @AssistedInject constructor(
                         // 16-bit mono PCM = 2 bytes per frame.
                         if (n > 0) totalFramesWritten += n / 2
                     }
-                    // Issue #540 — if we bailed because of user pause,
-                    // we may have written part of this chunk's PCM into
-                    // the AudioTrack ring buffer. That audio is still
-                    // queued and will be heard the moment resume() calls
-                    // track.play(). The remainder (chunk.pcm[written..])
-                    // is dropped on the floor — but since we're parked,
-                    // the SAME chunk will be retried on the next outer
-                    // loop iteration via a fresh nextChunk()... no, wait:
-                    // we already consumed this chunk from the queue.
-                    // Continuing past the trailing-silence branch below
-                    // is correct — the listener will hear the partial
-                    // chunk on resume, then the next chunk picks up
-                    // mid-sentence (~ 200 ms quantum, indistinguishable
-                    // from a clean pause to the listener).
-                    // Spool trailing silence from a shared zero-filled
-                    // buffer (no per-sentence allocation).
+                    // Issue #540 — if we broke out of the loop above because
+                    // the user paused mid-write, chunk.pcm[0..written] is
+                    // already in the AudioTrack ring buffer. The fast-pause
+                    // path keeps the track alive, so that audio plays the
+                    // moment resume() calls track.play(). The unwritten
+                    // remainder (chunk.pcm[written..]) is dropped: this chunk
+                    // was already dequeued, so the next outer iteration pulls
+                    // the FOLLOWING chunk — the tail of the current sentence is
+                    // lost across a pause/resume.
+                    //
+                    // #1144 — the #883 scaffold (pausedChunk / pausedPcmOffset /
+                    // pausedSilenceWritten) was meant to re-enter THIS chunk at
+                    // the saved byte offset to eliminate that tail-skip, but it
+                    // was never wired up (the fields were dead reads), so it has
+                    // been removed. Resuming exactly mid-sentence would re-init
+                    // `written` to the saved offset here and skip the trailing
+                    // silence already played; left as a possible follow-up — it
+                    // is runtime-only behaviour with no JVM test seam.
+                    //
+                    // Spool trailing silence from a shared zero-filled buffer
+                    // (no per-sentence allocation).
                     var remaining = chunk.trailingSilenceBytes
                     while (remaining > 0 && pipelineRunning.get()) {
                         if (userPaused.get()) break // #540 — same logic as PCM loop.


### PR DESCRIPTION
## Issue #1144 — dead `pausedChunk` / `pausedPcmOffset` / `pausedSilenceWritten`

Spotted while investigating #1126. The consumer loop in `EnginePlayer.startPlaybackPipeline()` declared three locals to resume a paused sentence at its saved byte offset (the #883 "pause-mid-write resume" intent):

```kotlin
var pausedChunk: PcmChunk? = null
var pausedPcmOffset = 0
var pausedSilenceWritten = 0
```

…but **nothing ever assigned them**. `pausedChunk` stayed `null` forever, so:
- `resumedFromPause = pausedChunk != null` was always `false`
- `chunkOrNull = if (resumedFromPause) pausedChunk else nextChunk()` always took the `else`
- `if (!resumedFromPause && …)` always reduced to `if (…)`
- `pausedPcmOffset` / `pausedSilenceWritten` were never read

The whole mechanism has been inert dead code since it landed (commit `4196aff5`, wave 2).

### Change
- Remove the three dead fields and collapse the two branches they gated. **Pure algebraic simplification** — every removed branch was unreachable, so behaviour is byte-for-byte identical.
- Rewrite the confused `#540` drop-remainder comment (it contained a literal "no, wait" mid-thought and a dubious "~200 ms quantum" claim — chunks are whole sentences, not 200 ms). The new comment accurately states current behaviour: pausing mid-sentence drops the tail of the current chunk and resumes at the next one, and records that true sub-sentence resume (the #883 intent) would re-init the write offset there — left as a possible follow-up since it's runtime-only with no JVM test seam.

### Why remove rather than implement
#1144 is a dead-code issue. Implementing real sub-sentence resume is a multi-case state machine on the URGENT_AUDIO hot path with no unit-test seam (runtime-only). Done wrong it could *reintroduce* the kind of audio artifact #1126 just fixed. Removal ships clean at zero risk; the implementation path is documented in-code for whoever picks up the enhancement with device-test coverage.

### Verification
- `./gradlew :core-playback:compileDebugKotlin` — clean.
- EnginePlayer pure-function suites (AutoPlayDecision, PositionCheckpoint, ThermalRebuild, PositionExtrapolation) — **20/20 pass**.
- No new test: zero behaviour change means nothing new to exercise.
- Net −20 lines; diff touches only `EnginePlayer.kt`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
