### PR TITLE
feat(fiction): chapter content previews in the chapter list (#1189)

### DIFF
--- a/app/src/main/kotlin/in/jphe/storyvox/di/AppBindings.kt
+++ b/app/src/main/kotlin/in/jphe/storyvox/di/AppBindings.kt
@@ -565,10 +565,17 @@ private class RealFictionRepositoryUi(
         // played" chapter ids so the circle fills as soon as the DB row
         // flips. Both flows are Room-backed and re-emit on any relevant
         // write; downstream combine fires once with whichever lands last.
+        // Issue #1189 — fold in a third sibling flow: per-chapter content
+        // previews (chapterId → ~100-char snippet). Like the played-ids
+        // set, it's a slim Room-backed flow that only carries chapters with
+        // a cached body, so the map is empty until the user reads/downloads
+        // and grows from there; a chapter absent from the map renders with
+        // no preview line.
         kotlinx.coroutines.flow.combine(
             repo.observeFiction(fictionId),
             chapters.observePlayedChapterIds(fictionId),
-        ) { detail, playedIds ->
+            chapters.observeChapterPreviews(fictionId),
+        ) { detail, playedIds, previews ->
             detail?.chapters.orEmpty().map { ch ->
                 UiChapter(
                     id = ch.id,
@@ -578,6 +585,7 @@ private class RealFictionRepositoryUi(
                     durationLabel = ch.wordCount?.let { "${(it / 250).coerceAtLeast(1)} min" } ?: "",
                     isDownloaded = false,
                     isFinished = ch.id in playedIds,
+                    preview = previews[ch.id],
                 )
             }
         }

--- a/app/src/test/kotlin/in/jphe/storyvox/di/RealPlaybackControllerUiTest.kt
+++ b/app/src/test/kotlin/in/jphe/storyvox/di/RealPlaybackControllerUiTest.kt
@@ -349,6 +349,9 @@ class RealPlaybackControllerUiTest {
         // flow can compute `isFinished` after auto-advance. No-op here.
         override fun observePlayedChapterIds(fictionId: String): Flow<Set<String>> =
             flowOf(emptySet())
+        // Issue #1189 — content-preview feed. No-op for this playback test.
+        override fun observeChapterPreviews(fictionId: String): Flow<Map<String, String>> =
+            flowOf(emptyMap())
         override suspend fun queueChapterDownload(
             fictionId: String,
             chapterId: String,

--- a/core-data/src/main/kotlin/in/jphe/storyvox/data/db/dao/ChapterDao.kt
+++ b/core-data/src/main/kotlin/in/jphe/storyvox/data/db/dao/ChapterDao.kt
@@ -36,6 +36,30 @@ interface ChapterDao {
     )
     fun observeChapterInfosByFiction(fictionId: String): Flow<List<ChapterInfoRow>>
 
+    /**
+     * Issue #1189 — slim per-chapter content-preview feed for the
+     * FictionDetail chapter list. Returns only chapters that already have
+     * a cached body (downloaded / read / pre-rendered), keyed by id, with
+     * just the opening slice of `plainBody` rather than the whole blob.
+     *
+     * `SUBSTR(plainBody, 1, 400)` bounds the bytes that cross the flow
+     * boundary to ~400 chars/row instead of the multi-KB body — the
+     * repository then cleans + truncates this to the ~100-char snippet the
+     * card shows. Sibling to [observeChapterInfosByFiction] (the TOC feed,
+     * which deliberately reads no body columns at all): the preview feed is
+     * combined in alongside the TOC rather than fattening it, so a fiction
+     * with no cached bodies yet pays nothing for previews.
+     */
+    @Query(
+        """
+        SELECT id, SUBSTR(plainBody, 1, 400) AS preview
+          FROM chapter
+         WHERE fictionId = :fictionId
+           AND plainBody IS NOT NULL AND plainBody <> ''
+        """,
+    )
+    fun observeChapterPreviews(fictionId: String): Flow<List<ChapterPreviewRow>>
+
     @Query("SELECT * FROM chapter WHERE id = :id")
     fun observe(id: String): Flow<Chapter?>
 
@@ -517,6 +541,19 @@ data class ChapterInfoRow(
     val title: String,
     val publishedAt: Long?,
     val wordCount: Int?,
+)
+
+/**
+ * Issue #1189 — (chapterId, opening-slice-of-body) projection backing
+ * [ChapterDao.observeChapterPreviews]. `preview` is the first ~400 chars of
+ * `plainBody` (still raw — residual tags/entities/whitespace possible); the
+ * repository runs it through `chapterPreviewText` before it reaches the UI.
+ * Nullable to match the column, though the query's `plainBody <> ''` guard
+ * means rows always carry text in practice.
+ */
+data class ChapterPreviewRow(
+    val id: String,
+    val preview: String?,
 )
 
 /** Joined chapter+fiction projection for the playback layer. */

--- a/core-data/src/main/kotlin/in/jphe/storyvox/data/repository/ChapterPreview.kt
+++ b/core-data/src/main/kotlin/in/jphe/storyvox/data/repository/ChapterPreview.kt
@@ -1,0 +1,115 @@
+package `in`.jphe.storyvox.data.repository
+
+/**
+ * Issue #1189 — derive a short, human-readable preview snippet from a
+ * chapter's cached body text.
+ *
+ * Why this exists: when a source numbers its chapters generically
+ * ("Chapter 1", "Chapter 2", …) the table-of-contents on FictionDetail
+ * gives the listener nothing to orient by. A ~100-char taste of the
+ * chapter's opening prose lets them find their place at a glance.
+ *
+ * Input is `Chapter.plainBody` (the source's plaintext rendering). That
+ * column is documented as possibly being a *naive* strip of the HTML
+ * body, so it can still carry residual tags, HTML entities and runaway
+ * whitespace. This cleaner is therefore defensive rather than trusting:
+ *
+ *  1. strip any residual `<…>` tags,
+ *  2. decode the handful of HTML entities that survive a naive strip,
+ *  3. collapse every whitespace run (newlines, tabs, doubled spaces) to
+ *     a single space and trim,
+ *  4. drop a leading "Chapter N" / "Ch. N -" style prefix — bodies that
+ *     open by repeating their own (often generic) title would otherwise
+ *     preview the exact text the snippet is meant to disambiguate
+ *     (mirrors the intent of core-ui's `stripChapterPrefix`),
+ *  5. truncate to [maxChars] on a word boundary, appending an ellipsis
+ *     when the body was longer.
+ *
+ * Pure Kotlin (no `android.text.Html`) so it unit-tests under the
+ * project's JUnit-only / no-Robolectric harness. Returns `null` when
+ * there's nothing meaningful left to show, so the UI can omit the line
+ * entirely rather than render an empty row.
+ */
+fun chapterPreviewText(raw: String?, maxChars: Int = PREVIEW_MAX_CHARS): String? {
+    if (raw.isNullOrBlank()) return null
+
+    val noTags = HTML_TAG.replace(raw, " ")
+    val decoded = decodeBasicEntities(noTags)
+    val collapsed = WHITESPACE.replace(decoded, " ").trim()
+    val deTitled = LEADING_CHAPTER_PREFIX.replaceFirst(collapsed, "").trim()
+    // Falling back to the collapsed text guards the pathological case where a
+    // chapter's whole body is just its "Chapter N" heading — stripping it
+    // would leave nothing, so we'd rather show the heading than an empty line.
+    val text = deTitled.ifBlank { collapsed }
+    if (text.isBlank()) return null
+
+    return truncateOnWordBoundary(text, maxChars)
+}
+
+/** Default snippet length — roughly one line of secondary text on a phone. */
+const val PREVIEW_MAX_CHARS: Int = 100
+
+private val HTML_TAG = Regex("<[^>]*>")
+private val WHITESPACE = Regex("\\s+")
+
+/** Same shapes core-ui's `stripChapterPrefix` collapses, plus a bare
+ *  "Chapter N" with no separator (a body opening on its own heading). */
+private val LEADING_CHAPTER_PREFIX =
+    Regex("^(?:ch(?:apter)?\\.?)\\s*\\d+\\s*[-:—–.]?\\s*", RegexOption.IGNORE_CASE)
+
+/** Numeric character references: `&#1234;` (decimal) and `&#x1F600;` (hex). */
+private val NUMERIC_ENTITY = Regex("&#(x?)([0-9a-fA-F]+);")
+
+/**
+ * Decode the small set of HTML entities that routinely survive a source's
+ * naive plaintext strip. Not a full entity table — just the ones that show
+ * up in real prose (ampersands, quotes, dashes, non-breaking spaces) plus
+ * numeric references. Anything unrecognised is left untouched.
+ */
+private fun decodeBasicEntities(s: String): String {
+    if ('&' !in s) return s
+    var out = s
+    NAMED_ENTITIES.forEach { (entity, replacement) -> out = out.replace(entity, replacement) }
+    out = NUMERIC_ENTITY.replace(out) { m ->
+        val isHex = m.groupValues[1] == "x"
+        val code = m.groupValues[2].toIntOrNull(if (isHex) 16 else 10)
+        if (code != null && code in 1..0x10FFFF) {
+            runCatching { String(Character.toChars(code)) }.getOrDefault(m.value)
+        } else {
+            m.value
+        }
+    }
+    return out
+}
+
+private val NAMED_ENTITIES = listOf(
+    "&nbsp;" to " ",
+    "&amp;" to "&",
+    "&lt;" to "<",
+    "&gt;" to ">",
+    "&quot;" to "\"",
+    "&apos;" to "'",
+    "&hellip;" to "…",
+    "&mdash;" to "—",
+    "&ndash;" to "–",
+    "&rsquo;" to "’",
+    "&lsquo;" to "‘",
+    "&rdquo;" to "”",
+    "&ldquo;" to "“",
+)
+
+/**
+ * Truncate to at most [maxChars], preferring the last word boundary so we
+ * don't slice a word in half. Appends a single-character ellipsis when the
+ * input was actually longer than the limit. A snippet at or under the limit
+ * is returned verbatim (no ellipsis).
+ */
+private fun truncateOnWordBoundary(text: String, maxChars: Int): String {
+    if (text.length <= maxChars) return text
+    val window = text.take(maxChars)
+    val lastSpace = window.lastIndexOf(' ')
+    // Only honour the word boundary when it isn't pathologically early
+    // (a single very long token shouldn't collapse the snippet to nothing).
+    val cut = if (lastSpace >= maxChars / 2) window.substring(0, lastSpace) else window
+    return cut.trimEnd().trimEnd('.', ',', ';', ':', '—', '–', '-') + "…"
+}

--- a/core-data/src/main/kotlin/in/jphe/storyvox/data/repository/ChapterRepository.kt
+++ b/core-data/src/main/kotlin/in/jphe/storyvox/data/repository/ChapterRepository.kt
@@ -7,6 +7,7 @@ import `in`.jphe.storyvox.data.repository.playback.PlaybackChapter
 import `in`.jphe.storyvox.data.source.model.ChapterContent
 import `in`.jphe.storyvox.data.source.model.ChapterInfo
 import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.flow.map
 import javax.inject.Inject
 import javax.inject.Singleton
@@ -34,6 +35,19 @@ interface ChapterRepository {
      * or played without being downloaded if streamed live).
      */
     fun observePlayedChapterIds(fictionId: String): Flow<Set<String>>
+
+    /**
+     * Issue #1189 — observable map of chapterId → cleaned content preview
+     * (~100 chars of opening prose) for chapters that have a cached body.
+     * The UI combines this with [observeChapters] to show a snippet under
+     * each chapter title, so listeners can orient when a source numbers its
+     * chapters generically ("Chapter 1", "Chapter 2", …).
+     *
+     * Only chapters with a cached body (downloaded / read / pre-rendered)
+     * appear; the map grows as the user reads or downloads. A chapter absent
+     * from the map simply renders without a preview line.
+     */
+    fun observeChapterPreviews(fictionId: String): Flow<Map<String, String>>
 
     /** Schedule a single chapter download via WorkManager. */
     suspend fun queueChapterDownload(
@@ -137,6 +151,20 @@ class ChapterRepositoryImpl @Inject constructor(
 
     override fun observePlayedChapterIds(fictionId: String): Flow<Set<String>> =
         dao.observePlayedChapterIds(fictionId).map { it.toSet() }
+
+    override fun observeChapterPreviews(fictionId: String): Flow<Map<String, String>> =
+        dao.observeChapterPreviews(fictionId)
+            .map { rows ->
+                rows.mapNotNull { row ->
+                    chapterPreviewText(row.preview)?.let { row.id to it }
+                }.toMap()
+            }
+            // Room invalidates this query on any write to the `chapter`
+            // table (read-state toggles, download-state flips), but the
+            // preview content only changes when a body is (re)written —
+            // dedupe so an unrelated row write doesn't re-push an identical
+            // map down the combine in [chaptersFor].
+            .distinctUntilChanged()
 
     override fun observeDownloadState(fictionId: String): Flow<Map<String, ChapterDownloadState>> =
         dao.observeDownloadStates(fictionId).map { rows ->

--- a/core-data/src/test/kotlin/in/jphe/storyvox/data/repository/ChapterPreviewTest.kt
+++ b/core-data/src/test/kotlin/in/jphe/storyvox/data/repository/ChapterPreviewTest.kt
@@ -1,0 +1,94 @@
+package `in`.jphe.storyvox.data.repository
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * Issue #1189 — unit coverage for the chapter content-preview cleaner. Pure
+ * Kotlin (no Android `Html.fromHtml`) so it runs under the project's
+ * JUnit-only / no-Robolectric harness.
+ */
+class ChapterPreviewTest {
+
+    @Test fun `null or blank input yields null`() {
+        assertNull(chapterPreviewText(null))
+        assertNull(chapterPreviewText(""))
+        assertNull(chapterPreviewText("    \n\t  "))
+    }
+
+    @Test fun `markup-only input yields null`() {
+        assertNull(chapterPreviewText("<p></p>"))
+        assertNull(chapterPreviewText("<div><span></span></div>"))
+    }
+
+    @Test fun `strips residual HTML tags`() {
+        assertEquals(
+            "Hello world",
+            chapterPreviewText("<p>Hello <b>world</b></p>"),
+        )
+    }
+
+    @Test fun `decodes common named HTML entities`() {
+        assertEquals(
+            "Jack & Jill said \"hi\"",
+            chapterPreviewText("Jack &amp; Jill said &quot;hi&quot;"),
+        )
+    }
+
+    @Test fun `decodes numeric and hex HTML entities`() {
+        // &#39; = apostrophe, &#x2014; = em dash
+        assertEquals(
+            "it's — done",
+            chapterPreviewText("it&#39;s &#x2014; done"),
+        )
+    }
+
+    @Test fun `collapses runs of whitespace into single spaces`() {
+        assertEquals(
+            "Line one. Line two.",
+            chapterPreviewText("Line one.\n\n\tLine two."),
+        )
+    }
+
+    @Test fun `strips a redundant leading chapter-number prefix`() {
+        assertEquals(
+            "The wind howled through the pass.",
+            chapterPreviewText("Chapter 1: The wind howled through the pass."),
+        )
+        assertEquals(
+            "Snow fell.",
+            chapterPreviewText("Ch. 12 — Snow fell."),
+        )
+    }
+
+    @Test fun `body that is only its heading falls back to the heading`() {
+        // Stripping the prefix would leave nothing; prefer showing the heading
+        // over emitting a blank (which the caller would drop).
+        assertEquals("Chapter 5", chapterPreviewText("Chapter 5"))
+    }
+
+    @Test fun `short text is returned verbatim without an ellipsis`() {
+        val text = "A short opening line."
+        assertEquals(text, chapterPreviewText(text, maxChars = 100))
+    }
+
+    @Test fun `long text is truncated on a word boundary with an ellipsis`() {
+        // 12-char budget over "The quick brown fox jumps" → last word boundary
+        // inside the window is after "quick".
+        assertEquals("The quick…", chapterPreviewText("The quick brown fox jumps", maxChars = 12))
+    }
+
+    @Test fun `a single oversized token is hard-cut rather than collapsed to nothing`() {
+        val result = chapterPreviewText("a".repeat(40), maxChars = 10)!!
+        assertTrue("should end with ellipsis", result.endsWith("…"))
+        // 10 chars of body + the ellipsis glyph.
+        assertEquals(11, result.length)
+    }
+
+    @Test fun `trailing punctuation is trimmed before the ellipsis`() {
+        // Window cut lands right after a comma → comma dropped, ellipsis added.
+        assertEquals("Hello…", chapterPreviewText("Hello, world and then some more", maxChars = 7))
+    }
+}

--- a/core-data/src/test/kotlin/in/jphe/storyvox/data/repository/ChapterRepositoryImplTest.kt
+++ b/core-data/src/test/kotlin/in/jphe/storyvox/data/repository/ChapterRepositoryImplTest.kt
@@ -3,6 +3,7 @@ package `in`.jphe.storyvox.data.repository
 import `in`.jphe.storyvox.data.db.dao.ChapterDao
 import `in`.jphe.storyvox.data.db.dao.ChapterDownloadStateRow
 import `in`.jphe.storyvox.data.db.dao.ChapterInfoRow
+import `in`.jphe.storyvox.data.db.dao.ChapterPreviewRow
 import `in`.jphe.storyvox.data.db.dao.PlaybackChapterRow
 import `in`.jphe.storyvox.data.db.dao.UnreadChapterRow
 import `in`.jphe.storyvox.data.db.entity.Chapter
@@ -30,6 +31,7 @@ class ChapterRepositoryImplTest {
         private val infoFeeds = mutableMapOf<String, MutableStateFlow<List<ChapterInfoRow>>>()
         private val rowFeeds = mutableMapOf<String, MutableStateFlow<Chapter?>>()
         private val stateFeeds = mutableMapOf<String, MutableStateFlow<List<ChapterDownloadStateRow>>>()
+        private val previewFeeds = mutableMapOf<String, MutableStateFlow<List<ChapterPreviewRow>>>()
 
         var nextChapterIdResult: String? = null
         var previousChapterIdResult: String? = null
@@ -52,9 +54,18 @@ class ChapterRepositoryImplTest {
             rows.values.filter { it.fictionId == fictionId }
                 .map { ChapterDownloadStateRow(id = it.id, downloadState = it.downloadState) }
 
+        // Issue #1189 — mirror the production query: only rows with a
+        // non-blank body, carrying the first 400 chars of plainBody.
+        private fun previewRows(fictionId: String): List<ChapterPreviewRow> =
+            rows.values
+                .filter { it.fictionId == fictionId && !it.plainBody.isNullOrEmpty() }
+                .sortedBy { it.index }
+                .map { ChapterPreviewRow(id = it.id, preview = it.plainBody?.take(400)) }
+
         private fun publishAll(fictionId: String) {
             infoFeeds[fictionId]?.value = fictionRows(fictionId)
             stateFeeds[fictionId]?.value = stateRows(fictionId)
+            previewFeeds[fictionId]?.value = previewRows(fictionId)
         }
 
         private fun publishRow(id: String) {
@@ -90,6 +101,11 @@ class ChapterRepositoryImplTest {
         // tracking; emit empty so the new override compiles.
         override fun observePlayedChapterIds(fictionId: String): Flow<List<String>> =
             MutableStateFlow(emptyList())
+
+        // Issue #1189 — content-preview feed, derived from the backing rows'
+        // bodies so a body write re-emits (mirrors the real Room query).
+        override fun observeChapterPreviews(fictionId: String): Flow<List<ChapterPreviewRow>> =
+            previewFeeds.getOrPut(fictionId) { MutableStateFlow(previewRows(fictionId)) }
 
         override suspend fun missingForFiction(fictionId: String): List<Chapter> {
             callLog += "missingForFiction($fictionId)"
@@ -382,6 +398,43 @@ class ChapterRepositoryImplTest {
         assertEquals(ChapterDownloadState.DOWNLOADED, states["c0"])
         assertEquals(ChapterDownloadState.QUEUED, states["c1"])
         assertEquals(ChapterDownloadState.NOT_DOWNLOADED, states["c2"])
+    }
+
+    // -- observeChapterPreviews (#1189) -----------------------------------------
+
+    @Test fun `observeChapterPreviews cleans bodies and omits chapters without one`() = runTest {
+        val (r, dao, _) = repo()
+        dao.upsert(
+            chapter(
+                "c0",
+                index = 0,
+                plainBody = "Chapter 1 &mdash; <b>The</b> wind howled &amp; the snow fell.",
+                htmlBody = "<p>body</p>",
+            ),
+        )
+        // No cached body → must not appear in the preview map at all.
+        dao.upsert(chapter("c1", index = 1, plainBody = null))
+
+        val previews = r.observeChapterPreviews("f1").first()
+
+        // Only the chapter with a body is present; tags stripped, entities
+        // decoded, and the redundant leading "Chapter 1 — " title removed.
+        assertEquals(setOf("c0"), previews.keys)
+        assertEquals("The wind howled & the snow fell.", previews["c0"])
+    }
+
+    @Test fun `observeChapterPreviews drops a chapter whose body is only its heading`() = runTest {
+        val (r, dao, _) = repo()
+        // Body that is nothing but the (generic) heading: cleaning would strip
+        // it to empty, so the cleaner falls back to the heading rather than
+        // emitting a blank — but a truly empty body yields no entry.
+        dao.upsert(chapter("c0", index = 0, plainBody = "Chapter 7", htmlBody = "<p>x</p>"))
+        dao.upsert(chapter("c1", index = 1, plainBody = "   ", htmlBody = "<p>x</p>"))
+
+        val previews = r.observeChapterPreviews("f1").first()
+
+        assertEquals(setOf("c0"), previews.keys)
+        assertEquals("Chapter 7", previews["c0"])
     }
 
     // -- queueChapterDownload ---------------------------------------------------

--- a/core-data/src/test/kotlin/in/jphe/storyvox/data/repository/FictionRepositoryImplTest.kt
+++ b/core-data/src/test/kotlin/in/jphe/storyvox/data/repository/FictionRepositoryImplTest.kt
@@ -3,6 +3,7 @@ package `in`.jphe.storyvox.data.repository
 import `in`.jphe.storyvox.data.db.dao.ChapterDao
 import `in`.jphe.storyvox.data.db.dao.ChapterDownloadStateRow
 import `in`.jphe.storyvox.data.db.dao.ChapterInfoRow
+import `in`.jphe.storyvox.data.db.dao.ChapterPreviewRow
 import `in`.jphe.storyvox.data.db.dao.FictionDao
 import `in`.jphe.storyvox.data.db.dao.PlaybackChapterRow
 import `in`.jphe.storyvox.data.db.dao.UnreadChapterRow
@@ -285,6 +286,10 @@ class FictionRepositoryImplTest {
 
         override fun observeChapterInfosByFiction(fictionId: String): Flow<List<ChapterInfoRow>> =
             infoFeeds.getOrPut(fictionId) { MutableStateFlow(fictionRows(fictionId)) }
+
+        // Issue #1189 — content-preview feed; this test doesn't assert previews.
+        override fun observeChapterPreviews(fictionId: String): Flow<List<ChapterPreviewRow>> =
+            MutableStateFlow<List<ChapterPreviewRow>>(emptyList())
 
         override fun observe(id: String): Flow<Chapter?> = MutableStateFlow(rows[id])
 

--- a/core-playback/src/test/kotlin/in/jphe/storyvox/playback/cache/PrerenderTriggersTest.kt
+++ b/core-playback/src/test/kotlin/in/jphe/storyvox/playback/cache/PrerenderTriggersTest.kt
@@ -102,6 +102,9 @@ class PrerenderTriggersTest {
             flowOf(emptyMap())
         override fun observePlayedChapterIds(fictionId: String): Flow<Set<String>> =
             flowOf(emptySet())
+        // Issue #1189 — content-preview feed; not exercised by prerender tests.
+        override fun observeChapterPreviews(fictionId: String): Flow<Map<String, String>> =
+            flowOf(emptyMap())
         override suspend fun queueChapterDownload(
             fictionId: String, chapterId: String, requireUnmetered: Boolean,
         ) {

--- a/core-sync/src/test/kotlin/in/jphe/storyvox/sync/BookmarksSyncerTest.kt
+++ b/core-sync/src/test/kotlin/in/jphe/storyvox/sync/BookmarksSyncerTest.kt
@@ -5,6 +5,7 @@ import `in`.jphe.storyvox.data.db.dao.BookmarkRow
 import `in`.jphe.storyvox.data.db.dao.ChapterDao
 import `in`.jphe.storyvox.data.db.dao.ChapterDownloadStateRow
 import `in`.jphe.storyvox.data.db.dao.ChapterInfoRow
+import `in`.jphe.storyvox.data.db.dao.ChapterPreviewRow
 import `in`.jphe.storyvox.data.db.dao.PlaybackChapterRow
 import `in`.jphe.storyvox.data.db.dao.UnreadChapterRow
 import `in`.jphe.storyvox.data.db.entity.Chapter
@@ -233,6 +234,7 @@ class BookmarksSyncerTest {
         // ---- everything below is "not used by BookmarksSyncer" ----
         override suspend fun allChapters(fictionId: String): List<Chapter> = emptyList()
         override fun observeChapterInfosByFiction(fictionId: String): Flow<List<ChapterInfoRow>> = flowOf(emptyList())
+        override fun observeChapterPreviews(fictionId: String): Flow<List<ChapterPreviewRow>> = flowOf(emptyList())
         override fun observe(id: String): Flow<Chapter?> = flowOf(null)
         override suspend fun get(id: String): Chapter? = null
         override fun observeDownloadStates(fictionId: String): Flow<List<ChapterDownloadStateRow>> = flowOf(emptyList())

--- a/core-sync/src/test/kotlin/in/jphe/storyvox/sync/PlaybackPositionSyncerTest.kt
+++ b/core-sync/src/test/kotlin/in/jphe/storyvox/sync/PlaybackPositionSyncerTest.kt
@@ -4,6 +4,7 @@ import `in`.jphe.storyvox.data.db.dao.ChapterDao
 import `in`.jphe.storyvox.data.db.dao.ChapterCacheUsageRow
 import `in`.jphe.storyvox.data.db.dao.ChapterDownloadStateRow
 import `in`.jphe.storyvox.data.db.dao.ChapterInfoRow
+import `in`.jphe.storyvox.data.db.dao.ChapterPreviewRow
 import `in`.jphe.storyvox.data.db.dao.ContinueListeningRow
 import `in`.jphe.storyvox.data.db.dao.FictionDao
 import `in`.jphe.storyvox.data.db.dao.LastPlayedRow
@@ -230,6 +231,7 @@ class PlaybackPositionSyncerTest {
 
         override suspend fun allChapters(fictionId: String): List<Chapter> = emptyList()
         override fun observeChapterInfosByFiction(fictionId: String): Flow<List<ChapterInfoRow>> = flowOf(emptyList())
+        override fun observeChapterPreviews(fictionId: String): Flow<List<ChapterPreviewRow>> = flowOf(emptyList())
         override fun observe(id: String): Flow<Chapter?> = flowOf(null)
         override suspend fun get(id: String): Chapter? = null
         override fun observeDownloadStates(fictionId: String): Flow<List<ChapterDownloadStateRow>> = flowOf(emptyList())

--- a/core-ui/src/main/kotlin/in/jphe/storyvox/ui/component/ChapterCard.kt
+++ b/core-ui/src/main/kotlin/in/jphe/storyvox/ui/component/ChapterCard.kt
@@ -27,6 +27,7 @@ import androidx.compose.ui.semantics.contentDescription
 import androidx.compose.ui.semantics.onClick
 import androidx.compose.ui.semantics.role
 import androidx.compose.ui.semantics.semantics
+import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import `in`.jphe.storyvox.playback.cache.ChapterCacheState
 import `in`.jphe.storyvox.ui.a11y.A11ySpeakChapterMode
@@ -51,6 +52,16 @@ data class ChapterCardState(
      *  `FictionDetailScreen.toCardState` forwards the real value from
      *  the view-model's per-fiction cache-state flow. */
     val cacheState: ChapterCacheState = ChapterCacheState.None,
+    /** Issue #1189 — ~100-char snippet of the chapter's opening prose,
+     *  rendered under the title to disambiguate generically-numbered
+     *  chapters. Null / blank hides the line entirely (the common case for
+     *  a chapter whose body isn't cached yet), so cards without a preview
+     *  look exactly as they did pre-#1189. Deliberately NOT folded into the
+     *  TalkBack [contentDescription] below: appending ~100 chars to every
+     *  row's announcement would bloat list-swipe readout, and the snippet is
+     *  a visual orientation aid — the title (already announced) is what a
+     *  screen-reader user navigates by. */
+    val preview: String? = null,
 )
 
 @Composable
@@ -168,6 +179,23 @@ fun ChapterCard(
                     style = MaterialTheme.typography.titleMedium,
                     maxLines = 2,
                 )
+                // Issue #1189 — content preview. Sits between the title and
+                // the published·duration metadata so the visual order is
+                // title → taste-of-the-prose → metadata. Hidden when blank
+                // (body not cached yet) so the card collapses to its
+                // pre-#1189 two-line shape. bodySmall / onSurfaceVariant
+                // keeps it clearly subordinate to the titleMedium title.
+                val preview = state.preview?.takeIf { it.isNotBlank() }
+                if (preview != null) {
+                    Text(
+                        preview,
+                        style = MaterialTheme.typography.bodySmall,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                        maxLines = 2,
+                        overflow = TextOverflow.Ellipsis,
+                        modifier = Modifier.padding(top = 2.dp),
+                    )
+                }
                 Row(
                     horizontalArrangement = Arrangement.spacedBy(spacing.xs),
                     modifier = Modifier.padding(top = 2.dp),

--- a/feature/src/main/kotlin/in/jphe/storyvox/feature/api/UiContracts.kt
+++ b/feature/src/main/kotlin/in/jphe/storyvox/feature/api/UiContracts.kt
@@ -60,6 +60,13 @@ data class UiChapter(
      *  FictionDetailViewModel composes the real value by combining
      *  this list with `CacheStateInspector.chapterStatesFor`. */
     val cacheState: ChapterCacheState = ChapterCacheState.None,
+    /** Issue #1189 — ~100-char snippet of the chapter's opening prose,
+     *  shown under the title so listeners can orient when a source numbers
+     *  its chapters generically ("Chapter 1", "Chapter 2", …). Null until
+     *  the body is cached (downloaded / read / pre-rendered); the row then
+     *  renders without a preview line. Composed in `AppBindings.chaptersFor`
+     *  from `ChapterRepository.observeChapterPreviews`. */
+    val preview: String? = null,
 )
 
 data class UiFollow(

--- a/feature/src/main/kotlin/in/jphe/storyvox/feature/fiction/FictionDetailScreen.kt
+++ b/feature/src/main/kotlin/in/jphe/storyvox/feature/fiction/FictionDetailScreen.kt
@@ -1617,6 +1617,9 @@ private fun UiChapter.toCardState(currentId: String?) = ChapterCardState(
     // flow's first emission), so the badge silently no-ops in that
     // window instead of flickering bogus state.
     cacheState = cacheState,
+    // Issue #1189 — content-preview snippet (null until the body is
+    // cached); the card hides the line when absent.
+    preview = preview,
 )
 
 /**

--- a/feature/src/test/kotlin/in/jphe/storyvox/feature/chat/tools/ChatToolHandlersTest.kt
+++ b/feature/src/test/kotlin/in/jphe/storyvox/feature/chat/tools/ChatToolHandlersTest.kt
@@ -188,6 +188,8 @@ private class FakeChapterRepo : ChapterRepository {
     override fun observeChapter(chapterId: String): Flow<ChapterContent?> = flowOf(null)
     override fun observeDownloadState(fictionId: String): Flow<Map<String, ChapterDownloadState>> = flowOf(emptyMap())
     override fun observePlayedChapterIds(fictionId: String): Flow<Set<String>> = flowOf(emptySet())
+    // Issue #1189 — content-preview feed; chat tools don't surface previews.
+    override fun observeChapterPreviews(fictionId: String): Flow<Map<String, String>> = flowOf(emptyMap())
     override suspend fun queueChapterDownload(fictionId: String, chapterId: String, requireUnmetered: Boolean) = Unit
     override suspend fun queueAllMissing(fictionId: String, requireUnmetered: Boolean) = Unit
     override suspend fun markRead(chapterId: String, read: Boolean) {

--- a/source-epub-writer/src/test/kotlin/in/jphe/storyvox/source/epub/writer/NoopDaos.kt
+++ b/source-epub-writer/src/test/kotlin/in/jphe/storyvox/source/epub/writer/NoopDaos.kt
@@ -4,6 +4,7 @@ import `in`.jphe.storyvox.data.db.dao.ChapterCacheUsageRow
 import `in`.jphe.storyvox.data.db.dao.ChapterDao
 import `in`.jphe.storyvox.data.db.dao.ChapterDownloadStateRow
 import `in`.jphe.storyvox.data.db.dao.ChapterInfoRow
+import `in`.jphe.storyvox.data.db.dao.ChapterPreviewRow
 import `in`.jphe.storyvox.data.db.dao.FictionDao
 import `in`.jphe.storyvox.data.db.dao.PlaybackChapterRow
 import `in`.jphe.storyvox.data.db.dao.UnreadChapterRow
@@ -44,6 +45,10 @@ internal class NoopFictionDao : FictionDao {
     override suspend fun setPinnedVoice(id: String, voiceId: String?, locale: String?) = Unit
     override suspend fun touchMetadata(id: String, now: Long) = Unit
     override suspend fun setSourceId(id: String, sourceId: String) = Unit
+    // Pre-existing gap (predates #1189): fake fell behind the FictionDao
+    // interface when the source-URL accessors landed. Filled to compile.
+    override suspend fun getSourceUrl(id: String): String? = null
+    override suspend fun setSourceUrlIfAbsent(id: String, url: String) = Unit
     override suspend fun placeholdersToBackfill(cutoff: Long): List<Fiction> = emptyList()
     override suspend fun placeholderCount(): Int = 0
     override suspend fun markBackfillFailed(id: String, now: Long) = Unit
@@ -55,6 +60,7 @@ internal class NoopFictionDao : FictionDao {
 
 internal class NoopChapterDao : ChapterDao {
     override fun observeChapterInfosByFiction(fictionId: String): Flow<List<ChapterInfoRow>> = flowOf(emptyList())
+    override fun observeChapterPreviews(fictionId: String): Flow<List<ChapterPreviewRow>> = flowOf(emptyList())
     override fun observe(id: String): Flow<Chapter?> = flowOf(null)
     override suspend fun get(id: String): Chapter? = null
     override suspend fun exists(id: String): Boolean = false
@@ -87,6 +93,10 @@ internal class NoopChapterDao : ChapterDao {
         audioUrl: String?,
     ) = Unit
     override suspend fun setRead(id: String, read: Boolean, now: Long) = Unit
+    // Pre-existing gap (predates #1189): this no-op fake fell behind the
+    // ChapterDao interface when #982's markFollowedCaughtUp landed. Filled
+    // here so the module's test source compiles.
+    override suspend fun markFollowedCaughtUp(now: Long): Int = 0
     override suspend fun trimDownloadedBodies(fictionId: String, keepLast: Int) = Unit
     override suspend fun setBookmark(id: String, charOffset: Int?) = Unit
     override suspend fun getBookmark(id: String): Int? = null


### PR DESCRIPTION
## What

Closes #1189. Chapters with generic titles ("Chapter 1", "Chapter 2", …) give listeners nothing to orient by. This adds a ~100-char snippet of each chapter's opening prose under the title in the FictionDetail chapter list.

![chapter card layout: title → preview snippet → published · duration]

## How

- **`ChapterDao.observeChapterPreviews(fictionId)`** — a slim Room feed that reads only `SUBSTR(plainBody, 1, 400)` for chapters that already have a cached body, keyed by id. It's a *sibling* to the body-free TOC feed (`observeChapterInfosByFiction`), not a fattening of it — a fiction with no cached bodies pays nothing.
- **`ChapterRepository.observeChapterPreviews`** maps + cleans rows through a new pure `chapterPreviewText()`:
  - strips residual `<…>` tags and decodes common HTML entities (a source's `plainBody` is documented as possibly a *naive* strip, so this is defensive),
  - collapses whitespace,
  - drops a redundant leading "Chapter N" / "Ch. N -" prefix (bodies that open by repeating their own generic title would otherwise preview the exact text we're trying to disambiguate — mirrors core-ui's `stripChapterPrefix`),
  - truncates on a word boundary with an ellipsis.
  - `distinctUntilChanged` so unrelated `chapter`-table writes (read-state/download-state flips) don't re-push an identical map down the combine.
- **`chaptersFor`** folds it in as a third sibling flow → `UiChapter.preview` → `ChapterCardState.preview`, rendered `bodySmall` / `onSurfaceVariant`, `maxLines = 2`, ellipsis, between the title and the metadata row. Hidden entirely when blank.

## Scope & trade-offs

- **No migration, no eager network fetch.** The preview derives from the existing cached `plainBody`, so previews populate progressively as chapters are downloaded / read / pre-rendered. Eager per-chapter fetching (N network calls at fiction-detail time) was deliberately out of scope — the source `fictionDetail()` call doesn't return bodies.
- **Accessibility:** the snippet is kept *out* of the TalkBack `contentDescription`. The title is already announced; appending ~100 chars to every row would bloat list-swipe readout. The preview is a visual orientation aid. (Documented inline.)

## Tests

- `ChapterPreviewTest` — 12 cases over the cleaner (tag strip, entity/numeric decode, whitespace, leading-prefix strip, word-boundary truncation, blank/markup-only → null, heading-only fallback). Pure Kotlin → runs under the JUnit-only / no-Robolectric harness.
- `ChapterRepositoryImplTest` — 2 new cases: row→cleaned-map mapping + omission of chapters without a cached body.
- Existing `ChapterCardClickableTest` stays green (the `preview` field defaults to null).

Adding the interface method required no-op overrides in 5 fake DAOs / 3 fake repositories across modules.

## Drive-by (flagged separately)

`:source-epub-writer`'s `NoopDaos` test fake was **already** stale at the base commit — missing `getSourceUrl` / `setSourceUrlIfAbsent` (FictionDao) and `markFollowedCaughtUp` (ChapterDao), so that test source set didn't compile (the required `Build APK` gate only builds main source). Since I had to edit the file to add my own override, I filled those three gaps with no-op stubs (clearly commented as predating #1189). Other branches likely share the latent gap.

## Verification

From the worktree: `:core-data:testDebugUnitTest` + `:core-ui:testDebugUnitTest` green; `:feature` / `:app` debug compile green; test-source compile green for `:core-sync`, `:source-epub-writer`, `:core-playback`, `:feature`, `:app`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)