### PR TITLE
chore: bump targetSdk 35 → 36 (Android 16)

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -183,7 +183,7 @@ android {
     defaultConfig {
         applicationId = "org.techempower.candela"
         minSdk = 26
-        targetSdk = 35
+        targetSdk = 36
         versionCode = 240
         versionName = "1.2.5"
 

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -68,7 +68,7 @@
         android:roundIcon="@mipmap/ic_launcher_round"
         android:supportsRtl="true"
         android:theme="@android:style/Theme.Material.NoActionBar"
-        tools:targetApi="35">
+        tools:targetApi="36">
 
         <activity
             android:name=".MainActivity"

--- a/baselineprofile/build.gradle.kts
+++ b/baselineprofile/build.gradle.kts
@@ -69,7 +69,7 @@ android {
         // needs to install on devices that can actually generate
         // profiles. The Tab A7 Lite is Android 14.)
         minSdk = 28
-        targetSdk = 35
+        targetSdk = 36
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
     }


### PR DESCRIPTION
## Summary
- Bumps `targetSdk` from 35 to 36 across `app` and `baselineprofile` modules
- Updates `tools:targetApi` lint hint in AndroidManifest.xml
- Wear module left at 34 per its own pinned cadence (separate decision)

Addresses the targetSdk finding from Play Store audit #1269.

**API 36 behavioral changes (verified by Reverie):**
- Edge-to-edge opt-out removal — already handled (`enableEdgeToEdge()` in MainActivity)
- 16KB page-size native libs — already required at targetSdk 35; no new exposure
- Predictive back — optional, no breaking change
- Large-screen adaptive — app already tablet-oriented, no restrictive flags set

## Test plan
- [ ] CI Build APK passes
- [ ] Smoke test: TTS + OCR load on API 36 device/emulator
- [ ] Smoke test: back-nav (reader→library→exit) on API 36

🤖 Generated with [Claude Code](https://claude.com/claude-code)