### PR TITLE
feat(wear): teleprompter remote protocol + UI (#1308 PR 2)

### DIFF
--- a/core-playback/src/main/kotlin/in/jphe/storyvox/playback/wear/PhoneWearBridge.kt
+++ b/core-playback/src/main/kotlin/in/jphe/storyvox/playback/wear/PhoneWearBridge.kt
@@ -103,5 +103,21 @@ class PhoneWearBridge @Inject constructor(
          * [SeekPayload] (absolute target position in ms).
          */
         const val CMD_SEEK = "/playback/cmd/seek"
+
+        /**
+         * Issue #1308 — teleprompter remote (wrist) commands. Toggle and
+         * play/pause are payload-less (the watch knows current state from the
+         * synced teleprompter state); [CMD_TELEPROMPTER_WPM] carries a 4-byte
+         * [TeleprompterWpmPayload] (absolute WPM).
+         *
+         * The `onMessageReceived` dispatch routing these to PR-1's
+         * `TeleprompterController` (`setEnabled` / `setPlaying` / `setWpm`)
+         * lands at integration once #1320 merges; these constants ship now so
+         * the watch send-side ([in.jphe.storyvox.wear.playback.WearPlaybackBridge])
+         * speaks the final protocol.
+         */
+        const val CMD_TELEPROMPTER_TOGGLE = "/playback/cmd/teleprompterToggle"
+        const val CMD_TELEPROMPTER_PLAY_PAUSE = "/playback/cmd/teleprompterPlayPause"
+        const val CMD_TELEPROMPTER_WPM = "/playback/cmd/teleprompterWpm"
     }
 }

--- a/core-playback/src/main/kotlin/in/jphe/storyvox/playback/wear/TeleprompterWpmPayload.kt
+++ b/core-playback/src/main/kotlin/in/jphe/storyvox/playback/wear/TeleprompterWpmPayload.kt
@@ -1,0 +1,60 @@
+package `in`.jphe.storyvox.playback.wear
+
+import java.nio.ByteBuffer
+
+/**
+ * Issue #1308 — wire format for the wear↔phone `CMD_TELEPROMPTER_WPM` message
+ * (voice-paced/manual teleprompter remote from the wrist).
+ *
+ * Mirrors [SeekPayload]: a shared, single-source encode/decode so the watch
+ * ([in.jphe.storyvox.wear.playback.WearPlaybackBridge], encode) and phone
+ * ([PhoneWearBridge], decode) can never drift. The payload is an **absolute
+ * words-per-minute** value — the watch owns the current WPM (synced from the
+ * phone's `TeleprompterController.wpm`) and sends the new absolute, the same
+ * way [SeekPayload] sends an absolute position rather than a delta.
+ *
+ * Encoding is a fixed 4-byte big-endian Int. The fixed width doubles as a
+ * validation check: anything that isn't exactly 4 bytes (including the `null`
+ * MessageClient delivers for payload-less CMD_* messages) decodes to `null`,
+ * which the phone bridge ignores rather than crashes on.
+ *
+ * [clamp]/[step] are watch-side helpers (the `wpm ±` stepper + rotary input
+ * compute the next value through them); [encode]/[decode] transport the value
+ * faithfully and leave range-enforcement to the helpers + the controller.
+ */
+object TeleprompterWpmPayload {
+
+    /** Slowest / fastest WPM the remote will request. The phone's
+     *  `TeleprompterController.setWpm` is the authority; this just keeps the
+     *  wrist UI from sending absurd values. */
+    const val MIN_WPM: Int = 60
+    const val MAX_WPM: Int = 400
+
+    /** Default increment for one `−` / `+` tap or rotary detent. */
+    const val DEFAULT_STEP_WPM: Int = 10
+
+    private const val SIZE_BYTES = 4
+
+    /** Pack [wpm] into a 4-byte big-endian payload. */
+    fun encode(wpm: Int): ByteArray =
+        ByteBuffer.allocate(SIZE_BYTES).putInt(wpm).array()
+
+    /**
+     * Decode a 4-byte big-endian payload back to a WPM, or `null` if the
+     * payload is absent or malformed (wrong length).
+     */
+    fun decode(payload: ByteArray?): Int? {
+        if (payload == null || payload.size != SIZE_BYTES) return null
+        return ByteBuffer.wrap(payload).int
+    }
+
+    /** Clamp a WPM to the [MIN_WPM]..[MAX_WPM] rails. */
+    fun clamp(wpm: Int): Int = wpm.coerceIn(MIN_WPM, MAX_WPM)
+
+    /**
+     * Next WPM after nudging [current] by [deltaSteps] detents (negative =
+     * slower), clamped to the rails. The watch sends the result via [encode].
+     */
+    fun step(current: Int, deltaSteps: Int, stepWpm: Int = DEFAULT_STEP_WPM): Int =
+        clamp(current + deltaSteps * stepWpm)
+}

