### PR TITLE
feat(ci): add Wear OS APK to release build

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -165,6 +165,14 @@ jobs:
         # existing sideload installs upgrade in place).
         run: PATH="$JAVA_HOME/bin:$PATH" ./gradlew :app:assembleRelease --no-daemon --stacktrace
 
+      - name: Assemble Wear release APK
+        # Companion watch app ("Library Nocturne"). Signed with the same
+        # checked-in keystore as :app (see wear/build.gradle.kts) so the
+        # two installs share a key — required for the Wearable Data Layer
+        # phone <-> watch bridge. Unconditional like the phone build above,
+        # so wear breakage is caught as a PR-time compile gate.
+        run: PATH="$JAVA_HOME/bin:$PATH" ./gradlew :wear:assembleRelease --no-daemon --stacktrace
+
       - name: Cold-launch perf guard (Issue #618)
         # Reads the StartupBenchmark JSON (if present) and fails the
         # build when the cold-launch median exceeds the threshold
@@ -182,7 +190,7 @@ jobs:
         # itself is skipped without a device.
         run: ./scripts/check-cold-launch.sh
 
-      - name: Rename APK with tag
+      - name: Rename APKs with tag
         # Only runs on tag builds — for PR / main pushes we just
         # verify the build compiles and stop. The local-build path
         # in `app/build.gradle.kts` (applicationVariants.all) already
@@ -209,6 +217,10 @@ jobs:
           if [ "$SRC" != "$DST" ]; then
             cp "$SRC" "$DST"
           fi
+          # Wear companion: :wear has no applicationVariants rename, so
+          # its output is always wear-release.apk. Copy to the tag name.
+          WEAR_DIR=wear/build/outputs/apk/release
+          cp "$WEAR_DIR/wear-release.apk" "$WEAR_DIR/candela-wear-${TAG}.apk"
 
       - name: Create GitHub release
         # Used to be a separate `release:` job that pulled the APK
@@ -229,5 +241,10 @@ jobs:
           body: |
             Release APK build for `${{ github.ref_name }}`.
 
-            > Signed with the project's checked-in keystore (stable since v0.4.15). Sideload-only distribution today.
-          files: app/build/outputs/apk/release/candela-${{ github.ref_name }}.apk
+            - `candela-${{ github.ref_name }}.apk` — phone / tablet
+            - `candela-wear-${{ github.ref_name }}.apk` — Wear OS companion ("Library Nocturne"), sideload to the watch
+
+            > Both signed with the project's checked-in keystore (stable since v0.4.15) so the watch ↔ phone Data Layer bridge pairs. Sideload-only distribution today.
+          files: |
+            app/build/outputs/apk/release/candela-${{ github.ref_name }}.apk
+            wear/build/outputs/apk/release/candela-wear-${{ github.ref_name }}.apk

--- a/wear/build.gradle.kts
+++ b/wear/build.gradle.kts
@@ -18,6 +18,20 @@ android {
         versionName = "0.1.0"
     }
 
+    signingConfigs {
+        // Reuse :app's checked-in keystore instead of the per-machine
+        // ~/.android/debug.keystore AGP defaults to, so the watch APK and
+        // the phone APK share one signing certificate: the Wearable Data
+        // Layer bridge only pairs phone <-> watch when both are signed
+        // with the same key.
+        getByName("debug") {
+            storeFile = rootProject.file("app/storyvox-debug.keystore")
+            storePassword = "android"
+            keyAlias = "androiddebugkey"
+            keyPassword = "android"
+        }
+    }
+
     buildTypes {
         debug {
             isMinifyEnabled = false
@@ -26,6 +40,9 @@ android {
         release {
             isMinifyEnabled = false
             proguardFiles(getDefaultProguardFile("proguard-android-optimize.txt"), "proguard-rules.pro")
+            // An unsigned release APK can't be adb-installed; sign the
+            // sideload build with the shared keystore above.
+            signingConfig = signingConfigs.getByName("debug")
         }
     }
 

--- a/wear/proguard-rules.pro
+++ b/wear/proguard-rules.pro
@@ -1,0 +1,9 @@
+# Library Nocturne (Wear OS companion) R8 / ProGuard rules.
+#
+# Intentionally empty: wear/build.gradle.kts keeps `isMinifyEnabled =
+# false` on the release buildType, so R8 never runs and no keep rules are
+# needed today. The file exists because the release block references it
+# via `proguardFiles(...)` (mirroring :app and :core-sync, which both
+# ship one). If minification is ever enabled here, add keep rules for the
+# kotlinx-serialization @Serializable wire models under playback/ — the
+# phone <-> watch Data Layer payloads are reflected over at runtime.


### PR DESCRIPTION
## What

Builds the **Wear OS companion app ("Library Nocturne")** in CI alongside the phone APK, so it can be sideloaded onto a Galaxy Watch4. The `wear/` module already existed, but since `:app` doesn't depend on it, CI never compiled it and no watch APK was ever produced.

## Changes (all additive — phone build path untouched)

**`.github/workflows/android.yml`**
- New step `Assemble Wear release APK` → `:wear:assembleRelease`, unconditional (same as the phone build) so Wear breakage is caught as a **PR-time compile gate**.
- The tag-rename step now also produces `candela-wear-<tag>.apk` (`:wear` has no `applicationVariants` rename, so its output is always `wear-release.apk`).
- The GitHub Release on tag builds now attaches **both** APKs, with a body that labels which is which.

**`wear/build.gradle.kts`** — signing
- The Wear `release` buildType had **no `signingConfig`**, so `:wear:assembleRelease` would emit an *unsigned*, non-installable APK.
- Added a `signingConfigs.debug` pointing at **`:app`'s checked-in keystore** (`app/storyvox-debug.keystore`) and assigned it to `release`. Reusing the phone app's key is deliberate: the **Wearable Data Layer** phone↔watch bridge only pairs the two installs when they share a signing certificate. This mirrors the phone app's own non-publish signing fallback exactly.

**`wear/proguard-rules.pro`** (new)
- The Wear `release` block already referenced this file via `proguardFiles(...)`, but it didn't exist (both `:app` and `:core-sync` ship one). Added it empty — `isMinifyEnabled = false` on Wear, so R8 never runs. Header notes what to add if minify is ever enabled.

## Why release (not debug)

The task offered `assembleDebug` as a fallback "if release needs signing". I went with **release + shared keystore** instead because:
1. Debug would sign with the per-machine auto-generated `~/.android/debug.keystore` (a *different* key from the phone app) and carry the `.debug` applicationId suffix — both of which break Data Layer pairing.
2. Release + the shared checked-in keystore yields `in.jphe.storyvox.wear` signed with the **same key as the phone**, which is what the companion bridge needs.

## CI expectations / risk

This is the **first time `:wear:assembleRelease` runs in CI**. The module has full sources (10 Kotlin files, manifest, tests), so it's expected to compile — but if there's a latent Wear-only compile error, this PR's `Build APK` run is where it'll surface. That's the intended gate; I'll triage anything that turns up.

Verified locally without compiling (per CLAUDE.md — CI is the compile gate): YAML parses, keystore path resolves, every Gradle idiom mirrors the proven `app/build.gradle.kts`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new Wear OS release APK to the Android build and release process.
  * Wear OS release builds now use a signing setup that supports installation on devices and matches the required certificate pairing.

* **Bug Fixes**
  * Tag-based releases now rename and publish both Android APKs correctly, including the Wear OS artifact.

* **Documentation**
  * Added clarifying notes for the Wear OS release configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->