### PR TITLE
feat(reader): recording mode — camera preview behind teleprompter (#1367)

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -40,13 +40,14 @@
         android:name="android.hardware.camera.autofocus"
         android:required="false" />
 
-    <!-- Issue #1368 — voice-paced teleprompter. RECORD_AUDIO is requested at
-         runtime when the reader picks the Voice follow mode, with a rationale
-         before the system prompt; a denied mic falls back to the manual-WPM
-         teleprompter (no dead-end). The microphone feature is OPTIONAL so a
-         device without a mic still installs and uses the other follow modes —
-         same required="false" posture as the camera above. -->
+    <!-- Issue #1368 — voice-paced teleprompter + Issue #1367 — Recording mode.
+         RECORD_AUDIO is requested at runtime for both voice-paced scroll (mic STT)
+         and recording mode (camera audio capture). WRITE_EXTERNAL_STORAGE is
+         scoped to API ≤28 for CameraX MediaStore output on legacy devices. -->
     <uses-permission android:name="android.permission.RECORD_AUDIO" />
+    <uses-permission
+        android:name="android.permission.WRITE_EXTERNAL_STORAGE"
+        android:maxSdkVersion="28" />
     <uses-feature
         android:name="android.hardware.microphone"
         android:required="false" />

--- a/app/src/main/kotlin/in/jphe/storyvox/navigation/StoryvoxNavHost.kt
+++ b/app/src/main/kotlin/in/jphe/storyvox/navigation/StoryvoxNavHost.kt
@@ -47,6 +47,7 @@ import `in`.jphe.storyvox.feature.library.LibraryScreen
 import `in`.jphe.storyvox.feature.reader.HybridReaderScreen
 import `in`.jphe.storyvox.feature.reader.NowPlayingDock
 import `in`.jphe.storyvox.feature.reader.NowPlayingDockViewModel
+import `in`.jphe.storyvox.feature.reader.recording.RecordingScreen
 import `in`.jphe.storyvox.feature.settings.AboutSettingsScreen
 import `in`.jphe.storyvox.feature.settings.OssLicensesScreen
 import `in`.jphe.storyvox.feature.settings.AccessibilitySettingsScreen
@@ -95,6 +96,13 @@ object StoryvoxRoutes {
     const val FICTION_DETAIL = "fiction/{fictionId}"
     const val READER = "reader/{fictionId}/{chapterId}"
     const val AUDIOBOOK = "audiobook/{fictionId}/{chapterId}"
+    /** Issue #1367 — Recording mode. Films the front camera behind the
+     *  semi-transparent teleprompter script (the chapter loaded in the
+     *  reader) for YouTube Shorts / Reels / TikTok. Reached from the Record
+     *  button in the reader's teleprompter transport; no args — the script,
+     *  title, and pace are read from the shared playback / teleprompter
+     *  singletons inside [RecordingViewModel]. */
+    const val RECORDING = "recording"
     /** Issue #440 — Settings hub (section index). The gear-icon
      *  destination as of v0.5.38; previously dumped users into the
      *  flat-scroll [SETTINGS] page with no top-of-page map. Each row
@@ -743,6 +751,9 @@ private fun StoryvoxNavHostContent(
                     onOpenLibrary = { fId ->
                         navController.navigate(StoryvoxRoutes.fictionDetail(fId))
                     },
+                    // Issue #1367 — Record button in the teleprompter transport
+                    // opens Recording mode (camera behind the scrolling script).
+                    onOpenRecording = { navController.navigate(StoryvoxRoutes.RECORDING) },
                 )
             }
             composable(
@@ -980,6 +991,9 @@ private fun StoryvoxNavHostContent(
                     onOpenLibrary = { fId ->
                         navController.navigate(StoryvoxRoutes.fictionDetail(fId))
                     },
+                    // Issue #1367 — Record button in the teleprompter transport
+                    // opens Recording mode (camera behind the scrolling script).
+                    onOpenRecording = { navController.navigate(StoryvoxRoutes.RECORDING) },
                 )
             }
 
@@ -1027,7 +1041,25 @@ private fun StoryvoxNavHostContent(
                     onOpenLibrary = { fId ->
                         navController.navigate(StoryvoxRoutes.fictionDetail(fId))
                     },
+                    // Issue #1367 — Record button in the teleprompter transport
+                    // opens Recording mode (camera behind the scrolling script).
+                    onOpenRecording = { navController.navigate(StoryvoxRoutes.RECORDING) },
                 )
+            }
+
+            // Issue #1367 — Recording mode. Standalone full-screen camera +
+            // teleprompter surface; a drill-down (push) from the reader's
+            // teleprompter Record button. No args — RecordingViewModel reads
+            // the script / title / pace from the shared playback +
+            // teleprompter singletons.
+            composable(
+                StoryvoxRoutes.RECORDING,
+                enterTransition = pushEnter,
+                exitTransition = pushExit,
+                popEnterTransition = popEnter,
+                popExitTransition = popExit,
+            ) {
+                RecordingScreen(onBack = { navController.popBackStack() })
             }
 
             composable(

--- a/feature/build.gradle.kts
+++ b/feature/build.gradle.kts
@@ -89,6 +89,10 @@ dependencies {
     // the capture surface (camera-view's PreviewView + CameraController).
     implementation(project(":source-ocr"))
     implementation(libs.bundles.camerax)
+    // Issue #1367 — Recording mode adds video capture on top of the OCR
+    // preview stack: LifecycleCameraController.startRecording needs the
+    // camera-video artifact (Recorder / MediaStoreOutputOptions / AudioConfig).
+    implementation(libs.androidx.camera.video)
 
     implementation(libs.androidx.core.ktx)
     implementation(libs.bundles.lifecycle)

--- a/feature/src/main/kotlin/in/jphe/storyvox/feature/reader/HybridReaderScreen.kt
+++ b/feature/src/main/kotlin/in/jphe/storyvox/feature/reader/HybridReaderScreen.kt
@@ -87,6 +87,12 @@ fun HybridReaderScreen(
      *  previews / tests; production callsites pass
      *  `navController.navigate(StoryvoxRoutes.fictionDetail(fId))`. */
     onOpenLibrary: (fictionId: String) -> Unit = {},
+    /** Issue #1367 — open Recording mode (camera behind the teleprompter
+     *  script) from the teleprompter transport's Record button. Wired by
+     *  [`in`.jphe.storyvox.navigation.StoryvoxNavHost] to
+     *  `navController.navigate(StoryvoxRoutes.RECORDING)`. Default no-op for
+     *  previews / tests. */
+    onOpenRecording: () -> Unit = {},
     viewModel: ReaderViewModel = hiltViewModel(),
 ) {
     val state by viewModel.uiState.collectAsStateWithLifecycle()
@@ -439,6 +445,9 @@ fun HybridReaderScreen(
                 onStartVoicePaced = viewModel::startVoicePaced,
                 onStopVoicePaced = viewModel::stopVoicePaced,
                 onPrepareVoicePaced = viewModel::prepareVoicePaced,
+                // Issue #1367 — Record button in the teleprompter transport
+                // opens Recording mode (camera behind the scrolling script).
+                onRecord = onOpenRecording,
             )
         },
     )

--- a/feature/src/main/kotlin/in/jphe/storyvox/feature/reader/ReaderView.kt
+++ b/feature/src/main/kotlin/in/jphe/storyvox/feature/reader/ReaderView.kt
@@ -38,6 +38,7 @@ import androidx.compose.material.icons.filled.Pause
 import androidx.compose.material.icons.filled.PlayArrow
 import androidx.compose.material.icons.filled.Remove
 import androidx.compose.material.icons.filled.Share
+import androidx.compose.material.icons.filled.Videocam
 import androidx.compose.material.icons.filled.VerticalAlignCenter
 import androidx.compose.material.icons.outlined.AutoAwesome
 import androidx.compose.material.icons.outlined.AutoStories
