### PR TITLE
fix(playback): surface error instead of silently skipping a zero-audio chapter (#1311)

### DIFF
--- a/core-playback/src/main/kotlin/in/jphe/storyvox/playback/tts/EnginePlayer.kt
+++ b/core-playback/src/main/kotlin/in/jphe/storyvox/playback/tts/EnginePlayer.kt
@@ -319,6 +319,38 @@ internal fun crossedThermalModerateBoundary(prev: Int, status: Int): Boolean =
         status < ThermalMonitor.THERMAL_STATUS_MODERATE)
 
 /**
+ * Issue #1311 — did playback reach a "natural end" having produced ZERO
+ * audio chunks?
+ *
+ * The producer ([in.jphe.storyvox.playback.tts.source.EngineStreamingSource])
+ * sets `producedAllSentences = true` once it has *walked* every sentence —
+ * but it `?: continue`s past any sentence whose `generateAudioPCM` returns
+ * null (engine not loaded, synth failure), enqueueing no chunk for it. If
+ * EVERY sentence comes back null the producer still flips that flag and
+ * pushes END_PILL, so the consumer reads `naturalEnd = producedAllSentences
+ * = true` having dequeued no chunks. Pre-#1311 that drove handleChapterDone
+ * → advanceChapter and the chapter was SILENTLY SKIPPED — the same
+ * user-visible failure class as #1262, but originating in synthesis rather
+ * than the buffering watchdog.
+ *
+ * [chunksEmitted] is the consumer's running count of non-null chunks
+ * dequeued for the chapter; zero at a natural end means "the chapter
+ * produced no audio at all," so the caller surfaces a retryable error
+ * instead of advancing.
+ *
+ * This is the empty-*PCM* sibling of the #442 empty-*sentence* guard (which
+ * fires before the pipeline starts, when the chunker yields 0 sentences);
+ * this fires after, when sentences existed but none synthesised to audio.
+ *
+ * Extracted as a top-level function so the rule can be exercised in a pure
+ * unit test (EnginePlayerSilentChapterTest) without standing up the full
+ * EnginePlayer + Hilt + sherpa-onnx graph — same constraint that gates
+ * [shouldAutoPlayAfterAdvance] / [shouldCheckpointPosition].
+ */
+internal fun isSilentNaturalEnd(naturalEnd: Boolean, chunksEmitted: Int): Boolean =
+    naturalEnd && chunksEmitted == 0
+
+/**
  * Issue #189 — playback state for the one-shot recap-aloud TTS pipeline.
  * Distinct from [PlaybackState] because the recap is a transient utterance
  * with its own AudioTrack; conflating the two would force every chapter
@@ -3092,6 +3124,12 @@ class EnginePlayer @AssistedInject constructor(
         consumerThread = Thread({
             AndroidProcess.setThreadPriority(AndroidProcess.THREAD_PRIORITY_URGENT_AUDIO)
             var naturalEnd = false
+            // Issue #1311 — count non-null chunks dequeued this chapter.
+            // A natural end (producedAllSentences) reached with zero chunks
+            // means every sentence's synth returned null and the chapter is
+            // silent; surface an error rather than silently auto-advancing
+            // past it (see [isSilentNaturalEnd] + the finally below).
+            var chunksProduced = 0
             var firstSentence = true
             // Track AudioTrack pause state so the buffer-low check below can
             // toggle play/pause without thrashing JNI on every iteration.
@@ -3212,6 +3250,11 @@ class EnginePlayer @AssistedInject constructor(
                         break
                     }
                     val chunk = chunkOrNull
+                    // #1311 — a non-null chunk means the producer emitted
+                    // real synth output (null PCM is `?: continue`'d in the
+                    // producer and never enqueued), so this chapter is not
+                    // silent. Counted for the silent-chapter guard below.
+                    chunksProduced++
 
                     // Surface the new sentence range BEFORE writing. Fire-
                     // and-forget on Main — withContext would force this
@@ -3591,6 +3634,51 @@ class EnginePlayer @AssistedInject constructor(
                     }
                 }
             } finally {
+                // Issue #1311 — silent-chapter guard, checked BEFORE the
+                // natural-end fanout below. The producer can report
+                // producedAllSentences=true having emitted ZERO audio chunks:
+                // every sentence's generateAudioPCM returned null (engine not
+                // loaded / synth failure) so the producer loop `?: continue`'d
+                // past all of them. `naturalEnd` was then set from that flag,
+                // and the #573 block below would dispatch handleChapterDone →
+                // advanceChapter, SILENTLY SKIPPING the chapter (same
+                // user-visible failure as #1262's hourglass skip, but from
+                // synthesis rather than the buffering watchdog). Surface a
+                // retryable typed error and do NOT advance, so the chapter is
+                // never silently lost. Mirror of the #442 empty-sentence guard
+                // (which fires before the pipeline starts); this catches the
+                // empty-PCM case after it.
+                if (isSilentNaturalEnd(naturalEnd, chunksProduced)) {
+                    android.util.Log.w(
+                        "EnginePlayer",
+                        "#1311 silent chapter: producedAllSentences=true but 0 audio " +
+                            "chunks emitted for ${sentences.size} sentence(s) — surfacing a " +
+                            "retryable error instead of auto-advancing (pre-#1311 this " +
+                            "silently skipped the chapter). Likely the engine wasn't loaded " +
+                            "or synth returned null for every sentence.",
+                    )
+                    // Do NOT finalizeCache(): an empty render must not write an
+                    // .idx.json sidecar — that would poison the entry into a
+                    // permanent silent-but-"complete" cache hit (the #1128
+                    // class of bug). Leaving only the partial .meta.json keeps
+                    // the next play a clean MISS that re-renders from scratch.
+                    runCatching { track.flush() }
+                    runCatching { track.release() }
+                    scope.launch {
+                        _observableState.update {
+                            it.copy(
+                                isPlaying = false,
+                                isBuffering = false,
+                                error = PlaybackError.ChapterFetchFailed(
+                                    "This chapter couldn't be read aloud — no audio was " +
+                                        "produced. Tap retry, or skip to the next chapter.",
+                                ),
+                            )
+                        }
+                        invalidateState()
+                    }
+                    return@Thread
+                }
                 // #573 — Gapless: fire the natural-end fanout FIRST,
                 // BEFORE we tear the AudioTrack down. Pre-fix the
                 // order was:

--- a/core-playback/src/test/kotlin/in/jphe/storyvox/playback/tts/EnginePlayerSilentChapterTest.kt
+++ b/core-playback/src/test/kotlin/in/jphe/storyvox/playback/tts/EnginePlayerSilentChapterTest.kt
@@ -1,0 +1,74 @@
+package `in`.jphe.storyvox.playback.tts
+
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * Issue #1311 — pure-function unit test for [isSilentNaturalEnd], the rule
+ * that stops a chapter which synthesised to ZERO audio from being silently
+ * auto-advanced past.
+ *
+ * Background: the producer (EngineStreamingSource) `?: continue`s past any
+ * sentence whose `generateAudioPCM` returns null, then still sets
+ * `producedAllSentences = true` once it has walked every sentence. If EVERY
+ * sentence comes back null, the consumer reads a "natural end" having
+ * dequeued no chunks. Pre-#1311 that fed handleChapterDone → advanceChapter
+ * and the chapter was silently skipped (the synth-side sibling of the #1262
+ * watchdog skip). The consumer now counts dequeued chunks and, at a natural
+ * end with zero of them, surfaces a retryable error instead of advancing.
+ *
+ * Like its #728 / #980 / #642 neighbours, the decision is extracted to a
+ * top-level function so it can be pinned here without standing up the full
+ * EnginePlayer + Hilt + sherpa-onnx graph.
+ */
+class EnginePlayerSilentChapterTest {
+
+    @Test
+    fun `natural end with zero chunks is a silent chapter — the #1311 case`() {
+        // producedAllSentences flipped true but the producer enqueued no
+        // chunk (every sentence's generateAudioPCM returned null). This is
+        // exactly the state that pre-#1311 silently skipped the chapter.
+        assertTrue(
+            "a natural end that produced no audio must be treated as silent (#1311)",
+            isSilentNaturalEnd(naturalEnd = true, chunksEmitted = 0),
+        )
+    }
+
+    @Test
+    fun `natural end with audio is a normal completion — not silent`() {
+        // The overwhelmingly common path: the chapter played, chunks were
+        // emitted, the producer finished. Must NOT trip the guard — that
+        // would block legitimate auto-advance at every chapter boundary.
+        assertFalse(
+            "a natural end that produced audio is a normal completion",
+            isSilentNaturalEnd(naturalEnd = true, chunksEmitted = 137),
+        )
+    }
+
+    @Test
+    fun `a single emitted chunk is enough to count as not-silent`() {
+        // Boundary: one chunk means the engine produced real audio, so the
+        // chapter is not silent even if it ended early for another reason.
+        assertFalse(isSilentNaturalEnd(naturalEnd = true, chunksEmitted = 1))
+    }
+
+    @Test
+    fun `a non-natural exit with zero chunks is NOT a silent chapter`() {
+        // User paused / seeked / swapped voice / hit book-end before any
+        // audio played: naturalEnd is false (producedAllSentences never
+        // set). That's an intentional stop, not a silent skip — the guard
+        // must not fire and surface a spurious error.
+        assertFalse(
+            "a non-natural exit before audio is not the #1311 silent-skip case",
+            isSilentNaturalEnd(naturalEnd = false, chunksEmitted = 0),
+        )
+    }
+
+    @Test
+    fun `a non-natural exit mid-chapter is NOT a silent chapter`() {
+        // Paused/stopped partway through a chapter that WAS producing audio.
+        // Not a natural end, so not the guard's concern.
+        assertFalse(isSilentNaturalEnd(naturalEnd = false, chunksEmitted = 42))
+    }
+}