--- a/core-playback/src/test/kotlin/in/jphe/storyvox/playback/wear/TeleprompterWpmPayloadTest.kt
+++ b/core-playback/src/test/kotlin/in/jphe/storyvox/playback/wear/TeleprompterWpmPayloadTest.kt
@@ -1,0 +1,51 @@
+package `in`.jphe.storyvox.playback.wear
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Test
+
+/**
+ * Issue #1308 — shared wire format for the teleprompter-WPM remote command,
+ * so the watch (encode) and phone (decode) sides can't drift. Mirrors
+ * [SeekPayloadTest]; WPM is an absolute 4-byte big-endian Int.
+ */
+class TeleprompterWpmPayloadTest {
+
+    @Test fun `round-trips a wpm`() {
+        assertEquals(140, TeleprompterWpmPayload.decode(TeleprompterWpmPayload.encode(140)))
+    }
+
+    @Test fun `encodes to exactly 4 bytes (big-endian Int)`() {
+        assertEquals(4, TeleprompterWpmPayload.encode(140).size)
+    }
+
+    @Test fun `the wire transports the value faithfully, without clamping`() {
+        // encode/decode are pure transport; range-enforcement is clamp()/the
+        // controller's job, not the wire's — mirrors SeekPayload.
+        assertEquals(1000, TeleprompterWpmPayload.decode(TeleprompterWpmPayload.encode(1000)))
+    }
+
+    @Test fun `decode returns null for a null payload`() {
+        assertNull(TeleprompterWpmPayload.decode(null))
+    }
+
+    @Test fun `decode returns null for a wrong-length payload`() {
+        assertNull(TeleprompterWpmPayload.decode(byteArrayOf(1, 2, 3)))
+        assertNull(TeleprompterWpmPayload.decode(ByteArray(0)))
+        assertNull(TeleprompterWpmPayload.decode(ByteArray(8))) // an 8-byte SeekPayload must not decode here
+    }
+
+    @Test fun `clamp pins to the rails`() {
+        assertEquals(TeleprompterWpmPayload.MIN_WPM, TeleprompterWpmPayload.clamp(10))
+        assertEquals(TeleprompterWpmPayload.MAX_WPM, TeleprompterWpmPayload.clamp(9_999))
+        assertEquals(150, TeleprompterWpmPayload.clamp(150))
+    }
+
+    @Test fun `step nudges by detents and clamps at the rails`() {
+        assertEquals(150, TeleprompterWpmPayload.step(140, 1))   // +1 detent × 10
+        assertEquals(130, TeleprompterWpmPayload.step(140, -1))  // −1 detent
+        assertEquals(160, TeleprompterWpmPayload.step(140, 1, stepWpm = 20))
+        assertEquals(TeleprompterWpmPayload.MIN_WPM, TeleprompterWpmPayload.step(TeleprompterWpmPayload.MIN_WPM, -5))
+        assertEquals(TeleprompterWpmPayload.MAX_WPM, TeleprompterWpmPayload.step(TeleprompterWpmPayload.MAX_WPM, 5))
+    }
+}

--- a/wear/src/main/kotlin/in/jphe/storyvox/wear/playback/WearPlaybackBridge.kt
+++ b/wear/src/main/kotlin/in/jphe/storyvox/wear/playback/WearPlaybackBridge.kt
@@ -10,6 +10,7 @@ import com.google.android.gms.wearable.Wearable
 import `in`.jphe.storyvox.playback.PlaybackState
 import `in`.jphe.storyvox.playback.wear.PhoneWearBridge
 import `in`.jphe.storyvox.playback.wear.SeekPayload
+import `in`.jphe.storyvox.playback.wear.TeleprompterWpmPayload
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.SupervisorJob
@@ -119,6 +120,24 @@ class WearPlaybackBridge(private val context: Context) : DataClient.OnDataChange
         val positionMs = SeekPayload.fromFraction(fraction, durationMs)
         return dispatch(PhoneWearBridge.CMD_SEEK, SeekPayload.encode(positionMs))
     }
