### PR TITLE
chore(cleanup): resolve stale TODOs + dead code from #1271 audit

### DIFF
--- a/core-playback/src/main/kotlin/in/jphe/storyvox/playback/voice/VoiceCatalog.kt
+++ b/core-playback/src/main/kotlin/in/jphe/storyvox/playback/voice/VoiceCatalog.kt
@@ -876,9 +876,9 @@ object VoiceCatalog {
         val M = VoiceGender.Male
         // Speaker order follows the Kitten/Kokoro convention: female
         // embeddings at low indices, male embeddings at high indices.
-        // TODO: verify the speaker index → gender mapping against the actual
-        // Supertonic 3 voices.bin layout. (#1114 shipped the engine but left
-        // this mapping unverified; it is not tracked by a live issue.)
+        // TODO(#1319): verify the speaker index → gender mapping against the
+        // actual Supertonic 3 voices.bin layout — #1114 shipped the engine but
+        // left this F/M assignment (Kitten/Kokoro convention) unverified.
         return listOf(
             supertonic("supertonic_f1_en_US_0", "Supertonic F1", 0, F),
             supertonic("supertonic_f2_en_US_1", "Supertonic F2", 1, F),

--- a/core-ui/src/main/kotlin/in/jphe/storyvox/ui/component/BottomTabBar.kt
+++ b/core-ui/src/main/kotlin/in/jphe/storyvox/ui/component/BottomTabBar.kt
@@ -115,7 +115,7 @@ enum class HomeTab(val label: String, val filled: ImageVector, val outlined: Ima
  * and the unselected items' pills fading out. The visual effect reads
  * as a "pop"; this bar paints a single pill that slides between tabs.
  *
- * Issue #XXX (2026-05-12) — the first cut put the indicator pill in its
+ * Hit-testing history — the first cut put the indicator pill in its
  * own `Box(.offset(x).size(...).background(...))` sibling to the tab
  * Row inside `BoxWithConstraints`. Two layout children + a mid-animation
  * `.offset` made hit-testing flaky under playback's high recomposition

--- a/feature/src/main/kotlin/in/jphe/storyvox/feature/reader/AudiobookView.kt
+++ b/feature/src/main/kotlin/in/jphe/storyvox/feature/reader/AudiobookView.kt
@@ -2078,7 +2078,7 @@ private fun CoverTapFeedback(
  *  the upstream message lands, deriving the name from voiceLabel keeps
  *  the UX honest with zero coupling.
  *
- * TODO(audio-fidelity-fixer): once `EngineState.Warming(message, progress)`
+ * TODO(#1319): once `EngineState.Warming(message, progress)`
  *  publishes, plumb the upstream `message` through UiPlaybackState
  *  (new field) and prefer it over [warmingMessageForVoice] when present.
  *  Progress, when non-null, drives the thin progress bar described in

--- a/feature/src/main/kotlin/in/jphe/storyvox/feature/reader/RecapModal.kt
+++ b/feature/src/main/kotlin/in/jphe/storyvox/feature/reader/RecapModal.kt
@@ -32,7 +32,6 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.alpha
 import androidx.compose.ui.draw.clip
-import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.semantics.LiveRegionMode
 import androidx.compose.ui.semantics.Role
@@ -339,6 +338,4 @@ private fun ErrorBody(state: RecapUiState.Error) {
             modifier = Modifier.semantics { liveRegion = LiveRegionMode.Assertive },
         )
     }
-    // Suppress "unused parameter" — Color is used via colorScheme.
-    @Suppress("UNUSED_VARIABLE") val unused: Color = MaterialTheme.colorScheme.error
 }

--- a/source-royalroad/src/main/kotlin/in/jphe/storyvox/source/royalroad/RoyalRoadSource.kt
+++ b/source-royalroad/src/main/kotlin/in/jphe/storyvox/source/royalroad/RoyalRoadSource.kt
@@ -26,7 +26,6 @@ import `in`.jphe.storyvox.source.royalroad.model.fictionUrl
 import `in`.jphe.storyvox.source.royalroad.net.RoyalRoadChallengeFetcher
 import `in`.jphe.storyvox.source.royalroad.net.FetchOutcome
 import `in`.jphe.storyvox.source.royalroad.net.RateLimitedClient
-import `in`.jphe.storyvox.source.royalroad.net.RoyalRoadCookieJar
 import `in`.jphe.storyvox.source.royalroad.parser.BrowseParser
 import `in`.jphe.storyvox.source.royalroad.parser.ChapterParser
 import `in`.jphe.storyvox.source.royalroad.parser.FictionDetailParser
@@ -62,8 +61,7 @@ import okhttp3.HttpUrl.Companion.toHttpUrl
 @Singleton
 class RoyalRoadSource @Inject internal constructor(
     private val fetcher: RoyalRoadChallengeFetcher,
-    @Suppress("unused") private val client: RateLimitedClient,
-    @Suppress("unused") private val cookieJar: RoyalRoadCookieJar,
+    private val client: RateLimitedClient,
     // #1243 — read-only session-presence check for the search() gate. The
     // shared auth store writes a row here on WebView sign-in
     // (AuthRepository.captureSession) and clears it on sign-out, so a


### PR DESCRIPTION
Implements the verifiable findings from the #1271 audit.

## Changes (5 files)
- **RecapModal** — removed the dead `@Suppress("UNUSED_VARIABLE") val unused: Color` (the error color is already applied at the Text call above it; the variable was never read) + its now-unused `Color` import.
- **RoyalRoadSource** — dropped the stale `@Suppress("unused")` on `client` (it *is* used — `client.post(...)` in the follow path), and removed the genuinely-unused `cookieJar` ctor param + import. Safe: `RoyalRoadCookieJar` is constructed/wired via `RoyalRoadModule`'s OkHttp builder (`.cookieJar(jar)`) and `RoyalRoadSessionHydrator`, not via this class — no behavior change.
- **BottomTabBar** — replaced the dangling `Issue #XXX (2026-05-12)` placeholder with a plain 'Hit-testing history' lead-in (the rationale is preserved).
- **AudiobookView** + **VoiceCatalog** — re-pointed the two genuinely-pending TODOs to the live tracking issue **#1319** (the `EngineState.Warming` plumbing, previously keyed to the `audio-fidelity-fixer` agent codename; and the Supertonic speaker→gender verification).

## Scope notes
Verified each finding against current `main` first — **about half were already resolved by intervening merges** and are intentionally left untouched: the Supertonic-comment cluster (VoiceCatalog kdoc / EngineSampleRateCache now read 'engine shipped'), the CreateAudiobookViewModel Supertonic exclusion (already lifted), the a11y comment (already corrected, #487), and the TelegramConfig `store` (now documented as a deliberate carrier). One audit finding had **flipped** — `RoyalRoadSource.client` is now used, so it was *not* removed (that would have broken the build).

Hardcoded strings (legacy SettingsScreen refactor) and intentional deprecated-API usage are out of scope per the assignment.

Refs #1271. Follow-ups tracked in #1319.

🤖 Generated with [Claude Code](https://claude.com/claude-code)