### PR TITLE
feat(playback): character-voice foundation — attribution + persistence + resolution (#1283)

### DIFF
--- a/core-data/src/main/kotlin/in/jphe/storyvox/data/db/StoryvoxDatabase.kt
+++ b/core-data/src/main/kotlin/in/jphe/storyvox/data/db/StoryvoxDatabase.kt
@@ -8,6 +8,7 @@ import `in`.jphe.storyvox.data.db.dao.AnnotationDao
 import `in`.jphe.storyvox.data.db.dao.AuthDao
 import `in`.jphe.storyvox.data.db.dao.ChapterDao
 import `in`.jphe.storyvox.data.db.dao.ChapterHistoryDao
+import `in`.jphe.storyvox.data.db.dao.CharacterVoiceDao
 import `in`.jphe.storyvox.data.db.dao.FictionDao
 import `in`.jphe.storyvox.data.db.dao.FictionMemoryDao
 import `in`.jphe.storyvox.data.db.dao.FictionShelfDao
@@ -20,6 +21,7 @@ import `in`.jphe.storyvox.data.db.entity.Annotation
 import `in`.jphe.storyvox.data.db.entity.AuthCookie
 import `in`.jphe.storyvox.data.db.entity.Chapter
 import `in`.jphe.storyvox.data.db.entity.ChapterHistory
+import `in`.jphe.storyvox.data.db.entity.CharacterVoice
 import `in`.jphe.storyvox.data.db.entity.Fiction
 import `in`.jphe.storyvox.data.db.entity.FictionMemoryEntry
 import `in`.jphe.storyvox.data.db.entity.FictionShelf
@@ -57,6 +59,9 @@ import `in`.jphe.storyvox.data.db.entity.PlaybackPosition
         // removed book drops its highlights. Char-offset range into the
         // chapter body (same coordinate as the bookmark + sentence-highlight).
         Annotation::class,
+        // v17 (#1283 per-character voice) — per-(fiction, character) voiceId
+        // map. Additive junction table; FK CASCADE to fiction.
+        CharacterVoice::class,
     ],
     // v11 (#965 per-chapter playback position) — PlaybackPosition PK changes
     // from `fictionId` to composite `(fictionId, chapterId)` so each chapter
@@ -83,7 +88,11 @@ import `in`.jphe.storyvox.data.db.entity.PlaybackPosition
     // v16 (#1231 per-fiction playback speed) — adds `fiction.playbackSpeed`
     // so a book can pin its own speed (auto-restored on load) independent of
     // the global default. Purely additive nullable REAL column.
-    version = 16,
+    //
+    // v17 (#1283 per-character voice) — adds the `character_voice` table
+    // (per-(fiction, character) → voiceId). Purely additive new table with a
+    // CASCADE FK to fiction. See MIGRATION_16_17.
+    version = 17,
     exportSchema = true,
 )
 @TypeConverters(Converters::class)
