### PR TITLE
feat(import): OpenDocument Text (.odt) import support (#1310)

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -142,6 +142,8 @@
                 <data android:scheme="file" />
                 <data android:mimeType="application/epub+zip" />
                 <data android:mimeType="text/plain" />
+                <!-- Issue #1310 — OpenDocument Text (.odt). -->
+                <data android:mimeType="application/vnd.oasis.opendocument.text" />
             </intent-filter>
             <!-- ACTION_VIEW: claim by .epub/.txt extension when the mime
                  is generic (octet-stream) or absent. host="*" + a
@@ -160,8 +162,10 @@
                 <data android:mimeType="*/*" />
                 <data android:pathPattern=".*\\.epub" />
                 <data android:pathPattern=".*\\.txt" />
+                <data android:pathPattern=".*\\.odt" />
                 <data android:pathPattern=".*\\..*\\.epub" />
                 <data android:pathPattern=".*\\..*\\.txt" />
+                <data android:pathPattern=".*\\..*\\.odt" />
             </intent-filter>
             <!-- ACTION_SEND: "Share → Candela" for an EPUB attachment.
                  (text/plain file-shares ride the #472 filter above —
@@ -170,6 +174,8 @@
                 <action android:name="android.intent.action.SEND" />
                 <category android:name="android.intent.category.DEFAULT" />
                 <data android:mimeType="application/epub+zip" />
+                <!-- Issue #1310 — OpenDocument Text (.odt) share. -->
+                <data android:mimeType="application/vnd.oasis.opendocument.text" />
             </intent-filter>
         </activity>
 

--- a/app/src/main/kotlin/in/jphe/storyvox/data/DocumentImporterUiImpl.kt
+++ b/app/src/main/kotlin/in/jphe/storyvox/data/DocumentImporterUiImpl.kt
@@ -12,6 +12,8 @@ import `in`.jphe.storyvox.feature.api.ImportFileResult
 import `in`.jphe.storyvox.navigation.DocumentImportClassifier
 import `in`.jphe.storyvox.navigation.ImportKind
 import `in`.jphe.storyvox.source.epub.config.EpubEntryKind
+import java.io.File
+import java.io.IOException
 import javax.inject.Inject
 import javax.inject.Singleton
 import kotlinx.coroutines.Dispatchers
@@ -65,6 +67,7 @@ class DocumentImporterUiImpl @Inject constructor(
                 ImportKind.Epub -> registerEpub(uri, uriString, displayName, EpubEntryKind.Epub)
                 ImportKind.Text -> registerEpub(uri, uriString, displayName, EpubEntryKind.Text)
                 ImportKind.Pdf -> registerPdf(uri, uriString, displayName)
+                ImportKind.Odt -> registerOdt(uri, uriString, displayName)
                 ImportKind.Unsupported -> ImportFileResult.Unsupported
             }
         }
@@ -90,6 +93,46 @@ class DocumentImporterUiImpl @Inject constructor(
         return runCatching {
             ImportFileResult.Success(pdfConfig.importFile(uriString, displayName))
         }.getOrElse { failure(displayName, it) }
+    }
+
+    /**
+     * Issue #1310 — OpenDocument Text. Unlike EPUB/PDF (which the source
+     * reads lazily from the original Uri), an `.odt` body must be unzipped +
+     * ODF-stripped up front, so we extract the plain text once, stage it as a
+     * UTF-8 file under `filesDir`, and import THAT through the same plaintext
+     * path as a `.txt`. Staging under `filesDir` (not `cacheDir`) keeps the
+     * imported book readable after a cache clear; we read the source bytes
+     * eagerly here, so no persistable Uri grant is needed.
+     */
+    private suspend fun registerOdt(
+        uri: Uri,
+        uriString: String,
+        displayName: String,
+    ): ImportFileResult {
+        val bytes = runCatching {
+            context.contentResolver.openInputStream(uri)?.use { it.readBytes() }
+        }.getOrNull() ?: return failure(displayName, IOException("Couldn't read the .odt file"))
+        val text = OdtTextExtractor.extract(bytes)
+        if (text.isBlank()) {
+            return ImportFileResult.Error(
+                "Couldn't read any text from ${displayName.ifBlank { "that file" }}.",
+            )
+        }
+        return runCatching {
+            val stagedUri = stageOdtText(uriString, text)
+            ImportFileResult.Success(epubConfig.importFile(stagedUri, displayName, EpubEntryKind.Text))
+        }.getOrElse { failure(displayName, it) }
+    }
+
+    /** Stage [text] as a UTF-8 file under `filesDir` and return its `file://`
+     *  Uri string. The filename is a hash of [sourceUriString] so the same
+     *  `.odt` always maps to the same staged file (and thus the same
+     *  fictionId — re-importing dedupes rather than duplicating). */
+    private fun stageOdtText(sourceUriString: String, text: String): String {
+        val dir = File(context.filesDir, "odt-import").apply { mkdirs() }
+        val staged = File(dir, Integer.toHexString(sourceUriString.hashCode()) + ".txt")
+        staged.writeText(text, Charsets.UTF_8)
+        return Uri.fromFile(staged).toString()
     }
 
     private fun failure(displayName: String, cause: Throwable): ImportFileResult {

--- a/app/src/main/kotlin/in/jphe/storyvox/data/OdtTextExtractor.kt
+++ b/app/src/main/kotlin/in/jphe/storyvox/data/OdtTextExtractor.kt
@@ -1,0 +1,81 @@
+package `in`.jphe.storyvox.data
+
+import java.io.ByteArrayInputStream
+import java.util.zip.ZipInputStream
+
+/**
+ * Issue #1310 — extract plain text from an OpenDocument Text (`.odt`) file.
+ *
+ * An `.odt` is a ZIP archive whose `content.xml` holds the body in ODF
+ * markup (`<office:text>` → `<text:p>` / `<text:h>` / `<text:span>` …).
+ * This mirrors the EPUB import shape (ZIP + markup), but ODF is regular,
+ * machine-generated XML, so a targeted strip is enough to recover the
+ * narratable prose without pulling in a full XML stack.
+ *
+ * Scope (v1, per #1310): paragraphs, headings, spans, tabs, line breaks,
+ * and runs of spaces (`<text:s text:c="N"/>`). Tables, footnotes, and
+ * tracked-changes degrade gracefully to their text content rather than
+ * erroring. The pure [odfXmlToText] seam is the unit-tested core; [extract]
+ * adds only the ZIP read so the conversion is testable without a real file.
+ */
+object OdtTextExtractor {
+
+    /** Extract plain text from raw `.odt` bytes; "" when there's no `content.xml`. */
+    fun extract(odtBytes: ByteArray): String =
+        readContentXml(odtBytes)?.let(::odfXmlToText).orEmpty()
+
+    private fun readContentXml(odtBytes: ByteArray): String? {
+        ZipInputStream(ByteArrayInputStream(odtBytes)).use { zip ->
+            // ODF mandates `content.xml` at the archive root.
+            generateSequence { zip.nextEntry }.forEach { entry ->
+                if (entry.name == "content.xml") {
+                    return zip.readBytes().toString(Charsets.UTF_8)
+                }
+            }
+        }
+        return null
+    }
+
+    /**
+     * Convert ODF `content.xml` markup to plain text. Pure (no I/O), so the
+     * conversion rules are unit-tested directly off an XML string.
+     */
+    fun odfXmlToText(contentXml: String): String {
+        // Scope to <office:text> so document styles / metadata never leak in.
+        val body = OFFICE_TEXT.find(contentXml)?.groupValues?.getOrNull(1) ?: contentXml
+        var s = body
+        // Inline whitespace constructs → their literal characters.
+        s = LINE_BREAK.replace(s, "\n")
+        s = TAB.replace(s, "\t")
+        s = SPACES.replace(s) { m ->
+            " ".repeat((m.groupValues[1].toIntOrNull() ?: 1).coerceIn(1, 64))
+        }
+        // Paragraph / heading ends become blank-line separators.
+        s = PARA_OR_HEADING_END.replace(s, "\n\n")
+        // Drop every remaining tag, keeping the text content between tags.
+        s = TAG.replace(s, "")
+        s = decodeEntities(s)
+        // Tidy: trim trailing space per line, collapse 3+ newlines to one blank line.
+        return s.lineSequence()
+            .joinToString("\n") { it.trimEnd() }
+            .replace(THREE_PLUS_NEWLINES, "\n\n")
+            .trim()
+    }
+
+    /** Decode the five predefined XML entities. `&amp;` is decoded LAST so a
+     *  literal `&amp;lt;` round-trips to `&lt;` rather than collapsing to `<`. */
+    private fun decodeEntities(s: String): String = s
+        .replace("&lt;", "<")
+        .replace("&gt;", ">")
+        .replace("&quot;", "\"")
+        .replace("&apos;", "'")
+        .replace("&amp;", "&")
+
+    private val OFFICE_TEXT = Regex("""<office:text[^>]*>(.*)</office:text>""", RegexOption.DOT_MATCHES_ALL)
+    private val LINE_BREAK = Regex("""<text:line-break\s*/>""")
+    private val TAB = Regex("""<text:tab\s*/>""")
+    private val SPACES = Regex("""<text:s(?:\s+text:c="(\d+)")?\s*/>""")
+    private val PARA_OR_HEADING_END = Regex("""</text:(?:p|h)>""")
+    private val TAG = Regex("""<[^>]+>""")
+    private val THREE_PLUS_NEWLINES = Regex("""\n{3,}""")
+}

--- a/app/src/main/kotlin/in/jphe/storyvox/navigation/DocumentImport.kt
+++ b/app/src/main/kotlin/in/jphe/storyvox/navigation/DocumentImport.kt
@@ -26,6 +26,12 @@ enum class ImportKind {
      *  [DocumentImportClassifier.PDF_ENABLED]. */
     Pdf,
 
+    /** `application/vnd.oasis.opendocument.text` (or a `.odt` filename).
+     *  Issue #1310 — unzipped + ODF→text via
+     *  [in.jphe.storyvox.data.OdtTextExtractor], then imported as a
+     *  single-chapter book through the same text-import path as plaintext. */
+    Odt,
+
     /** Anything we don't advertise an intent-filter for, or a payload
      *  whose mime + extension we can't confidently bucket. The resolver
      *  declines (returns null) rather than guessing. */
@@ -69,6 +75,11 @@ object DocumentImportClassifier {
         "application/pdf",
         "application/x-pdf",
     )
+    // Issue #1310 — OpenDocument Text (.odt).
+    private val ODT_MIMES = setOf(
+        "application/vnd.oasis.opendocument.text",
+        "application/x-vnd.oasis.opendocument.text",
+    )
 
     /**
      * Classify a document by its [mimeType] (as reported on the intent's
@@ -88,6 +99,7 @@ object DocumentImportClassifier {
         when {
             mime in EPUB_MIMES -> return ImportKind.Epub
             mime in PDF_MIMES -> return pdfOrUnsupported()
+            mime in ODT_MIMES -> return ImportKind.Odt
             mime == "text/plain" -> return ImportKind.Text
         }
 
@@ -96,6 +108,7 @@ object DocumentImportClassifier {
         when (ext) {
             "epub" -> return ImportKind.Epub
             "pdf" -> return pdfOrUnsupported()
+            "odt" -> return ImportKind.Odt
             "txt", "text", "md", "markdown" -> return ImportKind.Text
         }
 

--- a/app/src/test/kotlin/in/jphe/storyvox/data/OdtTextExtractorTest.kt
+++ b/app/src/test/kotlin/in/jphe/storyvox/data/OdtTextExtractorTest.kt
@@ -1,0 +1,80 @@
+package `in`.jphe.storyvox.data
+
+import java.io.ByteArrayOutputStream
+import java.util.zip.ZipEntry
+import java.util.zip.ZipOutputStream
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+/** Issue #1310 — ODF→text conversion + the ZIP read for `.odt` import. */
+class OdtTextExtractorTest {
+
+    @Test
+    fun `paragraphs and headings become blank-line-separated blocks; spans inline`() {
+        val xml = """<?xml version="1.0" encoding="UTF-8"?>""" +
+            "<office:document-content>" +
+            """<office:automatic-styles><style:style style:name="P1"/></office:automatic-styles>""" +
+            "<office:body><office:text>" +
+            """<text:h text:outline-level="1">Chapter One</text:h>""" +
+            "<text:p>Hello <text:span>brave</text:span> world.</text:p>" +
+            "</office:text></office:body></office:document-content>"
+        assertEquals("Chapter One\n\nHello brave world.", OdtTextExtractor.odfXmlToText(xml))
+    }
+
+    @Test
+    fun `line break, tab and space-run map to their characters`() {
+        val xml = "<office:text>" +
+            """<text:p>a<text:line-break/>b<text:tab/>c<text:s text:c="3"/>d</text:p>""" +
+            """<text:p>one<text:s/>space</text:p>""" +
+            "</office:text>"
+        assertEquals("a\nb\tc   d\n\none space", OdtTextExtractor.odfXmlToText(xml))
+    }
+
+    @Test
+    fun `xml entities are decoded, ampersand last`() {
+        val xml = "<office:text><text:p>Tom &amp; Jerry &lt;tag&gt; &quot;q&quot; &amp;lt;</text:p></office:text>"
+        assertEquals("""Tom & Jerry <tag> "q" &lt;""", OdtTextExtractor.odfXmlToText(xml))
+    }
+
+    @Test
+    fun `unknown tags are stripped but their text content is kept`() {
+        val xml = "<office:text>" +
+            """<text:p>See <text:a xlink:href="http://x">the link</text:a> here.</text:p>""" +
+            """<text:list><text:list-item><text:p>item</text:p></text:list-item></text:list>""" +
+            "</office:text>"
+        assertEquals("See the link here.\n\nitem", OdtTextExtractor.odfXmlToText(xml))
+    }
+
+    @Test
+    fun `without an office text body the whole input is processed`() {
+        // Defensive fallback — still recover paragraph text.
+        assertEquals("Loose text.", OdtTextExtractor.odfXmlToText("<text:p>Loose text.</text:p>"))
+    }
+
+    @Test
+    fun `extract reads content xml out of the odt zip`() {
+        val odt = zipOf(
+            "mimetype" to "application/vnd.oasis.opendocument.text",
+            "content.xml" to "<office:text><text:p>From the archive.</text:p></office:text>",
+        )
+        assertEquals("From the archive.", OdtTextExtractor.extract(odt))
+    }
+
+    @Test
+    fun `extract returns empty when there is no content xml`() {
+        val notOdt = zipOf("mimetype" to "application/zip", "other.xml" to "<x/>")
+        assertEquals("", OdtTextExtractor.extract(notOdt))
+    }
+
+    private fun zipOf(vararg entries: Pair<String, String>): ByteArray {
+        val bos = ByteArrayOutputStream()
+        ZipOutputStream(bos).use { zip ->
+            entries.forEach { (name, body) ->
+                zip.putNextEntry(ZipEntry(name))
+                zip.write(body.toByteArray(Charsets.UTF_8))
+                zip.closeEntry()
+            }
+        }
+        return bos.toByteArray()
+    }
+}

--- a/app/src/test/kotlin/in/jphe/storyvox/data/OdtTextExtractorTest.kt
+++ b/app/src/test/kotlin/in/jphe/storyvox/data/OdtTextExtractorTest.kt
@@ -10,7 +10,7 @@ import org.junit.Test
 class OdtTextExtractorTest {
 
     @Test
-    fun `paragraphs and headings become blank-line-separated blocks; spans inline`() {
+    fun `paragraphs and headings become blank-line-separated blocks, spans inline`() {
         val xml = """<?xml version="1.0" encoding="UTF-8"?>""" +
             "<office:document-content>" +
             """<office:automatic-styles><style:style style:name="P1"/></office:automatic-styles>""" +

--- a/app/src/test/kotlin/in/jphe/storyvox/navigation/DocumentImportClassifierTest.kt
+++ b/app/src/test/kotlin/in/jphe/storyvox/navigation/DocumentImportClassifierTest.kt
@@ -70,6 +70,19 @@ class DocumentImportClassifierTest {
         assertEquals(ImportKind.Pdf, classify("application/octet-stream", "manual.PDF"))
     }
 
+    // ── ODT (#1310 — OpenDocument Text) ──────────────────────────────
+
+    @Test
+    fun odt_classifiesOdt() {
+        assertEquals(ImportKind.Odt, classify("application/vnd.oasis.opendocument.text", "story.odt"))
+        assertEquals(ImportKind.Odt, classify(null, "story.odt"))
+        assertEquals(ImportKind.Odt, classify("APPLICATION/VND.OASIS.OPENDOCUMENT.TEXT", "story"))
+        // Generic mime + .odt extension (the common file-manager case).
+        assertEquals(ImportKind.Odt, classify("application/octet-stream", "novel.ODT"))
+        // A plain .zip must NOT be mistaken for an .odt (both are ZIP containers).
+        assertEquals(ImportKind.Unsupported, classify("application/zip", "archive.zip"))
+    }
+
     // ── Unsupported / edge ───────────────────────────────────────────
 
     @Test


### PR DESCRIPTION
Implements #1310 — **OpenDocument Text (`.odt`) import**. Mirrors the EPUB/PDF shape: an `.odt` is a ZIP whose `content.xml` holds ODF markup, so we unzip → strip to plain text → import through the existing plaintext path.

### Changes
- **`OdtTextExtractor`** (new, pure) — unzip `.odt`, read `content.xml`, convert ODF markup to plain text: `<text:p>`/`<text:h>` → blank-line-separated blocks, `<text:span>`/links inline, `<text:line-break/>`→`\n`, `<text:tab/>`→`\t`, `<text:s text:c="N"/>`→N spaces; scoped to `<office:text>`; XML entities decoded (`&amp;` last). The `odfXmlToText` seam is unit-tested directly off an XML string.
- **`DocumentImportClassifier`** — new `ImportKind.Odt` for `application/vnd.oasis.opendocument.text` (+ `application/x-vnd…`) and the `.odt` extension. A plain `.zip` is *not* misclassified.
- **`DocumentImporterUiImpl.registerOdt`** — extract the text once, stage it as a UTF-8 file under `filesDir` (durable across cache-clears; filename = hash of the source Uri so re-importing the same `.odt` dedupes to one fiction), then import via `EpubEntryKind.Text` — reusing the whole single-chapter plaintext path rather than adding a new source/parser stack.
- **AndroidManifest** — ODT mime + `.odt` pathPatterns in the VIEW (by-mime + by-extension) and SEND intent-filters, alongside the existing EPUB/TXT rows.

### Tests
- `OdtTextExtractorTest` — paragraphs/headings/spans, line-break/tab/space-run mapping, entity decoding (incl. the `&amp;lt;` round-trip), unknown-tag stripping, `<office:text>` scoping + fallback, and the real ZIP read (`extract`) incl. the no-`content.xml` case.
- `DocumentImportClassifierTest` — ODT by mime / extension / generic-mime+ext, and `.zip` staying Unsupported.

### Notes
ODT text is staged (not lazily re-extracted like EPUB/PDF) because the body needs unzip+strip up front; staging under `filesDir` keeps imported books readable after a cache clear.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
