### PR TITLE
fix(playback): rethrow CancellationException in 3 PCM cache sites (#1175)

### DIFF
--- a/core-playback/src/main/kotlin/in/jphe/storyvox/playback/tts/EnginePlayer.kt
+++ b/core-playback/src/main/kotlin/in/jphe/storyvox/playback/tts/EnginePlayer.kt
@@ -2646,6 +2646,13 @@ class EnginePlayer @AssistedInject constructor(
                             "fromSentence=$currentSentenceIndex base=${key.fileBaseName().take(12)}",
                     )
                 }.onFailure { t ->
+                    // #1175 — a cancellation here (user paused/skipped while the
+                    // cache entry was being opened) is NOT cache corruption.
+                    // Deleting on cancel would nuke a perfectly valid entry and
+                    // force a full re-render on the next play — the exact
+                    // cache-integrity behavior #1130 set out to protect. Rethrow
+                    // so the open unwinds without touching disk.
+                    if (t is kotlin.coroutines.cancellation.CancellationException) throw t
                     // #1128 — the entry is "complete" (isComplete passed) but
                     // failed CacheFileSource's integrity gate: empty/degenerate
                     // index, truncated/missing .pcm, or unreadable idx.json.
@@ -4230,6 +4237,10 @@ class EnginePlayer @AssistedInject constructor(
         if (direction >= 0) {
             runCatching { positionRepo.resetToChapterStart(fiction, nextId) }
                 .onFailure {
+                    // #1175 — don't swallow cancellation during advanceChapter.
+                    // If this reset is cancelled (skip/cancel), the coroutine
+                    // must stop, not fall through into the load/play below.
+                    if (it is kotlin.coroutines.cancellation.CancellationException) throw it
                     android.util.Log.w(
                         "EnginePlayer",
                         "advanceChapter: resetToChapterStart($nextId) failed " +

--- a/core-playback/src/main/kotlin/in/jphe/storyvox/playback/tts/source/CacheFileSource.kt
+++ b/core-playback/src/main/kotlin/in/jphe/storyvox/playback/tts/source/CacheFileSource.kt
@@ -243,6 +243,12 @@ class CacheFileSource private constructor(
             val index = runCatching {
                 pcmCacheJson.decodeFromString(PcmIndex.serializer(), indexFile.readText())
             }.getOrElse { t ->
+                // #1175 — never rewrap cancellation as IOException. The caller
+                // keys its fall-back-to-streaming + cache-delete on IOException,
+                // so a CancellationException (pause/skip mid-open) would be
+                // misread as cache corruption and nuke a valid entry. Let it
+                // propagate so the open simply unwinds.
+                if (t is kotlin.coroutines.cancellation.CancellationException) throw t
                 throw IOException("PCM cache index unreadable: ${indexFile.name}", t)
             }
 


### PR DESCRIPTION
## Summary

Fixes #1175 — `runCatching` swallowed `CancellationException` at three PCM-cache sites, breaking structured concurrency and corrupting cache-recovery logic when a user paused or skipped mid-operation.

## Sites fixed

1. **`CacheFileSource.open()`** — `getOrElse` rewrapped `CancellationException` as `IOException`. The caller keys its fall-back-to-streaming + cache-delete on `IOException`, so a cancellation (pause/skip mid-open) was misread as cache corruption and would nuke a valid entry.
2. **`EnginePlayer` cache-hit open (~L2648)** — `onFailure` deleted a valid cache entry when the open was cancelled, forcing a full re-render on next play — the exact cache-integrity behavior #1130 set out to protect.
3. **`EnginePlayer.advanceChapter` (~L4237)** — `onFailure` on `resetToChapterStart` swallowed cancellation, letting a torn-down coroutine fall through into the load/play below.

## Fix

Each `onFailure`/`getOrElse` now rethrows `CancellationException` before its existing handling, matching the established pattern at `EnginePlayer.observeActiveVoice` (#878, L924).

## Verification

`./gradlew :core-playback:compileDebugKotlin` → **BUILD SUCCESSFUL** (only pre-existing unrelated warnings).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
