### PR TITLE
docs(play-store): drop raw github.com URL from full-description (#1178)

### DIFF
--- a/docs/play-store/listing/full-description.txt
+++ b/docs/play-store/listing/full-description.txt
@@ -25,4 +25,4 @@ FEATURES
 • Dark and light themes; TalkBack-friendly; WCAG AA contrast
 • Free, GPL-3.0, ad-free, no tracking, no account required
 
-Candela is built by TechEmpower, a 501(c)(3) nonprofit closing the digital divide with free tools, training, and software. Open source at github.com/techempower-org/candela.
+Candela is built by TechEmpower, a 501(c)(3) nonprofit closing the digital divide with free tools, training, and software. Open source on GitHub.


### PR DESCRIPTION
Fixes #1178 — raw `github.com` URL in the Play Store full-description body.

Google Play metadata policy disallows raw URLs / external links in the description body; links belong in dedicated Console fields (Privacy Policy, Developer Website). The trailing line of `docs/play-store/listing/full-description.txt` linked to the code-hosting repo, which risked an automated rejection at submission (flagged **HIGH** by gemini-code-assist on #1151, confirmed live on `main`).

## Change

```diff
-… free tools, training, and software. Open source at github.com/techempower-org/candela.
+… free tools, training, and software. Open source on GitHub.
```

Removed the bare URL, kept the open-source messaging. (GPL-3.0 is also already called out in the FEATURES list.)

## Scope check

I scanned all of `docs/play-store/` for raw URLs. The only other `github.com`/`https` hits are in `RUNBOOK.md` and `AUDIT.md` — internal operational docs, **not** submitted listing copy — so they're intentionally left as-is. `title.txt`, `short-description.txt`, and `release-notes-template.txt` contain no URLs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
