### PR TITLE
feat(wear): chapter nav on long-press + time readout

### DIFF
--- a/wear/src/main/kotlin/in/jphe/storyvox/wear/components/TransportRow.kt
+++ b/wear/src/main/kotlin/in/jphe/storyvox/wear/components/TransportRow.kt
@@ -2,10 +2,15 @@ package `in`.jphe.storyvox.wear.components
 
 import androidx.compose.animation.Crossfade
 import androidx.compose.animation.core.tween
+import androidx.compose.foundation.ExperimentalFoundationApi
+import androidx.compose.foundation.background
+import androidx.compose.foundation.combinedClickable
 import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Pause
 import androidx.compose.material.icons.filled.PlayArrow
@@ -14,11 +19,13 @@ import androidx.compose.material.icons.filled.SkipPrevious
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.hapticfeedback.HapticFeedbackType
+import androidx.compose.ui.platform.LocalHapticFeedback
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.semantics.Role
 import androidx.compose.ui.unit.dp
-import androidx.wear.compose.material.Button
-import androidx.wear.compose.material.ButtonDefaults
 import androidx.wear.compose.material.Icon
 import `in`.jphe.storyvox.wear.R
 import `in`.jphe.storyvox.wear.theme.BrassMuted
@@ -33,13 +40,17 @@ import `in`.jphe.storyvox.wear.theme.WarmDarkSurface
  * on play/pause first. This mirrors the phone reader pattern where the active
  * sentence carries the brass underline and surrounding text is muted.
  *
