### PR TITLE
fix(audiobook): allow Supertonic voices in audiobook export (#1270)

### DIFF
--- a/feature/src/main/kotlin/in/jphe/storyvox/feature/library/CreateAudiobookViewModel.kt
+++ b/feature/src/main/kotlin/in/jphe/storyvox/feature/library/CreateAudiobookViewModel.kt
@@ -47,9 +47,7 @@ class CreateAudiobookViewModel @Inject constructor(
         .map { list ->
             list.filter { v ->
                 v.engineType !is EngineType.Azure &&
-                    v.engineType !is EngineType.SystemTts &&
-                    // TODO(#1114): remove this exclusion when SupertonicEngine ships.
-                    v.engineType !is EngineType.Supertonic
+                    v.engineType !is EngineType.SystemTts
             }
         }
         .stateIn(viewModelScope, SharingStarted.WhileSubscribed(5_000), emptyList())


### PR DESCRIPTION
Part of #1270 (Nebula's audit). `CreateAudiobookViewModel` filtered `EngineType.Supertonic` out of the exportable-voices list behind a stale `TODO(#1114): remove when SupertonicEngine ships`.

#1114 has shipped — Supertonic is fully enabled (`VoiceCatalog.SUPERTONIC_ENABLED = true`) and **`AudiobookSynthesizer` already supports it end-to-end**: `loadModel` (:150), `generateAudioPCM` (:165), `sampleRate` (:64), and `loadVoice` validation rejects only Azure / System TTS. The exclusion was hiding a working offline engine from the export picker.

**Fix:** remove the Supertonic clause. The filter now mirrors `AudiobookSynthesizer.loadVoice` exactly (Piper / Kokoro / Kitten / Supertonic allowed; Azure / System TTS out) and matches the existing kdoc, which only ever mentioned Azure / System TTS.

No file overlap with PR #1278 (the other #1270 stale-cleanup spots: VoiceCatalog / EnginePlayer / sample-rate cache / imports / a11y).

🤖 Generated with [Claude Code](https://claude.com/claude-code)