### PR TITLE
feat(wear): teleprompter remote integration — controller wiring + nav (#1308 PR 2)

### DIFF
--- a/core-playback/src/main/kotlin/in/jphe/storyvox/playback/PlaybackState.kt
+++ b/core-playback/src/main/kotlin/in/jphe/storyvox/playback/PlaybackState.kt
@@ -38,6 +38,13 @@ data class PlaybackState(
      * & Playback pitch slider) read this flag through PlaybackController.
      */
     val isLiveAudioChapter: Boolean = false,
+    /** Issue #1308 — teleprompter state mirrored from `TeleprompterController`
+     *  so the Wear remote can reflect it. Populated by `PhoneWearBridge` at
+     *  publish time; the controller stays the source of truth. Defaults keep
+     *  older watch builds + the non-teleprompter sync path unaffected. */
+    val teleprompterEnabled: Boolean = false,
+    val teleprompterPlaying: Boolean = false,
+    val teleprompterWpm: Int = 0,
 )
 
 @Serializable

--- a/core-playback/src/main/kotlin/in/jphe/storyvox/playback/wear/PhoneWearBridge.kt
+++ b/core-playback/src/main/kotlin/in/jphe/storyvox/playback/wear/PhoneWearBridge.kt
@@ -9,6 +9,7 @@ import dagger.hilt.android.qualifiers.ApplicationContext
 import `in`.jphe.storyvox.playback.PlaybackController
 import `in`.jphe.storyvox.playback.PlaybackState
 import `in`.jphe.storyvox.playback.SleepTimerMode
+import `in`.jphe.storyvox.playback.TeleprompterController
 import javax.inject.Inject
 import javax.inject.Singleton
 import kotlinx.coroutines.CoroutineScope
@@ -16,6 +17,7 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.cancel
 import kotlinx.coroutines.flow.collectLatest
+import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.tasks.await
 import kotlinx.serialization.encodeToString
@@ -36,6 +38,7 @@ import kotlinx.serialization.json.Json
 class PhoneWearBridge @Inject constructor(
     @ApplicationContext private val context: Context,
     private val controller: PlaybackController,
+    private val teleprompterController: TeleprompterController,
 ) : MessageClient.OnMessageReceivedListener {
 
     private val scope = CoroutineScope(SupervisorJob() + Dispatchers.Default)
@@ -46,7 +49,22 @@ class PhoneWearBridge @Inject constructor(
     fun start() {
         messageClient.addListener(this)
         scope.launch {
-            controller.state.collectLatest { state -> publishState(state) }
+            // #1308 — fold the teleprompter state (separate TeleprompterController
+            // singleton, #1320) into the published PlaybackState so the watch
+            // reflects it over the existing /playback/state sync. Any teleprompter
+            // change re-publishes, same as a playback change.
+            combine(
+                controller.state,
+                teleprompterController.enabled,
+                teleprompterController.playing,
+                teleprompterController.wpm,
+            ) { state, tpEnabled, tpPlaying, tpWpm ->
+                state.copy(
+                    teleprompterEnabled = tpEnabled,
+                    teleprompterPlaying = tpPlaying,
+                    teleprompterWpm = tpWpm,
+                )
+            }.collectLatest { state -> publishState(state) }
         }
     }
 
@@ -81,6 +99,15 @@ class PhoneWearBridge @Inject constructor(
                 // (ms) in the message payload. A malformed/absent payload
                 // decodes to null and is ignored (no blind seek-to-zero).
                 CMD_SEEK -> SeekPayload.decode(event.data)?.let { controller.seekToPositionMs(it) }
+                // Issue #1308 — teleprompter remote. Toggle/play-pause flip the
+                // controller's current value; WPM carries an absolute payload
+                // (malformed → ignored, same guard as CMD_SEEK).
+                CMD_TELEPROMPTER_TOGGLE ->
+                    teleprompterController.setEnabled(!teleprompterController.enabled.value)
+                CMD_TELEPROMPTER_PLAY_PAUSE ->
+                    teleprompterController.setPlaying(!teleprompterController.playing.value)
+                CMD_TELEPROMPTER_WPM ->
+                    TeleprompterWpmPayload.decode(event.data)?.let { teleprompterController.setWpm(it) }
             }
         }
     }

--- a/wear/src/main/kotlin/in/jphe/storyvox/wear/WearApp.kt
+++ b/wear/src/main/kotlin/in/jphe/storyvox/wear/WearApp.kt
@@ -2,14 +2,24 @@ package `in`.jphe.storyvox.wear
 
 import android.os.Bundle
 import androidx.activity.ComponentActivity
+import androidx.activity.compose.BackHandler
 import androidx.activity.compose.setContent
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.DisposableEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.platform.LocalContext
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import `in`.jphe.storyvox.playback.wear.TeleprompterWpmPayload
 import `in`.jphe.storyvox.wear.playback.WearPlaybackBridge
 import `in`.jphe.storyvox.wear.screens.NowPlayingScreen
+import `in`.jphe.storyvox.wear.screens.TeleprompterRemoteScreen
+import `in`.jphe.storyvox.wear.screens.TeleprompterRemoteUiState
 import `in`.jphe.storyvox.wear.theme.WearLibraryNocturneTheme
+import kotlinx.coroutines.launch
 
 class WearMainActivity : ComponentActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
