### PR TITLE
fix(sources): radio + librivox network off the main thread (#1134)

### DIFF
--- a/source-librivox/src/main/kotlin/in/jphe/storyvox/source/librivox/net/LibriVoxApi.kt
+++ b/source-librivox/src/main/kotlin/in/jphe/storyvox/source/librivox/net/LibriVoxApi.kt
@@ -1,6 +1,8 @@
 package `in`.jphe.storyvox.source.librivox.net
 
 import `in`.jphe.storyvox.data.source.model.FictionResult
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.json.Json
@@ -151,7 +153,7 @@ internal class LibriVoxApi @Inject constructor(
      * habit of returning `null` for fields our model types as strings
      * (e.g. `file_name`).
      */
-    private fun getBooks(url: String): FictionResult<List<LibriVoxBook>> =
+    private suspend fun getBooks(url: String): FictionResult<List<LibriVoxBook>> =
         when (val raw = doRequest(url)) {
             is FictionResult.Success -> try {
                 // No-results sentinel: LibriVox returns a 200 with an
@@ -174,8 +176,8 @@ internal class LibriVoxApi @Inject constructor(
             is FictionResult.Failure -> raw
         }
 
-    private fun doRequest(url: String): FictionResult<String> {
-        return try {
+    private suspend fun doRequest(url: String): FictionResult<String> = withContext(Dispatchers.IO) {
+        try {
             val request = Request.Builder()
                 .url(url)
                 .header("Accept", "application/json")

--- a/source-librivox/src/test/kotlin/in/jphe/storyvox/source/librivox/LibriVoxApiThreadingTest.kt
+++ b/source-librivox/src/test/kotlin/in/jphe/storyvox/source/librivox/LibriVoxApiThreadingTest.kt
@@ -1,0 +1,66 @@
+package `in`.jphe.storyvox.source.librivox
+
+import `in`.jphe.storyvox.data.source.model.FictionResult
+import `in`.jphe.storyvox.source.librivox.net.LibriVoxApi
+import kotlinx.coroutines.runBlocking
+import okhttp3.MediaType.Companion.toMediaType
+import okhttp3.OkHttpClient
+import okhttp3.Protocol
+import okhttp3.Response
+import okhttp3.ResponseBody.Companion.toResponseBody
+import org.junit.Assert.assertNotEquals
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import java.util.concurrent.atomic.AtomicReference
+
+/**
+ * Issue #1134 — regression guard for the LibriVox transport.
+ *
+ * `list`/`search`/`byId` route through `doRequest`, which runs a blocking
+ * OkHttp `.execute()`. That call MUST happen on `Dispatchers.IO`. Before
+ * the fix, `doRequest` was a plain (non-suspend) function with no
+ * `withContext(Dispatchers.IO)`, so a `list` call originating on
+ * `Dispatchers.Main` (BrowseViewModel.viewModelScope) blocked — and
+ * crashed — the main thread with `NetworkOnMainThreadException`.
+ *
+ * Plain JVM unit test (no Robolectric), so `StrictMode` is inert. We assert
+ * the thread that actually runs the HTTP call differs from the caller's:
+ * `withContext(Dispatchers.IO)` guarantees the hop; the bug ran the call
+ * inline on the caller thread. Fails red on the old code, green on the fix.
+ */
+class LibriVoxApiThreadingTest {
+
+    @Test
+    fun `list runs the blocking HTTP call off the caller thread (issue 1134)`() = runBlocking {
+        val callerThread = Thread.currentThread()
+        val ranOn = AtomicReference<Thread?>(null)
+
+        // Short-circuit interceptor: record the thread the OkHttp call runs
+        // on and return a synthetic empty-feed body — no real socket.
+        val client = OkHttpClient.Builder()
+            .addInterceptor { chain ->
+                ranOn.set(Thread.currentThread())
+                Response.Builder()
+                    .request(chain.request())
+                    .protocol(Protocol.HTTP_1_1)
+                    .code(200)
+                    .message("OK")
+                    .body("""{"books":[]}""".toResponseBody("application/json".toMediaType()))
+                    .build()
+            }
+            .build()
+
+        val result = LibriVoxApi(client).list()
+
+        // End-to-end still works: empty feed → empty success.
+        assertTrue("expected Success, got $result", result is FictionResult.Success)
+        val executed = ranOn.get()
+        assertNotNull("interceptor never ran — no request was made", executed)
+        assertNotEquals(
+            "Issue #1134: doRequest must run on Dispatchers.IO, not the caller thread",
+            callerThread,
+            executed,
+        )
+    }
+}

--- a/source-radio/src/main/kotlin/in/jphe/storyvox/source/radio/net/RadioBrowserApi.kt
+++ b/source-radio/src/main/kotlin/in/jphe/storyvox/source/radio/net/RadioBrowserApi.kt
@@ -2,6 +2,8 @@ package `in`.jphe.storyvox.source.radio.net
 
 import `in`.jphe.storyvox.data.source.model.FictionResult
 import `in`.jphe.storyvox.source.radio.RadioStation
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.json.Json
@@ -157,7 +159,7 @@ internal class RadioBrowserApi @Inject constructor(
 
     // ─── transport ────────────────────────────────────────────────────
 
-    private inline fun <reified T> getJson(url: String): FictionResult<T> =
+    private suspend inline fun <reified T> getJson(url: String): FictionResult<T> =
         when (val raw = doRequest(url)) {
             is FictionResult.Success -> try {
                 FictionResult.Success(json.decodeFromString<T>(raw.value))
@@ -170,8 +172,8 @@ internal class RadioBrowserApi @Inject constructor(
             is FictionResult.Failure -> raw
         }
 
-    private fun doRequest(url: String): FictionResult<String> {
-        return try {
+    private suspend fun doRequest(url: String): FictionResult<String> = withContext(Dispatchers.IO) {
+        try {
             val request = Request.Builder()
                 .url(url)
                 .header("Accept", "application/json")

--- a/source-radio/src/test/kotlin/in/jphe/storyvox/source/radio/RadioBrowserApiThreadingTest.kt
+++ b/source-radio/src/test/kotlin/in/jphe/storyvox/source/radio/RadioBrowserApiThreadingTest.kt
@@ -1,0 +1,71 @@
+package `in`.jphe.storyvox.source.radio
+
+import `in`.jphe.storyvox.data.source.model.FictionResult
+import `in`.jphe.storyvox.source.radio.net.RadioBrowserApi
+import kotlinx.coroutines.runBlocking
+import okhttp3.MediaType.Companion.toMediaType
+import okhttp3.OkHttpClient
+import okhttp3.Protocol
+import okhttp3.Response
+import okhttp3.ResponseBody.Companion.toResponseBody
+import org.junit.Assert.assertNotEquals
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import java.util.concurrent.atomic.AtomicReference
+
+/**
+ * Issue #1134 — regression guard for the Radio Browser transport.
+ *
+ * `byName`/`search` route through `doRequest`, which runs a blocking
+ * OkHttp `.execute()`. That call MUST happen on `Dispatchers.IO`. Before
+ * the fix, `doRequest` was a plain (non-suspend) function with no
+ * `withContext(Dispatchers.IO)`, so a `byName` call originating on
+ * `Dispatchers.Main` (BrowseViewModel.viewModelScope) blocked — and
+ * crashed — the main thread with `NetworkOnMainThreadException`. Both
+ * `source-radio` and `source-librivox` shipped this bug because the
+ * repository deliberately does not wrap browse/search; each source API
+ * owns its own IO dispatch (the #585 convention).
+ *
+ * This is a plain JVM unit test (no Robolectric, per the project's test
+ * convention), so `StrictMode.detectNetwork()` is inert. Instead we assert
+ * the thread that actually runs the HTTP call differs from the thread that
+ * called the API: `withContext(Dispatchers.IO)` guarantees that hop; the
+ * bug ran the call inline on the caller thread. Fails red on the old code,
+ * passes green on the fix.
+ */
+class RadioBrowserApiThreadingTest {
+
+    @Test
+    fun `byName runs the blocking HTTP call off the caller thread (issue 1134)`() = runBlocking {
+        val callerThread = Thread.currentThread()
+        val ranOn = AtomicReference<Thread?>(null)
+
+        // Short-circuit interceptor: record the thread the OkHttp call runs
+        // on and return a synthetic empty-array body — no real socket.
+        val client = OkHttpClient.Builder()
+            .addInterceptor { chain ->
+                ranOn.set(Thread.currentThread())
+                Response.Builder()
+                    .request(chain.request())
+                    .protocol(Protocol.HTTP_1_1)
+                    .code(200)
+                    .message("OK")
+                    .body("[]".toResponseBody("application/json".toMediaType()))
+                    .build()
+            }
+            .build()
+
+        val result = RadioBrowserApi(client).byName("anything")
+
+        // End-to-end still works: empty array → empty success.
+        assertTrue("expected Success, got $result", result is FictionResult.Success)
+        val executed = ranOn.get()
+        assertNotNull("interceptor never ran — no request was made", executed)
+        assertNotEquals(
+            "Issue #1134: doRequest must run on Dispatchers.IO, not the caller thread",
+            callerThread,
+            executed,
+        )
+    }
+}


### PR DESCRIPTION
Fixes #1134.

## Problem

`source-radio` and `source-librivox` ran their blocking OkHttp `.execute()` on the **main thread** → `NetworkOnMainThreadException` on the *first* Browse → Radio / Browse → LibriVox search or listing. Both sources are `@SourcePlugin(defaultEnabled = true)`, so the crash was reachable out of the box.

Root cause: each source's API is responsible for its own IO dispatch — `FictionRepository` deliberately does **not** wrap the browse/search path (`browsePopular`/`search`/… delegate straight to the source), and `BrowseViewModel` launches on `Dispatchers.Main.immediate`. Every other source API honors this by wrapping its transport in `withContext(Dispatchers.IO)` (see `WikipediaApi.getRaw`); these two modules had a plain, non-suspend `doRequest` with no dispatch hop. Recurrence of the #585 pattern.

## Fix

Wrap each module's `doRequest` in `withContext(Dispatchers.IO)` and make it `suspend`, mirroring `WikipediaApi.getRaw`. The suspend ripples one level up to the already-suspend callers:

- **RadioBrowserApi**: `doRequest` → `suspend … withContext(Dispatchers.IO)`; `getJson` → `suspend inline`.
- **LibriVoxApi**: `doRequest` → `suspend … withContext(Dispatchers.IO)`; `getBooks` → `suspend`.

No call-site changes needed (`byName`/`search`/`list`/`byId` were already `suspend`).

## Tests

Added a JVM regression test to each module (`RadioBrowserApiThreadingTest`, `LibriVoxApiThreadingTest`). The project is JUnit4 with no Robolectric, so `StrictMode.detectNetwork()` is inert — instead each test injects an `OkHttpClient` with a short-circuit `Interceptor` that records the thread the call runs on, invokes the API under `runBlocking`, and asserts that thread ≠ the caller thread. This is **red** on the old inline-`.execute()` code and **green** with the `withContext(Dispatchers.IO)` hop, so the pattern can't silently regress.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Network requests now run off the caller thread, improving responsiveness and reducing the risk of blocking the app during catalog lookups.
  * Added regression coverage to ensure these requests stay on a background thread and still return successful results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->