### PR TITLE
docs: Data Safety checklist + correct §4 deletion path (#1139)

### DIFF
--- a/docs/data-safety-checklist.md
+++ b/docs/data-safety-checklist.md
@@ -1,0 +1,94 @@
+# Data Safety declaration — verification + Play Console checklist (#1139)
+
+_Verified by Reverie against the candela code (main) — not taken on faith from the doc._
+
+## TL;DR / verdict
+- **"Users can request deletion = Yes" is TRUTHFUL** — but the doc §4's *mechanism* is **wrong**. Deletion is NOT via sign-out; it's a separate explicit in-app **"Delete cloud data"** action (#1248) plus an email-request backstop.
+- **All synced *app* data is deletable in-app** (8 syncer domains, verified).
+- **One gap:** the InstantDB `$users` email/identity record has **no in-app delete path** — it relies on the privacy-policy email-request channel. That channel must exist for the "Yes" to be fully honest.
+- **Independent security review → No** for v1.0 (confirmed).
+- **Net Data Safety recommendation: ship the §4 mapping as-is**, with the two corrections below.
+
+---
+
+## Task 1 — Deletion-flow verification (the important one)
+
+**Claim under test (doc §4 line 225):** _"Users can request deletion: Yes (sign out of sync deletes the record; uninstall deletes on-device data)."_
+
+**What the code actually does:**
+
+1. **Sign-out does NOT delete cloud data.** `SyncAuthViewModel.signOut()` → `InstantClient.signOut(refreshToken)` which POSTs `{appId, refreshToken}` to `…/runtime/signout`. That **revokes the refresh token only**; its kdoc says _"Sign the refresh token out server-side. Local state must be cleared by the caller."_ It then wipes the **local** session (`session.clear()`, #1217). The cloud record is **left intact**. So the doc's "sign out deletes the record" is **inaccurate** — sign-out = token revoke + local wipe.
+
+2. **Deletion exists as a separate, explicit action.** `SyncAuthViewModel.purgeRemoteData()` (#1248) — _"explicitly delete the user's cloud (InstantDB) record"_ — calls `SyncCoordinator.purgeRemoteData(user)`, which loops **every** registered syncer and calls `syncer.purge(user)` → `HttpInstantBackend.delete()` → an admin `["delete", entity, id]` transact step (`POST …/admin/transact`). This is a real server-side row delete.
+
+3. **Coverage = all 8 synced domains** (every `@IntoSet Syncer` in `SyncModule`, each implements `override suspend fun purge`):
+   Library · Follows · PlaybackPosition (reading positions) · PronunciationDict · Bookmarks · Annotations · Secrets · Settings (voice prefs).
+   → Everything the form declares as collected/shared **app data** (library state = fiction IDs, positions, voice prefs) is covered. ✓
+
+4. **Gap — the email / `$users` identity record.** No code path deletes the InstantDB `$users` row (the magic-code auth principal holding the email). That's expected — the as-token admin API can't delete its own auth principal — but it means **"email" deletion is NOT in-app**; it relies on the privacy-policy email-request path. The issue body already promises both ("add … a documented email-request path") — so this is fine **iff** the privacy policy documents a real deletion-request email.
+
+**Verdict:** "deletion = Yes" stands, but on the correct basis: in-app **Delete cloud data** (#1248) for synced app data + email-request for the identity record. Sign-out is irrelevant to deletion.
+
+### Required corrections
+- **Doc §4:** the "sign out of sync deletes the record" wording was corrected in this same change to describe the real path (in-app **Delete cloud data** action #1248 + email-request for the identity record; uninstall clears on-device data). ✅ done.
+- **Privacy policy:** ensure it lists a working deletion-request email. This backstops the `$users`-record gap and is what Play expects behind a "Yes."
+- **In Play Console:** when entering the deletion answer, point users at the **Delete cloud data** action + the email, **not** sign-out.
+
+---
+
+## Task 2 — Play Console Data Safety: copy-paste checklist
+
+Work top-to-bottom through the Console wizard. **Bold = the option to pick.**
+
+### Section A — Data collection overview
+- _Does your app collect or share any of the required user data types?_ → **Yes**
+- _Is all of the user data collected by your app encrypted in transit?_ → **Yes**
+- _Do you provide a way for users to request that their data be deleted?_ → **Yes**
+
+### Section B — Data types (mark only these as collected; everything else = **Not collected**)
+
+**Personal info → Email addresses**
+- Collected **Yes** · Shared **Yes** · Processed ephemerally **No**
+- Required or optional → **Optional** (only if the user turns on sync)
+- Purposes → **App functionality** + **Account management**
+
+**Personal info → User IDs** (the InstantDB record id)
+- Collected **Yes** · Shared **Yes** · Processed ephemerally **No**
+- **Optional** · Purpose → **App functionality**
+
+**App activity → Other user-generated content / Other actions** (library state: fiction IDs, reading positions, voice prefs)
+- Collected **Yes** · Shared **Yes** · Processed ephemerally **No**
+- **Optional** · Purpose → **App functionality**
+- ⚠️ _Mapping note:_ Play's taxonomy has no "library state" type. "App activity → Other user-generated content" is the best fit for synced reading state. JP — confirm this bucket; the alternative is "Other actions." Either is defensible; pick one and keep it consistent with the privacy policy.
+
+**Mark as Not collected (select nothing):**
+Location (approx/precise) · Financial info · Health & fitness · Messages (SMS/email/other in-app) · Photos & videos · Audio files/voice/music · Files & docs · Calendar · Contacts · App info & performance (crash logs, diagnostics) · Device or other IDs · Web browsing.
+
+> Reasoning carried from §4: OCR camera images + recognized text are processed **on-device** (ML Kit) and never transmitted → Photos/Audio stay **No** despite the CAMERA permission. EPUB/SAF file reads aren't sent anywhere → Files **No**. Discord/Slack/Matrix/Telegram are read via the **user's own credentials direct to the service**; Candela stores nothing → Messages **No**. No analytics/ads/crash SDK → App activity/info, Device IDs all **No**.
+
+### Section C — Data sharing
+Declare **one** sharing relationship:
+- **Email address + library state + User ID → shared with InstantDB** (sync backend), purpose **App functionality**, when sync is enabled.
+- **Do NOT declare as "shared":** BYOK Azure/Anthropic/OpenAI keys, and third-party sign-ins (Discord/Notion/Royal Road/etc.). Per Play's definition these are *the user transmitting their own data directly to that service*, not the app sharing it.
+
+### Section D — Security practices
+- Encrypted in transit → **Yes** (HTTPS enforced by `network_security_config.xml`)
+- Users can request deletion → **Yes** → provide the in-app **Delete cloud data** path + the deletion-request email (see Task 1 corrections; **not** sign-out)
+- Independent security review → **No** (see Task 3)
+- Committed to Play Families Policy → **No / N/A** (13+ app with a UGC advisory, not a Families app)
+
+---
+
+## Task 3 — Independent security review
+
+**Confirmed: answer No for v1.0.** No formal third-party security review / pentest has been performed. "No" is the truthful answer; the only effect is the absence of the optional "independent security review" badge — no listing penalty, no policy risk. Revisit post-v1.0 only if JP decides to commission one.
+
+---
+
+## Open items for JP (not blocking the mapping itself)
+1. ~~Correct doc §4 deletion wording (sign-out → Delete-cloud-data action + email).~~ ✅ done in this change.
+2. Confirm the privacy policy documents a deletion-request email (backstops the `$users` record).
+3. Pick the "library state" Play category (App activity → Other UGC vs Other actions) and keep policy + form consistent.
+4. Re-audit this form whenever a new data flow lands (e.g., opt-in crash reporting) — a Data Safety answer that contradicts observed network traffic is a top rejection trigger.
+
+_Code refs: `core-sync/.../client/InstantClient.kt` (signOut=token revoke), `feature/.../sync/SyncAuthViewModel.kt` (signOut vs purgeRemoteData #1248), `core-sync/.../coordinator/SyncCoordinator.kt` (purgeRemoteData loops all syncers), `core-sync/.../client/HttpInstantBackend.kt` (admin/transact delete), `core-sync/.../di/SyncModule.kt` (8 syncer domains)._

--- a/docs/play-store-policy-check.md
+++ b/docs/play-store-policy-check.md
@@ -195,9 +195,9 @@ submission time.
 
 | Data type | Collected? | Required? | Encrypted in transit? | Deletable? | Purpose |
 | --- | --- | --- | --- | --- | --- |
-| **Email address** | Yes, **only with optional sync** | No | Yes (HTTPS to InstantDB) | Yes — sign out of sync | Account / sync lookup key |
+| **Email address** | Yes, **only with optional sync** | No | Yes (HTTPS to InstantDB) | Yes — via deletion-request email (`$users` record; not removable by the in-app action) | Account / sync lookup key |
 | **User IDs** | The InstantDB user record ID — internal to InstantDB, not exposed to other users | No | Yes | Yes | Sync record key |
-| **Library state** (fiction IDs, reading positions, voice preferences) | Yes, **only with optional sync** | No | Yes | Yes — sign out | App functionality (sync) |
+| **Library state** (fiction IDs, reading positions, voice preferences) | Yes, **only with optional sync** | No | Yes | Yes — in-app **Delete cloud data** (#1248) | App functionality (sync) |
 | Crash / diagnostic data | **No** | — | — | — | We don't collect crash data |
 | Approximate / precise location | **No** | — | — | — | Never requested |
 | Photos / videos / audio | **No** | — | — | — | Camera is used on-device for OCR scan-to-read (#995): images + recognized text are processed by ML Kit on-device and are **never** transmitted, collected, or shared — so "collected" stays **No** even though the CAMERA permission is declared. No microphone access. |
@@ -222,8 +222,15 @@ submission time.
 
 - Data encrypted in transit: **Yes** (all HTTPS, enforced by
   `network_security_config.xml`)
-- Users can request deletion: **Yes** (sign out of sync deletes the
-  record; uninstall deletes on-device data)
+- Users can request deletion: **Yes** — the in-app **Delete cloud data**
+  action (`SyncAuthViewModel.purgeRemoteData`, #1248) deletes every synced
+  domain's remote rows (library, positions, follows, bookmarks, annotations,
+  pronunciation, secrets, settings) via `SyncCoordinator.purgeRemoteData` →
+  admin transact delete. The account email/identity (`$users`) record — which
+  the app can't delete via its own auth token — is removed on request via the
+  privacy-policy email channel. Uninstall clears on-device data. (Note: plain
+  **sign-out** only revokes the token + wipes local state; it does NOT delete
+  the cloud copy — that's deliberate, #1248, so other devices keep syncing.)
 - Independent security review: **Not yet** — JP's call whether to commit
   to this; safe to answer No
 - Follows Families policy guidelines: **No** — we're a 13+ app with a UGC


### PR DESCRIPTION
## #1139 — Data Safety declaration prep

Research + docs only (no code changes).

### Correct the §4 deletion claim (verified in code)
§4 said *"sign out of sync deletes the record."* That's **wrong** — verified:
- `SyncAuthViewModel.signOut()` → `InstantClient.signOut()` POSTs the refresh token to `/runtime/signout` = **token revoke** + local wipe; the cloud copy is **untouched**.
- Real deletion is a **separate explicit in-app "Delete cloud data"** action (`purgeRemoteData`, #1248) → `SyncCoordinator` loops **all 8 syncer domains** → `HttpInstantBackend.delete()` admin transact. Covers library/positions/follows/bookmarks/annotations/pronunciation/secrets/settings.
- The `$users` email/identity record isn't removable via the app's own auth token → relies on the privacy-policy **email-request** backstop.

So *"Users can request deletion = Yes"* is truthful, but on the correct basis. §4 bullet + the Email/Library Deletable cells rewritten accordingly.

### New: `docs/data-safety-checklist.md`
A verified, **copy-paste Play Console Data Safety checklist** organised by wizard section (collection overview · data types · sharing · security practices), plus the deletion-flow verification and **Independent security review = No** for v1.0.

### Follow-ups for JP (in the checklist, non-blocking)
- Confirm the privacy policy lists a real deletion-request email (backstops the `$users` record).
- Pick the Play category for "library state" (App activity → Other UGC vs Other actions).

Note: a sibling untracked file `docs/instantdb-email-template.html` (the deletion/auth email backstop) was already in the tree — left for its author, not included here.

Closes #1139

🤖 Generated with [Claude Code](https://claude.com/claude-code)