### PR TITLE
feat(reader): share quotes to clipboard and share sheet with attribution (#1234)

### DIFF
--- a/core-ui/src/main/kotlin/in/jphe/storyvox/ui/component/TestTags.kt
+++ b/core-ui/src/main/kotlin/in/jphe/storyvox/ui/component/TestTags.kt
@@ -70,6 +70,11 @@ object TestTags {
     const val HighlightConfirm = "highlight-confirm"
     const val HighlightSave = "highlight-save"
     const val HighlightDelete = "highlight-delete"
+    // #1234 — share a quote: the toolbar icon opens a menu with share-sheet +
+    // copy-to-clipboard items.
+    const val HighlightShare = "highlight-share"
+    const val HighlightShareSend = "highlight-share-send"
+    const val HighlightShareCopy = "highlight-share-copy"
 
     // ── Voices ───────────────────────────────────────────────────────────
     const val VoiceList = "voice-list"

--- a/feature/src/main/kotlin/in/jphe/storyvox/feature/reader/HybridReaderScreen.kt
+++ b/feature/src/main/kotlin/in/jphe/storyvox/feature/reader/HybridReaderScreen.kt
@@ -101,6 +101,8 @@ fun HybridReaderScreen(
     val wordHighlightArgb by viewModel.wordHighlightArgb.collectAsStateWithLifecycle()
     // Issue #999 phase 2 — the loaded chapter's saved highlights.
     val chapterHighlights by viewModel.chapterHighlights.collectAsStateWithLifecycle()
+    // Issue #1234 — author for the share-quote attribution (not on playback state).
+    val currentAuthor by viewModel.currentAuthor.collectAsStateWithLifecycle()
     val playback = state.playback
 
     // Chapter-completion celebration. The VM's confettiTrigger fires
@@ -376,6 +378,10 @@ fun HybridReaderScreen(
                 // create / edit / delete verbs; ReaderTextView renders the
                 // spans, drives the selection toolbar, and routes taps on a
                 // saved highlight to its edit/delete sheet.
+                // Issue #1234 — author for the share-quote attribution line;
+                // book + chapter titles come from the playback state inside
+                // ReaderTextView.
+                authorName = currentAuthor,
                 savedHighlights = chapterHighlights,
                 onCreateHighlight = viewModel::createHighlight,
                 onUpdateHighlight = viewModel::updateHighlight,

--- a/feature/src/main/kotlin/in/jphe/storyvox/feature/reader/QuoteShareActions.kt
+++ b/feature/src/main/kotlin/in/jphe/storyvox/feature/reader/QuoteShareActions.kt
@@ -1,0 +1,58 @@
+package `in`.jphe.storyvox.feature.reader
+
+import android.content.ClipData
+import android.content.ClipboardManager
+import android.content.Context
+import android.content.Intent
+import android.os.Build
+import android.widget.Toast
+
+/**
+ * Issue #1234 — Android dispatch for a shared quote. The string itself is
+ * built by the pure [QuoteShareFormatter]; this file does only the
+ * Context-coupled half (system share sheet + clipboard + toast), mirroring the
+ * intent/clipboard pattern already established in
+ * `feature/techempower/TechEmpowerIntents.kt`. Not unit-tested (no Robolectric
+ * in this project — see CLAUDE.md); the testable logic is the formatter.
+ */
+
+/** Clipboard label shown by the OS clip-preview UI on Android 13+. */
+private const val CLIP_LABEL = "Candela quote"
+
+/**
+ * Open the system share sheet (`Intent.ACTION_SEND`, `text/plain`) for a
+ * pre-formatted [text]. Wrapped in `Intent.createChooser` so the user always
+ * gets the picker (rather than a remembered default), and tagged
+ * `FLAG_ACTIVITY_NEW_TASK` so it launches cleanly from a Composable's
+ * non-Activity context — the same guard the TechEmpower launchers use.
+ */
+internal fun shareQuoteText(context: Context, text: String, chooserTitle: String) {
+    val send = Intent(Intent.ACTION_SEND).apply {
+        type = "text/plain"
+        putExtra(Intent.EXTRA_TEXT, text)
+    }
+    runCatching {
+        context.startActivity(
+            Intent.createChooser(send, chooserTitle).apply {
+                addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
+            },
+        )
+    }
+}
+
+/**
+ * Copy [text] to the clipboard and confirm with a [toastMessage].
+ *
+ * Android 13+ (API 33) shows its own system clip-preview chip on copy, so we
+ * suppress the redundant toast there to avoid a double confirmation — the
+ * pattern Google recommends for `setPrimaryClip`. On older releases the toast
+ * is the only feedback, so it always fires.
+ */
+internal fun copyQuoteToClipboard(context: Context, text: String, toastMessage: String) {
+    val clipboard = context.getSystemService(Context.CLIPBOARD_SERVICE) as? ClipboardManager
+        ?: return
+    clipboard.setPrimaryClip(ClipData.newPlainText(CLIP_LABEL, text))
+    if (Build.VERSION.SDK_INT < Build.VERSION_CODES.TIRAMISU) {
+        Toast.makeText(context, toastMessage, Toast.LENGTH_SHORT).show()
+    }
+}

--- a/feature/src/main/kotlin/in/jphe/storyvox/feature/reader/QuoteShareFormatter.kt
+++ b/feature/src/main/kotlin/in/jphe/storyvox/feature/reader/QuoteShareFormatter.kt
@@ -1,0 +1,73 @@
+package `in`.jphe.storyvox.feature.reader
+
+/**
+ * Issue #1234 — pure formatter that renders a single highlighted quote with
+ * book attribution for the share-sheet / clipboard. Compose- and Android-free
+ * by design, mirroring [ReaderHighlightSelection]'s pure offset helpers and
+ * core-data's `AnnotationExportFormatter`: keeping the formatting a pure
+ * function makes the exact shared text unit-testable without standing up a
+ * Compose runtime, a Context, or the share Intent.
+ *
+ * The dispatch half (Intent.ACTION_SEND + ClipboardManager + Toast) lives in
+ * [QuoteShareActions], which is Android-coupled and not unit-tested; this file
+ * owns the part worth pinning — the exact string a reader copies or posts.
+ *
+ * ## Output shape
+ * ```
+ * “Selected text here.”
+ *
+ * — Author Name, Book Title, Chapter Title
+ * via Candela
+ * ```
+ * Curly quotes “ ” (U+201C/U+201D) match the app's existing plain-text quote
+ * convention (`AnnotationExportFormatter.plain`) and read better in a social
+ * post than straight ASCII quotes. The attribution line is an em-dash (—)
+ * followed by the non-blank metadata joined with commas; the brand signature
+ * line is always last.
+ */
+object QuoteShareFormatter {
+
+    /** Brand signature appended as the final line. Not a string resource:
+     *  it's brand chrome (the product name never translates), and keeping it
+     *  here leaves the formatter self-contained + pure-testable. */
+    const val ATTRIBUTION = "via Candela"
+
+    /**
+     * Format [quote] with whatever attribution metadata is available.
+     *
+     * Any of [author] / [bookTitle] / [chapterTitle] may be blank (e.g. a
+     * source with no author, or a chapter loaded before its title resolves);
+     * blank parts are dropped from the attribution line and the surviving
+     * parts are comma-joined, so the dash never dangles a stray comma. When
+     * every metadata field is blank the attribution line is omitted entirely
+     * and only the quote + brand signature remain.
+     *
+     * The quote's internal whitespace — newlines from a multi-line selection,
+     * runs of spaces — is collapsed to single spaces and trimmed, so a
+     * paragraph-spanning highlight shares as one clean line rather than
+     * leaking the reader's line wrapping into the post.
+     */
+    fun format(
+        quote: String,
+        author: String,
+        bookTitle: String,
+        chapterTitle: String,
+    ): String {
+        val cleanQuote = WHITESPACE_RUN.replace(quote, " ").trim()
+        val attribution = listOf(author, bookTitle, chapterTitle)
+            .map { it.trim() }
+            .filter { it.isNotEmpty() }
+            .joinToString(", ")
+
+        return buildString {
+            append('“').append(cleanQuote).append('”')
+            if (attribution.isNotEmpty()) {
+                append("\n\n— ").append(attribution)
+            }
+            append('\n').append(ATTRIBUTION)
+        }
+    }
+
+    /** Any run of whitespace (newlines, tabs, repeated spaces) → one space. */
+    private val WHITESPACE_RUN = Regex("\\s+")
+}

--- a/feature/src/main/kotlin/in/jphe/storyvox/feature/reader/ReaderView.kt
+++ b/feature/src/main/kotlin/in/jphe/storyvox/feature/reader/ReaderView.kt
@@ -29,14 +29,18 @@ import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Close
 import androidx.compose.material.icons.filled.Pause
 import androidx.compose.material.icons.filled.PlayArrow
+import androidx.compose.material.icons.filled.Share
 import androidx.compose.material.icons.filled.VerticalAlignCenter
 import androidx.compose.material.icons.outlined.AutoAwesome
 import androidx.compose.material.icons.outlined.AutoStories
 import androidx.compose.material.icons.outlined.CenterFocusStrong
+import androidx.compose.material.icons.outlined.ContentCopy
 import androidx.compose.material.icons.outlined.ExpandLess
 import androidx.compose.material.icons.outlined.ExpandMore
 import androidx.compose.material.icons.outlined.Search
 import androidx.compose.material3.AlertDialog
+import androidx.compose.material3.DropdownMenu
+import androidx.compose.material3.DropdownMenuItem
 import androidx.compose.material3.FilledIconButton
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
@@ -69,6 +73,7 @@ import androidx.compose.ui.focus.focusRequester
 import androidx.compose.ui.layout.onGloballyPositioned
 import androidx.compose.ui.layout.onSizeChanged
 import androidx.compose.ui.layout.positionInParent
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalSoftwareKeyboardController
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.res.stringResource
@@ -204,6 +209,11 @@ fun ReaderTextView(
     /** Issue #994 — custom per-word highlight colour (ARGB int). 0 (default)
      *  derives from the reading-theme accent. */
     wordHighlightArgb: Int = 0,
+    /** Issue #1234 — the current fiction's author, for the share-quote
+     *  attribution line. Book + chapter titles come from [state]; the author
+     *  isn't on the playback state, so [HybridReaderScreen] sources it from the
+     *  fiction row. Blank (default) drops the author from the attribution. */
+    authorName: String = "",
     /** Issue #999 phase 2 — the loaded chapter's saved highlights to render as
      *  background spans + make tappable for edit/delete. Empty (default) keeps
      *  preview/test/audiobook callsites unchanged. */
@@ -864,6 +874,9 @@ fun ReaderTextView(
         pendingSelection?.let { sel ->
             HighlightCreateSheet(
                 quotedText = sel.quotedText,
+                authorName = authorName,
+                bookTitle = state.fictionTitle,
+                chapterTitle = state.chapterTitle,
                 onConfirm = { colorName, note ->
                     onCreateHighlight(sel.start, sel.end, sel.quotedText, colorName, note)
                     pendingSelection = null
@@ -878,6 +891,9 @@ fun ReaderTextView(
         editingHighlight?.let { ann ->
             HighlightEditSheet(
                 annotation = ann,
+                authorName = authorName,
+                bookTitle = state.fictionTitle,
+                chapterTitle = state.chapterTitle,
                 onSave = { colorName, note ->
                     onUpdateHighlight(ann, colorName, note)
                     editingHighlight = null
@@ -1036,6 +1052,9 @@ private fun ReaderSearchBar(
 @Composable
 private fun HighlightCreateSheet(
     quotedText: String,
+    authorName: String,
+    bookTitle: String,
+    chapterTitle: String,
     onConfirm: (colorName: String, note: String?) -> Unit,
     onDismiss: () -> Unit,
 ) {
@@ -1084,8 +1103,15 @@ private fun HighlightCreateSheet(
             )
             Row(
                 modifier = Modifier.fillMaxWidth(),
-                horizontalArrangement = Arrangement.End,
+                verticalAlignment = Alignment.CenterVertically,
             ) {
+                ShareQuoteAction(
+                    quotedText = quotedText,
+                    authorName = authorName,
+                    bookTitle = bookTitle,
+                    chapterTitle = chapterTitle,
+                )
+                Spacer(Modifier.weight(1f))
                 TextButton(onClick = onDismiss) {
                     Text(stringResource(R.string.reader_cancel))
                 }
@@ -1111,6 +1137,9 @@ private fun HighlightCreateSheet(
 @Composable
 private fun HighlightEditSheet(
     annotation: `in`.jphe.storyvox.data.db.entity.Annotation,
+    authorName: String,
+    bookTitle: String,
+    chapterTitle: String,
     onSave: (colorName: String, note: String?) -> Unit,
     onDelete: () -> Unit,
     onDismiss: () -> Unit,
@@ -1168,6 +1197,12 @@ private fun HighlightEditSheet(
                 ) {
                     Text(stringResource(R.string.reader_highlight_delete))
                 }
+                ShareQuoteAction(
+                    quotedText = annotation.quotedText,
+                    authorName = authorName,
+                    bookTitle = bookTitle,
+                    chapterTitle = chapterTitle,
+                )
                 Spacer(Modifier.weight(1f))
                 TextButton(onClick = onDismiss) {
                     Text(stringResource(R.string.reader_cancel))
@@ -1234,6 +1269,77 @@ private fun HighlightColorRow(
                         onClick = { onSelect(color) },
                     )
                     .semantics { contentDescription = label },
+            )
+        }
+    }
+}
+
+/**
+ * Issue #1234 — the share affordance shared by the create + edit highlight
+ * sheets. A single [Icons.Default.Share] [IconButton] that opens a compact
+ * [DropdownMenu] with two destinations: the system share sheet, or copy to the
+ * clipboard. One icon keeps the sheet uncluttered (the menu only materialises
+ * on tap) while still exposing both — the share button is "discoverable but
+ * not cluttered" per the issue.
+ *
+ * The shared text is built once by the pure [QuoteShareFormatter] from the
+ * quote + attribution metadata (remembered so it isn't rebuilt on every
+ * recomposition); dispatch goes through [shareQuoteText] / [copyQuoteToClipboard]
+ * (the Android-coupled half). Strings resolve here in Composable scope so the
+ * dispatch helpers stay free of resource lookups.
+ */
+@Composable
+private fun ShareQuoteAction(
+    quotedText: String,
+    authorName: String,
+    bookTitle: String,
+    chapterTitle: String,
+) {
+    val context = LocalContext.current
+    var menuOpen by remember { mutableStateOf(false) }
+    val shareLabel = stringResource(R.string.reader_quote_share)
+    val copiedMessage = stringResource(R.string.reader_quote_copied)
+    val formatted = remember(quotedText, authorName, bookTitle, chapterTitle) {
+        QuoteShareFormatter.format(
+            quote = quotedText,
+            author = authorName,
+            bookTitle = bookTitle,
+            chapterTitle = chapterTitle,
+        )
+    }
+
+    Box {
+        IconButton(
+            onClick = { menuOpen = true },
+            modifier = Modifier.testTag(TestTags.HighlightShare),
+        ) {
+            Icon(
+                Icons.Default.Share,
+                contentDescription = shareLabel,
+                tint = MaterialTheme.colorScheme.primary,
+            )
+        }
+        DropdownMenu(
+            expanded = menuOpen,
+            onDismissRequest = { menuOpen = false },
+        ) {
+            DropdownMenuItem(
+                text = { Text(stringResource(R.string.reader_quote_share_via)) },
+                leadingIcon = { Icon(Icons.Default.Share, contentDescription = null) },
+                modifier = Modifier.testTag(TestTags.HighlightShareSend),
+                onClick = {
+                    menuOpen = false
+                    shareQuoteText(context = context, text = formatted, chooserTitle = shareLabel)
+                },
+            )
+            DropdownMenuItem(
+                text = { Text(stringResource(R.string.reader_quote_copy)) },
+                leadingIcon = { Icon(Icons.Outlined.ContentCopy, contentDescription = null) },
+                modifier = Modifier.testTag(TestTags.HighlightShareCopy),
+                onClick = {
+                    menuOpen = false
+                    copyQuoteToClipboard(context = context, text = formatted, toastMessage = copiedMessage)
+                },
             )
         }
     }

--- a/feature/src/main/kotlin/in/jphe/storyvox/feature/reader/ReaderViewModel.kt
+++ b/feature/src/main/kotlin/in/jphe/storyvox/feature/reader/ReaderViewModel.kt
@@ -525,6 +525,23 @@ class ReaderViewModel @Inject constructor(
         .stateIn(viewModelScope, SharingStarted.WhileSubscribed(5_000), emptyList())
 
     /**
+     * Issue #1234 — the current fiction's author, for the share-quote
+     * attribution line. The playback state carries the fiction *title* and
+     * chapter title but not the author, so we resolve it from the fiction row
+     * keyed on the live fictionId (re-subscribing only on a book switch, like
+     * [chapters]). Blank while no fiction is loaded or the source has no
+     * author; [QuoteShareFormatter] drops a blank author from the attribution.
+     */
+    @OptIn(kotlinx.coroutines.ExperimentalCoroutinesApi::class)
+    val currentAuthor: StateFlow<String> = playback.state
+        .map { it.fictionId }
+        .distinctUntilChanged()
+        .flatMapLatest { id ->
+            if (id.isNullOrBlank()) flowOf("") else fictionRepo.fictionById(id).map { it?.author.orEmpty() }
+        }
+        .stateIn(viewModelScope, SharingStarted.WhileSubscribed(5_000), "")
+
+    /**
      * Issue #946 — magical reader auto-scroll toggle. Default true so
      * existing users keep their read-along behavior; flipping to false
      * frees the chapter body for manual scrolling while audio continues.

--- a/feature/src/main/res/values/strings.xml
+++ b/feature/src/main/res/values/strings.xml
@@ -190,6 +190,11 @@
     <!-- TalkBack labels for the colour-swatch chips; %1$s is the colour name -->
     <string name="reader_highlight_color_selected">%1$s highlight colour, selected</string>
     <string name="reader_highlight_color_unselected">%1$s highlight colour</string>
+    <!-- #1234 — share a highlighted quote with attribution -->
+    <string name="reader_quote_share">Share quote</string>
+    <string name="reader_quote_share_via">Share…</string>
+    <string name="reader_quote_copy">Copy to clipboard</string>
+    <string name="reader_quote_copied">Quote copied to clipboard</string>
 
     <!-- Reader / ResumePrompt -->
     <string name="reader_from_the_start">From the start</string>

--- a/feature/src/test/kotlin/in/jphe/storyvox/feature/reader/QuoteShareFormatterTest.kt
+++ b/feature/src/test/kotlin/in/jphe/storyvox/feature/reader/QuoteShareFormatterTest.kt
@@ -1,0 +1,92 @@
+package `in`.jphe.storyvox.feature.reader
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * Issue #1234 — pins the exact text a reader shares / copies from a highlight.
+ * Pure (no Compose / Android), mirroring [ReaderHighlightSelectionTest] and
+ * core-data's `AnnotationExportFormatterTest`: the dispatch (Intent / clipboard)
+ * isn't unit-testable here, but the string is the part that matters and it's
+ * worth locking down so attribution can't silently regress.
+ */
+class QuoteShareFormatterTest {
+
+    @Test
+    fun `full attribution renders quote, dash line, and brand signature`() {
+        val out = QuoteShareFormatter.format(
+            quote = "The quick brown fox.",
+            author = "Jane Doe",
+            bookTitle = "The Forest",
+            chapterTitle = "Chapter 3",
+        )
+        assertEquals(
+            "“The quick brown fox.”\n\n— Jane Doe, The Forest, Chapter 3\nvia Candela",
+            out,
+        )
+    }
+
+    @Test
+    fun `quote is wrapped in curly quotes`() {
+        val out = QuoteShareFormatter.format("hi", "A", "B", "C")
+        assertTrue(out.startsWith("“hi”"))
+        // No straight ASCII double-quote leaks into the shared text.
+        assertFalse(out.contains('"'))
+    }
+
+    @Test
+    fun `brand signature is always the last line`() {
+        val out = QuoteShareFormatter.format("hi", "A", "B", "C")
+        assertEquals("via Candela", out.lines().last())
+    }
+
+    @Test
+    fun `blank author is dropped without a dangling comma`() {
+        val out = QuoteShareFormatter.format(
+            quote = "Hi.",
+            author = "",
+            bookTitle = "The Forest",
+            chapterTitle = "Chapter 3",
+        )
+        assertEquals("“Hi.”\n\n— The Forest, Chapter 3\nvia Candela", out)
+    }
+
+    @Test
+    fun `blank chapter is dropped from the attribution`() {
+        val out = QuoteShareFormatter.format(
+            quote = "Hi.",
+            author = "Jane Doe",
+            bookTitle = "The Forest",
+            chapterTitle = "   ",
+        )
+        assertEquals("“Hi.”\n\n— Jane Doe, The Forest\nvia Candela", out)
+    }
+
+    @Test
+    fun `all-blank metadata omits the attribution line entirely`() {
+        val out = QuoteShareFormatter.format(
+            quote = "Hi.",
+            author = "",
+            bookTitle = "",
+            chapterTitle = "",
+        )
+        // No dash line, no blank gap — just the quote and the signature.
+        assertEquals("“Hi.”\nvia Candela", out)
+    }
+
+    @Test
+    fun `multi-line selection collapses internal whitespace to single spaces`() {
+        val out = QuoteShareFormatter.format(
+            quote = "  line one\n\n  line two\t",
+            author = "Jane Doe",
+            bookTitle = "The Forest",
+            chapterTitle = "Chapter 3",
+        )
+        assertEquals(
+            "“line one line two”\n\n— Jane Doe, The Forest, Chapter 3\nvia Candela",
+            out,
+        )
+    }
+}


### PR DESCRIPTION
## Issue #1234 — Share quotes to social / clipboard with book attribution

Highlights existed but there was no quick way to share a quote. This adds a **Share** affordance to the highlight sheets that formats the selected text with attribution.

### What it does
A single **Share** icon (`Icons.Default.Share`) sits in both the create- and edit-highlight sheets. Tapping it opens a compact Material 3 `DropdownMenu` with two destinations:
- **Share…** — Android system share sheet (`Intent.ACTION_SEND`, `text/plain`, wrapped in a chooser)
- **Copy to clipboard** — copies the formatted quote and shows a toast (suppressed on Android 13+, which shows its own clip-preview chip)

The shared/copied text:
```
“Selected text here.”

— Author Name, Book Title, Chapter Title
via Candela
```

### How it's built
- **`QuoteShareFormatter`** — pure, Compose/Android-free formatter (mirrors the `ReaderHighlightSelection` + `AnnotationExportFormatter` pure-helper pattern). Curly quotes match the app's existing plain-text quote convention; blank metadata fields drop cleanly with no dangling commas; multi-line selections collapse to one line. Fully unit-tested.
- **`QuoteShareActions`** — thin Android dispatch (chooser + clipboard + toast), mirroring `TechEmpowerIntents`' intent/clipboard pattern. Not unit-tested (no Robolectric — see CLAUDE.md); the testable logic lives in the formatter.
- **`ReaderViewModel.currentAuthor`** — author isn't on the playback state, so it's resolved from the fiction row keyed on the live `fictionId` (re-subscribes only on a book switch, like `chapters`). Book + chapter titles come from the playback state.
- **Discoverable but not cluttered** — one icon, the menu only materialises on tap. TalkBack content descriptions + test tags on every control.

### Scope
Text share only (no image-card generation — that was the issue's stretch goal). All new `ReaderTextView` params are defaulted, so existing callsites/tests/previews are unchanged.

### Testing
- `QuoteShareFormatterTest` — 7 cases: full attribution, curly quoting, brand signature placement, blank-author/blank-chapter drop, all-blank omission, multi-line whitespace collapse.
- Not compiled locally per project rules — CI `Build APK` is the compile gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
