### PR TITLE
fix(playback): stop auto-advance skipping a stuck/warming chapter (#1262)

### DIFF
--- a/core-playback/src/main/kotlin/in/jphe/storyvox/playback/PlaybackController.kt
+++ b/core-playback/src/main/kotlin/in/jphe/storyvox/playback/PlaybackController.kt
@@ -521,13 +521,25 @@ class DefaultPlaybackController @Inject constructor(
                 watchdogJob = scope.launch {
                     kotlinx.coroutines.delay(threshold)
                     val nowState = p.observableState.value
-                    // Only fire if we're STILL buffering AND still on
-                    // the same chapter id (i.e. nothing else has
-                    // happened — no advance, no pause, no error).
+                    // Snapshot the in-flight latch once: it both gates the
+                    // #1262 warm-up check and (when we do fire) chooses the
+                    // recovery direction. Reading it twice could tear across
+                    // a concurrent advanceChapter entry/exit.
+                    val inFlightDir = p.inFlightAdvanceDirection
+                    // Fire only for a genuinely stuck state. The base gate
+                    // (still buffering, same chapter, no error) PLUS the
+                    // #1262 refusal to skip a chapter that is merely warming
+                    // up its first synth chunk (no sentence emitted yet AND
+                    // no advance in flight) live in the pure resolver
+                    // [shouldWatchdogFireFallbackAdvance].
                     if (
-                        nowState.isBuffering &&
-                        nowState.currentChapterId == armedFor &&
-                        nowState.error == null
+                        shouldWatchdogFireFallbackAdvance(
+                            isBuffering = nowState.isBuffering,
+                            currentChapterIdMatchesArmed = nowState.currentChapterId == armedFor,
+                            hasError = nowState.error != null,
+                            noActiveSentenceRange = nowState.currentSentenceRange == null,
+                            inFlightAdvanceDirection = inFlightDir,
+                        )
                     ) {
                         // Issue #726 — mirror the in-flight direction
                         // instead of hardcoding +1. Pre-fix a slow
@@ -539,14 +551,12 @@ class DefaultPlaybackController @Inject constructor(
                         // semantics (mirror when set, fall back to +1
                         // for the original #553 case where the engine
                         // is stuck without an active advance call).
-                        val watchdogDir = watchdogRecoveryDirection(
-                            p.inFlightAdvanceDirection,
-                        )
+                        val watchdogDir = watchdogRecoveryDirection(inFlightDir)
                         android.util.Log.w(
                             "PlaybackController",
                             "#553/#726 watchdog: isBuffering stuck on $armedFor for " +
                                 "${threshold}ms; firing fallback advance " +
-                                "direction=$watchdogDir (in-flight=${p.inFlightAdvanceDirection})",
+                                "direction=$watchdogDir (in-flight=$inFlightDir)",
                         )
                         // #553 follow-up — Media3's Player object is
                         // thread-confined to the application's Main
@@ -589,6 +599,26 @@ class DefaultPlaybackController @Inject constructor(
                                 )
                             }
                         }
+                    } else if (
+                        nowState.isBuffering &&
+                        nowState.currentChapterId == armedFor &&
+                        nowState.error == null
+                    ) {
+                        // Issue #1262 — base gate held (still buffering on
+                        // the armed chapter, no surfaced error) but the
+                        // fallback advance was suppressed: the chapter is
+                        // loaded and its first synth chunk hasn't landed yet
+                        // (no sentence emitted) with no advance in flight —
+                        // i.e. it's warming up, not stuck. Skipping a chapter
+                        // mid-first-chunk is never valid recovery. Log so a
+                        // future recurrence stays observable in logcat
+                        // (adb run-as is gone post-isDebuggable=false).
+                        android.util.Log.i(
+                            "PlaybackController",
+                            "#1262 watchdog: $armedFor still warming up first chunk " +
+                                "(no sentence emitted, in-flight=$inFlightDir) after " +
+                                "${threshold}ms — NOT skipping; awaiting synth",
+                        )
                     }
                 }
             }
