### PR TITLE
feat(wear): sleep timer control from the watch

### DIFF
--- a/core-playback/src/main/kotlin/in/jphe/storyvox/playback/wear/PhoneWearBridge.kt
+++ b/core-playback/src/main/kotlin/in/jphe/storyvox/playback/wear/PhoneWearBridge.kt
@@ -113,6 +113,11 @@ class PhoneWearBridge @Inject constructor(
                 CMD_PREV_CH -> controller.previousChapter()
                 CMD_SLEEP_15 -> controller.startSleepTimer(SleepTimerMode.Duration(15))
                 CMD_SLEEP_OFF -> controller.cancelSleepTimer()
+                // Sleep timer from the wrist (15/30/45/end-of-chapter). CMD_SLEEP_SET
+                // carries a 4-byte SleepPayload (malformed → ignored, same guard as
+                // CMD_SEEK); CMD_SLEEP_CANCEL is payload-less.
+                CMD_SLEEP_SET -> SleepPayload.decode(event.data)?.let { controller.startSleepTimer(it) }
+                CMD_SLEEP_CANCEL -> controller.cancelSleepTimer()
                 // Issue #1031 — the circular scrubber sends a target position
                 // (ms) in the message payload. A malformed/absent payload
                 // decodes to null and is ignored (no blind seek-to-zero).
@@ -147,6 +152,16 @@ class PhoneWearBridge @Inject constructor(
         const val CMD_PREV_CH = "/playback/cmd/prevCh"
         const val CMD_SLEEP_15 = "/playback/cmd/sleep15"
         const val CMD_SLEEP_OFF = "/playback/cmd/sleepOff"
+
+        /**
+         * Sleep timer from the wrist. [CMD_SLEEP_SET] carries a 4-byte
+         * [SleepPayload] (a Duration in minutes, or `0` = end-of-chapter);
+         * [CMD_SLEEP_CANCEL] is payload-less. These generalize the older
+         * fixed-15-min [CMD_SLEEP_15]/[CMD_SLEEP_OFF] pair to the full
+         * 15/30/45/end-of-chapter option set the watch screen offers.
+         */
+        const val CMD_SLEEP_SET = "/playback/cmd/sleepSet"
+        const val CMD_SLEEP_CANCEL = "/playback/cmd/sleepCancel"
 
         /**
          * Issue #1031 — scrub from the wrist. Unlike the payload-less

--- a/core-playback/src/main/kotlin/in/jphe/storyvox/playback/wear/SleepPayload.kt
+++ b/core-playback/src/main/kotlin/in/jphe/storyvox/playback/wear/SleepPayload.kt
@@ -1,0 +1,53 @@
+package `in`.jphe.storyvox.playback.wear
+
+import `in`.jphe.storyvox.playback.SleepTimerMode
+import java.nio.ByteBuffer
+
+/**
+ * Wire format for the wear↔phone `CMD_SLEEP_SET` message (set a sleep timer
+ * from the wrist).
+ *
+ * Mirrors [TeleprompterWpmPayload] / [SeekPayload]: one shared encode/decode so
+ * the watch ([in.jphe.storyvox.wear.playback.WearPlaybackBridge], encode) and
+ * phone ([PhoneWearBridge], decode) can't drift. A fixed 4-byte big-endian Int
+ * carries the chosen option:
+ *  - a positive value = [SleepTimerMode.Duration] in minutes (15 / 30 / 45),
+ *  - the sentinel `0` = [SleepTimerMode.EndOfChapter].
+ *
+ * The fixed width doubles as validation: anything not exactly 4 bytes
+ * (including the `null` MessageClient delivers for payload-less messages) or a
+ * negative value decodes to `null`, which the phone bridge ignores rather than
+ * crashing on. Cancelling is the separate payload-less `CMD_SLEEP_CANCEL`, so
+ * this only ever encodes an arm request.
+ */
+object SleepPayload {
+
+    private const val SIZE_BYTES = 4
+    private const val END_OF_CHAPTER = 0
+
+    /** Duration presets the wrist offers (minutes). End-of-chapter is the
+     *  non-duration option, encoded via the [END_OF_CHAPTER] sentinel. */
+    val DURATION_PRESETS_MIN: List<Int> = listOf(15, 30, 45)
+
+    /** Pack a sleep [mode] into a 4-byte big-endian payload. */
+    fun encode(mode: SleepTimerMode): ByteArray {
+        val v = when (mode) {
+            is SleepTimerMode.Duration -> mode.minutes
+            SleepTimerMode.EndOfChapter -> END_OF_CHAPTER
+        }
+        return ByteBuffer.allocate(SIZE_BYTES).putInt(v).array()
+    }
+
+    /**
+     * Decode a 4-byte payload back to a [SleepTimerMode], or `null` if it's
+     * absent, the wrong length, or a negative (malformed) value.
+     */
+    fun decode(payload: ByteArray?): SleepTimerMode? {
+        if (payload == null || payload.size != SIZE_BYTES) return null
+        return when (val v = ByteBuffer.wrap(payload).int) {
+            END_OF_CHAPTER -> SleepTimerMode.EndOfChapter
+            in 1..Int.MAX_VALUE -> SleepTimerMode.Duration(v)
+            else -> null
+        }
+    }
+}

--- a/core-playback/src/test/kotlin/in/jphe/storyvox/playback/wear/SleepPayloadTest.kt
+++ b/core-playback/src/test/kotlin/in/jphe/storyvox/playback/wear/SleepPayloadTest.kt
@@ -1,0 +1,57 @@
+package `in`.jphe.storyvox.playback.wear
+
+import `in`.jphe.storyvox.playback.SleepTimerMode
+import java.nio.ByteBuffer
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Test
+
+/**
+ * The watch's sleep-timer screen sends a CMD_SLEEP_SET message carrying a
+ * [SleepPayload]; the phone decodes it. Shared wire format so the encode
+ * (watch) and decode (phone) sides can't drift — mirrors [SeekPayloadTest] /
+ * [TeleprompterWpmPayload].
+ *
+ * A positive value is a [SleepTimerMode.Duration] in minutes; the sentinel 0 is
+ * [SleepTimerMode.EndOfChapter]; anything else (wrong length / negative / null)
+ * decodes to null and the phone bridge ignores it.
+ */
+class SleepPayloadTest {
+
+    @Test fun `round-trips each duration preset`() {
+        for (minutes in SleepPayload.DURATION_PRESETS_MIN) {
+            val decoded = SleepPayload.decode(SleepPayload.encode(SleepTimerMode.Duration(minutes)))
+            assertEquals(SleepTimerMode.Duration(minutes), decoded)
+        }
+    }
+
+    @Test fun `round-trips end of chapter`() {
+        val decoded = SleepPayload.decode(SleepPayload.encode(SleepTimerMode.EndOfChapter))
+        assertEquals(SleepTimerMode.EndOfChapter, decoded)
+    }
+
+    @Test fun `encodes to exactly 4 bytes (big-endian Int)`() {
+        assertEquals(4, SleepPayload.encode(SleepTimerMode.Duration(30)).size)
+        assertEquals(4, SleepPayload.encode(SleepTimerMode.EndOfChapter).size)
+    }
+
+    @Test fun `decode returns null for null payload`() {
+        // MessageClient delivers null for payload-less messages (e.g. the
+        // separate CMD_SLEEP_CANCEL). A stray null here must not crash the bridge.
+        assertNull(SleepPayload.decode(null))
+    }
+
+    @Test fun `decode returns null for wrong-length payload`() {
+        assertNull(SleepPayload.decode(byteArrayOf(1, 2, 3)))
+        assertNull(SleepPayload.decode(ByteArray(0)))
+    }
+
+    @Test fun `decode returns null for a negative (malformed) value`() {
+        val negative = ByteBuffer.allocate(4).putInt(-5).array()
+        assertNull(SleepPayload.decode(negative))
+    }
+
+    @Test fun `duration presets are 15, 30, 45`() {
+        assertEquals(listOf(15, 30, 45), SleepPayload.DURATION_PRESETS_MIN)
+    }
+}

--- a/wear/src/main/kotlin/in/jphe/storyvox/wear/WearApp.kt
+++ b/wear/src/main/kotlin/in/jphe/storyvox/wear/WearApp.kt
@@ -13,9 +13,12 @@ import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.platform.LocalContext
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import `in`.jphe.storyvox.playback.SleepTimerMode
 import `in`.jphe.storyvox.playback.wear.TeleprompterWpmPayload
 import `in`.jphe.storyvox.wear.playback.WearPlaybackBridge
 import `in`.jphe.storyvox.wear.screens.NowPlayingScreen
+import `in`.jphe.storyvox.wear.screens.SleepTimerScreen
+import `in`.jphe.storyvox.wear.screens.SleepTimerUiState
 import `in`.jphe.storyvox.wear.screens.TeleprompterRemoteScreen
 import `in`.jphe.storyvox.wear.screens.TeleprompterRemoteUiState
 import `in`.jphe.storyvox.wear.theme.WearLibraryNocturneTheme
@@ -37,37 +40,68 @@ fun WearAppRoot() {
         onDispose { bridge.stop() }
     }
     WearLibraryNocturneTheme {
-        // Issue #1308 — two surfaces: Now Playing (transport) and the
-        // teleprompter remote. A flat toggle (no nav library) keeps it light;
-        // swipe/system back returns from the remote.
+        // Three surfaces: Now Playing (transport), the teleprompter remote
+        // (#1308), and the sleep timer. Flat boolean toggles (no nav library)
+        // keep it light; swipe/system back returns to Now Playing.
         var showTeleprompter by remember { mutableStateOf(false) }
-        if (showTeleprompter) {
-            val state by bridge.state.collectAsStateWithLifecycle()
-            val connected by bridge.connected.collectAsStateWithLifecycle()
-            val scope = rememberCoroutineScope()
-            BackHandler { showTeleprompter = false }
-            TeleprompterRemoteScreen(
-                state = TeleprompterRemoteUiState(
-                    enabled = state.teleprompterEnabled,
-                    playing = state.teleprompterPlaying,
-                    wpm = state.teleprompterWpm,
-                    connected = connected,
-                ),
-                onToggleEnabled = { scope.launch { bridge.toggleTeleprompter() } },
-                onTogglePlay = { scope.launch { bridge.toggleTeleprompterScroll() } },
-                onWpmDelta = { delta ->
-                    scope.launch {
-                        bridge.sendTeleprompterWpm(
-                            TeleprompterWpmPayload.step(state.teleprompterWpm, delta),
-                        )
-                    }
-                },
-            )
-        } else {
-            NowPlayingScreen(
-                bridge = bridge,
-                onOpenTeleprompter = { showTeleprompter = true },
-            )
+        var showSleepTimer by remember { mutableStateOf(false) }
+        when {
+            showTeleprompter -> {
+                val state by bridge.state.collectAsStateWithLifecycle()
+                val connected by bridge.connected.collectAsStateWithLifecycle()
+                val scope = rememberCoroutineScope()
+                BackHandler { showTeleprompter = false }
+                TeleprompterRemoteScreen(
+                    state = TeleprompterRemoteUiState(
+                        enabled = state.teleprompterEnabled,
+                        playing = state.teleprompterPlaying,
+                        wpm = state.teleprompterWpm,
+                        connected = connected,
+                    ),
+                    onToggleEnabled = { scope.launch { bridge.toggleTeleprompter() } },
+                    onTogglePlay = { scope.launch { bridge.toggleTeleprompterScroll() } },
+                    onWpmDelta = { delta ->
+                        scope.launch {
+                            bridge.sendTeleprompterWpm(
+                                TeleprompterWpmPayload.step(state.teleprompterWpm, delta),
+                            )
+                        }
+                    },
+                )
+            }
+            showSleepTimer -> {
+                val state by bridge.state.collectAsStateWithLifecycle()
+                val connected by bridge.connected.collectAsStateWithLifecycle()
+                val scope = rememberCoroutineScope()
+                BackHandler { showSleepTimer = false }
+                SleepTimerScreen(
+                    state = SleepTimerUiState(
+                        remainingMs = state.sleepTimerRemainingMs,
+                        connected = connected,
+                    ),
+                    // Each pick arms the timer on the phone and returns to Now
+                    // Playing, where the Sleep entry then shows the countdown.
+                    onPickDuration = { minutes ->
+                        scope.launch { bridge.sendSleepSet(SleepTimerMode.Duration(minutes)) }
+                        showSleepTimer = false
+                    },
+                    onPickEndOfChapter = {
+                        scope.launch { bridge.sendSleepSet(SleepTimerMode.EndOfChapter) }
+                        showSleepTimer = false
+                    },
+                    onCancel = {
+                        scope.launch { bridge.sendSleepCancel() }
+                        showSleepTimer = false
+                    },
+                )
+            }
+            else -> {
+                NowPlayingScreen(
+                    bridge = bridge,
+                    onOpenTeleprompter = { showTeleprompter = true },
+                    onOpenSleepTimer = { showSleepTimer = true },
+                )
+            }
         }
     }
 }

--- a/wear/src/main/kotlin/in/jphe/storyvox/wear/playback/WearPlaybackBridge.kt
+++ b/wear/src/main/kotlin/in/jphe/storyvox/wear/playback/WearPlaybackBridge.kt
@@ -8,8 +8,10 @@ import com.google.android.gms.wearable.DataItem
 import com.google.android.gms.wearable.DataMapItem
 import com.google.android.gms.wearable.Wearable
 import `in`.jphe.storyvox.playback.PlaybackState
+import `in`.jphe.storyvox.playback.SleepTimerMode
 import `in`.jphe.storyvox.playback.wear.PhoneWearBridge
 import `in`.jphe.storyvox.playback.wear.SeekPayload
+import `in`.jphe.storyvox.playback.wear.SleepPayload
 import `in`.jphe.storyvox.playback.wear.TeleprompterWpmPayload
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
@@ -138,6 +140,21 @@ class WearPlaybackBridge(private val context: Context) : DataClient.OnDataChange
 
     suspend fun sendTeleprompterWpm(wpm: Int): SendResult =
         dispatch(PhoneWearBridge.CMD_TELEPROMPTER_WPM, TeleprompterWpmPayload.encode(wpm))
+
+    /**
+     * Sleep timer from the wrist. [sendSleepSet] arms a 15/30/45-min or
+     * end-of-chapter timer (encoded via [SleepPayload]); [sendSleepCancel]
+     * clears it. The remaining time syncs back through
+     * `PlaybackState.sleepTimerRemainingMs` like any other playback state, so
+     * the now-playing countdown needs no separate channel. Both share
+     * [dispatch]/[send], so a tap while disconnected flips [connected] and
+     * surfaces the same "Phone not connected" hint as the transport controls.
+     */
+    suspend fun sendSleepSet(mode: SleepTimerMode): SendResult =
+        dispatch(PhoneWearBridge.CMD_SLEEP_SET, SleepPayload.encode(mode))
+
+    suspend fun sendSleepCancel(): SendResult =
+        send(PhoneWearBridge.CMD_SLEEP_CANCEL)
 
     /**
      * Single send path shared by every command. A successful send is the

--- a/wear/src/main/kotlin/in/jphe/storyvox/wear/screens/NowPlayingScreen.kt
+++ b/wear/src/main/kotlin/in/jphe/storyvox/wear/screens/NowPlayingScreen.kt
@@ -61,6 +61,7 @@ import `in`.jphe.storyvox.wear.components.LinearScrubber
 import `in`.jphe.storyvox.wear.components.TransportRow
 import `in`.jphe.storyvox.wear.playback.WearPlaybackBridge
 import `in`.jphe.storyvox.wear.theme.BrassPrimary
+import `in`.jphe.storyvox.wear.theme.BrassTint
 import `in`.jphe.storyvox.wear.theme.ParchmentOnMuted
 import `in`.jphe.storyvox.wear.theme.WearLibraryNocturneTheme
 import kotlinx.coroutines.launch
@@ -99,6 +100,7 @@ private const val ROTARY_VOLUME_STEP_PX = 48f
 fun NowPlayingScreen(
     bridge: WearPlaybackBridge,
     onOpenTeleprompter: () -> Unit = {},
+    onOpenSleepTimer: () -> Unit = {},
 ) {
     val state by bridge.state.collectAsStateWithLifecycle()
     val connected by bridge.connected.collectAsStateWithLifecycle()
@@ -129,6 +131,7 @@ fun NowPlayingScreen(
         // is dropped phone-side, so the watch only shows the control when armed.
         onStartRecording = { scope.launch { bridge.send(PhoneWearBridge.CMD_RECORDING_START) } },
         onStopRecording = { scope.launch { bridge.send(PhoneWearBridge.CMD_RECORDING_STOP) } },
+        onOpenSleepTimer = onOpenSleepTimer,
     )
 }
 
@@ -147,6 +150,7 @@ internal fun NowPlayingContent(
     onOpenTeleprompter: () -> Unit = {},
     onStartRecording: () -> Unit = {},
     onStopRecording: () -> Unit = {},
+    onOpenSleepTimer: () -> Unit = {},
 ) {
     val configuration = LocalConfiguration.current
     val isRound = configuration.isScreenRound
@@ -218,9 +222,9 @@ internal fun NowPlayingContent(
                 )
             }
             // Bottom-edge affordances, only when a phone is reachable: the
-            // #1367 recording control stacked above the #1308 teleprompter
-            // entry. Anchored at the bottom so they don't crowd the centered
-            // transport controls.
+            // #1367 recording control stacked above the #1308 teleprompter +
+            // sleep-timer entries. Anchored off the bottom bezel so they don't
+            // crowd the centered transport controls.
             if (connected) {
                 Column(
                     modifier = Modifier
@@ -239,19 +243,37 @@ internal fun NowPlayingContent(
                         onStart = onStartRecording,
                         onStop = onStopRecording,
                     )
-                    // #1308 — teleprompter remote entry. Hidden during an active
-                    // recording so the Stop affordance is unambiguous on a tiny
-                    // screen. caption1 reads legibly at arm's length.
+                    // Teleprompter remote (#1308) + sleep timer entries. Hidden
+                    // during an active recording so the Stop affordance is
+                    // unambiguous on a tiny screen. caption1 reads at arm's
+                    // length; the Sleep label doubles as the live countdown when
+                    // a duration timer is running.
                     if (!state.recording) {
-                        Text(
-                            text = stringResource(R.string.wear_teleprompter),
-                            color = BrassPrimary,
-                            textAlign = TextAlign.Center,
-                            style = MaterialTheme.typography.caption1,
-                            modifier = Modifier
-                                .clickable(onClick = onOpenTeleprompter)
-                                .padding(horizontal = 16.dp, vertical = 6.dp),
-                        )
+                        Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+                            Text(
+                                text = stringResource(R.string.wear_teleprompter),
+                                color = BrassPrimary,
+                                textAlign = TextAlign.Center,
+                                style = MaterialTheme.typography.caption1,
+                                modifier = Modifier
+                                    .clickable(onClick = onOpenTeleprompter)
+                                    .padding(horizontal = 12.dp, vertical = 6.dp),
+                            )
+                            val sleepRemaining = state.sleepTimerRemainingMs
+                            Text(
+                                text = if (sleepRemaining != null) {
+                                    "Sleep ${formatSleepRemaining(sleepRemaining)}"
+                                } else {
+                                    "Sleep"
+                                },
+                                color = if (sleepRemaining != null) BrassTint else BrassPrimary,
+                                textAlign = TextAlign.Center,
+                                style = MaterialTheme.typography.caption1,
+                                modifier = Modifier
+                                    .clickable(onClick = onOpenSleepTimer)
+                                    .padding(horizontal = 12.dp, vertical = 6.dp),
+                            )
+                        }
                     }
                 }
             }

--- a/wear/src/main/kotlin/in/jphe/storyvox/wear/screens/SleepTimerScreen.kt
+++ b/wear/src/main/kotlin/in/jphe/storyvox/wear/screens/SleepTimerScreen.kt
@@ -1,0 +1,169 @@
+package `in`.jphe.storyvox.wear.screens
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import androidx.wear.compose.material.MaterialTheme
+import androidx.wear.compose.material.Text
+import androidx.wear.tooling.preview.devices.WearDevices
+import `in`.jphe.storyvox.wear.theme.BrassMuted
+import `in`.jphe.storyvox.wear.theme.BrassPrimary
+import `in`.jphe.storyvox.wear.theme.BrassTint
+import `in`.jphe.storyvox.wear.theme.ParchmentOnMuted
+import `in`.jphe.storyvox.wear.theme.WarmDarkContainer
+import `in`.jphe.storyvox.wear.theme.WarmDarkContainerHigh
+import `in`.jphe.storyvox.wear.theme.WearLibraryNocturneTheme
+
+/**
+ * Wrist sleep-timer surface (reached from [NowPlayingScreen]). Mirrors
+ * [TeleprompterRemoteScreen]: stateless brass-on-warm-dark presentation; the
+ * caller supplies the synced [remainingMs] (from
+ * `PlaybackState.sleepTimerRemainingMs`) and the send callbacks (wired to
+ * [in.jphe.storyvox.wear.playback.WearPlaybackBridge]).
+ *
+ * Options: 15 / 30 / 45 minutes, End of chapter, and Cancel. Cancel is always
+ * offered (the phone's cancel is idempotent) so an end-of-chapter timer — which
+ * has no countdown to surface — is still dismissable from the wrist.
+ *
+ * @property remainingMs ms until pause for a *duration* timer, or null (no timer,
+ *   or an end-of-chapter timer that hasn't started its fade — no countdown).
+ * @property connected a phone node is reachable; when false the options grey out.
+ */
+data class SleepTimerUiState(
+    val remainingMs: Long? = null,
+    val connected: Boolean = true,
+)
+
+@Composable
+fun SleepTimerScreen(
+    state: SleepTimerUiState,
+    onPickDuration: (minutes: Int) -> Unit,
+    onPickEndOfChapter: () -> Unit,
+    onCancel: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    Column(
+        modifier = modifier
+            .fillMaxSize()
+            .verticalScroll(rememberScrollState())
+            .padding(horizontal = 16.dp, vertical = 28.dp),
+        horizontalAlignment = Alignment.CenterHorizontally,
+        verticalArrangement = Arrangement.spacedBy(6.dp),
+    ) {
+        Text(
+            text = "Sleep timer",
+            color = BrassPrimary,
+            textAlign = TextAlign.Center,
+            style = MaterialTheme.typography.title3,
+        )
+        // Active duration timer → show the live countdown synced from the phone.
+        if (state.remainingMs != null) {
+            Text(
+                text = formatSleepRemaining(state.remainingMs),
+                color = BrassTint,
+                textAlign = TextAlign.Center,
+                style = MaterialTheme.typography.title2,
+            )
+            Text(
+                text = "until pause",
+                color = ParchmentOnMuted,
+                textAlign = TextAlign.Center,
+                style = MaterialTheme.typography.caption2,
+            )
+        }
+        Spacer(Modifier.height(2.dp))
+
+        SleepOption("15 minutes", enabled = state.connected) { onPickDuration(15) }
+        SleepOption("30 minutes", enabled = state.connected) { onPickDuration(30) }
+        SleepOption("45 minutes", enabled = state.connected) { onPickDuration(45) }
+        SleepOption("End of chapter", enabled = state.connected) { onPickEndOfChapter() }
+        SleepOption("Cancel", enabled = state.connected, destructive = true) { onCancel() }
+    }
+}
+
+/** Format ms-until-pause as `m:ss` (sleep timers cap at 45 min, so no hours). */
+internal fun formatSleepRemaining(ms: Long): String {
+    val totalSeconds = (ms / 1000L).coerceAtLeast(0L)
+    val minutes = totalSeconds / 60
+    val seconds = totalSeconds % 60
+    return "%d:%02d".format(minutes, seconds)
+}
+
+/**
+ * A full-width, rounded, tappable option row — hand-rolled (Box + clickable)
+ * rather than a Wear `Chip` to stay on the exact component set
+ * [TeleprompterRemoteScreen] uses. Brass-on-warm-dark; greys out when the phone
+ * is unreachable; [destructive] (Cancel) tints with the muted brass fill.
+ */
+@Composable
+private fun SleepOption(
+    label: String,
+    enabled: Boolean,
+    destructive: Boolean = false,
+    onClick: () -> Unit,
+) {
+    val background = when {
+        !enabled -> WarmDarkContainer
+        destructive -> BrassMuted
+        else -> WarmDarkContainerHigh
+    }
+    val foreground = when {
+        !enabled -> BrassMuted
+        destructive -> BrassTint
+        else -> BrassPrimary
+    }
+    Box(
+        modifier = Modifier
+            .fillMaxWidth()
+            .clip(RoundedCornerShape(22.dp))
+            .background(background)
+            .clickable(enabled = enabled, onClick = onClick)
+            .padding(vertical = 10.dp, horizontal = 12.dp),
+        contentAlignment = Alignment.Center,
+    ) {
+        Text(
+            text = label,
+            color = foreground,
+            textAlign = TextAlign.Center,
+            maxLines = 1,
+            overflow = TextOverflow.Ellipsis,
+            style = MaterialTheme.typography.button,
+        )
+    }
+}
+
+@Preview(device = WearDevices.LARGE_ROUND, showSystemUi = true, name = "Sleep · idle")
+@Composable
+private fun PreviewSleepIdle() = WearLibraryNocturneTheme {
+    SleepTimerScreen(
+        state = SleepTimerUiState(remainingMs = null, connected = true),
+        onPickDuration = {}, onPickEndOfChapter = {}, onCancel = {},
+    )
+}
+
+@Preview(device = WearDevices.LARGE_ROUND, showSystemUi = true, name = "Sleep · running")
+@Composable
+private fun PreviewSleepRunning() = WearLibraryNocturneTheme {
+    SleepTimerScreen(
+        state = SleepTimerUiState(remainingMs = 14L * 60_000 + 32_000, connected = true),
+        onPickDuration = {}, onPickEndOfChapter = {}, onCancel = {},
+    )
+}


### PR DESCRIPTION
## What
Sleep-timer control from the Wear OS watch — bedtime listening without reaching for the phone. A new wrist surface (reached from `NowPlayingScreen`) offers **15 / 30 / 45 min / End of chapter / Cancel**, and the now-playing screen shows a **live countdown** when a timer is running. Mirrors the teleprompter-remote pattern (#1308).

## How it fits together
The phone already had most of the plumbing: `SleepTimer.remainingMs` is folded into `PlaybackState.sleepTimerRemainingMs` and published to the watch over `/playback/state`. So the **countdown syncs for free** — this PR adds the *commands* and the *UI*.

- **`SleepPayload`** (`core-playback/.../wear`) — shared 4-byte wire format for `CMD_SLEEP_SET`: a positive Int = `Duration(minutes)`, sentinel `0` = `EndOfChapter`; `null`/wrong-length/negative → `null` (ignored). Same single-source encode/decode contract as `SeekPayload` / `TeleprompterWpmPayload` so watch (encode) and phone (decode) can't drift.
- **`PhoneWearBridge`** — `CMD_SLEEP_SET` / `CMD_SLEEP_CANCEL` + dispatch to `PlaybackController.startSleepTimer` / `cancelSleepTimer`. Generalizes the old fixed-15-min `CMD_SLEEP_15`/`CMD_SLEEP_OFF` pair.
- **`WearPlaybackBridge`** — `sendSleepSet(mode)` / `sendSleepCancel()` (shared `dispatch`/`send`, so a tap while disconnected greys out like the transport controls).
- **`SleepTimerScreen`** — brass-on-warm-dark options + live `m:ss` countdown. **Cancel is always offered** so an end-of-chapter timer (which has no countdown signal) is still dismissable.
- **`NowPlayingScreen`** — a "Sleep" bottom entry beside "Teleprompter"; doubles as the countdown (`Sleep 14:32`) when active.
- **`WearApp`** — third flat surface toggle (Now Playing / Teleprompter / Sleep), back returns to Now Playing.

## Tests
`SleepPayloadTest` — round-trips each preset + end-of-chapter, 4-byte width, and null/wrong-length/negative → null guards.

## Notes / scope
- **End-of-chapter has no countdown** — `SleepTimer.remainingMs` is null until its fade tail, so the watch can't show a number for it (it just arms on the phone; Cancel still works). Duration timers count down live. Acceptable for v1.
- TTS synthesis stays on the phone — the watch is the remote, as designed.
- Components/theme match `TeleprompterRemoteScreen` exactly; option rows are hand-rolled clickable Boxes rather than a Wear `Chip`, to stay on the confirmed component set (no new dependency).
- **Merge-order heads-up:** the in-flight #105 (wear playback-speed control) likely also touches `NowPlayingScreen`/`WearApp`/the bridge. Whichever lands second will need a small rebase; happy to take that.
- No local gradle — CI compiles.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
