### PR TITLE
perf(fiction): move chapter preview transform off Main thread (#1220)

### DIFF
--- a/core-data/src/main/kotlin/in/jphe/storyvox/data/repository/ChapterRepository.kt
+++ b/core-data/src/main/kotlin/in/jphe/storyvox/data/repository/ChapterRepository.kt
@@ -6,8 +6,10 @@ import `in`.jphe.storyvox.data.db.entity.ChapterDownloadState
 import `in`.jphe.storyvox.data.repository.playback.PlaybackChapter
 import `in`.jphe.storyvox.data.source.model.ChapterContent
 import `in`.jphe.storyvox.data.source.model.ChapterInfo
+import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.distinctUntilChanged
+import kotlinx.coroutines.flow.flowOn
 import kotlinx.coroutines.flow.map
 import javax.inject.Inject
 import javax.inject.Singleton
@@ -165,6 +167,13 @@ class ChapterRepositoryImpl @Inject constructor(
             // dedupe so an unrelated row write doesn't re-push an identical
             // map down the combine in [chaptersFor].
             .distinctUntilChanged()
+            // Issue #1220 — chapterPreviewText (heavy regex + HTML-decode)
+            // runs over every chapter in the .map above; without flowOn it
+            // executes on the collector (Main) thread and janks large
+            // chapter lists. Move the whole upstream chain — the map and the
+            // distinctUntilChanged comparison — onto Default.
+            .flowOn(Dispatchers.Default)
+            .flowOn(Dispatchers.Default)
 
     override fun observeDownloadState(fictionId: String): Flow<Map<String, ChapterDownloadState>> =
         dao.observeDownloadStates(fictionId).map { rows ->


### PR DESCRIPTION
## Summary
- Added `.flowOn(Dispatchers.Default)` after the `map`+`distinctUntilChanged` chain in `ChapterRepository.observeChapterPreviews()` so the heavy regex + HTML-decode runs on a background dispatcher instead of the collector's Main thread.

Closes #1220.

## Test plan
- [ ] Build APK (CI compile gate)
- [ ] Large chapter lists should scroll without jank from preview computation

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>