### PR TITLE
feat(source-bookshare): wire Bookshare API v2 search/browse/categories (#1002)

### DIFF
--- a/source-bookshare/build.gradle.kts
+++ b/source-bookshare/build.gradle.kts
@@ -2,6 +2,7 @@ plugins {
     alias(libs.plugins.android.library)
     alias(libs.plugins.ksp)
     alias(libs.plugins.hilt)
+    alias(libs.plugins.kotlin.serialization)
 }
 
 android {
@@ -39,6 +40,11 @@ dependencies {
     implementation(project(":core-data"))
 
     implementation(libs.kotlinx.coroutines.android)
+    // Issue #1002 — Bookshare API v2 client (JSON over OkHttp). Same stack
+    // as :source-gutenberg's Gutendex client.
+    implementation(libs.kotlinx.serialization.json)
+    implementation(libs.okhttp)
+    implementation(libs.okhttp.logging)
 
     implementation(libs.hilt.android)
     ksp(libs.hilt.compiler)

--- a/source-bookshare/src/main/kotlin/in/jphe/storyvox/source/bookshare/BookshareConfig.kt
+++ b/source-bookshare/src/main/kotlin/in/jphe/storyvox/source/bookshare/BookshareConfig.kt
@@ -1,0 +1,34 @@
+package `in`.jphe.storyvox.source.bookshare
+
+import javax.inject.Inject
+
+/**
+ * Issue #1002 — runtime credentials for the Bookshare API.
+ *
+ * Bookshare API v2 requires a partner `api_key` on every endpoint (issued by
+ * partner-support@bookshare.org) and, for member-scoped endpoints, a per-user
+ * OAuth bearer token. Neither is hardcodable — they're partnership / user data
+ * — so [BookshareSource] reads them through this seam. The in-memory default
+ * ([InMemoryBookshareConfig]) returns null for both, so until a DataStore-backed
+ * implementation in :app supplies them, every Bookshare network call
+ * short-circuits to `FictionResult.AuthRequired`. Mirrors the
+ * `PalaceLibraryConfig` / `GoogleNewsConfig` config seams.
+ */
+interface BookshareConfig {
+
+    /** Partner API key (request param `api_key`), or null when unconfigured. */
+    suspend fun apiKey(): String?
+
+    /** Per-user OAuth bearer token for member-scoped endpoints, or null. */
+    suspend fun accessToken(): String?
+}
+
+/**
+ * Default no-credentials binding. Replaced by a DataStore-backed implementation
+ * in :app once the Bookshare partnership + settings UI land (tracked on #1002);
+ * until then the source stays gated.
+ */
+internal class InMemoryBookshareConfig @Inject constructor() : BookshareConfig {
+    override suspend fun apiKey(): String? = null
+    override suspend fun accessToken(): String? = null
+}

--- a/source-bookshare/src/main/kotlin/in/jphe/storyvox/source/bookshare/BookshareSource.kt
+++ b/source-bookshare/src/main/kotlin/in/jphe/storyvox/source/bookshare/BookshareSource.kt
@@ -54,7 +54,7 @@ import javax.inject.Singleton
     description = "Accessible DAISY library · partner API (see #1002)",
     sourceUrl = "https://www.bookshare.org",
 )
-class BookshareSource @Inject constructor(
+internal class BookshareSource @Inject constructor(
     private val api: BookshareApi,
     private val config: BookshareConfig,
 ) : FictionSource {

--- a/source-bookshare/src/main/kotlin/in/jphe/storyvox/source/bookshare/BookshareSource.kt
+++ b/source-bookshare/src/main/kotlin/in/jphe/storyvox/source/bookshare/BookshareSource.kt
@@ -8,40 +8,41 @@ import `in`.jphe.storyvox.data.source.model.FictionResult
 import `in`.jphe.storyvox.data.source.model.FictionSummary
 import `in`.jphe.storyvox.data.source.model.ListPage
 import `in`.jphe.storyvox.data.source.model.SearchQuery
+import `in`.jphe.storyvox.data.source.model.map
 import `in`.jphe.storyvox.data.source.plugin.SourceCategory
 import `in`.jphe.storyvox.data.source.plugin.SourcePlugin
+import `in`.jphe.storyvox.source.bookshare.net.BookshareApi
+import `in`.jphe.storyvox.source.bookshare.net.BookshareTitle
+import `in`.jphe.storyvox.source.bookshare.net.BookshareTitlesPage
 import javax.inject.Inject
 import javax.inject.Singleton
 
 /**
- * Issue #1002 — Bookshare / accessible-library (DAISY) source.
+ * Issue #1002 — Bookshare / accessible-library source.
  *
  * Bookshare (a Benetech program) is the largest accessible-book library for
  * people with print disabilities — 1M+ titles in DAISY format, free to
- * qualified users. This is the most mission-aligned source Candela could add.
+ * qualified users. The most mission-aligned source Candela could add.
  *
- * ## Why this is a guarded scaffold (not yet functional)
+ * ## What works now vs. what stays gated
  *
- * A working integration is gated on three things that need a partnership /
- * legal step, not engineering (full writeup in the #1002 research comment):
+ * **Discovery (search / browse / categories)** is wired to the Bookshare API
+ * v2 ([BookshareApi]). It activates as soon as a partner `api_key` is supplied
+ * through [BookshareConfig]; until then (the default in-memory config returns
+ * none) these calls return [FictionResult.AuthRequired] — the interface's
+ * graceful "no session" path.
  *
- *  1. **Partner `api_key`** — issued only by emailing
- *     `partner-support@bookshare.org`; required on every API v2 endpoint.
- *  2. **Per-user OAuth** — Authorization-Code grant against
- *     `auth.bookshare.org`; the user signs in with their *already
- *     disability-verified* Bookshare account (Bookshare verifies eligibility
- *     at signup, so Candela never collects proof-of-disability itself).
- *  3. **Protected DAISY (PDTB) decryption** — copyrighted downloads are
- *     encrypted per-user, fingerprinted, and watermarked; decryption needs
- *     Bookshare's scheme under partner terms and isn't publicly implementable.
+ * **Content (`fictionDetail` / `chapter`)** stays gated regardless of the key:
+ * Bookshare copyrighted downloads are Protected DAISY (PDTB) — encrypted
+ * per-user, fingerprinted, watermarked — and decryptable only under the
+ * partnership (see the #1002 research comment). When that lands, `chapter`
+ * will route an unprotected DAISY download through
+ * [`DaisyParser`][in.jphe.storyvox.source.bookshare.parse.DaisyParser] /
+ * [`Daisy202Parser`][in.jphe.storyvox.source.bookshare.parse.Daisy202Parser].
  *
- * Until those land, every call returns [FictionResult.AuthRequired] — the
- * interface's intended "no session" path, which surfaces a sign-in prompt
- * instead of throwing. The non-gated groundwork that DID ship in this PR is
- * the DAISY text parser
- * ([`DaisyParser`][in.jphe.storyvox.source.bookshare.parse.DaisyParser]):
- * once an `api_key` + OAuth land and an *unprotected* DAISY download is
- * available, [chapter] parses it via that parser into [ChapterContent].
+ * Bookshare verifies a user's print-disability eligibility at account signup,
+ * so Candela never collects proof-of-disability itself — it only forwards the
+ * user's `api_key`/OAuth token from [BookshareConfig].
  */
 @Singleton
 @SourcePlugin(
@@ -50,22 +51,41 @@ import javax.inject.Singleton
     defaultEnabled = false,
     category = SourceCategory.Ebook,
     supportsSearch = true,
-    description = "Accessible DAISY library · partner API (gated, see #1002)",
+    description = "Accessible DAISY library · partner API (see #1002)",
     sourceUrl = "https://www.bookshare.org",
 )
-class BookshareSource @Inject constructor() : FictionSource {
+class BookshareSource @Inject constructor(
+    private val api: BookshareApi,
+    private val config: BookshareConfig,
+) : FictionSource {
 
     override val id: String = SourceIds.BOOKSHARE
     override val displayName: String = "Bookshare"
 
-    override suspend fun popular(page: Int): FictionResult<ListPage<FictionSummary>> = gate()
+    override suspend fun popular(page: Int): FictionResult<ListPage<FictionSummary>> =
+        browse(page = page)
 
-    override suspend fun latestUpdates(page: Int): FictionResult<ListPage<FictionSummary>> = gate()
+    override suspend fun latestUpdates(page: Int): FictionResult<ListPage<FictionSummary>> =
+        // Bookshare's catalog API exposes no "newest" sort; fall back to browse.
+        browse(page = page)
 
-    override suspend fun byGenre(genre: String, page: Int): FictionResult<ListPage<FictionSummary>> = gate()
+    override suspend fun byGenre(genre: String, page: Int): FictionResult<ListPage<FictionSummary>> =
+        browse(category = genre, page = page)
 
-    override suspend fun search(query: SearchQuery): FictionResult<ListPage<FictionSummary>> = gate()
+    override suspend fun search(query: SearchQuery): FictionResult<ListPage<FictionSummary>> =
+        browse(
+            title = query.term.takeIf { it.isNotBlank() },
+            category = query.genres.firstOrNull(),
+            page = query.page,
+        )
 
+    override suspend fun genres(): FictionResult<List<String>> {
+        val key = config.apiKey() ?: return gate()
+        return api.categories(key, config.accessToken())
+            .map { page -> page.categories.mapNotNull { it.name.takeIf(String::isNotBlank) } }
+    }
+
+    // ── Content download stays gated (Protected DAISY / PDTB — see #1002). ──
     override suspend fun fictionDetail(fictionId: String): FictionResult<FictionDetail> = gate()
 
     override suspend fun chapter(fictionId: String, chapterId: String): FictionResult<ChapterContent> = gate()
@@ -74,18 +94,42 @@ class BookshareSource @Inject constructor() : FictionSource {
 
     override suspend fun setFollowed(fictionId: String, followed: Boolean): FictionResult<Unit> = gate()
 
-    override suspend fun genres(): FictionResult<List<String>> = gate()
+    /** Shared discovery path: requires a configured `api_key`, else [gate]. */
+    private suspend fun browse(
+        title: String? = null,
+        author: String? = null,
+        category: String? = null,
+        page: Int = 1,
+    ): FictionResult<ListPage<FictionSummary>> {
+        val key = config.apiKey() ?: return gate()
+        return api.searchTitles(
+            apiKey = key,
+            accessToken = config.accessToken(),
+            title = title,
+            author = author,
+            category = category,
+        ).map { it.toListPage(page) }
+    }
 
-    /**
-     * Every network path is gated until the Bookshare partnership lands (see
-     * the class kdoc + #1002). [FictionResult.AuthRequired] is the interface's
-     * intended graceful "no session" return — never throw.
-     */
     private fun gate(): FictionResult.AuthRequired = FictionResult.AuthRequired(GATE_MESSAGE)
 
     companion object {
         private const val GATE_MESSAGE =
-            "Bookshare needs a partner API key and your verified Bookshare sign-in, " +
-                "plus Protected-DAISY support — not available yet (see #1002)."
+            "Bookshare needs a partner API key (and, for downloads, your verified " +
+                "Bookshare sign-in + Protected-DAISY support) — see #1002."
     }
 }
+
+/** Maps a Bookshare titles page → the source layer's [ListPage]. `internal` for unit tests. */
+internal fun BookshareTitlesPage.toListPage(page: Int): ListPage<FictionSummary> =
+    ListPage(items = titles.map { it.toSummary() }, page = page, hasNext = next != null)
+
+/** Maps one Bookshare title → [FictionSummary]. `internal` for unit tests. */
+internal fun BookshareTitle.toSummary(): FictionSummary =
+    FictionSummary(
+        id = bookshareId.toString(),
+        sourceId = SourceIds.BOOKSHARE,
+        title = title,
+        author = authorDisplay(),
+        tags = categories.mapNotNull { it.name.takeIf(String::isNotBlank) },
+    )

--- a/source-bookshare/src/main/kotlin/in/jphe/storyvox/source/bookshare/di/BookshareModule.kt
+++ b/source-bookshare/src/main/kotlin/in/jphe/storyvox/source/bookshare/di/BookshareModule.kt
@@ -2,25 +2,76 @@ package `in`.jphe.storyvox.source.bookshare.di
 
 import dagger.Binds
 import dagger.Module
+import dagger.Provides
 import dagger.hilt.InstallIn
 import dagger.hilt.components.SingletonComponent
 import dagger.multibindings.IntoMap
 import dagger.multibindings.StringKey
+import `in`.jphe.storyvox.data.network.UserAgentHeader
 import `in`.jphe.storyvox.data.source.FictionSource
 import `in`.jphe.storyvox.data.source.SourceIds
+import `in`.jphe.storyvox.source.bookshare.BookshareConfig
 import `in`.jphe.storyvox.source.bookshare.BookshareSource
+import `in`.jphe.storyvox.source.bookshare.InMemoryBookshareConfig
+import `in`.jphe.storyvox.source.bookshare.net.BookshareApi
+import okhttp3.Interceptor
+import okhttp3.OkHttpClient
+import java.util.concurrent.TimeUnit
+import javax.inject.Qualifier
 import javax.inject.Singleton
+
+/** Dedicated OkHttp client for the Bookshare API v2 (JSON catalog calls). */
+@Qualifier
+@Retention(AnnotationRetention.BINARY)
+annotation class BookshareHttp
+
+@Module
+@InstallIn(SingletonComponent::class)
+internal object BookshareHttpModule {
+
+    @Provides
+    @Singleton
+    @BookshareHttp
+    fun provideClient(
+        @UserAgentHeader userAgent: Interceptor,
+    ): OkHttpClient =
+        OkHttpClient.Builder()
+            .connectTimeout(10, TimeUnit.SECONDS)
+            .readTimeout(30, TimeUnit.SECONDS)
+            .writeTimeout(30, TimeUnit.SECONDS)
+            .followRedirects(true)
+            .followSslRedirects(true)
+            .retryOnConnectionFailure(true)
+            // #1204 — shared descriptive User-Agent on every request.
+            .addInterceptor(userAgent)
+            .build()
+
+    @Provides
+    @Singleton
+    fun provideBookshareApi(
+        @BookshareHttp client: OkHttpClient,
+    ): BookshareApi = BookshareApi(client)
+}
+
+/**
+ * Default credentials binding — the in-memory config returns no api_key, so the
+ * source stays gated until a DataStore-backed implementation in :app supplies
+ * one (mirrors `:source-palace`'s `PalaceConfigBindings` / #501 pattern).
+ */
+@Module
+@InstallIn(SingletonComponent::class)
+internal abstract class BookshareConfigBindings {
+
+    @Binds
+    @Singleton
+    abstract fun bindConfig(impl: InMemoryBookshareConfig): BookshareConfig
+}
 
 /**
  * Issue #1002 — contributes [BookshareSource] into the multi-source
  * `Map<String, FictionSource>` so persisted rows with `sourceId="bookshare"`
- * resolve through it.
- *
- * The legacy `@IntoMap @StringKey` binding runs in parallel with the
- * auto-generated `@SourcePlugin` descriptor binding emitted by
- * `:core-plugin-ksp` — the same Phase 2 transitional pattern every other
- * source module uses (#384). Phase 3 will remove the legacy bindings across
- * the board.
+ * resolve through it. Runs in parallel with the auto-generated `@SourcePlugin`
+ * descriptor binding (Phase 2 pattern, #384).
  */
 @Module
 @InstallIn(SingletonComponent::class)

--- a/source-bookshare/src/main/kotlin/in/jphe/storyvox/source/bookshare/net/BookshareApi.kt
+++ b/source-bookshare/src/main/kotlin/in/jphe/storyvox/source/bookshare/net/BookshareApi.kt
@@ -1,0 +1,169 @@
+package `in`.jphe.storyvox.source.bookshare.net
+
+import `in`.jphe.storyvox.data.source.model.FictionResult
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.json.Json
+import okhttp3.OkHttpClient
+import okhttp3.Request
+import java.io.IOException
+import java.net.URLEncoder
+
+/**
+ * Issue #1002 — minimal client for the Bookshare API v2
+ * (https://apidocs.bookshare.org). Covers the discovery surface the Browse
+ * sheet needs: title search/browse + category listing. Content **download** is
+ * deliberately NOT here — Bookshare copyrighted titles are Protected DAISY
+ * (PDTB), gated on the partnership + per-user decryption (see #1002).
+ *
+ * Every endpoint takes the partner `api_key` (request param) and, optionally, a
+ * per-user OAuth bearer token (member-scoped endpoints). 401/403 map to
+ * [FictionResult.AuthRequired] so a missing/invalid key or sign-in surfaces as
+ * the interface's graceful auth path rather than a crash. Mirrors
+ * :source-gutenberg's GutendexApi (sync OkHttp on Dispatchers.IO; lenient Json).
+ */
+internal class BookshareApi(
+    private val client: OkHttpClient,
+) {
+    private val json = Json { ignoreUnknownKeys = true; isLenient = true; coerceInputValues = true }
+
+    /** `GET /v2/titles` — search / browse by title, author, and/or category. */
+    suspend fun searchTitles(
+        apiKey: String,
+        accessToken: String?,
+        title: String? = null,
+        author: String? = null,
+        category: String? = null,
+        limit: Int = DEFAULT_LIMIT,
+        start: String? = null,
+    ): FictionResult<BookshareTitlesPage> =
+        request(titlesPath(title, author, category, limit, start, apiKey), accessToken) {
+            json.decodeFromString<BookshareTitlesPage>(it)
+        }
+
+    /** `GET /v2/titles/categories` — subject list for the genre picker. */
+    suspend fun categories(
+        apiKey: String,
+        accessToken: String?,
+    ): FictionResult<BookshareCategoriesPage> =
+        request("/v2/titles/categories?api_key=${enc(apiKey)}", accessToken) {
+            json.decodeFromString<BookshareCategoriesPage>(it)
+        }
+
+    /**
+     * Sync OkHttp `execute()` wrapped in `withContext(Dispatchers.IO)` — a bare
+     * `suspend` doesn't move the call off the caller's thread (would crash with
+     * NetworkOnMainThreadException). Same posture as the other network sources.
+     */
+    private suspend fun <T> request(
+        path: String,
+        accessToken: String?,
+        parse: (String) -> T,
+    ): FictionResult<T> = withContext(Dispatchers.IO) {
+        val url = BASE_URL + path
+        try {
+            val builder = Request.Builder().url(url).header("Accept", "application/json").get()
+            if (!accessToken.isNullOrBlank()) builder.header("Authorization", "Bearer $accessToken")
+            client.newCall(builder.build()).execute().use { resp ->
+                when {
+                    resp.code == 401 || resp.code == 403 -> FictionResult.AuthRequired(
+                        "Bookshare rejected the request (HTTP ${resp.code}) — API key or sign-in required.",
+                    )
+                    resp.code == 404 -> FictionResult.NotFound("Bookshare: $path not found")
+                    resp.code == 429 -> FictionResult.RateLimited(null, "Bookshare rate limited")
+                    !resp.isSuccessful -> FictionResult.NetworkError(
+                        "HTTP ${resp.code} from $url", IOException("HTTP ${resp.code}"),
+                    )
+                    else -> {
+                        val text = resp.body?.string()
+                            ?: return@withContext FictionResult.NetworkError("empty body", IOException("empty body"))
+                        FictionResult.Success(parse(text))
+                    }
+                }
+            }
+        } catch (e: IOException) {
+            FictionResult.NetworkError(e.message ?: "fetch failed", e)
+        } catch (e: kotlinx.serialization.SerializationException) {
+            FictionResult.NetworkError("Bookshare returned unexpected JSON shape", e)
+        }
+    }
+
+    companion object {
+        const val BASE_URL = "https://api.bookshare.org"
+        const val DEFAULT_LIMIT = 24
+
+        private fun enc(s: String): String = URLEncoder.encode(s, Charsets.UTF_8)
+
+        /**
+         * Build `/v2/titles?…` with whichever filters are present, in a
+         * deterministic order (title → author → categories → limit → start →
+         * api_key) so URL-shape tests can pin exact strings. Exposed
+         * package-internal for unit-test pinning.
+         */
+        internal fun titlesPath(
+            title: String?,
+            author: String?,
+            category: String?,
+            limit: Int,
+            start: String?,
+            apiKey: String,
+        ): String {
+            val params = mutableListOf<Pair<String, String>>()
+            title?.takeIf { it.isNotBlank() }?.let { params += "title" to it }
+            author?.takeIf { it.isNotBlank() }?.let { params += "author" to it }
+            category?.takeIf { it.isNotBlank() }?.let { params += "categories" to it }
+            params += "limit" to limit.toString()
+            start?.takeIf { it.isNotBlank() }?.let { params += "start" to it }
+            params += "api_key" to apiKey
+            val qs = params.joinToString("&") { (k, v) -> "$k=${enc(v)}" }
+            return "/v2/titles?$qs"
+        }
+    }
+}
+
+// ── Wire types ──────────────────────────────────────────────────────────────
+
+@Serializable
+internal data class BookshareTitlesPage(
+    val totalResults: Int = 0,
+    val limit: Int = 0,
+    val next: String? = null,
+    val titles: List<BookshareTitle> = emptyList(),
+)
+
+@Serializable
+internal data class BookshareTitle(
+    val bookshareId: Long = 0L,
+    val title: String = "",
+    val authors: List<BookshareAuthor> = emptyList(),
+    val isbn13: String? = null,
+    val categories: List<BookshareCategory> = emptyList(),
+) {
+    /** Comma-joined author display ("First Last"), or a fallback. */
+    fun authorDisplay(): String =
+        authors.mapNotNull { it.display().takeIf(String::isNotBlank) }
+            .joinToString(", ")
+            .ifBlank { "Unknown author" }
+}
+
+@Serializable
+internal data class BookshareAuthor(
+    val firstName: String? = null,
+    val lastName: String? = null,
+) {
+    fun display(): String =
+        listOfNotNull(firstName?.takeIf { it.isNotBlank() }, lastName?.takeIf { it.isNotBlank() })
+            .joinToString(" ")
+}
+
+@Serializable
+internal data class BookshareCategoriesPage(
+    val categories: List<BookshareCategory> = emptyList(),
+)
+
+@Serializable
+internal data class BookshareCategory(
+    val name: String = "",
+    val description: String? = null,
+)

--- a/source-bookshare/src/test/kotlin/in/jphe/storyvox/source/bookshare/net/BookshareApiTest.kt
+++ b/source-bookshare/src/test/kotlin/in/jphe/storyvox/source/bookshare/net/BookshareApiTest.kt
@@ -1,0 +1,96 @@
+package `in`.jphe.storyvox.source.bookshare.net
+
+import `in`.jphe.storyvox.data.source.SourceIds
+import `in`.jphe.storyvox.source.bookshare.toListPage
+import kotlinx.serialization.json.Json
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * Issue #1002 — Bookshare API v2 URL building + response parsing. Pure JVM
+ * (kotlinx.serialization), no network or Robolectric: validates the wire-type
+ * contracts against documented response shapes and the summary mapping.
+ */
+class BookshareApiTest {
+
+    private val json = Json { ignoreUnknownKeys = true; isLenient = true; coerceInputValues = true }
+
+    @Test
+    fun `titlesPath builds a title query with limit and api_key`() {
+        val path = BookshareApi.titlesPath(
+            title = "tom sawyer", author = null, category = null,
+            limit = 10, start = null, apiKey = "KEY",
+        )
+        assertEquals("/v2/titles?title=tom+sawyer&limit=10&api_key=KEY", path)
+    }
+
+    @Test
+    fun `titlesPath includes author, category and start when present`() {
+        val path = BookshareApi.titlesPath(
+            title = null, author = "twain", category = "Fiction",
+            limit = 24, start = "tok123", apiKey = "K",
+        )
+        assertEquals(
+            "/v2/titles?author=twain&categories=Fiction&limit=24&start=tok123&api_key=K",
+            path,
+        )
+    }
+
+    @Test
+    fun `decodes a titles search response`() {
+        val body = """
+            {"totalResults":179,"limit":10,"next":"abcde","titles":[
+              {"bookshareId":1041744,"title":"The Adventures of Tom Sawyer",
+               "authors":[{"firstName":"Mark","lastName":"Twain"}],
+               "isbn13":"9781551998121","categories":[{"name":"Fiction"}]}
+            ]}
+        """.trimIndent()
+        val page = json.decodeFromString<BookshareTitlesPage>(body)
+        assertEquals(179, page.totalResults)
+        assertEquals("abcde", page.next)
+        assertEquals(1, page.titles.size)
+        val t = page.titles.first()
+        assertEquals(1041744L, t.bookshareId)
+        assertEquals("The Adventures of Tom Sawyer", t.title)
+        assertEquals("Mark Twain", t.authorDisplay())
+    }
+
+    @Test
+    fun `decodes a categories response`() {
+        val body = """{"categories":[{"name":"Fiction","description":"x"},{"name":"Biography"}]}"""
+        val page = json.decodeFromString<BookshareCategoriesPage>(body)
+        assertEquals(listOf("Fiction", "Biography"), page.categories.map { it.name })
+    }
+
+    @Test
+    fun `author display handles missing name parts`() {
+        assertEquals("Mark Twain", BookshareAuthor("Mark", "Twain").display())
+        assertEquals("Twain", BookshareAuthor(null, "Twain").display())
+        assertEquals("Unknown author", BookshareTitle(title = "X").authorDisplay())
+    }
+
+    @Test
+    fun `maps a titles page to source summaries`() {
+        val page = BookshareTitlesPage(
+            next = "more",
+            titles = listOf(
+                BookshareTitle(
+                    bookshareId = 42L,
+                    title = "Moby Dick",
+                    authors = listOf(BookshareAuthor("Herman", "Melville")),
+                    categories = listOf(BookshareCategory("Fiction")),
+                ),
+            ),
+        )
+        val listPage = page.toListPage(page = 2)
+        assertEquals(2, listPage.page)
+        assertTrue(listPage.hasNext)
+        val summary = listPage.items.single()
+        assertEquals("42", summary.id)
+        assertEquals(SourceIds.BOOKSHARE, summary.sourceId)
+        assertEquals("Moby Dick", summary.title)
+        assertEquals("Herman Melville", summary.author)
+        assertEquals(listOf("Fiction"), summary.tags)
+    }
+}


### PR DESCRIPTION
## Summary

Wires the Bookshare API v2 discovery surface (search / browse / categories) into the `:source-bookshare` scaffold from #1290/#1303. Follow-up now that the DAISY parsers are merged.

## What's wired

- **`BookshareApi`** — OkHttp + kotlinx.serialization client for `GET /v2/titles` (search/browse by title, author, category) and `GET /v2/titles/categories`. Sync OkHttp on `Dispatchers.IO`, lenient `Json`, `FictionResult` error mapping; **401/403 → `AuthRequired`**. Mirrors `:source-gutenberg`'s `GutendexApi`.
- **`BookshareSource`** — `search` / `popular` / `byGenre` / `genres` now call the API; `fictionDetail` / `chapter` stay gated (download = Protected DAISY / PDTB, partnership-gated).
- **`BookshareConfig`** — api-key + optional per-user OAuth-token seam. **No key is hardcoded**; the in-memory default returns none, so calls stay `AuthRequired` until a DataStore-backed `:app` impl supplies credentials. Mirrors `PalaceLibraryConfig` / `GoogleNewsConfig`.
- **DI** — dedicated `@BookshareHttp` OkHttp client (shared `@UserAgentHeader`), `BookshareApi` provider, config binding, and the `@IntoMap` source binding.

## Testing

Pure-JVM `BookshareApiTest`: `titlesPath` URL building, response parsing against documented JSON shapes, author display, and the title→`FictionSummary` mapping. The DTBook + NCC parser tests from #1290/#1303 are unchanged.

## Scope / gates

- No live API call is exercised here (no key); the client + parsing are validated against canned responses. Discovery activates when a partner `api_key` is configured.
- Content download stays gated on the #1002 partnership + PDTB DRM.
- Pagination: Bookshare uses cursor (`next`) tokens; v1 fetches the first page and reports `hasNext` from `next` — threading the cursor through the page-`Int` `FictionSource` interface is a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