- * Skip buttons map to `CMD_SKIP_BACK` / `CMD_SKIP_FWD` (30s seek) rather than
- * chapter nav — same defaults as the phone notification controls.
+ * Skip buttons are dual-action (#1404): a short press is a ±30s seek
+ * (`CMD_SKIP_BACK` / `CMD_SKIP_FWD`, the phone-notification default), and a
+ * long press jumps a whole chapter ([onSkipBackLong] / [onSkipForwardLong] →
+ * `CMD_PREV_CH` / `CMD_NEXT_CH`). Long press fires a haptic so the chapter
+ * jump is confirmed eyes-free. When a long handler is null the button is
+ * tap-only (the center play/pause never has one).
  *
  * When [enabled] is `false` (no phone node reachable, #1030) the buttons are
- * greyed and non-clickable — Wear's [Button] applies its disabled colours
- * automatically and TalkBack announces them as disabled — so a tap can't
- * silently no-op the way it did before.
+ * greyed and non-clickable — [combinedClickable]'s `enabled` flag drops the
+ * gesture and marks the node disabled for TalkBack — so a tap can't silently
+ * no-op the way it did before.
  */
 @Composable
 fun TransportRow(
@@ -49,6 +60,8 @@ fun TransportRow(
     onSkipForward: () -> Unit,
     modifier: Modifier = Modifier,
     enabled: Boolean = true,
+    onSkipBackLong: (() -> Unit)? = null,
+    onSkipForwardLong: (() -> Unit)? = null,
 ) {
     Row(
         modifier = modifier.fillMaxWidth(),
@@ -61,6 +74,8 @@ fun TransportRow(
             onClick = onSkipBack,
             isPrimary = false,
             enabled = enabled,
+            onLongClick = onSkipBackLong,
+            onLongClickLabel = stringResource(R.string.wear_cd_prev_chapter),
         )
         TransportButton(
             icon = if (isPlaying) Icons.Filled.Pause else Icons.Filled.PlayArrow,
@@ -75,10 +90,13 @@ fun TransportRow(
             onClick = onSkipForward,
             isPrimary = false,
             enabled = enabled,
+            onLongClick = onSkipForwardLong,
+            onLongClickLabel = stringResource(R.string.wear_cd_next_chapter),
         )
     }
 }
 
+@OptIn(ExperimentalFoundationApi::class)
 @Composable
 private fun TransportButton(
     icon: ImageVector,
@@ -86,6 +104,8 @@ private fun TransportButton(
     onClick: () -> Unit,
     isPrimary: Boolean,
     enabled: Boolean,
+    onLongClick: (() -> Unit)? = null,
+    onLongClickLabel: String? = null,
 ) {
     // Wear OS requires a ≥48dp touch target. These were 44/36dp — both under
     // the minimum, the muted skip buttons egregiously so, which made the
@@ -93,21 +113,34 @@ private fun TransportButton(
     // presence so the eye (and thumb) still land on play/pause first.
     val size = if (isPrimary) 52.dp else 48.dp
     val iconSize = if (isPrimary) 26.dp else 22.dp
-    Button(
-        onClick = onClick,
-        enabled = enabled,
-        modifier = Modifier.size(size),
-        colors = if (isPrimary) {
-            ButtonDefaults.primaryButtonColors(
-                backgroundColor = BrassPrimary,
-                contentColor = WarmDarkSurface,
-            )
-        } else {
-            ButtonDefaults.secondaryButtonColors(
-                backgroundColor = BrassMuted,
-                contentColor = BrassPrimary,
-            )
-        },
+    val haptic = LocalHapticFeedback.current
+    val background = if (isPrimary) BrassPrimary else BrassMuted
+    val content = if (isPrimary) WarmDarkSurface else BrassPrimary
+    // Mirror the prior Wear Button's disabled treatment (#1030): a dimmed fill
+    // + icon so the greyed, non-clickable state still reads as a button.
+    val disabledAlpha = 0.38f
+
+    Box(
+        modifier = Modifier
+            .size(size)
+            .clip(CircleShape)
+            .background(if (enabled) background else background.copy(alpha = disabledAlpha))
+            // Wear Button has no long-press, so the dual-action skip buttons
+            // (#1404) use combinedClickable; its `enabled` flag preserves the
+            // #1030 greyed/non-clickable + TalkBack-disabled behavior.
+            .combinedClickable(
+                enabled = enabled,
+                role = Role.Button,
+                onLongClickLabel = onLongClickLabel,
+                onClick = onClick,
+                onLongClick = onLongClick?.let { action ->
+                    {
+                        haptic.performHapticFeedback(HapticFeedbackType.LongPress)
+                        action()
+                    }
+                },
+            ),
+        contentAlignment = Alignment.Center,
     ) {
         // ~150ms crossfade so the play↔pause icon swap dissolves instead of
         // snapping. The skip buttons pass a constant icon, so Crossfade renders
@@ -120,6 +153,7 @@ private fun TransportButton(
             Icon(
                 imageVector = fadedIcon,
                 contentDescription = contentDescription,
+                tint = if (enabled) content else content.copy(alpha = disabledAlpha),
                 modifier = Modifier.size(iconSize),
             )
         }

--- a/wear/src/main/kotlin/in/jphe/storyvox/wear/screens/NowPlayingScreen.kt
+++ b/wear/src/main/kotlin/in/jphe/storyvox/wear/screens/NowPlayingScreen.kt
@@ -91,9 +91,10 @@ private const val ROTARY_VOLUME_STEP_PX = 48f
  *
  * On square faces the ring becomes a horizontal brass track at the bottom.
  *
- * Audio plumbing — MediaSession state + transport — is unchanged; we still
- * read from [WearPlaybackBridge] and send `PhoneWearBridge.CMD_*` over
- * MessageClient. This PR is pure UI polish per the #192 spec.
+ * Audio plumbing — MediaSession state + transport — reads from
+ * [WearPlaybackBridge] and sends `PhoneWearBridge.CMD_*` over MessageClient.
+ * #1404 added dual-action skip buttons (long-press = chapter jump via
+ * `CMD_PREV_CH` / `CMD_NEXT_CH`) and the elapsed/remaining time readout.
  */
 @Composable
 fun NowPlayingScreen(
@@ -121,6 +122,9 @@ fun NowPlayingScreen(
         },
         onSkipBack = { scope.launch { bridge.send(PhoneWearBridge.CMD_SKIP_BACK) } },
         onSkipForward = { scope.launch { bridge.send(PhoneWearBridge.CMD_SKIP_FWD) } },
+        // #1404 — long-press the skip buttons to jump a whole chapter.
+        onPrevChapter = { scope.launch { bridge.send(PhoneWearBridge.CMD_PREV_CH) } },
+        onNextChapter = { scope.launch { bridge.send(PhoneWearBridge.CMD_NEXT_CH) } },
         // #1031 — tap the ring to scrub; duration comes from the synced state.
         onScrub = { fraction -> scope.launch { bridge.sendSeek(fraction, state.durationEstimateMs) } },
         onOpenTeleprompter = onOpenTeleprompter,
@@ -144,6 +148,8 @@ internal fun NowPlayingContent(
     onSkipBack: () -> Unit,
     onSkipForward: () -> Unit,
     onScrub: ((fraction: Float) -> Unit)? = null,
+    onPrevChapter: () -> Unit = {},
+    onNextChapter: () -> Unit = {},
     onOpenTeleprompter: () -> Unit = {},
     onStartRecording: () -> Unit = {},
     onStopRecording: () -> Unit = {},
@@ -206,6 +212,8 @@ internal fun NowPlayingContent(
                     onSkipBack = onSkipBack,
                     onSkipForward = onSkipForward,
                     onScrub = onScrub,
+                    onPrevChapter = onPrevChapter,
+                    onNextChapter = onNextChapter,
                 )
             } else {
                 SquareNowPlaying(
@@ -215,6 +223,8 @@ internal fun NowPlayingContent(
                     onPlayPause = onPlayPause,
                     onSkipBack = onSkipBack,
                     onSkipForward = onSkipForward,
+                    onPrevChapter = onPrevChapter,
+                    onNextChapter = onNextChapter,
                 )
             }
             // Bottom-edge affordances, only when a phone is reachable: the
@@ -352,6 +362,8 @@ private fun RoundNowPlaying(
     onSkipBack: () -> Unit,
     onSkipForward: () -> Unit,
     onScrub: ((fraction: Float) -> Unit)? = null,
+    onPrevChapter: () -> Unit = {},
+    onNextChapter: () -> Unit = {},
 ) {
     // Scale the cover+ring to the watch instead of a fixed 116dp — small round
     // faces were crowded (worse now the transport row honours the 48dp touch
@@ -382,13 +394,17 @@ private fun RoundNowPlaying(
             )
         }
         ChapterMeta(state = state)
+        TimeReadout(progress = progress, durationMs = state.durationEstimateMs)
         TransportRow(
             isPlaying = state.isPlaying,
             enabled = connected,
             onPlayPause = onPlayPause,
             onSkipBack = onSkipBack,
             onSkipForward = onSkipForward,
+            onSkipBackLong = onPrevChapter,
+            onSkipForwardLong = onNextChapter,
         )
+        ChapterNavHint(connected = connected)
         DisconnectedHint(connected = connected)
     }
 }
@@ -401,6 +417,8 @@ private fun SquareNowPlaying(
     onPlayPause: () -> Unit,
     onSkipBack: () -> Unit,
     onSkipForward: () -> Unit,
+    onPrevChapter: () -> Unit = {},
+    onNextChapter: () -> Unit = {},
 ) {
     Column(
         modifier = Modifier
@@ -421,13 +439,17 @@ private fun SquareNowPlaying(
             indeterminate = state.isBuffering,
             modifier = Modifier.fillMaxWidth(),
         )
+        TimeReadout(progress = progress, durationMs = state.durationEstimateMs)
         TransportRow(
             isPlaying = state.isPlaying,
             enabled = connected,
             onPlayPause = onPlayPause,
             onSkipBack = onSkipBack,
             onSkipForward = onSkipForward,
+            onSkipBackLong = onPrevChapter,
+            onSkipForwardLong = onNextChapter,
         )
+        ChapterNavHint(connected = connected)
         DisconnectedHint(connected = connected)
     }
 }
@@ -477,6 +499,65 @@ private fun DisconnectedHint(connected: Boolean) {
         textAlign = TextAlign.Center,
         modifier = Modifier.fillMaxWidth(),
     )
+}
+
+/**
+ * Elapsed / remaining readout under the scrubber (#1404). Position is derived
+ * from [scrubProgress] × duration — the watch never receives an absolute
+ * position field, only the char-offset progress fraction the phone publishes.
+ * Hidden when there's no duration estimate yet (e.g. a live-audio chapter),
+ * where a time pair would be meaningless.
+ */
+@Composable
+private fun TimeReadout(progress: Float, durationMs: Long) {
+    if (durationMs <= 0L) return
+    val elapsedMs = (progress.coerceIn(0f, 1f) * durationMs).toLong()
+    Text(
+        text = "${formatPlaybackTime(elapsedMs)} / ${formatPlaybackTime(durationMs)}",
+        style = MaterialTheme.typography.caption2,
+        color = ParchmentOnMuted,
+        textAlign = TextAlign.Center,
+    )
+}
+
+/**
+ * One-line discoverability cue for the skip buttons' long-press chapter jump
+ * (#1404) — the gesture is otherwise invisible. Shown only when a phone is
+ * reachable (the buttons are disabled otherwise, so the hint would mislead);
+ * mutually exclusive with [DisconnectedHint].
+ */
+@Composable
+private fun ChapterNavHint(connected: Boolean) {
+    if (!connected) return
+    Text(
+        text = stringResource(R.string.wear_chapter_nav_hint),
+        style = MaterialTheme.typography.caption2,
+        color = ParchmentOnMuted,
+        maxLines = 1,
+        overflow = TextOverflow.Ellipsis,
+        textAlign = TextAlign.Center,
+        modifier = Modifier.fillMaxWidth(),
+    )
+}
+
+/**
+ * Format a millisecond duration as a compact wall-clock string: `m:ss` under
+ * an hour, `h:mm:ss` at or above one (e.g. `12:30`, `1:00:00`). Built by hand
+ * rather than via String.format so it's locale-independent and trivially
+ * unit-testable. Negative inputs clamp to zero. (Distinct from [formatElapsed],
+ * which is recording-only and never needs the hours field.)
+ */
+internal fun formatPlaybackTime(ms: Long): String {
+    val totalSeconds = (ms / 1000L).coerceAtLeast(0L)
+    val hours = totalSeconds / 3600
+    val minutes = (totalSeconds % 3600) / 60
+    val seconds = totalSeconds % 60
+    val ss = seconds.toString().padStart(2, '0')
+    return if (hours > 0) {
+        "$hours:${minutes.toString().padStart(2, '0')}:$ss"
+    } else {
+        "$minutes:$ss"
+    }
 }
 
 // region --- Previews ---

--- a/wear/src/main/res/values/strings.xml
+++ b/wear/src/main/res/values/strings.xml
@@ -5,12 +5,15 @@
     <!-- Now Playing -->
     <string name="wear_teleprompter">Teleprompter</string>
     <string name="wear_phone_not_connected">Phone not connected</string>
+    <string name="wear_chapter_nav_hint">Hold to change chapter</string>
 
     <!-- Transport controls (TalkBack content descriptions) -->
     <string name="wear_cd_skip_back">Skip back 30 seconds</string>
     <string name="wear_cd_play">Play</string>
     <string name="wear_cd_pause">Pause</string>
     <string name="wear_cd_skip_forward">Skip forward 30 seconds</string>
+    <string name="wear_cd_prev_chapter">Previous chapter</string>
+    <string name="wear_cd_next_chapter">Next chapter</string>
 
     <!-- Teleprompter remote -->
     <string name="wear_wpm_unit">wpm</string>

--- a/wear/src/test/kotlin/in/jphe/storyvox/wear/screens/NowPlayingTimeTest.kt
+++ b/wear/src/test/kotlin/in/jphe/storyvox/wear/screens/NowPlayingTimeTest.kt
@@ -1,0 +1,41 @@
+package `in`.jphe.storyvox.wear.screens
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+/**
+ * Issue #1404 — unit tests for [formatPlaybackTime], the elapsed/remaining
+ * readout formatter on the Wear now-playing surface. Pure logic, so it's
+ * verified here rather than via a Compose render.
+ */
+class NowPlayingTimeTest {
+
+    @Test fun `formats zero as minutes and seconds`() {
+        assertEquals("0:00", formatPlaybackTime(0L))
+    }
+
+    @Test fun `pads single-digit seconds`() {
+        assertEquals("0:07", formatPlaybackTime(7_000L))
+    }
+
+    @Test fun `formats sub-hour duration without an hours field`() {
+        assertEquals("1:30", formatPlaybackTime(90_000L))
+        assertEquals("12:30", formatPlaybackTime(750_000L))
+    }
+
+    @Test fun `formats exactly one hour with padded minutes and seconds`() {
+        assertEquals("1:00:00", formatPlaybackTime(3_600_000L))
+    }
+
+    @Test fun `formats hours minutes and seconds together`() {
+        assertEquals("1:02:03", formatPlaybackTime(3_723_000L))
+    }
+
+    @Test fun `truncates the sub-second remainder`() {
+        assertEquals("0:01", formatPlaybackTime(1_999L))
+    }
+
+    @Test fun `clamps negative input to zero`() {
+        assertEquals("0:00", formatPlaybackTime(-5_000L))
+    }
+}


### PR DESCRIPTION
Closes #1404.

## What

The watch `NowPlayingScreen` skip buttons only did ±30s seeks, even though `PhoneWearBridge` already implements `CMD_NEXT_CH` / `CMD_PREV_CH`. This exposes chapter navigation and adds a time readout.

## Changes

**Chapter nav (long-press)** — `TransportRow`
- Long-press skip-forward → `CMD_NEXT_CH`, long-press skip-back → `CMD_PREV_CH`. **Short-press unchanged** (±30s seek).
- The skip buttons move from Wear `Button` to a brass `Box` + `combinedClickable`, because Wear `Button` has no long-press handler. The **#1030 disabled behavior is preserved** via `combinedClickable(enabled = …)` (drops the gesture + marks the node disabled for TalkBack) and a dimmed fill/icon.
- **Haptic** on long-press so the chapter jump is confirmed eyes-free.
- **Subtle cue**: a "Hold to change chapter" caption, shown only while a phone is reachable (mutually exclusive with the existing "Phone not connected" hint), plus a `onLongClickLabel` ("Next/Previous chapter") for TalkBack.

**Time readout** — under the scrubber, both round + square: `"12:30 / 1:00:00"`. Position is derived from `scrubProgress() × durationEstimateMs` (the watch never receives an absolute position field). Hidden when there's no duration estimate (e.g. live-audio chapters).

## Tests

`NowPlayingTimeTest` covers the pure `formatPlaybackTime()` — padding, the sub-hour vs `h:mm:ss` switch, sub-second truncation, and negative clamping. The existing `NowPlayingScreen` previews (all of which use a playing/connected sample) now also render the time readout + hint, so layout is visually covered across round/small-round/square.

## Notes

- **Out of scope on purpose**: sleep timer (`CMD_SLEEP_*`) — tracked separately.
- Touch-target sizes (44dp center / 36dp skip) are unchanged from the prior Wear `Button`.
- Not compiled locally (per CLAUDE.md — CI is the compile gate). `combinedClickable` opt-in, haptic API, and the Wear `Icon` `tint` param all verified against existing usage / the module's theme types before pushing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added long-press chapter skip actions to the watch player controls.
  * Added an elapsed/remaining time readout under the scrubber.
  * Added a brief hint to help discover chapter navigation.

* **Bug Fixes**
  * Improved playback time formatting for zero, sub-second, negative, and hour-plus durations.
  * Updated disabled control behavior and accessibility labels for better clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->