### PR TITLE
fix(test): pin Robolectric to SDK 36 so unit suites run under compileSdk=37 (#1132)

### DIFF
--- a/core-data/src/test/resources/robolectric.properties
+++ b/core-data/src/test/resources/robolectric.properties
@@ -1,0 +1,9 @@
+# Issue #1132 — pin Robolectric's emulated SDK to 36, its current ceiling
+# (Robolectric 4.16.1 supports API 23..36 / Baklava). This module compiles
+# against compileSdk=37 with no explicit targetSdk, so the test manifest's
+# targetSdkVersion defaults to 37 — past Robolectric's maxSdkVersion=36 — and
+# every RobolectricTestRunner class in the module otherwise fails to even
+# initialize ("targetSdkVersion=37 > maxSdkVersion=36"). Emulating SDK 36 is
+# fine for these logic/IO tests; per-class @Config(sdk=...) still overrides.
+# Remove this once Robolectric ships SDK 37 support.
+sdk=36

--- a/core-llm/src/test/resources/robolectric.properties
+++ b/core-llm/src/test/resources/robolectric.properties
@@ -1,0 +1,9 @@
+# Issue #1132 — pin Robolectric's emulated SDK to 36, its current ceiling
+# (Robolectric 4.16.1 supports API 23..36 / Baklava). This module compiles
+# against compileSdk=37 with no explicit targetSdk, so the test manifest's
+# targetSdkVersion defaults to 37 — past Robolectric's maxSdkVersion=36 — and
+# every RobolectricTestRunner class in the module otherwise fails to even
+# initialize ("targetSdkVersion=37 > maxSdkVersion=36"). Emulating SDK 36 is
+# fine for these logic/IO tests; per-class @Config(sdk=...) still overrides.
+# Remove this once Robolectric ships SDK 37 support.
+sdk=36

--- a/core-playback/src/test/kotlin/in/jphe/storyvox/playback/tts/source/CacheFileSourceTest.kt
+++ b/core-playback/src/test/kotlin/in/jphe/storyvox/playback/tts/source/CacheFileSourceTest.kt
@@ -42,14 +42,12 @@ import java.io.FileOutputStream
  *    [java.io.IOException] (corrupt cache → re-render, not crash).
  *  - `startSentenceIndex` resumes mid-chapter (post-seek path).
  */
-// sdk=36: core-playback sets compileSdk=37 with no explicit targetSdk, so
-// the test manifest's targetSdkVersion defaults to 37 — past Robolectric
-// 4.16.1's maxSdkVersion=36, which makes the whole class fail to initialize
-// ("targetSdkVersion=37 > maxSdkVersion=36"). Pin the emulated SDK to 36
-// (Robolectric's current ceiling) so these pure-file-IO tests run until the
-// toolchain catches up to 37. The behavior under test is SDK-agnostic.
+// SDK pin lives module-wide in src/test/resources/robolectric.properties
+// (sdk=36) — see issue #1132. compileSdk=37 outpaces Robolectric 4.16.1's
+// maxSdkVersion=36, so without that pin every RobolectricTestRunner class
+// in core-playback fails to initialize.
 @RunWith(RobolectricTestRunner::class)
-@Config(application = Application::class, sdk = [36])
+@Config(application = Application::class)
 class CacheFileSourceTest {
 
     private lateinit var context: Application

--- a/core-playback/src/test/kotlin/in/jphe/storyvox/playback/voice/VoiceFamilyRegistryTest.kt
+++ b/core-playback/src/test/kotlin/in/jphe/storyvox/playback/voice/VoiceFamilyRegistryTest.kt
@@ -18,20 +18,23 @@ import org.junit.Test
  */
 class VoiceFamilyRegistryTest {
 
-    @Test fun `registry exposes SystemTts Piper Kokoro Kitten Azure and the upstream placeholder`() {
+    @Test fun `registry exposes SystemTts Piper Kokoro Kitten Supertonic Azure and the upstream placeholder`() {
         val registry = VoiceFamilyRegistry()
         val ids = registry.descriptors.map { it.id }
-        // #676 — System TTS joins as the zero-download first-launch
-        // tier, bringing the registry to six descriptors.
+        // #676 added System TTS (zero-download first-launch tier); #1114
+        // scaffolded the Supertonic family — together bringing the registry
+        // to seven descriptors. (#1132: this assertion drifted to 6 while the
+        // Robolectric suite was un-runnable under compileSdk=37.)
         assertEquals(
-            "Registry should ship exactly six descriptors today",
-            6,
+            "Registry should ship exactly seven descriptors today",
+            7,
             registry.descriptors.size,
         )
         assertTrue(VoiceFamilyIds.SYSTEM_TTS in ids)
         assertTrue(VoiceFamilyIds.PIPER in ids)
         assertTrue(VoiceFamilyIds.KOKORO in ids)
         assertTrue(VoiceFamilyIds.KITTEN in ids)
+        assertTrue(VoiceFamilyIds.SUPERTONIC in ids)
         assertTrue(VoiceFamilyIds.AZURE in ids)
         assertTrue(VoiceFamilyIds.VOXSHERPA_UPSTREAMS in ids)
     }

--- a/core-playback/src/test/resources/robolectric.properties
+++ b/core-playback/src/test/resources/robolectric.properties
@@ -1,0 +1,9 @@
+# Issue #1132 — pin Robolectric's emulated SDK to 36, its current ceiling
+# (Robolectric 4.16.1 supports API 23..36 / Baklava). This module compiles
+# against compileSdk=37 with no explicit targetSdk, so the test manifest's
+# targetSdkVersion defaults to 37 — past Robolectric's maxSdkVersion=36 — and
+# every RobolectricTestRunner class in the module otherwise fails to even
+# initialize ("targetSdkVersion=37 > maxSdkVersion=36"). Emulating SDK 36 is
+# fine for these logic/IO tests; per-class @Config(sdk=...) still overrides.
+# Remove this once Robolectric ships SDK 37 support.
+sdk=36

--- a/source-palace/src/test/resources/robolectric.properties
+++ b/source-palace/src/test/resources/robolectric.properties
@@ -1,0 +1,9 @@
+# Issue #1132 — pin Robolectric's emulated SDK to 36, its current ceiling
+# (Robolectric 4.16.1 supports API 23..36 / Baklava). This module compiles
+# against compileSdk=37 with no explicit targetSdk, so the test manifest's
+# targetSdkVersion defaults to 37 — past Robolectric's maxSdkVersion=36 — and
+# every RobolectricTestRunner class in the module otherwise fails to even
+# initialize ("targetSdkVersion=37 > maxSdkVersion=36"). Emulating SDK 36 is
+# fine for these logic/IO tests; per-class @Config(sdk=...) still overrides.
+# Remove this once Robolectric ships SDK 37 support.
+sdk=36

--- a/source-rss/src/test/resources/robolectric.properties
+++ b/source-rss/src/test/resources/robolectric.properties
@@ -1,0 +1,9 @@
+# Issue #1132 — pin Robolectric's emulated SDK to 36, its current ceiling
+# (Robolectric 4.16.1 supports API 23..36 / Baklava). This module compiles
+# against compileSdk=37 with no explicit targetSdk, so the test manifest's
+# targetSdkVersion defaults to 37 — past Robolectric's maxSdkVersion=36 — and
+# every RobolectricTestRunner class in the module otherwise fails to even
+# initialize ("targetSdkVersion=37 > maxSdkVersion=36"). Emulating SDK 36 is
+# fine for these logic/IO tests; per-class @Config(sdk=...) still overrides.
+# Remove this once Robolectric ships SDK 37 support.
+sdk=36


### PR DESCRIPTION
## What

Fixes #1132 — every Robolectric unit-test class in the library modules failed to initialize under `compileSdk=37` (`targetSdkVersion=37 > maxSdkVersion=36`), silently darkening the suites since #1111.

## Root cause

- #1111 bumped `compileSdk` to **37**, but **Robolectric 4.16.1 emulates at most API 36** (Baklava). No released Robolectric supports SDK 37 as of June 2026 ([Robolectric supports M…Baklava / API 23–36](https://github.com/robolectric/robolectric/releases/)).
- Library modules set **no explicit `targetSdk`**, so their test manifests default `targetSdkVersion` to `compileSdk=37`. Robolectric reads that and refuses to run → the whole test class errors out in `getChildren()` before a single test executes.
- **CI never caught it** — only `Build APK` is a required gate; unit tests aren't run in CI. So the suites have been dark and unnoticed since #1111.

## Fix

Add `src/test/resources/robolectric.properties` with `sdk=36` to each of the **5 affected modules** (`core-data`, `core-llm`, `core-playback`, `source-palace`, `source-rss`). This pins Robolectric's *emulated* runtime to its current ceiling while the code still *compiles* against 37 — the canonical mechanism for "compileSdk newer than Robolectric supports," and the per-module `robolectric.properties` is the only way (it's a test-classpath resource, not a global setting). Per-class `@Config(sdk=…)` still overrides where needed.

- **Bumping Robolectric is not an option** — no SDK-37-supporting release exists yet.
- **`app` was never affected** — it already pins `targetSdk=35`.
- Consolidated the per-class `@Config(sdk=36)` I added to `CacheFileSourceTest` in #1128 into the module-wide pin (single source of truth).

## Restored signal

Re-running the un-darkened suites confirms the pin works module-wide:

| Module | Tests | Result |
|--------|------:|--------|
| core-data | 305 | ✅ green |
| core-llm | 128 | ✅ green |
| source-palace | 15 | ✅ green |
| source-rss | 38 | ✅ green |
| core-playback | 356 | see below |

**`core-playback`** runs 356 tests. Re-enabling the suite surfaced two pre-existing issues that had been masked:

1. **`VoiceFamilyRegistryTest` — fixed here.** Its descriptor count drifted (asserted `6`, but #1114 scaffolded the Supertonic family → `7`) while the suite was un-runnable. Test-only sync to shipped reality; added the missing `SUPERTONIC` assertion.
2. **`EngineStreamingSourceGaplessTest."producedAllSentences stays false when close races a partially-drained source"` — NOT addressed here.** Pre-existing **flaky** concurrency test: passes in isolation, fails under full-suite load. The test pulls one chunk then `close()`s but doesn't gate the producer, so a fast fake engine over 50 tiny sentences can race to natural-end (setting `producedAll=true`) before `close()` lands. Unrelated to the SDK issue; needs a deterministic-gating rewrite of a race test. **Filing separately** to keep this PR focused. It doesn't block merge (unit tests aren't a CI gate).

## Net effect

From **0 Robolectric tests runnable** → 4 modules fully green + `core-playback` 355/356 (the 1 being a known pre-existing flake). Strict improvement, no production code touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
