### PR TITLE
feat(playback): Android Auto play-from-media-id/search + token bridge (#1232)

### DIFF
--- a/core-playback/src/main/kotlin/in/jphe/storyvox/playback/MediaSessionLocator.kt
+++ b/core-playback/src/main/kotlin/in/jphe/storyvox/playback/MediaSessionLocator.kt
@@ -1,15 +1,38 @@
 package `in`.jphe.storyvox.playback
 
+import android.support.v4.media.session.MediaSessionCompat
 import androidx.media3.session.SessionToken
 import javax.inject.Inject
 import javax.inject.Singleton
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
 
 /**
- * Bridge so that [auto.StoryvoxAutoBrowserService] can find the playback service's
- * session token without a direct service-to-service dependency. The playback service
- * writes the token on its onCreate; the auto browser reads it on demand.
+ * Bridge so that [auto.StoryvoxAutoBrowserService] (a legacy
+ * `MediaBrowserServiceCompat`) can find the playback service's session token
+ * without a direct service-to-service dependency. The playback service writes
+ * both tokens on its `onCreate`; the auto browser reads them on demand.
+ *
+ * Issue #1232 — Android Auto binds transport controls through the **legacy**
+ * [compatToken] (`MediaSessionCompat.Token`), which is what
+ * `MediaBrowserServiceCompat.setSessionToken()` requires; the Media3 [token]
+ * (`SessionToken`) is the wrong type for that call. [compatToken] is a
+ * [StateFlow] so the browser service — which can be created before the playback
+ * service — can await the token rather than racing it.
  */
 @Singleton
 class MediaSessionLocator @Inject constructor() {
+    /** Media3 session token. Retained for any Media3-side consumer. */
     @Volatile var token: SessionToken? = null
+
+    private val _compatToken = MutableStateFlow<MediaSessionCompat.Token?>(null)
+
+    /** Legacy token the Auto browser service hands to `setSessionToken()`.
+     *  Null until the playback service has built its session. */
+    val compatToken: StateFlow<MediaSessionCompat.Token?> = _compatToken.asStateFlow()
+
+    fun setCompatToken(value: MediaSessionCompat.Token?) {
+        _compatToken.value = value
+    }
 }

--- a/core-playback/src/main/kotlin/in/jphe/storyvox/playback/StoryvoxPlaybackService.kt
+++ b/core-playback/src/main/kotlin/in/jphe/storyvox/playback/StoryvoxPlaybackService.kt
@@ -65,6 +65,10 @@ class StoryvoxPlaybackService : MediaSessionService() {
     @Inject lateinit var wearBridge: PhoneWearBridge
     @Inject lateinit var mediaSessionLocator: MediaSessionLocator
 
+    /** Issue #1232 — resolves Android Auto play-from-media-id / play-from-search
+     *  requests (routed into the session callback) to a playable chapter. */
+    @Inject lateinit var autoPlaybackResolver: `in`.jphe.storyvox.playback.auto.AutoPlaybackResolver
+
     /** Issue #560 — process-wide audio-focus singleton. Held here so the
      *  service can wire the loss callback to controller.pause() once at
      *  onCreate(); the engine acquires/abandons through the same
@@ -141,11 +145,17 @@ class StoryvoxPlaybackService : MediaSessionService() {
         audioOutputMonitor.start()
 
         session = MediaSession.Builder(this, player)
-            .setCallback(StoryvoxSessionCallback(controller, scope))
+            .setCallback(StoryvoxSessionCallback(controller, scope, autoPlaybackResolver))
             .setBitmapLoader(CacheBitmapLoader(DataSourceBitmapLoader.Builder(this).build()))
             .setSessionActivity(buildSessionActivity(null, null))
             .build()
         mediaSessionLocator.token = session.token
+        // Issue #1232 — publish the legacy MediaSessionCompat.Token so the Auto
+        // browser service can setSessionToken() and bind transport controls.
+        // Media3's framework platformToken bridges to the compat token.
+        mediaSessionLocator.setCompatToken(
+            android.support.v4.media.session.MediaSessionCompat.Token.fromToken(session.platformToken),
+        )
 
         setMediaNotificationProvider(
             DefaultMediaNotificationProvider.Builder(this)

--- a/core-playback/src/main/kotlin/in/jphe/storyvox/playback/StoryvoxSessionCallback.kt
+++ b/core-playback/src/main/kotlin/in/jphe/storyvox/playback/StoryvoxSessionCallback.kt
@@ -2,14 +2,46 @@ package `in`.jphe.storyvox.playback
 
 import android.content.Intent
 import android.view.KeyEvent
+import androidx.media3.common.MediaItem
 import androidx.media3.common.util.UnstableApi
 import androidx.media3.session.MediaSession
+import com.google.common.util.concurrent.ListenableFuture
+import com.google.common.util.concurrent.SettableFuture
+import `in`.jphe.storyvox.playback.auto.AutoMediaId
+import `in`.jphe.storyvox.playback.auto.AutoPlaybackResolver
+import `in`.jphe.storyvox.playback.auto.PlayTarget
 import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.launch
 
+/**
+ * Issue #216 / #1232 — the Media3 session callback.
+ *
+ * `onMediaButtonEvent` handles BT/lock-screen keys (pre-existing). Issue #1232
+ * adds the **play-from-Android-Auto** path: when a legacy controller (Android
+ * Auto, Google Assistant) issues `playFromMediaId` / `playFromSearch`, Media3
+ * routes it into [onSetMediaItems] / [onAddMediaItems] with the browse media id
+ * in [MediaItem.mediaId] and any voice query in
+ * `MediaItem.requestMetadata.searchQuery`.
+ *
+ * Because [`in`.jphe.storyvox.playback.tts.EnginePlayer] is a `SimpleBasePlayer`
+ * that builds its **own** playlist (it has no externally-set media items — it
+ * synthesises TTS from chapter text), we don't hand Media3 a URI to play.
+ * Instead we resolve the request to a (fiction, chapter, offset) and drive
+ * playback through [DefaultPlaybackController.play] as a side effect; the player
+ * then reports its own timeline/metadata, which the session broadcasts back to
+ * Auto. The items we return are protocol echoes carrying the canonical media id.
+ *
+ * NOTE (on-device verify via DHU): the resolve→`controller.play` side effect is
+ * the source of truth for playback; Media3's attempt to apply the returned
+ * items to the player is expected to be a no-op since the player doesn't expose
+ * `COMMAND_SET_MEDIA_ITEM`. Validate the end-to-end "tap a book / say 'play X' /
+ * resume" flow on a real head unit (DHU) — see issue #1232 testing notes.
+ */
 @UnstableApi
 class StoryvoxSessionCallback(
-    controller: DefaultPlaybackController,
-    scope: CoroutineScope,
+    private val controller: DefaultPlaybackController,
+    private val scope: CoroutineScope,
+    private val autoResolver: AutoPlaybackResolver,
 ) : MediaSession.Callback {
 
     private val mediaButtonHandler = MediaButtonHandler(controller, scope)
@@ -23,4 +55,85 @@ class StoryvoxSessionCallback(
             ?: return false
         return mediaButtonHandler.handle(event)
     }
+
+    override fun onAddMediaItems(
+        mediaSession: MediaSession,
+        controller: MediaSession.ControllerInfo,
+        mediaItems: MutableList<MediaItem>,
+    ): ListenableFuture<MutableList<MediaItem>> {
+        val future = SettableFuture.create<MutableList<MediaItem>>()
+        scope.launch {
+            resolveAndPlay(mediaItems.firstOrNull())
+            // Echo the request back; EnginePlayer drives its own timeline.
+            future.set(mediaItems)
+        }
+        return future
+    }
+
+    override fun onSetMediaItems(
+        mediaSession: MediaSession,
+        controller: MediaSession.ControllerInfo,
+        mediaItems: MutableList<MediaItem>,
+        startIndex: Int,
+        startPositionMs: Long,
+    ): ListenableFuture<MediaSession.MediaItemsWithStartPosition> {
+        val future = SettableFuture.create<MediaSession.MediaItemsWithStartPosition>()
+        scope.launch {
+            // Auto may send C.INDEX_UNSET (-1); coerce to a valid index so
+            // MediaItemsWithStartPosition doesn't reject it.
+            val safeIndex = if (startIndex in mediaItems.indices) startIndex else 0
+            resolveAndPlay(mediaItems.getOrNull(safeIndex))
+            future.set(MediaSession.MediaItemsWithStartPosition(mediaItems, safeIndex, startPositionMs))
+        }
+        return future
+    }
+
+    override fun onPlaybackResumption(
+        mediaSession: MediaSession,
+        controller: MediaSession.ControllerInfo,
+    ): ListenableFuture<MediaSession.MediaItemsWithStartPosition> {
+        val future = SettableFuture.create<MediaSession.MediaItemsWithStartPosition>()
+        scope.launch {
+            val target = autoResolver.mostRecent()
+            if (target == null) {
+                future.setException(IllegalStateException("Nothing to resume"))
+            } else {
+                play(target)
+                future.set(
+                    MediaSession.MediaItemsWithStartPosition(
+                        mutableListOf(target.toMediaItem()),
+                        0,
+                        androidx.media3.common.C.TIME_UNSET,
+                    ),
+                )
+            }
+        }
+        return future
+    }
+
+    /** Resolve a requested item's media id / voice query and start playback.
+     *  Awaits only the (fast, Room-backed) resolve; the actual load is fired
+     *  async so we never block the returned future on `loadAndPlay` — Android
+     *  Auto can time the future out. No-op when nothing resolves. */
+    private suspend fun resolveAndPlay(item: MediaItem?) {
+        item ?: return
+        val mediaId = item.mediaId.takeIf { it.isNotEmpty() }
+        val query = item.requestMetadata.searchQuery
+        val target = autoResolver.resolve(mediaId, query) ?: return
+        play(target)
+    }
+
+    /** Fire-and-forget playback start; intentionally not awaited (see
+     *  [resolveAndPlay]). EnginePlayer then reports its own timeline. */
+    private fun play(target: PlayTarget) {
+        scope.launch {
+            controller.play(target.fictionId, target.chapterId, target.charOffset)
+        }
+    }
 }
+
+/** Protocol-echo MediaItem carrying the canonical Auto media id for a target. */
+private fun PlayTarget.toMediaItem(): MediaItem =
+    MediaItem.Builder()
+        .setMediaId(AutoMediaId.chapter(AutoMediaId.RECENT, fictionId, chapterId))
+        .build()

--- a/core-playback/src/main/kotlin/in/jphe/storyvox/playback/auto/AutoMediaId.kt
+++ b/core-playback/src/main/kotlin/in/jphe/storyvox/playback/auto/AutoMediaId.kt
@@ -1,0 +1,90 @@
+package `in`.jphe.storyvox.playback.auto
+
+/**
+ * Issue #1232 — the Android Auto media-id grammar, in one pure place so the
+ * browse service (which *builds* ids on every [android.support.v4.media.MediaBrowserCompat.MediaItem])
+ * and the session callback (which *parses* them on play-from-media-id) can
+ * never drift apart.
+ *
+ * Grammar — segments are percent-encoded so a fiction/chapter id may itself
+ * contain `/` (some sources mint composite chapter ids):
+ *
+ * ```
+ *   /                            root
+ *   /resume                      continue the most-recently-played book
+ *   /library                     category — library books   (browsable tab)
+ *   /follows                     category — followed books   (browsable tab)
+ *   /recent                      category — recent chapters  (browsable tab)
+ *   /new                         category — unread chapters  (browsable tab)
+ *   /library/<fiction>           a library book   (browsable → its chapters)
+ *   /follows/<fiction>           a followed book  (browsable → its chapters)
+ *   /library/<fiction>/<chapter> a chapter        (playable)
+ *   /follows/<fiction>/<chapter> a chapter        (playable)
+ *   /recent/<fiction>/<chapter>  a recent chapter (playable)
+ *   /new/<fiction>/<chapter>     an unread chapter (playable)
+ * ```
+ *
+ * Pure Kotlin, no Android types — covered by `AutoMediaIdTest`.
+ */
+object AutoMediaId {
+    const val ROOT = "/"
+    const val RESUME = "/resume"
+    const val LIBRARY = "/library"
+    const val FOLLOWS = "/follows"
+    const val RECENT = "/recent"
+    const val NEW = "/new"
+
+    /** The browsable root categories Auto renders as tabs. Order is
+     *  car-usefulness; Auto caps the root at 4 (see
+     *  `BROWSER_ROOT_HINTS_KEY_ROOT_CHILDREN_LIMIT`) and we already sit at 4. */
+    val ROOT_CATEGORIES: List<String> = listOf(LIBRARY, FOLLOWS, RECENT, NEW)
+
+    /** Categories whose books drill into a chapter list. */
+    private val BOOK_CATEGORIES = setOf(LIBRARY, FOLLOWS)
+
+    /** `/library/<fiction>` — a browsable book node. */
+    fun book(category: String, fictionId: String): String =
+        "$category/${enc(fictionId)}"
+
+    /** `/recent/<fiction>/<chapter>` — a playable chapter node. */
+    fun chapter(category: String, fictionId: String, chapterId: String): String =
+        "$category/${enc(fictionId)}/${enc(chapterId)}"
+
+    /** Parse a media id into a [Node]; null when it doesn't fit the grammar
+     *  (the session callback treats null as "not ours" and ignores it). */
+    fun parse(mediaId: String): Node? {
+        if (mediaId == ROOT) return Node.Root
+        if (mediaId == RESUME) return Node.Resume
+        if (!mediaId.startsWith("/")) return null
+        val parts = mediaId.removePrefix("/").split('/')
+        val category = "/" + (parts.getOrNull(0)?.takeIf { it.isNotEmpty() } ?: return null)
+        if (category !in ROOT_CATEGORIES) return null
+        return when (parts.size) {
+            1 -> Node.Category(category)
+            2 -> Node.Book(category, dec(parts[1]))
+            3 -> Node.Chapter(category, dec(parts[1]), dec(parts[2]))
+            else -> null
+        }
+    }
+
+    /** True when [category] is a book-style category that drills to chapters. */
+    fun isBookCategory(category: String): Boolean = category in BOOK_CATEGORIES
+
+    sealed interface Node {
+        data object Root : Node
+        data object Resume : Node
+        data class Category(val category: String) : Node
+        data class Book(val category: String, val fictionId: String) : Node
+        data class Chapter(
+            val category: String,
+            val fictionId: String,
+            val chapterId: String,
+        ) : Node
+    }
+
+    // Minimal reversible percent-encoding of '/' and the escape char itself.
+    // Decode order matters: '%2F' before '%25' so an encoded literal "%2F"
+    // round-trips (enc → "%252F", dec → "%2F").
+    private fun enc(s: String): String = s.replace("%", "%25").replace("/", "%2F")
+    private fun dec(s: String): String = s.replace("%2F", "/").replace("%25", "%")
+}

--- a/core-playback/src/main/kotlin/in/jphe/storyvox/playback/auto/AutoPlaybackResolver.kt
+++ b/core-playback/src/main/kotlin/in/jphe/storyvox/playback/auto/AutoPlaybackResolver.kt
@@ -1,0 +1,124 @@
+package `in`.jphe.storyvox.playback.auto
+
+import `in`.jphe.storyvox.data.repository.ChapterRepository
+import `in`.jphe.storyvox.data.repository.FollowsRepository
+import `in`.jphe.storyvox.data.repository.LibraryRepository
+import `in`.jphe.storyvox.data.repository.PlaybackPositionRepository
+import javax.inject.Inject
+import javax.inject.Singleton
+import kotlinx.coroutines.flow.first
+
+/** Where Android Auto should start playing: a resolved (fiction, chapter, offset). */
+data class PlayTarget(
+    val fictionId: String,
+    val chapterId: String,
+    val charOffset: Int,
+)
+
+/**
+ * Issue #1232 — turns an Android Auto play request (a browse media id, or a
+ * voice-search query) into a concrete [PlayTarget] the playback controller can
+ * start. Every dependency is a core-data repository and the return value
+ * carries no Android types, so the whole resolver is JVM-unit-testable
+ * (`AutoPlaybackResolverTest`).
+ *
+ * Voice search is **library-first**: a car request ("play Pride and Prejudice")
+ * resolves against the user's already-downloaded library + follows, so playback
+ * starts instantly instead of kicking off a network fetch at highway speed.
+ * Searching the source backends for not-yet-added books is a sensible follow-up
+ * but is deliberately out of scope here — it would pull the enabled-source
+ * settings and the source registry down into core-playback.
+ */
+@Singleton
+class AutoPlaybackResolver @Inject constructor(
+    private val chapterRepo: ChapterRepository,
+    private val positionRepo: PlaybackPositionRepository,
+    private val libraryRepo: LibraryRepository,
+    private val followsRepo: FollowsRepository,
+) {
+    /** Resolve a browse [mediaId] (preferred) or a voice [query] to a play
+     *  target. Returns null when nothing playable matches — the caller then
+     *  leaves playback untouched. */
+    suspend fun resolve(mediaId: String?, query: String?): PlayTarget? {
+        mediaId?.let { id ->
+            when (val node = AutoMediaId.parse(id)) {
+                is AutoMediaId.Node.Resume -> return mostRecent()
+                is AutoMediaId.Node.Chapter -> return targetForChapter(node.fictionId, node.chapterId)
+                is AutoMediaId.Node.Book -> return targetForBook(node.fictionId)
+                // Root / Category / unparseable are not playable.
+                else -> Unit
+            }
+        }
+        val q = query?.trim()?.takeIf { it.isNotBlank() } ?: return null
+        // "continue" / "resume" voice phrasing → the most-recent book.
+        if (q.equals("resume", ignoreCase = true) || q.contains("continue", ignoreCase = true)) {
+            mostRecent()?.let { return it }
+        }
+        val hitId = matchLibrary(q) ?: return null
+        return targetForBook(hitId)
+    }
+
+    /** The single most-recently-played (fiction, chapter, offset), or null when
+     *  nothing has been played yet. Powers `/resume`, onPlaybackResumption, and
+     *  "continue" voice commands. */
+    suspend fun mostRecent(): PlayTarget? {
+        val entry = positionRepo.observeMostRecentContinueListening().first() ?: return null
+        return PlayTarget(entry.fiction.id, entry.chapter.id, entry.charOffset)
+    }
+
+    /** Resume offset for an explicit (fiction, chapter): the saved char offset
+     *  when the save points at that very chapter, else 0 (start of chapter). */
+    private suspend fun targetForChapter(fictionId: String, chapterId: String): PlayTarget {
+        val saved = runCatching { positionRepo.load(fictionId) }.getOrNull()
+        val offset = if (saved?.chapterId == chapterId) saved.charOffset else 0
+        return PlayTarget(fictionId, chapterId, offset)
+    }
+
+    /** Resolve a whole book to its resume point: the saved chapter+offset if
+     *  there is one, else the first chapter at offset 0. Null when the book has
+     *  no chapters cached yet (nothing to play). */
+    private suspend fun targetForBook(fictionId: String): PlayTarget? {
+        val saved = runCatching { positionRepo.load(fictionId) }.getOrNull()
+        if (saved != null) {
+            return PlayTarget(fictionId, saved.chapterId, saved.charOffset)
+        }
+        val first = runCatching { chapterRepo.observeChapters(fictionId).first() }
+            .getOrNull()
+            ?.minByOrNull { it.index }
+            ?: return null
+        return PlayTarget(fictionId, first.id, 0)
+    }
+
+    /** Best library/follows title match for a voice [query], or null. */
+    private suspend fun matchLibrary(query: String): String? {
+        val library = runCatching { libraryRepo.snapshot() }.getOrDefault(emptyList())
+        val follows = runCatching { followsRepo.snapshot() }.getOrDefault(emptyList())
+        val candidates = library.map { it.id to it.title } + follows.map { it.id to it.title }
+        return bestTitleMatch(query, candidates)
+    }
+
+    companion object {
+        /** Pure title matcher, factored out for unit testing. Case-insensitive;
+         *  ranks exact > prefix > substring; first candidate wins on a tie. */
+        fun bestTitleMatch(query: String, candidates: List<Pair<String, String>>): String? {
+            val q = query.trim().lowercase()
+            if (q.isEmpty()) return null
+            var best: String? = null
+            var bestRank = 0
+            for ((id, title) in candidates) {
+                val t = title.lowercase()
+                val rank = when {
+                    t == q -> 3
+                    t.startsWith(q) -> 2
+                    t.contains(q) -> 1
+                    else -> 0
+                }
+                if (rank > bestRank) {
+                    bestRank = rank
+                    best = id
+                }
+            }
+            return best
+        }
+    }
+}

--- a/core-playback/src/main/kotlin/in/jphe/storyvox/playback/auto/StoryvoxAutoBrowserService.kt
+++ b/core-playback/src/main/kotlin/in/jphe/storyvox/playback/auto/StoryvoxAutoBrowserService.kt
@@ -1,33 +1,55 @@
 package `in`.jphe.storyvox.playback.auto
 
+import android.content.Intent
+import android.net.Uri
 import android.os.Bundle
 import android.support.v4.media.MediaBrowserCompat
 import android.support.v4.media.MediaDescriptionCompat
 import androidx.media.MediaBrowserServiceCompat
 import dagger.hilt.android.AndroidEntryPoint
+import `in`.jphe.storyvox.data.repository.ChapterRepository
 import `in`.jphe.storyvox.data.repository.FollowsRepository
 import `in`.jphe.storyvox.data.repository.LibraryRepository
 import `in`.jphe.storyvox.data.repository.PlaybackPositionRepository
 import `in`.jphe.storyvox.data.repository.playback.AutoBrowserConfig
+import `in`.jphe.storyvox.data.source.model.ChapterInfo
 import `in`.jphe.storyvox.playback.MediaSessionLocator
+import `in`.jphe.storyvox.playback.StoryvoxPlaybackService
 import javax.inject.Inject
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.cancel
+import kotlinx.coroutines.flow.filterNotNull
+import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
 
 /**
- * Android Auto browse tree:
+ * Issue #598 / #1232 — Android Auto browse tree:
  *
- *   /              (root, browseable)
- *   ├── /resume    (playable — last book)
- *   ├── /library   (browseable, ≤6 children)
- *   ├── /follows   (browseable, ≤6 children)
- *   ├── /recent    (browseable, ≤6 children)
- *   └── /new       (browseable, ≤6 children)
+ * ```
+ *   /                         (root)
+ *   ├── /library              (browsable tab → books → chapters)
+ *   ├── /follows              (browsable tab → books → chapters)
+ *   ├── /recent               (browsable tab → playable chapters)
+ *   └── /new                  (browsable tab → playable chapters)
+ * ```
  *
- * Auto's UX restrictions cap leaf depth and require artwork on every item.
+ * Four tabs because Android Auto caps the root menu at 4. "Continue where I
+ * left off" is served by the session callback's `onPlaybackResumption`
+ * (Auto's native resume affordance) rather than a browse node — see
+ * [`in`.jphe.storyvox.playback.StoryvoxSessionCallback].
+ *
+ * #1232 wires up the two pieces the prior browse-only scaffold left out:
+ * 1. [setSessionToken] — bridged from the Media3 session's platform token via
+ *    [MediaSessionLocator.compatToken]; without it Auto can browse but can't
+ *    control playback.
+ * 2. The book→chapter level (`/library/<f>` → `/library/<f>/<c>`), so tapping a
+ *    library/follows book opens its (playable) chapters instead of dead-ending.
+ *
+ * Media-id strings are built + parsed through [AutoMediaId] so the browse side
+ * and the play side can't drift.
  */
 @AndroidEntryPoint
 class StoryvoxAutoBrowserService : MediaBrowserServiceCompat() {
@@ -35,20 +57,31 @@ class StoryvoxAutoBrowserService : MediaBrowserServiceCompat() {
     @Inject lateinit var libraryRepo: LibraryRepository
     @Inject lateinit var followsRepo: FollowsRepository
     @Inject lateinit var positionRepo: PlaybackPositionRepository
+    @Inject lateinit var chapterRepo: ChapterRepository
     @Inject lateinit var sessionLocator: MediaSessionLocator
-    /** Issue #598 — user-tunable bucket size. Read at every
-     *  [onLoadChildren] call so a Settings flip takes effect the next
-     *  time Auto refreshes the tree (typically when the user
-     *  navigates back to a parent then forward into a category). */
+    /** Issue #598 — user-tunable bucket size. Read at every [onLoadChildren]
+     *  call so a Settings flip takes effect the next time Auto refreshes the
+     *  tree. */
     @Inject lateinit var autoConfig: AutoBrowserConfig
 
     private val scope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
 
     override fun onCreate() {
         super.onCreate()
-        // Defer session token attachment until the playback service has built it.
-        // We can attach lazily when the first browser connects; if absent, we
-        // return an empty list and the browser will retry.
+        // #1232 — nudge the playback service to build its MediaSession (and
+        // publish the legacy token) so transport controls can bind even when
+        // the user opened the app via Auto's browse UI. Guarded: background
+        // start can be refused on some OS versions; the token collector below
+        // still attaches the token whenever the session does come up.
+        runCatching {
+            startService(Intent(this, StoryvoxPlaybackService::class.java))
+        }
+        // Attach the session token as soon as the playback service publishes
+        // it. setSessionToken must run on the main thread.
+        scope.launch {
+            val token = sessionLocator.compatToken.filterNotNull().first()
+            withContext(Dispatchers.Main) { setSessionToken(token) }
+        }
     }
 
     override fun onDestroy() {
@@ -65,8 +98,11 @@ class StoryvoxAutoBrowserService : MediaBrowserServiceCompat() {
             putBoolean("android.media.browse.CONTENT_STYLE_SUPPORTED", true)
             putInt("android.media.browse.CONTENT_STYLE_BROWSABLE_HINT", 1) // list
             putInt("android.media.browse.CONTENT_STYLE_PLAYABLE_HINT", 2)  // grid
+            // #1232 — advertise that the session handles voice search so Auto
+            // routes "play <title>" through playFromSearch.
+            putBoolean("android.media.browse.SEARCH_SUPPORTED", true)
         }
-        return BrowserRoot(ROOT_ID, extras)
+        return BrowserRoot(AutoMediaId.ROOT, extras)
     }
 
     override fun onLoadChildren(
@@ -75,31 +111,54 @@ class StoryvoxAutoBrowserService : MediaBrowserServiceCompat() {
     ) {
         result.detach()
         scope.launch {
-            // Issue #598 — read the bucket size at the start of each
-            // tree load so a Settings flip propagates without an Auto
-            // service restart. Falls back to [MAX_PER_CATEGORY] (6,
-            // the HMI guideline) on the very first call when the
-            // store hasn't emitted yet.
             val bucket = autoConfig.currentItemsPerCategory()
-            val items = when (parentId) {
-                ROOT_ID -> rootItems()
-                LIBRARY_ID -> libraryRepo.snapshot().take(bucket).map { it.toBrowsableItem() }
-                FOLLOWS_ID -> followsRepo.snapshot().take(bucket).map { it.toBrowsableItem() }
-                RECENT_ID -> positionRepo.recent(bucket).map { it.toPlayableItem() }
-                NEW_ID -> followsRepo.unreadChapters(bucket).map { it.toPlayableItem() }
+            val items = when (val node = AutoMediaId.parse(parentId)) {
+                is AutoMediaId.Node.Root -> rootCategories()
+                is AutoMediaId.Node.Category -> categoryChildren(node.category, bucket)
+                is AutoMediaId.Node.Book -> bookChapters(node.category, node.fictionId)
+                // Chapter / Resume / unparseable have no children.
                 else -> emptyList()
             }
             result.sendResult(items.toMutableList())
         }
     }
 
-    private fun rootItems(): List<MediaBrowserCompat.MediaItem> = listOf(
-        browsable(RESUME_ID, "Resume"),
-        browsable(LIBRARY_ID, "Library"),
-        browsable(FOLLOWS_ID, "Follows"),
-        browsable(RECENT_ID, "Recent"),
-        browsable(NEW_ID, "New chapters"),
+    /** The four browsable root tabs (Auto caps the root at 4). */
+    private fun rootCategories(): List<MediaBrowserCompat.MediaItem> = listOf(
+        browsable(AutoMediaId.LIBRARY, "Library"),
+        browsable(AutoMediaId.FOLLOWS, "Follows"),
+        browsable(AutoMediaId.RECENT, "Recent"),
+        browsable(AutoMediaId.NEW, "New chapters"),
     )
+
+    private suspend fun categoryChildren(
+        category: String,
+        bucket: Int,
+    ): List<MediaBrowserCompat.MediaItem> = when (category) {
+        AutoMediaId.LIBRARY -> libraryRepo.snapshot().take(bucket)
+            .map { browsableBook(category, it.id, it.title, it.author, it.coverUrl) }
+        AutoMediaId.FOLLOWS -> followsRepo.snapshot().take(bucket)
+            .map { browsableBook(category, it.id, it.title, it.author, it.coverUrl) }
+        AutoMediaId.RECENT -> positionRepo.recent(bucket)
+            .map { playableChapter(AutoMediaId.RECENT, it.fictionId, it.chapterId, it.chapterTitle, it.bookTitle, it.coverUrl) }
+        AutoMediaId.NEW -> followsRepo.unreadChapters(bucket)
+            .map { playableChapter(AutoMediaId.NEW, it.fictionId, it.chapterId, it.chapterTitle, it.bookTitle, it.coverUrl) }
+        else -> emptyList()
+    }
+
+    /** A book's chapters, as playable leaves. Capped so a 2000-chapter web
+     *  serial doesn't build thousands of MediaItems (Auto truncates anyway). */
+    private suspend fun bookChapters(
+        category: String,
+        fictionId: String,
+    ): List<MediaBrowserCompat.MediaItem> {
+        val chapters: List<ChapterInfo> = runCatching {
+            chapterRepo.observeChapters(fictionId).first()
+        }.getOrDefault(emptyList())
+        return chapters.sortedBy { it.index }.take(CHAPTER_LIMIT).map { ch ->
+            playableChapter(category, fictionId, ch.id, ch.title, subtitle = null, coverUrl = null)
+        }
+    }
 
     private fun browsable(id: String, title: String): MediaBrowserCompat.MediaItem {
         val desc = MediaDescriptionCompat.Builder()
@@ -109,57 +168,48 @@ class StoryvoxAutoBrowserService : MediaBrowserServiceCompat() {
         return MediaBrowserCompat.MediaItem(desc, MediaBrowserCompat.MediaItem.FLAG_BROWSABLE)
     }
 
-    companion object {
-        const val ROOT_ID = "/"
-        const val RESUME_ID = "/resume"
-        const val LIBRARY_ID = "/library"
-        const val FOLLOWS_ID = "/follows"
-        const val RECENT_ID = "/recent"
-        const val NEW_ID = "/new"
-        const val MAX_PER_CATEGORY = 6
+    /** A book node — browsable, drills into [bookChapters]. */
+    private fun browsableBook(
+        category: String,
+        fictionId: String,
+        title: String,
+        author: String?,
+        coverUrl: String?,
+    ): MediaBrowserCompat.MediaItem {
+        val desc = MediaDescriptionCompat.Builder()
+            .setMediaId(AutoMediaId.book(category, fictionId))
+            .setTitle(title)
+            .setSubtitle(author)
+            .setIconUri(coverUrl?.let { Uri.parse(it) })
+            .build()
+        return MediaBrowserCompat.MediaItem(desc, MediaBrowserCompat.MediaItem.FLAG_BROWSABLE)
     }
-}
 
-private fun `in`.jphe.storyvox.data.repository.playback.LibraryItem.toBrowsableItem():
-    MediaBrowserCompat.MediaItem {
-    val desc = MediaDescriptionCompat.Builder()
-        .setMediaId("/library/$id")
-        .setTitle(title)
-        .setSubtitle(author)
-        .setIconUri(coverUrl?.let { android.net.Uri.parse(it) })
-        .build()
-    return MediaBrowserCompat.MediaItem(desc, MediaBrowserCompat.MediaItem.FLAG_BROWSABLE)
-}
+    /** A chapter node — playable; tapping routes to playFromMediaId. */
+    private fun playableChapter(
+        category: String,
+        fictionId: String,
+        chapterId: String,
+        title: String,
+        subtitle: String?,
+        coverUrl: String?,
+    ): MediaBrowserCompat.MediaItem {
+        val desc = MediaDescriptionCompat.Builder()
+            .setMediaId(AutoMediaId.chapter(category, fictionId, chapterId))
+            .setTitle(title)
+            .setSubtitle(subtitle)
+            .setIconUri(coverUrl?.let { Uri.parse(it) })
+            .build()
+        return MediaBrowserCompat.MediaItem(desc, MediaBrowserCompat.MediaItem.FLAG_PLAYABLE)
+    }
 
-private fun `in`.jphe.storyvox.data.repository.playback.FollowItem.toBrowsableItem():
-    MediaBrowserCompat.MediaItem {
-    val desc = MediaDescriptionCompat.Builder()
-        .setMediaId("/follows/$id")
-        .setTitle(title)
-        .setSubtitle(author)
-        .setIconUri(coverUrl?.let { android.net.Uri.parse(it) })
-        .build()
-    return MediaBrowserCompat.MediaItem(desc, MediaBrowserCompat.MediaItem.FLAG_BROWSABLE)
-}
+    companion object {
+        /** HMI guideline default bucket size; the live value comes from
+         *  [AutoBrowserConfig.currentItemsPerCategory]. Referenced by the
+         *  Settings copy in AdvancedSettingsScreen. */
+        const val MAX_PER_CATEGORY = 6
 
-private fun `in`.jphe.storyvox.data.repository.playback.RecentItem.toPlayableItem():
-    MediaBrowserCompat.MediaItem {
-    val desc = MediaDescriptionCompat.Builder()
-        .setMediaId("/recent/$fictionId/$chapterId")
-        .setTitle(chapterTitle)
-        .setSubtitle(bookTitle)
-        .setIconUri(coverUrl?.let { android.net.Uri.parse(it) })
-        .build()
-    return MediaBrowserCompat.MediaItem(desc, MediaBrowserCompat.MediaItem.FLAG_PLAYABLE)
-}
-
-private fun `in`.jphe.storyvox.data.repository.playback.UnreadChapter.toPlayableItem():
-    MediaBrowserCompat.MediaItem {
-    val desc = MediaDescriptionCompat.Builder()
-        .setMediaId("/new/$fictionId/$chapterId")
-        .setTitle(chapterTitle)
-        .setSubtitle(bookTitle)
-        .setIconUri(coverUrl?.let { android.net.Uri.parse(it) })
-        .build()
-    return MediaBrowserCompat.MediaItem(desc, MediaBrowserCompat.MediaItem.FLAG_PLAYABLE)
+        /** Max chapters listed under one book before we stop building items. */
+        const val CHAPTER_LIMIT = 200
+    }
 }

--- a/core-playback/src/test/kotlin/in/jphe/storyvox/playback/auto/AutoMediaIdTest.kt
+++ b/core-playback/src/test/kotlin/in/jphe/storyvox/playback/auto/AutoMediaIdTest.kt
@@ -1,0 +1,97 @@
+package `in`.jphe.storyvox.playback.auto
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * Issue #1232 — locks the Android Auto media-id grammar. The browse service
+ * builds these strings and the session callback parses them; a drift here means
+ * "tap a book → nothing plays", so the round-trip is pinned tight.
+ */
+class AutoMediaIdTest {
+
+    @Test
+    fun `root and resume parse to their singletons`() {
+        assertEquals(AutoMediaId.Node.Root, AutoMediaId.parse("/"))
+        assertEquals(AutoMediaId.Node.Resume, AutoMediaId.parse("/resume"))
+    }
+
+    @Test
+    fun `bare categories parse to Category`() {
+        assertEquals(AutoMediaId.Node.Category("/library"), AutoMediaId.parse("/library"))
+        assertEquals(AutoMediaId.Node.Category("/follows"), AutoMediaId.parse("/follows"))
+        assertEquals(AutoMediaId.Node.Category("/recent"), AutoMediaId.parse("/recent"))
+        assertEquals(AutoMediaId.Node.Category("/new"), AutoMediaId.parse("/new"))
+    }
+
+    @Test
+    fun `book id round-trips`() {
+        val id = AutoMediaId.book(AutoMediaId.LIBRARY, "rr-12345")
+        assertEquals("/library/rr-12345", id)
+        assertEquals(
+            AutoMediaId.Node.Book("/library", "rr-12345"),
+            AutoMediaId.parse(id),
+        )
+    }
+
+    @Test
+    fun `chapter id round-trips`() {
+        val id = AutoMediaId.chapter(AutoMediaId.RECENT, "fic1", "chap7")
+        assertEquals("/recent/fic1/chap7", id)
+        assertEquals(
+            AutoMediaId.Node.Chapter("/recent", "fic1", "chap7"),
+            AutoMediaId.parse(id),
+        )
+    }
+
+    @Test
+    fun `ids containing slashes survive the round-trip`() {
+        // Some sources mint composite chapter ids with '/'. Encoding must keep
+        // them in a single segment so parse doesn't mistake them for depth.
+        val fiction = "ao3/works/42"
+        val chapter = "ch/3"
+        val id = AutoMediaId.chapter(AutoMediaId.LIBRARY, fiction, chapter)
+        val node = AutoMediaId.parse(id)
+        assertEquals(
+            AutoMediaId.Node.Chapter("/library", fiction, chapter),
+            node,
+        )
+    }
+
+    @Test
+    fun `ids containing a literal percent-2F survive`() {
+        val fiction = "weird%2Fid"
+        val id = AutoMediaId.book(AutoMediaId.FOLLOWS, fiction)
+        assertEquals(
+            AutoMediaId.Node.Book("/follows", fiction),
+            AutoMediaId.parse(id),
+        )
+    }
+
+    @Test
+    fun `unknown or malformed ids parse to null`() {
+        assertNull(AutoMediaId.parse(""))
+        assertNull(AutoMediaId.parse("/bogus"))
+        assertNull(AutoMediaId.parse("/library/a/b/c")) // too deep
+        assertNull(AutoMediaId.parse("library")) // missing leading slash category
+    }
+
+    @Test
+    fun `root categories are exactly the four Auto tabs`() {
+        assertEquals(
+            listOf("/library", "/follows", "/recent", "/new"),
+            AutoMediaId.ROOT_CATEGORIES,
+        )
+        assertTrue(AutoMediaId.ROOT_CATEGORIES.size <= 4)
+    }
+
+    @Test
+    fun `only library and follows are book categories`() {
+        assertTrue(AutoMediaId.isBookCategory(AutoMediaId.LIBRARY))
+        assertTrue(AutoMediaId.isBookCategory(AutoMediaId.FOLLOWS))
+        assertTrue(!AutoMediaId.isBookCategory(AutoMediaId.RECENT))
+        assertTrue(!AutoMediaId.isBookCategory(AutoMediaId.NEW))
+    }
+}

--- a/core-playback/src/test/kotlin/in/jphe/storyvox/playback/auto/AutoPlaybackResolverTest.kt
+++ b/core-playback/src/test/kotlin/in/jphe/storyvox/playback/auto/AutoPlaybackResolverTest.kt
@@ -1,0 +1,86 @@
+package `in`.jphe.storyvox.playback.auto
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Test
+
+/**
+ * Issue #1232 — covers [AutoPlaybackResolver.bestTitleMatch], the voice-search
+ * ranking that turns "play <title>" into a library fiction id. The repo-backed
+ * `resolve()` paths are thin delegations over Room and are validated on-device
+ * (DHU) per the issue's testing notes; the ranking is the part worth pinning.
+ */
+class AutoPlaybackResolverTest {
+
+    private val library = listOf(
+        "f-pride" to "Pride and Prejudice",
+        "f-prejudice" to "Prejudice Revisited",
+        "f-mistborn" to "Mistborn",
+        "f-wax" to "The Wax and Wayne Saga",
+    )
+
+    @Test
+    fun `exact title wins over prefix and substring`() {
+        // "mistborn" is an exact hit; nothing else contains it.
+        assertEquals("f-mistborn", AutoPlaybackResolver.bestTitleMatch("Mistborn", library))
+    }
+
+    @Test
+    fun `prefix beats substring`() {
+        // "pride" is a prefix of "Pride and Prejudice" (rank 2) and a substring
+        // of "Prejudice Revisited"? no — only the first contains it as prefix.
+        assertEquals("f-pride", AutoPlaybackResolver.bestTitleMatch("pride", library))
+    }
+
+    @Test
+    fun `match is case-insensitive`() {
+        assertEquals("f-mistborn", AutoPlaybackResolver.bestTitleMatch("MISTBORN", library))
+        assertEquals("f-pride", AutoPlaybackResolver.bestTitleMatch("pride AND prejudice", library))
+    }
+
+    @Test
+    fun `substring matches when no prefix does`() {
+        // "wayne" appears mid-title only.
+        assertEquals("f-wax", AutoPlaybackResolver.bestTitleMatch("wayne", library))
+    }
+
+    @Test
+    fun `prefix is preferred even when a substring candidate comes first`() {
+        val candidates = listOf(
+            "f-sub" to "A Prequel to Prejudice", // contains "prejudice" (substring, rank 1)
+            "f-pre" to "Prejudice and Pride",     // starts with "prejudice" (prefix, rank 2)
+        )
+        assertEquals("f-pre", AutoPlaybackResolver.bestTitleMatch("prejudice", candidates))
+    }
+
+    @Test
+    fun `no match returns null`() {
+        assertNull(AutoPlaybackResolver.bestTitleMatch("nonexistent saga", library))
+    }
+
+    @Test
+    fun `blank query returns null`() {
+        assertNull(AutoPlaybackResolver.bestTitleMatch("   ", library))
+        assertNull(AutoPlaybackResolver.bestTitleMatch("", library))
+    }
+
+    @Test
+    fun `first candidate wins on equal rank`() {
+        val candidates = listOf(
+            "f-a" to "Dune",
+            "f-b" to "Dune Messiah", // also contains "dune" but "f-a" is exact
+        )
+        assertEquals("f-a", AutoPlaybackResolver.bestTitleMatch("dune", candidates))
+        // Two equal-rank prefixes → first wins.
+        val twoPrefixes = listOf(
+            "f-1" to "Star Wars",
+            "f-2" to "Star Trek",
+        )
+        assertEquals("f-1", AutoPlaybackResolver.bestTitleMatch("star", twoPrefixes))
+    }
+
+    @Test
+    fun `empty candidate list returns null`() {
+        assertNull(AutoPlaybackResolver.bestTitleMatch("anything", emptyList()))
+    }
+}


### PR DESCRIPTION
## Issue #1232 — Android Auto: make playback actually work from the car

The browse tree (`onGetRoot`/`onLoadChildren`) already shipped under #598/#660, so the original "implement onGetRoot/onLoadChildren" framing was out of date (full audit written into the [issue body](https://github.com/techempower-org/candela/issues/1232)). The real gap was that **playback from Auto never worked**: the legacy `MediaBrowserServiceCompat` had no session token attached, and there was no `play-from-media-id` / `play-from-search` handling.

This is **Option A — complete the hybrid** (lead's call): keep the legacy browser service for browse, drive playback through the existing Media3 `MediaSession`. No risky refactor of the working lock-screen/BT path.

### What this adds
- **Token bridge.** `StoryvoxPlaybackService` publishes the legacy `MediaSessionCompat.Token` (from the Media3 session's `platformToken`) via `MediaSessionLocator.compatToken` (a `StateFlow`). The Auto browser service awaits it and calls `setSessionToken()` — so Auto can finally bind transport controls.
- **Play-from-Auto.** `StoryvoxSessionCallback` now handles `onAddMediaItems` / `onSetMediaItems` / `onPlaybackResumption`. Legacy `playFromMediaId` / `playFromSearch` route here; we resolve the request and start playback via `PlaybackController.play`. (`EnginePlayer` is a `SimpleBasePlayer` with its own playlist — there's no URI to hand Media3 — so we drive it by side effect.)
- **`AutoMediaId`** — one pure place that builds + parses the media-id grammar (`/library`, `/library/<f>`, `/library/<f>/<c>`, `/recent/<f>/<c>`, …) so the browse side and play side can't drift. Segments are percent-encoded so composite ids containing `/` survive.
- **`AutoPlaybackResolver`** — turns a media id or voice query into a concrete `(fiction, chapter, offset)`. Voice search is **library-first** (instant play of already-downloaded books — the right call at highway speed); `/resume` + `onPlaybackResumption` use the most-recent continue-listening entry.
- **Browse tree fixes** — trimmed the root from 5 tabs to **4** (Auto's hard cap), dropped the redundant `/resume` tab (resume now flows through `onPlaybackResumption`), and added the **book→chapter level** so library/follows books open their playable chapters instead of dead-ending. Advertises `SEARCH_SUPPORTED`.

### Tests (JVM, run on CI)
- `AutoMediaIdTest` — build/parse round-trips, ids containing `/` and literal `%2F`, malformed-id rejection, the 4-tab invariant.
- `AutoPlaybackResolverTest` — library voice-search ranking (exact > prefix > substring, case-insensitive, tie-break, blank/no-match).

> [!IMPORTANT]
> **On-device verification needed (DHU).** Android Auto playback can't be unit-tested without a head unit (per the issue's testing notes). Two things to confirm on a real device over the Desktop Head Unit:
> 1. **`session.platformToken`** is the one Media3-version-sensitive call (Media3 1.10.1) — CI's Build APK is the compile gate for it.
> 2. The **resolve → `controller.play` side effect** drives playback; Media3's attempt to apply the returned items to the player is expected to no-op (the player exposes no `COMMAND_SET_MEDIA_ITEM`). Validate tap-a-book / "play \<title\>" / resume end-to-end.
>
> DHU needs a physical USB-connected phone (Waydroid can't drive it). If the side-effect approach proves insufficient on-device, the documented follow-up is migrating to a Media3 `MediaLibraryService`.

No local gradle (per project convention — CI Build APK is the compile gate). All new DI deps (`AutoPlaybackResolver`) resolve from repos already in the graph.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
