### PR TITLE
fix(sync): guard signOut with NonCancellable (#1217)

### DIFF
--- a/feature/src/main/kotlin/in/jphe/storyvox/feature/sync/SyncAuthViewModel.kt
+++ b/feature/src/main/kotlin/in/jphe/storyvox/feature/sync/SyncAuthViewModel.kt
@@ -9,10 +9,12 @@ import `in`.jphe.storyvox.sync.client.SignedInUser
 import `in`.jphe.storyvox.sync.client.SyncAuthResult
 import `in`.jphe.storyvox.sync.coordinator.SyncCoordinator
 import javax.inject.Inject
+import kotlinx.coroutines.NonCancellable
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
 
 /**
  * UI state machine for the sync sign-in screen.
@@ -141,6 +143,14 @@ class SyncAuthViewModel @Inject constructor(
      * policy's email-request path backstops a failed cloud delete. Local
      * on-device library/positions are intentionally kept — see
      * [SyncCoordinator]'s class kdoc.
+     *
+     * Issue #1217 — the local wipe ([InstantSession.clear] + the state
+     * reset) runs in a [NonCancellable] `finally`, so a cancellation of
+     * this coroutine mid-purge (e.g. the ViewModel being cleared as the
+     * user navigates away) can't strand a half-signed-out state where the
+     * cloud record is gone but the device still holds the now-revoked
+     * token and renders as signed-in. The cloud-side calls stay
+     * cancellable (they're best-effort); only the local wipe is guarded.
      */
     fun signOut() {
         val current = session.current() ?: run {
@@ -148,10 +158,18 @@ class SyncAuthViewModel @Inject constructor(
             return
         }
         viewModelScope.launch {
-            coordinator.purgeRemoteData(current) // #1139 delete cloud data while token is valid
-            client.signOut(current.refreshToken) // best-effort; ignored on failure
-            session.clear()
-            _state.value = SignInState.SignedOut(email = "")
+            try {
+                coordinator.purgeRemoteData(current) // #1139 delete cloud data while token is valid
+                client.signOut(current.refreshToken) // best-effort; ignored on failure
+            } finally {
+                // #1217 — local wipe must complete even if the coroutine is
+                // cancelled during the cloud purge above, or we leave a
+                // half-signed-out state.
+                withContext(NonCancellable) {
+                    session.clear()
+                    _state.value = SignInState.SignedOut(email = "")
+                }
+            }
         }
     }
 


### PR DESCRIPTION
## Problem

In `SyncAuthViewModel.signOut()`, the `viewModelScope` coroutine ran its cleanup sequence unguarded. If the coroutine is cancelled mid sign-out (user navigates away, ViewModel cleared) **after** the cloud purge but **before** `session.clear()`, the local wipe is skipped — leaving the user half-signed-out: the InstantDB record is already deleted but the device still holds the now-revoked refresh token and renders as signed-in.

Found by Gemini code review on #1194, verified REAL by Drift audit, unaddressed on `main`.

## Fix

Wrap the local wipe (`session.clear()` + the `SignedOut` state reset) in a `finally { withContext(NonCancellable) { … } }` block, so cancellation during the cloud-side purge can't strand a half-signed-out state.

The cloud-side calls (`coordinator.purgeRemoteData`, `client.signOut`) stay **cancellable** — they're best-effort by design (the privacy-policy email path backstops a failed cloud delete, and a forgotten token expires server-side). Only the local wipe is guarded.

```kotlin
viewModelScope.launch {
    try {
        coordinator.purgeRemoteData(current) // #1139 delete cloud data while token is valid
        client.signOut(current.refreshToken) // best-effort; ignored on failure
    } finally {
        withContext(NonCancellable) {   // #1217
            session.clear()
            _state.value = SignInState.SignedOut(email = "")
        }
    }
}
```

The `#1139` ordering invariant (purge runs first, while the token is valid) is preserved — the cloud calls keep their original order inside the `try`.

## Test plan

- No behavioral change on the happy path; pure cancellation-safety guard.
- Compile gate: CI `Build APK` (no local gradle per project policy).

Closes #1217

🤖 Generated with [Claude Code](https://claude.com/claude-code)