### PR TITLE
fix(playback): cancel stale PCM pre-render jobs on cold start (#1392)

### DIFF
--- a/app/src/main/kotlin/in/jphe/storyvox/StoryvoxApp.kt
+++ b/app/src/main/kotlin/in/jphe/storyvox/StoryvoxApp.kt
@@ -186,9 +186,7 @@ class StoryvoxApp : Application(), Configuration.Provider {
         initScope.launch {
             runCatching {
                 WorkManager.getInstance(this@StoryvoxApp)
-                    .cancelAllWorkByTag(
-                        `in`.jphe.storyvox.playback.cache.PcmRenderScheduler.TAG,
-                    )
+                    .cancelAllWorkByTag("pcm-render")
             }
         }
         // Issue #409 — every previous-eager step is now scheduled on

--- a/app/src/main/kotlin/in/jphe/storyvox/StoryvoxApp.kt
+++ b/app/src/main/kotlin/in/jphe/storyvox/StoryvoxApp.kt
@@ -23,6 +23,7 @@ import `in`.jphe.storyvox.feature.api.SettingsRepositoryUi
 import `in`.jphe.storyvox.playback.VoiceEngineQualityBridge
 import `in`.jphe.storyvox.sync.coordinator.SyncCoordinator
 import `in`.jphe.storyvox.widget.WidgetStateObserver
+import androidx.work.WorkManager
 import javax.inject.Inject
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
@@ -175,6 +176,21 @@ class StoryvoxApp : Application(), Configuration.Provider {
 
     override fun onCreate() {
         super.onCreate()
+        // #1392 — cancel stale PCM pre-render jobs BEFORE WorkManager
+        // restarts them. On memory-constrained Samsung devices, the
+        // sherpa-onnx model load (~120MB native heap) from a restarted
+        // ChapterRenderJob triggers the Low Memory Killer within 15s of
+        // app launch. Cancelling is safe: pre-renders are speculative
+        // and re-enqueue naturally on the next library-add / chapter-
+        // complete / Mode-C flip.
+        initScope.launch {
+            runCatching {
+                WorkManager.getInstance(this@StoryvoxApp)
+                    .cancelAllWorkByTag(
+                        `in`.jphe.storyvox.playback.cache.PcmRenderScheduler.TAG,
+                    )
+            }
+        }
         // Issue #409 — every previous-eager step is now scheduled on
         // [Dispatchers.IO] via the [Lazy] accessors. The main thread
         // returns from onCreate as fast as the Hilt component-injection

--- a/core-playback/src/main/kotlin/in/jphe/storyvox/playback/cache/PcmRenderScheduler.kt
+++ b/core-playback/src/main/kotlin/in/jphe/storyvox/playback/cache/PcmRenderScheduler.kt
@@ -93,6 +93,10 @@ class WorkManagerPcmRenderScheduler @Inject constructor(
         val request = OneTimeWorkRequestBuilder<ChapterRenderJob>()
             .setConstraints(constraints)
             .setInputData(input)
+            // #1392 — delay so the model load doesn't overlap with app
+            // startup. On memory-constrained Samsung devices, an
+            // immediate sherpa-onnx load triggers the Low Memory Killer.
+            .setInitialDelay(Duration.ofSeconds(30))
             // Long backoff — a render that fails (model load failure,
             // OOM mid-generate) is unlikely to succeed on a quick retry.
             // Give the device time to clean up; if it keeps failing, the


### PR DESCRIPTION
## Summary
- Cancel all `pcm-render` tagged WorkManager jobs on cold start in `StoryvoxApp.onCreate` before they restart and load sherpa-onnx
- Add 30s initial delay to new PCM render requests so they never overlap with the startup memory window
- Root cause confirmed via `dumpsys meminfo` comparison: JP's phone loads 119MB native heap at startup (pending render jobs load sherpa-onnx model) vs 18MB on the test phone (no pending jobs). Samsung's LMK kills the 307MB process within 15s on a device with 1.7GB available

## Context
Same issue as #1393 (Samsung TTS startup bypass) but a second, independent kill path. Even with TTS enumeration skipped, persisted WorkManager `ChapterRenderJob` entries restart immediately and load the ~120MB sherpa-onnx ONNX model, triggering Samsung's Low Memory Killer on memory-constrained daily-driver phones.

Pre-renders are speculative — they re-enqueue naturally on library-add, chapter-complete, or Mode-C flip.

Closes #1392

## Test plan
- [ ] CI Build APK green
- [ ] Install on JP's Samsung Z Flip3 (R5CR80DJ7TR) — app stays alive, no LMK kill
- [ ] `dumpsys meminfo` shows ~18MB native heap at startup, not ~119MB
- [ ] PCM pre-renders still fire after 30s delay when triggered by user interaction

Generated with [Claude Code](https://claude.com/claude-code)