### PR TITLE
feat(sources): LibriVox↔Gutenberg audio/text companion matcher (#1208)

### DIFF
--- a/app/src/main/kotlin/in/jphe/storyvox/navigation/StoryvoxNavHost.kt
+++ b/app/src/main/kotlin/in/jphe/storyvox/navigation/StoryvoxNavHost.kt
@@ -867,6 +867,8 @@ private fun StoryvoxNavHostContent(
                     // #211 — Follow on Royal Road button routes to the
                     // shared sign-in WebView when the user is anonymous.
                     onOpenRoyalRoadSignIn = { navController.navigate(StoryvoxRoutes.authWebView(SourceIds.ROYAL_ROAD)) },
+                    // #1208 — open the audio↔text companion's fiction detail.
+                    onOpenCompanion = { id -> navController.navigate(StoryvoxRoutes.fictionDetail(id)) },
                 )
             }
 

--- a/core-data/src/main/kotlin/in/jphe/storyvox/data/source/companion/CompanionResolver.kt
+++ b/core-data/src/main/kotlin/in/jphe/storyvox/data/source/companion/CompanionResolver.kt
@@ -1,0 +1,108 @@
+package `in`.jphe.storyvox.data.source.companion
+
+import `in`.jphe.storyvox.data.source.FictionSource
+import `in`.jphe.storyvox.data.source.SourceIds
+import `in`.jphe.storyvox.data.source.model.FictionResult
+import `in`.jphe.storyvox.data.source.model.FictionSummary
+import `in`.jphe.storyvox.data.source.model.SearchQuery
+import javax.inject.Inject
+import javax.inject.Singleton
+
+/**
+ * Issue #1208 — the audio↔text counterpart for a fiction the user is
+ * viewing: a LibriVox audiobook's Project Gutenberg text, or a Gutenberg
+ * text's LibriVox narration. Null [fictionId] never happens — a match
+ * always carries the companion's real `FictionSource` id so the UI can
+ * deep-link to its detail.
+ */
+data class CompanionMatch(
+    /** The companion's source id (`gutenberg` or `librivox`). */
+    val sourceId: String,
+    /** The companion's `FictionSource` fiction id, for navigation. */
+    val fictionId: String,
+    /** Display title (the companion's, or the originating work's when known). */
+    val title: String,
+    /** Whether the companion is the AUDIO or the TEXT side. */
+    val kind: Kind,
+) {
+    enum class Kind { AUDIO, TEXT }
+}
+
+/**
+ * Issue #1208 — pairs open audiobooks with their open text counterparts
+ * (LibriVox ↔ Gutenberg) so the UI can offer a "read along / listen along"
+ * companion.
+ *
+ * Lives in `:core-data` and works purely over the **public** source models
+ * + the injected `FictionSource` map (the same multibinding `FictionRepository`
+ * uses), so it never reaches into a leaf source's internals — honouring the
+ * leaf-source isolation rule (sources depend on core-data, not each other).
+ *
+ * The join key is [FictionSummary.companionSourceUrl]: LibriVox publishes its
+ * recording's `url_text_source` (the Gutenberg page it was read from). That
+ * makes the forward direction a pure parse, and the reverse direction a
+ * title search **verified** by an exact ebook-id back-link — no fuzzy
+ * false positives, and no LibriVox↔Gutenberg id table to maintain.
+ */
+@Singleton
+class CompanionResolver @Inject constructor(
+    private val sources: Map<String, @JvmSuppressWildcards FictionSource>,
+) {
+
+    /**
+     * The audio↔text companion for [fiction], or null when there's no
+     * high-confidence match or the companion's source is disabled. Safe to
+     * call for any fiction — non-LibriVox/Gutenberg sources return null.
+     */
+    suspend fun companionFor(fiction: FictionSummary): CompanionMatch? = when (fiction.sourceId) {
+        SourceIds.LIBRIVOX -> textCompanionOf(fiction)
+        GutenbergRef.SOURCE_ID -> audioCompanionOf(fiction)
+        else -> null
+    }
+
+    /**
+     * LibriVox audiobook → its Project Gutenberg text. The recording's
+     * published [FictionSummary.companionSourceUrl] back-link parses straight
+     * to the ebook id; we only surface it when the Gutenberg source is
+     * actually enabled (otherwise the deep-link would dead-end).
+     */
+    private fun textCompanionOf(audio: FictionSummary): CompanionMatch? {
+        val ebookId = GutenbergRef.parseEbookIdFromUrl(audio.companionSourceUrl) ?: return null
+        if (sources[GutenbergRef.SOURCE_ID] == null) return null
+        return CompanionMatch(
+            sourceId = GutenbergRef.SOURCE_ID,
+            fictionId = GutenbergRef.fictionIdFor(ebookId),
+            title = audio.title,
+            kind = CompanionMatch.Kind.TEXT,
+        )
+    }
+
+    /**
+     * Project Gutenberg text → its LibriVox narration. LibriVox exposes no
+     * by-ebook-id lookup, so we search by title and then **verify** each
+     * candidate's published back-link resolves to the SAME ebook id — turning
+     * a fuzzy substring search into an exact match. A book with no LibriVox
+     * recording (or whose recording back-links elsewhere) yields null rather
+     * than a wrong guess.
+     */
+    private suspend fun audioCompanionOf(text: FictionSummary): CompanionMatch? {
+        val targetEbookId = GutenbergRef.ebookIdFromFictionId(text.id) ?: return null
+        val librivox = sources[SourceIds.LIBRIVOX] ?: return null
+        if (text.title.isBlank()) return null
+
+        val candidates = when (val result = librivox.search(SearchQuery(term = text.title))) {
+            is FictionResult.Success -> result.value.items
+            else -> return null
+        }
+        val match = candidates.firstOrNull {
+            GutenbergRef.parseEbookIdFromUrl(it.companionSourceUrl) == targetEbookId
+        } ?: return null
+
+        return CompanionMatch(
+            sourceId = SourceIds.LIBRIVOX,
+            fictionId = match.id,
+            title = match.title,
+            kind = CompanionMatch.Kind.AUDIO,
+        )
+    }
+}

