### PR TITLE
feat(reader): persist teleprompter WPM across sessions (#1287)

### DIFF
--- a/app/src/main/kotlin/in/jphe/storyvox/data/SettingsRepositoryUiImpl.kt
+++ b/app/src/main/kotlin/in/jphe/storyvox/data/SettingsRepositoryUiImpl.kt
@@ -887,6 +887,9 @@ private object Keys {
     val HIGHLIGHT_MODE = stringPreferencesKey("pref_highlight_mode")
     val WORD_HIGHLIGHT_ARGB = intPreferencesKey("pref_word_highlight_argb")
 
+    /** Issue #1287 — persisted teleprompter (#1239) auto-scroll pace (WPM). */
+    val TELEPROMPTER_WPM = intPreferencesKey("pref_teleprompter_wpm_v1")
+
     // ── Reader-surface typography (issue #992) ──────────────────────
     /** Reader font family — stored as the [ReaderFontFamily] enum's name.
      *  Unknown values fall back to [ReaderFontFamily.Default] on read. Synced. */
@@ -1586,6 +1589,9 @@ class SettingsRepositoryUiImpl(
                 ?.let { runCatching { HighlightMode.valueOf(it) }.getOrNull() }
                 ?: HighlightMode.Sentence,
             wordHighlightArgb = prefs[Keys.WORD_HIGHLIGHT_ARGB] ?: 0,
+            // #1287 — clamp on read so a legacy / corrupt value can't drive the
+            // teleprompter out of its supported band (defensive; writes clamp too).
+            teleprompterWpm = (prefs[Keys.TELEPROMPTER_WPM] ?: 130).coerceIn(30, 500),
             // Issue #992 — reader-surface typography. Unknown enum strings
             // fall back to Default; numeric fields are clamped by
             // ReaderTypography.clamped() via UiSettings.readerTypography so we
@@ -2691,6 +2697,13 @@ class SettingsRepositoryUiImpl(
 
     override suspend fun setWordHighlightColor(argb: Int) {
         store.edit { it[Keys.WORD_HIGHLIGHT_ARGB] = argb }
+    }
+
+    override suspend fun setTeleprompterWpm(wpm: Int) {
+        // #1287 — clamp to the teleprompter's supported band (TELEPROMPTER_MIN_WPM
+        // /MAX_WPM in ReaderView, #1239) so a bad caller can't persist an
+        // out-of-range pace the reader would have to re-clamp on read.
+        store.edit { it[Keys.TELEPROMPTER_WPM] = wpm.coerceIn(30, 500) }
     }
 
     // ── Azure Speech Services BYOK (#182, PR-3) ────────────────────

--- a/app/src/test/kotlin/in/jphe/storyvox/data/SettingsRepositorySweeperPrefsTest.kt
+++ b/app/src/test/kotlin/in/jphe/storyvox/data/SettingsRepositorySweeperPrefsTest.kt
@@ -152,6 +152,27 @@ class SettingsRepositorySweeperPrefsTest {
         assertEquals(15, repo.skipDistanceSec.first())
     }
 
+    // ---- Issue #1287 — teleprompter WPM persistence ----
+
+    @Test
+    fun `default teleprompter WPM is 130`() = runTest {
+        assertEquals(130, repo.settings.first().teleprompterWpm)
+    }
+
+    @Test
+    fun `setTeleprompterWpm round-trips through the settings flow`() = runTest {
+        repo.setTeleprompterWpm(180)
+        assertEquals(180, repo.settings.first().teleprompterWpm)
+    }
+
+    @Test
+    fun `setTeleprompterWpm clamps to the supported band`() = runTest {
+        repo.setTeleprompterWpm(5) // below TELEPROMPTER_MIN_WPM (30)
+        assertEquals(30, repo.settings.first().teleprompterWpm)
+        repo.setTeleprompterWpm(9_999) // above TELEPROMPTER_MAX_WPM (500)
+        assertEquals(500, repo.settings.first().teleprompterWpm)
+    }
+
     // ---- Issue #594 — rewind-to-start threshold ----
 
     @Test

--- a/feature/src/main/kotlin/in/jphe/storyvox/feature/api/UiContracts.kt
+++ b/feature/src/main/kotlin/in/jphe/storyvox/feature/api/UiContracts.kt
@@ -1414,6 +1414,14 @@ data class UiSettings(
      * "customizable highlight color"). Per-device pref (NOT synced).
      */
     val wordHighlightArgb: Int = 0,
+    /**
+     * Issue #1287 — persisted teleprompter (solo-rehearsal, #1239) auto-scroll
+     * pace in words-per-minute, restored on the next teleprompter session so the
+     * MVP's transient pace survives an app restart. Default `130` matches
+     * `TELEPROMPTER_DEFAULT_WPM`; the impl clamps reads to the supported 30–500
+     * band (`TELEPROMPTER_MIN_WPM`/`MAX_WPM`). Per-device pref (NOT synced).
+     */
+    val teleprompterWpm: Int = 130,
 ) {
     /**
      * Resolved reading-surface colours for the reader (#993). Inactive when
@@ -1899,6 +1907,13 @@ interface SettingsRepositoryUi {
      * theme accent). Device-local (NOT synced). Default impl is a no-op.
      */
     suspend fun setWordHighlightColor(argb: Int) = Unit
+    /**
+     * Issue #1287 — persist the teleprompter (#1239) auto-scroll pace in WPM so
+     * it's restored next session. Clamped to the supported 30–500 band on write.
+     * Device-local (NOT synced). Default impl is a no-op so test fakes compile
+     * without overriding it.
+     */
+    suspend fun setTeleprompterWpm(wpm: Int) = Unit
     /**
      * Issue #992 — reader-surface typography setters. Each clamps into the safe
      * range from [ReaderTypography] on write. Default impls are no-ops so tests

--- a/feature/src/main/kotlin/in/jphe/storyvox/feature/reader/HybridReaderScreen.kt
+++ b/feature/src/main/kotlin/in/jphe/storyvox/feature/reader/HybridReaderScreen.kt
@@ -109,6 +109,8 @@ fun HybridReaderScreen(
     val currentAuthor by viewModel.currentAuthor.collectAsStateWithLifecycle()
     // Issue #1230 — tap-to-define dictionary popup state.
     val definitionState by viewModel.dictionary.collectAsStateWithLifecycle()
+    // Issue #1287 — persisted teleprompter pace (WPM).
+    val teleprompterWpm by viewModel.teleprompterWpm.collectAsStateWithLifecycle()
     val playback = state.playback
 
     // Chapter-completion celebration. The VM's confettiTrigger fires
@@ -404,6 +406,10 @@ fun HybridReaderScreen(
                 onDefineWord = viewModel::defineWord,
                 onDismissDefinition = viewModel::dismissDefinition,
                 onRetryDefine = viewModel::retryDefine,
+                // Issue #1287 — seed the teleprompter pace from the persisted
+                // pref and write changes back so it survives a restart.
+                persistedTeleprompterWpm = teleprompterWpm,
+                onTeleprompterWpmChange = viewModel::setTeleprompterWpm,
             )
         },
     )

--- a/feature/src/main/kotlin/in/jphe/storyvox/feature/reader/ReaderView.kt
+++ b/feature/src/main/kotlin/in/jphe/storyvox/feature/reader/ReaderView.kt
@@ -297,6 +297,13 @@ fun ReaderTextView(
     onDismissDefinition: () -> Unit = {},
     /** Issue #1230 — retry a failed lookup (→ [ReaderViewModel.retryDefine]). */
     onRetryDefine: (String) -> Unit = {},
+    /** Issue #1287 — persisted teleprompter (#1239) pace (WPM) to seed the
+     *  per-session pace from when the teleprompter opens. Default keeps
+     *  preview/test callsites at [TELEPROMPTER_DEFAULT_WPM]. */
+    persistedTeleprompterWpm: Int = TELEPROMPTER_DEFAULT_WPM,
+    /** Issue #1287 — persist a teleprompter pace change (→
+     *  [ReaderViewModel.setTeleprompterWpm]) so it survives a restart. No-op default. */
+    onTeleprompterWpmChange: (Int) -> Unit = {},
     modifier: Modifier = Modifier,
 ) {
     val spacing = LocalSpacing.current
@@ -345,7 +352,15 @@ fun ReaderTextView(
     // auto-scroll; `wpm` is the rehearsal pace.
     var teleprompterEnabled by remember { mutableStateOf(false) }
     var teleprompterPlaying by remember { mutableStateOf(false) }
-    var teleprompterWpm by remember { mutableIntStateOf(TELEPROMPTER_DEFAULT_WPM) }
+    // Issue #1287 — the pace is now persisted (#1239 shipped it transient). Seed
+    // the session value from the saved pref, and re-seed each time the
+    // teleprompter opens so a restart restores the last pace (the persisted Flow
+    // has loaded by the time the user taps the teleprompter button). Within a
+    // session the local value leads; adjustments write through below.
+    var teleprompterWpm by remember { mutableIntStateOf(persistedTeleprompterWpm) }
+    LaunchedEffect(teleprompterEnabled) {
+        if (teleprompterEnabled) teleprompterWpm = persistedTeleprompterWpm
+    }
     val totalWords = remember(chapterText) { countWords(chapterText) }
     // True once the body has scrolled to the very end — the teleprompter's
     // Play then replays from the top (see the transport's onPlayPause).
@@ -987,7 +1002,11 @@ fun ReaderTextView(
                         teleprompterPlaying = !teleprompterPlaying
                     }
                 },
-                onWpmDelta = { steps -> teleprompterWpm = adjustTeleprompterWpm(teleprompterWpm, steps) },
+                onWpmDelta = { steps ->
+                    teleprompterWpm = adjustTeleprompterWpm(teleprompterWpm, steps)
+                    // #1287 — write the new pace through so it survives a restart.
+                    onTeleprompterWpmChange(teleprompterWpm)
+                },
                 onExit = {
                     teleprompterPlaying = false
                     teleprompterEnabled = false

--- a/feature/src/main/kotlin/in/jphe/storyvox/feature/reader/ReaderViewModel.kt
+++ b/feature/src/main/kotlin/in/jphe/storyvox/feature/reader/ReaderViewModel.kt
@@ -793,6 +793,17 @@ class ReaderViewModel @Inject constructor(
         .distinctUntilChanged()
         .stateIn(viewModelScope, SharingStarted.WhileSubscribed(5_000), 0)
 
+    /**
+     * Issue #1287 — persisted teleprompter (#1239) auto-scroll pace (WPM).
+     * [ReaderTextView] seeds its per-session pace from this when the teleprompter
+     * opens, and writes user adjustments back via [setTeleprompterWpm] so the
+     * pace is restored on the next session. Device-local pref.
+     */
+    val teleprompterWpm: StateFlow<Int> = settings.settings
+        .map { it.teleprompterWpm }
+        .distinctUntilChanged()
+        .stateIn(viewModelScope, SharingStarted.WhileSubscribed(5_000), TELEPROMPTER_DEFAULT_WPM)
+
     /** Issue #278 — user-initiated retry from the timed-out error block.
      *  Re-invokes the playback `play()` path; the underlying controller
      *  will re-fetch the chapter / re-prime the voice. We also reset the
@@ -1137,6 +1148,13 @@ class ReaderViewModel @Inject constructor(
      *  re-emits and [ReaderTextView] re-renders in focus mode. */
     fun setFocusModeEnabled(enabled: Boolean) {
         viewModelScope.launch { settings.setReaderFocusModeEnabled(enabled) }
+    }
+
+    /** Issue #1287 — persist the teleprompter pace so it survives an app restart.
+     *  Fire-and-forget, same shape as [setAutoScrollEnabled]; the impl clamps to
+     *  the supported band and the [teleprompterWpm] StateFlow re-emits. */
+    fun setTeleprompterWpm(wpm: Int) {
+        viewModelScope.launch { settings.setTeleprompterWpm(wpm) }
     }
 
     // Issue #121 — in-chapter bookmark fan-out. ReaderViewModel stays


### PR DESCRIPTION
## Summary

Addresses #1287 (item 4): the teleprompter / solo-rehearsal mode (#1239/#1286) shipped its WPM pace **transient by design**. This persists it so the user's chosen pace **survives an app restart** and is restored on the next teleprompter session.

> Depends on #1286, which merged in wave-1 — this branch was rebased onto the refreshed `main` and verified the teleprompter WPM code is present before building.

## Implementation

Mirrors the existing per-device Int-pref pattern (`wordHighlightArgb` / `skipDistanceSec`):

| Layer | Change |
|---|---|
| `UiContracts` | `UiSettings.teleprompterWpm` (default `130` = `TELEPROMPTER_DEFAULT_WPM`) + `SettingsRepositoryUi.setTeleprompterWpm` (default no-op so test fakes compile) |
| `SettingsRepositoryUiImpl` | DataStore `intPreferencesKey("pref_teleprompter_wpm_v1")`, clamped to the supported **30–500** band (`TELEPROMPTER_MIN/MAX_WPM`) on both read and write |
| `ReaderViewModel` | `teleprompterWpm: StateFlow<Int>` + `setTeleprompterWpm(Int)` |
| `ReaderView` (`ReaderTextView`) | seeds the per-session pace from the persisted value when the teleprompter **opens** (local value leads within a session); writes each `±` adjustment back via `onTeleprompterWpmChange` |
| `HybridReaderScreen` | collects the StateFlow → `persistedTeleprompterWpm`, wires `onTeleprompterWpmChange = viewModel::setTeleprompterWpm` |

**Design choices**
- **Always-persist, no "Remember speed" toggle** — the simpler path #1287 explicitly allowed.
- **Seed-on-open** (not a continuous bind): the local `var` stays the responsive source of truth during a session, re-seeded from the pref each time the teleprompter opens, so there's no flicker fighting the user's `±` taps. By open-time the persisted Flow has loaded.
- Device-local pref (not synced), matching the other reader prefs.

## Scope — global WPM only (per-fiction deferred)

#1287 item 2 floats an *optional* per-fiction WPM (by analogy to `Fiction.pinnedVoiceId`). **Deferred**: that needs a Room entity column + migration, disproportionate to this follow-up, and the shared pref is the common case. Easy to layer on later. Flagging rather than silently dropping.

## Tests

`SettingsRepositorySweeperPrefsTest` (real-DataStore harness): default is `130`, `setTeleprompterWpm` round-trips through the `settings` flow, and writes clamp to the 30–500 band. New `ReaderTextView` params are defaulted, so existing reader callsites/tests are unaffected. No local gradle (CI is the compile/test gate).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
