### PR TITLE
fix(ao3): 1 req/sec politeness gate + honest compliance kdoc (#1141)

### DIFF
--- a/source-ao3/src/main/kotlin/in/jphe/storyvox/source/ao3/Ao3Source.kt
+++ b/source-ao3/src/main/kotlin/in/jphe/storyvox/source/ao3/Ao3Source.kt
@@ -49,9 +49,9 @@ import javax.inject.Singleton
  * picker (see [FANDOM_TAGS]); when no genre is selected the source
  * defaults to the Marvel Cinematic Universe feed (the curated list's
  * largest fandom) so the picker has something to render on first
- * open. Users wanting other fandoms use Search (deferred — AO3's
- * search is HTML-only and we don't want any scraping in v1) or a
- * future tag-picker UI.
+ * open. Users wanting other fandoms use Search (now live via
+ * [Ao3Api.searchWorks] — an HTML scrape of `/works/search`; see the
+ * compliance caveats below) or a future tag-picker UI.
  *
  * #408 — the Atom feed URL is built from each tag's numeric AO3 id
  * rather than its slug. AO3 dropped the slug→numeric redirect
@@ -62,10 +62,23 @@ import javax.inject.Singleton
  *
  * Legal posture: AO3 is run by the Organization for Transformative
  * Works, a 501(c)(3). Their ToS draws a hard line at commercial
- * scraping and paid-access apps. storyvox is free, open-source, and
- * uses only the two official surfaces above — no HTML scraping, no
- * paywall, no ads. The User-Agent identifies us with a contact URL so
- * OTW Ops can route any concerns to a real address.
+ * scraping and paid-access apps; storyvox is free, open-source, and
+ * has no paywall and no ads. The User-Agent identifies us with a
+ * contact URL so OTW Ops can route any concerns to a real address,
+ * and (#1141) requests are rate-limited to one per second via
+ * [Ao3RateLimitInterceptor][in.jphe.storyvox.source.ao3.net.Ao3RateLimitInterceptor].
+ *
+ * Compliance caveats (#1141 — be honest about what we actually do):
+ *  - Browse uses per-tag Atom feeds (`/tags/<id>/feed.atom`) and the
+ *    user's own index pages (`/users/<u>/subscriptions|readings`),
+ *    all of which AO3's robots.txt permits.
+ *  - But two surfaces touch robots.txt-*disallowed* paths for the
+ *    wildcard user-agent: per-work EPUB download (`/downloads/`) and
+ *    work Search ([Ao3Api.searchWorks] → `/works/search?`, which is
+ *    an HTML scrape). EPUB download is the only content path AO3
+ *    offers, so honoring robots there would disable the source
+ *    entirely; whether/how to reconcile this is a product decision
+ *    tracked in #1141. Do NOT assume "no scraping" — Search scrapes.
  *
  * Caveat carried in the issue: some "Archive Warning: Choose Not to
  * Use Warnings" works require a logged-in session for the EPUB

--- a/source-ao3/src/main/kotlin/in/jphe/storyvox/source/ao3/di/Ao3Module.kt
+++ b/source-ao3/src/main/kotlin/in/jphe/storyvox/source/ao3/di/Ao3Module.kt
@@ -19,6 +19,7 @@ import `in`.jphe.storyvox.source.ao3.auth.Ao3AuthSource
 import `in`.jphe.storyvox.source.ao3.auth.Ao3SessionHydrator
 import `in`.jphe.storyvox.source.ao3.net.Ao3Api
 import `in`.jphe.storyvox.source.ao3.net.Ao3CookieJar
+import `in`.jphe.storyvox.source.ao3.net.Ao3RateLimitInterceptor
 import okhttp3.OkHttpClient
 import java.io.File
 import java.util.concurrent.TimeUnit
@@ -65,7 +66,7 @@ internal object Ao3HttpModule {
     @Provides
     @Singleton
     @Ao3Http
-    fun provideClient(): OkHttpClient =
+    fun provideClient(rateLimit: Ao3RateLimitInterceptor): OkHttpClient =
         OkHttpClient.Builder()
             .connectTimeout(10, TimeUnit.SECONDS)
             // EPUB downloads dominate the read budget. AO3's longest
@@ -78,6 +79,12 @@ internal object Ao3HttpModule {
             .followRedirects(true)
             .followSslRedirects(true)
             .retryOnConnectionFailure(true)
+            // #1141 — process-wide 1 req/sec politeness gate. Shared
+            // singleton across both clients so anonymous catalog fetches
+            // and authed reads draw from one budget. OTW is publicly
+            // anti-scraping; AO3 was the only high-risk source with no
+            // throttle (Royal Road already gates at 1 req/sec).
+            .addInterceptor(rateLimit)
             .build()
 
     /**
@@ -94,7 +101,10 @@ internal object Ao3HttpModule {
     @Provides
     @Singleton
     @Ao3AuthedHttp
-    fun provideAuthedClient(jar: Ao3CookieJar): OkHttpClient =
+    fun provideAuthedClient(
+        jar: Ao3CookieJar,
+        rateLimit: Ao3RateLimitInterceptor,
+    ): OkHttpClient =
         OkHttpClient.Builder()
             .cookieJar(jar)
             .connectTimeout(10, TimeUnit.SECONDS)
@@ -103,6 +113,9 @@ internal object Ao3HttpModule {
             .followRedirects(true)
             .followSslRedirects(true)
             .retryOnConnectionFailure(true)
+            // #1141 — same shared politeness gate as the anonymous
+            // client (see provideClient). One budget across both.
+            .addInterceptor(rateLimit)
             .addInterceptor { chain ->
                 val req = chain.request().newBuilder()
                     .header("User-Agent", Ao3Api.USER_AGENT)

--- a/source-ao3/src/main/kotlin/in/jphe/storyvox/source/ao3/net/Ao3RateLimitInterceptor.kt
+++ b/source-ao3/src/main/kotlin/in/jphe/storyvox/source/ao3/net/Ao3RateLimitInterceptor.kt
@@ -1,0 +1,74 @@
+package `in`.jphe.storyvox.source.ao3.net
+
+import okhttp3.Interceptor
+import okhttp3.Response
+import javax.inject.Inject
+import javax.inject.Singleton
+
+/**
+ * Issue #1141 — process-wide politeness gate for archiveofourown.org.
+ *
+ * AO3 is run by the Organization for Transformative Works, which has
+ * publicly opposed scraping + AI ingestion (their robots.txt blocks
+ * GPTBot / CCBot / ChatGPT-User outright). Of storyvox's high-risk
+ * sources, AO3 was the *only* one with no request throttling at all —
+ * both OkHttp clients (anonymous + authed) were plain. Royal Road, a
+ * lower-risk source, already enforces a 1 req/sec gate
+ * ([`in`.jphe.storyvox.source.royalroad.net.RateLimitedClient]); AO3
+ * being the unguarded one was the wrong posture.
+ *
+ * This interceptor enforces a [MIN_REQUEST_INTERVAL_MS] floor between
+ * the *start* of consecutive requests, shared across both AO3 clients
+ * (it's a [Singleton] injected into both builders) so the anonymous
+ * catalog fetches and the authed subscription / Marked-for-Later reads
+ * draw from one politeness budget rather than two independent ones.
+ *
+ * Why a blocking sleep rather than a coroutine `delay`: OkHttp
+ * interceptors run synchronously on the client's dispatcher threads,
+ * never on the caller's coroutine. Blocking one of those worker
+ * threads briefly is exactly what they exist for, and it keeps the
+ * gate transparent to every call site in [Ao3Api] — no `suspend`
+ * plumbing, no change to the request-building code.
+ *
+ * Deliberately NOT a robots.txt enforcer: AO3's robots.txt disallows
+ * `/downloads/` (the only EPUB content path) and `/works/search?` for
+ * the wildcard user-agent, so strict enforcement would break the
+ * source. That trade-off is a product decision (see issue #1141), not
+ * something to encode silently here. This gate only spaces requests.
+ */
+@Singleton
+internal class Ao3RateLimitInterceptor @Inject constructor() : Interceptor {
+
+    private val lock = Any()
+
+    @Volatile
+    private var lastRequestAt: Long = 0L
+
+    override fun intercept(chain: Interceptor.Chain): Response {
+        synchronized(lock) {
+            val now = System.currentTimeMillis()
+            val wait = (lastRequestAt + MIN_REQUEST_INTERVAL_MS) - now
+            if (wait > 0) {
+                try {
+                    Thread.sleep(wait)
+                } catch (e: InterruptedException) {
+                    // Restore the flag so OkHttp's own cancellation /
+                    // timeout handling downstream still observes it.
+                    Thread.currentThread().interrupt()
+                }
+            }
+            lastRequestAt = System.currentTimeMillis()
+        }
+        return chain.proceed(chain.request())
+    }
+
+    companion object {
+        /** One request per second floor — matches Royal Road's
+         *  [`in`.jphe.storyvox.source.royalroad.model.RoyalRoadIds.MIN_REQUEST_INTERVAL_MS].
+         *  AO3's access pattern (paginated Atom Browse + one EPUB per
+         *  work open) is naturally low-volume, so this is cheap
+         *  insurance against bursts (rapid successive opens, fast Browse
+         *  paging) rather than a throughput bottleneck. */
+        const val MIN_REQUEST_INTERVAL_MS = 1_000L
+    }
+}


### PR DESCRIPTION
## Source-module ToS compliance audit (#1141)

Audited the three high-risk source modules — **Discord**, **AO3**, **Royal Road** — for authentication model, rate limiting, robots.txt compliance, and User-Agent honesty. This PR ships the one safe, in-scope fix found; the rest are documented findings (see below + scratch report).

### Risk ranking
| Source | Verdict |
|--------|---------|
| **AO3** | **HIGH** — fetches two robots.txt-disallowed paths, no robots check, **no rate limiting**. Fixed the throttling here. |
| **Royal Road** | LOW (well-handled) — 1 req/sec gate + RFC 9309 robots + crawl-delay + honeypot respect. Browser-impersonating UA the one weakness. |
| **Discord** | LOW (compliant) — **bot tokens only**, explicit no-self-bot, no bundled token, honest UA, 429 handling. |

### What this PR changes
- **`Ao3RateLimitInterceptor`** — new `@Singleton` process-wide politeness gate, **1 req/sec** floor, shared across AO3's anonymous + authed OkHttp clients so they draw from one budget. Synchronous gate inside the OkHttp interceptor (idiomatic — runs on dispatcher threads), so `Ao3Api` and its UA constant are untouched. Mirrors Royal Road's existing `RateLimitedClient` posture.
- **`Ao3Source` kdoc** — corrected the legal-posture comment. It claimed *"no HTML scraping / official surfaces only"*, but `searchWorks` scrapes `/works/search` and `downloadEpub` hits `/downloads/` — both **disallowed for the wildcard user-agent** in AO3's live robots.txt. Now documented honestly.

### Deliberately NOT changed (need decisions)
1. **robots.txt enforcement for AO3** — `/downloads/` (the only EPUB content path) and `/works/search?` are robots-disallowed. Strict enforcement would **disable the AO3 source entirely** → product decision for JP, not an autonomous change.
2. **User-Agent normalization** — owned by the #1141 UA task (Drift). Royal Road's browser-impersonating UA tension flagged there.
3. **Discord `MESSAGE_CONTENT` intent** — guild search needs the privileged intent; onboarding copy only mentions `READ_MESSAGE_HISTORY`. Doc-only follow-up.

### Verification
- `./gradlew :source-ao3:compileDebugKotlin` ✅
- `./gradlew :app:assembleDebug` ✅ (validates Hilt graph after the `@Provides` signature changes)

Full findings: `scratch/vesper-1141-source-audit.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)