@@ -359,6 +360,11 @@ fun ReaderTextView(
     onStartVoicePaced: (String) -> Unit = {},
     onStopVoicePaced: () -> Unit = {},
     onPrepareVoicePaced: () -> Unit = {},
+    /** Issue #1367 — open Recording mode (front camera behind the scrolling
+     *  script) from the teleprompter transport's Record button. Threaded up
+     *  through [HybridReaderScreen] to a `navigate(RECORDING)`. No-op default
+     *  keeps preview/test callsites working. */
+    onRecord: () -> Unit = {},
     modifier: Modifier = Modifier,
 ) {
     val spacing = LocalSpacing.current
@@ -1200,6 +1206,7 @@ fun ReaderTextView(
                             onSetTeleprompterEnabled(false)
                         },
                         onWriteScript = onWriteScript,
+                        onRecord = onRecord,
                     )
                     TeleprompterMode.Practice -> PracticeTransport(
                         playing = state.isPlaying,
@@ -1351,6 +1358,7 @@ private fun TeleprompterTransport(
     onWpmDelta: (Int) -> Unit,
     onExit: () -> Unit,
     onWriteScript: () -> Unit,
+    onRecord: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
     val spacing = LocalSpacing.current
@@ -1377,6 +1385,14 @@ private fun TeleprompterTransport(
                 modifier = Modifier.semantics { contentDescription = "Write a script" },
             ) {
                 Icon(imageVector = Icons.Outlined.AutoAwesome, contentDescription = null)
+            }
+            // Issue #1367 — Record: film yourself reading the script with the
+            // camera behind the teleprompter text.
+            IconButton(
+                onClick = onRecord,
+                modifier = Modifier.semantics { contentDescription = "Record video" },
+            ) {
+                Icon(imageVector = Icons.Filled.Videocam, contentDescription = null)
             }
             Spacer(modifier = Modifier.weight(1f))
             IconButton(

--- a/feature/src/main/kotlin/in/jphe/storyvox/feature/reader/recording/CameraRecorder.kt
+++ b/feature/src/main/kotlin/in/jphe/storyvox/feature/reader/recording/CameraRecorder.kt
@@ -7,7 +7,7 @@ import android.net.Uri
 import android.os.Build
 import android.provider.MediaStore
 import androidx.camera.core.CameraSelector
-import androidx.camera.video.AudioConfig
+import androidx.camera.view.video.AudioConfig
 import androidx.camera.video.MediaStoreOutputOptions
 import androidx.camera.video.Recording
 import androidx.camera.video.VideoRecordEvent

--- a/feature/src/main/kotlin/in/jphe/storyvox/feature/reader/recording/CameraRecorder.kt
+++ b/feature/src/main/kotlin/in/jphe/storyvox/feature/reader/recording/CameraRecorder.kt
@@ -1,0 +1,129 @@
+package `in`.jphe.storyvox.feature.reader.recording
+
+import android.annotation.SuppressLint
+import android.content.ContentValues
+import android.content.Context
+import android.net.Uri
+import android.os.Build
+import android.provider.MediaStore
+import androidx.camera.core.CameraSelector
+import androidx.camera.video.AudioConfig
+import androidx.camera.video.MediaStoreOutputOptions
+import androidx.camera.video.Recording
+import androidx.camera.video.VideoRecordEvent
+import androidx.camera.view.CameraController
+import androidx.camera.view.LifecycleCameraController
+import androidx.core.content.ContextCompat
+import androidx.core.util.Consumer
+import androidx.lifecycle.LifecycleOwner
+
+/**
+ * Issue #1367 — camera + video-recording lifecycle wrapper for Recording mode.
+ *
+ * Wraps a [LifecycleCameraController] (the same camera-view controller the OCR
+ * capture surface uses for preview) and adds the [CameraController.VIDEO_CAPTURE]
+ * use case so one object drives both the live [androidx.camera.view.PreviewView]
+ * feed and the MP4 (H.264 video + AAC audio) recording. CameraX finalizes the
+ * clip straight into [MediaStore], so it lands in the device gallery's Movies
+ * folder immediately — no manual file plumbing.
+ *
+ * Owned by [RecordingScreen] (created with `remember`, bound in a
+ * `DisposableEffect`) rather than the ViewModel, because the controller must
+ * bind to the composition's [LifecycleOwner] and outliving that lifecycle would
+ * leak the camera. The ViewModel stays camera-free and merely sends
+ * [RecordingCommand]s here.
+ *
+ * Recording resolution is left at the CameraController default
+ * (`QualitySelector.from(Quality.FHD, …)`), so a portrait capture yields a
+ * 1080×1920 (9:16) clip — the right shape for Shorts / Reels / TikTok — without
+ * pinning a quality the device may not offer.
+ */
+class CameraRecorder(context: Context) {
+
+    private val appContext = context.applicationContext
+
+    /** The shared preview+video controller. Exposed so the composable can hand
+     *  it to its `PreviewView`. */
+    val controller: LifecycleCameraController = LifecycleCameraController(appContext).apply {
+        setEnabledUseCases(CameraController.VIDEO_CAPTURE)
+        cameraSelector = CameraSelector.DEFAULT_FRONT_CAMERA
+    }
+
+    private var recording: Recording? = null
+
+    /** Bind the camera to [owner]'s lifecycle (starts the live preview). */
+    fun bind(owner: LifecycleOwner) {
+        controller.bindToLifecycle(owner)
+    }
+
+    /** Switch between the selfie (front) and rear camera. A no-op rebind while
+     *  already on the requested lens; CameraX rebinds the use cases internally
+     *  when the selector changes. */
+    fun setFrontCamera(front: Boolean) {
+        val target = if (front) CameraSelector.DEFAULT_FRONT_CAMERA else CameraSelector.DEFAULT_BACK_CAMERA
+        if (controller.cameraSelector != target) {
+            controller.cameraSelector = target
+        }
+    }
+
+    /**
+     * Start recording video+audio into a new MediaStore entry named
+     * [displayName] (CameraX appends the container suffix). [onFinalized] fires
+     * with the saved clip's content Uri on success; [onError] with a
+     * user-facing message on failure. Both are invoked on the main thread.
+     *
+     * The caller MUST have been granted RECORD_AUDIO (audio is enabled) — the
+     * [RecordingScreen] permission gate guarantees this before issuing
+     * [RecordingCommand.Start].
+     */
+    @SuppressLint("MissingPermission")
+    fun start(displayName: String, onFinalized: (Uri) -> Unit, onError: (String) -> Unit) {
+        if (recording != null) return
+        val values = ContentValues().apply {
+            put(MediaStore.Video.Media.DISPLAY_NAME, displayName)
+            put(MediaStore.Video.Media.MIME_TYPE, "video/mp4")
+            // Scoped storage (API 29+) routes the clip into the gallery's
+            // Movies/Candela album. On API ≤28 MediaStore ignores RELATIVE_PATH
+            // and drops it in the default Movies bucket via the legacy
+            // (maxSdk-28-scoped) WRITE_EXTERNAL_STORAGE grant.
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
+                put(MediaStore.Video.Media.RELATIVE_PATH, "Movies/Candela")
+            }
+        }
+        val output = MediaStoreOutputOptions
+            .Builder(appContext.contentResolver, MediaStore.Video.Media.EXTERNAL_CONTENT_URI)
+            .setContentValues(values)
+            .build()
+
+        recording = controller.startRecording(
+            output,
+            AudioConfig.create(true),
+            ContextCompat.getMainExecutor(appContext),
+            Consumer { event ->
+                if (event is VideoRecordEvent.Finalize) {
+                    recording = null
+                    if (event.hasError()) {
+                        onError("Couldn't save the recording (error ${event.error}).")
+                    } else {
+                        onFinalized(event.outputResults.outputUri)
+                    }
+                }
+            },
+        )
+    }
+
+    /** Stop the active recording; finalization arrives asynchronously via the
+     *  listener passed to [start]. */
+    fun stop() {
+        recording?.stop()
+        recording = null
+    }
+
+    /** Tear down: stop any active recording and unbind the camera. Called from
+     *  the composable's `DisposableEffect.onDispose`. */
+    fun release() {
+        recording?.stop()
+        recording = null
+        controller.unbind()
+    }
+}

--- a/feature/src/main/kotlin/in/jphe/storyvox/feature/reader/recording/RecordingScreen.kt
+++ b/feature/src/main/kotlin/in/jphe/storyvox/feature/reader/recording/RecordingScreen.kt
@@ -21,13 +21,12 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.statusBarsPadding
 import androidx.compose.foundation.layout.width
-import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
-import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
 import androidx.compose.material.icons.filled.Cameraswitch
+import androidx.compose.material.icons.filled.Flip
 import androidx.compose.material3.Button
 import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.Icon
@@ -44,12 +43,12 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
-import androidx.compose.runtime.withFrameNanos
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.semantics.contentDescription
 import androidx.compose.ui.semantics.semantics
@@ -62,11 +61,7 @@ import androidx.core.content.ContextCompat
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.LocalLifecycleOwner
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
-import `in`.jphe.storyvox.feature.reader.countWords
-import `in`.jphe.storyvox.feature.reader.teleprompterScrollDeltaPx
 import `in`.jphe.storyvox.ui.theme.LocalSpacing
-import kotlinx.coroutines.CancellationException
-import kotlinx.coroutines.isActive
 
 /**
  * Issue #1367 — Recording mode.
@@ -135,6 +130,8 @@ private fun RecordingContent(
     val wpm by viewModel.wpm.collectAsStateWithLifecycle()
     val opacity by viewModel.opacity.collectAsStateWithLifecycle()
     val frontCamera by viewModel.frontCamera.collectAsStateWithLifecycle()
+    val fontSize by viewModel.fontSize.collectAsStateWithLifecycle()
+    val mirror by viewModel.mirror.collectAsStateWithLifecycle()
 
     // The camera lives with the composition's lifecycle — created here, not in
     // the ViewModel, so it's torn down when we leave the screen.
@@ -197,11 +194,14 @@ private fun RecordingContent(
                 ),
         )
 
-        // 3 — the scrolling teleprompter script.
+        // 3 — the scrolling teleprompter script (speaker colour-coding, section
+        // banners, production-cue styling, eye-line markers, edge fades, mirror).
         TeleprompterOverlay(
             script = script,
             wpm = wpm,
+            fontSize = fontSize,
             opacity = opacity,
+            mirror = mirror,
             scrolling = uiState is RecordingState.Recording,
         )
 
@@ -253,9 +253,13 @@ private fun RecordingContent(
             BottomControls(
                 state = uiState,
                 opacity = opacity,
+                mirror = mirror,
                 canFlip = uiState !is RecordingState.Recording && uiState !is RecordingState.Saving,
                 onOpacityChange = viewModel::setOpacity,
                 onFlip = viewModel::flipCamera,
+                onToggleMirror = viewModel::toggleMirror,
+                onFontSmaller = { viewModel.adjustFontSize(-RecordingViewModel.FONT_STEP_SP) },
+                onFontLarger = { viewModel.adjustFontSize(RecordingViewModel.FONT_STEP_SP) },
                 onRecordButton = viewModel::onRecordButton,
                 modifier = Modifier.align(Alignment.BottomCenter),
             )
@@ -303,76 +307,6 @@ private fun RecordingContent(
     }
 }
 
-/**
- * The semi-transparent script that scrolls over the camera. Reuses
- * [teleprompterScrollDeltaPx] / [countWords] from the reader so the pace at a
- * given WPM is identical to the in-reader teleprompter (frame-rate independent,
- * sub-pixel remainder carried). Scrolls only while [scrolling] (i.e. recording);
- * before that it sits at the top so the user can frame themselves.
- */
-@Composable
-private fun TeleprompterOverlay(
-    script: String,
-    wpm: Int,
-    opacity: Float,
-    scrolling: Boolean,
-) {
-    val scroll = rememberScrollState()
-    val totalWords = remember(script) { countWords(script) }
-
-    LaunchedEffect(scrolling, wpm, totalWords) {
-        if (!scrolling || totalWords <= 0) return@LaunchedEffect
-        // Begin each take from the top of the script.
-        scroll.scrollTo(0)
-        var lastFrame = 0L
-        var carry = 0f
-        while (isActive) {
-            val frame = withFrameNanos { it }
-            if (lastFrame != 0L && scroll.maxValue > 0) {
-                val px = teleprompterScrollDeltaPx(
-                    wpm = wpm,
-                    totalWords = totalWords,
-                    scrollableHeightPx = scroll.maxValue,
-                    elapsedNanos = frame - lastFrame,
-                ) + carry
-                val whole = px.toInt()
-                carry = px - whole
-                if (whole > 0) {
-                    try {
-                        scroll.scrollTo(scroll.value + whole)
-                    } catch (e: CancellationException) {
-                        if (!isActive) throw e
-                        carry = 0f
-                    }
-                }
-                if (scroll.value >= scroll.maxValue) break
-            }
-            lastFrame = frame
-        }
-    }
-
-    if (script.isBlank()) return
-
-    Column(
-        modifier = Modifier
-            .fillMaxSize()
-            .verticalScroll(scroll)
-            // Generous vertical padding keeps the first/last lines clear of the
-            // top indicator and the bottom controls.
-            .padding(horizontal = 24.dp, vertical = 160.dp),
-    ) {
-        Text(
-            text = script,
-            color = Color.White.copy(alpha = opacity),
-            fontSize = 26.sp,
-            lineHeight = 38.sp,
-            fontWeight = FontWeight.Medium,
-            textAlign = TextAlign.Center,
-            modifier = Modifier.fillMaxWidth(),
-        )
-    }
-}
-
 /** Red dot + mm:ss elapsed, in a translucent pill — the live "REC" cue. */
 @Composable
 private fun RecordingIndicator(elapsedMs: Long) {
@@ -403,9 +337,13 @@ private fun RecordingIndicator(elapsedMs: Long) {
 private fun BottomControls(
     state: RecordingState,
     opacity: Float,
+    mirror: Boolean,
     canFlip: Boolean,
     onOpacityChange: (Float) -> Unit,
     onFlip: () -> Unit,
+    onToggleMirror: () -> Unit,
+    onFontSmaller: () -> Unit,
+    onFontLarger: () -> Unit,
     onRecordButton: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
@@ -416,6 +354,25 @@ private fun BottomControls(
             .padding(horizontal = 24.dp, vertical = 20.dp),
         horizontalAlignment = Alignment.CenterHorizontally,
     ) {
+        // Font size (A− / A+) + mirror — design cues from the show teleprompter.
+        Row(
+            modifier = Modifier.fillMaxWidth(),
+            horizontalArrangement = Arrangement.spacedBy(8.dp, Alignment.CenterHorizontally),
+            verticalAlignment = Alignment.CenterVertically,
+        ) {
+            ControlChip(label = "A−", contentDesc = "Smaller text", onClick = onFontSmaller)
+            ControlChip(label = "A+", contentDesc = "Larger text", onClick = onFontLarger)
+            ControlChip(
+                label = "Mirror",
+                icon = Icons.Filled.Flip,
+                active = mirror,
+                contentDesc = if (mirror) "Mirror on" else "Mirror off",
+                onClick = onToggleMirror,
+            )
+        }
+
+        Spacer(modifier = Modifier.size(14.dp))
+
         // Text-opacity slider (30–100%), in a translucent rail.
         Row(
             modifier = Modifier
@@ -471,6 +428,39 @@ private fun BottomControls(
             // Right: spacer to keep the record button centered.
             Spacer(modifier = Modifier.size(56.dp))
         }
+    }
+}
+
+/** A translucent rounded control pill (font A−/A+, mirror toggle). Highlights
+ *  when [active]. */
+@Composable
+private fun ControlChip(
+    label: String,
+    contentDesc: String,
+    onClick: () -> Unit,
+    modifier: Modifier = Modifier,
+    icon: ImageVector? = null,
+    active: Boolean = false,
+) {
+    Row(
+        modifier = modifier
+            .clip(RoundedCornerShape(50))
+            .background(if (active) Color.White.copy(alpha = 0.30f) else Color.Black.copy(alpha = 0.35f))
+            .clickable(onClick = onClick)
+            .padding(horizontal = 14.dp, vertical = 8.dp)
+            .semantics { contentDescription = contentDesc },
+        horizontalArrangement = Arrangement.spacedBy(6.dp),
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        if (icon != null) {
+            Icon(
+                imageVector = icon,
+                contentDescription = null,
+                tint = Color.White,
+                modifier = Modifier.size(18.dp),
+            )
+        }
+        Text(text = label, color = Color.White, fontSize = 15.sp, fontWeight = FontWeight.Bold)
     }
 }
 

--- a/feature/src/main/kotlin/in/jphe/storyvox/feature/reader/recording/RecordingScreen.kt
+++ b/feature/src/main/kotlin/in/jphe/storyvox/feature/reader/recording/RecordingScreen.kt
@@ -1,0 +1,621 @@
+package `in`.jphe.storyvox.feature.reader.recording
+
+import android.Manifest
+import android.content.Intent
+import android.content.pm.PackageManager
+import androidx.activity.compose.BackHandler
+import androidx.activity.compose.rememberLauncherForActivityResult
+import androidx.activity.result.contract.ActivityResultContracts
+import androidx.camera.view.PreviewView
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.navigationBarsPadding
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.statusBarsPadding
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material.icons.filled.Cameraswitch
+import androidx.compose.material3.Button
+import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Slider
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.DisposableEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.runtime.withFrameNanos
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Brush
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.semantics.contentDescription
+import androidx.compose.ui.semantics.semantics
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import androidx.compose.ui.viewinterop.AndroidView
+import androidx.core.content.ContextCompat
+import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.lifecycle.compose.LocalLifecycleOwner
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import `in`.jphe.storyvox.feature.reader.countWords
+import `in`.jphe.storyvox.feature.reader.teleprompterScrollDeltaPx
+import `in`.jphe.storyvox.ui.theme.LocalSpacing
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.isActive
+
+/**
+ * Issue #1367 — Recording mode.
+ *
+ * A full-screen surface that composites the (front, by default) camera preview
+ * behind the semi-transparent teleprompter script — the chapter currently
+ * loaded in the reader — so the user can film a vertical YouTube Short / Reel /
+ * TikTok while reading. The script auto-scrolls at the reader's teleprompter
+ * pace (#1308 WPM), there's a 3-2-1 countdown, a live red recording indicator,
+ * an opacity slider, and a front/back flip; the finished MP4 saves straight to
+ * the gallery (MediaStore → Movies/Candela).
+ *
+ * Reached from the Record button in the reader's teleprompter transport
+ * ([StoryvoxRoutes.RECORDING]). State lives in [RecordingViewModel]; this
+ * composable owns the lifecycle-bound [CameraRecorder] and executes the
+ * ViewModel's [RecordingCommand]s.
+ */
+@Composable
+fun RecordingScreen(
+    onBack: () -> Unit,
+    viewModel: RecordingViewModel = hiltViewModel(),
+) {
+    val context = LocalContext.current
+
+    // CAMERA + RECORD_AUDIO are both runtime-dangerous. CAMERA may already be
+    // granted (the OCR scan flow asks for it), but audio recording needs the
+    // mic too, so request the pair together. A denial leaves us on the
+    // rationale card rather than dead-ending.
+    val requiredPermissions = remember {
+        arrayOf(Manifest.permission.CAMERA, Manifest.permission.RECORD_AUDIO)
+    }
+    var granted by remember {
+        mutableStateOf(requiredPermissions.all { hasPermission(context, it) })
+    }
+    val permissionLauncher = rememberLauncherForActivityResult(
+        ActivityResultContracts.RequestMultiplePermissions(),
+    ) { result ->
+        granted = result.values.all { it } &&
+            requiredPermissions.all { hasPermission(context, it) }
+    }
+    LaunchedEffect(Unit) {
+        if (!granted) permissionLauncher.launch(requiredPermissions)
+    }
+
+    if (!granted) {
+        PermissionRationale(
+            onGrant = { permissionLauncher.launch(requiredPermissions) },
+            onBack = onBack,
+        )
+        return
+    }
+
+    RecordingContent(viewModel = viewModel, onBack = onBack)
+}
+
+@Composable
+private fun RecordingContent(
+    viewModel: RecordingViewModel,
+    onBack: () -> Unit,
+) {
+    val context = LocalContext.current
+    val lifecycleOwner = LocalLifecycleOwner.current
+
+    val uiState by viewModel.uiState.collectAsStateWithLifecycle()
+    val script by viewModel.script.collectAsStateWithLifecycle()
+    val wpm by viewModel.wpm.collectAsStateWithLifecycle()
+    val opacity by viewModel.opacity.collectAsStateWithLifecycle()
+    val frontCamera by viewModel.frontCamera.collectAsStateWithLifecycle()
+
+    // The camera lives with the composition's lifecycle — created here, not in
+    // the ViewModel, so it's torn down when we leave the screen.
+    val recorder = remember { CameraRecorder(context) }
+    DisposableEffect(lifecycleOwner) {
+        recorder.bind(lifecycleOwner)
+        onDispose { recorder.release() }
+    }
+    LaunchedEffect(frontCamera) { recorder.setFrontCamera(frontCamera) }
+
+    // Execute the ViewModel's camera commands against the bound recorder and
+    // report results back into the state machine.
+    LaunchedEffect(Unit) {
+        viewModel.commands.collect { command ->
+            when (command) {
+                is RecordingCommand.Start -> recorder.start(
+                    displayName = command.displayName,
+                    onFinalized = viewModel::onRecordingFinalized,
+                    onError = viewModel::onRecordingError,
+                )
+                RecordingCommand.Stop -> recorder.stop()
+            }
+        }
+    }
+
+    // Hardware Back: stop a live recording / abort a countdown first; otherwise
+    // leave the screen.
+    BackHandler {
+        when (uiState) {
+            is RecordingState.Recording -> viewModel.stopRecording()
+            is RecordingState.Countdown -> viewModel.onRecordButton()
+            else -> onBack()
+        }
+    }
+
+    Box(modifier = Modifier.fillMaxSize().background(Color.Black)) {
+        // 1 — live camera feed fills the screen.
+        AndroidView(
+            modifier = Modifier.fillMaxSize(),
+            factory = { ctx ->
+                PreviewView(ctx).apply {
+                    controller = recorder.controller
+                    scaleType = PreviewView.ScaleType.FILL_CENTER
+                }
+            },
+        )
+
+        // 2 — legibility scrim: darken top & bottom so white text and the
+        // controls read over a bright camera frame without dimming the face.
+        Box(
+            modifier = Modifier
+                .fillMaxSize()
+                .background(
+                    Brush.verticalGradient(
+                        0.0f to Color.Black.copy(alpha = 0.40f),
+                        0.18f to Color.Transparent,
+                        0.72f to Color.Transparent,
+                        1.0f to Color.Black.copy(alpha = 0.70f),
+                    ),
+                ),
+        )
+
+        // 3 — the scrolling teleprompter script.
+        TeleprompterOverlay(
+            script = script,
+            wpm = wpm,
+            opacity = opacity,
+            scrolling = uiState is RecordingState.Recording,
+        )
+
+        // 4 — top row: exit + live recording indicator.
+        Row(
+            modifier = Modifier
+                .align(Alignment.TopCenter)
+                .fillMaxWidth()
+                .statusBarsPadding()
+                .padding(horizontal = 8.dp, vertical = 8.dp),
+            verticalAlignment = Alignment.CenterVertically,
+        ) {
+            IconButton(
+                onClick = {
+                    when (uiState) {
+                        is RecordingState.Recording -> viewModel.stopRecording()
+                        else -> onBack()
+                    }
+                },
+                modifier = Modifier.semantics { contentDescription = "Close recording mode" },
+            ) {
+                Icon(
+                    imageVector = Icons.AutoMirrored.Filled.ArrowBack,
+                    contentDescription = null,
+                    tint = Color.White,
+                )
+            }
+            Spacer(modifier = Modifier.weight(1f))
+            (uiState as? RecordingState.Recording)?.let { rec ->
+                RecordingIndicator(elapsedMs = rec.elapsedMs)
+            }
+        }
+
+        // 5 — countdown number, centered.
+        (uiState as? RecordingState.Countdown)?.let { cd ->
+            Text(
+                text = cd.secondsLeft.toString(),
+                color = Color.White,
+                fontSize = 120.sp,
+                fontWeight = FontWeight.Bold,
+                modifier = Modifier
+                    .align(Alignment.Center)
+                    .semantics { contentDescription = "Recording in ${cd.secondsLeft}" },
+            )
+        }
+
+        // 6 — bottom controls (hidden while a result card is up).
+        if (uiState !is RecordingState.Done && uiState !is RecordingState.Error) {
+            BottomControls(
+                state = uiState,
+                opacity = opacity,
+                canFlip = uiState !is RecordingState.Recording && uiState !is RecordingState.Saving,
+                onOpacityChange = viewModel::setOpacity,
+                onFlip = viewModel::flipCamera,
+                onRecordButton = viewModel::onRecordButton,
+                modifier = Modifier.align(Alignment.BottomCenter),
+            )
+        }
+
+        // 7 — result overlays.
+        (uiState as? RecordingState.Done)?.let { done ->
+            ResultCard(
+                title = "Saved to your gallery",
+                body = "Your clip is in Movies / Candela — ready to share.",
+                primaryLabel = "Done",
+                onPrimary = onBack,
+                secondaryLabel = "Record again",
+                onSecondary = viewModel::reset,
+                tertiaryLabel = "View",
+                onTertiary = {
+                    runCatching {
+                        context.startActivity(
+                            Intent(Intent.ACTION_VIEW).apply {
+                                setDataAndType(done.uri, "video/*")
+                                addFlags(
+                                    Intent.FLAG_GRANT_READ_URI_PERMISSION or
+                                        Intent.FLAG_ACTIVITY_NEW_TASK,
+                                )
+                            },
+                        )
+                    }
+                },
+                modifier = Modifier.align(Alignment.Center),
+            )
+        }
+        (uiState as? RecordingState.Error)?.let { err ->
+            ResultCard(
+                title = "Recording failed",
+                body = err.message,
+                primaryLabel = "Try again",
+                onPrimary = viewModel::reset,
+                secondaryLabel = "Back",
+                onSecondary = onBack,
+                tertiaryLabel = null,
+                onTertiary = {},
+                modifier = Modifier.align(Alignment.Center),
+            )
+        }
+    }
+}
+
+/**
+ * The semi-transparent script that scrolls over the camera. Reuses
+ * [teleprompterScrollDeltaPx] / [countWords] from the reader so the pace at a
+ * given WPM is identical to the in-reader teleprompter (frame-rate independent,
+ * sub-pixel remainder carried). Scrolls only while [scrolling] (i.e. recording);
+ * before that it sits at the top so the user can frame themselves.
+ */
+@Composable
+private fun TeleprompterOverlay(
+    script: String,
+    wpm: Int,
+    opacity: Float,
+    scrolling: Boolean,
+) {
+    val scroll = rememberScrollState()
+    val totalWords = remember(script) { countWords(script) }
+
+    LaunchedEffect(scrolling, wpm, totalWords) {
+        if (!scrolling || totalWords <= 0) return@LaunchedEffect
+        // Begin each take from the top of the script.
+        scroll.scrollTo(0)
+        var lastFrame = 0L
+        var carry = 0f
+        while (isActive) {
+            val frame = withFrameNanos { it }
+            if (lastFrame != 0L && scroll.maxValue > 0) {
+                val px = teleprompterScrollDeltaPx(
+                    wpm = wpm,
+                    totalWords = totalWords,
+                    scrollableHeightPx = scroll.maxValue,
+                    elapsedNanos = frame - lastFrame,
+                ) + carry
+                val whole = px.toInt()
+                carry = px - whole
+                if (whole > 0) {
+                    try {
+                        scroll.scrollTo(scroll.value + whole)
+                    } catch (e: CancellationException) {
+                        if (!isActive) throw e
+                        carry = 0f
+                    }
+                }
+                if (scroll.value >= scroll.maxValue) break
+            }
+            lastFrame = frame
+        }
+    }
+
+    if (script.isBlank()) return
+
+    Column(
+        modifier = Modifier
+            .fillMaxSize()
+            .verticalScroll(scroll)
+            // Generous vertical padding keeps the first/last lines clear of the
+            // top indicator and the bottom controls.
+            .padding(horizontal = 24.dp, vertical = 160.dp),
+    ) {
+        Text(
+            text = script,
+            color = Color.White.copy(alpha = opacity),
+            fontSize = 26.sp,
+            lineHeight = 38.sp,
+            fontWeight = FontWeight.Medium,
+            textAlign = TextAlign.Center,
+            modifier = Modifier.fillMaxWidth(),
+        )
+    }
+}
+
+/** Red dot + mm:ss elapsed, in a translucent pill — the live "REC" cue. */
+@Composable
+private fun RecordingIndicator(elapsedMs: Long) {
+    Row(
+        modifier = Modifier
+            .clip(RoundedCornerShape(50))
+            .background(Color.Black.copy(alpha = 0.45f))
+            .padding(horizontal = 12.dp, vertical = 6.dp),
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        Box(
+            modifier = Modifier
+                .size(10.dp)
+                .clip(CircleShape)
+                .background(Color.Red),
+        )
+        Spacer(modifier = Modifier.width(8.dp))
+        Text(
+            text = formatElapsed(elapsedMs),
+            color = Color.White,
+            fontSize = 14.sp,
+            fontWeight = FontWeight.Medium,
+        )
+    }
+}
+
+@Composable
+private fun BottomControls(
+    state: RecordingState,
+    opacity: Float,
+    canFlip: Boolean,
+    onOpacityChange: (Float) -> Unit,
+    onFlip: () -> Unit,
+    onRecordButton: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    Column(
+        modifier = modifier
+            .fillMaxWidth()
+            .navigationBarsPadding()
+            .padding(horizontal = 24.dp, vertical = 20.dp),
+        horizontalAlignment = Alignment.CenterHorizontally,
+    ) {
+        // Text-opacity slider (30–100%), in a translucent rail.
+        Row(
+            modifier = Modifier
+                .fillMaxWidth()
+                .clip(RoundedCornerShape(50))
+                .background(Color.Black.copy(alpha = 0.35f))
+                .padding(horizontal = 16.dp, vertical = 4.dp),
+            verticalAlignment = Alignment.CenterVertically,
+        ) {
+            Text(text = "Text", color = Color.White, fontSize = 13.sp)
+            Slider(
+                value = opacity,
+                onValueChange = onOpacityChange,
+                valueRange = RecordingViewModel.MIN_OPACITY..RecordingViewModel.MAX_OPACITY,
+                modifier = Modifier
+                    .weight(1f)
+                    .padding(horizontal = 12.dp)
+                    .semantics { contentDescription = "Script opacity" },
+            )
+        }
+
+        Spacer(modifier = Modifier.size(20.dp))
+
+        Row(
+            modifier = Modifier.fillMaxWidth(),
+            verticalAlignment = Alignment.CenterVertically,
+            horizontalArrangement = Arrangement.SpaceBetween,
+        ) {
+            // Left: flip camera.
+            IconButton(
+                onClick = onFlip,
+                enabled = canFlip,
+                modifier = Modifier
+                    .size(56.dp)
+                    .semantics { contentDescription = "Flip camera" },
+            ) {
+                Icon(
+                    imageVector = Icons.Filled.Cameraswitch,
+                    contentDescription = null,
+                    tint = if (canFlip) Color.White else Color.White.copy(alpha = 0.4f),
+                )
+            }
+
+            // Center: the record / stop button (or a spinner while saving).
+            when (state) {
+                is RecordingState.Saving -> CircularProgressIndicator(color = Color.White)
+                else -> RecordButton(
+                    recording = state is RecordingState.Recording,
+                    onClick = onRecordButton,
+                )
+            }
+
+            // Right: spacer to keep the record button centered.
+            Spacer(modifier = Modifier.size(56.dp))
+        }
+    }
+}
+
+/**
+ * The shutter. A white ring with a red fill; the fill morphs from a circle
+ * (idle / ready) to a rounded square (recording → tap to stop), the universal
+ * camera record/stop affordance.
+ */
+@Composable
+private fun RecordButton(
+    recording: Boolean,
+    onClick: () -> Unit,
+) {
+    Box(
+        modifier = Modifier
+            .size(76.dp)
+            .clip(CircleShape)
+            .background(Color.White.copy(alpha = 0.25f))
+            .clickable(onClick = onClick)
+            .semantics {
+                contentDescription = if (recording) "Stop recording" else "Start recording"
+            },
+        contentAlignment = Alignment.Center,
+    ) {
+        // White ring.
+        Box(
+            modifier = Modifier
+                .size(68.dp)
+                .clip(CircleShape)
+                .background(Color.White),
+            contentAlignment = Alignment.Center,
+        ) {
+            Box(
+                modifier = Modifier
+                    .size(if (recording) 30.dp else 58.dp)
+                    .clip(if (recording) RoundedCornerShape(8.dp) else CircleShape)
+                    .background(Color.Red),
+            )
+        }
+    }
+}
+
+/** Centered result/error card with up to three actions. */
+@Composable
+private fun ResultCard(
+    title: String,
+    body: String,
+    primaryLabel: String,
+    onPrimary: () -> Unit,
+    secondaryLabel: String,
+    onSecondary: () -> Unit,
+    tertiaryLabel: String?,
+    onTertiary: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    val spacing = LocalSpacing.current
+    Surface(
+        modifier = modifier.padding(32.dp),
+        shape = RoundedCornerShape(20.dp),
+        color = MaterialTheme.colorScheme.surface,
+        tonalElevation = 6.dp,
+    ) {
+        Column(
+            modifier = Modifier.padding(spacing.lg),
+            horizontalAlignment = Alignment.CenterHorizontally,
+        ) {
+            Text(
+                text = title,
+                style = MaterialTheme.typography.titleLarge,
+                color = MaterialTheme.colorScheme.onSurface,
+                textAlign = TextAlign.Center,
+            )
+            Spacer(modifier = Modifier.size(spacing.sm))
+            Text(
+                text = body,
+                style = MaterialTheme.typography.bodyMedium,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                textAlign = TextAlign.Center,
+            )
+            Spacer(modifier = Modifier.size(spacing.lg))
+            Button(
+                onClick = onPrimary,
+                modifier = Modifier.fillMaxWidth(),
+            ) {
+                Text(primaryLabel)
+            }
+            Spacer(modifier = Modifier.size(spacing.xs))
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                horizontalArrangement = Arrangement.Center,
+            ) {
+                TextButton(onClick = onSecondary) { Text(secondaryLabel) }
+                if (tertiaryLabel != null) {
+                    TextButton(onClick = onTertiary) { Text(tertiaryLabel) }
+                }
+            }
+        }
+    }
+}
+
+/** Permission rationale shown when CAMERA / RECORD_AUDIO aren't granted. */
+@Composable
+private fun PermissionRationale(
+    onGrant: () -> Unit,
+    onBack: () -> Unit,
+) {
+    val spacing = LocalSpacing.current
+    Box(
+        modifier = Modifier.fillMaxSize().background(MaterialTheme.colorScheme.background),
+        contentAlignment = Alignment.Center,
+    ) {
+        Column(
+            modifier = Modifier.padding(spacing.xl),
+            horizontalAlignment = Alignment.CenterHorizontally,
+        ) {
+            Text(
+                text = "Camera & microphone needed",
+                style = MaterialTheme.typography.titleLarge,
+                color = MaterialTheme.colorScheme.onBackground,
+                textAlign = TextAlign.Center,
+            )
+            Spacer(modifier = Modifier.size(spacing.sm))
+            Text(
+                text = "Recording mode films you reading the script over the live " +
+                    "camera. Grant camera and microphone access to record video " +
+                    "with sound — nothing is captured until you tap record.",
+                style = MaterialTheme.typography.bodyMedium,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                textAlign = TextAlign.Center,
+            )
+            Spacer(modifier = Modifier.size(spacing.lg))
+            Button(onClick = onGrant) { Text("Grant access") }
+            Spacer(modifier = Modifier.size(spacing.xs))
+            TextButton(onClick = onBack) { Text("Not now") }
+        }
+    }
+}
+
+private fun hasPermission(context: android.content.Context, permission: String): Boolean =
+    ContextCompat.checkSelfPermission(context, permission) == PackageManager.PERMISSION_GRANTED
+
+/** mm:ss from elapsed millis (caps minutes at two digits; Shorts are short). */
+private fun formatElapsed(elapsedMs: Long): String {
+    val totalSeconds = elapsedMs / 1000
+    val minutes = totalSeconds / 60
+    val seconds = totalSeconds % 60
+    return "%02d:%02d".format(minutes, seconds)
+}

--- a/feature/src/main/kotlin/in/jphe/storyvox/feature/reader/recording/RecordingState.kt
+++ b/feature/src/main/kotlin/in/jphe/storyvox/feature/reader/recording/RecordingState.kt
@@ -1,0 +1,62 @@
+package `in`.jphe.storyvox.feature.reader.recording
+
+import android.net.Uri
+
+/**
+ * Issue #1367 — Recording mode state machine.
+ *
+ * A standalone recording surface composites the front camera preview behind
+ * the semi-transparent teleprompter script (the chapter currently loaded in
+ * the reader) so the user can film a YouTube Short / Reel / TikTok while
+ * reading. This sealed type is the single source of truth for what the
+ * [RecordingScreen] is showing; [RecordingViewModel] owns one
+ * `StateFlow<RecordingState>` and drives it through the lifecycle below.
+ *
+ * The actual CameraX recording is driven out-of-band: the ViewModel emits
+ * [RecordingCommand]s that the composable (which owns the lifecycle-bound
+ * [CameraRecorder]) executes, then reports back via
+ * [RecordingViewModel.onRecordingFinalized] / [RecordingViewModel.onRecordingError].
+ * Keeping the camera glue out of the ViewModel keeps the state machine a pure,
+ * Android-camera-free unit (testable without a device).
+ */
+sealed interface RecordingState {
+
+    /** Live camera preview, no recording in flight — the user frames
+     *  themselves and reads along (script scrolls only once recording). */
+    data object Preview : RecordingState
+
+    /** The 3-2-1 lead-in before recording arms. [secondsLeft] ticks 3 → 1; at
+     *  0 the ViewModel transitions to [Recording] and fires
+     *  [RecordingCommand.Start]. */
+    data class Countdown(val secondsLeft: Int) : RecordingState
+
+    /** Recording is live. [elapsedMs] advances ~10×/sec for the on-screen
+     *  timer; the teleprompter script auto-scrolls at the configured WPM. */
+    data class Recording(val elapsedMs: Long) : RecordingState
+
+    /** Stop was requested; waiting for CameraX to finalize the MP4 into
+     *  MediaStore. Brief — usually a few hundred ms. */
+    data object Saving : RecordingState
+
+    /** The clip finalized to the gallery. [uri] is the MediaStore content Uri
+     *  (openable / shareable). */
+    data class Done(val uri: Uri) : RecordingState
+
+    /** Recording or finalization failed. [message] is user-facing. */
+    data class Error(val message: String) : RecordingState
+}
+
+/**
+ * One-shot instructions from [RecordingViewModel] to the camera-owning
+ * composable. Delivered over a buffered channel (collected as a Flow) so a
+ * command issued during a recomposition gap isn't dropped.
+ */
+sealed interface RecordingCommand {
+
+    /** Begin capturing video+audio to a MediaStore entry named [displayName]
+     *  (no extension — CameraX appends `.mp4`). */
+    data class Start(val displayName: String) : RecordingCommand
+
+    /** Stop the active recording and finalize it. */
+    data object Stop : RecordingCommand
+}

--- a/feature/src/main/kotlin/in/jphe/storyvox/feature/reader/recording/RecordingViewModel.kt
+++ b/feature/src/main/kotlin/in/jphe/storyvox/feature/reader/recording/RecordingViewModel.kt
@@ -1,0 +1,200 @@
+package `in`.jphe.storyvox.feature.reader.recording
+
+import android.net.Uri
+import android.os.SystemClock
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import dagger.hilt.android.lifecycle.HiltViewModel
+import `in`.jphe.storyvox.feature.api.PlaybackControllerUi
+import `in`.jphe.storyvox.playback.TeleprompterController
+import java.text.SimpleDateFormat
+import java.util.Date
+import java.util.Locale
+import javax.inject.Inject
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.channels.Channel
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.SharingStarted
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.flow.receiveAsFlow
+import kotlinx.coroutines.flow.stateIn
+import kotlinx.coroutines.isActive
+import kotlinx.coroutines.launch
+
+/**
+ * Issue #1367 — Recording mode ViewModel.
+ *
+ * Drives the [RecordingState] machine for [RecordingScreen]. The script and
+ * its pace are read straight off the two playback singletons the reader
+ * already shares — no nav argument or bespoke holder:
+ *  - [PlaybackControllerUi.chapterText] is the chapter currently loaded in the
+ *    reader (the same text the teleprompter scrolls), used as the script.
+ *  - [PlaybackControllerUi.state] supplies the title for the saved clip's name.
+ *  - [TeleprompterController.wpm] is the live rehearsal pace (#1308) the
+ *    overlay auto-scrolls at, so Recording mode inherits whatever the user
+ *    last set in the reader's teleprompter transport.
+ *
+ * The ViewModel deliberately holds **no** CameraX types: it emits
+ * [RecordingCommand]s for the lifecycle-owning composable to run and receives
+ * results back via [onRecordingFinalized] / [onRecordingError]. That keeps the
+ * countdown / elapsed / save state logic a plain, device-free unit.
+ */
+@HiltViewModel
+class RecordingViewModel @Inject constructor(
+    playback: PlaybackControllerUi,
+    teleprompter: TeleprompterController,
+) : ViewModel() {
+
+    /** The chapter text to read — the same script the reader's teleprompter
+     *  shows. Empty until a chapter is loaded (the Record entry point only
+     *  exists once the teleprompter is on, so it's populated in practice). */
+    val script: StateFlow<String> = playback.chapterText
+        .stateIn(viewModelScope, SharingStarted.WhileSubscribed(5_000), "")
+
+    /** Display title for the saved clip's filename — chapter title, falling
+     *  back to the fiction title, then a generic label. */
+    val title: StateFlow<String> = playback.state
+        .map { it.chapterTitle.ifBlank { it.fictionTitle }.ifBlank { "Candela script" } }
+        .stateIn(viewModelScope, SharingStarted.WhileSubscribed(5_000), "Candela script")
+
+    /** Live teleprompter pace (#1308), inherited from the reader. */
+    val wpm: StateFlow<Int> = teleprompter.wpm
+
+    private val _uiState = MutableStateFlow<RecordingState>(RecordingState.Preview)
+    val uiState: StateFlow<RecordingState> = _uiState.asStateFlow()
+
+    /** Script-overlay opacity (white-on-camera), 30–100%. Default 70% per
+     *  #1367. Adjustable live so the user can trade legibility against how
+     *  much of their face the text covers. */
+    private val _opacity = MutableStateFlow(DEFAULT_OPACITY)
+    val opacity: StateFlow<Float> = _opacity.asStateFlow()
+
+    /** True = front (selfie) camera. Front by default — this is a
+     *  read-to-camera workflow. */
+    private val _frontCamera = MutableStateFlow(true)
+    val frontCamera: StateFlow<Boolean> = _frontCamera.asStateFlow()
+
+    private val _commands = Channel<RecordingCommand>(Channel.BUFFERED)
+
+    /** One-shot camera instructions for the composable to execute against its
+     *  lifecycle-bound [CameraRecorder]. */
+    val commands = _commands.receiveAsFlow()
+
+    private var countdownJob: Job? = null
+    private var elapsedJob: Job? = null
+
+    /**
+     * The record/stop button. Context-sensitive:
+     *  - [RecordingState.Preview] → start the 3-2-1 countdown.
+     *  - [RecordingState.Countdown] → abort back to preview (tap to cancel).
+     *  - [RecordingState.Recording] → stop and save.
+     *  - [RecordingState.Done] / [RecordingState.Error] → reset to preview
+     *    ("record again").
+     */
+    fun onRecordButton() {
+        when (_uiState.value) {
+            is RecordingState.Preview -> startCountdown()
+            is RecordingState.Countdown -> abortCountdown()
+            is RecordingState.Recording -> stopRecording()
+            is RecordingState.Done, is RecordingState.Error -> reset()
+            is RecordingState.Saving -> Unit // wait for finalize
+        }
+    }
+
+    private fun startCountdown() {
+        countdownJob?.cancel()
+        countdownJob = viewModelScope.launch {
+            for (s in COUNTDOWN_SECONDS downTo 1) {
+                _uiState.value = RecordingState.Countdown(s)
+                delay(1_000)
+            }
+            beginRecording()
+        }
+    }
+
+    private fun abortCountdown() {
+        countdownJob?.cancel()
+        countdownJob = null
+        _uiState.value = RecordingState.Preview
+    }
+
+    private fun beginRecording() {
+        _uiState.value = RecordingState.Recording(0L)
+        _commands.trySend(RecordingCommand.Start(buildDisplayName()))
+        elapsedJob?.cancel()
+        elapsedJob = viewModelScope.launch {
+            val start = SystemClock.elapsedRealtime()
+            while (isActive && _uiState.value is RecordingState.Recording) {
+                _uiState.value = RecordingState.Recording(SystemClock.elapsedRealtime() - start)
+                delay(ELAPSED_TICK_MS)
+            }
+        }
+    }
+
+    /** Stop the active recording — the composable finalizes the MP4 and reports
+     *  back via [onRecordingFinalized] / [onRecordingError]. */
+    fun stopRecording() {
+        if (_uiState.value !is RecordingState.Recording) return
+        elapsedJob?.cancel()
+        elapsedJob = null
+        _uiState.value = RecordingState.Saving
+        _commands.trySend(RecordingCommand.Stop)
+    }
+
+    /** Camera reported the clip finalized to the gallery. */
+    fun onRecordingFinalized(uri: Uri) {
+        _uiState.value = RecordingState.Done(uri)
+    }
+
+    /** Camera reported a recording / finalization failure. */
+    fun onRecordingError(message: String) {
+        countdownJob?.cancel()
+        elapsedJob?.cancel()
+        _uiState.value = RecordingState.Error(message)
+    }
+
+    /** Flip front/back. Disallowed while a recording or save is in flight —
+     *  rebinding the camera mid-capture would abort the clip. */
+    fun flipCamera() {
+        when (_uiState.value) {
+            is RecordingState.Recording, is RecordingState.Saving -> return
+            else -> _frontCamera.value = !_frontCamera.value
+        }
+    }
+
+    fun setOpacity(value: Float) {
+        _opacity.value = value.coerceIn(MIN_OPACITY, MAX_OPACITY)
+    }
+
+    /** Back to a clean live preview (after a save, an error, or "record
+     *  again"). */
+    fun reset() {
+        countdownJob?.cancel()
+        elapsedJob?.cancel()
+        countdownJob = null
+        elapsedJob = null
+        _uiState.value = RecordingState.Preview
+    }
+
+    private fun buildDisplayName(): String {
+        val stamp = SimpleDateFormat("yyyyMMdd_HHmmss", Locale.US).format(Date())
+        val safeTitle = title.value
+            .replace(Regex("[^A-Za-z0-9 ]"), "")
+            .trim()
+            .take(40)
+            .ifBlank { "script" }
+            .replace(' ', '_')
+        return "Candela_${safeTitle}_$stamp"
+    }
+
+    companion object {
+        const val COUNTDOWN_SECONDS = 3
+        const val DEFAULT_OPACITY = 0.7f
+        const val MIN_OPACITY = 0.3f
+        const val MAX_OPACITY = 1.0f
+        private const val ELAPSED_TICK_MS = 100L
+    }
+}

--- a/feature/src/main/kotlin/in/jphe/storyvox/feature/reader/recording/RecordingViewModel.kt
+++ b/feature/src/main/kotlin/in/jphe/storyvox/feature/reader/recording/RecordingViewModel.kt
@@ -77,6 +77,16 @@ class RecordingViewModel @Inject constructor(
     private val _frontCamera = MutableStateFlow(true)
     val frontCamera: StateFlow<Boolean> = _frontCamera.asStateFlow()
 
+    /** Script font size in sp (#1367 design ref — A−/A+). Sized for camera
+     *  distance: a phone on a tripod needs bigger text than one held close. */
+    private val _fontSize = MutableStateFlow(DEFAULT_FONT_SP)
+    val fontSize: StateFlow<Int> = _fontSize.asStateFlow()
+
+    /** Mirror the script horizontally for beam-splitter glass teleprompter
+     *  rigs (the text reads correctly through the half-silvered mirror). */
+    private val _mirror = MutableStateFlow(false)
+    val mirror: StateFlow<Boolean> = _mirror.asStateFlow()
+
     private val _commands = Channel<RecordingCommand>(Channel.BUFFERED)
 
     /** One-shot camera instructions for the composable to execute against its
@@ -169,6 +179,15 @@ class RecordingViewModel @Inject constructor(
         _opacity.value = value.coerceIn(MIN_OPACITY, MAX_OPACITY)
     }
 
+    /** Step the script font size (A− / A+) within the supported band. */
+    fun adjustFontSize(deltaSp: Int) {
+        _fontSize.value = (_fontSize.value + deltaSp).coerceIn(MIN_FONT_SP, MAX_FONT_SP)
+    }
+
+    fun toggleMirror() {
+        _mirror.value = !_mirror.value
+    }
+
     /** Back to a clean live preview (after a save, an error, or "record
      *  again"). */
     fun reset() {
@@ -195,6 +214,12 @@ class RecordingViewModel @Inject constructor(
         const val DEFAULT_OPACITY = 0.7f
         const val MIN_OPACITY = 0.3f
         const val MAX_OPACITY = 1.0f
+        // Font band (sp). The web ref uses 24–120px on a broadcast monitor;
+        // capped tighter here for a phone screen held / tripod-mounted.
+        const val DEFAULT_FONT_SP = 26
+        const val MIN_FONT_SP = 16
+        const val MAX_FONT_SP = 64
+        const val FONT_STEP_SP = 4
         private const val ELAPSED_TICK_MS = 100L
     }
 }

--- a/feature/src/main/kotlin/in/jphe/storyvox/feature/reader/recording/TeleprompterOverlay.kt
+++ b/feature/src/main/kotlin/in/jphe/storyvox/feature/reader/recording/TeleprompterOverlay.kt
@@ -1,0 +1,297 @@
+package `in`.jphe.storyvox.feature.reader.recording
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.IntrinsicSize
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxHeight
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.withFrameNanos
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.draw.drawBehind
+import androidx.compose.ui.draw.drawWithContent
+import androidx.compose.ui.geometry.CornerRadius
+import androidx.compose.ui.graphics.BlendMode
+import androidx.compose.ui.graphics.Brush
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.CompositingStrategy
+import androidx.compose.ui.graphics.PathEffect
+import androidx.compose.ui.graphics.drawscope.Stroke
+import androidx.compose.ui.graphics.graphicsLayer
+import androidx.compose.ui.text.AnnotatedString
+import androidx.compose.ui.text.SpanStyle
+import androidx.compose.ui.text.buildAnnotatedString
+import androidx.compose.ui.text.font.FontStyle
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.text.withStyle
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import `in`.jphe.storyvox.feature.reader.teleprompterScrollDeltaPx
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.isActive
+
+/**
+ * Issue #1367 — the teleprompter text layer composited over the camera, with
+ * the production cues ported from the TechEmpower Show web prompter:
+ *  - **Speaker colour-coding** — a left accent bar + label per speaker (coral,
+ *    teal, … by first appearance).
+ *  - **Section banners** — centered uppercase chips.
+ *  - **Production cues** (`[POST: ...]`) — dashed, italic, dimmed; not spoken.
+ *  - **Eye-line markers** — fixed chevrons at 38% height (look here ≈ the lens).
+ *  - **Edge fades** — the top/bottom 14% of the text fades to transparent so it
+ *    doesn't hard-cut over the camera (the camera stays fully visible — only the
+ *    text's alpha is masked).
+ *  - **Mirror mode** — horizontal flip for beam-splitter glass rigs.
+ *  - **Font size** — caller-controlled, for camera distance.
+ *
+ * The script is parsed once ([parseTeleprompterScript]); the spoken-word count
+ * (cues/sections excluded) drives the auto-scroll pace via the reader's shared
+ * [teleprompterScrollDeltaPx] math, so the pace matches the in-reader
+ * teleprompter exactly. Scrolls only while [scrolling] (recording); before that
+ * it rests at the top so the user can frame themselves.
+ */
+@Composable
+fun TeleprompterOverlay(
+    script: String,
+    wpm: Int,
+    fontSize: Int,
+    opacity: Float,
+    mirror: Boolean,
+    scrolling: Boolean,
+    modifier: Modifier = Modifier,
+) {
+    val parsed = remember(script) { parseTeleprompterScript(script) }
+    val scroll = rememberScrollState()
+
+    LaunchedEffect(scrolling, wpm, parsed.spokenWordCount) {
+        if (!scrolling || parsed.spokenWordCount <= 0) return@LaunchedEffect
+        scroll.scrollTo(0)
+        var lastFrame = 0L
+        var carry = 0f
+        while (isActive) {
+            val frame = withFrameNanos { it }
+            if (lastFrame != 0L && scroll.maxValue > 0) {
+                val px = teleprompterScrollDeltaPx(
+                    wpm = wpm,
+                    totalWords = parsed.spokenWordCount,
+                    scrollableHeightPx = scroll.maxValue,
+                    elapsedNanos = frame - lastFrame,
+                ) + carry
+                val whole = px.toInt()
+                carry = px - whole
+                if (whole > 0) {
+                    try {
+                        scroll.scrollTo(scroll.value + whole)
+                    } catch (e: CancellationException) {
+                        if (!isActive) throw e
+                        carry = 0f
+                    }
+                }
+                if (scroll.value >= scroll.maxValue) break
+            }
+            lastFrame = frame
+        }
+    }
+
+    Box(modifier = modifier.fillMaxSize()) {
+        if (parsed.blocks.isNotEmpty()) {
+            Column(
+                modifier = Modifier
+                    .fillMaxSize()
+                    .graphicsLayer {
+                        if (mirror) scaleX = -1f
+                        // Render to an offscreen layer so the edge-fade DstIn
+                        // mask blends against the layer's own transparency
+                        // (revealing the camera) rather than the camera pixels.
+                        compositingStrategy = CompositingStrategy.Offscreen
+                    }
+                    .drawWithContent {
+                        drawContent()
+                        val fade = size.height * EDGE_FADE_FRACTION
+                        drawRect(
+                            brush = Brush.verticalGradient(
+                                0f to Color.Transparent,
+                                (fade / size.height) to Color.Black,
+                                1f - (fade / size.height) to Color.Black,
+                                1f to Color.Transparent,
+                            ),
+                            blendMode = BlendMode.DstIn,
+                        )
+                    }
+                    .verticalScroll(scroll)
+                    .padding(horizontal = 24.dp, vertical = 150.dp),
+            ) {
+                parsed.blocks.forEach { block ->
+                    when (block) {
+                        is ScriptBlock.Section -> SectionChip(block.title, fontSize, opacity)
+                        is ScriptBlock.Cue -> CueCard(block.text, fontSize, opacity)
+                        is ScriptBlock.Line -> ScriptLineRow(block, fontSize, opacity)
+                    }
+                }
+            }
+        }
+
+        // Eye-line chevrons — fixed at 38% height, NOT inside the scroll/mirror
+        // layer (they stay put and unmirrored).
+        EyeLineMarkers(opacity)
+    }
+}
+
+/** Fixed inward-pointing chevrons at 38% viewport height — the speaker looks
+ *  here, near the lens, instead of down at the text. */
+@Composable
+private fun EyeLineMarkers(opacity: Float) {
+    Column(modifier = Modifier.fillMaxSize()) {
+        Spacer(modifier = Modifier.weight(EYELINE_FRACTION))
+        Row(
+            modifier = Modifier.fillMaxWidth().padding(horizontal = 12.dp),
+            horizontalArrangement = Arrangement.SpaceBetween,
+        ) {
+            val tint = AccentColor.copy(alpha = 0.85f * opacity)
+            Text(text = "▶", color = tint, fontSize = 22.sp) // ▶
+            Text(text = "◀", color = tint, fontSize = 22.sp) // ◀
+        }
+        Spacer(modifier = Modifier.weight(1f - EYELINE_FRACTION))
+    }
+}
+
+@Composable
+private fun SectionChip(title: String, fontSize: Int, opacity: Float) {
+    Box(
+        modifier = Modifier.fillMaxWidth().padding(vertical = 16.dp),
+        contentAlignment = Alignment.Center,
+    ) {
+        Text(
+            text = title.uppercase(),
+            color = AccentColor.copy(alpha = opacity),
+            fontSize = (fontSize * 0.5f).sp,
+            lineHeight = (fontSize * 0.7f).sp,
+            fontWeight = FontWeight.ExtraBold,
+            letterSpacing = 1.5.sp,
+            textAlign = TextAlign.Center,
+            maxLines = 3,
+            overflow = TextOverflow.Ellipsis,
+            modifier = Modifier
+                .clip(RoundedCornerShape(10.dp))
+                .background(Color.Black.copy(alpha = 0.32f))
+                .padding(horizontal = 14.dp, vertical = 8.dp),
+        )
+    }
+}
+
+@Composable
+private fun CueCard(text: String, fontSize: Int, opacity: Float) {
+    val dim = Color.White.copy(alpha = 0.62f * opacity)
+    Box(
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(vertical = 12.dp)
+            .drawBehind {
+                drawRoundRect(
+                    color = dim,
+                    cornerRadius = CornerRadius(10.dp.toPx()),
+                    style = Stroke(
+                        width = 1.5.dp.toPx(),
+                        pathEffect = PathEffect.dashPathEffect(floatArrayOf(12f, 10f)),
+                    ),
+                )
+            }
+            .padding(horizontal = 14.dp, vertical = 10.dp),
+    ) {
+        Text(
+            text = text,
+            color = dim,
+            fontStyle = FontStyle.Italic,
+            fontSize = (fontSize * 0.6f).sp,
+            lineHeight = (fontSize * 0.85f).sp,
+        )
+    }
+}
+
+@Composable
+private fun ScriptLineRow(line: ScriptBlock.Line, fontSize: Int, opacity: Float) {
+    val speakerColor = line.speaker?.let {
+        SpeakerPalette[it.colorIndex % SpeakerPalette.size].copy(alpha = opacity)
+    }
+    Column(modifier = Modifier.fillMaxWidth().padding(vertical = 4.dp)) {
+        if (line.showLabel && line.speaker != null && speakerColor != null) {
+            Text(
+                text = line.speaker.name,
+                color = speakerColor,
+                fontSize = (fontSize * 0.5f).sp,
+                fontWeight = FontWeight.ExtraBold,
+                letterSpacing = 1.sp,
+                modifier = Modifier.padding(top = 10.dp, bottom = 2.dp),
+            )
+        }
+        if (line.segments.isNotEmpty()) {
+            Row(modifier = Modifier.fillMaxWidth().height(IntrinsicSize.Min)) {
+                if (speakerColor != null) {
+                    Box(
+                        modifier = Modifier
+                            .width(3.dp)
+                            .fillMaxHeight()
+                            .clip(RoundedCornerShape(2.dp))
+                            .background(speakerColor),
+                    )
+                    Spacer(modifier = Modifier.width(10.dp))
+                }
+                Text(
+                    text = buildLine(line.segments, opacity),
+                    fontSize = fontSize.sp,
+                    lineHeight = (fontSize * 1.4f).sp,
+                    fontWeight = FontWeight.Medium,
+                    modifier = Modifier.weight(1f),
+                )
+            }
+        }
+    }
+}
+
+/** Spoken runs in white@opacity, inline cues dimmed + italic. */
+private fun buildLine(segments: List<LineSegment>, opacity: Float): AnnotatedString {
+    val spoken = SpanStyle(color = Color.White.copy(alpha = opacity))
+    val cue = SpanStyle(color = Color.White.copy(alpha = 0.62f * opacity), fontStyle = FontStyle.Italic)
+    return buildAnnotatedString {
+        segments.forEach { segment ->
+            when (segment) {
+                is LineSegment.Spoken -> withStyle(spoken) { append(segment.text) }
+                is LineSegment.InlineCue -> withStyle(cue) { append(segment.text) }
+            }
+        }
+    }
+}
+
+/** TechEmpower Show accent (amber) used for section chips + eye-line markers. */
+private val AccentColor = Color(0xFFE8A13C)
+
+/** Speaker colours assigned by first-appearance order. Coral + teal match the
+ *  web prompter's Shawna/Jeff; the rest cover scripts with more voices. */
+private val SpeakerPalette = listOf(
+    Color(0xFFE87A5D), // coral
+    Color(0xFF5DA89B), // teal
+    Color(0xFFE8A13C), // amber
+    Color(0xFFB98AE0), // violet
+    Color(0xFF7FB069), // sage
+)
+
+private const val EDGE_FADE_FRACTION = 0.14f
+private const val EYELINE_FRACTION = 0.38f

--- a/feature/src/main/kotlin/in/jphe/storyvox/feature/reader/recording/TeleprompterScript.kt
+++ b/feature/src/main/kotlin/in/jphe/storyvox/feature/reader/recording/TeleprompterScript.kt
@@ -1,0 +1,169 @@
+package `in`.jphe.storyvox.feature.reader.recording
+
+/**
+ * Issue #1367 — teleprompter script model + parser, ported from the TechEmpower
+ * Show web teleprompter (`techempower/show/ep2/teleprompter.html`).
+ *
+ * Production scripts (multi-speaker, section-structured, with production cues)
+ * follow a plain-text convention the web prompter already parses:
+ *  - **Section banners** — a title line framed by rows of `=` (or `-`):
+ *    ```
+ *    ================================
+ *    BENEFIT ONE: THE ZERO-DOLLAR PHONE
+ *    ================================
+ *    ```
+ *  - **Speaker tags** — an ALL-CAPS name + colon starting a block (`SHAWNA:`),
+ *    which colours that turn and every following turn until the next tag.
+ *  - **Production cues** — `[POST: ...]` blocks (or inline `[...]`), shown
+ *    dimmed/italic and **never counted as spoken words** (they're editor notes,
+ *    not dialogue).
+ *  - Everything else is spoken dialogue.
+ *
+ * The parser is pure (no Android / Compose) so it's unit-testable against the
+ * real ep1/ep2 scripts. Plain prose with none of these markers degrades to a
+ * single unattributed [ScriptBlock.Line] — so a novel chapter still renders.
+ *
+ * ## Classification order matters
+ * Section banners are detected **before** speaker tags: `BENEFIT ONE:` /
+ * `THE MYTH:` are ALL-CAPS-and-colon (they look like speaker tags) but always
+ * sit between `=` rows, so catching banners first keeps them out of the speaker
+ * path — exactly as the reference JS does.
+ */
+
+/** A parsed block of the script in render order. */
+sealed interface ScriptBlock {
+    /** A centered section banner (the title between `=` rows). */
+    data class Section(val title: String) : ScriptBlock
+
+    /** A standalone production cue (`[POST: ...]`) — not spoken. */
+    data class Cue(val text: String) : ScriptBlock
+
+    /**
+     * A spoken line. [speaker] is the attributed speaker (null before the first
+     * tag / in unattributed prose); [showLabel] is true only when this block
+     * carried an explicit `NAME:` tag, so multi-block turns repeat the colour
+     * bar but not the label. [segments] interleaves spoken text and inline cues.
+     */
+    data class Line(
+        val speaker: ScriptSpeaker?,
+        val showLabel: Boolean,
+        val segments: List<LineSegment>,
+    ) : ScriptBlock
+}
+
+/** A speaker, with a stable [colorIndex] assigned by order of first appearance
+ *  (0 = first speaker seen). The UI maps the index onto a colour palette, so
+ *  the first speaker is coral, the second teal, etc. — matching the web
+ *  prompter's Shawna/Jeff colouring without hard-coding names. */
+data class ScriptSpeaker(val name: String, val colorIndex: Int)
+
+/** A run within a spoken line. */
+sealed interface LineSegment {
+    data class Spoken(val text: String) : LineSegment
+    data class InlineCue(val text: String) : LineSegment
+}
+
+/**
+ * The parse result: [blocks] in render order plus [spokenWordCount] (cues and
+ * section banners excluded), which drives the auto-scroll pace so the prompter
+ * finishes a script in roughly `spokenWords / wpm` minutes — the cues scroll by
+ * "for free" in the gaps.
+ */
+data class ParsedScript(
+    val blocks: List<ScriptBlock>,
+    val spokenWordCount: Int,
+)
+
+private val BLANK_LINE = Regex("\\n\\s*\\n")
+private val DIVIDER = Regex("^[=\\-]{3,}$")
+private val STANDALONE_CUE = Regex("^\\[[^\\]]+\\]$")
+private val INLINE_CUE = Regex("\\[[^\\]]+\\]")
+private val WHITESPACE = Regex("\\s+")
+
+/** A speaker tag: an ALL-CAPS (digits / space / `.` / `'` / `-` allowed) name
+ *  up to 25 chars, then a colon, then the rest of the (joined) block. The
+ *  upper-case-only, length-capped shape keeps lowercase prose such as `Hosts:`
+ *  or `PROMPTER NOTES (do not read):` from registering as speakers. */
+private val SPEAKER_TAG = Regex("^([A-Z][A-Z0-9 .'\\-]{0,24}):\\s*(.*)$")
+
+/** Parse a raw chapter/script into [ParsedScript]. See the file KDoc for the
+ *  convention. Safe on arbitrary text — unmarked prose becomes plain lines. */
+fun parseTeleprompterScript(raw: String): ParsedScript {
+    val blocks = mutableListOf<ScriptBlock>()
+    val speakerIndex = LinkedHashMap<String, Int>()
+    var currentSpeaker: ScriptSpeaker? = null
+    var spokenWords = 0
+
+    val rawBlocks = raw.split(BLANK_LINE).map { it.trim() }.filter { it.isNotEmpty() }
+    for (block in rawBlocks) {
+        val lines = block.split("\n").map { it.trim() }
+
+        // 1 — section banner (checked first; see file KDoc).
+        if (lines.any { DIVIDER.matches(it) }) {
+            val title = lines.filterNot { DIVIDER.matches(it) }.joinToString(" ").trim()
+            if (title.isNotEmpty()) {
+                blocks.add(ScriptBlock.Section(title))
+                currentSpeaker = null
+            }
+            continue
+        }
+
+        val text = lines.joinToString(" ").trim()
+        if (text.isEmpty()) continue
+
+        // 2 — standalone production cue.
+        if (STANDALONE_CUE.matches(text)) {
+            blocks.add(ScriptBlock.Cue(text))
+            continue
+        }
+
+        // 3 — speaker tag (optional), then the spoken line.
+        var lineText = text
+        var explicitTag = false
+        val match = SPEAKER_TAG.matchEntire(text)
+        if (match != null) {
+            val name = match.groupValues[1].trim()
+            val index = speakerIndex.getOrPut(name) { speakerIndex.size }
+            currentSpeaker = ScriptSpeaker(name, index)
+            lineText = match.groupValues[2].trim()
+            explicitTag = true
+        }
+
+        if (lineText.isEmpty()) {
+            // A bare `NAME:` block — render the label, dialogue follows in the
+            // next block (inherits currentSpeaker).
+            blocks.add(ScriptBlock.Line(currentSpeaker, showLabel = true, segments = emptyList()))
+            continue
+        }
+
+        val segments = segmentLine(lineText)
+        spokenWords += segments.filterIsInstance<LineSegment.Spoken>()
+            .sumOf { countWords(it.text) }
+        blocks.add(ScriptBlock.Line(currentSpeaker, showLabel = explicitTag, segments = segments))
+    }
+
+    return ParsedScript(blocks, spokenWords)
+}
+
+/** Split a line into spoken runs and inline `[...]` cues, in order. */
+private fun segmentLine(text: String): List<LineSegment> {
+    val segments = mutableListOf<LineSegment>()
+    var cursor = 0
+    for (match in INLINE_CUE.findAll(text)) {
+        if (match.range.first > cursor) {
+            val spoken = text.substring(cursor, match.range.first)
+            if (spoken.isNotEmpty()) segments.add(LineSegment.Spoken(spoken))
+        }
+        segments.add(LineSegment.InlineCue(match.value))
+        cursor = match.range.last + 1
+    }
+    if (cursor < text.length) {
+        val spoken = text.substring(cursor)
+        if (spoken.isNotEmpty()) segments.add(LineSegment.Spoken(spoken))
+    }
+    if (segments.isEmpty()) segments.add(LineSegment.Spoken(text))
+    return segments
+}
+
+private fun countWords(text: String): Int =
+    if (text.isBlank()) 0 else text.trim().split(WHITESPACE).count { it.isNotBlank() }

--- a/feature/src/test/kotlin/in/jphe/storyvox/feature/reader/recording/TeleprompterScriptTest.kt
+++ b/feature/src/test/kotlin/in/jphe/storyvox/feature/reader/recording/TeleprompterScriptTest.kt
@@ -1,0 +1,97 @@
+package `in`.jphe.storyvox.feature.reader.recording
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * Issue #1367 — pins the teleprompter script parser against the real
+ * TechEmpower Show format (multi-speaker, `====` section banners, `[POST: ...]`
+ * production cues), exercising the pure parser directly (no Android / Compose).
+ */
+class TeleprompterScriptTest {
+
+    @Test
+    fun `speakers, section banners, and cues classify in order`() {
+        val raw = """
+            [POST: JINGLE + LOGO INTRO -- hold one beat]
+
+            SHAWNA:
+            Welcome back to the show. I'm Shawna.
+
+            JEFF:
+            And I'm Jeff.
+
+            ================================================================
+            BENEFIT ONE: THE ZERO-DOLLAR PHONE PLAN
+            ================================================================
+
+            SHAWNA:
+            Okay -- start with the phone [POST: card on screen] now.
+        """.trimIndent()
+
+        val blocks = parseTeleprompterScript(raw).blocks
+
+        // [POST...] standalone cue.
+        assertTrue(blocks[0] is ScriptBlock.Cue)
+
+        // First speaker → colorIndex 0, label shown.
+        val shawna = blocks[1] as ScriptBlock.Line
+        assertEquals("SHAWNA", shawna.speaker?.name)
+        assertEquals(0, shawna.speaker?.colorIndex)
+        assertTrue(shawna.showLabel)
+
+        // Second distinct speaker → colorIndex 1.
+        val jeff = blocks[2] as ScriptBlock.Line
+        assertEquals("JEFF", jeff.speaker?.name)
+        assertEquals(1, jeff.speaker?.colorIndex)
+
+        // `BENEFIT ONE:` looks like a speaker tag but is framed by `=` rows, so
+        // it must classify as a Section (banner-before-speaker ordering).
+        val section = blocks[3] as ScriptBlock.Section
+        assertTrue(section.title.contains("BENEFIT ONE"))
+
+        // Re-used speaker keeps colorIndex 0; the inline cue splits out.
+        val shawnaAgain = blocks[4] as ScriptBlock.Line
+        assertEquals(0, shawnaAgain.speaker?.colorIndex)
+        assertTrue(shawnaAgain.segments.any { it is LineSegment.InlineCue })
+        assertTrue(shawnaAgain.segments.any { it is LineSegment.Spoken })
+    }
+
+    @Test
+    fun `inline and standalone cues are excluded from spoken word count`() {
+        val raw = """
+            [POST: this whole block is an ignored cue]
+
+            JEFF:
+            Two words [POST: ignored cue words here] more text.
+        """.trimIndent()
+
+        // Spoken = "Two words" + "more text." = 4; cues contribute nothing.
+        assertEquals(4, parseTeleprompterScript(raw).spokenWordCount)
+    }
+
+    @Test
+    fun `plain prose with no markers is one unattributed line`() {
+        val raw = "It was a bright cold day in April and the clocks were striking thirteen."
+        val parsed = parseTeleprompterScript(raw)
+        assertEquals(1, parsed.blocks.size)
+        assertNull((parsed.blocks[0] as ScriptBlock.Line).speaker)
+        assertEquals(14, parsed.spokenWordCount)
+    }
+
+    @Test
+    fun `lowercase or parenthetical labels are not treated as speakers`() {
+        val raw = """
+            Hosts: Shawna and Jeff are here.
+
+            PROMPTER NOTES (do not read):
+            don't read this part aloud.
+        """.trimIndent()
+
+        parseTeleprompterScript(raw).blocks.forEach { block ->
+            if (block is ScriptBlock.Line) assertNull(block.speaker)
+        }
+    }
+}

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -136,6 +136,12 @@ androidx-camera-core = { module = "androidx.camera:camera-core", version.ref = "
 androidx-camera-camera2 = { module = "androidx.camera:camera-camera2", version.ref = "camerax" }
 androidx-camera-lifecycle = { module = "androidx.camera:camera-lifecycle", version.ref = "camerax" }
 androidx-camera-view = { module = "androidx.camera:camera-view", version.ref = "camerax" }
+# Issue #1367 — Recording mode. camera-video supplies the VideoCapture stack
+# (Recorder / MediaStoreOutputOptions / AudioConfig) that LifecycleCameraController
+# drives for the teleprompter video recorder. Kept out of the `camerax` bundle
+# because only :feature's recording surface needs it (the OCR scan path is
+# image-only).
+androidx-camera-video = { module = "androidx.camera:camera-video", version.ref = "camerax" }
 
 # Navigation
 androidx-navigation-compose = { module = "androidx.navigation:navigation-compose", version.ref = "navigation-compose" }


### PR DESCRIPTION
## Recording Mode — camera preview behind the teleprompter (#1367)

A new standalone **Recording mode** that composites the front camera preview behind the semi-transparent, auto-scrolling teleprompter script — so a user can film a vertical YouTube Short / Reel / TikTok while reading their script.

### What you get
- **Full-screen camera preview** (CameraX `PreviewView`, front camera by default) as the background.
- **Semi-transparent script overlay** floating on top — the chapter currently loaded in the reader, styled like the teleprompter — auto-scrolling at the configured **WPM** (reuses `ReaderView.teleprompterScrollDeltaPx`, so the pace matches the in-reader teleprompter exactly, frame-rate independent).
- **3-2-1 countdown** before recording arms.
- **Live REC indicator** (red dot + mm:ss timer) while recording.
- **Bottom controls:** record/stop shutter (red circle → rounded square), camera flip, and a **text-opacity slider** (30–100%, default 70%).
- **9:16 output** for Shorts/Reels/TikTok — MP4 (H.264 + AAC) saved straight to the gallery (`MediaStore.Video` → `Movies/Candela`), with a **"View"** deep-link to open it.

### Entry point
A small **Record** `IconButton` (📹) in the reader's teleprompter transport bar → new `StoryvoxRoutes.RECORDING`, wired on all three player routes (Playing / Reader / Audiobook).

### Architecture
| File | Role |
|---|---|
| `RecordingScreen.kt` | The composable: permission gate (CAMERA + RECORD_AUDIO), camera preview, scrolling overlay, countdown, controls, result/error cards. Owns the lifecycle-bound `CameraRecorder`. |
| `RecordingViewModel.kt` | Pure, **camera-free** state machine (`Preview → Countdown → Recording → Saving → Done/Error`). Reads the script + title from `PlaybackControllerUi` and the pace from `TeleprompterController` — both existing `@Singleton`s, so **no nav argument or bespoke holder** is needed; the Record button just navigates. |
| `RecordingState.kt` | Sealed `RecordingState` + `RecordingCommand` (VM → composable). |
| `CameraRecorder.kt` | `LifecycleCameraController` + `camera-video` `VideoCapture`, finalizing to `MediaStore`. Same controller idiom the OCR scan surface already uses. |

The ViewModel emits `RecordingCommand`s that the composable executes against the lifecycle-bound recorder, then reports results back — keeping all CameraX types out of the ViewModel.

### Notable decisions (flagging for review)
- **CameraX `VideoCapture` instead of raw `MediaRecorder`.** The issue suggested `MediaRecorder`, but mixing it with a CameraX preview requires manual `Surface` sharing and is error-prone. `LifecycleCameraController.startRecording` is the modern, recommended path — it handles audio, MediaStore output, and the FHD/9:16 framing in one controller, and reuses the exact idiom already in `OcrCaptureScreen`. Same output contract (MP4 H.264 + AAC to the gallery).
- **New `RECORD_AUDIO` permission** (runtime-requested alongside CAMERA). Heads-up: this is a new dangerous permission → a Play Console data-safety note may be needed at release time.
- **`WRITE_EXTERNAL_STORAGE` scoped to `maxSdkVersion="28"`** — required for `MediaStore` video writes on API 26–28 (minSdk is 26); a no-op on 29+ (scoped storage).
- **Necessary extra touch beyond the issue's file list:** `HybridReaderScreen.kt` gains one `onOpenRecording` param to thread the callback from the nav host down to the transport — unavoidable since it's the `ReaderTextView` call site.

### Files
- **New:** `feature/.../reader/recording/{RecordingScreen,RecordingViewModel,RecordingState,CameraRecorder}.kt`
- **Modified:** `AndroidManifest.xml` (perms), `StoryvoxNavHost.kt` (route + wiring), `feature/build.gradle.kts` + `gradle/libs.versions.toml` (camera-video dep), `ReaderView.kt` (Record button), `HybridReaderScreen.kt` (callback thread-through)

### Testing
Compile is gated on CI (per repo convention — no local gradle). Camera capture, the countdown→record→save flow, and MediaStore output need on-device verification (Z Flip3 has a usable front camera; Waydroid has no real camera). Logic is structured so the ViewModel state machine is device-free if a unit test is wanted later.

Closes #1367

🤖 Generated with [Claude Code](https://claude.com/claude-code)
