### PR TITLE
feat(playback): RecordingController seam for Wear record remote (#1367)

### DIFF
--- a/core-playback/src/main/kotlin/in/jphe/storyvox/playback/PlaybackState.kt
+++ b/core-playback/src/main/kotlin/in/jphe/storyvox/playback/PlaybackState.kt
@@ -45,6 +45,16 @@ data class PlaybackState(
     val teleprompterEnabled: Boolean = false,
     val teleprompterPlaying: Boolean = false,
     val teleprompterWpm: Int = 0,
+    /** Issue #1367 (Wear PR1) — recording-mode state mirrored from
+     *  `RecordingController` so the Wear remote can reflect it + gate its
+     *  record button. [recordingArmed] is true only while the phone is on the
+     *  RecordingScreen with the camera ready (watch shows "open Recording on
+     *  your phone first" when false). Populated by `PhoneWearBridge` at publish
+     *  time; the controller stays the source of truth. Defaults keep older
+     *  watch builds + the non-recording sync path unaffected. */
+    val recordingArmed: Boolean = false,
+    val recording: Boolean = false,
+    val recordingElapsedMs: Long = 0L,
 )
 
 @Serializable

--- a/core-playback/src/main/kotlin/in/jphe/storyvox/playback/RecordingController.kt
+++ b/core-playback/src/main/kotlin/in/jphe/storyvox/playback/RecordingController.kt
@@ -1,0 +1,91 @@
+package `in`.jphe.storyvox.playback
+
+import javax.inject.Inject
+import javax.inject.Singleton
+import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.SharedFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asSharedFlow
+import kotlinx.coroutines.flow.asStateFlow
+
+/**
+ * Issue #1367 (Wear PR1) — single source of truth for Recording mode's
+ * remote-able controls, hoisted into core-playback so **both** the phone's
+ * `RecordingScreen` and the Wear bridge ([`in`.jphe.storyvox.playback.wear.PhoneWearBridge])
+ * can drive one shared state — exactly the move #1308 made for the teleprompter
+ * with [TeleprompterController].
+ *
+ * ## Why a controller at all
+ * Recording state otherwise lives in the UI-scoped `RecordingViewModel` + the
+ * composition-scoped `CameraRecorder`, neither reachable from `PhoneWearBridge`
+ * (core-playback can't see Compose / `:feature`). This `@Singleton` gives the
+ * watch a StateFlow contract to reflect (`armed` / `recording` / `elapsedMs`)
+ * and an intent channel to drive (`requestStart` / `requestStop`).
+ *
+ * ## State vs. intent — why a SharedFlow
+ * Unlike the teleprompter's purely-stateful toggles, recording start/stop are
+ * **events**, not levels: "start" means "run the 3-2-1 countdown then record",
+ * which the camera-owning composable must execute. So intents flow one-way over
+ * [requests] (a replay-0 [SharedFlow]); the resulting state flows back through
+ * the `set*` writebacks. A start emitted while no `RecordingScreen` is
+ * collecting (i.e. [armed] is false) reaches no collector and is harmlessly
+ * dropped — the watch is expected to gate its button on [armed] and surface
+ * "open Recording on your phone first" instead.
+ *
+ * ## The camera lifecycle constraint
+ * The camera (CameraX `VideoCapture`) binds to the phone `RecordingScreen`'s
+ * composition lifecycle, so it can only record while that screen is foreground.
+ * [armed] encodes exactly that: the `RecordingViewModel` sets it true on init
+ * and false in `onCleared`, so the wrist remote is a trigger for an
+ * already-framed session, not a background launcher.
+ */
+@Singleton
+class RecordingController @Inject constructor() {
+
+    private val _armed = MutableStateFlow(false)
+
+    /** True only while the phone is on `RecordingScreen` with the camera bound
+     *  and ready. The Wear remote gates its record button on this. */
+    val armed: StateFlow<Boolean> = _armed.asStateFlow()
+
+    private val _recording = MutableStateFlow(false)
+
+    /** True while a clip is actively being captured (between countdown end and
+     *  finalize). */
+    val recording: StateFlow<Boolean> = _recording.asStateFlow()
+
+    private val _elapsedMs = MutableStateFlow(0L)
+
+    /** Elapsed capture time in ms, so the watch can mirror the REC timer. 0
+     *  when not recording. */
+    val elapsedMs: StateFlow<Long> = _elapsedMs.asStateFlow()
+
+    // replay=0 (intents aren't state), small extra buffer so a trySend from the
+    // non-suspend bridge/VM isn't lost if the collector is momentarily busy.
+    private val _requests = MutableSharedFlow<RecordingRequest>(extraBufferCapacity = 8)
+
+    /** One-way intent stream the `RecordingScreen` collects to drive the camera.
+     *  Emitting with no active collector is a no-op (see class KDoc). */
+    val requests: SharedFlow<RecordingRequest> = _requests.asSharedFlow()
+
+    // ── Phone-side state writeback (RecordingViewModel) ──────────────────────
+
+    fun setArmed(armed: Boolean) { _armed.value = armed }
+
+    fun setRecording(recording: Boolean) { _recording.value = recording }
+
+    fun setElapsedMs(elapsedMs: Long) { _elapsedMs.value = elapsedMs }
+
+    // ── Remote / phone intents ───────────────────────────────────────────────
+
+    /** Request the start of a recording (runs the countdown on the phone). Only
+     *  effective when a `RecordingScreen` is collecting (i.e. [armed]). */
+    fun requestStart() { _requests.tryEmit(RecordingRequest.Start) }
+
+    /** Request that the active recording stop and finalize. */
+    fun requestStop() { _requests.tryEmit(RecordingRequest.Stop) }
+}
+
+/** A payload-less recording intent carried over [RecordingController.requests]. */
+enum class RecordingRequest { Start, Stop }

--- a/core-playback/src/main/kotlin/in/jphe/storyvox/playback/wear/PhoneWearBridge.kt
+++ b/core-playback/src/main/kotlin/in/jphe/storyvox/playback/wear/PhoneWearBridge.kt
@@ -8,6 +8,7 @@ import com.google.android.gms.wearable.Wearable
 import dagger.hilt.android.qualifiers.ApplicationContext
 import `in`.jphe.storyvox.playback.PlaybackController
 import `in`.jphe.storyvox.playback.PlaybackState
+import `in`.jphe.storyvox.playback.RecordingController
 import `in`.jphe.storyvox.playback.SleepTimerMode
 import `in`.jphe.storyvox.playback.TeleprompterController
 import javax.inject.Inject
@@ -39,6 +40,7 @@ class PhoneWearBridge @Inject constructor(
     @ApplicationContext private val context: Context,
     private val controller: PlaybackController,
     private val teleprompterController: TeleprompterController,
+    private val recordingController: RecordingController,
 ) : MessageClient.OnMessageReceivedListener {
 
     private val scope = CoroutineScope(SupervisorJob() + Dispatchers.Default)
@@ -53,7 +55,11 @@ class PhoneWearBridge @Inject constructor(
             // singleton, #1320) into the published PlaybackState so the watch
             // reflects it over the existing /playback/state sync. Any teleprompter
             // change re-publishes, same as a playback change.
-            combine(
+            // #1367 (Wear PR1) — also fold RecordingController state in, so the
+            // watch reflects recording over the same /playback/state sync.
+            // Two nested 4-arg combines keep each within the typed overload
+            // limit (a single 7-flow combine would fall to the untyped vararg).
+            val withTeleprompter = combine(
                 controller.state,
                 teleprompterController.enabled,
                 teleprompterController.playing,
@@ -63,6 +69,18 @@ class PhoneWearBridge @Inject constructor(
                     teleprompterEnabled = tpEnabled,
                     teleprompterPlaying = tpPlaying,
                     teleprompterWpm = tpWpm,
+                )
+            }
+            combine(
+                withTeleprompter,
+                recordingController.armed,
+                recordingController.recording,
+                recordingController.elapsedMs,
+            ) { state, recArmed, recActive, recElapsed ->
+                state.copy(
+                    recordingArmed = recArmed,
+                    recording = recActive,
+                    recordingElapsedMs = recElapsed,
                 )
             }.collectLatest { state -> publishState(state) }
         }
@@ -108,6 +126,12 @@ class PhoneWearBridge @Inject constructor(
                     teleprompterController.setPlaying(!teleprompterController.playing.value)
                 CMD_TELEPROMPTER_WPM ->
                     TeleprompterWpmPayload.decode(event.data)?.let { teleprompterController.setWpm(it) }
+                // Issue #1367 (Wear PR1) — recording remote. Payload-less: the
+                // controller turns Start into the phone's 3-2-1 countdown +
+                // record (only effective when a RecordingScreen is collecting,
+                // i.e. recordingArmed); Stop finalizes the clip.
+                CMD_RECORDING_START -> recordingController.requestStart()
+                CMD_RECORDING_STOP -> recordingController.requestStop()
             }
         }
     }
@@ -146,5 +170,19 @@ class PhoneWearBridge @Inject constructor(
         const val CMD_TELEPROMPTER_TOGGLE = "/playback/cmd/teleprompterToggle"
         const val CMD_TELEPROMPTER_PLAY_PAUSE = "/playback/cmd/teleprompterPlayPause"
         const val CMD_TELEPROMPTER_WPM = "/playback/cmd/teleprompterWpm"
+
+        /**
+         * Issue #1367 (Wear PR1) — recording remote (wrist) commands. Both are
+         * payload-less: the watch knows recording / armed state from the synced
+         * [PlaybackState] (`recordingArmed` / `recording` / `recordingElapsedMs`),
+         * and should gate its record button on `recordingArmed` — Start reaches
+         * no collector and is dropped if the phone isn't on RecordingScreen.
+         *
+         * The watch-side UI that sends these is built separately on top of this
+         * contract; the constants + dispatch ship here so the phone seam is
+         * complete.
+         */
+        const val CMD_RECORDING_START = "/playback/cmd/recordingStart"
+        const val CMD_RECORDING_STOP = "/playback/cmd/recordingStop"
     }
 }

