### PR TITLE
ci: add test-compile job to catch DAO interface drift (#1211)

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -15,6 +15,31 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  test-compile:
+    name: Test Compile
+    runs-on: [self-hosted, linux, android]
+    timeout-minutes: 30
+    if: github.event_name == 'pull_request'
+    env:
+      JAVA_HOME: /usr/lib/jvm/java-17-openjdk-amd64
+      ANDROID_HOME: /home/jp/Android/Sdk
+      ANDROID_SDK_ROOT: /home/jp/Android/Sdk
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+
+      - name: Make gradlew executable
+        run: chmod +x ./gradlew
+
+      - name: Materialize local.properties from runner-persistent location
+        run: |
+          if [ -f /home/jp/Projects/storyvox/local.properties ]; then
+            cp /home/jp/Projects/storyvox/local.properties ./local.properties
+          fi
+
+      - name: Compile test sources
+        run: PATH="$JAVA_HOME/bin:$PATH" ./gradlew compileDebugUnitTestKotlin --no-daemon --stacktrace
+
   build:
     # Job key + name kept verbatim ("build" / "Build APK") so the
     # workflow's required-status-check context on `main` flips to a


### PR DESCRIPTION
## Summary
- Add `Test Compile` job (`compileDebugUnitTestKotlin`) to the Android CI workflow
- Runs on PRs only (skipped on main pushes and tag builds)
- Catches interface drift in test fakes (e.g., `NoopFictionDao` missing new abstract methods) at PR time instead of letting it rot

Closes #1211

## Context
Found during #1210 — 3 abstract methods had been missing from test fakes since #982 and #989, causing compilation failures CI never caught because `assembleRelease` doesn't compile test source sets.

## Test plan
- [ ] CI runs both `Build APK` and `Test Compile` jobs on this PR
- [ ] `Test Compile` passes (all test source sets compile)

🤖 Generated with [Claude Code](https://claude.com/claude-code)