### PR TITLE
fix(privacy): finalize policy for Play Store — drafts, /privacy/ URL, in-app link (#1138)

### DIFF
--- a/docs/play-store-listing.md
+++ b/docs/play-store-listing.md
@@ -261,9 +261,9 @@ library state, encrypted in transit, deletable by the user.
 
 `https://candela.techempower.org/privacy/`
 
-The policy lives at `docs/privacy-policy.md`; Jekyll renders it at
-`/privacy/` via the `permalink: /privacy/` front-matter directive. Verify
-the URL resolves before Play submission.
+The policy lives at `docs/privacy.md`; Jekyll renders it at `/privacy/`
+from the filename under the site's pretty-permalink config (keep the file
+named `privacy.md`). Verify the URL resolves before Play submission.
 
 ---
 

--- a/docs/privacy.md
+++ b/docs/privacy.md
@@ -2,7 +2,6 @@
 layout: default
 title: Candela · Privacy Policy
 description: Candela's privacy policy. Plain-language summary: nothing leaves your device without your explicit action, no analytics, no ads, no tracking.
-permalink: /privacy/
 ---
 
 # Privacy Policy
@@ -13,12 +12,11 @@ permalink: /privacy/
 > downloading a voice). Uninstalling the app deletes everything stored
 > locally; signing out of sync deletes the cloud-side copy too.
 
-**Effective date:** _draft — to be set at v1.0 ship date_  
+**Effective date:** 2026-06-26  
 **App:** Candela (`org.techempower.candela`)  
 **Publisher:** TechEmpower (501(c)(3) nonprofit, operating Candela)  
 **Maintainer:** JP Hein (`jp@jphein.com`)  
-**Contact for privacy questions:** _DRAFT — JP to confirm. Candidates:
-`claude2@techempower.org` or `jp@jphein.com`._
+**Contact for privacy questions:** `jp@jphein.com`
 
 ---
 
@@ -254,7 +252,7 @@ statutory timeframe.
 
 We'll post material changes to this page with an updated "Effective date"
 above. The previous versions are visible in the git history at
-`docs/privacy-policy.md` in the Candela repository — the policy itself is
+`docs/privacy.md` in the Candela repository — the policy itself is
 versioned alongside the app.
 
 For substantive changes (new third-party service, new data collected, etc.)
@@ -267,7 +265,7 @@ that introduces the change, and surface a one-time notice in-app.
 
 For questions, requests, or concerns about your privacy in Candela:
 
