### PR TITLE
fix(settings): guard 2 more uriHandler.openUri calls (#1203)

### DIFF
--- a/feature/src/main/kotlin/in/jphe/storyvox/feature/settings/AccessibilitySettingsScreen.kt
+++ b/feature/src/main/kotlin/in/jphe/storyvox/feature/settings/AccessibilitySettingsScreen.kt
@@ -272,7 +272,11 @@ fun AccessibilitySettingsScreen(
                     title = stringResource(R.string.settings_accessibility_learn_more_title),
                     subtitle = stringResource(R.string.settings_accessibility_learn_more_subtitle),
                     onClick = {
-                        uriHandler.openUri("https://candela.techempower.org/accessibility")
+                        // #1203 — guard against ActivityNotFoundException on
+                        // devices with no browser (same fix as #1177/#1186).
+                        runCatching {
+                            uriHandler.openUri("https://candela.techempower.org/accessibility")
+                        }
                     },
                 )
             }

--- a/feature/src/main/kotlin/in/jphe/storyvox/feature/settings/SettingsScreen.kt
+++ b/feature/src/main/kotlin/in/jphe/storyvox/feature/settings/SettingsScreen.kt
@@ -1330,7 +1330,9 @@ internal fun AzureSection(
             annotated,
             style = MaterialTheme.typography.bodySmall,
             modifier = Modifier.clickable(role = Role.Button, onClickLabel = "Open Azure Speech docs") {
-                uriHandler.openUri(helpUrl)
+                // #1203 — guard against ActivityNotFoundException on devices
+                // with no browser (same fix as #1177/#1186).
+                runCatching { uriHandler.openUri(helpUrl) }
             },
         )
 


### PR DESCRIPTION
Closes #1203. Two more unguarded `uriHandler.openUri` calls crash with
`ActivityNotFoundException` on devices with no browser. Same fix as
#1177/#1186 — wrap each in `runCatching`.

| File | Link |
|---|---|
| `AccessibilitySettingsScreen.kt` (~L275) | "Learn more" → hosted accessibility doc |
| `SettingsScreen.kt` `AzureSection` (~L1333) | inline "How do I get an Azure Speech key?" help link |

These were the only two remaining unguarded `openUri` calls under
`feature/settings/` (verified by grep). No new imports — `runCatching` is
kotlin-stdlib; the `Result` is Unit-coerced in the `onClick`/`clickable`
lambda, identical to the merged #1186 fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)