### PR TITLE
feat(reader): Script Manager — save, edit & organize teleprompter scripts (#1369)

### DIFF
--- a/app/src/main/kotlin/in/jphe/storyvox/navigation/StoryvoxNavHost.kt
+++ b/app/src/main/kotlin/in/jphe/storyvox/navigation/StoryvoxNavHost.kt
@@ -94,6 +94,17 @@ object StoryvoxRoutes {
 
     /** Issue #1235 — Listening stats dashboard, reached from the Settings hub. */
     const val STATS = "stats"
+
+    /** Issue #1369 — teleprompter script manager (save/edit/organize). The
+     *  list is reached from the Settings hub and (once wired) the teleprompter
+     *  transport bar; [SCRIPT_EDIT] is the per-script editor. */
+    const val SCRIPT_LIST = "scripts"
+    const val SCRIPT_EDIT = "scripts/{scriptId}"
+
+    /** Build the editor route for [scriptId]. The id is a client UUID (no
+     *  slashes) but we encode it for parity with [reader]/[fictionDetail]. */
+    fun scriptEdit(scriptId: String) = "scripts/${Uri.encode(scriptId)}"
+
     const val SETTINGS = "settings"
     const val SETTINGS_PRONUNCIATION = "settings/pronunciation"
     const val VOICE_LIBRARY = "settings/voices"
@@ -1034,6 +1045,7 @@ private fun StoryvoxNavHostContent(
                     onOpenAbout = { navController.navigate(StoryvoxRoutes.SETTINGS_ABOUT) },
                     onOpenAdvanced = { navController.navigate(StoryvoxRoutes.SETTINGS_ADVANCED) },
                     onOpenStats = { navController.navigate(StoryvoxRoutes.STATS) },
+                    onOpenScripts = { navController.navigate(StoryvoxRoutes.SCRIPT_LIST) },
                 )
             }
 
@@ -1048,6 +1060,42 @@ private fun StoryvoxNavHostContent(
                 popExitTransition = popExit,
             ) {
                 ListeningStatsScreen(onBack = { navController.popBackStack() })
+            }
+
+            // Issue #1369 — teleprompter script manager. List + editor are
+            // drill-downs (push enter/exit) reached from the Settings hub.
+            // "Load into Teleprompter" queues the script into the shared
+            // TeleprompterScriptStore (core-playback) and routes to PLAYING,
+            // where the reader picks it up in teleprompter mode.
+            composable(
+                StoryvoxRoutes.SCRIPT_LIST,
+                enterTransition = pushEnter,
+                exitTransition = pushExit,
+                popEnterTransition = popEnter,
+                popExitTransition = popExit,
+            ) {
+                `in`.jphe.storyvox.feature.reader.script.ScriptListScreen(
+                    onBack = { navController.popBackStack() },
+                    onOpenScript = { id -> navController.navigate(StoryvoxRoutes.scriptEdit(id)) },
+                    onOpenTeleprompter = {
+                        navController.navigate(StoryvoxRoutes.PLAYING) { launchSingleTop = true }
+                    },
+                )
+            }
+            composable(
+                route = StoryvoxRoutes.SCRIPT_EDIT,
+                arguments = listOf(navArgument("scriptId") { type = NavType.StringType }),
+                enterTransition = pushEnter,
+                exitTransition = pushExit,
+                popEnterTransition = popEnter,
+                popExitTransition = popExit,
+            ) {
+                `in`.jphe.storyvox.feature.reader.script.ScriptEditScreen(
+                    onBack = { navController.popBackStack() },
+                    onOpenTeleprompter = {
+                        navController.navigate(StoryvoxRoutes.PLAYING) { launchSingleTop = true }
+                    },
+                )
             }
 
             composable(

--- a/core-data/src/main/kotlin/in/jphe/storyvox/data/db/StoryvoxDatabase.kt
+++ b/core-data/src/main/kotlin/in/jphe/storyvox/data/db/StoryvoxDatabase.kt
@@ -17,6 +17,7 @@ import `in`.jphe.storyvox.data.db.dao.ListeningStatsDao
 import `in`.jphe.storyvox.data.db.dao.LlmMessageDao
 import `in`.jphe.storyvox.data.db.dao.LlmSessionDao
 import `in`.jphe.storyvox.data.db.dao.PlaybackDao
+import `in`.jphe.storyvox.data.db.dao.TeleprompterScriptDao
 import `in`.jphe.storyvox.data.db.entity.Annotation
 import `in`.jphe.storyvox.data.db.entity.AuthCookie
 import `in`.jphe.storyvox.data.db.entity.Chapter
@@ -29,6 +30,7 @@ import `in`.jphe.storyvox.data.db.entity.InboxEvent
 import `in`.jphe.storyvox.data.db.entity.LlmSession
 import `in`.jphe.storyvox.data.db.entity.LlmStoredMessage
 import `in`.jphe.storyvox.data.db.entity.PlaybackPosition
+import `in`.jphe.storyvox.data.db.entity.TeleprompterScript
 
 @Database(
     entities = [
@@ -62,6 +64,9 @@ import `in`.jphe.storyvox.data.db.entity.PlaybackPosition
         // v17 (#1283 per-character voice) — per-(fiction, character) voiceId
         // map. Additive junction table; FK CASCADE to fiction.
         CharacterVoice::class,
+        // v18 (#1369 script manager) — user-authored teleprompter scripts
+        // (save/edit/organize). Standalone rows with no FK to fiction/chapter.
+        TeleprompterScript::class,
     ],
     // v11 (#965 per-chapter playback position) — PlaybackPosition PK changes
     // from `fictionId` to composite `(fictionId, chapterId)` so each chapter
@@ -92,7 +97,12 @@ import `in`.jphe.storyvox.data.db.entity.PlaybackPosition
     // v17 (#1283 per-character voice) — adds the `character_voice` table
     // (per-(fiction, character) → voiceId). Purely additive new table with a
     // CASCADE FK to fiction. See MIGRATION_16_17.
-    version = 17,
+    //
+    // v18 (#1369 script manager) — adds the `teleprompter_script` table for
+    // user-authored teleprompter scripts (save/edit/organize). Purely additive
+    // new table; no FK (scripts are independent of fiction/chapter). See
+    // MIGRATION_17_18.
+    version = 18,
     exportSchema = true,
 )
 @TypeConverters(Converters::class)
@@ -111,6 +121,9 @@ abstract class StoryvoxDatabase : RoomDatabase() {
 
     // Issue #1283 — per-character voice assignment map.
     abstract fun characterVoiceDao(): CharacterVoiceDao
+
+    // Issue #1369 — user-authored teleprompter scripts (save/edit/organize).
+    abstract fun teleprompterScriptDao(): TeleprompterScriptDao
 
     // Issue #1235 — read-only aggregate queries for the listening-stats
     // dashboard. No entity of its own; aggregates chapter_history +

--- a/core-data/src/main/kotlin/in/jphe/storyvox/data/db/dao/TeleprompterScriptDao.kt
+++ b/core-data/src/main/kotlin/in/jphe/storyvox/data/db/dao/TeleprompterScriptDao.kt
@@ -1,0 +1,48 @@
+package `in`.jphe.storyvox.data.db.dao
+
+import androidx.room.Dao
+import androidx.room.Insert
+import androidx.room.OnConflictStrategy
+import androidx.room.Query
+import `in`.jphe.storyvox.data.db.entity.TeleprompterScript
+import kotlinx.coroutines.flow.Flow
+
+/**
+ * Issue #1369 — CRUD for user-authored teleprompter scripts. See
+ * [TeleprompterScript] for the schema and the duration/word-count helpers.
+ *
+ * Upsert is an `@Insert(onConflict = REPLACE)` rather than `@Upsert` because
+ * the screens save a fully-formed row each time (new + edit both build the
+ * complete entity), so a replace-on-id is exactly the semantics we want and
+ * keeps the generated SQL identical to the migration's expectations.
+ */
+@Dao
+interface TeleprompterScriptDao {
+
+    /** Insert a new script or replace an existing one with the same [TeleprompterScript.id]. */
+    @Insert(onConflict = OnConflictStrategy.REPLACE)
+    suspend fun upsert(script: TeleprompterScript)
+
+    /** All scripts, most-recently-edited first — the list screen's default feed. */
+    @Query("SELECT * FROM teleprompter_script ORDER BY updatedAt DESC")
+    fun observeAll(): Flow<List<TeleprompterScript>>
+
+    @Query("SELECT * FROM teleprompter_script WHERE id = :id")
+    suspend fun get(id: String): TeleprompterScript?
+
+    @Query("DELETE FROM teleprompter_script WHERE id = :id")
+    suspend fun delete(id: String)
+
+    /**
+     * Title-or-tags substring search, newest-edited first. Matches the list
+     * screen's search bar; an empty query returns everything (the `LIKE
+     * '%%'` degenerates to "match all"), so the screen can bind the same flow
+     * for both the unfiltered and filtered states.
+     */
+    @Query(
+        "SELECT * FROM teleprompter_script " +
+            "WHERE title LIKE '%' || :query || '%' OR tags LIKE '%' || :query || '%' " +
+            "ORDER BY updatedAt DESC",
+    )
+    fun search(query: String): Flow<List<TeleprompterScript>>
+}

--- a/core-data/src/main/kotlin/in/jphe/storyvox/data/db/entity/TeleprompterScript.kt
+++ b/core-data/src/main/kotlin/in/jphe/storyvox/data/db/entity/TeleprompterScript.kt
@@ -1,0 +1,93 @@
+package `in`.jphe.storyvox.data.db.entity
+
+import androidx.room.Entity
+import androidx.room.PrimaryKey
+
+/**
+ * Issue #1369 — a user-authored teleprompter script.
+ *
+ * The teleprompter (solo-rehearsal / read-aloud mode, #1239) historically
+ * scrolled only the *current chapter's* body. This entity lets a user save,
+ * edit, and organize standalone scripts — talks, narration drafts, lines to
+ * rehearse — that have no backing [Fiction]/[Chapter], then load any of them
+ * into the teleprompter on demand.
+ *
+ * ## Identity
+ * [id] is a client-generated UUID (see `SyncIds` for the same pattern used by
+ * [Annotation]). A stable id is what lets a list-screen swipe-to-delete with
+ * undo address one row, and what a future cross-device syncer would key on.
+ *
+ * ## No foreign keys
+ * Scripts are independent objects — they are deliberately NOT tied to a
+ * fiction or chapter, so nothing cascades into or out of them. Removing a book
+ * never touches a script; deleting a script never touches a book.
+ *
+ * ## Duration estimate
+ * [estimatedDurationSecs] is a *stored snapshot* of "how long this reads aloud"
+ * at the canonical [WPM_BASELINE] pace, recomputed on every save via
+ * [estimateDurationSecs]. It is denormalized into the row so the list screen
+ * can render a duration badge without re-tokenizing every body on every frame.
+ * The edit screen shows a *live* duration at the user's current teleprompter
+ * WPM (which may differ from the baseline); the two are intentionally distinct
+ * — the row badge is a stable at-a-glance figure, the editor figure tracks the
+ * pace the user will actually read at.
+ *
+ * ## Tags
+ * [tags] is a comma-separated string rather than a junction table — scripts are
+ * a lightweight, single-user, local-first feature and the search query
+ * (`tags LIKE '%query%'`) is all the filtering the list screen needs. The chip
+ * display in the editor splits/trims on commas. Keeping it a plain column
+ * avoids a second table + migration for what is effectively a freeform label.
+ */
+@Entity(tableName = "teleprompter_script")
+data class TeleprompterScript(
+    /** Client-generated UUID — the stable identity for edits/deletes. */
+    @PrimaryKey val id: String,
+    /** User-visible title (single line). May be blank for an untitled draft. */
+    val title: String,
+    /** The script text the teleprompter scrolls. */
+    val body: String,
+    /**
+     * Read-aloud duration estimate in whole seconds at [WPM_BASELINE], stored
+     * so the list badge needs no per-frame recompute. Refreshed on each save
+     * via [estimateDurationSecs].
+     */
+    val estimatedDurationSecs: Int,
+    /** Comma-separated freeform tags. Empty string = no tags. */
+    val tags: String = "",
+    /** Wall-clock millis the script was first created. */
+    val createdAt: Long,
+    /** Wall-clock millis of the last edit. Equal to [createdAt] on first save;
+     *  drives the `ORDER BY updatedAt DESC` list ordering. */
+    val updatedAt: Long,
+) {
+    companion object {
+        /**
+         * Canonical reading pace for the stored [estimatedDurationSecs]. 150
+         * wpm is a conventional spoken-narration midpoint (the teleprompter's
+         * own default of `TELEPROMPTER_DEFAULT_WPM` = 130 is a slower
+         * rehearsal pace; the stored estimate uses a neutral baseline so a
+         * script's badge doesn't shift when the user nudges their live pace).
+         */
+        const val WPM_BASELINE: Int = 150
+
+        /** Whitespace-delimited word count — the same notion the teleprompter
+         *  paces on (one "word" per token). Blank/whitespace-only → 0. */
+        fun wordCount(body: String): Int =
+            if (body.isBlank()) 0 else body.trim().split(Regex("\\s+")).size
+
+        /**
+         * Estimated read-aloud duration of [body] in whole seconds at
+         * [WPM_BASELINE]. Rounds up so a short script never shows 0:00 (a
+         * single word still reads as ~1s). Pure + side-effect-free so it's
+         * unit-testable without a clock.
+         */
+        fun estimateDurationSecs(body: String, wpm: Int = WPM_BASELINE): Int {
+            val words = wordCount(body)
+            if (words == 0) return 0
+            val safeWpm = wpm.coerceAtLeast(1)
+            // ceil(words / wpm * 60) without floating-point surprises.
+            return ((words * 60) + safeWpm - 1) / safeWpm
+        }
+    }
+}

--- a/core-data/src/main/kotlin/in/jphe/storyvox/data/db/entity/TeleprompterScript.kt
+++ b/core-data/src/main/kotlin/in/jphe/storyvox/data/db/entity/TeleprompterScript.kt
@@ -55,6 +55,14 @@ data class TeleprompterScript(
     val estimatedDurationSecs: Int,
     /** Comma-separated freeform tags. Empty string = no tags. */
     val tags: String = "",
+    /**
+     * Script format, persisted as a [ScriptFormat] enum *name* (string, not
+     * ordinal — same forward-compat pattern as `FictionShelf.shelf`) so a new
+     * format can be appended without a schema migration. Drives organization
+     * and (future) format-aware behavior; the spoken-text parser
+     * ([spokenText]) is format-agnostic so duration is correct regardless.
+     */
+    val format: String = ScriptFormat.FREEFORM.name,
     /** Wall-clock millis the script was first created. */
     val createdAt: Long,
     /** Wall-clock millis of the last edit. Equal to [createdAt] on first save;
@@ -71,23 +79,89 @@ data class TeleprompterScript(
          */
         const val WPM_BASELINE: Int = 150
 
-        /** Whitespace-delimited word count — the same notion the teleprompter
-         *  paces on (one "word" per token). Blank/whitespace-only → 0. */
-        fun wordCount(body: String): Int =
-            if (body.isBlank()) 0 else body.trim().split(Regex("\\s+")).size
+        /** A `[bracketed]` production cue — `[POST: JINGLE]`, `[pause]`, etc.
+         *  May span lines, so DOT_MATCHES_ALL. Not spoken. */
+        private val BRACKET_CUE = Regex("""\[[^\[\]]*]""", RegexOption.DOT_MATCHES_ALL)
+
+        /** A full-line `====` banner. Toggles in/out of a non-spoken block
+         *  (the top metadata block AND `====`-wrapped section headers). */
+        private val BANNER_LINE = Regex("""^\s*={3,}\s*$""")
+
+        /** A full-line `----` rule (metadata separator). Not spoken. */
+        private val RULE_LINE = Regex("""^\s*-{3,}\s*$""")
+
+        /** A speaker label alone on its line — `SHAWNA:`, `JEFF:`,
+         *  `SHAWNA AND JEFF:`. All-caps name(s) + colon. Not spoken. */
+        private val SPEAKER_LABEL = Regex("""^\s*[A-Z][A-Z0-9 .'&/()-]*:\s*$""")
+
+        private val WHITESPACE = Regex("""\s+""")
+
+        /** Total whitespace-delimited word count of [text] (markup included).
+         *  Blank/whitespace-only → 0. */
+        fun wordCount(text: String): Int =
+            if (text.isBlank()) 0 else text.trim().split(WHITESPACE).size
 
         /**
-         * Estimated read-aloud duration of [body] in whole seconds at
-         * [WPM_BASELINE]. Rounds up so a short script never shows 0:00 (a
-         * single word still reads as ~1s). Pure + side-effect-free so it's
-         * unit-testable without a clock.
+         * The *spoken* portion of a show-format [body]: strips `[bracketed]`
+         * production cues, `====`-delimited banner blocks (the top metadata /
+         * "prompter notes" block AND `====`-wrapped section headers), `----`
+         * rule lines, and whole-line `SPEAKER:` labels. Plain freeform text
+         * (no markup) passes through unchanged. This is what the teleprompter
+         * actually reads aloud, so the duration estimate counts these words —
+         * not the cues/headers/labels (issue #1369, TechEmpower Show format).
+         */
+        fun spokenText(body: String): String {
+            // 1. Remove [bracketed] cues first (they can span lines).
+            val noCues = BRACKET_CUE.replace(body, " ")
+            // 2. Line pass with a "inside ==== banner block" toggle. Each
+            //    banner line flips the toggle, so both the top metadata block
+            //    and every ====-wrapped section header fall inside it.
+            var inBanner = false
+            val kept = StringBuilder()
+            for (line in noCues.lineSequence()) {
+                if (BANNER_LINE.matches(line)) { inBanner = !inBanner; continue }
+                if (inBanner) continue
+                if (RULE_LINE.matches(line)) continue
+                if (SPEAKER_LABEL.matches(line)) continue
+                kept.append(line).append('\n')
+            }
+            return kept.toString().trim()
+        }
+
+        /** Word count of the spoken text only — see [spokenText]. */
+        fun spokenWordCount(body: String): Int = wordCount(spokenText(body))
+
+        /**
+         * Estimated read-aloud duration of [body] in whole seconds at the given
+         * pace, counting [spokenWordCount] (cues / headers / speaker labels
+         * excluded). Rounds up so a short script never shows 0:00. Pure +
+         * side-effect-free so it's unit-testable without a clock.
          */
         fun estimateDurationSecs(body: String, wpm: Int = WPM_BASELINE): Int {
-            val words = wordCount(body)
+            val words = spokenWordCount(body)
             if (words == 0) return 0
             val safeWpm = wpm.coerceAtLeast(1)
             // ceil(words / wpm * 60) without floating-point surprises.
             return ((words * 60) + safeWpm - 1) / safeWpm
         }
+    }
+}
+
+/**
+ * Issue #1369 — the kind of script, used for organization (and future
+ * format-aware behavior). JP's three named buckets; persisted as the enum
+ * `name` on [TeleprompterScript.format].
+ */
+enum class ScriptFormat(val label: String) {
+    FREEFORM("Freeform"),
+    SHORT("YouTube Short"),
+    FULL_SHOW("Full Show"),
+    ;
+
+    companion object {
+        /** Parse a stored [TeleprompterScript.format] string, falling back to
+         *  [FREEFORM] for an unknown/legacy value. */
+        fun fromName(name: String): ScriptFormat =
+            entries.firstOrNull { it.name == name } ?: FREEFORM
     }
 }

--- a/core-data/src/main/kotlin/in/jphe/storyvox/data/db/migration/Migrations.kt
+++ b/core-data/src/main/kotlin/in/jphe/storyvox/data/db/migration/Migrations.kt
@@ -542,6 +542,7 @@ val MIGRATION_17_18: Migration = object : Migration(17, 18) {
                 `body` TEXT NOT NULL,
                 `estimatedDurationSecs` INTEGER NOT NULL,
                 `tags` TEXT NOT NULL DEFAULT '',
+                `format` TEXT NOT NULL DEFAULT 'FREEFORM',
                 `createdAt` INTEGER NOT NULL,
                 `updatedAt` INTEGER NOT NULL
             )

--- a/core-data/src/main/kotlin/in/jphe/storyvox/data/db/migration/Migrations.kt
+++ b/core-data/src/main/kotlin/in/jphe/storyvox/data/db/migration/Migrations.kt
@@ -518,6 +518,38 @@ val MIGRATION_16_17: Migration = object : Migration(16, 17) {
     }
 }
 
+/**
+ * v18 — issue #1369: teleprompter script manager. Adds the
+ * `teleprompter_script` table backing the save/edit/organize feature — a row
+ * per user-authored script (talk, narration draft, lines to rehearse) the
+ * teleprompter can load on demand. Purely additive new table; no existing
+ * table or row is touched, and no foreign keys (scripts are independent of
+ * any fiction/chapter — see the [`in`.jphe.storyvox.data.db.entity.TeleprompterScript]
+ * kdoc).
+ *
+ * The CREATE TABLE SQL must match what Room generates from the
+ * [`in`.jphe.storyvox.data.db.entity.TeleprompterScript] `@Entity` exactly
+ * (column order, types, the `tags` NOT NULL DEFAULT '') or Room's startup
+ * identity-hash check rejects the migration.
+ */
+val MIGRATION_17_18: Migration = object : Migration(17, 18) {
+    override fun migrate(db: SupportSQLiteDatabase) {
+        db.execSQL(
+            """
+            CREATE TABLE IF NOT EXISTS `teleprompter_script` (
+                `id` TEXT NOT NULL PRIMARY KEY,
+                `title` TEXT NOT NULL,
+                `body` TEXT NOT NULL,
+                `estimatedDurationSecs` INTEGER NOT NULL,
+                `tags` TEXT NOT NULL DEFAULT '',
+                `createdAt` INTEGER NOT NULL,
+                `updatedAt` INTEGER NOT NULL
+            )
+            """.trimIndent(),
+        )
+    }
+}
+
 val ALL_MIGRATIONS: Array<Migration> = arrayOf(
     MIGRATION_1_2,
     MIGRATION_2_3,
@@ -535,4 +567,5 @@ val ALL_MIGRATIONS: Array<Migration> = arrayOf(
     MIGRATION_14_15,
     MIGRATION_15_16,
     MIGRATION_16_17,
+    MIGRATION_17_18,
 )

--- a/core-data/src/main/kotlin/in/jphe/storyvox/data/di/DataModule.kt
+++ b/core-data/src/main/kotlin/in/jphe/storyvox/data/di/DataModule.kt
@@ -30,6 +30,7 @@ import `in`.jphe.storyvox.data.db.dao.ListeningStatsDao
 import `in`.jphe.storyvox.data.db.dao.LlmMessageDao
 import `in`.jphe.storyvox.data.db.dao.LlmSessionDao
 import `in`.jphe.storyvox.data.db.dao.PlaybackDao
+import `in`.jphe.storyvox.data.db.dao.TeleprompterScriptDao
 import `in`.jphe.storyvox.data.db.migration.ALL_MIGRATIONS
 import `in`.jphe.storyvox.data.repository.AuthRepository
 import `in`.jphe.storyvox.data.repository.AnnotationRepository
@@ -131,6 +132,8 @@ object DataModule {
     @Provides fun annotationDao(db: StoryvoxDatabase): AnnotationDao = db.annotationDao()
     // Issue #1283 — per-character voice assignment map.
     @Provides fun characterVoiceDao(db: StoryvoxDatabase): CharacterVoiceDao = db.characterVoiceDao()
+    // Issue #1369 — user-authored teleprompter scripts (save/edit/organize).
+    @Provides fun teleprompterScriptDao(db: StoryvoxDatabase): TeleprompterScriptDao = db.teleprompterScriptDao()
     // Issue #1235 — read-only aggregate DAO for the listening-stats dashboard.
     @Provides fun listeningStatsDao(db: StoryvoxDatabase): ListeningStatsDao = db.listeningStatsDao()
 

--- a/core-data/src/test/kotlin/in/jphe/storyvox/data/db/entity/TeleprompterScriptTest.kt
+++ b/core-data/src/test/kotlin/in/jphe/storyvox/data/db/entity/TeleprompterScriptTest.kt
@@ -1,6 +1,7 @@
 package `in`.jphe.storyvox.data.db.entity
 
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
 import org.junit.Test
 
 /**
@@ -42,5 +43,73 @@ class TeleprompterScriptTest {
     @Test fun `estimateDurationSecs clamps a non-positive wpm to avoid div-by-zero`() {
         // wpm coerced to >= 1; "a b" = 2 words @ 1 wpm = 120s.
         assertEquals(120, TeleprompterScript.estimateDurationSecs("a b", wpm = 0))
+    }
+
+    // ── Show-script format parsing (#1369 / TechEmpower Show) ──────────────
+
+    @Test fun `spokenText passes plain freeform text through unchanged`() {
+        assertEquals("Just some plain words.", TeleprompterScript.spokenText("Just some plain words."))
+        assertEquals(4, TeleprompterScript.spokenWordCount("Just some plain words."))
+    }
+
+    @Test fun `spokenText strips bracketed cues, inline and multi-line`() {
+        assertEquals(5, TeleprompterScript.spokenWordCount("Glad to be here [chuckles] really."))
+        // Multi-line cue is removed whole — only "Before" + "after" remain.
+        val multi = "Before [POST: jingle\nand logo] after"
+        assertEquals(2, TeleprompterScript.spokenWordCount(multi))
+        assertTrue(
+            "bracketed cue content must be gone",
+            !TeleprompterScript.spokenText(multi).contains("jingle"),
+        )
+    }
+
+    @Test fun `spokenText strips banner blocks, rules, and speaker labels`() {
+        val script = """
+            ================================================================
+            WAIT, I QUALIFY?!  --  EPISODE 1
+            ----------------------------------------------------------------
+            PROMPTER NOTES (do not read):
+            - Lines in [BRACKETS] are cues, not dialogue.
+            ================================================================
+
+            [POST: JINGLE + LOGO INTRO]
+
+            SHAWNA:
+            Welcome to the show.
+
+            JEFF:
+            Glad to be here [chuckles] really.
+
+            ================================================================
+            MYTH ONE: "BENEFITS ARE ONLY FOR THE DESTITUTE"
+            ================================================================
+
+            SHAWNA:
+            Let's jump in.
+        """.trimIndent()
+
+        // Only the three dialogue lines are spoken: 4 + 5 + 3 = 12 words.
+        assertEquals(12, TeleprompterScript.spokenWordCount(script))
+        // The raw total is much larger (metadata, headers, labels, cues).
+        assertTrue(
+            "total word count must exceed spoken",
+            TeleprompterScript.wordCount(script) > TeleprompterScript.spokenWordCount(script),
+        )
+    }
+
+    @Test fun `estimateDurationSecs counts spoken words only`() {
+        val script = """
+            [intro music plays for a while with many bracketed words here]
+            SHAWNA:
+            Hello there.
+        """.trimIndent()
+        // Only "Hello there." is spoken → 2 words → ceil(2*60/150) = 1s.
+        assertEquals(1, TeleprompterScript.estimateDurationSecs(script))
+    }
+
+    @Test fun `ScriptFormat fromName falls back to FREEFORM for unknown values`() {
+        assertEquals(ScriptFormat.FULL_SHOW, ScriptFormat.fromName("FULL_SHOW"))
+        assertEquals(ScriptFormat.FREEFORM, ScriptFormat.fromName("not-a-format"))
+        assertEquals(ScriptFormat.FREEFORM, ScriptFormat.fromName(""))
     }
 }

--- a/core-data/src/test/kotlin/in/jphe/storyvox/data/db/entity/TeleprompterScriptTest.kt
+++ b/core-data/src/test/kotlin/in/jphe/storyvox/data/db/entity/TeleprompterScriptTest.kt
@@ -1,0 +1,46 @@
+package `in`.jphe.storyvox.data.db.entity
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+/**
+ * Issue #1369 — pure unit coverage for [TeleprompterScript]'s word-count and
+ * read-aloud duration math. No Android/Room/Robolectric dependency.
+ */
+class TeleprompterScriptTest {
+
+    @Test fun `wordCount counts whitespace-delimited tokens`() {
+        assertEquals(0, TeleprompterScript.wordCount(""))
+        assertEquals(0, TeleprompterScript.wordCount("   \n\t "))
+        assertEquals(1, TeleprompterScript.wordCount("hello"))
+        assertEquals(3, TeleprompterScript.wordCount("one two three"))
+        assertEquals(3, TeleprompterScript.wordCount("  one\ntwo\t three  "))
+    }
+
+    @Test fun `estimateDurationSecs is zero for an empty body`() {
+        assertEquals(0, TeleprompterScript.estimateDurationSecs(""))
+        assertEquals(0, TeleprompterScript.estimateDurationSecs("   "))
+    }
+
+    @Test fun `estimateDurationSecs rounds up so a one-word script is never zero`() {
+        // 1 word @ 150 wpm = 0.4s → ceil → 1s.
+        assertEquals(1, TeleprompterScript.estimateDurationSecs("hello"))
+    }
+
+    @Test fun `estimateDurationSecs at the 150 wpm baseline`() {
+        // Exactly 150 words @ 150 wpm = 60s.
+        val body = (1..150).joinToString(" ") { "w$it" }
+        assertEquals(60, TeleprompterScript.estimateDurationSecs(body))
+    }
+
+    @Test fun `estimateDurationSecs honors a custom wpm`() {
+        // 130 words @ 130 wpm = 60s.
+        val body = (1..130).joinToString(" ") { "w$it" }
+        assertEquals(60, TeleprompterScript.estimateDurationSecs(body, wpm = 130))
+    }
+
+    @Test fun `estimateDurationSecs clamps a non-positive wpm to avoid div-by-zero`() {
+        // wpm coerced to >= 1; "a b" = 2 words @ 1 wpm = 120s.
+        assertEquals(120, TeleprompterScript.estimateDurationSecs("a b", wpm = 0))
+    }
+}

--- a/core-playback/src/main/kotlin/in/jphe/storyvox/playback/TeleprompterScriptStore.kt
+++ b/core-playback/src/main/kotlin/in/jphe/storyvox/playback/TeleprompterScriptStore.kt
@@ -1,0 +1,74 @@
+package `in`.jphe.storyvox.playback
+
+import javax.inject.Inject
+import javax.inject.Singleton
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+
+/**
+ * Issue #1369 — the one-way seam that lets a caller push arbitrary text into
+ * the teleprompter **without a backing `Fiction`/`Chapter`**.
+ *
+ * The teleprompter (#1239) historically scrolled only the *current chapter's*
+ * body, reachable solely through the reader's normal chapter pipeline. Two
+ * features need to feed it free text instead:
+ *   - #1369 Script Manager — "Load this saved script into the teleprompter".
+ *   - #1366 AI Script Writer — "Run this just-generated script in the teleprompter".
+ *
+ * Rather than each feature inventing its own reader hook (and clobbering
+ * `ReaderView` in parallel), both write a [PendingTeleprompterScript] here and
+ * navigate to the player. The reader observes [pending] and, when non-null,
+ * renders that text in teleprompter mode instead of the chapter body, then
+ * calls [consume] so a back-out + return doesn't re-trigger it.
+ *
+ * Lives in `:core-playback` (not `:feature`) for the same reason as
+ * [TeleprompterController]: it's a `@Singleton` both the UI and non-Compose
+ * layers can reach, and it has no Compose dependency.
+ */
+@Singleton
+class TeleprompterScriptStore @Inject constructor() {
+
+    private val _pending = MutableStateFlow<PendingTeleprompterScript?>(null)
+
+    /**
+     * The script queued for the teleprompter, or null when none is pending
+     * (the reader falls back to the normal chapter body). Set by [load],
+     * cleared by [consume]/[clear].
+     */
+    val pending: StateFlow<PendingTeleprompterScript?> = _pending.asStateFlow()
+
+    /** Queue [script] for the teleprompter. Replaces any prior pending script. */
+    fun load(script: PendingTeleprompterScript) { _pending.value = script }
+
+    /**
+     * Atomically read-and-clear the pending script. The reader calls this once
+     * it has taken ownership of the text so navigating away and back doesn't
+     * reload the same script over the user's place. Returns null if nothing
+     * was pending.
+     */
+    fun consume(): PendingTeleprompterScript? {
+        val current = _pending.value
+        _pending.value = null
+        return current
+    }
+
+    /** Drop any pending script without consuming it (e.g. user cancelled). */
+    fun clear() { _pending.value = null }
+}
+
+/**
+ * A piece of text destined for the teleprompter.
+ *
+ * @property id The source [`in`.jphe.storyvox.data] script id when loaded from
+ *   a saved row (#1369), or null for ephemeral/unsaved text (e.g. an AI draft,
+ *   #1366). Carried only so the reader/consumer can attribute or persist
+ *   position later; the teleprompter itself only needs [title] + [body].
+ * @property title Display title for the teleprompter chrome (may be blank).
+ * @property body The text to scroll.
+ */
+data class PendingTeleprompterScript(
+    val id: String? = null,
+    val title: String,
+    val body: String,
+)

--- a/feature/src/main/kotlin/in/jphe/storyvox/feature/reader/script/ScriptEditScreen.kt
+++ b/feature/src/main/kotlin/in/jphe/storyvox/feature/reader/script/ScriptEditScreen.kt
@@ -20,6 +20,7 @@ import androidx.compose.material.icons.outlined.PlayArrow
 import androidx.compose.material3.DropdownMenu
 import androidx.compose.material3.DropdownMenuItem
 import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.FilterChip
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.InputChip
@@ -41,6 +42,7 @@ import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import `in`.jphe.storyvox.data.db.entity.ScriptFormat
 import `in`.jphe.storyvox.data.db.entity.TeleprompterScript
 import `in`.jphe.storyvox.ui.theme.LocalSpacing
 
@@ -134,6 +136,19 @@ fun ScriptEditScreen(
                 label = { Text("Title") },
             )
 
+            FlowRow(
+                modifier = Modifier.fillMaxWidth(),
+                horizontalArrangement = Arrangement.spacedBy(spacing.xs),
+            ) {
+                ScriptFormat.entries.forEach { fmt ->
+                    FilterChip(
+                        selected = state.format == fmt.name,
+                        onClick = { viewModel.onFormatChange(fmt) },
+                        label = { Text(fmt.label) },
+                    )
+                }
+            }
+
             OutlinedTextField(
                 value = state.tags,
                 onValueChange = viewModel::onTagsChange,
@@ -195,14 +210,22 @@ private fun ScriptMetricsFooter(
     wpm: Int,
     modifier: Modifier = Modifier,
 ) {
-    val words = remember(body) { TeleprompterScript.wordCount(body) }
+    val total = remember(body) { TeleprompterScript.wordCount(body) }
+    val spoken = remember(body) { TeleprompterScript.spokenWordCount(body) }
     val durationSecs = remember(body, wpm) { TeleprompterScript.estimateDurationSecs(body, wpm) }
+    // When the script carries cues / headers / speaker labels, spoken < total —
+    // show both so the user knows the duration counts only what's read aloud.
+    val wordsLabel = if (spoken == total) {
+        "$total words"
+    } else {
+        "$spoken spoken / $total total words"
+    }
     Row(
         modifier = modifier,
         horizontalArrangement = Arrangement.spacedBy(LocalSpacing.current.xs),
     ) {
         Text(
-            text = "$words words · ${formatDuration(durationSecs)} at $wpm wpm",
+            text = "$wordsLabel · ${formatDuration(durationSecs)} at $wpm wpm",
             style = MaterialTheme.typography.labelLarge,
             color = MaterialTheme.colorScheme.onSurfaceVariant,
         )

--- a/feature/src/main/kotlin/in/jphe/storyvox/feature/reader/script/ScriptEditScreen.kt
+++ b/feature/src/main/kotlin/in/jphe/storyvox/feature/reader/script/ScriptEditScreen.kt
@@ -1,0 +1,222 @@
+package `in`.jphe.storyvox.feature.reader.script
+
+import android.content.ClipboardManager
+import android.content.Context
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.ExperimentalLayoutApi
+import androidx.compose.foundation.layout.FlowRow
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material.icons.outlined.Check
+import androidx.compose.material.icons.outlined.Close
+import androidx.compose.material.icons.outlined.ContentPaste
+import androidx.compose.material.icons.outlined.MoreVert
+import androidx.compose.material.icons.outlined.PlayArrow
+import androidx.compose.material3.DropdownMenu
+import androidx.compose.material3.DropdownMenuItem
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.InputChip
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.SnackbarHost
+import androidx.compose.material3.SnackbarHostState
+import androidx.compose.material3.Text
+import androidx.compose.material3.TopAppBar
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import `in`.jphe.storyvox.data.db.entity.TeleprompterScript
+import `in`.jphe.storyvox.ui.theme.LocalSpacing
+
+/**
+ * Issue #1369 — the script editor. Title (single line) + body (multi-line,
+ * fills the screen) + tags (comma-separated, with a removable-chip display) +
+ * a live word-count/duration footer at the user's current teleprompter pace.
+ * Save lives in the top bar; "Load into Teleprompter" and "Import from
+ * clipboard" live in the overflow menu.
+ *
+ * @param onOpenTeleprompter navigate to the player after the editor content
+ *   has been queued into the shared [TeleprompterScriptStore].
+ */
+@OptIn(ExperimentalMaterial3Api::class, ExperimentalLayoutApi::class)
+@Composable
+fun ScriptEditScreen(
+    onBack: () -> Unit,
+    onOpenTeleprompter: () -> Unit,
+    modifier: Modifier = Modifier,
+    viewModel: ScriptEditViewModel = hiltViewModel(),
+) {
+    val spacing = LocalSpacing.current
+    val state by viewModel.uiState.collectAsStateWithLifecycle()
+    val wpm by viewModel.wpm.collectAsStateWithLifecycle()
+    val context = LocalContext.current
+
+    val snackbarHostState = remember { SnackbarHostState() }
+    var menuOpen by remember { mutableStateOf(false) }
+
+    LaunchedEffect(Unit) {
+        viewModel.events.collect { event ->
+            when (event) {
+                ScriptEditEvent.Saved -> snackbarHostState.showSnackbar("Saved")
+            }
+        }
+    }
+
+    Scaffold(
+        modifier = modifier.fillMaxSize(),
+        topBar = {
+            TopAppBar(
+                title = { Text(if (state.isNewDraft) "New script" else "Edit script") },
+                navigationIcon = {
+                    IconButton(onClick = onBack) {
+                        Icon(Icons.AutoMirrored.Filled.ArrowBack, contentDescription = "Back")
+                    }
+                },
+                actions = {
+                    IconButton(onClick = viewModel::save, enabled = state.isDirty) {
+                        Icon(Icons.Outlined.Check, contentDescription = "Save")
+                    }
+                    IconButton(onClick = { menuOpen = true }) {
+                        Icon(Icons.Outlined.MoreVert, contentDescription = "More options")
+                    }
+                    DropdownMenu(expanded = menuOpen, onDismissRequest = { menuOpen = false }) {
+                        DropdownMenuItem(
+                            text = { Text("Load into Teleprompter") },
+                            leadingIcon = { Icon(Icons.Outlined.PlayArrow, contentDescription = null) },
+                            onClick = {
+                                menuOpen = false
+                                viewModel.loadIntoTeleprompter()
+                                onOpenTeleprompter()
+                            },
+                        )
+                        DropdownMenuItem(
+                            text = { Text("Import from clipboard") },
+                            leadingIcon = { Icon(Icons.Outlined.ContentPaste, contentDescription = null) },
+                            onClick = {
+                                menuOpen = false
+                                readClipboardText(context)?.let(viewModel::appendToBody)
+                            },
+                        )
+                    }
+                },
+            )
+        },
+        snackbarHost = { SnackbarHost(snackbarHostState) },
+    ) { padding ->
+        Column(
+            modifier = Modifier
+                .fillMaxSize()
+                .padding(padding)
+                .padding(horizontal = spacing.md),
+            verticalArrangement = Arrangement.spacedBy(spacing.xs),
+        ) {
+            OutlinedTextField(
+                value = state.title,
+                onValueChange = viewModel::onTitleChange,
+                modifier = Modifier.fillMaxWidth(),
+                singleLine = true,
+                label = { Text("Title") },
+            )
+
+            OutlinedTextField(
+                value = state.tags,
+                onValueChange = viewModel::onTagsChange,
+                modifier = Modifier.fillMaxWidth(),
+                singleLine = true,
+                label = { Text("Tags (comma-separated)") },
+            )
+
+            val tagList = remember(state.tags) {
+                state.tags.split(',').map { it.trim() }.filter { it.isNotEmpty() }
+            }
+            if (tagList.isNotEmpty()) {
+                FlowRow(
+                    modifier = Modifier.fillMaxWidth(),
+                    horizontalArrangement = Arrangement.spacedBy(spacing.xs),
+                ) {
+                    tagList.forEach { tag ->
+                        InputChip(
+                            selected = false,
+                            onClick = {
+                                // Tap a chip to remove that tag from the field.
+                                viewModel.onTagsChange(
+                                    normalizeTags(tagList.filterNot { it == tag }.joinToString(", ")),
+                                )
+                            },
+                            label = { Text(tag, maxLines = 1, overflow = TextOverflow.Ellipsis) },
+                            trailingIcon = {
+                                Icon(Icons.Outlined.Close, contentDescription = "Remove tag")
+                            },
+                        )
+                    }
+                }
+            }
+
+            OutlinedTextField(
+                value = state.body,
+                onValueChange = viewModel::onBodyChange,
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .weight(1f),
+                label = { Text("Script") },
+                placeholder = { Text("Write or paste your script here…") },
+            )
+
+            ScriptMetricsFooter(
+                body = state.body,
+                wpm = wpm,
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(vertical = spacing.xs),
+            )
+        }
+    }
+}
+
+@Composable
+private fun ScriptMetricsFooter(
+    body: String,
+    wpm: Int,
+    modifier: Modifier = Modifier,
+) {
+    val words = remember(body) { TeleprompterScript.wordCount(body) }
+    val durationSecs = remember(body, wpm) { TeleprompterScript.estimateDurationSecs(body, wpm) }
+    Row(
+        modifier = modifier,
+        horizontalArrangement = Arrangement.spacedBy(LocalSpacing.current.xs),
+    ) {
+        Text(
+            text = "$words words · ${formatDuration(durationSecs)} at $wpm wpm",
+            style = MaterialTheme.typography.labelLarge,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+        )
+    }
+}
+
+/** Read the current clipboard text, or null if empty/unavailable. Mirrors the
+ *  platform-`ClipboardManager` read used elsewhere in the feature module
+ *  (`AddByUrlSheet`, `FirstFictionPicker`) rather than the Compose clipboard
+ *  API, for consistency. */
+private fun readClipboardText(context: Context): String? {
+    val cm = context.getSystemService(Context.CLIPBOARD_SERVICE) as? ClipboardManager
+        ?: return null
+    val clip = cm.primaryClip ?: return null
+    if (clip.itemCount == 0) return null
+    return clip.getItemAt(0)?.text?.toString()?.takeIf { it.isNotBlank() }
+}

--- a/feature/src/main/kotlin/in/jphe/storyvox/feature/reader/script/ScriptListScreen.kt
+++ b/feature/src/main/kotlin/in/jphe/storyvox/feature/reader/script/ScriptListScreen.kt
@@ -1,0 +1,375 @@
+package `in`.jphe.storyvox.feature.reader.script
+
+import android.text.format.DateUtils
+import androidx.compose.foundation.ExperimentalFoundationApi
+import androidx.compose.foundation.combinedClickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material.icons.outlined.Add
+import androidx.compose.material.icons.outlined.Close
+import androidx.compose.material.icons.outlined.ContentCopy
+import androidx.compose.material.icons.outlined.Delete
+import androidx.compose.material.icons.outlined.PlayArrow
+import androidx.compose.material.icons.outlined.Search
+import androidx.compose.material3.CenterAlignedTopAppBar
+import androidx.compose.material3.DropdownMenu
+import androidx.compose.material3.DropdownMenuItem
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.FloatingActionButton
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.SnackbarHost
+import androidx.compose.material3.SnackbarHostState
+import androidx.compose.material3.SnackbarResult
+import androidx.compose.material3.SuggestionChip
+import androidx.compose.material3.Surface
+import androidx.compose.material3.SwipeToDismissBox
+import androidx.compose.material3.SwipeToDismissBoxValue
+import androidx.compose.material3.Text
+import androidx.compose.material3.rememberSwipeToDismissBoxState
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import `in`.jphe.storyvox.data.db.entity.TeleprompterScript
+import `in`.jphe.storyvox.ui.theme.LocalSpacing
+import java.util.UUID
+import kotlinx.coroutines.launch
+
+/**
+ * Issue #1369 — the saved-scripts list. Search bar, a feed of script cards
+ * (title · duration badge · tags · last-edited), swipe-to-delete with undo, a
+ * long-press context menu (Duplicate / Delete / Load into Teleprompter), and a
+ * FAB to author a new one. Tapping a card opens the editor.
+ *
+ * @param onOpenScript open the editor for the given script id. The FAB passes
+ *   a freshly-minted UUID (the editor starts blank; first save inserts it).
+ * @param onOpenTeleprompter navigate to the player after a script has been
+ *   queued into the shared [TeleprompterScriptStore].
+ */
+@OptIn(ExperimentalMaterial3Api::class, ExperimentalFoundationApi::class)
+@Composable
+fun ScriptListScreen(
+    onBack: () -> Unit,
+    onOpenScript: (String) -> Unit,
+    onOpenTeleprompter: () -> Unit,
+    modifier: Modifier = Modifier,
+    viewModel: ScriptManagerViewModel = hiltViewModel(),
+) {
+    val spacing = LocalSpacing.current
+    val query by viewModel.query.collectAsStateWithLifecycle()
+    val scripts by viewModel.scripts.collectAsStateWithLifecycle()
+
+    val snackbarHostState = remember { SnackbarHostState() }
+    val scope = rememberCoroutineScope()
+
+    // Delete + "Undo" snackbar, shared by the swipe gesture and the long-press
+    // context menu so both paths behave identically.
+    val deleteWithUndo: (TeleprompterScript) -> Unit = { script ->
+        viewModel.deleteWithUndo(script)
+        scope.launch {
+            val result = snackbarHostState.showSnackbar(
+                message = "Deleted \"${script.title.ifBlank { "Untitled" }}\"",
+                actionLabel = "Undo",
+                withDismissAction = true,
+            )
+            if (result == SnackbarResult.ActionPerformed) {
+                viewModel.undoDelete()
+            }
+        }
+    }
+
+    Scaffold(
+        modifier = modifier.fillMaxSize(),
+        topBar = {
+            CenterAlignedTopAppBar(
+                title = { Text("Scripts") },
+                navigationIcon = {
+                    IconButton(onClick = onBack) {
+                        Icon(Icons.AutoMirrored.Filled.ArrowBack, contentDescription = "Back")
+                    }
+                },
+            )
+        },
+        floatingActionButton = {
+            FloatingActionButton(onClick = { onOpenScript(UUID.randomUUID().toString()) }) {
+                Icon(Icons.Outlined.Add, contentDescription = "New script")
+            }
+        },
+        snackbarHost = { SnackbarHost(snackbarHostState) },
+    ) { padding ->
+        Column(
+            modifier = Modifier
+                .fillMaxSize()
+                .padding(padding),
+        ) {
+            OutlinedTextField(
+                value = query,
+                onValueChange = viewModel::onQueryChange,
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(horizontal = spacing.md, vertical = spacing.xs),
+                singleLine = true,
+                leadingIcon = { Icon(Icons.Outlined.Search, contentDescription = null) },
+                trailingIcon = {
+                    if (query.isNotEmpty()) {
+                        IconButton(onClick = { viewModel.onQueryChange("") }) {
+                            Icon(Icons.Outlined.Close, contentDescription = "Clear search")
+                        }
+                    }
+                },
+                placeholder = { Text("Search scripts") },
+            )
+
+            if (scripts.isEmpty()) {
+                ScriptsEmptyState(
+                    isSearching = query.isNotBlank(),
+                    query = query,
+                    modifier = Modifier.fillMaxSize(),
+                )
+            } else {
+                LazyColumn(
+                    modifier = Modifier.fillMaxSize(),
+                    contentPadding = PaddingValues(
+                        start = spacing.md,
+                        end = spacing.md,
+                        top = spacing.xs,
+                        // Clear the FAB so the last row isn't trapped beneath it.
+                        bottom = spacing.xxxl,
+                    ),
+                    verticalArrangement = Arrangement.spacedBy(spacing.xs),
+                ) {
+                    items(scripts, key = { it.id }) { script ->
+                        val dismissState = rememberSwipeToDismissBoxState(
+                            confirmValueChange = { value ->
+                                if (value != SwipeToDismissBoxValue.Settled) {
+                                    deleteWithUndo(script)
+                                    true
+                                } else {
+                                    false
+                                }
+                            },
+                        )
+                        SwipeToDismissBox(
+                            state = dismissState,
+                            backgroundContent = { SwipeDeleteBackground() },
+                        ) {
+                            ScriptRow(
+                                script = script,
+                                onOpen = { onOpenScript(script.id) },
+                                onDuplicate = { viewModel.duplicate(script) },
+                                onDelete = { deleteWithUndo(script) },
+                                onLoadIntoTeleprompter = {
+                                    viewModel.loadIntoTeleprompter(script)
+                                    onOpenTeleprompter()
+                                },
+                            )
+                        }
+                    }
+                }
+            }
+        }
+    }
+}
+
+@OptIn(ExperimentalFoundationApi::class, ExperimentalMaterial3Api::class)
+@Composable
+private fun ScriptRow(
+    script: TeleprompterScript,
+    onOpen: () -> Unit,
+    onDuplicate: () -> Unit,
+    onDelete: () -> Unit,
+    onLoadIntoTeleprompter: () -> Unit,
+) {
+    val spacing = LocalSpacing.current
+    var menuOpen by remember { mutableStateOf(false) }
+
+    Surface(
+        color = MaterialTheme.colorScheme.surfaceContainerHigh,
+        shape = MaterialTheme.shapes.large,
+        modifier = Modifier
+            .fillMaxWidth()
+            .combinedClickable(
+                onClick = onOpen,
+                onLongClick = { menuOpen = true },
+            ),
+    ) {
+        Box {
+            Column(modifier = Modifier.padding(spacing.md)) {
+                Text(
+                    text = script.title.ifBlank { "Untitled" },
+                    style = MaterialTheme.typography.titleMedium,
+                    maxLines = 1,
+                    overflow = TextOverflow.Ellipsis,
+                )
+                Row(
+                    modifier = Modifier.padding(top = spacing.xxs),
+                    horizontalArrangement = Arrangement.spacedBy(spacing.xs),
+                    verticalAlignment = Alignment.CenterVertically,
+                ) {
+                    Text(
+                        text = formatDuration(script.estimatedDurationSecs),
+                        style = MaterialTheme.typography.labelMedium,
+                        color = MaterialTheme.colorScheme.primary,
+                    )
+                    Text(
+                        text = "·",
+                        style = MaterialTheme.typography.labelMedium,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    )
+                    Text(
+                        text = "${TeleprompterScript.wordCount(script.body)} words",
+                        style = MaterialTheme.typography.labelMedium,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    )
+                    Text(
+                        text = "·",
+                        style = MaterialTheme.typography.labelMedium,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    )
+                    Text(
+                        text = DateUtils.getRelativeTimeSpanString(
+                            script.updatedAt,
+                            System.currentTimeMillis(),
+                            DateUtils.MINUTE_IN_MILLIS,
+                        ).toString(),
+                        style = MaterialTheme.typography.labelMedium,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                        maxLines = 1,
+                        overflow = TextOverflow.Ellipsis,
+                    )
+                }
+                val tagList = remember(script.tags) {
+                    script.tags.split(',').map { it.trim() }.filter { it.isNotEmpty() }
+                }
+                if (tagList.isNotEmpty()) {
+                    Row(
+                        modifier = Modifier.padding(top = spacing.xs),
+                        horizontalArrangement = Arrangement.spacedBy(spacing.xxs),
+                    ) {
+                        // Cap the inline chip row; the editor shows them all.
+                        tagList.take(4).forEach { tag ->
+                            SuggestionChip(
+                                onClick = onOpen,
+                                label = { Text(tag, style = MaterialTheme.typography.labelSmall) },
+                            )
+                        }
+                    }
+                }
+            }
+
+            DropdownMenu(expanded = menuOpen, onDismissRequest = { menuOpen = false }) {
+                DropdownMenuItem(
+                    text = { Text("Load into Teleprompter") },
+                    leadingIcon = { Icon(Icons.Outlined.PlayArrow, contentDescription = null) },
+                    onClick = {
+                        menuOpen = false
+                        onLoadIntoTeleprompter()
+                    },
+                )
+                DropdownMenuItem(
+                    text = { Text("Duplicate") },
+                    leadingIcon = { Icon(Icons.Outlined.ContentCopy, contentDescription = null) },
+                    onClick = {
+                        menuOpen = false
+                        onDuplicate()
+                    },
+                )
+                DropdownMenuItem(
+                    text = { Text("Delete") },
+                    leadingIcon = { Icon(Icons.Outlined.Delete, contentDescription = null) },
+                    onClick = {
+                        menuOpen = false
+                        onDelete()
+                    },
+                )
+            }
+        }
+    }
+}
+
+@Composable
+private fun SwipeDeleteBackground() {
+    val spacing = LocalSpacing.current
+    Surface(
+        color = MaterialTheme.colorScheme.errorContainer,
+        shape = MaterialTheme.shapes.large,
+        modifier = Modifier.fillMaxSize(),
+    ) {
+        Row(
+            modifier = Modifier
+                .fillMaxSize()
+                .padding(horizontal = spacing.lg),
+            horizontalArrangement = Arrangement.SpaceBetween,
+            verticalAlignment = Alignment.CenterVertically,
+        ) {
+            DeleteGlyph()
+            DeleteGlyph()
+        }
+    }
+}
+
+@Composable
+private fun DeleteGlyph() {
+    Icon(
+        Icons.Outlined.Delete,
+        contentDescription = null,
+        tint = MaterialTheme.colorScheme.onErrorContainer,
+    )
+}
+
+@Composable
+private fun ScriptsEmptyState(
+    isSearching: Boolean,
+    query: String,
+    modifier: Modifier = Modifier,
+) {
+    val spacing = LocalSpacing.current
+    Box(modifier = modifier, contentAlignment = Alignment.Center) {
+        Text(
+            text = if (isSearching) {
+                "No scripts match \"$query\"."
+            } else {
+                "No scripts yet.\nTap + to write one, or generate one with AI."
+            },
+            style = MaterialTheme.typography.bodyLarge,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+            textAlign = TextAlign.Center,
+            modifier = Modifier.padding(spacing.xl),
+        )
+    }
+}
+
+/** Format whole seconds as `M:SS`, or `H:MM:SS` past an hour. */
+internal fun formatDuration(totalSecs: Int): String {
+    val s = totalSecs.coerceAtLeast(0)
+    val hours = s / 3600
+    val minutes = (s % 3600) / 60
+    val seconds = s % 60
+    return if (hours > 0) {
+        "%d:%02d:%02d".format(hours, minutes, seconds)
+    } else {
+        "%d:%02d".format(minutes, seconds)
+    }
+}

--- a/feature/src/main/kotlin/in/jphe/storyvox/feature/reader/script/ScriptListScreen.kt
+++ b/feature/src/main/kotlin/in/jphe/storyvox/feature/reader/script/ScriptListScreen.kt
@@ -204,6 +204,10 @@ private fun ScriptRow(
 ) {
     val spacing = LocalSpacing.current
     var menuOpen by remember { mutableStateOf(false) }
+    // Spoken word count (cues/headers/labels excluded) — matches the
+    // spoken-based duration badge. Remembered so a 2,500-word show script
+    // isn't re-tokenized on every recomposition.
+    val spokenWords = remember(script.body) { TeleprompterScript.spokenWordCount(script.body) }
 
     Surface(
         color = MaterialTheme.colorScheme.surfaceContainerHigh,
@@ -239,7 +243,7 @@ private fun ScriptRow(
                         color = MaterialTheme.colorScheme.onSurfaceVariant,
                     )
                     Text(
-                        text = "${TeleprompterScript.wordCount(script.body)} words",
+                        text = "$spokenWords words",
                         style = MaterialTheme.typography.labelMedium,
                         color = MaterialTheme.colorScheme.onSurfaceVariant,
                     )

--- a/feature/src/main/kotlin/in/jphe/storyvox/feature/reader/script/ScriptManagerViewModel.kt
+++ b/feature/src/main/kotlin/in/jphe/storyvox/feature/reader/script/ScriptManagerViewModel.kt
@@ -6,6 +6,7 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import dagger.hilt.android.lifecycle.HiltViewModel
 import `in`.jphe.storyvox.data.db.dao.TeleprompterScriptDao
+import `in`.jphe.storyvox.data.db.entity.ScriptFormat
 import `in`.jphe.storyvox.data.db.entity.TeleprompterScript
 import `in`.jphe.storyvox.playback.PendingTeleprompterScript
 import `in`.jphe.storyvox.playback.TeleprompterController
@@ -117,6 +118,8 @@ data class ScriptEditUiState(
     val title: String = "",
     val body: String = "",
     val tags: String = "",
+    /** [ScriptFormat] name — Freeform / YouTube Short / Full Show. */
+    val format: String = ScriptFormat.FREEFORM.name,
     /** True until the first save — drives the top-bar title ("New script" vs
      *  "Edit script") and whether Back warns about unsaved changes. */
     val isNewDraft: Boolean = true,
@@ -174,6 +177,7 @@ class ScriptEditViewModel @Inject constructor(
                     title = existing.title,
                     body = existing.body,
                     tags = existing.tags,
+                    format = existing.format,
                     isNewDraft = false,
                     isDirty = false,
                 )
@@ -192,6 +196,10 @@ class ScriptEditViewModel @Inject constructor(
 
     fun onTagsChange(value: String) {
         _uiState.value = _uiState.value.copy(tags = value, isDirty = true)
+    }
+
+    fun onFormatChange(format: ScriptFormat) {
+        _uiState.value = _uiState.value.copy(format = format.name, isDirty = true)
     }
 
     /** Import-from-clipboard: append the pasted [text] to the body (the screen
@@ -218,6 +226,7 @@ class ScriptEditViewModel @Inject constructor(
                     body = state.body,
                     estimatedDurationSecs = TeleprompterScript.estimateDurationSecs(state.body),
                     tags = normalizeTags(state.tags),
+                    format = state.format,
                     createdAt = createdAt,
                     updatedAt = now,
                 ),

--- a/feature/src/main/kotlin/in/jphe/storyvox/feature/reader/script/ScriptManagerViewModel.kt
+++ b/feature/src/main/kotlin/in/jphe/storyvox/feature/reader/script/ScriptManagerViewModel.kt
@@ -1,0 +1,252 @@
+package `in`.jphe.storyvox.feature.reader.script
+
+import androidx.compose.runtime.Immutable
+import androidx.lifecycle.SavedStateHandle
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import dagger.hilt.android.lifecycle.HiltViewModel
+import `in`.jphe.storyvox.data.db.dao.TeleprompterScriptDao
+import `in`.jphe.storyvox.data.db.entity.TeleprompterScript
+import `in`.jphe.storyvox.playback.PendingTeleprompterScript
+import `in`.jphe.storyvox.playback.TeleprompterController
+import `in`.jphe.storyvox.playback.TeleprompterScriptStore
+import java.util.UUID
+import javax.inject.Inject
+import kotlinx.coroutines.channels.Channel
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.SharingStarted
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.flatMapLatest
+import kotlinx.coroutines.flow.receiveAsFlow
+import kotlinx.coroutines.flow.stateIn
+import kotlinx.coroutines.launch
+
+/**
+ * Issue #1369 — ViewModel for the script **list** screen ([ScriptListScreen]).
+ *
+ * Owns the search box state, the observed feed, swipe-to-delete-with-undo,
+ * duplicate, and "Load into Teleprompter" (writes the shared
+ * [TeleprompterScriptStore]; the screen performs the actual navigation).
+ *
+ * The edit screen uses the separate [ScriptEditViewModel] below — it needs a
+ * per-route `scriptId` from [SavedStateHandle], which a list-route VM instance
+ * wouldn't have.
+ */
+@OptIn(kotlinx.coroutines.ExperimentalCoroutinesApi::class)
+@HiltViewModel
+class ScriptManagerViewModel @Inject constructor(
+    private val dao: TeleprompterScriptDao,
+    private val store: TeleprompterScriptStore,
+    private val teleprompter: TeleprompterController,
+) : ViewModel() {
+
+    private val _query = MutableStateFlow("")
+    /** Live search text bound to the list screen's search bar. */
+    val query: StateFlow<String> = _query.asStateFlow()
+
+    /**
+     * The script feed for the current [query]. `search("")` matches every row
+     * (`LIKE '%%'`), so binding the search flow for both the empty and
+     * non-empty query states keeps a single source of truth.
+     */
+    val scripts: StateFlow<List<TeleprompterScript>> =
+        _query
+            .flatMapLatest { q -> dao.search(q.trim()) }
+            .stateIn(viewModelScope, SharingStarted.WhileSubscribed(5_000), emptyList())
+
+    /** The most-recently-deleted script, retained so the undo snackbar can
+     *  restore it. Cleared once a new delete supersedes it. */
+    private var lastDeleted: TeleprompterScript? = null
+
+    fun onQueryChange(value: String) { _query.value = value }
+
+    /**
+     * Delete [script], remembering it so [undoDelete] can put it back. The
+     * screen pairs this with an "Undo" snackbar (#1369 swipe-to-delete).
+     */
+    fun deleteWithUndo(script: TeleprompterScript) {
+        lastDeleted = script
+        viewModelScope.launch { dao.delete(script.id) }
+    }
+
+    /** Restore the last [deleteWithUndo]'d script (re-inserts the same row). */
+    fun undoDelete() {
+        val restore = lastDeleted ?: return
+        lastDeleted = null
+        viewModelScope.launch { dao.upsert(restore) }
+    }
+
+    /** Long-press → Duplicate: a fresh row with a new id, a "(copy)" title,
+     *  and refreshed timestamps; sorts to the top of the feed. */
+    fun duplicate(script: TeleprompterScript) {
+        val now = System.currentTimeMillis()
+        viewModelScope.launch {
+            dao.upsert(
+                script.copy(
+                    id = UUID.randomUUID().toString(),
+                    title = duplicateTitle(script.title),
+                    createdAt = now,
+                    updatedAt = now,
+                ),
+            )
+        }
+    }
+
+    /**
+     * Queue [script] for the teleprompter and flip the transport on (the
+     * screen then navigates to Playing). Mirrors #1366's producer-half: the
+     * reader/#1368 consumer renders the parked script as the scroll content.
+     */
+    fun loadIntoTeleprompter(script: TeleprompterScript) {
+        store.load(
+            PendingTeleprompterScript(id = script.id, title = script.title, body = script.body),
+        )
+        teleprompter.setEnabled(true)
+    }
+}
+
+/** "Talk" → "Talk (copy)"; blank/untitled → "Untitled (copy)". */
+internal fun duplicateTitle(title: String): String =
+    (title.ifBlank { "Untitled" }) + " (copy)"
+
+@Immutable
+data class ScriptEditUiState(
+    val id: String = "",
+    val title: String = "",
+    val body: String = "",
+    val tags: String = "",
+    /** True until the first save — drives the top-bar title ("New script" vs
+     *  "Edit script") and whether Back warns about unsaved changes. */
+    val isNewDraft: Boolean = true,
+    /** True once the current in-memory content differs from what's persisted
+     *  (or, for a new draft, once anything has been typed). Gates the Save
+     *  button's enabled state. */
+    val isDirty: Boolean = false,
+)
+
+/** One-shot events from the editor to its screen. */
+sealed interface ScriptEditEvent {
+    /** A save completed — the screen shows a confirmation snackbar. */
+    data object Saved : ScriptEditEvent
+}
+
+/**
+ * Issue #1369 — ViewModel for the script **edit** screen ([ScriptEditScreen]).
+ *
+ * Loads the script named by the `scriptId` route arg (or starts a blank draft
+ * with that id when the row doesn't exist yet — the list FAB navigates with a
+ * freshly-minted UUID, so the first [save] inserts it). Exposes the live word
+ * count + duration (computed in the composable from the pure
+ * [TeleprompterScript] helpers and the current [wpm]), clipboard import, save,
+ * and "Load into Teleprompter".
+ */
+@HiltViewModel
+class ScriptEditViewModel @Inject constructor(
+    private val dao: TeleprompterScriptDao,
+    private val store: TeleprompterScriptStore,
+    private val teleprompterController: TeleprompterController,
+    savedStateHandle: SavedStateHandle,
+) : ViewModel() {
+
+    private val scriptId: String = checkNotNull(savedStateHandle["scriptId"]) {
+        "ScriptEditViewModel requires a scriptId route arg"
+    }
+
+    private val _uiState = MutableStateFlow(ScriptEditUiState(id = scriptId))
+    val uiState: StateFlow<ScriptEditUiState> = _uiState.asStateFlow()
+
+    /** The live teleprompter pace, so the editor's duration figure tracks the
+     *  speed the user will actually read at (distinct from the row badge's
+     *  fixed [TeleprompterScript.WPM_BASELINE]). */
+    val wpm: StateFlow<Int> = teleprompterController.wpm
+
+    private val _events = Channel<ScriptEditEvent>(Channel.BUFFERED)
+    val events: Flow<ScriptEditEvent> = _events.receiveAsFlow()
+
+    init {
+        viewModelScope.launch {
+            val existing = dao.get(scriptId)
+            if (existing != null) {
+                _uiState.value = ScriptEditUiState(
+                    id = existing.id,
+                    title = existing.title,
+                    body = existing.body,
+                    tags = existing.tags,
+                    isNewDraft = false,
+                    isDirty = false,
+                )
+            }
+            // No row → keep the blank new-draft state seeded above.
+        }
+    }
+
+    fun onTitleChange(value: String) {
+        _uiState.value = _uiState.value.copy(title = value, isDirty = true)
+    }
+
+    fun onBodyChange(value: String) {
+        _uiState.value = _uiState.value.copy(body = value, isDirty = true)
+    }
+
+    fun onTagsChange(value: String) {
+        _uiState.value = _uiState.value.copy(tags = value, isDirty = true)
+    }
+
+    /** Import-from-clipboard: append the pasted [text] to the body (the screen
+     *  reads the clipboard; the VM stays Android-free). No-op on blank text. */
+    fun appendToBody(text: String) {
+        if (text.isBlank()) return
+        val current = _uiState.value.body
+        val joined = if (current.isEmpty()) text else "$current\n$text"
+        onBodyChange(joined)
+    }
+
+    /** Persist the current content. Recomputes the stored duration estimate at
+     *  the canonical baseline. Emits [ScriptEditEvent.Saved] when done. */
+    fun save() {
+        val state = _uiState.value
+        val now = System.currentTimeMillis()
+        viewModelScope.launch {
+            val existing = dao.get(state.id)
+            val createdAt = existing?.createdAt ?: now
+            dao.upsert(
+                TeleprompterScript(
+                    id = state.id,
+                    title = state.title.trim(),
+                    body = state.body,
+                    estimatedDurationSecs = TeleprompterScript.estimateDurationSecs(state.body),
+                    tags = normalizeTags(state.tags),
+                    createdAt = createdAt,
+                    updatedAt = now,
+                ),
+            )
+            _uiState.value = state.copy(isNewDraft = false, isDirty = false)
+            _events.send(ScriptEditEvent.Saved)
+        }
+    }
+
+    /** Queue the current (possibly unsaved) editor content for the
+     *  teleprompter and flip the transport on. The screen navigates to Playing
+     *  afterward; the reader/#1368 consumer renders the parked script. */
+    fun loadIntoTeleprompter() {
+        val state = _uiState.value
+        store.load(
+            PendingTeleprompterScript(id = state.id, title = state.title, body = state.body),
+        )
+        teleprompterController.setEnabled(true)
+    }
+}
+
+/**
+ * Normalize a comma-separated tag string: trim each tag, drop blanks and
+ * case-insensitive duplicates, re-join with ", ". Keeps stored tags tidy so
+ * the chip display and the `tags LIKE` search behave predictably.
+ */
+internal fun normalizeTags(raw: String): String =
+    raw.split(',')
+        .map { it.trim() }
+        .filter { it.isNotEmpty() }
+        .distinctBy { it.lowercase() }
+        .joinToString(", ")

--- a/feature/src/main/kotlin/in/jphe/storyvox/feature/settings/SettingsHubScreen.kt
+++ b/feature/src/main/kotlin/in/jphe/storyvox/feature/settings/SettingsHubScreen.kt
@@ -23,6 +23,7 @@ import androidx.compose.material.icons.outlined.ChevronRight
 import androidx.compose.material.icons.outlined.Cloud
 import androidx.compose.material.icons.outlined.Extension
 import androidx.compose.material.icons.outlined.Info
+import androidx.compose.material.icons.outlined.Description
 import androidx.compose.material.icons.outlined.Insights
 import androidx.compose.material.icons.outlined.RecordVoiceOver
 import androidx.compose.material.icons.outlined.Search
@@ -157,6 +158,12 @@ fun SettingsHubScreen(
      * lives in [`in.jphe.storyvox.navigation.StoryvoxNavHost`].
      */
     onOpenStats: () -> Unit = {},
+    /**
+     * Issue #1369 — teleprompter script manager. Default no-op so existing
+     * callers / smoke tests compile without wiring it; production wiring lives
+     * in [`in.jphe.storyvox.navigation.StoryvoxNavHost`].
+     */
+    onOpenScripts: () -> Unit = {},
 ) {
     val spacing = LocalSpacing.current
     var query by remember { mutableStateOf("") }
@@ -246,6 +253,14 @@ fun SettingsHubScreen(
                     title = stringResource(R.string.settings_hub_stats_title),
                     subtitle = stringResource(R.string.settings_hub_stats_subtitle),
                     onClick = onOpenStats,
+                )
+                // Issue #1369 — teleprompter script manager. Reading-adjacent:
+                // save/edit/organize scripts the teleprompter can load.
+                SettingsHubRow(
+                    icon = Icons.Outlined.Description,
+                    title = stringResource(R.string.settings_hub_scripts_title),
+                    subtitle = stringResource(R.string.settings_hub_scripts_subtitle),
+                    onClick = onOpenScripts,
                 )
                 // v0.5.59 (#cover-style-toggle) — Appearance. Book-
                 // cover fallback style (Monogram / Branded / Cover

--- a/feature/src/main/res/values/strings.xml
+++ b/feature/src/main/res/values/strings.xml
@@ -652,6 +652,9 @@
     <!-- Issue #1235 — Listening stats hub row -->
     <string name="settings_hub_stats_title">Listening stats</string>
     <string name="settings_hub_stats_subtitle">Time listened, streaks, books finished.</string>
+    <!-- Issue #1369 — teleprompter script manager hub row -->
+    <string name="settings_hub_scripts_title">Scripts</string>
+    <string name="settings_hub_scripts_subtitle">Save, edit, and organize teleprompter scripts.</string>
     <string name="settings_hub_all_settings_title">All settings</string>
     <string name="settings_hub_all_settings_subtitle">Every setting on one long page (legacy).</string>
 

--- a/feature/src/test/kotlin/in/jphe/storyvox/feature/reader/script/ScriptManagerLogicTest.kt
+++ b/feature/src/test/kotlin/in/jphe/storyvox/feature/reader/script/ScriptManagerLogicTest.kt
@@ -1,0 +1,32 @@
+package `in`.jphe.storyvox.feature.reader.script
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+/**
+ * Issue #1369 — pure unit coverage for the script-manager helper functions
+ * (tag normalization, duplicate naming, duration formatting). No Android
+ * dependency; runs on the JVM.
+ */
+class ScriptManagerLogicTest {
+
+    @Test fun `normalizeTags trims, drops blanks, and dedupes case-insensitively`() {
+        assertEquals("talk, demo", normalizeTags("  talk , , demo , Talk "))
+        assertEquals("", normalizeTags("   ,  , "))
+        assertEquals("a, b, c", normalizeTags("a,b,c"))
+    }
+
+    @Test fun `duplicateTitle appends copy and falls back for blank titles`() {
+        assertEquals("Talk (copy)", duplicateTitle("Talk"))
+        assertEquals("Untitled (copy)", duplicateTitle(""))
+        assertEquals("Untitled (copy)", duplicateTitle("   "))
+    }
+
+    @Test fun `formatDuration renders M_SS and H_MM_SS`() {
+        assertEquals("0:00", formatDuration(0))
+        assertEquals("0:45", formatDuration(45))
+        assertEquals("3:20", formatDuration(200))
+        assertEquals("1:00:00", formatDuration(3600))
+        assertEquals("1:01:05", formatDuration(3665))
+    }
+}


### PR DESCRIPTION
Closes #1369.

A local-first manager for user-authored teleprompter scripts — talks, narration drafts, lines to rehearse — that have no backing Fiction/Chapter. Save, edit, search, tag, duplicate, delete, and load any of them into the teleprompter.

## What's in it

**Data (`core-data`)**
- `TeleprompterScript` `@Entity` — UUID PK, `title`/`body`/`tags` (comma-separated), and a stored `estimatedDurationSecs` snapshot at a canonical 150-wpm baseline. Word-count + duration helpers live on the companion (pure, unit-tested).
- `TeleprompterScriptDao` — `upsert` / `observeAll` / `get` / `delete` / `search` (title-or-tags `LIKE`).
- DB **v17 → v18**: entity + DAO registered in `StoryvoxDatabase`, `MIGRATION_17_18` (purely additive `CREATE TABLE`, no FK — scripts are independent of fiction/chapter), and a `@Provides` in `DataModule` (per project convention, a new DAO needs the app-graph binding or `:app:assembleRelease` fails Hilt resolution).

**UI (`feature`, package `reader/script/`)**
- `ScriptListScreen` — search bar, feed of cards (title · duration · word count · last-edited · tag chips), swipe-to-delete with **undo** snackbar, long-press context menu (Duplicate / Delete / Load into Teleprompter), FAB, and the empty state ("No scripts yet. Tap + to write one, or generate one with AI.").
- `ScriptEditScreen` — title (single-line), body (multi-line, fills the screen), tags field with removable chips, a live **word count + duration at the current teleprompter WPM** footer, Save in the top bar, and an overflow menu (Load into Teleprompter / Import from clipboard).
- `ScriptManagerViewModel` (list) + `ScriptEditViewModel` (edit — reads the `scriptId` route arg, blank draft when the row doesn't exist yet so the first Save inserts it).

**Navigation**
- `SCRIPT_LIST = "scripts"` + `SCRIPT_EDIT = "scripts/{scriptId}"` in `StoryvoxRoutes`, wired in `StoryvoxNavHost`. Reachable from the **Settings hub** ("Scripts" row).

## Teleprompter hand-off (coordination — please read)

The teleprompter is a mode inside the reader that scrolls the *current chapter body*; there's no free-text path. So "Load into Teleprompter" needs a shared seam. This is the **same seam #1366 (AI script writer) needs**.

- Here, `loadIntoTeleprompter` parks the script in a `@Singleton TeleprompterScriptStore` (`core-playback`, next to `TeleprompterController`) and flips the transport on — mirroring #1366's producer-half.
- **#1366 independently added a parallel `ScriptDraftStore` in `:feature`.** No compile conflict (distinct names/files; verified the shared package compiles with both branches), but the two stores should be **unified to one** in a follow-up, and **#1368 (Echo) is the consumer** that renders the parked script as scroll content (its own kdoc defers that for #1366 too). I've flagged this to the orchestrator and am happy to own the unification once #1366 + #1369 are both merged.

## Deliberately deferred

- **`schemas/…/18.json` + a v17/v18 migration test.** Room regenerates the schema during the build with `exportSchema=true`, so this does **not** block `Build APK`. The committed schema is only consumed by `runMigrationsAndValidate` (a unit test CI compiles but doesn't run). I can't generate a valid `18.json` (its `identityHash` is computed by Room) without a local build, which project policy disallows (compile on CI only). This matches the current repo state — `17.json` is also absent and main is green. Backfill alongside the schema/test once a real build is available.
- **Teleprompter transport-bar "Scripts" icon.** `ReaderView` is being actively reworked by the teleprompter agents (#1366/#1367/#1368). Adding a one-icon affordance there now is a high-conflict edit, and the feature is already reachable via Settings. Best added once the teleprompter UI settles; flagged to the orchestrator.

## Testing
- `TeleprompterScriptTest` (core-data) — word count, duration estimate (ceil so a one-word script is never 0:00, exact at the baseline, custom WPM, div-by-zero clamp).
- `ScriptManagerLogicTest` (feature) — tag normalize (trim/dedupe case-insensitive), duplicate-title naming, `M:SS`/`H:MM:SS` duration formatting.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
