### PR TITLE
feat(playback): per-fiction playback speed with auto-restore (#1231)

### DIFF
--- a/app/src/main/kotlin/in/jphe/storyvox/di/AppBindings.kt
+++ b/app/src/main/kotlin/in/jphe/storyvox/di/AppBindings.kt
@@ -107,7 +107,11 @@ object AppBindings {
         controller: PlaybackController,
         chapters: ChapterRepository,
         settings: SettingsRepositoryUi,
-    ): PlaybackControllerUi = RealPlaybackControllerUi(context, controller, chapters, settings)
+        // #1231 — per-fiction speed auto-restore needs to read the loaded
+        // book's pinned speed from the data layer.
+        fictionRepo: FictionRepository,
+    ): PlaybackControllerUi =
+        RealPlaybackControllerUi(context, controller, chapters, settings, fictionRepo)
 
     /**
      * Vesper (v0.4.97) — debug snapshot binding. Sits alongside
@@ -596,6 +600,13 @@ private class RealFictionRepositoryUi(
     override fun observeIsInLibrary(fictionId: String): Flow<Boolean> =
         repo.observeIsInLibrary(fictionId)
 
+    // #1231 — per-fiction playback speed passthrough to Selene's data layer.
+    override fun observePlaybackSpeed(fictionId: String): Flow<Float?> =
+        repo.observePlaybackSpeed(fictionId)
+
+    override suspend fun setPlaybackSpeed(fictionId: String, speed: Float?) =
+        repo.setPlaybackSpeed(fictionId, speed)
+
     override fun chaptersFor(fictionId: String): Flow<List<UiChapter>> =
         // Issue #282 — the previous mapping hard-coded `isFinished = false`,
         // so the played-indicator on the Fiction detail chapter list never
@@ -852,11 +863,21 @@ private class RealBrowseRepositoryUi(
  * new bytes from the network.
  */
 @OptIn(ExperimentalCoroutinesApi::class)
