### PR TITLE
fix(a11y): live regions for dynamic status across surfaces (#1160) + derive wiki counts (#1146)

### DIFF
--- a/.github/workflows/release-docs-sync.yml
+++ b/.github/workflows/release-docs-sync.yml
@@ -9,6 +9,10 @@ name: Release docs sync
 # CODEOWNERS review, no auto-merge. This workflow OWNS the release-current
 # sections of wiki Home.md (the version line, the "Latest release" line, and
 # the "What's new in vX.Y.Z" section), regenerated from CHANGELOG.md each tag.
+# It ALSO owns the intro/Pages source + module counts ("twenty-five fiction
+# backends", "thirty-eight modules"), which render_release_home.py recomputes
+# live from settings.gradle.kts + the source-* tree so they can't silently
+# re-stale (#1146) — previously those numbers were owned by no workflow.
 #
 # The repo's own docs/index.md + README headline are deliberately NOT touched
 # here — those ride the normal human-reviewed PR flow into main. This workflow

--- a/core-ui/src/main/kotlin/in/jphe/storyvox/ui/component/ErrorBlock.kt
+++ b/core-ui/src/main/kotlin/in/jphe/storyvox/ui/component/ErrorBlock.kt
@@ -16,6 +16,9 @@ import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.semantics.LiveRegionMode
+import androidx.compose.ui.semantics.liveRegion
+import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
@@ -118,7 +121,14 @@ fun ErrorBlock(
         }
 
         ErrorPlacement.Banner -> Card(
-            modifier = modifier.fillMaxWidth().padding(horizontal = spacing.md, vertical = spacing.xs),
+            modifier = modifier
+                .fillMaxWidth()
+                .padding(horizontal = spacing.md, vertical = spacing.xs)
+                // #1160: the banner is inserted above existing content on a
+                // refresh/append failure — focus doesn't move, so without a
+                // live region "Couldn't refresh" is never spoken. Assertive
+                // because it reports a failure the user should hear promptly.
+                .semantics { liveRegion = LiveRegionMode.Assertive },
             colors = CardDefaults.cardColors(
                 containerColor = MaterialTheme.colorScheme.errorContainer,
                 contentColor = MaterialTheme.colorScheme.onErrorContainer,

--- a/feature/src/main/kotlin/in/jphe/storyvox/feature/components/OfflineBanner.kt
+++ b/feature/src/main/kotlin/in/jphe/storyvox/feature/components/OfflineBanner.kt
@@ -15,6 +15,9 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.semantics.LiveRegionMode
+import androidx.compose.ui.semantics.liveRegion
+import androidx.compose.ui.semantics.semantics
 import `in`.jphe.storyvox.feature.R
 import `in`.jphe.storyvox.ui.component.BrassButton
 import `in`.jphe.storyvox.ui.component.BrassButtonVariant
@@ -29,9 +32,11 @@ import `in`.jphe.storyvox.ui.theme.LocalSpacing
  * status banners. The retry CTA is optional: Browse wires it to a re-fetch,
  * Library passes `null` (there's nothing to retry until the user taps a cover).
  *
- * A11y: TalkBack announces the message once when the banner enters composition,
- * which is the whole point of the issue — one announcement instead of one per
- * failed network retry.
+ * A11y: the banner is a [LiveRegionMode.Polite] live region so TalkBack
+ * announces the offline message when it appears (and again if it re-appears
+ * after reconnecting) — without a tap, focus never moves here, so composition
+ * entry alone does not reliably announce. Polite (not Assertive) so it queues
+ * behind whatever the user is currently hearing instead of interrupting.
  */
 @Composable
 fun OfflineBanner(
@@ -45,7 +50,8 @@ fun OfflineBanner(
         ),
         modifier = modifier
             .fillMaxWidth()
-            .padding(horizontal = spacing.md, vertical = spacing.xs),
+            .padding(horizontal = spacing.md, vertical = spacing.xs)
+            .semantics { liveRegion = LiveRegionMode.Polite },
     ) {
         Row(
             modifier = Modifier.padding(

--- a/feature/src/main/kotlin/in/jphe/storyvox/feature/library/CreateAudiobookSheet.kt
+++ b/feature/src/main/kotlin/in/jphe/storyvox/feature/library/CreateAudiobookSheet.kt
@@ -32,7 +32,10 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.semantics.LiveRegionMode
 import androidx.compose.ui.semantics.Role
+import androidx.compose.ui.semantics.liveRegion
+import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.text.input.ImeAction
 import androidx.compose.ui.text.input.KeyboardCapitalization
 import androidx.compose.ui.unit.dp
@@ -255,7 +258,15 @@ private fun ComposePhase(
 @Composable
 private fun RenderingPhase(progress: Float) {
     val spacing = LocalSpacing.current
-    Text("Creating your audiobook…", style = MaterialTheme.typography.titleMedium)
+    // #1160: the sheet flips Compose → Rendering → Done/Failed without a tap.
+    // The phase headline is a polite live region so TalkBack announces the
+    // transition; the climbing % is deliberately NOT a live region (announcing
+    // per-percent would be noise).
+    Text(
+        "Creating your audiobook…",
+        style = MaterialTheme.typography.titleMedium,
+        modifier = Modifier.semantics { liveRegion = LiveRegionMode.Polite },
+    )
     Text(
         "Narrating chapters offline. You can leave this screen — we'll keep going " +
             "in the background.",
@@ -283,7 +294,12 @@ private fun DonePhase(
     onDone: () -> Unit,
 ) {
     val spacing = LocalSpacing.current
-    Text("Your audiobook is ready", style = MaterialTheme.typography.titleMedium)
+    // #1160: announce arrival at the Done phase (no tap moves focus here).
+    Text(
+        "Your audiobook is ready",
+        style = MaterialTheme.typography.titleMedium,
+        modifier = Modifier.semantics { liveRegion = LiveRegionMode.Polite },
+    )
     Text(
         "$fileName · $chapterCount chapter${if (chapterCount == 1) "" else "s"}",
         style = MaterialTheme.typography.bodySmall,
@@ -319,7 +335,13 @@ private fun DonePhase(
 
 @Composable
 private fun FailedPhase(message: String, onRetry: () -> Unit) {
-    Text("Couldn't create the audiobook", style = MaterialTheme.typography.titleMedium)
+    // #1160: failure is actionable (Retry) — announce assertively so TalkBack
+    // interrupts rather than queuing behind whatever was being read.
+    Text(
+        "Couldn't create the audiobook",
+        style = MaterialTheme.typography.titleMedium,
+        modifier = Modifier.semantics { liveRegion = LiveRegionMode.Assertive },
+    )
     Text(message, style = MaterialTheme.typography.bodySmall, color = MaterialTheme.colorScheme.error)
     BrassButton(
         label = "Try again",

--- a/feature/src/main/kotlin/in/jphe/storyvox/feature/reader/HybridReaderScreen.kt
+++ b/feature/src/main/kotlin/in/jphe/storyvox/feature/reader/HybridReaderScreen.kt
@@ -20,6 +20,9 @@ import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.semantics.LiveRegionMode
+import androidx.compose.ui.semantics.liveRegion
+import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
@@ -494,6 +497,11 @@ private fun ExplicitArgsLoadingPrompt(
                     style = MaterialTheme.typography.titleMedium,
                     color = MaterialTheme.colorScheme.primary,
                     textAlign = TextAlign.Center,
+                    // #1160: this pre-controller screen flips loading → Slow →
+                    // TimedOut with no tap. The silent flip to this actionable
+                    // "Couldn't start / Retry" state is the worst gap — announce
+                    // assertively so TalkBack surfaces it immediately.
+                    modifier = Modifier.semantics { liveRegion = LiveRegionMode.Assertive },
                 )
                 Spacer(Modifier.height(spacing.xs))
                 Text(
@@ -533,6 +541,8 @@ private fun ExplicitArgsLoadingPrompt(
                     text = stringResource(R.string.reader_still_loading),
                     style = MaterialTheme.typography.titleSmall,
                     color = MaterialTheme.colorScheme.primary,
+                    // #1160: announce the loading → Slow transition politely.
+                    modifier = Modifier.semantics { liveRegion = LiveRegionMode.Polite },
                 )
                 Spacer(Modifier.height(spacing.xs))
                 Text(
@@ -558,6 +568,8 @@ private fun ExplicitArgsLoadingPrompt(
                     text = stringResource(R.string.reader_loading_chapter),
                     style = MaterialTheme.typography.titleSmall,
                     color = MaterialTheme.colorScheme.primary,
+                    // #1160: announce entry into the chapter-loading state.
+                    modifier = Modifier.semantics { liveRegion = LiveRegionMode.Polite },
                 )
             }
         }

--- a/feature/src/main/kotlin/in/jphe/storyvox/feature/reader/RecapModal.kt
+++ b/feature/src/main/kotlin/in/jphe/storyvox/feature/reader/RecapModal.kt
@@ -34,7 +34,9 @@ import androidx.compose.ui.draw.alpha
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.semantics.LiveRegionMode
 import androidx.compose.ui.semantics.Role
+import androidx.compose.ui.semantics.liveRegion
 import androidx.compose.ui.semantics.role
 import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.text.style.TextAlign
@@ -111,6 +113,13 @@ fun RecapModal(
                     text = stringResource(subtitleResFor(state)),
                     style = MaterialTheme.typography.bodySmall,
                     color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    // #1160: the recap runs Loading → Streaming → Done/Error
+                    // with no tap. This subtitle is the one header node whose
+                    // text tracks state (in-flight → done → error), so making
+                    // it a polite live region announces each transition once.
+                    // The streamed body is deliberately NOT a live region —
+                    // announcing per token would be unusable.
+                    modifier = Modifier.semantics { liveRegion = LiveRegionMode.Polite },
                 )
             }
 
@@ -324,6 +333,10 @@ private fun ErrorBody(state: RecapUiState.Error) {
             style = MaterialTheme.typography.bodyMedium,
             color = MaterialTheme.colorScheme.error,
             textAlign = TextAlign.Center,
+            // #1160: the error body mounts on a failed recap with no tap;
+            // announce the actual error assertively so TalkBack surfaces it
+            // (the polite header subtitle only carries a neutral descriptor).
+            modifier = Modifier.semantics { liveRegion = LiveRegionMode.Assertive },
         )
     }
     // Suppress "unused parameter" — Color is used via colorScheme.

--- a/feature/src/main/kotlin/in/jphe/storyvox/feature/settings/RoyalRoadTagSyncRow.kt
+++ b/feature/src/main/kotlin/in/jphe/storyvox/feature/settings/RoyalRoadTagSyncRow.kt
@@ -15,6 +15,9 @@ import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.semantics.LiveRegionMode
+import androidx.compose.ui.semantics.liveRegion
+import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.unit.dp
 import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import androidx.lifecycle.ViewModel
@@ -160,7 +163,12 @@ fun RoyalRoadTagSyncRow(
                     text = msg,
                     style = MaterialTheme.typography.bodySmall,
                     color = MaterialTheme.colorScheme.onSurfaceVariant,
-                    modifier = Modifier.weight(1f),
+                    // #1160: the sync outcome appears asynchronously after the
+                    // user taps "Sync now" — no further tap moves focus here, so
+                    // announce it politely when it lands.
+                    modifier = Modifier
+                        .weight(1f)
+                        .semantics { liveRegion = LiveRegionMode.Polite },
                 )
             } ?: Spacer(Modifier.weight(1f))
 

--- a/feature/src/main/kotlin/in/jphe/storyvox/feature/settings/SettingsHubScreen.kt
+++ b/feature/src/main/kotlin/in/jphe/storyvox/feature/settings/SettingsHubScreen.kt
@@ -44,6 +44,10 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.semantics.LiveRegionMode
+import androidx.compose.ui.semantics.liveRegion
+import androidx.compose.ui.semantics.semantics
+import androidx.compose.ui.text.style.TextAlign
 import `in`.jphe.storyvox.feature.R
 import `in`.jphe.storyvox.feature.settings.components.SectionHeading
 import `in`.jphe.storyvox.ui.component.MagicTitleBar
@@ -324,6 +328,24 @@ fun SettingsHubScreen(
                     onClick = onOpenAllSettings,
                 )
             }
+            }
+            // #1160: rows self-hide on a non-matching query, so a search with
+            // no hits collapsed to a blank card with no feedback. Surface a
+            // polite live-region "No results" line. SettingsHubSections is
+            // test-pinned to mirror the rendered rows, so reusing matchesHubQuery
+            // over it tracks visibility exactly; a blank query matches every
+            // section, so this branch only fires when the user has typed.
+            val hasResults = SettingsHubSections.any { matchesHubQuery(query, it.title, it.subtitle) }
+            if (!hasResults) {
+                Text(
+                    text = stringResource(R.string.settings_hub_no_results, query.trim()),
+                    style = MaterialTheme.typography.bodyMedium,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    textAlign = TextAlign.Center,
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .semantics { liveRegion = LiveRegionMode.Polite },
+                )
             }
         }
     }

--- a/feature/src/main/kotlin/in/jphe/storyvox/feature/settings/components/StatusPill.kt
+++ b/feature/src/main/kotlin/in/jphe/storyvox/feature/settings/components/StatusPill.kt
@@ -14,6 +14,9 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.semantics.LiveRegionMode
+import androidx.compose.ui.semantics.liveRegion
+import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import `in`.jphe.storyvox.ui.theme.LibraryNocturneTheme
@@ -51,7 +54,17 @@ fun StatusPill(
     Row(
         modifier = modifier
             .fillMaxWidth()
-            .padding(horizontal = spacing.md, vertical = spacing.sm),
+            .padding(horizontal = spacing.md, vertical = spacing.sm)
+            // #1160: pill text flips ("Syncing…" → "Connected" / "Key rejected")
+            // without a tap, so TalkBack must announce it. Errors are assertive
+            // (interrupt) since they're actionable; healthy/neutral states are polite.
+            .semantics {
+                liveRegion = if (tone == StatusTone.Error) {
+                    LiveRegionMode.Assertive
+                } else {
+                    LiveRegionMode.Polite
+                }
+            },
         verticalAlignment = Alignment.CenterVertically,
         horizontalArrangement = Arrangement.spacedBy(spacing.xs),
     ) {

--- a/feature/src/main/kotlin/in/jphe/storyvox/feature/sync/SyncStatusSheet.kt
+++ b/feature/src/main/kotlin/in/jphe/storyvox/feature/sync/SyncStatusSheet.kt
@@ -22,6 +22,9 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.semantics.LiveRegionMode
+import androidx.compose.ui.semantics.liveRegion
+import androidx.compose.ui.semantics.semantics
 
 import androidx.compose.ui.unit.dp
 import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
@@ -169,6 +172,10 @@ private fun SignedInBody(
             },
             style = MaterialTheme.typography.titleMedium,
             color = MaterialTheme.colorScheme.primary,
+            // #1160: while the sheet is open the header flips "Syncing in
+            // progress" → "Signed in" with no tap. Polite live region so
+            // TalkBack announces the change; per-domain rows stay quiet.
+            modifier = Modifier.semantics { liveRegion = LiveRegionMode.Polite },
         )
     }
     Text(

--- a/feature/src/main/res/values/strings.xml
+++ b/feature/src/main/res/values/strings.xml
@@ -535,6 +535,7 @@
     <string name="settings_hub_descriptor">Pick a section to configure.</string>
     <string name="settings_hub_search_label">Search settings</string>
     <string name="settings_hub_clear_search">Clear search</string>
+    <string name="settings_hub_no_results">No settings match “%1$s”. Try a different term or clear the search.</string>
     <string name="settings_hub_voice_playback_title">Voice &amp; Playback</string>
     <string name="settings_hub_voice_playback_subtitle">Voice, speed, cadence, pitch.</string>
     <string name="settings_hub_voice_library_title">Voice library</string>

--- a/scripts/wiki/render_release_home.py
+++ b/scripts/wiki/render_release_home.py
@@ -6,16 +6,26 @@ on every release tag (no PR, no PAT — the .wiki repo is unprotected). This is
 the ONLY writer of wiki Home.md; the companion wiki-sync.yml deliberately never
 touches Home.md, so the two workflows never collide.
 
-Three regions are regenerated from the tag's CHANGELOG.md section:
+Four regions are regenerated — three from the tag's CHANGELOG.md section, plus
+the intro counts derived live from the repo's own source of truth:
 
   1. The current-version line          `_Current version: vX.Y.Z_`
   2. The "Latest release" line         `📦 **Latest release:** [vX — Title](url) — tagline`
   3. The "What's new" section          fenced by AUTO-GENERATED markers and
                                        rebuilt from the release's bullets.
+  4. The intro/Pages counts            "twenty-five fiction backends" and
+                                       "thirty-eight modules" — recomputed from
+                                       settings.gradle.kts + the source-* tree so
+                                       they can never silently re-stale (#1146).
 
-Everything else in Home.md (the intro, the Pages list, "Recent highlights",
-Quick links) is hand-authored and left untouched — this script only rewrites
-the three regions above and fails loudly if it cannot.
+Region 4 self-heals: it finds the spelled-out number-word in front of "fiction
+backends" / "backends" (the Pages link) / "modules" and rewrites it to match the
+live count, preserving the original capitalization. If the phrasing ever changes
+so a count can't be located it warns (so the workflow log flags it) but does NOT
+fail the release — the intro is hand-authored prose, not a release-blocking region.
+
+Everything else in Home.md ("Recent highlights", Quick links) is hand-authored
+and left untouched — regions 1-3 fail loudly if they cannot be rewritten.
 
 Usage:  REPO=owner/name TAG=v1.1.3 CHANGELOG=/path/to/CHANGELOG.md \\
             render_release_home.py /path/to/Home.md
@@ -111,6 +121,161 @@ def render_whats_new(version: str, tagline: str, bullets: list[str]) -> str:
     return "\n".join(lines)
 
 
+# ---------------------------------------------------------------------------
+# Intro count derivation (#1146). The wiki Home intro carries spelled-out
+# counts ("twenty-five fiction backends", "thirty-eight modules") that were
+# owned by no sync workflow and silently re-staled on every release that added
+# a source or module. We now recompute them from the repo's source of truth.
+# ---------------------------------------------------------------------------
+
+_ONES_WORDS = [
+    "zero", "one", "two", "three", "four", "five", "six", "seven", "eight",
+    "nine", "ten", "eleven", "twelve", "thirteen", "fourteen", "fifteen",
+    "sixteen", "seventeen", "eighteen", "nineteen",
+]
+_TENS_WORDS = [
+    "", "", "twenty", "thirty", "forty", "fifty", "sixty", "seventy",
+    "eighty", "ninety",
+]
+_ONES_INDEX = {w: i for i, w in enumerate(_ONES_WORDS)}
+_TENS_INDEX = {w: i * 10 for i, w in enumerate(_TENS_WORDS) if w}
+
+
+def num_to_words(n: int) -> str:
+    """Spell a 0-99 integer ("twenty-five"). Out of range -> digits."""
+    if not 0 <= n <= 99:
+        return str(n)
+    if n < 20:
+        return _ONES_WORDS[n]
+    tens, ones = divmod(n, 10)
+    return _TENS_WORDS[tens] + (f"-{_ONES_WORDS[ones]}" if ones else "")
+
+
+def parse_number_word(word: str) -> int | None:
+    """Inverse of [num_to_words] for 0-99; None if `word` isn't a number-word.
+
+    Used as a guard so the count substitution only ever touches spans whose
+    leading token is genuinely a spelled number — "core modules" or "Gradle
+    modules" parse to None and are left alone.
+    """
+    w = word.strip().lower()
+    if w in _ONES_INDEX:
+        return _ONES_INDEX[w]
+    if w in _TENS_INDEX:
+        return _TENS_INDEX[w]
+    if "-" in w:
+        tens, _, ones = w.partition("-")
+        if tens in _TENS_INDEX and ones in _ONES_INDEX and 1 <= _ONES_INDEX[ones] <= 9:
+            return _TENS_INDEX[tens] + _ONES_INDEX[ones]
+    return None
+
+
+def count_modules(settings_text: str) -> int:
+    """Count live `include(":...")` modules — mirrors sync_wiki.parse_modules."""
+    include_re = re.compile(r"""include\(\s*['"](:[^'"]+)['"]\s*\)""")
+    mods: set[str] = set()
+    for line in settings_text.splitlines():
+        stripped = line.strip()
+        if stripped.startswith(("//", "/*", "*")):
+            continue
+        m = include_re.search(stripped)
+        if m:
+            mods.add(m.group(1))
+    return len(mods)
+
+
+def count_fiction_backends(repo_root: Path) -> int:
+    """Count `source-*` modules whose main sources implement `FictionSource`."""
+    impl_re = re.compile(r":\s*FictionSource\b")
+    count = 0
+    for module_dir in sorted(repo_root.glob("source-*")):
+        main_dir = module_dir / "src" / "main"
+        if not main_dir.is_dir():
+            continue
+        for kt in main_dir.rglob("*.kt"):
+            try:
+                if impl_re.search(kt.read_text(encoding="utf-8", errors="ignore")):
+                    count += 1
+                    break
+            except OSError:
+                continue
+    return count
+
+
+# Three count spans, each (prefix)(number-word)(suffix). The number-word group
+# is validated against parse_number_word before substitution, so non-numeric
+# matches (e.g. "core modules") are left untouched.
+_FICTION_RE = re.compile(
+    r"(?P<num>[A-Za-z]+(?:-[A-Za-z]+)?)(?P<post>\s+fiction\s+backends)"
+)
+_ALL_BACKENDS_RE = re.compile(
+    r"(?P<pre>\bAll\s+)(?P<num>[A-Za-z]+(?:-[A-Za-z]+)?)(?P<post>\s+backends)"
+)
+_MODULES_RE = re.compile(
+    r"(?P<num>[A-Za-z]+(?:-[A-Za-z]+)?)(?P<post>\s+modules\b)"
+)
+
+
+def _match_leading_case(template: str, new: str) -> str:
+    """Apply the leading-cap of `template` to `new` (Thirty-four vs twenty-five)."""
+    if template[:1].isupper():
+        return new[:1].upper() + new[1:]
+    return new
+
+
+def update_intro_counts(
+    s: str, n_sources: int, n_modules: int
+) -> tuple[str, list[str]]:
+    """Rewrite the spelled-out intro counts to match the live repo counts.
+
+    Scoped to the hand-authored upper region (intro + Pages list) — never the
+    generated What's-new section or the hand-curated highlights below it.
+    Returns the new text plus a list of human-readable warnings for any count
+    span that couldn't be located (non-fatal; surfaced in the workflow log).
+    """
+    split_idx = len(s)
+    for marker in (WN_BEGIN, "\n## What's new", "\n## Recent"):
+        idx = s.find(marker)
+        if idx != -1:
+            split_idx = min(split_idx, idx)
+    head, tail = s[:split_idx], s[split_idx:]
+    notes: list[str] = []
+
+    src_word = num_to_words(n_sources)
+    mod_word = num_to_words(n_modules)
+
+    def make_repl(target_word: str, counter: list[int]):
+        def _repl(m: "re.Match[str]") -> str:
+            if parse_number_word(m.group("num")) is None:
+                return m.group(0)  # not a number-word — leave the prose alone
+            counter[0] += 1
+            pre = m.groupdict().get("pre") or ""
+            return pre + _match_leading_case(m.group("num"), target_word) + m.group("post")
+        return _repl
+
+    # Count only REAL substitutions — a span whose token actually parsed as a
+    # number — not raw regex hits. "many fiction backends" matches the pattern
+    # but is not a count, so it must still be reported as missing (and left
+    # untouched), not silently treated as "found".
+    n_fiction = [0]
+    n_all = [0]
+    n_modules_hits = [0]
+    head = _FICTION_RE.sub(make_repl(src_word, n_fiction), head)
+    head = _ALL_BACKENDS_RE.sub(make_repl(src_word, n_all), head)
+    head = _MODULES_RE.sub(make_repl(mod_word, n_modules_hits), head)
+
+    if n_fiction[0] == 0:
+        notes.append("no '<N> fiction backends' count found in Home intro")
+    if n_modules_hits[0] == 0:
+        notes.append("no '<N> modules' count found in Home intro")
+    # The Pages "All <N> backends" link is optional — only warn if neither
+    # backend phrasing was found at all (i.e. the whole backends count is gone).
+    if n_fiction[0] == 0 and n_all[0] == 0:
+        notes.append("no 'All <N> backends' Pages link count found")
+
+    return head + tail, notes
+
+
 def main() -> None:
     if len(sys.argv) != 2:
         raise SystemExit("usage: render_release_home.py <Home.md>")
@@ -167,6 +332,27 @@ def main() -> None:
             s = legacy_re.sub(whats_new + "\n\n", s, count=1)
         else:
             raise SystemExit("render_release_home: no '## What's new' section to take over")
+
+    # 4. Intro counts (#1146) — derive live from the repo's source of truth so
+    # the "twenty-five fiction backends" / "thirty-eight modules" intro can't
+    # silently re-stale. Non-fatal: a derivation failure (missing settings file,
+    # script run outside the repo) must never block a release.
+    repo_root = Path(os.environ.get("REPO_ROOT") or Path(__file__).resolve().parents[2])
+    try:
+        settings_path = repo_root / "settings.gradle.kts"
+        n_modules = count_modules(settings_path.read_text(encoding="utf-8"))
+        n_sources = count_fiction_backends(repo_root)
+        if n_modules and n_sources:
+            s, notes = update_intro_counts(s, n_sources, n_modules)
+            for note in notes:
+                print(f"::warning::render_release_home: {note}")
+            print(f"render_release_home: intro counts -> {n_sources} fiction "
+                  f"backends, {n_modules} modules.")
+        else:
+            print("::warning::render_release_home: could not derive intro counts "
+                  f"(modules={n_modules}, sources={n_sources}) — leaving intro untouched.")
+    except OSError as e:
+        print(f"::warning::render_release_home: intro-count derivation skipped: {e}")
 
     if s != orig:
         home_path.write_text(s, encoding="utf-8")

--- a/scripts/wiki/test_render_release_home.py
+++ b/scripts/wiki/test_render_release_home.py
@@ -162,5 +162,114 @@ class RenderHome(unittest.TestCase):
             render(broken)
 
 
+class NumberWords(unittest.TestCase):
+    def test_num_to_words(self):
+        self.assertEqual(rr.num_to_words(0), "zero")
+        self.assertEqual(rr.num_to_words(7), "seven")
+        self.assertEqual(rr.num_to_words(20), "twenty")
+        self.assertEqual(rr.num_to_words(25), "twenty-five")
+        self.assertEqual(rr.num_to_words(38), "thirty-eight")
+        self.assertEqual(rr.num_to_words(99), "ninety-nine")
+
+    def test_out_of_range_falls_back_to_digits(self):
+        self.assertEqual(rr.num_to_words(100), "100")
+        self.assertEqual(rr.num_to_words(-1), "-1")
+
+    def test_parse_number_word_roundtrip(self):
+        for n in range(0, 100):
+            self.assertEqual(rr.parse_number_word(rr.num_to_words(n)), n)
+
+    def test_parse_number_word_rejects_non_numbers(self):
+        self.assertIsNone(rr.parse_number_word("core"))
+        self.assertIsNone(rr.parse_number_word("Gradle"))
+        self.assertIsNone(rr.parse_number_word("twenty-zero"))
+        self.assertIsNone(rr.parse_number_word("twenty-twenty"))
+
+    def test_parse_number_word_case_insensitive(self):
+        self.assertEqual(rr.parse_number_word("Thirty-Four"), 34)
+
+
+class CountModules(unittest.TestCase):
+    def test_counts_live_includes_only(self):
+        settings = (
+            'include(":app")\n'
+            'include(":feature")\n'
+            '// include(":disabled")\n'
+            '  include(":source-ao3")\n'
+            'include(":app")\n'  # dup — counted once
+        )
+        self.assertEqual(rr.count_modules(settings), 3)
+
+
+class CountFictionBackends(unittest.TestCase):
+    def test_counts_source_modules_implementing_fictionsource(self):
+        with tempfile.TemporaryDirectory() as d:
+            root = Path(d)
+            # Two real backends + one source module with no FictionSource impl.
+            for name, body in (
+                ("source-ao3", "class Ao3Source : FictionSource { }"),
+                ("source-rss", "class RssSource(x: Y) : FictionSource {"),
+                ("source-empty", "object NotASource"),
+            ):
+                main = root / name / "src" / "main"
+                main.mkdir(parents=True)
+                (main / "S.kt").write_text(body)
+            # A non-source module is ignored even if it mentions FictionSource.
+            cd = root / "core-data" / "src" / "main"
+            cd.mkdir(parents=True)
+            (cd / "F.kt").write_text("interface FictionSource")
+            self.assertEqual(rr.count_fiction_backends(root), 2)
+
+
+class UpdateIntroCounts(unittest.TestCase):
+    INTRO = """\
+# Candela wiki
+
+Candela reads from twenty-one fiction backends across the web.
+
+## Pages
+
+- **[Fiction sources](Fiction-sources)** — All twenty-one backends.
+- **[Architecture](Architecture)** — Thirty-four modules and how they fit.
+
+## What's new in v1.0.0
+
+- A bullet mentioning ten modules that must NOT be rewritten.
+"""
+
+    def test_rewrites_all_three_counts(self):
+        out, notes = rr.update_intro_counts(self.INTRO, 25, 38)
+        self.assertIn("twenty-five fiction backends", out)
+        self.assertIn("All twenty-five backends", out)
+        self.assertIn("Thirty-eight modules", out)  # leading-cap preserved
+        self.assertEqual(notes, [])
+
+    def test_leaves_whats_new_section_untouched(self):
+        out, _ = rr.update_intro_counts(self.INTRO, 25, 38)
+        # The bullet below "## What's new" keeps its original "ten modules".
+        self.assertIn("ten modules that must NOT be rewritten", out)
+
+    def test_self_heals_from_already_current(self):
+        once, _ = rr.update_intro_counts(self.INTRO, 25, 38)
+        twice, _ = rr.update_intro_counts(once, 30, 40)
+        self.assertIn("thirty fiction backends", twice)
+        self.assertIn("All thirty backends", twice)
+        self.assertIn("Forty modules", twice)
+
+    def test_does_not_touch_non_number_words(self):
+        text = "The app has many fiction backends and core modules.\n## What's new\n"
+        out, notes = rr.update_intro_counts(text, 25, 38)
+        self.assertIn("many fiction backends", out)
+        self.assertIn("core modules", out)
+        # 'many fiction backends' isn't a number-word, so it reports as missing.
+        self.assertTrue(any("fiction backends" in n for n in notes))
+
+    def test_warns_when_count_phrase_absent(self):
+        text = "Intro with no counts at all.\n## What's new\n"
+        _, notes = rr.update_intro_counts(text, 25, 38)
+        self.assertTrue(any("fiction backends" in n for n in notes))
+        self.assertTrue(any("modules" in n for n in notes))
+
+
 if __name__ == "__main__":
     unittest.main(verbosity=2)


### PR DESCRIPTION
Closes #1160 · Closes #1146

## #1160 — dynamic status/loading not announced (live regions)

Several surfaces change content **without a user tap** (loading, progress, success/failure, sync state) but weren't `liveRegion`s, so TalkBack users got silence and had to blindly re-traverse the screen. **WCAG 4.1.3 Status Messages (Level AA).**

All 9 checklist items fixed — pattern: `Modifier.semantics { liveRegion = LiveRegionMode.Polite }`, **Assertive** for actionable errors:

| Surface | Fix | Mode |
|---|---|---|
| **StatusPill** (shared, 4 call sites) | tone-aware live region | Assertive on Error, else Polite |
| **ErrorBlock** Banner (shared) | refresh/append failure never moved focus | Assertive |
| **OfflineBanner** (shared) | add the real liveRegion its kdoc already claimed | Polite |
| **CreateAudiobookSheet** | announce Compose→Rendering→Done/Failed phases (not the % climb) | Polite / Assertive |
| **HybridReaderScreen** loading prompt | loading/Slow + the actionable TimedOut "Couldn't start / Retry" | Polite / Assertive |
| **RecapModal** | header subtitle tracks state transitions; error body assertive; streamed tokens stay silent | Polite / Assertive |
| **SyncStatusSheet** | header "Syncing in progress" → "Signed in" | Polite |
| **RoyalRoadTagSyncRow** | async sync outcome | Polite |
| **SettingsHubScreen** | "No results" message for empty search (was a blank card) | Polite |

Priority went to the **shared** components (StatusPill / ErrorBlock / OfflineBanner) — one fix each covers multiple call sites. Matches the in-house pattern already used in `SyncAuthScreen`, `PlaybackErrorBanner`, `OnboardingScaffold`.

## #1146 — wiki Home counts drift every release

The Home intro/Pages counts ("twenty-one fiction backends", "Thirty-four modules") were owned by **no** sync workflow and silently re-staled on every release that added a source or module.

`render_release_home.py` now **derives them live** (option 1 from the issue):
- modules from `settings.gradle.kts` `include()` count → **38**
- fiction backends from `source-*` modules implementing `FictionSource` → **25**

It rewrites the spelled-out number-words in place (`twenty-one`→`twenty-five`, `Thirty-four`→`thirty-eight`), preserving capitalization, scoped to the hand-authored upper region so the generated What's-new section is never touched. A non-numeric token (e.g. "core modules") is left alone; a missing count phrase emits a non-fatal `::warning::` rather than blocking the release. Workflow ownership comment updated to reflect the new region.

## Tests
- 12 new pure-stdlib tests in `test_render_release_home.py` (number-word round-trips, count derivation, in-place self-heal, capitalization, scoping, non-number-word guard, missing-phrase warnings). **All 23 pass.**
- End-to-end smoke test against a realistic stale Home.md confirmed correct rewrites.
- Kotlin: not compiled locally per project convention — CI on the self-hosted runner validates.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
