### PR TITLE
feat(source-bookshare): DAISY parser + guarded Bookshare scaffold (#1002)

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -609,6 +609,10 @@ dependencies {
     // documented under scratch/libby-hoopla-palace-scope/ but deferred
     // to their own PRs.
     implementation(project(":source-palace"))
+    // Issue #1002 — Bookshare accessible-library (DAISY) source. Guarded
+    // scaffold today (partner API key + PDTB DRM + per-user OAuth pending);
+    // ships the DAISY text parser as the non-gated groundwork.
+    implementation(project(":source-bookshare"))
     implementation(project(":source-azure"))
     implementation(project(":core-sync"))
     implementation(project(":feature"))

--- a/core-data/src/main/kotlin/in/jphe/storyvox/data/source/SourceIds.kt
+++ b/core-data/src/main/kotlin/in/jphe/storyvox/data/source/SourceIds.kt
@@ -122,6 +122,14 @@ object SourceIds {
      *  texts read aloud); LibriVox↔Gutenberg text alignment is a future
      *  enhancement, not part of v1. */
     const val LIBRIVOX: String = "librivox"
+    /** Bookshare (#1002) — Benetech's accessible-book library (1M+
+     *  DAISY titles) for users with print disabilities. Functional
+     *  integration is gated on a partner `api_key`
+     *  (partner-support@bookshare.org), per-user OAuth, and Protected
+     *  DAISY (PDTB) decryption — see the #1002 research comment. The
+     *  shipped `:source-bookshare` scaffold returns `AuthRequired`
+     *  until those land; the DAISY text parser is the non-gated piece. */
+    const val BOOKSHARE: String = "bookshare"
     /** Notion (#233) — Notion databases as a fiction backend. Each
      *  database row is one fiction; each page's top-level `heading_1`
      *  boundary splits it into chapters. Requires a Notion Internal

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -113,6 +113,10 @@ include(":source-readability")
 // see scratch/libby-hoopla-palace-scope/lcp-drm-scope.md). Libby +
 // Hoopla follow-ups defer to their own PRs (see sibling scope notes).
 include(":source-palace")
+// Issue #1002 — Bookshare / accessible-library (DAISY) source. Ships a
+// DAISY text parser + a guarded FictionSource scaffold; functional
+// integration is partnership/DRM-gated (see the #1002 research comment).
+include(":source-bookshare")
 include(":core-sync")
 include(":feature")
 // Issue #409 — Baseline Profile producer module. Pure test APK

--- a/source-bookshare/build.gradle.kts
+++ b/source-bookshare/build.gradle.kts
@@ -1,0 +1,59 @@
+plugins {
+    alias(libs.plugins.android.library)
+    alias(libs.plugins.ksp)
+    alias(libs.plugins.hilt)
+}
+
+android {
+    namespace = "in.jphe.storyvox.source.bookshare"
+    compileSdk = 37
+
+    defaultConfig {
+        minSdk = 26
+    }
+
+    compileOptions {
+        sourceCompatibility = JavaVersion.VERSION_17
+        targetCompatibility = JavaVersion.VERSION_17
+    }
+
+    testOptions {
+        unitTests {
+            // Issue #1002 — the DAISY DTBook parser uses `android.util.Xml`
+            // (XmlPullParser), so unit tests need Android resources on the
+            // classpath to resolve the SDK shim. Same posture as
+            // `:source-palace` (#502) / `:source-rss` (#464).
+            isIncludeAndroidResources = true
+            isReturnDefaultValues = true
+        }
+    }
+}
+
+kotlin {
+    compilerOptions {
+        jvmTarget.set(org.jetbrains.kotlin.gradle.dsl.JvmTarget.JVM_17)
+    }
+}
+
+dependencies {
+    implementation(project(":core-data"))
+
+    implementation(libs.kotlinx.coroutines.android)
+
+    implementation(libs.hilt.android)
+    ksp(libs.hilt.compiler)
+
+    // Plugin-seam Phase 2 (#384) — emits the @SourcePlugin → @IntoSet
+    // SourcePluginDescriptor Hilt module for BookshareSource. The legacy
+    // @IntoMap binding lives in di/BookshareModule.kt for parity with the
+    // other source modules until Phase 3 removes that pattern.
+    ksp(project(":core-plugin-ksp"))
+
+    testImplementation(libs.junit)
+    testImplementation(libs.kotlinx.coroutines.test)
+    // Robolectric so `android.util.Xml` resolves for the DTBook XML parsing
+    // path in unit tests — same dep used by `:source-palace` / `:source-rss`.
+    testImplementation(libs.robolectric)
+    testImplementation("androidx.test:core:1.7.0")
+    testImplementation("androidx.test.ext:junit:1.3.0")
+}

--- a/source-bookshare/src/main/kotlin/in/jphe/storyvox/source/bookshare/BookshareSource.kt
+++ b/source-bookshare/src/main/kotlin/in/jphe/storyvox/source/bookshare/BookshareSource.kt
@@ -1,0 +1,91 @@
+package `in`.jphe.storyvox.source.bookshare
+
+import `in`.jphe.storyvox.data.source.FictionSource
+import `in`.jphe.storyvox.data.source.SourceIds
+import `in`.jphe.storyvox.data.source.model.ChapterContent
+import `in`.jphe.storyvox.data.source.model.FictionDetail
+import `in`.jphe.storyvox.data.source.model.FictionResult
+import `in`.jphe.storyvox.data.source.model.FictionSummary
+import `in`.jphe.storyvox.data.source.model.ListPage
+import `in`.jphe.storyvox.data.source.model.SearchQuery
+import `in`.jphe.storyvox.data.source.plugin.SourceCategory
+import `in`.jphe.storyvox.data.source.plugin.SourcePlugin
+import javax.inject.Inject
+import javax.inject.Singleton
+
+/**
+ * Issue #1002 — Bookshare / accessible-library (DAISY) source.
+ *
+ * Bookshare (a Benetech program) is the largest accessible-book library for
+ * people with print disabilities — 1M+ titles in DAISY format, free to
+ * qualified users. This is the most mission-aligned source Candela could add.
+ *
+ * ## Why this is a guarded scaffold (not yet functional)
+ *
+ * A working integration is gated on three things that need a partnership /
+ * legal step, not engineering (full writeup in the #1002 research comment):
+ *
+ *  1. **Partner `api_key`** — issued only by emailing
+ *     `partner-support@bookshare.org`; required on every API v2 endpoint.
+ *  2. **Per-user OAuth** — Authorization-Code grant against
+ *     `auth.bookshare.org`; the user signs in with their *already
+ *     disability-verified* Bookshare account (Bookshare verifies eligibility
+ *     at signup, so Candela never collects proof-of-disability itself).
+ *  3. **Protected DAISY (PDTB) decryption** — copyrighted downloads are
+ *     encrypted per-user, fingerprinted, and watermarked; decryption needs
+ *     Bookshare's scheme under partner terms and isn't publicly implementable.
+ *
+ * Until those land, every call returns [FictionResult.AuthRequired] — the
+ * interface's intended "no session" path, which surfaces a sign-in prompt
+ * instead of throwing. The non-gated groundwork that DID ship in this PR is
+ * the DAISY text parser
+ * ([`DaisyParser`][in.jphe.storyvox.source.bookshare.parse.DaisyParser]):
+ * once an `api_key` + OAuth land and an *unprotected* DAISY download is
+ * available, [chapter] parses it via that parser into [ChapterContent].
+ */
+@Singleton
+@SourcePlugin(
+    id = "bookshare",
+    displayName = "Bookshare",
+    defaultEnabled = false,
+    category = SourceCategory.Ebook,
+    supportsSearch = true,
+    description = "Accessible DAISY library · partner API (gated, see #1002)",
+    sourceUrl = "https://www.bookshare.org",
+)
+class BookshareSource @Inject constructor() : FictionSource {
+
+    override val id: String = SourceIds.BOOKSHARE
+    override val displayName: String = "Bookshare"
+
+    override suspend fun popular(page: Int): FictionResult<ListPage<FictionSummary>> = gate()
+
+    override suspend fun latestUpdates(page: Int): FictionResult<ListPage<FictionSummary>> = gate()
+
+    override suspend fun byGenre(genre: String, page: Int): FictionResult<ListPage<FictionSummary>> = gate()
+
+    override suspend fun search(query: SearchQuery): FictionResult<ListPage<FictionSummary>> = gate()
+
+    override suspend fun fictionDetail(fictionId: String): FictionResult<FictionDetail> = gate()
+
+    override suspend fun chapter(fictionId: String, chapterId: String): FictionResult<ChapterContent> = gate()
+
+    override suspend fun followsList(page: Int): FictionResult<ListPage<FictionSummary>> = gate()
+
+    override suspend fun setFollowed(fictionId: String, followed: Boolean): FictionResult<Unit> = gate()
+
+    override suspend fun genres(): FictionResult<List<String>> = gate()
+
+    /**
+     * Every network path is gated until the Bookshare partnership lands (see
+     * the class kdoc + #1002). [FictionResult.AuthRequired] is the interface's
+     * intended graceful "no session" return — never throw.
+     */
+    private fun gate(): FictionResult.AuthRequired = FictionResult.AuthRequired(GATE_MESSAGE)
+
+    companion object {
+        private const val GATE_MESSAGE =
+            "Bookshare needs a partner API key and your verified Bookshare sign-in, " +
+                "plus Protected-DAISY support — not available yet (see #1002)."
+    }
+}

--- a/source-bookshare/src/main/kotlin/in/jphe/storyvox/source/bookshare/di/BookshareModule.kt
+++ b/source-bookshare/src/main/kotlin/in/jphe/storyvox/source/bookshare/di/BookshareModule.kt
@@ -1,0 +1,34 @@
+package `in`.jphe.storyvox.source.bookshare.di
+
+import dagger.Binds
+import dagger.Module
+import dagger.hilt.InstallIn
+import dagger.hilt.components.SingletonComponent
+import dagger.multibindings.IntoMap
+import dagger.multibindings.StringKey
+import `in`.jphe.storyvox.data.source.FictionSource
+import `in`.jphe.storyvox.data.source.SourceIds
+import `in`.jphe.storyvox.source.bookshare.BookshareSource
+import javax.inject.Singleton
+
+/**
+ * Issue #1002 — contributes [BookshareSource] into the multi-source
+ * `Map<String, FictionSource>` so persisted rows with `sourceId="bookshare"`
+ * resolve through it.
+ *
+ * The legacy `@IntoMap @StringKey` binding runs in parallel with the
+ * auto-generated `@SourcePlugin` descriptor binding emitted by
+ * `:core-plugin-ksp` — the same Phase 2 transitional pattern every other
+ * source module uses (#384). Phase 3 will remove the legacy bindings across
+ * the board.
+ */
+@Module
+@InstallIn(SingletonComponent::class)
+internal abstract class BookshareBindings {
+
+    @Binds
+    @Singleton
+    @IntoMap
+    @StringKey(SourceIds.BOOKSHARE)
+    abstract fun bindFictionSource(impl: BookshareSource): FictionSource
+}

--- a/source-bookshare/src/main/kotlin/in/jphe/storyvox/source/bookshare/parse/DaisyModels.kt
+++ b/source-bookshare/src/main/kotlin/in/jphe/storyvox/source/bookshare/parse/DaisyModels.kt
@@ -1,0 +1,29 @@
+package `in`.jphe.storyvox.source.bookshare.parse
+
+/**
+ * Issue #1002 — a parsed DAISY book, text only.
+ *
+ * A TTS app re-narrates with its own voices, so we keep only the text +
+ * structure; DAISY's bundled audio and SMIL timing are dropped. See
+ * [DaisyParser].
+ */
+data class DaisyBook(
+    val title: String?,
+    val author: String?,
+    val chapters: List<DaisyChapter>,
+)
+
+/**
+ * One DAISY top-level section, in the (title, htmlBody, plainBody) shape the
+ * source layer maps onto
+ * [`ChapterContent`][in.jphe.storyvox.data.source.model.ChapterContent].
+ */
+data class DaisyChapter(
+    val id: String,
+    val title: String,
+    val htmlBody: String,
+    val plainBody: String,
+)
+
+/** Thrown when a DAISY document can't be parsed. */
+class DaisyParseException(message: String, cause: Throwable? = null) : Exception(message, cause)

--- a/source-bookshare/src/main/kotlin/in/jphe/storyvox/source/bookshare/parse/DaisyParser.kt
+++ b/source-bookshare/src/main/kotlin/in/jphe/storyvox/source/bookshare/parse/DaisyParser.kt
@@ -1,0 +1,151 @@
+package `in`.jphe.storyvox.source.bookshare.parse
+
+import android.util.Xml
+import org.xmlpull.v1.XmlPullParser
+import java.io.StringReader
+
+/**
+ * Issue #1002 — minimal DAISY 3 **DTBook** text extractor.
+ *
+ * Bookshare (and other accessible-library) titles arrive as DAISY. For a
+ * text-to-speech app we only need the TEXT — we re-narrate with our own
+ * voices, so DAISY's bundled audio + SMIL timing are irrelevant. This parser
+ * reads a DAISY 3 DTBook XML document (`http://www.daisy.org/z3986/2005/dtbook/`)
+ * and flattens it into ordered chapters (title + simple HTML body + plaintext
+ * body) — the same (title, htmlBody, plainBody) shape the rest of the source
+ * layer consumes.
+ *
+ * Scope: each top-level `<level1>` / `<level>` becomes one chapter; its first
+ * heading (`<h1>`..`<h6>` / `<hd>`) is the title and the remaining block text
+ * (`<p>` + sub-headings) is the body. Book title/author come from the DTBook
+ * `<head>` `dc:Title` / `dc:Creator` meta. Uses only Android's bundled
+ * `XmlPullParser` (no third-party XML dep), mirroring
+ * [`EpubParser`][in.jphe.storyvox.source.epub.parse.EpubParser]'s posture.
+ *
+ * Deliberately NOT handled in this scaffold (follow-ups): DAISY 2.02
+ * `ncc.html` navigation + its separate content docs, the zip package/manifest
+ * walk, MathML/tables, and — critically — **Protected DAISY (PDTB)
+ * decryption**, which Bookshare copyrighted downloads require and which is
+ * gated on the partner relationship (see the #1002 research comment).
+ */
+object DaisyParser {
+
+    private val HEADING_TAGS = setOf("h1", "h2", "h3", "h4", "h5", "h6", "hd")
+    private val CHAPTER_TAGS = setOf("level1", "level")
+
+    /** Parse a DAISY 3 DTBook XML document into a [DaisyBook]. */
+    fun parseDtbook(xml: String): DaisyBook {
+        try {
+            val parser = Xml.newPullParser()
+            parser.setInput(StringReader(xml))
+
+            var bookTitle: String? = null
+            var bookAuthor: String? = null
+            val chapters = mutableListOf<DaisyChapter>()
+
+            // Per-chapter accumulation.
+            var chapterDepth = 0            // >0 while inside a top-level section
+            var chapterId: String? = null
+            var chapterTitle: String? = null
+            var titleTaken = false
+            var titleBuf: StringBuilder? = null   // capturing the chapter's first heading
+            var blockBuf: StringBuilder? = null   // capturing a <p> / sub-heading block
+            val htmlParas = mutableListOf<String>()
+            val plainParas = mutableListOf<String>()
+            var chapterIndex = 0
+
+            fun resetChapter() {
+                chapterId = null
+                chapterTitle = null
+                titleTaken = false
+                titleBuf = null
+                blockBuf = null
+                htmlParas.clear()
+                plainParas.clear()
+            }
+
+            var event = parser.eventType
+            while (event != XmlPullParser.END_DOCUMENT) {
+                when (event) {
+                    XmlPullParser.START_TAG -> {
+                        val name = parser.name?.lowercase()
+                        when {
+                            name == "meta" -> {
+                                val metaName = parser.getAttributeValue(null, "name")
+                                val content = parser.getAttributeValue(null, "content")
+                                if (content != null) when (metaName) {
+                                    "dc:Title", "dc:title" -> if (bookTitle == null) bookTitle = content.collapseWhitespace()
+                                    "dc:Creator", "dc:creator" -> if (bookAuthor == null) bookAuthor = content.collapseWhitespace()
+                                }
+                            }
+                            name in CHAPTER_TAGS -> {
+                                if (chapterDepth == 0) {
+                                    resetChapter()
+                                    chapterId = parser.getAttributeValue(null, "id")
+                                }
+                                chapterDepth++
+                            }
+                            chapterDepth > 0 && name in HEADING_TAGS && !titleTaken ->
+                                titleBuf = StringBuilder()
+                            chapterDepth > 0 && (name == "p" || (name in HEADING_TAGS && titleTaken)) ->
+                                blockBuf = StringBuilder()
+                        }
+                    }
+
+                    XmlPullParser.TEXT -> {
+                        val text = parser.text ?: ""
+                        titleBuf?.append(text)
+                        blockBuf?.append(text)
+                    }
+
+                    XmlPullParser.END_TAG -> {
+                        val name = parser.name?.lowercase()
+                        when {
+                            titleBuf != null && name in HEADING_TAGS && !titleTaken -> {
+                                chapterTitle = titleBuf!!.toString().collapseWhitespace()
+                                titleBuf = null
+                                titleTaken = true
+                            }
+                            blockBuf != null && (name == "p" || name in HEADING_TAGS) -> {
+                                val block = blockBuf!!.toString().collapseWhitespace()
+                                if (block.isNotEmpty()) {
+                                    htmlParas.add("<p>${block.escapeHtml()}</p>")
+                                    plainParas.add(block)
+                                }
+                                blockBuf = null
+                            }
+                            name in CHAPTER_TAGS && chapterDepth > 0 -> {
+                                chapterDepth--
+                                if (chapterDepth == 0) {
+                                    chapterIndex++
+                                    val title = chapterTitle?.takeIf { it.isNotEmpty() }
+                                        ?: "Section $chapterIndex"
+                                    chapters.add(
+                                        DaisyChapter(
+                                            id = chapterId ?: "level-$chapterIndex",
+                                            title = title,
+                                            htmlBody = htmlParas.joinToString("\n"),
+                                            plainBody = plainParas.joinToString("\n\n"),
+                                        ),
+                                    )
+                                    resetChapter()
+                                }
+                            }
+                        }
+                    }
+                }
+                event = parser.next()
+            }
+
+            return DaisyBook(title = bookTitle, author = bookAuthor, chapters = chapters)
+        } catch (t: Throwable) {
+            throw DaisyParseException("Failed to parse DTBook XML: ${t.message}", t)
+        }
+    }
+
+    private fun String.collapseWhitespace(): String =
+        replace(Regex("\\s+"), " ").trim()
+
+    private fun String.escapeHtml(): String =
+        replace("&", "&amp;").replace("<", "&lt;").replace(">", "&gt;")
+}

--- a/source-bookshare/src/main/kotlin/in/jphe/storyvox/source/bookshare/parse/DaisyParser.kt
+++ b/source-bookshare/src/main/kotlin/in/jphe/storyvox/source/bookshare/parse/DaisyParser.kt
@@ -15,23 +15,46 @@ import java.io.StringReader
  * body) — the same (title, htmlBody, plainBody) shape the rest of the source
  * layer consumes.
  *
- * Scope: each top-level `<level1>` / `<level>` becomes one chapter; its first
- * heading (`<h1>`..`<h6>` / `<hd>`) is the title and the remaining block text
- * (`<p>` + sub-headings) is the body. Book title/author come from the DTBook
- * `<head>` `dc:Title` / `dc:Creator` meta. Uses only Android's bundled
- * `XmlPullParser` (no third-party XML dep), mirroring
- * [`EpubParser`][in.jphe.storyvox.source.epub.parse.EpubParser]'s posture.
+ * ## Text capture model
  *
- * Deliberately NOT handled in this scaffold (follow-ups): DAISY 2.02
- * `ncc.html` navigation + its separate content docs, the zip package/manifest
- * walk, MathML/tables, and — critically — **Protected DAISY (PDTB)
- * decryption**, which Bookshare copyrighted downloads require and which is
- * gated on the partner relationship (see the #1002 research comment).
+ * Each top-level `<level1>` / `<level>` becomes one chapter; its first heading
+ * (`<h1>`..`<h6>` / `<hd>`) is the title. For the body we **capture all text
+ * inside the chapter** and split it into paragraphs at known **block-level**
+ * boundaries ([BLOCK_TAGS] — `p`, list items, blockquotes, verse lines, notes,
+ * table cells, …). Anything not in that set is treated as *inline*, so its text
+ * flows into the surrounding paragraph — which means an unrecognised element
+ * never silently drops content (worst case two paragraphs merge). Page-turn and
+ * note-reference markers ([SKIP_TEXT_TAGS]) are dropped so they don't interrupt
+ * narration. Uses only Android's bundled `XmlPullParser` (no third-party XML
+ * dep), mirroring [`EpubParser`][in.jphe.storyvox.source.epub.parse.EpubParser].
+ *
+ * Deliberately NOT handled in this scaffold (tracked as #1293 / partnership):
+ * DAISY 2.02 `ncc.html` navigation + its separate content docs, the zip
+ * package/manifest walk, MathML/tables-as-structure, and **Protected DAISY
+ * (PDTB) decryption** (Bookshare copyrighted downloads — gated on the #1002
+ * partnership).
  */
 object DaisyParser {
 
     private val HEADING_TAGS = setOf("h1", "h2", "h3", "h4", "h5", "h6", "hd")
     private val CHAPTER_TAGS = setOf("level1", "level")
+
+    /**
+     * Block-level elements that delimit a paragraph. Containers (list, table,
+     * linegroup, …) are included too — flushing an already-empty buffer is a
+     * no-op, so listing them is harmless and future-proofs odd nestings.
+     * Anything NOT here is treated as inline (its text flows into the current
+     * paragraph), so DTBook inline markup like `<sent>` / `<w>` / `<em>` keeps
+     * a paragraph intact instead of shattering it.
+     */
+    private val BLOCK_TAGS = setOf(
+        "p", "list", "li", "dl", "dt", "dd", "blockquote", "note", "sidebar",
+        "prodnote", "table", "tr", "td", "th", "caption", "linegroup", "line",
+        "poem", "byline", "dateline", "epigraph", "author", "div", "bridgehead",
+    ) + HEADING_TAGS
+
+    /** Elements whose text is structural, not narratable (page-turn + note markers). */
+    private val SKIP_TEXT_TAGS = setOf("pagenum", "noteref", "linenum")
 
     /** Parse a DAISY 3 DTBook XML document into a [DaisyBook]. */
     fun parseDtbook(xml: String): DaisyBook {
@@ -43,25 +66,37 @@ object DaisyParser {
             var bookAuthor: String? = null
             val chapters = mutableListOf<DaisyChapter>()
 
-            // Per-chapter accumulation.
             var chapterDepth = 0            // >0 while inside a top-level section
             var chapterId: String? = null
             var chapterTitle: String? = null
             var titleTaken = false
-            var titleBuf: StringBuilder? = null   // capturing the chapter's first heading
-            var blockBuf: StringBuilder? = null   // capturing a <p> / sub-heading block
+            var capturingTitle = false
+            val titleBuf = StringBuilder()
+            val paraBuf = StringBuilder()
             val htmlParas = mutableListOf<String>()
             val plainParas = mutableListOf<String>()
+            var skipDepth = 0               // >0 while inside a non-narratable marker
             var chapterIndex = 0
+
+            fun flushPara() {
+                val block = paraBuf.toString().collapseWhitespace()
+                if (block.isNotEmpty()) {
+                    htmlParas.add("<p>${block.escapeHtml()}</p>")
+                    plainParas.add(block)
+                }
+                paraBuf.setLength(0)
+            }
 
             fun resetChapter() {
                 chapterId = null
                 chapterTitle = null
                 titleTaken = false
-                titleBuf = null
-                blockBuf = null
+                capturingTitle = false
+                titleBuf.setLength(0)
+                paraBuf.setLength(0)
                 htmlParas.clear()
                 plainParas.clear()
+                skipDepth = 0
             }
 
             var event = parser.eventType
@@ -85,38 +120,38 @@ object DaisyParser {
                                 }
                                 chapterDepth++
                             }
-                            chapterDepth > 0 && name in HEADING_TAGS && !titleTaken ->
-                                titleBuf = StringBuilder()
-                            chapterDepth > 0 && (name == "p" || (name in HEADING_TAGS && titleTaken)) ->
-                                blockBuf = StringBuilder()
+                            chapterDepth > 0 && name in SKIP_TEXT_TAGS -> skipDepth++
+                            chapterDepth > 0 && name in HEADING_TAGS && !titleTaken -> {
+                                flushPara()                 // close any pre-heading prose
+                                capturingTitle = true
+                                titleBuf.setLength(0)
+                            }
+                            chapterDepth > 0 && name in BLOCK_TAGS -> flushPara()
                         }
                     }
 
                     XmlPullParser.TEXT -> {
-                        val text = parser.text ?: ""
-                        titleBuf?.append(text)
-                        blockBuf?.append(text)
+                        if (chapterDepth > 0 && skipDepth == 0) {
+                            val text = parser.text ?: ""
+                            if (capturingTitle) titleBuf.append(text) else paraBuf.append(text)
+                        }
                     }
 
                     XmlPullParser.END_TAG -> {
                         val name = parser.name?.lowercase()
                         when {
-                            titleBuf != null && name in HEADING_TAGS && !titleTaken -> {
-                                chapterTitle = titleBuf!!.toString().collapseWhitespace()
-                                titleBuf = null
+                            chapterDepth > 0 && name in SKIP_TEXT_TAGS && skipDepth > 0 -> skipDepth--
+                            capturingTitle && name in HEADING_TAGS -> {
+                                chapterTitle = titleBuf.toString().collapseWhitespace()
+                                capturingTitle = false
                                 titleTaken = true
+                                titleBuf.setLength(0)
                             }
-                            blockBuf != null && (name == "p" || name in HEADING_TAGS) -> {
-                                val block = blockBuf!!.toString().collapseWhitespace()
-                                if (block.isNotEmpty()) {
-                                    htmlParas.add("<p>${block.escapeHtml()}</p>")
-                                    plainParas.add(block)
-                                }
-                                blockBuf = null
-                            }
+                            chapterDepth > 0 && name in BLOCK_TAGS -> flushPara()
                             name in CHAPTER_TAGS && chapterDepth > 0 -> {
                                 chapterDepth--
                                 if (chapterDepth == 0) {
+                                    flushPara()             // final paragraph
                                     chapterIndex++
                                     val title = chapterTitle?.takeIf { it.isNotEmpty() }
                                         ?: "Section $chapterIndex"

--- a/source-bookshare/src/test/kotlin/in/jphe/storyvox/source/bookshare/parse/DaisyParserTest.kt
+++ b/source-bookshare/src/test/kotlin/in/jphe/storyvox/source/bookshare/parse/DaisyParserTest.kt
@@ -1,0 +1,127 @@
+package `in`.jphe.storyvox.source.bookshare.parse
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+
+/**
+ * Issue #1002 — DAISY 3 DTBook parsing. Robolectric-backed because
+ * [DaisyParser] uses `android.util.Xml` (same posture as `:source-palace`'s
+ * OPDS parser tests). These exercise the non-gated half of the Bookshare
+ * source: turning a DTBook document into ordered, re-narratable chapters.
+ */
+@RunWith(RobolectricTestRunner::class)
+class DaisyParserTest {
+
+    private val twoChapterDtbook = """
+        <?xml version="1.0" encoding="UTF-8"?>
+        <dtbook version="2005-3" xml:lang="en">
+          <head>
+            <meta name="dc:Title" content="A Tale of Testing"/>
+            <meta name="dc:Creator" content="Ada Lovelace"/>
+          </head>
+          <book>
+            <frontmatter>
+              <doctitle>A Tale of Testing</doctitle>
+              <docauthor>Ada Lovelace</docauthor>
+            </frontmatter>
+            <bodymatter>
+              <level1 id="ch1">
+                <h1>Chapter One</h1>
+                <p>It was the best of tests.</p>
+                <p>It was the worst of tests.</p>
+              </level1>
+              <level1 id="ch2">
+                <h1>Chapter Two</h1>
+                <p>The second chapter begins.</p>
+              </level1>
+            </bodymatter>
+          </book>
+        </dtbook>
+    """.trimIndent()
+
+    @Test
+    fun `extracts book title and author from dc meta`() {
+        val book = DaisyParser.parseDtbook(twoChapterDtbook)
+        assertEquals("A Tale of Testing", book.title)
+        assertEquals("Ada Lovelace", book.author)
+    }
+
+    @Test
+    fun `splits level1 sections into ordered chapters with titles`() {
+        val book = DaisyParser.parseDtbook(twoChapterDtbook)
+        assertEquals(2, book.chapters.size)
+        assertEquals("ch1", book.chapters[0].id)
+        assertEquals("Chapter One", book.chapters[0].title)
+        assertEquals("ch2", book.chapters[1].id)
+        assertEquals("Chapter Two", book.chapters[1].title)
+    }
+
+    @Test
+    fun `captures paragraph text into plain and html bodies`() {
+        val first = DaisyParser.parseDtbook(twoChapterDtbook).chapters[0]
+        // Plain body keeps both paragraphs, joined by a blank line.
+        assertTrue(first.plainBody.contains("It was the best of tests."))
+        assertTrue(first.plainBody.contains("It was the worst of tests."))
+        // HTML body wraps each paragraph in <p>.
+        assertTrue(first.htmlBody.contains("<p>It was the best of tests.</p>"))
+        assertTrue(first.htmlBody.contains("<p>It was the worst of tests.</p>"))
+    }
+
+    @Test
+    fun `falls back to a numbered title when a section has no heading`() {
+        val xml = """
+            <?xml version="1.0" encoding="UTF-8"?>
+            <dtbook version="2005-3">
+              <book><bodymatter>
+                <level1><p>No heading here.</p></level1>
+              </bodymatter></book>
+            </dtbook>
+        """.trimIndent()
+        val book = DaisyParser.parseDtbook(xml)
+        assertEquals(1, book.chapters.size)
+        assertEquals("Section 1", book.chapters[0].title)
+        assertTrue(book.chapters[0].plainBody.contains("No heading here."))
+    }
+
+    @Test
+    fun `collapses whitespace across wrapped paragraph text`() {
+        val xml = """
+            <?xml version="1.0" encoding="UTF-8"?>
+            <dtbook version="2005-3">
+              <book><bodymatter>
+                <level1 id="x">
+                  <h1>Title</h1>
+                  <p>
+                    line one
+                    line two
+                  </p>
+                </level1>
+              </bodymatter></book>
+            </dtbook>
+        """.trimIndent()
+        val ch = DaisyParser.parseDtbook(xml).chapters.single()
+        assertEquals("line one line two", ch.plainBody)
+    }
+
+    @Test
+    fun `escapes html-significant characters in the html body`() {
+        val xml = """
+            <?xml version="1.0" encoding="UTF-8"?>
+            <dtbook version="2005-3">
+              <book><bodymatter>
+                <level1 id="x">
+                  <h1>Title</h1>
+                  <p>5 &lt; 6 &amp; 7 &gt; 6</p>
+                </level1>
+              </bodymatter></book>
+            </dtbook>
+        """.trimIndent()
+        val ch = DaisyParser.parseDtbook(xml).chapters.single()
+        // Parser decodes the entities to text, then re-escapes for HTML output.
+        assertEquals("5 < 6 & 7 > 6", ch.plainBody)
+        assertTrue(ch.htmlBody.contains("5 &lt; 6 &amp; 7 &gt; 6"))
+    }
+}

--- a/source-bookshare/src/test/kotlin/in/jphe/storyvox/source/bookshare/parse/DaisyParserTest.kt
+++ b/source-bookshare/src/test/kotlin/in/jphe/storyvox/source/bookshare/parse/DaisyParserTest.kt
@@ -124,4 +124,53 @@ class DaisyParserTest {
         assertEquals("5 < 6 & 7 > 6", ch.plainBody)
         assertTrue(ch.htmlBody.contains("5 &lt; 6 &amp; 7 &gt; 6"))
     }
+
+    @Test
+    fun `captures list, blockquote, and verse line text — not just p`() {
+        // Real DTBook books put narratable prose in list items, blockquotes,
+        // and verse lines, not only <p>. None of it may be dropped.
+        val xml = """
+            <?xml version="1.0" encoding="UTF-8"?>
+            <dtbook version="2005-3">
+              <book><bodymatter>
+                <level1 id="x">
+                  <h1>Mixed</h1>
+                  <p>Opening.</p>
+                  <list>
+                    <li>First item</li>
+                    <li>Second item</li>
+                  </list>
+                  <blockquote><p>A quoted line.</p></blockquote>
+                  <linegroup>
+                    <line>Verse one</line>
+                    <line>Verse two</line>
+                  </linegroup>
+                </level1>
+              </bodymatter></book>
+            </dtbook>
+        """.trimIndent()
+        val ch = DaisyParser.parseDtbook(xml).chapters.single()
+        assertEquals("Mixed", ch.title)
+        listOf("Opening.", "First item", "Second item", "A quoted line.", "Verse one", "Verse two")
+            .forEach { assertTrue("missing \"$it\" in: ${ch.plainBody}", ch.plainBody.contains(it)) }
+    }
+
+    @Test
+    fun `drops page numbers and note references from narrated text`() {
+        // pagenum + noteref are structural markers — narrating "42" / "1"
+        // mid-sentence would be wrong.
+        val xml = """
+            <?xml version="1.0" encoding="UTF-8"?>
+            <dtbook version="2005-3">
+              <book><bodymatter>
+                <level1 id="x">
+                  <h1>Title</h1>
+                  <p>Before<pagenum>42</pagenum> after<noteref idref="n1">1</noteref>.</p>
+                </level1>
+              </bodymatter></book>
+            </dtbook>
+        """.trimIndent()
+        val ch = DaisyParser.parseDtbook(xml).chapters.single()
+        assertEquals("Before after.", ch.plainBody)
+    }
 }


### PR DESCRIPTION
## Summary

Groundwork for #1002 (Bookshare / accessible-library DAISY integration). The issue is `deferred-strategic` / `priority:low`, and a *functional* source is gated on a partnership/legal step — so this PR lands the **non-gated engineering** + a **guarded scaffold**, with the full feasibility research posted to the issue (see the #1002 research comment).

## Why a functional source is gated (not built here)

Three hard, non-engineering gates (full detail in the research comment):

1. **Partner `api_key`** — issued only by emailing `partner-support@bookshare.org`; required on every Bookshare API v2 endpoint.
2. **Per-user OAuth** — Authorization-Code grant against `auth.bookshare.org`; the user signs in with their *already disability-verified* Bookshare account (Bookshare verifies eligibility at signup — Candela never handles proof-of-disability).
3. **Protected DAISY (PDTB) DRM** — copyrighted downloads are per-user encrypted + fingerprinted + watermarked; decryption needs Bookshare's scheme under partner terms, not publicly implementable.

## What this PR ships

**1. DAISY 3 DTBook text parser** (`DaisyParser`) — the issue's non-gated "scope DAISY parsing" step. A TTS app only needs the text (we re-narrate with our own voices), so it flattens `<level1>` sections into ordered chapters (title + html/plain body) and drops DAISY's bundled audio + SMIL timing. `XmlPullParser`-only (no third-party XML dep), mirroring `:source-epub`'s `EpubParser`. **6 Robolectric unit tests** cover dc meta title/author, chapter splitting, paragraph capture, whitespace collapsing, HTML escaping, and the no-heading fallback title.

**2. Guarded `:source-bookshare` module** — `BookshareSource` implements `FictionSource` + `@SourcePlugin(category = Ebook, defaultEnabled = false)`, wired exactly like `:source-palace` (legacy `@IntoMap` binding + `SourceIds.BOOKSHARE` + `settings.gradle` + `:app` dependency). Every network path returns `FictionResult.AuthRequired` behind a loud `#1002` guard — the interface's intended no-session path (never throws) — until the gates above land. When they do, `chapter()` parses an unprotected DAISY download through `DaisyParser` into `ChapterContent`.

## Deferred (documented in code)

DAISY 2.02 `ncc.html` navigation + its separate content docs, the zip package/manifest walk, and PDTB decryption (partnership-gated).

## Testing

`:source-bookshare:testDebugUnitTest` — 6 `DaisyParserTest` cases. CI `Build APK` validates the new module + Hilt/KSP wiring at `:app`. Not runnable on-device (no `api_key`/partnership yet); this is the feasible-now groundwork for a deferred-strategic issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
