### PR TITLE
fix(royalroad): follow now works when signed in (#1331)

### DIFF
--- a/source-royalroad/src/main/kotlin/in/jphe/storyvox/source/royalroad/RoyalRoadSource.kt
+++ b/source-royalroad/src/main/kotlin/in/jphe/storyvox/source/royalroad/RoyalRoadSource.kt
@@ -30,6 +30,8 @@ import `in`.jphe.storyvox.source.royalroad.parser.BrowseParser
 import `in`.jphe.storyvox.source.royalroad.parser.ChapterParser
 import `in`.jphe.storyvox.source.royalroad.parser.FictionDetailParser
 import `in`.jphe.storyvox.source.royalroad.parser.FollowsParser
+import `in`.jphe.storyvox.source.royalroad.tagsync.RoyalRoadTagSyncEndpoints
+import `in`.jphe.storyvox.source.royalroad.tagsync.SavedTagsParser
 import javax.inject.Inject
 import javax.inject.Singleton
 import kotlin.time.Duration.Companion.seconds
@@ -274,21 +276,44 @@ class RoyalRoadSource @Inject internal constructor(
         }
 
     override suspend fun setFollowed(fictionId: String, followed: Boolean): FictionResult<Unit> {
-        // Two requests:
-        // 1. GET the fiction page to harvest a fresh __RequestVerificationToken
-        //    (RR's antiforgery cookie + token pair is per-session-per-page).
-        // 2. POST /fictions/setbookmark/{id} with type=follow&mark=True|False
-        //    and the token in the form body. Auth cookies attach automatically
-        //    from the OkHttp jar.
-        val pageHtml = when (val outcome = fetcher.fetchHtml(fictionUrl(fictionId))) {
-            is FetchOutcome.Body -> outcome.html
-            FetchOutcome.NotFound -> return FictionResult.NotFound("Fiction $fictionId not found")
+        // Reliable logged-out short-circuit: the shared auth store holds a row
+        // only after WebView sign-in, so a null row means "never signed in" —
+        // the same proactive check search() uses (#1243). Doing this first lets
+        // us tell a genuinely signed-out user apart from a token/markup glitch
+        // below, instead of conflating the two into a false "sign in" (#1331).
+        if (authDao.get(SourceIds.ROYAL_ROAD) == null) {
+            return FictionResult.AuthRequired(message = "Sign in to follow fictions")
+        }
+
+        // Harvest a fresh antiforgery token, then POST the follow toggle:
+        // 1. GET a page that *reliably* server-renders the hidden
+        //    __RequestVerificationToken input. The fiction page does NOT — RR
+        //    drives its Follow button via AJAX, so the old fiction-page harvest
+        //    came back null and wrongly told signed-in users to "sign in"
+        //    (#1331). We reuse the /fictions/search form the working tag-sync
+        //    writer harvests from (RoyalRoadTagSyncEndpoints.readUrl).
+        // 2. POST /fictions/setbookmark/{id} with type=follow&mark=True|False and
+        //    that token. The antiforgery cookie set by the GET pairs with it and
+        //    the auth cookies attach automatically from the OkHttp jar.
+        val token = when (val outcome = fetcher.fetchHtml(RoyalRoadTagSyncEndpoints.readUrl)) {
+            is FetchOutcome.Body -> when (val tags = SavedTagsParser.parse(outcome.html, outcome.finalUrl)) {
+                SavedTagsParser.Result.NotAuthenticated ->
+                    return FictionResult.AuthRequired(message = "Sign in to follow fictions")
+                is SavedTagsParser.Result.Ok -> tags.parsed.csrfToken
+                    // Authed, but the token form is gone → RR markup changed.
+                    // Not an auth failure, so don't mislead with "sign in" (#1331).
+                    ?: return FictionResult.NetworkError(
+                        message = "Couldn't get a follow token from Royal Road — try again later",
+                    )
+            }
+            FetchOutcome.NotFound -> return FictionResult.NetworkError(message = "Royal Road follow endpoint unavailable")
             is FetchOutcome.CloudflareChallenge -> return FictionResult.Cloudflare(outcome.url)
             is FetchOutcome.RateLimited -> return FictionResult.RateLimited(retryAfter = outcome.retryAfterSec.seconds)
-            is FetchOutcome.HttpError -> return FictionResult.NetworkError(message = "HTTP ${outcome.code}: ${outcome.message}")
+            is FetchOutcome.HttpError -> return when (outcome.code) {
+                401, 403 -> FictionResult.AuthRequired(message = "Sign in to follow fictions")
+                else -> FictionResult.NetworkError(message = "HTTP ${outcome.code}: ${outcome.message}")
+            }
         }
-        val token = extractCsrfToken(pageHtml)
-            ?: return FictionResult.AuthRequired(message = "Sign in to follow fictions")
 
         val body = okhttp3.FormBody.Builder()
             .add("type", "follow")
@@ -314,13 +339,6 @@ class RoyalRoadSource @Inject internal constructor(
         }.getOrElse { FictionResult.NetworkError(message = "POST failed: ${it.message}", cause = it) }
     }
 
-    /** Pulls the CSRF token from the bookmark-form hidden input on the fiction page. */
-    private fun extractCsrfToken(html: String): String? {
-        val doc = org.jsoup.Jsoup.parse(html)
-        return doc.selectFirst("input[name=__RequestVerificationToken]")
-            ?.attr("value")
-            ?.takeIf { it.isNotBlank() }
-    }
     override suspend fun genres(): FictionResult<List<String>> = FictionResult.Success(KnownTagSlugs)
 
     private suspend fun fetchBrowsePage(url: String, page: Int): FictionResult<ListPage<FictionSummary>> =


### PR DESCRIPTION
## Fixes #1331 — "follow my Royal Road book doesn't work even after login"

### Root cause
`RoyalRoadSource.setFollowed` GET-harvested the antiforgery `__RequestVerificationToken` from the **fiction page** (`/fiction/{id}`). Royal Road drives its Follow button via AJAX and does **not** server-render that hidden form input on the fiction page, so `extractCsrfToken` returned `null` and the method returned `AuthRequired("Sign in to follow fictions")`. A logged-in user was told to sign in, and the follow silently never happened — exactly the report.

This was confirmed structurally rather than by symptom-guessing. Ruled out, with evidence in code:
- **Cookie hydration is wired** — `AuthViewModel` hydrates on WebView login; `StoryvoxApp.rehydrateRoyalRoadCookies()` re-hydrates on app start.
- **The harvest GET is authenticated** — `fetcher` → `RateLimitedClient` → the `@RoyalRoadHttp` client with `.cookieJar(jar)`.
- **`fictionId` and the setbookmark URL are correct** (bare numeric id).
- **The token selector is identical to the working tag-sync flow** — the only difference is *which page* it reads. Tag-sync deliberately reads `/fictions/search`, whose KDoc notes it harvests the token "the same way `setFollowed` harvests its token" — but they GET different pages, and only the search form reliably carries the hidden input.

### Fix
Harvest the token from `/fictions/search` (`RoyalRoadTagSyncEndpoints.readUrl`) — the same server-rendered form the **working** tag-sync writer reads — and split the old single failure mode into three honest outcomes:

| Condition | Result |
|---|---|
| No session row (`authDao`, the same signal `search()` gates on) | `AuthRequired` — genuinely signed out |
| Authed but token absent | `NetworkError` — RR markup changed, **not** a false "sign in" |
| Token present | POST the follow toggle, unchanged |

The antiforgery cookie set by the search-page GET pairs with the harvested token; the POST body/URL/Referer are unchanged. Removes the now-dead `extractCsrfToken`.

### Testing
- Reuses `SavedTagsParser`'s tri-state, which is already unit-tested for all three branches this fix routes on (`SavedTagsParserTest`: token extraction, `NotAuthenticated` via redirect **and** inline login form, and `csrfToken == null`).
- No new unit test for `setFollowed` itself: like its siblings `search()`/`followsList()`, it orchestrates the non-`open` `RoyalRoadChallengeFetcher`/`RateLimitedClient` with no test seam (module convention: parser-level tests, no Robolectric). Adding a seam would be a refactor beyond this fix.

### Caveat — confirmation pending
The fiction-page-lacks-token hypothesis is strongly supported by code (tag-sync's deliberate choice of the search form) but was **not** verified against live authenticated RR HTML. Regardless of that specific mechanism, harvesting from the proven `/fictions/search` form is strictly more robust than the fiction page, and the logged-out-vs-token-missing split is a correct UX improvement on its own. Worth a device check on a signed-in account.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
