### PR TITLE
fix(inbox): load the chapter before opening the reader (#1343)

### DIFF
--- a/feature/src/main/kotlin/in/jphe/storyvox/feature/library/LibraryViewModel.kt
+++ b/feature/src/main/kotlin/in/jphe/storyvox/feature/library/LibraryViewModel.kt
@@ -397,6 +397,21 @@ class LibraryViewModel @Inject constructor(
     fun openInboxEvent(event: InboxEvent) {
         viewModelScope.launch {
             inboxRepo.markRead(event.id)
+            // Issue #1343 — a "new chapter" inbox event points at a chapter
+            // the user has never opened, so the global PlaybackController is
+            // NOT holding it. The reader is a passive view of the controller:
+            // navigating to /reader/{fid}/{cid} without first loading leaves
+            // it stuck on the "loading chapter" prompt forever (then the 30s
+            // timeout). FictionDetail's Play button only works because it
+            // calls startListening BEFORE navigating (FictionDetailViewModel),
+            // and `startListening` is what queues the chapter-body download +
+            // loads it into the controller. Mirror that here so the reader's
+            // loading card resolves once the body arrives.
+            val fictionId = event.fictionId
+            val chapterId = event.chapterId
+            if (fictionId != null && chapterId != null) {
+                playback.startListening(fictionId = fictionId, chapterId = chapterId)
+            }
             val link = event.deepLinkUri ?: return@launch
             _events.send(LibraryUiEvent.OpenInboxLink(link))
         }

--- a/feature/src/main/kotlin/in/jphe/storyvox/feature/library/LibraryViewModel.kt
+++ b/feature/src/main/kotlin/in/jphe/storyvox/feature/library/LibraryViewModel.kt
@@ -397,22 +397,37 @@ class LibraryViewModel @Inject constructor(
     fun openInboxEvent(event: InboxEvent) {
         viewModelScope.launch {
             inboxRepo.markRead(event.id)
-            // Issue #1343 — a "new chapter" inbox event points at a chapter
-            // the user has never opened, so the global PlaybackController is
-            // NOT holding it. The reader is a passive view of the controller:
-            // navigating to /reader/{fid}/{cid} without first loading leaves
-            // it stuck on the "loading chapter" prompt forever (then the 30s
-            // timeout). FictionDetail's Play button only works because it
-            // calls startListening BEFORE navigating (FictionDetailViewModel),
-            // and `startListening` is what queues the chapter-body download +
-            // loads it into the controller. Mirror that here so the reader's
-            // loading card resolves once the body arrives.
+            // Resolve the landing page FIRST: an event with no deepLinkUri is a
+            // pure "mark read" acknowledgement (no nav) — preloading playback
+            // before this guard would turn that into a stray playback side
+            // effect for an event that never navigates (CodeRabbit, #1345).
+            val link = event.deepLinkUri ?: return@launch
+            // Issue #1343 — preload the chapter into the global
+            // PlaybackController BEFORE navigating. The reader is a passive
+            // view of the controller: navigating to /reader/{fid}/{cid}
+            // without first loading leaves it stuck on the "loading chapter"
+            // prompt forever (then the 30s timeout). FictionDetail's Play
+            // works only because it calls startListening before navigating;
+            // startListening is what queues the chapter-body download + loads
+            // the controller, so the reader's loading card resolves once the
+            // body arrives.
+            //
+            // autoPlay = false: an inbox tap is a browse/navigate action, not
+            // a "play" action — load the chapter and open the reader, but let
+            // the user press play if they want audio (matches the history-row
+            // intent). runCatching so a startForegroundService hiccup can't
+            // swallow the navigation below.
             val fictionId = event.fictionId
             val chapterId = event.chapterId
             if (fictionId != null && chapterId != null) {
-                playback.startListening(fictionId = fictionId, chapterId = chapterId)
+                runCatching {
+                    playback.startListening(
+                        fictionId = fictionId,
+                        chapterId = chapterId,
+                        autoPlay = false,
+                    )
+                }
             }
-            val link = event.deepLinkUri ?: return@launch
             _events.send(LibraryUiEvent.OpenInboxLink(link))
         }
     }


### PR DESCRIPTION
## Inbox new-chapter tap hangs on "loading chapter" (#1343)

**Symptom:** tapping a new chapter in the Inbox shows "loading chapter" but never opens the chapter.

### Root cause
The reader (`HybridReaderScreen`) is a **passive view of the global `PlaybackController`** — it renders whatever chapter the controller currently holds, and shows the `ExplicitArgsLoadingPrompt` ("loading chapter") whenever its `/reader/{fictionId}/{chapterId}` nav args don't match the controller's loaded chapter (see `readerContentMode` + the #638 prompt).

Nothing in the reader auto-loads from the nav args — verified across the `init` block, both `HybridReaderScreen` `LaunchedEffect`s, and the `READER` composable destination; none call `startListening`. `FictionDetail`'s Play button works **only** because it calls `playback.startListening(...)` *before* navigating (`FictionDetailViewModel`), and `startListening` is what queues the chapter-body download and loads it into the controller.

`LibraryViewModel.openInboxEvent` only navigated (`OpenInboxLink` → `navigate(reader/{fid}/{cid})`) — it never told the controller to load the brand-new, not-yet-downloaded chapter. So the controller never switched to it, the body never downloaded, and the reader sat on the loading prompt until the 30s timeout ("Couldn't start this chapter").

This is the navigation-layer sibling of the #1330/#1336 fiction/chapter resolution issues the assignment pointed at.

### Fix
`openInboxEvent` now calls `playback.startListening(fictionId, chapterId)` for chapter events (both ids non-null) before emitting the nav event — mirroring the proven FictionDetail path. `startListening` queues the download, waits for the body, then plays; the reader's loading card then resolves into the chapter. One-file, ~8-line change; `LibraryViewModel` already injects `playback`.

### ⚠️ Verification status: DONE_WITH_CONCERNS
- **Root cause:** confirmed by full code trace (inbox path vs. the working FictionDetail path vs. the passive reader).
- **No unit test added.** A `LibraryViewModel` regression test needs its full 9-dep constructor incl. a ~30-method `PlaybackControllerUi` fake (~200 lines, no existing harness), which I can't compile-check locally (project rule: no local gradle) and which has a high Test-Compile-break risk. That cost is disproportionate to a code-trace-conclusive one-line wiring fix. **Recommend device verification** (the team's established gate for UI bugs) using the recipe below. Happy to add the full VM-test harness if you want it.

**Device verification recipe:**
1. Follow a fiction with new chapters (or wait for the poll to record a "N new chapters" inbox event).
2. Library → Inbox → tap the new-chapter row.
3. Before fix: reader shows "loading chapter" → 30s → "Couldn't start." After fix: the new chapter loads and opens.

### Related (not in this PR)
`LibraryViewModel.openHistoryEntry` has the **identical** navigate-without-load shape (its "deliberately don't call `startListening`" comment assumes the reader renders the chapter without a controller load — which this investigation shows isn't true). Recommend the same fix (with `autoPlay = false` to honor its browse-context intent) as a sibling — left out here to keep this scoped to #1343.

Closes #1343

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Opening an inbox chapter now begins playback listening when the chapter and fiction are available, helping the “loading chapter” state resolve after the chapter is queued.
  * Inbox items still get marked as read, and links continue to open only when a destination is available.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->