### PR TITLE
fix(playback): reject all-silence PCM cache entries on read (#1281)

### DIFF
--- a/core-playback/src/main/kotlin/in/jphe/storyvox/playback/cache/PcmSilence.kt
+++ b/core-playback/src/main/kotlin/in/jphe/storyvox/playback/cache/PcmSilence.kt
@@ -1,0 +1,97 @@
+package `in`.jphe.storyvox.playback.cache
+
+import java.io.File
+
+/**
+ * Issue #1281 — "is this PCM all silence?" helpers backing the read-side content
+ * gate in `CacheFileSource.open`.
+ *
+ * The structural belt added in #1128 (sentence count / byte length / offsets)
+ * never inspects the samples, so a render that emitted non-empty but
+ * zero-amplitude PCM (transient engine glitch, model decline that still emits a
+ * silent buffer, low-memory partial synth) finalizes as a structurally-valid
+ * "complete" entry and plays back as a silent, never-re-rendered chapter — a
+ * silent skip. The read gate rejects such an entry (→ delete + re-render),
+ * making it self-healing.
+ *
+ * A symmetric write-side discard in `PcmAppender.complete` was considered but
+ * deliberately not added: the read gate already heals a silent entry on next
+ * play, and an all-zero buffer is a common content-agnostic fixture across the
+ * cache test suite, so a finalize-time content guard carried outsized blast
+ * radius for marginal benefit (see #1281 / the PR).
+ *
+ * Signed PCM16 / float32 silence is all-zero bytes, so "silence" is defined
+ * conservatively as *at most [PCM_SILENCE_TOLERANCE_BYTES] non-zero bytes* — 0
+ * by default, i.e. strictly all-zero. Real neural-TTS audio always carries
+ * non-zero samples (even a leading pause is followed by speech), so this only
+ * ever rejects a provably all-zero render and never a quiet-but-real chapter.
+ */
+
+/**
+ * Non-zero byte budget below which a `.pcm` region counts as silence. **0** —
+ * strictly all-zero is silence, any non-zero sample is audio. Kept as a named,
+ * tunable knob: raise it only if field data shows "near-silent garbage" glitch
+ * buffers (a stray DC offset / click) that should also be rejected. Deliberately
+ * conservative at 0 so a genuine (even very short) render is never discarded.
+ */
+internal const val PCM_SILENCE_TOLERANCE_BYTES: Int = 0
+
+/**
+ * True if [bytes] over `[0, len)` is PCM silence: at most [tolerance] non-zero
+ * bytes. Early-exits once the tolerance is exceeded, so an audible buffer
+ * returns false near-instantly. Pure (no I/O) — the unit-tested encoding of the
+ * silence definition; [pcmIsAllSilence] applies the same accounting across a
+ * whole file (accumulating across read buffers, so it stays correct if the
+ * tolerance is ever raised above 0).
+ */
+internal fun isPcmBufferSilent(
+    bytes: ByteArray,
+    len: Int = bytes.size,
+    tolerance: Int = PCM_SILENCE_TOLERANCE_BYTES,
+): Boolean {
+    var nonZero = 0
+    var i = 0
+    while (i < len) {
+        if (bytes[i].toInt() != 0) {
+            nonZero++
+            if (nonZero > tolerance) return false
+        }
+        i++
+    }
+    return true
+}
+
+/**
+ * Stream up to [scanBytes] of [pcmFile] and report whether the declared content
+ * is all silence (≤ [PCM_SILENCE_TOLERANCE_BYTES] non-zero bytes across the
+ * whole scanned region). Reads in 64 KB buffers and early-exits on the first
+ * audible run — so a valid entry reads only its first buffer, while a genuinely
+ * silent entry (rare, and about to be discarded) is read in full. The non-zero
+ * count accumulates across buffers, so scanning a finalized file is correct even
+ * on the resume path (where the file carries bytes from a prior session).
+ *
+ * A missing / empty file reads as silent — callers gate that case separately
+ * (the read belt's `isFile`/length checks, the write belt's empty-sentences
+ * check run first).
+ */
+internal fun pcmIsAllSilence(pcmFile: File, scanBytes: Long): Boolean {
+    if (scanBytes <= 0L) return true
+    var nonZero = 0
+    pcmFile.inputStream().buffered().use { input ->
+        val buf = ByteArray(64 * 1024)
+        var remaining = scanBytes
+        while (remaining > 0L) {
+            val toRead = minOf(buf.size.toLong(), remaining).toInt()
+            val n = input.read(buf, 0, toRead)
+            if (n <= 0) break
+            for (i in 0 until n) {
+                if (buf[i].toInt() != 0) {
+                    nonZero++
+                    if (nonZero > PCM_SILENCE_TOLERANCE_BYTES) return false
+                }
+            }
+            remaining -= n.toLong()
+        }
+    }
+    return true
+}

--- a/core-playback/src/main/kotlin/in/jphe/storyvox/playback/tts/source/CacheFileSource.kt
+++ b/core-playback/src/main/kotlin/in/jphe/storyvox/playback/tts/source/CacheFileSource.kt
@@ -4,6 +4,7 @@ import `in`.jphe.storyvox.playback.SentenceRange
 import `in`.jphe.storyvox.playback.cache.PcmIndex
 import `in`.jphe.storyvox.playback.cache.PcmIndexEntry
 import `in`.jphe.storyvox.playback.cache.pcmCacheJson
+import `in`.jphe.storyvox.playback.cache.pcmIsAllSilence
 import java.io.File
 import java.io.IOException
 import java.io.RandomAccessFile
@@ -304,6 +305,26 @@ class CacheFileSource private constructor(
             if (maxExtent > pcmLen) {
                 throw IOException(
                     "PCM cache index overruns file: maxExtent=$maxExtent > length=$pcmLen",
+                )
+            }
+            // Issue #1281 — content gate. Every check above is STRUCTURAL
+            // (sentence count, byte length, offsets); none inspects the PCM
+            // samples. A render that produced non-empty but zero-amplitude PCM
+            // (transient engine glitch, model decline that still emits a silent
+            // buffer, low-memory partial synth) finalizes as a structurally
+            // valid "complete" entry, passes everything above, and then plays
+            // back as pure silence to a clean natural-end — the chapter is
+            // SILENTLY SKIPPED on every play, never erroring and never
+            // re-rendering (the same user-facing shape as #1128, via a path
+            // #1128's structural belt doesn't close). Reject an all-silence
+            // entry here so EnginePlayer deletes it and re-renders, exactly like
+            // the truncation/degenerate cases. The scan early-exits on the first
+            // non-zero sample (a normal entry reads ~one buffer); real audio has
+            // non-zero samples from its first instant, so a quiet-but-real
+            // chapter is never rejected — only a provably all-zero render is.
+            if (pcmIsAllSilence(pcmFile, index.totalBytes)) {
+                throw IOException(
+                    "PCM cache all-silence: ${pcmFile.name} — re-rendering (#1281)",
                 )
             }
             val raf = RandomAccessFile(pcmFile, "r")

--- a/core-playback/src/test/kotlin/in/jphe/storyvox/playback/tts/source/CacheFileSourceTest.kt
+++ b/core-playback/src/test/kotlin/in/jphe/storyvox/playback/tts/source/CacheFileSourceTest.kt
@@ -4,8 +4,10 @@ import android.app.Application
 import `in`.jphe.storyvox.playback.cache.PcmCache
 import `in`.jphe.storyvox.playback.cache.PcmCacheConfig
 import `in`.jphe.storyvox.playback.cache.PcmCacheKey
+import `in`.jphe.storyvox.playback.cache.PCM_SILENCE_TOLERANCE_BYTES
 import `in`.jphe.storyvox.playback.cache.PcmIndex
 import `in`.jphe.storyvox.playback.cache.PcmIndexEntry
+import `in`.jphe.storyvox.playback.cache.isPcmBufferSilent
 import `in`.jphe.storyvox.playback.cache.pcmCacheJson
 import `in`.jphe.storyvox.playback.tts.CHUNKER_VERSION
 import `in`.jphe.storyvox.playback.tts.Sentence
@@ -13,6 +15,7 @@ import kotlinx.coroutines.runBlocking
 import org.junit.After
 import org.junit.Assert.assertArrayEquals
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
 import org.junit.Assert.assertNull
 import org.junit.Assert.assertTrue
 import org.junit.Before
@@ -244,6 +247,81 @@ class CacheFileSourceTest {
             )
         }
         assertTrue("open should reject a zero-sentence index (#1128)", threw)
+    }
+
+    @Test
+    fun `all-silence pcm fails to open with IOException`() = runBlocking {
+        // Issue #1281 — a STRUCTURALLY valid entry (correct sentenceCount,
+        // totalBytes, contiguous in-bounds offsets) whose .pcm is all
+        // zero-amplitude samples. It passes every #1128 structural check, so
+        // pre-fix CacheFileSource served pure silence to a clean natural-end
+        // and the chapter silently skipped on every play. open() must now
+        // reject it via the content gate so EnginePlayer deletes + re-renders.
+        writeIndex(
+            PcmIndex(
+                sampleRate = 22050,
+                sentenceCount = 3,
+                totalBytes = 300L,
+                sentences = listOf(
+                    PcmIndexEntry(i = 0, start = 0, end = 10, byteOffset = 0L, byteLen = 100, trailingSilenceMs = 0),
+                    PcmIndexEntry(i = 1, start = 11, end = 20, byteOffset = 100L, byteLen = 100, trailingSilenceMs = 0),
+                    PcmIndexEntry(i = 2, start = 21, end = 30, byteOffset = 200L, byteLen = 100, trailingSilenceMs = 0),
+                ),
+            ),
+            ByteArray(300), // all zeros == digital silence
+        )
+        var threw = false
+        try {
+            CacheFileSource.open(pcmFile = cache.pcmFileFor(key), indexFile = cache.indexFileFor(key))
+        } catch (e: java.io.IOException) {
+            threw = true
+            assertTrue(
+                "message should flag silence, got: ${e.message}",
+                e.message?.contains("silence") == true,
+            )
+        }
+        assertTrue("open should reject an all-silence entry so it re-renders (#1281)", threw)
+    }
+
+    @Test
+    fun `mostly-silent but audible pcm still opens`() = runBlocking {
+        // Issue #1281 no-over-reject: a real chapter can be mostly quiet yet
+        // carry genuine speech. One audible sentence among silent ones puts the
+        // non-zero byte count well past the tolerance, so the content gate must
+        // KEEP the entry (only an essentially all-zero render is rejected).
+        val pcm = ByteArray(300) // sentences 0 and 2 silent...
+        for (j in 100 until 200) pcm[j] = 0x7F // ...sentence 1 is audible
+        writeIndex(
+            PcmIndex(
+                sampleRate = 22050,
+                sentenceCount = 3,
+                totalBytes = 300L,
+                sentences = listOf(
+                    PcmIndexEntry(i = 0, start = 0, end = 10, byteOffset = 0L, byteLen = 100, trailingSilenceMs = 0),
+                    PcmIndexEntry(i = 1, start = 11, end = 20, byteOffset = 100L, byteLen = 100, trailingSilenceMs = 0),
+                    PcmIndexEntry(i = 2, start = 21, end = 30, byteOffset = 200L, byteLen = 100, trailingSilenceMs = 0),
+                ),
+            ),
+            pcm,
+        )
+        val source = CacheFileSource.open(
+            pcmFile = cache.pcmFileFor(key),
+            indexFile = cache.indexFileFor(key),
+        )
+        assertEquals(0, source.nextChunk()?.sentenceIndex)
+        source.close()
+    }
+
+    @Test
+    fun `isPcmBufferSilent honors the tolerance`() {
+        // Pure helper (#1281): all-zero is silence; real audio is not; the
+        // boundary is the tolerance.
+        assertTrue("all-zero buffer is silence", isPcmBufferSilent(ByteArray(1000)))
+        assertFalse("audible buffer is not silence", isPcmBufferSilent(ByteArray(1000) { 0x40 }))
+        val atTolerance = ByteArray(1000).also { b -> for (j in 0 until PCM_SILENCE_TOLERANCE_BYTES) b[j] = 1 }
+        assertTrue("<= tolerance non-zero bytes still counts as silence", isPcmBufferSilent(atTolerance))
+        val overTolerance = ByteArray(1000).also { b -> for (j in 0..PCM_SILENCE_TOLERANCE_BYTES) b[j] = 1 }
+        assertFalse("> tolerance non-zero bytes is not silence", isPcmBufferSilent(overTolerance))
     }
 
     @Test


