### PR TITLE
fix(a11y): label DynamicFilterSheet RangeSlider/Toggle + bare-percent sliders (#1158, #1159)

### DIFF
--- a/feature/src/main/kotlin/in/jphe/storyvox/feature/browse/DynamicFilterSheet.kt
+++ b/feature/src/main/kotlin/in/jphe/storyvox/feature/browse/DynamicFilterSheet.kt
@@ -8,6 +8,7 @@ import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.selection.toggleable
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material3.Button
 import androidx.compose.material3.ExperimentalMaterial3Api
@@ -30,6 +31,10 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.semantics.Role
+import androidx.compose.ui.semantics.contentDescription
+import androidx.compose.ui.semantics.semantics
+import androidx.compose.ui.semantics.stateDescription
 import androidx.compose.ui.text.style.TextDecoration
 import `in`.jphe.storyvox.data.source.filter.FilterDimension
 import `in`.jphe.storyvox.feature.R
@@ -337,7 +342,17 @@ private fun NumberRangeSection(
         },
         valueRange = dim.min..dim.max,
         steps = ((dim.max - dim.min) / dim.step).toInt() - 1,
-        modifier = Modifier.fillMaxWidth(),
+        // #1158 — M3 only exposes the slider role + a raw value; the
+        // dimension name (SectionLabel) and the unit/range Text above are
+        // sibling nodes TalkBack never associates. Name + range-with-units
+        // here so it reads "Length, 50 to 200 words" instead of "50.0, slider".
+        modifier = Modifier
+            .fillMaxWidth()
+            .semantics {
+                contentDescription = dim.label
+                stateDescription =
+                    "${formatNumber(rangeMin, dim.step)} to ${formatNumber(rangeMax, dim.step)}$suffix"
+            },
     )
 }
 
@@ -375,18 +390,31 @@ private fun ToggleSection(
     onChange: (FilterState) -> Unit,
 ) {
     val checked = state.boolVal(dim.key) ?: dim.default
+    // #1158 — pre-fix the label Text and the Switch were separate focus
+    // stops, so TalkBack landed on the Switch and said "Switch, on" with no
+    // idea which filter it controlled. The toggleable Row now owns the
+    // Role.Switch semantics + name, merging both into one node that reads
+    // "Completed only, on, switch"; the inner Switch defers (onCheckedChange
+    // = null) so it isn't a redundant, unlabeled second focus stop.
     Row(
-        modifier = Modifier.fillMaxWidth(),
+        modifier = Modifier
+            .fillMaxWidth()
+            .toggleable(
+                value = checked,
+                role = Role.Switch,
+                onValueChange = { value ->
+                    if (value == dim.default) onChange(state.without(dim.key))
+                    else onChange(state.with(dim.key, FilterValue.BoolVal(value)))
+                },
+            )
+            .semantics { contentDescription = dim.label },
         horizontalArrangement = Arrangement.SpaceBetween,
         verticalAlignment = Alignment.CenterVertically,
     ) {
         Text(dim.label, style = MaterialTheme.typography.bodyLarge)
         Switch(
             checked = checked,
-            onCheckedChange = { value ->
-                if (value == dim.default) onChange(state.without(dim.key))
-                else onChange(state.with(dim.key, FilterValue.BoolVal(value)))
-            },
+            onCheckedChange = null,
         )
     }
 }

--- a/feature/src/main/kotlin/in/jphe/storyvox/feature/settings/ReadingSettingsScreen.kt
+++ b/feature/src/main/kotlin/in/jphe/storyvox/feature/settings/ReadingSettingsScreen.kt
@@ -25,6 +25,7 @@ import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.toArgb
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.semantics.clearAndSetSemantics
 import androidx.compose.ui.semantics.contentDescription
 import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.semantics.stateDescription
@@ -447,14 +448,25 @@ private fun ChannelSlider(name: String, value: Float, onValue: (Float) -> Unit) 
             text = name.take(1),
             style = MaterialTheme.typography.labelSmall,
             color = MaterialTheme.colorScheme.onSurfaceVariant,
