### PR TITLE
fix(a11y): extract hardcoded UI strings + onClickLabel pass (#1268)

### DIFF
--- a/feature/src/main/kotlin/in/jphe/storyvox/feature/fiction/FictionDetailScreen.kt
+++ b/feature/src/main/kotlin/in/jphe/storyvox/feature/fiction/FictionDetailScreen.kt
@@ -324,7 +324,7 @@ fun FictionDetailScreen(
                     IconButton(onClick = onBack) {
                         Icon(
                             Icons.AutoMirrored.Filled.ArrowBack,
-                            contentDescription = "Back",
+                            contentDescription = stringResource(R.string.fiction_detail_back),
                         )
                     }
                 },
@@ -346,11 +346,13 @@ fun FictionDetailScreen(
                             // the text changes. Without this the spinner
                             // is silent — user can't tell the long
                             // export is actually running.
+                            val buildingEpubCd =
+                                stringResource(R.string.fiction_detail_building_epub_cd)
                             Row(
                                 modifier = Modifier
                                     .padding(end = 12.dp)
                                     .semantics(mergeDescendants = true) {
-                                        contentDescription = "Loading: Building .epub"
+                                        contentDescription = buildingEpubCd
                                         liveRegion = LiveRegionMode.Polite
                                     },
                                 verticalAlignment = Alignment.CenterVertically,
@@ -373,7 +375,7 @@ fun FictionDetailScreen(
                             }
                         } else {
                             IconButton(onClick = { menuOpen = true }) {
-                                Icon(Icons.Filled.MoreVert, contentDescription = "More")
+                                Icon(Icons.Filled.MoreVert, contentDescription = stringResource(R.string.fiction_detail_more))
                             }
                             DropdownMenu(
                                 expanded = menuOpen,
@@ -862,9 +864,9 @@ private fun AudiobookExportSheet(
         ) {
             when (status) {
                 is `in`.jphe.storyvox.playback.audiobook.AudiobookExportStatus.Running -> {
-                    Text("Creating your audiobook…", style = MaterialTheme.typography.titleMedium)
+                    Text(stringResource(R.string.audiobook_creating), style = MaterialTheme.typography.titleMedium)
                     Text(
-                        "Narrating chapters offline. This keeps going in the background.",
+                        stringResource(R.string.audiobook_creating_body),
                         style = MaterialTheme.typography.bodySmall,
                         color = MaterialTheme.colorScheme.onSurfaceVariant,
                     )
@@ -884,7 +886,7 @@ private fun AudiobookExportSheet(
                     }
                 }
                 is `in`.jphe.storyvox.playback.audiobook.AudiobookExportStatus.Succeeded -> {
-                    Text("Your audiobook is ready", style = MaterialTheme.typography.titleMedium)
+                    Text(stringResource(R.string.audiobook_ready), style = MaterialTheme.typography.titleMedium)
                     Text(
                         "${status.fileName} · ${status.chapterCount} " +
                             "chapter${if (status.chapterCount == 1) "" else "s"}",
@@ -903,13 +905,13 @@ private fun AudiobookExportSheet(
                         horizontalArrangement = Arrangement.spacedBy(spacing.sm),
                     ) {
                         BrassButton(
-                            label = "Save…",
+                            label = stringResource(R.string.audiobook_save),
                             onClick = { onSaveAs(status) },
                             variant = BrassButtonVariant.Secondary,
                             modifier = Modifier.weight(1f),
                         )
                         BrassButton(
-                            label = "Share",
+                            label = stringResource(R.string.audiobook_share),
                             onClick = { onShare(status) },
                             variant = BrassButtonVariant.Primary,
                             modifier = Modifier.weight(1f),
@@ -917,7 +919,7 @@ private fun AudiobookExportSheet(
                     }
                 }
                 is `in`.jphe.storyvox.playback.audiobook.AudiobookExportStatus.Failed -> {
-                    Text("Couldn't create the audiobook", style = MaterialTheme.typography.titleMedium)
+                    Text(stringResource(R.string.audiobook_failed), style = MaterialTheme.typography.titleMedium)
                     Text(
                         status.message,
                         style = MaterialTheme.typography.bodySmall,

--- a/feature/src/main/kotlin/in/jphe/storyvox/feature/library/CreateAudiobookSheet.kt
+++ b/feature/src/main/kotlin/in/jphe/storyvox/feature/library/CreateAudiobookSheet.kt
@@ -32,6 +32,7 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.semantics.LiveRegionMode
 import androidx.compose.ui.semantics.Role
 import androidx.compose.ui.semantics.liveRegion
@@ -42,6 +43,7 @@ import androidx.compose.ui.unit.dp
 import androidx.core.content.FileProvider
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.compose.foundation.text.KeyboardOptions
+import `in`.jphe.storyvox.feature.R
 import `in`.jphe.storyvox.playback.audiobook.AudiobookExportStatus
 import `in`.jphe.storyvox.ui.component.BrassButton
 import `in`.jphe.storyvox.ui.component.BrassButtonVariant
@@ -162,10 +164,9 @@ private fun ComposePhase(
     onCreate: () -> Unit,
 ) {
     val spacing = LocalSpacing.current
-    Text("Make your own audiobook", style = MaterialTheme.typography.titleLarge)
+    Text(stringResource(R.string.create_audiobook_heading), style = MaterialTheme.typography.titleLarge)
     Text(
-        "Paste or type your text, pick a voice, and Candela narrates it into a " +
-            "chaptered audiobook you can keep and share — all offline, no account.",
+        stringResource(R.string.create_audiobook_intro),
         style = MaterialTheme.typography.bodyMedium,
         color = MaterialTheme.colorScheme.onSurfaceVariant,
     )
@@ -173,7 +174,7 @@ private fun ComposePhase(
     OutlinedTextField(
         value = title,
         onValueChange = onTitle,
-        label = { Text("Title") },
+        label = { Text(stringResource(R.string.create_audiobook_field_title)) },
         singleLine = true,
         enabled = !isStarting,
         keyboardOptions = KeyboardOptions(capitalization = KeyboardCapitalization.Words),
@@ -182,7 +183,7 @@ private fun ComposePhase(
     OutlinedTextField(
         value = author,
         onValueChange = onAuthor,
-        label = { Text("Author (optional)") },
+        label = { Text(stringResource(R.string.create_audiobook_field_author)) },
         singleLine = true,
         enabled = !isStarting,
         keyboardOptions = KeyboardOptions(capitalization = KeyboardCapitalization.Words),
@@ -191,8 +192,8 @@ private fun ComposePhase(
     OutlinedTextField(
         value = text,
         onValueChange = onText,
-        label = { Text("Your text") },
-        placeholder = { Text("Paste a chapter, an article, a story…") },
+        label = { Text(stringResource(R.string.create_audiobook_field_text)) },
+        placeholder = { Text(stringResource(R.string.create_audiobook_text_placeholder)) },
         enabled = !isStarting,
         keyboardOptions = KeyboardOptions(imeAction = ImeAction.Default),
         modifier = Modifier
@@ -204,7 +205,7 @@ private fun ComposePhase(
         horizontalArrangement = Arrangement.End,
     ) {
         BrassButton(
-            label = "Paste from clipboard",
+            label = stringResource(R.string.create_audiobook_paste),
             onClick = onPaste,
             variant = BrassButtonVariant.Text,
             enabled = !isStarting,
@@ -212,7 +213,7 @@ private fun ComposePhase(
     }
 
     if (voices.isNotEmpty()) {
-        Text("Voice", style = MaterialTheme.typography.labelLarge)
+        Text(stringResource(R.string.create_audiobook_voice), style = MaterialTheme.typography.labelLarge)
         LazyRow(horizontalArrangement = Arrangement.spacedBy(spacing.xs)) {
             items(voices, key = { it.id }) { v ->
                 AssistChip(
@@ -296,7 +297,7 @@ private fun DonePhase(
     val spacing = LocalSpacing.current
     // #1160: announce arrival at the Done phase (no tap moves focus here).
     Text(
-        "Your audiobook is ready",
+        stringResource(R.string.audiobook_ready),
         style = MaterialTheme.typography.titleMedium,
         modifier = Modifier.semantics { liveRegion = LiveRegionMode.Polite },
     )

--- a/feature/src/main/kotlin/in/jphe/storyvox/feature/settings/OssLicensesScreen.kt
+++ b/feature/src/main/kotlin/in/jphe/storyvox/feature/settings/OssLicensesScreen.kt
@@ -91,7 +91,9 @@ fun OssLicensesScreen(
                         modifier = Modifier
                             .fillMaxWidth()
                             .padding(vertical = spacing.xxs)
-                            .clickable { runCatching { uriHandler.openUri(sourceUrl) } }
+                            .clickable(
+                                onClickLabel = stringResource(R.string.oss_open_license_page),
+                            ) { runCatching { uriHandler.openUri(sourceUrl) } }
                             .semantics { contentDescription = sourceLabel },
                     )
                 }

--- a/feature/src/main/kotlin/in/jphe/storyvox/feature/settings/plugins/PluginManagerScreen.kt
+++ b/feature/src/main/kotlin/in/jphe/storyvox/feature/settings/plugins/PluginManagerScreen.kt
@@ -46,6 +46,7 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.semantics.Role
 import androidx.compose.ui.semantics.clearAndSetSemantics
 import androidx.compose.ui.semantics.contentDescription
@@ -57,6 +58,7 @@ import androidx.compose.ui.unit.dp
 import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import `in`.jphe.storyvox.data.source.plugin.SourcePluginDescriptor
+import `in`.jphe.storyvox.feature.R
 import `in`.jphe.storyvox.playback.voice.VoiceEngineFamily
 import `in`.jphe.storyvox.playback.voice.VoiceFamilyDescriptor
 import `in`.jphe.storyvox.ui.component.fictionMonogram
@@ -116,7 +118,7 @@ fun PluginManagerScreen(
             CenterAlignedTopAppBar(
                 title = {
                     Text(
-                        "Plugins",
+                        stringResource(R.string.plugin_manager_title),
                         style = MaterialTheme.typography.titleMedium,
                     )
                 },
@@ -124,7 +126,7 @@ fun PluginManagerScreen(
                     IconButton(onClick = onNavigateBack) {
                         Icon(
                             Icons.AutoMirrored.Filled.ArrowBack,
-                            contentDescription = "Back",
+                            contentDescription = stringResource(R.string.plugin_manager_back),
                         )
                     }
                 },
@@ -143,7 +145,7 @@ fun PluginManagerScreen(
                 OutlinedTextField(
                     value = state.searchQuery,
                     onValueChange = viewModel::setSearchQuery,
-                    label = { Text("Search plugins") },
+                    label = { Text(stringResource(R.string.plugin_manager_search)) },
                     singleLine = true,
                     modifier = Modifier.fillMaxWidth(),
                 )
@@ -156,17 +158,17 @@ fun PluginManagerScreen(
                     FilterChip(
                         selected = state.filterChip == PluginFilterChip.On,
                         onClick = { viewModel.setFilterChip(PluginFilterChip.On) },
-                        label = { Text("On") },
+                        label = { Text(stringResource(R.string.plugin_manager_filter_on)) },
                     )
                     FilterChip(
                         selected = state.filterChip == PluginFilterChip.Off,
                         onClick = { viewModel.setFilterChip(PluginFilterChip.Off) },
-                        label = { Text("Off") },
+                        label = { Text(stringResource(R.string.plugin_manager_filter_off)) },
                     )
                     FilterChip(
                         selected = state.filterChip == PluginFilterChip.All,
                         onClick = { viewModel.setFilterChip(PluginFilterChip.All) },
-                        label = { Text("All") },
+                        label = { Text(stringResource(R.string.plugin_manager_filter_all)) },
                     )
                 }
             }
@@ -174,7 +176,7 @@ fun PluginManagerScreen(
             // Fiction sources section
             item("fiction-header") {
                 CategoryHeader(
-                    title = "Fiction sources",
+                    title = stringResource(R.string.plugin_manager_section_fiction),
                     count = fictionVisible.size,
                 )
             }
@@ -189,7 +191,7 @@ fun PluginManagerScreen(
             // Audio streams section
             item("audio-header") {
                 CategoryHeader(
-                    title = "Audio streams",
+                    title = stringResource(R.string.plugin_manager_section_audio),
                     count = audioVisible.size,
                 )
             }
@@ -207,7 +209,7 @@ fun PluginManagerScreen(
             // same brass-edged shape as the fiction cards.
             item("voice-header") {
                 CategoryHeader(
-                    title = "Voice bundles",
+                    title = stringResource(R.string.plugin_manager_section_voice),
                     count = voiceFamiliesVisible.count { !it.descriptor.isPlaceholder },
                 )
             }
@@ -425,7 +427,7 @@ private fun PluginDetailsContent(row: PluginManagerRow) {
             )
         }
         HorizontalDivider(modifier = Modifier.padding(vertical = spacing.sm))
-        Text("Capabilities", style = MaterialTheme.typography.titleSmall)
+        Text(stringResource(R.string.plugin_manager_capabilities), style = MaterialTheme.typography.titleSmall)
         Row(horizontalArrangement = Arrangement.spacedBy(spacing.xs)) {
             CapabilityChip(if (descriptor.supportsSearch) "Search ✓" else "Search ✗")
             CapabilityChip(if (descriptor.supportsFollow) "Follow ✓" else "Follow ✗")
@@ -587,11 +589,11 @@ private fun VoiceFamilyCard(
                 )
                 if (descriptor.requiresConfiguration && !row.isConfigured) {
                     TextButton(onClick = onConfigure) {
-                        Text("Configure →", style = MaterialTheme.typography.labelMedium)
+                        Text(stringResource(R.string.plugin_manager_configure), style = MaterialTheme.typography.labelMedium)
                     }
                 } else {
                     TextButton(onClick = onManageVoices) {
-                        Text("Manage voices →", style = MaterialTheme.typography.labelMedium)
+                        Text(stringResource(R.string.plugin_manager_manage_voices), style = MaterialTheme.typography.labelMedium)
                     }
                 }
             }
@@ -665,11 +667,11 @@ private fun VoiceFamilyDetailsContent(
         if (!descriptor.isPlaceholder) {
             if (descriptor.requiresConfiguration && !row.isConfigured) {
                 TextButton(onClick = onConfigure) {
-                    Text("Configure ${descriptor.displayName} →")
+                    Text(stringResource(R.string.plugin_manager_configure_named, descriptor.displayName))
                 }
             } else {
                 TextButton(onClick = onManageVoices) {
-                    Text("Manage voices →")
+                    Text(stringResource(R.string.plugin_manager_manage_voices))
                 }
             }
         }

--- a/feature/src/main/kotlin/in/jphe/storyvox/feature/settings/pronunciation/PronunciationDictScreen.kt
+++ b/feature/src/main/kotlin/in/jphe/storyvox/feature/settings/pronunciation/PronunciationDictScreen.kt
@@ -36,6 +36,7 @@ import androidx.compose.ui.focus.FocusDirection
 import androidx.compose.ui.focus.FocusRequester
 import androidx.compose.ui.focus.focusRequester
 import androidx.compose.ui.platform.LocalFocusManager
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.semantics.Role
 import androidx.compose.ui.text.input.ImeAction
 import androidx.compose.ui.unit.dp
@@ -43,6 +44,7 @@ import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import `in`.jphe.storyvox.data.repository.pronunciation.MatchType
 import `in`.jphe.storyvox.data.repository.pronunciation.PronunciationEntry
+import `in`.jphe.storyvox.feature.R
 import `in`.jphe.storyvox.ui.component.BrassButton
 import `in`.jphe.storyvox.ui.component.BrassButtonVariant
 import `in`.jphe.storyvox.ui.theme.LocalSpacing
@@ -76,7 +78,7 @@ fun PronunciationDictScreen(
     Scaffold(
         topBar = {
             TopAppBar(
-                title = { Text("Pronunciation") },
+                title = { Text(stringResource(R.string.pronunciation_title)) },
                 // Issues #275 + #276 — standardize the back affordance
                 // across all settings sub-screens to the TopAppBar arrow
                 // (matching Sessions). The old inline 'Back' BrassButton
@@ -85,7 +87,7 @@ fun PronunciationDictScreen(
                     IconButton(onClick = onBack) {
                         Icon(
                             Icons.AutoMirrored.Filled.ArrowBack,
-                            contentDescription = "Back",
+                            contentDescription = stringResource(R.string.pronunciation_back),
                         )
                     }
                 },
@@ -224,13 +226,18 @@ private fun EntryEditorDialog(
 
     AlertDialog(
         onDismissRequest = onDismiss,
-        title = { Text(if (initial == null) "Add entry" else "Edit entry") },
+        title = {
+            Text(
+                if (initial == null) stringResource(R.string.pronunciation_dialog_add)
+                else stringResource(R.string.pronunciation_dialog_edit),
+            )
+        },
         text = {
             Column(verticalArrangement = Arrangement.spacedBy(8.dp)) {
                 OutlinedTextField(
                     value = pattern,
                     onValueChange = { pattern = it },
-                    label = { Text("Pattern (the word as written)") },
+                    label = { Text(stringResource(R.string.pronunciation_field_pattern)) },
                     singleLine = true,
                     keyboardOptions = KeyboardOptions(imeAction = ImeAction.Next),
                     keyboardActions = KeyboardActions(
@@ -243,7 +250,7 @@ private fun EntryEditorDialog(
                 OutlinedTextField(
                     value = replacement,
                     onValueChange = { replacement = it },
-                    label = { Text("Replacement (how to say it)") },
+                    label = { Text(stringResource(R.string.pronunciation_field_replacement)) },
                     singleLine = true,
                     keyboardOptions = KeyboardOptions(imeAction = ImeAction.Done),
                     keyboardActions = KeyboardActions(
@@ -258,7 +265,7 @@ private fun EntryEditorDialog(
                 // REGEX (power users); the other 5 NVDA modes land in
                 // phase 2.
                 Row(verticalAlignment = Alignment.CenterVertically) {
-                    Text("Match: ", style = MaterialTheme.typography.bodyMedium)
+                    Text(stringResource(R.string.pronunciation_match_label), style = MaterialTheme.typography.bodyMedium)
                     MatchType.entries.forEach { mt ->
                         val variant = if (matchType == mt) BrassButtonVariant.Primary else BrassButtonVariant.Secondary
                         BrassButton(

--- a/feature/src/main/res/values/strings.xml
+++ b/feature/src/main/res/values/strings.xml
@@ -1083,4 +1083,58 @@
     <string name="stats_empty_title">No listening yet</string>
     <string name="stats_empty_body">Finish a chapter and your reading stats will appear here.</string>
     <string name="stats_estimate_note">Time figures are estimates based on the length of the chapters you\'ve finished — Candela doesn\'t track exact playback time yet.</string>
+
+    <!-- Issue #1268 — extract hardcoded UI strings for localization / a11y.
+         Shared audiobook-export copy (used by both CreateAudiobookSheet and
+         FictionDetailScreen's export overlay). -->
+    <string name="audiobook_creating">Creating your audiobook…</string>
+    <string name="audiobook_creating_body">Narrating chapters offline. This keeps going in the background.</string>
+    <string name="audiobook_ready">Your audiobook is ready</string>
+    <string name="audiobook_failed">Couldn\'t create the audiobook</string>
+    <string name="audiobook_save">Save…</string>
+    <string name="audiobook_share">Share</string>
+
+    <!-- #1268 — Create-audiobook sheet (library) -->
+    <string name="create_audiobook_heading">Make your own audiobook</string>
+    <string name="create_audiobook_intro">Paste or type your text, pick a voice, and Candela narrates it into a chaptered audiobook you can keep and share — all offline, no account.</string>
+    <string name="create_audiobook_field_title">Title</string>
+    <string name="create_audiobook_field_author">Author (optional)</string>
+    <string name="create_audiobook_field_text">Your text</string>
+    <string name="create_audiobook_text_placeholder">Paste a chapter, an article, a story…</string>
+    <string name="create_audiobook_paste">Paste from clipboard</string>
+    <string name="create_audiobook_voice">Voice</string>
+
+    <!-- #1268 — Plugin manager -->
+    <string name="plugin_manager_title">Plugins</string>
+    <string name="plugin_manager_back">Back</string>
+    <string name="plugin_manager_search">Search plugins</string>
+    <string name="plugin_manager_filter_on">On</string>
+    <string name="plugin_manager_filter_off">Off</string>
+    <string name="plugin_manager_filter_all">All</string>
+    <string name="plugin_manager_section_fiction">Fiction sources</string>
+    <string name="plugin_manager_section_audio">Audio streams</string>
+    <string name="plugin_manager_section_voice">Voice bundles</string>
+    <string name="plugin_manager_capabilities">Capabilities</string>
+    <string name="plugin_manager_configure">Configure →</string>
+    <!-- %1$s = source/plugin display name -->
+    <string name="plugin_manager_configure_named">Configure %1$s →</string>
+    <string name="plugin_manager_manage_voices">Manage voices →</string>
+
+    <!-- #1268 — Pronunciation dictionary -->
+    <string name="pronunciation_title">Pronunciation</string>
+    <string name="pronunciation_back">Back</string>
+    <string name="pronunciation_dialog_add">Add entry</string>
+    <string name="pronunciation_dialog_edit">Edit entry</string>
+    <string name="pronunciation_field_pattern">Pattern (the word as written)</string>
+    <string name="pronunciation_field_replacement">Replacement (how to say it)</string>
+    <string name="pronunciation_match_label">Match: </string>
+
+    <!-- #1268 — Fiction detail -->
+    <string name="fiction_detail_back">Back</string>
+    <string name="fiction_detail_more">More</string>
+    <string name="fiction_detail_building_epub_cd">Loading: Building .epub</string>
+
+    <!-- #1268 — onClickLabel: the dependency-name link opens its license page
+         in a browser; the visible text is just the name, so describe the action. -->
+    <string name="oss_open_license_page">Open license page in browser</string>
 </resources>


### PR DESCRIPTION
## What & why

Addresses the two **actionable** findings in #1268 (accessibility gaps for Play Store):
1. **Hardcoded UI strings** → routed through `feature/.../res/values/strings.xml` (localization + Play-readiness).
2. **`onClickLabel` coverage** → spot-pass on a clickable whose action ≠ its visible text.

~38 strings extracted across the four **non-legacy** screens the issue prioritized. `SettingsScreen.kt` is deliberately left for its planned hub migration (per the issue), and decorative `contentDescription = null` was **not** touched (the issue explicitly warns against that — it's the verified v0.5.42–43 state).

## Changes

**String extraction**
- **PluginManagerScreen** — title, back, search, On/Off/All filter chips, the three section headers (Fiction sources / Audio streams / Voice bundles), Capabilities, Configure / Manage-voices labels (incl. the `Configure %1$s →` format string).
- **CreateAudiobookSheet** — heading, intro paragraph, Title / Author / Your-text field labels, placeholder, Paste-from-clipboard, Voice; done-title reuses the shared `audiobook_*` set.
- **PronunciationDictScreen** — title, back, Add/Edit dialog title, Pattern / Replacement field labels, Match label.
- **FictionDetailScreen** — back, more, the building-`.epub` a11y label, and the audiobook export overlay (creating / body / ready / failed / Save / Share) via the shared `audiobook_*` resources.

**onClickLabel** (#1268 item 2)
- **OssLicensesScreen** — the dependency-name link opens its license page in a browser, but the visible text is just the name. Added `onClickLabel = "Open license page in browser"` so TalkBack announces the action (the existing `contentDescription` only conveyed the name).

## Notable implementation details
- **Shared `audiobook_*` resources** dedupe copy common to `CreateAudiobookSheet` and `FictionDetailScreen`'s export overlay — one canonical string per translator instead of two divergent copies.
- **`semantics {}` hoist**: `FictionDetailScreen`'s building-epub `contentDescription` lives inside a non-composable `semantics {}` lambda, so `stringResource` is hoisted to a `val` above the `Row` rather than called inside the lambda.
- **Verified** (since CI is the compile gate): every new `R.string.*` reference is defined in `strings.xml` (no typos → compiles) and every new string is referenced (no unused-resource lint). Residual `Text("…")` on the touched screens are only the intentional deferrals below.

## Deferred (format/decorative — not translation targets)
Noted for a follow-up so this PR stays a clean, reviewable string-extraction pass:
- `"%d%%"` progress labels and the `"• warning"` bullet prefix (presentation, not prose).
- The `"file · N chapters"` summary — wants a proper `<plurals>` resource.
- The ✓/✗ capability chips and the numeric `"%.1f"` rating formatter.
- Deeper `DetailRow` labels inside the plugin detail bottom-sheets (Engine / Voices / Size / License / Status).

Per #1268, **item 3** (TalkBack hints + live on-device TalkBack pass) is roadmap and explicitly out of scope here.

## Test / verification
No unit tests (pure resource extraction + a modifier arg; the project has no Robolectric/Compose-UI coverage for these screens). Correctness verified statically (defined-vs-referenced cross-check); behavior is the compile gate on CI + a visual/ TalkBack smoke check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
