### PR TITLE
docs(play-store): fix inverted privacy-policy URL + refresh stale checklist (#1301)

### DIFF
--- a/docs/play-store-policy-check.md
+++ b/docs/play-store-policy-check.md
@@ -61,7 +61,7 @@ mechanism."
 | --- | --- | --- |
 | UGC platform? | **No, we're a reader** | The app reads content from public web or user-authenticated services. Source is the third-party service's own moderation. |
 | Scheme allowlist on magic-link | **Done in PR #587** | http/https only. No `javascript:`, no `file://`, no `content://`. Sufficient — the remaining surface ("any URL on the public web") is the same surface a web browser exposes, which Play accepts. |
-| In-app "Report content" affordance | **Add for v1.0** — Settings → About → "Report objectionable content" → mailto with a pre-filled subject including the active fiction's title + URL. Lightweight; no separate web form. | Not yet implemented in the worktree; orchestrator's call whether to wire in this PR or a follow-up. |
+| In-app "Report content" affordance | **Done** — Settings → About → "Report objectionable content" → mailto with a pre-filled subject. Lightweight; no separate web form. | Implemented in `feature/.../settings/AboutSettingsScreen.kt` (`CONTENT_REPORT_SUBJECT`). |
 | In-app block / mute | **N/A** | No social graph. |
 | Defaults that surface family-safe content | **Yes** | TechEmpower Home is the default landing surface in v0.5.51+, library defaults to TechEmpower's Notion-backed resource library — not the Royal Road browse tab. |
 
@@ -295,19 +295,17 @@ are scoped to real workloads.
 - [ ] Release keystore generated (see `release-keystore.md`)
 - [ ] AAB built with the release keystore, verified with `apksigner verify --print-certs`
 - [ ] Play App Signing enrolled (upload key cert exported & uploaded)
-- [ ] Privacy policy live at `https://candela.techempower.org/privacy/`
+- [x] Privacy policy live at `https://candela.techempower.org/privacy/` (verified resolving — HTTP 200, 2026-06-28; `/privacy-policy/` 404s — see `listing/AUDIT.md`)
 - [ ] Listing copy finalized (`play-store-listing.md`)
 - [ ] Graphics produced (icon, feature graphic, 4–8 phone, 4–8 tablet)
 - [ ] Data Safety form completed per section 4 above
 - [ ] Content rating questionnaire completed → likely 13+ with UGC advisory
-- [ ] Permissions justified per section 5
-- [ ] Foreground service types justified per section 2
-- [ ] Emergency Help disclaimer added ("US/Canada numbers; use your local
-      emergency number elsewhere") — section 3
-- [ ] Settings → About → Privacy Policy link added (links to
+- [x] Permissions justified per section 5
+- [x] Foreground service types justified per section 2
+- [x] Settings → About → Privacy Policy link added (links to
       `candela.techempower.org/privacy/`)
-- [ ] Settings → About → Report objectionable content (mailto) added —
+- [x] Settings → About → Report objectionable content (mailto) added —
       section 1
-- [ ] Settings → About → Open Source Licenses verified complete
+- [x] Settings → About → Open Source Licenses verified complete (#1142)
 - [ ] First internal-testing build uploaded and confirmed launchable on
       a clean install

--- a/docs/play-store/listing/AUDIT.md
+++ b/docs/play-store/listing/AUDIT.md
@@ -80,7 +80,7 @@ consolidated here so it's in one place for the questionnaire.
 - [ ] **Category: Books & Reference** (brief's recommendation; confirm).
 - [ ] **Contact email** on the listing — brief leaves as DRAFT (`claude2@techempower.org` or `jp@jphein.com`?).
 - [ ] **Developer phone** (Play requires one on the developer profile).
-- [ ] **Privacy policy URL** — use **`https://candela.techempower.org/privacy-policy/`** (the path that actually resolves). ⚠️ The design brief and `docs/privacy-policy.md`'s `permalink: /privacy/` both point at `/privacy/`, which **404s** (confirmed by Drift): the docs microsite is **static-served**, so Jekyll's per-page `permalink` isn't honored and the page serves at its filename path `/privacy-policy/`. Either fix the deploy so `/privacy/` resolves **or** (recommended) use `/privacy-policy/` in Play Console since it works today. Play **requires** a resolving privacy-policy URL or the submission is rejected, so don't ship the `/privacy/` form.
+- [x] **Privacy policy URL** — use **`https://candela.techempower.org/privacy/`** (verified resolving — **HTTP 200**, 2026-06-28). ⚠️ Do **NOT** use `/privacy-policy/` — it **404s** (verified). `docs/privacy.md` is served at `/privacy/` on the static microsite (it carries no conflicting `permalink`), and the in-app link (`feature/.../settings/AboutSettingsScreen.kt`), `docs/play-store-policy-check.md`, and `docs/index.md` all already use `/privacy/`. Play **requires** a resolving privacy-policy URL or the submission is rejected, so use the `/privacy/` form. _(Earlier guidance here had this backwards — the static deploy serves the filename path `/privacy/`, not `/privacy-policy/`; corrected per #1301.)_
 
 ## Data Safety + permissions (pointers — already drafted)
 


### PR DESCRIPTION
Closes #1301.

## The bug
`docs/play-store/listing/AUDIT.md` recommended `https://candela.techempower.org/privacy-policy/` and warned that `/privacy/` 404s — **backwards**. Verified live 2026-06-28:

| URL | Status |
|---|---|
| `/privacy/` | **200 ✅** (used by the app + other docs) |
| `/privacy-policy/` | **404 ❌** (the old recommendation) |

Following the stale guidance when filling the Play Console listing would have caused a **submission rejection** (Play requires a resolving privacy-policy URL). The in-app link (`AboutSettingsScreen.kt`), `play-store-policy-check.md`, and `index.md` were all already correct on `/privacy/`; only this audit doc was wrong.

## Changes (docs-only)
- **AUDIT.md** — inverted the privacy-URL guidance to the working `/privacy/` form.
- **play-store-policy-check.md §7** — checked the items verified done in code (Privacy Policy link, Report-objectionable-content mailto, Open-source licenses #1142, permissions/FGS justification §2/§5, privacy-policy live HTTP 200). Removed the **obsolete** 'Emergency Help disclaimer' item (988/911 card removed in #775; only United Way Call 211 remains).
- **§1** — fixed the stale 'not yet implemented' note for the report-content affordance.

Manual Console gates (keystore, signing, Data Safety #1139, content rating, etc.) remain tracked in #1302. No code paths touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)