### PR TITLE
feat(source-google-news): full-article text via batchexecute decode + Readability (#1295)

### DIFF
--- a/app/src/main/kotlin/in/jphe/storyvox/data/SettingsRepositoryUiImpl.kt
+++ b/app/src/main/kotlin/in/jphe/storyvox/data/SettingsRepositoryUiImpl.kt
@@ -47,6 +47,7 @@ import `in`.jphe.storyvox.feature.api.UiParticleIntensity
 import `in`.jphe.storyvox.feature.api.UiSkeletonStyle
 import `in`.jphe.storyvox.data.repository.net.NetworkPatience
 import `in`.jphe.storyvox.data.repository.net.NetworkPatienceConfig
+import `in`.jphe.storyvox.data.repository.GoogleNewsConfig
 import `in`.jphe.storyvox.data.repository.playback.AutoBrowserConfig
 import `in`.jphe.storyvox.data.repository.playback.PrerenderChapterCountConfig
 import `in`.jphe.storyvox.data.repository.playback.SleepTimerDndConfig
@@ -524,6 +525,11 @@ private object Keys {
      *  StoryvoxAutoBrowserService. */
     val AUTO_ITEMS_PER_CATEGORY =
         intPreferencesKey("pref_auto_items_per_category_v1")
+
+    /** Issue #1295 — opt-in for Google News full-article-text extraction
+     *  (ToS-gray + fragile, so default OFF). Per-device, not synced. */
+    val GOOGLE_NEWS_FULL_TEXT =
+        booleanPreferencesKey("pref_google_news_full_text_v1")
 
     // ── AI / LLM (issue #81) ────────────────────────────────────────
     /** Active provider — stored as the [ProviderId] enum's name.
@@ -1119,6 +1125,7 @@ class SettingsRepositoryUiImpl(
     `in`.jphe.storyvox.data.repository.playback.BedtimeSleepConfig,
     PrerenderChapterCountConfig,
     AutoBrowserConfig,
+    GoogleNewsConfig,
     NetworkPatienceConfig,
     PronunciationDictRepository,
     LlmConfigProvider,
@@ -1569,6 +1576,8 @@ class SettingsRepositoryUiImpl(
             autoItemsPerCategory = snapAutoItemsPerCategory(
                 prefs[Keys.AUTO_ITEMS_PER_CATEGORY] ?: 6,
             ),
+            // Issue #1295 — Google News full-article-text opt-in (default OFF).
+            googleNewsFullArticleText = prefs[Keys.GOOGLE_NEWS_FULL_TEXT] ?: false,
             // Issue #993 — reading-theme. Unknown enum strings fall back to
             // Default; custom fg/bg are raw ARGB ints (0 = unset). The
             // UiSettings.readerColors accessor resolves these into the
@@ -1863,6 +1872,15 @@ class SettingsRepositoryUiImpl(
     }
 
     override suspend fun currentItemsPerCategory(): Int = itemsPerCategory.first()
+
+    // --- GoogleNewsConfig (issue #1295, consumed by :source-google-news's
+    //     GoogleNewsArticleResolver) ---
+
+    override val fullArticleTextEnabled: Flow<Boolean> = store.data.map { prefs ->
+        prefs[Keys.GOOGLE_NEWS_FULL_TEXT] ?: false
+    }
+
+    override suspend fun isFullArticleTextEnabled(): Boolean = fullArticleTextEnabled.first()
 
     // --- NetworkPatienceConfig (issue #597, consumed by source-* OkHttp
     //     module builders) ---
@@ -2650,6 +2668,12 @@ class SettingsRepositoryUiImpl(
     override suspend fun setNetworkPatience(patience: UiNetworkPatience) {
         store.edit { it[Keys.NETWORK_PATIENCE] = patience.name }
         stampSyncedWrite()
+    }
+
+    /** Issue #1295 — toggle Google News full-article-text extraction.
+     *  Per-device, not synced (the ToS-gray decode is a local choice). */
+    override suspend fun setGoogleNewsFullArticleText(enabled: Boolean) {
+        store.edit { it[Keys.GOOGLE_NEWS_FULL_TEXT] = enabled }
     }
 
     /** Issue #598 — Android Auto bucket size. Synced as of #916. */

--- a/app/src/main/kotlin/in/jphe/storyvox/di/AppBindings.kt
+++ b/app/src/main/kotlin/in/jphe/storyvox/di/AppBindings.kt
@@ -391,6 +391,12 @@ object AppBindings {
     fun provideAutoBrowserConfig(impl: SettingsRepositoryUiImpl):
         `in`.jphe.storyvox.data.repository.playback.AutoBrowserConfig = impl
 
+    /** Issue #1295 — Google News full-article-text opt-in. Same singleton;
+     *  consumed by `:source-google-news`'s `GoogleNewsArticleResolver`. */
+    @Provides @Singleton
+    fun provideGoogleNewsConfig(impl: SettingsRepositoryUiImpl):
+        `in`.jphe.storyvox.data.repository.GoogleNewsConfig = impl
+
     /** Issue #597 — user-tunable HTTP timeout preset. Same singleton;
      *  consumed by source-* modules' OkHttp factories via an
      *  Interceptor / timeout override. v1 wires this into the most-

--- a/core-data/src/main/kotlin/in/jphe/storyvox/data/repository/GoogleNewsConfig.kt
+++ b/core-data/src/main/kotlin/in/jphe/storyvox/data/repository/GoogleNewsConfig.kt
@@ -1,0 +1,25 @@
+package `in`.jphe.storyvox.data.repository
+
+import kotlinx.coroutines.flow.Flow
+
+/**
+ * Issue #1295 — gate for Google News full-article-text extraction.
+ *
+ * Resolving a story's real publisher URL goes through Google's internal
+ * `batchexecute` RPC, which is fragile (breaks on Google format changes) and
+ * ToS-gray (the feed restricts use to personal feed-reader rendering). So the
+ * behaviour is **opt-in, default OFF**: when disabled, the Google News source
+ * narrates its headline + related-coverage digest exactly as before.
+ *
+ * Implemented by the app's settings store (DataStore-backed) and consumed by
+ * `:source-google-news`'s article resolver — same shape as [playback.AutoBrowserConfig].
+ */
+interface GoogleNewsConfig {
+
+    /** Live flow of the opt-in flag. */
+    val fullArticleTextEnabled: Flow<Boolean>
+
+    /** Snapshot read; false until the store emits (safe default — never
+     *  performs the ToS-gray decode unless the user explicitly opted in). */
+    suspend fun isFullArticleTextEnabled(): Boolean
+}

--- a/feature/src/main/kotlin/in/jphe/storyvox/feature/api/UiContracts.kt
+++ b/feature/src/main/kotlin/in/jphe/storyvox/feature/api/UiContracts.kt
@@ -1361,6 +1361,12 @@ data class UiSettings(
      */
     val autoItemsPerCategory: Int = 6,
     /**
+     * Issue #1295 — opt-in for Google News full-article-text extraction.
+     * Default OFF (the publisher-URL decode is ToS-gray + fragile); when
+     * off, Google News narrates its headline + related-coverage digest.
+     */
+    val googleNewsFullArticleText: Boolean = false,
+    /**
      * Issue #993 — reading-theme (color overlay) for the chapter-reading
      * surface only, not app chrome. [ReaderTheme.Default] inherits the app
      * theme (the reader renders exactly as today). Presets cover sepia /
@@ -1877,6 +1883,11 @@ interface SettingsRepositoryUi {
      * [4, 6, 8, 12] on write. Default impl is a no-op.
      */
     suspend fun setAutoItemsPerCategory(count: Int) = Unit
+    /**
+     * Issue #1295 — toggle Google News full-article-text extraction.
+     * Default impl is a no-op (real impl persists to DataStore).
+     */
+    suspend fun setGoogleNewsFullArticleText(enabled: Boolean) = Unit
     /**
      * Issue #993 — set the reading-theme (color overlay) for the reader
      * surface. Device-local (NOT synced). Default impl is a no-op.

--- a/feature/src/main/kotlin/in/jphe/storyvox/feature/settings/SettingsScreen.kt
+++ b/feature/src/main/kotlin/in/jphe/storyvox/feature/settings/SettingsScreen.kt
@@ -640,6 +640,13 @@ fun SettingsScreen(
                 onApiTokenChange = viewModel::setTelegramApiToken,
                 onRefreshProbe = viewModel::refreshTelegramProbe,
             )
+            // #1295 — Google News full-article text (opt-in, default OFF).
+            SettingsSwitchRow(
+                title = stringResource(R.string.settings_google_news_full_text_title),
+                subtitle = stringResource(R.string.settings_google_news_full_text_subtitle),
+                checked = s.googleNewsFullArticleText,
+                onCheckedChange = viewModel::setGoogleNewsFullArticleText,
+            )
         }
 
         // ── Inbox notifications sub-card (#383) ────────────────────

--- a/feature/src/main/kotlin/in/jphe/storyvox/feature/settings/SettingsViewModel.kt
+++ b/feature/src/main/kotlin/in/jphe/storyvox/feature/settings/SettingsViewModel.kt
@@ -140,6 +140,9 @@ class SettingsViewModel @Inject constructor(
     fun setDefaultVoice(id: String?) = viewModelScope.launch { repo.setDefaultVoice(id) }
     fun setWifiOnly(enabled: Boolean) = viewModelScope.launch { repo.setDownloadOnWifiOnly(enabled) }
     fun setPollHours(h: Int) = viewModelScope.launch { repo.setPollIntervalHours(h) }
+    // #1295 — Google News full-article-text opt-in.
+    fun setGoogleNewsFullArticleText(enabled: Boolean) =
+        viewModelScope.launch { repo.setGoogleNewsFullArticleText(enabled) }
     /** Issue #109 — continuous inter-sentence pause multiplier (was a
      *  3-stop selector under #93). Repo coerces to the engine's [0..4]
      *  range; the slider in the screen passes a raw Float. */

--- a/feature/src/main/res/values/strings.xml
+++ b/feature/src/main/res/values/strings.xml
@@ -941,6 +941,9 @@
     <string name="settings_section_library_descriptor">Where stories come from and how often we check for updates.</string>
     <string name="settings_legacy_plugins_title">Plugins</string>
     <string name="settings_legacy_plugins_subtitle">Fiction sources, audio streams, and voice bundles.</string>
+    <!-- #1295 — Google News full-article text opt-in -->
+    <string name="settings_google_news_full_text_title">Google News: full article text</string>
+    <string name="settings_google_news_full_text_subtitle">Narrate the full publisher article instead of just the headline digest. Off by default — uses Google\'s internal endpoint (may break on their changes) and is intended for personal feed-reader use.</string>
 
     <!-- Settings · legacy Inbox notifications sub-card -->
     <string name="settings_inbox_royalroad_title">Inbox: Royal Road</string>

--- a/source-google-news/build.gradle.kts
+++ b/source-google-news/build.gradle.kts
@@ -27,9 +27,16 @@ kotlin {
 
 dependencies {
     implementation(project(":core-data"))
+    // #1295 — full-article text reuses Readability's fetch + boilerplate
+    // stripping rather than reimplementing extraction. One-way dep
+    // (:source-readability never references Google News) so no cycle.
+    implementation(project(":source-readability"))
 
     implementation(libs.kotlinx.coroutines.android)
     implementation(libs.okhttp)
+    // #1295 — parse the batchexecute JSON response (pure-JVM, so the
+    // decoder's parse step is unit-testable without Robolectric).
+    implementation(libs.kotlinx.serialization.json)
 
     implementation(libs.hilt.android)
     ksp(libs.hilt.compiler)

--- a/source-google-news/src/main/kotlin/in/jphe/storyvox/source/googlenews/article/ArticleResolver.kt
+++ b/source-google-news/src/main/kotlin/in/jphe/storyvox/source/googlenews/article/ArticleResolver.kt
@@ -1,36 +1,26 @@
 package `in`.jphe.storyvox.source.googlenews.article
 
 import `in`.jphe.storyvox.source.googlenews.parse.GoogleNewsItem
-import javax.inject.Inject
 
 /**
- * Issue #1238 — seam for (future) full-article text extraction.
+ * Issue #1238 / #1295 — seam for full-article text extraction.
  *
- * Google News obfuscates article URLs behind `CBMi…` redirects whose
- * real publisher URL can only be recovered via a fragile internal
- * `batchexecute` RPC (see the issue body for the live investigation).
- * v1 deliberately does NOT implement that decode — [NoOpArticleResolver]
- * returns null and [GoogleNewsSource][in.jphe.storyvox.source.googlenews.GoogleNewsSource]
- * falls back to a headline + publisher + related-coverage digest.
+ * Google News obfuscates article URLs behind `CBMi…` redirects whose real
+ * publisher URL can only be recovered via a fragile internal `batchexecute`
+ * RPC. [GoogleNewsArticleResolver] (issue #1295) implements that decode +
+ * `:source-readability` extraction; it is gated opt-in (default OFF) and
+ * returns null whenever the flag is off or any step fails, which signals
+ * [GoogleNewsSource][in.jphe.storyvox.source.googlenews.GoogleNewsSource]
+ * to fall back to its headline + publisher + related-coverage digest.
  *
- * When a future resolver can recover a publisher URL, it fetches the
- * page and hands the HTML to `:source-readability`'s `ReadabilityExtractor`,
- * returning the cleaned article text to prepend to the chapter body. That
- * decode + extraction is tracked as a follow-up issue; this interface is
- * the extension point so adding it later touches one binding, not the
- * source's control flow.
+ * Keeping this an interface means the resolver swaps behind a single Hilt
+ * binding without touching the source's control flow.
  */
 internal interface ArticleResolver {
 
     /**
-     * Resolved full-article plain text for [item], or null when the
-     * article body can't be recovered — the v1 default, which signals
-     * the source to use its digest fallback.
+     * Resolved full-article plain text for [item], or null when the article
+     * body can't be recovered — signals the source to use its digest fallback.
      */
     suspend fun resolve(item: GoogleNewsItem): String?
-}
-
-/** v1 no-op: the article body is never recoverable from the feed alone. */
-internal class NoOpArticleResolver @Inject constructor() : ArticleResolver {
-    override suspend fun resolve(item: GoogleNewsItem): String? = null
 }

--- a/source-google-news/src/main/kotlin/in/jphe/storyvox/source/googlenews/article/GoogleNewsArticleResolver.kt
+++ b/source-google-news/src/main/kotlin/in/jphe/storyvox/source/googlenews/article/GoogleNewsArticleResolver.kt
@@ -1,0 +1,43 @@
+package `in`.jphe.storyvox.source.googlenews.article
+
+import `in`.jphe.storyvox.data.repository.GoogleNewsConfig
+import `in`.jphe.storyvox.data.source.model.FictionResult
+import `in`.jphe.storyvox.source.googlenews.parse.GoogleNewsItem
+import `in`.jphe.storyvox.source.readability.extract.ReadabilityExtractor
+import `in`.jphe.storyvox.source.readability.net.ReadabilityFetcher
+import javax.inject.Inject
+
+/**
+ * Issue #1295 — the real [ArticleResolver]: recovers a story's full article
+ * text so the chapter narrates the body, not just the headline digest.
+ *
+ * Pipeline: opt-in gate → decode the `CBMi…` link to the publisher URL
+ * ([GoogleNewsUrlDecoder]) → fetch the page (`:source-readability`'s
+ * [ReadabilityFetcher]) → strip boilerplate ([ReadabilityExtractor]). **Every
+ * step degrades to null**, which signals [GoogleNewsSource][in.jphe.storyvox.source.googlenews.GoogleNewsSource]
+ * to use its always-available digest — a decode/fetch/extract failure must
+ * never produce a broken chapter (issue #1295 acceptance).
+ */
+internal class GoogleNewsArticleResolver @Inject constructor(
+    private val decoder: GoogleNewsUrlDecoder,
+    private val fetcher: ReadabilityFetcher,
+    private val extractor: ReadabilityExtractor,
+    private val config: GoogleNewsConfig,
+) : ArticleResolver {
+
+    override suspend fun resolve(item: GoogleNewsItem): String? {
+        // Opt-in gate (default OFF — ToS-gray + fragile).
+        if (!config.isFullArticleTextEnabled()) return null
+
+        val publisherUrl = decoder.decode(item.link) ?: return null
+
+        val html = when (val r = fetcher.fetch(publisherUrl)) {
+            is FictionResult.Success -> r.value
+            is FictionResult.Failure -> return null
+        }
+
+        return runCatching { extractor.extract(publisherUrl, html)?.contentText }
+            .getOrNull()
+            ?.takeIf { it.isNotBlank() }
+    }
+}

--- a/source-google-news/src/main/kotlin/in/jphe/storyvox/source/googlenews/article/GoogleNewsArticleResolver.kt
+++ b/source-google-news/src/main/kotlin/in/jphe/storyvox/source/googlenews/article/GoogleNewsArticleResolver.kt
@@ -22,12 +22,16 @@ internal class GoogleNewsArticleResolver @Inject constructor(
     private val decoder: GoogleNewsUrlDecoder,
     private val fetcher: ReadabilityFetcher,
     private val extractor: ReadabilityExtractor,
-    private val config: GoogleNewsConfig,
+    // dagger.Lazy breaks a Dagger dependency cycle: GoogleNewsConfig is
+    // provided by SettingsRepositoryUiImpl, which transitively depends on the
+    // FictionSource map (→ GoogleNewsSource → this resolver). A direct edge
+    // closes the loop; a Lazy edge defers config construction past it.
+    private val config: dagger.Lazy<GoogleNewsConfig>,
 ) : ArticleResolver {
 
     override suspend fun resolve(item: GoogleNewsItem): String? {
         // Opt-in gate (default OFF — ToS-gray + fragile).
-        if (!config.isFullArticleTextEnabled()) return null
+        if (!config.get().isFullArticleTextEnabled()) return null
 
         val publisherUrl = decoder.decode(item.link) ?: return null
 

--- a/source-google-news/src/main/kotlin/in/jphe/storyvox/source/googlenews/article/GoogleNewsUrlDecoder.kt
+++ b/source-google-news/src/main/kotlin/in/jphe/storyvox/source/googlenews/article/GoogleNewsUrlDecoder.kt
@@ -1,0 +1,145 @@
+package `in`.jphe.storyvox.source.googlenews.article
+
+import `in`.jphe.storyvox.source.googlenews.di.GoogleNewsHttp
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonArray
+import kotlinx.serialization.json.JsonPrimitive
+import kotlinx.serialization.json.contentOrNull
+import okhttp3.MediaType.Companion.toMediaType
+import okhttp3.OkHttpClient
+import okhttp3.Request
+import okhttp3.RequestBody.Companion.toRequestBody
+import java.io.IOException
+import java.net.URLEncoder
+import javax.inject.Inject
+
+/**
+ * Issue #1295 — recovers the real publisher URL behind a Google News
+ * `…/rss/articles/CBMi…` redirect.
+ *
+ * The post-2024 `CBMi…` id is an opaque token, not a base64'd URL, so the
+ * only way to resolve it is Google's internal **`batchexecute` RPC**:
+ *  1. GET the article page → scrape `data-n-a-sg` (signature) + `data-n-a-ts`
+ *     (timestamp) off the `c-wiz` element.
+ *  2. POST those + the id to `…/_/DotsSplashUi/data/batchexecute` (`Fbv4je`).
+ *  3. Parse the anti-XSSI-prefixed JSON for the publisher URL.
+ *
+ * This is **fragile by nature** — Google changes the request/response shape
+ * periodically and this will need maintenance when it does. Everything is
+ * `runCatching`-guarded and returns null on any failure so the caller
+ * ([GoogleNewsArticleResolver]) falls back to the headline digest.
+ *
+ * The four parsing/encoding steps are pure functions (no network, no Android)
+ * so they're covered by `GoogleNewsUrlDecoderTest` against captured fixtures —
+ * the network shell is the only untested part.
+ */
+internal open class GoogleNewsUrlDecoder @Inject constructor(
+    @GoogleNewsHttp private val client: OkHttpClient,
+) {
+
+    /** Resolve [googleNewsUrl] (a `…/articles/CBMi…` link) to the publisher
+     *  URL, or null on any failure. [locale] is the `gl:hl` pair embedded in
+     *  the RPC (e.g. `US:en`). IO-pinned (#585). `open` so the resolver test
+     *  can stub the network round-trip. */
+    open suspend fun decode(googleNewsUrl: String, locale: String = DEFAULT_LOCALE): String? =
+        withContext(Dispatchers.IO) {
+            val id = extractArticleId(googleNewsUrl) ?: return@withContext null
+            val pageHtml = runCatching { httpGet("$ARTICLE_BASE/$id") }.getOrNull()
+                ?: return@withContext null
+            val (signature, timestamp) = parseSignatureTimestamp(pageHtml)
+                ?: return@withContext null
+            val body = buildBatchExecuteBody(id, timestamp, signature, locale)
+            val response = runCatching { httpPostForm(BATCH_URL, body) }.getOrNull()
+                ?: return@withContext null
+            parseBatchResponse(response)
+        }
+
+    private fun httpGet(url: String): String? =
+        client.newCall(Request.Builder().url(url).build()).execute().use { resp ->
+            if (!resp.isSuccessful) null else resp.body?.string()
+        }
+
+    private fun httpPostForm(url: String, formBody: String): String? {
+        val req = Request.Builder()
+            .url(url)
+            .post(formBody.toRequestBody(FORM_MEDIA_TYPE))
+            .build()
+        return client.newCall(req).execute().use { resp ->
+            if (!resp.isSuccessful) null else resp.body?.string()
+        }
+    }
+
+    companion object {
+        const val DEFAULT_LOCALE = "US:en"
+        private const val ARTICLE_BASE = "https://news.google.com/rss/articles"
+        private const val BATCH_URL =
+            "https://news.google.com/_/DotsSplashUi/data/batchexecute"
+        private val FORM_MEDIA_TYPE =
+            "application/x-www-form-urlencoded;charset=UTF-8".toMediaType()
+
+        private val ARTICLE_ID = Regex("""/articles/([^/?#]+)""")
+        private val SIGNATURE = Regex("""data-n-a-sg="([^"]+)"""")
+        private val TIMESTAMP = Regex("""data-n-a-ts="([^"]+)"""")
+        private val HTTP_URL = Regex("""https?://[^\s"\\]+""")
+
+        /** Pull the `CBMi…` id out of a `…/articles/<id>` link. */
+        fun extractArticleId(url: String): String? =
+            ARTICLE_ID.find(url)?.groupValues?.get(1)?.takeIf { it.isNotBlank() }
+
+        /** Scrape (signature, timestamp) from the article page HTML. */
+        fun parseSignatureTimestamp(html: String): Pair<String, String>? {
+            val sg = SIGNATURE.find(html)?.groupValues?.get(1)
+            val ts = TIMESTAMP.find(html)?.groupValues?.get(1)
+            return if (sg != null && ts != null) sg to ts else null
+        }
+
+        /** Build the `f.req=…` form body for the `Fbv4je` RPC. [locale] is the
+         *  `gl:hl` pair (e.g. `US:en`). The inner request is a JSON string that
+         *  we encode (quote + escape) and embed in the outer `[[[ ... ]]]`. */
+        fun buildBatchExecuteBody(
+            articleId: String,
+            timestamp: String,
+            signature: String,
+            locale: String = DEFAULT_LOCALE,
+        ): String {
+            val inner =
+                """["garturlreq",[["X","X",["X","X"],null,null,1,1,"$locale",null,1,null,null,null,null,null,0,1],"X","X",1,[1,1,1],1,1,null,0,0,null,0],"$articleId",$timestamp,"$signature"]"""
+            // JsonPrimitive(...).toString() emits the JSON-quoted, escaped form
+            // of the inner request string — exactly what the outer array needs.
+            val innerEncoded = JsonPrimitive(inner).toString()
+            val freq = """[[["Fbv4je",$innerEncoded]]]"""
+            return "f.req=" + URLEncoder.encode(freq, "UTF-8")
+        }
+
+        /** Extract the publisher URL from the anti-XSSI-prefixed batchexecute
+         *  response. Tries the structured `Fbv4je` payload first, then falls
+         *  back to scanning for the first non-Google http(s) URL — deliberately
+         *  lenient because Google reshuffles the inner array indices. */
+        fun parseBatchResponse(body: String): String? {
+            val start = body.indexOf('[')
+            if (start >= 0) {
+                val rows = runCatching {
+                    Json.parseToJsonElement(body.substring(start)) as? JsonArray
+                }.getOrNull()
+                rows?.forEach { row ->
+                    val arr = row as? JsonArray ?: return@forEach
+                    val rpc = (arr.getOrNull(1) as? JsonPrimitive)?.contentOrNull
+                    if (rpc == "Fbv4je") {
+                        val payload = (arr.getOrNull(2) as? JsonPrimitive)?.contentOrNull
+                        if (payload != null) firstPublisherUrl(payload)?.let { return it }
+                    }
+                }
+            }
+            return firstPublisherUrl(body)
+        }
+
+        /** First http(s) URL that isn't a Google/gstatic asset. */
+        private fun firstPublisherUrl(s: String): String? =
+            HTTP_URL.findAll(s).map { it.value.trim('"', ',', '\\') }
+                .firstOrNull { url ->
+                    !url.contains("google.com") && !url.contains("gstatic.com")
+                }
+    }
+}

--- a/source-google-news/src/main/kotlin/in/jphe/storyvox/source/googlenews/di/GoogleNewsModule.kt
+++ b/source-google-news/src/main/kotlin/in/jphe/storyvox/source/googlenews/di/GoogleNewsModule.kt
@@ -12,7 +12,7 @@ import `in`.jphe.storyvox.data.source.FictionSource
 import `in`.jphe.storyvox.data.source.SourceIds
 import `in`.jphe.storyvox.source.googlenews.GoogleNewsSource
 import `in`.jphe.storyvox.source.googlenews.article.ArticleResolver
-import `in`.jphe.storyvox.source.googlenews.article.NoOpArticleResolver
+import `in`.jphe.storyvox.source.googlenews.article.GoogleNewsArticleResolver
 import `in`.jphe.storyvox.source.googlenews.net.GoogleNewsApi
 import okhttp3.Interceptor
 import okhttp3.OkHttpClient
@@ -62,8 +62,9 @@ internal object GoogleNewsHttpModule {
  * `Map<String, FictionSource>` (legacy routing) alongside the
  * plugin-seam descriptor KSP emits from the `@SourcePlugin` annotation —
  * both coexist, the same pattern as `:source-rss` / `:source-hackernews`.
- * Also binds the v1 no-op [ArticleResolver]; a future full-text resolver
- * swaps this single binding.
+ * Binds the #1295 [GoogleNewsArticleResolver] for full-article text (opt-in,
+ * default OFF via [GoogleNewsConfig][in.jphe.storyvox.data.repository.GoogleNewsConfig]);
+ * when disabled it returns null and the source falls back to the digest.
  */
 @Module
 @InstallIn(SingletonComponent::class)
@@ -77,5 +78,5 @@ internal abstract class GoogleNewsBindings {
 
     @Binds
     @Singleton
-    abstract fun bindArticleResolver(impl: NoOpArticleResolver): ArticleResolver
+    abstract fun bindArticleResolver(impl: GoogleNewsArticleResolver): ArticleResolver
 }

--- a/source-google-news/src/test/kotlin/in/jphe/storyvox/source/googlenews/article/GoogleNewsArticleResolverTest.kt
+++ b/source-google-news/src/test/kotlin/in/jphe/storyvox/source/googlenews/article/GoogleNewsArticleResolverTest.kt
@@ -1,0 +1,71 @@
+package `in`.jphe.storyvox.source.googlenews.article
+
+import `in`.jphe.storyvox.data.repository.GoogleNewsConfig
+import `in`.jphe.storyvox.source.googlenews.parse.GoogleNewsItem
+import `in`.jphe.storyvox.source.readability.extract.ReadabilityExtractor
+import `in`.jphe.storyvox.source.readability.net.ReadabilityFetcher
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.test.runTest
+import okhttp3.OkHttpClient
+import org.junit.Assert.assertNull
+import org.junit.Test
+
+/**
+ * Issue #1295 — the resolver's two behavioural guarantees, tested without
+ * network: the opt-in gate (default OFF) and graceful degradation to the
+ * digest when the link can't be decoded. The decode/fetch/extract internals
+ * are covered by [GoogleNewsUrlDecoderTest] + on-device.
+ */
+class GoogleNewsArticleResolverTest {
+
+    @Test
+    fun `gate off returns null and never attempts a decode`() = runTest {
+        val resolver = GoogleNewsArticleResolver(
+            decoder = ExplodingDecoder(),
+            fetcher = ReadabilityFetcher(OkHttpClient()),
+            extractor = ReadabilityExtractor(),
+            config = FakeConfig(enabled = false),
+        )
+        // ExplodingDecoder.decode() throws if reached — a pass proves the
+        // flag short-circuits before any network work.
+        assertNull(resolver.resolve(item()))
+    }
+
+    @Test
+    fun `enabled but undecodable link degrades to null`() = runTest {
+        val resolver = GoogleNewsArticleResolver(
+            decoder = StubDecoder(decoded = null),
+            fetcher = ReadabilityFetcher(OkHttpClient()),
+            extractor = ReadabilityExtractor(),
+            config = FakeConfig(enabled = true),
+        )
+        assertNull(resolver.resolve(item()))
+    }
+
+    // ── fakes ──────────────────────────────────────────────────────
+
+    private fun item() = GoogleNewsItem(
+        title = "Headline",
+        publisher = "Example Times",
+        link = "https://news.google.com/rss/articles/CBMiTEST?oc=5",
+        guid = "guid-1",
+        publishedAtEpochMs = null,
+        relatedHeadlines = emptyList(),
+    )
+
+    private class FakeConfig(private val enabled: Boolean) : GoogleNewsConfig {
+        override val fullArticleTextEnabled: Flow<Boolean> = flowOf(enabled)
+        override suspend fun isFullArticleTextEnabled(): Boolean = enabled
+    }
+
+    private class StubDecoder(private val decoded: String?) :
+        GoogleNewsUrlDecoder(OkHttpClient()) {
+        override suspend fun decode(googleNewsUrl: String, locale: String): String? = decoded
+    }
+
+    private class ExplodingDecoder : GoogleNewsUrlDecoder(OkHttpClient()) {
+        override suspend fun decode(googleNewsUrl: String, locale: String): String? =
+            error("decode must not be called when the full-text flag is off")
+    }
+}

--- a/source-google-news/src/test/kotlin/in/jphe/storyvox/source/googlenews/article/GoogleNewsArticleResolverTest.kt
+++ b/source-google-news/src/test/kotlin/in/jphe/storyvox/source/googlenews/article/GoogleNewsArticleResolverTest.kt
@@ -25,7 +25,7 @@ class GoogleNewsArticleResolverTest {
             decoder = ExplodingDecoder(),
             fetcher = ReadabilityFetcher(OkHttpClient()),
             extractor = ReadabilityExtractor(),
-            config = FakeConfig(enabled = false),
+            config = dagger.Lazy { FakeConfig(enabled = false) },
         )
         // ExplodingDecoder.decode() throws if reached — a pass proves the
         // flag short-circuits before any network work.
@@ -38,7 +38,7 @@ class GoogleNewsArticleResolverTest {
             decoder = StubDecoder(decoded = null),
             fetcher = ReadabilityFetcher(OkHttpClient()),
             extractor = ReadabilityExtractor(),
-            config = FakeConfig(enabled = true),
+            config = dagger.Lazy { FakeConfig(enabled = true) },
         )
         assertNull(resolver.resolve(item()))
     }

--- a/source-google-news/src/test/kotlin/in/jphe/storyvox/source/googlenews/article/GoogleNewsUrlDecoderTest.kt
+++ b/source-google-news/src/test/kotlin/in/jphe/storyvox/source/googlenews/article/GoogleNewsUrlDecoderTest.kt
@@ -1,0 +1,114 @@
+package `in`.jphe.storyvox.source.googlenews.article
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import java.net.URLDecoder
+
+/**
+ * Issue #1295 — covers the pure parse/encode steps of [GoogleNewsUrlDecoder].
+ * These are the fragile bits (Google changes the format periodically), so each
+ * is pinned against representative payloads. The network shell (`decode`) is
+ * the only untested part — verified on-device when the feature flag is enabled.
+ */
+class GoogleNewsUrlDecoderTest {
+
+    // ── extractArticleId ───────────────────────────────────────────
+
+    @Test
+    fun `extracts article id with query string`() {
+        val url = "https://news.google.com/rss/articles/CBMiABCDEF123?oc=5&hl=en-US"
+        assertEquals("CBMiABCDEF123", GoogleNewsUrlDecoder.extractArticleId(url))
+    }
+
+    @Test
+    fun `extracts article id without query`() {
+        val url = "https://news.google.com/rss/articles/CBMixyz"
+        assertEquals("CBMixyz", GoogleNewsUrlDecoder.extractArticleId(url))
+    }
+
+    @Test
+    fun `non-article url yields null id`() {
+        assertNull(GoogleNewsUrlDecoder.extractArticleId("https://news.google.com/topics/CAAq"))
+        assertNull(GoogleNewsUrlDecoder.extractArticleId("https://example.com/foo"))
+    }
+
+    // ── parseSignatureTimestamp ────────────────────────────────────
+
+    @Test
+    fun `parses signature and timestamp off the c-wiz element`() {
+        val html = """
+            <c-wiz><div jsdata="x" data-n-a-ts="1719876543" data-n-a-sg="AB_cd-EF12" data-n-a-id="z">
+            </div></c-wiz>
+        """.trimIndent()
+        val (sg, ts) = GoogleNewsUrlDecoder.parseSignatureTimestamp(html)!!
+        assertEquals("AB_cd-EF12", sg)
+        assertEquals("1719876543", ts)
+    }
+
+    @Test
+    fun `missing signature or timestamp yields null`() {
+        assertNull(GoogleNewsUrlDecoder.parseSignatureTimestamp("""<div data-n-a-ts="123"></div>"""))
+        assertNull(GoogleNewsUrlDecoder.parseSignatureTimestamp("""<div data-n-a-sg="abc"></div>"""))
+        assertNull(GoogleNewsUrlDecoder.parseSignatureTimestamp("<div></div>"))
+    }
+
+    // ── buildBatchExecuteBody ──────────────────────────────────────
+
+    @Test
+    fun `builds an f_req body embedding id, timestamp, signature, locale`() {
+        val body = GoogleNewsUrlDecoder.buildBatchExecuteBody("CBMiID", "1719", "SIG99", "GB:en")
+        assertTrue(body.startsWith("f.req="))
+        // The value is URL-encoded; decode it back and assert the structure.
+        val decoded = URLDecoder.decode(body.removePrefix("f.req="), "UTF-8")
+        assertTrue("has the Fbv4je rpc id", decoded.contains("Fbv4je"))
+        assertTrue("embeds the article id", decoded.contains("CBMiID"))
+        assertTrue("embeds the timestamp (unquoted)", decoded.contains("1719"))
+        assertTrue("embeds the signature", decoded.contains("SIG99"))
+        assertTrue("embeds the locale", decoded.contains("GB:en"))
+        assertTrue("is the nested array shape", decoded.startsWith("[[[\"Fbv4je\""))
+    }
+
+    // ── parseBatchResponse ─────────────────────────────────────────
+
+    @Test
+    fun `parses the publisher url from a single-array response`() {
+        val resp = ")]}'\n\n" +
+            """[["wrb.fr","Fbv4je","[\"garturlres\",\"https://www.example.com/news/story-42\"]",null,null,null,"generic"],["di",9],["af.httprm",9,"x",4]]"""
+        assertEquals(
+            "https://www.example.com/news/story-42",
+            GoogleNewsUrlDecoder.parseBatchResponse(resp),
+        )
+    }
+
+    @Test
+    fun `recovers the url from a chunked length-prefixed response via fallback`() {
+        // Real responses are sometimes chunked with length prefixes, which is
+        // not a single valid JSON document — the regex fallback must still find
+        // the publisher URL.
+        val resp = ")]}'\n\n" +
+            "352\n" +
+            """[["wrb.fr","Fbv4je","[\"garturlres\",\"https://publisher.example.org/a/b\"]"]]""" + "\n" +
+            "26\n" +
+            """[["di",9],["af.httprm",9,"x",4]]"""
+        assertEquals(
+            "https://publisher.example.org/a/b",
+            GoogleNewsUrlDecoder.parseBatchResponse(resp),
+        )
+    }
+
+    @Test
+    fun `ignores google and gstatic urls`() {
+        val resp = ")]}'\n\n" +
+            """[["wrb.fr","Fbv4je","[\"garturlres\",\"https://news.google.com/rss/articles/CBMi\"]"]]"""
+        assertNull(GoogleNewsUrlDecoder.parseBatchResponse(resp))
+    }
+
+    @Test
+    fun `malformed response yields null`() {
+        assertNull(GoogleNewsUrlDecoder.parseBatchResponse(")]}'"))
+        assertNull(GoogleNewsUrlDecoder.parseBatchResponse(""))
+        assertNull(GoogleNewsUrlDecoder.parseBatchResponse("no urls here at all"))
+    }
+}


### PR DESCRIPTION
## Issue #1295 — Google News full-article text (follow-up to #1238/#1294)

The v1 Google News source narrates a **headline + publisher + related-coverage digest** because article links are obfuscated `news.google.com/rss/articles/CBMi…` redirects (the post-2024 id is an opaque token, not a base64'd URL). This implements the real `ArticleResolver` so — **when the user opts in** — chapters narrate the full publisher article.

### How it works
`GoogleNewsArticleResolver` runs: **opt-in gate → decode `CBMi…` → publisher URL → fetch → Readability extraction**. The `GoogleNewsSource` control flow was already wired in #1294 (`composePlainBody` inserts the resolved text and falls back to the digest when null) — so this is a self-contained resolver + decoder + DI swap.

- **`GoogleNewsUrlDecoder`** recovers the publisher URL via Google's internal `batchexecute` RPC: scrape `data-n-a-sg`/`data-n-a-ts` off the article page → POST the `Fbv4je` request → parse the anti-XSSI JSON. The four parse/encode steps are **pure functions** (fixture-tested); only the network shell is untested. Response parsing is deliberately lenient (structured path **plus** a first-non-Google-URL regex fallback) so it survives Google's periodic format churn.
- **Reuses `:source-readability`** (`ReadabilityFetcher` + `ReadabilityExtractor`) rather than reimplementing extraction — adds a one-way `:source-google-news → :source-readability` Gradle dep (no cycle).

### Graceful degradation (issue acceptance)
**Every step degrades to null → the existing digest.** Flag off, undecodable link, fetch failure, or empty extraction all fall back to today's behaviour — a failure never produces a broken chapter.

### Opt-in flag (default OFF)
The decode is ToS-gray (the feed restricts use to personal feed-reader rendering) and fragile, so it's **off by default**. Wired exactly like `AutoBrowserConfig`: `GoogleNewsConfig` (core-data) ← `SettingsRepositoryUiImpl` (DataStore) ← `AppBindings`, exposed on `SettingsRepositoryUi` + a **Settings → Sources** toggle. Per-device, not synced.

### Tests (JVM/CI)
- `GoogleNewsUrlDecoderTest` — id extraction (incl. `?oc=`), signature/timestamp scrape, `f.req` build (id/ts/sig/locale embedded), response parse (single-array, **chunked length-prefixed fallback**, google-URL rejection, malformed → null).
- `GoogleNewsArticleResolverTest` — gate-off returns null and **never decodes** (decoder explodes if reached); enabled-but-undecodable degrades to null.

> [!NOTE]
> **Deferred** (issue's "also worth bundling"): user-configurable locale (`hl`/`gl`/`ceid`) — stays en-US, follow-up.
>
> **On-device:** the live decode can't be unit-tested without a real feed + Google's current format. The flag **defaults OFF**, so this ships dormant — zero behaviour change until a user opts in. Expect periodic decoder maintenance when Google changes the format (the regex fallback buys resilience). No local gradle (CI Build APK is the compile gate).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
