### PR TITLE
fix(sync): per-key merge for SecretsSyncer to stop whole-bag LWW data loss (#1162)

### DIFF
--- a/core-sync/src/main/kotlin/in/jphe/storyvox/sync/domain/SecretsSyncer.kt
+++ b/core-sync/src/main/kotlin/in/jphe/storyvox/sync/domain/SecretsSyncer.kt
@@ -5,6 +5,7 @@ import androidx.core.content.edit
 import `in`.jphe.storyvox.sync.SyncIds
 import `in`.jphe.storyvox.sync.client.InstantBackend
 import `in`.jphe.storyvox.sync.client.SignedInUser
+import `in`.jphe.storyvox.sync.coordinator.ConflictPolicies
 import `in`.jphe.storyvox.sync.coordinator.Stamped
 import `in`.jphe.storyvox.sync.coordinator.SyncOutcome
 import `in`.jphe.storyvox.sync.coordinator.Syncer
@@ -13,7 +14,6 @@ import javax.crypto.SecretKey
 import javax.inject.Inject
 import javax.inject.Named
 import javax.inject.Singleton
-import kotlinx.serialization.Serializable
 import kotlinx.serialization.builtins.MapSerializer
 import kotlinx.serialization.builtins.serializer
 import kotlinx.serialization.json.Json
@@ -62,8 +62,45 @@ interface PassphraseManager : PassphraseProvider {
  * will need to be re-entered on reinstall. We don't fall back to
  * "push plaintext" — that would silently break the threat model.
  *
- * Conflict resolution: LWW on the envelope. There is no per-secret
- * merging because we can only decrypt the whole bag at once.
+ * ## Field-level merge (#1162)
+ *
+ * Conflict resolution used to be whole-bag last-write-wins on the
+ * envelope: the side with the newer `updatedAt` won and the loser's
+ * entire bag was discarded. That silently dropped concurrent
+ * cross-device edits — device A adds an OpenAI key, device B adds a
+ * Slack token, B's bag wins on timestamp, A's OpenAI key is gone (and
+ * vice-versa). Same gap settings closed in #978.
+ *
+ * This syncer now reconciles **per-secret**: each entry carries its own
+ * `updatedAt` and the merge is a union with newest-per-key-wins (see
+ * [ConflictPolicies.mergeStampedMap], shared with [SettingsSyncer]).
+ * Two devices adding two different secrets both survive a round-trip.
+ * The blob is opaque on the wire, but both sides are plaintext by the
+ * time the merge runs (we decrypt local AND remote first), so the merge
+ * is identical to settings' — only the IO is encrypted.
+ *
+ * ### Wire format (v2) and back-compat
+ *
+ * The per-secret timestamps live **inside** the encrypted envelope so
+ * they stay private. The decrypted plaintext is still a flat
+ * `{key: value}` JSON map (the v1 shape) plus two reserved string
+ * entries an old client ignores as non-secret keys: `"_v": "2"` and
+ * `"_field_stamps": "<json {key: updatedAt}>"` (stamps stringified so
+ * every top-level value stays a String — the same trick settings use).
+ *
+ * Neither read direction loses data:
+ *  - **v2 reads a v1 envelope** (no `_field_stamps`): synthesize every
+ *    secret's stamp from the row's `updatedAt` — the only timestamp a
+ *    v1 blob ever had — then merge per-key.
+ *  - **old (v1) client reads a v2 envelope**: it decrypts the flat map
+ *    and drops `_v` / `_field_stamps` on the floor (they fail the
+ *    [isSecretKey] allowlist), keeping every real secret. It degrades to
+ *    blob-LWW until it upgrades; it never corrupts the real entries.
+ *
+ * No migration job: the first push from a #1162 device rewrites that
+ * user's row to v2 in place (lazy, per-user). Concurrency: the
+ * [SyncCoordinator] serialises push/pull per domain, so the
+ * fetch→merge→upsert round has no internal race.
  *
  * Key scope (which prefs get synced): everything matching one of
  * [SECRET_KEY_PREFIXES], plus the explicit-name entries in
@@ -91,11 +128,10 @@ class SecretsSyncer @Inject constructor(
 ) : Syncer {
 
     private val json: Json = Json { ignoreUnknownKeys = true; encodeDefaults = true; coerceInputValues = true }
+    private val mapSerializer = MapSerializer(String.serializer(), String.serializer())
+    private val stampSerializer = MapSerializer(String.serializer(), Long.serializer())
 
     override val name: String get() = DOMAIN
-
-    @Serializable
-    data class Bundle(val entries: Map<String, String>)
 
     override suspend fun push(user: SignedInUser): SyncOutcome = reconcile(user)
     override suspend fun pull(user: SignedInUser): SyncOutcome = reconcile(user)
@@ -116,7 +152,7 @@ class SecretsSyncer @Inject constructor(
             passphrase.fill(' ')
         }
 
-        val local = snapshotLocal()
+        val local = readLocalStamped()
 
         val remote = backend.fetch(user, ENTITY, rowId(user)).getOrElse {
             return SyncOutcome.Transient("remote fetch: ${it.message}")
@@ -136,78 +172,113 @@ class SecretsSyncer @Inject constructor(
         // Permanent outcome so the coordinator stops retrying and the UI
         // can prompt for the right passphrase, and leave both the remote
         // blob and local prefs untouched.
-        val remoteDecoded: Stamped<Map<String, String>>? = when (val d = remote?.let { decode(it.payload, it.updatedAt, key) }) {
+        val remoteDecoded: Map<String, Stamped<String>>? = when (val d = remote?.let { decode(it.payload, it.updatedAt, key) }) {
             null -> null // no remote row at all — safe to originate from local
             is DecodeResult.Undecryptable -> return SyncOutcome.Permanent(PASSPHRASE_MISMATCH_MESSAGE)
-            is DecodeResult.Decoded -> d.stamped
-        }
-        val localStamp = Stamped(local, localUpdatedAt(local))
-
-        val merged = when {
-            remoteDecoded == null -> localStamp
-            local.isEmpty() && remoteDecoded.value.isNotEmpty() -> remoteDecoded
-            remoteDecoded.updatedAt > localStamp.updatedAt -> remoteDecoded
-            else -> localStamp
+            is DecodeResult.Decoded -> d.entries
         }
 
-        // Apply merged to local if it's newer-than-or-equal-to and differs.
-        if (merged !== localStamp && merged.value != local) {
-            applyLocal(merged.value)
-            secrets.edit { putLong(LAST_TOUCH_KEY, merged.updatedAt) }
+        // Empty-side fast paths (mirror SettingsSyncer). These avoid a
+        // pointless re-encrypt+push when one side has nothing to merge.
+        when {
+            local.isEmpty() && remoteDecoded.isNullOrEmpty() -> return SyncOutcome.Ok(0)
+            local.isEmpty() -> {
+                // Fresh device — adopt the remote bag wholesale. No push:
+                // we'd just re-encrypt the identical entries.
+                applyLocal(remoteDecoded!!)
+                return SyncOutcome.Ok(remoteDecoded.size)
+            }
+            remoteDecoded.isNullOrEmpty() -> {
+                // No remote row (or it decoded empty) — originate from
+                // local. Reaching here for a present row means it decoded
+                // cleanly (the #1027 Undecryptable case already returned).
+                return pushMerged(user, local, key) ?: SyncOutcome.Ok(local.size)
+            }
         }
 
-        // Push merged back. Reaching here guarantees either there was no
-        // remote row, or the remote row decoded cleanly under this key —
-        // so this push never clobbers an opaque-but-present remote blob
-        // (the #1027 invariant). `merged` was therefore encrypted under the
-        // same key the existing remote uses (or originates a fresh blob).
-        val envelope = encode(merged.value, key)
+        // Field-level union merge — the #1162 fix. A secret present on
+        // only one side survives; a secret on both sides resolves to the
+        // newer per-key stamp. This is exactly what dropped concurrent
+        // different-key adds under the old whole-bag LWW.
+        val merged = ConflictPolicies.mergeStampedMap(local, remoteDecoded!!)
+
+        if (merged != local) {
+            applyLocal(merged)
+        }
+        if (merged != remoteDecoded) {
+            // Push merged back. Reaching here guarantees the remote row
+            // decoded cleanly under this key — so this push never clobbers
+            // an opaque-but-present remote blob (the #1027 invariant).
+            pushMerged(user, merged, key)?.let { return it }
+        }
+        return SyncOutcome.Ok(merged.size)
+    }
+
+    /**
+     * Encrypt [merged] and upsert it. Returns null on success, or the
+     * [SyncOutcome.Transient] to propagate on a push failure.
+     */
+    private suspend fun pushMerged(
+        user: SignedInUser,
+        merged: Map<String, Stamped<String>>,
+        key: SecretKey,
+    ): SyncOutcome? {
+        val envelope = encode(merged, key)
         val pushed = backend.upsert(
             user = user,
             entity = ENTITY,
             id = rowId(user),
             payload = envelope,
-            updatedAt = merged.updatedAt,
+            updatedAt = rowStamp(merged),
         )
-        return if (pushed.isSuccess) {
-            SyncOutcome.Ok(merged.value.size)
-        } else {
-            SyncOutcome.Transient("remote push: ${pushed.exceptionOrNull()?.message}")
-        }
+        return if (pushed.isSuccess) null
+        else SyncOutcome.Transient("remote push: ${pushed.exceptionOrNull()?.message}")
     }
 
     /**
-     * The `updatedAt` to stamp on the local secrets bundle.
+     * Read the local secrets as a per-key stamped map — the local input
+     * to [ConflictPolicies.mergeStampedMap].
      *
-     * Issue #979: secrets were the one LWW domain that pushed
-     * `updatedAt=0`. [LAST_TOUCH_KEY] is only ever written from a
-     * *resolved* sync (line: `putLong(LAST_TOUCH_KEY, merged.updatedAt)`)
-     * — nothing observes the user typing an API key, so on a device
-     * that originated its secrets the key stays unset (`0L`). A blob
-     * pushed at `updatedAt=0` can NEVER win LWW ("higher updatedAt
-     * wins"), so the remote secrets blob stays pinned at 0 and never
-     * pulls down to a second device — even with the right passphrase.
+     * Each secret's stamp comes from the persisted [SECRET_FIELD_STAMPS_KEY]
+     * sidecar (a JSON `{key: updatedAt}` map kept in the same
+     * EncryptedSharedPreferences, so it's encrypted at rest too). A secret
+     * with no recorded per-key stamp yet — freshly typed since the last
+     * sync, or pre-existing from before this upgrade — falls back to the
+     * legacy bag-level [LAST_TOUCH_KEY] if set, else `now`.
      *
-     * Fix: mirror [SettingsSyncer.readLocal] — when we have local
-     * secrets but no recorded write time, stamp `System.currentTimeMillis()`
-     * and **persist it**. Persisting is what keeps LWW symmetric: the
-     * stamp is materialised once and then stable across reconciles, so
-     * a genuinely newer remote (real timestamp from another device) can
-     * still out-stamp it on the next round. A fresh `?: now()` recomputed
-     * every reconcile would make local perpetually "newest" and silently
-     * re-break the pull side.
+     * Issue #979 (carried forward): a freshly-stamped key is **materialised
+     * and persisted** here. Persisting is what keeps LWW symmetric — the
+     * stamp is fixed once and then stable across reconciles, so a genuinely
+     * newer remote can still out-stamp it on the next round. Recomputing
+     * `now` every reconcile would make local perpetually "newest" and
+     * silently re-break the pull side.
      *
-     * Empty local → 0L: a device with no secrets must not out-stamp a
-     * real remote blob (the `local.isEmpty()` branch in [reconcile]
-     * already prefers remote, but 0L keeps the LWW comparison honest).
+     * Empty local → empty map: a device with no secrets must not originate
+     * or out-stamp a real remote blob; [reconcile]'s empty-side fast paths
+     * handle that.
      */
-    private fun localUpdatedAt(local: Map<String, String>): Long {
-        val existing = secrets.getLong(LAST_TOUCH_KEY, 0L)
-        if (existing > 0L) return existing
-        if (local.isEmpty()) return 0L
-        val now = System.currentTimeMillis()
-        secrets.edit { putLong(LAST_TOUCH_KEY, now) }
-        return now
+    private fun readLocalStamped(): Map<String, Stamped<String>> {
+        val snap = snapshotLocal()
+        if (snap.isEmpty()) return emptyMap()
+        val persisted = loadFieldStamps()
+        val fallback = secrets.getLong(LAST_TOUCH_KEY, 0L).takeIf { it > 0L }
+            ?: System.currentTimeMillis()
+        val stamps = LinkedHashMap(persisted)
+        var materialisedAny = false
+        val out = LinkedHashMap<String, Stamped<String>>(snap.size)
+        for ((k, v) in snap) {
+            val stamp = persisted[k] ?: fallback.also { stamps[k] = it; materialisedAny = true }
+            out[k] = Stamped(v, stamp)
+        }
+        if (materialisedAny) {
+            secrets.edit {
+                putString(SECRET_FIELD_STAMPS_KEY, json.encodeToString(stampSerializer, stamps))
+                // Keep the legacy bag stamp advanced to the newest field —
+                // it's the v1 fallback any pre-#1162 reader still uses.
+                putLong(LAST_TOUCH_KEY, stamps.values.maxOrNull() ?: fallback)
+            }
+        }
+        return out
     }
 
     private fun snapshotLocal(): Map<String, String> {
@@ -220,40 +291,76 @@ class SecretsSyncer @Inject constructor(
         return out
     }
 
-    private fun applyLocal(entries: Map<String, String>) {
+    /** Load the persisted per-key stamp sidecar, or empty on first run /
+     *  a corrupt entry (treated as "no stamps yet"). */
+    private fun loadFieldStamps(): Map<String, Long> {
+        val raw = secrets.getString(SECRET_FIELD_STAMPS_KEY, null) ?: return emptyMap()
+        return runCatching { json.decodeFromString(stampSerializer, raw) }.getOrDefault(emptyMap())
+    }
+
+    /**
+     * Write the merged bag to local prefs and persist its per-key stamps.
+     *
+     * We only write keys that pass the [isSecretKey] allowlist — a
+     * forward-compat clause so a future build pushing an unrecognised key
+     * can't land arbitrary attacker-controlled entries in
+     * EncryptedSharedPreferences. Keys absent from [merged] are left
+     * untouched (no delete semantic — a cleared secret is encoded as the
+     * empty string, not a removed key).
+     */
+    private fun applyLocal(merged: Map<String, Stamped<String>>) {
+        val stamps = loadFieldStamps().toMutableMap()
         secrets.edit {
-            // Don't blow away local-only secrets that aren't in the merged
-            // bundle (the user might have a key set on this device that
-            // they intentionally haven't synced — corner case but cheap
-            // to support). We only overwrite keys present in [entries] AND
-            // that pass the allowlist check (a forward-compat clause — if
-            // a future build pushes a key this build doesn't recognise as
-            // a secret, we drop it on the floor rather than blindly
-            // writing arbitrary attacker-controlled keys to
-            // EncryptedSharedPreferences).
-            for ((k, v) in entries) {
-                if (isSecretKey(k)) putString(k, v)
+            for ((k, sv) in merged) {
+                if (!isSecretKey(k)) continue
+                putString(k, sv.value)
+                stamps[k] = sv.updatedAt
             }
+            putString(SECRET_FIELD_STAMPS_KEY, json.encodeToString(stampSerializer, stamps))
+            rowStampOrNull(merged)?.let { putLong(LAST_TOUCH_KEY, it) }
         }
     }
 
     private fun isSecretKey(key: String): Boolean =
         key in SECRET_KEY_NAMES || SECRET_KEY_PREFIXES.any { key.startsWith(it) }
 
-    private fun encode(values: Map<String, String>, key: SecretKey): String {
-        // Issue #360 finding 5 (argus): the v1 envelope stored a fresh
-        // per-encrypt salt, but the AES key was actually derived from
-        // [deterministicSaltFor] — the envelope salt was unused on
-        // decrypt. Cross-device decrypt has always worked by both
-        // devices independently recomputing the deterministic salt; the
-        // envelope's random salt was dead bytes. v2 envelope drops the
-        // salt slot — see [UserDerivedKey.envelope] for the design.
-        val plaintext = json.encodeToString(
-            MapSerializer(String.serializer(), String.serializer()), values,
-        ).encodeToByteArray()
+    /**
+     * Encrypt [merged] as the v2 payload: the flat `{key: value}` map
+     * (v1-readable once decrypted) plus the reserved `_v` and stringified
+     * `_field_stamps` entries. Keys are sorted so byte-identical input
+     * yields a byte-identical envelope — no no-op push thrash.
+     *
+     * Issue #360 finding 5 (argus): the v1 envelope stored a fresh
+     * per-encrypt salt, but the AES key was actually derived from
+     * [deterministicSaltFor] — the envelope salt was unused on decrypt.
+     * Cross-device decrypt has always worked by both devices independently
+     * recomputing the deterministic salt; the envelope's random salt was
+     * dead bytes. The current envelope drops the salt slot — see
+     * [UserDerivedKey.envelope] for the design.
+     */
+    private fun encode(merged: Map<String, Stamped<String>>, key: SecretKey): String {
+        val flat = sortedMapOf<String, String>()
+        val stamps = sortedMapOf<String, Long>()
+        for ((k, sv) in merged) {
+            flat[k] = sv.value
+            stamps[k] = sv.updatedAt
+        }
+        val out = LinkedHashMap<String, String>(flat.size + 2)
+        out.putAll(flat)
+        out[KEY_VERSION] = WIRE_VERSION.toString()
+        out[KEY_FIELD_STAMPS] = json.encodeToString(stampSerializer, stamps)
+        val plaintext = json.encodeToString(mapSerializer, out).encodeToByteArray()
         val blob = UserDerivedKey.encrypt(key, plaintext)
         return UserDerivedKey.envelope(blob)
     }
+
+    /** Row-level `updatedAt` for an upsert — the newest per-key stamp, so
+     *  the v1 fallback an old reader sees is the most recent edit. */
+    private fun rowStamp(merged: Map<String, Stamped<String>>): Long =
+        rowStampOrNull(merged) ?: System.currentTimeMillis()
+
+    private fun rowStampOrNull(merged: Map<String, Stamped<String>>): Long? =
+        merged.values.maxOfOrNull { it.updatedAt }
 
     /**
      * Outcome of decoding a remote secrets row that we KNOW exists.
@@ -265,7 +372,7 @@ class SecretsSyncer @Inject constructor(
      * via the nullable `remote?.let { … }`.)
      */
     private sealed interface DecodeResult {
-        data class Decoded(val stamped: Stamped<Map<String, String>>) : DecodeResult
+        data class Decoded(val entries: Map<String, Stamped<String>>) : DecodeResult
 
         /**
          * The envelope failed to parse, failed to decrypt (AES-GCM tag
@@ -276,6 +383,15 @@ class SecretsSyncer @Inject constructor(
         data object Undecryptable : DecodeResult
     }
 
+    /**
+     * Decrypt and parse a remote row into a per-key stamped map. Handles
+     * both wire shapes (see the class kdoc):
+     *  - **v2**: strip the reserved `_v` / `_field_stamps` entries and use
+     *    the parsed stamp sidecar; a key missing from the sidecar falls
+     *    back to the row's [updatedAt].
+     *  - **v1** (no `_field_stamps`): every secret inherits the row's
+     *    [updatedAt] — the only timestamp a v1 blob ever had.
+     */
     private fun decode(envelope: String, updatedAt: Long, key: SecretKey): DecodeResult {
         val parsed = UserDerivedKey.parseEnvelope(envelope) ?: return DecodeResult.Undecryptable
         // AES-GCM authentication failure (wrong key) surfaces as an
@@ -283,13 +399,18 @@ class SecretsSyncer @Inject constructor(
         // treated as "can't read this row," never as "no row."
         val plain = runCatching { UserDerivedKey.decrypt(key, parsed.blob) }.getOrNull()
             ?: return DecodeResult.Undecryptable
-        val map = runCatching {
-            json.decodeFromString(
-                MapSerializer(String.serializer(), String.serializer()),
-                plain.decodeToString(),
-            )
+        val raw = runCatching {
+            json.decodeFromString(mapSerializer, plain.decodeToString())
         }.getOrNull() ?: return DecodeResult.Undecryptable
-        return DecodeResult.Decoded(Stamped(value = map, updatedAt = updatedAt))
+        val perKey: Map<String, Long> = raw[KEY_FIELD_STAMPS]?.let { stampsJson ->
+            runCatching { json.decodeFromString(stampSerializer, stampsJson) }.getOrDefault(emptyMap())
+        } ?: emptyMap()
+        val out = LinkedHashMap<String, Stamped<String>>(raw.size)
+        for ((k, v) in raw) {
+            if (k == KEY_VERSION || k == KEY_FIELD_STAMPS) continue
+            out[k] = Stamped(v, perKey[k] ?: updatedAt)
+        }
+        return DecodeResult.Decoded(out)
     }
 
     /** A 16-byte salt derived from the userId. Stable across devices for
@@ -306,6 +427,29 @@ class SecretsSyncer @Inject constructor(
         const val DOMAIN: String = "secrets"
         private const val ENTITY = "blobs"
         private const val LAST_TOUCH_KEY = "instantdb.secrets_synced_at"
+
+        /**
+         * Local-only prefs key holding the per-secret stamp sidecar — a
+         * JSON `{key: updatedAt}` map. Lives in the same
+         * EncryptedSharedPreferences as the secrets (so it's encrypted at
+         * rest) but is never itself a synced secret: it fails [isSecretKey]
+         * and so is skipped by [snapshotLocal]. Issue #1162.
+         */
+        private const val SECRET_FIELD_STAMPS_KEY = "instantdb.secrets_field_stamps"
+
+        /** v2 = per-secret field-level merge (#1162). v1 envelopes have no
+         *  version marker and decode as flat blob-LWW. */
+        private const val WIRE_VERSION: Int = 2
+
+        /**
+         * Reserved keys inside the encrypted plaintext. Underscore-prefixed
+         * so they can't collide with a real synced secret (every allowlisted
+         * key is namespaced `llm.` / `cookie:` / `pref_source_*` etc., none
+         * start with `_`) and so a pre-#1162 reader drops them via the
+         * [isSecretKey] allowlist instead of writing them to prefs.
+         */
+        private const val KEY_VERSION: String = "_v"
+        private const val KEY_FIELD_STAMPS: String = "_field_stamps"
 
         /**
          * Issue #1027 — user-facing outcome when the remote secrets blob

--- a/core-sync/src/test/kotlin/in/jphe/storyvox/sync/SecretsSyncerTest.kt
+++ b/core-sync/src/test/kotlin/in/jphe/storyvox/sync/SecretsSyncerTest.kt
@@ -375,4 +375,51 @@ class SecretsSyncerTest {
             handed.all { it == ' ' || it == ' ' },
         )
     }
+
+    @Test fun `concurrent different-key adds both survive a round-trip (regression #1162)`() = runTest {
+        // #1162 (data loss): whole-bag LWW dropped the loser's ENTIRE
+        // secret set when two devices edited DIFFERENT keys between syncs.
+        // Per-key union merge must keep both devices' unique secrets — and
+        // propagate them to the cloud so a third device pulls the union.
+        val backend = FakeInstantBackend()
+        val now = System.currentTimeMillis()
+
+        // Device A originates two secrets with a LATER bag stamp (now+1h).
+        // Under the old LWW, A's newer bag would win wholesale and erase
+        // anything B added.
+        val prefsA = FakePrefs().apply {
+            edit().putString("llm.openai_key", "sk-from-A").apply()
+            edit().putString("github.token", "ghp-from-A").apply()
+            edit().putLong("instantdb.secrets_synced_at", now + 3_600_000L).apply()
+        }
+        SecretsSyncer(prefsA, backend, { PASSPHRASE.copyOf() }).push(USER)
+
+        // Device B holds a DIFFERENT secret with an EARLIER bag stamp
+        // (now-1h). On pull it sees the newer remote; old LWW adopted the
+        // remote wholesale, so B's slack token never reached the cloud
+        // (silently lost on B's next reinstall).
+        val prefsB = FakePrefs().apply {
+            edit().putString("pref_source_slack_token", "xoxb-from-B").apply()
+            edit().putLong("instantdb.secrets_synced_at", now - 3_600_000L).apply()
+        }
+        SecretsSyncer(prefsB, backend, { PASSPHRASE.copyOf() }).pull(USER)
+
+        // B now holds the UNION locally (its own key + A's two keys).
+        assertEquals("xoxb-from-B", prefsB.getString("pref_source_slack_token", null))
+        assertEquals("sk-from-A", prefsB.getString("llm.openai_key", null))
+        assertEquals("ghp-from-A", prefsB.getString("github.token", null))
+
+        // The cloud now holds the union too — a fresh device C pulls all
+        // three secrets. Under whole-bag LWW, C would be missing the slack
+        // token (it never made it past B's local store).
+        val prefsC = FakePrefs()
+        SecretsSyncer(prefsC, backend, { PASSPHRASE.copyOf() }).pull(USER)
+        assertEquals("sk-from-A", prefsC.getString("llm.openai_key", null))
+        assertEquals("ghp-from-A", prefsC.getString("github.token", null))
+        assertEquals(
+            "device B's unique secret must survive to the cloud and reach a third device",
+            "xoxb-from-B",
+            prefsC.getString("pref_source_slack_token", null),
+        )
+    }
 }


### PR DESCRIPTION
## Summary

Fixes #1162 — `SecretsSyncer` resolved sync conflicts with **whole-bag last-write-wins**. When two devices added/edited *different* secret keys between syncs, the device with the newer `updatedAt` overwrote the entire encrypted blob, silently destroying the other device's unique secrets (API keys, source cookies/tokens) both in the cloud and on the next pull. This is the same conflict-resolution gap that settings closed in #978.

## Fix

Per-secret field-level merge, mirroring settings' `mergeStampedMap`:

- **Decrypt both sides first.** The blob is opaque on the wire, but local and remote are both plaintext by the time the merge runs, so the merge is identical to settings' — only the IO is encrypted.
- **Union + newest-per-key-wins** via `ConflictPolicies.mergeStampedMap`. A secret present on only one device now survives; only a genuine same-key edit resolves by timestamp.
- **Per-secret timestamps ride inside the encrypted envelope** as a v2 payload: the decrypted plaintext stays a flat `{key: value}` map (v1-readable) plus reserved `_v` and stringified `_field_stamps` entries. An old (v1) client drops those reserved keys via the `isSecretKey` allowlist and keeps every real secret — graceful degradation, no corruption. A v2 client reading a v1 blob synthesizes per-key stamps from the row `updatedAt`.
- **Local stamps persist** in an encrypted sidecar pref (`instantdb.secrets_field_stamps`) so LWW stays symmetric (#979 carried forward).
- **#1027 invariant preserved**: a present-but-undecryptable remote still returns `Permanent` and never clobbers.

No migration job — the first push from a fixed device lazily rewrites that user's row to v2 in place.

## Test

Adds a regression test (`concurrent different-key adds both survive a round-trip`): device A originates two secrets, device B holds a different one, and after a sync round all three reach a fresh third device. Under the old whole-bag LWW, B's unique secret never reached the cloud. All 8 existing `SecretsSyncerTest` / 11 `SecretsSyncerExtensionTest` cases still hold.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
