### PR TITLE
fix(sources): centralize User-Agent across 13 remaining sources (#1204)

### DIFF
--- a/app/src/main/kotlin/in/jphe/storyvox/di/AppBindings.kt
+++ b/app/src/main/kotlin/in/jphe/storyvox/di/AppBindings.kt
@@ -9,7 +9,10 @@ import dagger.Provides
 import dagger.hilt.InstallIn
 import dagger.hilt.android.qualifiers.ApplicationContext
 import dagger.hilt.components.SingletonComponent
+import `in`.jphe.storyvox.BuildConfig
 import `in`.jphe.storyvox.data.PalaceConfigImpl
+import `in`.jphe.storyvox.data.network.UserAgent
+import `in`.jphe.storyvox.data.network.UserAgentHeader
 import `in`.jphe.storyvox.data.SettingsRepositoryUiImpl
 import `in`.jphe.storyvox.data.VoiceProviderUiImpl
 import `in`.jphe.storyvox.source.mempalace.config.PalaceConfig
@@ -73,6 +76,7 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.launch
+import okhttp3.Interceptor
 
 /**
  * Hilt bindings that bridge `feature.api.*` UI contracts to the concrete
@@ -487,6 +491,35 @@ object AppBindings {
                 }
             }
         }
+
+    /**
+     * Issue #1141 — descriptive User-Agent interceptor, shared across the
+     * source modules whose upstreams require/request an identifying UA
+     * (Wikipedia, Wikisource, arXiv, Radio Browser). Built from the live
+     * build's [BuildConfig.VERSION_NAME] so the version never drifts out
+     * of sync with the app — see [UserAgent] for the policy rationale and
+     * the canonical string shape.
+     *
+     * Lives in `:app` because only the app module carries
+     * `BuildConfig.VERSION_NAME`; the per-source DI modules inject this
+     * [UserAgentHeader]-qualified interceptor into their dedicated
+     * OkHttpClient builders. It does not clobber a request that already
+     * set its own `User-Agent`, leaving room for a source to override if
+     * a future upstream needs a bespoke token.
+     */
+    @Provides @Singleton @UserAgentHeader
+    fun provideUserAgentInterceptor(): Interceptor {
+        val header = UserAgent.format(BuildConfig.VERSION_NAME)
+        return Interceptor { chain ->
+            val request = chain.request()
+            val withUserAgent = if (request.header("User-Agent") == null) {
+                request.newBuilder().header("User-Agent", header).build()
+            } else {
+                request
+            }
+            chain.proceed(withUserAgent)
+        }
+    }
 
     /**
      * Stub WebViewFetcher — Selene's `:core-data` declares the interface; the

--- a/core-data/src/main/kotlin/in/jphe/storyvox/data/network/UserAgent.kt
+++ b/core-data/src/main/kotlin/in/jphe/storyvox/data/network/UserAgent.kt
@@ -1,0 +1,70 @@
+package `in`.jphe.storyvox.data.network
+
+import javax.inject.Qualifier
+
+/**
+ * Issue #1141 — single source of truth for Candela's descriptive
+ * User-Agent string.
+ *
+ * Several upstream APIs require or explicitly request an identifying
+ * User-Agent that names the app + version + a contact channel:
+ *
+ *  - **Wikimedia** (Wikipedia + Wikisource) *requires* it — the REST /
+ *    Action API 403s anonymous traffic without a descriptive UA per
+ *    https://meta.wikimedia.org/wiki/User-Agent_policy.
+ *  - **arXiv** asks automated clients to identify themselves
+ *    (https://info.arxiv.org/help/robots.html).
+ *  - **Radio Browser** asks callers to identify themselves in the UA so
+ *    abusive clients can be contacted directly.
+ *
+ * Before #1141 each source baked its own stale `storyvox-*` string mixing
+ * pre-rebrand identities (`jphein/storyvox`, `jp@jphein.com`) with
+ * hand-maintained version numbers that drifted out of sync with the app's
+ * real version. Centralising the pieces here — and building the final
+ * header from the live build's version — means the rebrand or a version
+ * bump is a one-line change and every source stays consistent.
+ *
+ * The header is applied per-OkHttpClient via the [UserAgentHeader]-qualified
+ * `okhttp3.Interceptor` provided in `:app` (where `BuildConfig.VERSION_NAME`
+ * is available); see `AppBindings.provideUserAgentInterceptor`. Keeping the
+ * builder okhttp-free lets this foundational module stay dependency-light —
+ * only the `:app` provider and the per-source DI modules touch OkHttp.
+ */
+object UserAgent {
+    /** Product token — the rebranded app name. */
+    const val APP_NAME: String = "Candela"
+
+    /** Contact URL embedded in the UA so an upstream operator can reach
+     *  the project. The app's public microsite. */
+    const val CONTACT_URL: String = "https://candela.techempower.org"
+
+    /** Contact email embedded in the UA — reaches the maintainers. */
+    const val CONTACT_EMAIL: String = "support@techempower.org"
+
+    /** Platform token. */
+    const val PLATFORM: String = "Android"
+
+    /**
+     * Build the canonical descriptive User-Agent for a given app
+     * [version], e.g. `Candela/1.1.6 (https://candela.techempower.org;
+     * support@techempower.org) Android`.
+     *
+     * The shape — `product/version` followed by a parenthetical comment
+     * carrying the contact URL + email — is the form Wikimedia's
+     * User-Agent policy documents and the one arXiv / Radio Browser
+     * expect for identifiable automated traffic.
+     */
+    fun format(version: String): String =
+        "$APP_NAME/$version ($CONTACT_URL; $CONTACT_EMAIL) $PLATFORM"
+}
+
+/**
+ * Qualifies the descriptive-User-Agent `okhttp3.Interceptor` provided in
+ * `:app` (it needs `BuildConfig.VERSION_NAME`, which only the app module
+ * carries). Source modules inject the qualified interceptor into their
+ * dedicated OkHttpClient builders so every outbound request identifies the
+ * app + version + contact — see issue #1141 and [UserAgent].
+ */
+@Qualifier
+@Retention(AnnotationRetention.BINARY)
+annotation class UserAgentHeader

--- a/source-ao3/src/main/kotlin/in/jphe/storyvox/source/ao3/net/Ao3Api.kt
+++ b/source-ao3/src/main/kotlin/in/jphe/storyvox/source/ao3/net/Ao3Api.kt
@@ -1,5 +1,6 @@
 package `in`.jphe.storyvox.source.ao3.net
 
+import `in`.jphe.storyvox.data.network.UserAgent
 import `in`.jphe.storyvox.data.source.model.FictionResult
 import `in`.jphe.storyvox.data.source.model.FictionSummary
 import `in`.jphe.storyvox.data.source.model.ListPage
@@ -417,7 +418,21 @@ internal class Ao3Api @Inject constructor(
             return "/works/search?$qs"
         }
 
-        const val USER_AGENT = "storyvox-ao3/1.0 (+https://github.com/jphein/storyvox)"
+        /**
+         * #1204 — AO3 identity used by the anonymous + authed OkHttp clients
+         * AND the login WebView's `userAgentString` (see Ao3AuthWebView /
+         * Ao3HttpModule). Built from the centralized [UserAgent] tokens so the
+         * rebrand + contact info live in one place; versionless because a
+         * WebView can't read `BuildConfig.VERSION_NAME` from a source module.
+         * Replaces the stale pre-rebrand `storyvox-ao3/jphein` string.
+         *
+         * AO3 keeps this explicit constant rather than the shared
+         * `@UserAgentHeader` interceptor because the WebView path needs a
+         * literal string, and OTW Ops asks for ONE identity across a client's
+         * traffic — so the OkHttp calls and the WebView advertise the same UA.
+         */
+        val USER_AGENT: String =
+            "${UserAgent.APP_NAME} (${UserAgent.CONTACT_URL}; ${UserAgent.CONTACT_EMAIL}) ${UserAgent.PLATFORM}"
 
         /**
          * Cheap signal that AO3 returned the login form instead of

--- a/source-arxiv/src/main/kotlin/in/jphe/storyvox/source/arxiv/di/ArxivModule.kt
+++ b/source-arxiv/src/main/kotlin/in/jphe/storyvox/source/arxiv/di/ArxivModule.kt
@@ -7,9 +7,11 @@ import dagger.hilt.InstallIn
 import dagger.hilt.components.SingletonComponent
 import dagger.multibindings.IntoMap
 import dagger.multibindings.StringKey
+import `in`.jphe.storyvox.data.network.UserAgentHeader
 import `in`.jphe.storyvox.data.source.FictionSource
 import `in`.jphe.storyvox.data.source.SourceIds
 import `in`.jphe.storyvox.source.arxiv.ArxivSource
+import okhttp3.Interceptor
 import okhttp3.OkHttpClient
 import javax.inject.Qualifier
 import javax.inject.Singleton
@@ -36,7 +38,9 @@ internal object ArxivHttpModule {
     @Provides
     @Singleton
     @ArxivHttp
-    fun provideClient(): OkHttpClient =
+    fun provideClient(
+        @UserAgentHeader userAgent: Interceptor,
+    ): OkHttpClient =
         OkHttpClient.Builder()
             .connectTimeout(5, TimeUnit.SECONDS)
             .readTimeout(30, TimeUnit.SECONDS)
@@ -44,6 +48,9 @@ internal object ArxivHttpModule {
             .followRedirects(true)
             .followSslRedirects(true)
             .retryOnConnectionFailure(true)
+            // #1141 — arXiv asks automated clients to identify themselves
+            // (https://info.arxiv.org/help/robots.html).
+            .addInterceptor(userAgent)
             .build()
 
     @Provides

--- a/source-arxiv/src/main/kotlin/in/jphe/storyvox/source/arxiv/net/ArxivApi.kt
+++ b/source-arxiv/src/main/kotlin/in/jphe/storyvox/source/arxiv/net/ArxivApi.kt
@@ -131,10 +131,14 @@ internal class ArxivApi @Inject constructor(
     private suspend fun getRaw(url: String): FictionResult<String> =
         withContext(Dispatchers.IO) {
             try {
+                // #1141 — the identifying `User-Agent` arXiv asks
+                // automated clients to send is applied for every request
+                // by the shared UserAgentHeader interceptor on the
+                // injected client; see
+                // `in.jphe.storyvox.data.network.UserAgent`.
                 val req = Request.Builder()
                     .url(url)
                     .header("Accept", "application/atom+xml, text/html;q=0.9, */*;q=0.5")
-                    .header("User-Agent", USER_AGENT)
                     .get()
                     .build()
                 client.newCall(req).execute().use { resp ->
@@ -192,11 +196,6 @@ internal class ArxivApi @Inject constructor(
 
         /** Per-paper abstract page host. */
         const val ABS_BASE: String = "https://arxiv.org/abs"
-
-        /** arXiv requests an identifying User-Agent on automated traffic
-         *  (see https://info.arxiv.org/help/robots.html). */
-        const val USER_AGENT: String =
-            "storyvox-arxiv/1.0 (https://github.com/techempower-org/candela; jp@jphein.com)"
     }
 }
 

--- a/source-discord/src/main/kotlin/in/jphe/storyvox/source/discord/config/DiscordDefaults.kt
+++ b/source-discord/src/main/kotlin/in/jphe/storyvox/source/discord/config/DiscordDefaults.kt
@@ -46,8 +46,7 @@ object DiscordDefaults {
     /** User-Agent header per Discord's API guidelines — should
      *  identify storyvox and the version so Discord's abuse team can
      *  reach out before banning a misbehaving bot. */
-    const val USER_AGENT: String =
-        "Storyvox-Discord/1.0 (+https://github.com/techempower-org/candela)"
+    // #1204 — UA applied via the shared @UserAgentHeader interceptor (UserAgent.kt).
 
     /**
      * Issue #517 — Discord channel id for the TechEmpower peer-support

--- a/source-discord/src/main/kotlin/in/jphe/storyvox/source/discord/di/DiscordModule.kt
+++ b/source-discord/src/main/kotlin/in/jphe/storyvox/source/discord/di/DiscordModule.kt
@@ -8,8 +8,10 @@ import dagger.hilt.components.SingletonComponent
 import dagger.multibindings.IntoMap
 import dagger.multibindings.StringKey
 import `in`.jphe.storyvox.data.source.FictionSource
+import `in`.jphe.storyvox.data.network.UserAgentHeader
 import `in`.jphe.storyvox.data.source.SourceIds
 import `in`.jphe.storyvox.source.discord.DiscordSource
+import okhttp3.Interceptor
 import okhttp3.OkHttpClient
 import javax.inject.Qualifier
 import javax.inject.Singleton
@@ -36,7 +38,9 @@ internal object DiscordHttpModule {
     @Provides
     @Singleton
     @DiscordHttp
-    fun provideClient(): OkHttpClient =
+    fun provideClient(
+        @UserAgentHeader userAgent: Interceptor,
+    ): OkHttpClient =
         OkHttpClient.Builder()
             .connectTimeout(5, TimeUnit.SECONDS)
             .readTimeout(30, TimeUnit.SECONDS)
@@ -44,6 +48,9 @@ internal object DiscordHttpModule {
             .followRedirects(true)
             .followSslRedirects(true)
             .retryOnConnectionFailure(true)
+            // #1204 — shared descriptive UA on every request
+            // (see in.jphe.storyvox.data.network.UserAgent).
+            .addInterceptor(userAgent)
             .build()
 
     @Provides

--- a/source-discord/src/main/kotlin/in/jphe/storyvox/source/discord/net/DiscordApi.kt
+++ b/source-discord/src/main/kotlin/in/jphe/storyvox/source/discord/net/DiscordApi.kt
@@ -166,7 +166,6 @@ internal class DiscordApi @Inject constructor(
                 // single most common bot-onboarding mistake.
                 .header("Authorization", "Bot ${state.apiToken}")
                 .header("Accept", "application/json")
-                .header("User-Agent", DiscordDefaults.USER_AGENT)
                 .get()
                 .build()
             client.newCall(request).execute().use { resp ->

--- a/source-github/src/main/kotlin/in/jphe/storyvox/source/github/auth/DeviceFlowApi.kt
+++ b/source-github/src/main/kotlin/in/jphe/storyvox/source/github/auth/DeviceFlowApi.kt
@@ -77,7 +77,6 @@ open class DeviceFlowApi @Inject constructor(
             .url(deviceCodeUrl)
             .post(body)
             .header("Accept", "application/json")
-            .header("User-Agent", USER_AGENT)
             .build()
         val response = try {
             httpClient.newCall(req).await()
@@ -138,7 +137,6 @@ open class DeviceFlowApi @Inject constructor(
             .url(accessTokenUrl)
             .post(body)
             .header("Accept", "application/json")
-            .header("User-Agent", USER_AGENT)
             .build()
         val response = try {
             httpClient.newCall(req).await()
@@ -207,7 +205,7 @@ open class DeviceFlowApi @Inject constructor(
 
     companion object {
         const val DEVICE_CODE_GRANT: String = "urn:ietf:params:oauth:grant-type:device_code"
-        const val USER_AGENT: String = "storyvox/0.4 (+https://github.com/jphein/storyvox)"
+        // #1204 — UA applied via the shared @UserAgentHeader interceptor (UserAgent.kt).
         // ignoreUnknownKeys: GitHub freely adds new fields; don't break on them.
         // explicitNulls = false: keeps the wire format permissive on optional values.
         private val JSON: Json = Json {

--- a/source-github/src/main/kotlin/in/jphe/storyvox/source/github/auth/GitHubProfileService.kt
+++ b/source-github/src/main/kotlin/in/jphe/storyvox/source/github/auth/GitHubProfileService.kt
@@ -50,7 +50,6 @@ open class GitHubProfileService @Inject constructor(
             .url(USER_URL)
             .header("Accept", "application/vnd.github+json")
             .header("X-GitHub-Api-Version", API_VERSION)
-            .header("User-Agent", USER_AGENT)
             .build()
         val response = try {
             httpClient.newCall(req).await()
@@ -81,7 +80,7 @@ open class GitHubProfileService @Inject constructor(
     private companion object {
         const val USER_URL: String = "https://api.github.com/user"
         const val API_VERSION: String = "2022-11-28"
-        const val USER_AGENT: String = "storyvox/0.4 (+https://github.com/jphein/storyvox)"
+        // #1204 — UA applied via the shared @UserAgentHeader interceptor (UserAgent.kt).
         val JSON: Json = Json {
             ignoreUnknownKeys = true
             explicitNulls = false

--- a/source-github/src/main/kotlin/in/jphe/storyvox/source/github/di/GitHubModule.kt
+++ b/source-github/src/main/kotlin/in/jphe/storyvox/source/github/di/GitHubModule.kt
@@ -8,6 +8,7 @@ import dagger.hilt.components.SingletonComponent
 import dagger.multibindings.IntoMap
 import dagger.multibindings.StringKey
 import `in`.jphe.storyvox.data.source.FictionSource
+import `in`.jphe.storyvox.data.network.UserAgentHeader
 import `in`.jphe.storyvox.data.source.SourceIds
 import `in`.jphe.storyvox.source.github.GitHubAuthedSource
 import `in`.jphe.storyvox.source.github.GitHubSource
@@ -15,6 +16,7 @@ import `in`.jphe.storyvox.source.github.auth.DeviceFlowApi
 import `in`.jphe.storyvox.source.github.auth.GitHubAuthInterceptor
 import `in`.jphe.storyvox.source.github.auth.GitHubAuthRepository
 import `in`.jphe.storyvox.source.github.auth.GitHubAuthRepositoryImpl
+import okhttp3.Interceptor
 import okhttp3.OkHttpClient
 import javax.inject.Qualifier
 import javax.inject.Singleton
@@ -51,12 +53,18 @@ internal object GitHubHttpModule {
     @Provides
     @Singleton
     @GitHubHttp
-    fun provideClient(authInterceptor: GitHubAuthInterceptor): OkHttpClient =
+    fun provideClient(
+        authInterceptor: GitHubAuthInterceptor,
+        @UserAgentHeader userAgent: Interceptor,
+    ): OkHttpClient =
         OkHttpClient.Builder()
             .addInterceptor(authInterceptor)
             .followRedirects(true)
             .followSslRedirects(true)
             .retryOnConnectionFailure(true)
+            // #1204 — shared descriptive UA on every request
+            // (see in.jphe.storyvox.data.network.UserAgent).
+            .addInterceptor(userAgent)
             .build()
 
     /**
@@ -68,11 +76,16 @@ internal object GitHubHttpModule {
     @Provides
     @Singleton
     @GitHubDeviceFlowHttp
-    fun provideDeviceFlowClient(): OkHttpClient =
+    fun provideDeviceFlowClient(
+        @UserAgentHeader userAgent: Interceptor,
+    ): OkHttpClient =
         OkHttpClient.Builder()
             .followRedirects(true)
             .followSslRedirects(true)
             .retryOnConnectionFailure(true)
+            // #1204 — shared descriptive UA on every request
+            // (see in.jphe.storyvox.data.network.UserAgent).
+            .addInterceptor(userAgent)
             .build()
 
     /**

--- a/source-github/src/main/kotlin/in/jphe/storyvox/source/github/net/GitHubApi.kt
+++ b/source-github/src/main/kotlin/in/jphe/storyvox/source/github/net/GitHubApi.kt
@@ -259,7 +259,6 @@ internal open class GitHubApi @Inject constructor(
                 .url(url)
                 .header("Accept", "application/vnd.github+json")
                 .header("X-GitHub-Api-Version", API_VERSION)
-                .header("User-Agent", USER_AGENT)
                 .build()
             val response = try {
                 httpClient.newCall(req).await()
@@ -303,7 +302,7 @@ internal open class GitHubApi @Inject constructor(
         // Generic UA — GitHub requires *something* in User-Agent for
         // unauthenticated REST calls. App version travels in BuildConfig
         // when we need it; for now identifying as the project is enough.
-        const val USER_AGENT: String = "storyvox/0.4 (+https://github.com/jphein/storyvox)"
+        // #1204 — UA applied via the shared @UserAgentHeader interceptor (UserAgent.kt).
     }
 }
 

--- a/source-github/src/main/kotlin/in/jphe/storyvox/source/github/registry/Registry.kt
+++ b/source-github/src/main/kotlin/in/jphe/storyvox/source/github/registry/Registry.kt
@@ -83,7 +83,6 @@ internal open class Registry @Inject constructor(
         val req = Request.Builder()
             .url(REGISTRY_URL)
             .header("Accept", "application/json")
-            .header("User-Agent", USER_AGENT)
             .build()
         val response = try {
             httpClient.newCall(req).await()
@@ -118,8 +117,7 @@ internal open class Registry @Inject constructor(
     companion object {
         const val REGISTRY_URL: String =
             "https://raw.githubusercontent.com/techempower-org/candela-registry/main/registry.json"
-        const val USER_AGENT: String =
-            "storyvox/0.5 (+https://github.com/techempower-org/candela)"
+        // #1204 — UA applied via the shared @UserAgentHeader interceptor (UserAgent.kt).
     }
 }
 

--- a/source-gutenberg/src/main/kotlin/in/jphe/storyvox/source/gutenberg/GutenbergSource.kt
+++ b/source-gutenberg/src/main/kotlin/in/jphe/storyvox/source/gutenberg/GutenbergSource.kt
@@ -52,9 +52,10 @@ import javax.inject.Singleton
  * programmatic access (their [robot
  * policy](https://www.gutenberg.org/policy/robot_access.html) is "be
  * polite, identify yourself, throttle"). Gutendex sits between us
- * and PG specifically to absorb catalog traffic; we send a
- * `storyvox-gutenberg/1.0` User-Agent so any rate-limit hits can be
- * routed to a real contact.
+ * and PG specifically to absorb catalog traffic; we send the shared
+ * descriptive User-Agent (app + version + contact, see
+ * `in.jphe.storyvox.data.network.UserAgent`) so any rate-limit hits can
+ * be routed to a real contact.
  */
 @SourcePlugin(
     id = SourceIds.GUTENBERG,

--- a/source-gutenberg/src/main/kotlin/in/jphe/storyvox/source/gutenberg/di/GutenbergModule.kt
+++ b/source-gutenberg/src/main/kotlin/in/jphe/storyvox/source/gutenberg/di/GutenbergModule.kt
@@ -9,10 +9,12 @@ import dagger.hilt.android.qualifiers.ApplicationContext
 import dagger.hilt.components.SingletonComponent
 import dagger.multibindings.IntoMap
 import dagger.multibindings.StringKey
+import `in`.jphe.storyvox.data.network.UserAgentHeader
 import `in`.jphe.storyvox.data.source.FictionSource
 import `in`.jphe.storyvox.data.source.SourceIds
 import `in`.jphe.storyvox.source.gutenberg.GutenbergSource
 import `in`.jphe.storyvox.source.gutenberg.net.GutendexApi
+import okhttp3.Interceptor
 import okhttp3.OkHttpClient
 import java.io.File
 import java.util.concurrent.TimeUnit
@@ -46,7 +48,9 @@ internal object GutenbergHttpModule {
     @Provides
     @Singleton
     @GutenbergHttp
-    fun provideClient(): OkHttpClient =
+    fun provideClient(
+        @UserAgentHeader userAgent: Interceptor,
+    ): OkHttpClient =
         OkHttpClient.Builder()
             .connectTimeout(10, TimeUnit.SECONDS)
             // EPUB downloads dominate the read budget — give them
@@ -56,6 +60,10 @@ internal object GutenbergHttpModule {
             .followRedirects(true)
             .followSslRedirects(true)
             .retryOnConnectionFailure(true)
+            // #1204 — PG's robot policy asks clients to identify themselves;
+            // apply the shared descriptive UA on every request (see
+            // in.jphe.storyvox.data.network.UserAgent).
+            .addInterceptor(userAgent)
             .build()
 
     @Provides

--- a/source-gutenberg/src/main/kotlin/in/jphe/storyvox/source/gutenberg/net/GutendexApi.kt
+++ b/source-gutenberg/src/main/kotlin/in/jphe/storyvox/source/gutenberg/net/GutendexApi.kt
@@ -120,7 +120,6 @@ internal class GutendexApi @Inject constructor(
             val req = Request.Builder()
                 .url(url)
                 .header("Accept", "application/json")
-                .header("User-Agent", USER_AGENT)
                 .get()
                 .build()
             client.newCall(req).execute().use { resp ->
@@ -154,7 +153,6 @@ internal class GutendexApi @Inject constructor(
         try {
             val req = Request.Builder()
                 .url(url)
-                .header("User-Agent", USER_AGENT)
                 .header("Accept", "application/epub+zip")
                 .get()
                 .build()
@@ -183,12 +181,10 @@ internal class GutendexApi @Inject constructor(
     companion object {
         const val BASE_URL = "https://gutendex.com"
 
-        /**
-         * Identifies storyvox in the User-Agent per PG's robot policy
-         * — the contact URL gives operators a way to reach us if our
-         * traffic ever looks misbehaved.
-         */
-        const val USER_AGENT = "storyvox-gutenberg/1.0 (+https://github.com/jphein/storyvox)"
+        // #1204 — the per-request User-Agent is applied for every call by the
+        // shared @UserAgentHeader interceptor on the injected client; see
+        // in.jphe.storyvox.data.network.UserAgent. (Removed the stale
+        // storyvox-gutenberg/jphein UA constant.)
 
         /**
          * Build the `/books` query string with whichever params are

--- a/source-hackernews/src/main/kotlin/in/jphe/storyvox/source/hackernews/di/HackerNewsModule.kt
+++ b/source-hackernews/src/main/kotlin/in/jphe/storyvox/source/hackernews/di/HackerNewsModule.kt
@@ -7,10 +7,12 @@ import dagger.hilt.InstallIn
 import dagger.hilt.components.SingletonComponent
 import dagger.multibindings.IntoMap
 import dagger.multibindings.StringKey
+import `in`.jphe.storyvox.data.network.UserAgentHeader
 import `in`.jphe.storyvox.data.source.FictionSource
 import `in`.jphe.storyvox.data.source.SourceIds
 import `in`.jphe.storyvox.source.hackernews.HackerNewsSource
 import `in`.jphe.storyvox.source.hackernews.net.HackerNewsApi
+import okhttp3.Interceptor
 import okhttp3.OkHttpClient
 import java.util.concurrent.TimeUnit
 import javax.inject.Qualifier
@@ -33,13 +35,18 @@ internal object HackerNewsHttpModule {
     @Provides
     @Singleton
     @HackerNewsHttp
-    fun provideClient(): OkHttpClient =
+    fun provideClient(
+        @UserAgentHeader userAgent: Interceptor,
+    ): OkHttpClient =
         OkHttpClient.Builder()
             .connectTimeout(10, TimeUnit.SECONDS)
             .readTimeout(15, TimeUnit.SECONDS)
             .writeTimeout(10, TimeUnit.SECONDS)
             .followRedirects(true)
             .retryOnConnectionFailure(true)
+            // #1204 — shared descriptive UA on every request (see
+            // in.jphe.storyvox.data.network.UserAgent).
+            .addInterceptor(userAgent)
             .build()
 
     @Provides

--- a/source-hackernews/src/main/kotlin/in/jphe/storyvox/source/hackernews/net/HackerNewsApi.kt
+++ b/source-hackernews/src/main/kotlin/in/jphe/storyvox/source/hackernews/net/HackerNewsApi.kt
@@ -75,7 +75,6 @@ internal open class HackerNewsApi @Inject constructor(
             val req = Request.Builder()
                 .url(url)
                 .header("Accept", "application/json")
-                .header("User-Agent", USER_AGENT)
                 .get()
                 .build()
             client.newCall(req).execute().use { resp ->
@@ -116,7 +115,6 @@ internal open class HackerNewsApi @Inject constructor(
                 val req = Request.Builder()
                     .url(url)
                     .header("Accept", "application/json")
-                    .header("User-Agent", USER_AGENT)
                     .get()
                     .build()
                 client.newCall(req).execute().use { resp ->
@@ -141,7 +139,6 @@ internal open class HackerNewsApi @Inject constructor(
                 val req = Request.Builder()
                     .url(url)
                     .header("Accept", "application/json")
-                    .header("User-Agent", USER_AGENT)
                     .get()
                     .build()
                 client.newCall(req).execute().use { resp ->
@@ -187,9 +184,9 @@ internal open class HackerNewsApi @Inject constructor(
         const val FIREBASE_BASE = "https://hacker-news.firebaseio.com"
         const val ALGOLIA_BASE = "https://hn.algolia.com/api/v1"
 
-        /** Polite identifier — gives any future rate-limit hits a contact
-         *  point. Matches the pattern used by `:source-gutenberg`. */
-        const val USER_AGENT = "storyvox-hackernews/1.0 (+https://github.com/techempower-org/candela)"
+        // #1204 — the per-request User-Agent is applied for every call by the
+        // shared @UserAgentHeader interceptor on the injected client; see
+        // in.jphe.storyvox.data.network.UserAgent.
 
         /** Browse landing fetches the first 50 of ~500 top-story ids
          *  per #379's spec. Defined here so the source and tests share

--- a/source-librivox/src/main/kotlin/in/jphe/storyvox/source/librivox/LibriVoxSource.kt
+++ b/source-librivox/src/main/kotlin/in/jphe/storyvox/source/librivox/LibriVoxSource.kt
@@ -474,8 +474,7 @@ internal class LibriVoxSource @Inject constructor(
          */
         internal fun bookIdFromFictionId(fictionId: String): String = fictionId.trim()
 
-        const val USER_AGENT: String =
-            "storyvox-librivox/1.0 (+https://github.com/techempower-org/candela)"
+        // #1204 — UA applied via the shared @UserAgentHeader interceptor (UserAgent.kt).
 
         /**
          * Sentinel prefixes used by [applyFilters] to smuggle the

--- a/source-librivox/src/main/kotlin/in/jphe/storyvox/source/librivox/di/LibriVoxModule.kt
+++ b/source-librivox/src/main/kotlin/in/jphe/storyvox/source/librivox/di/LibriVoxModule.kt
@@ -8,10 +8,12 @@ import dagger.hilt.components.SingletonComponent
 import dagger.multibindings.IntoMap
 import dagger.multibindings.StringKey
 import `in`.jphe.storyvox.data.source.FictionSource
+import `in`.jphe.storyvox.data.network.UserAgentHeader
 import `in`.jphe.storyvox.data.source.SourceIds
 import `in`.jphe.storyvox.source.librivox.LibriVoxSource
 import `in`.jphe.storyvox.source.librivox.net.GutenbergTextApi
 import `in`.jphe.storyvox.source.librivox.net.LibriVoxApi
+import okhttp3.Interceptor
 import okhttp3.OkHttpClient
 import javax.inject.Qualifier
 import javax.inject.Singleton
@@ -39,7 +41,9 @@ internal object LibriVoxHttpModule {
     @Provides
     @Singleton
     @LibriVoxHttp
-    fun provideClient(): OkHttpClient =
+    fun provideClient(
+        @UserAgentHeader userAgent: Interceptor,
+    ): OkHttpClient =
         OkHttpClient.Builder()
             .connectTimeout(5, TimeUnit.SECONDS)
             .readTimeout(30, TimeUnit.SECONDS)
@@ -47,6 +51,9 @@ internal object LibriVoxHttpModule {
             .followRedirects(true)
             .followSslRedirects(true)
             .retryOnConnectionFailure(true)
+            // #1204 — shared descriptive UA on every request
+            // (see in.jphe.storyvox.data.network.UserAgent).
+            .addInterceptor(userAgent)
             .build()
 
     @Provides

--- a/source-librivox/src/main/kotlin/in/jphe/storyvox/source/librivox/net/GutenbergTextApi.kt
+++ b/source-librivox/src/main/kotlin/in/jphe/storyvox/source/librivox/net/GutenbergTextApi.kt
@@ -60,7 +60,6 @@ internal class GutenbergTextApi @Inject constructor(
                 .header("Accept", "text/plain")
                 // gutenberg.org's robot policy asks clients to identify
                 // themselves; reuse the LibriVox user-agent contact.
-                .header("User-Agent", USER_AGENT)
                 .get()
                 .build()
             // The blocking `execute()` below doesn't observe coroutine
@@ -96,8 +95,7 @@ internal class GutenbergTextApi @Inject constructor(
     companion object {
         const val BASE_URL: String = "https://www.gutenberg.org"
 
-        const val USER_AGENT: String =
-            "storyvox-librivox/1.0 (+https://github.com/techempower-org/candela)"
+        // #1204 — UA applied via the shared @UserAgentHeader interceptor (UserAgent.kt).
 
         /**
          * Gutenberg's stable "Plain Text UTF-8" download alias. 302-

--- a/source-librivox/src/main/kotlin/in/jphe/storyvox/source/librivox/net/LibriVoxApi.kt
+++ b/source-librivox/src/main/kotlin/in/jphe/storyvox/source/librivox/net/LibriVoxApi.kt
@@ -184,7 +184,6 @@ internal class LibriVoxApi @Inject constructor(
                 // LibriVox / archive.org ask clients to identify
                 // themselves; the repo URL doubles as the contact channel
                 // and lets their ops contact abusive callers directly.
-                .header("User-Agent", USER_AGENT)
                 .get()
                 .build()
             client.newCall(request).execute().use { resp ->
@@ -222,8 +221,7 @@ internal class LibriVoxApi @Inject constructor(
          *  response. */
         const val PAGE_SIZE: Int = 50
 
-        const val USER_AGENT: String =
-            "storyvox-librivox/1.0 (+https://github.com/techempower-org/candela)"
+        // #1204 — UA applied via the shared @UserAgentHeader interceptor (UserAgent.kt).
     }
 }
 

--- a/source-librivox/src/test/kotlin/in/jphe/storyvox/source/librivox/LibriVoxSourceTest.kt
+++ b/source-librivox/src/test/kotlin/in/jphe/storyvox/source/librivox/LibriVoxSourceTest.kt
@@ -135,10 +135,9 @@ class LibriVoxSourceTest {
         assertTrue(result is FictionResult.Success)
     }
 
-    @Test fun `user-agent identifies storyvox-librivox`() {
-        assertTrue(LibriVoxSource.USER_AGENT.contains("storyvox-librivox"))
-        assertTrue(LibriVoxSource.USER_AGENT.contains("github.com/techempower-org/candela"))
-    }
+    // #1204 — removed `user-agent identifies storyvox-librivox`: LibriVox's
+    // per-source UA constant is gone; the descriptive User-Agent is now applied
+    // centrally by the shared @UserAgentHeader interceptor (UserAgent.format).
 
     // ─── Issue #1046 — open-domain text companion ──────────────────────
 

--- a/source-notion/src/main/kotlin/in/jphe/storyvox/source/notion/config/NotionDefaults.kt
+++ b/source-notion/src/main/kotlin/in/jphe/storyvox/source/notion/config/NotionDefaults.kt
@@ -93,8 +93,7 @@ object NotionDefaults {
      * the project + gives a contact path so Notion's abuse / rate-limit
      * tooling can route concerns somewhere useful.
      */
-    const val USER_AGENT: String =
-        "storyvox-notion/1.0 (+https://github.com/techempower-org/candela)"
+    // #1204 — UA applied via the shared @UserAgentHeader interceptor (UserAgent.kt).
 
     /**
      * Issue #393 / v0.5.26 — four-fiction layout for TechEmpower in

--- a/source-notion/src/main/kotlin/in/jphe/storyvox/source/notion/di/NotionModule.kt
+++ b/source-notion/src/main/kotlin/in/jphe/storyvox/source/notion/di/NotionModule.kt
@@ -11,9 +11,11 @@ import dagger.Lazy
 import `in`.jphe.storyvox.data.repository.net.NetworkPatience
 import `in`.jphe.storyvox.data.repository.net.NetworkPatienceConfig
 import `in`.jphe.storyvox.data.source.FictionSource
+import `in`.jphe.storyvox.data.network.UserAgentHeader
 import `in`.jphe.storyvox.data.source.SourceIds
 import `in`.jphe.storyvox.source.notion.NotionPATSource
 import `in`.jphe.storyvox.source.notion.NotionTechEmpowerSource
+import okhttp3.Interceptor
 import okhttp3.OkHttpClient
 import javax.inject.Qualifier
 import javax.inject.Singleton
@@ -40,7 +42,10 @@ internal object NotionHttpModule {
     @Provides
     @Singleton
     @NotionHttp
-    fun provideClient(patienceConfig: Lazy<NetworkPatienceConfig>): OkHttpClient {
+    fun provideClient(
+        patienceConfig: Lazy<NetworkPatienceConfig>,
+        @UserAgentHeader userAgent: Interceptor,
+    ): OkHttpClient {
         // Issue #597 — user-tunable patience preset. Notion's multi-
         // page block-children walks especially benefit from the
         // Patient (30s budget) preset. `Lazy<>` breaks the Dagger
@@ -54,6 +59,9 @@ internal object NotionHttpModule {
             .followRedirects(true)
             .followSslRedirects(true)
             .retryOnConnectionFailure(true)
+            // #1204 — shared descriptive UA on every request
+            // (see in.jphe.storyvox.data.network.UserAgent).
+            .addInterceptor(userAgent)
             .addInterceptor { chain ->
                 val patience = patienceConfig.get().currentPatienceSync()
                 chain

--- a/source-notion/src/main/kotlin/in/jphe/storyvox/source/notion/net/NotionApi.kt
+++ b/source-notion/src/main/kotlin/in/jphe/storyvox/source/notion/net/NotionApi.kt
@@ -215,7 +215,6 @@ internal class NotionApi @Inject constructor(
                 .header("Authorization", "Bearer ${state.apiToken}")
                 .header("Notion-Version", state.apiVersion)
                 .header("Accept", "application/json")
-                .header("User-Agent", NotionDefaults.USER_AGENT)
             when (method) {
                 "POST" -> reqBuilder.post((body ?: "{}").toRequestBody(mediaTypeJson))
                 else -> reqBuilder.get()

--- a/source-notion/src/main/kotlin/in/jphe/storyvox/source/notion/net/NotionUnofficialApi.kt
+++ b/source-notion/src/main/kotlin/in/jphe/storyvox/source/notion/net/NotionUnofficialApi.kt
@@ -274,7 +274,6 @@ internal class NotionUnofficialApi @Inject constructor(
                 // client uses for consistency. Spoofing a browser UA
                 // would be misleading and the unofficial endpoint
                 // doesn't gate on it anyway.
-                .header("User-Agent", NotionDefaults.USER_AGENT)
                 .post(body.toRequestBody(mediaTypeJson))
             client.newCall(reqBuilder.build()).execute().use { resp ->
                 val text = resp.body?.string().orEmpty()

--- a/source-outline/src/main/kotlin/in/jphe/storyvox/source/outline/di/OutlineModule.kt
+++ b/source-outline/src/main/kotlin/in/jphe/storyvox/source/outline/di/OutlineModule.kt
@@ -8,8 +8,10 @@ import dagger.hilt.components.SingletonComponent
 import dagger.multibindings.IntoMap
 import dagger.multibindings.StringKey
 import `in`.jphe.storyvox.data.source.FictionSource
+import `in`.jphe.storyvox.data.network.UserAgentHeader
 import `in`.jphe.storyvox.data.source.SourceIds
 import `in`.jphe.storyvox.source.outline.OutlineSource
+import okhttp3.Interceptor
 import okhttp3.OkHttpClient
 import javax.inject.Qualifier
 import javax.inject.Singleton
@@ -32,7 +34,9 @@ internal object OutlineHttpModule {
     @Provides
     @Singleton
     @OutlineHttp
-    fun provideClient(): OkHttpClient =
+    fun provideClient(
+        @UserAgentHeader userAgent: Interceptor,
+    ): OkHttpClient =
         OkHttpClient.Builder()
             .connectTimeout(5, TimeUnit.SECONDS)
             .readTimeout(30, TimeUnit.SECONDS)
@@ -40,6 +44,9 @@ internal object OutlineHttpModule {
             .followRedirects(true)
             .followSslRedirects(true)
             .retryOnConnectionFailure(true)
+            // #1204 — shared descriptive UA on every request (see
+            // in.jphe.storyvox.data.network.UserAgent).
+            .addInterceptor(userAgent)
             .build()
 
     @Provides

--- a/source-outline/src/main/kotlin/in/jphe/storyvox/source/outline/net/OutlineApi.kt
+++ b/source-outline/src/main/kotlin/in/jphe/storyvox/source/outline/net/OutlineApi.kt
@@ -90,7 +90,6 @@ internal class OutlineApi @Inject constructor(
                     .header("Authorization", "Bearer ${state.apiKey}")
                     .header("Content-Type", "application/json")
                     .header("Accept", "application/json")
-                    .header("User-Agent", USER_AGENT)
                     .post(body.toRequestBody("application/json".toMediaType()))
                     .build()
                 client.newCall(req).execute().use { resp ->
@@ -121,7 +120,7 @@ internal class OutlineApi @Inject constructor(
     }
 
     companion object {
-        const val USER_AGENT = "storyvox-outline/1.0 (+https://github.com/jphein/storyvox)"
+        // #1204 — UA applied via the shared @UserAgentHeader interceptor (UserAgent.kt).
     }
 }
 

--- a/source-palace/src/main/kotlin/in/jphe/storyvox/source/palace/di/PalaceModule.kt
+++ b/source-palace/src/main/kotlin/in/jphe/storyvox/source/palace/di/PalaceModule.kt
@@ -10,11 +10,13 @@ import dagger.hilt.components.SingletonComponent
 import dagger.multibindings.IntoMap
 import dagger.multibindings.StringKey
 import `in`.jphe.storyvox.data.source.FictionSource
+import `in`.jphe.storyvox.data.network.UserAgentHeader
 import `in`.jphe.storyvox.data.source.SourceIds
 import `in`.jphe.storyvox.source.palace.InMemoryPalaceLibraryConfig
 import `in`.jphe.storyvox.source.palace.PalaceLibraryConfig
 import `in`.jphe.storyvox.source.palace.PalaceSource
 import `in`.jphe.storyvox.source.palace.net.PalaceApi
+import okhttp3.Interceptor
 import okhttp3.OkHttpClient
 import java.io.File
 import java.util.concurrent.TimeUnit
@@ -52,7 +54,9 @@ internal object PalaceHttpModule {
     @Provides
     @Singleton
     @PalaceHttp
-    fun provideClient(): OkHttpClient =
+    fun provideClient(
+        @UserAgentHeader userAgent: Interceptor,
+    ): OkHttpClient =
         OkHttpClient.Builder()
             .connectTimeout(10, TimeUnit.SECONDS)
             // EPUB downloads dominate the read budget — give them
@@ -64,6 +68,9 @@ internal object PalaceHttpModule {
             .followRedirects(true)
             .followSslRedirects(true)
             .retryOnConnectionFailure(true)
+            // #1204 — shared descriptive UA on every request (see
+            // in.jphe.storyvox.data.network.UserAgent).
+            .addInterceptor(userAgent)
             .build()
 
     @Provides

--- a/source-palace/src/main/kotlin/in/jphe/storyvox/source/palace/net/PalaceApi.kt
+++ b/source-palace/src/main/kotlin/in/jphe/storyvox/source/palace/net/PalaceApi.kt
@@ -94,7 +94,6 @@ internal class PalaceApi @Inject constructor(
             try {
                 val req = Request.Builder()
                     .url(url)
-                    .header("User-Agent", USER_AGENT)
                     .header("Accept", "application/epub+zip")
                     .get()
                     .build()
@@ -150,7 +149,6 @@ internal class PalaceApi @Inject constructor(
                     "application/atom+xml;profile=opds-catalog, application/atom+xml, " +
                         "application/xml;q=0.9, */*;q=0.1",
                 )
-                .header("User-Agent", USER_AGENT)
                 .get()
                 .build()
             client.newCall(req).execute().use { resp ->
@@ -184,6 +182,6 @@ internal class PalaceApi @Inject constructor(
          * URL routes any rate-limit / abuse signal back to a real human
          * — same etiquette as the Gutenberg / Standard Ebooks clients.
          */
-        const val USER_AGENT = "storyvox-palace/1.0 (+https://github.com/jphein/storyvox)"
+        // #1204 — UA applied via the shared @UserAgentHeader interceptor (UserAgent.kt).
     }
 }

--- a/source-plos/src/main/kotlin/in/jphe/storyvox/source/plos/di/PlosModule.kt
+++ b/source-plos/src/main/kotlin/in/jphe/storyvox/source/plos/di/PlosModule.kt
@@ -8,9 +8,11 @@ import dagger.hilt.components.SingletonComponent
 import dagger.multibindings.IntoMap
 import dagger.multibindings.StringKey
 import `in`.jphe.storyvox.data.source.FictionSource
+import `in`.jphe.storyvox.data.network.UserAgentHeader
 import `in`.jphe.storyvox.data.source.SourceIds
 import `in`.jphe.storyvox.source.plos.PlosSource
 import `in`.jphe.storyvox.source.plos.net.PlosApi
+import okhttp3.Interceptor
 import okhttp3.OkHttpClient
 import java.util.concurrent.TimeUnit
 import javax.inject.Qualifier
@@ -34,7 +36,9 @@ internal object PlosHttpModule {
     @Provides
     @Singleton
     @PlosHttp
-    fun provideClient(): OkHttpClient =
+    fun provideClient(
+        @UserAgentHeader userAgent: Interceptor,
+    ): OkHttpClient =
         OkHttpClient.Builder()
             .connectTimeout(5, TimeUnit.SECONDS)
             .readTimeout(30, TimeUnit.SECONDS)
@@ -42,6 +46,9 @@ internal object PlosHttpModule {
             .followRedirects(true)
             .followSslRedirects(true)
             .retryOnConnectionFailure(true)
+            // #1204 — shared descriptive UA on every request (see
+            // in.jphe.storyvox.data.network.UserAgent).
+            .addInterceptor(userAgent)
             .build()
 
     @Provides

--- a/source-plos/src/main/kotlin/in/jphe/storyvox/source/plos/net/PlosApi.kt
+++ b/source-plos/src/main/kotlin/in/jphe/storyvox/source/plos/net/PlosApi.kt
@@ -173,7 +173,6 @@ internal open class PlosApi @Inject constructor(
                     .url(url)
                     .header("Accept", "application/json, text/html, */*")
                     .header("Accept-Language", "en")
-                    .header("User-Agent", USER_AGENT)
                     .get()
                     .build()
                 client.newCall(req).execute().use { resp ->
@@ -224,8 +223,7 @@ internal open class PlosApi @Inject constructor(
          *  (anonymous traffic works without one), but their public docs
          *  ask harvesters to identify themselves so an op can reach out
          *  if a client misbehaves. */
-        const val USER_AGENT: String =
-            "storyvox-plos/1.0 (https://github.com/jphein/storyvox; jp@jphein.com)"
+        // #1204 — UA applied via the shared @UserAgentHeader interceptor (UserAgent.kt).
     }
 }
 

--- a/source-radio/src/main/kotlin/in/jphe/storyvox/source/radio/RadioSource.kt
+++ b/source-radio/src/main/kotlin/in/jphe/storyvox/source/radio/RadioSource.kt
@@ -412,9 +412,6 @@ internal class RadioSource @Inject constructor(
         /** Legacy v0.5.20+ KVMR chapterId — same preservation rationale. */
         const val LEGACY_KVMR_CHAPTER_ID: String = "kvmr:live:0"
 
-        const val USER_AGENT: String =
-            "storyvox-radio/0.5.32 (+https://github.com/techempower-org/candela)"
-
         /**
          * Sentinel prefixes used by [applyFilters] to smuggle the
          * country / language / tag filters through [SearchQuery.tags].

--- a/source-radio/src/main/kotlin/in/jphe/storyvox/source/radio/di/RadioModule.kt
+++ b/source-radio/src/main/kotlin/in/jphe/storyvox/source/radio/di/RadioModule.kt
@@ -7,9 +7,11 @@ import dagger.hilt.InstallIn
 import dagger.hilt.components.SingletonComponent
 import dagger.multibindings.IntoMap
 import dagger.multibindings.StringKey
+import `in`.jphe.storyvox.data.network.UserAgentHeader
 import `in`.jphe.storyvox.data.source.FictionSource
 import `in`.jphe.storyvox.data.source.SourceIds
 import `in`.jphe.storyvox.source.radio.RadioSource
+import okhttp3.Interceptor
 import okhttp3.OkHttpClient
 import javax.inject.Qualifier
 import javax.inject.Singleton
@@ -37,7 +39,9 @@ internal object RadioHttpModule {
     @Provides
     @Singleton
     @RadioHttp
-    fun provideClient(): OkHttpClient =
+    fun provideClient(
+        @UserAgentHeader userAgent: Interceptor,
+    ): OkHttpClient =
         OkHttpClient.Builder()
             .connectTimeout(5, TimeUnit.SECONDS)
             .readTimeout(30, TimeUnit.SECONDS)
@@ -45,6 +49,9 @@ internal object RadioHttpModule {
             .followRedirects(true)
             .followSslRedirects(true)
             .retryOnConnectionFailure(true)
+            // #1141 — Radio Browser asks callers to identify themselves
+            // in the UA so abusive clients can be contacted directly.
+            .addInterceptor(userAgent)
             .build()
 
     @Provides

--- a/source-radio/src/main/kotlin/in/jphe/storyvox/source/radio/net/RadioBrowserApi.kt
+++ b/source-radio/src/main/kotlin/in/jphe/storyvox/source/radio/net/RadioBrowserApi.kt
@@ -174,13 +174,14 @@ internal class RadioBrowserApi @Inject constructor(
 
     private suspend fun doRequest(url: String): FictionResult<String> = withContext(Dispatchers.IO) {
         try {
+            // #1141 — Radio Browser asks clients to identify themselves
+            // so abusive callers can be contacted directly. The
+            // descriptive `User-Agent` is applied for every request by the
+            // shared UserAgentHeader interceptor on the injected client;
+            // see `in.jphe.storyvox.data.network.UserAgent`.
             val request = Request.Builder()
                 .url(url)
                 .header("Accept", "application/json")
-                // Radio Browser asks clients to identify themselves so
-                // abusive callers can be contacted directly. The repo
-                // URL doubles as the contact channel.
-                .header("User-Agent", USER_AGENT)
                 .get()
                 .build()
             client.newCall(request).execute().use { resp ->
@@ -216,9 +217,6 @@ internal class RadioBrowserApi @Inject constructor(
          * round-robin DNS endpoint is a worse fit for our usage shape.
          */
         const val BASE_URL: String = "https://de1.api.radio-browser.info"
-
-        const val USER_AGENT: String =
-            "storyvox-radio/0.5.32 (+https://github.com/techempower-org/candela)"
     }
 }
 

--- a/source-radio/src/test/kotlin/in/jphe/storyvox/source/radio/RadioSourceTest.kt
+++ b/source-radio/src/test/kotlin/in/jphe/storyvox/source/radio/RadioSourceTest.kt
@@ -1,5 +1,6 @@
 package `in`.jphe.storyvox.source.radio
 
+import `in`.jphe.storyvox.data.network.UserAgent
 import `in`.jphe.storyvox.data.source.SourceIds
 import `in`.jphe.storyvox.data.source.model.FictionResult
 import `in`.jphe.storyvox.data.source.model.SearchQuery
@@ -249,8 +250,16 @@ class RadioSourceTest {
         assertEquals("kvmr:live:0", RadioSource.liveChapterIdFor(kvmr))
     }
 
-    @Test fun `user-agent identifies storyvox-radio`() {
-        assertTrue(RadioSource.USER_AGENT.contains("storyvox-radio"))
-        assertTrue(RadioSource.USER_AGENT.contains("github.com/techempower-org/candela"))
+    // #1141 — the descriptive User-Agent is now centralised in
+    // `in.jphe.storyvox.data.network.UserAgent` and applied to every
+    // Radio Browser request by the shared UserAgentHeader interceptor.
+    // Radio Browser asks callers to identify the app + a contact channel
+    // so abusive clients can be reached directly; pin that contract here.
+    @Test fun `user-agent identifies candela with contact info`() {
+        val ua = UserAgent.format("9.9.9")
+        assertTrue("UA names the app + version", ua.contains("Candela/9.9.9"))
+        assertTrue("UA carries a contact URL", ua.contains("candela.techempower.org"))
+        assertTrue("UA carries a contact email", ua.contains("support@techempower.org"))
+        assertTrue("UA identifies the platform", ua.contains("Android"))
     }
 }

--- a/source-readability/src/main/kotlin/in/jphe/storyvox/source/readability/di/ReadabilityModule.kt
+++ b/source-readability/src/main/kotlin/in/jphe/storyvox/source/readability/di/ReadabilityModule.kt
@@ -8,8 +8,10 @@ import dagger.hilt.components.SingletonComponent
 import dagger.multibindings.IntoMap
 import dagger.multibindings.StringKey
 import `in`.jphe.storyvox.data.source.FictionSource
+import `in`.jphe.storyvox.data.network.UserAgentHeader
 import `in`.jphe.storyvox.data.source.SourceIds
 import `in`.jphe.storyvox.source.readability.ReadabilitySource
+import okhttp3.Interceptor
 import okhttp3.OkHttpClient
 import java.util.concurrent.TimeUnit
 import javax.inject.Qualifier
@@ -31,7 +33,9 @@ internal object ReadabilityHttpModule {
     @Provides
     @Singleton
     @ReadabilityHttp
-    fun provideClient(): OkHttpClient =
+    fun provideClient(
+        @UserAgentHeader userAgent: Interceptor,
+    ): OkHttpClient =
         OkHttpClient.Builder()
             .connectTimeout(10, TimeUnit.SECONDS)
             .readTimeout(45, TimeUnit.SECONDS)
@@ -39,6 +43,9 @@ internal object ReadabilityHttpModule {
             .followRedirects(true)
             .followSslRedirects(true)
             .retryOnConnectionFailure(true)
+            // #1204 — shared descriptive UA on every request (see
+            // in.jphe.storyvox.data.network.UserAgent).
+            .addInterceptor(userAgent)
             .build()
 }
 

--- a/source-readability/src/main/kotlin/in/jphe/storyvox/source/readability/net/ReadabilityFetcher.kt
+++ b/source-readability/src/main/kotlin/in/jphe/storyvox/source/readability/net/ReadabilityFetcher.kt
@@ -32,7 +32,6 @@ class ReadabilityFetcher @Inject constructor(
         try {
             val request = Request.Builder()
                 .url(url)
-                .header("User-Agent", USER_AGENT)
                 .header("Accept", "text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8")
                 .build()
             client.newCall(request).execute().use { response ->
@@ -79,6 +78,6 @@ class ReadabilityFetcher @Inject constructor(
         // Polite UA — identifies us as a personal audiobook reader so a
         // server admin who notices the traffic can see what it's for.
         // Same convention as the RSS / Wikipedia / Outline backends.
-        const val USER_AGENT = "storyvox-readability/1.0 (+https://github.com/techempower-org/candela)"
+        // #1204 — UA applied via the shared @UserAgentHeader interceptor (UserAgent.kt).
     }
 }

--- a/source-rss/src/main/kotlin/in/jphe/storyvox/source/rss/di/RssModule.kt
+++ b/source-rss/src/main/kotlin/in/jphe/storyvox/source/rss/di/RssModule.kt
@@ -11,8 +11,10 @@ import dagger.Lazy
 import `in`.jphe.storyvox.data.repository.net.NetworkPatience
 import `in`.jphe.storyvox.data.repository.net.NetworkPatienceConfig
 import `in`.jphe.storyvox.data.source.FictionSource
+import `in`.jphe.storyvox.data.network.UserAgentHeader
 import `in`.jphe.storyvox.data.source.SourceIds
 import `in`.jphe.storyvox.source.rss.RssSource
+import okhttp3.Interceptor
 import okhttp3.OkHttpClient
 import javax.inject.Qualifier
 import javax.inject.Singleton
@@ -35,7 +37,10 @@ internal object RssHttpModule {
     @Provides
     @Singleton
     @RssHttp
-    fun provideClient(patienceConfig: Lazy<NetworkPatienceConfig>): OkHttpClient {
+    fun provideClient(
+        patienceConfig: Lazy<NetworkPatienceConfig>,
+        @UserAgentHeader userAgent: Interceptor,
+    ): OkHttpClient {
         // Issue #597 — user-tunable patience preset. `Lazy<>` breaks
         // a Dagger graph cycle (NetworkPatienceConfig ↔ source-map
         // closure); see [RoyalRoadHttpModule.provideClient] for the
@@ -50,6 +55,9 @@ internal object RssHttpModule {
             .followRedirects(true)
             .followSslRedirects(true)
             .retryOnConnectionFailure(true)
+            // #1204 — shared descriptive UA on every request
+            // (see in.jphe.storyvox.data.network.UserAgent).
+            .addInterceptor(userAgent)
             .addInterceptor { chain ->
                 val patience = patienceConfig.get().currentPatienceSync()
                 chain

--- a/source-rss/src/main/kotlin/in/jphe/storyvox/source/rss/net/RssFetcher.kt
+++ b/source-rss/src/main/kotlin/in/jphe/storyvox/source/rss/net/RssFetcher.kt
@@ -40,7 +40,6 @@ class RssFetcher @Inject constructor(
         try {
             val builder = Request.Builder()
                 .url(url)
-                .header("User-Agent", USER_AGENT)
                 .header("Accept", "application/rss+xml, application/atom+xml, application/xml, text/xml")
             if (!previousEtag.isNullOrBlank()) builder.header("If-None-Match", previousEtag)
             if (!previousLastModified.isNullOrBlank()) builder.header("If-Modified-Since", previousLastModified)
@@ -73,7 +72,7 @@ class RssFetcher @Inject constructor(
     companion object {
         // Identifies storyvox in feed-server logs so feed authors can
         // see who's pulling. Same posture move as the GitHub backend.
-        const val USER_AGENT = "storyvox-rss/1.0 (+https://github.com/jphein/storyvox)"
+        // #1204 — UA applied via the shared @UserAgentHeader interceptor (UserAgent.kt).
     }
 }
 

--- a/source-standard-ebooks/src/main/kotlin/in/jphe/storyvox/source/standardebooks/StandardEbooksSource.kt
+++ b/source-standard-ebooks/src/main/kotlin/in/jphe/storyvox/source/standardebooks/StandardEbooksSource.kt
@@ -51,8 +51,9 @@ import javax.inject.Singleton
  *
  * Legal posture: zero ToS friction. Every release is dedicated to the
  * public domain under [CC0 1.0](https://creativecommons.org/publicdomain/zero/1.0/);
- * we send a `storyvox-standardebooks/1.0` User-Agent so any rate-limit
- * hits route to a real contact.
+ * we send the shared descriptive User-Agent (app + version + contact, see
+ * `in.jphe.storyvox.data.network.UserAgent`) so any rate-limit hits route
+ * to a real contact.
  */
 @SourcePlugin(
     id = SourceIds.STANDARD_EBOOKS,

--- a/source-standard-ebooks/src/main/kotlin/in/jphe/storyvox/source/standardebooks/di/StandardEbooksModule.kt
+++ b/source-standard-ebooks/src/main/kotlin/in/jphe/storyvox/source/standardebooks/di/StandardEbooksModule.kt
@@ -10,9 +10,11 @@ import dagger.hilt.components.SingletonComponent
 import dagger.multibindings.IntoMap
 import dagger.multibindings.StringKey
 import `in`.jphe.storyvox.data.source.FictionSource
+import `in`.jphe.storyvox.data.network.UserAgentHeader
 import `in`.jphe.storyvox.data.source.SourceIds
 import `in`.jphe.storyvox.source.standardebooks.StandardEbooksSource
 import `in`.jphe.storyvox.source.standardebooks.net.StandardEbooksApi
+import okhttp3.Interceptor
 import okhttp3.OkHttpClient
 import java.io.File
 import java.util.concurrent.TimeUnit
@@ -48,7 +50,9 @@ internal object StandardEbooksHttpModule {
     @Provides
     @Singleton
     @StandardEbooksHttp
-    fun provideClient(): OkHttpClient =
+    fun provideClient(
+        @UserAgentHeader userAgent: Interceptor,
+    ): OkHttpClient =
         OkHttpClient.Builder()
             .connectTimeout(10, TimeUnit.SECONDS)
             // EPUB downloads dominate the read budget — give them
@@ -58,6 +62,9 @@ internal object StandardEbooksHttpModule {
             .followRedirects(true)
             .followSslRedirects(true)
             .retryOnConnectionFailure(true)
+            // #1204 — shared descriptive UA on every request (see
+            // in.jphe.storyvox.data.network.UserAgent).
+            .addInterceptor(userAgent)
             .build()
 
     @Provides

--- a/source-standard-ebooks/src/main/kotlin/in/jphe/storyvox/source/standardebooks/net/StandardEbooksApi.kt
+++ b/source-standard-ebooks/src/main/kotlin/in/jphe/storyvox/source/standardebooks/net/StandardEbooksApi.kt
@@ -111,7 +111,6 @@ internal open class StandardEbooksApi @Inject constructor(
             try {
                 val req = Request.Builder()
                     .url(url)
-                    .header("User-Agent", USER_AGENT)
                     .header("Accept", "application/epub+zip")
                     .get()
                     .build()
@@ -203,7 +202,6 @@ internal open class StandardEbooksApi @Inject constructor(
             val req = Request.Builder()
                 .url(url)
                 .header("Accept", "application/xhtml+xml, text/html, */*")
-                .header("User-Agent", USER_AGENT)
                 .get()
                 .build()
             client.newCall(req).execute().use { resp ->
@@ -236,7 +234,7 @@ internal open class StandardEbooksApi @Inject constructor(
          * URL routes any rate-limit / abuse signal back to a real human
          * — same etiquette as the Gutenberg client (#237).
          */
-        const val USER_AGENT = "storyvox-standardebooks/1.0 (+https://github.com/jphein/storyvox)"
+        // #1204 — UA applied via the shared @UserAgentHeader interceptor (UserAgent.kt).
     }
 }
 

--- a/source-wikipedia/src/main/kotlin/in/jphe/storyvox/source/wikipedia/di/WikipediaModule.kt
+++ b/source-wikipedia/src/main/kotlin/in/jphe/storyvox/source/wikipedia/di/WikipediaModule.kt
@@ -7,9 +7,11 @@ import dagger.hilt.InstallIn
 import dagger.hilt.components.SingletonComponent
 import dagger.multibindings.IntoMap
 import dagger.multibindings.StringKey
+import `in`.jphe.storyvox.data.network.UserAgentHeader
 import `in`.jphe.storyvox.data.source.FictionSource
 import `in`.jphe.storyvox.data.source.SourceIds
 import `in`.jphe.storyvox.source.wikipedia.WikipediaSource
+import okhttp3.Interceptor
 import okhttp3.OkHttpClient
 import javax.inject.Qualifier
 import javax.inject.Singleton
@@ -37,7 +39,9 @@ internal object WikipediaHttpModule {
     @Provides
     @Singleton
     @WikipediaHttp
-    fun provideClient(): OkHttpClient =
+    fun provideClient(
+        @UserAgentHeader userAgent: Interceptor,
+    ): OkHttpClient =
         OkHttpClient.Builder()
             .connectTimeout(5, TimeUnit.SECONDS)
             .readTimeout(30, TimeUnit.SECONDS)
@@ -45,6 +49,10 @@ internal object WikipediaHttpModule {
             .followRedirects(true)
             .followSslRedirects(true)
             .retryOnConnectionFailure(true)
+            // #1141 — Wikimedia *requires* a descriptive UA with contact
+            // info per https://meta.wikimedia.org/wiki/User-Agent_policy;
+            // anonymous traffic without one is 403'd into a restrictive tier.
+            .addInterceptor(userAgent)
             .build()
 
     @Provides

--- a/source-wikipedia/src/main/kotlin/in/jphe/storyvox/source/wikipedia/net/WikipediaApi.kt
+++ b/source-wikipedia/src/main/kotlin/in/jphe/storyvox/source/wikipedia/net/WikipediaApi.kt
@@ -208,11 +208,14 @@ internal class WikipediaApi @Inject constructor(
             // signature + `withContext(Dispatchers.IO)` wrapper. The
             // original non-suspend shape crashed Browse → Wikipedia
             // with NetworkOnMainThreadException on first chip tap.
+            // #1141 — the descriptive `User-Agent` Wikimedia requires
+            // (project + contact) is applied for every request by the
+            // shared UserAgentHeader interceptor on the injected client;
+            // see `in.jphe.storyvox.data.network.UserAgent`.
             val req = Request.Builder()
                 .url(url)
                 .header("Accept", "application/json")
                 .header("Accept-Language", extractLanguageFromUrl(url))
-                .header("User-Agent", USER_AGENT)
                 .get()
                 .build()
             client.newCall(req).execute().use { resp ->
@@ -252,15 +255,6 @@ internal class WikipediaApi @Inject constructor(
         val host = url.substringAfter("://").substringBefore('/')
         val prefix = host.substringBefore(".wikipedia.org", missingDelimiterValue = "")
         return if (prefix.isNotBlank() && !prefix.contains('.')) prefix else "en"
-    }
-
-    companion object {
-        /** Wikimedia User-Agent policy
-         *  (https://meta.wikimedia.org/wiki/User-Agent_policy):
-         *  identify the project + give a contact. Without this the
-         *  REST API returns 403 for anonymous-tier traffic. */
-        const val USER_AGENT: String =
-            "storyvox-wikipedia/1.0 (https://github.com/jphein/storyvox; jp@jphein.com)"
     }
 }
 

--- a/source-wikisource/src/main/kotlin/in/jphe/storyvox/source/wikisource/di/WikisourceModule.kt
+++ b/source-wikisource/src/main/kotlin/in/jphe/storyvox/source/wikisource/di/WikisourceModule.kt
@@ -7,10 +7,12 @@ import dagger.hilt.InstallIn
 import dagger.hilt.components.SingletonComponent
 import dagger.multibindings.IntoMap
 import dagger.multibindings.StringKey
+import `in`.jphe.storyvox.data.network.UserAgentHeader
 import `in`.jphe.storyvox.data.source.FictionSource
 import `in`.jphe.storyvox.data.source.SourceIds
 import `in`.jphe.storyvox.source.wikisource.WikisourceSource
 import `in`.jphe.storyvox.source.wikisource.net.WikisourceApi
+import okhttp3.Interceptor
 import okhttp3.OkHttpClient
 import javax.inject.Qualifier
 import javax.inject.Singleton
@@ -38,7 +40,9 @@ internal object WikisourceHttpModule {
     @Provides
     @Singleton
     @WikisourceHttp
-    fun provideClient(): OkHttpClient =
+    fun provideClient(
+        @UserAgentHeader userAgent: Interceptor,
+    ): OkHttpClient =
         OkHttpClient.Builder()
             .connectTimeout(5, TimeUnit.SECONDS)
             .readTimeout(30, TimeUnit.SECONDS)
@@ -46,6 +50,10 @@ internal object WikisourceHttpModule {
             .followRedirects(true)
             .followSslRedirects(true)
             .retryOnConnectionFailure(true)
+            // #1141 — Wikimedia *requires* a descriptive UA with contact
+            // info per https://meta.wikimedia.org/wiki/User-Agent_policy;
+            // anonymous traffic without one is 403'd into a restrictive tier.
+            .addInterceptor(userAgent)
             .build()
 
     @Provides

--- a/source-wikisource/src/main/kotlin/in/jphe/storyvox/source/wikisource/net/WikisourceApi.kt
+++ b/source-wikisource/src/main/kotlin/in/jphe/storyvox/source/wikisource/net/WikisourceApi.kt
@@ -201,11 +201,14 @@ internal class WikisourceApi @Inject constructor(
     // with NetworkOnMainThreadException on first chip tap.
     private suspend fun getRaw(url: String): FictionResult<String> = withContext(Dispatchers.IO) {
         try {
+            // #1141 — the descriptive `User-Agent` Wikimedia requires
+            // (project + contact) is applied for every request by the
+            // shared UserAgentHeader interceptor on the injected client;
+            // see `in.jphe.storyvox.data.network.UserAgent`.
             val req = Request.Builder()
                 .url(url)
                 .header("Accept", "application/json")
                 .header("Accept-Language", "en")
-                .header("User-Agent", USER_AGENT)
                 .get()
                 .build()
             client.newCall(req).execute().use { resp ->
@@ -243,12 +246,6 @@ internal class WikisourceApi @Inject constructor(
          *  Keeping the host as a const avoids the WikipediaConfig
          *  DataStore plumbing for a single-language launch. */
         const val BASE_URL: String = "https://en.wikisource.org"
-
-        /** Wikimedia User-Agent policy — identify the project + give a
-         *  contact URL. Without this the REST API returns 403 for
-         *  anonymous-tier traffic. */
-        const val USER_AGENT: String =
-            "storyvox-wikisource/1.0 (https://github.com/jphein/storyvox; jp@jphein.com)"
     }
 }
 


### PR DESCRIPTION
## Summary

Fixes #1204 — extends #1141/#1196's centralized User-Agent (`UserAgent.format` + `@UserAgentHeader` interceptor) to the **13 remaining source modules** that still baked their own stale hardcoded UAs, most leaking the pre-rebrand identities `github.com/jphein/storyvox` + `jp@jphein.com` on every outbound request.

> ⚠️ **Stacked on #1196** (`fix/1141-user-agent`) — `UserAgent.kt` isn't on `main` yet, so this PR is based on that branch and should merge **after** #1196. (GitHub will auto-retarget to `main` once #1196 lands.)

## Mechanism (mirrors the 4 sources #1196 converted)

Each source's dedicated `OkHttpClient` now injects the shared `@UserAgentHeader` interceptor (`.addInterceptor(userAgent)`); the per-request `.header("User-Agent", …)` calls and per-source `USER_AGENT` constants are removed. The interceptor builds the canonical `Candela/<version> (<url>; <email>) Android` string from the live `BuildConfig.VERSION_NAME`, so the version never drifts again.

**Converted:** ao3, github, gutenberg, hackernews, librivox, notion, outline, palace, plos, readability, rss, standard-ebooks, discord.

## Per-source notes

- **github** — wired **both** clients: the `@GitHubHttp` REST client *and* the vanilla `@GitHubDeviceFlowHttp` device-flow client. GitHub **requires** a UA on every request, so neither could lose it. Removed 4 stale consts (GitHubApi, GitHubProfileService, DeviceFlowApi, Registry).
- **ao3** — kept an explicit constant (rebranded off jphein, now built from the centralized `UserAgent` tokens) instead of the interceptor: the AO3 login **WebView**'s `userAgentString` needs a literal string, and OTW Ops asks for one identity across a client's traffic, so the OkHttp calls + WebView share it.
- **notion/rss** — interceptor added alongside the existing #597 patience interceptor.
- **librivox** — removed 3 consts; dropped the now-obsolete `LibriVoxSourceTest` UA assertion.
- Refreshed stale UA prose in `GutenbergSource`/`StandardEbooksSource` kdoc.

## Verification

Per the no-gradle-on-katana rule, **not built locally — relying on CI (familiar)** to compile. Verified statically:
- All script anchors matched exactly (DI param + `.addInterceptor` + const removal, presence-asserted).
- No dangling `USER_AGENT` references; no external references to any removed const.
- `okhttp3.Interceptor` + `UserAgentHeader` imports added to every wired module.

## Out-of-scope leaks found (NOT in this PR — flagging for triage)

The audit's "13 sources" missed two more `jphein/storyvox` UA leaks **outside** the source modules:
- `app/.../data/SuggestedFeedsRegistry.kt` — `"storyvox/1.0 (+…/jphein/storyvox)"`
- `core-llm/.../auth/AnthropicTeamsAuthApi.kt` — `"storyvox/0.4 (+…/jphein/storyvox)"`

Both are self-contained (don't affect this PR). Worth a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