@@ -960,6 +990,69 @@ class DefaultPlaybackController @Inject constructor(
             inFlightDirection > 0 -> 1
             inFlightDirection < 0 -> -1
             else -> 1
+        }
+
+        /**
+         * Issue #1262 — should the buffering-stuck watchdog actually fire
+         * its fallback advance, given the [PlaybackState] sampled at fire
+         * time (after the threshold delay) plus the engine's in-flight
+         * advance latch?
+         *
+         * The base gate is unchanged from the pre-#1262 fire condition:
+         * only act if we are STILL buffering, STILL on the chapter the
+         * timer was armed for, and there is no surfaced error.
+         *
+         * The #1262 addition refuses to fire for ONE specific state — the
+         * post-load first-chunk synthesis warm-up of a freshly-loaded
+         * chapter:
+         *
+         *  - [noActiveSentenceRange] `== true`  — no sentence has emitted
+         *    yet (the pipeline hasn't produced its first PCM chunk), AND
+         *  - [inFlightAdvanceDirection] `== 0`  — NO advance is in flight.
+         *    `advanceChapter` sets the latch on entry and clears it in its
+         *    `finally`, so a zero latch means `advanceChapter` already
+         *    returned and [EnginePlayer.loadAndPlay] HAS started the new
+         *    chapter's pipeline. The chapter is loaded and synthesizing.
+         *
+         * That combination is a chapter warming up, not a stuck
+         * transition. On a phone the first Piper/Kokoro chunk of a
+         * cache-MISS chapter routinely takes several seconds; the
+         * consumer's pre-buffer/underrun gate flips `isBuffering = true`
+         * with `currentSentenceRange == null` during that window, which the
+         * pre-#1262 watchdog misread as a stuck 1.5 s "transition" and
+         * "recovered" by advancing PAST the chapter — silently skipping it.
+         * That is the #1262 symptom: a chapter whose PCM prerender never
+         * finalized (the "hourglass" partial cache) is ALWAYS a MISS, so
+         * its warm-up always overran 1.5 s and it was always skipped on
+         * auto-advance, yet played fine on a manual tap whose warm-up
+         * happened to beat the timer. Skipping a chapter whose engine is
+         * mid-first-chunk is never valid recovery — the next chapter uses
+         * the same engine and is just as slow.
+         *
+         * Both genuinely-stuck states still fire:
+         *  - Next chapter's body never loads → an advance is parked on the
+         *    body-wait, so [inFlightAdvanceDirection] `!= 0` (and the wait
+         *    is independently bounded by
+         *    [EnginePlayer.CHAPTER_BODY_WAIT_TIMEOUT_MS]).
+         *  - Natural end never fired END_PILL (the original #553 case) → a
+         *    sentence WAS emitted, so [noActiveSentenceRange] `== false`.
+         *
+         * Trade-off: a chapter whose engine truly hangs on its first chunk
+         * (the chunk never arrives) is no longer auto-skipped. That is
+         * rare, is not helped by skipping to the same-engine next chapter,
+         * and leaves the user a visible spinner to act on — strictly better
+         * than silently losing a perfectly playable chapter on every pass.
+         */
+        fun shouldWatchdogFireFallbackAdvance(
+            isBuffering: Boolean,
+            currentChapterIdMatchesArmed: Boolean,
+            hasError: Boolean,
+            noActiveSentenceRange: Boolean,
+            inFlightAdvanceDirection: Int,
+        ): Boolean {
+            if (!isBuffering || !currentChapterIdMatchesArmed || hasError) return false
+            val firstChunkWarmUp = noActiveSentenceRange && inFlightAdvanceDirection == 0
+            return !firstChunkWarmUp
         }
 
         /**

--- a/core-playback/src/main/kotlin/in/jphe/storyvox/playback/tts/EnginePlayer.kt
+++ b/core-playback/src/main/kotlin/in/jphe/storyvox/playback/tts/EnginePlayer.kt
@@ -75,14 +75,17 @@ import kotlinx.coroutines.Job
 import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.cancel
 import kotlinx.coroutines.delay
+import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharedFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asSharedFlow
 import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.filter
 import kotlinx.coroutines.flow.filterNotNull
 import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.runBlocking
@@ -135,6 +138,89 @@ import kotlinx.coroutines.withContext
  */
 internal fun shouldAutoPlayAfterAdvance(stateAfterWait: PlaybackState): Boolean =
     stateAfterWait.isPlaying
