### PR TITLE
feat(playback): auto-enable Do Not Disturb with sleep timer (#1190)

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -18,6 +18,13 @@
     <uses-permission android:name="android.permission.POST_NOTIFICATIONS" />
     <uses-permission android:name="android.permission.RECEIVE_BOOT_COMPLETED" />
 
+    <!-- Issue #1190 — auto Do Not Disturb with the sleep timer. A normal
+         permission (no runtime prompt), but actually toggling DND
+         additionally needs the user to grant notification-policy access
+         from system settings; the Voice & Playback toggle hops the user
+         there once via ACTION_NOTIFICATION_POLICY_ACCESS_SETTINGS. -->
+    <uses-permission android:name="android.permission.ACCESS_NOTIFICATION_POLICY" />
+
     <!-- Issue #995 — OCR scan-to-read. CAMERA is requested at runtime
          with a plain-language rationale before the system prompt; a
          denied camera never dead-ends the feature (the gallery-pick

--- a/app/src/main/kotlin/in/jphe/storyvox/data/SettingsRepositoryUiImpl.kt
+++ b/app/src/main/kotlin/in/jphe/storyvox/data/SettingsRepositoryUiImpl.kt
@@ -49,6 +49,7 @@ import `in`.jphe.storyvox.data.repository.net.NetworkPatience
 import `in`.jphe.storyvox.data.repository.net.NetworkPatienceConfig
 import `in`.jphe.storyvox.data.repository.playback.AutoBrowserConfig
 import `in`.jphe.storyvox.data.repository.playback.PrerenderChapterCountConfig
+import `in`.jphe.storyvox.data.repository.playback.SleepTimerDndConfig
 import `in`.jphe.storyvox.data.repository.playback.SleepTimerExtendConfig
 import `in`.jphe.storyvox.feature.api.PalaceProbeResult
 import `in`.jphe.storyvox.feature.api.ReadingDirection
@@ -672,6 +673,9 @@ private object Keys {
     // ── Sleep timer shake-to-extend (issue #150) ───────────────────
     val SLEEP_SHAKE_TO_EXTEND_ENABLED = booleanPreferencesKey("pref_sleep_shake_to_extend_enabled")
 
+    // ── Auto Do Not Disturb with the sleep timer (issue #1190) ─────
+    val SLEEP_TIMER_DND_ENABLED = booleanPreferencesKey("pref_sleep_timer_dnd_enabled")
+
     // ── Debug overlay (Vesper, v0.4.97) ────────────────────────────
     /** Master switch for the on-Reader debug overlay. Default false;
      *  power users opt in from Settings → Developer. The dedicated
@@ -1107,6 +1111,7 @@ class SettingsRepositoryUiImpl(
     PlaybackResumePolicyConfig,
     `in`.jphe.storyvox.data.repository.playback.PlaybackSkipConfig,
     SleepTimerExtendConfig,
+    SleepTimerDndConfig,
     `in`.jphe.storyvox.data.repository.playback.BedtimeSleepConfig,
     PrerenderChapterCountConfig,
     AutoBrowserConfig,
@@ -1531,6 +1536,8 @@ class SettingsRepositoryUiImpl(
                 prefs[Keys.SLEEP_SHAKE_EXTEND_MINUTES] ?: 15,
             ),
             sleepBedtimeAutoEnabled = prefs[Keys.SLEEP_BEDTIME_AUTO_ENABLED] ?: false,
+            // Issue #1190 — auto Do Not Disturb while a sleep timer runs.
+            dndWithSleepTimerEnabled = prefs[Keys.SLEEP_TIMER_DND_ENABLED] ?: false,
             // Issue #596 — pre-render window in chapters.
             prerenderChapterCount = snapPrerenderChapterCount(
                 prefs[Keys.PRERENDER_CHAPTER_COUNT] ?: 5,
@@ -1812,6 +1819,16 @@ class SettingsRepositoryUiImpl(
     }
 
     override suspend fun currentShakeExtendMinutes(): Int = shakeExtendMinutes.first()
+
+    // --- SleepTimerDndConfig (issue #1190, consumed by core-playback's
+    //     AndroidDndController) ---
+
+    override val dndWithSleepTimerEnabled: Flow<Boolean> = store.data.map { prefs ->
+        prefs[Keys.SLEEP_TIMER_DND_ENABLED] ?: false
+    }
+
+    override suspend fun currentDndWithSleepTimerEnabled(): Boolean =
+        dndWithSleepTimerEnabled.first()
 
     // --- BedtimeSleepConfig (consumed by core-playback's
     //     StoryvoxPlaybackService to auto-arm sleep timer on DND) ---
@@ -2577,6 +2594,13 @@ class SettingsRepositoryUiImpl(
 
     override suspend fun setSleepBedtimeAutoEnabled(enabled: Boolean) {
         store.edit { it[Keys.SLEEP_BEDTIME_AUTO_ENABLED] = enabled }
+    }
+
+    /** Issue #1190 — auto Do Not Disturb with the sleep timer.
+     *  Per-device (NOT synced); DND is an inherently device-local
+     *  concern. */
+    override suspend fun setDndWithSleepTimerEnabled(enabled: Boolean) {
+        store.edit { it[Keys.SLEEP_TIMER_DND_ENABLED] = enabled }
     }
 
     /** Issue #596 — PCM-cache pre-render window in chapters. Synced as of #916. */

--- a/app/src/main/kotlin/in/jphe/storyvox/di/AppBindings.kt
+++ b/app/src/main/kotlin/in/jphe/storyvox/di/AppBindings.kt
@@ -344,6 +344,12 @@ object AppBindings {
     fun provideBedtimeSleepConfig(impl: SettingsRepositoryUiImpl):
         `in`.jphe.storyvox.data.repository.playback.BedtimeSleepConfig = impl
 
+    /** Issue #1190 — auto Do Not Disturb with the sleep timer. Same
+     *  singleton; consumed by `:core-playback`'s `AndroidDndController`. */
+    @Provides @Singleton
+    fun provideSleepTimerDndConfig(impl: SettingsRepositoryUiImpl):
+        `in`.jphe.storyvox.data.repository.playback.SleepTimerDndConfig = impl
+
     /** Issue #596 — user-tunable PCM-cache pre-render window size.
      *  Same singleton; consumed by `:core-playback`'s
      *  `PrerenderTriggers`. */

--- a/core-data/src/main/kotlin/in/jphe/storyvox/data/repository/playback/SleepTimerDndConfig.kt
+++ b/core-data/src/main/kotlin/in/jphe/storyvox/data/repository/playback/SleepTimerDndConfig.kt
@@ -1,0 +1,37 @@
+package `in`.jphe.storyvox.data.repository.playback
+
+import kotlinx.coroutines.flow.Flow
+
+/**
+ * Issue #1190 — auto-enable Do Not Disturb while a sleep timer is armed.
+ *
+ * When a listener sets a bedtime sleep timer, optionally flip the device
+ * into Do Not Disturb so a late-night notification doesn't wake them; the
+ * prior interruption filter is restored when the timer expires or is
+ * cancelled.
+ *
+ * Surfaced as its own contract (mirroring [SleepTimerExtendConfig] /
+ * [BedtimeSleepConfig]) so `:core-playback`'s `SleepTimer` /
+ * `DndController` can read the user's pref without taking a feature-layer
+ * dep.
+ *
+ * Per-device (NOT synced) — DND is an inherently device-local concern; a
+ * bedroom tablet and a commuting phone want different behaviour.
+ *
+ * Implementations read from the same DataStore that hosts the rest of
+ * the UI settings. The `:app` module's `SettingsRepositoryUiImpl`
+ * implements this alongside the existing contracts; one DataStore, many
+ * contracts.
+ */
+interface SleepTimerDndConfig {
+
+    /** Live flow of whether DND should auto-enable with the sleep timer. */
+    val dndWithSleepTimerEnabled: Flow<Boolean>
+
+    /**
+     * Snapshot read for callers that need a single value without
+     * subscribing. Implementations should return the most-recent value,
+     * falling back to `false` if the underlying store hasn't emitted yet.
+     */
+    suspend fun currentDndWithSleepTimerEnabled(): Boolean
+}

--- a/core-playback/src/main/kotlin/in/jphe/storyvox/playback/DndController.kt
+++ b/core-playback/src/main/kotlin/in/jphe/storyvox/playback/DndController.kt
@@ -1,0 +1,86 @@
+package `in`.jphe.storyvox.playback
+
+import android.app.NotificationManager
+import android.content.Context
+import dagger.hilt.android.qualifiers.ApplicationContext
+import `in`.jphe.storyvox.data.repository.playback.SleepTimerDndConfig
+import javax.inject.Inject
+import javax.inject.Singleton
+
+/**
+ * Issue #1190 — toggles system Do Not Disturb around the sleep timer's
+ * lifetime.
+ *
+ * [SleepTimer] calls [activateForSleepTimer] when a timer is armed and
+ * [restorePrevious] when it expires or is cancelled. Pulled behind an
+ * interface so the pure-Kotlin [SleepTimer] stays Android-free and unit
+ * tests can supply [NoopDndController].
+ */
+interface DndController {
+    /**
+     * Enable DND **iff** the user opted in AND notification-policy access
+     * is granted AND DND isn't already on. Snapshots the prior
+     * interruption filter so [restorePrevious] can put it back.
+     * Idempotent — a no-op in every other case (including a second call
+     * while already holding DND).
+     */
+    suspend fun activateForSleepTimer()
+
+    /**
+     * Restore the interruption filter captured by the matching
+     * [activateForSleepTimer]. No-op if we never activated — in
+     * particular, if the user already had DND on when the timer armed we
+     * recorded nothing, so we must not switch their DND off here.
+     */
+    fun restorePrevious()
+}
+
+/** Test / no-Android default. */
+object NoopDndController : DndController {
+    override suspend fun activateForSleepTimer() = Unit
+    override fun restorePrevious() = Unit
+}
+
+@Singleton
+class AndroidDndController @Inject constructor(
+    @ApplicationContext private val context: Context,
+    private val config: SleepTimerDndConfig,
+) : DndController {
+
+    private val notificationManager: NotificationManager?
+        get() = context.getSystemService(NotificationManager::class.java)
+
+    /**
+     * The interruption filter in effect before we switched DND on, or
+     * `null` when we are not currently holding DND on the timer's behalf.
+     * Doubles as the idempotency guard: a non-null value means "already
+     * active", so a second [activateForSleepTimer] is a no-op.
+     */
+    private var savedFilter: Int? = null
+
+    override suspend fun activateForSleepTimer() {
+        if (!config.currentDndWithSleepTimerEnabled()) return
+        val nm = notificationManager ?: return
+        if (!nm.isNotificationPolicyAccessGranted) return
+        // Already holding DND for this timer — don't re-snapshot.
+        if (savedFilter != null) return
+        val current = nm.currentInterruptionFilter
+        // Only act when DND is currently OFF. If the user already has a
+        // DND mode on, leave it untouched and record nothing, so
+        // restorePrevious() can't switch their DND off later (the #1190
+        // "already enabled by user" edge case).
+        if (current != NotificationManager.INTERRUPTION_FILTER_ALL) return
+        savedFilter = current
+        // PRIORITY (not NONE) so alarms still fire — a bedtime listener
+        // still needs their morning alarm.
+        nm.setInterruptionFilter(NotificationManager.INTERRUPTION_FILTER_PRIORITY)
+    }
+
+    override fun restorePrevious() {
+        val saved = savedFilter ?: return
+        savedFilter = null
+        val nm = notificationManager ?: return
+        if (!nm.isNotificationPolicyAccessGranted) return
+        nm.setInterruptionFilter(saved)
+    }
+}

--- a/core-playback/src/main/kotlin/in/jphe/storyvox/playback/SleepTimer.kt
+++ b/core-playback/src/main/kotlin/in/jphe/storyvox/playback/SleepTimer.kt
@@ -26,6 +26,10 @@ interface VolumeRamp {
 class SleepTimer @Inject constructor(
     private val volumeRamp: VolumeRamp,
     private val pauseAction: PauseAction,
+    // Issue #1190 — flips system Do Not Disturb on while a timer is armed
+    // and restores it when the timer fires or is cancelled. No-op unless
+    // the user opted in and granted notification-policy access.
+    private val dndController: DndController,
 ) {
     private var scope: CoroutineScope = CoroutineScope(SupervisorJob() + Dispatchers.Default)
     private var job: Job? = null
@@ -35,7 +39,8 @@ class SleepTimer @Inject constructor(
         volumeRamp: VolumeRamp,
         pauseAction: PauseAction,
         scope: CoroutineScope,
-    ) : this(volumeRamp, pauseAction) {
+        dndController: DndController = NoopDndController,
+    ) : this(volumeRamp, pauseAction, dndController) {
         this.scope = scope
     }
 
@@ -75,6 +80,9 @@ class SleepTimer @Inject constructor(
         _remainingMs.value = null
         volumeRamp.set(1.0f)
         job = scope.launch {
+            // #1190 — arm DND for the duration of the timer. Idempotent,
+            // so re-arming an already-running timer won't re-snapshot.
+            dndController.activateForSleepTimer()
             when (mode) {
                 is SleepTimerMode.Duration -> runCountdown(mode.minutes * 60_000L)
                 SleepTimerMode.EndOfChapter -> {
@@ -109,6 +117,8 @@ class SleepTimer @Inject constructor(
         // Drop the consumed signal so a future EndOfChapter timer
         // doesn't see a stale value (issue #34).
         chapterEndSignal.resetReplayCache()
+        // #1190 — timer fired and playback paused; hand DND back.
+        dndController.restorePrevious()
     }
 
     fun cancel() {
@@ -121,6 +131,8 @@ class SleepTimer @Inject constructor(
         // ended while the timer was active should not arm the next
         // timer (issue #34).
         chapterEndSignal.resetReplayCache()
+        // #1190 — user cancelled the timer; restore their DND state.
+        dndController.restorePrevious()
     }
 
     fun interface PauseAction {

--- a/core-playback/src/main/kotlin/in/jphe/storyvox/playback/di/PlaybackModule.kt
+++ b/core-playback/src/main/kotlin/in/jphe/storyvox/playback/di/PlaybackModule.kt
@@ -5,7 +5,9 @@ import dagger.Module
 import dagger.Provides
 import dagger.hilt.InstallIn
 import dagger.hilt.components.SingletonComponent
+import `in`.jphe.storyvox.playback.AndroidDndController
 import `in`.jphe.storyvox.playback.DefaultPlaybackController
+import `in`.jphe.storyvox.playback.DndController
 import `in`.jphe.storyvox.playback.PlaybackController
 import `in`.jphe.storyvox.playback.SleepTimer
 import `in`.jphe.storyvox.playback.TtsVolumeRamp
@@ -25,6 +27,11 @@ abstract class PlaybackModule {
     @Binds
     @Singleton
     abstract fun bindVolumeRamp(impl: TtsVolumeRamp): VolumeRamp
+
+    /** Issue #1190 — auto Do Not Disturb around the sleep timer. */
+    @Binds
+    @Singleton
+    abstract fun bindDndController(impl: AndroidDndController): DndController
 
     /** PR-F (#86) — background PCM cache pre-render scheduler. */
     @Binds

--- a/feature/src/main/kotlin/in/jphe/storyvox/feature/api/UiContracts.kt
+++ b/feature/src/main/kotlin/in/jphe/storyvox/feature/api/UiContracts.kt
@@ -1277,6 +1277,11 @@ data class UiSettings(
      *  / DND mode during playback. Uses [sleepShakeExtendMinutes] as
      *  the timer duration. Per-device pref (NOT synced). */
     val sleepBedtimeAutoEnabled: Boolean = false,
+    /** Issue #1190 — auto-enable system Do Not Disturb while a sleep
+     *  timer is armed, restoring the prior interruption filter when it
+     *  expires or is cancelled. Requires notification-policy access.
+     *  Per-device pref (NOT synced). */
+    val dndWithSleepTimerEnabled: Boolean = false,
     /**
      * Issue #596 — PCM-cache pre-render window size, in chapters.
      * The pre-render scheduler caches the next N chapters ahead of the
@@ -1815,6 +1820,9 @@ interface SettingsRepositoryUi {
     suspend fun setSleepShakeExtendMinutes(minutes: Int) = Unit
     /** Auto-arm sleep timer on Bedtime / DND mode. Default no-op. */
     suspend fun setSleepBedtimeAutoEnabled(enabled: Boolean) = Unit
+    /** Issue #1190 — auto Do Not Disturb with the sleep timer. Default
+     *  no-op so existing test fakes compile without overrides. */
+    suspend fun setDndWithSleepTimerEnabled(enabled: Boolean) = Unit
     /**
      * Issue #596 — set the PCM-cache pre-render window size, in
      * chapters. Snapped to [1, 2, 3, 5] on write. Default impl is a

--- a/feature/src/main/kotlin/in/jphe/storyvox/feature/settings/SettingsViewModel.kt
+++ b/feature/src/main/kotlin/in/jphe/storyvox/feature/settings/SettingsViewModel.kt
@@ -551,6 +551,10 @@ class SettingsViewModel @Inject constructor(
     fun setSleepBedtimeAutoEnabled(enabled: Boolean) =
         viewModelScope.launch { repo.setSleepBedtimeAutoEnabled(enabled) }
 
+    /** Issue #1190 — auto Do Not Disturb with the sleep timer. */
+    fun setDndWithSleepTimerEnabled(enabled: Boolean) =
+        viewModelScope.launch { repo.setDndWithSleepTimerEnabled(enabled) }
+
     /** Issue #596 — PCM-cache pre-render window size in chapters. */
     fun setPrerenderChapterCount(count: Int) =
         viewModelScope.launch { repo.setPrerenderChapterCount(count) }

--- a/feature/src/main/kotlin/in/jphe/storyvox/feature/settings/VoiceAndPlaybackSettingsScreen.kt
+++ b/feature/src/main/kotlin/in/jphe/storyvox/feature/settings/VoiceAndPlaybackSettingsScreen.kt
@@ -45,6 +45,7 @@ fun VoiceAndPlaybackSettingsScreen(
 ) {
     val state by viewModel.uiState.collectAsStateWithLifecycle()
     val spacing = LocalSpacing.current
+    val context = androidx.compose.ui.platform.LocalContext.current
 
     SettingsSubscreenScaffold(title = stringResource(R.string.settings_voice_title), onBack = onBack) { padding ->
         val s = state.settings ?: run {
@@ -210,6 +211,38 @@ fun VoiceAndPlaybackSettingsScreen(
                     subtitle = stringResource(R.string.settings_voice_bedtime_auto_subtitle),
                     checked = s.sleepBedtimeAutoEnabled,
                     onCheckedChange = viewModel::setSleepBedtimeAutoEnabled,
+                )
+
+                // Issue #1190 — auto Do Not Disturb with the sleep timer.
+                // DND access is a *special* grant the user flips manually
+                // (the manifest ACCESS_NOTIFICATION_POLICY permission is
+                // not enough on its own), so flipping this ON hops once to
+                // the system DND-access screen when access isn't held yet.
+                // The actual filter swap happens in core-playback's
+                // AndroidDndController, which no-ops until access is
+                // granted — the toggle never dead-ends.
+                SettingsSwitchRow(
+                    title = stringResource(R.string.settings_voice_dnd_sleep_title),
+                    subtitle = stringResource(R.string.settings_voice_dnd_sleep_subtitle),
+                    checked = s.dndWithSleepTimerEnabled,
+                    onCheckedChange = { enabled ->
+                        viewModel.setDndWithSleepTimerEnabled(enabled)
+                        if (enabled) {
+                            val nm = context.getSystemService(android.app.NotificationManager::class.java)
+                            if (nm != null && !nm.isNotificationPolicyAccessGranted) {
+                                // Guarded — a stripped ROM may not resolve
+                                // the DND-access settings activity (mirrors
+                                // the uriHandler guard in #1177).
+                                runCatching {
+                                    context.startActivity(
+                                        android.content.Intent(
+                                            android.provider.Settings.ACTION_NOTIFICATION_POLICY_ACCESS_SETTINGS,
+                                        ).addFlags(android.content.Intent.FLAG_ACTIVITY_NEW_TASK),
+                                    )
+                                }
+                            }
+                        }
+                    },
                 )
             }
         }

--- a/feature/src/main/res/values/strings.xml
+++ b/feature/src/main/res/values/strings.xml
@@ -715,6 +715,8 @@
     <string name="settings_voice_shake_extend_option">%1$d min</string>
     <string name="settings_voice_bedtime_auto_title">Sleep timer with Bedtime mode</string>
     <string name="settings_voice_bedtime_auto_subtitle">Auto-start the sleep timer when your phone enters Sleep or Bedtime mode.</string>
+    <string name="settings_voice_dnd_sleep_title">Do Not Disturb with sleep timer</string>
+    <string name="settings_voice_dnd_sleep_subtitle">Silence notifications while a sleep timer is running, then restore your previous setting when it ends. Needs Do Not Disturb access.</string>
 
     <!-- Settings · Performance subscreen -->
     <string name="settings_performance_title">Performance</string>


### PR DESCRIPTION
## Summary

Closes #1190 — auto-enable **Do Not Disturb** while a sleep timer is armed for bedtime listening, then restore the user's previous interruption filter when the timer expires or is cancelled.

Opt-in (default **OFF**) via a new toggle in **Settings → Voice & Playback**.

## What changed

- **Settings toggle** "Do Not Disturb with sleep timer" (`SettingsSwitchRow`, right under the existing Bedtime-mode auto-arm switch). Flipping it **on** hops once to the system DND-access screen (`ACTION_NOTIFICATION_POLICY_ACCESS_SETTINGS`) when notification-policy access isn't granted yet — guarded with `runCatching` (mirrors the #1177 uriHandler guard) so a stripped ROM never crashes.
- **`DndController`** (interface + `AndroidDndController`) in `core-playback`:
  - `SleepTimer.start()` → `activateForSleepTimer()`
  - `SleepTimer.cancel()` and the fade-to-pause completion → `restorePrevious()`
  - Only acts when DND is currently **OFF** (`INTERRUPTION_FILTER_ALL`); if the user already had a DND mode on, it records nothing and restore is a no-op — **never switches the user's own DND off**.
  - Uses `INTERRUPTION_FILTER_PRIORITY` (not `NONE`) so **alarms still fire** — a bedtime listener still needs their morning alarm.
  - Idempotent: re-arming an already-running timer won't re-snapshot.
- **`SleepTimerDndConfig`** read contract in `core-data` (mirrors `SleepTimerExtendConfig`) so `core-playback` reads the pref without a feature-layer dep; bound to `SettingsRepositoryUiImpl` in `AppBindings`.
- **Manifest**: `ACCESS_NOTIFICATION_POLICY` (normal permission, no runtime prompt).
- Per-device pref (**NOT synced**) — DND is inherently device-local.

## Design notes

`SleepTimer` stays pure-Kotlin/Android-free; the Android bits live behind `DndController`, with a `NoopDndController` default on the `@VisibleForTesting` constructor so the existing `SleepTimerTest` suite compiles and runs unchanged.

## Testing

- `./gradlew :app:assembleDebug` — **BUILD SUCCESSFUL** (full app build; exercises the manifest + Hilt DI wiring).
- Existing `SleepTimerTest` unchanged (no-op DND in tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
