### PR TITLE
refactor(playback): extract VoiceEnginePlugin interface (#1372)

### DIFF
--- a/core-playback/src/main/kotlin/in/jphe/storyvox/playback/audiobook/AudiobookSynthesizer.kt
+++ b/core-playback/src/main/kotlin/in/jphe/storyvox/playback/audiobook/AudiobookSynthesizer.kt
@@ -11,6 +11,7 @@ import `in`.jphe.storyvox.playback.tts.SentenceChunker
 import `in`.jphe.storyvox.playback.tts.detectLocale
 import `in`.jphe.storyvox.playback.voice.EngineType
 import `in`.jphe.storyvox.playback.voice.UiVoiceInfo
+import `in`.jphe.storyvox.playback.voice.VoiceEngineRegistry
 import `in`.jphe.storyvox.playback.voice.VoiceManager
 import java.io.ByteArrayOutputStream
 import java.io.File
@@ -45,6 +46,9 @@ class AudiobookSynthesizer @Inject constructor(
     private val voiceManager: VoiceManager,
     private val engineMutex: EngineMutex,
     private val chunker: SentenceChunker,
+    // #1372 — synthesis + export-capability dispatch goes through the
+    // VoiceEnginePlugin registry instead of a per-engine `when` here.
+    private val voiceEngines: VoiceEngineRegistry,
 ) {
 
     /** Raised when the chosen voice can't be rendered offline by this path. */
@@ -74,19 +78,31 @@ class AudiobookSynthesizer @Inject constructor(
      * @throws EngineLoadException when the native load fails.
      */
     suspend fun loadVoice(voice: UiVoiceInfo) {
-        when (voice.engineType) {
-            is EngineType.Azure -> throw UnsupportedVoiceException(
-                "Azure voices need a network round-trip and can't be used for " +
-                    "offline audiobook export — pick a downloaded voice.",
-            )
-            is EngineType.SystemTts -> throw UnsupportedVoiceException(
-                "System (device) voices can't be exported to a file — pick a " +
-                    "downloaded Piper, Kokoro, Kitten or Supertonic voice.",
-            )
-            else -> Unit
+        // #1372 — the can-export decision is data-driven off the plugin's
+        // supportsExport rather than a hardcoded Azure/SystemTts `when`, so
+        // any future non-export engine is rejected here automatically. The
+        // friendly per-engine copy is preserved by exportUnsupportedReason.
+        val plugin = voiceEngines.forType(voice.engineType)
+        if (plugin == null || !plugin.supportsExport) {
+            throw UnsupportedVoiceException(exportUnsupportedReason(voice.engineType))
         }
         val result = engineMutex.mutex.withLock { loadModel(voice) }
         if (result != "Success") throw EngineLoadException("Voice failed to load: $result")
+    }
+
+    /** User-facing reason a voice can't be rendered offline. The decision
+     *  is made in [loadVoice] via [VoiceEnginePlugin.supportsExport]; this
+     *  only chooses the wording. */
+    private fun exportUnsupportedReason(type: EngineType): String = when (type) {
+        is EngineType.Azure ->
+            "Azure voices need a network round-trip and can't be used for " +
+                "offline audiobook export — pick a downloaded voice."
+        is EngineType.SystemTts ->
+            "System (device) voices can't be exported to a file — pick a " +
+                "downloaded Piper, Kokoro, Kitten or Supertonic voice."
+        else ->
+            "This voice can't be exported offline — pick a downloaded " +
+                "Piper, Kokoro, Kitten or Supertonic voice."
     }
 
     /**
@@ -158,14 +174,15 @@ class AudiobookSynthesizer @Inject constructor(
             is EngineType.SystemTts -> "Error: System TTS not supported for export"
         }
 
+    // #1372 — synthesis routes through the VoiceEnginePlugin registry.
+    // The plugin re-asserts the shared-model speaker from voice.engineType
+    // before each synth (the #1263-correct pattern), which also fixes a
+    // latent gap here: this path released and re-acquired engineMutex
+    // per sentence, so a concurrent ChapterRenderJob could leave the
+    // singleton on another speaker between sentences. Azure / System TTS
+    // plugins return null, exactly as the old `when` did.
     private fun generateAudioPCM(voice: UiVoiceInfo, text: String): ByteArray? =
-        when (voice.engineType) {
-            is EngineType.Kokoro -> KokoroEngine.getInstance().generateAudioPCM(text, 1.0f, 1.0f)
-            is EngineType.Kitten -> KittenEngine.getInstance().generateAudioPCM(text, 1.0f, 1.0f)
-            is EngineType.Supertonic -> SupertonicEngine.getInstance().generateAudioPCM(text, 1.0f, 1.0f)
-            is EngineType.Azure, is EngineType.SystemTts -> null
-            else -> VoiceEngine.getInstance().generateAudioPCM(text, 1.0f, 1.0f)
-        }
+        voiceEngines.forType(voice.engineType)?.generateAudioPCM(voice.engineType, text, 1.0f, 1.0f)
 
     /** A block of silence: 16-bit mono zero samples for [ms] milliseconds. */
     private fun silenceBytes(ms: Int, sampleRate: Int): ByteArray {

--- a/core-playback/src/main/kotlin/in/jphe/storyvox/playback/cache/ChapterRenderJob.kt
+++ b/core-playback/src/main/kotlin/in/jphe/storyvox/playback/cache/ChapterRenderJob.kt
@@ -26,6 +26,7 @@ import `in`.jphe.storyvox.playback.tts.detectLocale
 import `in`.jphe.storyvox.playback.tts.source.trailingPauseMs
 import `in`.jphe.storyvox.playback.voice.EngineType
 import `in`.jphe.storyvox.playback.voice.UiVoiceInfo
+import `in`.jphe.storyvox.playback.voice.VoiceEngineRegistry
 import `in`.jphe.storyvox.playback.voice.VoiceManager
 import java.io.File
 import kotlinx.coroutines.flow.first
@@ -88,6 +89,9 @@ class ChapterRenderJob @AssistedInject constructor(
     private val pcmCache: PcmCache,
     private val engineMutex: EngineMutex,
     private val chunker: SentenceChunker,
+    // #1372 — PCM synthesis dispatch goes through the VoiceEnginePlugin
+    // registry instead of a per-engine `when` here.
+    private val voiceEngines: VoiceEngineRegistry,
 ) : CoroutineWorker(appContext, params) {
 
     override suspend fun doWork(): Result {
@@ -329,35 +333,20 @@ class ChapterRenderJob @AssistedInject constructor(
             else -> VoiceEngine.getInstance().sampleRate
         }.takeIf { it > 0 } ?: DEFAULT_SAMPLE_RATE_HZ
 
+    // #1372 — synthesis routes through the VoiceEnginePlugin registry.
+    // The plugin owns the #1263 speaker re-assertion: shared-model engines
+    // (Kokoro / Kitten / Supertonic) re-assert OUR speaker from
+    // voice.engineType before each synth — these are process-wide
+    // singletons the foreground EnginePlayer mutates per sentence, so a
+    // prerender that set its speaker only once at loadModel would render
+    // later sentences in the foreground's voice. Atomic with the generate
+    // under the caller's engineMutex.withLock (see doWork);
+    // setActiveSpeakerId is a cheap reload-free index flip. Piper is
+    // per-voice (no shared speaker state) so its plugin ignores the type.
+    // Azure / System TTS are pre-filtered before this point (see doWork)
+    // and their plugins return null regardless.
     private fun generateAudioPCM(voice: UiVoiceInfo, text: String): ByteArray? =
-        when (voice.engineType) {
-            // Issue #1263 — re-assert OUR speaker before each synth. These
-            // engines are process-wide shared-model singletons: the foreground
-            // EnginePlayer now mutates the active speaker per sentence (its own
-            // #1263 fix), so a prerender that set its speaker only once at
-            // loadModel would render later sentences in the foreground's voice.
-            // Atomic with the generate under the caller's engineMutex.withLock
-            // (see doWork); setActiveSpeakerId is a cheap reload-free index flip.
-            is EngineType.Kokoro -> {
-                KokoroEngine.getInstance()
-                    .setActiveSpeakerId((voice.engineType as EngineType.Kokoro).speakerId)
-                KokoroEngine.getInstance().generateAudioPCM(text, 1.0f, 1.0f)
-            }
-            is EngineType.Kitten -> {
-                KittenEngine.getInstance()
-                    .setActiveSpeakerId((voice.engineType as EngineType.Kitten).speakerId)
-                KittenEngine.getInstance().generateAudioPCM(text, 1.0f, 1.0f)
-            }
-            is EngineType.Supertonic -> {
-                SupertonicEngine.getInstance()
-                    .setActiveSpeakerId((voice.engineType as EngineType.Supertonic).speakerId)
-                SupertonicEngine.getInstance().generateAudioPCM(text, 1.0f, 1.0f)
-            }
-            // Piper is per-voice (not a shared multi-speaker singleton) — no
-            // active-speaker state to re-assert.
-            else -> VoiceEngine.getInstance()
-                .generateAudioPCM(text, 1.0f, 1.0f)
-        }
+        voiceEngines.forType(voice.engineType)?.generateAudioPCM(voice.engineType, text, 1.0f, 1.0f)
 
     // ── foreground notification ─────────────────────────────────────────
 

--- a/core-playback/src/main/kotlin/in/jphe/storyvox/playback/di/VoiceEnginePluginModule.kt
+++ b/core-playback/src/main/kotlin/in/jphe/storyvox/playback/di/VoiceEnginePluginModule.kt
@@ -1,0 +1,67 @@
+package `in`.jphe.storyvox.playback.di
+
+import dagger.Binds
+import dagger.Module
+import dagger.hilt.InstallIn
+import dagger.hilt.components.SingletonComponent
+import dagger.multibindings.IntoMap
+import dagger.multibindings.StringKey
+import `in`.jphe.storyvox.playback.voice.VoiceEnginePlugin
+import `in`.jphe.storyvox.playback.voice.VoiceFamilyIds
+import `in`.jphe.storyvox.playback.voice.engines.AzureEnginePlugin
+import `in`.jphe.storyvox.playback.voice.engines.KittenEnginePlugin
+import `in`.jphe.storyvox.playback.voice.engines.KokoroEnginePlugin
+import `in`.jphe.storyvox.playback.voice.engines.PiperEnginePlugin
+import `in`.jphe.storyvox.playback.voice.engines.SupertonicEnginePlugin
+import `in`.jphe.storyvox.playback.voice.engines.SystemTtsEnginePlugin
+
+/**
+ * Issue #1372 — binds every [VoiceEnginePlugin] into the
+ * `Map<String, VoiceEnginePlugin>` multibinding that
+ * `VoiceEngineRegistry` consumes, keyed by [VoiceEnginePlugin.engineId]
+ * (a [VoiceFamilyIds] constant).
+ *
+ * Adding an engine = a new plugin class + one `@Binds @IntoMap
+ * @StringKey(...)` line here. No `when (engineType)` arm to grow, which
+ * is the whole point of the seam. Mirrors `SourcePluginModule`, except
+ * the `@SourcePlugin` set is KSP-generated whereas these six engines
+ * are bound by hand (they're in-tree, not annotation-discovered).
+ *
+ * No `@Multibinds` default is needed: this module always contributes
+ * six entries, so the map is never empty in any build that links
+ * `:core-playback`.
+ */
+@Module
+@InstallIn(SingletonComponent::class)
+abstract class VoiceEnginePluginModule {
+
+    @Binds
+    @IntoMap
+    @StringKey(VoiceFamilyIds.PIPER)
+    abstract fun bindPiper(impl: PiperEnginePlugin): VoiceEnginePlugin
+
+    @Binds
+    @IntoMap
+    @StringKey(VoiceFamilyIds.KOKORO)
+    abstract fun bindKokoro(impl: KokoroEnginePlugin): VoiceEnginePlugin
+
+    @Binds
+    @IntoMap
+    @StringKey(VoiceFamilyIds.KITTEN)
+    abstract fun bindKitten(impl: KittenEnginePlugin): VoiceEnginePlugin
+
+    @Binds
+    @IntoMap
+    @StringKey(VoiceFamilyIds.SUPERTONIC)
+    abstract fun bindSupertonic(impl: SupertonicEnginePlugin): VoiceEnginePlugin
+
+    @Binds
+    @IntoMap
+    @StringKey(VoiceFamilyIds.AZURE)
+    abstract fun bindAzure(impl: AzureEnginePlugin): VoiceEnginePlugin
+
+    @Binds
+    @IntoMap
+    @StringKey(VoiceFamilyIds.SYSTEM_TTS)
+    abstract fun bindSystemTts(impl: SystemTtsEnginePlugin): VoiceEnginePlugin
+}

--- a/core-playback/src/main/kotlin/in/jphe/storyvox/playback/voice/VoiceCatalog.kt
+++ b/core-playback/src/main/kotlin/in/jphe/storyvox/playback/voice/VoiceCatalog.kt
@@ -115,7 +115,11 @@ object VoiceCatalog {
         "piper_cori_en_GB_medium",
         "piper_cori_en_GB_high",
     )
-    private fun piperEntries(): List<CatalogEntry> = listOf(
+    // #1372 — `internal` (was `private`) so each in-process
+    // `VoiceEnginePlugin.catalogEntries()` can delegate here; the union
+    // across plugins reproduces [voices]. Still the single source of the
+    // static roster — [voices] composes these in display order.
+    internal fun piperEntries(): List<CatalogEntry> = listOf(
         CatalogEntry(
             id = "piper_lessac_en_US_high",
             displayName = "Lessac",
@@ -718,7 +722,7 @@ object VoiceCatalog {
      *  title as `<flag> <displayName>` and the subtitle as
      *  `<Engine> · <Tier> · <Gender>`. Language is already represented by
      *  the rendered flag, so we don't repeat it. */
-    private fun kokoroEntries(): List<CatalogEntry> {
+    internal fun kokoroEntries(): List<CatalogEntry> {
         fun kokoro(id: String, displayName: String, language: String, speakerId: Int, gender: VoiceGender): CatalogEntry =
             CatalogEntry(
                 id = id,
@@ -809,7 +813,7 @@ object VoiceCatalog {
      *  picker's group-by-engine ordering will surface Kitten beneath
      *  Piper / above Kokoro per the VoiceLibraryViewModel engine-sort
      *  rule. */
-    private fun kittenEntries(): List<CatalogEntry> {
+    internal fun kittenEntries(): List<CatalogEntry> {
         fun kitten(id: String, displayName: String, speakerId: Int, gender: VoiceGender): CatalogEntry =
             CatalogEntry(
                 id = id,
@@ -860,7 +864,7 @@ object VoiceCatalog {
      * all 10 speakers share one download, so a per-voice byte count is
      * misleading and the Voice Library suppresses the size chip when it's 0.
      */
-    private fun supertonicEntries(): List<CatalogEntry> {
+    internal fun supertonicEntries(): List<CatalogEntry> {
         fun supertonic(id: String, displayName: String, speakerId: Int, gender: VoiceGender): CatalogEntry =
             CatalogEntry(
                 id = id,

--- a/core-playback/src/main/kotlin/in/jphe/storyvox/playback/voice/VoiceEnginePlugin.kt
+++ b/core-playback/src/main/kotlin/in/jphe/storyvox/playback/voice/VoiceEnginePlugin.kt
@@ -1,0 +1,116 @@
+package `in`.jphe.storyvox.playback.voice
+
+/**
+ * Issue #1372 — plugin contract for a TTS voice engine.
+ *
+ * Adding a new TTS engine used to mean touching ~10 files, each with a
+ * `when (engineType)` arm that grew a new branch
+ * (`EnginePlayer`, `AudiobookSynthesizer`, `ChapterRenderJob`,
+ * `EngineSampleRateCache`, `VoiceManager`, `VoiceCatalog`,
+ * `VoiceFamilyRegistry`, …). This interface inverts that: each engine
+ * owns its own behaviour (which [EngineType] it [handles], its
+ * [sampleRate], whether it [supportsExport], how it synthesises, the
+ * voices it contributes to the catalog, and its family card) so a new
+ * engine becomes a self-contained class plus one Hilt binding rather
+ * than a sweep of edits.
+ *
+ * Implementations are wired into [VoiceEngineRegistry] via a Hilt
+ * `@IntoMap` multibinding keyed by [engineId] (mirrors
+ * `SourcePluginRegistry`'s `@SourcePlugin` seam). Call sites resolve a
+ * plugin with [VoiceEngineRegistry.forType] / [VoiceEngineRegistry.byId]
+ * and dispatch through it instead of re-deriving the `when`.
+ *
+ * ## Naming
+ *
+ * Deliberately **not** named `VoiceEngine`: three classes already own
+ * that shape — the vendor `com.CodeBySonu.VoxSherpa.VoiceEngine` (the
+ * Piper engine), `in.jphe.storyvox.source.azure.AzureVoiceEngine`, and
+ * [`in`.jphe.storyvox.playback.tts.SystemTtsEngine]. The `…Plugin`
+ * suffix reuses the codebase's existing plugin-seam vocabulary
+ * (`SourcePlugin`, `SourcePluginRegistry`, `SourcePluginDescriptor`)
+ * and sidesteps all three collisions.
+ *
+ * ## What this contract intentionally does NOT cover (yet)
+ *
+ * - **`loadModel`** — the four in-process engines have divergent load
+ *   signatures (Piper: onnx + tokens; Kokoro/Kitten: onnx + tokens +
+ *   voices.bin; Supertonic: a shared dir) and need `VoiceManager` for
+ *   on-disk paths. Folding that in means injecting `VoiceManager` +
+ *   `Context` into the plugins, which is the natural next PR. For now
+ *   the load `when` stays in `AudiobookSynthesizer` / `ChapterRenderJob`.
+ * - **Streaming / secondary engines** — `EnginePlayer`'s parallel-synth
+ *   streaming path (`secondaryKokoroEngines`, `EngineStreamingSource`,
+ *   per-engine handles) is a separate architecture, not a simple
+ *   `generateAudioPCM`. It keeps its own dispatch.
+ * - **A `suspend synthesize`** — synthesis must be serialised through
+ *   `EngineMutex` and sequenced after a `loadModel`; a context-free
+ *   suspend entry point would bypass that and corrupt the shared
+ *   singletons. Callers already guard [generateAudioPCM] with
+ *   `EngineMutex.withLock`, so the plugin exposes only that synchronous
+ *   surface.
+ */
+interface VoiceEnginePlugin {
+
+    /**
+     * Stable engine key. Equals the owning family id in
+     * [VoiceFamilyIds] (engine ⇄ family is 1:1 today), and is the
+     * `@StringKey` this plugin is bound under in [VoiceEngineRegistry].
+     */
+    val engineId: String
+
+    /**
+     * PCM sample rate (Hz) this engine outputs.
+     *
+     * For the in-process model engines this reads the lock-free
+     * [`in`.jphe.storyvox.playback.EngineSampleRateCache] (the #582
+     * ANR-safe path) rather than touching the native engine monitor.
+     * Cloud / system engines report a nominal default — their real
+     * rate comes from the live engine instance in `EnginePlayer`, which
+     * this contract does not yet own.
+     */
+    val sampleRate: Int
+
+    /**
+     * Whether this engine can render to a file for offline audiobook
+     * export. The in-process model engines (Piper / Kokoro / Kitten /
+     * Supertonic) are `true`; cloud (Azure) and framework (System TTS)
+     * engines are `false` and are rejected by the export path.
+     */
+    val supportsExport: Boolean
+
+    /** True when this plugin owns [type]. Keeps the `is EngineType.X`
+     *  discrimination inside the engine instead of a central `when`. */
+    fun handles(type: EngineType): Boolean
+
+    /**
+     * Synthesise [text] to one 16-bit-mono-LE PCM buffer at
+     * [sampleRate], or `null` when this engine can't render synchronously
+     * (Azure / System TTS). [type] carries the per-voice selection
+     * (e.g. the Kokoro/Kitten/Supertonic `speakerId`): shared-model
+     * engines re-assert their active speaker from it before synth, the
+     * #1263-correct behaviour, since the singleton may have been left on
+     * another speaker by a concurrent render/playback.
+     *
+     * Callers MUST hold `EngineMutex.mutex` across [type]-matched
+     * loadModel + this call (see `AudiobookSynthesizer` / `ChapterRenderJob`).
+     */
+    fun generateAudioPCM(
+        type: EngineType,
+        text: String,
+        speed: Float = 1f,
+        pitch: Float = 1f,
+    ): ByteArray?
+
+    /**
+     * Static catalog voices this engine contributes — the in-process
+     * model engines return their bundled roster; engines whose voices
+     * are discovered at runtime from a live roster (Azure, System TTS)
+     * return an empty list here and project rows through their roster
+     * path instead. The union across all plugins reproduces
+     * [VoiceCatalog.voices].
+     */
+    fun catalogEntries(): List<CatalogEntry>
+
+    /** The Plugin Manager family card for this engine. */
+    fun familyDescriptor(): VoiceFamilyDescriptor
+}

--- a/core-playback/src/main/kotlin/in/jphe/storyvox/playback/voice/VoiceEngineRegistry.kt
+++ b/core-playback/src/main/kotlin/in/jphe/storyvox/playback/voice/VoiceEngineRegistry.kt
@@ -1,0 +1,75 @@
+package `in`.jphe.storyvox.playback.voice
+
+import javax.inject.Inject
+import javax.inject.Singleton
+
+/**
+ * Issue #1372 — runtime registry of every [VoiceEnginePlugin].
+ *
+ * Singleton. Hilt injects the `Map<String, VoiceEnginePlugin>`
+ * multibinding populated by the `@Binds @IntoMap @StringKey(...)`
+ * factories in `VoiceEnginePluginModule` (one per engine, keyed by
+ * [VoiceEnginePlugin.engineId]). Call sites that used to grow a
+ * `when (engineType)` arm per engine instead ask the registry —
+ * [forType] to dispatch by [EngineType], [byId] for the family key —
+ * so a new engine is a new plugin class + one binding, touching no
+ * existing dispatch site.
+ *
+ * Mirrors `SourcePluginRegistry` (the `@SourcePlugin` seam): same
+ * `@Inject`-but-not-`internal` constructor so a `:core-playback` unit
+ * test can build one directly from a `Map<String, VoiceEnginePlugin>`
+ * of real or fake plugins without standing up Hilt.
+ */
+@Singleton
+class VoiceEngineRegistry @Inject constructor(
+    private val plugins: Map<String, @JvmSuppressWildcards VoiceEnginePlugin>,
+) {
+
+    init {
+        // Fail fast at graph build if a plugin's declared engineId
+        // disagrees with the @StringKey it was bound under — the map
+        // key is what byId() looks up, the engineId is what plugins
+        // self-report (and what forType() round-trips through), so a
+        // mismatch would make byId(plugin.engineId) silently miss.
+        val mismatched = plugins.entries.filter { (key, plugin) -> key != plugin.engineId }
+        if (mismatched.isNotEmpty()) {
+            val detail = mismatched.joinToString("; ") { (key, plugin) ->
+                "bound as '$key' but engineId='${plugin.engineId}' (${plugin::class.simpleName})"
+            }
+            error(
+                "VoiceEngineRegistry: @StringKey / engineId mismatch — $detail. " +
+                    "Bind each VoiceEnginePlugin under @StringKey(<its engineId>).",
+            )
+        }
+    }
+
+    /** The plugin owning [type], or null if no registered engine
+     *  handles it. Dispatch entry point that replaces a
+     *  `when (engineType)`. */
+    fun forType(type: EngineType): VoiceEnginePlugin? =
+        plugins.values.firstOrNull { it.handles(type) }
+
+    /** The plugin registered under [engineId] (a [VoiceFamilyIds]
+     *  constant), or null. */
+    fun byId(engineId: String): VoiceEnginePlugin? = plugins[engineId]
+
+    /** Every registered plugin. Iteration order is unspecified (Hilt
+     *  map order); sort by [VoiceEnginePlugin.engineId] at call sites
+     *  that need determinism. */
+    fun all(): Collection<VoiceEnginePlugin> = plugins.values
+
+    /**
+     * The union of every plugin's static [VoiceEnginePlugin.catalogEntries].
+     * Reproduces the set of [VoiceCatalog.voices] (the in-process model
+     * engines contribute their rosters; Azure / System TTS contribute
+     * nothing static). Order is unspecified — sort if a consumer needs
+     * a stable order.
+     */
+    fun allCatalogEntries(): List<CatalogEntry> = plugins.values.flatMap { it.catalogEntries() }
+
+    /** Each registered engine's family descriptor. Does NOT include the
+     *  non-engine "VoxSherpa upstreams" placeholder — that stays owned
+     *  by [VoiceFamilyRegistry]. Order is unspecified. */
+    fun allFamilyDescriptors(): List<VoiceFamilyDescriptor> =
+        plugins.values.map { it.familyDescriptor() }
+}

--- a/core-playback/src/main/kotlin/in/jphe/storyvox/playback/voice/VoiceFamilyDescriptors.kt
+++ b/core-playback/src/main/kotlin/in/jphe/storyvox/playback/voice/VoiceFamilyDescriptors.kt
@@ -1,0 +1,111 @@
+package `in`.jphe.storyvox.playback.voice
+
+/**
+ * Issue #1372 — the canonical [VoiceFamilyDescriptor] literals, lifted
+ * out of [VoiceFamilyRegistry] so they have a single home.
+ *
+ * Both [VoiceFamilyRegistry.descriptors] (the curated, ordered list the
+ * Plugin Manager renders) and each `VoiceEnginePlugin.familyDescriptor()`
+ * reference these constants, so the family metadata can't drift between
+ * the two surfaces. Extracting them is behaviour-preserving: the
+ * registry list is rebuilt from exactly these objects in the same order.
+ *
+ * The `displayName` / `description` / `sizeHint` copy is unchanged from
+ * the pre-#1372 inline literals — `VoiceFamilyRegistryTest` pins the id
+ * set, count, and placeholder behaviour.
+ */
+object VoiceFamilyDescriptors {
+
+    /** Issue #676 — Android System TTS, the zero-download first-launch tier. */
+    val SYSTEM_TTS = VoiceFamilyDescriptor(
+        id = VoiceFamilyIds.SYSTEM_TTS,
+        displayName = "System TTS",
+        description = "Uses your device's built-in voice — no download needed",
+        sourceUrl = "https://developer.android.com/reference/android/speech/tts/TextToSpeech",
+        license = "Bundled with Android — varies by engine (Google / Samsung / eSpeak / etc.)",
+        sizeHint = "0 MB — synthesis happens via Android's TextToSpeech framework",
+        defaultEnabled = true,
+        // The OS engine runs locally (no network for Google's
+        // offline voices, no network for Samsung TTS), so we
+        // classify Local. A handful of Google network-tier voices
+        // do require connectivity; future work could split tier
+        // chips per-voice — keep this Local for now so the family
+        // card reads honestly about the common case.
+        engineFamily = VoiceEngineFamily.Local,
+    )
+
+    val PIPER = VoiceFamilyDescriptor(
+        id = VoiceFamilyIds.PIPER,
+        displayName = "Piper",
+        description = "Local neural voices · per-voice ONNX download",
+        sourceUrl = "https://github.com/rhasspy/piper-voices",
+        license = "MIT (sherpa-onnx) · CC-BY / CC0 voice datasets",
+        sizeHint = "~14–30 MB per voice (low / medium tier), ~120 MB high tier",
+        defaultEnabled = true,
+        engineFamily = VoiceEngineFamily.Local,
+    )
+
+    val KOKORO = VoiceFamilyDescriptor(
+        id = VoiceFamilyIds.KOKORO,
+        displayName = "Kokoro",
+        description = "Local multi-speaker · one shared ~330 MB model",
+        sourceUrl = "https://huggingface.co/hexgrad/Kokoro-82M",
+        license = "Apache 2.0",
+        sizeHint = "~330 MB single download, 53 speakers share the model",
+        defaultEnabled = true,
+        engineFamily = VoiceEngineFamily.Local,
+    )
+
+    val KITTEN = VoiceFamilyDescriptor(
+        id = VoiceFamilyIds.KITTEN,
+        displayName = "KittenTTS",
+        description = "Local lightweight · ~25 MB shared, 8 en_US speakers",
+        sourceUrl = "https://github.com/KittenML/KittenTTS",
+        license = "Apache 2.0",
+        sizeHint = "~25 MB shared model, 8 en_US speakers (Bella, Luna, Rosie, Kiki / Jasper, Bruno, Hugo, Leo)",
+        defaultEnabled = true,
+        engineFamily = VoiceEngineFamily.Local,
+    )
+
+    /** Issue #1114 / #1236 — Supertonic 3. Gated on [VoiceCatalog.SUPERTONIC_ENABLED]
+     *  by [VoiceFamilyRegistry] (and by the catalog), so one flag re-gates
+     *  both the family card and the voices. */
+    val SUPERTONIC = VoiceFamilyDescriptor(
+        id = VoiceFamilyIds.SUPERTONIC,
+        displayName = "Supertonic 3",
+        description = "Local high-quality · shared model, 10 en_US speakers",
+        sourceUrl = "https://github.com/k2-fsa/sherpa-onnx",
+        license = "Apache 2.0",
+        sizeHint = "~TBD MB shared model, 10 en_US speakers (F1–F5 / M1–M5)",
+        defaultEnabled = true,
+        engineFamily = VoiceEngineFamily.Local,
+    )
+
+    val AZURE = VoiceFamilyDescriptor(
+        id = VoiceFamilyIds.AZURE,
+        displayName = "Azure HD voices",
+        description = "Cloud · BYOK · Dragon HD + Multilingual + Neural tiers",
+        sourceUrl = "https://learn.microsoft.com/en-us/azure/ai-services/speech-service/language-support",
+        license = "Proprietary · billed by Azure ($30 / 1M chars)",
+        sizeHint = "0 MB local — synthesis happens server-side",
+        requiresConfiguration = true,
+        // Default OFF so a fresh install doesn't pretend to have Azure
+        // voices ready; the user opts in by configuring credentials.
+        defaultEnabled = false,
+        engineFamily = VoiceEngineFamily.Cloud,
+    )
+
+    /** Not an engine — the muted "next thing that lands here" card.
+     *  Stays owned by [VoiceFamilyRegistry], never a `VoiceEnginePlugin`. */
+    val VOXSHERPA_PLACEHOLDER = VoiceFamilyDescriptor(
+        id = VoiceFamilyIds.VOXSHERPA_UPSTREAMS,
+        displayName = "VoxSherpa upstreams",
+        description = "Placeholder for future engine-lib voice families",
+        sourceUrl = "https://github.com/techempower-org/VoxSherpa-TTS",
+        license = "—",
+        sizeHint = "—",
+        isPlaceholder = true,
+        defaultEnabled = false,
+        engineFamily = VoiceEngineFamily.Local,
+    )
+}

--- a/core-playback/src/main/kotlin/in/jphe/storyvox/playback/voice/VoiceFamilyRegistry.kt
+++ b/core-playback/src/main/kotlin/in/jphe/storyvox/playback/voice/VoiceFamilyRegistry.kt
@@ -109,95 +109,22 @@ class VoiceFamilyRegistry @Inject constructor() {
      *  (#1236 flipped [VoiceCatalog.SUPERTONIC_ENABLED] to true), so
      *  [listOfNotNull] keeps it and a shipped build shows seven
      *  descriptors. The flag stays as the single re-gate point. */
+    // #1372 — the literals now live in [VoiceFamilyDescriptors] so the
+    // family cards and each `VoiceEnginePlugin.familyDescriptor()` share
+    // one source of truth. This list keeps the curated display order
+    // (System TTS first as the zero-download tier; then the in-process
+    // neural families; then cloud; then the placeholder) and the
+    // [VoiceCatalog.SUPERTONIC_ENABLED] gate, so the rendered output is
+    // unchanged. listOfNotNull drops Supertonic if the flag is ever
+    // flipped back, re-gating the card and the voices together.
     val descriptors: List<VoiceFamilyDescriptor> = listOfNotNull(
-        VoiceFamilyDescriptor(
-            id = VoiceFamilyIds.SYSTEM_TTS,
-            displayName = "System TTS",
-            description = "Uses your device's built-in voice — no download needed",
-            sourceUrl = "https://developer.android.com/reference/android/speech/tts/TextToSpeech",
-            license = "Bundled with Android — varies by engine (Google / Samsung / eSpeak / etc.)",
-            sizeHint = "0 MB — synthesis happens via Android's TextToSpeech framework",
-            defaultEnabled = true,
-            // The OS engine runs locally (no network for Google's
-            // offline voices, no network for Samsung TTS), so we
-            // classify Local. A handful of Google network-tier voices
-            // do require connectivity; future work could split tier
-            // chips per-voice — keep this Local for now so the family
-            // card reads honestly about the common case.
-            engineFamily = VoiceEngineFamily.Local,
-        ),
-        VoiceFamilyDescriptor(
-            id = VoiceFamilyIds.PIPER,
-            displayName = "Piper",
-            description = "Local neural voices · per-voice ONNX download",
-            sourceUrl = "https://github.com/rhasspy/piper-voices",
-            license = "MIT (sherpa-onnx) · CC-BY / CC0 voice datasets",
-            sizeHint = "~14–30 MB per voice (low / medium tier), ~120 MB high tier",
-            defaultEnabled = true,
-            engineFamily = VoiceEngineFamily.Local,
-        ),
-        VoiceFamilyDescriptor(
-            id = VoiceFamilyIds.KOKORO,
-            displayName = "Kokoro",
-            description = "Local multi-speaker · one shared ~330 MB model",
-            sourceUrl = "https://huggingface.co/hexgrad/Kokoro-82M",
-            license = "Apache 2.0",
-            sizeHint = "~330 MB single download, 53 speakers share the model",
-            defaultEnabled = true,
-            engineFamily = VoiceEngineFamily.Local,
-        ),
-        VoiceFamilyDescriptor(
-            id = VoiceFamilyIds.KITTEN,
-            displayName = "KittenTTS",
-            description = "Local lightweight · ~25 MB shared, 8 en_US speakers",
-            sourceUrl = "https://github.com/KittenML/KittenTTS",
-            license = "Apache 2.0",
-            sizeHint = "~25 MB shared model, 8 en_US speakers (Bella, Luna, Rosie, Kiki / Jasper, Bruno, Hugo, Leo)",
-            defaultEnabled = true,
-            engineFamily = VoiceEngineFamily.Local,
-        ),
-        // The Supertonic family card ships now that the engine has landed
-        // (#1236 set [VoiceCatalog.SUPERTONIC_ENABLED] = true), sharing the
-        // flag with the voices. listOfNotNull would drop this entry if the
-        // flag were ever flipped back, so one toggle re-gates both surfaces.
-        if (VoiceCatalog.SUPERTONIC_ENABLED) {
-            VoiceFamilyDescriptor(
-                id = VoiceFamilyIds.SUPERTONIC,
-                displayName = "Supertonic 3",
-                description = "Local high-quality · shared model, 10 en_US speakers",
-                sourceUrl = "https://github.com/k2-fsa/sherpa-onnx",
-                license = "Apache 2.0",
-                sizeHint = "~TBD MB shared model, 10 en_US speakers (F1–F5 / M1–M5)",
-                defaultEnabled = true,
-                engineFamily = VoiceEngineFamily.Local,
-            )
-        } else {
-            null
-        },
-        VoiceFamilyDescriptor(
-            id = VoiceFamilyIds.AZURE,
-            displayName = "Azure HD voices",
-            description = "Cloud · BYOK · Dragon HD + Multilingual + Neural tiers",
-            sourceUrl = "https://learn.microsoft.com/en-us/azure/ai-services/speech-service/language-support",
-            license = "Proprietary · billed by Azure ($30 / 1M chars)",
-            sizeHint = "0 MB local — synthesis happens server-side",
-            requiresConfiguration = true,
-            // Default OFF so a fresh install doesn't pretend to have Azure
-            // voices ready; the user opts in by configuring credentials.
-            defaultEnabled = false,
-            engineFamily = VoiceEngineFamily.Cloud,
-        ),
-        VoiceFamilyDescriptor(
-            id = VoiceFamilyIds.VOXSHERPA_UPSTREAMS,
-            displayName = "VoxSherpa upstreams",
-            description = "Placeholder for future engine-lib voice families",
-            sourceUrl = "https://github.com/techempower-org/VoxSherpa-TTS",
-            license = "—",
-            sizeHint = "—",
-            isPlaceholder = true,
-            defaultEnabled = false,
-            engineFamily = VoiceEngineFamily.Local,
-        ),
+        VoiceFamilyDescriptors.SYSTEM_TTS,
+        VoiceFamilyDescriptors.PIPER,
+        VoiceFamilyDescriptors.KOKORO,
+        VoiceFamilyDescriptors.KITTEN,
+        if (VoiceCatalog.SUPERTONIC_ENABLED) VoiceFamilyDescriptors.SUPERTONIC else null,
+        VoiceFamilyDescriptors.AZURE,
+        VoiceFamilyDescriptors.VOXSHERPA_PLACEHOLDER,
     )
 
     /** Lookup by stable family id. */

--- a/core-playback/src/main/kotlin/in/jphe/storyvox/playback/voice/engines/AzureEnginePlugin.kt
+++ b/core-playback/src/main/kotlin/in/jphe/storyvox/playback/voice/engines/AzureEnginePlugin.kt
@@ -1,0 +1,63 @@
+package `in`.jphe.storyvox.playback.voice.engines
+
+import `in`.jphe.storyvox.playback.voice.CatalogEntry
+import `in`.jphe.storyvox.playback.voice.EngineType
+import `in`.jphe.storyvox.playback.voice.VoiceEnginePlugin
+import `in`.jphe.storyvox.playback.voice.VoiceFamilyDescriptor
+import `in`.jphe.storyvox.playback.voice.VoiceFamilyDescriptors
+import `in`.jphe.storyvox.playback.voice.VoiceFamilyIds
+import javax.inject.Inject
+import javax.inject.Singleton
+
+/**
+ * Issue #1372 — [VoiceEnginePlugin] for Azure HD cloud voices.
+ *
+ * Azure is fundamentally different from the in-process model engines:
+ * synthesis is an async HTTPS round-trip handled by
+ * `in.jphe.storyvox.source.azure.AzureVoiceEngine` inside `EnginePlayer`,
+ * not a synchronous local generate. So this plugin reports the
+ * non-synthesising surface:
+ *
+ * - [supportsExport] is `false` — export is offline-first; Azure needs
+ *   the network and is rejected by the export path.
+ * - [generateAudioPCM] returns `null` — there is no synchronous PCM
+ *   path; the streaming network synth in `EnginePlayer` is out of scope
+ *   for this contract (see [VoiceEnginePlugin]).
+ * - [catalogEntries] is empty — Azure voices are discovered at runtime
+ *   from the live region roster (`VoiceCatalog.azureEntriesFromRoster`),
+ *   not from the static catalog.
+ * - [sampleRate] is a nominal default; the authoritative rate comes
+ *   from the live `AzureVoiceEngine` instance, which this plugin
+ *   deliberately does not inject (keeping every plugin dependency-free
+ *   sidesteps the Dagger-cycle risk the source/settings seam has hit
+ *   before).
+ */
+@Singleton
+class AzureEnginePlugin @Inject constructor() : VoiceEnginePlugin {
+
+    override val engineId: String = VoiceFamilyIds.AZURE
+
+    /** Nominal — Azure Neural / HD voices stream at 24 kHz by default.
+     *  The real per-request rate is owned by the live AzureVoiceEngine
+     *  in EnginePlayer; nothing consumes this plugin's value yet. */
+    override val sampleRate: Int = NOMINAL_AZURE_SAMPLE_RATE
+
+    override val supportsExport: Boolean = false
+
+    override fun handles(type: EngineType): Boolean = type is EngineType.Azure
+
+    override fun generateAudioPCM(
+        type: EngineType,
+        text: String,
+        speed: Float,
+        pitch: Float,
+    ): ByteArray? = null
+
+    override fun catalogEntries(): List<CatalogEntry> = emptyList()
+
+    override fun familyDescriptor(): VoiceFamilyDescriptor = VoiceFamilyDescriptors.AZURE
+
+    private companion object {
+        const val NOMINAL_AZURE_SAMPLE_RATE = 24_000
+    }
+}

--- a/core-playback/src/main/kotlin/in/jphe/storyvox/playback/voice/engines/KittenEnginePlugin.kt
+++ b/core-playback/src/main/kotlin/in/jphe/storyvox/playback/voice/engines/KittenEnginePlugin.kt
@@ -1,0 +1,48 @@
+package `in`.jphe.storyvox.playback.voice.engines
+
+import com.CodeBySonu.VoxSherpa.KittenEngine
+import `in`.jphe.storyvox.playback.EngineSampleRateCache
+import `in`.jphe.storyvox.playback.voice.CatalogEntry
+import `in`.jphe.storyvox.playback.voice.EngineType
+import `in`.jphe.storyvox.playback.voice.VoiceCatalog
+import `in`.jphe.storyvox.playback.voice.VoiceEnginePlugin
+import `in`.jphe.storyvox.playback.voice.VoiceFamilyDescriptor
+import `in`.jphe.storyvox.playback.voice.VoiceFamilyDescriptors
+import `in`.jphe.storyvox.playback.voice.VoiceFamilyIds
+import javax.inject.Inject
+import javax.inject.Singleton
+
+/**
+ * Issue #1372 — [VoiceEnginePlugin] for KittenTTS, wrapping the vendor
+ * `com.CodeBySonu.VoxSherpa.KittenEngine` singleton.
+ *
+ * Shared multi-speaker model (a twin of Kokoro): [generateAudioPCM]
+ * re-asserts the speaker from [EngineType.Kitten.speakerId] before each
+ * synth (the #1263-correct pattern).
+ */
+@Singleton
+class KittenEnginePlugin @Inject constructor() : VoiceEnginePlugin {
+
+    override val engineId: String = VoiceFamilyIds.KITTEN
+
+    override val sampleRate: Int get() = EngineSampleRateCache.kittenRate()
+
+    override val supportsExport: Boolean = true
+
+    override fun handles(type: EngineType): Boolean = type is EngineType.Kitten
+
+    override fun generateAudioPCM(
+        type: EngineType,
+        text: String,
+        speed: Float,
+        pitch: Float,
+    ): ByteArray? {
+        val speakerId = (type as? EngineType.Kitten)?.speakerId ?: return null
+        KittenEngine.getInstance().setActiveSpeakerId(speakerId)
+        return KittenEngine.getInstance().generateAudioPCM(text, speed, pitch)
+    }
+
+    override fun catalogEntries(): List<CatalogEntry> = VoiceCatalog.kittenEntries()
+
+    override fun familyDescriptor(): VoiceFamilyDescriptor = VoiceFamilyDescriptors.KITTEN
+}

--- a/core-playback/src/main/kotlin/in/jphe/storyvox/playback/voice/engines/KokoroEnginePlugin.kt
+++ b/core-playback/src/main/kotlin/in/jphe/storyvox/playback/voice/engines/KokoroEnginePlugin.kt
@@ -1,0 +1,50 @@
+package `in`.jphe.storyvox.playback.voice.engines
+
+import com.CodeBySonu.VoxSherpa.KokoroEngine
+import `in`.jphe.storyvox.playback.EngineSampleRateCache
+import `in`.jphe.storyvox.playback.voice.CatalogEntry
+import `in`.jphe.storyvox.playback.voice.EngineType
+import `in`.jphe.storyvox.playback.voice.VoiceCatalog
+import `in`.jphe.storyvox.playback.voice.VoiceEnginePlugin
+import `in`.jphe.storyvox.playback.voice.VoiceFamilyDescriptor
+import `in`.jphe.storyvox.playback.voice.VoiceFamilyDescriptors
+import `in`.jphe.storyvox.playback.voice.VoiceFamilyIds
+import javax.inject.Inject
+import javax.inject.Singleton
+
+/**
+ * Issue #1372 — [VoiceEnginePlugin] for Kokoro, wrapping the vendor
+ * `com.CodeBySonu.VoxSherpa.KokoroEngine` singleton.
+ *
+ * Kokoro is a shared multi-speaker model: one loaded model, the active
+ * speaker selected by index. [generateAudioPCM] re-asserts the speaker
+ * from the [EngineType.Kokoro.speakerId] before each synth (the
+ * #1263-correct pattern), because the process-wide singleton may have
+ * been left on another speaker by a concurrent render or playback.
+ */
+@Singleton
+class KokoroEnginePlugin @Inject constructor() : VoiceEnginePlugin {
+
+    override val engineId: String = VoiceFamilyIds.KOKORO
+
+    override val sampleRate: Int get() = EngineSampleRateCache.kokoroRate()
+
+    override val supportsExport: Boolean = true
+
+    override fun handles(type: EngineType): Boolean = type is EngineType.Kokoro
+
+    override fun generateAudioPCM(
+        type: EngineType,
+        text: String,
+        speed: Float,
+        pitch: Float,
+    ): ByteArray? {
+        val speakerId = (type as? EngineType.Kokoro)?.speakerId ?: return null
+        KokoroEngine.getInstance().setActiveSpeakerId(speakerId)
+        return KokoroEngine.getInstance().generateAudioPCM(text, speed, pitch)
+    }
+
+    override fun catalogEntries(): List<CatalogEntry> = VoiceCatalog.kokoroEntries()
+
+    override fun familyDescriptor(): VoiceFamilyDescriptor = VoiceFamilyDescriptors.KOKORO
+}

--- a/core-playback/src/main/kotlin/in/jphe/storyvox/playback/voice/engines/PiperEnginePlugin.kt
+++ b/core-playback/src/main/kotlin/in/jphe/storyvox/playback/voice/engines/PiperEnginePlugin.kt
@@ -1,0 +1,44 @@
+package `in`.jphe.storyvox.playback.voice.engines
+
+import com.CodeBySonu.VoxSherpa.VoiceEngine
+import `in`.jphe.storyvox.playback.EngineSampleRateCache
+import `in`.jphe.storyvox.playback.voice.CatalogEntry
+import `in`.jphe.storyvox.playback.voice.EngineType
+import `in`.jphe.storyvox.playback.voice.VoiceCatalog
+import `in`.jphe.storyvox.playback.voice.VoiceEnginePlugin
+import `in`.jphe.storyvox.playback.voice.VoiceFamilyDescriptor
+import `in`.jphe.storyvox.playback.voice.VoiceFamilyDescriptors
+import `in`.jphe.storyvox.playback.voice.VoiceFamilyIds
+import javax.inject.Inject
+import javax.inject.Singleton
+
+/**
+ * Issue #1372 — [VoiceEnginePlugin] for Piper, wrapping the vendor
+ * `com.CodeBySonu.VoxSherpa.VoiceEngine` singleton.
+ *
+ * Piper is per-voice (each voice is its own ONNX, not a shared
+ * multi-speaker model), so there is no active-speaker index to
+ * re-assert before synth — [generateAudioPCM] ignores the [EngineType].
+ */
+@Singleton
+class PiperEnginePlugin @Inject constructor() : VoiceEnginePlugin {
+
+    override val engineId: String = VoiceFamilyIds.PIPER
+
+    override val sampleRate: Int get() = EngineSampleRateCache.piperRate()
+
+    override val supportsExport: Boolean = true
+
+    override fun handles(type: EngineType): Boolean = type is EngineType.Piper
+
+    override fun generateAudioPCM(
+        type: EngineType,
+        text: String,
+        speed: Float,
+        pitch: Float,
+    ): ByteArray? = VoiceEngine.getInstance().generateAudioPCM(text, speed, pitch)
+
+    override fun catalogEntries(): List<CatalogEntry> = VoiceCatalog.piperEntries()
+
+    override fun familyDescriptor(): VoiceFamilyDescriptor = VoiceFamilyDescriptors.PIPER
+}

--- a/core-playback/src/main/kotlin/in/jphe/storyvox/playback/voice/engines/SupertonicEnginePlugin.kt
+++ b/core-playback/src/main/kotlin/in/jphe/storyvox/playback/voice/engines/SupertonicEnginePlugin.kt
@@ -1,0 +1,54 @@
+package `in`.jphe.storyvox.playback.voice.engines
+
+import com.CodeBySonu.VoxSherpa.SupertonicEngine
+import `in`.jphe.storyvox.playback.EngineSampleRateCache
+import `in`.jphe.storyvox.playback.voice.CatalogEntry
+import `in`.jphe.storyvox.playback.voice.EngineType
+import `in`.jphe.storyvox.playback.voice.VoiceCatalog
+import `in`.jphe.storyvox.playback.voice.VoiceEnginePlugin
+import `in`.jphe.storyvox.playback.voice.VoiceFamilyDescriptor
+import `in`.jphe.storyvox.playback.voice.VoiceFamilyDescriptors
+import `in`.jphe.storyvox.playback.voice.VoiceFamilyIds
+import javax.inject.Inject
+import javax.inject.Singleton
+
+/**
+ * Issue #1372 — [VoiceEnginePlugin] for Supertonic 3, wrapping the vendor
+ * `com.CodeBySonu.VoxSherpa.SupertonicEngine` singleton.
+ *
+ * Shared multi-speaker model (a twin of Kokoro / Kitten):
+ * [generateAudioPCM] re-asserts the speaker from
+ * [EngineType.Supertonic.speakerId] before each synth (the
+ * #1263-correct pattern).
+ *
+ * [catalogEntries] honours [VoiceCatalog.SUPERTONIC_ENABLED] so the
+ * union of every plugin's entries reproduces [VoiceCatalog.voices] —
+ * one flag still re-gates the voices and the family card together.
+ */
+@Singleton
+class SupertonicEnginePlugin @Inject constructor() : VoiceEnginePlugin {
+
+    override val engineId: String = VoiceFamilyIds.SUPERTONIC
+
+    override val sampleRate: Int get() = EngineSampleRateCache.supertonicRate()
+
+    override val supportsExport: Boolean = true
+
+    override fun handles(type: EngineType): Boolean = type is EngineType.Supertonic
+
+    override fun generateAudioPCM(
+        type: EngineType,
+        text: String,
+        speed: Float,
+        pitch: Float,
+    ): ByteArray? {
+        val speakerId = (type as? EngineType.Supertonic)?.speakerId ?: return null
+        SupertonicEngine.getInstance().setActiveSpeakerId(speakerId)
+        return SupertonicEngine.getInstance().generateAudioPCM(text, speed, pitch)
+    }
+
+    override fun catalogEntries(): List<CatalogEntry> =
+        if (VoiceCatalog.SUPERTONIC_ENABLED) VoiceCatalog.supertonicEntries() else emptyList()
+
+    override fun familyDescriptor(): VoiceFamilyDescriptor = VoiceFamilyDescriptors.SUPERTONIC
+}

--- a/core-playback/src/main/kotlin/in/jphe/storyvox/playback/voice/engines/SystemTtsEnginePlugin.kt
+++ b/core-playback/src/main/kotlin/in/jphe/storyvox/playback/voice/engines/SystemTtsEnginePlugin.kt
@@ -1,0 +1,53 @@
+package `in`.jphe.storyvox.playback.voice.engines
+
+import `in`.jphe.storyvox.playback.tts.SystemTtsEngine
+import `in`.jphe.storyvox.playback.voice.CatalogEntry
+import `in`.jphe.storyvox.playback.voice.EngineType
+import `in`.jphe.storyvox.playback.voice.VoiceEnginePlugin
+import `in`.jphe.storyvox.playback.voice.VoiceFamilyDescriptor
+import `in`.jphe.storyvox.playback.voice.VoiceFamilyDescriptors
+import `in`.jphe.storyvox.playback.voice.VoiceFamilyIds
+import javax.inject.Inject
+import javax.inject.Singleton
+
+/**
+ * Issue #1372 / #676 — [VoiceEnginePlugin] for Android System TTS.
+ *
+ * System TTS routes through the OS `TextToSpeech` framework via an
+ * instance-based `in.jphe.storyvox.playback.tts.SystemTtsEngine` (bound
+ * per-engine-package, async `onInit`), not a process-wide singleton. So,
+ * like Azure, this plugin reports the non-synthesising surface:
+ *
+ * - [supportsExport] is `false` — a framework binder can't render to a
+ *   file in the export path; rejected there.
+ * - [generateAudioPCM] returns `null` — synthesis runs through the live
+ *   `SystemTtsEngine.generateAudioPCMBlocking` in `EnginePlayer`, which
+ *   this contract does not yet own.
+ * - [catalogEntries] is empty — System TTS voices are discovered at
+ *   runtime from the device roster
+ *   (`VoiceCatalog.systemTtsEntriesFromRoster`).
+ * - [sampleRate] reports `SystemTtsEngine.DEFAULT_SAMPLE_RATE`; the real
+ *   rate comes from the live engine instance per chosen OS voice.
+ */
+@Singleton
+class SystemTtsEnginePlugin @Inject constructor() : VoiceEnginePlugin {
+
+    override val engineId: String = VoiceFamilyIds.SYSTEM_TTS
+
+    override val sampleRate: Int = SystemTtsEngine.DEFAULT_SAMPLE_RATE
+
+    override val supportsExport: Boolean = false
+
+    override fun handles(type: EngineType): Boolean = type is EngineType.SystemTts
+
+    override fun generateAudioPCM(
+        type: EngineType,
+        text: String,
+        speed: Float,
+        pitch: Float,
+    ): ByteArray? = null
+
+    override fun catalogEntries(): List<CatalogEntry> = emptyList()
+
+    override fun familyDescriptor(): VoiceFamilyDescriptor = VoiceFamilyDescriptors.SYSTEM_TTS
+}

--- a/core-playback/src/test/kotlin/in/jphe/storyvox/playback/voice/VoiceEngineRegistryTest.kt
+++ b/core-playback/src/test/kotlin/in/jphe/storyvox/playback/voice/VoiceEngineRegistryTest.kt
@@ -1,0 +1,172 @@
+package `in`.jphe.storyvox.playback.voice
+
+import `in`.jphe.storyvox.playback.voice.engines.AzureEnginePlugin
+import `in`.jphe.storyvox.playback.voice.engines.KittenEnginePlugin
+import `in`.jphe.storyvox.playback.voice.engines.KokoroEnginePlugin
+import `in`.jphe.storyvox.playback.voice.engines.PiperEnginePlugin
+import `in`.jphe.storyvox.playback.voice.engines.SupertonicEnginePlugin
+import `in`.jphe.storyvox.playback.voice.engines.SystemTtsEnginePlugin
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertSame
+import org.junit.Assert.assertThrows
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * Issue #1372 — [VoiceEngineRegistry] shape + dispatch tests.
+ *
+ * Builds the registry directly from the six in-tree plugins (each has a
+ * no-arg `@Inject` constructor) keyed by `engineId`, exactly as the Hilt
+ * `@IntoMap` multibinding does at runtime — so this exercises the real
+ * routing without standing up Hilt.
+ *
+ * Deliberately native-free: it never reads `sampleRate` or calls
+ * `generateAudioPCM` (those reach the VoxSherpa JNI engines). The seam's
+ * value here is metadata + dispatch — which [EngineType] routes to which
+ * plugin, export capability, and that the union of catalog entries
+ * reproduces [VoiceCatalog.voices].
+ */
+class VoiceEngineRegistryTest {
+
+    private fun realPlugins(): List<VoiceEnginePlugin> = listOf(
+        PiperEnginePlugin(),
+        KokoroEnginePlugin(),
+        KittenEnginePlugin(),
+        SupertonicEnginePlugin(),
+        AzureEnginePlugin(),
+        SystemTtsEnginePlugin(),
+    )
+
+    /** The map exactly as `VoiceEnginePluginModule`'s @StringKey binds it. */
+    private fun registry(): VoiceEngineRegistry =
+        VoiceEngineRegistry(realPlugins().associateBy { it.engineId })
+
+    @Test fun `registry holds all six engine plugins`() {
+        assertEquals(6, registry().all().size)
+    }
+
+    @Test fun `byId resolves each family key to its plugin`() {
+        val r = registry()
+        assertEquals(VoiceFamilyIds.PIPER, r.byId(VoiceFamilyIds.PIPER)?.engineId)
+        assertEquals(VoiceFamilyIds.KOKORO, r.byId(VoiceFamilyIds.KOKORO)?.engineId)
+        assertEquals(VoiceFamilyIds.KITTEN, r.byId(VoiceFamilyIds.KITTEN)?.engineId)
+        assertEquals(VoiceFamilyIds.SUPERTONIC, r.byId(VoiceFamilyIds.SUPERTONIC)?.engineId)
+        assertEquals(VoiceFamilyIds.AZURE, r.byId(VoiceFamilyIds.AZURE)?.engineId)
+        assertEquals(VoiceFamilyIds.SYSTEM_TTS, r.byId(VoiceFamilyIds.SYSTEM_TTS)?.engineId)
+    }
+
+    @Test fun `byId returns null for an unregistered id`() {
+        assertNull(registry().byId("voice_does_not_exist"))
+    }
+
+    @Test fun `forType dispatches every EngineType variant to the owning plugin`() {
+        val r = registry()
+        assertEquals(VoiceFamilyIds.PIPER, r.forType(EngineType.Piper)?.engineId)
+        assertEquals(VoiceFamilyIds.KOKORO, r.forType(EngineType.Kokoro(speakerId = 7))?.engineId)
+        assertEquals(VoiceFamilyIds.KITTEN, r.forType(EngineType.Kitten(speakerId = 3))?.engineId)
+        assertEquals(VoiceFamilyIds.SUPERTONIC, r.forType(EngineType.Supertonic(speakerId = 2))?.engineId)
+        assertEquals(
+            VoiceFamilyIds.AZURE,
+            r.forType(EngineType.Azure(voiceName = "en-US-AvaDragonHDLatestNeural", region = "eastus"))?.engineId,
+        )
+        assertEquals(
+            VoiceFamilyIds.SYSTEM_TTS,
+            r.forType(EngineType.SystemTts(engineName = "com.google.android.tts", voiceName = "en-us-x-iol-network"))?.engineId,
+        )
+    }
+
+    @Test fun `forType agrees with the existing voiceFamilyId mapping for every variant`() {
+        // Ties the new dispatch seam to the pre-#1372 EngineType→family
+        // map: the plugin that handles a type must be the one keyed under
+        // that type's family id. If they ever drift, both this and
+        // VoiceFamilyRegistryTest's mapping tests should be revisited.
+        val r = registry()
+        val variants = listOf(
+            EngineType.Piper,
+            EngineType.Kokoro(speakerId = 0),
+            EngineType.Kitten(speakerId = 0),
+            EngineType.Supertonic(speakerId = 0),
+            EngineType.Azure(voiceName = "v", region = "eastus"),
+            EngineType.SystemTts(engineName = "e", voiceName = "v"),
+        )
+        variants.forEach { type ->
+            assertEquals(
+                "forType($type) should resolve the plugin keyed under ${type.voiceFamilyId()}",
+                type.voiceFamilyId(),
+                r.forType(type)?.engineId,
+            )
+        }
+    }
+
+    @Test fun `only the in-process model engines support export`() {
+        val r = registry()
+        assertTrue(r.byId(VoiceFamilyIds.PIPER)!!.supportsExport)
+        assertTrue(r.byId(VoiceFamilyIds.KOKORO)!!.supportsExport)
+        assertTrue(r.byId(VoiceFamilyIds.KITTEN)!!.supportsExport)
+        assertTrue(r.byId(VoiceFamilyIds.SUPERTONIC)!!.supportsExport)
+        // Cloud / framework engines are offline-export-incapable.
+        assertFalse(r.byId(VoiceFamilyIds.AZURE)!!.supportsExport)
+        assertFalse(r.byId(VoiceFamilyIds.SYSTEM_TTS)!!.supportsExport)
+    }
+
+    @Test fun `allCatalogEntries reproduces the static VoiceCatalog voices`() {
+        // The seam's catalog union must equal the legacy static roster:
+        // the in-process engines contribute their entries; Azure / System
+        // TTS contribute nothing static (they're roster-driven at runtime).
+        // Compared as sets — registry order is unspecified (Hilt map order).
+        assertEquals(VoiceCatalog.voices.toSet(), registry().allCatalogEntries().toSet())
+        assertEquals(
+            "no duplicate catalog entries across plugins",
+            VoiceCatalog.voices.size,
+            registry().allCatalogEntries().size,
+        )
+    }
+
+    @Test fun `allFamilyDescriptors covers the six engine families but not the placeholder`() {
+        val ids = registry().allFamilyDescriptors().map { it.id }.toSet()
+        assertEquals(
+            setOf(
+                VoiceFamilyIds.PIPER,
+                VoiceFamilyIds.KOKORO,
+                VoiceFamilyIds.KITTEN,
+                VoiceFamilyIds.SUPERTONIC,
+                VoiceFamilyIds.AZURE,
+                VoiceFamilyIds.SYSTEM_TTS,
+            ),
+            ids,
+        )
+        // The "VoxSherpa upstreams" placeholder is not an engine — it
+        // stays owned by VoiceFamilyRegistry, never surfaced here.
+        assertFalse(VoiceFamilyIds.VOXSHERPA_UPSTREAMS in ids)
+    }
+
+    @Test fun `each engine plugin reports the family descriptor matching its engineId`() {
+        registry().all().forEach { plugin ->
+            assertEquals(plugin.engineId, plugin.familyDescriptor().id)
+        }
+    }
+
+    @Test fun `plugin family descriptors are the shared VoiceFamilyDescriptors constants`() {
+        // Guards against a plugin minting a divergent descriptor: it must
+        // hand back the same object VoiceFamilyRegistry renders.
+        val r = registry()
+        assertSame(VoiceFamilyDescriptors.PIPER, r.byId(VoiceFamilyIds.PIPER)!!.familyDescriptor())
+        assertSame(VoiceFamilyDescriptors.AZURE, r.byId(VoiceFamilyIds.AZURE)!!.familyDescriptor())
+        assertSame(VoiceFamilyDescriptors.SYSTEM_TTS, r.byId(VoiceFamilyIds.SYSTEM_TTS)!!.familyDescriptor())
+    }
+
+    @Test fun `construction fails fast when a plugin is bound under the wrong key`() {
+        // Mirrors the @StringKey contract: the map key must equal the
+        // plugin's engineId. A mismatch is a wiring bug and should blow
+        // up at graph build, not silently break byId().
+        val ex = assertThrows(IllegalStateException::class.java) {
+            VoiceEngineRegistry(mapOf(VoiceFamilyIds.KOKORO to PiperEnginePlugin()))
+        }
+        assertTrue(
+            "message should name the offending binding",
+            ex.message?.contains("engineId") == true,
+        )
+    }
+}


### PR DESCRIPTION
## Summary

Extracts a `VoiceEnginePlugin` seam so adding a TTS engine stops meaning "touch ~10 files and grow a `when (engineType)` arm in each." A new engine is now a plugin class + one Hilt binding.

**The contract** — `VoiceEnginePlugin` (core-playback `playback/voice/`): each engine self-describes `engineId`, `sampleRate`, `supportsExport`, `handles(type)`, `generateAudioPCM(type, …)`, `catalogEntries()`, `familyDescriptor()`.

**Six plugins** wrapping the existing singletons (wrap, don't rewrite): `PiperEnginePlugin`, `KokoroEnginePlugin`, `KittenEnginePlugin`, `SupertonicEnginePlugin`, `AzureEnginePlugin`, `SystemTtsEnginePlugin`. Shared-model engines (Kokoro/Kitten/Supertonic) re-assert their speaker from the `EngineType` before each synth — the #1263-correct pattern, now owned in one place.

**Registry + wiring** — `VoiceEngineRegistry` (`@Singleton` over a Hilt `@IntoMap` multibinding, keyed by `engineId`) and `VoiceEnginePluginModule` binding all six, mirroring `SourcePluginRegistry`'s `@SourcePlugin` seam. The registry fails fast on a `@StringKey`/`engineId` mismatch.

**DRY family cards** — descriptor literals lifted to `VoiceFamilyDescriptors`; `VoiceFamilyRegistry` (~200 inline lines → references) and each plugin's `familyDescriptor()` now share one source. `VoiceCatalog`'s per-engine entry builders made `internal` so plugins delegate to them; the union reproduces `VoiceCatalog.voices`.

**First consumers migrated** (proves the seam, fully within core-playback):
- `AudiobookSynthesizer` — `generateAudioPCM` now dispatches through the registry; the export gate is data-driven via `supportsExport` (friendly per-engine copy preserved), so a future non-export engine is rejected automatically. Also closes a latent bug: that loop re-acquires `engineMutex` per sentence, so a concurrent render could leave the shared singleton on another speaker between sentences — the plugin now re-asserts ours each synth.
- `ChapterRenderJob` — `generateAudioPCM` dispatches through the registry; behaviour-identical (the plugin owns the speaker re-assertion it already did).

## Naming

The interface is `VoiceEnginePlugin`, **not** `VoiceEngine`, to avoid three live collisions — the vendor `com.CodeBySonu.VoxSherpa.VoiceEngine` (the Piper engine), `in.jphe.storyvox.source.azure.AzureVoiceEngine`, and `SystemTtsEngine` — reusing the existing `SourcePlugin`/`SourcePluginRegistry` vocabulary.

## Deliberately deferred

Documented in the `VoiceEnginePlugin` kdoc; each is more than a trivial when-swap and is its own follow-up:
- **`loadModel` + speaker setup** — divergent per-engine load signatures (Piper onnx+tokens; Kokoro/Kitten +voices.bin; Supertonic shared dir), needs `VoiceManager`/`Context` injected into plugins.
- **`EnginePlayer` streaming / secondary-engine dispatch** — a parallel-synth architecture, not a simple `generateAudioPCM`.
- **A `suspend synthesize`** — synthesis must stay serialised behind `EngineMutex` + a prior `loadModel`; a context-free entry point would corrupt the shared singletons.
- **`EngineSampleRateCache`** (a static `object`) and the `sampleRate`-read sites stay as-is — the cached-vs-live read distinction matters for 16 kHz Piper voices.

## Test plan

- [x] `VoiceEngineRegistryTest` — `forType`/`byId` dispatch for all six variants, `supportsExport`, catalog union == `VoiceCatalog.voices`, family-descriptor coverage, agreement with the existing `EngineType.voiceFamilyId()` map, and the fail-fast mismatch guard. Native-free (never touches the VoxSherpa JNI).
- [x] Existing `VoiceFamilyRegistryTest` pins the descriptor extraction (same 7 cards, same order).
- [ ] CI Build APK (the real Hilt-graph compile gate) + Test Compile.

Closes #1372

🤖 Generated with [Claude Code](https://claude.com/claude-code)
