### PR TITLE
feat(playback): auto-detect text language and switch TTS voice (#1233)

### DIFF
--- a/app/src/main/kotlin/in/jphe/storyvox/data/SettingsRepositoryUiImpl.kt
+++ b/app/src/main/kotlin/in/jphe/storyvox/data/SettingsRepositoryUiImpl.kt
@@ -461,6 +461,9 @@ private object Keys {
      *  values. */
     val VOICE_STEADY = booleanPreferencesKey("pref_voice_steady_v1")
 
+    /** Issue #1233 — auto-detect-language & switch-voice toggle. Default false. */
+    val AUTO_LANGUAGE_DETECTION = booleanPreferencesKey("pref_auto_language_detection_v1")
+
     /** Issue #589 — global animation-speed master multiplier (Float).
      *  Synced as of #916. Default 1.0× preserves existing behavior
      *  on fresh installs. */
@@ -1106,6 +1109,7 @@ class SettingsRepositoryUiImpl(
     PlaybackBufferConfig,
     PlaybackModeConfig,
     VoiceTuningConfig,
+    `in`.jphe.storyvox.data.repository.playback.LanguageDetectionConfig,
     AzureFallbackConfig,
     ParallelSynthConfig,
     PlaybackResumePolicyConfig,
@@ -1320,6 +1324,7 @@ class SettingsRepositoryUiImpl(
             cacheUsedBytes = configs.cacheStats.usedBytes,
             cacheQuotaBytes = configs.cacheStats.quotaBytes,
             voiceSteady = prefs[Keys.VOICE_STEADY] ?: true,
+            autoLanguageDetectionEnabled = prefs[Keys.AUTO_LANGUAGE_DETECTION] ?: false,
             palace = UiPalaceConfig(host = palace.host, apiKey = palace.apiKey),
             github = githubSession.toUi(),
             githubPrivateReposEnabled = prefs[Keys.GITHUB_PRIVATE_REPOS_ENABLED] ?: false,
@@ -1904,6 +1909,18 @@ class SettingsRepositoryUiImpl(
 
     override val voiceSteady: Flow<Boolean> = store.data.map { it[Keys.VOICE_STEADY] ?: true }
     override suspend fun currentVoiceSteady(): Boolean = voiceSteady.first()
+
+    // --- LanguageDetectionConfig (#1233) + SettingsRepository toggle ---
+    // One set of overrides satisfies both contracts: the core-playback
+    // LanguageDetectionConfig (EnginePlayer collects the flow) and the
+    // UiContracts SettingsRepository setter (the Settings UI writes it).
+    override val autoLanguageDetectionEnabled: Flow<Boolean> =
+        store.data.map { it[Keys.AUTO_LANGUAGE_DETECTION] ?: false }
+    override suspend fun currentAutoLanguageDetectionEnabled(): Boolean =
+        autoLanguageDetectionEnabled.first()
+    override suspend fun setAutoLanguageDetectionEnabled(enabled: Boolean) {
+        store.edit { it[Keys.AUTO_LANGUAGE_DETECTION] = enabled }
+    }
 
     // --- AzureFallbackConfig (#185, PR-6) ---
     // Surfaced through the same DataStore-backed flow as the other

--- a/app/src/main/kotlin/in/jphe/storyvox/di/AppBindings.kt
+++ b/app/src/main/kotlin/in/jphe/storyvox/di/AppBindings.kt
@@ -314,6 +314,15 @@ object AppBindings {
     fun provideVoiceTuningConfig(impl: SettingsRepositoryUiImpl): VoiceTuningConfig = impl
 
     /**
+     * Issue #1233 — auto-detect-language config binding. Same
+     * SettingsRepositoryUiImpl singleton; consumed by `core-playback`'s
+     * EnginePlayer to route foreign passages to a matching Kokoro voice.
+     */
+    @Provides @Singleton
+    fun provideLanguageDetectionConfig(impl: SettingsRepositoryUiImpl):
+        `in`.jphe.storyvox.data.repository.playback.LanguageDetectionConfig = impl
+
+    /**
      * PR-6 (#185) — Azure offline-fallback contract. Same
      * SettingsRepositoryUiImpl singleton; one DataStore, four contracts
      * now. EnginePlayer reads this to decide whether to auto-swap to a

--- a/core-data/src/main/kotlin/in/jphe/storyvox/data/repository/playback/LanguageDetectionConfig.kt
+++ b/core-data/src/main/kotlin/in/jphe/storyvox/data/repository/playback/LanguageDetectionConfig.kt
@@ -1,0 +1,46 @@
+package `in`.jphe.storyvox.data.repository.playback
+
+import kotlinx.coroutines.flow.Flow
+
+/**
+ * Issue #1233 — auto-detect a sentence's language and switch the TTS
+ * voice to one that matches it.
+ *
+ * Sibling of [VoiceTuningConfig] / [PlaybackBufferConfig] / [ParallelSynthConfig]:
+ * surfaced as its own narrow contract so `core-playback` (whose
+ * `EnginePlayer` is the only consumer) stays free of feature-layer
+ * types. The implementation lives in `:app`'s `SettingsRepositoryUiImpl`,
+ * which already implements the other playback configs against a single
+ * DataStore.
+ *
+ * **Off by default.** When `false` (the default), playback is
+ * byte-identical to pre-#1233 behaviour — the detector never runs, the
+ * synth path is unchanged, and the on-disk PCM cache is keyed exactly as
+ * before. Flipping it `true` opts the listener into per-sentence
+ * language routing.
+ *
+ * **Scope of effect.** Routing currently acts only on the **Kokoro**
+ * engine family, the one in-app family with multi-language speakers
+ * (en/es/fr/hi/it/ja/pt/zh — see [`in`.jphe.storyvox.playback.voice.VoiceCatalog]).
+ * Kokoro shares one model across all 53 speakers, so switching to a
+ * target-language speaker is a reload-free `setActiveSpeakerId` call.
+ * For every other engine (Piper, Kitten, Azure, System TTS) the router
+ * finds no same-family target-language voice and the listener stays on
+ * their chosen voice — the graceful fallback required by #1233.
+ */
+interface LanguageDetectionConfig {
+
+    /**
+     * Live flow of the "auto-detect language & switch voice" preference.
+     * Default `false` (disabled).
+     */
+    val autoLanguageDetectionEnabled: Flow<Boolean>
+
+    /**
+     * Snapshot read for callers that need a single value without
+     * subscribing. Implementations return the most recent value, falling
+     * back to the documented default (`false`) if the underlying store
+     * hasn't emitted yet.
+     */
+    suspend fun currentAutoLanguageDetectionEnabled(): Boolean
+}

--- a/core-playback/src/main/kotlin/in/jphe/storyvox/playback/lang/LanguageDetector.kt
+++ b/core-playback/src/main/kotlin/in/jphe/storyvox/playback/lang/LanguageDetector.kt
@@ -1,0 +1,86 @@
+package `in`.jphe.storyvox.playback.lang
+
+/**
+ * Issue #1233 — the detected language of a span of text.
+ *
+ * @property languageCode ISO-639 base language subtag, lower-cased and
+ *   stripped of any region/script suffix (e.g. `"fr"`, `"ja"`, `"zh"`).
+ *   Normalised at the detector boundary so downstream code
+ *   ([LanguageVoiceRouter]) never has to re-parse a BCP-47 tag.
+ * @property confidence detector confidence in `0f..1f`.
+ */
+data class DetectedLanguage(
+    val languageCode: String,
+    val confidence: Float,
+)
+
+/**
+ * Issue #1233 — detects the dominant language of a chunk of text so the
+ * TTS engine can route foreign passages to a matching voice.
+ *
+ * Kept as an interface so [`in`.jphe.storyvox.playback.tts.EnginePlayer]
+ * depends on the contract, not the Android `TextClassifier` plumbing —
+ * which keeps the decision logic ([LanguageVoiceRouter]) and the
+ * threshold logic ([decideDetection]) unit-testable on a plain JVM
+ * without Robolectric (the project ships no Robolectric — see CLAUDE.md).
+ *
+ * Implementations MUST be deterministic for a given input within a
+ * device/runtime: the on-disk PCM cache key namespaces auto-language
+ * renders, and a cache hit replays whatever voices the previous render
+ * chose, so the same text must route the same way on re-render.
+ */
+interface LanguageDetector {
+    /**
+     * Detect the dominant language of [text]. Returns `null` when the
+     * text is too short to classify reliably, the platform can't
+     * classify it, confidence is below threshold, or anything throws —
+     * every "don't know" collapses to `null` so the caller's fallback
+     * (stay on the current voice) is the single, obvious branch.
+     */
+    fun detect(text: String): DetectedLanguage?
+}
+
+/**
+ * The pure, Android-free core of the detection decision: given a raw
+ * detected language tag, its confidence, and the length of the source
+ * text, decide whether the detection is trustworthy enough to act on.
+ *
+ * Split out from the `TextClassifier`-backed detector so the
+ * thresholding rules — the part with actual branching — are unit-tested
+ * directly. The `TextClassifier` call itself is a thin, untestable
+ * (no Robolectric) shell around this.
+ *
+ * Rules, in order:
+ *  - Text shorter than [minTextLength] is rejected: language detection
+ *    on 1–2 words is unreliable (#1233 explicitly calls this out).
+ *  - A blank/absent tag is rejected.
+ *  - Confidence below [minConfidence] is rejected.
+ *
+ * @param rawLanguageTag a BCP-47-ish tag from the platform (e.g. `"fr"`,
+ *   `"zh-Hant"`), or `null`/blank if the platform returned nothing.
+ */
+internal fun decideDetection(
+    rawLanguageTag: String?,
+    confidence: Float,
+    textLength: Int,
+    minTextLength: Int,
+    minConfidence: Float,
+): DetectedLanguage? {
+    if (textLength < minTextLength) return null
+    val base = baseLanguage(rawLanguageTag.orEmpty())
+    if (base.isBlank()) return null
+    if (confidence < minConfidence) return null
+    return DetectedLanguage(languageCode = base, confidence = confidence)
+}
+
+/**
+ * Normalise a language code to its ISO-639 base subtag: lower-cased,
+ * with any region (`fr-FR`, `pt_BR`) or script (`zh-Hant`) suffix
+ * dropped. `"zh-Hant"` → `"zh"`, `"en_US"` → `"en"`, `"  FR "` → `"fr"`.
+ *
+ * Both the detector and [LanguageVoiceRouter] route through this so a
+ * detected tag and a catalog `language` ("fr_FR") compare on the same
+ * footing.
+ */
+internal fun baseLanguage(code: String): String =
+    code.trim().lowercase().substringBefore('-').substringBefore('_')

--- a/core-playback/src/main/kotlin/in/jphe/storyvox/playback/lang/LanguageVoiceRouter.kt
+++ b/core-playback/src/main/kotlin/in/jphe/storyvox/playback/lang/LanguageVoiceRouter.kt
@@ -1,0 +1,86 @@
+package `in`.jphe.storyvox.playback.lang
+
+import `in`.jphe.storyvox.playback.voice.CatalogEntry
+import `in`.jphe.storyvox.playback.voice.VoiceGender
+import `in`.jphe.storyvox.playback.voice.voiceFamilyId
+
+/**
+ * Issue #1233 — pure decision logic that maps a detected language to the
+ * best voice for narrating it.
+ *
+ * No Android, no I/O, no engine state — just `(detected language, current
+ * voice, candidate catalog) -> CatalogEntry?`. That makes the whole
+ * routing policy directly unit-testable, and keeps it deterministic,
+ * which the on-disk PCM cache relies on (a cache hit replays the voices a
+ * previous render chose, so identical inputs must route identically).
+ *
+ * ### Policy
+ *
+ * 1. **Same-family only.** A candidate must share the current voice's
+ *    engine family ([voiceFamilyId]). Switching among Kokoro's 53
+ *    shared-model speakers is a reload-free `setActiveSpeakerId`;
+ *    crossing to another family would force a model download / multi-second
+ *    reload mid-chapter, which is a worse experience than just reading the
+ *    foreign passage in the current voice. Cross-family routing is a
+ *    deliberate non-goal here.
+ * 2. **No-op when already matching.** If the detected language already
+ *    matches the current voice's language, return `null` — nothing to do.
+ * 3. **Graceful fallback.** If no same-family voice exists for the
+ *    detected language, return `null` and the caller stays on the current
+ *    voice (#1233's required fallback). This is why Piper/Kitten/Azure/
+ *    System-TTS voices — none of which ship sibling foreign-language
+ *    voices in the catalog — simply never switch.
+ * 4. **Best-match ordering** among same-language same-family candidates:
+ *    same gender as the current voice first (narration continuity), then
+ *    same quality tier, then highest quality, then a stable id tiebreak
+ *    for determinism.
+ */
+object LanguageVoiceRouter {
+
+    /**
+     * Resolve the voice to narrate text detected as [detectedLanguage].
+     *
+     * @param detectedLanguage an ISO-639 base subtag (see [baseLanguage]);
+     *   callers should pass [DetectedLanguage.languageCode], which is
+     *   already normalised.
+     * @param current the voice the listener selected (the primary voice).
+     * @param catalog the candidate voices to route among — typically
+     *   [`in`.jphe.storyvox.playback.voice.VoiceCatalog.voices].
+     * @return the voice to switch to for this language, or `null` to stay
+     *   on [current].
+     */
+    fun route(
+        detectedLanguage: String,
+        current: CatalogEntry,
+        catalog: List<CatalogEntry>,
+    ): CatalogEntry? {
+        val target = baseLanguage(detectedLanguage)
+        if (target.isBlank()) return null
+
+        // Already the current voice's language → nothing to switch to.
+        if (target == baseLanguage(current.language)) return null
+
+        val family = current.engineType.voiceFamilyId()
+        val candidates = catalog.filter { entry ->
+            entry.id != current.id &&
+                entry.engineType.voiceFamilyId() == family &&
+                baseLanguage(entry.language) == target
+        }
+        if (candidates.isEmpty()) return null
+
+        return candidates.sortedWith(
+            // Best first. Each clause is descending so `true`/higher sorts
+            // ahead; the final id clause is the deterministic tiebreak.
+            compareByDescending<CatalogEntry> { it.matchesGenderOf(current) }
+                .thenByDescending { it.qualityLevel == current.qualityLevel }
+                .thenByDescending { it.qualityLevel.ordinal }
+                .thenBy { it.id },
+        ).first()
+    }
+
+    /** Gender continuity: a real (non-[VoiceGender.Unknown]) gender that
+     *  equals the current voice's. Unknown never counts as a match so a
+     *  multi-speaker corpus entry doesn't out-rank a true gender match. */
+    private fun CatalogEntry.matchesGenderOf(current: CatalogEntry): Boolean =
+        gender != VoiceGender.Unknown && gender == current.gender
+}

--- a/core-playback/src/main/kotlin/in/jphe/storyvox/playback/lang/TextClassifierLanguageDetector.kt
+++ b/core-playback/src/main/kotlin/in/jphe/storyvox/playback/lang/TextClassifierLanguageDetector.kt
@@ -1,0 +1,99 @@
+package `in`.jphe.storyvox.playback.lang
+
+import android.content.Context
+import android.os.Build
+import android.view.textclassifier.TextClassificationManager
+import android.view.textclassifier.TextClassifier
+import android.view.textclassifier.TextLanguage
+import androidx.annotation.RequiresApi
+
+/**
+ * Issue #1233 — [LanguageDetector] backed by Android's on-device
+ * `TextClassifier.detectLanguage`.
+ *
+ * ### API level
+ *
+ * `TextClassifier.detectLanguage(TextLanguage.Request)` is **API 29+**
+ * (Android 10) — note the `TextClassifier` *interface* exists from API 26,
+ * but the language-detection method does not. The app's `minSdk` is 26,
+ * so on API 26–28 [create] returns a detector whose [detect] always
+ * returns `null`. That's not a defect: a `null` detection is exactly the
+ * "stay on the current voice" fallback, so the feature simply no-ops on
+ * older devices instead of needing a separate code path.
+ *
+ * ### Robustness
+ *
+ * Everything is wrapped so a "don't know" — short text, no hypothesis,
+ * low confidence, a `TextClassifier` that throws — collapses to `null`.
+ * This runs on the audio producer thread inside the engine mutex
+ * (see `EnginePlayer.activeVoiceEngineHandle`), so it must never throw
+ * into the synth path.
+ *
+ * @property classifier the platform classifier, or `null` on API < 29 /
+ *   when the system service is unavailable.
+ * @property minTextLength reject text shorter than this — single words
+ *   classify unreliably (#1233).
+ * @property minConfidence reject detections below this confidence.
+ */
+class TextClassifierLanguageDetector internal constructor(
+    private val classifier: TextClassifier?,
+    private val minTextLength: Int = DEFAULT_MIN_TEXT_LENGTH,
+    private val minConfidence: Float = DEFAULT_MIN_CONFIDENCE,
+) : LanguageDetector {
+
+    override fun detect(text: String): DetectedLanguage? {
+        if (text.length < minTextLength) return null
+        val classifier = classifier ?: return null
+        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.Q) return null
+        return runCatching { detectApi29(classifier, text) }.getOrNull()
+    }
+
+    @RequiresApi(Build.VERSION_CODES.Q)
+    private fun detectApi29(classifier: TextClassifier, text: String): DetectedLanguage? {
+        val request = TextLanguage.Request.Builder(text).build()
+        val result: TextLanguage = classifier.detectLanguage(request)
+        if (result.localeHypothesisCount <= 0) return null
+        // Hypotheses come ranked best-first; take the top one.
+        val locale = result.getLocale(0)
+        val confidence = result.getConfidenceScore(locale)
+        return decideDetection(
+            rawLanguageTag = locale.toLanguageTag(),
+            confidence = confidence,
+            textLength = text.length,
+            minTextLength = minTextLength,
+            minConfidence = minConfidence,
+        )
+    }
+
+    companion object {
+        /** ~3–4 words; below this, single-word false positives dominate. */
+        const val DEFAULT_MIN_TEXT_LENGTH: Int = 16
+
+        /** Conservative floor — embedded foreign phrases that the model is
+         *  unsure about read fine in the primary voice, so only act on
+         *  confident detections. */
+        const val DEFAULT_MIN_CONFIDENCE: Float = 0.55f
+
+        /**
+         * Build a detector from a [Context]. Returns a no-op detector
+         * (always `null`) on API < 29 or when the system can't provide a
+         * `TextClassifier`, so callers get a single non-null
+         * [LanguageDetector] regardless of device.
+         */
+        fun create(
+            context: Context,
+            minTextLength: Int = DEFAULT_MIN_TEXT_LENGTH,
+            minConfidence: Float = DEFAULT_MIN_CONFIDENCE,
+        ): TextClassifierLanguageDetector {
+            val classifier: TextClassifier? = runCatching {
+                if (Build.VERSION.SDK_INT < Build.VERSION_CODES.Q) {
+                    null
+                } else {
+                    context.getSystemService(TextClassificationManager::class.java)
+                        ?.textClassifier
+                }
+            }.getOrNull()
+            return TextClassifierLanguageDetector(classifier, minTextLength, minConfidence)
+        }
+    }
+}

--- a/core-playback/src/main/kotlin/in/jphe/storyvox/playback/tts/EnginePlayer.kt
+++ b/core-playback/src/main/kotlin/in/jphe/storyvox/playback/tts/EnginePlayer.kt
@@ -29,6 +29,7 @@ import `in`.jphe.storyvox.data.log.DebugLog
 import `in`.jphe.storyvox.data.repository.ChapterRepository
 import `in`.jphe.storyvox.data.repository.HistoryRepository
 import `in`.jphe.storyvox.data.repository.PlaybackPositionRepository
+import `in`.jphe.storyvox.data.repository.playback.LanguageDetectionConfig
 import `in`.jphe.storyvox.data.repository.playback.NOISE_SCALE_EXPRESSIVE
 import `in`.jphe.storyvox.data.repository.playback.NOISE_SCALE_STEADY
 import `in`.jphe.storyvox.data.repository.playback.NOISE_SCALE_W_EXPRESSIVE
@@ -55,11 +56,15 @@ import `in`.jphe.storyvox.playback.cache.PcmCacheKey
 import `in`.jphe.storyvox.playback.cache.PcmIndex
 import `in`.jphe.storyvox.playback.cache.PrerenderTriggers
 import `in`.jphe.storyvox.playback.cache.pcmCacheJson
+import `in`.jphe.storyvox.playback.lang.LanguageDetector
+import `in`.jphe.storyvox.playback.lang.LanguageVoiceRouter
+import `in`.jphe.storyvox.playback.lang.TextClassifierLanguageDetector
 import `in`.jphe.storyvox.playback.tts.source.CacheFileSource
 import `in`.jphe.storyvox.playback.tts.source.EngineStreamingSource
 import `in`.jphe.storyvox.playback.tts.source.PcmChunk
 import `in`.jphe.storyvox.playback.tts.source.PcmSource
 import `in`.jphe.storyvox.playback.voice.EngineType
+import `in`.jphe.storyvox.playback.voice.VoiceCatalog
 import `in`.jphe.storyvox.playback.voice.VoiceManager
 import java.io.File
 import java.util.concurrent.atomic.AtomicBoolean
@@ -316,6 +321,11 @@ class EnginePlayer @AssistedInject constructor(
      *  when the device is in battery-saver mode. The consumer thread keeps
      *  URGENT_AUDIO — audio glitches are worse than battery drain. */
     private val powerSaveMonitor: `in`.jphe.storyvox.playback.PowerSaveMonitor,
+    /** Issue #1233 — "auto-detect language & switch voice" preference.
+     *  Off by default; when on, the Kokoro synth path routes each
+     *  sentence to a target-language speaker (see [observeLanguageDetectionConfig]
+     *  and [routeKokoroSpeaker]). */
+    private val languageDetectionConfig: LanguageDetectionConfig,
 ) : SimpleBasePlayer(Looper.getMainLooper()) {
 
     @AssistedFactory
@@ -558,6 +568,7 @@ class EnginePlayer @AssistedInject constructor(
         observeAzureFallbackConfig()
         observeA11yPacing()
         observeThermalStatus()
+        observeLanguageDetectionConfig()
     }
 
     /**
@@ -899,6 +910,73 @@ class EnginePlayer @AssistedInject constructor(
                 VoiceEngine.getInstance().setNoiseScaleW(noiseScaleW)
             }
         }
+    }
+
+    /**
+     * Issue #1233 — cached snapshot of
+     * [LanguageDetectionConfig.autoLanguageDetectionEnabled]. Read on the
+     * audio producer thread inside [activeVoiceEngineHandle], which is not
+     * a coroutine, so a live `Flow.collect` there would be wrong — this
+     * mirrors the `cachedVoiceSteady` / `cachedParallelSynthInstances`
+     * volatile-snapshot pattern. The collector in
+     * [observeLanguageDetectionConfig] writes it; the pipeline reads it at
+     * construction (serial-vs-parallel + cache key) and per sentence.
+     *
+     * A flip takes effect on the next natural pipeline boundary (chapter /
+     * seek / voice-swap / speed change) — like the thermal and
+     * parallel-synth snapshots — because both the serial decision and the
+     * cache key are captured at construction time. We deliberately do NOT
+     * force a mid-chapter rebuild (it causes an audible pause-then-repeat).
+     */
+    @Volatile private var cachedAutoLanguageDetection: Boolean = false
+
+    /**
+     * Issue #1233 — on-device language detector, built once from the
+     * assisted [context]. Lazy so devices/tests that never enable the
+     * feature pay nothing. On API < 29 this is a no-op detector that always
+     * returns null (see [TextClassifierLanguageDetector]).
+     */
+    private val languageDetector: LanguageDetector by lazy {
+        TextClassifierLanguageDetector.create(context)
+    }
+
+    private fun observeLanguageDetectionConfig() {
+        scope.launch {
+            languageDetectionConfig.autoLanguageDetectionEnabled.collect { enabled ->
+                cachedAutoLanguageDetection = enabled
+            }
+        }
+    }
+
+    /**
+     * Issue #1233 — resolve the Kokoro speaker id to synthesize [text]
+     * with, given the chapter's primary speaker ([primarySpeakerId]).
+     *
+     * Returns [primarySpeakerId] unchanged unless auto-language routing is
+     * on AND the detector confidently reports a language that maps to a
+     * *different* Kokoro speaker (French dialogue → the Siwis `fr_FR`
+     * speaker, a Japanese passage → a `ja_JP` speaker, …). Every "stay
+     * put" case — feature off, unknown active voice, low-confidence/short
+     * text, no Kokoro voice for that language — collapses to
+     * [primarySpeakerId], which is #1233's graceful fallback.
+     *
+     * Called on the producer thread inside the engine mutex (see
+     * [activeVoiceEngineHandle]): pure reads plus a deterministic router,
+     * so it is cheap and thread-safe there. Determinism matters — the PCM
+     * cache replays whatever speakers a prior render chose, so identical
+     * text must resolve to the identical speaker on re-render.
+     */
+    private fun routeKokoroSpeaker(text: String, primarySpeakerId: Int): Int {
+        if (!cachedAutoLanguageDetection) return primarySpeakerId
+        val current = VoiceCatalog.byId(loadedVoiceId ?: return primarySpeakerId)
+            ?: return primarySpeakerId
+        val detected = languageDetector.detect(text) ?: return primarySpeakerId
+        val target = LanguageVoiceRouter.route(
+            detectedLanguage = detected.languageCode,
+            current = current,
+            catalog = VoiceCatalog.voices,
+        ) ?: return primarySpeakerId
+        return (target.engineType as? EngineType.Kokoro)?.speakerId ?: primarySpeakerId
     }
 
     /**
@@ -2448,7 +2526,12 @@ class EnginePlayer @AssistedInject constructor(
         // it touches AudioTrack / Compose state which are main-thread-bound.
         val cachedIndexSampleRate: Int? = run {
             val chapId = _observableState.value.currentChapterId
-            val voiceId = loadedVoiceId
+            // #1233 — keep the sample-rate probe key in lockstep with the
+            // render key below: routed renders live under a "+autolang"
+            // voiceId namespace, so the probe must read that same entry.
+            val voiceId = loadedVoiceId?.let {
+                if (cachedAutoLanguageDetection && engineType is EngineType.Kokoro) "$it+autolang" else it
+            }
             if (chapId == null || voiceId == null) return@run null
             val probeKey = PcmCacheKey(
                 chapterId = chapId,
@@ -2643,6 +2726,16 @@ class EnginePlayer @AssistedInject constructor(
         // so a thermal change takes effect on the next natural pipeline
         // boundary (next chapter / seek / voice-swap / speed change),
         // restoring or capping concurrency without re-loading models.
+        // Issue #1233 — per-sentence language routing mutates the shared
+        // KokoroEngine's active speaker, which only the serial producer
+        // serializes safely (via engineMutex). The parallel secondaries are
+        // independent KokoroEngine instances pinned to the primary speaker
+        // at load, so they'd synthesize the wrong voice for routed
+        // sentences. Force serial whenever routing is active on Kokoro.
+        val autoLangForcesSerial =
+            cachedAutoLanguageDetection &&
+                engineType is EngineType.Kokoro &&
+                secondaryHandles.isNotEmpty()
         val effectiveSecondaryHandles = if (
             thermalStatus >= ThermalMonitor.THERMAL_STATUS_MODERATE &&
             secondaryHandles.isNotEmpty()
@@ -2657,6 +2750,14 @@ class EnginePlayer @AssistedInject constructor(
                     "parallel synth ${secondaryHandles.size + 1} -> 1 instance(s)",
             )
             emptyList()
+        } else if (autoLangForcesSerial) {
+            android.util.Log.i(
+                "EnginePlayer",
+                "#1233 auto-language routing active: parallel synth " +
+                    "${secondaryHandles.size + 1} -> 1 instance(s) " +
+                    "(serial required for per-sentence speaker swap)",
+            )
+            emptyList()
         } else {
             secondaryHandles
         }
@@ -2668,7 +2769,20 @@ class EnginePlayer @AssistedInject constructor(
         // mid-pipeline state mutation can't shift the key out from
         // under the live appender.
         val chapterIdForCache = _observableState.value.currentChapterId
-        val voiceIdForCache = loadedVoiceId
+        // Issue #1233 — when per-sentence language routing is active the
+        // rendered audio is a MIX of the primary voice and target-language
+        // speakers, so it must not share an on-disk entry with the plain
+        // single-voice render. Namespacing the voiceId (rather than adding a
+        // PcmCacheKey field) keeps every pre-#1233 cache entry valid — only
+        // routed renders get a fresh basename, nothing self-evicts on
+        // upgrade. Routing only ever changes audio for Kokoro, so the suffix
+        // is scoped to that case. The voiceId in a cache key is opaque (only
+        // hashed into the basename, never decoded back), so the suffix is safe.
+        val routingActiveForCache =
+            cachedAutoLanguageDetection && engineType is EngineType.Kokoro
+        val voiceIdForCache = loadedVoiceId?.let {
+            if (routingActiveForCache) "$it+autolang" else it
+        }
         val cacheKey: PcmCacheKey? = if (
             chapterIdForCache != null && voiceIdForCache != null
         ) {
@@ -3579,8 +3693,23 @@ class EnginePlayer @AssistedInject constructor(
                     // Issue #801 — respect power-save mode on the producer thread.
                     AndroidProcess.setThreadPriority(producerPriority())
                     return when (engineType) {
-                        is EngineType.Kokoro -> KokoroEngine.getInstance()
-                            .generateAudioPCM(text, speed, pitch)
+                        is EngineType.Kokoro -> {
+                            // Issue #1233 — per-sentence language routing.
+                            // No-op unless the listener enabled auto-detect.
+                            // setActiveSpeakerId is reload-free across Kokoro's
+                            // one shared model, and this runs inside the
+                            // producer's engineMutex lock — the sole writer of
+                            // the active speaker on the serial path (parallel
+                            // secondaries are forced off when routing is on; see
+                            // effectiveSecondaryHandles), so there's no speaker-id
+                            // race against a concurrent synth.
+                            if (cachedAutoLanguageDetection) {
+                                KokoroEngine.getInstance().setActiveSpeakerId(
+                                    routeKokoroSpeaker(text, engineType.speakerId),
+                                )
+                            }
+                            KokoroEngine.getInstance().generateAudioPCM(text, speed, pitch)
+                        }
                         // Issue #119 — Kitten dispatch.
                         is EngineType.Kitten -> KittenEngine.getInstance()
                             .generateAudioPCM(text, speed, pitch)

--- a/core-playback/src/test/kotlin/in/jphe/storyvox/playback/lang/LanguageDetectorDecisionTest.kt
+++ b/core-playback/src/test/kotlin/in/jphe/storyvox/playback/lang/LanguageDetectorDecisionTest.kt
@@ -1,0 +1,66 @@
+package `in`.jphe.storyvox.playback.lang
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Test
+
+/**
+ * Issue #1233 — the Android-free decision core of language detection.
+ * [decideDetection] holds the thresholding rules and [baseLanguage] the
+ * tag normalisation; the `TextClassifier`-backed detector is a thin shell
+ * over these, so testing them directly covers the branching logic without
+ * Robolectric.
+ */
+class LanguageDetectorDecisionTest {
+
+    private val minLen = 16
+    private val minConf = 0.55f
+
+    @Test
+    fun `text shorter than the minimum is rejected`() {
+        // "Bonjour" — confidently French, but too short to trust.
+        assertNull(decideDetection("fr", 0.99f, textLength = 7, minLen, minConf))
+    }
+
+    @Test
+    fun `confidence below the floor is rejected`() {
+        assertNull(decideDetection("fr", 0.40f, textLength = 80, minLen, minConf))
+    }
+
+    @Test
+    fun `a blank or absent tag is rejected`() {
+        assertNull(decideDetection(null, 0.99f, textLength = 80, minLen, minConf))
+        assertNull(decideDetection("", 0.99f, textLength = 80, minLen, minConf))
+        assertNull(decideDetection("   ", 0.99f, textLength = 80, minLen, minConf))
+    }
+
+    @Test
+    fun `a confident, long-enough detection is accepted and normalised`() {
+        val result = decideDetection("fr", 0.92f, textLength = 80, minLen, minConf)
+        assertEquals(DetectedLanguage("fr", 0.92f), result)
+    }
+
+    @Test
+    fun `script and region suffixes are normalised to the base subtag`() {
+        assertEquals("zh", decideDetection("zh-Hant", 0.8f, 80, minLen, minConf)?.languageCode)
+        assertEquals("pt", decideDetection("pt_BR", 0.8f, 80, minLen, minConf)?.languageCode)
+    }
+
+    @Test
+    fun `thresholds are inclusive at the boundary`() {
+        // textLength == minLen and confidence == minConf both pass (the
+        // rejects are strict `<`).
+        val result = decideDetection("ja", minConf, textLength = minLen, minLen, minConf)
+        assertEquals(DetectedLanguage("ja", minConf), result)
+    }
+
+    @Test
+    fun `baseLanguage strips region, script, case and whitespace`() {
+        assertEquals("fr", baseLanguage("fr-FR"))
+        assertEquals("en", baseLanguage("en_US"))
+        assertEquals("zh", baseLanguage("  ZH-Hant "))
+        assertEquals("ja", baseLanguage("JA"))
+        assertEquals("", baseLanguage(""))
+        assertEquals("", baseLanguage("   "))
+    }
+}

--- a/core-playback/src/test/kotlin/in/jphe/storyvox/playback/lang/LanguageVoiceRouterTest.kt
+++ b/core-playback/src/test/kotlin/in/jphe/storyvox/playback/lang/LanguageVoiceRouterTest.kt
@@ -1,0 +1,154 @@
+package `in`.jphe.storyvox.playback.lang
+
+import `in`.jphe.storyvox.playback.voice.CatalogEntry
+import `in`.jphe.storyvox.playback.voice.EngineType
+import `in`.jphe.storyvox.playback.voice.QualityLevel
+import `in`.jphe.storyvox.playback.voice.VoiceCatalog
+import `in`.jphe.storyvox.playback.voice.VoiceGender
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * Issue #1233 — the routing policy that maps a detected language to a
+ * voice. This is the load-bearing, fully-deterministic core of the
+ * feature, so it gets exercised hard against the REAL [VoiceCatalog]
+ * (the Kokoro section ships the multi-language speakers the feature
+ * leans on) plus a few synthetic entries for the family/gender edges.
+ *
+ * Pure-JVM (no Robolectric / emulator) — [LanguageVoiceRouter] is a pure
+ * function over data.
+ */
+class LanguageVoiceRouterTest {
+
+    private fun voice(id: String): CatalogEntry =
+        VoiceCatalog.byId(id) ?: error("catalog missing $id — test fixture drift")
+
+    // Real catalog anchors (see VoiceCatalog.kokoroEntries).
+    private val kokoroHeartEnUsFemale get() = voice("kokoro_heart_en_US_3")
+    private val kokoroAdamEnUsMale get() = voice("kokoro_adam_en_US_11")
+    private val piperLessacEnUs get() = voice("piper_lessac_en_US_high")
+
+    @Test
+    fun `English Kokoro voice routes French text to the French Kokoro speaker`() {
+        val target = LanguageVoiceRouter.route("fr", kokoroHeartEnUsFemale, VoiceCatalog.voices)
+        assertEquals("kokoro_siwis_fr_FR_30", target?.id)
+    }
+
+    @Test
+    fun `detected language already matching the current voice does not switch`() {
+        assertNull(LanguageVoiceRouter.route("en", kokoroHeartEnUsFemale, VoiceCatalog.voices))
+    }
+
+    @Test
+    fun `Piper voice has no French sibling so it stays put (graceful fallback)`() {
+        // The shipped Piper catalog is English-only; #1233 requires the
+        // listener simply keeps their voice when no same-family match
+        // exists, rather than crossing engines into a 330 MB Kokoro pull.
+        assertNull(LanguageVoiceRouter.route("fr", piperLessacEnUs, VoiceCatalog.voices))
+    }
+
+    @Test
+    fun `gender continuity — female English routes Spanish to the female Spanish voice`() {
+        // es_ES ships exactly one female (Dora, 28) and one male (Alex, 29)
+        // Kokoro speaker, so gender preference is unambiguous.
+        val target = LanguageVoiceRouter.route("es", kokoroHeartEnUsFemale, VoiceCatalog.voices)
+        assertEquals("kokoro_dora_es_ES_28", target?.id)
+    }
+
+    @Test
+    fun `gender continuity — male English routes Spanish to the male Spanish voice`() {
+        val target = LanguageVoiceRouter.route("es", kokoroAdamEnUsMale, VoiceCatalog.voices)
+        assertEquals("kokoro_alex_es_ES_29", target?.id)
+    }
+
+    @Test
+    fun `gender preference never blocks a switch when only the other gender exists`() {
+        // fr_FR ships only Siwis (female). A male listener should still be
+        // routed to French — gender is a soft tiebreak, not a filter.
+        val target = LanguageVoiceRouter.route("fr", kokoroAdamEnUsMale, VoiceCatalog.voices)
+        assertEquals("kokoro_siwis_fr_FR_30", target?.id)
+    }
+
+    @Test
+    fun `Japanese routing picks a Japanese Kokoro voice of the matching gender`() {
+        val female = LanguageVoiceRouter.route("ja", kokoroHeartEnUsFemale, VoiceCatalog.voices)
+        assertEquals("ja_JP", female?.language)
+        assertEquals(VoiceGender.Female, female?.gender)
+        assertTrue(female?.engineType is EngineType.Kokoro)
+
+        // Only one male ja_JP voice (Kumo, 41) — fully deterministic.
+        val male = LanguageVoiceRouter.route("ja", kokoroAdamEnUsMale, VoiceCatalog.voices)
+        assertEquals("kokoro_kumo_ja_JP_41", male?.id)
+    }
+
+    @Test
+    fun `BCP-47 region and script suffixes are normalised before matching`() {
+        // "fr-FR" (region) and "zh-Hant" (script) must reduce to fr / zh.
+        assertEquals(
+            "kokoro_siwis_fr_FR_30",
+            LanguageVoiceRouter.route("fr-FR", kokoroHeartEnUsFemale, VoiceCatalog.voices)?.id,
+        )
+        val zh = LanguageVoiceRouter.route("zh-Hant", kokoroHeartEnUsFemale, VoiceCatalog.voices)
+        assertEquals("zh_CN", zh?.language)
+    }
+
+    @Test
+    fun `blank detection yields no switch`() {
+        assertNull(LanguageVoiceRouter.route("", kokoroHeartEnUsFemale, VoiceCatalog.voices))
+        assertNull(LanguageVoiceRouter.route("   ", kokoroHeartEnUsFemale, VoiceCatalog.voices))
+    }
+
+    @Test
+    fun `routing is deterministic — identical inputs yield the identical voice`() {
+        // Determinism is load-bearing: the PCM cache replays whatever
+        // speakers a prior render chose, so re-rendering the same text
+        // must resolve identically.
+        val a = LanguageVoiceRouter.route("ja", kokoroHeartEnUsFemale, VoiceCatalog.voices)
+        val b = LanguageVoiceRouter.route("ja", kokoroHeartEnUsFemale, VoiceCatalog.voices)
+        assertEquals(a?.id, b?.id)
+    }
+
+    @Test
+    fun `routing never crosses engine families`() {
+        // Current voice is Kokoro; the only French candidate offered is a
+        // Piper entry. Same-family policy must reject it → no switch.
+        val syntheticFrenchPiper = CatalogEntry(
+            id = "piper_fake_fr_FR_high",
+            displayName = "Fake French Piper",
+            language = "fr_FR",
+            sizeBytes = 0L,
+            qualityLevel = QualityLevel.High,
+            engineType = EngineType.Piper,
+            piper = null,
+            gender = VoiceGender.Female,
+        )
+        val catalog = listOf(kokoroHeartEnUsFemale, syntheticFrenchPiper)
+        assertNull(LanguageVoiceRouter.route("fr", kokoroHeartEnUsFemale, catalog))
+    }
+
+    @Test
+    fun `higher quality tier wins among same-gender same-language candidates`() {
+        val current = CatalogEntry(
+            id = "kokoro_cur_en_US_99",
+            displayName = "Cur",
+            language = "en_US",
+            sizeBytes = 0L,
+            qualityLevel = QualityLevel.High,
+            engineType = EngineType.Kokoro(speakerId = 99),
+            piper = null,
+            gender = VoiceGender.Female,
+        )
+        fun frVoice(id: String, sid: Int, tier: QualityLevel) = CatalogEntry(
+            id = id, displayName = id, language = "fr_FR", sizeBytes = 0L,
+            qualityLevel = tier, engineType = EngineType.Kokoro(speakerId = sid),
+            piper = null, gender = VoiceGender.Female,
+        )
+        val low = frVoice("kokoro_a_fr_FR_1", 1, QualityLevel.Low)
+        val studio = frVoice("kokoro_z_fr_FR_2", 2, QualityLevel.Studio)
+        // 'z…' sorts last by id, but Studio must beat the id tiebreak.
+        val target = LanguageVoiceRouter.route("fr", current, listOf(current, low, studio))
+        assertEquals("kokoro_z_fr_FR_2", target?.id)
+    }
+}

--- a/feature/src/main/kotlin/in/jphe/storyvox/feature/api/UiContracts.kt
+++ b/feature/src/main/kotlin/in/jphe/storyvox/feature/api/UiContracts.kt
@@ -890,6 +890,10 @@ data class UiSettings(
      * (introduced in `VoxSherpa-TTS` v2.7.4).
      */
     val voiceSteady: Boolean = true,
+    /** Issue #1233 — auto-detect each sentence's language and switch to a
+     *  matching voice. Off by default; effect is Kokoro-only (the one
+     *  in-app family with multi-language speakers). */
+    val autoLanguageDetectionEnabled: Boolean = false,
     /** Memory Palace daemon config (#79). Empty host = source disabled. */
     val palace: UiPalaceConfig = UiPalaceConfig(),
     /**
@@ -2422,6 +2426,24 @@ interface SettingsRepositoryUi {
      *  brass IconButton in the reader controls overlay. Default no-op
      *  for fakes; the DataStore impl persists. */
     suspend fun setReaderAutoScrollEnabled(enabled: Boolean) {}
+
+    /**
+     * Issue #1233 — auto-detect each sentence's language and switch to a
+     * matching TTS voice (e.g. French dialogue in an English novel reads
+     * in a French voice instead of English phonemes).
+     *
+     * Default emits `false` (off) so test fakes and the first-launch
+     * state opt out; the DataStore impl overrides with the persisted
+     * value. Only affects the Kokoro engine family (the one with
+     * multi-language speakers); every other voice stays put — see
+     * [`in`.jphe.storyvox.data.repository.playback.LanguageDetectionConfig].
+     */
+    val autoLanguageDetectionEnabled: Flow<Boolean>
+        get() = kotlinx.coroutines.flow.flowOf(false)
+
+    /** Persist the auto-detect-language toggle (#1233). Default no-op
+     *  for fakes; the DataStore impl persists. */
+    suspend fun setAutoLanguageDetectionEnabled(enabled: Boolean) {}
 
     /**
      * Issue #997 — Focused Reading mode. When true, the reader dims the

--- a/feature/src/main/kotlin/in/jphe/storyvox/feature/settings/SettingsViewModel.kt
+++ b/feature/src/main/kotlin/in/jphe/storyvox/feature/settings/SettingsViewModel.kt
@@ -179,6 +179,9 @@ class SettingsViewModel @Inject constructor(
     fun resetOnboarding() = viewModelScope.launch { repo.resetOnboardingV1() }
     /** Issue #85 — Voice-Determinism preset (Steady / Expressive). */
     fun setVoiceSteady(enabled: Boolean) = viewModelScope.launch { repo.setVoiceSteady(enabled) }
+    /** Issue #1233 — auto-detect language & switch voice (Kokoro). */
+    fun setAutoLanguageDetection(enabled: Boolean) =
+        viewModelScope.launch { repo.setAutoLanguageDetectionEnabled(enabled) }
     fun signIn() = viewModelScope.launch { repo.signIn() }
     fun signOut() = viewModelScope.launch { repo.signOut() }
     /** GitHub OAuth (#91) — local sign-out. Remote revoke deep-links to github.com. */

--- a/feature/src/main/kotlin/in/jphe/storyvox/feature/settings/VoiceAndPlaybackSettingsScreen.kt
+++ b/feature/src/main/kotlin/in/jphe/storyvox/feature/settings/VoiceAndPlaybackSettingsScreen.kt
@@ -136,6 +136,17 @@ fun VoiceAndPlaybackSettingsScreen(
                     onCheckedChange = viewModel::setPitchInterpolationHighQuality,
                 )
 
+                SettingsSwitchRow(
+                    title = stringResource(R.string.settings_voice_autolang_title),
+                    subtitle = if (s.autoLanguageDetectionEnabled) {
+                        stringResource(R.string.settings_voice_autolang_on)
+                    } else {
+                        stringResource(R.string.settings_voice_autolang_off)
+                    },
+                    checked = s.autoLanguageDetectionEnabled,
+                    onCheckedChange = viewModel::setAutoLanguageDetection,
+                )
+
                 SettingsLinkRow(
                     title = stringResource(R.string.settings_voice_pronunciation_title),
                     subtitle = stringResource(R.string.settings_voice_pronunciation_subtitle),

--- a/feature/src/main/res/values/strings.xml
+++ b/feature/src/main/res/values/strings.xml
@@ -757,6 +757,9 @@
     <string name="settings_voice_hq_pitch_title">High-quality pitch interpolation</string>
     <string name="settings_voice_hq_pitch_on">Smoother pitch-shifted audio. ~20%% extra CPU per chapter render.</string>
     <string name="settings_voice_hq_pitch_off">Faster pitch shifting. Some grittiness at non-neutral pitch.</string>
+    <string name="settings_voice_autolang_title">Auto-detect language</string>
+    <string name="settings_voice_autolang_on">Foreign passages switch to a matching voice. Kokoro voices only.</string>
+    <string name="settings_voice_autolang_off">Off — all text reads in your selected voice.</string>
     <string name="settings_voice_pronunciation_title">Pronunciation</string>
     <string name="settings_voice_pronunciation_subtitle">Teach the voice how to say specific names and words.</string>
     <string name="settings_voice_skip_distance_title">Skip distance</string>


### PR DESCRIPTION
Closes #1233.

When a book contains foreign passages — French dialogue in an English novel, a Latin quote, a Japanese light-novel chapter — the TTS engine reads them with the primary voice's phonemes, producing gibberish. This adds **opt-in, per-sentence language detection** that routes foreign passages to a matching voice.

## How it works

- **`LanguageDetector` / `TextClassifierLanguageDetector`** (core-playback) — on-device detection via Android's `TextClassifier.detectLanguage` (API 29+; a no-op `null` detector below that, which is exactly the graceful fallback). Short text and low-confidence results are rejected so single words don't mis-route.
- **`LanguageVoiceRouter`** (pure, deterministic) — maps a detected ISO-639 language to the best **same-engine-family** voice: same gender first (narration continuity), then quality tier, then a stable id tiebreak. No match → return `null` and stay on the current voice.
- **`EnginePlayer`** wires this into the **Kokoro** synth path only. Kokoro's 53 speakers share one model (en/es/fr/hi/it/ja/pt/zh), so switching to a target-language speaker is a reload-free `setActiveSpeakerId`, executed inside the producer's `engineMutex` lock. Piper / Kitten / Azure / System-TTS have no foreign siblings in the catalog, so the router returns `null` and they never switch.
- **`LanguageDetectionConfig`** (core-data) + a **Settings → Voice & Playback** toggle, "Auto-detect language".

## Correctness & safety

- **Off by default.** The plain synth path and the PCM cache are byte-identical to before until a listener opts in.
- **Cache-correct.** Routed renders namespace their cache `voiceId` with `+autolang`, so the mixed-voice audio never collides with a plain single-voice render — and no pre-existing cache entry self-evicts on upgrade (no `PcmCacheKey` field added). The sample-rate probe key is kept in lockstep.
- **No concurrency hazard.** Parallel-synth is forced serial when routing is active — the secondary Kokoro instances are pinned to the primary speaker at load and can't honor a per-sentence swap. The speaker mutation happens only on the serial producer under `engineMutex`. Detection is deterministic, so cache replay is sound.

## Tests

Pure JVM (no Robolectric, per project convention):
- **`LanguageVoiceRouterTest`** — routing against the real `VoiceCatalog`: fr→Siwis, es gender continuity (Dora/Alex), ja (female set + the lone male Kumo), `en` no-op, Piper→no-French fallback, BCP-47 region/script normalization (`fr-FR`, `zh-Hant`), family isolation, quality-tier ordering, and determinism.
- **`LanguageDetectorDecisionTest`** — threshold + normalization logic (`decideDetection`, `baseLanguage`): short-text reject, low-confidence reject, blank-tag reject, inclusive boundaries, suffix stripping.

## Scope notes (deliberate non-goals, follow-ups)

- **Kokoro-only effect this PR.** It's the only in-app family with multi-language voices. Other families fall back gracefully. A future PR could route Piper across its 20+ language models, but that means a cross-voice model download, so it's a separate UX decision.
- **No phonemizer-lang path.** Issue #1233 mentions Kokoro's `phonemizerLang` (#198), but that field is read at model-construction time, not per-sentence, so it can't drive per-sentence pronunciation without a reload. Per-sentence *speaker* routing is the reload-free mechanism and gives a true target-language voice, which is higher quality than re-phonemizing the primary voice.
- **No pre-caching of the secondary-language voice** (an issue "consideration") — unnecessary here since Kokoro's shared model is already resident; speaker swaps are free.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
