### PR TITLE
feat(source-radio): directory browse via topclick/topvote/lastchange + sort filter (#1282)

### DIFF
--- a/source-radio/src/main/kotlin/in/jphe/storyvox/source/radio/RadioSource.kt
+++ b/source-radio/src/main/kotlin/in/jphe/storyvox/source/radio/RadioSource.kt
@@ -118,6 +118,20 @@ internal class RadioSource @Inject constructor(
      * tags are user-added). Bake an autocomplete picker as a v2.
      */
     override fun filterDimensions(): List<FilterDimension> = listOf(
+        // Issue #1282 — directory sort. "Relevance" is the existing
+        // name/facet search; the other three route to Radio Browser's
+        // global top-N endpoints so the user can browse popular / voted
+        // / freshly-updated stations with no search term at all.
+        FilterDimension.Sort(
+            key = "sort",
+            label = "Sort by",
+            options = listOf(
+                FilterDimension.SortOption(SORT_RELEVANCE, "Relevance"),
+                FilterDimension.SortOption(SORT_TOP_CLICK, "Most popular"),
+                FilterDimension.SortOption(SORT_TOP_VOTE, "Most voted"),
+                FilterDimension.SortOption(SORT_LAST_CHANGE, "Recently updated"),
+            ),
+        ),
         FilterDimension.Text(
             key = "country",
             label = "Country",
@@ -152,6 +166,12 @@ internal class RadioSource @Inject constructor(
         }
         state.stringVal("tags")?.takeIf { it.isNotBlank() }?.let { t ->
             q = q.copy(tags = q.tags + "$TAG_PREFIX$t")
+        }
+        // Issue #1282 — stash the directory sort, except the default
+        // "relevance" (which IS the existing name/facet search, so it
+        // needs no sentinel).
+        state.stringVal("sort")?.takeIf { it.isNotBlank() && it != SORT_RELEVANCE }?.let { s ->
+            q = q.copy(tags = q.tags + "$SORT_PREFIX$s")
         }
         return q
     }
@@ -197,8 +217,8 @@ internal class RadioSource @Inject constructor(
     override suspend fun search(query: SearchQuery): FictionResult<ListPage<FictionSummary>> {
         val term = query.term.trim()
         // Peel filter state back out of [SearchQuery]. [applyFilters]
-        // stashes country / language / tag under sentinel prefixes in
-        // tags.
+        // stashes country / language / tag / sort under sentinel prefixes
+        // in tags.
         val countryFilter = query.tags
             .firstOrNull { it.startsWith(COUNTRY_PREFIX) }
             ?.removePrefix(COUNTRY_PREFIX)
@@ -208,66 +228,76 @@ internal class RadioSource @Inject constructor(
         val tagFilter = query.tags
             .firstOrNull { it.startsWith(TAG_PREFIX) }
             ?.removePrefix(TAG_PREFIX)
+        // Issue #1282 — directory sort (topclick / topvote / lastchange).
+        val sortFilter = query.tags
+            .firstOrNull { it.startsWith(SORT_PREFIX) }
+            ?.removePrefix(SORT_PREFIX)
         val hasFilters = !countryFilter.isNullOrBlank() ||
             !languageFilter.isNullOrBlank() ||
             !tagFilter.isNullOrBlank()
+        val hasSort = !sortFilter.isNullOrBlank()
 
-        if (term.isEmpty() && !hasFilters) {
+        if (term.isEmpty() && !hasFilters && !hasSort) {
             // Match the popular() shape for empty-query so the Search
-            // tab feels populated rather than blank-on-arrival.
+            // tab feels populated rather than blank-on-arrival. A
+            // directory sort counts as "active" — it surfaces the top-N
+            // list even with no term/facets.
             return popular(page = 1)
         }
-        // Local match against the curated set + starred imports first
-        // (zero network, instant) — this is what kept the old
-        // :source-kvmr "search for kvmr" surface fast. Anything beyond
-        // the local matches comes from the Radio Browser API call.
-        // With filters active, narrow the local match using the same
-        // axes the remote call applies so the merged list stays
-        // coherent (don't show a US curated station when the filter
-        // says "country = France").
-        val lowered = term.lowercase()
-        val localMatches = (RadioStations.curated + config.snapshot())
-            .asSequence()
-            .filter { station ->
-                term.isEmpty() ||
-                    station.displayName.lowercase().contains(lowered) ||
-                    station.tags.any { it.lowercase().contains(lowered) } ||
-                    station.country.lowercase().contains(lowered)
-            }
-            .filter { station ->
-                countryFilter.isNullOrBlank() ||
-                    station.country.contains(countryFilter, ignoreCase = true)
-            }
-            .filter { station ->
-                languageFilter.isNullOrBlank() ||
-                    station.language.contains(languageFilter, ignoreCase = true)
-            }
-            .filter { station ->
-                tagFilter.isNullOrBlank() ||
-                    station.tags.any { it.contains(tagFilter, ignoreCase = true) }
-            }
-            .map { it.toSummary() }
-            .toList()
 
-        // Hit Radio Browser for the long-tail. Use the multi-facet
-        // `/search` endpoint when any filter is active, otherwise the
-        // original `byname` endpoint (preserves the legacy URL shape
-        // for term-only searches). Failures don't sink the whole
-        // result — local matches still come back even if the network
-        // call fails.
-        val remoteMatches = when (val result = if (hasFilters) {
-            api.search(
+        // Shared predicate: free-text term (name / tag / country) AND each
+        // active facet. Used both for the local roster and to narrow the
+        // global top-N sort endpoints client-side, so a US curated station
+        // never leaks past a "country = France" filter.
+        val lowered = term.lowercase()
+        fun RadioStation.matchesQuery(): Boolean {
+            val termOk = term.isEmpty() ||
+                displayName.lowercase().contains(lowered) ||
+                tags.any { it.lowercase().contains(lowered) } ||
+                country.lowercase().contains(lowered)
+            val countryOk = countryFilter.isNullOrBlank() ||
+                country.contains(countryFilter, ignoreCase = true)
+            val languageOk = languageFilter.isNullOrBlank() ||
+                language.contains(languageFilter, ignoreCase = true)
+            val tagOk = tagFilter.isNullOrBlank() ||
+                tags.any { it.contains(tagFilter, ignoreCase = true) }
+            return termOk && countryOk && languageOk && tagOk
+        }
+
+        // Local match against the curated set + starred imports first
+        // (zero network, instant).
+        val localMatches = (RadioStations.curated + config.snapshot())
+            .filter { it.matchesQuery() }
+            .map { it.toSummary() }
+
+        // Remote long-tail: a directory sort routes to the matching
+        // global top-N endpoint; otherwise the multi-facet `/search`
+        // (when facets active) or the legacy `byname`. Failures don't
+        // sink the result — local matches still come back.
+        val remoteResult = when {
+            hasSort -> when (sortFilter) {
+                SORT_TOP_CLICK -> api.topClick()
+                SORT_TOP_VOTE -> api.topVote()
+                SORT_LAST_CHANGE -> api.lastChange()
+                else -> api.byName(term)
+            }
+            hasFilters -> api.search(
                 name = term.ifBlank { null },
                 country = countryFilter,
                 language = languageFilter,
                 tag = tagFilter,
             )
-        } else {
-            api.byName(term)
-        }) {
-            is FictionResult.Success -> result.value.map { it.toSummary() }
+            else -> api.byName(term)
+        }
+        val remoteStations = when (remoteResult) {
+            is FictionResult.Success -> remoteResult.value
             is FictionResult.Failure -> emptyList()
         }
+        // The top-N endpoints are global (no facet params), so narrow them
+        // client-side to the active term/facets; the byname/search paths
+        // already filtered server-side.
+        val remoteMatches = (if (hasSort) remoteStations.filter { it.matchesQuery() } else remoteStations)
+            .map { it.toSummary() }
 
         // De-dupe by id so a starred Radio Browser station doesn't show
         // up twice when it also matches the live API call.
@@ -423,5 +453,19 @@ internal class RadioSource @Inject constructor(
         internal const val COUNTRY_PREFIX = "country:"
         internal const val LANGUAGE_PREFIX = "language:"
         internal const val TAG_PREFIX = "tag:"
+
+        /**
+         * Issue #1282 — directory sort. [SORT_PREFIX] smuggles the
+         * selected [FilterDimension.Sort] option through [SearchQuery.tags]
+         * (same sentinel trick as the facet prefixes above); [search]
+         * routes the popularity / vote / recency options to the matching
+         * Radio Browser top-N endpoint. "relevance" is the default and is
+         * NOT stashed — it stays the existing name/facet search path.
+         */
+        internal const val SORT_PREFIX = "sort:"
+        internal const val SORT_RELEVANCE = "relevance"
+        internal const val SORT_TOP_CLICK = "topclick"
+        internal const val SORT_TOP_VOTE = "topvote"
+        internal const val SORT_LAST_CHANGE = "lastchange"
     }
 }

--- a/source-radio/src/main/kotlin/in/jphe/storyvox/source/radio/net/RadioBrowserApi.kt
+++ b/source-radio/src/main/kotlin/in/jphe/storyvox/source/radio/net/RadioBrowserApi.kt
@@ -31,11 +31,16 @@ import kotlin.time.Duration.Companion.seconds
  *   Browse → Radio → Search tab. Capped server-side to ~10k results;
  *   we apply a client-side limit of 50 below (anything beyond that
  *   isn't useful in a phone list view).
+ * - **`GET /json/stations/search`** — multi-facet search (name +
+ *   country + language + tag, AND-composed server-side). Drives the
+ *   Browse → Radio filter chips (#795).
+ * - **`GET /json/stations/{topclick,topvote,lastchange}/<limit>`** —
+ *   directory browse by popularity / votes / recency (#1282). These
+ *   are global top-N lists (no facet params); the source narrows them
+ *   client-side when a term/facet is also active.
  *
- * Other Radio Browser endpoints (`bycountry`, `bytag`, `bylanguage`,
- * `byuuid`) are intentionally NOT wired in v1 — the issue calls for
- * search + star, not a multi-facet picker. The shape is here for a
- * follow-up PR to add filter chips without an API client rewrite.
+ * `open` (with `open` methods) purely so the source's filter tests can
+ * substitute a recording double — production wires the real singleton.
  *
  * ## Server selection
  *
@@ -63,7 +68,7 @@ import kotlin.time.Duration.Companion.seconds
  *   as `cause` for debug-overlay surfacing.
  */
 @Singleton
-internal class RadioBrowserApi @Inject constructor(
+internal open class RadioBrowserApi @Inject constructor(
     private val client: OkHttpClient,
 ) {
     private val json = Json { ignoreUnknownKeys = true; isLenient = true; coerceInputValues = true }
@@ -81,7 +86,7 @@ internal class RadioBrowserApi @Inject constructor(
      * (curated stations use short ids like `"kvmr"`; imports look like
      * `"rb:4af97ba5-..."`).
      */
-    suspend fun byName(
+    open suspend fun byName(
         query: String,
         limit: Int = 50,
     ): FictionResult<List<RadioStation>> {
@@ -98,15 +103,7 @@ internal class RadioBrowserApi @Inject constructor(
             .addQueryParameter("limit", limit.coerceIn(1, 100).toString())
             .build()
             .toString()
-        return getJson<List<RadioBrowserStation>>(url)
-            .let { result ->
-                when (result) {
-                    is FictionResult.Success -> FictionResult.Success(
-                        result.value.mapNotNull { it.toRadioStation() },
-                    )
-                    is FictionResult.Failure -> result
-                }
-            }
+        return getJson<List<RadioBrowserStation>>(url).mapStations()
     }
 
     /**
@@ -119,7 +116,7 @@ internal class RadioBrowserApi @Inject constructor(
      * Same HTTPS-only / lastcheckok / ssl_error filtering as [byName]
      * via the shared [RadioBrowserStation.toRadioStation] mapper.
      */
-    suspend fun search(
+    open suspend fun search(
         name: String? = null,
         country: String? = null,
         language: String? = null,
@@ -146,16 +143,45 @@ internal class RadioBrowserApi @Inject constructor(
             }
             .build()
             .toString()
-        return getJson<List<RadioBrowserStation>>(url)
-            .let { result ->
-                when (result) {
-                    is FictionResult.Success -> FictionResult.Success(
-                        result.value.mapNotNull { it.toRadioStation() },
-                    )
-                    is FictionResult.Failure -> result
-                }
-            }
+        return getJson<List<RadioBrowserStation>>(url).mapStations()
     }
+
+    /**
+     * Issue #1282 — directory browse by popularity (`topclick`), votes
+     * (`topvote`), or recency (`lastchange`). Path-param top-N lists; no
+     * facet params (the source narrows client-side). HTTPS-only / broken
+     * filtering via the shared [RadioBrowserStation.toRadioStation] mapper.
+     */
+    open suspend fun topClick(limit: Int = 50): FictionResult<List<RadioStation>> =
+        stationList("topclick", limit)
+
+    open suspend fun topVote(limit: Int = 50): FictionResult<List<RadioStation>> =
+        stationList("topvote", limit)
+
+    open suspend fun lastChange(limit: Int = 50): FictionResult<List<RadioStation>> =
+        stationList("lastchange", limit)
+
+    /** Shared shape for the path-param station-list endpoints
+     *  (`/json/stations/<endpoint>/<limit>`). */
+    private suspend fun stationList(
+        endpoint: String,
+        limit: Int,
+    ): FictionResult<List<RadioStation>> {
+        val url = "$BASE_URL/json/stations/$endpoint/${limit.coerceIn(1, 100)}"
+            .toHttpUrl().newBuilder()
+            .addQueryParameter("hidebroken", "true")
+            .build()
+            .toString()
+        return getJson<List<RadioBrowserStation>>(url).mapStations()
+    }
+
+    /** Map a raw station-list result to storyvox [RadioStation]s,
+     *  dropping unusable entries; pass failures through unchanged. */
+    private fun FictionResult<List<RadioBrowserStation>>.mapStations(): FictionResult<List<RadioStation>> =
+        when (this) {
+            is FictionResult.Success -> FictionResult.Success(value.mapNotNull { it.toRadioStation() })
+            is FictionResult.Failure -> this
+        }
 
     // ─── transport ────────────────────────────────────────────────────
 

--- a/source-radio/src/test/kotlin/in/jphe/storyvox/source/radio/RadioFiltersTest.kt
+++ b/source-radio/src/test/kotlin/in/jphe/storyvox/source/radio/RadioFiltersTest.kt
@@ -58,14 +58,28 @@ class RadioFiltersTest {
 
     // ─── filterDimensions ─────────────────────────────────────────────
 
-    @Test fun `filterDimensions exposes country language and tag as text inputs`() {
+    @Test fun `filterDimensions exposes sort plus country language and tag`() {
         val dims = source().filterDimensions()
-        assertEquals(3, dims.size)
-        val keys = dims.map { it.key }.toSet()
-        assertEquals(setOf("country", "language", "tags"), keys)
-        // All three are free-form text — Radio Browser's facet
-        // taxonomies are too large for a select picker.
-        assertTrue(dims.all { it is FilterDimension.Text })
+        // #1282 — directory sort leads, then the three free-form facet
+        // text inputs (Radio Browser's taxonomies are too large for a
+        // select picker).
+        assertEquals(4, dims.size)
+        assertTrue("sort dimension leads the list", dims.first() is FilterDimension.Sort)
+        val textKeys = dims.filterIsInstance<FilterDimension.Text>().map { it.key }.toSet()
+        assertEquals(setOf("country", "language", "tags"), textKeys)
+    }
+
+    @Test fun `sort dimension offers relevance plus the three directory endpoints`() {
+        val sort = source().filterDimensions()
+            .filterIsInstance<FilterDimension.Sort>()
+            .single()
+        assertEquals("sort", sort.key)
+        assertEquals(
+            listOf("relevance", "topclick", "topvote", "lastchange"),
+            sort.options.map { it.id },
+        )
+        // Default is relevance (the existing name/facet search path).
+        assertEquals(RadioSource.SORT_RELEVANCE, sort.default.id)
     }
 
     // ─── applyFilters ──────────────────────────────────────────────────
@@ -201,5 +215,90 @@ class RadioFiltersTest {
         val popular = (src.popular() as FictionResult.Success).value.items
         val searched = (src.search(SearchQuery(term = "")) as FictionResult.Success).value.items
         assertEquals(popular.map { it.id }, searched.map { it.id })
+    }
+
+    // ─── #1282 directory sort ─────────────────────────────────────────
+
+    @Test fun `applyFilters stashes a non-default sort under the sort prefix`() {
+        val q = source().applyFilters(
+            base = SearchQuery(),
+            state = FilterState(
+                values = mapOf("sort" to FilterValue.StringVal(RadioSource.SORT_TOP_CLICK)),
+            ),
+        )
+        assertTrue(
+            q.tags.contains("${RadioSource.SORT_PREFIX}${RadioSource.SORT_TOP_CLICK}"),
+        )
+    }
+
+    @Test fun `applyFilters does not stash the default relevance sort`() {
+        val q = source().applyFilters(
+            base = SearchQuery(),
+            state = FilterState(
+                values = mapOf("sort" to FilterValue.StringVal(RadioSource.SORT_RELEVANCE)),
+            ),
+        )
+        assertTrue(
+            "relevance is the default search path — no sentinel",
+            q.tags.none { it.startsWith(RadioSource.SORT_PREFIX) },
+        )
+    }
+
+    @Test fun `search routes each directory sort to its Radio Browser endpoint`() = runTest {
+        val cases = mapOf(
+            RadioSource.SORT_TOP_CLICK to "topclick",
+            RadioSource.SORT_TOP_VOTE to "topvote",
+            RadioSource.SORT_LAST_CHANGE to "lastchange",
+        )
+        for ((sortId, expectedCall) in cases) {
+            val api = RecordingApi()
+            val q = SearchQuery(tags = setOf("${RadioSource.SORT_PREFIX}$sortId"))
+            RadioSource(api, fakeConfig()).search(q)
+            assertEquals(
+                "sort=$sortId must hit the $expectedCall endpoint",
+                listOf(expectedCall),
+                api.calls,
+            )
+        }
+    }
+
+    @Test fun `search with a sort and no term still queries instead of mirroring popular`() = runTest {
+        // A directory sort is "active" even with empty term/facets — it
+        // must reach the endpoint, not early-return popular().
+        val api = RecordingApi()
+        val q = SearchQuery(
+            term = "",
+            tags = setOf("${RadioSource.SORT_PREFIX}${RadioSource.SORT_TOP_VOTE}"),
+        )
+        RadioSource(api, fakeConfig()).search(q)
+        assertEquals(listOf("topvote"), api.calls)
+    }
+
+    /** Records which Radio Browser endpoint the source routed to. All
+     *  return empty so the source's combine path is exercised without a
+     *  network. Relies on [RadioBrowserApi] being `open` (#1282). */
+    private class RecordingApi : RadioBrowserApi(OkHttpClient()) {
+        val calls = mutableListOf<String>()
+        override suspend fun byName(query: String, limit: Int): FictionResult<List<RadioStation>> {
+            calls += "byname"; return FictionResult.Success(emptyList())
+        }
+        override suspend fun search(
+            name: String?,
+            country: String?,
+            language: String?,
+            tag: String?,
+            limit: Int,
+        ): FictionResult<List<RadioStation>> {
+            calls += "search"; return FictionResult.Success(emptyList())
+        }
+        override suspend fun topClick(limit: Int): FictionResult<List<RadioStation>> {
+            calls += "topclick"; return FictionResult.Success(emptyList())
+        }
+        override suspend fun topVote(limit: Int): FictionResult<List<RadioStation>> {
+            calls += "topvote"; return FictionResult.Success(emptyList())
+        }
+        override suspend fun lastChange(limit: Int): FictionResult<List<RadioStation>> {
+            calls += "lastchange"; return FictionResult.Success(emptyList())
+        }
     }
 }


### PR DESCRIPTION
## Issue #1282 — Radio directory browse

Adds a **directory discovery surface** to the Radio source using the Radio Browser endpoints the issue names as unused.

> [!NOTE]
> **Scope note (verified against origin/main):** the country/language/tag facet filters the issue mentions are **already shipped** under #795 — `filterDimensions()` exposes them, `applyFilters()`/`search()` route them through `/json/stations/search`. So this PR focuses on the genuinely-missing piece: the **popularity/recency** endpoints (`topclick`, `topvote`, `lastchange`) + a sort dimension to surface them. (`bytag`/`bycountry` are already covered functionally by `search(tag=, country=)`, so I skipped the redundant dedicated list endpoints — shout if you want them.)

### What's new
- **`RadioBrowserApi`** — `topClick` / `topVote` / `lastChange` against the global top-N `/json/stations/{topclick,topvote,lastchange}/<limit>` endpoints, behind a shared `stationList()` helper + a `mapStations()` extension that also de-dupes the existing `byName`/`search` result-mapping. The class + entry methods are now `open` purely so the filter tests can substitute a recording double (no production change).
- **`RadioSource`** — a **"Sort by"** dimension: *Relevance · Most popular · Most voted · Recently updated*. Relevance keeps the existing name/facet search; the other three route to the matching top-N endpoint. The selection rides through `SearchQuery.tags` under a `sort:` sentinel (same trick as the existing `country:`/`language:`/`tag:` prefixes), and a sort counts as "active" so the directory surfaces top stations **with no search term**. Global top-N results are narrowed client-side by any active term/facets (shared `matchesQuery` predicate) so "Most popular + jazz" stays coherent.
- Curated + starred stations still lead; the existing search/star surfaces are untouched.

### No UI changes
Renders through the generic `DynamicFilterSheet` — `SortSection` already handles `FilterDimension.Sort` and writes the selection as a `StringVal` under the `sort` key, which `applyFilters` reads. Verified the full path end-to-end.

### Tests (`RadioFiltersTest`, JVM)
- Sort dimension shape + option ids; updated the existing 3-dimension assertion for the new 4th.
- `applyFilters` stashes a non-default sort under the sentinel; drops the default `relevance`.
- `search` routes each sort option to its endpoint (recording `RadioBrowserApi` double), including the no-term directory-browse case.

Entirely within `:source-radio` — no cross-module/Hilt graph changes. No local gradle (CI Build APK is the compile gate). The live HTTP round-trip is verified at integration time per the existing API-test convention.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
