### PR TITLE
fix(a11y): merge cards, picker selected-state, minor a11y polish (#1153, #1157, #1161)

### DIFF
--- a/core-ui/src/main/kotlin/in/jphe/storyvox/ui/component/BrassButton.kt
+++ b/core-ui/src/main/kotlin/in/jphe/storyvox/ui/component/BrassButton.kt
@@ -17,6 +17,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.alpha
 import androidx.compose.ui.semantics.Role
 import androidx.compose.ui.semantics.role
+import androidx.compose.ui.semantics.selected
 import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.unit.dp
 import `in`.jphe.storyvox.ui.a11y.LocalAccessibleTouchTargets
@@ -50,6 +51,20 @@ fun BrassButton(
     variant: BrassButtonVariant = BrassButtonVariant.Primary,
     enabled: Boolean = true,
     loading: Boolean = false,
+    /**
+     * #1157 — single-choice picker support. The codebase uses a row of
+     * BrassButtons (selected = [BrassButtonVariant.Primary], the rest
+     * [BrassButtonVariant.Secondary]) as a radio-group idiom in several
+     * settings pickers (cache size, AI provider/model, pronunciation
+     * match type). Pre-fix the selection was conveyed by fill colour
+     * only: TalkBack announced every option as a plain "button" with no
+     * "selected" state (WCAG 4.1.2) and the cue failed colour-only
+     * contrast (WCAG 1.4.1). When non-null this flips the button's
+     * a11y role from [Role.Button] to [Role.RadioButton] and publishes
+     * the `selected` state so TalkBack reads "<label>, selected, radio
+     * button". Leave null for ordinary action buttons.
+     */
+    selected: Boolean? = null,
 ) {
     // #690 Phase 2 — under [LocalAccessibleTouchTargets], grow the
     // button's minimum height from the M3 default 40dp to 64dp so
@@ -65,7 +80,19 @@ fun BrassButton(
     // text="" content-desc="" and flags NAF (the network-error retry
     // button under Browse → Hacker News was the report site, but every
     // BrassButton was affected).
-    val baseSem = Modifier.semantics(mergeDescendants = true) { role = Role.Button }
+    // #1157 — when `selected` is supplied the button is part of a
+    // single-choice picker, so expose it as a radio button with state;
+    // otherwise it stays a plain action button. mergeDescendants stays
+    // true either way so the inner Text(label) reaches the a11y tree
+    // (#743 canary [brassButtonMergesDescendantsForLabel]).
+    val baseSem = Modifier.semantics(mergeDescendants = true) {
+        if (selected != null) {
+            role = Role.RadioButton
+            this.selected = selected
+        } else {
+            role = Role.Button
+        }
+    }
     val sem = if (enlarged) {
         baseSem.then(Modifier.defaultMinSize(minHeight = 64.dp))
     } else {

--- a/feature/src/main/kotlin/in/jphe/storyvox/feature/browse/BrowseScreen.kt
+++ b/feature/src/main/kotlin/in/jphe/storyvox/feature/browse/BrowseScreen.kt
@@ -694,6 +694,12 @@ fun BrowseScreen(
 
 @Composable
 private fun FilterButton(activeCount: Int, onClick: () -> Unit) {
+    // #1161 — the active-filter count lives in a BadgedBox Badge, whose
+    // content TalkBack doesn't reliably surface; the IconButton's
+    // contentDescription stayed the literal "Filter" so a blind user
+    // couldn't tell filters were active. Fold the count into the icon's
+    // description (WCAG 4.1.2 / 1.3.1).
+    val filterCd = if (activeCount > 0) "Filter, $activeCount active" else "Filter"
     // UI-test selector for the filter entrypoint. Same tag on both
     // branches (badged vs. plain) so a flow addresses `browse-filter`
     // regardless of whether any filter is currently active.
@@ -707,12 +713,12 @@ private fun FilterButton(activeCount: Int, onClick: () -> Unit) {
             },
         ) {
             IconButton(onClick = onClick, modifier = Modifier.testTag(TestTags.BrowseFilter)) {
-                Icon(Icons.Outlined.FilterAlt, contentDescription = "Filter")
+                Icon(Icons.Outlined.FilterAlt, contentDescription = filterCd)
             }
         }
     } else {
         IconButton(onClick = onClick, modifier = Modifier.testTag(TestTags.BrowseFilter)) {
-            Icon(Icons.Outlined.FilterAlt, contentDescription = "Filter")
+            Icon(Icons.Outlined.FilterAlt, contentDescription = filterCd)
         }
     }
 }

--- a/feature/src/main/kotlin/in/jphe/storyvox/feature/fiction/FictionDetailScreen.kt
+++ b/feature/src/main/kotlin/in/jphe/storyvox/feature/fiction/FictionDetailScreen.kt
@@ -61,6 +61,7 @@ import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalFocusManager
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.semantics.LiveRegionMode
+import androidx.compose.ui.semantics.clearAndSetSemantics
 import androidx.compose.ui.semantics.contentDescription
 import androidx.compose.ui.semantics.liveRegion
 import androidx.compose.ui.semantics.semantics
@@ -1069,9 +1070,25 @@ private fun Hero(fiction: UiFiction) {
             // visible at every width, and on wider devices the
             // single-line layout is unchanged because no wrap is
             // triggered.
+            // #1153 — pre-fix the hero metadata read as a string of
+            // disconnected TalkBack tokens: a decorative Star, a bare
+            // "4.5", literal "·" separators, then chapter count + status.
+            // Merge the FlowRow into one curated phrase ("Rated 4.5, 38
+            // chapters, Ongoing") and mark the separators decorative. No
+            // tap action lives here, so clearAndSetSemantics is safe.
+            val statusLabel = if (fiction.isOngoing) "Ongoing" else "Completed"
+            val heroMetaDescription =
+                "Rated %.1f, %d chapters, %s".format(
+                    fiction.rating,
+                    fiction.chapterCount,
+                    statusLabel,
+                )
             FlowRow(
                 horizontalArrangement = Arrangement.spacedBy(spacing.xxs),
                 verticalArrangement = Arrangement.spacedBy(spacing.xxs),
+                modifier = Modifier.clearAndSetSemantics {
+                    contentDescription = heroMetaDescription
+                },
             ) {
                 Row(
                     verticalAlignment = Alignment.CenterVertically,

--- a/feature/src/main/kotlin/in/jphe/storyvox/feature/follows/FollowsScreen.kt
+++ b/feature/src/main/kotlin/in/jphe/storyvox/feature/follows/FollowsScreen.kt
@@ -25,6 +25,10 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.semantics.Role
+import androidx.compose.ui.semantics.clearAndSetSemantics
+import androidx.compose.ui.semantics.contentDescription
+import androidx.compose.ui.semantics.onClick
+import androidx.compose.ui.semantics.role
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
@@ -308,9 +312,32 @@ private fun FollowCardSkeleton() {
 @Composable
 private fun FollowCard(follow: UiFollow, onClick: () -> Unit) {
     val spacing = LocalSpacing.current
+    // #1153 — merge the cover + title + author + unread badge into a single
+    // curated TalkBack stop (was up to four fragmented stops). The unread
+    // count rendered as a bare Badge number with no context; fold it into
+    // the description so TalkBack says "3 unread chapters" rather than "3".
+    // clearAndSetSemantics sits on the SAME modifier as the clickable so the
+    // card keeps its open action (ChapterCard #612 pattern).
+    val cardDescription = buildString {
+        append(follow.fiction.title)
+        if (follow.fiction.author.isNotBlank()) append(", by ${follow.fiction.author}")
+        if (follow.unreadCount > 0) {
+            append(
+                if (follow.unreadCount == 1) ", 1 unread chapter"
+                else ", ${follow.unreadCount} unread chapters",
+            )
+        }
+    }
     Card(
         // a11y (#481): Role.Button for the card-level tap target.
-        modifier = Modifier.fillMaxWidth().clickable(role = Role.Button) { onClick() },
+        modifier = Modifier
+            .fillMaxWidth()
+            .clickable(role = Role.Button, onClickLabel = "Open") { onClick() }
+            .clearAndSetSemantics {
+                role = Role.Button
+                contentDescription = cardDescription
+                onClick(label = "Open") { onClick(); true }
+            },
         colors = CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.surfaceContainer),
         shape = MaterialTheme.shapes.medium,
     ) {

--- a/feature/src/main/kotlin/in/jphe/storyvox/feature/library/LibraryScreen.kt
+++ b/feature/src/main/kotlin/in/jphe/storyvox/feature/library/LibraryScreen.kt
@@ -44,9 +44,14 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.semantics.Role
+import androidx.compose.ui.semantics.clearAndSetSemantics
+import androidx.compose.ui.semantics.contentDescription
+import androidx.compose.ui.semantics.onClick
+import androidx.compose.ui.semantics.onLongClick
 import androidx.compose.ui.semantics.role
 import androidx.compose.ui.semantics.selected
 import androidx.compose.ui.semantics.semantics
+import androidx.compose.ui.semantics.stateDescription
 import androidx.compose.ui.unit.dp
 import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
@@ -652,7 +657,17 @@ private fun ResumeCard(entry: ContinueListeningEntry, onResume: () -> Unit) {
         shape = MaterialTheme.shapes.large,
     ) {
         Row(
-            modifier = Modifier.padding(spacing.md).fillMaxSize(),
+            // #1153 — merge the cover + text column into one TalkBack stop
+            // instead of four (cover, "Resume" label, title, chapter,
+            // progress). The Resume BrassButton is its own merging
+            // semantics node so it stays a separate, actionable stop — we
+            // can't clearAndSetSemantics here without wiping that action,
+            // so mergeDescendants is the right tool for a card whose action
+            // is a child button rather than a whole-card tap.
+            modifier = Modifier
+                .padding(spacing.md)
+                .fillMaxSize()
+                .semantics(mergeDescendants = true) {},
             verticalAlignment = Alignment.CenterVertically,
             horizontalArrangement = Arrangement.spacedBy(spacing.md),
         ) {
@@ -662,7 +677,12 @@ private fun ResumeCard(entry: ContinueListeningEntry, onResume: () -> Unit) {
                 monogram = fictionMonogram(entry.fiction.author, entry.fiction.title),
                 author = entry.fiction.author,
                 sourceFamily = coverSourceFamilyFor(entry.fiction.sourceId),
-                modifier = Modifier.size(width = 68.dp, height = 100.dp),
+                // Decorative under the merged row — the title is already
+                // spoken by the text column, so suppress the thumb's
+                // "Cover for {title}" to avoid a duplicate readout.
+                modifier = Modifier
+                    .size(width = 68.dp, height = 100.dp)
+                    .clearAndSetSemantics {},
             )
             Column(modifier = Modifier.weight(1f)) {
                 Text(stringResource(R.string.library_resume), style = MaterialTheme.typography.labelMedium, color = MaterialTheme.colorScheme.primary)
@@ -1061,15 +1081,52 @@ private fun LibraryGridBody(
             }
         }
         itemsIndexed(dedupedFictions, key = { _, item -> item.id }) { index, fiction ->
+            // #1153 — pre-fix the combinedClickable lived on the cover thumb
+            // only, so TalkBack split each tile into a tappable "Cover for
+            // {title}, button" stop plus separate non-clickable title/author
+            // text stops, and the long-press manage-shelves action had no
+            // spoken hint. Move the tap target onto the whole Column (title +
+            // author now live inside it) and curate a single merged
+            // announcement via clearAndSetSemantics, mirroring ChapterCard
+            // (#612). clearAndSetSemantics also wipes the test tag, so it's
+            // re-set inside the block.
+            val itemDescription = when {
+                fiction.isPlaceholder && fiction.backfillFailed ->
+                    "${fiction.title}, couldn't load, tap to retry"
+                fiction.isPlaceholder -> "${fiction.title}, loading"
+                fiction.author.isNotBlank() -> "${fiction.title}, by ${fiction.author}"
+                else -> fiction.title
+            }
             Column(
                 modifier = Modifier
                     .fillMaxWidth()
-                    // UI-test selector for an individual library tile. Every
-                    // fiction cell carries the same `library-item` tag; flows
-                    // select the first match (or count) rather than by title.
-                    .testTag(TestTags.LibraryItem)
                     .animateItem()
-                    .cascadeReveal(index = index, key = fiction.id),
+                    .cascadeReveal(index = index, key = fiction.id)
+                    // Long-press → manage-shelves bottom sheet (#116).
+                    // Tap → fiction detail (#908): always opens the
+                    // detail page (chapter list, metadata). The #827
+                    // resume-or-open shortcut was reverted because it
+                    // skipped the detail page unexpectedly.
+                    .combinedClickable(
+                        role = Role.Button,
+                        onClickLabel = "Open",
+                        onLongClickLabel = "Manage shelves",
+                        onClick = { onTapFiction(fiction.id) },
+                        onLongClick = { onLongPress(fiction) },
+                    )
+                    .clearAndSetSemantics {
+                        // UI-test selector for an individual library tile.
+                        // Every fiction cell carries the same `library-item`
+                        // tag; flows select the first match (or count) rather
+                        // than by title.
+                        testTag = TestTags.LibraryItem
+                        role = Role.Button
+                        contentDescription = itemDescription
+                        onClick(label = "Open") { onTapFiction(fiction.id); true }
+                        onLongClick(label = "Manage shelves") {
+                            onLongPress(fiction); true
+                        }
+                    },
                 horizontalAlignment = Alignment.Start,
                 verticalArrangement = Arrangement.spacedBy(spacing.xs),
             ) {
@@ -1079,17 +1136,7 @@ private fun LibraryGridBody(
                     monogram = fictionMonogram(fiction.author, fiction.title),
                     author = fiction.author,
                     sourceFamily = coverSourceFamilyFor(fiction.sourceId),
-                    // Long-press → manage-shelves bottom sheet (#116).
-                    // Tap → fiction detail (#908): always opens the
-                    // detail page (chapter list, metadata). The #827
-                    // resume-or-open shortcut was reverted because it
-                    // skipped the detail page unexpectedly.
-                    modifier = Modifier
-                        .fillMaxWidth()
-                        .combinedClickable(
-                            onClick = { onTapFiction(fiction.id) },
-                            onLongClick = { onLongPress(fiction) },
-                        ),
+                    modifier = Modifier.fillMaxWidth(),
                 )
                 // Issue #981 — a synced placeholder row (added on another
                 // device, not yet hydrated by MetadataBackfillWorker)
@@ -1180,11 +1227,32 @@ private fun HistoryList(
 @Composable
 private fun HistoryRow(entry: HistoryEntry, onClick: () -> Unit) {
     val spacing = LocalSpacing.current
+    val fictionTitle = entry.fictionTitle ?: "(removed)"
+    // Match Resume card formatting: "Ch. N · title" with the
+    // dangling-separator guard for blank titles (see #265).
+    val chapterLabel = buildString {
+        entry.chapterIndex?.let { append("Ch. $it") }
+        val title = entry.chapterTitle.orEmpty()
+        if (entry.chapterIndex != null && title.isNotBlank()) append(" · ")
+        if (title.isNotBlank()) append(title)
+        if (isEmpty()) append("(chapter removed)")
+    }
+    val timeLabel = relativeTimeLabel(entry.openedAt)
+    // #1153 — merge the cover + title + chapter + timestamp into a single
+    // curated TalkBack stop (was four fragmented stops). clearAndSetSemantics
+    // sits on the SAME modifier as the clickable so the row keeps its open
+    // action (ChapterCard #612 pattern).
+    val rowDescription = "$fictionTitle, $chapterLabel, $timeLabel"
     Card(
         // a11y (#481): Role.Button for the history-row open tap.
         modifier = Modifier
             .fillMaxWidth()
-            .clickable(role = Role.Button, onClick = onClick),
+            .clickable(role = Role.Button, onClickLabel = "Open", onClick = onClick)
+            .clearAndSetSemantics {
+                role = Role.Button
+                contentDescription = rowDescription
+                onClick(label = "Open") { onClick(); true }
+            },
         colors = CardDefaults.cardColors(
             containerColor = MaterialTheme.colorScheme.surfaceContainerHigh,
             contentColor = MaterialTheme.colorScheme.onSurface,
@@ -1208,20 +1276,11 @@ private fun HistoryRow(entry: HistoryEntry, onClick: () -> Unit) {
             )
             Column(modifier = Modifier.weight(1f)) {
                 Text(
-                    text = entry.fictionTitle ?: "(removed)",
+                    text = fictionTitle,
                     style = MaterialTheme.typography.titleSmall,
                     maxLines = 1,
                     overflow = androidx.compose.ui.text.style.TextOverflow.Ellipsis,
                 )
-                // Match Resume card formatting: "Ch. N · title" with the
-                // dangling-separator guard for blank titles (see #265).
-                val chapterLabel = buildString {
-                    entry.chapterIndex?.let { append("Ch. $it") }
-                    val title = entry.chapterTitle.orEmpty()
-                    if (entry.chapterIndex != null && title.isNotBlank()) append(" · ")
-                    if (title.isNotBlank()) append(title)
-                    if (isEmpty()) append("(chapter removed)")
-                }
                 Text(
                     text = chapterLabel,
                     style = MaterialTheme.typography.bodySmall,
@@ -1230,7 +1289,7 @@ private fun HistoryRow(entry: HistoryEntry, onClick: () -> Unit) {
                     overflow = androidx.compose.ui.text.style.TextOverflow.Ellipsis,
                 )
                 Text(
-                    text = relativeTimeLabel(entry.openedAt),
+                    text = timeLabel,
                     style = MaterialTheme.typography.labelSmall,
                     color = MaterialTheme.colorScheme.primary,
                 )
@@ -1386,11 +1445,31 @@ private fun InboxList(
 @Composable
 private fun InboxRow(event: InboxEvent, onClick: () -> Unit) {
     val spacing = LocalSpacing.current
+    val source = event.sourceId.replaceFirstChar { it.uppercase() }
+    val timeLabel = relativeTimeLabel(event.ts)
+    val body = event.body?.takeIf { it.isNotBlank() }
+    // #1153 — merge the title + body + source + timestamp into a single
+    // curated TalkBack stop, and surface read/unread as a real semantic
+    // state. Pre-fix unread was conveyed by a brighter container colour
+    // only, which TalkBack can't perceive and which fails colour-only
+    // (WCAG 1.4.1). clearAndSetSemantics sits on the SAME modifier as the
+    // clickable so the row keeps its open action (ChapterCard #612 pattern).
+    val rowDescription = buildString {
+        append(event.title)
+        if (body != null) append(", $body")
+        append(", $source, $timeLabel")
+    }
     Card(
         // a11y (#481): Role.Button for the inbox-row open tap.
         modifier = Modifier
             .fillMaxWidth()
-            .clickable(role = Role.Button, onClick = onClick),
+            .clickable(role = Role.Button, onClickLabel = "Open", onClick = onClick)
+            .clearAndSetSemantics {
+                role = Role.Button
+                contentDescription = rowDescription
+                stateDescription = if (event.isRead) "Read" else "Unread"
+                onClick(label = "Open") { onClick(); true }
+            },
         colors = CardDefaults.cardColors(
             // Quiet visual cue: unread events sit slightly brighter so
             // a quick scan tells the user where to look.
@@ -1430,9 +1509,9 @@ private fun InboxRow(event: InboxEvent, onClick: () -> Unit) {
                     maxLines = 2,
                     overflow = androidx.compose.ui.text.style.TextOverflow.Ellipsis,
                 )
-                event.body?.takeIf { it.isNotBlank() }?.let { body ->
+                body?.let { bodyText ->
                     Text(
-                        text = body,
+                        text = bodyText,
                         style = MaterialTheme.typography.bodySmall,
                         color = MaterialTheme.colorScheme.onSurfaceVariant,
                         maxLines = 2,
@@ -1444,7 +1523,7 @@ private fun InboxRow(event: InboxEvent, onClick: () -> Unit) {
                     horizontalArrangement = Arrangement.spacedBy(spacing.xs),
                 ) {
                     Text(
-                        text = event.sourceId.replaceFirstChar { it.uppercase() },
+                        text = source,
                         style = MaterialTheme.typography.labelSmall,
                         color = MaterialTheme.colorScheme.onSurfaceVariant,
                     )
@@ -1454,7 +1533,7 @@ private fun InboxRow(event: InboxEvent, onClick: () -> Unit) {
                         color = MaterialTheme.colorScheme.onSurfaceVariant,
                     )
                     Text(
-                        text = relativeTimeLabel(event.ts),
+                        text = timeLabel,
                         style = MaterialTheme.typography.labelSmall,
                         color = MaterialTheme.colorScheme.primary,
                     )

--- a/feature/src/main/kotlin/in/jphe/storyvox/feature/library/LibraryScreen.kt
+++ b/feature/src/main/kotlin/in/jphe/storyvox/feature/library/LibraryScreen.kt
@@ -1114,12 +1114,8 @@ private fun LibraryGridBody(
                         onClick = { onTapFiction(fiction.id) },
                         onLongClick = { onLongPress(fiction) },
                     )
+                    .testTag(TestTags.LibraryItem)
                     .clearAndSetSemantics {
-                        // UI-test selector for an individual library tile.
-                        // Every fiction cell carries the same `library-item`
-                        // tag; flows select the first match (or count) rather
-                        // than by title.
-                        testTag = TestTags.LibraryItem
                         role = Role.Button
                         contentDescription = itemDescription
                         onClick(label = "Open") { onTapFiction(fiction.id); true }

--- a/feature/src/main/kotlin/in/jphe/storyvox/feature/library/LibrarySortChip.kt
+++ b/feature/src/main/kotlin/in/jphe/storyvox/feature/library/LibrarySortChip.kt
@@ -22,6 +22,7 @@ import androidx.compose.ui.semantics.Role
 import androidx.compose.ui.semantics.contentDescription
 import androidx.compose.ui.semantics.role
 import androidx.compose.ui.semantics.semantics
+import androidx.compose.ui.semantics.stateDescription
 import androidx.compose.ui.unit.dp
 import `in`.jphe.storyvox.feature.R
 
@@ -46,6 +47,12 @@ fun LibrarySortChip(
 ) {
     var expanded by remember { mutableStateOf(false) }
     val chipCd = stringResource(R.string.library_sort_chip_cd)
+    // #1157 — the static contentDescription ("Sort library") used to
+    // *override* the visible active-mode label, so TalkBack never spoke
+    // the current sort. Publish the active mode as the node's state so
+    // it announces "Sort library, Recently added" instead of just
+    // "Sort library, button".
+    val currentSortLabel = labelFor(selected)
     Box(modifier = modifier) {
         AssistChip(
             onClick = { expanded = true },
@@ -65,6 +72,7 @@ fun LibrarySortChip(
             modifier = Modifier.semantics {
                 role = Role.Button
                 contentDescription = chipCd
+                stateDescription = currentSortLabel
             },
         )
         DropdownMenu(

--- a/feature/src/main/kotlin/in/jphe/storyvox/feature/settings/PerformanceSettingsScreen.kt
+++ b/feature/src/main/kotlin/in/jphe/storyvox/feature/settings/PerformanceSettingsScreen.kt
@@ -245,6 +245,9 @@ private fun CacheSizeSelector(
                     label = CacheQuotaOptions.label(opt),
                     onClick = { onQuotaChange(opt) },
                     variant = variant,
+                    // #1157 — radio-group semantics for this single-choice
+                    // cache-size picker (kdoc above calls these radio buttons).
+                    selected = opt == quotaBytes,
                     modifier = Modifier.weight(1f),
                 )
             }

--- a/feature/src/main/kotlin/in/jphe/storyvox/feature/settings/ReadingSettingsScreen.kt
+++ b/feature/src/main/kotlin/in/jphe/storyvox/feature/settings/ReadingSettingsScreen.kt
@@ -25,7 +25,10 @@ import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.toArgb
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.semantics.Role
 import androidx.compose.ui.semantics.contentDescription
+import androidx.compose.ui.semantics.role
+import androidx.compose.ui.semantics.selected
 import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.semantics.stateDescription
 import androidx.compose.ui.text.font.FontWeight
@@ -202,7 +205,15 @@ private fun HighlightGroup(
                     color = MaterialTheme.colorScheme.primary,
                     modifier = Modifier
                         .padding(horizontal = spacing.md)
-                        .clickable { onSetWordColor(0) },
+                        // #1161 — this is a tappable reset link, not static
+                        // text. Give it the Button role + an onClickLabel so
+                        // TalkBack announces it as actionable (WCAG 4.1.2).
+                        .clickable(
+                            role = Role.Button,
+                            onClickLabel = stringResource(
+                                R.string.settings_highlight_color_reset_a11y,
+                            ),
+                        ) { onSetWordColor(0) },
                 )
             }
         }
@@ -318,7 +329,14 @@ private fun ThemeChip(
             .border(borderWidth, borderColor, RoundedCornerShape(10.dp))
             .background(bg)
             .clickable(onClick = onClick)
-            .semantics { contentDescription = cd }
+            // #1157 — single-choice theme picker. Pre-fix the selected
+            // theme was conveyed by border colour only (WCAG 1.4.1) and
+            // TalkBack announced no "selected" state (WCAG 4.1.2).
+            .semantics {
+                role = Role.RadioButton
+                this.selected = selected
+                contentDescription = cd
+            }
             .padding(vertical = 10.dp, horizontal = 6.dp),
         horizontalAlignment = Alignment.CenterHorizontally,
         verticalArrangement = Arrangement.spacedBy(4.dp),

--- a/feature/src/main/kotlin/in/jphe/storyvox/feature/settings/SettingsScreen.kt
+++ b/feature/src/main/kotlin/in/jphe/storyvox/feature/settings/SettingsScreen.kt
@@ -2345,6 +2345,8 @@ private fun ProviderChip(label: String, selected: Boolean, onClick: () -> Unit) 
         label = label,
         onClick = onClick,
         variant = if (selected) BrassButtonVariant.Primary else BrassButtonVariant.Secondary,
+        // #1157 — AI-provider picker is single-choice; expose radio state.
+        selected = selected,
     )
 }
 
@@ -2429,6 +2431,8 @@ private fun ClaudeProviderRows(
                     label = m.removePrefix("claude-"),
                     onClick = { onSetClaudeModel(m) },
                     variant = if (ai.claudeModel == m) BrassButtonVariant.Primary else BrassButtonVariant.Secondary,
+                    // #1157 — single-choice model picker; expose radio state.
+                    selected = ai.claudeModel == m,
                 )
             }
         }
@@ -2508,6 +2512,8 @@ private fun OpenAiProviderRows(
                     label = m,
                     onClick = { onSetOpenAiModel(m) },
                     variant = if (ai.openAiModel == m) BrassButtonVariant.Primary else BrassButtonVariant.Secondary,
+                    // #1157 — single-choice model picker; expose radio state.
+                    selected = ai.openAiModel == m,
                 )
             }
         }
@@ -2740,6 +2746,8 @@ private fun VertexProviderRows(
                     label = m.removePrefix("gemini-"),
                     onClick = { onSetVertexModel(m) },
                     variant = if (ai.vertexModel == m) BrassButtonVariant.Primary else BrassButtonVariant.Secondary,
+                    // #1157 — single-choice model picker; expose radio state.
+                    selected = ai.vertexModel == m,
                 )
             }
         }

--- a/feature/src/main/kotlin/in/jphe/storyvox/feature/settings/plugins/PluginManagerScreen.kt
+++ b/feature/src/main/kotlin/in/jphe/storyvox/feature/settings/plugins/PluginManagerScreen.kt
@@ -47,8 +47,11 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.semantics.Role
+import androidx.compose.ui.semantics.clearAndSetSemantics
 import androidx.compose.ui.semantics.contentDescription
 import androidx.compose.ui.semantics.semantics
+import androidx.compose.ui.semantics.text
+import androidx.compose.ui.text.AnnotatedString
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
@@ -378,6 +381,13 @@ private fun PluginCard(
 
 @Composable
 private fun CapabilityChip(label: String) {
+    // #1161 — these chips are purely informational (Search / Follow /
+    // Audio / Text / Local / Cloud / "N voices" / "Coming soon"), but
+    // wrapping an AssistChip(onClick = {}) made TalkBack announce each as
+    // an actionable "<label>, button" and gave Switch Access a dead focus
+    // stop on a no-op (WCAG 4.1.2 — false interactive role). Keep the
+    // visual chip, but collapse its a11y node to plain text so it reads
+    // as a label, not a control.
     AssistChip(
         onClick = {},
         label = {
@@ -389,6 +399,7 @@ private fun CapabilityChip(label: String) {
         colors = AssistChipDefaults.assistChipColors(
             containerColor = MaterialTheme.colorScheme.surfaceVariant,
         ),
+        modifier = Modifier.clearAndSetSemantics { text = AnnotatedString(label) },
     )
 }
 

--- a/feature/src/main/kotlin/in/jphe/storyvox/feature/settings/pronunciation/PronunciationDictScreen.kt
+++ b/feature/src/main/kotlin/in/jphe/storyvox/feature/settings/pronunciation/PronunciationDictScreen.kt
@@ -265,6 +265,9 @@ private fun EntryEditorDialog(
                             label = mt.label(),
                             onClick = { matchType = mt },
                             variant = variant,
+                            // #1157 — radio-group semantics for the
+                            // single-choice match-type picker.
+                            selected = matchType == mt,
                         )
                     }
                 }

--- a/feature/src/main/res/values/strings.xml
+++ b/feature/src/main/res/values/strings.xml
@@ -639,6 +639,8 @@
     <string name="settings_highlight_color_theme">Using the reading theme color</string>
     <string name="settings_highlight_color_custom">Custom color</string>
     <string name="settings_highlight_color_reset">Use theme color</string>
+    <!-- #1161 — TalkBack onClickLabel for the highlight-color reset link. -->
+    <string name="settings_highlight_color_reset_a11y">Reset highlight color to theme accent</string>
 
     <!-- Settings · Cloud voices subscreen -->
     <string name="settings_cloud_voices_title">Cloud voices</string>


### PR DESCRIPTION
Closes #1153, #1157, #1161.

Three related accessibility issues from the deep audit, grouped because they share the same Compose semantics patterns (descendant merge, `selected`/`stateDescription`, role correction).

## #1153 — list/grid cards split into 3-5 TalkBack stops
Carries the `ChapterCard` (#612) merge pattern to the rest of the rows so each book reads as one coherent stop instead of fragmented cover/title/author/badge stops.

- **Library grid item** (worst case): moved `combinedClickable` off the cover thumb onto the whole `Column` (title + author now inside the tap target); curated single announcement via `clearAndSetSemantics`; added `onLongClickLabel = "Manage shelves"`; re-set the `library-item` test tag inside the cleared block so UI selectors keep working.
- **HistoryRow / InboxRow / FollowCard**: curated merged description on the same modifier as the click handler (keeps the open action).
- **ResumeCard**: `mergeDescendants` on the info Row (its action is a child Resume button, not a whole-card tap, so `clearAndSetSemantics` can't be used here); cover marked decorative to avoid a duplicate title readout.
- **InboxRow read/unread**: now a real `stateDescription` ("Unread"/"Read") instead of container-colour only (WCAG 1.4.1).
- **FictionDetailScreen hero metadata** (related sub-finding): merged into "Rated 4.5, 38 chapters, Ongoing"; separators decorative.

## #1157 — single-choice pickers didn't announce selected state
- **`BrassButton`** gains an optional `selected: Boolean?`. When non-null the a11y role flips from `Button` to `RadioButton` and the `selected` state is published — fixes all six BrassButton-as-radio sites at once (cache-size, AI provider, Claude/OpenAI/Vertex model pickers, pronunciation match-type). `mergeDescendants = true` preserved (#743 canary).
- **LibrarySortChip**: dropped the silent `contentDescription` override by adding `stateDescription = <active mode>` so TalkBack speaks the current sort.
- **ReadingSettings theme preview chip**: added `RadioButton` role + `selected`.

## #1161 — minor a11y
- **PluginManager `CapabilityChip`**: collapsed the dead `AssistChip(onClick = {})` to plain-text semantics (`clearAndSetSemantics { text = … }`) — no more false "button" role / dead Switch-Access focus stop. Visual chip unchanged.
- **ReadingSettings highlight-reset link**: `clickable(role = Role.Button, onClickLabel = …)` so it announces as actionable.
- **Browse filter button**: folds active-filter count into the icon `contentDescription` ("Filter, 3 active").

## Testing
Not compiled locally — pushed for CI (familiar) to validate. No existing unit/UI tests reference these card structures or the affected strings; the `BrassButtonSemanticsTest` / `brassButtonMergesDescendantsForLabel` canary stays green (mergeDescendants preserved).

🤖 Generated with [Claude Code](https://claude.com/claude-code)