### PR TITLE
feat(fiction): deep-link sharing — candela://fiction/<id> (#1313)

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -92,6 +92,21 @@
             </intent-filter>
 
             <!--
+                Issue #1313 — fiction share deep link. A shared
+                `candela://fiction/<url-encoded fictionId>` link opens the
+                app straight to that fiction's detail. DeepLinkResolver
+                parses it off the intent's dataString (FictionShareLink); the
+                fictionId carries its own source prefix, so FictionRepository
+                routes it to the right backend on open (#1298).
+            -->
+            <intent-filter android:label="@string/open_with_label">
+                <action android:name="android.intent.action.VIEW" />
+                <category android:name="android.intent.category.DEFAULT" />
+                <category android:name="android.intent.category.BROWSABLE" />
+                <data android:scheme="candela" android:host="fiction" />
+            </intent-filter>
+
+            <!--
                 Issue #472 — Magic-link audiobook. Accept ACTION_SEND
                 with text/plain so the user can share any URL from any
                 app (browser, RSS reader, podcast app, social-media

--- a/app/src/main/kotlin/in/jphe/storyvox/navigation/StoryvoxNavHost.kt
+++ b/app/src/main/kotlin/in/jphe/storyvox/navigation/StoryvoxNavHost.kt
@@ -32,6 +32,7 @@ import `in`.jphe.storyvox.R
 import `in`.jphe.storyvox.auth.AuthWebViewScreen
 import `in`.jphe.storyvox.auth.anthropic.AnthropicTeamsSignInScreen
 import `in`.jphe.storyvox.auth.github.GitHubSignInScreen
+import `in`.jphe.storyvox.data.share.FictionShareLink
 import `in`.jphe.storyvox.data.source.SourceIds
 import `in`.jphe.storyvox.source.github.auth.GitHubAuthConfig
 import `in`.jphe.storyvox.feature.browse.BrowseScreen
@@ -1542,6 +1543,15 @@ object DeepLinkResolver {
                 return StoryvoxRoutes.libraryWithShare(shared)
             }
             return null
+        }
+        // Issue #1313 — fiction share deep link: candela://fiction/<id>.
+        // Parse off the raw dataString so the share-link builder and this
+        // parser share one implementation ([FictionShareLink]) instead of
+        // re-deriving via android.net.Uri. The fictionId carries its own
+        // source prefix, so FictionRepository routes it on open.
+        if (intent.action == Intent.ACTION_VIEW) {
+            intent.dataString?.let { FictionShareLink.parse(it) }
+                ?.let { return StoryvoxRoutes.fictionDetail(it) }
         }
         // Open-with deep link from royalroad.com.
         if (intent.action != Intent.ACTION_VIEW) return null

--- a/core-data/src/main/kotlin/in/jphe/storyvox/data/share/FictionShareLink.kt
+++ b/core-data/src/main/kotlin/in/jphe/storyvox/data/share/FictionShareLink.kt
@@ -1,0 +1,55 @@
+package `in`.jphe.storyvox.data.share
+
+import java.net.URLDecoder
+import java.net.URLEncoder
+
+/**
+ * Issue #1313 — shareable deep link for a fiction.
+ *
+ * Format: `candela://fiction/<url-encoded fictionId>`
+ *
+ * The fictionId already carries its source — `gutenberg:84`, `epub:<hash>`,
+ * `ao3:123`, … — or is a bare numeric id (Royal Road). `FictionRepository`
+ * routes it to the right backend by that prefix (`sourceIdForFictionId`,
+ * #1298), so the whole id in a single path segment is all the link needs;
+ * no separate `sourceId` segment.
+ *
+ * The id is percent-encoded so reserved characters survive one path segment
+ * — the `:` in every prefixed id, and the `/` in ids like
+ * `discord:guild/channel`. [build] and [parse] are exact inverses.
+ *
+ * Pure string operations (no `android.net.Uri`) so the build side
+ * (FictionDetail share) and the parse side (`DeepLinkResolver`) use one
+ * implementation and it unit-tests without Robolectric. `DeepLinkResolver`
+ * feeds [parse] the inbound intent's `dataString`.
+ */
+object FictionShareLink {
+    const val SCHEME: String = "candela"
+    const val HOST: String = "fiction"
+
+    /** `candela://fiction/` — the scheme + authority every link starts with. */
+    private const val PREFIX: String = "$SCHEME://$HOST/"
+
+    /** Build the shareable link for [fictionId]. */
+    fun build(fictionId: String): String = PREFIX + encode(fictionId)
+
+    /**
+     * If [uri] is a fiction share link, return its decoded fictionId; else
+     * null. Tolerant of case in the scheme/authority (RFC 3986 §3.1 — and
+     * Android lowercases the scheme) and of a query/fragment or trailing
+     * slash tail.
+     */
+    fun parse(uri: String): String? {
+        val trimmed = uri.trim()
+        if (!trimmed.regionMatches(0, PREFIX, 0, PREFIX.length, ignoreCase = true)) return null
+        val tail = trimmed.substring(PREFIX.length)
+            .substringBefore('?')
+            .substringBefore('#')
+            .trimEnd('/')
+        if (tail.isEmpty()) return null
+        return runCatching { decode(tail) }.getOrNull()?.takeIf { it.isNotBlank() }
+    }
+
+    private fun encode(s: String): String = URLEncoder.encode(s, Charsets.UTF_8.name())
+    private fun decode(s: String): String = URLDecoder.decode(s, Charsets.UTF_8.name())
+}

--- a/core-data/src/test/kotlin/in/jphe/storyvox/data/share/FictionShareLinkTest.kt
+++ b/core-data/src/test/kotlin/in/jphe/storyvox/data/share/FictionShareLinkTest.kt
@@ -1,0 +1,65 @@
+package `in`.jphe.storyvox.data.share
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Test
+
+/**
+ * Issue #1313 — fiction share-link build/parse round-trips. Pure (no Android
+ * types), so it runs as a plain JUnit test.
+ */
+class FictionShareLinkTest {
+
+    @Test
+    fun roundTrip_prefixedId() {
+        val id = "gutenberg:84"
+        val link = FictionShareLink.build(id)
+        assertEquals("candela://fiction/gutenberg%3A84", link)
+        assertEquals(id, FictionShareLink.parse(link))
+    }
+
+    @Test
+    fun roundTrip_bareNumericRoyalRoadId() {
+        val id = "123456"
+        assertEquals("candela://fiction/123456", FictionShareLink.build(id))
+        assertEquals(id, FictionShareLink.parse(FictionShareLink.build(id)))
+    }
+
+    @Test
+    fun roundTrip_idWithSlash_isPreservedInOneSegment() {
+        // discord:guild/channel — the '/' must be encoded so it stays one
+        // path segment and decodes back intact.
+        val id = "discord:111/222"
+        val link = FictionShareLink.build(id)
+        assertEquals("candela://fiction/discord%3A111%2F222", link)
+        assertEquals(id, FictionShareLink.parse(link))
+    }
+
+    @Test
+    fun roundTrip_epubHashId() {
+        val id = "epub:9469520f"
+        assertEquals(id, FictionShareLink.parse(FictionShareLink.build(id)))
+    }
+
+    @Test
+    fun parse_isCaseInsensitiveOnSchemeAndHost() {
+        assertEquals("gutenberg:84", FictionShareLink.parse("CANDELA://Fiction/gutenberg%3A84"))
+    }
+
+    @Test
+    fun parse_toleratesTrailingSlashAndQueryAndFragment() {
+        assertEquals("ao3:42", FictionShareLink.parse("candela://fiction/ao3%3A42/"))
+        assertEquals("ao3:42", FictionShareLink.parse("candela://fiction/ao3%3A42?utm=x"))
+        assertEquals("ao3:42", FictionShareLink.parse("candela://fiction/ao3%3A42#frag"))
+    }
+
+    @Test
+    fun parse_rejectsNonFictionLinks() {
+        assertNull(FictionShareLink.parse("https://royalroad.com/fiction/123"))
+        assertNull(FictionShareLink.parse("candela://reader/abc"))
+        assertNull(FictionShareLink.parse("candela://fiction/")) // no id
+        assertNull(FictionShareLink.parse("storyvox://fiction/123"))
+        assertNull(FictionShareLink.parse(""))
+        assertNull(FictionShareLink.parse("not a uri at all"))
+    }
+}

--- a/feature/src/main/kotlin/in/jphe/storyvox/feature/fiction/FictionDetailScreen.kt
+++ b/feature/src/main/kotlin/in/jphe/storyvox/feature/fiction/FictionDetailScreen.kt
@@ -1,5 +1,6 @@
 package `in`.jphe.storyvox.feature.fiction
 
+import android.content.Context
 import android.content.Intent
 import androidx.activity.compose.rememberLauncherForActivityResult
 import androidx.activity.result.contract.ActivityResultContracts
@@ -72,6 +73,7 @@ import androidx.compose.ui.unit.dp
 import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import `in`.jphe.storyvox.data.annotation.AnnotationExportFormatter
+import `in`.jphe.storyvox.data.share.FictionShareLink
 import `in`.jphe.storyvox.data.source.companion.CompanionMatch
 import `in`.jphe.storyvox.feature.R
 import `in`.jphe.storyvox.feature.api.UiChapter
@@ -400,6 +402,18 @@ fun FictionDetailScreen(
                                     onClick = {
                                         menuOpen = false
                                         viewModel.exportToAudiobook()
+                                    },
+                                )
+                                // Issue #1313 — share a deep link to this
+                                // fiction (candela://fiction/<id>); the
+                                // recipient's app opens straight to detail.
+                                DropdownMenuItem(
+                                    text = { Text(stringResource(R.string.fiction_share_link)) },
+                                    onClick = {
+                                        menuOpen = false
+                                        state.fiction?.let { f ->
+                                            shareFictionLink(context, f.id, f.title)
+                                        }
                                     },
                                 )
                                 // PR-H (#86) — destructive cache wipe for
@@ -845,6 +859,21 @@ fun FictionDetailScreen(
         },
         onDismiss = { viewModel.clearAudiobookExport() },
     )
