### PR TITLE
fix(ui): ellipsis on clipping text + theme-aware voice avatar monogram

### DIFF
--- a/core-ui/src/main/kotlin/in/jphe/storyvox/ui/component/BrandedCoverTile.kt
+++ b/core-ui/src/main/kotlin/in/jphe/storyvox/ui/component/BrandedCoverTile.kt
@@ -22,6 +22,7 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.drawscope.Stroke
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import `in`.jphe.storyvox.ui.theme.BrassRamp
@@ -156,6 +157,7 @@ fun BrandedCoverTile(
                     color = MaterialTheme.colorScheme.onSurface,
                     textAlign = TextAlign.Center,
                     maxLines = 3,
+                    overflow = TextOverflow.Ellipsis,
                 )
                 if (!author.isNullOrBlank()) {
                     Spacer(modifier = Modifier.height(8.dp))
@@ -169,6 +171,7 @@ fun BrandedCoverTile(
                         color = brass,
                         textAlign = TextAlign.Center,
                         maxLines = 1,
+                        overflow = TextOverflow.Ellipsis,
                     )
                 }
             }

--- a/core-ui/src/main/kotlin/in/jphe/storyvox/ui/component/ChapterCard.kt
+++ b/core-ui/src/main/kotlin/in/jphe/storyvox/ui/component/ChapterCard.kt
@@ -178,6 +178,7 @@ fun ChapterCard(
                     stripChapterPrefix(state.title),
                     style = MaterialTheme.typography.titleMedium,
                     maxLines = 2,
+                    overflow = TextOverflow.Ellipsis,
                 )
                 // Issue #1189 — content preview. Sits between the title and
                 // the published·duration metadata so the visual order is

--- a/core-ui/src/main/kotlin/in/jphe/storyvox/ui/component/ErrorBlock.kt
+++ b/core-ui/src/main/kotlin/in/jphe/storyvox/ui/component/ErrorBlock.kt
@@ -20,6 +20,7 @@ import androidx.compose.ui.semantics.LiveRegionMode
 import androidx.compose.ui.semantics.liveRegion
 import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import `in`.jphe.storyvox.ui.theme.LibraryNocturneTheme
@@ -147,6 +148,7 @@ fun ErrorBlock(
                         style = MaterialTheme.typography.bodySmall,
                         color = MaterialTheme.colorScheme.onErrorContainer.copy(alpha = 0.85f),
                         maxLines = 2,
+                        overflow = TextOverflow.Ellipsis,
                     )
                 }
                 if (onRetry != null) {

--- a/feature/src/main/kotlin/in/jphe/storyvox/feature/follows/FollowsScreen.kt
+++ b/feature/src/main/kotlin/in/jphe/storyvox/feature/follows/FollowsScreen.kt
@@ -30,6 +30,7 @@ import androidx.compose.ui.semantics.contentDescription
 import androidx.compose.ui.semantics.onClick
 import androidx.compose.ui.semantics.role
 import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
@@ -355,7 +356,7 @@ private fun FollowCard(follow: UiFollow, onClick: () -> Unit) {
                 modifier = Modifier.size(width = 56.dp, height = 84.dp),
             )
             Column(modifier = Modifier.weight(1f)) {
-                Text(follow.fiction.title, style = MaterialTheme.typography.titleMedium, maxLines = 2)
+                Text(follow.fiction.title, style = MaterialTheme.typography.titleMedium, maxLines = 2, overflow = TextOverflow.Ellipsis)
                 Text(follow.fiction.author, style = MaterialTheme.typography.bodySmall, color = MaterialTheme.colorScheme.onSurfaceVariant)
             }
             if (follow.unreadCount > 0) {

--- a/feature/src/main/kotlin/in/jphe/storyvox/feature/library/AddByUrlSheet.kt
+++ b/feature/src/main/kotlin/in/jphe/storyvox/feature/library/AddByUrlSheet.kt
@@ -37,6 +37,7 @@ import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.text.input.ImeAction
 import androidx.compose.ui.text.input.KeyboardCapitalization
 import androidx.compose.ui.text.input.KeyboardType
+import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import `in`.jphe.storyvox.feature.R
 import `in`.jphe.storyvox.feature.api.UiRouteCandidate
@@ -208,6 +209,7 @@ private fun ChooseSourceBody(
         style = MaterialTheme.typography.labelSmall,
         color = MaterialTheme.colorScheme.onSurfaceVariant,
         maxLines = 2,
+        overflow = TextOverflow.Ellipsis,
     )
 
     LazyColumn(

--- a/feature/src/main/kotlin/in/jphe/storyvox/feature/ocr/OcrCaptureScreen.kt
+++ b/feature/src/main/kotlin/in/jphe/storyvox/feature/ocr/OcrCaptureScreen.kt
@@ -47,6 +47,7 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.text.style.TextOverflow
 import androidx.lifecycle.compose.LocalLifecycleOwner
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.semantics.LiveRegionMode
@@ -376,6 +377,7 @@ private fun CapturedPagesList(
                             style = MaterialTheme.typography.bodySmall,
                             color = MaterialTheme.colorScheme.onSurfaceVariant,
                             maxLines = 2,
+                            overflow = TextOverflow.Ellipsis,
                         )
                     }
                     IconButton(onClick = { onRemove(page.index) }, enabled = enabled) {

--- a/feature/src/main/kotlin/in/jphe/storyvox/feature/reader/ReaderView.kt
+++ b/feature/src/main/kotlin/in/jphe/storyvox/feature/reader/ReaderView.kt
@@ -77,6 +77,7 @@ import androidx.compose.ui.semantics.contentDescription
 import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.text.TextLayoutResult
 import androidx.compose.ui.text.input.ImeAction
+import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import `in`.jphe.storyvox.feature.R
 import `in`.jphe.storyvox.feature.api.HighlightMode
@@ -774,12 +775,14 @@ fun ReaderTextView(
                             state.chapterTitle.ifEmpty { "—" },
                             style = MaterialTheme.typography.titleSmall,
                             maxLines = 1,
+                            overflow = TextOverflow.Ellipsis,
                         )
                         Text(
                             state.fictionTitle,
                             style = MaterialTheme.typography.bodySmall,
                             color = MaterialTheme.colorScheme.onSurfaceVariant,
                             maxLines = 1,
+                            overflow = TextOverflow.Ellipsis,
                         )
                     }
                 } else {

--- a/feature/src/main/kotlin/in/jphe/storyvox/feature/techempower/TechEmpowerHomeScreen.kt
+++ b/feature/src/main/kotlin/in/jphe/storyvox/feature/techempower/TechEmpowerHomeScreen.kt
@@ -48,6 +48,7 @@ import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.semantics.Role
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import `in`.jphe.storyvox.data.TechEmpowerLinks
 import `in`.jphe.storyvox.ui.R as UiR
@@ -446,6 +447,7 @@ private fun GuideChip(title: String, onClick: () -> Unit) {
             color = brass,
             textAlign = TextAlign.Center,
             maxLines = 3,
+            overflow = TextOverflow.Ellipsis,
         )
     }
 }

