### PR TITLE
feat(sync): separate purge remote data from sign-out (#1248)

### DIFF
--- a/feature/src/main/kotlin/in/jphe/storyvox/feature/sync/SyncAuthScreen.kt
+++ b/feature/src/main/kotlin/in/jphe/storyvox/feature/sync/SyncAuthScreen.kt
@@ -1,5 +1,6 @@
 package `in`.jphe.storyvox.feature.sync
 
+import androidx.compose.foundation.BorderStroke
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Spacer
@@ -49,7 +50,7 @@ import `in`.jphe.storyvox.ui.component.MagicCircularProgress
  * One screen, three field configurations:
  *  - Email entry → "Send code"
  *  - Code entry → "Verify"
- *  - Signed in → status + "Sign out"
+ *  - Signed in → status + "Purge cloud data" / "Sign out"
  *
  * Why one screen rather than a multi-step navigation graph: the user
  * journey is linear and short, and a Compose `when (state)` keeps the
@@ -122,7 +123,9 @@ fun SyncAuthScreen(
                 is SignInState.Verifying -> InProgress("Verifying…")
                 is SignInState.SignedIn -> SignedInPanel(
                     email = current.user.email ?: "(no email on file)",
+                    purge = current.purge,
                     onSignOut = viewModel::signOut,
+                    onPurge = viewModel::purgeRemoteData,
                     onClose = onClose,
                 )
             }
@@ -226,13 +229,20 @@ private fun InProgress(label: String) {
 @Composable
 private fun SignedInPanel(
     email: String,
+    purge: PurgeState,
     onSignOut: () -> Unit,
+    onPurge: () -> Unit,
     onClose: () -> Unit,
 ) {
-    // #1197 — sign-out now permanently deletes all synced cloud data
-    // (#1194), so gate it behind an explicit, undismissable confirmation
-    // rather than firing on a single tap of an OutlinedButton.
+    // #1248 — sign-out and "purge cloud data" are now distinct actions.
+    // Sign-out only clears the LOCAL session (cloud data survives, so it's
+    // a light, reversible confirmation), while purging permanently deletes
+    // the cloud record and is gated behind its own destructive, undismiss-
+    // able confirmation. The purge button is only ever rendered here, i.e.
+    // when the user is signed in.
     var showSignOutConfirm by remember { mutableStateOf(false) }
+    var showPurgeConfirm by remember { mutableStateOf(false) }
+    val purging = purge == PurgeState.Running
 
     Text(
         text = "Signed in",
@@ -249,12 +259,73 @@ private fun SignedInPanel(
     Button(
         onClick = onClose,
         modifier = Modifier.fillMaxWidth(),
+        enabled = !purging,
     ) { Text(stringResource(R.string.sync_done)) }
+    Spacer(Modifier.height(8.dp))
+    // Destructive: delete the cloud record. Placed ABOVE sign-out and
+    // tinted with the error colour so it reads as the dangerous action —
+    // sign-out is now safe/reversible since cloud data survives it.
+    OutlinedButton(
+        onClick = { showPurgeConfirm = true },
+        modifier = Modifier.fillMaxWidth(),
+        enabled = !purging,
+        colors = ButtonDefaults.outlinedButtonColors(
+            contentColor = MaterialTheme.colorScheme.error,
+        ),
+        border = BorderStroke(1.dp, MaterialTheme.colorScheme.error),
+    ) { Text(stringResource(R.string.sync_purge)) }
     Spacer(Modifier.height(8.dp))
     OutlinedButton(
         onClick = { showSignOutConfirm = true },
         modifier = Modifier.fillMaxWidth(),
+        enabled = !purging,
     ) { Text(stringResource(R.string.sync_sign_out)) }
+
+    // Purge progress / outcome (#1248). The coordinator makes network
+    // calls, so surface a spinner while in flight and a success/error line
+    // afterward. The result line is a polite live region so TalkBack
+    // announces the outcome.
+    when (purge) {
+        PurgeState.Running -> {
+            Spacer(Modifier.height(20.dp))
+            MagicCircularProgress(
+                color = MaterialTheme.colorScheme.error,
+                modifier = Modifier
+                    .size(36.dp)
+                    .semantics {
+                        contentDescription = "Loading: deleting your cloud data"
+                        liveRegion = LiveRegionMode.Polite
+                    },
+            )
+            Spacer(Modifier.height(8.dp))
+            Text(
+                text = stringResource(R.string.sync_purge_running),
+                style = MaterialTheme.typography.bodyMedium,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
+        }
+        PurgeState.Success -> {
+            Spacer(Modifier.height(20.dp))
+            Text(
+                text = stringResource(R.string.sync_purge_success),
+                style = MaterialTheme.typography.bodyMedium,
+                color = MaterialTheme.colorScheme.primary,
+                textAlign = TextAlign.Center,
+                modifier = Modifier.semantics { liveRegion = LiveRegionMode.Polite },
+            )
+        }
+        PurgeState.Error -> {
+            Spacer(Modifier.height(20.dp))
+            Text(
+                text = stringResource(R.string.sync_purge_error),
+                style = MaterialTheme.typography.bodyMedium,
+                color = MaterialTheme.colorScheme.error,
+                textAlign = TextAlign.Center,
+                modifier = Modifier.semantics { liveRegion = LiveRegionMode.Polite },
+            )
+        }
+        PurgeState.Idle -> Unit
+    }
 
     if (showSignOutConfirm) {
         SignOutConfirmDialog(
@@ -265,15 +336,27 @@ private fun SignedInPanel(
             onDismiss = { showSignOutConfirm = false },
         )
     }
+
+    if (showPurgeConfirm) {
+        PurgeConfirmDialog(
+            onConfirm = {
+                showPurgeConfirm = false
+                onPurge()
+            },
+            onDismiss = { showPurgeConfirm = false },
+        )
+    }
 }
 
 /**
- * Destructive-action confirmation for sync sign-out (#1197).
+ * Light confirmation for sync sign-out (#1197, revised #1248).
  *
- * Sign-out deletes all synced cloud data (#1194), so the dialog forces
- * an explicit choice: [DialogProperties] disables both back-press and
- * outside-tap dismissal, and the confirm button is tinted with
- * [MaterialTheme.colorScheme.error] to signal that it destroys data.
+ * Sign-out now only clears the LOCAL session — cloud data is preserved, so
+ * this is a reversible action (the user can sign back in to resume
+ * syncing). Deleting cloud data is the separate, destructive
+ * [PurgeConfirmDialog]. Accordingly this is a light speed-bump rather than
+ * a hard gate: it stays dismissable (default [DialogProperties]) and the
+ * confirm button uses the default tint rather than the error colour.
  */
 @Composable
 private fun SignOutConfirmDialog(
@@ -285,16 +368,47 @@ private fun SignOutConfirmDialog(
         title = { Text(stringResource(R.string.sync_sign_out_confirm_title)) },
         text = { Text(stringResource(R.string.sync_sign_out_confirm_body)) },
         confirmButton = {
+            TextButton(onClick = onConfirm) {
+                Text(stringResource(R.string.sync_sign_out_confirm_button))
+            }
+        },
+        dismissButton = {
+            TextButton(onClick = onDismiss) {
+                Text(stringResource(R.string.sync_sign_out_confirm_dismiss))
+            }
+        },
+    )
+}
+
+/**
+ * Destructive-action confirmation for purging cloud data (#1248).
+ *
+ * Purging permanently deletes the user's InstantDB record, so the dialog
+ * forces an explicit choice: [DialogProperties] disables both back-press
+ * and outside-tap dismissal, and the confirm button is tinted with
+ * [MaterialTheme.colorScheme.error] to signal that it destroys data. The
+ * local session is untouched — the user stays signed in afterward.
+ */
+@Composable
+private fun PurgeConfirmDialog(
+    onConfirm: () -> Unit,
+    onDismiss: () -> Unit,
+) {
+    AlertDialog(
+        onDismissRequest = onDismiss,
+        title = { Text(stringResource(R.string.sync_purge_confirm_title)) },
+        text = { Text(stringResource(R.string.sync_purge_confirm_body)) },
+        confirmButton = {
             TextButton(
                 onClick = onConfirm,
                 colors = ButtonDefaults.textButtonColors(
                     contentColor = MaterialTheme.colorScheme.error,
                 ),
-            ) { Text(stringResource(R.string.sync_sign_out_confirm_button)) }
+            ) { Text(stringResource(R.string.sync_purge_confirm_button)) }
         },
         dismissButton = {
             TextButton(onClick = onDismiss) {
-                Text(stringResource(R.string.sync_sign_out_confirm_dismiss))
+                Text(stringResource(R.string.sync_purge_confirm_dismiss))
             }
         },
         properties = DialogProperties(

--- a/feature/src/main/kotlin/in/jphe/storyvox/feature/sync/SyncAuthViewModel.kt
+++ b/feature/src/main/kotlin/in/jphe/storyvox/feature/sync/SyncAuthViewModel.kt
@@ -127,30 +127,29 @@ class SyncAuthViewModel @Inject constructor(
     }
 
     /**
-     * Sign out: delete the user's cloud data, revoke the token server-side,
-     * then wipe local credentials.
+     * Sign out: revoke the refresh token server-side, then wipe local
+     * credentials. Cloud data is intentionally PRESERVED.
      *
-     * Issue #1139 — signing out must actually delete the InstantDB record,
-     * as the privacy policy promises ("signing out of sync deletes your
-     * record"). [SyncCoordinator.purgeRemoteData] runs FIRST, while
-     * [current]'s refresh token is still valid — the admin delete API
-     * authorizes via as-token impersonation with that token, so deletion
-     * must precede [InstantClient.signOut] (which revokes it) and
-     * [InstantSession.clear] (which forgets it).
+     * Issue #1248 — sign-out and "purge cloud data" are now separate
+     * actions. Sign-out used to delete the user's InstantDB record first
+     * (#1139), so there was no way to sign out on one device while keeping
+     * the cloud copy for the others, nor to sign out at all without losing
+     * everything. Deleting cloud data is now an explicit, separately-
+     * confirmed action — see [purgeRemoteData]. After signing out the user
+     * can sign back in and pull their cloud data down again.
      *
-     * All three steps are best-effort: an offline sign-out still completes
-     * locally (the user shouldn't be trapped signed-in), and the privacy
-     * policy's email-request path backstops a failed cloud delete. Local
+     * Both remaining steps are best-effort: an offline sign-out still
+     * completes locally (the user shouldn't be trapped signed-in). Local
      * on-device library/positions are intentionally kept — see
      * [SyncCoordinator]'s class kdoc.
      *
      * Issue #1217 — the local wipe ([InstantSession.clear] + the state
      * reset) runs in a [NonCancellable] `finally`, so a cancellation of
-     * this coroutine mid-purge (e.g. the ViewModel being cleared as the
+     * this coroutine mid-sign-out (e.g. the ViewModel being cleared as the
      * user navigates away) can't strand a half-signed-out state where the
-     * cloud record is gone but the device still holds the now-revoked
-     * token and renders as signed-in. The cloud-side calls stay
-     * cancellable (they're best-effort); only the local wipe is guarded.
+     * token is revoked server-side but the device still holds it and
+     * renders as signed-in. The cloud-side [InstantClient.signOut] call
+     * stays cancellable (it's best-effort); only the local wipe is guarded.
      */
     fun signOut() {
         val current = session.current() ?: run {
@@ -159,16 +158,53 @@ class SyncAuthViewModel @Inject constructor(
         }
         viewModelScope.launch {
             try {
-                coordinator.purgeRemoteData(current) // #1139 delete cloud data while token is valid
                 client.signOut(current.refreshToken) // best-effort; ignored on failure
             } finally {
                 // #1217 — local wipe must complete even if the coroutine is
-                // cancelled during the cloud purge above, or we leave a
+                // cancelled during the cloud call above, or we leave a
                 // half-signed-out state.
                 withContext(NonCancellable) {
                     session.clear()
                     _state.value = SignInState.SignedOut(email = "")
                 }
+            }
+        }
+    }
+
+    /**
+     * Issue #1248 — explicitly delete the user's cloud (InstantDB) record
+     * WITHOUT signing out. Separate from [signOut] so a user can delete
+     * their cloud data while keeping their local session (and can sign out
+     * on one device without affecting the cloud copy other devices rely
+     * on).
+     *
+     * Delegates to [SyncCoordinator.purgeRemoteData], which deletes every
+     * domain's remote row using the still-valid refresh token (the admin
+     * delete API authorizes via as-token impersonation). Best-effort by
+     * design — the coordinator returns false if any domain failed, and the
+     * privacy policy's email-request path backstops a partial failure.
+     *
+     * Progress + outcome are surfaced via [SignInState.SignedIn.purge] so
+     * the screen can show a loading indicator while the network calls run
+     * and a success/error result afterward. The local session is untouched
+     * — the user stays signed in throughout.
+     */
+    fun purgeRemoteData() {
+        val current = session.current() ?: run {
+            _state.value = SignInState.SignedOut(email = "")
+            return
+        }
+        val signedIn = _state.value as? SignInState.SignedIn ?: return
+        _state.value = signedIn.copy(purge = PurgeState.Running)
+        viewModelScope.launch {
+            val ok = coordinator.purgeRemoteData(current)
+            // Only publish the outcome if we're still on the signed-in
+            // screen — the user may have signed out / navigated away while
+            // the network calls were in flight.
+            (_state.value as? SignInState.SignedIn)?.let { now ->
+                _state.value = now.copy(
+                    purge = if (ok) PurgeState.Success else PurgeState.Error,
+                )
             }
         }
     }
@@ -184,7 +220,25 @@ sealed interface SignInState {
     data class SendingCode(val email: String) : SignInState
     data class CodePrompt(val email: String, val code: String, val error: String?) : SignInState
     data class Verifying(val email: String, val code: String) : SignInState
-    data class SignedIn(val user: SignedInUser) : SignInState
+    data class SignedIn(
+        val user: SignedInUser,
+        val purge: PurgeState = PurgeState.Idle,
+    ) : SignInState
+}
+
+/**
+ * Issue #1248 — progress/outcome of an explicit "purge cloud data" action,
+ * tracked on [SignInState.SignedIn] so the screen can render a loading
+ * indicator while the coordinator's network calls run and a success/error
+ * result afterward without leaving the signed-in screen. [Error] carries
+ * no message: [SyncCoordinator.purgeRemoteData] is a best-effort boolean,
+ * so the screen shows a generic retry prompt.
+ */
+sealed interface PurgeState {
+    data object Idle : PurgeState
+    data object Running : PurgeState
+    data object Success : PurgeState
+    data object Error : PurgeState
 }
 
 /**

--- a/feature/src/main/res/values/strings.xml
+++ b/feature/src/main/res/values/strings.xml
@@ -318,11 +318,20 @@
     <string name="sync_different_email">Use a different email</string>
     <string name="sync_done">Done</string>
     <string name="sync_sign_out">Sign out</string>
-    <!-- Sign-out confirmation (#1197): sign-out deletes all synced cloud data (#1194), so force an explicit, loud choice. -->
-    <string name="sync_sign_out_confirm_title">Delete your synced data?</string>
-    <string name="sync_sign_out_confirm_body">Signing out will permanently delete all your synced data from the cloud — your library, reading positions, bookmarks, voice settings, and follows. Data on this device will remain until you uninstall.\n\nThis cannot be undone.</string>
-    <string name="sync_sign_out_confirm_button">Sign out &amp; delete</string>
-    <string name="sync_sign_out_confirm_dismiss">Keep syncing</string>
+    <!-- Sign-out confirmation (#1197, revised #1248): sign-out now only clears the LOCAL session — cloud data is preserved so the user can sign back in to resume syncing. Deleting cloud data is a separate, explicit action (sync_purge_* below). -->
+    <string name="sync_sign_out_confirm_title">Sign out of sync?</string>
+    <string name="sync_sign_out_confirm_body">Your cloud data will remain intact. You can sign back in to resume syncing.</string>
+    <string name="sync_sign_out_confirm_button">Sign out</string>
+    <string name="sync_sign_out_confirm_dismiss">Cancel</string>
+    <!-- Purge cloud data (#1248): a destructive, irreversible action, separate from sign-out. Deletes the user's InstantDB cloud record while keeping the local session signed in. -->
+    <string name="sync_purge">Purge cloud data</string>
+    <string name="sync_purge_confirm_title">Delete your cloud data?</string>
+    <string name="sync_purge_confirm_body">This permanently deletes all your synced data from the cloud — your library, reading positions, bookmarks, voice settings, and follows. Data on this device is not affected, and you stay signed in.\n\nThis cannot be undone.</string>
+    <string name="sync_purge_confirm_button">Delete cloud data</string>
+    <string name="sync_purge_confirm_dismiss">Cancel</string>
+    <string name="sync_purge_running">Deleting your cloud data…</string>
+    <string name="sync_purge_success">Your cloud data has been deleted.</string>
+    <string name="sync_purge_error">Couldn\'t delete your cloud data. Please try again.</string>
 
     <!-- Fiction detail -->
     <string name="fiction_clear_cache_title">Clear cached audio for %1$s?</string>


### PR DESCRIPTION
## What

Separates **"Purge Remote Data"** from **Sign Out** (#1248).

Previously `SyncAuthViewModel.signOut()` atomically purged the user's InstantDB cloud record (#1139) *before* clearing the local session. There was no way to sign out while keeping cloud data intact — signing out on one device nuked the cloud copy every other device relied on.

## Changes

**`SyncAuthViewModel.kt`**
- `signOut()` no longer calls `coordinator.purgeRemoteData(...)`. It now only revokes the refresh token (best-effort `client.signOut`) and clears the local session. The #1217 `NonCancellable` guard around the local wipe is preserved.
- New `purgeRemoteData()` deletes the cloud record via `coordinator.purgeRemoteData(current)` **without** touching the local session, surfacing progress/outcome through a new `PurgeState` field (`Idle` / `Running` / `Success` / `Error`) on `SignInState.SignedIn`. The outcome is only published if the user is still on the signed-in screen.

**`SyncAuthScreen.kt`**
- New destructive **"Purge cloud data"** button (error-tinted outlined button, above Sign Out, only shown when signed in) with its own **undismissable** confirmation dialog (`PurgeConfirmDialog`).
- Loading spinner + success/error result line (polite live region for TalkBack) while/after the purge runs; buttons disable during the purge.
- The Sign Out confirmation dialog is downgraded to a **light, dismissable, non-destructive** confirmation (default tint, no `DialogProperties` hard gate) now that signing out preserves data.

**`strings.xml`**
- New `sync_purge*` strings (button, confirm title/body/button/dismiss, running/success/error).
- Sign-out confirmation copy updated: *"Your cloud data will remain intact. You can sign back in to resume syncing."*

**`SyncCoordinator.kt`** — `purgeRemoteData` was already public (`suspend fun`, no visibility modifier); no change required.

## Notes
- No local compile per project rules — CI's Build APK is the compile gate.
- No existing test asserts the old purge-on-sign-out behavior; adding the defaulted `purge` field to `SignedIn` is backward-compatible. The sync test file deliberately covers only the pure helpers (`isLikelyEmail` / `sanitizeAuthError`), so no VM-coroutine test was added.

Closes #1248

🤖 Generated with [Claude Code](https://claude.com/claude-code)
