### PR TITLE
feat(chat): expose source catalog search to AI agent (#1227)

### DIFF
--- a/core-llm/src/main/kotlin/in/jphe/storyvox/llm/tools/StoryvoxToolSpecs.kt
+++ b/core-llm/src/main/kotlin/in/jphe/storyvox/llm/tools/StoryvoxToolSpecs.kt
@@ -32,6 +32,13 @@ object StoryvoxToolSpecs {
     const val SET_SPEED = "set_speed"
     const val OPEN_VOICE_LIBRARY = "open_voice_library"
 
+    /** Issue #1227 — catalog-discovery tools. Read-only: they give the
+     *  model eyes on the source backends so it can answer "find me a
+     *  book about…" / "what should I read next" prompts with real
+     *  titles + ids instead of hallucinated ones. */
+    const val SEARCH_SOURCES = "search_sources"
+    const val GET_BOOK_DETAILS = "get_book_details"
+
     /** Allowed values for the `shelf` parameter of [ADD_TO_SHELF]. */
     val SHELVES: List<String> = listOf("Reading", "Read", "Wishlist")
 
@@ -40,6 +47,14 @@ object StoryvoxToolSpecs {
      *  range the user sees on the playback speed slider. */
     const val SPEED_MIN: Float = 0.5f
     const val SPEED_MAX: Float = 2.5f
+
+    /** Issue #1227 — default + ceiling for [SEARCH_SOURCES]'s `limit`.
+     *  The default keeps the aggregated tool-result blob small enough
+     *  to sit comfortably in the model's context window; the ceiling
+     *  caps a greedy `limit` before we render the rows. The handler
+     *  coerces into `1..SEARCH_LIMIT_MAX`. */
+    const val SEARCH_LIMIT_DEFAULT: Int = 8
+    const val SEARCH_LIMIT_MAX: Int = 25
 
     val addToShelf: ToolSpec = ToolSpec(
         name = ADD_TO_SHELF,
@@ -132,13 +147,75 @@ object StoryvoxToolSpecs {
         parameters = emptyList(),
     )
 
-    /** Ordered list of all v1 tools. Iteration order is the order
-     *  they appear in this file. */
+    val searchSources: ToolSpec = ToolSpec(
+        name = SEARCH_SOURCES,
+        description = "Search the user's enabled content sources for " +
+            "books, stories, or articles. Use this whenever the user " +
+            "asks you to find or recommend something to read — 'find " +
+            "me a cultivation story', 'any good sci-fi on Royal Road?', " +
+            "'what should I read next?'. Returns matching titles with " +
+            "their author, source, and a stable id + source id you can " +
+            "pass to get_book_details or add_to_shelf. Results are " +
+            "aggregated across every enabled source unless you name one.",
+        parameters = listOf(
+            ToolParameter.StringParam(
+                name = "query",
+                description = "What to search for — a topic, genre, " +
+                    "title fragment, or author. Plain words work best.",
+            ),
+            ToolParameter.StringParam(
+                name = "source",
+                description = "Optional. Restrict the search to a single " +
+                    "source by its id or display name (e.g. 'royalroad' " +
+                    "or 'Royal Road'). Omit to search all enabled sources.",
+                required = false,
+            ),
+            ToolParameter.IntParam(
+                name = "limit",
+                description = "Optional. Maximum number of results to " +
+                    "return (default $SEARCH_LIMIT_DEFAULT, max " +
+                    "$SEARCH_LIMIT_MAX).",
+                required = false,
+                min = 1,
+                max = SEARCH_LIMIT_MAX,
+            ),
+        ),
+    )
+
+    val getBookDetails: ToolSpec = ToolSpec(
+        name = GET_BOOK_DETAILS,
+        description = "Fetch full metadata for one fiction by id — " +
+            "synopsis, chapter count, tags/genres, rating, word count, " +
+            "and status. Use this after search_sources when the user " +
+            "wants more detail on a specific result, or to decide " +
+            "whether to recommend a book. Pass the `source` from the " +
+            "search result so the lookup routes to the right backend.",
+        parameters = listOf(
+            ToolParameter.StringParam(
+                name = "fictionId",
+                description = "The stable id of the fiction, as returned " +
+                    "by search_sources (the `id=` field).",
+            ),
+            ToolParameter.StringParam(
+                name = "source",
+                description = "Optional but recommended. The source id " +
+                    "the fiction belongs to (the `source=` field from " +
+                    "the search result). Omit and storyvox will try the " +
+                    "enabled sources in turn.",
+                required = false,
+            ),
+        ),
+    )
+
+    /** Ordered list of all tools. Iteration order is the order they
+     *  appear in this file. */
     val ALL: List<ToolSpec> = listOf(
         addToShelf,
         queueChapter,
         markChapterRead,
         setSpeed,
         openVoiceLibrary,
+        searchSources,
+        getBookDetails,
     )
 }

--- a/core-llm/src/test/kotlin/in/jphe/storyvox/llm/tools/StoryvoxToolSpecsTest.kt
+++ b/core-llm/src/test/kotlin/in/jphe/storyvox/llm/tools/StoryvoxToolSpecsTest.kt
@@ -11,10 +11,11 @@ import org.junit.Assert.assertTrue
 import org.junit.Test
 
 /**
- * Issue #216 — contract tests for the v1 [StoryvoxToolSpecs] catalog.
- * Locks in: exactly five tools, non-blank descriptions, valid
+ * Issue #216 / #1227 — contract tests for the [StoryvoxToolSpecs]
+ * catalog. Locks in: exactly seven tools, non-blank descriptions, valid
  * JSON-schema shape for every parameter, the explicit shelf enum for
- * `add_to_shelf`, and the speed clamp range for `set_speed`.
+ * `add_to_shelf`, the speed clamp range for `set_speed`, and the
+ * required/optional param split for `search_sources` / `get_book_details`.
  *
  * These are intentionally tight assertions — every advertised tool
  * round-trips through Anthropic's `input_schema` validator, so a
@@ -23,17 +24,19 @@ import org.junit.Test
 class StoryvoxToolSpecsTest {
 
     @Test
-    fun `catalog has exactly five v1 tools`() {
+    fun `catalog has exactly the seven registered tools`() {
         val names = StoryvoxToolSpecs.ALL.map { it.name }.toSet()
-        assertEquals(5, names.size)
+        assertEquals(7, names.size)
         assertTrue(
-            "Expected v1 tool set",
+            "Expected the full tool set",
             names == setOf(
                 "add_to_shelf",
                 "queue_chapter",
                 "mark_chapter_read",
                 "set_speed",
                 "open_voice_library",
+                "search_sources",
+                "get_book_details",
             ),
         )
     }
@@ -151,5 +154,36 @@ class StoryvoxToolSpecsTest {
         val schema = StoryvoxToolSpecs.openVoiceLibrary.toAnthropicInputSchema()
         assertEquals(0, schema["properties"]!!.jsonObject.size)
         assertEquals(0, schema["required"]!!.jsonArray.size)
+    }
+
+    @Test
+    fun `search_sources requires only query, with optional source and limit`() {
+        val spec = StoryvoxToolSpecs.searchSources
+        val required = spec.parameters.filter { it.required }.map { it.name }.toSet()
+        assertEquals("Only query is required", setOf("query"), required)
+        val optional = spec.parameters.filterNot { it.required }.map { it.name }.toSet()
+        assertEquals(setOf("source", "limit"), optional)
+        // The limit param advertises the catalog's clamp ceiling so the
+        // model self-limits before the handler coerces.
+        val limit = spec.parameters.single { it.name == "limit" } as ToolParameter.IntParam
+        assertEquals(1, limit.min)
+        assertEquals(StoryvoxToolSpecs.SEARCH_LIMIT_MAX, limit.max)
+    }
+
+    @Test
+    fun `get_book_details requires only fictionId, with optional source`() {
+        val spec = StoryvoxToolSpecs.getBookDetails
+        val required = spec.parameters.filter { it.required }.map { it.name }.toSet()
+        assertEquals(setOf("fictionId"), required)
+        val optional = spec.parameters.filterNot { it.required }.map { it.name }.toSet()
+        assertEquals(setOf("source"), optional)
+    }
+
+    @Test
+    fun `search limit default is within the allowed range`() {
+        assertTrue(
+            "Default must sit inside 1..max",
+            StoryvoxToolSpecs.SEARCH_LIMIT_DEFAULT in 1..StoryvoxToolSpecs.SEARCH_LIMIT_MAX,
+        )
     }
 }

--- a/feature/src/main/kotlin/in/jphe/storyvox/feature/chat/ChatScreen.kt
+++ b/feature/src/main/kotlin/in/jphe/storyvox/feature/chat/ChatScreen.kt
@@ -527,6 +527,8 @@ private fun describeInFlight(name: String): String = when (name) {
     "mark_chapter_read" -> stringResource(R.string.chat_tool_in_flight_mark_chapter_read)
     "set_speed" -> stringResource(R.string.chat_tool_in_flight_set_speed)
     "open_voice_library" -> stringResource(R.string.chat_tool_in_flight_open_voice_library)
+    "search_sources" -> stringResource(R.string.chat_tool_in_flight_search_sources)
+    "get_book_details" -> stringResource(R.string.chat_tool_in_flight_get_book_details)
     else -> stringResource(R.string.chat_tool_in_flight_generic, name)
 }
 

--- a/feature/src/main/kotlin/in/jphe/storyvox/feature/chat/ChatViewModel.kt
+++ b/feature/src/main/kotlin/in/jphe/storyvox/feature/chat/ChatViewModel.kt
@@ -8,6 +8,7 @@ import dagger.hilt.android.lifecycle.HiltViewModel
 import `in`.jphe.storyvox.data.repository.ChapterRepository
 import `in`.jphe.storyvox.data.repository.FictionMemoryRepository
 import `in`.jphe.storyvox.data.repository.ShelfRepository
+import `in`.jphe.storyvox.data.source.plugin.SourcePluginRegistry
 import `in`.jphe.storyvox.feature.api.FictionRepositoryUi
 import `in`.jphe.storyvox.feature.api.PlaybackControllerUi
 import `in`.jphe.storyvox.feature.api.SettingsRepositoryUi
@@ -241,6 +242,11 @@ class ChatViewModel @Inject constructor(
     private val shelfRepo: ShelfRepository? = null,
     private val chapterRepo: ChapterRepository? = null,
     private val llmRepo: LlmRepository? = null,
+    /** Issue #1227 — source catalog the search_sources / get_book_details
+     *  tools read from. Nullable + defaulted like the repos above so the
+     *  positional test-construction path still compiles; Hilt always
+     *  binds the real singleton in the app. */
+    private val sourceRegistry: SourcePluginRegistry? = null,
 ) : ViewModel() {
 
     /** Issue #217 — cross-fiction prompt-block builder. The title
@@ -642,6 +648,10 @@ class ChatViewModel @Inject constructor(
             fictionRepo = fictionRepo,
             playback = playback,
             settingsRepo = settingsRepo,
+            // Hilt always binds the singleton; the empty fallback only
+            // applies to the positional test-construction path, where it
+            // degrades search to "no enabled sources" rather than crashing.
+            sourceRegistry = sourceRegistry ?: SourcePluginRegistry(emptySet()),
             onOpenVoiceLibrary = {
                 _navEvents.tryEmit(ChatNavEvent.OpenVoiceLibrary)
             },

--- a/feature/src/main/kotlin/in/jphe/storyvox/feature/chat/tools/ChatToolHandlers.kt
+++ b/feature/src/main/kotlin/in/jphe/storyvox/feature/chat/tools/ChatToolHandlers.kt
@@ -3,6 +3,12 @@ package `in`.jphe.storyvox.feature.chat.tools
 import `in`.jphe.storyvox.data.db.entity.Shelf
 import `in`.jphe.storyvox.data.repository.ChapterRepository
 import `in`.jphe.storyvox.data.repository.ShelfRepository
+import `in`.jphe.storyvox.data.source.model.FictionDetail
+import `in`.jphe.storyvox.data.source.model.FictionResult
+import `in`.jphe.storyvox.data.source.model.FictionSummary
+import `in`.jphe.storyvox.data.source.model.SearchQuery
+import `in`.jphe.storyvox.data.source.plugin.SourcePluginDescriptor
+import `in`.jphe.storyvox.data.source.plugin.SourcePluginRegistry
 import `in`.jphe.storyvox.feature.api.FictionRepositoryUi
 import `in`.jphe.storyvox.feature.api.PlaybackControllerUi
 import `in`.jphe.storyvox.feature.api.SettingsRepositoryUi
@@ -10,6 +16,9 @@ import `in`.jphe.storyvox.llm.tools.StoryvoxToolSpecs
 import `in`.jphe.storyvox.llm.tools.ToolHandler
 import `in`.jphe.storyvox.llm.tools.ToolRegistry
 import `in`.jphe.storyvox.llm.tools.ToolResult
+import kotlinx.coroutines.async
+import kotlinx.coroutines.awaitAll
+import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.flow.first
 import kotlinx.serialization.json.JsonObject
 import kotlinx.serialization.json.contentOrNull
@@ -18,16 +27,22 @@ import kotlinx.serialization.json.intOrNull
 import kotlinx.serialization.json.jsonPrimitive
 
 /**
- * Issue #216 — concrete [ToolHandler] implementations wiring the v1
- * tool catalog to storyvox's data + playback layers.
+ * Issue #216 / #1227 — concrete [ToolHandler] implementations wiring
+ * the tool catalog to storyvox's data + playback + source layers.
  *
- * Constructed per-chat-turn by the ViewModel (cheap — five lambdas
- * holding repo refs), passed into the provider's tool-aware chat
- * path via [ToolRegistry]. The chat's active fiction id is captured
- * at construction time; the AI's `fictionId` argument is honored
- * over the active fiction only when the user explicitly named a
- * different book — practical guard against the model "helpfully"
+ * Constructed per-chat-turn by the ViewModel (cheap — a handful of
+ * lambdas holding repo refs), passed into the provider's tool-aware
+ * chat path via [ToolRegistry]. The chat's active fiction id is
+ * captured at construction time; the AI's `fictionId` argument is
+ * honored over the active fiction only when the user explicitly named
+ * a different book — practical guard against the model "helpfully"
  * targeting the wrong book on a search-shaped prompt.
+ *
+ * Issue #1227 — `search_sources` / `get_book_details` reach the source
+ * backends through [sourceRegistry], honoring the same enabled-set
+ * projection the Browse screen uses (`sourcePluginsEnabled[id]` with a
+ * `defaultEnabled` fallback). Auth-gated or unreachable sources are
+ * skipped so one signed-out backend never sinks the whole search.
  */
 class ChatToolHandlers(
     private val activeFictionId: String,
@@ -36,6 +51,7 @@ class ChatToolHandlers(
     private val fictionRepo: FictionRepositoryUi,
     private val playback: PlaybackControllerUi,
     private val settingsRepo: SettingsRepositoryUi,
+    private val sourceRegistry: SourcePluginRegistry,
     /** Fired on `open_voice_library` calls. The Chat ViewModel relays
      *  this to ChatScreen, which navigates via the nav controller. */
     private val onOpenVoiceLibrary: () -> Unit,
@@ -53,6 +69,8 @@ class ChatToolHandlers(
         StoryvoxToolSpecs.MARK_CHAPTER_READ -> ToolHandler { markChapterRead(it) }
         StoryvoxToolSpecs.SET_SPEED -> ToolHandler { setSpeed(it) }
         StoryvoxToolSpecs.OPEN_VOICE_LIBRARY -> ToolHandler { openVoiceLibrary() }
+        StoryvoxToolSpecs.SEARCH_SOURCES -> ToolHandler { searchSources(it) }
+        StoryvoxToolSpecs.GET_BOOK_DETAILS -> ToolHandler { getBookDetails(it) }
         else -> ToolHandler {
             ToolResult.Error("Unknown tool: $name")
         }
@@ -185,5 +203,184 @@ class ChatToolHandlers(
     internal suspend fun openVoiceLibrary(): ToolResult {
         onOpenVoiceLibrary()
         return ToolResult.Success("Opening the voice library.")
+    }
+
+    /** `search_sources(query, source?, limit?)` — aggregate a free-text
+     *  search across the enabled source backends. Optionally narrowed
+     *  to one source by id or display name. Auth-gated / unreachable
+     *  sources are skipped (partial results beat a hard failure), and
+     *  the rendered rows carry each hit's `id` + `source` so the model
+     *  can chain into [getBookDetails] / [addToShelf]. */
+    internal suspend fun searchSources(args: JsonObject): ToolResult {
+        val query = args["query"]?.jsonPrimitive?.contentOrNull?.trim()
+            ?.takeIf { it.isNotBlank() }
+            ?: return ToolResult.Error("Tell me what to search for.")
+        val sourceFilter = args["source"]?.jsonPrimitive?.contentOrNull?.trim()
+            ?.takeIf { it.isNotBlank() }
+        val limit = (args["limit"]?.jsonPrimitive?.intOrNull ?: StoryvoxToolSpecs.SEARCH_LIMIT_DEFAULT)
+            .coerceIn(1, StoryvoxToolSpecs.SEARCH_LIMIT_MAX)
+
+        val searchable = enabledDescriptors().filter { it.supportsSearch }
+        if (searchable.isEmpty()) {
+            return ToolResult.Error(
+                "No searchable sources are enabled right now — turn some " +
+                    "on in Settings → Sources.",
+            )
+        }
+        val targets = if (sourceFilter != null) {
+            searchable.filter { it.matches(sourceFilter) }.ifEmpty {
+                return ToolResult.Error(
+                    "I don't have a searchable source called \"$sourceFilter\". " +
+                        "Enabled: ${searchable.joinToString { it.displayName }}.",
+                )
+            }
+        } else {
+            searchable
+        }
+
+        val q = SearchQuery(term = query)
+        // Fan the searches out concurrently — a sequential sweep over a
+        // dozen network backends would stall the tool call for seconds.
+        // Each source is independently runCatching-guarded so a backend
+        // that throws / times out / comes back auth-gated or rate-limited
+        // contributes nothing rather than sinking the whole search.
+        // awaitAll preserves target order, so registry order survives.
+        val hits = coroutineScope {
+            targets.map { descriptor ->
+                async {
+                    val result = runCatching { descriptor.source.search(q) }.getOrNull()
+                    if (result is FictionResult.Success) {
+                        result.value.items.map { descriptor to it }
+                    } else {
+                        emptyList()
+                    }
+                }
+            }.awaitAll().flatten()
+        }
+        if (hits.isEmpty()) {
+            return ToolResult.Success(
+                "No matches for \"$query\" across " +
+                    "${targets.size} source(s).",
+            )
+        }
+        val shown = hits.take(limit)
+        val header = buildString {
+            append("Found ${hits.size} result(s) for \"$query\"")
+            if (hits.size > shown.size) append(" (showing ${shown.size})")
+            append(":")
+        }
+        val rows = shown.joinToString("\n") { (descriptor, f) ->
+            formatSearchRow(descriptor.displayName, f)
+        }
+        return ToolResult.Success("$header\n$rows")
+    }
+
+    /** `get_book_details(fictionId, source?)` — fetch the full detail
+     *  record for one fiction. Routes to the named [source] when given
+     *  (the fast path the search rows steer the model toward); falls
+     *  back to trying each enabled source in turn when it's omitted. */
+    internal suspend fun getBookDetails(args: JsonObject): ToolResult {
+        val fictionId = args["fictionId"]?.jsonPrimitive?.contentOrNull
+            ?.takeIf { it.isNotBlank() }
+            ?: return ToolResult.Error("Tell me which book — I need its fiction id.")
+        val sourceFilter = args["source"]?.jsonPrimitive?.contentOrNull?.trim()
+            ?.takeIf { it.isNotBlank() }
+
+        val enabled = enabledDescriptors()
+        if (enabled.isEmpty()) {
+            return ToolResult.Error("No sources are enabled right now.")
+        }
+        // Named source first (and only, when it resolves); otherwise sweep
+        // every enabled source until one returns a Success.
+        val ordered = if (sourceFilter != null) {
+            enabled.filter { it.matches(sourceFilter) }.ifEmpty { enabled }
+        } else {
+            enabled
+        }
+        for (descriptor in ordered) {
+            val result = runCatching { descriptor.source.fictionDetail(fictionId) }.getOrNull()
+            if (result is FictionResult.Success) {
+                return ToolResult.Success(
+                    formatBookDetails(descriptor.displayName, result.value),
+                )
+            }
+        }
+        return ToolResult.Error(
+            "I couldn't fetch details for \"$fictionId\" from any enabled source.",
+        )
+    }
+
+    // ── Source helpers ─────────────────────────────────────────────
+
+    /** The enabled subset of registered sources, mirroring the Browse
+     *  screen's projection: an explicit `sourcePluginsEnabled[id]` wins,
+     *  else the plugin's `defaultEnabled`. Settings read failures
+     *  degrade to "defaults only" rather than throwing. */
+    private suspend fun enabledDescriptors(): List<SourcePluginDescriptor> {
+        val enabledMap = runCatching { settingsRepo.settings.first().sourcePluginsEnabled }
+            .getOrDefault(emptyMap())
+        return sourceRegistry.descriptors.filter { d ->
+            enabledMap[d.id] ?: d.defaultEnabled
+        }
+    }
+
+    /** True when [needle] names this source by id or display name
+     *  (case-insensitive) — the two handles the model is likely to use. */
+    private fun SourcePluginDescriptor.matches(needle: String): Boolean =
+        id.equals(needle, ignoreCase = true) ||
+            displayName.equals(needle, ignoreCase = true)
+
+    /** One compact, dual-purpose line per search hit: readable in the
+     *  tool-call card AND parseable by the model (the `id=`/`source=`
+     *  tail feeds [getBookDetails] / [addToShelf]). */
+    private fun formatSearchRow(sourceName: String, f: FictionSummary): String {
+        val parts = buildList {
+            add("\"${f.title}\"")
+            if (f.author.isNotBlank()) add("by ${f.author}")
+            add("— $sourceName")
+            f.rating?.let { add("★${"%.1f".format(it)}") }
+            f.chapterCount?.let { add("$it ch") }
+        }
+        return "• ${parts.joinToString(" ")} [id=${f.id} source=${f.sourceId}]"
+    }
+
+    /** Multi-line metadata block for one fiction. Prefers the live
+     *  table-of-contents size for the chapter count, falling back to the
+     *  summary's hint; trims the synopsis so a long description can't
+     *  blow out the model's context. */
+    private fun formatBookDetails(sourceName: String, detail: FictionDetail): String {
+        val s = detail.summary
+        return buildString {
+            append("\"${s.title}\"")
+            if (s.author.isNotBlank()) append(" by ${s.author}")
+            append(" — $sourceName\n")
+            val chapters = detail.chapters.size.takeIf { it > 0 } ?: s.chapterCount
+            chapters?.let { append("Chapters: $it\n") }
+            detail.wordCount?.let { append("Words: ~${formatCount(it)}\n") }
+            s.rating?.let { append("Rating: ${"%.1f".format(it)}/5\n") }
+            detail.followers?.let { append("Followers: ${formatCount(it.toLong())}\n") }
+            append("Status: ")
+            append(s.status.name.lowercase().replaceFirstChar { it.uppercase() })
+            append("\n")
+            val tags = (detail.genres + s.tags).distinct().filter { it.isNotBlank() }
+            if (tags.isNotEmpty()) {
+                append("Tags: ${tags.take(12).joinToString(", ")}\n")
+            }
+            val desc = s.description?.trim()?.takeIf { it.isNotBlank() }
+            if (desc != null) {
+                append("\n")
+                append(desc.take(700))
+                if (desc.length > 700) append("…")
+            }
+        }.trimEnd()
+    }
+
+    /** Compact thousands/millions formatter for word + follower counts
+     *  (`1234 → 1.2k`, `2_500_000 → 2.5M`). Keeps the detail block
+     *  scannable without dragging in a locale-aware NumberFormat. */
+    private fun formatCount(n: Long): String = when {
+        n >= 1_000_000 -> "${"%.1f".format(n / 1_000_000.0)}M"
+        n >= 1_000 -> "${"%.1f".format(n / 1_000.0)}k"
+        else -> n.toString()
     }
 }

--- a/feature/src/main/res/values/strings.xml
+++ b/feature/src/main/res/values/strings.xml
@@ -408,6 +408,8 @@
     <string name="chat_tool_in_flight_mark_chapter_read">Marking as read…</string>
     <string name="chat_tool_in_flight_set_speed">Setting playback speed…</string>
     <string name="chat_tool_in_flight_open_voice_library">Opening voice library…</string>
+    <string name="chat_tool_in_flight_search_sources">Searching sources…</string>
+    <string name="chat_tool_in_flight_get_book_details">Fetching book details…</string>
     <string name="chat_tool_in_flight_generic">Running %1$s…</string>
     <!-- Chat · empty states -->
     <string name="chat_empty_no_provider_body">Pick a provider in Settings → AI to start chatting.</string>

--- a/feature/src/test/kotlin/in/jphe/storyvox/feature/chat/tools/ChatToolHandlersTest.kt
+++ b/feature/src/test/kotlin/in/jphe/storyvox/feature/chat/tools/ChatToolHandlersTest.kt
@@ -6,9 +6,17 @@ import `in`.jphe.storyvox.data.repository.ChapterRepository
 import `in`.jphe.storyvox.data.repository.ShelfRepository
 import `in`.jphe.storyvox.data.repository.playback.PlaybackChapter
 import `in`.jphe.storyvox.data.db.entity.ChapterDownloadState
+import `in`.jphe.storyvox.data.source.FictionSource
 import `in`.jphe.storyvox.data.source.model.ChapterContent
 import `in`.jphe.storyvox.data.source.model.ChapterInfo
+import `in`.jphe.storyvox.data.source.model.FictionDetail
+import `in`.jphe.storyvox.data.source.model.FictionResult
 import `in`.jphe.storyvox.data.source.model.FictionSummary
+import `in`.jphe.storyvox.data.source.model.ListPage
+import `in`.jphe.storyvox.data.source.model.SearchQuery
+import `in`.jphe.storyvox.data.source.plugin.SourceCategory
+import `in`.jphe.storyvox.data.source.plugin.SourcePluginDescriptor
+import `in`.jphe.storyvox.data.source.plugin.SourcePluginRegistry
 import `in`.jphe.storyvox.feature.api.DownloadMode
 import `in`.jphe.storyvox.feature.api.FictionRepositoryUi
 import `in`.jphe.storyvox.feature.api.PlaybackControllerUi
@@ -135,7 +143,7 @@ class ChatToolHandlersTest {
     fun `registry exposes every catalog tool by name`() {
         val handlers = makeHandlers()
         val registry = handlers.registry()
-        assertEquals(5, registry.catalog.size)
+        assertEquals(7, registry.catalog.size)
         registry.catalog.forEach { spec ->
             assertNotNull(
                 "Registry missing handler for ${spec.name}",
@@ -144,7 +152,181 @@ class ChatToolHandlersTest {
         }
     }
 
+    // ── search_sources ─────────────────────────────────────────────
+
+    @Test
+    fun `search_sources aggregates hits across enabled sources`() = runTest {
+        val rr = FakeSearchSource(
+            "royalroad", "Royal Road",
+            searchResult = pageOf(summary("rr1", "royalroad", "Wandering Inn", "pirateaba")),
+        )
+        val ao3 = FakeSearchSource(
+            "ao3", "AO3",
+            searchResult = pageOf(summary("ao1", "ao3", "All the Young Dudes", "MsKingBean89")),
+        )
+        val handlers = makeHandlers(sourceRegistry = registryOf(descriptorFor(rr), descriptorFor(ao3)))
+
+        val result = handlers.searchSources(buildJsonObject { put("query", "magic") })
+        assertTrue("Expected Success, got $result", result is ToolResult.Success)
+        val msg = (result as ToolResult.Success).message
+        assertTrue("Should list the RR hit (was $msg)", msg.contains("Wandering Inn"))
+        assertTrue("Should list the AO3 hit (was $msg)", msg.contains("All the Young Dudes"))
+        // The id/source tail is what lets the model chain into details.
+        assertTrue("Row should carry the fiction id", msg.contains("id=rr1"))
+        assertTrue("Row should carry the source id", msg.contains("source=ao3"))
+    }
+
+    @Test
+    fun `search_sources skips a failing source and returns the rest`() = runTest {
+        val dead = FakeSearchSource(
+            "royalroad", "Royal Road",
+            searchResult = FictionResult.AuthRequired(),
+        )
+        val live = FakeSearchSource(
+            "gutenberg", "Gutenberg",
+            searchResult = pageOf(summary("g1", "gutenberg", "Frankenstein", "Mary Shelley")),
+        )
+        val handlers = makeHandlers(sourceRegistry = registryOf(descriptorFor(dead), descriptorFor(live)))
+
+        val result = handlers.searchSources(buildJsonObject { put("query", "gothic") })
+        assertTrue("Auth-gated source must not sink the search", result is ToolResult.Success)
+        assertTrue((result as ToolResult.Success).message.contains("Frankenstein"))
+    }
+
+    @Test
+    fun `search_sources throwing source is swallowed`() = runTest {
+        val boom = FakeSearchSource(
+            "boom", "Boom", searchResult = pageOf(), throwOnSearch = true,
+        )
+        val live = FakeSearchSource(
+            "gutenberg", "Gutenberg",
+            searchResult = pageOf(summary("g1", "gutenberg", "Dracula", "Bram Stoker")),
+        )
+        val handlers = makeHandlers(sourceRegistry = registryOf(descriptorFor(boom), descriptorFor(live)))
+
+        val result = handlers.searchSources(buildJsonObject { put("query", "vampire") })
+        assertTrue(result is ToolResult.Success)
+        assertTrue((result as ToolResult.Success).message.contains("Dracula"))
+    }
+
+    @Test
+    fun `search_sources narrows to the named source`() = runTest {
+        val rr = FakeSearchSource(
+            "royalroad", "Royal Road",
+            searchResult = pageOf(summary("rr1", "royalroad", "Only RR", "a")),
+        )
+        val ao3 = FakeSearchSource(
+            "ao3", "AO3",
+            searchResult = pageOf(summary("ao1", "ao3", "Only AO3", "b")),
+        )
+        val handlers = makeHandlers(sourceRegistry = registryOf(descriptorFor(rr), descriptorFor(ao3)))
+
+        // Filter by display name (case-insensitive).
+        val result = handlers.searchSources(
+            buildJsonObject { put("query", "x"); put("source", "royal road") },
+        )
+        assertTrue(result is ToolResult.Success)
+        val msg = (result as ToolResult.Success).message
+        assertTrue(msg.contains("Only RR"))
+        assertTrue("AO3 should be excluded by the filter", !msg.contains("Only AO3"))
+    }
+
+    @Test
+    fun `search_sources caps the result count at limit`() = runTest {
+        val many = (1..5).map { summary("g$it", "gutenberg", "Book $it", "auth") }
+        val src = FakeSearchSource("gutenberg", "Gutenberg", searchResult = pageOf(*many.toTypedArray()))
+        val handlers = makeHandlers(sourceRegistry = registryOf(descriptorFor(src)))
+
+        val result = handlers.searchSources(
+            buildJsonObject { put("query", "x"); put("limit", 2) },
+        )
+        assertTrue(result is ToolResult.Success)
+        val msg = (result as ToolResult.Success).message
+        assertTrue("Header should note the cap (was $msg)", msg.contains("showing 2"))
+        // Exactly two bullet rows rendered.
+        assertEquals(2, msg.lines().count { it.startsWith("•") })
+    }
+
+    @Test
+    fun `search_sources errors on a blank query`() = runTest {
+        val handlers = makeHandlers(
+            sourceRegistry = registryOf(descriptorFor(FakeSearchSource("g", "G", pageOf()))),
+        )
+        val result = handlers.searchSources(buildJsonObject { put("query", "   ") })
+        assertTrue(result is ToolResult.Error)
+    }
+
+    @Test
+    fun `search_sources errors when no searchable source is enabled`() = runTest {
+        // A registered source that doesn't advertise search is not a target.
+        val noSearch = descriptorFor(FakeSearchSource("g", "G", pageOf()), supportsSearch = false)
+        val handlers = makeHandlers(sourceRegistry = registryOf(noSearch))
+        val result = handlers.searchSources(buildJsonObject { put("query", "x") })
+        assertTrue(result is ToolResult.Error)
+    }
+
+    // ── get_book_details ───────────────────────────────────────────
+
+    @Test
+    fun `get_book_details routes to the named source and renders metadata`() = runTest {
+        val detail = FictionDetail(
+            summary = summary("g1", "gutenberg", "Moby Dick", "Herman Melville").copy(
+                description = "A whale of a tale.",
+                rating = 4.2f,
+            ),
+            chapters = listOf(chapterInfo("c1", 0), chapterInfo("c2", 1), chapterInfo("c3", 2)),
+            genres = listOf("Adventure", "Classic"),
+            wordCount = 206_052L,
+        )
+        val src = FakeSearchSource("gutenberg", "Gutenberg", pageOf(), detailResult = FictionResult.Success(detail))
+        val handlers = makeHandlers(sourceRegistry = registryOf(descriptorFor(src)))
+
+        val result = handlers.getBookDetails(
+            buildJsonObject { put("fictionId", "g1"); put("source", "gutenberg") },
+        )
+        assertTrue("Expected Success, got $result", result is ToolResult.Success)
+        val msg = (result as ToolResult.Success).message
+        assertTrue(msg.contains("Moby Dick"))
+        assertTrue("Chapter count from the live TOC", msg.contains("Chapters: 3"))
+        assertTrue(msg.contains("Adventure"))
+        assertTrue(msg.contains("A whale of a tale."))
+    }
+
+    @Test
+    fun `get_book_details errors when no enabled source can resolve the id`() = runTest {
+        val src = FakeSearchSource("gutenberg", "Gutenberg", pageOf()) // detail defaults to NotFound
+        val handlers = makeHandlers(sourceRegistry = registryOf(descriptorFor(src)))
+        val result = handlers.getBookDetails(buildJsonObject { put("fictionId", "ghost") })
+        assertTrue(result is ToolResult.Error)
+    }
+
     // ── Helpers ────────────────────────────────────────────────────
+
+    private fun summary(id: String, sourceId: String, title: String, author: String) =
+        FictionSummary(id = id, sourceId = sourceId, title = title, author = author)
+
+    private fun chapterInfo(id: String, index: Int) =
+        ChapterInfo(id = id, sourceChapterId = id, index = index, title = "Chapter ${index + 1}")
+
+    private fun pageOf(vararg items: FictionSummary): FictionResult<ListPage<FictionSummary>> =
+        FictionResult.Success(ListPage(items.toList(), page = 1, hasNext = false))
+
+    private fun descriptorFor(
+        source: FictionSource,
+        defaultEnabled: Boolean = true,
+        supportsSearch: Boolean = true,
+    ) = SourcePluginDescriptor(
+        id = source.id,
+        displayName = source.displayName,
+        defaultEnabled = defaultEnabled,
+        category = SourceCategory.Text,
+        supportsFollow = false,
+        supportsSearch = supportsSearch,
+        source = source,
+    )
+
+    private fun registryOf(vararg descriptors: SourcePluginDescriptor) =
+        SourcePluginRegistry(descriptors.toSet())
 
     private fun makeHandlers(
         shelfRepo: FakeShelfRepo = FakeShelfRepo(),
@@ -152,6 +334,7 @@ class ChatToolHandlersTest {
         fictionRepo: FakeFictionRepoT = FakeFictionRepoT(),
         playback: FakePlayback = FakePlayback(),
         settings: FakeSettings = FakeSettings(),
+        sourceRegistry: SourcePluginRegistry = SourcePluginRegistry(emptySet()),
         onOpenVoiceLibrary: () -> Unit = {},
     ): ChatToolHandlers = ChatToolHandlers(
         activeFictionId = "f1",
@@ -160,6 +343,7 @@ class ChatToolHandlersTest {
         fictionRepo = fictionRepo,
         playback = playback,
         settingsRepo = settings,
+        sourceRegistry = sourceRegistry,
         onOpenVoiceLibrary = onOpenVoiceLibrary,
     )
 }
@@ -387,4 +571,34 @@ private class FakeSettings : SettingsRepositoryUi {
     override suspend fun setAzureFallbackEnabled(enabled: Boolean) = Unit
     override suspend fun setAzureFallbackVoiceId(voiceId: String?) = Unit
     override suspend fun testAzureConnection(): AzureProbeResult = AzureProbeResult.NotConfigured
+}
+
+/**
+ * Issue #1227 — a [FictionSource] whose `search` / `fictionDetail` return
+ * canned results, with a `throwOnSearch` escape hatch for the
+ * skip-a-broken-backend path. Only the methods the catalog tools touch
+ * carry behaviour; the rest are inert stubs.
+ */
+private class FakeSearchSource(
+    override val id: String,
+    override val displayName: String,
+    private val searchResult: FictionResult<ListPage<FictionSummary>>,
+    private val detailResult: FictionResult<FictionDetail> = FictionResult.NotFound("fake"),
+    private val throwOnSearch: Boolean = false,
+) : FictionSource {
+    override suspend fun popular(page: Int) = emptyPage(page)
+    override suspend fun latestUpdates(page: Int) = emptyPage(page)
+    override suspend fun byGenre(genre: String, page: Int) = emptyPage(page)
+    override suspend fun search(query: SearchQuery): FictionResult<ListPage<FictionSummary>> {
+        if (throwOnSearch) error("boom")
+        return searchResult
+    }
+    override suspend fun fictionDetail(fictionId: String): FictionResult<FictionDetail> = detailResult
+    override suspend fun chapter(fictionId: String, chapterId: String): FictionResult<ChapterContent> =
+        FictionResult.NotFound("fake")
+    override suspend fun followsList(page: Int) = emptyPage(page)
+    override suspend fun setFollowed(fictionId: String, followed: Boolean) = FictionResult.Success(Unit)
+    override suspend fun genres() = FictionResult.Success(emptyList<String>())
+    private fun emptyPage(page: Int) =
+        FictionResult.Success(ListPage<FictionSummary>(items = emptyList(), page = page, hasNext = false))
 }


### PR DESCRIPTION
## Issue #1227 — expose source catalog search to the AI agent

The chat librarian had no visibility into the content catalog, so it couldn't recommend or look up books — it would hallucinate titles. This adds two **read-only** tools so the agent can search the real source backends and pull detail on a result.

### What's new

**`search_sources(query, source?, limit?)`**
- Fans a free-text `SearchQuery` out across the enabled, **search-capable** sources **concurrently** (`coroutineScope`/`async`/`awaitAll`) and aggregates the hits — a sequential sweep over a dozen network backends would stall the tool call for seconds.
- Each source is independently `runCatching`-guarded: a backend that throws, times out, or returns `AuthRequired`/`RateLimited` contributes nothing rather than sinking the whole search.
- Optional `source` narrows to one backend by id or display name; `limit` defaults to 8, caps at 25.
- Rows are dual-purpose — readable in the tool-call card **and** parseable by the model: `• "Title" by Author — Source ★4.5 12 ch [id=… source=…]`. The `id`/`source` tail feeds `get_book_details` / `add_to_shelf`.

**`get_book_details(fictionId, source?)`**
- Full metadata for one fiction: synopsis (trimmed), chapter count (live TOC, falling back to the summary hint), tags/genres, rating, word count, followers, status.
- Routes to the named `source` (the fast path the search rows steer the model toward); sweeps enabled sources in turn when it's omitted.

### Wiring
- Both specs land in `StoryvoxToolSpecs.ALL`, so they're advertised + executable through the existing `ToolRegistry` whenever AI actions are enabled — provider-agnostic (Claude + OpenAI shapes both serialize from the same spec).
- Enabled-set projection mirrors the Browse screen exactly: `sourcePluginsEnabled[id]` with a `defaultEnabled` fallback.
- `ChatToolHandlers` gains a `SourcePluginRegistry` dependency; `ChatViewModel` injects the Hilt singleton (nullable + defaulted to preserve the positional test-construction path, matching the existing `shelfRepo`/`chapterRepo`/`llmRepo` convention).
- In-flight card copy + string resources added for both tool names.

### Tests
- **Catalog contract** (`core-llm`): 7 tools, valid JSON-schema per param, required/optional split for the two new tools, limit min/max.
- **Handler behaviour** (`feature`): cross-source aggregation, skip-a-failing-source (auth-gated + throwing), `source` filter, `limit` cap, blank-query rejection, no-searchable-source error, detail routing + metadata render, unresolved-id error.

> [!NOTE]
> No local gradle run (per project convention — CI's Build APK is the compile gate). All tests are JVM unit tests against fake `FictionSource` implementations.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for searching content sources and fetching book details in chat.
  * Chat now shows more specific in-flight status messages for these actions.

* **Bug Fixes**
  * Improved result handling across multiple sources, including partial failures and source-specific filtering.
  * Added safeguards for search limits and clearer handling when a book can’t be found.

* **Tests**
  * Expanded coverage for the new chat tools and their expected inputs, routing, and output formatting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->