### PR TITLE
refactor(reader): hoist teleprompter control state to a shared controller (#1308 PR1)

### DIFF
--- a/core-playback/src/main/kotlin/in/jphe/storyvox/playback/TeleprompterController.kt
+++ b/core-playback/src/main/kotlin/in/jphe/storyvox/playback/TeleprompterController.kt
@@ -1,0 +1,79 @@
+package `in`.jphe.storyvox.playback
+
+import javax.inject.Inject
+import javax.inject.Singleton
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+
+/**
+ * Issue #1308 — single source of truth for the teleprompter's user-facing
+ * controls (#1239 / #1306), hoisted out of `ReaderView`'s local Compose state so
+ * **both** the phone reader and the Wear bridge can drive one shared state.
+ *
+ * The teleprompter shipped (#1239) with `enabled` / `playing` / `wpm` held as
+ * `var … by remember` inside the reader composition — reachable only from the
+ * phone UI. The Wear teleprompter remote (#1308 PR2) needs to drive those same
+ * controls from `PhoneWearBridge` (core-playback), which can't see Compose
+ * state. Lifting them here — a `@Singleton`, exactly like [PlaybackController]
+ * that `PhoneWearBridge` already drives — gives both surfaces one source of
+ * truth.
+ *
+ * ## Scope
+ * Only the three **remote-able controls** live here. The teleprompter's *mode*
+ * (auto-scroll vs practice, #1306) and its practice-flow internals
+ * (`practiceTurn` / `practiceResumeFrom`) stay local to the reader — they're
+ * playhead/scroll-derived, not wrist controls, and a watch v1 only needs
+ * play / pause / pace.
+ *
+ * ## Lifecycle
+ * Being a `@Singleton`, this outlives any single reader visit. To preserve the
+ * #1239 "transient per session" phone behavior, the reader resets [setEnabled]
+ * and [setPlaying] to `false` when it leaves composition (a singleton retaining
+ * `enabled = true` across navigation would otherwise be a behavior change).
+ *
+ * ## WPM
+ * [wpm] is the **live** session pace. Persistence (#1287/#1304, via
+ * `SettingsRepositoryUi`) is bridged in `ReaderViewModel` — this module can't
+ * reach the settings layer. Clamping and the step math stay in the reader's
+ * pure helpers (`adjustTeleprompterWpm`); this holder stores whatever pace it's
+ * given.
+ */
+@Singleton
+class TeleprompterController @Inject constructor() {
+
+    private val _enabled = MutableStateFlow(false)
+
+    /** True when the teleprompter transport has replaced the normal reader
+     *  chrome. */
+    val enabled: StateFlow<Boolean> = _enabled.asStateFlow()
+
+    private val _playing = MutableStateFlow(false)
+
+    /** True while the auto-scroll is running (the rehearsal is "playing"). */
+    val playing: StateFlow<Boolean> = _playing.asStateFlow()
+
+    private val _wpm = MutableStateFlow(DEFAULT_WPM)
+
+    /** The live rehearsal pace in words-per-minute. Seeded from the persisted
+     *  pref (on enable) and written through to it on change — both bridged by
+     *  `ReaderViewModel`. */
+    val wpm: StateFlow<Int> = _wpm.asStateFlow()
+
+    fun setEnabled(enabled: Boolean) { _enabled.value = enabled }
+
+    fun setPlaying(playing: Boolean) { _playing.value = playing }
+
+    fun setWpm(wpm: Int) { _wpm.value = wpm }
+
+    private companion object {
+        /**
+         * Pre-seed default, mirroring `TELEPROMPTER_DEFAULT_WPM` in
+         * `:feature` (#1239). Duplicated as a literal because core-playback
+         * can't depend on `:feature`; it's only the value shown before the
+         * reader seeds the persisted pace on enable (#1287/#1304), so the two
+         * never meaningfully diverge.
+         */
+        const val DEFAULT_WPM = 130
+    }
+}

--- a/core-playback/src/test/kotlin/in/jphe/storyvox/playback/TeleprompterControllerTest.kt
+++ b/core-playback/src/test/kotlin/in/jphe/storyvox/playback/TeleprompterControllerTest.kt
@@ -1,0 +1,45 @@
+package `in`.jphe.storyvox.playback
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * Issue #1308 — the teleprompter control state, hoisted out of `ReaderView` into
+ * this shared `@Singleton` so the phone reader and the Wear remote (PR2) drive
+ * one source of truth. These pin the holder's defaults + setter→StateFlow
+ * contract (the reader collects these flows and calls the setters).
+ */
+class TeleprompterControllerTest {
+
+    @Test
+    fun `defaults are off, off, and the 130 wpm pre-seed`() {
+        val controller = TeleprompterController()
+        assertFalse("teleprompter starts disabled", controller.enabled.value)
+        assertFalse("teleprompter starts not playing", controller.playing.value)
+        assertEquals("pre-seed pace mirrors TELEPROMPTER_DEFAULT_WPM", 130, controller.wpm.value)
+    }
+
+    @Test
+    fun `setters update their state flows`() {
+        val controller = TeleprompterController()
+
+        controller.setEnabled(true)
+        assertTrue(controller.enabled.value)
+
+        controller.setPlaying(true)
+        assertTrue(controller.playing.value)
+
+        controller.setWpm(220)
+        assertEquals(220, controller.wpm.value)
+
+        // The reader resets the transient controls on dispose (#1308); the
+        // holder just stores whatever it's given.
+        controller.setEnabled(false)
+        controller.setPlaying(false)
+        assertFalse(controller.enabled.value)
+        assertFalse(controller.playing.value)
+        assertEquals("wpm is independent of enabled/playing", 220, controller.wpm.value)
+    }
+}

--- a/feature/src/main/kotlin/in/jphe/storyvox/feature/reader/HybridReaderScreen.kt
+++ b/feature/src/main/kotlin/in/jphe/storyvox/feature/reader/HybridReaderScreen.kt
@@ -109,7 +109,10 @@ fun HybridReaderScreen(
     val currentAuthor by viewModel.currentAuthor.collectAsStateWithLifecycle()
     // Issue #1230 — tap-to-define dictionary popup state.
     val definitionState by viewModel.dictionary.collectAsStateWithLifecycle()
-    // Issue #1287 — persisted teleprompter pace (WPM).
+    // Issue #1308 — teleprompter control state, hoisted to the shared
+    // TeleprompterController (single source of truth for the reader + Wear remote).
+    val teleprompterEnabled by viewModel.teleprompterEnabled.collectAsStateWithLifecycle()
+    val teleprompterPlaying by viewModel.teleprompterPlaying.collectAsStateWithLifecycle()
     val teleprompterWpm by viewModel.teleprompterWpm.collectAsStateWithLifecycle()
     val playback = state.playback
 
@@ -406,10 +409,16 @@ fun HybridReaderScreen(
                 onDefineWord = viewModel::defineWord,
                 onDismissDefinition = viewModel::dismissDefinition,
                 onRetryDefine = viewModel::retryDefine,
-                // Issue #1287 — seed the teleprompter pace from the persisted
-                // pref and write changes back so it survives a restart.
-                persistedTeleprompterWpm = teleprompterWpm,
-                onTeleprompterWpmChange = viewModel::setTeleprompterWpm,
+                // Issue #1308 — teleprompter controls from the shared controller;
+                // setters drive it (and persist WPM via the VM, #1287/#1304), and
+                // onReset clears the transient state when the reader leaves.
+                teleprompterEnabled = teleprompterEnabled,
+                teleprompterPlaying = teleprompterPlaying,
+                teleprompterWpm = teleprompterWpm,
+                onSetTeleprompterEnabled = viewModel::setTeleprompterEnabled,
+                onSetTeleprompterPlaying = viewModel::setTeleprompterPlaying,
+                onSetTeleprompterWpm = viewModel::setTeleprompterWpm,
+                onResetTeleprompter = viewModel::resetTeleprompter,
             )
         },
     )

