### PR TITLE
fix(playback): use chapter's FK-bound fiction ID in PlaybackState (#1336)

### DIFF
--- a/core-playback/src/main/kotlin/in/jphe/storyvox/playback/tts/EnginePlayer.kt
+++ b/core-playback/src/main/kotlin/in/jphe/storyvox/playback/tts/EnginePlayer.kt
@@ -351,6 +351,33 @@ internal fun isSilentNaturalEnd(naturalEnd: Boolean, chunksEmitted: Int): Boolea
     naturalEnd && chunksEmitted == 0
 
 /**
+ * Issue #1330 — the fiction id the player should expose in [PlaybackState]
+ * while a [chapter] is loaded. The chapter's [PlaybackChapter.fictionId] is
+ * FK-bound to a real `fiction` row, so it's the source of truth even when the
+ * caller's [requestedFictionId] is non-canonical — e.g. a Royal Road URL slug
+ * ("archmage-coefficient") instead of the numeric fiction id ("156215").
+ *
+ * Playback still works with a non-canonical request (the chapter loads by
+ * chapterId), but pre-fix the bad id leaked into `currentFictionId`, so the
+ * reader's "Open chapter list" → FictionDetail lookup
+ * (fictionById/refreshDetail) 404'd ("Fiction <slug> not found") for a book
+ * that played fine — the playback path resolved by chapter while the reader
+ * resolved by fiction id and they disagreed.
+ *
+ * Falls back to [requestedFictionId] only if the chapter somehow carries a
+ * blank id (the column is NOT NULL, so this shouldn't happen) — that keeps the
+ * fix from ever regressing `currentFictionId` to blank. A no-op in the common
+ * case where the caller already passed the canonical id.
+ *
+ * Extracted as a top-level function so the rule is unit-testable
+ * ([EnginePlayerFictionIdTest]) without standing up the full EnginePlayer +
+ * Hilt + sherpa-onnx graph — same constraint as [isSilentNaturalEnd] /
+ * [shouldAutoPlayAfterAdvance].
+ */
+internal fun playingFictionId(requestedFictionId: String, chapter: PlaybackChapter): String =
+    chapter.fictionId.ifBlank { requestedFictionId }
+
+/**
  * Issue #189 — playback state for the one-shot recap-aloud TTS pipeline.
  * Distinct from [PlaybackState] because the recap is a transient utterance
  * with its own AudioTrack; conflating the two would force every chapter
@@ -1968,7 +1995,9 @@ class EnginePlayer @AssistedInject constructor(
         )
         _observableState.update {
             it.copy(
-                currentFictionId = fictionId,
+                // Issue #1330 — expose the chapter's FK-bound parent id, not the
+                // caller's (possibly non-canonical) arg. See [playingFictionId].
+                currentFictionId = playingFictionId(fictionId, chapter),
                 currentChapterId = chapterId,
                 charOffset = charOffset,
                 // Issue #728 — respect a pause that landed during the
@@ -5379,7 +5408,8 @@ class EnginePlayer @AssistedInject constructor(
 
         _observableState.update {
             it.copy(
-                currentFictionId = fictionId,
+                // Issue #1330 — mirror the TTS path: chapter's id wins. See [playingFictionId].
+                currentFictionId = playingFictionId(fictionId, chapter),
                 currentChapterId = chapterId,
                 charOffset = 0,
                 isPlaying = true,

--- a/core-playback/src/test/kotlin/in/jphe/storyvox/playback/tts/EnginePlayerFictionIdTest.kt
+++ b/core-playback/src/test/kotlin/in/jphe/storyvox/playback/tts/EnginePlayerFictionIdTest.kt
@@ -1,0 +1,68 @@
+package `in`.jphe.storyvox.playback.tts
+
+import `in`.jphe.storyvox.data.repository.playback.PlaybackChapter
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+/**
+ * Issue #1330 — regression test for [playingFictionId], the rule that the
+ * fiction id the player exposes while playing comes from the loaded chapter
+ * (FK-bound to a real `fiction` row), not the caller's possibly-non-canonical
+ * request.
+ *
+ * The bug: a book whose playback was started with a Royal Road URL *slug*
+ * ("archmage-coefficient") instead of its numeric id ("156215") played fine —
+ * the chapter loads by chapterId — but leaked the slug into `currentFictionId`,
+ * so the reader's "Open chapter list" → FictionDetail lookup 404'd ("Fiction
+ * archmage-coefficient not found") for a book that was playing. Pinning the
+ * pure rule guards the fix without standing up the full EnginePlayer graph
+ * (same approach as [EnginePlayerSilentChapterTest]).
+ */
+class EnginePlayerFictionIdTest {
+
+    private fun chapter(fictionId: String) = PlaybackChapter(
+        id = "3132975",
+        fictionId = fictionId,
+        text = "Once upon a time…",
+        title = "Chapter 1",
+        bookTitle = "The Archmage Coefficient",
+        coverUrl = null,
+    )
+
+    @Test
+    fun `chapter id wins over a non-canonical requested id — the #1330 case`() {
+        // Started with the URL slug; the chapter's FK-bound numeric id is real.
+        assertEquals(
+            "156215",
+            playingFictionId(requestedFictionId = "archmage-coefficient", chapter = chapter("156215")),
+        )
+    }
+
+    @Test
+    fun `a canonical requested id is unchanged (no-op for correct callers)`() {
+        assertEquals(
+            "156215",
+            playingFictionId(requestedFictionId = "156215", chapter = chapter("156215")),
+        )
+    }
+
+    @Test
+    fun `a prefixed import id round-trips when the chapter agrees`() {
+        // EPUB/PDF imports use `<source>:<hash>` ids; the chapter carries the
+        // same id, so the helper returns it unchanged (no prefix stripping).
+        assertEquals(
+            "epub:abc123",
+            playingFictionId(requestedFictionId = "epub:abc123", chapter = chapter("epub:abc123")),
+        )
+    }
+
+    @Test
+    fun `falls back to the requested id only when the chapter id is blank`() {
+        // The fictionId column is NOT NULL, so this shouldn't happen — but the
+        // fallback guarantees we never regress currentFictionId to blank.
+        assertEquals(
+            "156215",
+            playingFictionId(requestedFictionId = "156215", chapter = chapter("")),
+        )
+    }
+}


