### PR TITLE
fix(library): load chapter before opening reader from history (#1350)

### DIFF
--- a/feature/src/main/kotlin/in/jphe/storyvox/feature/library/LibraryViewModel.kt
+++ b/feature/src/main/kotlin/in/jphe/storyvox/feature/library/LibraryViewModel.kt
@@ -408,14 +408,29 @@ class LibraryViewModel @Inject constructor(
     }
 
     /**
-     * Issue #158 — History row tap. Navigates to the reader at that
-     * (fictionId, chapterId). We deliberately *don't* call
-     * `playback.startListening` here: the user might be browsing history
-     * to find context, not to start playing right now. Reader opens the
-     * chapter view; if they want audio they tap play from there.
+     * Issue #1350 — History row tap. Preload the chapter into the global
+     * [PlaybackController] BEFORE navigating: the reader is a passive view of
+     * the controller, so opening /reader/{fid}/{cid} without first loading
+     * leaves it stuck on the "loading chapter" prompt (then the 30s timeout).
+     * `startListening` is what queues the chapter-body download + loads the
+     * controller, so the reader's loading card resolves once the body arrives.
+     * This is the identical navigate-without-load bug fixed for the inbox path
+     * in #1343 / #1345.
+     *
+     * `autoPlay = false` keeps Issue #158's intent — a history tap is browsing
+     * for context, not "play now" — so the chapter loads and the reader opens,
+     * but audio stays paused until the user taps play. `runCatching` so a
+     * `startForegroundService` hiccup can't swallow the navigation below.
      */
     fun openHistoryEntry(entry: HistoryEntry) {
         viewModelScope.launch {
+            runCatching {
+                playback.startListening(
+                    fictionId = entry.fictionId,
+                    chapterId = entry.chapterId,
+                    autoPlay = false,
+                )
+            }
             _events.send(LibraryUiEvent.OpenReader(entry.fictionId, entry.chapterId))
         }
     }


### PR DESCRIPTION
## Fixes #1350 — History entry tap stuck on "loading chapter"

Sibling of #1343 / #1345 — same root cause, same fix shape, different entry point.

### Root cause
`LibraryViewModel.openHistoryEntry` sent `OpenReader(fictionId, chapterId)` **without** first calling `playback.startListening`. The reader is a *passive view* of the global `PlaybackController` — it does not load the chapter body on its own. `startListening` is what queues the chapter-body download + loads the controller, so without it the reader sits on "loading chapter" until the 30s timeout.

A stale comment (Issue #158) claimed we *deliberately* skipped `startListening` because "the reader opens the chapter view." That premise predates the passive-reader architecture, under which skipping the load **is** the bug.

### Fix
Preload via `startListening(autoPlay = false)` before navigating:

```kotlin
runCatching {
    playback.startListening(
        fictionId = entry.fictionId,
        chapterId = entry.chapterId,
        autoPlay = false,
    )
}
_events.send(LibraryUiEvent.OpenReader(entry.fictionId, entry.chapterId))
```

- **`autoPlay = false`** honors #158's intent — a history tap is browsing for context, not "play now." The chapter loads and the reader opens, but audio stays paused until the user taps play. (Confirmed by the `UiContracts.startListening` KDoc: `autoPlay=false` → "the chapter loads + navigation fires but the engine remains paused.")
- **`runCatching`** so a `startForegroundService` hiccup can't swallow the navigation — mirrors #1345.
- The stale #158 comment is rewritten to match.

### Testing
No unit test added: `LibraryViewModel` has no existing test suite, and the directly-analogous sibling fix #1345 shipped without one. This is a one-call navigation fix mirroring an established pattern (`resume()`, `resumeOrOpenFiction()`, and #1345's `openInboxEvent()` all `startListening` before navigating).

### Merge note
Branched off `origin/main` (v1.4.4, 7e73b8af). Touches the same file as #1345 (`LibraryViewModel.kt`) but a **different method** (`openHistoryEntry` vs `openInboxEvent`) — non-overlapping, so the two merge cleanly in either order. Worth a device check of the History tab on the tablet post-merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
