### PR TITLE
fix(playback): prevent synthesis cancel loop on Piper cache MISS (#1383)

### DIFF
--- a/core-playback/src/main/kotlin/in/jphe/storyvox/playback/tts/EnginePlayer.kt
+++ b/core-playback/src/main/kotlin/in/jphe/storyvox/playback/tts/EnginePlayer.kt
@@ -351,6 +351,51 @@ internal fun isSilentNaturalEnd(naturalEnd: Boolean, chunksEmitted: Int): Boolea
     naturalEnd && chunksEmitted == 0
 
 /**
+ * Issue #1383 — should an [VoiceManager.activeVoice] emission tear down and
+ * rebuild the playback pipeline, or is it a spurious re-emission to ignore?
+ *
+ * `activeVoice` is `combine(prefs, azureRoster, systemTtsRoster)`, so it
+ * re-emits whenever ANY input changes — not only when the user picks a new
+ * voice. On a Samsung Z Flip3 the framework `TextToSpeech` client the
+ * system-TTS roster is built from connects/disconnects in a tight loop
+ * (#1384), so `systemTtsRoster` churns and `activeVoice` re-fires the SAME
+ * active id many times a second. [EnginePlayer.observeActiveVoice] reacted to
+ * each one with `stopPlaybackPipeline()` + `loadAndPlay()`; stopPlaybackPipeline
+ * closes the in-flight [in.jphe.storyvox.playback.tts.source.EngineStreamingSource]
+ * (cancelling its producer), so a dense churn burst cancels Piper synthesis
+ * faster than it can emit a single PCM chunk and the chapter stays silent —
+ * the #1383 "synthesis cancelled immediately after cache MISS" loop.
+ *
+ * Rebuild ONLY for a genuine change of the user-selected voice:
+ *  - [newVoiceId] == null (nothing active) → never rebuild.
+ *  - [newVoiceId] == [loadedVoiceId] → the model is already loaded; we're
+ *    already playing this voice, so re-selecting it is a no-op.
+ *  - [newVoiceId] == [lastReactedVoiceId] → a same-id re-emission, i.e. roster
+ *    churn rather than a user pick. Drop it. This guard is independent of
+ *    [loadedVoiceId], which lags a full model load behind the decision and so
+ *    can't suppress churn that arrives WHILE the first load is still in
+ *    flight — the exact window the #1383 burst exploits.
+ *
+ * A real swap (different id) always passes, so the system-TTS and Piper voice
+ * changes the user actually makes are unaffected.
+ *
+ * Extracted as a top-level function so the rule can be exercised in a pure
+ * unit test (EnginePlayerVoiceChurnTest) without standing up the full
+ * EnginePlayer + Hilt + sherpa-onnx graph — same constraint that gates
+ * [shouldAutoPlayAfterAdvance] / [crossedThermalModerateBoundary].
+ */
+internal fun shouldRebuildForVoiceChange(
+    newVoiceId: String?,
+    lastReactedVoiceId: String?,
+    loadedVoiceId: String?,
+): Boolean {
+    if (newVoiceId == null) return false
+    if (newVoiceId == loadedVoiceId) return false
+    if (newVoiceId == lastReactedVoiceId) return false
+    return true
+}
+
+/**
  * Issue #1330 — the fiction id the player should expose in [PlaybackState]
  * while a [chapter] is loaded. The chapter's [PlaybackChapter.fictionId] is
  * FK-bound to a real `fiction` row, so it's the source of truth even when the
@@ -546,6 +591,16 @@ class EnginePlayer @AssistedInject constructor(
      *  paused. The flag tells [resume] to route through [loadAndPlay] for
      *  a fresh model load instead of restarting the existing pipeline. */
     private var voiceReloadPending: Boolean = false
+
+    /** Issue #1383 — id of the last [VoiceManager.activeVoice] emission
+     *  [observeActiveVoice] acted on. The churn-dedup key for
+     *  [shouldRebuildForVoiceChange]: distinct from [loadedVoiceId] (which
+     *  only updates after a full model load completes) so a burst of same-id
+     *  re-emissions arriving WHILE the first load is in flight can't each
+     *  trigger a fresh teardown+rebuild and cancel synthesis mid-MISS. Written
+     *  and read only on the single [observeActiveVoice] collector coroutine,
+     *  so no `@Volatile` is needed. */
+    private var lastReactedVoiceId: String? = null
 
     /**
      * Issue #569 — last loaded model's parallel-synth state. Combined
@@ -1156,9 +1211,12 @@ class EnginePlayer @AssistedInject constructor(
      *  - Active voice changes before any chapter is loaded → no-op; the
      *    next [loadAndPlay] reads activeVoice itself.
      *
-     *  De-dup: we track [loadedVoiceId] so re-emissions of the same id
-     *  (e.g. after [setActive] writes the same value, or first-launch
-     *  hydration) are filtered out.
+     *  De-dup: we track [loadedVoiceId] (the voice whose model is loaded) and
+     *  [lastReactedVoiceId] (the last emission we acted on) so re-emissions of
+     *  the same id are filtered out — whether they come from [setActive]
+     *  re-writing the same value, first-launch hydration, or the system-TTS
+     *  roster churning under `activeVoice`'s `combine` (#1383/#1384). See
+     *  [shouldRebuildForVoiceChange].
      */
     private fun observeActiveVoice() {
         scope.launch {
@@ -1173,8 +1231,20 @@ class EnginePlayer @AssistedInject constructor(
                     // flag so we don't force a needless model reload (a
                     // 30 s Kokoro warm-up) on the next [resume].
                     voiceReloadPending = false
+                    lastReactedVoiceId = newId
                     return@collect
                 }
+                // #1383 — `activeVoice` re-emits on every roster change, not
+                // just user voice picks; on Samsung the system-TTS roster
+                // churns (#1384) and re-fires the same id many times a second.
+                // Reacting to a same-id re-emission tears down the in-flight
+                // pipeline and cancels Piper synthesis mid-MISS, so the chapter
+                // never gets audio. Gate on a genuine change of the selected
+                // voice — see [shouldRebuildForVoiceChange].
+                if (!shouldRebuildForVoiceChange(newId, lastReactedVoiceId, loadedVoiceId)) {
+                    return@collect
+                }
+                lastReactedVoiceId = newId
                 val s = _observableState.value
                 val fictionId = s.currentFictionId
                 val chapterId = s.currentChapterId

--- a/core-playback/src/test/kotlin/in/jphe/storyvox/playback/tts/EnginePlayerVoiceChurnTest.kt
+++ b/core-playback/src/test/kotlin/in/jphe/storyvox/playback/tts/EnginePlayerVoiceChurnTest.kt
@@ -1,0 +1,151 @@
+package `in`.jphe.storyvox.playback.tts
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * Issue #1383 — pure-function unit test for [shouldRebuildForVoiceChange], the
+ * gate that decides whether a [VoiceManager.activeVoice] emission represents a
+ * genuine user voice change worth a pipeline rebuild, or a spurious re-emission
+ * to ignore.
+ *
+ * The bug: on a Samsung Z Flip3, Piper produced only intermittent fragments and
+ * usually no audio at all. Logcat showed the streaming producer cancelled ~35 ms
+ * after each `pcm-cache MISS`, then another MISS, in a loop:
+ *
+ * ```
+ * pcm-cache MISS chapter=3609400 voice=piper_cori_en_GB_medium fromSentence=11
+ * serial producer: cancelled (close/seek/voice swap) — silent exit
+ * pcm-cache MISS chapter=3609400 voice=piper_cori_en_GB_medium fromSentence=11
+ * ```
+ *
+ * Root cause: `activeVoice` is `combine(prefs, azureRoster, systemTtsRoster)`,
+ * so it re-emits on ANY input change. The framework `TextToSpeech` client the
+ * system-TTS roster is built from connect/disconnect-loops on Samsung (#1384),
+ * churning `systemTtsRoster` and re-firing `activeVoice` with the SAME active
+ * id many times a second. [EnginePlayer.observeActiveVoice] reacted to each with
+ * `stopPlaybackPipeline()` (which closes the in-flight EngineStreamingSource and
+ * cancels its producer) + `loadAndPlay()` — so the churn cancelled Piper
+ * synthesis before it could emit a single chunk.
+ *
+ * The pre-fix `newId == loadedVoiceId` guard couldn't stop it: `loadedVoiceId`
+ * only updates AFTER a full model load, so churn arriving while the first load
+ * is still in flight slips past it. The fix adds [lastReactedVoiceId] — the id
+ * of the last emission we acted on — as a churn-dedup key that is updated the
+ * instant we decide to react, closing that window.
+ *
+ * Like [EnginePlayerAutoPlayDecisionTest] / [EnginePlayerThermalRebuildTest]
+ * this deliberately stays at the pure-function layer; a full EnginePlayer needs
+ * a Hilt graph + sherpa-onnx AARs and a real AudioTrack.
+ */
+class EnginePlayerVoiceChurnTest {
+
+    private val piper = "piper_cori_en_GB_medium"
+    private val kokoro = "kokoro_af_heart"
+    private val system = "system_com.google.android.tts"
+
+    @Test
+    fun `a genuine change of the selected voice rebuilds`() {
+        // First-ever pick (nothing loaded, nothing reacted to yet).
+        assertTrue(shouldRebuildForVoiceChange(piper, lastReactedVoiceId = null, loadedVoiceId = null))
+        // Real swap from a loaded voice to a different one.
+        assertTrue(shouldRebuildForVoiceChange(kokoro, lastReactedVoiceId = piper, loadedVoiceId = piper))
+    }
+
+    @Test
+    fun `a same-id re-emission is dropped even before the model finishes loading`() {
+        // The #1383 window: we already reacted to `piper` and kicked off a
+        // load, but loadedVoiceId is still the OLD voice (or null) because the
+        // model load hasn't returned. A churn re-emission of `piper` must NOT
+        // rebuild — that's what cancels synthesis mid-MISS.
+        assertFalse(shouldRebuildForVoiceChange(piper, lastReactedVoiceId = piper, loadedVoiceId = null))
+        assertFalse(shouldRebuildForVoiceChange(piper, lastReactedVoiceId = piper, loadedVoiceId = kokoro))
+    }
+
+    @Test
+    fun `re-selecting the already-loaded voice does not rebuild`() {
+        assertFalse(shouldRebuildForVoiceChange(piper, lastReactedVoiceId = piper, loadedVoiceId = piper))
+        // Even if we never recorded a reaction, a match against the loaded
+        // voice (e.g. loadAndPlay loaded it directly) is a no-op.
+        assertFalse(shouldRebuildForVoiceChange(piper, lastReactedVoiceId = null, loadedVoiceId = piper))
+    }
+
+    @Test
+    fun `a null active voice never rebuilds`() {
+        assertFalse(shouldRebuildForVoiceChange(null, lastReactedVoiceId = piper, loadedVoiceId = piper))
+        assertFalse(shouldRebuildForVoiceChange(null, lastReactedVoiceId = null, loadedVoiceId = null))
+    }
+
+    @Test
+    fun `system-TTS voice swaps are unaffected`() {
+        // The fix only suppresses SAME-id re-emissions; switching to or from a
+        // system-TTS voice is a real id change and still rebuilds.
+        assertTrue(shouldRebuildForVoiceChange(system, lastReactedVoiceId = piper, loadedVoiceId = piper))
+        assertTrue(shouldRebuildForVoiceChange(piper, lastReactedVoiceId = system, loadedVoiceId = system))
+    }
+
+    /**
+     * Drives the exact [EnginePlayer.observeActiveVoice] gate over a simulated
+     * emission stream and counts how many pipeline rebuilds it would trigger.
+     * Mirrors the collector: track [lastReactedVoiceId] and react only when
+     * [shouldRebuildForVoiceChange] returns true.
+     *
+     * `loadedVoiceId` is held FIXED at [initialLoaded] for the whole stream —
+     * the #1383 window. The load never completes because every churn-driven
+     * rebuild tears it down before `loadedVoiceId` can advance, so the
+     * pre-existing `newId == loadedVoiceId` guard provides no help here. Only
+     * [lastReactedVoiceId] can suppress the burst; if this test passes with the
+     * `lastReactedVoiceId` guard removed, the fix has regressed.
+     */
+    private fun countRebuilds(emissions: List<String?>, initialLoaded: String? = null): Int {
+        var lastReacted: String? = null
+        val loaded = initialLoaded
+        var rebuilds = 0
+        for (id in emissions) {
+            if (id == null) continue
+            if (id == loaded) { lastReacted = id; continue }
+            if (!shouldRebuildForVoiceChange(id, lastReacted, loaded)) continue
+            lastReacted = id
+            rebuilds++
+        }
+        return rebuilds
+    }
+
+    @Test
+    fun `a roster-churn burst of the same voice produces exactly one rebuild`() {
+        // #1383 reproduction: one real pick of Piper, then the system-TTS
+        // roster churns and re-fires the same id 200 times while the model load
+        // is still in flight (loadedVoiceId never advances). Pre-fix this was
+        // 200 teardown+rebuilds (synthesis never survived). Post-fix: 1.
+        val churn = listOf(piper) + List(200) { piper }
+        assertEquals(
+            "roster churn must not rebuild the pipeline more than once for one voice (#1383)",
+            1,
+            countRebuilds(churn),
+        )
+    }
+
+    @Test
+    fun `churn interleaved with a genuine swap still honors the swap exactly once each`() {
+        // Piper (real) → churn → churn → Kokoro (real) → churn → back to Piper
+        // (real, because it differs from the last-reacted Kokoro). Three real
+        // changes; the churn in between suppressed — even though loadedVoiceId
+        // never advances across the whole stream.
+        val stream = listOf(
+            piper, piper, piper,
+            kokoro, kokoro,
+            piper, piper,
+        )
+        assertEquals(3, countRebuilds(stream))
+    }
+
+    @Test
+    fun `the loaded voice re-emitting does not rebuild even amid churn`() {
+        // Player already loaded Piper via a direct loadAndPlay (loaded = piper
+        // from the start). A churn storm of the loaded voice stays a no-op via
+        // the pre-existing loadedVoiceId guard.
+        assertEquals(0, countRebuilds(List(50) { piper }, initialLoaded = piper))
+    }
+}


### PR DESCRIPTION
## Issue #1383 — Piper synthesis cancelled immediately after PCM cache MISS

On a Samsung Z Flip3, Piper voice produced only intermittent fragments and usually **no audio at all**. Logcat showed the streaming producer cancelled ~35 ms after each cache MISS, then another MISS, in a loop:

```
pcm-cache MISS chapter=3609400 voice=piper_cori_en_GB_medium fromSentence=11
serial producer: cancelled (close/seek/voice swap) — silent exit
pcm-cache MISS chapter=3609400 voice=piper_cori_en_GB_medium fromSentence=11
```

### Root cause
`VoiceManager.activeVoice` is `combine(prefs, azureRoster, systemTtsRoster)`, so it re-emits on **any** input change — not just user voice picks. The framework `TextToSpeech` client the system-TTS roster is built from connect/disconnect-loops on Samsung (#1384), churning `systemTtsRoster` and re-firing `activeVoice` with the **same** active id many times a second.

`EnginePlayer.observeActiveVoice` reacted to each re-emission with `stopPlaybackPipeline()` — which closes the in-flight `EngineStreamingSource` and cancels its producer — followed by `loadAndPlay()`. A dense churn burst therefore cancelled Piper synthesis faster than it could emit a single PCM chunk, so the chapter stayed silent.

The pre-existing `newId == loadedVoiceId` guard couldn't stop it: `loadedVoiceId` only updates **after** a full model load, so churn arriving while the first load is still in flight slips straight past it — the exact window the burst exploits.

### Fix
Add `lastReactedVoiceId` — the id of the last emission we actually acted on, updated the instant we decide to react — as a churn-dedup key that is **independent of the load lag**. The decision is extracted into a pure top-level function `shouldRebuildForVoiceChange(newVoiceId, lastReactedVoiceId, loadedVoiceId)`, mirroring the existing `shouldAutoPlayAfterAdvance` / `crossedThermalModerateBoundary` decision-helper pattern.

- A **genuine** voice change (different id) always rebuilds → system-TTS and Piper swaps the user actually makes are unaffected.
- A **same-id** re-emission (roster churn) is dropped → no teardown, no synthesis cancel.

### Test
`EnginePlayerVoiceChurnTest` (pure JVM, no Robolectric) covers the decision table and reproduces the bug: a 200-emission churn burst with `loadedVoiceId` held stale (load never completes, as in the real loop) asserts **exactly one** rebuild. The simulation holds `loadedVoiceId` fixed so the test genuinely guards the new `lastReactedVoiceId` key — it would fail if that guard were removed.

Closes #1383.

🤖 Generated with [Claude Code](https://claude.com/claude-code)