### PR TITLE
feat(reader): tap-to-define dictionary via Wiktionary (#1230)

### DIFF
--- a/app/src/main/kotlin/in/jphe/storyvox/data/WiktionaryDictionaryRepository.kt
+++ b/app/src/main/kotlin/in/jphe/storyvox/data/WiktionaryDictionaryRepository.kt
@@ -1,0 +1,97 @@
+package `in`.jphe.storyvox.data
+
+import `in`.jphe.storyvox.data.dictionary.DictionaryRepository
+import `in`.jphe.storyvox.data.dictionary.DictionaryResult
+import `in`.jphe.storyvox.data.dictionary.WordDefinition
+import `in`.jphe.storyvox.data.dictionary.lemmaCandidates
+import `in`.jphe.storyvox.data.dictionary.normalizeLookupWord
+import `in`.jphe.storyvox.data.dictionary.parseWiktionaryDefinitions
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+import okhttp3.HttpUrl
+import okhttp3.OkHttpClient
+import okhttp3.Request
+import java.io.IOException
+
+/**
+ * Issue #1230 — [DictionaryRepository] over the free Wiktionary REST API.
+ *
+ * Endpoint: `GET https://en.wiktionary.org/api/rest_v1/page/definition/{word}`
+ * (no API key). Wiktionary is a Wikimedia property, so the request **must**
+ * carry the descriptive User-Agent Wikimedia's policy requires — that's why
+ * this lives in `:app` (the only module with `BuildConfig.VERSION_NAME`) and is
+ * constructed with the shared `@UserAgentHeader` interceptor; an anonymous
+ * client 403s. See `UserAgent` / `AppBindings.provideUserAgentInterceptor`.
+ *
+ * Parsing + word-normalisation are the pure, unit-tested helpers in
+ * `:core-data`; this class is the thin IO seam over them. It never throws —
+ * every failure maps to [DictionaryResult.Error] so the reader can render a
+ * Retry row.
+ *
+ * Case fallback: Wiktionary titles are case-sensitive, so a sentence-initial
+ * "The" must be retried as "the". [lemmaCandidates] enumerates the variants and
+ * we try each until one resolves, capping at the (≤3) distinct forms so a
+ * genuinely-unknown word costs at most a few quick 404s.
+ */
+class WiktionaryDictionaryRepository(
+    private val client: OkHttpClient,
+) : DictionaryRepository {
+
+    override suspend fun define(word: String): DictionaryResult = withContext(Dispatchers.IO) {
+        val lemma = normalizeLookupWord(word)
+            ?: return@withContext DictionaryResult.NotFound(word.trim())
+
+        var lastError: String? = null
+        for (candidate in lemmaCandidates(lemma)) {
+            when (val result = fetch(candidate)) {
+                is DictionaryResult.Success -> return@withContext result
+                is DictionaryResult.NotFound -> Unit // try the next case variant
+                is DictionaryResult.Error -> lastError = result.message
+            }
+        }
+        // Every candidate 404'd, or the last attempt errored. Prefer surfacing a
+        // real network error (Retry-able) over a misleading "no definition".
+        lastError?.let { DictionaryResult.Error(lemma, it) } ?: DictionaryResult.NotFound(lemma)
+    }
+
+    private fun fetch(lemma: String): DictionaryResult {
+        val url = HttpUrl.Builder()
+            .scheme("https")
+            .host(WIKTIONARY_HOST)
+            .addPathSegments("api/rest_v1/page/definition")
+            .addPathSegment(lemma) // okhttp percent-encodes the single path segment
+            .build()
+        val request = Request.Builder()
+            .url(url)
+            .header("Accept", "application/json")
+            .get()
+            .build()
+        return try {
+            client.newCall(request).execute().use { response ->
+                when {
+                    response.code == 404 -> DictionaryResult.NotFound(lemma)
+                    !response.isSuccessful -> DictionaryResult.Error(lemma, "HTTP ${response.code}")
+                    else -> {
+                        val entries = parseWiktionaryDefinitions(
+                            body = response.body?.string().orEmpty(),
+                            languageCode = "en",
+                        )
+                        if (entries.isEmpty()) {
+                            DictionaryResult.NotFound(lemma)
+                        } else {
+                            DictionaryResult.Success(
+                                WordDefinition(word = lemma, pronunciation = null, entries = entries),
+                            )
+                        }
+                    }
+                }
+            }
+        } catch (e: IOException) {
+            DictionaryResult.Error(lemma, e.message ?: "Network error")
+        }
+    }
+
+    private companion object {
+        const val WIKTIONARY_HOST = "en.wiktionary.org"
+    }
+}

--- a/app/src/main/kotlin/in/jphe/storyvox/di/AppBindings.kt
+++ b/app/src/main/kotlin/in/jphe/storyvox/di/AppBindings.kt
@@ -77,6 +77,9 @@ import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.launch
 import okhttp3.Interceptor
+import okhttp3.OkHttpClient
+import `in`.jphe.storyvox.data.WiktionaryDictionaryRepository
+import `in`.jphe.storyvox.data.dictionary.DictionaryRepository
 
 /**
  * Hilt bindings that bridge `feature.api.*` UI contracts to the concrete
@@ -530,6 +533,27 @@ object AppBindings {
             chain.proceed(withUserAgent)
         }
     }
+
+    /**
+     * Issue #1230 — tap-to-define dictionary backend. A dedicated OkHttpClient
+     * with tight timeouts (a reader interrupting their book wants a fast answer
+     * or a fast failure) carrying the [UserAgentHeader] interceptor Wikimedia's
+     * policy requires — an anonymous client to a Wikimedia REST endpoint 403s.
+     * Bound here in `:app` (not `:core-data`, which stays OkHttp-free) because
+     * the UA interceptor needs `BuildConfig.VERSION_NAME`; the parsing it feeds
+     * is the pure, unit-tested helper in `:core-data`.
+     */
+    @Provides @Singleton
+    fun provideDictionaryRepository(
+        @UserAgentHeader userAgent: Interceptor,
+    ): DictionaryRepository = WiktionaryDictionaryRepository(
+        OkHttpClient.Builder()
+            .addInterceptor(userAgent)
+            .connectTimeout(10, java.util.concurrent.TimeUnit.SECONDS)
+            .readTimeout(15, java.util.concurrent.TimeUnit.SECONDS)
+            .retryOnConnectionFailure(true)
+            .build(),
+    )
 
     /**
      * Stub WebViewFetcher — Selene's `:core-data` declares the interface; the

--- a/core-data/src/main/kotlin/in/jphe/storyvox/data/dictionary/DictionaryModels.kt
+++ b/core-data/src/main/kotlin/in/jphe/storyvox/data/dictionary/DictionaryModels.kt
@@ -1,0 +1,89 @@
+package `in`.jphe.storyvox.data.dictionary
+
+/**
+ * Issue #1230 — tap-to-define dictionary in the reader. The model layer the
+ * reader's long-press popup renders, and the contract its repository fulfils.
+ *
+ * The shapes are deliberately source-agnostic: today the only implementation
+ * is [DictionaryRepository] over the Wiktionary REST API, but a [WordDefinition]
+ * carries nothing Wiktionary-specific, so an offline cache or an alternate
+ * dictionary backend can satisfy the same contract without touching the UI.
+ *
+ * Pure Kotlin (no Android, no OkHttp) so the parser + normaliser that produce
+ * these can be unit-tested under the project's JUnit-only / no-Robolectric
+ * harness — the okhttp-backed implementation lives in `:app` (the only module
+ * that carries the descriptive User-Agent Wikimedia's policy requires).
+ */
+
+/**
+ * One part-of-speech grouping for a word — e.g. *Noun* with its senses, then
+ * *Verb* with its senses. Mirrors a single Wiktionary REST definition group.
+ *
+ * @property partOfSpeech display label ("Noun", "Verb", "Adjective", …). May be
+ *   blank when the source omits it; the UI then renders the senses without a
+ *   heading rather than an empty chip.
+ * @property senses human-readable definition glosses, in source order, already
+ *   stripped of the inline HTML the REST API embeds. Never empty — a group with
+ *   no usable glosses is dropped by the parser rather than represented here.
+ */
+data class DictionaryEntry(
+    val partOfSpeech: String,
+    val senses: List<String>,
+)
+
+/**
+ * A resolved dictionary entry for a single [word].
+ *
+ * @property word the lemma actually looked up (post-normalisation), so the UI
+ *   shows the headword it found rather than the raw glyphs under the finger.
+ * @property pronunciation IPA / respelling when the source provides it. The
+ *   Wiktionary REST *definition* endpoint generally omits pronunciation, so this
+ *   is usually null; the sheet shows the row only when it's present.
+ * @property entries one [DictionaryEntry] per part of speech. Never empty — an
+ *   empty result is surfaced as [DictionaryResult.NotFound], not a hollow
+ *   [WordDefinition].
+ */
+data class WordDefinition(
+    val word: String,
+    val pronunciation: String?,
+    val entries: List<DictionaryEntry>,
+)
+
+/**
+ * The outcome of a [DictionaryRepository.define] call. Modelled as a sealed
+ * result rather than a nullable + thrown exception so the reader can render a
+ * distinct surface for each case — a real definition, a clean "no entry"
+ * (offer the system-dictionary / Ask-AI fallbacks), or a transient network
+ * error (offer Retry) — without try/catch in the UI layer.
+ */
+sealed interface DictionaryResult {
+    /** A definition was found. */
+    data class Success(val definition: WordDefinition) : DictionaryResult
+
+    /** The lookup succeeded but the word has no entry (HTTP 404 or an empty
+     *  body). [word] is the normalised lemma that was searched. */
+    data class NotFound(val word: String) : DictionaryResult
+
+    /** The lookup failed (no network, server error, malformed body). [message]
+     *  is a short human-readable reason for the reader's error row. */
+    data class Error(val word: String, val message: String) : DictionaryResult
+}
+
+/**
+ * Looks up a word's definition. Implementations do the network / cache work on
+ * an IO dispatcher; callers (the reader ViewModel) invoke from a coroutine and
+ * map the [DictionaryResult] onto UI state.
+ *
+ * The interface lives in `:core-data` so the ViewModel can depend on it without
+ * pulling OkHttp into the feature graph; the concrete Wiktionary implementation
+ * is bound in `:app`.
+ */
+interface DictionaryRepository {
+    /**
+     * Resolve [word] (a raw token straight from the reader's word-boundary
+     * gesture — normalisation is the implementation's job via
+     * [normalizeLookupWord]). Never throws; failures come back as
+     * [DictionaryResult.Error].
+     */
+    suspend fun define(word: String): DictionaryResult
+}

--- a/core-data/src/main/kotlin/in/jphe/storyvox/data/dictionary/LookupWord.kt
+++ b/core-data/src/main/kotlin/in/jphe/storyvox/data/dictionary/LookupWord.kt
@@ -1,0 +1,82 @@
+package `in`.jphe.storyvox.data.dictionary
+
+/**
+ * Issue #1230 — turn the raw token under a reader long-press into a clean
+ * dictionary lemma, and enumerate the case variants worth querying.
+ *
+ * The reader resolves the pressed glyph to a word via
+ * `TextLayoutResult.getWordBoundary`, which is generous: it can hand back the
+ * word with an attached quote, a trailing comma/period, a possessive `'s`, or
+ * (sentence-initial) a leading capital. Wiktionary page titles, by contrast,
+ * are exact — `dog`, not `"Dog,`. This file does the squaring-up, and is pure
+ * so it unit-tests without a Compose/Android runtime (the same split the rest
+ * of the reader's logic — `normalizeSelection`, `findMatches` — already uses).
+ */
+
+/**
+ * Edge punctuation, quotes and stray digits the word-boundary gesture can drag
+ * in. Kept to the *edges*: an internal hyphen (`mother-in-law`) or apostrophe
+ * (`don't`) is part of the headword and must survive.
+ */
+private val EDGE_TRASH = Regex("""^[^\p{L}]+|[^\p{L}]+$""")
+
+/** A trailing English possessive — `dog's` / `dogs'` → `dog` / `dogs`. Wiktionary
+ *  lemmatises the base form, so the possessive clitic is stripped before lookup.
+ *  Both the straight and typographic apostrophe are handled. */
+private val TRAILING_POSSESSIVE = Regex("""['’]s?$""")
+
+/**
+ * Normalise [raw] into a dictionary lemma, or null when there's nothing
+ * look-up-able left (empty, all-punctuation, or a bare number).
+ *
+ * Steps, in order:
+ *  1. trim surrounding whitespace,
+ *  2. strip leading/trailing non-letters (quotes, commas, ellipses, digits),
+ *  3. strip a trailing possessive clitic (`'s` / `'`),
+ *  4. re-strip any edge punctuation the clitic removal exposed,
+ *  5. reject the result if it now contains no letter at all.
+ *
+ * Case is **preserved** — `Serendipity` stays capitalised here so a genuine
+ * proper noun keeps its form; [lemmaCandidates] handles the de-capitalisation
+ * fallback for ordinary sentence-initial words.
+ */
+fun normalizeLookupWord(raw: String): String? {
+    if (raw.isBlank()) return null
+    var word = raw.trim()
+    word = EDGE_TRASH.replace(word, "")
+    word = TRAILING_POSSESSIVE.replace(word, "")
+    word = EDGE_TRASH.replace(word, "")
+    if (word.isEmpty()) return null
+    if (word.none { it.isLetter() }) return null
+    return word
+}
+
+/**
+ * The lemma forms to try, in priority order, for a [word] already run through
+ * [normalizeLookupWord]. Wiktionary entry titles are case-sensitive: common
+ * words are lower-case (`the`, `serendipity`) while proper nouns keep their
+ * capital (`London`). A word lifted from mid-sentence is usually already in its
+ * dictionary case; a sentence-initial word is capitalised only by position.
+ *
+ * So we query the word as-seen first (correct for proper nouns and mid-sentence
+ * words), then — only if it differs — a de-capitalised variant that lower-cases
+ * just the first letter (`The` → `the`, `Serendipity` → `serendipity`). An
+ * all-caps acronym additionally gets a fully lower-cased try. Duplicates are
+ * removed so the implementation never makes a redundant request.
+ *
+ * Returns an empty list for a blank input (the caller should have rejected it
+ * via [normalizeLookupWord] first).
+ */
+fun lemmaCandidates(word: String): List<String> {
+    if (word.isEmpty()) return emptyList()
+    val candidates = LinkedHashSet<String>()
+    candidates += word
+    // De-capitalise the first letter only (the common sentence-initial case).
+    if (word.first().isUpperCase()) {
+        candidates += word.replaceFirstChar { it.lowercaseChar() }
+    }
+    // A SHOUTED or Mixed-case token: a fully lower-cased form is worth a try.
+    val lower = word.lowercase()
+    candidates += lower
+    return candidates.toList()
+}

--- a/core-data/src/main/kotlin/in/jphe/storyvox/data/dictionary/WiktionaryParser.kt
+++ b/core-data/src/main/kotlin/in/jphe/storyvox/data/dictionary/WiktionaryParser.kt
@@ -1,0 +1,123 @@
+package `in`.jphe.storyvox.data.dictionary
+
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonArray
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.JsonPrimitive
+import kotlinx.serialization.json.contentOrNull
+
+/**
+ * Issue #1230 — parse a Wiktionary REST `page/definition/{word}` response body
+ * into the reader's [DictionaryEntry] list.
+ *
+ * ## Response shape
+ * The endpoint returns a JSON object keyed by language code, each value an
+ * array of part-of-speech groups:
+ * ```json
+ * { "en": [
+ *     { "partOfSpeech": "Noun", "language": "English",
+ *       "definitions": [ { "definition": "The <a href=\"…\">phenomenon</a> of …" } ] }
+ * ] }
+ * ```
+ * The `definition` strings carry inline MediaWiki HTML (`<a>` links, `<i>`
+ * emphasis, `&amp;` entities); [stripDefinitionHtml] reduces each to plain
+ * prose for the bottom sheet.
+ *
+ * Pure + defensive: a malformed body, a missing language, or a group with no
+ * usable glosses yields an empty list (the repository maps that to
+ * [DictionaryResult.NotFound]) rather than throwing.
+ */
+
+private val json = Json {
+    ignoreUnknownKeys = true
+    isLenient = true
+}
+
+/** Cap senses per part of speech — Wiktionary can list a dozen rare/obsolete
+ *  senses; the first few are what a reader interrupting their book wants. */
+const val MAX_SENSES_PER_POS: Int = 6
+
+/**
+ * Parse [body] into definition groups for [languageCode] (default English).
+ *
+ * Falls back to the first language present when the requested code is absent,
+ * so a word that only has, say, a Latin entry still returns something rather
+ * than nothing. Senses are capped at [MAX_SENSES_PER_POS] per group; blank
+ * glosses (groups that are pure usage examples) are dropped, and a group left
+ * with no senses is omitted entirely.
+ */
+fun parseWiktionaryDefinitions(
+    body: String,
+    languageCode: String = "en",
+): List<DictionaryEntry> {
+    val root = runCatching { json.parseToJsonElement(body) }.getOrNull() as? JsonObject
+        ?: return emptyList()
+
+    val groups = (root[languageCode] as? JsonArray)
+        ?: root.values.firstOrNull { it is JsonArray } as? JsonArray
+        ?: return emptyList()
+
+    return groups.mapNotNull { element ->
+        val group = element as? JsonObject ?: return@mapNotNull null
+        val partOfSpeech = (group["partOfSpeech"] as? JsonPrimitive)?.contentOrNull?.trim().orEmpty()
+        val definitions = group["definitions"] as? JsonArray ?: return@mapNotNull null
+
+        val senses = definitions.asSequence()
+            .mapNotNull { (it as? JsonObject)?.get("definition") as? JsonPrimitive }
+            .map { stripDefinitionHtml(it.content) }
+            .filter { it.isNotBlank() }
+            .take(MAX_SENSES_PER_POS)
+            .toList()
+
+        if (senses.isEmpty()) null else DictionaryEntry(partOfSpeech, senses)
+    }
+}
+
+private val HTML_TAG = Regex("<[^>]*>")
+private val WHITESPACE = Regex("\\s+")
+private val NUMERIC_ENTITY = Regex("&#(x?)([0-9a-fA-F]+);")
+
+/**
+ * Reduce a Wiktionary definition's inline HTML to plain reading text: drop
+ * tags, decode the entities that survive (`&amp;`, `&quot;`, numeric refs),
+ * collapse whitespace, trim. Pure Kotlin — no `android.text.Html` — so it runs
+ * under the JVM unit-test harness. Mirrors the cleaner in `chapterPreviewText`;
+ * kept local so the dictionary parser carries no cross-feature coupling.
+ */
+internal fun stripDefinitionHtml(raw: String): String {
+    val noTags = HTML_TAG.replace(raw, " ")
+    val decoded = decodeEntities(noTags)
+    return WHITESPACE.replace(decoded, " ").trim()
+}
+
+private fun decodeEntities(s: String): String {
+    if ('&' !in s) return s
+    var out = s
+    NAMED_ENTITIES.forEach { (entity, replacement) -> out = out.replace(entity, replacement) }
+    out = NUMERIC_ENTITY.replace(out) { m ->
+        val isHex = m.groupValues[1] == "x"
+        val code = m.groupValues[2].toIntOrNull(if (isHex) 16 else 10)
+        if (code != null && code in 1..0x10FFFF) {
+            runCatching { String(Character.toChars(code)) }.getOrDefault(m.value)
+        } else {
+            m.value
+        }
+    }
+    return out
+}
+
+private val NAMED_ENTITIES = listOf(
+    "&nbsp;" to " ",
+    "&amp;" to "&",
+    "&lt;" to "<",
+    "&gt;" to ">",
+    "&quot;" to "\"",
+    "&apos;" to "'",
+    "&hellip;" to "…",
+    "&mdash;" to "—",
+    "&ndash;" to "–",
+    "&rsquo;" to "’",
+    "&lsquo;" to "‘",
+    "&rdquo;" to "”",
+    "&ldquo;" to "“",
+)

--- a/core-data/src/test/kotlin/in/jphe/storyvox/data/dictionary/LookupWordTest.kt
+++ b/core-data/src/test/kotlin/in/jphe/storyvox/data/dictionary/LookupWordTest.kt
@@ -1,0 +1,87 @@
+package `in`.jphe.storyvox.data.dictionary
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Test
+
+/**
+ * Issue #1230 — word-extraction unit coverage. The reader hands
+ * [normalizeLookupWord] whatever `getWordBoundary` grabbed under the finger;
+ * these pin the squaring-up to a clean Wiktionary lemma, and [lemmaCandidates]
+ * to the minimal set of case variants worth querying.
+ */
+class LookupWordTest {
+
+    @Test
+    fun `plain lowercase word is returned unchanged`() {
+        assertEquals("serendipity", normalizeLookupWord("serendipity"))
+    }
+
+    @Test
+    fun `surrounding whitespace is trimmed`() {
+        assertEquals("phlegmatic", normalizeLookupWord("  phlegmatic\n"))
+    }
+
+    @Test
+    fun `leading and trailing punctuation is stripped`() {
+        assertEquals("Gatsby", normalizeLookupWord("“Gatsby,”"))
+        assertEquals("end", normalizeLookupWord("end."))
+        assertEquals("wait", normalizeLookupWord("(wait)"))
+        assertEquals("really", normalizeLookupWord("really…"))
+    }
+
+    @Test
+    fun `trailing possessive is removed`() {
+        assertEquals("dog", normalizeLookupWord("dog's"))
+        assertEquals("dog", normalizeLookupWord("dog’s"))
+        assertEquals("dogs", normalizeLookupWord("dogs'"))
+    }
+
+    @Test
+    fun `internal hyphen and apostrophe survive`() {
+        assertEquals("mother-in-law", normalizeLookupWord("mother-in-law"))
+        assertEquals("don't", normalizeLookupWord("don't"))
+    }
+
+    @Test
+    fun `case is preserved for proper nouns`() {
+        assertEquals("London", normalizeLookupWord("London"))
+    }
+
+    @Test
+    fun `tokens with no letters are rejected`() {
+        assertNull(normalizeLookupWord(""))
+        assertNull(normalizeLookupWord("   "))
+        assertNull(normalizeLookupWord("1234"))
+        assertNull(normalizeLookupWord("--—--"))
+        assertNull(normalizeLookupWord("?!?"))
+    }
+
+    @Test
+    fun `lowercase word yields a single candidate`() {
+        assertEquals(listOf("serendipity"), lemmaCandidates("serendipity"))
+    }
+
+    @Test
+    fun `sentence-initial capital adds a decapitalised candidate`() {
+        assertEquals(listOf("The", "the"), lemmaCandidates("The"))
+    }
+
+    @Test
+    fun `all-caps acronym adds a fully lowercased candidate`() {
+        // "NASA" -> as-seen, then first-letter-lower ("nASA"), then full lower ("nasa").
+        assertEquals(listOf("NASA", "nASA", "nasa"), lemmaCandidates("NASA"))
+    }
+
+    @Test
+    fun `candidate list never repeats a variant`() {
+        // A capitalised word whose decapitalised form equals its lowercase form
+        // must not list "serendipity" twice.
+        assertEquals(listOf("Serendipity", "serendipity"), lemmaCandidates("Serendipity"))
+    }
+
+    @Test
+    fun `blank input yields no candidates`() {
+        assertEquals(emptyList<String>(), lemmaCandidates(""))
+    }
+}

--- a/core-data/src/test/kotlin/in/jphe/storyvox/data/dictionary/WiktionaryParserTest.kt
+++ b/core-data/src/test/kotlin/in/jphe/storyvox/data/dictionary/WiktionaryParserTest.kt
@@ -1,0 +1,123 @@
+package `in`.jphe.storyvox.data.dictionary
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * Issue #1230 — Wiktionary REST parsing unit coverage. Fixtures mirror the
+ * real `en.wiktionary.org/api/rest_v1/page/definition/{word}` shape (object
+ * keyed by language → array of part-of-speech groups → `definitions[].definition`
+ * carrying inline MediaWiki HTML). Hermetic: no network.
+ */
+class WiktionaryParserTest {
+
+    @Test
+    fun `parses multiple parts of speech with HTML stripped`() {
+        val body = """
+            {
+              "en": [
+                {
+                  "partOfSpeech": "Noun",
+                  "language": "English",
+                  "definitions": [
+                    { "definition": "The <a rel=\"mw:WikiLink\" href=\"/wiki/phenomenon\">phenomenon</a> of finding pleasant things by chance." },
+                    { "definition": "An instance of such an occurrence." }
+                  ]
+                },
+                {
+                  "partOfSpeech": "Verb",
+                  "language": "English",
+                  "definitions": [
+                    { "definition": "To <i>move</i> swiftly &amp; lightly." }
+                  ]
+                }
+              ]
+            }
+        """.trimIndent()
+
+        val entries = parseWiktionaryDefinitions(body)
+
+        assertEquals(2, entries.size)
+        assertEquals("Noun", entries[0].partOfSpeech)
+        assertEquals(
+            listOf(
+                "The phenomenon of finding pleasant things by chance.",
+                "An instance of such an occurrence.",
+            ),
+            entries[0].senses,
+        )
+        assertEquals("Verb", entries[1].partOfSpeech)
+        assertEquals(listOf("To move swiftly & lightly."), entries[1].senses)
+    }
+
+    @Test
+    fun `drops groups whose definitions are all blank after stripping`() {
+        val body = """
+            {
+              "en": [
+                { "partOfSpeech": "Noun", "definitions": [ { "definition": "<span></span>" }, { "definition": "   " } ] },
+                { "partOfSpeech": "Verb", "definitions": [ { "definition": "To do a thing." } ] }
+              ]
+            }
+        """.trimIndent()
+
+        val entries = parseWiktionaryDefinitions(body)
+
+        assertEquals(1, entries.size)
+        assertEquals("Verb", entries[0].partOfSpeech)
+    }
+
+    @Test
+    fun `caps senses per part of speech`() {
+        val defs = (1..20).joinToString(",") { """{ "definition": "Sense $it." }""" }
+        val body = """{ "en": [ { "partOfSpeech": "Noun", "definitions": [ $defs ] } ] }"""
+
+        val entries = parseWiktionaryDefinitions(body)
+
+        assertEquals(MAX_SENSES_PER_POS, entries[0].senses.size)
+        assertEquals("Sense 1.", entries[0].senses.first())
+    }
+
+    @Test
+    fun `falls back to the first language when requested code is absent`() {
+        val body = """
+            { "la": [ { "partOfSpeech": "Noun", "definitions": [ { "definition": "A Latin word." } ] } ] }
+        """.trimIndent()
+
+        val entries = parseWiktionaryDefinitions(body, languageCode = "en")
+
+        assertEquals(1, entries.size)
+        assertEquals(listOf("A Latin word."), entries[0].senses)
+    }
+
+    @Test
+    fun `tolerates a missing part of speech label`() {
+        val body = """{ "en": [ { "definitions": [ { "definition": "No POS here." } ] } ] }"""
+
+        val entries = parseWiktionaryDefinitions(body)
+
+        assertEquals(1, entries.size)
+        assertEquals("", entries[0].partOfSpeech)
+        assertEquals(listOf("No POS here."), entries[0].senses)
+    }
+
+    @Test
+    fun `malformed or empty bodies yield an empty list`() {
+        assertTrue(parseWiktionaryDefinitions("").isEmpty())
+        assertTrue(parseWiktionaryDefinitions("not json at all").isEmpty())
+        assertTrue(parseWiktionaryDefinitions("{}").isEmpty())
+        assertTrue(parseWiktionaryDefinitions("[]").isEmpty())
+        assertTrue(parseWiktionaryDefinitions("""{ "en": [] }""").isEmpty())
+    }
+
+    @Test
+    fun `stripDefinitionHtml decodes entities and collapses whitespace`() {
+        assertEquals(
+            "A & B \"quoted\" — done",
+            stripDefinitionHtml("A &amp; B &quot;quoted&quot; &mdash;   done"),
+        )
+        assertEquals("plain text", stripDefinitionHtml("<b>plain</b>\n<i>text</i>"))
+        assertEquals("café", stripDefinitionHtml("caf&#233;"))
+    }
+}

--- a/feature/src/main/kotlin/in/jphe/storyvox/feature/reader/DefineWordSheet.kt
+++ b/feature/src/main/kotlin/in/jphe/storyvox/feature/reader/DefineWordSheet.kt
@@ -1,0 +1,278 @@
+package `in`.jphe.storyvox.feature.reader
+
+import android.app.SearchManager
+import android.content.ActivityNotFoundException
+import android.content.Context
+import android.content.Intent
+import android.widget.Toast
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.FlowRow
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.outlined.AutoStories
+import androidx.compose.material.icons.outlined.AutoAwesome
+import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.HorizontalDivider
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.ModalBottomSheet
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.material3.rememberModalBottomSheetState
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.font.FontStyle
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import `in`.jphe.storyvox.data.dictionary.DictionaryEntry
+import `in`.jphe.storyvox.feature.R
+import `in`.jphe.storyvox.ui.theme.LocalSpacing
+
+/**
+ * Issue #1230 — the reader's tap-to-define popup. Long-pressing a word in
+ * [ReaderTextView] runs a lookup through [ReaderViewModel.defineWord]; this
+ * brass-tinted [ModalBottomSheet] renders the resulting [DictionaryUiState].
+ *
+ * Every non-[DictionaryUiState.Hidden] state still surfaces two fallbacks so a
+ * lookup is never a dead end:
+ *  - **Open in dictionary app** — Android's [Intent.ACTION_DEFINE] (the offline
+ *    path the issue calls for), with an [Intent.ACTION_WEB_SEARCH] backstop and
+ *    a toast if the device has neither.
+ *  - **Ask AI** — hands a prebuilt "what does X mean?" question to [onAskAi],
+ *    which the reader routes to the chat surface (preserving the older #188
+ *    character-lookup affordance this sheet supersedes).
+ *
+ * The sheet is presentational: all lookup state is hoisted to the ViewModel, so
+ * a config change re-renders from the collected [DictionaryUiState] rather than
+ * re-fetching.
+ */
+@Composable
+fun DefineWordSheet(
+    state: DictionaryUiState,
+    onDismiss: () -> Unit,
+    /** Invoked with a prebuilt, localized "what does X mean?" question to seed
+     *  the chat surface. */
+    onAskAi: (question: String) -> Unit,
+    onRetry: (word: String) -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    if (state is DictionaryUiState.Hidden) return
+    val spacing = LocalSpacing.current
+    val context = LocalContext.current
+    val sheetState = rememberModalBottomSheetState(skipPartiallyExpanded = true)
+
+    val word = when (state) {
+        is DictionaryUiState.Hidden -> return
+        is DictionaryUiState.Loading -> state.word
+        is DictionaryUiState.Loaded -> state.definition.word
+        is DictionaryUiState.Empty -> state.word
+        is DictionaryUiState.Error -> state.word
+    }
+    val askAiQuestion = stringResource(R.string.reader_define_ask_ai_question, word)
+
+    ModalBottomSheet(
+        onDismissRequest = onDismiss,
+        sheetState = sheetState,
+        containerColor = MaterialTheme.colorScheme.surfaceContainerHigh,
+        modifier = modifier,
+    ) {
+        Column(
+            modifier = Modifier
+                .fillMaxWidth()
+                .verticalScroll(rememberScrollState())
+                .padding(horizontal = spacing.lg)
+                .padding(bottom = spacing.xl),
+        ) {
+            // Headword + the open-book sigil. The word is the title; the
+            // pronunciation (when the source carries it) sits just beneath.
+            Row(verticalAlignment = Alignment.CenterVertically) {
+                Icon(
+                    imageVector = Icons.Outlined.AutoStories,
+                    contentDescription = null,
+                    tint = MaterialTheme.colorScheme.primary,
+                    modifier = Modifier.size(28.dp),
+                )
+                Spacer(Modifier.size(spacing.sm))
+                Text(
+                    text = word,
+                    style = MaterialTheme.typography.headlineSmall,
+                    fontWeight = FontWeight.SemiBold,
+                    color = MaterialTheme.colorScheme.primary,
+                )
+            }
+            (state as? DictionaryUiState.Loaded)?.definition?.pronunciation?.let { ipa ->
+                Text(
+                    text = ipa,
+                    style = MaterialTheme.typography.bodyMedium,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    modifier = Modifier.padding(start = 36.dp, top = spacing.xxs),
+                )
+            }
+
+            Spacer(Modifier.height(spacing.md))
+
+            when (state) {
+                is DictionaryUiState.Hidden -> Unit
+                is DictionaryUiState.Loading -> LoadingRow(word)
+                is DictionaryUiState.Loaded -> DefinitionBody(state.definition.entries)
+                is DictionaryUiState.Empty -> Text(
+                    text = stringResource(R.string.reader_define_empty, word),
+                    style = MaterialTheme.typography.bodyLarge,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                )
+                is DictionaryUiState.Error -> ErrorBody(
+                    message = state.message,
+                    onRetry = { onRetry(word) },
+                )
+            }
+
+            Spacer(Modifier.height(spacing.md))
+            HorizontalDivider(color = MaterialTheme.colorScheme.outlineVariant)
+            Spacer(Modifier.height(spacing.sm))
+
+            // Fallback actions — always present, so a missing entry or a dropped
+            // network still leaves the listener a way to look the word up.
+            FlowRow(horizontalArrangement = Arrangement.spacedBy(spacing.xs)) {
+                TextButton(onClick = { launchWordLookup(context, word) }) {
+                    Icon(
+                        imageVector = Icons.Outlined.AutoStories,
+                        contentDescription = null,
+                        modifier = Modifier.size(18.dp),
+                    )
+                    Spacer(Modifier.size(spacing.xs))
+                    Text(stringResource(R.string.reader_define_system_dict))
+                }
+                TextButton(onClick = { onAskAi(askAiQuestion) }) {
+                    Icon(
+                        imageVector = Icons.Outlined.AutoAwesome,
+                        contentDescription = null,
+                        modifier = Modifier.size(18.dp),
+                    )
+                    Spacer(Modifier.size(spacing.xs))
+                    Text(stringResource(R.string.reader_ask_ai))
+                }
+            }
+
+            // Attribution only when we actually showed Wiktionary content.
+            if (state is DictionaryUiState.Loaded) {
+                Spacer(Modifier.height(spacing.sm))
+                Text(
+                    text = stringResource(R.string.reader_define_attribution),
+                    style = MaterialTheme.typography.labelSmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                )
+            }
+        }
+    }
+}
+
+@Composable
+private fun LoadingRow(word: String) {
+    val spacing = LocalSpacing.current
+    Row(verticalAlignment = Alignment.CenterVertically) {
+        CircularProgressIndicator(
+            modifier = Modifier.size(20.dp),
+            strokeWidth = 2.dp,
+        )
+        Spacer(Modifier.size(spacing.sm))
+        Text(
+            text = stringResource(R.string.reader_define_loading, word),
+            style = MaterialTheme.typography.bodyLarge,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+        )
+    }
+}
+
+@Composable
+private fun DefinitionBody(entries: List<DictionaryEntry>) {
+    val spacing = LocalSpacing.current
+    Column(verticalArrangement = Arrangement.spacedBy(spacing.md)) {
+        entries.forEach { entry ->
+            Column(verticalArrangement = Arrangement.spacedBy(spacing.xxs)) {
+                if (entry.partOfSpeech.isNotBlank()) {
+                    Text(
+                        text = entry.partOfSpeech,
+                        style = MaterialTheme.typography.labelLarge,
+                        fontStyle = FontStyle.Italic,
+                        color = MaterialTheme.colorScheme.primary,
+                    )
+                }
+                entry.senses.forEachIndexed { index, sense ->
+                    Row {
+                        Text(
+                            text = "${index + 1}.",
+                            style = MaterialTheme.typography.bodyMedium,
+                            color = MaterialTheme.colorScheme.onSurfaceVariant,
+                            modifier = Modifier.width(22.dp),
+                        )
+                        Text(
+                            text = sense,
+                            style = MaterialTheme.typography.bodyMedium,
+                        )
+                    }
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun ErrorBody(message: String, onRetry: () -> Unit) {
+    val spacing = LocalSpacing.current
+    Column(verticalArrangement = Arrangement.spacedBy(spacing.xs)) {
+        Text(
+            text = stringResource(R.string.reader_define_error),
+            style = MaterialTheme.typography.bodyLarge,
+        )
+        if (message.isNotBlank()) {
+            Text(
+                text = message,
+                style = MaterialTheme.typography.bodySmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
+        }
+        TextButton(onClick = onRetry) {
+            Text(stringResource(R.string.reader_define_retry))
+        }
+    }
+}
+
+/**
+ * Issue #1230 — the offline / system fallback. Tries Android's dictionary
+ * intent ([Intent.ACTION_DEFINE], passing the word via [Intent.EXTRA_TEXT] per
+ * the platform contract), then a web search, then a toast — so the action does
+ * *something* useful on every device, with or without a dictionary app.
+ */
+private fun launchWordLookup(context: Context, word: String) {
+    val define = Intent(Intent.ACTION_DEFINE).putExtra(Intent.EXTRA_TEXT, word)
+    if (tryStart(context, define)) return
+
+    val search = Intent(Intent.ACTION_WEB_SEARCH)
+        .putExtra(SearchManager.QUERY, "define $word")
+    if (tryStart(context, search)) return
+
+    Toast.makeText(
+        context,
+        context.getString(R.string.reader_define_no_dictionary_app),
+        Toast.LENGTH_SHORT,
+    ).show()
+}
+
+private fun tryStart(context: Context, intent: Intent): Boolean = try {
+    context.startActivity(intent)
+    true
+} catch (e: ActivityNotFoundException) {
+    false
+}

--- a/feature/src/main/kotlin/in/jphe/storyvox/feature/reader/HybridReaderScreen.kt
+++ b/feature/src/main/kotlin/in/jphe/storyvox/feature/reader/HybridReaderScreen.kt
@@ -107,6 +107,8 @@ fun HybridReaderScreen(
     val bookSearch by viewModel.bookSearch.collectAsStateWithLifecycle()
     // Issue #1234 — author for the share-quote attribution (not on playback state).
     val currentAuthor by viewModel.currentAuthor.collectAsStateWithLifecycle()
+    // Issue #1230 — tap-to-define dictionary popup state.
+    val definitionState by viewModel.dictionary.collectAsStateWithLifecycle()
     val playback = state.playback
 
     // Chapter-completion celebration. The VM's confettiTrigger fires
@@ -396,6 +398,12 @@ fun HybridReaderScreen(
                 onCreateHighlight = viewModel::createHighlight,
                 onUpdateHighlight = viewModel::updateHighlight,
                 onDeleteHighlight = viewModel::deleteHighlight,
+                // Issue #1230 — tap-to-define: long-press a word → Wiktionary
+                // lookup in a bottom sheet. State + verbs hoisted to the VM.
+                definitionState = definitionState,
+                onDefineWord = viewModel::defineWord,
+                onDismissDefinition = viewModel::dismissDefinition,
+                onRetryDefine = viewModel::retryDefine,
             )
         },
     )

--- a/feature/src/main/kotlin/in/jphe/storyvox/feature/reader/ReaderView.kt
+++ b/feature/src/main/kotlin/in/jphe/storyvox/feature/reader/ReaderView.kt
@@ -38,7 +38,6 @@ import androidx.compose.material.icons.outlined.ContentCopy
 import androidx.compose.material.icons.outlined.ExpandLess
 import androidx.compose.material.icons.outlined.ExpandMore
 import androidx.compose.material.icons.outlined.Search
-import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.DropdownMenu
 import androidx.compose.material3.DropdownMenuItem
 import androidx.compose.material3.FilledIconButton
@@ -159,11 +158,12 @@ fun ReaderTextView(
     chapterText: String,
     onPlayPause: () -> Unit,
     onSeekToChar: (Int) -> Unit = {},
-    /** Long-press a word in the chapter body → open the chat surface
-     *  with `Who is <word>?` pre-filled in the input field. The reader
-     *  doesn't know about navigation, so HybridReaderScreen wires this
-     *  to `navController.navigate(StoryvoxRoutes.chat(fId, prefill = q))`.
-     *  No-op default keeps preview/test callsites working unchanged. */
+    /** The tap-to-define sheet's "Ask AI" action (#1230) → open the chat
+     *  surface with a prebuilt "What does <word> mean?" question pre-filled in
+     *  the input field. The reader doesn't know about navigation, so
+     *  HybridReaderScreen wires this to
+     *  `navController.navigate(StoryvoxRoutes.chat(fId, prefill = q))`. No-op
+     *  default keeps preview/test callsites working unchanged. */
     onAskAiAbout: (String) -> Unit = {},
     /**
      * Issue #946 — magical auto-scroll toggle. When true, the chapter
@@ -225,6 +225,17 @@ fun ReaderTextView(
     onUpdateHighlight: (`in`.jphe.storyvox.data.db.entity.Annotation, String, String?) -> Unit = { _, _, _ -> },
     /** Issue #999 phase 2 — delete a highlight by id. */
     onDeleteHighlight: (String) -> Unit = {},
+    /** Issue #1230 — tap-to-define dictionary state for the long-press popup.
+     *  [DictionaryUiState.Hidden] (default) keeps the sheet closed, so
+     *  preview/test callsites render unchanged. */
+    definitionState: DictionaryUiState = DictionaryUiState.Hidden,
+    /** Issue #1230 — long-press a word → look it up. Wired by
+     *  [HybridReaderScreen] to [ReaderViewModel.defineWord]. No-op default. */
+    onDefineWord: (String) -> Unit = {},
+    /** Issue #1230 — dismiss the tap-to-define sheet (→ [ReaderViewModel.dismissDefinition]). */
+    onDismissDefinition: () -> Unit = {},
+    /** Issue #1230 — retry a failed lookup (→ [ReaderViewModel.retryDefine]). */
+    onRetryDefine: (String) -> Unit = {},
     modifier: Modifier = Modifier,
 ) {
     val spacing = LocalSpacing.current
@@ -236,14 +247,6 @@ fun ReaderTextView(
     var bodyTopPx by remember { mutableFloatStateOf(0f) }
     var viewportHeightPx by remember { mutableFloatStateOf(0f) }
     var textLayout by remember { mutableStateOf<TextLayoutResult?>(null) }
-
-    // Long-press lookup state. When non-null, the dialog is showing for
-    // this word — tapping its primary action navigates to the chat
-    // surface with `Who is <word>?` pre-filled. The state lives on
-    // ReaderTextView (not the SentenceHighlight) because the SentenceHighlight
-    // is a low-level rendering primitive shared with the audiobook view —
-    // putting the popup here keeps that primitive stateless.
-    var lookupWord by remember { mutableStateOf<String?>(null) }
 
     // Issue #999 phase 2 — in-reader highlight state.
     //  - selectionRange: the live drag selection (raw anchor/focus, normalised
@@ -544,7 +547,12 @@ fun ReaderTextView(
                             val hit = hitId?.let { id -> savedHighlights.firstOrNull { it.id == id } }
                             if (hit != null) editingHighlight = hit else onSeekToChar(charIndex)
                         },
-                        onLongPressWord = { word -> lookupWord = word },
+                        // Issue #1230 — long-press a word opens the
+                        // tap-to-define sheet (supersedes the older #188
+                        // ask-AI-only popup; the sheet still offers Ask AI).
+                        // The drag-to-select highlight gesture (#999) is a
+                        // separate detector, so this doesn't disturb it.
+                        onLongPressWord = { word -> onDefineWord(word) },
                         onLayout = { layout -> textLayout = layout },
                         // #998 — paint in-text search hits; the active one
                         // (chevron target) gets the stronger fill.
@@ -816,54 +824,21 @@ fun ReaderTextView(
             }
         }
 
-        // Character-lookup popup (#188). Long-press a word → AlertDialog
-        // with the librarian sigil + a primary "Ask AI" action. We use
-        // AlertDialog rather than a popup-at-position because the M3 dialog
-        // already gives us the brass scrim, dismiss-on-outside-tap, and
-        // back-button handling for free; pinning a popup to the press
-        // coordinate would ride on top of the moving sentence underline
-        // and obscure the very word the user just selected.
-        lookupWord?.let { word ->
-            AlertDialog(
-                onDismissRequest = { lookupWord = null },
-                icon = {
-                    Icon(
-                        Icons.Outlined.AutoAwesome,
-                        contentDescription = null,
-                        tint = MaterialTheme.colorScheme.primary,
-                    )
-                },
-                title = {
-                    Text(
-                        text = stringResource(R.string.reader_ask_ai_title, word),
-                        style = MaterialTheme.typography.titleMedium,
-                    )
-                },
-                text = {
-                    Text(
-                        text = stringResource(R.string.reader_ask_ai_body),
-                        style = MaterialTheme.typography.bodyMedium,
-                        color = MaterialTheme.colorScheme.onSurfaceVariant,
-                    )
-                },
-                confirmButton = {
-                    TextButton(
-                        onClick = {
-                            val q = "Who is $word?"
-                            lookupWord = null
-                            onAskAiAbout(q)
-                        },
-                    ) {
-                        Text(stringResource(R.string.reader_ask_ai))
-                    }
-                },
-                dismissButton = {
-                    TextButton(onClick = { lookupWord = null }) {
-                        Text(stringResource(R.string.reader_cancel))
-                    }
-                },
-            )
-        }
+        // Issue #1230 — tap-to-define popup. Long-press a word (a no-drag
+        // long-press; the drag variant selects text for a highlight) opens a
+        // bottom sheet with its Wiktionary definition, an "open in dictionary
+        // app" offline fallback, and an "Ask AI" action that preserves the
+        // older #188 character-lookup affordance this supersedes. All lookup
+        // state is hoisted to [ReaderViewModel]; this just renders it.
+        DefineWordSheet(
+            state = definitionState,
+            onDismiss = onDismissDefinition,
+            onAskAi = { question ->
+                onDismissDefinition()
+                onAskAiAbout(question)
+            },
+            onRetry = onRetryDefine,
+        )
 
         // Issue #999 phase 2 — highlight create toolbar. Shown after a
         // selection drag lifts (pendingSelection set). A compact bottom sheet

--- a/feature/src/main/kotlin/in/jphe/storyvox/feature/reader/ReaderViewModel.kt
+++ b/feature/src/main/kotlin/in/jphe/storyvox/feature/reader/ReaderViewModel.kt
@@ -6,6 +6,10 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import dagger.hilt.android.lifecycle.HiltViewModel
 import `in`.jphe.storyvox.data.db.entity.Annotation
+import `in`.jphe.storyvox.data.dictionary.DictionaryRepository
+import `in`.jphe.storyvox.data.dictionary.DictionaryResult
+import `in`.jphe.storyvox.data.dictionary.WordDefinition
+import `in`.jphe.storyvox.data.dictionary.normalizeLookupWord
 import `in`.jphe.storyvox.data.repository.AnnotationRepository
 import `in`.jphe.storyvox.data.repository.ChapterRepository
 import `in`.jphe.storyvox.data.repository.ContinueListeningEntry
@@ -210,6 +214,31 @@ private data class BookSearchResultsState(
     val truncated: Boolean = false,
 )
 
+/**
+ * Issue #1230 — observable state for the reader's tap-to-define popup.
+ * [ReaderViewModel.defineWord] drives the transition
+ * [Hidden] → [Loading] → [Loaded] / [Empty] / [Error]; [HybridReaderScreen]
+ * collects it and [ReaderTextView] renders the bottom sheet accordingly.
+ * [Empty] and [Error] both still offer the system-dictionary + Ask-AI
+ * fallbacks, so a missing word or a dropped network is never a dead end.
+ */
+sealed interface DictionaryUiState {
+    /** No lookup in flight — the sheet is closed (resting state). */
+    data object Hidden : DictionaryUiState
+
+    /** A lookup for [word] is in flight; the sheet shows a spinner. */
+    data class Loading(val word: String) : DictionaryUiState
+
+    /** [definition] resolved — the sheet renders the part-of-speech entries. */
+    data class Loaded(val definition: WordDefinition) : DictionaryUiState
+
+    /** [word] is valid but has no dictionary entry (404 / empty body). */
+    data class Empty(val word: String) : DictionaryUiState
+
+    /** The lookup failed for [word]; [message] is the reason for the Retry row. */
+    data class Error(val word: String, val message: String) : DictionaryUiState
+}
+
 @HiltViewModel
 class ReaderViewModel @Inject constructor(
     private val playback: PlaybackControllerUi,
@@ -249,6 +278,15 @@ class ReaderViewModel @Inject constructor(
      * already use — so book-search doesn't add a parallel `*Ui` port.
      */
     private val chapterRepo: ChapterRepository,
+    /**
+     * Issue #1230 — tap-to-define dictionary lookups for the reader's
+     * long-press popup. The core-data interface is bound to the okhttp-backed
+     * Wiktionary implementation in `:app`; the ViewModel only maps its
+     * [DictionaryResult] onto [DictionaryUiState]. Injected as the core-data
+     * repository directly, mirroring [annotationRepo] / [chapterRepo] — no
+     * parallel `*Ui` port.
+     */
+    private val dictionaryRepo: DictionaryRepository,
     savedState: SavedStateHandle,
 ) : ViewModel() {
 
@@ -882,6 +920,55 @@ class ReaderViewModel @Inject constructor(
     /** Issue #999 phase 2 — delete a highlight by id (the edit sheet's Delete). */
     fun deleteHighlight(id: String) {
         viewModelScope.launch { annotationRepo.delete(id) }
+    }
+
+    // ── Issue #1230 — tap-to-define dictionary ────────────────────────────
+    private val _dictionary = MutableStateFlow<DictionaryUiState>(DictionaryUiState.Hidden)
+
+    /** Tap-to-define popup state. [HybridReaderScreen] collects this and hands
+     *  it to [ReaderTextView], which renders the bottom sheet. */
+    val dictionary: StateFlow<DictionaryUiState> = _dictionary.asStateFlow()
+
+    /** The in-flight lookup, cancelled when a new word is requested or the
+     *  sheet is dismissed so a slow response can't clobber a fresh one. */
+    private var dictionaryJob: Job? = null
+
+    /**
+     * Issue #1230 — look up [rawWord] (the token under a reader long-press) and
+     * drive [dictionary] through Loading → Loaded / Empty / Error.
+     *
+     * Normalisation (strip punctuation / possessives, reject non-words) is the
+     * pure [normalizeLookupWord]; a token with no letters short-circuits to
+     * [DictionaryUiState.Empty] without a network call, so the sheet still opens
+     * with the fallbacks rather than spinning on a hopeless query. The previous
+     * lookup is cancelled so rapid long-presses don't race.
+     */
+    fun defineWord(rawWord: String) {
+        val normalized = normalizeLookupWord(rawWord)
+        if (normalized == null) {
+            dictionaryJob?.cancel()
+            _dictionary.value = DictionaryUiState.Empty(rawWord.trim())
+            return
+        }
+        dictionaryJob?.cancel()
+        _dictionary.value = DictionaryUiState.Loading(normalized)
+        dictionaryJob = viewModelScope.launch {
+            _dictionary.value = when (val result = dictionaryRepo.define(normalized)) {
+                is DictionaryResult.Success -> DictionaryUiState.Loaded(result.definition)
+                is DictionaryResult.NotFound -> DictionaryUiState.Empty(result.word)
+                is DictionaryResult.Error -> DictionaryUiState.Error(result.word, result.message)
+            }
+        }
+    }
+
+    /** Re-run the lookup for [word] (the Error row's Retry). */
+    fun retryDefine(word: String) = defineWord(word)
+
+    /** Close the tap-to-define sheet and drop any in-flight lookup. */
+    fun dismissDefinition() {
+        dictionaryJob?.cancel()
+        dictionaryJob = null
+        _dictionary.value = DictionaryUiState.Hidden
     }
 
     fun skipForward() = playback.skipForward()

--- a/feature/src/main/res/values/strings.xml
+++ b/feature/src/main/res/values/strings.xml
@@ -142,10 +142,17 @@
     <string name="generic_filter_chip_any">Any</string>
 
     <!-- Reader / ReaderView -->
-    <string name="reader_ask_ai_title">Ask AI: who is \"%1$s\"?</string>
-    <string name="reader_ask_ai_body">The librarian-companion will answer based on what you\'ve read so far — no spoilers from later chapters.</string>
     <string name="reader_ask_ai">Ask AI</string>
     <string name="reader_cancel">Cancel</string>
+    <!-- Reader / tap-to-define dictionary (#1230) -->
+    <string name="reader_define_loading">Looking up \"%1$s\"…</string>
+    <string name="reader_define_empty">No dictionary entry for \"%1$s\".</string>
+    <string name="reader_define_error">Couldn\'t reach the dictionary.</string>
+    <string name="reader_define_retry">Retry</string>
+    <string name="reader_define_system_dict">Dictionary app</string>
+    <string name="reader_define_attribution">Definitions from Wiktionary · CC BY-SA</string>
+    <string name="reader_define_no_dictionary_app">No dictionary or browser app found.</string>
+    <string name="reader_define_ask_ai_question">What does \"%1$s\" mean?</string>
 
     <!-- Reader / HybridReaderScreen -->
     <string name="reader_empty_library_title">Your library awaits</string>


### PR DESCRIPTION
## Summary

Closes #1230. Long-press a word in the reader to look it up in a **tap-to-define bottom sheet**:

- **Definition** — part-of-speech entries + senses from the free **Wiktionary REST API** (`/api/rest_v1/page/definition/{word}`, no key).
- **Offline / system fallback** — "Dictionary app" button fires Android's `ACTION_DEFINE` (the issue's requested intent), backstopped by a web search, then a toast if the device has neither.
- **Ask AI** — seeds the chat surface with "What does *X* mean?". This **subsumes the older #188 ask-AI-only popup**, which is removed (its `reader_ask_ai_title`/`reader_ask_ai_body` strings go with it).

The long-press-**drag** highlight gesture (#999) is on a separate pointer detector and is **untouched** — the issue's "must not interfere with the existing highlight/annotation flow" requirement.

## Design

| Layer | Lives in | Why |
|---|---|---|
| Parser, word normalizer, `DictionaryRepository` contract, models | **core-data** (pure Kotlin) | Unit-testable under the JUnit-only harness; no OkHttp, honoring the module's `UserAgent` "stay dependency-light" note |
| `WiktionaryDictionaryRepository` (OkHttp) + Hilt `@Provides` | **app** | Only `:app` carries the `@UserAgentHeader` interceptor — **Wikimedia's UA policy 403s anonymous traffic**, so the descriptive User-Agent is mandatory |
| `DefineWordSheet` + `ReaderViewModel` dictionary state | **feature** | State hoisted to the VM; `ReaderTextView` stays presentational |

Notable details:
- **Wikimedia User-Agent**: reuses the existing `UserAgent` / `provideUserAgentInterceptor` seam (issue #1141) — without it the API rejects us.
- **Case fallback**: Wiktionary titles are case-sensitive, so a sentence-initial "The" is retried as "the" (`lemmaCandidates`), capped at the ≤3 distinct variants.
- **Network**: lookups run on `Dispatchers.IO`; 404/empty → `NotFound`, transport errors → `Error` (Retry row). Definition HTML is stripped to plain prose.
- **Pronunciation**: the REST *definition* endpoint omits IPA, so the model carries it optionally and the sheet shows the row only when present.

## Integration points

- `ReaderTextView` gains `definitionState` / `onDefineWord` / `onDismissDefinition` / `onRetryDefine`, all **defaulted** (preview/test/AudiobookView callsites unchanged). `onLongPressWord` now routes to `onDefineWord`.
- `HybridReaderScreen` collects `viewModel.dictionary` and wires the verbs.
- `AudiobookView` has no per-word gesture surface (cover + transport pane), so tap-to-define applies to the reader pane only.

## Testing

Pure JVM unit tests in `:core-data` (no network):
- **`WiktionaryParserTest`** — multi-POS parsing, HTML/entity stripping, language fallback, sense cap, blank-group dropping, malformed-body tolerance.
- **`LookupWordTest`** — word extraction (edge punctuation, possessives, internal hyphen/apostrophe, case preservation, non-word rejection) + case-candidate enumeration.

No local gradle build (compile gate is CI's *Build APK*). The new `DictionaryRepository` dep is bound in `AppBindings`, so the Hilt graph resolves at `:app`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