### PR DESCRIPTION
## Summary

Closes #1281. `CacheFileSource`'s #1128 integrity gate validates a cached chapter's **structure** (sentence count, byte length, offsets) but never its **audio content**. A render that produced non-empty but **zero-amplitude PCM** (transient engine glitch, model decline emitting a silent buffer, low-memory partial synth) finalizes as a structurally-valid "complete" entry, passes the gate, and plays back as pure silence to a clean natural-end — the chapter is **silently skipped on every play**, never erroring and never re-rendering. Same user-facing shape as #1128, via a path its structural belt doesn't close.

## Fix

A **content gate** in `CacheFileSource.open()`, right after the structural checks:

```kotlin
if (pcmIsAllSilence(pcmFile, index.totalBytes)) {
    throw IOException("PCM cache all-silence: ${pcmFile.name} — re-rendering (#1281)")
}
```

→ EnginePlayer catches the `IOException`, deletes the entry, and re-renders — exactly like the existing truncation/degenerate cases. **Self-healing**: a silent entry re-renders on next play.

- **Conservative silence definition**: strictly all-zero (`PCM_SILENCE_TOLERANCE_BYTES = 0`). Signed PCM16/float32 silence is all-zero bytes; real neural-TTS audio always carries non-zero samples (even a leading pause is followed by speech), so a quiet-but-real chapter is **never** rejected — only a provably all-zero render is.
- **Cheap**: the scan early-exits on the first non-zero sample, so a normal entry reads ~one 64 KB buffer; only a genuinely-silent entry (rare, being discarded) is read in full.
- Helpers in a shared `cache/PcmSilence.kt` (pure `isPcmBufferSilent` + file-scanning `pcmIsAllSilence`).

