### PR TITLE
feat(offline): refreshDetail TTL guard + offline 'showing cached' banner (#1314)

### DIFF
--- a/app/src/main/kotlin/in/jphe/storyvox/di/AppBindings.kt
+++ b/app/src/main/kotlin/in/jphe/storyvox/di/AppBindings.kt
@@ -726,7 +726,9 @@ private class RealFictionRepositoryUi(
         // call refreshDetail and update the per-id error state. The
         // value flow is already a Room observer on the same row, so a
         // successful refresh will surface automatically.
-        when (val result = repo.refreshDetail(id)) {
+        // #1314 — force past the TTL guard: an explicit Retry tap must always
+        // re-hit the source, not short-circuit on a recently-cached row.
+        when (val result = repo.refreshDetail(id, force = true)) {
             is FictionResult.Success -> errorState(id).value = null
             is FictionResult.Failure -> errorState(id).value = result.message
         }

--- a/app/src/test/kotlin/in/jphe/storyvox/di/RealPlaybackControllerUiTest.kt
+++ b/app/src/test/kotlin/in/jphe/storyvox/di/RealPlaybackControllerUiTest.kt
@@ -406,7 +406,7 @@ class RealPlaybackControllerUiTest {
         ) = result
         override suspend fun genres(sourceId: String) =
             FictionResult.Success(emptyList<String>())
-        override suspend fun refreshDetail(id: String) = FictionResult.Success(Unit)
+        override suspend fun refreshDetail(id: String, force: Boolean) = FictionResult.Success(Unit)
         override suspend fun refreshRemoteFollows() = FictionResult.Success(Unit)
         override suspend fun addToLibrary(id: String, mode: DownloadMode?) = Unit
         override suspend fun removeFromLibrary(id: String) = Unit

--- a/core-data/src/main/kotlin/in/jphe/storyvox/data/repository/FictionRepository.kt
+++ b/core-data/src/main/kotlin/in/jphe/storyvox/data/repository/FictionRepository.kt
@@ -92,8 +92,21 @@ interface FictionRepository {
         sourceId: String = SourceIds.ROYAL_ROAD,
     ): FictionResult<List<String>>
 
-    /** Force a detail-page refresh, upserting the cached row. */
-    suspend fun refreshDetail(id: String): FictionResult<Unit>
+    /**
+     * Force a detail-page refresh, upserting the cached row.
+     *
+     * Issue #1314 — stale-while-revalidate TTL guard. With [force] = false
+     * (the default, used by the auto first-subscription refresh in
+     * `fictionById`) the network fetch is skipped when the cached row was
+     * hydrated within the TTL window — a rapid re-open of a just-viewed
+     * fiction reads straight from Room instead of re-hitting the source.
+     * [force] = true bypasses the TTL for deliberate refreshes: the manual
+     * Retry button (`retryDetail`), the new-chapter poll worker, and the
+     * metadata back-fill worker all must fetch regardless of cache age.
+     * Placeholder rows (`metadataFetchedAt == 0`) are always stale, so the
+     * back-fill path fetches even without [force].
+     */
+    suspend fun refreshDetail(id: String, force: Boolean = false): FictionResult<Unit>
 
     /**
      * Re-fetch the user's source-side follows list and reconcile against the
@@ -291,14 +304,29 @@ class FictionRepositoryImpl @Inject constructor(
         result: FictionResult<ListPage<FictionSummary>>,
     ): FictionResult<ListPage<FictionSummary>> = cacheListing(result)
 
-    override suspend fun refreshDetail(id: String): FictionResult<Unit> = withContext(Dispatchers.IO) {
+    override suspend fun refreshDetail(id: String, force: Boolean): FictionResult<Unit> = withContext(Dispatchers.IO) {
         // Look up the persisted row to route to the correct source. When the
         // row is absent — the EPUB/PDF import flows navigate straight to
         // FictionDetail before any row is written (#1298) — derive the source
         // from the fictionId's `<sourceId>:` prefix; bare-id sources (Royal
         // Road) fall back to the legacy default. A successful hydrate below
         // then writes the row, so subsequent loads route off the row.
-        val src = sourceFor(fictionDao.get(id)?.sourceId ?: sourceIdForFictionId(id, sources.keys))
+        val existing = fictionDao.get(id)
+        // Issue #1314 — stale-while-revalidate TTL guard. Skip the network when
+        // the caller didn't force, we have a fully-hydrated row
+        // (metadataFetchedAt > 0 excludes #981 placeholders, which must always
+        // fetch), and that hydrate is younger than the TTL. The value flow is a
+        // Room observer on the same row, so the already-cached data keeps
+        // showing; we just avoid a redundant source round-trip on a rapid
+        // re-open. `now - fetchedAt` is robust to clock skew here — a future
+        // fetchedAt yields a negative age (< TTL) and still skips, which is the
+        // safe direction (don't hammer the source).
+        if (!force && existing != null && existing.metadataFetchedAt > 0L &&
+            System.currentTimeMillis() - existing.metadataFetchedAt < METADATA_TTL_MS
+        ) {
+            return@withContext FictionResult.Success(Unit)
+        }
+        val src = sourceFor(existing?.sourceId ?: sourceIdForFictionId(id, sources.keys))
         when (val result = src.fictionDetail(id)) {
             is FictionResult.Success -> {
                 upsertDetail(result.value)
@@ -533,6 +561,16 @@ class FictionRepositoryImpl @Inject constructor(
         const val CHOOSER_THRESHOLD: Float = 0.5f
         const val DOMINANT_GAP: Float = 0.2f
         const val MAX_FOLLOWS_PAGES: Int = 200
+
+        /**
+         * Issue #1314 — stale-while-revalidate window for [refreshDetail]. A
+         * non-forced refresh of a row hydrated within this window skips the
+         * network. Five minutes covers the "rapid re-open of a just-viewed
+         * fiction" case the guard targets without letting genuinely stale
+         * metadata linger — background workers (poll / back-fill) and the
+         * manual Retry button pass `force = true` to bypass it entirely.
+         */
+        const val METADATA_TTL_MS: Long = 5 * 60 * 1000L
     }
 
     // ─── helpers ──────────────────────────────────────────────────────────

--- a/core-data/src/main/kotlin/in/jphe/storyvox/data/work/MetadataBackfillWorker.kt
+++ b/core-data/src/main/kotlin/in/jphe/storyvox/data/work/MetadataBackfillWorker.kt
@@ -144,7 +144,11 @@ class MetadataBackfillWorker @AssistedInject constructor(
             // refreshDetail routes by the (now-repaired) row sourceId and,
             // on success, upserts real metadata + stamps metadataFetchedAt
             // + clears the failure flag.
-            fictionRepository.refreshDetail(id)
+            // #1314 — force past the TTL guard: back-fill is a deliberate
+            // hydration pass and must fetch. (Placeholders carry
+            // metadataFetchedAt == 0 so the TTL wouldn't skip them anyway;
+            // force is belt-and-suspenders + self-documenting.)
+            fictionRepository.refreshDetail(id, force = true)
         } catch (cancel: CancellationException) {
             throw cancel
         } catch (t: Throwable) {

--- a/core-data/src/main/kotlin/in/jphe/storyvox/data/work/NewChapterPollWorker.kt
+++ b/core-data/src/main/kotlin/in/jphe/storyvox/data/work/NewChapterPollWorker.kt
@@ -111,7 +111,10 @@ class NewChapterPollWorker @AssistedInject constructor(
             // chapters" instead of the one chapter that actually landed.
             val priorChapterIds = chapterDao.chapterIdsForFiction(fiction.id).toSet()
 
-            when (val result = fictionRepository.refreshDetail(fiction.id)) {
+            // #1314 — force past the TTL guard: a scheduled poll must always
+            // re-fetch to detect new chapters, even if the detail page was
+            // opened (and the row hydrated) within the TTL window.
+            when (val result = fictionRepository.refreshDetail(fiction.id, force = true)) {
                 is FictionResult.Success -> {
                     // After a successful refresh, persist whatever new
                     // revision token the source has now. We re-ask

--- a/core-data/src/test/kotlin/in/jphe/storyvox/data/repository/FictionRepositoryImplTest.kt
+++ b/core-data/src/test/kotlin/in/jphe/storyvox/data/repository/FictionRepositoryImplTest.kt
@@ -628,6 +628,77 @@ class FictionRepositoryImplTest {
         assertEquals(3, chapterDao.rows.size)
     }
 
+    // -- #1314 stale-while-revalidate TTL guard ----------------------------------
+
+    @Test fun `refreshDetail skips the source when the cached row is fresh`() = runTest {
+        val src = FakeSource(SourceIds.ROYAL_ROAD).apply {
+            detailResult = FictionResult.Success(detail("99"))
+        }
+        val (r, fictionDao, _) = repo(sources = mapOf(SourceIds.ROYAL_ROAD to src))
+        // A fully-hydrated row fetched "now" is inside the TTL window.
+        fictionDao.rows["99"] = Fiction(
+            id = "99", sourceId = SourceIds.ROYAL_ROAD, title = "Cached", author = "A",
+            firstSeenAt = 0L, metadataFetchedAt = System.currentTimeMillis(),
+        )
+
+        val result = r.refreshDetail("99")
+
+        assertTrue("fresh cache → Success without a fetch", result is FictionResult.Success)
+        assertEquals("source must not be hit for a fresh row", emptyList<String>(), src.callLog)
+    }
+
+    @Test fun `refreshDetail fetches when the cached row is stale`() = runTest {
+        val src = FakeSource(SourceIds.ROYAL_ROAD).apply {
+            detailResult = FictionResult.Success(detail("99"))
+        }
+        val (r, fictionDao, _) = repo(sources = mapOf(SourceIds.ROYAL_ROAD to src))
+        // Hydrated an hour ago — well past the 5-minute TTL.
+        fictionDao.rows["99"] = Fiction(
+            id = "99", sourceId = SourceIds.ROYAL_ROAD, title = "Old", author = "A",
+            firstSeenAt = 0L, metadataFetchedAt = System.currentTimeMillis() - 60 * 60 * 1000L,
+        )
+
+        r.refreshDetail("99")
+
+        assertEquals(listOf("fictionDetail(99)"), src.callLog)
+    }
+
+    @Test fun `refreshDetail force bypasses the TTL even for a fresh row`() = runTest {
+        val src = FakeSource(SourceIds.ROYAL_ROAD).apply {
+            detailResult = FictionResult.Success(detail("99"))
+        }
+        val (r, fictionDao, _) = repo(sources = mapOf(SourceIds.ROYAL_ROAD to src))
+        fictionDao.rows["99"] = Fiction(
+            id = "99", sourceId = SourceIds.ROYAL_ROAD, title = "Cached", author = "A",
+            firstSeenAt = 0L, metadataFetchedAt = System.currentTimeMillis(),
+        )
+
+        r.refreshDetail("99", force = true)
+
+        assertEquals("force must hit the source despite a fresh row", listOf("fictionDetail(99)"), src.callLog)
+    }
+
+    @Test fun `refreshDetail failure leaves the cached row intact (offline path)`() = runTest {
+        // The offline guarantee: a failed background refresh never wipes the
+        // cache, so observeFiction keeps emitting the cached row and the UI
+        // shows it (with the #1314 offline banner) instead of going blank.
+        val src = FakeSource(SourceIds.ROYAL_ROAD).apply {
+            detailResult = FictionResult.NetworkError("offline")
+        }
+        val (r, fictionDao, _) = repo(sources = mapOf(SourceIds.ROYAL_ROAD to src))
+        val cached = Fiction(
+            id = "99", sourceId = SourceIds.ROYAL_ROAD, title = "Cached title", author = "Author",
+            firstSeenAt = 0L, metadataFetchedAt = System.currentTimeMillis() - 60 * 60 * 1000L,
+            inLibrary = true,
+        )
+        fictionDao.rows["99"] = cached
+
+        val result = r.refreshDetail("99")
+
+        assertTrue("network failure surfaces to the caller", result is FictionResult.Failure)
+        assertEquals("cached row must survive a failed refresh", cached, fictionDao.rows["99"])
+    }
+
     @Test fun `refreshDetail success clears a stale backfill failure stamp`() = runTest {
         // #981 — a placeholder row whose previous back-fill failed carries
         // a metadataBackfillFailedAt stamp. A later successful hydrate must

--- a/feature/src/main/kotlin/in/jphe/storyvox/feature/fiction/FictionDetailScreen.kt
+++ b/feature/src/main/kotlin/in/jphe/storyvox/feature/fiction/FictionDetailScreen.kt
@@ -77,6 +77,7 @@ import `in`.jphe.storyvox.feature.R
 import `in`.jphe.storyvox.feature.api.UiChapter
 import `in`.jphe.storyvox.feature.api.UiFiction
 import `in`.jphe.storyvox.feature.api.UiRecapPlaybackState
+import `in`.jphe.storyvox.feature.components.OfflineBanner
 import `in`.jphe.storyvox.source.epub.writer.EpubExportResult
 import `in`.jphe.storyvox.ui.a11y.LocalAccessibleTouchTargets
 import `in`.jphe.storyvox.ui.a11y.accessibleSize
@@ -462,7 +463,13 @@ fun FictionDetailScreen(
                         .fillMaxSize()
                         .verticalScroll(rememberScrollState()),
                 ) {
-                    if (state.error != null) {
+                    // #1314 — offline-first: when offline with cached data,
+                    // show the friendly "showing cached content" banner instead
+                    // of the raw refresh error (the error is just the offline
+                    // network failure; the offline banner explains it better).
+                    if (state.isOffline) {
+                        OfflineBanner()
+                    } else if (state.error != null) {
                         ErrorBlock(
                             title = "Couldn't refresh",
                             message = friendlyErrorMessage(state.error),
@@ -605,7 +612,7 @@ fun FictionDetailScreen(
             // Notebook, [search?]. Notebook is rendered as a LazyColumn
             // item even when empty (it early-returns inside, but the item
             // slot is still consumed).
-            val narrowHeaderCount = (if (state.error != null) 1 else 0) +
+            val narrowHeaderCount = (if (state.isOffline || state.error != null) 1 else 0) +
                 1 + // Hero
                 1 + // ActionRow
                 1 + // Synopsis
@@ -616,7 +623,10 @@ fun FictionDetailScreen(
                 modifier = Modifier.fillMaxSize(),
                 contentPadding = PaddingValues(bottom = spacing.md),
             ) {
-                if (state.error != null) {
+                // #1314 — offline-first banner (see wide-layout note above).
+                if (state.isOffline) {
+                    item { OfflineBanner() }
+                } else if (state.error != null) {
                     item {
                         ErrorBlock(
                             title = "Couldn't refresh",

--- a/feature/src/main/kotlin/in/jphe/storyvox/feature/fiction/FictionDetailViewModel.kt
+++ b/feature/src/main/kotlin/in/jphe/storyvox/feature/fiction/FictionDetailViewModel.kt
@@ -11,6 +11,7 @@ import `in`.jphe.storyvox.data.annotation.AnnotationExportResult
 import `in`.jphe.storyvox.data.annotation.ExportAnnotationsUseCase
 import `in`.jphe.storyvox.data.db.entity.Annotation
 import `in`.jphe.storyvox.data.db.entity.FictionMemoryEntry
+import `in`.jphe.storyvox.data.network.ConnectivityObserver
 import `in`.jphe.storyvox.data.repository.AnnotationRepository
 import `in`.jphe.storyvox.data.repository.FictionMemoryRepository
 import `in`.jphe.storyvox.data.repository.pronunciation.PronunciationDictRepository
@@ -84,6 +85,13 @@ data class FictionDetailUiState(
      *  this fiction has no high-confidence counterpart. Drives the
      *  "listen/read along" row. */
     val companion: CompanionMatch? = null,
+    /** Issue #1314 — true when the device is offline AND we have a cached
+     *  [fiction] to show. Drives the subtle "Offline — showing cached data"
+     *  banner so the user knows the metadata may be stale and a background
+     *  refresh is pending. False when online, or when there's no cache yet
+     *  (that's the genuine loading/error state, surfaced via [isLoading] /
+     *  [error] instead). */
+    val isOffline: Boolean = false,
 )
 
 /**
@@ -178,6 +186,9 @@ class FictionDetailViewModel @Inject constructor(
     private val exportAnnotations: ExportAnnotationsUseCase,
     /** Issue #1208 — cross-source audio↔text companion matcher (LibriVox↔Gutenberg). */
     private val companionResolver: CompanionResolver,
+    /** Issue #1314 — live network reachability. Folded into [uiState] so the
+     *  screen can flag "showing cached data" while offline. */
+    private val connectivity: ConnectivityObserver,
     savedState: SavedStateHandle,
 ) : ViewModel() {
 
@@ -370,6 +381,13 @@ class FictionDetailViewModel @Inject constructor(
         }
             // Issue #1208 — fold in the lazily-resolved audio↔text companion.
             .combine(companion) { state, companionMatch -> state.copy(companion = companionMatch) }
+            // Issue #1314 — fold in live connectivity. Offline + a cached row
+            // present ⇒ flag "showing cached data". Offline with no cache is the
+            // real empty/error state (isLoading/error already cover it), so we
+            // gate on state.fiction != null to avoid a misleading banner there.
+            .combine(connectivity.state) { state, conn ->
+                state.copy(isOffline = !conn.isOnline && state.fiction != null)
+            }
             .stateIn(viewModelScope, SharingStarted.WhileSubscribed(5_000), FictionDetailUiState())
     }
 


### PR DESCRIPTION
## Offline-first polish for fiction metadata (#1314)

**Context:** #1314 originally asked for an offline-first Room cache for fiction metadata. On investigation, the canonical cache already exists — the `Fiction`/`Chapter` Room entities, `observeFiction()` (a Room `Flow<FictionDetail?>`), and the `fictionById` stale-while-revalidate flow (cache-first + background `refreshDetail`, which preserves the cached row on network failure). A new `FictionMetadataCache` entity would have duplicated and forked that infra away from sync + the #981 back-fill worker.

Per the redirect (option C), this PR adds the two incremental improvements that deliver real value on the existing infra — **no new entity**:

### 1. TTL guard on `refreshDetail`
Skip the source fetch when the cached row was hydrated within `METADATA_TTL_MS` (5 min) and the caller didn't force — saves a redundant round-trip on rapid re-opens of a just-viewed fiction. A new `force: Boolean = false` param lets deliberate refreshes bypass the TTL:
- manual **Retry** button (`retryDetail`) → `force = true`
- **new-chapter poll worker** → `force = true` (a scheduled poll must always re-fetch)
- **#981 back-fill worker** → `force = true` (placeholders carry `metadataFetchedAt == 0` so they're always stale anyway; force is explicit)

The auto first-subscription refresh in `fictionById` stays `force = false`, so it's the one path the TTL optimizes.

### 2. "Offline — showing cached content" banner on FictionDetail
`FictionDetailViewModel` now injects `ConnectivityObserver` (the existing #786 seam) and derives `isOffline` = offline **and** a cached `fiction` is present. The screen renders the existing `OfflineBanner` in both layouts **in place of** the raw "Couldn't refresh" error block when offline — the error is just the offline network failure, and the banner explains it more clearly. Reuses the existing `offline_banner_message` ("You're offline — showing cached content"), already a polite a11y live region.

### Tests
`FictionRepositoryImplTest`:
- `refreshDetail skips the source when the cached row is fresh`
- `refreshDetail fetches when the cached row is stale`
- `refreshDetail force bypasses the TTL even for a fresh row`
- `refreshDetail failure leaves the cached row intact (offline path)` — the data-layer offline guarantee

All pre-existing `refreshDetail` tests stay green (they seed `metadataFetchedAt = 0L` or no row → always fetch, TTL-safe).

8 files, no new entities, no migration. Built on `feat/offline-cache` off `main`.

Closes #1314

🤖 Generated with [Claude Code](https://claude.com/claude-code)