--- a/core-data/src/main/kotlin/in/jphe/storyvox/data/source/companion/GutenbergRef.kt
+++ b/core-data/src/main/kotlin/in/jphe/storyvox/data/source/companion/GutenbergRef.kt
@@ -1,0 +1,54 @@
+package `in`.jphe.storyvox.data.source.companion
+
+import `in`.jphe.storyvox.data.source.SourceIds
+
+/**
+ * Issue #1208 — shared Project Gutenberg id helpers for the cross-source
+ * audio↔text companion matcher.
+ *
+ * The matcher ([CompanionResolver]) runs in `:core-data` and may only touch
+ * the *public* source models — it can't reach the `internal`
+ * `GutenbergTextApi.parseGutenbergId` inside `:source-librivox` (leaf-source
+ * isolation: sources depend on core-data, not the reverse). So the
+ * URL→ebook-id parse lives here, where both the matcher and (eventually, via
+ * a follow-up dedupe) the LibriVox source can share it.
+ *
+ * The numeric "ebook id" (e.g. `1342`) is Gutenberg's catalog id; the
+ * `FictionSource` id for the same work is `gutenberg:1342`
+ * ([fictionIdFor] / [ebookIdFromFictionId]).
+ */
+object GutenbergRef {
+
+    /** The Gutenberg [FictionSource][in.jphe.storyvox.data.source.FictionSource] id. */
+    const val SOURCE_ID: String = SourceIds.GUTENBERG
+
+    /**
+     * Pull the numeric ebook id out of a gutenberg.org URL (LibriVox's
+     * `url_text_source` back-link), or null when the URL isn't a Gutenberg
+     * book. Mirrors the URL shapes the LibriVox `GutenbergTextApi` handles:
+     * `/ebooks/<id>`, `/etext/<id>`, `/files/<id>/…`, `/cache/epub/<id>/…`.
+     */
+    fun parseEbookIdFromUrl(url: String?): String? {
+        val trimmed = url?.trim().orEmpty()
+        if (trimmed.isEmpty()) return null
+        return EBOOK_URL_PATTERN.find(trimmed)?.groupValues?.getOrNull(1)
+    }
+
+    /**
+     * The numeric ebook id encoded in a `gutenberg:<id>` FictionSource id,
+     * or null if [fictionId] isn't a Gutenberg id. Mirrors GutenbergSource's
+     * own `substringAfter("gutenberg:")` convention.
+     */
+    fun ebookIdFromFictionId(fictionId: String): String? =
+        fictionId.substringAfter("gutenberg:", missingDelimiterValue = "")
+            .takeIf { it.isNotEmpty() }
+
+    /** The `gutenberg:<id>` FictionSource id for a numeric [ebookId]. */
+    fun fictionIdFor(ebookId: String): String = "gutenberg:$ebookId"
+
+    private val EBOOK_URL_PATTERN: Regex = Regex(
+        """^https?://(?:www\.)?gutenberg\.org/""" +
+            """(?:ebooks|etext|files|cache/epub)/(\d+)(?:[/?#.].*)?$""",
+        RegexOption.IGNORE_CASE,
+    )
+}