--- a/feature/src/main/kotlin/in/jphe/storyvox/feature/reader/ReaderView.kt
+++ b/feature/src/main/kotlin/in/jphe/storyvox/feature/reader/ReaderView.kt
@@ -59,6 +59,7 @@ import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.derivedStateOf
 import androidx.compose.runtime.getValue
@@ -313,13 +314,23 @@ fun ReaderTextView(
     onDismissDefinition: () -> Unit = {},
     /** Issue #1230 — retry a failed lookup (→ [ReaderViewModel.retryDefine]). */
     onRetryDefine: (String) -> Unit = {},
-    /** Issue #1287 — persisted teleprompter (#1239) pace (WPM) to seed the
-     *  per-session pace from when the teleprompter opens. Default keeps
-     *  preview/test callsites at [TELEPROMPTER_DEFAULT_WPM]. */
-    persistedTeleprompterWpm: Int = TELEPROMPTER_DEFAULT_WPM,
-    /** Issue #1287 — persist a teleprompter pace change (→
-     *  [ReaderViewModel.setTeleprompterWpm]) so it survives a restart. No-op default. */
-    onTeleprompterWpmChange: (Int) -> Unit = {},
+    /** Issue #1308 — teleprompter control state, hoisted to [TeleprompterController]
+     *  (collected via [ReaderViewModel]) so the reader and the Wear remote share
+     *  one source of truth. Mode + practice-flow state stay local below. Defaults
+     *  keep preview/test/audiobook callsites unchanged. */
+    teleprompterEnabled: Boolean = false,
+    teleprompterPlaying: Boolean = false,
+    teleprompterWpm: Int = TELEPROMPTER_DEFAULT_WPM,
+    /** Issue #1308 — drive the shared teleprompter controls (→ ReaderViewModel
+     *  setters). [onSetTeleprompterWpm] also persists the pace (#1287/#1304);
+     *  [onSetTeleprompterEnabled] with `true` seeds the pace from the saved pref. */
+    onSetTeleprompterEnabled: (Boolean) -> Unit = {},
+    onSetTeleprompterPlaying: (Boolean) -> Unit = {},
+    onSetTeleprompterWpm: (Int) -> Unit = {},
+    /** Issue #1308 — reset the transient controls when the reader leaves
+     *  composition (→ [ReaderViewModel.resetTeleprompter]). Preserves #1239's
+     *  per-visit-transient behavior against the @Singleton controller. */
+    onResetTeleprompter: () -> Unit = {},
     modifier: Modifier = Modifier,
 ) {
     val spacing = LocalSpacing.current
@@ -361,21 +372,18 @@ fun ReaderTextView(
         }
     }
 