@@ -27,6 +37,37 @@ fun WearAppRoot() {
         onDispose { bridge.stop() }
     }
     WearLibraryNocturneTheme {
-        NowPlayingScreen(bridge = bridge)
+        // Issue #1308 — two surfaces: Now Playing (transport) and the
+        // teleprompter remote. A flat toggle (no nav library) keeps it light;
+        // swipe/system back returns from the remote.
+        var showTeleprompter by remember { mutableStateOf(false) }
+        if (showTeleprompter) {
+            val state by bridge.state.collectAsStateWithLifecycle()
+            val connected by bridge.connected.collectAsStateWithLifecycle()
+            val scope = rememberCoroutineScope()
+            BackHandler { showTeleprompter = false }
+            TeleprompterRemoteScreen(
+                state = TeleprompterRemoteUiState(
+                    enabled = state.teleprompterEnabled,
+                    playing = state.teleprompterPlaying,
+                    wpm = state.teleprompterWpm,
+                    connected = connected,
+                ),
+                onToggleEnabled = { scope.launch { bridge.toggleTeleprompter() } },
+                onTogglePlay = { scope.launch { bridge.toggleTeleprompterScroll() } },
+                onWpmDelta = { delta ->
+                    scope.launch {
+                        bridge.sendTeleprompterWpm(
+                            TeleprompterWpmPayload.step(state.teleprompterWpm, delta),
+                        )
+                    }
+                },
+            )
+        } else {
+            NowPlayingScreen(
+                bridge = bridge,
+                onOpenTeleprompter = { showTeleprompter = true },
+            )
+        }
     }
 }

--- a/wear/src/main/kotlin/in/jphe/storyvox/wear/screens/NowPlayingScreen.kt
+++ b/wear/src/main/kotlin/in/jphe/storyvox/wear/screens/NowPlayingScreen.kt
@@ -1,6 +1,7 @@
 package `in`.jphe.storyvox.wear.screens
 
 import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -66,7 +67,10 @@ import kotlinx.coroutines.launch
  * MessageClient. This PR is pure UI polish per the #192 spec.
  */
 @Composable
-fun NowPlayingScreen(bridge: WearPlaybackBridge) {
+fun NowPlayingScreen(
+    bridge: WearPlaybackBridge,
+    onOpenTeleprompter: () -> Unit = {},
+) {
     val state by bridge.state.collectAsStateWithLifecycle()
     val connected by bridge.connected.collectAsStateWithLifecycle()
     val scope = rememberCoroutineScope()
@@ -90,6 +94,7 @@ fun NowPlayingScreen(bridge: WearPlaybackBridge) {
         onSkipForward = { scope.launch { bridge.send(PhoneWearBridge.CMD_SKIP_FWD) } },
         // #1031 — tap the ring to scrub; duration comes from the synced state.
         onScrub = { fraction -> scope.launch { bridge.sendSeek(fraction, state.durationEstimateMs) } },
+        onOpenTeleprompter = onOpenTeleprompter,
     )
 }
 
@@ -105,6 +110,7 @@ internal fun NowPlayingContent(
     onSkipBack: () -> Unit,
     onSkipForward: () -> Unit,
     onScrub: ((fraction: Float) -> Unit)? = null,
+    onOpenTeleprompter: () -> Unit = {},
 ) {
     val configuration = LocalConfiguration.current
     val isRound = configuration.isScreenRound
@@ -138,6 +144,21 @@ internal fun NowPlayingContent(
                     onPlayPause = onPlayPause,
                     onSkipBack = onSkipBack,
                     onSkipForward = onSkipForward,
+                )
+            }
+            // #1308 — entry to the teleprompter remote (a separate surface).
+            // Bottom-edge label so it doesn't crowd the transport controls;
+            // only offered when a phone is reachable.
+            if (connected) {
+                Text(
+                    text = "Teleprompter",
+                    color = BrassPrimary,
+                    textAlign = TextAlign.Center,
+                    style = MaterialTheme.typography.caption2,
+                    modifier = Modifier
+                        .align(Alignment.BottomCenter)
+                        .padding(bottom = 2.dp)
+                        .clickable(onClick = onOpenTeleprompter),
                 )
             }
         }


### PR DESCRIPTION
The **integration half** of #1308 PR 2. #1328 merged the Wear-side protocol + UI (payload, command constants, watch sends, `TeleprompterRemoteScreen`), but the controller-wiring commit landed just after the squash-merge and was stranded on the closed branch — so the remote currently ships as inert scaffolding. This re-applies that wiring onto current main (now that #1320's `TeleprompterController` is merged).

### What this lands (cherry-picked, clean)
- **`PhoneWearBridge`** — inject `TeleprompterController`; dispatch the 3 commands → `setEnabled(!enabled.value)` / `setPlaying(!playing.value)` / `setWpm(decoded)` (malformed WPM ignored, same guard as `CMD_SEEK`); fold the controller's `enabled/playing/wpm` flows into the published `PlaybackState` so the watch reflects + re-publishes teleprompter state over the existing `/playback/state` sync.
- **`PlaybackState`** — `+teleprompterEnabled/Playing/Wpm` (defaults; the controller stays source of truth — these are a publish-time snapshot for the watch).
- **`WearApp`** — NowPlaying ⇄ `TeleprompterRemoteScreen` toggle (swipe/system back via `BackHandler`), feeding the remote from synced state + bridge sends.
- **`NowPlayingScreen`** — a "Teleprompter" entry affordance (shown when connected).

Without this, the Wear-side from #1328 doesn't do anything — this makes the remote functional end-to-end.

**Note:** the on-watch entry-label placement + remote layout are the one part not visually verified (no Wear device locally) — worth a glance on phone-check. Logic/protocol are covered by `TeleprompterWpmPayloadTest` + `WearStateDecodeTest` (round-trips the new `PlaybackState` fields).

🤖 Generated with [Claude Code](https://claude.com/claude-code)