--- a/core-data/src/main/kotlin/in/jphe/storyvox/data/source/model/FictionSummary.kt
+++ b/core-data/src/main/kotlin/in/jphe/storyvox/data/source/model/FictionSummary.kt
@@ -58,4 +58,15 @@ data class FictionSummary(
      * cool-down. Only meaningful when [isPlaceholder] is also true.
      */
     val backfillFailed: Boolean = false,
+    /**
+     * Issue #1208 — back-link to the public-domain *text* this fiction was
+     * sourced from, when the backend knows it. LibriVox populates it with the
+     * recording's `url_text_source` (usually a `gutenberg.org/ebooks/<id>`
+     * page); other backends leave it null. The cross-source companion matcher
+     * ([CompanionResolver][in.jphe.storyvox.data.source.companion.CompanionResolver])
+     * reads this to pair an audiobook with its text counterpart (and to
+     * verify a reverse title/author match by exact ebook id) — all via the
+     * public model, without reaching into a leaf source's internals.
+     */
+    val companionSourceUrl: String? = null,
 )

--- a/core-data/src/test/kotlin/in/jphe/storyvox/data/source/companion/CompanionResolverTest.kt
+++ b/core-data/src/test/kotlin/in/jphe/storyvox/data/source/companion/CompanionResolverTest.kt
@@ -1,0 +1,132 @@
+package `in`.jphe.storyvox.data.source.companion
+
+import `in`.jphe.storyvox.data.source.FictionSource
+import `in`.jphe.storyvox.data.source.SourceIds
+import `in`.jphe.storyvox.data.source.model.FictionResult
+import `in`.jphe.storyvox.data.source.model.FictionSummary
+import `in`.jphe.storyvox.data.source.model.ListPage
+import `in`.jphe.storyvox.data.source.model.SearchQuery
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertNotNull
+import org.junit.Test
+
+/**
+ * Issue #1208 — the cross-source audio↔text matcher. Exercised with a fake
+ * [FictionSource] (the documented `:core-data` test pattern); only `id` +
+ * `search` carry behaviour, the rest are inert stubs.
+ */
+class CompanionResolverTest {
+
+    private class FakeSource(
+        override val id: String,
+        private val searchResults: List<FictionSummary> = emptyList(),
+    ) : FictionSource {
+        var lastSearchTerm: String? = null
+
+        override suspend fun search(query: SearchQuery): FictionResult<ListPage<FictionSummary>> {
+            lastSearchTerm = query.term
+            return FictionResult.Success(ListPage(searchResults, page = 1, hasNext = false))
+        }
+
+        // Inert stubs — the matcher only calls search().
+        override suspend fun popular(page: Int): FictionResult<ListPage<FictionSummary>> =
+            FictionResult.Success(ListPage(emptyList(), page, hasNext = false))
+        override suspend fun latestUpdates(page: Int): FictionResult<ListPage<FictionSummary>> =
+            FictionResult.Success(ListPage(emptyList(), page, hasNext = false))
+        override suspend fun byGenre(genre: String, page: Int): FictionResult<ListPage<FictionSummary>> =
+            FictionResult.Success(ListPage(emptyList(), page, hasNext = false))
+        override suspend fun followsList(page: Int): FictionResult<ListPage<FictionSummary>> =
+            FictionResult.Success(ListPage(emptyList(), page, hasNext = false))
+        override suspend fun fictionDetail(fictionId: String) = FictionResult.NotFound("fake")
+        override suspend fun chapter(fictionId: String, chapterId: String) = FictionResult.NotFound("fake")
+        override suspend fun setFollowed(fictionId: String, followed: Boolean) = FictionResult.Success(Unit)
+        override suspend fun genres() = FictionResult.Success(emptyList<String>())
+    }
+
+    private fun summary(
+        id: String,
+        sourceId: String,
+        title: String = "Pride and Prejudice",
+        companionSourceUrl: String? = null,
+    ) = FictionSummary(
+        id = id,
+        sourceId = sourceId,
+        title = title,
+        author = "Jane Austen",
+        companionSourceUrl = companionSourceUrl,
+    )
+
+    private fun resolver(vararg sources: FictionSource) =
+        CompanionResolver(sources.associateBy { it.id })
+
+    // ── forward: LibriVox audiobook → Gutenberg text ───────────────────
+
+    @Test
+    fun `librivox audiobook resolves to its gutenberg text via the back-link`() = runTest {
+        val match = resolver(FakeSource(SourceIds.LIBRIVOX), FakeSource(SourceIds.GUTENBERG))
+            .companionFor(summary("123", SourceIds.LIBRIVOX, companionSourceUrl = "https://www.gutenberg.org/ebooks/1342"))
+        assertNotNull(match)
+        assertEquals(SourceIds.GUTENBERG, match!!.sourceId)
+        assertEquals("gutenberg:1342", match.fictionId)
+        assertEquals(CompanionMatch.Kind.TEXT, match.kind)
+    }
+
+    @Test
+    fun `librivox with no gutenberg back-link yields null`() = runTest {
+        val r = resolver(FakeSource(SourceIds.LIBRIVOX), FakeSource(SourceIds.GUTENBERG))
+        assertNull(r.companionFor(summary("123", SourceIds.LIBRIVOX, companionSourceUrl = null)))
+        assertNull(r.companionFor(summary("123", SourceIds.LIBRIVOX, companionSourceUrl = "https://archive.org/x")))
+    }
+
+    @Test
+    fun `text companion is suppressed when the gutenberg source is disabled`() = runTest {
+        // No Gutenberg source in the map — deep-link would dead-end, so no offer.
+        val match = resolver(FakeSource(SourceIds.LIBRIVOX))
+            .companionFor(summary("123", SourceIds.LIBRIVOX, companionSourceUrl = "https://www.gutenberg.org/ebooks/1342"))
+        assertNull(match)
+    }
+
+    // ── reverse: Gutenberg text → LibriVox audio (search + verify) ──────
+
+    @Test
+    fun `gutenberg text resolves to librivox audio, picking the back-link-verified candidate`() = runTest {
+        val librivox = FakeSource(
+            SourceIds.LIBRIVOX,
+            searchResults = listOf(
+                // Same title, WRONG ebook id — must be rejected despite ranking first.
+                summary("999", SourceIds.LIBRIVOX, companionSourceUrl = "https://www.gutenberg.org/ebooks/9999"),
+                // The true match, verified by exact back-link id.
+                summary("42", SourceIds.LIBRIVOX, companionSourceUrl = "https://www.gutenberg.org/ebooks/1342"),
+            ),
+        )
+        val match = resolver(librivox, FakeSource(SourceIds.GUTENBERG))
+            .companionFor(summary("gutenberg:1342", SourceIds.GUTENBERG))
+        assertNotNull(match)
+        assertEquals(SourceIds.LIBRIVOX, match!!.sourceId)
+        assertEquals("42", match.fictionId) // the verified one, not the first hit
+        assertEquals(CompanionMatch.Kind.AUDIO, match.kind)
+        assertEquals("Pride and Prejudice", librivox.lastSearchTerm) // searched by title
+    }
+
+    @Test
+    fun `gutenberg text with no matching librivox recording yields null`() = runTest {
+        val librivox = FakeSource(
+            SourceIds.LIBRIVOX,
+            searchResults = listOf(
+                summary("999", SourceIds.LIBRIVOX, companionSourceUrl = "https://www.gutenberg.org/ebooks/9999"),
+            ),
+        )
+        val match = resolver(librivox, FakeSource(SourceIds.GUTENBERG))
+            .companionFor(summary("gutenberg:1342", SourceIds.GUTENBERG))
+        assertNull(match)
+    }
+
+    @Test
+    fun `non-pairable source yields null`() = runTest {
+        val match = resolver(FakeSource(SourceIds.LIBRIVOX), FakeSource(SourceIds.GUTENBERG))
+            .companionFor(summary("rr:1", SourceIds.ROYAL_ROAD))
+        assertNull(match)
+    }
+}

