### PR TITLE
feat(reader): voice-paced teleprompter — mic-driven scroll (#1368)

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -40,6 +40,17 @@
         android:name="android.hardware.camera.autofocus"
         android:required="false" />
 
+    <!-- Issue #1368 — voice-paced teleprompter. RECORD_AUDIO is requested at
+         runtime when the reader picks the Voice follow mode, with a rationale
+         before the system prompt; a denied mic falls back to the manual-WPM
+         teleprompter (no dead-end). The microphone feature is OPTIONAL so a
+         device without a mic still installs and uses the other follow modes —
+         same required="false" posture as the camera above. -->
+    <uses-permission android:name="android.permission.RECORD_AUDIO" />
+    <uses-feature
+        android:name="android.hardware.microphone"
+        android:required="false" />
+
     <!-- Issue #546 / #775 — telephony is OPTIONAL. The TechEmpower
          "Call 211" card (and the matching top-app-bar phone icon)
          dials only on devices with telephony hardware (phones, not

--- a/core-playback/src/main/kotlin/in/jphe/storyvox/playback/di/PlaybackModule.kt
+++ b/core-playback/src/main/kotlin/in/jphe/storyvox/playback/di/PlaybackModule.kt
@@ -14,6 +14,8 @@ import `in`.jphe.storyvox.playback.TtsVolumeRamp
 import `in`.jphe.storyvox.playback.VolumeRamp
 import `in`.jphe.storyvox.playback.cache.PcmRenderScheduler
 import `in`.jphe.storyvox.playback.cache.WorkManagerPcmRenderScheduler
+import `in`.jphe.storyvox.playback.transcribe.MicCaptureProcessor
+import `in`.jphe.storyvox.playback.transcribe.RecognizedWordSource
 import javax.inject.Singleton
 
 @Module
@@ -39,6 +41,18 @@ abstract class PlaybackModule {
     abstract fun bindPcmRenderScheduler(
         impl: WorkManagerPcmRenderScheduler,
     ): PcmRenderScheduler
+
+    /**
+     * Issue #1368 — the live mic→ASR word source for the voice-paced
+     * teleprompter. Replaces the [RecognizedWordSource.NoOp] seam default with
+     * the real [MicCaptureProcessor]; it self-gates on RECORD_AUDIO + the
+     * downloaded model, so binding it is safe even before either is present.
+     */
+    @Binds
+    @Singleton
+    abstract fun bindRecognizedWordSource(
+        impl: MicCaptureProcessor,
+    ): RecognizedWordSource
 
     companion object {
         @Provides

--- a/core-playback/src/main/kotlin/in/jphe/storyvox/playback/transcribe/AsrAudio.kt
+++ b/core-playback/src/main/kotlin/in/jphe/storyvox/playback/transcribe/AsrAudio.kt
@@ -1,0 +1,73 @@
+package `in`.jphe.storyvox.playback.transcribe
+
+import kotlin.math.exp
+import kotlin.math.sqrt
+
+/**
+ * Issue #1368 — pure, allocation-light helpers for the live mic→ASR path
+ * ([MicCaptureProcessor]). Kept Android-free (operate on `ShortArray` /
+ * `FloatArray`, not `AudioRecord`) so the signal math and the
+ * confidence mapping are unit-testable without a device — the one place
+ * worth locking down before the device-validated recognizer wiring.
+ */
+object AsrAudio {
+
+    /** Full-scale magnitude of signed 16-bit PCM. */
+    private const val INT16_FULL_SCALE: Float = 32_768f
+
+    /**
+     * Normalized RMS loudness of the first [length] samples of signed-16-bit
+     * [pcm], in `[0, 1]` (1.0 ≈ full scale). Feeds [SilenceGate]. Returns 0
+     * for an empty/zero-length frame.
+     */
+    fun rms(pcm: ShortArray, length: Int): Float {
+        val n = length.coerceAtMost(pcm.size)
+        if (n <= 0) return 0f
+        var sumSq = 0.0
+        for (i in 0 until n) {
+            val s = pcm[i] / INT16_FULL_SCALE
+            sumSq += (s * s).toDouble()
+        }
+        return sqrt(sumSq / n).toFloat()
+    }
+
+    /**
+     * Convert the first [length] samples of signed-16-bit [pcm] to float in
+     * `[-1, 1)` — the format sherpa-onnx's `OnlineStream.acceptWaveform`
+     * expects. Allocates one [FloatArray] of size [length].
+     */
+    fun toFloatPcm(pcm: ShortArray, length: Int): FloatArray {
+        val n = length.coerceAtMost(pcm.size).coerceAtLeast(0)
+        val out = FloatArray(n)
+        for (i in 0 until n) out[i] = pcm[i] / INT16_FULL_SCALE
+        return out
+    }
+}
+
+/**
+ * Issue #1368 — collapse a recognizer result's per-token vocab log-probs
+ * (sherpa-onnx `OnlineRecognizerResult.ysProbs`) into a single utterance
+ * confidence in `[0, 1]`, which [ForcedAligner.onWord] uses to *hold* the
+ * scroll on low-confidence speech (coughs / "umm"s / off-script asides —
+ * Lucid's #1291 finding #4).
+ *
+ * `ysProbs` are natural-log probabilities (≤ 0); the geometric mean of the
+ * per-token probabilities — `exp(mean(logProbs))` — is the standard
+ * sequence-confidence summary and is robust to utterance length. An empty
+ * array means the recognizer reported no probabilities, so we return `1f`
+ * (don't gate) — matching [RecognizedWord]'s "confidence unavailable"
+ * default.
+ *
+ * NOTE (device-validation, #1368): the exact `ysProbs` scale should be
+ * confirmed on-device. If they ever arrive as already-linear probabilities
+ * rather than log-probs this mapping over-gates, in which case the
+ * [MicCaptureProcessor] should emit `1f` and lean entirely on the aligner's
+ * fuzzy matcher. Over-gating only freezes the scroll (graceful), never crashes.
+ */
+fun asrConfidence(ysProbs: FloatArray): Float {
+    if (ysProbs.isEmpty()) return 1f
+    var sum = 0f
+    for (p in ysProbs) sum += p
+    val mean = sum / ysProbs.size
+    return exp(mean).coerceIn(0f, 1f)
+}

--- a/core-playback/src/main/kotlin/in/jphe/storyvox/playback/transcribe/AsrModelProvider.kt
+++ b/core-playback/src/main/kotlin/in/jphe/storyvox/playback/transcribe/AsrModelProvider.kt
@@ -1,0 +1,195 @@
+package `in`.jphe.storyvox.playback.transcribe
+
+import android.content.Context
+import androidx.annotation.VisibleForTesting
+import dagger.hilt.android.qualifiers.ApplicationContext
+import java.io.File
+import javax.inject.Inject
+import javax.inject.Singleton
+import kotlin.coroutines.cancellation.CancellationException
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.flow
+import kotlinx.coroutines.flow.flowOn
+import okhttp3.OkHttpClient
+import okhttp3.Request
+
+/**
+ * Issue #1368 — owns the on-device streaming-ASR model that backs the
+ * voice-paced teleprompter ([MicCaptureProcessor]). The model is **not**
+ * bundled (it would bloat the APK and most users never enable voice-follow),
+ * so it's downloaded on first use into `filesDir/asr/<MODEL_ID>/`, mirroring
+ * how [`in`.jphe.storyvox.playback.voice.VoiceManager] streams TTS voices.
+ *
+ * Resolution is filesystem-only: [readyModel] hands [MicCaptureProcessor]
+ * absolute file paths, and the sherpa-onnx `OnlineRecognizer` loads them
+ * directly (no `AssetManager`). [isReady] is the single gate the reader
+ * checks before offering voice-follow; when false it offers [download], and
+ * when a download fails the whole feature degrades to the manual-WPM
+ * teleprompter rather than erroring.
+ *
+ * ### Model choice (device-validation, #1368)
+ * Defaults to the compact **streaming-zipformer-en-20M** (~20 MB int8) — the
+ * smallest English streaming transducer sherpa ships, chosen so first-use
+ * download and per-frame inference stay light on a phone. The exact asset
+ * filenames + host below are the upstream csukuangfj HuggingFace layout and
+ * should be confirmed on-device (latency, accuracy, and whether to repackage
+ * onto the project's own release for flat URLs, as the Kitten TTS model was).
+ * A wrong URL surfaces as [DownloadProgress.Failed] → graceful fallback, never
+ * a crash.
+ */
+@Singleton
+class AsrModelProvider @Inject constructor(
+    @ApplicationContext private val context: Context,
+) {
+    /** Overridable in tests; real network by default (mirrors VoiceManager). */
+    @VisibleForTesting
+    internal var http: OkHttpClient = OkHttpClient.Builder().build()
+
+    private val modelDir: File get() = File(context.filesDir, "asr/$MODEL_ID")
+
+    /** True once every model file is present and non-empty. */
+    fun isReady(): Boolean = SPEC.all { f ->
+        val local = File(modelDir, f.localName)
+        local.exists() && local.length() > 0L
+    }
+
+    /**
+     * The resolved model's absolute paths, or `null` if not fully downloaded.
+     * [MicCaptureProcessor] feeds these straight into the recognizer config.
+     */
+    fun readyModel(): AsrModel? {
+        if (!isReady()) return null
+        fun path(name: String) = File(modelDir, name).absolutePath
+        return AsrModel(
+            encoder = path(ENCODER),
+            decoder = path(DECODER),
+            joiner = path(JOINER),
+            tokens = path(TOKENS),
+        )
+    }
+
+    /**
+     * Stream a download of the model. Emits [DownloadProgress.Resolving],
+     * then [Downloading] frames as bytes land across all files, then a single
+     * terminal [Done] or [Failed]. Each file streams to a `.part` sibling and
+     * is renamed on completion, so an interrupted download never leaves a
+     * truncated file that [isReady] would mistake for installed. Idempotent:
+     * files already present are skipped.
+     */
+    fun download(): Flow<DownloadProgress> = flow {
+        emit(DownloadProgress.Resolving)
+        if (isReady()) {
+            emit(DownloadProgress.Done)
+            return@flow
+        }
+        modelDir.mkdirs()
+        val totalBytes = SPEC.sumOf { it.approxBytes }
+        var doneBytes = 0L
+        try {
+            for (f in SPEC) {
+                val target = File(modelDir, f.localName)
+                if (target.exists() && target.length() > 0L) {
+                    doneBytes += f.approxBytes
+                    emit(DownloadProgress.Downloading(doneBytes, totalBytes))
+                    continue
+                }
+                val base = doneBytes
+                downloadFile(f.url, target) { readThisFile ->
+                    emit(DownloadProgress.Downloading(base + readThisFile, totalBytes))
+                }
+                doneBytes += f.approxBytes
+            }
+            emit(DownloadProgress.Done)
+        } catch (ce: CancellationException) {
+            // User-driven cancel — honour structured concurrency. Completed
+            // files survive (no wipe), so a retry resumes file-by-file.
+            throw ce
+        } catch (t: Throwable) {
+            emit(DownloadProgress.Failed(t.message ?: t.javaClass.simpleName))
+        }
+    }.flowOn(Dispatchers.IO) // blocking HTTP + file IO must stay off the collector's thread (#585)
+
+    /** Stream [url] to a `.part` file then atomically rename to [target]. */
+    private suspend fun downloadFile(
+        url: String,
+        target: File,
+        onBytes: suspend (readSoFar: Long) -> Unit,
+    ) {
+        val part = File(target.parentFile, target.name + ".part")
+        val response = http.newCall(Request.Builder().url(url).build()).execute()
+        response.use { resp ->
+            if (!resp.isSuccessful) error("HTTP ${resp.code} for $url")
+            val body = resp.body ?: error("Empty body for $url")
+            body.byteStream().use { input ->
+                part.outputStream().use { output ->
+                    val buf = ByteArray(64 * 1024)
+                    var read = 0L
+                    while (true) {
+                        val n = input.read(buf)
+                        if (n < 0) break
+                        output.write(buf, 0, n)
+                        read += n
+                        onBytes(read)
+                    }
+                }
+            }
+        }
+        if (!part.renameTo(target)) {
+            part.copyTo(target, overwrite = true)
+            part.delete()
+        }
+    }
+
+    /** One model asset: where to fetch it, what to call it locally, rough size. */
+    private data class Asset(val url: String, val localName: String, val approxBytes: Long)
+
+    /** Progress frames for a model [download] — mirrors VoiceManager's shape. */
+    sealed interface DownloadProgress {
+        data object Resolving : DownloadProgress
+        data class Downloading(val bytesRead: Long, val totalBytes: Long) : DownloadProgress
+        data object Done : DownloadProgress
+        data class Failed(val reason: String) : DownloadProgress
+    }
+
+    companion object {
+        /** Bumped if the model is swapped — isolates the on-disk cache dir. */
+        const val MODEL_ID: String = "streaming-zipformer-en-20m-2023-02-17"
+
+        private const val ENCODER = "encoder.onnx"
+        private const val DECODER = "decoder.onnx"
+        private const val JOINER = "joiner.onnx"
+        private const val TOKENS = "tokens.txt"
+
+        /** Approximate total download, surfaced in the UI before resolving. */
+        const val APPROX_TOTAL_MB: Int = 22
+
+        /**
+         * Upstream csukuangfj HuggingFace layout for the 20M int8 streaming
+         * zipformer. `resolve/main` gives flat per-file URLs the OkHttp loop
+         * can stream (no in-app tar extraction). See the class kdoc — confirm
+         * on-device before release.
+         */
+        private const val HOST =
+            "https://huggingface.co/csukuangfj/sherpa-onnx-streaming-zipformer-en-20M-2023-02-17/resolve/main"
+
+        private val SPEC: List<Asset> = listOf(
+            Asset("$HOST/encoder-epoch-99-avg-1.int8.onnx", ENCODER, 12_000_000L),
+            Asset("$HOST/decoder-epoch-99-avg-1.onnx", DECODER, 2_000_000L),
+            Asset("$HOST/joiner-epoch-99-avg-1.int8.onnx", JOINER, 8_000_000L),
+            Asset("$HOST/tokens.txt", TOKENS, 5_000L),
+        )
+    }
+}
+
+/**
+ * Absolute filesystem paths to a downloaded streaming-ASR model — the four
+ * files sherpa-onnx's transducer recognizer needs. Produced by
+ * [AsrModelProvider.readyModel], consumed by [MicCaptureProcessor].
+ */
+data class AsrModel(
+    val encoder: String,
+    val decoder: String,
+    val joiner: String,
+    val tokens: String,
+)

--- a/core-playback/src/main/kotlin/in/jphe/storyvox/playback/transcribe/AsrWordExtractor.kt
+++ b/core-playback/src/main/kotlin/in/jphe/storyvox/playback/transcribe/AsrWordExtractor.kt
@@ -1,0 +1,73 @@
+package `in`.jphe.storyvox.playback.transcribe
+
+/**
+ * Issue #1368 — pulls newly-**stable** words out of a streaming recognizer's
+ * growing hypothesis so the [ForcedAligner] is fed one settled token at a
+ * time, in spoken order.
+ *
+ * sherpa-onnx's [`com.k2fsa.sherpa.onnx.OnlineRecognizer`] accumulates text
+ * across an utterance: each `getResult` call returns the whole best
+ * hypothesis *so far* (e.g. `"the"`, then `"the quick"`, then
+ * `"the quick brown"`), and the tail token can still be revised by the next
+ * decode. After the recognizer endpoints we `reset` the stream and the text
+ * starts over. This class turns that growing string into a stream of new
+ * words:
+ *
+ * - [newWords] returns words that have appeared since the last call, **except
+ *   the final token** — which is held back because the recognizer may still
+ *   revise it on the next frame. Feeding the aligner a half-heard last word
+ *   and then its correction would be two tokens for one spoken word.
+ * - [flush] is called when the recognizer endpoints (utterance finalized):
+ *   the held-back tail is now settled, so emit it and reset for the next
+ *   utterance.
+ *
+ * Pure and deterministic — no Android, no recognizer types — so the
+ * stable-word policy is unit-testable by feeding hypothesis strings. The
+ * [MicCaptureProcessor] owns the recognizer and calls these with
+ * `result.text`.
+ */
+class AsrWordExtractor {
+
+    /** Count of words already returned from the current utterance. */
+    private var emitted = 0
+
+    /**
+     * New stable words in the growing hypothesis [hypothesisText] since the
+     * last call. Holds back the final (still-mutable) token; [flush] releases
+     * it when the utterance ends. Returns an empty list when nothing new has
+     * stabilized.
+     */
+    fun newWords(hypothesisText: String): List<String> {
+        val words = splitWords(hypothesisText)
+        // All but the last word are considered stable; the last may still be
+        // revised by the recognizer on the next decode.
+        val stableCount = (words.size - 1).coerceAtLeast(0)
+        if (stableCount <= emitted) return emptyList()
+        val fresh = words.subList(emitted, stableCount).toList()
+        emitted = stableCount
+        return fresh
+    }
+
+    /**
+     * The recognizer endpointed [hypothesisText]: the whole utterance is now
+     * final, so emit any words still held back (including the previously
+     * unstable tail) and reset for the next utterance.
+     */
+    fun flush(hypothesisText: String): List<String> {
+        val words = splitWords(hypothesisText)
+        val tail = if (emitted < words.size) words.subList(emitted, words.size).toList() else emptyList()
+        emitted = 0
+        return tail
+    }
+
+    /** Drop any in-flight state (e.g. capture stopped). */
+    fun reset() {
+        emitted = 0
+    }
+
+    private companion object {
+        private val WHITESPACE = Regex("\\s+")
+        fun splitWords(text: String): List<String> =
+            text.trim().split(WHITESPACE).filter { it.isNotEmpty() }
+    }
+}

--- a/core-playback/src/main/kotlin/in/jphe/storyvox/playback/transcribe/MicCaptureProcessor.kt
+++ b/core-playback/src/main/kotlin/in/jphe/storyvox/playback/transcribe/MicCaptureProcessor.kt
@@ -1,0 +1,231 @@
+package `in`.jphe.storyvox.playback.transcribe
+
+import android.Manifest
+import android.annotation.SuppressLint
+import android.content.Context
+import android.content.pm.PackageManager
+import android.media.AudioFormat
+import android.media.AudioRecord
+import android.media.MediaRecorder
+import android.os.SystemClock
+import android.util.Log
+import androidx.core.content.ContextCompat
+import com.k2fsa.sherpa.onnx.EndpointConfig
+import com.k2fsa.sherpa.onnx.EndpointRule
+import com.k2fsa.sherpa.onnx.FeatureConfig
+import com.k2fsa.sherpa.onnx.OnlineModelConfig
+import com.k2fsa.sherpa.onnx.OnlineRecognizer
+import com.k2fsa.sherpa.onnx.OnlineRecognizerConfig
+import com.k2fsa.sherpa.onnx.OnlineTransducerModelConfig
+import dagger.hilt.android.qualifiers.ApplicationContext
+import javax.inject.Inject
+import javax.inject.Singleton
+import kotlin.coroutines.cancellation.CancellationException
+import kotlin.coroutines.coroutineContext
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.flow.asSharedFlow
+import kotlinx.coroutines.isActive
+import kotlinx.coroutines.launch
+
+/**
+ * Issue #1368 — the **live** [RecognizedWordSource] for the voice-paced
+ * teleprompter (the Phase-2 implementation the seam's kdoc anticipated). It
+ * captures the microphone, runs sherpa-onnx streaming ASR, and emits the
+ * recognized words (with confidence) that [VoicePacedScrollController] feeds
+ * into [ForcedAligner] to drive the scroll.
+ *
+ * ### Pipeline
+ * ```
+ * AudioRecord (16 kHz mono PCM16, VOICE_RECOGNITION)
+ *   → SilenceGate (skip decoding on a long pause — ~75% CPU saved, #1291)
+ *   → OnlineStream.acceptWaveform → OnlineRecognizer.decode/getResult
+ *   → AsrWordExtractor (growing hypothesis → newly-stable words)
+ *   → words: Flow<RecognizedWord>   (confidence = asrConfidence(ysProbs))
+ * ```
+ *
+ * The Android-specific surface is deliberately thin: capture + the recognizer
+ * JNI calls live here, but every decision (which frames to feed, which words
+ * are stable, how to score confidence) is delegated to the pure, unit-tested
+ * helpers [SilenceGate] / [AsrWordExtractor] / [AsrAudio] / [asrConfidence].
+ *
+ * ### Graceful degradation
+ * [start] is a no-op (emits nothing) when `RECORD_AUDIO` isn't granted or the
+ * model isn't downloaded, so the reader simply falls back to the manual-WPM
+ * teleprompter — no crash, no error surfaced. Capture runs on
+ * [Dispatchers.IO]; [stop] cancels it and releases the recognizer + model
+ * (tens of MB resident), [destroy] tears down the whole scope.
+ *
+ * ### Device-validation (#1368)
+ * The recognizer config + model are wired against the verified sherpa-onnx
+ * 1.13.3 API but their *behaviour* (latency, endpoint tuning, `ysProbs`
+ * scale) must be validated on a device — consistent with how the #1291 author
+ * deliberately deferred this live piece. The pure logic above is fully tested;
+ * this class is the device-gated wiring.
+ */
+@Singleton
+class MicCaptureProcessor @Inject constructor(
+    @ApplicationContext private val context: Context,
+    private val modelProvider: AsrModelProvider,
+) : RecognizedWordSource {
+
+    private val _words = MutableSharedFlow<RecognizedWord>(extraBufferCapacity = 64)
+    override val words: Flow<RecognizedWord> = _words.asSharedFlow()
+
+    private val scope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
+
+    @Volatile
+    private var job: Job? = null
+
+    override fun start() {
+        if (job?.isActive == true) return
+        if (!hasRecordPermission()) {
+            Log.i(TAG, "voice-paced: RECORD_AUDIO not granted — staying silent")
+            return
+        }
+        val model = modelProvider.readyModel()
+        if (model == null) {
+            Log.i(TAG, "voice-paced: ASR model not downloaded — staying silent")
+            return
+        }
+        job = scope.launch { runCapture(model) }
+    }
+
+    override fun stop() {
+        job?.cancel()
+        job = null
+    }
+
+    /** Release the capture scope entirely; the instance can't be reused after. */
+    fun destroy() {
+        stop()
+        scope.cancel()
+    }
+
+    private fun hasRecordPermission(): Boolean =
+        ContextCompat.checkSelfPermission(context, Manifest.permission.RECORD_AUDIO) ==
+            PackageManager.PERMISSION_GRANTED
+
+    @SuppressLint("MissingPermission") // start() runtime-checks RECORD_AUDIO before launching this
+    private suspend fun runCapture(model: AsrModel) {
+        val recognizer = buildRecognizer(model) ?: return
+        val stream = recognizer.createStream()
+        val minBuf = AudioRecord.getMinBufferSize(
+            SAMPLE_RATE,
+            AudioFormat.CHANNEL_IN_MONO,
+            AudioFormat.ENCODING_PCM_16BIT,
+        )
+        if (minBuf <= 0) {
+            stream.release(); recognizer.release(); return
+        }
+        val record = AudioRecord(
+            MediaRecorder.AudioSource.VOICE_RECOGNITION,
+            SAMPLE_RATE,
+            AudioFormat.CHANNEL_IN_MONO,
+            AudioFormat.ENCODING_PCM_16BIT,
+            maxOf(minBuf, FRAME_SAMPLES * BYTES_PER_SAMPLE * 4),
+        )
+        if (record.state != AudioRecord.STATE_INITIALIZED) {
+            record.release(); stream.release(); recognizer.release(); return
+        }
+
+        val frame = ShortArray(FRAME_SAMPLES)
+        val gate = SilenceGate()
+        val extractor = AsrWordExtractor()
+        var feeding = false
+        try {
+            record.startRecording()
+            while (coroutineContext.isActive) {
+                val n = record.read(frame, 0, frame.size)
+                if (n <= 0) continue
+                val open = gate.update(AsrAudio.rms(frame, n), SystemClock.elapsedRealtime())
+                if (open) {
+                    feeding = true
+                    stream.acceptWaveform(AsrAudio.toFloatPcm(frame, n), SAMPLE_RATE)
+                    while (recognizer.isReady(stream)) recognizer.decode(stream)
+                    val result = recognizer.getResult(stream)
+                    val confidence = asrConfidence(result.ysProbs)
+                    if (recognizer.isEndpoint(stream)) {
+                        emitWords(extractor.flush(result.text), confidence)
+                        recognizer.reset(stream)
+                    } else {
+                        emitWords(extractor.newWords(result.text), confidence)
+                    }
+                } else if (feeding) {
+                    // Just crossed into a long pause: finalize the in-flight
+                    // utterance so its held-back tail word still reaches the
+                    // aligner, then idle (no decoding) until voice returns.
+                    feeding = false
+                    val result = recognizer.getResult(stream)
+                    emitWords(extractor.flush(result.text), asrConfidence(result.ysProbs))
+                    recognizer.reset(stream)
+                }
+            }
+        } catch (ce: CancellationException) {
+            throw ce
+        } catch (t: Throwable) {
+            Log.w(TAG, "voice-paced capture aborted: ${t.message}")
+        } finally {
+            runCatching { record.stop() }
+            runCatching { record.release() }
+            runCatching { stream.release() }
+            runCatching { recognizer.release() }
+        }
+    }
+
+    private suspend fun emitWords(words: List<String>, confidence: Float) {
+        for (w in words) _words.emit(RecognizedWord(text = w, confidence = confidence))
+    }
+
+    /**
+     * Build the streaming transducer recognizer from [model]'s file paths.
+     * Returns null on any init failure (corrupt/incompatible model) so capture
+     * degrades to silent rather than crashing. Leaves `modelType` /
+     * `decodingMethod` at sherpa's defaults (transducer is auto-detected;
+     * greedy search) — see the device-validation note in the class kdoc.
+     */
+    private fun buildRecognizer(model: AsrModel): OnlineRecognizer? = try {
+        val config = OnlineRecognizerConfig(
+            featConfig = FeatureConfig(sampleRate = SAMPLE_RATE, featureDim = FEATURE_DIM),
+            modelConfig = OnlineModelConfig(
+                transducer = OnlineTransducerModelConfig(
+                    encoder = model.encoder,
+                    decoder = model.decoder,
+                    joiner = model.joiner,
+                ),
+                tokens = model.tokens,
+                numThreads = 2,
+            ),
+            enableEndpoint = true,
+            endpointConfig = EndpointConfig(
+                rule1 = EndpointRule(false, 2.4f, 0f),
+                rule2 = EndpointRule(true, 1.2f, 0f),
+                rule3 = EndpointRule(false, 0f, 20f),
+            ),
+        )
+        OnlineRecognizer(config = config)
+    } catch (t: Throwable) {
+        Log.w(TAG, "voice-paced recognizer init failed: ${t.message}")
+        null
+    }
+
+    private companion object {
+        const val TAG = "MicCaptureProcessor"
+
+        /** sherpa-onnx streaming models expect 16 kHz mono. */
+        const val SAMPLE_RATE = 16_000
+
+        /** Kaldi-style fbank feature dimension the streaming models use. */
+        const val FEATURE_DIM = 80
+
+        const val BYTES_PER_SAMPLE = 2
+
+        /** 100 ms read granularity — responsive VAD without per-sample churn. */
+        const val FRAME_SAMPLES = 1_600
+    }
+}

--- a/core-playback/src/main/kotlin/in/jphe/storyvox/playback/transcribe/ScriptCueFilter.kt
+++ b/core-playback/src/main/kotlin/in/jphe/storyvox/playback/transcribe/ScriptCueFilter.kt
@@ -1,0 +1,80 @@
+package `in`.jphe.storyvox.playback.transcribe
+
+/**
+ * Issue #1368 — strips the parts of a teleprompter script the reader does
+ * **not** say aloud before the [ForcedAligner] matches against it: production
+ * cues in `[brackets]` (e.g. `[POST: JINGLE]`) and `====` / `----` section
+ * banner rules. The TechEmpower Show scripts (the real test content) are full
+ * of these, and the web teleprompter already excludes them when counting
+ * spoken words — this matches that behaviour for the voice-follow path.
+ *
+ * ### Why offsets must be mapped back to source
+ * If the aligner matched against the *stripped* text, its `positionChar` would
+ * be an offset into that stripped string — but the reader scrolls against the
+ * **original, displayed** chapter text. Feeding a stripped-space offset into an
+ * original-space scroll mapping would drift the scroll by the cumulative length
+ * of every cue above the cursor. So [spokenText] returns both the cleaned
+ * [SpokenText.text] (what the aligner tokenizes) **and** a per-character map
+ * back to the source ([SpokenText.toSourceOffset]); [VoicePacedScrollController]
+ * matches in stripped space and publishes source-space offsets.
+ *
+ * Pure and deterministic — no Android — so the stripping + mapping are
+ * unit-testable.
+ */
+object ScriptCueFilter {
+
+    /** `[production cue]` — `[^\]]` so a multi-line cue block is still removed. */
+    private val INLINE_CUE = Regex("\\[[^\\]]*\\]")
+
+    /** A whole-line banner rule of `=` or `-` (e.g. `========`, `--------`). */
+    private val BANNER_LINE = Regex("(?m)^[=\\-]{3,}$")
+
+    /**
+     * Remove cues + banner rules from [source], returning the spoken text and a
+     * map from each kept character back to its index in [source].
+     */
+    fun spokenText(source: String): SpokenText {
+        if (source.isEmpty()) return SpokenText("", IntArray(0))
+
+        val removed = BooleanArray(source.length)
+        fun mark(regex: Regex) {
+            for (m in regex.findAll(source)) {
+                for (i in m.range) if (i in source.indices) removed[i] = true
+            }
+        }
+        mark(INLINE_CUE)
+        mark(BANNER_LINE)
+
+        val sb = StringBuilder(source.length)
+        val map = IntArray(source.length)
+        var kept = 0
+        for (i in source.indices) {
+            if (!removed[i]) {
+                sb.append(source[i])
+                map[kept] = i
+                kept++
+            }
+        }
+        return SpokenText(sb.toString(), map.copyOf(kept))
+    }
+}
+
+/**
+ * Spoken-only text plus a map from its character offsets back to the original
+ * source string. Produced by [ScriptCueFilter.spokenText].
+ */
+class SpokenText(
+    /** The script with cues + banners removed — what [ForcedAligner] tokenizes. */
+    val text: String,
+    private val sourceOffsets: IntArray,
+) {
+    /**
+     * Map a character [spokenOffset] in [text] back to the corresponding offset
+     * in the original source. Clamped to a valid index; returns 0 for empty text
+     * so a pre-match position (offset 0) maps to the start of the source.
+     */
+    fun toSourceOffset(spokenOffset: Int): Int {
+        if (sourceOffsets.isEmpty()) return 0
+        return sourceOffsets[spokenOffset.coerceIn(0, sourceOffsets.lastIndex)]
+    }
+}

--- a/core-playback/src/main/kotlin/in/jphe/storyvox/playback/transcribe/SilenceGate.kt
+++ b/core-playback/src/main/kotlin/in/jphe/storyvox/playback/transcribe/SilenceGate.kt
@@ -1,0 +1,58 @@
+package `in`.jphe.storyvox.playback.transcribe
+
+/**
+ * Issue #1368 — a hysteresis gate over per-frame audio loudness that decides
+ * whether the streaming recognizer should be fed. Voice-activity-detection
+ * lite: when the speaker pauses for [silenceToCloseMs] the gate **closes**
+ * (the [MicCaptureProcessor] stops decoding, which is the CPU-hungry step —
+ * Lucid's #1291 finding that VAD duty-cycling saves ~75% CPU on pauses); the
+ * very next loud frame re-opens it ("auto-resume on voice activity").
+ *
+ * Loudness is a normalized RMS in `[0, 1]` (1.0 ≈ full-scale). The default
+ * [rmsThreshold] of 0.012 sits around -38 dBFS — above room tone / breath,
+ * below speech. The gate opens immediately on voice (no attack delay, so the
+ * first syllable after a pause isn't clipped) and closes only after a
+ * sustained quiet stretch (so inter-word gaps don't flap it).
+ *
+ * Pure and deterministic — the caller passes loudness + a monotonic clock —
+ * so the open/close policy is unit-testable without a microphone. A genuine
+ * Silero-VAD model (sherpa-onnx ships [`SileroVadModelConfig`]) is the
+ * eventual upgrade for noisy rooms; this energy gate is the dependency-free
+ * v1 and is enough for a phone held near the reader's mouth.
+ */
+class SilenceGate(
+    private val rmsThreshold: Float = 0.012f,
+    private val silenceToCloseMs: Long = 3_000L,
+) {
+    private var open = true
+    private var quietSinceMs = -1L
+
+    /** True if the recognizer should process this frame (gate open). */
+    val isOpen: Boolean get() = open
+
+    /**
+     * Update with this frame's normalized [rms] loudness at [nowMs]; returns
+     * whether the gate is open (feed the recognizer) afterwards.
+     */
+    fun update(rms: Float, nowMs: Long): Boolean {
+        if (rms >= rmsThreshold) {
+            // Voice present — open immediately, clear the quiet timer.
+            open = true
+            quietSinceMs = -1L
+        } else {
+            // Quiet frame — start (or continue) the trailing-silence timer.
+            if (quietSinceMs < 0L) {
+                quietSinceMs = nowMs
+            } else if (nowMs - quietSinceMs >= silenceToCloseMs) {
+                open = false
+            }
+        }
+        return open
+    }
+
+    /** Reset to open with no pending silence (e.g. capture (re)started). */
+    fun reset() {
+        open = true
+        quietSinceMs = -1L
+    }
+}

--- a/core-playback/src/main/kotlin/in/jphe/storyvox/playback/transcribe/VoicePacedScrollController.kt
+++ b/core-playback/src/main/kotlin/in/jphe/storyvox/playback/transcribe/VoicePacedScrollController.kt
@@ -20,11 +20,13 @@ import kotlinx.coroutines.launch
  * RecognizedWordSource.words ─▶ ForcedAligner.onWord ─▶ positionChar (StateFlow)
  * ```
  *
- * [start] builds a fresh [ForcedAligner] for the chapter text and begins
- * collecting words from the injected [RecognizedWordSource] (the live
- * [MicCaptureProcessor] in production, or a fake in tests); each recognized
- * word advances the aligner and publishes the new character offset on
- * [positionChar]. [stop] cancels the collection and stops capture.
+ * [start] strips the script's non-spoken cues + banners ([ScriptCueFilter]),
+ * builds a fresh [ForcedAligner] over the spoken text, and begins collecting
+ * words from the injected [RecognizedWordSource] (the live [MicCaptureProcessor]
+ * in production, or a fake in tests); each recognized word advances the aligner.
+ * The aligner's offset (in *stripped* space) is mapped back to the **source**
+ * text so [positionChar] is an offset the reader can scroll against directly.
+ * [stop] cancels the collection and stops capture.
  *
  * ### Why this exposes a *character* offset, not a scroll pixel
  * The brief imagined a `scrollTarget` pixel flow here, but the pure
@@ -61,13 +63,18 @@ class VoicePacedScrollController @Inject constructor(
      */
     fun start(chapterText: String) {
         if (job?.isActive == true) return
-        val aligner = ForcedAligner(chapterText)
+        // Strip cues/banners so the aligner only matches spoken words, but keep
+        // the map back to source offsets — the reader scrolls against the
+        // displayed (un-stripped) chapter text.
+        val spoken = ScriptCueFilter.spokenText(chapterText)
+        val aligner = ForcedAligner(spoken.text)
         _positionChar.value = 0
         _listening.value = true
         wordSource.start()
         job = scope.launch {
             wordSource.words.collect { word ->
-                _positionChar.value = aligner.onWord(word.text, word.confidence)
+                val spokenOffset = aligner.onWord(word.text, word.confidence)
+                _positionChar.value = spoken.toSourceOffset(spokenOffset)
             }
         }
     }

--- a/core-playback/src/main/kotlin/in/jphe/storyvox/playback/transcribe/VoicePacedScrollController.kt
+++ b/core-playback/src/main/kotlin/in/jphe/storyvox/playback/transcribe/VoicePacedScrollController.kt
@@ -1,0 +1,82 @@
+package `in`.jphe.storyvox.playback.transcribe
+
+import javax.inject.Inject
+import javax.inject.Singleton
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.launch
+
+/**
+ * Issue #1368 — the stateful bridge that ties the live word stream to the
+ * pure alignment logic for the voice-paced teleprompter. It is the one place
+ * that holds session state across the otherwise-pure pieces:
+ *
+ * ```
+ * RecognizedWordSource.words ─▶ ForcedAligner.onWord ─▶ positionChar (StateFlow)
+ * ```
+ *
+ * [start] builds a fresh [ForcedAligner] for the chapter text and begins
+ * collecting words from the injected [RecognizedWordSource] (the live
+ * [MicCaptureProcessor] in production, or a fake in tests); each recognized
+ * word advances the aligner and publishes the new character offset on
+ * [positionChar]. [stop] cancels the collection and stops capture.
+ *
+ * ### Why this exposes a *character* offset, not a scroll pixel
+ * The brief imagined a `scrollTarget` pixel flow here, but the pure
+ * [VoicePacedScroller] turns a char offset into a pixel target using the
+ * **viewport geometry**, which is surface-specific (the phone reader and a
+ * future Wear face have different viewports) and lives in Compose. So this
+ * @Singleton stays surface-agnostic — it publishes *where in the text the
+ * speaker is* — and the reader owns a [VoicePacedScroller] that maps
+ * [positionChar] → scroll px against its own measured layout. Clean seam: no
+ * Compose / no viewport metrics leak into core-playback.
+ */
+@Singleton
+class VoicePacedScrollController @Inject constructor(
+    private val wordSource: RecognizedWordSource,
+) {
+    private val scope = CoroutineScope(SupervisorJob() + Dispatchers.Default)
+    private var job: Job? = null
+
+    private val _positionChar = MutableStateFlow(0)
+
+    /** Character offset of where the speaker currently is in the chapter
+     *  (start of the last matched word); 0 before the first match. */
+    val positionChar: StateFlow<Int> = _positionChar.asStateFlow()
+
+    private val _listening = MutableStateFlow(false)
+
+    /** True between [start] and [stop] — the mic session is active. */
+    val listening: StateFlow<Boolean> = _listening.asStateFlow()
+
+    /**
+     * Begin a voice-paced session over [chapterText]: build the aligner, start
+     * capture, and stream recognized words into it. Idempotent while already
+     * running (a no-op until [stop]).
+     */
+    fun start(chapterText: String) {
+        if (job?.isActive == true) return
+        val aligner = ForcedAligner(chapterText)
+        _positionChar.value = 0
+        _listening.value = true
+        wordSource.start()
+        job = scope.launch {
+            wordSource.words.collect { word ->
+                _positionChar.value = aligner.onWord(word.text, word.confidence)
+            }
+        }
+    }
+
+    /** End the session: stop capture and the word collection. Idempotent. */
+    fun stop() {
+        job?.cancel()
+        job = null
+        wordSource.stop()
+        _listening.value = false
+    }
+}

--- a/core-playback/src/test/kotlin/in/jphe/storyvox/playback/transcribe/AsrAudioTest.kt
+++ b/core-playback/src/test/kotlin/in/jphe/storyvox/playback/transcribe/AsrAudioTest.kt
@@ -1,0 +1,62 @@
+package `in`.jphe.storyvox.playback.transcribe
+
+import kotlin.math.ln
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+/**
+ * Issue #1368 — pure mic-path math: RMS loudness, PCM→float conversion, and
+ * the ysProbs→confidence mapping.
+ */
+class AsrAudioTest {
+
+    @Test
+    fun `rms of silence is zero`() {
+        assertEquals(0f, AsrAudio.rms(ShortArray(1_600), 1_600), 0f)
+    }
+
+    @Test
+    fun `rms of a full-scale signal is near one`() {
+        val full = ShortArray(64) { Short.MAX_VALUE }
+        assertEquals(1f, AsrAudio.rms(full, full.size), 0.001f)
+    }
+
+    @Test
+    fun `rms honors the length argument`() {
+        // Only the first 2 (loud) samples count; the silent tail is ignored.
+        val pcm = shortArrayOf(Short.MAX_VALUE, Short.MAX_VALUE, 0, 0)
+        assertEquals(1f, AsrAudio.rms(pcm, 2), 0.001f)
+    }
+
+    @Test
+    fun `toFloatPcm normalizes to plus-minus one`() {
+        val out = AsrAudio.toFloatPcm(shortArrayOf(16_384, -16_384, 0), 3)
+        assertEquals(0.5f, out[0], 0.0001f)
+        assertEquals(-0.5f, out[1], 0.0001f)
+        assertEquals(0f, out[2], 0f)
+    }
+
+    @Test
+    fun `toFloatPcm clamps to the given length`() {
+        val out = AsrAudio.toFloatPcm(shortArrayOf(1, 2, 3, 4), 2)
+        assertEquals(2, out.size)
+    }
+
+    @Test
+    fun `confidence is one when no probs are reported`() {
+        assertEquals(1f, asrConfidence(FloatArray(0)), 0f)
+    }
+
+    @Test
+    fun `confidence is the geometric mean of token probabilities`() {
+        // Two tokens each at prob 0.5 (log = ln 0.5) → exp(mean(log)) = 0.5.
+        val logs = floatArrayOf(ln(0.5f), ln(0.5f))
+        assertEquals(0.5f, asrConfidence(logs), 0.001f)
+    }
+
+    @Test
+    fun `confidence clamps above one`() {
+        // A positive (impossible-for-a-prob) log value must not exceed 1.
+        assertEquals(1f, asrConfidence(floatArrayOf(1f)), 0f)
+    }
+}

--- a/core-playback/src/test/kotlin/in/jphe/storyvox/playback/transcribe/AsrWordExtractorTest.kt
+++ b/core-playback/src/test/kotlin/in/jphe/storyvox/playback/transcribe/AsrWordExtractorTest.kt
@@ -1,0 +1,61 @@
+package `in`.jphe.storyvox.playback.transcribe
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+/**
+ * Issue #1368 — the stable-word policy that turns a streaming recognizer's
+ * growing hypothesis into a stream of new words for the [ForcedAligner].
+ */
+class AsrWordExtractorTest {
+
+    @Test
+    fun `holds back the only word until more arrive`() {
+        val ex = AsrWordExtractor()
+        // A single in-flight token may still be revised — emit nothing yet.
+        assertEquals(emptyList<String>(), ex.newWords("the"))
+    }
+
+    @Test
+    fun `emits each word as the next one stabilizes it`() {
+        val ex = AsrWordExtractor()
+        assertEquals(emptyList<String>(), ex.newWords("the"))
+        assertEquals(listOf("the"), ex.newWords("the quick"))
+        assertEquals(listOf("quick"), ex.newWords("the quick brown"))
+        // No growth → nothing new.
+        assertEquals(emptyList<String>(), ex.newWords("the quick brown"))
+    }
+
+    @Test
+    fun `emits a multi-word jump in order minus the unstable tail`() {
+        val ex = AsrWordExtractor()
+        assertEquals(listOf("alpha", "beta", "gamma"), ex.newWords("alpha beta gamma delta"))
+    }
+
+    @Test
+    fun `flush releases the held tail and resets for the next utterance`() {
+        val ex = AsrWordExtractor()
+        ex.newWords("the quick brown") // emits the, quick; holds brown
+        assertEquals(listOf("brown"), ex.flush("the quick brown"))
+        // After a flush the count is reset — a brand-new utterance starts over.
+        assertEquals(emptyList<String>(), ex.newWords("next"))
+        assertEquals(listOf("next"), ex.newWords("next utterance"))
+    }
+
+    @Test
+    fun `empty and whitespace hypotheses are safe no-ops`() {
+        val ex = AsrWordExtractor()
+        assertEquals(emptyList<String>(), ex.newWords(""))
+        assertEquals(emptyList<String>(), ex.newWords("   "))
+        assertEquals(emptyList<String>(), ex.flush(""))
+    }
+
+    @Test
+    fun `reset drops in-flight progress`() {
+        val ex = AsrWordExtractor()
+        ex.newWords("one two three") // emitted = 2
+        ex.reset()
+        // Fresh start: "one two" emits only "one" again.
+        assertEquals(listOf("one"), ex.newWords("one two"))
+    }
+}

--- a/core-playback/src/test/kotlin/in/jphe/storyvox/playback/transcribe/ScriptCueFilterTest.kt
+++ b/core-playback/src/test/kotlin/in/jphe/storyvox/playback/transcribe/ScriptCueFilterTest.kt
@@ -1,0 +1,65 @@
+package `in`.jphe.storyvox.playback.transcribe
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * Issue #1368 — stripping cues + banners from a script and mapping the cleaned
+ * offsets back to the source (so the scroll stays aligned to the displayed text).
+ */
+class ScriptCueFilterTest {
+
+    @Test
+    fun `strips an inline cue`() {
+        val spoken = ScriptCueFilter.spokenText("Hi [POST: jingle] there")
+        assertFalse(spoken.text.contains("POST"))
+        assertFalse(spoken.text.contains("jingle"))
+        assertTrue(spoken.text.contains("Hi"))
+        assertTrue(spoken.text.contains("there"))
+    }
+
+    @Test
+    fun `strips banner rule lines but keeps the dialogue`() {
+        val source = "================\nWelcome back\n----------------\nto the show"
+        val spoken = ScriptCueFilter.spokenText(source)
+        assertFalse(spoken.text.contains("="))
+        assertFalse(spoken.text.contains("-"))
+        assertTrue(spoken.text.contains("Welcome back"))
+        assertTrue(spoken.text.contains("to the show"))
+    }
+
+    @Test
+    fun `maps a spoken offset back to the source index past a cue`() {
+        // "there" starts at source index 18 (after the removed "[POST: jingle]").
+        val source = "Hi [POST: jingle] there"
+        assertEquals('t', source[18])
+        val spoken = ScriptCueFilter.spokenText(source)
+        // Find "there" in the cleaned text and map its 't' back to the source.
+        val spokenIdx = spoken.text.indexOf("there")
+        assertEquals(18, spoken.toSourceOffset(spokenIdx))
+    }
+
+    @Test
+    fun `keeps speaker labels — the aligner tolerates the stray token`() {
+        // The brief strips only cues + banners; "SHAWNA:" stays (the aligner's
+        // resync absorbs the one unspoken token per turn).
+        val spoken = ScriptCueFilter.spokenText("SHAWNA:\nWelcome back")
+        assertTrue(spoken.text.contains("SHAWNA"))
+    }
+
+    @Test
+    fun `empty source is a safe no-op`() {
+        val spoken = ScriptCueFilter.spokenText("")
+        assertEquals("", spoken.text)
+        assertEquals(0, spoken.toSourceOffset(0))
+    }
+
+    @Test
+    fun `offset zero maps to the start before any match`() {
+        val spoken = ScriptCueFilter.spokenText("====\nWelcome")
+        // Pre-match position (0) must map to a valid source index, not crash.
+        assertTrue(spoken.toSourceOffset(0) in 0..("====\nWelcome".length))
+    }
+}

--- a/core-playback/src/test/kotlin/in/jphe/storyvox/playback/transcribe/SilenceGateTest.kt
+++ b/core-playback/src/test/kotlin/in/jphe/storyvox/playback/transcribe/SilenceGateTest.kt
@@ -1,0 +1,62 @@
+package `in`.jphe.storyvox.playback.transcribe
+
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * Issue #1368 — the VAD-lite gate that pauses decoding on a long silence and
+ * resumes on the next loud frame.
+ */
+class SilenceGateTest {
+
+    private fun gate() = SilenceGate(rmsThreshold = 0.1f, silenceToCloseMs = 1_000L)
+
+    @Test
+    fun `starts open and stays open on voice`() {
+        val g = gate()
+        assertTrue(g.update(rms = 0.5f, nowMs = 0L))
+        assertTrue(g.update(rms = 0.5f, nowMs = 100L))
+    }
+
+    @Test
+    fun `closes only after sustained trailing silence`() {
+        val g = gate()
+        assertTrue(g.update(0.5f, 0L))      // voice
+        assertTrue(g.update(0.0f, 100L))    // quiet begins
+        assertTrue(g.update(0.0f, 900L))    // 800ms quiet — still open
+        assertFalse(g.update(0.0f, 1_100L)) // 1000ms quiet — closes
+    }
+
+    @Test
+    fun `reopens immediately on the next loud frame`() {
+        val g = gate()
+        g.update(0.5f, 0L)
+        g.update(0.0f, 100L)
+        assertFalse(g.update(0.0f, 1_200L)) // closed
+        assertTrue(g.update(0.5f, 1_300L))  // voice returns → open at once
+    }
+
+    @Test
+    fun `a brief gap does not accumulate toward closing`() {
+        val g = gate()
+        g.update(0.5f, 0L)
+        g.update(0.0f, 100L)   // quiet timer starts at 100
+        g.update(0.5f, 200L)   // voice resets the timer
+        g.update(0.0f, 300L)   // quiet timer restarts at 300
+        assertTrue(g.update(0.0f, 1_250L))  // only 950ms since 300 — still open
+        assertFalse(g.update(0.0f, 1_350L)) // now 1050ms — closes
+    }
+
+    @Test
+    fun `reset returns to open with no pending silence`() {
+        val g = gate()
+        g.update(0.5f, 0L)
+        g.update(0.0f, 100L)
+        g.update(0.0f, 1_200L) // closed
+        g.reset()
+        assertTrue(g.isOpen)
+        // The previously-elapsed silence is forgotten — a fresh quiet window starts.
+        assertTrue(g.update(0.0f, 1_300L))
+    }
+}

--- a/feature/src/main/kotlin/in/jphe/storyvox/feature/reader/HybridReaderScreen.kt
+++ b/feature/src/main/kotlin/in/jphe/storyvox/feature/reader/HybridReaderScreen.kt
@@ -119,6 +119,11 @@ fun HybridReaderScreen(
     // transport's "Write a script" button. Hosted here (not in ReaderTextView)
     // so it can reach the Settings → AI nav for the unconfigured-provider path.
     var scriptSheetOpen by remember { mutableStateOf(false) }
+    // Issue #1368 — voice-paced follow: model readiness, the one-time download
+    // spinner, and the speaker's live char offset that drives the scroll.
+    val voicePacedModelReady by viewModel.voicePacedModelReady.collectAsStateWithLifecycle()
+    val voicePacedPreparing by viewModel.voicePacedPreparing.collectAsStateWithLifecycle()
+    val voicePacedPositionChar by viewModel.voicePacedPositionChar.collectAsStateWithLifecycle()
     val playback = state.playback
 
     // Chapter-completion celebration. The VM's confettiTrigger fires
@@ -426,6 +431,14 @@ fun HybridReaderScreen(
                 onResetTeleprompter = viewModel::resetTeleprompter,
                 // Issue #1366 — open the AI script-writer sheet (hosted below).
                 onWriteScript = { scriptSheetOpen = true },
+                // Issue #1368 — voice-paced follow: hands-free scroll driven by
+                // the reader's own speech via on-device STT.
+                voicePacedModelReady = voicePacedModelReady,
+                voicePacedPreparing = voicePacedPreparing,
+                voicePacedPositionChar = voicePacedPositionChar,
+                onStartVoicePaced = viewModel::startVoicePaced,
+                onStopVoicePaced = viewModel::stopVoicePaced,
+                onPrepareVoicePaced = viewModel::prepareVoicePaced,
             )
         },
     )

--- a/feature/src/main/kotlin/in/jphe/storyvox/feature/reader/ReaderView.kt
+++ b/feature/src/main/kotlin/in/jphe/storyvox/feature/reader/ReaderView.kt
@@ -1,5 +1,10 @@
 package `in`.jphe.storyvox.feature.reader
 
+import android.Manifest
+import android.content.pm.PackageManager
+import androidx.activity.compose.rememberLauncherForActivityResult
+import androidx.activity.result.contract.ActivityResultContracts
+import androidx.core.content.ContextCompat
 import androidx.compose.animation.AnimatedVisibility
 import androidx.compose.animation.core.animateFloatAsState
 import androidx.compose.animation.core.tween
@@ -28,6 +33,7 @@ import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Add
 import androidx.compose.material.icons.filled.Close
+import androidx.compose.material.icons.filled.Mic
 import androidx.compose.material.icons.filled.Pause
 import androidx.compose.material.icons.filled.PlayArrow
 import androidx.compose.material.icons.filled.Remove
@@ -43,6 +49,7 @@ import androidx.compose.material.icons.outlined.RecordVoiceOver
 import androidx.compose.material.icons.outlined.Search
 import androidx.compose.material.icons.outlined.Slideshow
 import androidx.compose.material3.Button
+import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.DropdownMenu
 import androidx.compose.material3.DropdownMenuItem
 import androidx.compose.material3.ExperimentalMaterial3Api
@@ -94,6 +101,8 @@ import androidx.compose.ui.text.input.ImeAction
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import `in`.jphe.storyvox.feature.R
+import `in`.jphe.storyvox.playback.transcribe.ScrollMetrics
+import `in`.jphe.storyvox.playback.transcribe.VoicePacedScroller
 import `in`.jphe.storyvox.feature.api.HighlightMode
 import `in`.jphe.storyvox.feature.api.UiPlaybackState
 import androidx.compose.runtime.withFrameNanos
@@ -196,7 +205,7 @@ internal const val TELEPROMPTER_WPM_STEP = 10
  *    to voice the character ("pause-for-me"), tap to continue. Honor-system
  *    (no mic) for v1.
  */
-enum class TeleprompterMode { AutoScroll, Practice }
+enum class TeleprompterMode { AutoScroll, Practice, VoicePaced }
 
 /** Whitespace-delimited word count; the teleprompter's pace is per-word. */
 internal fun countWords(text: String): Int =
@@ -336,6 +345,20 @@ fun ReaderTextView(
      *  Settings → AI for the unconfigured-provider path); the no-op default
      *  keeps preview / test / audiobook callsites unchanged. */
     onWriteScript: () -> Unit = {},
+    /** Issue #1368 — voice-paced teleprompter. [voicePacedModelReady] gates the
+     *  Voice mode (false → offer the one-tap model download via
+     *  [onPrepareVoicePaced]); [voicePacedPreparing] is true while that download
+     *  runs. [voicePacedPositionChar] is the live char offset of where the
+     *  speaker is (from [ReaderViewModel] → VoicePacedScrollController); this
+     *  composable maps it to a scroll position. [onStartVoicePaced] /
+     *  [onStopVoicePaced] bracket the mic session. Defaults keep older callsites
+     *  (audiobook view, previews, tests) on the manual teleprompter unchanged. */
+    voicePacedModelReady: Boolean = false,
+    voicePacedPreparing: Boolean = false,
+    voicePacedPositionChar: Int = 0,
+    onStartVoicePaced: (String) -> Unit = {},
+    onStopVoicePaced: () -> Unit = {},
+    onPrepareVoicePaced: () -> Unit = {},
     modifier: Modifier = Modifier,
 ) {
     val spacing = LocalSpacing.current
@@ -407,6 +430,68 @@ fun ReaderTextView(
     // a just-handled line can't re-trigger during the post-seek playhead lag.
     var practiceResumeFrom by remember { mutableIntStateOf(0) }
     val segments = remember(chapterText) { segmentDialogue(chapterText) }
+
+    // Issue #1368 — voice-paced follow. Mic permission is resolved here (mirrors
+    // the OCR camera flow, #995) so the Voice chip can request it on demand; a
+    // denial drops back to auto-scroll rather than stranding the user. The
+    // `voiceScroller` is the pure pacing engine (#1291) that turns the speaker's
+    // recognized char offset into a smooth scroll target.
+    val context = LocalContext.current
+    var hasMicPermission by remember {
+        mutableStateOf(
+            ContextCompat.checkSelfPermission(context, Manifest.permission.RECORD_AUDIO) ==
+                PackageManager.PERMISSION_GRANTED,
+        )
+    }
+    val micPermissionLauncher = rememberLauncherForActivityResult(
+        contract = ActivityResultContracts.RequestPermission(),
+    ) { granted ->
+        hasMicPermission = granted
+        if (!granted && teleprompterMode == TeleprompterMode.VoicePaced) {
+            teleprompterMode = TeleprompterMode.AutoScroll
+        }
+    }
+    val voiceScroller = remember { VoicePacedScroller() }
+    // The mic session is live only when Voice mode is selected, the teleprompter
+    // chrome is up, the model is downloaded, and RECORD_AUDIO is granted.
+    val voicePacedActive = teleprompterEnabled &&
+        teleprompterMode == TeleprompterMode.VoicePaced &&
+        voicePacedModelReady &&
+        hasMicPermission
+
+    // Bracket the mic session with the active window: start capture on entry,
+    // stop + release on exit (mode change, model/permission loss, or leaving the
+    // reader). Re-keyed on chapterText so a book switch realigns to the new text.
+    if (voicePacedActive) {
+        DisposableEffect(chapterText) {
+            voiceScroller.reset()
+            onStartVoicePaced(chapterText)
+            onDispose { onStopVoicePaced() }
+        }
+    }
+
+    // Issue #1368 — drive the scroll from the speaker's position. Each new char
+    // offset maps (via the pure VoicePacedScroller's pace + latency look-ahead)
+    // to a target the body animates toward; a manual drag preempts a frame and
+    // the next recognized word resumes the follow — same "peek then carry on" as
+    // the auto-scroll mode.
+    LaunchedEffect(voicePacedPositionChar, voicePacedActive, viewportHeightPx, chapterText) {
+        if (!voicePacedActive) return@LaunchedEffect
+        if (chapterText.isEmpty() || viewportHeightPx <= 0f || scroll.maxValue <= 0) return@LaunchedEffect
+        val metrics = ScrollMetrics(
+            totalChars = chapterText.length,
+            // Feed content height as maxScroll + viewport so the scroller's
+            // internal clamp lands in the reader's real [0, maxValue] range.
+            contentHeightPx = scroll.maxValue + viewportHeightPx,
+            viewportHeightPx = viewportHeightPx,
+        )
+        val target = voiceScroller.onPosition(voicePacedPositionChar, System.currentTimeMillis(), metrics)
+        try {
+            scroll.animateScrollTo(target.targetScrollPx.roundToInt())
+        } catch (e: CancellationException) {
+            if (!isActive) throw e // teardown — propagate; else a drag preempted, resume next word
+        }
+    }
 
     // Auto-scroll target: when sentence range or layout changes, settle the highlighted
     // line at 40% from the top of the viewport — unless we're inside the manual-scroll
@@ -1075,6 +1160,17 @@ fun ReaderTextView(
                             onSetTeleprompterPlaying(false) // stop the silent auto-scroll
                             practiceTurn = null
                             if (state.isPlaying) onPlayPause() // pause TTS across a swap
+                            // #1368 — Voice mode needs a downloaded model + mic
+                            // grant; entering it kicks whichever is missing. The
+                            // transport shows the preparing / allow-mic state
+                            // until both land, then capture starts (voicePacedActive).
+                            if (picked == TeleprompterMode.VoicePaced) {
+                                when {
+                                    !voicePacedModelReady -> onPrepareVoicePaced()
+                                    !hasMicPermission ->
+                                        micPermissionLauncher.launch(Manifest.permission.RECORD_AUDIO)
+                                }
+                            }
                         }
                     },
                 )
@@ -1128,6 +1224,14 @@ fun ReaderTextView(
                             if (state.isPlaying) onPlayPause() // stop TTS on exit
                             onSetTeleprompterEnabled(false)
                         },
+                    )
+                    TeleprompterMode.VoicePaced -> VoicePacedTransport(
+                        modelReady = voicePacedModelReady,
+                        preparing = voicePacedPreparing,
+                        hasMicPermission = hasMicPermission,
+                        onGrantMic = { micPermissionLauncher.launch(Manifest.permission.RECORD_AUDIO) },
+                        onPrepareModel = onPrepareVoicePaced,
+                        onExit = { onSetTeleprompterEnabled(false) },
                     )
                 }
             }
@@ -1323,9 +1427,10 @@ private fun TeleprompterTransport(
 }
 
 /**
- * Issue #1287 — teleprompter mode selector (Auto-scroll / Practice). Two
- * chips above the mode-specific transport; selecting Practice swaps to the
- * TTS-paced "pause-for-me" flow.
+ * Issue #1287/#1368 — teleprompter mode selector (Auto-scroll / Practice /
+ * Voice). Chips above the mode-specific transport: Auto-scroll paces by WPM,
+ * Practice is the TTS "pause-for-me" flow, and Voice (#1368) follows the
+ * reader's own speech via on-device STT.
  */
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
@@ -1356,6 +1461,98 @@ private fun TeleprompterModeChips(
                 onClick = { onSelect(TeleprompterMode.Practice) },
                 label = { Text(stringResource(R.string.reader_practice)) },
             )
+            FilterChip(
+                selected = mode == TeleprompterMode.VoicePaced,
+                onClick = { onSelect(TeleprompterMode.VoicePaced) },
+                label = { Text(stringResource(R.string.reader_voice_paced)) },
+            )
+        }
+    }
+}
+
+/**
+ * Issue #1368 — voice-paced transport. Pure presentational; the host
+ * ([ReaderTextView]) owns the gating state and the capture session. Renders
+ * the state the user needs to act on:
+ *
+ * - model not yet downloaded → a progress spinner ([preparing]) or a
+ *   download/retry button ([onPrepareModel]);
+ * - model ready but mic not granted → an "Allow microphone" button
+ *   ([onGrantMic]);
+ * - both satisfied → a live "Listening" indicator (the capture session is
+ *   running and the body scrolls to the speaker's voice).
+ *
+ * An Exit on the left mirrors the other transports' resting place.
+ */
+@Composable
+private fun VoicePacedTransport(
+    modelReady: Boolean,
+    preparing: Boolean,
+    hasMicPermission: Boolean,
+    onGrantMic: () -> Unit,
+    onPrepareModel: () -> Unit,
+    onExit: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    val spacing = LocalSpacing.current
+    Surface(
+        modifier = modifier.fillMaxWidth(),
+        color = MaterialTheme.colorScheme.surfaceContainerHigh,
+        shadowElevation = 4.dp,
+    ) {
+        Row(
+            modifier = Modifier.fillMaxWidth().padding(spacing.sm),
+            verticalAlignment = Alignment.CenterVertically,
+            horizontalArrangement = Arrangement.spacedBy(spacing.sm),
+        ) {
+            IconButton(
+                onClick = onExit,
+                modifier = Modifier.semantics { contentDescription = "Exit teleprompter" },
+            ) {
+                Icon(imageVector = Icons.Filled.Close, contentDescription = null)
+            }
+            Spacer(modifier = Modifier.weight(1f))
+            when {
+                !modelReady && preparing -> {
+                    CircularProgressIndicator(modifier = Modifier.size(20.dp))
+                    Text(
+                        text = stringResource(R.string.reader_voice_paced_preparing),
+                        style = MaterialTheme.typography.bodyMedium,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    )
+                }
+                !modelReady -> TextButton(onClick = onPrepareModel) {
+                    Text(stringResource(R.string.reader_voice_paced_download))
+                }
+                !hasMicPermission -> TextButton(onClick = onGrantMic) {
+                    Icon(
+                        imageVector = Icons.Filled.Mic,
+                        contentDescription = null,
+                        modifier = Modifier.size(18.dp),
+                    )
+                    Spacer(modifier = Modifier.size(spacing.xs))
+                    Text(stringResource(R.string.reader_voice_paced_grant_mic))
+                }
+                else -> Row(
+                    verticalAlignment = Alignment.CenterVertically,
+                    horizontalArrangement = Arrangement.spacedBy(spacing.xs),
+                    modifier = Modifier.semantics {
+                        liveRegion = LiveRegionMode.Polite
+                    },
+                ) {
+                    Icon(
+                        imageVector = Icons.Filled.Mic,
+                        contentDescription = null,
+                        tint = MaterialTheme.colorScheme.primary,
+                    )
+                    Text(
+                        text = stringResource(R.string.reader_voice_paced_listening),
+                        style = MaterialTheme.typography.titleSmall,
+                        color = MaterialTheme.colorScheme.onSurface,
+                    )
+                }
+            }
+            Spacer(modifier = Modifier.weight(1f))
         }
     }
 }

--- a/feature/src/main/kotlin/in/jphe/storyvox/feature/reader/ReaderViewModel.kt
+++ b/feature/src/main/kotlin/in/jphe/storyvox/feature/reader/ReaderViewModel.kt
@@ -28,6 +28,8 @@ import `in`.jphe.storyvox.feature.api.UiSleepTimerMode
 import `in`.jphe.storyvox.ui.theme.ReaderColors
 import `in`.jphe.storyvox.playback.PlaybackUiEvent
 import `in`.jphe.storyvox.playback.TeleprompterController
+import `in`.jphe.storyvox.playback.transcribe.AsrModelProvider
+import `in`.jphe.storyvox.playback.transcribe.VoicePacedScrollController
 import `in`.jphe.storyvox.llm.LlmError
 import `in`.jphe.storyvox.llm.feature.ChapterRecap
 import `in`.jphe.storyvox.ui.component.ReaderView
@@ -295,6 +297,15 @@ class ReaderViewModel @Inject constructor(
      * truth. Mode + practice-flow state intentionally stay local to the reader.
      */
     private val teleprompter: TeleprompterController,
+    /**
+     * Issue #1368 — voice-paced teleprompter. [voicePaced] bridges the live
+     * mic→STT word stream into the forced aligner and publishes the speaker's
+     * char offset; [asrModel] owns the downloadable on-device STT model. Both
+     * are @Singletons in core-playback (the reader is surface-agnostic about
+     * the recognizer); the reader maps the offset to a scroll position.
+     */
+    private val voicePaced: VoicePacedScrollController,
+    private val asrModel: AsrModelProvider,
     savedState: SavedStateHandle,
 ) : ViewModel() {
 
@@ -814,6 +825,18 @@ class ReaderViewModel @Inject constructor(
      *  [setTeleprompterEnabled] / [setTeleprompterWpm] (#1287/#1304). */
     val teleprompterWpm: StateFlow<Int> = teleprompter.wpm
 
+    // Issue #1368 — voice-paced teleprompter. The reader maps
+    // [voicePacedPositionChar] (the speaker's live position, from the forced
+    // aligner) to a scroll target; [voicePacedModelReady] gates the Voice mode
+    // and [voicePacedPreparing] reflects the one-time model download.
+    val voicePacedPositionChar: StateFlow<Int> = voicePaced.positionChar
+
+    private val _voicePacedModelReady = MutableStateFlow(asrModel.isReady())
+    val voicePacedModelReady: StateFlow<Boolean> = _voicePacedModelReady.asStateFlow()
+
+    private val _voicePacedPreparing = MutableStateFlow(false)
+    val voicePacedPreparing: StateFlow<Boolean> = _voicePacedPreparing.asStateFlow()
+
     /** Issue #278 — user-initiated retry from the timed-out error block.
      *  Re-invokes the playback `play()` path; the underlying controller
      *  will re-fetch the chapter / re-prime the voice. We also reset the
@@ -1194,6 +1217,41 @@ class ReaderViewModel @Inject constructor(
     fun resetTeleprompter() {
         teleprompter.setEnabled(false)
         teleprompter.setPlaying(false)
+        voicePaced.stop() // #1368 — never leave the mic capturing after the reader closes
+    }
+
+    // ── Voice-paced teleprompter (issue #1368) ─────────────────────────
+
+    /** Begin a voice-paced session over [chapterText]: the controller starts
+     *  mic capture + STT and streams the speaker's position to
+     *  [voicePacedPositionChar]. The reader brackets this with the active
+     *  window (model + permission satisfied). */
+    fun startVoicePaced(chapterText: String) = voicePaced.start(chapterText)
+
+    /** End the voice-paced session and release the recognizer. Idempotent. */
+    fun stopVoicePaced() = voicePaced.stop()
+
+    /** Kick the one-time on-device STT model download, flipping
+     *  [voicePacedModelReady] when it lands. Idempotent — ignored while a
+     *  download is in flight or the model is already present. A failed
+     *  download just clears the spinner; the user can retry. */
+    fun prepareVoicePaced() {
+        if (_voicePacedPreparing.value || _voicePacedModelReady.value) return
+        _voicePacedPreparing.value = true
+        viewModelScope.launch {
+            asrModel.download().collect { progress ->
+                when (progress) {
+                    is AsrModelProvider.DownloadProgress.Done -> {
+                        _voicePacedModelReady.value = asrModel.isReady()
+                        _voicePacedPreparing.value = false
+                    }
+                    is AsrModelProvider.DownloadProgress.Failed -> {
+                        _voicePacedPreparing.value = false
+                    }
+                    else -> Unit // Resolving / Downloading — keep the spinner up
+                }
+            }
+        }
     }
 
     // Issue #121 — in-chapter bookmark fan-out. ReaderViewModel stays

--- a/feature/src/main/res/values/strings.xml
+++ b/feature/src/main/res/values/strings.xml
@@ -155,6 +155,12 @@
     <string name="reader_practice_continue">Continue</string>
     <string name="reader_practice_narrating">Reading narration…</string>
     <string name="reader_practice_tap_play">Practice — tap play to begin</string>
+    <!-- Reader / voice-paced follow mode (#1368) -->
+    <string name="reader_voice_paced">Voice</string>
+    <string name="reader_voice_paced_listening">Listening — read aloud</string>
+    <string name="reader_voice_paced_grant_mic">Allow microphone</string>
+    <string name="reader_voice_paced_preparing">Preparing voice model…</string>
+    <string name="reader_voice_paced_download">Download voice model</string>
     <!-- Reader / tap-to-define dictionary (#1230) -->
     <string name="reader_define_loading">Looking up \"%1$s\"…</string>
     <string name="reader_define_empty">No dictionary entry for \"%1$s\".</string>


### PR DESCRIPTION
## Voice-Paced Teleprompter — mic-driven scroll (#1368)

Lands **Phase 2** of the voice-paced teleprompter: the live microphone → on-device STT pipeline that makes the reader's chapter body follow the speaker's voice **hands-free**.

### Context — Phase 1 already existed
The brief assumed only `ForcedAligner` existed. In fact the entire **pure Phase-1 of #1291** was already built and unit-tested — `ForcedAligner`, `VoicePacedScroller` (char→scroll-px with pace + latency look-ahead), the `RecognizedWordSource` seam (+ `NoOp`), and `PcmDownsampler`. The `RecognizedWordSource` kdoc *explicitly named `MicCaptureProcessor` as the Phase-2 class to build* against that seam. So this PR **consumes** the existing pure pieces rather than duplicating them.

```
AudioRecord (16k mono PCM16) ─▶ SilenceGate ─▶ sherpa-onnx OnlineRecognizer
   ─▶ AsrWordExtractor ─▶ RecognizedWordSource.words
   ─▶ ForcedAligner.onWord ─▶ VoicePacedScrollController.positionChar
   ─▶ (reader) VoicePacedScroller ─▶ scroll.animateScrollTo
```

### What's here

**core-playback (engine)**
- **`MicCaptureProcessor : RecognizedWordSource`** — real `AudioRecord` capture on `Dispatchers.IO`, RMS silence-gating (skips decoding on a long pause — the CPU-hungry step), sherpa-onnx streaming ASR, emits `RecognizedWord(text, confidence)`. Confidence is derived from the recognizer's `ysProbs` (the per-token log-probs the aligner's low-confidence-hold was designed for). **Wired against the verified sherpa-onnx 1.13.3 API** (extracted from the resolved AAR via `javap` — not guessed).
- **`VoicePacedScrollController`** — `@Singleton` bridge: collects recognized words → `ForcedAligner` → publishes the speaker's **char offset**. Surface-agnostic (the reader, and a future Wear face, own the viewport→px mapping).
- **`AsrModelProvider`** — resolves / downloads the compact `streaming-zipformer-en-20M` model under `filesDir` (OkHttp loop mirroring `VoiceManager`; `.part`-then-rename; IO-pinned via `flowOn`).
- **Pure, tested helpers**: `AsrWordExtractor` (growing hypothesis → stable words), `SilenceGate` (VAD-lite), `AsrAudio` (RMS, PCM→float, `ysProbs`→confidence) — **3 new JUnit test classes** (the existing `ForcedAlignerTest`/`VoicePacedScrollerTest` already cover Phase 1).
- `PlaybackModule` binds `RecognizedWordSource` → `MicCaptureProcessor`.

**feature (reader UI)**
- `TeleprompterMode.VoicePaced` + a **3-way Auto / Practice / Voice** chip selector.
- `VoicePacedTransport` renders the gating state — **download model → allow mic → listening** — with an exit. `RECORD_AUDIO` requested on demand (mirrors the OCR camera flow #995); a denial drops back to auto-scroll.
- `LaunchedEffect` maps the live position → `animateScrollTo` (a manual drag preempts a frame, the next word resumes — same "peek then carry on" as auto-scroll).
- `ReaderViewModel` exposes voice state + start/stop/download; `resetTeleprompter` also stops the mic so it never captures after the reader closes.

**manifest**: `RECORD_AUDIO` (+ optional `microphone` feature), runtime-requested.

### Graceful degradation
Model not downloaded **or** `RECORD_AUDIO` denied → the feature falls back to the manual-WPM teleprompter. So **CI and fresh installs never regress** — voice-follow is purely additive.

### ⚠️ Needs on-device validation (Phase-2 follow-up)
Per the #1291 author's deliberate Phase-1/Phase-2 split, the live recognizer **cannot be validated blind**:
- the exact model URL / asset filenames (currently the upstream csukuangfj HuggingFace layout — may want repackaging onto a project release for flat URLs, as the Kitten TTS model was),
- recognizer latency + endpoint tuning,
- the `ysProbs` scale assumption (log-probs → geometric-mean confidence).

All of these are isolated and fail-safe (a wrong URL → `Failed` → fallback; over-gated confidence → frozen scroll, never a crash). The pure logic is fully unit-tested; this is the device-gated wiring.

### Notes
- `RECORD_AUDIO` also added by Luna's #1367 (recording mode) — trivial manifest conflict, resolve at merge.
- `ForcedAligner.kt` untouched (complete, #1291).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
