### PR TITLE
fix(a11y): announce chat streaming, OCR status, and voice-download progress (#1154, #1155, #1156)

### DIFF
--- a/core-ui/src/main/kotlin/in/jphe/storyvox/ui/component/BrassProgressBar.kt
+++ b/core-ui/src/main/kotlin/in/jphe/storyvox/ui/component/BrassProgressBar.kt
@@ -10,6 +10,7 @@ import androidx.compose.animation.core.tween
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.progressSemantics
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
@@ -44,6 +45,13 @@ import `in`.jphe.storyvox.ui.theme.LocalReducedMotion
  * Distinct from [BrassProgressTrack], which is the **interactive** seek
  * control on the audiobook player. This component is passive — observers
  * can't drag it.
+ *
+ * Accessibility (#1156): carries [progressSemantics] so TalkBack has a
+ * non-visual equivalent for the brass-on-rail drawing — the determinate
+ * fraction is announced as a percentage; the indeterminate forms mark the
+ * node busy. Without it the pure `drawBehind` rail is invisible to a
+ * screen reader (WCAG 1.1.1 / 4.1.3). Status text at the call site should
+ * still carry its own `liveRegion` for the Done/Failed transitions.
  *
  * @param progress 0..1 fraction. `null` for indeterminate.
  * @param modifier sizing modifier; height defaults to 4.dp via the rail
@@ -83,6 +91,11 @@ fun BrassProgressBar(
             modifier = modifier
                 .fillMaxWidth()
                 .height(railHeight)
+                // a11y (#1156) — the bar is a pure drawBehind Box, so without
+                // this it has no non-visual equivalent (WCAG 1.1.1) and the
+                // percentage is silent everywhere the bar is used. Report the
+                // determinate fraction so TalkBack announces "N percent".
+                .progressSemantics(clamped)
                 .clip(shape)
                 .drawBehind {
                     drawRect(trackColor, size = size)
@@ -99,6 +112,9 @@ fun BrassProgressBar(
             modifier = modifier
                 .fillMaxWidth()
                 .height(railHeight)
+                // a11y (#1156) — indeterminate equivalent: marks the node as
+                // a busy progress bar so TalkBack announces "in progress".
+                .progressSemantics()
                 .clip(shape)
                 .drawBehind {
                     drawRect(trackColor, size = size)
@@ -127,6 +143,9 @@ fun BrassProgressBar(
             modifier = modifier
                 .fillMaxWidth()
                 .height(railHeight)
+                // a11y (#1156) — indeterminate equivalent for the animated
+                // comet: TalkBack announces "in progress" rather than silence.
+                .progressSemantics()
                 .clip(shape)
                 .drawBehind {
                     drawRect(trackColor, size = size)

--- a/feature/src/main/kotlin/in/jphe/storyvox/feature/chat/ChatScreen.kt
+++ b/feature/src/main/kotlin/in/jphe/storyvox/feature/chat/ChatScreen.kt
@@ -57,8 +57,10 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.alpha
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.semantics.LiveRegionMode
 import androidx.compose.ui.semantics.Role
 import androidx.compose.ui.semantics.contentDescription
+import androidx.compose.ui.semantics.liveRegion
 import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
@@ -259,6 +261,20 @@ private fun TurnBubble(
     }
     val alignment = if (isUser) Alignment.End else Alignment.Start
 
+    // a11y (#1154) — role is otherwise conveyed only by colour +
+    // alignment, so TalkBack reads the thread as one undifferentiated
+    // wall of text. Merge a spoken speaker prefix onto the bubble. When
+    // a user turn is image-only (blank text), name the image rather than
+    // announce an empty "You said:".
+    val spokenLabel = when {
+        turn.text.isNotBlank() -> stringResource(
+            if (isUser) R.string.chat_bubble_user_cd else R.string.chat_bubble_assistant_cd,
+            turn.text,
+        )
+        turn.imageUri != null -> stringResource(R.string.chat_bubble_user_image_cd)
+        else -> ""
+    }
+
     Column(
         modifier = Modifier.fillMaxWidth(),
         horizontalAlignment = alignment,
@@ -266,6 +282,7 @@ private fun TurnBubble(
         Box(
             modifier = Modifier
                 .widthIn(max = 320.dp)
+                .semantics(mergeDescendants = true) { contentDescription = spokenLabel }
                 .background(containerColor, RoundedCornerShape(12.dp))
                 .padding(horizontal = 12.dp, vertical = 8.dp),
         ) {
@@ -397,6 +414,13 @@ private fun StreamingBubble(text: String) {
         Box(
             modifier = Modifier
                 .widthIn(max = 320.dp)
+                // a11y (#1154) — Polite live region re-announces the
+                // assistant's reply as the partial grows, so a TalkBack
+                // user hears the answer stream in rather than sitting in
+                // silence. No speaker prefix here: a prefix on a region
+                // that re-fires every delta would stutter "Librarian
+                // said…" on each token.
+                .semantics { liveRegion = LiveRegionMode.Polite }
                 .background(
                     MaterialTheme.colorScheme.surfaceVariant,
                     RoundedCornerShape(12.dp),
@@ -463,6 +487,11 @@ private fun ToolCallCard(event: ToolCallEvent) {
             .fillMaxWidth()
             .semantics(mergeDescendants = true) {
                 contentDescription = statusText
+                // a11y (#1154) — the card flips in-flight → success/error
+                // with no user tap, so make it a live region; otherwise
+                // the transition is read only if focus happens to land
+                // here. Polite: a tool result is informational, not urgent.
+                liveRegion = LiveRegionMode.Polite
             }
             .border(BorderStroke(1.dp, borderColor), RoundedCornerShape(8.dp))
             .background(
@@ -768,12 +797,21 @@ private fun ChatInput(
                     )
                 }
             }
+            val inputCd = stringResource(R.string.chat_input_field_cd)
             OutlinedTextField(
                 value = text,
                 onValueChange = { text = it },
                 enabled = enabled,
                 placeholder = { Text(stringResource(R.string.chat_ask_question_placeholder)) },
-                modifier = Modifier.weight(1f),
+                // a11y (#1154) — the placeholder is announced only while
+                // the field is empty + focused; once text is present
+                // TalkBack has no name for the chat's primary input. A
+                // semantics contentDescription gives it a persistent name
+                // without adding a floating label that competes with the
+                // placeholder visually.
+                modifier = Modifier
+                    .weight(1f)
+                    .semantics { contentDescription = inputCd },
                 singleLine = false,
                 maxLines = 4,
             )
@@ -814,6 +852,9 @@ private fun ImageDroppedBanner(onDismiss: () -> Unit) {
     Row(
         modifier = Modifier
             .fillMaxWidth()
+            // a11y (#1154) — banner appears without a tap; Polite because
+            // the message still sent (this is an FYI, not a failure).
+            .semantics { liveRegion = LiveRegionMode.Polite }
             .background(MaterialTheme.colorScheme.surfaceVariant)
             .padding(horizontal = spacing.md, vertical = spacing.sm),
         verticalAlignment = Alignment.CenterVertically,
@@ -852,6 +893,9 @@ private fun ErrorBanner(
     Row(
         modifier = Modifier
             .fillMaxWidth()
+            // a11y (#1154) — Assertive: an error interrupts the user's
+            // flow and needs to preempt whatever TalkBack is reading.
+            .semantics { liveRegion = LiveRegionMode.Assertive }
             .background(MaterialTheme.colorScheme.errorContainer)
             .padding(horizontal = spacing.md, vertical = spacing.sm),
         verticalAlignment = Alignment.CenterVertically,

--- a/feature/src/main/kotlin/in/jphe/storyvox/feature/engine/VoicePickerGate.kt
+++ b/feature/src/main/kotlin/in/jphe/storyvox/feature/engine/VoicePickerGate.kt
@@ -25,7 +25,10 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.semantics.LiveRegionMode
 import androidx.compose.ui.semantics.Role
+import androidx.compose.ui.semantics.liveRegion
+import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
@@ -421,7 +424,13 @@ private fun DownloadProgressBlock(
     val spacing = LocalSpacing.current
     when (progress) {
         DownloadProgress.Resolving -> {
-            Text(stringResource(R.string.engine_voice_resolving), style = MaterialTheme.typography.bodySmall)
+            Text(
+                stringResource(R.string.engine_voice_resolving),
+                style = MaterialTheme.typography.bodySmall,
+                // a11y (#1156) — the full-screen gate blocks first launch on
+                // this download; Polite live regions speak each state change.
+                modifier = Modifier.semantics { liveRegion = LiveRegionMode.Polite },
+            )
             Spacer(Modifier.height(spacing.xs))
             // Indeterminate brass comet — the manifest fetch is brief but
             // network-flaky enough that callers sit on this state for 1-3s.
@@ -436,6 +445,9 @@ private fun DownloadProgressBlock(
             Text(
                 "Downloading… $mb MB / $totalMb MB",
                 style = MaterialTheme.typography.bodySmall,
+                // a11y (#1156) — MB figure ticks once per megabyte; Polite
+                // gives periodic progress without spamming TalkBack.
+                modifier = Modifier.semantics { liveRegion = LiveRegionMode.Polite },
             )
             Spacer(Modifier.height(spacing.xs))
             // Determinate when we know totalBytes (sherpa-onnx serves
@@ -451,6 +463,8 @@ private fun DownloadProgressBlock(
                 "Voice ready.",
                 style = MaterialTheme.typography.bodySmall,
                 color = MaterialTheme.colorScheme.primary,
+                // a11y (#1156) — "voice ready" is the unblock signal; speak it.
+                modifier = Modifier.semantics { liveRegion = LiveRegionMode.Polite },
             )
         }
         is DownloadProgress.Failed -> {
@@ -458,6 +472,9 @@ private fun DownloadProgressBlock(
                 progress.reason,
                 style = MaterialTheme.typography.bodySmall,
                 color = MaterialTheme.colorScheme.error,
+                // a11y (#1156) — Assertive: a failed download blocks first
+                // launch, so it must preempt rather than wait for focus.
+                modifier = Modifier.semantics { liveRegion = LiveRegionMode.Assertive },
             )
             Spacer(Modifier.height(spacing.xs))
             BrassButton(

--- a/feature/src/main/kotlin/in/jphe/storyvox/feature/ocr/OcrCaptureScreen.kt
+++ b/feature/src/main/kotlin/in/jphe/storyvox/feature/ocr/OcrCaptureScreen.kt
@@ -49,7 +49,9 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
 import androidx.lifecycle.compose.LocalLifecycleOwner
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.semantics.LiveRegionMode
 import androidx.compose.ui.semantics.contentDescription
+import androidx.compose.ui.semantics.liveRegion
 import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.viewinterop.AndroidView
@@ -209,6 +211,13 @@ fun OcrCaptureScreen(
                 Text(
                     stringResource(R.string.ocr_recognizing),
                     style = MaterialTheme.typography.bodyMedium,
+                    // a11y (#1155) — this screen exists so blind/low-vision
+                    // users can scan print, so "is OCR running?" must be
+                    // spoken. Assertive: the user just tapped Capture and is
+                    // waiting on exactly this feedback.
+                    modifier = Modifier.semantics {
+                        liveRegion = LiveRegionMode.Assertive
+                    },
                 )
             }
 
@@ -216,7 +225,11 @@ fun OcrCaptureScreen(
                 Surface(
                     color = MaterialTheme.colorScheme.errorContainer,
                     shape = RoundedCornerShape(12.dp),
-                    modifier = Modifier.fillMaxWidth(),
+                    // a11y (#1155) — a failed scan must be announced, not
+                    // left for a focus-walk to discover. Assertive.
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .semantics { liveRegion = LiveRegionMode.Assertive },
                 ) {
                     Text(
                         err,
@@ -245,6 +258,13 @@ fun OcrCaptureScreen(
                         state.totalWords,
                     ),
                     style = MaterialTheme.typography.labelLarge,
+                    // a11y (#1155) — re-announces the running tally after
+                    // each successful capture ("3 pages · 540 words") so a
+                    // non-visual user hears the scan landed. Polite: success
+                    // info, no need to preempt.
+                    modifier = Modifier.semantics {
+                        liveRegion = LiveRegionMode.Polite
+                    },
                 )
 
                 CapturedPagesList(

--- a/feature/src/main/kotlin/in/jphe/storyvox/feature/onboarding/VoicePickerOnboarding.kt
+++ b/feature/src/main/kotlin/in/jphe/storyvox/feature/onboarding/VoicePickerOnboarding.kt
@@ -29,8 +29,10 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.semantics.LiveRegionMode
 import androidx.compose.ui.semantics.Role
 import androidx.compose.ui.semantics.contentDescription
+import androidx.compose.ui.semantics.liveRegion
 import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.text.font.FontFamily
 import androidx.compose.ui.text.font.FontWeight
@@ -412,6 +414,10 @@ private fun FriendlyDownloadProgress(
             Text(
                 stringResource(R.string.onboarding_voice_download_resolving, voiceName),
                 style = MaterialTheme.typography.bodySmall,
+                // a11y (#1156) — first-run is gated on this download with
+                // zero feedback otherwise; Polite live regions speak each
+                // state change (resolving → downloading → done/failed).
+                modifier = Modifier.semantics { liveRegion = LiveRegionMode.Polite },
             )
             Spacer(Modifier.height(spacing.xs))
             BrassProgressBar(progress = null, modifier = Modifier.fillMaxWidth())
@@ -425,6 +431,9 @@ private fun FriendlyDownloadProgress(
             Text(
                 stringResource(R.string.onboarding_voice_downloading, voiceName, mb.toInt(), totalMb.toInt()),
                 style = MaterialTheme.typography.bodySmall,
+                // a11y (#1156) — the MB figure ticks once per megabyte, so
+                // Polite gives periodic "X / Y MB" progress without spamming.
+                modifier = Modifier.semantics { liveRegion = LiveRegionMode.Polite },
             )
             Spacer(Modifier.height(spacing.xs))
             BrassProgressBar(
@@ -437,6 +446,8 @@ private fun FriendlyDownloadProgress(
                 stringResource(R.string.onboarding_voice_download_done, voiceName),
                 style = MaterialTheme.typography.bodySmall,
                 color = MaterialTheme.colorScheme.primary,
+                // a11y (#1156) — "voice ready" is the unblock signal; speak it.
+                modifier = Modifier.semantics { liveRegion = LiveRegionMode.Polite },
             )
         }
         is VoiceManager.DownloadProgress.Failed -> {
@@ -444,6 +455,9 @@ private fun FriendlyDownloadProgress(
                 stringResource(R.string.onboarding_voice_download_failed, voiceName, progress.reason),
                 style = MaterialTheme.typography.bodySmall,
                 color = MaterialTheme.colorScheme.error,
+                // a11y (#1156) — Assertive: a failed download blocks first
+                // run, so it must preempt rather than wait for focus.
+                modifier = Modifier.semantics { liveRegion = LiveRegionMode.Assertive },
             )
             Spacer(Modifier.height(spacing.xs))
             BrassButton(

--- a/feature/src/main/kotlin/in/jphe/storyvox/feature/voicelibrary/VoiceLibraryScreen.kt
+++ b/feature/src/main/kotlin/in/jphe/storyvox/feature/voicelibrary/VoiceLibraryScreen.kt
@@ -69,9 +69,11 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.semantics.LiveRegionMode
 import androidx.compose.ui.semantics.Role
 import androidx.compose.ui.semantics.clearAndSetSemantics
 import androidx.compose.ui.semantics.contentDescription
+import androidx.compose.ui.semantics.liveRegion
 import androidx.compose.ui.semantics.onClick
 import androidx.compose.ui.semantics.role
 import androidx.compose.ui.semantics.selected
@@ -1393,6 +1395,10 @@ private fun FailedDownloadSubtile(
     Column(
         modifier = Modifier
             .fillMaxWidth()
+            // a11y (#1156) — the failure tile appears without a tap when a
+            // download dies; Assertive so TalkBack speaks the failure +
+            // retry affordance rather than leaving it for a focus-walk.
+            .semantics { liveRegion = LiveRegionMode.Assertive }
             .clip(RoundedCornerShape(8.dp))
             .background(MaterialTheme.colorScheme.errorContainer.copy(alpha = 0.55f))
             .padding(spacing.sm),

--- a/feature/src/main/res/values/strings.xml
+++ b/feature/src/main/res/values/strings.xml
@@ -381,6 +381,13 @@
     <string name="chat_attached_image_cd">Attached image</string>
     <string name="chat_read_aloud_stop">Stop reading</string>
     <string name="chat_read_aloud_play">Read aloud</string>
+    <!-- Chat · a11y speaker labels (#1154). Merged onto each bubble so
+         TalkBack distinguishes who said what instead of reading the
+         conversation as an undifferentiated wall of text. -->
+    <string name="chat_bubble_user_cd">You said: %1$s</string>
+    <string name="chat_bubble_assistant_cd">Librarian said: %1$s</string>
+    <string name="chat_bubble_user_image_cd">You sent an image</string>
+    <string name="chat_input_field_cd">Message to the librarian</string>
     <!-- Chat · tool-call in-flight copy (#216) -->
     <string name="chat_tool_in_flight_add_to_shelf">Adding to shelf…</string>
     <string name="chat_tool_in_flight_queue_chapter">Queueing chapter…</string>


### PR DESCRIPTION
## Summary

Adds TalkBack live-region announcements (and progress-bar semantics) to three streaming/async surfaces that were previously silent to screen-reader users. Closes #1154, #1155, #1156.

The shared idiom: `Modifier.semantics { liveRegion = LiveRegionMode.Polite }` (or `Assertive` for errors) on status content that changes without a user tap — mirroring the existing `OnboardingScaffold` / `PlaybackErrorBanner` / `SyncAuthScreen` usage.

## #1154 — Chat (`ChatScreen.kt`)
- **Streaming reply** → `StreamingBubble` gets a Polite live region so the assistant's answer is read as it streams in (no speaker prefix — would stutter on every token).
- **Tool-call card** → Polite live region added to the existing semantics block so in-flight→success/error transitions are spoken.
- **Banners** → error banner Assertive, image-dropped banner Polite.
- **Bubbles** → merged speaker prefix ("You said: …" / "Librarian said: …"); image-only user turns announce "You sent an image". New string resources.
- **Message input** → persistent `contentDescription` (the placeholder is announced only while empty + focused). Kept as semantics rather than a floating label to preserve the visual.

## #1155 — OCR (`OcrCaptureScreen.kt`)
- "Recognizing…" text and the error Surface → **Assertive** (the user just tapped Capture and is waiting on exactly this).
- Pages summary → **Polite**, re-announces "N pages · M words" after each successful capture.

## #1156 — Voice download (onboarding, gate, Voice Library)
- **`BrassProgressBar` (core-ui)** → `progressSemantics()` added once at the root. The bar was a pure `drawBehind` Box with no non-visual equivalent (WCAG 1.1.1); now the determinate fraction is announced as a percentage and indeterminate forms mark the node busy. Fixes all three call sites' shared root cause.
- **Status text** in the onboarding picker, first-launch gate, and Voice Library failure tile → Polite (resolving / downloading / done) and Assertive (failed) live regions. The MB figure ticks once per megabyte, so Polite gives periodic progress without spamming.

## WCAG
4.1.3 Status Messages (AA), 1.3.1 / 4.1.2 (A) for the chat speaker labels, 1.1.1 Non-text Content (A) for the progress bar.

## Testing
Not compiled locally — CI on the self-hosted runner validates. Changes are additive semantics modifiers + 4 new string resources; no logic paths touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
