### PR TITLE
feat(reader): practice "pause-for-me" mode — TTS narrates, user voices dialogue (#1287)

### DIFF
--- a/feature/src/main/kotlin/in/jphe/storyvox/feature/reader/DialogueSegmenter.kt
+++ b/feature/src/main/kotlin/in/jphe/storyvox/feature/reader/DialogueSegmenter.kt
@@ -1,0 +1,170 @@
+package `in`.jphe.storyvox.feature.reader
+
+/**
+ * Issue #1287 — practice / "pause-for-me" rehearsal mode.
+ *
+ * Splits chapter text into a contiguous run of [TextSegment]s classified as
+ * [SegmentKind.Narration] or [SegmentKind.Dialogue], so practice mode can
+ * let TTS read the narration and hand the dialogue to the user (pause →
+ * "your turn" → tap to continue).
+ *
+ * Pure logic, no Compose/Android/engine deps, so the turn-taking boundaries
+ * are unit-testable on the JVM (mirrors the [focusScrollTargetY] /
+ * teleprompter pace-math pattern).
+ *
+ * Detection is deliberately **double-quote-only** — straight `"` (open/close
+ * ambiguous, so it toggles) and curly `“…”` (unambiguous). This sidesteps
+ * the apostrophe trap entirely: contractions and possessives (`don't`,
+ * `it's`, `Hermione's`) use the single quote / apostrophe `'` `’`, which we
+ * never treat as a delimiter — so they can't falsely flip "inside dialogue".
+ *
+ * Known limits (acceptable for an honor-system v1; see #1287):
+ *  - Double quotes used as scare-quotes or inch-marks are misread as speech.
+ *  - An unbalanced opening quote runs to end-of-text as dialogue.
+ *  - Speaker attribution ([guessSpeaker]) is best-effort and may be null.
+ */
+enum class SegmentKind { Narration, Dialogue }
+
+/**
+ * A contiguous classified run of chapter text. [start] inclusive, [end]
+ * exclusive — i.e. `chapterText.substring(start, end)` is the run, and the
+ * segments tile the whole string with no gaps or overlaps.
+ *
+ * [speaker] is a best-effort guess of who voices a [SegmentKind.Dialogue]
+ * run (null when unknown or for narration).
+ */
+data class TextSegment(
+    val start: Int,
+    val end: Int,
+    val kind: SegmentKind,
+    val speaker: String? = null,
+)
+
+private const val STRAIGHT_QUOTE = '"'
+private const val CURLY_OPEN = '“' // “
+private const val CURLY_CLOSE = '”' // ”
+
+/**
+ * Split [text] into narration/dialogue segments tiling the whole string.
+ * Returns an empty list for empty input. Adjacent same-kind runs never
+ * occur (narration runs are maximal; a dialogue run is one quote pair).
+ *
+ * When [attributeSpeakers] is true, each dialogue run gets a best-effort
+ * [TextSegment.speaker] from the surrounding narration (see [guessSpeaker]).
+ */
+internal fun segmentDialogue(text: String, attributeSpeakers: Boolean = true): List<TextSegment> {
+    if (text.isEmpty()) return emptyList()
+    val out = mutableListOf<TextSegment>()
+    var segStart = 0
+    var inQuote = false
+    var closer = STRAIGHT_QUOTE
+    var i = 0
+    while (i < text.length) {
+        val c = text[i]
+        if (!inQuote) {
+            if (c == STRAIGHT_QUOTE || c == CURLY_OPEN) {
+                // Close the narration run that precedes this opening quote.
+                if (i > segStart) out += TextSegment(segStart, i, SegmentKind.Narration)
+                segStart = i
+                inQuote = true
+                closer = if (c == CURLY_OPEN) CURLY_CLOSE else STRAIGHT_QUOTE
+            }
+        } else if (c == closer) {
+            // Dialogue run is [segStart, i] inclusive of the closing quote.
+            out += dialogueSegment(text, segStart, i + 1, attributeSpeakers)
+            segStart = i + 1
+            inQuote = false
+        }
+        i++
+    }
+    if (segStart < text.length) {
+        out += if (inQuote) {
+            dialogueSegment(text, segStart, text.length, attributeSpeakers)
+        } else {
+            TextSegment(segStart, text.length, SegmentKind.Narration)
+        }
+    }
+    return out
+}
+
+private fun dialogueSegment(text: String, start: Int, end: Int, attribute: Boolean): TextSegment =
+    TextSegment(
+        start = start,
+        end = end,
+        kind = SegmentKind.Dialogue,
+        speaker = if (attribute) guessSpeaker(text, start, end) else null,
+    )
+
+/** Speech verbs that flag an attribution clause (`"…," said Harry` / `Harry asked, "…"`). */
+private val SPEECH_VERBS = listOf(
+    "said", "says", "asked", "asks", "replied", "replies", "whispered", "shouted",
+    "cried", "muttered", "exclaimed", "answered", "added", "continued", "called",
+    "murmured", "yelled", "began", "responded", "remarked", "declared", "snapped",
+).joinToString("|")
+
+/** Pronouns / articles that look capitalised at sentence start but aren't names. */
+private val NON_NAMES = setOf(
+    "He", "She", "They", "It", "I", "We", "You", "The", "A", "An", "And", "But", "Then",
+)
+
+// `Harry said` / `Professor McGonagall asked` (capitalised name immediately before a speech verb)
+private val SPEAKER_BEFORE_VERB = Regex("\\b([A-Z][a-zA-Z]+)\\s+(?:$SPEECH_VERBS)\\b")
+// `said Harry` / `asked Hermione` (speech verb immediately before a capitalised name)
+private val VERB_BEFORE_SPEAKER = Regex("\\b(?:$SPEECH_VERBS)\\s+([A-Z][a-zA-Z]+)\\b")
+
+/**
+ * Best-effort: who voices the dialogue run [dialogueStart, dialogueEnd)?
+ * Looks first at the narration immediately AFTER the closing quote
+ * (`"…," she said` is the common attribution position), then BEFORE the
+ * opening quote (`Harry said, "…"`). Returns null when no confident match —
+ * practice mode then just shows a generic "Your turn".
+ */
+internal fun guessSpeaker(text: String, dialogueStart: Int, dialogueEnd: Int): String? {
+    val after = text.substring(dialogueEnd, (dialogueEnd + ATTR_WINDOW).coerceAtMost(text.length))
+    speakerIn(after)?.let { return it }
+    val before = text.substring((dialogueStart - ATTR_WINDOW).coerceAtLeast(0), dialogueStart)
+    return speakerIn(before)
+}
+
+private const val ATTR_WINDOW = 48
+
+private fun speakerIn(window: String): String? {
+    // "said Harry" reads more reliably than the before-verb form, so check it first.
+    VERB_BEFORE_SPEAKER.find(window)?.groupValues?.get(1)?.let { if (it !in NON_NAMES) return it }
+    SPEAKER_BEFORE_VERB.find(window)?.groupValues?.get(1)?.let { if (it !in NON_NAMES) return it }
+    return null
+}
+
+// ─────────────────────────────────────────────────────────────────────
+// Turn-taking decision logic (pure) — drives the auto-pause in practice mode
+// ─────────────────────────────────────────────────────────────────────
+// Practice mode plays narration via TTS and watches the playhead's current
+// char offset (UiPlaybackState.sentenceStart). These helpers answer the two
+// questions the turn-taking effect asks each time the playhead moves; both
+// are pure so the hand-off boundaries are unit-testable.
+
+/**
+ * The dialogue segment the playhead at [charOffset] currently falls in, or
+ * null when the playhead is in narration. When non-null, it's the user's
+ * turn: practice mode pauses TTS and shows "your turn" (+ [TextSegment.speaker]
+ * if known).
+ */
+internal fun dialogueAt(segments: List<TextSegment>, charOffset: Int): TextSegment? =
+    segments.firstOrNull { it.kind == SegmentKind.Dialogue && charOffset in it.start until it.end }
+
+/**
+ * The next dialogue segment that starts at or after [charOffset] — i.e. the
+ * upcoming hand-off point while narration is playing. Null when no dialogue
+ * remains (TTS just narrates to the end). Used to know where the next pause
+ * will land; segments are in document order so the first match wins.
+ */
+internal fun nextDialogueAtOrAfter(segments: List<TextSegment>, charOffset: Int): TextSegment? =
+    segments.firstOrNull { it.kind == SegmentKind.Dialogue && it.start >= charOffset }
+
+/**
+ * Where TTS should resume after the user reads [dialogue] aloud: the end of
+ * the dialogue run, which is the start of the following narration (or the
+ * chapter end). practice mode seeks here on "continue", so the synthesized
+ * voice never reads the line the user just voiced.
+ */
+internal fun resumeOffsetAfter(dialogue: TextSegment): Int = dialogue.end

--- a/feature/src/main/kotlin/in/jphe/storyvox/feature/reader/ReaderView.kt
+++ b/feature/src/main/kotlin/in/jphe/storyvox/feature/reader/ReaderView.kt
@@ -39,11 +39,15 @@ import androidx.compose.material.icons.outlined.CenterFocusStrong
 import androidx.compose.material.icons.outlined.ContentCopy
 import androidx.compose.material.icons.outlined.ExpandLess
 import androidx.compose.material.icons.outlined.ExpandMore
+import androidx.compose.material.icons.outlined.RecordVoiceOver
 import androidx.compose.material.icons.outlined.Search
 import androidx.compose.material.icons.outlined.Slideshow
+import androidx.compose.material3.Button
 import androidx.compose.material3.DropdownMenu
 import androidx.compose.material3.DropdownMenuItem
+import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.FilledIconButton
+import androidx.compose.material3.FilterChip
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.IconButtonDefaults
@@ -79,8 +83,10 @@ import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalSoftwareKeyboardController
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.semantics.LiveRegionMode
 import androidx.compose.ui.semantics.Role
 import androidx.compose.ui.semantics.contentDescription
+import androidx.compose.ui.semantics.liveRegion
 import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.text.TextLayoutResult
 import androidx.compose.ui.text.input.ImeAction
@@ -180,6 +186,16 @@ internal const val TELEPROMPTER_DEFAULT_WPM = 130
 internal const val TELEPROMPTER_MIN_WPM = 30
 internal const val TELEPROMPTER_MAX_WPM = 500
 internal const val TELEPROMPTER_WPM_STEP = 10
+
+/**
+ * Issue #1287 — the two teleprompter sub-modes.
+ *  - [AutoScroll]: silent, manual-WPM auto-scroll (#1286) — rehearse aloud
+ *    at your own pace.
+ *  - [Practice]: TTS narrates and pauses at each dialogue line for the user
+ *    to voice the character ("pause-for-me"), tap to continue. Honor-system
+ *    (no mic) for v1.
+ */
+enum class TeleprompterMode { AutoScroll, Practice }
 
 /** Whitespace-delimited word count; the teleprompter's pace is per-word. */
 internal fun countWords(text: String): Int =
@@ -367,6 +383,17 @@ fun ReaderTextView(
     val teleprompterAtEnd by remember {
         derivedStateOf { scroll.maxValue > 0 && scroll.value >= scroll.maxValue }
     }
+    // #1287 — practice mode: TTS narrates and pauses at dialogue for the user
+    // to voice. `mode` selects auto-scroll vs practice; `practiceTurn` is the
+    // dialogue segment the user is currently on (non-null = paused on their
+    // turn), null while narration plays. `segments` is the cached split.
+    var teleprompterMode by remember { mutableStateOf(TeleprompterMode.AutoScroll) }
+    var practiceTurn by remember { mutableStateOf<TextSegment?>(null) }
+    // Char offset we last resumed narration from after a hand-off — the
+    // turn-taking effect won't re-fire on any dialogue starting before it, so
+    // a just-handled line can't re-trigger during the post-seek playhead lag.
+    var practiceResumeFrom by remember { mutableIntStateOf(0) }
+    val segments = remember(chapterText) { segmentDialogue(chapterText) }
 
     // Auto-scroll target: when sentence range or layout changes, settle the highlighted
     // line at 40% from the top of the viewport — unless we're inside the manual-scroll
@@ -377,11 +404,14 @@ fun ReaderTextView(
     // and never schedules another animateScrollTo. Flipping back on re-keys and resumes
     // following the next sentence boundary (no jump — only the next emit triggers a
     // scroll, so the user's manual position is preserved until then).
-    LaunchedEffect(autoScrollEnabled, focusModeEnabled, teleprompterEnabled, state.sentenceStart, state.sentenceEnd, textLayout, viewportHeightPx, bodyTopPx, chapterText) {
+    LaunchedEffect(autoScrollEnabled, focusModeEnabled, teleprompterEnabled, teleprompterMode, practiceTurn, state.sentenceStart, state.sentenceEnd, textLayout, viewportHeightPx, bodyTopPx, chapterText) {
         if (!autoScrollEnabled) return@LaunchedEffect
-        // #1239 — rehearsal owns the wheel; the sentence-follow must not
-        // fight the teleprompter's auto-scroll.
-        if (teleprompterEnabled) return@LaunchedEffect
+        // #1239 — the silent auto-scroll mode owns the wheel; suppress the
+        // sentence-follow only then. #1287 — practice mode WANTS the follow
+        // while TTS narrates, so leave it on; only the user's-turn pause
+        // suspends it (the dialogue-centering effect repositions instead).
+        if (teleprompterEnabled && teleprompterMode == TeleprompterMode.AutoScroll) return@LaunchedEffect
+        if (practiceTurn != null) return@LaunchedEffect
         val layout = textLayout ?: return@LaunchedEffect
         if (chapterText.isEmpty()) return@LaunchedEffect
         if (viewportHeightPx <= 0f) return@LaunchedEffect
@@ -414,8 +444,10 @@ fun ReaderTextView(
     // "peek then carry on". Frame-rate independent via withFrameNanos +
     // elapsed nanos; the sub-pixel remainder is carried so slow paces still
     // creep smoothly.
-    LaunchedEffect(teleprompterEnabled, teleprompterPlaying, teleprompterWpm, totalWords) {
-        if (!teleprompterEnabled || !teleprompterPlaying || totalWords <= 0) return@LaunchedEffect
+    LaunchedEffect(teleprompterEnabled, teleprompterMode, teleprompterPlaying, teleprompterWpm, totalWords) {
+        if (!teleprompterEnabled || teleprompterMode != TeleprompterMode.AutoScroll ||
+            !teleprompterPlaying || totalWords <= 0
+        ) return@LaunchedEffect
         var lastFrame = 0L
         var carry = 0f
         while (isActive) {
@@ -448,6 +480,40 @@ fun ReaderTextView(
             }
             lastFrame = frame
         }
+    }
+
+    // Issue #1287 — practice mode turn-taking. While practice mode narrates,
+    // watch the playhead; when it crosses into a dialogue segment, pause TTS
+    // and hand that line to the user ("your turn"). Continue seeks past the
+    // line (see the transport), so the playhead lands in the following
+    // narration and the same line never re-triggers.
+    LaunchedEffect(teleprompterEnabled, teleprompterMode, practiceTurn, practiceResumeFrom, state.isPlaying, state.sentenceStart, segments) {
+        if (!teleprompterEnabled || teleprompterMode != TeleprompterMode.Practice) return@LaunchedEffect
+        if (practiceTurn != null || !state.isPlaying) return@LaunchedEffect
+        val dialogue = dialogueAt(segments, state.sentenceStart) ?: return@LaunchedEffect
+        // Skip a line we just handed off and sought past — the playhead can
+        // transiently still report the old dialogue right after seek+resume.
+        if (dialogue.start < practiceResumeFrom) return@LaunchedEffect
+        practiceTurn = dialogue // the user's turn for this line
+        onPlayPause()           // state.isPlaying is true here, so this pauses TTS
+    }
+
+    // Issue #1287 — on the user's turn, centre the dialogue line they should
+    // read aloud (reuses the Focused-Reading centring math). The sentence-
+    // follow is suspended while practiceTurn != null, so this won't fight it.
+    LaunchedEffect(practiceTurn, textLayout, viewportHeightPx, bodyTopPx) {
+        val turn = practiceTurn ?: return@LaunchedEffect
+        val layout = textLayout ?: return@LaunchedEffect
+        if (viewportHeightPx <= 0f || chapterText.isEmpty()) return@LaunchedEffect
+        val safeStart = turn.start.coerceIn(0, (chapterText.length - 1).coerceAtLeast(0))
+        val targetY = focusScrollTargetY(
+            bodyTopPx = bodyTopPx,
+            lineTopWithinText = layout.getLineTop(layout.getLineForOffset(safeStart)),
+            viewportHeightPx = viewportHeightPx,
+            viewportFraction = FOCUS_VIEWPORT_FRACTION,
+            maxScroll = scroll.maxValue,
+        )
+        scroll.animateScrollTo(targetY)
     }
 
     // Issue #919 — "scroll to current sentence" FAB. Derived state tracks
@@ -983,36 +1049,74 @@ fun ReaderTextView(
             }
         }
 
-        // Issue #1239 — Teleprompter transport. Replaces the normal bottom
-        // bar while rehearsal mode is on: Play/Pause for the auto-scroll,
-        // WPM −/+, and an exit. Brass surface mirroring the normal bar.
+        // Issue #1239/#1287 — Teleprompter bottom chrome: a mode selector
+        // (Auto-scroll / Practice) above the mode-specific transport,
+        // replacing the normal bottom bar while teleprompter is on.
         if (teleprompterEnabled) {
-            TeleprompterTransport(
-                playing = teleprompterPlaying,
-                wpm = teleprompterWpm,
-                onPlayPause = {
-                    if (teleprompterAtEnd && !teleprompterPlaying) {
-                        // Replay from the top — scroll home, then arm so the
-                        // per-frame effect starts from a fresh position.
-                        scope.launch {
-                            scroll.scrollTo(0)
-                            teleprompterPlaying = true
+            Column(modifier = Modifier.align(Alignment.BottomCenter).fillMaxWidth()) {
+                TeleprompterModeChips(
+                    mode = teleprompterMode,
+                    onSelect = { picked ->
+                        if (picked != teleprompterMode) {
+                            teleprompterMode = picked
+                            teleprompterPlaying = false // stop the silent auto-scroll
+                            practiceTurn = null
+                            if (state.isPlaying) onPlayPause() // pause TTS across a swap
                         }
-                    } else {
-                        teleprompterPlaying = !teleprompterPlaying
-                    }
-                },
-                onWpmDelta = { steps ->
-                    teleprompterWpm = adjustTeleprompterWpm(teleprompterWpm, steps)
-                    // #1287 — write the new pace through so it survives a restart.
-                    onTeleprompterWpmChange(teleprompterWpm)
-                },
-                onExit = {
-                    teleprompterPlaying = false
-                    teleprompterEnabled = false
-                },
-                modifier = Modifier.align(Alignment.BottomCenter),
-            )
+                    },
+                )
+                when (teleprompterMode) {
+                    TeleprompterMode.AutoScroll -> TeleprompterTransport(
+                        playing = teleprompterPlaying,
+                        wpm = teleprompterWpm,
+                        onPlayPause = {
+                            if (teleprompterAtEnd && !teleprompterPlaying) {
+                                // Replay from the top — scroll home, then arm
+                                // so the per-frame effect starts fresh.
+                                scope.launch {
+                                    scroll.scrollTo(0)
+                                    teleprompterPlaying = true
+                                }
+                            } else {
+                                teleprompterPlaying = !teleprompterPlaying
+                            }
+                        },
+                        onWpmDelta = { steps ->
+                            teleprompterWpm = adjustTeleprompterWpm(teleprompterWpm, steps)
+                            // #1287/#1304 — persist the pace so it survives a restart.
+                            onTeleprompterWpmChange(teleprompterWpm)
+                        },
+                        onExit = {
+                            teleprompterPlaying = false
+                            teleprompterEnabled = false
+                        },
+                    )
+                    TeleprompterMode.Practice -> PracticeTransport(
+                        playing = state.isPlaying,
+                        turn = practiceTurn,
+                        onPlayPause = onPlayPause,
+                        onContinue = {
+                            val t = practiceTurn
+                            practiceTurn = null
+                            // Seek past the line the user just voiced, then
+                            // resume narration — TTS never reads it back. Record
+                            // the resume point so the turn-taking effect won't
+                            // re-fire on this same line during the seek lag.
+                            if (t != null) {
+                                val resume = resumeOffsetAfter(t).coerceIn(0, chapterText.length)
+                                practiceResumeFrom = resume
+                                onSeekToChar(resume)
+                            }
+                            if (!state.isPlaying) onPlayPause()
+                        },
+                        onExit = {
+                            practiceTurn = null
+                            if (state.isPlaying) onPlayPause() // stop TTS on exit
+                            teleprompterEnabled = false
+                        },
+                    )
+                }
+            }
         }
 
         // Issue #1230 — tap-to-define popup. Long-press a word (a no-drag
@@ -1189,6 +1293,134 @@ private fun TeleprompterTransport(
                     imageVector = if (playing) Icons.Filled.Pause else Icons.Filled.PlayArrow,
                     contentDescription = if (playing) "Pause rehearsal" else "Start rehearsal",
                 )
+            }
+        }
+    }
+}
+
+/**
+ * Issue #1287 — teleprompter mode selector (Auto-scroll / Practice). Two
+ * chips above the mode-specific transport; selecting Practice swaps to the
+ * TTS-paced "pause-for-me" flow.
+ */
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+private fun TeleprompterModeChips(
+    mode: TeleprompterMode,
+    onSelect: (TeleprompterMode) -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    val spacing = LocalSpacing.current
+    Surface(
+        modifier = modifier.fillMaxWidth(),
+        color = MaterialTheme.colorScheme.surfaceContainerHigh,
+    ) {
+        Row(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(horizontal = spacing.sm, vertical = spacing.xs),
+            horizontalArrangement = Arrangement.spacedBy(spacing.sm, Alignment.CenterHorizontally),
+            verticalAlignment = Alignment.CenterVertically,
+        ) {
+            FilterChip(
+                selected = mode == TeleprompterMode.AutoScroll,
+                onClick = { onSelect(TeleprompterMode.AutoScroll) },
+                label = { Text(stringResource(R.string.reader_teleprompter_autoscroll)) },
+            )
+            FilterChip(
+                selected = mode == TeleprompterMode.Practice,
+                onClick = { onSelect(TeleprompterMode.Practice) },
+                label = { Text(stringResource(R.string.reader_practice)) },
+            )
+        }
+    }
+}
+
+/**
+ * Issue #1287 — practice / "pause-for-me" transport. While narration plays
+ * it shows a play/pause for the TTS; when the playhead hits dialogue ([turn]
+ * non-null) it becomes the user's turn — a "Your turn" cue (+ speaker if
+ * known) and a Continue button that seeks past the line and resumes. Pure
+ * presentational; all state hoisted to [ReaderTextView].
+ */
+@Composable
+private fun PracticeTransport(
+    playing: Boolean,
+    turn: TextSegment?,
+    onPlayPause: () -> Unit,
+    onContinue: () -> Unit,
+    onExit: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    val spacing = LocalSpacing.current
+    Surface(
+        modifier = modifier.fillMaxWidth(),
+        color = MaterialTheme.colorScheme.surfaceContainerHigh,
+        shadowElevation = 4.dp,
+    ) {
+        Row(
+            modifier = Modifier.fillMaxWidth().padding(spacing.sm),
+            verticalAlignment = Alignment.CenterVertically,
+        ) {
+            IconButton(
+                onClick = onExit,
+                modifier = Modifier.semantics { contentDescription = "Exit practice mode" },
+            ) {
+                Icon(imageVector = Icons.Filled.Close, contentDescription = null)
+            }
+            Spacer(modifier = Modifier.weight(1f))
+            if (turn != null) {
+                Row(
+                    verticalAlignment = Alignment.CenterVertically,
+                    horizontalArrangement = Arrangement.spacedBy(spacing.xs),
+                    modifier = Modifier.semantics(mergeDescendants = true) {
+                        liveRegion = LiveRegionMode.Polite
+                    },
+                ) {
+                    Icon(
+                        imageVector = Icons.Outlined.RecordVoiceOver,
+                        contentDescription = null,
+                        tint = MaterialTheme.colorScheme.primary,
+                    )
+                    Column {
+                        Text(
+                            text = stringResource(R.string.reader_practice_your_turn),
+                            style = MaterialTheme.typography.titleSmall,
+                            color = MaterialTheme.colorScheme.primary,
+                        )
+                        Text(
+                            text = turn.speaker ?: stringResource(R.string.reader_practice_read_aloud),
+                            style = MaterialTheme.typography.bodySmall,
+                            color = MaterialTheme.colorScheme.onSurfaceVariant,
+                        )
+                    }
+                }
+                Spacer(modifier = Modifier.weight(1f))
+                Button(onClick = onContinue) {
+                    Text(stringResource(R.string.reader_practice_continue))
+                }
+            } else {
+                Text(
+                    text = stringResource(
+                        if (playing) R.string.reader_practice_narrating else R.string.reader_practice_tap_play,
+                    ),
+                    style = MaterialTheme.typography.bodyMedium,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                )
+                Spacer(modifier = Modifier.weight(1f))
+                FilledIconButton(
+                    onClick = onPlayPause,
+                    modifier = Modifier.size(48.dp),
+                    colors = IconButtonDefaults.filledIconButtonColors(
+                        containerColor = MaterialTheme.colorScheme.primary,
+                        contentColor = MaterialTheme.colorScheme.onPrimary,
+                    ),
+                ) {
+                    Icon(
+                        imageVector = if (playing) Icons.Filled.Pause else Icons.Filled.PlayArrow,
+                        contentDescription = if (playing) "Pause narration" else "Start narration",
+                    )
+                }
             }
         }
     }

--- a/feature/src/main/res/values/strings.xml
+++ b/feature/src/main/res/values/strings.xml
@@ -147,6 +147,14 @@
     <string name="reader_cancel">Cancel</string>
     <!-- Reader / teleprompter rehearsal mode (#1239) -->
     <string name="reader_teleprompter_wpm_unit">words/min</string>
+    <!-- Reader / practice "pause-for-me" mode (#1287) -->
+    <string name="reader_teleprompter_autoscroll">Auto-scroll</string>
+    <string name="reader_practice">Practice</string>
+    <string name="reader_practice_your_turn">Your turn</string>
+    <string name="reader_practice_read_aloud">Read the dialogue aloud</string>
+    <string name="reader_practice_continue">Continue</string>
+    <string name="reader_practice_narrating">Reading narration…</string>
+    <string name="reader_practice_tap_play">Practice — tap play to begin</string>
     <!-- Reader / tap-to-define dictionary (#1230) -->
     <string name="reader_define_loading">Looking up \"%1$s\"…</string>
     <string name="reader_define_empty">No dictionary entry for \"%1$s\".</string>

--- a/feature/src/test/kotlin/in/jphe/storyvox/feature/reader/DialogueSegmenterTest.kt
+++ b/feature/src/test/kotlin/in/jphe/storyvox/feature/reader/DialogueSegmenterTest.kt
@@ -1,0 +1,161 @@
+package `in`.jphe.storyvox.feature.reader
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * Issue #1287 — practice mode. Pins the narration/dialogue split that the
+ * turn-taking flow relies on. Pure JVM (no Compose/Android), per the
+ * project's testing convention for extracted logic.
+ *
+ * Assertions reconstruct each segment's substring (`text.substring(start,
+ * end)`) rather than hand-computing offsets — readable and offset-bug-proof
+ * — and check the tiling invariant (segments cover the whole string with no
+ * gaps/overlaps).
+ */
+class DialogueSegmenterTest {
+
+    private fun parts(text: String) =
+        segmentDialogue(text).map { text.substring(it.start, it.end) }
+
+    private fun kinds(text: String) = segmentDialogue(text).map { it.kind }
+
+    /** Every segment list must tile [text] exactly: start at 0, end at length,
+     *  each segment starts where the previous ended. */
+    private fun assertTiles(text: String) {
+        val segs = segmentDialogue(text)
+        if (text.isEmpty()) {
+            assertTrue(segs.isEmpty()); return
+        }
+        assertEquals(0, segs.first().start)
+        assertEquals(text.length, segs.last().end)
+        for (i in 1 until segs.size) assertEquals(segs[i - 1].end, segs[i].start)
+        assertEquals(text, segs.joinToString("") { text.substring(it.start, it.end) })
+    }
+
+    @Test
+    fun `empty text yields no segments`() {
+        assertEquals(emptyList<TextSegment>(), segmentDialogue(""))
+    }
+
+    @Test
+    fun `plain narration is a single narration segment`() {
+        val t = "He walked into the room and sat down."
+        assertEquals(listOf(SegmentKind.Narration), kinds(t))
+        assertEquals(listOf(t), parts(t))
+    }
+
+    @Test
+    fun `leading dialogue then narration`() {
+        val t = "\"Hello,\" he said."
+        assertEquals(listOf(SegmentKind.Dialogue, SegmentKind.Narration), kinds(t))
+        assertEquals(listOf("\"Hello,\"", " he said."), parts(t))
+        assertTiles(t)
+    }
+
+    @Test
+    fun `narration wrapping dialogue`() {
+        val t = "He turned. \"Wait!\" she cried."
+        assertEquals(
+            listOf(SegmentKind.Narration, SegmentKind.Dialogue, SegmentKind.Narration),
+            kinds(t),
+        )
+        assertEquals(listOf("He turned. ", "\"Wait!\"", " she cried."), parts(t))
+        assertTiles(t)
+    }
+
+    @Test
+    fun `apostrophes inside dialogue do not split it`() {
+        // The ' in don't / it's is an apostrophe, never a delimiter — the
+        // whole quote stays one dialogue segment.
+        val t = "\"I don't know, it's complicated.\""
+        assertEquals(listOf(SegmentKind.Dialogue), kinds(t))
+        assertEquals(listOf(t), parts(t))
+    }
+
+    @Test
+    fun `curly quotes are detected`() {
+        val t = "“Hi,” said Tom."
+        assertEquals(listOf(SegmentKind.Dialogue, SegmentKind.Narration), kinds(t))
+        assertEquals(listOf("“Hi,”", " said Tom."), parts(t))
+        assertTiles(t)
+    }
+
+    @Test
+    fun `unbalanced opening quote runs to end as dialogue`() {
+        val t = "She paused. \"This was never closed"
+        assertEquals(listOf(SegmentKind.Narration, SegmentKind.Dialogue), kinds(t))
+        assertEquals(listOf("She paused. ", "\"This was never closed"), parts(t))
+        assertTiles(t)
+    }
+
+    @Test
+    fun `two back-to-back exchanges tile cleanly`() {
+        val t = "\"Hi.\" \"Bye.\" they chorused."
+        assertTiles(t)
+        assertEquals(
+            listOf(SegmentKind.Dialogue, SegmentKind.Narration, SegmentKind.Dialogue, SegmentKind.Narration),
+            kinds(t),
+        )
+    }
+
+    // ===== speaker attribution (best-effort) =====
+
+    private fun firstDialogueSpeaker(text: String) =
+        segmentDialogue(text).first { it.kind == SegmentKind.Dialogue }.speaker
+
+    @Test
+    fun `attributes speaker after the quote`() {
+        assertEquals("Harry", firstDialogueSpeaker("\"Hello there,\" said Harry."))
+    }
+
+    @Test
+    fun `attributes speaker before the quote`() {
+        assertEquals("Hermione", firstDialogueSpeaker("Hermione asked, \"Why?\""))
+    }
+
+    @Test
+    fun `pronoun is not mistaken for a name`() {
+        // "She said" is capitalised at sentence start but isn't a name.
+        assertNull(firstDialogueSpeaker("\"Run!\" She said quietly."))
+        // lowercase pronoun also yields no name.
+        assertNull(firstDialogueSpeaker("\"Hi,\" he said."))
+    }
+
+    // ===== turn-taking decision logic =====
+
+    private val turnText = "He turned. \"Wait!\" she cried. \"Stop,\" he added."
+
+    @Test
+    fun `dialogueAt finds the segment the playhead is inside`() {
+        val segs = segmentDialogue(turnText)
+        val firstDlg = segs.first { it.kind == SegmentKind.Dialogue }
+        // Inside the dialogue run → it's the user's turn for that segment.
+        assertEquals(firstDlg, dialogueAt(segs, firstDlg.start))
+        assertEquals(firstDlg, dialogueAt(segs, firstDlg.start + 1))
+        // In narration → null (TTS keeps reading).
+        assertNull(dialogueAt(segs, 0))
+        // The exclusive end belongs to the following narration, not the run.
+        assertNull(dialogueAt(segs, firstDlg.end))
+    }
+
+    @Test
+    fun `nextDialogueAtOrAfter walks to the upcoming hand-off`() {
+        val segs = segmentDialogue(turnText)
+        val dialogues = segs.filter { it.kind == SegmentKind.Dialogue }
+        assertEquals(dialogues[0], nextDialogueAtOrAfter(segs, 0))
+        // From the end of the first dialogue, the next pause is the 2nd line.
+        assertEquals(dialogues[1], nextDialogueAtOrAfter(segs, dialogues[0].end))
+        // Past all dialogue → none (narrate to the end).
+        assertNull(nextDialogueAtOrAfter(segs, turnText.length))
+    }
+
+    @Test
+    fun `resumeOffsetAfter is the end of the dialogue run`() {
+        val segs = segmentDialogue(turnText)
+        val firstDlg = segs.first { it.kind == SegmentKind.Dialogue }
+        assertEquals(firstDlg.end, resumeOffsetAfter(firstDlg))
+    }
+}


### PR DESCRIPTION
## What

Implements #1287 — the **practice / "pause-for-me" rehearsal mode**, Lucid's mission-aligned differentiator from the #1239 research. TTS reads the narration and **pauses at each line of dialogue for the user to voice the character** (tap to continue). For people practicing reading aloud, language learners, and actors running lines. Honor-system, **no microphone** in v1.

It lands as the **3rd teleprompter mode**, alongside #1286's manual-WPM auto-scroll (now on main).

## How it works

**Pure core** (`DialogueSegmenter.kt`, first commit — fully unit-tested):
- `segmentDialogue()` tiles chapter text into narration/dialogue segments. **Double-quote-only** detection (straight `"` toggles, curly `“…”` unambiguous) so apostrophes in contractions never falsely flip "inside dialogue".
- `guessSpeaker()` — best-effort attribution from adjacent narration (`"…," said Harry`), pronoun-aware, null when unsure.
- `dialogueAt` / `nextDialogueAtOrAfter` / `resumeOffsetAfter` — the turn-taking decision helpers.

**Integration** (`ReaderView.kt`, second commit):
- `TeleprompterMode { AutoScroll, Practice }` + a FilterChip selector above the transport.
- **Turn-taking effect**: while narration plays (with the existing #946 sentence-follow scroll), a `LaunchedEffect` watches the playhead (`UiPlaybackState.sentenceStart`); when it enters a dialogue segment it pauses TTS and shows **"Your turn" (+ speaker)** in the new `PracticeTransport`. **Continue** seeks past the line (`onSeekToChar(resumeOffsetAfter)`) and resumes — the synth never reads the line the user just voiced.
- A `practiceResumeFrom` watermark prevents the just-handled line re-triggering during the post-seek playhead lag.
- On the user's turn the dialogue line is **centred** (reuses `focusScrollTargetY`); the silent auto-scroll engine and the #946 follow are gated to the right mode so the two scroll drivers never fight.

## Scroll behavior (spec #4)
- Narration → #946 follow-scroll (playhead-tracked), as normal playback.
- User's turn → scroll centres the dialogue line; follow + auto-scroll suspended.
- Continue → resumes follow.

## Tests
`DialogueSegmenterTest` (JVM, no Compose): segmentation, apostrophe/curly/unbalanced edge cases, the tiling invariant, speaker attribution (incl. pronoun exclusion), and the turn-taking boundaries (`dialogueAt`/`nextDialogueAtOrAfter`/`resumeOffsetAfter`). The turn-taking *effect* and UI follow the reader's no-Compose-harness convention; their decision logic is the pure layer that's tested.

## Scope / deferred (tracked in #1287)
Honor-system tap-to-continue v1. Deferred: on-device **ASR-gated advance** (auto-detect when the user finishes speaking), per-segment **emotion**, and the cross-book/age work. No mic permission added.

## Notes
- Rebased onto main after #1286 landed — clean (new files + teleprompter region only).
- Touches the teleprompter region of `ReaderView.kt`; if Selene's WPM-persistence PR also did, a trivial rebase may be needed — flag me on merge order.
- No local compile (project rule); CI's Test Compile + Build APK are the gate.

h/t **Lucid** (research) and the #1286 teleprompter scaffolding this builds on.

Closes #1287

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new teleprompter practice mode for dialogue reading, alongside auto-scroll.
  * Reader playback can now pause on dialogue, show a “your turn” prompt, and continue after the line is read.
  * Added dialogue/narration splitting support with optional speaker attribution for improved turn-taking.

* **Bug Fixes**
  * Improved handling of quotes and apostrophes so dialogue boundaries are detected more reliably.
  * Added support for unbalanced and curly quotes without breaking text flow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->