### PR TITLE
feat(wear): watch-face complications for Now Playing + Listening Stats

### DIFF
--- a/core-playback/src/main/kotlin/in/jphe/storyvox/playback/wear/PhoneWearBridge.kt
+++ b/core-playback/src/main/kotlin/in/jphe/storyvox/playback/wear/PhoneWearBridge.kt
@@ -6,6 +6,7 @@ import com.google.android.gms.wearable.MessageEvent
 import com.google.android.gms.wearable.PutDataMapRequest
 import com.google.android.gms.wearable.Wearable
 import dagger.hilt.android.qualifiers.ApplicationContext
+import `in`.jphe.storyvox.data.repository.stats.ListeningStatsRepository
 import `in`.jphe.storyvox.playback.PlaybackController
 import `in`.jphe.storyvox.playback.PlaybackState
 import `in`.jphe.storyvox.playback.RecordingController
@@ -19,6 +20,8 @@ import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.cancel
 import kotlinx.coroutines.flow.collectLatest
 import kotlinx.coroutines.flow.combine
+import kotlinx.coroutines.flow.distinctUntilChanged
+import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.tasks.await
 import kotlinx.serialization.encodeToString
@@ -41,6 +44,7 @@ class PhoneWearBridge @Inject constructor(
     private val controller: PlaybackController,
     private val teleprompterController: TeleprompterController,
     private val recordingController: RecordingController,
+    private val statsRepository: ListeningStatsRepository,
 ) : MessageClient.OnMessageReceivedListener {
 
     private val scope = CoroutineScope(SupervisorJob() + Dispatchers.Default)
@@ -84,6 +88,19 @@ class PhoneWearBridge @Inject constructor(
                 )
             }.collectLatest { state -> publishState(state) }
         }