-    // Issue #1239 — Teleprompter / solo-rehearsal mode state. Transient
-    // (per-session) by design for this first cut — no persistence plumbing.
-    // `enabled` swaps the bottom transport for the teleprompter controls and
-    // steps the TTS-follow affordances aside; `playing` drives the per-frame
-    // auto-scroll; `wpm` is the rehearsal pace.
-    var teleprompterEnabled by remember { mutableStateOf(false) }
-    var teleprompterPlaying by remember { mutableStateOf(false) }
-    // Issue #1287 — the pace is now persisted (#1239 shipped it transient). Seed
-    // the session value from the saved pref, and re-seed each time the
-    // teleprompter opens so a restart restores the last pace (the persisted Flow
-    // has loaded by the time the user taps the teleprompter button). Within a
-    // session the local value leads; adjustments write through below.
-    var teleprompterWpm by remember { mutableIntStateOf(persistedTeleprompterWpm) }
-    LaunchedEffect(teleprompterEnabled) {
-        if (teleprompterEnabled) teleprompterWpm = persistedTeleprompterWpm
+    // Issue #1308 — `teleprompterEnabled` / `teleprompterPlaying` / `teleprompterWpm`
+    // are now hoisted to the shared [TeleprompterController] and arrive as
+    // parameters (collected from [ReaderViewModel]); writes go through the
+    // on-set callbacks. Mode + practice-flow state below stay local. Seeding the
+    // pace from the persisted pref now happens in the VM's setTeleprompterEnabled
+    // (#1287/#1304), not here.
+    //
+    // The controller is a @Singleton, so reset the transient controls when the
+    // reader leaves composition — this preserves #1239's per-visit-transient
+    // behavior (a leftover `enabled = true` must not survive navigating away).
+    DisposableEffect(Unit) {
+        onDispose { onResetTeleprompter() }
     }
     val totalWords = remember(chapterText) { countWords(chapterText) }
     // True once the body has scrolled to the very end — the teleprompter's
@@ -474,7 +482,7 @@ fun ReaderTextView(
                     }
                 }
                 if (scroll.value >= scroll.maxValue) {
-                    teleprompterPlaying = false
+                    onSetTeleprompterPlaying(false)
                     break
                 }
             }
