### PR TITLE
test(browse): apply #1333 testTags to source chips, result cards, detail nav

### DIFF
--- a/feature/src/main/kotlin/in/jphe/storyvox/feature/browse/BrowseScreen.kt
+++ b/feature/src/main/kotlin/in/jphe/storyvox/feature/browse/BrowseScreen.kt
@@ -584,6 +584,8 @@ fun BrowseScreen(
                         Column(
                             modifier = Modifier
                                 .fillMaxWidth()
+                                // #1333 — per-result id so on-device QA can open a specific fiction.
+                                .testTag(TestTags.browseResultCard(fiction.id))
                                 .animateItem()
                                 .cascadeReveal(index = index, key = fiction.id)
                                 // a11y (#481): Role.Button + label for the fiction-card tap.

--- a/feature/src/main/kotlin/in/jphe/storyvox/feature/browse/BrowseSourceCarousel.kt
+++ b/feature/src/main/kotlin/in/jphe/storyvox/feature/browse/BrowseSourceCarousel.kt
@@ -93,6 +93,7 @@ import androidx.compose.ui.zIndex
 import `in`.jphe.storyvox.data.source.SourceIds
 import `in`.jphe.storyvox.data.source.plugin.SourcePluginDescriptor
 import `in`.jphe.storyvox.feature.R
+import `in`.jphe.storyvox.ui.component.TestTags
 import `in`.jphe.storyvox.ui.theme.LocalSpacing
 import kotlin.math.abs
 import kotlin.math.roundToInt
@@ -323,6 +324,8 @@ private fun BrowseSourceCard(
         modifier = Modifier
             .width(CARD_WIDTH)
             .height(cardHeight)
+            // #1333 — per-source id so on-device QA can tap a specific source.
+            .testTag(TestTags.browseSourceChip(descriptor.id))
             // Drag-and-drop: the dragged card floats above siblings via
             // zIndex and translates horizontally by the accumulated drag
             // offset. Non-dragged cards use animateItem() on the LazyRow

--- a/feature/src/main/kotlin/in/jphe/storyvox/feature/fiction/FictionDetailScreen.kt
+++ b/feature/src/main/kotlin/in/jphe/storyvox/feature/fiction/FictionDetailScreen.kt
@@ -55,18 +55,21 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
+import androidx.compose.ui.ExperimentalComposeUiApi
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.focus.FocusDirection
 import androidx.compose.ui.focus.FocusRequester
 import androidx.compose.ui.focus.focusRequester
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalFocusManager
+import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.semantics.LiveRegionMode
 import androidx.compose.ui.semantics.clearAndSetSemantics
 import androidx.compose.ui.semantics.contentDescription
 import androidx.compose.ui.semantics.liveRegion
 import androidx.compose.ui.semantics.semantics
+import androidx.compose.ui.semantics.testTagsAsResourceId
 import androidx.compose.ui.text.input.ImeAction
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
@@ -85,6 +88,7 @@ import `in`.jphe.storyvox.ui.a11y.LocalAccessibleTouchTargets
 import `in`.jphe.storyvox.ui.a11y.accessibleSize
 import `in`.jphe.storyvox.ui.component.BrassButton
 import `in`.jphe.storyvox.ui.component.BrassButtonVariant
+import `in`.jphe.storyvox.ui.component.TestTags
 import `in`.jphe.storyvox.ui.component.ChapterCard
 import `in`.jphe.storyvox.ui.component.ChapterCardState
 import `in`.jphe.storyvox.ui.component.MagicCircularProgress
@@ -100,7 +104,7 @@ import `in`.jphe.storyvox.ui.layout.isAtLeastTablet
 import `in`.jphe.storyvox.ui.theme.LocalSpacing
 import kotlinx.coroutines.launch
 
-@OptIn(ExperimentalMaterial3Api::class)
+@OptIn(ExperimentalMaterial3Api::class, ExperimentalComposeUiApi::class)
 @Composable
 fun FictionDetailScreen(
     onOpenReader: (String, String) -> Unit,
@@ -312,6 +316,9 @@ fun FictionDetailScreen(
     // copy is intentionally compact so the dual rendering reads as
     // 'context + content' not 'duplicate'.
     Scaffold(
+        // #1333 — surface descendant testTags as uiautomator resource-ids for
+        // on-device QA. Semantics-only; no layout/behavior effect.
+        modifier = Modifier.semantics { testTagsAsResourceId = true },
         topBar = {
             // Issue #117 — overflow menu now houses the EPUB export entry.
             // Held local-to-the-bar so the menu state doesn't survive
@@ -328,7 +335,10 @@ fun FictionDetailScreen(
                     )
                 },
                 navigationIcon = {
-                    IconButton(onClick = onBack) {
+                    IconButton(
+                        onClick = onBack,
+                        modifier = Modifier.testTag(TestTags.FictionDetailBack),
+                    ) {
                         Icon(
                             Icons.AutoMirrored.Filled.ArrowBack,
                             contentDescription = stringResource(R.string.fiction_detail_back),
@@ -381,7 +391,10 @@ fun FictionDetailScreen(
                                 Text(stringResource(R.string.fiction_building_epub), style = MaterialTheme.typography.labelSmall)
                             }
                         } else {
-                            IconButton(onClick = { menuOpen = true }) {
+                            IconButton(
+                                onClick = { menuOpen = true },
+                                modifier = Modifier.testTag(TestTags.FictionDetailMenu),
+                            ) {
                                 Icon(Icons.Filled.MoreVert, contentDescription = stringResource(R.string.fiction_detail_more))
                             }
                             DropdownMenu(


### PR DESCRIPTION
## Follow-up to #1335 — wire up the testTags

#1335 added the `TestTags` constants + enabled `testTagsAsResourceId` on the BrowseScreen root, but didn't apply the actual `Modifier.testTag(...)` calls to the elements. This finishes the wiring so on-device uiautomator/adb (and Maestro) can target them by id.

- **`BrowseSourceCarousel`** — `browseSourceChip(descriptor.id)` on each source card, so a flow can select a specific source (`browse-source-<id>`).
- **`BrowseScreen`** — `browseResultCard(fiction.id)` on each grid result, so a flow can open a specific fiction (`browse-result-<id>`).
- **`FictionDetailScreen`** — `Modifier.semantics { testTagsAsResourceId = true }` on the detail Scaffold (the enabler was only on BrowseScreen) + `FictionDetailBack` / `FictionDetailMenu` on the nav buttons.

Semantics-only — no layout/behaviour change. +21 lines, 3 files, all in `:feature` browse/fiction; uses the constants already merged in #1335 (TestTags untouched here).

> [!NOTE]
> Discovered during v1.4.0/v1.4.1 Waydroid browse QA, where `uiautomator dump` returned 0 nodes (#1333). Caveat: that dump was on v1.4.1, which predates #1335's enabler — so on-device verification that these tags actually surface needs a build cycle (the empty dump may also have an environment cause). Correct + useful regardless: it's the addressing layer Maestro/instrumented tests already rely on. Hero primary actions (add-to-library / resume) constants exist; applying them is a trivial fast-follow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
