### PR TITLE
fix(librivox): normalize CRLF + make Gutenberg fetch cancellable (#1176)

### DIFF
--- a/source-librivox/src/main/kotlin/in/jphe/storyvox/source/librivox/LibriVoxSource.kt
+++ b/source-librivox/src/main/kotlin/in/jphe/storyvox/source/librivox/LibriVoxSource.kt
@@ -428,8 +428,7 @@ internal class LibriVoxSource @Inject constructor(
      *  paragraph newlines become `<br/>`). The reader's text pane reads
      *  `plainBody`, but persistence keeps both. */
     private fun gutenbergHtml(plain: String): String =
-        plain.split(PARAGRAPH_BREAK)
-            .asSequence()
+        PARAGRAPH_BREAK.splitToSequence(plain)
             .map { it.trim() }
             .filter { it.isNotEmpty() }
             .joinToString(separator = "") { para ->

--- a/source-librivox/src/main/kotlin/in/jphe/storyvox/source/librivox/net/GutenbergTextApi.kt
+++ b/source-librivox/src/main/kotlin/in/jphe/storyvox/source/librivox/net/GutenbergTextApi.kt
@@ -8,6 +8,7 @@ import okhttp3.Request
 import java.io.IOException
 import javax.inject.Inject
 import javax.inject.Singleton
+import kotlin.coroutines.coroutineContext
 
 /**
  * Issue #1046 — fetch the public-domain *text* that matches a LibriVox
@@ -62,7 +63,14 @@ internal class GutenbergTextApi @Inject constructor(
                 .header("User-Agent", USER_AGENT)
                 .get()
                 .build()
-            client.newCall(request).execute().use { resp ->
+            // The blocking `execute()` below doesn't observe coroutine
+            // cancellation on its own; tie the OkHttp call's lifetime to
+            // this coroutine's Job so a cancelled scope (e.g. the reader
+            // pane closes mid-fetch) aborts the in-flight request instead
+            // of leaking the socket until the response completes.
+            val call = client.newCall(request)
+            coroutineContext[kotlinx.coroutines.Job]?.invokeOnCompletion { call.cancel() }
+            call.execute().use { resp ->
                 val body = resp.body?.string().orEmpty()
                 when {
                     resp.code == 404 ->
@@ -134,7 +142,12 @@ internal class GutenbergTextApi @Inject constructor(
          * absent (a rare malformed file) the whole trimmed text is kept
          * so the reader still gets the book rather than nothing.
          */
-        internal fun stripGutenbergBoilerplate(raw: String): String {
+        internal fun stripGutenbergBoilerplate(input: String): String {
+            // Gutenberg plain-text files ship with CRLF (and the odd lone
+            // CR) line endings. Normalize to `\n` first so the marker
+            // line-slicing (`indexOf('\n', …)`) and the reader's paragraph
+            // splitting both see a single, consistent line terminator.
+            val raw = input.replace("\r\n", "\n").replace("\r", "\n")
             val startMatch = START_MARKER.find(raw)
             val afterStart = if (startMatch != null) {
                 // Skip to the end of the marker's line.

--- a/source-librivox/src/test/kotlin/in/jphe/storyvox/source/librivox/LibriVoxSourceTest.kt
+++ b/source-librivox/src/test/kotlin/in/jphe/storyvox/source/librivox/LibriVoxSourceTest.kt
@@ -219,4 +219,15 @@ class LibriVoxSourceTest {
         val raw = "A short public-domain snippet with no PG wrapper."
         assertEquals(raw, GutenbergTextApi.stripGutenbergBoilerplate(raw))
     }
+
+    @Test fun `stripGutenbergBoilerplate normalizes CRLF and lone CR line endings`() {
+        // Gutenberg files ship CRLF; the marker line-slicing keys off `\n`,
+        // so the body must come back with normalized `\n` separators and no
+        // stray carriage returns (issue #1176).
+        val raw = "junk\r\n***START OF THE PROJECT GUTENBERG EBOOK FOO***\r\n" +
+            "Line one.\r\nLine two.\r\n***END OF THE PROJECT GUTENBERG EBOOK FOO***\r\nfooter"
+        val body = GutenbergTextApi.stripGutenbergBoilerplate(raw)
+        assertEquals("Line one.\nLine two.", body)
+        assertFalse("no carriage returns remain", body.contains('\r'))
+    }
 }


### PR DESCRIPTION
Fixes #1176 — two issues in the Gutenberg companion-text client (`source-librivox`).

## Changes

**1. CRLF normalization** (`GutenbergTextApi.stripGutenbergBoilerplate`)
Gutenberg plain-text files ship with CRLF line endings (and the occasional lone CR). The boilerplate stripper slices on `\n` (`indexOf('\n', …)`), so carriage returns leaked into the reader's body and into the reader's paragraph splitting. The raw text is now normalized to `\n` at the top of the function.

**2. Cancellable OkHttp call** (`GutenbergTextApi.fetchPlainText`)
The synchronous `execute()` didn't observe coroutine cancellation, so closing the reader pane mid-fetch leaked the socket until the response finished. The call's lifetime is now tied to the coroutine `Job` via `invokeOnCompletion { call.cancel() }`.

**3. Streaming paragraph split** (`LibriVoxSource.gutenbergHtml`)
Replaced `plain.split(PARAGRAPH_BREAK).asSequence()` with the lazy `PARAGRAPH_BREAK.splitToSequence(plain)`, avoiding materialization of the full list.

## Tests
- Added `stripGutenbergBoilerplate normalizes CRLF and lone CR line endings`.
- `./gradlew :source-librivox:testDebugUnitTest` → **BUILD SUCCESSFUL**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