+}
+
+/**
+ * Issue #1313 — share a deep link to a fiction via the system share sheet.
+ * The link ([FictionShareLink.build]) is `candela://fiction/<id>`, which a
+ * receiving Candela install opens straight to this fiction's detail screen
+ * (DeepLinkResolver → FictionRepository routes the id by its source prefix).
+ */
+private fun shareFictionLink(context: Context, fictionId: String, title: String) {
+    val send = Intent(Intent.ACTION_SEND).apply {
+        type = "text/plain"
+        putExtra(Intent.EXTRA_TEXT, FictionShareLink.build(fictionId))
+        putExtra(Intent.EXTRA_SUBJECT, title)
+    }
+    context.startActivity(Intent.createChooser(send, null))
 }
 
 /**

--- a/feature/src/main/res/values/strings.xml
+++ b/feature/src/main/res/values/strings.xml
@@ -401,6 +401,8 @@
     <string name="fiction_export_epub">Export as EPUB…</string>
     <!-- Issue #1003 — turn this fiction into a chaptered .m4b audiobook. -->
     <string name="fiction_export_audiobook">Export as audiobook…</string>
+    <!-- #1313 — share a deep link (candela://fiction/<id>) to this fiction -->
+    <string name="fiction_share_link">Share link</string>
     <string name="fiction_clear_cache">Clear fiction cache…</string>
     <!-- Issue #999 — highlights + notes list + export. -->
     <string name="fiction_highlights_title">Highlights &amp; notes</string>


### PR DESCRIPTION
## Closes #1313 — deep-link support for fiction sharing

Share a fiction as a link; tapping it opens Candela straight to that fiction's detail screen.

## What

1. **URI scheme** `candela://fiction/<url-encoded fictionId>` — `FictionShareLink` (core-data, pure: `build` / `parse`).
2. **Intent filter** — `AndroidManifest.xml` VIEW filter for `scheme=candela host=fiction` (DEFAULT + BROWSABLE).
3. **Deep-link route** — `DeepLinkResolver.resolve()` parses the link off the intent's `dataString` → `StoryvoxRoutes.fictionDetail(id)` (the existing route into `FictionDetailScreen`).
4. **Share button** — "Share link" item in the FictionDetail overflow menu → system share sheet (`ACTION_SEND`).
5. **Tests** — `FictionShareLinkTest` (pure JUnit).

## Design notes

- **No separate `sourceId` segment.** The fictionId *already* carries its source — `gutenberg:84`, `epub:<hash>`, `ao3:123` — or is bare-numeric (Royal Road). `FictionRepository` routes it to the right backend by that prefix (`sourceIdForFictionId`, #1298). So the whole id rides in one path segment.
- **Percent-encoded** so reserved chars survive one segment: the `:` in every prefix and the `/` in ids like `discord:guild/channel`. `build`/`parse` are exact inverses and share one pure impl (no `android.net.Uri`), so the share side and the resolver side can't drift — and it unit-tests without Robolectric.
- **Reuses existing infrastructure** — `DeepLinkResolver`, the `fictionDetail` route, MainActivity's intent handling — rather than a parallel path. The resolver slots the `candela://` check ahead of the existing royalroad.com / ACTION_SEND handling.
- **Cross-device**: opening a shared link routes through `refreshDetail`, which hydrates network-source fictions (Gutenberg/AO3/Royal Road/Wikipedia/…) on the recipient's device. Local-only ids (`epub:`/`pdf:` SAF imports) can't be rebuilt on another device — they surface the standard "couldn't load" state rather than crashing. A future enhancement could hide Share for non-shareable sources.
- **https App Links** (verified, via `candela.techempower.org` which we control) are a viable follow-up; the custom scheme is the minimal-infra choice per the issue's default.

## Test
`FictionShareLinkTest` round-trips prefixed / bare-numeric / slash-containing / hash ids, is case-insensitive on scheme+host, tolerates query/fragment/trailing-slash, and rejects non-fiction links. Not compiled locally — CI is the gate.

## Risk
Additive: a new intent-filter, a new resolver branch (ahead of existing ones, falls through on non-match), a new pure module, and one overflow menu item. No existing path changes behavior.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
