### PR TITLE
test(playback): regression test for #1225 false "Paused for a call"

### DIFF
--- a/core-playback/src/test/kotlin/in/jphe/storyvox/playback/diagnostics/AudioOutputMonitorTest.kt
+++ b/core-playback/src/test/kotlin/in/jphe/storyvox/playback/diagnostics/AudioOutputMonitorTest.kt
@@ -123,6 +123,52 @@ class AudioOutputMonitorTest {
     }
 
     @Test
+    fun `diagnose returns FocusLost when focus not held on the TTS path`() {
+        // Precedence #3: the TTS AudioTrack path relies on
+        // AudioFocusController to own focus. A fresh (never-acquired)
+        // controller reports isHeld()==false, so a non-live chapter that
+        // claims to be Playing must surface FocusLost. This pins the
+        // "guard on" side of the #1225 fix — the focus check still fires
+        // for everything that isn't a live-audio chapter.
+        val m = monitor() // default controller, focus never acquired
+        val r = m.diagnose(
+            state = PlaybackState(
+                currentChapterId = "c1",
+                chapterTitle = "Chapter 1",
+                isLiveAudioChapter = false,
+            ),
+            engine = EngineState.Playing,
+            positionMs = 1000L,
+        )
+        assertTrue("TTS path with un-held focus should be FocusLost — got $r", r is WaitReason.FocusLost)
+    }
+
+    @Test
+    fun `diagnose skips FocusLost for live-audio chapters (#1225)`() {
+        // Regression for #1225: radio / LibriVox streams play through
+        // ExoPlayer (handleAudioFocus=true), so AudioFocusController never
+        // acquires focus and isHeld() stays false even while audio is
+        // healthy. The focus-loss branch must be skipped for live-audio
+        // chapters, or the diagnostic panel falsely shows "Paused for a
+        // call" over normal playback. Same un-held controller as the test
+        // above — only isLiveAudioChapter differs.
+        val m = monitor()
+        val r = m.diagnose(
+            state = PlaybackState(
+                currentChapterId = "c1",
+                chapterTitle = "Radio Stream",
+                isLiveAudioChapter = true,
+            ),
+            engine = EngineState.Playing,
+            positionMs = 1000L,
+        )
+        assertTrue(
+            "Live-audio chapter must not surface a false FocusLost — got $r",
+            r !is WaitReason.FocusLost,
+        )
+    }
+
+    @Test
     fun `diagnose returns DeviceMuted when STREAM_MUSIC volume is zero`() {
         val af = AudioFocusController(RuntimeEnvironment.getApplication())
         af.acquire()


### PR DESCRIPTION
## Context

Issue #1225 — radio / LibriVox audio streams showed a persistent false **"Paused for a call"** diagnostic panel during healthy playback.

**The code fix already landed** in #1226 (commit `55d851b1`, merged 2026-06-27): `AudioOutputMonitor.diagnose()` now skips the `AudioFocusController.isHeld()` check when `PlaybackState.isLiveAudioChapter` is true, because ExoPlayer owns its own audio focus (`handleAudioFocus=true`) and `AudioFocusController` never acquires focus for that path.

That fix shipped **without a regression test**. This PR adds one.

## What this PR does

Adds two cases to `AudioOutputMonitorTest` pinning both sides of the `isLiveAudioChapter` guard at `AudioOutputMonitor.kt:273`:

- **TTS path** (`isLiveAudioChapter=false`) with un-held focus → must surface `FocusLost` (the guard stays "on" for the AudioTrack path).
- **Live-audio path** (`isLiveAudioChapter=true`) with un-held focus → must **not** surface `FocusLost` (the #1225 false-positive).

Both use a freshly-constructed `AudioFocusController` whose focus is never acquired (`isHeld()==false`) — exactly the radio/LibriVox condition. The only difference between the two cases is `isLiveAudioChapter`, so the test isolates the guard precisely.

## Why

Without a test, the guard could be silently removed and the false "Paused for a call" diagnostic would regress unnoticed. Test-only change — no production code touched.

Closes #1225

🤖 Generated with [Claude Code](https://claude.com/claude-code)