### PR TITLE
feat(ui): collapse headers on scroll in Library & Browse (#1195)

### DIFF
--- a/core-ui/src/main/kotlin/in/jphe/storyvox/ui/component/CollapsingHeader.kt
+++ b/core-ui/src/main/kotlin/in/jphe/storyvox/ui/component/CollapsingHeader.kt
@@ -1,0 +1,128 @@
+package `in`.jphe.storyvox.ui.component
+
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.mutableFloatStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clipToBounds
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.input.nestedscroll.NestedScrollConnection
+import androidx.compose.ui.input.nestedscroll.NestedScrollSource
+import androidx.compose.ui.input.nestedscroll.nestedScroll
+import androidx.compose.ui.layout.Layout
+import kotlin.math.roundToInt
+
+/**
+ * Issue #1195 — a [header] region that scrolls away as the [content]
+ * below it is scrolled, reclaiming vertical space on small phones.
+ *
+ * Library and Browse stack a lot of fixed chrome above their lists —
+ * sub-tabs, a search bar, filter chips, a source carousel. On a small
+ * device that chrome can eat a third of the viewport before a single
+ * result is visible. [CollapsingHeader] wires a [NestedScrollConnection]
+ * that translates the header up as the inner scrollable is dragged down
+ * (and back as it's dragged up), while the content reflows to fill the
+ * space the header vacates.
+ *
+ * Mechanics:
+ * - The header is offset by `[-headerHeight, 0]` px. At `0` it's fully
+ *   visible; at `-headerHeight` it has slid entirely off the top.
+ * - The content is placed directly below the *visible* portion of the
+ *   header, so as the header collapses the content grows to fill the
+ *   freed height. This is a layout reflow (the inner list genuinely
+ *   gets taller), not a clip — so the list's own scroll range stays
+ *   correct.
+ * - Only vertical scroll that actually moves the header is consumed;
+ *   the remainder passes through to the inner list (and to any
+ *   pull-to-refresh / outer top-bar behavior layered around this), so
+ *   those keep working unchanged.
+ *
+ * Because the header is always composed (it's just translated), it stays
+ * interactive in every content state — including non-scrolling states
+ * like empty/error screens, where there's nothing to scroll and the
+ * header simply stays expanded. That's what lets Browse keep its source
+ * carousel and tab row reachable even when the current listing is empty.
+ *
+ * @param resetKey when this value changes, the header snaps back to fully
+ *   expanded. Pass the identity of the content surface (e.g. the selected
+ *   tab / source) so switching surfaces always reveals the full chrome
+ *   rather than inheriting the previous list's collapse state. Must be a
+ *   value with stable structural equality (a String or enum) so it
+ *   doesn't spuriously re-trigger every recomposition.
+ */
+@Composable
+fun CollapsingHeader(
+    header: @Composable () -> Unit,
+    content: @Composable () -> Unit,
+    modifier: Modifier = Modifier,
+    resetKey: Any? = null,
+) {
+    val state = remember { CollapsingHeaderState() }
+
+    // Re-expand whenever the caller's content surface changes (tab /
+    // source switch) so the user lands on fresh, fully-visible chrome
+    // instead of mid-collapse from the previous list's scroll. Programmatic
+    // scroll-to-top on the inner list doesn't dispatch nested scroll, so
+    // this is the hook that keeps the two in sync.
+    LaunchedEffect(resetKey) { state.offset.floatValue = 0f }
+
+    Layout(
+        // clipToBounds so the header doesn't overdraw above its own bounds
+        // (into the top bar / status area) while it translates up to collapse.
+        modifier = modifier.clipToBounds().nestedScroll(state.connection),
+        content = {
+            // A Column so multiple stacked header rows (tabs + search +
+            // chips) lay out vertically; a Box would overlap them.
+            Column { header() }
+            Box { content() }
+        },
+    ) { measurables, constraints ->
+        // Header is free to be as tall as it wants; clamp its minimums so
+        // it wraps content height but still fills the available width.
+        val headerPlaceable = measurables[0].measure(constraints.copy(minHeight = 0))
+        state.headerHeight = headerPlaceable.height
+
+        val offset = state.offset.floatValue.roundToInt()
+        val visibleHeader = (headerPlaceable.height + offset).coerceAtLeast(0)
+
+        val contentMaxHeight = (constraints.maxHeight - visibleHeader).coerceAtLeast(0)
+        val contentPlaceable = measurables[1].measure(
+            constraints.copy(minHeight = 0, maxHeight = contentMaxHeight),
+        )
+
+        layout(constraints.maxWidth, constraints.maxHeight) {
+            contentPlaceable.placeRelative(0, visibleHeader)
+            headerPlaceable.placeRelative(0, offset)
+        }
+    }
+}
+
+/**
+ * Holds the live collapse [offset] (snapshot-backed so a change remeasures
+ * the [CollapsingHeader]) plus the last-measured [headerHeight] (a plain
+ * field, constant after first layout, read by [connection] to clamp).
+ */
+private class CollapsingHeaderState {
+    /** Header translation in px, clamped to `[-headerHeight, 0]`. */
+    val offset = mutableFloatStateOf(0f)
+
+    /** Measured header height in px; written during layout. */
+    var headerHeight: Int = 0
+
+    val connection = object : NestedScrollConnection {
+        override fun onPreScroll(available: Offset, source: NestedScrollSource): Offset {
+            val limit = -headerHeight.toFloat()
+            // Nothing to collapse (header unmeasured or zero-height).
+            if (limit >= 0f) return Offset.Zero
+            val old = offset.floatValue
+            val new = (old + available.y).coerceIn(limit, 0f)
+            if (new == old) return Offset.Zero
+            offset.floatValue = new
+            // Consume only what moved the header; the rest scrolls the list.
+            return Offset(0f, new - old)
+        }
+    }
+}

--- a/core-ui/src/main/kotlin/in/jphe/storyvox/ui/component/MagicTitleBar.kt
+++ b/core-ui/src/main/kotlin/in/jphe/storyvox/ui/component/MagicTitleBar.kt
@@ -10,6 +10,7 @@ import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
+import androidx.compose.material3.TopAppBarScrollBehavior
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -36,6 +37,14 @@ import `in`.jphe.storyvox.ui.theme.LocalSpacing
  * [Icons.Outlined.AutoAwesome] used by the Settings hub heading, so it
  * reads as one design family. Slots for [navigationIcon] and [actions]
  * mirror the underlying [CenterAlignedTopAppBar] API.
+ *
+ * Issue #1195 — pass a [scrollBehavior] (e.g.
+ * `TopAppBarDefaults.enterAlwaysScrollBehavior()`) to let the bar slide
+ * away as the screen's content scrolls down and return on scroll up,
+ * reclaiming vertical space on small phones. The host must also wire
+ * `Modifier.nestedScroll(scrollBehavior.nestedScrollConnection)` onto
+ * its [androidx.compose.material3.Scaffold]. Default null keeps the bar
+ * pinned (the behavior for every call site that doesn't opt in).
  */
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
@@ -44,10 +53,12 @@ fun MagicTitleBar(
     modifier: Modifier = Modifier,
     navigationIcon: @Composable () -> Unit = {},
     actions: @Composable () -> Unit = {},
+    scrollBehavior: TopAppBarScrollBehavior? = null,
 ) {
     val spacing = LocalSpacing.current
     CenterAlignedTopAppBar(
         modifier = modifier,
+        scrollBehavior = scrollBehavior,
         title = {
             Row(
                 verticalAlignment = Alignment.CenterVertically,
@@ -87,12 +98,14 @@ fun MagicTitleBar(
  */
 internal const val magicTitleBarMarksTitleAsHeading: Boolean = true
 
+@OptIn(ExperimentalMaterial3Api::class)
 @Preview(name = "MagicTitleBar — dark", widthDp = 360)
 @Composable
 private fun PreviewMagicTitleBarDark() = LibraryNocturneTheme(darkTheme = true) {
     MagicTitleBar(title = "Library")
 }
 
+@OptIn(ExperimentalMaterial3Api::class)
 @Preview(name = "MagicTitleBar — light", widthDp = 360)
 @Composable
 private fun PreviewMagicTitleBarLight() = LibraryNocturneTheme(darkTheme = false) {

--- a/feature/src/main/kotlin/in/jphe/storyvox/feature/browse/BrowseScreen.kt
+++ b/feature/src/main/kotlin/in/jphe/storyvox/feature/browse/BrowseScreen.kt
@@ -43,6 +43,8 @@ import androidx.compose.material3.Scaffold
 import androidx.compose.material3.SecondaryScrollableTabRow
 import androidx.compose.material3.Tab
 import androidx.compose.material3.Text
+import androidx.compose.material3.TopAppBarDefaults
+import androidx.compose.material3.TopAppBarScrollBehavior
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.derivedStateOf
@@ -56,6 +58,7 @@ import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.flow.filter
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.input.nestedscroll.nestedScroll
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.semantics.Role
 import androidx.compose.ui.res.stringResource
@@ -70,6 +73,7 @@ import `in`.jphe.storyvox.data.source.plugin.SourcePluginDescriptor
 import `in`.jphe.storyvox.ui.component.BrassButton
 import `in`.jphe.storyvox.ui.component.BrassButtonVariant
 import `in`.jphe.storyvox.ui.component.cascadeReveal
+import `in`.jphe.storyvox.ui.component.CollapsingHeader
 import `in`.jphe.storyvox.ui.component.coverSourceFamilyFor
 import `in`.jphe.storyvox.ui.component.ErrorBlock
 import `in`.jphe.storyvox.ui.component.friendlyErrorMessage
@@ -95,6 +99,9 @@ import `in`.jphe.storyvox.ui.theme.LocalSpacing
 @Composable
 private fun BrowseScaffoldOrFrame(
     embedded: Boolean,
+    // Issue #1195 — drives the collapsing top bar on the standalone path.
+    // Null on the embedded path (Library owns the bar there).
+    scrollBehavior: TopAppBarScrollBehavior? = null,
     content: @Composable () -> Unit,
 ) {
     if (embedded) {
@@ -102,9 +109,18 @@ private fun BrowseScaffoldOrFrame(
         content()
     } else {
         Scaffold(
+            modifier = if (scrollBehavior != null) {
+                Modifier.nestedScroll(scrollBehavior.nestedScrollConnection)
+            } else {
+                Modifier
+            },
             topBar = {
                 // #830 — shared title bar across all primary-nav surfaces.
-                MagicTitleBar(title = stringResource(R.string.browse_title))
+                // #1195 — slides away as the listing scrolls (standalone path).
+                MagicTitleBar(
+                    title = stringResource(R.string.browse_title),
+                    scrollBehavior = scrollBehavior,
+                )
             },
         ) { scaffoldPadding ->
             Box(modifier = Modifier.fillMaxSize().padding(scaffoldPadding)) {
@@ -172,15 +188,34 @@ fun BrowseScreen(
         out
     }
 
+    // Issue #1195 — collapsing top bar for the standalone Browse Scaffold.
+    // enterAlways so the bar returns the instant the user scrolls up. The
+    // carousel + tab row collapse independently via [CollapsingHeader] below;
+    // the two nested-scroll connections cascade (bar first, then chrome).
+    val scrollBehavior = TopAppBarDefaults.enterAlwaysScrollBehavior()
+
     // Restructure (v0.5.40) — when embedded under Library, skip the
     // standalone Scaffold/TopAppBar: the parent screen already owns
     // those. The inner Box stays in both branches because the RSS FAB
     // uses `Modifier.align(Alignment.BottomEnd)` against it.
     BrowseScaffoldOrFrame(
         embedded = embedded,
+        // Issue #1195 — only the standalone path owns a top bar to collapse.
+        scrollBehavior = if (embedded) null else scrollBehavior,
     ) {
     Box(modifier = Modifier.fillMaxSize()) {
-    Column(modifier = Modifier.fillMaxSize().padding(top = spacing.md)) {
+    // Issue #1195 — the source carousel, tab row and filter funnel scroll
+    // away as the listing is scrolled and return on scroll-up. The header is
+    // composed in every content state (loading / empty / error / grid), so
+    // source + tab switching keeps working even on a non-scrolling state.
+    CollapsingHeader(
+        modifier = Modifier.fillMaxSize(),
+        // Re-expand whenever the listing identity changes (source / tab /
+        // query / filter); the grid resets its own scroll-to-top on the same
+        // signals, so header and list stay in sync.
+        resetKey = "${state.sourceId}|${state.tab}|${state.query}|${state.filterState.activeCount()}",
+        header = {
+    Column(modifier = Modifier.fillMaxWidth().padding(top = spacing.md)) {
         // v0.5.72 — magical hero source carousel for the first-class
         // Browse tab. Replaces the v0.5.40 chip strip with brass-edged
         // source cards showing icon + name + tagline so the picker
@@ -361,7 +396,9 @@ fun BrowseScreen(
         if (isOffline && state.items.isNotEmpty()) {
             OfflineBanner(onRetry = { viewModel.loadMore() })
         }
-
+    }
+        },
+        content = {
         when {
             // Issue #241 — RR listings are gated on sign-in. CTA sits ahead
             // of the SkeletonGrid branch so the user never sees a loading
@@ -626,7 +663,8 @@ fun BrowseScreen(
                 }  // #776 PullToRefreshBox
             }
         }
-    }
+        },
+    )
 
     // Issue #247 — FAB for RSS feed management. Only visible on the
     // RSS source; other backends manage subscriptions elsewhere

--- a/feature/src/main/kotlin/in/jphe/storyvox/feature/library/LibraryScreen.kt
+++ b/feature/src/main/kotlin/in/jphe/storyvox/feature/library/LibraryScreen.kt
@@ -36,11 +36,13 @@ import androidx.compose.material3.SecondaryScrollableTabRow
 import androidx.compose.material3.Tab
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
+import androidx.compose.material3.TopAppBarDefaults
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.input.nestedscroll.nestedScroll
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.semantics.Role
@@ -70,6 +72,7 @@ import androidx.compose.ui.draw.clip
 import `in`.jphe.storyvox.ui.component.BrassButton
 import `in`.jphe.storyvox.ui.component.BrassButtonVariant
 import `in`.jphe.storyvox.ui.component.BrassProgressBar
+import `in`.jphe.storyvox.ui.component.CollapsingHeader
 import `in`.jphe.storyvox.ui.component.coverSourceFamilyFor
 import `in`.jphe.storyvox.ui.component.FictionCoverThumb
 import `in`.jphe.storyvox.ui.component.fictionMonogram
@@ -151,6 +154,13 @@ fun LibraryScreen(
     val isOffline by viewModel.isOffline.collectAsStateWithLifecycle()
     val spacing = LocalSpacing.current
 
+    // Issue #1195 — let the top app bar slide away as the content scrolls
+    // down (and return on scroll up). The sub-tab row, search bar and
+    // filter chips collapse independently via [CollapsingHeader] below;
+    // the two nested-scroll connections cascade (the bar consumes scroll
+    // first until fully hidden, then the chrome, then the list).
+    val scrollBehavior = TopAppBarDefaults.enterAlwaysScrollBehavior()
+
     // #328 — dedupe defensively before the LazyVerticalGrid sees the list.
     // Compose enforces unique item keys; duplicates throw and crash the
     // activity. Hoisted out of the grid builder via remember so the
@@ -209,6 +219,7 @@ fun LibraryScreen(
     }
 
     Scaffold(
+        modifier = Modifier.nestedScroll(scrollBehavior.nestedScrollConnection),
         // Issue #255 — Library used to fade straight from the system status
         // bar into a Resume card with no header — no 'Library' title, no
         // identity. The shared [MagicTitleBar] (#830) renders a
@@ -218,6 +229,7 @@ fun LibraryScreen(
         topBar = {
             MagicTitleBar(
                 title = stringResource(R.string.library_title),
+                scrollBehavior = scrollBehavior,
                 actions = {
                     // Issue #533 — top-bar action icons used to pack
                     // flush together at 0dp gap on the Flip3 (1080dp
@@ -303,74 +315,88 @@ fun LibraryScreen(
             }
         },
     ) { scaffoldPadding ->
-        Column(modifier = Modifier.fillMaxSize().padding(scaffoldPadding)) {
-            // Issue #158 — Library sub-tabs. SecondaryScrollableTabRow
-            // rather than the fixed SecondaryTabRow because the
-            // restructure (v0.5.40) grew the tab count to five
-            // (Library / Browse / Follows / Inbox / History) and the
-            // labels do not fit the Flip3 portrait width laid out
-            // evenly. Scrollable is the same pattern BrowseScreen
-            // already uses for its narrow-viewport tab row, so this
-            // stays inside the existing visual vocabulary.
-            //
-            // Layering with #116 (shelves): the chip row is shown only
-            // on Tab.Library — on Tab.Browse / Follows the embedded
-            // surfaces own their own scoping, on Tab.Inbox / History
-            // the chip row isn't meaningful.
-            // Issue #532 — the tab row used to use `edgePadding = 0.dp`
-            // which lined the rightmost tab flush with the screen edge.
-            // On the Flip3 cover (1080dp narrow) only 4 of the 5 tabs
-            // fit visibly with no visual hint that "History" (the
-            // fifth) is reachable by horizontal swipe. Bumping
-            // edgePadding to spacing.md (16dp) lets the rightmost
-            // visible tab land as an obviously-partial chip — the same
-            // "scroll for more →" discoverability fix the
-            // VoiceLibrary chip row uses (#420 + #534). Scroll
-            // mechanics were already wired; this is the discovery fix.
-            SecondaryScrollableTabRow(
-                selectedTabIndex = state.tab.ordinal,
-                modifier = Modifier.fillMaxWidth(),
-                edgePadding = spacing.md,
-            ) {
-                LibraryTab.entries.forEach { tab ->
-                    val isSelected = state.tab == tab
-                    Tab(
-                        selected = isSelected,
-                        onClick = { viewModel.selectTab(tab) },
-                        // Issue #613 (v1.0 blocker) — Material3's Tab
-                        // applies Role.Tab via its internal clickable on
-                        // 1.2+, but earlier baselines + custom
-                        // SecondaryScrollableTabRow layouts have been
-                        // observed (R5CRB0W66MK semantics dump,
-                        // 2026-05-15) dropping the role on the merged
-                        // node. Belt-and-suspenders an explicit
-                        // `role = Role.Tab` + `selected` here so the
-                        // a11y tree always carries both, regardless of
-                        // Material version. The semantics modifier
-                        // comes BEFORE Tab's internal clickable so the
-                        // role properties get merged in rather than
-                        // overwritten.
-                        modifier = Modifier.semantics {
-                            role = Role.Tab
-                            selected = isSelected
-                        },
-                        text = {
-                            // Issue #383 — Inbox tab carries an unread-count
-                            // badge. BadgedBox positions the badge at the
-                            // top-right of the label without disturbing the
-                            // tab row's alignment. Zero unread = no badge
-                            // (same convention as FollowsScreen #290).
-                            if (tab == LibraryTab.Inbox && state.inboxUnreadCount > 0) {
-                                BadgedBox(
-                                    badge = {
-                                        Badge(
-                                            containerColor = MaterialTheme.colorScheme.primary,
-                                            contentColor = MaterialTheme.colorScheme.onPrimary,
-                                        ) {
-                                            Text(state.inboxUnreadCount.toString())
-                                        }
-                                    },
-                                ) {
+        CollapsingHeader(
+            modifier = Modifier.fillMaxSize().padding(scaffoldPadding),
+            // Issue #1195 — re-expand the chrome on every sub-tab switch so
+            // each surface opens with its full header rather than inheriting
+            // the previous list's collapse offset.
+            resetKey = state.tab,
+            header = {
+                // Issue #158 — Library sub-tabs. SecondaryScrollableTabRow
+                // rather than the fixed SecondaryTabRow because the
+                // restructure (v0.5.40) grew the tab count to five
+                // (Library / Browse / Follows / Inbox / History) and the
+                // labels do not fit the Flip3 portrait width laid out
+                // evenly. Scrollable is the same pattern BrowseScreen
+                // already uses for its narrow-viewport tab row, so this
+                // stays inside the existing visual vocabulary.
+                //
+                // Layering with #116 (shelves): the chip row is shown only
+                // on Tab.Library — on Tab.Browse / Follows the embedded
+                // surfaces own their own scoping, on Tab.Inbox / History
+                // the chip row isn't meaningful.
+                // Issue #532 — the tab row used to use `edgePadding = 0.dp`
+                // which lined the rightmost tab flush with the screen edge.
+                // On the Flip3 cover (1080dp narrow) only 4 of the 5 tabs
+                // fit visibly with no visual hint that "History" (the
+                // fifth) is reachable by horizontal swipe. Bumping
+                // edgePadding to spacing.md (16dp) lets the rightmost
+                // visible tab land as an obviously-partial chip — the same
+                // "scroll for more →" discoverability fix the
+                // VoiceLibrary chip row uses (#420 + #534). Scroll
+                // mechanics were already wired; this is the discovery fix.
+                SecondaryScrollableTabRow(
+                    selectedTabIndex = state.tab.ordinal,
+                    modifier = Modifier.fillMaxWidth(),
+                    edgePadding = spacing.md,
+                ) {
+                    LibraryTab.entries.forEach { tab ->
+                        val isSelected = state.tab == tab
+                        Tab(
+                            selected = isSelected,
+                            onClick = { viewModel.selectTab(tab) },
+                            // Issue #613 (v1.0 blocker) — Material3's Tab
+                            // applies Role.Tab via its internal clickable on
+                            // 1.2+, but earlier baselines + custom
+                            // SecondaryScrollableTabRow layouts have been
+                            // observed (R5CRB0W66MK semantics dump,
+                            // 2026-05-15) dropping the role on the merged
+                            // node. Belt-and-suspenders an explicit
+                            // `role = Role.Tab` + `selected` here so the
+                            // a11y tree always carries both, regardless of
+                            // Material version. The semantics modifier
+                            // comes BEFORE Tab's internal clickable so the
+                            // role properties get merged in rather than
+                            // overwritten.
+                            modifier = Modifier.semantics {
+                                role = Role.Tab
+                                selected = isSelected
+                            },
+                            text = {
+                                // Issue #383 — Inbox tab carries an unread-count
+                                // badge. BadgedBox positions the badge at the
+                                // top-right of the label without disturbing the
+                                // tab row's alignment. Zero unread = no badge
+                                // (same convention as FollowsScreen #290).
+                                if (tab == LibraryTab.Inbox && state.inboxUnreadCount > 0) {
+                                    BadgedBox(
+                                        badge = {
+                                            Badge(
+                                                containerColor = MaterialTheme.colorScheme.primary,
+                                                contentColor = MaterialTheme.colorScheme.onPrimary,
+                                            ) {
+                                                Text(state.inboxUnreadCount.toString())
+                                            }
+                                        },
+                                    ) {
+                                        Text(
+                                            text = tab.label,
+                                            style = MaterialTheme.typography.labelLarge,
+                                            maxLines = 1,
+                                            softWrap = false,
+                                        )
+                                    }
+                                } else {
                                     Text(
                                         text = tab.label,
                                         style = MaterialTheme.typography.labelLarge,
@@ -378,78 +404,74 @@ fun LibraryScreen(
                                         softWrap = false,
                                     )
                                 }
-                            } else {
-                                Text(
-                                    text = tab.label,
-                                    style = MaterialTheme.typography.labelLarge,
-                                    maxLines = 1,
-                                    softWrap = false,
-                                )
-                            }
-                        },
-                    )
+                            },
+                        )
+                    }
                 }
-            }
 
-            when (state.tab) {
-                LibraryTab.Library -> Column(modifier = Modifier.fillMaxSize().padding(top = spacing.md)) {
-                    // #786 — offline banner above the Library grid. Cached
-                    // covers still render, but tapping a non-downloaded
-                    // fiction needs a network fetch we can't satisfy, so warn
-                    // up-front rather than letting the tap dead-end on a
-                    // timeout. No retry CTA: there's nothing to retry until
-                    // the user taps a cover, and reconnect dismisses it.
-                    if (isOffline) {
-                        OfflineBanner()
-                    }
-                    // Issue #785 — search bar above the chip/sort row. Filters
-                    // the library grid by title or author as the user types
-                    // (debounced at 300ms in the ViewModel). Works in
-                    // combination with the shelf chip filter.
-                    LibrarySearchBar(
-                        query = state.searchQuery,
-                        onQueryChange = viewModel::onSearchQueryChange,
-                        onClear = viewModel::clearSearch,
-                        modifier = Modifier
-                            .fillMaxWidth()
-                            .padding(horizontal = spacing.md),
-                    )
-                    // #116 — chip strip above the grid (and above the
-                    // Resume card) so it's always reachable regardless of
-                    // scroll. #438 collapsed the old `Reading` tab into a
-                    // chip in this row, so this strip is the *only* nested
-                    // navigation surface for shelves now — no more
-                    // duplicate-label tab/chip pair.
-                    //
-                    // #793 — sort dropdown sits trailing in the same row.
-                    // ShelfChipRow takes `weight(1f)` so its horizontal
-                    // scroll can grow into the available width without
-                    // pushing the sort chip off-screen.
-                    Row(
-                        modifier = Modifier.fillMaxWidth(),
-                        verticalAlignment = Alignment.CenterVertically,
-                    ) {
-                        ShelfChipRow(
-                            selected = state.filter,
-                            onSelect = viewModel::selectFilter,
-                            modifier = Modifier.weight(1f),
+                // Issue #1195 — the Library tab's search bar + filter/sort
+                // chips ride in the collapsing header so they scroll away
+                // with the grid. The other sub-tabs (Follows / Inbox /
+                // History) carry no chrome here beyond the tab row above.
+                if (state.tab == LibraryTab.Library) {
+                    Column(modifier = Modifier.padding(top = spacing.md)) {
+                        // #786 — offline banner above the Library grid. Cached
+                        // covers still render, but tapping a non-downloaded
+                        // fiction needs a network fetch we can't satisfy, so warn
+                        // up-front rather than letting the tap dead-end on a
+                        // timeout. No retry CTA: there's nothing to retry until
+                        // the user taps a cover, and reconnect dismisses it.
+                        if (isOffline) {
+                            OfflineBanner()
+                        }
+                        // Issue #785 — search bar above the chip/sort row. Filters
+                        // the library grid by title or author as the user types
+                        // (debounced at 300ms in the ViewModel). Works in
+                        // combination with the shelf chip filter.
+                        LibrarySearchBar(
+                            query = state.searchQuery,
+                            onQueryChange = viewModel::onSearchQueryChange,
+                            onClear = viewModel::clearSearch,
+                            modifier = Modifier
+                                .fillMaxWidth()
+                                .padding(horizontal = spacing.md),
                         )
-                        LibrarySortChip(
-                            selected = state.sortMode,
-                            onSelect = viewModel::selectSortMode,
-                            modifier = Modifier.padding(end = spacing.md),
-                        )
+                        // #116 — chip strip above the grid (and above the
+                        // Resume card) so it's always reachable regardless of
+                        // scroll. #438 collapsed the old `Reading` tab into a
+                        // chip in this row, so this strip is the *only* nested
+                        // navigation surface for shelves now — no more
+                        // duplicate-label tab/chip pair.
+                        //
+                        // #793 — sort dropdown sits trailing in the same row.
+                        // ShelfChipRow takes `weight(1f)` so its horizontal
+                        // scroll can grow into the available width without
+                        // pushing the sort chip off-screen.
+                        Row(
+                            modifier = Modifier.fillMaxWidth(),
+                            verticalAlignment = Alignment.CenterVertically,
+                        ) {
+                            ShelfChipRow(
+                                selected = state.filter,
+                                onSelect = viewModel::selectFilter,
+                                modifier = Modifier.weight(1f),
+                            )
+                            LibrarySortChip(
+                                selected = state.sortMode,
+                                onSelect = viewModel::selectSortMode,
+                                modifier = Modifier.padding(end = spacing.md),
+                            )
+                        }
                     }
-                    // Issue #452 — LazyVerticalGrid inside a Column needs a
-                    // bounded height constraint. Without `weight(1f)`, the
-                    // grid was being measured with `Constraints.Infinity` on
-                    // the inner axis: it survived in portrait because the
-                    // parent Column's natural height happened to bound it,
-                    // but in landscape (or Flip3 unfolded → wider-than-tall)
-                    // the unbounded measurement collapsed the grid to zero
-                    // rows. Wrapping in a Box with `weight(1f)` gives the
-                    // grid a concrete bounded height in both orientations.
-                    Box(modifier = Modifier.weight(1f).fillMaxWidth()) {
+                }
+            },
+            content = {
+                when (state.tab) {
+                    // Issue #452 / #1195 — the grid is the scroll container
+                    // that drives the header collapse; [CollapsingHeader]
+                    // bounds its height, replacing the old `weight(1f)` Box
+                    // wrapper that previously gave the grid a concrete height.
+                    LibraryTab.Library -> Box(modifier = Modifier.fillMaxSize()) {
                         LibraryGridBody(
                             state = state,
                             dedupedFictions = dedupedFictions,
@@ -459,33 +481,33 @@ fun LibraryScreen(
                             onOpenTechEmpower = onOpenTechEmpower,
                         )
                     }
-                }
 
-                // Restructure (v0.5.40) — Follows embedded under Library.
-                LibraryTab.Follows -> Box(modifier = Modifier.fillMaxSize()) {
-                    FollowsScreen(
-                        onOpenFiction = onOpenFiction,
-                        onOpenSignIn = onOpenFollowsSignIn,
-                        embedded = true,
-                    )
-                }
+                    // Restructure (v0.5.40) — Follows embedded under Library.
+                    LibraryTab.Follows -> Box(modifier = Modifier.fillMaxSize()) {
+                        FollowsScreen(
+                            onOpenFiction = onOpenFiction,
+                            onOpenSignIn = onOpenFollowsSignIn,
+                            embedded = true,
+                        )
+                    }
 
-                LibraryTab.Inbox -> Box(modifier = Modifier.fillMaxSize().padding(top = spacing.md)) {
-                    InboxList(
-                        events = state.inbox,
-                        onOpenEvent = viewModel::openInboxEvent,
-                        onMarkAllRead = viewModel::markAllInboxRead,
-                    )
-                }
+                    LibraryTab.Inbox -> Box(modifier = Modifier.fillMaxSize().padding(top = spacing.md)) {
+                        InboxList(
+                            events = state.inbox,
+                            onOpenEvent = viewModel::openInboxEvent,
+                            onMarkAllRead = viewModel::markAllInboxRead,
+                        )
+                    }
 
-                LibraryTab.History -> Box(modifier = Modifier.fillMaxSize().padding(top = spacing.md)) {
-                    HistoryList(
-                        entries = state.history,
-                        onOpenChapter = viewModel::openHistoryEntry,
-                    )
+                    LibraryTab.History -> Box(modifier = Modifier.fillMaxSize().padding(top = spacing.md)) {
+                        HistoryList(
+                            entries = state.history,
+                            onOpenChapter = viewModel::openHistoryEntry,
+                        )
+                    }
                 }
-            }
-        }
+            },
+        )
     }
 
     AddByUrlSheet(
@@ -928,15 +950,21 @@ private fun ContinueListeningEntry.progressFraction(): Float? {
 }
 
 /**
- * Issue #452 — structural marker for [LibraryGridLandscapeTest]. Set
- * to `true` when `LibraryGridBody` is wrapped in a
- * `Box(Modifier.weight(1f).fillMaxWidth())` inside its parent Column.
- * The regressed pre-#452 shape placed `LazyVerticalGrid` directly as a
- * Column child without a weight wrapper; in landscape orientation
- * (incl. Z Flip3 unfolded) the grid measured to zero height and the
- * library appeared empty even though the books were in the database.
+ * Issue #452 — structural marker for [LibraryGridLandscapeTest]. Set to
+ * `true` while `LibraryGridBody` is given a concrete, bounded inner-axis
+ * height so its `LazyVerticalGrid` can never be measured with an unbounded
+ * height. The regressed pre-#452 shape placed `LazyVerticalGrid` directly
+ * as a `Column(fillMaxSize)` child without a bounded wrapper; in landscape
+ * orientation (incl. Z Flip3 unfolded) the grid measured to zero height
+ * and the library appeared empty even though the books were in the database.
+ *
+ * #452 originally fixed this with a `Box(Modifier.weight(1f))` wrapper.
+ * #1195 moved the grid into [CollapsingHeader]'s content slot, which
+ * measures it with `maxHeight = viewport - visibleHeader` — still a
+ * concrete bounded height, so the guarantee holds. Flip to `false` only if
+ * a refactor lets the grid be measured unbounded again.
  */
-internal const val libraryGridIsWeightBounded: Boolean = true
+internal const val libraryGridIsHeightBounded: Boolean = true
 
 /**
  * Issue #452 — pinned value of the `GridCells.Adaptive` `minSize` (in

--- a/feature/src/main/kotlin/in/jphe/storyvox/feature/voicelibrary/VoiceLibraryScreen.kt
+++ b/feature/src/main/kotlin/in/jphe/storyvox/feature/voicelibrary/VoiceLibraryScreen.kt
@@ -106,7 +106,11 @@ import androidx.compose.animation.core.animateFloatAsState
 import androidx.compose.animation.core.tween
 import androidx.compose.ui.draw.rotate
 import `in`.jphe.storyvox.ui.theme.LocalSpacing
+import androidx.compose.material3.ExperimentalMaterial3Api
 
+// Issue #1195 — MagicTitleBar's signature now carries an (optional,
+// experimental) TopAppBarScrollBehavior, so every call site opts in.
+@OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun VoiceLibraryScreen(
     viewModel: VoiceLibraryViewModel = hiltViewModel(),

--- a/feature/src/test/kotlin/in/jphe/storyvox/feature/library/LibraryGridLandscapeTest.kt
+++ b/feature/src/test/kotlin/in/jphe/storyvox/feature/library/LibraryGridLandscapeTest.kt
@@ -12,9 +12,11 @@ import org.junit.Test
  * wider-than-tall state) the unbounded measurement collapsed the grid
  * to zero rows and the user's books became invisible.
  *
- * Fix: wrap `LibraryGridBody` in `Box(Modifier.weight(1f).fillMaxWidth())`
- * inside the parent Column so the grid always has a concrete bounded
- * inner-axis constraint.
+ * Fix: give `LibraryGridBody` a concrete bounded inner-axis height.
+ * #452 did this with a `Box(Modifier.weight(1f).fillMaxWidth())` wrapper;
+ * #1195 moved the grid into `CollapsingHeader`'s content slot, which
+ * measures it with `maxHeight = viewport - visibleHeader`. Either way the
+ * grid is never measured unbounded.
  *
  * The grid also uses `GridCells.Adaptive(minSize = 140.dp)`, which
  * remains the right choice in both orientations: at 140dp minimum the
@@ -46,15 +48,17 @@ class LibraryGridLandscapeTest {
     }
 
     @Test
-    fun `LibraryGridBody is wrapped in a weight-bounded Box per issue #452`() {
-        // Structural canary — see the marker constant in
-        // LibraryScreen. If a future refactor drops the Box wrapper
-        // and goes back to the regressed shape (LazyVerticalGrid as
-        // direct Column child), the canary flips false and this fails
-        // before the user-facing landscape regression returns.
+    fun `LibraryGridBody has a bounded inner-axis height per issue #452`() {
+        // Structural canary — see the marker constant in LibraryScreen.
+        // If a future refactor lets the grid be measured unbounded again
+        // (the regressed shape: LazyVerticalGrid as a direct
+        // Column(fillMaxSize) child), the canary flips false and this
+        // fails before the user-facing landscape regression returns.
+        // #1195 — the bound now comes from CollapsingHeader's content slot
+        // rather than a weight(1f) Box, but the guarantee is the same.
         assertTrue(
-            "LibraryGridBody must be wrapped in a weight(1f)/fillMaxWidth Box (issue #452)",
-            libraryGridIsWeightBounded,
+            "LibraryGridBody must be measured with a concrete bounded height (issue #452 / #1195)",
+            libraryGridIsHeightBounded,
         )
     }
 


### PR DESCRIPTION
## What & why

Issue #1195 — the fixed header chrome on **Library** and **Browse** (top bar, sub-tabs, search bar, filter chips, source carousel) consumed a large slice of the viewport on small phones before any content was visible. This makes that chrome **scroll away** as the list is scrolled down, and return on scroll-up.

## Approach

Two cascading nested-scroll mechanisms:

1. **Top app bar** — `MagicTitleBar` gains an optional `scrollBehavior`; the screens pass `TopAppBarDefaults.enterAlwaysScrollBehavior()` and wire `Modifier.nestedScroll(...)` on their `Scaffold`. Battle-tested Material3 path.
2. **Secondary chrome** — new `CollapsingHeader` (core-ui): a small `Layout` + `NestedScrollConnection` that translates a header region off the top as its content scrolls, and **reflows** the content (shrinks its `maxHeight` constraint — a real relayout, so the list's scroll range stays correct) to fill the freed space.

The two connections cascade because `onPreScroll` runs outer→inner: the bar consumes scroll first (until fully hidden), then the chrome, then the list. `clipToBounds` keeps the header from overdrawing as it translates up.

### Library
Sub-tab row + search bar + shelf/sort chips ride the `CollapsingHeader`; the grid drives the collapse. Tab switching (Library/Follows/Inbox/History) unchanged; `resetKey = state.tab` re-expands the chrome on each switch.

### Browse
Source carousel + tab row + filter funnel ride the `CollapsingHeader`. The header stays **composed in every content state** (loading / empty / error / grid), so source + tab switching keeps working even when the current listing is empty or errored. Pull-to-refresh and near-end pagination are untouched (they live inside the content lambda). `resetKey` re-expands on source/tab/query/filter change, matching the grid's existing scroll-to-top reset.

## #452 regression canary updated
Moving the grid into `CollapsingHeader`'s content slot replaces the old `Box(Modifier.weight(1f))` wrapper that gave the grid a concrete bounded height (the #452 landscape fix). The grid is still measured with a finite `maxHeight = viewport − visibleHeader`, so the guarantee holds — I renamed the structural canary `libraryGridIsWeightBounded` → `libraryGridIsHeightBounded` and updated `LibraryGridLandscapeTest` + docs to describe the new bounding mechanism. Canary stays `true`.

## Note — opt-in ripple (mechanical)
`MagicTitleBar`'s signature now carries an experimental `TopAppBarScrollBehavior`, so its callers must opt into `ExperimentalMaterial3Api`. Most already did; **VoiceLibraryScreen** and the two **MagicTitleBar previews** were updated. No behavior change for those surfaces.

## Testing
- `./gradlew :feature:compileDebugKotlin` → **BUILD SUCCESSFUL** (compiled locally once before the no-local-gradle rule took effect; CI on familiar is the gate). Only pre-existing deprecation warnings.
- `LibraryGridLandscapeTest` / `MagicTitleBarSemanticsTest` canaries kept green (verified by inspection).
- No new unit tests — layout/scroll-behavior change with no JVM-testable logic (no Robolectric here); best verified on-device by scrolling Library & Browse.

## Files
- `core-ui/.../CollapsingHeader.kt` (new)
- `core-ui/.../MagicTitleBar.kt` (+ optional `scrollBehavior`)
- `feature/.../library/LibraryScreen.kt`
- `feature/.../browse/BrowseScreen.kt`
- `feature/.../voicelibrary/VoiceLibraryScreen.kt` (opt-in)
- `feature/src/test/.../library/LibraryGridLandscapeTest.kt` (#452 canary rename)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
