### PR TITLE
fix(wear): rebrand storyvox → Candela in Wear app display strings

### DIFF
--- a/wear/src/main/kotlin/in/jphe/storyvox/wear/screens/NowPlayingScreen.kt
+++ b/wear/src/main/kotlin/in/jphe/storyvox/wear/screens/NowPlayingScreen.kt
@@ -251,7 +251,7 @@ private fun ChapterMeta(state: PlaybackState) {
         modifier = Modifier.fillMaxWidth(),
     ) {
         Text(
-            text = state.chapterTitle ?: state.bookTitle ?: "storyvox",
+            text = state.chapterTitle ?: state.bookTitle ?: "Candela",
             style = MaterialTheme.typography.title3,
             color = BrassPrimary,
             maxLines = 1,

--- a/wear/src/main/res/values/strings.xml
+++ b/wear/src/main/res/values/strings.xml
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <string name="wear_app_name">storyvox</string>
+    <string name="wear_app_name">Candela</string>
 </resources>


### PR DESCRIPTION
## Wear OS rebrand: storyvox → Candela

The Wear companion app still displayed the old **storyvox** name. This rebrands the two user-visible spots and nothing else.

### Changed
| Location | Before | After | What the user sees |
|---|---|---|---|
| `wear/src/main/res/values/strings.xml` (`wear_app_name`) | `storyvox` | `Candela` | App label — launcher icon + `AndroidManifest android:label` |
| `wear/src/main/.../screens/NowPlayingScreen.kt:254` | `?: "storyvox"` | `?: "Candela"` | Now-Playing title fallback, shown when the watch has no chapter/book metadata yet |

### Deliberately left unchanged
- **`wear.xml` → `storyvox_playback_controller`** — phone↔watch capability is a **wire-protocol identifier**; renaming it would break communication between the app and the watch.
- **`build.gradle.kts` → `app/storyvox-debug.keystore`** — a real on-disk filename, not user-visible.
- **`in.jphe.storyvox.*`** package declarations, imports, and KDoc cross-references — source identifiers, invisible to users.
- The **`PlaybackError.FutureV2Error` JSON test fixture** (`WearPlaybackBridge` decode test) — a serialized class FQN mirroring the phone's real error payload; not display text, and renaming it would break both the test and the protocol contract.

A full case-insensitive `wear/` sweep confirms no other user-visible "storyvox" strings remain (the only resource hit left is the intentional capability identifier above).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the fallback title shown on the Now Playing screen when no chapter or book title is available.
  * Renamed the Wear app display name to **Candela** for a consistent user-facing experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->