### PR TITLE
fix(voices): flip SUPERTONIC_ENABLED gate to true (#1236)

### DIFF
--- a/core-playback/src/main/kotlin/in/jphe/storyvox/playback/voice/VoiceCatalog.kt
+++ b/core-playback/src/main/kotlin/in/jphe/storyvox/playback/voice/VoiceCatalog.kt
@@ -25,7 +25,7 @@ object VoiceCatalog {
      * gated (#1202) — an empty "coming" family card in a shipped app is
      * confusing. One flag flip re-enables both the voices and the card.
      */
-    internal const val SUPERTONIC_ENABLED = false
+    internal const val SUPERTONIC_ENABLED = true
 
     /**
      * The static catalog — Piper, Kokoro, and Kitten entries that ship


### PR DESCRIPTION
## Summary

- Supertonic 3 voices don't appear in Settings > Voices despite the engine being fully wired since v1.2.0 (#1191)
- Root cause: `VoiceCatalog.SUPERTONIC_ENABLED` was never flipped from `false` to `true` when the engine PR landed
- Fix: one-line `false` → `true`

## Test plan
- [ ] Open Voices screen — Supertonic 3 family card appears
- [ ] Select a Supertonic voice — playback works
- [ ] CI build passes

Generated with [Claude Code](https://claude.com/claude-code)