### PR TITLE
fix(wear): UI polish — 48dp touch targets, adaptive cover, teleprompter entry

### DIFF
--- a/wear/src/main/kotlin/in/jphe/storyvox/wear/components/TransportRow.kt
+++ b/wear/src/main/kotlin/in/jphe/storyvox/wear/components/TransportRow.kt
@@ -83,8 +83,12 @@ private fun TransportButton(
     isPrimary: Boolean,
     enabled: Boolean,
 ) {
-    val size = if (isPrimary) 44.dp else 36.dp
-    val iconSize = if (isPrimary) 24.dp else 20.dp
+    // Wear OS requires a ≥48dp touch target. These were 44/36dp — both under
+    // the minimum, the muted skip buttons egregiously so, which made the
+    // transport row hard to hit on the wrist. Primary keeps a little more
+    // presence so the eye (and thumb) still land on play/pause first.
+    val size = if (isPrimary) 52.dp else 48.dp
+    val iconSize = if (isPrimary) 26.dp else 22.dp
     Button(
         onClick = onClick,
         enabled = enabled,

--- a/wear/src/main/kotlin/in/jphe/storyvox/wear/screens/NowPlayingScreen.kt
+++ b/wear/src/main/kotlin/in/jphe/storyvox/wear/screens/NowPlayingScreen.kt
@@ -146,19 +146,23 @@ internal fun NowPlayingContent(
                     onSkipForward = onSkipForward,
                 )
             }
-            // #1308 — entry to the teleprompter remote (a separate surface).
-            // Bottom-edge label so it doesn't crowd the transport controls;
-            // only offered when a phone is reachable.
+            // #1308 — entry to the teleprompter remote (a separate surface),
+            // only offered when a phone is reachable. Anchored at the bottom
+            // edge so it doesn't crowd the centered transport controls. Lifted
+            // off the bezel (was 2dp — clipped on round faces) and given a
+            // larger interior tap target (was bare caption2 text, too small to
+            // hit reliably); caption1 reads more legibly at arm's length.
             if (connected) {
                 Text(
                     text = "Teleprompter",
                     color = BrassPrimary,
                     textAlign = TextAlign.Center,
-                    style = MaterialTheme.typography.caption2,
+                    style = MaterialTheme.typography.caption1,
                     modifier = Modifier
                         .align(Alignment.BottomCenter)
-                        .padding(bottom = 2.dp)
-                        .clickable(onClick = onOpenTeleprompter),
+                        .padding(bottom = 8.dp)
+                        .clickable(onClick = onOpenTeleprompter)
+                        .padding(horizontal = 16.dp, vertical = 6.dp),
                 )
             }
         }
