### PR TITLE
feat(reader): AI script writer for the teleprompter (#1366)

### DIFF
--- a/feature/src/main/kotlin/in/jphe/storyvox/feature/reader/HybridReaderScreen.kt
+++ b/feature/src/main/kotlin/in/jphe/storyvox/feature/reader/HybridReaderScreen.kt
@@ -30,6 +30,7 @@ import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import `in`.jphe.storyvox.feature.R
 import `in`.jphe.storyvox.feature.debug.DebugOverlay
 import `in`.jphe.storyvox.feature.debug.DebugViewModel
+import `in`.jphe.storyvox.feature.reader.script.ScriptGeneratorSheet
 import `in`.jphe.storyvox.ui.component.BrassButton
 import `in`.jphe.storyvox.ui.component.BrassButtonVariant
 import `in`.jphe.storyvox.ui.component.HybridReaderShell
@@ -114,6 +115,10 @@ fun HybridReaderScreen(
     val teleprompterEnabled by viewModel.teleprompterEnabled.collectAsStateWithLifecycle()
     val teleprompterPlaying by viewModel.teleprompterPlaying.collectAsStateWithLifecycle()
     val teleprompterWpm by viewModel.teleprompterWpm.collectAsStateWithLifecycle()
+    // Issue #1366 — AI script-writer sheet, opened from the teleprompter
+    // transport's "Write a script" button. Hosted here (not in ReaderTextView)
+    // so it can reach the Settings → AI nav for the unconfigured-provider path.
+    var scriptSheetOpen by remember { mutableStateOf(false) }
     val playback = state.playback
 
     // Chapter-completion celebration. The VM's confettiTrigger fires
@@ -419,6 +424,8 @@ fun HybridReaderScreen(
                 onSetTeleprompterPlaying = viewModel::setTeleprompterPlaying,
                 onSetTeleprompterWpm = viewModel::setTeleprompterWpm,
                 onResetTeleprompter = viewModel::resetTeleprompter,
+                // Issue #1366 — open the AI script-writer sheet (hosted below).
+                onWriteScript = { scriptSheetOpen = true },
             )
         },
     )
@@ -435,6 +442,20 @@ fun HybridReaderScreen(
         onResultClick = viewModel::openBookSearchResult,
         onClose = viewModel::closeBookSearch,
     )
+
+    // Issue #1366 — AI script writer. Self-gated so its own
+    // ModalBottomSheet state machine only spins up while open; the
+    // unconfigured-provider error routes to Settings → AI via the same
+    // nav the recap modal uses.
+    if (scriptSheetOpen) {
+        ScriptGeneratorSheet(
+            onDismiss = { scriptSheetOpen = false },
+            onOpenAiSettings = {
+                scriptSheetOpen = false
+                onOpenAiSettings()
+            },
+        )
+    }
 
     // Recap modal — overlays everything when not Hidden. Driven by
     // ReaderViewModel.requestRecap().