### PR DESCRIPTION
## Problem (#1311)

A chapter that synthesizes to **zero audio** is silently skipped on auto-advance.

The producer (`EngineStreamingSource`) `?: continue`s past any sentence whose `generateAudioPCM` returns null (engine not loaded, synth failure), then still sets `producedAllSentences = true` once it has *walked* every sentence. If **every** sentence comes back null, the consumer reads a "natural end" (`naturalEnd = producedAllSentences = true`) having dequeued **no chunks**, and the `#573` fanout dispatches `handleChapterDone → advanceChapter` — the chapter is silently skipped, no audio, no error.

This is the **synth-side sibling of the #1262 watchdog skip**. The existing `#442` guard only covers empty *sentences* (the chunker yields 0 before the pipeline starts); it does **not** cover sentences that exist but all synth to empty *PCM*.

Found while investigating #1262 (reproduced on R5CR80DJ7TR) and filed as a separate latent gap.

## Fix

- The consumer counts non-null chunks dequeued for the chapter (`chunksProduced`).
- New pure rule `isSilentNaturalEnd(naturalEnd, chunksEmitted) = naturalEnd && chunksEmitted == 0`.
- In the consumer `finally`, **before** the natural-end fanout: if the chapter reached a natural end with **zero** chunks, surface a **retryable** `PlaybackError.ChapterFetchFailed` ("This chapter couldn't be read aloud — no audio was produced…") and `return@Thread` **without** advancing. The UI shows a Retry affordance instead of losing the chapter.
- Deliberately **skip `finalizeCache()`** on this path: an empty render must not write an `.idx.json` sidecar, which would poison the entry into a permanent silent-but-"complete" cache hit (the #1128 class). Leaving only the partial `.meta.json` keeps the next play a clean MISS that re-renders.
- A `Log.w` breadcrumb (`#1311 silent chapter…`) so any recurrence is visible in logcat (run-as is gone on release builds).

Behaviour is unchanged for every normal completion (`chunksProduced > 0`) and every non-natural exit (pause/seek/swap/book-end, `naturalEnd == false`).

## Tests

`EnginePlayerSilentChapterTest` (pure-function, JVM — same pattern as `EnginePlayerAutoPlayDecisionTest`): silent natural end → guard fires; natural end with audio / single chunk → no fire; non-natural exit (zero or many chunks) → no fire.

## Risk

Narrow. The guard only fires for a chapter that produced *literally zero* audio at a natural end — previously a guaranteed silent skip. Trade-off: a chapter whose engine truly hangs on its first chunk is no longer auto-skipped, but that's rare, isn't helped by skipping to a same-engine next chapter, and now leaves a visible, retryable error instead of silent data loss.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