@@ -825,7 +833,7 @@ fun ReaderTextView(
         // When on, the bottom chrome becomes the teleprompter controls.
         if (!focusModeEnabled && !teleprompterEnabled) {
             SmallFloatingActionButton(
-                onClick = { teleprompterEnabled = true },
+                onClick = { onSetTeleprompterEnabled(true) },
                 modifier = Modifier
                     .align(Alignment.BottomEnd)
                     .padding(end = spacing.md, bottom = 360.dp)
@@ -1059,7 +1067,7 @@ fun ReaderTextView(
                     onSelect = { picked ->
                         if (picked != teleprompterMode) {
                             teleprompterMode = picked
-                            teleprompterPlaying = false // stop the silent auto-scroll
+                            onSetTeleprompterPlaying(false) // stop the silent auto-scroll
                             practiceTurn = null
                             if (state.isPlaying) onPlayPause() // pause TTS across a swap
                         }
@@ -1075,20 +1083,20 @@ fun ReaderTextView(
                                 // so the per-frame effect starts fresh.
                                 scope.launch {
                                     scroll.scrollTo(0)
-                                    teleprompterPlaying = true
+                                    onSetTeleprompterPlaying(true)
                                 }
                             } else {
-                                teleprompterPlaying = !teleprompterPlaying
+                                onSetTeleprompterPlaying(!teleprompterPlaying)
                             }
                         },
                         onWpmDelta = { steps ->
-                            teleprompterWpm = adjustTeleprompterWpm(teleprompterWpm, steps)
-                            // #1287/#1304 — persist the pace so it survives a restart.
-                            onTeleprompterWpmChange(teleprompterWpm)
+                            // #1308 — update the live pace and persist it (the VM
+                            // setter writes through to SettingsRepositoryUi, #1287/#1304).
+                            onSetTeleprompterWpm(adjustTeleprompterWpm(teleprompterWpm, steps))
                         },
                         onExit = {
-                            teleprompterPlaying = false
-                            teleprompterEnabled = false
+                            onSetTeleprompterPlaying(false)
+                            onSetTeleprompterEnabled(false)
                         },
                     )
                     TeleprompterMode.Practice -> PracticeTransport(
@@ -1112,7 +1120,7 @@ fun ReaderTextView(
                         onExit = {
                             practiceTurn = null
                             if (state.isPlaying) onPlayPause() // stop TTS on exit
-                            teleprompterEnabled = false
+                            onSetTeleprompterEnabled(false)
                         },
                     )
                 }

--- a/feature/src/main/kotlin/in/jphe/storyvox/feature/reader/ReaderViewModel.kt
+++ b/feature/src/main/kotlin/in/jphe/storyvox/feature/reader/ReaderViewModel.kt
@@ -27,6 +27,7 @@ import `in`.jphe.storyvox.feature.api.UiRecapPlaybackState
 import `in`.jphe.storyvox.feature.api.UiSleepTimerMode
 import `in`.jphe.storyvox.ui.theme.ReaderColors
 import `in`.jphe.storyvox.playback.PlaybackUiEvent
+import `in`.jphe.storyvox.playback.TeleprompterController
 import `in`.jphe.storyvox.llm.LlmError
 import `in`.jphe.storyvox.llm.feature.ChapterRecap
 import `in`.jphe.storyvox.ui.component.ReaderView
@@ -287,6 +288,13 @@ class ReaderViewModel @Inject constructor(
      * parallel `*Ui` port.
      */
     private val dictionaryRepo: DictionaryRepository,
+    /**
+     * Issue #1308 — shared teleprompter control state (enabled / playing / wpm),
+     * hoisted out of `ReaderView`'s local Compose state into a `@Singleton` in
+     * core-playback so the reader and the Wear remote (PR2) drive one source of
+     * truth. Mode + practice-flow state intentionally stay local to the reader.
+     */
+    private val teleprompter: TeleprompterController,
     savedState: SavedStateHandle,
 ) : ViewModel() {
 
@@ -793,16 +801,18 @@ class ReaderViewModel @Inject constructor(
         .distinctUntilChanged()
         .stateIn(viewModelScope, SharingStarted.WhileSubscribed(5_000), 0)
 
-    /**
-     * Issue #1287 — persisted teleprompter (#1239) auto-scroll pace (WPM).
-     * [ReaderTextView] seeds its per-session pace from this when the teleprompter
-     * opens, and writes user adjustments back via [setTeleprompterWpm] so the
-     * pace is restored on the next session. Device-local pref.
-     */
-    val teleprompterWpm: StateFlow<Int> = settings.settings
-        .map { it.teleprompterWpm }
-        .distinctUntilChanged()
-        .stateIn(viewModelScope, SharingStarted.WhileSubscribed(5_000), TELEPROMPTER_DEFAULT_WPM)
+    // Issue #1308 — teleprompter control state, now owned by the shared
+    // [TeleprompterController] (single source of truth for the phone reader and
+    // the Wear remote). The reader collects these and drives them via the
+    // setters below; the controller is a @Singleton, so PR2's Wear bridge drives
+    // the same state.
+    val teleprompterEnabled: StateFlow<Boolean> = teleprompter.enabled
+    val teleprompterPlaying: StateFlow<Boolean> = teleprompter.playing
+
+    /** Live rehearsal pace (WPM). Seeded from the persisted pref when the
+     *  teleprompter opens and written through on change — see
+     *  [setTeleprompterEnabled] / [setTeleprompterWpm] (#1287/#1304). */
+    val teleprompterWpm: StateFlow<Int> = teleprompter.wpm
 
     /** Issue #278 — user-initiated retry from the timed-out error block.
      *  Re-invokes the playback `play()` path; the underlying controller
@@ -1150,11 +1160,40 @@ class ReaderViewModel @Inject constructor(
         viewModelScope.launch { settings.setReaderFocusModeEnabled(enabled) }
     }
 
-    /** Issue #1287 — persist the teleprompter pace so it survives an app restart.
-     *  Fire-and-forget, same shape as [setAutoScrollEnabled]; the impl clamps to
-     *  the supported band and the [teleprompterWpm] StateFlow re-emits. */
+    /** Issue #1308 — drive the shared teleprompter controls. The reader calls
+     *  these (and, in PR2, the Wear bridge); the controller's StateFlows re-emit
+     *  so every observer stays in sync. */
+    fun setTeleprompterEnabled(enabled: Boolean) {
+        teleprompter.setEnabled(enabled)
+        // Issue #1287/#1304 — seed the live pace from the persisted pref each
+        // time the teleprompter opens, so a restart restores the last pace. Read
+        // the current pref on demand (the settings flow is cached) rather than a
+        // hot StateFlow, so the seed is the real saved value, not a placeholder.
+        if (enabled) {
+            viewModelScope.launch {
+                teleprompter.setWpm(settings.settings.first().teleprompterWpm)
+            }
+        }
+    }
+
+    fun setTeleprompterPlaying(playing: Boolean) {
+        teleprompter.setPlaying(playing)
+    }
+
+    /** Issue #1287/#1304 — update the live pace AND persist it (the impl clamps
+     *  to the supported band; the next open re-seeds from the saved value). */
     fun setTeleprompterWpm(wpm: Int) {
+        teleprompter.setWpm(wpm)
         viewModelScope.launch { settings.setTeleprompterWpm(wpm) }
+    }
+
+    /** Issue #1308 — reset the transient controls when the reader leaves
+     *  composition. The [TeleprompterController] is a @Singleton, so without
+     *  this it would retain `enabled` across navigation — a behavior change from
+     *  #1239's per-visit-transient local state. */
+    fun resetTeleprompter() {
+        teleprompter.setEnabled(false)
+        teleprompter.setPlaying(false)
     }
 
     // Issue #121 — in-chapter bookmark fan-out. ReaderViewModel stays


### PR DESCRIPTION
## Summary

**PR 1 of 2** for the Wear teleprompter remote (#1308). Pure refactor — **no phone behavior change**. Hoists the teleprompter's control state out of `ReaderView`'s local Compose state into a shared, observable controller so PR 2's `PhoneWearBridge` can drive the same state the reader shows.

### Why
The teleprompter (#1239) held `enabled` / `playing` / `wpm` as `var … by remember` inside `ReaderView` — reachable only from the phone UI. The Wear remote needs to drive those from `PhoneWearBridge` (core-playback), which can't see Compose state. There has to be one source of truth both surfaces share.

## What changed

- **New `TeleprompterController`** (core-playback) — a `@Singleton` with an `@Inject` constructor (Hilt auto-binds), exposing `enabled` / `playing` / `wpm` as `StateFlow`s + setters. Same shape `PhoneWearBridge` already uses to drive `PlaybackController`, so PR 2 injects it the same way.
- **`ReaderViewModel`** injects it, exposes the flows + `setTeleprompterEnabled` / `setTeleprompterPlaying` / `setTeleprompterWpm` / `resetTeleprompter`, and **bridges WPM persistence** (seeds the live pace from `SettingsRepositoryUi` on open via an on-demand `settings.first()` read; writes through on change — preserving #1287/#1304).
- **`ReaderView`** reads the three as parameters and writes via on-set callbacks; a `DisposableEffect` resets the transient controls on leave. `HybridReaderScreen` collects + wires.

## Behavior preservation (the bar for this PR)

- **Per-visit-transient**: a `@Singleton` would otherwise keep `enabled = true` across navigation. The `DisposableEffect { onDispose { resetTeleprompter() } }` mirrors the old `remember { false }` exactly — including the existing reset-on-rotation behavior.
- **WPM seed-on-open + persist**: unchanged user-visible behavior; the seed now reads the real saved value (not a placeholder) and the `±` write-through still persists.
- All ~32 `ReaderView` references rewired; reads resolve to the collected params, writes to callbacks. No bare assignments remain.

## Scope (as agreed)

Only the **three remote-able controls** move. Teleprompter **`mode`** (auto-scroll vs practice, #1306) and **practice-flow internals** (`practiceTurn` / `practiceResumeFrom`) stay local to the reader — they're playhead/scroll-derived, not wrist controls, and a watch v1 needs only play / pause / pace. The #1306 practice effect only *reads* `enabled`, so the touch there is minimal.

**`PhoneWearBridge` is untouched here** — this PR just establishes the controller where the bridge can inject it. The `/teleprompter/cmd` protocol + watch UI are **PR 2**.

## Tests

`TeleprompterControllerTest` (plain JUnit, core-playback) pins the defaults + setter→StateFlow contract. New `ReaderTextView` params are defaulted, so existing reader callsites/tests are unaffected. No local gradle (CI is the compile/test gate).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
