### PR TITLE
feat(settings): link accessibility statement from About (#1143)

### DIFF
--- a/feature/src/main/kotlin/in/jphe/storyvox/feature/settings/AboutSettingsScreen.kt
+++ b/feature/src/main/kotlin/in/jphe/storyvox/feature/settings/AboutSettingsScreen.kt
@@ -20,6 +20,7 @@ import `in`.jphe.storyvox.ui.theme.LocalSpacing
  *  reachable privacy-policy URL, and the policy must be reachable from inside
  *  the app too — surfaced here per #1138. */
 private const val PRIVACY_POLICY_URL = "https://candela.techempower.org/privacy/"
+private const val ACCESSIBILITY_STATEMENT_URL = "https://candela.techempower.org/accessibility/"
 
 /**
  * Settings → About subscreen (follow-up to #440 / #467).
@@ -90,7 +91,14 @@ fun AboutSettingsScreen(
                 SettingsLinkRow(
                     title = stringResource(R.string.settings_about_privacy_policy),
                     subtitle = stringResource(R.string.settings_about_privacy_policy_subtitle),
-                    onClick = { uriHandler.openUri(PRIVACY_POLICY_URL) },
+                    onClick = { runCatching { uriHandler.openUri(PRIVACY_POLICY_URL) } },
+                )
+            }
+            SettingsGroupCard {
+                SettingsLinkRow(
+                    title = stringResource(R.string.settings_about_accessibility),
+                    subtitle = stringResource(R.string.settings_about_accessibility_subtitle),
+                    onClick = { runCatching { uriHandler.openUri(ACCESSIBILITY_STATEMENT_URL) } },
                 )
             }
             SettingsGroupCard {

--- a/feature/src/main/res/values/strings.xml
+++ b/feature/src/main/res/values/strings.xml
@@ -668,6 +668,8 @@
     <string name="settings_about_built"> · built %1$s</string>
     <string name="settings_about_privacy_policy">Privacy Policy</string>
     <string name="settings_about_privacy_policy_subtitle">Opens in your browser</string>
+    <string name="settings_about_accessibility">Accessibility Statement</string>
+    <string name="settings_about_accessibility_subtitle">How Candela supports assistive technology</string>
     <!-- Settings · About → Open-source licenses (#1142) -->
     <string name="settings_about_licenses">Open-source licenses</string>
     <string name="settings_about_licenses_subtitle">The libraries that power Candela.</string>


### PR DESCRIPTION
## Summary
- Adds Accessibility Statement link row in Settings → About, between Privacy Policy and OSS Licenses
- Points to the existing hosted page at `candela.techempower.org/accessibility/`
- Guards all `uriHandler.openUri` calls in AboutSettingsScreen with `runCatching` (per #1177)
- 2 new string resources

Closes #1143

## Test plan
- [ ] Build APK CI
- [ ] Tap Accessibility Statement row → opens browser to the statement

Generated with [Claude Code](https://claude.com/claude-code)