-- **Email:** _DRAFT — JP to fill in: claude2@techempower.org or jp@jphein.com_
+- **Email:** `jp@jphein.com`
 - **GitHub issues:** [github.com/techempower-org/candela/issues](https://github.com/techempower-org/candela/issues)
   (public; do not include private information)
 

--- a/docs/release-keystore.md
+++ b/docs/release-keystore.md
@@ -12,7 +12,7 @@ v1.0 Play Store launch.
 
 > **Audience.** JP (the developer) and any future maintainer who needs to
 > rebuild a release APK or recover from a keystore loss. Public-facing context
-> for users lives in [Privacy Policy](privacy-policy.html) and the
+> for users lives in [Privacy Policy](privacy.html) and the
 > [install guide](install.html).
 
 ---

--- a/feature/src/main/kotlin/in/jphe/storyvox/feature/settings/AboutSettingsScreen.kt
+++ b/feature/src/main/kotlin/in/jphe/storyvox/feature/settings/AboutSettingsScreen.kt
@@ -9,11 +9,17 @@ import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalUriHandler
 import androidx.compose.ui.res.stringResource
 import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import `in`.jphe.storyvox.feature.R
 import `in`.jphe.storyvox.ui.theme.LocalSpacing
+
+/** Hosted privacy policy (source: `docs/privacy.md`). Play Console requires a
+ *  reachable privacy-policy URL, and the policy must be reachable from inside
+ *  the app too — surfaced here per #1138. */
+private const val PRIVACY_POLICY_URL = "https://candela.techempower.org/privacy/"
 
 /**
  * Settings → About subscreen (follow-up to #440 / #467).
@@ -35,6 +41,7 @@ fun AboutSettingsScreen(
 ) {
     val state by viewModel.uiState.collectAsStateWithLifecycle()
     val spacing = LocalSpacing.current
+    val uriHandler = LocalUriHandler.current
 
     SettingsSubscreenScaffold(title = stringResource(R.string.settings_about_title), onBack = onBack) { padding ->
         val s = state.settings ?: run {
@@ -72,6 +79,17 @@ fun AboutSettingsScreen(
                         MilestoneBadgePill(s.sigil.versionName)
                     }
                 }
+            }
+
+            // Privacy Policy link (#1138). Play Console requires a reachable
+            // privacy-policy URL; it must also be reachable from inside the
+            // app. Opens the hosted policy in the user's browser.
+            SettingsGroupCard {
+                SettingsLinkRow(
+                    title = stringResource(R.string.settings_about_privacy_policy),
+                    subtitle = stringResource(R.string.settings_about_privacy_policy_subtitle),
+                    onClick = { uriHandler.openUri(PRIVACY_POLICY_URL) },
+                )
             }
         }
     }

--- a/feature/src/main/res/values/strings.xml
+++ b/feature/src/main/res/values/strings.xml
@@ -656,6 +656,8 @@
     <string name="settings_about_version">Candela v%1$s</string>
     <string name="settings_about_dirty"> · dirty</string>
     <string name="settings_about_built"> · built %1$s</string>
+    <string name="settings_about_privacy_policy">Privacy Policy</string>
+    <string name="settings_about_privacy_policy_subtitle">Opens in your browser</string>
 
     <!-- Settings · AI subscreen -->
     <string name="settings_ai_title">AI</string>


### PR DESCRIPTION
## What & why

Finalizes Candela's privacy policy so it's Play-Store-submittable. Closes #1138 — the first of the P0 Play Store compliance blockers.

### 1. Resolved the DRAFT placeholders
The policy shipped (and served publicly) with live `DRAFT` placeholders:
- **Effective date** → `2026-06-26`
- **Contact** (header + §10) → `jp@jphein.com`

All `DRAFT` / "to be set" / "JP to confirm" / `claude2@` tokens removed.

### 2. Fixed the `/privacy/` URL (it was 404ing)
**Root cause:** `privacy-policy.md` was the *only* page on the docs site with a `permalink:` front-matter override — and the *only* page whose URL 404s. GitHub Pages' Jekyll build **ignores** the override: its own SEO `<link rel="canonical">` resolved the page to `/privacy-policy/`, and every other page on the site (`/accessibility/`, `/install/`, …) resolves by **filename** under the site's `permalink: pretty` config.

**Fix:** `git mv docs/privacy-policy.md → docs/privacy.md` so `/privacy/` derives from the filename like every other page, and dropped the dead `permalink:` line. Updated the three references the rename touched:
- `play-store-listing.md` (mechanism prose)
- `release-keystore.md` (relative link)
- the policy's own §9 self-reference

> **Post-merge:** Pages rebuilds from `main:/docs` on merge → `https://candela.techempower.org/privacy/` will resolve, and the site footer's existing `/privacy/` link (currently a dangling 404) self-heals. Worth a quick live-URL check after the Pages build completes before entering the URL in Play Console.

### 3. Added the in-app link
`Settings → About` now has a **"Privacy Policy"** row (`SettingsLinkRow`) that opens the hosted policy via `LocalUriHandler` — Play policy expects the policy reachable from inside the app, and the About screen previously had no link.

## Verification
- `./gradlew :app:assembleDebug` → **green** (APK produced); validates the new `strings.xml` entries and the Compose changes.
- Grep-confirmed no placeholder tokens remain in the staged policy.

## Scope note
This PR is scoped to #1138 only. The sibling Play Store compliance items (#1139 data safety, #1140 content rating, #1141 source licensing, #1142 OSS licenses, #1143 accessibility link) remain tracked separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
