### PR TITLE
feat(playback): wire Supertonic 3 TTS engine (#1191)

### DIFF
--- a/core-playback/build.gradle.kts
+++ b/core-playback/build.gradle.kts
@@ -117,12 +117,7 @@ dependencies {
     // voice family wrapping sherpa-onnx's OfflineTtsSupertonicModelConfig +
     // GenerationConfig path (Supertonic 3: seven-file int8 bundle, 10
     // voices, 24 kHz, unicode-tokenised flow-matching, no espeak data).
-    // Pinned to the feature branch's JitPack SNAPSHOT until v2.9.0 is
-    // tagged; locally it resolves from mavenLocal (settings.gradle.kts
-    // lists mavenLocal ahead of JitPack), on CI from JitPack's
-    // branch→SNAPSHOT build. Bump to v2.9.0 once the VoxSherpa PR merges
-    // and is tagged.
-    implementation("com.github.techempower-org:VoxSherpa-TTS:feat-supertonic-engine-SNAPSHOT")
+    implementation("com.github.techempower-org:VoxSherpa-TTS:v2.9.0")
     implementation("com.github.k2-fsa:sherpa-onnx:1.13.3")
 
     // Media3 — session, player base classes

--- a/core-playback/build.gradle.kts
+++ b/core-playback/build.gradle.kts
@@ -113,7 +113,16 @@ dependencies {
     // shared model + speaker index, public no-arg ctor for Tier 3
     // parallelism, XNNPACK→CPU fallback). Storyvox dispatches via
     // EngineType.Kitten in this PR.
-    implementation("com.github.techempower-org:VoxSherpa-TTS:v2.8.0")
+    // v2.9.0 (storyvox #1114) adds SupertonicEngine — fourth in-process
+    // voice family wrapping sherpa-onnx's OfflineTtsSupertonicModelConfig +
+    // GenerationConfig path (Supertonic 3: seven-file int8 bundle, 10
+    // voices, 24 kHz, unicode-tokenised flow-matching, no espeak data).
+    // Pinned to the feature branch's JitPack SNAPSHOT until v2.9.0 is
+    // tagged; locally it resolves from mavenLocal (settings.gradle.kts
+    // lists mavenLocal ahead of JitPack), on CI from JitPack's
+    // branch→SNAPSHOT build. Bump to v2.9.0 once the VoxSherpa PR merges
+    // and is tagged.
+    implementation("com.github.techempower-org:VoxSherpa-TTS:feat-supertonic-engine-SNAPSHOT")
     implementation("com.github.k2-fsa:sherpa-onnx:1.13.3")
 
     // Media3 — session, player base classes

--- a/core-playback/src/main/kotlin/in/jphe/storyvox/playback/EngineSampleRateCache.kt
+++ b/core-playback/src/main/kotlin/in/jphe/storyvox/playback/EngineSampleRateCache.kt
@@ -2,6 +2,7 @@ package `in`.jphe.storyvox.playback
 
 import com.CodeBySonu.VoxSherpa.KittenEngine
 import com.CodeBySonu.VoxSherpa.KokoroEngine
+import com.CodeBySonu.VoxSherpa.SupertonicEngine
 import com.CodeBySonu.VoxSherpa.VoiceEngine
 
 /**
@@ -83,9 +84,10 @@ object EngineSampleRateCache {
      *  per #119 — 24 kHz across every speaker. */
     private const val DEFAULT_KITTEN = 24000
 
-    /** Issue #1114 — Default Supertonic 3 sample rate. Assumed 24 kHz
-     *  (the standard for modern sherpa-onnx multi-speaker models).
-     *  TODO(#1114): verify against actual Supertonic 3 model output. */
+    /** Issue #1114 — Default Supertonic 3 sample rate (24 kHz, the
+     *  standard for modern sherpa-onnx multi-speaker models). Used only as
+     *  the pre-load fallback; once a model loads, [readSupertonicFromEngine]
+     *  reads the engine's actual rate and seeds the cache. */
     private const val DEFAULT_SUPERTONIC = 24000
 
     /** Cached rates. 0 = "not yet observed"; readers fall through to
@@ -192,9 +194,9 @@ object EngineSampleRateCache {
     private fun readKittenFromEngine(): Int =
         runCatching { KittenEngine.getInstance().sampleRate }.getOrDefault(0)
 
-    /** TODO(#1114): VoxSherpa has no SupertonicEngine yet. Returns 0 so
-     *  callers fall through to DEFAULT_SUPERTONIC. Replace with
-     *  `SupertonicEngine.getInstance().sampleRate` when VoxSherpa v2.9.0
-     *  ships. */
-    private fun readSupertonicFromEngine(): Int = 0
+    /** Issue #1114 — reads the loaded Supertonic engine's sample rate.
+     *  Returns 0 before a model is loaded so callers fall through to
+     *  DEFAULT_SUPERTONIC (24 kHz). */
+    private fun readSupertonicFromEngine(): Int =
+        runCatching { SupertonicEngine.getInstance().sampleRate }.getOrDefault(0)
 }

--- a/core-playback/src/main/kotlin/in/jphe/storyvox/playback/audiobook/AudiobookSynthesizer.kt
+++ b/core-playback/src/main/kotlin/in/jphe/storyvox/playback/audiobook/AudiobookSynthesizer.kt
@@ -3,9 +3,9 @@ package `in`.jphe.storyvox.playback.audiobook
 import android.content.Context
 import com.CodeBySonu.VoxSherpa.KittenEngine
 import com.CodeBySonu.VoxSherpa.KokoroEngine
+import com.CodeBySonu.VoxSherpa.SupertonicEngine
 import com.CodeBySonu.VoxSherpa.VoiceEngine
 import dagger.hilt.android.qualifiers.ApplicationContext
-import `in`.jphe.storyvox.playback.EngineSampleRateCache
 import `in`.jphe.storyvox.playback.cache.EngineMutex
 import `in`.jphe.storyvox.playback.tts.SentenceChunker
 import `in`.jphe.storyvox.playback.tts.detectLocale
@@ -60,9 +60,8 @@ class AudiobookSynthesizer @Inject constructor(
         when (voice.engineType) {
             is EngineType.Kokoro -> KokoroEngine.getInstance().sampleRate
             is EngineType.Kitten -> KittenEngine.getInstance().sampleRate
-            // TODO(#1114): replace with SupertonicEngine.getInstance().sampleRate
-            // when VoxSherpa v2.9.0 ships. Uses the cache default (24 kHz) for now.
-            is EngineType.Supertonic -> EngineSampleRateCache.supertonicRate()
+            // Issue #1114 — Supertonic engine sample rate.
+            is EngineType.Supertonic -> SupertonicEngine.getInstance().sampleRate
             else -> VoiceEngine.getInstance().sampleRate
         }.takeIf { it > 0 } ?: DEFAULT_SAMPLE_RATE_HZ
 
@@ -148,9 +147,12 @@ class AudiobookSynthesizer @Inject constructor(
                 KittenEngine.getInstance().loadModel(appContext, onnx, tokens, voicesBin)
                     ?: ERR_LOAD_NULL
             }
-            // TODO(#1114): wire SupertonicEngine.loadModel when VoxSherpa v2.9.0 ships.
-            is EngineType.Supertonic ->
-                "Error: Supertonic engine not yet available (needs VoxSherpa v2.9.0)"
+            is EngineType.Supertonic -> {
+                val sharedDir = voiceManager.supertonicSharedDir()
+                SupertonicEngine.getInstance().setActiveSpeakerId(type.speakerId)
+                SupertonicEngine.getInstance().loadModel(appContext, sharedDir.absolutePath)
+                    ?: ERR_LOAD_NULL
+            }
             // Guarded in loadVoice; defensive typed errors keep the when exhaustive.
             is EngineType.Azure -> "Error: Azure not supported for export"
             is EngineType.SystemTts -> "Error: System TTS not supported for export"
@@ -160,8 +162,7 @@ class AudiobookSynthesizer @Inject constructor(
         when (voice.engineType) {
             is EngineType.Kokoro -> KokoroEngine.getInstance().generateAudioPCM(text, 1.0f, 1.0f)
             is EngineType.Kitten -> KittenEngine.getInstance().generateAudioPCM(text, 1.0f, 1.0f)
-            // TODO(#1114): SupertonicEngine.getInstance().generateAudioPCM(text, 1.0f, 1.0f)
-            is EngineType.Supertonic -> null
+            is EngineType.Supertonic -> SupertonicEngine.getInstance().generateAudioPCM(text, 1.0f, 1.0f)
             is EngineType.Azure, is EngineType.SystemTts -> null
             else -> VoiceEngine.getInstance().generateAudioPCM(text, 1.0f, 1.0f)
         }

--- a/core-playback/src/main/kotlin/in/jphe/storyvox/playback/cache/ChapterRenderJob.kt
+++ b/core-playback/src/main/kotlin/in/jphe/storyvox/playback/cache/ChapterRenderJob.kt
@@ -13,6 +13,7 @@ import androidx.work.ForegroundInfo
 import androidx.work.WorkerParameters
 import com.CodeBySonu.VoxSherpa.KittenEngine
 import com.CodeBySonu.VoxSherpa.KokoroEngine
+import com.CodeBySonu.VoxSherpa.SupertonicEngine
 import com.CodeBySonu.VoxSherpa.VoiceEngine
 import dagger.assisted.Assisted
 import dagger.assisted.AssistedInject
@@ -146,16 +147,9 @@ class ChapterRenderJob @AssistedInject constructor(
             )
             return Result.success()
         }
-        // TODO(#1114) — Skip Supertonic background pre-rendering until
-        // VoxSherpa ships a SupertonicEngine wrapper. Remove this guard
-        // when the engine is wired in.
-        if (voice.engineType is EngineType.Supertonic) {
-            Log.i(
-                LOG_TAG,
-                "pcm-cache PRERENDER-SKIP-SUPERTONIC chapterId=$chapterId voiceId=${voice.id}",
-            )
-            return Result.success()
-        }
+        // Issue #1114 — Supertonic pre-renders like the other local engines
+        // (Piper/Kokoro/Kitten); no skip guard. It's an in-process VoxSherpa
+        // engine, so the loadModel + generateAudioPCM bridge below handles it.
 
         // 4. Build the cache key. Render at the 1.0×/1.0× empty-dict
         // identity — see kdoc on speed/pitch quantization.
@@ -312,9 +306,12 @@ class ChapterRenderJob @AssistedInject constructor(
                 KittenEngine.getInstance().loadModel(appContext, onnx, tokens, voicesBin)
                     ?: "Error: load returned null"
             }
-            // TODO(#1114): wire SupertonicEngine.loadModel when VoxSherpa v2.9.0 ships.
-            is EngineType.Supertonic ->
-                "Error: Supertonic engine not yet available (needs VoxSherpa v2.9.0)"
+            is EngineType.Supertonic -> {
+                val sharedDir = voiceManager.supertonicSharedDir()
+                SupertonicEngine.getInstance().setActiveSpeakerId(type.speakerId)
+                SupertonicEngine.getInstance().loadModel(appContext, sharedDir.absolutePath)
+                    ?: "Error: load returned null"
+            }
             // Guarded above — defensive fall-through if surface evolves.
             is EngineType.Azure -> "Error: Azure not supported in background pre-render"
             // #676 — also guarded above; mirrors Azure with a typed error
@@ -327,8 +324,8 @@ class ChapterRenderJob @AssistedInject constructor(
         when (voice.engineType) {
             is EngineType.Kokoro -> KokoroEngine.getInstance().sampleRate
             is EngineType.Kitten -> KittenEngine.getInstance().sampleRate
-            // TODO(#1114): SupertonicEngine.getInstance().sampleRate
-            is EngineType.Supertonic -> EngineSampleRateCache.supertonicRate()
+            // Issue #1114 — Supertonic engine sample rate.
+            is EngineType.Supertonic -> SupertonicEngine.getInstance().sampleRate
             else -> VoiceEngine.getInstance().sampleRate
         }.takeIf { it > 0 } ?: DEFAULT_SAMPLE_RATE_HZ
 
@@ -338,8 +335,8 @@ class ChapterRenderJob @AssistedInject constructor(
                 .generateAudioPCM(text, 1.0f, 1.0f)
             is EngineType.Kitten -> KittenEngine.getInstance()
                 .generateAudioPCM(text, 1.0f, 1.0f)
-            // TODO(#1114): SupertonicEngine.getInstance().generateAudioPCM(text, 1.0f, 1.0f)
-            is EngineType.Supertonic -> null
+            is EngineType.Supertonic -> SupertonicEngine.getInstance()
+                .generateAudioPCM(text, 1.0f, 1.0f)
             else -> VoiceEngine.getInstance()
                 .generateAudioPCM(text, 1.0f, 1.0f)
         }

--- a/core-playback/src/main/kotlin/in/jphe/storyvox/playback/tts/EnginePlayer.kt
+++ b/core-playback/src/main/kotlin/in/jphe/storyvox/playback/tts/EnginePlayer.kt
@@ -17,6 +17,7 @@ import androidx.media3.common.SimpleBasePlayer
 import androidx.media3.common.util.UnstableApi
 import com.CodeBySonu.VoxSherpa.KittenEngine
 import com.CodeBySonu.VoxSherpa.KokoroEngine
+import com.CodeBySonu.VoxSherpa.SupertonicEngine
 import com.CodeBySonu.VoxSherpa.VoiceEngine
 import com.google.common.collect.ImmutableList
 import com.google.common.util.concurrent.Futures
@@ -400,8 +401,10 @@ class EnginePlayer @AssistedInject constructor(
     @Volatile
     private var secondaryKittenEngines: List<com.CodeBySonu.VoxSherpa.KittenEngine> = emptyList()
 
-    // TODO(#1114): Supertonic secondaries for Tier 3 parallel-synth.
-    // Uncomment and wire when VoxSherpa v2.9.0 ships SupertonicEngine.
+    // Issue #1114 — Supertonic has no Tier 3 secondaries: it runs serial
+    // (each session loads four ONNX graphs, so a multi-instance fan-out is
+    // memory-heavy). SupertonicEngine supports a public constructor, so
+    // wiring secondaries here is a future parallel-synth enhancement.
     // @Volatile
     // private var secondarySupertonicEngines: List<SupertonicEngine> = emptyList()
 
@@ -1495,10 +1498,8 @@ class EnginePlayer @AssistedInject constructor(
                             runCatching { KokoroEngine.getInstance().sampleRate }
                         is EngineType.Kitten ->
                             runCatching { KittenEngine.getInstance().sampleRate }
-                        is EngineType.Supertonic -> {
-                            // TODO(#1114): warm SupertonicEngine.getInstance()
-                            // when VoxSherpa v2.9.0 ships. No-op for now.
-                        }
+                        is EngineType.Supertonic ->
+                            runCatching { SupertonicEngine.getInstance().sampleRate }
                         is EngineType.Azure -> {
                             // Azure has no JNI singleton to warm; the
                             // HTTPS client lazy-inits on first request
@@ -2063,14 +2064,15 @@ class EnginePlayer @AssistedInject constructor(
                         primaryResult ?: "Error: load returned null"
                     }
                     is EngineType.Supertonic -> {
-                        // TODO(#1114) — Supertonic 3 loadAndPlay path.
-                        // Mirrors Kitten structurally: shared model, multi-
-                        // speaker via speakerId. VoxSherpa v2.8.0 has no
-                        // SupertonicEngine yet; stub returns an error so the
-                        // scaffold compiles and the UI surfaces the voice
-                        // family (catalog, filter, picker) without crashing
-                        // if someone taps a Supertonic voice before the
-                        // engine lands.
+                        // Issue #1114 — Supertonic 3 loadAndPlay path.
+                        // Mirrors Kitten structurally: one shared 7-file int8
+                        // bundle underpins all 10 speakers; switching speakers
+                        // reuses the loaded engine via setActiveSpeakerId (the
+                        // speaker id is just a GenerationConfig knob, no
+                        // reload). Tier 3 secondaries are NOT wired for
+                        // Supertonic — each session loads four ONNX graphs
+                        // (duration/encoder/vector/vocoder), so it runs serial
+                        // for now (see the secondary-engines branch below).
                         secondaryPiperEngines.forEach { runCatching { it.destroy() } }
                         secondaryPiperEngines = emptyList()
                         secondaryKokoroEngines.forEach { runCatching { it.destroy() } }
@@ -2081,7 +2083,15 @@ class EnginePlayer @AssistedInject constructor(
                         systemTtsEngine = null
                         loadedSystemTtsEngineName = null
                         loadedSystemTtsVoiceName = null
-                        "Error: Supertonic engine not yet available (needs VoxSherpa v2.9.0)"
+                        val sharedDir = voiceManager.supertonicSharedDir()
+                        SupertonicEngine.getInstance().setActiveSpeakerId(
+                            (active.engineType as EngineType.Supertonic).speakerId,
+                        )
+                        val parallelState = parallelSynthConfig.currentParallelSynthState()
+                        val nt = parallelState.threadsPerInstance
+                        SupertonicEngine.getInstance()
+                            .loadModel(context, sharedDir.absolutePath, nt)
+                            ?: "Error: load returned null"
                     }
                     is EngineType.Azure -> {
                         // Tier 3 (#88) — voice swap AWAY from local
@@ -2518,8 +2528,10 @@ class EnginePlayer @AssistedInject constructor(
                     }
                 }
             }
-            // TODO(#1114): Supertonic secondaries — wire when VoxSherpa
-            // v2.9.0 ships. Empty list = serial mode until then.
+            // Issue #1114 — Supertonic runs serial (no Tier 3 secondaries).
+            // The engine supports multi-instance construction, but each
+            // Supertonic session loads four ONNX graphs, so a fan-out is
+            // memory-heavy; deferred as a future parallel-synth enhancement.
             is EngineType.Supertonic -> emptyList()
             is EngineType.Azure -> {
                 // Reuse the parallelSynthInstances knob as Azure
@@ -3511,8 +3523,9 @@ class EnginePlayer @AssistedInject constructor(
                         // Issue #119 — Kitten dispatch.
                         is EngineType.Kitten -> KittenEngine.getInstance()
                             .generateAudioPCM(text, speed, pitch)
-                        // TODO(#1114): SupertonicEngine.getInstance().generateAudioPCM(...)
-                        is EngineType.Supertonic -> null
+                        // Issue #1114 — Supertonic dispatch.
+                        is EngineType.Supertonic -> SupertonicEngine.getInstance()
+                            .generateAudioPCM(text, speed, pitch)
                         else -> VoiceEngine.getInstance()
                             .generateAudioPCM(text, speed, pitch)
                     }
@@ -5267,9 +5280,18 @@ class EnginePlayer @AssistedInject constructor(
                         KittenEngine.getInstance().loadModel(context, onnx, tokens, voicesBin)
                             ?: "Error: load returned null"
                     }
-                    // TODO(#1114): wire SupertonicEngine recap path.
-                    is EngineType.Supertonic ->
-                        return@withContext "Error: Supertonic unsupported in recap (needs VoxSherpa v2.9.0)"
+                    // Issue #1114 — Supertonic recap path. Like Kitten, no
+                    // Tier 3 secondaries (recap is a one-off short read; the
+                    // primary engine is sufficient).
+                    is EngineType.Supertonic -> {
+                        val sharedDir = voiceManager.supertonicSharedDir()
+                        SupertonicEngine.getInstance().setActiveSpeakerId(
+                            (active.engineType as EngineType.Supertonic).speakerId,
+                        )
+                        SupertonicEngine.getInstance()
+                            .loadModel(context, sharedDir.absolutePath)
+                            ?: "Error: load returned null"
+                    }
                     is EngineType.Azure -> return@withContext "Error: Azure unsupported in recap"
                     is EngineType.SystemTts -> {
                         // #676 — recap-aloud path for System TTS.

--- a/core-playback/src/main/kotlin/in/jphe/storyvox/playback/voice/UiVoiceInfo.kt
+++ b/core-playback/src/main/kotlin/in/jphe/storyvox/playback/voice/UiVoiceInfo.kt
@@ -100,17 +100,14 @@ sealed interface EngineType {
     /**
      * Supertonic 3 speaker — shared Supertonic model, picks a speaker by index.
      *
-     * Issue #1114 — fourth in-process voice family. Wraps sherpa-onnx's
-     * `OfflineTtsSupertonicModelConfig` path (available in sherpa-onnx
-     * 1.13.2+). Architecturally a twin of [Kokoro] and [Kitten]: a single
-     * shared model supports 10 speakers selected at synth time by
-     * [speakerId].
-     *
-     * TODO(#1114): VoxSherpa v2.8.0 has no `SupertonicEngine` wrapper yet.
-     * The scaffold stubs all call sites with TODO markers; a VoxSherpa
-     * v2.9.0 update is the follow-up dependency. Alternatively, the engine
-     * could call sherpa-onnx's `OfflineTts` directly using
-     * `OfflineTtsSupertonicModelConfig`.
+     * Issue #1114 — fourth in-process voice family. Backed by VoxSherpa's
+     * `SupertonicEngine`, which wraps sherpa-onnx's
+     * `OfflineTtsSupertonicModelConfig` + `GenerationConfig` path
+     * (sherpa-onnx 1.13.x). Architecturally a twin of [Kokoro] and
+     * [Kitten]: a single shared (seven-file int8) bundle supports 10
+     * speakers selected at synth time by [speakerId]. Unlike the other
+     * families it's unicode-tokenised (no espeak data) and runs through
+     * `generateWithConfig` rather than the legacy `generate(text,sid,speed)`.
      */
     data class Supertonic(val speakerId: Int) : EngineType
 

--- a/core-playback/src/main/kotlin/in/jphe/storyvox/playback/voice/VoiceCatalog.kt
+++ b/core-playback/src/main/kotlin/in/jphe/storyvox/playback/voice/VoiceCatalog.kt
@@ -832,9 +832,9 @@ object VoiceCatalog {
      * prosody and naturalness than Kitten (Low) and sits alongside the best
      * Piper voices. Studio is reserved for the curated Kokoro peak.
      *
-     * TODO(#1114): sizeBytes is 0L (shared-model sentinel, same as
-     * Kokoro/Kitten). Update to the actual model size once the download
-     * pipeline is wired.
+     * sizeBytes is 0L — the shared-model sentinel (same as Kokoro/Kitten):
+     * all 10 speakers share one download, so a per-voice byte count is
+     * misleading and the Voice Library suppresses the size chip when it's 0.
      */
     private fun supertonicEntries(): List<CatalogEntry> {
         fun supertonic(id: String, displayName: String, speakerId: Int, gender: VoiceGender): CatalogEntry =

--- a/core-playback/src/main/kotlin/in/jphe/storyvox/playback/voice/VoiceManager.kt
+++ b/core-playback/src/main/kotlin/in/jphe/storyvox/playback/voice/VoiceManager.kt
@@ -9,6 +9,7 @@ import androidx.datastore.preferences.core.stringPreferencesKey
 import androidx.datastore.preferences.core.stringSetPreferencesKey
 import androidx.datastore.preferences.preferencesDataStore
 import androidx.annotation.VisibleForTesting
+import com.CodeBySonu.VoxSherpa.SupertonicEngine
 import dagger.hilt.android.qualifiers.ApplicationContext
 import `in`.jphe.storyvox.data.source.AzureVoiceProvider
 import `in`.jphe.storyvox.data.source.SystemTtsVoiceProvider
@@ -211,8 +212,8 @@ class VoiceManager @Inject constructor(
         // is the single source of truth for "every Kitten voice is
         // playable." Each speaker is just an index into voices.bin.
         val kittenReady = isKittenSharedModelInstalled()
-        // TODO(#1114): wire isSupertonicSharedModelInstalled() when
-        // the download pipeline lands.
+        // Issue #1114 — Supertonic mirrors Kokoro/Kitten: shared-bundle
+        // presence makes every Supertonic speaker playable.
         val supertonicReady = isSupertonicSharedModelInstalled()
         VoiceCatalog.voicesWithAzureAndSystemTts(azureRoster, systemTtsRoster)
             .filter {
@@ -304,15 +305,13 @@ class VoiceManager @Inject constructor(
             File(dir, "tokens.txt").exists()
     }
 
-    /** Issue #1114 — Supertonic 3 mirrors Kokoro/Kitten: shared model
-     *  presence is the single source of truth. TODO(#1114): verify the
-     *  on-disk artifact names against the actual Supertonic 3 model
-     *  bundle when the download pipeline is wired. */
+    /** Issue #1114 — Supertonic 3 mirrors Kokoro/Kitten: shared-model
+     *  presence is the single source of truth for "every Supertonic voice
+     *  is playable." Unlike the other engines, the bundle is seven files
+     *  (see [SupertonicEngine.MODEL_FILES]) — all must be present. */
     private fun isSupertonicSharedModelInstalled(): Boolean {
         val dir = supertonicSharedDir()
-        return File(dir, "model.onnx").exists() &&
-            File(dir, "voices.bin").exists() &&
-            File(dir, "tokens.txt").exists()
+        return SupertonicEngine.MODEL_FILES.all { File(dir, it).exists() }
     }
 
     sealed interface DownloadProgress {
@@ -503,14 +502,71 @@ class VoiceManager @Inject constructor(
                 emit(DownloadProgress.Done)
             }
             is EngineType.Supertonic -> {
-                // TODO(#1114) — Supertonic 3 shared-model download.
-                // Mirrors Kitten's pattern: one shared dir with model.onnx +
-                // tokens.txt + voices.bin (or equivalent). Stub until the
-                // model hosting URL and file sizes are known.
-                emit(DownloadProgress.Failed(
-                    "Supertonic download not yet available — engine ships in a follow-up PR",
-                ))
-                return@flow
+                // Issue #1114 — Supertonic 3 ships as a seven-file int8
+                // bundle (see [SupertonicEngine.MODEL_FILES]). One shared dir
+                // underpins all 10 speakers; first install lands the bundle,
+                // subsequent voice picks just flip the active speaker index
+                // with no additional payload.
+                //
+                // PLACEHOLDER HOSTING: the upstream pack
+                // (sherpa-onnx-supertonic-3-tts-int8-2026-05-11) is
+                // distributed as a tar.bz2, which this flat-file streaming
+                // loop can't extract in-app. The seven files must be
+                // re-hosted as flat per-file release assets — the same way
+                // the Kitten/Kokoro bundles were repackaged onto a VoxSherpa
+                // release. Until that release is cut, the GETs below 404 and
+                // the UI surfaces a Failed state: the wiring is complete, only
+                // the asset hosting is pending. Update [supertonicBaseUrl] and
+                // the size estimate when the release lands.
+                val supertonicBaseUrl =
+                    "https://github.com/techempower-org/VoxSherpa-TTS/releases/download/supertonic-v1"
+                // Rough total for the progress bar; the int8 pack is ~60 MB.
+                // Exact per-file sizes land with hosting (contentLength from
+                // the response refines the bar mid-download).
+                val supertonicTotalBytes = 60_000_000L
+                val sharedDir = supertonicSharedDir()
+                val present = SupertonicEngine.MODEL_FILES.all {
+                    File(sharedDir, it).let { f -> f.exists() && f.length() > 0 }
+                }
+                if (!present) {
+                    sharedDir.mkdirs()
+                    try {
+                        var done = 0L
+                        for (name in SupertonicEngine.MODEL_FILES) {
+                            val target = File(sharedDir, name)
+                            if (target.exists() && target.length() > 0) continue
+                            val url = "$supertonicBaseUrl/$name"
+                            // ONNX graphs are the big files and benefit from
+                            // the gzip-capable path; the JSON / .bin metadata
+                            // files are tiny, so raw is fine.
+                            if (name.endsWith(".onnx")) {
+                                downloadFile(url, target, knownTotalBytes = 0L) { read, _ ->
+                                    emit(DownloadProgress.Downloading(done + read, supertonicTotalBytes))
+                                }
+                            } else {
+                                downloadFileRaw(url, target, knownTotalBytes = 0L) { read, _ ->
+                                    emit(DownloadProgress.Downloading(done + read, supertonicTotalBytes))
+                                }
+                            }
+                            done += target.length()
+                        }
+                    } catch (ce: CancellationException) {
+                        // User-driven cancel — re-throw to honour structured
+                        // concurrency. Partial files survive (no wipe) so a
+                        // sibling that finished before the cancel isn't
+                        // re-fetched on retry. Mirrors the Kokoro/Kitten path.
+                        throw ce
+                    } catch (t: Throwable) {
+                        // Real failure: wipe the shared dir so retries are
+                        // deterministic (a half-written ONNX would fail to
+                        // load). Mirrors the Kokoro/Kitten branches.
+                        sharedDir.deleteRecursively()
+                        emit(DownloadProgress.Failed(t.message ?: t::class.java.simpleName))
+                        return@flow
+                    }
+                }
+                markInstalled(voiceId)
+                emit(DownloadProgress.Done)
             }
             EngineType.Piper -> {
                 val piper = entry.piper


### PR DESCRIPTION
Closes #1191. Activates the **Supertonic 3** voice family scaffolded in
#1114/#1120 by wiring every `TODO(#1114)` dispatch stub to VoxSherpa's new
`SupertonicEngine`.

**Two-repo change** — depends on techempower-org/VoxSherpa-TTS#3 (the
`SupertonicEngine.java` wrapper). Merge/tag that first, then bump the dep
here to `v2.9.0`.

## What's wired

| Site | Before | After |
|---|---|---|
| `EnginePlayer` prewarm / loadAndPlay / generate / recap | stub errors / no-op | drive `SupertonicEngine` (dir-based `loadModel` on `supertonicSharedDir`, speaker via `setActiveSpeakerId`) |
| `EngineSampleRateCache.readSupertonicFromEngine` | returned 0 | real engine readback |
| `AudiobookSynthesizer` (export) | stub | load + synth + sample rate |
| `ChapterRenderJob` (pre-render) | skipped | pre-renders like other local engines |
| `VoiceManager.isSupertonicSharedModelInstalled` | wrong file names | seven-file bundle via `SupertonicEngine.MODEL_FILES` |
| `VoiceManager.download` | hard failure | streams the seven files |

Supertonic runs **serial** (no Tier 3 secondaries — each session loads
four ONNX graphs, so a fan-out is memory-heavy; the engine supports a
public ctor, so it's a future enhancement).

## Dependency

`:core-playback` points at
`com.github.techempower-org:VoxSherpa-TTS:feat-supertonic-engine-SNAPSHOT`
(JitPack branch build; resolves from mavenLocal during local dev — settings
lists mavenLocal ahead of JitPack). **Bump to `v2.9.0` once the VoxSherpa PR
is tagged.**

## Known follow-up (not blocking the wiring)

**Model hosting is a placeholder.** The upstream int8 pack
(`sherpa-onnx-supertonic-3-tts-int8-2026-05-11`) ships as a `tar.bz2`,
which the flat-file download loop can't extract in-app. The seven files
must be re-hosted as flat per-file release assets (the way the Kitten /
Kokoro bundles were). Until then, the download 404s and the UI surfaces a
Failed state — the code path is complete, only the assets are pending. The
placeholder base URL + size estimate are documented inline in
`VoiceManager`.

## Verification
- `./gradlew :core-playback:compileDebugKotlin` ✅
- `./gradlew :core-playback:testDebugUnitTest` ✅ (incl. `VoiceFamilyRegistryTest`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)