### PR TITLE
fix(rebrand): replace stale storyvox User-Agent strings (#1216)

### DIFF
--- a/app/src/main/kotlin/in/jphe/storyvox/data/SuggestedFeedsRegistry.kt
+++ b/app/src/main/kotlin/in/jphe/storyvox/data/SuggestedFeedsRegistry.kt
@@ -1,5 +1,7 @@
 package `in`.jphe.storyvox.data
 
+import `in`.jphe.storyvox.BuildConfig
+import `in`.jphe.storyvox.data.network.UserAgent
 import `in`.jphe.storyvox.feature.api.SuggestedFeed
 import `in`.jphe.storyvox.feature.api.SuggestedFeedKind
 import javax.inject.Inject
@@ -124,7 +126,14 @@ class SuggestedFeedsRegistry @Inject constructor() {
     companion object {
         const val REGISTRY_URL =
             "https://raw.githubusercontent.com/techempower-org/candela-feeds/main/suggestions.json"
-        const val USER_AGENT = "storyvox/1.0 (+https://github.com/jphein/storyvox)"
+        /**
+         * Descriptive User-Agent built from the centralized [UserAgent]
+         * tokens + the live build version (#1216). `:app` carries
+         * `BuildConfig.VERSION_NAME`, so this can use the full
+         * `UserAgent.format()` shape. Replaces the stale pre-rebrand
+         * `storyvox/1.0 (jphein)` string.
+         */
+        val USER_AGENT: String = UserAgent.format(BuildConfig.VERSION_NAME)
         const val SUPPORTED_SCHEMA_VERSION = 1
     }
 }

--- a/core-llm/src/main/kotlin/in/jphe/storyvox/llm/auth/AnthropicTeamsAuthApi.kt
+++ b/core-llm/src/main/kotlin/in/jphe/storyvox/llm/auth/AnthropicTeamsAuthApi.kt
@@ -188,7 +188,7 @@ open class AnthropicTeamsAuthApi @Inject constructor(
     )
 
     companion object {
-        const val USER_AGENT: String = "storyvox/0.4 (+https://github.com/jphein/storyvox)"
+        const val USER_AGENT: String = "Candela (https://candela.techempower.org; support@techempower.org)"
         private val JSON_MEDIA = "application/json".toMediaType()
         private val JSON: Json = Json {
             ignoreUnknownKeys = true

--- a/core-llm/src/main/kotlin/in/jphe/storyvox/llm/auth/AnthropicTeamsAuthApi.kt
+++ b/core-llm/src/main/kotlin/in/jphe/storyvox/llm/auth/AnthropicTeamsAuthApi.kt
@@ -1,5 +1,6 @@
 package `in`.jphe.storyvox.llm.auth
 
+import `in`.jphe.storyvox.data.network.UserAgent
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.suspendCancellableCoroutine
 import kotlinx.coroutines.withContext
@@ -188,7 +189,8 @@ open class AnthropicTeamsAuthApi @Inject constructor(
     )
 
     companion object {
-        const val USER_AGENT: String = "Candela (https://candela.techempower.org; support@techempower.org)"
+        const val USER_AGENT: String =
+            UserAgent.APP_NAME + " (" + UserAgent.CONTACT_URL + "; " + UserAgent.CONTACT_EMAIL + ")"
         private val JSON_MEDIA = "application/json".toMediaType()
         private val JSON: Json = Json {
             ignoreUnknownKeys = true

--- a/source-azure/src/main/kotlin/in/jphe/storyvox/source/azure/AzureSpeechClient.kt
+++ b/source-azure/src/main/kotlin/in/jphe/storyvox/source/azure/AzureSpeechClient.kt
@@ -1,6 +1,7 @@
 package `in`.jphe.storyvox.source.azure
 
 import android.os.SystemClock
+import `in`.jphe.storyvox.data.network.UserAgent
 import `in`.jphe.storyvox.data.source.AzureVoiceDescriptor
 import `in`.jphe.storyvox.source.azure.di.AzureHttp
 import kotlinx.coroutines.flow.Flow
@@ -580,7 +581,8 @@ open class AzureSpeechClient @Inject constructor(
          *  service-side debugging when a request misbehaves. The
          *  version suffix is filled by Hilt at runtime; tests use
          *  the literal string. */
-        internal const val USER_AGENT = "storyvox/azure-tts"
+        internal const val USER_AGENT =
+            UserAgent.APP_NAME + "/azure-tts (" + UserAgent.CONTACT_URL + ")"
 
         /** Read size for the streaming variant. 8 KB lines up with TLS
          *  record sizes (most chunks come in at one record per read)

--- a/source-matrix/src/main/kotlin/in/jphe/storyvox/source/matrix/config/MatrixDefaults.kt
+++ b/source-matrix/src/main/kotlin/in/jphe/storyvox/source/matrix/config/MatrixDefaults.kt
@@ -1,5 +1,7 @@
 package `in`.jphe.storyvox.source.matrix.config
 
+import `in`.jphe.storyvox.data.network.UserAgent
+
 /**
  * Issue 457 — Matrix backend defaults. Matrix is federated, so there
  * is no single matrix.org-style default homeserver baked in — the
@@ -54,9 +56,9 @@ object MatrixDefaults {
     const val MAX_COALESCE_MINUTES: Int = 30
 
     /** User-Agent header surfaced to the homeserver so admins can
-     *  identify storyvox traffic + the version in their logs. Matrix
+     *  identify Candela traffic + the version in their logs. Matrix
      *  homeservers are commonly self-hosted on small hardware; a
-     *  clear UA keeps storyvox from looking like an anonymous scrape. */
+     *  clear UA keeps Candela from looking like an anonymous scrape. */
     const val USER_AGENT: String =
-        "Storyvox-Matrix/1.0 (+https://github.com/techempower-org/candela)"
+        UserAgent.APP_NAME + "-Matrix/1.0 (+" + UserAgent.CONTACT_URL + ")"
 }

--- a/source-slack/src/main/kotlin/in/jphe/storyvox/source/slack/config/SlackDefaults.kt
+++ b/source-slack/src/main/kotlin/in/jphe/storyvox/source/slack/config/SlackDefaults.kt
@@ -1,5 +1,7 @@
 package `in`.jphe.storyvox.source.slack.config
 
+import `in`.jphe.storyvox.data.network.UserAgent
+
 /**
  * Issue #454 — Slack backend defaults. Minimal: no bundled bot
  * token (ToS posture — storyvox doesn't ship credentials and won't
@@ -27,7 +29,7 @@ object SlackDefaults {
      *  identifying ourselves makes abuse-team contact easier if a
      *  bot misbehaves. Mirrors the Discord / Telegram UA pattern. */
     const val USER_AGENT: String =
-        "Storyvox-Slack/1.0 (+https://github.com/techempower-org/candela)"
+        UserAgent.APP_NAME + "-Slack/1.0 (+" + UserAgent.CONTACT_URL + ")"
 
     /** `conversations.list` page size. Slack caps this at 1000 but
      *  recommends staying ≤200 for performance + rate-limit

--- a/source-telegram/src/main/kotlin/in/jphe/storyvox/source/telegram/config/TelegramDefaults.kt
+++ b/source-telegram/src/main/kotlin/in/jphe/storyvox/source/telegram/config/TelegramDefaults.kt
@@ -1,5 +1,7 @@
 package `in`.jphe.storyvox.source.telegram.config
 
+import `in`.jphe.storyvox.data.network.UserAgent
+
 /**
  * Issue #462 — Telegram backend defaults. Minimal: no bundled bot
  * token (ToS posture — storyvox doesn't ship credentials and won't
@@ -24,7 +26,7 @@ object TelegramDefaults {
      *  but identifying ourselves makes abuse-team contact easier
      *  if a bot misbehaves. Mirrors the Discord UA pattern. */
     const val USER_AGENT: String =
-        "Storyvox-Telegram/1.0 (+https://github.com/techempower-org/candela)"
+        UserAgent.APP_NAME + "-Telegram/1.0 (+" + UserAgent.CONTACT_URL + ")"
 
     /** Max messages per `getUpdates` poll. The API caps at 100;
      *  we pull the full window so a single poll reflects every


### PR DESCRIPTION
## Summary
- Replace 2 stale pre-rebrand `storyvox` User-Agent strings in `SuggestedFeedsRegistry` and `AnthropicTeamsAuthApi`
- Replace 4 additional stale `Storyvox-*` UAs in `source-azure`, `source-matrix`, `source-slack`, `source-telegram`
- All six sites now derive their product token from `UserAgent.APP_NAME` / `CONTACT_URL` / `CONTACT_EMAIL` constants — a future rebrand is a one-line change
- `SuggestedFeedsRegistry` uses `UserAgent.format(BuildConfig.VERSION_NAME)` for the full versioned UA
- The remaining five use `const val` concatenation from `UserAgent` constants (no runtime version needed)

Closes #1216

## Test plan
- [ ] CI Build APK passes
- [ ] Grep confirms no remaining `storyvox` product tokens outside package names

🤖 Generated with [Claude Code](https://claude.com/claude-code)