+
+/**
+ * Issue #1262 — wait for a chapter's body to land in Room before
+ * [EnginePlayer.advanceChapter] hands off to `loadAndPlay`, RE-QUEUING a
+ * fresh download on every attempt.
+ *
+ * ## Root cause this fixes
+ *
+ * Auto-advance and the manual "Listen" path (`PlaybackBindings.startListening`)
+ * share the exact same `queueChapterDownload` + `observeChapter()
+ * .filterNotNull().first()` shape — and auto-advance actually waits LONGER
+ * (60 s vs 30 s). So there is no code-path difference that would make a
+ * chapter play on a manual tap yet skip on auto-advance; the difference is
+ * timing. When the next chapter's body isn't already cached — its #558
+ * prefetch download was killed mid-flight (e.g. a low-memory kill during
+ * TTS playback) and left the row stuck at `DOWNLOADING` — the single
+ * fixed-window wait loses the race against the download completing and
+ * surfaces a terminal error, stranding the chapter. A later manual tap
+ * finds the by-then-completed body in Room and plays it fine, which is the
+ * "manual works, auto-advance skips" symptom from the field report.
+ *
+ * Note the issue's own proposed fixes do NOT address this: resetting the
+ * row to `QUEUED` on timeout is a no-op (`queueChapterDownload` already
+ * sets `QUEUED` before scheduling), and the #705 reaper's 5-minute cutoff
+ * never gates the target chapter for the same reason.
+ *
+ * ## The recovery
+ *
+ * Re-queue on EVERY attempt. [ChapterRepository.queueChapterDownload] flips
+ * the row to `QUEUED` and REPLACE-enqueues a brand-new worker
+ * (`runAttemptCount = 0`, no exponential backoff), so a worker that was
+ * killed mid-flight gets a CLEAN restart on the retry instead of the wait
+ * parking on a dead/stuck job. The first attempt keeps the full
+ * `firstTimeoutMs` window (preserving #558's headroom for slow Notion
+ * walks); follow-up attempts use the shorter `retryTimeoutMs`, keeping the
+ * worst-case total wait bounded so a truly dead chapter still surfaces an
+ * actionable error promptly.
+ *
+ * Returns `true` once the body is present, `false` if it never lands across
+ * [attempts] windows (the caller then surfaces the terminal error).
+ * Rethrows [kotlin.coroutines.cancellation.CancellationException] so a skip
+ * / seek / teardown during the wait propagates instead of being swallowed
+ * (#1175), rather than being mistaken for "not ready" and retried.
+ *
+ * Extracted as a top-level suspend function so the retry semantics can be
+ * exercised in a pure coroutine-test (ChapterBodyWaitRetryTest) without
+ * standing up the full EnginePlayer + Hilt + sherpa-onnx graph — the same
+ * constraint that gates [shouldAutoPlayAfterAdvance].
+ *
+ * @param observeBodyPresent re-subscribed on each attempt; emits `true`
+ *   when the chapter's body is present in Room (Room re-queries on write).
+ */
+internal suspend fun awaitChapterBodyReady(
+    attempts: Int,
+    firstTimeoutMs: Long,
+    retryTimeoutMs: Long,
+    queueDownload: suspend () -> Unit,
+    observeBodyPresent: () -> Flow<Boolean>,
+): Boolean {
+    var attempt = 0
+    while (attempt < attempts) {
+        queueDownload()
+        val timeoutMs = if (attempt == 0) firstTimeoutMs else retryTimeoutMs
+        val present = try {
+            kotlinx.coroutines.withTimeoutOrNull(timeoutMs) {
+                observeBodyPresent().filter { it }.first()
+            }
+        } catch (t: Throwable) {
+            // #1175 — never swallow cancellation: a skip / seek / teardown
+            // during the wait must stop advanceChapter, not fall through to
+            // another re-queue + retry. (withTimeoutOrNull handles its OWN
+            // timeout by returning null; anything reaching here is either an
+            // external cancellation or an observe error.)
+            if (t is kotlin.coroutines.cancellation.CancellationException) throw t
+            // observe failed (Room flow hiccup) — treat as "not ready this
+            // window" and let the loop re-queue + retry.
+            null
+        }
+        if (present == true) return true
+        attempt++
+    }
+    return false
+}
 
 /**
  * Issue #980 — pure guard for whether a position checkpoint has anything to
@@ -4466,36 +4552,39 @@ class EnginePlayer @AssistedInject constructor(
             "EnginePlayer",
             "advanceChapter: targeting next=$nextId, queueing download + waiting for body",
         )
-        chapterRepo.queueChapterDownload(fiction, nextId, requireUnmetered = false)
-        // Issue #553 — wait for the chapter body, but with a hard cap.
-        // Pre-fix `observeChapter(nextId).filterNotNull().first()` could
-        // park indefinitely if the row never lands (download stuck,
-        // network down, scheduler queue blocked). The audit's stall
-        // symptom (isBuffering=true forever, no audio, MediaSession
-        // state=PLAYING) is exactly what an indefinite park produces.
+        // Issue #553 — wait for the chapter body, but with a hard cap so we
+        // never park indefinitely if the row never lands (download stuck,
+        // network down, scheduler queue blocked). The audit's stall symptom
+        // (isBuffering=true forever, no audio, MediaSession state=PLAYING)
+        // is exactly what an indefinite park produces.
         //
-        // 30 s is generous for an in-library Notion chapter on LAN
-        // (typically <1 s) and short enough that the user can recover
-        // by tapping skip-next manually before the buffer-watchdog in
-        // PlaybackController fires its own retry (~5 s).
-        val readyChapter = try {
-            kotlinx.coroutines.withTimeoutOrNull(
-                CHAPTER_BODY_WAIT_TIMEOUT_MS,
-            ) {
-                chapterRepo.observeChapter(nextId).filterNotNull().first()
-            }
-        } catch (t: Throwable) {
+        // Issue #1262 — do it across CHAPTER_BODY_WAIT_ATTEMPTS windows,
+        // re-queuing a FRESH download worker each time. The re-queue is the
+        // actual recovery: if the next chapter's prefetch download was
+        // killed mid-flight and left the row stuck at DOWNLOADING, one fixed
+        // window parked on that dead job timed out and skipped the chapter
+        // on auto-advance forever — even though a later manual tap (finding
+        // the by-then-completed body) played it fine. Re-queuing
+        // REPLACE-enqueues a clean worker so the retry actually makes
+        // progress. The first window keeps the full 60 s (#558's headroom
+        // for slow Notion walks); the follow-up is shorter. See
+        // [awaitChapterBodyReady] for the full root-cause writeup.
+        val bodyReady = awaitChapterBodyReady(
+            attempts = CHAPTER_BODY_WAIT_ATTEMPTS,
+            firstTimeoutMs = CHAPTER_BODY_WAIT_TIMEOUT_MS,
+            retryTimeoutMs = CHAPTER_BODY_WAIT_RETRY_TIMEOUT_MS,
+            queueDownload = {
+                chapterRepo.queueChapterDownload(fiction, nextId, requireUnmetered = false)
+            },
+            observeBodyPresent = {
+                chapterRepo.observeChapter(nextId).map { it != null }
+            },
+        )
+        if (!bodyReady) {
             android.util.Log.w(
                 "EnginePlayer",
-                "advanceChapter: observeChapter($nextId) failed (${t.javaClass.simpleName}) — surfacing error",
-            )
-            null
-        }
-        if (readyChapter == null) {
-            android.util.Log.w(
-                "EnginePlayer",
-                "advanceChapter: next chapter $nextId not ready within " +
-                    "${CHAPTER_BODY_WAIT_TIMEOUT_MS}ms; clearing buffering + surfacing error",
+                "advanceChapter: next chapter $nextId not ready after " +
+                    "$CHAPTER_BODY_WAIT_ATTEMPTS attempts; clearing buffering + surfacing error",
             )
             _observableState.update {
                 it.copy(
@@ -5720,6 +5809,25 @@ class EnginePlayer @AssistedInject constructor(
          *  network surfaces an actionable error before the user
          *  walks away from the device. */
         const val CHAPTER_BODY_WAIT_TIMEOUT_MS = 60_000L
