### PR TITLE
feat(radio): STT foundation for live read-along captions (#1223)

### DIFF
--- a/core-playback/src/main/kotlin/in/jphe/storyvox/playback/transcribe/PcmDownsampler.kt
+++ b/core-playback/src/main/kotlin/in/jphe/storyvox/playback/transcribe/PcmDownsampler.kt
@@ -1,0 +1,74 @@
+package `in`.jphe.storyvox.playback.transcribe
+
+/**
+ * Issue #1223 — convert decoded radio PCM into the format sherpa-onnx's
+ * streaming ASR wants: **mono, 16 kHz, float samples in [-1, 1]**.
+ *
+ * The radio [`in`.jphe.storyvox.playback.tts.EnginePlayer] plays through a
+ * Media3 `ExoPlayer`, whose decoded audio is typically 44.1/48 kHz stereo
+ * 16-bit PCM. The Phase-2 `AudioProcessor` tap hands those raw frames here
+ * before pushing the result into `OnlineStream.acceptWaveform`.
+ *
+ * Pure and allocation-simple so it can run on the audio thread and be
+ * unit-tested without a device — this is the one signal-processing step
+ * worth locking down with tests before the (device-validated) recognizer
+ * wiring lands.
+ *
+ * Resampling is linear interpolation: more than adequate for ASR feature
+ * extraction (the recognizer's own front-end is the quality bottleneck,
+ * not the resampler) and cheap enough for the hot path. Channel downmix is
+ * a straight average.
+ */
+object PcmDownsampler {
+
+    /** Sample rate every sherpa-onnx streaming model expects. */
+    const val TARGET_RATE_HZ: Int = 16_000
+
+    /** Full-scale divisor for signed 16-bit → float normalisation. */
+    private const val INT16_FULL_SCALE: Float = 32_768f
+
+    /**
+     * Convert interleaved signed-16-bit-little-endian [pcm] at [srcRateHz]
+     * with [channels] channels into mono float at [TARGET_RATE_HZ],
+     * normalised to [-1, 1].
+     *
+     * Returns an empty array for empty/degenerate input ([channels] < 1,
+     * [srcRateHz] < 1, or fewer than one whole frame). Trailing bytes that
+     * don't complete a frame are ignored.
+     */
+    fun toMono16k(pcm: ByteArray, srcRateHz: Int, channels: Int): FloatArray {
+        if (channels < 1 || srcRateHz < 1) return FloatArray(0)
+        val bytesPerFrame = 2 * channels
+        val frameCount = pcm.size / bytesPerFrame
+        if (frameCount == 0) return FloatArray(0)
+
+        // 1. Decode + downmix to mono float in one pass.
+        val mono = FloatArray(frameCount)
+        var b = 0
+        for (f in 0 until frameCount) {
+            var acc = 0
+            for (c in 0 until channels) {
+                val lo = pcm[b].toInt() and 0xFF
+                val hi = pcm[b + 1].toInt() // signed — sign-extends the sample
+                acc += (hi shl 8) or lo
+                b += 2
+            }
+            mono[f] = (acc.toFloat() / channels) / INT16_FULL_SCALE
+        }
+
+        // 2. Resample to 16 kHz (skip when already there).
+        if (srcRateHz == TARGET_RATE_HZ) return mono
+        val outLen = (frameCount.toLong() * TARGET_RATE_HZ / srcRateHz).toInt()
+        if (outLen <= 0) return FloatArray(0)
+        val out = FloatArray(outLen)
+        val step = srcRateHz.toDouble() / TARGET_RATE_HZ
+        for (i in 0 until outLen) {
+            val srcPos = i * step
+            val i0 = srcPos.toInt()
+            val frac = (srcPos - i0).toFloat()
+            val i1 = if (i0 + 1 < frameCount) i0 + 1 else frameCount - 1
+            out[i] = mono[i0] * (1f - frac) + mono[i1] * frac
+        }
+        return out
+    }
+}

--- a/core-playback/src/main/kotlin/in/jphe/storyvox/playback/transcribe/RadioTranscriber.kt
+++ b/core-playback/src/main/kotlin/in/jphe/storyvox/playback/transcribe/RadioTranscriber.kt
@@ -1,0 +1,81 @@
+package `in`.jphe.storyvox.playback.transcribe
+
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.flow.asSharedFlow
+
+/**
+ * Issue #1223 — live speech-to-text for radio streams (read-along for
+ * audio). Abstraction boundary between the radio playback path and the
+ * on-device recognizer, so the (device-validated, Phase-2) sherpa-onnx
+ * `OnlineRecognizer` implementation can be swapped in without the caller
+ * — or the reader/captions UI — depending on the native API.
+ *
+ * Lifecycle: [start] when a radio stream begins playing with captions
+ * enabled → [acceptPcm] for every decoded audio buffer the Media3
+ * `AudioProcessor` tap copies out → [stop] on pause / chapter change /
+ * teardown (the recognizer + model are tens of MB resident and must be
+ * released, see the research notes on #1223).
+ *
+ * Implementations MUST be safe to drive from the audio thread:
+ * [acceptPcm] runs in the ExoPlayer audio pipeline and must not block on
+ * model inference (offload to a worker; emit results on [segments]).
+ */
+interface RadioTranscriber {
+
+    /**
+     * Stream of transcript updates. Interim (`isFinal = false`) segments
+     * update the live caption line; final segments (`isFinal = true`) are
+     * committed — the point at which the reader read-along could append
+     * them to the chapter body (Phase 2). Replay is 0: late collectors
+     * see only new segments, matching live-caption semantics.
+     */
+    val segments: Flow<TranscriptSegment>
+
+    /**
+     * Begin a recognition session. [languageHint] is a BCP-47-ish code
+     * (e.g. `"en"`) seeded from the RadioBrowser station `language` field
+     * to pick the right model; `null` falls back to the default model.
+     */
+    fun start(languageHint: String?)
+
+    /**
+     * Feed one buffer of decoded PCM. Format is whatever ExoPlayer
+     * produced; the implementation normalises via [PcmDownsampler] before
+     * the recognizer. No-op if no session is active.
+     */
+    fun acceptPcm(pcm: ByteArray, srcRateHz: Int, channels: Int)
+
+    /** End the session and release the recognizer + model. Idempotent. */
+    fun stop()
+
+    companion object {
+        /**
+         * Phase-1 no-op transcriber: emits nothing, holds no model. The
+         * default binding until the Phase-2 sherpa-onnx implementation
+         * lands, so the radio path and DI graph compile and run unchanged
+         * with the feature off.
+         */
+        val NoOp: RadioTranscriber = object : RadioTranscriber {
+            private val _segments = MutableSharedFlow<TranscriptSegment>()
+            override val segments: Flow<TranscriptSegment> = _segments.asSharedFlow()
+            override fun start(languageHint: String?) {}
+            override fun acceptPcm(pcm: ByteArray, srcRateHz: Int, channels: Int) {}
+            override fun stop() {}
+        }
+    }
+}
+
+/**
+ * One transcript update.
+ *
+ * @property text the recognized text. For an interim segment this is the
+ *   recognizer's current best hypothesis for the in-flight utterance; for
+ *   a final segment it's the committed utterance.
+ * @property isFinal `true` once the recognizer endpoints the utterance and
+ *   commits it; `false` for live interim hypotheses that may still change.
+ */
+data class TranscriptSegment(
+    val text: String,
+    val isFinal: Boolean,
+)

--- a/core-playback/src/test/kotlin/in/jphe/storyvox/playback/transcribe/PcmDownsamplerTest.kt
+++ b/core-playback/src/test/kotlin/in/jphe/storyvox/playback/transcribe/PcmDownsamplerTest.kt
@@ -1,0 +1,80 @@
+package `in`.jphe.storyvox.playback.transcribe
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+/**
+ * Issue #1223 — locks down the one signal-processing step of the radio
+ * STT path before the (device-validated) recognizer wiring lands:
+ * decode → downmix → resample → normalise. Pure JVM, no device.
+ */
+class PcmDownsamplerTest {
+
+    /** Build interleaved signed-16-bit-LE PCM from raw Int samples. */
+    private fun pcm(vararg samples: Int): ByteArray {
+        val b = ByteArray(samples.size * 2)
+        for (i in samples.indices) {
+            b[i * 2] = (samples[i] and 0xFF).toByte()
+            b[i * 2 + 1] = ((samples[i] shr 8) and 0xFF).toByte()
+        }
+        return b
+    }
+
+    @Test
+    fun `mono 16k passes through and normalises to minus-one-to-one`() {
+        val out = PcmDownsampler.toMono16k(pcm(0, 16384, -16384, 32767), 16_000, 1)
+        assertEquals(4, out.size)
+        assertEquals(0f, out[0], 1e-4f)
+        assertEquals(0.5f, out[1], 1e-4f)
+        assertEquals(-0.5f, out[2], 1e-4f)
+        assertEquals(0.99997f, out[3], 1e-4f)
+    }
+
+    @Test
+    fun `full-scale extremes map to the rails`() {
+        assertEquals(-1.0f, PcmDownsampler.toMono16k(pcm(-32768), 16_000, 1)[0], 1e-6f)
+        assertEquals(0f, PcmDownsampler.toMono16k(pcm(0), 16_000, 1)[0], 1e-6f)
+        // +full-scale is 32767/32768 — just shy of 1.0, never clips past it.
+        assertEquals(0.99997f, PcmDownsampler.toMono16k(pcm(32767), 16_000, 1)[0], 1e-4f)
+    }
+
+    @Test
+    fun `stereo is downmixed by averaging the channels`() {
+        // frame 0: L=16384 R=-16384 → avg 0; frame 1: L=32766 R=0 → avg 16383
+        val out = PcmDownsampler.toMono16k(pcm(16384, -16384, 32766, 0), 16_000, 2)
+        assertEquals(2, out.size)
+        assertEquals(0f, out[0], 1e-4f)
+        assertEquals(0.49997f, out[1], 1e-4f)
+    }
+
+    @Test
+    fun `48k downsamples to a third of the frames`() {
+        val twelveFrames = pcm(*IntArray(12) { it * 100 })
+        val out = PcmDownsampler.toMono16k(twelveFrames, 48_000, 1)
+        assertEquals(4, out.size) // 12 * 16000 / 48000
+    }
+
+    @Test
+    fun `32k downsample halves length and linearly samples`() {
+        // mono ramp [0, .25, .5, .75] @ 32k → step 2.0 → picks indices 0 and 2.
+        val out = PcmDownsampler.toMono16k(pcm(0, 8192, 16384, 24576), 32_000, 1)
+        assertEquals(2, out.size)
+        assertEquals(0f, out[0], 1e-4f)
+        assertEquals(0.5f, out[1], 1e-4f)
+    }
+
+    @Test
+    fun `empty and degenerate input yield empty output`() {
+        assertEquals(0, PcmDownsampler.toMono16k(ByteArray(0), 16_000, 1).size)
+        assertEquals(0, PcmDownsampler.toMono16k(pcm(1, 2, 3), 16_000, 0).size)
+        assertEquals(0, PcmDownsampler.toMono16k(pcm(1, 2, 3), 0, 1).size)
+    }
+
+    @Test
+    fun `trailing bytes that do not complete a frame are ignored`() {
+        // 3 bytes = one whole 16-bit sample (0x4000 = 16384) + one stray byte.
+        val out = PcmDownsampler.toMono16k(byteArrayOf(0x00, 0x40, 0x00), 16_000, 1)
+        assertEquals(1, out.size)
+        assertEquals(0.5f, out[0], 1e-4f)
+    }
+}


### PR DESCRIPTION
Phase 1 of #1223 — live speech-to-text for radio streams (read-along for audio; an accessibility win for deaf/HoH listeners).

**Full research is written up in the [issue body](https://github.com/techempower-org/candela/issues/1223)** (STT-engine evaluation, audio-routing mechanism, model selection, latency, display options, battery, and the phased plan). Headline: the issue's instinct is right — **sherpa-onnx is already a direct dependency** (`com.github.k2-fsa:sherpa-onnx:1.13.3`), so its streaming `OnlineRecognizer` is on the classpath with no new dependency.

### What this PR lands (compile-safe, device-free, tested)

- **`PcmDownsampler`** — decode/downmix/resample interleaved 16-bit ExoPlayer PCM → the mono 16 kHz float `[-1,1]` sherpa-onnx wants. The one signal-processing step worth locking down with tests before native wiring. **7 unit tests** (normalisation, stereo downmix, 48k/32k resample ratios + linear interpolation, degenerate/trailing-byte input).
- **`RadioTranscriber`** — the abstraction between the radio playback path and the recognizer (`start` / `acceptPcm` / `stop` + a `TranscriptSegment` flow), with a `NoOp` default so the DI graph and radio path compile/run unchanged with the feature off.

Purely additive — no edits to existing code, **no behaviour change**.

### Phase 2 (needs a device — deliberately not landed blind)

The real `OnlineRecognizer` impl, a Media3 `AudioProcessor` tap on the radio `ExoPlayer` (`EnginePlayer.loadAndPlayAudioStream`), on-demand streaming-model download, the live-captions UI, and the opt-in setting. These depend on the exact sherpa-onnx ASR Kotlin API, ExoPlayer audio-format assumptions, and on-device latency/battery — all of which must be validated on a device (can't compile or run audio/ASR locally), so they shouldn't ship unvalidated. The research lays out exactly where each piece goes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added live speech-to-text support for radio playback, including streaming transcript updates and interim/final segment handling.
  * Added audio preprocessing to convert PCM input into mono 16 kHz normalized samples for transcription.

* **Bug Fixes**
  * Improved handling of edge cases such as invalid audio input, incomplete frames, and unsupported channel/sample-rate combinations.
  * Added coverage for downmixing, resampling, and normalization behavior to ensure consistent transcription input.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->