### PR TITLE
chore: bot-review advisory cleanups (#1265)

### DIFF
--- a/app/src/main/kotlin/in/jphe/storyvox/MainActivity.kt
+++ b/app/src/main/kotlin/in/jphe/storyvox/MainActivity.kt
@@ -275,7 +275,10 @@ class MainActivity : ComponentActivity() {
                         // the URL / notification resolver.
                         val importRoute = sampleRoute
                             ?: DeepLinkResolver.documentImportUri(i)
-                                ?.let { uri -> importDocument(uri) }
+                                // #1265 — pass THIS intent's MIME, not the
+                                // mutable Activity `intent` field (onNewIntent
+                                // could swap it before importDocument reads it).
+                                ?.let { uri -> importDocument(uri, i.type) }
                         val route = importRoute ?: DeepLinkResolver.resolve(i)
                         route?.let { navController.navigate(it) }
                         intentFlow.value = null
@@ -405,8 +408,8 @@ class MainActivity : ComponentActivity() {
      * intent's `type` is passed as the mime hint — a file manager's SEND
      * intent often carries a better mime than `ContentResolver.getType`.
      */
-    private suspend fun importDocument(uri: Uri): String? =
-        when (val result = documentImporter.get().importLocalFile(uri.toString(), intent?.type)) {
+    private suspend fun importDocument(uri: Uri, mimeHint: String?): String? =
+        when (val result = documentImporter.get().importLocalFile(uri.toString(), mimeHint)) {
             is ImportFileResult.Success -> StoryvoxRoutes.fictionDetail(result.fictionId)
             // #1264 — surface the importer's user-facing reason. Without this the
             // "Open With" / Share path silently no-ops on a failed import: the
@@ -457,7 +460,9 @@ class MainActivity : ComponentActivity() {
         // file:// to our own cacheDir — the importer reads it directly
         // (we own the file), and the takePersistableUriPermission call
         // no-ops on a file Uri.
-        return importDocument(Uri.fromFile(cached))
+        // #1265 — the seed fixture is plaintext; pass its MIME explicitly now
+        // that importDocument no longer reads the Activity intent field.
+        return importDocument(Uri.fromFile(cached), "text/plain")
     }
 
     private companion object {

--- a/app/src/main/kotlin/in/jphe/storyvox/data/DocumentImporterUiImpl.kt
+++ b/app/src/main/kotlin/in/jphe/storyvox/data/DocumentImporterUiImpl.kt
@@ -45,22 +45,29 @@ class DocumentImporterUiImpl @Inject constructor(
     private val pdfConfig: PdfConfigImpl,
 ) : DocumentImporterUi {
 
-    override suspend fun importLocalFile(uriString: String, mimeHint: String?): ImportFileResult {
-        val uri = runCatching { Uri.parse(uriString) }.getOrNull()
-            ?: return ImportFileResult.Error("That file couldn't be read.")
-        // intent-supplied mime (when present) wins; otherwise ask the
-        // resolver. File managers are inconsistent, so the classifier also
-        // falls back to the filename extension.
-        val mime = mimeHint ?: runCatching { context.contentResolver.getType(uri) }.getOrNull()
-        val displayName = queryDisplayName(uri) ?: uri.lastPathSegment.orEmpty()
+    override suspend fun importLocalFile(uriString: String, mimeHint: String?): ImportFileResult =
+        // #1265 — the whole sequence touches blocking I/O off the bat
+        // (`contentResolver.getType`, the SAF display-name query, and the
+        // per-format `importFile` DataStore writes). Both entry points call
+        // this from a main-ish dispatcher (viewModelScope / LaunchedEffect),
+        // so offload the lot to IO rather than relying on each callee to
+        // re-dispatch.
+        withContext(Dispatchers.IO) {
+            val uri = runCatching { Uri.parse(uriString) }.getOrNull()
+                ?: return@withContext ImportFileResult.Error("That file couldn't be read.")
+            // intent-supplied mime (when present) wins; otherwise ask the
+            // resolver. File managers are inconsistent, so the classifier also
+            // falls back to the filename extension.
+            val mime = mimeHint ?: runCatching { context.contentResolver.getType(uri) }.getOrNull()
+            val displayName = queryDisplayName(uri) ?: uri.lastPathSegment.orEmpty()
 
-        return when (DocumentImportClassifier.classify(mime, displayName)) {
-            ImportKind.Epub -> registerEpub(uri, uriString, displayName, EpubEntryKind.Epub)
-            ImportKind.Text -> registerEpub(uri, uriString, displayName, EpubEntryKind.Text)
-            ImportKind.Pdf -> registerPdf(uri, uriString, displayName)
-            ImportKind.Unsupported -> ImportFileResult.Unsupported
+            when (DocumentImportClassifier.classify(mime, displayName)) {
+                ImportKind.Epub -> registerEpub(uri, uriString, displayName, EpubEntryKind.Epub)
+                ImportKind.Text -> registerEpub(uri, uriString, displayName, EpubEntryKind.Text)
+                ImportKind.Pdf -> registerPdf(uri, uriString, displayName)
+                ImportKind.Unsupported -> ImportFileResult.Unsupported
+            }
         }
-    }
 
     private suspend fun registerEpub(
         uri: Uri,
@@ -86,7 +93,10 @@ class DocumentImporterUiImpl @Inject constructor(
     }
 
     private fun failure(displayName: String, cause: Throwable): ImportFileResult {
-        Log.w(TAG, "Import failed for $displayName", cause)
+        // #1265 — don't log the document name (private content) at warn
+        // level; the cause/stack is enough to diagnose. The name still goes
+        // in the user-facing error string, which isn't persisted to logcat.
+        Log.w(TAG, "Import failed", cause)
         return ImportFileResult.Error("Couldn't import ${displayName.ifBlank { "that file" }}.")
     }
 
@@ -98,12 +108,17 @@ class DocumentImporterUiImpl @Inject constructor(
      * this session, and a failed persist must not abort the open.
      */
     private fun persistReadGrant(uri: Uri) {
+        // #1265 — only content:// Uris can carry a persistable grant. A
+        // file:// Uri (the debug sample seed) would just throw a caught
+        // SecurityException and emit a noisy warn, so skip it outright.
+        if (uri.scheme != "content") return
         runCatching {
             context.contentResolver.takePersistableUriPermission(
                 uri,
                 Intent.FLAG_GRANT_READ_URI_PERMISSION,
             )
-        }.onFailure { Log.w(TAG, "Could not persist URI permission for $uri", it) }
+            // #1265 — don't log the Uri (can encode a private document path).
+        }.onFailure { Log.w(TAG, "Could not persist URI permission", it) }
     }
 
     /** Query the SAF [OpenableColumns.DISPLAY_NAME] for a content Uri.

--- a/app/src/main/kotlin/in/jphe/storyvox/data/PdfConfigImpl.kt
+++ b/app/src/main/kotlin/in/jphe/storyvox/data/PdfConfigImpl.kt
@@ -200,10 +200,15 @@ class PdfConfigImpl internal constructor(
         uriString: String,
         displayName: String,
     ): String {
+        // #1265 — normalize the Uri ONCE and hash the normalized form, so the
+        // stored `uriString` and the `fictionId` derived from it agree. Hashing
+        // the raw string while storing the trimmed one meant a whitespace-padded
+        // Uri yielded an id that later (trimmed) lookups couldn't match.
+        val normalizedUri = uriString.trim()
         val entry = PdfFileEntry(
-            fictionId = fictionIdForPdfUri(uriString),
-            uriString = uriString.trim(),
-            displayName = displayName.ifBlank { uriString.substringAfterLast('/') },
+            fictionId = fictionIdForPdfUri(normalizedUri),
+            uriString = normalizedUri,
+            displayName = displayName.ifBlank { normalizedUri.substringAfterLast('/') },
         )
         store.edit { prefs ->
             val existing = prefs[PdfKeys.IMPORTED_FILES].orEmpty()

--- a/app/src/main/kotlin/in/jphe/storyvox/data/WiktionaryDictionaryRepository.kt
+++ b/app/src/main/kotlin/in/jphe/storyvox/data/WiktionaryDictionaryRepository.kt
@@ -7,6 +7,7 @@ import `in`.jphe.storyvox.data.dictionary.lemmaCandidates
 import `in`.jphe.storyvox.data.dictionary.normalizeLookupWord
 import `in`.jphe.storyvox.data.dictionary.parseWiktionaryDefinitions
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ensureActive
 import kotlinx.coroutines.withContext
 import okhttp3.HttpUrl
 import okhttp3.OkHttpClient
@@ -43,6 +44,10 @@ class WiktionaryDictionaryRepository(
 
         var lastError: String? = null
         for (candidate in lemmaCandidates(lemma)) {
+            // #1265 — `fetch` is a blocking network call; bail promptly if the
+            // lookup was cancelled (e.g. the user dismissed the sheet) rather
+            // than working through the remaining case variants.
+            ensureActive()
             when (val result = fetch(candidate)) {
                 is DictionaryResult.Success -> return@withContext result
                 is DictionaryResult.NotFound -> Unit // try the next case variant

--- a/core-data/src/main/kotlin/in/jphe/storyvox/data/db/dao/ListeningStatsDao.kt
+++ b/core-data/src/main/kotlin/in/jphe/storyvox/data/db/dao/ListeningStatsDao.kt
@@ -77,7 +77,7 @@ interface ListeningStatsDao {
         """
         SELECT COALESCE(SUM(c.wordCount), 0)
           FROM chapter_history h
-          JOIN chapter c ON c.id = h.chapterId
+          JOIN chapter c ON c.fictionId = h.fictionId AND c.id = h.chapterId
          WHERE h.completed = 1
         """,
     )

--- a/core-data/src/main/kotlin/in/jphe/storyvox/data/dictionary/LookupWord.kt
+++ b/core-data/src/main/kotlin/in/jphe/storyvox/data/dictionary/LookupWord.kt
@@ -71,8 +71,13 @@ fun lemmaCandidates(word: String): List<String> {
     if (word.isEmpty()) return emptyList()
     val candidates = LinkedHashSet<String>()
     candidates += word
+    // #1265 — an all-caps acronym ("NASA") skips the first-letter-decapitalise
+    // step: lowercasing only its first letter yields a nonsense mixed-case form
+    // ("nASA") that's a guaranteed Wiktionary 404 — a wasted sequential request
+    // on mobile. The fully-lower-cased form below ("nasa") still covers it.
+    val isAcronym = word == word.uppercase() && word != word.lowercase()
     // De-capitalise the first letter only (the common sentence-initial case).
-    if (word.first().isUpperCase()) {
+    if (word.first().isUpperCase() && !isAcronym) {
         candidates += word.replaceFirstChar { it.lowercaseChar() }
     }
     // A SHOUTED or Mixed-case token: a fully lower-cased form is worth a try.

--- a/core-data/src/main/kotlin/in/jphe/storyvox/data/repository/stats/ListeningStats.kt
+++ b/core-data/src/main/kotlin/in/jphe/storyvox/data/repository/stats/ListeningStats.kt
@@ -122,13 +122,16 @@ object ListeningStatsCalculator {
         val activeDays = activity.mapTo(HashSet()) { localDate(it.openedAt, zone) }
 
         // Finished-chapter contributions, bucketed once and reused.
-        val finished = activity.asSequence().filter { it.completed }
         var todayMs = 0L
         var weekMs = 0L
         val perDayFinished = HashMap<LocalDate, Int>()
         val perDayMs = HashMap<LocalDate, Long>()
         val perPart = IntArray(DayPart.entries.size)
-        for (row in finished) {
+        // #1265 — iterate the list directly, skipping incomplete rows, instead
+        // of wrapping it in `asSequence().filter {}` (which allocates a Sequence
+        // + filtering machinery for a single in-memory pass).
+        for (row in activity) {
+            if (!row.completed) continue
             val zdt = Instant.ofEpochMilli(row.openedAt).atZone(zone)
             val day = zdt.toLocalDate()
             if (day == today) todayMs += row.durationEstimateMs

--- a/core-data/src/test/kotlin/in/jphe/storyvox/data/dictionary/LookupWordTest.kt
+++ b/core-data/src/test/kotlin/in/jphe/storyvox/data/dictionary/LookupWordTest.kt
@@ -68,9 +68,10 @@ class LookupWordTest {
     }
 
     @Test
-    fun `all-caps acronym adds a fully lowercased candidate`() {
-        // "NASA" -> as-seen, then first-letter-lower ("nASA"), then full lower ("nasa").
-        assertEquals(listOf("NASA", "nASA", "nasa"), lemmaCandidates("NASA"))
+    fun `all-caps acronym skips the nonsense mixed-case candidate`() {
+        // #1265 — "NASA" -> as-seen + full lower ("nasa"). The first-letter-lower
+        // form ("nASA") is a guaranteed Wiktionary 404, so it's no longer emitted.
+        assertEquals(listOf("NASA", "nasa"), lemmaCandidates("NASA"))
     }
 
     @Test

--- a/core-playback/src/main/kotlin/in/jphe/storyvox/playback/lang/TextClassifierLanguageDetector.kt
+++ b/core-playback/src/main/kotlin/in/jphe/storyvox/playback/lang/TextClassifierLanguageDetector.kt
@@ -89,7 +89,11 @@ class TextClassifierLanguageDetector internal constructor(
                 if (Build.VERSION.SDK_INT < Build.VERSION_CODES.Q) {
                     null
                 } else {
-                    context.getSystemService(TextClassificationManager::class.java)
+                    // #1265 — resolve the manager off the application context so
+                    // we never pin a short-lived context (the detector keeps the
+                    // TextClassifier, not the Context, so this is defensive).
+                    context.applicationContext
+                        .getSystemService(TextClassificationManager::class.java)
                         ?.textClassifier
                 }
             }.getOrNull()

--- a/feature/src/main/kotlin/in/jphe/storyvox/feature/reader/DefineWordSheet.kt
+++ b/feature/src/main/kotlin/in/jphe/storyvox/feature/reader/DefineWordSheet.kt
@@ -1,7 +1,7 @@
 package `in`.jphe.storyvox.feature.reader
 
+import android.app.Activity
 import android.app.SearchManager
-import android.content.ActivityNotFoundException
 import android.content.Context
 import android.content.Intent
 import android.widget.Toast
@@ -271,8 +271,17 @@ private fun launchWordLookup(context: Context, word: String) {
 }
 
 private fun tryStart(context: Context, intent: Intent): Boolean = try {
+    // #1265 — a non-Activity context (e.g. the application context) can't
+    // launch an Activity without FLAG_ACTIVITY_NEW_TASK. In Compose
+    // LocalContext is normally the Activity, but guard anyway. Catch every
+    // exception (not just ActivityNotFoundException) so a SecurityException or
+    // an odd OEM throw from a dictionary/search app can't crash the reader —
+    // we just fall through to the next candidate / the no-app toast.
+    if (context !is Activity) {
+        intent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
+    }
     context.startActivity(intent)
     true
-} catch (e: ActivityNotFoundException) {
+} catch (e: Exception) {
     false
 }

--- a/feature/src/main/kotlin/in/jphe/storyvox/feature/stats/ListeningStatsScreen.kt
+++ b/feature/src/main/kotlin/in/jphe/storyvox/feature/stats/ListeningStatsScreen.kt
@@ -40,6 +40,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.res.pluralStringResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.semantics.heading
 import androidx.compose.ui.semantics.semantics
@@ -100,11 +101,35 @@ fun ListeningStatsScreen(
                 },
                 actions = {
                     if (shareableStats != null) {
+                        // #1265 — resolve every share line from string resources
+                        // here (plurals for the book/streak counts); the formatter
+                        // stays free of hardcoded English and JVM-testable.
+                        val shareContent = ShareSummaryContent(
+                            header = stringResource(R.string.stats_share_header, appName),
+                            timeListened = stringResource(
+                                R.string.stats_share_time,
+                                StatsFormatting.formatDuration(shareableStats.totalEstimatedMs),
+                            ),
+                            booksFinished = pluralStringResource(
+                                R.plurals.stats_share_books_finished,
+                                shareableStats.booksCompleted,
+                                shareableStats.booksCompleted,
+                            ),
+                            chaptersRead = stringResource(
+                                R.string.stats_share_chapters,
+                                StatsFormatting.formatCompactNumber(shareableStats.chaptersFinished.toLong()),
+                            ),
+                            dayStreak = pluralStringResource(
+                                R.plurals.stats_share_streak,
+                                shareableStats.currentStreakDays,
+                                shareableStats.currentStreakDays,
+                            ),
+                        )
                         IconButton(
                             onClick = {
                                 shareStatsText(
                                     context = context,
-                                    text = StatsFormatting.shareSummary(shareableStats, appName),
+                                    text = StatsFormatting.shareSummary(shareableStats, shareContent),
                                     chooserTitle = chooserTitle,
                                 )
                             },

--- a/feature/src/main/kotlin/in/jphe/storyvox/feature/stats/ListeningStatsViewModel.kt
+++ b/feature/src/main/kotlin/in/jphe/storyvox/feature/stats/ListeningStatsViewModel.kt
@@ -7,6 +7,7 @@ import dagger.hilt.android.lifecycle.HiltViewModel
 import `in`.jphe.storyvox.data.repository.stats.ListeningStats
 import `in`.jphe.storyvox.data.repository.stats.ListeningStatsRepository
 import javax.inject.Inject
+import kotlinx.coroutines.Job
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
@@ -37,12 +38,18 @@ class ListeningStatsViewModel @Inject constructor(
     private val _uiState = MutableStateFlow<ListeningStatsUiState>(ListeningStatsUiState.Loading)
     val uiState: StateFlow<ListeningStatsUiState> = _uiState.asStateFlow()
 
+    /** #1265 — the in-flight load, cancelled before each new [refresh]. */
+    private var refreshJob: Job? = null
+
     init {
         refresh()
     }
 
     fun refresh() {
-        viewModelScope.launch {
+        // #1265 — cancel any in-flight load first so rapid re-entry can't
+        // overlap DB queries or let a stale snapshot land after a newer one.
+        refreshJob?.cancel()
+        refreshJob = viewModelScope.launch {
             _uiState.value = ListeningStatsUiState.Loading
             // A query failure on a stats screen should degrade to the
             // empty state, never crash the app — the data is informational.

--- a/feature/src/main/kotlin/in/jphe/storyvox/feature/stats/StatsFormatting.kt
+++ b/feature/src/main/kotlin/in/jphe/storyvox/feature/stats/StatsFormatting.kt
@@ -100,35 +100,26 @@ object StatsFormatting {
     }
 
     /**
-     * A short, shareable plain-text summary of the snapshot — backs the
-     * top-bar "share" action (the issue's "I listened to N hours" card,
-     * as text rather than a rendered image). Lines are emitted only when
-     * they carry a non-zero figure, so a sparse history reads cleanly.
+     * A short, shareable plain-text summary — backs the top-bar share action
+     * (the issue's "I listened to N hours" card, as text). Lines are emitted
+     * only when they carry a non-zero figure, so a sparse history reads cleanly.
+     *
+     * #1265 — the wording (header, "listened", the plurals, the 🔥) lives in
+     * string resources and is resolved by the UI into [content], so this stays
+     * free of hardcoded English and JVM-testable. The value worth testing here
+     * is the inclusion logic, which the unit test pins.
      */
-    fun shareSummary(stats: ListeningStats, appName: String): String = buildString {
-        append("My listening on ")
-        append(appName)
-        append(':')
-        if (stats.totalEstimatedMs > 0L) {
-            append("\n• ≈ ")
-            append(formatDuration(stats.totalEstimatedMs))
-            append(" listened")
-        }
-        if (stats.booksCompleted > 0) {
-            append("\n• ")
-            append(stats.booksCompleted)
-            append(if (stats.booksCompleted == 1) " book finished" else " books finished")
-        }
-        if (stats.chaptersFinished > 0) {
-            append("\n• ")
-            append(formatCompactNumber(stats.chaptersFinished.toLong()))
-            append(" chapters read")
-        }
-        if (stats.currentStreakDays > 0) {
-            append("\n• ")
-            append(stats.currentStreakDays)
-            append(if (stats.currentStreakDays == 1) " day streak" else " day streak 🔥")
-        }
+    fun shareSummary(stats: ListeningStats, content: ShareSummaryContent): String = buildString {
+        append(content.header)
+        if (stats.totalEstimatedMs > 0L) appendBullet(content.timeListened)
+        if (stats.booksCompleted > 0) appendBullet(content.booksFinished)
+        if (stats.chaptersFinished > 0) appendBullet(content.chaptersRead)
+        if (stats.currentStreakDays > 0) appendBullet(content.dayStreak)
+    }
+
+    private fun StringBuilder.appendBullet(line: String) {
+        append("\n• ")
+        append(line)
     }
 
     /** Single-letter weekday initial (Mon→"M") for the compact trend axis. */
@@ -150,3 +141,17 @@ object StatsFormatting {
         DayPart.NIGHT -> "Night"
     }
 }
+
+/**
+ * Localized, fully-resolved lines for [StatsFormatting.shareSummary]. The UI
+ * supplies these from string resources (including plurals for the book/streak
+ * counts), so the formatter holds no hardcoded English and stays JVM-testable.
+ * #1265.
+ */
+data class ShareSummaryContent(
+    val header: String,
+    val timeListened: String,
+    val booksFinished: String,
+    val chaptersRead: String,
+    val dayStreak: String,
+)

--- a/feature/src/main/res/values/strings.xml
+++ b/feature/src/main/res/values/strings.xml
@@ -1054,6 +1054,19 @@
     <string name="stats_share">Share stats</string>
     <string name="stats_share_chooser">Share your listening stats</string>
     <string name="stats_app_name">Candela</string>
+    <!-- #1265 — share-summary lines: resolved in the UI (plurals for the
+         book/streak counts) and assembled by StatsFormatting.shareSummary. -->
+    <string name="stats_share_header">My listening on %1$s:</string>
+    <string name="stats_share_time">≈ %1$s listened</string>
+    <string name="stats_share_chapters">%1$s chapters read</string>
+    <plurals name="stats_share_books_finished">
+        <item quantity="one">%1$d book finished</item>
+        <item quantity="other">%1$d books finished</item>
+    </plurals>
+    <plurals name="stats_share_streak">
+        <item quantity="one">%1$d day streak</item>
+        <item quantity="other">%1$d day streak 🔥</item>
+    </plurals>
     <string name="stats_total_time_label">Time listened</string>
     <!-- %1$d current streak, %2$d longest streak -->
     <string name="stats_streak_line">🔥 %1$d-day streak · best ever %2$d</string>

--- a/feature/src/test/kotlin/in/jphe/storyvox/feature/stats/StatsFormattingTest.kt
+++ b/feature/src/test/kotlin/in/jphe/storyvox/feature/stats/StatsFormattingTest.kt
@@ -3,7 +3,6 @@ package `in`.jphe.storyvox.feature.stats
 import `in`.jphe.storyvox.data.repository.stats.ListeningStats
 import `in`.jphe.storyvox.data.repository.stats.SourceShare
 import org.junit.Assert.assertEquals
-import org.junit.Assert.assertTrue
 import org.junit.Test
 
 /**
@@ -59,7 +58,17 @@ class StatsFormattingTest {
     }
 
     @Test
-    fun `share summary only emits lines with non-zero figures`() {
+    fun `share summary emits the header plus one bullet per non-zero figure`() {
+        // #1265 — wording is now supplied by the UI; the formatter just decides
+        // which lines appear and assembles them. Sentinel strings make the
+        // assembly + inclusion logic exact.
+        val content = ShareSummaryContent(
+            header = "HEADER",
+            timeListened = "TIME",
+            booksFinished = "BOOKS",
+            chaptersRead = "CHAPTERS",
+            dayStreak = "STREAK",
+        )
         val populated = ListeningStats.EMPTY.copy(
             totalEstimatedMs = 15 * 60_000L,
             booksCompleted = 2,
@@ -67,24 +76,21 @@ class StatsFormattingTest {
             currentStreakDays = 3,
             chaptersOpened = 50,
         )
-        val text = StatsFormatting.shareSummary(populated, "Candela")
-        assertTrue(text.startsWith("My listening on Candela:"))
-        assertTrue(text.contains("≈ 15m listened"))
-        assertTrue(text.contains("2 books finished"))
-        assertTrue(text.contains("42 chapters read"))
-        assertTrue(text.contains("3 day streak"))
+        assertEquals(
+            "HEADER\n• TIME\n• BOOKS\n• CHAPTERS\n• STREAK",
+            StatsFormatting.shareSummary(populated, content),
+        )
 
         // An empty snapshot collapses to just the header — no zero-value noise.
-        val empty = StatsFormatting.shareSummary(ListeningStats.EMPTY, "Candela")
-        assertEquals("My listening on Candela:", empty)
+        assertEquals("HEADER", StatsFormatting.shareSummary(ListeningStats.EMPTY, content))
     }
 
     @Test
-    fun `share summary singularizes a one-book, one-day result`() {
-        val one = ListeningStats.EMPTY.copy(booksCompleted = 1, currentStreakDays = 1, chaptersOpened = 1)
-        val text = StatsFormatting.shareSummary(one, "Candela")
-        assertTrue(text.contains("1 book finished"))
-        assertTrue(text.contains("1 day streak"))
+    fun `share summary omits the lines whose figures are zero`() {
+        val content = ShareSummaryContent("H", "TIME", "BOOKS", "CHAPTERS", "STREAK")
+        // Only books-finished + streak are non-zero here.
+        val partial = ListeningStats.EMPTY.copy(booksCompleted = 1, currentStreakDays = 1, chaptersOpened = 1)
+        assertEquals("H\n• BOOKS\n• STREAK", StatsFormatting.shareSummary(partial, content))
     }
 
     @Test


### PR DESCRIPTION
Closes #1265 — the consolidated tracker of **valid-but-non-blocking** bot-review findings across the four #1235-series PRs (#1258–#1261), triaged by Nebula. All 12 items + the recommended defensive SQL join, in one commit.

### #1258 — in-app file import
- **IO offload** — `importLocalFile` now runs the whole resolve→classify→register sequence on `Dispatchers.IO` (`contentResolver.getType`, the SAF display-name query, and the per-format DataStore writes were on the caller's main-ish dispatcher).
- **Privacy** — dropped the document name / URI from the two `Log.w` calls (the name still appears in the user-facing error string, which isn't logged).
- **URI normalization** — `PdfConfigImpl.importFile` normalizes (`trim`) once and hashes the normalized form, so the stored `uriString` and the derived `fictionId` agree.
- **MIME threading** — `importDocument(uri, mimeHint)` takes the processed intent's `type` instead of reading the mutable Activity `intent` field (`onNewIntent` could swap it first).
- **Scheme guard** — `persistReadGrant` skips non-`content://` Uris instead of throwing a caught `SecurityException` + noisy warn on the `file://` debug seed.

### #1259 — auto language detection
- `TextClassificationManager` resolved off `context.applicationContext` (defensive against pinning a short-lived context).

### #1260 — tap-to-define dictionary
- **Acronym lemma** — all-caps words skip the first-letter-lowercased candidate (`"NASA"` → `["NASA", "nasa"]`, no guaranteed-404 `"nASA"` request). `LookupWordTest` updated.
- **Cancellation** — `ensureActive()` before each blocking `fetch` in the candidate loop.
- **`tryStart` hardening** — adds `FLAG_ACTIVITY_NEW_TASK` for non-Activity contexts and catches any `Exception` (not just `ActivityNotFoundException`).

### #1261 — listening stats
- **Micro-opt** — direct `for` loop (skip incomplete rows) instead of `asSequence().filter {}` in `ListeningStatsCalculator.assemble`.
- **Refresh races** — `ListeningStatsViewModel` cancels the prior refresh job before relaunch.
- **i18n `shareSummary`** — the English wording (header, "listened", plurals, the 🔥) moves to string resources; the UI resolves localized lines (incl. `pluralStringResource` for book/streak counts) and passes them in via `ShareSummaryContent`, keeping `StatsFormatting` free of hardcoded English and JVM-testable. The unit test now pins the assembly + inclusion logic with sentinel strings.
- **Defensive join** — `ListeningStatsDao` word-count query uses the composite `c.fictionId = h.fictionId AND c.id = h.chapterId`, matching the file's sibling `playback_position` joins (the "Cartesian product" finding was triaged a false positive; this is the recommended consistency tweak).

### Tests
- `LookupWordTest`: acronym case updated.
- `StatsFormattingTest`: `shareSummary` tests rewritten for the new signature (assembly + inclusion logic; plurals are now the UI's concern).

No behavioral change to the share output for English users (plurals reproduce the prior "1 book finished" / "N books finished 🔥-on-streak" wording).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Listening stats sharing now uses localized text and pluralized labels, making shared summaries clearer and more natural.

* **Bug Fixes**
  * Improved document import handling from notifications and deep links.
  * Fixed crashes when opening dictionary lookups from non-activity contexts.
  * Made word lookup smarter for acronyms like “NASA”.
  * Improved stats refresh behavior to avoid overlapping updates.
  * Fixed several import and playback edge cases for more reliable behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->