### PR TITLE
feat(onboarding): add source picker step (#1370)

### DIFF
--- a/feature/src/main/kotlin/in/jphe/storyvox/feature/browse/BrowseSourceCarousel.kt
+++ b/feature/src/main/kotlin/in/jphe/storyvox/feature/browse/BrowseSourceCarousel.kt
@@ -668,9 +668,9 @@ private fun sourceTagline(id: String): String {
  * material-icons-extended, already on the classpath via the BottomTabBar
  * compass import.
  *
- * `internal` so the Source Catalog screen (#1365) reuses the exact same
- * id→glyph mapping — the carousel card and the catalog card show the same
- * icon for a given source, with one table to keep in sync.
+ * `internal` so the Source Catalog screen (#1365) and onboarding source
+ * picker (#1370) reuse the exact same id→glyph mapping — one table to
+ * keep in sync rather than duplicates that silently drift.
  */
 internal fun sourceGlyph(id: String): ImageVector = when (id) {
     SourceIds.ROYAL_ROAD -> Icons.Filled.AutoStories

--- a/feature/src/main/kotlin/in/jphe/storyvox/feature/onboarding/OnboardingHost.kt
+++ b/feature/src/main/kotlin/in/jphe/storyvox/feature/onboarding/OnboardingHost.kt
@@ -47,16 +47,19 @@ import `in`.jphe.storyvox.feature.components.overlayForeground
  * install (until Settings → Developer → Reset onboarding flips it
  * back for testing).
  *
- * State machine (three steps, forward-only — no Back, by design; if
+ * State machine (four steps, forward-only — no Back, by design; if
  * the user needs to revisit a choice they completed earlier they can
  * use the corresponding affordance in the post-welcome app):
  *
- *   Welcome → VoicePicker → FirstFiction → done.
+ *   Welcome → VoicePicker → SourcePick → FirstFiction → done.
+ *
+ * (#1370 inserted SourcePick — "What do you want to read?" — between the
+ * voice picker and the first-fiction picker.)
  *
  * Each transition is a fade — the screens share the same background
  * colour so a horizontal slide would feel like the user moved
  * "inside" the welcome, which is wrong; the welcome is a single
- * conceptual step composed of three pages.
+ * conceptual step composed of four pages.
  *
  * The host renders `content()` underneath itself unconditionally so
  * the embedded NavHost is alive when the user finally taps a CTA
@@ -96,7 +99,7 @@ fun OnboardingHost(
             content()
         }
         if (show) {
-            // Forward-only three-step state machine. rememberSaveable
+            // Forward-only four-step state machine. rememberSaveable
             // so a configuration change (rotation) doesn't snap the
             // user back to step 1 mid-flow.
             var step by rememberSaveable { mutableStateOf(OnboardingStep.Welcome) }
@@ -119,7 +122,7 @@ fun OnboardingHost(
                     ),
             ) {
                 // Issue #787 — the shared scaffold (dot row +
-                // "Step X of 3" indicator) is hoisted OUTSIDE the
+                // "Step X of N" indicator) is hoisted OUTSIDE the
                 // AnimatedContent so the indicator and any future
                 // chrome stay mounted across step transitions; only
                 // the per-step page body cross-fades. Issue #933
@@ -134,7 +137,13 @@ fun OnboardingHost(
                 // own state (not AnimatedContent's `current`), so the
                 // indicator updates the instant the user taps a CTA
                 // rather than waiting for the cross-fade to complete.
-                OnboardingScaffold(stepIndex = step.ordinal) {
+                OnboardingScaffold(
+                    stepIndex = step.ordinal,
+                    // Derive the dot count from the enum so adding a step
+                    // (e.g. #1370's SourcePick) updates the indicator
+                    // without a second hand-edit here.
+                    totalSteps = OnboardingStep.entries.size,
+                ) {
                     AnimatedContent(
                         targetState = step,
                         transitionSpec = { fadeIn() togetherWith fadeOut() },
@@ -148,12 +157,21 @@ fun OnboardingHost(
                                 },
                             )
                             OnboardingStep.VoicePick -> VoicePickerOnboarding(
-                                onContinue = { step = OnboardingStep.FirstFiction },
-                                onSkip = { step = OnboardingStep.FirstFiction },
+                                onContinue = { step = OnboardingStep.SourcePick },
+                                onSkip = { step = OnboardingStep.SourcePick },
                                 onMoreVoices = {
                                     viewModel.markCompleted()
                                     onOpenVoiceLibrary()
                                 },
+                            )
+                            // #1370 — "What do you want to read?" Toggles
+                            // write straight through to settings, so both
+                            // CTAs are pure navigation onward to the
+                            // first-fiction picker; Skip just leaves the
+                            // default-enabled roster untouched.
+                            OnboardingStep.SourcePick -> SourcePickerOnboarding(
+                                onContinue = { step = OnboardingStep.FirstFiction },
+                                onSkip = { step = OnboardingStep.FirstFiction },
                             )
                             OnboardingStep.FirstFiction -> FirstFictionPicker(
                                 // Issues #644 + #647 (v1.0) — bypass the
@@ -198,8 +216,9 @@ fun OnboardingHost(
     }
 }
 
-/** The three pages of the welcome flow, in display order. */
-internal enum class OnboardingStep { Welcome, VoicePick, FirstFiction }
+/** The four pages of the welcome flow, in display order. #1370 added
+ *  [SourcePick] between the voice picker and the first-fiction picker. */
+internal enum class OnboardingStep { Welcome, VoicePick, SourcePick, FirstFiction }
 
 @HiltViewModel
 class OnboardingHostViewModel @Inject constructor(

--- a/feature/src/main/kotlin/in/jphe/storyvox/feature/onboarding/OnboardingScaffold.kt
+++ b/feature/src/main/kotlin/in/jphe/storyvox/feature/onboarding/OnboardingScaffold.kt
@@ -29,14 +29,16 @@ import `in`.jphe.storyvox.feature.R
 import `in`.jphe.storyvox.ui.theme.LocalSpacing
 
 /**
- * Issue #787 — shared scaffold wrapping each of the three onboarding
- * screens with a step indicator that tells the user where they are in
- * the forward-only flow (Welcome → VoicePick → FirstFiction).
+ * Issue #787 — shared scaffold wrapping each onboarding screen with a
+ * step indicator that tells the user where they are in the forward-only
+ * flow (Welcome → VoicePick → SourcePick → FirstFiction as of #1370).
  *
- * Visual: a row of three dots at the top of the page (filled brass =
- * visited or current, outlined = upcoming) plus a small "Step X of 3"
- * text label below the dots. The dots alone are not screen-reader
- * accessible — TalkBack needs the explicit count — so we surface both.
+ * Visual: a row of [totalSteps] dots at the top of the page (filled
+ * brass = visited or current, outlined = upcoming) plus a small
+ * "Step X of N" text label below the dots. The dots alone are not
+ * screen-reader accessible — TalkBack needs the explicit count — so we
+ * surface both. The host passes [totalSteps] from `OnboardingStep`'s
+ * size so the indicator tracks the flow length automatically.
  *
  * The indicator is informational only: dots are NOT clickable. Per
  * `OnboardingHost.kt`'s state-machine doc, the welcome flow is
@@ -44,7 +46,7 @@ import `in`.jphe.storyvox.ui.theme.LocalSpacing
  * Back affordance.
  *
  * The whole indicator row is wrapped in a [contentDescription] +
- * [liveRegion] so TalkBack announces the step change ("Step 2 of 3")
+ * [liveRegion] so TalkBack announces the step change ("Step 2 of 4")
  * once when the AnimatedContent transition lands on a new screen,
  * rather than re-reading the dot count on every focus pass.
  */

--- a/feature/src/main/kotlin/in/jphe/storyvox/feature/onboarding/SourcePickerOnboarding.kt
+++ b/feature/src/main/kotlin/in/jphe/storyvox/feature/onboarding/SourcePickerOnboarding.kt
@@ -267,7 +267,7 @@ private fun SourceCard(
  * renders, plus the resolved enabled state.
  */
 @Immutable
-internal data class SourcePickRow(
+data class SourcePickRow(
     val id: String,
     val displayName: String,
     val description: String,
@@ -295,7 +295,7 @@ data class OnboardingSourceSection(
  * 20-row wall. A brand-new user thinks in "books vs. news vs. my own
  * stuff", not "Text vs. Ebook", so we re-bucket by intent.
  */
-internal enum class OnboardingSourceGroup(@StringRes val titleRes: Int) {
+enum class OnboardingSourceGroup(@StringRes val titleRes: Int) {
     Books(R.string.onboarding_sources_group_books),
     WebFiction(R.string.onboarding_sources_group_webfiction),
     News(R.string.onboarding_sources_group_news),

--- a/feature/src/main/kotlin/in/jphe/storyvox/feature/onboarding/SourcePickerOnboarding.kt
+++ b/feature/src/main/kotlin/in/jphe/storyvox/feature/onboarding/SourcePickerOnboarding.kt
@@ -281,7 +281,7 @@ internal data class SourcePickRow(
  * this point so the screen never renders a header with no cards.
  */
 @Immutable
-internal data class OnboardingSourceSection(
+data class OnboardingSourceSection(
     val group: OnboardingSourceGroup,
     val rows: List<SourcePickRow>,
 )

--- a/feature/src/main/kotlin/in/jphe/storyvox/feature/onboarding/SourcePickerOnboarding.kt
+++ b/feature/src/main/kotlin/in/jphe/storyvox/feature/onboarding/SourcePickerOnboarding.kt
@@ -1,0 +1,397 @@
+package `in`.jphe.storyvox.feature.onboarding
+
+import androidx.annotation.StringRes
+import androidx.compose.foundation.background
+import androidx.compose.foundation.border
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.widthIn
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.selection.toggleable
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Switch
+import androidx.compose.material3.SwitchDefaults
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.Immutable
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.semantics.Role
+import androidx.compose.ui.text.font.FontFamily
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import androidx.lifecycle.viewModelScope
+import dagger.hilt.android.lifecycle.HiltViewModel
+import `in`.jphe.storyvox.data.source.SourceIds
+import `in`.jphe.storyvox.data.source.plugin.SourceCategory
+import `in`.jphe.storyvox.data.source.plugin.SourcePluginRegistry
+import `in`.jphe.storyvox.feature.R
+import `in`.jphe.storyvox.feature.api.SettingsRepositoryUi
+import `in`.jphe.storyvox.feature.browse.sourceGlyph
+import `in`.jphe.storyvox.ui.component.BrassButton
+import `in`.jphe.storyvox.ui.component.BrassButtonVariant
+import `in`.jphe.storyvox.ui.theme.LocalSpacing
+import javax.inject.Inject
+import kotlinx.coroutines.flow.SharingStarted
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.flow.stateIn
+import kotlinx.coroutines.launch
+
+/**
+ * Issue #1370 — third of the (now four) first-launch welcome screens,
+ * inserted between [VoicePickerOnboarding] and [FirstFictionPicker].
+ *
+ * The voice picker answers "how should it sound"; this screen answers
+ * "what do you want to read". A brand-new user otherwise lands on Browse
+ * with whatever the default-enabled backends happen to be, with no idea
+ * the catalog spans 25+ sources. Surfacing the roster here — grouped
+ * into five plain-English buckets, each row a one-tap toggle — turns
+ * source discovery into an opt-in moment instead of a Settings dig.
+ *
+ * Nothing here is destructive or committing: every toggle writes through
+ * to [SettingsRepositoryUi.setSourcePluginEnabled] immediately (same
+ * persistence path as the full Plugin Manager), so "Continue" and "Skip"
+ * are both pure navigation — Skip simply means "I didn't change the
+ * defaults". The user can revisit every choice in Settings → Plugins,
+ * which the subtitle says out loud.
+ *
+ * Visual style mirrors [VoicePickerOnboarding]: serif brass headline,
+ * a quiet subtitle, then a vertical scroll of brass-edged cards. The
+ * shared dot-row step indicator is supplied by the [OnboardingScaffold]
+ * the host wraps every step in, so this screen owns only its own body.
+ */
+@Composable
+fun SourcePickerOnboarding(
+    onContinue: () -> Unit,
+    onSkip: () -> Unit,
+    viewModel: SourcePickerOnboardingViewModel = hiltViewModel(),
+) {
+    val sections by viewModel.sections.collectAsStateWithLifecycle()
+    SourcePickerOnboardingContent(
+        sections = sections,
+        onToggle = viewModel::toggle,
+        onContinue = onContinue,
+        onSkip = onSkip,
+    )
+}
+
+@Composable
+private fun SourcePickerOnboardingContent(
+    sections: List<OnboardingSourceSection>,
+    onToggle: (id: String, enabled: Boolean) -> Unit,
+    onContinue: () -> Unit,
+    onSkip: () -> Unit,
+) {
+    val spacing = LocalSpacing.current
+    Box(
+        modifier = Modifier
+            .fillMaxSize()
+            .padding(spacing.lg),
+    ) {
+        Column(
+            modifier = Modifier
+                .fillMaxSize()
+                .verticalScroll(rememberScrollState()),
+            horizontalAlignment = Alignment.CenterHorizontally,
+        ) {
+            // Clear the scaffold's step-indicator dot row at the top.
+            Spacer(Modifier.height(spacing.xl))
+            Text(
+                stringResource(R.string.onboarding_sources_headline),
+                fontFamily = FontFamily.Serif,
+                fontWeight = FontWeight.Medium,
+                fontSize = 28.sp,
+                color = MaterialTheme.colorScheme.primary,
+                textAlign = TextAlign.Center,
+                modifier = Modifier.fillMaxWidth(),
+            )
+            Spacer(Modifier.height(spacing.sm))
+            Text(
+                stringResource(R.string.onboarding_sources_subtitle),
+                style = MaterialTheme.typography.bodyMedium,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                textAlign = TextAlign.Center,
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .widthIn(max = 400.dp),
+            )
+            Spacer(Modifier.height(spacing.lg))
+
+            sections.forEach { section ->
+                SourceSectionHeader(titleRes = section.group.titleRes)
+                Spacer(Modifier.height(spacing.sm))
+                section.rows.forEach { row ->
+                    SourceCard(row = row, onToggle = { onToggle(row.id, it) })
+                    Spacer(Modifier.height(spacing.sm))
+                }
+                Spacer(Modifier.height(spacing.md))
+            }
+
+            BrassButton(
+                label = stringResource(R.string.onboarding_sources_continue),
+                onClick = onContinue,
+                variant = BrassButtonVariant.Primary,
+            )
+            BrassButton(
+                label = stringResource(R.string.onboarding_sources_skip),
+                onClick = onSkip,
+                variant = BrassButtonVariant.Text,
+            )
+            Spacer(Modifier.height(spacing.xl))
+        }
+    }
+}
+
+@Composable
+private fun SourceSectionHeader(@StringRes titleRes: Int) {
+    Text(
+        text = stringResource(titleRes),
+        style = MaterialTheme.typography.titleSmall,
+        fontWeight = FontWeight.SemiBold,
+        color = MaterialTheme.colorScheme.primary,
+        modifier = Modifier
+            .fillMaxWidth()
+            .widthIn(max = 480.dp),
+    )
+}
+
+/**
+ * One source row — icon disc + name + one-line description + a brass
+ * toggle. The whole row is the toggle target (there is no details sheet
+ * to compete for the tap, unlike the Plugin Manager's card), so we hang
+ * a single [Modifier.toggleable] with [Role.Switch] on the Row and leave
+ * the [Switch]'s own `onCheckedChange` null. TalkBack then announces the
+ * merged node once — "<name>, <description>, switch, on" — and Switch
+ * Access gets one focus stop instead of two.
+ */
+@Composable
+private fun SourceCard(
+    row: SourcePickRow,
+    onToggle: (Boolean) -> Unit,
+) {
+    val spacing = LocalSpacing.current
+    val brass = MaterialTheme.colorScheme.primary
+    val brassColors = SwitchDefaults.colors(
+        checkedThumbColor = brass,
+        checkedTrackColor = MaterialTheme.colorScheme.primaryContainer,
+        checkedBorderColor = brass,
+        uncheckedThumbColor = MaterialTheme.colorScheme.outline,
+    )
+    Row(
+        modifier = Modifier
+            .fillMaxWidth()
+            .widthIn(max = 480.dp)
+            .clip(RoundedCornerShape(12.dp))
+            .border(
+                width = 1.dp,
+                color = if (row.enabled) brass else MaterialTheme.colorScheme.outlineVariant,
+                shape = RoundedCornerShape(12.dp),
+            )
+            .background(MaterialTheme.colorScheme.surfaceVariant)
+            .toggleable(
+                value = row.enabled,
+                role = Role.Switch,
+                onValueChange = onToggle,
+            )
+            .padding(spacing.md),
+        verticalAlignment = Alignment.CenterVertically,
+        horizontalArrangement = Arrangement.spacedBy(spacing.md),
+    ) {
+        Box(
+            modifier = Modifier
+                .size(40.dp)
+                .clip(CircleShape)
+                .background(MaterialTheme.colorScheme.primaryContainer),
+            contentAlignment = Alignment.Center,
+        ) {
+            Icon(
+                imageVector = sourceGlyph(row.id),
+                // Decorative — the row's merged semantics already speak
+                // the source name, so a glyph description would just
+                // double up for TalkBack.
+                contentDescription = null,
+                tint = MaterialTheme.colorScheme.onPrimaryContainer,
+                modifier = Modifier.size(22.dp),
+            )
+        }
+        Column(modifier = Modifier.weight(1f)) {
+            Text(
+                row.displayName,
+                style = MaterialTheme.typography.titleMedium,
+                fontWeight = FontWeight.Medium,
+                color = MaterialTheme.colorScheme.onSurface,
+            )
+            if (row.description.isNotBlank()) {
+                Text(
+                    row.description,
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                )
+            }
+        }
+        Switch(
+            checked = row.enabled,
+            // Row owns the toggle (see [SourceCard] kdoc) — null keeps
+            // the Switch a non-interactive visual so it isn't a second
+            // focus stop.
+            onCheckedChange = null,
+            colors = brassColors,
+        )
+    }
+}
+
+/**
+ * Compose-facing projection of one registered source plugin for the
+ * onboarding picker — the subset of [SourcePluginDescriptor] the screen
+ * renders, plus the resolved enabled state.
+ */
+@Immutable
+internal data class SourcePickRow(
+    val id: String,
+    val displayName: String,
+    val description: String,
+    val category: SourceCategory,
+    val enabled: Boolean,
+)
+
+/**
+ * One rendered section of the picker — a friendly group plus the rows
+ * that landed in it, in display order. Empty groups are dropped before
+ * this point so the screen never renders a header with no cards.
+ */
+@Immutable
+internal data class OnboardingSourceSection(
+    val group: OnboardingSourceGroup,
+    val rows: List<SourcePickRow>,
+)
+
+/**
+ * The five plain-English buckets the onboarding picker groups sources
+ * into, in display order. Deliberately coarser and friendlier than the
+ * raw [SourceCategory] enum: most backends are technically
+ * [SourceCategory.Text] (Royal Road, Wikipedia, RSS and the book
+ * catalogs all are), which would collapse into one undifferentiated
+ * 20-row wall. A brand-new user thinks in "books vs. news vs. my own
+ * stuff", not "Text vs. Ebook", so we re-bucket by intent.
+ */
+internal enum class OnboardingSourceGroup(@StringRes val titleRes: Int) {
+    Books(R.string.onboarding_sources_group_books),
+    WebFiction(R.string.onboarding_sources_group_webfiction),
+    News(R.string.onboarding_sources_group_news),
+    YourContent(R.string.onboarding_sources_group_yourcontent),
+    Audio(R.string.onboarding_sources_group_audio),
+}
+
+/**
+ * Hand-curated id→bucket assignment. The codebase already curates
+ * per-id tables this way (`sourceGlyph`, `friendlyVoiceSelection`), and
+ * the trade-off is the same: a new backend that isn't listed here falls
+ * through to [OnboardingSourceGroup.YourContent] — a safe, sensible
+ * catch-all — rather than vanishing. Audio and explicitly-Ebook sources
+ * are bucketed by [SourceCategory] (authoritative for those), so only
+ * the big [SourceCategory.Text] family needs the by-intent split.
+ */
+private val BOOK_IDS: Set<String> = setOf(
+    SourceIds.GUTENBERG,
+    SourceIds.STANDARD_EBOOKS,
+    SourceIds.EPUB,
+    SourceIds.PDF,
+)
+
+private val WEB_FICTION_IDS: Set<String> = setOf(
+    SourceIds.ROYAL_ROAD,
+    SourceIds.AO3,
+)
+
+private val NEWS_IDS: Set<String> = setOf(
+    SourceIds.WIKIPEDIA,
+    SourceIds.WIKISOURCE,
+    SourceIds.HACKERNEWS,
+    SourceIds.ARXIV,
+    SourceIds.PLOS,
+    SourceIds.GOOGLE_NEWS,
+    SourceIds.NOTION_TECHEMPOWER,
+)
+
+/** Which friendly bucket a single row belongs to. Category wins for the
+ *  two unambiguous families (audio streams, EPUB-shaped catalogs); the
+ *  rest is the curated by-intent split over the Text family. */
+internal fun onboardingGroupOf(row: SourcePickRow): OnboardingSourceGroup = when {
+    row.category == SourceCategory.AudioStream -> OnboardingSourceGroup.Audio
+    row.category == SourceCategory.Ebook -> OnboardingSourceGroup.Books
+    row.id in BOOK_IDS -> OnboardingSourceGroup.Books
+    row.id in WEB_FICTION_IDS -> OnboardingSourceGroup.WebFiction
+    row.id in NEWS_IDS -> OnboardingSourceGroup.News
+    else -> OnboardingSourceGroup.YourContent
+}
+
+/**
+ * Bucket [rows] into [OnboardingSourceSection]s in [OnboardingSourceGroup]
+ * display order, alphabetised within each group and with empty groups
+ * dropped. Pure so it can be unit-tested without Compose or Hilt.
+ */
+internal fun groupSourcesForOnboarding(
+    rows: List<SourcePickRow>,
+): List<OnboardingSourceSection> {
+    val byGroup = rows.groupBy(::onboardingGroupOf)
+    return OnboardingSourceGroup.entries.mapNotNull { group ->
+        val groupRows = byGroup[group]?.sortedBy { it.displayName.lowercase() }
+        if (groupRows.isNullOrEmpty()) null
+        else OnboardingSourceSection(group = group, rows = groupRows)
+    }
+}
+
+/**
+ * Issue #1370 — drives [SourcePickerOnboarding]. Joins the live
+ * [SourcePluginRegistry] roster with the user's per-plugin enabled map
+ * (falling back to each descriptor's `defaultEnabled` for ids the user
+ * hasn't touched), then groups for display. Toggling writes straight
+ * through to settings — the same single-source-of-truth path the Plugin
+ * Manager uses — so the picker holds no draft state of its own.
+ */
+@HiltViewModel
+class SourcePickerOnboardingViewModel @Inject constructor(
+    private val registry: SourcePluginRegistry,
+    private val settings: SettingsRepositoryUi,
+) : ViewModel() {
+
+    val sections: StateFlow<List<OnboardingSourceSection>> = settings.settings
+        .map { s ->
+            val rows = registry.descriptors.map { descriptor ->
+                SourcePickRow(
+                    id = descriptor.id,
+                    displayName = descriptor.displayName,
+                    description = descriptor.description,
+                    category = descriptor.category,
+                    enabled = s.sourcePluginsEnabled[descriptor.id] ?: descriptor.defaultEnabled,
+                )
+            }
+            groupSourcesForOnboarding(rows)
+        }
+        .stateIn(viewModelScope, SharingStarted.WhileSubscribed(5_000), emptyList())
+
+    fun toggle(id: String, enabled: Boolean) {
+        viewModelScope.launch { settings.setSourcePluginEnabled(id, enabled) }
+    }
+}

--- a/feature/src/main/res/values/strings.xml
+++ b/feature/src/main/res/values/strings.xml
@@ -592,6 +592,17 @@
     <string name="onboarding_voice_download_failed">Couldn\'t download %1$s. %2$s</string>
     <string name="onboarding_voice_try_again">Try again</string>
 
+    <!-- Onboarding · SourcePickerOnboarding (#1370) -->
+    <string name="onboarding_sources_headline">What do you want to read?</string>
+    <string name="onboarding_sources_subtitle">You can always change these later in Settings.</string>
+    <string name="onboarding_sources_group_books">Books &amp; Literature</string>
+    <string name="onboarding_sources_group_webfiction">Web Fiction</string>
+    <string name="onboarding_sources_group_news">News &amp; Research</string>
+    <string name="onboarding_sources_group_yourcontent">Your Content</string>
+    <string name="onboarding_sources_group_audio">Audio</string>
+    <string name="onboarding_sources_continue">Continue</string>
+    <string name="onboarding_sources_skip">Skip for now</string>
+
     <!-- Onboarding · Friendly voice descriptions (keyed by catalog displayName) -->
     <string name="voice_desc_lessac">Warm American narrator — clear and steady.</string>
     <string name="voice_desc_cori">British, gentle and even — good for long sessions.</string>

--- a/feature/src/test/kotlin/in/jphe/storyvox/feature/onboarding/SourcePickerGroupingTest.kt
+++ b/feature/src/test/kotlin/in/jphe/storyvox/feature/onboarding/SourcePickerGroupingTest.kt
@@ -1,0 +1,152 @@
+package `in`.jphe.storyvox.feature.onboarding
+
+import `in`.jphe.storyvox.data.source.SourceIds
+import `in`.jphe.storyvox.data.source.plugin.SourceCategory
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * Issue #1370 — unit tests for the pure grouping layer of the onboarding
+ * source picker. The Compose rendering follows the established
+ * onboarding-screen pattern; this file covers the by-intent bucketing
+ * that re-shapes the raw [SourceCategory] roster into the five friendly
+ * sections, which is the only piece with real branching logic.
+ */
+class SourcePickerGroupingTest {
+
+    private fun row(
+        id: String,
+        displayName: String = id,
+        description: String = "",
+        category: SourceCategory = SourceCategory.Text,
+        enabled: Boolean = false,
+    ) = SourcePickRow(
+        id = id,
+        displayName = displayName,
+        description = description,
+        category = category,
+        enabled = enabled,
+    )
+
+    // ─── onboardingGroupOf ──────────────────────────────────────────
+
+    @Test fun `audio stream category buckets under Audio regardless of id`() {
+        val r = row(id = "some-unknown-stream", category = SourceCategory.AudioStream)
+        assertEquals(OnboardingSourceGroup.Audio, onboardingGroupOf(r))
+    }
+
+    @Test fun `explicit ebook category buckets under Books`() {
+        val r = row(id = "bookshare", category = SourceCategory.Ebook)
+        assertEquals(OnboardingSourceGroup.Books, onboardingGroupOf(r))
+    }
+
+    @Test fun `curated book ids bucket under Books despite Text category`() {
+        // Gutenberg, Standard Ebooks, EPUB and PDF are all annotated
+        // SourceCategory.Text in their @SourcePlugin descriptors — the
+        // curated id set is what pulls them into Books.
+        listOf(SourceIds.GUTENBERG, SourceIds.STANDARD_EBOOKS, SourceIds.EPUB, SourceIds.PDF)
+            .forEach { id ->
+                assertEquals(
+                    "expected $id under Books",
+                    OnboardingSourceGroup.Books,
+                    onboardingGroupOf(row(id = id)),
+                )
+            }
+    }
+
+    @Test fun `web fiction ids bucket under Web Fiction`() {
+        listOf(SourceIds.ROYAL_ROAD, SourceIds.AO3).forEach { id ->
+            assertEquals(OnboardingSourceGroup.WebFiction, onboardingGroupOf(row(id = id)))
+        }
+    }
+
+    @Test fun `news and research ids bucket under News`() {
+        listOf(
+            SourceIds.WIKIPEDIA,
+            SourceIds.HACKERNEWS,
+            SourceIds.ARXIV,
+            SourceIds.PLOS,
+            SourceIds.GOOGLE_NEWS,
+        ).forEach { id ->
+            assertEquals(OnboardingSourceGroup.News, onboardingGroupOf(row(id = id)))
+        }
+    }
+
+    @Test fun `uncurated text source falls through to Your Content`() {
+        val r = row(id = "rss", category = SourceCategory.Text)
+        assertEquals(OnboardingSourceGroup.YourContent, onboardingGroupOf(r))
+    }
+
+    @Test fun `unknown future source still lands in a real bucket`() {
+        // A backend nobody listed yet must not vanish from the picker.
+        val r = row(id = "brand-new-backend-2099", category = SourceCategory.Text)
+        assertEquals(OnboardingSourceGroup.YourContent, onboardingGroupOf(r))
+    }
+
+    // ─── groupSourcesForOnboarding ──────────────────────────────────
+
+    @Test fun `sections render in group display order`() {
+        val rows = listOf(
+            row(id = SourceIds.RADIO, category = SourceCategory.AudioStream),
+            row(id = SourceIds.RSS),
+            row(id = SourceIds.WIKIPEDIA),
+            row(id = SourceIds.ROYAL_ROAD),
+            row(id = SourceIds.GUTENBERG),
+        )
+        val sections = groupSourcesForOnboarding(rows)
+        assertEquals(
+            listOf(
+                OnboardingSourceGroup.Books,
+                OnboardingSourceGroup.WebFiction,
+                OnboardingSourceGroup.News,
+                OnboardingSourceGroup.YourContent,
+                OnboardingSourceGroup.Audio,
+            ),
+            sections.map { it.group },
+        )
+    }
+
+    @Test fun `empty groups are dropped`() {
+        // Only News + Audio populated — Books, Web Fiction, Your Content
+        // must not produce empty header sections.
+        val rows = listOf(
+            row(id = SourceIds.ARXIV),
+            row(id = SourceIds.RADIO, category = SourceCategory.AudioStream),
+        )
+        val sections = groupSourcesForOnboarding(rows)
+        assertEquals(
+            listOf(OnboardingSourceGroup.News, OnboardingSourceGroup.Audio),
+            sections.map { it.group },
+        )
+        assertTrue(sections.all { it.rows.isNotEmpty() })
+    }
+
+    @Test fun `rows within a section are alphabetised by display name`() {
+        val rows = listOf(
+            row(id = SourceIds.STANDARD_EBOOKS, displayName = "Standard Ebooks"),
+            row(id = SourceIds.GUTENBERG, displayName = "Project Gutenberg"),
+            row(id = SourceIds.EPUB, displayName = "Local EPUB files"),
+        )
+        val books = groupSourcesForOnboarding(rows).single { it.group == OnboardingSourceGroup.Books }
+        assertEquals(
+            listOf("Local EPUB files", "Project Gutenberg", "Standard Ebooks"),
+            books.rows.map { it.displayName },
+        )
+    }
+
+    @Test fun `enabled state is carried through grouping unchanged`() {
+        val rows = listOf(
+            row(id = SourceIds.ROYAL_ROAD, displayName = "Royal Road", enabled = true),
+            row(id = SourceIds.AO3, displayName = "AO3", enabled = false),
+        )
+        val webFiction = groupSourcesForOnboarding(rows)
+            .single { it.group == OnboardingSourceGroup.WebFiction }
+        assertEquals(true, webFiction.rows.single { it.id == SourceIds.ROYAL_ROAD }.enabled)
+        assertEquals(false, webFiction.rows.single { it.id == SourceIds.AO3 }.enabled)
+    }
+
+    @Test fun `empty input yields no sections`() {
+        assertTrue(groupSourcesForOnboarding(emptyList()).isEmpty())
+    }
+}


### PR DESCRIPTION
## What

Adds a **"What do you want to read?"** step to the first-launch onboarding flow, between the voice picker and the first-fiction picker. New users now discover and toggle the source catalog before landing on Browse, instead of meeting whatever the default-enabled backends happen to be with no idea the catalog spans 25+ sources.

Closes #1370.

## Flow

`Welcome → VoicePick → **SourcePick** → FirstFiction → done`

The shared `OnboardingScaffold` dot-row now derives its count from `OnboardingStep.entries.size`, so the "Step X of N" indicator tracks the flow length automatically (no second hand-edit when a step is added).

## The screen

- Serif brass headline + quiet subtitle ("You can always change these later in Settings"), matching `VoicePickerOnboarding`'s visual language.
- Sources grouped into **five friendly buckets** with section headers: **Books & Literature**, **Web Fiction**, **News & Research**, **Your Content**, **Audio**.
  - Most backends are `SourceCategory.Text` (the book catalogs, Royal Road, Wikipedia, RSS all are), so grouping by raw category would collapse into one undifferentiated wall. The split is therefore a curated **by-intent** mapping, with `Audio`/`Ebook` bucketed by category (authoritative there) and an unknown-id catch-all into **Your Content** so a future backend never vanishes from the picker.
- Each card: source icon + name + one-line description + a brass toggle.
- The **whole row is the toggle** (`Modifier.toggleable` + `Role.Switch`, `Switch(onCheckedChange = null)`) — same a11y pattern as `PronunciationDictScreen`, so TalkBack announces one merged "<name>, <description>, switch, on" node.

## Persistence

Toggles write straight through to `SettingsRepositoryUi.setSourcePluginEnabled` (the same path the full Plugin Manager uses), so the picker holds **no draft state** — **Continue** and **Skip** are both pure navigation; Skip just leaves the default-enabled roster untouched.

## Notes for reviewers

- **No `SettingsRepositoryUi` changes** — the per-plugin toggle API (`setSourcePluginEnabled` + `UiSettings.sourcePluginsEnabled`) already existed, so no hand-rolled test fakes break.
- `sourceGlyph()` in `BrowseSourceCarousel.kt` was made `internal` (was `private`) and reused rather than duplicating the 28-entry id→glyph table, which would otherwise drift on every new backend.
- New `SourcePickerOnboardingViewModel` injects only `SourcePluginRegistry` + `SettingsRepositoryUi` — the exact pair `PluginManagerViewModel` already injects, so the Hilt graph resolves it unchanged.

## Tests

`SourcePickerGroupingTest` covers the pure `onboardingGroupOf` / `groupSourcesForOnboarding` logic: category-vs-curated bucketing, the unknown-id fallback, display ordering, empty-group dropping, alphabetisation, and enabled-state pass-through. UI composition follows the established onboarding-screen pattern.

🤖 Generated with [Claude Code](https://claude.com/claude-code)