@@ -99,6 +108,9 @@ abstract class StoryvoxDatabase : RoomDatabase() {
     abstract fun inboxEventDao(): InboxEventDao
     abstract fun fictionMemoryDao(): FictionMemoryDao
     abstract fun annotationDao(): AnnotationDao
+
+    // Issue #1283 — per-character voice assignment map.
+    abstract fun characterVoiceDao(): CharacterVoiceDao
 
     // Issue #1235 — read-only aggregate queries for the listening-stats
     // dashboard. No entity of its own; aggregates chapter_history +

--- a/core-data/src/main/kotlin/in/jphe/storyvox/data/db/dao/CharacterVoiceDao.kt
+++ b/core-data/src/main/kotlin/in/jphe/storyvox/data/db/dao/CharacterVoiceDao.kt
@@ -1,0 +1,36 @@
+package `in`.jphe.storyvox.data.db.dao
+
+import androidx.room.Dao
+import androidx.room.Insert
+import androidx.room.OnConflictStrategy
+import androidx.room.Query
+import `in`.jphe.storyvox.data.db.entity.CharacterVoice
+import kotlinx.coroutines.flow.Flow
+
+/**
+ * Issue #1283 — read/write the per-fiction character→voice map.
+ *
+ * Consumed by the (forthcoming) Cast-assignment UI and the playback layer's
+ * per-segment voice resolution. `REPLACE` on insert makes re-assigning a
+ * character idempotent (one row per `(fictionId, characterName)`).
+ */
+@Dao
+interface CharacterVoiceDao {
+
+    /** Live map for one fiction — drives the Cast sheet + playback. */
+    @Query("SELECT * FROM character_voice WHERE fictionId = :fictionId")
+    fun observeForFiction(fictionId: String): Flow<List<CharacterVoice>>
+
+    /** Synchronous snapshot for the playback load path. */
+    @Query("SELECT * FROM character_voice WHERE fictionId = :fictionId")
+    suspend fun forFiction(fictionId: String): List<CharacterVoice>
+
+    @Insert(onConflict = OnConflictStrategy.REPLACE)
+    suspend fun upsert(entry: CharacterVoice)
+
+    @Query("DELETE FROM character_voice WHERE fictionId = :fictionId AND characterName = :characterName")
+    suspend fun delete(fictionId: String, characterName: String)
+
+    @Query("DELETE FROM character_voice WHERE fictionId = :fictionId")
+    suspend fun clearForFiction(fictionId: String)
+}

--- a/core-data/src/main/kotlin/in/jphe/storyvox/data/db/entity/CharacterVoice.kt
+++ b/core-data/src/main/kotlin/in/jphe/storyvox/data/db/entity/CharacterVoice.kt
@@ -1,0 +1,38 @@
+package `in`.jphe.storyvox.data.db.entity
+
+import androidx.room.Entity
+import androidx.room.ForeignKey
+
+/**
+ * Issue #1283 — per-character voice assignment. One row = one character in
+ * one fiction is narrated by one voice. A fiction with three assigned
+ * characters has three rows, keyed by `(fictionId, characterName)`.
+ *
+ * `voiceId` is a [in.jphe.storyvox] VoiceCatalog id (e.g.
+ * `kokoro_alice_en_GB_20`, `azure_en_US_AvaDragonHDLatestNeural`). The
+ * resolution order at playback time is **character voice → the fiction's
+ * narrator default (`Fiction.pinnedVoiceId`) → the global active voice**
+ * (see `CharacterVoiceResolver`).
+ *
+ * `ON DELETE CASCADE` on the fiction FK drops a book's character mappings
+ * when the book is purged — mirrors [FictionShelf]. The composite PK is
+ * `fictionId`-first, so it doubles as the index the FK needs for cascade
+ * deletes (no separate `@Index` required).
+ */
+@Entity(
+    tableName = "character_voice",
+    primaryKeys = ["fictionId", "characterName"],
+    foreignKeys = [
+        ForeignKey(
+            entity = Fiction::class,
+            parentColumns = ["id"],
+            childColumns = ["fictionId"],
+            onDelete = ForeignKey.CASCADE,
+        ),
+    ],
+)
+data class CharacterVoice(
+    val fictionId: String,
+    val characterName: String,
+    val voiceId: String,
+)

--- a/core-data/src/main/kotlin/in/jphe/storyvox/data/db/migration/Migrations.kt
+++ b/core-data/src/main/kotlin/in/jphe/storyvox/data/db/migration/Migrations.kt
@@ -494,6 +494,30 @@ val MIGRATION_15_16: Migration = object : Migration(15, 16) {
     }
 }
 
