### PR TITLE
fix(a11y): enlarge touch targets and add scrubber seek action (#1135, #1148)

### DIFF
--- a/core-ui/src/main/kotlin/in/jphe/storyvox/ui/component/BrassProgressTrack.kt
+++ b/core-ui/src/main/kotlin/in/jphe/storyvox/ui/component/BrassProgressTrack.kt
@@ -28,8 +28,14 @@ import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.geometry.Size
 import androidx.compose.ui.graphics.drawscope.Stroke
 import androidx.compose.ui.input.pointer.pointerInput
+import androidx.compose.ui.semantics.CustomAccessibilityAction
+import androidx.compose.ui.semantics.ProgressBarRangeInfo
 import androidx.compose.ui.semantics.contentDescription
+import androidx.compose.ui.semantics.customActions
+import androidx.compose.ui.semantics.progressBarRangeInfo
 import androidx.compose.ui.semantics.semantics
+import androidx.compose.ui.semantics.setProgress
+import androidx.compose.ui.semantics.stateDescription
 import androidx.compose.ui.unit.dp
 import `in`.jphe.storyvox.ui.theme.LocalReducedMotion
 import `in`.jphe.storyvox.ui.theme.LocalSpacing
@@ -110,11 +116,15 @@ fun BrassProgressTrack(
         )
     }
 
