### PR TITLE
feat(sync): confirm before destructive sign-out (#1197)

### DIFF
--- a/feature/src/main/kotlin/in/jphe/storyvox/feature/sync/SyncAuthScreen.kt
+++ b/feature/src/main/kotlin/in/jphe/storyvox/feature/sync/SyncAuthScreen.kt
@@ -10,6 +10,7 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.CloudSync
+import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.Button
 import androidx.compose.material3.ButtonDefaults
 import androidx.compose.material3.Icon
@@ -18,9 +19,13 @@ import androidx.compose.material3.OutlinedButton
 import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
 import androidx.compose.material3.TopAppBar
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
@@ -31,6 +36,7 @@ import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
+import androidx.compose.ui.window.DialogProperties
 import androidx.compose.foundation.text.KeyboardOptions
 import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
@@ -223,6 +229,11 @@ private fun SignedInPanel(
     onSignOut: () -> Unit,
     onClose: () -> Unit,
 ) {
+    // #1197 — sign-out now permanently deletes all synced cloud data
+    // (#1194), so gate it behind an explicit, undismissable confirmation
+    // rather than firing on a single tap of an OutlinedButton.
+    var showSignOutConfirm by remember { mutableStateOf(false) }
+
     Text(
         text = "Signed in",
         style = MaterialTheme.typography.titleMedium,
@@ -241,7 +252,54 @@ private fun SignedInPanel(
     ) { Text(stringResource(R.string.sync_done)) }
     Spacer(Modifier.height(8.dp))
     OutlinedButton(
-        onClick = onSignOut,
+        onClick = { showSignOutConfirm = true },
         modifier = Modifier.fillMaxWidth(),
     ) { Text(stringResource(R.string.sync_sign_out)) }
+
+    if (showSignOutConfirm) {
+        SignOutConfirmDialog(
+            onConfirm = {
+                showSignOutConfirm = false
+                onSignOut()
+            },
+            onDismiss = { showSignOutConfirm = false },
+        )
+    }
+}
+
+/**
+ * Destructive-action confirmation for sync sign-out (#1197).
+ *
+ * Sign-out deletes all synced cloud data (#1194), so the dialog forces
+ * an explicit choice: [DialogProperties] disables both back-press and
+ * outside-tap dismissal, and the confirm button is tinted with
+ * [MaterialTheme.colorScheme.error] to signal that it destroys data.
+ */
+@Composable
+private fun SignOutConfirmDialog(
+    onConfirm: () -> Unit,
+    onDismiss: () -> Unit,
+) {
+    AlertDialog(
+        onDismissRequest = onDismiss,
+        title = { Text(stringResource(R.string.sync_sign_out_confirm_title)) },
+        text = { Text(stringResource(R.string.sync_sign_out_confirm_body)) },
+        confirmButton = {
+            TextButton(
+                onClick = onConfirm,
+                colors = ButtonDefaults.textButtonColors(
+                    contentColor = MaterialTheme.colorScheme.error,
+                ),
+            ) { Text(stringResource(R.string.sync_sign_out_confirm_button)) }
+        },
+        dismissButton = {
+            TextButton(onClick = onDismiss) {
+                Text(stringResource(R.string.sync_sign_out_confirm_dismiss))
+            }
+        },
+        properties = DialogProperties(
+            dismissOnBackPress = false,
+            dismissOnClickOutside = false,
+        ),
+    )
 }

--- a/feature/src/main/res/values/strings.xml
+++ b/feature/src/main/res/values/strings.xml
@@ -318,6 +318,11 @@
     <string name="sync_different_email">Use a different email</string>
     <string name="sync_done">Done</string>
     <string name="sync_sign_out">Sign out</string>
+    <!-- Sign-out confirmation (#1197): sign-out deletes all synced cloud data (#1194), so force an explicit, loud choice. -->
+    <string name="sync_sign_out_confirm_title">Delete your synced data?</string>
+    <string name="sync_sign_out_confirm_body">Signing out will permanently delete all your synced data from the cloud — your library, reading positions, bookmarks, voice settings, and follows. Data on this device will remain until you uninstall.\n\nThis cannot be undone.</string>
+    <string name="sync_sign_out_confirm_button">Sign out &amp; delete</string>
+    <string name="sync_sign_out_confirm_dismiss">Keep syncing</string>
 
     <!-- Fiction detail -->
     <string name="fiction_clear_cache_title">Clear cached audio for %1$s?</string>


### PR DESCRIPTION
## What

Adds a loud, undismissable confirmation dialog before sync sign-out.

PR #1194 makes sign-out **permanently delete all synced data from InstantDB** (library, reading positions, bookmarks, voice settings, follows). A single errant tap of the plain `OutlinedButton` could wipe a user's cloud data with no warning. This gates that action behind an explicit confirmation.

## Changes

- **`SyncAuthScreen.kt`** — the "Sign out" button in `SignedInPanel` now opens a `SignOutConfirmDialog` instead of calling `signOut()` directly. The real `onSignOut()` only fires on confirm.
  - **Title:** "Delete your synced data?"
  - **Body:** explains exactly what gets deleted from the cloud, that on-device data survives until uninstall, and that it can't be undone.
  - **Confirm:** "Sign out & delete" — tinted with `MaterialTheme.colorScheme.error` (destructive styling).
  - **Dismiss:** "Keep syncing" — default styling, no side effects.
  - `DialogProperties(dismissOnBackPress = false, dismissOnClickOutside = false)` forces an explicit choice.
- **`strings.xml`** — four new string resources for the dialog copy.

## Scope note

This is the only InstantDB sync sign-out call site. The `AccountSettingsScreen` "Sign out" button is for **Royal Road** (`SettingsViewModel.signOut()`), not cloud sync; `SyncStatusSheet`'s button only routes to this screen. Both were deliberately left untouched.

## Testing

- `./gradlew :feature:compileDebugKotlin` — **BUILD SUCCESSFUL** (no new warnings in the changed file).
- No automated test added: the `feature` module has no Compose UI (androidTest) harness — all existing sync tests are pure-JVM logic tests — and the change is a stateless dialog wired to a callback with no unit-testable logic. Standing up an instrumented test source set (and the documented `singleTask`/`POST_NOTIFICATIONS` launch gotchas) for a state toggle would be disproportionate. Verified visually via the diff.

## Dependency

Pairs with #1194 (makes sign-out destructive). Safe to merge independently — the dialog is correct either way.

Closes #1197

🤖 Generated with [Claude Code](https://claude.com/claude-code)
