### PR TITLE
docs(play-store): sync live short-description to canonical wording

### DIFF
--- a/app/src/main/play/listings/en-US/short-description.txt
+++ b/app/src/main/play/listings/en-US/short-description.txt
@@ -1,1 +1,1 @@
-Listen to free books, guides, and the web — read aloud by beautiful voices.
+Free books, tech guides, and the web — read aloud by on-device voices.


### PR DESCRIPTION
## Summary
Resolves **M3** (the last open Play Store listing-copy item): the live upload `short-description.txt` and the docs canonical had diverged in wording. Syncs the live copy to the canonical.

## Change (1 file)
`app/src/main/play/listings/en-US/short-description.txt`:
- before: `Listen to free books, guides, and the web — read aloud by beautiful voices.` (75)
- after: `Free books, tech guides, and the web — read aloud by on-device voices.` (70)

Picks the canonical wording — "tech guides" (TechEmpower nod) + "on-device" (the real differentiator) — so live ↔ docs match. Both ≤80, so this was never an upload blocker, just consistency.

Context: lucid-1229 handed this off after #1362 merged (short-desc is the listing-copy lane). All hard blockers already on main via #1361/#1362.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
