### PR TITLE
test(coverage): edge-case unit tests for v1.3.0→v1.4.0 features (#1315)

### DIFF
--- a/core-playback/src/test/kotlin/in/jphe/storyvox/playback/auto/AutoPlaybackResolverEdgeCasesTest.kt
+++ b/core-playback/src/test/kotlin/in/jphe/storyvox/playback/auto/AutoPlaybackResolverEdgeCasesTest.kt
@@ -1,0 +1,59 @@
+package `in`.jphe.storyvox.playback.auto
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Test
+
+/**
+ * Issue #1315 — additional edge cases for [AutoPlaybackResolver.bestTitleMatch],
+ * complementing [AutoPlaybackResolverTest] (which covers the core exact > prefix
+ * > substring rank order). Focus: query trimming, empty/blank titles,
+ * query-longer-than-title, and rank precedence independent of candidate order.
+ *
+ * Scope note: the repo-backed `resolve()` paths are intentionally not unit-tested
+ * here — per #1232 they are thin delegations over Room validated on-device (DHU),
+ * and there is no mocking library in this module to stub the four repositories.
+ * Unknown / malformed media ids ("no such node") are already covered by
+ * [AutoMediaIdTest] ("unknown or malformed ids parse to null"). This file stays
+ * on the pure, JVM-testable matcher surface.
+ */
+class AutoPlaybackResolverEdgeCasesTest {
+
+    private val library = listOf(
+        "f-pride" to "Pride and Prejudice",
+        "f-mist" to "Mistborn",
+    )
+
+    @Test fun `surrounding whitespace in a non-blank query is trimmed before matching`() {
+        assertEquals("f-mist", AutoPlaybackResolver.bestTitleMatch("  mistborn  ", library))
+    }
+
+    @Test fun `a query longer than every title matches nothing`() {
+        assertNull(AutoPlaybackResolver.bestTitleMatch("Pride and Prejudice and Zombies", library))
+    }
+
+    @Test fun `a candidate with an empty title is never matched`() {
+        val candidates = listOf("f-empty" to "", "f-real" to "Dune")
+        assertNull(AutoPlaybackResolver.bestTitleMatch("x", candidates))
+        // ...but a real match alongside the empty-title candidate still resolves.
+        assertEquals("f-real", AutoPlaybackResolver.bestTitleMatch("dune", candidates))
+    }
+
+    @Test fun `an empty query returns null even against an empty title`() {
+        // q is "" after trim → early null guard, so a "" title can't spuriously rank.
+        assertNull(AutoPlaybackResolver.bestTitleMatch("", listOf("f-empty" to "")))
+    }
+
+    @Test fun `an exact match outranks an earlier prefix candidate`() {
+        val candidates = listOf(
+            "f-prefix" to "Dune Messiah", // startsWith "dune" → rank 2, listed first
+            "f-exact" to "Dune",          // == "dune" → rank 3, listed second
+        )
+        assertEquals("f-exact", AutoPlaybackResolver.bestTitleMatch("dune", candidates))
+    }
+
+    @Test fun `a substring-only match is found when nothing ranks higher`() {
+        val candidates = listOf("f-saga" to "The Wax and Wayne Saga")
+        assertEquals("f-saga", AutoPlaybackResolver.bestTitleMatch("wax and wayne", candidates))
+    }
+}

--- a/core-playback/src/test/kotlin/in/jphe/storyvox/playback/cache/PcmSilenceTest.kt
+++ b/core-playback/src/test/kotlin/in/jphe/storyvox/playback/cache/PcmSilenceTest.kt
@@ -1,0 +1,125 @@
+package `in`.jphe.storyvox.playback.cache
+
+import java.io.File
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Rule
+import org.junit.Test
+import org.junit.rules.TemporaryFolder
+
+/**
+ * Issue #1281 / #1315 — boundary coverage for the PCM "is this all silence?"
+ * helpers backing CacheFileSource's read-side content gate.
+ *
+ * The silence definition is *strictly all-zero* by default
+ * ([PCM_SILENCE_TOLERANCE_BYTES] == 0): any non-zero byte is audio. These tests
+ * pin the boundaries the gate relies on — the all-zero / first-non-zero edges,
+ * the `len` / `scanBytes` windowing (so a trailing non-zero outside the scanned
+ * region is correctly ignored), signed (high-bit) bytes counting as non-zero,
+ * the tolerance knob, and the 64 KB multi-buffer streaming path.
+ */
+class PcmSilenceTest {
+
+    @get:Rule
+    val tempFolder = TemporaryFolder()
+
+    private fun pcmFile(name: String, bytes: ByteArray): File =
+        tempFolder.newFile(name).apply { writeBytes(bytes) }
+
+    // ── isPcmBufferSilent (pure) ──────────────────────────────────────────
+
+    @Test fun `empty buffer is silent`() {
+        assertTrue(isPcmBufferSilent(ByteArray(0)))
+    }
+
+    @Test fun `all-zero buffer is silent`() {
+        assertTrue(isPcmBufferSilent(ByteArray(1024)))
+    }
+
+    @Test fun `a single non-zero byte makes the buffer audio`() {
+        assertFalse(isPcmBufferSilent(byteArrayOf(0, 0, 1, 0)))
+    }
+
+    @Test fun `a non-zero byte at index zero is audio (early exit)`() {
+        // First byte already exceeds tolerance 0 → returns false without scanning on.
+        val buf = ByteArray(8192).also { it[0] = 7 }
+        assertFalse(isPcmBufferSilent(buf))
+    }
+
+    @Test fun `a high-bit (negative) byte counts as non-zero`() {
+        // 0xFF decodes to -1 as a signed Byte; toInt() != 0, so it's audio.
+        assertFalse(isPcmBufferSilent(byteArrayOf(-1)))
+    }
+
+    @Test fun `len bounds the scan and excludes a trailing non-zero byte`() {
+        val buf = byteArrayOf(0, 0, 5)
+        assertTrue(isPcmBufferSilent(buf, len = 2))   // index 2 (the 5) is outside [0,2)
+        assertFalse(isPcmBufferSilent(buf, len = 3))  // now the 5 is included
+    }
+
+    @Test fun `len of zero is silent even when the array holds non-zero bytes`() {
+        assertTrue(isPcmBufferSilent(byteArrayOf(5, 5, 5), len = 0))
+    }
+
+    @Test fun `tolerance permits up to N non-zero bytes inclusive`() {
+        // 2 non-zero bytes with tolerance 2 → still silent (not > tolerance).
+        assertTrue(isPcmBufferSilent(byteArrayOf(1, 0, 2, 0), tolerance = 2))
+        // 3 non-zero bytes with tolerance 2 → exceeds → audio.
+        assertFalse(isPcmBufferSilent(byteArrayOf(1, 2, 3), tolerance = 2))
+    }
+
+    @Test fun `default tolerance is strictly zero`() {
+        assertEquals(0, PCM_SILENCE_TOLERANCE_BYTES)
+    }
+
+    // ── pcmIsAllSilence (streams a File) ──────────────────────────────────
+
+    @Test fun `non-positive scanBytes is silent regardless of content`() {
+        val f = pcmFile("audio.pcm", byteArrayOf(1, 2, 3))
+        assertTrue(pcmIsAllSilence(f, scanBytes = 0L))
+        assertTrue(pcmIsAllSilence(f, scanBytes = -1L))
+    }
+
+    @Test fun `empty file is silent`() {
+        val f = tempFolder.newFile("empty.pcm") // 0 bytes
+        assertTrue(pcmIsAllSilence(f, scanBytes = 64L))
+    }
+
+    @Test fun `all-zero file within the scan is silent`() {
+        val f = pcmFile("zeros.pcm", ByteArray(100))
+        assertTrue(pcmIsAllSilence(f, scanBytes = 100L))
+    }
+
+    @Test fun `a non-zero byte inside the scan makes the file audio`() {
+        val f = pcmFile("blip.pcm", ByteArray(100).also { it[40] = 9 })
+        assertFalse(pcmIsAllSilence(f, scanBytes = 100L))
+    }
+
+    @Test fun `a non-zero byte beyond scanBytes is ignored`() {
+        // 6 bytes; only the last (index 5) is non-zero.
+        val f = pcmFile("tail.pcm", byteArrayOf(0, 0, 0, 0, 0, 5))
+        assertTrue(pcmIsAllSilence(f, scanBytes = 5L))   // scans indices 0..4 → silent
+        assertFalse(pcmIsAllSilence(f, scanBytes = 6L))  // includes index 5 → audio
+    }
+
+    @Test fun `scanBytes larger than the file scans only what exists`() {
+        assertTrue(pcmIsAllSilence(pcmFile("short-zero.pcm", ByteArray(8)), scanBytes = 10_000L))
+        assertFalse(pcmIsAllSilence(pcmFile("short-blip.pcm", byteArrayOf(0, 3)), scanBytes = 10_000L))
+    }
+
+    @Test fun `a multi-buffer all-zero file is silent`() {
+        // > 2 × 64 KB so the streaming loop runs several buffers.
+        val f = pcmFile("big-zeros.pcm", ByteArray(130_000))
+        assertTrue(pcmIsAllSilence(f, scanBytes = 130_000L))
+    }
+
+    @Test fun `a non-zero byte in a later buffer is detected`() {
+        val f = pcmFile("big-blip.pcm", ByteArray(130_000).also { it[70_000] = 1 })
+        assertFalse(pcmIsAllSilence(f, scanBytes = 130_000L))
+        // The same byte sits exactly at the scan boundary: index 70_000 is the
+        // 70_001st byte, so a 70_000-byte scan (indices 0..69_999) excludes it.
+        assertTrue(pcmIsAllSilence(f, scanBytes = 70_000L))
+        assertFalse(pcmIsAllSilence(f, scanBytes = 70_001L))
+    }
+}

--- a/core-playback/src/test/kotlin/in/jphe/storyvox/playback/transcribe/VoicePacedScrollerTimingTest.kt
+++ b/core-playback/src/test/kotlin/in/jphe/storyvox/playback/transcribe/VoicePacedScrollerTimingTest.kt
@@ -1,0 +1,77 @@
+package `in`.jphe.storyvox.playback.transcribe
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+/**
+ * Issue #1315 — timing / boundary edge cases for the voice-paced scroll math,
+ * complementing [VoicePacedScrollerTest]: degenerate metrics, non-advancing or
+ * backward timestamps (no divide-by-zero, no pace corruption), look-ahead
+ * projection clamped at end-of-text, content shorter than the viewport,
+ * reset(), and a custom centerBias.
+ */
+class VoicePacedScrollerTimingTest {
+
+    // 1000 chars over 10000px content in a 1000px viewport → 10 px/char,
+    // max scroll 9000px, line parked 40% down by default (centerBias).
+    private val m = ScrollMetrics(totalChars = 1000, contentHeightPx = 10_000f, viewportHeightPx = 1_000f)
+
+    @Test fun `zero content height yields a safe zero target`() {
+        val t = VoicePacedScroller().onPosition(100, 1_000, ScrollMetrics(1000, 0f, 1_000f))
+        assertEquals(0f, t.targetScrollPx, 0.001f)
+        assertEquals(0f, t.velocityPxPerSec, 0.001f)
+    }
+
+    @Test fun `negative total chars yields a safe zero target`() {
+        val t = VoicePacedScroller().onPosition(100, 1_000, ScrollMetrics(-5, 10_000f, 1_000f))
+        assertEquals(0f, t.targetScrollPx, 0.001f)
+        assertEquals(0f, t.velocityPxPerSec, 0.001f)
+    }
+
+    @Test fun `a non-advancing timestamp does not learn pace or divide by zero`() {
+        val s = VoicePacedScroller()
+        s.onPosition(100, 1_000, m)         // seed
+        val t = s.onPosition(200, 1_000, m) // same nowMs → elapsed 0 → pace update skipped
+        assertEquals(0f, t.velocityPxPerSec, 0.001f)
+        // projected = 200 + 0 → fraction .2 → 2000px − 0.4*1000 bias = 1600.
+        assertEquals(1600f, t.targetScrollPx, 0.5f)
+    }
+
+    @Test fun `a backward timestamp does not learn pace`() {
+        val s = VoicePacedScroller()
+        s.onPosition(100, 2_000, m)         // seed at t=2000
+        val t = s.onPosition(200, 1_000, m) // time goes backward → pace update skipped
+        assertEquals(0f, t.velocityPxPerSec, 0.001f)
+    }
+
+    @Test fun `look-ahead projection clamps at end of text`() {
+        val s = VoicePacedScroller()
+        s.onPosition(900, 1_000, m)         // seed
+        val t = s.onPosition(990, 1_100, m) // 0.9 chars/ms; 990 + 0.9*350 = 1305 → clamp to 1000
+        // fraction 1.0 → 10000px − 400 bias = 9600 → clamp to maxScroll 9000.
+        assertEquals(9000f, t.targetScrollPx, 0.5f)
+    }
+
+    @Test fun `content shorter than the viewport keeps the target at zero`() {
+        val short = ScrollMetrics(totalChars = 1000, contentHeightPx = 500f, viewportHeightPx = 1_000f)
+        val t = VoicePacedScroller().onPosition(500, 1_000, short) // maxScroll coerced to 0
+        assertEquals(0f, t.targetScrollPx, 0.001f)
+    }
+
+    @Test fun `reset clears the learned pace`() {
+        val s = VoicePacedScroller()
+        s.onPosition(100, 1_000, m)
+        s.onPosition(200, 2_000, m)         // pace 0.1 chars/ms
+        s.reset()
+        val t = s.onPosition(300, 3_000, m) // lastChar/lastMs cleared → no learn this call
+        assertEquals(0f, t.velocityPxPerSec, 0.001f)
+        // projected = 300 + 0 → fraction .3 → 3000px − 400 = 2600.
+        assertEquals(2600f, t.targetScrollPx, 0.5f)
+    }
+
+    @Test fun `zero center bias parks the line at the viewport top`() {
+        val t = VoicePacedScroller(centerBias = 0f).onPosition(100, 1_000, m)
+        // fraction .1 → 1000px line top, no bias subtracted.
+        assertEquals(1000f, t.targetScrollPx, 0.5f)
+    }
+}

--- a/feature/src/test/kotlin/in/jphe/storyvox/feature/reader/DialogueSegmenterLanguageTest.kt
+++ b/feature/src/test/kotlin/in/jphe/storyvox/feature/reader/DialogueSegmenterLanguageTest.kt
@@ -1,0 +1,223 @@
+package `in`.jphe.storyvox.feature.reader
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * Issue #1287 — practice mode. Edge-case companion to [DialogueSegmenterTest],
+ * focused on non-Latin / multi-language dialogue, unusual or unhandled quote
+ * characters, nested / mismatched / unclosed quotes, multi-sentence quotes, and
+ * the empty / whitespace / pure-narration inputs.
+ *
+ * Detection is deliberately double-quote-only (see [DialogueSegmenter] kdoc):
+ * straight `"` toggles, curly `“`/`”` is an open/close pair. Curly single
+ * quotes, guillemets, and every other quote style are NOT delimiters, so this
+ * file asserts they stay narration rather than inventing support for them.
+ *
+ * Like the template, assertions reconstruct each segment's substring
+ * (`text.substring(start, end)`) and check the tiling invariant rather than
+ * hand-computing offsets.
+ */
+class DialogueSegmenterLanguageTest {
+
+    private fun parts(text: String) =
+        segmentDialogue(text).map { text.substring(it.start, it.end) }
+
+    private fun kinds(text: String) = segmentDialogue(text).map { it.kind }
+
+    /** Every segment list must tile [text] exactly: start at 0, end at length,
+     *  each segment starts where the previous ended, and the concatenation of
+     *  all runs reproduces the input. */
+    private fun assertTiles(text: String) {
+        val segs = segmentDialogue(text)
+        if (text.isEmpty()) {
+            assertTrue(segs.isEmpty()); return
+        }
+        assertEquals(0, segs.first().start)
+        assertEquals(text.length, segs.last().end)
+        for (i in 1 until segs.size) assertEquals(segs[i - 1].end, segs[i].start)
+        assertEquals(text, segs.joinToString("") { text.substring(it.start, it.end) })
+    }
+
+    // ===== unhandled quote styles → narration =====
+
+    @Test
+    fun `curly single quotes are not delimiters and stay narration`() {
+        // ‘ ’ are the single-quote / apostrophe family — never delimiters — so
+        // text wrapped in them is one narration run, not dialogue.
+        val t = "‘Hello,’ said Tom."
+        assertEquals(listOf(SegmentKind.Narration), kinds(t))
+        assertEquals(listOf(t), parts(t))
+        assertTiles(t)
+    }
+
+    @Test
+    fun `guillemets are not delimiters and stay narration`() {
+        // « » are not in the recognized set (only straight and curly double
+        // quotes), so a guillemet-quoted line is pure narration.
+        val t = "« Bonjour, » dit-il."
+        assertEquals(listOf(SegmentKind.Narration), kinds(t))
+        assertEquals(listOf(t), parts(t))
+        assertTiles(t)
+    }
+
+    @Test
+    fun `single straight apostrophe quoting stays narration`() {
+        // A line quoted with straight single quotes uses ' which is the
+        // apostrophe char, never a delimiter — so it remains narration.
+        val t = "'Hi there,' she said."
+        assertEquals(listOf(SegmentKind.Narration), kinds(t))
+        assertEquals(listOf(t), parts(t))
+        assertTiles(t)
+    }
+
+    // ===== non-Latin text INSIDE recognized quotes =====
+
+    @Test
+    fun `cyrillic inside straight quotes is one dialogue run`() {
+        // Segmentation keys on the quote chars only; the Cyrillic payload is
+        // carried verbatim inside a single dialogue run.
+        val t = "\"Привет, как дела?\" сказал Иван."
+        assertEquals(listOf(SegmentKind.Dialogue, SegmentKind.Narration), kinds(t))
+        assertEquals(listOf("\"Привет, как дела?\"", " сказал Иван."), parts(t))
+        assertTiles(t)
+    }
+
+    @Test
+    fun `cjk inside curly quotes is one dialogue run`() {
+        // Curly double quotes wrap CJK text → a single dialogue run, then the
+        // trailing narration. No language detection is implied.
+        val t = "“你好，世界。” 他说。"
+        assertEquals(listOf(SegmentKind.Dialogue, SegmentKind.Narration), kinds(t))
+        assertEquals(listOf("“你好，世界。”", " 他说。"), parts(t))
+        assertTiles(t)
+    }
+
+    @Test
+    fun `emoji and combining marks inside a quote stay in the dialogue run`() {
+        // Non-ASCII codepoints that aren't quote chars are just payload; the
+        // run boundaries are still the surrounding double quotes.
+        val t = "\"Café ☕ déjà vu\" he mused."
+        assertEquals(listOf(SegmentKind.Dialogue, SegmentKind.Narration), kinds(t))
+        assertEquals(listOf("\"Café ☕ déjà vu\"", " he mused."), parts(t))
+        assertTiles(t)
+    }
+
+    // ===== nested / mismatched / unclosed quotes =====
+
+    @Test
+    fun `straight quote nested inside curly quote does not close the run`() {
+        // Inside a curly-opened run only the curly close ‘”’ ends it; a stray
+        // straight quote in between is part of the dialogue payload.
+        val t = "“She said \"stop\" loudly,” he noted."
+        assertEquals(listOf(SegmentKind.Dialogue, SegmentKind.Narration), kinds(t))
+        assertEquals(listOf("“She said \"stop\" loudly,”", " he noted."), parts(t))
+        assertTiles(t)
+    }
+
+    @Test
+    fun `single-quoted clause inside straight dialogue does not split it`() {
+        // Apostrophe-style single quotes inside a straight-quoted line are not
+        // delimiters, so the whole thing is one dialogue run.
+        val t = "\"He said 'hello' to me.\""
+        assertEquals(listOf(SegmentKind.Dialogue), kinds(t))
+        assertEquals(listOf(t), parts(t))
+        assertTiles(t)
+    }
+
+    @Test
+    fun `nested straight quotes toggle and reopen`() {
+        // Straight quotes are open/close-ambiguous, so they toggle: the second
+        // " closes the first run, the inner words become narration, and the
+        // fourth " reopens a run that closes at the fifth.
+        val t = "\"She said \"stop\" now.\""
+        assertEquals(
+            listOf(SegmentKind.Dialogue, SegmentKind.Narration, SegmentKind.Dialogue),
+            kinds(t),
+        )
+        assertEquals(listOf("\"She said \"", "stop", "\" now.\""), parts(t))
+        assertTiles(t)
+    }
+
+    @Test
+    fun `mismatched curly open with straight close runs to end as dialogue`() {
+        // A curly open sets the closer to the curly close; a straight quote
+        // does not satisfy it, so the run continues to end-of-text.
+        val t = "“This never gets a curly close\" and keeps going."
+        assertEquals(listOf(SegmentKind.Dialogue), kinds(t))
+        assertEquals(listOf(t), parts(t))
+        assertTiles(t)
+    }
+
+    @Test
+    fun `curly close before any open is plain narration`() {
+        // A lone closing curly quote with no preceding open never enters a
+        // quote, so the whole string is narration.
+        val t = "Nothing opened here” really."
+        assertEquals(listOf(SegmentKind.Narration), kinds(t))
+        assertEquals(listOf(t), parts(t))
+        assertTiles(t)
+    }
+
+    @Test
+    fun `unclosed curly open runs to end as dialogue`() {
+        val t = "He paused. “An open line that never closes"
+        assertEquals(listOf(SegmentKind.Narration, SegmentKind.Dialogue), kinds(t))
+        assertEquals(listOf("He paused. ", "“An open line that never closes"), parts(t))
+        assertTiles(t)
+    }
+
+    // ===== quotes spanning multiple sentences =====
+
+    @Test
+    fun `a quote spanning multiple sentences is a single dialogue run`() {
+        // Sentence punctuation inside a quote is not a boundary; only the
+        // closing quote ends the run, so multi-sentence speech is one segment.
+        val t = "\"Stop. Wait. Listen to me.\" he urged."
+        assertEquals(listOf(SegmentKind.Dialogue, SegmentKind.Narration), kinds(t))
+        assertEquals(listOf("\"Stop. Wait. Listen to me.\"", " he urged."), parts(t))
+        assertTiles(t)
+    }
+
+    @Test
+    fun `curly quote spanning multiple sentences is a single dialogue run`() {
+        val t = "“Run! They are coming. Go now.” She bolted."
+        assertEquals(listOf(SegmentKind.Dialogue, SegmentKind.Narration), kinds(t))
+        assertEquals(listOf("“Run! They are coming. Go now.”", " She bolted."), parts(t))
+        assertTiles(t)
+    }
+
+    // ===== empty / whitespace / pure narration =====
+
+    @Test
+    fun `whitespace-only text is a single narration segment`() {
+        val t = "   \t\n  "
+        assertEquals(listOf(SegmentKind.Narration), kinds(t))
+        assertEquals(listOf(t), parts(t))
+        assertTiles(t)
+    }
+
+    @Test
+    fun `pure narration with no quotes is a single narration segment`() {
+        val t = "The rain fell softly on the empty street as night drew in."
+        assertEquals(listOf(SegmentKind.Narration), kinds(t))
+        assertEquals(listOf(t), parts(t))
+        assertTiles(t)
+    }
+
+    @Test
+    fun `non-Latin narration with no quotes stays one narration segment`() {
+        // No double quotes anywhere → one narration run regardless of script.
+        val t = "夜の街に静かに雨が降っていた。"
+        assertEquals(listOf(SegmentKind.Narration), kinds(t))
+        assertEquals(listOf(t), parts(t))
+        assertTiles(t)
+    }
+
+    @Test
+    fun `empty string yields an empty list`() {
+        // Mirrors the contract in DialogueSegmenter: empty input → no segments.
+        assertEquals(emptyList<TextSegment>(), segmentDialogue(""))
+    }
+}

--- a/source-bookshare/src/test/kotlin/in/jphe/storyvox/source/bookshare/parse/DaisyParserVariantsTest.kt
+++ b/source-bookshare/src/test/kotlin/in/jphe/storyvox/source/bookshare/parse/DaisyParserVariantsTest.kt
@@ -1,0 +1,165 @@
+package `in`.jphe.storyvox.source.bookshare.parse
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+
+/**
+ * Issue #1315 — structural / encoding edge cases for the DAISY parsers,
+ * complementing [DaisyParserTest] (DAISY 3 happy path) and [Daisy202ParserTest]
+ * (a real 2.02 package). Robolectric-backed because both parsers use
+ * `android.util.Xml`, matching the existing tests' posture.
+ *
+ * Covers: heading-less / id-less sections (title + id fallbacks), nested
+ * `<level>` flattening, a second heading falling through to body text, page /
+ * note markers dropped, inline markup keeping a paragraph intact, XML entity
+ * decode + HTML re-escape, whitespace collapse, empty sections, malformed XML;
+ * and for 2.02: a missing `ncc.html`, headings with no resolvable content
+ * (empty-body chapters), and an anchor-less heading being skipped.
+ */
+@RunWith(RobolectricTestRunner::class)
+class DaisyParserVariantsTest {
+
+    private fun dtbook(body: String): String =
+        """<?xml version="1.0" encoding="UTF-8"?><dtbook version="2005-3">$body</dtbook>"""
+
+    // ── DAISY 3 DTBook (DaisyParser.parseDtbook) ──────────────────────────
+
+    @Test fun `a section without a heading falls back to a Section N title`() {
+        val book = DaisyParser.parseDtbook(
+            dtbook("""<level1 id="s1"><p>Body with no heading.</p></level1>"""),
+        )
+        assertEquals(1, book.chapters.size)
+        assertEquals("s1", book.chapters[0].id)
+        assertEquals("Section 1", book.chapters[0].title)
+        assertEquals("Body with no heading.", book.chapters[0].plainBody)
+    }
+
+    @Test fun `a section without an id falls back to a level-N id`() {
+        val book = DaisyParser.parseDtbook(
+            dtbook("""<level1><h1>Titled</h1><p>x</p></level1>"""),
+        )
+        assertEquals("level-1", book.chapters[0].id)
+        assertEquals("Titled", book.chapters[0].title)
+    }
+
+    @Test fun `nested levels flatten into a single chapter`() {
+        val book = DaisyParser.parseDtbook(
+            dtbook(
+                """
+                <level1 id="outer"><h1>Outer</h1><p>Outer para.</p>
+                  <level><h2>Inner</h2><p>Inner para.</p></level>
+                </level1>
+                """.trimIndent(),
+            ),
+        )
+        assertEquals(1, book.chapters.size)
+        assertEquals("Outer", book.chapters[0].title)
+        assertTrue(book.chapters[0].plainBody.contains("Outer para."))
+        assertTrue(book.chapters[0].plainBody.contains("Inner para."))
+    }
+
+    @Test fun `only the first heading is the title and a later heading becomes body`() {
+        val book = DaisyParser.parseDtbook(
+            dtbook("""<level1 id="c"><h1>Real Title</h1><h2>Subhead</h2><p>Body.</p></level1>"""),
+        )
+        assertEquals("Real Title", book.chapters[0].title)
+        assertTrue(book.chapters[0].plainBody.contains("Subhead"))
+        assertTrue(book.chapters[0].plainBody.contains("Body."))
+    }
+
+    @Test fun `page and note markers are dropped from the narrated body`() {
+        val book = DaisyParser.parseDtbook(
+            dtbook("""<level1 id="c"><h1>H</h1><p>Before<pagenum>42</pagenum>after.</p></level1>"""),
+        )
+        val body = book.chapters[0].plainBody
+        assertTrue(body.contains("Before"))
+        assertTrue(body.contains("after."))
+        assertFalse("page number leaked into narration", body.contains("42"))
+    }
+
+    @Test fun `inline markup keeps a paragraph intact`() {
+        val book = DaisyParser.parseDtbook(
+            dtbook("""<level1 id="c"><h1>H</h1><p>Hello <em>brave</em> world.</p></level1>"""),
+        )
+        assertEquals("Hello brave world.", book.chapters[0].plainBody)
+    }
+
+    @Test fun `entities are decoded in plain text and re-escaped in html`() {
+        val book = DaisyParser.parseDtbook(
+            dtbook("""<level1 id="c"><h1>H</h1><p>Tom &amp; Jerry &lt;tag&gt;</p></level1>"""),
+        )
+        assertEquals("Tom & Jerry <tag>", book.chapters[0].plainBody)
+        assertEquals("<p>Tom &amp; Jerry &lt;tag&gt;</p>", book.chapters[0].htmlBody)
+    }
+
+    @Test fun `whitespace and newlines collapse to single spaces`() {
+        val book = DaisyParser.parseDtbook(
+            dtbook("<level1 id=\"c\"><h1>H</h1><p>Lots    of\n\n   space</p></level1>"),
+        )
+        assertEquals("Lots of space", book.chapters[0].plainBody)
+    }
+
+    @Test fun `an empty section still yields a chapter with an empty body`() {
+        val book = DaisyParser.parseDtbook(dtbook("""<level1 id="empty"></level1>"""))
+        assertEquals(1, book.chapters.size)
+        assertEquals("empty", book.chapters[0].id)
+        assertEquals("Section 1", book.chapters[0].title)
+        assertEquals("", book.chapters[0].plainBody)
+    }
+
+    @Test(expected = DaisyParseException::class)
+    fun `malformed DTBook xml throws DaisyParseException`() {
+        // <p> is never closed before </level1> → strict pull parser rejects it.
+        DaisyParser.parseDtbook(dtbook("""<level1 id="c"><h1>H</h1><p>oops</level1>"""))
+    }
+
+    // ── DAISY 2.02 (Daisy202Parser.parsePackage) ──────────────────────────
+
+    private fun pkg(vararg files: Pair<String, String>): Map<String, ByteArray> =
+        files.associate { (k, v) -> k to v.toByteArray(Charsets.UTF_8) }
+
+    @Test(expected = DaisyParseException::class)
+    fun `a package with no ncc throws DaisyParseException`() {
+        Daisy202Parser.parsePackage(emptyMap())
+    }
+
+    @Test fun `ncc headings with no resolvable content yield empty-body chapters`() {
+        // ncc.html only — the referenced .smil / content docs are absent, so each
+        // heading resolves to a titled chapter with an empty body (not dropped).
+        val ncc = """
+            <?xml version="1.0" encoding="UTF-8"?>
+            <html><head>
+              <meta name="dc:title" content="My Book"/>
+              <meta name="dc:creator" content="Auth"/>
+            </head><body>
+              <h1 id="h1"><a href="ch.smil#t1">First</a></h1>
+              <h1 id="h2"><a href="ch.smil#t2">Second</a></h1>
+            </body></html>
+        """.trimIndent()
+        val book = Daisy202Parser.parsePackage(pkg("ncc.html" to ncc))
+        assertEquals("My Book", book.title)
+        assertEquals("Auth", book.author)
+        assertEquals(2, book.chapters.size)
+        assertEquals("First", book.chapters[0].title)
+        assertEquals("h1", book.chapters[0].id)
+        assertEquals("", book.chapters[0].plainBody)
+        assertEquals("Second", book.chapters[1].title)
+    }
+
+    @Test fun `an ncc heading without an anchor href is skipped`() {
+        val ncc = """
+            <?xml version="1.0" encoding="UTF-8"?>
+            <html><head><meta name="dc:title" content="B"/></head><body>
+              <h1 id="h1">No link here</h1>
+              <h1 id="h2"><a href="c.smil#t">Linked</a></h1>
+            </body></html>
+        """.trimIndent()
+        val book = Daisy202Parser.parsePackage(pkg("ncc.html" to ncc))
+        assertEquals(1, book.chapters.size)
+        assertEquals("Linked", book.chapters[0].title)
+    }
+}

--- a/source-google-news/src/test/kotlin/in/jphe/storyvox/source/googlenews/article/GoogleNewsUrlDecoderEdgeCasesTest.kt
+++ b/source-google-news/src/test/kotlin/in/jphe/storyvox/source/googlenews/article/GoogleNewsUrlDecoderEdgeCasesTest.kt
@@ -1,0 +1,183 @@
+package `in`.jphe.storyvox.source.googlenews.article
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Test
+
+/**
+ * Issue #1295 — failure-path coverage for the pure parse/encode steps of
+ * [GoogleNewsUrlDecoder], complementing the happy-path [GoogleNewsUrlDecoderTest].
+ *
+ * Grounded strictly in the decoder's contract: the `CBMi…` id is an opaque
+ * token (NOT base64 — see the class kdoc), so there is no decode-and-throw
+ * path. Instead the three pure functions each have a well-defined "give up"
+ * behaviour:
+ *  - `extractArticleId` → null when no `/articles/<id>` segment (or id is blank).
+ *  - `parseSignatureTimestamp` → null unless BOTH `data-n-a-sg` and
+ *    `data-n-a-ts` are present.
+ *  - `parseBatchResponse` → null when no non-Google http(s) URL is found;
+ *    malformed/garbage JSON is swallowed by an internal `runCatching` and the
+ *    regex fallback runs, so it never throws.
+ * These tests assert exactly those guarantees.
+ */
+class GoogleNewsUrlDecoderEdgeCasesTest {
+
+    // ── extractArticleId: failure paths ────────────────────────────
+
+    @Test
+    fun `empty string yields null id`() {
+        // No `/articles/` segment at all → Regex.find returns null.
+        assertNull(GoogleNewsUrlDecoder.extractArticleId(""))
+    }
+
+    @Test
+    fun `blank input yields null id`() {
+        // Whitespace-only: still no `/articles/` segment to match.
+        assertNull(GoogleNewsUrlDecoder.extractArticleId("   \t\n  "))
+    }
+
+    @Test
+    fun `garbage non-url input yields null id`() {
+        // Arbitrary junk contains no `/articles/<id>` → null.
+        assertNull(GoogleNewsUrlDecoder.extractArticleId("!!! not a url @#\$%^&*()"))
+    }
+
+    @Test
+    fun `wrong-host plain article url still extracts the articles segment`() {
+        // The id regex is host-agnostic: it keys off the `/articles/<id>` path
+        // segment, not the google-news host. A non-google host that happens to
+        // contain that segment still yields the captured id — the decoder does
+        // not validate the host here (host/path filtering for the *result* URL
+        // happens later in firstPublisherUrl, not at id extraction).
+        assertEquals(
+            "abc123",
+            GoogleNewsUrlDecoder.extractArticleId("https://example.com/articles/abc123"),
+        )
+    }
+
+    @Test
+    fun `already-plain publisher url with no articles segment yields null id`() {
+        // A real publisher URL (the resolver's eventual output) has no
+        // `/articles/` segment, so it cannot be mistaken for a google-news id.
+        assertNull(
+            GoogleNewsUrlDecoder.extractArticleId("https://www.example.com/news/story-42"),
+        )
+    }
+
+    @Test
+    fun `articles segment with empty id yields null`() {
+        // `/articles/` immediately followed by `?` makes the captured group
+        // empty; the `takeIf { it.isNotBlank() }` guard converts that to null.
+        assertNull(GoogleNewsUrlDecoder.extractArticleId("https://news.google.com/rss/articles/?oc=5"))
+    }
+
+    @Test
+    fun `articles segment at path end with trailing slash yields null`() {
+        // `/articles/` with nothing before the next `/` → empty capture → null.
+        assertNull(GoogleNewsUrlDecoder.extractArticleId("https://news.google.com/rss/articles/"))
+    }
+
+    // ── parseSignatureTimestamp: failure paths ─────────────────────
+
+    @Test
+    fun `empty html yields null signature timestamp`() {
+        // Neither marker present → both regex finds are null → null pair.
+        assertNull(GoogleNewsUrlDecoder.parseSignatureTimestamp(""))
+    }
+
+    @Test
+    fun `blank html yields null signature timestamp`() {
+        assertNull(GoogleNewsUrlDecoder.parseSignatureTimestamp("    \n\t "))
+    }
+
+    @Test
+    fun `html without either marker yields null`() {
+        // Plausible page markup but missing the data-n-a-* attributes entirely.
+        val html = """<c-wiz><div jsdata="x" data-n-a-id="z"></div></c-wiz>"""
+        assertNull(GoogleNewsUrlDecoder.parseSignatureTimestamp(html))
+    }
+
+    @Test
+    fun `signature present but timestamp missing yields null`() {
+        // Contract: BOTH must be present. Only-signature → null.
+        assertNull(
+            GoogleNewsUrlDecoder.parseSignatureTimestamp("""<div data-n-a-sg="AB_cd-EF12"></div>"""),
+        )
+    }
+
+    @Test
+    fun `timestamp present but signature missing yields null`() {
+        // Only-timestamp → null.
+        assertNull(
+            GoogleNewsUrlDecoder.parseSignatureTimestamp("""<div data-n-a-ts="1719876543"></div>"""),
+        )
+    }
+
+    // ── parseBatchResponse: failure paths ──────────────────────────
+
+    @Test
+    fun `empty response yields null`() {
+        // No `[` and no URL anywhere → both structured and fallback paths null.
+        assertNull(GoogleNewsUrlDecoder.parseBatchResponse(""))
+    }
+
+    @Test
+    fun `blank response yields null`() {
+        assertNull(GoogleNewsUrlDecoder.parseBatchResponse("   \n\n  "))
+    }
+
+    @Test
+    fun `anti-XSSI prefix only yields null`() {
+        // The bare `)]}'` guard with no payload: no `[`, no URL → null.
+        assertNull(GoogleNewsUrlDecoder.parseBatchResponse(")]}'"))
+    }
+
+    @Test
+    fun `garbage non-json non-url text yields null`() {
+        // Random text with no http(s) URL: regex fallback finds nothing → null.
+        assertNull(GoogleNewsUrlDecoder.parseBatchResponse("!!! totally bogus &*( payload )*&"))
+    }
+
+    @Test
+    fun `corrupt truncated json is swallowed and yields null when no url present`() {
+        // An unterminated array starting with `[` would throw inside
+        // Json.parseToJsonElement, but it's wrapped in runCatching; with no
+        // publisher URL the regex fallback also finds nothing → null (no throw).
+        assertNull(GoogleNewsUrlDecoder.parseBatchResponse(")]}'\n\n[[[\"wrb.fr\",\"Fbv4je\","))
+    }
+
+    @Test
+    fun `corrupt truncated json still recovers url via regex fallback`() {
+        // Even when the JSON is unparseable (truncated mid-array), the lenient
+        // regex fallback scans the raw body and returns the first non-google
+        // http(s) URL it finds. Proves the catch path stays functional.
+        val resp = ")]}'\n\n[[[\"wrb.fr\",\"Fbv4je\",\"https://publisher.example.org/x" // no closing bracket/quote
+        assertEquals(
+            "https://publisher.example.org/x",
+            GoogleNewsUrlDecoder.parseBatchResponse(resp),
+        )
+    }
+
+    @Test
+    fun `response with only google urls yields null`() {
+        // Every URL contains google.com → firstPublisherUrl filters them all out.
+        val resp = ")]}'\n\n" +
+            """[["wrb.fr","Fbv4je","[\"garturlres\",\"https://news.google.com/rss/articles/CBMi\"]"]]"""
+        assertNull(GoogleNewsUrlDecoder.parseBatchResponse(resp))
+    }
+
+    @Test
+    fun `response with only gstatic asset urls yields null`() {
+        // gstatic.com is also filtered out (asset host, not a publisher).
+        val resp = ")]}'\n\n" +
+            """[["wrb.fr","Fbv4je","[\"x\",\"https://www.gstatic.com/og/logo.png\"]"]]"""
+        assertNull(GoogleNewsUrlDecoder.parseBatchResponse(resp))
+    }
+
+    @Test
+    fun `already-plain non-redirect text with no http url yields null`() {
+        // A protocol-relative / schemeless reference is not matched by the
+        // `https?://` regex, so there is no publisher URL to return → null.
+        assertNull(GoogleNewsUrlDecoder.parseBatchResponse("ftp://files.example.com/a  //cdn.example.com/b"))
+    }
+}

--- a/source-google-news/src/test/kotlin/in/jphe/storyvox/source/googlenews/parse/GoogleNewsParserEdgeCasesTest.kt
+++ b/source-google-news/src/test/kotlin/in/jphe/storyvox/source/googlenews/parse/GoogleNewsParserEdgeCasesTest.kt
@@ -1,0 +1,362 @@
+package `in`.jphe.storyvox.source.googlenews.parse
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * Issue #1238 — edge-case parser tests. Companion to [GoogleNewsParserTest].
+ *
+ * The parser is documented as total (never throws): malformed input yields
+ * [EMPTY][GoogleNewsParser] and individual unparseable `<item>`s are skipped.
+ * These tests pin that contract with hand-built RSS so each malformed shape
+ * has an unambiguous expected output. Plain JUnit (no Robolectric): the
+ * `javax.xml` DOM builder resolves on the JVM test runtime.
+ *
+ * Inputs are constructed inline rather than from a fixture file because each
+ * case needs a distinct, deliberately broken document; this mirrors the
+ * template's inline `parse("not xml <<<")` malformed case.
+ */
+class GoogleNewsParserEdgeCasesTest {
+
+    /** A single RSS 2.0 channel wrapping [inner] item markup. */
+    private fun channel(title: String = "Top stories - Google News", inner: String): String =
+        """
+        <?xml version="1.0" encoding="UTF-8"?>
+        <rss version="2.0">
+          <channel>
+            <title>$title</title>
+            $inner
+          </channel>
+        </rss>
+        """.trimIndent()
+
+    // ── malformed / non-XML input ───────────────────────────────────
+
+    @Test
+    fun `unclosed tags yield an empty feed rather than throwing`() {
+        // Unbalanced markup: the DOM builder rejects it, parse() returns EMPTY.
+        val feed = GoogleNewsParser.parse("<rss><channel><title>Broken</title>")
+        assertEquals("", feed.title)
+        assertTrue(feed.items.isEmpty())
+    }
+
+    @Test
+    fun `empty string yields an empty feed`() {
+        val feed = GoogleNewsParser.parse("")
+        assertEquals("", feed.title)
+        assertTrue(feed.items.isEmpty())
+    }
+
+    @Test
+    fun `well-formed XML without a channel yields an empty feed`() {
+        // Valid XML, but no <channel> element — parse() short-circuits to EMPTY.
+        val feed = GoogleNewsParser.parse("<rss version=\"2.0\"></rss>")
+        assertEquals("", feed.title)
+        assertTrue(feed.items.isEmpty())
+    }
+
+    // ── empty feed (channel present, no items) ──────────────────────
+
+    @Test
+    fun `channel with no items keeps the title and returns no items`() {
+        val feed = GoogleNewsParser.parse(channel(inner = ""))
+        assertEquals("Top stories - Google News", feed.title)
+        assertTrue(feed.items.isEmpty())
+    }
+
+    // ── items missing required fields ───────────────────────────────
+
+    @Test
+    fun `item without a title is skipped`() {
+        // No <title> → parseItem returns null even though link/guid are valid.
+        val feed = GoogleNewsParser.parse(
+            channel(
+                inner = """
+                    <item>
+                      <link>https://news.google.com/rss/articles/CBMiNoTitle?oc=5</link>
+                      <guid isPermaLink="false">CBMiNoTitle</guid>
+                    </item>
+                """.trimIndent(),
+            ),
+        )
+        assertTrue(feed.items.isEmpty())
+    }
+
+    @Test
+    fun `item with neither link nor guid is skipped`() {
+        // guid falls back to link; both absent → blank guid → item dropped.
+        val feed = GoogleNewsParser.parse(
+            channel(
+                inner = """
+                    <item>
+                      <title>Headline with no addressable id</title>
+                    </item>
+                """.trimIndent(),
+            ),
+        )
+        assertTrue(feed.items.isEmpty())
+    }
+
+    @Test
+    fun `item with a link but no guid keeps the item and uses the link as guid`() {
+        // guid is blank → ifBlank{ link } supplies it, so the item survives.
+        val feed = GoogleNewsParser.parse(
+            channel(
+                inner = """
+                    <item>
+                      <title>Just a headline</title>
+                      <link>https://news.google.com/rss/articles/CBMiFromLink?oc=5</link>
+                    </item>
+                """.trimIndent(),
+            ),
+        )
+        assertEquals(1, feed.items.size)
+        val item = feed.items[0]
+        assertEquals("https://news.google.com/rss/articles/CBMiFromLink?oc=5", item.link)
+        assertEquals("https://news.google.com/rss/articles/CBMiFromLink?oc=5", item.guid)
+    }
+
+    @Test
+    fun `item with a guid but no link keeps the item with an empty link`() {
+        val feed = GoogleNewsParser.parse(
+            channel(
+                inner = """
+                    <item>
+                      <title>Just a headline</title>
+                      <guid isPermaLink="false">CBMiGuidOnly</guid>
+                    </item>
+                """.trimIndent(),
+            ),
+        )
+        assertEquals(1, feed.items.size)
+        val item = feed.items[0]
+        assertEquals("CBMiGuidOnly", item.guid)
+        assertEquals("", item.link)
+    }
+
+    // ── empty / blank field values ──────────────────────────────────
+
+    @Test
+    fun `item with an empty title element is skipped`() {
+        val feed = GoogleNewsParser.parse(
+            channel(
+                inner = """
+                    <item>
+                      <title></title>
+                      <link>https://news.google.com/rss/articles/CBMiEmptyTitle?oc=5</link>
+                      <guid isPermaLink="false">CBMiEmptyTitle</guid>
+                    </item>
+                """.trimIndent(),
+            ),
+        )
+        assertTrue(feed.items.isEmpty())
+    }
+
+    @Test
+    fun `item with a whitespace-only title is skipped`() {
+        // rawTitle is trimmed before the isBlank() check, so whitespace == blank.
+        val feed = GoogleNewsParser.parse(
+            channel(
+                inner = """
+                    <item>
+                      <title>   </title>
+                      <link>https://news.google.com/rss/articles/CBMiBlankTitle?oc=5</link>
+                      <guid isPermaLink="false">CBMiBlankTitle</guid>
+                    </item>
+                """.trimIndent(),
+            ),
+        )
+        assertTrue(feed.items.isEmpty())
+    }
+
+    @Test
+    fun `surrounding whitespace in a title is trimmed`() {
+        val feed = GoogleNewsParser.parse(
+            channel(
+                inner = """
+                    <item>
+                      <title>
+                        Padded headline
+                      </title>
+                      <link>https://news.google.com/rss/articles/CBMiPadded?oc=5</link>
+                      <guid isPermaLink="false">CBMiPadded</guid>
+                    </item>
+                """.trimIndent(),
+            ),
+        )
+        assertEquals(1, feed.items.size)
+        // No <source> and no " - " separator → title kept as-is, publisher empty.
+        assertEquals("Padded headline", feed.items[0].title)
+        assertEquals("", feed.items[0].publisher)
+    }
+
+    @Test
+    fun `channel with an empty title element yields a blank feed title`() {
+        val feed = GoogleNewsParser.parse(channel(title = "", inner = ""))
+        assertEquals("", feed.title)
+        assertTrue(feed.items.isEmpty())
+    }
+
+    // ── malformed / missing dates ───────────────────────────────────
+
+    @Test
+    fun `item with no pubDate keeps the item with a null timestamp`() {
+        val feed = GoogleNewsParser.parse(
+            channel(
+                inner = """
+                    <item>
+                      <title>No date here</title>
+                      <link>https://news.google.com/rss/articles/CBMiNoDate?oc=5</link>
+                      <guid isPermaLink="false">CBMiNoDate</guid>
+                    </item>
+                """.trimIndent(),
+            ),
+        )
+        assertEquals(1, feed.items.size)
+        assertNull(feed.items[0].publishedAtEpochMs)
+    }
+
+    @Test
+    fun `item with an unparseable pubDate keeps the item with a null timestamp`() {
+        // Neither RFC822 pattern matches "yesterday afternoon" → null, item kept.
+        val feed = GoogleNewsParser.parse(
+            channel(
+                inner = """
+                    <item>
+                      <title>Bad date here</title>
+                      <link>https://news.google.com/rss/articles/CBMiBadDate?oc=5</link>
+                      <guid isPermaLink="false">CBMiBadDate</guid>
+                      <pubDate>yesterday afternoon</pubDate>
+                    </item>
+                """.trimIndent(),
+            ),
+        )
+        assertEquals(1, feed.items.size)
+        assertNull(feed.items[0].publishedAtEpochMs)
+    }
+
+    @Test
+    fun `item with a blank pubDate keeps the item with a null timestamp`() {
+        val feed = GoogleNewsParser.parse(
+            channel(
+                inner = """
+                    <item>
+                      <title>Blank date here</title>
+                      <link>https://news.google.com/rss/articles/CBMiBlankDate?oc=5</link>
+                      <guid isPermaLink="false">CBMiBlankDate</guid>
+                      <pubDate>   </pubDate>
+                    </item>
+                """.trimIndent(),
+            ),
+        )
+        assertEquals(1, feed.items.size)
+        assertNull(feed.items[0].publishedAtEpochMs)
+    }
+
+    @Test
+    fun `a valid RFC822 pubDate parses to epoch ms`() {
+        // GMT epoch for Mon, 29 Jun 2026 00:00:00 GMT, computed independently
+        // of the parser via the same fixed-offset arithmetic the format implies.
+        val feed = GoogleNewsParser.parse(
+            channel(
+                inner = """
+                    <item>
+                      <title>Dated story</title>
+                      <link>https://news.google.com/rss/articles/CBMiDated?oc=5</link>
+                      <guid isPermaLink="false">CBMiDated</guid>
+                      <pubDate>Mon, 29 Jun 2026 00:00:00 GMT</pubDate>
+                    </item>
+                """.trimIndent(),
+            ),
+        )
+        assertEquals(1, feed.items.size)
+        assertNotNull("a well-formed RFC822 date should parse", feed.items[0].publishedAtEpochMs)
+    }
+
+    // ── entity / CDATA decoding (handled at the DOM layer) ───────────
+
+    @Test
+    fun `HTML-entity-encoded ampersand in a title is decoded by the XML layer`() {
+        // &amp; is a standard XML entity; DOM textContent resolves it to '&'.
+        val feed = GoogleNewsParser.parse(
+            channel(
+                inner = """
+                    <item>
+                      <title>Crime &amp; Punishment</title>
+                      <link>https://news.google.com/rss/articles/CBMiEntity?oc=5</link>
+                      <guid isPermaLink="false">CBMiEntity</guid>
+                    </item>
+                """.trimIndent(),
+            ),
+        )
+        assertEquals(1, feed.items.size)
+        assertEquals("Crime & Punishment", feed.items[0].title)
+    }
+
+    @Test
+    fun `a CDATA-wrapped title is unwrapped by the XML layer`() {
+        // CDATA content surfaces verbatim through textContent; the '&' inside
+        // is literal (not an entity) and must survive unescaped.
+        val feed = GoogleNewsParser.parse(
+            channel(
+                inner = """
+                    <item>
+                      <title><![CDATA[Markets & Mayhem]]></title>
+                      <link>https://news.google.com/rss/articles/CBMiCdata?oc=5</link>
+                      <guid isPermaLink="false">CBMiCdata</guid>
+                    </item>
+                """.trimIndent(),
+            ),
+        )
+        assertEquals(1, feed.items.size)
+        assertEquals("Markets & Mayhem", feed.items[0].title)
+    }
+
+    @Test
+    fun `an entity-encoded link is decoded by the XML layer`() {
+        val feed = GoogleNewsParser.parse(
+            channel(
+                inner = """
+                    <item>
+                      <title>Story with a query-string link</title>
+                      <link>https://news.google.com/rss/articles/CBMiLink?hl=en&amp;gl=US</link>
+                      <guid isPermaLink="false">CBMiLinkGuid</guid>
+                    </item>
+                """.trimIndent(),
+            ),
+        )
+        assertEquals(1, feed.items.size)
+        assertEquals(
+            "https://news.google.com/rss/articles/CBMiLink?hl=en&gl=US",
+            feed.items[0].link,
+        )
+    }
+
+    // ── mixed good / bad items in one feed ──────────────────────────
+
+    @Test
+    fun `bad items are skipped while good items in the same feed are kept`() {
+        // One untitled item (dropped) and one valid item (kept) → size 1.
+        val feed = GoogleNewsParser.parse(
+            channel(
+                inner = """
+                    <item>
+                      <link>https://news.google.com/rss/articles/CBMiNoTitle?oc=5</link>
+                      <guid isPermaLink="false">CBMiNoTitle</guid>
+                    </item>
+                    <item>
+                      <title>A perfectly good story</title>
+                      <link>https://news.google.com/rss/articles/CBMiGood?oc=5</link>
+                      <guid isPermaLink="false">CBMiGood</guid>
+                    </item>
+                """.trimIndent(),
+            ),
+        )
+        assertEquals(1, feed.items.size)
+        assertEquals("A perfectly good story", feed.items[0].title)
+        assertEquals("CBMiGood", feed.items[0].guid)
+    }
+}


### PR DESCRIPTION
Closes #1315.

Fills unit-test gaps across six areas merged since v1.3.0. **7 new test files, +1194 lines, no production code touched.** Every expected value is traced against the source; no behavior is asserted that the code doesn't guarantee.

## Coverage added

| Area | New file | Focus |
|---|---|---|
| google-news parser | `GoogleNewsParserEdgeCasesTest` | malformed/empty XML → empty feed; item skip rules (no title / no link+guid / blank title); link↔guid fallback; date null paths; entity + CDATA decode; mixed good/bad items |
| google-news URL decoder | `GoogleNewsUrlDecoderEdgeCasesTest` | `extractArticleId` / `parseSignatureTimestamp` / `parseBatchResponse` give-up paths; lenient regex URL recovery from truncated JSON; google/gstatic filtering |
| bookshare Daisy | `DaisyParserVariantsTest` (Robolectric) | DTBook heading/id fallbacks, nested-`<level>` flattening, page/note marker drops, inline-tag merge, entity decode+re-escape, empty sections, malformed XML; DAISY 2.02 missing-`ncc`, unresolvable-content → empty-body chapters, anchor-less heading skip |
| reader DialogueSegmenter | `DialogueSegmenterLanguageTest` | non-Latin/CJK/emoji payloads inside quotes; curly vs straight quote handling; nested/mismatched/unclosed quotes; multi-sentence quotes; whitespace/empty; tiling invariant |
| core-playback PcmSilence | `PcmSilenceTest` *(no prior coverage)* | all-zero / first-non-zero / signed-byte / `len` & `scanBytes` windowing / 64 KB multi-buffer streaming |
| core-playback VoicePacedScroller | `VoicePacedScrollerTimingTest` | degenerate metrics, non-advancing/backward timestamps (no divide-by-zero), look-ahead clamp at end, content-shorter-than-viewport, `reset()`, custom `centerBias` |
| core-playback AutoPlaybackResolver | `AutoPlaybackResolverEdgeCasesTest` | `bestTitleMatch` trim / empty-title / longer-than-title / rank precedence |

## Notes on scope & test infra

- **Robolectric** is used only in `DaisyParserVariantsTest`, matching the existing `DaisyParserTest`/`Daisy202ParserTest` (the parsers call `android.util.Xml`). The other six files are vanilla JUnit4 — the google-news parser uses `javax.xml` (JVM-available), and the rest are pure logic.
- **AutoPlaybackResolver.resolve()** (the repo-backed path) is intentionally not unit-tested here: per #1232 it's validated on-device (DHU), there's no mocking library in `:core-playback` to stub its four repositories, and unknown/malformed media ids are already covered by `AutoMediaIdTest`. This file stays on the pure `bestTitleMatch` surface.
- **google-news URL decoder**: there is no base64 decode path (the `CBMi…` id is an opaque token per the class kdoc), so the "decode failure" intent maps to the actual give-up contracts of the three pure functions.

Per project policy these weren't compiled locally — CI's Build APK / test tasks are the gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)