### PR TITLE
fix(library): epub import — route prefixed fictionIds to their source when no row exists (#1298)

### DIFF
--- a/core-data/src/main/kotlin/in/jphe/storyvox/data/repository/FictionRepository.kt
+++ b/core-data/src/main/kotlin/in/jphe/storyvox/data/repository/FictionRepository.kt
@@ -292,12 +292,13 @@ class FictionRepositoryImpl @Inject constructor(
     ): FictionResult<ListPage<FictionSummary>> = cacheListing(result)
 
     override suspend fun refreshDetail(id: String): FictionResult<Unit> = withContext(Dispatchers.IO) {
-        // Look up the persisted row to route to the correct source. Falls
-        // back to the default source when the row is absent (first-add flow:
-        // addToLibrary → refreshDetail before the row exists). Future
-        // multi-source addByUrl pre-writes a stub row with sourceId so this
-        // path always finds it.
-        val src = sourceFor(fictionDao.get(id)?.sourceId ?: SourceIds.ROYAL_ROAD)
+        // Look up the persisted row to route to the correct source. When the
+        // row is absent — the EPUB/PDF import flows navigate straight to
+        // FictionDetail before any row is written (#1298) — derive the source
+        // from the fictionId's `<sourceId>:` prefix; bare-id sources (Royal
+        // Road) fall back to the legacy default. A successful hydrate below
+        // then writes the row, so subsequent loads route off the row.
+        val src = sourceFor(fictionDao.get(id)?.sourceId ?: sourceIdForFictionId(id, sources.keys))
         when (val result = src.fictionDetail(id)) {
             is FictionResult.Success -> {
                 upsertDetail(result.value)
@@ -404,7 +405,7 @@ class FictionRepositoryImpl @Inject constructor(
 
     override suspend fun setFollowedRemote(id: String, followed: Boolean): FictionResult<Unit> =
         withContext(Dispatchers.IO) {
-            val src = sourceFor(fictionDao.get(id)?.sourceId ?: SourceIds.ROYAL_ROAD)
+            val src = sourceFor(fictionDao.get(id)?.sourceId ?: sourceIdForFictionId(id, sources.keys))
             when (val r = src.setFollowed(id, followed)) {
                 is FictionResult.Success -> {
                     fictionDao.setFollowedRemote(id, followed)
@@ -693,6 +694,25 @@ internal fun FictionDetail.toEntity(existing: Fiction?, now: Long): Fiction {
  *  catching it here rather than asking every source to opt in keeps the
  *  guard durable.
  */
+/**
+ * Issue #1298 — derive the backing source for a fictionId that has no
+ * persisted row yet. Most sources prefix their ids with `<sourceId>:`
+ * (`epub:`, `pdf:`, `gutenberg:`, `ao3:`, `ocr:`, `readability:`, …); Royal
+ * Road uses bare numeric ids. Returns the prefix when it names a
+ * currently-bound source, else falls back to [SourceIds.ROYAL_ROAD] — never
+ * an unbound prefix, since [FictionRepositoryImpl.sourceFor] errors on an
+ * unknown source id.
+ *
+ * Why this exists: the EPUB/PDF import flows (Open-With #1000 and the in-app
+ * picker #1228) navigate straight to FictionDetail, so `refreshDetail` runs
+ * before any row is written. Defaulting to Royal Road there sent
+ * `epub:<hash>` to RoyalRoadSource → "Fiction epub:<hash> not found".
+ */
+internal fun sourceIdForFictionId(id: String, boundSourceIds: Set<String>): String =
+    id.substringBefore(':', missingDelimiterValue = "")
+        .takeIf { it.isNotEmpty() && it in boundSourceIds }
+        ?: SourceIds.ROYAL_ROAD
+
 internal fun preferTitle(incoming: String, existing: String, sourceFallback: String?): String {
     if (incoming.isBlank()) return existing.ifBlank { incoming }
     if (existing.isBlank()) return incoming

--- a/core-data/src/test/kotlin/in/jphe/storyvox/data/repository/SourceIdForFictionIdTest.kt
+++ b/core-data/src/test/kotlin/in/jphe/storyvox/data/repository/SourceIdForFictionIdTest.kt
@@ -1,0 +1,64 @@
+package `in`.jphe.storyvox.data.repository
+
+import `in`.jphe.storyvox.data.source.SourceIds
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+/**
+ * Issue #1298 — source routing for a fictionId with no persisted row yet.
+ *
+ * Regression: importing an EPUB (or PDF) and opening it navigates straight
+ * to FictionDetail before any row is written, so `refreshDetail` resolved
+ * the source from the absent row and defaulted to Royal Road — sending
+ * `epub:<hash>` to RoyalRoadSource, which answered "Fiction epub:<hash> not
+ * found". The fix derives the source from the id's `<sourceId>:` prefix.
+ */
+class SourceIdForFictionIdTest {
+
+    private val bound = setOf(
+        SourceIds.ROYAL_ROAD, SourceIds.EPUB, SourceIds.PDF,
+        SourceIds.AO3, SourceIds.GUTENBERG, SourceIds.OCR,
+    )
+
+    @Test
+    fun epubImportId_routesToEpub_notRoyalRoad() {
+        // The exact #1298 repro (id from the bug screenshot shape).
+        assertEquals(SourceIds.EPUB, sourceIdForFictionId("epub:9469520f", bound))
+    }
+
+    @Test
+    fun pdfImportId_routesToPdf() {
+        assertEquals(SourceIds.PDF, sourceIdForFictionId("pdf:abc12345", bound))
+    }
+
+    @Test
+    fun bareNumericId_routesToRoyalRoad() {
+        // Royal Road uses bare numeric ids (no prefix) — unchanged.
+        assertEquals(SourceIds.ROYAL_ROAD, sourceIdForFictionId("123456", bound))
+    }
+
+    @Test
+    fun otherPrefixedSources_routeToTheirSource() {
+        assertEquals(SourceIds.AO3, sourceIdForFictionId("ao3:42", bound))
+        assertEquals(SourceIds.GUTENBERG, sourceIdForFictionId("gutenberg:84", bound))
+        assertEquals(SourceIds.OCR, sourceIdForFictionId("ocr:deadbeef", bound))
+    }
+
+    @Test
+    fun multiColonId_usesFirstSegment() {
+        // EPUB direct-download variant is `epub:url:<hash>`.
+        assertEquals(SourceIds.EPUB, sourceIdForFictionId("epub:url:deadbeef", bound))
+    }
+
+    @Test
+    fun unboundPrefix_fallsBackToRoyalRoad() {
+        // Must NOT return a prefix that isn't bound — sourceFor() errors on
+        // an unknown source id. Fall back to Royal Road instead.
+        assertEquals(SourceIds.ROYAL_ROAD, sourceIdForFictionId("mystery:1", bound))
+    }
+
+    @Test
+    fun emptyId_routesToRoyalRoad() {
+        assertEquals(SourceIds.ROYAL_ROAD, sourceIdForFictionId("", bound))
+    }
+}


### PR DESCRIPTION
## Closes #1298 — "import of epub did not work"

JP's screenshot showed the FictionDetail error: **"Couldn't load this fiction — Fiction `epub:9469520f` not found"** after importing an EPUB.

## Root cause (systematic-debugging)

The displayed message is `RoyalRoadSource`'s `NotFound("Fiction $fictionId not found")` — **not** `EpubSource`'s own miss (which reads `"EPUB not indexed: …"`). So the `epub:` id was being **routed to Royal Road**.

`FictionRepository` resolves a fictionId's source from its persisted Room row's `sourceId`, and **defaults to Royal Road when the row is absent** (`FictionRepository.kt:300/407`). The EPUB/PDF **import flows** (Open-With #1000, in-app picker #1228) navigate **straight to FictionDetail before any row is written**, so `refreshDetail` ran row-less → defaulted to Royal Road → `RoyalRoadSource.fictionDetail("epub:9469520f")` → not found.

The file *was* imported and persisted (the RR-sourced message proves it; EpubSource would have said "EPUB not indexed" if the entry were actually missing) — it was just sent to the wrong source.

## Fix

When no row exists, derive the source from the fictionId's `<sourceId>:` prefix (`epub:`, `pdf:`, `gutenberg:`, `ao3:`, `ocr:`, `readability:`, …), validated against the **bound** source set; bare-numeric ids (Royal Road) keep the legacy default:

```kotlin
internal fun sourceIdForFictionId(id: String, boundSourceIds: Set<String>): String =
    id.substringBefore(':', missingDelimiterValue = "")
        .takeIf { it.isNotEmpty() && it in boundSourceIds }
        ?: SourceIds.ROYAL_ROAD
```

A successful hydrate then writes the Room row, so later loads route off the row exactly as before. Applied at both row-absent default sites (`refreshDetail` + `setFollowedRemote`). It **never** returns an unbound prefix — `sourceFor()` errors on an unknown source id, so the validation against `sources.keys` is load-bearing.

**General fix:** any prefixed-source fiction opened before its row exists now routes correctly — not just EPUB. (This was a latent bug the prominent in-app import button #1228 made easy to hit.)

## Test
`SourceIdForFictionIdTest` (pure JUnit) — the exact `epub:9469520f` repro routes to EPUB; `pdf:`/`ao3:`/`gutenberg:`/`ocr:` route to their sources; bare-numeric, unbound-prefix, and empty all fall back to Royal Road (never an unbound id). Not compiled locally — CI is the gate.

## Risk
Low + additive: only the **row-absent** fallback changes (was "always Royal Road" → "prefix-derived, else Royal Road"). Row-present routing is untouched; bare-numeric (Royal Road) row-less ids are unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
