### PR TITLE
feat(ao3,royalroad): gate search behind login to avoid anonymous rate limits (#1243)

### DIFF
--- a/source-ao3/src/main/kotlin/in/jphe/storyvox/source/ao3/Ao3Source.kt
+++ b/source-ao3/src/main/kotlin/in/jphe/storyvox/source/ao3/Ao3Source.kt
@@ -269,6 +269,14 @@ internal class Ao3Source @Inject constructor(
     }
 
     override suspend fun search(query: SearchQuery): FictionResult<ListPage<FictionSummary>> {
+        // #1243 — AO3 throttles anonymous search hard; gate it behind the
+        // captured session so queries ride the signed-in user's more
+        // generous rate limits. Mirrors the follows surface
+        // ([subscriptions] / [markedForLater]), which gate on the same
+        // [readUsername] session check. Browse (popular / byGenre /
+        // latestUpdates) stays anonymous.
+        readUsername()
+            ?: return FictionResult.AuthRequired("Sign in to AO3 to search")
         val term = query.term.trim()
         // Peel filter state back out of [SearchQuery]. [applyFilters]
         // stuffs the rating into `tags` with a "rating:" prefix because

--- a/source-royalroad/src/main/kotlin/in/jphe/storyvox/source/royalroad/RoyalRoadSource.kt
+++ b/source-royalroad/src/main/kotlin/in/jphe/storyvox/source/royalroad/RoyalRoadSource.kt
@@ -1,5 +1,6 @@
 package `in`.jphe.storyvox.source.royalroad
 
+import `in`.jphe.storyvox.data.db.dao.AuthDao
 import `in`.jphe.storyvox.data.source.FictionSource
 import `in`.jphe.storyvox.data.source.SourceIds
 import `in`.jphe.storyvox.data.source.filter.FilterDimension
@@ -63,6 +64,11 @@ class RoyalRoadSource @Inject internal constructor(
     private val fetcher: RoyalRoadChallengeFetcher,
     @Suppress("unused") private val client: RateLimitedClient,
     @Suppress("unused") private val cookieJar: RoyalRoadCookieJar,
+    // #1243 — read-only session-presence check for the search() gate. The
+    // shared auth store writes a row here on WebView sign-in
+    // (AuthRepository.captureSession) and clears it on sign-out, so a
+    // non-null row is the proactive "is signed in" signal search() needs.
+    private val authDao: AuthDao,
 ) : FictionSource {
 
     override val id: String = RoyalRoadIds.SOURCE_ID
@@ -198,8 +204,18 @@ class RoyalRoadSource @Inject internal constructor(
             page,
         )
 
-    override suspend fun search(query: SearchQuery): FictionResult<ListPage<FictionSummary>> =
-        fetchBrowsePage(buildSearchUrl(query), query.page)
+    override suspend fun search(query: SearchQuery): FictionResult<ListPage<FictionSummary>> {
+        // #1243 — RR throttles anonymous search; gate it behind the captured
+        // session so queries ride the signed-in user's more generous rate
+        // limits. The shared auth store holds a row per signed-in source, so a
+        // non-null row means a session was captured — the same proactive check
+        // the AO3 search gate uses. browse()/byGenre() stay anonymous (the
+        // popular/trending pages serve fine unauthenticated).
+        if (authDao.get(SourceIds.ROYAL_ROAD) == null) {
+            return FictionResult.AuthRequired(message = "Sign in to Royal Road to search")
+        }
+        return fetchBrowsePage(buildSearchUrl(query), query.page)
+    }
 
     override suspend fun fictionDetail(fictionId: String): FictionResult<FictionDetail> =
         when (val outcome = fetcher.fetchHtml(fictionUrl(fictionId))) {


### PR DESCRIPTION
Closes #1243.

## Problem
AO3 and RoyalRoad both throttle/block **anonymous** search requests. Authenticated sessions get more generous limits, so search should ride the signed-in session instead of firing anonymously and tripping the throttle.

## Change
Gate `search()` behind the captured session on both sources. `browse()`, `byGenre()`, and the popular/trending feeds stay **anonymous** — they serve fine unauthenticated.

### AO3 — `Ao3Source.search()`
Bails with `AuthRequired("Sign in to AO3 to search")` when no session username is captured. Reuses the existing `readUsername()` check that already gates the follows surface (`subscriptions()` / `markedForLater()`) — no new auth mechanism.

### RoyalRoad — `RoyalRoadSource.search()`
Bails with `AuthRequired("Sign in to Royal Road to search")` when the shared auth store (`AuthDao`) holds no row for the source.

RR's follows gate is **reactive** (it detects the login-redirect on the response), but anonymous RR search returns throttled `200`s rather than a redirect — so a reactive check can't gate it. Search uses the same **proactive** `AuthDao` presence check the AO3 gate uses, keeping both gates symmetric. `AuthDao` is the existing shared session store (already provided in the Hilt graph and used by AO3 + `AuthRepositoryImpl`), so this is not a new mechanism — `authDao` is injected into the source for the read-only check.

## Notes
- No new auth UI — both sources already have cookie sessions, login screens, and `AuthRequired` handling in the UI.
- No tests affected: both sources are `internal` (no cross-module construction), no test constructs them directly, and no test asserts on `search()`. `Ao3SearchPathTest` exercises the URL builder, not `Ao3Source.search()`.
- Per project rules, not compiled locally — leaving the Build APK CI job as the compile gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