+
+    /**
+     * Issue #1308 — teleprompter remote. Three wrist controls mirroring the
+     * phone's `TeleprompterController`: enable/disable the mode, run/pause the
+     * scroll, and set an absolute WPM (the watch computes the new value via
+     * [TeleprompterWpmPayload.step] from the synced current, then sends it —
+     * same absolute-value contract as [sendSeek]). All share [dispatch], so a
+     * tap while disconnected flips [connected] and surfaces the same
+     * "Phone not connected" hint as the transport controls.
+     */
+    suspend fun toggleTeleprompter(): SendResult =
+        send(PhoneWearBridge.CMD_TELEPROMPTER_TOGGLE)
+
+    suspend fun toggleTeleprompterScroll(): SendResult =
+        send(PhoneWearBridge.CMD_TELEPROMPTER_PLAY_PAUSE)
+
+    suspend fun sendTeleprompterWpm(wpm: Int): SendResult =
+        dispatch(PhoneWearBridge.CMD_TELEPROMPTER_WPM, TeleprompterWpmPayload.encode(wpm))
 
     /**
      * Single send path shared by every command. A successful send is the

--- a/wear/src/main/kotlin/in/jphe/storyvox/wear/screens/TeleprompterRemoteScreen.kt
+++ b/wear/src/main/kotlin/in/jphe/storyvox/wear/screens/TeleprompterRemoteScreen.kt
@@ -1,0 +1,182 @@
+package `in`.jphe.storyvox.wear.screens
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Add
+import androidx.compose.material.icons.filled.Pause
+import androidx.compose.material.icons.filled.PlayArrow
+import androidx.compose.material.icons.filled.Remove
+import androidx.compose.material.icons.filled.Visibility
+import androidx.compose.material.icons.filled.VisibilityOff
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.unit.dp
+import androidx.wear.compose.material.Button
+import androidx.wear.compose.material.ButtonDefaults
+import androidx.wear.compose.material.Icon
+import androidx.wear.compose.material.MaterialTheme
+import androidx.wear.compose.material.Text
+import `in`.jphe.storyvox.wear.theme.BrassMuted
+import `in`.jphe.storyvox.wear.theme.BrassPrimary
+import `in`.jphe.storyvox.wear.theme.WarmDarkSurface
+
+/**
+ * Issue #1308 — wrist teleprompter remote. Snapshot of the teleprompter state
+ * the watch shows + drives.
+ *
+ * @property enabled teleprompter mode on/off (phone `TeleprompterController.enabled`).
+ * @property playing scroll running vs paused (`TeleprompterController.playing`).
+ * @property wpm current words-per-minute (`TeleprompterController.wpm`).
+ * @property connected a phone node is reachable; when false, all controls grey
+ *   out (mirrors the transport controls' disconnected handling).
+ */
+data class TeleprompterRemoteUiState(
+    val enabled: Boolean = false,
+    val playing: Boolean = false,
+    val wpm: Int = 0,
+    val connected: Boolean = true,
+)
+
+/**
+ * Issue #1308 — dedicated Wear teleprompter-remote surface (reached from
+ * [NowPlayingScreen]). Stateless: the caller supplies the synced state and the
+ * send callbacks (wired to [in.jphe.storyvox.wear.playback.WearPlaybackBridge]),
+ * so this composable is pure presentation and the integration wiring stays out
+ * of it.
+ *
+ * Controls: an **enable** toggle, **play/pause** of the scroll, and a
+ * **`− wpm +`** stepper. Play/pause + the stepper are only active once the mode
+ * is enabled; everything greys out when the phone is unreachable. Brass-on-warm-dark
+ * per the Wear Library Nocturne theme, mirroring [TransportRow]'s button idiom.
+ */
+@Composable
+fun TeleprompterRemoteScreen(
+    state: TeleprompterRemoteUiState,
+    onToggleEnabled: () -> Unit,
+    onTogglePlay: () -> Unit,
+    onWpmDelta: (Int) -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    val transportEnabled = state.connected && state.enabled
+    Column(
+        modifier = modifier
+            .fillMaxSize()
+            .padding(horizontal = 12.dp),
+        verticalArrangement = Arrangement.Center,
+        horizontalAlignment = Alignment.CenterHorizontally,
+    ) {
+        Text(
+            text = "Teleprompter",
+            color = BrassPrimary,
+            textAlign = TextAlign.Center,
+            style = MaterialTheme.typography.title3,
+        )
+        Spacer(Modifier.height(8.dp))
+
+        // Enable / disable the mode — always tappable while connected.
+        RoundIconButton(
+            icon = if (state.enabled) Icons.Filled.Visibility else Icons.Filled.VisibilityOff,
+            contentDescription = if (state.enabled) "Teleprompter on, tap to turn off" else "Teleprompter off, tap to turn on",
+            onClick = onToggleEnabled,
+            isPrimary = state.enabled,
+            enabled = state.connected,
+        )
+        Spacer(Modifier.height(10.dp))
+
+        // WPM stepper: − [ value ] +
+        Row(
+            modifier = Modifier.fillMaxWidth(),
+            horizontalArrangement = Arrangement.SpaceEvenly,
+            verticalAlignment = Alignment.CenterVertically,
+        ) {
+            RoundIconButton(
+                icon = Icons.Filled.Remove,
+                contentDescription = "Slower",
+                onClick = { onWpmDelta(-1) },
+                isPrimary = false,
+                enabled = transportEnabled,
+            )
+            Text(
+                text = "${state.wpm}",
+                color = if (transportEnabled) BrassPrimary else BrassMuted,
+                textAlign = TextAlign.Center,
+                style = MaterialTheme.typography.title2,
+                modifier = Modifier.width(56.dp),
+            )
+            RoundIconButton(
+                icon = Icons.Filled.Add,
+                contentDescription = "Faster",
+                onClick = { onWpmDelta(1) },
+                isPrimary = false,
+                enabled = transportEnabled,
+            )
+        }
+        Text(
+            text = "wpm",
+            color = BrassMuted,
+            textAlign = TextAlign.Center,
+            style = MaterialTheme.typography.caption2,
+        )
+        Spacer(Modifier.height(10.dp))
+
+        // Run / pause the scroll.
+        RoundIconButton(
+            icon = if (state.playing) Icons.Filled.Pause else Icons.Filled.PlayArrow,
+            contentDescription = if (state.playing) "Pause scroll" else "Start scroll",
+            onClick = onTogglePlay,
+            isPrimary = true,
+            enabled = transportEnabled,
+        )
+    }
+}
+
+/**
+ * Brass round icon button — mirrors `TransportRow`'s private button so the
+ * teleprompter controls match the transport vocabulary (primary = full brass
+ * fill, secondary = muted tint, disabled greys via Wear's [Button]).
+ */
+@Composable
+private fun RoundIconButton(
+    icon: ImageVector,
+    contentDescription: String,
+    onClick: () -> Unit,
+    isPrimary: Boolean,
+    enabled: Boolean,
+) {
+    val size = if (isPrimary) 44.dp else 36.dp
+    val iconSize = if (isPrimary) 24.dp else 20.dp
+    Button(
+        onClick = onClick,
+        enabled = enabled,
+        modifier = Modifier.size(size),
+        colors = if (isPrimary) {
+            ButtonDefaults.primaryButtonColors(
+                backgroundColor = BrassPrimary,
+                contentColor = WarmDarkSurface,
+            )
+        } else {
+            ButtonDefaults.secondaryButtonColors(
+                backgroundColor = BrassMuted,
+                contentColor = BrassPrimary,
+            )
+        },
+    ) {
+        Icon(
+            imageVector = icon,
+            contentDescription = contentDescription,
+            modifier = Modifier.size(iconSize),
+        )
+    }
+}


