### PR TITLE
feat(reader): in-book text search (#1229)

### DIFF
--- a/app/src/test/kotlin/in/jphe/storyvox/di/RealPlaybackControllerUiTest.kt
+++ b/app/src/test/kotlin/in/jphe/storyvox/di/RealPlaybackControllerUiTest.kt
@@ -368,5 +368,10 @@ class RealPlaybackControllerUiTest {
             `in`.jphe.storyvox.data.repository.CachedBodyUsage(count = 0, bytesEstimate = 0L)
         override suspend fun setChapterBookmark(chapterId: String, charOffset: Int?) = Unit
         override suspend fun chapterBookmark(chapterId: String): Int? = null
+        override suspend fun searchChapterBodies(
+            fictionId: String,
+            query: String,
+            limit: Int,
+        ): List<`in`.jphe.storyvox.data.db.dao.ChapterSearchRow> = emptyList()
     }
 }

--- a/core-data/src/main/kotlin/in/jphe/storyvox/data/db/dao/ChapterDao.kt
+++ b/core-data/src/main/kotlin/in/jphe/storyvox/data/db/dao/ChapterDao.kt
@@ -498,6 +498,57 @@ interface ChapterDao {
         """,
     )
     suspend fun cacheUsage(): ChapterCacheUsageRow
+
+    /**
+     * Issue #1229 — in-book text search. Returns every *downloaded* chapter
+     * of [fictionId] whose plain-text body contains [query], in reading
+     * order, capped at [limit] rows.
+     *
+     * # Why LIKE, not FTS
+     *
+     * Book-sized content (a fiction's downloaded chapters) is small enough
+     * that a `LIKE '%term%'` table scan is well within budget on a single
+     * fiction's rows — there's no full-text index to build/maintain and no
+     * schema migration. The `index` column carries the unique
+     * `(fictionId, index)` index, so SQLite still narrows to one fiction's
+     * rows before scanning bodies. SQLite's `LIKE` is case-insensitive for
+     * ASCII by default (`PRAGMA case_sensitive_like` is off), which is the
+     * desired find-in-book behaviour.
+     *
+     * # Why this is a coarse pre-filter
+     *
+     * `LIKE` treats `%` and `_` in [query] as wildcards, so a literal
+     * search for "100%" would over-match. The feature layer re-scans each
+     * returned body with a *literal*, case-insensitive substring pass
+     * (`findMatches`) to compute exact match offsets, counts, and the
+     * highlighted snippet — that pass is the source of truth. Over-matched
+     * chapters simply yield zero literal hits and are dropped; LIKE can
+     * never *under*-match (a literal substring always satisfies
+     * `'%' || term || '%'`), so coverage is preserved without an `ESCAPE`
+     * clause here.
+     *
+     * # Why return the body
+     *
+     * The snippet/offset extraction lives in the feature module's pure,
+     * unit-tested search core rather than in SQL, so the full `plainBody`
+     * crosses the boundary for matching chapters only. [limit] bounds the
+     * bytes a pathological match-everything query (e.g. "e") can pull into
+     * memory; the caller surfaces truncation when the cap is hit. Pure-audio
+     * chapters (empty body) are excluded by the `plainBody <> ''` guard, so
+     * they never appear as text-search hits.
+     */
+    @Query(
+        """
+        SELECT id, `index`, title, plainBody
+          FROM chapter
+         WHERE fictionId = :fictionId
+           AND plainBody IS NOT NULL AND plainBody <> ''
+           AND plainBody LIKE '%' || :query || '%'
+         ORDER BY `index` ASC
+         LIMIT :limit
+        """,
+    )
+    suspend fun searchChapters(fictionId: String, query: String, limit: Int): List<ChapterSearchRow>
 }
 
 /** Light projection used by [ChapterDao.observeDownloadStates]. */
@@ -526,6 +577,20 @@ data class BookmarkRow(
 data class ChapterCacheUsageRow(
     val count: Int,
     val bytes: Long,
+)
+
+/**
+ * Issue #1229 — projection backing [ChapterDao.searchChapters]. Carries the
+ * full `plainBody` of each matching chapter so the feature layer's pure
+ * search core can compute exact match offsets, counts, and a highlighted
+ * snippet. `index` mirrors the entity column (reading order); `title` labels
+ * the result row.
+ */
+data class ChapterSearchRow(
+    val id: String,
+    val index: Int,
+    val title: String,
+    val plainBody: String,
 )
 
 /**

--- a/core-data/src/main/kotlin/in/jphe/storyvox/data/repository/ChapterRepository.kt
+++ b/core-data/src/main/kotlin/in/jphe/storyvox/data/repository/ChapterRepository.kt
@@ -1,6 +1,7 @@
 package `in`.jphe.storyvox.data.repository
 
 import `in`.jphe.storyvox.data.db.dao.ChapterDao
+import `in`.jphe.storyvox.data.db.dao.ChapterSearchRow
 import `in`.jphe.storyvox.data.db.entity.Chapter
 import `in`.jphe.storyvox.data.db.entity.ChapterDownloadState
 import `in`.jphe.storyvox.data.repository.playback.PlaybackChapter
@@ -109,7 +110,25 @@ interface ChapterRepository {
 
     /** Issue #121 — read the persisted bookmark for a chapter, or null. */
     suspend fun chapterBookmark(chapterId: String): Int?
+
+    /**
+     * Issue #1229 — in-book text search. Returns the downloaded chapters of
+     * [fictionId] whose body contains [query] (case-insensitive substring),
+     * in reading order, each with its full plain-text body so the caller can
+     * extract exact match offsets + a highlighted snippet. Capped at [limit]
+     * chapters to bound memory on a match-everything query; the caller treats
+     * a full result list as "possibly truncated". A blank [query] returns
+     * empty without touching the DB.
+     */
+    suspend fun searchChapterBodies(
+        fictionId: String,
+        query: String,
+        limit: Int = DEFAULT_BOOK_SEARCH_LIMIT,
+    ): List<ChapterSearchRow>
 }
+
+/** Issue #1229 — default chapter cap for [ChapterRepository.searchChapterBodies]. */
+const val DEFAULT_BOOK_SEARCH_LIMIT = 500
 
 /** Issue #293 — paired count/bytes return for [ChapterRepository.cachedBodyUsage]. */
 data class CachedBodyUsage(
@@ -260,4 +279,18 @@ class ChapterRepositoryImpl @Inject constructor(
 
     override suspend fun chapterBookmark(chapterId: String): Int? =
         dao.getBookmark(chapterId)
+
+    override suspend fun searchChapterBodies(
+        fictionId: String,
+        query: String,
+        limit: Int,
+    ): List<ChapterSearchRow> {
+        // Trim so a stray paste space doesn't zero the LIKE pre-filter; the
+        // feature layer's findMatches trims the same way, keeping the coarse
+        // SQL filter and the exact literal re-scan in agreement. Room runs
+        // this suspend query off the main thread on its own executor.
+        val needle = query.trim()
+        if (needle.isEmpty()) return emptyList()
+        return dao.searchChapters(fictionId, needle, limit)
+    }
 }

--- a/core-data/src/test/kotlin/in/jphe/storyvox/data/repository/ChapterRepositoryImplTest.kt
+++ b/core-data/src/test/kotlin/in/jphe/storyvox/data/repository/ChapterRepositoryImplTest.kt
@@ -242,6 +242,28 @@ class ChapterRepositoryImplTest {
             )
         }
 
+        // Issue #1229 — mirror the production LIKE query: downloaded chapters
+        // of the fiction whose body contains the (ASCII-case-insensitive)
+        // needle, in reading order, capped at [limit].
+        override suspend fun searchChapters(
+            fictionId: String,
+            query: String,
+            limit: Int,
+        ): List<`in`.jphe.storyvox.data.db.dao.ChapterSearchRow> {
+            callLog += "searchChapters($fictionId, $query, $limit)"
+            return rows.values
+                .filter { it.fictionId == fictionId && !it.plainBody.isNullOrEmpty() }
+                .filter { it.plainBody!!.contains(query, ignoreCase = true) }
+                .sortedBy { it.index }
+                .take(limit)
+                .map {
+                    `in`.jphe.storyvox.data.db.dao.ChapterSearchRow(
+                        id = it.id, index = it.index, title = it.title,
+                        plainBody = it.plainBody!!,
+                    )
+                }
+        }
+
         // Issue #121 — bookmark read/write. Reflect the underlying rows
         // so getBookmark stays consistent after setBookmark; matches the
         // SQL update + select pair on the real DAO.
@@ -623,5 +645,53 @@ class ChapterRepositoryImplTest {
 
         dao.previousChapterIdResult = null
         assertNull(r.getPreviousChapterId("c-first"))
+    }
+
+    // -- searchChapterBodies (#1229) -------------------------------------------
+
+    @Test fun `searchChapterBodies returns matching downloaded chapters in index order`() = runTest {
+        val (r, dao, _) = repo()
+        dao.upsert(chapter("c0", index = 0, plainBody = "the dragon sleeps"))
+        dao.upsert(chapter("c1", index = 1, plainBody = "nothing here"))
+        dao.upsert(chapter("c2", index = 2, plainBody = "a DRAGON wakes"))
+
+        val hits = r.searchChapterBodies("f1", "dragon")
+        assertEquals(listOf("c0", "c2"), hits.map { it.id })
+        assertEquals(listOf(0, 2), hits.map { it.index })
+        assertEquals("the dragon sleeps", hits.first().plainBody)
+    }
+
+    @Test fun `searchChapterBodies is case-insensitive`() = runTest {
+        val (r, dao, _) = repo()
+        dao.upsert(chapter("c0", index = 0, plainBody = "The Sword of Aeons"))
+        assertEquals(listOf("c0"), r.searchChapterBodies("f1", "SWORD").map { it.id })
+    }
+
+    @Test fun `searchChapterBodies excludes chapters with no body`() = runTest {
+        val (r, dao, _) = repo()
+        dao.upsert(chapter("c0", index = 0, plainBody = null))
+        dao.upsert(chapter("c1", index = 1, plainBody = ""))
+        assertTrue(r.searchChapterBodies("f1", "anything").isEmpty())
+    }
+
+    @Test fun `searchChapterBodies blank query short-circuits without touching DAO`() = runTest {
+        val (r, dao, _) = repo()
+        dao.upsert(chapter("c0", index = 0, plainBody = "body"))
+        assertTrue(r.searchChapterBodies("f1", "   ").isEmpty())
+        assertTrue(dao.callLog.none { it.startsWith("searchChapters(") })
+    }
+
+    @Test fun `searchChapterBodies trims the needle before querying`() = runTest {
+        val (r, dao, _) = repo()
+        dao.upsert(chapter("c0", index = 0, plainBody = "find the relic"))
+        assertEquals(listOf("c0"), r.searchChapterBodies("f1", "  relic  ").map { it.id })
+        assertTrue(dao.callLog.any { it == "searchChapters(f1, relic, $DEFAULT_BOOK_SEARCH_LIMIT)" })
+    }
+
+    @Test fun `searchChapterBodies honours the limit`() = runTest {
+        val (r, dao, _) = repo()
+        repeat(5) { dao.upsert(chapter("c$it", index = it, plainBody = "echo $it")) }
+        val hits = r.searchChapterBodies("f1", "echo", limit = 3)
+        assertEquals(listOf("c0", "c1", "c2"), hits.map { it.id })
     }
 }

--- a/core-data/src/test/kotlin/in/jphe/storyvox/data/repository/FictionRepositoryImplTest.kt
+++ b/core-data/src/test/kotlin/in/jphe/storyvox/data/repository/FictionRepositoryImplTest.kt
@@ -400,6 +400,12 @@ class FictionRepositoryImplTest {
             chapters.forEach { rows[it.id] = it }
             chapters.map { it.fictionId }.toSet().forEach(::publishInfo)
         }
+
+        override suspend fun searchChapters(
+            fictionId: String,
+            query: String,
+            limit: Int,
+        ): List<`in`.jphe.storyvox.data.db.dao.ChapterSearchRow> = emptyList()
     }
 
     // -- Fake source -------------------------------------------------------------

--- a/core-playback/src/test/kotlin/in/jphe/storyvox/playback/cache/PrerenderTriggersTest.kt
+++ b/core-playback/src/test/kotlin/in/jphe/storyvox/playback/cache/PrerenderTriggersTest.kt
@@ -146,6 +146,11 @@ class PrerenderTriggersTest {
             CachedBodyUsage(count = 0, bytesEstimate = 0L)
         override suspend fun setChapterBookmark(chapterId: String, charOffset: Int?) = Unit
         override suspend fun chapterBookmark(chapterId: String): Int? = null
+        override suspend fun searchChapterBodies(
+            fictionId: String,
+            query: String,
+            limit: Int,
+        ): List<`in`.jphe.storyvox.data.db.dao.ChapterSearchRow> = emptyList()
     }
 
     /**

--- a/core-sync/src/test/kotlin/in/jphe/storyvox/sync/BookmarksSyncerTest.kt
+++ b/core-sync/src/test/kotlin/in/jphe/storyvox/sync/BookmarksSyncerTest.kt
@@ -266,5 +266,10 @@ class BookmarksSyncerTest {
             error("not used")
         override suspend fun chapterIdsForFiction(fictionId: String): List<String> = emptyList()
         override suspend fun deleteByIds(ids: List<String>) = error("not used")
+        override suspend fun searchChapters(
+            fictionId: String,
+            query: String,
+            limit: Int,
+        ): List<`in`.jphe.storyvox.data.db.dao.ChapterSearchRow> = error("not used")
     }
 }

--- a/core-sync/src/test/kotlin/in/jphe/storyvox/sync/PlaybackPositionSyncerTest.kt
+++ b/core-sync/src/test/kotlin/in/jphe/storyvox/sync/PlaybackPositionSyncerTest.kt
@@ -265,5 +265,10 @@ class PlaybackPositionSyncerTest {
         override suspend fun cacheUsage(): ChapterCacheUsageRow = error("not used")
         override suspend fun chapterIdsForFiction(fictionId: String): List<String> = emptyList()
         override suspend fun deleteByIds(ids: List<String>) = error("not used")
+        override suspend fun searchChapters(
+            fictionId: String,
+            query: String,
+            limit: Int,
+        ): List<`in`.jphe.storyvox.data.db.dao.ChapterSearchRow> = error("not used")
     }
 }

--- a/core-ui/src/main/kotlin/in/jphe/storyvox/ui/component/TestTags.kt
+++ b/core-ui/src/main/kotlin/in/jphe/storyvox/ui/component/TestTags.kt
@@ -56,6 +56,17 @@ object TestTags {
     const val ReaderPlay = "reader-play"
     const val ReaderBack = "reader-back"
 
+    // ── Reader in-book search (#1229) ─────────────────────────────────────
+    // The whole-book find flow: a top-bar magnifying glass ([ReaderBookSearch])
+    // opens the [BookSearchOverlay], whose field ([BookSearchField]) drives a
+    // results list ([BookSearchResults]); tapping a result jumps to that
+    // chapter. [BookSearchClose] dismisses the overlay.
+    const val ReaderBookSearch = "reader-book-search"
+    const val BookSearchOverlay = "book-search-overlay"
+    const val BookSearchField = "book-search-field"
+    const val BookSearchResults = "book-search-results"
+    const val BookSearchClose = "book-search-close"
+
     // ── Reader highlights (#1079 phase 2) ────────────────────────────────
     // The select-text → highlight flow. A Maestro flow drives: drag-select
     // body text → [HighlightSheet] appears → pick a swatch in

--- a/feature/src/main/kotlin/in/jphe/storyvox/feature/reader/AudiobookView.kt
+++ b/feature/src/main/kotlin/in/jphe/storyvox/feature/reader/AudiobookView.kt
@@ -54,6 +54,7 @@ import androidx.compose.material.icons.outlined.Bookmark
 import androidx.compose.material.icons.outlined.BookmarkAdd
 import androidx.compose.material.icons.outlined.ChevronRight
 import androidx.compose.material.icons.outlined.MoreVert
+import androidx.compose.material.icons.outlined.Search
 import androidx.compose.material.icons.outlined.Settings
 import androidx.compose.material3.AssistChip
 import androidx.compose.material3.AssistChipDefaults
@@ -174,6 +175,11 @@ fun AudiobookView(
      *  previews / tests; production callsites pass
      *  `navController.navigate(StoryvoxRoutes.fictionDetail(fId))`. */
     onOpenLibrary: () -> Unit = {},
+    /** Issue #1229 — open the whole-book ("find in book") search overlay. The
+     *  top-bar magnifying glass invokes this; [HybridReaderScreen] wires it to
+     *  [ReaderViewModel.openBookSearch] and renders the overlay above both
+     *  panes. Default no-op for previews / tests. */
+    onOpenSearch: () -> Unit = {},
     /** Issue #1016 — "another magical way of accessing the reading mode in
      *  the play tab besides just swiping to the right." The [HybridReaderShell]
      *  reaches the text reader by a horizontal swipe (offset 0 → -width); the
@@ -401,7 +407,10 @@ fun AudiobookView(
                         // the player → fiction-detail jump. Asymmetric
                         // padding via start/end keeps the title visually
                         // centered across both sides' negative space.
-                        .padding(start = 104.dp, end = 104.dp),
+                        // Issue #1229 — trailing side now carries THREE icons
+                        // (search + voice + overflow), so its reserve grows to
+                        // 152 dp; leading stays 104 dp (Back + MenuBook).
+                        .padding(start = 104.dp, end = 152.dp),
                     horizontalAlignment = Alignment.CenterHorizontally,
                 ) {
                     Text(
@@ -437,6 +446,21 @@ fun AudiobookView(
                     modifier = Modifier.align(Alignment.CenterEnd),
                     verticalAlignment = Alignment.CenterVertically,
                 ) {
+                    // Issue #1229 — whole-book ("find in book") search. Leads
+                    // the trailing cluster (search → voice → overflow) so the
+                    // magnifying glass reads as a first-class affordance, not
+                    // a buried menu item. Opens the overlay rendered above both
+                    // panes by HybridReaderScreen.
+                    IconButton(
+                        onClick = onOpenSearch,
+                        modifier = Modifier.testTag(TestTags.ReaderBookSearch),
+                    ) {
+                        Icon(
+                            imageVector = Icons.Outlined.Search,
+                            contentDescription = stringResource(R.string.reader_book_search),
+                            tint = MaterialTheme.colorScheme.primary,
+                        )
+                    }
                     val voiceInteraction = remember { androidx.compose.foundation.interaction.MutableInteractionSource() }
                     Box(
                         modifier = Modifier

--- a/feature/src/main/kotlin/in/jphe/storyvox/feature/reader/BookSearchOverlay.kt
+++ b/feature/src/main/kotlin/in/jphe/storyvox/feature/reader/BookSearchOverlay.kt
@@ -9,6 +9,7 @@ import androidx.compose.animation.slideInVertically
 import androidx.compose.animation.slideOutVertically
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
+import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -107,6 +108,8 @@ fun BookSearchOverlay(
                     .fillMaxSize()
                     .background(Color.Black.copy(alpha = 0.45f))
                     .clickable(
+                        interactionSource = remember { MutableInteractionSource() },
+                        indication = null,
                         role = Role.Button,
                         onClickLabel = stringResource(R.string.reader_search_close),
                         onClick = onClose,
@@ -150,8 +153,10 @@ private fun BookSearchPanel(
     LaunchedEffect(state.open) {
         if (state.open) focus.requestFocus()
     }
-    // Keep the selected result scrolled into view as the chevrons step it.
-    LaunchedEffect(state.selectedIndex, state.results.size) {
+    LaunchedEffect(state.results.size) {
+        if (hasResults) listState.scrollToItem(0)
+    }
+    LaunchedEffect(state.selectedIndex) {
         if (hasResults && state.selectedIndex in state.results.indices) {
             listState.animateScrollToItem(state.selectedIndex)
         }
@@ -360,7 +365,7 @@ private fun BookSearchResultRow(
             .background(rowColor)
             .clickable(
                 role = Role.Button,
-                onClickLabel = result.chapterTitle,
+                onClickLabel = stringResource(R.string.reader_book_search_go_to),
                 onClick = onClick,
             )
             .padding(horizontal = spacing.md, vertical = spacing.sm),

--- a/feature/src/main/kotlin/in/jphe/storyvox/feature/reader/BookSearchOverlay.kt
+++ b/feature/src/main/kotlin/in/jphe/storyvox/feature/reader/BookSearchOverlay.kt
@@ -1,0 +1,398 @@
+package `in`.jphe.storyvox.feature.reader
+
+import androidx.activity.compose.BackHandler
+import androidx.compose.animation.AnimatedVisibility
+import androidx.compose.animation.core.tween
+import androidx.compose.animation.fadeIn
+import androidx.compose.animation.fadeOut
+import androidx.compose.animation.slideInVertically
+import androidx.compose.animation.slideOutVertically
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.heightIn
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.statusBarsPadding
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.itemsIndexed
+import androidx.compose.foundation.lazy.rememberLazyListState
+import androidx.compose.foundation.text.KeyboardActions
+import androidx.compose.foundation.text.KeyboardOptions
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Close
+import androidx.compose.material.icons.outlined.ExpandLess
+import androidx.compose.material.icons.outlined.ExpandMore
+import androidx.compose.material.icons.outlined.Search
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.focus.FocusRequester
+import androidx.compose.ui.focus.focusRequester
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.res.pluralStringResource
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.semantics.Role
+import androidx.compose.ui.semantics.contentDescription
+import androidx.compose.ui.semantics.semantics
+import androidx.compose.ui.text.SpanStyle
+import androidx.compose.ui.text.buildAnnotatedString
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.input.ImeAction
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.dp
+import `in`.jphe.storyvox.feature.R
+import `in`.jphe.storyvox.ui.component.MagicCircularProgress
+import `in`.jphe.storyvox.ui.component.TestTags
+import `in`.jphe.storyvox.ui.theme.LocalSpacing
+
+/** Cap on the results panel's height so it never swallows the whole screen —
+ *  the scrim below it stays tappable to dismiss. The list scrolls within. */
+private val RESULTS_MAX_HEIGHT = 440.dp
+
+/**
+ * Issue #1229 — the reader's whole-book ("find in book") search overlay.
+ *
+ * A top-anchored brass panel: a query field, a stepper over the matching
+ * chapters, and a results list (chapter title + match-count badge + a snippet
+ * with the query term highlighted). Tapping a result — or pressing the IME
+ * "Search" action on the selected one — jumps to that chapter at the match
+ * (handled by [ReaderViewModel.openBookSearchResult]). The prev/next chevrons
+ * cycle the selection through the results without leaving the overlay.
+ *
+ * Purely presentational: every piece of state ([BookSearchUiState]) and every
+ * verb is hoisted to [ReaderViewModel], so the overlay can float over either
+ * reader pane from [HybridReaderScreen]. Rendered unconditionally and gated by
+ * [BookSearchUiState.open] so the slide/fade entrance and exit both animate.
+ */
+@Composable
+fun BookSearchOverlay(
+    state: BookSearchUiState,
+    onQueryChange: (String) -> Unit,
+    onPrev: () -> Unit,
+    onNext: () -> Unit,
+    onResultClick: (BookSearchResult) -> Unit,
+    onClose: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    // System back closes the overlay rather than popping the reader.
+    BackHandler(enabled = state.open) { onClose() }
+
+    AnimatedVisibility(
+        visible = state.open,
+        enter = fadeIn(tween(150)),
+        exit = fadeOut(tween(150)),
+        modifier = modifier,
+    ) {
+        Box(modifier = Modifier.fillMaxSize().testTag(TestTags.BookSearchOverlay)) {
+            // Scrim: dims the reader and catches taps below the panel to dismiss.
+            Box(
+                modifier = Modifier
+                    .fillMaxSize()
+                    .background(Color.Black.copy(alpha = 0.45f))
+                    .clickable(
+                        role = Role.Button,
+                        onClickLabel = stringResource(R.string.reader_search_close),
+                        onClick = onClose,
+                    ),
+            )
+
+            AnimatedVisibility(
+                visible = state.open,
+                enter = slideInVertically(tween(220)) { -it } + fadeIn(tween(220)),
+                exit = slideOutVertically(tween(180)) { -it } + fadeOut(tween(180)),
+                modifier = Modifier.align(Alignment.TopCenter),
+            ) {
+                BookSearchPanel(
+                    state = state,
+                    onQueryChange = onQueryChange,
+                    onPrev = onPrev,
+                    onNext = onNext,
+                    onResultClick = onResultClick,
+                    onClose = onClose,
+                )
+            }
+        }
+    }
+}
+
+@Composable
+private fun BookSearchPanel(
+    state: BookSearchUiState,
+    onQueryChange: (String) -> Unit,
+    onPrev: () -> Unit,
+    onNext: () -> Unit,
+    onResultClick: (BookSearchResult) -> Unit,
+    onClose: () -> Unit,
+) {
+    val spacing = LocalSpacing.current
+    val focus = remember { FocusRequester() }
+    val listState = rememberLazyListState()
+    val hasResults = state.results.isNotEmpty()
+
+    // Focus the field as the overlay opens so the keyboard is ready to type.
+    LaunchedEffect(state.open) {
+        if (state.open) focus.requestFocus()
+    }
+    // Keep the selected result scrolled into view as the chevrons step it.
+    LaunchedEffect(state.selectedIndex, state.results.size) {
+        if (hasResults && state.selectedIndex in state.results.indices) {
+            listState.animateScrollToItem(state.selectedIndex)
+        }
+    }
+
+    Surface(
+        color = MaterialTheme.colorScheme.surfaceContainerHigh,
+        shadowElevation = 6.dp,
+        modifier = Modifier.fillMaxWidth().statusBarsPadding(),
+    ) {
+        Column(modifier = Modifier.fillMaxWidth().padding(spacing.sm)) {
+            // ── Query field + close ──────────────────────────────────────
+            Row(verticalAlignment = Alignment.CenterVertically) {
+                OutlinedTextField(
+                    value = state.query,
+                    onValueChange = onQueryChange,
+                    label = { Text(stringResource(R.string.reader_book_search_field_label)) },
+                    singleLine = true,
+                    leadingIcon = { Icon(Icons.Outlined.Search, contentDescription = null) },
+                    keyboardOptions = KeyboardOptions(imeAction = ImeAction.Search),
+                    keyboardActions = KeyboardActions(
+                        // Enter on the selected result jumps to it ("search & go").
+                        onSearch = { state.results.getOrNull(state.selectedIndex)?.let(onResultClick) },
+                    ),
+                    modifier = Modifier
+                        .weight(1f)
+                        .focusRequester(focus)
+                        .testTag(TestTags.BookSearchField),
+                )
+                IconButton(
+                    onClick = onClose,
+                    modifier = Modifier.testTag(TestTags.BookSearchClose),
+                ) {
+                    Icon(
+                        Icons.Filled.Close,
+                        contentDescription = stringResource(R.string.reader_search_close),
+                    )
+                }
+            }
+
+            // ── Stepper row (only when there are results) ────────────────
+            if (hasResults) {
+                val positionDescription = stringResource(
+                    R.string.reader_book_search_position_description,
+                    state.selectedIndex + 1,
+                    state.results.size,
+                )
+                Row(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .padding(horizontal = spacing.xs),
+                    verticalAlignment = Alignment.CenterVertically,
+                ) {
+                    Text(
+                        text = pluralStringResource(
+                            R.plurals.reader_book_search_chapter_count,
+                            state.results.size,
+                            state.results.size,
+                        ),
+                        style = MaterialTheme.typography.labelMedium,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                        modifier = Modifier.weight(1f),
+                    )
+                    Text(
+                        text = stringResource(
+                            R.string.reader_book_search_position,
+                            state.selectedIndex + 1,
+                            state.results.size,
+                        ),
+                        style = MaterialTheme.typography.labelMedium,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                        modifier = Modifier
+                            .padding(horizontal = spacing.xs)
+                            .semantics { contentDescription = positionDescription },
+                    )
+                    IconButton(onClick = onPrev) {
+                        Icon(
+                            Icons.Outlined.ExpandLess,
+                            contentDescription = stringResource(R.string.reader_book_search_prev),
+                        )
+                    }
+                    IconButton(onClick = onNext) {
+                        Icon(
+                            Icons.Outlined.ExpandMore,
+                            contentDescription = stringResource(R.string.reader_book_search_next),
+                        )
+                    }
+                }
+            }
+
+            // ── Results / status ─────────────────────────────────────────
+            when {
+                hasResults -> {
+                    LazyColumn(
+                        state = listState,
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .heightIn(max = RESULTS_MAX_HEIGHT)
+                            .testTag(TestTags.BookSearchResults),
+                    ) {
+                        itemsIndexed(
+                            items = state.results,
+                            key = { _, r -> r.chapterId },
+                        ) { index, result ->
+                            BookSearchResultRow(
+                                result = result,
+                                selected = index == state.selectedIndex,
+                                onClick = { onResultClick(result) },
+                            )
+                        }
+                        if (state.truncated) {
+                            item(key = "truncated-note") {
+                                Text(
+                                    text = stringResource(
+                                        R.string.reader_book_search_truncated,
+                                        state.results.size,
+                                    ),
+                                    style = MaterialTheme.typography.labelSmall,
+                                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                                    modifier = Modifier
+                                        .fillMaxWidth()
+                                        .padding(spacing.md),
+                                )
+                            }
+                        }
+                    }
+                }
+                state.phase == BookSearchPhase.Searching -> {
+                    StatusRow {
+                        MagicCircularProgress(modifier = Modifier.size(28.dp))
+                        Spacer(Modifier.width(spacing.sm))
+                        Text(
+                            stringResource(R.string.reader_book_search_searching),
+                            style = MaterialTheme.typography.bodyMedium,
+                            color = MaterialTheme.colorScheme.onSurfaceVariant,
+                        )
+                    }
+                }
+                state.phase == BookSearchPhase.Done -> {
+                    StatusRow {
+                        Text(
+                            stringResource(R.string.reader_book_search_no_matches),
+                            style = MaterialTheme.typography.bodyMedium,
+                            color = MaterialTheme.colorScheme.onSurfaceVariant,
+                        )
+                    }
+                }
+                else -> {
+                    StatusRow {
+                        Text(
+                            stringResource(R.string.reader_book_search_hint),
+                            style = MaterialTheme.typography.bodyMedium,
+                            color = MaterialTheme.colorScheme.onSurfaceVariant,
+                        )
+                    }
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun StatusRow(content: @Composable () -> Unit) {
+    val spacing = LocalSpacing.current
+    Row(
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(horizontal = spacing.md, vertical = spacing.lg),
+        verticalAlignment = Alignment.CenterVertically,
+        horizontalArrangement = Arrangement.Center,
+    ) {
+        content()
+    }
+}
+
+@Composable
+private fun BookSearchResultRow(
+    result: BookSearchResult,
+    selected: Boolean,
+    onClick: () -> Unit,
+) {
+    val spacing = LocalSpacing.current
+    val highlightBg = MaterialTheme.colorScheme.primary.copy(alpha = 0.30f)
+    val snippet = remember(result.snippet, result.snippetMatchRange, highlightBg) {
+        buildAnnotatedString {
+            append(result.snippet)
+            val range = result.snippetMatchRange
+            val start = range.first.coerceIn(0, result.snippet.length)
+            val end = (range.last + 1).coerceIn(start, result.snippet.length)
+            if (end > start) {
+                addStyle(
+                    SpanStyle(background = highlightBg, fontWeight = FontWeight.SemiBold),
+                    start,
+                    end,
+                )
+            }
+        }
+    }
+    val rowColor =
+        if (selected) MaterialTheme.colorScheme.secondaryContainer.copy(alpha = 0.55f)
+        else Color.Transparent
+
+    Column(
+        modifier = Modifier
+            .fillMaxWidth()
+            .background(rowColor)
+            .clickable(
+                role = Role.Button,
+                onClickLabel = result.chapterTitle,
+                onClick = onClick,
+            )
+            .padding(horizontal = spacing.md, vertical = spacing.sm),
+    ) {
+        Row(verticalAlignment = Alignment.CenterVertically) {
+            Text(
+                text = result.chapterTitle,
+                style = MaterialTheme.typography.titleSmall,
+                color = MaterialTheme.colorScheme.primary,
+                maxLines = 1,
+                overflow = TextOverflow.Ellipsis,
+                modifier = Modifier.weight(1f),
+            )
+            Spacer(Modifier.width(spacing.sm))
+            Text(
+                text = pluralStringResource(
+                    R.plurals.reader_book_search_match_badge,
+                    result.matchCount,
+                    result.matchCount,
+                ),
+                style = MaterialTheme.typography.labelSmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                maxLines = 1,
+            )
+        }
+        Spacer(Modifier.size(spacing.xs))
+        Text(
+            text = snippet,
+            style = MaterialTheme.typography.bodySmall,
+            color = MaterialTheme.colorScheme.onSurface,
+            maxLines = 2,
+            overflow = TextOverflow.Ellipsis,
+        )
+    }
+}

--- a/feature/src/main/kotlin/in/jphe/storyvox/feature/reader/BookTextSearch.kt
+++ b/feature/src/main/kotlin/in/jphe/storyvox/feature/reader/BookTextSearch.kt
@@ -1,0 +1,140 @@
+package `in`.jphe.storyvox.feature.reader
+
+/**
+ * Issue #1229 — whole-book ("find in book") text search core.
+ *
+ * Pure, Compose-/Room-free so the aggregation + snippet logic is unit-testable
+ * without a rendering or database runtime — the same split #998's [findMatches]
+ * uses for single-chapter find-in-text. The ViewModel pulls matching chapter
+ * bodies from [in.jphe.storyvox.data.repository.ChapterRepository.searchChapterBodies]
+ * (a coarse SQL `LIKE` pre-filter) and feeds them here; [searchBook] re-scans
+ * each body with the exact, literal [findMatches] pass to compute real match
+ * offsets, counts, and a highlighted snippet, dropping any chapter the `LIKE`
+ * over-matched.
+ */
+
+/** Default context window (chars on each side of the first match) for a result
+ *  snippet. ~48 chars/side keeps a result row to roughly one comfortable line. */
+internal const val SNIPPET_RADIUS = 48
+
+/**
+ * Minimal per-chapter input to [searchBook]. Decoupled from Room / core-data
+ * row types so the search core stays free of an Android/Room dependency; the
+ * ViewModel maps `ChapterSearchRow → ChapterBody` at the seam.
+ */
+data class ChapterBody(
+    val chapterId: String,
+    val index: Int,
+    val title: String,
+    val body: String,
+)
+
+/**
+ * One whole-book search hit — a chapter whose body contains the query, ready to
+ * render as a result row and to navigate to.
+ */
+data class BookSearchResult(
+    val chapterId: String,
+    val chapterIndex: Int,
+    val chapterTitle: String,
+    /**
+     * 0-based char offset of the *first* match in the chapter's plain body.
+     * Fed straight to `PlaybackControllerUi.startListening(charOffset = …)`
+     * for jump-to-match (the body offset and the playback text offset are the
+     * same string — the player speaks `plainBody`).
+     */
+    val matchOffset: Int,
+    /** Total non-overlapping matches in this chapter (drives the count badge). */
+    val matchCount: Int,
+    /** One-line context window of the body around the first match. */
+    val snippet: String,
+    /**
+     * End-inclusive range of the query *within* [snippet] — for the result
+     * row's highlight span. Inclusive to match [findMatches]'s convention; the
+     * renderer adds +1 for the exclusive `AnnotatedString` span end.
+     */
+    val snippetMatchRange: IntRange,
+)
+
+private val WHITESPACE_RUN = Regex("\\s+")
+
+/** Collapse every run of whitespace (incl. newlines) to a single space so a
+ *  raw `plainBody` slice reads as one snippet line. */
+private fun collapseWhitespace(s: String): String = s.replace(WHITESPACE_RUN, " ")
+
+/**
+ * Build a one-line context snippet around the match at [matchStart]
+ * (length [matchLength]) in [body], plus the match's end-inclusive range
+ * *within the returned snippet* so the result row can paint a highlight.
+ *
+ * Whitespace is collapsed segment-by-segment (before / matched / after) rather
+ * than over the whole slice, so collapsing newlines never desyncs the highlight
+ * range from the visible text. A leading "…" / trailing "…" marks a clipped
+ * window; the boundary segments are trimmed on their outer edges so the snippet
+ * never reads as "… word".
+ */
+internal fun buildSnippet(
+    body: String,
+    matchStart: Int,
+    matchLength: Int,
+    radius: Int = SNIPPET_RADIUS,
+): Pair<String, IntRange> {
+    if (body.isEmpty() || matchLength <= 0) return "" to IntRange.EMPTY
+    val start = matchStart.coerceIn(0, body.length)
+    val matchEnd = (matchStart + matchLength).coerceIn(start, body.length)
+    val from = (start - radius).coerceAtLeast(0)
+    val to = (matchEnd + radius).coerceAtMost(body.length)
+
+    val before = collapseWhitespace(body.substring(from, start)).trimStart()
+    val matched = collapseWhitespace(body.substring(start, matchEnd))
+    val after = collapseWhitespace(body.substring(matchEnd, to)).trimEnd()
+
+    val left = if (from > 0) "…" else ""
+    val right = if (to < body.length) "…" else ""
+
+    val snippet = left + before + matched + after + right
+    val rangeStart = left.length + before.length
+    val rangeEnd = (rangeStart + matched.length - 1).coerceAtLeast(rangeStart)
+    return snippet to (rangeStart..rangeEnd)
+}
+
+/**
+ * Scan each chapter [body] for [query] and return one [BookSearchResult] per
+ * chapter that genuinely contains it, in the order the chapters were supplied
+ * (the repository hands them over in reading order). A blank query — or a
+ * chapter the SQL `LIKE` over-matched but that holds no literal occurrence —
+ * yields nothing for that input.
+ *
+ * The query is trimmed once here (and again, harmlessly, inside [findMatches])
+ * so a stray paste space doesn't zero the result set, matching #998 / #794.
+ */
+internal fun searchBook(
+    chapters: List<ChapterBody>,
+    query: String,
+    radius: Int = SNIPPET_RADIUS,
+): List<BookSearchResult> {
+    val needle = query.trim()
+    if (needle.isEmpty()) return emptyList()
+    val results = ArrayList<BookSearchResult>()
+    for (chapter in chapters) {
+        val matches = findMatches(chapter.body, needle)
+        if (matches.isEmpty()) continue
+        val first = matches.first()
+        val (snippet, range) = buildSnippet(
+            body = chapter.body,
+            matchStart = first.first,
+            matchLength = first.last - first.first + 1,
+            radius = radius,
+        )
+        results += BookSearchResult(
+            chapterId = chapter.chapterId,
+            chapterIndex = chapter.index,
+            chapterTitle = chapter.title,
+            matchOffset = first.first,
+            matchCount = matches.size,
+            snippet = snippet,
+            snippetMatchRange = range,
+        )
+    }
+    return results
+}

--- a/feature/src/main/kotlin/in/jphe/storyvox/feature/reader/HybridReaderScreen.kt
+++ b/feature/src/main/kotlin/in/jphe/storyvox/feature/reader/HybridReaderScreen.kt
@@ -101,6 +101,8 @@ fun HybridReaderScreen(
     val wordHighlightArgb by viewModel.wordHighlightArgb.collectAsStateWithLifecycle()
     // Issue #999 phase 2 — the loaded chapter's saved highlights.
     val chapterHighlights by viewModel.chapterHighlights.collectAsStateWithLifecycle()
+    // Issue #1229 — whole-book ("find in book") search overlay state.
+    val bookSearch by viewModel.bookSearch.collectAsStateWithLifecycle()
     val playback = state.playback
 
     // Chapter-completion celebration. The VM's confettiTrigger fires
@@ -295,6 +297,9 @@ fun HybridReaderScreen(
                 onOpenLibrary = {
                     playbackState.fictionId?.let { onOpenLibrary(it) }
                 },
+                // Issue #1229 — top-bar magnifying glass opens the whole-book
+                // search overlay (rendered below, over both panes).
+                onOpenSearch = viewModel::openBookSearch,
                 // Issue #1016 — the visible "Read along" chip flips the
                 // shell to the reader pane exactly as the rightward swipe
                 // does. setActivePane feeds HybridReaderShell's
@@ -382,6 +387,19 @@ fun HybridReaderScreen(
                 onDeleteHighlight = viewModel::deleteHighlight,
             )
         },
+    )
+
+    // Issue #1229 — whole-book search overlay. Floats over whichever reader
+    // pane is active; rendered above the shell but below the recap/debug
+    // surfaces so those still win if they happen to coincide. Self-gated by
+    // `bookSearch.open` (renders unconditionally so the entrance/exit animate).
+    BookSearchOverlay(
+        state = bookSearch,
+        onQueryChange = viewModel::setBookSearchQuery,
+        onPrev = viewModel::selectPreviousResult,
+        onNext = viewModel::selectNextResult,
+        onResultClick = viewModel::openBookSearchResult,
+        onClose = viewModel::closeBookSearch,
     )
 
     // Recap modal — overlays everything when not Hidden. Driven by

--- a/feature/src/main/kotlin/in/jphe/storyvox/feature/reader/ReaderViewModel.kt
+++ b/feature/src/main/kotlin/in/jphe/storyvox/feature/reader/ReaderViewModel.kt
@@ -7,7 +7,9 @@ import androidx.lifecycle.viewModelScope
 import dagger.hilt.android.lifecycle.HiltViewModel
 import `in`.jphe.storyvox.data.db.entity.Annotation
 import `in`.jphe.storyvox.data.repository.AnnotationRepository
+import `in`.jphe.storyvox.data.repository.ChapterRepository
 import `in`.jphe.storyvox.data.repository.ContinueListeningEntry
+import `in`.jphe.storyvox.data.repository.DEFAULT_BOOK_SEARCH_LIMIT
 import `in`.jphe.storyvox.data.repository.PlaybackPositionRepository
 import `in`.jphe.storyvox.data.repository.playback.PlaybackResumePolicyConfig
 import `in`.jphe.storyvox.feature.api.FictionRepositoryUi
@@ -25,10 +27,15 @@ import `in`.jphe.storyvox.llm.LlmError
 import `in`.jphe.storyvox.llm.feature.ChapterRecap
 import `in`.jphe.storyvox.ui.component.ReaderView
 import javax.inject.Inject
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.FlowPreview
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.debounce
+import kotlinx.coroutines.flow.flow
+import kotlinx.coroutines.flow.flowOn
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
@@ -160,6 +167,49 @@ sealed class RecapUiState {
     }
 }
 
+/**
+ * Issue #1229 — observable state for the reader's whole-book search overlay.
+ * [HybridReaderScreen] collects this; the overlay renders the field
+ * ([query]), the [results] list (one row per matching chapter), a stepper
+ * over them ([selectedIndex]), and a [phase]-driven empty/searching/no-match
+ * surface. [truncated] is set when the chapter cap was hit so the overlay can
+ * tell the user not every chapter was searched.
+ */
+@Immutable
+data class BookSearchUiState(
+    val open: Boolean = false,
+    val query: String = "",
+    val results: List<BookSearchResult> = emptyList(),
+    val selectedIndex: Int = 0,
+    val phase: BookSearchPhase = BookSearchPhase.Idle,
+    val truncated: Boolean = false,
+)
+
+/** Issue #1229 — lifecycle of a single book-search query. */
+enum class BookSearchPhase {
+    /** No query yet (or below the minimum length) — show the prompt copy. */
+    Idle,
+    /** Query is in flight against the DB / search core. */
+    Searching,
+    /** Search finished — [BookSearchUiState.results] is authoritative (may be empty). */
+    Done,
+}
+
+/** Issue #1229 — debounce before a keystroke triggers a DB search. */
+private const val BOOK_SEARCH_DEBOUNCE_MS = 250L
+
+/** Issue #1229 — minimum query length before searching, so a single common
+ *  letter doesn't pull every chapter body into memory. */
+private const val MIN_BOOK_SEARCH_QUERY = 2
+
+/** Issue #1229 — internal carrier for the debounced results pipeline, merged
+ *  with the open/query/selection flows into the public [BookSearchUiState]. */
+private data class BookSearchResultsState(
+    val phase: BookSearchPhase = BookSearchPhase.Idle,
+    val results: List<BookSearchResult> = emptyList(),
+    val truncated: Boolean = false,
+)
+
 @HiltViewModel
 class ReaderViewModel @Inject constructor(
     private val playback: PlaybackControllerUi,
@@ -190,6 +240,15 @@ class ReaderViewModel @Inject constructor(
      * "Highlights & notes" list, so phase 2 doesn't add a parallel `*Ui` port.
      */
     private val annotationRepo: AnnotationRepository,
+    /**
+     * Issue #1229 — in-book text search. The reader runs a whole-book
+     * find through [ChapterRepository.searchChapterBodies] (a `LIKE`
+     * pre-filter over the fiction's downloaded chapters) and refines the
+     * hits with the pure [searchBook] core. Injected as the core-data
+     * repository directly — the same seam the playback layer + FictionDetail
+     * already use — so book-search doesn't add a parallel `*Ui` port.
+     */
+    private val chapterRepo: ChapterRepository,
     savedState: SavedStateHandle,
 ) : ViewModel() {
 
@@ -524,6 +583,75 @@ class ReaderViewModel @Inject constructor(
         }
         .stateIn(viewModelScope, SharingStarted.WhileSubscribed(5_000), emptyList())
 
+    // ─── Issue #1229: whole-book ("find in book") search ──────────────────
+    private val _bookSearchOpen = MutableStateFlow(false)
+    private val _bookSearchQuery = MutableStateFlow("")
+    private val _bookSearchSelected = MutableStateFlow(0)
+
+    /**
+     * Debounced query × currently-loaded fiction → refined results, computed
+     * off the main thread. `flatMapLatest` cancels a stale search the moment
+     * the user types another character or the loaded book changes, so only
+     * the newest query's DB scan + [searchBook] pass survives. A query below
+     * [MIN_BOOK_SEARCH_QUERY] (or no fiction) collapses to the idle state
+     * without touching the DB.
+     */
+    @OptIn(FlowPreview::class, kotlinx.coroutines.ExperimentalCoroutinesApi::class)
+    private val bookSearchResults: StateFlow<BookSearchResultsState> = combine(
+        _bookSearchQuery
+            .debounce(BOOK_SEARCH_DEBOUNCE_MS)
+            .map { it.trim() }
+            .distinctUntilChanged(),
+        playback.state.map { it.fictionId }.distinctUntilChanged(),
+    ) { query, fictionId -> query to fictionId }
+        .flatMapLatest { (query, fictionId) ->
+            if (query.length < MIN_BOOK_SEARCH_QUERY || fictionId.isNullOrBlank()) {
+                flowOf(BookSearchResultsState())
+            } else {
+                flow {
+                    emit(BookSearchResultsState(phase = BookSearchPhase.Searching))
+                    val rows = chapterRepo.searchChapterBodies(fictionId, query, DEFAULT_BOOK_SEARCH_LIMIT)
+                    val results = searchBook(
+                        rows.map { ChapterBody(it.id, it.index, it.title, it.plainBody) },
+                        query,
+                    )
+                    emit(
+                        BookSearchResultsState(
+                            phase = BookSearchPhase.Done,
+                            results = results,
+                            // The chapter cap was hit — not every chapter was scanned.
+                            truncated = rows.size >= DEFAULT_BOOK_SEARCH_LIMIT,
+                        ),
+                    )
+                }.flowOn(Dispatchers.Default)
+            }
+        }
+        .stateIn(viewModelScope, SharingStarted.WhileSubscribed(5_000), BookSearchResultsState())
+
+    /**
+     * Issue #1229 — merged book-search state for [HybridReaderScreen]'s
+     * overlay: open flag, the live query text, the refined results, the
+     * stepper selection (clamped into range as the result set changes), and
+     * the search phase / truncation flags.
+     */
+    val bookSearch: StateFlow<BookSearchUiState> = combine(
+        _bookSearchOpen,
+        _bookSearchQuery,
+        bookSearchResults,
+        _bookSearchSelected,
+    ) { open, query, res, selected ->
+        val safeSelected =
+            if (res.results.isEmpty()) 0 else selected.coerceIn(0, res.results.lastIndex)
+        BookSearchUiState(
+            open = open,
+            query = query,
+            results = res.results,
+            selectedIndex = safeSelected,
+            phase = res.phase,
+            truncated = res.truncated,
+        )
+    }.stateIn(viewModelScope, SharingStarted.WhileSubscribed(5_000), BookSearchUiState())
+
     /**
      * Issue #946 — magical reader auto-scroll toggle. Default true so
      * existing users keep their read-along behavior; flipping to false
@@ -726,6 +854,60 @@ class ReaderViewModel @Inject constructor(
         _loadingPhase.value = LoadingPhase.Loading
         _bookFinished.value = false
         playback.startListening(fictionId = fictionId, chapterId = chapterId)
+    }
+
+    // ─── Issue #1229: book-search actions ─────────────────────────────────
+    fun openBookSearch() { _bookSearchOpen.value = true }
+
+    fun closeBookSearch() {
+        _bookSearchOpen.value = false
+        _bookSearchQuery.value = ""
+        _bookSearchSelected.value = 0
+    }
+
+    fun setBookSearchQuery(query: String) {
+        _bookSearchQuery.value = query
+        // A fresh query re-bases the stepper at the first result.
+        _bookSearchSelected.value = 0
+    }
+
+    /** Step the result selection forward / back with wraparound, reusing the
+     *  #998 cycling math so an empty list is a safe no-op. */
+    fun selectNextResult() {
+        val count = bookSearch.value.results.size
+        if (count > 0) {
+            _bookSearchSelected.value = nextMatchIndex(bookSearch.value.selectedIndex, count)
+        }
+    }
+
+    fun selectPreviousResult() {
+        val count = bookSearch.value.results.size
+        if (count > 0) {
+            _bookSearchSelected.value = prevMatchIndex(bookSearch.value.selectedIndex, count)
+        }
+    }
+
+    /**
+     * Navigate to a search result: load its chapter at the first match's char
+     * offset and land on the reader (text) pane so the hit is visible — the
+     * existing auto-scroll (#946/#919) settles the seeked sentence into view.
+     * We deliberately don't auto-play: the user asked to *find* a passage, not
+     * to start narration there; they can press play. Closes the overlay; a
+     * blank-id window (cold-load) drops the tap rather than firing a malformed
+     * load.
+     */
+    fun openBookSearchResult(result: BookSearchResult) {
+        val fictionId = uiState.value.playback?.fictionId ?: return
+        closeBookSearch()
+        _loadingPhase.value = LoadingPhase.Loading
+        _bookFinished.value = false
+        _activePane.value = ReaderView.Reader
+        playback.startListening(
+            fictionId = fictionId,
+            chapterId = result.chapterId,
+            charOffset = result.matchOffset,
+            autoPlay = false,
+        )
     }
     fun nextSentence() = playback.nextSentence()
     fun previousSentence() = playback.previousSentence()

--- a/feature/src/main/res/values/strings.xml
+++ b/feature/src/main/res/values/strings.xml
@@ -195,6 +195,7 @@
     <string name="reader_book_search_position_description">Result %1$d of %2$d</string>
     <!-- Footer shown when the chapter cap was hit before scanning the whole book -->
     <string name="reader_book_search_truncated">Showing the first %1$d chapters.</string>
+    <string name="reader_book_search_go_to">Go to match</string>
     <!-- Header: how many chapters contain the query -->
     <plurals name="reader_book_search_chapter_count">
         <item quantity="one">%1$d chapter</item>

--- a/feature/src/main/res/values/strings.xml
+++ b/feature/src/main/res/values/strings.xml
@@ -180,6 +180,32 @@
     <!-- TalkBack summary of the result counter -->
     <string name="reader_search_count_description">Match %1$d of %2$d</string>
 
+    <!-- Reader / in-book search (#1229) -->
+    <string name="reader_book_search">Search this book</string>
+    <string name="reader_book_search_field_label">Find in book</string>
+    <string name="reader_book_search_prev">Previous result</string>
+    <string name="reader_book_search_next">Next result</string>
+    <!-- Prompt shown before a query has been entered -->
+    <string name="reader_book_search_hint">Search the text of every downloaded chapter.</string>
+    <string name="reader_book_search_searching">Searching…</string>
+    <string name="reader_book_search_no_matches">No matches in this book</string>
+    <!-- Stepper position, e.g. "2 / 7" -->
+    <string name="reader_book_search_position">%1$d / %2$d</string>
+    <!-- TalkBack summary of the stepper position -->
+    <string name="reader_book_search_position_description">Result %1$d of %2$d</string>
+    <!-- Footer shown when the chapter cap was hit before scanning the whole book -->
+    <string name="reader_book_search_truncated">Showing the first %1$d chapters.</string>
+    <!-- Header: how many chapters contain the query -->
+    <plurals name="reader_book_search_chapter_count">
+        <item quantity="one">%1$d chapter</item>
+        <item quantity="other">%1$d chapters</item>
+    </plurals>
+    <!-- Per-result badge: matches within that one chapter -->
+    <plurals name="reader_book_search_match_badge">
+        <item quantity="one">%1$d match</item>
+        <item quantity="other">%1$d matches</item>
+    </plurals>
+
     <!-- Reader / in-text highlights (#999 phase 2) -->
     <string name="reader_highlight_create_title">Highlight</string>
     <string name="reader_highlight_edit_title">Edit highlight</string>

--- a/feature/src/test/kotlin/in/jphe/storyvox/feature/chat/tools/ChatToolHandlersTest.kt
+++ b/feature/src/test/kotlin/in/jphe/storyvox/feature/chat/tools/ChatToolHandlersTest.kt
@@ -205,6 +205,11 @@ private class FakeChapterRepo : ChapterRepository {
     override suspend fun cachedBodyUsage() = CachedBodyUsage(0, 0L)
     override suspend fun setChapterBookmark(chapterId: String, charOffset: Int?) = Unit
     override suspend fun chapterBookmark(chapterId: String): Int? = null
+    override suspend fun searchChapterBodies(
+        fictionId: String,
+        query: String,
+        limit: Int,
+    ): List<`in`.jphe.storyvox.data.db.dao.ChapterSearchRow> = emptyList()
 }
 
 private class FakeFictionRepoT : FictionRepositoryUi {

--- a/feature/src/test/kotlin/in/jphe/storyvox/feature/reader/BookTextSearchTest.kt
+++ b/feature/src/test/kotlin/in/jphe/storyvox/feature/reader/BookTextSearchTest.kt
@@ -1,0 +1,137 @@
+package `in`.jphe.storyvox.feature.reader
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * Issue #1229 — whole-book ("find in book") search core. Pins the pure
+ * aggregation + snippet surface [searchBook] / [buildSnippet] builds on, so the
+ * "search the whole book, list the chapters, jump to a hit" workflow can't
+ * silently regress on a reader refactor.
+ *
+ * Pure (no Compose / Room) so the core is unit-testable without rendering the
+ * overlay or standing up a database — the same split #998's [findMatches] uses.
+ */
+class BookTextSearchTest {
+
+    private fun ch(id: String, index: Int, body: String, title: String = "Chapter $index") =
+        ChapterBody(chapterId = id, index = index, title = title, body = body)
+
+    // --- searchBook ---------------------------------------------------------
+
+    @Test
+    fun `returns one result per matching chapter, in input order`() {
+        val chapters = listOf(
+            ch("c0", 0, "the dragon sleeps under the mountain"),
+            ch("c1", 1, "a quiet village, nothing stirs"),
+            ch("c2", 2, "the DRAGON wakes at last"),
+        )
+        val results = searchBook(chapters, "dragon")
+        assertEquals(listOf("c0", "c2"), results.map { it.chapterId })
+        assertEquals(listOf(0, 2), results.map { it.chapterIndex })
+    }
+
+    @Test
+    fun `is case-insensitive`() {
+        val results = searchBook(listOf(ch("c0", 0, "The Sword of Aeons")), "SWORD")
+        assertEquals(1, results.size)
+    }
+
+    @Test
+    fun `counts every non-overlapping match in the chapter`() {
+        val results = searchBook(listOf(ch("c0", 0, "fox fox fox")), "fox")
+        assertEquals(3, results.single().matchCount)
+    }
+
+    @Test
+    fun `matchOffset is the first occurrence`() {
+        val results = searchBook(listOf(ch("c0", 0, "aaa needle bbb needle")), "needle")
+        assertEquals("aaa needle bbb needle".indexOf("needle"), results.single().matchOffset)
+    }
+
+    @Test
+    fun `blank query yields no results`() {
+        val chapters = listOf(ch("c0", 0, "anything at all"))
+        assertTrue(searchBook(chapters, "").isEmpty())
+        assertTrue(searchBook(chapters, "   ").isEmpty())
+    }
+
+    @Test
+    fun `query is trimmed before matching`() {
+        val results = searchBook(listOf(ch("c0", 0, "find the relic here")), "  relic  ")
+        assertEquals(1, results.size)
+        assertEquals("find the relic here".indexOf("relic"), results.single().matchOffset)
+    }
+
+    @Test
+    fun `drops a chapter with no literal occurrence (LIKE over-match guard)`() {
+        // SQL `LIKE '%100%%'` would return this row (wildcard %), but the body
+        // holds no literal "100%", so the literal re-scan drops it.
+        val results = searchBook(listOf(ch("c0", 0, "scored 100 points")), "100%")
+        assertTrue(results.isEmpty())
+    }
+
+    @Test
+    fun `empty chapter list yields no results`() {
+        assertTrue(searchBook(emptyList(), "anything").isEmpty())
+    }
+
+    @Test
+    fun `snippet contains the matched term at the reported range`() {
+        val results = searchBook(
+            listOf(ch("c0", 0, "The quick brown fox jumps over the lazy dog")),
+            "brown",
+        )
+        val r = results.single()
+        // End-inclusive range → exclusive end for substring.
+        val highlighted = r.snippet.substring(r.snippetMatchRange.first, r.snippetMatchRange.last + 1)
+        assertEquals("brown", highlighted)
+    }
+
+    @Test
+    fun `snippet preserves match casing from the body, not the query`() {
+        val results = searchBook(listOf(ch("c0", 0, "The DRAGON roars")), "dragon")
+        val r = results.single()
+        val highlighted = r.snippet.substring(r.snippetMatchRange.first, r.snippetMatchRange.last + 1)
+        assertEquals("DRAGON", highlighted)
+    }
+
+    // --- buildSnippet -------------------------------------------------------
+
+    @Test
+    fun `short body is returned whole with no ellipsis`() {
+        val (snippet, range) = buildSnippet("brown fox", matchStart = 0, matchLength = 5)
+        assertEquals("brown fox", snippet)
+        assertEquals(0, range.first)
+        assertEquals("brown", snippet.substring(range.first, range.last + 1))
+    }
+
+    @Test
+    fun `long body is clipped with leading and trailing ellipsis around the match`() {
+        val body = "a".repeat(60) + "TARGET" + "b".repeat(60)
+        val (snippet, range) = buildSnippet(body, matchStart = 60, matchLength = 6, radius = 48)
+        assertTrue("expected leading ellipsis", snippet.startsWith("…"))
+        assertTrue("expected trailing ellipsis", snippet.endsWith("…"))
+        assertEquals("TARGET", snippet.substring(range.first, range.last + 1))
+    }
+
+    @Test
+    fun `match at body start has no leading ellipsis`() {
+        val body = "TARGET" + "x".repeat(80)
+        val (snippet, range) = buildSnippet(body, matchStart = 0, matchLength = 6, radius = 48)
+        assertTrue(snippet.startsWith("TARGET"))
+        assertTrue(snippet.endsWith("…"))
+        assertEquals("TARGET", snippet.substring(range.first, range.last + 1))
+    }
+
+    @Test
+    fun `whitespace and newlines collapse without desyncing the highlight range`() {
+        val body = "alpha\n\nbeta   TARGET\tgamma"
+        val matchStart = body.indexOf("TARGET")
+        val (snippet, range) = buildSnippet(body, matchStart = matchStart, matchLength = 6)
+        // No raw newlines/tabs survive in the snippet.
+        assertTrue(snippet.none { it == '\n' || it == '\t' })
+        assertEquals("TARGET", snippet.substring(range.first, range.last + 1))
+    }
+}

--- a/source-epub-writer/src/test/kotlin/in/jphe/storyvox/source/epub/writer/NoopDaos.kt
+++ b/source-epub-writer/src/test/kotlin/in/jphe/storyvox/source/epub/writer/NoopDaos.kt
@@ -97,4 +97,9 @@ internal class NoopChapterDao : ChapterDao {
     override suspend fun getBookmark(id: String): Int? = null
     override suspend fun allBookmarks(): List<`in`.jphe.storyvox.data.db.dao.BookmarkRow> = emptyList()
     override suspend fun cacheUsage(): ChapterCacheUsageRow = ChapterCacheUsageRow(count = 0, bytes = 0L)
+    override suspend fun searchChapters(
+        fictionId: String,
+        query: String,
+        limit: Int,
+    ): List<`in`.jphe.storyvox.data.db.dao.ChapterSearchRow> = emptyList()
 }


### PR DESCRIPTION
Closes #1229.

## What

Adds **find-in-book** to the reader. A magnifying glass in the player's top bar opens a top-anchored search overlay that scans the text of **every downloaded chapter** and lists the matching chapters — each with a snippet and the query term highlighted. Tapping a result jumps to that chapter at the match position; prev/next chevrons cycle the selection.

This is distinct from #998's in-*chapter* find-in-text (the bottom search bar / FAB on the reader pane), which stays untouched. #998 = "find on this page"; #1229 = "search the whole book."

## How it maps to the issue

1. **Search bar** — magnifying glass in the reader top bar (`AudiobookView`) opens a top overlay (`BookSearchOverlay`), rendered over both panes by `HybridReaderScreen`.
2. **Room query** — `ChapterDao.searchChapters`: `… WHERE fictionId = :fictionId AND plainBody IS NOT NULL AND plainBody <> '' AND plainBody LIKE '%' || :query || '%' ORDER BY \`index\` ASC LIMIT :limit`. LIKE, not FTS. Downloaded chapters only.
3. **Results list** — one row per matching chapter: title + match-count badge + snippet with the term background-highlighted via `AnnotatedString`.
4. **Navigate to match** — tap (or IME *Search* on the selected result) → `startListening(chapterId, charOffset = matchOffset, autoPlay = false)` and switch to the reader pane; the existing auto-scroll settles the seeked sentence into view.
5. **Next / Previous** — chevrons step the selected result with wraparound (reusing #998's `nextMatchIndex` / `prevMatchIndex`), scrolling the list to keep it visible.

## Design notes

- **LIKE is a coarse pre-filter.** It returns *bodies* for matching chapters; the pure `searchBook` core re-scans each with the literal, case-insensitive `findMatches` (the #998 core) to compute exact offsets, counts, and the highlighted snippet. A LIKE over-match (e.g. `%` wildcard in the query) yields zero literal hits and is dropped; LIKE can never *under*-match, so no `ESCAPE` clause is needed.
- **Bounded memory.** The query is capped at `DEFAULT_BOOK_SEARCH_LIMIT = 500` chapters; the overlay surfaces a "showing the first N chapters" note if the cap is hit. Search is debounced (250 ms), min query length 2, and runs on `Dispatchers.Default` with `flatMapLatest` cancelling stale searches.
- **Pure, testable core.** `BookTextSearch.kt` (`searchBook` / `buildSnippet`) is Compose-/Room-free, mirroring #998's split — snippet whitespace is collapsed segment-by-segment so newlines never desync the highlight range.

## Tests

- `BookTextSearchTest` — ordering, case-insensitivity, match counts, blank/trim handling, LIKE over-match drop, and snippet/highlight-range correctness (clipping ellipsis, whitespace collapse, match casing).
- `ChapterRepositoryImplTest` — new cases for `searchChapterBodies` (matching/ordering, case-insensitivity, body-required filter, blank short-circuit, trim, limit). `FakeChapterDao` implements the new query.

No local gradle run (per project policy — CI's Build APK is the compile gate).

## Follow-up (out of scope)

Background-highlighting the search term in the reader body after a cross-chapter jump would require hoisting #998's chapter-local search state; left as a follow-up to avoid entangling the two features. The snippet already shows the highlighted term, and the jump lands on the matched sentence.

🤖 Generated with [Claude Code](https://claude.com/claude-code)