### PR TITLE
fix(playback): synchronize DndController and guard system calls (#1218)

### DIFF
--- a/core-playback/src/main/kotlin/in/jphe/storyvox/playback/DndController.kt
+++ b/core-playback/src/main/kotlin/in/jphe/storyvox/playback/DndController.kt
@@ -55,32 +55,66 @@ class AndroidDndController @Inject constructor(
      * `null` when we are not currently holding DND on the timer's behalf.
      * Doubles as the idempotency guard: a non-null value means "already
      * active", so a second [activateForSleepTimer] is a no-op.
+     *
+     * `@Volatile` for visibility and [lock] for the check-then-act: this
+     * controller is a `@Singleton`, so activate (from the timer-arm
+     * coroutine) and [restorePrevious] (from expiry/cancel) can race on
+     * different threads. Without the monitor a concurrent restore could
+     * null the snapshot mid-activate, leaking DND on forever (#1218).
      */
+    @Volatile
     private var savedFilter: Int? = null
 
+    /** Guards the compound read-modify-write on [savedFilter]. */
+    private val lock = Any()
+
     override suspend fun activateForSleepTimer() {
+        // Suspend call stays OUTSIDE the monitor — never hold a lock across
+        // a suspension point.
         if (!config.currentDndWithSleepTimerEnabled()) return
-        val nm = notificationManager ?: return
-        if (!nm.isNotificationPolicyAccessGranted) return
-        // Already holding DND for this timer — don't re-snapshot.
-        if (savedFilter != null) return
-        val current = nm.currentInterruptionFilter
-        // Only act when DND is currently OFF. If the user already has a
-        // DND mode on, leave it untouched and record nothing, so
-        // restorePrevious() can't switch their DND off later (the #1190
-        // "already enabled by user" edge case).
-        if (current != NotificationManager.INTERRUPTION_FILTER_ALL) return
-        savedFilter = current
-        // PRIORITY (not NONE) so alarms still fire — a bedtime listener
-        // still needs their morning alarm.
-        nm.setInterruptionFilter(NotificationManager.INTERRUPTION_FILTER_PRIORITY)
+        synchronized(lock) {
+            val nm = notificationManager ?: return
+            if (!nm.isPolicyAccessGrantedSafe()) return
+            // Already holding DND for this timer — don't re-snapshot.
+            if (savedFilter != null) return
+            val current = nm.currentInterruptionFilter
+            // Only act when DND is currently OFF. If the user already has a
+            // DND mode on, leave it untouched and record nothing, so
+            // restorePrevious() can't switch their DND off later (the #1190
+            // "already enabled by user" edge case).
+            if (current != NotificationManager.INTERRUPTION_FILTER_ALL) return
+            // PRIORITY (not NONE) so alarms still fire — a bedtime listener
+            // still needs their morning alarm. Only record the snapshot if
+            // the ROM actually let us flip DND on; otherwise stay a no-op.
+            if (nm.setInterruptionFilterSafe(NotificationManager.INTERRUPTION_FILTER_PRIORITY)) {
+                savedFilter = current
+            }
+        }
     }
 
     override fun restorePrevious() {
-        val saved = savedFilter ?: return
-        savedFilter = null
-        val nm = notificationManager ?: return
-        if (!nm.isNotificationPolicyAccessGranted) return
-        nm.setInterruptionFilter(saved)
+        synchronized(lock) {
+            val saved = savedFilter ?: return
+            savedFilter = null
+            val nm = notificationManager ?: return
+            if (!nm.isPolicyAccessGrantedSafe()) return
+            nm.setInterruptionFilterSafe(saved)
+        }
     }
+
+    /**
+     * [NotificationManager.isNotificationPolicyAccessGranted] can throw
+     * `SecurityException` on stripped / custom ROMs (#1218). Treat any
+     * throw as "not granted" so the caller bails cleanly.
+     */
+    private fun NotificationManager.isPolicyAccessGrantedSafe(): Boolean =
+        runCatching { isNotificationPolicyAccessGranted }.getOrDefault(false)
+
+    /**
+     * [NotificationManager.setInterruptionFilter] can throw
+     * `SecurityException` on non-standard ROMs (#1218). Returns `true`
+     * iff the filter was applied.
+     */
+    private fun NotificationManager.setInterruptionFilterSafe(filter: Int): Boolean =
+        runCatching { setInterruptionFilter(filter) }.isSuccess
 }


### PR DESCRIPTION
## Issue #1218

`AndroidDndController` is a `@Singleton`, but `savedFilter` was a plain unsynchronized `var`. Two paths touch it from potentially different threads:

- `activateForSleepTimer()` — from the timer-arm coroutine
- `restorePrevious()` — from timer expiry / cancel

The check-then-act on `savedFilter` (`if (savedFilter != null) return … savedFilter = current`) raced: a concurrent `restorePrevious` could null the snapshot mid-activate, **leaking DND on forever**.

Separately, `setInterruptionFilter` and `isNotificationPolicyAccessGranted` are unguarded — a `SecurityException` on stripped / custom ROMs could crash the playback service.

## Fix

1. **Thread safety** — `savedFilter` is now `@Volatile`, and the compound read-modify-write in both methods is wrapped in a `synchronized(lock)` monitor. The `suspend` config call (`currentDndWithSleepTimerEnabled()`) stays **outside** the lock so we never hold a monitor across a suspension point.
2. **SecurityException guards** — `setInterruptionFilter` and `isNotificationPolicyAccessGranted` go through `runCatching` helpers (`setInterruptionFilterSafe` / `isPolicyAccessGrantedSafe`). A throw on a non-standard ROM is treated as "not granted" / "couldn't apply" and the controller stays a clean no-op instead of crashing.

As a bonus, `savedFilter` is only recorded when the ROM actually applied the filter — so on a ROM that can't set DND, `restorePrevious` has nothing to undo.

## Testing

No unit tests reference `DndController` (the contract is exercised via `NoopDndController` in `SleepTimer` tests). Behavior on the happy path is unchanged; CI `Build APK` is the compile gate per project convention.

Closes #1218

🤖 Generated with [Claude Code](https://claude.com/claude-code)