### PR TITLE
fix(playback): assert shared-model engine speaker ID unconditionally before synth (#1263)

### DIFF
--- a/core-playback/src/main/kotlin/in/jphe/storyvox/playback/cache/ChapterRenderJob.kt
+++ b/core-playback/src/main/kotlin/in/jphe/storyvox/playback/cache/ChapterRenderJob.kt
@@ -331,12 +331,30 @@ class ChapterRenderJob @AssistedInject constructor(
 
     private fun generateAudioPCM(voice: UiVoiceInfo, text: String): ByteArray? =
         when (voice.engineType) {
-            is EngineType.Kokoro -> KokoroEngine.getInstance()
-                .generateAudioPCM(text, 1.0f, 1.0f)
-            is EngineType.Kitten -> KittenEngine.getInstance()
-                .generateAudioPCM(text, 1.0f, 1.0f)
-            is EngineType.Supertonic -> SupertonicEngine.getInstance()
-                .generateAudioPCM(text, 1.0f, 1.0f)
+            // Issue #1263 — re-assert OUR speaker before each synth. These
+            // engines are process-wide shared-model singletons: the foreground
+            // EnginePlayer now mutates the active speaker per sentence (its own
+            // #1263 fix), so a prerender that set its speaker only once at
+            // loadModel would render later sentences in the foreground's voice.
+            // Atomic with the generate under the caller's engineMutex.withLock
+            // (see doWork); setActiveSpeakerId is a cheap reload-free index flip.
+            is EngineType.Kokoro -> {
+                KokoroEngine.getInstance()
+                    .setActiveSpeakerId((voice.engineType as EngineType.Kokoro).speakerId)
+                KokoroEngine.getInstance().generateAudioPCM(text, 1.0f, 1.0f)
+            }
+            is EngineType.Kitten -> {
+                KittenEngine.getInstance()
+                    .setActiveSpeakerId((voice.engineType as EngineType.Kitten).speakerId)
+                KittenEngine.getInstance().generateAudioPCM(text, 1.0f, 1.0f)
+            }
+            is EngineType.Supertonic -> {
+                SupertonicEngine.getInstance()
+                    .setActiveSpeakerId((voice.engineType as EngineType.Supertonic).speakerId)
+                SupertonicEngine.getInstance().generateAudioPCM(text, 1.0f, 1.0f)
+            }
+            // Piper is per-voice (not a shared multi-speaker singleton) — no
+            // active-speaker state to re-assert.
             else -> VoiceEngine.getInstance()
                 .generateAudioPCM(text, 1.0f, 1.0f)
         }

--- a/core-playback/src/main/kotlin/in/jphe/storyvox/playback/tts/EnginePlayer.kt
+++ b/core-playback/src/main/kotlin/in/jphe/storyvox/playback/tts/EnginePlayer.kt
@@ -960,6 +960,14 @@ class EnginePlayer @AssistedInject constructor(
      * text, no Kokoro voice for that language — collapses to
      * [primarySpeakerId], which is #1233's graceful fallback.
      *
+     * Issue #1263 — the Kokoro handle now calls this **unconditionally**
+     * before every synth (not only when auto-detect is on) to re-assert the
+     * active speaker against a background [`in`.jphe.storyvox.playback.cache.ChapterRenderJob]
+     * mutating the shared `KokoroEngine` singleton. That makes the
+     * "auto-detect off ⇒ return [primarySpeakerId]" guard load-bearing, not a
+     * mere optimization: it must keep returning the primary speaker when the
+     * feature is off, or the leak-guard re-assertion would itself mis-route.
+     *
      * Called on the producer thread inside the engine mutex (see
      * [activeVoiceEngineHandle]): pure reads plus a deterministic router,
      * so it is cheap and thread-safe there. Determinism matters — the PCM
@@ -3694,20 +3702,30 @@ class EnginePlayer @AssistedInject constructor(
                     AndroidProcess.setThreadPriority(producerPriority())
                     return when (engineType) {
                         is EngineType.Kokoro -> {
-                            // Issue #1233 — per-sentence language routing.
-                            // No-op unless the listener enabled auto-detect.
-                            // setActiveSpeakerId is reload-free across Kokoro's
-                            // one shared model, and this runs inside the
-                            // producer's engineMutex lock — the sole writer of
-                            // the active speaker on the serial path (parallel
-                            // secondaries are forced off when routing is on; see
-                            // effectiveSecondaryHandles), so there's no speaker-id
-                            // race against a concurrent synth.
-                            if (cachedAutoLanguageDetection) {
-                                KokoroEngine.getInstance().setActiveSpeakerId(
-                                    routeKokoroSpeaker(text, engineType.speakerId),
-                                )
-                            }
+                            // Issue #1263 — KokoroEngine is a process-wide
+                            // singleton, so a background ChapterRenderJob
+                            // (prerender) that calls setActiveSpeakerId on it for
+                            // a different voice (ChapterRenderJob.loadModel) can
+                            // leak that speaker into foreground playback between
+                            // our sentences. So re-assert OUR speaker before
+                            // EVERY synth, unconditionally — not only when
+                            // auto-language routing is on (#1233).
+                            //
+                            // routeKokoroSpeaker returns the primary speaker
+                            // (engineType.speakerId) when auto-detect is off, so
+                            // this one call serves both the plain path and the
+                            // per-sentence language-routing path. The set + the
+                            // generate below are atomic under the producer's
+                            // engineMutex.withLock — both on the serial path and
+                            // on the useEngineMutex=true primary parallel worker —
+                            // and ChapterRenderJob serializes on the same
+                            // engineMutex, so no background swap can land between
+                            // them. setActiveSpeakerId is a reload-free index flip
+                            // across Kokoro's one shared model, so re-asserting
+                            // per sentence is cheap.
+                            KokoroEngine.getInstance().setActiveSpeakerId(
+                                routeKokoroSpeaker(text, engineType.speakerId),
+                            )
                             KokoroEngine.getInstance().generateAudioPCM(text, speed, pitch)
                         }
                         // Issue #119 — Kitten dispatch.

--- a/core-playback/src/main/kotlin/in/jphe/storyvox/playback/tts/EnginePlayer.kt
+++ b/core-playback/src/main/kotlin/in/jphe/storyvox/playback/tts/EnginePlayer.kt
@@ -383,8 +383,15 @@ class EnginePlayer @AssistedInject constructor(
      *  watcher (see [observeActiveVoice]) to decide whether a DataStore
      *  emission represents a real change worth reloading for, and by
      *  [resume] to detect a "voice changed while paused" situation that
-     *  needs a full reload before playback can continue with the new model. */
-    private var loadedVoiceId: String? = null
+     *  needs a full reload before playback can continue with the new model.
+     *
+     *  `@Volatile` (#1263): written on the load coroutine but read off other
+     *  threads without always holding [engineMutex] — notably the audio
+     *  producer thread via [routeKokoroSpeaker], plus pipeline / cache-key
+     *  construction in [startPlaybackPipeline]. The volatile write/read pair
+     *  guarantees those threads see the latest loaded voice rather than a
+     *  stale cached reference. */
+    @Volatile private var loadedVoiceId: String? = null
 
     /** Flagged when the user picks a different voice while playback is
      *  paused. The flag tells [resume] to route through [loadAndPlay] for

--- a/core-playback/src/main/kotlin/in/jphe/storyvox/playback/tts/EnginePlayer.kt
+++ b/core-playback/src/main/kotlin/in/jphe/storyvox/playback/tts/EnginePlayer.kt
@@ -3729,11 +3729,28 @@ class EnginePlayer @AssistedInject constructor(
                             KokoroEngine.getInstance().generateAudioPCM(text, speed, pitch)
                         }
                         // Issue #119 — Kitten dispatch.
-                        is EngineType.Kitten -> KittenEngine.getInstance()
-                            .generateAudioPCM(text, speed, pitch)
+                        is EngineType.Kitten -> {
+                            // Issue #1263 — KittenEngine is also a shared-model
+                            // singleton, so re-assert our speaker before every
+                            // synth for the same reason as the Kokoro branch
+                            // above (a background ChapterRenderJob can overwrite
+                            // the active speaker between our sentences). Kitten
+                            // has no language routing, so it's always the primary
+                            // speaker. Atomic with the generate under the
+                            // producer's engineMutex; cheap reload-free index flip.
+                            KittenEngine.getInstance().setActiveSpeakerId(engineType.speakerId)
+                            KittenEngine.getInstance().generateAudioPCM(text, speed, pitch)
+                        }
                         // Issue #1114 — Supertonic dispatch.
-                        is EngineType.Supertonic -> SupertonicEngine.getInstance()
-                            .generateAudioPCM(text, speed, pitch)
+                        is EngineType.Supertonic -> {
+                            // Issue #1263 — same shared-model singleton leak guard
+                            // as the Kokoro/Kitten branches above.
+                            SupertonicEngine.getInstance().setActiveSpeakerId(engineType.speakerId)
+                            SupertonicEngine.getInstance().generateAudioPCM(text, speed, pitch)
+                        }
+                        // Piper voices are per-voice models (not a shared
+                        // multi-speaker singleton), so there's no active-speaker
+                        // state to leak — no re-assertion needed here.
                         else -> VoiceEngine.getInstance()
                             .generateAudioPCM(text, speed, pitch)
                     }


### PR DESCRIPTION
Closes #1263.

## The bug

The three in-app **shared-model TTS engines** — Kokoro, Kitten, Supertonic — are each a **process-wide singleton** whose active speaker ID is mutable global state. The foreground synth handle re-asserted the speaker only for Kokoro *when auto-language-detect was on* (added in #1233); otherwise it relied on the speaker set once at pipeline load.

A background `ChapterRenderJob` (prerender) loads its own voice via `…Engine.getInstance().setActiveSpeakerId()` (`ChapterRenderJob.kt:296` / `:305` / `:311`) on those **same singletons**. When the prerender's voice differs from the one currently playing — e.g. just after a voice switch, while the old chapter's pipeline is still draining — its speaker leaks into the next foreground sentence: wrong-voice audio mid-chapter, and a corrupted sentence can even get cached under the primary voice's key.

## The fix

Re-assert the foreground speaker before **every** synth, unconditionally, for **all three** shared-model engines (`EnginePlayer.kt`, `activeVoiceEngineHandle`):

- **Kokoro** — `setActiveSpeakerId(routeKokoroSpeaker(text, primary))`. `routeKokoroSpeaker` already returns the primary speaker when auto-detect is off, so the one call serves both the plain path and the #1233 per-sentence language-routing path.
- **Kitten / Supertonic** — `setActiveSpeakerId(engineType.speakerId)`. Neither has language routing, so it's always the primary speaker.

This generalizes the already-shipping, proven auto-detect-**on** behavior to all sentences and all shared-model engines.

**Why it closes the race:** the `setActiveSpeakerId` + `generateAudioPCM` run inside a single `engineMutex.withLock` — on the serial producer (`EngineStreamingSource:726`) and on the `useEngineMutex=true` primary parallel worker (`:551`) — and `ChapterRenderJob` serializes its own set+generate on the **same** `engineMutex`. So no background swap can land between our set and our synth. `setActiveSpeakerId` is a reload-free index flip across the shared model, so per-sentence re-assertion is cheap. Covers main playback and the recap path (both route through this handle); parallel secondaries use their own engine instances and are unaffected.

**Piper is deliberately untouched:** its voices are per-voice models, not a shared multi-speaker singleton, so there is no active-speaker state to leak.

## Testing

No new unit test. The change is a control-flow guard in a private anonymous handle calling the JNI engine singletons, gated by cross-thread `engineMutex` serialization — not reproducible in a pure-JVM unit test (project is JUnit 4 / no Robolectric, and there is no `EnginePlayer`-construction test harness; existing `EnginePlayer*Test`s only cover extracted top-level pure functions). Verified by the lock-structure analysis above; the Kokoro speaker-*selection* logic it calls is already covered by `LanguageVoiceRouterTest`. `routeKokoroSpeaker`'s kdoc now records that its "auto-detect off → primary" return is load-bearing for this fix.

Two commits: the Kokoro fix (CI green), then the Kitten + Supertonic extension.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
