### PR TITLE
feat(import): in-app single-file import for EPUB/PDF/TXT (#1228)

### DIFF
--- a/app/src/main/kotlin/in/jphe/storyvox/MainActivity.kt
+++ b/app/src/main/kotlin/in/jphe/storyvox/MainActivity.kt
@@ -2,12 +2,10 @@ package `in`.jphe.storyvox
 
 import android.Manifest
 import android.content.Intent
-import android.database.Cursor
 import android.content.pm.PackageManager
 import android.net.Uri
 import android.os.Build
 import android.os.Bundle
-import android.provider.OpenableColumns
 import android.util.Log
 import android.view.Choreographer
 import androidx.activity.ComponentActivity
@@ -33,6 +31,7 @@ import androidx.compose.foundation.isSystemInDarkTheme
 import dagger.Lazy
 import dagger.hilt.android.AndroidEntryPoint
 import `in`.jphe.storyvox.feature.api.CoverStyle
+import `in`.jphe.storyvox.feature.api.ImportFileResult
 import `in`.jphe.storyvox.feature.api.ReadingDirection
 import `in`.jphe.storyvox.feature.api.SettingsRepositoryUi
 import `in`.jphe.storyvox.feature.api.SpeakChapterMode
@@ -55,13 +54,10 @@ import `in`.jphe.storyvox.ui.a11y.LocalIsTalkBackActive
 import `in`.jphe.storyvox.ui.component.CoverStyleLocal
 import `in`.jphe.storyvox.ui.component.LocalCoverStyle
 import `in`.jphe.storyvox.ui.theme.LibraryNocturneTheme
-import `in`.jphe.storyvox.data.EpubConfigImpl
+import `in`.jphe.storyvox.data.DocumentImporterUiImpl
 import `in`.jphe.storyvox.navigation.DeepLinkResolver
-import `in`.jphe.storyvox.navigation.DocumentImportClassifier
-import `in`.jphe.storyvox.navigation.ImportKind
 import `in`.jphe.storyvox.navigation.StoryvoxNavHost
 import `in`.jphe.storyvox.navigation.StoryvoxRoutes
-import `in`.jphe.storyvox.source.epub.config.EpubEntryKind
 import javax.inject.Inject
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -121,15 +117,16 @@ class MainActivity : ComponentActivity() {
     @Inject lateinit var accessibilityStateBridge: Lazy<AccessibilityStateBridge>
 
     /**
-     * Issue #1000 — "Open With" file import. The EPUB config impl is
-     * the registry the import path writes into (a single inbound EPUB /
-     * TXT file becomes a standalone fiction, reusing the `:source-epub`
-     * read path). Wrapped in [Lazy] for the same cold-launch reason as
-     * the other injects (#409): the DataStore-backed graph isn't
-     * materialised during activity injection, only when an import
-     * intent actually arrives.
+     * Issue #1000 / #1228 — single-file document import. The shared
+     * [DocumentImporterUiImpl] owns the resolve → classify → persist-grant
+     * → register sequence; this "Open With" / share path and the in-app
+     * "Import a file…" picker both route through it (a single inbound
+     * EPUB / TXT / PDF file becomes a standalone fiction). Wrapped in
+     * [Lazy] for the same cold-launch reason as the other injects (#409):
+     * the DataStore-backed graph isn't materialised during activity
+     * injection, only when an import intent actually arrives.
      */
-    @Inject lateinit var epubConfig: Lazy<EpubConfigImpl>
+    @Inject lateinit var documentImporter: Lazy<DocumentImporterUiImpl>
 
     // testTagsAsResourceId is experimental Compose UI API. We opt in at
     // the function holding setContent {} because that's where the flag is
@@ -394,57 +391,22 @@ class MainActivity : ComponentActivity() {
     }
 
     /**
-     * Issue #1000 — ingest a document Uri received via "Open With"
+     * Issue #1000 / #1228 — ingest a document Uri received via "Open With"
      * (ACTION_VIEW) or "Share → Candela" (ACTION_SEND with EXTRA_STREAM)
-     * and return the fiction-detail route to navigate to, or null if
-     * the document type isn't one we can open.
+     * and return the fiction-detail route to navigate to, or null if the
+     * document type isn't one we can open.
      *
-     * Steps:
-     *  1. Resolve the mime type (intent type → ContentResolver type) and
-     *     a human filename (OpenableColumns.DISPLAY_NAME → last path
-     *     segment) for the Uri.
-     *  2. [DocumentImportClassifier.classify] buckets it (Epub / Text /
-     *     Pdf / Unsupported). Unsupported (incl. PDF until #996 lands)
-     *     → return null; the resolver fall-through then declines too.
-     *  3. [takePersistableUriPermission] so re-opens from Library
-     *     survive a relaunch — content Uris from SAF / file managers
-     *     carry FLAG_GRANT_READ_URI_PERMISSION; persisting it converts
-     *     the one-shot grant into a durable one.
-     *  4. Register with the EPUB config and return its fictionId route.
+     * The resolve → classify → persist-grant → register work lives in
+     * [DocumentImporterUiImpl] (#1228) so this path and the in-app
+     * "Import a file…" picker share one implementation. The inbound
+     * intent's `type` is passed as the mime hint — a file manager's SEND
+     * intent often carries a better mime than `ContentResolver.getType`.
      */
-    private suspend fun importDocument(uri: Uri): String? {
-        val mime = intent?.type ?: contentResolver.getType(uri)
-        val displayName = queryDisplayName(uri) ?: uri.lastPathSegment.orEmpty()
-        val kind = DocumentImportClassifier.classify(mime, displayName)
-        val entryKind = when (kind) {
-            ImportKind.Epub -> EpubEntryKind.Epub
-            ImportKind.Text -> EpubEntryKind.Text
-            // PDF lands here once #996 flips DocumentImportClassifier
-            // .PDF_ENABLED and wires its extractor into the import store;
-            // until then classify() never returns Pdf, so this is the
-            // single hook to extend (don't import as EPUB — the parser
-            // would reject the bytes).
-            ImportKind.Pdf -> return null
-            ImportKind.Unsupported -> return null
+    private suspend fun importDocument(uri: Uri): String? =
+        when (val result = documentImporter.get().importLocalFile(uri.toString(), intent?.type)) {
+            is ImportFileResult.Success -> StoryvoxRoutes.fictionDetail(result.fictionId)
+            ImportFileResult.Unsupported, is ImportFileResult.Error -> null
         }
-        // Persist read access so Library re-opens work after relaunch.
-        // Best-effort: some providers grant only a one-shot read (no
-        // persistable flag) — the import still works for this session,
-        // and a failed persist shouldn't abort the open.
-        runCatching {
-            contentResolver.takePersistableUriPermission(
-                uri,
-                Intent.FLAG_GRANT_READ_URI_PERMISSION,
-            )
-        }.onFailure { Log.w(TAG, "Could not persist URI permission for $uri", it) }
-
-        val fictionId = epubConfig.get().importFile(
-            uriString = uri.toString(),
-            displayName = displayName,
-            kind = entryKind,
-        )
-        return StoryvoxRoutes.fictionDetail(fictionId)
-    }
 
     /**
      * Debug-only deterministic reader seed (Layer 1 of the UI-test
@@ -475,33 +437,11 @@ class MainActivity : ComponentActivity() {
                 null
             }
         } ?: return null
-        // file:// to our own cacheDir — importDocument's
-        // openInputStream reads it directly (we own the file), and the
-        // takePersistableUriPermission call no-ops on a file Uri.
+        // file:// to our own cacheDir — the importer reads it directly
+        // (we own the file), and the takePersistableUriPermission call
+        // no-ops on a file Uri.
         return importDocument(Uri.fromFile(cached))
     }
-
-    /** Query the SAF [OpenableColumns.DISPLAY_NAME] for a content Uri.
-     *  Returns null for non-content Uris or when the provider doesn't
-     *  expose the column (the caller falls back to the last path
-     *  segment). Off the main thread — ContentResolver.query touches a
-     *  binder. */
-    private suspend fun queryDisplayName(uri: Uri): String? =
-        withContext(Dispatchers.IO) {
-            if (uri.scheme != "content") return@withContext null
-            runCatching {
-                contentResolver.query(
-                    uri,
-                    arrayOf(OpenableColumns.DISPLAY_NAME),
-                    null,
-                    null,
-                    null,
-                )?.use { cursor: Cursor ->
-                    val idx = cursor.getColumnIndex(OpenableColumns.DISPLAY_NAME)
-                    if (idx >= 0 && cursor.moveToFirst()) cursor.getString(idx) else null
-                }
-            }.getOrNull()?.takeIf { it.isNotBlank() }
-        }
 
     private companion object {
         private const val TAG = "MainActivity"

--- a/app/src/main/kotlin/in/jphe/storyvox/data/DocumentImporterUiImpl.kt
+++ b/app/src/main/kotlin/in/jphe/storyvox/data/DocumentImporterUiImpl.kt
@@ -1,0 +1,135 @@
+package `in`.jphe.storyvox.data
+
+import android.content.Context
+import android.content.Intent
+import android.database.Cursor
+import android.net.Uri
+import android.provider.OpenableColumns
+import android.util.Log
+import dagger.hilt.android.qualifiers.ApplicationContext
+import `in`.jphe.storyvox.feature.api.DocumentImporterUi
+import `in`.jphe.storyvox.feature.api.ImportFileResult
+import `in`.jphe.storyvox.navigation.DocumentImportClassifier
+import `in`.jphe.storyvox.navigation.ImportKind
+import `in`.jphe.storyvox.source.epub.config.EpubEntryKind
+import javax.inject.Inject
+import javax.inject.Singleton
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+
+/**
+ * Issue #1228 — the shared single-file import path. Both the in-app
+ * "Import a file…" picker (via [DocumentImporterUi] injected into the
+ * Library ViewModel) and MainActivity's "Open With" / share ingest (#1000)
+ * route through here, so the four-step sequence —
+ *
+ *   1. resolve the (mime, filename) pair,
+ *   2. classify it via [DocumentImportClassifier],
+ *   3. take a persistable read grant on the Uri,
+ *   4. register it with the matching per-format store,
+ *
+ * — lives in exactly one place rather than being copy-pasted across the
+ * two entry points.
+ *
+ * EPUB and plaintext register with [EpubConfigImpl] (the EPUB source
+ * synthesises a one-chapter book from a `.txt` body, #1000); PDF registers
+ * with [PdfConfigImpl] (#996 text-layer extraction + scanned-page OCR).
+ * [DocumentImportClassifier] is the single source of truth for which
+ * bucket a (mime, filename) pair falls into; the actual chapter bodies are
+ * read lazily by the respective `FictionSource` when a chapter is opened.
+ */
+@Singleton
+class DocumentImporterUiImpl @Inject constructor(
+    @ApplicationContext private val context: Context,
+    private val epubConfig: EpubConfigImpl,
+    private val pdfConfig: PdfConfigImpl,
+) : DocumentImporterUi {
+
+    override suspend fun importLocalFile(uriString: String, mimeHint: String?): ImportFileResult {
+        val uri = runCatching { Uri.parse(uriString) }.getOrNull()
+            ?: return ImportFileResult.Error("That file couldn't be read.")
+        // intent-supplied mime (when present) wins; otherwise ask the
+        // resolver. File managers are inconsistent, so the classifier also
+        // falls back to the filename extension.
+        val mime = mimeHint ?: runCatching { context.contentResolver.getType(uri) }.getOrNull()
+        val displayName = queryDisplayName(uri) ?: uri.lastPathSegment.orEmpty()
+
+        return when (DocumentImportClassifier.classify(mime, displayName)) {
+            ImportKind.Epub -> registerEpub(uri, uriString, displayName, EpubEntryKind.Epub)
+            ImportKind.Text -> registerEpub(uri, uriString, displayName, EpubEntryKind.Text)
+            ImportKind.Pdf -> registerPdf(uri, uriString, displayName)
+            ImportKind.Unsupported -> ImportFileResult.Unsupported
+        }
+    }
+
+    private suspend fun registerEpub(
+        uri: Uri,
+        uriString: String,
+        displayName: String,
+        kind: EpubEntryKind,
+    ): ImportFileResult {
+        persistReadGrant(uri)
+        return runCatching {
+            ImportFileResult.Success(epubConfig.importFile(uriString, displayName, kind))
+        }.getOrElse { failure(displayName, it) }
+    }
+
+    private suspend fun registerPdf(
+        uri: Uri,
+        uriString: String,
+        displayName: String,
+    ): ImportFileResult {
+        persistReadGrant(uri)
+        return runCatching {
+            ImportFileResult.Success(pdfConfig.importFile(uriString, displayName))
+        }.getOrElse { failure(displayName, it) }
+    }
+
+    private fun failure(displayName: String, cause: Throwable): ImportFileResult {
+        Log.w(TAG, "Import failed for $displayName", cause)
+        return ImportFileResult.Error("Couldn't import ${displayName.ifBlank { "that file" }}.")
+    }
+
+    /**
+     * Convert the one-shot SAF read grant into a durable one so Library
+     * re-opens survive a relaunch. Best-effort: some providers grant only
+     * a one-shot read (no persistable flag), and `file://` Uris (the debug
+     * sample seed) have nothing to persist — the import still works for
+     * this session, and a failed persist must not abort the open.
+     */
+    private fun persistReadGrant(uri: Uri) {
+        runCatching {
+            context.contentResolver.takePersistableUriPermission(
+                uri,
+                Intent.FLAG_GRANT_READ_URI_PERMISSION,
+            )
+        }.onFailure { Log.w(TAG, "Could not persist URI permission for $uri", it) }
+    }
+
+    /** Query the SAF [OpenableColumns.DISPLAY_NAME] for a content Uri.
+     *  Returns null for non-content Uris or when the provider doesn't
+     *  expose the column (the caller falls back to the last path segment).
+     *  Off the main thread — ContentResolver.query touches a binder.
+     *  Lifted from MainActivity's #1000 ingest so both entry points resolve
+     *  the display name identically. */
+    private suspend fun queryDisplayName(uri: Uri): String? =
+        withContext(Dispatchers.IO) {
+            if (uri.scheme != "content") return@withContext null
+            runCatching {
+                context.contentResolver.query(
+                    uri,
+                    arrayOf(OpenableColumns.DISPLAY_NAME),
+                    null,
+                    null,
+                    null,
+                )?.use { cursor: Cursor ->
+                    val idx = cursor.getColumnIndex(OpenableColumns.DISPLAY_NAME)
+                    if (idx >= 0 && cursor.moveToFirst()) cursor.getString(idx) else null
+                }
+            }.getOrNull()?.takeIf { it.isNotBlank() }
+        }
+
+    private companion object {
+        const val TAG = "DocumentImporter"
+    }
+}

--- a/app/src/main/kotlin/in/jphe/storyvox/data/PdfConfigImpl.kt
+++ b/app/src/main/kotlin/in/jphe/storyvox/data/PdfConfigImpl.kt
@@ -6,6 +6,7 @@ import androidx.datastore.core.DataStore
 import androidx.datastore.preferences.core.Preferences
 import androidx.datastore.preferences.core.edit
 import androidx.datastore.preferences.core.stringPreferencesKey
+import androidx.datastore.preferences.core.stringSetPreferencesKey
 import androidx.datastore.preferences.preferencesDataStore
 import androidx.documentfile.provider.DocumentFile
 import dagger.hilt.android.qualifiers.ApplicationContext
@@ -16,6 +17,7 @@ import javax.inject.Inject
 import javax.inject.Singleton
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.map
@@ -29,6 +31,56 @@ private object PdfKeys {
      *  reboots — we don't re-prompt. Empty / missing = no folder
      *  configured (Browse → Local PDFs shows empty state). */
     val FOLDER_URI = stringPreferencesKey("pref_pdf_folder_uri")
+
+    /** Issue #1228 — single PDFs imported via the in-app "Import a file…"
+     *  picker (vs the folder picker). Each member is one encoded record
+     *  (`displayName|uriString` — see [encodeImportedPdf] /
+     *  [decodeImportedPdf]). A `Set<String>` dedups by exact record; the
+     *  indexed list also keys on fictionId so re-importing the same
+     *  document doesn't create a duplicate fiction. Mirrors the
+     *  [EpubConfigImpl] #1000 import store; PDFs carry no entry-kind so
+     *  the record is one field shorter. */
+    val IMPORTED_FILES = stringSetPreferencesKey("pref_pdf_imported_files")
+}
+
+/** Issue #1228 — encoded `Set<String>` record for one imported PDF.
+ *  Pipe-delimited; the uriString is last so it can legally contain the
+ *  delimiter (we `substringAfter` the first pipe). */
+private fun encodeImportedPdf(entry: PdfFileEntry): String =
+    "${entry.displayName.replace('|', '_')}|${entry.uriString}"
+
+private fun decodeImportedPdf(record: String): PdfFileEntry? {
+    val pipe = record.indexOf('|')
+    if (pipe < 0) return null
+    val displayName = record.substring(0, pipe)
+    val uriString = record.substring(pipe + 1)
+    if (uriString.isBlank()) return null
+    return PdfFileEntry(
+        fictionId = fictionIdForPdfUri(uriString),
+        uriString = uriString,
+        displayName = displayName,
+    )
+}
+
+/** Decode the persisted import-record set into entries, sorted by
+ *  display name. Malformed records are dropped silently (forward-
+ *  compat / corruption resilience). Mirrors [EpubConfigImpl]'s decoder. */
+private fun decodeImportedPdfSet(records: Set<String>?): List<PdfFileEntry> =
+    records.orEmpty()
+        .mapNotNull { decodeImportedPdf(it) }
+        .sortedBy { it.displayName.lowercase() }
+
+/** Issue #1228 — merge folder-enumerated PDFs with single-file imports.
+ *  Folder entries win on fictionId collision (the folder is the canonical
+ *  surface); imports for files not in the folder are appended. Stable
+ *  order: folder documents first, then imports. Mirrors [mergeBooks]. */
+private fun mergeDocuments(
+    folder: List<PdfFileEntry>,
+    imported: List<PdfFileEntry>,
+): List<PdfFileEntry> {
+    if (imported.isEmpty()) return folder
+    val folderIds = folder.mapTo(HashSet()) { it.fictionId }
+    return folder + imported.filter { it.fictionId !in folderIds }
 }
 
 /**
@@ -89,13 +141,25 @@ class PdfConfigImpl internal constructor(
     override suspend fun snapshot(): String? =
         store.data.first()[PdfKeys.FOLDER_URI]?.takeIf { it.isNotBlank() }
 
-    override val documents: Flow<List<PdfFileEntry>> = folderUriString.map { uri ->
-        if (uri == null) emptyList() else withContext(Dispatchers.IO) { enumerator.enumerate(uri) }
-    }.distinctUntilChanged()
+    /** Issue #1228 — single PDFs imported via the in-app picker, decoded
+     *  from the [PdfKeys.IMPORTED_FILES] preference set. Independent of the
+     *  folder picker; merged into [documents] below. */
+    private val importedFiles: Flow<List<PdfFileEntry>> = store.data
+        .map { prefs -> decodeImportedPdfSet(prefs[PdfKeys.IMPORTED_FILES]) }
+        .distinctUntilChanged()
+
+    override val documents: Flow<List<PdfFileEntry>> =
+        combine(folderUriString, importedFiles) { uri, imported ->
+            val folder = if (uri == null) emptyList()
+            else withContext(Dispatchers.IO) { enumerator.enumerate(uri) }
+            mergeDocuments(folder, imported)
+        }.distinctUntilChanged()
 
     override suspend fun documents(): List<PdfFileEntry> {
-        val uri = snapshot() ?: return emptyList()
-        return withContext(Dispatchers.IO) { enumerator.enumerate(uri) }
+        val folder = snapshot()?.let { withContext(Dispatchers.IO) { enumerator.enumerate(it) } }
+            ?: emptyList()
+        val imported = decodeImportedPdfSet(store.data.first()[PdfKeys.IMPORTED_FILES])
+        return mergeDocuments(folder, imported)
     }
 
     /**
@@ -115,6 +179,43 @@ class PdfConfigImpl internal constructor(
 
     suspend fun clearFolder() {
         store.edit { prefs -> prefs.remove(PdfKeys.FOLDER_URI) }
+    }
+
+    /**
+     * Issue #1228 — register a single PDF picked via the in-app "Import a
+     * file…" flow as a standalone fiction, independent of the folder
+     * picker. The caller (the shared document-import path) is expected to
+     * have already taken persistable read permission on the Uri via
+     * [android.content.ContentResolver.takePersistableUriPermission] so the
+     * grant survives the next launch (re-opens from Library work). Returns
+     * the stable fictionId the caller navigates to.
+     *
+     * Idempotent on the Uri: the persisted record set is keyed by the
+     * exact encoded record, and the indexed list dedups by fictionId
+     * ([fictionIdForPdfUri] is a stable hash of the Uri), so importing the
+     * same file twice doesn't create a second fiction. Direct mirror of
+     * [EpubConfigImpl.importFile].
+     */
+    suspend fun importFile(
+        uriString: String,
+        displayName: String,
+    ): String {
+        val entry = PdfFileEntry(
+            fictionId = fictionIdForPdfUri(uriString),
+            uriString = uriString.trim(),
+            displayName = displayName.ifBlank { uriString.substringAfterLast('/') },
+        )
+        store.edit { prefs ->
+            val existing = prefs[PdfKeys.IMPORTED_FILES].orEmpty()
+            // Drop any prior record for the same fictionId (e.g. the
+            // display name changed) before adding the fresh one.
+            val pruned = existing.filterTo(mutableSetOf()) { rec ->
+                decodeImportedPdf(rec)?.fictionId != entry.fictionId
+            }
+            pruned.add(encodeImportedPdf(entry))
+            prefs[PdfKeys.IMPORTED_FILES] = pruned
+        }
+        return entry.fictionId
     }
 
     companion object {

--- a/app/src/main/kotlin/in/jphe/storyvox/di/AppBindings.kt
+++ b/app/src/main/kotlin/in/jphe/storyvox/di/AppBindings.kt
@@ -33,6 +33,7 @@ import `in`.jphe.storyvox.feature.api.BrowseRepositoryUi
 import `in`.jphe.storyvox.feature.api.BrowseSource
 import `in`.jphe.storyvox.feature.api.DownloadMode
 import `in`.jphe.storyvox.data.repository.AddByUrlResult
+import `in`.jphe.storyvox.feature.api.DocumentImporterUi
 import `in`.jphe.storyvox.feature.api.FictionRepositoryUi
 import `in`.jphe.storyvox.feature.api.UiAddByUrlResult
 import `in`.jphe.storyvox.feature.api.PlaybackControllerUi
@@ -91,6 +92,15 @@ object AppBindings {
         repo: FictionRepository,
         chapters: ChapterRepository,
     ): FictionRepositoryUi = RealFictionRepositoryUi(repo, chapters)
+
+    /** Issue #1228 — bridges the `:feature` [DocumentImporterUi] seam to
+     *  the app-side single-file import path (the same one MainActivity's
+     *  "Open With" ingest uses), so the Library "Import a file…" picker can
+     *  drive an import without `:feature` depending on `:app`. */
+    @Provides @Singleton
+    fun provideDocumentImporterUi(
+        impl: `in`.jphe.storyvox.data.DocumentImporterUiImpl,
+    ): DocumentImporterUi = impl
 
     @Provides @Singleton
     fun provideBrowseRepositoryUi(

--- a/app/src/main/kotlin/in/jphe/storyvox/navigation/DocumentImport.kt
+++ b/app/src/main/kotlin/in/jphe/storyvox/navigation/DocumentImport.kt
@@ -46,15 +46,19 @@ enum class ImportKind {
 object DocumentImportClassifier {
 
     /**
-     * #996 hook — flip to `true` once Somnia's PDF text-extraction path
-     * (`:source-pdf`) is merged and wired into the import store. While
-     * `false`, PDFs classify as [ImportKind.Unsupported] so the resolver
-     * declines them (the manifest still advertises the filter, behind
-     * the same gate, so we don't appear in the chooser for a type we
-     * can't yet open). Keeping the branch live + tested means #996 is a
-     * one-line flip + a store wire, not a re-derivation.
+     * #996 hook — now enabled (#1228). `:source-pdf`'s text-extraction
+     * path is merged and wired into the import store, and the in-app
+     * "Import a file…" picker (#1228) routes [ImportKind.Pdf] through
+     * [in.jphe.storyvox.data.PdfConfigImpl.importFile]. PDFs therefore
+     * classify as [ImportKind.Pdf] rather than [ImportKind.Unsupported].
+     *
+     * Note this gate governs *classification* only — it does not advertise
+     * the external "Open With" PDF intent-filter, which the manifest still
+     * intentionally withholds (a separate, deferred decision). In-app
+     * single-file PDF import works; file-manager "Open With → Candela" for
+     * PDFs remains opt-in for a future change.
      */
-    const val PDF_ENABLED: Boolean = false
+    const val PDF_ENABLED: Boolean = true
 
     private val EPUB_MIMES = setOf(
         "application/epub+zip",

--- a/app/src/test/kotlin/in/jphe/storyvox/navigation/DocumentImportClassifierTest.kt
+++ b/app/src/test/kotlin/in/jphe/storyvox/navigation/DocumentImportClassifierTest.kt
@@ -55,16 +55,19 @@ class DocumentImportClassifierTest {
         assertEquals(ImportKind.Text, classify("text/markdown", "doc"))
     }
 
-    // ── PDF (gated on #996) ──────────────────────────────────────────
+    // ── PDF (#996 landed, #1228 enabled the gate) ─────────────────────
 
     @Test
-    fun pdf_isUnsupportedWhileGated() {
-        // PDF_ENABLED is false until #996 lands — until then PDFs must
-        // NOT be opened (the EPUB parser would choke on the bytes).
-        assertEquals(false, DocumentImportClassifier.PDF_ENABLED)
-        assertEquals(ImportKind.Unsupported, classify("application/pdf", "report.pdf"))
-        assertEquals(ImportKind.Unsupported, classify(null, "report.pdf"))
-        assertEquals(ImportKind.Unsupported, classify("application/x-pdf", "report"))
+    fun pdf_classifiesPdf() {
+        // #1228 — :source-pdf (#996) is merged and wired into the import
+        // store, so the gate is open: PDFs route to the PDF text-extraction
+        // path (in-app "Import a file…" picker) instead of being declined.
+        assertEquals(true, DocumentImportClassifier.PDF_ENABLED)
+        assertEquals(ImportKind.Pdf, classify("application/pdf", "report.pdf"))
+        assertEquals(ImportKind.Pdf, classify(null, "report.pdf"))
+        assertEquals(ImportKind.Pdf, classify("application/x-pdf", "report"))
+        // Generic mime + .pdf extension (the common file-manager case).
+        assertEquals(ImportKind.Pdf, classify("application/octet-stream", "manual.PDF"))
     }
 
     // ── Unsupported / edge ───────────────────────────────────────────

--- a/feature/src/main/kotlin/in/jphe/storyvox/feature/api/DocumentImporterUi.kt
+++ b/feature/src/main/kotlin/in/jphe/storyvox/feature/api/DocumentImporterUi.kt
@@ -1,0 +1,41 @@
+package `in`.jphe.storyvox.feature.api
+
+/**
+ * Issue #1228 — UI-facing seam for importing a single local file
+ * (EPUB / PDF / TXT) picked via Android SAF into the library as a
+ * standalone fiction.
+ *
+ * Declared here in `:feature/api` (mirrors [FictionRepositoryUi]) so the
+ * Library ViewModel can drive an import without `:feature` taking a
+ * dependency on `:app`, where the `ContentResolver` + SAF plumbing and the
+ * per-format import stores (`EpubConfig` / `PdfConfig`) live. The
+ * implementation is bound in `AppBindings`.
+ */
+interface DocumentImporterUi {
+    /**
+     * Persist the document at [uriString] as a fiction and return the
+     * outcome. The implementation resolves the document's mime type and
+     * display name, classifies it, takes a persistable read grant on the
+     * Uri, and registers it with the matching per-format store
+     * (EPUB / TXT → EpubConfig, PDF → PdfConfig).
+     *
+     * [mimeHint] is a mime the caller already knows (e.g. an inbound
+     * intent's `type`); pass null to let the implementation resolve it
+     * from the content Uri.
+     */
+    suspend fun importLocalFile(uriString: String, mimeHint: String? = null): ImportFileResult
+}
+
+/** Outcome of [DocumentImporterUi.importLocalFile]. */
+sealed interface ImportFileResult {
+    /** Imported (or already present); [fictionId] is the stable id to
+     *  navigate to. */
+    data class Success(val fictionId: String) : ImportFileResult
+
+    /** The file's type isn't one Candela can import (not EPUB / PDF / TXT). */
+    data object Unsupported : ImportFileResult
+
+    /** Import failed (unreadable Uri, permission, or store write error);
+     *  [message] is a short user-facing explanation. */
+    data class Error(val message: String) : ImportFileResult
+}

--- a/feature/src/main/kotlin/in/jphe/storyvox/feature/library/LibraryScreen.kt
+++ b/feature/src/main/kotlin/in/jphe/storyvox/feature/library/LibraryScreen.kt
@@ -1,5 +1,8 @@
 package `in`.jphe.storyvox.feature.library
 
+import android.widget.Toast
+import androidx.activity.compose.rememberLauncherForActivityResult
+import androidx.activity.result.contract.ActivityResultContracts
 import androidx.compose.foundation.ExperimentalFoundationApi
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.combinedClickable
@@ -89,6 +92,7 @@ import androidx.compose.material.icons.filled.Clear
 import androidx.compose.material.icons.filled.Search
 import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.OutlinedTextFieldDefaults
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalFocusManager
 import androidx.compose.ui.text.input.ImeAction
 import androidx.compose.ui.text.style.TextAlign
@@ -186,6 +190,21 @@ fun LibraryScreen(
         androidx.compose.runtime.mutableStateOf(false)
     }
 
+    // Issue #1228 — in-app single-file import. The "Import a file…" entry
+    // in the add menu launches the SAF document picker filtered to the
+    // formats Candela can read; the picked Uri is handed to the ViewModel,
+    // which classifies + registers it (reusing the same #1000 import path
+    // as "Open With") and navigates to the new fiction, or emits a
+    // ShowMessage toast on failure. `text/*` rather than bare `text/plain`
+    // lets the picker surface .md / .markdown too — the importer's
+    // classifier buckets those as plaintext.
+    val context = LocalContext.current
+    val importLauncher = rememberLauncherForActivityResult(
+        contract = ActivityResultContracts.OpenDocument(),
+    ) { uri ->
+        uri?.let { viewModel.importPickedFile(it.toString()) }
+    }
+
     // Issue #828 — confirm-before-remove dialog state for the
     // "Remove from library" row on ManageShelvesSheet. Holds the
     // (fictionId, title) the sheet asked to remove; null = no dialog.
@@ -214,6 +233,8 @@ fun LibraryScreen(
                 is LibraryUiEvent.OpenFiction -> onOpenFiction(event.fictionId)
                 is LibraryUiEvent.OpenReader -> onOpenReader(event.fictionId, event.chapterId)
                 is LibraryUiEvent.OpenInboxLink -> onOpenInboxLink(event.deepLinkUri)
+                is LibraryUiEvent.ShowMessage ->
+                    Toast.makeText(context, event.text, Toast.LENGTH_LONG).show()
             }
         }
     }
@@ -308,6 +329,22 @@ fun LibraryScreen(
                             onClick = {
                                 addMenuOpen = false
                                 createAudiobookOpen = true
+                            },
+                        )
+                        // Issue #1228 — import an EPUB / PDF / TXT off the
+                        // device. `text/*` widens the picker to .md /
+                        // .markdown too; the importer classifies the pick.
+                        androidx.compose.material3.DropdownMenuItem(
+                            text = { Text("Import a file…") },
+                            onClick = {
+                                addMenuOpen = false
+                                importLauncher.launch(
+                                    arrayOf(
+                                        "application/epub+zip",
+                                        "application/pdf",
+                                        "text/*",
+                                    ),
+                                )
                             },
                         )
                     }

--- a/feature/src/main/kotlin/in/jphe/storyvox/feature/library/LibraryViewModel.kt
+++ b/feature/src/main/kotlin/in/jphe/storyvox/feature/library/LibraryViewModel.kt
@@ -17,8 +17,10 @@ import `in`.jphe.storyvox.data.repository.ShelfRepository
 import `in`.jphe.storyvox.data.repository.playback.PlaybackResumePolicyConfig
 import `in`.jphe.storyvox.data.work.MetadataBackfillScheduler
 import `in`.jphe.storyvox.data.source.model.FictionSummary
+import `in`.jphe.storyvox.feature.api.DocumentImporterUi
 import `in`.jphe.storyvox.feature.api.DownloadMode
 import `in`.jphe.storyvox.feature.api.FictionRepositoryUi
+import `in`.jphe.storyvox.feature.api.ImportFileResult
 import `in`.jphe.storyvox.feature.api.PlaybackControllerUi
 import `in`.jphe.storyvox.feature.api.UiAddByUrlResult
 import `in`.jphe.storyvox.feature.api.UiRouteCandidate
@@ -156,6 +158,13 @@ sealed interface ManageShelvesSheetState {
 sealed interface LibraryUiEvent {
     data class OpenFiction(val fictionId: String) : LibraryUiEvent
     data class OpenReader(val fictionId: String, val chapterId: String) : LibraryUiEvent
+
+    /**
+     * Issue #1228 — transient toast for the "Import a file…" flow, e.g.
+     * an unreadable pick or a type Candela can't import. Success navigates
+     * via [OpenFiction] instead; this carries only the failure copy.
+     */
+    data class ShowMessage(val text: String) : LibraryUiEvent
     /**
      * Issue #383 — Inbox row tap. Carries a fully-resolved deep-link URI
      * string (`storyvox://reader/<fid>/<cid>` or `storyvox://fiction/<fid>`).
@@ -216,6 +225,9 @@ class LibraryViewModel @Inject constructor(
     /** Issue #981 — kick the metadata back-fill worker on screen open so
      *  synced "Loading…" placeholder rows hydrate. */
     private val metadataBackfillScheduler: MetadataBackfillScheduler,
+    /** Issue #1228 — single-file import seam backing the "Import a file…"
+     *  add-menu entry (EPUB / PDF / TXT via SAF). */
+    private val documentImporter: DocumentImporterUi,
 ) : ViewModel() {
 
     init {
@@ -546,6 +558,32 @@ class LibraryViewModel @Inject constructor(
 
     fun dismissAddByUrl() {
         _addByUrlState.value = AddByUrlSheetState.Hidden
+    }
+
+    /**
+     * Issue #1228 — import a single local file (EPUB / PDF / TXT) the user
+     * picked via the SAF document picker. Delegates to [DocumentImporterUi]
+     * (classify → take a persistable read grant → register with the
+     * matching per-format store) and, on success, navigates to the new
+     * fiction via the same [LibraryUiEvent.OpenFiction] event the
+     * Add-by-URL flow uses. A non-success outcome surfaces a transient
+     * message rather than failing silently.
+     */
+    fun importPickedFile(uriString: String) {
+        viewModelScope.launch {
+            when (val result = documentImporter.importLocalFile(uriString)) {
+                is ImportFileResult.Success ->
+                    _events.send(LibraryUiEvent.OpenFiction(result.fictionId))
+                ImportFileResult.Unsupported ->
+                    _events.send(
+                        LibraryUiEvent.ShowMessage(
+                            "That file can't be imported. Try an EPUB, PDF, or text file.",
+                        ),
+                    )
+                is ImportFileResult.Error ->
+                    _events.send(LibraryUiEvent.ShowMessage(result.message))
+            }
+        }
     }
 
     /**


### PR DESCRIPTION
## What & why

Closes #1228 — local file import (EPUB / PDF / TXT) from device storage.

Adds an **"Import a file…"** entry to the Library add-menu (alongside *Add by
URL* and *Make your own audiobook*). It launches the SAF document picker and
imports a single EPUB / PDF / TXT off the device as a standalone fiction —
narration, bookmarks, annotations, everything — with no folder picker and no
external "Open With" round-trip.

## Scope decision (Option B)

#1228 as filed asked for a **new `source-local` module**. Research found the
capability is **~90% already shipped**:

| Capability | Already exists |
|---|---|
| EPUB parse (container.xml→OPF→spine→XHTML) + SAF | `:source-epub` (#235) |
| TXT → one-chapter book | `EpubEntryKind.Text` (#1000) |
| PDF text extraction + scanned-page OCR + SAF | `:source-pdf` (#996) |
| Persist as Fiction + Chapters | `FictionRepository` → `upsertDetail` |

(The issue cited `source-epub-**writer**`, the export module, for "EPUB
knowledge" — a tell that it predated the EPUB/PDF *readers*.)

Building `source-local` as written would duplicate three modules, add a
conflicting sourceId + Hilt binding, and put a second "Local files" chip in
Browse. Per orchestrator decision, this PR builds the **one genuine gap** — a
unified in-app single-file picker — as a thin layer over the existing sources.

## Changes

- **`DocumentImporterUi`** (`feature/api`) + **`DocumentImporterUiImpl`**
  (`:app`): one shared *resolve → classify → persist-grant → register* path.
  `MainActivity`'s "Open With" ingest (#1000) now **delegates** to it, so the
  ingest logic lives in one place instead of being copy-pasted. (Mirrors the
  existing `FictionRepositoryUi` seam — `:feature` can't depend on `:app`.)
- **`LibraryViewModel.importPickedFile`** + **`LibraryScreen`** "Import a file…"
  menu item (`OpenDocument` picker, mime `["application/epub+zip",
  "application/pdf", "text/*"]`). Success navigates via the existing
  `OpenFiction` event; failure surfaces a toast (`ShowMessage`).
- **`PdfConfigImpl.importFile`** + imported-files merge, mirroring
  `EpubConfigImpl` (#1000), so single-file PDFs index alongside folder-picked
  ones. PDFs route through the same `PdfSource` text-extraction path.
- **`DocumentImportClassifier.PDF_ENABLED` → true** now that `:source-pdf` is
  wired. Classification only — the external Open-With PDF intent-filter stays
  unadvertised (a separate, deferred decision).

## Testing

- `DocumentImportClassifierTest` updated (TDD) for the PDF gate: PDFs now
  classify as `ImportKind.Pdf`.
- The SAF / DataStore / Compose glue follows the project's existing test
  boundary (JUnit 4, no Robolectric) — verified via CI compile + on-device
  import of a real EPUB, PDF, and `.txt`.

## Risk / rollback

Additive. The "Open With" path is unchanged in behavior (now routed through the
shared importer). No DB migration, no new permissions, no manifest changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * You can now import individual EPUB, PDF, TXT, and Markdown files from the Library “+” menu.
  * Imported PDFs are now recognized and added alongside existing library items.
  * Import errors and unsupported files now show a clear message to the user.

* **Bug Fixes**
  * Improved handling of file imports so selected documents open more reliably and are added to the library when supported.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->