--- a/feature/src/main/kotlin/in/jphe/storyvox/feature/reader/recording/RecordingViewModel.kt
+++ b/feature/src/main/kotlin/in/jphe/storyvox/feature/reader/recording/RecordingViewModel.kt
@@ -6,6 +6,8 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import dagger.hilt.android.lifecycle.HiltViewModel
 import `in`.jphe.storyvox.feature.api.PlaybackControllerUi
+import `in`.jphe.storyvox.playback.RecordingController
+import `in`.jphe.storyvox.playback.RecordingRequest
 import `in`.jphe.storyvox.playback.TeleprompterController
 import java.text.SimpleDateFormat
 import java.util.Date
@@ -18,6 +20,7 @@ import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.collect
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.receiveAsFlow
 import kotlinx.coroutines.flow.stateIn
@@ -46,6 +49,11 @@ import kotlinx.coroutines.launch
 class RecordingViewModel @Inject constructor(
     playback: PlaybackControllerUi,
     teleprompter: TeleprompterController,
+    /** Issue #1367 (Wear PR1) — shared recording control state so the Wear
+     *  remote can start/stop and mirror the REC timer. This VM is the phone-side
+     *  owner: it acts on inbound [RecordingController.requests] and writes back
+     *  `armed` / `recording` / `elapsedMs`. */
+    private val recordingController: RecordingController,
 ) : ViewModel() {
 
     /** The chapter text to read — the same script the reader's teleprompter
@@ -95,6 +103,51 @@ class RecordingViewModel @Inject constructor(
 
     private var countdownJob: Job? = null
     private var elapsedJob: Job? = null
+
+    init {
+        // This VM's lifetime ≈ the RecordingScreen being on-screen with the
+        // camera bound, so `armed` tells the Wear remote when its record button
+        // is live ("open Recording on your phone first" otherwise).
+        recordingController.setArmed(true)
+
+        // Inbound remote intents (watch): Start only begins a fresh take from
+        // Preview; Stop defers to stopRecording()'s own Recording-only guard.
+        viewModelScope.launch {
+            recordingController.requests.collect { request ->
+                when (request) {
+                    RecordingRequest.Start ->
+                        if (_uiState.value is RecordingState.Preview) startCountdown()
+                    RecordingRequest.Stop -> stopRecording()
+                }
+            }
+        }
+
+        // Write recording state back to the controller for the watch to mirror.
+        // elapsedMs is pushed only when the whole-second changes (the phone UI
+        // ticks at 100ms for smoothness, but a 10Hz Wear DataItem sync would be
+        // wasteful — the wrist timer is mm:ss).
+        viewModelScope.launch {
+            var lastSecond = -1L
+            uiState.collect { state ->
+                val elapsed = (state as? RecordingState.Recording)?.elapsedMs ?: 0L
+                recordingController.setRecording(state is RecordingState.Recording)
+                val second = elapsed / 1_000
+                if (second != lastSecond) {
+                    lastSecond = second
+                    recordingController.setElapsedMs(second * 1_000)
+                }
+            }
+        }
+    }
+
+    override fun onCleared() {
+        super.onCleared()
+        // Leaving RecordingScreen → the camera is gone; tell the watch it can no
+        // longer drive a recording.
+        recordingController.setArmed(false)
+        recordingController.setRecording(false)
+        recordingController.setElapsedMs(0L)
+    }
 
     /**
      * The record/stop button. Context-sensitive:


### PR DESCRIPTION
## RecordingController — phone-side seam for the Wear record remote (#1367)

Phone-side infrastructure so the Wear companion can **start/stop recording from the wrist** and mirror the REC timer. Mirrors the #1308 `TeleprompterController` pattern exactly. The watch-side UI is built separately on top of this contract.

### What's here
| File | Change |
|---|---|
| **`RecordingController.kt`** (new, core-playback) | `@Singleton` with `armed` / `recording` / `elapsedMs` StateFlows + `setArmed/setRecording/setElapsedMs` writebacks, **plus a replay-0 `requests: SharedFlow<RecordingRequest>`** + `requestStart()` / `requestStop()`. |
| `PlaybackState.kt` | +`recordingArmed` / `recording` / `recordingElapsedMs`, all defaulted. |
| `PhoneWearBridge.kt` | injects the controller, folds its 3 flows into the published `/playback/state`, routes `CMD_RECORDING_START/STOP`, adds the 2 command constants. |
| `RecordingViewModel.kt` | injects the controller, collects `requests`, sets `armed`, writes back recording state. |

### Key design decisions
- **State vs. intent.** Unlike the teleprompter's purely-stateful toggles, record start/stop are **events** ("start" = run the 3-2-1 countdown then record), so intents flow one-way over a replay-0 `requests` SharedFlow and the resulting state flows back via the `set*` writebacks. A Start emitted while no `RecordingScreen` is collecting reaches no collector and is harmlessly dropped.
- **`armed` is the camera-lifecycle gate.** The camera (CameraX `VideoCapture`) binds to the `RecordingScreen` composition, so it can only record while that screen is foreground. The VM sets `armed` true in `init` / false in `onCleared`, so the watch can gate its button and show *"open Recording on your phone first"* instead of a dead button — the watch is a remote trigger for an armed session, not a background launcher.
- **No Wear Data Layer flooding.** The phone UI ticks elapsed at 100ms for smoothness, but the writeback to the controller is **second-aligned**, so the watch sync fires ~1×/sec (a wrist timer is mm:ss). `setRecording` relies on `StateFlow` equality-dedup, so repeated same-value sets don't re-publish.
- **Nested `combine` in the bridge.** Folding 3 more flows would push the bridge's `combine` to 7 args (past the typed 5-arg overloads, into the untyped vararg). Two nested 4-arg combines keep it typed.

### Compatibility / safety
- `PlaybackState` fields are defaulted and `:wear` decodes with `ignoreUnknownKeys=true` (both directions) — old watch ↔ new phone and vice-versa are non-breaking. `:wear` shares this exact class, so the watch UI team gets the new fields for free.
- `RecordingController` uses constructor injection (`@Inject` + `@Singleton`) — self-bound, no Hilt module needed (same as `TeleprompterController`). No manual instantiation of the changed-constructor classes anywhere.
- Note: `RealPlaybackControllerUiTest` has an unrelated `private class RecordingController : PlaybackController` (a test spy) — different package, never imports mine, same-file private resolution wins → no clash.

### Testing
Compile is CI-gated (no local gradle). This is a pure StateFlow/SharedFlow contract; the watch-side send/UI lands separately and will exercise it end-to-end.

Part of #1367 (Wear integration). 🤖 Generated with [Claude Code](https://claude.com/claude-code)