+/**
+ * v17 — issue #1283: per-character voice assignment. Adds the
+ * `character_voice` junction table (one row per `(fictionId, characterName)`
+ * → `voiceId`). Purely additive new table; no existing table or row is
+ * touched. FK CASCADE to `fiction` so purging a book drops its mappings.
+ *
+ * DDL must match Room's generated schema for [CharacterVoice] exactly
+ * (column order, the composite PRIMARY KEY, and the FK clause) or Room's
+ * startup identity-hash check rejects the migration.
+ */
+val MIGRATION_16_17: Migration = object : Migration(16, 17) {
+    override fun migrate(db: SupportSQLiteDatabase) {
+        db.execSQL(
+            "CREATE TABLE IF NOT EXISTS `character_voice` (" +
+                "`fictionId` TEXT NOT NULL, " +
+                "`characterName` TEXT NOT NULL, " +
+                "`voiceId` TEXT NOT NULL, " +
+                "PRIMARY KEY(`fictionId`, `characterName`), " +
+                "FOREIGN KEY(`fictionId`) REFERENCES `fiction`(`id`) " +
+                "ON UPDATE NO ACTION ON DELETE CASCADE )",
+        )
+    }
+}
+
 val ALL_MIGRATIONS: Array<Migration> = arrayOf(
     MIGRATION_1_2,
     MIGRATION_2_3,
@@ -510,4 +534,5 @@ val ALL_MIGRATIONS: Array<Migration> = arrayOf(
     MIGRATION_13_14,
     MIGRATION_14_15,
     MIGRATION_15_16,
+    MIGRATION_16_17,
 )

--- a/core-data/src/main/kotlin/in/jphe/storyvox/data/di/DataModule.kt
+++ b/core-data/src/main/kotlin/in/jphe/storyvox/data/di/DataModule.kt
@@ -21,6 +21,7 @@ import `in`.jphe.storyvox.data.db.dao.AnnotationDao
 import `in`.jphe.storyvox.data.db.dao.AuthDao
 import `in`.jphe.storyvox.data.db.dao.ChapterDao
 import `in`.jphe.storyvox.data.db.dao.ChapterHistoryDao
+import `in`.jphe.storyvox.data.db.dao.CharacterVoiceDao
 import `in`.jphe.storyvox.data.db.dao.FictionDao
 import `in`.jphe.storyvox.data.db.dao.FictionMemoryDao
 import `in`.jphe.storyvox.data.db.dao.FictionShelfDao
@@ -128,6 +129,8 @@ object DataModule {
     // Issue #999 — highlights + notes. Consumed by AnnotationsSyncer,
     // ExportAnnotationsUseCase, and AnnotationRepository.
     @Provides fun annotationDao(db: StoryvoxDatabase): AnnotationDao = db.annotationDao()
+    // Issue #1283 — per-character voice assignment map.
+    @Provides fun characterVoiceDao(db: StoryvoxDatabase): CharacterVoiceDao = db.characterVoiceDao()
     // Issue #1235 — read-only aggregate DAO for the listening-stats dashboard.
     @Provides fun listeningStatsDao(db: StoryvoxDatabase): ListeningStatsDao = db.listeningStatsDao()
 

--- a/core-playback/src/main/kotlin/in/jphe/storyvox/playback/tts/DialogueAttributor.kt
+++ b/core-playback/src/main/kotlin/in/jphe/storyvox/playback/tts/DialogueAttributor.kt
@@ -1,0 +1,109 @@
+package `in`.jphe.storyvox.playback.tts
+
+import javax.inject.Inject
+import javax.inject.Singleton
+
+/**
+ * Issue #1283 — one attributed run of dialogue. [characterName] speaks the
+ * quoted text at `text.substring(startOffset, endOffset)` (offsets bracket
+ * the quotation marks). Offsets index the original chapter text so they
+ * line up with [Sentence] `(startChar, endChar)` ranges.
+ */
+data class DialogueSegment(
+    val characterName: String,
+    val startOffset: Int,
+    val endOffset: Int,
+)
+
+/**
+ * Heuristic dialogue attribution (#1283 MVP, Phase 1). Pairs double-quote
+ * spans (straight `"..."` and curly `“...”`) and attributes each to a
+ * speaker by matching a dialogue tag — `said Alice` / `Alice said` —
+ * immediately after the quote (preferred) or before it. Pure,
+ * dependency-free, on-device: no network, no NLP model, no Android types.
+ *
+ * Deliberately conservative — when no clear proper-noun name sits next to a
+ * quote, the span is left **unattributed** (omitted from the result) so the
+ * caller falls back to the narrator voice rather than guessing. Single
+ * quotes are NOT treated as span delimiters, so a nested `‘…’` stays inside
+ * its outer span. Pronoun/coreference resolution ("he said") and
+ * LLM-assisted attribution are explicit Phase-2 scope on #1283 — see the
+ * research comment on the issue.
+ */
+@Singleton
+class DialogueAttributor @Inject constructor() {
+
+    /** Speaker spans in document order, non-overlapping (one per quote). */
+    fun attribute(text: String): List<DialogueSegment> {
+        if (text.isEmpty()) return emptyList()
+        val out = mutableListOf<DialogueSegment>()
+        for ((start, end) in quoteSpans(text)) {
+            // After the quote wins ("…," said Alice); fall back to before
+            // the quote (Bob said, "…").
+            val name = speakerAfter(text, end) ?: speakerBefore(text, start)
+            if (name != null) out += DialogueSegment(name, start, end)
+        }
+        return out
+    }
+
+    /** `(startInclusive, endExclusive)` of each double-quoted span, both
+     *  styles, sorted by start. Inner single quotes are not delimiters. */
+    private fun quoteSpans(text: String): List<Pair<Int, Int>> {
+        val spans = mutableListOf<Pair<Int, Int>>()
+        CURLY.findAll(text).forEach { spans += it.range.first to (it.range.last + 1) }
+        STRAIGHT.findAll(text).forEach { spans += it.range.first to (it.range.last + 1) }
+        return spans.sortedBy { it.first }
+    }
+
+    /** Name from a dialogue tag right after the quote: `said Alice` or
+     *  `Alice replied`. */
+    private fun speakerAfter(text: String, spanEnd: Int): String? {
+        if (spanEnd >= text.length) return null
+        val window = text.substring(spanEnd, minOf(text.length, spanEnd + WINDOW))
+            .substringBefore('\n')
+        val verbFirst = AFTER_VERB_NAME.find(window)?.groupValues?.get(1)
+        val nameFirst = AFTER_NAME_VERB.find(window)?.groupValues?.get(1)
+        return (verbFirst ?: nameFirst)?.takeUnless { it in STOPWORDS }
+    }
+
+    /** Name from a dialogue tag right before the quote: `Bob said, "…"`. */
+    private fun speakerBefore(text: String, spanStart: Int): String? {
+        if (spanStart <= 0) return null
+        val window = text.substring(maxOf(0, spanStart - WINDOW), spanStart)
+            .substringAfterLast('\n')
+        return BEFORE_NAME_VERB.find(window)?.groupValues?.get(1)?.takeUnless { it in STOPWORDS }
+    }
+
+    private companion object {
+        /** Chars to scan either side of a quote for a dialogue tag. */
+        const val WINDOW = 48
+
+        /** Speech verbs that mark a dialogue tag. */
+        private const val VERBS =
+            "said|asked|replied|answered|shouted|whispered|murmured|muttered|" +
+                "cried|exclaimed|added|continued|began|called|demanded|repeated|" +
+                "wondered|breathed|growled|snapped|sighed|yelled|hissed|gasped|roared"
+
+        /** A capitalized proper-noun-ish token (name capture is group 1). */
+        private const val NAME = "([A-Z][\\p{L}]+)"
+
+        /** Pronouns / articles / sentence-openers that look like names but
+         *  aren't — reject so we don't attribute to "He" or "The". */
+        val STOPWORDS = setOf(
+            "He", "She", "They", "It", "We", "You", "I", "His", "Her", "Their",
+            "The", "A", "An", "And", "But", "Then", "There", "That", "This",
+            "What", "Who", "Why", "How", "When", "Where", "So", "Yet", "Still",
+        )
+
+        // Anchored at the window start (just past the quote): optional
+        // leading whitespace/comma/dash, then either verb→name or name→verb.
+        val AFTER_VERB_NAME = Regex("^[\\s,“\"”—-]*\\b(?:$VERBS)\\b\\s+$NAME")
+        val AFTER_NAME_VERB = Regex("^[\\s,“\"”—-]*$NAME\\s+\\b(?:$VERBS)\\b")
+        // Anchored at the window end (just before the quote): name→verb then
+        // optional trailing comma/colon/dash/space.
+        val BEFORE_NAME_VERB = Regex("$NAME\\s+\\b(?:$VERBS)\\b[\\s,:—-]*$")
+
+        val CURLY = Regex("“[^“”]*”")
+        val STRAIGHT = Regex("\"[^\"]*\"")
+    }
+}

--- a/core-playback/src/main/kotlin/in/jphe/storyvox/playback/voice/CharacterVoiceResolver.kt
+++ b/core-playback/src/main/kotlin/in/jphe/storyvox/playback/voice/CharacterVoiceResolver.kt
@@ -1,0 +1,24 @@
+package `in`.jphe.storyvox.playback.voice
+
+/**
+ * Issue #1283 — pure resolution of which voice narrates a given line.
+ *
+ * Resolution order:
+ *   1. the speaker's explicitly-assigned **character voice**, if any;
+ *   2. the fiction's **narrator default** (`Fiction.pinnedVoiceId`), if set;
+ *   3. the **global active voice** (always present — it's the engine's
+ *      current voice).
+ *
+ * [speaker] is null for narration (un-attributed text), which resolves to
+ * the narrator default / global voice. Stateless + dependency-free so it
+ * unit-tests without the DB or the engine.
+ */
+object CharacterVoiceResolver {
+    fun resolve(
+        speaker: String?,
+        characterVoices: Map<String, String>,
+        narratorVoiceId: String?,
+        globalVoiceId: String,
+    ): String =
+        speaker?.let { characterVoices[it] } ?: narratorVoiceId ?: globalVoiceId
+}

--- a/core-playback/src/test/kotlin/in/jphe/storyvox/playback/tts/DialogueAttributorTest.kt
+++ b/core-playback/src/test/kotlin/in/jphe/storyvox/playback/tts/DialogueAttributorTest.kt
@@ -1,0 +1,113 @@
+package `in`.jphe.storyvox.playback.tts
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * Issue #1283 — heuristic dialogue attribution. Pure logic (no Android),
+ * so it runs as a plain JUnit test. Assertions check the attributed
+ * speaker name and that the segment offsets bracket the intended quoted
+ * span (via `text.substring(start, end)`), rather than hardcoding brittle
+ * absolute offsets.
+ */
+class DialogueAttributorTest {
+
+    private val attr = DialogueAttributor()
+
+    private fun span(text: String, seg: DialogueSegment): String =
+        text.substring(seg.startOffset, seg.endOffset)
+
+    // ── trailing attribution: "...," said Alice. ─────────────────────────
+
+    @Test
+    fun trailingSaidAttribution_namesSpeaker() {
+        val text = "“Hello there,” said Alice."
+        val segs = attr.attribute(text)
+        assertEquals(1, segs.size)
+        assertEquals("Alice", segs[0].characterName)
+        assertTrue(span(text, segs[0]).contains("Hello there"))
+    }
+
+    @Test
+    fun trailingAttribution_straightQuotes() {
+        val text = "\"Get down!\" shouted Bob."
+        val segs = attr.attribute(text)
+        assertEquals(1, segs.size)
+        assertEquals("Bob", segs[0].characterName)
+    }
+
+    // ── leading attribution: Bob said, "..." ─────────────────────────────
+
+    @Test
+    fun leadingSaidAttribution_namesSpeaker() {
+        val text = "Bob said, “Goodbye.”"
+        val segs = attr.attribute(text)
+        assertEquals(1, segs.size)
+        assertEquals("Bob", segs[0].characterName)
+        assertTrue(span(text, segs[0]).contains("Goodbye"))
+    }
+
+    // ── multiple speakers in one passage ─────────────────────────────────
+
+    @Test
+    fun twoSpeakers_attributedIndependently() {
+        val text = "“Where were you?” asked Alice. “Out,” Bob replied."
+        val segs = attr.attribute(text)
+        assertEquals(2, segs.size)
+        assertEquals("Alice", segs[0].characterName)
+        assertEquals("Bob", segs[1].characterName)
+        // Segments are returned in document order.
+        assertTrue(segs[0].startOffset < segs[1].startOffset)
+    }
+
+    // ── nested / inner quotes must not split the outer span ──────────────
+
+    @Test
+    fun innerSingleQuotes_doNotSplitOuterSpan() {
+        val text = "“He told me ‘run’ and I ran,” Alice said."
+        val segs = attr.attribute(text)
+        assertEquals(1, segs.size)
+        assertEquals("Alice", segs[0].characterName)
+        // The whole outer quote (including the inner 'run') is one segment.
+        assertTrue(span(text, segs[0]).contains("run"))
+        assertTrue(span(text, segs[0]).contains("I ran"))
+    }
+
+    // ── narration-only passages yield nothing ────────────────────────────
+
+    @Test
+    fun narrationOnly_returnsEmpty() {
+        val text = "The rain fell on the empty street. Nobody spoke."
+        assertEquals(emptyList<DialogueSegment>(), attr.attribute(text))
+    }
+
+    @Test
+    fun unattributedQuote_isNotEmitted() {
+        // No name anywhere near the quote → we don't guess; narrator handles it.
+        val text = "“Who's there?”"
+        assertEquals(emptyList<DialogueSegment>(), attr.attribute(text))
+    }
+
+    @Test
+    fun emptyText_returnsEmpty() {
+        assertEquals(emptyList<DialogueSegment>(), attr.attribute(""))
+    }
+
+    // ── offsets are valid + non-overlapping + in range ───────────────────
+
+    @Test
+    fun segmentsAreInRangeAndOrdered() {
+        val text = "“One,” said Alice. “Two,” said Bob. “Three,” said Cara."
+        val segs = attr.attribute(text)
+        assertEquals(3, segs.size)
+        var prevEnd = 0
+        for (s in segs) {
+            assertTrue("start in range", s.startOffset in 0..text.length)
+            assertTrue("end in range", s.endOffset in 0..text.length)
+            assertTrue("start < end", s.startOffset < s.endOffset)
+            assertTrue("ordered + non-overlapping", s.startOffset >= prevEnd)
+            prevEnd = s.endOffset
+        }
+    }
+}

--- a/core-playback/src/test/kotlin/in/jphe/storyvox/playback/voice/CharacterVoiceResolverTest.kt
+++ b/core-playback/src/test/kotlin/in/jphe/storyvox/playback/voice/CharacterVoiceResolverTest.kt
@@ -1,0 +1,56 @@
+package `in`.jphe.storyvox.playback.voice
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+/**
+ * Issue #1283 — the character → narrator → global resolution order.
+ */
+class CharacterVoiceResolverTest {
+
+    private val map = mapOf("Alice" to "kokoro_alice", "Bob" to "kokoro_bob")
+
+    @Test
+    fun assignedCharacter_winsOverNarratorAndGlobal() {
+        assertEquals(
+            "kokoro_alice",
+            CharacterVoiceResolver.resolve("Alice", map, narratorVoiceId = "narrator_v", globalVoiceId = "global_v"),
+        )
+    }
+
+    @Test
+    fun unassignedSpeaker_fallsBackToNarrator() {
+        assertEquals(
+            "narrator_v",
+            CharacterVoiceResolver.resolve("Stranger", map, narratorVoiceId = "narrator_v", globalVoiceId = "global_v"),
+        )
+    }
+
+    @Test
+    fun narration_nullSpeaker_usesNarrator() {
+        assertEquals(
+            "narrator_v",
+            CharacterVoiceResolver.resolve(null, map, narratorVoiceId = "narrator_v", globalVoiceId = "global_v"),
+        )
+    }
+
+    @Test
+    fun noNarrator_fallsBackToGlobal() {
+        assertEquals(
+            "global_v",
+            CharacterVoiceResolver.resolve("Stranger", map, narratorVoiceId = null, globalVoiceId = "global_v"),
+        )
+        assertEquals(
+            "global_v",
+            CharacterVoiceResolver.resolve(null, emptyMap(), narratorVoiceId = null, globalVoiceId = "global_v"),
+        )
+    }
+
+    @Test
+    fun assignedCharacter_winsEvenWhenNarratorNull() {
+        assertEquals(
+            "kokoro_bob",
+            CharacterVoiceResolver.resolve("Bob", map, narratorVoiceId = null, globalVoiceId = "global_v"),
+        )
+    }
+}


### PR DESCRIPTION
## What & why — #1283 per-character voice, Phase 1a (foundation)

Builds the tested, low-risk **substrate** for per-character voice assignment: dialogue attribution, the persistence model, and the voice-resolution hierarchy. The two pieces that mutate the **`EnginePlayer` playback hot path** are deliberately split into a focused follow-up (rationale below).

## In this PR

**1. `DialogueAttributor`** (`core-playback`, pure) + tests
- Heuristic attribution: pairs double-quote spans (single quotes are **not** delimiters, so a nested `‘…’` stays inside its outer span) and matches a `said Alice` / `Alice said` dialogue tag after (preferred) or before the quote.
- Pronoun/article **stoplist** so it won't attribute to "He"/"The". Unattributed quotes are **left to the narrator** (omitted) rather than guessed.
- Output: `DialogueSegment(characterName, startOffset, endOffset)`, offsets aligned to chapter text.
- Tests: trailing/leading tags, two speakers, nested quotes, narration-only, unattributed, ordering/bounds.

**2. `CharacterVoice` persistence** (`core-data`)
- Room entity `character_voice` — composite PK `(fictionId, characterName)` → `voiceId`, CASCADE FK to `fiction` (mirrors `FictionShelf`). `CharacterVoiceDao` (observe/snapshot/upsert/delete/clear). Migration **v16→v17** (purely additive table; DDL matches Room's generated schema) + `@Provides` in `DataModule`.

**3. `CharacterVoiceResolver`** (`core-playback`, pure) + tests
- The resolution order: **character voice → `Fiction.pinnedVoiceId` (narrator default) → global active voice**. Pure; unit-tested across all fallbacks.

## Deferred to Phase 1b (the engine-wiring follow-up)

Both remaining MVP items mutate the **5500-line `EnginePlayer` playback hot path**, which I can't compile or run locally (CI is the compile gate; there's no behavioral test harness for the engine). Bundling un-verifiable hot-path surgery into this foundation would put the core listening experience at risk. The precise seam is mapped so the follow-up is a tight change:

- **Per-segment voice switch** — thread `voiceId` onto `Sentence`, build a segment→voice map in `loadAndPlay` (attributor → resolver), switch per segment in `EngineStreamingSource`'s producer for the near-free engines (Kokoro/Kitten/Supertonic `setActiveSpeakerId`; Azure per-call `voiceName`). Needs the `PcmCacheKey` handled (single-voice today). **Also un-exercisable until the Cast-assignment UI exists** (nothing populates `character_voice` yet), so it belongs with that UI where it can be tested.
- **`pinnedVoiceId` as narrator default** — wire it into `loadAndPlay` (replaces the global-only `voiceManager.activeVoice` at `EnginePlayer.kt:1863`). Needs (a) a roster-aware `voiceById(id): UiVoiceInfo?` on `VoiceManager`, and (b) reading the fiction's pin — a new dependency on the `@AssistedInject EnginePlayer` (touches its factory). Safe-by-default (no pin → identical behavior), but shouldn't ship blind.

## Test / verification
`DialogueAttributorTest` + `CharacterVoiceResolverTest` (pure JUnit, no Robolectric). Not compiled locally — CI is the gate. The migration DDL is written to match Room's generated v17 schema; CI's Room schema validation / migration test is the check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