### PR DESCRIPTION
PR 2 of #1308 (Wear teleprompter remote). The **Wear-side protocol + UI** — everything that doesn't depend on Selene's PR 1 state hoist (#1320). **Lands after #1320 merges**, when the small phone-side integration goes in.

### What this lands (compile-safe, no #1320 dependency)
- **`TeleprompterWpmPayload`** — shared 4-byte big-endian Int wire format for the WPM command (absolute value, mirrors `SeekPayload`). `clamp()`/`step()` helpers for the wrist stepper + rotary; `encode`/`decode` transport faithfully.
- **`PhoneWearBridge`** — 3 command path constants: `CMD_TELEPROMPTER_TOGGLE`, `CMD_TELEPROMPTER_PLAY_PAUSE` (payload-less), `CMD_TELEPROMPTER_WPM` (Int payload).
- **`WearPlaybackBridge`** — watch send methods `toggleTeleprompter()` / `toggleTeleprompterScroll()` / `sendTeleprompterWpm()`, sharing the existing `dispatch` (a disconnected send flips `connected`, same UX as transport).
- **`TeleprompterRemoteScreen`** — stateless Wear surface: enable toggle, scroll play/pause, `− wpm +` stepper; greys out when disconnected/disabled. Brass-on-warm-dark, mirroring `TransportRow` (only Wear Compose APIs + icons already used in the module).
- **`TeleprompterWpmPayloadTest`** — round-trip, 4-byte width, null/wrong-length → null, faithful transport, clamp rails, step arithmetic.

### Integration follow-up (after #1320 merges)
Per the agreed PR1 API (`TeleprompterController.setEnabled/setPlaying/setWpm` + `enabled/playing/wpm` StateFlows):
1. `PhoneWearBridge.onMessageReceived` dispatch → `controller.setEnabled(!enabled.value)` / `setPlaying(!playing.value)` / `setWpm(decoded)` (malformed → ignored, same as `CMD_SEEK`).
2. Publish the controller's `enabled`/`playing`/`wpm` to the watch (so the wrist reflects the phone).
3. Wire `TeleprompterRemoteScreen` into `NowPlayingScreen` nav, fed by the synced state.

These are deferred deliberately — they reference `TeleprompterController`, which isn't in `main` until #1320, so wiring them now would be a red build. The seam is ready; integration is a small, well-specified drop-in.

🤖 Generated with [Claude Code](https://claude.com/claude-code)