+            // #1159 — the channel name now lives on the Slider's semantics
+            // (with the 0-255 value) so TalkBack reads "Red, 128" as one node.
+            // Clear this single-letter label from the a11y tree so it isn't a
+            // redundant "R" focus stop preceding the slider.
             modifier = Modifier
                 .width(16.dp)
-                .semantics { contentDescription = name },
+                .clearAndSetSemantics {},
         )
         Slider(
             value = value,
             onValueChange = onValue,
-            modifier = Modifier.fillMaxWidth(),
+            // #1159 — pre-fix the slider announced only the bare M3 percent
+            // ("57%"); name + 0-255 channel value here yield "Red, 128".
+            modifier = Modifier
+                .fillMaxWidth()
+                .semantics {
+                    contentDescription = name
+                    stateDescription = "${(value * 255).roundToInt()}"
+                },
         )
     }
 }

--- a/feature/src/main/kotlin/in/jphe/storyvox/feature/settings/SettingsScreen.kt
+++ b/feature/src/main/kotlin/in/jphe/storyvox/feature/settings/SettingsScreen.kt
@@ -1470,7 +1470,14 @@ internal fun ParallelSynthSliders(
             onValueChange = { onInstancesChange(it.toInt().coerceIn(1, 8)) },
             valueRange = 1f..8f,
             steps = 6,
-            modifier = Modifier.fillMaxWidth(),
+            // #1159 — without these TalkBack read the bare M3 percent ("57%").
+            // The value Text is a sibling node, so name + count live here.
+            modifier = Modifier
+                .fillMaxWidth()
+                .semantics {
+                    contentDescription = "Engines"
+                    stateDescription = if (instances <= 1) "1 (serial)" else "$instances"
+                },
         )
         Text(
             text = when {
@@ -1505,7 +1512,14 @@ internal fun ParallelSynthSliders(
             onValueChange = { onThreadsChange(it.toInt().coerceIn(0, 8)) },
             valueRange = 0f..8f,
             steps = 7,
-            modifier = Modifier.fillMaxWidth(),
+            // #1159 — name + count for TalkBack; 0 reads as "Auto" to match
+            // the visible value Text (a sibling node) above the slider.
+            modifier = Modifier
+                .fillMaxWidth()
+                .semantics {
+                    contentDescription = "Threads per engine"
+                    stateDescription = if (threadsPerInstance == 0) "Auto" else "$threadsPerInstance"
+                },
         )
         Text(
             text = when {


### PR DESCRIPTION
Fixes #1158 and #1159 — accessibility labelling for filter and settings sliders.

## #1158 — DynamicFilterSheet (generic renderer for all 24 sources, high reach)

- **RangeSlider** (`NumberRangeSection`): added `Modifier.semantics` with `contentDescription = dim.label` and `stateDescription` carrying the current range + unit suffix. TalkBack now reads e.g. **"Length, 50 to 200 words"** instead of "50.0, slider" (dimension name and unit Text were sibling nodes M3 never associated).
- **Toggle** (`ToggleSection`): wrapped the Row in `Modifier.toggleable(value, role = Role.Switch, onValueChange)` + `semantics { contentDescription = dim.label }`, and set the inner `Switch`'s `onCheckedChange = null` so it defers to the parent. One merged focus stop reading **"Completed only, on, switch"** instead of an unlabeled "Switch, on". Mirrors the FavoriteToggle pattern in `VoiceLibraryScreen.kt`.

## #1159 — sliders announcing the bare M3 percent

- **ParallelSynth "Engines" / "Threads per engine"** (`SettingsScreen.kt`): added `contentDescription` + `stateDescription` mirroring the visible value Text → "Engines, 4", "Threads per engine, Auto".
- **RGB `ChannelSlider`** (`ReadingSettingsScreen.kt`): moved the channel name onto the Slider's semantics with the 0-255 value (**"Red, 128"**) and cleared the single-letter "R"/"G"/"B" label from the a11y tree (`clearAndSetSemantics {}`) so it is not a redundant focus stop.

## Standards

WCAG **4.1.2 Name, Role, Value (Level A)** and **1.3.1 Info & Relationships (Level A)**.

Follows the established `stateDescription` pattern already used by the voice speed/pitch, buffer, and typography sliders.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
