### PR TITLE
test(browse): wire testTag to source chips, result cards, fiction detail (#1333)

### DIFF
--- a/feature/src/main/kotlin/in/jphe/storyvox/feature/browse/BrowseScreen.kt
+++ b/feature/src/main/kotlin/in/jphe/storyvox/feature/browse/BrowseScreen.kt
@@ -584,6 +584,8 @@ fun BrowseScreen(
                         Column(
                             modifier = Modifier
                                 .fillMaxWidth()
+                                // #1333 — per-result id so on-device QA can open a specific fiction.
+                                .testTag(TestTags.browseResultCard(fiction.id))
                                 .animateItem()
                                 .cascadeReveal(index = index, key = fiction.id)
                                 // a11y (#481): Role.Button + label for the fiction-card tap.

--- a/feature/src/main/kotlin/in/jphe/storyvox/feature/browse/BrowseSourceCarousel.kt
+++ b/feature/src/main/kotlin/in/jphe/storyvox/feature/browse/BrowseSourceCarousel.kt
@@ -93,6 +93,7 @@ import androidx.compose.ui.zIndex
 import `in`.jphe.storyvox.data.source.SourceIds
 import `in`.jphe.storyvox.data.source.plugin.SourcePluginDescriptor
 import `in`.jphe.storyvox.feature.R
+import `in`.jphe.storyvox.ui.component.TestTags
 import `in`.jphe.storyvox.ui.theme.LocalSpacing
 import kotlin.math.abs
 import kotlin.math.roundToInt
@@ -323,6 +324,8 @@ private fun BrowseSourceCard(
         modifier = Modifier
             .width(CARD_WIDTH)
             .height(cardHeight)
+            // #1333 — per-source id so on-device QA can tap a specific source.
+            .testTag(TestTags.browseSourceChip(descriptor.id))
             // Drag-and-drop: the dragged card floats above siblings via
             // zIndex and translates horizontally by the accumulated drag
             // offset. Non-dragged cards use animateItem() on the LazyRow

--- a/feature/src/main/kotlin/in/jphe/storyvox/feature/fiction/FictionDetailScreen.kt
+++ b/feature/src/main/kotlin/in/jphe/storyvox/feature/fiction/FictionDetailScreen.kt
@@ -55,18 +55,21 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
+import androidx.compose.ui.ExperimentalComposeUiApi
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.focus.FocusDirection
 import androidx.compose.ui.focus.FocusRequester
 import androidx.compose.ui.focus.focusRequester
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalFocusManager
+import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.semantics.LiveRegionMode
 import androidx.compose.ui.semantics.clearAndSetSemantics
 import androidx.compose.ui.semantics.contentDescription
 import androidx.compose.ui.semantics.liveRegion
 import androidx.compose.ui.semantics.semantics
+import androidx.compose.ui.semantics.testTagsAsResourceId
 import androidx.compose.ui.text.input.ImeAction
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
@@ -85,6 +88,7 @@ import `in`.jphe.storyvox.ui.a11y.LocalAccessibleTouchTargets
 import `in`.jphe.storyvox.ui.a11y.accessibleSize
 import `in`.jphe.storyvox.ui.component.BrassButton
 import `in`.jphe.storyvox.ui.component.BrassButtonVariant
+import `in`.jphe.storyvox.ui.component.TestTags
 import `in`.jphe.storyvox.ui.component.ChapterCard
 import `in`.jphe.storyvox.ui.component.ChapterCardState
 import `in`.jphe.storyvox.ui.component.MagicCircularProgress
@@ -100,7 +104,7 @@ import `in`.jphe.storyvox.ui.layout.isAtLeastTablet
 import `in`.jphe.storyvox.ui.theme.LocalSpacing
 import kotlinx.coroutines.launch
 
-@OptIn(ExperimentalMaterial3Api::class)
+@OptIn(ExperimentalMaterial3Api::class, ExperimentalComposeUiApi::class)
 @Composable
 fun FictionDetailScreen(
     onOpenReader: (String, String) -> Unit,
@@ -312,6 +316,9 @@ fun FictionDetailScreen(
     // copy is intentionally compact so the dual rendering reads as
     // 'context + content' not 'duplicate'.
     Scaffold(
+        // #1333 — surface descendant testTags as uiautomator resource-ids for
+        // on-device QA. Semantics-only; no layout/behavior effect.
+        modifier = Modifier.semantics { testTagsAsResourceId = true },
         topBar = {
             // Issue #117 — overflow menu now houses the EPUB export entry.
             // Held local-to-the-bar so the menu state doesn't survive
@@ -328,7 +335,10 @@ fun FictionDetailScreen(
                     )
                 },
                 navigationIcon = {
-                    IconButton(onClick = onBack) {
+                    IconButton(
+                        onClick = onBack,
+                        modifier = Modifier.testTag(TestTags.FictionDetailBack),
+                    ) {
                         Icon(
                             Icons.AutoMirrored.Filled.ArrowBack,
                             contentDescription = stringResource(R.string.fiction_detail_back),
@@ -381,7 +391,10 @@ fun FictionDetailScreen(
                                 Text(stringResource(R.string.fiction_building_epub), style = MaterialTheme.typography.labelSmall)
                             }
                         } else {
-                            IconButton(onClick = { menuOpen = true }) {
+                            IconButton(
+                                onClick = { menuOpen = true },
+                                modifier = Modifier.testTag(TestTags.FictionDetailMenu),
+                            ) {
                                 Icon(Icons.Filled.MoreVert, contentDescription = stringResource(R.string.fiction_detail_more))
                             }
                             DropdownMenu(


### PR DESCRIPTION
## Summary
Follow-up to #1335 (which defined `TestTags` constants and enabled `testTagsAsResourceId` on BrowseScreen). This PR wires the actual `Modifier.testTag()` calls to composables:

- **BrowseScreen** — `browseResultCard(fiction.id)` on each search result column
- **BrowseSourceCarousel** — `browseSourceChip(descriptor.id)` on each source card
- **FictionDetailScreen** — `testTagsAsResourceId = true` on the Scaffold root, plus `FictionDetailBack` and `FictionDetailMenu` on the nav icon buttons

These tags make browse → fiction-detail flows visible to uiautomator on-device QA (Waydroid or physical).

Closes #1333

## Test plan
- [ ] Build APK (CI)
- [ ] uiautomator `resource-id` visible for browse chips and result cards on Waydroid

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved support for on-device UI automation across browse and fiction detail screens.
  * Individual browse results and source cards can now be uniquely identified for testing.
  * Updated the fiction detail screen so key controls like back and overflow actions are easier to target in automated checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->