+
+        /** Issue #1262 — number of body-wait windows [advanceChapter] tries
+         *  before surfacing the "still downloading" error. Each attempt
+         *  re-queues a FRESH download worker (see [awaitChapterBodyReady]),
+         *  so a worker killed mid-flight (e.g. a low-memory kill during TTS
+         *  playback, which leaves the row stuck at DOWNLOADING) gets a clean
+         *  restart on the retry instead of the wait parking on a dead job —
+         *  the difference between auto-advance skipping a chapter forever
+         *  and it playing the way a manual tap already does. */
+        const val CHAPTER_BODY_WAIT_ATTEMPTS = 2
+
+        /** Issue #1262 — timeout for the follow-up body-wait window(s) after
+         *  the first [CHAPTER_BODY_WAIT_TIMEOUT_MS] one lapses. Shorter than
+         *  the first because the re-queued worker starts clean (no
+         *  exponential backoff) and the body, if it lands at all, lands
+         *  fast; keeps the worst-case total wait bounded (~80 s) so a truly
+         *  dead chapter still surfaces an actionable error before the user
+         *  walks away from the device. */
+        const val CHAPTER_BODY_WAIT_RETRY_TIMEOUT_MS = 20_000L
 
         /** Issue #196 — Kokoro's previously-hardcoded silence scale
          *  (0.2f) is the multiplier=1.0 baseline. We linearly scale

--- a/core-playback/src/test/kotlin/in/jphe/storyvox/playback/WatchdogDirectionTest.kt
+++ b/core-playback/src/test/kotlin/in/jphe/storyvox/playback/WatchdogDirectionTest.kt
@@ -70,4 +70,131 @@ class WatchdogDirectionTest {
     fun `normalizes stale negative values to minus one`() {
         assertEquals(-1, DefaultPlaybackController.watchdogRecoveryDirection(-7))
     }
+
+    // ---- Issue #1262 — shouldWatchdogFireFallbackAdvance ----
+    //
+    // The buffering-stuck watchdog must not skip a chapter that is merely
+    // warming up its first synth chunk. A never-finalized "hourglass"
+    // (partial PCM cache) chapter is always a cache MISS, so its first-chunk
+    // warm-up always overran the 1.5 s "transition" threshold and the
+    // pre-#1262 watchdog advanced PAST it on every auto-advance — yet a
+    // manual tap (warm/foreground) beat the timer and played fine. The
+    // resolver refuses to fire for exactly that warm-up state.
+
+    @Test
+    fun `does NOT fire during first-chunk warm-up — the #1262 case`() {
+        // Buffering, on the armed chapter, no error, NO sentence emitted
+        // yet, and NO advance in flight (advanceChapter already returned and
+        // cleared its latch, so loadAndPlay HAS started the pipeline). This
+        // is the post-load synth warm-up of a cache-MISS chapter — skipping
+        // it is the #1262 bug.
+        assertEquals(
+            false,
+            DefaultPlaybackController.shouldWatchdogFireFallbackAdvance(
+                isBuffering = true,
+                currentChapterIdMatchesArmed = true,
+                hasError = false,
+                noActiveSentenceRange = true,
+                inFlightAdvanceDirection = 0,
+            ),
+        )
+    }
+
+    @Test
+    fun `fires when an advance is parked on the body-wait — forward`() {
+        // No sentence emitted yet, but an advance IS in flight (+1): the
+        // next chapter's body genuinely hasn't landed. Fire (the engine-side
+        // mutex then dedups it if the body lands first; advanceChapter's own
+        // 60 s timeout is the hard backstop).
+        assertEquals(
+            true,
+            DefaultPlaybackController.shouldWatchdogFireFallbackAdvance(
+                isBuffering = true,
+                currentChapterIdMatchesArmed = true,
+                hasError = false,
+                noActiveSentenceRange = true,
+                inFlightAdvanceDirection = 1,
+            ),
+        )
+    }
+
+    @Test
+    fun `fires when a Previous advance is parked on the body-wait`() {
+        // Same as above but the user tapped Previous (-1). Fire — the
+        // direction resolver keeps it going backward (#726).
+        assertEquals(
+            true,
+            DefaultPlaybackController.shouldWatchdogFireFallbackAdvance(
+                isBuffering = true,
+                currentChapterIdMatchesArmed = true,
+                hasError = false,
+                noActiveSentenceRange = true,
+                inFlightAdvanceDirection = -1,
+            ),
+        )
+    }
+
+    @Test
+    fun `fires on an end-of-chapter stall with no advance in flight — original #553`() {
+        // A sentence WAS emitted (noActiveSentenceRange == false): the
+        // chapter played to its end but the natural-end advance never fired
+        // (the original #553 Notion symptom). Fire even with no advance in
+        // flight — this is genuinely stuck, not a warm-up.
+        assertEquals(
+            true,
+            DefaultPlaybackController.shouldWatchdogFireFallbackAdvance(
+                isBuffering = true,
+                currentChapterIdMatchesArmed = true,
+                hasError = false,
+                noActiveSentenceRange = false,
+                inFlightAdvanceDirection = 0,
+            ),
+        )
+    }
+
+    @Test
+    fun `does not fire when no longer buffering`() {
+        assertEquals(
+            false,
+            DefaultPlaybackController.shouldWatchdogFireFallbackAdvance(
+                isBuffering = false,
+                currentChapterIdMatchesArmed = true,
+                hasError = false,
+                noActiveSentenceRange = true,
+                inFlightAdvanceDirection = 0,
+            ),
+        )
+    }
+
+    @Test
+    fun `does not fire when the chapter moved off the armed id`() {
+        // A clean transition happened between arm and fire — don't skip the
+        // chapter we just landed on.
+        assertEquals(
+            false,
+            DefaultPlaybackController.shouldWatchdogFireFallbackAdvance(
+                isBuffering = true,
+                currentChapterIdMatchesArmed = false,
+                hasError = false,
+                noActiveSentenceRange = true,
+                inFlightAdvanceDirection = 1,
+            ),
+        )
+    }
+
+    @Test
+    fun `does not fire when an error is already surfaced`() {
+        // The engine surfaced a typed error (e.g. body-wait timeout); the UI
+        // shows it. Don't pile a skip on top.
+        assertEquals(
+            false,
+            DefaultPlaybackController.shouldWatchdogFireFallbackAdvance(
+                isBuffering = true,
+                currentChapterIdMatchesArmed = true,
+                hasError = true,
+                noActiveSentenceRange = false,
+                inFlightAdvanceDirection = 1,
+            ),
+        )
+    }
 }

--- a/core-playback/src/test/kotlin/in/jphe/storyvox/playback/tts/ChapterBodyWaitRetryTest.kt
+++ b/core-playback/src/test/kotlin/in/jphe/storyvox/playback/tts/ChapterBodyWaitRetryTest.kt
@@ -1,0 +1,101 @@
+package `in`.jphe.storyvox.playback.tts
+
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * Issue #1262 — pure coroutine-test for [awaitChapterBodyReady], the
+ * body-wait-with-retry that lets auto-advance recover a next chapter whose
+ * body isn't cached yet (its #558 prefetch download was killed mid-flight
+ * and left the row stuck at DOWNLOADING).
+ *
+ * Pre-fix `advanceChapter` waited ONE fixed window then surfaced a terminal
+ * error, so a stuck chapter was skipped on auto-advance forever — yet a
+ * later manual tap (finding the by-then-completed body) played it fine. The
+ * decisive test below pins the fix: a body that only lands AFTER a re-queue
+ * is now recovered, and every attempt re-queues a fresh download worker.
+ *
+ * Stays at the pure-function layer; the full EnginePlayer needs a Hilt graph
+ * + sherpa-onnx AARs (same constraint as EnginePlayerAutoPlayDecisionTest).
+ * runTest skips the (virtual) timeout delays, so the window values below
+ * only need to preserve first-vs-retry ordering, not the production 60s/20s.
+ */
+class ChapterBodyWaitRetryTest {
+
+    private val attempts = 2
+    private val firstMs = 60_000L
+    private val retryMs = 20_000L
+
+    @Test
+    fun `returns true immediately when the body is already present`() = runTest {
+        val present = MutableStateFlow(true)
+        var queueCalls = 0
+        val ready = awaitChapterBodyReady(
+            attempts = attempts,
+            firstTimeoutMs = firstMs,
+            retryTimeoutMs = retryMs,
+            queueDownload = { queueCalls++ },
+            observeBodyPresent = { present },
+        )
+        assertTrue("body present on the first window → ready", ready)
+        assertEquals("queued exactly once — no retry needed", 1, queueCalls)
+    }
+
+    @Test
+    fun `recovers a chapter whose body only lands after a re-queue (#1262)`() = runTest {
+        // Body absent on attempt 1; the SECOND queueDownload — the fresh
+        // REPLACE worker that restarts the killed/stuck download — is what
+        // makes it land. Pre-fix's single window would have surfaced the
+        // terminal error here and skipped the chapter forever.
+        val present = MutableStateFlow(false)
+        var queueCalls = 0
+        val ready = awaitChapterBodyReady(
+            attempts = attempts,
+            firstTimeoutMs = firstMs,
+            retryTimeoutMs = retryMs,
+            queueDownload = {
+                queueCalls++
+                if (queueCalls == 2) present.value = true
+            },
+            observeBodyPresent = { present },
+        )
+        assertTrue("body landed after the re-queue → recovered, not skipped", ready)
+        assertEquals("re-queued a fresh worker on the retry", 2, queueCalls)
+    }
+
+    @Test
+    fun `returns false after exhausting all attempts when the body never lands`() = runTest {
+        val present = MutableStateFlow(false)
+        var queueCalls = 0
+        val ready = awaitChapterBodyReady(
+            attempts = attempts,
+            firstTimeoutMs = firstMs,
+            retryTimeoutMs = retryMs,
+            queueDownload = { queueCalls++ },
+            observeBodyPresent = { present },
+        )
+        assertFalse("body never landed → caller surfaces the terminal error", ready)
+        assertEquals("tried every window, re-queuing each time", attempts, queueCalls)
+    }
+
+    @Test
+    fun `a single attempt behaves like the pre-fix single-shot wait`() = runTest {
+        // attempts = 1 collapses to the old one-window behaviour: one queue,
+        // and a body that never lands in that window returns false.
+        val present = MutableStateFlow(false)
+        var queueCalls = 0
+        val ready = awaitChapterBodyReady(
+            attempts = 1,
+            firstTimeoutMs = firstMs,
+            retryTimeoutMs = retryMs,
+            queueDownload = { queueCalls++ },
+            observeBodyPresent = { present },
+        )
+        assertFalse(ready)
+        assertEquals("no retry when attempts == 1", 1, queueCalls)
+    }
+}