-    Box(
-        modifier = modifier.semantics {
-            contentDescription = "Playback progress, ${formatMs(positionMs)} of ${formatMs(durationMs)}"
-        },
-    ) {
+    // #1148 — the scrubber is an accessible seek control. The interactive
+    // 48dp band below now carries Role.Slider-equivalent semantics
+    // (progressBarRangeInfo + setProgress) plus ±30s custom actions so
+    // TalkBack / Switch Access users can seek; before this it exposed only
+    // a contentDescription (a value with no settable action), failing
+    // WCAG 4.1.2 (Name/Role/Value) and 2.1.1 (Keyboard) / 2.5.7 (Dragging
+    // Movements). This outer Box is a plain layout container so it doesn't
+    // create a competing a11y node above the slider.
+    Box(modifier = modifier) {
         Box(
             modifier = Modifier
                 .fillMaxWidth()
@@ -135,6 +145,42 @@ fun BrassProgressTrack(
                 // surrounding verticalScroll absorbs it on phone
                 // viewports.
                 .height(48.dp)
+                .semantics {
+                    // #1148 — sighted users operate the rail via the
+                    // pointerInput drag below; accessibility services
+                    // can't observe pointer gestures, so the seek
+                    // affordance is re-expressed declaratively here.
+                    // stateDescription replaces the auto percentage
+                    // readout with "2:04 of 47:12"; setProgress is where
+                    // TalkBack's swipe-up/down-to-adjust lands; the two
+                    // custom actions mirror the Replay30 / Forward30 skip
+                    // buttons so Switch Access menus can jump ±30s.
+                    contentDescription = "Playback progress"
+                    stateDescription =
+                        "${formatMs(positionMs)} of ${formatMs(durationMs)}"
+                    progressBarRangeInfo = ProgressBarRangeInfo(
+                        current = brassProgressFraction(positionMs, durationMs),
+                        range = 0f..1f,
+                    )
+                    setProgress { target ->
+                        onSeekTo(brassSeekTargetMs(target, durationMs))
+                        true
+                    }
+                    customActions = listOf(
+                        CustomAccessibilityAction("Skip back 30 seconds") {
+                            onSeekTo(
+                                brassSkipTargetMs(positionMs, durationMs, -SCRUBBER_SKIP_MS),
+                            )
+                            true
+                        },
+                        CustomAccessibilityAction("Skip forward 30 seconds") {
+                            onSeekTo(
+                                brassSkipTargetMs(positionMs, durationMs, SCRUBBER_SKIP_MS),
+                            )
+                            true
+                        },
+                    )
+                }
                 .pointerInput(durationMs) {
                     // Hand-rolled gesture so a single tap also seeks. The built-in
                     // detectHorizontalDragGestures only fires after enough drag
@@ -210,6 +256,42 @@ fun BrassProgressTrack(
         }
     }
 }
+
+/**
+ * Scrubber accessibility seek step — matches the Replay30 / Forward30
+ * skip buttons in the player (AudiobookView). Kept in sync by intent:
+ * the skip duration is hard-coded to 30s today (#268).
+ */
+internal const val SCRUBBER_SKIP_MS: Long = 30_000L
+
+/**
+ * Structural a11y canary (#1148). [BrassProgressTrack] must expose a
+ * *settable* seek control to accessibility services —
+ * `progressBarRangeInfo` + `setProgress` + ±30s `CustomAccessibilityAction`s
+ * — not just a read-only `contentDescription`. A unit test pins this
+ * `true`; flip it only after proving on a real device with TalkBack /
+ * Switch Access that a different shape still lets those users seek.
+ */
+internal const val brassProgressTrackExposesSeekSemantics: Boolean = true
+
+/** Current playback position as a 0..1 fraction; 0 when duration is unknown. */
+internal fun brassProgressFraction(positionMs: Long, durationMs: Long): Float =
+    if (durationMs > 0) (positionMs.toFloat() / durationMs).coerceIn(0f, 1f) else 0f
+
+/**
+ * Seek target (ms) for a slider fraction in 0..1 (the value
+ * accessibility services pass to `setProgress`), clamped to the chapter.
+ */
+internal fun brassSeekTargetMs(fraction: Float, durationMs: Long): Long =
+    (fraction.coerceIn(0f, 1f) * durationMs).roundToLong()
+        .coerceIn(0L, durationMs.coerceAtLeast(0L))
+
+/**
+ * Seek target (ms) for a relative ±skip (the ±30s custom actions),
+ * clamped to the chapter bounds.
+ */
+internal fun brassSkipTargetMs(positionMs: Long, durationMs: Long, deltaMs: Long): Long =
+    (positionMs + deltaMs).coerceIn(0L, durationMs.coerceAtLeast(0L))
 
 private fun formatMs(ms: Long): String {
     if (ms <= 0) return "0:00"

--- a/core-ui/src/test/kotlin/in/jphe/storyvox/ui/component/BrassProgressTrackSemanticsTest.kt
+++ b/core-ui/src/test/kotlin/in/jphe/storyvox/ui/component/BrassProgressTrackSemanticsTest.kt
@@ -1,0 +1,83 @@
+package `in`.jphe.storyvox.ui.component
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * Issue #1148 — regression guard for `BrassProgressTrack` accessibility
+ * seek semantics.
+ *
+ * Before #1148 the chapter scrubber exposed only a `contentDescription`
+ * (a value with no settable action), so TalkBack / Switch Access users
+ * could hear "Playback progress, 2:04 of 47:12" but had **no way to
+ * seek** — failing WCAG 4.1.2 (Name/Role/Value), 2.1.1 (Keyboard) and
+ * 2.5.7 (Dragging Movements). The fix re-expresses the seek affordance
+ * declaratively: `progressBarRangeInfo` + `setProgress` make it an
+ * adjustable slider, and ±30s `CustomAccessibilityAction`s mirror the
+ * Replay30 / Forward30 skip buttons.
+ *
+ * The unit-test source set has no Robolectric / ComposeTestRule (per the
+ * `BottomTabBarSemanticsTest` convention), so this test pins:
+ *  (a) the structural canary [brassProgressTrackExposesSeekSemantics],
+ *      which must stay `true`, and
+ *  (b) the pure seek-target math the semantics actions delegate to, so a
+ *      regression in clamping/rounding is caught off-device.
+ */
+class BrassProgressTrackSemanticsTest {
+
+    @Test
+    fun `scrubber exposes a settable seek control to accessibility services per issue #1148`() {
+        assertTrue(
+            "BrassProgressTrack must expose progressBarRangeInfo + setProgress " +
+                "+ ±30s custom actions so TalkBack / Switch Access users can seek (#1148)",
+            brassProgressTrackExposesSeekSemantics,
+        )
+    }
+
+    @Test
+    fun `progress fraction maps position over duration into 0,,1`() {
+        assertEquals(0f, brassProgressFraction(0, 100_000), 0f)
+        assertEquals(0.5f, brassProgressFraction(50_000, 100_000), 1e-4f)
+        assertEquals(1f, brassProgressFraction(100_000, 100_000), 0f)
+    }
+
+    @Test
+    fun `progress fraction is clamped and safe when position exceeds or duration is unknown`() {
+        // Over-run (position past the end) clamps to 1, never > 1.
+        assertEquals(1f, brassProgressFraction(150_000, 100_000), 0f)
+        // Unknown duration must not divide-by-zero — reports 0.
+        assertEquals(0f, brassProgressFraction(5_000, 0), 0f)
+        assertEquals(0f, brassProgressFraction(5_000, -1), 0f)
+    }
+
+    @Test
+    fun `setProgress fraction converts to a clamped, rounded ms target`() {
+        assertEquals(0L, brassSeekTargetMs(0f, 100_000))
+        assertEquals(50_000L, brassSeekTargetMs(0.5f, 100_000))
+        assertEquals(100_000L, brassSeekTargetMs(1f, 100_000))
+        // Out-of-range fractions clamp into the chapter.
+        assertEquals(0L, brassSeekTargetMs(-0.3f, 100_000))
+        assertEquals(100_000L, brassSeekTargetMs(1.5f, 100_000))
+        // Degenerate duration can't produce a negative/overshoot target.
+        assertEquals(0L, brassSeekTargetMs(0.5f, 0))
+    }
+
+    @Test
+    fun `skip custom actions move +-30s and clamp to chapter bounds`() {
+        // Mid-chapter: clean ±30s.
+        assertEquals(70_000L, brassSkipTargetMs(40_000, 100_000, SCRUBBER_SKIP_MS))
+        assertEquals(10_000L, brassSkipTargetMs(40_000, 100_000, -SCRUBBER_SKIP_MS))
+        // Skip-back near the start floors at 0, never negative.
+        assertEquals(0L, brassSkipTargetMs(10_000, 100_000, -SCRUBBER_SKIP_MS))
+        // Skip-forward near the end caps at duration, never past it.
+        assertEquals(100_000L, brassSkipTargetMs(90_000, 100_000, SCRUBBER_SKIP_MS))
+    }
+
+    @Test
+    fun `skip step matches the player's 30 second Replay30 - Forward30 buttons`() {
+        // If the player skip interval ever changes, this and the icons
+        // must move together (#268). Pin the contract.
+        assertEquals(30_000L, SCRUBBER_SKIP_MS)
+    }
+}

--- a/feature/src/main/kotlin/in/jphe/storyvox/feature/fiction/FictionDetailScreen.kt
+++ b/feature/src/main/kotlin/in/jphe/storyvox/feature/fiction/FictionDetailScreen.kt
@@ -75,6 +75,8 @@ import `in`.jphe.storyvox.feature.api.UiChapter
 import `in`.jphe.storyvox.feature.api.UiFiction
 import `in`.jphe.storyvox.feature.api.UiRecapPlaybackState
 import `in`.jphe.storyvox.source.epub.writer.EpubExportResult
+import `in`.jphe.storyvox.ui.a11y.LocalAccessibleTouchTargets
+import `in`.jphe.storyvox.ui.a11y.accessibleSize
 import `in`.jphe.storyvox.ui.component.BrassButton
 import `in`.jphe.storyvox.ui.component.BrassButtonVariant
 import `in`.jphe.storyvox.ui.component.ChapterCard
@@ -1325,7 +1327,14 @@ private fun Synopsis(
             )
             IconButton(
                 onClick = onToggleListen,
-                modifier = Modifier.size(36.dp),
+                // #1135 — was 36dp (sub-48 touch target, WCAG 2.5.8 fail).
+                // accessibleSize gives a 48dp button surface that widens
+                // to 64dp under the "larger touch targets" preference /
+                // Switch Access; the inner Icon keeps its 20dp visual size.
+                modifier = Modifier.accessibleSize(
+                    enlargedFlag = LocalAccessibleTouchTargets.current,
+                    base = 48.dp,
+                ),
             ) {
                 Icon(
                     imageVector = if (isSpeaking) Icons.Filled.Pause else Icons.Filled.PlayArrow,

--- a/feature/src/main/kotlin/in/jphe/storyvox/feature/reader/PlaybackErrorBanner.kt
+++ b/feature/src/main/kotlin/in/jphe/storyvox/feature/reader/PlaybackErrorBanner.kt
@@ -37,6 +37,8 @@ import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import `in`.jphe.storyvox.feature.R
 import `in`.jphe.storyvox.playback.EngineState
+import `in`.jphe.storyvox.ui.a11y.LocalAccessibleTouchTargets
+import `in`.jphe.storyvox.ui.a11y.accessibleSize
 import `in`.jphe.storyvox.ui.component.BrassButton
 import `in`.jphe.storyvox.ui.component.BrassButtonVariant
 import `in`.jphe.storyvox.ui.theme.LibraryNocturneTheme
@@ -130,7 +132,14 @@ fun PlaybackErrorBanner(
                 }
                 IconButton(
                     onClick = onDismiss,
-                    modifier = Modifier.size(36.dp),
+                    // #1135 — was 36dp (sub-48 touch target, WCAG 2.5.8 fail).
+                    // accessibleSize gives a 48dp button surface that widens
+                    // to 64dp under the "larger touch targets" preference /
+                    // Switch Access; the inner Icon keeps its 18dp visual size.
+                    modifier = Modifier.accessibleSize(
+                        enlargedFlag = LocalAccessibleTouchTargets.current,
+                        base = 48.dp,
+                    ),
                 ) {
                     Icon(
                         imageVector = Icons.Filled.Close,


### PR DESCRIPTION
## Summary

Two related accessibility fixes for the player/detail surfaces.

### #1135 — IconButtons below 48dp touch target
Two interactive `IconButton`s rendered a **36dp** tap surface, below the 48dp minimum (WCAG 2.5.8). Both now use `Modifier.accessibleSize(base = 48.dp)` (the project helper from `core-ui/.../ui/a11y/AccessibleTouchTarget.kt`), so the surface is 48dp and **widens to 64dp** when the "larger touch targets" preference or Switch Access is active. Inner `Icon` visual sizes are unchanged.

| File | Control | Before → After |
|---|---|---|
| `FictionDetailScreen.kt:1326` | "Listen to summary" play/pause | `size(36.dp)` → `accessibleSize(base = 48.dp)` |
| `PlaybackErrorBanner.kt:131` | Error-banner dismiss | `size(36.dp)` → `accessibleSize(base = 48.dp)` |

### #1148 — chapter scrubber had no seek action
`BrassProgressTrack` exposed only a `contentDescription` — TalkBack/Switch Access users could hear *"Playback progress, 2:04 of 47:12"* but **could not seek** (WCAG 4.1.2 Name/Role/Value, 2.1.1 Keyboard, 2.5.7 Dragging Movements). The interactive 48dp band now carries slider semantics:

- `progressBarRangeInfo` + `setProgress` → announced as an adjustable slider; TalkBack swipe-up/down adjusts.
- `stateDescription` = `"2:04 of 47:12"` (replaces the auto percentage readout).
- ±30s `CustomAccessibilityAction`s ("Skip back/forward 30 seconds") mirroring the Replay30/Forward30 buttons, so Switch Access menus can jump.

The custom Box + hand-rolled tap/drag gesture (from #615/#620) is preserved — the seek affordance is re-expressed declaratively for AT rather than replacing the control.

## Tests
`BrassProgressTrackSemanticsTest` (new) follows the `BottomTabBarSemanticsTest` canary convention: a structural marker (`brassProgressTrackExposesSeekSemantics`) plus pure-function coverage of the extracted seek math (fraction mapping, `setProgress` clamp/round, ±30s clamp to chapter bounds). The unit source set has no Robolectric/ComposeTestRule, so on-device semantics can't be asserted directly — the canary forces re-verification if the semantics are dropped.

Closes #1135
Closes #1148

🤖 Generated with [Claude Code](https://claude.com/claude-code)