--- a/core-data/src/test/kotlin/in/jphe/storyvox/data/source/companion/CompanionResolverTest.kt
+++ b/core-data/src/test/kotlin/in/jphe/storyvox/data/source/companion/CompanionResolverTest.kt
@@ -23,6 +23,7 @@ class CompanionResolverTest {
         override val id: String,
         private val searchResults: List<FictionSummary> = emptyList(),
     ) : FictionSource {
+        override val displayName: String get() = id
         var lastSearchTerm: String? = null
 
         override suspend fun search(query: SearchQuery): FictionResult<ListPage<FictionSummary>> {

--- a/core-data/src/test/kotlin/in/jphe/storyvox/data/source/companion/GutenbergRefTest.kt
+++ b/core-data/src/test/kotlin/in/jphe/storyvox/data/source/companion/GutenbergRefTest.kt
@@ -1,0 +1,43 @@
+package `in`.jphe.storyvox.data.source.companion
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Test
+
+/** Issue #1208 — the Gutenberg id helpers backing the companion matcher. */
+class GutenbergRefTest {
+
+    @Test
+    fun `parses the ebook id from every catalog URL shape`() {
+        assertEquals("1342", GutenbergRef.parseEbookIdFromUrl("https://www.gutenberg.org/ebooks/1342"))
+        assertEquals(
+            "1342",
+            GutenbergRef.parseEbookIdFromUrl("http://www.gutenberg.org/files/1342/1342-h/1342-h.htm"),
+        )
+        assertEquals("1342", GutenbergRef.parseEbookIdFromUrl("https://www.gutenberg.org/etext/1342"))
+        assertEquals(
+            "1342",
+            GutenbergRef.parseEbookIdFromUrl("https://www.gutenberg.org/cache/epub/1342/pg1342.txt"),
+        )
+        // www-less host + surrounding whitespace both tolerated.
+        assertEquals("1342", GutenbergRef.parseEbookIdFromUrl("  https://gutenberg.org/ebooks/1342  "))
+    }
+
+    @Test
+    fun `non-Gutenberg or idless URLs yield null`() {
+        assertNull(GutenbergRef.parseEbookIdFromUrl(null))
+        assertNull(GutenbergRef.parseEbookIdFromUrl(""))
+        assertNull(GutenbergRef.parseEbookIdFromUrl("https://en.wikisource.org/wiki/Pride"))
+        assertNull(GutenbergRef.parseEbookIdFromUrl("https://archive.org/details/prideprejudice"))
+        assertNull(GutenbergRef.parseEbookIdFromUrl("https://www.gutenberg.org/about/")) // no numeric id
+    }
+
+    @Test
+    fun `converts between ebook id and the gutenberg fiction id`() {
+        assertEquals("gutenberg:1342", GutenbergRef.fictionIdFor("1342"))
+        assertEquals("1342", GutenbergRef.ebookIdFromFictionId("gutenberg:1342"))
+        assertNull(GutenbergRef.ebookIdFromFictionId("librivox:9999")) // wrong source
+        assertNull(GutenbergRef.ebookIdFromFictionId("gutenberg:")) // empty after prefix
+        assertNull(GutenbergRef.ebookIdFromFictionId("1342")) // bare id, no prefix
+    }
+}

--- a/feature/src/main/kotlin/in/jphe/storyvox/feature/fiction/FictionDetailScreen.kt
+++ b/feature/src/main/kotlin/in/jphe/storyvox/feature/fiction/FictionDetailScreen.kt
@@ -3,6 +3,7 @@ package `in`.jphe.storyvox.feature.fiction
 import android.content.Intent
 import androidx.activity.compose.rememberLauncherForActivityResult
 import androidx.activity.result.contract.ActivityResultContracts
+import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -71,6 +72,7 @@ import androidx.compose.ui.unit.dp
 import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import `in`.jphe.storyvox.data.annotation.AnnotationExportFormatter
+import `in`.jphe.storyvox.data.source.companion.CompanionMatch
 import `in`.jphe.storyvox.feature.R
 import `in`.jphe.storyvox.feature.api.UiChapter
 import `in`.jphe.storyvox.feature.api.UiFiction
@@ -110,6 +112,8 @@ fun FictionDetailScreen(
      *  as Settings → Royal Road and the Browse anonymous-CTA from
      *  #241. */
     onOpenRoyalRoadSignIn: () -> Unit = {},
+    /** Issue #1208 — open the audio↔text companion's detail (LibriVox↔Gutenberg). */
+    onOpenCompanion: (String) -> Unit = {},
     viewModel: FictionDetailViewModel = hiltViewModel(),
 ) {
     val state by viewModel.uiState.collectAsStateWithLifecycle()
@@ -470,6 +474,8 @@ fun FictionDetailScreen(
                         speakingState = synopsisSpeaking,
                         onToggleListen = viewModel::toggleSynopsisAloud,
                     )
+                    // Issue #1208 — audio↔text companion (LibriVox↔Gutenberg).
+                    CompanionRow(state.companion, onOpenCompanion)
                     // Issue #217 — Notebook section in the wide-layout
                     // left column. Hides itself if there's nothing to show
                     // and the user hasn't tapped Add.
@@ -670,6 +676,8 @@ fun FictionDetailScreen(
                         onToggleListen = viewModel::toggleSynopsisAloud,
                     )
                 }
+                // Issue #1208 — audio↔text companion (LibriVox↔Gutenberg).
+                item { CompanionRow(state.companion, onOpenCompanion) }
                 // Issue #217 — Notebook section in the narrow (phone)
                 // layout. Inserted as a single LazyColumn item so it
                 // scrolls with the chapter list rather than pinning.
@@ -1306,6 +1314,43 @@ private fun NotebookSection(
                 )
             }
         }
