### PR TITLE
fix(sources): centralize descriptive User-Agent for Wikipedia, arXiv, Radio Browser (#1141)

### DIFF
--- a/app/src/main/kotlin/in/jphe/storyvox/di/AppBindings.kt
+++ b/app/src/main/kotlin/in/jphe/storyvox/di/AppBindings.kt
@@ -9,7 +9,10 @@ import dagger.Provides
 import dagger.hilt.InstallIn
 import dagger.hilt.android.qualifiers.ApplicationContext
 import dagger.hilt.components.SingletonComponent
+import `in`.jphe.storyvox.BuildConfig
 import `in`.jphe.storyvox.data.PalaceConfigImpl
+import `in`.jphe.storyvox.data.network.UserAgent
+import `in`.jphe.storyvox.data.network.UserAgentHeader
 import `in`.jphe.storyvox.data.SettingsRepositoryUiImpl
 import `in`.jphe.storyvox.data.VoiceProviderUiImpl
 import `in`.jphe.storyvox.source.mempalace.config.PalaceConfig
@@ -73,6 +76,7 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.launch
+import okhttp3.Interceptor
 
 /**
  * Hilt bindings that bridge `feature.api.*` UI contracts to the concrete
@@ -487,6 +491,35 @@ object AppBindings {
                 }
             }
         }
+
+    /**
+     * Issue #1141 — descriptive User-Agent interceptor, shared across the
+     * source modules whose upstreams require/request an identifying UA
+     * (Wikipedia, Wikisource, arXiv, Radio Browser). Built from the live
+     * build's [BuildConfig.VERSION_NAME] so the version never drifts out
+     * of sync with the app — see [UserAgent] for the policy rationale and
+     * the canonical string shape.
+     *
+     * Lives in `:app` because only the app module carries
+     * `BuildConfig.VERSION_NAME`; the per-source DI modules inject this
+     * [UserAgentHeader]-qualified interceptor into their dedicated
+     * OkHttpClient builders. It does not clobber a request that already
+     * set its own `User-Agent`, leaving room for a source to override if
+     * a future upstream needs a bespoke token.
+     */
+    @Provides @Singleton @UserAgentHeader
+    fun provideUserAgentInterceptor(): Interceptor {
+        val header = UserAgent.format(BuildConfig.VERSION_NAME)
+        return Interceptor { chain ->
+            val request = chain.request()
+            val withUserAgent = if (request.header("User-Agent") == null) {
+                request.newBuilder().header("User-Agent", header).build()
+            } else {
+                request
+            }
+            chain.proceed(withUserAgent)
+        }
+    }
 
     /**
      * Stub WebViewFetcher — Selene's `:core-data` declares the interface; the

--- a/core-data/src/main/kotlin/in/jphe/storyvox/data/network/UserAgent.kt
+++ b/core-data/src/main/kotlin/in/jphe/storyvox/data/network/UserAgent.kt
@@ -1,0 +1,70 @@
+package `in`.jphe.storyvox.data.network
+
+import javax.inject.Qualifier
+
+/**
+ * Issue #1141 — single source of truth for Candela's descriptive
+ * User-Agent string.
+ *
+ * Several upstream APIs require or explicitly request an identifying
+ * User-Agent that names the app + version + a contact channel:
+ *
+ *  - **Wikimedia** (Wikipedia + Wikisource) *requires* it — the REST /
+ *    Action API 403s anonymous traffic without a descriptive UA per
+ *    https://meta.wikimedia.org/wiki/User-Agent_policy.
+ *  - **arXiv** asks automated clients to identify themselves
+ *    (https://info.arxiv.org/help/robots.html).
+ *  - **Radio Browser** asks callers to identify themselves in the UA so
+ *    abusive clients can be contacted directly.
+ *
+ * Before #1141 each source baked its own stale `storyvox-*` string mixing
+ * pre-rebrand identities (`jphein/storyvox`, `jp@jphein.com`) with
+ * hand-maintained version numbers that drifted out of sync with the app's
+ * real version. Centralising the pieces here — and building the final
+ * header from the live build's version — means the rebrand or a version
+ * bump is a one-line change and every source stays consistent.
+ *
+ * The header is applied per-OkHttpClient via the [UserAgentHeader]-qualified
+ * `okhttp3.Interceptor` provided in `:app` (where `BuildConfig.VERSION_NAME`
+ * is available); see `AppBindings.provideUserAgentInterceptor`. Keeping the
+ * builder okhttp-free lets this foundational module stay dependency-light —
+ * only the `:app` provider and the per-source DI modules touch OkHttp.
+ */
+object UserAgent {
+    /** Product token — the rebranded app name. */
+    const val APP_NAME: String = "Candela"
+
+    /** Contact URL embedded in the UA so an upstream operator can reach
+     *  the project. The app's public microsite. */
+    const val CONTACT_URL: String = "https://candela.techempower.org"
+
+    /** Contact email embedded in the UA — reaches the maintainers. */
+    const val CONTACT_EMAIL: String = "support@techempower.org"
+
+    /** Platform token. */
+    const val PLATFORM: String = "Android"
+
+    /**
+     * Build the canonical descriptive User-Agent for a given app
+     * [version], e.g. `Candela/1.1.6 (https://candela.techempower.org;
+     * support@techempower.org) Android`.
+     *
+     * The shape — `product/version` followed by a parenthetical comment
+     * carrying the contact URL + email — is the form Wikimedia's
+     * User-Agent policy documents and the one arXiv / Radio Browser
+     * expect for identifiable automated traffic.
+     */
+    fun format(version: String): String =
+        "$APP_NAME/$version ($CONTACT_URL; $CONTACT_EMAIL) $PLATFORM"
+}
+
+/**
+ * Qualifies the descriptive-User-Agent `okhttp3.Interceptor` provided in
+ * `:app` (it needs `BuildConfig.VERSION_NAME`, which only the app module
+ * carries). Source modules inject the qualified interceptor into their
+ * dedicated OkHttpClient builders so every outbound request identifies the
+ * app + version + contact — see issue #1141 and [UserAgent].
+ */
+@Qualifier
+@Retention(AnnotationRetention.BINARY)
+annotation class UserAgentHeader

--- a/source-arxiv/src/main/kotlin/in/jphe/storyvox/source/arxiv/di/ArxivModule.kt
+++ b/source-arxiv/src/main/kotlin/in/jphe/storyvox/source/arxiv/di/ArxivModule.kt
@@ -7,9 +7,11 @@ import dagger.hilt.InstallIn
 import dagger.hilt.components.SingletonComponent
 import dagger.multibindings.IntoMap
 import dagger.multibindings.StringKey
+import `in`.jphe.storyvox.data.network.UserAgentHeader
 import `in`.jphe.storyvox.data.source.FictionSource
 import `in`.jphe.storyvox.data.source.SourceIds
 import `in`.jphe.storyvox.source.arxiv.ArxivSource
+import okhttp3.Interceptor
 import okhttp3.OkHttpClient
 import javax.inject.Qualifier
 import javax.inject.Singleton
@@ -36,7 +38,9 @@ internal object ArxivHttpModule {
     @Provides
     @Singleton
     @ArxivHttp
-    fun provideClient(): OkHttpClient =
+    fun provideClient(
+        @UserAgentHeader userAgent: Interceptor,
+    ): OkHttpClient =
         OkHttpClient.Builder()
             .connectTimeout(5, TimeUnit.SECONDS)
             .readTimeout(30, TimeUnit.SECONDS)
@@ -44,6 +48,9 @@ internal object ArxivHttpModule {
             .followRedirects(true)
             .followSslRedirects(true)
             .retryOnConnectionFailure(true)
+            // #1141 — arXiv asks automated clients to identify themselves
+            // (https://info.arxiv.org/help/robots.html).
+            .addInterceptor(userAgent)
             .build()
 
     @Provides

--- a/source-arxiv/src/main/kotlin/in/jphe/storyvox/source/arxiv/net/ArxivApi.kt
+++ b/source-arxiv/src/main/kotlin/in/jphe/storyvox/source/arxiv/net/ArxivApi.kt
@@ -131,10 +131,14 @@ internal class ArxivApi @Inject constructor(
     private suspend fun getRaw(url: String): FictionResult<String> =
         withContext(Dispatchers.IO) {
             try {
+                // #1141 — the identifying `User-Agent` arXiv asks
+                // automated clients to send is applied for every request
+                // by the shared UserAgentHeader interceptor on the
+                // injected client; see
+                // `in.jphe.storyvox.data.network.UserAgent`.
                 val req = Request.Builder()
                     .url(url)
                     .header("Accept", "application/atom+xml, text/html;q=0.9, */*;q=0.5")
-                    .header("User-Agent", USER_AGENT)
                     .get()
                     .build()
                 client.newCall(req).execute().use { resp ->
@@ -192,11 +196,6 @@ internal class ArxivApi @Inject constructor(
 
         /** Per-paper abstract page host. */
         const val ABS_BASE: String = "https://arxiv.org/abs"
-
-        /** arXiv requests an identifying User-Agent on automated traffic
-         *  (see https://info.arxiv.org/help/robots.html). */
-        const val USER_AGENT: String =
-            "storyvox-arxiv/1.0 (https://github.com/techempower-org/candela; jp@jphein.com)"
     }
 }
 

--- a/source-radio/src/main/kotlin/in/jphe/storyvox/source/radio/RadioSource.kt
+++ b/source-radio/src/main/kotlin/in/jphe/storyvox/source/radio/RadioSource.kt
@@ -412,9 +412,6 @@ internal class RadioSource @Inject constructor(
         /** Legacy v0.5.20+ KVMR chapterId — same preservation rationale. */
         const val LEGACY_KVMR_CHAPTER_ID: String = "kvmr:live:0"
 
-        const val USER_AGENT: String =
-            "storyvox-radio/0.5.32 (+https://github.com/techempower-org/candela)"
-
         /**
          * Sentinel prefixes used by [applyFilters] to smuggle the
          * country / language / tag filters through [SearchQuery.tags].

--- a/source-radio/src/main/kotlin/in/jphe/storyvox/source/radio/di/RadioModule.kt
+++ b/source-radio/src/main/kotlin/in/jphe/storyvox/source/radio/di/RadioModule.kt
@@ -7,9 +7,11 @@ import dagger.hilt.InstallIn
 import dagger.hilt.components.SingletonComponent
 import dagger.multibindings.IntoMap
 import dagger.multibindings.StringKey
+import `in`.jphe.storyvox.data.network.UserAgentHeader
 import `in`.jphe.storyvox.data.source.FictionSource
 import `in`.jphe.storyvox.data.source.SourceIds
 import `in`.jphe.storyvox.source.radio.RadioSource
+import okhttp3.Interceptor
 import okhttp3.OkHttpClient
 import javax.inject.Qualifier
 import javax.inject.Singleton
@@ -37,7 +39,9 @@ internal object RadioHttpModule {
     @Provides
     @Singleton
     @RadioHttp
-    fun provideClient(): OkHttpClient =
+    fun provideClient(
+        @UserAgentHeader userAgent: Interceptor,
+    ): OkHttpClient =
         OkHttpClient.Builder()
             .connectTimeout(5, TimeUnit.SECONDS)
             .readTimeout(30, TimeUnit.SECONDS)
@@ -45,6 +49,9 @@ internal object RadioHttpModule {
             .followRedirects(true)
             .followSslRedirects(true)
             .retryOnConnectionFailure(true)
+            // #1141 — Radio Browser asks callers to identify themselves
+            // in the UA so abusive clients can be contacted directly.
+            .addInterceptor(userAgent)
             .build()
 
     @Provides

--- a/source-radio/src/main/kotlin/in/jphe/storyvox/source/radio/net/RadioBrowserApi.kt
+++ b/source-radio/src/main/kotlin/in/jphe/storyvox/source/radio/net/RadioBrowserApi.kt
@@ -174,13 +174,14 @@ internal class RadioBrowserApi @Inject constructor(
 
     private suspend fun doRequest(url: String): FictionResult<String> = withContext(Dispatchers.IO) {
         try {
+            // #1141 — Radio Browser asks clients to identify themselves
+            // so abusive callers can be contacted directly. The
+            // descriptive `User-Agent` is applied for every request by the
+            // shared UserAgentHeader interceptor on the injected client;
+            // see `in.jphe.storyvox.data.network.UserAgent`.
             val request = Request.Builder()
                 .url(url)
                 .header("Accept", "application/json")
-                // Radio Browser asks clients to identify themselves so
-                // abusive callers can be contacted directly. The repo
-                // URL doubles as the contact channel.
-                .header("User-Agent", USER_AGENT)
                 .get()
                 .build()
             client.newCall(request).execute().use { resp ->
@@ -216,9 +217,6 @@ internal class RadioBrowserApi @Inject constructor(
          * round-robin DNS endpoint is a worse fit for our usage shape.
          */
         const val BASE_URL: String = "https://de1.api.radio-browser.info"
-
-        const val USER_AGENT: String =
-            "storyvox-radio/0.5.32 (+https://github.com/techempower-org/candela)"
     }
 }
 

--- a/source-radio/src/test/kotlin/in/jphe/storyvox/source/radio/RadioSourceTest.kt
+++ b/source-radio/src/test/kotlin/in/jphe/storyvox/source/radio/RadioSourceTest.kt
@@ -1,5 +1,6 @@
 package `in`.jphe.storyvox.source.radio
 
+import `in`.jphe.storyvox.data.network.UserAgent
 import `in`.jphe.storyvox.data.source.SourceIds
 import `in`.jphe.storyvox.data.source.model.FictionResult
 import `in`.jphe.storyvox.data.source.model.SearchQuery
@@ -249,8 +250,16 @@ class RadioSourceTest {
         assertEquals("kvmr:live:0", RadioSource.liveChapterIdFor(kvmr))
     }
 
-    @Test fun `user-agent identifies storyvox-radio`() {
-        assertTrue(RadioSource.USER_AGENT.contains("storyvox-radio"))
-        assertTrue(RadioSource.USER_AGENT.contains("github.com/techempower-org/candela"))
+    // #1141 — the descriptive User-Agent is now centralised in
+    // `in.jphe.storyvox.data.network.UserAgent` and applied to every
+    // Radio Browser request by the shared UserAgentHeader interceptor.
+    // Radio Browser asks callers to identify the app + a contact channel
+    // so abusive clients can be reached directly; pin that contract here.
+    @Test fun `user-agent identifies candela with contact info`() {
+        val ua = UserAgent.format("9.9.9")
+        assertTrue("UA names the app + version", ua.contains("Candela/9.9.9"))
+        assertTrue("UA carries a contact URL", ua.contains("candela.techempower.org"))
+        assertTrue("UA carries a contact email", ua.contains("support@techempower.org"))
+        assertTrue("UA identifies the platform", ua.contains("Android"))
     }
 }

--- a/source-wikipedia/src/main/kotlin/in/jphe/storyvox/source/wikipedia/di/WikipediaModule.kt
+++ b/source-wikipedia/src/main/kotlin/in/jphe/storyvox/source/wikipedia/di/WikipediaModule.kt
@@ -7,9 +7,11 @@ import dagger.hilt.InstallIn
 import dagger.hilt.components.SingletonComponent
 import dagger.multibindings.IntoMap
 import dagger.multibindings.StringKey
+import `in`.jphe.storyvox.data.network.UserAgentHeader
 import `in`.jphe.storyvox.data.source.FictionSource
 import `in`.jphe.storyvox.data.source.SourceIds
 import `in`.jphe.storyvox.source.wikipedia.WikipediaSource
+import okhttp3.Interceptor
 import okhttp3.OkHttpClient
 import javax.inject.Qualifier
 import javax.inject.Singleton
@@ -37,7 +39,9 @@ internal object WikipediaHttpModule {
     @Provides
     @Singleton
     @WikipediaHttp
-    fun provideClient(): OkHttpClient =
+    fun provideClient(
+        @UserAgentHeader userAgent: Interceptor,
+    ): OkHttpClient =
         OkHttpClient.Builder()
             .connectTimeout(5, TimeUnit.SECONDS)
             .readTimeout(30, TimeUnit.SECONDS)
@@ -45,6 +49,10 @@ internal object WikipediaHttpModule {
             .followRedirects(true)
             .followSslRedirects(true)
             .retryOnConnectionFailure(true)
+            // #1141 — Wikimedia *requires* a descriptive UA with contact
+            // info per https://meta.wikimedia.org/wiki/User-Agent_policy;
+            // anonymous traffic without one is 403'd into a restrictive tier.
+            .addInterceptor(userAgent)
             .build()
 
     @Provides

--- a/source-wikipedia/src/main/kotlin/in/jphe/storyvox/source/wikipedia/net/WikipediaApi.kt
+++ b/source-wikipedia/src/main/kotlin/in/jphe/storyvox/source/wikipedia/net/WikipediaApi.kt
@@ -208,11 +208,14 @@ internal class WikipediaApi @Inject constructor(
             // signature + `withContext(Dispatchers.IO)` wrapper. The
             // original non-suspend shape crashed Browse → Wikipedia
             // with NetworkOnMainThreadException on first chip tap.
+            // #1141 — the descriptive `User-Agent` Wikimedia requires
+            // (project + contact) is applied for every request by the
+            // shared UserAgentHeader interceptor on the injected client;
+            // see `in.jphe.storyvox.data.network.UserAgent`.
             val req = Request.Builder()
                 .url(url)
                 .header("Accept", "application/json")
                 .header("Accept-Language", extractLanguageFromUrl(url))
-                .header("User-Agent", USER_AGENT)
                 .get()
                 .build()
             client.newCall(req).execute().use { resp ->
@@ -252,15 +255,6 @@ internal class WikipediaApi @Inject constructor(
         val host = url.substringAfter("://").substringBefore('/')
         val prefix = host.substringBefore(".wikipedia.org", missingDelimiterValue = "")
         return if (prefix.isNotBlank() && !prefix.contains('.')) prefix else "en"
-    }
-
-    companion object {
-        /** Wikimedia User-Agent policy
-         *  (https://meta.wikimedia.org/wiki/User-Agent_policy):
-         *  identify the project + give a contact. Without this the
-         *  REST API returns 403 for anonymous-tier traffic. */
-        const val USER_AGENT: String =
-            "storyvox-wikipedia/1.0 (https://github.com/jphein/storyvox; jp@jphein.com)"
     }
 }
 

--- a/source-wikisource/src/main/kotlin/in/jphe/storyvox/source/wikisource/di/WikisourceModule.kt
+++ b/source-wikisource/src/main/kotlin/in/jphe/storyvox/source/wikisource/di/WikisourceModule.kt
@@ -7,10 +7,12 @@ import dagger.hilt.InstallIn
 import dagger.hilt.components.SingletonComponent
 import dagger.multibindings.IntoMap
 import dagger.multibindings.StringKey
+import `in`.jphe.storyvox.data.network.UserAgentHeader
 import `in`.jphe.storyvox.data.source.FictionSource
 import `in`.jphe.storyvox.data.source.SourceIds
 import `in`.jphe.storyvox.source.wikisource.WikisourceSource
 import `in`.jphe.storyvox.source.wikisource.net.WikisourceApi
+import okhttp3.Interceptor
 import okhttp3.OkHttpClient
 import javax.inject.Qualifier
 import javax.inject.Singleton
@@ -38,7 +40,9 @@ internal object WikisourceHttpModule {
     @Provides
     @Singleton
     @WikisourceHttp
-    fun provideClient(): OkHttpClient =
+    fun provideClient(
+        @UserAgentHeader userAgent: Interceptor,
+    ): OkHttpClient =
         OkHttpClient.Builder()
             .connectTimeout(5, TimeUnit.SECONDS)
             .readTimeout(30, TimeUnit.SECONDS)
@@ -46,6 +50,10 @@ internal object WikisourceHttpModule {
             .followRedirects(true)
             .followSslRedirects(true)
             .retryOnConnectionFailure(true)
+            // #1141 — Wikimedia *requires* a descriptive UA with contact
+            // info per https://meta.wikimedia.org/wiki/User-Agent_policy;
+            // anonymous traffic without one is 403'd into a restrictive tier.
+            .addInterceptor(userAgent)
             .build()
 
     @Provides

--- a/source-wikisource/src/main/kotlin/in/jphe/storyvox/source/wikisource/net/WikisourceApi.kt
+++ b/source-wikisource/src/main/kotlin/in/jphe/storyvox/source/wikisource/net/WikisourceApi.kt
@@ -201,11 +201,14 @@ internal class WikisourceApi @Inject constructor(
     // with NetworkOnMainThreadException on first chip tap.
     private suspend fun getRaw(url: String): FictionResult<String> = withContext(Dispatchers.IO) {
         try {
+            // #1141 — the descriptive `User-Agent` Wikimedia requires
+            // (project + contact) is applied for every request by the
+            // shared UserAgentHeader interceptor on the injected client;
+            // see `in.jphe.storyvox.data.network.UserAgent`.
             val req = Request.Builder()
                 .url(url)
                 .header("Accept", "application/json")
                 .header("Accept-Language", "en")
-                .header("User-Agent", USER_AGENT)
                 .get()
                 .build()
             client.newCall(req).execute().use { resp ->
@@ -243,12 +246,6 @@ internal class WikisourceApi @Inject constructor(
          *  Keeping the host as a const avoids the WikipediaConfig
          *  DataStore plumbing for a single-language launch. */
         const val BASE_URL: String = "https://en.wikisource.org"
-
-        /** Wikimedia User-Agent policy — identify the project + give a
-         *  contact URL. Without this the REST API returns 403 for
-         *  anonymous-tier traffic. */
-        const val USER_AGENT: String =
-            "storyvox-wikisource/1.0 (https://github.com/jphein/storyvox; jp@jphein.com)"
     }
 }
 


### PR DESCRIPTION
## Summary

- Centralizes User-Agent into `UserAgent.kt` in core-data — single source of truth for app name, version, contact URL/email
- Adds `@UserAgentHeader`-qualified OkHttp interceptor in `:app` that reads `BuildConfig.VERSION_NAME`
- Wires descriptive UA into Wikipedia, Wikisource, arXiv, and Radio Browser source modules
- Replaces stale pre-rebrand UAs (`storyvox-*`, `jphein/storyvox`) with canonical `Candela/1.1.6 (https://candela.techempower.org; support@techempower.org) Android`

Closes part of #1141 (the User-Agent compliance portion).

## Test plan
- [x] `:app:compileDebugKotlin` passes
- [x] `:source-radio:testDebugUnitTest` — RadioSourceTest updated
- [ ] Manual: verify UA header appears in Wikipedia/arXiv/Radio requests

🤖 Generated with [Claude Code](https://claude.com/claude-code)