--- a/feature/src/main/kotlin/in/jphe/storyvox/feature/voicelibrary/VoiceLibraryScreen.kt
+++ b/feature/src/main/kotlin/in/jphe/storyvox/feature/voicelibrary/VoiceLibraryScreen.kt
@@ -66,6 +66,8 @@ import androidx.compose.ui.draw.drawBehind
 import androidx.compose.ui.geometry.CornerRadius
 import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.compositeOver
+import androidx.compose.ui.graphics.luminance
 import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.res.stringResource
@@ -1525,6 +1527,19 @@ private fun VoiceAvatar(
 ) {
     val brass = MaterialTheme.colorScheme.primary
     val avatarBg = engineAvatarColor(voice.engineType)
+    // #912 follow-up — the monogram was always Color.White, which fails
+    // contrast on the lighter engine chips in light mode (the brass / plum /
+    // inversePrimary backgrounds composite to a pale fill over the cream
+    // surface). Choose black or white by the chip's effective luminance so the
+    // initial stays legible in every theme. 0.179 is the WCAG relative-
+    // luminance crossover where black and white yield equal contrast.
+    val monogramColor = if (
+        avatarBg.compositeOver(MaterialTheme.colorScheme.surface).luminance() > 0.179f
+    ) {
+        Color.Black
+    } else {
+        Color.White
+    }
     val initial = voice.displayName.firstOrNull()?.uppercaseChar() ?: '?'
     Box(
         modifier = Modifier
@@ -1544,7 +1559,7 @@ private fun VoiceAvatar(
             text = initial.toString(),
             style = MaterialTheme.typography.titleSmall,
             fontWeight = FontWeight.Bold,
-            color = Color.White,
+            color = monogramColor,
         )
     }
 }


### PR DESCRIPTION
## Summary

UI/UX polish pass across the reader, library, browse, voices, and shared `core-ui` surfaces. **No functional changes** — visual only.

Candela's design system is already mature (token ramps, `LocalSpacing` 4dp grid, high-contrast variant #486, WCAG AA pass #477, thorough TalkBack handling), so this targets the *remaining* gaps rather than reworking anything.

## Changes

### Text overflow — clip → ellipsis
Capped `Text` in Compose defaults to `TextOverflow.Clip`: long strings cut mid-word with **no "…" indicator**. Candela pulls titles/authors from 20+ web sources (arbitrary length), so every capped `Text` on dynamic content now pairs `maxLines` with `overflow = TextOverflow.Ellipsis`:

| File | Element |
|---|---|
| `core-ui/ChapterCard` | chapter title |
| `core-ui/ErrorBlock` | banner error message |
| `core-ui/BrandedCoverTile` | fallback-cover title + author |
| `reader/ReaderView` | mini-player chapter title + fiction title |
| `follows/FollowsScreen` | followed-fiction title |
| `ocr/OcrCaptureScreen` | captured-page snippet |
| `techempower/TechEmpowerHomeScreen` | guide-tile title |
| `library/AddByUrlSheet` | pasted URL |

### Voice avatar monogram contrast (light-mode a11y)
`voicelibrary/VoiceLibraryScreen` — the avatar initial was hardcoded `Color.White`. The avatar background is a theme color at 0.75–0.8 alpha; over the light-mode cream surface the brass/plum/inversePrimary chips composite to a pale fill where white fails contrast. It now picks black/white from the chip's *effective* luminance (`compositeOver(surface).luminance()`, WCAG 0.179 crossover), staying legible in dark, light, and high-contrast themes.

## Deliberately left alone
- Fixed short labels (tab labels with `softWrap=false`, counters, "Tap to retry") — never overflow.
- `SettingsScreen` buffer-slider amber/red danger colors — intentional semantic UX, and there's no amber theme token to map to without splitting the pair.
- Reader custom fg/bg color defaults — those are user-chosen data, not chrome.

## Testing
- Module compile check (`:feature:compileDebugKotlin`) from the worktree.
- Visual confirmation of the avatar-monogram change across the 5 engine types is best done on-device once a release APK builds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Long titles, labels, URLs, and messages now truncate cleanly with ellipses instead of overflowing in several screens.
  * Banner error messages are capped to two lines for better readability.
  * Voice avatar initials now use a contrasting text color automatically, improving visibility in light and dark themes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->