### PR TITLE
chore: housekeeping — .gitignore + CLAUDE.md CI runner docs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -60,6 +60,13 @@ scratch/
 # See issue #696.
 source-kvmr/
 
+# Python (scripts/wiki tooling)
+__pycache__/
+*.pyc
+
+# Profiling
+*.hprof
+
 # Misc
 *.bak
 *.swp

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -11,7 +11,13 @@ Android app that turns text from 20+ sources into narrated audiobooks via TTS. K
 ./gradlew testDebugUnitTest           # all tests
 ```
 
-CI runs on self-hosted runner (katana). Tags trigger release APK build + GitHub release.
+CI runs on self-hosted runners (katana + familiar). Tags trigger release APK build + GitHub release.
+
+**CI runner — familiar**: familiar sleeps when idle. If a CI run stays queued >60s, wake it:
+```bash
+realm wol wake familiar
+```
+Wait ~60s for boot, then CI picks up automatically. Never compile locally on katana — push and let CI be the compile gate.
 
 ## Module layout
 


### PR DESCRIPTION
## Summary
- Add `__pycache__/`, `*.pyc`, `*.hprof` to `.gitignore` (found during stale code audit #1270)
- Update CLAUDE.md with familiar CI runner wake instructions (`realm wol wake familiar`) so agents know to wake the sleeping runner

## Test plan
- [ ] CI passes (no code changes)

🤖 Generated with [Claude Code](https://claude.com/claude-code)