### PR TITLE
fix(playback): set audioUrl at chapter creation to eliminate load race (#1221)

### DIFF
--- a/core-data/src/main/kotlin/in/jphe/storyvox/data/repository/FictionRepository.kt
+++ b/core-data/src/main/kotlin/in/jphe/storyvox/data/repository/FictionRepository.kt
@@ -550,6 +550,7 @@ class FictionRepositoryImpl @Inject constructor(
                 lastDownloadError = previous.lastDownloadError,
                 userMarkedRead = previous.userMarkedRead,
                 firstReadAt = previous.firstReadAt,
+                audioUrl = fresh.audioUrl ?: previous.audioUrl,
             )
         }
         // Issues #349 / #652 — RSS feeds (and any future window-style
@@ -705,6 +706,7 @@ internal fun ChapterInfo.toEntity(fictionId: String): Chapter = Chapter(
     publishedAt = publishedAt,
     wordCount = wordCount,
     downloadState = ChapterDownloadState.NOT_DOWNLOADED,
+    audioUrl = audioUrl,
 )
 
 internal fun Chapter.toInfo(): ChapterInfo = ChapterInfo(
@@ -714,6 +716,7 @@ internal fun Chapter.toInfo(): ChapterInfo = ChapterInfo(
     title = title,
     publishedAt = publishedAt,
     wordCount = wordCount,
+    audioUrl = audioUrl,
 )
 
 internal fun toInfo(row: `in`.jphe.storyvox.data.db.dao.ChapterInfoRow): ChapterInfo = ChapterInfo(

--- a/core-data/src/main/kotlin/in/jphe/storyvox/data/source/model/ChapterInfo.kt
+++ b/core-data/src/main/kotlin/in/jphe/storyvox/data/source/model/ChapterInfo.kt
@@ -10,4 +10,8 @@ data class ChapterInfo(
     val title: String,
     val publishedAt: Long? = null,
     val wordCount: Int? = null,
+    /** Issue #1221 — audio-stream sources (radio) set this at TOC time so
+     *  the chapter row carries the URL from creation, eliminating the race
+     *  between download-worker [ChapterContent.audioUrl] and loadAndPlay. */
+    val audioUrl: String? = null,
 )

--- a/source-librivox/src/main/kotlin/in/jphe/storyvox/source/librivox/LibriVoxSource.kt
+++ b/source-librivox/src/main/kotlin/in/jphe/storyvox/source/librivox/LibriVoxSource.kt
@@ -374,6 +374,7 @@ internal class LibriVoxSource @Inject constructor(
             sourceChapterId = sectionNumber.ifBlank { (index + 1).toString() },
             index = index,
             title = title.ifBlank { "Section ${sectionNumber.ifBlank { (index + 1).toString() }}" },
+            audioUrl = listenUrl.ifBlank { null },
         )
 
     /** Issue #1046 — TOC entry for the open-domain text companion. Sits

--- a/source-radio/src/main/kotlin/in/jphe/storyvox/source/radio/RadioSource.kt
+++ b/source-radio/src/main/kotlin/in/jphe/storyvox/source/radio/RadioSource.kt
@@ -373,6 +373,7 @@ internal class RadioSource @Inject constructor(
             sourceChapterId = "live",
             index = 0,
             title = "Live",
+            audioUrl = station.streamUrl,
         )
 
     companion object {


### PR DESCRIPTION
## Summary

- Audio-stream sources (radio, LibriVox) only set `audioUrl` via the download worker's `setBody()`, but `loadAndPlay` can read the chapter before that completes — `audioUrl` is null, text is empty, `getChapter()` returns null, user sees permanent "Retry" error
- Added `audioUrl` field to `ChapterInfo` so it's written at chapter upsert time (before any playback attempt)
- RadioSource and LibriVoxSource now pass their stream URLs through `ChapterInfo`
- `upsertDetail` merge preserves whichever `audioUrl` is non-null (fresh from source wins, previous download is fallback)

Fixes #1221

## Test plan
- [ ] CI Build APK passes
- [ ] Radio (KVMR) plays without Retry error on first tap
- [ ] LibriVox audiobook plays without Retry error on first tap
- [ ] Text-only sources (Royal Road, AO3, etc.) unaffected

Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Chapter entries now retain audio stream URLs, improving playback for live radio and other streamed content.
  * Live radio chapters now carry the stream source directly, helping playback start more reliably.
* **Bug Fixes**
  * Refreshed chapter details now preserve existing audio URLs when a new one isn’t provided.
  * Blank audio links are now treated as missing, reducing broken or empty playback sources.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->