### PR TITLE
fix(wear): use shared StatusTokens.ErrorDark instead of inlined error color

### DIFF
--- a/wear/src/main/kotlin/in/jphe/storyvox/wear/theme/WearLibraryNocturneTheme.kt
+++ b/wear/src/main/kotlin/in/jphe/storyvox/wear/theme/WearLibraryNocturneTheme.kt
@@ -13,6 +13,7 @@ import androidx.wear.compose.material.Colors
 import androidx.wear.compose.material.MaterialTheme
 import androidx.wear.compose.material.Typography
 import `in`.jphe.storyvox.ui.R as CoreUiR
+import `in`.jphe.storyvox.ui.theme.StatusTokens
 
 /**
  * Wear OS port of the phone/tablet Library Nocturne palette.
@@ -39,6 +40,10 @@ internal val WarmDarkContainerHigh = Color(0xFF1B1822) // SurfaceTokens.SurfaceC
 internal val ParchmentOn = Color(0xFFE8DFD1)         // SurfaceTokens.OnSurfaceDark
 internal val ParchmentOnMuted = Color(0xFFB8AE9F)    // SurfaceTokens.OnSurfaceVariantDark
 internal val BrassRingTrack = Color(0xFF3A3530)      // SurfaceTokens.OutlineVariantDark
+// Semantic status color: referenced from the shared token rather than
+// duplicated by value (the brass/surface tokens above mirror :core-ui by
+// literal; the one error role stays single-source via StatusTokens.ErrorDark).
+internal val ErrorTerracotta = StatusTokens.ErrorDark
 
 private val WearNocturneColors = Colors(
     primary = BrassPrimary,
@@ -47,7 +52,7 @@ private val WearNocturneColors = Colors(
     secondaryVariant = BrassMuted,
     background = WarmDarkSurface,
     surface = WarmDarkContainer,
-    error = Color(0xFFE07A6A),
+    error = ErrorTerracotta,
     onPrimary = WarmDarkSurface,
     onSecondary = WarmDarkSurface,
     onBackground = ParchmentOn,


### PR DESCRIPTION
## Use the shared error token in the Wear theme

nebula's #1268 theme-token audit flagged an **inlined error color** in the Wear module: `WearLibraryNocturneTheme.kt` hardcoded `error = Color(0xFFE07A6A)` in the `Colors(...)` block — the one role defined by a raw literal while every sibling (`primary`, `surface`, …) is a named token.

That literal duplicated `StatusTokens.ErrorDark` (`0xFFE07A6A`) in `:core-ui`, so a future change to the shared error color would silently skip the watch. Wear already depends on `:core-ui`, so this references the shared token via a named `ErrorTerracotta` val — keeping the `Colors` block uniform with its siblings (all named vals) while making the error role single-source.

**No behavior change** — identical color, just sourced from the shared token. Small + independent of #1399.

🤖 Generated with [Claude Code](https://claude.com/claude-code)