### PR TITLE
fix(playback): lock-screen pill skip — wire MediaSession seek to chapter advance (#1341)

### DIFF
--- a/core-playback/src/main/kotlin/in/jphe/storyvox/playback/tts/EnginePlayer.kt
+++ b/core-playback/src/main/kotlin/in/jphe/storyvox/playback/tts/EnginePlayer.kt
@@ -1509,6 +1509,16 @@ class EnginePlayer @AssistedInject constructor(
                 Player.Commands.Builder()
                     .addAll(
                         Player.COMMAND_PLAY_PAUSE,
+                        // Issue #1341 — advertise the *combined* seek commands
+                        // (COMMAND_SEEK_TO_PREVIOUS / _NEXT) alongside the
+                        // media-item variants. The lock-screen / notification
+                        // pill's prev+next buttons resolve to
+                        // Player.seekToPrevious()/seekToNext(), which are gated
+                        // on these combined commands; without them advertised
+                        // the system media controls render no skip buttons.
+                        // handleSeek() (below) routes all four to advanceChapter.
+                        Player.COMMAND_SEEK_TO_PREVIOUS,
+                        Player.COMMAND_SEEK_TO_NEXT,
                         Player.COMMAND_SEEK_TO_PREVIOUS_MEDIA_ITEM,
                         Player.COMMAND_SEEK_TO_NEXT_MEDIA_ITEM,
                         Player.COMMAND_GET_METADATA,
@@ -5193,6 +5203,60 @@ class EnginePlayer @AssistedInject constructor(
         }
         if (playWhenReady) resume() else pauseTts()
         return Futures.immediateVoidFuture()
+    }
+
+    override fun handleSeek(
+        mediaItemIndex: Int,
+        positionMs: Long,
+        seekCommand: Int,
+    ): ListenableFuture<*> {
+        // Issue #1341 — the lock-screen / notification "pill" drives the
+        // session with transport *commands* (Player.seekToNext/Previous), a
+        // separate path from the BT/headset KeyEvents that MediaButtonHandler
+        // handles. SimpleBasePlayer dispatches those commands here. EnginePlayer
+        // exposes a single-item playlist (it synthesises TTS one chapter at a
+        // time — see buildPlaylist), so there is no adjacent timeline item to
+        // land on and, before this override, the pill's skip buttons were inert
+        // (the seek had nowhere to go and no handler to redirect it). Route
+        // next/prev to the same chapter-advance the hardware path uses
+        // (MediaButtonHandler → controller.nextChapter → advanceChapter) so the
+        // pill and BT keys share one behaviour.
+        when (seekCommand) {
+            Player.COMMAND_SEEK_TO_NEXT,
+            Player.COMMAND_SEEK_TO_NEXT_MEDIA_ITEM,
+            -> launchAdvanceChapter(direction = 1)
+
+            Player.COMMAND_SEEK_TO_PREVIOUS,
+            Player.COMMAND_SEEK_TO_PREVIOUS_MEDIA_ITEM,
+            -> launchAdvanceChapter(direction = -1)
+            // Within-item scrubbing / seek-to-default aren't advertised in
+            // getState (COMMAND_SEEK_IN_CURRENT_MEDIA_ITEM is absent), so they
+            // won't reach here; no-op defensively if a controller sends one.
+        }
+        return Futures.immediateVoidFuture()
+    }
+
+    /**
+     * Issue #1341 — bridge a (suspend) chapter advance out of the non-suspend
+     * [handleSeek]. advanceChapter guards itself (advance mutex + invocation
+     * token), so driving it from several entry points at once — handleChapterDone,
+     * the controller, the stall watchdog, and now the MediaSession pill — is safe
+     * by design. Fire-and-return: we never block the session controller's seek
+     * future on the chapter load. Mirrors the handleChapterDone runCatching /
+     * onFailure idiom (issue #553).
+     */
+    private fun launchAdvanceChapter(direction: Int) {
+        scope.launch {
+            runCatching { advanceChapter(direction = direction) }
+                .onFailure { t ->
+                    android.util.Log.e(
+                        "EnginePlayer",
+                        "handleSeek: advanceChapter(direction=$direction) threw " +
+                            "(${t.javaClass.simpleName}: ${t.message})",
+                        t,
+                    )
+                }
+        }
     }
 
     override fun handleStop(): ListenableFuture<*> {


### PR DESCRIPTION
Closes #1341.

## Symptom
The lock-screen / notification "pill" did nothing for **skip** (and, per the report, play/pause). Hardware/BT skip already worked.

## Root cause — two separate transport paths
- **BT / headset keys** → `MediaSession.Callback.onMediaButtonEvent` → `MediaButtonHandler` → `controller.nextChapter()` → `advanceChapter(±1)`. **Worked.**
- **Lock-screen / notification pill** → player *commands* (`Player.seekToNext()/seekToPrevious()`) → `SimpleBasePlayer.handleSeek`. EnginePlayer advertised the seek commands but had **no `handleSeek` override**, so the `SimpleBasePlayer` default would *throw* if a seek dispatched, and the pill's skip did nothing. **Broken.**

## Fix
- Override `handleSeek` in `EnginePlayer`: `COMMAND_SEEK_TO_NEXT` / `_NEXT_MEDIA_ITEM` → `advanceChapter(+1)`; the `PREVIOUS` variants → `advanceChapter(-1)`.
- Advertise the combined `COMMAND_SEEK_TO_NEXT` / `COMMAND_SEEK_TO_PREVIOUS` alongside the existing media-item variants.
- `advanceChapter` is concurrency-safe (advance mutex + invocation token), so the new MediaSession caller composes safely with the controller / watchdog / chapter-done callers — the engine already anticipates a "MediaSession-Next" caller (see the comment inside `advanceChapter`).

## ⚠️ Device verification needed — the crux
EnginePlayer exposes a **single-item playlist** (`buildPlaylist` returns one item — it synthesises TTS one chapter at a time). In `SimpleBasePlayer` / `BasePlayer`, `seekToNext()/seekToPrevious()` are gated on `getNextMediaItemIndex()` / `getPreviousMediaItemIndex()`, which return `C.INDEX_UNSET` for a single-item timeline with `REPEAT_MODE_OFF`. That means the seek may be **dropped at the player layer before it ever reaches `handleSeek`**.

**Please verify on R5CRB0W66MK** with playback active:

    adb -s R5CRB0W66MK shell cmd media_session dispatch next
    adb -s R5CRB0W66MK shell cmd media_session dispatch previous
    adb -s R5CRB0W66MK shell cmd media_session dispatch play-pause
    adb -s R5CRB0W66MK logcat -d | grep -iE 'EnginePlayer|advanceChapter'

- **If logcat shows `advanceChapter direction=…`** → the fix dispatched; skip is restored. ✅
- **If pill-skip is still inert** (no `advanceChapter` line) → confirms the single-item-timeline drop. **Ready follow-up (~10 min):** a 3-slot synthetic timeline window in `buildPlaylist` — `[prev, current, next]` + `setCurrentMediaItemIndex(1)` — so `seekToNextMediaItem()` resolves a valid neighbour and dispatches into `handleSeek`.

**Play/pause** is handled by `handleSetPlayWhenReady` (→ `resume()/pauseTts()`), which is correctly wired and likely already works — the report's "play pause" may be conflation. Worth a quick confirm during the test.

## Risk
Strict improvement: at worst a no-op (seek dropped at the player layer, same as today), at best skip is fixed; it also removes the latent default-`handleSeek` throw. No change to play/pause, stop, playback params, or the `getState` hot path / playlist shape.