### PR DESCRIPTION
## Summary
Root cause fix for #1330 / #1336. When a Royal Road book is started with a URL slug (e.g. `"archmage-coefficient"`) instead of its numeric Room ID (`"156215"`), the slug leaked into `PlaybackState.currentFictionId`. Playback worked fine (chapters load by `chapterId`), but the reader's "Open chapter list" → FictionDetail lookup used the slug to query Room, got null, and showed a full-screen "Fiction not found" error for a book that was actively playing.

**Fix**: `playingFictionId()` prefers `chapter.fictionId` (FK-bound to the fiction table, always the canonical numeric ID) over the caller's `requestedFictionId`. Applied at both the TTS and non-TTS `startPlaying` paths in EnginePlayer.

**Why the closed PR #1334 was wrong**: It tried to gate the error in the ViewModel, but FictionDetailScreen.kt:450 already gates full-screen error on `fiction == null`. The ViewModel gate was both ineffective (fiction IS null because of wrong ID) and harmful (would suppress the legitimate "Couldn't refresh" banner).

Supersedes closed PR #1334.
Fixes #1330
Fixes #1336

## Test plan
- [ ] Build APK (CI)
- [ ] `EnginePlayerFictionIdTest` — 4 unit tests covering slug→canonical, no-op, import ID, and blank-fallback cases
- [ ] Waydroid repro: start Royal Road book via browse → play → open chapter list → should show FictionDetail, not error

🤖 Generated with [Claude Code](https://claude.com/claude-code)