### PR TITLE
fix(fiction): suppress refresh error when cached fiction exists (#1330)

### DIFF
--- a/feature/src/main/kotlin/in/jphe/storyvox/feature/fiction/FictionDetailViewModel.kt
+++ b/feature/src/main/kotlin/in/jphe/storyvox/feature/fiction/FictionDetailViewModel.kt
@@ -319,7 +319,7 @@ class FictionDetailViewModel @Inject constructor(
                 // OR the refresh has failed — otherwise a Cloudflare/network
                 // error leaves the user on a permanent spinner with no signal.
                 isLoading = fiction == null && error == null,
-                error = error,
+                error = error?.takeIf { fiction == null },
                 isExportingEpub = exporting,
             )
         }


### PR DESCRIPTION
## Summary
- Gate `FictionDetailUiState.error` on `fiction == null` so a refresh failure no longer shows a full-screen error overlay when the user has a cached, playable fiction
- This is the stale-while-revalidate pattern: cached data stays visible while a background refresh silently fails

Closes #1330

## Test plan
- [ ] CI Build APK green
- [ ] Open a fiction, let it cache, then go offline — "Read along" should still work without error overlay
- [ ] When no cache exists and fetch fails, error screen still appears correctly

Generated with [Claude Code](https://claude.com/claude-code)