### PR TITLE
fix(reader): use current LinearProgressIndicator lambda overload

### DIFF
--- a/feature/src/main/kotlin/in/jphe/storyvox/feature/reader/AudiobookView.kt
+++ b/feature/src/main/kotlin/in/jphe/storyvox/feature/reader/AudiobookView.kt
@@ -841,7 +841,7 @@ fun AudiobookView(
             if (warmingUp) {
                 state.warmingProgress?.let { p ->
                     LinearProgressIndicator(
-                        progress = p.coerceIn(0f, 1f),
+                        progress = { p.coerceIn(0f, 1f) },
                         modifier = Modifier
                             .fillMaxWidth()
                             .height(2.dp),


### PR DESCRIPTION
Follow-up to #1353. The #1319 Gemini-review fix changed the warmup bar's `progress` arg to the bare `progress: Float` overload, which Material3 **deprecated in 1.2** in favour of `progress: () -> Float`. This reverts that one line to the lambda form:

```diff
-                        progress = p.coerceIn(0f, 1f),
+                        progress = { p.coerceIn(0f, 1f) },
```

- It's the **non-deprecated** API and matches the existing usage in `NowPlayingDock.kt:237`.
- Keeps the `if (warmingUp)` gating added in the same #1319 follow-up.
- No behavior change (the bar still renders identically when `warmingProgress` is non-null) — this just removes the deprecation warning + restores codebase consistency.