### PR TITLE
test(playback): regression net for synthesis pipeline re-entrancy (#1383)

### DIFF
--- a/core-playback/src/main/kotlin/in/jphe/storyvox/playback/tts/SynthPipelineGuards.kt
+++ b/core-playback/src/main/kotlin/in/jphe/storyvox/playback/tts/SynthPipelineGuards.kt
@@ -1,0 +1,74 @@
+package `in`.jphe.storyvox.playback.tts
+
+import `in`.jphe.storyvox.playback.voice.EngineType
+
+/**
+ * Issue #1383 — pure decision functions guarding the two synthesis-pipeline
+ * rebuild paths that caused the "Piper synthesis cancelled immediately after a
+ * PCM cache MISS → intermittent fragments" bug. Extracted as pure functions
+ * (no Android, no coroutines) so the *policy* is unit-testable without standing
+ * up the full [EnginePlayer] + Hilt graph + sherpa-onnx AARs — the same
+ * pattern the engine already uses for [shouldAutoPlayAfterAdvance],
+ * [shouldCheckpointPosition], `crossedThermalModerateBoundary`, and
+ * `DefaultPlaybackController.shouldWatchdogFireFallbackAdvance`.
+ *
+ * These encode the *contract* the #1383 fix must uphold; the fix wires
+ * `loadAndPlay` / the voice-event path through them (a one-line call each) so
+ * the regression net guards the real path rather than a parallel copy. Until
+ * then they stand as the executable specification of the invariant.
+ *
+ * The on-device repro (R5CRB0W66MK, v1.x) logged:
+ * ```
+ * pcm-cache MISS chapter=3609400 voice=piper... fromSentence=11
+ * serial producer: cancelled (close/seek/voice swap) — silent exit
+ * pcm-cache MISS chapter=3609400 voice=piper... fromSentence=11   ← 54 ms later
+ * ```
+ * Two MISSes for the same chapter+sentence 54 ms apart = a re-entrant pipeline
+ * rebuild. The two guards below close the two doors that let that happen.
+ */
+
+/**
+ * Issue #1383 / #944 / #956 — should a second, concurrent `loadAndPlay` for the
+ * same chapter be **deduplicated** (skipped) rather than tearing down and
+ * rebuilding the pipeline?
+ *
+ * `true` when the engine is *already on* the requested `(fictionId, chapterId)`
+ * with a **live pipeline**: a near-simultaneous re-trigger (the double-fire
+ * behind the "two MISSes 54 ms apart" log) must be a no-op, not a second
+ * teardown+rebuild that cancels the first producer mid-synth and strands the
+ * listener on fragments. This is the "never two pipelines for the same chapter"
+ * invariant the `loadAndPlayMutex` exists to enforce.
+ *
+ * When no pipeline is running yet (cold start), or the request targets a
+ * *different* chapter (a genuine navigation / advance), it returns `false` so
+ * the real load proceeds.
+ */
+internal fun shouldDedupeConcurrentLoad(
+    armedFictionId: String?,
+    armedChapterId: String?,
+    requestedFictionId: String,
+    requestedChapterId: String,
+    pipelineRunning: Boolean,
+): Boolean =
+    pipelineRunning &&
+        armedFictionId == requestedFictionId &&
+        armedChapterId == requestedChapterId
+
+/**
+ * Issue #1383 — should a **system-TTS framework reconnection** event trigger a
+ * playback-pipeline rebuild?
+ *
+ * Only when the *currently active* voice is actually an [EngineType.SystemTts]
+ * voice (which is driven by the framework `TextToSpeech` instance that just
+ * reconnected). When an on-device neural engine is active — Piper, Kokoro,
+ * Kitten, Supertonic — or a cloud engine (Azure), the framework reconnect is
+ * irrelevant: those render through their own sherpa-onnx / HTTP paths, not the
+ * system `TextToSpeech`. Rebuilding the pipeline for them is the spurious
+ * teardown that cancelled the Piper producer mid-MISS in #1383.
+ *
+ * So: `true` iff [activeEngineType] is [EngineType.SystemTts]; `false` for
+ * every neural / cloud engine. The voice-change propagation path gates on this
+ * instead of rebuilding unconditionally.
+ */
+internal fun shouldRebuildForSystemTtsReconnect(activeEngineType: EngineType): Boolean =
+    activeEngineType is EngineType.SystemTts

--- a/core-playback/src/test/kotlin/in/jphe/storyvox/playback/tts/SynthPipelineGuardsTest.kt
+++ b/core-playback/src/test/kotlin/in/jphe/storyvox/playback/tts/SynthPipelineGuardsTest.kt
@@ -1,0 +1,122 @@
+package `in`.jphe.storyvox.playback.tts
+
+import `in`.jphe.storyvox.playback.voice.EngineType
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * Issue #1383 — regression net for the two synthesis-pipeline rebuild guards
+ * (see [shouldDedupeConcurrentLoad] / [shouldRebuildForSystemTtsReconnect]).
+ * These pin the policy that prevents "Piper synthesis cancelled right after a
+ * PCM cache MISS → intermittent fragments": a double-fired load for the same
+ * chapter must not rebuild, and a system-TTS framework reconnect must not
+ * rebuild while a neural/cloud voice is active.
+ */
+class SynthPipelineGuardsTest {
+
+    // ── shouldDedupeConcurrentLoad — the "two MISSes 54 ms apart" door ──
+
+    @Test
+    fun `dedupes a second load for the same chapter while a pipeline is live`() {
+        // The exact #1383 double-fire: already playing chapter 3609400, a
+        // near-simultaneous re-trigger for the SAME chapter must be a no-op.
+        assertTrue(
+            shouldDedupeConcurrentLoad(
+                armedFictionId = "f1",
+                armedChapterId = "3609400",
+                requestedFictionId = "f1",
+                requestedChapterId = "3609400",
+                pipelineRunning = true,
+            ),
+        )
+    }
+
+    @Test
+    fun `does NOT dedupe when no pipeline is running yet — cold start must proceed`() {
+        assertFalse(
+            shouldDedupeConcurrentLoad(
+                armedFictionId = "f1",
+                armedChapterId = "3609400",
+                requestedFictionId = "f1",
+                requestedChapterId = "3609400",
+                pipelineRunning = false,
+            ),
+        )
+    }
+
+    @Test
+    fun `does NOT dedupe a genuine navigation to a different chapter`() {
+        assertFalse(
+            shouldDedupeConcurrentLoad(
+                armedFictionId = "f1",
+                armedChapterId = "3609400",
+                requestedFictionId = "f1",
+                requestedChapterId = "3609401",
+                pipelineRunning = true,
+            ),
+        )
+    }
+
+    @Test
+    fun `does NOT dedupe a load for a different fiction`() {
+        assertFalse(
+            shouldDedupeConcurrentLoad(
+                armedFictionId = "f1",
+                armedChapterId = "3609400",
+                requestedFictionId = "f2",
+                requestedChapterId = "3609400",
+                pipelineRunning = true,
+            ),
+        )
+    }
+
+    @Test
+    fun `does NOT dedupe when nothing is armed yet`() {
+        // First-ever load: armed ids are null, so there is nothing to dedupe
+        // against even if a stale running flag lingered.
+        assertFalse(
+            shouldDedupeConcurrentLoad(
+                armedFictionId = null,
+                armedChapterId = null,
+                requestedFictionId = "f1",
+                requestedChapterId = "3609400",
+                pipelineRunning = true,
+            ),
+        )
+    }
+
+    // ── shouldRebuildForSystemTtsReconnect — the voice-event gating door ──
+
+    @Test
+    fun `rebuilds on a system-TTS reconnect only when a system voice is active`() {
+        assertTrue(
+            shouldRebuildForSystemTtsReconnect(
+                EngineType.SystemTts(engineName = "com.google.android.tts", voiceName = "en-us-x-iol"),
+            ),
+        )
+    }
+
+    @Test
+    fun `does NOT rebuild for Piper — the #1383 case`() {
+        // Piper renders through sherpa-onnx, not the framework TextToSpeech;
+        // a system-TTS reconnect must not tear its producer down mid-MISS.
+        assertFalse(shouldRebuildForSystemTtsReconnect(EngineType.Piper))
+    }
+
+    @Test
+    fun `does NOT rebuild for Kokoro Kitten or Supertonic neural engines`() {
+        assertFalse(shouldRebuildForSystemTtsReconnect(EngineType.Kokoro(speakerId = 0)))
+        assertFalse(shouldRebuildForSystemTtsReconnect(EngineType.Kitten(speakerId = 3)))
+        assertFalse(shouldRebuildForSystemTtsReconnect(EngineType.Supertonic(speakerId = 1)))
+    }
+
+    @Test
+    fun `does NOT rebuild for a cloud Azure voice`() {
+        assertFalse(
+            shouldRebuildForSystemTtsReconnect(
+                EngineType.Azure(voiceName = "en-US-AvaMultilingualNeural", region = "eastus"),
+            ),
+        )
+    }
+}


### PR DESCRIPTION
## Playback pipeline regression net for #1383

**Bug (#1383):** Piper synthesis gets cancelled within ~35 ms of a PCM cache MISS (close/seek/voice-swap), leaving the listener with intermittent fragments. The log shows **two MISSes for the same chapter+sentence 54 ms apart** — a re-entrant pipeline rebuild. Root causes are being fixed by Lucid (`fix/1383-piper-synthesis-cancel`) and Drift (`fix/1383-voice-guard`); this is the "never regress" safety net.

### Coverage audit (done first — the brief's 5 behaviors)

I audited the existing suite before writing anything. **3 of the 5 requested behaviors are already covered** — re-testing them would duplicate:

| Behavior | Already covered by |
|---|---|
| #1 producer lifecycle (runs to completion, END_PILL; close → terminal) | `EngineStreamingSourceTest`, `ProducedAllRaceTest`, `EngineStreamingSourceGaplessTest` (incl. `producedAllSentences` **false** on close/seek-race) |
| #4 cache MISS → producer → finalize | `EngineStreamingSourceCacheTeeTest` (tee per sentence, finalize completes, close/seek abandon, null no-op, idempotent finalize) |
| #5 watchdog quiet/fires | `WatchdogDirectionTest` (`shouldWatchdogFireFallbackAdvance`, `watchdogRecoveryDirection`) |

### What this PR adds (the genuinely-uncovered contracts: #2, #3)

The real #1383 regression surface lives in `EnginePlayer.loadAndPlay` and the voice-event path, which **can't be stood up in a pure JVM test** (Hilt + sherpa-onnx AARs). The codebase's established answer is a pure top-level `internal fun shouldX(...)` decision function that the engine calls and a unit test covers (`shouldAutoPlayAfterAdvance`, `crossedThermalModerateBoundary`, `shouldWatchdogFireFallbackAdvance`). Following that pattern, `SynthPipelineGuards.kt` adds:

- **`shouldDedupeConcurrentLoad(armed…, requested…, pipelineRunning)`** — a second concurrent `loadAndPlay` for the **same chapter while a pipeline is live** must be a no-op, not a teardown+rebuild that cancels the first producer mid-synth. Encodes the "never two pipelines for the same chapter" invariant (the "two MISSes 54 ms apart" door). *(#2)*
- **`shouldRebuildForSystemTtsReconnect(activeEngineType)`** — a system-TTS framework reconnect rebuilds **only** when a `SystemTts` voice is active; Piper / Kokoro / Kitten / Supertonic / Azure return `false`. *(#3)*

Both are pure + **exhaustively unit-tested** (`SynthPipelineGuardsTest`), pure JVM, no Robolectric. Green on `main` independently.

### ⚠️ Wiring dependency (coordination)

These guards are the **seam the #1383 fixes route through** — one call each from `loadAndPlay` (Lucid) and the voice-event path (Drift) — so the net guards the *real* path. Until wired they stand as the executable spec of the invariant. I've pinged Lucid + Drift to adopt them; if either fix lands its own seam instead, I'll retarget these tests onto it (the assertions are identical, just the function reference changes).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
