### PR TITLE
docs: feature audit — 25 sources, 4 voice families (Supertonic), missing features

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,14 +21,14 @@ Stream chapters from **twenty-five fiction backends** — [Royal Road](https://r
   </picture>
 </div>
 
-> **What just shipped** lives on the [latest release](https://github.com/techempower-org/candela/releases/latest) and in the [changelog](CHANGELOG.md) — both always resolve to the current version, so this line never goes stale. Where Candela is now: **twenty-five fiction backends** behind a plugin-seam architecture (a new backend is ~4 touchpoints — `@SourcePlugin` annotation + KSP-generated Hilt registration); **three in-process neural voice families** (Piper, Kokoro, KittenTTS) plus optional Azure HD cloud voices; **AI chat per fiction** with cross-fiction memory, function calling, and multi-modal image input; a **hybrid reader/audiobook view** that highlights the spoken sentence in brass; **Wear OS** support; and a **TechEmpower-first** home. GPL-3.0 (downstream of the engine, not a posture choice — see [License](#license)).
+> **What just shipped** lives on the [latest release](https://github.com/techempower-org/candela/releases/latest) and in the [changelog](CHANGELOG.md) — both always resolve to the current version, so this line never goes stale. Where Candela is now: **twenty-five fiction backends** behind a plugin-seam architecture (a new backend is ~4 touchpoints — `@SourcePlugin` annotation + KSP-generated Hilt registration); **four in-process neural voice families** (Piper, Kokoro, KittenTTS, Supertonic 3) plus optional Azure HD cloud voices; **AI chat per fiction** with cross-fiction memory, function calling, and multi-modal image input; a **hybrid reader/audiobook view** that highlights the spoken sentence in brass; **Wear OS** support; and a **TechEmpower-first** home. GPL-3.0 (downstream of the engine, not a posture choice — see [License](#license)).
 
 ---
 
 ## What it does
 
 - **Twenty-five fiction backends, side by side.** Browse [Royal Road](https://royalroad.com) with the full filter set (tags include/exclude, status, type, length, rating, content warnings, sort); browse fiction repos on GitHub via the curated [candela-registry](https://github.com/techempower-org/candela-registry) plus live `/search/repositories` results; subscribe to any **RSS / Atom feed** with a managed suggested-feeds list from [candela-feeds](https://github.com/techempower-org/candela-feeds); pull articles from a self-hosted **[Outline](https://www.getoutline.com)** wiki; mount a **[Memory Palace](https://github.com/techempower-org/mempalace)** you host yourself; open **local EPUB files** from any folder via the system file picker; browse **Project Gutenberg's** 70,000+ public-domain books; pull fanfic from **Archive of Our Own** (per-tag feeds + official EPUBs); read **Standard Ebooks'** hand-curated typographically-polished classics; narrate any **Wikipedia** or **Wikisource** article (heading-split chapters; Wikisource walks multi-part works as `/Subpage` chapters); listen to **Radio** with 5 curated stations (KVMR 89.3, Capital Public Radio, KQED 88.5, KCSB 91.9, SomaFM Groove Salad) plus **Radio Browser API** search across 30,000+ stations worldwide; read a **Notion** database (defaults to the techempower.org content DB — paste an integration token and you're in); narrate **Hacker News** top stories + Ask HN / Show HN threads with comments; listen to **arXiv** abstracts in cs.AI and other categories; read **PLOS** open-access peer-reviewed science papers; or pull serialized fiction from **Discord** channels (channels = fictions, messages = chapters, bot-token auth). Open **local PDF files** and **scanned documents** (on-device OCR turns photos and scans into readable text); browse **LibriVox** public-domain human-narrated audiobooks; pull serialized fiction from **Telegram**, **Slack**, and **Matrix** channels; browse **Palace Project** free-library titles; and turn **any web article** into a chapter via Readability extraction. Each backend has its own on/off toggle in **Settings → Plugins** (the plugin manager iterates the registry, so adding a new backend is automatic).
-- **Plays chapters as audiobooks** through an in-process neural TTS engine. **Three voice families ship**: [Piper](https://github.com/rhasspy/piper) (compact, ~14–30 MB per voice), [Kokoro](https://github.com/hexgrad/kokoro) (multi-speaker, ~330 MB total), and **KittenTTS** (lightest tier, ~24 MB shared across 8 en_US speakers — designed for slow devices where Piper struggles). Voice models download on demand from `voices-v2`; nothing is bundled in the APK. No cloud, no API keys, no per-character billing.
+- **Plays chapters as audiobooks** through an in-process neural TTS engine. **Four voice families ship**: [Piper](https://github.com/rhasspy/piper) (compact, ~14–30 MB per voice), [Kokoro](https://github.com/hexgrad/kokoro) (multi-speaker, ~330 MB total), **KittenTTS** (lightest tier, ~24 MB shared across 8 en_US speakers — designed for slow devices where Piper struggles), and **Supertonic 3** (newest — live since v1.2.3, 10 en_US speakers from a ~139 MB shared model). Voice models download on demand from `voices-v2`; nothing is bundled in the APK. No cloud, no API keys, no per-character billing.
 - **Optional cloud voices** — bring-your-own-key [Azure Cognitive Services HD voices](https://learn.microsoft.com/azure/ai-services/speech-service/text-to-speech) for studio-grade narration on slow devices. Offline fallback to the local engine if your key fails or the network drops. Azure is opt-in, never required, never billed by Candela.
 - **Tier 3 multi-engine parallel synthesis.** Run 1–8 VoxSherpa engine instances side-by-side, each with its own thread pool, so a single sentence's chunks render in parallel and the next sentence is already queued before the current one finishes. Twin sliders in **Settings → Performance** (Engines, Threads/engine) let you tune for your CPU. The producer pins to a dedicated `URGENT_AUDIO` thread to keep audio scheduling honest under load.
 - **Highlights the current sentence** in brass as the engine speaks. Swipe between audiobook view (cover, scrubber, transport) and reader view (chapter text). The highlight glides between sentences to match the read-aloud rhythm.
@@ -41,6 +41,12 @@ Stream chapters from **twenty-five fiction backends** — [Royal Road](https://r
 - **Voice library with tiers and favorites.** Engine-grouped picker, star toggles for the voices you keep coming back to, and a Starred surface that floats them to the top.
 - **Sleep timer** with 15/30/45/60-minute presets, an "end of chapter" mode, a countdown pulse as time runs out, and shake-to-extend during the fade-out tail (#150).
 - **Smart-resume CTA** — the Library "Resume" button respects your last paused/playing intent so it never auto-plays at you when you opened the app to *read*.
+- **Highlights & notes.** Long-press to select text in the reader, pick a colour, and attach a note — highlights persist and sync, and tapping a saved one lets you edit or remove it. Plus **find-in-chapter** search with next/previous match, and **chapter previews** (a body-text snippet in the chapter list).
+- **Library shelves & sort.** Built-in **Reading / Read / Wishlist** shelves (a book can sit on several at once), and sort the library by title, author, recently added, recently played, or longest-unread.
+- **Make your own audiobook.** Export any fiction to a chaptered `.m4b` with per-chapter markers, rendered through your chosen neural voice — play it in any audiobook app. EPUB export too.
+- **Now-Playing home-screen widget** — play/pause, next, and the sleep timer straight from your launcher (1×1 / 4×1 / 4×2 sizes).
+- **Bedtime auto-sleep + Do Not Disturb.** The sleep timer can auto-arm when your phone enters Bedtime mode, and optionally silence notifications while it runs.
+- **First-run onboarding** — a three-screen welcome (intro → voice picker → first fiction) gets newcomers listening in under a minute.
 - **Library + Follows tabs** with sign-in via WebView (your Royal Road follow list syncs into the app).
 - **Infinite-scroll Browse** across every tab.
 - **Cheap polling for new chapters.** GitHub-sourced fictions watch the repo's HEAD SHA; the manifest is only re-scanned when something changes — one HTTP request per fiction per check.
@@ -163,7 +169,7 @@ The CI workflow (`.github/workflows/android.yml`) shows the canonical build step
       │               │  in-process)   │
       ▼               │                ▼
 ┌─────────────────────────────┐  ┌──────────────────────┐
-│ Fiction sources (21)        │  │ :core-sync           │
+│ Fiction sources (25)        │  │ :core-sync           │
 │ ─────────────────────────── │  │ InstantDB sync —     │
 │ :source-royalroad           │  │ library / follows /  │
 │ :source-github              │  │ positions / book-    │
@@ -191,6 +197,12 @@ The CI workflow (`.github/workflows/android.yml`) shows the canonical build step
 │ ─────────────────────────── │
 │ :source-readability         │
 │ :source-epub-writer         │
+│ :source-audiobook-writer    │
+│                             │
+│ Local files (v1.1.0):       │
+│ :source-pdf                 │
+│ :source-ocr                 │
+│ :source-librivox            │
 │                             │
 │ TTS backends                │
 │ ─────────────────────────── │
@@ -200,7 +212,7 @@ The CI workflow (`.github/workflows/android.yml`) shows the canonical build step
                    (audio out)
 ```
 
-34 Gradle modules now (was 13 at v0.4.x; 29 at v0.5.38). Fiction sources implement `FictionSource` from `:core-data` and self-register via the `@SourcePlugin` annotation; the `:core-plugin-ksp` KSP processor emits a Hilt `@IntoSet` factory per annotated class, so `SourcePluginRegistry` discovers them at startup. Adding a new backend is ~4 touchpoints today (was ~17 pre-Phase-2). The playback layer is independent of the UI; the local engine library is a single transitive dep on `:core-playback`. AI chat lives in its own `:core-llm` module — the seven-provider matrix shares one `ChatStreamEvent` flow type that carries text deltas + tool-call events + tool-result events end-to-end. Cross-device sync lives in `:core-sync` against InstantDB. A `:baselineprofile` producer module (UI Automator hot-path walk) emits `baseline-prof.txt` for the AndroidX Baseline Profile plugin — cold launch dropped 6.7 s → 0.8 s on Tab A7 Lite (v0.5.46).
+38 Gradle modules now (was 13 at v0.4.x; 29 at v0.5.38). Fiction sources implement `FictionSource` from `:core-data` and self-register via the `@SourcePlugin` annotation; the `:core-plugin-ksp` KSP processor emits a Hilt `@IntoSet` factory per annotated class, so `SourcePluginRegistry` discovers them at startup. Adding a new backend is ~4 touchpoints today (was ~17 pre-Phase-2). The playback layer is independent of the UI; the local engine library is a single transitive dep on `:core-playback`. AI chat lives in its own `:core-llm` module — the seven-provider matrix shares one `ChatStreamEvent` flow type that carries text deltas + tool-call events + tool-result events end-to-end. Cross-device sync lives in `:core-sync` against InstantDB. A `:baselineprofile` producer module (UI Automator hot-path walk) emits `baseline-prof.txt` for the AndroidX Baseline Profile plugin — cold launch dropped 6.7 s → 0.8 s on Tab A7 Lite (v0.5.46).
 
 Design specs (each shipped or in flight) read as a thread:
 
@@ -224,7 +236,7 @@ Per-dreamer detail specs live in `scratch/dreamers/`.
 | Storage | Room, DataStore Preferences, EncryptedSharedPreferences |
 | Networking | OkHttp + Jsoup (RR is HTML, not JSON) + commonmark (GitHub markdown) |
 | Playback | Media3 SimpleBasePlayer + custom AudioTrack pipeline + Tier 3 multi-engine producer |
-| TTS (local) | VoxSherpa-TTS engine-lib (Piper + Kokoro on sherpa-onnx) — in-process |
+| TTS (local) | VoxSherpa-TTS engine-lib (Piper + Kokoro + KittenTTS + Supertonic on sherpa-onnx) — in-process |
 | TTS (cloud, optional) | Azure Cognitive Services HD voices (BYOK) with offline fallback |
 | Async | Coroutines + Flow |
 | Wear OS | Compose for Wear, `play-services-wearable` |

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -11,9 +11,10 @@ Last refreshed for **v1.1.5** (AGP 9 migration + deprecation cleanup). Prior maj
 
 ## Shipped in the v0.5 line
 
-The full v0.5 line landed the bulk of the user-visible surface — twenty-one fiction
-backends, three voice families, the AI chat heavies, performance work that hit the
-0.8 s cold-launch target, the a11y pass, and the TechEmpower repositioning.
+The v0.5 line landed the bulk of the user-visible surface, and the v1.x line has since
+carried it to **twenty-five fiction backends** and **four voice families** — plus the
+AI chat heavies, performance work that hit the 0.8 s cold-launch target, the a11y
+pass, and the TechEmpower repositioning.
 
 ### Voice + audio
 - [x] **KittenTTS** lightest-tier voice family (v0.5.36, [#119](https://github.com/techempower-org/candela/issues/119)) — ~24 MB shared across 8 en_US speakers, "first chapter in 10 seconds" on slow devices
@@ -59,6 +60,29 @@ backends, three voice families, the AI chat heavies, performance work that hit t
 - [x] **17 → 21 fiction backends** — Telegram + Palace + Slack + Matrix (v0.5.51) on top of Hacker News, arXiv, PLOS, Discord, Wikisource, Radio Browser (v0.5.38)
 - [x] **`@SourcePlugin` annotation + KSP processor** (v0.5.27) — adding a backend is ~4 touchpoints; Plugin manager auto-discovers
 - [x] **Plugin manager Settings hub** — brass-edged card grid iterating the registry
+
+---
+
+## Shipped in the v1.x line
+
+The v1.x line broadened sources, added a fourth voice family, and filled in the reading surface.
+
+### Sources & voices
+- [x] **OCR, PDF, and LibriVox sources** (v1.1.0) — on-device scan-to-read (ML Kit), local PDF read-aloud, and public-domain human-narrated audiobooks; the roster reaches **25 fiction backends**
+- [x] **Supertonic 3 voice family** — engine wired v1.2.0 ([#1191](https://github.com/techempower-org/candela/issues/1191)), voices enabled v1.2.3, models hosted v1.2.4 ([#1236](https://github.com/techempower-org/candela/issues/1236)); 10 en_US speakers, the fourth in-process family
+- [x] **KittenTTS v0.8 voices** (v1.1.5) — clearer nano models with named speakers
+
+### Reading & library
+- [x] **In-reader highlights & notes** (v1.1.3, [#1079](https://github.com/techempower-org/candela/issues/1079)) — long-press select, pick a colour, optional note; persists and syncs
+- [x] **Find-in-chapter search** + **chapter previews** (v1.2.0)
+- [x] **Library shelves & sort** — Reading / Read / Wishlist (many-to-many) + five sort modes ([#793](https://github.com/techempower-org/candela/issues/793))
+- [x] **Make-your-own-audiobook** — chaptered `.m4b` export ([#1003](https://github.com/techempower-org/candela/issues/1003)); plus EPUB export
+
+### Playback & extras
+- [x] **Bedtime auto-sleep** (v1.1.4) + **auto Do Not Disturb with the sleep timer** (v1.2.0)
+- [x] **Now-Playing home-screen widget** — play/pause, next, sleep from the launcher
+- [x] **First-run onboarding** (v1.0, [#599](https://github.com/techempower-org/candela/issues/599)) — three-screen welcome
+- [x] **Play Store readiness** (v1.1.6 / v1.2.0) — accessibility statement, content reporting, compliance polish
 
 ---
 

--- a/docs/VOICES.md
+++ b/docs/VOICES.md
@@ -2,9 +2,9 @@
 
 ## Where voices come from
 
-Candela embeds the [VoxSherpa-TTS](https://github.com/techempower-org/VoxSherpa-TTS) engine via JitPack, which itself wraps [k2-fsa/sherpa-onnx](https://github.com/k2-fsa/sherpa-onnx) for the actual ONNX inference. The neural model weights — Piper voices, the multi-speaker Kokoro model, and the **KittenTTS** lightest-tier model (shipped v0.5.36) — are not bundled in the APK (they'd add 1+ GB) but downloaded on demand by `VoiceManager` from the `voices-v2` GitHub release on `techempower-org/VoxSherpa-TTS`.
+Candela embeds the [VoxSherpa-TTS](https://github.com/techempower-org/VoxSherpa-TTS) engine via JitPack, which itself wraps [k2-fsa/sherpa-onnx](https://github.com/k2-fsa/sherpa-onnx) for the actual ONNX inference. The neural model weights — Piper voices, the multi-speaker Kokoro model, the **KittenTTS** lightest-tier model (shipped v0.5.36), and the **Supertonic 3** model (live v1.2.3) — are not bundled in the APK (they'd add 1+ GB) but downloaded on demand by `VoiceManager` from the `voices-v2` GitHub release on `techempower-org/VoxSherpa-TTS`.
 
-Three voice families ship today: **Piper** (compact, ~14–30 MB per voice), **Kokoro** (multi-speaker, ~330 MB shared), and **KittenTTS** (~24 MB shared across 8 en_US speakers — the "first chapter in 10 seconds" tier for slow devices).
+Four voice families ship today: **Piper** (compact, ~14–30 MB per voice), **Kokoro** (multi-speaker, ~330 MB shared), **KittenTTS** (~24 MB shared across 8 en_US speakers — the "first chapter in 10 seconds" tier for slow devices), and **Supertonic 3** (newest, live since v1.2.3 — 10 en_US speakers from a ~139 MB shared model).
 
 `voices-v2` is a re-hosting of the upstream k2-fsa tarballs as flat, single-file downloads. Each Piper voice ships as `{lang}-{voice}-{quality}.onnx` + `{lang}-{voice}-{quality}.tokens.txt`. Kokoro ships as `kokoro-model.onnx` + `kokoro-voices.bin` + `kokoro-tokens.txt`. The flattening is deliberate: extracting `.tar.bz2` archives on modest hardware (Tab A7 Lite) is slow enough to delay the first chapter for tens of seconds. Doing it once server-side and serving plain files moves that cost off the device.
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -47,7 +47,7 @@ Candela is **thirty-eight Gradle modules** (up from 13 at v0.4.x; 29 at v0.5.38)
       │               │  in-process)   │
       ▼               │                ▼
 ┌─────────────────────────────┐  ┌──────────────────────┐
-│ Fiction sources (21)        │  │ :core-sync           │
+│ Fiction sources (25)        │  │ :core-sync           │
 │ ─────────────────────────── │  │ InstantDB sync —     │
 │ :source-royalroad           │  │ library / follows /  │
 │ :source-github              │  │ positions / book-    │
@@ -75,6 +75,12 @@ Candela is **thirty-eight Gradle modules** (up from 13 at v0.4.x; 29 at v0.5.38)
 │ ─────────────────────────── │  │ → 0.8 s on Tab A7    │
 │ :source-readability         │  │ Lite                 │
 │ :source-epub-writer         │  └──────────────────────┘
+│ :source-audiobook-writer    │
+│                             │
+│ Local files (v1.1.0):       │
+│ :source-pdf                 │
+│ :source-ocr                 │
+│ :source-librivox            │
 │                             │
 │ TTS backends                │
 │ ─────────────────────────── │

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: Candela — TechEmpower's accessible resource app, with audiobook everything
-description: TechEmpower's accessible resource app — free tech guides, peer-support Discord, dial 211 for local help. Under the hood, a neural-voice audiobook player for twenty-five fiction backends with three in-process voice families plus optional Azure HD cloud voices. Free, GPL-3.0, no telemetry.
+description: TechEmpower's accessible resource app — free tech guides, peer-support Discord, dial 211 for local help. Under the hood, a neural-voice audiobook player for twenty-five fiction backends with four in-process voice families plus optional Azure HD cloud voices. Free, GPL-3.0, no telemetry.
 image: /screenshots/03-reader.png
 ---
 
@@ -71,7 +71,7 @@ image: /screenshots/03-reader.png
     <div class="card">
       <h3>On-device neural TTS</h3>
       <p>
-        Three voice families ship — <a href="https://github.com/rhasspy/piper">Piper</a> (compact),
+        Four voice families ship — <a href="https://github.com/rhasspy/piper">Piper</a> (compact),
         <a href="https://github.com/hexgrad/kokoro">Kokoro</a> (multi-speaker), and
         <strong>KittenTTS</strong> (lightest tier, designed for slow devices). Voices download
         once, then live on-device. No cloud, no API keys, no per-character billing.
@@ -250,11 +250,31 @@ image: /screenshots/03-reader.png
       <h3>Matrix</h3>
       <p>Federated open-standard chat (matrix.org, kde.org, FOSDEM, self-hosted Synapse / Dendrite / Conduit) — rooms are fictions, messages are chapters with same-sender coalescing.</p>
     </a>
+    <a class="source-card" href="https://librivox.org">
+      <span class="source-glyph" aria-hidden="true">LV</span>
+      <h3>LibriVox</h3>
+      <p>Public-domain audiobooks read by volunteers — streamed as real human narration (not TTS). Thousands of classic titles.</p>
+    </a>
+    <a class="source-card">
+      <span class="source-glyph" aria-hidden="true">PDF</span>
+      <h3>Local PDF</h3>
+      <p>Open a PDF from your device and have its text read aloud, page by page.</p>
+    </a>
+    <a class="source-card">
+      <span class="source-glyph" aria-hidden="true">OCR</span>
+      <h3>Scanned text (OCR)</h3>
+      <p>Point your camera at a page — on-device ML Kit turns the photo into narrated text. Nothing leaves the phone.</p>
+    </a>
+    <a class="source-card">
+      <span class="source-glyph" aria-hidden="true">URL</span>
+      <h3>Any web article</h3>
+      <p>Paste any link — Readability extraction turns an arbitrary web page into a single-chapter fiction. No URL is a dead-end.</p>
+    </a>
   </div>
 </section>
 
 <section class="voices">
-  <h2>Three voice families, all on-device</h2>
+  <h2>Four voice families, all on-device</h2>
   <p class="muted">
     Voices download on demand from the <code>voices-v2</code> release; nothing is bundled in the APK.
     The voice picker shows what's installed and what's available. <a href="voices/">Full voice catalog →</a>
@@ -403,7 +423,7 @@ image: /screenshots/03-reader.png
   <p>
     <strong>Where Candela is now:</strong> <strong>twenty-five fiction backends</strong> behind a
     plugin-seam architecture (a new backend is ~4 touchpoints — a <code>@SourcePlugin</code> annotation
-    plus KSP-generated Hilt registration); <strong>three in-process neural voice families</strong>
+    plus KSP-generated Hilt registration); <strong>four in-process neural voice families</strong>
     (Piper, Kokoro, KittenTTS) plus optional Azure HD cloud voices; a full <strong>PCM cache</strong>
     pipeline for glitch-free playback; a <strong>hybrid reader/audiobook view</strong> that highlights
     the spoken sentence in brass; <strong>Wear OS</strong> support; <strong>cross-device InstantDB

--- a/docs/index.md
+++ b/docs/index.md
@@ -424,7 +424,7 @@ image: /screenshots/03-reader.png
     <strong>Where Candela is now:</strong> <strong>twenty-five fiction backends</strong> behind a
     plugin-seam architecture (a new backend is ~4 touchpoints — a <code>@SourcePlugin</code> annotation
     plus KSP-generated Hilt registration); <strong>four in-process neural voice families</strong>
-    (Piper, Kokoro, KittenTTS) plus optional Azure HD cloud voices; a full <strong>PCM cache</strong>
+    (Piper, Kokoro, KittenTTS, Supertonic 3) plus optional Azure HD cloud voices; a full <strong>PCM cache</strong>
     pipeline for glitch-free playback; a <strong>hybrid reader/audiobook view</strong> that highlights
     the spoken sentence in brass; <strong>Wear OS</strong> support; <strong>cross-device InstantDB
     sync</strong>; an accessibility-first design (high-contrast brass-on-near-black, reduced-motion,

--- a/docs/privacy.md
+++ b/docs/privacy.md
@@ -235,8 +235,9 @@ You have the right to:
   InstantDB sync record (you can view via the sync settings screen).
 - **Delete your data.** Uninstall the app to delete on-device data; sign
   out of sync to delete the InstantDB record.
-- **Export your data.** EPUB export of your library is on the roadmap;
-  contact us if you need an export today.
+- **Export your data.** Per-fiction EPUB and chaptered `.m4b` audiobook
+  export shipped in the v1.x line; contact us if you need a full export
+  of your account data.
 - **Contact us with privacy questions** at the contact address listed at
   the top of this document.
 

--- a/docs/sync.md
+++ b/docs/sync.md
@@ -1,6 +1,6 @@
 # Cloud sync (InstantDB)
 
-Candela v0.6 introduces cloud sync via [InstantDB](https://www.instantdb.com).
+Candela introduces cloud sync via [InstantDB](https://www.instantdb.com) (shipped in v0.5.12).
 The goal: a reinstall (or accidental `adb uninstall`) doesn't wipe your
 library, follows, reading positions, bookmarks, pronunciation dictionary,
 or your AI keys. Sign in on a new device → everything comes back.

--- a/docs/voices.md
+++ b/docs/voices.md
@@ -1,16 +1,17 @@
 ---
 layout: default
 title: Voice catalog
-description: Three in-process voice families (Piper, Kokoro, KittenTTS) plus optional Azure HD cloud voices. Sizes, quality tiers, refresh workflow, and why we don't quantize.
+description: Four in-process voice families (Piper, Kokoro, KittenTTS, Supertonic 3) plus optional Azure HD cloud voices. Sizes, quality tiers, refresh workflow, and why we don't quantize.
 ---
 
 # Voice catalog
 
-Candela ships **three local voice families**, with an **optional cloud backend** wired in for users who want studio-grade narration on slow devices:
+Candela ships **four local voice families**, with an **optional cloud backend** wired in for users who want studio-grade narration on slow devices:
 
 - **[Piper](https://github.com/rhasspy/piper)** *(local, in-process)* — single-speaker, compact, fast. Each voice is ~14–30 MB. Best for first-time installs and for fast turnaround on slow hardware.
 - **[Kokoro](https://github.com/hexgrad/kokoro)** *(local, in-process)* — multi-speaker, ~330 MB single download, ships dozens of voice profiles in one model. Higher quality, slower to synthesize.
 - **KittenTTS** *(local, in-process — shipped v0.5.36, [#119](https://github.com/techempower-org/candela/issues/119))* — the lightest tier, ~24 MB shared across 8 en_US speakers. Designed for slow devices where Piper-high struggles. The "first chapter in 10 seconds" voice family.
+- **Supertonic 3** *(local, in-process — newest, live since v1.2.3, [#1191](https://github.com/techempower-org/candela/issues/1191))* — 10 en_US speakers (5 female, 5 male) from a ~139 MB shared model. The newest neural family; a step up in naturalness for modern devices.
 - **[Azure Cognitive Services HD voices](https://learn.microsoft.com/azure/ai-services/speech-service/text-to-speech)** *(cloud, BYOK)* — opt-in, paid by you to Microsoft, never by Candela. Studio-grade narration with offline fallback to a local voice if your key fails or the network drops. See [Cloud voices](#cloud-voices-azure-hd-byok) below.
 
 Local voices run **in-process** via the [VoxSherpa-TTS](https://github.com/techempower-org/VoxSherpa-TTS) `:engine-lib` AAR, which wraps [k2-fsa/sherpa-onnx](https://github.com/k2-fsa/sherpa-onnx) for inference. No second APK, no system-TTS handoff, no per-character billing.


### PR DESCRIPTION
## Documentation feature audit

Audits **all current Candela features** against shipped **v1.2.5** and brings the docs site + README back in line. The GitHub **wiki** hand-authored pages were updated and pushed separately (the wiki is a different repo and can't ride a PR); the wiki's auto-generated pages (Architecture, Roadmap, Cloud-sync) pick up these `docs/` changes via `wiki-sync.yml` on merge.

### What was wrong
- README + `docs/architecture.md` diagrams said **21 fiction sources / 34 modules** — actual is **25 / 38**.
- **OCR, PDF, and LibriVox** (shipped v1.1.0) were absent from the landing-page source grid and the architecture source list.
- Everything said **"three voice families"** — **Supertonic 3** shipped as a fourth local family (engine v1.2.0, voices live v1.2.3, models hosted v1.2.4).
- A cluster of features was undocumented anywhere: **highlights & notes, find-in-chapter, chapter previews, library shelves & sort, add-by-URL, `.m4b` audiobook export, EPUB export, the Now-Playing widget, bedtime auto-sleep + DND, and first-run onboarding**.
- `docs/sync.md` opened with a never-shipped **"v0.6"** label (sync shipped v0.5.12); `docs/privacy.md` called EPUB export "on the roadmap" (it shipped).

### Changes (docs-only)
- **README** — 4 voice families incl. Supertonic 3; architecture diagram 21→25 sources / 34→38 modules + `:source-audiobook-writer` / PDF / OCR / LibriVox; new feature bullets for the previously-undocumented features.
- **docs/architecture.md** — 25 fiction sources; writers + local-file sources in the module map.
- **docs/voices.md + docs/VOICES.md** — Supertonic 3 as the fourth local family.
- **docs/ROADMAP.md** — new "Shipped in the v1.x line" section; summary now 25 sources / 4 families.
- **docs/index.md** — four voice families; +LibriVox / PDF / OCR / "Any web article" source cards (grid now matches the stated 25).
- **docs/sync.md** — drop the "v0.6" label.
- **docs/privacy.md** — EPUB + `.m4b` export shipped.

### Wiki (already pushed to `candela.wiki`)
Fiction-sources (25 + LibriVox/OCR/PDF + rebranded `storyvox-*`→`candela-*` repos), Voices + Voice-catalog (Supertonic; 136 voices / 5 engines + a Supertonic ID table), Getting-started, Settings-reference (DND + bedtime), Building-from-source (38 modules, Gradle 9.6.1, SDK 37, fixed `adb` applicationId), two **new pages** (Reading-and-library, Export-and-extras), and a `_Sidebar`.

No code touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