## Scope decision — read-side only (PcmAppender untouched)

The issue suggested a write-side guard too (refuse to *finalize* an all-silence render in `PcmAppender.complete()`). I prototyped it, then **dropped it deliberately**:

- The read gate already makes a silent entry self-healing (deleted + re-rendered on next play), so the write-side is only a minor optimization (saving one render cycle).
- An all-zero `ByteArray` is a **common content-agnostic fixture** across the cache test suite — `PcmCacheTest`, `PcmCacheLeaseTest`, `CacheStateInspectorTest`, `CacheStatsRepositoryTest` all `complete()` zero-filled renders and assert they persist. A finalize-time content guard would abandon those and break 4+ test files, for marginal benefit, while touching the delicate single-owner write path.

So `PcmAppender` is unchanged. If field data later shows value in not even *writing* silent entries, the shared helper is ready to wire in as a follow-up.

## Tests (`CacheFileSourceTest`)

- `all-silence pcm fails to open with IOException` — a structurally-valid, all-zero entry is rejected.
- `mostly-silent but audible pcm still opens` — one audible sentence among silent ones keeps the entry (no over-reject).
- `isPcmBufferSilent honors the tolerance` — pure boundary test.

No local gradle (compile/test gate is CI). `core-playback` runs Robolectric (#1132 SDK pin), so these exercise the real `PcmCache`/`CacheFileSource` path on disk.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