+        // Wear Listening Stats complication — publish today's estimated
+        // listening total + current streak to /stats/today. todayEstimatedMs is
+        // finished-chapter based, so it only moves at chapter boundaries:
+        // recompute when the current chapter id changes (distinctUntilChanged
+        // also fires once up front so the complication has data before the
+        // first playback of the session). publishStatsSnapshot dedupes the
+        // DataItem write on the (today, streak) value.
+        scope.launch {
+            controller.state
+                .map { it.currentChapterId }
+                .distinctUntilChanged()
+                .collectLatest { publishStatsSnapshot() }
+        }
     }
 
     fun stop() {
@@ -95,6 +112,28 @@ class PhoneWearBridge @Inject constructor(
         runCatching {
             val req = PutDataMapRequest.create(PATH_STATE).apply {
                 dataMap.putString("state", json.encodeToString(state))
+                dataMap.putLong("ts", System.currentTimeMillis())
+            }.asPutDataRequest().setUrgent()
+            dataClient.putDataItem(req).await()
+        }
+    }
+
+    /** Last published (todayEstimatedMs, currentStreakDays), to dedupe writes. */
+    private var lastStats: Pair<Long, Int>? = null
+
+    private suspend fun publishStatsSnapshot() {
+        val stats = runCatching { statsRepository.snapshot() }.getOrNull() ?: return
+        val pair = stats.todayEstimatedMs to stats.currentStreakDays
+        if (pair == lastStats) return
+        lastStats = pair
+        publishStats(todayMs = pair.first, streakDays = pair.second)
+    }
+
+    private suspend fun publishStats(todayMs: Long, streakDays: Int) {
+        runCatching {
+            val req = PutDataMapRequest.create(PATH_STATS_TODAY).apply {
+                dataMap.putLong("todayMs", todayMs)
+                dataMap.putInt("streakDays", streakDays)
                 dataMap.putLong("ts", System.currentTimeMillis())
             }.asPutDataRequest().setUrgent()
             dataClient.putDataItem(req).await()
@@ -143,6 +182,10 @@ class PhoneWearBridge @Inject constructor(
 
     companion object {
         const val PATH_STATE = "/playback/state"
+
+        /** DataItem path for the Wear Listening Stats complication —
+         *  today's estimated listening (ms) + current streak (days). */
+        const val PATH_STATS_TODAY = "/stats/today"
         const val CMD_PLAY = "/playback/cmd/play"
         const val CMD_PAUSE = "/playback/cmd/pause"
         const val CMD_TOGGLE = "/playback/cmd/toggle"

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -73,6 +73,7 @@ androidx-media = "1.8.0"
 # Wear
 wear-compose = "1.6.2"
 wear-tooling = "1.0.0"
+wear-watchface = "1.2.1"
 play-services-wearable = "20.0.1"
 
 # Test
@@ -220,6 +221,7 @@ androidx-wear-compose-material = { module = "androidx.wear.compose:compose-mater
 androidx-wear-compose-foundation = { module = "androidx.wear.compose:compose-foundation", version.ref = "wear-compose" }
 androidx-wear-compose-navigation = { module = "androidx.wear.compose:compose-navigation", version.ref = "wear-compose" }
 androidx-wear-tooling-preview = { module = "androidx.wear:wear-tooling-preview", version.ref = "wear-tooling" }
+androidx-wear-watchface-complications-datasource-ktx = { module = "androidx.wear.watchface:watchface-complications-data-source-ktx", version.ref = "wear-watchface" }
 
 # Desugaring
 android-desugar-jdk-libs = { module = "com.android.tools:desugar_jdk_libs", version.ref = "desugar" }

--- a/wear/build.gradle.kts
+++ b/wear/build.gradle.kts
@@ -108,6 +108,10 @@ dependencies {
     implementation(libs.bundles.wear.compose)
     implementation(libs.androidx.wear.tooling.preview)
 
+    // Wear watch-face complications — data-source services + update requester
+    // (the watch-face renders our Now Playing / Listening Stats complications).
+    implementation(libs.androidx.wear.watchface.complications.datasource.ktx)
+
     // Hilt (optional in v1; wired so Hypnos can use @AndroidEntryPoint)
     implementation(libs.hilt.android)
     ksp(libs.hilt.compiler)

--- a/wear/src/main/AndroidManifest.xml
+++ b/wear/src/main/AndroidManifest.xml
@@ -37,6 +37,53 @@
                 <category android:name="android.intent.category.LAUNCHER" />
             </intent-filter>
         </activity>
+
+        <!-- Wear watch-face complications (Now Playing + Listening Today).
+             Provider services are bound by the watch face; the listener service
+             refreshes them when the phone republishes the backing DataItems. -->
+        <service
+            android:name=".complication.NowPlayingComplicationService"
+            android:exported="true"
+            android:icon="@android:drawable/ic_media_play"
+            android:label="@string/complication_now_playing_label"
+            android:permission="com.google.android.wearable.permission.BIND_COMPLICATION_PROVIDER">
+            <intent-filter>
+                <action android:name="android.support.wearable.complications.ACTION_COMPLICATION_UPDATE_REQUEST" />
+            </intent-filter>
+            <meta-data
+                android:name="android.support.wearable.complications.SUPPORTED_TYPES"
+                android:value="SHORT_TEXT,RANGED_VALUE" />
+            <meta-data
+                android:name="android.support.wearable.complications.UPDATE_PERIOD_SECONDS"
+                android:value="0" />
+        </service>
+
+        <service
+            android:name=".complication.ListeningStatsComplicationService"
+            android:exported="true"
+            android:icon="@android:drawable/ic_menu_recent_history"
+            android:label="@string/complication_stats_label"
+            android:permission="com.google.android.wearable.permission.BIND_COMPLICATION_PROVIDER">
+            <intent-filter>
+                <action android:name="android.support.wearable.complications.ACTION_COMPLICATION_UPDATE_REQUEST" />
+            </intent-filter>
+            <meta-data
+                android:name="android.support.wearable.complications.SUPPORTED_TYPES"
+                android:value="SHORT_TEXT" />
+            <meta-data
+                android:name="android.support.wearable.complications.UPDATE_PERIOD_SECONDS"
+                android:value="0" />
+        </service>
+
+        <service
+            android:name=".complication.ComplicationUpdateListenerService"
+            android:exported="true">
+            <intent-filter>
+                <action android:name="com.google.android.gms.wearable.DATA_CHANGED" />
+                <data android:scheme="wear" android:host="*" android:pathPrefix="/playback" />
+                <data android:scheme="wear" android:host="*" android:pathPrefix="/stats" />
+            </intent-filter>
+        </service>
     </application>
 
 </manifest>

--- a/wear/src/main/kotlin/in/jphe/storyvox/wear/complication/ComplicationReaders.kt
+++ b/wear/src/main/kotlin/in/jphe/storyvox/wear/complication/ComplicationReaders.kt
@@ -1,0 +1,62 @@
+package `in`.jphe.storyvox.wear.complication
+
+import android.content.Context
+import com.google.android.gms.wearable.DataMapItem
+import com.google.android.gms.wearable.Wearable
+import `in`.jphe.storyvox.playback.PlaybackState
+import `in`.jphe.storyvox.playback.wear.PhoneWearBridge
+import `in`.jphe.storyvox.wear.playback.WearPlaybackBridge
+import kotlinx.coroutines.tasks.await
+
+/** Today's listening glance for the Listening Stats complication. */
+internal data class TodayStats(val todayMs: Long, val streakDays: Int)
+
+/**
+ * Read the latest phone-published [PlaybackState] from the cached
+ * `/playback/state` DataItem — the same source [WearPlaybackBridge] consumes for
+ * the Now Playing screen. Returns an empty state when GMS is unavailable or no
+ * item has synced yet, and reuses the bridge's tested [WearPlaybackBridge.decodeState]
+ * so a malformed/version-skewed blob degrades to empty instead of crashing the
+ * complication.
+ */
+internal suspend fun Context.readPlaybackState(): PlaybackState {
+    val buffer = runCatching { Wearable.getDataClient(this).dataItems.await() }.getOrNull()
+        ?: return PlaybackState()
+    return try {
+        var state = PlaybackState()
+        for (item in buffer) {
+            if (item.uri.path == PhoneWearBridge.PATH_STATE) {
+                val raw = DataMapItem.fromDataItem(item).dataMap.getString("state")
+                state = WearPlaybackBridge.decodeState(raw, state)
+            }
+        }
+        state
+    } finally {
+        buffer.release()
+    }
+}
+
+/**
+ * Read the latest `/stats/today` DataItem (today's estimated listening ms +
+ * current streak), pushed by [PhoneWearBridge]. Returns zeros when nothing has
+ * synced yet.
+ */
+internal suspend fun Context.readTodayStats(): TodayStats {
+    val buffer = runCatching { Wearable.getDataClient(this).dataItems.await() }.getOrNull()
+        ?: return TodayStats(todayMs = 0L, streakDays = 0)
+    return try {
+        var stats = TodayStats(todayMs = 0L, streakDays = 0)
+        for (item in buffer) {
+            if (item.uri.path == PhoneWearBridge.PATH_STATS_TODAY) {
+                val map = DataMapItem.fromDataItem(item).dataMap
+                stats = TodayStats(
+                    todayMs = map.getLong("todayMs"),
+                    streakDays = map.getInt("streakDays"),
+                )
+            }
+        }
+        stats
+    } finally {
+        buffer.release()
+    }
+}

--- a/wear/src/main/kotlin/in/jphe/storyvox/wear/complication/ComplicationUpdateListenerService.kt
+++ b/wear/src/main/kotlin/in/jphe/storyvox/wear/complication/ComplicationUpdateListenerService.kt
@@ -1,0 +1,37 @@
+package `in`.jphe.storyvox.wear.complication
+
+import android.content.ComponentName
+import androidx.wear.watchface.complications.datasource.ComplicationDataSourceUpdateRequester
+import com.google.android.gms.wearable.DataEventBuffer
+import com.google.android.gms.wearable.WearableListenerService
+import `in`.jphe.storyvox.playback.wear.PhoneWearBridge
+
+/**
+ * Bridges phone DataItem changes to complication refreshes. The complication
+ * services declare `UPDATE_PERIOD_SECONDS=0` (no polling — battery), so this
+ * GMS-managed service is what makes Now Playing / "37m today" update promptly:
+ * on a `/playback/state` or `/stats/today` change it asks the matching data
+ * source to re-emit. Coalesces per buffer so a burst of edits triggers at most
+ * one update per complication.
+ */
+class ComplicationUpdateListenerService : WearableListenerService() {
+
+    override fun onDataChanged(events: DataEventBuffer) {
+        var refreshNowPlaying = false
+        var refreshStats = false
+        for (event in events) {
+            when (event.dataItem.uri.path) {
+                PhoneWearBridge.PATH_STATE -> refreshNowPlaying = true
+                PhoneWearBridge.PATH_STATS_TODAY -> refreshStats = true
+            }
+        }
+        if (refreshNowPlaying) requestUpdate(NowPlayingComplicationService::class.java)
+        if (refreshStats) requestUpdate(ListeningStatsComplicationService::class.java)
+    }
+
+    private fun requestUpdate(service: Class<*>) {
+        ComplicationDataSourceUpdateRequester
+            .create(this, ComponentName(this, service))
+            .requestUpdateAll()
+    }
+}

--- a/wear/src/main/kotlin/in/jphe/storyvox/wear/complication/ListeningStatsComplicationService.kt
+++ b/wear/src/main/kotlin/in/jphe/storyvox/wear/complication/ListeningStatsComplicationService.kt
@@ -1,0 +1,66 @@
+package `in`.jphe.storyvox.wear.complication
+
+import android.app.PendingIntent
+import android.content.Intent
+import androidx.wear.watchface.complications.data.ComplicationData
+import androidx.wear.watchface.complications.data.ComplicationType
+import androidx.wear.watchface.complications.data.PlainComplicationText
+import androidx.wear.watchface.complications.data.ShortTextComplicationData
+import androidx.wear.watchface.complications.datasource.ComplicationRequest
+import androidx.wear.watchface.complications.datasource.SuspendingComplicationDataSourceService
+import `in`.jphe.storyvox.wear.WearMainActivity
+
+/**
+ * Watch-face complication for today's listening — the audiobook analog to an
+ * activity ring. Reads the phone-published `/stats/today` DataItem and renders
+ * time-listened-today as the main SHORT_TEXT ("37m" / "1h05") with the current
+ * streak as the title ("🔥7"). Tapping opens [WearMainActivity].
+ *
+ * No polling — refreshed by [ComplicationUpdateListenerService] when the phone
+ * republishes stats (at chapter boundaries).
+ */
+class ListeningStatsComplicationService : SuspendingComplicationDataSourceService() {
+
+    override suspend fun onComplicationRequest(request: ComplicationRequest): ComplicationData? =
+        render(request.complicationType, readTodayStats())
+
+    override fun getPreviewData(type: ComplicationType): ComplicationData? =
+        render(type, TodayStats(todayMs = 37 * 60_000L, streakDays = 7))
+
+    private fun render(type: ComplicationType, stats: TodayStats): ComplicationData? {
+        if (type != ComplicationType.SHORT_TEXT) return null
+        val today = formatToday(stats.todayMs)
+        val builder = ShortTextComplicationData.Builder(
+            text = PlainComplicationText.Builder(today).build(),
+            contentDescription = PlainComplicationText.Builder(
+                "Candela — $today listened today" +
+                    if (stats.streakDays > 0) ", ${stats.streakDays}-day streak" else "",
+            ).build(),
+        ).setTapAction(openApp())
+        if (stats.streakDays > 0) {
+            builder.setTitle(PlainComplicationText.Builder("🔥${stats.streakDays}").build())
+        }
+        return builder.build()
+    }
+
+    /** ms → glanceable duration: "0m", "37m", or "1h05". */
+    private fun formatToday(ms: Long): String {
+        val minutes = (ms / 60_000L).toInt()
+        return when {
+            minutes <= 0 -> "0m"
+            minutes < 60 -> "${minutes}m"
+            else -> "${minutes / 60}h${(minutes % 60).toString().padStart(2, '0')}"
+        }
+    }
+
+    private fun openApp(): PendingIntent = PendingIntent.getActivity(
+        this,
+        REQUEST_STATS,
+        Intent(this, WearMainActivity::class.java),
+        PendingIntent.FLAG_IMMUTABLE,
+    )
+
+    private companion object {
+        const val REQUEST_STATS = 1
+    }
+}

--- a/wear/src/main/kotlin/in/jphe/storyvox/wear/complication/NowPlayingComplicationService.kt
+++ b/wear/src/main/kotlin/in/jphe/storyvox/wear/complication/NowPlayingComplicationService.kt
@@ -1,0 +1,77 @@
+package `in`.jphe.storyvox.wear.complication
+
+import android.app.PendingIntent
+import android.content.Intent
+import androidx.wear.watchface.complications.data.ComplicationData
+import androidx.wear.watchface.complications.data.ComplicationType
+import androidx.wear.watchface.complications.data.PlainComplicationText
+import androidx.wear.watchface.complications.data.RangedValueComplicationData
+import androidx.wear.watchface.complications.data.ShortTextComplicationData
+import androidx.wear.watchface.complications.datasource.ComplicationRequest
+import androidx.wear.watchface.complications.datasource.SuspendingComplicationDataSourceService
+import `in`.jphe.storyvox.playback.PlaybackState
+import `in`.jphe.storyvox.playback.scrubProgress
+import `in`.jphe.storyvox.wear.WearMainActivity
+
+/**
+ * Watch-face complication for what's playing on the phone. Reads the
+ * phone-published `/playback/state` DataItem and renders the chapter/book title
+ * (SHORT_TEXT) or the chapter progress ring (RANGED_VALUE). Tapping opens
+ * [WearMainActivity] (the Now Playing screen).
+ *
+ * No polling — `UPDATE_PERIOD_SECONDS=0` in the manifest. Refreshed reactively
+ * by [ComplicationUpdateListenerService] when the phone republishes state.
+ */
+class NowPlayingComplicationService : SuspendingComplicationDataSourceService() {
+
+    override suspend fun onComplicationRequest(request: ComplicationRequest): ComplicationData? =
+        render(request.complicationType, readPlaybackState())
+
+    override fun getPreviewData(type: ComplicationType): ComplicationData? = render(type, PREVIEW)
+
+    private fun render(type: ComplicationType, state: PlaybackState): ComplicationData? {
+        val title = state.chapterTitle?.takeIf { it.isNotBlank() }
+            ?: state.bookTitle?.takeIf { it.isNotBlank() }
+            ?: NOT_PLAYING
+        val short = if (title.length <= MAX_CHARS) title else title.take(MAX_CHARS - 1) + "…"
+        val description = PlainComplicationText.Builder("Candela — $title").build()
+        return when (type) {
+            ComplicationType.SHORT_TEXT -> ShortTextComplicationData.Builder(
+                text = PlainComplicationText.Builder(short).build(),
+                contentDescription = description,
+            ).setTapAction(openReader()).build()
+
+            ComplicationType.RANGED_VALUE -> RangedValueComplicationData.Builder(
+                value = state.scrubProgress(),
+                min = 0f,
+                max = 1f,
+                contentDescription = description,
+            ).setText(PlainComplicationText.Builder(short).build())
+                .setTapAction(openReader())
+                .build()
+
+            else -> null
+        }
+    }
+
+    private fun openReader(): PendingIntent = PendingIntent.getActivity(
+        this,
+        REQUEST_NOW_PLAYING,
+        Intent(this, WearMainActivity::class.java),
+        PendingIntent.FLAG_IMMUTABLE,
+    )
+
+    private companion object {
+        const val NOT_PLAYING = "Not playing"
+        const val MAX_CHARS = 18
+        const val REQUEST_NOW_PLAYING = 0
+
+        /** Preview shown in the complication picker. */
+        val PREVIEW = PlaybackState(
+            bookTitle = "Moby Dick",
+            chapterTitle = "Chapter 3",
+            charOffset = 1_200,
+            durationEstimateMs = 600_000L,
+        )
+    }
+}

--- a/wear/src/main/res/values/strings.xml
+++ b/wear/src/main/res/values/strings.xml
@@ -28,4 +28,8 @@
     <!-- Chapter cover -->
     <string name="wear_cd_cover_for">Cover for %1$s</string>
     <string name="wear_cd_cover_generic">Chapter cover</string>
+
+    <!-- Complications -->
+    <string name="complication_now_playing_label">Candela — Now Playing</string>
+    <string name="complication_stats_label">Candela — Listening Today</string>
 </resources>


### PR DESCRIPTION
## Wear OS watch-face complications — Now Playing + Listening Stats

Two glanceable complications for the Library Nocturne watch app, plus the phone→watch data push that backs the stats one.

### Complications (watch side)
- **`NowPlayingComplicationService`** — `SHORT_TEXT` (chapter, falling back to book title) or `RANGED_VALUE` (chapter progress ring via `PlaybackState.scrubProgress()`). Reads the phone-published `/playback/state` DataItem. Tap → `WearMainActivity` (Now Playing screen).
- **`ListeningStatsComplicationService`** — `SHORT_TEXT` "37m" / "1h05" listened today with a "🔥N" streak title. Reads a new `/stats/today` DataItem. The audiobook analog to an activity ring.

Both declare `UPDATE_PERIOD_SECONDS=0` (no polling — battery). **`ComplicationUpdateListenerService`** (`WearableListenerService`) refreshes the matching data source on a `/playback/state` or `/stats/today` change via `ComplicationDataSourceUpdateRequester`.

### Phone side
`PhoneWearBridge` now also publishes `/stats/today` (`todayEstimatedMs` + `currentStreakDays` from `ListeningStatsRepository`). `todayEstimatedMs` is finished-chapter based, so it only moves at chapter boundaries — I recompute on `currentChapterId` changes (`distinctUntilChanged`, which also fires once up front so the complication has data before the first playback) and dedupe the DataItem write on the `(today, streak)` value. No new lifecycle — it rides the existing `PhoneWearBridge.start()` already managed by `StoryvoxPlaybackService`.

### Design notes
- Complication readers reuse the bridge's tested `WearPlaybackBridge.decodeState`, so a malformed/version-skewed state blob degrades to an empty complication instead of crashing.
- Module deps already supported this: `core-playback → core-data` (lets the bridge inject the stats repo), `wear → core-playback` (lets complications use `PhoneWearBridge.PATH_*` + `PlaybackState`). `PhoneWearBridge` has no direct constructors anywhere (Hilt-only), so the new ctor param touches no fakes.
- Adds `androidx.wear.watchface:watchface-complications-data-source-ktx`.

### Testing
- ⚠️ **Compiled on CI, not locally** (per project policy — no local gradle). This is my first pass at the Wear complications API without a local compile, so I'll fix-forward on any API/signature mismatch CI surfaces.
- No unit tests added: the services are thin adapters over the GMS DataLayer + the complications API (no seam without Robolectric/GMS); the one piece of logic worth isolating — `decodeState` — is already unit-tested on the bridge.
- Device check worth doing once green: add both complications to a watch face, confirm Now Playing title/progress + "Xm today / 🔥N" update as the phone plays.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
