### PR TITLE
feat(wear): glanceable "Now Playing" tile — title, progress, one-tap play/pause

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -75,6 +75,9 @@ wear-compose = "1.6.2"
 wear-tooling = "1.0.0"
 wear-watchface = "1.2.1"
 wear-ongoing = "1.0.0"
+wear-tiles = "1.6.0"
+wear-protolayout = "1.4.0"
+concurrent-futures = "1.2.0"
 play-services-wearable = "20.0.1"
 
 # Test
@@ -224,6 +227,9 @@ androidx-wear-compose-navigation = { module = "androidx.wear.compose:compose-nav
 androidx-wear-tooling-preview = { module = "androidx.wear:wear-tooling-preview", version.ref = "wear-tooling" }
 androidx-wear-watchface-complications-datasource-ktx = { module = "androidx.wear.watchface:watchface-complications-data-source-ktx", version.ref = "wear-watchface" }
 androidx-wear-ongoing = { module = "androidx.wear:wear-ongoing", version.ref = "wear-ongoing" }
+androidx-wear-tiles = { module = "androidx.wear.tiles:tiles", version.ref = "wear-tiles" }
+androidx-wear-protolayout = { module = "androidx.wear.protolayout:protolayout", version.ref = "wear-protolayout" }
+androidx-concurrent-futures = { module = "androidx.concurrent:concurrent-futures", version.ref = "concurrent-futures" }
 
 # Desugaring
 android-desugar-jdk-libs = { module = "com.android.tools:desugar_jdk_libs", version.ref = "desugar" }

--- a/wear/build.gradle.kts
+++ b/wear/build.gradle.kts
@@ -114,6 +114,13 @@ dependencies {
     // Wear Ongoing Activity — watch-face media chip while the phone plays
     implementation(libs.androidx.wear.ongoing)
 
+    // Wear Tiles — glanceable "Now Playing" tile. Protolayout builds the layout;
+    // the tiles lib hosts the TileService; concurrent-futures' CallbackToFutureAdapter
+    // bridges the coroutine state read to the ListenableFuture the API returns.
+    implementation(libs.androidx.wear.tiles)
+    implementation(libs.androidx.wear.protolayout)
+    implementation(libs.androidx.concurrent.futures)
+
     // Hilt (optional in v1; wired so Hypnos can use @AndroidEntryPoint)
     implementation(libs.hilt.android)
     ksp(libs.hilt.compiler)

--- a/wear/src/main/AndroidManifest.xml
+++ b/wear/src/main/AndroidManifest.xml
@@ -110,6 +110,34 @@
                     android:pathPrefix="/playback" />
             </intent-filter>
         </service>
+
+        <!-- Wear Tile — glanceable "Now Playing". Renders the PlaybackState synced
+             over the DataClient (same /playback/state DataItem WearPlaybackBridge
+             reads); play/pause routes through the command trampoline below. -->
+        <service
+            android:name=".tile.PlaybackTileService"
+            android:exported="true"
+            android:icon="@android:drawable/ic_media_play"
+            android:label="@string/wear_tile_label"
+            android:description="@string/wear_tile_description"
+            android:permission="com.google.android.wearable.permission.BIND_TILE_PROVIDER">
+            <intent-filter>
+                <action android:name="androidx.wear.tiles.action.BIND_TILE_PROVIDER" />
+            </intent-filter>
+            <meta-data
+                android:name="androidx.wear.tiles.PREVIEW"
+                android:resource="@android:drawable/ic_media_play" />
+        </service>
+
+        <!-- Invisible trampoline: a Tile Clickable can only launch an Activity, so
+             this receives the chosen CMD_* path, sends it to the phone via
+             WearPlaybackBridge, requests a tile refresh, and finishes. -->
+        <activity
+            android:name=".tile.PlaybackTileCommandActivity"
+            android:exported="true"
+            android:excludeFromRecents="true"
+            android:taskAffinity=""
+            android:theme="@android:style/Theme.Translucent.NoTitleBar" />
     </application>
 
 </manifest>

--- a/wear/src/main/kotlin/in/jphe/storyvox/wear/tile/PlaybackTileCommandActivity.kt
+++ b/wear/src/main/kotlin/in/jphe/storyvox/wear/tile/PlaybackTileCommandActivity.kt
@@ -1,0 +1,43 @@
+package `in`.jphe.storyvox.wear.tile
+
+import android.os.Bundle
+import androidx.activity.ComponentActivity
+import androidx.lifecycle.lifecycleScope
+import androidx.wear.tiles.TileService
+import `in`.jphe.storyvox.wear.playback.WearPlaybackBridge
+import kotlinx.coroutines.launch
+
+/**
+ * Invisible trampoline for the [PlaybackTileService] play/pause button.
+ *
+ * A Protolayout `Clickable` can only launch an Activity or reload the tile — it
+ * can't send a data-layer message. So the tile's play/pause click launches this
+ * activity with the chosen `CMD_*` path in [EXTRA_CMD]; we forward it to the
+ * phone via [WearPlaybackBridge.send] (which only needs the lazy node/message
+ * clients — no `start()`), ask the system to refresh the tile so the icon flips
+ * immediately, and finish without ever drawing UI.
+ *
+ * Declared with a translucent theme + `excludeFromRecents` in the manifest so
+ * the user only ever sees the tile, never this shim.
+ */
+class PlaybackTileCommandActivity : ComponentActivity() {
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        val command = intent?.getStringExtra(EXTRA_CMD)
+        if (command.isNullOrBlank()) {
+            finish()
+            return
+        }
+        lifecycleScope.launch {
+            // Best-effort: a failed send already flips the bridge's connectivity
+            // state; the tile simply re-renders from the next synced PlaybackState.
+            runCatching { WearPlaybackBridge(applicationContext).send(command) }
+            runCatching {
+                TileService.getUpdater(applicationContext)
+                    .requestUpdate(PlaybackTileService::class.java)
+            }
+            finish()
+        }
+    }
+}

--- a/wear/src/main/kotlin/in/jphe/storyvox/wear/tile/PlaybackTileService.kt
+++ b/wear/src/main/kotlin/in/jphe/storyvox/wear/tile/PlaybackTileService.kt
@@ -1,0 +1,359 @@
+package `in`.jphe.storyvox.wear.tile
+
+import androidx.concurrent.futures.CallbackToFutureAdapter
+import androidx.wear.protolayout.ActionBuilders
+import androidx.wear.protolayout.ColorBuilders.argb
+import androidx.wear.protolayout.DimensionBuilders.degrees
+import androidx.wear.protolayout.DimensionBuilders.dp
+import androidx.wear.protolayout.DimensionBuilders.expand
+import androidx.wear.protolayout.DimensionBuilders.sp
+import androidx.wear.protolayout.DimensionBuilders.wrap
+import androidx.wear.protolayout.LayoutElementBuilders
+import androidx.wear.protolayout.LayoutElementBuilders.ARC_ANCHOR_START
+import androidx.wear.protolayout.LayoutElementBuilders.FONT_WEIGHT_BOLD
+import androidx.wear.protolayout.LayoutElementBuilders.FONT_WEIGHT_MEDIUM
+import androidx.wear.protolayout.LayoutElementBuilders.HORIZONTAL_ALIGN_CENTER
+import androidx.wear.protolayout.LayoutElementBuilders.TEXT_ALIGN_CENTER
+import androidx.wear.protolayout.LayoutElementBuilders.TEXT_OVERFLOW_ELLIPSIZE_END
+import androidx.wear.protolayout.ModifiersBuilders
+import androidx.wear.protolayout.ResourceBuilders
+import androidx.wear.protolayout.TimelineBuilders
+import androidx.wear.tiles.RequestBuilders
+import androidx.wear.tiles.TileBuilders
+import androidx.wear.tiles.TileService
+import com.google.android.gms.wearable.DataMapItem
+import com.google.android.gms.wearable.Wearable
+import com.google.common.util.concurrent.ListenableFuture
+import `in`.jphe.storyvox.playback.PlaybackState
+import `in`.jphe.storyvox.playback.scrubProgress
+import `in`.jphe.storyvox.playback.wear.PhoneWearBridge
+import `in`.jphe.storyvox.wear.playback.WearPlaybackBridge
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.tasks.await
+import kotlin.math.roundToInt
+
+/**
+ * Glanceable "Now Playing" Tile — the #1 missing Wear surface. Swipe from the
+ * watch face for cover/title + a play/pause button + progress, one tap to
+ * resume without opening the app.
+ *
+ * ## How it stays in sync without holding state
+ * A [TileService] is a stateless renderer: the system calls [onTileRequest]
+ * on demand and we return a layout. So the tile reads the **same**
+ * `/playback/state` DataItem that [WearPlaybackBridge] consumes — decoded
+ * through the very same [WearPlaybackBridge.decodeState] seam, so the tile and
+ * the app can never interpret the wire format differently. A modest freshness
+ * interval re-renders periodically; [PlaybackTileCommandActivity] also requests
+ * an immediate refresh right after a transport tap so the icon flips at once.
+ *
+ * ## Why the play/pause tap needs a trampoline
+ * Protolayout `Clickable`s can only [ActionBuilders.LaunchAction] (start an
+ * activity) or `LoadAction` (reload the tile) — there is no "send a data-layer
+ * message" click. So play/pause launches the invisible
+ * [PlaybackTileCommandActivity], which forwards the chosen `CMD_*` to the phone
+ * over the MessageClient (reusing [WearPlaybackBridge.send]) and finishes. The
+ * tile body itself launches `WearMainActivity`.
+ */
+class PlaybackTileService : TileService() {
+
+    private val scope = CoroutineScope(SupervisorJob() + Dispatchers.Main)
+
+    override fun onTileRequest(
+        requestParams: RequestBuilders.TileRequest,
+    ): ListenableFuture<TileBuilders.Tile> = CallbackToFutureAdapter.getFuture { completer ->
+        val job = scope.launch {
+            try {
+                val tile = TileBuilders.Tile.Builder()
+                    .setResourcesVersion(RESOURCES_VERSION)
+                    .setFreshnessIntervalMillis(FRESHNESS_MS)
+                    .setTileTimeline(
+                        TimelineBuilders.Timeline.fromLayoutElement(rootLayout(latestState())),
+                    )
+                    .build()
+                completer.set(tile)
+            } catch (t: CancellationException) {
+                throw t
+            } catch (t: Throwable) {
+                completer.setException(t)
+            }
+        }
+        completer.addCancellationListener({ job.cancel() }, Runnable::run)
+        "PlaybackTileService#onTileRequest"
+    }
+
+    override fun onTileResourcesRequest(
+        requestParams: RequestBuilders.ResourcesRequest,
+    ): ListenableFuture<ResourceBuilders.Resources> = CallbackToFutureAdapter.getFuture { completer ->
+        // No bitmap resources — the cover is a brass monogram drawn as text and
+        // progress is an Arc, so resources carry only the version stamp.
+        completer.set(ResourceBuilders.Resources.Builder().setVersion(RESOURCES_VERSION).build())
+        "PlaybackTileService#onTileResourcesRequest"
+    }
+
+    override fun onDestroy() {
+        scope.cancel()
+        super.onDestroy()
+    }
+
+    /**
+     * Read the latest phone-published [PlaybackState] off the cached
+     * `/playback/state` DataItem, decoded via the shared
+     * [WearPlaybackBridge.decodeState] seam. Falls back to an empty state when
+     * the phone has never published or GMS is unavailable, so the tile renders
+     * a clean "Nothing playing" rather than failing the request.
+     */
+    private suspend fun latestState(): PlaybackState {
+        val buffer = runCatching { Wearable.getDataClient(this).dataItems.await() }.getOrNull()
+            ?: return PlaybackState()
+        return try {
+            val item = buffer.firstOrNull { it.uri.path == PhoneWearBridge.PATH_STATE }
+            val raw = item?.let { DataMapItem.fromDataItem(it).dataMap.getString("state") }
+            WearPlaybackBridge.decodeState(raw, PlaybackState())
+        } finally {
+            buffer.release()
+        }
+    }
+
+    // ─── layout ─────────────────────────────────────────────────────────────
+
+    private fun rootLayout(state: PlaybackState): LayoutElementBuilders.LayoutElement =
+        LayoutElementBuilders.Box.Builder()
+            .setWidth(expand())
+            .setHeight(expand())
+            .setModifiers(
+                ModifiersBuilders.Modifiers.Builder()
+                    .setBackground(
+                        ModifiersBuilders.Background.Builder().setColor(argb(SURFACE)).build(),
+                    )
+                    // Tap anywhere but the button → open the full watch app.
+                    .setClickable(
+                        ModifiersBuilders.Clickable.Builder()
+                            .setId("open_app")
+                            .setOnClick(launchActivity(WEAR_MAIN_ACTIVITY))
+                            .build(),
+                    )
+                    .build(),
+            )
+            .addContent(progressRing(state.scrubProgress()))
+            .addContent(centerColumn(state))
+            .build()
+
+    private fun progressRing(progress: Float): LayoutElementBuilders.LayoutElement =
+        LayoutElementBuilders.Arc.Builder()
+            .setAnchorAngle(degrees(270f)) // 12 o'clock
+            .setAnchorType(ARC_ANCHOR_START)
+            .addContent(
+                LayoutElementBuilders.ArcLine.Builder()
+                    .setLength(degrees(360f))
+                    .setThickness(dp(6f))
+                    .setColor(argb(RING_TRACK))
+                    .build(),
+            )
+            .addContent(
+                LayoutElementBuilders.ArcLine.Builder()
+                    .setLength(degrees(360f * progress.coerceIn(0f, 1f)))
+                    .setThickness(dp(6f))
+                    .setColor(argb(BRASS))
+                    .build(),
+            )
+            .build()
+
+    private fun centerColumn(state: PlaybackState): LayoutElementBuilders.LayoutElement {
+        val column = LayoutElementBuilders.Column.Builder()
+            .setWidth(expand())
+            .setHeight(wrap())
+            .setHorizontalAlignment(HORIZONTAL_ALIGN_CENTER)
+            .setModifiers(
+                ModifiersBuilders.Modifiers.Builder()
+                    .setPadding(ModifiersBuilders.Padding.Builder().setAll(dp(20f)).build())
+                    .build(),
+            )
+            .addContent(monogram(state.bookTitle))
+            .addContent(spacer(8f))
+            .addContent(titleText(bookLine(state), 18f, BRASS_TINT, FONT_WEIGHT_BOLD, maxLines = 2))
+
+        chapterLine(state)?.let { chapter ->
+            column.addContent(spacer(2f))
+            column.addContent(titleText(chapter, 13f, PARCHMENT_MUTED, FONT_WEIGHT_MEDIUM, maxLines = 1))
+        }
+
+        // Progress percent — only when something is loaded (skip the "0%" noise
+        // on the empty state).
+        if (state.bookTitle != null) {
+            column.addContent(spacer(4f))
+            column.addContent(
+                titleText("${progressPercent(state)}%", 12f, PARCHMENT_MUTED, FONT_WEIGHT_MEDIUM, maxLines = 1),
+            )
+        }
+
+        column.addContent(spacer(12f))
+        column.addContent(playPauseButton(state))
+        return column.build()
+    }
+
+    /** Brass monogram disc standing in for the cover (the phone's coverUri may be
+     *  a content/file URI the watch can't resolve; a real bitmap cover is a
+     *  follow-up via the Coil → InlineImageResource path). */
+    private fun monogram(book: String?): LayoutElementBuilders.LayoutElement {
+        val letter = book?.trim()?.takeIf { it.isNotEmpty() }
+            ?.first()?.uppercaseChar()?.toString() ?: "♪"
+        return LayoutElementBuilders.Box.Builder()
+            .setWidth(dp(40f))
+            .setHeight(dp(40f))
+            .setModifiers(
+                ModifiersBuilders.Modifiers.Builder()
+                    .setBackground(
+                        ModifiersBuilders.Background.Builder()
+                            .setColor(argb(BRASS_MUTED))
+                            .setCorner(ModifiersBuilders.Corner.Builder().setRadius(dp(20f)).build())
+                            .build(),
+                    )
+                    .build(),
+            )
+            .addContent(
+                LayoutElementBuilders.Text.Builder()
+                    .setText(letter)
+                    .setFontStyle(
+                        LayoutElementBuilders.FontStyle.Builder()
+                            .setSize(sp(20f))
+                            .setColor(argb(BRASS_TINT))
+                            .setWeight(FONT_WEIGHT_BOLD)
+                            .build(),
+                    )
+                    .build(),
+            )
+            .build()
+    }
+
+    private fun titleText(
+        text: String,
+        sizeSp: Float,
+        color: Int,
+        weight: Int,
+        maxLines: Int,
+    ): LayoutElementBuilders.LayoutElement =
+        LayoutElementBuilders.Text.Builder()
+            .setText(text)
+            .setMaxLines(maxLines)
+            .setOverflow(TEXT_OVERFLOW_ELLIPSIZE_END)
+            .setMultilineAlignment(TEXT_ALIGN_CENTER)
+            .setFontStyle(
+                LayoutElementBuilders.FontStyle.Builder()
+                    .setSize(sp(sizeSp))
+                    .setColor(argb(color))
+                    .setWeight(weight)
+                    .build(),
+            )
+            .build()
+
+    private fun playPauseButton(state: PlaybackState): LayoutElementBuilders.LayoutElement =
+        LayoutElementBuilders.Box.Builder()
+            .setWidth(wrap())
+            .setHeight(wrap())
+            .setModifiers(
+                ModifiersBuilders.Modifiers.Builder()
+                    .setBackground(
+                        ModifiersBuilders.Background.Builder()
+                            .setColor(argb(BRASS))
+                            .setCorner(ModifiersBuilders.Corner.Builder().setRadius(dp(22f)).build())
+                            .build(),
+                    )
+                    .setPadding(
+                        ModifiersBuilders.Padding.Builder()
+                            .setStart(dp(22f))
+                            .setEnd(dp(22f))
+                            .setTop(dp(10f))
+                            .setBottom(dp(10f))
+                            .build(),
+                    )
+                    .setClickable(
+                        ModifiersBuilders.Clickable.Builder()
+                            .setId("play_pause")
+                            .setOnClick(
+                                launchActivity(
+                                    COMMAND_ACTIVITY,
+                                    EXTRA_CMD to playPauseCommand(state),
+                                ),
+                            )
+                            .build(),
+                    )
+                    .build(),
+            )
+            .addContent(
+                LayoutElementBuilders.Text.Builder()
+                    .setText(if (state.isPlaying) "Pause" else "Play")
+                    .setFontStyle(
+                        LayoutElementBuilders.FontStyle.Builder()
+                            .setSize(sp(15f))
+                            .setColor(argb(SURFACE))
+                            .setWeight(FONT_WEIGHT_MEDIUM)
+                            .build(),
+                    )
+                    .build(),
+            )
+            .build()
+
+    private fun spacer(heightDp: Float): LayoutElementBuilders.LayoutElement =
+        LayoutElementBuilders.Spacer.Builder().setHeight(dp(heightDp)).build()
+
+    /** Build a [ActionBuilders.LaunchAction] to one of our own activities, with
+     *  optional string extras (used to carry the chosen CMD_* to the trampoline). */
+    private fun launchActivity(
+        className: String,
+        vararg extras: Pair<String, String>,
+    ): ActionBuilders.LaunchAction {
+        val activity = ActionBuilders.AndroidActivity.Builder()
+            .setPackageName(packageName)
+            .setClassName(className)
+        for ((key, value) in extras) {
+            activity.addKeyToExtraMapping(
+                key,
+                ActionBuilders.AndroidStringExtra.Builder().setValue(value).build(),
+            )
+        }
+        return ActionBuilders.LaunchAction.Builder().setAndroidActivity(activity.build()).build()
+    }
+
+    private companion object {
+        const val RESOURCES_VERSION = "1"
+        const val FRESHNESS_MS = 60_000L
+
+        const val WEAR_MAIN_ACTIVITY = "in.jphe.storyvox.wear.WearMainActivity"
+        const val COMMAND_ACTIVITY = "in.jphe.storyvox.wear.tile.PlaybackTileCommandActivity"
+
+        // Library Nocturne palette — ARGB mirrors of the Compose tokens in
+        // WearLibraryNocturneTheme (Protolayout wants raw ints, not Compose Color).
+        const val SURFACE = 0xFF0E0C12.toInt()         // WarmDarkSurface
+        const val BRASS = 0xFFB48C5A.toInt()           // BrassPrimary
+        const val BRASS_TINT = 0xFFC9A774.toInt()      // BrassTint
+        const val BRASS_MUTED = 0xFF3A2A14.toInt()     // BrassMuted
+        const val PARCHMENT_MUTED = 0xFFB8AE9F.toInt() // ParchmentOnMuted
+        const val RING_TRACK = 0xFF3A3530.toInt()      // BrassRingTrack
+    }
+}
+
+/** Key for the CMD_* path the tile asks [PlaybackTileCommandActivity] to send. */
+internal const val EXTRA_CMD = "in.jphe.storyvox.wear.tile.EXTRA_CMD"
+
+// ─── pure render helpers (unit-tested in PlaybackTileLogicTest) ──────────────
+
+/** Which transport command a play/pause tap should send, given the live state. */
+internal fun playPauseCommand(state: PlaybackState): String =
+    if (state.isPlaying) PhoneWearBridge.CMD_PAUSE else PhoneWearBridge.CMD_PLAY
+
+/** Primary line: the book title, or a calm empty-state when nothing is loaded. */
+internal fun bookLine(state: PlaybackState): String =
+    state.bookTitle?.takeIf { it.isNotBlank() } ?: "Nothing playing"
+
+/** Secondary line: the chapter title, or null when absent/blank (row is dropped). */
+internal fun chapterLine(state: PlaybackState): String? =
+    state.chapterTitle?.takeIf { it.isNotBlank() }
+
+/** Progress as a whole-number percent (0..100), matching the app's scrubber math. */
+internal fun progressPercent(state: PlaybackState): Int =
+    (state.scrubProgress() * 100f).roundToInt()

--- a/wear/src/main/res/values/strings.xml
+++ b/wear/src/main/res/values/strings.xml
@@ -42,4 +42,8 @@
     <string name="wear_state_buffering">Buffering</string>
     <string name="wear_cd_chapter_progress">Chapter progress</string>
     <string name="wear_cd_open_teleprompter">Open teleprompter remote</string>
+
+    <!-- Now Playing tile -->
+    <string name="wear_tile_label">Now Playing</string>
+    <string name="wear_tile_description">Resume your audiobook — play/pause and progress at a glance.</string>
 </resources>

--- a/wear/src/test/kotlin/in/jphe/storyvox/wear/tile/PlaybackTileLogicTest.kt
+++ b/wear/src/test/kotlin/in/jphe/storyvox/wear/tile/PlaybackTileLogicTest.kt
@@ -1,0 +1,54 @@
+package `in`.jphe.storyvox.wear.tile
+
+import `in`.jphe.storyvox.playback.PlaybackState
+import `in`.jphe.storyvox.playback.wear.PhoneWearBridge
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Test
+
+/**
+ * Pure tests for the [PlaybackTileService] render helpers — the state→display
+ * decisions, exercised without standing up a TileService or GMS (the seam
+ * pattern, mirroring SeekPayloadTest / WearStateDecodeTest).
+ */
+class PlaybackTileLogicTest {
+
+    @Test fun `play command issued when paused`() {
+        assertEquals(PhoneWearBridge.CMD_PLAY, playPauseCommand(PlaybackState(isPlaying = false)))
+    }
+
+    @Test fun `pause command issued when playing`() {
+        assertEquals(PhoneWearBridge.CMD_PAUSE, playPauseCommand(PlaybackState(isPlaying = true)))
+    }
+
+    @Test fun `book line falls back to empty-state copy`() {
+        assertEquals("Nothing playing", bookLine(PlaybackState()))
+        assertEquals("Nothing playing", bookLine(PlaybackState(bookTitle = "   ")))
+    }
+
+    @Test fun `book line uses the title when present`() {
+        assertEquals("Dune", bookLine(PlaybackState(bookTitle = "Dune")))
+    }
+
+    @Test fun `chapter line is null when absent or blank`() {
+        assertNull(chapterLine(PlaybackState()))
+        assertNull(chapterLine(PlaybackState(chapterTitle = " ")))
+    }
+
+    @Test fun `chapter line uses the title when present`() {
+        assertEquals("Chapter 3", chapterLine(PlaybackState(chapterTitle = "Chapter 3")))
+    }
+
+    @Test fun `progress percent tracks the scrubber math`() {
+        // scrubProgress: totalChars = (durationMs/1000) * 12.5 baseline cps.
+        // 600_000ms → 7500 chars; offset 3750 → 0.5 → 50%.
+        val half = PlaybackState(charOffset = 3750, durationEstimateMs = 600_000L)
+        assertEquals(50, progressPercent(half))
+    }
+
+    @Test fun `progress percent is zero when duration is unknown`() {
+        // Before the first state sync durationEstimateMs == 0; must not divide by
+        // a zero rail.
+        assertEquals(0, progressPercent(PlaybackState(charOffset = 100, durationEstimateMs = 0L)))
+    }
+}


### PR DESCRIPTION
## What

A Wear OS **Tile** for Candela — the #1 missing glanceable surface. Swipe from the watch face to see the current book/chapter, a progress ring, and a **play/pause** button, and resume **without opening the app**.

## How it works

- **`PlaybackTileService`** renders from the **same `/playback/state` DataItem** that `WearPlaybackBridge` already syncs from the phone — decoded through the shared **`WearPlaybackBridge.decodeState`** seam, so the tile and the in-app UI can never interpret the wire format differently. A 60s freshness interval re-renders periodically.
- **Play/pause → `CMD_PLAY`/`CMD_PAUSE`.** A Protolayout `Clickable` can only *launch an activity* or *reload the tile* — it can't send a data-layer message. So the button launches an invisible trampoline (**`PlaybackTileCommandActivity`**) that reuses **`WearPlaybackBridge.send()`** (works without `start()` — it only needs the lazy node/message clients), then calls `TileService.getUpdater().requestUpdate()` so the icon flips immediately, and finishes. The chosen command is decided at render time (`isPlaying ? CMD_PAUSE : CMD_PLAY`).
- **Tile body tap → `WearMainActivity`** (the existing launcher).
- **Library Nocturne** brass-on-warm-dark, with the tile's ARGB constants mirroring `WearLibraryNocturneTheme`.
- Registered as a `BIND_TILE_PROVIDER` service in the Wear manifest.

## Notes / decisions

- **Cover = brass monogram for v1.** A real bitmap cover (`coverUri` → Coil → `InlineImageResource`) is a deliberate follow-up: the phone's `coverUri` is frequently a `content://`/`file://` URI the watch can't resolve, and it needs an async resources path. The monogram keeps v1 robust and glanceable. Happy to do the photo cover as a fast-follow if wanted.
- **Tests:** pure render helpers (`playPauseCommand`, `bookLine`, `chapterLine`, `progressPercent`) are unit-tested in `PlaybackTileLogicTest`, mirroring the `SeekPayloadTest` / `WearStateDecodeTest` seam pattern (no GMS, no Robolectric).
- **Deps added:** `androidx.wear.tiles:1.6.0` + `androidx.wear.protolayout:1.4.0` + `androidx.concurrent:concurrent-futures:1.2.0` (the last bridges the coroutine state read to the `ListenableFuture` the TileService API returns). Versions verified against Google Maven.
- Not compiled locally (per project rules) — leaving the `Build APK` CI job as the compile gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
