### PR TITLE
fix(tts): skip all TextToSpeech creation on Samsung at startup (#1392)

### DIFF
--- a/app/src/main/kotlin/in/jphe/storyvox/data/SystemTtsVoiceRoster.kt
+++ b/app/src/main/kotlin/in/jphe/storyvox/data/SystemTtsVoiceRoster.kt
@@ -102,6 +102,16 @@ class SystemTtsVoiceRoster @Inject constructor(
      * others).
      */
     private suspend fun enumerate(): List<SystemTtsVoiceDescriptor> {
+        // #1392 — Samsung's modified framework disconnects ALL TTS
+        // instances when its internal private-engine check fires during
+        // connection setup, even with an explicit public engine target.
+        // Skip system TTS enumeration entirely on Samsung; Piper /
+        // Kokoro / Azure voices still populate the picker.
+        if (engineResolver.isSamsungDevice) {
+            Log.i(TAG, "Samsung device — skipping system TTS enumeration (#1392)")
+            return emptyList()
+        }
+
         // Step 1: list installed engines. #1384 — bind an explicit
         // public engine rather than the null/device-default target: on
         // Samsung the default is a private engine whose failed bind

--- a/app/src/main/kotlin/in/jphe/storyvox/data/TtsEngineResolver.kt
+++ b/app/src/main/kotlin/in/jphe/storyvox/data/TtsEngineResolver.kt
@@ -2,6 +2,7 @@ package `in`.jphe.storyvox.data
 
 import android.content.Context
 import android.content.Intent
+import android.os.Build
 import android.speech.tts.TextToSpeech
 
 /**
@@ -43,6 +44,14 @@ internal class TtsEngineResolver(private val context: Context) {
      *  loop that [TextToSpeech.shutdown] cannot stop. */
     fun bindableEnginePackages(): List<String> =
         installedEnginePackages().filter { it !in PRIVATE_ENGINES }
+
+    /** #1392 — Samsung's modified framework disconnects ALL TTS
+     *  instances when its internal private-engine check fails during
+     *  connection setup, even for TextToSpeech created with an explicit
+     *  public engine target. Any TextToSpeech on Samsung triggers the
+     *  loop. Returns true on Samsung OneUI devices. */
+    val isSamsungDevice: Boolean
+        get() = Build.MANUFACTURER.equals("samsung", ignoreCase = true)
 
     internal companion object {
         /** Google's TTS — the canonical public engine and the framework's

--- a/app/src/main/kotlin/in/jphe/storyvox/data/VoiceProviderUiImpl.kt
+++ b/app/src/main/kotlin/in/jphe/storyvox/data/VoiceProviderUiImpl.kt
@@ -81,25 +81,33 @@ class VoiceProviderUiImpl @Inject constructor(
      * is timeout-bounded and cancellation tears the instance down so a
      * stuck init can't leak the instance into that loop.
      */
-    private suspend fun bootTts(): TextToSpeech? = withTimeoutOrNull(INIT_TIMEOUT_MS) {
-        kotlinx.coroutines.suspendCancellableCoroutine { cont ->
-            var tts: TextToSpeech? = null
-            val onInit = TextToSpeech.OnInitListener { status ->
-                if (cont.isCompleted) return@OnInitListener
-                if (status == TextToSpeech.SUCCESS) {
-                    cont.resume(tts) { runCatching { tts?.shutdown() } }
-                } else {
-                    runCatching { tts?.shutdown() }
-                    cont.resume(null) {}
+    private suspend fun bootTts(): TextToSpeech? {
+        // #1392 — any TextToSpeech on Samsung triggers the infinite
+        // reconnect loop via the framework's internal private-engine
+        // probe. Skip entirely; system TTS voices are hidden on Samsung
+        // anyway (SystemTtsVoiceRoster returns empty), so nothing to
+        // boot for.
+        if (engineResolver.isSamsungDevice) return null
+        return withTimeoutOrNull(INIT_TIMEOUT_MS) {
+            kotlinx.coroutines.suspendCancellableCoroutine { cont ->
+                var tts: TextToSpeech? = null
+                val onInit = TextToSpeech.OnInitListener { status ->
+                    if (cont.isCompleted) return@OnInitListener
+                    if (status == TextToSpeech.SUCCESS) {
+                        cont.resume(tts) { runCatching { tts?.shutdown() } }
+                    } else {
+                        runCatching { tts?.shutdown() }
+                        cont.resume(null) {}
+                    }
                 }
+                val engine = engineResolver.preferredPublicEngine()
+                tts = if (engine.isNullOrBlank()) {
+                    TextToSpeech(context, onInit)
+                } else {
+                    TextToSpeech(context, onInit, engine)
+                }
+                cont.invokeOnCancellation { runCatching { tts?.shutdown() } }
             }
-            val engine = engineResolver.preferredPublicEngine()
-            tts = if (engine.isNullOrBlank()) {
-                TextToSpeech(context, onInit)
-            } else {
-                TextToSpeech(context, onInit, engine)
-            }
-            cont.invokeOnCancellation { runCatching { tts?.shutdown() } }
         }
     }
 


### PR DESCRIPTION
## Summary
- Add `TtsEngineResolver.isSamsungDevice` property (`Build.MANUFACTURER` check)
- `SystemTtsVoiceRoster.enumerate()` returns empty immediately on Samsung — no `TextToSpeech` constructed
- `VoiceProviderUiImpl.bootTts()` returns null immediately on Samsung — no `TextToSpeech` constructed
- Piper/Kokoro/Azure voices still populate the voice picker; only system TTS enumeration is deferred
- Playback via `SystemTtsEngine` remains available for user-initiated actions

## Context
v1.5.2 (#1390) filtered `com.samsung.SMT` from per-engine probing, but Samsung's modified framework bypasses our filter — it internally probes the private default engine during ANY `TextToSpeech` connection setup, disconnecting all active TTS instances and entering a Handler-posted reconnect loop that `shutdown()` can't stop. The only effective defense is to avoid constructing any `TextToSpeech` on Samsung at startup.

Closes #1392

## Test plan
- [ ] CI Build APK green
- [ ] Install on Samsung Z Flip3 — app launches without TTS reconnect loop
- [ ] Voice picker still shows Piper/Kokoro voices (system TTS voices hidden on Samsung)
- [ ] Playback with non-system TTS voice works normally

Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved voice loading on Samsung devices by skipping unsupported system voice enumeration and initialization.
  * Reduced the chance of delays or failures when opening voice settings on affected devices.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->