### PR TITLE
docs(privacy): drop stale v0.5.x version pin from the backend list

### DIFF
--- a/docs/privacy.md
+++ b/docs/privacy.md
@@ -58,7 +58,7 @@ us to delete it (see _Your rights_ below).
 ### 2.2 Fiction backends (your choice, per backend)
 
 Candela connects to the public APIs and websites of the fiction backends
-you enable. Each is opt-in via Settings → Plugins. The list, in v0.5.x:
+you enable. Each is opt-in via Settings → Plugins. The list currently includes:
 Royal Road, GitHub, RSS, Outline, Memory Palace, Project Gutenberg, AO3,
 Standard Ebooks, Wikipedia, Wikisource, Radio (Radio Browser API),
 Notion, Hacker News, arXiv, PLOS, Discord, Telegram, Palace Project, Slack,


### PR DESCRIPTION
## What
The privacy policy (`docs/privacy.md`) pinned the fiction-backend list to **"in v0.5.x"** — stale at the current v1.4.x line.

## Change
`The list, in v0.5.x:` → `The list currently includes:`

One-line, docs-only. **Genericized rather than re-pinned** to the current version: pinning a concrete version (v1.4.5) would just re-stale on the next release bump (the same docs-restale trap we've hit before). The backend list is illustrative/non-exhaustive ("and a few dozen more" appears just above), so "currently includes" reads correctly without version churn.

## Verification
The policy is otherwise current and Play-ready (verified against the actual manifest permissions in the privacy-policy audit). No other stale version refs in the file. No code touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)