### PR DESCRIPTION
## Summary

Fixes #1262 — a chapter that always skips during auto-advance (hourglass icon, never plays) while a manual tap plays it fine. Investigation turned up **two distinct mechanisms**, both fixed here.

> ⚠️ The issue's own root-cause analysis and all three proposed fixes don't hold up against the code (see "Why the issue's fixes don't work"). This PR fixes the actual causes.

## Mechanism 1 (primary): watchdog skips chapters mid-warm-up

The buffering-stuck watchdog (`PlaybackController`, #553/#640/#726) fires a fallback advance after a 1.5s "transition" threshold. A freshly-loaded chapter whose **first synth chunk** hasn't landed yet sits at `isBuffering=true, currentSentenceRange=null` during warm-up — and the watchdog misread that as a stuck transition and **skipped past the chapter**.

A chapter whose PCM prerender never finalized (the "hourglass" partial cache) is *always* a cache miss, so its first-chunk warm-up *always* overran 1.5s → **always skipped on auto-advance**. A manual tap (warm engine / foreground) beat the timer, so it "played fine" — exactly the reported asymmetry, and consistent with the chapter having full content (177 sentences) once it does play.

**Fix:** extract `shouldWatchdogFireFallbackAdvance()` — fire only for genuinely stuck states (an advance parked on the body-wait → `inFlightDir != 0`; or an end-of-chapter stall → a sentence was already emitted), never for the post-load first-chunk warm-up. Trade-off documented: a chapter whose engine truly hangs on its first chunk is no longer auto-skipped (rare; the same-engine next chapter is just as slow), leaving the user a visible spinner instead of silently losing a playable chapter. 7 pure unit tests.

## Mechanism 2 (the issue's literal "stuck DOWNLOADING"): no download retry on auto-advance

`advanceChapter` waited a single fixed window for the next chapter's body to land in Room, then surfaced a terminal error and stopped. A body download killed mid-flight (low-memory kill during playback) leaves the row stuck at `DOWNLOADING` and never recovers on auto-advance, while a later manual tap finds the by-then-completed body.

**Fix:** extract `awaitChapterBodyReady()` to wait across `CHAPTER_BODY_WAIT_ATTEMPTS` windows, **re-queuing a fresh worker each attempt**. `queueChapterDownload` REPLACE-enqueues a clean worker (`runAttemptCount=0`, no backoff), so a killed/stuck download gets a real restart rather than the wait parking on a dead job. First window keeps the full 60s (#558 headroom for slow Notion walks); follow-ups shorter (bounded ~80s). 4 unit tests.

The two fixes compose: #2 gets the body loaded reliably; #1 protects the subsequent synth warm-up from being skipped.

## Why the issue's proposed fixes don't work

- **"Reset to QUEUED on timeout"** — no-op: `queueChapterDownload` already sets `QUEUED` before scheduling, so the next advance already does exactly this.
- **"Reduce the #705 reaper's 5-min cutoff"** — the reaper never gates the *target* chapter (it's QUEUED-first); it only reaps stuck *siblings*.
- **"Periodic reaper"** — doesn't address the in-playback race.
- The download paths are nearly identical: manual `startListening` uses the same queue+wait+play shape and actually waits *less* (30s vs 60s), so there is no code-path difference making manual succeed where auto fails — the difference is runtime timing/state.

## Testing

- `WatchdogDirectionTest` — 7 new cases for `shouldWatchdogFireFallbackAdvance`.
- `ChapterBodyWaitRetryTest` — 4 cases for `awaitChapterBodyReady` (incl. the decisive "recovers a chapter whose body only lands after a re-queue").
- ⚠️ Not reproduced on-device (timing / memory-pressure dependent). Device verification on R83W80CAFZB is the final gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
