### PR TITLE
fix(ao3): use monotonic clock in rate limiter (#1219)

### DIFF
--- a/source-ao3/src/main/kotlin/in/jphe/storyvox/source/ao3/net/Ao3RateLimitInterceptor.kt
+++ b/source-ao3/src/main/kotlin/in/jphe/storyvox/source/ao3/net/Ao3RateLimitInterceptor.kt
@@ -41,12 +41,24 @@ internal class Ao3RateLimitInterceptor @Inject constructor() : Interceptor {
 
     private val lock = Any()
 
-    @Volatile
+    /**
+     * Monotonic-clock millis ([System.nanoTime] / 1_000_000) of the last
+     * request's start. Guarded by [lock]; no `@Volatile` is needed because
+     * every read and write happens inside the `synchronized` block.
+     */
     private var lastRequestAt: Long = 0L
 
     override fun intercept(chain: Interceptor.Chain): Response {
         synchronized(lock) {
-            val now = System.currentTimeMillis()
+            // Monotonic clock (issue #1219): System.nanoTime() is immune to
+            // wall-clock jumps (NTP steps, manual time changes). With a
+            // non-monotonic source — the old System.currentTimeMillis() — a
+            // backward adjustment could make `wait` enormous and freeze this
+            // dispatcher thread inside Thread.sleep. Only deltas between
+            // nanoTime() reads are meaningful, so we keep the field in millis
+            // and the sleep math unchanged. Monotonicity also structurally
+            // bounds `wait` to at most MIN_REQUEST_INTERVAL_MS.
+            val now = System.nanoTime() / 1_000_000
             val wait = (lastRequestAt + MIN_REQUEST_INTERVAL_MS) - now
             if (wait > 0) {
                 try {
@@ -57,7 +69,7 @@ internal class Ao3RateLimitInterceptor @Inject constructor() : Interceptor {
                     Thread.currentThread().interrupt()
                 }
             }
-            lastRequestAt = System.currentTimeMillis()
+            lastRequestAt = System.nanoTime() / 1_000_000
         }
         return chain.proceed(chain.request())
     }


### PR DESCRIPTION
Fixes #1219.

## Problem
`Ao3RateLimitInterceptor` computed its inter-request wait from `System.currentTimeMillis()` — a **wall clock**. A backward clock adjustment (NTP step, manual time change) between the `now` read and the stored `lastRequestAt` could make `wait = (lastRequestAt + MIN_REQUEST_INTERVAL_MS) - now` enormous, freezing the OkHttp dispatcher thread inside `Thread.sleep(wait)`.

## Fix
- Switch both timestamp reads to `System.nanoTime()` (monotonic, immune to wall-clock jumps). The field and sleep math stay in **milliseconds** by dividing the nanos by `1_000_000`, so `Thread.sleep(wait)` is unchanged and `MIN_REQUEST_INTERVAL_MS` keeps its units. Only deltas between `nanoTime()` reads are meaningful, which is exactly how the value is used.
- Because a monotonic clock guarantees `now >= lastRequestAt`, `wait` is now **structurally bounded** to at most `MIN_REQUEST_INTERVAL_MS` (1000 ms) — the enormous-wait freeze becomes impossible, not just unlikely.
- Drop the redundant `@Volatile` on `lastRequestAt`: every read and write already happens inside the `synchronized(lock)` block, which provides the necessary visibility.

## Testing
No unit tests reference this interceptor (no timing assumptions to update). Push lets CI's `Build APK` job be the compile gate per project convention. Behavior is unchanged in the normal case; the only difference is immunity to non-monotonic clock movement.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved request pacing for AO3 by using a monotonic clock, making rate limiting more reliable even if the device clock changes.
  * Kept the same waiting behavior for back-to-back requests, with no change to user-visible workflow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->