+    }
+}
+
+/**
+ * Issue #1208 — a clickable row offering this fiction's audio↔text companion
+ * (a LibriVox narration for a Gutenberg text, or vice versa). Self-hiding: a
+ * null [match] renders nothing, so callers place it unconditionally alongside
+ * the synopsis the way [NotebookSection] hides itself when empty.
+ */
+@Composable
+private fun CompanionRow(match: CompanionMatch?, onOpenCompanion: (String) -> Unit) {
+    if (match == null) return
+    val spacing = LocalSpacing.current
+    Row(
+        modifier = Modifier
+            .fillMaxWidth()
+            .clickable { onOpenCompanion(match.fictionId) }
+            .padding(spacing.md),
+        horizontalArrangement = Arrangement.spacedBy(spacing.sm),
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        Icon(
+            imageVector = Icons.Filled.PlayArrow,
+            contentDescription = null,
+            tint = MaterialTheme.colorScheme.primary,
+        )
+        Text(
+            text = stringResource(
+                if (match.kind == CompanionMatch.Kind.AUDIO) {
+                    R.string.fiction_companion_listen_along
+                } else {
+                    R.string.fiction_companion_read_along
+                },
+            ),
+            style = MaterialTheme.typography.bodyLarge,
+            color = MaterialTheme.colorScheme.primary,
+        )
     }
 }
 