+/**
+ * #1231 — the inputs that decide which speed the engine runs at: the loaded
+ * fiction and whether it's a live-audio chapter. Distinct-keyed so the
+ * per-fiction speed observation only restarts on an actual book / radio change,
+ * not on every position tick from [PlaybackController.state].
+ */
+private data class FictionSpeedKey(val fictionId: String?, val isLiveAudio: Boolean)
+
 internal class RealPlaybackControllerUi(
     private val context: Context,
     private val controller: PlaybackController,
     private val chapters: ChapterRepository,
     private val settings: SettingsRepositoryUi,
+    // #1231 — source of the loaded book's pinned per-fiction speed.
+    private val fictionRepo: FictionRepository,
 ) : PlaybackControllerUi {
 
     private val scope = CoroutineScope(SupervisorJob() + Dispatchers.Main.immediate)
@@ -902,14 +923,49 @@ internal class RealPlaybackControllerUi(
         // the playback pipeline if anything's playing, so a duplicate emission
         // from DataStore hydration would interrupt audio for no reason.
         scope.launch {
-            // #195 — observe the *effective* speed/pitch (per-voice
-            // override, with global fallback) so a voice swap that
-            // brings new override values triggers setSpeed/setPitch
-            // automatically. distinctUntilChanged is still load-bearing
-            // — same value re-emitting (e.g. settings hydration) would
-            // otherwise rebuild the playback pipeline mid-sentence.
-            settings.settings
-                .map { it.effectiveSpeed }
+            // #195 + #1231 — resolve the speed the engine should run at,
+            // re-evaluated whenever the loaded book changes, its pinned
+            // per-book speed changes, or the effective (per-voice override
+            // → global) default changes.
+            //
+            // Resolution order:
+            //   1. Live-audio / radio chapter → 1.0×. Speeding a live stream
+            //      is meaningless (#1231); force baseline regardless of any
+            //      stored or effective value.
+            //   2. A non-null per-fiction `playbackSpeed` → that book's pin.
+            //   3. Otherwise the effective speed (#195 per-voice override
+            //      with the global `pref_default_speed` fallback).
+            //
+            // flatMapLatest keys on (fictionId, isLiveAudio): a book switch
+            // tears down the old book's per-speed observation and starts the
+            // new one. When no book is loaded yet (cold start, currentFictionId
+            // null) we still track the effective speed so the engine is
+            // pre-set before the first chapter loads — matching the pre-#1231
+            // behaviour. distinctUntilChanged + the controller's own
+            // same-value guard keep a redundant emission from rebuilding the
+            // pipeline mid-sentence.
+            controller.state
+                .map { FictionSpeedKey(it.currentFictionId, it.isLiveAudioChapter) }
+                .distinctUntilChanged()
+                .flatMapLatest { key ->
+                    val effective = settings.settings
+                        .map { it.effectiveSpeed }
+                        .distinctUntilChanged()
+                    if (key.fictionId == null) {
+                        effective
+                    } else {
+                        combine(
+                            fictionRepo.observePlaybackSpeed(key.fictionId),
+                            effective,
+                        ) { perBook, eff ->
+                            when {
+                                key.isLiveAudio -> 1.0f
+                                perBook != null -> perBook
+                                else -> eff
+                            }
+                        }
+                    }
+                }
                 .distinctUntilChanged()
                 .collect { controller.setSpeed(it) }
         }

--- a/app/src/test/kotlin/in/jphe/storyvox/di/RealPlaybackControllerUiTest.kt
+++ b/app/src/test/kotlin/in/jphe/storyvox/di/RealPlaybackControllerUiTest.kt
@@ -2,8 +2,17 @@ package `in`.jphe.storyvox.di
 
 import android.app.Application
 import `in`.jphe.storyvox.data.db.entity.ChapterDownloadState
+import `in`.jphe.storyvox.data.db.entity.DownloadMode
+import `in`.jphe.storyvox.data.repository.AddByUrlResult
 import `in`.jphe.storyvox.data.repository.ChapterRepository
+import `in`.jphe.storyvox.data.repository.FictionRepository
 import `in`.jphe.storyvox.data.repository.playback.PlaybackChapter
+import `in`.jphe.storyvox.data.source.RouteMatch
+import `in`.jphe.storyvox.data.source.model.FictionDetail
+import `in`.jphe.storyvox.data.source.model.FictionResult
+import `in`.jphe.storyvox.data.source.model.FictionSummary
+import `in`.jphe.storyvox.data.source.model.ListPage
+import `in`.jphe.storyvox.data.source.model.SearchQuery
 import `in`.jphe.storyvox.data.source.model.ChapterContent
 import `in`.jphe.storyvox.data.source.model.ChapterInfo
 import `in`.jphe.storyvox.feature.api.PUNCTUATION_PAUSE_DEFAULT_MULTIPLIER
@@ -62,6 +71,7 @@ class RealPlaybackControllerUiTest {
             controller = controller,
             chapters = NoOpChapters(),
             settings = settings,
+            fictionRepo = NoOpFictionRepository(),
         )
         advanceUntilIdle()
 
@@ -83,6 +93,7 @@ class RealPlaybackControllerUiTest {
             controller = controller,
             chapters = NoOpChapters(),
             settings = settings,
+            fictionRepo = NoOpFictionRepository(),
         )
         advanceUntilIdle()
 
@@ -106,6 +117,7 @@ class RealPlaybackControllerUiTest {
             controller = controller,
             chapters = NoOpChapters(),
             settings = settings,
+            fictionRepo = NoOpFictionRepository(),
         )
         advanceUntilIdle()
 
@@ -125,6 +137,7 @@ class RealPlaybackControllerUiTest {
             controller = controller,
             chapters = NoOpChapters(),
             settings = settings,
+            fictionRepo = NoOpFictionRepository(),
         )
         advanceUntilIdle()
 
@@ -368,5 +381,39 @@ class RealPlaybackControllerUiTest {
             `in`.jphe.storyvox.data.repository.CachedBodyUsage(count = 0, bytesEstimate = 0L)
         override suspend fun setChapterBookmark(chapterId: String, charOffset: Int?) = Unit
         override suspend fun chapterBookmark(chapterId: String): Int? = null
+    }
+
+    private class NoOpFictionRepository : FictionRepository {
+        override fun observeLibrary(): Flow<List<FictionSummary>> = flowOf(emptyList())
+        override fun observeFollowsRemote(): Flow<List<FictionSummary>> = flowOf(emptyList())
+        override fun observeFiction(id: String): Flow<FictionDetail?> = flowOf(null)
+        override fun observeIsInLibrary(id: String): Flow<Boolean> = flowOf(false)
+        override suspend fun browsePopular(page: Int, sourceId: String) =
+            FictionResult.Success(ListPage<FictionSummary>(emptyList(), hasMore = false))
+        override suspend fun browseLatest(page: Int, sourceId: String) =
+            FictionResult.Success(ListPage<FictionSummary>(emptyList(), hasMore = false))
+        override suspend fun browseByGenre(genre: String, page: Int, sourceId: String) =
+            FictionResult.Success(ListPage<FictionSummary>(emptyList(), hasMore = false))
+        override suspend fun search(query: SearchQuery, sourceId: String) =
+            FictionResult.Success(ListPage<FictionSummary>(emptyList(), hasMore = false))
+        override suspend fun cacheBrowseListing(
+            result: FictionResult<ListPage<FictionSummary>>,
+        ) = result
+        override suspend fun genres(sourceId: String) =
+            FictionResult.Success(emptyList<String>())
+        override suspend fun refreshDetail(id: String) = FictionResult.Success(Unit)
+        override suspend fun refreshRemoteFollows() = FictionResult.Success(Unit)
+        override suspend fun addToLibrary(id: String, mode: DownloadMode?) = Unit
+        override suspend fun removeFromLibrary(id: String) = Unit
+        override suspend fun setDownloadMode(id: String, mode: DownloadMode?) = Unit
+        override suspend fun setPinnedVoice(id: String, voiceId: String?, locale: String?) = Unit
+        override suspend fun setPlaybackSpeed(id: String, speed: Float?) = Unit
+        override fun observePlaybackSpeed(id: String): Flow<Float?> = flowOf(null)
+        override suspend fun setFollowedRemote(id: String, followed: Boolean) =
+            FictionResult.Success(Unit)
+        override suspend fun markAllCaughtUp(): Int = 0
+        override suspend fun addByUrl(url: String, preferredSourceId: String?) =
+            AddByUrlResult.UnrecognizedUrl
+        override fun previewUrl(url: String): List<RouteMatch> = emptyList()
     }
 }

--- a/app/src/test/kotlin/in/jphe/storyvox/di/RealPlaybackControllerUiTest.kt
+++ b/app/src/test/kotlin/in/jphe/storyvox/di/RealPlaybackControllerUiTest.kt
@@ -389,13 +389,13 @@ class RealPlaybackControllerUiTest {
         override fun observeFiction(id: String): Flow<FictionDetail?> = flowOf(null)
         override fun observeIsInLibrary(id: String): Flow<Boolean> = flowOf(false)
         override suspend fun browsePopular(page: Int, sourceId: String) =
-            FictionResult.Success(ListPage<FictionSummary>(emptyList(), hasMore = false))
+            FictionResult.Success(ListPage<FictionSummary>(emptyList(), page = 0, hasNext = false))
         override suspend fun browseLatest(page: Int, sourceId: String) =
-            FictionResult.Success(ListPage<FictionSummary>(emptyList(), hasMore = false))
+            FictionResult.Success(ListPage<FictionSummary>(emptyList(), page = 0, hasNext = false))
         override suspend fun browseByGenre(genre: String, page: Int, sourceId: String) =
-            FictionResult.Success(ListPage<FictionSummary>(emptyList(), hasMore = false))
+            FictionResult.Success(ListPage<FictionSummary>(emptyList(), page = 0, hasNext = false))
         override suspend fun search(query: SearchQuery, sourceId: String) =
-            FictionResult.Success(ListPage<FictionSummary>(emptyList(), hasMore = false))
+            FictionResult.Success(ListPage<FictionSummary>(emptyList(), page = 0, hasNext = false))
         override suspend fun cacheBrowseListing(
             result: FictionResult<ListPage<FictionSummary>>,
         ) = result

--- a/core-data/schemas/in.jphe.storyvox.data.db.StoryvoxDatabase/16.json
+++ b/core-data/schemas/in.jphe.storyvox.data.db.StoryvoxDatabase/16.json
@@ -1,0 +1,1111 @@
+{
+  "formatVersion": 1,
+  "database": {
+    "version": 16,
+    "identityHash": "00000000000000000000000000000000",
+    "entities": [
+      {
+        "tableName": "fiction",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `sourceId` TEXT NOT NULL, `title` TEXT NOT NULL, `author` TEXT NOT NULL, `authorId` TEXT, `coverUrl` TEXT, `description` TEXT, `genres` TEXT NOT NULL, `tags` TEXT NOT NULL, `status` TEXT NOT NULL, `chapterCount` INTEGER NOT NULL, `wordCount` INTEGER, `rating` REAL, `views` INTEGER, `followers` INTEGER, `lastUpdatedAt` INTEGER, `firstSeenAt` INTEGER NOT NULL, `metadataFetchedAt` INTEGER NOT NULL, `inLibrary` INTEGER NOT NULL, `addedToLibraryAt` INTEGER, `followedRemotely` INTEGER NOT NULL, `downloadMode` TEXT, `pinnedVoiceId` TEXT, `pinnedVoiceLocale` TEXT, `notesEverSeen` INTEGER NOT NULL, `sourceUrl` TEXT, `lastSeenRevision` TEXT, `metadataBackfillFailedAt` INTEGER, `playbackSpeed` REAL, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "sourceId",
+            "columnName": "sourceId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "title",
+            "columnName": "title",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "author",
+            "columnName": "author",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "authorId",
+            "columnName": "authorId",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "coverUrl",
+            "columnName": "coverUrl",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "description",
+            "columnName": "description",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "genres",
+            "columnName": "genres",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "tags",
+            "columnName": "tags",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "status",
+            "columnName": "status",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "chapterCount",
+            "columnName": "chapterCount",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "wordCount",
+            "columnName": "wordCount",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "rating",
+            "columnName": "rating",
+            "affinity": "REAL"
+          },
+          {
+            "fieldPath": "views",
+            "columnName": "views",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "followers",
+            "columnName": "followers",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "lastUpdatedAt",
+            "columnName": "lastUpdatedAt",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "firstSeenAt",
+            "columnName": "firstSeenAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "metadataFetchedAt",
+            "columnName": "metadataFetchedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "inLibrary",
+            "columnName": "inLibrary",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "addedToLibraryAt",
+            "columnName": "addedToLibraryAt",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "followedRemotely",
+            "columnName": "followedRemotely",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "downloadMode",
+            "columnName": "downloadMode",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "pinnedVoiceId",
+            "columnName": "pinnedVoiceId",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "pinnedVoiceLocale",
+            "columnName": "pinnedVoiceLocale",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "notesEverSeen",
+            "columnName": "notesEverSeen",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "sourceUrl",
+            "columnName": "sourceUrl",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "lastSeenRevision",
+            "columnName": "lastSeenRevision",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "metadataBackfillFailedAt",
+            "columnName": "metadataBackfillFailedAt",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "playbackSpeed",
+            "columnName": "playbackSpeed",
+            "affinity": "REAL"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_fiction_inLibrary",
+            "unique": false,
+            "columnNames": [
+              "inLibrary"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_fiction_inLibrary` ON `${TABLE_NAME}` (`inLibrary`)"
+          },
+          {
+            "name": "index_fiction_followedRemotely",
+            "unique": false,
+            "columnNames": [
+              "followedRemotely"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_fiction_followedRemotely` ON `${TABLE_NAME}` (`followedRemotely`)"
+          },
+          {
+            "name": "index_fiction_sourceId_lastUpdatedAt",
+            "unique": false,
+            "columnNames": [
+              "sourceId",
+              "lastUpdatedAt"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_fiction_sourceId_lastUpdatedAt` ON `${TABLE_NAME}` (`sourceId`, `lastUpdatedAt`)"
+          },
+          {
+            "name": "index_fiction_inLibrary_addedToLibraryAt",
+            "unique": false,
+            "columnNames": [
+              "inLibrary",
+              "addedToLibraryAt"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_fiction_inLibrary_addedToLibraryAt` ON `${TABLE_NAME}` (`inLibrary`, `addedToLibraryAt`)"
+          },
+          {
+            "name": "index_fiction_followedRemotely_lastUpdatedAt",
+            "unique": false,
+            "columnNames": [
+              "followedRemotely",
+              "lastUpdatedAt"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_fiction_followedRemotely_lastUpdatedAt` ON `${TABLE_NAME}` (`followedRemotely`, `lastUpdatedAt`)"
+          }
+        ]
+      },
+      {
+        "tableName": "chapter",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `fictionId` TEXT NOT NULL, `sourceChapterId` TEXT NOT NULL, `index` INTEGER NOT NULL, `title` TEXT NOT NULL, `publishedAt` INTEGER, `wordCount` INTEGER, `htmlBody` TEXT, `plainBody` TEXT, `bodyFetchedAt` INTEGER, `bodyChecksum` TEXT, `downloadState` TEXT NOT NULL, `lastDownloadAttemptAt` INTEGER, `lastDownloadError` TEXT, `notesAuthor` TEXT, `notesAuthorPosition` TEXT, `userMarkedRead` INTEGER NOT NULL, `firstReadAt` INTEGER, `bookmarkCharOffset` INTEGER, `audioUrl` TEXT, PRIMARY KEY(`id`), FOREIGN KEY(`fictionId`) REFERENCES `fiction`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "fictionId",
+            "columnName": "fictionId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "sourceChapterId",
+            "columnName": "sourceChapterId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "index",
+            "columnName": "index",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "title",
+            "columnName": "title",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "publishedAt",
+            "columnName": "publishedAt",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "wordCount",
+            "columnName": "wordCount",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "htmlBody",
+            "columnName": "htmlBody",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "plainBody",
+            "columnName": "plainBody",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "bodyFetchedAt",
+            "columnName": "bodyFetchedAt",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "bodyChecksum",
+            "columnName": "bodyChecksum",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "downloadState",
+            "columnName": "downloadState",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastDownloadAttemptAt",
+            "columnName": "lastDownloadAttemptAt",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "lastDownloadError",
+            "columnName": "lastDownloadError",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "notesAuthor",
+            "columnName": "notesAuthor",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "notesAuthorPosition",
+            "columnName": "notesAuthorPosition",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "userMarkedRead",
+            "columnName": "userMarkedRead",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "firstReadAt",
+            "columnName": "firstReadAt",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "bookmarkCharOffset",
+            "columnName": "bookmarkCharOffset",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "audioUrl",
+            "columnName": "audioUrl",
+            "affinity": "TEXT"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_chapter_fictionId",
+            "unique": false,
+            "columnNames": [
+              "fictionId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_chapter_fictionId` ON `${TABLE_NAME}` (`fictionId`)"
+          },
+          {
+            "name": "index_chapter_fictionId_index",
+            "unique": true,
+            "columnNames": [
+              "fictionId",
+              "index"
+            ],
+            "orders": [],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_chapter_fictionId_index` ON `${TABLE_NAME}` (`fictionId`, `index`)"
+          },
+          {
+            "name": "index_chapter_downloadState",
+            "unique": false,
+            "columnNames": [
+              "downloadState"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_chapter_downloadState` ON `${TABLE_NAME}` (`downloadState`)"
+          },
+          {
+            "name": "index_chapter_fictionId_userMarkedRead",
+            "unique": false,
+            "columnNames": [
+              "fictionId",
+              "userMarkedRead"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_chapter_fictionId_userMarkedRead` ON `${TABLE_NAME}` (`fictionId`, `userMarkedRead`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "fiction",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "fictionId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "playback_position",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`fictionId` TEXT NOT NULL, `chapterId` TEXT NOT NULL, `charOffset` INTEGER NOT NULL, `paragraphIndex` INTEGER NOT NULL, `playbackSpeed` REAL NOT NULL, `durationEstimateMs` INTEGER NOT NULL, `updatedAt` INTEGER NOT NULL, PRIMARY KEY(`fictionId`, `chapterId`), FOREIGN KEY(`fictionId`) REFERENCES `fiction`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE , FOREIGN KEY(`chapterId`) REFERENCES `chapter`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "fictionId",
+            "columnName": "fictionId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "chapterId",
+            "columnName": "chapterId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "charOffset",
+            "columnName": "charOffset",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "paragraphIndex",
+            "columnName": "paragraphIndex",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "playbackSpeed",
+            "columnName": "playbackSpeed",
+            "affinity": "REAL",
+            "notNull": true
+          },
+          {
+            "fieldPath": "durationEstimateMs",
+            "columnName": "durationEstimateMs",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "updatedAt",
+            "columnName": "updatedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "fictionId",
+            "chapterId"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_playback_position_chapterId",
+            "unique": false,
+            "columnNames": [
+              "chapterId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_playback_position_chapterId` ON `${TABLE_NAME}` (`chapterId`)"
+          },
+          {
+            "name": "index_playback_position_updatedAt",
+            "unique": false,
+            "columnNames": [
+              "updatedAt"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_playback_position_updatedAt` ON `${TABLE_NAME}` (`updatedAt`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "fiction",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "fictionId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          },
+          {
+            "table": "chapter",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "chapterId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "auth_cookie",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`sourceId` TEXT NOT NULL, `userDisplayName` TEXT, `userId` TEXT, `capturedAt` INTEGER NOT NULL, `expiresAt` INTEGER, `lastVerifiedAt` INTEGER NOT NULL, PRIMARY KEY(`sourceId`))",
+        "fields": [
+          {
+            "fieldPath": "sourceId",
+            "columnName": "sourceId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "userDisplayName",
+            "columnName": "userDisplayName",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "userId",
+            "columnName": "userId",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "capturedAt",
+            "columnName": "capturedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "expiresAt",
+            "columnName": "expiresAt",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "lastVerifiedAt",
+            "columnName": "lastVerifiedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "sourceId"
+          ]
+        }
+      },
+      {
+        "tableName": "llm_session",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `name` TEXT NOT NULL, `provider` TEXT NOT NULL, `model` TEXT NOT NULL, `systemPrompt` TEXT, `createdAt` INTEGER NOT NULL, `lastUsedAt` INTEGER NOT NULL, `featureKind` TEXT, `anchorFictionId` TEXT, `anchorChapterId` TEXT, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "provider",
+            "columnName": "provider",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "model",
+            "columnName": "model",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "systemPrompt",
+            "columnName": "systemPrompt",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "createdAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastUsedAt",
+            "columnName": "lastUsedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "featureKind",
+            "columnName": "featureKind",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "anchorFictionId",
+            "columnName": "anchorFictionId",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "anchorChapterId",
+            "columnName": "anchorChapterId",
+            "affinity": "TEXT"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "llm_message",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `sessionId` TEXT NOT NULL, `role` TEXT NOT NULL, `content` TEXT NOT NULL, `createdAt` INTEGER NOT NULL, FOREIGN KEY(`sessionId`) REFERENCES `llm_session`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "sessionId",
+            "columnName": "sessionId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "role",
+            "columnName": "role",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "content",
+            "columnName": "content",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "createdAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_llm_message_sessionId",
+            "unique": false,
+            "columnNames": [
+              "sessionId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_llm_message_sessionId` ON `${TABLE_NAME}` (`sessionId`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "llm_session",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "sessionId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "fiction_shelf",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`fictionId` TEXT NOT NULL, `shelf` TEXT NOT NULL, `addedAt` INTEGER NOT NULL, PRIMARY KEY(`fictionId`, `shelf`), FOREIGN KEY(`fictionId`) REFERENCES `fiction`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "fictionId",
+            "columnName": "fictionId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "shelf",
+            "columnName": "shelf",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "addedAt",
+            "columnName": "addedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "fictionId",
+            "shelf"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_fiction_shelf_shelf",
+            "unique": false,
+            "columnNames": [
+              "shelf"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_fiction_shelf_shelf` ON `${TABLE_NAME}` (`shelf`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "fiction",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "fictionId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "chapter_history",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`fictionId` TEXT NOT NULL, `chapterId` TEXT NOT NULL, `openedAt` INTEGER NOT NULL, `completed` INTEGER NOT NULL, `fractionRead` REAL, PRIMARY KEY(`fictionId`, `chapterId`), FOREIGN KEY(`fictionId`) REFERENCES `fiction`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE , FOREIGN KEY(`chapterId`) REFERENCES `chapter`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "fictionId",
+            "columnName": "fictionId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "chapterId",
+            "columnName": "chapterId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "openedAt",
+            "columnName": "openedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "completed",
+            "columnName": "completed",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "fractionRead",
+            "columnName": "fractionRead",
+            "affinity": "REAL"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "fictionId",
+            "chapterId"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_chapter_history_openedAt",
+            "unique": false,
+            "columnNames": [
+              "openedAt"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_chapter_history_openedAt` ON `${TABLE_NAME}` (`openedAt`)"
+          },
+          {
+            "name": "index_chapter_history_chapterId",
+            "unique": false,
+            "columnNames": [
+              "chapterId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_chapter_history_chapterId` ON `${TABLE_NAME}` (`chapterId`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "fiction",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "fictionId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          },
+          {
+            "table": "chapter",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "chapterId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "inbox_event",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `sourceId` TEXT NOT NULL, `fictionId` TEXT, `chapterId` TEXT, `title` TEXT NOT NULL, `body` TEXT, `ts` INTEGER NOT NULL, `isRead` INTEGER NOT NULL, `newChapterCount` INTEGER NOT NULL, `deepLinkUri` TEXT)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "sourceId",
+            "columnName": "sourceId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "fictionId",
+            "columnName": "fictionId",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "chapterId",
+            "columnName": "chapterId",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "title",
+            "columnName": "title",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "body",
+            "columnName": "body",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "ts",
+            "columnName": "ts",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "isRead",
+            "columnName": "isRead",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "newChapterCount",
+            "columnName": "newChapterCount",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "deepLinkUri",
+            "columnName": "deepLinkUri",
+            "affinity": "TEXT"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_inbox_event_ts",
+            "unique": false,
+            "columnNames": [
+              "ts"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_inbox_event_ts` ON `${TABLE_NAME}` (`ts`)"
+          },
+          {
+            "name": "index_inbox_event_isRead",
+            "unique": false,
+            "columnNames": [
+              "isRead"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_inbox_event_isRead` ON `${TABLE_NAME}` (`isRead`)"
+          },
+          {
+            "name": "index_inbox_event_sourceId_fictionId",
+            "unique": false,
+            "columnNames": [
+              "sourceId",
+              "fictionId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_inbox_event_sourceId_fictionId` ON `${TABLE_NAME}` (`sourceId`, `fictionId`)"
+          }
+        ]
+      },
+      {
+        "tableName": "fiction_memory_entry",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`fictionId` TEXT NOT NULL, `entityType` TEXT NOT NULL, `name` TEXT NOT NULL, `summary` TEXT NOT NULL, `firstSeenChapterIndex` INTEGER, `lastUpdated` INTEGER NOT NULL, `userEdited` INTEGER NOT NULL, PRIMARY KEY(`fictionId`, `name`))",
+        "fields": [
+          {
+            "fieldPath": "fictionId",
+            "columnName": "fictionId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "entityType",
+            "columnName": "entityType",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "summary",
+            "columnName": "summary",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "firstSeenChapterIndex",
+            "columnName": "firstSeenChapterIndex",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "lastUpdated",
+            "columnName": "lastUpdated",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "userEdited",
+            "columnName": "userEdited",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "fictionId",
+            "name"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_fiction_memory_entry_name",
+            "unique": false,
+            "columnNames": [
+              "name"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_fiction_memory_entry_name` ON `${TABLE_NAME}` (`name`)"
+          },
+          {
+            "name": "index_fiction_memory_entry_fictionId",
+            "unique": false,
+            "columnNames": [
+              "fictionId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_fiction_memory_entry_fictionId` ON `${TABLE_NAME}` (`fictionId`)"
+          }
+        ]
+      },
+      {
+        "tableName": "annotation",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `fictionId` TEXT NOT NULL, `chapterId` TEXT NOT NULL, `startOffset` INTEGER NOT NULL, `endOffset` INTEGER NOT NULL, `color` TEXT NOT NULL, `note` TEXT, `quotedText` TEXT NOT NULL, `createdAt` INTEGER NOT NULL, `updatedAt` INTEGER NOT NULL, PRIMARY KEY(`id`), FOREIGN KEY(`fictionId`) REFERENCES `fiction`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE , FOREIGN KEY(`chapterId`) REFERENCES `chapter`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "fictionId",
+            "columnName": "fictionId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "chapterId",
+            "columnName": "chapterId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "startOffset",
+            "columnName": "startOffset",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "endOffset",
+            "columnName": "endOffset",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "color",
+            "columnName": "color",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "note",
+            "columnName": "note",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "quotedText",
+            "columnName": "quotedText",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "createdAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "updatedAt",
+            "columnName": "updatedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_annotation_fictionId",
+            "unique": false,
+            "columnNames": [
+              "fictionId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_annotation_fictionId` ON `${TABLE_NAME}` (`fictionId`)"
+          },
+          {
+            "name": "index_annotation_chapterId",
+            "unique": false,
+            "columnNames": [
+              "chapterId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_annotation_chapterId` ON `${TABLE_NAME}` (`chapterId`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "fiction",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "fictionId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          },
+          {
+            "table": "chapter",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "chapterId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      }
+    ],
+    "setupQueries": [
+      "CREATE TABLE IF NOT EXISTS room_master_table (id INTEGER PRIMARY KEY,identity_hash TEXT)",
+      "INSERT OR REPLACE INTO room_master_table (id,identity_hash) VALUES(42, '7d8297870f92b9751fad505603bce1b5')"
+    ]
+  }
+}

--- a/core-data/src/main/kotlin/in/jphe/storyvox/data/db/StoryvoxDatabase.kt
+++ b/core-data/src/main/kotlin/in/jphe/storyvox/data/db/StoryvoxDatabase.kt
@@ -78,7 +78,11 @@ import `in`.jphe.storyvox.data.db.entity.PlaybackPosition
     // v15 (#1083 inbox unread-count) — adds `inbox_event.newChapterCount`
     // so coalesced polls accumulate chapter deltas instead of overwriting.
     // Purely additive NOT NULL DEFAULT 0 column.
-    version = 15,
+    //
+    // v16 (#1231 per-fiction playback speed) — adds `fiction.playbackSpeed`
+    // so a book can pin its own speed (auto-restored on load) independent of
+    // the global default. Purely additive nullable REAL column.
+    version = 16,
     exportSchema = true,
 )
 @TypeConverters(Converters::class)

--- a/core-data/src/main/kotlin/in/jphe/storyvox/data/db/dao/FictionDao.kt
+++ b/core-data/src/main/kotlin/in/jphe/storyvox/data/db/dao/FictionDao.kt
@@ -87,6 +87,15 @@ interface FictionDao {
     @Query("UPDATE fiction SET pinnedVoiceId = :voiceId, pinnedVoiceLocale = :locale WHERE id = :id")
     suspend fun setPinnedVoice(id: String, voiceId: String?, locale: String?)
 
+    /**
+     * Issue #1231 — pin (or clear) this fiction's per-book playback speed.
+     * `null` reverts the book to the global/effective default; a non-null
+     * value is auto-restored by the playback wiring every time the book
+     * loads. See [Fiction.playbackSpeed].
+     */
+    @Query("UPDATE fiction SET playbackSpeed = :speed WHERE id = :id")
+    suspend fun updatePlaybackSpeed(id: String, speed: Float?)
+
     @Query("UPDATE fiction SET metadataFetchedAt = :now WHERE id = :id")
     suspend fun touchMetadata(id: String, now: Long)
 
@@ -223,6 +232,9 @@ interface FictionDao {
                 downloadMode = existing.downloadMode,
                 pinnedVoiceId = existing.pinnedVoiceId,
                 pinnedVoiceLocale = existing.pinnedVoiceLocale,
+                // #1231 — per-book speed is user-owned; a browse-listing
+                // upsert must not reset a pinned book back to global.
+                playbackSpeed = existing.playbackSpeed,
                 notesEverSeen = existing.notesEverSeen,
                 firstSeenAt = existing.firstSeenAt,
                 // Listing pages don't carry revision tokens — only the

--- a/core-data/src/main/kotlin/in/jphe/storyvox/data/db/entity/Fiction.kt
+++ b/core-data/src/main/kotlin/in/jphe/storyvox/data/db/entity/Fiction.kt
@@ -103,6 +103,23 @@ data class Fiction(
      * null at the same time via [FictionDao.clearBackfillFailure].
      */
     val metadataBackfillFailedAt: Long? = null,
+    /**
+     * Issue #1231 — per-fiction playback speed override. Null = inherit the
+     * global default (`pref_default_speed`, with the #195 per-voice override
+     * layered on top); a non-null value pins this book to that speed and is
+     * auto-restored whenever the book is loaded for playback, regardless of
+     * what the user last left some other book at.
+     *
+     * Resolution order applied by the playback wiring
+     * (`RealPlaybackControllerUi`): live-audio/radio chapters force 1.0×
+     * (speeding up a live stream is meaningless), then a non-null
+     * [playbackSpeed] wins, then the global/effective speed. Persisted via
+     * [FictionDao.updatePlaybackSpeed] from the reader's speed control when
+     * the user picks "this book"; cleared back to null when they pick
+     * "all books". Like the other user-owned columns it is preserved across
+     * browse-listing upserts in [FictionDao.upsertAllPreservingUserState].
+     */
+    val playbackSpeed: Float? = null,
 ) {
     companion object {
         /**

--- a/core-data/src/main/kotlin/in/jphe/storyvox/data/db/migration/Migrations.kt
+++ b/core-data/src/main/kotlin/in/jphe/storyvox/data/db/migration/Migrations.kt
@@ -479,6 +479,21 @@ val MIGRATION_14_15: Migration = object : Migration(14, 15) {
     }
 }
 
+/**
+ * v16 — issue #1231: per-fiction playback speed. Adds the nullable
+ * `fiction.playbackSpeed` column so a book can pin its own speed and have
+ * it auto-restored on load, independent of the global default. Purely
+ * additive; existing rows get NULL (inherit the global/effective speed).
+ *
+ * SQLite `ALTER TABLE ADD COLUMN` with a nullable type is a metadata-only
+ * change — no row is rewritten. REAL affinity matches the `Float?` field.
+ */
+val MIGRATION_15_16: Migration = object : Migration(15, 16) {
+    override fun migrate(db: SupportSQLiteDatabase) {
+        db.execSQL("ALTER TABLE `fiction` ADD COLUMN `playbackSpeed` REAL")
+    }
+}
+
 val ALL_MIGRATIONS: Array<Migration> = arrayOf(
     MIGRATION_1_2,
     MIGRATION_2_3,
@@ -494,4 +509,5 @@ val ALL_MIGRATIONS: Array<Migration> = arrayOf(
     MIGRATION_12_13,
     MIGRATION_13_14,
     MIGRATION_14_15,
+    MIGRATION_15_16,
 )

--- a/core-data/src/main/kotlin/in/jphe/storyvox/data/repository/FictionRepository.kt
+++ b/core-data/src/main/kotlin/in/jphe/storyvox/data/repository/FictionRepository.kt
@@ -108,6 +108,15 @@ interface FictionRepository {
     suspend fun setDownloadMode(id: String, mode: DownloadMode?)
     suspend fun setPinnedVoice(id: String, voiceId: String?, locale: String?)
 
+    /**
+     * Issue #1231 — per-fiction playback speed. [setPlaybackSpeed] pins (or,
+     * with `null`, clears) the book's own speed; [observePlaybackSpeed] is the
+     * reactive read the playback wiring uses to auto-restore that speed on
+     * load and the reader UI uses to reflect whether "this book" is pinned.
+     */
+    suspend fun setPlaybackSpeed(id: String, speed: Float?)
+    fun observePlaybackSpeed(id: String): Flow<Float?>
+
     suspend fun setFollowedRemote(id: String, followed: Boolean): FictionResult<Unit>
 
     /**
@@ -385,6 +394,13 @@ class FictionRepositoryImpl @Inject constructor(
     override suspend fun setPinnedVoice(id: String, voiceId: String?, locale: String?) {
         fictionDao.setPinnedVoice(id, voiceId, locale)
     }
+
+    override suspend fun setPlaybackSpeed(id: String, speed: Float?) {
+        fictionDao.updatePlaybackSpeed(id, speed)
+    }
+
+    override fun observePlaybackSpeed(id: String): Flow<Float?> =
+        fictionDao.observe(id).map { it?.playbackSpeed }.distinctUntilChanged()
 
     override suspend fun setFollowedRemote(id: String, followed: Boolean): FictionResult<Unit> =
         withContext(Dispatchers.IO) {

--- a/core-data/src/test/kotlin/in/jphe/storyvox/data/db/StoryvoxDatabaseMigrationTest.kt
+++ b/core-data/src/test/kotlin/in/jphe/storyvox/data/db/StoryvoxDatabaseMigrationTest.kt
@@ -18,6 +18,7 @@ import `in`.jphe.storyvox.data.db.migration.MIGRATION_11_12
 import `in`.jphe.storyvox.data.db.migration.MIGRATION_12_13
 import `in`.jphe.storyvox.data.db.migration.MIGRATION_13_14
 import `in`.jphe.storyvox.data.db.migration.MIGRATION_14_15
+import `in`.jphe.storyvox.data.db.migration.MIGRATION_15_16
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNotNull
 import org.junit.Assert.assertTrue
@@ -157,6 +158,8 @@ class StoryvoxDatabaseMigrationTest {
         helper.runMigrationsAndValidate(dbName, 14, true, MIGRATION_13_14).close()
         // #1083 — v15 adds inbox_event.newChapterCount. Chain through.
         helper.runMigrationsAndValidate(dbName, 15, true, MIGRATION_14_15).close()
+        // #1231 — chain through v16 (fiction.playbackSpeed).
+        helper.runMigrationsAndValidate(dbName, 16, true, MIGRATION_15_16).close()
 
         val ctx = org.robolectric.RuntimeEnvironment.getApplication() as android.content.Context
         val db = Room.databaseBuilder(ctx, StoryvoxDatabase::class.java, dbName)
@@ -164,6 +167,7 @@ class StoryvoxDatabaseMigrationTest {
                 MIGRATION_4_5, MIGRATION_5_6, MIGRATION_6_7, MIGRATION_7_8,
                 MIGRATION_8_9, MIGRATION_9_10, MIGRATION_10_11, MIGRATION_11_12,
                 MIGRATION_12_13, MIGRATION_13_14, MIGRATION_14_15,
+                MIGRATION_15_16,
             )
             .build()
 
@@ -330,6 +334,8 @@ class StoryvoxDatabaseMigrationTest {
         helper.runMigrationsAndValidate(dbName, 14, true, MIGRATION_13_14).close()
         // #1083 — chain through v15 (inbox_event.newChapterCount).
         helper.runMigrationsAndValidate(dbName, 15, true, MIGRATION_14_15).close()
+        // #1231 — chain through v16 (fiction.playbackSpeed).
+        helper.runMigrationsAndValidate(dbName, 16, true, MIGRATION_15_16).close()
 
         val ctx = org.robolectric.RuntimeEnvironment.getApplication() as android.content.Context
         val db = Room.databaseBuilder(ctx, StoryvoxDatabase::class.java, dbName)
@@ -337,6 +343,7 @@ class StoryvoxDatabaseMigrationTest {
                 MIGRATION_4_5, MIGRATION_5_6, MIGRATION_6_7, MIGRATION_7_8,
                 MIGRATION_8_9, MIGRATION_9_10, MIGRATION_10_11, MIGRATION_11_12,
                 MIGRATION_12_13, MIGRATION_13_14, MIGRATION_14_15,
+                MIGRATION_15_16,
             )
             .build()
 
@@ -1133,6 +1140,8 @@ class StoryvoxDatabaseMigrationTest {
         helper.runMigrationsAndValidate(dbName, 14, true, MIGRATION_13_14).close()
         // #1083 — chain through v15 (inbox_event.newChapterCount).
         helper.runMigrationsAndValidate(dbName, 15, true, MIGRATION_14_15).close()
+        // #1231 — chain through v16 (fiction.playbackSpeed).
+        helper.runMigrationsAndValidate(dbName, 16, true, MIGRATION_15_16).close()
 
         val ctx = org.robolectric.RuntimeEnvironment.getApplication() as android.content.Context
         val db = Room.databaseBuilder(ctx, StoryvoxDatabase::class.java, dbName)
@@ -1140,6 +1149,7 @@ class StoryvoxDatabaseMigrationTest {
                 MIGRATION_4_5, MIGRATION_5_6, MIGRATION_6_7, MIGRATION_7_8,
                 MIGRATION_8_9, MIGRATION_9_10, MIGRATION_10_11, MIGRATION_11_12,
                 MIGRATION_12_13, MIGRATION_13_14, MIGRATION_14_15,
+                MIGRATION_15_16,
             )
             .build()
 
@@ -1301,6 +1311,100 @@ class StoryvoxDatabaseMigrationTest {
         ).use { c ->
             assertTrue(c.moveToFirst())
             assertEquals(5, c.getInt(0))
+        }
+
+        db.close()
+    }
+
+    /**
+     * Issue #1231 — v16 adds the nullable `fiction.playbackSpeed` column so a
+     * book can pin its own playback speed (auto-restored on load) independent
+     * of the global default. Purely additive; existing rows get NULL (inherit
+     * the global/effective speed).
+     *
+     * Seeds a v15 fiction row, runs 15->16, and asserts the column exists, is
+     * nullable, defaults to NULL on the pre-existing row, and that a pinned
+     * speed write round-trips. `runMigrationsAndValidate(..., 16, true,
+     * MIGRATION_15_16)` also triggers Room's schema validation against
+     * `16.json`, so a malformed ALTER TABLE or a drifted entity fails here too.
+     */
+    @Test fun `migrate v15 to v16 adds fiction playbackSpeed column`() {
+        val dbName = "playback-speed-migration-test.db"
+
+        helper.createDatabase(dbName, 4).close()
+        helper.runMigrationsAndValidate(dbName, 5, true, MIGRATION_4_5).close()
+        helper.runMigrationsAndValidate(dbName, 6, true, MIGRATION_5_6).close()
+        helper.runMigrationsAndValidate(dbName, 7, true, MIGRATION_6_7).close()
+        helper.runMigrationsAndValidate(dbName, 8, true, MIGRATION_7_8).close()
+        helper.runMigrationsAndValidate(dbName, 9, true, MIGRATION_8_9).close()
+        helper.runMigrationsAndValidate(dbName, 10, true, MIGRATION_9_10).close()
+        helper.runMigrationsAndValidate(dbName, 11, true, MIGRATION_10_11).close()
+        helper.runMigrationsAndValidate(dbName, 12, true, MIGRATION_11_12).close()
+        helper.runMigrationsAndValidate(dbName, 13, true, MIGRATION_12_13).close()
+        helper.runMigrationsAndValidate(dbName, 14, true, MIGRATION_13_14).close()
+        helper.runMigrationsAndValidate(dbName, 15, true, MIGRATION_14_15).use { db ->
+            // Seed a fiction at v15 so the existing row exercises the
+            // NULL-default behaviour after the column lands.
+            db.execSQL(
+                """
+                INSERT INTO fiction(
+                    id, sourceId, title, author, genres, tags, status,
+                    chapterCount, firstSeenAt, metadataFetchedAt,
+                    inLibrary, followedRemotely, notesEverSeen
+                ) VALUES (
+                    'rr:42', 'royalroad', 'Mother of Learning', 'nobody103',
+                    '[]', '[]', 'ONGOING', 0, 0, 0, 1, 0, 0
+                )
+                """.trimIndent(),
+            )
+        }
+
+        val db = helper.runMigrationsAndValidate(
+            dbName,
+            16,
+            /* validateDroppedTables = */ true,
+            MIGRATION_15_16,
+        )
+
+        db.query("PRAGMA table_info('fiction')").use { c ->
+            var sawColumn = false
+            while (c.moveToNext()) {
+                val name = c.getString(c.getColumnIndexOrThrow("name"))
+                if (name == "playbackSpeed") {
+                    sawColumn = true
+                    val type = c.getString(c.getColumnIndexOrThrow("type"))
+                    assertEquals("REAL", type)
+                    val notnull = c.getInt(c.getColumnIndexOrThrow("notnull"))
+                    assertEquals(
+                        "playbackSpeed must be nullable (NULL = inherit global)",
+                        0,
+                        notnull,
+                    )
+                }
+            }
+            assertTrue(
+                "fiction.playbackSpeed column must exist post-migration",
+                sawColumn,
+            )
+        }
+
+        // Pre-existing v15 row must round-trip with a NULL playbackSpeed.
+        db.query(
+            "SELECT id, playbackSpeed FROM fiction WHERE id = 'rr:42'",
+        ).use { c ->
+            assertTrue("seeded v15 fiction row must survive the migration", c.moveToFirst())
+            assertEquals("rr:42", c.getString(0))
+            assertTrue(
+                "playbackSpeed must default to NULL for existing rows",
+                c.isNull(1),
+            )
+        }
+
+        // A pinned per-book speed write round-trips through the new column.
+        db.execSQL("UPDATE fiction SET playbackSpeed = 1.5 WHERE id = 'rr:42'")
+        db.query("SELECT playbackSpeed FROM fiction WHERE id = 'rr:42'").use { c ->
+            assertTrue(c.moveToFirst())
+            assertEquals(1.5f, c.getFloat(0), 0.0001f)
         }
 
         db.close()

--- a/core-data/src/test/kotlin/in/jphe/storyvox/data/db/dao/FictionDaoTest.kt
+++ b/core-data/src/test/kotlin/in/jphe/storyvox/data/db/dao/FictionDaoTest.kt
@@ -235,6 +235,22 @@ class FictionDaoTest {
         assertEquals("en-US", row.pinnedVoiceLocale)
     }
 
+    // ----- #1231 per-fiction playback speed --------------------------------------
+
+    @Test
+    fun updatePlaybackSpeed_pinsAndClears() = runTest {
+        dao.upsert(fixture(id = "f1"))
+        // Default: no per-book override.
+        assertNull(dao.get("f1")!!.playbackSpeed)
+
+        dao.updatePlaybackSpeed("f1", 1.75f)
+        assertEquals(1.75f, dao.get("f1")!!.playbackSpeed!!, 0.0001f)
+
+        // null clears the override back to "inherit global".
+        dao.updatePlaybackSpeed("f1", null)
+        assertNull(dao.get("f1")!!.playbackSpeed)
+    }
+
     @Test
     fun touchMetadata_writesTimestamp() = runTest {
         dao.upsert(fixture(id = "f1").copy(metadataFetchedAt = 0L))
@@ -326,6 +342,7 @@ class FictionDaoTest {
                     downloadMode = DownloadMode.EAGER,
                     pinnedVoiceId = "tony",
                     pinnedVoiceLocale = "en-US",
+                    playbackSpeed = 1.75f,
                     notesEverSeen = true,
                     firstSeenAt = 50L,
                     lastSeenRevision = "rev-1",
@@ -347,6 +364,8 @@ class FictionDaoTest {
         assertEquals(DownloadMode.EAGER, row.downloadMode)
         assertEquals("tony", row.pinnedVoiceId)
         assertEquals("en-US", row.pinnedVoiceLocale)
+        // #1231 — per-book speed is user-owned; a listing upsert must not reset it.
+        assertEquals(1.75f, row.playbackSpeed!!, 0.0001f)
         assertTrue(row.notesEverSeen)
         // firstSeenAt is preserved (not overwritten with the listing's 999).
         assertEquals(50L, row.firstSeenAt)

--- a/core-data/src/test/kotlin/in/jphe/storyvox/data/repository/FictionRepositoryImplTest.kt
+++ b/core-data/src/test/kotlin/in/jphe/storyvox/data/repository/FictionRepositoryImplTest.kt
@@ -167,6 +167,13 @@ class FictionRepositoryImplTest {
             publish(id)
         }
 
+        override suspend fun updatePlaybackSpeed(id: String, speed: Float?) {
+            callLog += "updatePlaybackSpeed($id, $speed)"
+            val r = rows[id] ?: return
+            rows[id] = r.copy(playbackSpeed = speed)
+            publish(id)
+        }
+
         override suspend fun touchMetadata(id: String, now: Long) {
             val r = rows[id] ?: return
             rows[id] = r.copy(metadataFetchedAt = now)

--- a/core-playback/src/main/kotlin/in/jphe/storyvox/playback/PlaybackController.kt
+++ b/core-playback/src/main/kotlin/in/jphe/storyvox/playback/PlaybackController.kt
@@ -818,6 +818,15 @@ class DefaultPlaybackController @Inject constructor(
 
     override fun setSpeed(speed: Float) {
         val clamped = speed.coerceIn(0.5f, 3.0f)
+        // #1231 — no-op when the speed is already what's playing.
+        // [EnginePlayer.setSpeed] unconditionally tears down + rebuilds the
+        // pipeline (the #555 position handoff), so a redundant set — e.g. the
+        // per-fiction auto-restore flow re-emitting a value the live slider
+        // drag already applied — would hiccup the audio for nothing. Both the
+        // settings/effective-speed collector and the reader slider already feed
+        // distinct values; this guards the one case they can't see (a flow
+        // value converging on the live engine speed).
+        if (clamped == state.value.speed) return
         player?.setSpeed(clamped)
     }
 

--- a/core-sync/src/test/kotlin/in/jphe/storyvox/sync/PlaybackPositionSyncerTest.kt
+++ b/core-sync/src/test/kotlin/in/jphe/storyvox/sync/PlaybackPositionSyncerTest.kt
@@ -197,6 +197,7 @@ class PlaybackPositionSyncerTest {
         override suspend fun setFollowedRemote(id: String, followed: Boolean) = error("not used")
         override suspend fun setDownloadMode(id: String, mode: DownloadMode?) = error("not used")
         override suspend fun setPinnedVoice(id: String, voiceId: String?, locale: String?) = error("not used")
+        override suspend fun updatePlaybackSpeed(id: String, speed: Float?) = error("not used")
         override suspend fun touchMetadata(id: String, now: Long) = error("not used")
         override suspend fun setSourceId(id: String, sourceId: String) = error("not used")
         override suspend fun getSourceUrl(id: String): String? = error("not used")

--- a/feature/src/main/kotlin/in/jphe/storyvox/feature/api/UiContracts.kt
+++ b/feature/src/main/kotlin/in/jphe/storyvox/feature/api/UiContracts.kt
@@ -6,6 +6,7 @@ import `in`.jphe.storyvox.ui.theme.ReaderTheme
 import `in`.jphe.storyvox.ui.theme.ReaderFontFamily
 import `in`.jphe.storyvox.ui.theme.ReaderTypography
 import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.flowOf
 
 /**
  * Lightweight contracts the feature module depends on. The real impls live in
@@ -161,6 +162,17 @@ interface FictionRepositoryUi {
      * FictionDetailViewModel to avoid the O(n) full-list scan.
      */
     fun observeIsInLibrary(fictionId: String): Flow<Boolean>
+    /**
+     * Issue #1231 — per-fiction playback speed. [observePlaybackSpeed] is a
+     * targeted stream of this book's pinned speed (null = inherit the global
+     * default); [setPlaybackSpeed] pins it, or clears it with null. The
+     * reader's speed control uses these to offer "this book vs all books" and
+     * to reflect which scope is currently active. Defaulted so the many
+     * lightweight [FictionRepositoryUi] fakes in tests don't have to implement
+     * them; the real adapter overrides both.
+     */
+    fun observePlaybackSpeed(fictionId: String): Flow<Float?> = flowOf(null)
+    suspend fun setPlaybackSpeed(fictionId: String, speed: Float?) {}
     /**
      * Issue #212 — fetch the plain-text body of a downloaded chapter
      * for AI grounding. Returns null if the chapter row doesn't exist

--- a/feature/src/main/kotlin/in/jphe/storyvox/feature/reader/AudiobookView.kt
+++ b/feature/src/main/kotlin/in/jphe/storyvox/feature/reader/AudiobookView.kt
@@ -139,6 +139,13 @@ fun AudiobookView(
     onPickVoice: () -> Unit,
     onSetSpeed: (Float) -> Unit,
     onPersistSpeed: (Float) -> Unit,
+    /** #1231 — true when the current book has its own pinned speed; drives the
+     *  voice quick-sheet's "This book / All books" scope toggle. Default false
+     *  so older callsites (tests, previews) keep compiling. */
+    perBookSpeedActive: Boolean = false,
+    /** #1231 — pin the current speed to this book (true) or clear the pin and
+     *  fall back to the global default (false). */
+    onToggleSpeedScope: (Boolean) -> Unit = {},
     onSetPitch: (Float) -> Unit,
     onPersistPitch: (Float) -> Unit,
     onStartSleepTimer: (UiSleepTimerMode) -> Unit,
@@ -1045,6 +1052,8 @@ fun AudiobookView(
                     pitchInterpolationHighQuality = pitchInterpolationHighQuality,
                     onSetSpeed = onSetSpeed,
                     onPersistSpeed = onPersistSpeed,
+                    perBookSpeedActive = perBookSpeedActive,
+                    onToggleSpeedScope = onToggleSpeedScope,
                     onSetPitch = onSetPitch,
                     onPersistPitch = onPersistPitch,
                     onSetPunctuationPause = onSetPunctuationPause,

--- a/feature/src/main/kotlin/in/jphe/storyvox/feature/reader/HybridReaderScreen.kt
+++ b/feature/src/main/kotlin/in/jphe/storyvox/feature/reader/HybridReaderScreen.kt
@@ -93,6 +93,8 @@ fun HybridReaderScreen(
     val recapPlayback by viewModel.recapPlayback.collectAsStateWithLifecycle()
     val resumeEntry by viewModel.resumeEntry.collectAsStateWithLifecycle()
     val chapters by viewModel.chapters.collectAsStateWithLifecycle()
+    // #1231 — whether the current book has its own pinned playback speed.
+    val speedIsPerBook by viewModel.speedIsPerBook.collectAsStateWithLifecycle()
     val autoScrollEnabled by viewModel.autoScrollEnabled.collectAsStateWithLifecycle()
     val focusModeEnabled by viewModel.focusModeEnabled.collectAsStateWithLifecycle()
     val readerColors by viewModel.readerColors.collectAsStateWithLifecycle()
@@ -276,6 +278,9 @@ fun HybridReaderScreen(
                 onPickVoice = onPickVoice,
                 onSetSpeed = viewModel::setSpeed,
                 onPersistSpeed = viewModel::persistSpeed,
+                // #1231 — per-fiction speed scope toggle.
+                perBookSpeedActive = speedIsPerBook,
+                onToggleSpeedScope = viewModel::toggleSpeedScope,
                 onSetPitch = viewModel::setPitch,
                 onPersistPitch = viewModel::persistPitch,
                 onStartSleepTimer = viewModel::startSleepTimer,

--- a/feature/src/main/kotlin/in/jphe/storyvox/feature/reader/ReaderViewModel.kt
+++ b/feature/src/main/kotlin/in/jphe/storyvox/feature/reader/ReaderViewModel.kt
@@ -508,6 +508,29 @@ class ReaderViewModel @Inject constructor(
         .stateIn(viewModelScope, SharingStarted.WhileSubscribed(5_000), emptyList())
 
     /**
+     * Issue #1231 — the loaded book's pinned per-fiction speed, or null when
+     * it inherits the global default. Observed per-fiction (re-subscribes on a
+     * book switch) so the reader's speed-scope toggle reflects the right book.
+     */
+    @OptIn(kotlinx.coroutines.ExperimentalCoroutinesApi::class)
+    val perBookSpeed: StateFlow<Float?> = playback.state
+        .map { it.fictionId }
+        .distinctUntilChanged()
+        .flatMapLatest { id ->
+            if (id.isNullOrBlank()) flowOf(null) else fictionRepo.observePlaybackSpeed(id)
+        }
+        .stateIn(viewModelScope, SharingStarted.WhileSubscribed(5_000), null)
+
+    /**
+     * Issue #1231 — whether the speed control's "this book" scope is active
+     * (the current book has its own pinned speed). Drives the segmented toggle
+     * in the voice quick-sheet and the routing in [persistSpeed].
+     */
+    val speedIsPerBook: StateFlow<Boolean> = perBookSpeed
+        .map { it != null }
+        .stateIn(viewModelScope, SharingStarted.WhileSubscribed(5_000), false)
+
+    /**
      * Issue #999 phase 2 — the loaded chapter's saved highlights, observed
      * per-chapter so the reader renders only the current chapter's spans and
      * the observer re-subscribes on a chapter switch (not on every fiction
@@ -737,8 +760,37 @@ class ReaderViewModel @Inject constructor(
         playback.setSpeed(speed)
     }
 
+    /**
+     * Issue #1231 — commit a speed change to the active scope. When the
+     * current book is pinned ("this book"), the new speed updates that book's
+     * override; otherwise it updates the global default. The reader's speed
+     * chips + slider both route through here on commit; the auto-restore flow
+     * in RealPlaybackControllerUi reacts to whichever store changed.
+     */
     fun persistSpeed(speed: Float) {
-        viewModelScope.launch { settings.setDefaultSpeed(speed) }
+        val fictionId = uiState.value.playback?.fictionId
+        viewModelScope.launch {
+            if (fictionId != null && speedIsPerBook.value) {
+                fictionRepo.setPlaybackSpeed(fictionId, speed)
+            } else {
+                settings.setDefaultSpeed(speed)
+            }
+        }
+    }
+
+    /**
+     * Issue #1231 — flip the speed-scope for the current book. `perBook = true`
+     * pins the book to the speed it's playing at right now; `false` clears the
+     * pin so the book reverts to the global/effective default. A pin/clear is
+     * all this does — the live engine speed is re-resolved by the auto-restore
+     * flow reacting to the persisted change. No-op when no book is loaded.
+     */
+    fun toggleSpeedScope(perBook: Boolean) {
+        val fictionId = uiState.value.playback?.fictionId ?: return
+        val currentSpeed = uiState.value.playback?.speed ?: 1.0f
+        viewModelScope.launch {
+            fictionRepo.setPlaybackSpeed(fictionId, if (perBook) currentSpeed else null)
+        }
     }
 
     fun setPitch(pitch: Float) {

--- a/feature/src/main/kotlin/in/jphe/storyvox/feature/reader/VoiceQuickSheet.kt
+++ b/feature/src/main/kotlin/in/jphe/storyvox/feature/reader/VoiceQuickSheet.kt
@@ -40,6 +40,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.semantics.Role
 import androidx.compose.ui.semantics.contentDescription
+import androidx.compose.ui.semantics.role
 import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.semantics.stateDescription
 import `in`.jphe.storyvox.feature.R
@@ -82,6 +83,12 @@ internal fun VoiceQuickSheetContent(
     pitchInterpolationHighQuality: Boolean,
     onSetSpeed: (Float) -> Unit,
     onPersistSpeed: (Float) -> Unit,
+    // #1231 — speed-scope toggle: true when the current book has its own
+    // pinned speed. Tapping a chip pins ("This book") or clears ("All books").
+    // Defaulted so previews / unit tests that exercise the chip rows don't
+    // have to supply them.
+    perBookSpeedActive: Boolean = false,
+    onToggleSpeedScope: (Boolean) -> Unit = {},
     onSetPitch: (Float) -> Unit,
     onPersistPitch: (Float) -> Unit,
     onSetPunctuationPause: (Float) -> Unit,
@@ -116,6 +123,34 @@ internal fun VoiceQuickSheetContent(
         // the value is committed immediately. The slider stays
         // available for fine-tuning between presets.
         QuickSheetHeader(stringResource(R.string.reader_voice_speed_header), "${"%.2f".format(state.speed)}×")
+        // #1231 — scope toggle: pin this speed to just this book, or apply it
+        // to all books (the global default). Hidden for live-audio/radio
+        // chapters, which always play at 1.0× (per-book speed is meaningless
+        // for a live stream).
+        if (!state.isLiveAudioChapter) {
+            val thisBookCd = stringResource(R.string.reader_speed_scope_this_book_cd)
+            val allBooksCd = stringResource(R.string.reader_speed_scope_all_books_cd)
+            Row(horizontalArrangement = Arrangement.spacedBy(spacing.sm)) {
+                FilterChip(
+                    selected = perBookSpeedActive,
+                    onClick = { if (!perBookSpeedActive) onToggleSpeedScope(true) },
+                    label = { Text(stringResource(R.string.reader_speed_scope_this_book)) },
+                    modifier = Modifier.semantics {
+                        contentDescription = thisBookCd
+                        role = Role.RadioButton
+                    },
+                )
+                FilterChip(
+                    selected = !perBookSpeedActive,
+                    onClick = { if (perBookSpeedActive) onToggleSpeedScope(false) },
+                    label = { Text(stringResource(R.string.reader_speed_scope_all_books)) },
+                    modifier = Modifier.semantics {
+                        contentDescription = allBooksCd
+                        role = Role.RadioButton
+                    },
+                )
+            }
+        }
         QuickSheetPresetChipRow(
             presets = SPEED_PRESETS,
             isSelected = { preset -> isSpeedPresetSelected(state.speed, preset) },

--- a/feature/src/main/res/values/strings.xml
+++ b/feature/src/main/res/values/strings.xml
@@ -222,6 +222,11 @@
     <string name="reader_voice_hide_custom_slider">Hide custom slider</string>
     <string name="reader_voice_show_custom_slider">Show custom slider</string>
     <string name="reader_voice_speed_header">Speed</string>
+    <!-- #1231 — per-fiction playback speed scope toggle in the voice quick-sheet. -->
+    <string name="reader_speed_scope_this_book">This book</string>
+    <string name="reader_speed_scope_all_books">All books</string>
+    <string name="reader_speed_scope_this_book_cd">Save speed for this book only</string>
+    <string name="reader_speed_scope_all_books_cd">Use this speed for all books</string>
     <string name="reader_voice_pitch_header">Pitch</string>
     <string name="reader_voice_sentence_silence_header">Sentence silence</string>
     <string name="reader_voice_speech_speed_cd">Speech speed</string>

--- a/source-epub-writer/src/test/kotlin/in/jphe/storyvox/source/epub/writer/NoopDaos.kt
+++ b/source-epub-writer/src/test/kotlin/in/jphe/storyvox/source/epub/writer/NoopDaos.kt
@@ -43,6 +43,7 @@ internal class NoopFictionDao : FictionDao {
     override suspend fun setFollowedRemote(id: String, followed: Boolean) = Unit
     override suspend fun setDownloadMode(id: String, mode: DownloadMode?) = Unit
     override suspend fun setPinnedVoice(id: String, voiceId: String?, locale: String?) = Unit
+    override suspend fun updatePlaybackSpeed(id: String, speed: Float?) = Unit
     override suspend fun touchMetadata(id: String, now: Long) = Unit
     override suspend fun setSourceId(id: String, sourceId: String) = Unit
     override suspend fun getSourceUrl(id: String): String? = null


### PR DESCRIPTION
## Per-fiction playback speed (#1231)

Playback speed was global. Now each book remembers its own speed and restores it automatically when reloaded; books without an override still follow the global default (with the #195 per-voice override layered on top).

### Behaviour
- **Pin a book's speed**: in the reader's voice quick-sheet, a new **This book / All books** toggle sits under the Speed header. "This book" pins the current speed to the loaded fiction; "All books" clears the pin and reverts to the global default. The speed chips + slider then commit to whichever scope is active.
- **Auto-restore**: switching to a pinned book applies its speed; switching to an unpinned book applies the global/effective speed. No mid-listen jump — the controller no-ops a same-value set.
- **Radio / live audio** (`isLiveAudioChapter`): always 1.0× (speeding a live stream is meaningless). The scope toggle is hidden for live audio.

### Data layer
- `Fiction.playbackSpeed: Float?` — nullable; `null` = inherit global.
- `MIGRATION_15_16` — additive `ALTER TABLE fiction ADD COLUMN playbackSpeed REAL`; DB version 15 → 16; exported `16.json`.
- `FictionDao.updatePlaybackSpeed(id, speed)`; preserved in `upsertAllPreservingUserState` (user-owned column — a browse-listing upsert must not reset a pinned book).
- `FictionRepository.setPlaybackSpeed` / `observePlaybackSpeed`; mirrored on `FictionRepositoryUi` (defaulted so existing lightweight fakes keep compiling).

### Where auto-restore lives
Implemented in `RealPlaybackControllerUi` (the existing settings→controller speed seam), **not** in `EnginePlayer.loadAndPlay`. This keeps `core-playback` free of a `FictionDao` dependency — the same layering `pinnedVoice` and `effectiveSpeed` already follow (see the `DataModule` kdoc) — and covers *every* playback entry point (reader, Library Resume, Auto/Wear, MediaSession, chat tools) since they all flow through `controller.state`. The old `effectiveSpeed`-only collector is replaced by a combine that resolves `(currentFictionId, isLiveAudioChapter, effectiveSpeed)` → engine speed.

`PlaybackController.setSpeed` now no-ops when the value already matches the playing speed, so a flow re-emission can't tear down + rebuild the pipeline mid-sentence (`EnginePlayer.setSpeed` always rebuilds for the #555 position handoff).

### Tests
- Migration `v15 → v16`: column exists, nullable, NULL default on existing rows, pinned-speed write round-trips; chain-through + `addMigrations` updates for the three round-trip tests.
- `FictionDao`: pin/clear round-trip + per-book-speed preservation across `upsertAllPreservingUserState`.

### Note on the schema hash
`16.json`'s `identityHash` is a placeholder (`000…`); KSP regenerates the real hash at build (`assembleRelease`). Local gradle is intentionally not run here per the project's CI-is-the-compile-gate rule, so the structure (createSql + fields) is hand-written correct and the hash is produced by the build. `runMigrationsAndValidate` compares schema *structure*, not the hash, and the runtime uses the generated `_Impl`'s compiled hash.

Closes #1231

🤖 Generated with [Claude Code](https://claude.com/claude-code)
