### PR TITLE
test(playback): VoiceFamilyRegistry now ships 7 families (#1145)

### DIFF
--- a/core-playback/src/test/kotlin/in/jphe/storyvox/playback/voice/VoiceFamilyRegistryTest.kt
+++ b/core-playback/src/test/kotlin/in/jphe/storyvox/playback/voice/VoiceFamilyRegistryTest.kt
@@ -18,20 +18,21 @@ import org.junit.Test
  */
 class VoiceFamilyRegistryTest {
 
-    @Test fun `registry exposes SystemTts Piper Kokoro Kitten Azure and the upstream placeholder`() {
+    @Test fun `registry exposes SystemTts Piper Kokoro Kitten Supertonic Azure and the upstream placeholder`() {
         val registry = VoiceFamilyRegistry()
         val ids = registry.descriptors.map { it.id }
-        // #676 — System TTS joins as the zero-download first-launch
-        // tier, bringing the registry to six descriptors.
+        // #676 — System TTS joined as the zero-download first-launch tier;
+        // #1120 — the Supertonic 3 scaffold added the seventh descriptor.
         assertEquals(
-            "Registry should ship exactly six descriptors today",
-            6,
+            "Registry should ship exactly seven descriptors today",
+            7,
             registry.descriptors.size,
         )
         assertTrue(VoiceFamilyIds.SYSTEM_TTS in ids)
         assertTrue(VoiceFamilyIds.PIPER in ids)
         assertTrue(VoiceFamilyIds.KOKORO in ids)
         assertTrue(VoiceFamilyIds.KITTEN in ids)
+        assertTrue(VoiceFamilyIds.SUPERTONIC in ids)
         assertTrue(VoiceFamilyIds.AZURE in ids)
         assertTrue(VoiceFamilyIds.VOXSHERPA_UPSTREAMS in ids)
     }


### PR DESCRIPTION
Closes #1145.

## Summary

The Supertonic 3 scaffold (#1120) added a seventh `VoiceFamilyDescriptor`
(`SUPERTONIC`) to `VoiceFamilyRegistry`, but `VoiceFamilyRegistryTest` still
asserted **6** descriptors — so the registry-contract test was failing on a
stale count.

## Change

- Expected count `6 → 7` (+ assertion message and the `#676`/`#1120` comment).
- Added the missing `assertTrue(VoiceFamilyIds.SUPERTONIC in ids)` so the test
  guards the new family's **presence**, not just the total — the count alone
  would still pass if Supertonic were dropped and a different 7th added. This
  matches the per-family enumeration the rest of the test already does.
- Renamed the test to include Supertonic.

The registry's 7 families: SystemTts, Piper, Kokoro, Kitten, **Supertonic**,
Azure, VoxSherpa-upstreams (placeholder).

## Verification

`VoiceFamilyRegistryTest` 9/9 green (pure JUnit — no Robolectric, so unaffected
by the #1132 SDK pin issue).