--- a/feature/src/main/kotlin/in/jphe/storyvox/feature/fiction/FictionDetailViewModel.kt
+++ b/feature/src/main/kotlin/in/jphe/storyvox/feature/fiction/FictionDetailViewModel.kt
@@ -133,7 +133,6 @@ sealed interface FictionDetailUiEvent {
     data class AnnotationsExportFailed(val message: String) : FictionDetailUiEvent
 }
 
-@HiltViewModel
 /** Issue #1208 — identity key that re-triggers a companion resolve only when
  *  the fiction's id/title actually changes (e.g. a placeholder hydrates), not
  *  on every unrelated cache-state re-emission of the fiction flow. */
@@ -144,6 +143,7 @@ private data class CompanionKey(
     val author: String,
 )
 
+@HiltViewModel
 class FictionDetailViewModel @Inject constructor(
     private val repo: FictionRepositoryUi,
     private val playback: PlaybackControllerUi,

--- a/feature/src/main/kotlin/in/jphe/storyvox/feature/fiction/FictionDetailViewModel.kt
+++ b/feature/src/main/kotlin/in/jphe/storyvox/feature/fiction/FictionDetailViewModel.kt
@@ -14,6 +14,9 @@ import `in`.jphe.storyvox.data.db.entity.FictionMemoryEntry
 import `in`.jphe.storyvox.data.repository.AnnotationRepository
 import `in`.jphe.storyvox.data.repository.FictionMemoryRepository
 import `in`.jphe.storyvox.data.repository.pronunciation.PronunciationDictRepository
+import `in`.jphe.storyvox.data.source.companion.CompanionMatch
+import `in`.jphe.storyvox.data.source.companion.CompanionResolver
+import `in`.jphe.storyvox.data.source.model.FictionSummary
 import `in`.jphe.storyvox.feature.api.DownloadMode
 import `in`.jphe.storyvox.feature.api.FictionRepositoryUi
 import `in`.jphe.storyvox.feature.api.PlaybackControllerUi
@@ -77,6 +80,10 @@ data class FictionDetailUiState(
     /** Issue #999 — true while [ExportAnnotationsUseCase] writes the
      *  Markdown/TXT file. Surfaces a building chip, like [isExportingEpub]. */
     val isExportingAnnotations: Boolean = false,
+    /** Issue #1208 — the audio↔text companion (LibriVox↔Gutenberg), or null when
+     *  this fiction has no high-confidence counterpart. Drives the
+     *  "listen/read along" row. */
+    val companion: CompanionMatch? = null,
 )
 
 /**
@@ -127,6 +134,16 @@ sealed interface FictionDetailUiEvent {
 }
 
 @HiltViewModel
+/** Issue #1208 — identity key that re-triggers a companion resolve only when
+ *  the fiction's id/title actually changes (e.g. a placeholder hydrates), not
+ *  on every unrelated cache-state re-emission of the fiction flow. */
+private data class CompanionKey(
+    val id: String,
+    val sourceId: String,
+    val title: String,
+    val author: String,
+)
+
 class FictionDetailViewModel @Inject constructor(
     private val repo: FictionRepositoryUi,
     private val playback: PlaybackControllerUi,
@@ -159,6 +176,8 @@ class FictionDetailViewModel @Inject constructor(
     /** Issue #999 — builds the Markdown/TXT export file + FileProvider URI
      *  for the share-sheet. Injected like [exportEpub] (#117). */
     private val exportAnnotations: ExportAnnotationsUseCase,
+    /** Issue #1208 — cross-source audio↔text companion matcher (LibriVox↔Gutenberg). */
+    private val companionResolver: CompanionResolver,
     savedState: SavedStateHandle,
 ) : ViewModel() {
 
@@ -232,6 +251,35 @@ class FictionDetailViewModel @Inject constructor(
      *  this counter via `value++` re-fires the cache-state flow on
      *  demand without rebuilding the upstream chapter list. */
     private val cacheStateNudge = MutableStateFlow(0)
+
+    /**
+     * Issue #1208 — the audio↔text companion (LibriVox↔Gutenberg) for this
+     * fiction, resolved by [CompanionResolver] over the public source models.
+     * Re-resolves only when the [CompanionKey] changes (placeholder→hydrated),
+     * not on every cache-state re-emission. Best-effort: a network hiccup on
+     * the reverse LibriVox lookup degrades to null (no row), never an error.
+     */
+    private val companion: StateFlow<CompanionMatch?> =
+        repo.fictionById(fictionId)
+            .map { f -> f?.let { CompanionKey(it.id, it.sourceId, it.title, it.author) } }
+            .distinctUntilChanged()
+            .map { key ->
+                if (key == null) {
+                    null
+                } else {
+                    runCatching {
+                        companionResolver.companionFor(
+                            FictionSummary(
+                                id = key.id,
+                                sourceId = key.sourceId,
+                                title = key.title,
+                                author = key.author,
+                            ),
+                        )
+                    }.getOrNull()
+                }
+            }
+            .stateIn(viewModelScope, SharingStarted.WhileSubscribed(5_000), null)
 
     val uiState: StateFlow<FictionDetailUiState> = run {
         // Issue #217 — Notebook entries surface in the detail page's
@@ -319,7 +367,10 @@ class FictionDetailViewModel @Inject constructor(
                 annotationGroups = annotationGroups,
                 isExportingAnnotations = exportingAnnotations,
             )
-        }.stateIn(viewModelScope, SharingStarted.WhileSubscribed(5_000), FictionDetailUiState())
+        }
+            // Issue #1208 — fold in the lazily-resolved audio↔text companion.
+            .combine(companion) { state, companionMatch -> state.copy(companion = companionMatch) }
+            .stateIn(viewModelScope, SharingStarted.WhileSubscribed(5_000), FictionDetailUiState())
     }
 
     /**

--- a/feature/src/main/res/values/strings.xml
+++ b/feature/src/main/res/values/strings.xml
@@ -409,6 +409,9 @@
     <string name="fiction_chapter_search_label">Search chapters</string>
     <string name="fiction_chapter_jump_label">Go to #</string>
     <string name="fiction_chapter_search_no_results">No chapters match your search.</string>
+    <!-- Issue #1208 — audio↔text companion (LibriVox↔Gutenberg) row on fiction detail. -->
+    <string name="fiction_companion_listen_along">🎧 Listen along on LibriVox</string>
+    <string name="fiction_companion_read_along">📖 Read along on Project Gutenberg</string>
 
     <!-- Voice library -->
     <string name="voicelibrary_title">Voice library</string>

--- a/source-librivox/src/main/kotlin/in/jphe/storyvox/source/librivox/LibriVoxSource.kt
+++ b/source-librivox/src/main/kotlin/in/jphe/storyvox/source/librivox/LibriVoxSource.kt
@@ -366,6 +366,10 @@ internal class LibriVoxSource @Inject constructor(
             // releases completed books) — COMPLETED reads correctly.
             status = FictionStatus.COMPLETED,
             chapterCount = numSections.toIntOrNull(),
+            // #1208 — publish the Gutenberg back-link so the cross-source
+            // companion matcher can pair this audiobook with its text (and
+            // verify a reverse title/author match by the exact ebook id).
+            companionSourceUrl = urlTextSource.ifBlank { null },
         )
 
     private fun LibriVoxSection.toChapterInfo(bookId: String, index: Int): ChapterInfo =


### PR DESCRIPTION
Implements #1208 (LibriVox ↔ Gutenberg audio↔text matching), scope **A+B** — **complete, CI green**.

Research findings (why this isn't greenfield) on the issue: the forward LibriVox→Gutenberg *text companion* already shipped under #1046, so this PR adds the **reverse** direction + a reusable matcher + a fiction-detail surface.

### A — data layer (`:core-data`, `:source-librivox`)
- **`GutenbergRef`** — shared ebook-id helpers (URL→id across catalog URL shapes; `gutenberg:<id>` ↔ id). Keeps the matcher out of `:source-librivox` internals (leaf-source isolation).
- **`FictionSummary.companionSourceUrl`** — public back-link; LibriVox publishes its recording's `url_text_source`.
- **`CompanionResolver`** — over the public `FictionSource` map (mirrors `FictionRepository`'s existing core-data consumption, so sources still don't depend on each other): forward = parse the back-link; **reverse = LibriVox title search VERIFIED by exact ebook-id back-link** → high-confidence, no fuzzy false positives, no id table.

### B — UI surface (`:feature`, `:app`)
- `FictionDetailViewModel` async-resolves the companion (keyed on fiction identity so it re-resolves only on a real change, e.g. placeholder→hydrated; best-effort — a reverse-lookup network hiccup degrades to no row). Reverse needs only the cached id+title → **no Room migration / refetch**.
- Self-hiding `CompanionRow` (matches `NotebookSection`'s hide-when-empty idiom) in both screen layouts; tap deep-links to the companion's detail. Forward (LibriVox→Gutenberg) already surfaces via the #1046 "📖 Read the text" chapter.

### Tests
`GutenbergRef` URL shapes + `CompanionResolver` forward/reverse/no-match/disabled-source/non-pairable, including picking the back-link-verified candidate over a same-title wrong-id hit.

### Deferred
(C) full synced read-along (audio↔text position sync) — large, overlaps #1046's STT track.
