### PR TITLE
feat(stats): listening statistics dashboard (#1235)

### DIFF
--- a/app/src/main/kotlin/in/jphe/storyvox/navigation/StoryvoxNavHost.kt
+++ b/app/src/main/kotlin/in/jphe/storyvox/navigation/StoryvoxNavHost.kt
@@ -57,6 +57,7 @@ import `in`.jphe.storyvox.feature.settings.MemoryPalaceSettingsScreen
 import `in`.jphe.storyvox.feature.settings.PerformanceSettingsScreen
 import `in`.jphe.storyvox.feature.settings.ReadingSettingsScreen
 import `in`.jphe.storyvox.feature.settings.SettingsHubScreen
+import `in`.jphe.storyvox.feature.stats.ListeningStatsScreen
 import `in`.jphe.storyvox.feature.settings.SettingsScreen
 import `in`.jphe.storyvox.feature.settings.VoiceAndPlaybackSettingsScreen
 import `in`.jphe.storyvox.feature.settings.pronunciation.PronunciationDictScreen
@@ -89,6 +90,9 @@ object StoryvoxRoutes {
      *  [SETTINGS] page is preserved as an "All settings" escape hatch
      *  for power users who want everything on one searchable page. */
     const val SETTINGS_HUB = "settings/hub"
+
+    /** Issue #1235 — Listening stats dashboard, reached from the Settings hub. */
+    const val STATS = "stats"
     const val SETTINGS = "settings"
     const val SETTINGS_PRONUNCIATION = "settings/pronunciation"
     const val VOICE_LIBRARY = "settings/voices"
@@ -1026,7 +1030,21 @@ private fun StoryvoxNavHostContent(
                     onOpenMemoryPalace = { navController.navigate(StoryvoxRoutes.SETTINGS_MEMORY_PALACE) },
                     onOpenAbout = { navController.navigate(StoryvoxRoutes.SETTINGS_ABOUT) },
                     onOpenAdvanced = { navController.navigate(StoryvoxRoutes.SETTINGS_ADVANCED) },
+                    onOpenStats = { navController.navigate(StoryvoxRoutes.STATS) },
                 )
+            }
+
+            // Issue #1235 — Listening stats dashboard. Push enter/exit
+            // because it's a drill-down from the Settings hub, like the
+            // other dedicated subscreens.
+            composable(
+                StoryvoxRoutes.STATS,
+                enterTransition = pushEnter,
+                exitTransition = pushExit,
+                popEnterTransition = popEnter,
+                popExitTransition = popExit,
+            ) {
+                ListeningStatsScreen(onBack = { navController.popBackStack() })
             }
 
             composable(

--- a/core-data/src/main/kotlin/in/jphe/storyvox/data/db/StoryvoxDatabase.kt
+++ b/core-data/src/main/kotlin/in/jphe/storyvox/data/db/StoryvoxDatabase.kt
@@ -12,6 +12,7 @@ import `in`.jphe.storyvox.data.db.dao.FictionDao
 import `in`.jphe.storyvox.data.db.dao.FictionMemoryDao
 import `in`.jphe.storyvox.data.db.dao.FictionShelfDao
 import `in`.jphe.storyvox.data.db.dao.InboxEventDao
+import `in`.jphe.storyvox.data.db.dao.ListeningStatsDao
 import `in`.jphe.storyvox.data.db.dao.LlmMessageDao
 import `in`.jphe.storyvox.data.db.dao.LlmSessionDao
 import `in`.jphe.storyvox.data.db.dao.PlaybackDao
@@ -98,6 +99,11 @@ abstract class StoryvoxDatabase : RoomDatabase() {
     abstract fun inboxEventDao(): InboxEventDao
     abstract fun fictionMemoryDao(): FictionMemoryDao
     abstract fun annotationDao(): AnnotationDao
+
+    // Issue #1235 — read-only aggregate queries for the listening-stats
+    // dashboard. No entity of its own; aggregates chapter_history +
+    // playback_position + fiction + chapter, so no schema-version bump.
+    abstract fun listeningStatsDao(): ListeningStatsDao
 
     companion object {
         const val NAME: String = "storyvox.db"

--- a/core-data/src/main/kotlin/in/jphe/storyvox/data/db/dao/ListeningStatsDao.kt
+++ b/core-data/src/main/kotlin/in/jphe/storyvox/data/db/dao/ListeningStatsDao.kt
@@ -1,0 +1,175 @@
+package `in`.jphe.storyvox.data.db.dao
+
+import androidx.room.Dao
+import androidx.room.Query
+
+/**
+ * Issue #1235 — listening-statistics aggregation DAO.
+ *
+ * Read-only. Every query here is a pure aggregate over tables that
+ * *already exist* — `chapter_history` (#158 reading breadcrumb),
+ * `playback_position` (#965 per-chapter offset + duration estimate),
+ * `fiction`, and `chapter`. There is intentionally **no** new entity
+ * and **no** schema migration: the stats dashboard derives everything
+ * from data the playback layer is already writing, so it can't drift
+ * out of sync with a separate recording pipeline and adds zero cost to
+ * the playback hot path.
+ *
+ * ## What's honest here, and what's an estimate
+ *
+ * `chapter_history.completed` / `openedAt` are ground truth — they're
+ * stamped by [HistoryRepository] on real open / end-of-chapter events.
+ * Counts and the activity timeline built from them are exact.
+ *
+ * "Time listened", by contrast, is an **estimate**: there is no
+ * per-session stopwatch in the schema (the #1235 issue body notes a
+ * future `ListeningSession` entity would give true wall-clock time).
+ * We approximate it as the summed `playback_position.durationEstimateMs`
+ * of the chapters the user actually *finished* — i.e. "the duration of
+ * the audio content you've completed". The UI labels every time figure
+ * with a "≈" so the estimate never masquerades as a measurement.
+ *
+ * ## Why bucketing isn't done in SQL
+ *
+ * Day / hour bucketing (streak, weekly trend, time-of-day) needs the
+ * *device's* local calendar, and we want it unit-testable with a fixed
+ * clock and zone. SQLite's `strftime(..., 'localtime')` would bind the
+ * result to the JVM's default zone at query time and can't be pinned
+ * from a test. So the heavy SUM/COUNT aggregates stay in SQL (they're
+ * zone-independent) and the calendar math happens in
+ * [ListeningStatsCalculator] over the raw [ActivityRow] timestamps.
+ */
+@Dao
+interface ListeningStatsDao {
+
+    /** Total chapters the user has ever opened (one row per fiction/chapter). */
+    @Query("SELECT COUNT(*) FROM chapter_history")
+    suspend fun chaptersOpened(): Int
+
+    /** Chapters the user has read/listened to the end of. */
+    @Query("SELECT COUNT(*) FROM chapter_history WHERE completed = 1")
+    suspend fun chaptersFinished(): Int
+
+    /** Distinct fictions the user has ever opened a chapter of ("books started"). */
+    @Query("SELECT COUNT(DISTINCT fictionId) FROM chapter_history")
+    suspend fun booksStarted(): Int
+
+    /**
+     * Estimated audio time of every finished chapter, in ms. Joins each
+     * completed history row to its saved playback position to recover the
+     * chapter's `durationEstimateMs`. Chapters finished before a position
+     * was ever saved (no matching row) contribute 0 — an under-count we
+     * accept rather than fabricate.
+     */
+    @Query(
+        """
+        SELECT COALESCE(SUM(p.durationEstimateMs), 0)
+          FROM chapter_history h
+          JOIN playback_position p
+            ON p.fictionId = h.fictionId AND p.chapterId = h.chapterId
+         WHERE h.completed = 1
+        """,
+    )
+    suspend fun estimatedFinishedMs(): Long
+
+    /** Total words across finished chapters (chapter bodies that lack a word count contribute 0). */
+    @Query(
+        """
+        SELECT COALESCE(SUM(c.wordCount), 0)
+          FROM chapter_history h
+          JOIN chapter c ON c.id = h.chapterId
+         WHERE h.completed = 1
+        """,
+    )
+    suspend fun wordsInFinishedChapters(): Long
+
+    /**
+     * Books the user has *fully* finished: every chapter of a
+     * known-length fiction marked completed. `f.chapterCount > 0` skips
+     * placeholder rows whose length we don't know yet (a synced
+     * "Loading…" row), so they can't masquerade as a finished book. The
+     * `>=` (not `=`) tolerates a stale chapter count that shrank after
+     * the user had already finished more chapters than the source now
+     * reports.
+     */
+    @Query(
+        """
+        SELECT COUNT(*) FROM (
+            SELECT h.fictionId
+              FROM chapter_history h
+              JOIN fiction f ON f.id = h.fictionId
+             WHERE h.completed = 1 AND f.chapterCount > 0
+             GROUP BY h.fictionId
+            HAVING COUNT(*) >= MAX(f.chapterCount)
+        )
+        """,
+    )
+    suspend fun booksCompleted(): Int
+
+    /**
+     * Per-source breakdown over finished chapters — count + estimated ms,
+     * busiest source first. Backs the "listening by source" donut. The
+     * LEFT JOIN keeps a source represented even when none of its finished
+     * chapters has a saved duration (it just contributes 0 ms).
+     */
+    @Query(
+        """
+        SELECT f.sourceId            AS sourceId,
+               COUNT(*)              AS finishedChapters,
+               COALESCE(SUM(p.durationEstimateMs), 0) AS estimatedMs
+          FROM chapter_history h
+          JOIN fiction f ON f.id = h.fictionId
+          LEFT JOIN playback_position p
+            ON p.fictionId = h.fictionId AND p.chapterId = h.chapterId
+         WHERE h.completed = 1
+         GROUP BY f.sourceId
+         ORDER BY finishedChapters DESC, estimatedMs DESC
+        """,
+    )
+    suspend fun perSourceFinished(): List<SourceStatRow>
+
+    /**
+     * Raw activity timeline — one row per chapter-history entry, carrying
+     * its last-open timestamp, completion flag, and (when known) duration
+     * estimate. [ListeningStatsCalculator] buckets these into the streak,
+     * the 7-day trend, the today/week time totals, and the time-of-day
+     * histogram using a caller-supplied clock + zone.
+     *
+     * Caveat inherited from the #158 schema: `chapter_history` keeps a
+     * single row per (fiction, chapter) and updates `openedAt` in place
+     * on re-open, so a re-listened chapter moves to "today" rather than
+     * adding a second day. Trends therefore reflect *last-touched* days,
+     * not an append-only listening log — the honest limit of deriving
+     * stats without a dedicated session table.
+     */
+    @Query(
+        """
+        SELECT h.openedAt   AS openedAt,
+               h.completed  AS completed,
+               COALESCE(p.durationEstimateMs, 0) AS durationEstimateMs
+          FROM chapter_history h
+          LEFT JOIN playback_position p
+            ON p.fictionId = h.fictionId AND p.chapterId = h.chapterId
+         ORDER BY h.openedAt
+        """,
+    )
+    suspend fun activityRows(): List<ActivityRow>
+}
+
+/** Per-source finished-chapter aggregate row. */
+data class SourceStatRow(
+    val sourceId: String,
+    val finishedChapters: Int,
+    val estimatedMs: Long,
+)
+
+/**
+ * One chapter-history entry projected for stats bucketing. Slim on
+ * purpose — only the three fields the calendar math needs, never the
+ * chapter body blobs.
+ */
+data class ActivityRow(
+    val openedAt: Long,
+    val completed: Boolean,
+    val durationEstimateMs: Long,
+)

--- a/core-data/src/main/kotlin/in/jphe/storyvox/data/di/DataModule.kt
+++ b/core-data/src/main/kotlin/in/jphe/storyvox/data/di/DataModule.kt
@@ -25,6 +25,7 @@ import `in`.jphe.storyvox.data.db.dao.FictionDao
 import `in`.jphe.storyvox.data.db.dao.FictionMemoryDao
 import `in`.jphe.storyvox.data.db.dao.FictionShelfDao
 import `in`.jphe.storyvox.data.db.dao.InboxEventDao
+import `in`.jphe.storyvox.data.db.dao.ListeningStatsDao
 import `in`.jphe.storyvox.data.db.dao.LlmMessageDao
 import `in`.jphe.storyvox.data.db.dao.LlmSessionDao
 import `in`.jphe.storyvox.data.db.dao.PlaybackDao
@@ -52,6 +53,8 @@ import `in`.jphe.storyvox.data.repository.PlaybackPositionRepository
 import `in`.jphe.storyvox.data.repository.PlaybackPositionRepositoryImpl
 import `in`.jphe.storyvox.data.repository.ShelfRepository
 import `in`.jphe.storyvox.data.repository.ShelfRepositoryImpl
+import `in`.jphe.storyvox.data.repository.stats.ListeningStatsRepository
+import `in`.jphe.storyvox.data.repository.stats.ListeningStatsRepositoryImpl
 import `in`.jphe.storyvox.data.repository.WorkManagerChapterDownloadScheduler
 import `in`.jphe.storyvox.data.work.MetadataBackfillScheduler
 import `in`.jphe.storyvox.data.work.WorkManagerMetadataBackfillScheduler
@@ -125,6 +128,8 @@ object DataModule {
     // Issue #999 — highlights + notes. Consumed by AnnotationsSyncer,
     // ExportAnnotationsUseCase, and AnnotationRepository.
     @Provides fun annotationDao(db: StoryvoxDatabase): AnnotationDao = db.annotationDao()
+    // Issue #1235 — read-only aggregate DAO for the listening-stats dashboard.
+    @Provides fun listeningStatsDao(db: StoryvoxDatabase): ListeningStatsDao = db.listeningStatsDao()
 
     /**
      * Long-lived [CoroutineScope] for singleton repositories that need to fire
@@ -298,6 +303,13 @@ abstract class RepositoryBindings {
 
     @Binds @Singleton
     abstract fun bindHistoryRepository(impl: HistoryRepositoryImpl): HistoryRepository
+
+    // Issue #1235 — listening-statistics dashboard. Read-only aggregate
+    // over chapter_history + playback_position; no recording pipeline.
+    @Binds @Singleton
+    abstract fun bindListeningStatsRepository(
+        impl: ListeningStatsRepositoryImpl,
+    ): ListeningStatsRepository
 
     @Binds @Singleton
     abstract fun bindInboxRepository(impl: InboxRepositoryImpl): InboxRepository

--- a/core-data/src/main/kotlin/in/jphe/storyvox/data/repository/stats/ListeningStats.kt
+++ b/core-data/src/main/kotlin/in/jphe/storyvox/data/repository/stats/ListeningStats.kt
@@ -1,0 +1,219 @@
+package `in`.jphe.storyvox.data.repository.stats
+
+import `in`.jphe.storyvox.data.db.dao.ActivityRow
+import `in`.jphe.storyvox.data.db.dao.SourceStatRow
+import java.time.Instant
+import java.time.LocalDate
+import java.time.ZoneId
+
+/**
+ * Issue #1235 — immutable snapshot backing the listening-statistics
+ * dashboard. Assembled by [ListeningStatsCalculator.assemble] from the
+ * raw `ListeningStatsDao` outputs plus a clock + zone, so the whole
+ * thing is computed in one pure step that's trivial to unit-test.
+ *
+ * Time figures are estimates (see `ListeningStatsDao` kdoc) — the UI
+ * prefixes them with "≈".
+ */
+data class ListeningStats(
+    /** Estimated audio time of all finished chapters, ms. */
+    val totalEstimatedMs: Long,
+    /** Estimated time finished *today* (device-local day), ms. */
+    val todayEstimatedMs: Long,
+    /** Estimated time finished in the last 7 days inclusive, ms. */
+    val weekEstimatedMs: Long,
+    val chaptersOpened: Int,
+    val chaptersFinished: Int,
+    val booksCompleted: Int,
+    val booksStarted: Int,
+    val wordsRead: Long,
+    /** Consecutive active days ending today (or yesterday, if today is idle). */
+    val currentStreakDays: Int,
+    /** Best-ever run of consecutive active days. */
+    val longestStreakDays: Int,
+    /** Last 7 calendar days, oldest first — backs the weekly bar chart. */
+    val weeklyActivity: List<DayActivity>,
+    /** The four day-parts in fixed order — backs the time-of-day chart. */
+    val timeOfDay: List<TimeOfDayBucket>,
+    /** Finished-chapter breakdown per source, busiest first — backs the donut. */
+    val perSource: List<SourceShare>,
+) {
+    /** True once there's anything worth charting (the screen shows an empty state otherwise). */
+    val hasData: Boolean get() = chaptersOpened > 0
+
+    companion object {
+        val EMPTY = ListeningStats(
+            totalEstimatedMs = 0L,
+            todayEstimatedMs = 0L,
+            weekEstimatedMs = 0L,
+            chaptersOpened = 0,
+            chaptersFinished = 0,
+            booksCompleted = 0,
+            booksStarted = 0,
+            wordsRead = 0L,
+            currentStreakDays = 0,
+            longestStreakDays = 0,
+            weeklyActivity = emptyList(),
+            timeOfDay = emptyList(),
+            perSource = emptyList(),
+        )
+    }
+}
+
+/** One day on the weekly trend: how many chapters were finished and the estimated time. */
+data class DayActivity(
+    val date: LocalDate,
+    val finishedChapters: Int,
+    val estimatedMs: Long,
+)
+
+/** Coarse part of the day a chapter was last opened in. */
+enum class DayPart { MORNING, AFTERNOON, EVENING, NIGHT }
+
+/** Finished-chapter count within one [DayPart]. */
+data class TimeOfDayBucket(
+    val part: DayPart,
+    val finishedChapters: Int,
+)
+
+/** Finished-chapter share for one source. */
+data class SourceShare(
+    val sourceId: String,
+    val finishedChapters: Int,
+    val estimatedMs: Long,
+)
+
+/**
+ * Pure calendar/aggregation math for [ListeningStats]. No Android, no
+ * Room, no system clock — everything that touches "now" or a time zone
+ * is passed in, so the unit tests pin a fixed [Instant] + [ZoneId] and
+ * assert exact buckets.
+ */
+object ListeningStatsCalculator {
+
+    /** Number of days shown on the weekly trend (today + the previous six). */
+    const val TREND_DAYS: Int = 7
+
+    /**
+     * Assemble a full snapshot from the raw DAO outputs.
+     *
+     * @param activity every chapter-history row (for the calendar math)
+     * @param now the moment "today" is anchored to
+     * @param zone the device-local zone that defines day/hour boundaries
+     */
+    fun assemble(
+        chaptersOpened: Int,
+        chaptersFinished: Int,
+        booksCompleted: Int,
+        booksStarted: Int,
+        wordsRead: Long,
+        totalEstimatedMs: Long,
+        perSource: List<SourceStatRow>,
+        activity: List<ActivityRow>,
+        now: Instant,
+        zone: ZoneId,
+    ): ListeningStats {
+        val today = now.atZone(zone).toLocalDate()
+        val weekStart = today.minusDays((TREND_DAYS - 1).toLong())
+
+        // Any opened chapter marks the day "active" for streak purposes —
+        // the most generous honest reading of "a day you were reading",
+        // since we have no per-minute signal to apply the issue's "≥15min".
+        val activeDays = activity.mapTo(HashSet()) { localDate(it.openedAt, zone) }
+
+        // Finished-chapter contributions, bucketed once and reused.
+        val finished = activity.asSequence().filter { it.completed }
+        var todayMs = 0L
+        var weekMs = 0L
+        val perDayFinished = HashMap<LocalDate, Int>()
+        val perDayMs = HashMap<LocalDate, Long>()
+        val perPart = IntArray(DayPart.entries.size)
+        for (row in finished) {
+            val zdt = Instant.ofEpochMilli(row.openedAt).atZone(zone)
+            val day = zdt.toLocalDate()
+            if (day == today) todayMs += row.durationEstimateMs
+            if (!day.isBefore(weekStart) && !day.isAfter(today)) {
+                weekMs += row.durationEstimateMs
+                perDayFinished[day] = (perDayFinished[day] ?: 0) + 1
+                perDayMs[day] = (perDayMs[day] ?: 0L) + row.durationEstimateMs
+            }
+            perPart[dayPartOf(zdt.hour).ordinal]++
+        }
+
+        val weekly = (0 until TREND_DAYS).map { offset ->
+            val day = weekStart.plusDays(offset.toLong())
+            DayActivity(
+                date = day,
+                finishedChapters = perDayFinished[day] ?: 0,
+                estimatedMs = perDayMs[day] ?: 0L,
+            )
+        }
+
+        val timeOfDay = DayPart.entries.map { part ->
+            TimeOfDayBucket(part = part, finishedChapters = perPart[part.ordinal])
+        }
+
+        return ListeningStats(
+            totalEstimatedMs = totalEstimatedMs,
+            todayEstimatedMs = todayMs,
+            weekEstimatedMs = weekMs,
+            chaptersOpened = chaptersOpened,
+            chaptersFinished = chaptersFinished,
+            booksCompleted = booksCompleted,
+            booksStarted = booksStarted,
+            wordsRead = wordsRead,
+            currentStreakDays = currentStreak(activeDays, today),
+            longestStreakDays = longestStreak(activeDays),
+            weeklyActivity = weekly,
+            timeOfDay = timeOfDay,
+            perSource = perSource.map { SourceShare(it.sourceId, it.finishedChapters, it.estimatedMs) },
+        )
+    }
+
+    /**
+     * Consecutive active days ending at [today]. If today has no activity
+     * yet but yesterday did, the streak is still "live" and anchored to
+     * yesterday (you haven't broken it by not having read yet today).
+     */
+    fun currentStreak(activeDays: Set<LocalDate>, today: LocalDate): Int {
+        var anchor = when {
+            activeDays.contains(today) -> today
+            activeDays.contains(today.minusDays(1)) -> today.minusDays(1)
+            else -> return 0
+        }
+        var count = 0
+        while (activeDays.contains(anchor)) {
+            count++
+            anchor = anchor.minusDays(1)
+        }
+        return count
+    }
+
+    /** Longest run of consecutive active days anywhere in the history. */
+    fun longestStreak(activeDays: Set<LocalDate>): Int {
+        if (activeDays.isEmpty()) return 0
+        val sorted = activeDays.sorted()
+        var best = 1
+        var run = 1
+        for (i in 1 until sorted.size) {
+            run = if (sorted[i] == sorted[i - 1].plusDays(1)) run + 1 else 1
+            if (run > best) best = run
+        }
+        return best
+    }
+
+    /**
+     * Day-part bucket boundaries: morning 05–11, afternoon 12–16,
+     * evening 17–21, night 22–04. Matches the issue's
+     * "morning/afternoon/evening/night" split.
+     */
+    fun dayPartOf(hour: Int): DayPart = when (hour) {
+        in 5..11 -> DayPart.MORNING
+        in 12..16 -> DayPart.AFTERNOON
+        in 17..21 -> DayPart.EVENING
+        else -> DayPart.NIGHT
+    }
+
+    private fun localDate(epochMillis: Long, zone: ZoneId): LocalDate =
+        Instant.ofEpochMilli(epochMillis).atZone(zone).toLocalDate()
+}

--- a/core-data/src/main/kotlin/in/jphe/storyvox/data/repository/stats/ListeningStatsRepository.kt
+++ b/core-data/src/main/kotlin/in/jphe/storyvox/data/repository/stats/ListeningStatsRepository.kt
@@ -1,0 +1,55 @@
+package `in`.jphe.storyvox.data.repository.stats
+
+import `in`.jphe.storyvox.data.db.dao.ListeningStatsDao
+import java.time.Instant
+import java.time.ZoneId
+import javax.inject.Inject
+import javax.inject.Singleton
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+
+/**
+ * Issue #1235 — one-shot source for the listening-statistics dashboard.
+ *
+ * Snapshot semantics on purpose: a stats screen is opened occasionally
+ * and read top-to-bottom, so a single suspend load is simpler and more
+ * deterministic than wiring a dozen reactive `Flow`s together. The
+ * caller (the ViewModel) re-loads on each visit.
+ */
+interface ListeningStatsRepository {
+
+    /**
+     * Compute the current snapshot. [now] / [zone] are injectable so the
+     * "today", "this week", streak, and time-of-day buckets are testable
+     * against a fixed clock; production callers pass the system clock.
+     */
+    suspend fun snapshot(
+        now: Instant = Instant.now(),
+        zone: ZoneId = ZoneId.systemDefault(),
+    ): ListeningStats
+}
+
+@Singleton
+class ListeningStatsRepositoryImpl @Inject constructor(
+    private val dao: ListeningStatsDao,
+) : ListeningStatsRepository {
+
+    override suspend fun snapshot(now: Instant, zone: ZoneId): ListeningStats =
+        withContext(Dispatchers.IO) {
+            // Sequential reads: ~7 cheap aggregate queries on a small,
+            // single-connection DB. Not worth parallelizing for a screen
+            // the user opens by hand.
+            ListeningStatsCalculator.assemble(
+                chaptersOpened = dao.chaptersOpened(),
+                chaptersFinished = dao.chaptersFinished(),
+                booksCompleted = dao.booksCompleted(),
+                booksStarted = dao.booksStarted(),
+                wordsRead = dao.wordsInFinishedChapters(),
+                totalEstimatedMs = dao.estimatedFinishedMs(),
+                perSource = dao.perSourceFinished(),
+                activity = dao.activityRows(),
+                now = now,
+                zone = zone,
+            )
+        }
+}

--- a/core-data/src/test/kotlin/in/jphe/storyvox/data/db/dao/ListeningStatsDaoTest.kt
+++ b/core-data/src/test/kotlin/in/jphe/storyvox/data/db/dao/ListeningStatsDaoTest.kt
@@ -1,0 +1,204 @@
+package `in`.jphe.storyvox.data.db.dao
+
+import android.content.Context
+import androidx.room.Room
+import androidx.test.core.app.ApplicationProvider
+import `in`.jphe.storyvox.data.db.StoryvoxDatabase
+import `in`.jphe.storyvox.data.db.entity.Chapter
+import `in`.jphe.storyvox.data.db.entity.ChapterHistory
+import `in`.jphe.storyvox.data.db.entity.Fiction
+import `in`.jphe.storyvox.data.db.entity.PlaybackPosition
+import kotlinx.coroutines.test.runTest
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+
+/**
+ * Issue #1235 — Room+Robolectric test for [ListeningStatsDao].
+ *
+ * The DAO is pure SQL aggregation over `chapter_history` +
+ * `playback_position` + `fiction` + `chapter`; a typo in a JOIN
+ * condition or a `HAVING` clause compiles fine and silently returns
+ * wrong numbers, so the aggregates are the valuable surface to pin.
+ */
+@RunWith(RobolectricTestRunner::class)
+// SDK pin matches PlaybackDaoTest (#1132) — Robolectric 4.16.1 ceilings at API 36.
+@Config(manifest = Config.NONE, sdk = [36])
+class ListeningStatsDaoTest {
+
+    private lateinit var db: StoryvoxDatabase
+    private lateinit var stats: ListeningStatsDao
+    private lateinit var fictionDao: FictionDao
+    private lateinit var chapterDao: ChapterDao
+    private lateinit var historyDao: ChapterHistoryDao
+    private lateinit var playbackDao: PlaybackDao
+
+    private fun fiction(
+        id: String,
+        sourceId: String = "royalroad",
+        chapterCount: Int = 0,
+    ) = Fiction(
+        id = id,
+        sourceId = sourceId,
+        title = "Title $id",
+        author = "Author",
+        firstSeenAt = 0L,
+        metadataFetchedAt = 0L,
+        chapterCount = chapterCount,
+        inLibrary = true,
+    )
+
+    private fun chapter(
+        id: String,
+        fictionId: String,
+        index: Int = 0,
+        wordCount: Int? = 100,
+    ) = Chapter(
+        id = id,
+        fictionId = fictionId,
+        sourceChapterId = "src-$id",
+        index = index,
+        title = "Ch $id",
+        wordCount = wordCount,
+    )
+
+    private suspend fun seedChapter(
+        chapterId: String,
+        fictionId: String,
+        index: Int,
+        wordCount: Int?,
+        completed: Boolean,
+        openedAt: Long,
+        durationMs: Long?,
+    ) {
+        chapterDao.upsert(chapter(chapterId, fictionId, index, wordCount))
+        historyDao.upsert(
+            ChapterHistory(
+                fictionId = fictionId,
+                chapterId = chapterId,
+                openedAt = openedAt,
+                completed = completed,
+            ),
+        )
+        if (durationMs != null) {
+            playbackDao.upsert(
+                PlaybackPosition(
+                    fictionId = fictionId,
+                    chapterId = chapterId,
+                    durationEstimateMs = durationMs,
+                    updatedAt = openedAt,
+                ),
+            )
+        }
+    }
+
+    @Before
+    fun setUp() {
+        val ctx = ApplicationProvider.getApplicationContext<Context>()
+        db = Room.inMemoryDatabaseBuilder(ctx, StoryvoxDatabase::class.java)
+            .allowMainThreadQueries()
+            .build()
+        stats = db.listeningStatsDao()
+        fictionDao = db.fictionDao()
+        chapterDao = db.chapterDao()
+        historyDao = db.chapterHistoryDao()
+        playbackDao = db.playbackDao()
+    }
+
+    @After
+    fun tearDown() = db.close()
+
+    /**
+     * A populated library:
+     *  - f1 (royalroad, 2 chapters): both finished, both with durations → a finished book.
+     *  - f2 (gutenberg, 3 chapters): 1 finished, 1 opened-not-finished → started, not finished.
+     */
+    private suspend fun seedLibrary() {
+        fictionDao.upsert(fiction("f1", sourceId = "royalroad", chapterCount = 2))
+        fictionDao.upsert(fiction("f2", sourceId = "gutenberg", chapterCount = 3))
+        seedChapter("c1", "f1", 0, wordCount = 100, completed = true, openedAt = 1_000L, durationMs = 600_000L)
+        seedChapter("c2", "f1", 1, wordCount = 200, completed = true, openedAt = 2_000L, durationMs = 300_000L)
+        seedChapter("c3", "f2", 0, wordCount = 50, completed = true, openedAt = 3_000L, durationMs = 1_200_000L)
+        seedChapter("c4", "f2", 1, wordCount = 999, completed = false, openedAt = 4_000L, durationMs = 0L)
+    }
+
+    @Test
+    fun `counts and sums aggregate finished chapters correctly`() = runTest {
+        seedLibrary()
+        assertEquals(4, stats.chaptersOpened())
+        assertEquals(3, stats.chaptersFinished())
+        assertEquals(2, stats.booksStarted())
+        // c1 + c2 + c3 durations; c4 isn't finished so it's excluded.
+        assertEquals(2_100_000L, stats.estimatedFinishedMs())
+        // 100 + 200 + 50; c4's 999 is excluded (not finished).
+        assertEquals(350L, stats.wordsInFinishedChapters())
+    }
+
+    @Test
+    fun `books completed counts only fully-finished known-length fictions`() = runTest {
+        seedLibrary()
+        // f1: 2/2 finished → counts. f2: 1/3 finished → doesn't.
+        assertEquals(1, stats.booksCompleted())
+    }
+
+    @Test
+    fun `books completed ignores placeholder fictions with unknown length`() = runTest {
+        // chapterCount = 0 (a synced "Loading…" placeholder) must never
+        // count as a finished book even if its one cached chapter is done.
+        fictionDao.upsert(fiction("p1", chapterCount = 0))
+        seedChapter("pc1", "p1", 0, wordCount = 10, completed = true, openedAt = 10L, durationMs = 100L)
+        assertEquals(0, stats.booksCompleted())
+    }
+
+    @Test
+    fun `books completed tolerates a chapter count that shrank below finished`() = runTest {
+        // Source now reports 1 chapter but the user finished 2 before the
+        // recount — `>=` keeps it counted as finished.
+        fictionDao.upsert(fiction("f3", chapterCount = 1))
+        seedChapter("c5", "f3", 0, wordCount = 10, completed = true, openedAt = 10L, durationMs = 100L)
+        seedChapter("c6", "f3", 1, wordCount = 10, completed = true, openedAt = 20L, durationMs = 100L)
+        assertEquals(1, stats.booksCompleted())
+    }
+
+    @Test
+    fun `per-source breakdown groups and orders by finished count`() = runTest {
+        seedLibrary()
+        val rows = stats.perSourceFinished()
+        assertEquals(2, rows.size)
+        // royalroad has 2 finished chapters → first; gutenberg 1 → second.
+        assertEquals("royalroad", rows[0].sourceId)
+        assertEquals(2, rows[0].finishedChapters)
+        assertEquals(900_000L, rows[0].estimatedMs)
+        assertEquals("gutenberg", rows[1].sourceId)
+        assertEquals(1, rows[1].finishedChapters)
+        assertEquals(1_200_000L, rows[1].estimatedMs)
+    }
+
+    @Test
+    fun `activity rows project every history entry ordered by openedAt`() = runTest {
+        seedLibrary()
+        val rows = stats.activityRows()
+        assertEquals(4, rows.size)
+        assertEquals(listOf(1_000L, 2_000L, 3_000L, 4_000L), rows.map { it.openedAt })
+        // The not-finished c4 carries its completed flag and a 0 duration.
+        val c4 = rows.last()
+        assertEquals(false, c4.completed)
+        assertEquals(0L, c4.durationEstimateMs)
+    }
+
+    @Test
+    fun `empty database returns zeroes, not nulls`() = runTest {
+        assertEquals(0, stats.chaptersOpened())
+        assertEquals(0, stats.chaptersFinished())
+        assertEquals(0, stats.booksStarted())
+        assertEquals(0L, stats.estimatedFinishedMs())
+        assertEquals(0L, stats.wordsInFinishedChapters())
+        assertEquals(0, stats.booksCompleted())
+        assertEquals(emptyList<SourceStatRow>(), stats.perSourceFinished())
+        assertEquals(emptyList<ActivityRow>(), stats.activityRows())
+    }
+}

--- a/core-data/src/test/kotlin/in/jphe/storyvox/data/repository/stats/ListeningStatsCalculatorTest.kt
+++ b/core-data/src/test/kotlin/in/jphe/storyvox/data/repository/stats/ListeningStatsCalculatorTest.kt
@@ -1,0 +1,190 @@
+package `in`.jphe.storyvox.data.repository.stats
+
+import `in`.jphe.storyvox.data.db.dao.ActivityRow
+import `in`.jphe.storyvox.data.db.dao.SourceStatRow
+import java.time.Instant
+import java.time.LocalDate
+import java.time.ZoneId
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+/**
+ * Issue #1235 — pure calendar/aggregation math for the listening-stats
+ * dashboard. Everything time-dependent is injected (a fixed [Instant] +
+ * UTC [ZoneId]) so the day/hour buckets are exact and deterministic, no
+ * Robolectric needed.
+ */
+class ListeningStatsCalculatorTest {
+
+    private val zone: ZoneId = ZoneId.of("UTC")
+    private fun millis(iso: String): Long = Instant.parse(iso).toEpochMilli()
+
+    // ── currentStreak ──────────────────────────────────────────────────
+
+    @Test
+    fun `current streak counts back from today`() {
+        val today = LocalDate.of(2026, 6, 28)
+        val days = setOf(today, today.minusDays(1), today.minusDays(2))
+        assertEquals(3, ListeningStatsCalculator.currentStreak(days, today))
+    }
+
+    @Test
+    fun `current streak stops at the first gap`() {
+        val today = LocalDate.of(2026, 6, 28)
+        val days = setOf(today, today.minusDays(1), today.minusDays(3))
+        assertEquals(2, ListeningStatsCalculator.currentStreak(days, today))
+    }
+
+    @Test
+    fun `current streak stays live when today is idle but yesterday was active`() {
+        val today = LocalDate.of(2026, 6, 28)
+        val days = setOf(today.minusDays(1), today.minusDays(2))
+        assertEquals(2, ListeningStatsCalculator.currentStreak(days, today))
+    }
+
+    @Test
+    fun `current streak is zero when neither today nor yesterday is active`() {
+        val today = LocalDate.of(2026, 6, 28)
+        val days = setOf(today.minusDays(2), today.minusDays(3))
+        assertEquals(0, ListeningStatsCalculator.currentStreak(days, today))
+    }
+
+    @Test
+    fun `current streak is zero with no active days`() {
+        assertEquals(0, ListeningStatsCalculator.currentStreak(emptySet(), LocalDate.of(2026, 6, 28)))
+    }
+
+    // ── longestStreak ──────────────────────────────────────────────────
+
+    @Test
+    fun `longest streak finds the best run anywhere in history`() {
+        val d = LocalDate.of(2026, 6, 1)
+        val days = setOf(d, d.plusDays(1), d.plusDays(2), d.plusDays(5), d.plusDays(6))
+        assertEquals(3, ListeningStatsCalculator.longestStreak(days))
+    }
+
+    @Test
+    fun `longest streak of isolated days is one`() {
+        val d = LocalDate.of(2026, 6, 1)
+        assertEquals(1, ListeningStatsCalculator.longestStreak(setOf(d, d.plusDays(2), d.plusDays(4))))
+    }
+
+    @Test
+    fun `longest streak of empty history is zero`() {
+        assertEquals(0, ListeningStatsCalculator.longestStreak(emptySet()))
+    }
+
+    // ── dayPartOf ──────────────────────────────────────────────────────
+
+    @Test
+    fun `day part boundaries map to the four buckets`() {
+        assertEquals(DayPart.NIGHT, ListeningStatsCalculator.dayPartOf(4))
+        assertEquals(DayPart.MORNING, ListeningStatsCalculator.dayPartOf(5))
+        assertEquals(DayPart.MORNING, ListeningStatsCalculator.dayPartOf(11))
+        assertEquals(DayPart.AFTERNOON, ListeningStatsCalculator.dayPartOf(12))
+        assertEquals(DayPart.AFTERNOON, ListeningStatsCalculator.dayPartOf(16))
+        assertEquals(DayPart.EVENING, ListeningStatsCalculator.dayPartOf(17))
+        assertEquals(DayPart.EVENING, ListeningStatsCalculator.dayPartOf(21))
+        assertEquals(DayPart.NIGHT, ListeningStatsCalculator.dayPartOf(22))
+        assertEquals(DayPart.NIGHT, ListeningStatsCalculator.dayPartOf(0))
+    }
+
+    // ── assemble ───────────────────────────────────────────────────────
+
+    @Test
+    fun `assemble buckets today, week, trend, time-of-day and streaks`() {
+        val now = Instant.parse("2026-06-28T12:00:00Z")
+        val activity = listOf(
+            // today (Sun 2026-06-28)
+            ActivityRow(millis("2026-06-28T10:00:00Z"), completed = true, durationEstimateMs = 600_000),
+            ActivityRow(millis("2026-06-28T20:00:00Z"), completed = true, durationEstimateMs = 300_000),
+            ActivityRow(millis("2026-06-28T11:00:00Z"), completed = false, durationEstimateMs = 0), // active day, no time
+            // earlier in the 7-day window
+            ActivityRow(millis("2026-06-27T14:00:00Z"), completed = true, durationEstimateMs = 1_200_000),
+            ActivityRow(millis("2026-06-25T08:00:00Z"), completed = true, durationEstimateMs = 600_000),
+            // outside the 7-day window — counts toward time-of-day + longest streak inputs but NOT week
+            ActivityRow(millis("2026-06-18T23:00:00Z"), completed = true, durationEstimateMs = 9_999_999),
+        )
+        val perSource = listOf(
+            SourceStatRow("royalroad", finishedChapters = 4, estimatedMs = 2_700_000),
+            SourceStatRow("gutenberg", finishedChapters = 1, estimatedMs = 9_999_999),
+        )
+
+        val stats = ListeningStatsCalculator.assemble(
+            chaptersOpened = 6,
+            chaptersFinished = 5,
+            booksCompleted = 1,
+            booksStarted = 2,
+            wordsRead = 12_345,
+            totalEstimatedMs = 13_399_999,
+            perSource = perSource,
+            activity = activity,
+            now = now,
+            zone = zone,
+        )
+
+        // Scalars pass through untouched.
+        assertEquals(6, stats.chaptersOpened)
+        assertEquals(5, stats.chaptersFinished)
+        assertEquals(1, stats.booksCompleted)
+        assertEquals(2, stats.booksStarted)
+        assertEquals(12_345L, stats.wordsRead)
+        assertEquals(13_399_999L, stats.totalEstimatedMs)
+
+        // Today = the two completed rows dated 06-28 (the incomplete one adds 0).
+        assertEquals(900_000L, stats.todayEstimatedMs)
+        // Week = today + 06-27 + 06-25; the 06-18 row is outside the window.
+        assertEquals(2_700_000L, stats.weekEstimatedMs)
+
+        // Trend = 7 days, 06-22 .. 06-28, oldest first.
+        assertEquals(ListeningStatsCalculator.TREND_DAYS, stats.weeklyActivity.size)
+        assertEquals(LocalDate.of(2026, 6, 22), stats.weeklyActivity.first().date)
+        assertEquals(LocalDate.of(2026, 6, 28), stats.weeklyActivity.last().date)
+        val byDate = stats.weeklyActivity.associateBy { it.date }
+        assertEquals(2, byDate[LocalDate.of(2026, 6, 28)]!!.finishedChapters)
+        assertEquals(1, byDate[LocalDate.of(2026, 6, 27)]!!.finishedChapters)
+        assertEquals(1, byDate[LocalDate.of(2026, 6, 25)]!!.finishedChapters)
+        assertEquals(0, byDate[LocalDate.of(2026, 6, 24)]!!.finishedChapters)
+
+        // Time of day over all FINISHED rows: morning 10:00 + 08:00 = 2,
+        // afternoon 14:00 = 1, evening 20:00 = 1, night 23:00 = 1.
+        val tod = stats.timeOfDay.associate { it.part to it.finishedChapters }
+        assertEquals(2, tod[DayPart.MORNING])
+        assertEquals(1, tod[DayPart.AFTERNOON])
+        assertEquals(1, tod[DayPart.EVENING])
+        assertEquals(1, tod[DayPart.NIGHT])
+
+        // Active days {06-18, 06-25, 06-27, 06-28}: current = 06-28 + 06-27 = 2.
+        assertEquals(2, stats.currentStreakDays)
+        assertEquals(2, stats.longestStreakDays)
+
+        // Per-source mapped 1:1, order preserved.
+        assertEquals(2, stats.perSource.size)
+        assertEquals("royalroad", stats.perSource.first().sourceId)
+        assertEquals(4, stats.perSource.first().finishedChapters)
+    }
+
+    @Test
+    fun `assemble of empty history yields a zeroed snapshot with a full week scaffold`() {
+        val stats = ListeningStatsCalculator.assemble(
+            chaptersOpened = 0,
+            chaptersFinished = 0,
+            booksCompleted = 0,
+            booksStarted = 0,
+            wordsRead = 0,
+            totalEstimatedMs = 0,
+            perSource = emptyList(),
+            activity = emptyList(),
+            now = Instant.parse("2026-06-28T12:00:00Z"),
+            zone = zone,
+        )
+        assertEquals(0, stats.currentStreakDays)
+        assertEquals(0L, stats.weekEstimatedMs)
+        // The trend always scaffolds all 7 days (each zeroed) so the chart axis is stable.
+        assertEquals(7, stats.weeklyActivity.size)
+        assertEquals(0, stats.weeklyActivity.sumOf { it.finishedChapters })
+        // All four day-parts always present.
+        assertEquals(4, stats.timeOfDay.size)
+        assertEquals(false, stats.hasData)
+    }
+}

--- a/feature/src/main/kotlin/in/jphe/storyvox/feature/settings/SettingsHubScreen.kt
+++ b/feature/src/main/kotlin/in/jphe/storyvox/feature/settings/SettingsHubScreen.kt
@@ -23,6 +23,7 @@ import androidx.compose.material.icons.outlined.ChevronRight
 import androidx.compose.material.icons.outlined.Cloud
 import androidx.compose.material.icons.outlined.Extension
 import androidx.compose.material.icons.outlined.Info
+import androidx.compose.material.icons.outlined.Insights
 import androidx.compose.material.icons.outlined.RecordVoiceOver
 import androidx.compose.material.icons.outlined.Search
 import androidx.compose.material.icons.outlined.Speed
@@ -87,6 +88,7 @@ private fun matchesHubQuery(query: String, title: String, subtitle: String): Boo
  *  - Voice & Playback → [VoiceAndPlaybackSettingsScreen]
  *  - Voice library → [VoiceLibraryScreen][in.jphe.storyvox.feature.voicelibrary.VoiceLibraryScreen]
  *  - Reading → [ReadingSettingsScreen]
+ *  - Listening stats → [ListeningStatsScreen][in.jphe.storyvox.feature.stats.ListeningStatsScreen]
  *  - Performance → [PerformanceSettingsScreen]
  *  - AI → [AiSettingsScreen]
  *  - Accessibility → [AccessibilitySettingsScreen] (Phase 1 scaffold)
@@ -149,6 +151,12 @@ fun SettingsHubScreen(
      * [`in.jphe.storyvox.navigation.StoryvoxNavHost`].
      */
     onOpenAdvanced: () -> Unit = {},
+    /**
+     * Issue #1235 — Listening stats dashboard. Default no-op so existing
+     * callers / smoke tests compile without wiring it; production wiring
+     * lives in [`in.jphe.storyvox.navigation.StoryvoxNavHost`].
+     */
+    onOpenStats: () -> Unit = {},
 ) {
     val spacing = LocalSpacing.current
     var query by remember { mutableStateOf("") }
@@ -229,6 +237,15 @@ fun SettingsHubScreen(
                     title = stringResource(R.string.settings_hub_reading_title),
                     subtitle = stringResource(R.string.settings_hub_reading_subtitle),
                     onClick = onOpenReading,
+                )
+                // Issue #1235 — Listening stats dashboard. Sits next to
+                // Reading: both are about the user's own reading, one the
+                // knobs, the other the retrospective.
+                SettingsHubRow(
+                    icon = Icons.Outlined.Insights,
+                    title = stringResource(R.string.settings_hub_stats_title),
+                    subtitle = stringResource(R.string.settings_hub_stats_subtitle),
+                    onClick = onOpenStats,
                 )
                 // v0.5.59 (#cover-style-toggle) — Appearance. Book-
                 // cover fallback style (Monogram / Branded / Cover
@@ -410,6 +427,8 @@ val SettingsHubSections: List<SettingsHubSection> = listOf(
     SettingsHubSection("Voice & Playback", "Voice, speed, cadence, pitch."),
     SettingsHubSection("Voice library", "Browse and switch between available voices."),
     SettingsHubSection("Reading", "Theme, sleep timer."),
+    // Issue #1235 — Listening stats dashboard.
+    SettingsHubSection("Listening stats", "Time listened, streaks, books finished."),
     // v0.5.59 (#cover-style-toggle) — Appearance.
     SettingsHubSection("Appearance", "Book cover style."),
     SettingsHubSection("Performance", "Buffer, parallel synth, decoder choice."),

--- a/feature/src/main/kotlin/in/jphe/storyvox/feature/stats/ListeningStatsScreen.kt
+++ b/feature/src/main/kotlin/in/jphe/storyvox/feature/stats/ListeningStatsScreen.kt
@@ -1,0 +1,490 @@
+package `in`.jphe.storyvox.feature.stats
+
+import android.content.Context
+import android.content.Intent
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material.icons.automirrored.outlined.MenuBook
+import androidx.compose.material.icons.outlined.AutoStories
+import androidx.compose.material.icons.outlined.Bookmark
+import androidx.compose.material.icons.outlined.Notes
+import androidx.compose.material.icons.outlined.Schedule
+import androidx.compose.material.icons.outlined.Share
+import androidx.compose.material3.Card
+import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.CenterAlignedTopAppBar
+import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.semantics.heading
+import androidx.compose.ui.semantics.semantics
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.unit.dp
+import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import `in`.jphe.storyvox.data.repository.stats.ListeningStats
+import `in`.jphe.storyvox.data.repository.stats.SourceShare
+import `in`.jphe.storyvox.feature.R
+import `in`.jphe.storyvox.ui.theme.LocalSpacing
+
+/**
+ * Issue #1235 — "Listening Stats" dashboard.
+ *
+ * Reached from the Settings hub. Card-based layout in the app's brass
+ * surface idiom (`surfaceContainerHigh` + `shapes.large`, mirroring
+ * `SettingsGroupCard` / the Library resume card). All time figures are
+ * estimates derived from finished-chapter durations — every one is
+ * prefixed "≈" and a footnote explains why (see `ListeningStatsDao`).
+ */
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun ListeningStatsScreen(
+    onBack: () -> Unit,
+    modifier: Modifier = Modifier,
+    viewModel: ListeningStatsViewModel = hiltViewModel(),
+) {
+    val uiState by viewModel.uiState.collectAsStateWithLifecycle()
+    val context = LocalContext.current
+    val appName = stringResource(R.string.stats_app_name)
+    val chooserTitle = stringResource(R.string.stats_share_chooser)
+
+    val shareableStats = (uiState as? ListeningStatsUiState.Loaded)
+        ?.stats
+        ?.takeIf { it.hasData }
+
+    Scaffold(
+        modifier = modifier,
+        topBar = {
+            CenterAlignedTopAppBar(
+                title = {
+                    Text(
+                        text = stringResource(R.string.stats_title),
+                        style = MaterialTheme.typography.titleMedium,
+                        // #1136 idiom — heading() so TalkBack heading-nav lands here.
+                        modifier = Modifier.semantics { heading() },
+                    )
+                },
+                navigationIcon = {
+                    IconButton(onClick = onBack) {
+                        Icon(
+                            Icons.AutoMirrored.Filled.ArrowBack,
+                            contentDescription = stringResource(R.string.stats_back),
+                        )
+                    }
+                },
+                actions = {
+                    if (shareableStats != null) {
+                        IconButton(
+                            onClick = {
+                                shareStatsText(
+                                    context = context,
+                                    text = StatsFormatting.shareSummary(shareableStats, appName),
+                                    chooserTitle = chooserTitle,
+                                )
+                            },
+                        ) {
+                            Icon(
+                                Icons.Outlined.Share,
+                                contentDescription = stringResource(R.string.stats_share),
+                            )
+                        }
+                    }
+                },
+            )
+        },
+    ) { padding ->
+        when (val state = uiState) {
+            is ListeningStatsUiState.Loading ->
+                Box(
+                    Modifier
+                        .fillMaxSize()
+                        .padding(padding),
+                    contentAlignment = Alignment.Center,
+                ) { CircularProgressIndicator() }
+
+            is ListeningStatsUiState.Loaded ->
+                if (state.stats.hasData) {
+                    StatsBody(stats = state.stats, contentPadding = padding)
+                } else {
+                    EmptyStats(contentPadding = padding)
+                }
+        }
+    }
+}
+
+@Composable
+private fun StatsBody(
+    stats: ListeningStats,
+    contentPadding: androidx.compose.foundation.layout.PaddingValues,
+) {
+    val spacing = LocalSpacing.current
+    Column(
+        modifier = Modifier
+            .fillMaxSize()
+            .padding(contentPadding)
+            .verticalScroll(rememberScrollState())
+            .padding(spacing.md),
+        verticalArrangement = Arrangement.spacedBy(spacing.lg),
+    ) {
+        HeroCard(stats)
+        StatTileGrid(stats)
+        WeeklyCard(stats)
+        if (stats.perSource.isNotEmpty()) SourceCard(stats)
+        TimeOfDayCard(stats)
+        Text(
+            text = stringResource(R.string.stats_estimate_note),
+            style = MaterialTheme.typography.bodySmall,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+            modifier = Modifier.fillMaxWidth(),
+        )
+    }
+}
+
+@Composable
+private fun HeroCard(stats: ListeningStats) {
+    StatsCard {
+        Row(verticalAlignment = Alignment.CenterVertically) {
+            Icon(
+                Icons.Outlined.Schedule,
+                contentDescription = null,
+                tint = MaterialTheme.colorScheme.primary,
+                modifier = Modifier.size(28.dp),
+            )
+            Spacer(Modifier.width(12.dp))
+            Column {
+                Text(
+                    text = stringResource(R.string.stats_total_time_label),
+                    style = MaterialTheme.typography.labelLarge,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                )
+                Text(
+                    text = "≈ " + StatsFormatting.formatDuration(stats.totalEstimatedMs),
+                    style = MaterialTheme.typography.displaySmall,
+                    fontWeight = FontWeight.SemiBold,
+                    color = MaterialTheme.colorScheme.onSurface,
+                )
+            }
+        }
+        if (stats.currentStreakDays > 0) {
+            Spacer(Modifier.height(12.dp))
+            Text(
+                text = stringResource(
+                    R.string.stats_streak_line,
+                    stats.currentStreakDays,
+                    stats.longestStreakDays,
+                ),
+                style = MaterialTheme.typography.bodyMedium,
+                color = MaterialTheme.colorScheme.primary,
+                fontWeight = FontWeight.Medium,
+            )
+        }
+    }
+}
+
+@Composable
+private fun StatTileGrid(stats: ListeningStats) {
+    val spacing = LocalSpacing.current
+    Column(verticalArrangement = Arrangement.spacedBy(spacing.sm)) {
+        Row(horizontalArrangement = Arrangement.spacedBy(spacing.sm)) {
+            StatTile(
+                modifier = Modifier.weight(1f),
+                icon = Icons.Outlined.AutoStories,
+                value = StatsFormatting.formatCompactNumber(stats.booksCompleted.toLong()),
+                label = stringResource(R.string.stats_books_finished),
+            )
+            StatTile(
+                modifier = Modifier.weight(1f),
+                icon = Icons.AutoMirrored.Outlined.MenuBook,
+                value = StatsFormatting.formatCompactNumber(stats.chaptersFinished.toLong()),
+                label = stringResource(R.string.stats_chapters_read),
+            )
+        }
+        Row(horizontalArrangement = Arrangement.spacedBy(spacing.sm)) {
+            StatTile(
+                modifier = Modifier.weight(1f),
+                icon = Icons.Outlined.Notes,
+                value = StatsFormatting.formatCompactNumber(stats.wordsRead),
+                label = stringResource(R.string.stats_words_read),
+            )
+            StatTile(
+                modifier = Modifier.weight(1f),
+                icon = Icons.Outlined.Bookmark,
+                value = StatsFormatting.formatCompactNumber(stats.booksStarted.toLong()),
+                label = stringResource(R.string.stats_books_started),
+            )
+        }
+    }
+}
+
+@Composable
+private fun WeeklyCard(stats: ListeningStats) {
+    StatsCard {
+        SectionTitle(stringResource(R.string.stats_this_week_title))
+        Spacer(Modifier.height(12.dp))
+        WeeklyActivityChart(days = stats.weeklyActivity)
+        Spacer(Modifier.height(16.dp))
+        Row(Modifier.fillMaxWidth()) {
+            InlineMetric(
+                modifier = Modifier.weight(1f),
+                label = stringResource(R.string.stats_today),
+                value = "≈ " + StatsFormatting.formatDuration(stats.todayEstimatedMs),
+            )
+            InlineMetric(
+                modifier = Modifier.weight(1f),
+                label = stringResource(R.string.stats_last_seven_days),
+                value = "≈ " + StatsFormatting.formatDuration(stats.weekEstimatedMs),
+            )
+        }
+    }
+}
+
+@Composable
+private fun SourceCard(stats: ListeningStats) {
+    val displayShares = collapseSources(stats.perSource)
+    val palette = donutPalette()
+    StatsCard {
+        SectionTitle(stringResource(R.string.stats_by_source_title))
+        Spacer(Modifier.height(12.dp))
+        Row(verticalAlignment = Alignment.CenterVertically) {
+            SourceDonut(
+                shares = displayShares,
+                sliceColors = palette,
+            )
+            Spacer(Modifier.width(16.dp))
+            Column(
+                modifier = Modifier.weight(1f),
+                verticalArrangement = Arrangement.spacedBy(8.dp),
+            ) {
+                displayShares.forEachIndexed { i, share ->
+                    LegendRow(
+                        color = palette[i % palette.size],
+                        label = sourceLabel(share),
+                        value = StatsFormatting.formatCompactNumber(share.finishedChapters.toLong()),
+                    )
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun TimeOfDayCard(stats: ListeningStats) {
+    val maxCount = stats.timeOfDay.maxOfOrNull { it.finishedChapters } ?: 0
+    StatsCard {
+        SectionTitle(stringResource(R.string.stats_time_of_day_title))
+        Spacer(Modifier.height(12.dp))
+        Column(verticalArrangement = Arrangement.spacedBy(10.dp)) {
+            stats.timeOfDay.forEach { bucket ->
+                TimeOfDayRow(bucket = bucket, maxCount = maxCount)
+            }
+        }
+    }
+}
+
+// ── Small shared pieces ────────────────────────────────────────────────
+
+/** Brass group card matching the Settings / Library surface idiom. */
+@Composable
+private fun StatsCard(content: @Composable () -> Unit) {
+    Card(
+        modifier = Modifier.fillMaxWidth(),
+        colors = CardDefaults.cardColors(
+            containerColor = MaterialTheme.colorScheme.surfaceContainerHigh,
+        ),
+        shape = MaterialTheme.shapes.large,
+    ) {
+        Column(Modifier.padding(LocalSpacing.current.md)) { content() }
+    }
+}
+
+@Composable
+private fun SectionTitle(text: String) {
+    Text(
+        text = text,
+        style = MaterialTheme.typography.titleSmall,
+        fontWeight = FontWeight.SemiBold,
+        color = MaterialTheme.colorScheme.onSurface,
+        modifier = Modifier.semantics { heading() },
+    )
+}
+
+@Composable
+private fun StatTile(
+    icon: ImageVector,
+    value: String,
+    label: String,
+    modifier: Modifier = Modifier,
+) {
+    Card(
+        modifier = modifier,
+        colors = CardDefaults.cardColors(
+            containerColor = MaterialTheme.colorScheme.surfaceContainerHigh,
+        ),
+        shape = MaterialTheme.shapes.large,
+    ) {
+        Column(Modifier.padding(LocalSpacing.current.md)) {
+            Icon(
+                icon,
+                contentDescription = null,
+                tint = MaterialTheme.colorScheme.primary,
+                modifier = Modifier.size(22.dp),
+            )
+            Spacer(Modifier.height(8.dp))
+            Text(
+                text = value,
+                style = MaterialTheme.typography.headlineSmall,
+                fontWeight = FontWeight.SemiBold,
+                color = MaterialTheme.colorScheme.onSurface,
+            )
+            Text(
+                text = label,
+                style = MaterialTheme.typography.bodySmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
+        }
+    }
+}
+
+@Composable
+private fun InlineMetric(
+    label: String,
+    value: String,
+    modifier: Modifier = Modifier,
+) {
+    Column(modifier) {
+        Text(
+            text = value,
+            style = MaterialTheme.typography.titleMedium,
+            fontWeight = FontWeight.SemiBold,
+            color = MaterialTheme.colorScheme.onSurface,
+        )
+        Text(
+            text = label,
+            style = MaterialTheme.typography.bodySmall,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+        )
+    }
+}
+
+@Composable
+private fun EmptyStats(contentPadding: androidx.compose.foundation.layout.PaddingValues) {
+    Column(
+        modifier = Modifier
+            .fillMaxSize()
+            .padding(contentPadding)
+            .padding(LocalSpacing.current.xl),
+        horizontalAlignment = Alignment.CenterHorizontally,
+        verticalArrangement = Arrangement.Center,
+    ) {
+        Icon(
+            Icons.Outlined.AutoStories,
+            contentDescription = null,
+            tint = MaterialTheme.colorScheme.primary,
+            modifier = Modifier.size(48.dp),
+        )
+        Spacer(Modifier.height(16.dp))
+        Text(
+            text = stringResource(R.string.stats_empty_title),
+            style = MaterialTheme.typography.titleMedium,
+            color = MaterialTheme.colorScheme.onSurface,
+            textAlign = TextAlign.Center,
+        )
+        Spacer(Modifier.height(8.dp))
+        Text(
+            text = stringResource(R.string.stats_empty_body),
+            style = MaterialTheme.typography.bodyMedium,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+            textAlign = TextAlign.Center,
+        )
+    }
+}
+
+// ── Pure-ish helpers used only by this screen ──────────────────────────
+
+/** Theme-derived, visually-distinct palette for the donut + legend. */
+@Composable
+private fun donutPalette(): List<Color> {
+    val cs = MaterialTheme.colorScheme
+    return listOf(
+        cs.primary,
+        cs.tertiary,
+        cs.secondary,
+        cs.primary.copy(alpha = 0.55f),
+        cs.tertiary.copy(alpha = 0.55f),
+        cs.onSurfaceVariant,
+    )
+}
+
+@Composable
+private fun sourceLabel(share: SourceShare): String =
+    if (share.sourceId == OTHER_SOURCE_ID) {
+        stringResource(R.string.stats_other_sources)
+    } else {
+        StatsFormatting.sourceDisplayName(share.sourceId)
+    }
+
+/**
+ * Collapse a long source list to the top [MAX_DONUT_SLICES] - 1 sources
+ * plus a single combined "Other" slice, so the donut stays readable. A
+ * list at or under the cap passes through unchanged.
+ */
+internal fun collapseSources(shares: List<SourceShare>): List<SourceShare> {
+    if (shares.size <= MAX_DONUT_SLICES) return shares
+    val head = shares.take(MAX_DONUT_SLICES - 1)
+    val tail = shares.drop(MAX_DONUT_SLICES - 1)
+    val other = SourceShare(
+        sourceId = OTHER_SOURCE_ID,
+        finishedChapters = tail.sumOf { it.finishedChapters },
+        estimatedMs = tail.sumOf { it.estimatedMs },
+    )
+    return head + other
+}
+
+internal const val MAX_DONUT_SLICES = 6
+internal const val OTHER_SOURCE_ID = "__other__"
+
+/**
+ * Open the system share sheet for a plain-text stats summary. Mirrors
+ * the reader's `shareQuoteText` (issue #1234): `ACTION_SEND` wrapped in
+ * a chooser, `FLAG_ACTIVITY_NEW_TASK` so it launches from a Composable's
+ * non-Activity context.
+ */
+private fun shareStatsText(context: Context, text: String, chooserTitle: String) {
+    val send = Intent(Intent.ACTION_SEND).apply {
+        type = "text/plain"
+        putExtra(Intent.EXTRA_TEXT, text)
+    }
+    runCatching {
+        context.startActivity(
+            Intent.createChooser(send, chooserTitle).apply {
+                addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
+            },
+        )
+    }
+}

--- a/feature/src/main/kotlin/in/jphe/storyvox/feature/stats/ListeningStatsViewModel.kt
+++ b/feature/src/main/kotlin/in/jphe/storyvox/feature/stats/ListeningStatsViewModel.kt
@@ -1,0 +1,54 @@
+package `in`.jphe.storyvox.feature.stats
+
+import androidx.compose.runtime.Immutable
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import dagger.hilt.android.lifecycle.HiltViewModel
+import `in`.jphe.storyvox.data.repository.stats.ListeningStats
+import `in`.jphe.storyvox.data.repository.stats.ListeningStatsRepository
+import javax.inject.Inject
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.launch
+
+/**
+ * Issue #1235 — view-model for the listening-statistics dashboard.
+ *
+ * One-shot load on construction (and on [refresh]). The repository
+ * snapshot is a handful of cheap aggregate queries, so there's no need
+ * for a long-lived reactive subscription; re-opening the screen mints a
+ * fresh ViewModel and re-loads.
+ */
+@Immutable
+sealed interface ListeningStatsUiState {
+    /** Initial load — the screen shows a spinner. */
+    data object Loading : ListeningStatsUiState
+
+    /** Snapshot ready. [ListeningStats.hasData] decides full UI vs. empty state. */
+    data class Loaded(val stats: ListeningStats) : ListeningStatsUiState
+}
+
+@HiltViewModel
+class ListeningStatsViewModel @Inject constructor(
+    private val repository: ListeningStatsRepository,
+) : ViewModel() {
+
+    private val _uiState = MutableStateFlow<ListeningStatsUiState>(ListeningStatsUiState.Loading)
+    val uiState: StateFlow<ListeningStatsUiState> = _uiState.asStateFlow()
+
+    init {
+        refresh()
+    }
+
+    fun refresh() {
+        viewModelScope.launch {
+            _uiState.value = ListeningStatsUiState.Loading
+            // A query failure on a stats screen should degrade to the
+            // empty state, never crash the app — the data is informational.
+            val stats = runCatching { repository.snapshot() }
+                .getOrDefault(ListeningStats.EMPTY)
+            _uiState.value = ListeningStatsUiState.Loaded(stats)
+        }
+    }
+}

--- a/feature/src/main/kotlin/in/jphe/storyvox/feature/stats/StatsCharts.kt
+++ b/feature/src/main/kotlin/in/jphe/storyvox/feature/stats/StatsCharts.kt
@@ -1,0 +1,215 @@
+package `in`.jphe.storyvox.feature.stats
+
+import androidx.compose.foundation.Canvas
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.geometry.CornerRadius
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.geometry.Size
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.StrokeCap
+import androidx.compose.ui.graphics.drawscope.Stroke
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.unit.dp
+import `in`.jphe.storyvox.data.repository.stats.DayActivity
+import `in`.jphe.storyvox.data.repository.stats.SourceShare
+import `in`.jphe.storyvox.data.repository.stats.TimeOfDayBucket
+
+/**
+ * Issue #1235 — hand-drawn charts for the listening-stats dashboard.
+ * No external charting dependency (the issue calls this out): the
+ * weekly trend and the source breakdown are drawn with Compose
+ * [Canvas], and the time-of-day rows are plain clipped boxes. All
+ * colours come from the active [MaterialTheme] so light/dark both work.
+ */
+
+/** Vertical bar chart of finished chapters per day, oldest → newest. */
+@Composable
+fun WeeklyActivityChart(
+    days: List<DayActivity>,
+    modifier: Modifier = Modifier,
+    barColor: Color = MaterialTheme.colorScheme.primary,
+    trackColor: Color = MaterialTheme.colorScheme.surfaceVariant,
+    labelColor: Color = MaterialTheme.colorScheme.onSurfaceVariant,
+) {
+    if (days.isEmpty()) return
+    val maxChapters = (days.maxOfOrNull { it.finishedChapters } ?: 0).coerceAtLeast(1)
+    Column(modifier) {
+        Canvas(
+            modifier = Modifier
+                .fillMaxWidth()
+                .height(132.dp),
+        ) {
+            val slot = size.width / days.size
+            val barWidth = slot * 0.46f
+            val gap = (slot - barWidth) / 2f
+            val radius = CornerRadius(6f, 6f)
+            val minVisible = 3.dp.toPx() // a non-zero day always shows a sliver
+            days.forEachIndexed { i, day ->
+                val left = i * slot + gap
+                // Track (full-height faint pill) for every day.
+                drawRoundRect(
+                    color = trackColor,
+                    topLeft = Offset(left, 0f),
+                    size = Size(barWidth, size.height),
+                    cornerRadius = radius,
+                )
+                if (day.finishedChapters > 0) {
+                    val frac = day.finishedChapters.toFloat() / maxChapters
+                    val barHeight = (size.height * frac).coerceAtLeast(minVisible)
+                    drawRoundRect(
+                        color = barColor,
+                        topLeft = Offset(left, size.height - barHeight),
+                        size = Size(barWidth, barHeight),
+                        cornerRadius = radius,
+                    )
+                }
+            }
+        }
+        Spacer(Modifier.height(6.dp))
+        Row(Modifier.fillMaxWidth()) {
+            days.forEach { day ->
+                Text(
+                    text = StatsFormatting.weekdayInitial(day.date.dayOfWeek.value),
+                    modifier = Modifier.weight(1f),
+                    textAlign = TextAlign.Center,
+                    style = MaterialTheme.typography.labelSmall,
+                    color = labelColor,
+                )
+            }
+        }
+    }
+}
+
+/**
+ * Donut of finished-chapter share per source. Sweep is proportional to
+ * each slice's [SourceShare.finishedChapters]; [sliceColors] is indexed
+ * positionally so the donut and the legend agree on colour.
+ */
+@Composable
+fun SourceDonut(
+    shares: List<SourceShare>,
+    sliceColors: List<Color>,
+    modifier: Modifier = Modifier,
+) {
+    if (shares.isEmpty() || sliceColors.isEmpty()) return
+    val total = shares.sumOf { it.finishedChapters }.coerceAtLeast(1)
+    Canvas(modifier.size(156.dp)) {
+        val strokePx = 30.dp.toPx()
+        val diameter = size.minDimension - strokePx
+        val topLeft = Offset((size.width - diameter) / 2f, (size.height - diameter) / 2f)
+        val arcSize = Size(diameter, diameter)
+        val stroke = Stroke(width = strokePx, cap = StrokeCap.Butt)
+        var startAngle = -90f
+        shares.forEachIndexed { i, share ->
+            val sweep = 360f * (share.finishedChapters.toFloat() / total)
+            drawArc(
+                color = sliceColors[i % sliceColors.size],
+                startAngle = startAngle,
+                sweepAngle = sweep,
+                useCenter = false,
+                topLeft = topLeft,
+                size = arcSize,
+                style = stroke,
+            )
+            startAngle += sweep
+        }
+    }
+}
+
+/** A coloured swatch + label + trailing value, for the donut legend. */
+@Composable
+fun LegendRow(
+    color: Color,
+    label: String,
+    value: String,
+    modifier: Modifier = Modifier,
+) {
+    Row(
+        modifier = modifier.fillMaxWidth(),
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        Box(
+            modifier = Modifier
+                .size(12.dp)
+                .clip(CircleShape)
+                .background(color),
+        )
+        Spacer(Modifier.width(10.dp))
+        Text(
+            text = label,
+            style = MaterialTheme.typography.bodyMedium,
+            color = MaterialTheme.colorScheme.onSurface,
+            modifier = Modifier.weight(1f),
+        )
+        Text(
+            text = value,
+            style = MaterialTheme.typography.bodyMedium,
+            fontWeight = FontWeight.SemiBold,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+        )
+    }
+}
+
+/** One labelled horizontal bar for the time-of-day histogram. */
+@Composable
+fun TimeOfDayRow(
+    bucket: TimeOfDayBucket,
+    maxCount: Int,
+    modifier: Modifier = Modifier,
+    barColor: Color = MaterialTheme.colorScheme.secondary,
+    trackColor: Color = MaterialTheme.colorScheme.surfaceVariant,
+) {
+    val frac = if (maxCount <= 0) 0f else bucket.finishedChapters.toFloat() / maxCount
+    Row(
+        modifier = modifier.fillMaxWidth(),
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        Text(
+            text = StatsFormatting.dayPartLabel(bucket.part),
+            style = MaterialTheme.typography.bodyMedium,
+            color = MaterialTheme.colorScheme.onSurface,
+            modifier = Modifier.width(88.dp),
+        )
+        Box(
+            modifier = Modifier
+                .weight(1f)
+                .height(14.dp)
+                .clip(RoundedCornerShape(7.dp))
+                .background(trackColor),
+        ) {
+            if (frac > 0f) {
+                Box(
+                    Modifier
+                        .fillMaxWidth(frac.coerceIn(0f, 1f))
+                        .height(14.dp)
+                        .background(barColor),
+                )
+            }
+        }
+        Spacer(Modifier.width(10.dp))
+        Text(
+            text = bucket.finishedChapters.toString(),
+            style = MaterialTheme.typography.bodyMedium,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+            modifier = Modifier.padding(start = 2.dp),
+        )
+    }
+}

--- a/feature/src/main/kotlin/in/jphe/storyvox/feature/stats/StatsFormatting.kt
+++ b/feature/src/main/kotlin/in/jphe/storyvox/feature/stats/StatsFormatting.kt
@@ -1,0 +1,152 @@
+package `in`.jphe.storyvox.feature.stats
+
+import `in`.jphe.storyvox.data.repository.stats.DayPart
+import `in`.jphe.storyvox.data.repository.stats.ListeningStats
+import `in`.jphe.storyvox.data.source.SourceIds
+import kotlin.math.round
+
+/**
+ * Issue #1235 — pure presentation helpers for the listening-stats
+ * dashboard. Kept free of Android/Compose imports so they're unit-
+ * tested directly in `:feature`'s JVM test source set (the module ships
+ * no Compose-test infrastructure — see SettingsSubscreenContractTest).
+ */
+object StatsFormatting {
+
+    /**
+     * Human duration: "12h 30m", "45m", "<1m" (for a non-zero sub-minute
+     * span), or "0m". The "≈" estimate marker is added by the caller, not
+     * baked in here, so the same formatter serves both estimated and
+     * exact figures.
+     */
+    fun formatDuration(ms: Long): String {
+        if (ms <= 0L) return "0m"
+        val totalMinutes = ms / 60_000L
+        if (totalMinutes <= 0L) return "<1m"
+        val hours = totalMinutes / 60L
+        val minutes = totalMinutes % 60L
+        return when {
+            hours <= 0L -> "${minutes}m"
+            minutes == 0L -> "${hours}h"
+            else -> "${hours}h ${minutes}m"
+        }
+    }
+
+    /**
+     * Compact count: exact below 1,000, then "12.3k" / "1.2M" with a
+     * single decimal that drops a trailing ".0". Built arithmetically
+     * (no `String.format`) so it's locale-stable and deterministic in
+     * tests.
+     */
+    fun formatCompactNumber(n: Long): String = when {
+        n < 0L -> "0"
+        n < 1_000L -> n.toString()
+        n < 1_000_000L -> trimOneDecimal(n / 1_000.0) + "k"
+        else -> trimOneDecimal(n / 1_000_000.0) + "M"
+    }
+
+    private fun trimOneDecimal(value: Double): String {
+        val rounded = round(value * 10.0) / 10.0
+        val whole = rounded.toLong()
+        val frac = round((rounded - whole) * 10.0).toLong()
+        return if (frac == 0L) whole.toString() else "$whole.$frac"
+    }
+
+    /**
+     * Human label for a source id. Covers the full [SourceIds] roster;
+     * an unknown id (a future source, or a legacy alias) falls back to a
+     * title-cased version of the id so the row is never blank.
+     */
+    fun sourceDisplayName(sourceId: String): String = when (sourceId) {
+        SourceIds.ROYAL_ROAD -> "Royal Road"
+        SourceIds.GITHUB -> "GitHub"
+        SourceIds.MEMPALACE -> "Memory Palace"
+        SourceIds.RSS -> "RSS"
+        SourceIds.EPUB -> "EPUB"
+        SourceIds.OCR -> "Scanned text"
+        SourceIds.PDF -> "PDF"
+        SourceIds.OUTLINE -> "Outline"
+        SourceIds.GUTENBERG -> "Project Gutenberg"
+        SourceIds.AO3 -> "AO3"
+        SourceIds.STANDARD_EBOOKS -> "Standard Ebooks"
+        SourceIds.WIKIPEDIA -> "Wikipedia"
+        SourceIds.WIKISOURCE -> "Wikisource"
+        SourceIds.RADIO, SourceIds.KVMR -> "Radio"
+        SourceIds.LIBRIVOX -> "LibriVox"
+        SourceIds.NOTION, SourceIds.NOTION_PAT -> "Notion"
+        SourceIds.NOTION_TECHEMPOWER -> "TechEmpower"
+        SourceIds.HACKERNEWS -> "Hacker News"
+        SourceIds.ARXIV -> "arXiv"
+        SourceIds.PLOS -> "PLOS"
+        SourceIds.DISCORD -> "Discord"
+        SourceIds.MATRIX -> "Matrix"
+        SourceIds.TELEGRAM -> "Telegram"
+        SourceIds.SLACK -> "Slack"
+        SourceIds.PALACE -> "Palace Project"
+        SourceIds.READABILITY -> "Web articles"
+        SourceIds.MY_AUDIOBOOK -> "My audiobooks"
+        else -> prettifyUnknownId(sourceId)
+    }
+
+    private fun prettifyUnknownId(sourceId: String): String {
+        if (sourceId.isBlank()) return "Other"
+        return sourceId
+            .split('-', '_', ':')
+            .filter { it.isNotBlank() }
+            .joinToString(" ") { part ->
+                part.replaceFirstChar { it.uppercaseChar() }
+            }
+            .ifBlank { "Other" }
+    }
+
+    /**
+     * A short, shareable plain-text summary of the snapshot — backs the
+     * top-bar "share" action (the issue's "I listened to N hours" card,
+     * as text rather than a rendered image). Lines are emitted only when
+     * they carry a non-zero figure, so a sparse history reads cleanly.
+     */
+    fun shareSummary(stats: ListeningStats, appName: String): String = buildString {
+        append("My listening on ")
+        append(appName)
+        append(':')
+        if (stats.totalEstimatedMs > 0L) {
+            append("\n• ≈ ")
+            append(formatDuration(stats.totalEstimatedMs))
+            append(" listened")
+        }
+        if (stats.booksCompleted > 0) {
+            append("\n• ")
+            append(stats.booksCompleted)
+            append(if (stats.booksCompleted == 1) " book finished" else " books finished")
+        }
+        if (stats.chaptersFinished > 0) {
+            append("\n• ")
+            append(formatCompactNumber(stats.chaptersFinished.toLong()))
+            append(" chapters read")
+        }
+        if (stats.currentStreakDays > 0) {
+            append("\n• ")
+            append(stats.currentStreakDays)
+            append(if (stats.currentStreakDays == 1) " day streak" else " day streak 🔥")
+        }
+    }
+
+    /** Single-letter weekday initial (Mon→"M") for the compact trend axis. */
+    fun weekdayInitial(dayOfWeekValue: Int): String = when (dayOfWeekValue) {
+        1 -> "M"
+        2 -> "T"
+        3 -> "W"
+        4 -> "T"
+        5 -> "F"
+        6 -> "S"
+        else -> "S"
+    }
+
+    /** Display label for a [DayPart]. */
+    fun dayPartLabel(part: DayPart): String = when (part) {
+        DayPart.MORNING -> "Morning"
+        DayPart.AFTERNOON -> "Afternoon"
+        DayPart.EVENING -> "Evening"
+        DayPart.NIGHT -> "Night"
+    }
+}

--- a/feature/src/main/res/values/strings.xml
+++ b/feature/src/main/res/values/strings.xml
@@ -626,6 +626,9 @@
     <string name="settings_hub_developer_subtitle">Debug overlay, log ring, advanced toggles.</string>
     <string name="settings_hub_about_title">About</string>
     <string name="settings_hub_about_subtitle">Version, sigil, open-source notices.</string>
+    <!-- Issue #1235 — Listening stats hub row -->
+    <string name="settings_hub_stats_title">Listening stats</string>
+    <string name="settings_hub_stats_subtitle">Time listened, streaks, books finished.</string>
     <string name="settings_hub_all_settings_title">All settings</string>
     <string name="settings_hub_all_settings_subtitle">Every setting on one long page (legacy).</string>
 
@@ -1034,4 +1037,27 @@
     <string name="ocr_save_and_read">Save and read</string>
     <string name="library_scan_page_cd">Scan a printed page to read aloud</string>
 
+
+    <!-- Issue #1235 — Listening statistics dashboard -->
+    <string name="stats_title">Listening Stats</string>
+    <string name="stats_back">Back</string>
+    <string name="stats_share">Share stats</string>
+    <string name="stats_share_chooser">Share your listening stats</string>
+    <string name="stats_app_name">Candela</string>
+    <string name="stats_total_time_label">Time listened</string>
+    <!-- %1$d current streak, %2$d longest streak -->
+    <string name="stats_streak_line">🔥 %1$d-day streak · best ever %2$d</string>
+    <string name="stats_books_finished">Books finished</string>
+    <string name="stats_chapters_read">Chapters read</string>
+    <string name="stats_words_read">Words read</string>
+    <string name="stats_books_started">Books started</string>
+    <string name="stats_this_week_title">This week</string>
+    <string name="stats_today">Today</string>
+    <string name="stats_last_seven_days">Last 7 days</string>
+    <string name="stats_by_source_title">By source</string>
+    <string name="stats_time_of_day_title">Time of day</string>
+    <string name="stats_other_sources">Other</string>
+    <string name="stats_empty_title">No listening yet</string>
+    <string name="stats_empty_body">Finish a chapter and your reading stats will appear here.</string>
+    <string name="stats_estimate_note">Time figures are estimates based on the length of the chapters you\'ve finished — Candela doesn\'t track exact playback time yet.</string>
 </resources>

--- a/feature/src/test/kotlin/in/jphe/storyvox/feature/settings/SettingsHubSectionsTest.kt
+++ b/feature/src/test/kotlin/in/jphe/storyvox/feature/settings/SettingsHubSectionsTest.kt
@@ -27,16 +27,16 @@ import org.junit.Test
 class SettingsHubSectionsTest {
 
     @Test
-    fun `hub catalog renders sixteen sections in fixed order`() {
-        // 15 named sections + 1 escape hatch ("All settings"). The
+    fun `hub catalog renders seventeen sections in fixed order`() {
+        // 16 named sections + 1 escape hatch ("All settings"). The
         // count bumped 13 → 14 in v0.5.42 (Accessibility scaffold);
         // 14 → 15 in v0.5.59 (Appearance / book cover style); 15 →
         // 16 in the v1 settings-bundle-7 (Advanced subscreen — #598
-        // Android Auto bucket size and future integration tunables).
-        // Adding a new section requires updating both this assertion
-        // AND the composable's row list — that drift is the point of
-        // pinning.
-        assertEquals(16, SettingsHubSections.size)
+        // Android Auto bucket size and future integration tunables);
+        // 16 → 17 in #1235 (Listening stats dashboard). Adding a new
+        // section requires updating both this assertion AND the
+        // composable's row list — that drift is the point of pinning.
+        assertEquals(17, SettingsHubSections.size)
     }
 
     @Test

--- a/feature/src/test/kotlin/in/jphe/storyvox/feature/stats/StatsFormattingTest.kt
+++ b/feature/src/test/kotlin/in/jphe/storyvox/feature/stats/StatsFormattingTest.kt
@@ -1,0 +1,111 @@
+package `in`.jphe.storyvox.feature.stats
+
+import `in`.jphe.storyvox.data.repository.stats.ListeningStats
+import `in`.jphe.storyvox.data.repository.stats.SourceShare
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * Issue #1235 — pure presentation helpers for the listening-stats
+ * dashboard. JVM-only (no Compose), per the :feature test discipline.
+ */
+class StatsFormattingTest {
+
+    @Test
+    fun `formatDuration renders hours and minutes`() {
+        assertEquals("0m", StatsFormatting.formatDuration(0))
+        assertEquals("0m", StatsFormatting.formatDuration(-5))
+        assertEquals("<1m", StatsFormatting.formatDuration(30_000)) // 30s
+        assertEquals("5m", StatsFormatting.formatDuration(5 * 60_000L))
+        assertEquals("1h 30m", StatsFormatting.formatDuration(90 * 60_000L))
+        assertEquals("2h", StatsFormatting.formatDuration(120 * 60_000L))
+        assertEquals("10h", StatsFormatting.formatDuration(600 * 60_000L))
+    }
+
+    @Test
+    fun `formatCompactNumber abbreviates thousands and millions`() {
+        assertEquals("0", StatsFormatting.formatCompactNumber(0))
+        assertEquals("0", StatsFormatting.formatCompactNumber(-3))
+        assertEquals("999", StatsFormatting.formatCompactNumber(999))
+        assertEquals("1k", StatsFormatting.formatCompactNumber(1_000))
+        assertEquals("1.2k", StatsFormatting.formatCompactNumber(1_234))
+        assertEquals("12k", StatsFormatting.formatCompactNumber(12_000))
+        assertEquals("12.3k", StatsFormatting.formatCompactNumber(12_345))
+        assertEquals("1M", StatsFormatting.formatCompactNumber(1_000_000))
+        assertEquals("1.2M", StatsFormatting.formatCompactNumber(1_234_567))
+    }
+
+    @Test
+    fun `sourceDisplayName maps known ids and prettifies unknown ones`() {
+        assertEquals("Royal Road", StatsFormatting.sourceDisplayName("royalroad"))
+        assertEquals("AO3", StatsFormatting.sourceDisplayName("ao3"))
+        assertEquals("LibriVox", StatsFormatting.sourceDisplayName("librivox"))
+        assertEquals("Project Gutenberg", StatsFormatting.sourceDisplayName("gutenberg"))
+        // Unknown id → title-cased on separators.
+        assertEquals("Foo Bar", StatsFormatting.sourceDisplayName("foo-bar"))
+        assertEquals("Other", StatsFormatting.sourceDisplayName(""))
+    }
+
+    @Test
+    fun `weekday initials follow Mon-Sun`() {
+        assertEquals("M", StatsFormatting.weekdayInitial(1))
+        assertEquals("T", StatsFormatting.weekdayInitial(2))
+        assertEquals("W", StatsFormatting.weekdayInitial(3))
+        assertEquals("T", StatsFormatting.weekdayInitial(4))
+        assertEquals("F", StatsFormatting.weekdayInitial(5))
+        assertEquals("S", StatsFormatting.weekdayInitial(6))
+        assertEquals("S", StatsFormatting.weekdayInitial(7))
+    }
+
+    @Test
+    fun `share summary only emits lines with non-zero figures`() {
+        val populated = ListeningStats.EMPTY.copy(
+            totalEstimatedMs = 15 * 60_000L,
+            booksCompleted = 2,
+            chaptersFinished = 42,
+            currentStreakDays = 3,
+            chaptersOpened = 50,
+        )
+        val text = StatsFormatting.shareSummary(populated, "Candela")
+        assertTrue(text.startsWith("My listening on Candela:"))
+        assertTrue(text.contains("≈ 15m listened"))
+        assertTrue(text.contains("2 books finished"))
+        assertTrue(text.contains("42 chapters read"))
+        assertTrue(text.contains("3 day streak"))
+
+        // An empty snapshot collapses to just the header — no zero-value noise.
+        val empty = StatsFormatting.shareSummary(ListeningStats.EMPTY, "Candela")
+        assertEquals("My listening on Candela:", empty)
+    }
+
+    @Test
+    fun `share summary singularizes a one-book, one-day result`() {
+        val one = ListeningStats.EMPTY.copy(booksCompleted = 1, currentStreakDays = 1, chaptersOpened = 1)
+        val text = StatsFormatting.shareSummary(one, "Candela")
+        assertTrue(text.contains("1 book finished"))
+        assertTrue(text.contains("1 day streak"))
+    }
+
+    @Test
+    fun `collapseSources keeps a short list intact`() {
+        val shares = (1..MAX_DONUT_SLICES).map { SourceShare("s$it", finishedChapters = it, estimatedMs = it * 100L) }
+        assertEquals(shares, collapseSources(shares))
+    }
+
+    @Test
+    fun `collapseSources folds the tail into a single Other slice`() {
+        val shares = (1..8).map { SourceShare("s$it", finishedChapters = 10 - it, estimatedMs = (10 - it) * 100L) }
+        // finishedChapters: 9,8,7,6,5,4,3,2 (already descending)
+        val collapsed = collapseSources(shares)
+        assertEquals(MAX_DONUT_SLICES, collapsed.size)
+        // First five untouched.
+        assertEquals("s1", collapsed[0].sourceId)
+        assertEquals("s5", collapsed[4].sourceId)
+        // Last is the synthetic "Other" summing s6 (4) + s7 (3) + s8 (2) = 9 chapters.
+        val other = collapsed.last()
+        assertEquals(OTHER_SOURCE_ID, other.sourceId)
+        assertEquals(9, other.finishedChapters)
+        assertEquals(900L, other.estimatedMs)
+    }
+}


### PR DESCRIPTION
Implements #1235 — a **Listening Stats** dashboard reached from the Settings hub.

Built entirely by **aggregating data the app already writes** (`chapter_history` + `playback_position` + `fiction` + `chapter`) — **no new entity, no schema migration**, and zero cost on the playback hot path.

## What you get
- **Hero card** — estimated total time listened (big), plus a streak line.
- **Stat tiles** — books finished, chapters read, words read, books started.
- **This week** — a Canvas 7-day bar chart + today / last-7-days time totals.
- **By source** — a Canvas donut + legend (top 5 + “Other”), e.g. Royal Road vs LibriVox vs AO3.
- **Time of day** — morning / afternoon / evening / night histogram.
- **Share** — a plain-text summary via the system share sheet (“My listening on Candela: …”).
- Empty state when there’s nothing to show; dark/light via `MaterialTheme`; heading semantics for TalkBack.

No external charting library — the bar chart and donut are hand-drawn with Compose `Canvas`.

## Honesty about “time listened”
There is no per-session stopwatch in the schema, so **every time figure is an estimate** (the summed `durationEstimateMs` of the chapters you’ve *finished*). Each is prefixed **“≈”** and a footnote explains why. Streak/trend are based on `chapter_history` open days (the issue’s “≥15 min” can’t be honoured without time data, so a day with any activity counts).

## Deferred (out of scope, reported to orchestrator)
Two stats from the issue genuinely require a new `ListeningSession` recording pipeline and are **not** included:
- **Voice engine usage** (Piper/Kokoro/…): the engine isn’t recorded per chapter.
- **Average session length**: needs real start/end timestamps.

These are a clean follow-up: add a `ListeningSession` entity + a recording hook at the existing `EnginePlayer` completion seam, then extend the DAO.

## Architecture
- `core-data`: `ListeningStatsDao` (SQL aggregates), `ListeningStatsCalculator` (pure, clock/zone-injectable calendar math), `ListeningStatsRepository` (one-shot snapshot, IO-dispatched). Wired into `StoryvoxDatabase` + `DataModule`.
- `feature`: `ListeningStatsScreen` + `ListeningStatsViewModel` + `StatsCharts` (Canvas) + `StatsFormatting` (pure). Settings hub row + `StoryvoxRoutes.STATS`.

## Tests
- **Robolectric** DAO test (in-memory Room) pinning every aggregate, the `HAVING`-based books-completed logic, placeholder exclusion, and per-source grouping.
- **Pure JVM** tests for the calculator (streaks, trend buckets, time-of-day, today/week sums against a fixed clock) and the formatting/`collapseSources` helpers.
- Bumps the pinned Settings-hub section count 16 → 17.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
