### PR TITLE
feat(librivox): split Gutenberg text into per-section read-along (#1224)

### DIFF
--- a/source-librivox/src/main/kotlin/in/jphe/storyvox/source/librivox/GutenbergChapterSplitter.kt
+++ b/source-librivox/src/main/kotlin/in/jphe/storyvox/source/librivox/GutenbergChapterSplitter.kt
@@ -1,0 +1,205 @@
+package `in`.jphe.storyvox.source.librivox
+
+/**
+ * Issue #1224 — split a LibriVox book's companion Project Gutenberg
+ * plain text into per-audio-section segments for read-along.
+ *
+ * LibriVox serves a book as N per-section MP3s; Project Gutenberg serves
+ * the matching public-domain text as one blob. To show the right text
+ * while a given section's human narration plays, the blob has to be cut
+ * into N pieces aligned to the section boundaries.
+ *
+ * Two strategies, in order:
+ *
+ *  1. **Heading-aligned** — when the number of detected chapter headings
+ *     ("CHAPTER I", "Chapter 1", a lone Roman numeral, …) is *exactly*
+ *     [sectionCount], cut at those headings. Any front matter before the
+ *     first heading rides along with segment 0. This is the
+ *     high-confidence path: for the typical classic novel one Gutenberg
+ *     chapter maps to one LibriVox section, so the mapping is clean.
+ *
+ *  2. **Proportional** — otherwise, walk paragraphs and balance them into
+ *     [sectionCount] roughly word-equal segments on paragraph boundaries
+ *     (char-split as a last resort when there are fewer paragraphs than
+ *     sections). Alignment is approximate, but read-along is a manual
+ *     "follow along" affordance — there is no word-level sync until STT
+ *     (#1223) — so approximate text beats the status-quo single bonus
+ *     chapter that showed nothing during section playback.
+ *
+ * The exact-count gate is deliberate: heading detection is noisy (tables
+ * of contents, prefaces, dedications), so anything other than a clean
+ * 1:1 match falls back to the always-correct proportional split rather
+ * than risk an off-by-one misalignment that is worse than no headings.
+ *
+ * Pure + deterministic: no Android, no network, fully unit-testable.
+ */
+internal object GutenbergChapterSplitter {
+
+    /**
+     * Cut [plainText] into exactly [sectionCount] read-along segments
+     * (one per LibriVox audio section). Returns an empty list only when
+     * [sectionCount] <= 0; otherwise the result size is always
+     * [sectionCount] (trailing segments may be empty for pathological
+     * input, never more entries than sections).
+     */
+    fun split(plainText: String, sectionCount: Int): List<String> {
+        if (sectionCount <= 0) return emptyList()
+        val text = plainText.trim()
+        if (text.isEmpty()) return List(sectionCount) { "" }
+        if (sectionCount == 1) return listOf(text)
+
+        val headings = detectBodyHeadings(text)
+        return if (headings.size == sectionCount) {
+            // Segment 0 absorbs any front matter before the first heading,
+            // so the cut points are the 2nd..Nth heading offsets — that's
+            // (sectionCount - 1) cuts producing sectionCount segments.
+            sliceAt(text, headings.drop(1))
+        } else {
+            proportionalSplit(text, sectionCount)
+        }
+    }
+
+    // ─── heading detection ──────────────────────────────────────────────
+
+    /**
+     * Char offsets of lines that look like real chapter headings. A
+     * "real" heading is followed by at least [MIN_BODY_GAP] characters of
+     * text before the next heading; this drops table-of-contents lines,
+     * which are packed tightly together with no body between them.
+     */
+    private fun detectBodyHeadings(text: String): List<Int> {
+        val offsets = ArrayList<Int>()
+        var pos = 0
+        for (line in text.split('\n')) {
+            if (isHeadingLine(line.trim())) offsets.add(pos)
+            pos += line.length + 1 // + the '\n' that split() consumed
+        }
+        if (offsets.isEmpty()) return emptyList()
+        return offsets.filterIndexed { i, off ->
+            val next = offsets.getOrNull(i + 1) ?: text.length
+            next - off >= MIN_BODY_GAP
+        }
+    }
+
+    private fun isHeadingLine(line: String): Boolean =
+        line.isNotEmpty() && (
+            HEADING_KEYWORD.matches(line) ||
+                HEADING_ROMAN.matches(line) ||
+                HEADING_NUMBER.matches(line)
+            )
+
+    // ─── slicing ────────────────────────────────────────────────────────
+
+    /** Cut [text] at each ascending offset in [cutPoints]; yields
+     *  cutPoints.size + 1 trimmed segments. */
+    private fun sliceAt(text: String, cutPoints: List<Int>): List<String> {
+        val bounds = buildList {
+            add(0)
+            addAll(cutPoints)
+            add(text.length)
+        }
+        return bounds.zipWithNext { a, b -> text.substring(a, b).trim() }
+    }
+
+    // ─── proportional fallback ──────────────────────────────────────────
+
+    private fun proportionalSplit(text: String, n: Int): List<String> {
+        val paras = text.split(PARAGRAPH_BREAK)
+            .map { it.trim() }
+            .filter { it.isNotEmpty() }
+        if (paras.size < n) return charSplit(text, n)
+
+        val totalWords = paras.sumOf { wordCount(it) }.coerceAtLeast(1)
+        val target = totalWords.toDouble() / n
+        val result = ArrayList<String>(n)
+        val cur = StringBuilder()
+        var curWords = 0
+        for ((i, p) in paras.withIndex()) {
+            if (cur.isNotEmpty()) cur.append("\n\n")
+            cur.append(p)
+            curWords += wordCount(p)
+            val remainingParas = paras.size - i - 1
+            val remainingSegs = n - result.size - 1
+            // Force a close when there are only just enough paragraphs left
+            // to give every remaining segment at least one — guarantees we
+            // never starve the tail. Otherwise close once we've reached the
+            // per-segment word target.
+            val mustClose = remainingSegs > 0 && remainingParas <= remainingSegs
+            val wantClose = result.size < n - 1 && curWords >= target
+            if (mustClose || wantClose) {
+                result.add(cur.toString())
+                cur.setLength(0)
+                curWords = 0
+            }
+        }
+        if (cur.isNotEmpty()) result.add(cur.toString())
+        while (result.size < n) result.add("")
+        if (result.size > n) {
+            val head = result.subList(0, n - 1).toList()
+            val tail = result.subList(n - 1, result.size).joinToString("\n\n")
+            return head + tail
+        }
+        return result
+    }
+
+    /** Even split by character count, breaking on whitespace so words
+     *  aren't cut. Last resort when a book has fewer paragraphs than
+     *  sections (e.g. one giant un-delimited blob). */
+    private fun charSplit(text: String, n: Int): List<String> {
+        if (text.isEmpty()) return List(n) { "" }
+        val approx = (text.length + n - 1) / n
+        val result = ArrayList<String>(n)
+        var start = 0
+        for (i in 0 until n) {
+            if (start >= text.length) {
+                result.add("")
+                continue
+            }
+            if (i == n - 1) {
+                result.add(text.substring(start).trim())
+                start = text.length
+                continue
+            }
+            var end = (start + approx).coerceAtMost(text.length)
+            while (end < text.length && !text[end].isWhitespace()) end++
+            result.add(text.substring(start, end).trim())
+            start = end
+        }
+        while (result.size < n) result.add("")
+        return result
+    }
+
+    private fun wordCount(s: String): Int {
+        val t = s.trim()
+        return if (t.isEmpty()) 0 else t.split(WHITESPACE).size
+    }
+
+    // ─── patterns ───────────────────────────────────────────────────────
+
+    /** Blank-line paragraph delimiter in Gutenberg plain text. */
+    private val PARAGRAPH_BREAK = Regex("\\n\\s*\\n")
+    private val WHITESPACE = Regex("\\s+")
+
+    /**
+     * Real chapter bodies run for thousands of characters; table-of-
+     * contents entries sit a line apart. 400 chars cleanly separates the
+     * two without tripping on genuinely short chapters in the common case
+     * (and a miss only downgrades to the proportional split).
+     */
+    private const val MIN_BODY_GAP = 400
+
+    /** "CHAPTER I", "Chapter 1", "BOOK IV — The Return", etc. The keyword
+     *  must be followed by a Roman numeral or digits; trailing title text
+     *  is allowed. */
+    private val HEADING_KEYWORD = Regex(
+        "^(?:CHAPTER|BOOK|PART|SECTION|LETTER|ACT|SCENE|CANTO)\\s+(?:[IVXLCDM]+|\\d+)\\b.*$",
+        RegexOption.IGNORE_CASE,
+    )
+
+    /** A lone upper-case Roman numeral line ("IV", "XII."). Case-sensitive
+     *  so it doesn't match lower-case words like "i" or "mix". */
+    private val HEADING_ROMAN = Regex("^[IVXLCDM]{1,7}\\.?$")
+
+    /** A lone number line ("12", "12."). */
+    private val HEADING_NUMBER = Regex("^\\d{1,3}\\.?$")
+}

--- a/source-librivox/src/main/kotlin/in/jphe/storyvox/source/librivox/LibriVoxSource.kt
+++ b/source-librivox/src/main/kotlin/in/jphe/storyvox/source/librivox/LibriVoxSource.kt
@@ -18,8 +18,11 @@ import `in`.jphe.storyvox.source.librivox.net.GutenbergTextApi
 import `in`.jphe.storyvox.source.librivox.net.LibriVoxApi
 import `in`.jphe.storyvox.source.librivox.net.LibriVoxBook
 import `in`.jphe.storyvox.source.librivox.net.LibriVoxSection
+import java.util.concurrent.ConcurrentHashMap
 import javax.inject.Inject
 import javax.inject.Singleton
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
 
 /**
  * Issue #1015 — `:source-librivox`, storyvox's first **pre-recorded**
@@ -44,17 +47,20 @@ import javax.inject.Singleton
  *   Each chapter's [ChapterContent.audioUrl] is the section's
  *   `listen_url`; text bodies are empty so EnginePlayer takes the
  *   Media3 branch.
- * - **Open-domain text companion (issue #1046)**. A LibriVox recording
- *   is a volunteer reading a public-domain text — almost always a
- *   Project Gutenberg ebook, linked from the book's `url_text_source`.
- *   When that link resolves to a Gutenberg id ([GutenbergTextApi]),
- *   [fictionDetail] appends one extra **text** chapter
- *   ("📖 Read the text (Project Gutenberg)", chapterId
- *   `"<bookId>:gutenberg-text"`) after the audio sections. It carries
- *   NO `audioUrl`, so the reader shows the public-domain text and the
- *   TTS pipeline can narrate it — the open-domain text "alongside" the
- *   human-narrated audio. The Gutenberg fetch is lazy: only [chapter]
- *   for that id pays it, never the browse/detail listing.
+ * - **Read-along text (issues #1046 / #1224)**. A LibriVox recording is
+ *   a volunteer reading a public-domain text — almost always a Project
+ *   Gutenberg ebook, linked from the book's `url_text_source`. When that
+ *   link resolves to a Gutenberg id ([GutenbergTextApi]), [chapter]
+ *   fetches the cleaned plain text once, splits it across the audio
+ *   sections ([GutenbergChapterSplitter]) and populates each section's
+ *   text body with its matching segment — so the reader shows the right
+ *   text while that section's human narration plays (read-along). The
+ *   split is built lazily on the first section download and cached per
+ *   book; the browse/detail listing never pays the text fetch.
+ *   Pre-#1224 the text was instead appended as a single bonus chapter
+ *   `"<bookId>:gutenberg-text"`; [chapter] still resolves that legacy id
+ *   defensively for any persisted/deep-linked rows, but [fictionDetail]
+ *   no longer advertises it.
  *
  * ## Two API shapes (lazy section hydration)
  *
@@ -65,15 +71,15 @@ import javax.inject.Singleton
  * `extended=1` single-book fetch that returns the sections. See
  * [LibriVoxApi] for the endpoint detail.
  *
- * ## Audio-stream backend invariant (issue #373 / #1046)
+ * ## Audio-stream backend invariant (issues #373 / #1046 / #1224)
  *
- * Every *audio section* chapter has `audioUrl != null` with empty text
- * bodies — EnginePlayer's audio-vs-TTS branch keys off `audioUrl` and
- * routes those through Media3. The lone exception is the optional
- * Gutenberg text companion above: it deliberately has `audioUrl == null`
- * and a populated body so it flows through the normal text → TTS / reader
- * path. Keep the section chapters' `audioUrl` non-null in lockstep with
- * `:core-playback`'s expectations or audio playback regresses.
+ * Every *audio section* chapter keeps `audioUrl != null` — EnginePlayer's
+ * audio-vs-TTS branch keys off `audioUrl` and routes those through Media3
+ * regardless of the body, so populating the section's text body for
+ * read-along (#1224) does NOT change playback: the human narration still
+ * streams, the body is only surfaced in the reader. Keep the section
+ * chapters' `audioUrl` non-null in lockstep with `:core-playback`'s
+ * expectations or audio playback regresses.
  */
 @SourcePlugin(
     id = SourceIds.LIBRIVOX,
@@ -93,6 +99,27 @@ internal class LibriVoxSource @Inject constructor(
 
     override val id: String = SourceIds.LIBRIVOX
     override val displayName: String = "LibriVox"
+
+    /**
+     * Issue #1224 — per-book read-along segments (one entry per audio
+     * section), built lazily on the first section download and reused by
+     * its siblings. `LibriVoxSource` is a `@Singleton`, so this map
+     * survives across `ChapterDownloadWorker` runs in-process — without it
+     * every section download would re-fetch + re-split the whole book
+     * text. Only successful splits are cached, so a transient Gutenberg
+     * fetch failure can still be retried on the next section open.
+     */
+    private val readAlongCache = ConcurrentHashMap<String, List<String>>()
+
+    /**
+     * Per-book mutex guarding the build-and-cache of [readAlongCache] so
+     * concurrent section downloads for the same book fetch + split once,
+     * not once each. Mirrors `:source-gutenberg`'s `lockFor` pattern (#942).
+     */
+    private val readAlongLocks = ConcurrentHashMap<String, Mutex>()
+
+    private fun readAlongLockFor(bookId: String): Mutex =
+        readAlongLocks.computeIfAbsent(bookId) { Mutex() }
 
     // ─── filters ──────────────────────────────────────────────────────
 
@@ -256,17 +283,11 @@ internal class LibriVoxSource @Inject constructor(
                 val audioChapters = book.sections.mapIndexed { index, section ->
                     section.toChapterInfo(book.id, index)
                 }
-                // Issue #1046 — append the open-domain text companion
-                // when `url_text_source` resolves to a Project Gutenberg
-                // ebook. Sits after the audio sections; carries no audio
-                // so the reader/TTS path handles it. The id is checked
-                // here (cheap, offline) but the text itself is fetched
-                // lazily in [chapter].
-                val chapters = audioChapters + listOfNotNull(
-                    GutenbergTextApi.parseGutenbergId(book.urlTextSource)?.let {
-                        gutenbergTextChapterInfo(book.id, audioChapters.size)
-                    },
-                )
+                // Issue #1224 — the Project Gutenberg companion text is now
+                // split across the audio sections (read-along, populated in
+                // [chapter]) rather than appended as a single bonus chapter,
+                // so the TOC is exactly the audio sections.
+                val chapters = audioChapters
                 FictionResult.Success(
                     FictionDetail(
                         summary = book.toSummary(),
@@ -285,10 +306,12 @@ internal class LibriVoxSource @Inject constructor(
         chapterId: String,
     ): FictionResult<ChapterContent> {
         val bookId = bookIdFromFictionId(fictionId)
-        // Issue #1046 — the open-domain text companion. Resolve the
-        // Gutenberg id from the book's `url_text_source`, then fetch +
-        // clean the plain text. Returned with NO audioUrl so the reader
-        // shows it and the TTS pipeline (not Media3) handles playback.
+        // Issues #1046 / #1224 — legacy single bonus-chapter id. No longer
+        // advertised by [fictionDetail] (the text is now split across the
+        // audio sections for read-along), but still resolved here so a
+        // persisted or deep-linked "<bookId>:gutenberg-text" row from a
+        // pre-#1224 build still opens the full text. Carries NO audioUrl,
+        // so it flows through the reader / TTS path, not Media3.
         if (chapterId == gutenbergTextChapterIdFor(bookId)) {
             return fetchGutenbergTextChapter(bookId, chapterId)
         }
@@ -309,14 +332,20 @@ internal class LibriVoxSource @Inject constructor(
                         "LibriVox section has no audio URL: $chapterId",
                     )
                 }
+                // Issue #1224 — populate the section's text body with its
+                // matching slice of the Project Gutenberg companion text so
+                // the reader shows it while the human narration plays
+                // (read-along). Empty when the book has no Gutenberg source
+                // or the fetch/split yields nothing — the section then
+                // behaves exactly as the pre-#1224 audio-only chapter.
+                // `audioUrl` stays set regardless, so EnginePlayer still
+                // routes playback through Media3 (#373), not TTS.
+                val readAlong = readAlongSegmentFor(book, idx)
                 FictionResult.Success(
                     ChapterContent(
                         info = section.toChapterInfo(book.id, idx),
-                        // Issue #373 — audio chapters carry empty text
-                        // bodies; EnginePlayer sees `audioUrl != null` and
-                        // routes through Media3 instead of TTS.
-                        htmlBody = "",
-                        plainBody = "",
+                        htmlBody = if (readAlong.isEmpty()) "" else gutenbergHtml(readAlong),
+                        plainBody = readAlong,
                         audioUrl = section.listenUrl,
                     ),
                 )
@@ -421,6 +450,40 @@ internal class LibriVoxSource @Inject constructor(
                 ),
             )
             is FictionResult.Failure -> text
+        }
+    }
+
+    /**
+     * Issue #1224 — read-along text for audio section [idx] of [book]: its
+     * slice of the Project Gutenberg companion text, or "" when the book
+     * has no Gutenberg source, the fetch fails, or the split has no
+     * segment for this index (the caller then renders an audio-only
+     * chapter, exactly as before #1224).
+     */
+    private suspend fun readAlongSegmentFor(book: LibriVoxBook, idx: Int): String =
+        readAlongSegments(book).getOrNull(idx).orEmpty()
+
+    /**
+     * Build-or-fetch the per-section read-along segments for [book],
+     * memoised in [readAlongCache]. Fetches the cleaned Gutenberg plain
+     * text once and splits it into `book.sections.size` segments via
+     * [GutenbergChapterSplitter]. Returns an empty list — left *uncached*
+     * so a later open can retry — when the book has no Gutenberg
+     * `url_text_source` or the text fetch fails. The per-book mutex makes
+     * concurrent sibling-section downloads share a single fetch + split.
+     */
+    private suspend fun readAlongSegments(book: LibriVoxBook): List<String> {
+        readAlongCache[book.id]?.let { return it }
+        val gutenbergId = GutenbergTextApi.parseGutenbergId(book.urlTextSource)
+            ?: return emptyList()
+        return readAlongLockFor(book.id).withLock {
+            readAlongCache[book.id]?.let { return@withLock it }
+            val text = when (val result = gutenberg.fetchPlainText(gutenbergId)) {
+                is FictionResult.Success -> result.value
+                is FictionResult.Failure -> return@withLock emptyList()
+            }
+            GutenbergChapterSplitter.split(text, book.sections.size)
+                .also { readAlongCache[book.id] = it }
         }
     }
 

--- a/source-librivox/src/test/kotlin/in/jphe/storyvox/source/librivox/GutenbergChapterSplitterTest.kt
+++ b/source-librivox/src/test/kotlin/in/jphe/storyvox/source/librivox/GutenbergChapterSplitterTest.kt
@@ -1,0 +1,146 @@
+package `in`.jphe.storyvox.source.librivox
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * Issue #1224 — unit coverage for [GutenbergChapterSplitter], the pure
+ * Gutenberg-text → per-LibriVox-section splitter behind read-along.
+ *
+ * Covers the two strategies (heading-aligned, proportional), the
+ * table-of-contents filter, the char-split last resort, and the
+ * always-exactly-N / no-text-lost guarantees.
+ */
+class GutenbergChapterSplitterTest {
+
+    /** A chapter body comfortably above the splitter's MIN_BODY_GAP (400
+     *  chars) so its preceding heading survives the TOC filter. */
+    private fun body(marker: String): String {
+        val sentence = "$marker — and the wind moved slow across the long grey field that morning. "
+        return buildString { repeat(8) { append(sentence) } }.trim()
+    }
+
+    @Test fun `non-positive section count yields empty list`() {
+        assertEquals(emptyList<String>(), GutenbergChapterSplitter.split("anything", 0))
+        assertEquals(emptyList<String>(), GutenbergChapterSplitter.split("anything", -3))
+    }
+
+    @Test fun `single section gets the whole text`() {
+        val text = "Once upon a time.\n\nThe end."
+        assertEquals(listOf(text), GutenbergChapterSplitter.split(text, 1))
+    }
+
+    @Test fun `empty text yields n empty segments`() {
+        val result = GutenbergChapterSplitter.split("   \n  \n ", 3)
+        assertEquals(3, result.size)
+        assertTrue(result.all { it.isEmpty() })
+    }
+
+    @Test fun `headings matching section count split at chapter boundaries`() {
+        val text = buildString {
+            append("A short preface before the story begins.\n\n")
+            append("CHAPTER I\n\n").append(body("BODYONE")).append("\n\n")
+            append("CHAPTER II\n\n").append(body("BODYTWO")).append("\n\n")
+            append("CHAPTER III\n\n").append(body("BODYTHREE"))
+        }
+        val segs = GutenbergChapterSplitter.split(text, 3)
+
+        assertEquals(3, segs.size)
+        // Front matter rides along with the first chapter.
+        assertTrue(segs[0].contains("A short preface"))
+        assertTrue(segs[0].contains("CHAPTER I"))
+        assertTrue(segs[0].contains("BODYONE"))
+        assertTrue(segs[1].startsWith("CHAPTER II"))
+        assertTrue(segs[1].contains("BODYTWO"))
+        assertTrue(segs[2].contains("CHAPTER III"))
+        assertTrue(segs[2].contains("BODYTHREE"))
+        // Boundaries are clean — chapter 2's segment doesn't bleed into 3.
+        assertFalse(segs[1].contains("BODYTHREE"))
+        assertFalse(segs[0].contains("BODYTWO"))
+    }
+
+    @Test fun `lone roman numeral headings split`() {
+        val text = buildString {
+            append("I\n\n").append(body("ALPHA")).append("\n\n")
+            append("II\n\n").append(body("BETA")).append("\n\n")
+            append("III\n\n").append(body("GAMMA"))
+        }
+        val segs = GutenbergChapterSplitter.split(text, 3)
+        assertEquals(3, segs.size)
+        assertTrue(segs[0].contains("ALPHA"))
+        assertTrue(segs[1].contains("BETA"))
+        assertTrue(segs[2].contains("GAMMA"))
+    }
+
+    @Test fun `table-of-contents entries are filtered out`() {
+        // A packed TOC block, immediately followed by the real chapters.
+        // The TOC headings sit a line apart (< MIN_BODY_GAP) so they're
+        // dropped; only the three body-backed headings survive → a clean
+        // 3-way split.
+        val text = buildString {
+            append("CONTENTS\n")
+            append("CHAPTER I\n")
+            append("CHAPTER II\n")
+            append("CHAPTER III\n")
+            append("CHAPTER I\n\n").append(body("REALONE")).append("\n\n")
+            append("CHAPTER II\n\n").append(body("REALTWO")).append("\n\n")
+            append("CHAPTER III\n\n").append(body("REALTHREE"))
+        }
+        val segs = GutenbergChapterSplitter.split(text, 3)
+        assertEquals(3, segs.size)
+        assertTrue(segs[1].contains("REALTWO"))
+        assertTrue(segs[2].contains("REALTHREE"))
+        // The real chapter 2 starts at its real heading, not a TOC line.
+        assertFalse(segs[2].contains("REALTWO"))
+    }
+
+    @Test fun `heading count mismatch falls back to proportional and stays exactly n`() {
+        // Two headings, but three sections — heading split can't align, so
+        // proportional takes over and still yields exactly three segments.
+        val text = buildString {
+            append("CHAPTER I\n\n").append(body("ONE")).append("\n\n")
+            append("CHAPTER II\n\n").append(body("TWO"))
+        }
+        val segs = GutenbergChapterSplitter.split(text, 3)
+        assertEquals(3, segs.size)
+        assertTrue(segs.all { it.isNotEmpty() })
+    }
+
+    @Test fun `proportional split preserves every paragraph in order and loses no text`() {
+        val paras = (1..9).map { "Paragraph number $it with several words to count here." }
+        val text = paras.joinToString("\n\n")
+        val segs = GutenbergChapterSplitter.split(text, 3)
+
+        assertEquals(3, segs.size)
+        assertTrue(segs.all { it.isNotEmpty() })
+        // Every paragraph survives exactly once, in order.
+        val rejoined = segs.joinToString("\n\n")
+        for (p in paras) assertTrue("missing: $p", rejoined.contains(p))
+        // Order preserved: paragraph 1 before 9 in the concatenation.
+        assertTrue(rejoined.indexOf("number 1 ") < rejoined.indexOf("number 9 "))
+    }
+
+    @Test fun `fewer paragraphs than sections uses char split covering all words`() {
+        // One un-delimited blob, three sections — no paragraph boundaries,
+        // so the char-split last resort runs.
+        val text = (1..30).joinToString(" ") { "word$it" }
+        val segs = GutenbergChapterSplitter.split(text, 3)
+
+        assertEquals(3, segs.size)
+        // Words aren't cut mid-token and none are lost.
+        val rejoined = segs.joinToString(" ")
+        for (i in 1..30) assertTrue("missing word$i", Regex("\\bword$i\\b").containsMatchIn(rejoined))
+    }
+
+    @Test fun `result size always equals section count`() {
+        val text = buildString {
+            append("CHAPTER I\n\n").append(body("X")).append("\n\n")
+            append("CHAPTER II\n\n").append(body("Y"))
+        }
+        for (n in 1..6) {
+            assertEquals("n=$n", n, GutenbergChapterSplitter.split(text, n).size)
+        }
+    }
+}


### PR DESCRIPTION
Closes #1224.

LibriVox books that link to Project Gutenberg already fetched the full text, but it was dumped into a single synthetic bonus chapter — the reader showed **nothing** while a section's human narration played. This splits the Gutenberg plain text across the audio sections so each section carries its matching text body, and the reader shows it during playback (**manual read-along**; word-level highlight sync awaits STT #1223).

## Why no core changes were needed
Traced the audio↔text↔reader path first (full notes in the [issue comment](https://github.com/techempower-org/candela/issues/1224)):
- `AppBindings.chapterText` is **DB-sourced** (`currentChapterId → observeChapter(id).plainBody`), and `observeChapter` round-trips `plainBody` for audio chapters — so populating an audio chapter's body **displays it**.
- `startListening` already calls `queueChapterDownload` **unconditionally**, so `ChapterDownloadWorker → source.chapter() → setBody` persists the read-along text for audio chapters.
- `EnginePlayer` routes on `audioUrl != null` and never reads the body, so Media3 playback is **unaffected**.

⇒ The whole feature is contained in `:source-librivox`.

## Changes
- **`GutenbergChapterSplitter`** (new, pure, unit-tested) — splits cleaned plain text into exactly N segments:
  - **Heading-aligned** when detected headings (`CHAPTER I`, `Chapter 1`, lone Roman numerals/numbers) number *exactly* N — cut at headings, front matter rides with segment 0, table-of-contents lines filtered by a min-body-gap heuristic.
  - **Proportional** fallback otherwise (word-balanced on paragraph boundaries; char-split when paragraphs < N). The exact-count gate degrades noisy detection to proportional rather than risk an off-by-one misalignment.
- **`LibriVoxSource`** — `chapter()` attaches each section's matching segment to `plainBody`/`htmlBody` (keeps `audioUrl`); the split is fetched once and **cached per book** (`@Singleton` + per-book mutex, mirroring `:source-gutenberg`). `fictionDetail()` drops the bonus chapter from the TOC; the legacy `"<bookId>:gutenberg-text"` id is still resolved defensively in `chapter()` for pre-#1224 persisted/deep-linked rows.

## Scope / honest limits (v1)
- **Manual** read-along, not word-synced highlight (Media3 has no per-word signal; `currentSentenceRange = null`). Word-level sync = STT follow-up #1223.
- A heading-split puts a leading internal TOC (when the Gutenberg file has one) into segment 0's front matter — all text is present, just slightly untidy before chapter 1. Proportional path unaffected. Future polish.
- LibriVox finite MP3s still show the "LIVE" badge instead of a seekbar (`isLiveAudioChapter`) — pre-existing (#373/#448), out of scope.
- Side benefit: in-book search (#1229) now finds LibriVox read-along text.

## Testing
- `GutenbergChapterSplitterTest` covers: heading split + front-matter, lone Roman numerals, TOC filtering, proportional fallback (exactly N, no text lost, order preserved), char-split last resort, and the always-exactly-N guarantee.
- JVM unit tests run on CI (`Test Compile` / module `testDebugUnitTest`); no local gradle per repo policy. Reader read-along to be confirmed on-device.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
