### PR TITLE
feat(wear): voice-paced teleprompter line display on the wrist (#1368)

### DIFF
--- a/core-playback/src/main/kotlin/in/jphe/storyvox/playback/PlaybackState.kt
+++ b/core-playback/src/main/kotlin/in/jphe/storyvox/playback/PlaybackState.kt
@@ -55,6 +55,13 @@ data class PlaybackState(
     val recordingArmed: Boolean = false,
     val recording: Boolean = false,
     val recordingElapsedMs: Long = 0L,
+    /** Voice-paced teleprompter (#1368) — the line the speaker is currently on
+     *  and the upcoming one, derived from `VoicePacedScrollController.positionChar`
+     *  and published by `PhoneWearBridge` so the Wear remote can render the
+     *  current/next line without holding the chapter text. Empty when voice-paced
+     *  isn't active; defaults keep older watch builds unaffected. */
+    val teleprompterCurrentLine: String = "",
+    val teleprompterNextLine: String = "",
 )
 
 @Serializable

--- a/core-playback/src/main/kotlin/in/jphe/storyvox/playback/transcribe/VoicePacedScrollController.kt
+++ b/core-playback/src/main/kotlin/in/jphe/storyvox/playback/transcribe/VoicePacedScrollController.kt
@@ -56,6 +56,22 @@ class VoicePacedScrollController @Inject constructor(
     /** True between [start] and [stop] — the mic session is active. */
     val listening: StateFlow<Boolean> = _listening.asStateFlow()
 
+    private val _wristLines = MutableStateFlow(WristLines.EMPTY)
+
+    /**
+     * The current + next display line the speaker is on, derived from
+     * [positionChar]. Surface-agnostic *text* (not pixels) — the phone ships it
+     * to the Wear teleprompter remote so the watch can render the line without
+     * holding the whole chapter. Empty between sessions; a [StateFlow] dedups,
+     * so it only changes when the speaker crosses into a new line, not on every
+     * recognized word.
+     */
+    val wristLines: StateFlow<WristLines> = _wristLines.asStateFlow()
+
+    /** Display-line spans of the current chapter (original text, so spans line
+     *  up with the source-space [positionChar]). Rebuilt each [start]. */
+    private var lineSpans: List<LineSpan> = emptyList()
+
     /**
      * Begin a voice-paced session over [chapterText]: build the aligner, start
      * capture, and stream recognized words into it. Idempotent while already
@@ -68,13 +84,19 @@ class VoicePacedScrollController @Inject constructor(
         // displayed (un-stripped) chapter text.
         val spoken = ScriptCueFilter.spokenText(chapterText)
         val aligner = ForcedAligner(spoken.text)
+        // Display lines are split from the ORIGINAL text so their spans align
+        // with the source-space offset published below.
+        lineSpans = splitTeleprompterLines(chapterText)
         _positionChar.value = 0
+        _wristLines.value = wristLinesAt(lineSpans, 0)
         _listening.value = true
         wordSource.start()
         job = scope.launch {
             wordSource.words.collect { word ->
                 val spokenOffset = aligner.onWord(word.text, word.confidence)
-                _positionChar.value = spoken.toSourceOffset(spokenOffset)
+                val sourceOffset = spoken.toSourceOffset(spokenOffset)
+                _positionChar.value = sourceOffset
+                _wristLines.value = wristLinesAt(lineSpans, sourceOffset)
             }
         }
     }
@@ -85,5 +107,6 @@ class VoicePacedScrollController @Inject constructor(
         job = null
         wordSource.stop()
         _listening.value = false
+        _wristLines.value = WristLines.EMPTY
     }
 }

--- a/core-playback/src/main/kotlin/in/jphe/storyvox/playback/transcribe/WristTeleprompterLines.kt
+++ b/core-playback/src/main/kotlin/in/jphe/storyvox/playback/transcribe/WristTeleprompterLines.kt
@@ -1,0 +1,86 @@
+package `in`.jphe.storyvox.playback.transcribe
+
+/**
+ * Issue #1372/#1308 follow-up — turns the voice-paced [VoicePacedScrollController]'s
+ * character offset into the **current + next display line** for a glanceable
+ * surface (the Wear teleprompter remote). Pure (no Android, no Compose) so the
+ * line-splitting + lookup are unit-testable, and surface-agnostic: it produces
+ * *text*, not pixels (the px mapping stays the reader's job — see the
+ * VoicePacedScrollController kdoc).
+ *
+ * The watch can't hold the chapter text (too large to sync over the Wearable
+ * data layer), so the phone derives these two short strings from `positionChar`
+ * and ships only them in `PlaybackState`.
+ */
+
+/** A line of the chapter with its character span in the original text. */
+data class LineSpan(val start: Int, val end: Int, val text: String)
+
+/** The line the speaker is currently on plus the upcoming one (either may be
+ *  empty — e.g. no text, or the last line has no successor). */
+data class WristLines(val current: String, val next: String) {
+    companion object {
+        val EMPTY = WristLines("", "")
+    }
+}
+
+/**
+ * Split [text] into teleprompter "lines" — sentence/line units broken at
+ * terminal punctuation (`.`, `!`, `?`, `…`) or newlines, with their spans in
+ * the original string preserved so a [positionChar] can be located. Runs of
+ * terminators/newlines (e.g. `"..."`, `".\n\n"`) collapse into one break, and
+ * whitespace-only fragments are dropped, so a script's blank lines and ellipses
+ * don't produce empty "lines".
+ */
+fun splitTeleprompterLines(text: String): List<LineSpan> {
+    val out = ArrayList<LineSpan>()
+    var start = 0
+    var i = 0
+
+    fun isBreak(c: Char) = c == '\n' || c == '.' || c == '!' || c == '?' || c == '…'
+
+    fun flush(end: Int) {
+        var s = start
+        var e = end
+        while (s < e && text[s].isWhitespace()) s++
+        while (e > s && text[e - 1].isWhitespace()) e--
+        // Keep only spans that contain at least one letter/digit — drops
+        // pure-punctuation crumbs left by a run of terminators.
+        if (e > s && (s until e).any { text[it].isLetterOrDigit() }) {
+            out.add(LineSpan(s, e, text.substring(s, e)))
+        }
+        start = end
+    }
+
+    while (i < text.length) {
+        if (isBreak(text[i])) {
+            var j = i + 1
+            while (j < text.length && isBreak(text[j])) j++
+            flush(j)
+            i = j
+        } else {
+            i++
+        }
+    }
+    if (start < text.length) flush(text.length)
+    return out
+}
+
+/**
+ * The [WristLines] for [positionChar] against pre-split [spans]: the current
+ * line is the last span starting at or before [positionChar] (so a cursor
+ * mid-line still resolves to that line, and offset 0 / pre-first-match resolves
+ * to the first line), and the next line is the span after it. Empty spans →
+ * [WristLines.EMPTY].
+ */
+fun wristLinesAt(spans: List<LineSpan>, positionChar: Int): WristLines {
+    if (spans.isEmpty()) return WristLines.EMPTY
+    var idx = 0
+    for (k in spans.indices) {
+        if (spans[k].start <= positionChar) idx = k else break
+    }
+    return WristLines(
+        current = spans[idx].text,
+        next = spans.getOrNull(idx + 1)?.text ?: "",
+    )
+}

--- a/core-playback/src/main/kotlin/in/jphe/storyvox/playback/wear/PhoneWearBridge.kt
+++ b/core-playback/src/main/kotlin/in/jphe/storyvox/playback/wear/PhoneWearBridge.kt
@@ -12,6 +12,7 @@ import `in`.jphe.storyvox.playback.PlaybackState
 import `in`.jphe.storyvox.playback.RecordingController
 import `in`.jphe.storyvox.playback.SleepTimerMode
 import `in`.jphe.storyvox.playback.TeleprompterController
+import `in`.jphe.storyvox.playback.transcribe.VoicePacedScrollController
 import javax.inject.Inject
 import javax.inject.Singleton
 import kotlinx.coroutines.CoroutineScope
@@ -45,6 +46,7 @@ class PhoneWearBridge @Inject constructor(
     private val teleprompterController: TeleprompterController,
     private val recordingController: RecordingController,
     private val statsRepository: ListeningStatsRepository,
+    private val voicePaced: VoicePacedScrollController,
 ) : MessageClient.OnMessageReceivedListener {
 
     private val scope = CoroutineScope(SupervisorJob() + Dispatchers.Default)
@@ -61,18 +63,25 @@ class PhoneWearBridge @Inject constructor(
             // change re-publishes, same as a playback change.
             // #1367 (Wear PR1) — also fold RecordingController state in, so the
             // watch reflects recording over the same /playback/state sync.
-            // Two nested 4-arg combines keep each within the typed overload
-            // limit (a single 7-flow combine would fall to the untyped vararg).
+            // #1368 — the voice-paced wristLines rides the first combine.
+            // Two nested combines (a 5-arg teleprompter+lines stage, then a
+            // 4-arg recording stage) keep each within combine's typed-overload
+            // limit — a single 8-flow combine would fall to the untyped vararg.
             val withTeleprompter = combine(
                 controller.state,
                 teleprompterController.enabled,
                 teleprompterController.playing,
                 teleprompterController.wpm,
-            ) { state, tpEnabled, tpPlaying, tpWpm ->
+                voicePaced.wristLines,
+            ) { state, tpEnabled, tpPlaying, tpWpm, lines ->
                 state.copy(
                     teleprompterEnabled = tpEnabled,
                     teleprompterPlaying = tpPlaying,
                     teleprompterWpm = tpWpm,
+                    // #1368 — voice-paced current/next line for the wrist; empty
+                    // (and the watch hides the strip) unless voice-paced is live.
+                    teleprompterCurrentLine = lines.current,
+                    teleprompterNextLine = lines.next,
                 )
             }
             combine(

--- a/core-playback/src/test/kotlin/in/jphe/storyvox/playback/transcribe/WristTeleprompterLinesTest.kt
+++ b/core-playback/src/test/kotlin/in/jphe/storyvox/playback/transcribe/WristTeleprompterLinesTest.kt
@@ -1,0 +1,74 @@
+package `in`.jphe.storyvox.playback.transcribe
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+/**
+ * Wrist teleprompter line derivation — splitting a chapter into glanceable
+ * lines and locating the speaker's current + next line by char offset.
+ */
+class WristTeleprompterLinesTest {
+
+    @Test
+    fun `splits sentences and newlines preserving spans`() {
+        val text = "One. Two!\nThree"
+        val spans = splitTeleprompterLines(text)
+        assertEquals(listOf("One.", "Two!", "Three"), spans.map { it.text })
+        // Spans index back into the original string.
+        assertEquals("One.", text.substring(spans[0].start, spans[0].end))
+        assertEquals("Three", text.substring(spans[2].start, spans[2].end))
+    }
+
+    @Test
+    fun `collapses ellipsis runs into one line — no punctuation crumbs`() {
+        assertEquals(
+            listOf("Wait...", "Go."),
+            splitTeleprompterLines("Wait... Go.").map { it.text },
+        )
+    }
+
+    @Test
+    fun `drops blank lines from a script`() {
+        assertEquals(
+            listOf("A.", "B."),
+            splitTeleprompterLines("A.\n\n\nB.").map { it.text },
+        )
+    }
+
+    @Test
+    fun `empty text yields no lines`() {
+        assertEquals(emptyList<String>(), splitTeleprompterLines("   \n  ").map { it.text })
+    }
+
+    @Test
+    fun `current line is the one containing the cursor and next is the following`() {
+        val text = "One. Two! Three."
+        val spans = splitTeleprompterLines(text)
+        // Cursor inside "Two!" (index ~6).
+        val lines = wristLinesAt(spans, positionChar = 6)
+        assertEquals("Two!", lines.current)
+        assertEquals("Three.", lines.next)
+    }
+
+    @Test
+    fun `offset zero resolves to the first line before any match`() {
+        val spans = splitTeleprompterLines("First line. Second line.")
+        val lines = wristLinesAt(spans, positionChar = 0)
+        assertEquals("First line.", lines.current)
+        assertEquals("Second line.", lines.next)
+    }
+
+    @Test
+    fun `last line has an empty next`() {
+        val text = "Only. Last."
+        val spans = splitTeleprompterLines(text)
+        val lines = wristLinesAt(spans, positionChar = text.length - 1)
+        assertEquals("Last.", lines.current)
+        assertEquals("", lines.next)
+    }
+
+    @Test
+    fun `no spans yields EMPTY`() {
+        assertEquals(WristLines.EMPTY, wristLinesAt(emptyList(), positionChar = 5))
+    }
+}

--- a/wear/src/main/kotlin/in/jphe/storyvox/wear/WearApp.kt
+++ b/wear/src/main/kotlin/in/jphe/storyvox/wear/WearApp.kt
@@ -70,6 +70,8 @@ private fun InteractiveContent(bridge: WearPlaybackBridge) {
                     playing = state.teleprompterPlaying,
                     wpm = state.teleprompterWpm,
                     connected = connected,
+                    currentLine = state.teleprompterCurrentLine,
+                    nextLine = state.teleprompterNextLine,
                 ),
                 onToggleEnabled = { scope.launch { bridge.toggleTeleprompter() } },
                 onTogglePlay = { scope.launch { bridge.toggleTeleprompterScroll() } },

--- a/wear/src/main/kotlin/in/jphe/storyvox/wear/screens/TeleprompterRemoteScreen.kt
+++ b/wear/src/main/kotlin/in/jphe/storyvox/wear/screens/TeleprompterRemoteScreen.kt
@@ -25,6 +25,7 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.semantics.clearAndSetSemantics
 import androidx.compose.ui.semantics.contentDescription
 import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import androidx.wear.compose.material.Button
 import androidx.wear.compose.material.ButtonDefaults
@@ -45,12 +46,20 @@ import `in`.jphe.storyvox.wear.theme.WarmDarkSurface
  * @property wpm current words-per-minute (`TeleprompterController.wpm`).
  * @property connected a phone node is reachable; when false, all controls grey
  *   out (mirrors the transport controls' disconnected handling).
+ * @property currentLine the line the speaker is currently on in voice-paced
+ *   mode (#1368), pushed from the phone's `VoicePacedScrollController`. Empty
+ *   unless a voice-paced session is live — its non-emptiness is what switches
+ *   the screen into the hands-free line display (the watch never holds the
+ *   chapter text; the phone ships only these two lines).
+ * @property nextLine the upcoming line, shown dimmed beneath [currentLine].
  */
 data class TeleprompterRemoteUiState(
     val enabled: Boolean = false,
     val playing: Boolean = false,
     val wpm: Int = 0,
     val connected: Boolean = true,
+    val currentLine: String = "",
+    val nextLine: String = "",
 )
 
 /**
@@ -89,68 +98,105 @@ fun TeleprompterRemoteScreen(
         )
         Spacer(Modifier.height(6.dp))
 
-        // Enable / disable the mode — always tappable while connected.
-        RoundIconButton(
-            icon = if (state.enabled) Icons.Filled.Visibility else Icons.Filled.VisibilityOff,
-            contentDescription = stringResource(
-                if (state.enabled) R.string.wear_cd_teleprompter_on else R.string.wear_cd_teleprompter_off,
-            ),
-            onClick = onToggleEnabled,
-            isPrimary = state.enabled,
-            enabled = state.connected,
-        )
-        Spacer(Modifier.height(6.dp))
-
-        // WPM stepper: − [ value ] +
-        Row(
-            modifier = Modifier.fillMaxWidth(),
-            horizontalArrangement = Arrangement.SpaceEvenly,
-            verticalAlignment = Alignment.CenterVertically,
-        ) {
-            RoundIconButton(
-                icon = Icons.Filled.Remove,
-                contentDescription = stringResource(R.string.wear_cd_wpm_slower),
-                onClick = { onWpmDelta(-1) },
-                isPrimary = false,
-                enabled = transportEnabled,
-            )
-            val wpmDescription = stringResource(R.string.wear_cd_wpm, state.wpm)
+        if (state.currentLine.isNotEmpty()) {
+            // Issue #1368 — voice-paced line display. The phone follows the
+            // speaker's voice (mic + on-device STT) and pushes the current +
+            // next line; the wrist just renders them, advancing hands-free. WPM
+            // is irrelevant here (the voice sets the pace), so only the lines +
+            // an off toggle show. A non-empty currentLine IS the "voice mode
+            // active" signal — see TeleprompterRemoteUiState.
             Text(
-                text = "${state.wpm}",
-                color = if (transportEnabled) BrassPrimary else BrassMuted,
+                text = state.currentLine,
+                color = BrassPrimary,
                 textAlign = TextAlign.Center,
                 style = MaterialTheme.typography.title2,
-                modifier = Modifier
-                    .width(56.dp)
-                    .clearAndSetSemantics { contentDescription = wpmDescription },
+                maxLines = 4,
+                overflow = TextOverflow.Ellipsis,
             )
+            if (state.nextLine.isNotEmpty()) {
+                Spacer(Modifier.height(6.dp))
+                Text(
+                    text = state.nextLine,
+                    color = BrassMuted,
+                    textAlign = TextAlign.Center,
+                    style = MaterialTheme.typography.body2,
+                    maxLines = 2,
+                    overflow = TextOverflow.Ellipsis,
+                )
+            }
+            Spacer(Modifier.height(10.dp))
+            // Turn voice follow (the whole teleprompter) off from the wrist.
             RoundIconButton(
-                icon = Icons.Filled.Add,
-                contentDescription = stringResource(R.string.wear_cd_wpm_faster),
-                onClick = { onWpmDelta(1) },
-                isPrimary = false,
+                icon = Icons.Filled.Visibility,
+                contentDescription = stringResource(R.string.wear_cd_voice_follow_on),
+                onClick = onToggleEnabled,
+                isPrimary = true,
+                enabled = state.connected,
+            )
+        } else {
+            // Enable / disable the mode — always tappable while connected.
+            RoundIconButton(
+                icon = if (state.enabled) Icons.Filled.Visibility else Icons.Filled.VisibilityOff,
+                contentDescription = stringResource(
+                    if (state.enabled) R.string.wear_cd_teleprompter_on else R.string.wear_cd_teleprompter_off,
+                ),
+                onClick = onToggleEnabled,
+                isPrimary = state.enabled,
+                enabled = state.connected,
+            )
+            Spacer(Modifier.height(6.dp))
+
+            // WPM stepper: − [ value ] +
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                horizontalArrangement = Arrangement.SpaceEvenly,
+                verticalAlignment = Alignment.CenterVertically,
+            ) {
+                RoundIconButton(
+                    icon = Icons.Filled.Remove,
+                    contentDescription = stringResource(R.string.wear_cd_wpm_slower),
+                    onClick = { onWpmDelta(-1) },
+                    isPrimary = false,
+                    enabled = transportEnabled,
+                )
+                val wpmDescription = stringResource(R.string.wear_cd_wpm, state.wpm)
+                Text(
+                    text = "${state.wpm}",
+                    color = if (transportEnabled) BrassPrimary else BrassMuted,
+                    textAlign = TextAlign.Center,
+                    style = MaterialTheme.typography.title2,
+                    modifier = Modifier
+                        .width(56.dp)
+                        .clearAndSetSemantics { contentDescription = wpmDescription },
+                )
+                RoundIconButton(
+                    icon = Icons.Filled.Add,
+                    contentDescription = stringResource(R.string.wear_cd_wpm_faster),
+                    onClick = { onWpmDelta(1) },
+                    isPrimary = false,
+                    enabled = transportEnabled,
+                )
+            }
+            Text(
+                text = stringResource(R.string.wear_wpm_unit),
+                color = BrassMuted,
+                textAlign = TextAlign.Center,
+                style = MaterialTheme.typography.caption2,
+                modifier = Modifier.clearAndSetSemantics { },
+            )
+            Spacer(Modifier.height(6.dp))
+
+            // Run / pause the scroll.
+            RoundIconButton(
+                icon = if (state.playing) Icons.Filled.Pause else Icons.Filled.PlayArrow,
+                contentDescription = stringResource(
+                    if (state.playing) R.string.wear_cd_scroll_pause else R.string.wear_cd_scroll_start,
+                ),
+                onClick = onTogglePlay,
+                isPrimary = true,
                 enabled = transportEnabled,
             )
         }
-        Text(
-            text = stringResource(R.string.wear_wpm_unit),
-            color = BrassMuted,
-            textAlign = TextAlign.Center,
-            style = MaterialTheme.typography.caption2,
-            modifier = Modifier.clearAndSetSemantics { },
-        )
-        Spacer(Modifier.height(6.dp))
-
-        // Run / pause the scroll.
-        RoundIconButton(
-            icon = if (state.playing) Icons.Filled.Pause else Icons.Filled.PlayArrow,
-            contentDescription = stringResource(
-                if (state.playing) R.string.wear_cd_scroll_pause else R.string.wear_cd_scroll_start,
-            ),
-            onClick = onTogglePlay,
-            isPrimary = true,
-            enabled = transportEnabled,
-        )
     }
 }
 

--- a/wear/src/main/res/values/strings.xml
+++ b/wear/src/main/res/values/strings.xml
@@ -25,6 +25,8 @@
     <string name="wear_cd_wpm">%1$d words per minute</string>
     <string name="wear_cd_scroll_pause">Pause scroll</string>
     <string name="wear_cd_scroll_start">Start scroll</string>
+    <!-- Voice-paced follow (#1368) -->
+    <string name="wear_cd_voice_follow_on">Voice follow on, tap to turn off</string>
 
     <!-- Chapter cover -->
     <string name="wear_cd_cover_for">Cover for %1$s</string>

--- a/wear/src/test/kotlin/in/jphe/storyvox/wear/playback/WearStateDecodeTest.kt
+++ b/wear/src/test/kotlin/in/jphe/storyvox/wear/playback/WearStateDecodeTest.kt
@@ -49,6 +49,25 @@ class WearStateDecodeTest {
     }
 
     @Test
+    fun `round-trips the voice-paced teleprompter lines`() {
+        // #1368 — the phone derives the current/next line from positionChar and
+        // ships them in PlaybackState so the wrist renders the hands-free
+        // teleprompter without holding the chapter text. Pin that the wire
+        // carries them (non-default Strings aren't omitted by the encoder).
+        val published = PlaybackState(
+            teleprompterEnabled = true,
+            teleprompterCurrentLine = "Welcome back to the show.",
+            teleprompterNextLine = "Today we are talking about getting connected.",
+        )
+        val decoded = WearPlaybackBridge.decodeState(
+            phoneJson.encodeToString(published),
+            PlaybackState(),
+        )
+        assertEquals("Welcome back to the show.", decoded.teleprompterCurrentLine)
+        assertEquals("Today we are talking about getting connected.", decoded.teleprompterNextLine)
+    }
+
+    @Test
     fun `round-trips a sealed PlaybackError subtype`() {
         val published = PlaybackState(error = PlaybackError.AzureThrottled("F0 quota exhausted"))
         val raw = phoneJson.encodeToString(published)


### PR DESCRIPTION
## Voice-paced teleprompter on the wrist (#1368 → Wear)

Extends the Wear teleprompter remote so the watch **follows the speaker's voice hands-free**: the phone runs mic + on-device STT (the #1368 pipeline), and the watch renders the current/next line in large type, auto-advancing as the speaker reads. A presenter can keep the phone on a stand and read off the wrist.

### Data flow (rides the existing bridge — no new message path)
```
phone: VoicePacedScrollController.positionChar ──▶ wristLines (current,next)
       └─ PhoneWearBridge folds into PlaybackState (existing /playback/state DataItem)
watch: WearPlaybackBridge decodes PlaybackState ──▶ WearApp ──▶ TeleprompterRemoteScreen
```
The watch never holds the chapter text — only the two short line strings cross the BT data layer.

### Changes
- **`WristTeleprompterLines.kt`** (pure, core-playback): `splitTeleprompterLines()` breaks a chapter into sentence/line spans (collapsing ellipsis runs + blank lines, preserving original offsets); `wristLinesAt(positionChar)` resolves the current + next line. Unit-tested (`WristTeleprompterLinesTest`).
- **`VoicePacedScrollController`**: new `wristLines: StateFlow<WristLines>`, derived from the source-space `positionChar` against the original text; `EMPTY` between sessions. A `StateFlow` dedups, so it changes only when the speaker crosses into a new line — not on every recognized word, keeping the BT sync quiet.
- **`PlaybackState`**: `teleprompterCurrentLine` / `teleprompterNextLine` (default `""`). Backward-compatible — older watch builds ignore them (same posture as the #1308 teleprompter fields), so no version-skew risk.
- **`PhoneWearBridge`**: folds `wristLines` into the published state (5-way `combine`).
- **`TeleprompterRemoteScreen`**: a non-empty `currentLine` switches the screen into the hands-free **line display** (current large + next dimmed + an off toggle); WPM is hidden because the voice sets the pace. Empty → the existing WPM remote, unchanged.
- **`WearStateDecodeTest`**: pins the lines round-trip across the wire.

### Notes
- `positionChar` source (`VoicePacedScrollController`, #1368) is already on main.
- v1 derives lines from the original text (cues/labels not stripped for display) — a small future polish; the *aligner* already strips them for matching.
- The screen keeps the plain centered `Column`; lines are capped (`maxLines` + ellipsis) so a long sentence can't overflow a round face. A `ScalingLazyColumn` refactor is out of scope.
- No local gradle (CI is the compile gate). Pure logic is unit-tested; the live voice-follow on the wrist is an on-device check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
