### PR TITLE
fix(playback): guard voice-model load against missing files (#1342)

### DIFF
--- a/core-playback/src/main/kotlin/in/jphe/storyvox/playback/tts/EnginePlayer.kt
+++ b/core-playback/src/main/kotlin/in/jphe/storyvox/playback/tts/EnginePlayer.kt
@@ -2136,7 +2136,23 @@ class EnginePlayer @AssistedInject constructor(
             // withLock here waits for the in-flight call to finish before
             // we tear the model down.
             engineMutex.withLock {
-                when (active.engineType) {
+                // Issue #1342 — gate the native loadModel on the voice's model
+                // files actually being present on disk. VoxSherpa's loadModel
+                // (OfflineTts.newFromFile et al.) SIGSEGVs on a missing/partial
+                // model file rather than erroring, so a voice that's marked
+                // installed in prefs but whose files were never fully downloaded
+                // (or were deleted) hard-crashes the app when it's loaded — the
+                // #1342 native SIGSEGV in OfflineTts.newFromFile. Refuse the JNI
+                // call and return a typed error; the `loadResult != "Success"`
+                // path below handles it gracefully (no crash).
+                if (!voiceManager.modelFilesPresent(active)) {
+                    android.util.Log.w(
+                        "EnginePlayer",
+                        "loadModel: model files missing for voice ${active.id} " +
+                            "(${active.engineType}); refusing native load — #1342",
+                    )
+                    "This voice isn't fully downloaded — re-download it in Voices, or pick another voice."
+                } else when (active.engineType) {
                     EngineType.Piper -> {
                         // Voice swap AWAY from Kokoro/Kitten → free
                         // their secondaries. Tier 3 (#88) honors the
@@ -5698,7 +5714,23 @@ class EnginePlayer @AssistedInject constructor(
 
         val loadResult: String = withContext(Dispatchers.IO) {
             engineMutex.withLock {
-                when (active.engineType) {
+                // Issue #1342 — gate the native loadModel on the voice's model
+                // files actually being present on disk. VoxSherpa's loadModel
+                // (OfflineTts.newFromFile et al.) SIGSEGVs on a missing/partial
+                // model file rather than erroring, so a voice that's marked
+                // installed in prefs but whose files were never fully downloaded
+                // (or were deleted) hard-crashes the app when it's loaded — the
+                // #1342 native SIGSEGV in OfflineTts.newFromFile. Refuse the JNI
+                // call and return a typed error; the `loadResult != "Success"`
+                // path below handles it gracefully (no crash).
+                if (!voiceManager.modelFilesPresent(active)) {
+                    android.util.Log.w(
+                        "EnginePlayer",
+                        "loadModel: model files missing for voice ${active.id} " +
+                            "(${active.engineType}); refusing native load — #1342",
+                    )
+                    "This voice isn't fully downloaded — re-download it in Voices, or pick another voice."
+                } else when (active.engineType) {
                     EngineType.Piper -> {
                         val voiceDir = voiceManager.voiceDirFor(active.id)
                         val onnx = File(voiceDir, "model.onnx").absolutePath

--- a/core-playback/src/main/kotlin/in/jphe/storyvox/playback/voice/VoiceManager.kt
+++ b/core-playback/src/main/kotlin/in/jphe/storyvox/playback/voice/VoiceManager.kt
@@ -341,6 +341,35 @@ class VoiceManager @Inject constructor(
         return SupertonicEngine.MODEL_FILES.all { File(dir, it).exists() }
     }
 
+    /**
+     * Issue #1342 — true when every on-disk model file [voice]'s engine family
+     * needs is actually present. The playback engine MUST gate VoxSherpa's
+     * `loadModel` on this: the native loader (`OfflineTts.newFromFile` and its
+     * Kokoro/Kitten/Supertonic siblings) **SIGSEGVs on a missing/partial model
+     * file** rather than returning an error, so a voice whose download was
+     * interrupted — or whose files were deleted after selection — hard-crashes
+     * the app at play time. (#1342 was reported as "playing an imported EPUB
+     * crashed", but the EPUB is incidental: any text fiction loads the active
+     * voice, and the crash is a native SIGSEGV in `OfflineTts.newFromFile`.)
+     *
+     * Deliberately a *file* check, distinct from the pref-tracked installed set
+     * ([UiVoiceInfo.isInstalled] / [installedVoices]): a Piper voice stays in
+     * `INSTALLED_IDS` even after its files are removed, so the pref alone is
+     * unsafe to hand to the native loader. Azure / System TTS have no on-disk
+     * sherpa model (cloud / framework synthesis) and never reach the crashing
+     * JNI path, so they're trivially present.
+     */
+    fun modelFilesPresent(voice: UiVoiceInfo): Boolean = when (voice.engineType) {
+        is EngineType.Piper -> {
+            val dir = voiceDirFor(voice.id)
+            File(dir, "model.onnx").exists() && File(dir, "tokens.txt").exists()
+        }
+        is EngineType.Kokoro -> isKokoroSharedModelInstalled()
+        is EngineType.Kitten -> isKittenSharedModelInstalled()
+        is EngineType.Supertonic -> isSupertonicSharedModelInstalled()
+        is EngineType.Azure, is EngineType.SystemTts -> true
+    }
+
     sealed interface DownloadProgress {
         data object Resolving : DownloadProgress
         data class Downloading(val bytesRead: Long, val totalBytes: Long) : DownloadProgress


### PR DESCRIPTION
Closes #1342.

## Forensics (Z Flip3 R5CRB0W66MK, v1.4.2 vc244)

The crash logged on-device is a **native SIGSEGV** (signal 11, SEGV_MAPERR, **fault addr 0x98** = null deref) in `com.k2fsa.sherpa.onnx.OfflineTts.newFromFile` → `libonnxruntime.so`, on the TTS producer coroutine — i.e. **voice-model loading**, not EPUB parsing. 3 identical tombstones (06-28 09:07/09:08/09:19). No abort message.

**Why "imported EPUB" is incidental:** playing any text fiction → TTS → `VoiceEngine.loadModel(onnx, tokens)` → `OfflineTts.newFromFile`. The voice is resolved as `pinnedVoiceId(fictionId)?.takeIf { isInstalled } ?: activeVoice` (EnginePlayer ~1931) — and `isInstalled` is the **pref-tracked** flag, never a file check. So `active` can point to a voice marked installed in prefs whose model files were never fully downloaded (or were deleted), and the JNI loader SIGSEGVs on the missing file instead of erroring. The same crash hits any text fiction with that voice — the reporter just happened to be on an imported EPUB.

I reproduced the *exact* user-facing error screen separately during the #1330 work, and confirmed via the tombstones + code trace here.

## Fix

- **`VoiceManager.modelFilesPresent(voice)`** — a per-engine-family **file existence** check: reuses the authoritative shared-model checks (`isKokoro/Kitten/SupertonicSharedModelInstalled`) and adds a real `File(dir,"model.onnx"/"tokens.txt").exists()` check for Piper (distinct from the pref-based `installed` set). Azure / System TTS have no on-disk sherpa model → trivially present.
- **EnginePlayer** — both model-load paths (`loadAndPlay` and the recap-aloud `ensureVoiceLoaded`) now gate the `loadModel` `when` on `modelFilesPresent(active)`. On missing files they **refuse the JNI call** and return a typed error string, which the existing `loadResult != "Success"` handler turns into a recoverable `PlaybackError.ChapterFetchFailed` (Back / Retry / re-download) — converting a hard native crash into graceful recovery.

The guard can only *prevent* a crash: when the files are present (the overwhelming common case) it's a no-op; when they're missing the old behaviour was a SIGSEGV.

## Scope decisions
- **Graceful error over silent voice-fallback.** The lead suggested falling back to an installed voice; I went with a clear "re-download or pick another voice" error + Retry instead — auto-switching a voice mid-load is riskier and surprising. Fallback can be a follow-up.
- The **export / prerender** `loadModel` paths (`AudiobookSynthesizer`, `ChapterRenderJob`) share the same latent hazard; left for a follow-up to keep this focused on the reported playback crash.

## Verification
- CI compile (no local gradle per policy).
- **Device repro-verify pending**: on the Z Flip3, trigger playback with a missing-file voice and confirm the graceful error replaces the SIGSEGV. The phone is currently busy with another agent's sync sign-in flow — I'll run this once it's free and report back.
- No unit test: `VoiceManager` needs `@ApplicationContext` + the Azure/System rosters so it isn't JVM-constructible, and its sibling file-check helpers are likewise untested; the device repro is the authoritative regression check for this native crash.

🤖 Generated with [Claude Code](https://claude.com/claude-code)