--- a/feature/src/main/kotlin/in/jphe/storyvox/feature/reader/ReaderView.kt
+++ b/feature/src/main/kotlin/in/jphe/storyvox/feature/reader/ReaderView.kt
@@ -331,6 +331,11 @@ fun ReaderTextView(
      *  composition (→ [ReaderViewModel.resetTeleprompter]). Preserves #1239's
      *  per-visit-transient behavior against the @Singleton controller. */
     onResetTeleprompter: () -> Unit = {},
+    /** Issue #1366 — open the AI script-writer sheet from the teleprompter
+     *  transport. Hosted by [HybridReaderScreen] (which owns the nav to
+     *  Settings → AI for the unconfigured-provider path); the no-op default
+     *  keeps preview / test / audiobook callsites unchanged. */
+    onWriteScript: () -> Unit = {},
     modifier: Modifier = Modifier,
 ) {
     val spacing = LocalSpacing.current
@@ -1098,6 +1103,7 @@ fun ReaderTextView(
                             onSetTeleprompterPlaying(false)
                             onSetTeleprompterEnabled(false)
                         },
+                        onWriteScript = onWriteScript,
                     )
                     TeleprompterMode.Practice -> PracticeTransport(
                         playing = state.isPlaying,
@@ -1240,6 +1246,7 @@ private fun TeleprompterTransport(
     onPlayPause: () -> Unit,
     onWpmDelta: (Int) -> Unit,
     onExit: () -> Unit,
+    onWriteScript: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
     val spacing = LocalSpacing.current
@@ -1257,6 +1264,15 @@ private fun TeleprompterTransport(
                 modifier = Modifier.semantics { contentDescription = "Exit teleprompter" },
             ) {
                 Icon(imageVector = Icons.Filled.Close, contentDescription = null)
+            }
+            // Issue #1366 — AI script writer entry point. Opens the
+            // ScriptGeneratorSheet (hosted by HybridReaderScreen) so a user
+            // rehearsing can generate fresh teleprompter copy on the spot.
+            IconButton(
+                onClick = onWriteScript,
+                modifier = Modifier.semantics { contentDescription = "Write a script" },
+            ) {
+                Icon(imageVector = Icons.Outlined.AutoAwesome, contentDescription = null)
             }
             Spacer(modifier = Modifier.weight(1f))
             IconButton(

--- a/feature/src/main/kotlin/in/jphe/storyvox/feature/reader/script/ScriptDraftStore.kt
+++ b/feature/src/main/kotlin/in/jphe/storyvox/feature/reader/script/ScriptDraftStore.kt
@@ -1,0 +1,47 @@
+package `in`.jphe.storyvox.feature.reader.script
+
+import javax.inject.Inject
+import javax.inject.Singleton
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+
+/**
+ * Issue #1366 — the hand-off seam between the AI script writer and the
+ * reader's teleprompter.
+ *
+ * The generator is a screen-scoped ViewModel; the teleprompter consumer is
+ * the reader composition (and, later, #1368's voice-paced teleprompter).
+ * They live in different scopes and can't share Compose state directly, so
+ * the finished script is parked here in a `@Singleton` — exactly the shape
+ * [`in`.jphe.storyvox.playback.TeleprompterController] uses to hoist the
+ * transport controls so both the phone reader and the Wear bridge can reach
+ * them.
+ *
+ * ## Scope (v1 — the producer half)
+ * [ScriptGeneratorViewModel.loadIntoTeleprompter] writes [activeScript] and
+ * flips the teleprompter transport on. Rendering the parked script *as* the
+ * teleprompter's scroll content is the integration follow-up: it touches the
+ * reader's shared text / TTS / highlight path (also owned by #1368), so it's
+ * deliberately kept out of this one-button change. Consumers observe
+ * [activeScript] and call [clear] once they've taken ownership.
+ */
+@Singleton
+class ScriptDraftStore @Inject constructor() {
+
+    private val _activeScript = MutableStateFlow<String?>(null)
+
+    /** The script most recently loaded for teleprompter rehearsal, or null
+     *  when none is pending. */
+    val activeScript: StateFlow<String?> = _activeScript.asStateFlow()
+
+    /** Park [script] for the reader to pick up. */
+    fun load(script: String) {
+        _activeScript.value = script
+    }
+
+    /** Drop the pending script once a consumer has taken it (or on reset). */
+    fun clear() {
+        _activeScript.value = null
+    }
+}

--- a/feature/src/main/kotlin/in/jphe/storyvox/feature/reader/script/ScriptGeneratorSheet.kt
+++ b/feature/src/main/kotlin/in/jphe/storyvox/feature/reader/script/ScriptGeneratorSheet.kt
@@ -99,7 +99,7 @@ fun ScriptGeneratorSheet(
                 )
             }
             Text(
-                "Generate a teleprompter-ready script for a short video.",
+                "Generate a teleprompter-ready script — speaker labels, short lines, and cue marks.",
                 style = MaterialTheme.typography.bodyMedium,
                 color = MaterialTheme.colorScheme.onSurfaceVariant,
             )

--- a/feature/src/main/kotlin/in/jphe/storyvox/feature/reader/script/ScriptGeneratorSheet.kt
+++ b/feature/src/main/kotlin/in/jphe/storyvox/feature/reader/script/ScriptGeneratorSheet.kt
@@ -1,0 +1,290 @@
+package `in`.jphe.storyvox.feature.reader.script
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.heightIn
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.outlined.AutoAwesome
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.FilterChip
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.ModalBottomSheet
+import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.material3.rememberModalBottomSheetState
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.saveable.rememberSaveable
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.dp
+import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import `in`.jphe.storyvox.ui.component.BrassButton
+import `in`.jphe.storyvox.ui.component.BrassButtonVariant
+import `in`.jphe.storyvox.ui.theme.LocalSpacing
+
+/**
+ * Issue #1366 — AI script writer bottom sheet. Opened from the teleprompter
+ * transport's "Write a script" button; a lightweight sheet rather than a full
+ * screen so it overlays the reader the user is already standing in.
+ *
+ * Topic field + length chips → Generate. Tokens stream into a preview as they
+ * arrive; the finished script can be regenerated, hand-edited, then loaded
+ * into the teleprompter. An unconfigured-provider error routes to Settings →
+ * AI via [onOpenAiSettings] (the same nav the recap surface uses, #152).
+ *
+ * The ViewModel is screen-scoped (resolved from the reader's
+ * `NavBackStackEntry`), so a freshly generated script survives an accidental
+ * dismiss + reopen while the reader is up.
+ */
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun ScriptGeneratorSheet(
+    onDismiss: () -> Unit,
+    onOpenAiSettings: () -> Unit = {},
+    viewModel: ScriptGeneratorViewModel = hiltViewModel(),
+) {
+    val state by viewModel.state.collectAsStateWithLifecycle()
+    val sheetState = rememberModalBottomSheetState(skipPartiallyExpanded = true)
+    val spacing = LocalSpacing.current
+
+    var topic by rememberSaveable { mutableStateOf("") }
+    var durationSecs by rememberSaveable {
+        mutableStateOf(ScriptGeneratorViewModel.DEFAULT_DURATION_SECS)
+    }
+    // Inline edit of the finished script. `editText` seeds from the Done
+    // script when Edit is tapped; committing writes it back through the VM.
+    var editing by rememberSaveable { mutableStateOf(false) }
+    var editText by rememberSaveable { mutableStateOf("") }
+
+    val generating = state is ScriptGeneratorState.Generating
+
+    ModalBottomSheet(
+        onDismissRequest = onDismiss,
+        sheetState = sheetState,
+        containerColor = MaterialTheme.colorScheme.surfaceContainerHigh,
+    ) {
+        Column(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(horizontal = spacing.lg)
+                .padding(bottom = spacing.xl),
+            verticalArrangement = Arrangement.spacedBy(spacing.sm),
+        ) {
+            Row(
+                verticalAlignment = Alignment.CenterVertically,
+                horizontalArrangement = Arrangement.spacedBy(spacing.sm),
+                modifier = Modifier.padding(top = spacing.sm),
+            ) {
+                Icon(
+                    imageVector = Icons.Outlined.AutoAwesome,
+                    contentDescription = null,
+                    tint = MaterialTheme.colorScheme.primary,
+                )
+                Text(
+                    "Write a script",
+                    style = MaterialTheme.typography.titleLarge,
+                )
+            }
+            Text(
+                "Generate a teleprompter-ready script for a short video.",
+                style = MaterialTheme.typography.bodyMedium,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
+
+            OutlinedTextField(
+                value = topic,
+                onValueChange = { topic = it },
+                label = { Text("Topic") },
+                placeholder = { Text("e.g., Why accessibility matters in 60 seconds") },
+                enabled = !generating,
+                maxLines = 3,
+                modifier = Modifier.fillMaxWidth(),
+            )
+
+            Text(
+                "Length",
+                style = MaterialTheme.typography.labelLarge,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                horizontalArrangement = Arrangement.spacedBy(spacing.sm),
+            ) {
+                SCRIPT_DURATION_OPTIONS.forEach { secs ->
+                    FilterChip(
+                        selected = durationSecs == secs,
+                        onClick = { durationSecs = secs },
+                        enabled = !generating,
+                        label = { Text("${secs}s") },
+                    )
+                }
+            }
+
+            BrassButton(
+                label = when {
+                    generating -> "Generating…"
+                    state is ScriptGeneratorState.Done -> "Regenerate"
+                    else -> "Generate"
+                },
+                onClick = {
+                    editing = false
+                    viewModel.generateScript(topic, durationSecs)
+                },
+                variant = BrassButtonVariant.Primary,
+                enabled = !generating && topic.isNotBlank(),
+                loading = generating,
+                modifier = Modifier.fillMaxWidth(),
+            )
+
+            when (val s = state) {
+                is ScriptGeneratorState.Idle -> Unit
+
+                is ScriptGeneratorState.Generating -> {
+                    ScriptPreview(text = s.partial, placeholder = "Writing…")
+                    StatsRow(text = s.partial, viewModel = viewModel)
+                    TextButton(
+                        onClick = viewModel::stop,
+                        modifier = Modifier.align(Alignment.End),
+                    ) {
+                        Text("Stop")
+                    }
+                }
+
+                is ScriptGeneratorState.Done -> {
+                    if (editing) {
+                        OutlinedTextField(
+                            value = editText,
+                            onValueChange = { editText = it },
+                            label = { Text("Edit script") },
+                            modifier = Modifier
+                                .fillMaxWidth()
+                                .heightIn(min = 120.dp, max = 280.dp),
+                        )
+                    } else {
+                        ScriptPreview(text = s.script, placeholder = "")
+                    }
+                    StatsRow(text = if (editing) editText else s.script, viewModel = viewModel)
+
+                    Row(
+                        modifier = Modifier.fillMaxWidth(),
+                        horizontalArrangement = Arrangement.spacedBy(spacing.sm),
+                    ) {
+                        if (editing) {
+                            BrassButton(
+                                label = "Done editing",
+                                onClick = {
+                                    viewModel.setScript(editText.trim())
+                                    editing = false
+                                },
+                                variant = BrassButtonVariant.Secondary,
+                                enabled = editText.isNotBlank(),
+                            )
+                        } else {
+                            BrassButton(
+                                label = "Edit",
+                                onClick = {
+                                    editText = s.script
+                                    editing = true
+                                },
+                                variant = BrassButtonVariant.Secondary,
+                            )
+                        }
+                    }
+
+                    BrassButton(
+                        label = "Load into Teleprompter",
+                        onClick = {
+                            if (editing) {
+                                viewModel.setScript(editText.trim())
+                                editing = false
+                            }
+                            viewModel.loadIntoTeleprompter()
+                            onDismiss()
+                        },
+                        variant = BrassButtonVariant.Primary,
+                        enabled = (if (editing) editText else s.script).isNotBlank(),
+                        modifier = Modifier.fillMaxWidth(),
+                    )
+                }
+
+                is ScriptGeneratorState.Error -> {
+                    Text(
+                        s.message,
+                        style = MaterialTheme.typography.bodyMedium,
+                        color = MaterialTheme.colorScheme.error,
+                    )
+                    if (s.routeToSettings) {
+                        BrassButton(
+                            label = "Open AI settings",
+                            onClick = onOpenAiSettings,
+                            variant = BrassButtonVariant.Secondary,
+                        )
+                    }
+                }
+            }
+        }
+    }
+}
+
+/**
+ * Read-only, scrollable rendering of the (streaming or finished) script,
+ * capped so a long script scrolls inside the sheet instead of pushing the
+ * action buttons off-screen.
+ */
+@Composable
+private fun ScriptPreview(
+    text: String,
+    placeholder: String,
+) {
+    val spacing = LocalSpacing.current
+    Surface(
+        color = MaterialTheme.colorScheme.surfaceContainerLow,
+        shape = MaterialTheme.shapes.medium,
+        modifier = Modifier.fillMaxWidth(),
+    ) {
+        Text(
+            text = text.ifBlank { placeholder },
+            style = MaterialTheme.typography.bodyLarge,
+            color = if (text.isBlank()) {
+                MaterialTheme.colorScheme.onSurfaceVariant
+            } else {
+                MaterialTheme.colorScheme.onSurface
+            },
+            modifier = Modifier
+                .fillMaxWidth()
+                .heightIn(min = 80.dp, max = 280.dp)
+                .verticalScroll(rememberScrollState())
+                .padding(spacing.md),
+        )
+    }
+}
+
+/** Word count + estimated spoken duration for [text]. */
+@Composable
+private fun StatsRow(
+    text: String,
+    viewModel: ScriptGeneratorViewModel,
+) {
+    val words = viewModel.wordCount(text)
+    val secs = viewModel.estimatedDuration(text)
+    Text(
+        text = "$words words · ~${secs}s",
+        style = MaterialTheme.typography.labelMedium,
+        color = MaterialTheme.colorScheme.onSurfaceVariant,
+        maxLines = 1,
+        overflow = TextOverflow.Ellipsis,
+    )
+}

--- a/feature/src/main/kotlin/in/jphe/storyvox/feature/reader/script/ScriptGeneratorState.kt
+++ b/feature/src/main/kotlin/in/jphe/storyvox/feature/reader/script/ScriptGeneratorState.kt
@@ -1,0 +1,43 @@
+package `in`.jphe.storyvox.feature.reader.script
+
+import androidx.compose.runtime.Immutable
+
+/**
+ * Issue #1366 — UI state for the AI script writer sheet.
+ *
+ * One flow, four resting states: the topic awaits input ([Idle]), a
+ * generation streams in ([Generating] carries the text so far so the sheet
+ * can render tokens as they arrive), a finished or user-edited script is
+ * ready to rehearse ([Done]), or something went wrong ([Error]).
+ *
+ * [Done] also covers a *stopped* generation (the user tapped Stop with
+ * partial text) and an *edited* script — both are "a script the user can
+ * load", so they share the one terminal state rather than multiplying
+ * cases the UI would treat identically.
+ */
+@Immutable
+sealed interface ScriptGeneratorState {
+
+    /** Nothing generated yet — the topic field + length picker await input. */
+    data object Idle : ScriptGeneratorState
+
+    /** A generation is in flight; [partial] is the text streamed so far. */
+    @Immutable
+    data class Generating(val partial: String) : ScriptGeneratorState
+
+    /** A finished (or stopped, or hand-edited) script ready to load. */
+    @Immutable
+    data class Done(val script: String) : ScriptGeneratorState
+
+    /**
+     * Generation failed. [routeToSettings] is true when the cause was an
+     * unconfigured / disabled / mis-keyed provider, so the sheet offers an
+     * "Open AI settings" CTA instead of a bare retry — mirroring the recap
+     * surface's NotConfigured handling (#152).
+     */
+    @Immutable
+    data class Error(
+        val message: String,
+        val routeToSettings: Boolean = false,
+    ) : ScriptGeneratorState
+}

--- a/feature/src/main/kotlin/in/jphe/storyvox/feature/reader/script/ScriptGeneratorViewModel.kt
+++ b/feature/src/main/kotlin/in/jphe/storyvox/feature/reader/script/ScriptGeneratorViewModel.kt
@@ -178,13 +178,32 @@ internal val SCRIPT_DURATION_OPTIONS: List<Int> = listOf(30, 60, 90)
 
 private val WHITESPACE = Regex("\\s+")
 
+// The teleprompter format (matching the TechEmpower Show scripts) carries
+// non-spoken scaffolding: `[cue]` blocks, `=====` section-banner rules, and
+// leading `SPEAKER:` labels. None of it is read aloud, so it must not inflate
+// the spoken-duration estimate. Banner *title* lines (ALL-CAPS, no `=`) are a
+// known, accepted exception — detecting them needs block parsing we don't do.
+private val CUE_SPAN = Regex("\\[[^\\]]*\\]")
+private val BANNER_RULE = Regex("(?m)^\\s*=+\\s*$")
+private val SPEAKER_LABEL = Regex("(?m)^\\s*[A-Z][A-Z0-9 .'’&/-]{0,30}:")
+
 /** Target word count for [durationSecs] of speech at [wpm]. */
 internal fun targetWordCount(durationSecs: Int, wpm: Int = SCRIPT_WPM): Int =
     if (durationSecs <= 0 || wpm <= 0) 0 else (durationSecs * wpm) / 60
 
-/** Whitespace-delimited word count; blank text is zero words. */
-internal fun scriptWordCount(text: String): Int =
-    if (text.isBlank()) 0 else text.trim().split(WHITESPACE).size
+/** Strip non-spoken scaffolding — `[cues]`, `=====` banner rules, and leading
+ *  `SPEAKER:` labels — leaving just what a presenter reads aloud. */
+internal fun spokenText(raw: String): String =
+    raw
+        .replace(CUE_SPAN, " ")
+        .replace(BANNER_RULE, " ")
+        .replace(SPEAKER_LABEL, " ")
+
+/** Spoken-word count (scaffolding stripped); blank text is zero words. */
+internal fun scriptWordCount(text: String): Int {
+    val spoken = spokenText(text).trim()
+    return if (spoken.isEmpty()) 0 else spoken.split(WHITESPACE).size
+}
 
 /** Estimated spoken duration of [text] in whole seconds at [wpm]. */
 internal fun estimatedDurationSecs(text: String, wpm: Int = SCRIPT_WPM): Int =
@@ -194,26 +213,44 @@ internal fun estimatedDurationSecs(text: String, wpm: Int = SCRIPT_WPM): Int =
  * The teleprompter-script system prompt (#1366). Short and explicit, like
  * ChapterRecap's librarian persona — interpolates the duration + word-count
  * target so the model paces to length.
+ *
+ * The output format mirrors the TechEmpower Show teleprompter scripts so a
+ * generated script renders cleanly in the same prompter: blocks split by blank
+ * lines, `SPEAKER:` labels, `[bracketed]` production cues, and optional `===`
+ * section banners. (Reference: techempower/show/ep2/teleprompter.html.)
  */
 internal fun buildScriptSystemPrompt(durationSecs: Int, wpm: Int = SCRIPT_WPM): String {
     val words = targetWordCount(durationSecs, wpm)
     return """
-        You are a script writer for short-form video (YouTube Shorts, TikTok, Reels).
-        Write a teleprompter-ready script for the given topic and target duration.
-        Rules:
-        - Write in a conversational, direct tone — as if speaking to the camera
-        - Open with a hook (question, bold claim, or surprising fact) in the first 5 words
-        - Use short sentences (8-12 words max)
-        - Include natural pause markers: "..." for beats, "[pause]" for 1-second breaks
-        - Target ${durationSecs}s at $wpm words per minute ($words words)
-        - End with a clear call-to-action or memorable closing line
-        - No stage directions, no "(smiles)", no camera instructions
-        - Output the script text only, no headers or meta-commentary
+        You are a script writer for short-form video (YouTube Shorts, TikTok, Reels),
+        writing for a teleprompter. Write a script for the given topic and duration.
+
+        Format it so it renders cleanly in the teleprompter:
+        - Separate every block with a blank line.
+        - Begin each spoken block with a SPEAKER label in capitals on its own line,
+          ending in a colon (for example "HOST:"). Use one speaker for a solo piece;
+          add a second named speaker only when the topic is a conversation.
+        - Put production cues — cuts, b-roll, on-screen text, post notes — in [SQUARE
+          BRACKETS], on their own line or inline. Cues are never spoken aloud.
+        - For a longer piece you may add a section banner as its own block: a line of
+          ===, a short ALL-CAPS title, then another line of ===.
+
+        Write to be spoken:
+        - Conversational, direct tone — as if speaking to the camera.
+        - Open with a hook (a question, bold claim, or surprising fact) in the first
+          five words.
+        - Keep sentences short — 8 to 12 words.
+        - Spell out numbers, prices, and web addresses as spoken words, not digits.
+        - Pace for about ${durationSecs}s at $wpm words per minute (~$words spoken words). Labels and cues do not count toward that.
+        - End with a clear call-to-action or a memorable closing line.
+        - Output only the script — no preamble, no explanation, no markdown.
     """.trimIndent()
 }
 
 /** The per-request user prompt carrying the topic + length target. */
 internal fun buildScriptUserPrompt(topic: String, durationSecs: Int, wpm: Int = SCRIPT_WPM): String {
     val words = targetWordCount(durationSecs, wpm)
-    return "Topic: ${topic.trim()}\nTarget: about $durationSecs seconds (~$words words).\nWrite the script."
+    return "Topic: ${topic.trim()}\n" +
+        "Target: about $durationSecs seconds (~$words spoken words).\n" +
+        "Write the script now, in the teleprompter format described."
 }

--- a/feature/src/main/kotlin/in/jphe/storyvox/feature/reader/script/ScriptGeneratorViewModel.kt
+++ b/feature/src/main/kotlin/in/jphe/storyvox/feature/reader/script/ScriptGeneratorViewModel.kt
@@ -1,0 +1,219 @@
+package `in`.jphe.storyvox.feature.reader.script
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import dagger.hilt.android.lifecycle.HiltViewModel
+import `in`.jphe.storyvox.llm.LlmConfig
+import `in`.jphe.storyvox.llm.LlmError
+import `in`.jphe.storyvox.llm.LlmMessage
+import `in`.jphe.storyvox.llm.LlmRepository
+import `in`.jphe.storyvox.playback.TeleprompterController
+import javax.inject.Inject
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.catch
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.flow.onCompletion
+import kotlinx.coroutines.launch
+
+/**
+ * Issue #1366 — AI script writer for the teleprompter.
+ *
+ * Streams a short-form video script for a topic + target duration through
+ * the active LLM provider, following the same `LlmRepository.stream()` shape
+ * as [`in`.jphe.storyvox.llm.feature.ChapterRecap]: build a system prompt +
+ * user prompt, collect the `Flow<String>` of deltas, accumulate. The pace
+ * knobs (system prompt, word-count target, duration estimate) are pulled out
+ * into pure top-level helpers below so they're unit-testable without Hilt,
+ * coroutines, or a live provider.
+ *
+ * The finished script is handed to the teleprompter via [ScriptDraftStore]
+ * (the cross-scope seam) plus [TeleprompterController.setEnabled] — see
+ * [loadIntoTeleprompter].
+ */
+@HiltViewModel
+class ScriptGeneratorViewModel @Inject constructor(
+    private val llm: LlmRepository,
+    private val configFlow: Flow<LlmConfig>,
+    private val teleprompter: TeleprompterController,
+    private val draftStore: ScriptDraftStore,
+) : ViewModel() {
+
+    private val _state = MutableStateFlow<ScriptGeneratorState>(ScriptGeneratorState.Idle)
+    val state: StateFlow<ScriptGeneratorState> = _state.asStateFlow()
+
+    /** The in-flight generation, cancelled cooperatively on Regenerate /
+     *  Stop so a replaced stream can't keep writing state. */
+    private var genJob: Job? = null
+
+    /**
+     * Stream a script for [topic] at the given [durationSecs] target. A new
+     * call cancels any in-flight generation. Blank topics are ignored (the
+     * sheet also disables the button). Emits [ScriptGeneratorState.Generating]
+     * as tokens arrive, then [ScriptGeneratorState.Done], or
+     * [ScriptGeneratorState.Error] on failure.
+     */
+    fun generateScript(topic: String, durationSecs: Int = DEFAULT_DURATION_SECS) {
+        val trimmed = topic.trim()
+        if (trimmed.isEmpty()) return
+
+        genJob?.cancel()
+        val buf = StringBuilder()
+        _state.value = ScriptGeneratorState.Generating("")
+        genJob = viewModelScope.launch {
+            // Up-front config check gives a clean "route to Settings" path
+            // without flashing a doomed Generating state through the wire
+            // (mirrors ChapterRecap's pre-stream guard). `llm.stream` would
+            // also throw NotConfigured — handled in [mapError] as a backstop.
+            val cfg = configFlow.first()
+            if (cfg.provider == null) {
+                _state.value = notConfiguredError()
+                return@launch
+            }
+            llm.stream(
+                messages = listOf(
+                    LlmMessage(LlmMessage.Role.user, buildScriptUserPrompt(trimmed, durationSecs)),
+                ),
+                systemPrompt = buildScriptSystemPrompt(durationSecs),
+            )
+                .catch { e -> _state.value = mapError(e) }
+                .onCompletion { cause ->
+                    // Only a clean completion finalises, and only if we're
+                    // still Generating — a `.catch` that set Error, or a
+                    // Stop() that already wrote Done, must not be clobbered
+                    // by the normal-completion path (catch swallows the
+                    // throwable, so the flow then completes with cause=null).
+                    if (cause == null && _state.value is ScriptGeneratorState.Generating) {
+                        _state.value = ScriptGeneratorState.Done(buf.toString().trim())
+                    }
+                }
+                .collect { delta ->
+                    buf.append(delta)
+                    _state.value = ScriptGeneratorState.Generating(buf.toString())
+                }
+        }
+    }
+
+    /**
+     * Stop an in-flight generation, keeping whatever streamed so far as a
+     * [ScriptGeneratorState.Done] the user can still load or edit. Falls back
+     * to [ScriptGeneratorState.Idle] when nothing usable arrived yet.
+     */
+    fun stop() {
+        val current = _state.value
+        genJob?.cancel()
+        genJob = null
+        if (current is ScriptGeneratorState.Generating) {
+            val partial = current.partial.trim()
+            _state.value =
+                if (partial.isEmpty()) ScriptGeneratorState.Idle
+                else ScriptGeneratorState.Done(partial)
+        }
+    }
+
+    /** Replace the working script with a user-edited version. */
+    fun setScript(text: String) {
+        _state.value = ScriptGeneratorState.Done(text)
+    }
+
+    /**
+     * Hand the finished script to the teleprompter: park it in
+     * [ScriptDraftStore] for the reader to pick up and flip the transport on.
+     * No-op unless a non-blank [ScriptGeneratorState.Done] script is ready.
+     */
+    fun loadIntoTeleprompter() {
+        val script = (_state.value as? ScriptGeneratorState.Done)?.script?.trim().orEmpty()
+        if (script.isEmpty()) return
+        draftStore.load(script)
+        teleprompter.setEnabled(true)
+    }
+
+    /** Estimated spoken duration of [text] in whole seconds at [wpm]. */
+    fun estimatedDuration(text: String, wpm: Int = SCRIPT_WPM): Int =
+        estimatedDurationSecs(text, wpm)
+
+    /** Whitespace-delimited word count of [text]. */
+    fun wordCount(text: String): Int = scriptWordCount(text)
+
+    private fun mapError(e: Throwable): ScriptGeneratorState.Error = when (e) {
+        is LlmError.NotConfigured -> notConfiguredError()
+        is LlmError.AuthFailed -> ScriptGeneratorState.Error(
+            "${e.provider} key is invalid — check Settings → AI.",
+            routeToSettings = true,
+        )
+        is LlmError.Transport -> ScriptGeneratorState.Error(
+            "Couldn't reach the AI — check your connection and try again.",
+        )
+        is LlmError.ProviderError -> ScriptGeneratorState.Error(
+            "AI service error (${e.status}). Try again in a moment.",
+        )
+        else -> ScriptGeneratorState.Error(e.message ?: "Generation failed.")
+    }
+
+    private fun notConfiguredError() = ScriptGeneratorState.Error(
+        "AI isn't set up yet. Choose a provider in Settings → AI.",
+        routeToSettings = true,
+    )
+
+    companion object {
+        const val DEFAULT_DURATION_SECS: Int = 60
+    }
+}
+
+// ── Pure helpers (unit-tested in ScriptGeneratorLogicTest) ──────────────────
+
+/**
+ * Standard short-form speaking pace (words/min). Used for both the generation
+ * word-count target and the duration estimate so the sheet's "~Ns" readout
+ * matches what we asked the model to write. The teleprompter's *scroll* pace
+ * is a separate, user-adjustable knob ([TeleprompterController.wpm]).
+ */
+internal const val SCRIPT_WPM: Int = 150
+
+/** Duration presets offered as chips in the sheet (seconds). */
+internal val SCRIPT_DURATION_OPTIONS: List<Int> = listOf(30, 60, 90)
+
+private val WHITESPACE = Regex("\\s+")
+
+/** Target word count for [durationSecs] of speech at [wpm]. */
+internal fun targetWordCount(durationSecs: Int, wpm: Int = SCRIPT_WPM): Int =
+    if (durationSecs <= 0 || wpm <= 0) 0 else (durationSecs * wpm) / 60
+
+/** Whitespace-delimited word count; blank text is zero words. */
+internal fun scriptWordCount(text: String): Int =
+    if (text.isBlank()) 0 else text.trim().split(WHITESPACE).size
+
+/** Estimated spoken duration of [text] in whole seconds at [wpm]. */
+internal fun estimatedDurationSecs(text: String, wpm: Int = SCRIPT_WPM): Int =
+    if (wpm <= 0) 0 else Math.round(scriptWordCount(text) * 60.0 / wpm).toInt()
+
+/**
+ * The teleprompter-script system prompt (#1366). Short and explicit, like
+ * ChapterRecap's librarian persona — interpolates the duration + word-count
+ * target so the model paces to length.
+ */
+internal fun buildScriptSystemPrompt(durationSecs: Int, wpm: Int = SCRIPT_WPM): String {
+    val words = targetWordCount(durationSecs, wpm)
+    return """
+        You are a script writer for short-form video (YouTube Shorts, TikTok, Reels).
+        Write a teleprompter-ready script for the given topic and target duration.
+        Rules:
+        - Write in a conversational, direct tone — as if speaking to the camera
+        - Open with a hook (question, bold claim, or surprising fact) in the first 5 words
+        - Use short sentences (8-12 words max)
+        - Include natural pause markers: "..." for beats, "[pause]" for 1-second breaks
+        - Target ${durationSecs}s at $wpm words per minute ($words words)
+        - End with a clear call-to-action or memorable closing line
+        - No stage directions, no "(smiles)", no camera instructions
+        - Output the script text only, no headers or meta-commentary
+    """.trimIndent()
+}
+
+/** The per-request user prompt carrying the topic + length target. */
+internal fun buildScriptUserPrompt(topic: String, durationSecs: Int, wpm: Int = SCRIPT_WPM): String {
+    val words = targetWordCount(durationSecs, wpm)
+    return "Topic: ${topic.trim()}\nTarget: about $durationSecs seconds (~$words words).\nWrite the script."
+}

--- a/feature/src/test/kotlin/in/jphe/storyvox/feature/reader/script/ScriptGeneratorLogicTest.kt
+++ b/feature/src/test/kotlin/in/jphe/storyvox/feature/reader/script/ScriptGeneratorLogicTest.kt
@@ -1,0 +1,143 @@
+package `in`.jphe.storyvox.feature.reader.script
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * Issue #1366 — AI script writer. The pace math (word-count target, duration
+ * estimate) and prompt construction are extracted to pure functions so
+ * they're pinned without Hilt, coroutines, or a live LLM provider — mirroring
+ * [`in`.jphe.storyvox.feature.reader.TeleprompterScrollTest]. The streaming
+ * orchestration itself is exercised on-device (the provider layer isn't
+ * cheaply fakeable in a unit test).
+ *
+ * Backtick test names stay ASCII and avoid JVM-illegal chars (no `. : / [ ]`)
+ * so these compile under Test Compile, not just Build APK.
+ */
+class ScriptGeneratorLogicTest {
+
+    // ===== targetWordCount =====
+
+    @Test
+    fun `target word count is duration times pace over sixty`() {
+        // 150 wpm is the speaking-pace constant; 60s of speech is 150 words.
+        assertEquals(150, targetWordCount(60))
+        assertEquals(75, targetWordCount(30))
+        assertEquals(225, targetWordCount(90))
+    }
+
+    @Test
+    fun `target word count honours a custom pace`() {
+        assertEquals(120, targetWordCount(60, wpm = 120))
+        assertEquals(60, targetWordCount(30, wpm = 120))
+    }
+
+    @Test
+    fun `non-positive duration or pace yields zero words`() {
+        assertEquals(0, targetWordCount(0))
+        assertEquals(0, targetWordCount(-30))
+        assertEquals(0, targetWordCount(60, wpm = 0))
+    }
+
+    // ===== scriptWordCount =====
+
+    @Test
+    fun `counts whitespace-delimited words`() {
+        assertEquals(2, scriptWordCount("hello world"))
+        assertEquals(1, scriptWordCount("solo"))
+        // Collapsed whitespace runs (spaces, tabs, newlines) are one delimiter.
+        assertEquals(4, scriptWordCount("one  two\tthree\nfour"))
+    }
+
+    @Test
+    fun `blank or empty text has no words`() {
+        assertEquals(0, scriptWordCount(""))
+        assertEquals(0, scriptWordCount("   \t\n  "))
+    }
+
+    @Test
+    fun `leading and trailing whitespace does not inflate the count`() {
+        assertEquals(3, scriptWordCount("  one two three  "))
+    }
+
+    // ===== estimatedDurationSecs =====
+
+    @Test
+    fun `estimated duration inverts the pace`() {
+        // 150 words at 150 wpm is exactly one minute.
+        assertEquals(60, estimatedDurationSecs("word ".repeat(150).trim()))
+        assertEquals(30, estimatedDurationSecs("word ".repeat(75).trim()))
+    }
+
+    @Test
+    fun `estimated duration rounds to whole seconds`() {
+        // 151 words at 150 wpm = 60.4s, rounds to 60.
+        assertEquals(60, estimatedDurationSecs("word ".repeat(151).trim()))
+        // 153 words at 150 wpm = 61.2s, rounds to 61.
+        assertEquals(61, estimatedDurationSecs("word ".repeat(153).trim()))
+    }
+
+    @Test
+    fun `empty text or zero pace estimates zero seconds`() {
+        assertEquals(0, estimatedDurationSecs(""))
+        assertEquals(0, estimatedDurationSecs("word", wpm = 0))
+    }
+
+    // ===== prompt construction =====
+
+    @Test
+    fun `system prompt interpolates the duration and word target`() {
+        val prompt = buildScriptSystemPrompt(60)
+        assertTrue(prompt.contains("60s at 150 words per minute (150 words)"))
+        // The voice rules survive the trimIndent.
+        assertTrue(prompt.contains("short-form video"))
+        assertTrue(prompt.contains("hook"))
+        assertTrue(prompt.contains("[pause]"))
+        assertTrue(prompt.contains("call-to-action"))
+    }
+
+    @Test
+    fun `system prompt scales the word target with duration`() {
+        assertTrue(buildScriptSystemPrompt(30).contains("(75 words)"))
+        assertTrue(buildScriptSystemPrompt(90).contains("(225 words)"))
+    }
+
+    @Test
+    fun `user prompt carries the topic and length target`() {
+        val prompt = buildScriptUserPrompt("Why accessibility matters", 60)
+        assertTrue(prompt.contains("Why accessibility matters"))
+        assertTrue(prompt.contains("60 seconds"))
+        assertTrue(prompt.contains("150 words"))
+    }
+
+    @Test
+    fun `user prompt trims topic whitespace`() {
+        val prompt = buildScriptUserPrompt("   padded topic   ", 30)
+        assertTrue(prompt.contains("Topic: padded topic\n"))
+    }
+
+    // ===== duration presets =====
+
+    @Test
+    fun `duration presets are the three short-form lengths`() {
+        assertEquals(listOf(30, 60, 90), SCRIPT_DURATION_OPTIONS)
+    }
+
+    // ===== ScriptDraftStore =====
+
+    @Test
+    fun `draft store starts empty`() {
+        assertNull(ScriptDraftStore().activeScript.value)
+    }
+
+    @Test
+    fun `draft store load then clear round-trips the script`() {
+        val store = ScriptDraftStore()
+        store.load("Hook them in five words.")
+        assertEquals("Hook them in five words.", store.activeScript.value)
+        store.clear()
+        assertNull(store.activeScript.value)
+    }
+}

--- a/feature/src/test/kotlin/in/jphe/storyvox/feature/reader/script/ScriptGeneratorLogicTest.kt
+++ b/feature/src/test/kotlin/in/jphe/storyvox/feature/reader/script/ScriptGeneratorLogicTest.kt
@@ -62,6 +62,51 @@ class ScriptGeneratorLogicTest {
         assertEquals(3, scriptWordCount("  one two three  "))
     }
 
+    // ===== spoken-word stripping (teleprompter format scaffolding) =====
+
+    @Test
+    fun `speaker labels are not counted as spoken words`() {
+        assertEquals(2, scriptWordCount("HOST: hello world"))
+        // Label on its own line, dialogue on the next — the show format.
+        assertEquals(2, scriptWordCount("HOST:\nhello world"))
+        assertEquals(4, scriptWordCount("SHAWNA: hello there\nJEFF: hi back"))
+    }
+
+    @Test
+    fun `bracketed cues are not counted as spoken words`() {
+        assertEquals(2, scriptWordCount("[B-ROLL: city skyline at dusk] hello world"))
+        assertEquals(4, scriptWordCount("look here [CUT to close-up] right now"))
+        assertEquals(0, scriptWordCount("[POST: jingle and logo intro]"))
+    }
+
+    @Test
+    fun `section-banner rule lines are not counted but titles remain`() {
+        // The ===== rules drop out; the ALL-CAPS title line is a known,
+        // accepted exception that still counts (no block parsing).
+        assertEquals(4, scriptWordCount("=====\nMY SECTION\n=====\nHOST: go now"))
+    }
+
+    @Test
+    fun `a full show-format block counts only the spoken words`() {
+        val block = """
+            =====
+            THE HOOK
+            =====
+
+            [POST: JINGLE + LOGO INTRO]
+
+            HOST:
+            Wait — you qualify for this.
+
+            HOST:
+            Here is the catch nobody mentions. [b-roll: phone]
+        """.trimIndent()
+        // Spoken: "THE HOOK" (2, title exception)
+        // + "Wait — you qualify for this." (6 — the spaced em-dash is its own token)
+        // + "Here is the catch nobody mentions." (6) = 14.
+        assertEquals(14, scriptWordCount(block))
+    }
+
     // ===== estimatedDurationSecs =====
 
     @Test
@@ -90,18 +135,25 @@ class ScriptGeneratorLogicTest {
     @Test
     fun `system prompt interpolates the duration and word target`() {
         val prompt = buildScriptSystemPrompt(60)
-        assertTrue(prompt.contains("60s at 150 words per minute (150 words)"))
-        // The voice rules survive the trimIndent.
+        assertTrue(prompt.contains("60s at 150 words per minute (~150 spoken words)"))
+        // The voice + format rules survive the trimIndent.
         assertTrue(prompt.contains("short-form video"))
         assertTrue(prompt.contains("hook"))
-        assertTrue(prompt.contains("[pause]"))
         assertTrue(prompt.contains("call-to-action"))
     }
 
     @Test
+    fun `system prompt specifies the teleprompter format`() {
+        val prompt = buildScriptSystemPrompt(60)
+        assertTrue(prompt.contains("SPEAKER label"))
+        assertTrue(prompt.contains("[SQUARE"))
+        assertTrue(prompt.contains("section banner"))
+    }
+
+    @Test
     fun `system prompt scales the word target with duration`() {
-        assertTrue(buildScriptSystemPrompt(30).contains("(75 words)"))
-        assertTrue(buildScriptSystemPrompt(90).contains("(225 words)"))
+        assertTrue(buildScriptSystemPrompt(30).contains("(~75 spoken words)"))
+        assertTrue(buildScriptSystemPrompt(90).contains("(~225 spoken words)"))
     }
 
     @Test
@@ -109,7 +161,7 @@ class ScriptGeneratorLogicTest {
         val prompt = buildScriptUserPrompt("Why accessibility matters", 60)
         assertTrue(prompt.contains("Why accessibility matters"))
         assertTrue(prompt.contains("60 seconds"))
-        assertTrue(prompt.contains("150 words"))
+        assertTrue(prompt.contains("150 spoken words"))
     }
 
     @Test


### PR DESCRIPTION
## AI Script Writer for the Teleprompter (#1366)

Generate teleprompter-ready short-form video scripts (YouTube Shorts / TikTok / Reels) from a topic prompt, streamed live through the user's active LLM provider, then loaded into the teleprompter to rehearse.

### What you get
- A **"Write a script"** sparkle button in the teleprompter transport (auto-scroll mode).
- A lightweight **bottom sheet**: topic field, **30s / 60s / 90s** length chips, **Generate** → tokens stream into a live preview, then **Stop / Regenerate / Edit** and **Load into Teleprompter**. Word count + estimated spoken duration (`N words · ~Ms`) update as it streams.
- An **unconfigured-provider** error that routes straight to **Settings → AI** (same nav the recap surface uses, #152).

### How it works
- **`ScriptGeneratorViewModel`** injects `LlmRepository` + `Flow<LlmConfig>` (exactly like `ChapterRecap`) and streams `llm.stream(messages, systemPrompt)`, accumulating deltas into `Generating(partial)` → `Done(script)`. A short-form **system prompt** tuned for spoken pacing (hook in 5 words, 8–12-word sentences, pause markers, length target) is interpolated with the duration + 150-wpm word target.
- State machine: `Idle → Generating → Done → Error` (a sealed interface). `Done` also covers *stopped* (kept partial) and *edited* scripts. Error handling mirrors `ChatViewModel.mapError`; the normal-completion path is guarded so a `.catch` that set `Error` can't be clobbered back to `Done`.
- **`ScriptDraftStore`** (`@Singleton`) is the cross-scope hand-off seam between the generator (a screen-scoped VM) and the reader's teleprompter — same shape `TeleprompterController` uses to hoist transport state for the Wear bridge. `loadIntoTeleprompter()` parks the script there and flips the transport on.

### Scope / coordination note
This PR ships the **producer half**: generation, the sheet, the entry point, and the `ScriptDraftStore` seam. **Rendering the parked script *as* the teleprompter's scroll content is a deliberate follow-up** — it touches the reader's shared text / TTS / highlight path (also owned by **#1368** voice-paced teleprompter), and doing it here would blow past the "one small button in `ReaderView`" boundary and risk conflicts. Consumers observe `ScriptDraftStore.activeScript` and call `clear()` when they take ownership.

`ScriptDraftStore` is a 4th file beyond the 3 in the brief — it's the concrete answer to "communicate the script text to the reader," kept tiny and documented.

### Files
**New** (`feature/.../reader/script/`): `ScriptGeneratorState.kt`, `ScriptGeneratorViewModel.kt`, `ScriptDraftStore.kt`, `ScriptGeneratorSheet.kt`
**Touched (minimal):**
- `ReaderView.kt` — one `onWriteScript` callback param (no-op default → preview/test/audiobook callsites unchanged) + the transport button.
- `HybridReaderScreen.kt` — hosts the sheet (so it can reach the `onOpenAiSettings` nav) + wires the button. `ReaderTextView` stays Hilt-free, so the standalone gesture tests are unaffected.

**Not touched** (per brief): `StoryvoxNavHost.kt`, `StoryvoxDatabase.kt`, `AndroidManifest.xml`, `core-llm/`. No new Hilt module — every dependency already has a binding (`LlmRepository`, `Flow<LlmConfig>`, `TeleprompterController`), and `ScriptDraftStore` is `@Inject constructor()`.

### Tests
`ScriptGeneratorLogicTest` (JUnit4, pure — no Hilt/coroutines/provider): word-count target, whitespace word count, duration estimate + rounding, system/user prompt interpolation, duration presets, and `ScriptDraftStore` load/clear round-trip. The streaming orchestration is thin and exercised on-device.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an AI script-writer flow in the reader, including a bottom sheet to create scripts from a topic.
  * Added a new action in teleprompter mode to start script writing quickly.
  * Support now includes script preview, editing, loading into the teleprompter, and duration-based script estimates.
* **Bug Fixes**
  * Improved handling of generation stops and partial results so drafts can be preserved and reused.
  * Added clearer error states, including a direct path to AI settings when needed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->