### PR TITLE
fix(playback): sample radio ExoPlayer position only on the main looper (#1192)

### DIFF
--- a/core-playback/src/main/kotlin/in/jphe/storyvox/playback/tts/EnginePlayer.kt
+++ b/core-playback/src/main/kotlin/in/jphe/storyvox/playback/tts/EnginePlayer.kt
@@ -152,6 +152,51 @@ internal fun shouldCheckpointPosition(state: PlaybackState): Boolean =
     state.currentFictionId != null && state.currentChapterId != null
 
 /**
+ * Issue #1192 — pure resolver for the live audio-stream chapter position,
+ * factored out so its off-main-thread safety contract can be pinned in a
+ * unit test (EnginePlayerLiveAudioPositionTest) without standing up the full
+ * EnginePlayer + Hilt + sherpa-onnx graph — same constraint that gates
+ * [shouldAutoPlayAfterAdvance] / [shouldCheckpointPosition].
+ *
+ * [EnginePlayer.currentPositionMs] is documented "safe to call from any
+ * thread" and is in fact polled off-main every 50 ms by
+ * [in.jphe.storyvox.playback.PlaybackController]'s position loop (its scope is
+ * [kotlinx.coroutines.Dispatchers.Default]). For a live audio chapter the
+ * position lives on the sibling Media3 [androidx.media3.exoplayer.ExoPlayer],
+ * which is thread-confined to the Main looper — touching it off-main throws
+ * `IllegalStateException: Player is accessed on the wrong thread` (the #1192
+ * radio-playback crash, ~50 ms after the stream loaded; the same wrong-thread
+ * class as #969 / #553).
+ *
+ * So the live position is sampled from the player ONLY when [onMainLooper];
+ * off-main callers reuse [cachedMs] — the value last sampled on main. Either
+ * way the monotonic latch from [lastTruthfulMs] is applied so the reported
+ * position never regresses within a chapter (#536). The live-stream scrubber
+ * is hidden (#373), so a one-poll-stale value off-main is invisible.
+ *
+ * @param onMainLooper true iff the caller is on the player's application
+ *   (Main) looper — the only thread on which [samplePlayerPositionMs] is safe.
+ * @param samplePlayerPositionMs reads the live player position; returns null
+ *   when the player isn't built yet. Invoked ONLY when [onMainLooper].
+ * @return the position to report now plus the cache value the caller must
+ *   store back for the next off-main read.
+ */
+internal fun resolveLiveAudioPositionMs(
+    onMainLooper: Boolean,
+    cachedMs: Long,
+    lastTruthfulMs: Long,
+    samplePlayerPositionMs: () -> Long?,
+): LiveAudioPosition {
+    val cache = if (onMainLooper) (samplePlayerPositionMs() ?: cachedMs) else cachedMs
+    val reported = maxOf(cache, lastTruthfulMs)
+    return LiveAudioPosition(reportedMs = reported, cachedMs = cache)
+}
+
+/** Result of [resolveLiveAudioPositionMs]: the position to report now and the
+ *  cache value to persist for the next off-main read. */
+internal data class LiveAudioPosition(val reportedMs: Long, val cachedMs: Long)
+
+/**
  * Issue #1126 — did a thermal-status transition cross the MODERATE
  * boundary in either direction?
  *
@@ -1343,10 +1388,26 @@ class EnginePlayer @AssistedInject constructor(
         // Audio-stream chapters route through ExoPlayer, which owns
         // its own currentPosition. Defer to it; the UI scrubber for
         // live streams isn't useful anyway (#373 hides the rail).
+        //
+        // Issue #1192 — [audioStreamPlayer] is a Media3 ExoPlayer pinned to
+        // the Main looper, but currentPositionMs() is contractually "safe to
+        // call from any thread" and IS polled off-main every 50 ms by
+        // PlaybackController's position loop (scope = Dispatchers.Default).
+        // Reading ExoPlayer.currentPosition from that worker threw
+        // "Player is accessed on the wrong thread" ~50 ms after a radio
+        // stream loaded — the reported crash. Sample the player only on the
+        // main looper (the getState position-supplier / pause / resume paths);
+        // off-main callers reuse the last main-sampled value via the cache.
         if (state.isLiveAudioChapter) {
-            val pos = audioStreamPlayer?.currentPosition ?: 0L
-            if (pos > lastTruthfulPositionMs) lastTruthfulPositionMs = pos
-            return lastTruthfulPositionMs
+            val resolved = resolveLiveAudioPositionMs(
+                onMainLooper = Looper.myLooper() == Looper.getMainLooper(),
+                cachedMs = audioStreamPositionMs,
+                lastTruthfulMs = lastTruthfulPositionMs,
+                samplePlayerPositionMs = { audioStreamPlayer?.currentPosition },
+            )
+            audioStreamPositionMs = resolved.cachedMs
+            lastTruthfulPositionMs = resolved.reportedMs
+            return resolved.reportedMs
         }
 
         val track = audioTrack
@@ -4871,6 +4932,18 @@ class EnginePlayer @AssistedInject constructor(
      */
     private var audioStreamPlayer: androidx.media3.exoplayer.ExoPlayer? = null
 
+    /**
+     * Issue #1192 — last [audioStreamPlayer] position sampled on the Main
+     * looper. ExoPlayer is Main-confined; [currentPositionMs] is polled
+     * off-main by PlaybackController, so off-main reads serve this cache
+     * instead of touching the player (which would throw
+     * "Player is accessed on the wrong thread"). Written only on the main
+     * looper (the getState position-supplier / pause / resume paths) and
+     * reset to 0 on each fresh [loadAndPlayAudioStream]. `@Volatile` for
+     * the cross-thread read from PlaybackController's Dispatchers.Default poll.
+     */
+    @Volatile private var audioStreamPositionMs: Long = 0L
+
     /** Listener attached to [audioStreamPlayer] so isPlaying flips on
      *  the MediaSession surface follow real player events (buffer →
      *  ready → playing). Held so [stopAudioStreamPlayer] can detach
@@ -4918,6 +4991,10 @@ class EnginePlayer @AssistedInject constructor(
         stopPlaybackPipeline()
         sentences = emptyList()
         currentSentenceIndex = 0
+        // #1192 — drop the previous station's cached position so a station
+        // swap starts the (hidden) live scrubber at 0 rather than inheriting
+        // the prior stream's higher latched value.
+        audioStreamPositionMs = 0L
 
         // #807 — fresh chapter load wipes the retry budget; any pending
         // backoff from the previous load is cancelled so it doesn't

--- a/core-playback/src/test/kotlin/in/jphe/storyvox/playback/tts/EnginePlayerLiveAudioPositionTest.kt
+++ b/core-playback/src/test/kotlin/in/jphe/storyvox/playback/tts/EnginePlayerLiveAudioPositionTest.kt
@@ -1,0 +1,114 @@
+package `in`.jphe.storyvox.playback.tts
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * Issue #1192 — pins the off-main-thread safety contract of
+ * [resolveLiveAudioPositionMs], the resolver behind [EnginePlayer.currentPositionMs]'s
+ * live-audio (radio) branch.
+ *
+ * The crash: `audioStreamPlayer` is a Media3 ExoPlayer thread-confined to the
+ * Main looper, but currentPositionMs() is documented "safe to call from any
+ * thread" and is polled off-main every 50 ms by PlaybackController's position
+ * loop (scope = Dispatchers.Default). The pre-fix radio branch read
+ * `audioStreamPlayer.currentPosition` directly, so the first off-main poll
+ * after a station loaded threw
+ * `IllegalStateException: Player is accessed on the wrong thread` — the same
+ * wrong-thread class already fixed at #969 / #553 for other engine touches.
+ *
+ * The headline guarantee is [`off-main never samples the thread-confined player`]:
+ * the player-sampling lambda must NOT run off the main looper.
+ *
+ * Stays at the pure-function layer — full EnginePlayer construction needs a
+ * Hilt graph + sherpa-onnx AARs (same constraint documented on
+ * EnginePlayerPositionCheckpointTest).
+ */
+class EnginePlayerLiveAudioPositionTest {
+
+    @Test
+    fun `off-main never samples the thread-confined player`() {
+        // The #1192 crash guard: PlaybackController's 50 ms poll runs on
+        // Dispatchers.Default (no main looper). The sampling lambda would read
+        // ExoPlayer.currentPosition and throw — it must not be invoked.
+        var sampled = false
+        val r = resolveLiveAudioPositionMs(
+            onMainLooper = false,
+            cachedMs = 1_234L,
+            lastTruthfulMs = 1_000L,
+            samplePlayerPositionMs = { sampled = true; 9_999L },
+        )
+        assertFalse(
+            "off-main callers must NOT touch the Main-confined ExoPlayer (#1192)",
+            sampled,
+        )
+        // Off-main serves the last main-sampled cache value (latched).
+        assertEquals(1_234L, r.cachedMs)
+        assertEquals(1_234L, r.reportedMs)
+    }
+
+    @Test
+    fun `on-main samples the player and refreshes the cache`() {
+        val r = resolveLiveAudioPositionMs(
+            onMainLooper = true,
+            cachedMs = 0L,
+            lastTruthfulMs = 0L,
+            samplePlayerPositionMs = { 4_200L },
+        )
+        assertEquals("on-main refreshes the cache from the live player", 4_200L, r.cachedMs)
+        assertEquals(4_200L, r.reportedMs)
+    }
+
+    @Test
+    fun `position never regresses within a chapter`() {
+        // #536 monotonic latch — a fresh sample that dips (e.g. ExoPlayer
+        // re-clamps during a buffering blip) must not drag the reported
+        // position backwards, even though the raw cache tracks the dip.
+        val r = resolveLiveAudioPositionMs(
+            onMainLooper = true,
+            cachedMs = 5_000L,
+            lastTruthfulMs = 5_000L,
+            samplePlayerPositionMs = { 100L },
+        )
+        assertEquals("reported position stays latched at the high-water mark", 5_000L, r.reportedMs)
+        assertEquals("cache still tracks the raw sample for the next read", 100L, r.cachedMs)
+    }
+
+    @Test
+    fun `null player position on-main falls back to the cache`() {
+        // Window between isLiveAudioChapter=true and ensureAudioStreamPlayer():
+        // the player isn't built yet, so the sample is null. Reuse the cache
+        // rather than collapsing to 0 (avoids a transient scrubber glitch, #536).
+        val r = resolveLiveAudioPositionMs(
+            onMainLooper = true,
+            cachedMs = 777L,
+            lastTruthfulMs = 0L,
+            samplePlayerPositionMs = { null },
+        )
+        assertEquals(777L, r.cachedMs)
+        assertEquals(777L, r.reportedMs)
+    }
+
+    @Test
+    fun `on-main advances the cache as the live stream plays`() {
+        // Successive main-thread samples advance both the cache and the latch.
+        var raw = 1_000L
+        val first = resolveLiveAudioPositionMs(
+            onMainLooper = true,
+            cachedMs = 0L,
+            lastTruthfulMs = 0L,
+            samplePlayerPositionMs = { raw },
+        )
+        raw = 2_500L
+        val second = resolveLiveAudioPositionMs(
+            onMainLooper = true,
+            cachedMs = first.cachedMs,
+            lastTruthfulMs = first.reportedMs,
+            samplePlayerPositionMs = { raw },
+        )
+        assertTrue("live position advances", second.reportedMs > first.reportedMs)
+        assertEquals(2_500L, second.reportedMs)
+    }
+}


### PR DESCRIPTION
## Summary

Fixes #1192 — radio playback crashed ~50 ms after a station started (Browse → Radio → a station → Play → app dies).

**Root cause is a wrong-thread access of the live-stream player — not the `Dispatchers.IO` change (#1134) the issue suspected.** That fix only touches `RadioBrowserApi`'s *search* path and is correct (it's the #585 convention).

`EnginePlayer.currentPositionMs()` is documented *"safe to call from any thread"* and is in fact polled **off-main every 50 ms** by `PlaybackController`'s position loop (its scope is `Dispatchers.Default`). Its live-audio branch read `audioStreamPlayer.currentPosition` directly — but `audioStreamPlayer` is a Media3 **ExoPlayer pinned to the Main looper**, and every ExoPlayer accessor calls `verifyApplicationThread()`. So the first off-main poll after a radio stream loaded threw:

```
IllegalStateException: Player is accessed on the wrong thread
```

TTS chapters read the AudioTrack frame counter (not ExoPlayer), so **only radio** (`isLiveAudioChapter`) hit it — exactly the reported symptom. This is the same wrong-thread class already fixed at #969 / #553 for other engine touches.

## Fix

- Sample the live player **only when on the main looper** (the `getState` position-supplier / pause / resume paths). Off-main callers reuse the last main-sampled value via a new `@Volatile` cache.
- The live-stream scrubber is hidden (#373) and duration is 0, so a one-poll-stale value off-main is invisible. The monotonic position latch (#536) is preserved.
- Branch logic extracted into a pure `resolveLiveAudioPositionMs()` so the off-main contract is unit-testable without the sherpa-onnx graph (mirrors `shouldCheckpointPosition`).

## Tests

New `EnginePlayerLiveAudioPositionTest` (5 cases). The headline case asserts the player-sampling lambda is **never invoked off-main** — the exact regression guard.

```
:core-playback:testDebugUnitTest — 366 tests, 0 failures, 0 errors, 0 skipped (5 new)
```

## Out-of-scope notes (for the orchestrator)

- The `#` / `?` / `/` characters in a radio **search** query get mis-parsed by `RadioBrowserApi.byName` (interpolated into the URL path → treated as fragment/query). This yields wrong/empty results but does **not** crash (OkHttp percent-encodes the rest). Separate, low-priority.
- `pauseRouted` / `resumeRouted` also touch `audioStreamPlayer` directly but are only ever invoked on Main (Compose callbacks / Media3 handlers), so they're safe today. A background-thread pause (e.g. a future sleep-timer auto-pause on a non-Main dispatcher) would reintroduce the wrong-thread class — worth keeping in mind.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
