### PR TITLE
fix(sync): delete InstantDB record on sign-out (#1139)

### DIFF
--- a/core-sync/src/main/kotlin/in/jphe/storyvox/sync/client/HttpInstantBackend.kt
+++ b/core-sync/src/main/kotlin/in/jphe/storyvox/sync/client/HttpInstantBackend.kt
@@ -193,6 +193,50 @@ class HttpInstantBackend(
         Unit
     }
 
+    /**
+     * Delete a row via a single `["delete", entity, id]` transact step
+     * (#1139 — the sign-out data-deletion path). Same admin-transact
+     * endpoint + as-token auth as [upsert]; the only difference is the verb
+     * and that a delete step carries no args object.
+     *
+     * Idempotent on the server: deleting a row that was never written
+     * returns 200, so purging every domain is safe even when only some rows
+     * exist. Wire shape mirrors `tx.<entity>[<id>].delete()` in the JS admin
+     * SDK (`client/packages/admin/src/index.ts`).
+     */
+    override suspend fun delete(
+        user: SignedInUser,
+        entity: String,
+        id: String,
+    ): Result<Unit> = runCatching {
+        if (!isConfigured) error(NOT_CONFIGURED)
+        android.util.Log.d(TAG, "delete: entity=$entity id=${id.take(12)}…")
+        val body = json.encodeToString(
+            JsonObject.serializer(),
+            buildJsonObject {
+                put("steps", buildJsonArray {
+                    add(buildJsonArray {
+                        add(JsonPrimitive("delete"))
+                        add(JsonPrimitive(entity))
+                        add(JsonPrimitive(id))
+                    })
+                })
+                put("throw-on-missing-attrs?", JsonPrimitive(false))
+            },
+        )
+        val res = transport.postJson(
+            url = "$apiUri/admin/transact?app_id=$appId",
+            jsonBody = body,
+            headers = adminHeaders(user.refreshToken),
+        )
+        if (!res.isSuccessful) {
+            android.util.Log.w(TAG, "delete: HTTP ${res.code} for $entity/${id.take(12)}…")
+            error(parseError(res, "transact"))
+        }
+        android.util.Log.d(TAG, "delete: HTTP ${res.code} OK")
+        Unit
+    }
+
     private fun adminHeaders(refreshToken: String): Map<String, String> = mapOf(
         // Lowercase header keys — exactly how the JS admin SDK sets them
         // (see `client/packages/admin/src/index.ts`). HTTP headers are

--- a/core-sync/src/main/kotlin/in/jphe/storyvox/sync/client/InstantBackend.kt
+++ b/core-sync/src/main/kotlin/in/jphe/storyvox/sync/client/InstantBackend.kt
@@ -45,6 +45,18 @@ interface InstantBackend {
         updatedAt: Long,
     ): Result<Unit>
 
+    /**
+     * Delete a row by entity + id. Used by the sign-out data-deletion path
+     * (#1139) so signing out actually removes the user's cloud record, as
+     * the privacy policy promises.
+     *
+     * Idempotent: deleting a row that doesn't exist (a domain the user never
+     * pushed) is a success, not an error — InstantDB's transact treats a
+     * delete of a missing entity as a no-op. So a blanket purge across every
+     * domain is safe even when only some rows were ever written.
+     */
+    suspend fun delete(user: SignedInUser, entity: String, id: String): Result<Unit>
+
     /** Whether the backend is wired up to talk to a real InstantDB.
      *  False when [BuildConfig.INSTANTDB_APP_ID] is the sentinel. */
     val isConfigured: Boolean
@@ -75,6 +87,13 @@ class DisabledBackend : InstantBackend {
         updatedAt: Long,
     ): Result<Unit> = Result.failure(IllegalStateException(NOT_CONFIGURED))
 
+    /** Vacuous success: with sync disabled nothing was ever written to
+     *  InstantDB, so there is nothing to delete. The sign-out deletion path
+     *  (#1139) must not report a spurious failure just because this build
+     *  has no sync backend. */
+    override suspend fun delete(user: SignedInUser, entity: String, id: String): Result<Unit> =
+        Result.success(Unit)
+
     private companion object {
         const val NOT_CONFIGURED = "Sync isn't configured for this build (placeholder INSTANTDB_APP_ID)"
     }
@@ -98,6 +117,12 @@ class FakeInstantBackend : InstantBackend {
         updatedAt: Long,
     ): Result<Unit> {
         store[entity to id] = RowSnapshot(payload, updatedAt)
+        return Result.success(Unit)
+    }
+
+    override suspend fun delete(user: SignedInUser, entity: String, id: String): Result<Unit> {
+        // Idempotent like the real backend: removing an absent key is fine.
+        store.remove(entity to id)
         return Result.success(Unit)
     }
 }

--- a/core-sync/src/main/kotlin/in/jphe/storyvox/sync/coordinator/SyncCoordinator.kt
+++ b/core-sync/src/main/kotlin/in/jphe/storyvox/sync/coordinator/SyncCoordinator.kt
@@ -29,9 +29,12 @@ import kotlinx.coroutines.sync.withLock
  *    a push pass first (the "migration" — every local row that exists
  *    today gets uploaded so a fresh install on another device can pull
  *    it back).
- *  - On sign-out, we don't auto-wipe local state — the user signs out
- *    to disable sync, not to nuke their on-device library. The
- *    refresh token is cleared and the syncers go quiet.
+ *  - On sign-out, we don't auto-wipe LOCAL state — the user signs out
+ *    to disable sync, not to nuke their on-device library. But we DO
+ *    delete the user's CLOUD copy via [purgeRemoteData] (#1139), which
+ *    is the deletion the privacy policy promises ("signing out deletes
+ *    your InstantDB record"). The refresh token is then revoked +
+ *    cleared and the syncers go quiet.
  *
  * Concurrency model: a single [SupervisorJob] scope, with one mutex per
  * domain (so a push and pull for the same domain don't race) but
@@ -110,6 +113,42 @@ class SyncCoordinator @Inject constructor(
             android.util.Log.i(TAG, "syncNow: pullAll done, starting pushAll")
             requestPushAll()
         }
+    }
+
+    /**
+     * Delete every domain's remote (InstantDB) row for [user] — the
+     * data-deletion path the privacy policy promises on sign-out (#1139).
+     *
+     * Called from the sign-out flow BEFORE the refresh token is revoked /
+     * cleared, because the admin API authorizes the delete via as-token
+     * impersonation with that same token. Runs each domain's [Syncer.purge]
+     * under the domain's own mutex (so a concurrent push/pull can't race the
+     * delete), serially across domains for deterministic logging.
+     *
+     * Returns true iff every domain purged cleanly. Best-effort by design:
+     * an offline sign-out still completes (the caller proceeds regardless),
+     * and the privacy policy's email-request path is the backstop for the
+     * rare partial-failure case. Local on-device data is intentionally NOT
+     * touched here — see the class kdoc.
+     */
+    suspend fun purgeRemoteData(user: SignedInUser): Boolean {
+        android.util.Log.i(TAG, "purgeRemoteData: deleting ${syncers.size} domains for user=${user.userId.take(8)}…")
+        var allOk = true
+        for (syncer in syncers) {
+            val mutex = locks[syncer.name] ?: continue
+            val outcome = mutex.withLock {
+                runCatching { syncer.purge(user) }
+                    .getOrElse { SyncOutcome.Transient(it.message ?: "purge threw") }
+            }
+            if (outcome is SyncOutcome.Ok) {
+                android.util.Log.i(TAG, "purge ${syncer.name}: OK")
+            } else {
+                allOk = false
+                android.util.Log.w(TAG, "purge ${syncer.name}: $outcome")
+            }
+        }
+        android.util.Log.i(TAG, "purgeRemoteData: complete, allOk=$allOk")
+        return allOk
     }
 
     /** Request a push for every domain. Used by the post-sign-in

--- a/core-sync/src/main/kotlin/in/jphe/storyvox/sync/coordinator/Syncer.kt
+++ b/core-sync/src/main/kotlin/in/jphe/storyvox/sync/coordinator/Syncer.kt
@@ -40,7 +40,36 @@ interface Syncer {
      * whether to LWW, union, or max-scalar.
      */
     suspend fun pull(user: SignedInUser): SyncOutcome
+
+    /**
+     * Delete this domain's remote (InstantDB) row(s) for [user]. Called by
+     * [SyncCoordinator.purgeRemoteData] on sign-out so signing out actually
+     * removes the user's cloud record — the deletion the privacy policy
+     * promises (#1139).
+     *
+     * Deliberately ABSTRACT (no default): a privacy/compliance guarantee
+     * must not silently skip a domain. Adding a new syncer forces a
+     * deliberate `purge` decision at compile time, the same safety the
+     * multibound `Set<Syncer>` gives the push/pull paths.
+     *
+     * Scope: this deletes only the CLOUD copy. Local on-device data is
+     * intentionally left intact (signing out disables sync; uninstalling
+     * clears local) — see [SyncCoordinator]'s class kdoc. Idempotent: a
+     * domain the user never pushed deletes a missing row, which the backend
+     * treats as success.
+     */
+    suspend fun purge(user: SignedInUser): SyncOutcome
 }
+
+/**
+ * Map a remote-delete [Result] to the [SyncOutcome] the purge path expects.
+ * Any failure is [SyncOutcome.Transient] — purge is best-effort on sign-out
+ * and the privacy policy's email-request path backstops the offline case.
+ */
+internal fun Result<Unit>.toPurgeOutcome(): SyncOutcome = fold(
+    onSuccess = { SyncOutcome.Ok(recordsAffected = 1) },
+    onFailure = { SyncOutcome.Transient(it.message ?: "delete failed") },
+)
 
 /** Result of a single push or pull. */
 sealed interface SyncOutcome {

--- a/core-sync/src/main/kotlin/in/jphe/storyvox/sync/domain/AnnotationsSyncer.kt
+++ b/core-sync/src/main/kotlin/in/jphe/storyvox/sync/domain/AnnotationsSyncer.kt
@@ -9,6 +9,7 @@ import `in`.jphe.storyvox.sync.client.InstantBackend
 import `in`.jphe.storyvox.sync.client.SignedInUser
 import `in`.jphe.storyvox.sync.coordinator.SyncOutcome
 import `in`.jphe.storyvox.sync.coordinator.Syncer
+import `in`.jphe.storyvox.sync.coordinator.toPurgeOutcome
 import javax.inject.Inject
 import javax.inject.Singleton
 import kotlinx.serialization.Serializable
@@ -80,6 +81,10 @@ class AnnotationsSyncer @Inject constructor(
 
     override suspend fun push(user: SignedInUser): SyncOutcome = reconcile(user)
     override suspend fun pull(user: SignedInUser): SyncOutcome = reconcile(user)
+
+    /** #1139 — delete the remote annotations blob on sign-out. */
+    override suspend fun purge(user: SignedInUser): SyncOutcome =
+        backend.delete(user, ENTITY, rowId(user)).toPurgeOutcome()
 
     private suspend fun reconcile(user: SignedInUser): SyncOutcome {
         val localRows = annotationDao.allAnnotations()

--- a/core-sync/src/main/kotlin/in/jphe/storyvox/sync/domain/BookmarksSyncer.kt
+++ b/core-sync/src/main/kotlin/in/jphe/storyvox/sync/domain/BookmarksSyncer.kt
@@ -8,6 +8,7 @@ import `in`.jphe.storyvox.sync.client.InstantBackend
 import `in`.jphe.storyvox.sync.client.SignedInUser
 import `in`.jphe.storyvox.sync.coordinator.SyncOutcome
 import `in`.jphe.storyvox.sync.coordinator.Syncer
+import `in`.jphe.storyvox.sync.coordinator.toPurgeOutcome
 import javax.inject.Inject
 import javax.inject.Singleton
 import kotlinx.serialization.Serializable
@@ -52,6 +53,10 @@ class BookmarksSyncer @Inject constructor(
 
     override suspend fun push(user: SignedInUser): SyncOutcome = reconcile(user)
     override suspend fun pull(user: SignedInUser): SyncOutcome = reconcile(user)
+
+    /** #1139 — delete the remote bookmarks blob on sign-out. */
+    override suspend fun purge(user: SignedInUser): SyncOutcome =
+        backend.delete(user, ENTITY, rowId(user)).toPurgeOutcome()
 
     private suspend fun reconcile(user: SignedInUser): SyncOutcome {
         val localRows = chapterDao.allBookmarks()

--- a/core-sync/src/main/kotlin/in/jphe/storyvox/sync/domain/FollowsSyncer.kt
+++ b/core-sync/src/main/kotlin/in/jphe/storyvox/sync/domain/FollowsSyncer.kt
@@ -35,6 +35,9 @@ class FollowsSyncer @Inject constructor(
     override suspend fun push(user: SignedInUser): SyncOutcome = delegate.push(user)
     override suspend fun pull(user: SignedInUser): SyncOutcome = delegate.pull(user)
 
+    /** #1139 — delete the remote follows set on sign-out. */
+    override suspend fun purge(user: SignedInUser): SyncOutcome = delegate.purge(user)
+
     suspend fun recordUnfollow(fictionId: String) {
         tombstones.add(DOMAIN, fictionId)
     }

--- a/core-sync/src/main/kotlin/in/jphe/storyvox/sync/domain/LibrarySyncer.kt
+++ b/core-sync/src/main/kotlin/in/jphe/storyvox/sync/domain/LibrarySyncer.kt
@@ -46,6 +46,9 @@ class LibrarySyncer @Inject constructor(
     override suspend fun push(user: SignedInUser): SyncOutcome = delegate.push(user)
     override suspend fun pull(user: SignedInUser): SyncOutcome = delegate.pull(user)
 
+    /** #1139 — delete the remote library set on sign-out. */
+    override suspend fun purge(user: SignedInUser): SyncOutcome = delegate.purge(user)
+
     /** Record that the user removed a fiction from their library. Called
      *  from the FictionRepository's remove-from-library path so the
      *  removal propagates on next sync. */

--- a/core-sync/src/main/kotlin/in/jphe/storyvox/sync/domain/LwwBlobSyncer.kt
+++ b/core-sync/src/main/kotlin/in/jphe/storyvox/sync/domain/LwwBlobSyncer.kt
@@ -5,6 +5,7 @@ import `in`.jphe.storyvox.sync.coordinator.ConflictPolicies
 import `in`.jphe.storyvox.sync.coordinator.Stamped
 import `in`.jphe.storyvox.sync.coordinator.SyncOutcome
 import `in`.jphe.storyvox.sync.coordinator.Syncer
+import `in`.jphe.storyvox.sync.coordinator.toPurgeOutcome
 
 /**
  * Reusable last-write-wins syncer for blob-shaped domains — the
@@ -29,10 +30,17 @@ class LwwBlobSyncer(
     interface BlobRemote {
         suspend fun fetch(user: SignedInUser): Result<Stamped<String>?>
         suspend fun push(user: SignedInUser, payload: Stamped<String>): Result<Unit>
+
+        /** Delete the remote row backing this blob domain (#1139). */
+        suspend fun delete(user: SignedInUser): Result<Unit>
     }
 
     override suspend fun push(user: SignedInUser): SyncOutcome = reconcile(user)
     override suspend fun pull(user: SignedInUser): SyncOutcome = reconcile(user)
+
+    /** #1139 — delete the remote blob row. Local copy is untouched
+     *  (sign-out deletes the cloud copy only; see [Syncer.purge]). */
+    override suspend fun purge(user: SignedInUser): SyncOutcome = remote.delete(user).toPurgeOutcome()
 
     private suspend fun reconcile(user: SignedInUser): SyncOutcome {
         val tag = "LwwSyncer[$name]"

--- a/core-sync/src/main/kotlin/in/jphe/storyvox/sync/domain/PlaybackPositionSyncer.kt
+++ b/core-sync/src/main/kotlin/in/jphe/storyvox/sync/domain/PlaybackPositionSyncer.kt
@@ -7,6 +7,7 @@ import `in`.jphe.storyvox.sync.client.InstantBackend
 import `in`.jphe.storyvox.sync.client.SignedInUser
 import `in`.jphe.storyvox.sync.coordinator.SyncOutcome
 import `in`.jphe.storyvox.sync.coordinator.Syncer
+import `in`.jphe.storyvox.sync.coordinator.toPurgeOutcome
 import javax.inject.Inject
 import javax.inject.Singleton
 import kotlinx.serialization.Serializable
@@ -91,6 +92,11 @@ class PlaybackPositionSyncer @Inject constructor(
 
     override suspend fun push(user: SignedInUser): SyncOutcome = reconcile(user)
     override suspend fun pull(user: SignedInUser): SyncOutcome = reconcile(user)
+
+    /** #1139 — delete the remote positions blob on sign-out. Local
+     *  positions stay on-device (cloud-copy-only deletion). */
+    override suspend fun purge(user: SignedInUser): SyncOutcome =
+        backend.delete(user, ENTITY, rowId(user)).toPurgeOutcome()
 
     private suspend fun reconcile(user: SignedInUser): SyncOutcome {
         val localPositions = localSnapshot()

--- a/core-sync/src/main/kotlin/in/jphe/storyvox/sync/domain/PronunciationDictSyncer.kt
+++ b/core-sync/src/main/kotlin/in/jphe/storyvox/sync/domain/PronunciationDictSyncer.kt
@@ -48,6 +48,9 @@ class PronunciationDictSyncer @Inject constructor(
     override suspend fun push(user: SignedInUser): SyncOutcome = delegate.push(user)
     override suspend fun pull(user: SignedInUser): SyncOutcome = delegate.pull(user)
 
+    /** #1139 — delete the remote pronunciation-dict blob on sign-out. */
+    override suspend fun purge(user: SignedInUser): SyncOutcome = delegate.purge(user)
+
     private suspend fun readLocal(): Stamped<String>? {
         val dict = repo.current()
         if (dict.entries.isEmpty()) return null

--- a/core-sync/src/main/kotlin/in/jphe/storyvox/sync/domain/Remotes.kt
+++ b/core-sync/src/main/kotlin/in/jphe/storyvox/sync/domain/Remotes.kt
@@ -103,6 +103,10 @@ class BackendSetRemote(
         )
     }
 
+    /** #1139 — delete this set domain's remote row on sign-out. */
+    override suspend fun delete(user: SignedInUser): Result<Unit> =
+        backend.delete(user, entity = ENTITY, id = rowId(user))
+
     private fun rowId(user: SignedInUser) = SyncIds.rowUuid(domain, user.userId)
 
     private companion object { const val ENTITY = "sets" }
@@ -131,6 +135,10 @@ class BackendBlobRemote(
             payload = payload.value,
             updatedAt = payload.updatedAt,
         )
+
+    /** #1139 — delete this blob domain's remote row on sign-out. */
+    override suspend fun delete(user: SignedInUser): Result<Unit> =
+        backend.delete(user, entity = ENTITY, id = rowId(user))
 
     private fun rowId(user: SignedInUser) = SyncIds.rowUuid(domain, user.userId)
 

--- a/core-sync/src/main/kotlin/in/jphe/storyvox/sync/domain/SecretsSyncer.kt
+++ b/core-sync/src/main/kotlin/in/jphe/storyvox/sync/domain/SecretsSyncer.kt
@@ -9,6 +9,7 @@ import `in`.jphe.storyvox.sync.coordinator.ConflictPolicies
 import `in`.jphe.storyvox.sync.coordinator.Stamped
 import `in`.jphe.storyvox.sync.coordinator.SyncOutcome
 import `in`.jphe.storyvox.sync.coordinator.Syncer
+import `in`.jphe.storyvox.sync.coordinator.toPurgeOutcome
 import `in`.jphe.storyvox.sync.crypto.UserDerivedKey
 import javax.crypto.SecretKey
 import javax.inject.Inject
@@ -135,6 +136,11 @@ class SecretsSyncer @Inject constructor(
 
     override suspend fun push(user: SignedInUser): SyncOutcome = reconcile(user)
     override suspend fun pull(user: SignedInUser): SyncOutcome = reconcile(user)
+
+    /** #1139 — delete the remote encrypted-secrets blob on sign-out. No
+     *  passphrase needed: deletion removes the row by id without reading it. */
+    override suspend fun purge(user: SignedInUser): SyncOutcome =
+        backend.delete(user, ENTITY, rowId(user)).toPurgeOutcome()
 
     private suspend fun reconcile(user: SignedInUser): SyncOutcome {
         val passphrase = passphraseProvider.get()

--- a/core-sync/src/main/kotlin/in/jphe/storyvox/sync/domain/SetSyncer.kt
+++ b/core-sync/src/main/kotlin/in/jphe/storyvox/sync/domain/SetSyncer.kt
@@ -5,6 +5,7 @@ import `in`.jphe.storyvox.sync.coordinator.ConflictPolicies
 import `in`.jphe.storyvox.sync.coordinator.SyncOutcome
 import `in`.jphe.storyvox.sync.coordinator.Syncer
 import `in`.jphe.storyvox.sync.coordinator.TombstonesAccess
+import `in`.jphe.storyvox.sync.coordinator.toPurgeOutcome
 
 /**
  * Reusable syncer for set-shaped domains — Library, Follows, Starred
@@ -66,6 +67,9 @@ class SetSyncer(
             tombstones: Map<String, Long>,
             memberData: Map<String, String>,
         ): Result<Unit>
+
+        /** Delete the remote row backing this set domain (#1139). */
+        suspend fun delete(user: SignedInUser): Result<Unit>
     }
 
     data class RemoteSet(
@@ -77,6 +81,10 @@ class SetSyncer(
     override suspend fun push(user: SignedInUser): SyncOutcome = pushImpl(user)
 
     override suspend fun pull(user: SignedInUser): SyncOutcome = pushImpl(user)
+
+    /** #1139 — delete the remote set row. Local membership is untouched
+     *  (sign-out deletes the cloud copy only; see [Syncer.purge]). */
+    override suspend fun purge(user: SignedInUser): SyncOutcome = remote.delete(user).toPurgeOutcome()
 
     /**
      * Push and pull are the same operation for set sync: read both

--- a/core-sync/src/main/kotlin/in/jphe/storyvox/sync/domain/SettingsSyncer.kt
+++ b/core-sync/src/main/kotlin/in/jphe/storyvox/sync/domain/SettingsSyncer.kt
@@ -9,6 +9,7 @@ import `in`.jphe.storyvox.sync.coordinator.ConflictPolicies
 import `in`.jphe.storyvox.sync.coordinator.Stamped
 import `in`.jphe.storyvox.sync.coordinator.SyncOutcome
 import `in`.jphe.storyvox.sync.coordinator.Syncer
+import `in`.jphe.storyvox.sync.coordinator.toPurgeOutcome
 import javax.inject.Inject
 import javax.inject.Singleton
 import kotlinx.serialization.builtins.MapSerializer
@@ -86,6 +87,10 @@ class SettingsSyncer @Inject constructor(
 
     override suspend fun push(user: SignedInUser): SyncOutcome = reconcile(user)
     override suspend fun pull(user: SignedInUser): SyncOutcome = reconcile(user)
+
+    /** #1139 — delete the remote settings blob on sign-out. */
+    override suspend fun purge(user: SignedInUser): SyncOutcome =
+        backend.delete(user, ENTITY, rowId(user)).toPurgeOutcome()
 
     /**
      * Fetch the remote row, merge per-key against the local snapshot,

--- a/core-sync/src/test/kotlin/in/jphe/storyvox/sync/HttpInstantBackendTest.kt
+++ b/core-sync/src/test/kotlin/in/jphe/storyvox/sync/HttpInstantBackendTest.kt
@@ -199,14 +199,59 @@ class HttpInstantBackendTest {
         )
     }
 
+    @Test fun `delete posts a single delete step with entity and id (issue 1139)`() = runTest {
+        val transport = FakeTransport(mapOf(
+            "/admin/transact" to TransportResult(200, """{"tx-id":43}"""),
+        ))
+        val backend = HttpInstantBackend("test-app", transport)
+
+        val res = backend.delete(
+            user,
+            entity = "blobs",
+            id = "0e9a6111-40d8-3ef1-9fd1-fadfe3240618",
+        )
+        assertTrue(res.isSuccess)
+
+        val call = transport.calls.single()
+        assertTrue(call.url.endsWith("/admin/transact?app_id=test-app"))
+        assertEquals("rt-1", call.headers["as-token"])
+        // Body: { steps: [["delete","blobs","0e9a6111-…"]], "throw-on-missing-attrs?": false }
+        // The delete step carries NO args object — that's the only shape
+        // difference from update; a stray payload object would be a wire drift.
+        assertTrue("body has steps envelope", call.body.contains("\"steps\""))
+        assertTrue("body includes delete verb", call.body.contains("\"delete\""))
+        assertFalse("delete must NOT carry an update verb", call.body.contains("\"update\""))
+        assertFalse("delete step carries no payload args", call.body.contains("\"payload\""))
+        assertTrue("body includes entity", call.body.contains("\"blobs\""))
+        assertTrue("body includes id", call.body.contains("\"0e9a6111-40d8-3ef1-9fd1-fadfe3240618\""))
+    }
+
+    @Test fun `delete surfaces server error on transact failure`() = runTest {
+        val transport = FakeTransport(mapOf(
+            "/admin/transact" to TransportResult(
+                403,
+                """{"message":"permission denied"}""",
+            ),
+        ))
+        val backend = HttpInstantBackend("test-app", transport)
+
+        val res = backend.delete(user, "blobs", "id")
+        assertTrue(res.isFailure)
+        assertTrue(
+            res.exceptionOrNull()?.message?.contains("permission denied") == true,
+        )
+    }
+
     @Test fun `placeholder appId disables the backend`() = runTest {
         val transport = FakeTransport(emptyMap())
         val backend = HttpInstantBackend(HttpInstantBackend.PLACEHOLDER_APP_ID, transport)
         assertFalse(backend.isConfigured)
         val r1 = backend.fetch(user, "blobs", "x")
         val r2 = backend.upsert(user, "blobs", "x", "p", 1L)
+        val r3 = backend.delete(user, "blobs", "x")
         assertTrue(r1.isFailure)
         assertTrue(r2.isFailure)
+        assertTrue(r3.isFailure)
         assertEquals("no network calls made", 0, transport.calls.size)
     }
 }

--- a/core-sync/src/test/kotlin/in/jphe/storyvox/sync/LwwBlobSyncerTest.kt
+++ b/core-sync/src/test/kotlin/in/jphe/storyvox/sync/LwwBlobSyncerTest.kt
@@ -10,6 +10,7 @@ import `in`.jphe.storyvox.sync.domain.LwwBlobSyncer
 import kotlinx.coroutines.test.runTest
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNull
 import org.junit.Assert.assertTrue
 import org.junit.Test
 
@@ -48,6 +49,26 @@ class LwwBlobSyncerTest {
         assertNotNull(newDevice.value)
         assertEquals("hello", newDevice.value!!.value)
         assertEquals(1000L, newDevice.value!!.updatedAt)
+    }
+
+    @Test fun `purge deletes the remote blob row but keeps local (issue 1139)`() = runTest {
+        val backend = FakeInstantBackend()
+        val local = LocalCell().apply { value = Stamped("secret-data", 1000L) }
+        val syncer = LwwBlobSyncer(
+            name = "pronunciation",
+            localRead = { local.value },
+            localWrite = { local.value = it },
+            remote = BackendBlobRemote("pronunciation", backend),
+        )
+        syncer.push(USER)
+        val rowId = SyncIds.rowUuid("pronunciation", USER.userId)
+        assertNotNull("remote row exists after push", backend.fetch(USER, "blobs", rowId).getOrThrow())
+
+        val outcome = syncer.purge(USER)
+        assertTrue(outcome is SyncOutcome.Ok)
+        assertNull("remote blob row deleted by purge", backend.fetch(USER, "blobs", rowId).getOrThrow())
+        // Cloud-copy-only deletion — the local blob is intentionally retained.
+        assertNotNull("local copy retained after purge", local.value)
     }
 
     @Test fun `newer remote overrides local on pull`() = runTest {

--- a/core-sync/src/test/kotlin/in/jphe/storyvox/sync/SetSyncerTest.kt
+++ b/core-sync/src/test/kotlin/in/jphe/storyvox/sync/SetSyncerTest.kt
@@ -10,6 +10,8 @@ import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.test.runTest
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNull
 import org.junit.Assert.assertTrue
 import org.junit.Test
 
@@ -81,6 +83,28 @@ class SetSyncerTest {
         val pull2 = syncer2.pull(USER)
         assertTrue(pull2 is SyncOutcome.Ok)
         assertEquals(setOf("a", "b", "c"), device2)
+    }
+
+    @Test fun `purge deletes the remote set row but keeps local (issue 1139)`() = runTest {
+        val backend = FakeInstantBackend()
+        val localState = mutableSetOf("a", "b")
+        val syncer = SetSyncer(
+            name = "library",
+            tombstones = InMemoryTombstones(),
+            localSnapshot = { localState.toSet() },
+            localAdd = { localState.add(it) },
+            localRemove = { localState.remove(it) },
+            remote = BackendSetRemote("library", backend),
+        )
+        syncer.push(USER)
+        val rowId = SyncIds.rowUuid("library", USER.userId)
+        assertNotNull("remote row exists after push", backend.fetch(USER, "sets", rowId).getOrThrow())
+
+        val outcome = syncer.purge(USER)
+        assertTrue(outcome is SyncOutcome.Ok)
+        assertNull("remote set row deleted by purge", backend.fetch(USER, "sets", rowId).getOrThrow())
+        // Sign-out deletes the CLOUD copy only — local membership is retained.
+        assertEquals(setOf("a", "b"), localState)
     }
 
     @Test fun `tombstone on one device removes the member on the other after sync`() = runTest {

--- a/feature/src/main/kotlin/in/jphe/storyvox/feature/sync/SyncAuthViewModel.kt
+++ b/feature/src/main/kotlin/in/jphe/storyvox/feature/sync/SyncAuthViewModel.kt
@@ -124,13 +124,31 @@ class SyncAuthViewModel @Inject constructor(
         }
     }
 
-    /** Local sign-out + best-effort server sign-out. */
+    /**
+     * Sign out: delete the user's cloud data, revoke the token server-side,
+     * then wipe local credentials.
+     *
+     * Issue #1139 — signing out must actually delete the InstantDB record,
+     * as the privacy policy promises ("signing out of sync deletes your
+     * record"). [SyncCoordinator.purgeRemoteData] runs FIRST, while
+     * [current]'s refresh token is still valid — the admin delete API
+     * authorizes via as-token impersonation with that token, so deletion
+     * must precede [InstantClient.signOut] (which revokes it) and
+     * [InstantSession.clear] (which forgets it).
+     *
+     * All three steps are best-effort: an offline sign-out still completes
+     * locally (the user shouldn't be trapped signed-in), and the privacy
+     * policy's email-request path backstops a failed cloud delete. Local
+     * on-device library/positions are intentionally kept — see
+     * [SyncCoordinator]'s class kdoc.
+     */
     fun signOut() {
         val current = session.current() ?: run {
             _state.value = SignInState.SignedOut(email = "")
             return
         }
         viewModelScope.launch {
+            coordinator.purgeRemoteData(current) // #1139 delete cloud data while token is valid
             client.signOut(current.refreshToken) // best-effort; ignored on failure
             session.clear()
             _state.value = SignInState.SignedOut(email = "")


### PR DESCRIPTION
## Problem

The privacy policy (`docs/privacy.md`) repeatedly promises **"signing out of sync deletes your InstantDB record"** (L13, L53–54, L182, L236–237), and the Play Store Data Safety form claims **"Users can request data deletion = Yes."** Both were **untruthful as implemented.**

Sign-out (`SyncAuthViewModel.signOut()`) only:
1. `InstantClient.signOut()` → `POST /runtime/signout` — **revokes the refresh token server-side only**.
2. `InstantSession.clear()` → wipes local `EncryptedSharedPreferences`.

The user's cloud data — library/follows sets, reading positions, bookmarks, annotations, pronunciation dict, **encrypted secrets**, settings — **persisted on InstantDB's servers indefinitely** after sign-out. Root cause: the `InstantBackend` interface had only `fetch` + `upsert`; **no delete operation existed anywhere in core-sync.**

## Fix

A real deletion path, wired into sign-out, using the same InstantDB admin transact API the syncers already use:

- **`InstantBackend.delete(user, entity, id)`** — new method. `HttpInstantBackend` emits a `["delete", entity, id]` transact step (idempotent — deleting a never-written row is a 200 no-op, so a blanket purge is safe). `DisabledBackend` → vacuous success; `FakeInstantBackend` → map remove.
- **`SetSyncer.SetRemote.delete` / `LwwBlobSyncer.BlobRemote.delete`** seams → `BackendSetRemote` / `BackendBlobRemote`.
- **`Syncer.purge(user)`** — new **abstract** method (compile-time-enforced so no syncer silently skips deletion); implemented across all 10 syncers.
- **`SyncCoordinator.purgeRemoteData(user)`** — deletes every domain's row under its per-domain mutex; returns true iff all succeeded.
- **`SyncAuthViewModel.signOut()`** purges **first** (while the token is still valid — the admin delete authorizes via as-token impersonation), then revokes + clears.

### Every row deleted (one deterministic row per user)

| Domain | entity | Domain | entity |
|---|---|---|---|
| library | `sets` | bookmarks | `blobs` |
| follows | `sets` | annotations | `blobs` |
| positions | `positions` | pronunciation | `blobs` |
| secrets | `blobs` | settings | `blobs` |

### Scope boundaries
- **CLOUD copy only.** Local on-device library/positions stay until uninstall — matches the privacy policy ("uninstalling clears local") and the pre-existing coordinator design ("the user signs out to disable sync, not to nuke their on-device library").
- **Best-effort.** An offline sign-out still completes (user isn't trapped signed-in), consistent with the existing best-effort `signOut()`. The policy's email-request path (`jp@jphein.com`) backstops the offline edge — together they satisfy Data Safety = Yes.
- The Royal Road content-source logout (`SettingsViewModel.signOut()`) is unrelated and untouched.

## Tests
- `HttpInstantBackendTest`: delete wire-shape (asserts the delete step carries **no** payload args), transact-error surfacing, placeholder-disabled.
- `SetSyncerTest` + `LwwBlobSyncerTest`: purge round-trips — remote row gone after `purge()`, local copy retained.

`:core-sync:compileDebugKotlin`, `:feature:compileDebugKotlin`, and `:core-sync:testDebugUnitTest` all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)