### PR TITLE
feat(wear): haptic feedback for bezel volume + transport controls

### DIFF
--- a/wear/src/main/kotlin/in/jphe/storyvox/wear/components/TransportRow.kt
+++ b/wear/src/main/kotlin/in/jphe/storyvox/wear/components/TransportRow.kt
@@ -1,5 +1,6 @@
 package `in`.jphe.storyvox.wear.components
 
+import android.view.HapticFeedbackConstants
 import androidx.compose.animation.Crossfade
 import androidx.compose.animation.core.tween
 import androidx.compose.foundation.ExperimentalFoundationApi
@@ -23,6 +24,7 @@ import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.hapticfeedback.HapticFeedbackType
 import androidx.compose.ui.platform.LocalHapticFeedback
+import androidx.compose.ui.platform.LocalView
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.semantics.Role
 import androidx.compose.ui.unit.dp
@@ -114,6 +116,7 @@ private fun TransportButton(
     val size = if (isPrimary) 52.dp else 48.dp
     val iconSize = if (isPrimary) 26.dp else 22.dp
     val haptic = LocalHapticFeedback.current
+    val view = LocalView.current
     val background = if (isPrimary) BrassPrimary else BrassMuted
     val content = if (isPrimary) WarmDarkSurface else BrassPrimary
     // Mirror the prior Wear Button's disabled treatment (#1030): a dimmed fill
@@ -132,7 +135,11 @@ private fun TransportButton(
                 enabled = enabled,
                 role = Role.Button,
                 onLongClickLabel = onLongClickLabel,
-                onClick = onClick,
+                onClick = {
+                    // Light tap so a short press registers without looking at the watch.
+                    view.performHapticFeedback(HapticFeedbackConstants.KEYBOARD_TAP)
+                    onClick()
+                },
                 onLongClick = onLongClick?.let { action ->
                     {
                         haptic.performHapticFeedback(HapticFeedbackType.LongPress)

--- a/wear/src/main/kotlin/in/jphe/storyvox/wear/screens/NowPlayingScreen.kt
+++ b/wear/src/main/kotlin/in/jphe/storyvox/wear/screens/NowPlayingScreen.kt
@@ -34,6 +34,7 @@ import androidx.compose.ui.tooling.preview.Devices
 import androidx.compose.ui.tooling.preview.Preview
 import android.content.Context
 import android.media.AudioManager
+import android.view.HapticFeedbackConstants
 import androidx.compose.foundation.focusable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.mutableFloatStateOf
@@ -43,6 +44,7 @@ import androidx.compose.ui.focus.FocusRequester
 import androidx.compose.ui.focus.focusRequester
 import androidx.compose.ui.input.rotary.onRotaryScrollEvent
 import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.platform.LocalView
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.compose.LifecycleResumeEffect
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
@@ -172,6 +174,7 @@ internal fun NowPlayingContent(
     val audioManager = remember(context) {
         context.getSystemService(Context.AUDIO_SERVICE) as AudioManager
     }
+    val view = LocalView.current
     val rotaryFocus = remember { FocusRequester() }
     var rotaryAccumPx by remember { mutableFloatStateOf(0f) }
     LaunchedEffect(Unit) { runCatching { rotaryFocus.requestFocus() } }
@@ -192,12 +195,14 @@ internal fun NowPlayingContent(
                         audioManager.adjustStreamVolume(
                             AudioManager.STREAM_MUSIC, AudioManager.ADJUST_RAISE, 0,
                         )
+                        view.performHapticFeedback(HapticFeedbackConstants.CLOCK_TICK)
                         rotaryAccumPx -= ROTARY_VOLUME_STEP_PX
                     }
                     while (rotaryAccumPx <= -ROTARY_VOLUME_STEP_PX) {
                         audioManager.adjustStreamVolume(
                             AudioManager.STREAM_MUSIC, AudioManager.ADJUST_LOWER, 0,
                         )
+                        view.performHapticFeedback(HapticFeedbackConstants.CLOCK_TICK)
                         rotaryAccumPx += ROTARY_VOLUME_STEP_PX
                     }
                     true


### PR DESCRIPTION
Closes the #1 Wear interaction gap (no haptics anywhere) identified during the #1397 bezel work.

- **Bezel/touch-ring volume** steps fire `HapticFeedbackConstants.CLOCK_TICK` per detent — spinning the bezel feels like physical clicks, and you get confirmation without looking at the watch.
- **Transport taps** (play/pause/skip) fire `KEYBOARD_TAP` so a press registers tactilely.
- Both via `view.performHapticFeedback(...)` (respects the user's system haptic setting; no-op when disabled). Transport haptic lives in `TransportButton` so every caller benefits; bezel haptic is per volume step in the rotary handler.

Follow-ups filed from the same review: #1401 (transient volume indicator), #1402 (teleprompter touch-target). No local gradle — CI compiles; hands-on feel best verified on the Galaxy Watch4 Classic.

🤖 Generated with [Claude Code](https://claude.com/claude-code)