### PR TITLE
fix(playback): skip AudioFocusController check for ExoPlayer streams (#1225)

### DIFF
--- a/core-playback/src/main/kotlin/in/jphe/storyvox/playback/diagnostics/AudioOutputMonitor.kt
+++ b/core-playback/src/main/kotlin/in/jphe/storyvox/playback/diagnostics/AudioOutputMonitor.kt
@@ -267,7 +267,10 @@ class AudioOutputMonitor @Inject constructor(
         // 3. Audio focus lost → we asked the framework, the framework
         //    said no. Translate the most-likely-cause (best effort —
         //    Android doesn't expose the focus-stack contents).
-        if (!audioFocus.isHeld()) {
+        //    Skip for live-audio chapters (#1225): ExoPlayer manages its
+        //    own focus (handleAudioFocus=true); AudioFocusController is
+        //    only relevant for the TTS AudioTrack path.
+        if (!state.isLiveAudioChapter && !audioFocus.isHeld()) {
             return WaitReason.FocusLost(cause = guessFocusCause())
         }
 


### PR DESCRIPTION
## Summary

- Radio and LibriVox audio streams show a false "Paused for a call — will resume when you're done" diagnostic panel even when audio is playing normally
- Root cause: `AudioOutputMonitor.diagnose()` checks `AudioFocusController.isHeld()`, but ExoPlayer manages its own audio focus (`handleAudioFocus=true`), so the controller's state is irrelevant for audio stream chapters
- Fix: skip the `audioFocus.isHeld()` check when `PlaybackState.isLiveAudioChapter` is true

## Test plan
- [ ] Open a radio station — no "Paused for a call" panel
- [ ] Open a LibriVox audiobook — no false diagnostic
- [ ] Receive an actual phone call during TTS playback — "Paused for a call" still appears correctly
- [ ] CI build passes

Generated with [Claude Code](https://claude.com/claude-code)