### PR TITLE
fix(settings): guard uriHandler.openUri against missing browser (#1177)

### DIFF
--- a/feature/src/main/kotlin/in/jphe/storyvox/feature/settings/AboutSettingsScreen.kt
+++ b/feature/src/main/kotlin/in/jphe/storyvox/feature/settings/AboutSettingsScreen.kt
@@ -90,7 +90,7 @@ fun AboutSettingsScreen(
                 SettingsLinkRow(
                     title = stringResource(R.string.settings_about_privacy_policy),
                     subtitle = stringResource(R.string.settings_about_privacy_policy_subtitle),
-                    onClick = { uriHandler.openUri(PRIVACY_POLICY_URL) },
+                    onClick = { runCatching { uriHandler.openUri(PRIVACY_POLICY_URL) } },
                 )
             }
             SettingsGroupCard {

--- a/feature/src/main/kotlin/in/jphe/storyvox/feature/settings/OssLicensesScreen.kt
+++ b/feature/src/main/kotlin/in/jphe/storyvox/feature/settings/OssLicensesScreen.kt
@@ -90,8 +90,8 @@ fun OssLicensesScreen(
                         color = MaterialTheme.colorScheme.primary,
                         modifier = Modifier
                             .fillMaxWidth()
-                            .clickable { uriHandler.openUri(sourceUrl) }
                             .padding(vertical = spacing.xxs)
+                            .clickable { runCatching { uriHandler.openUri(sourceUrl) } }
                             .semantics { contentDescription = sourceLabel },
                     )
                 }


### PR DESCRIPTION
Fixes #1177.

## Problem
`uriHandler.openUri(...)` throws `ActivityNotFoundException` when no browser (or no activity able to handle the URI) is installed/enabled, crashing the app from the Settings → About surface.

## Changes
- **AboutSettingsScreen.kt** — wrap the privacy-policy link open in `runCatching { uriHandler.openUri(PRIVACY_POLICY_URL) }`.
- **OssLicensesScreen.kt** — wrap the source-URL link open in `runCatching { uriHandler.openUri(sourceUrl) }`.
- **OssLicensesScreen.kt** — reorder modifiers so `.padding(vertical = spacing.xxs)` precedes `.clickable { … }`, keeping the ripple/touch target within the padded bounds (modifier-order nit).

## Verification
`./gradlew :feature:compileDebugKotlin` passes (only unrelated deprecation notes from generated KSP code).

🤖 Generated with [Claude Code](https://claude.com/claude-code)