### PR TITLE
docs(privacy): disclose camera/OCR, drop stale 988/911, fix permissions table (#1269)

### DIFF
--- a/docs/play-store-policy-check.md
+++ b/docs/play-store-policy-check.md
@@ -131,13 +131,14 @@ visible workloads and are user-stoppable.
 
 ### Surface
 
-The TechEmpower Home screen's Emergency Help card surfaces three buttons:
+The TechEmpower Home screen surfaces a single **Call 211** affordance:
 
-- **988** — 988 Suicide & Crisis Lifeline (US)
-- **211** — United Way local services (US / Canada)
-- **911** — emergency services (US / Canada)
+- **211** — United Way local community services (US / Canada)
 
-Tapping any of them fires `Intent.ACTION_DIAL` with the number pre-filled.
+(The earlier **988** Suicide & Crisis Lifeline and **911** emergency
+buttons were removed in #775; 211 is the only surviving dial affordance.)
+
+Tapping it fires `Intent.ACTION_DIAL` with the number pre-filled.
 **Candela never calls `ACTION_CALL`** (which would dial automatically and
 need `CALL_PHONE` permission). The user has to tap "Call" in the dialer
 themselves.
@@ -160,8 +161,8 @@ can't make calls" dialog with copy-to-clipboard and a web fallback for 211
   emergency-service contact info.
 
 Candela doesn't charge, doesn't claim to be an emergency service, and
-uses the public, well-known short codes (988 / 211 / 911 are first-party
-US numbers). The UX is "open the dialer with a number pre-filled" —
+uses the public, well-known 211 short code (a first-party US/Canada
+social-services number). The UX is "open the dialer with a number pre-filled" —
 identical to clicking a `tel:` link in a web browser.
 
 ### Disclosure / remediation
@@ -170,7 +171,7 @@ identical to clicking a `tel:` link in a web browser.
 | --- | --- |
 | Uses `CALL_PHONE` permission? | **No** — uses `ACTION_DIAL` only, no permission required |
 | Auto-places calls? | **No** — user must confirm in the dialer |
-| Accurate numbers? | **Yes** — 988, 211, 911 are the documented US/CA short codes |
+| Accurate numbers? | **Yes** — 211 is the documented US/CA social-services short code |
 | Tablet / WiFi-only handling? | **Yes** — runtime check + fallback dialog |
 | Disclaimer text in the card? | **Recommend adding for v1.0** — one line "These are US/Canada numbers. For emergencies outside US/Canada, use your local emergency number." |
 
@@ -199,7 +200,7 @@ submission time.
 | **Library state** (fiction IDs, reading positions, voice preferences) | Yes, **only with optional sync** | No | Yes | Yes — sign out | App functionality (sync) |
 | Crash / diagnostic data | **No** | — | — | — | We don't collect crash data |
 | Approximate / precise location | **No** | — | — | — | Never requested |
-| Photos / videos / audio | **No** | — | — | — | No camera / mic access |
+| Photos / videos / audio | **No** | — | — | — | Camera is used on-device for OCR scan-to-read (#995): images + recognized text are processed by ML Kit on-device and are **never** transmitted, collected, or shared — so "collected" stays **No** even though the CAMERA permission is declared. No microphone access. |
 | Files / docs | **No** | — | — | — | EPUB import reads files via SAF; doesn't send them anywhere |
 | Contacts | **No** | — | — | — | Never requested |
 | App activity (page views, in-app actions) | **No** | — | — | — | No analytics |
@@ -233,7 +234,8 @@ submission time.
 ## 5. Permissions audit
 
 Every `<uses-permission>` in `app/src/main/AndroidManifest.xml`, why it's
-declared, and the user benefit. (Source: lines 5–19 of the manifest.)
+declared, and the user benefit. (Source: the `<uses-permission>`
+declarations in the manifest.)
 
 | Permission | Why | User benefit |
 | --- | --- | --- |
@@ -245,6 +247,8 @@ declared, and the user benefit. (Source: lines 5–19 of the manifest.)
 | `android.permission.FOREGROUND_SERVICE_DATA_SYNC` | ChapterRenderJob + tag-sync worker (API 34+) | Gapless chapter transitions (pre-render); cross-device sync |
 | `android.permission.POST_NOTIFICATIONS` | The playback notification (transport buttons + Continue Listening); also used by the WorkManager foreground notifications | Lock-screen and notification-shade transport controls — primary UX for audiobook playback. Without this on API 33+ the user has no transport surface outside the app itself. |
 | `android.permission.RECEIVE_BOOT_COMPLETED` | The home-screen widget (#159) needs to redraw on boot if the user has a widget placed; the receiver listens for the broadcast so the widget shows the last-played state when the device finishes booting | Widget shows correct state after reboot rather than a "tap to launch" placeholder |
+| `android.permission.ACCESS_NOTIFICATION_POLICY` | The sleep-timer (#1190) can auto-enable Do Not Disturb as audio fades at the end of a timed session; this permission lets the app toggle the user's interruption filter | The device goes quiet when the audiobook stops, without the user manually enabling DND |
+| `android.permission.CAMERA` | OCR scan-to-read (#995): capture printed text with the camera and convert it **on-device** (ML Kit) into a narratable chapter. Requested at runtime with a plain-language rationale; the optional `uses-feature android:required="false"` keeps the app installable on camera-less tablets | Read physical books / printouts aloud; the gallery-pick fallback needs no permission |
 | `<uses-feature android:hardware.telephony required="false" />` | (not a permission — feature gate) | Keeps app installable on WiFi-only tablets; runtime check before dial |
 
 **Permissions NOT requested** (and why each is intentionally absent):
@@ -255,7 +259,6 @@ declared, and the user benefit. (Source: lines 5–19 of the manifest.)
 | `READ_PHONE_STATE` | We don't need device identifiers, IMEI, line type |
 | `ACCESS_FINE_LOCATION` / `ACCESS_COARSE_LOCATION` | No location features |
 | `RECORD_AUDIO` | No mic access (TTS generates; nothing records) |
-| `CAMERA` | No camera access |
 | `READ_CONTACTS` / `WRITE_CONTACTS` | No contacts use |
 | `READ_EXTERNAL_STORAGE` / `WRITE_EXTERNAL_STORAGE` / `MANAGE_EXTERNAL_STORAGE` | EPUB import uses the Storage Access Framework (SAF) — no broad storage permission needed |
 | `com.google.android.gms.permission.AD_ID` | No advertising; no ad ID needed |

--- a/docs/privacy.md
+++ b/docs/privacy.md
@@ -118,15 +118,27 @@ for users on an Anthropic Teams plan who'd rather not paste an API key.
 Sign-in lands a token in `EncryptedSharedPreferences` on-device. The token
 goes to Anthropic when you chat; nowhere else.
 
-### 2.7 Emergency Help card
+### 2.7 Call 211 (social services)
 
-The TechEmpower Home screen surfaces three emergency-resource shortcuts:
-**988** (988 Suicide & Crisis Lifeline, US), **211** (United Way local
-services, US/Canada), and **911** (emergency, US/Canada). Tapping a shortcut
-opens the device's dialer with the number pre-filled — **Candela does not
-place the call automatically**, you have to tap "Call" in the dialer. No
-data about whether you tapped a shortcut is collected or transmitted by
-Candela.
+The TechEmpower Home screen surfaces a single **Call 211** shortcut (211 —
+United Way local community services, US/Canada). Tapping it opens the
+device's dialer with the number pre-filled — **Candela does not place the
+call automatically**, you have to tap "Call" in the dialer. No data about
+whether you tapped the shortcut is collected or transmitted by Candela.
+(The earlier 988 and 911 shortcuts were removed in a prior release; 211 is
+the only remaining dial affordance.)
+
+### 2.8 Camera / OCR text capture (optional)
+
+Candela can scan printed text with the device camera and turn it into a
+readable, narratable chapter (optical character recognition). When you
+start a scan, Candela requests camera permission with a plain-language
+explanation first, and the camera is active **only** while you are actively
+capturing. Text recognition runs **entirely on-device** via Google ML Kit:
+the captured image and the recognized text **never leave your device** and
+are never uploaded, collected, or shared. Declining the camera permission
+does not dead-end the feature — you can instead pick an existing image from
+your gallery, which needs no permission.
 
 ---
 


### PR DESCRIPTION
## Summary

Addresses the doc-drift fixes from Reverie's **#1269** Play-Store readiness audit — reconciling `docs/privacy.md` and `docs/play-store-policy-check.md` with the **shipped manifest**. Docs-only, no code change. Each finding was re-verified against source before editing.

## Fixes

### 1. Camera / OCR (#995) — was undisclosed and actively contradicted (HIGH)
The manifest declares `CAMERA` (`AndroidManifest.xml:35`) for OCR scan-to-read, but the docs denied it — a Data Safety form that contradicts a declared permission is a rejection risk (feeds blocker #1139).
- **privacy.md**: new **§2.8 Camera / OCR text capture** — strong, honest story (on-device ML Kit; image + recognized text never leave the device; gallery fallback needs no permission).
- **policy-check.md §4 (Data Safety)**: "Photos/videos/audio → *No camera / mic access*" was **false** → reworded to the on-device-OCR rationale (`Collected` stays **No** since nothing is transmitted, but the permission is no longer denied).
- **policy-check.md §5**: `CAMERA` moved out of "NOT requested" into the requested-permissions table.

### 2. Stale 988 / 911 emergency content (MEDIUM)
#775 removed the 988/911 affordances — `Help211` is the only surviving target (confirmed in `TechEmpowerIntents.kt:92-93` + `TechEmpowerHomeScreen.kt`). Reconciled **privacy.md §2.7** and **policy-check.md §3** to **211-only**, keeping a one-line "removed in #775" note for provenance.

### 3. Permissions-table gap (LOW)
Added the two declared-but-undocumented permissions to the policy-check §5 table: `CAMERA` (#995) and `ACCESS_NOTIFICATION_POLICY` (#1190 sleep-timer auto-DND). Also fixed the table's stale "Source: lines 5–19" note.

## Verification
- `CAMERA` (manifest:35) and `ACCESS_NOTIFICATION_POLICY` (manifest:26) confirmed declared.
- 211-only confirmed in the TechEmpower UI source (no `Crisis988`/`Dispatch911` remain).
- Post-edit grep: no surviving "no camera access" claims; no stray 988/911 except the intentional historical notes.

## Out of scope (tracked in #1269)
The live **website** privacy policy likely needs a matching sync (static microsite — separate from these repo docs); plus #1269's M2 (targetSdk), M3 (keystore), L2 (CHANGELOG), L3/L4/L5 doc nits, and the #1139 Data Safety form itself.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
