### PR TITLE
feat(browse): source catalog browser — browse backends like books (#1365)

### DIFF
--- a/app/src/main/kotlin/in/jphe/storyvox/navigation/StoryvoxNavHost.kt
+++ b/app/src/main/kotlin/in/jphe/storyvox/navigation/StoryvoxNavHost.kt
@@ -36,6 +36,7 @@ import `in`.jphe.storyvox.data.share.FictionShareLink
 import `in`.jphe.storyvox.data.source.SourceIds
 import `in`.jphe.storyvox.source.github.auth.GitHubAuthConfig
 import `in`.jphe.storyvox.feature.browse.BrowseScreen
+import `in`.jphe.storyvox.feature.browse.catalog.SourceCatalogScreen
 import `in`.jphe.storyvox.feature.chat.ChatScreen
 import `in`.jphe.storyvox.feature.debug.DebugScreen
 import `in`.jphe.storyvox.feature.engine.VoicePickerGate
@@ -77,6 +78,16 @@ object StoryvoxRoutes {
     const val LIBRARY = "library"
     const val FOLLOWS = "follows"
     const val BROWSE = "browse"
+    /** #1365 — Source Catalog ("Source Library"): a full-screen,
+     *  shelf-style browser for all registered backends. Pushed from the
+     *  "Browse all sources" entry below the Browse carousel; returns the
+     *  chosen source id to Browse via the saved-state-handle result. */
+    const val SOURCE_CATALOG = "sources"
+    /** #1365 — saved-state-handle key the Source Catalog writes the
+     *  chosen source id under, on the Browse back-stack entry, before
+     *  popping. Browse observes it and selects that source. A one-shot
+     *  result: Browse clears it to null after applying. */
+    const val SOURCE_CATALOG_RESULT = "catalog_selected_source"
     /** Issue #995 — OCR scan-to-read capture surface. Reached from the
      *  Library add-flow ("Scan a page"); CameraX / gallery capture →
      *  on-device ML Kit OCR → a fiction the reader narrates. */
@@ -842,7 +853,13 @@ private fun StoryvoxNavHostContent(
                 exitTransition = homeExit,
                 popEnterTransition = homeEnter,
                 popExitTransition = homeExit,
-            ) {
+            ) { browseEntry ->
+                // #1365 — observe the one-shot source id the Source Catalog
+                // writes onto this entry before popping. Applied + cleared
+                // inside BrowseScreen so it never replays.
+                val pendingSource by browseEntry.savedStateHandle
+                    .getStateFlow<String?>(StoryvoxRoutes.SOURCE_CATALOG_RESULT, null)
+                    .collectAsStateWithLifecycle()
                 BrowseScreen(
                     onOpenFiction = { id -> navController.navigate(StoryvoxRoutes.fictionDetail(id)) },
                     // #241 / #211 — RR sign-in CTA shared between Browse
@@ -851,6 +868,36 @@ private fun StoryvoxNavHostContent(
                     onOpenRoyalRoadSignIn = { navController.navigate(StoryvoxRoutes.authWebView(SourceIds.ROYAL_ROAD)) },
                     // #426 PR2 — AO3 sign-in CTA on the Browse → AO3 chip.
                     onOpenAo3SignIn = { navController.navigate(StoryvoxRoutes.authWebView(SourceIds.AO3)) },
+                    // #1365 — Source Catalog entry + result round-trip.
+                    onOpenSourceCatalog = { navController.navigate(StoryvoxRoutes.SOURCE_CATALOG) },
+                    pendingSourceSelection = pendingSource,
+                    onSourceSelectionConsumed = {
+                        // Explicit type param: a bare `= null` can't infer T
+                        // on SavedStateHandle.set. Writing null re-emits null
+                        // through the getStateFlow so the one-shot clears.
+                        browseEntry.savedStateHandle.set<String?>(StoryvoxRoutes.SOURCE_CATALOG_RESULT, null)
+                    },
+                )
+            }
+
+            // #1365 — Source Catalog ("Source Library"). Pushed from
+            // Browse; returns the chosen source id to the Browse entry via
+            // its saved-state-handle, then pops back so Browse lands on it.
+            composable(
+                StoryvoxRoutes.SOURCE_CATALOG,
+                enterTransition = homeEnter,
+                exitTransition = homeExit,
+                popEnterTransition = homeEnter,
+                popExitTransition = homeExit,
+            ) {
+                SourceCatalogScreen(
+                    onNavigateBack = { navController.popBackStack() },
+                    onSelectSource = { id ->
+                        navController.previousBackStackEntry
+                            ?.savedStateHandle
+                            ?.set(StoryvoxRoutes.SOURCE_CATALOG_RESULT, id)
+                        navController.popBackStack()
+                    },
                 )
             }
 

--- a/core-ui/src/main/kotlin/in/jphe/storyvox/ui/component/TestTags.kt
+++ b/core-ui/src/main/kotlin/in/jphe/storyvox/ui/component/TestTags.kt
@@ -65,6 +65,18 @@ object TestTags {
      */
     fun browseResultCard(fictionId: String): String = "browse-result-$fictionId"
 
+    // ── Source Catalog (#1365) ────────────────────────────────────────────
+    /** The Browse → "Source Library" catalog list. */
+    const val SourceCatalogList = "source-catalog-list"
+
+    /** The entry-point affordance below the Browse carousel that opens the
+     *  Source Catalog. */
+    const val SourceCatalogEntry = "source-catalog-entry"
+
+    /** Per-source card in the catalog, keyed by source id, e.g.
+     *  `SourceIds.ARXIV` → `"source-catalog-card-arxiv"`. */
+    fun sourceCatalogCard(sourceId: String): String = "source-catalog-card-$sourceId"
+
     // ── Reader ───────────────────────────────────────────────────────────
     const val ReaderBody = "reader-body"
     const val ReaderPlay = "reader-play"

--- a/feature/src/main/kotlin/in/jphe/storyvox/feature/browse/BrowseScreen.kt
+++ b/feature/src/main/kotlin/in/jphe/storyvox/feature/browse/BrowseScreen.kt
@@ -1,5 +1,6 @@
 package `in`.jphe.storyvox.feature.browse
 
+import androidx.compose.foundation.BorderStroke
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
@@ -20,9 +21,12 @@ import androidx.compose.foundation.lazy.grid.itemsIndexed
 import androidx.compose.foundation.lazy.grid.items
 import androidx.compose.foundation.lazy.grid.rememberLazyGridState
 import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.ArrowForward
 import androidx.compose.material.icons.filled.Add
 import androidx.compose.material.icons.filled.Close
+import androidx.compose.material.icons.filled.GridView
 import androidx.compose.material.icons.filled.Search
 import androidx.compose.material.icons.outlined.FilterAlt
 import androidx.compose.material3.AssistChip
@@ -41,6 +45,7 @@ import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.pulltorefresh.PullToRefreshBox
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.SecondaryScrollableTabRow
+import androidx.compose.material3.Surface
 import androidx.compose.material3.Tab
 import androidx.compose.material3.Text
 import androidx.compose.material3.TopAppBarDefaults
@@ -58,6 +63,7 @@ import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.flow.filter
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
 import androidx.compose.ui.input.nestedscroll.nestedScroll
 import androidx.compose.ui.ExperimentalComposeUiApi
 import androidx.compose.ui.platform.testTag
@@ -148,6 +154,20 @@ fun BrowseScreen(
      *  the only call site that needs the real route is the
      *  StoryvoxNavHost Library branch. */
     onOpenAo3SignIn: () -> Unit = {},
+    /** #1365 — opens the Source Catalog ("Source Library"), the
+     *  full-screen shelf-style browser for all registered backends.
+     *  Reached from the entry-point card below the source carousel.
+     *  Defaults to a no-op so pre-#1365 callers don't need to thread it. */
+    onOpenSourceCatalog: () -> Unit = {},
+    /** #1365 — a source id handed back from the Source Catalog (via the
+     *  host's saved-state-handle result). When non-null, the screen
+     *  selects that source on the live [BrowseViewModel] and calls
+     *  [onSourceSelectionConsumed] so the one-shot result isn't replayed
+     *  on the next recomposition. */
+    pendingSourceSelection: String? = null,
+    /** #1365 — clears the [pendingSourceSelection] result after it's been
+     *  applied. */
+    onSourceSelectionConsumed: () -> Unit = {},
     /**
      * Restructure (v0.5.40) — when true, BrowseScreen renders without
      * its own Scaffold + TopAppBar. The Library tab's TopAppBar serves
@@ -160,6 +180,17 @@ fun BrowseScreen(
     embedded: Boolean = false,
     viewModel: BrowseViewModel = hiltViewModel(),
 ) {
+    // #1365 — apply a source chosen from the Source Catalog. Keyed on the
+    // pending id so it fires once per distinct selection; selectSource is
+    // a no-op when the id is already current, and the catalog has already
+    // enabled a disabled source so BrowseViewModel's enabled-set guard
+    // won't bounce it.
+    LaunchedEffect(pendingSourceSelection) {
+        pendingSourceSelection?.let { id ->
+            viewModel.selectSource(id)
+            onSourceSelectionConsumed()
+        }
+    }
     val state by viewModel.uiState.collectAsStateWithLifecycle()
     // #776 — pull-to-refresh state lives off the ViewModel so the
     // M3 spinner overlay's `isRefreshing` flag survives recomposition
@@ -242,6 +273,17 @@ fun BrowseScreen(
             onReorder = viewModel::reorderSources,
             // UI-test selector for the source picker row.
             modifier = Modifier.fillMaxWidth().testTag(TestTags.BrowseSourceList),
+        )
+
+        // #1365 — entry point to the Source Catalog. The carousel can
+        // only show a handful of cards at once; this invites the user
+        // into the full shelf-style browser for all sources. Placed
+        // directly under the carousel so it reads as "…and the rest".
+        BrowseAllSourcesEntry(
+            onClick = onOpenSourceCatalog,
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(horizontal = spacing.md, vertical = spacing.xs),
         )
 
         // Issue #695 — read the active source's `supportsSearch`
@@ -766,6 +808,72 @@ private fun FilterButton(activeCount: Int, onClick: () -> Unit) {
     } else {
         IconButton(onClick = onClick, modifier = Modifier.testTag(TestTags.BrowseFilter)) {
             Icon(Icons.Outlined.FilterAlt, contentDescription = filterCd)
+        }
+    }
+}
+
+/**
+ * #1365 — entry point to the Source Catalog, rendered as a slim
+ * brass-edged row directly beneath the source carousel. A grid glyph +
+ * "Browse all sources" copy + a trailing chevron read as "there's more
+ * here than the carousel shows". Tapping opens the full shelf-style
+ * [SourceCatalogScreen][`in`.jphe.storyvox.feature.browse.catalog.SourceCatalogScreen].
+ *
+ * Lives in the Browse header (composed in every content state) so the
+ * affordance is present on the standalone Browse tab AND the embedded
+ * Library → Browse sub-tab, where Browse owns no top bar of its own.
+ */
+@Composable
+private fun BrowseAllSourcesEntry(
+    onClick: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    val spacing = LocalSpacing.current
+    Surface(
+        modifier = modifier
+            .testTag(TestTags.SourceCatalogEntry)
+            .clip(RoundedCornerShape(12.dp))
+            .clickable(
+                role = Role.Button,
+                onClickLabel = "Browse all sources",
+                onClick = onClick,
+            ),
+        shape = RoundedCornerShape(12.dp),
+        color = MaterialTheme.colorScheme.surfaceContainerHigh,
+        border = BorderStroke(
+            1.dp,
+            MaterialTheme.colorScheme.primary.copy(alpha = 0.30f),
+        ),
+    ) {
+        Row(
+            modifier = Modifier.padding(horizontal = spacing.md, vertical = spacing.sm),
+            verticalAlignment = Alignment.CenterVertically,
+            horizontalArrangement = Arrangement.spacedBy(spacing.sm),
+        ) {
+            Icon(
+                imageVector = Icons.Filled.GridView,
+                contentDescription = null,
+                tint = MaterialTheme.colorScheme.primary,
+                modifier = Modifier.size(22.dp),
+            )
+            Column(modifier = Modifier.weight(1f)) {
+                Text(
+                    text = "Browse all sources",
+                    style = MaterialTheme.typography.titleSmall,
+                    color = MaterialTheme.colorScheme.onSurface,
+                )
+                Text(
+                    text = "Explore the full Source Library",
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                )
+            }
+            Icon(
+                imageVector = Icons.AutoMirrored.Filled.ArrowForward,
+                contentDescription = null,
+                tint = MaterialTheme.colorScheme.onSurfaceVariant,
+                modifier = Modifier.size(20.dp),
+            )
         }
     }
 }

--- a/feature/src/main/kotlin/in/jphe/storyvox/feature/browse/BrowseSourceCarousel.kt
+++ b/feature/src/main/kotlin/in/jphe/storyvox/feature/browse/BrowseSourceCarousel.kt
@@ -667,8 +667,12 @@ private fun sourceTagline(id: String): String {
  * a generic compass for "everything else". The same icon set ships with
  * material-icons-extended, already on the classpath via the BottomTabBar
  * compass import.
+ *
+ * `internal` so the Source Catalog screen (#1365) reuses the exact same
+ * id→glyph mapping — the carousel card and the catalog card show the same
+ * icon for a given source, with one table to keep in sync.
  */
-private fun sourceGlyph(id: String): ImageVector = when (id) {
+internal fun sourceGlyph(id: String): ImageVector = when (id) {
     SourceIds.ROYAL_ROAD -> Icons.Filled.AutoStories
     SourceIds.AO3 -> Icons.Filled.LibraryBooks
     SourceIds.GUTENBERG -> Icons.Filled.MenuBook

--- a/feature/src/main/kotlin/in/jphe/storyvox/feature/browse/catalog/SourceCatalogCard.kt
+++ b/feature/src/main/kotlin/in/jphe/storyvox/feature/browse/catalog/SourceCatalogCard.kt
@@ -1,0 +1,259 @@
+package `in`.jphe.storyvox.feature.browse.catalog
+
+import androidx.compose.foundation.BorderStroke
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.Card
+import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Switch
+import androidx.compose.material3.SwitchDefaults
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.semantics.Role
+import androidx.compose.ui.semantics.contentDescription
+import androidx.compose.ui.semantics.semantics
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.dp
+import `in`.jphe.storyvox.feature.browse.BrowseSourceUi
+import `in`.jphe.storyvox.feature.browse.sourceGlyph
+import `in`.jphe.storyvox.ui.component.TestTags
+import `in`.jphe.storyvox.ui.theme.LocalSpacing
+
+/**
+ * Source Catalog (#1365) — per-category theme accent.
+ *
+ * Each catalog section reads with its own colour so the four shelves are
+ * visually distinct without leaving the brass palette. Pulled from the
+ * Material3 [androidx.compose.material3.ColorScheme] roles (not literal
+ * hex) so dark/light both resolve automatically:
+ *  - Books  → primary    (brass — the app's signature)
+ *  - Text   → tertiary
+ *  - Audio  → secondary
+ *  - Other  → onSurfaceVariant (neutral)
+ */
+@Composable
+internal fun catalogAccent(group: CatalogGroup): Color = when (group) {
+    CatalogGroup.Books -> MaterialTheme.colorScheme.primary
+    CatalogGroup.Text -> MaterialTheme.colorScheme.tertiary
+    CatalogGroup.Audio -> MaterialTheme.colorScheme.secondary
+    CatalogGroup.Other -> MaterialTheme.colorScheme.onSurfaceVariant
+}
+
+/**
+ * Source Catalog (#1365) — section header: a coloured accent bar, the
+ * group title, and the source count. The accent bar ties the header to
+ * its cards' icon tint so the eye reads "this shelf" at a glance.
+ */
+@Composable
+internal fun SourceCatalogSectionHeader(
+    group: CatalogGroup,
+    count: Int,
+) {
+    val spacing = LocalSpacing.current
+    val accent = catalogAccent(group)
+    Row(
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(top = spacing.sm, bottom = spacing.xs)
+            // One spoken node: "Books & Literature, 8 sources".
+            .semantics(mergeDescendants = true) { },
+        verticalAlignment = Alignment.CenterVertically,
+        horizontalArrangement = Arrangement.spacedBy(spacing.sm),
+    ) {
+        Box(
+            modifier = Modifier
+                .size(width = 4.dp, height = 24.dp)
+                .clip(RoundedCornerShape(2.dp))
+                .background(accent),
+        )
+        Text(
+            text = group.label,
+            style = MaterialTheme.typography.titleMedium,
+            fontWeight = FontWeight.SemiBold,
+            color = accent,
+        )
+        Text(
+            text = if (count == 1) "1 source" else "$count sources",
+            style = MaterialTheme.typography.labelMedium,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+        )
+    }
+}
+
+/**
+ * Source Catalog (#1365) — a rich, shelf-style card for one source.
+ *
+ * Layout: an accent-tinted icon tile on the left (the same id→glyph the
+ * Browse carousel uses, via [sourceGlyph]), the source name + one-line
+ * description in the middle with a row of small badges (category +
+ * capabilities), and a brass enable switch on the right.
+ *
+ * Two affordances, deliberately separated:
+ *  - **Tap the card body** → browse this source ([onOpen]). The card is
+ *    the invitation; tapping it is "take me there".
+ *  - **The switch** → enable/disable in place ([onToggle]) without
+ *    leaving the catalog, for users curating which sources show up in
+ *    Browse. The switch swallows its own taps so toggling never also
+ *    fires the browse navigation.
+ *
+ * Disabled sources render at reduced emphasis (the card reads as "off")
+ * but stay tappable — tapping a disabled source enables it on the way to
+ * Browse (see [SourceCatalogViewModel.onSourceChosen]).
+ */
+@Composable
+internal fun SourceCatalogCard(
+    row: SourceCatalogRow,
+    onOpen: () -> Unit,
+    onToggle: (Boolean) -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    val spacing = LocalSpacing.current
+    val descriptor = row.descriptor
+    val group = catalogGroupOf(descriptor.category)
+    val accent = catalogAccent(group)
+    val brass = MaterialTheme.colorScheme.primary
+
+    val label = BrowseSourceUi.chipLabel(descriptor.id, descriptor.displayName)
+    // Disabled cards hold back the title/icon emphasis so the shelf reads
+    // enabled-vs-not at a glance without hiding the source entirely.
+    val contentAlpha = if (row.enabled) 1f else 0.55f
+
+    val brassColors = SwitchDefaults.colors(
+        checkedThumbColor = brass,
+        checkedTrackColor = MaterialTheme.colorScheme.primaryContainer,
+        checkedBorderColor = brass,
+        uncheckedThumbColor = MaterialTheme.colorScheme.outline,
+    )
+
+    Card(
+        modifier = modifier
+            .fillMaxWidth()
+            .testTag(TestTags.sourceCatalogCard(descriptor.id))
+            // a11y: the whole card is the "browse this source" button.
+            // The switch below overrides with its own toggle semantics.
+            .clickable(
+                role = Role.Button,
+                onClickLabel = "Browse $label",
+                onClick = onOpen,
+            ),
+        shape = RoundedCornerShape(16.dp),
+        colors = CardDefaults.cardColors(
+            containerColor = MaterialTheme.colorScheme.surfaceContainer,
+        ),
+        border = BorderStroke(
+            width = 1.dp,
+            color = if (row.enabled) accent.copy(alpha = 0.40f) else MaterialTheme.colorScheme.outlineVariant,
+        ),
+    ) {
+        Row(
+            modifier = Modifier.padding(spacing.md),
+            verticalAlignment = Alignment.CenterVertically,
+            horizontalArrangement = Arrangement.spacedBy(spacing.md),
+        ) {
+            // Accent-tinted icon tile — the catalog's "book spine".
+            Box(
+                modifier = Modifier
+                    .size(52.dp)
+                    .clip(RoundedCornerShape(12.dp))
+                    .background(accent.copy(alpha = if (row.enabled) 0.16f else 0.08f)),
+                contentAlignment = Alignment.Center,
+            ) {
+                Icon(
+                    imageVector = sourceGlyph(descriptor.id),
+                    contentDescription = null,
+                    tint = accent.copy(alpha = contentAlpha),
+                    modifier = Modifier.size(26.dp),
+                )
+            }
+
+            Column(modifier = Modifier.weight(1f)) {
+                Text(
+                    text = descriptor.displayName,
+                    style = MaterialTheme.typography.titleMedium,
+                    fontWeight = FontWeight.SemiBold,
+                    color = MaterialTheme.colorScheme.onSurface.copy(alpha = contentAlpha),
+                    maxLines = 1,
+                    overflow = TextOverflow.Ellipsis,
+                )
+                if (descriptor.description.isNotBlank()) {
+                    Text(
+                        text = descriptor.description,
+                        style = MaterialTheme.typography.bodySmall,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = contentAlpha),
+                        maxLines = 2,
+                        overflow = TextOverflow.Ellipsis,
+                        modifier = Modifier.padding(top = 2.dp),
+                    )
+                }
+                Spacer(Modifier.size(spacing.xs))
+                Row(
+                    horizontalArrangement = Arrangement.spacedBy(spacing.xxs),
+                    verticalAlignment = Alignment.CenterVertically,
+                ) {
+                    CatalogBadge(text = group.badge, accent = accent, filled = true)
+                    if (descriptor.supportsSearch) {
+                        CatalogBadge(text = "Search", accent = MaterialTheme.colorScheme.onSurfaceVariant)
+                    }
+                    if (descriptor.supportsFollow) {
+                        CatalogBadge(text = "Follow", accent = MaterialTheme.colorScheme.onSurfaceVariant)
+                    }
+                }
+            }
+
+            // Enable/disable in place. contentDescription so TalkBack reads
+            // "Enable <source>, switch, on" instead of a bare "switch".
+            Switch(
+                checked = row.enabled,
+                onCheckedChange = onToggle,
+                colors = brassColors,
+                modifier = Modifier.semantics {
+                    contentDescription = "Enable ${descriptor.displayName}"
+                },
+            )
+        }
+    }
+}
+
+/**
+ * Small pill used for the category + capability badges on a catalog
+ * card. `filled` gives the category badge a tinted background so it
+ * stands out from the outlined capability badges next to it.
+ */
+@Composable
+private fun CatalogBadge(
+    text: String,
+    accent: Color,
+    filled: Boolean = false,
+) {
+    val spacing = LocalSpacing.current
+    Surface(
+        shape = RoundedCornerShape(50),
+        color = if (filled) accent.copy(alpha = 0.16f) else Color.Transparent,
+        border = if (filled) null else BorderStroke(1.dp, MaterialTheme.colorScheme.outlineVariant),
+    ) {
+        Text(
+            text = text,
+            style = MaterialTheme.typography.labelSmall,
+            color = if (filled) accent else MaterialTheme.colorScheme.onSurfaceVariant,
+            modifier = Modifier.padding(horizontal = spacing.xs, vertical = 2.dp),
+        )
+    }
+}

--- a/feature/src/main/kotlin/in/jphe/storyvox/feature/browse/catalog/SourceCatalogScreen.kt
+++ b/feature/src/main/kotlin/in/jphe/storyvox/feature/browse/catalog/SourceCatalogScreen.kt
@@ -1,0 +1,225 @@
+package `in`.jphe.storyvox.feature.browse.catalog
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material.icons.filled.SearchOff
+import androidx.compose.material3.CenterAlignedTopAppBar
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.semantics.semantics
+import androidx.compose.ui.semantics.testTagsAsResourceId
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.unit.dp
+import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import `in`.jphe.storyvox.ui.component.TestTags
+import `in`.jphe.storyvox.ui.theme.LocalSpacing
+
+/**
+ * Source Catalog (#1365) — Browse → "Source Library".
+ *
+ * A full-screen, shelf-style browser for all 25 registered backends.
+ * Reached from the entry-point card below the Browse carousel. Sources
+ * are grouped into four category sections (Books & Literature, Web
+ * Fiction & Text, Audio & Radio, Other), each rendered as a rich
+ * [SourceCatalogCard] with an icon, description, category badge, and an
+ * inline enable switch.
+ *
+ * Two ways out:
+ *  - [onNavigateBack] — the top-bar back arrow / OS back.
+ *  - [onSelectSource] — tapping a card's body; the host wires this to
+ *    return the chosen source id to the Browse screen and pop, so Browse
+ *    lands on that source. [SourceCatalogViewModel.onSourceChosen] runs
+ *    first to enable a disabled source so it actually shows up.
+ *
+ * @param onSelectSource invoked with the chosen source id. The screen
+ *  has already called [SourceCatalogViewModel.onSourceChosen] for it.
+ */
+@OptIn(ExperimentalMaterial3Api::class, androidx.compose.ui.ExperimentalComposeUiApi::class)
+@Composable
+fun SourceCatalogScreen(
+    onNavigateBack: () -> Unit,
+    onSelectSource: (String) -> Unit,
+    viewModel: SourceCatalogViewModel = hiltViewModel(),
+) {
+    val state by viewModel.uiState.collectAsStateWithLifecycle()
+    val spacing = LocalSpacing.current
+
+    // Filter + group are pure functions; recompute only when their inputs
+    // change rather than on every recomposition.
+    val sections = remember(state.rows, state.query) {
+        groupCatalog(filterCatalog(state.rows, state.query))
+    }
+    val matchCount = remember(sections) { sections.sumOf { it.rows.size } }
+
+    Scaffold(
+        topBar = {
+            CenterAlignedTopAppBar(
+                title = {
+                    Text(
+                        text = "Source Library",
+                        style = MaterialTheme.typography.titleMedium,
+                    )
+                },
+                navigationIcon = {
+                    IconButton(onClick = onNavigateBack) {
+                        Icon(
+                            Icons.AutoMirrored.Filled.ArrowBack,
+                            contentDescription = "Back to Browse",
+                        )
+                    }
+                },
+            )
+        },
+    ) { padding ->
+        // #1333 pattern — surface descendant testTags as resource-ids so
+        // on-device uiautomator/adb can target catalog elements by id.
+        Box(
+            modifier = Modifier
+                .fillMaxSize()
+                .padding(padding)
+                .semantics { testTagsAsResourceId = true },
+        ) {
+            LazyColumn(
+                modifier = Modifier
+                    .fillMaxSize()
+                    .testTag(TestTags.SourceCatalogList),
+                contentPadding = PaddingValues(
+                    start = spacing.md,
+                    end = spacing.md,
+                    top = spacing.sm,
+                    bottom = spacing.xl,
+                ),
+                verticalArrangement = Arrangement.spacedBy(spacing.sm),
+            ) {
+                // Hero subtitle — "N sources to explore". The top-bar
+                // already carries the title; this is the inviting count.
+                item("header") {
+                    Text(
+                        text = "${state.totalCount} sources to explore",
+                        style = MaterialTheme.typography.bodyMedium,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                        modifier = Modifier.padding(bottom = spacing.xs),
+                    )
+                }
+
+                // Search across name + description.
+                item("search") {
+                    OutlinedTextField(
+                        value = state.query,
+                        onValueChange = viewModel::setQuery,
+                        label = { Text("Search sources") },
+                        singleLine = true,
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .testTag(TestTags.BrowseSearchField),
+                    )
+                }
+
+                if (sections.isEmpty()) {
+                    item("empty") {
+                        EmptyCatalogState(query = state.query)
+                    }
+                } else {
+                    sections.forEach { section ->
+                        item(key = "header-${section.group.name}") {
+                            SourceCatalogSectionHeader(
+                                group = section.group,
+                                count = section.rows.size,
+                            )
+                        }
+                        items(
+                            items = section.rows,
+                            key = { it.descriptor.id },
+                        ) { row ->
+                            SourceCatalogCard(
+                                row = row,
+                                onOpen = {
+                                    // Enable-if-disabled first, then hand the
+                                    // id back to the host to drive Browse.
+                                    viewModel.onSourceChosen(row.descriptor.id)
+                                    onSelectSource(row.descriptor.id)
+                                },
+                                onToggle = { enabled ->
+                                    viewModel.toggleEnabled(row.descriptor.id, enabled)
+                                },
+                            )
+                        }
+                    }
+
+                    // Footer count line — mirrors the active-filter result
+                    // count so a long search still tells the user how many
+                    // matched.
+                    item("footer") {
+                        Text(
+                            text = if (state.query.isBlank()) {
+                                "Tap a source to browse it · toggle to add it to your shelf"
+                            } else {
+                                "$matchCount of ${state.totalCount} sources match “${state.query.trim()}”"
+                            },
+                            style = MaterialTheme.typography.labelMedium,
+                            color = MaterialTheme.colorScheme.onSurfaceVariant,
+                            textAlign = TextAlign.Center,
+                            modifier = Modifier
+                                .fillMaxWidth()
+                                .padding(top = spacing.md),
+                        )
+                    }
+                }
+            }
+        }
+    }
+}
+
+/** Source Catalog (#1365) — empty state when a search matches nothing. */
+@Composable
+private fun EmptyCatalogState(query: String) {
+    val spacing = LocalSpacing.current
+    Column(
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(vertical = spacing.xxl, horizontal = spacing.lg),
+        horizontalAlignment = Alignment.CenterHorizontally,
+        verticalArrangement = Arrangement.spacedBy(spacing.sm),
+    ) {
+        Icon(
+            imageVector = Icons.Filled.SearchOff,
+            contentDescription = null,
+            tint = MaterialTheme.colorScheme.primary,
+            modifier = Modifier.size(48.dp),
+        )
+        Text(
+            text = "No sources match",
+            style = MaterialTheme.typography.titleMedium,
+            color = MaterialTheme.colorScheme.onSurface,
+            textAlign = TextAlign.Center,
+        )
+        Text(
+            text = "Nothing in the catalog matches “${query.trim()}”. Try a different name — or clear the search to see every source.",
+            style = MaterialTheme.typography.bodySmall,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+            textAlign = TextAlign.Center,
+        )
+    }
+}

--- a/feature/src/main/kotlin/in/jphe/storyvox/feature/browse/catalog/SourceCatalogViewModel.kt
+++ b/feature/src/main/kotlin/in/jphe/storyvox/feature/browse/catalog/SourceCatalogViewModel.kt
@@ -1,0 +1,182 @@
+package `in`.jphe.storyvox.feature.browse.catalog
+
+import androidx.compose.runtime.Immutable
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import dagger.hilt.android.lifecycle.HiltViewModel
+import `in`.jphe.storyvox.data.source.plugin.SourceCategory
+import `in`.jphe.storyvox.data.source.plugin.SourcePluginDescriptor
+import `in`.jphe.storyvox.data.source.plugin.SourcePluginRegistry
+import `in`.jphe.storyvox.feature.api.SettingsRepositoryUi
+import javax.inject.Inject
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.SharingStarted
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.combine
+import kotlinx.coroutines.flow.stateIn
+import kotlinx.coroutines.launch
+
+/**
+ * Source Catalog (#1365) — the "browse backends like books" discovery
+ * surface.
+ *
+ * With 25 registered sources the horizontal chip carousel in Browse is a
+ * cramped discovery surface — it auto-scrolls to the selected card and
+ * truncates everything else. This screen turns the catalog itself into
+ * something worth exploring: every backend gets a rich card, grouped by
+ * category, searchable by name + description.
+ *
+ * Data source is the same [SourcePluginRegistry] the Browse carousel and
+ * the Settings → Plugins manager read — no parallel store. Enabled state
+ * is projected off the `sourcePluginsEnabled` settings map exactly like
+ * [PluginManagerViewModel][`in`.jphe.storyvox.feature.settings.plugins.PluginManagerViewModel],
+ * with each descriptor's `defaultEnabled` as the fallback for ids the
+ * user hasn't explicitly toggled.
+ *
+ * The screen owns the filter + grouping (pure functions [filterCatalog]
+ * / [groupCatalog]) so the view-model stays a thin projection and the
+ * transformation layer is unit-testable without a Compose host.
+ */
+@HiltViewModel
+class SourceCatalogViewModel @Inject constructor(
+    private val registry: SourcePluginRegistry,
+    private val settings: SettingsRepositoryUi,
+) : ViewModel() {
+
+    private val _query = MutableStateFlow("")
+    val query: StateFlow<String> = _query.asStateFlow()
+
+    val uiState: StateFlow<SourceCatalogUiState> =
+        combine(settings.settings, _query) { s, q ->
+            val rows = registry.descriptors.map { descriptor ->
+                val explicit = s.sourcePluginsEnabled[descriptor.id]
+                SourceCatalogRow(
+                    descriptor = descriptor,
+                    enabled = explicit ?: descriptor.defaultEnabled,
+                )
+            }
+            SourceCatalogUiState(rows = rows, query = q)
+        }.stateIn(
+            viewModelScope,
+            SharingStarted.WhileSubscribed(5_000),
+            SourceCatalogUiState(),
+        )
+
+    fun setQuery(query: String) { _query.value = query }
+
+    /** Enable/disable a source plugin in place — the catalog twin of the
+     *  Plugin Manager's switch and the Browse carousel long-press "hide".
+     *  Same single setter ([SettingsRepositoryUi.setSourcePluginEnabled]),
+     *  so all three surfaces stay in lock-step. */
+    fun toggleEnabled(id: String, enabled: Boolean) {
+        viewModelScope.launch { settings.setSourcePluginEnabled(id, enabled) }
+    }
+
+    /**
+     * Called when the user taps a card to *browse* that source.
+     *
+     * A disabled source must be enabled first: BrowseViewModel's
+     * enabled-set guard bounces `_sourceId` to an enabled source whenever
+     * the selected id isn't in the enabled set, and the carousel only
+     * renders enabled descriptors — so navigating to Browse with a
+     * disabled source selected would silently snap back to another
+     * source and never show the one the user tapped. Enabling on choose
+     * makes the source appear in the carousel AND loads its listing.
+     *
+     * No-op when the source is already enabled (the common case), so we
+     * don't churn the settings store on every browse.
+     */
+    fun onSourceChosen(id: String) {
+        val row = uiState.value.rows.firstOrNull { it.descriptor.id == id } ?: return
+        if (!row.enabled) {
+            viewModelScope.launch { settings.setSourcePluginEnabled(id, enabled = true) }
+        }
+    }
+}
+
+/** Source Catalog (#1365) — Compose-facing state: every registered
+ *  source as a row (enabled flag resolved) plus the live search query.
+ *  Filtering + category grouping happen in the screen via [filterCatalog]
+ *  / [groupCatalog] so this stays a flat projection. */
+@Immutable
+data class SourceCatalogUiState(
+    val rows: List<SourceCatalogRow> = emptyList(),
+    val query: String = "",
+) {
+    /** Total registered source count — drives the "N sources to explore"
+     *  header subtitle. Independent of the active search filter. */
+    val totalCount: Int get() = rows.size
+}
+
+/** Source Catalog (#1365) — one source's descriptor joined with its
+ *  resolved enabled state, mirroring `PluginManagerRow`. */
+@Immutable
+data class SourceCatalogRow(
+    val descriptor: SourcePluginDescriptor,
+    val enabled: Boolean,
+)
+
+/**
+ * Source Catalog (#1365) — the four shelf-style groupings the catalog
+ * renders, in display order. Distinct from the `:core-data`
+ * [SourceCategory] enum: the catalog collapses Database into Other and
+ * gives each group reader-facing copy + a short badge label.
+ *
+ * @property label Section-header title.
+ * @property badge Compact label for the per-card category chip.
+ */
+enum class CatalogGroup(val label: String, val badge: String) {
+    Books("Books & Literature", "Books"),
+    Text("Web Fiction & Text", "Text"),
+    Audio("Audio & Radio", "Audio"),
+    Other("Other", "Other"),
+}
+
+/** Map a `:core-data` [SourceCategory] onto its catalog [CatalogGroup].
+ *  Database folds into [CatalogGroup.Other] per the #1365 grouping. */
+fun catalogGroupOf(category: SourceCategory): CatalogGroup = when (category) {
+    SourceCategory.Ebook -> CatalogGroup.Books
+    SourceCategory.Text -> CatalogGroup.Text
+    SourceCategory.AudioStream -> CatalogGroup.Audio
+    SourceCategory.Database, SourceCategory.Other -> CatalogGroup.Other
+}
+
+/** Source Catalog (#1365) — one rendered category section: the group and
+ *  the rows that fell into it, input order preserved (registry display
+ *  order). */
+@Immutable
+data class SourceCatalogSection(
+    val group: CatalogGroup,
+    val rows: List<SourceCatalogRow>,
+)
+
+/**
+ * Source Catalog (#1365) — substring filter across displayName,
+ * description, and id (case-insensitive), matching the Plugin Manager's
+ * `filterPlugins` semantics so "wiki" finds Wikipedia + Wikisource and
+ * "radio" finds the Radio source via its description. Blank query keeps
+ * everything.
+ */
+fun filterCatalog(rows: List<SourceCatalogRow>, query: String): List<SourceCatalogRow> {
+    if (query.isBlank()) return rows
+    val needle = query.trim().lowercase()
+    return rows.filter { row ->
+        row.descriptor.displayName.lowercase().contains(needle) ||
+            row.descriptor.description.lowercase().contains(needle) ||
+            row.descriptor.id.lowercase().contains(needle)
+    }
+}
+
+/**
+ * Source Catalog (#1365) — bucket rows into [CatalogGroup] sections in
+ * enum-declared order (Books → Text → Audio → Other), dropping empty
+ * sections so a filtered search doesn't render bare headers. Row order
+ * within each section is preserved from the input (the registry's stable
+ * display order).
+ */
+fun groupCatalog(rows: List<SourceCatalogRow>): List<SourceCatalogSection> =
+    CatalogGroup.entries.mapNotNull { group ->
+        val inGroup = rows.filter { catalogGroupOf(it.descriptor.category) == group }
+        if (inGroup.isEmpty()) null else SourceCatalogSection(group, inGroup)
+    }

--- a/feature/src/test/kotlin/in/jphe/storyvox/feature/browse/catalog/SourceCatalogLogicTest.kt
+++ b/feature/src/test/kotlin/in/jphe/storyvox/feature/browse/catalog/SourceCatalogLogicTest.kt
@@ -1,0 +1,147 @@
+package `in`.jphe.storyvox.feature.browse.catalog
+
+import `in`.jphe.storyvox.data.source.FictionSource
+import `in`.jphe.storyvox.data.source.model.ChapterContent
+import `in`.jphe.storyvox.data.source.model.FictionDetail
+import `in`.jphe.storyvox.data.source.model.FictionResult
+import `in`.jphe.storyvox.data.source.model.FictionSummary
+import `in`.jphe.storyvox.data.source.model.ListPage
+import `in`.jphe.storyvox.data.source.model.SearchQuery
+import `in`.jphe.storyvox.data.source.plugin.SourceCategory
+import `in`.jphe.storyvox.data.source.plugin.SourcePluginDescriptor
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * Source Catalog (#1365) — unit tests for the pure transformation layer
+ * of the catalog view-model: the search filter ([filterCatalog]), the
+ * category→group mapping ([catalogGroupOf]), and the section grouping
+ * ([groupCatalog]). Plain JUnit, no Compose host — the rendering is a
+ * thin shell over these functions.
+ */
+class SourceCatalogLogicTest {
+
+    private val books = row("gutenberg", "Project Gutenberg", "Public-domain classics", SourceCategory.Ebook)
+    private val ebook2 = row("standard-ebooks", "Standard Ebooks", "Hand-crafted editions", SourceCategory.Ebook)
+    private val text = row("royalroad", "Royal Road", "Web serials & litRPG", SourceCategory.Text)
+    private val text2 = row("wikipedia", "Wikipedia", "Encyclopedia articles", SourceCategory.Text)
+    private val audio = row("radio", "Radio", "Community radio streams", SourceCategory.AudioStream)
+    private val db = row("notion", "Notion", "Structured database pages", SourceCategory.Database)
+    private val other = row("readability", "Reader", "Any web article", SourceCategory.Other)
+
+    private val all = listOf(books, ebook2, text, text2, audio, db, other)
+
+    // ─── filterCatalog ───────────────────────────────────────────────
+
+    @Test fun `blank query keeps everything`() {
+        assertEquals(all, filterCatalog(all, "   "))
+    }
+
+    @Test fun `filter matches display name case-insensitively`() {
+        val out = filterCatalog(all, "ROYAL")
+        assertEquals(listOf("royalroad"), out.map { it.descriptor.id })
+    }
+
+    @Test fun `filter matches description substring`() {
+        val out = filterCatalog(all, "radio")
+        assertEquals(listOf("radio"), out.map { it.descriptor.id })
+    }
+
+    @Test fun `filter matches plugin id`() {
+        val out = filterCatalog(all, "wikipedia")
+        assertEquals(listOf("wikipedia"), out.map { it.descriptor.id })
+    }
+
+    @Test fun `filter with no match returns empty`() {
+        assertTrue(filterCatalog(all, "zzz-nonexistent").isEmpty())
+    }
+
+    // ─── catalogGroupOf ──────────────────────────────────────────────
+
+    @Test fun `category maps to catalog group`() {
+        assertEquals(CatalogGroup.Books, catalogGroupOf(SourceCategory.Ebook))
+        assertEquals(CatalogGroup.Text, catalogGroupOf(SourceCategory.Text))
+        assertEquals(CatalogGroup.Audio, catalogGroupOf(SourceCategory.AudioStream))
+        assertEquals(CatalogGroup.Other, catalogGroupOf(SourceCategory.Other))
+    }
+
+    @Test fun `Database folds into Other`() {
+        assertEquals(CatalogGroup.Other, catalogGroupOf(SourceCategory.Database))
+    }
+
+    // ─── groupCatalog ────────────────────────────────────────────────
+
+    @Test fun `grouping buckets sources by category in display order`() {
+        val sections = groupCatalog(all)
+        assertEquals(
+            listOf(CatalogGroup.Books, CatalogGroup.Text, CatalogGroup.Audio, CatalogGroup.Other),
+            sections.map { it.group },
+        )
+    }
+
+    @Test fun `grouping preserves input order within a section`() {
+        val sections = groupCatalog(all)
+        val booksSection = sections.first { it.group == CatalogGroup.Books }
+        assertEquals(listOf("gutenberg", "standard-ebooks"), booksSection.rows.map { it.descriptor.id })
+    }
+
+    @Test fun `grouping folds Database and Other into the Other section`() {
+        val sections = groupCatalog(all)
+        val otherSection = sections.first { it.group == CatalogGroup.Other }
+        assertEquals(listOf("notion", "readability"), otherSection.rows.map { it.descriptor.id })
+    }
+
+    @Test fun `grouping drops empty sections`() {
+        // Only Text sources — Books / Audio / Other sections must not appear.
+        val sections = groupCatalog(listOf(text, text2))
+        assertEquals(listOf(CatalogGroup.Text), sections.map { it.group })
+    }
+
+    @Test fun `grouping empty input yields no sections`() {
+        assertTrue(groupCatalog(emptyList()).isEmpty())
+    }
+
+    @Test fun `filter then group composes - audio query yields only the Audio section`() {
+        val sections = groupCatalog(filterCatalog(all, "radio"))
+        assertEquals(listOf(CatalogGroup.Audio), sections.map { it.group })
+        assertEquals(listOf("radio"), sections.single().rows.map { it.descriptor.id })
+    }
+
+    // ─── fixtures ────────────────────────────────────────────────────
+
+    private fun row(
+        id: String,
+        displayName: String,
+        description: String,
+        category: SourceCategory,
+        enabled: Boolean = true,
+    ): SourceCatalogRow = SourceCatalogRow(
+        descriptor = SourcePluginDescriptor(
+            id = id,
+            displayName = displayName,
+            defaultEnabled = enabled,
+            category = category,
+            supportsFollow = false,
+            supportsSearch = true,
+            description = description,
+            sourceUrl = "",
+            source = FakeFictionSource(id),
+        ),
+        enabled = enabled,
+    )
+
+    private class FakeFictionSource(override val id: String) : FictionSource {
+        override val displayName: String = id
+        override suspend fun popular(page: Int): FictionResult<ListPage<FictionSummary>> =
+            FictionResult.Success(ListPage(items = emptyList(), page = page, hasNext = false))
+        override suspend fun latestUpdates(page: Int): FictionResult<ListPage<FictionSummary>> = popular(page)
+        override suspend fun byGenre(genre: String, page: Int): FictionResult<ListPage<FictionSummary>> = popular(page)
+        override suspend fun search(query: SearchQuery): FictionResult<ListPage<FictionSummary>> = popular(1)
+        override suspend fun fictionDetail(fictionId: String): FictionResult<FictionDetail> = FictionResult.NotFound("fake")
+        override suspend fun chapter(fictionId: String, chapterId: String): FictionResult<ChapterContent> = FictionResult.NotFound("fake")
+        override suspend fun followsList(page: Int): FictionResult<ListPage<FictionSummary>> = popular(page)
+        override suspend fun setFollowed(fictionId: String, followed: Boolean): FictionResult<Unit> = FictionResult.Success(Unit)
+        override suspend fun genres(): FictionResult<List<String>> = FictionResult.Success(emptyList())
+    }
+}


### PR DESCRIPTION
## Source Catalog Browser — "Browse backends like books" (#1365)

With 25 registered sources, the horizontal chip carousel in Browse is a cramped discovery surface — it auto-scrolls to the selected card and truncates the rest. This adds a dedicated **Source Library**: a full-screen, shelf-style browser where every backend is a rich card, grouped by category, searchable by name + description.

### What's new
- **`SourceCatalogScreen`** — top bar (`Source Library`) + a hero `N sources to explore` subtitle + search field, then four category sections:
  - **Books & Literature** (Ebook) · **Web Fiction & Text** (Text) · **Audio & Radio** (AudioStream) · **Other** (Other + Database)
  - Each section has a colour-accented header with a live count; empty-search state when nothing matches.
- **`SourceCatalogCard`** — accent-tinted icon tile (reusing the carousel's exact `id→glyph` map), source name, one-line description, a category badge + capability badges (Search/Follow), and an inline **brass enable switch**.
  - **Tap the card body** → browse that source. **Toggle the switch** → enable/disable in place without leaving the catalog.
- **`SourceCatalogViewModel`** — projects `SourcePluginRegistry.descriptors` joined with the `sourcePluginsEnabled` settings map (same pattern as `PluginManagerViewModel`; no parallel store). Search + grouping are pure functions (`filterCatalog` / `groupCatalog` / `catalogGroupOf`) so they're unit-testable without a Compose host.

### How tap → browse works
Tapping a card returns the chosen source id to the Browse back-stack entry via its `SavedStateHandle`, then pops — so Browse (the same live ViewModel) lands on that source. `onSourceChosen` **enables a disabled source first**, otherwise `BrowseViewModel`'s enabled-set guard would bounce the selection (and the carousel only renders enabled descriptors). The result is one-shot: Browse clears it after applying so it never replays.

### Wiring / touchpoints
- `BrowseSourceCarousel.sourceGlyph`: `private` → `internal` so the catalog reuses the same icon table.
- `BrowseScreen`: a **"Browse all sources"** entry card below the carousel (present on both the standalone Browse tab and the embedded Library→Browse path) + the `pendingSourceSelection` consume effect.
- `StoryvoxNavHost`: new `SOURCE_CATALOG = "sources"` route + the savedStateHandle result round-trip. The `BROWSE` constant is **unchanged** (`NavStructureTest` stays green).
- `TestTags`: `SourceCatalogList`, `SourceCatalogEntry`, `sourceCatalogCard(id)` for on-device QA.

### Out of scope (untouched)
`StoryvoxDatabase.kt`, `core-data/`, `AndroidManifest.xml` — the registry API was sufficient; no persistence or permissions needed.

### Tests
`SourceCatalogLogicTest` covers the filter (name/description/id, case-insensitive), the category→group mapping (incl. Database→Other), and the section grouping (display order, empty-section drop, filter∘group composition).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
