### PR TITLE
fix(tts): break infinite connect/disconnect loop on Samsung private engines (#1384)

### DIFF
--- a/app/src/main/kotlin/in/jphe/storyvox/data/SystemTtsVoiceRoster.kt
+++ b/app/src/main/kotlin/in/jphe/storyvox/data/SystemTtsVoiceRoster.kt
@@ -22,6 +22,7 @@ import kotlinx.coroutines.launch
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
 import kotlinx.coroutines.withContext
+import kotlinx.coroutines.withTimeoutOrNull
 
 /**
  * Issue #676 — implementation of [SystemTtsVoiceProvider].
@@ -29,9 +30,10 @@ import kotlinx.coroutines.withContext
  * Enumerates installed TTS engines and their voices via Android's
  * framework `TextToSpeech`. The enumeration is a two-step dance:
  *
- *  1. Construct a one-shot [TextToSpeech] tied to the OS-default engine
- *     so we can list `engines` (every installed TTS provider package
- *     on the device).
+ *  1. Construct a one-shot [TextToSpeech] pinned to a resolved *public*
+ *     engine (see [TtsEngineResolver]; never the possibly-private OS
+ *     default — #1384) so we can list `engines` (every installed TTS
+ *     provider package on the device — the list is engine-independent).
  *  2. For each engine package, construct a second one-shot
  *     [TextToSpeech] pinned to that engine, wait for onInit, then read
  *     `.voices` and shut it down. The framework's voice list is
@@ -64,6 +66,7 @@ class SystemTtsVoiceRoster @Inject constructor(
     private val state = MutableStateFlow<List<SystemTtsVoiceDescriptor>>(emptyList())
     private val refreshMutex = Mutex()
     private val scope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
+    private val engineResolver = TtsEngineResolver(context)
 
     override val voices: Flow<List<SystemTtsVoiceDescriptor>> = state.asStateFlow()
         .onStart { refreshAsync() }
@@ -99,11 +102,23 @@ class SystemTtsVoiceRoster @Inject constructor(
      * others).
      */
     private suspend fun enumerate(): List<SystemTtsVoiceDescriptor> {
-        // Step 1: list installed engines via the default-engine TTS.
-        val defaultTts = bootTts(engine = null) ?: return emptyList()
-        val engineInfos = runCatching { defaultTts.engines?.toList().orEmpty() }
-            .getOrDefault(emptyList())
-        runCatching { defaultTts.shutdown() }
+        // Step 1: list installed engines. #1384 — bind an explicit
+        // public engine rather than the null/device-default target: on
+        // Samsung the default is a private engine whose failed bind
+        // spins a connect/disconnect loop that never fires onInit. The
+        // `.engines` list is engine-independent, so a public-engine
+        // instance still enumerates every installed engine for step 2.
+        val preferredEngine = engineResolver.preferredPublicEngine()
+        if (preferredEngine == null) {
+            Log.i(TAG, "No installed TTS engine packages — skipping enumeration")
+            return emptyList()
+        }
+        val defaultTts = bootTts(engine = preferredEngine) ?: return emptyList()
+        val engineInfos = try {
+            runCatching { defaultTts.engines?.toList().orEmpty() }.getOrDefault(emptyList())
+        } finally {
+            runCatching { defaultTts.shutdown() }
+        }
 
         if (engineInfos.isEmpty()) {
             Log.i(TAG, "No installed TTS engines found")
@@ -194,8 +209,15 @@ class SystemTtsVoiceRoster @Inject constructor(
             Log.w(TAG, "TextToSpeech ctor threw for engine=$engine: ${t.message}")
             return@withContext null
         }
-        val status = initDeferred.await()
+        // #1384 — bound the init await. A private or otherwise unbindable
+        // engine can leave onInit pending indefinitely while the framework
+        // spins a connect/disconnect loop; without this cap the instance is
+        // never shut down and the loop runs forever.
+        val status = withTimeoutOrNull(INIT_TIMEOUT_MS) { initDeferred.await() }
         if (status != TextToSpeech.SUCCESS) {
+            if (status == null) {
+                Log.w(TAG, "TextToSpeech init timed out after ${INIT_TIMEOUT_MS}ms engine=$engine")
+            }
             runCatching { tts.shutdown() }
             return@withContext null
         }
@@ -215,6 +237,12 @@ class SystemTtsVoiceRoster @Inject constructor(
 
     internal companion object {
         const val TAG = "SystemTtsVoiceRoster"
+
+        /** #1384 — ceiling on the per-engine onInit await. Init normally
+         *  resolves in ~50–150 ms; 8 s is generous headroom for slow
+         *  cold starts while still bounding an engine whose onInit never
+         *  fires (the Samsung private-engine loop). */
+        const val INIT_TIMEOUT_MS: Long = 8_000
 
         /**
          * #740 — second pass over the raw roster that assigns

--- a/app/src/main/kotlin/in/jphe/storyvox/data/TtsEngineResolver.kt
+++ b/app/src/main/kotlin/in/jphe/storyvox/data/TtsEngineResolver.kt
@@ -1,0 +1,57 @@
+package `in`.jphe.storyvox.data
+
+import android.content.Context
+import android.content.Intent
+import android.speech.tts.TextToSpeech
+
+/**
+ * #1384 — picks a publicly bindable TTS engine so we never construct a
+ * framework [TextToSpeech] with a null target.
+ *
+ * On Samsung the device-default TTS is a *private* engine. A null-target
+ * `TextToSpeech(context)` asks the framework to bind that default; the
+ * bind is refused ("not allowed to bind to private engine") and the
+ * framework's fallback-then-reconnect path spins a connect/disconnect
+ * loop that never delivers a clean `onInit`. The instance is therefore
+ * never torn down and the loop (plus its CPU burn) runs forever — even
+ * for users on Piper/Kokoro voices, because roster enumeration probes
+ * System TTS at startup. Binding an explicit public engine skips the
+ * private-default bind entirely.
+ */
+internal class TtsEngineResolver(private val context: Context) {
+
+    /** Package ids of every installed engine that advertises the TTS
+     *  service intent — the same set [TextToSpeech.getEngines] derives,
+     *  obtained without first booting a [TextToSpeech]. */
+    fun installedEnginePackages(): List<String> = runCatching {
+        context.packageManager
+            .queryIntentServices(Intent(TextToSpeech.Engine.INTENT_ACTION_TTS_SERVICE), 0)
+            .mapNotNull { it.serviceInfo?.packageName }
+            .distinct()
+    }.getOrDefault(emptyList())
+
+    /** Engine to bind for default-style probing: never the (possibly
+     *  private) device default — the highest-ranked public engine
+     *  instead. Null only when no TTS engine is installed at all, in
+     *  which case the caller skips enumeration rather than fall back to
+     *  a null target. */
+    fun preferredPublicEngine(): String? = pickPreferred(installedEnginePackages())
+
+    internal companion object {
+        /** Google's TTS — the canonical public engine and the framework's
+         *  own fallback when the device default can't be bound. */
+        const val GOOGLE_TTS = "com.google.android.tts"
+
+        /**
+         * Choose which engine to bind from the installed set: Google
+         * first, then a deterministic (sorted) pick so repeated probes
+         * resolve to the same engine. Returns null only for an empty
+         * set — the signal to skip enumeration entirely.
+         */
+        internal fun pickPreferred(packages: List<String>): String? = when {
+            packages.isEmpty() -> null
+            GOOGLE_TTS in packages -> GOOGLE_TTS
+            else -> packages.sorted().first()
+        }
+    }
+}

--- a/app/src/main/kotlin/in/jphe/storyvox/data/VoiceProviderUiImpl.kt
+++ b/app/src/main/kotlin/in/jphe/storyvox/data/VoiceProviderUiImpl.kt
@@ -15,6 +15,7 @@ import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.flow.shareIn
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.withTimeoutOrNull
 
 /**
  * Legacy voice surface for SettingsViewModel + the legacy VoicePickerScreen +
@@ -29,49 +30,76 @@ class VoiceProviderUiImpl @Inject constructor(
 ) : VoiceProviderUi {
 
     private val scope = CoroutineScope(SupervisorJob() + Dispatchers.Default)
+    private val engineResolver = TtsEngineResolver(context)
 
     override val installedVoices: Flow<List<UiVoice>> = flow {
         val tts = bootTts() ?: run {
             emit(emptyList())
             return@flow
         }
-        val voices = runCatching { tts.voices?.toList().orEmpty() }.getOrDefault(emptyList())
-        val mapped = voices
-            .map {
-                UiVoice(
-                    id = it.name,
-                    label = humanize(it.name),
-                    engine = "System TTS",
-                    locale = it.locale.toLanguageTag(),
-                )
-            }
-            .sortedWith(compareBy({ it.locale }, { it.label }))
-        runCatching { tts.shutdown() }
+        // try/finally so a WhileSubscribed cancellation between boot and
+        // shutdown can't leak the instance into a reconnect loop (#1384).
+        val mapped = try {
+            val voices = runCatching { tts.voices?.toList().orEmpty() }.getOrDefault(emptyList())
+            voices
+                .map {
+                    UiVoice(
+                        id = it.name,
+                        label = humanize(it.name),
+                        engine = "System TTS",
+                        locale = it.locale.toLanguageTag(),
+                    )
+                }
+                .sortedWith(compareBy({ it.locale }, { it.label }))
+        } finally {
+            runCatching { tts.shutdown() }
+        }
         emit(mapped)
     }.shareIn(scope, SharingStarted.WhileSubscribed(5_000), replay = 1)
 
     override fun previewVoice(voice: UiVoice) {
         scope.launch {
             val tts = bootTts() ?: return@launch
-            runCatching {
-                tts.voices?.firstOrNull { it.name == voice.id }?.let { tts.voice = it }
-                tts.speak(PREVIEW_TEXT, TextToSpeech.QUEUE_FLUSH, null, "preview-${voice.id}")
+            try {
+                runCatching {
+                    tts.voices?.firstOrNull { it.name == voice.id }?.let { tts.voice = it }
+                    tts.speak(PREVIEW_TEXT, TextToSpeech.QUEUE_FLUSH, null, "preview-${voice.id}")
+                }
+                // Let the utterance play, then release.
+                kotlinx.coroutines.delay(4_000L)
+            } finally {
+                runCatching { tts.shutdown() }
             }
-            // Let the utterance play, then release.
-            kotlinx.coroutines.delay(4_000L)
-            runCatching { tts.shutdown() }
         }
     }
 
-    /** Boot a one-shot Android [TextToSpeech] tied to whatever engine the OS picks. */
-    private suspend fun bootTts(): TextToSpeech? = kotlinx.coroutines.suspendCancellableCoroutine { cont ->
-        var tts: TextToSpeech? = null
-        tts = TextToSpeech(context) { status ->
-            if (cont.isCompleted) return@TextToSpeech
-            if (status == TextToSpeech.SUCCESS) cont.resume(tts) {} else {
-                runCatching { tts?.shutdown() }
-                cont.resume(null) {}
+    /**
+     * Boot a one-shot Android [TextToSpeech] bound to an explicit public
+     * engine. #1384 — a null target asks the framework to bind the device
+     * default, which on Samsung is a private engine whose refused bind
+     * spins a connect/disconnect loop that never fires onInit. The await
+     * is timeout-bounded and cancellation tears the instance down so a
+     * stuck init can't leak the instance into that loop.
+     */
+    private suspend fun bootTts(): TextToSpeech? = withTimeoutOrNull(INIT_TIMEOUT_MS) {
+        kotlinx.coroutines.suspendCancellableCoroutine { cont ->
+            var tts: TextToSpeech? = null
+            val onInit = TextToSpeech.OnInitListener { status ->
+                if (cont.isCompleted) return@OnInitListener
+                if (status == TextToSpeech.SUCCESS) {
+                    cont.resume(tts) { runCatching { tts?.shutdown() } }
+                } else {
+                    runCatching { tts?.shutdown() }
+                    cont.resume(null) {}
+                }
             }
+            val engine = engineResolver.preferredPublicEngine()
+            tts = if (engine.isNullOrBlank()) {
+                TextToSpeech(context, onInit)
+            } else {
+                TextToSpeech(context, onInit, engine)
+            }
+            cont.invokeOnCancellation { runCatching { tts?.shutdown() } }
         }
     }
 
@@ -82,5 +110,9 @@ class VoiceProviderUiImpl @Inject constructor(
 
     private companion object {
         const val PREVIEW_TEXT = "The brass lantern flickers. Welcome back to the Library Nocturne."
+
+        /** #1384 — ceiling on the onInit await so a stuck engine init
+         *  can't suspend (and leak) the instance forever. */
+        const val INIT_TIMEOUT_MS: Long = 8_000
     }
 }

--- a/app/src/test/kotlin/in/jphe/storyvox/data/TtsEngineResolverTest.kt
+++ b/app/src/test/kotlin/in/jphe/storyvox/data/TtsEngineResolverTest.kt
@@ -1,0 +1,56 @@
+package `in`.jphe.storyvox.data
+
+import `in`.jphe.storyvox.data.TtsEngineResolver.Companion.GOOGLE_TTS
+import `in`.jphe.storyvox.data.TtsEngineResolver.Companion.pickPreferred
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * #1384 — engine selection that keeps System TTS probing off the
+ * null/private-default bind path. On Samsung a null-target
+ * `TextToSpeech` binds the private device default, fails, and spins a
+ * connect/disconnect loop forever; binding an explicit public engine
+ * avoids it. These pin the resolver's contract: never null unless there
+ * is genuinely no engine, prefer Google, and resolve deterministically.
+ */
+class TtsEngineResolverTest {
+
+    @Test
+    fun `no installed engines resolves to null so the caller skips enumeration`() {
+        assertNull(pickPreferred(emptyList()))
+    }
+
+    @Test
+    fun `Google TTS is preferred when present among others`() {
+        assertEquals(
+            GOOGLE_TTS,
+            pickPreferred(listOf("com.samsung.SMT", GOOGLE_TTS, "org.example.espeak")),
+        )
+    }
+
+    @Test
+    fun `Google TTS is chosen regardless of list order`() {
+        assertEquals(GOOGLE_TTS, pickPreferred(listOf(GOOGLE_TTS)))
+        assertEquals(GOOGLE_TTS, pickPreferred(listOf("a.b.c", GOOGLE_TTS)))
+        assertEquals(GOOGLE_TTS, pickPreferred(listOf(GOOGLE_TTS, "z.y.x")))
+    }
+
+    @Test
+    fun `without Google selection is deterministic, never null, and from the set`() {
+        val inOrder = listOf("org.example.espeak", "com.samsung.SMT")
+        val reversed = inOrder.reversed()
+        val a = pickPreferred(inOrder)
+        val b = pickPreferred(reversed)
+        assertNotNull("a public engine must be chosen rather than a null target", a)
+        assertEquals("order must not change the choice", a, b)
+        assertTrue("chosen engine must be one of the installed engines", a in inOrder)
+    }
+
+    @Test
+    fun `a single non-Google engine is selected`() {
+        assertEquals("org.example.espeak", pickPreferred(listOf("org.example.espeak")))
+    }
+}


### PR DESCRIPTION
## #1384 — System TTS infinite connect/disconnect loop on Samsung

### Symptom
At app startup on Samsung (e.g. Z Flip3), the system TTS init spins forever:
```
TextToSpeech: Create TextToSpeech : target[null]
TextToSpeech: not allowed to bind to private engine.
TextToSpeech: getHighestRankedPublicEngineName = com.google.android.tts
TextToSpeech: Sucessfully bound to com.google.android.tts
TextToSpeech: Disconnected from TTS engine
TextToSpeech: Connected to TTS engine
(repeat every ~1–2 s forever)
```
Burns CPU even when the user is on a Piper/Kokoro voice, because the voice roster probes System TTS at startup (`VoicePickerGate.hasSystemTtsEngines` subscribes `Eagerly` → `SystemTtsVoiceRoster` enumeration).

### Root cause
Both startup probe sites constructed `TextToSpeech(context)` with a **null target**. Samsung's device-default TTS is a *private* engine: the framework refuses to bind it, then its fallback-then-reconnect path spins connect/disconnect **without ever delivering a clean `onInit`**. So the suspended boot coroutine never resumes, the instance is never `shutdown()`, and the framework's auto-rebind keeps the loop alive forever.

### Fix
- **`TtsEngineResolver`** (new) resolves a *publicly bindable* engine via `PackageManager` (prefer `com.google.android.tts` — the framework's own fallback), and we pass it explicitly. The private-default bind is never attempted, so the loop's trigger is gone.
  - `SystemTtsVoiceRoster` step 1 still lists **every** installed engine (`TextToSpeech.getEngines()` is engine-independent), so Samsung's own voices stay enumerable via step 2's per-engine binds. Catalog functionality preserved.
- **Timeout-bounded init** (8 s) in both probe sites: any engine whose `onInit` never fires is torn down instead of leaking into the loop. 8 s ≫ the ~50–150 ms typical init, so it never false-fires on a healthy slow device.
- **Leak guards**: `try/finally` around the read/preview bodies + `invokeOnCancellation`, so a `WhileSubscribed` cancellation between boot and shutdown can't leak a live instance either.

### Test
`TtsEngineResolverTest` (pure JVM, no framework) pins the selection contract: never a null target when any engine is installed, prefer Google, resolve deterministically regardless of input order.

### Scope notes
- `SystemTtsEngine.loadModel()` (core-playback) has a similar null-engine branch, but it runs only when a System TTS voice is *actively playing* (not at startup) and its descriptor always carries an engine name — out of scope for this startup-loop fix.
- The `queryIntentServices(Intent, Int)` overload is the correct one for `minSdk 26` (the `ResolveInfoFlags` variant is API 33+).

Fixes #1384

🤖 Generated with [Claude Code](https://claude.com/claude-code)
