### PR TITLE
feat(settings): add "Report objectionable content" mailto in About (#1140)

### DIFF
--- a/feature/src/main/kotlin/in/jphe/storyvox/feature/settings/AboutSettingsScreen.kt
+++ b/feature/src/main/kotlin/in/jphe/storyvox/feature/settings/AboutSettingsScreen.kt
@@ -22,6 +22,20 @@ import `in`.jphe.storyvox.ui.theme.LocalSpacing
 private const val PRIVACY_POLICY_URL = "https://candela.techempower.org/privacy/"
 private const val ACCESSIBILITY_STATEMENT_URL = "https://candela.techempower.org/accessibility/"
 
+/** Content-report mailto (#1140). Play Store IARC content rating expects a
+ *  reporting channel for the user-generated content Candela surfaces from
+ *  third-party sources (AO3, Royal Road, etc.). Subject + body are URL-encoded
+ *  at click time via [android.net.Uri.encode] so the em-dash and newlines
+ *  survive the mailto: scheme. */
+private const val CONTENT_REPORT_EMAIL = "support@techempower.org"
+private const val CONTENT_REPORT_SUBJECT = "Candela — Content Report"
+private const val CONTENT_REPORT_BODY = "Source: \nTitle: \nURL: \nDescription of concern: \n"
+
+private fun contentReportMailto(): String =
+    "mailto:$CONTENT_REPORT_EMAIL" +
+        "?subject=${android.net.Uri.encode(CONTENT_REPORT_SUBJECT)}" +
+        "&body=${android.net.Uri.encode(CONTENT_REPORT_BODY)}"
+
 /**
  * Settings → About subscreen (follow-up to #440 / #467).
  *
@@ -99,6 +113,13 @@ fun AboutSettingsScreen(
                     title = stringResource(R.string.settings_about_accessibility),
                     subtitle = stringResource(R.string.settings_about_accessibility_subtitle),
                     onClick = { runCatching { uriHandler.openUri(ACCESSIBILITY_STATEMENT_URL) } },
+                )
+            }
+            SettingsGroupCard {
+                SettingsLinkRow(
+                    title = stringResource(R.string.settings_about_report_content),
+                    subtitle = stringResource(R.string.settings_about_report_content_subtitle),
+                    onClick = { runCatching { uriHandler.openUri(contentReportMailto()) } },
                 )
             }
             SettingsGroupCard {

--- a/feature/src/main/res/values/strings.xml
+++ b/feature/src/main/res/values/strings.xml
@@ -670,6 +670,9 @@
     <string name="settings_about_privacy_policy_subtitle">Opens in your browser</string>
     <string name="settings_about_accessibility">Accessibility Statement</string>
     <string name="settings_about_accessibility_subtitle">How Candela supports assistive technology</string>
+    <!-- Settings · About → Report objectionable content (#1140, IARC content-rating compliance) -->
+    <string name="settings_about_report_content">Report objectionable content</string>
+    <string name="settings_about_report_content_subtitle">Flag inappropriate content from third-party sources</string>
     <!-- Settings · About → Open-source licenses (#1142) -->
     <string name="settings_about_licenses">Open-source licenses</string>
     <string name="settings_about_licenses_subtitle">The libraries that power Candela.</string>


### PR DESCRIPTION
## Summary

Adds a **Report objectionable content** link to **Settings → About**, opening a pre-filled email so users can flag inappropriate content surfaced from third-party sources.

Needed for **Play Store IARC content-rating compliance** — Candela surfaces user-generated content (AO3, Royal Road, etc.), so reviewers expect an in-app reporting mechanism. Closes #1140.

## What changed

- New `SettingsLinkRow` in the About subscreen, placed after the Accessibility Statement link:
  - **Title:** "Report objectionable content"
  - **Subtitle:** "Flag inappropriate content from third-party sources"
- `onClick` opens a `mailto:` to **support@techempower.org**:
  - Subject: `Candela — Content Report`
  - Body template: `Source: \nTitle: \nURL: \nDescription of concern: \n`
- Subject + body are URL-encoded via `android.net.Uri.encode` so the em-dash and newlines survive the `mailto:` scheme.
- Reuses the existing `runCatching { uriHandler.openUri(...) }` pattern (per #1177) so a missing mail client fails silently rather than crashing.
- New string resources: `settings_about_report_content`, `settings_about_report_content_subtitle`.

## Notes

- The legacy long-scroll `SettingsScreen` does **not** render the privacy/accessibility/licenses About links (those live only in the `AboutSettingsScreen` subscreen), so no mirror was needed.

## Test

- `./gradlew :feature:compileDebugKotlin` — **BUILD SUCCESSFUL** (only pre-existing deprecation warnings).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new “Report content” option in Settings > About.
  * Users can now quickly open an email draft to report objectionable content, with the subject and message prefilled.

* **Bug Fixes**
  * Improved handling of the prefilled message so special characters and line breaks are preserved correctly when opening the email app.



<!-- end of auto-generated comment: release notes by coderabbit.ai -->