@@ -175,6 +179,12 @@ private fun RoundNowPlaying(
     onSkipForward: () -> Unit,
     onScrub: ((fraction: Float) -> Unit)? = null,
 ) {
+    // Scale the cover+ring to the watch instead of a fixed 116dp — small round
+    // faces were crowded (worse now the transport row honours the 48dp touch
+    // minimum). ~40% of the face diameter, clamped to a sane range so it stays
+    // generous on large faces without pushing the transport off small ones.
+    val coverSize = (LocalConfiguration.current.screenWidthDp * 0.40f).dp
+        .coerceIn(80.dp, 108.dp)
     Column(
         modifier = Modifier
             .fillMaxSize()
@@ -187,7 +197,7 @@ private fun RoundNowPlaying(
             indeterminate = state.isBuffering,
             onScrub = onScrub,
             modifier = Modifier
-                .size(116.dp)
+                .size(coverSize)
                 .aspectRatio(1f),
         ) {
             ChapterCover(

--- a/wear/src/main/kotlin/in/jphe/storyvox/wear/screens/TeleprompterRemoteScreen.kt
+++ b/wear/src/main/kotlin/in/jphe/storyvox/wear/screens/TeleprompterRemoteScreen.kt
@@ -83,7 +83,7 @@ fun TeleprompterRemoteScreen(
             textAlign = TextAlign.Center,
             style = MaterialTheme.typography.title3,
         )
-        Spacer(Modifier.height(8.dp))
+        Spacer(Modifier.height(6.dp))
 
         // Enable / disable the mode — always tappable while connected.
         RoundIconButton(
@@ -93,7 +93,7 @@ fun TeleprompterRemoteScreen(
             isPrimary = state.enabled,
             enabled = state.connected,
         )
-        Spacer(Modifier.height(10.dp))
+        Spacer(Modifier.height(6.dp))
 
         // WPM stepper: − [ value ] +
         Row(
@@ -129,7 +129,7 @@ fun TeleprompterRemoteScreen(
             textAlign = TextAlign.Center,
             style = MaterialTheme.typography.caption2,
         )
-        Spacer(Modifier.height(10.dp))
+        Spacer(Modifier.height(6.dp))
 
         // Run / pause the scroll.
         RoundIconButton(
@@ -155,8 +155,9 @@ private fun RoundIconButton(
     isPrimary: Boolean,
     enabled: Boolean,
 ) {
-    val size = if (isPrimary) 44.dp else 36.dp
-    val iconSize = if (isPrimary) 24.dp else 20.dp
+    // Wear OS ≥48dp touch target (mirrors TransportRow). Were 44/36dp.
+    val size = if (isPrimary) 52.dp else 48.dp
+    val iconSize = if (isPrimary) 26.dp else 22.dp
     Button(
         onClick = onClick,
         enabled = enabled,


### PR DESCRIPTION
Polish pass on the Wear now-playing + teleprompter-remote surfaces (Library Nocturne, brass-on-warm-dark). Investigated against the 8 jank checkpoints; fixed the clear, safe wins and flagged one that needs a structural redesign.

## Fixed
- **Touch targets (Wear ≥48dp):** `TransportRow` and `TeleprompterRemoteScreen` buttons were **44dp primary / 36dp secondary** — both under the minimum, the skip/stepper buttons especially hard to hit on the wrist. Bumped to **52 / 48dp** with proportional icons (26/22dp). *This is the headline fix — it appeared in both files.*
- **Cramped small round faces / hardcoded size:** the round cover+ring was a fixed **116dp**; now scales to **~40% of the face diameter, clamped 80–108dp** (via `LocalConfiguration.screenWidthDp`). De-crowds small round and absorbs the now-taller transport row.
- **Teleprompter entry label:** sat **2dp off the bezel** (clipped on round faces) with a sub-minimum tap area and tiny `caption2` text. Lifted to **8dp**, enlarged the tap target via interior padding, and bumped to **`caption1`** for arm's-length legibility.
- **Teleprompter-remote fit:** tightened the inter-control spacers (8/10 → 6dp) so the larger 48dp buttons still fit the face.

## Checkpoints
✅ #3 touch targets · ✅ #1/#8 spacing + relative sizing (adaptive cover) · ✅ #5 teleprompter label · ✅ #4 alignment. #2 truncation already handled (`maxLines` + `Ellipsis`). #6 disconnected + #7 round buffering already read fine.

## Deliberately deferred (flagged, not done blind)
A **fully 48dp in-flow** teleprompter slot and a guaranteed small-round fit would require the round now-playing to become a **`ScalingLazyColumn`** (scrollable) — but that trades off the signature ring-framed-cover layout (a fixed, centered focal element). The cover-ring + metadata + 48dp transport + a 48dp teleprompter slot can't all fit a round face without scrolling. That's a design decision worth a dedicated pass rather than a blind structural rewrite (no Wear preview in this environment). The teleprompter entry here is meaningfully improved (legible, off-edge, larger target) in the meantime.

Layout/visual only — no playback or branding changes. Coordinated with the parallel `fix/wear-icon-candela` and `fix/wear-rebrand-candela` branches (which own the icon/branding); no file overlap. Not compiled locally per the compile-on-CI workflow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
