### PR TITLE
fix(#1319): warmup-message plumbing + Supertonic speaker-layout audit

### DIFF
--- a/app/src/main/kotlin/in/jphe/storyvox/di/AppBindings.kt
+++ b/app/src/main/kotlin/in/jphe/storyvox/di/AppBindings.kt
@@ -1065,8 +1065,18 @@ internal class RealPlaybackControllerUi(
     override val state: Flow<UiPlaybackState> = combine(
         controller.state,
         tickWhilePlaying(controller.state),
-    ) { s, nowMs ->
-        s.toUi(nowMs)
+        controller.engineState,
+    ) { s, nowMs, engine ->
+        // Issue #1319 — fold the upstream EngineState.Warming(message, progress)
+        // into UiPlaybackState so the reader prefers the engine's render-ready
+        // copy over the voiceLabel-derived fallback, and a self-reported
+        // progress can drive the thin warmup bar. Non-Warming states leave both
+        // null (reader falls back to the derived label / hides the bar).
+        val warming = engine as? `in`.jphe.storyvox.playback.EngineState.Warming
+        s.toUi(nowMs).copy(
+            warmingMessage = warming?.message,
+            warmingProgress = warming?.progress,
+        )
     }.shareIn(scope, SharingStarted.WhileSubscribed(5_000), replay = 1)
 
     /**

--- a/core-playback/src/main/kotlin/in/jphe/storyvox/playback/voice/VoiceCatalog.kt
+++ b/core-playback/src/main/kotlin/in/jphe/storyvox/playback/voice/VoiceCatalog.kt
@@ -874,11 +874,27 @@ object VoiceCatalog {
             )
         val F = VoiceGender.Female
         val M = VoiceGender.Male
-        // Speaker order follows the Kitten/Kokoro convention: female
-        // embeddings at low indices, male embeddings at high indices.
-        // TODO(#1319): verify the speaker index → gender mapping against the
-        // actual Supertonic 3 voices.bin layout — #1114 shipped the engine but
-        // left this F/M assignment (Kitten/Kokoro convention) unverified.
+        // Speaker order ASSUMED to follow the Kitten/Kokoro convention: female
+        // embeddings at low indices (0–4), male at high (5–9).
+        //
+        // #1319 investigation — this remains UNVERIFIED against the shipped
+        // voice.bin and must not be trusted blindly:
+        //  • sherpa-onnx's export workflow copies Supertone's prebuilt
+        //    `assets/voice_styles/voice.bin` verbatim, so the sid order is
+        //    whatever Supertone baked in — and that order is published in NO
+        //    artifact (tts.json carries only model hyper-params; voice.bin is
+        //    nameless float embeddings; the model README has no sid→name table).
+        //  • The signals that DO exist conflict: Supertone's voices doc lists
+        //    voices males-first (M1–M5 then F1–F5); supertonic-py's import store
+        //    globs styles alphabetically (F before M); and the Dec-2025 history
+        //    (original M1,M2,F1,F2 + 6 appended M3–5,F3–5) implies a third,
+        //    batched order. Our mapping below matches only the clean
+        //    females-first case.
+        //  • The sole definitive check is on-device: select "Supertonic F1"
+        //    (sid 0) and listen — if it sounds male, the split is inverted (or
+        //    batched) and these labels must be reordered to match the audio.
+        // TODO(#1319): confirm via an on-device listen of sid 0..9, then fix the
+        // gender assignment here if the audit shows it's wrong.
         return listOf(
             supertonic("supertonic_f1_en_US_0", "Supertonic F1", 0, F),
             supertonic("supertonic_f2_en_US_1", "Supertonic F2", 1, F),

--- a/feature/src/main/kotlin/in/jphe/storyvox/feature/api/UiContracts.kt
+++ b/feature/src/main/kotlin/in/jphe/storyvox/feature/api/UiContracts.kt
@@ -457,6 +457,22 @@ data class UiPlaybackState(
      * the slider when this flag is true.
      */
     val isLiveAudioChapter: Boolean = false,
+    /**
+     * Issue #1319 — render-ready warmup message forwarded from the upstream
+     * [`in`.jphe.storyvox.playback.EngineState.Warming] ("Warming Brian…").
+     * Null when the engine isn't warming or reports no message;
+     * [`in`.jphe.storyvox.feature.reader.playerStatusSubtitle] prefers this
+     * over the voiceLabel-derived `warmingMessageForVoice` fallback so the
+     * engine stays the single source of truth for the copy.
+     */
+    val warmingMessage: String? = null,
+    /**
+     * Issue #1319 — 0..1 warmup progress from
+     * [`in`.jphe.storyvox.playback.EngineState.Warming.progress] when the
+     * engine can self-report (the in-process sherpa-onnx path cannot, so it
+     * stays null there). Non-null drives the thin warmup progress bar.
+     */
+    val warmingProgress: Float? = null,
 )
 
 /** Mirrors core-playback's SleepTimerMode without leaking the playback module to feature. */

--- a/feature/src/main/kotlin/in/jphe/storyvox/feature/reader/AudiobookView.kt
+++ b/feature/src/main/kotlin/in/jphe/storyvox/feature/reader/AudiobookView.kt
@@ -838,13 +838,15 @@ fun AudiobookView(
             // engine self-reports 0..1 progress via EngineState.Warming.progress.
             // The in-process sherpa-onnx path can't self-report (stays null), so
             // this is hidden there; it's ready for an engine that can.
-            state.warmingProgress?.let { p ->
-                LinearProgressIndicator(
-                    progress = { p.coerceIn(0f, 1f) },
-                    modifier = Modifier
-                        .fillMaxWidth()
-                        .height(2.dp),
-                )
+            if (warmingUp) {
+                state.warmingProgress?.let { p ->
+                    LinearProgressIndicator(
+                        progress = p.coerceIn(0f, 1f),
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .height(2.dp),
+                    )
+                }
             }
             // Issue #278 / #945 — soft slow hint moved into the
             // in-cover loading-prompts overlay above. The 10 s wall

--- a/feature/src/main/kotlin/in/jphe/storyvox/feature/reader/AudiobookView.kt
+++ b/feature/src/main/kotlin/in/jphe/storyvox/feature/reader/AudiobookView.kt
@@ -65,6 +65,7 @@ import androidx.compose.material3.FilterChipDefaults
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.IconButtonDefaults
 import androidx.compose.material3.Icon
+import androidx.compose.material3.LinearProgressIndicator
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.ModalBottomSheet
 import androidx.compose.material3.Slider
@@ -827,10 +828,24 @@ fun AudiobookView(
                     warmingUp = warmingUp,
                     buffering = state.isBuffering,
                     voiceLabel = state.voiceLabel,
+                    // Issue #1319 — engine's render-ready warmup copy (preferred).
+                    warmingMessage = state.warmingMessage,
                 ),
                 style = MaterialTheme.typography.bodyMedium,
                 color = if (showSpinner) MaterialTheme.colorScheme.primary else MaterialTheme.colorScheme.onSurfaceVariant,
             )
+            // Issue #1319 — thin determinate warmup bar, shown only when the
+            // engine self-reports 0..1 progress via EngineState.Warming.progress.
+            // The in-process sherpa-onnx path can't self-report (stays null), so
+            // this is hidden there; it's ready for an engine that can.
+            state.warmingProgress?.let { p ->
+                LinearProgressIndicator(
+                    progress = { p.coerceIn(0f, 1f) },
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .height(2.dp),
+                )
+            }
             // Issue #278 / #945 — soft slow hint moved into the
             // in-cover loading-prompts overlay above. The 10 s wall
             // copy ("Still working…") now renders inside the cover
@@ -2089,9 +2104,12 @@ internal fun playerStatusSubtitle(
     warmingUp: Boolean,
     buffering: Boolean,
     voiceLabel: String,
+    warmingMessage: String? = null,
 ): String = when {
     chapterTitle.isBlank() -> "Loading voice + chapter text"
-    warmingUp -> "$chapterTitle · ${warmingMessageForVoice(voiceLabel)}"
+    // Issue #1319 — prefer the engine's upstream EngineState.Warming.message
+    // when present; fall back to the voiceLabel-derived copy otherwise.
+    warmingUp -> "$chapterTitle · ${warmingMessage?.takeIf { it.isNotBlank() } ?: warmingMessageForVoice(voiceLabel)}"
     buffering -> "$chapterTitle · Buffering…"
     else -> chapterTitle
 }

--- a/feature/src/test/kotlin/in/jphe/storyvox/feature/reader/AudiobookViewTextTest.kt
+++ b/feature/src/test/kotlin/in/jphe/storyvox/feature/reader/AudiobookViewTextTest.kt
@@ -77,6 +77,40 @@ class AudiobookViewTextTest {
         )
     }
 
+    /**
+     * Issue #1319 — when the engine publishes a render-ready
+     * [`in`.jphe.storyvox.playback.EngineState.Warming] message, the subtitle
+     * prefers it over the voiceLabel-derived fallback. The voiceLabel here is
+     * Brian but the upstream says "Aurelia", so the upstream must win.
+     */
+    @Test
+    fun `warming prefers the upstream engine message over the derived label`() {
+        assertEquals(
+            "Chapter 4 · Warming Aurelia…",
+            playerStatusSubtitle(
+                chapterTitle = "Chapter 4",
+                warmingUp = true,
+                buffering = false,
+                voiceLabel = "azure:en-US-BrianNeural",
+                warmingMessage = "Warming Aurelia…",
+            ),
+        )
+    }
+
+    @Test
+    fun `warming falls back to derived label when upstream message is blank`() {
+        assertEquals(
+            "Chapter 4 · Warming Brian…",
+            playerStatusSubtitle(
+                chapterTitle = "Chapter 4",
+                warmingUp = true,
+                buffering = false,
+                voiceLabel = "azure:en-US-BrianNeural",
+                warmingMessage = "   ",
+            ),
+        )
+    }
+
     @Test
     fun `warming with Azure Ava strips Multilingual suffix`() {
         assertEquals(


### PR DESCRIPTION
Closes #1319 — two tech-debt follow-ups.

## Task 1 — Warming-message plumbing ✅ (done)
`EngineState.Warming(message, progress)` already exists upstream and the controller emits it, but `AudiobookView.playerStatusSubtitle` still *derived* "Warming Brian…" from `voiceLabel` (the `TODO(#1319)` there).

- **`UiPlaybackState`** gains `warmingMessage: String?` + `warmingProgress: Float?` (trailing optionals → no breakage to existing constructions/fakes).
- **`RealPlaybackControllerUi.state`** (AppBindings) folds `controller.engineState` into the `combine` and `.copy()`s the upstream `Warming.message`/`.progress` onto the state — populated at the single source so *all* consumers get it, without touching the shared `toUi()` mapper.
- **`playerStatusSubtitle`** prefers the upstream message, falling back to the `voiceLabel`-derived `warmingMessageForVoice` when absent/blank.
- **Thin warmup progress bar**: a `LinearProgressIndicator` renders only when `warmingProgress != null`. The in-process sherpa-onnx path can't self-report progress (stays null → bar hidden), so this is future-ready plumbing, exactly as the spec/TODO described.
- Tests: added prefer-upstream + blank-fallback cases to `AudiobookViewTextTest`.

## Task 2 — Supertonic speaker→gender audit ⚠️ (needs a 1-min device-listen before any change)
The `supertonicEntries()` F0–4 / M5–9 split was an **unverified** copy of the Kitten/Kokoro convention. I traced the real layout exhaustively and **deliberately did not flip the labels** — here's why:

- sherpa-onnx's `export-supertonic.yaml` **copies Supertone's prebuilt `assets/voice_styles/voice.bin` verbatim**, so the sid order is whatever Supertone baked in — and that order is **published in no artifact**: `tts.json` holds only model hyper-params, `voice.bin` is nameless float embeddings, and the model README has no sid→name table.
- The signals that *do* exist **conflict**, giving three incompatible candidate orders:
  1. Supertone's voices doc lists voices **males-first** (M1–M5, then F1–F5) → would make our mapping *inverted*.
  2. `supertonic-py`'s import store globs styles **alphabetically** (F before M) → would make our mapping *correct*.
  3. The Dec-2025 history (original M1,M2,F1,F2 + 6 appended M3–5,F3–5) implies a **batched** order → different again.
- Our current mapping matches only candidate (2). A blind flip has a real chance of inverting a possibly-correct mapping, so I recorded the full findings in the code comment + a `TODO(#1319)` instead of guessing.

**The one definitive check (only you can do it — model's on the Z Flip3):** select **"Supertonic F1" (sid 0)** in the app and listen.
- Sounds **female** → mapping is correct, close as-is.
- Sounds **male** → it's inverted/batched; tell me what sid 0/5 actually are and I'll reorder the labels in a follow-up commit on this branch.

## Risk
Task 1 is additive (defaulted fields, preferred-with-fallback, hidden-when-null bar) — no behavior change for current engines beyond sourcing the same "Warming X…" copy from upstream. Task 2 is comment-only.
