### PR TITLE
feat(playback): honor Fiction.pinnedVoiceId as per-fiction narrator voice (#1299)

### DIFF
--- a/app/src/test/kotlin/in/jphe/storyvox/di/RealPlaybackControllerUiTest.kt
+++ b/app/src/test/kotlin/in/jphe/storyvox/di/RealPlaybackControllerUiTest.kt
@@ -412,6 +412,7 @@ class RealPlaybackControllerUiTest {
         override suspend fun removeFromLibrary(id: String) = Unit
         override suspend fun setDownloadMode(id: String, mode: DownloadMode?) = Unit
         override suspend fun setPinnedVoice(id: String, voiceId: String?, locale: String?) = Unit
+        override suspend fun pinnedVoiceId(id: String): String? = null
         override suspend fun setPlaybackSpeed(id: String, speed: Float?) = Unit
         override fun observePlaybackSpeed(id: String): Flow<Float?> = flowOf(null)
         override suspend fun setFollowedRemote(id: String, followed: Boolean) =

--- a/core-data/src/main/kotlin/in/jphe/storyvox/data/repository/FictionRepository.kt
+++ b/core-data/src/main/kotlin/in/jphe/storyvox/data/repository/FictionRepository.kt
@@ -108,6 +108,11 @@ interface FictionRepository {
     suspend fun setDownloadMode(id: String, mode: DownloadMode?)
     suspend fun setPinnedVoice(id: String, voiceId: String?, locale: String?)
 
+    /** Issue #1299 — read the per-fiction narrator voice pin, or null when
+     *  unpinned. [EnginePlayer.loadAndPlay] reads this to narrate with the
+     *  book's pinned voice, falling back to the global active voice. */
+    suspend fun pinnedVoiceId(id: String): String?
+
     /**
      * Issue #1231 — per-fiction playback speed. [setPlaybackSpeed] pins (or,
      * with `null`, clears) the book's own speed; [observePlaybackSpeed] is the
@@ -395,6 +400,9 @@ class FictionRepositoryImpl @Inject constructor(
     override suspend fun setPinnedVoice(id: String, voiceId: String?, locale: String?) {
         fictionDao.setPinnedVoice(id, voiceId, locale)
     }
+
+    override suspend fun pinnedVoiceId(id: String): String? =
+        fictionDao.get(id)?.pinnedVoiceId
 
     override suspend fun setPlaybackSpeed(id: String, speed: Float?) {
         fictionDao.updatePlaybackSpeed(id, speed)

--- a/core-data/src/test/kotlin/in/jphe/storyvox/data/repository/FictionRepositoryImplTest.kt
+++ b/core-data/src/test/kotlin/in/jphe/storyvox/data/repository/FictionRepositoryImplTest.kt
@@ -488,6 +488,28 @@ class FictionRepositoryImplTest {
         chapterDao,
     )
 
+    // -- Issue #1299 — per-fiction narrator pin read --------------------------
+
+    @Test fun `pinnedVoiceId returns the stored pin`() = runTest {
+        val (r, fictionDao, _) = repo()
+        fictionDao.rows["f1"] = Fiction(
+            id = "f1", sourceId = SourceIds.ROYAL_ROAD, title = "", author = "",
+            firstSeenAt = 0L, metadataFetchedAt = 0L,
+            pinnedVoiceId = "piper_lessac_en_US_medium",
+        )
+        assertEquals("piper_lessac_en_US_medium", r.pinnedVoiceId("f1"))
+    }
+
+    @Test fun `pinnedVoiceId is null when unpinned or row absent`() = runTest {
+        val (r, fictionDao, _) = repo()
+        fictionDao.rows["f2"] = Fiction(
+            id = "f2", sourceId = SourceIds.ROYAL_ROAD, title = "", author = "",
+            firstSeenAt = 0L, metadataFetchedAt = 0L,
+        )
+        assertNull(r.pinnedVoiceId("f2"))      // row exists, no pin
+        assertNull(r.pinnedVoiceId("missing")) // no row at all
+    }
+
     // -- sourceFor() routing -----------------------------------------------------
 
     @Test fun `single bound source is used as fallback when sourceId is null`() = runTest {

--- a/core-playback/src/main/kotlin/in/jphe/storyvox/playback/tts/EnginePlayer.kt
+++ b/core-playback/src/main/kotlin/in/jphe/storyvox/playback/tts/EnginePlayer.kt
@@ -331,6 +331,11 @@ class EnginePlayer @AssistedInject constructor(
     @Assisted private val context: Context,
     private val chunker: SentenceChunker,
     private val chapterRepo: ChapterRepository,
+    /** Issue #1299 — per-fiction narrator-pin source. [loadAndPlay] reads
+     *  the fiction's `pinnedVoiceId` to narrate with the book's pinned voice,
+     *  falling back to the global active voice when unpinned or the pinned
+     *  voice isn't installed. */
+    private val fictionRepo: `in`.jphe.storyvox.data.repository.FictionRepository,
     private val positionRepo: PlaybackPositionRepository,
     /**
      * Issue #158 — reading-history breadcrumb. Written on every
@@ -1860,7 +1865,14 @@ class EnginePlayer @AssistedInject constructor(
             _observableState.update { it.copy(isLiveAudioChapter = false) }
         }
 
-        val active = voiceManager.activeVoice.first()
+        // Issue #1299 — per-fiction narrator pin. If this fiction has a pinned
+        // voice that's actually installed, narrate with it; otherwise fall back
+        // to the global active voice. Safe-by-default: no pin, or a pin whose
+        // voice isn't installed, behaves identically to pre-#1299.
+        val pinnedNarrator = fictionRepo.pinnedVoiceId(fictionId)
+            ?.let { voiceManager.voiceById(it) }
+            ?.takeIf { it.isInstalled }
+        val active = pinnedNarrator ?: voiceManager.activeVoice.first()
         if (active == null) {
             _observableState.update {
                 it.copy(isPlaying = false, error = PlaybackError.EngineUnavailable)

--- a/core-playback/src/main/kotlin/in/jphe/storyvox/playback/voice/VoiceManager.kt
+++ b/core-playback/src/main/kotlin/in/jphe/storyvox/playback/voice/VoiceManager.kt
@@ -254,6 +254,33 @@ class VoiceManager @Inject constructor(
     }
 
     /**
+     * Issue #1299 — roster-aware lookup of a single voice by id, mirroring
+     * [activeVoice]'s resolution: legacy-id normalization, the Azure +
+     * SystemTts rosters, and the per-engine installed checks. Returns null
+     * when the id matches no catalog/roster entry. [UiVoiceInfo.isInstalled]
+     * is computed identically to [activeVoice], so callers that require a
+     * usable voice (the per-fiction narrator pin in
+     * [in.jphe.storyvox.playback.tts.EnginePlayer.loadAndPlay]) can gate on it.
+     */
+    suspend fun voiceById(id: String): UiVoiceInfo? {
+        val normalized = normalizeId(id)
+        val prefs = store.data.first()
+        val azureRoster = azureVoiceProvider.voices.first()
+        val systemTtsRoster = systemTtsVoiceProvider.voices.first()
+        val entry = VoiceCatalog.byIdWithAzureAndSystemTts(
+            normalized, azureRoster, systemTtsRoster,
+        ) ?: return null
+        val installed = prefs[VoiceKeys.INSTALLED_IDS].orEmpty().map(::normalizeId).toSet()
+        val isInstalled = normalized in installed ||
+            (entry.engineType is EngineType.Kokoro && isKokoroSharedModelInstalled()) ||
+            (entry.engineType is EngineType.Kitten && isKittenSharedModelInstalled()) ||
+            (entry.engineType is EngineType.Supertonic && isSupertonicSharedModelInstalled()) ||
+            entry.engineType is EngineType.Azure ||
+            entry.engineType is EngineType.SystemTts
+        return entry.toUiVoiceInfo(installed = isInstalled)
+    }
+
+    /**
      * Issue #547 — sticky onboarding-dismissed flag, DataStore-backed.
      * `true` means the user has made a choice about the voice picker
      * (either picked a voice or tapped "Continue without audio"); the

--- a/core-playback/src/test/kotlin/in/jphe/storyvox/playback/voice/VoiceManagerTest.kt
+++ b/core-playback/src/test/kotlin/in/jphe/storyvox/playback/voice/VoiceManagerTest.kt
@@ -28,7 +28,10 @@ import okhttp3.Response
 import okhttp3.ResponseBody.Companion.toResponseBody
 import org.junit.After
 import org.junit.Assert.assertArrayEquals
+import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNull
 import org.junit.Assert.assertTrue
 import org.junit.Before
 import org.junit.Test
@@ -85,6 +88,27 @@ class VoiceManagerTest {
     @After
     fun tearDown() {
         voicesRoot.deleteRecursively()
+    }
+
+    // ===== Issue #1299 — voiceById roster-aware lookup =====
+
+    @Test
+    fun voiceById_resolvesKnownCatalogVoice() = runBlocking {
+        val vm = VoiceManager(context, EmptyAzureProvider, EmptySystemTtsProvider)
+        val knownId = VoiceCatalog.featuredIds.first()
+        val resolved = vm.voiceById(knownId)
+        assertNotNull(resolved)
+        assertEquals(knownId, resolved!!.id)
+        // Empty filesDir → a downloadable featured (Piper) voice resolves but
+        // reports not-installed. The loadAndPlay narrator-pin gate relies on
+        // this so an uninstalled pin falls back to the active voice.
+        assertFalse(resolved.isInstalled)
+    }
+
+    @Test
+    fun voiceById_unknownId_returnsNull() = runBlocking {
+        val vm = VoiceManager(context, EmptyAzureProvider, EmptySystemTtsProvider)
+        assertNull(vm.voiceById("not-a-real-voice-id"))
     }
 
     /**


### PR DESCRIPTION
## What

Implements **#1299 Item 4** — makes the per-fiction **narrator voice pin actually work**. `Fiction.pinnedVoiceId` was already persisted (and settable from the UI), but playback ignored it: `EnginePlayer.loadAndPlay` always narrated with the global `voiceManager.activeVoice`. This wires the pin through. Ships independently of the per-segment Cast work.

## Changes
- **`VoiceManager.voiceById(id): UiVoiceInfo?`** — roster-aware single-voice lookup, mirroring `activeVoice`'s resolution exactly (legacy-id normalization, Azure + SystemTts rosters, per-engine installed checks). Returns null for an unknown id; the `isInstalled` flag is computed identically so callers can require a usable voice.
- **`EnginePlayer`** — injects `FictionRepository` (already bound in core-playback) and, in `loadAndPlay` (line ~1863), resolves the fiction's pin as the narrator voice **when set and installed**, falling back to `activeVoice`:
  ```kotlin
  val pinnedNarrator = fictionRepo.pinnedVoiceId(fictionId)
      ?.let { voiceManager.voiceById(it) }
      ?.takeIf { it.isInstalled }
  val active = pinnedNarrator ?: voiceManager.activeVoice.first()
  ```
- **`FictionRepository.pinnedVoiceId(id): String?`** — narrow suspend getter (`fictionDao.get(id)?.pinnedVoiceId`).

## Safe-by-default
No pin → `pinnedVoiceId` is null → `activeVoice` (today's behavior, byte-for-byte). A pin whose voice was since **uninstalled** → `takeIf { isInstalled }` drops it → `activeVoice`. So the change is inert unless a fiction has a pin to an installed voice.

## Tests
- `VoiceManager.voiceById` — resolves a known catalog voice (correct id, reports not-installed in an empty fixture), returns null for an unknown id.
- `FictionRepository.pinnedVoiceId` — stored pin round-trips; null when the row is unpinned or absent.

## Out of scope (per the issue)
- **Item 3** (per-segment voice switch / `DialogueAttributor` wiring / `PcmCacheKey` changes) — deliberately untouched; needs the Cast UI + device testing.
- The **live-audio-stream path** (`loadAndPlayAudioStream`, ~line 5565) is left alone: it plays recorded audio, not TTS narration, so there's no narrator voice to pin.

## Notes
- DI: `FictionRepository` is already injected elsewhere in core-playback (PrerenderTriggers/PcmRenderScheduler), so no new Hilt binding is needed. `EnginePlayer` is only constructed via its `@AssistedFactory` (no direct test construction), so the added constructor param is safe.
- No local compile (project rule); CI Test Compile + Build APK are the gate.

Closes #1299 (Item 4)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
